### PR TITLE
t3427: integrate plugin namespaces into subagent discovery

### DIFF
--- a/.agents/aidevops/plugins.md
+++ b/.agents/aidevops/plugins.md
@@ -142,6 +142,12 @@ plugin-loader-helper.sh status     # Show plugin system status
 
 Loading priority: (1) `plugin.json` `agents` array if present; (2) scan directory for `.md` files with YAML frontmatter.
 
+The shared `subagent-index.toon` discovery file is regenerated after plugin add,
+update, enable, and disable actions. `subagent-index-helper.sh generate` preserves
+the core `subagents` TOON block and appends `plugin-loader-helper.sh index` output
+as a lightweight `plugin_agents` block, so runtimes can discover plugin namespaces
+from one startup index without reading every plugin file.
+
 ## Lifecycle Hooks
 
 | Hook | When | Use Case |

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -347,7 +347,7 @@ main() {
 		done < <(rt_detect_installed)
 	fi
 
-	# Regenerate subagent index (shared between runtimes)
+	# Regenerate subagent index (shared between runtimes, includes plugin namespaces)
 	local subagent_index_helper="$AGENTS_DIR/scripts/subagent-index-helper.sh"
 	if [[ -x "$subagent_index_helper" ]]; then
 		print_info "Regenerating subagent index..."

--- a/.agents/scripts/subagent-index-helper.sh
+++ b/.agents/scripts/subagent-index-helper.sh
@@ -17,7 +17,7 @@
 #   - aidevops update
 #   - build-agent workflow (after agent create/promote)
 #
-# Scans: shared agents, custom/, draft/ (all tiers)
+# Scans: shared agents, custom/, draft/ (all tiers), plus enabled plugins
 #
 # Source shared-constants.sh for portable stat functions
 # Performance: pure find + awk pipeline, no per-file reads
@@ -33,8 +33,20 @@ AGENTS_DIR="${HOME}/.aidevops/agents"
 INDEX_FILE="${AGENTS_DIR}/subagent-index.toon"
 
 # Directories to scan for subagents (relative to AGENTS_DIR)
-# Covers all tiers: shared, custom, draft
+# Covers all tiers: shared, custom, draft; plugins are appended separately
 SUBAGENT_DIRS="aidevops content seo tools services workflows memory custom draft"
+
+generate_plugin_agents_block() {
+	local agents_dir="$1"
+	local plugin_loader="${agents_dir}/scripts/plugin-loader-helper.sh"
+
+	if [[ ! -x "$plugin_loader" ]]; then
+		return 0
+	fi
+
+	AIDEVOPS_AGENTS_DIR="$agents_dir" "$plugin_loader" index 2>/dev/null || true
+	return 0
+}
 
 # ---------------------------------------------------------------------------
 # Generate subagents block: pure find + awk (no per-file reads)
@@ -123,16 +135,18 @@ cmd_generate() {
 		return 1
 	fi
 
-	local tmpfile new_block_file result_file
+	local tmpfile new_block_file plugin_block_file result_file
 	tmpfile=$(mktemp)
 	new_block_file=$(mktemp)
+	plugin_block_file=$(mktemp)
 	result_file=$(mktemp)
 
 	generate_subagents_block "$AGENTS_DIR" >"$new_block_file"
+	generate_plugin_agents_block "$AGENTS_DIR" >"$plugin_block_file"
 
 	if [[ -f "$INDEX_FILE" ]]; then
-		# Preserve existing sections (agents, model_tiers, workflows, scripts)
-		# and replace only the subagents block
+		# Preserve existing sections (agents, model_tiers, workflows, scripts),
+		# replace the subagents block, and refresh plugin_agents at EOF.
 		# Uses sed to delete old block, then inserts new block from file
 		local in_block=0
 		while IFS= read -r line; do
@@ -141,20 +155,32 @@ cmd_generate() {
 				cat "$new_block_file"
 				continue
 			fi
+			if [[ "$line" == "<!--TOON:plugin_agents["* ]]; then
+				in_block=1
+				continue
+			fi
 			if [[ "$in_block" -eq 1 ]]; then
 				[[ "$line" == "-->" ]] && in_block=0
 				continue
 			fi
 			echo "$line"
 		done <"$INDEX_FILE" >"$result_file"
+		if [[ -s "$plugin_block_file" ]]; then
+			echo "" >>"$result_file"
+			cat "$plugin_block_file" >>"$result_file"
+		fi
 		mv "$result_file" "$tmpfile"
 	else
 		# No existing file — generate minimal index with just subagents
-		mv "$new_block_file" "$tmpfile"
+		cat "$new_block_file" >"$tmpfile"
+		if [[ -s "$plugin_block_file" ]]; then
+			echo "" >>"$tmpfile"
+			cat "$plugin_block_file" >>"$tmpfile"
+		fi
 	fi
 
 	mv "$tmpfile" "$INDEX_FILE"
-	rm -f "$new_block_file" "$result_file" 2>/dev/null
+	rm -f "$new_block_file" "$plugin_block_file" "$result_file" 2>/dev/null
 
 	# Count entries for summary
 	local entry_count
@@ -164,9 +190,10 @@ cmd_generate() {
 }
 
 cmd_check() {
+	local regenerate_hint="Regenerate with subagent-index-helper.sh generate"
 	if [[ ! -f "$INDEX_FILE" ]]; then
 		echo "Index not found: ${INDEX_FILE}"
-		echo "Run: subagent-index-helper.sh generate"
+		echo "$regenerate_hint"
 		return 1
 	fi
 
@@ -194,10 +221,30 @@ cmd_check() {
 	echo "Declared subagent rows: ${declared_rows}"
 	echo "Actual TOON rows: ${actual_block_rows}"
 
+	local declared_plugin_rows
+	declared_plugin_rows=$(sed -n 's/^<!--TOON:plugin_agents\[\([0-9][0-9]*\)\]{folder,purpose,key_files}:$/\1/p' "$INDEX_FILE")
+	if [[ -n "$declared_plugin_rows" ]]; then
+		local actual_plugin_rows
+		actual_plugin_rows=$(sed -n '/^<!--TOON:plugin_agents\[/,/^-->/p' "$INDEX_FILE" |
+			awk 'BEGIN { in_block = 0; count = 0 }
+				/^<!--TOON:plugin_agents\[/ { in_block = 1; next }
+				/^-->/ { if (in_block) { in_block = 0 }; next }
+				{ if (in_block && NF > 0) { count++ } }
+				END { print count }')
+		echo "Declared plugin rows: ${declared_plugin_rows}"
+		echo "Actual plugin rows: ${actual_plugin_rows}"
+		if [[ "$declared_plugin_rows" != "$actual_plugin_rows" ]]; then
+			echo ""
+			echo "Error: plugin_agents TOON header cardinality mismatch (declared ${declared_plugin_rows}, actual ${actual_plugin_rows})."
+			echo "$regenerate_hint"
+			return 1
+		fi
+	fi
+
 	if [[ "$declared_rows" != "$actual_block_rows" ]]; then
 		echo ""
 		echo "Error: TOON header cardinality mismatch (declared ${declared_rows}, actual ${actual_block_rows})."
-		echo "Run: subagent-index-helper.sh generate"
+		echo "$regenerate_hint"
 		return 1
 	fi
 
@@ -215,9 +262,19 @@ cmd_check() {
 
 	# Count index leaf entries (pipe-separated names)
 	local index_leaves
-	index_leaves=$(sed -n '/^<!--TOON:subagents/,/^-->/p' "$INDEX_FILE" |
-		grep -v '^<!--' | grep -v '^-->' |
-		tr ',' '\n' | grep '|' | tr '|' '\n' | wc -l | tr -d ' ')
+	index_leaves=$(awk '
+		BEGIN { in_block = 0; count = 0 }
+		/^<!--TOON:(subagents|plugin_agents)\[/ { in_block = 1; next }
+		/^-->/ { if (in_block) { in_block = 0 }; next }
+		{
+			if (in_block && NF > 0) {
+				split($0, cols, ",")
+				if (cols[3] != "") {
+					count += split(cols[3], files, "|")
+				}
+			}
+		}
+		END { print count }' "$INDEX_FILE")
 
 	echo "Actual .md files: ${actual_count}"
 	echo "Index leaf entries: ${index_leaves}"
@@ -239,7 +296,7 @@ Usage:
   subagent-index-helper.sh help        Show this help
 
 The index is read by the OpenCode plugin at startup (1 file read vs 500+).
-It covers shared, custom, and draft agent tiers.
+	It covers shared, custom, draft, and enabled plugin agent tiers.
 
 Called automatically by:
   - setup.sh / aidevops update

--- a/.agents/scripts/tests/test-plugin-subagent-index.sh
+++ b/.agents/scripts/tests/test-plugin-subagent-index.sh
@@ -41,9 +41,8 @@ setup() {
 	mkdir -p "$agents_dir/scripts" "$agents_dir/example-plugin" "$config_dir"
 	cp "$REPO_ROOT/.agents/scripts/subagent-index-helper.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/plugin-loader-helper.sh" "$agents_dir/scripts/"
-	cp "$REPO_ROOT/.agents/scripts/shared-constants.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/portable-stat.sh" "$agents_dir/scripts/"
-	cp "$REPO_ROOT"/.agents/scripts/shared-gh-wrappers*.sh "$agents_dir/scripts/"
+	cp "$REPO_ROOT"/.agents/scripts/shared-*.sh "$agents_dir/scripts/"
 	chmod +x "$agents_dir/scripts/subagent-index-helper.sh" "$agents_dir/scripts/plugin-loader-helper.sh"
 
 	cat >"$config_dir/plugins.json" <<'JSON'

--- a/.agents/scripts/tests/test-plugin-subagent-index.sh
+++ b/.agents/scripts/tests/test-plugin-subagent-index.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#22270: enabled plugin namespaces appear in the shared
+# subagent discovery index without startup-time reads of every plugin file.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+TEST_HOME=""
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_HOME=$(mktemp -d)
+	trap teardown EXIT
+
+	local agents_dir="$TEST_HOME/.aidevops/agents"
+	local config_dir="$TEST_HOME/.config/aidevops"
+	mkdir -p "$agents_dir/scripts" "$agents_dir/example-plugin" "$config_dir"
+	cp "$REPO_ROOT/.agents/scripts/subagent-index-helper.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT/.agents/scripts/plugin-loader-helper.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT/.agents/scripts/shared-constants.sh" "$agents_dir/scripts/"
+	chmod +x "$agents_dir/scripts/subagent-index-helper.sh" "$agents_dir/scripts/plugin-loader-helper.sh"
+
+	cat >"$config_dir/plugins.json" <<'JSON'
+{"plugins":[{"name":"Example Plugin","repo":"local","branch":"main","namespace":"example-plugin","enabled":true}]}
+JSON
+	cat >"$agents_dir/example-plugin/plugin.json" <<'JSON'
+{"name":"Example Plugin","version":"1.0.0","description":"Example plugin agents","agents":[{"file":"example-agent.md","name":"example-agent","description":"Example agent","model":"sonnet"}]}
+JSON
+	cat >"$agents_dir/example-plugin/example-agent.md" <<'EOF_AGENT'
+---
+name: example-agent
+mode: subagent
+---
+# Example Agent
+EOF_AGENT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_HOME" && -d "$TEST_HOME" ]]; then
+		rm -rf "$TEST_HOME"
+	fi
+	return 0
+}
+
+test_plugin_namespace_indexed() {
+	local output=""
+	local status=0
+	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" generate 2>&1)
+	status=$?
+	if [[ "$status" -ne 0 ]]; then
+		print_result "generate includes plugin namespace" 1 "$output"
+		return 0
+	fi
+
+	local index_file="$TEST_HOME/.aidevops/agents/subagent-index.toon"
+	if [[ ! -f "$index_file" ]]; then
+		print_result "generate includes plugin namespace" 1 "index file not created"
+		return 0
+	fi
+
+	if grep -q '^<!--TOON:plugin_agents\[1\]{folder,purpose,key_files}:$' "$index_file" && \
+		grep -q '^example-plugin/,Example plugin agents,example-agent$' "$index_file"; then
+		print_result "generate includes plugin namespace" 0
+	else
+		print_result "generate includes plugin namespace" 1 "plugin entry missing from index"
+	fi
+	return 0
+}
+
+test_check_validates_plugin_cardinality() {
+	local output=""
+	local status=0
+	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" check 2>&1)
+	status=$?
+	if [[ "$status" -eq 0 && "$output" == *"Declared plugin rows: 1"* && "$output" == *"Actual plugin rows: 1"* ]]; then
+		print_result "check validates plugin cardinality" 0
+	else
+		print_result "check validates plugin cardinality" 1 "$output"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	test_plugin_namespace_indexed
+	test_check_validates_plugin_cardinality
+
+	echo ""
+	echo "Tests run: $TESTS_RUN"
+	echo "Passed: $TESTS_PASSED"
+	echo "Failed: $TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-plugin-subagent-index.sh
+++ b/.agents/scripts/tests/test-plugin-subagent-index.sh
@@ -43,7 +43,7 @@ setup() {
 	cp "$REPO_ROOT/.agents/scripts/plugin-loader-helper.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/shared-constants.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/portable-stat.sh" "$agents_dir/scripts/"
-	cp "$REPO_ROOT/.agents/scripts/shared-gh-wrappers.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT"/.agents/scripts/shared-gh-wrappers*.sh "$agents_dir/scripts/"
 	chmod +x "$agents_dir/scripts/subagent-index-helper.sh" "$agents_dir/scripts/plugin-loader-helper.sh"
 
 	cat >"$config_dir/plugins.json" <<'JSON'

--- a/.agents/scripts/tests/test-plugin-subagent-index.sh
+++ b/.agents/scripts/tests/test-plugin-subagent-index.sh
@@ -43,6 +43,7 @@ setup() {
 	cp "$REPO_ROOT/.agents/scripts/plugin-loader-helper.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/shared-constants.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/portable-stat.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT/.agents/scripts/shared-gh-wrappers.sh" "$agents_dir/scripts/"
 	chmod +x "$agents_dir/scripts/subagent-index-helper.sh" "$agents_dir/scripts/plugin-loader-helper.sh"
 
 	cat >"$config_dir/plugins.json" <<'JSON'

--- a/.agents/scripts/tests/test-plugin-subagent-index.sh
+++ b/.agents/scripts/tests/test-plugin-subagent-index.sh
@@ -42,6 +42,7 @@ setup() {
 	cp "$REPO_ROOT/.agents/scripts/subagent-index-helper.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/plugin-loader-helper.sh" "$agents_dir/scripts/"
 	cp "$REPO_ROOT/.agents/scripts/shared-constants.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT/.agents/scripts/portable-stat.sh" "$agents_dir/scripts/"
 	chmod +x "$agents_dir/scripts/subagent-index-helper.sh" "$agents_dir/scripts/plugin-loader-helper.sh"
 
 	cat >"$config_dir/plugins.json" <<'JSON'

--- a/aidevops-skills-plugin-lib.sh
+++ b/aidevops-skills-plugin-lib.sh
@@ -207,6 +207,33 @@ _plugin_validate_ns() {
 _plugin_field() {
 	local pf="$1" n="$2" f="$3"
 	jq -r --arg n "$n" --arg f "$f" '.plugins[] | select(.name == $n) | .[$f] // empty' "$pf" 2>/dev/null || echo ""
+	return 0
+}
+
+_plugin_regenerate_discovery_index() {
+	local ad="$1"
+	local runtime_generator="$ad/scripts/generate-runtime-config.sh"
+	local index_helper="$ad/scripts/subagent-index-helper.sh"
+
+	if [[ -x "$runtime_generator" ]]; then
+		if bash "$runtime_generator" all >/dev/null 2>&1; then
+			print_success "Runtime config and subagent index regenerated"
+			return 0
+		fi
+		print_warning "Runtime config regeneration encountered issues; trying subagent index only"
+	fi
+
+	if [[ -x "$index_helper" ]]; then
+		if bash "$index_helper" generate >/dev/null 2>&1; then
+			print_success "Subagent index regenerated"
+			return 0
+		fi
+		print_warning "Subagent index regeneration encountered issues"
+		return 1
+	fi
+
+	print_warning "Subagent index helper not found; run 'aidevops update' to regenerate discovery"
+	return 1
 }
 
 _plugin_add() {
@@ -287,6 +314,7 @@ _plugin_add() {
 		'.plugins += [{"name": $name, "repo": $repo, "branch": $branch, "namespace": $ns, "enabled": true}]' "$pf" >"$tmp" && mv "$tmp" "$pf"
 	local loader="$ad/scripts/plugin-loader-helper.sh"
 	[[ -f "$loader" ]] && bash "$loader" hooks "$namespace" init 2>/dev/null || true
+	_plugin_regenerate_discovery_index "$ad" || true
 	print_success "Plugin '$plugin_name' installed to $clone_dir"
 	echo ""
 	echo "  Agents available at: ~/.aidevops/agents/$namespace/"
@@ -336,6 +364,7 @@ _plugin_update() {
 		if git clone --branch "$bn" --depth 1 "$repo" "$cd2" 2>&1; then
 			rm -rf "$cd2/.git"
 			print_success "Plugin '$target' updated"
+			_plugin_regenerate_discovery_index "$ad" || true
 		else
 			print_error "Failed to update plugin '$target'"
 			return 1
@@ -371,6 +400,7 @@ _plugin_update() {
 			return 1
 		}
 		print_success "All plugins updated"
+		_plugin_regenerate_discovery_index "$ad" || true
 	fi
 	return 0
 }
@@ -397,6 +427,7 @@ _plugin_toggle() {
 		}
 		local loader="$ad/scripts/plugin-loader-helper.sh"
 		[[ -f "$loader" ]] && bash "$loader" hooks "$tns" init 2>/dev/null || true
+		_plugin_regenerate_discovery_index "$ad" || true
 		print_success "Plugin '$tn' enabled"
 	else
 		local tns
@@ -410,6 +441,7 @@ _plugin_toggle() {
 		local tmp="${pf}.tmp"
 		jq --arg n "$tn" '(.plugins[] | select(.name == $n)).enabled = false' "$pf" >"$tmp" && mv "$tmp" "$pf"
 		[[ -d "$ad/${tns:?}" ]] && rm -rf "$ad/${tns:?}"
+		_plugin_regenerate_discovery_index "$ad" || true
 		print_success "Plugin '$tn' disabled (config preserved)"
 	fi
 	return 0


### PR DESCRIPTION
## Summary

Integrated plugin-loader index output into the shared subagent-index generation path, refreshed discovery after plugin lifecycle changes, documented plugin discovery behavior, and added a regression test for plugin namespace visibility.

## Files Changed

.agents/aidevops/plugins.md,.agents/scripts/generate-runtime-config.sh,.agents/scripts/subagent-index-helper.sh,.agents/scripts/tests/test-plugin-subagent-index.sh,aidevops-skills-plugin-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/subagent-index-helper.sh generate && .agents/scripts/subagent-index-helper.sh check && .agents/scripts/plugin-loader-helper.sh validate && .agents/scripts/tests/test-plugin-subagent-index.sh && shellcheck modified shell scripts

Resolves #22270


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 11m and 372,369 tokens on this as a headless worker.