### PR TITLE
t3455: Make shared-constants source cleanly from zsh

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -773,8 +773,9 @@ fast_cp() {
 # Provides: _file_mtime_epoch, _file_size_bytes, _file_perms, _file_owner.
 # =============================================================================
 
+_SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # shellcheck source=./portable-stat.sh
-source "${BASH_SOURCE[0]%/*}/portable-stat.sh"
+source "${_SC_SELF%/*}/portable-stat.sh"
 # _file_size_bytes, _file_perms, _file_mtime_epoch, _file_owner, _stat_batch,
 # _stat_translate_fmt are now provided by portable-stat.sh (GH#21742).
 

--- a/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
@@ -4,9 +4,9 @@
 #
 # test-shared-gh-wrappers-source.sh — t2709 / GH#20357 regression guard.
 #
-# Asserts that sourcing shared-constants.sh (which sources shared-gh-wrappers.sh)
-# emits zero output about shared-gh-wrappers-rest-fallback.sh under both bash
-# and zsh, and that the REST fallback helpers are loaded correctly in both.
+# Asserts that sourcing shared-constants.sh (which sources portable-stat.sh and
+# shared-gh-wrappers.sh) emits no missing-source warnings under both bash and zsh,
+# and that the REST fallback helpers are loaded correctly in both.
 #
 # Root cause: shared-gh-wrappers.sh:44-46 used ${BASH_SOURCE[0]%/*} to resolve
 # its own directory. Under zsh, BASH_SOURCE is not populated, so the expansion
@@ -21,9 +21,9 @@
 # fallback — pure bash syntax, shfmt-parseable, same directory.
 #
 # Tests:
-#   1. bash: source shared-constants.sh emits zero REST-fallback warnings
+#   1. bash: source shared-constants.sh emits zero missing-source warnings
 #   2. bash: _rest_issue_create is defined after sourcing
-#   3. zsh:  source shared-constants.sh emits zero REST-fallback warnings (t2709)
+#   3. zsh:  source shared-constants.sh emits zero missing-source warnings (t2709/t3455)
 #   4. zsh:  _rest_issue_create is defined after sourcing (t2709)
 
 set -uo pipefail
@@ -67,15 +67,15 @@ skip() {
 }
 
 # =============================================================================
-# Test 1 + 2: bash — source emits no REST-fallback warning, helper defined
+# Test 1 + 2: bash — source emits no missing-source warning, helper defined
 # =============================================================================
 printf '\n=== bash source tests ===\n'
 
 bash_output=$(bash -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>&1" || true)
-if printf '%s\n' "$bash_output" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
-	fail "bash source emits REST-fallback warning" "$bash_output"
+if printf '%s\n' "$bash_output" | grep -Eq 'shared-gh-wrappers-rest-fallback\.sh|portable-stat\.sh'; then
+	fail "bash source emits missing-source warning" "$bash_output"
 else
-	pass "bash source emits no REST-fallback warning"
+	pass "bash source emits no missing-source warning"
 fi
 
 bash_fn=$(bash -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _rest_issue_create 2>/dev/null" || true)
@@ -86,7 +86,7 @@ else
 fi
 
 # =============================================================================
-# Test 3 + 4: zsh — source emits no REST-fallback warning, helper defined
+# Test 3 + 4: zsh — source emits no missing-source warning, helper defined
 # =============================================================================
 printf '\n=== zsh source tests ===\n'
 
@@ -95,10 +95,10 @@ if ! command -v zsh >/dev/null 2>&1; then
 	skip "zsh: _rest_issue_create defined after source (zsh unavailable)"
 else
 	zsh_output=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>&1" || true)
-	if printf '%s\n' "$zsh_output" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
-		fail "zsh source emits REST-fallback warning (t2709)" "$zsh_output"
+	if printf '%s\n' "$zsh_output" | grep -Eq 'shared-gh-wrappers-rest-fallback\.sh|portable-stat\.sh'; then
+		fail "zsh source emits missing-source warning (t2709/t3455)" "$zsh_output"
 	else
-		pass "zsh source emits no REST-fallback warning (t2709)"
+		pass "zsh source emits no missing-source warning (t2709/t3455)"
 	fi
 
 	zsh_fn=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _rest_issue_create 2>/dev/null" || true)


### PR DESCRIPTION
## Summary

Resolved shared-constants portable-stat path resolution under zsh by reusing the cross-shell _SC_SELF path fallback before sourcing portable-stat.sh, and extended the existing bash/zsh source regression test to catch portable-stat missing-source warnings.

## Files Changed

.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-shared-gh-wrappers-source.sh,.task-counter

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** zsh -c 'source .agents/scripts/shared-constants.sh'; bash .agents/scripts/tests/test-shared-gh-wrappers-source.sh; shellcheck .agents/scripts/shared-constants.sh .agents/scripts/tests/test-shared-gh-wrappers-source.sh

Resolves #22311


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 5m and 140,194 tokens on this as a headless worker.