### PR TITLE
GH#22306: recover stuck profile README LaunchAgent

### DIFF
--- a/.agents/configs/sh.aidevops.profile-readme-update.plist
+++ b/.agents/configs/sh.aidevops.profile-readme-update.plist
@@ -8,7 +8,7 @@
 	<array>
 		<string>/bin/bash</string>
 		<string>-c</string>
-		<string>$HOME/.aidevops/agents/scripts/profile-readme-helper.sh update >> $HOME/.aidevops/.agent-workspace/logs/profile-readme-update.log 2>&1</string>
+		<string>log="$HOME/.aidevops/.agent-workspace/logs/profile-readme-update.log"; mkdir -p "$(dirname "$log")"; printf 'Profile README launchd wrapper started at %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$log"; exec "$HOME/.aidevops/agents/scripts/profile-readme-helper.sh" update >> "$log" 2&gt;&amp;1</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>3600</integer>

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -885,9 +885,10 @@ _update_push_with_recovery() {
 
 	git -C "$profile_repo" add README.md
 	git -C "$profile_repo" commit -m "$commit_msg" --no-verify 2>/dev/null || {
-		echo "No changes to commit"
+		echo "No changes to commit after profile README update"
 		return 0
 	}
+	echo "Committed profile README update: $commit_msg"
 
 	local default_branch
 	default_branch=$(git -C "$profile_repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
@@ -908,6 +909,8 @@ _update_push_with_recovery() {
 		else
 			echo "Warning: push failed and could not resolve username for recovery" >&2
 		fi
+	else
+		echo "Pushed profile README update to origin/${default_branch}"
 	fi
 	return 0
 }
@@ -918,6 +921,7 @@ cmd_update() {
 	if [[ "${1:-}" == "--dry-run" ]]; then
 		dry_run=true
 	fi
+	echo "Profile README update started at $(date -u +%Y-%m-%dT%H:%M:%SZ) (dry_run=${dry_run})"
 
 	# Resolve profile repo
 	local profile_repo
@@ -998,6 +1002,7 @@ cmd_update() {
 
 	# Apply changes and push
 	mv "$tmp_file" "$readme_path"
+	echo "Profile README content changed — committing and pushing"
 	_update_push_with_recovery "$profile_repo" "chore: update profile stats ($(date -u +%Y-%m-%d))" "$@"
 
 	echo "Profile README updated and pushed"

--- a/.agents/scripts/tests/test-launchd-install-if-changed.sh
+++ b/.agents/scripts/tests/test-launchd-install-if-changed.sh
@@ -80,6 +80,74 @@ _define_launchd_install_if_changed() {
 	launchctl() { return 0; }
 
 	# _launchd_install_if_changed — inline from setup.sh (GH#21063 fixes)
+	_launchd_agent_state() {
+		local label="$1"
+		local state=""
+		state=$(launchctl print "gui/$(id -u)/${label}" 2>/dev/null | awk -F'= ' '/state =/ { print $2; exit }' || true)
+		printf '%s\n' "$state"
+		return 0
+	}
+
+	_launchd_bootout_bootstrap() {
+		local label="$1"
+		local plist_path="$2"
+		local domain
+		domain="gui/$(id -u)"
+
+		launchctl bootout "${domain}/${label}" 2>/dev/null || true
+		launchctl bootstrap "$domain" "$plist_path" 2>/dev/null
+		return $?
+	}
+
+	_launchd_recover_xpcproxy_if_stuck() {
+		local label="$1"
+		local plist_path="$2"
+		local state
+		state=$(_launchd_agent_state "$label")
+		if [[ "$state" != "xpcproxy" ]]; then
+			return 0
+		fi
+
+		print_warning "LaunchAgent $label stuck in xpcproxy; reloading with bootout/bootstrap"
+		if ! _launchd_bootout_bootstrap "$label" "$plist_path"; then
+			return 1
+		fi
+
+		state=$(_launchd_agent_state "$label")
+		if [[ "$state" == "xpcproxy" ]]; then
+			print_warning "LaunchAgent $label still stuck in xpcproxy after recovery"
+			return 1
+		fi
+		return 0
+	}
+
+	_launchd_load_agent() {
+		local label="$1"
+		local plist_path="$2"
+
+		if launchctl load "$plist_path" 2>/dev/null; then
+			_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path" || return 1
+			return 0
+		fi
+
+		if _launchd_bootout_bootstrap "$label" "$plist_path"; then
+			_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path" || return 1
+			return 0
+		fi
+		return 1
+	}
+
+	_launchd_kickstart_and_recover() {
+		local label="$1"
+		local plist_path="$2"
+		local domain
+		domain="gui/$(id -u)"
+
+		launchctl kickstart -k "${domain}/${label}" 2>/dev/null || return 1
+		_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path"
+		return $?
+	}
+
 	_launchd_install_if_changed() {
 		local label="$1"
 		local plist_path="$2"
@@ -90,7 +158,9 @@ _define_launchd_install_if_changed() {
 			existing_content=$(cat "$plist_path")
 			if [[ "$existing_content" == "$new_content" ]]; then
 				if ! _launchd_has_agent "$label"; then
-					launchctl load "$plist_path" 2>/dev/null || return 1
+					_launchd_load_agent "$label" "$plist_path" || return 1
+				else
+					_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path" || return 1
 				fi
 				return 0
 			fi
@@ -119,7 +189,7 @@ _define_launchd_install_if_changed() {
 			rm -f "$tmp_plist"
 			return 1
 		fi
-		launchctl load "$plist_path" 2>/dev/null || return 1
+		_launchd_load_agent "$label" "$plist_path" || return 1
 		return 0
 	}
 	return 0
@@ -296,6 +366,117 @@ test_empty_content_rejected() {
 }
 
 # ---------------------------------------------------------------------------
+# (d) Loaded-but-stuck xpcproxy agents are recovered without content changes
+# ---------------------------------------------------------------------------
+
+test_xpcproxy_recovered_when_content_unchanged() {
+	local plist_dir="$TEST_DIR/la_xpcproxy"
+	mkdir -p "$plist_dir"
+	local plist_path="$plist_dir/test.plist"
+	local recovered_marker="$plist_dir/recovered"
+	printf 'some plist content\n' >"$plist_path"
+
+	_launchd_has_agent() { return 0; }
+
+	local bootout_count=0
+	local bootstrap_count=0
+	launchctl() {
+		case "${1:-}" in
+		print)
+			if [[ -f "$recovered_marker" ]]; then
+				printf 'state = running\n'
+			else
+				printf 'state = xpcproxy\n'
+			fi
+			return 0
+			;;
+		bootout)
+			bootout_count=$((bootout_count + 1))
+			return 0
+			;;
+		bootstrap)
+			bootstrap_count=$((bootstrap_count + 1))
+			: >"$recovered_marker"
+			return 0
+			;;
+		esac
+		return 0
+	}
+
+	local rc=0
+	_launchd_install_if_changed "test-label" "$plist_path" "some plist content" || rc=$?
+
+	unset -f launchctl _launchd_has_agent
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "xpcproxy_recovered_when_content_unchanged" 1 "expected recovery return 0, got $rc"
+		return 0
+	fi
+	if [[ "$bootout_count" -lt 1 || "$bootstrap_count" -lt 1 ]]; then
+		print_result "xpcproxy_recovered_when_content_unchanged" 1 \
+			"expected bootout/bootstrap recovery (bootout=$bootout_count bootstrap=$bootstrap_count)"
+		return 0
+	fi
+
+	print_result "xpcproxy_recovered_when_content_unchanged" 0
+	return 0
+}
+
+test_kickstart_recovers_xpcproxy() {
+	local plist_dir="$TEST_DIR/la_kickstart"
+	mkdir -p "$plist_dir"
+	local plist_path="$plist_dir/test.plist"
+	local recovered_marker="$plist_dir/recovered"
+	printf 'some plist content\n' >"$plist_path"
+
+	local kickstart_count=0
+	local bootstrap_count=0
+	launchctl() {
+		case "${1:-}" in
+		print)
+			if [[ -f "$recovered_marker" ]]; then
+				printf 'state = running\n'
+			else
+				printf 'state = xpcproxy\n'
+			fi
+			return 0
+			;;
+		kickstart)
+			kickstart_count=$((kickstart_count + 1))
+			return 0
+			;;
+		bootout)
+			return 0
+			;;
+		bootstrap)
+			bootstrap_count=$((bootstrap_count + 1))
+			: >"$recovered_marker"
+			return 0
+			;;
+		esac
+		return 0
+	}
+
+	local rc=0
+	_launchd_kickstart_and_recover "test-label" "$plist_path" || rc=$?
+
+	unset -f launchctl
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "kickstart_recovers_xpcproxy" 1 "expected recovery return 0, got $rc"
+		return 0
+	fi
+	if [[ "$kickstart_count" -ne 1 || "$bootstrap_count" -lt 1 ]]; then
+		print_result "kickstart_recovers_xpcproxy" 1 \
+			"expected kickstart and bootstrap recovery (kickstart=$kickstart_count bootstrap=$bootstrap_count)"
+		return 0
+	fi
+
+	print_result "kickstart_recovers_xpcproxy" 0
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -313,6 +494,8 @@ main() {
 
 	test_mv_failure_returns_1
 	test_empty_content_rejected
+	test_xpcproxy_recovered_when_content_unchanged
+	test_kickstart_recovers_xpcproxy
 
 	# Test (b) needs _install_pulse_launchd from schedulers.sh
 	_load_schedulers_functions

--- a/setup-modules/schedulers-platform.sh
+++ b/setup-modules/schedulers-platform.sh
@@ -554,6 +554,11 @@ PR_PLIST
 	)
 
 	if _launchd_install_if_changed "$pr_label" "$pr_plist" "$pr_plist_content"; then
+		if _launchd_kickstart_and_recover "$pr_label" "$pr_plist"; then
+			print_info "Profile README update kickstart verified"
+		else
+			print_warning "Profile README update LaunchAgent loaded but kickstart verification failed"
+		fi
 		print_info "Profile README update enabled (launchd, hourly)"
 	else
 		print_warning "Failed to load profile README update LaunchAgent"

--- a/setup.sh
+++ b/setup.sh
@@ -253,6 +253,74 @@ _launchd_has_agent() {
 	return $?
 }
 
+_launchd_agent_state() {
+	local label="$1"
+	local state=""
+	state=$(launchctl print "gui/$(id -u)/${label}" 2>/dev/null | awk -F'= ' '/state =/ { print $2; exit }' || true)
+	printf '%s\n' "$state"
+	return 0
+}
+
+_launchd_bootout_bootstrap() {
+	local label="$1"
+	local plist_path="$2"
+	local domain
+	domain="gui/$(id -u)"
+
+	launchctl bootout "${domain}/${label}" 2>/dev/null || true
+	launchctl bootstrap "$domain" "$plist_path" 2>/dev/null
+	return $?
+}
+
+_launchd_recover_xpcproxy_if_stuck() {
+	local label="$1"
+	local plist_path="$2"
+	local state
+	state=$(_launchd_agent_state "$label")
+	if [[ "$state" != "xpcproxy" ]]; then
+		return 0
+	fi
+
+	print_warning "LaunchAgent $label stuck in xpcproxy; reloading with bootout/bootstrap"
+	if ! _launchd_bootout_bootstrap "$label" "$plist_path"; then
+		return 1
+	fi
+
+	state=$(_launchd_agent_state "$label")
+	if [[ "$state" == "xpcproxy" ]]; then
+		print_warning "LaunchAgent $label still stuck in xpcproxy after recovery"
+		return 1
+	fi
+	return 0
+}
+
+_launchd_load_agent() {
+	local label="$1"
+	local plist_path="$2"
+
+	if launchctl load "$plist_path" 2>/dev/null; then
+		_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path" || return 1
+		return 0
+	fi
+
+	if _launchd_bootout_bootstrap "$label" "$plist_path"; then
+		_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path" || return 1
+		return 0
+	fi
+	return 1
+}
+
+_launchd_kickstart_and_recover() {
+	local label="$1"
+	local plist_path="$2"
+	local domain
+	domain="gui/$(id -u)"
+
+	launchctl kickstart -k "${domain}/${label}" 2>/dev/null || return 1
+	_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path"
+	return $?
+}
+
 # Install a launchd plist only if its content has changed.
 # Avoids unnecessary unload/reload which resets StartInterval timers.
 # Usage: _launchd_install_if_changed <label> <plist_path> <new_content>
@@ -269,7 +337,9 @@ _launchd_install_if_changed() {
 		if [[ "$existing_content" == "$new_content" ]]; then
 			# Ensure it's loaded even if content unchanged
 			if ! _launchd_has_agent "$label"; then
-				launchctl load "$plist_path" 2>/dev/null || return 1
+				_launchd_load_agent "$label" "$plist_path" || return 1
+			else
+				_launchd_recover_xpcproxy_if_stuck "$label" "$plist_path" || return 1
 			fi
 			return 0
 		fi
@@ -305,7 +375,7 @@ _launchd_install_if_changed() {
 		rm -f "$tmp_plist"
 		return 1
 	fi
-	launchctl load "$plist_path" 2>/dev/null || return 1
+	_launchd_load_agent "$label" "$plist_path" || return 1
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Added launchd xpcproxy detection/recovery around LaunchAgent load and profile README kickstart verification, improved profile README run logging, and covered recovery paths with launchd installer tests.

## Files Changed

.agents/configs/sh.aidevops.profile-readme-update.plist,.agents/scripts/profile-readme-helper.sh,.agents/scripts/tests/test-launchd-install-if-changed.sh,setup-modules/schedulers-platform.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup.sh setup-modules/schedulers-platform.sh .agents/scripts/profile-readme-helper.sh .agents/scripts/tests/test-launchd-install-if-changed.sh; bash .agents/scripts/tests/test-launchd-install-if-changed.sh; plutil -lint .agents/configs/sh.aidevops.profile-readme-update.plist; bash -n setup.sh setup-modules/schedulers-platform.sh .agents/scripts/profile-readme-helper.sh .agents/scripts/tests/test-launchd-install-if-changed.sh. Note: .agents/scripts/profile-readme-helper.sh update --dry-run emitted the new start record but exceeded the 120s worker command timeout before completion.

Resolves #22306


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 12m and 264,319 tokens on this as a headless worker.