### PR TITLE
GH#22267: normalize feedback redispatch ownership

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -286,6 +286,69 @@ _normalize_get_feedback_routed_rows() {
 	return 0
 }
 
+#######################################
+# Find feedback-routed status:available issues that still carry stale
+# interactive ownership and therefore need owner/assignee normalization before
+# the pulse can safely reassign them for worker dispatch.
+#
+# Outputs pipe-delimited rows: issue_number|comma-separated-assignees
+#
+# Args:
+#   $1 issue_rows_json — JSON from gh issue list (number,assignees,labels)
+#   $2 slug            — repo slug for body-marker lookups
+# Returns: 0 always
+#######################################
+_normalize_get_stale_feedback_interactive_rows() {
+	local issue_rows_json="$1"
+	local slug="$2"
+	local status_label=status:available
+	local origin_label=origin:interactive
+	local ci_label=source:ci-feedback
+	local conflict_label=source:conflict-feedback
+	local review_label=source:review-feedback
+
+	local _stale_candidates=""
+	_stale_candidates=$(printf '%s' "$issue_rows_json" | jq -r \
+		--arg status_label "$status_label" \
+		--arg origin_label "$origin_label" \
+		--arg ci_label "$ci_label" \
+		--arg conflict_label "$conflict_label" \
+		--arg review_label "$review_label" '
+		.[] | select(
+			(.labels | map(.name) as $n |
+				($n | index($status_label)) and ($n | index($origin_label))
+			) and ((.assignees | length) > 0)
+		) | [
+			.number,
+			(if (.labels | map(.name) | (index($ci_label) or index($conflict_label) or index($review_label)))
+			 then 1 else 0 end),
+			(.assignees | map(.login) | join(","))
+		] | join("|")
+	' 2>/dev/null) || _stale_candidates=""
+
+	[[ -n "$_stale_candidates" ]] || return 0
+
+	local _pair _cand_num _has_label _assignees _cand_body
+	while IFS= read -r _pair; do
+		_cand_num="${_pair%%|*}"
+		_has_label="${_pair#*|}"
+		_has_label="${_has_label%%|*}"
+		_assignees="${_pair##*|}"
+		[[ "$_cand_num" =~ ^[0-9]+$ ]] || continue
+
+		if [[ "$_has_label" == "1" ]]; then
+			printf '%s|%s\n' "$_cand_num" "$_assignees"
+		else
+			_cand_body=$(gh issue view "$_cand_num" --repo "$slug" --json body --jq '.body' 2>/dev/null) || _cand_body=""
+			if printf '%s' "$_cand_body" | grep -qE '<!-- (ci-feedback|conflict-feedback|review-followup):PR'; then
+				printf '%s|%s\n' "$_cand_num" "$_assignees"
+			fi
+		fi
+	done <<<"$_stale_candidates"
+
+	return 0
+}
+
 _normalize_reassign_self() {
 	local runner_user="$1"
 	local repos_json="$2"
@@ -318,6 +381,41 @@ _normalize_reassign_self() {
 		# Pass 2 (t2396): status:available + origin:worker + feedback-routed
 		local feedback_rows=""
 		feedback_rows=$(_normalize_get_feedback_routed_rows "$issue_rows_json" "$slug")
+
+		# Pass 2b (t3425): status:available + feedback-routed issues that were
+		# requeued for worker dispatch but retained stale interactive ownership.
+		local stale_feedback_rows=""
+		stale_feedback_rows=$(_normalize_get_stale_feedback_interactive_rows "$issue_rows_json" "$slug")
+		local _stale_pair _stale_issue _stale_assignees _stale_assignee
+		local _origin_worker_label=origin:worker
+		local _origin_interactive_label=origin:interactive
+		local _origin_takeover_label=origin:worker-takeover
+		local _add_label_flag=--add-label
+		local _remove_label_flag=--remove-label
+		local _remove_assignee_flag=--remove-assignee
+		while IFS= read -r _stale_pair; do
+			[[ -n "$_stale_pair" ]] || continue
+			_stale_issue="${_stale_pair%%|*}"
+			_stale_assignees="${_stale_pair#*|}"
+			[[ "$_stale_issue" =~ ^[0-9]+$ ]] || continue
+
+			local -a _normalize_flags=(
+				"$_add_label_flag" "$_origin_worker_label"
+				"$_remove_label_flag" "$_origin_interactive_label"
+				"$_remove_label_flag" "$_origin_takeover_label"
+			)
+			IFS=',' read -r -a _stale_assignee_array <<<"$_stale_assignees"
+			for _stale_assignee in "${_stale_assignee_array[@]}"; do
+				[[ -n "$_stale_assignee" ]] && _normalize_flags+=("$_remove_assignee_flag" "$_stale_assignee")
+			done
+
+			if gh issue edit "$_stale_issue" --repo "$slug" "${_normalize_flags[@]}" >/dev/null 2>&1; then
+				feedback_rows=$(printf '%s\n%s\n' "$feedback_rows" "$_stale_issue")
+				echo "[pulse-wrapper] Assignment normalization: cleared stale interactive ownership on feedback-routed #${_stale_issue} in ${slug}" >>"$LOGFILE"
+			else
+				echo "[pulse-wrapper] Assignment normalization: skipped feedback-routed #${_stale_issue} in ${slug} — failed to clear stale interactive ownership" >>"$LOGFILE"
+			fi
+		done <<<"$stale_feedback_rows"
 
 		# Merge Pass 1 + Pass 2 rows (dedup via sort -u)
 		local all_rows=""

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -193,13 +193,26 @@ _transition_issue_for_redispatch() {
 	local linked_issue="$1"
 	local repo_slug="$2"
 	local source_label="$3"
+	local _assignees=""
+	_assignees=$(gh issue view "$linked_issue" --repo "$repo_slug" --json assignees --jq '.assignees[].login' 2>/dev/null) || _assignees=""
+
+	local -a _redispatch_flags=(
+		--add-label "origin:worker"
+		--remove-label "origin:interactive"
+		--remove-label "origin:worker-takeover"
+	)
+	local _assignee
+	while IFS= read -r _assignee; do
+		[[ -n "$_assignee" ]] && _redispatch_flags+=(--remove-assignee "$_assignee")
+	done <<<"$_assignees"
 
 	if declare -F set_issue_status >/dev/null 2>&1; then
 		set_issue_status "$linked_issue" "$repo_slug" "available" \
-			--add-label "$source_label" >/dev/null 2>&1 || true
+			--add-label "$source_label" "${_redispatch_flags[@]}" >/dev/null 2>&1 || true
 	else
 		gh issue edit "$linked_issue" --repo "$repo_slug" \
 			--add-label "status:available" --add-label "$source_label" \
+			"${_redispatch_flags[@]}" \
 			--remove-label "status:queued" --remove-label "status:in-progress" \
 			--remove-label "status:in-review" --remove-label "status:claimed" \
 			>/dev/null 2>&1 || true

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -102,6 +102,10 @@ case "$_subcmd" in
 	exit 0
 	;;
 "issue view")
+	if [[ "$*" == *"--json assignees"* ]]; then
+		printf '%s\n' 'stale-owner'
+		exit 0
+	fi
 	if [[ "$*" == *"--json body"* ]]; then
 		cat "${TEST_ROOT}/issue-body.txt"
 		exit 0
@@ -286,6 +290,21 @@ test_dispatch_appends_to_issue_body_and_closes_pr() {
 	if ! grep -qF 'status:available' "$GH_LOG"; then
 		print_result "dispatch transitions issue status to available" 1 \
 			"Expected 'status:available' in call log"
+		return 0
+	fi
+	if ! grep -qF 'origin:worker' "$GH_LOG"; then
+		print_result "dispatch marks issue as worker-owned for redispatch" 1 \
+			"Expected 'origin:worker' in call log"
+		return 0
+	fi
+	if ! grep -qF -- '--remove-label origin:interactive' "$GH_LOG"; then
+		print_result "dispatch clears stale interactive origin on redispatch" 1 \
+			"Expected '--remove-label origin:interactive' in call log"
+		return 0
+	fi
+	if ! grep -qF -- '--remove-assignee stale-owner' "$GH_LOG"; then
+		print_result "dispatch removes stale assignee on redispatch" 1 \
+			"Expected '--remove-assignee stale-owner' in call log"
 		return 0
 	fi
 	print_result "dispatch appends body, closes PR, transitions labels" 0

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -177,6 +177,7 @@ teardown_test_env() {
 # for the dispatch tests to reach their assertions.
 define_helpers_under_test() {
 	local fn fn_src
+	gh_issue_edit_safe() { gh issue edit "$@"; return $?; }
 	# Functions to extract, in source order. _build_review_feedback_section
 	# is used by the "build section" tests; the three shared helpers are
 	# required by the refactored _dispatch_pr_fix_worker body.

--- a/.agents/scripts/tests/test-reassign-self-normalization.sh
+++ b/.agents/scripts/tests/test-reassign-self-normalization.sh
@@ -162,6 +162,9 @@ source_function_under_test() {
 	if ! type print_info &>/dev/null; then
 		print_info() { echo "[INFO] $*"; return 0; }
 	fi
+	if ! type gh_issue_list &>/dev/null; then
+		gh_issue_list() { gh issue list "$@"; return $?; }
+	fi
 	# Stub arrays that label-invariant functions need (we don't test those here)
 	ISSUE_STATUS_LABEL_PRECEDENCE=("done" "in-review" "in-progress" "queued" "claimed" "available" "blocked")
 	ISSUE_TIER_LABEL_RANK=("reasoning" "standard" "simple")

--- a/.agents/scripts/tests/test-reassign-self-normalization.sh
+++ b/.agents/scripts/tests/test-reassign-self-normalization.sh
@@ -7,9 +7,10 @@
 #   1. Self-assigns status:queued / status:in-progress issues (regression)
 #   2. Self-assigns status:available + origin:worker + feedback label issues
 #   3. Self-assigns status:available + origin:worker + body marker issues
-#   4. Skips status:available without origin:worker
-#   5. Skips status:available with existing assignees
-#   6. Skips fresh scanner issues (no feedback markers/labels)
+#   4. Normalizes stale interactive ownership on feedback-routed issues
+#   5. Skips status:available without origin:worker
+#   6. Skips status:available with existing assignees
+#   7. Skips fresh scanner issues (no feedback markers/labels)
 #
 # Requires only: bash, a stub gh binary.
 
@@ -108,12 +109,20 @@ elif [[ "\$1" == "issue" && "\$2" == "view" ]]; then
 	exit 0
 elif [[ "\$1" == "issue" && "\$2" == "edit" ]]; then
 	# Track which issues got assigned
+	printf '%s\n' "gh \$*" >> "${TEST_ROOT}/gh-calls.log"
 	echo "\$3" >> "${TEST_ROOT}/assigned.txt"
 	exit 0
 fi
 exit 1
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+get_gh_calls() {
+	if [[ -f "${TEST_ROOT}/gh-calls.log" ]]; then
+		cat "${TEST_ROOT}/gh-calls.log"
+	fi
 	return 0
 }
 
@@ -180,6 +189,7 @@ get_assigned_issues() {
 
 reset_assignments() {
 	rm -f "${TEST_ROOT}/assigned.txt"
+	rm -f "${TEST_ROOT}/gh-calls.log"
 	return 0
 }
 
@@ -279,7 +289,39 @@ test_available_worker_conflict_feedback_label_self_assigns() {
 	return 0
 }
 
-# ─── Test 5: status:available + origin:worker + body marker → self-assigned ───
+# ─── Test 5: stale interactive feedback-routed issue → worker ownership normalized ───
+test_available_conflict_feedback_stale_interactive_claim_normalized() {
+	setup_test_env
+	local json='[
+		{"number": 202, "assignees": [{"login": "marcusquinn"}], "labels": [{"name": "status:available"}, {"name": "origin:interactive"}, {"name": "source:conflict-feedback"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned calls
+	assigned=$(get_assigned_issues)
+	calls=$(get_gh_calls)
+	if ! echo "$assigned" | grep -q "202"; then
+		print_result "status:available + conflict-feedback + stale interactive claim → self-assigned" 1 \
+			"Expected issue 202 to be assigned, got: ${assigned:-<empty>}"
+		cleanup_test_env
+		return 0
+	fi
+	if [[ "$calls" != *"--add-label origin:worker"* || "$calls" != *"--remove-label origin:interactive"* || "$calls" != *"--remove-assignee marcusquinn"* ]]; then
+		print_result "status:available + conflict-feedback + stale interactive claim → ownership normalized" 1 \
+			"Expected origin/assignee normalization in gh calls. Got: ${calls:-<empty>}"
+		cleanup_test_env
+		return 0
+	fi
+	print_result "status:available + conflict-feedback + stale interactive claim → normalized and self-assigned" 0
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 6: status:available + origin:worker + body marker → self-assigned ───
 test_available_worker_body_marker_self_assigns() {
 	setup_test_env
 	local body_marker='<!-- ci-feedback:PR1234 -->'
@@ -304,7 +346,7 @@ test_available_worker_body_marker_self_assigns() {
 	return 0
 }
 
-# ─── Test 6: status:available + NO origin:worker → NOT assigned ───
+# ─── Test 7: status:available + NO origin:worker → NOT assigned ───
 test_available_no_worker_label_skips() {
 	setup_test_env
 	local json='[
@@ -328,7 +370,7 @@ test_available_no_worker_label_skips() {
 	return 0
 }
 
-# ─── Test 7: status:available + existing assignees → NOT assigned ───
+# ─── Test 8: status:available + existing assignees → NOT assigned ───
 test_available_with_assignee_skips() {
 	setup_test_env
 	local json='[
@@ -352,7 +394,7 @@ test_available_with_assignee_skips() {
 	return 0
 }
 
-# ─── Test 8: Fresh scanner issue (status:available, no feedback markers) → NOT assigned ───
+# ─── Test 9: Fresh scanner issue (status:available, no feedback markers) → NOT assigned ───
 test_fresh_scanner_issue_skips() {
 	setup_test_env
 	local json='[
@@ -386,6 +428,7 @@ main() {
 	test_in_progress_no_assignee_self_assigns
 	test_available_worker_ci_feedback_label_self_assigns
 	test_available_worker_conflict_feedback_label_self_assigns
+	test_available_conflict_feedback_stale_interactive_claim_normalized
 	test_available_worker_body_marker_self_assigns
 	test_available_no_worker_label_skips
 	test_available_with_assignee_skips


### PR DESCRIPTION
## Summary

Feedback-routed redispatch now switches issues back to worker ownership and clears stale interactive assignees before workers re-pick them.

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh,.agents/scripts/pulse-merge-feedback.sh,.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh,.agents/scripts/tests/test-reassign-self-normalization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-reassign-self-normalization.sh; bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh; shellcheck .agents/scripts/pulse-merge-feedback.sh .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/pulse-dispatch-worker-launch.sh

Resolves #22267


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 11m and 193,930 tokens on this as a headless worker.