### PR TITLE
GH#22224: restore agents backups atomically

### DIFF
--- a/.agents/scripts/tests/test-deploy-mutex.sh
+++ b/.agents/scripts/tests/test-deploy-mutex.sh
@@ -177,10 +177,38 @@ test_failed_deploy_verification_restores_backup() {
 	return 0
 }
 
+test_agents_backup_restore_preserves_live_tree_on_stage_failure() {
+	local test_name="backup restore preserves live agents when staging copy fails"
+	local target="${TEST_ROOT}/restore-preserve/.aidevops/agents"
+	local backup="${TEST_ROOT}/restore-preserve/.aidevops/agents-backups/20260501_130000/agents"
+	local rc=0
+	mkdir -p "$(dirname "$backup")"
+	_make_agent_tree "$target" 2
+	_make_agent_tree "$backup" 120
+
+	if ! declare -f _restore_latest_agents_backup >/dev/null; then
+		# shellcheck source=/dev/null
+		source "$AGENT_DEPLOY"
+	fi
+
+	(
+		cp() { return 1; }
+		HOME="${TEST_ROOT}/restore-preserve" _restore_latest_agents_backup "$target"
+	) || rc=$?
+
+	if [[ "$rc" -ne 0 && -f "$target/file-2.md" && ! -f "$target/file-120.md" ]]; then
+		print_result "$test_name" 0
+	else
+		print_result "$test_name" 1 "rc=$rc live_file=$([[ -f "$target/file-2.md" ]] && printf yes || printf no) backup_file=$([[ -f "$target/file-120.md" ]] && printf yes || printf no)"
+	fi
+	return 0
+}
+
 main() {
 	setup
 	test_noninteractive_setup_lock_single_owner
 	test_failed_deploy_verification_restores_backup
+	test_agents_backup_restore_preserves_live_tree_on_stage_failure
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -355,6 +355,9 @@ _restore_latest_agents_backup() {
 	local target_dir="$1"
 	local backup_base="$HOME/.aidevops/agents-backups"
 	local latest_backup=""
+	local parent_dir=""
+	local restore_staging=""
+	local old_dir=""
 
 	if [[ ! -d "$backup_base" ]]; then
 		print_warning "No agents backup directory found for restore: $backup_base"
@@ -368,14 +371,44 @@ _restore_latest_agents_backup() {
 	fi
 
 	print_warning "Restoring agents from latest backup: $latest_backup"
-	rm -rf "$target_dir"
-	mkdir -p "$(dirname "$target_dir")"
-	if cp -a "$latest_backup" "$target_dir"; then
+	parent_dir=$(dirname "$target_dir")
+	mkdir -p "$parent_dir"
+	restore_staging=$(mktemp -d "${target_dir}.restore.XXXXXX") || {
+		print_error "Failed to create agents restore staging directory"
+		return 1
+	}
+	old_dir="${target_dir}.restore-old.$$"
+	rm -rf "$old_dir"
+
+	if ! cp -a "$latest_backup/." "$restore_staging/"; then
+		print_error "Failed to stage agents backup for restore: $latest_backup"
+		rm -rf "$restore_staging"
+		return 1
+	fi
+
+	if [[ -d "$target_dir" ]]; then
+		if ! mv "$target_dir" "$old_dir"; then
+			print_error "Failed to move current agents directory aside during restore — agents directory preserved"
+			rm -rf "$restore_staging"
+			return 1
+		fi
+	fi
+
+	if mv "$restore_staging" "$target_dir"; then
+		rm -rf "$old_dir"
 		print_success "Restored agents directory from backup"
 		return 0
 	fi
 
-	print_error "Failed to restore agents directory from backup: $latest_backup"
+	print_error "Failed to move staged agents backup into place — attempting restore rollback"
+	if [[ -d "$old_dir" ]]; then
+		if mv "$old_dir" "$target_dir"; then
+			print_info "Restore rollback successful — previous agents directory restored"
+		else
+			print_error "Restore rollback failed — previous agents directory preserved in $old_dir"
+		fi
+	fi
+	rm -rf "$restore_staging"
 	return 1
 }
 


### PR DESCRIPTION
## Summary
- Restore agents backups through a staged copy and atomic same-filesystem swap.
- Preserve the current live agents tree if staging the backup copy fails, and roll back if the final swap fails.
- Add regression coverage for failed restore staging preserving the live tree.

## Verification
- `shellcheck setup-modules/agent-deploy.sh .agents/scripts/tests/test-deploy-mutex.sh`
- `.agents/scripts/tests/test-deploy-mutex.sh`

Resolves #22224

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 9m and 88,436 tokens on this as a headless worker.
