### PR TITLE
GH#22268: fix attribution printf hyphen output

### DIFF
--- a/.agents/scripts/attribution-check-helper.sh
+++ b/.agents/scripts/attribution-check-helper.sh
@@ -46,13 +46,13 @@ for label, path in [('source', sys.argv[1]), ('deployed', sys.argv[2])]:
         print(f'- {label}: missing ({path})')
 PY
 	if [[ -n "$claim" ]]; then
-		printf '- Claim: %s (hypothesis until code evidence below matches)\n' "$claim"
+		printf '%s\n' "- Claim: ${claim} (hypothesis until code evidence below matches)"
 	fi
 	if [[ -n "$symbol" ]]; then
 		if rg -n "(^|[[:space:]])${symbol}[[:space:]]*\(" "$source_path" >/dev/null 2>&1; then
-			printf '- Symbol check: found %s in source\n' "$symbol"
+			printf '%s\n' "- Symbol check: found ${symbol} in source"
 		else
-			printf '- Symbol check: missing %s in source\n' "$symbol"
+			printf '%s\n' "- Symbol check: missing ${symbol} in source"
 			printf 'RESULT: hypothesis-only\n'
 			return 1
 		fi

--- a/.agents/scripts/tests/test-attribution-check-helper.sh
+++ b/.agents/scripts/tests/test-attribution-check-helper.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-attribution-check-helper.sh — regression tests for attribution checks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+HELPER="${REPO_ROOT}/.agents/scripts/attribution-check-helper.sh"
+
+pass_count=0
+fail_count=0
+
+_pass() {
+	local msg="$1"
+	printf '  [PASS] %s\n' "$msg"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+_fail() {
+	local msg="$1"
+	printf '  [FAIL] %s\n' "$msg" >&2
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+_assert_contains() {
+	local label="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		_pass "$label"
+	else
+		_fail "$label — missing ${needle}"
+	fi
+	return 0
+}
+
+printf '=== attribution-check-helper tests ===\n\n'
+
+output=$(cd "$REPO_ROOT" && "$HELPER" --file .agents/scripts/attribution-check-helper.sh --symbol main --claim t000 2>&1)
+
+_assert_contains "claim line can begin with hyphen" "$output" "- Claim: t000"
+_assert_contains "symbol-found line can begin with hyphen" "$output" "- Symbol check: found main in source"
+_assert_contains "success result is reported" "$output" "RESULT: evidence-collected"
+
+if missing_output=$(cd "$REPO_ROOT" && "$HELPER" --file .agents/scripts/attribution-check-helper.sh --symbol definitely_missing_symbol_for_test 2>&1); then
+	_fail "missing symbol exits non-zero"
+else
+	_assert_contains "symbol-missing line can begin with hyphen" "$missing_output" "- Symbol check: missing definitely_missing_symbol_for_test in source"
+	_assert_contains "hypothesis-only result is reported" "$missing_output" "RESULT: hypothesis-only"
+fi
+
+printf '\n=== Results ===\n'
+printf '  Passed: %d\n' "$pass_count"
+printf '  Failed: %d\n' "$fail_count"
+
+if [[ "$fail_count" -gt 0 ]]; then
+	exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0


### PR DESCRIPTION
## Summary

Updated attribution-check-helper hyphen-prefixed status lines to use safe printf formatting and added a regression test covering claim, found-symbol, and missing-symbol output.

## Files Changed

.agents/scripts/attribution-check-helper.sh,.agents/scripts/tests/test-attribution-check-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-attribution-check-helper.sh; .agents/scripts/attribution-check-helper.sh --file .agents/scripts/pulse-merge-feedback.sh --symbol _transition_issue_for_redispatch; shellcheck .agents/scripts/attribution-check-helper.sh .agents/scripts/tests/test-attribution-check-helper.sh

Resolves #22268


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 3m and 70,807 tokens on this as a headless worker.