### PR TITLE
GH#22302: harden worker canary soft-failure handling

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -944,6 +944,12 @@ CANARY_CONFIG_ERROR_TTL_SECONDS="${CANARY_CONFIG_ERROR_TTL_SECONDS:-3600}"
 # load time to subside without wasting canary CPU on doomed attempts.
 CANARY_OVERLOAD_TTL_SECONDS="${CANARY_OVERLOAD_TTL_SECONDS:-300}"
 
+# t3449: Soft canary failures (timeouts/provider/rate-limit blips) may be
+# bypassed by the dispatcher only when there is recent worker evidence. Hard
+# failures (auth/runtime/config/local) still block. This window bounds the
+# bypass so a stale success cannot mask a real outage indefinitely.
+CANARY_SOFT_FAILURE_RECENT_SUCCESS_TTL_SECONDS="${CANARY_SOFT_FAILURE_RECENT_SUCCESS_TTL_SECONDS:-900}"
+
 # t3210: Load multiplier for the pre-canary overload check.
 # load_avg_1min > NCPU * MULTIPLIER = system overloaded, skip canary.
 # Default 2 = system is noticeably contending. Lower = more aggressive
@@ -1166,6 +1172,31 @@ _check_system_overload() {
 		fi
 		return 1
 	fi
+	return 0
+}
+
+_classify_canary_failure_reason() {
+	local output_file="$1"
+	local exit_code="$2"
+	local reason
+	reason=$(classify_failure_reason "$output_file")
+	case "$reason" in
+		auth_error | rate_limit | provider_error)
+			printf '%s' "$reason"
+			return 0
+			;;
+	esac
+	case "$exit_code" in
+		124 | 137 | 142)
+			printf '%s' "timeout"
+			return 0
+			;;
+		126 | 127)
+			printf '%s' "runtime_error"
+			return 0
+			;;
+	esac
+	printf '%s' "local_error"
 	return 0
 }
 
@@ -1415,14 +1446,15 @@ _run_canary_test() {
 	local oc_version="${_VALIDATE_OC_VERSION:-unknown}"
 	print_warning "Canary test FAILED (exit=$canary_exit, model=$canary_model, opencode=$oc_version, timeout=${CANARY_TIMEOUT_SECONDS}s)"
 	print_warning "Output (last 20 lines): $(tail -20 "$canary_output" 2>/dev/null || echo '<empty>')"
-	# t2814 (Phase 3, fix #4): Stamp the negative cache so subsequent
-	# dispatches within CANARY_NEGATIVE_TTL_SECONDS short-circuit.
-	# t2887: stamp reason as "transient" -- the binary is valid (we
-	# pre-validated above) but the actual run failed. Keeps the standard
-	# 90s TTL for API/auth/timeout-class failures.
+	# t2814/t2887/t3449: Stamp the negative cache with a concrete reason so
+	# dispatch can distinguish hard failures (auth/runtime/local) from bounded
+	# soft failures (timeout/rate_limit/provider_error) when recent workers prove
+	# the runtime is still capable of launching.
+	local canary_reason
+	canary_reason=$(_classify_canary_failure_reason "$canary_output" "$canary_exit")
 	mkdir -p "${STATE_DIR}" 2>/dev/null || true
 	date +%s >"$fail_cache_file" 2>/dev/null || true
-	printf 'transient\n' >"$fail_reason_file" 2>/dev/null || true
+	printf '%s\n' "$canary_reason" >"$fail_reason_file" 2>/dev/null || true
 	rm -f "$canary_output"
 	return 1
 }

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -958,6 +958,80 @@ _dlw_min_worker_floor_active() {
 	return 1
 }
 
+_dlw_headless_state_dir() {
+	printf '%s' "${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+	return 0
+}
+
+_dlw_canary_last_failure_reason() {
+	local state_dir reason_file reason
+	state_dir=$(_dlw_headless_state_dir)
+	reason_file="${state_dir}/canary-last-fail.reason"
+	reason=$(cat "$reason_file" 2>/dev/null || printf '%s' "transient")
+	printf '%s' "$reason"
+	return 0
+}
+
+_dlw_canary_failure_is_soft() {
+	local reason="$1"
+	case "$reason" in
+		overload | provider_error | rate_limit | timeout | transient)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+_dlw_recent_worker_evidence() {
+	local ttl ledger_file
+	ttl="${CANARY_SOFT_FAILURE_RECENT_SUCCESS_TTL_SECONDS:-900}"
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=900
+	ledger_file="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/dispatch-ledger.jsonl"
+	[[ -f "$ledger_file" ]] || return 1
+	python3 - "$ledger_file" "$ttl" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+ledger_path = sys.argv[1]
+ttl = int(sys.argv[2])
+now = datetime.now(timezone.utc).timestamp()
+allowed = {"in-flight", "completed"}
+
+def parse_ts(value):
+    if not value:
+        return 0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return 0
+
+try:
+    with open(ledger_path, "r", encoding="utf-8") as handle:
+        for raw in handle:
+            try:
+                entry = json.loads(raw)
+            except Exception:
+                continue
+            if entry.get("status") not in allowed:
+                continue
+            stamp = parse_ts(entry.get("updated_at") or entry.get("dispatched_at"))
+            if stamp and 0 <= now - stamp <= ttl:
+                sys.exit(0)
+except FileNotFoundError:
+    pass
+sys.exit(1)
+PY
+	return $?
+}
+
+_dlw_allow_soft_canary_failure() {
+	local reason="$1"
+	_dlw_canary_failure_is_soft "$reason" || return 1
+	_dlw_recent_worker_evidence || return 1
+	return 0
+}
+
 _dlw_canary_preflight() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -976,6 +1050,13 @@ _dlw_canary_preflight() {
 	fi
 
 	if env "${_canary_env[@]}" "${_canary_cmd[@]}" >>"$worker_log" 2>&1; then
+		return 0
+	fi
+
+	local canary_reason
+	canary_reason=$(_dlw_canary_last_failure_reason)
+	if _dlw_allow_soft_canary_failure "$canary_reason"; then
+		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: soft worker canary failure reason=${canary_reason} bypassed because recent worker evidence exists (bounded t3449)" >>"$LOGFILE"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -210,12 +210,79 @@ test_apply_dispatch_refills_until_active_floor_after_partial_launch() {
 	return 0
 }
 
+write_recent_ledger_evidence() {
+	local status="$1"
+	local ledger_dir timestamp
+	ledger_dir="${HOME}/.aidevops/.agent-workspace/tmp"
+	mkdir -p "$ledger_dir"
+	timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+	printf '{"session_key":"test-canary","issue_number":"100","repo_slug":"o/r","pid":"1","dispatched_at":"%s","status":"%s","updated_at":"%s"}\n' \
+		"$timestamp" "$status" "$timestamp" >"${ledger_dir}/dispatch-ledger.jsonl"
+	return 0
+}
+
+test_soft_canary_failure_bypasses_with_recent_worker_evidence() {
+	local fake_helper worker_log state_dir
+	fake_helper="${TEST_ROOT}/fake-soft-canary.sh"
+	worker_log="${TEST_ROOT}/worker-soft.log"
+	state_dir="${HOME}/.aidevops/.agent-workspace/headless-runtime"
+	cat >"$fake_helper" <<'EOF'
+#!/usr/bin/env bash
+state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+mkdir -p "$state_dir"
+date +%s >"${state_dir}/canary-last-fail"
+printf 'timeout\n' >"${state_dir}/canary-last-fail.reason"
+exit 124
+EOF
+	chmod +x "$fake_helper"
+	write_recent_ledger_evidence "in-flight"
+	HEADLESS_RUNTIME_HELPER="$fake_helper"
+	AIDEVOPS_HEADLESS_RUNTIME_DIR="$state_dir"
+	TEST_ACTIVE_WORKERS=6
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	if _dlw_canary_preflight 102 "o/r" "$worker_log" "standard" ""; then
+		print_result "canary: soft failure bypassed with recent worker evidence" 0
+	else
+		print_result "canary: soft failure bypassed with recent worker evidence" 1
+	fi
+	return 0
+}
+
+test_hard_canary_failure_blocks_despite_recent_worker_evidence() {
+	local fake_helper worker_log state_dir
+	fake_helper="${TEST_ROOT}/fake-hard-canary.sh"
+	worker_log="${TEST_ROOT}/worker-hard.log"
+	state_dir="${HOME}/.aidevops/.agent-workspace/headless-runtime"
+	cat >"$fake_helper" <<'EOF'
+#!/usr/bin/env bash
+state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+mkdir -p "$state_dir"
+date +%s >"${state_dir}/canary-last-fail"
+printf 'auth_error\n' >"${state_dir}/canary-last-fail.reason"
+exit 1
+EOF
+	chmod +x "$fake_helper"
+	write_recent_ledger_evidence "completed"
+	HEADLESS_RUNTIME_HELPER="$fake_helper"
+	AIDEVOPS_HEADLESS_RUNTIME_DIR="$state_dir"
+	TEST_ACTIVE_WORKERS=6
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	if _dlw_canary_preflight 103 "o/r" "$worker_log" "standard" ""; then
+		print_result "canary: hard failure blocks despite recent worker evidence" 1 "unexpected success"
+	else
+		print_result "canary: hard failure blocks despite recent worker evidence" 0
+	fi
+	return 0
+}
+
 test_capacity_raises_soft_cap_to_floor
 test_capacity_respects_existing_higher_cap
 test_throttle_does_not_force_serial_under_floor
 test_throttle_forces_serial_above_floor
 test_canary_preflight_bypasses_overload_only_below_floor
 test_apply_dispatch_refills_until_active_floor_after_partial_launch
+test_soft_canary_failure_bypasses_with_recent_worker_evidence
+test_hard_canary_failure_blocks_despite_recent_worker_evidence
 
 echo ""
 echo "===================="


### PR DESCRIPTION
## Summary

Classified canary failures by reason and allowed bounded soft-failure bypass only when recent worker evidence exists, while keeping hard auth/runtime failures blocking.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-dispatch-min-concurrency.sh,.claude-plugin/marketplace.json,CHANGELOG.md,VERSION,aidevops.sh,package.json,setup.sh,sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-wrapper-canary.sh; bash .agents/scripts/tests/test-dispatch-min-concurrency.sh; shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh .agents/scripts/tests/test-pulse-wrapper-canary.sh; pulse-current-state-helper.sh --window 15m

Resolves #22302


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 16m and 250,642 tokens on this as a headless worker.