### PR TITLE
GH#22236: harden opencode maintenance-window cleanup

### DIFF
--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -670,15 +670,10 @@ cmd_maintain() {
 # when a step fails. Interactive OpenCode TUIs are not stopped; they require
 # --force-opencode so the operator consciously accepts the risk.
 
-_maintenance_window_restart_pulse() {
-	if [[ "${_OCDBM_RESTART_PULSE:-0}" == "1" ]]; then
-		print_info "Restarting pulse after maintenance window..."
-		"$PULSE_LIFECYCLE_HELPER" start || print_warning "pulse restart failed; run pulse-lifecycle-helper.sh start"
-	fi
-	return 0
-}
-
 cmd_maintenance_window() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+
 	local force_opencode=false
 	local keep_sessions="$MAINTENANCE_WINDOW_KEEP_SESSIONS"
 	local skip_archive=false
@@ -722,8 +717,9 @@ cmd_maintenance_window() {
 	if command -v "$PULSE_LIFECYCLE_HELPER" >/dev/null 2>&1; then
 		print_info "Stopping pulse for maintenance window..."
 		"$PULSE_LIFECYCLE_HELPER" stop || print_warning "pulse stop returned non-zero; continuing with DB holder checks"
-		_OCDBM_RESTART_PULSE=1
-		trap _maintenance_window_restart_pulse RETURN
+		local restart_cmd
+		restart_cmd=$(printf '%q start' "$PULSE_LIFECYCLE_HELPER")
+		push_cleanup "$restart_cmd"
 	else
 		print_warning "pulse lifecycle helper not found; skipping pulse stop/start"
 	fi
@@ -760,6 +756,8 @@ cmd_maintenance_window() {
 		print_success "post-maintenance quick_check: ok"
 	fi
 
+	trap - RETURN
+	_run_cleanups
 	return "$rc"
 }
 

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -81,9 +81,11 @@ SQL
 
 	# Insert+delete rows to create freelist pages (fragmentation)
 	local i
-	for i in $(seq 1 500); do
+	local payload
+	for i in $(seq 1 120); do
+		payload=$(printf 'payload-%04d-%01024d' "$i" 0)
 		sqlite3 "$OPENCODE_DIR/opencode.db" \
-			"INSERT INTO message VALUES ('msg$i', 'ses1', $i, $i, '$(head -c 1024 /dev/urandom | base64 | tr -d '\n' | head -c 1024)');" 2>/dev/null
+			"INSERT INTO message VALUES ('msg$i', 'ses1', $i, $i, '$payload');" 2>/dev/null
 	done
 	sqlite3 "$OPENCODE_DIR/opencode.db" "DELETE FROM message WHERE CAST(substr(id, 4) AS INTEGER) % 2 = 0;" 2>/dev/null
 }
@@ -356,6 +358,32 @@ if [[ "$rc" -eq 0 ]] && grep -q '^stop$' "$mock_pulse_log" && grep -q '^start$' 
 	_pass "maintenance-window stops pulse, archives, maintains, and restarts pulse"
 else
 	_fail "maintenance-window mocked lifecycle failed (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 14: maintenance-window restarts pulse on early active-holder exit
+# -----------------------------------------------------------------------------
+
+cat >"$mock_bin/pgrep" <<'MOCK_PGREP'
+#!/usr/bin/env bash
+printf '%s\n' '12345'
+exit 0
+MOCK_PGREP
+chmod +x "$mock_bin/pgrep"
+: >"$mock_pulse_log"
+: >"$mock_archive_log"
+
+set +e
+out=$(PATH="$mock_bin:$PATH" MOCK_PULSE_LOG="$mock_pulse_log" MOCK_ARCHIVE_LOG="$mock_archive_log" \
+	OPENCODE_DB_ARCHIVE_HELPER="$mock_bin/opencode-db-archive.sh" \
+	_run_helper maintenance-window --keep-sessions 123 2>&1)
+rc=$?
+set -e
+rm -f "$mock_bin/pgrep"
+if [[ "$rc" -eq 2 ]] && grep -q '^stop$' "$mock_pulse_log" && grep -q '^start$' "$mock_pulse_log" && [[ ! -s "$mock_archive_log" ]]; then
+	_pass "maintenance-window restarts pulse after active-holder early return"
+else
+	_fail "maintenance-window early-return cleanup failed (rc=$rc) — output: $out"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaced the maintenance-window restart RETURN trap with the shared cleanup stack pattern, added a normal-path cleanup fast path, and added regression coverage for early active-holder returns.

## Files Changed

.agents/scripts/opencode-db-maintenance-helper.sh,.agents/scripts/tests/test-opencode-db-maintenance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/opencode-db-maintenance-helper.sh .agents/scripts/tests/test-opencode-db-maintenance.sh; .agents/scripts/tests/test-opencode-db-maintenance.sh

Resolves #22236


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 24m and 180,619 tokens on this as a headless worker.