### PR TITLE
t3440: reduce headless prompt argv size

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -415,6 +415,9 @@ _exit_trap_handler() {
 	# t2923: Push any WIP commits before releasing the claim so re-dispatch
 	# can continue from the pushed branch instead of starting over.
 	_push_wip_commits_on_exit
+	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
+		_cleanup_headless_runtime_temp_paths
+	fi
 	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
 	_release_session_lock "$session_key"
 	_update_dispatch_ledger "$session_key" "fail"

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -45,6 +45,81 @@ readonly LOCK_DIR="${STATE_DIR}/locks"
 readonly METRICS_DIR="${HOME}/.aidevops/logs"
 readonly METRICS_FILE="${METRICS_DIR}/headless-runtime-metrics.jsonl"
 
+# Runtime temp paths owned by this helper. The worker EXIT trap also calls the
+# cleanup function below so prompt/auth dirs are removed after normal exits,
+# watchdog kills, and retry-path failures. Kept newline-delimited for bash 3.2.
+_HEADLESS_RUNTIME_TEMP_PATHS=""
+_HEADLESS_RUN_PROMPT_ARG=""
+_HEADLESS_RUN_PROMPT_FILE=""
+_HEADLESS_CLAUDE_STDIN_FILE=""
+
+_register_headless_runtime_temp_path() {
+	local path="$1"
+	[[ -n "$path" ]] || return 0
+	_HEADLESS_RUNTIME_TEMP_PATHS="${_HEADLESS_RUNTIME_TEMP_PATHS}${path}
+"
+	return 0
+}
+
+_cleanup_headless_runtime_temp_paths() {
+	local path=""
+	local tmp_root="${TMPDIR:-/tmp}"
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		case "$path" in
+		"$tmp_root"/aidevops-* | /tmp/aidevops-* | /var/folders/*/T/*/aidevops-*)
+			rm -rf "$path" 2>/dev/null || true
+			;;
+		*)
+			print_warning "[lifecycle] refusing to cleanup unexpected temp path: $path"
+			;;
+		esac
+	done <<EOF
+$_HEADLESS_RUNTIME_TEMP_PATHS
+EOF
+	_HEADLESS_RUNTIME_TEMP_PATHS=""
+	return 0
+}
+
+_prepare_runtime_prompt_transport() {
+	local runtime="$1"
+	local prompt_text="$2"
+	local threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-8192}"
+	_HEADLESS_RUN_PROMPT_ARG="$prompt_text"
+	_HEADLESS_RUN_PROMPT_FILE=""
+	_HEADLESS_CLAUDE_STDIN_FILE=""
+
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=8192
+	[[ "${#prompt_text}" -ge "$threshold" ]] || return 0
+
+	local prompt_dir=""
+	prompt_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-headless-prompt.XXXXXX") || return 0
+	_register_headless_runtime_temp_path "$prompt_dir"
+
+	local prompt_path="${prompt_dir}/seed-prompt.md"
+	if ! printf '%s' "$prompt_text" >"$prompt_path"; then
+		rm -rf "$prompt_dir" 2>/dev/null || true
+		return 0
+	fi
+
+	case "$runtime" in
+	claude)
+		# Claude Code -p reads the prompt from stdin when no prompt argument is
+		# supplied; keep the large seed out of argv while preserving content.
+		_HEADLESS_RUN_PROMPT_ARG=""
+		_HEADLESS_CLAUDE_STDIN_FILE="$prompt_path"
+		;;
+	opencode | *)
+		# OpenCode has no stdin prompt mode in `opencode run --help`; attach the
+		# seed file and pass a short instruction, avoiding process-table bloat.
+		_HEADLESS_RUN_PROMPT_ARG="Read and execute the complete seed prompt attached as seed-prompt.md. Treat the attached file as the user prompt for this headless run."
+		_HEADLESS_RUN_PROMPT_FILE="$prompt_path"
+		;;
+	esac
+
+	return 0
+}
+
 # Source the stable utility library (t2013 split).
 # All state DB, provider auth, backoff, output parsing, metrics, sandbox,
 # worker contract, watchdog, DB merge, dispatch ledger, failure reporting,
@@ -233,6 +308,7 @@ _invoke_opencode() {
 		else
 			isolated_data_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-worker-auth.XXXXXX")
 		fi
+		_register_headless_runtime_temp_path "$isolated_data_dir"
 		mkdir -p "${isolated_data_dir}/opencode"
 		# Copy the current auth.json so the worker has valid tokens at startup
 		if [[ -f "$OPENCODE_AUTH_FILE" ]]; then
@@ -722,6 +798,17 @@ _execute_run_attempt() {
 
 	# Determine which runtime to use. Default is opencode unless explicitly overridden.
 	local runtime="${headless_runtime:-opencode}"
+	local prompt_arg="$prompt"
+	local prompt_file_arg=""
+	local claude_stdin_file=""
+	_prepare_runtime_prompt_transport "$runtime" "$prompt"
+	prompt_arg="$_HEADLESS_RUN_PROMPT_ARG"
+	prompt_file_arg="$_HEADLESS_RUN_PROMPT_FILE"
+	claude_stdin_file="$_HEADLESS_CLAUDE_STDIN_FILE"
+	if [[ -n "$prompt_file_arg" ]]; then
+		extra_args+=(--file "$prompt_file_arg")
+	fi
+	_HEADLESS_CLAUDE_STDIN_FILE="$claude_stdin_file"
 
 	local provider persisted_session=""
 	provider=$(extract_provider "$selected_model")
@@ -744,13 +831,13 @@ _execute_run_attempt() {
 		fi
 		while IFS= read -r -d '' arg; do
 			cmd+=("$arg")
-		done < <(_build_claude_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
+		done < <(_build_claude_cmd "$selected_model" "$work_dir" "$prompt_arg" "$title" \
 			"$agent_name" "${extra_args[@]+"${extra_args[@]}"}")
 		;;
 	opencode | *)
 		while IFS= read -r -d '' arg; do
 			cmd+=("$arg")
-		done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
+		done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt_arg" "$title" \
 			"$variant_override" "$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
 		;;
 	esac
@@ -890,8 +977,8 @@ _execute_run_attempt() {
 			cmd=()
 			while IFS= read -r -d '' arg; do
 				cmd+=("$arg")
-			done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
-				"$agent_name" "" "${extra_args[@]+"${extra_args[@]}"}")
+			done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt_arg" "$title" \
+				"$variant_override" "$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
 			_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
 			exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
 			if [[ -f "${exit_code_file}.watchdog_killed" ]]; then

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -495,7 +495,11 @@ _build_claude_cmd() {
 	# default-assign below so static analysis does not flag it unused (the
 	# function signature is shared with _build_run_cmd for interchangeability).
 	: "${work_dir:=}"
-	printf '%s\0' "claude" "-p" "$prompt" "--output-format" "stream-json" "--verbose"
+	printf '%s\0' "claude" "-p"
+	if [[ -n "$prompt" ]]; then
+		printf '%s\0' "$prompt"
+	fi
+	printf '%s\0' "--output-format" "stream-json" "--verbose"
 	if [[ -n "$agent_name" ]]; then
 		printf '%s\0' "--agent" "$agent_name"
 	elif type -P claude >/dev/null 2>&1; then

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -247,16 +247,28 @@ _invoke_claude() {
 			local passthrough_csv
 			passthrough_csv="$(build_sandbox_passthrough_csv)"
 			if [[ -n "$passthrough_csv" ]]; then
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				if [[ -n "${_HEADLESS_CLAUDE_STDIN_FILE:-}" && -f "${_HEADLESS_CLAUDE_STDIN_FILE:-}" ]]; then
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
+				else
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				fi
 			else
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				if [[ -n "${_HEADLESS_CLAUDE_STDIN_FILE:-}" && -f "${_HEADLESS_CLAUDE_STDIN_FILE:-}" ]]; then
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
+				else
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				fi
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else
 			if [[ "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" == "1" ]]; then
 				print_info "AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1 — using bare exec (no privilege isolation) (GH#20146 audit)"
 			fi
-			"${cmd[@]}" 2>&1 | tee "$output_file"
+			if [[ -n "${_HEADLESS_CLAUDE_STDIN_FILE:-}" && -f "${_HEADLESS_CLAUDE_STDIN_FILE:-}" ]]; then
+				"${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
+			else
+				"${cmd[@]}" 2>&1 | tee "$output_file"
+			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		fi
 	) || true
@@ -701,6 +713,9 @@ _cmd_run_finish() {
 
 	_update_dispatch_ledger "$session_key" "$ledger_status"
 	_release_session_lock "$session_key"
+	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
+		_cleanup_headless_runtime_temp_paths
+	fi
 	trap - EXIT
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -234,6 +234,122 @@ EOF
 	return 0
 }
 
+test_large_opencode_prompt_uses_file_attachment() {
+	local prompt="large-seed-prompt-with-worker-contract"
+	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
+	HEADLESS_PROMPT_FILE_THRESHOLD_BYTES=8
+
+	_prepare_runtime_prompt_transport "opencode" "$prompt"
+
+	local prompt_arg="$_HEADLESS_RUN_PROMPT_ARG"
+	local prompt_file="$_HEADLESS_RUN_PROMPT_FILE"
+	local cmd_text=""
+	cmd_text=$(
+		while IFS= read -r -d '' arg; do
+			printf '<%s>' "$arg"
+		done < <(_build_run_cmd "anthropic/claude-sonnet-4-6" "$TEST_ROOT" "$prompt_arg" \
+			"Prompt Transport Test" "" "" "" --file "$prompt_file")
+	)
+
+	if [[ "$prompt_arg" != *"$prompt"* ]] &&
+		[[ -f "$prompt_file" ]] &&
+		[[ "$(<"$prompt_file")" == "$prompt" ]] &&
+		[[ "$cmd_text" == *"<--file><${prompt_file}>"* ]] &&
+		[[ "$cmd_text" != *"$prompt"* ]]; then
+		_cleanup_headless_runtime_temp_paths
+		if [[ -n "$old_threshold" ]]; then
+			HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
+		else
+			unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+		fi
+		print_result "large opencode prompts use file attachment instead of argv" 0
+		return 0
+	fi
+
+	_cleanup_headless_runtime_temp_paths
+	if [[ -n "$old_threshold" ]]; then
+		HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
+	else
+		unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+	fi
+	print_result "large opencode prompts use file attachment instead of argv" 1 \
+		"prompt_arg=${prompt_arg} prompt_file=${prompt_file} cmd=${cmd_text}"
+	return 0
+}
+
+test_large_claude_prompt_uses_stdin_file() {
+	local prompt="large-claude-seed-prompt"
+	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
+	HEADLESS_PROMPT_FILE_THRESHOLD_BYTES=8
+
+	_prepare_runtime_prompt_transport "claude" "$prompt"
+
+	local prompt_arg="$_HEADLESS_RUN_PROMPT_ARG"
+	local stdin_file="$_HEADLESS_CLAUDE_STDIN_FILE"
+	local cmd_text=""
+	cmd_text=$(
+		while IFS= read -r -d '' arg; do
+			printf '<%s>' "$arg"
+		done < <(_build_claude_cmd "anthropic/claude-sonnet-4-6" "$TEST_ROOT" "$prompt_arg" \
+			"Prompt Transport Test" "")
+	)
+
+	if [[ -z "$prompt_arg" ]] &&
+		[[ -f "$stdin_file" ]] &&
+		[[ "$(<"$stdin_file")" == "$prompt" ]] &&
+		[[ "$cmd_text" == "<claude><-p>"* ]] &&
+		[[ "$cmd_text" != *"$prompt"* ]]; then
+		_cleanup_headless_runtime_temp_paths
+		if [[ -n "$old_threshold" ]]; then
+			HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
+		else
+			unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+		fi
+		print_result "large claude prompts use stdin file instead of argv" 0
+		return 0
+	fi
+
+	_cleanup_headless_runtime_temp_paths
+	if [[ -n "$old_threshold" ]]; then
+		HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
+	else
+		unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+	fi
+	print_result "large claude prompts use stdin file instead of argv" 1 \
+		"prompt_arg=${prompt_arg} stdin_file=${stdin_file} cmd=${cmd_text}"
+	return 0
+}
+
+test_registered_prompt_temp_cleanup_removes_dir() {
+	local prompt="cleanup-seed-prompt"
+	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
+	HEADLESS_PROMPT_FILE_THRESHOLD_BYTES=1
+
+	_prepare_runtime_prompt_transport "opencode" "$prompt"
+	local prompt_file="$_HEADLESS_RUN_PROMPT_FILE"
+	local prompt_dir="${prompt_file%/*}"
+	_cleanup_headless_runtime_temp_paths
+
+	if [[ -n "$prompt_dir" && ! -e "$prompt_dir" ]]; then
+		if [[ -n "$old_threshold" ]]; then
+			HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
+		else
+			unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+		fi
+		print_result "registered prompt temp cleanup removes prompt dir" 0
+		return 0
+	fi
+
+	if [[ -n "$old_threshold" ]]; then
+		HEADLESS_PROMPT_FILE_THRESHOLD_BYTES="$old_threshold"
+	else
+		unset HEADLESS_PROMPT_FILE_THRESHOLD_BYTES
+	fi
+	print_result "registered prompt temp cleanup removes prompt dir" 1 \
+		"Prompt temp dir still exists: ${prompt_dir:-<empty>}"
+	return 0
+}
+
 # Helper: create a bare git repo and a feature branch with optional commits.
 # Each call uses work_dir-derived remote path to avoid inter-test collisions.
 # Args: $1 = work_dir path, $2 = 1 to add a commit (0 for none)
@@ -647,6 +763,9 @@ main() {
 	test_canary_uses_builtin_agent_without_default_agent
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
+	test_large_opencode_prompt_uses_file_attachment
+	test_large_claude_prompt_uses_stdin_file
+	test_registered_prompt_temp_cleanup_removes_dir
 	# Classification tests (GH#20819 refactor of _worker_produced_output)
 	test_worker_produced_output_no_commits_returns_noop
 	test_worker_produced_output_with_commits_returns_pr_exists_failopen


### PR DESCRIPTION
## Summary

Large headless seed prompts now travel via an attached prompt file for OpenCode or stdin for Claude, keeping full prompt content out of process argv while documenting the runtime-specific command construction path. Runtime temp prompt/auth dirs are registered for cleanup on normal finish and exit-trap paths.

## Files Changed

.agents/scripts/headless-runtime-failure.sh,.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-model.sh,.agents/scripts/headless-runtime-worker.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-worker.sh .agents/scripts/headless-runtime-model.sh .agents/scripts/headless-runtime-failure.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #22290


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 17m and 275,772 tokens on this as a headless worker.