### PR TITLE
t3475: Fix worker activity future timestamp examples

### DIFF
--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -89,6 +89,7 @@ NOW=$(date +%s)
 T_5MIN_AGO=$((NOW - 300))
 T_2H_AGO=$((NOW - 7200))
 T_25H_AGO=$((NOW - 90000))
+T_FUTURE_SENTINEL=4102444800
 
 # Build metrics fixture covering every bucket and the regression cases that
 # the original awk implementation handled correctly:
@@ -102,6 +103,9 @@ T_25H_AGO=$((NOW - 90000))
 #                      is the t3215 of-bucket regression case. The bucket is
 #                      result-name-based fallthrough, NOT exit-code-based —
 #                      this record must count as wc, NOT as of.
+#   issue-9          — synthetic future sentinel timestamp (year 2100); must
+#                      be excluded from bounded-window metrics and examples.
+#   issue-10         — missing timestamp; must not appear in bounded windows.
 {
 	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
@@ -111,6 +115,8 @@ T_25H_AGO=$((NOW - 90000))
 	printf '{"ts":%d,"role":"worker","session_key":"issue-6","result":"unknown_failure","exit_code":2}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-7","result":"success","exit_code":0}\n' "$T_25H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-8","result":"watchdog_stall_continue","exit_code":124}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-9","result":"success","exit_code":0}\n' "$T_FUTURE_SENTINEL"
+	printf '{"role":"worker","session_key":"issue-10","result":"success","exit_code":0}\n'
 } >"$METRICS"
 
 # Build pulse-stats fixture: counter arrays with timestamps inside and outside window.
@@ -196,6 +202,10 @@ assert_eq "2h3: timing summary includes samples" "7" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
 assert_eq "2h4: recent example carries load context" "2.0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
+assert_eq "2h5: future sentinel excluded from examples" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-9")] | length')"
+assert_eq "2h6: missing timestamp excluded from examples" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-10")] | length')"
 
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \
@@ -220,13 +230,16 @@ echo
 echo "--- Section 3: 1h window ---"
 
 JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 1h --no-pr-check --json 2>&1)
-# 1h window: only events at 5min ago (issue-1, issue-4) qualify.
+# 1h window: only events at 5min ago (issue-1, issue-4) qualify; future
+# sentinel and missing-ts rows are invalid worker evidence.
 assert_eq "3a: 1h total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
 assert_eq "3b: 1h succeeded = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "3c: 1h watchdog_continued = 1" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
 assert_eq "3d: 1h watchdog_killed = 0" "0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
+assert_eq "3e: 1h recent examples exclude future sentinel" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-9")] | length')"
 
 # ---------------------------------------------------------------------------
 # Section 4: missing files fail-open to zeros.

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -75,11 +75,13 @@ _wah_parse_since() {
 _wah_aggregate_metrics() {
 	local cutoff_epoch="$1"
 	local metrics="$WAH_METRICS_FILE"
+	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
 		printf '0 0 0 0 0 0\n'
 		return 0
 	fi
+	now_epoch=$(date +%s)
 
 	# Bucket semantics (must match the original awk fallthrough chain):
 	#   succ — result=="success" AND exit_code==0
@@ -92,8 +94,8 @@ _wah_aggregate_metrics() {
 	#          is nonzero)
 	# Fail-open to zeros if jq fails (stale/corrupt jsonl).
 	local result
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" '
-		[inputs | select((.ts // 0) >= $cutoff)] as $w | {
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
+		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w | {
 			total:  ($w | length),
 			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
 			wk:     ([$w[] | select(.result == "watchdog_stall_killed")] | length),
@@ -122,14 +124,16 @@ _wah_aggregate_metrics() {
 _wah_metric_details_json() {
 	local cutoff_epoch="$1"
 	local metrics="$WAH_METRICS_FILE"
+	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
 		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[]}'
 		return 0
 	fi
+	now_epoch=$(date +%s)
 
-	jq -rn --argjson cutoff "$cutoff_epoch" '
-		[inputs | select((.ts // 0) >= $cutoff)] as $w
+	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
+		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 		| ($w | map(.duration_ms // 0)) as $durations
 		| {
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),


### PR DESCRIPTION
## Summary

Filtered worker metric aggregation and recent example selection to ignore missing/future timestamps so year-2100 sentinel rows cannot be reported as current evidence; added fixture coverage for future sentinel and missing timestamp rows.

## Files Changed

.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worker-activity-helper.sh .agents/scripts/tests/test-worker-activity-helper.sh; .agents/scripts/tests/test-worker-activity-helper.sh; PATH="$PWD/.agents/scripts:$PATH" worker-activity-helper.sh summary --since 1h --json --no-pr-check --repo marcusquinn/aidevops

Resolves #22370


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 2m and 125,196 tokens on this as a headless worker.