### PR TITLE
GH#22225: remove redundant NMR timestamp jq guard

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -631,7 +631,7 @@ _find_qualifying_pr_for_stale_recovery() {
 		--arg origin_worker "origin:worker" \
 		--arg origin_interactive "origin:interactive" '
 		.[]?
-		| select((.createdAt // $blank) != $blank and (($nmr_at // $blank) != $blank))
+		| select((.createdAt // $blank) != $blank)
 		| select((.createdAt | fromdateiso8601) > ($nmr_at | fromdateiso8601))
 		| select(.reviewDecision == $approved)
 		| select(.authorAssociation == $owner or .authorAssociation == $member)


### PR DESCRIPTION
## Summary

Removed the redundant jq-side nmr_at non-empty check from _find_qualifying_pr_for_stale_recovery because the caller already validates nmr_at before invoking the helper.

## Files Changed

.agents/scripts/pulse-nmr-approval.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-nmr-approval.sh; bash .agents/scripts/tests/test-pulse-nmr-approval.sh

Resolves #22225


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 155,911 tokens on this as a headless worker.