### PR TITLE
t3424: add manual worker launcher

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -26,6 +26,31 @@ Pulse cycle (every 3 min, configurable)
     → On failure: CLAIM_RELEASED posted, issue available for re-dispatch
 ```
 
+## Manual Worker Launch
+
+Use `aidevops launch-worker` when an operator needs a controlled headless
+worker launch instead of waiting for the next pulse cycle. Common cases:
+
+- Smoke-test a newly filed issue.
+- Retry after fixing a dispatch blocker.
+- Validate worker-readiness for a brief.
+- Start a small batch with an explicit model.
+
+Examples:
+
+```bash
+aidevops launch-worker 22259 marcusquinn/aidevops --dry-run
+aidevops launch-worker 22259 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+aidevops launch-worker --batch 22259,22260 marcusquinn/aidevops --agent Build+
+aidevops launch-worker status 22259 marcusquinn/aidevops
+```
+
+The command wraps `dispatch-single-issue-helper.sh dispatch`, so it preserves the
+manual-dispatch ceremony: open-issue validation, parent-task block, fail-closed
+dedup check, `status:queued`, `origin:worker`, runner assignment, worktree
+creation from `origin/<default>`, and ledger registration. It is not a pulse
+replacement; the pulse still owns scanning, cadence, capacity, and merge flow.
+
 ## Architecture Decisions
 
 ### SQLite DB Isolation (v3.6.130)

--- a/.agents/scripts/commands/launch-worker.md
+++ b/.agents/scripts/commands/launch-worker.md
@@ -1,0 +1,68 @@
+---
+description: Manually launch headless workers against one or more GitHub issues.
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Args: `$ARGUMENTS` — `<issue|issue,issue> [owner/repo] [--model <id>] [--agent <name>] [--batch <list>] [--dry-run]`
+
+## What this does
+
+Runs the first-class manual worker launcher:
+
+```bash
+aidevops launch-worker $ARGUMENTS
+```
+
+Use it when an operator needs to start workers intentionally instead of waiting
+for the next pulse cycle: smoke-testing a new issue, retrying after fixing a
+dispatch blocker, or launching a controlled batch with a specific model.
+
+## Syntax
+
+```bash
+# Preview one dispatch without launching
+aidevops launch-worker 22259 marcusquinn/aidevops --dry-run
+
+# Launch one issue with default agent Build+
+aidevops launch-worker 22259 marcusquinn/aidevops
+
+# Force a model and agent
+aidevops launch-worker 22259 marcusquinn/aidevops \
+  --model anthropic/claude-opus-4-7 --agent Build+
+
+# Batch launch
+aidevops launch-worker --batch 22259,22260 marcusquinn/aidevops --dry-run
+
+# Status
+aidevops launch-worker status 22259 marcusquinn/aidevops
+```
+
+## Safety expectations
+
+The launcher delegates to `dispatch-single-issue-helper.sh dispatch`, preserving
+the manual-dispatch ceremony: issue must be open, parent tasks are blocked,
+dedup is checked fail-closed, status moves to `status:queued`, `origin:worker`
+is applied, the runner is assigned, a worktree is created from `origin/<default>`,
+and the dispatch ledger is registered.
+
+## Output
+
+Successful real launches print:
+
+- Worker PID
+- Issue and repo
+- Tier/model
+- Worktree path
+- Log path
+- Session key
+- Status command
+
+## Related
+
+- `aidevops pulse status` — inspect the normal dispatcher.
+- `dispatch-single-issue-helper.sh dispatch` — backend used by this command.
+- `dispatch-ledger-helper.sh check-issue` — ledger source for status output.

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -421,8 +421,9 @@ _dsi_build_prompt() {
 #   $4 - prompt
 #   $5 - tier
 #   $6 - selected_model (may be empty for auto-select)
-#   $7 - worker_log path
-#   $8 - issue_number
+#   $7 - agent_name
+#   $8 - worker_log path
+#   $9 - issue_number
 # Stdout (on success): worker PID (single line)
 # Returns: 0 launched, 1 failed
 #######################################
@@ -433,8 +434,9 @@ _dsi_launch_worker() {
 	local prompt="$4"
 	local tier="$5"
 	local selected_model="$6"
-	local worker_log="$7"
-	local issue_number="$8"
+	local agent_name="$7"
+	local worker_log="$8"
+	local issue_number="$9"
 
 	local -a cmd=(
 		env
@@ -453,6 +455,9 @@ _dsi_launch_worker() {
 	)
 	if [[ -n "$selected_model" ]]; then
 		cmd+=(--model "$selected_model")
+	fi
+	if [[ -n "$agent_name" ]]; then
+		cmd+=(--agent "$agent_name")
 	fi
 
 	# Run in background, redirect stdout/stderr to worker_log so caller
@@ -475,13 +480,14 @@ _dsi_launch_worker() {
 #######################################
 # Parse + validate dispatch args. Sets globals:
 #   _DSI_ARG_ISSUE, _DSI_ARG_REPO, _DSI_ARG_MODEL, _DSI_ARG_DRYRUN,
-#   _DSI_ARG_NO_CEREMONY
+#   _DSI_ARG_NO_CEREMONY, _DSI_ARG_AGENT
 # Returns: 0 ok, 2 invalid usage (caller should propagate)
 #######################################
 _dsi_parse_dispatch_args() {
 	_DSI_ARG_ISSUE=""
 	_DSI_ARG_REPO=""
 	_DSI_ARG_MODEL=""
+	_DSI_ARG_AGENT="Build+"
 	_DSI_ARG_DRYRUN=0
 	_DSI_ARG_NO_CEREMONY=0
 	while [[ $# -gt 0 ]]; do
@@ -497,6 +503,14 @@ _dsi_parse_dispatch_args() {
 				return 2
 			fi
 			_DSI_ARG_MODEL="${2}"
+			shift 2
+			;;
+		--agent)
+			if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+				_dsi_err "--agent requires an agent name (default: Build+)"
+				return 2
+			fi
+			_DSI_ARG_AGENT="${2}"
 			shift 2
 			;;
 		--dry-run)
@@ -568,6 +582,7 @@ _dsi_print_dryrun() {
 	_dsi_info "  Labels:       ${_DSI_ISSUE_LABELS}"
 	_dsi_info "  Tier:         ${_DSI_TIER}"
 	_dsi_info "  Model:        ${_DSI_SELECTED_MODEL:-<auto>}"
+	_dsi_info "  Agent:        ${_DSI_ARG_AGENT}"
 	_dsi_info "  Session key:  ${session_key}"
 	_dsi_info "  Prompt:       $(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")"
 	_dsi_info "  Worktree:     would create auto-<ts>-gh${issue_number}"
@@ -676,7 +691,7 @@ cmd_dispatch() {
 #   $2 repo_slug
 #   $3 session_key
 # Reads: _DSI_ISSUE_URL, _DSI_LOG_DIR, _DSI_WORKTREE_PATH, _DSI_ISSUE_TITLE,
-#        _DSI_TIER, _DSI_SELECTED_MODEL.
+#        _DSI_TIER, _DSI_SELECTED_MODEL, _DSI_ARG_AGENT.
 _dsi_launch_and_report() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -689,7 +704,7 @@ _dsi_launch_and_report() {
 	launch_pid=$(_dsi_launch_worker \
 		"$session_key" "$_DSI_WORKTREE_PATH" "$_DSI_ISSUE_TITLE" \
 		"$prompt" "$_DSI_TIER" "$_DSI_SELECTED_MODEL" \
-		"$worker_log" "$issue_number") || return 1
+		"$_DSI_ARG_AGENT" "$worker_log" "$issue_number") || return 1
 
 	local worker_pid
 	worker_pid=$(_dsi_resolve_worker_pid "$worker_log" "$launch_pid")
@@ -700,6 +715,7 @@ _dsi_launch_and_report() {
 	_dsi_info "  Worker PID: ${worker_pid}"
 	_dsi_info "  Issue:      #${issue_number} (${repo_slug})"
 	_dsi_info "  Tier/model: ${_DSI_TIER} / ${_DSI_SELECTED_MODEL:-<auto>}"
+	_dsi_info "  Agent:      ${_DSI_ARG_AGENT}"
 	_dsi_info "  Worktree:   ${_DSI_WORKTREE_PATH}"
 	_dsi_info "  Log:        ${worker_log}"
 	_dsi_info "  Session:    ${session_key}"
@@ -777,6 +793,7 @@ Usage: dispatch-single-issue-helper.sh dispatch <issue_number> <owner/repo> [opt
 Options:
   --model <id>    Override model (e.g. anthropic/claude-opus-4-7).
                   Default: inferred from tier:* and model:* labels.
+  --agent <name>  Worker agent name. Default: Build+.
   --dry-run       Print planned dispatch without launching.
   --no-ceremony   Skip the pre-launch ceremony (status:queued + origin:worker
                   + assignee normalize). Default: ceremony is ON. Use only
@@ -786,6 +803,7 @@ Options:
 Examples:
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --agent Build+
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --no-ceremony
 EOF
@@ -810,6 +828,9 @@ Examples:
 
   # Force a specific model
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+
+  # Force an agent name (default: Build+)
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --agent Build+
 
   # Check status
   dispatch-single-issue-helper.sh status 20882 marcusquinn/aidevops

--- a/.agents/scripts/tests/test-aidevops-launch-worker-command.sh
+++ b/.agents/scripts/tests/test-aidevops-launch-worker-command.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for the first-class `aidevops launch-worker` command.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+_result() {
+	local name="$1"
+	local failed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$failed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_NC" "$name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_NC" "$name" >&2
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message" >&2
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_help_lists_launch_worker() {
+	local out rc=0
+	out=$(bash "$AIDEVOPS_SH" help 2>&1) || rc=$?
+	local failed=1
+	[[ "$rc" -eq 0 && "$out" == *"launch-worker"* ]] && failed=0
+	_result "help lists launch-worker command" "$failed" "rc=$rc"
+	return 0
+}
+
+test_launch_worker_help() {
+	local out rc=0
+	out=$(bash "$AIDEVOPS_SH" launch-worker --help 2>&1) || rc=$?
+	local failed=1
+	[[ "$rc" -eq 0 && "$out" == *"Usage: aidevops launch-worker"* && "$out" == *"--batch"* ]] && failed=0
+	_result "launch-worker help exposes batch syntax" "$failed" "rc=$rc out=$out"
+	return 0
+}
+
+test_launch_worker_invalid_batch_value() {
+	local out rc=0
+	out=$(bash "$AIDEVOPS_SH" launch-worker --batch --dry-run marcusquinn/aidevops 2>&1) || rc=$?
+	local failed=1
+	[[ "$rc" -eq 2 && "$out" == *"--batch requires"* ]] && failed=0
+	_result "launch-worker rejects missing --batch value" "$failed" "rc=$rc out=$out"
+	return 0
+}
+
+main() {
+	test_help_lists_launch_worker
+	test_launch_worker_help
+	test_launch_worker_invalid_batch_value
+
+	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -391,6 +391,34 @@ test_load_issue_meta_accepts_lowercase_open() {
 	return 0
 }
 
+test_agent_flag_parses_with_default() {
+	reset_test_state
+
+	local rc=0
+	_dsi_parse_dispatch_args 12345 owner/repo >/dev/null 2>&1 || rc=$?
+	local default_agent="$_DSI_ARG_AGENT"
+	local check1=1
+	[[ "$rc" -eq 0 && "$default_agent" == "Build+" ]] && check1=0
+	print_result "default worker agent is Build+" "$check1" \
+		"rc=$rc agent=$default_agent"
+
+	rc=0
+	_dsi_parse_dispatch_args 12345 owner/repo --agent CustomAgent >/dev/null 2>&1 || rc=$?
+	local custom_agent="$_DSI_ARG_AGENT"
+	local check2=1
+	[[ "$rc" -eq 0 && "$custom_agent" == "CustomAgent" ]] && check2=0
+	print_result "--agent overrides worker agent" "$check2" \
+		"rc=$rc agent=$custom_agent"
+
+	rc=0
+	_dsi_parse_dispatch_args 12345 owner/repo --agent --dry-run >/dev/null 2>&1 || rc=$?
+	local check3=1
+	[[ "$rc" -eq 2 ]] && check3=0
+	print_result "--agent requires a value" "$check3" "rc=$rc"
+
+	return 0
+}
+
 test_load_issue_meta_blocks_lowercase_closed() {
 	MOCK_GH_FAIL="0"
 	MOCK_GH_ISSUE_STATE="closed"
@@ -403,6 +431,15 @@ test_load_issue_meta_blocks_lowercase_closed() {
 	print_result "load issue meta blocks lowercase closed" "$check" \
 		"expected rc=1 for closed state, got rc=$rc"
 
+	return 0
+}
+
+test_launch_worker_forwards_agent() {
+	local failed=1
+	if grep -Fq "cmd+=(--agent \"\$agent_name\")" "$HELPER_PATH"; then
+		failed=0
+	fi
+	print_result "worker launch forwards --agent to headless runtime" "$failed"
 	return 0
 }
 
@@ -429,6 +466,8 @@ _run_tests() {
 	test_no_ceremony_flag_parses_correctly
 	test_load_issue_meta_accepts_lowercase_open
 	test_load_issue_meta_blocks_lowercase_closed
+	test_agent_flag_parses_with_default
+	test_launch_worker_forwards_agent
 
 	echo
 	echo "======================================"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -747,6 +747,7 @@ _help_commands() {
 	echo "  update             Update aidevops to the latest version (alias: upgrade)"
 	echo "  upgrade            Alias for update"
 	echo "  pulse <cmd>        Session-based pulse control (start/stop/status)"
+	echo "  launch-worker      Manually launch headless workers for GitHub issues"
 	echo "  auto-update <cmd>  Manage automatic update polling (enable/disable/status)"
 	echo "  repo-sync <cmd>    Daily git pull for repos in parent dirs (enable/disable/status/dirs)"
 	echo "  update-tools       Check for outdated tools (--update to auto-update)"
@@ -975,6 +976,7 @@ cmd_help() {
 	echo "  aidevops doctor --fix        # Interactively remove duplicates"
 	echo "  aidevops update              # Update framework + check projects"
 	echo "  aidevops repos               # List registered projects"
+	echo "  aidevops launch-worker 22259 marcusquinn/aidevops --dry-run"
 	echo "  aidevops repos add           # Register current project"
 	echo "  aidevops detect              # Find unregistered projects"
 	echo "  aidevops update-tools        # Check for outdated tools"
@@ -1026,6 +1028,171 @@ _dispatch_config() {
 		exit 1
 	fi
 	return 0
+}
+
+_launch_worker_usage() {
+	cat <<'EOF'
+Usage: aidevops launch-worker <issue|issue,issue> [owner/repo] [options]
+       aidevops launch-worker --batch <issue,issue> [owner/repo] [options]
+       aidevops launch-worker status <issue> [owner/repo]
+
+Launch one or more headless workers manually without waiting for the pulse.
+
+Options:
+  --model <id>      Override model (for example, anthropic/claude-opus-4-7).
+  --agent <name>    Worker agent name (default: Build+).
+  --batch <list>    Comma-separated issue numbers to launch.
+  --dry-run         Print the planned dispatch without launching.
+  --no-ceremony     Skip status/origin/assignee ceremony (debug only).
+  -h, --help        Show this help.
+
+Output includes the worker PID, worktree path, log path, session key, and a
+status command for each launched issue.
+EOF
+	return 0
+}
+
+_launch_worker_default_repo() {
+	local remote_url=""
+	remote_url=$(git remote get-url origin 2>/dev/null || true)
+	if [[ "$remote_url" =~ github\.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+_launch_worker_helper_path() {
+	local source_dir helper_path
+	source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	helper_path="$source_dir/.agents/scripts/dispatch-single-issue-helper.sh"
+	[[ ! -f "$helper_path" ]] && helper_path="$INSTALL_DIR/.agents/scripts/dispatch-single-issue-helper.sh"
+	[[ ! -f "$helper_path" ]] && helper_path="$AGENTS_DIR/scripts/dispatch-single-issue-helper.sh"
+	if [[ ! -f "$helper_path" ]]; then
+		print_error "dispatch-single-issue-helper.sh not found. Run: aidevops update"
+		return 1
+	fi
+	printf '%s\n' "$helper_path"
+	return 0
+}
+
+_launch_worker_status() {
+	local status_issue="${1:-}"
+	local status_repo="${2:-}"
+	if [[ -z "$status_issue" ]]; then
+		print_error "launch-worker status requires <issue> [owner/repo]"
+		return 2
+	fi
+	if [[ -z "$status_repo" ]]; then
+		status_repo=$(_launch_worker_default_repo) || {
+			print_error "Could not infer owner/repo from git remote; pass it explicitly"
+			return 2
+		}
+	fi
+	local status_helper_path
+	status_helper_path=$(_launch_worker_helper_path) || return 1
+	bash "$status_helper_path" status "$status_issue" "$status_repo"
+	return 0
+}
+
+cmd_launch_worker() {
+	local sub_or_issue="${1:-}"
+	if [[ -z "$sub_or_issue" || "$sub_or_issue" == "help" || "$sub_or_issue" == "--help" || "$sub_or_issue" == "-h" ]]; then
+		_launch_worker_usage
+		return 0
+	fi
+
+	if [[ "$sub_or_issue" == "status" ]]; then
+		shift || true
+		_launch_worker_status "$@"
+		return $?
+	fi
+
+	local issue_spec=""
+	local repo_slug=""
+	local batch_spec=""
+	local -a helper_opts=()
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--batch)
+			if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+				print_error "--batch requires a comma-separated issue list"
+				return 2
+			fi
+			batch_spec="${2}"
+			shift 2
+			;;
+		--model | --agent)
+			if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+				print_error "$arg requires a value"
+				return 2
+			fi
+			helper_opts+=("$arg" "${2}")
+			shift 2
+			;;
+		--dry-run | --no-ceremony)
+			helper_opts+=("$arg")
+			shift
+			;;
+		--help | -h)
+			_launch_worker_usage
+			return 0
+			;;
+		--*)
+			print_error "Unknown launch-worker flag: $arg"
+			return 2
+			;;
+		*)
+			if [[ -z "$issue_spec" ]]; then
+				issue_spec="$arg"
+			elif [[ -z "$repo_slug" ]]; then
+				repo_slug="$arg"
+			else
+				print_error "Unexpected launch-worker argument: $arg"
+				return 2
+			fi
+			shift
+			;;
+		esac
+	done
+
+	[[ -n "$batch_spec" ]] && issue_spec="$batch_spec"
+	if [[ -z "$issue_spec" ]]; then
+		print_error "launch-worker requires an issue number or --batch list"
+		return 2
+	fi
+	if [[ -z "$repo_slug" ]]; then
+		repo_slug=$(_launch_worker_default_repo) || {
+			print_error "Could not infer owner/repo from git remote; pass it explicitly"
+			return 2
+		}
+	fi
+	if [[ ! "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		print_error "Repo slug must be owner/repo format: $repo_slug"
+		return 2
+	fi
+
+	local old_ifs="$IFS"
+	IFS=','
+	local -a issues=()
+	read -r -a issues <<<"$issue_spec"
+	IFS="$old_ifs"
+
+	local helper_path
+	helper_path=$(_launch_worker_helper_path) || return 1
+
+	local issue rc=0
+	for issue in "${issues[@]}"; do
+		if [[ ! "$issue" =~ ^[0-9]+$ ]]; then
+			print_error "Issue number must be numeric: $issue"
+			rc=2
+			continue
+		fi
+		bash "$helper_path" dispatch "$issue" "$repo_slug" "${helper_opts[@]}" || rc=$?
+		echo "Status: aidevops launch-worker status $issue $repo_slug"
+	done
+	return "$rc"
 }
 
 # Emit tip if the current directory has aidevops but isn't registered
@@ -1229,6 +1396,7 @@ main() {
 	sources | agent-sources) _dispatch_helper "agent-sources-helper.sh" "agent-sources-helper.sh" "$@" ;;
 	plugin | plugins) cmd_plugin "$@" ;;
 	pulse) _dispatch_helper "pulse-session-helper.sh" "pulse-session-helper.sh" "$@" ;;
+	launch-worker | launch_worker) cmd_launch_worker "$@" ;;
 	check-workflows | workflows) _dispatch_helper "check-workflows-helper.sh" "check-workflows-helper.sh" "$@" ;;
 	sync-workflows) _dispatch_helper "sync-workflows-helper.sh" "sync-workflows-helper.sh" "$@" ;;
 	badges)


### PR DESCRIPTION
## Summary

Added aidevops launch-worker with single/batch dry-run support, wired dispatch helper agent forwarding, added slash-command docs, diagnostics docs, and regression tests.

## Files Changed

.agents/reference/worker-diagnostics.md,.agents/scripts/commands/launch-worker.md,.agents/scripts/dispatch-single-issue-helper.sh,.agents/scripts/tests/test-aidevops-launch-worker-command.sh,.agents/scripts/tests/test-dispatch-single-issue-helper.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n aidevops.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh .agents/scripts/tests/test-aidevops-launch-worker-command.sh; shellcheck aidevops.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh .agents/scripts/tests/test-aidevops-launch-worker-command.sh; bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh; bash .agents/scripts/tests/test-aidevops-launch-worker-command.sh; bash aidevops.sh launch-worker 22265 marcusquinn/aidevops --dry-run; .agents/scripts/dispatch-single-issue-helper.sh dispatch 22265 marcusquinn/aidevops --dry-run --agent Build+; npx --yes markdownlint-cli2 .agents/scripts/commands/launch-worker.md .agents/reference/worker-diagnostics.md; git diff --check

Resolves #22265


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 14m and 222,850 tokens on this as a headless worker.