### PR TITLE
t3421: improve worker telemetry

### DIFF
--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -231,6 +231,14 @@ If aidevops attributes are missing in a mode where they should work:
 
 - `observability-helper.sh cache-health` — prompt cache hit rate per model
 - `observability-helper.sh rate-limits` — provider quota telemetry
+- `pulse-current-state-helper.sh --window 15m [--json]` — live pulse throughput
+  snapshot. It aggregates recent dispatch stages, worker outcomes, resource
+  context, GraphQL-budget counters, and top recent examples so “is work
+  happening now?” can be answered from current evidence.
+- `worker-activity-helper.sh summary --since 1h [--json]` — historical worker
+  outcome summary. JSON output includes `metrics.result_counts`,
+  `metrics.timing_ms`, and `metrics.recent_examples` with load context from
+  `headless-runtime-metrics.jsonl`.
 - `session-miner` routine — post-hoc mining of successful/failed sessions
   into the shared memory (SQLite FTS5). Different layer: session-miner
   extracts *lessons* across sessions; OTEL captures per-call *traces*

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -502,6 +502,7 @@ The hold is branch-specific: a different branch or a different issue does not in
 - **REST fallback (t2574, t2744, t2902):** `shared-gh-wrappers.sh` routes eligible writes/reads through REST when GraphQL remaining <= 1500, preserving GraphQL for calls without REST equivalents. Override: `AIDEVOPS_GH_REST_FALLBACK_THRESHOLD`.
 - **Instrumentation (t2902):** routed `gh` calls append to `~/.aidevops/logs/gh-api-calls.log` and aggregate by stage in `~/.aidevops/logs/gh-api-calls-by-stage.json`. Helper: `gh-api-instrument.sh record|report|trim|clear`. Instrumentation is fail-open.
 - **Circuit breaker (t2690, t2744, t2896):** worker dispatch pauses when GraphQL budget is below the emergency 5% floor. Counter: `pulse_dispatch_circuit_broken` in `pulse-stats.json`. Overrides: `AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD`, `AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1`.
+- **Current-state GraphQL telemetry:** `pulse-current-state-helper.sh --window 15m --json` reports `graphql_budget.skipped_low_count`, `graphql_budget.circuit_broken_count`, `graphql_budget.prefetch_throttled_count`, and any recent GraphQL/rate-limit gauges already present in `pulse-stats.json`. This reuses local counters/gauges and does not make duplicate API calls.
 - **Cache priming (t2992, t2994):** `pulse-wrapper.sh::main()` pre-warms L3 per-owner JSON caches after lock/canary/session/dedup gates and before `prefetch_state`. Sentinel: `~/.aidevops/cache/pulse-cache-prime-last-run`; log: `~/.aidevops/logs/pulse-cache-prime.log`; counters: `pulse_cache_prime_runs`, `pulse_cache_prime_failures`; overrides: `AIDEVOPS_SKIP_CACHE_PRIME=1`, `AIDEVOPS_PULSE_PRIME_MAX_AGE`.
 
 Background: t2994 moved priming from `pulse-lifecycle-helper.sh::_start` into `pulse-wrapper.sh::main()` because launchd `KeepAlive` could respawn the pulse before `_start` ran, causing the lifecycle hook to early-return and skip priming.
@@ -551,6 +552,28 @@ worker-activity-helper.sh summary --since 1h --repo <owner/repo>
 The helper combines canonical worker metrics with `solved:worker` closed-issue
 counts. Treat `origin:worker` PR counts as branch-creation telemetry only; they
 are not sufficient evidence of worker productivity.
+
+For “right now” diagnosis, prefer the current-state helper:
+
+```bash
+pulse-current-state-helper.sh --window 15m --json
+```
+
+Key fields:
+
+- `worker_outcomes.spawned` — launch-stage events (`worker_launch_total`) plus
+  recent worker-start lifecycle lines.
+- `worker_outcomes.canary_failed` — canary preflight failure counter plus recent
+  wrapper failure lines.
+- `worker_outcomes.watchdog_killed`, `rate_limited`, `no_op` — classified from
+  `headless-runtime-metrics.jsonl` result/failure fields.
+- `worker_outcomes.pr_opened`, `pr_merged`, `issue_closed` — recent wrapper-log
+  outcome examples for quick operator correlation.
+- `dispatch_stage_timing_ms` — avg/max/count per dispatch stage, separating slow
+  startup (`canary_preflight`, `worker_launch_total`) from slow implementation or
+  later CI/review wait.
+- `resource_context` — recent worker load context (`load_1min`, `load_per_cpu`)
+  and load-blocked dispatch count.
 
 ```bash
 # Measure actual output growth over 15 seconds

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -291,6 +291,16 @@ record = {
     "activity": os.environ.get("ACTIVITY", "0") == "1",
     "duration_ms": int(os.environ.get("DURATION_MS", "0") or 0),
 }
+try:
+    load_1min, _load_5min, _load_15min = os.getloadavg()
+    cpu_count = os.cpu_count() or 0
+    record["load_1min"] = round(load_1min, 2)
+    record["cpu_count"] = cpu_count
+    record["load_per_cpu"] = round(load_1min / cpu_count, 3) if cpu_count else None
+except (AttributeError, OSError):
+    record["load_1min"] = None
+    record["cpu_count"] = os.cpu_count() or 0
+    record["load_per_cpu"] = None
 with open(os.environ["METRICS_PATH"], "a") as f:
     f.write(json.dumps(record, separators=(",", ":")) + "\n")
 PY
@@ -1101,6 +1111,9 @@ _check_system_overload() {
 	is_overloaded=$(awk -v l="$load_1min" -v t="$threshold" 'BEGIN{print (l > t) ? "1" : "0"}')
 	if [[ "$is_overloaded" == "1" ]]; then
 		print_warning "Canary skipped: system overloaded (load_1min=${load_1min}, ncpu=${ncpu}, threshold=${threshold}, multiplier=${CANARY_OVERLOAD_LOAD_MULTIPLIER}) -- canary cold-start cannot complete reliably under contention (t3210)"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "dispatch_load_blocked" 2>/dev/null || true
+		fi
 		return 1
 	fi
 	return 0

--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -46,11 +46,13 @@ main() {
 	local window_s
 	window_s="$(_seconds "$window")"
 	python3 - "$log_dir" "$repo_path" "$window_s" "$as_json" <<'PY'
+import datetime
 import json
 import os
 import subprocess
 import sys
 import time
+from collections import Counter, defaultdict
 
 log_dir, repo_path, window_s, as_json = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4] == '1'
 now = time.time()
@@ -65,19 +67,68 @@ def recent_lines(path, limit=2000):
     return [line.rstrip('\n') for line in lines]
 
 
+def parse_time(value):
+    value = str(value).strip()
+    if not value:
+        return 0.0
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    try:
+        return datetime.datetime.fromisoformat(value.replace('Z', '+00:00')).timestamp()
+    except ValueError:
+        return 0.0
+
+
 def parse_stage(line):
     parts = line.split('\t')
-    for part in parts:
-        try:
-            value = float(part)
-        except ValueError:
-            continue
-        if value > since:
-            return True
-    return False
+    if not parts:
+        return None
+    ts = parse_time(parts[0])
+    if ts < since:
+        return None
+    return {
+        'ts': ts,
+        'issue': parts[1] if len(parts) > 1 else '',
+        'repo': parts[2] if len(parts) > 2 else '',
+        'stage': parts[3] if len(parts) > 3 else 'unknown',
+        'duration_ms': int(parts[4]) if len(parts) > 4 and str(parts[4]).isdigit() else 0,
+    }
 
 
-stage_lines = [line for line in recent_lines(os.path.join(log_dir, 'dispatch-stages.tsv')) if parse_stage(line)]
+def classify_metric(item):
+    result = str(item.get('result') or 'unknown')
+    failure_reason = str(item.get('failure_reason') or '')
+    exit_code = item.get('exit_code')
+    if result == 'success' and exit_code == 0:
+        return 'success'
+    if result in {'watchdog_stall_killed', 'watchdog_stall_continue'}:
+        return result
+    if result in {'rate_limit', 'rate_limit_fast'} or 'rate_limit' in failure_reason:
+        return 'rate_limit'
+    if result in {'worker_noop', 'no_work', 'noop'}:
+        return 'worker_noop'
+    return result
+
+
+def line_count(patterns, lines):
+    count = 0
+    examples = []
+    for line in lines:
+        lower = line.lower()
+        if any(pattern in lower for pattern in patterns):
+            count += 1
+            if len(examples) < 3:
+                examples.append(line[-180:])
+    return count, examples
+
+
+stage_records = []
+for line in recent_lines(os.path.join(log_dir, 'dispatch-stages.tsv')):
+    record = parse_stage(line)
+    if record:
+        stage_records.append(record)
 metrics = []
 for line in recent_lines(os.path.join(log_dir, 'headless-runtime-metrics.jsonl')):
     try:
@@ -88,6 +139,7 @@ for line in recent_lines(os.path.join(log_dir, 'headless-runtime-metrics.jsonl')
         metrics.append(item)
 
 counter_hits = {}
+gauge_values = {}
 stats_path = os.path.join(log_dir, 'pulse-stats.json')
 if os.path.exists(stats_path):
     try:
@@ -97,8 +149,12 @@ if os.path.exists(stats_path):
                 hits = [v for v in values if isinstance(v, (int, float)) and v >= since]
                 if hits:
                     counter_hits[key] = len(hits)
+        for key, item in (stats.get('gauges') or {}).items():
+            if isinstance(item, dict) and float(item.get('ts', 0)) >= since:
+                gauge_values[key] = item.get('value')
     except (OSError, json.JSONDecodeError):
         counter_hits = {}
+        gauge_values = {}
 
 wrapper_activity = []
 for line in recent_lines(os.path.join(log_dir, 'pulse-wrapper.log'), 400):
@@ -107,6 +163,45 @@ for line in recent_lines(os.path.join(log_dir, 'pulse-wrapper.log'), 400):
     if line.strip():
         wrapper_activity.append(line)
 wrapper_activity = wrapper_activity[-10:]
+
+metric_class_counts = Counter(classify_metric(item) for item in metrics)
+stage_counts = Counter(record['stage'] for record in stage_records)
+stage_timing = defaultdict(lambda: {'count': 0, 'sum_ms': 0, 'max_ms': 0})
+for record in stage_records:
+    item = stage_timing[record['stage']]
+    item['count'] += 1
+    item['sum_ms'] += record['duration_ms']
+    item['max_ms'] = max(item['max_ms'], record['duration_ms'])
+stage_timing_summary = {
+    key: {
+        'count': value['count'],
+        'avg_ms': int(value['sum_ms'] / value['count']) if value['count'] else 0,
+        'max_ms': value['max_ms'],
+    }
+    for key, value in stage_timing.items()
+}
+
+worker_spawn_count = stage_counts.get('worker_launch_total', 0) + sum(
+    1 for line in wrapper_activity if 'worker_start' in line or 'worker_started' in line
+)
+canary_fail_count = counter_hits.get('worker_canary_preflight_failed_count', 0) + sum(
+    1 for line in wrapper_activity if 'canary failed' in line.lower()
+)
+load_blocked_count = counter_hits.get('dispatch_load_blocked', 0) + sum(
+    1 for line in wrapper_activity if 'system overloaded' in line.lower() or 'load-blocked' in line.lower()
+)
+rate_limit_count = metric_class_counts.get('rate_limit', 0)
+watchdog_kill_count = metric_class_counts.get('watchdog_stall_killed', 0)
+noop_count = metric_class_counts.get('worker_noop', 0)
+pr_opened_count, pr_opened_examples = line_count(['pr opened', 'opened pr', 'pull request'], wrapper_activity)
+pr_merged_count, pr_merged_examples = line_count(['pr merged', 'merged pr', 'squash merged'], wrapper_activity)
+issue_closed_count, issue_closed_examples = line_count(['issue closed', 'closed issue', 'status:done'], wrapper_activity)
+graphql_budget = {
+    'skipped_low_count': counter_hits.get('pulse_cycle_skipped_graphql_low', 0),
+    'circuit_broken_count': counter_hits.get('pulse_dispatch_circuit_broken', 0),
+    'prefetch_throttled_count': counter_hits.get('pulse_prefetch_budget_throttled', 0),
+    'gauges': {k: v for k, v in gauge_values.items() if 'graphql' in k.lower() or 'budget' in k.lower() or 'rate' in k.lower()},
+}
 
 worktrees = []
 try:
@@ -117,14 +212,39 @@ except (OSError, subprocess.CalledProcessError):
 
 result = {
     'window_seconds': window_s,
-    'dispatch_stage_events': len(stage_lines),
+    'dispatch_stage_events': len(stage_records),
+    'dispatch_stage_counts': dict(stage_counts),
+    'dispatch_stage_timing_ms': stage_timing_summary,
     'worker_terminal_events': len(metrics),
-    'worker_successes': sum(1 for item in metrics if item.get('result') == 'success'),
-    'worker_failures_or_stalls': sum(1 for item in metrics if item.get('result') and item.get('result') != 'success'),
+    'worker_result_counts': dict(metric_class_counts),
+    'worker_successes': metric_class_counts.get('success', 0),
+    'worker_failures_or_stalls': sum(count for key, count in metric_class_counts.items() if key != 'success'),
+    'worker_outcomes': {
+        'spawned': worker_spawn_count,
+        'canary_failed': canary_fail_count,
+        'watchdog_killed': watchdog_kill_count,
+        'rate_limited': rate_limit_count,
+        'no_op': noop_count,
+        'pr_opened': pr_opened_count,
+        'pr_merged': pr_merged_count,
+        'issue_closed': issue_closed_count,
+    },
+    'worker_outcome_examples': {
+        'pr_opened': pr_opened_examples,
+        'pr_merged': pr_merged_examples,
+        'issue_closed': issue_closed_examples,
+    },
+    'resource_context': {
+        'load_1min_last': next((item.get('load_1min') for item in reversed(metrics) if item.get('load_1min') is not None), None),
+        'load_per_cpu_last': next((item.get('load_per_cpu') for item in reversed(metrics) if item.get('load_per_cpu') is not None), None),
+        'load_blocked_count': load_blocked_count,
+    },
+    'graphql_budget': graphql_budget,
     'pulse_counter_hits': counter_hits,
+    'pulse_gauges': gauge_values,
     'wrapper_activity_lines': len(wrapper_activity),
     'worker_worktrees': len(worktrees),
-    'dispatch_alive': bool(stage_lines or metrics or counter_hits or worktrees),
+    'dispatch_alive': bool(stage_records or metrics or counter_hits or worktrees),
 }
 
 if as_json:
@@ -134,7 +254,11 @@ else:
     print(f'- Window: {window_s}s')
     print(f'- Dispatch alive: {str(result["dispatch_alive"]).lower()}')
     print(f'- Dispatch stage events: {result["dispatch_stage_events"]}')
+    print(f'- Dispatch stage counts: {json.dumps(result["dispatch_stage_counts"], sort_keys=True)}')
     print(f'- Worker terminal events: {result["worker_terminal_events"]} ({result["worker_successes"]} success, {result["worker_failures_or_stalls"]} non-success)')
+    print(f'- Worker outcomes: {json.dumps(result["worker_outcomes"], sort_keys=True)}')
+    print(f'- Resource context: {json.dumps(result["resource_context"], sort_keys=True)}')
+    print(f'- GraphQL budget: {json.dumps(result["graphql_budget"], sort_keys=True)}')
     print(f'- Pulse counter hits: {json.dumps(counter_hits, sort_keys=True)}')
     print(f'- Worker worktrees: {result["worker_worktrees"]}')
     if wrapper_activity:

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -79,6 +79,21 @@ pulse_dispatch_debug_log() {
 }
 
 #######################################
+# Increment a pulse-stats counter when the stats helper is loaded.
+#
+# Arguments:
+#   $1 - counter name
+# Returns: 0 always (telemetry must never block dispatch).
+#######################################
+_dispatch_stats_increment() {
+	local counter_name="$1"
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "$counter_name" 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
 # Compute the dispatch capacity for this round.
 #
 # Stdout: "<max_workers> <active_workers> <available_slots>" on success.
@@ -101,6 +116,7 @@ _dispatch_compute_capacity() {
 		is_graphql_budget_sufficient || _cb_rc=$?
 		if [[ "$_cb_rc" -eq 1 ]]; then
 			echo "[pulse-wrapper] Dispatch_max skipped: GraphQL rate-limit circuit breaker tripped (t2690)" >>"$LOGFILE"
+			_dispatch_stats_increment "dispatch_graphql_circuit_blocked"
 			return 1
 		fi
 		# _cb_rc == 2 means API error — fail-open, proceed with dispatch.
@@ -207,6 +223,7 @@ _dispatch_should_skip_candidate() {
 	pulse_dispatch_debug_log "#${issue_number}: check_terminal_blockers rc=${terminal_rc}"
 	if [[ "$terminal_rc" -eq 0 ]]; then
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — terminal blocker detected (check_terminal_blockers rc=0)" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_skipped_terminal_blocker"
 		return 0
 	fi
 
@@ -218,6 +235,7 @@ _dispatch_should_skip_candidate() {
 
 	if fast_fail_is_skipped "$issue_number" "$repo_slug"; then
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — fast-fail threshold reached" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_skipped_fast_fail"
 		return 0
 	fi
 
@@ -231,6 +249,7 @@ _dispatch_should_skip_candidate() {
 		_backoff_output=$(check_dispatch_backoff "$issue_number" "$repo_slug" 2>&1 >/dev/null) || _backoff_rc=$?
 		if [[ "$_backoff_rc" -eq 1 ]]; then
 			echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — ${_backoff_output}" >>"$LOGFILE"
+			_dispatch_stats_increment "dispatch_candidate_skipped_backoff"
 			# Apply NMR when the backoff helper signals 4th+ failure threshold.
 			if printf '%s' "$_backoff_output" | grep -q 'NMR_REQUIRED'; then
 				local _backoff_count=""
@@ -256,10 +275,12 @@ _dispatch_should_skip_candidate() {
 	pulse_dispatch_debug_log "#${issue_number}: body length=${#issue_body}"
 	if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" ]]; then
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — placeholder/empty issue body, needs enrichment before dispatch" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_skipped_empty_body"
 		return 0
 	fi
 	if [[ "$issue_body" == *"no description provided — enrich before dispatch"* ]]; then
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — claim-task-id.sh stub body, needs enrichment before dispatch" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_skipped_empty_body"
 		return 0
 	fi
 
@@ -431,6 +452,7 @@ _dispatch_graphql_budget_allows_next() {
 	local _budget_rc=0
 	is_graphql_budget_sufficient >/dev/null 2>&1 || _budget_rc=$?
 	if [[ "$_budget_rc" -eq 1 ]]; then
+		_dispatch_stats_increment "dispatch_graphql_circuit_blocked"
 		return 1
 	fi
 	return 0
@@ -530,6 +552,7 @@ _dispatch_check_model_concurrency_cap() {
 
 	if ((opus_inflight >= opus_cap)); then
 		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) deferred — opus_concurrency_cap: inflight=${opus_inflight} cap=${opus_cap} model=${resolved_model} (retry next cycle)" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_deferred_model_cap"
 		return 1
 	fi
 	return 0
@@ -620,6 +643,11 @@ _dispatch_process_candidate() {
 		"$self_login" "$repo_path" "$prompt" "issue-${issue_number}" "$model_override" || dispatch_rc=$?
 	if [[ "$dispatch_rc" -ne 0 ]]; then
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — dispatch_with_dedup returned rc=${dispatch_rc}" >>"$LOGFILE"
+		if [[ "$dispatch_rc" -eq 2 ]]; then
+			_dispatch_stats_increment "dispatch_candidate_noop"
+		else
+			_dispatch_stats_increment "dispatch_candidate_failed"
+		fi
 		return 1
 	fi
 
@@ -631,9 +659,11 @@ _dispatch_process_candidate() {
 	check_worker_launch "$issue_number" "$repo_slug" >/dev/null 2>&1 || launch_rc=$?
 	if [[ "$launch_rc" -ne 0 ]]; then
 		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) launch validation failed (rc=${launch_rc}, last_failure='${_PULSE_LAST_LAUNCH_FAILURE}')" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_worker_launch_failed"
 		_dispatch_record_launch_failure
 		return 1
 	fi
+	_dispatch_stats_increment "dispatch_worker_spawned"
 
 	# Launch confirmed. Reset consecutive streak and clear throttle if active.
 	_DISPATCH_CONSECUTIVE_NO_WORKER=0

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -13,17 +13,48 @@ python3 - "$TMP_DIR" <<'PY'
 import json, os, sys, time
 root = sys.argv[1]
 now = time.time()
-open(os.path.join(root, 'dispatch-stages.tsv'), 'w').write(f'{now}\tworker_spawn\tissue=1\n')
-open(os.path.join(root, 'headless-runtime-metrics.jsonl'), 'w').write(json.dumps({'ts': now, 'result': 'success'}) + '\n')
-json.dump({'counters': {'dispatch_backoff_skipped': [now]}}, open(os.path.join(root, 'pulse-stats.json'), 'w'))
-open(os.path.join(root, 'pulse-wrapper.log'), 'w').write('[pulse] useful activity\nInstance lock acquired\n')
+iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(now))
+open(os.path.join(root, 'dispatch-stages.tsv'), 'w').write(
+    f'{iso}\t#1\tmarcusquinn/aidevops\tworker_launch_total\t123\n'
+    f'{iso}\t#1\tmarcusquinn/aidevops\tceremony_total\t456\n'
+)
+open(os.path.join(root, 'headless-runtime-metrics.jsonl'), 'w').write(
+    json.dumps({'ts': now, 'result': 'success', 'exit_code': 0, 'duration_ms': 1000, 'load_1min': 1.5, 'load_per_cpu': 0.2}) + '\n' +
+    json.dumps({'ts': now, 'result': 'watchdog_stall_killed', 'exit_code': 79, 'duration_ms': 2000}) + '\n' +
+    json.dumps({'ts': now, 'result': 'rate_limit_fast', 'exit_code': 80, 'failure_reason': 'rate_limit_fast'}) + '\n' +
+    json.dumps({'ts': now, 'result': 'worker_noop', 'exit_code': 2}) + '\n'
+)
+json.dump({
+    'counters': {
+        'dispatch_backoff_skipped': [now],
+        'worker_canary_preflight_failed_count': [now],
+        'pulse_cycle_skipped_graphql_low': [now],
+        'dispatch_load_blocked': [now],
+    },
+    'gauges': {'graphql_remaining': {'value': 1234, 'ts': now}},
+}, open(os.path.join(root, 'pulse-stats.json'), 'w'))
+open(os.path.join(root, 'pulse-wrapper.log'), 'w').write('[pulse] useful activity\nPR opened #2\nPR merged #2\nissue closed #1\nInstance lock acquired\n')
 PY
 
 output="$TMP_DIR/out.txt"
 "$HELPER" --log-dir "$TMP_DIR" --repo-path "$PWD" --window 15m >"$output"
 
 grep -q 'Dispatch alive: true' "$output"
-grep -q 'Worker terminal events: 1' "$output"
+grep -q 'Worker terminal events: 4' "$output"
 grep -q 'dispatch_backoff_skipped' "$output"
+grep -q 'worker_launch_total' "$output"
+grep -q 'watchdog_killed' "$output"
+grep -q 'rate_limited' "$output"
+grep -q 'canary_failed' "$output"
+
+json_output="$TMP_DIR/out.json"
+"$HELPER" --log-dir "$TMP_DIR" --repo-path "$PWD" --window 15m --json >"$json_output"
+jq -e '.worker_outcomes.spawned == 1' "$json_output" >/dev/null
+jq -e '.worker_outcomes.watchdog_killed == 1' "$json_output" >/dev/null
+jq -e '.worker_outcomes.rate_limited == 1' "$json_output" >/dev/null
+jq -e '.worker_outcomes.no_op == 1' "$json_output" >/dev/null
+jq -e '.worker_outcomes.canary_failed == 1' "$json_output" >/dev/null
+jq -e '.graphql_budget.skipped_low_count == 1' "$json_output" >/dev/null
+jq -e '.dispatch_stage_timing_ms.worker_launch_total.avg_ms == 123' "$json_output" >/dev/null
 
 printf 'PASS pulse-current-state-helper\n'

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -103,7 +103,7 @@ T_25H_AGO=$((NOW - 90000))
 #                      result-name-based fallthrough, NOT exit-code-based —
 #                      this record must count as wc, NOT as of.
 {
-	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0}\n' "$T_5MIN_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-3","result":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-4","result":"watchdog_stall_continue","exit_code":0}\n' "$T_5MIN_AGO"
@@ -190,6 +190,12 @@ assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
 assert_eq "2g: rate_limited = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.rate_limited')"
 assert_eq "2h: other_failure = 1 (NOT 2 — heartbeat exclusion lock)" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
+assert_eq "2h2: rich result_counts includes success bucket" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.success')"
+assert_eq "2h3: timing summary includes samples" "7" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
+assert_eq "2h4: recent example carries load context" "2.0" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
 
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \
@@ -253,6 +259,7 @@ assert_contains "5c: human output shows succeeded count" "Succeeded:            
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
 assert_contains "5e: human output shows --no-pr-check note" "--no-pr-check" "$OUT"
+assert_contains "5f: human output shows timing summary" "Timing ms" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Section 6: solved:worker attribution query excludes origin-only PR counts.

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -113,6 +113,46 @@ _wah_aggregate_metrics() {
 }
 
 #######################################
+# Emit richer metric detail for JSON consumers.
+#
+# $1 — cutoff_epoch (entries with ts < cutoff are dropped).
+# stdout — JSON object containing result counts, duration summary, and examples.
+#######################################
+_wah_metric_details_json() {
+	local cutoff_epoch="$1"
+	local metrics="$WAH_METRICS_FILE"
+
+	if [[ ! -f "$metrics" ]]; then
+		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[]}'
+		return 0
+	fi
+
+	jq -rn --argjson cutoff "$cutoff_epoch" '
+		[inputs | select((.ts // 0) >= $cutoff)] as $w
+		| ($w | map(.duration_ms // 0)) as $durations
+		| {
+			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
+			timing_ms: {
+				samples: ($durations | length),
+				avg: (if ($durations | length) > 0 then (($durations | add) / ($durations | length) | floor) else 0 end),
+				max: (if ($durations | length) > 0 then ($durations | max) else 0 end)
+			},
+			recent_examples: ($w | sort_by(.ts // 0) | reverse | .[0:5] | map({
+				ts,
+				session_key,
+				result,
+				exit_code,
+				failure_reason,
+				duration_ms,
+				load_1min,
+				load_per_cpu
+			}))
+		}' <"$metrics" 2>/dev/null || \
+		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[]}'
+	return 0
+}
+
+#######################################
 # Count pulse-stats counter entries since cutoff.
 # Counter values in pulse-stats.json are arrays of unix-second timestamps.
 # Reading via `// []` handles missing keys without masking real counts.
@@ -192,6 +232,7 @@ _wah_emit_human() {
 	local total="$3" succ="$4" wk="$5" wc="$6" rl="$7" of="$8"
 	local cb="$9" gqlow="${10}" db_skip="${11}" nwbreaker="${12}"
 	local solved_count="${13}" pr_check_state="${14}" repo_label="${15}"
+	local details_json="${16}"
 
 	local divider="==========================================================="
 
@@ -215,6 +256,11 @@ _wah_emit_human() {
 	printf '  Watchdog stall-continued:    %d  (heartbeat, not terminal)\n' "$wc"
 	printf '  Rate-limited:                %d\n' "$rl"
 	printf '  Other failure:               %d\n' "$of"
+	printf '  Result classes:              %s\n' "$(printf '%s' "$details_json" | jq -c '.result_counts' 2>/dev/null || printf '{}')"
+	printf '  Timing ms (avg/max/samples): %s/%s/%s\n' \
+		"$(printf '%s' "$details_json" | jq -r '.timing_ms.avg // 0' 2>/dev/null || printf '0')" \
+		"$(printf '%s' "$details_json" | jq -r '.timing_ms.max // 0' 2>/dev/null || printf '0')" \
+		"$(printf '%s' "$details_json" | jq -r '.timing_ms.samples // 0' 2>/dev/null || printf '0')"
 	printf '\n'
 	printf 'pulse-stats.json (dispatch-side counters):\n'
 	printf '  pulse_dispatch_circuit_broken:           %d\n' "$cb"
@@ -239,6 +285,7 @@ _wah_emit_json() {
 	local total="$4" succ="$5" wk="$6" wc="$7" rl="$8" of="$9"
 	local cb="${10}" gqlow="${11}" db_skip="${12}" nwbreaker="${13}"
 	local solved_count="${14}" pr_check_state="${15}" repo_label="${16}"
+	local details_json="${17}"
 
 	# solved_count may be "?" on gh failure — coerce to null in JSON.
 	local solved_json="$solved_count"
@@ -259,6 +306,7 @@ _wah_emit_json() {
 		--argjson db_skip "$db_skip" \
 		--argjson nwbreaker "$nwbreaker" \
 		--argjson solved_count "$solved_json" \
+		--argjson details "$details_json" \
 		--arg pr_check_state "$pr_check_state" \
 		--arg repo "$repo_label" \
 		'{
@@ -270,7 +318,10 @@ _wah_emit_json() {
 				watchdog_killed: $wk,
 				watchdog_continued: $wc,
 				rate_limited: $rl,
-				other_failure: $of
+				other_failure: $of,
+				result_counts: $details.result_counts,
+				timing_ms: $details.timing_ms,
+				recent_examples: $details.recent_examples
 			},
 			pulse_stats: {
 				pulse_dispatch_circuit_broken: $cb,
@@ -334,9 +385,10 @@ cmd_summary() {
 		cutoff_iso="(unknown)"
 
 	# Aggregate metrics (single jq+awk pass).
-	local agg total succ wk wc rl of
+	local agg total succ wk wc rl of details_json
 	agg=$(_wah_aggregate_metrics "$cutoff_epoch")
 	read -r total succ wk wc rl of <<<"$agg"
+	details_json=$(_wah_metric_details_json "$cutoff_epoch")
 
 	# Pulse-stats counters.
 	local cb gqlow db_skip nwbreaker
@@ -359,12 +411,12 @@ cmd_summary() {
 		_wah_emit_json "$since_label" "$cutoff_iso" "$cutoff_epoch" \
 			"$total" "$succ" "$wk" "$wc" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
-			"$pr_count" "$pr_check_state" "$repo_label"
+			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
 	else
 		_wah_emit_human "$since_label" "$cutoff_iso" \
 			"$total" "$succ" "$wk" "$wc" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
-			"$pr_count" "$pr_check_state" "$repo_label"
+			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Added richer worker outcome, timing, resource, dispatch, and GraphQL budget telemetry to worker activity/current-state diagnostics, with documentation updates.

## Files Changed

.agents/reference/observability.md,.agents/reference/worker-diagnostics.md,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/pulse-current-state-helper.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-current-state-helper.sh,.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck touched shell scripts and tests; bash .agents/scripts/tests/test-worker-activity-helper.sh; bash .agents/scripts/tests/test-pulse-current-state-helper.sh; worker-activity-helper.sh summary --since 1h --json --no-pr-check; pulse-current-state-helper.sh --window 15m --json; npx --yes markdownlint-cli2 .agents/reference/observability.md .agents/reference/worker-diagnostics.md

Resolves #22256


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 174,125 tokens on this as a headless worker.