### PR TITLE
t3462: Fix BSD awk syntax in efficiency speed collection

### DIFF
--- a/.agents/scripts/orchestration-efficiency-collector.sh
+++ b/.agents/scripts/orchestration-efficiency-collector.sh
@@ -304,7 +304,14 @@ collect_speed() {
 	if [[ -f "$PULSE_LOG" ]]; then
 		local preflight_times
 		preflight_times=$(grep -a "preflight.*duration\|preflight.*seconds\|preflight.*elapsed" "$PULSE_LOG" 2>/dev/null |
-			awk -v date="$date" '$0 ~ date { match($0, /([0-9]+(\.[0-9]+)?)s/, t); if (t[1] != "") print t[1] }' |
+			awk -v date="$date" '$0 ~ date {
+				line = $0
+				while (match(line, /[0-9][0-9.]*s/)) {
+					value = substr(line, RSTART, RLENGTH - 1)
+					if (value ~ /^[0-9]+([.][0-9]+)?$/) print value
+					line = substr(line, RSTART + RLENGTH)
+				}
+			}' |
 			sort -n)
 		if [[ -n "$preflight_times" ]]; then
 			local pf_count


### PR DESCRIPTION
## Summary

Replaced the speed collector preflight-duration awk capture-array regex with a portable RSTART/RLENGTH extraction loop so BSD awk no longer emits syntax errors.

## Files Changed

.agents/scripts/orchestration-efficiency-collector.sh,.task-counter,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/orchestration-efficiency-collector.sh; bash .agents/scripts/orchestration-efficiency-collector.sh --date 2026-05-02 --output /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/efficiency-test-22339.json >/var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/efficiency-test-22339.out 2>/var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/efficiency-test-22339.err; jq . /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/efficiency-test-22339.json; confirmed stderr has no awk syntax errors

Resolves #22339


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31