### PR TITLE
GH#22308: use app usage fallback for sparse backlit screen time

### DIFF
--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -28,10 +28,10 @@ set -euo pipefail
 
 HISTORY_DIR="${HOME}/.aidevops/.agent-workspace/observability"
 HISTORY_FILE="${HISTORY_DIR}/screen-time.jsonl"
-OS_TYPE="$(uname -s)"
+OS_TYPE="${AIDEVOPS_SCREEN_TIME_OS_TYPE:-$(uname -s)}"
 
 # macOS-specific paths
-KNOWLEDGE_DB="${HOME}/Library/Application Support/Knowledge/knowledgeC.db"
+KNOWLEDGE_DB="${AIDEVOPS_KNOWLEDGE_DB:-${HOME}/Library/Application Support/Knowledge/knowledgeC.db}"
 
 # ============================================================
 # macOS: Knowledge DB queries
@@ -90,14 +90,98 @@ _macos_query_screen_hours() {
 		)
 		SELECT COALESCE(ROUND(SUM(off_time - on_time) / 3600.0, 1), 0) FROM pairs;" 2>/dev/null || echo "0")
 
-		# Fallback: /app/usage when isBacklit returns 0
-		if [[ "$hours" == "0" || "$hours" == "0.0" ]]; then
+		# Fallback: /app/usage when isBacklit returns 0 or has sparse coverage.
+		# macOS can keep emitting occasional /display/isBacklit events after the stream
+		# stops covering every active day. Treat sparse multi-day windows as incomplete
+		# so a single recent backlit day does not undercount 7d/28d profile totals.
+		if [[ "$hours" == "0" || "$hours" == "0.0" ]] || _macos_should_use_app_usage_for_window "$days" "$hours"; then
 			hours=$(_macos_query_screen_hours_from_app_usage "$days")
 		fi
 	fi
 
 	echo "$hours"
 	return 0
+}
+
+#######################################
+# [macOS] Count distinct local dates with events in a Knowledge DB stream window
+# Arguments:
+#   $1 - stream name
+#   $2 - timestamp column name
+#   $3 - number of days to look back
+# Returns: 0
+# Outputs: integer count
+#######################################
+_macos_count_stream_days() {
+	local stream_name="$1"
+	local timestamp_column="$2"
+	local days="$3"
+
+	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	case "$timestamp_column" in
+	ZCREATIONDATE | ZSTARTDATE) ;;
+	*)
+		echo "0"
+		return 0
+		;;
+	esac
+
+	local active_days
+	local stream_filter=""
+	if [[ "$stream_name" == "/display/isBacklit" ]]; then
+		stream_filter="AND ZVALUEINTEGER = 1"
+	fi
+	active_days=$(sqlite3 "$KNOWLEDGE_DB" "
+		SELECT COUNT(DISTINCT date(${timestamp_column} + 978307200, 'unixepoch', 'localtime'))
+		FROM ZOBJECT
+		WHERE ZSTREAMNAME = '${stream_name}'
+			AND ${timestamp_column} > (strftime('%s', 'now') - 978307200 - 86400*${days})
+			${stream_filter};" 2>/dev/null || echo "0")
+
+	[[ "$active_days" =~ ^[0-9]+$ ]] || active_days="0"
+	echo "$active_days"
+	return 0
+}
+
+#######################################
+# [macOS] Decide whether /display/isBacklit coverage is too sparse for a window
+# Arguments:
+#   $1 - number of days to look back
+#   $2 - hours computed from /display/isBacklit
+# Returns: 0 when /app/usage should be used, 1 otherwise
+#######################################
+_macos_should_use_app_usage_for_window() {
+	local days="$1"
+	local backlit_hours="$2"
+
+	if [[ "$days" -le 1 ]]; then
+		return 1
+	fi
+
+	local backlit_days
+	local app_days
+	backlit_days=$(_macos_count_stream_days "/display/isBacklit" "ZCREATIONDATE" "$days")
+	app_days=$(_macos_count_stream_days "/app/usage" "ZSTARTDATE" "$days")
+
+	# A multi-day app/usage window with only one backlit event day is the regression
+	# that makes 24h and 7d totals collapse to the same value.
+	if [[ "$backlit_days" -le 1 && "$app_days" -ge 2 ]]; then
+		return 0
+	fi
+
+	# More generally, when app usage covers at least two extra active days and is
+	# materially higher than backlit, prefer the richer source for the whole window.
+	local app_hours
+	app_hours=$(_macos_query_screen_hours_from_app_usage "$days")
+	if awk "BEGIN {exit !(${app_days} >= ${backlit_days} + 1 && ${app_hours} > ${backlit_hours} * 1.25)}"; then
+		return 0
+	fi
+
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+HELPER="${SCRIPTS_DIR}/screen-time-helper.sh"
+TMPDIR_TEST=""
+
+cleanup() {
+	if [[ -n "$TMPDIR_TEST" ]]; then
+		rm -rf "$TMPDIR_TEST"
+	fi
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+core_data_offset() {
+	local epoch="$1"
+	printf '%s\n' "$((epoch - 978307200))"
+	return 0
+}
+
+insert_backlit_pair() {
+	local db="$1"
+	local on_epoch="$2"
+	local off_epoch="$3"
+	sqlite3 "$db" "
+		INSERT INTO ZOBJECT (ZSTREAMNAME, ZCREATIONDATE, ZVALUEINTEGER) VALUES ('/display/isBacklit', $(core_data_offset "$on_epoch"), 1);
+		INSERT INTO ZOBJECT (ZSTREAMNAME, ZCREATIONDATE, ZVALUEINTEGER) VALUES ('/display/isBacklit', $(core_data_offset "$off_epoch"), 0);"
+	return 0
+}
+
+insert_app_usage() {
+	local db="$1"
+	local start_epoch="$2"
+	local end_epoch="$3"
+	sqlite3 "$db" "
+		INSERT INTO ZOBJECT (ZSTREAMNAME, ZSTARTDATE, ZENDDATE) VALUES ('/app/usage', $(core_data_offset "$start_epoch"), $(core_data_offset "$end_epoch"));"
+	return 0
+}
+
+query_hours() {
+	local db="$1"
+	local days="$2"
+	AIDEVOPS_SCREEN_TIME_OS_TYPE=Darwin AIDEVOPS_KNOWLEDGE_DB="$db" "$HELPER" query "$days" | awk '{print $1}' | tr -d 'h'
+	return 0
+}
+
+main() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	TMPDIR_TEST="$tmpdir"
+	trap cleanup EXIT
+
+	local db="${tmpdir}/knowledgeC.db"
+	sqlite3 "$db" "
+		CREATE TABLE ZOBJECT (
+			ZSTREAMNAME TEXT,
+			ZCREATIONDATE REAL,
+			ZVALUEINTEGER INTEGER,
+			ZSTARTDATE REAL,
+			ZENDDATE REAL
+		);"
+
+	local now
+	now=$(date +%s)
+	local one_hour=3600
+	local one_day=86400
+
+	# Sparse backlit: one recent day only. App usage spans multiple active days.
+	insert_backlit_pair "$db" "$((now - one_hour * 8))" "$((now - one_hour))"
+	insert_app_usage "$db" "$((now - one_hour * 8))" "$((now - one_hour))"
+	insert_app_usage "$db" "$((now - one_day * 2))" "$((now - one_day * 2 + one_hour * 6))"
+	insert_app_usage "$db" "$((now - one_day * 4))" "$((now - one_day * 4 + one_hour * 5))"
+
+	local day_hours
+	local week_hours
+	day_hours=$(query_hours "$db" 1)
+	week_hours=$(query_hours "$db" 7)
+
+	[[ "$day_hours" == "7.0" ]] || fail "expected 1d backlit hours to stay primary at 7.0, got ${day_hours}"
+	[[ "$week_hours" == "18.0" ]] || fail "expected sparse 7d backlit window to fall back to app usage at 18.0, got ${week_hours}"
+
+	# Healthy backlit: events on multiple days should remain primary even when app usage exists.
+	local healthy_db="${tmpdir}/healthy-knowledgeC.db"
+	sqlite3 "$healthy_db" "
+		CREATE TABLE ZOBJECT (
+			ZSTREAMNAME TEXT,
+			ZCREATIONDATE REAL,
+			ZVALUEINTEGER INTEGER,
+			ZSTARTDATE REAL,
+			ZENDDATE REAL
+		);"
+	insert_backlit_pair "$healthy_db" "$((now - one_hour * 8))" "$((now - one_hour))"
+	insert_backlit_pair "$healthy_db" "$((now - one_day * 2))" "$((now - one_day * 2 + one_hour * 4))"
+	insert_app_usage "$healthy_db" "$((now - one_hour * 8))" "$((now - one_hour))"
+	insert_app_usage "$healthy_db" "$((now - one_day * 2))" "$((now - one_day * 2 + one_hour * 4))"
+
+	local healthy_week_hours
+	healthy_week_hours=$(query_hours "$healthy_db" 7)
+	[[ "$healthy_week_hours" == "11.0" ]] || fail "expected healthy 7d backlit stream to remain primary at 11.0, got ${healthy_week_hours}"
+
+	pass "screen-time helper falls back only for sparse backlit windows"
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Falls back to `/app/usage` when `/display/isBacklit` has sparse multi-day coverage, preventing 7d/28d undercounts from one recent backlit day.
- Adds a screen-time regression test using a synthetic Knowledge DB and keeps healthy backlit streams as primary.

Resolves #22308

## Testing
- `shellcheck .agents/scripts/screen-time-helper.sh .agents/scripts/tests/test-screen-time-helper.sh`
- `bash .agents/scripts/tests/test-screen-time-helper.sh`
- `.agents/scripts/screen-time-helper.sh query 1`
- `.agents/scripts/screen-time-helper.sh query 7`
- `.agents/scripts/screen-time-helper.sh profile-stats`

## Runtime Testing
- Low-risk shell helper bugfix; runtime-verified locally against the macOS Knowledge DB. Observed `query 1` = 7.3h and `query 7` = 66.2h after the sparse fallback.

## Key decisions
- Keep `/display/isBacklit` as primary for healthy streams.
- Fall back only when `/app/usage` covers more active days and materially exceeds backlit totals.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.91 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 10m and 81,165 tokens on this as a headless worker.
