### PR TITLE
GH#22284: define data-plane registry and routing map

### DIFF
--- a/.agents/aidevops/campaigns-plane.md
+++ b/.agents/aidevops/campaigns-plane.md
@@ -6,6 +6,11 @@ The `_campaigns/` plane is a peer-level user-data plane for marketing/advertisin
 work. It houses brand assets, competitive intel, inspiration swipe files, in-flight
 campaign creative, and post-launch performance + learnings. It is opt-in per repo.
 
+For cross-plane routing metadata, use `.agents/configs/data-planes.json` as the
+canonical registry. This document owns the `_campaigns/` directory contract; the
+registry owns shared facts such as default sensitivity, ingress/egress, helper,
+and retrieval surfaces.
+
 ## Why a Separate Plane
 
 Marketing/campaign work has a distinct shape from other planes:
@@ -210,6 +215,9 @@ layout to any collaborator or AI agent encountering the directory for the first 
 It is the user-facing equivalent of this framework doc.
 
 ## Cross-Plane Connections
+
+The canonical cross-plane registry is `.agents/configs/data-planes.json`; the
+table below is the campaign-specific operational view.
 
 | Direction | Connection |
 |-----------|-----------|

--- a/.agents/aidevops/cases-plane.md
+++ b/.agents/aidevops/cases-plane.md
@@ -4,6 +4,11 @@
 
 The cases plane (`_cases/`) is an audit-trail-driven matter management system for legal, compliance, dispute, and operational case work. Each case is a directory with a structured dossier, a chronological timeline, pointers to attached knowledge sources, and sub-files for notes, communications, and drafts.
 
+For cross-plane routing metadata, use `.agents/configs/data-planes.json` as the
+canonical registry. This document owns the `_cases/` directory contract; the
+registry owns shared facts such as default sensitivity, ingress/egress, helper,
+and retrieval surfaces.
+
 ## Directory Contract
 
 ```

--- a/.agents/aidevops/knowledge-plane.md
+++ b/.agents/aidevops/knowledge-plane.md
@@ -4,6 +4,11 @@ The knowledge plane is an opt-in file staging area for AI-assisted ingestion of
 external documents, data exports, and reference material into aidevops-managed
 repos. Each repo can independently enable or disable the plane.
 
+For cross-plane routing metadata, use `.agents/configs/data-planes.json` as the
+canonical registry. This document owns the `_knowledge/` directory contract; the
+registry owns shared facts such as default sensitivity, ingress/egress, helper,
+and retrieval surfaces.
+
 ## Modes (`repos.json` field: `knowledge`)
 
 | Value | Description |

--- a/.agents/configs/data-planes.json
+++ b/.agents/configs/data-planes.json
@@ -1,0 +1,111 @@
+{
+  "version": 1,
+  "description": "Canonical aidevops registry for underscore-prefixed data planes and cross-plane routing surfaces.",
+  "planes": {
+    "_knowledge": {
+      "purpose": "Curated source material, references, extracted facts, and reusable knowledge for AI-assisted retrieval.",
+      "lifecycle_state": "source-captured -> staged -> promoted -> indexed -> enriched",
+      "helper": ".agents/scripts/knowledge-helper.sh",
+      "versioning_policy": {
+        "versioned_paths": ["sources/", "collections/", "_config/"],
+        "gitignored_paths": ["inbox/", "staging/", "index/"],
+        "large_blob_policy": "Files at or above the blob threshold are stored under ~/.aidevops/.agent-workspace/knowledge-blobs/ with metadata in git."
+      },
+      "sensitivity_default": "internal",
+      "ingress": ["_inbox routed general references", "knowledge-helper add", "campaign learnings promotion", "case source attachments by reference"],
+      "egress": ["retrieval for agents", "case sources.toon attachments", "campaign RAG grounding", "document enrichment outputs"],
+      "index_retrieval_surface": ["_knowledge/index/", "knowledge-helper list", "knowledge-helper search", "document-enrich-helper extracted fields"],
+      "routing_notes": "Use for durable reference material after sensitivity classification and promotion."
+    },
+    "_cases": {
+      "purpose": "Audit-trail-driven matter management for legal, compliance, dispute, and operational case work.",
+      "lifecycle_state": "open -> hold -> closed -> archived",
+      "helper": ".agents/scripts/case-helper.sh",
+      "versioning_policy": {
+        "versioned_paths": ["case-*/dossier.toon", "case-*/timeline.jsonl", "case-*/sources.toon", "case-*/notes/", "case-*/comms/", "archived/"],
+        "gitignored_paths": ["case-*/drafts/"],
+        "large_blob_policy": "Large evidence stays in _knowledge/blob storage and cases attach source pointers rather than duplicating content."
+      },
+      "sensitivity_default": "privileged",
+      "ingress": ["_inbox routed case-specific files", "case-helper open", "case-helper attach from _knowledge/sources", "case comm logs"],
+      "egress": ["case alarms", "case chasers", "case timeline audit", "knowledge source references"],
+      "index_retrieval_surface": ["case-helper list", "case-helper show", "case dossier fields", "case timeline events"],
+      "routing_notes": "Use for matter-specific work where chronology, parties, deadlines, or privileged handling matter."
+    },
+    "_inbox": {
+      "purpose": "Transit zone for unclassified captures before sensitivity detection, triage, and routing to durable planes.",
+      "lifecycle_state": "captured -> pending -> routed|needs-review -> superseded",
+      "helper": ".agents/scripts/inbox-helper.sh",
+      "versioning_policy": {
+        "versioned_paths": ["README.md", ".gitignore", "triage.log", "triage-examples.jsonl"],
+        "gitignored_paths": ["_drop/", "email/", "web/", "scan/", "voice/", "import/", "_needs-review/"],
+        "large_blob_policy": "Captured binaries remain gitignored until routed or manually promoted."
+      },
+      "sensitivity_default": "unverified",
+      "ingress": ["inbox-helper add", "inbox-helper add --url", "watch-folder drops", "workspace inbox captures"],
+      "egress": ["_knowledge", "_cases", "_campaigns", "_projects", "_feedback", "_needs-review"],
+      "index_retrieval_surface": ["_inbox/triage.log", "_inbox/triage-examples.jsonl", "inbox-helper find", "inbox-helper status", "inbox-helper digest"],
+      "routing_notes": "Never treat as authoritative; classify sensitivity before cloud routing."
+    },
+    "_campaigns": {
+      "purpose": "Marketing, advertising, outreach, brand assets, campaign creative, and post-launch learnings.",
+      "lifecycle_state": "concept -> research -> creative -> review -> distribution -> measure -> learn",
+      "helper": ".agents/scripts/campaigns-provision-helper.sh",
+      "versioning_policy": {
+        "versioned_paths": ["lib/", "launched/", "_config/"],
+        "gitignored_paths": ["intel/", "active/", "index/"],
+        "large_blob_policy": "Campaign assets at or above the blob threshold use the knowledge-blobs store with manifest references."
+      },
+      "sensitivity_default": "internal",
+      "ingress": ["_inbox routed campaign captures", "campaign-helper new", "campaign asset add", "_feedback audience insight import"],
+      "egress": ["_knowledge/insights/marketing", "_performance/marketing", "launched campaign audit trail"],
+      "index_retrieval_surface": ["campaign-helper list", "campaign-helper status", "asset manifest", "channel specs"],
+      "routing_notes": "Use for campaign-shaped work; competitive intel remains local-only."
+    },
+    "_projects": {
+      "purpose": "Project artefacts, plans, deliverables, and execution context that are not generic framework TODOs.",
+      "lifecycle_state": "idea -> scoped -> active -> shipped -> archived",
+      "helper": "agent-managed; no single helper yet",
+      "versioning_policy": {
+        "versioned_paths": ["plans/", "deliverables/", "archive/", "README.md"],
+        "gitignored_paths": ["scratch/", "tmp/", "drafts/"],
+        "large_blob_policy": "Store large binaries in the agent workspace or a project-specific blob store and keep manifests in git."
+      },
+      "sensitivity_default": "internal",
+      "ingress": ["_inbox routed project artefacts", "agent-created project plans", "user-provided project files"],
+      "egress": ["implementation tasks", "project-specific knowledge promotion", "deliverable handoff"],
+      "index_retrieval_surface": ["project README/contracts", "agent search over versioned project files"],
+      "routing_notes": "Use for bounded project execution context when another specialised plane is not a better fit."
+    },
+    "_performance": {
+      "purpose": "Metrics, analytics snapshots, experiment results, and operational performance evidence.",
+      "lifecycle_state": "captured -> normalised -> analysed -> reported -> archived",
+      "helper": "agent-managed; no single helper yet",
+      "versioning_policy": {
+        "versioned_paths": ["reports/", "summaries/", "_config/"],
+        "gitignored_paths": ["raw/", "exports/", "index/"],
+        "large_blob_policy": "Raw exports stay gitignored or external; derived summaries and reports are versioned."
+      },
+      "sensitivity_default": "internal",
+      "ingress": ["campaign results promotion", "analytics exports", "operational measurement routines"],
+      "egress": ["campaign learnings", "decision reports", "knowledge insights"],
+      "index_retrieval_surface": ["performance reports", "agent search over summaries", "future metrics indexes"],
+      "routing_notes": "Use for measured outcomes, not unverified anecdotes."
+    },
+    "_feedback": {
+      "purpose": "User feedback, survey responses, review extracts, pain points, and qualitative signals.",
+      "lifecycle_state": "captured -> classified -> clustered -> actioned -> archived",
+      "helper": "agent-managed; no single helper yet",
+      "versioning_policy": {
+        "versioned_paths": ["summaries/", "clusters/", "_config/"],
+        "gitignored_paths": ["raw/", "pii/", "index/"],
+        "large_blob_policy": "Raw feedback exports remain gitignored; redacted summaries may be versioned."
+      },
+      "sensitivity_default": "pii",
+      "ingress": ["_inbox routed feedback", "survey exports", "support review imports", "campaign feedback command"],
+      "egress": ["_campaigns active research", "_projects backlog inputs", "_knowledge insights"],
+      "index_retrieval_surface": ["feedback clusters", "redacted summaries", "future feedback indexes"],
+      "routing_notes": "Treat raw feedback as potentially personal data until redacted or classified."
+    }
+  }
+}

--- a/.agents/scripts/inbox-helper.sh
+++ b/.agents/scripts/inbox-helper.sh
@@ -59,6 +59,7 @@ readonly WORKSPACE_INBOX_DIR="${HOME}/.aidevops/.agent-workspace/inbox"
 
 # Path to the README template
 readonly README_TEMPLATE="${SCRIPT_DIR}/../templates/inbox-readme.md"
+readonly DATA_PLANES_REGISTRY="${SCRIPT_DIR}/../configs/data-planes.json"
 
 # Triage log JSON field names and status values — defined as constants to
 # avoid repeated string literals triggering the pre-commit ratchet gate.
@@ -1041,6 +1042,11 @@ _triage_run_classification() {
 	prompt_file="$(mktemp "${TMPDIR:-/tmp}/aidevops-inbox-prompt.XXXXXX")"
 	{
 		printf 'Classify this _inbox item into the correct aidevops plane. Return JSON with target_plane, sub_folder, confidence, and reasoning.\n\n'
+		if [[ -f "$DATA_PLANES_REGISTRY" ]] && command -v jq >/dev/null 2>&1; then
+			printf 'Canonical data-plane registry excerpt (JSON):\n'
+			jq -c '{planes: .planes | with_entries({key, value: {purpose: .value.purpose, helper: .value.helper, sensitivity_default: .value.sensitivity_default, ingress: .value.ingress, egress: .value.egress, index_retrieval_surface: .value.index_retrieval_surface, routing_notes: .value.routing_notes}})}' "$DATA_PLANES_REGISTRY" 2>/dev/null || true
+			printf '\n'
+		fi
 		if [[ -n "$examples" ]]; then
 			printf 'Prior human-approved correction examples (JSONL, append-only audit facts):\n%s\n' "$examples"
 		fi
@@ -1503,11 +1509,13 @@ Sub-folder routing:
   _drop/   Everything else (or drag-drop target for watch folder)
 
 Triage routing (when dependencies available):
+  Canonical plane registry: .agents/configs/data-planes.json
   _needs-review/  Low-confidence or unknown-sensitivity items
   _knowledge/     General reference material
   _cases/         Case/matter specific files
   _campaigns/     Marketing and campaign material
   _projects/      Project artefacts
+  _performance/   Metrics, analytics snapshots, and experiment results
   _feedback/      Feedback and surveys
 
 Audit log:

--- a/.agents/scripts/tests/test-data-planes-registry.sh
+++ b/.agents/scripts/tests/test-data-planes-registry.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+REGISTRY="$REPO_ROOT/.agents/configs/data-planes.json"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		if [[ -n "$message" ]]; then
+			printf '  %s\n' "$message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+validate_registry() {
+	local registry_path="$1"
+
+	python3 - "$registry_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry = json.loads(Path(sys.argv[1]).read_text())
+required_planes = {"_knowledge", "_cases", "_inbox", "_campaigns", "_projects", "_performance", "_feedback"}
+required_fields = {
+    "purpose",
+    "helper",
+    "versioning_policy",
+    "sensitivity_default",
+    "ingress",
+    "egress",
+    "index_retrieval_surface",
+}
+required_versioning_fields = {"versioned_paths", "gitignored_paths"}
+allowed_sensitivity = {"public", "internal", "pii", "sensitive", "privileged", "unverified"}
+errors = []
+
+planes = registry.get("planes", {})
+missing_planes = required_planes - set(planes)
+if missing_planes:
+    errors.append("missing planes: " + ", ".join(sorted(missing_planes)))
+
+for plane_name, plane in sorted(planes.items()):
+    if not plane_name.startswith("_"):
+        errors.append(f"plane name must start with underscore: {plane_name}")
+    for field in required_fields:
+        if field not in plane or plane[field] in ("", [], {}):
+            errors.append(f"{plane_name} missing {field}")
+    sensitivity = plane.get("sensitivity_default")
+    if sensitivity and sensitivity not in allowed_sensitivity:
+        errors.append(f"{plane_name} invalid sensitivity_default: {sensitivity}")
+    versioning = plane.get("versioning_policy", {})
+    for field in required_versioning_fields:
+        if field not in versioning or not isinstance(versioning[field], list):
+            errors.append(f"{plane_name} versioning_policy missing list {field}")
+    for list_field in ("ingress", "egress", "index_retrieval_surface"):
+        if list_field in plane and not isinstance(plane[list_field], list):
+            errors.append(f"{plane_name} {list_field} must be a list")
+
+if errors:
+    print("\n".join(errors))
+    sys.exit(1)
+PY
+	return $?
+}
+
+test_registry_json_valid() {
+	if jq . "$REGISTRY" >/dev/null; then
+		print_result "data planes registry is valid JSON" 0
+	else
+		print_result "data planes registry is valid JSON" 1 "jq failed for $REGISTRY"
+	fi
+	return 0
+}
+
+test_registry_contract_valid() {
+	if validate_registry "$REGISTRY"; then
+		print_result "data planes registry declares required fields" 0
+	else
+		print_result "data planes registry declares required fields" 1 "Registry contract validation failed"
+	fi
+	return 0
+}
+
+test_missing_required_field_fails() {
+	local tmp_registry
+	tmp_registry="$(mktemp)"
+	python3 - "$REGISTRY" "$tmp_registry" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry = json.loads(Path(sys.argv[1]).read_text())
+del registry["planes"]["_knowledge"]["helper"]
+Path(sys.argv[2]).write_text(json.dumps(registry))
+PY
+
+	if validate_registry "$tmp_registry" >/dev/null 2>&1; then
+		print_result "missing required registry field fails validation" 1 "Validator accepted missing helper field"
+	else
+		print_result "missing required registry field fails validation" 0
+	fi
+	rm -f "$tmp_registry"
+	return 0
+}
+
+main() {
+	printf 'Running data planes registry tests\n'
+	test_registry_json_valid
+	test_registry_contract_valid
+	test_missing_required_field_fails
+	printf 'Results: %s/%s passed, %s failed\n' "$TESTS_PASSED" "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added a canonical .agents/configs/data-planes.json registry for underscore planes, wired inbox triage prompts/help to the registry, and referenced it from plane docs.

## Files Changed

.agents/aidevops/campaigns-plane.md,.agents/aidevops/cases-plane.md,.agents/aidevops/knowledge-plane.md,.agents/configs/data-planes.json,.agents/scripts/inbox-helper.sh,.agents/scripts/tests/test-data-planes-registry.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** jq . .agents/configs/data-planes.json; bash .agents/scripts/tests/test-data-planes-registry.sh; shellcheck .agents/scripts/inbox-helper.sh .agents/scripts/tests/test-data-planes-registry.sh

Resolves #22284


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 214,972 tokens on this as a headless worker.