### PR TITLE
GH#22305: harden profile README session stats

### DIFF
--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -44,6 +44,10 @@ fi
 # --- Format number with commas (bash 3.2 compatible) ---
 _format_number() {
 	local num="$1"
+	if [[ -z "$num" || "$num" == "null" || ! "$num" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+		num="0"
+	fi
+
 	# Handle decimals: split on dot
 	local integer_part decimal_part
 	integer_part="${num%%.*}"
@@ -63,6 +67,9 @@ _format_number() {
 # --- Format hours with 1 decimal place ---
 _format_hours() {
 	local val="$1"
+	if [[ -z "$val" || "$val" == "null" || ! "$val" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+		val="0"
+	fi
 	printf "%.1f" "$val"
 	return 0
 }

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -310,32 +310,32 @@ _generate_session_time_vars() {
 	local year_json="$4"
 
 	local day_human day_worker day_total day_interactive day_workers
-	day_human=$(_format_hours "$(echo "$day_json" | jq -r '.interactive_human_hours')")
-	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
-	day_total=$(_format_hours "$(echo "$day_json" | jq -r '.total_human_hours + .total_machine_hours')")
-	day_interactive=$(echo "$day_json" | jq -r '.interactive_sessions')
-	day_workers=$(echo "$day_json" | jq -r '.worker_sessions')
+	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0)')")
+	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	day_total=$(_format_hours "$(echo "$day_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
+	day_interactive=$(_format_number "$(echo "$day_json" | jq -r '(.interactive_sessions // 0)')")
+	day_workers=$(_format_number "$(echo "$day_json" | jq -r '(.worker_sessions // 0)')")
 
 	local week_human week_worker week_total week_interactive week_workers
-	week_human=$(_format_hours "$(echo "$week_json" | jq -r '.interactive_human_hours')")
-	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
-	week_total=$(_format_hours "$(echo "$week_json" | jq -r '.total_human_hours + .total_machine_hours')")
-	week_interactive=$(echo "$week_json" | jq -r '.interactive_sessions')
-	week_workers=$(echo "$week_json" | jq -r '.worker_sessions')
+	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0)')")
+	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	week_total=$(_format_hours "$(echo "$week_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
+	week_interactive=$(_format_number "$(echo "$week_json" | jq -r '(.interactive_sessions // 0)')")
+	week_workers=$(_format_number "$(echo "$week_json" | jq -r '(.worker_sessions // 0)')")
 
 	local month_human month_worker month_total month_interactive month_workers
-	month_human=$(_format_hours "$(echo "$month_json" | jq -r '.interactive_human_hours')")
-	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
-	month_total=$(_format_hours "$(echo "$month_json" | jq -r '.total_human_hours + .total_machine_hours')")
-	month_interactive=$(echo "$month_json" | jq -r '.interactive_sessions')
-	month_workers=$(echo "$month_json" | jq -r '.worker_sessions')
+	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0)')")
+	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	month_total=$(_format_hours "$(echo "$month_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
+	month_interactive=$(_format_number "$(echo "$month_json" | jq -r '(.interactive_sessions // 0)')")
+	month_workers=$(_format_number "$(echo "$month_json" | jq -r '(.worker_sessions // 0)')")
 
 	local year_human year_worker year_total year_interactive year_workers
-	year_human=$(_format_hours "$(echo "$year_json" | jq -r '.interactive_human_hours')")
-	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
-	year_total=$(_format_hours "$(echo "$year_json" | jq -r '.total_human_hours + .total_machine_hours')")
-	year_interactive=$(echo "$year_json" | jq -r '.interactive_sessions')
-	year_workers=$(echo "$year_json" | jq -r '.worker_sessions')
+	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0)')")
+	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	year_total=$(_format_hours "$(echo "$year_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
+	year_interactive=$(_format_number "$(echo "$year_json" | jq -r '(.interactive_sessions // 0)')")
+	year_workers=$(_format_number "$(echo "$year_json" | jq -r '(.worker_sessions // 0)')")
 
 	# Emit as shell variable assignments for eval
 	printf 'day_human=%q day_worker=%q day_total=%q day_interactive=%q day_workers=%q\n' \

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -107,6 +107,7 @@ EOF
 	git init -b main "${profile_repo}" >/dev/null
 	git -C "${profile_repo}" config user.name "Fixture"
 	git -C "${profile_repo}" config user.email "fixture@example.com"
+	git -C "${profile_repo}" config commit.gpgsign false
 	git -C "${profile_repo}" remote add origin "${remote_repo}"
 
 	cat >"${profile_repo}/README.md" <<'EOF'
@@ -225,6 +226,7 @@ test_inject_markers_into_existing_readme() {
 	git init -b main "${fixture_repo}" >/dev/null
 	git -C "${fixture_repo}" config user.name "Fixture"
 	git -C "${fixture_repo}" config user.email "fixture@example.com"
+	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	# Write a user-authored README without any aidevops markers
@@ -310,6 +312,7 @@ test_diverged_history_recovery() {
 	git init -b main "${fixture_repo}" >/dev/null
 	git -C "${fixture_repo}" config user.name "Fixture"
 	git -C "${fixture_repo}" config user.email "fixture@example.com"
+	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	cat >"${fixture_repo}/README.md" <<'EOF'
@@ -336,6 +339,7 @@ EOF
 	git clone "${fixture_remote}" "${tmp_clone}" 2>/dev/null
 	git -C "${tmp_clone}" config user.name "GitHub"
 	git -C "${tmp_clone}" config user.email "noreply@github.com"
+	git -C "${tmp_clone}" config commit.gpgsign false
 	echo "# fixture" >"${tmp_clone}/README.md"
 	git -C "${tmp_clone}" add README.md
 	git -C "${tmp_clone}" commit -m "Initial commit" >/dev/null
@@ -402,6 +406,7 @@ test_default_template_replaced_with_rich_readme() {
 	git init -b main "${fixture_repo}" >/dev/null
 	git -C "${fixture_repo}" config user.name "Fixture"
 	git -C "${fixture_repo}" config user.email "fixture@example.com"
+	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	# Write the exact default GitHub profile template
@@ -493,6 +498,7 @@ test_default_template_with_existing_markers_replaced() {
 	git init -b main "${fixture_repo}" >/dev/null
 	git -C "${fixture_repo}" config user.name "Fixture"
 	git -C "${fixture_repo}" config user.email "fixture@example.com"
+	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	# Simulate Alex's exact case: default GitHub template with markers already
@@ -576,6 +582,60 @@ EOF
 	return 0
 }
 
+test_session_time_vars_default_missing_null_values() {
+	local test_name="session time vars default missing and null values"
+
+	TEST_DIR=$(mktemp -d)
+	local stdout_file="${TEST_DIR}/stdout"
+	local stderr_file="${TEST_DIR}/stderr"
+
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "${SOURCE_DATA_LIB}"
+	# shellcheck source=../profile-readme-render-lib.sh
+	source "${SOURCE_RENDER_LIB}"
+
+	local valid_json null_json empty_json assignments
+	valid_json='{"interactive_human_hours":1.25,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":6,"worker_sessions":7}'
+	null_json='{"interactive_human_hours":null,"worker_human_hours":null,"worker_machine_hours":null,"total_human_hours":null,"total_machine_hours":null,"interactive_sessions":null,"worker_sessions":null}'
+	empty_json='{}'
+
+	if ! _generate_session_time_vars "${empty_json}" "${null_json}" "${valid_json}" "${valid_json}" >"${stdout_file}" 2>"${stderr_file}"; then
+		print_result "${test_name}" 1 "session time var generation failed"
+		return 0
+	fi
+
+	assignments=$(<"${stdout_file}")
+	if grep -q 'printf: null' "${stderr_file}"; then
+		print_result "${test_name}" 1 "printf emitted null numeric warning"
+		return 0
+	fi
+	if grep -q 'null' "${stdout_file}"; then
+		print_result "${test_name}" 1 "rendered shell assignments contain raw null"
+		return 0
+	fi
+
+	local day_human day_worker day_total day_interactive day_workers
+	local week_human week_worker week_total week_interactive week_workers
+	local month_human month_worker month_total month_interactive month_workers
+	local year_human year_worker year_total year_interactive year_workers
+	eval "${assignments}"
+	if [[ "${day_human}" != "0.0" || "${day_worker}" != "0.0" || "${day_total}" != "0.0" ]]; then
+		print_result "${test_name}" 1 "missing day hour fields did not default to 0.0"
+		return 0
+	fi
+	if [[ "${day_interactive}" != "0" || "${day_workers}" != "0" || "${week_interactive}" != "0" || "${week_workers}" != "0" ]]; then
+		print_result "${test_name}" 1 "missing/null count fields did not default to 0"
+		return 0
+	fi
+	if [[ "${month_human}" != "1.2" || "${month_worker}" != "5.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
+		print_result "${test_name}" 1 "valid session data rendering changed"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 main() {
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
 		echo "Helper script not found or not executable: ${SOURCE_HELPER}" >&2
@@ -591,6 +651,8 @@ main() {
 	test_default_template_replaced_with_rich_readme
 	teardown
 	test_default_template_with_existing_markers_replaced
+	teardown
+	test_session_time_vars_default_missing_null_values
 	teardown
 
 	echo ""


### PR DESCRIPTION
## Summary

Defaulted missing/null session stat fields before formatting so profile README generation cannot render raw null values or printf null warnings.

## Files Changed

.agents/scripts/profile-readme-data-lib.sh,.agents/scripts/profile-readme-render-lib.sh,.agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-profile-readme-boundary.sh; shellcheck .agents/scripts/profile-readme-data-lib.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/tests/test-profile-readme-boundary.sh; profile-readme-helper.sh generate 2>&1 | rg 'null|printf: null' returned no matches

Resolves #22305


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 8m and 87,722 tokens on this as a headless worker.