### PR TITLE
t3445: ignore generated Beads export state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ vault-export-*.csv
 setup-wizard-responses.json
 tmp.*.json
 quality-report.md
+.beads/
 
 # Logs
 *.log


### PR DESCRIPTION
## Summary

- Ignore generated `.beads/` export state so pre-commit hook output does not leave unrelated untracked files after commits.

## Verification

- `git check-ignore -v .beads/issues.jsonl`
- pre-commit hook passed during commit

Resolves #22297
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 44m and 377,696 tokens on this with the user in an interactive session.