### PR TITLE
GH#22234: use portable token advisory temp paths

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -7,14 +7,18 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { createTtsrHooks } from "../ttsr.mjs";
 
 function createHooks() {
   const logs = [];
+  const tempPrefix = `${Date.now()}-${process.pid}-${randomUUID()}-aidevops-token-advisory-test`;
   const hooks = createTtsrHooks({
-    agentsDir: "/tmp/aidevops-token-advisory-test-agents",
-    scriptsDir: "/tmp/aidevops-token-advisory-test-scripts",
+    agentsDir: join(tmpdir(), `${tempPrefix}-agents`),
+    scriptsDir: join(tmpdir(), `${tempPrefix}-scripts`),
     readIfExists: () => "",
     qualityLog: (level, message) => logs.push({ level, message }),
     run: () => "",


### PR DESCRIPTION
## Summary

Updated the token advisory threshold regression test to derive temporary agent and script paths from os.tmpdir() with per-hook unique names instead of hard-coded /tmp paths.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs; npm run typecheck could not run because this repo has no tsconfig.json (tsc exits with help text).

Resolves #22234


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 119,779 tokens on this as a headless worker.