### PR TITLE
GH#22220: route solved label edits through gh timeout wrapper

### DIFF
--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -525,6 +525,6 @@ set_solved_label() {
 	done
 	_flags+=("$@")
 
-	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
+	_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
 	return $?
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -131,6 +131,11 @@ _gh_with_timeout() {
 	write) secs="${AIDEVOPS_GH_WRITE_TIMEOUT:-45}" ;;
 	*) secs=30 ;;
 	esac
+	local cmd="${1:-}"
+	if [[ -n "$cmd" && "$(type -t "$cmd" 2>/dev/null || true)" == "function" ]]; then
+		"$@"
+		return $?
+	fi
 	if command -v timeout >/dev/null 2>&1; then
 		timeout "$secs" "$@"
 		return $?


### PR DESCRIPTION
## Summary

Updated set_solved_label to call gh issue edit through _gh_with_timeout write, and preserved test stubs by bypassing external timeout for shell functions.

## Files Changed

.agents/scripts/shared-gh-wrappers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers.sh; .agents/scripts/tests/test-solved-label-attribution.sh; .agents/scripts/tests/test-shared-gh-wrappers-source.sh; .agents/scripts/tests/test-shared-gh-wrappers-standalone.sh

Resolves #22220


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 381,135 tokens on this as a headless worker.