### PR TITLE
GH#22288: improve pulse API call attribution

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -137,7 +137,7 @@ _is_search_rate_limited() {
 # Returns: 0 on success (cache written), 1 on failure (REST also failed/no data)
 _prefetch_rest_issues_for_slug() {
 	local slug="$1"
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest pulse_batch_prefetch_rest_issues 2>/dev/null || true
 	local rest_json
 	rest_json=$(gh api "/repos/${slug}/issues?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
 	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
@@ -177,7 +177,7 @@ _prefetch_rest_issues_for_slug() {
 # Returns: 0 on success (cache written), 1 on failure (REST also failed/no data)
 _prefetch_rest_prs_for_slug() {
 	local slug="$1"
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest pulse_batch_prefetch_rest_prs 2>/dev/null || true
 	local rest_json
 	rest_json=$(gh api "/repos/${slug}/pulls?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
 	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
@@ -378,11 +378,11 @@ _refresh_owner_issues() {
 	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
 	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search issues for owner=${owner}, going straight to REST"
-		gh_record_call search-rest 2>/dev/null || true
+		gh_record_call search-rest pulse_batch_prefetch_search_issues_fallback 2>/dev/null || true
 		_prefetch_rest_per_slug issues "$slugs"
 		return 0
 	fi
-	gh_record_call search-graphql 2>/dev/null || true
+	gh_record_call search-graphql pulse_batch_prefetch_search_issues 2>/dev/null || true
 	local issue_err
 	issue_err=$(mktemp)
 	local issue_json=""
@@ -434,11 +434,11 @@ _refresh_owner_prs() {
 	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
 	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search prs for owner=${owner}, going straight to REST"
-		gh_record_call search-rest 2>/dev/null || true
+		gh_record_call search-rest pulse_batch_prefetch_search_prs_fallback 2>/dev/null || true
 		_prefetch_rest_per_slug prs "$slugs"
 		return 0
 	fi
-	gh_record_call search-graphql 2>/dev/null || true
+	gh_record_call search-graphql pulse_batch_prefetch_search_prs 2>/dev/null || true
 	local pr_err
 	pr_err=$(mktemp)
 	local pr_json=""
@@ -517,6 +517,7 @@ _cmd_refresh() {
 	# Fail-open: if the fetch fails, an empty string is passed and the per-owner functions
 	# fall back to their own rate-limit call (the existing behaviour).
 	local _graphql_remaining=""
+	gh_record_call rest pulse_batch_prefetch_rate_limit 2>/dev/null || true
 	_graphql_remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || _graphql_remaining=""
 
 	# L1 tickle counters — reset per refresh cycle (module globals from

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -137,7 +137,7 @@ _is_search_rate_limited() {
 # Returns: 0 on success (cache written), 1 on failure (REST also failed/no data)
 _prefetch_rest_issues_for_slug() {
 	local slug="$1"
-	gh_record_call rest pulse_batch_prefetch_rest_issues 2>/dev/null || true
+	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_issues || true
 	local rest_json
 	rest_json=$(gh api "/repos/${slug}/issues?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
 	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
@@ -177,7 +177,7 @@ _prefetch_rest_issues_for_slug() {
 # Returns: 0 on success (cache written), 1 on failure (REST also failed/no data)
 _prefetch_rest_prs_for_slug() {
 	local slug="$1"
-	gh_record_call rest pulse_batch_prefetch_rest_prs 2>/dev/null || true
+	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_prs || true
 	local rest_json
 	rest_json=$(gh api "/repos/${slug}/pulls?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
 	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
@@ -378,11 +378,11 @@ _refresh_owner_issues() {
 	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
 	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search issues for owner=${owner}, going straight to REST"
-		gh_record_call search-rest pulse_batch_prefetch_search_issues_fallback 2>/dev/null || true
+		declare -F gh_record_call >/dev/null && gh_record_call search-rest pulse_batch_prefetch_search_issues_fallback || true
 		_prefetch_rest_per_slug issues "$slugs"
 		return 0
 	fi
-	gh_record_call search-graphql pulse_batch_prefetch_search_issues 2>/dev/null || true
+	declare -F gh_record_call >/dev/null && gh_record_call search-graphql pulse_batch_prefetch_search_issues || true
 	local issue_err
 	issue_err=$(mktemp)
 	local issue_json=""
@@ -434,11 +434,11 @@ _refresh_owner_prs() {
 	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
 	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search prs for owner=${owner}, going straight to REST"
-		gh_record_call search-rest pulse_batch_prefetch_search_prs_fallback 2>/dev/null || true
+		declare -F gh_record_call >/dev/null && gh_record_call search-rest pulse_batch_prefetch_search_prs_fallback || true
 		_prefetch_rest_per_slug prs "$slugs"
 		return 0
 	fi
-	gh_record_call search-graphql pulse_batch_prefetch_search_prs 2>/dev/null || true
+	declare -F gh_record_call >/dev/null && gh_record_call search-graphql pulse_batch_prefetch_search_prs || true
 	local pr_err
 	pr_err=$(mktemp)
 	local pr_json=""
@@ -517,7 +517,7 @@ _cmd_refresh() {
 	# Fail-open: if the fetch fails, an empty string is passed and the per-owner functions
 	# fall back to their own rate-limit call (the existing behaviour).
 	local _graphql_remaining=""
-	gh_record_call rest pulse_batch_prefetch_rate_limit 2>/dev/null || true
+	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rate_limit || true
 	_graphql_remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || _graphql_remaining=""
 
 	# L1 tickle counters — reset per refresh cycle (module globals from

--- a/.agents/scripts/pulse-events-tickle.sh
+++ b/.agents/scripts/pulse-events-tickle.sh
@@ -85,6 +85,7 @@ _events_tickle_log() {
 _events_tickle_detect_owner_type() {
 	local owner="$1"
 	local api_type
+	declare -F gh_record_call >/dev/null 2>&1 && gh_record_call rest events_tickle_owner_type || true
 	api_type=$(gh api "/users/${owner}" --jq '.type' 2>/dev/null) || api_type=""
 	if [[ "$api_type" == "Organization" ]]; then
 		printf 'orgs'
@@ -182,6 +183,7 @@ events_tickle() {
 	# detect the 304 status code and extract the ETag from the headers.
 	# gh exits non-zero for non-2xx responses including 304.
 	local response="" exit_code=0
+	declare -F gh_record_call >/dev/null 2>&1 && gh_record_call rest events_tickle_events || true
 	if [[ -n "$stored_etag" ]]; then
 		response=$(gh api -i "$api_path" -H "If-None-Match: \"${stored_etag}\"" 2>&1) || exit_code=$?
 	else
@@ -217,6 +219,7 @@ events_tickle() {
 		# Retry with the other type; update cache if the retry succeeds.
 		if [[ "$owner_type" == "users" ]]; then
 			local org_response="" org_exit=0
+			declare -F gh_record_call >/dev/null 2>&1 && gh_record_call rest events_tickle_org_retry || true
 			org_response=$(gh api -i "/orgs/${owner}/events?per_page=1" 2>&1) || org_exit=$?
 			local org_status
 			org_status=$(_events_tickle_parse_status "$org_response")

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -164,6 +164,27 @@ else
 	PASS=$((PASS + 1))
 fi
 
+# --- Test 7: explicit call-site names partition coarse callers ----------
+unset AIDEVOPS_GH_API_INSTRUMENT_DISABLE
+gh_clear_log
+gh_record_call rest pulse_batch_prefetch_rate_limit
+gh_record_call search-graphql pulse_batch_prefetch_search_issues
+gh_record_call search-graphql pulse_batch_prefetch_search_prs
+gh_record_call rest events_tickle_events
+gh_aggregate_calls
+
+rate_limit_count=$(jq -r '.by_caller["pulse_batch_prefetch_rate_limit"].rest_calls' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "explicit caller: rate-limit REST call counted separately" "1" "$rate_limit_count"
+
+search_issue_count=$(jq -r '.by_caller["pulse_batch_prefetch_search_issues"].search_graphql_calls' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "explicit caller: issue search counted separately" "1" "$search_issue_count"
+
+search_pr_count=$(jq -r '.by_caller["pulse_batch_prefetch_search_prs"].search_graphql_calls' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "explicit caller: PR search counted separately" "1" "$search_pr_count"
+
+tickle_count=$(jq -r '.by_caller["events_tickle_events"].rest_calls' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "explicit caller: events tickle REST call counted separately" "1" "$tickle_count"
+
 # --- Summary ----------------------------------------------------------
 echo ""
 echo "===================================================="


### PR DESCRIPTION
## Summary
- Added explicit gh-api instrumentation caller names for batch prefetch rate-limit checks, owner search paths, REST fallbacks, and events ETag tickles.
- Added regression coverage proving coarse pulse callers are now partitioned into actionable call-site buckets.

## Call-budget report
Using `gh-api-instrument.sh` synthetic aggregation for the audited pulse paths:

### Before
- `pulse-batch-prefetch-helper.sh`: total=3, rest=1, search_graphql=2 — issue search, PR search, and rate-limit attribution collapsed into one caller.
- `pulse-events-tickle.sh`: total=1, rest=1 — events tickle attribution collapsed into one caller.

### After
- `pulse_batch_prefetch_rate_limit`: rest=1
- `pulse_batch_prefetch_search_issues`: search_graphql=1
- `pulse_batch_prefetch_search_prs`: search_graphql=1
- `events_tickle_events`: rest=1

## Verification
- `shellcheck .agents/scripts/pulse-events-tickle.sh .agents/scripts/pulse-batch-prefetch-helper.sh .agents/scripts/tests/test-gh-api-instrument.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh` — 9 passed, 0 failed
- `bash .agents/scripts/tests/test-pulse-wrapper-delta-prefetch.sh` — 11 passed, 0 failed
- `bash .agents/scripts/tests/test-pulse-events-tickle.sh` — 30 passed, 0 failed
- `bash .agents/scripts/tests/test-gh-api-instrument.sh` — 18 passed, 0 failed

Resolves #22288
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 5m and 97,872 tokens on this as a headless worker.