### PR TITLE
GH#22299: document seeded draft PR workflow

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -704,7 +704,7 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 - **Worker-ready issue body heuristic (t2417):** Before creating a full brief, `/define`, `/new-task`, and `task-brief-helper.sh` check whether the linked issue body is already worker-ready — i.e., it contains 4+ of the 7 known heading signals (`## Task`, `## Why`, `## How`, `## Acceptance`, `## What`, `## Session Origin`, `## Files to modify`). When the issue body is worker-ready, the brief file is either skipped (headless default) or replaced with a stub that links to the issue as the canonical brief. This prevents brief/issue body duplication and the collision surface it creates (see GH#20015). Helper: `scripts/brief-readiness-helper.sh`. Threshold override: `BRIEF_READINESS_THRESHOLD` env var.
 
-**Brief composition**: All GitHub-written content (issue bodies, PR descriptions, comments, escalation reports) follows `workflows/brief.md` — the centralised formatting workflow.
+**Brief composition**: All GitHub-written content (issue bodies, briefs, PR descriptions, comments, escalation reports, worker guidance) follows `workflows/brief.md` — the centralised formatting workflow. Load it before publishing; optional seeded draft PRs are governed there, not in this root guide.
 
 **Model tiers and dispatchability**: Use GitHub `tier:*` labels; default to `tier:standard` when uncertain. Before recommending a tier or queueing work, run `task-dispatchability-helper.sh check --task-id tNNN [--issue N]`. Full tier rules live in `reference/task-taxonomy.md`; `tier-simple-body-shape-helper.sh` still enforces high-confidence simple-tier downgrades pre-dispatch.
 

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -18,6 +18,7 @@ mode: subagent
 - [ ] Discovery pass: `<N>` commits / `<N>` merged PRs / `<N>` open PRs touch target files in last 48h
 - [ ] File refs verified: `<N>` refs checked, all present at HEAD
 - [ ] Tier: `<tier>` — disqualifier check clean (`<1-line rationale>`)
+- [ ] Seeded draft PR decision recorded: `<created draft PR #N | skipped — rationale>`
 
 ## Origin
 
@@ -54,7 +55,7 @@ Answer each question for `tier:simple`. If **any** answer is "no", use `tier:sta
 - [ ] **No cross-package or cross-module changes?** (no `packages/a/` + `packages/b/`, no changes spanning unrelated subsystems)
 - [ ] **Estimate 1h or less?**
 - [ ] **4 or fewer acceptance criteria?**
-- [ ] **Dispatch-path classification (t2821):** Does the `### Files Scope` or `## How` section reference any file in `.agents/configs/self-hosting-files.conf` (pulse-wrapper.sh, pulse-dispatch-*, headless-runtime-helper.sh, etc.)? If yes, use `#parent` + `no-auto-dispatch` + `#interactive` instead of `#auto-dispatch`. Override with `#dispatch-path-ok` if auto-dispatch is intentional.
+- [ ] **Dispatch-path classification (t2821/t2920):** Does the `### Files Scope` or `## How` section reference any file in `.agents/configs/self-hosting-files.conf` (pulse-wrapper.sh, pulse-dispatch-*, headless-runtime-helper.sh, etc.)? If yes, keep the normal `#auto-dispatch` default; the pre-dispatch detector auto-elevates to `model:opus-4-7`. Opt out only with `#no-auto-dispatch #interactive` when intentionally implementing interactively.
 
 All checked = `tier:simple`. Any unchecked = `tier:standard` (default) or `tier:thinking` (no existing pattern to follow).
 
@@ -115,8 +116,23 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
 {If this task is for a `parent-task`-labeled issue, confirm: PR body will use `For #NNN`, not `Resolves`.}
 {If leaf task: use `Resolves #NNN` as normal — delete this section or leave it blank.}
 
+## Seeded Draft PR
+
+<!-- Optional seeded draft PR record, governed by workflows/brief.md "Seeded Draft PR Decision".
+     Use only when current-session discovery produced high-confidence implementation
+     context and the seed will reduce duplicate exploration without anchoring the
+     next worker to stale or unverified assumptions. Draft means not merge-ready. -->
+
+- **Decision:** Created draft PR `{#N}` | Skipped
+- **Rationale:** {Why this is safe and useful, or why issue-only is better}
+- **Status:** `draft` | `blocked` | `unverified` | `not-created`
+- **Freshness evidence:** {memory/discovery/file verification performed against current HEAD}
+- **Verification run:** {commands and results, or `UNVERIFIED — not run`}
+- **Stale-assumption warning:** {What changed code, failed checks, or design uncertainty would make the seed wrong}
+
 ## Phases
 
+<!-- markdownlint-disable MD046 -->
 <!-- For `parent-task`-labeled issues only. Delete this section for leaf tasks.
 
      The sequential phase auto-file mechanism (t2740) is ON by default since t2787.
@@ -127,17 +143,17 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
 
      **List format (preferred — auto-fire works out of the box):**
 
-       - Phase 1 - description [auto-fire:on-prior-merge]
-       - Phase 2 - description [auto-fire:on-prior-merge]
-       - Phase 3 - description
+     - Phase 1 - description [auto-fire:on-prior-merge]
+     - Phase 2 - description [auto-fire:on-prior-merge]
+     - Phase 3 - description
 
      **Narrative bold-heading format (for prose-style decomposition plans):**
 
-       **Phase 1 — description [auto-fire:on-prior-merge]**
-       Detailed implementation notes...
+     **Phase 1 — description [auto-fire:on-prior-merge]**
+     Detailed implementation notes...
 
-       **Phase 2 — description**
-       Detailed implementation notes...
+     **Phase 2 — description**
+     Detailed implementation notes...
 
      Available markers:
      - `[auto-fire:on-prior-merge]` — file this phase when the prior phase PR merges (recommended)
@@ -154,7 +170,8 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
      without it, children appear in the parent body but the GitHub UI does not
      show them as sub-issues. The pulse also runs a periodic backfill
      (`AIDEVOPS_PARENT_BACKFILL_INTERVAL_SECS`, default 3600s) so any
-     missed links are reconciled within an hour. -->
+      missed links are reconciled within an hour. -->
+<!-- markdownlint-enable MD046 -->
 
 {Delete this section for leaf tasks. For parent tasks, list phases here.}
 
@@ -324,19 +341,24 @@ Each criterion may include an optional `verify:` block (YAML in a fenced code bl
 that defines how to machine-check the criterion. See `.agents/scripts/verify-brief.sh` for the runner.
 
 - [ ] {Specific, testable criterion — e.g., "User can toggle sidebar with Cmd+B"}
+
   ```yaml
   verify:
     method: bash
     run: "{shell command — pass if exit 0}"
   ```
+
 - [ ] {Another criterion — e.g., "Conversation history persists across page reloads"}
+
   ```yaml
   verify:
     method: codebase
     pattern: "{regex pattern to search for}"
     path: "{directory or file to search in}"
   ```
+
 - [ ] {Negative criterion — e.g., "Org A's data never appears in Org B's context"}
+
   ```yaml
   verify:
     method: codebase
@@ -344,22 +366,28 @@ that defines how to machine-check the criterion. See `.agents/scripts/verify-bri
     path: "{search scope}"
     expect: absent
   ```
+
 - [ ] {Criterion requiring AI review}
+
   ```yaml
   verify:
     method: subagent
     prompt: "{review prompt for AI to evaluate}"
     files: "{optional: files to include as context}"
   ```
+
 - [ ] {Criterion requiring human review}
+
   ```yaml
   verify:
     method: manual
     prompt: "{what the human should check}"
   ```
+
 - [ ] Tests pass (`npm test` / `bun test` / project-specific)
 - [ ] Lint clean (`eslint` / `shellcheck` / project-specific)
 - [ ] Qlty smells resolved (for `#simplification` tasks): `~/.qlty/bin/qlty smells --all 2>&1 | grep '<target_file>' | grep -c . | grep -q '^0$'`
+
   ```yaml
   verify:
     method: bash

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -86,6 +86,38 @@ The wrapper currently self-assigns in violation of t2157. Until t2406/GH#19991 m
 
 **The brief IS the product.** A vague brief dispatched to Opus wastes more money than a prescriptive brief dispatched to Haiku. Invest the effort in the brief, not the worker.
 
+## Seeded Draft PR Decision
+
+When an issue or brief is created after enough discovery to know the likely implementation path, the author MAY open a seeded draft PR that gives the worker verified implementation context. This is opt-in. Issue-only remains the default when confidence is not high.
+
+### Seed only when ALL criteria hold
+
+- **Fresh discovery:** memory recall, duplicate/in-flight discovery, and file-ref verification were completed in this session against current `HEAD`.
+- **Verified files:** every seeded change references existing files and line ranges checked immediately before composing the PR; new-file paths have verified parent directories.
+- **High-confidence pattern:** the implementation follows an existing pattern or exact skeleton already captured in the brief.
+- **Honest verification state:** any tests, lint, or build commands already run are named with results; unrun checks are explicitly marked unverified.
+- **Draft safety:** the PR is opened as a draft, linked to the issue/brief, and clearly says it is a seed for continuation, not merge-ready work.
+
+### Do NOT seed when any caution applies
+
+- The target code is moving quickly or discovery found recent related commits/PRs that need reassessment.
+- The likely implementation depends on design judgment, credentials, production state, or a human decision.
+- The seed would anchor the worker to an untested hypothesis instead of evidence.
+- The author cannot describe how to verify the seeded approach.
+- The PR would be easy to mistake for ready-to-merge work.
+
+### Required seeded PR content
+
+Seeded draft PR bodies must mentor the next worker with:
+
+- Issue link using `For #NNN` while the PR is draft-only; switch to the normal closing keyword only when the PR becomes the final implementation PR.
+- Files and line ranges already verified.
+- What was implemented or only sketched.
+- Verification already run, plus explicit `UNVERIFIED` items.
+- Stale-assumption warning: what would make the seed wrong and what to re-check before continuing.
+
+Record the decision in `templates/brief-template.md` under **Seeded Draft PR** whether a seed was created or intentionally skipped.
+
 ## Tier Classification
 
 Assess every work item against these empirical criteria (from 47-PR research):

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -97,6 +97,15 @@ Fill in the `### Complexity Impact` subsection in the brief (see `templates/brie
 
 **Subtasks:** MUST reference parent: `**Parent task:** {parent_id} — see [todo/tasks/{parent_id}-brief.md]`. Inherit context; add only subtask-specific details.
 
+### Step 3.2: Decide Whether to Seed a Draft PR
+
+After the brief is worker-ready, consider an optional implementation-seeded draft PR using `workflows/brief.md` "Seeded Draft PR Decision". Do not make this the default.
+
+- Seed only when current-session discovery produced high-confidence file paths, line ranges, and implementation patterns verified against current `HEAD`.
+- Keep issue-only when the implementation is uncertain, depends on design judgment, or would anchor workers to stale assumptions.
+- If seeded, create the PR as draft, link it back to the issue/brief, mark unrun checks as `UNVERIFIED`, and record the draft PR number/status in the brief's **Seeded Draft PR** section.
+- If skipped, record the rationale in the same section so later workers know whether the absence of a seed was intentional.
+
 ### Step 3.5: Classify and Decompose (t1408.2)
 
 Run `task-decompose-helper.sh classify "{title}"` if available. Skip with `--no-decompose` or if helper missing (t1408.1).
@@ -110,7 +119,7 @@ If the task is tagged `#parent`, add a `## Phases` section to the issue body (an
 
 **Canonical list format (preferred):**
 
-```
+```markdown
 - Phase 1 - description [auto-fire:on-prior-merge]
 - Phase 2 - description [auto-fire:on-prior-merge]
 - Phase 3 - description
@@ -118,7 +127,7 @@ If the task is tagged `#parent`, add a `## Phases` section to the issue body (an
 
 **Narrative bold-heading format:**
 
-```
+```markdown
 **Phase 1 — description [auto-fire:on-prior-merge]**
 Implementation notes...
 ```


### PR DESCRIPTION
## Summary
- Added brief workflow guidance for optional seeded draft PRs, including seed/no-seed criteria, verification expectations, and stale-assumption cautions.
- Updated the brief template to record seeded draft PR decisions and corrected dispatch-path checklist language for the t2920 auto-dispatch default.
- Added `/new-task` documentation for deciding whether to seed a draft PR without making it the default.

## Testing
- `npx --yes markdownlint-cli2 .agents/AGENTS.md .agents/workflows/brief.md .agents/templates/brief-template.md .agents/scripts/commands/new-task.md`
- `rg -n "seeded draft PR|implementation seeded|dispatch-path" .agents/AGENTS.md .agents/workflows/brief.md .agents/templates/brief-template.md .agents/scripts/commands/new-task.md`

Resolves #22299


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 9m and 165,089 tokens on this as a headless worker.