### PR TITLE
GH#22237: skip orphan loop check for fresh worker branches

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -192,7 +192,8 @@ _dlw_resolve_tier_and_model() {
 # module-level globals:
 #   _DLW_WORKTREE_PATH    — absolute path on success, empty on failure
 #   _DLW_WORKTREE_BRANCH  — branch name on success, empty on failure
-# Both are reset on entry so the orchestrator always sees the fresh state.
+#   _DLW_WORKTREE_REUSED  — 1 when an existing issue worktree was reused, else 0
+# All are reset on entry so the orchestrator always sees the fresh state.
 #
 # Issue-linked branch naming (GH#19042):
 #   Branch format: feature/auto-YYYYMMDD-HHMMSS-gh<issue_number>
@@ -328,6 +329,7 @@ _dlw_precreate_worktree() {
 	local repo_path="$2"
 	_DLW_WORKTREE_PATH=""
 	_DLW_WORKTREE_BRANCH=""
+	_DLW_WORKTREE_REUSED=0
 
 	local _wt_helper="${SCRIPT_DIR}/worktree-helper.sh"
 	if [[ ! -x "$_wt_helper" || ! -d "$repo_path" ]]; then
@@ -361,6 +363,7 @@ _dlw_precreate_worktree() {
 		git -C "$_existing_path" reset --hard "origin/${_main_branch}" 2>/dev/null || true
 		_DLW_WORKTREE_PATH="$_existing_path"
 		_DLW_WORKTREE_BRANCH="$_existing_branch"
+		_DLW_WORKTREE_REUSED=1
 		# Restore gitignored deps that git clean -fd just wiped
 		_dlw_restore_worktree_deps "$_DLW_WORKTREE_PATH" "$repo_path"
 		echo "[dispatch_with_dedup] Reusing existing worktree for #${issue_number}: ${_DLW_WORKTREE_PATH} (branch: ${_DLW_WORKTREE_BRANCH})" >>"$LOGFILE"
@@ -915,14 +918,17 @@ Dispatching worker (deterministic).
 # issue-linked branch or creating a fresh branch. A new branch therefore does
 # not inherit an old branch's orphan count.
 #
-# Args: $1 = issue number, $2 = repo slug, $3 = worker worktree branch
+# Args: $1 = issue number, $2 = repo slug, $3 = worker worktree branch,
+#       $4 = 1 when the branch was reused, 0 for a freshly-created branch
 # Returns: exit 0 if dispatch should be held, exit 1 if safe to continue
 #######################################
 _dlw_check_worker_branch_orphan_loop() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local worker_worktree_branch="$3"
+	local worker_worktree_reused="${4:-0}"
 
+	[[ "$worker_worktree_reused" == "1" ]] || return 1
 	[[ -n "$worker_worktree_branch" ]] || return 1
 
 	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
@@ -1057,7 +1063,8 @@ _dispatch_launch_worker() {
 	_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 	local worker_worktree_path="$_DLW_WORKTREE_PATH"
 	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
-	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch"; then
+	local worker_worktree_reused="${_DLW_WORKTREE_REUSED:-0}"
+	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused"; then
 		return 2
 	fi
 

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -7,10 +7,13 @@
 #
 # Asserts that worktree pre-creation failures are observable:
 #   1. _dlw_precreate_worktree returns 1 when path extraction fails
-#   2. _dlw_precreate_worktree returns 0 when worktree creation succeeds
-#   3. _dispatch_launch_worker skips dispatch (no setsid) when pre-creation fails
-#   4. worktree_precreation_failed_count counter is incremented on failure
-#   5. --dir argument no longer contains repo_path fallback
+#   2. _dlw_precreate_worktree marks fresh worktree creation as non-reused
+#   3. _dlw_precreate_worktree marks existing issue worktree reuse
+#   4. _dlw_check_worker_branch_orphan_loop skips fresh branches
+#   5. _dlw_check_worker_branch_orphan_loop still checks reused branches
+#   6. _dispatch_launch_worker skips dispatch (no setsid) when pre-creation fails
+#   7. worktree_precreation_failed_count counter is incremented on failure
+#   8. --dir argument no longer contains repo_path fallback
 #
 # Stub strategy: stub worktree-helper.sh, git, and dependent functions
 # to isolate _dlw_precreate_worktree and _dispatch_launch_worker.
@@ -91,6 +94,9 @@ chmod +x "$STUB_WT_HELPER"
 git() {
 	# For worktree list, return nothing (no existing worktrees)
 	if [[ "${1:-}" == "-C" && "${3:-}" == "worktree" && "${4:-}" == "list" ]]; then
+		if [[ -n "${STUB_EXISTING_WORKTREE_LINE:-}" ]]; then
+			printf '%s\n' "$STUB_EXISTING_WORKTREE_LINE"
+		fi
 		return 0
 	fi
 	# For symbolic-ref, return main
@@ -166,6 +172,17 @@ _dlw_canary_preflight() { return 0; }
 
 printf '\n%s\n' "=== t2981: worktree pre-creation failure observability ==="
 
+# Stub dispatch-dedup-helper.sh used by _dlw_check_worker_branch_orphan_loop.
+STUB_DEDUP_HELPER="${TMP}/dispatch-dedup-helper.sh"
+cat >"$STUB_DEDUP_HELPER" <<'STUB_DEDUP_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >>"${STUB_DEDUP_CALLS_FILE:?}"
+printf 'orphan-loop-detected\n'
+exit 0
+STUB_DEDUP_EOF
+chmod +x "$STUB_DEDUP_HELPER"
+export STUB_DEDUP_CALLS_FILE="${TMP}/dedup-helper-calls.txt"
+
 # =============================================================================
 # Test 1: _dlw_precreate_worktree returns 1 when path extraction fails
 # =============================================================================
@@ -215,13 +232,73 @@ else
 	fail "worktree path is set on success" "got: '$_DLW_WORKTREE_PATH', expected: '$STUB_WT_SUCCESS_PATH'"
 fi
 
+if [[ "${_DLW_WORKTREE_REUSED:-unset}" == "0" ]]; then
+	pass "freshly-created worktree is marked non-reused"
+else
+	fail "freshly-created worktree is marked non-reused" "got: '${_DLW_WORKTREE_REUSED:-unset}', expected: '0'"
+fi
+
 # =============================================================================
-# Test 3: _dispatch_launch_worker skips dispatch when pre-creation fails
+# Test 3: _dlw_precreate_worktree marks existing issue worktree reuse
+# =============================================================================
+export STUB_WT_MODE="fail"
+STUB_EXISTING_PATH="${TMP}/Git/fake-repo-existing"
+STUB_EXISTING_BRANCH="feature/auto-20260502-000000-gh66666"
+mkdir -p "$STUB_EXISTING_PATH"
+export STUB_EXISTING_WORKTREE_LINE="${STUB_EXISTING_PATH} abcdef [${STUB_EXISTING_BRANCH}]"
+: >"$LOGFILE"
+_dlw_precreate_worktree "66666" "$FAKE_REPO"
+rc=$?
+unset STUB_EXISTING_WORKTREE_LINE
+
+if [[ $rc -eq 0 && "$_DLW_WORKTREE_PATH" == "$STUB_EXISTING_PATH" && "$_DLW_WORKTREE_BRANCH" == "$STUB_EXISTING_BRANCH" ]]; then
+	pass "existing issue worktree is reused"
+else
+	fail "existing issue worktree is reused" "rc=$rc path='$_DLW_WORKTREE_PATH' branch='$_DLW_WORKTREE_BRANCH'"
+fi
+
+if [[ "${_DLW_WORKTREE_REUSED:-unset}" == "1" ]]; then
+	pass "reused worktree is marked reused"
+else
+	fail "reused worktree is marked reused" "got: '${_DLW_WORKTREE_REUSED:-unset}', expected: '1'"
+fi
+
+# =============================================================================
+# Test 4: _dlw_check_worker_branch_orphan_loop skips fresh branches
+# =============================================================================
+: >"$STUB_DEDUP_CALLS_FILE"
+if _dlw_check_worker_branch_orphan_loop "55555" "owner/repo" "feature/auto-gh55555" "0"; then
+	fail "fresh branch orphan-loop check is skipped" "check returned hold for a non-reused branch"
+else
+	if [[ ! -s "$STUB_DEDUP_CALLS_FILE" ]]; then
+		pass "fresh branch orphan-loop check is skipped"
+	else
+		fail "fresh branch orphan-loop check is skipped" "dedup helper was called"
+	fi
+fi
+
+# =============================================================================
+# Test 5: _dlw_check_worker_branch_orphan_loop still checks reused branches
+# =============================================================================
+: >"$STUB_DEDUP_CALLS_FILE"
+if _dlw_check_worker_branch_orphan_loop "44444" "owner/repo" "feature/auto-gh44444" "1"; then
+	if grep -q '^check-orphan-loop$' "$STUB_DEDUP_CALLS_FILE" 2>/dev/null; then
+		pass "reused branch orphan-loop check calls dedup helper"
+	else
+		fail "reused branch orphan-loop check calls dedup helper" "helper call log missing check-orphan-loop"
+	fi
+else
+	fail "reused branch orphan-loop check calls dedup helper" "check did not return hold from stub helper"
+fi
+
+# =============================================================================
+# Test 6: _dispatch_launch_worker skips dispatch when pre-creation fails
 # =============================================================================
 # Override _dlw_precreate_worktree to simulate failure
 _dlw_precreate_worktree() {
 	_DLW_WORKTREE_PATH=""
 	_DLW_WORKTREE_BRANCH=""
+	_DLW_WORKTREE_REUSED=0
 	return 1
 }
 
@@ -247,7 +324,7 @@ else
 fi
 
 # =============================================================================
-# Test 4: worktree_precreation_failed_count counter is incremented
+# Test 7: worktree_precreation_failed_count counter is incremented
 # =============================================================================
 local_count=""
 if command -v jq &>/dev/null; then
@@ -267,7 +344,7 @@ else
 fi
 
 # =============================================================================
-# Test 5: --dir argument no longer contains repo_path fallback
+# Test 8: --dir argument no longer contains repo_path fallback
 # =============================================================================
 # Grep the source file for the old pattern (single quotes intentional — literal search)
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary

Tracked whether worker worktree pre-creation reused an existing branch and only ran the orphan-loop GitHub API check for reused branches; added regression coverage for fresh vs reused branch behavior.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-precreation-failure-skip.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-precreation-failure-skip.sh; .agents/scripts/tests/test-precreation-failure-skip.sh

Resolves #22237


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 97,277 tokens on this as a headless worker.