### PR TITLE
GH#22247: paginate orphan loop comment fetch

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -833,9 +833,13 @@ check_worker_branch_orphan_loop() {
 	[[ "$window_s" =~ ^[0-9]+$ ]] || window_s=7200
 	[[ "$threshold" -gt 0 && "$window_s" -gt 0 ]] || return 1
 
-	local comments_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	# Fetch all comment pages. The issue-comments endpoint is oldest-first and may
+	# hold orphan markers beyond the first 30/100 results on noisy issues. Keep the
+	# POST endpoint separate because --paginate --slurp returns page arrays for jq.
+	local comments_post_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	local comments_endpoint="${comments_post_endpoint}?per_page=100"
 	local comments_json
-	comments_json=$(gh api "$comments_endpoint" 2>/dev/null) || return 1
+	comments_json=$(gh api --paginate --slurp "$comments_endpoint" 2>/dev/null) || return 1
 	[[ -n "$comments_json" ]] || return 1
 
 	local now_epoch
@@ -857,7 +861,7 @@ check_worker_branch_orphan_loop() {
 		fi
 	done < <(printf '%s' "$comments_json" |
 		jq -r --arg branch "$branch_name" '
-			.[]
+			.[][]
 			| (.body // "")
 			| select(contains("WORKER_BRANCH_ORPHAN branch=" + $branch + " "))
 			| (capture("WORKER_BRANCH_ORPHAN branch=[^ ]+ session=[^ ]+ ts=(?<ts>[^\\n ]+)")? // {})
@@ -869,7 +873,7 @@ check_worker_branch_orphan_loop() {
 	local existing_block=""
 	existing_block=$(printf '%s' "$comments_json" |
 		jq -r --arg branch "$branch_name" '
-			[.[] | (.body // "") | select(contains("worker-branch-orphan-loop:blocked branch=" + $branch + " "))] | length
+			[.[][] | (.body // "") | select(contains("worker-branch-orphan-loop:blocked branch=" + $branch + " "))] | length
 		' 2>/dev/null) || existing_block="0"
 	[[ "$existing_block" =~ ^[0-9]+$ ]] || existing_block=0
 
@@ -886,7 +890,7 @@ check_worker_branch_orphan_loop() {
 			"$branch_name" "$issue_number" "$count" "$window_s" \
 			"$count" "$issue_number" "$branch_name" "$window_s" \
 			"$branch_name" "${latest_iso:-unknown}" "$pr_hint" "$repo_slug" "$branch_name")
-		gh api "$comments_endpoint" \
+		gh api "$comments_post_endpoint" \
 			--method POST \
 			--field body="$diag" \
 			>/dev/null 2>&1 || true

--- a/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
+++ b/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
@@ -63,17 +63,23 @@ create_gh_stub() {
 
 	cat >"${TEST_ROOT}/comments-100.json" <<EOF
 [
-  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${old_iso}\n<!-- ops:end -->"},
-  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
-  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
-  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/other session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
-  {"body":"<!-- ops:start -->\nWORKER_NOOP branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"}
+  [
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${old_iso}\n<!-- ops:end -->"},
+    {"body":"<!-- ops:start -->\nWORKER_NOOP branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"}
+  ],
+  [
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/other session=issue-100 ts=${now_iso}\n<!-- ops:end -->"}
+  ]
 ]
 EOF
 
 	cat >"${TEST_ROOT}/comments-200.json" <<EOF
 [
-  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-200 ts=${now_iso}\n<!-- ops:end -->"}
+  [
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-200 ts=${now_iso}\n<!-- ops:end -->"}
+  ]
 ]
 EOF
 
@@ -81,8 +87,15 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${1:-}" == "api" && "${2:-}" =~ /issues/([0-9]+)/comments ]]; then
-	issue="${BASH_REMATCH[1]}"
+if [[ "${1:-}" == "api" ]]; then
+	issue=""
+	for arg in "$@"; do
+		if [[ "$arg" =~ /issues/([0-9]+)/comments ]]; then
+			issue="${BASH_REMATCH[1]}"
+			break
+		fi
+	done
+	[[ -n "$issue" ]] || exit 1
 	if [[ " $* " == *" --method POST "* ]]; then
 		printf '%s\n' "$*" >>"${TEST_ROOT}/posts/${issue}.argv"
 		exit 0
@@ -91,7 +104,7 @@ if [[ "${1:-}" == "api" && "${2:-}" =~ /issues/([0-9]+)/comments ]]; then
 	if [[ -f "$comments_file" ]]; then
 		cat "$comments_file"
 	else
-		printf '[]\n'
+		printf '[[]]\n'
 	fi
 	exit 0
 fi


### PR DESCRIPTION
## Summary

Updated worker_branch_orphan loop detection to fetch all issue comment pages with gh api --paginate --slurp and parse slurped page arrays; extended the regression test to model paginated comments.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-worker-branch-orphan-loop.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-worker-branch-orphan-loop.sh; .agents/scripts/tests/test-worker-branch-orphan-loop.sh

Resolves #22247


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 8m and 97,573 tokens on this as a headless worker.