### PR TITLE
GH#22300: enforce active worker minimum floor

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -633,6 +633,7 @@ apply_dispatch_max() {
 	[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
 
 	_adaptive_launch_settle_wait "$fill_dispatched" "dispatch_max"
+	_dispatch_min_worker_floor_refill
 
 	# t2749: Phase 2 — re-enumerate when consolidation created a child during
 	# Phase 1. The sentinel is written by _dispatch_issue_consolidation in
@@ -654,10 +655,61 @@ apply_dispatch_max() {
 			fill_dispatched_p2=$(dispatch_max) || fill_dispatched_p2=0
 			[[ "$fill_dispatched_p2" =~ ^[0-9]+$ ]] || fill_dispatched_p2=0
 			_adaptive_launch_settle_wait "$fill_dispatched_p2" "dispatch_max phase 2"
+			_dispatch_min_worker_floor_refill
 		else
 			echo "[pulse-wrapper] Dispatch_max Phase 2: consolidation child created but slots full (active=${_p2_active}, max=${_p2_max}) — skipping (t2749)" >>"$LOGFILE"
 		fi
 	fi
+	return 0
+}
+
+#######################################
+# Re-run dispatch_max while the active-worker count is below the configured
+# minimum floor and dispatch is still making progress.
+#
+# The floor is an active-worker floor, not merely a CPU/load throttle bypass:
+# a partial launch/failure round can leave active workers below the floor even
+# though dispatch_max attempted candidates. Hard stops remain hard because each
+# dispatch_max call re-checks STOP_FLAG, GraphQL budget, candidate eligibility,
+# and per-candidate blockers; a zero-dispatch round ends the refill.
+#
+# Returns 0 always; best-effort refill should not abort the pulse cycle.
+#######################################
+_dispatch_min_worker_floor_refill() {
+	local min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
+	if ! [[ "$min_worker_floor" =~ ^[0-9]+$ ]]; then
+		min_worker_floor=6
+	fi
+	if ((min_worker_floor <= 0)); then
+		return 0
+	fi
+
+	local refill_attempt=0
+	local max_refill_attempts="$min_worker_floor"
+	local active_workers fill_dispatched
+	while ((refill_attempt < max_refill_attempts)); do
+		if [[ -f "$STOP_FLAG" ]]; then
+			echo "[pulse-wrapper] Minimum worker floor refill stopped: stop flag present" >>"$LOGFILE"
+			return 0
+		fi
+		active_workers=$(count_active_workers)
+		[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+		if ((active_workers >= min_worker_floor)); then
+			return 0
+		fi
+
+		refill_attempt=$((refill_attempt + 1))
+		echo "[pulse-wrapper] Minimum worker floor refill: active=${active_workers}/${min_worker_floor}, attempt=${refill_attempt}/${max_refill_attempts} — re-enumerating candidates" >>"$LOGFILE"
+		fill_dispatched=$(dispatch_max) || fill_dispatched=0
+		[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
+		if ((fill_dispatched <= 0)); then
+			echo "[pulse-wrapper] Minimum worker floor refill stopped: dispatch_max returned ${fill_dispatched} (no eligible candidates or hard gate exhausted)" >>"$LOGFILE"
+			return 0
+		fi
+		_adaptive_launch_settle_wait "$fill_dispatched" "minimum worker floor refill"
+	done
+
+	echo "[pulse-wrapper] Minimum worker floor refill stopped: reached attempt cap ${max_refill_attempts}" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -46,6 +46,26 @@ get_max_workers_target() {
 }
 
 count_active_workers() {
+	if [[ -n "${TEST_ACTIVE_WORKERS_SEQUENCE_FILE:-}" && -f "$TEST_ACTIVE_WORKERS_SEQUENCE_FILE" ]]; then
+		local next remaining_file
+		next=$(awk 'NR==1 {print; exit}' "$TEST_ACTIVE_WORKERS_SEQUENCE_FILE" 2>/dev/null)
+		remaining_file="${TEST_ACTIVE_WORKERS_SEQUENCE_FILE}.next"
+		awk 'NR>1 {print}' "$TEST_ACTIVE_WORKERS_SEQUENCE_FILE" >"$remaining_file" 2>/dev/null || : >"$remaining_file"
+		mv "$remaining_file" "$TEST_ACTIVE_WORKERS_SEQUENCE_FILE"
+		[[ -n "$next" ]] || next="${TEST_ACTIVE_WORKERS:-0}"
+		printf '%s\n' "$next"
+		return 0
+	fi
+	if [[ -n "${TEST_ACTIVE_WORKERS_SEQUENCE:-}" ]]; then
+		local next="${TEST_ACTIVE_WORKERS_SEQUENCE%% *}"
+		if [[ "$TEST_ACTIVE_WORKERS_SEQUENCE" == *" "* ]]; then
+			TEST_ACTIVE_WORKERS_SEQUENCE="${TEST_ACTIVE_WORKERS_SEQUENCE#* }"
+		else
+			TEST_ACTIVE_WORKERS_SEQUENCE=""
+		fi
+		printf '%s\n' "$next"
+		return 0
+	fi
 	printf '%s\n' "${TEST_ACTIVE_WORKERS:-0}"
 	return 0
 }
@@ -131,6 +151,7 @@ exit 42
 EOF
 	chmod +x "$fake_helper"
 	HEADLESS_RUNTIME_HELPER="$fake_helper"
+	unset AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK AIDEVOPS_MIN_WORKER_FLOOR_BYPASS_ACTIVE || true
 	TEST_ACTIVE_WORKERS=5
 	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
 	if _dlw_canary_preflight 100 "o/r" "$worker_log" "standard" ""; then
@@ -138,6 +159,7 @@ EOF
 	else
 		print_result "canary: overload check bypassed below minimum floor" 1
 	fi
+	unset AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK AIDEVOPS_MIN_WORKER_FLOOR_BYPASS_ACTIVE || true
 	TEST_ACTIVE_WORKERS=6
 	if _dlw_canary_preflight 101 "o/r" "$worker_log" "standard" ""; then
 		print_result "canary: overload check enforced at floor" 1 "unexpected success"
@@ -147,11 +169,53 @@ EOF
 	return 0
 }
 
+test_apply_dispatch_refills_until_active_floor_after_partial_launch() {
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	TEST_ACTIVE_WORKERS_SEQUENCE_FILE="${TEST_ROOT}/active-sequence.txt"
+	TEST_DISPATCH_CALLS_FILE="${TEST_ROOT}/dispatch-calls.txt"
+	TEST_DISPATCH_RETURNS_FILE="${TEST_ROOT}/dispatch-returns.txt"
+	printf '%s\n%s\n' 4 6 >"$TEST_ACTIVE_WORKERS_SEQUENCE_FILE"
+	printf '%s\n' 0 >"$TEST_DISPATCH_CALLS_FILE"
+	printf '%s\n%s\n' 2 2 >"$TEST_DISPATCH_RETURNS_FILE"
+	STOP_FLAG="${HOME}/.aidevops/logs/stop"
+	# shellcheck disable=SC2329  # Override sourced function for this regression.
+	dispatch_max() {
+		local calls next remaining_file
+		calls=$(<"$TEST_DISPATCH_CALLS_FILE")
+		[[ "$calls" =~ ^[0-9]+$ ]] || calls=0
+		printf '%s\n' "$((calls + 1))" >"$TEST_DISPATCH_CALLS_FILE"
+		next=$(awk 'NR==1 {print; exit}' "$TEST_DISPATCH_RETURNS_FILE" 2>/dev/null)
+		remaining_file="${TEST_DISPATCH_RETURNS_FILE}.next"
+		awk 'NR>1 {print}' "$TEST_DISPATCH_RETURNS_FILE" >"$remaining_file" 2>/dev/null || : >"$remaining_file"
+		mv "$remaining_file" "$TEST_DISPATCH_RETURNS_FILE"
+		[[ -n "$next" ]] || next=0
+		printf '%s\n' "$next"
+		return 0
+	}
+	# shellcheck disable=SC2329  # Override sourced function to keep the test fast.
+	_adaptive_launch_settle_wait() {
+		return 0
+	}
+
+	apply_dispatch_max
+
+	local dispatch_calls
+	dispatch_calls=$(<"$TEST_DISPATCH_CALLS_FILE")
+	if [[ "$dispatch_calls" -eq 2 ]]; then
+		print_result "apply: refills minimum active-worker floor after partial launch" 0
+	else
+		print_result "apply: refills minimum active-worker floor after partial launch" 1 "dispatch_calls=${dispatch_calls}"
+	fi
+	unset TEST_ACTIVE_WORKERS_SEQUENCE_FILE TEST_DISPATCH_CALLS_FILE TEST_DISPATCH_RETURNS_FILE
+	return 0
+}
+
 test_capacity_raises_soft_cap_to_floor
 test_capacity_respects_existing_higher_cap
 test_throttle_does_not_force_serial_under_floor
 test_throttle_forces_serial_above_floor
 test_canary_preflight_bypasses_overload_only_below_floor
+test_apply_dispatch_refills_until_active_floor_after_partial_launch
 
 echo ""
 echo "===================="


### PR DESCRIPTION
## Summary

Added a minimum-worker floor refill pass after dispatch_max so partial launches keep re-enumerating candidates until active workers reach the configured floor or dispatch makes no progress.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-dispatch-min-concurrency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-min-concurrency.sh; bash .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh; shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh

Resolves #22300


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 112,708 tokens on this as a headless worker.