### PR TITLE
t3448: reduce pulse GraphQL read pressure

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -291,6 +291,16 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		return 0
 	}
 
+	_shim_read_has_json_flag() {
+		local _arg=""
+		for _arg in "$@"; do
+			case "$_arg" in
+			--json | --json=*) return 0 ;;
+			esac
+		done
+		return 1
+	}
+
 	_shim_rest_rewrite_read() {
 		# Source the REST fallback helper (contains _rest_should_fallback
 		# and the _rest_* translator functions).
@@ -314,6 +324,14 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		[[ -n "$_inst_helper" ]] && source "$_inst_helper" 2>/dev/null || true
 		# shellcheck source=/dev/null
 		source "$_rest_helper" 2>/dev/null || return 1
+
+		# `gh * view/list --json ...` returns GraphQL-shaped field names and
+		# may include GraphQL-only safety-gate fields (reviews, statusCheckRollup,
+		# mergeStateStatus). The REST translators intentionally expose raw REST
+		# objects plus jq filtering, so rewriting --json calls is not semantically
+		# equivalent. Preserve gate safety by leaving those calls on GraphQL and
+		# let current-state telemetry count them as unavoidable read pressure.
+		_shim_read_has_json_flag "$@" && return 1
 
 		# Check GraphQL budget. If above threshold, return 1 to fall through.
 		_rest_should_fallback || return 1

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -128,6 +128,28 @@ _shim_classify_endpoint() {
 	esac
 }
 
+# _shim_caller_label <sub1> [<sub2>]
+# Return a stable instrumentation label for gh shim calls.  The old catch-all
+# `gh-shim` label hid which read/list subcommand was consuming GraphQL budget;
+# keeping the label operation-specific makes duplicate pressure visible in
+# pulse-current-state-helper without changing call semantics.
+_shim_caller_label() {
+	local sub1="${1:-}" sub2="${2:-}"
+	case "${sub1}:${sub2}" in
+	issue:list) printf 'gh_issue_list' ;;
+	issue:view) printf 'gh_issue_view' ;;
+	pr:list) printf 'gh_pr_list' ;;
+	pr:view) printf 'gh_pr_view' ;;
+	api:graphql | api:graphql/*) printf 'gh_api_graphql' ;;
+	api:*) printf 'gh_api_rest' ;;
+	search:issues) printf 'gh_search_issues' ;;
+	search:prs) printf 'gh_search_prs' ;;
+	search:*) printf 'gh_search' ;;
+	*) printf 'gh_%s%s' "${sub1:-unknown}" "${sub2:+_${sub2}}" ;;
+	esac
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Locate the REAL gh binary, excluding our own shim directory from PATH lookup
 # so we never recurse into ourselves even if PATH is unusual.
@@ -176,9 +198,9 @@ api:*)
 		echo "[aidevops] gh shim: real gh binary not found on PATH" >&2
 		exit 127
 	}
-	# GH#21857: instrument every passthrough gh call (pr merge, pr checks,
+	# GH#21857/t3448: instrument every passthrough gh call (pr merge, pr checks,
 	# run list, repo clone, etc.) that previously bypassed all recording.
-	gh_record_call "$(_shim_classify_endpoint "${1:-}" "${2:-}")" gh-shim 2>/dev/null || true
+	gh_record_call "$(_shim_classify_endpoint "${1:-}" "${2:-}")" "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
 	exec "$_real_gh" "$@"
 	;;
 esac
@@ -299,8 +321,10 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# Extract repo and build stripped args.
 		_shim_extract_repo_and_args "$@" || return 1
 
-		# Record the call as "rest" with caller "gh-shim".
-		gh_record_call rest gh-shim 2>/dev/null || true
+		# Record the call as REST under the original gh operation. The REST
+		# translator records its own _rest_* label too; this shadow record keeps
+		# before/after ratios visible for the original high-frequency command.
+		gh_record_call rest "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
 
 		# Dispatch to the appropriate REST translator.
 		case "$_SHIM_READ_REWRITE" in
@@ -327,8 +351,8 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# get here when rc=1 from the function wrapper. The translator errors
 		# are already printed to stderr by the _rest_* functions.
 		# Conservative: always fall through to real gh.
-		# GH#21857: record the graphql call — the real gh will use GraphQL.
-		gh_record_call graphql gh-shim 2>/dev/null || true
+		# GH#21857/t3448: record the graphql call — the real gh will use GraphQL.
+		gh_record_call graphql "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
 		exec "$REAL_GH" "$@"
 	fi
 fi
@@ -777,5 +801,5 @@ fi
 
 # GH#21857: instrument write commands (issue comment/create/edit, pr create/
 # comment/edit) — these all use the GraphQL endpoint.
-gh_record_call graphql gh-shim 2>/dev/null || true
+gh_record_call graphql "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
 exec "$REAL_GH" "${_modified_args[@]}"

--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -222,18 +222,62 @@ except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
     pass
 
 api_consumers = []
+api_pressure = {
+    'graphql_read_calls': 0,
+    'rest_read_calls': 0,
+    'graphql_search_calls': 0,
+    'rest_search_calls': 0,
+    'graphql_other_calls': 0,
+    'read_rest_ratio': None,
+    'top_read_graphql_callers': [],
+    'shadow_mode': 'gh shim records operation-specific read/list callers; REST rows are before/after counter for fallback routing',
+}
 api_report = os.path.join(log_dir, 'gh-api-calls-by-stage.json')
 if os.path.exists(api_report):
     try:
         report = json.load(open(api_report, encoding='utf-8'))
+        read_graphql_callers = []
+        read_caller_names = {'gh_issue_list', 'gh_pr_list', 'gh_issue_view', 'gh_pr_view'}
+        rest_read_caller_names = {'_rest_issue_list', '_rest_pr_list', '_rest_issue_view', '_rest_pr_view'}
         for caller, data in (report.get('by_caller') or {}).items():
             if isinstance(data, dict):
                 gql = int(data.get('graphql_calls') or 0) + int(data.get('search_graphql_calls') or 0)
                 if gql > 0:
                     api_consumers.append({'caller': caller, 'graphql_calls': gql})
+                graphql_calls = int(data.get('graphql_calls') or 0)
+                rest_calls = int(data.get('rest_calls') or 0)
+                search_graphql_calls = int(data.get('search_graphql_calls') or 0)
+                search_rest_calls = int(data.get('search_rest_calls') or 0)
+                if caller in read_caller_names:
+                    api_pressure['graphql_read_calls'] += graphql_calls
+                    api_pressure['rest_read_calls'] += rest_calls
+                    if graphql_calls > 0:
+                        read_graphql_callers.append({'caller': caller, 'graphql_calls': graphql_calls})
+                elif caller in rest_read_caller_names:
+                    api_pressure['rest_read_calls'] += rest_calls
+                else:
+                    api_pressure['graphql_other_calls'] += graphql_calls
+                api_pressure['graphql_search_calls'] += search_graphql_calls
+                api_pressure['rest_search_calls'] += search_rest_calls
         api_consumers = sorted(api_consumers, key=lambda item: item['graphql_calls'], reverse=True)[:5]
+        read_total = api_pressure['graphql_read_calls'] + api_pressure['rest_read_calls']
+        if read_total > 0:
+            api_pressure['read_rest_ratio'] = round(api_pressure['rest_read_calls'] / read_total, 4)
+        api_pressure['top_read_graphql_callers'] = sorted(
+            read_graphql_callers, key=lambda item: item['graphql_calls'], reverse=True
+        )[:5]
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         api_consumers = []
+        api_pressure = {
+            'graphql_read_calls': 0,
+            'rest_read_calls': 0,
+            'graphql_search_calls': 0,
+            'rest_search_calls': 0,
+            'graphql_other_calls': 0,
+            'read_rest_ratio': None,
+            'top_read_graphql_callers': [],
+            'shadow_mode': 'unavailable: failed to parse gh-api report',
+        }
 
 result = {
     'window_seconds': window_s,
@@ -272,6 +316,7 @@ result = {
     'dispatch_alive': bool(stage_records or metrics or counter_hits or worktrees),
     'graphql_budget_status': graphql_budget_status,
     'top_graphql_consumers': api_consumers,
+    'api_call_pressure': api_pressure,
 }
 
 if as_json:
@@ -290,6 +335,7 @@ else:
     print(f'- GraphQL budget: {graphql_budget_status}')
     if api_consumers:
         print(f'- Top GraphQL consumers: {json.dumps(api_consumers)}')
+    print(f'- API call pressure: {json.dumps(api_pressure, sort_keys=True)}')
     print(f'- Worker worktrees: {result["worker_worktrees"]}')
     if wrapper_activity:
         print('- Recent wrapper activity:')

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -51,7 +51,15 @@ _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 #                         threshold to give earlier headroom (1500 = 30%
 #                         remaining). Pair: instrumentation + earlier
 #                         fallback. Trivial revert: set back to 1000 here.
-_GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-1500}"
+#   t3448 (default 3000): route safe read/list/search traffic through REST
+#                         before GraphQL drops near the dispatch circuit-breaker
+#                         floor. Operational evidence showed repeated trips while
+#                         GraphQL was still around 2500/5000 because list/view
+#                         bursts drained the remaining headroom between pulse
+#                         cycles. Writes and GraphQL-only gates remain unchanged;
+#                         this only shifts supported read/list/search translators
+#                         to the REST core bucket earlier.
+_GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-3000}"
 
 #######################################
 # Execute a gh api command with optional wall-clock timeout (t2913).

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -283,6 +283,22 @@ else
 fi
 
 # =============================================================================
+# Test 12: --json read calls stay on GraphQL to preserve gh-shaped fields
+# =============================================================================
+echo ""
+echo "Test 12: --json read calls do not REST rewrite"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-json.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+_GH_SHOULD_FALLBACK_OVERRIDE=1 "$SHIM_RUN" pr view 123 --repo owner/repo --json number,statusCheckRollup 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == $'pr\nview\n123\n--repo\nowner/repo\n--json\nnumber,statusCheckRollup' ]] && grep -q $'\tgh_pr_view\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "--json read stays on GraphQL with operation label"
+else
+	_fail "--json read GraphQL preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo ""

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -164,13 +164,15 @@ body_file="$TMP/body.md"
 printf 'unsigned body content\n' >"$body_file"
 _reset_log
 "$SHIM_RUN" issue comment 456 --repo owner/repo --body-file "$body_file" 2>/dev/null
-if grep -q "<!-- aidevops:sig -->" "$body_file"; then
-	_pass "sig marker appended to --body-file"
+argv=$(_read_argv)
+resolved_body_file=$(printf '%s\n' "$argv" | awk 'prev { print; exit } $0 == "--body-file" { prev=1 }')
+if [[ -n "$resolved_body_file" && -f "$resolved_body_file" ]] && grep -q "<!-- aidevops:sig -->" "$resolved_body_file"; then
+	_pass "sig marker appended to temporary --body-file"
 else
-	_fail "--body-file sig injection" "file contents: $(cat "$body_file")"
+	_fail "--body-file sig injection" "argv: $argv"
 fi
-if grep -q "unsigned body content" "$body_file"; then
-	_pass "original --body-file content preserved"
+if grep -q "unsigned body content" "$body_file" && ! grep -q "<!-- aidevops:sig -->" "$body_file"; then
+	_pass "original --body-file content preserved without mutation"
 else
 	_fail "--body-file original preservation" ""
 fi

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -79,6 +79,7 @@ chmod +x "$TMP/scripts/gh-signature-helper.sh"
 # instead of the real one installed in ~/.aidevops/agents/scripts/.
 cp "$SHIM" "$TMP/scripts/gh"
 chmod +x "$TMP/scripts/gh"
+cp "$REPO_DIR/.agents/scripts/gh-api-instrument.sh" "$TMP/scripts/gh-api-instrument.sh"
 
 # Put stub gh in PATH (for shim's REAL_GH discovery) and the shim in
 # $TMP/scripts (for direct invocation in tests).
@@ -263,6 +264,22 @@ if [[ "$argv" == "$expected" ]]; then
 	_pass "gh api pass-through"
 else
 	_fail "gh api pass-through" "argv: $argv"
+fi
+
+# =============================================================================
+# Test 11: gh shim records operation-specific instrumentation labels
+# =============================================================================
+echo ""
+echo "Test 11: operation-specific instrumentation labels"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+"$SHIM_RUN" issue list --repo owner/repo 2>/dev/null
+"$SHIM_RUN" pr view 123 --repo owner/repo 2>/dev/null
+if grep -q $'\tgh_issue_list\tgraphql' "$AIDEVOPS_GH_API_LOG" && grep -q $'\tgh_pr_view\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "read/list calls use operation-specific labels"
+else
+	_fail "operation-specific instrumentation labels" "log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -33,6 +33,16 @@ json.dump({
     },
     'gauges': {'graphql_remaining': {'value': 1234, 'ts': now}},
 }, open(os.path.join(root, 'pulse-stats.json'), 'w'))
+json.dump({
+    '_meta': {'total_calls': 42},
+    'by_caller': {
+        'gh_issue_list': {'graphql_calls': 7, 'rest_calls': 3, 'search_graphql_calls': 0, 'search_rest_calls': 0, 'other_calls': 0, 'total': 10},
+        'gh_pr_view': {'graphql_calls': 2, 'rest_calls': 0, 'search_graphql_calls': 0, 'search_rest_calls': 0, 'other_calls': 0, 'total': 2},
+        '_rest_pr_list': {'graphql_calls': 0, 'rest_calls': 5, 'search_graphql_calls': 0, 'search_rest_calls': 0, 'other_calls': 0, 'total': 5},
+        'pulse-batch-prefetch-helper.sh': {'graphql_calls': 0, 'rest_calls': 0, 'search_graphql_calls': 11, 'search_rest_calls': 4, 'other_calls': 0, 'total': 15},
+        'gh_api_graphql': {'graphql_calls': 10, 'rest_calls': 0, 'search_graphql_calls': 0, 'search_rest_calls': 0, 'other_calls': 0, 'total': 10},
+    }
+}, open(os.path.join(root, 'gh-api-calls-by-stage.json'), 'w'))
 open(os.path.join(root, 'pulse-wrapper.log'), 'w').write('[pulse] useful activity\nPR opened #2\nPR merged #2\nissue closed #1\nInstance lock acquired\n')
 PY
 
@@ -43,6 +53,7 @@ grep -q 'Dispatch alive: true' "$output"
 grep -q 'Worker terminal events: 4' "$output"
 grep -q 'dispatch_backoff_skipped' "$output"
 grep -q 'GraphQL budget:' "$output"
+grep -q 'API call pressure:' "$output"
 grep -q 'worker_launch_total' "$output"
 grep -q 'watchdog_killed' "$output"
 grep -q 'rate_limited' "$output"
@@ -57,5 +68,11 @@ jq -e '.worker_outcomes.no_op == 1' "$json_output" >/dev/null
 jq -e '.worker_outcomes.canary_failed == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.skipped_low_count == 1' "$json_output" >/dev/null
 jq -e '.dispatch_stage_timing_ms.worker_launch_total.avg_ms == 123' "$json_output" >/dev/null
+jq -e '.api_call_pressure.graphql_read_calls == 9' "$json_output" >/dev/null
+jq -e '.api_call_pressure.rest_read_calls == 8' "$json_output" >/dev/null
+jq -e '.api_call_pressure.graphql_search_calls == 11' "$json_output" >/dev/null
+jq -e '.api_call_pressure.rest_search_calls == 4' "$json_output" >/dev/null
+jq -e '.api_call_pressure.graphql_other_calls == 10' "$json_output" >/dev/null
+jq -e '.api_call_pressure.read_rest_ratio == 0.4706' "$json_output" >/dev/null
 
 printf 'PASS pulse-current-state-helper\n'


### PR DESCRIPTION
## Summary

Raised the safe REST fallback threshold for supported read/list/search paths, added operation-specific gh shim attribution, and exposed read/search REST-vs-GraphQL pressure in current-state telemetry.

## Files Changed

.agents/scripts/gh,.agents/scripts/pulse-current-state-helper.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-shim.sh,.agents/scripts/tests/test-pulse-current-state-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh .agents/scripts/pulse-current-state-helper.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-pulse-current-state-helper.sh .agents/scripts/tests/test-gh-shim.sh .agents/scripts/tests/test-gh-api-instrument.sh; bash .agents/scripts/tests/test-pulse-current-state-helper.sh; bash .agents/scripts/tests/test-gh-shim.sh; bash .agents/scripts/tests/test-gh-api-instrument.sh; .agents/scripts/stat-portability-check.sh --dry-run --base origin/main

Resolves #22301


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 8m and 140,951 tokens on this as a headless worker.