### PR TITLE
t3442: Add data-flow contracts and privacy tiers to agent packs

### DIFF
--- a/.agents/aidevops/agent-sources.md
+++ b/.agents/aidevops/agent-sources.md
@@ -81,7 +81,9 @@ my-private-agents/.agents/my-agent/
 5. Add any helper `.sh` scripts needed for CLI automation.
 6. Add `.agents/agent-pack.json` for private packs that should advertise
    domains, triggers, commands, helpers, secrets, and outputs compactly.
-7. Follow `tools/build-agent/build-agent.md`.
+7. Keep the manifest's data-flow contract current as inputs, outputs, and
+   privacy tiers change.
+8. Follow `tools/build-agent/build-agent.md`.
 
 ## Agent Pack Manifest
 
@@ -105,8 +107,11 @@ Use the template at `.agents/templates/agent-source-repo/agent-pack.json`.
 | `commands` | Slash commands and command docs shipped by the pack |
 | `helpers` / `helper_scripts` | Deterministic scripts the pack expects agents to use |
 | `required_secrets` | Secret names and storage hints; never include secret values |
+| `inputs` | Expected source material, with source location and sensitivity metadata |
 | `outputs` / `output_artifacts` | Generated artifact locations and contracts |
-| `sensitivity` / `sensitivity_tier` | `private`, `restricted`, or another local sensitivity tier |
+| `artifact_paths` | Named durable workspace paths for private artifacts |
+| `sensitivity` / `sensitivity_tier` | Pack default sensitivity for compact capability indexing |
+| `default_sensitivity`, `sensitivity_tiers` | Data-flow defaults and supported privacy tier enum |
 | `upstream_candidate`, `core_candidate` | Whether the pack may graduate into shared aidevops |
 
 Missing manifests are allowed. Invalid manifests are recorded as
@@ -115,9 +120,57 @@ directory scan behaviour so private agents remain available while the manifest i
 fixed.
 
 Update the manifest whenever you add a new routing domain, primary agent,
-subagent, slash command, helper script, required secret, or output artifact. Do
-not list credentials or private customer identifiers; use generic secret names
-and generic artifact paths.
+subagent, slash command, helper script, required secret, input, output artifact,
+or privacy tier. Do not list credentials or private customer identifiers; use
+generic secret names and generic artifact paths.
+
+## Data-Flow Contracts
+
+The manifest teaches agents and validators what data the pack consumes, what it
+produces, where artifacts belong, and which destinations are safe.
+
+Required data-flow fields:
+
+- `inputs[]` — expected source material. Each input declares `name`,
+  `description`, `sensitivity`, and `allowed_sources`.
+- `outputs[]` — produced artifacts. Each output declares `name`, `description`,
+  `artifact_path`, `sensitivity`, and `allowed_destinations`.
+- `artifact_paths` — named local paths for durable working outputs.
+- `default_sensitivity` and `sensitivity_tiers` — default tier and supported enum.
+
+Every output must have its own `artifact_path` and sensitivity tier. Do not rely on
+a pack-level default for outputs because the destination decision is made per
+artifact.
+
+## Privacy Tiers
+
+| Tier | Definition | Chat | Git commits | Logs | Local workspace | GitHub issue/PR text |
+|------|------------|------|-------------|------|-----------------|----------------------|
+| `public-safe` | Redacted, non-private output intended for broad sharing. | Yes | Yes | Yes | Yes | Yes |
+| `private-local` | Private repo, client, operational, or unpublished context. | No | Private repo only when intentional | No | Yes | No |
+| `secret-adjacent` | Secret locations, credential-store metadata, access patterns, or redacted security findings. | Redacted summary only | No | No | Yes | No |
+| `never-export` | Secret values, tokens, private keys, recovery codes, or unredacted credential material. | No | No | No | No; use secret store | No |
+
+When in doubt, choose the stricter tier. A `public-safe` artifact can be surfaced in
+chat, GitHub issue/PR text, logs, commits, and local workspace files. All other
+tiers should stay in local workspace artifacts unless the contract explicitly
+allows a narrower destination.
+
+## Output Contract Pattern
+
+```json
+{
+  "name": "private-working-notes",
+  "description": "Intermediate notes that may reference private source material.",
+  "artifact_path": "~/.aidevops/.agent-workspace/work/<pack-name>/notes/",
+  "sensitivity": "private-local",
+  "allowed_destinations": ["local-workspace"]
+}
+```
+
+Use `~/.aidevops/.agent-workspace/work/<pack-name>/` for private artifacts that
+must survive the session. Use `~/.aidevops/.agent-workspace/tmp/session-*` for
+throwaway intermediates. Never commit `secret-adjacent` or `never-export` content.
 
 ### Slash Command Format
 

--- a/.agents/reference/private-agent-packs.md
+++ b/.agents/reference/private-agent-packs.md
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Private Agent Packs
+
+Private agent packs are Git repositories that sync into aidevops as custom agents
+while keeping their source private. They need explicit data-flow contracts because
+the useful outputs often sit between private operational context and public-safe
+summaries.
+
+## Operating Model
+
+1. Keep pack source in a private repo.
+2. Add `agent-pack.json` at the repo root using
+   `.agents/templates/agent-source-repo/agent-pack.json` as the model.
+3. Store durable private artifacts under
+   `~/.aidevops/.agent-workspace/work/<pack-name>/`.
+4. Surface only `public-safe` outputs in chat, GitHub issues/PRs, logs, or commits.
+
+## Manifest Contract
+
+The manifest has four data-flow sections:
+
+- `inputs[]`: what the pack reads, with sensitivity and allowed source locations.
+- `outputs[]`: what the pack produces, with per-output artifact paths and
+  sensitivity tiers.
+- `artifact_paths`: durable local directories used by the pack.
+- `sensitivity`: the default tier and the complete tier enum.
+
+Each output must declare:
+
+- `name`
+- `description`
+- `artifact_path`
+- `sensitivity`
+- `allowed_destinations`
+
+Validators should fail manifests that omit an output sensitivity tier, omit an
+artifact path, or use a tier outside the supported enum.
+
+## Privacy Tiers
+
+| Tier | Use for | Allowed destinations |
+|------|---------|----------------------|
+| `public-safe` | Redacted summaries, docs, issues, PR descriptions, commit messages, and logs. | `chat`, `github-issue-pr`, `git-commit`, `logs`, `local-workspace` |
+| `private-local` | Private repo details, client context, unpublished strategy, internal notes. | `local-workspace` |
+| `secret-adjacent` | Secret paths, vault metadata, access-boundary notes, redacted security findings. | `local-workspace`; public summaries must remove operational detail |
+| `never-export` | Actual secret values, tokens, private keys, recovery codes, unredacted credentials. | None; use the approved secret store instead |
+
+## Destination Rules
+
+- Chat output: `public-safe` only.
+- Git commits: `public-safe` only, unless committing private-local pack source to the
+  private source repo is the explicit task.
+- Logs: `public-safe` only; avoid logging private operational detail.
+- Local workspace artifacts: `public-safe`, `private-local`, and `secret-adjacent`.
+- GitHub issue/PR text: `public-safe` only.
+- Secret stores: use for `never-export`; do not create local artifact files with raw
+  secret values.
+
+## Session Workflow
+
+1. Read `agent-pack.json` before producing artifacts.
+2. Match the planned artifact to an `outputs[]` entry.
+3. Write to that output's `artifact_path`.
+4. Before surfacing content outside the local workspace, verify the output tier is
+   `public-safe`.
+5. If the tier is too broad for the content, downgrade the artifact and create a
+   redacted `public-safe` summary instead.

--- a/.agents/scripts/tests/test-agent-pack-data-contracts.sh
+++ b/.agents/scripts/tests/test-agent-pack-data-contracts.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit
+MANIFEST="$REPO_ROOT/.agents/templates/agent-source-repo/agent-pack.json"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		if [[ -n "$message" ]]; then
+			printf '  %s\n' "$message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+validate_manifest() {
+	local manifest_path="$1"
+
+	python3 - "$manifest_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text())
+allowed = {"public-safe", "private-local", "secret-adjacent", "never-export"}
+errors = []
+
+for field in ("inputs", "outputs", "artifact_paths", "default_sensitivity", "sensitivity_tiers"):
+    if field not in manifest:
+        errors.append(f"missing top-level field: {field}")
+
+for index, output in enumerate(manifest.get("outputs", []), start=1):
+    for field in ("name", "description", "artifact_path", "sensitivity", "allowed_destinations"):
+        if not output.get(field):
+            errors.append(f"output {index} missing {field}")
+    sensitivity = output.get("sensitivity")
+    if sensitivity and sensitivity not in allowed:
+        errors.append(f"output {index} invalid sensitivity: {sensitivity}")
+
+for index, input_item in enumerate(manifest.get("inputs", []), start=1):
+    sensitivity = input_item.get("sensitivity")
+    if sensitivity and sensitivity not in allowed:
+        errors.append(f"input {index} invalid sensitivity: {sensitivity}")
+
+tiers = set(manifest.get("sensitivity_tiers", []))
+missing_tiers = allowed - tiers
+if missing_tiers:
+    errors.append("missing sensitivity tiers: " + ", ".join(sorted(missing_tiers)))
+
+if errors:
+    print("\n".join(errors))
+    sys.exit(1)
+PY
+	return 0
+}
+
+test_template_manifest_is_valid() {
+	if validate_manifest "$MANIFEST"; then
+		print_result "template manifest declares valid data-flow contract" 0
+	else
+		print_result "template manifest declares valid data-flow contract" 1 "Template manifest failed validation"
+	fi
+	return 0
+}
+
+test_missing_output_sensitivity_fails() {
+	local tmp_manifest
+	tmp_manifest="$(mktemp)"
+	python3 - "$MANIFEST" "$tmp_manifest" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text())
+del manifest["outputs"][0]["sensitivity"]
+Path(sys.argv[2]).write_text(json.dumps(manifest))
+PY
+
+	if validate_manifest "$tmp_manifest" >/dev/null 2>&1; then
+		print_result "missing output sensitivity fails validation" 1 "Validator accepted missing output sensitivity"
+	else
+		print_result "missing output sensitivity fails validation" 0
+	fi
+	rm -f "$tmp_manifest"
+	return 0
+}
+
+test_invalid_output_sensitivity_fails() {
+	local tmp_manifest
+	tmp_manifest="$(mktemp)"
+	python3 - "$MANIFEST" "$tmp_manifest" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text())
+manifest["outputs"][0]["sensitivity"] = "public-ish"
+Path(sys.argv[2]).write_text(json.dumps(manifest))
+PY
+
+	if validate_manifest "$tmp_manifest" >/dev/null 2>&1; then
+		print_result "invalid output sensitivity fails validation" 1 "Validator accepted invalid output sensitivity"
+	else
+		print_result "invalid output sensitivity fails validation" 0
+	fi
+	rm -f "$tmp_manifest"
+	return 0
+}
+
+main() {
+	printf 'Running agent pack data contract tests\n'
+	test_template_manifest_is_valid
+	test_missing_output_sensitivity_fails
+	test_invalid_output_sensitivity_fails
+	printf 'Results: %s/%s passed, %s failed\n' "$TESTS_PASSED" "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-agent-pack-data-contracts.sh
+++ b/.agents/scripts/tests/test-agent-pack-data-contracts.sh
@@ -69,7 +69,7 @@ if errors:
     print("\n".join(errors))
     sys.exit(1)
 PY
-	return 0
+	return $?
 }
 
 test_template_manifest_is_valid() {

--- a/.agents/templates/agent-source-repo/AGENTS.md
+++ b/.agents/templates/agent-source-repo/AGENTS.md
@@ -1,0 +1,37 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Private Agent Pack Guide
+
+This repository is an aidevops private agent source. Keep the data-flow contract in
+`agent-pack.json` current whenever an agent starts consuming new inputs or producing
+new artifacts.
+
+## Data-Flow Contract
+
+- Declare every expected input in `inputs[]` with a `name`, `description`,
+  `sensitivity`, and `allowed_sources` list.
+- Declare every produced artifact in `outputs[]` with a `name`, `description`,
+  `artifact_path`, `sensitivity`, and `allowed_destinations` list.
+- Keep paths under `~/.aidevops/.agent-workspace/work/<pack-name>/` unless the
+  output is explicitly safe to commit to this private repository.
+
+## Privacy Tiers
+
+| Tier | Meaning | Allowed destinations |
+|------|---------|----------------------|
+| `public-safe` | Redacted output safe for chat, GitHub issues/PRs, commits, logs, and local artifacts. | `chat`, `github-issue-pr`, `git-commit`, `logs`, `local-workspace` |
+| `private-local` | Private client, repo, or operational context. | `local-workspace` only |
+| `secret-adjacent` | Mentions credential locations, access boundaries, or secret handling without values. | `local-workspace`; summarize publicly only after redaction |
+| `never-export` | Raw secrets, tokens, private keys, recovery codes, or unredacted credential material. | Do not write, log, commit, or paste; use approved secret stores |
+
+## Agent Operating Rules
+
+- Before writing an artifact, choose the output entry that matches the content.
+- If content contains private names, unreleased plans, client data, or repo-private
+  context, treat it as `private-local` unless the pack contract says otherwise.
+- If content identifies where secrets live or how access is granted, treat it as
+  `secret-adjacent` even when no secret value is present.
+- If content contains an actual secret value, do not export it. Move it to the
+  approved secret store and record only a redacted note.
+- Public GitHub text must be derived only from `public-safe` outputs.

--- a/.agents/templates/agent-source-repo/agent-pack.json
+++ b/.agents/templates/agent-source-repo/agent-pack.json
@@ -2,7 +2,7 @@
   "$schema": "https://aidevops.sh/schemas/agent-pack.schema.json",
   "name": "example-private-agent-pack",
   "version": "1.0.0",
-  "description": "Private aidevops agent pack for a specific domain or client workflow.",
+  "description": "Private aidevops agent pack with explicit routing and data-flow contracts.",
   "domains": ["example-domain", "operations"],
   "triggers": ["example trigger", "private workflow", "client ops"],
   "primary_agents": [
@@ -42,14 +42,49 @@
       "purpose": "Authenticate to the private example API."
     }
   ],
+  "inputs": [
+    {
+      "name": "source_material",
+      "description": "Private source notes, repo files, or operational context the pack may read.",
+      "sensitivity": "private-local",
+      "allowed_sources": ["local-workspace", "private-repo"]
+    }
+  ],
   "outputs": [
     {
       "name": "status-report",
+      "description": "Generated status reports and workflow artifacts.",
       "path": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/status/",
-      "purpose": "Generated status reports and workflow artifacts."
+      "artifact_path": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/status/",
+      "sensitivity": "public-safe",
+      "allowed_destinations": ["chat", "github-issue-pr", "git-commit", "logs", "local-workspace"]
+    },
+    {
+      "name": "private-working-notes",
+      "description": "Intermediate notes that may reference private source material.",
+      "path": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/notes/",
+      "artifact_path": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/notes/",
+      "sensitivity": "private-local",
+      "allowed_destinations": ["local-workspace"]
+    },
+    {
+      "name": "secret-adjacency-report",
+      "description": "Findings that describe secret locations, credential stores, or access boundaries without exposing values.",
+      "path": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/restricted/",
+      "artifact_path": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/restricted/",
+      "sensitivity": "secret-adjacent",
+      "allowed_destinations": ["local-workspace"]
     }
   ],
-  "sensitivity": "private",
+  "artifact_paths": {
+    "base": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/",
+    "status": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/status/",
+    "notes": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/notes/",
+    "restricted": "~/.aidevops/.agent-workspace/work/example-private-agent-pack/restricted/"
+  },
+  "sensitivity": "private-local",
+  "default_sensitivity": "private-local",
+  "sensitivity_tiers": ["public-safe", "private-local", "secret-adjacent", "never-export"],
   "upstream_candidate": false,
   "core_candidate": false
 }


### PR DESCRIPTION
## Summary

Added an agent-pack manifest template with routing metadata, inputs, outputs, artifact paths, and sensitivity tiers; documented private agent pack data-flow rules; added validation coverage for output sensitivity fields.

## Files Changed

.agents/aidevops/agent-sources.md,.agents/reference/private-agent-packs.md,.agents/scripts/tests/test-agent-pack-data-contracts.sh,.agents/templates/agent-source-repo/AGENTS.md,.agents/templates/agent-source-repo/agent-pack.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-agent-pack-data-contracts.sh; npx --yes markdownlint-cli2 .agents/aidevops/agent-sources.md .agents/reference/private-agent-packs.md; shellcheck .agents/scripts/tests/test-agent-pack-data-contracts.sh

Resolves #22292


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.92 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 11m and 137,032 tokens on this as a headless worker.