### PR TITLE
GH#22230: enforce task ID boundary in release extraction

### DIFF
--- a/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
+++ b/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
@@ -50,6 +50,7 @@ git init -q -b main
 git config user.email 'test@example.com'
 git config user.name 'Test Runner'
 git config commit.gpgsign false
+git config tag.gpgSign false
 
 printf 'initial\n' >README.md
 git add README.md
@@ -72,6 +73,10 @@ printf 'legacy\n' >>work.txt
 git add work.txt
 git commit -q -m 'complete t123'
 
+printf 'prefix-boundary\n' >>work.txt
+git add work.txt
+git commit -q -m 'chore: at9876 complete should stay ignored'
+
 SCRIPT_DIR="$TEST_SCRIPTS_DIR"
 REPO_ROOT="$REPO_DIR"
 VERSION_FILE="${REPO_DIR}/VERSION"
@@ -86,6 +91,12 @@ if [[ "$actual" != *$'t337\n'* && "$actual" != "t337" ]]; then
 	print_result 'extract_task_ids_from_commits: does not truncate t3375 to t337' 0
 else
 	print_result 'extract_task_ids_from_commits: does not truncate t3375 to t337' 1 "got [$actual]"
+fi
+
+if [[ "$actual" != *"t9876"* ]]; then
+	print_result 'extract_task_ids_from_commits: requires leading boundary before Pattern 4 task ID' 0
+else
+	print_result 'extract_task_ids_from_commits: requires leading boundary before Pattern 4 task ID' 1 "got [$actual]"
 fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -185,8 +185,8 @@ extract_task_ids_from_commits() {
 
 		# Pattern 4: "tXXX complete/done/finished" - task ID before completion word
 		# e.g., "t001 complete", "t002 done"
-		if [[ "$commit" =~ (t[0-9]+(\.[0-9]+)*)[[:space:]]+(complete|done|finished)($|[^[:alnum:]_]) ]]; then
-			task_ids+=("${BASH_REMATCH[1]}")
+		if [[ "$commit" =~ (^|[^[:alnum:]_])(t[0-9]+(\.[0-9]+)*)[[:space:]]+(complete|done|finished)($|[^[:alnum:]_]) ]]; then
+			task_ids+=("${BASH_REMATCH[2]}")
 		fi
 
 	done <<<"$commits"


### PR DESCRIPTION
## Summary

Added a leading boundary to Pattern 4 task ID extraction so prefixed strings like at9876 complete are ignored, and covered it with a regression test.

## Files Changed

.agents/scripts/tests/test-version-manager-task-id-extraction.sh,.agents/scripts/version-manager-git.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager-git.sh .agents/scripts/tests/test-version-manager-ta*.sh; bash .agents/scripts/tests/test-version-manager-ta*.sh

Resolves #22230


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 143,002 tokens on this as a headless worker.