### PR TITLE
t3422: reduce GraphQL budget usage in diagnostics

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -490,6 +490,9 @@ The hold is branch-specific: a different branch or a different issue does not in
 - **REST fallback (t2574, t2744, t2902):** `shared-gh-wrappers.sh` routes eligible writes/reads through REST when GraphQL remaining <= 1500, preserving GraphQL for calls without REST equivalents. Override: `AIDEVOPS_GH_REST_FALLBACK_THRESHOLD`.
 - **Instrumentation (t2902):** routed `gh` calls append to `~/.aidevops/logs/gh-api-calls.log` and aggregate by stage in `~/.aidevops/logs/gh-api-calls-by-stage.json`. Helper: `gh-api-instrument.sh record|report|trim|clear`. Instrumentation is fail-open.
 - **Circuit breaker (t2690, t2744, t2896):** worker dispatch pauses when GraphQL budget is below the emergency 5% floor. Counter: `pulse_dispatch_circuit_broken` in `pulse-stats.json`. Overrides: `AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD`, `AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1`.
+- **Rate-limit status cache (t3422):** `pulse-rate-limit-circuit-breaker.sh` caches the free `gh api rate_limit` response for 20s at `~/.aidevops/cache/pulse-graphql-rate-limit.json`. Use `pulse-rate-limit-circuit-breaker.sh status --cached` inside diagnostics that must not touch the network; use plain `status` when you need a fresh free endpoint read. Override: `AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL`.
+- **GraphQL-efficient current-state check (t3422):** start with `pulse-current-state-helper.sh --window 15m`. It reads local pulse/worker logs, shows cached GraphQL budget state, and surfaces top GraphQL consumers from the instrumentation report without issuing GraphQL queries.
+- **Solved-issue search is opt-in (t3422):** `worker-activity-helper.sh summary` no longer runs the `gh issue list --search ... label:solved:worker` path by default because GitHub search uses GraphQL. Add `--pr-check` only when GraphQL budget is healthy or the external solved-count is required; `--no-pr-check` remains accepted and explicit.
 - **Cache priming (t2992, t2994):** `pulse-wrapper.sh::main()` pre-warms L3 per-owner JSON caches after lock/canary/session/dedup gates and before `prefetch_state`. Sentinel: `~/.aidevops/cache/pulse-cache-prime-last-run`; log: `~/.aidevops/logs/pulse-cache-prime.log`; counters: `pulse_cache_prime_runs`, `pulse_cache_prime_failures`; overrides: `AIDEVOPS_SKIP_CACHE_PRIME=1`, `AIDEVOPS_PULSE_PRIME_MAX_AGE`.
 
 Background: t2994 moved priming from `pulse-lifecycle-helper.sh::_start` into `pulse-wrapper.sh::main()` because launchd `KeepAlive` could respawn the pulse before `_start` ran, causing the lifecycle hook to early-return and skip priming.
@@ -533,12 +536,16 @@ either live output growth or completed work attributed to workers:
   merged it automatically after CI passed.
 
 ```bash
-worker-activity-helper.sh summary --since 1h --repo <owner/repo>
+pulse-current-state-helper.sh --window 15m
+worker-activity-helper.sh summary --since 1h --repo <owner/repo> --no-pr-check
 ```
 
-The helper combines canonical worker metrics with `solved:worker` closed-issue
-counts. Treat `origin:worker` PR counts as branch-creation telemetry only; they
-are not sufficient evidence of worker productivity.
+The current-state helper is the cheapest live signal: local logs + cached
+GraphQL budget + instrumentation report. The worker-activity helper combines
+canonical worker metrics with local pulse counters by default; add `--pr-check`
+only when you need the `solved:worker` closed-issue count and have GraphQL
+budget available. Treat `origin:worker` PR counts as branch-creation telemetry
+only; they are not sufficient evidence of worker productivity.
 
 ```bash
 # Measure actual output growth over 15 seconds

--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
 _usage() {
 	cat <<'EOF'
 Usage: pulse-current-state-helper.sh [--window 15m] [--repo-path PATH] [--log-dir DIR] [--json]
@@ -45,14 +47,14 @@ main() {
 	done
 	local window_s
 	window_s="$(_seconds "$window")"
-	python3 - "$log_dir" "$repo_path" "$window_s" "$as_json" <<'PY'
+	python3 - "$log_dir" "$repo_path" "$window_s" "$as_json" "$SCRIPT_DIR" <<'PY'
 import json
 import os
 import subprocess
 import sys
 import time
 
-log_dir, repo_path, window_s, as_json = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4] == '1'
+log_dir, repo_path, window_s, as_json, script_dir = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4] == '1', sys.argv[5]
 now = time.time()
 since = now - window_s
 
@@ -115,6 +117,29 @@ try:
 except (OSError, subprocess.CalledProcessError):
     worktrees = []
 
+graphql_budget_status = 'UNKNOWN: no cached status'
+breaker = os.path.join(script_dir, 'pulse-rate-limit-circuit-breaker.sh')
+try:
+    graphql_budget_status = subprocess.check_output(
+        [breaker, 'status', '--cached'], text=True, stderr=subprocess.DEVNULL, timeout=5
+    ).strip() or graphql_budget_status
+except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    pass
+
+api_consumers = []
+api_report = os.path.join(log_dir, 'gh-api-calls-by-stage.json')
+if os.path.exists(api_report):
+    try:
+        report = json.load(open(api_report, encoding='utf-8'))
+        for caller, data in (report.get('by_caller') or {}).items():
+            if isinstance(data, dict):
+                gql = int(data.get('graphql_calls') or 0) + int(data.get('search_graphql_calls') or 0)
+                if gql > 0:
+                    api_consumers.append({'caller': caller, 'graphql_calls': gql})
+        api_consumers = sorted(api_consumers, key=lambda item: item['graphql_calls'], reverse=True)[:5]
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        api_consumers = []
+
 result = {
     'window_seconds': window_s,
     'dispatch_stage_events': len(stage_lines),
@@ -125,6 +150,8 @@ result = {
     'wrapper_activity_lines': len(wrapper_activity),
     'worker_worktrees': len(worktrees),
     'dispatch_alive': bool(stage_lines or metrics or counter_hits or worktrees),
+    'graphql_budget_status': graphql_budget_status,
+    'top_graphql_consumers': api_consumers,
 }
 
 if as_json:
@@ -136,6 +163,9 @@ else:
     print(f'- Dispatch stage events: {result["dispatch_stage_events"]}')
     print(f'- Worker terminal events: {result["worker_terminal_events"]} ({result["worker_successes"]} success, {result["worker_failures_or_stalls"]} non-success)')
     print(f'- Pulse counter hits: {json.dumps(counter_hits, sort_keys=True)}')
+    print(f'- GraphQL budget: {graphql_budget_status}')
+    if api_consumers:
+        print(f'- Top GraphQL consumers: {json.dumps(api_consumers)}')
     print(f'- Worker worktrees: {result["worker_worktrees"]}')
     if wrapper_activity:
         print('- Recent wrapper activity:')

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -232,11 +232,13 @@ _dispatch_should_skip_candidate() {
 	fi
 
 	# t1899/t1937: Skip issues with placeholder/empty bodies — dispatching a
-	# worker to an undescribed issue wastes a session. The body check is
-	# a single API call per candidate. Detects both the legacy GitLab stub
-	# and the current claim-task-id.sh stub marker.
+	# worker to an undescribed issue wastes a session. Use REST here instead of
+	# `gh issue view --json body`: this pre-dedup fast-fail runs once per
+	# candidate, so a GraphQL-backed CLI read can drain the shared GraphQL budget
+	# before workers ever launch.
 	local issue_body
-	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body --jq '.body // ""' 2>/dev/null) || issue_body=""
+	declare -F gh_record_call >/dev/null 2>&1 && gh_record_call rest "pulse-dispatch-lib.sh" || true
+	issue_body=$(gh api "repos/${repo_slug}/issues/${issue_number}" --jq '.body // ""' 2>/dev/null) || issue_body=""
 	pulse_dispatch_debug_log "#${issue_number}: body length=${#issue_body}"
 	if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" ]]; then
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — placeholder/empty issue body, needs enrichment before dispatch" >>"$LOGFILE"

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -79,11 +79,57 @@ LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 # State file for tracking when the breaker last tripped (for status reporting).
 _CIRCUIT_BREAKER_STATE_FILE="${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
 
+# Short-lived cache for the free rate_limit endpoint. The dispatch loop can ask
+# for budget state once per candidate; caching keeps diagnostics and in-loop
+# checks from hammering GitHub while preserving sub-minute recovery.
+_CB_RL_CACHE_FILE="${AIDEVOPS_PULSE_RATE_LIMIT_CACHE:-${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json}"
+_CB_RL_CACHE_TTL="${AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL:-20}"
+_CB_RL_MODE_CACHED_ONLY="cached-only"
+
 # Log prefix for all messages from this module.
 _CB_RL_LOG_PREFIX="[circuit-breaker-rl]"
 
 # Unknown value placeholder for status output.
 _CB_RL_UNKNOWN="?"
+
+#######################################
+# Read GitHub rate-limit state with a short TTL cache.
+#
+# Args:
+#   $1 - mode: normal (default) or cached-only
+#
+# Stdout: raw `gh api rate_limit` JSON.
+#######################################
+_cb_rate_limit_json() {
+	local mode="${1:-normal}"
+	local now cached_ts age rate_json tmp
+	now=$(date +%s 2>/dev/null) || now=0
+
+	if [[ -f "$_CB_RL_CACHE_FILE" ]]; then
+		cached_ts=$(jq -r '.ts // 0' "$_CB_RL_CACHE_FILE" 2>/dev/null) || cached_ts=0
+		[[ "$cached_ts" =~ ^[0-9]+$ ]] || cached_ts=0
+		age=$((now - cached_ts))
+		if [[ "$mode" == "$_CB_RL_MODE_CACHED_ONLY" ]] || { [[ "$_CB_RL_CACHE_TTL" =~ ^[0-9]+$ ]] && [[ "$age" -ge 0 ]] && [[ "$age" -lt "$_CB_RL_CACHE_TTL" ]]; }; then
+			rate_json=$(jq -c '.rate // empty' "$_CB_RL_CACHE_FILE" 2>/dev/null) || rate_json=""
+			if [[ -n "$rate_json" && "$rate_json" != "null" ]]; then
+				printf '%s\n' "$rate_json"
+				return 0
+			fi
+		fi
+	fi
+
+	[[ "$mode" == "$_CB_RL_MODE_CACHED_ONLY" ]] && return 1
+
+	rate_json=$(gh api rate_limit 2>/dev/null) || return 1
+	[[ -n "$rate_json" ]] || return 1
+	mkdir -p "${_CB_RL_CACHE_FILE%/*}" 2>/dev/null || true
+	tmp=$(mktemp "${_CB_RL_CACHE_FILE}.XXXXXX" 2>/dev/null) || tmp=""
+	if [[ -n "$tmp" ]]; then
+		printf '{"ts":%s,"rate":%s}\n' "$now" "$rate_json" >"$tmp" 2>/dev/null && mv "$tmp" "$_CB_RL_CACHE_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+	fi
+	printf '%s\n' "$rate_json"
+	return 0
+}
 
 #######################################
 # Check whether the GitHub GraphQL rate-limit budget is sufficient for dispatch.
@@ -111,9 +157,9 @@ is_graphql_budget_sufficient() {
 		return 0
 	fi
 
-	# Query rate limit (free endpoint).
+	# Query rate limit (free endpoint, short-TTL cached).
 	local rate_json
-	rate_json=$(gh api rate_limit 2>/dev/null) || rate_json=""
+	rate_json=$(_cb_rate_limit_json normal) || rate_json=""
 
 	if [[ -z "$rate_json" ]]; then
 		echo "${_CB_RL_LOG_PREFIX} WARNING: gh api rate_limit failed — proceeding with dispatch (fail-open)" >>"$LOGFILE"
@@ -201,6 +247,7 @@ _compute_threshold_count() {
 # Stdout: status line (one of: "OK: ...", "TRIPPED: ...", "UNKNOWN: ...")
 #######################################
 _circuit_breaker_status() {
+	local mode="${1:-normal}"
 	# Check for emergency bypass.
 	if [[ "${AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER:-0}" == "1" ]]; then
 		printf 'BYPASSED: AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1\n'
@@ -215,10 +262,14 @@ _circuit_breaker_status() {
 
 	# Check current rate-limit state.
 	local rate_json
-	rate_json=$(gh api rate_limit 2>/dev/null) || rate_json=""
+	rate_json=$(_cb_rate_limit_json "$mode") || rate_json=""
 
 	if [[ -z "$rate_json" ]]; then
-		printf 'UNKNOWN: gh api rate_limit unavailable\n'
+		if [[ "$mode" == "$_CB_RL_MODE_CACHED_ONLY" ]]; then
+			printf 'UNKNOWN: no cached gh api rate_limit data\n'
+		else
+			printf 'UNKNOWN: gh api rate_limit unavailable\n'
+		fi
 		return 0
 	fi
 
@@ -384,7 +435,11 @@ _main() {
 			return $?
 			;;
 		status)
-			_circuit_breaker_status
+			local status_mode="normal"
+			if [[ "${1:-}" == "--cached" ]]; then
+				status_mode="$_CB_RL_MODE_CACHED_ONLY"
+			fi
+			_circuit_breaker_status "$status_mode"
 			return 0
 			;;
 		help | --help | -h)
@@ -393,11 +448,12 @@ _main() {
 			echo "Usage:"
 			echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=tripped, 2=API error"
 			echo "  pulse-rate-limit-circuit-breaker.sh check-actions-queue OWNER/REPO # KEY=VALUE: queued/in_progress/ratio/saturated"
-			echo "  pulse-rate-limit-circuit-breaker.sh status                         # human-readable status line"
+			echo "  pulse-rate-limit-circuit-breaker.sh status [--cached]              # human-readable status line"
 			echo ""
 			echo "Environment (GraphQL):"
 			echo "  AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD  fraction threshold (default 0.30 = 30%)"
 			echo "  AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1     emergency bypass"
+			echo "  AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL       rate_limit cache TTL seconds (default 20)"
 			echo ""
 			echo "Environment (Actions queue, t3211):"
 			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  min queued runs (default 50; 0 disables)"

--- a/.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh
@@ -48,6 +48,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
 
 CORE_SH="${REPO_ROOT}/.agents/scripts/pulse-dispatch-core.sh"
+DISPATCH_LIB_SH="${REPO_ROOT}/.agents/scripts/pulse-dispatch-lib.sh"
 LARGE_FILE_GATE_SH="${REPO_ROOT}/.agents/scripts/pulse-dispatch-large-file-gate.sh"
 TRIAGE_SH="${REPO_ROOT}/.agents/scripts/pulse-triage.sh"
 
@@ -104,7 +105,7 @@ _extract_function_body() {
 	' "$file"
 }
 
-_count_gh_issue_view_in_function() {
+_count_issue_view_in_function() {
 	# Counts ACTUAL `gh issue view` invocations — skips lines whose first
 	# non-whitespace character is `#` (shell comments). Without this filter
 	# the t2996 audit markers in the function bodies (which legitimately
@@ -114,7 +115,7 @@ _count_gh_issue_view_in_function() {
 	local fname="$2"
 	_extract_function_body "$file" "$fname" \
 		| grep -vE '^[[:space:]]*#' \
-		| grep -cE 'gh issue view ' || true
+		| grep -cE '(gh issue view |gh_issue_view )' || true
 }
 
 # ---------------------------------------------------------------------------
@@ -125,7 +126,7 @@ test_canonical_bundle_includes_body() {
 	body=$(_extract_function_body "$CORE_SH" "dispatch_with_dedup")
 
 	# shellcheck disable=SC2016 # Literal '$issue_number' inside regex pattern is intentional.
-	if printf '%s' "$body" | grep -qE 'gh issue view "\$issue_number" --repo "\$repo_slug" \\$'; then
+	if printf '%s' "$body" | grep -qE 'gh_issue_view "\$issue_number" --repo "\$repo_slug" \\$'; then
 		# header line present; check the next line includes body
 		if printf '%s' "$body" | grep -qE -- '--json number,title,state,labels,assignees,body'; then
 			_print_result "dispatch_with_dedup canonical gh call includes body" 1
@@ -142,7 +143,7 @@ test_canonical_bundle_includes_body() {
 # ---------------------------------------------------------------------------
 test_dispatch_with_dedup_single_gh_call() {
 	local count
-	count=$(_count_gh_issue_view_in_function "$CORE_SH" "dispatch_with_dedup")
+	count=$(_count_issue_view_in_function "$CORE_SH" "dispatch_with_dedup")
 	count="${count//[!0-9]/}"
 	count="${count:-0}"
 	if [[ "$count" -eq 1 ]]; then
@@ -159,7 +160,7 @@ test_dispatch_with_dedup_single_gh_call() {
 # ---------------------------------------------------------------------------
 test_check_layers_no_gh_issue_view() {
 	local count
-	count=$(_count_gh_issue_view_in_function "$CORE_SH" "_dispatch_dedup_check_layers")
+	count=$(_count_issue_view_in_function "$CORE_SH" "_dispatch_dedup_check_layers")
 	count="${count//[!0-9]/}"
 	count="${count:-0}"
 	if [[ "$count" -eq 0 ]]; then
@@ -268,6 +269,24 @@ test_t2996_markers_present() {
 	fi
 }
 
+# ---------------------------------------------------------------------------
+# Test 9: pre-dedup placeholder-body check uses REST, not `gh issue view`.
+# This path runs before the canonical dispatch_with_dedup bundle exists, so it
+# must avoid an extra GraphQL-backed CLI read per candidate.
+# ---------------------------------------------------------------------------
+test_dispatch_skip_candidate_body_uses_rest() {
+	local body
+	body=$(_extract_function_body "$DISPATCH_LIB_SH" "_dispatch_should_skip_candidate")
+	if printf '%s' "$body" | grep -qE 'gh api "repos/\$\{repo_slug\}/issues/\$\{issue_number\}"' \
+		&& ! printf '%s' "$body" | grep -vE '^[[:space:]]*#' | grep -qE 'gh issue view .*body'; then
+		_print_result "_dispatch_should_skip_candidate fetches body via REST" 1
+	else
+		_print_result "_dispatch_should_skip_candidate fetches body via REST" 0 \
+			"expected gh api repos/\${repo_slug}/issues/\${issue_number} and no active gh issue view --json body"
+	fi
+	return 0
+}
+
 main() {
 	test_canonical_bundle_includes_body || true
 	test_dispatch_with_dedup_single_gh_call || true
@@ -277,6 +296,7 @@ main() {
 	test_ensure_issue_body_has_brief_accepts_meta || true
 	test_check_dispatch_dedup_passes_meta_env || true
 	test_t2996_markers_present || true
+	test_dispatch_skip_candidate_body_uses_rest || true
 
 	printf '\n--- Tests run: %d, failed: %d ---\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -25,5 +25,6 @@ output="$TMP_DIR/out.txt"
 grep -q 'Dispatch alive: true' "$output"
 grep -q 'Worker terminal events: 1' "$output"
 grep -q 'dispatch_backoff_skipped' "$output"
+grep -q 'GraphQL budget:' "$output"
 
 printf 'PASS pulse-current-state-helper\n'

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -140,7 +140,9 @@ reset_test_state() {
 	: >"$LOGFILE"
 	: >"$STATS_COUNTER_FILE"
 	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
+	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER 2>/dev/null || true
+	unset AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL 2>/dev/null || true
 	unset STUB_GH_FAIL 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
@@ -316,6 +318,7 @@ test_state_file_lifecycle() {
 
 	# Recover.
 	STUB_GH_REMAINING=1000
+	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	is_graphql_budget_sufficient || true
 	if [[ ! -f "$state_file" ]]; then
 		pass "state file cleared on recovery"
@@ -351,6 +354,22 @@ test_status_output_tripped() {
 		pass "status output shows TRIPPED when budget exhausted"
 	else
 		fail "status should show TRIPPED (got: $output)"
+	fi
+	return 0
+}
+
+# --- Test 14: Cached-only status does not call gh on cache hit ---
+test_status_cached_only_uses_cache() {
+	reset_test_state
+	STUB_GH_REMAINING=4321
+	local output
+	output=$(_circuit_breaker_status 2>/dev/null)
+	STUB_GH_REMAINING=1
+	output=$(_circuit_breaker_status cached-only 2>/dev/null)
+	if [[ "$output" == OK:*remaining=4321/5000* ]]; then
+		pass "cached-only status reuses cached rate_limit response"
+	else
+		fail "cached-only status should reuse cached response (got: $output)"
 	fi
 	return 0
 }
@@ -675,6 +694,7 @@ test_stats_counter_no_increment_on_pass
 test_state_file_lifecycle
 test_status_output_ok
 test_status_output_tripped
+test_status_cached_only_uses_cache
 test_log_message_on_trip
 
 # =============================================================================

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -252,7 +252,7 @@ assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
 assert_contains "5c: human output shows succeeded count" "Succeeded:                   2" "$OUT"
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
-assert_contains "5e: human output shows --no-pr-check note" "--no-pr-check" "$OUT"
+assert_contains "5e: human output shows pr-check opt-in note" "use --pr-check" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Section 6: solved:worker attribution query excludes origin-only PR counts.
@@ -275,7 +275,7 @@ EOF
 chmod +x "$GH_STUB_DIR/gh"
 
 JSON=$(env "${RUN_ENV[@]}" "GH_CALL_LOG=$GH_CALL_LOG" "PATH=$GH_STUB_DIR:$PATH" \
-	"$HELPER" summary --since 24h --repo marcusquinn/aidevops --json 2>&1)
+	"$HELPER" summary --since 24h --repo marcusquinn/aidevops --pr-check --json 2>&1)
 RC=$?
 assert_rc "6a: solved attribution query exits 0" 0 "$RC"
 assert_eq "6b: solved worker issue count = 2" "2" \

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -12,8 +12,9 @@
 #   2. ~/.aidevops/logs/pulse-stats.json
 #      Pulse-level dispatch counters (each value is an array of unix-second
 #      timestamps; query with `jq '.counters[<name>] // []'`).
-#   3. `gh issue list label:solved:worker --state closed`
-#      External truth: did headless workers actually solve tasks?
+#   3. Optional `gh issue list label:solved:worker --state closed`
+#      External truth: did headless workers actually solve tasks? Disabled by
+#      default because gh issue search uses the GraphQL search path.
 #
 # Replaces the misdiagnosis-prone habit of reading worker-NNN.log mtimes,
 # which was the exact mistake that triggered this task. mtime tells you when
@@ -23,7 +24,7 @@
 # Usage:
 #   worker-activity-helper.sh summary [--since 1h|6h|24h|48h|7d]
 #                                     [--json]
-#                                     [--no-pr-check]
+#                                     [--pr-check|--no-pr-check]
 #                                     [--repo OWNER/REPO]
 #   worker-activity-helper.sh help
 
@@ -224,7 +225,7 @@ _wah_emit_human() {
 	printf '\n'
 	printf 'solved:worker issues closed in window:\n'
 	printf '  %s' "$solved_count"
-	[[ "$pr_check_state" == "skipped" ]] && printf '  (--no-pr-check)'
+	[[ "$pr_check_state" == "skipped" ]] && printf '  (skipped; use --pr-check)'
 	[[ "$pr_check_state" == "failed" ]] && printf '  (gh query failed)'
 	printf '\n'
 	printf '%s\n' "$divider"
@@ -289,7 +290,7 @@ _wah_emit_json() {
 # to the right emitter.
 #######################################
 cmd_summary() {
-	local since_label="24h" emit_json=0 do_pr_check=1 repo_label=""
+	local since_label="24h" emit_json=0 do_pr_check=0 repo_label=""
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
@@ -299,6 +300,10 @@ cmd_summary() {
 			;;
 		--json)
 			emit_json=1
+			shift
+			;;
+		--pr-check)
+			do_pr_check=1
 			shift
 			;;
 		--no-pr-check)
@@ -383,13 +388,14 @@ Usage:
 Options:
   --since 1h|6h|24h|48h|7d   Lookback window (default: 24h)
   --json                     Emit machine-readable JSON
-  --no-pr-check              Skip the gh solved-issue query (offline / rate-limited)
+  --pr-check                 Run the gh solved-issue query (GraphQL search path)
+  --no-pr-check              Explicitly keep the gh solved-issue query skipped (default)
   --repo OWNER/REPO          Constrain solved-issue query to a single repo
 
 Sources read (in canonical-precedence order):
   1. ~/.aidevops/logs/headless-runtime-metrics.jsonl  (worker outcomes)
   2. ~/.aidevops/logs/pulse-stats.json                (dispatch counters)
-  3. gh issue list label:solved:worker                (external truth)
+  3. gh issue list label:solved:worker                (optional external truth)
 
 Examples:
   # Last 24 hours, human-readable.
@@ -400,6 +406,9 @@ Examples:
 
   # Last 7 days, single repo, no network call.
   worker-activity-helper.sh summary --since 7d --repo marcusquinn/aidevops --no-pr-check
+
+  # Include solved:worker issue search when GraphQL budget is healthy.
+  worker-activity-helper.sh summary --since 24h --pr-check
 
 NOT a substitute for:
   - worker-NNN.log mtime → file touch time, not outcome.


### PR DESCRIPTION
## Summary

Added short-lived rate_limit caching, switched pre-dispatch issue-body reads to REST, made solved-worker searches opt-in, surfaced cached budget and top GraphQL consumers in current-state diagnostics, and documented the low-budget workflow.

## Files Changed

.agents/reference/worker-diagnostics.md,.agents/scripts/pulse-current-state-helper.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/pulse-rate-limit-circuit-breaker.sh,.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh,.agents/scripts/tests/test-pulse-current-state-helper.sh,.agents/scripts/tests/test-rate-limit-circuit-breaker.sh,.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck touched shell scripts; bash .agents/scripts/tests/test-rate-limit-circuit-breaker.sh; bash .agents/scripts/tests/test-worker-activity-helper.sh; bash .agents/scripts/tests/test-pulse-current-state-helper.sh; bash .agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh; npx --yes markdownlint-cli2 .agents/reference/worker-diagnostics.md; .agents/scripts/pulse-rate-limit-circuit-breaker.sh status graphql; .agents/scripts/pulse-current-state-helper.sh --window 15m; .agents/scripts/worker-activity-helper.sh summary --since 1h --json --no-pr-check

Resolves #22257


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 183,503 tokens on this as a headless worker.