### PR TITLE
t3457: normalize escaped newlines in issue bodies

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -443,6 +443,12 @@ _read_brief_what_section() {
 _compose_issue_body() {
 	local title="$1"
 	local description="$2"
+	local fmt_helper="${SCRIPT_DIR}/issue-body-format-helper.sh"
+	if [[ -n "$description" && -x "$fmt_helper" ]]; then
+		local normalized_description=""
+		normalized_description=$("$fmt_helper" normalize "$description" 2>/dev/null) || normalized_description="$description"
+		description="$normalized_description"
+	fi
 
 	# Extract task ID from title (format: "tNNN: description")
 	local task_id=""

--- a/.agents/scripts/issue-body-format-helper.sh
+++ b/.agents/scripts/issue-body-format-helper.sh
@@ -104,6 +104,29 @@ _ibfh_heading_count() {
 	return 0
 }
 
+# _ibfh_has_escaped_markdown_newlines: detect issue bodies where Markdown
+# structure was passed as literal "\n" text instead of real newlines. Keep the
+# trigger structural so incidental prose like "the string \n means newline" is
+# not rewritten.
+_ibfh_has_escaped_markdown_newlines() {
+	local body="$1"
+	case "$body" in
+	*'\n## '* | *'\n### '* | *'\n- '* | *'\n```'* | *'\n\n'*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+# _ibfh_decode_escaped_markdown_newlines: convert literal backslash-n tokens
+# to real newlines after _ibfh_has_escaped_markdown_newlines has established
+# that the body contains escaped Markdown structure.
+_ibfh_decode_escaped_markdown_newlines() {
+	local body="$1"
+	printf '%s' "${body//\\n/$'\n'}"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Advisory checks (always emit to stderr, never abort on their own)
 # ---------------------------------------------------------------------------
@@ -137,11 +160,16 @@ _ibfh_warn_dense_prose() {
 
 # ---------------------------------------------------------------------------
 # normalize: auto-fix issues that can be corrected without human judgment.
-# Currently: insert blank line before code fences that lack one.
+# Currently: decode escaped Markdown newlines and insert blank lines before
+# code fences that lack one.
 # Prints corrected body on stdout.
 # ---------------------------------------------------------------------------
 cmd_normalize() {
 	local body="$1"
+	if _ibfh_has_escaped_markdown_newlines "$body"; then
+		body=$(_ibfh_decode_escaped_markdown_newlines "$body")
+	fi
+
 	local prev="" out="" line
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^'```' ]] && [[ -n "$prev" ]]; then
@@ -164,6 +192,11 @@ cmd_check() {
 	local body="$1"
 	local strict="${AIDEVOPS_BODY_FORMAT_STRICT:-0}"
 	local non_dispatchable=0
+
+	if _ibfh_has_escaped_markdown_newlines "$body"; then
+		log_warn "issue-body-format: body contains literal \\n sequences in Markdown structure; normalize before publishing"
+		body=$(_ibfh_decode_escaped_markdown_newlines "$body")
+	fi
 
 	# Advisory-only checks
 	_ibfh_warn_fence_spacing "$body"

--- a/.agents/scripts/tests/test-issue-body-format-helper.sh
+++ b/.agents/scripts/tests/test-issue-body-format-helper.sh
@@ -185,6 +185,24 @@ shellcheck foo.sh
 \`\`\`
 "
 
+# Body accidentally passed with literal backslash-n Markdown structure.
+BODY_ESCAPED_MARKDOWN='## Task\nFix escaped body.\n\n## Files to modify\n- EDIT: .agents/scripts/foo.sh\n\n## Reference pattern\nModel on .agents/scripts/bar.sh\n\n## Verification\nshellcheck .agents/scripts/foo.sh\n\n## Acceptance\n- [ ] Published body has real Markdown headings'
+
+# Incidental backslash-n prose should not be decoded unless it forms escaped
+# Markdown structure.
+BODY_INCIDENTAL_ESCAPED="## Task
+
+Document that the literal \n token can appear in prose.
+
+## Files to modify
+
+- EDIT: .agents/scripts/foo.sh
+
+## Acceptance
+
+- [ ] Prose stays unchanged
+"
+
 # ---------------------------------------------------------------------------
 # Test suite
 # ---------------------------------------------------------------------------
@@ -306,6 +324,23 @@ if [[ $rc -ne 0 ]]; then
 	pass "12. unknown command exits non-zero"
 else
 	fail "12. unknown command exits non-zero" "got exit 0"
+fi
+
+# 13. Normalize decodes escaped Markdown newlines into real newlines
+normalized=$("$HELPER" normalize "$BODY_ESCAPED_MARKDOWN" 2>/dev/null) || true
+heading_count=$(printf '%s\n' "$normalized" | grep -cE '^##' 2>/dev/null || true)
+if [[ "$normalized" != *'\n## '* && "$heading_count" =~ ^[0-9]+$ && "$heading_count" -ge 5 ]]; then
+	pass "13. normalize decodes escaped Markdown newlines"
+else
+	fail "13. normalize decodes escaped Markdown newlines" "headings=${heading_count}; output: $(printf '%s' "$normalized")"
+fi
+
+# 14. Normalize preserves incidental backslash-n prose
+normalized=$("$HELPER" normalize "$BODY_INCIDENTAL_ESCAPED" 2>/dev/null) || true
+if [[ "$normalized" == *'literal \n token'* ]]; then
+	pass "14. normalize preserves incidental backslash-n prose"
+else
+	fail "14. normalize preserves incidental backslash-n prose" "output: $(printf '%s' "$normalized")"
 fi
 
 # ---------------------------------------------------------------------------

--- a/TODO.md
+++ b/TODO.md
@@ -912,6 +912,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3403 Fix quality gate false failures from workflow cancellation #bug ref:GH#22194 pr:#22196 completed:2026-05-01
 
+- [ ] t3457 Normalize escaped newlines in issue bodies #auto-dispatch #bug ref:GH#22316
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Normalizes escaped Markdown newline sequences before `claim-task-id.sh` publishes issue bodies.
- Keeps incidental `\n` prose untouched unless the body clearly contains escaped Markdown structure.
- Adds regression coverage for the #22314 formatting failure mode.

## Root cause
Issue #22314 was created from a description containing literal backslash-n tokens (16 `\n`, only 8 real newlines), so GitHub rendered the worker-ready sections as one dense paragraph. #22287 had 0 literal `\n` tokens and 27 real newlines, so headings/lists rendered normally.

## Verification
- shellcheck .agents/scripts/issue-body-format-helper.sh .agents/scripts/claim-task-id-issue.sh .agents/scripts/tests/test-issue-body-format-helper.sh
- bash .agents/scripts/tests/test-issue-body-format-helper.sh
- claim composer check: literal_backslash_n=0, heading_lines=3

Resolves #22316
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 24m and 490,401 tokens on this as a headless worker.