### PR TITLE
t3429: Support core-style layout in private agent source repos

### DIFF
--- a/.agents/aidevops/agent-sources.md
+++ b/.agents/aidevops/agent-sources.md
@@ -48,7 +48,50 @@ aidevops sources remove my-private-agents                     # Remove source, k
 - Slash command conflicts append the source slug, for example `/run-pipeline-my-private-agents`.
 - Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning.
 
-## Layout
+## Layouts
+
+Use the **core-style layout** for new private agent source repos. It mirrors the
+public framework: root primary agents own strategy, matching directories hold
+optional extended context, and shared capabilities live under cross-domain
+directories. Use the older **package-style layout** only for small legacy packs
+where each agent is intentionally self-contained under one folder.
+
+### Core-style source repo (recommended)
+
+```text
+# Private repo
+my-private-agents/.agents/
+├── client-ops.md             # mode: primary
+├── client-ops/               # extended context for client-ops
+│   └── reporting.md          # mode: subagent
+├── tools/                    # reusable capabilities for any private agent
+│   └── data-cleanup.md
+├── services/
+│   └── private-crm.md
+├── workflows/
+│   └── monthly-report.md
+├── reference/
+│   └── account-boundaries.md
+└── scripts/commands/
+    └── client-report.md      # agent: → /client-report
+
+# After sync
+~/.aidevops/agents/
+├── client-ops.md → custom/my-private-agents/client-ops.md
+└── custom/my-private-agents/
+    ├── client-ops.md
+    ├── client-ops/
+    ├── tools/
+    ├── services/
+    ├── workflows/
+    ├── reference/
+    └── scripts/commands/client-report.md
+
+~/.config/opencode/command/
+└── client-report.md → symlink
+```
+
+### Package-style source repo (legacy-compatible)
 
 ```text
 # Private repo
@@ -73,6 +116,11 @@ my-private-agents/.agents/my-agent/
 ├── run-pipeline.md → symlink
 └── check-status.md → symlink
 ```
+
+Both layouts may coexist in one source repo. `aidevops sources sync` preserves
+the full `.agents/` tree under `custom/<source-name>/`, symlinks `mode: primary`
+docs from either root `.agents/<agent>.md` or package `.agents/<agent>/<agent>.md`,
+and deploys slash commands from package folders or `scripts/commands/`.
 
 ## Repo Checklist
 

--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -12,8 +12,9 @@
 #   agent-sources-helper.sh status            Show sync status for all sources
 #   agent-sources-helper.sh help              Show this help
 #
-# Private agent repos contain a .agents/ directory with agent folders.
-# Each agent folder is synced into ~/.aidevops/agents/custom/<source-name>/<agent>/
+# Private agent repos contain a .agents/ directory using either package-style
+# .agents/<agent>/ folders or the core-style .agents/<agent>.md + .agents/<agent>/
+# layout. The full tree is synced into ~/.aidevops/agents/custom/<source-name>/.
 
 set -euo pipefail
 
@@ -66,8 +67,9 @@ show_help() {
 	echo "                                            OpenCode runtime dirs (self-heal)"
 	echo "  agent-sources-helper.sh help              Show this help"
 	echo ""
-	echo "Private repos must contain a .agents/ directory with agent folders."
-	echo "Agents are synced into ~/.aidevops/agents/custom/<source-name>/<agent>/"
+	echo "Private repos must contain a .agents/ directory."
+	echo "Supported layouts: package-style .agents/<agent>/ or core-style .agents/<agent>.md + .agents/<agent>/"
+	echo "The full .agents tree is synced into ~/.aidevops/agents/custom/<source-name>/"
 	return 0
 }
 
@@ -429,11 +431,28 @@ cleanup_source_symlinks() {
 
 	[[ -d "${source_dir}" ]] || return 0
 
-	# Remove primary agent symlinks from agents root
+	# Remove package-style primary agent symlinks from agents root
 	for agent_dir in "${source_dir}"/*/; do
 		[[ -d "${agent_dir}" ]] || continue
 		local agent_name
 		agent_name="$(basename "${agent_dir}")"
+		local link="${AGENTS_DIR}/${agent_name}.md"
+		if [[ -L "${link}" ]]; then
+			local target
+			target="$(readlink "${link}")"
+			if [[ "${target}" == *"${name}"* ]]; then
+				rm -f "${link}"
+				info "  Removed primary agent symlink: ${agent_name}"
+			fi
+		fi
+	done
+
+	# Remove core-style root primary agent symlinks from agents root
+	for agent_md in "${source_dir}"/*.md; do
+		[[ -f "${agent_md}" ]] || continue
+		local agent_name
+		agent_name="$(basename "${agent_md}" .md)"
+		[[ "${agent_name}" == "AGENTS" || "${agent_name}" == "README" || "${agent_name}" == "SKILL" ]] && continue
 		local link="${AGENTS_DIR}/${agent_name}.md"
 		if [[ -L "${link}" ]]; then
 			local target
@@ -460,6 +479,35 @@ cleanup_source_symlinks() {
 			fi
 		done
 	fi
+	return 0
+}
+
+# Count likely agent entries in a source .agents/ tree for status output.
+# Package-style directories and core-style root .md files both count.
+count_source_agent_entries() {
+	local source_agents_dir="$1"
+	local agent_count=0
+	local entry entry_name
+
+	for entry in "${source_agents_dir}"/*/; do
+		[[ -d "${entry}" ]] || continue
+		entry_name="$(basename "${entry}")"
+		case "${entry_name}" in
+		tools|services|workflows|reference|scripts|configs|templates|rules|tests|bundles|custom|draft)
+			continue
+			;;
+		esac
+		agent_count=$((agent_count + 1))
+	done
+
+	for entry in "${source_agents_dir}"/*.md; do
+		[[ -f "${entry}" ]] || continue
+		entry_name="$(basename "${entry}" .md)"
+		[[ "${entry_name}" == "AGENTS" || "${entry_name}" == "README" || "${entry_name}" == "SKILL" ]] && continue
+		agent_count=$((agent_count + 1))
+	done
+
+	printf '%s\n' "${agent_count}"
 	return 0
 }
 
@@ -533,21 +581,13 @@ cmd_status() {
 			echo -e "    Status:      ${RED}INVALID${NC} (no .agents/ directory)"
 		else
 			local agent_count=0
-			for agent_dir in "${path}/.agents"/*/; do
-				if [[ -d "${agent_dir}" ]]; then
-					agent_count=$((agent_count + 1))
-				fi
-			done
+			agent_count="$(count_source_agent_entries "${path}/.agents")"
 			echo -e "    Status:      ${GREEN}OK${NC} (${agent_count} agents)"
 
 			# Check if synced copy exists
 			if [[ -d "${CUSTOM_DIR}/${name}" ]]; then
 				local synced_count=0
-				for synced_dir in "${CUSTOM_DIR}/${name}"/*/; do
-					if [[ -d "${synced_dir}" ]]; then
-						synced_count=$((synced_count + 1))
-					fi
-				done
+				synced_count="$(count_source_agent_entries "${CUSTOM_DIR}/${name}")"
 				echo "    Deployed:    ${synced_count} agents in custom/${name}/"
 			else
 				echo -e "    Deployed:    ${YELLOW}NOT SYNCED${NC}"
@@ -614,30 +654,35 @@ cmd_sync() {
 			(cd "${path}" && git pull --ff-only 2>/dev/null) || warn "  Git pull failed, using current state"
 		fi
 
-		# Sync each agent directory from source .agents/ into custom/<source-name>/
+		# Sync the full source .agents/ tree into custom/<source-name>/ so
+		# private repos can use either package-style .agents/<agent>/ folders or
+		# the core-style .agents/<agent>.md + shared tools/services/workflows tree.
 		local dest_dir="${CUSTOM_DIR}/${name}"
 		mkdir -p "${dest_dir}"
 
+		# Safety: skip empty source trees to prevent --delete wiping destination.
+		if [[ -z "$(find "${path}/.agents" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+			warn "  Skipping empty .agents tree"
+			((++i))
+			continue
+		fi
+
+		rsync -a --delete "${path}/.agents/" "${dest_dir}/"
+
 		local agent_count=0
-		for agent_dir in "${path}/.agents"/*/; do
+		agent_count="$(count_source_agent_entries "${dest_dir}")"
+
+		# Post-sync: register core-style root primary agents, package-style primary
+		# agents, package-local commands, and shared scripts/commands.
+		sync_root_primary_agents "${dest_dir}"
+		local agent_dir agent_name
+		for agent_dir in "${dest_dir}"/*/; do
 			[[ -d "${agent_dir}" ]] || continue
-			local agent_name
 			agent_name="$(basename "${agent_dir}")"
-
-			# Safety: skip empty source dirs to prevent --delete wiping destination
-			if [[ -z "$(find "${agent_dir}" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
-				warn "  Skipping empty agent directory: ${agent_name}"
-				continue
-			fi
-
-			# rsync the agent directory (preserves permissions, handles deletions)
-			rsync -a --delete "${agent_dir}" "${dest_dir}/${agent_name}/"
-			((++agent_count))
-
-			# Post-sync: register primary agents and deploy slash commands
-			sync_primary_agent "${dest_dir}/${agent_name}" "${agent_name}"
-			sync_slash_commands "${dest_dir}/${agent_name}" "${agent_name}" "${name}"
+			sync_primary_agent "${agent_dir}" "${agent_name}"
+			sync_slash_commands "${agent_dir}" "${agent_name}" "${name}"
 		done
+		sync_shared_slash_commands "${dest_dir}/scripts/commands" "${name}"
 
 		update_last_synced "${name}" "${agent_count}"
 		success "  Synced ${agent_count} agent(s) to custom/${name}/"
@@ -690,6 +735,20 @@ sync_primary_agent() {
 	return 0
 }
 
+# Register all root-level core-style primary agents from a synced source tree.
+sync_root_primary_agents() {
+	local source_dir="$1"
+	local agent_md agent_name
+
+	for agent_md in "${source_dir}"/*.md; do
+		[[ -f "${agent_md}" ]] || continue
+		agent_name="$(basename "${agent_md}" .md)"
+		[[ "${agent_name}" == "AGENTS" || "${agent_name}" == "README" || "${agent_name}" == "SKILL" ]] && continue
+		sync_primary_agent "${source_dir}" "${agent_name}"
+	done
+	return 0
+}
+
 # Deploy slash commands from an agent directory to OpenCode command dir
 # Slash commands are .md files with 'agent:' in frontmatter (not the agent doc itself, not subagents)
 sync_slash_commands() {
@@ -724,6 +783,35 @@ sync_slash_commands() {
 		fi
 
 		# Symlink rather than copy — stays in sync without re-running
+		ln -sf "${md_file}" "${target}"
+		((++total_commands))
+	done
+	return 0
+}
+
+# Deploy slash commands from a shared scripts/commands directory.
+sync_shared_slash_commands() {
+	local commands_dir="$1"
+	local source_name="$2"
+	local opencode_cmd_dir="${HOME}/.config/opencode/command"
+
+	[[ -d "${commands_dir}" ]] || return 0
+	mkdir -p "${opencode_cmd_dir}"
+
+	local md_file filename cmd_name target suffixed_name
+	for md_file in "${commands_dir}"/*.md; do
+		[[ -f "${md_file}" ]] || continue
+		if ! sed -n '/^---$/,/^---$/p' "${md_file}" 2>/dev/null | grep -q '^agent:'; then
+			continue
+		fi
+		filename="$(basename "${md_file}")"
+		cmd_name="${filename%.md}"
+		target="${opencode_cmd_dir}/${cmd_name}.md"
+		if [[ -f "${target}" ]] && ! [[ -L "${target}" && "$(readlink "${target}")" == "${md_file}" ]]; then
+			suffixed_name="${cmd_name}-${source_name}"
+			target="${opencode_cmd_dir}/${suffixed_name}.md"
+			warn "  Command collision: /${cmd_name} exists, deploying as /${suffixed_name}"
+		fi
 		ln -sf "${md_file}" "${target}"
 		((++total_commands))
 	done

--- a/.agents/scripts/tests/test-agent-sources-core-layout.sh
+++ b/.agents/scripts/tests/test-agent-sources-core-layout.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#22274: private agent-source repos can use the same
+# core-style .agents layout as the shared framework.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+TEST_HOME=""
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_HOME=$(mktemp -d)
+	trap teardown EXIT
+
+	local agents_dir="$TEST_HOME/.aidevops/agents"
+	local source_dir="$TEST_HOME/private-core/.agents"
+	mkdir -p "$agents_dir/scripts" "$agents_dir/configs" "$source_dir/client-ops" \
+		"$source_dir/tools" "$source_dir/services" "$source_dir/workflows" \
+		"$source_dir/reference" "$source_dir/scripts/commands"
+	cp "$REPO_ROOT/.agents/scripts/agent-sources-helper.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT/.agents/scripts/subagent-index-helper.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT/.agents/scripts/portable-stat.sh" "$agents_dir/scripts/"
+	cp "$REPO_ROOT"/.agents/scripts/shared-*.sh "$agents_dir/scripts/"
+	chmod +x "$agents_dir/scripts/agent-sources-helper.sh" "$agents_dir/scripts/subagent-index-helper.sh"
+
+	cat >"$agents_dir/configs/agent-sources.json" <<JSON
+{
+  "version": "1.0.0",
+  "sources": [
+    {
+      "name": "private-core",
+      "local_path": "$TEST_HOME/private-core",
+      "remote_url": "",
+      "last_synced": ""
+    }
+  ]
+}
+JSON
+
+	cat >"$source_dir/client-ops.md" <<'EOF_AGENT'
+---
+mode: primary
+---
+# Client Ops
+EOF_AGENT
+
+	cat >"$source_dir/client-ops/reporting.md" <<'EOF_SUBAGENT'
+---
+mode: subagent
+---
+# Reporting
+EOF_SUBAGENT
+
+	cat >"$source_dir/tools/data-cleanup.md" <<'EOF_TOOL'
+# Data Cleanup
+EOF_TOOL
+	cat >"$source_dir/services/private-crm.md" <<'EOF_SERVICE'
+# Private CRM
+EOF_SERVICE
+	cat >"$source_dir/workflows/monthly-report.md" <<'EOF_WORKFLOW'
+# Monthly Report
+EOF_WORKFLOW
+	cat >"$source_dir/reference/account-boundaries.md" <<'EOF_REFERENCE'
+# Account Boundaries
+EOF_REFERENCE
+	cat >"$source_dir/scripts/commands/client-report.md" <<'EOF_COMMAND'
+---
+agent: Client Ops
+---
+# Client Report
+EOF_COMMAND
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_HOME" && -d "$TEST_HOME" ]]; then
+		rm -rf "$TEST_HOME"
+	fi
+	return 0
+}
+
+assert_path() {
+	local test_name="$1"
+	local path="$2"
+	if [[ -e "$path" ]]; then
+		print_result "$test_name" 0
+	else
+		print_result "$test_name" 1 "missing $path"
+	fi
+	return 0
+}
+
+test_sync_preserves_core_layout() {
+	local output=""
+	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/agent-sources-helper.sh" sync 2>&1)
+	local status=$?
+	if [[ "$status" -ne 0 ]]; then
+		print_result "sync core layout" 1 "$output"
+		return 0
+	fi
+
+	local dest="$TEST_HOME/.aidevops/agents/custom/private-core"
+	assert_path "root primary agent synced" "$dest/client-ops.md"
+	assert_path "matching agent directory synced" "$dest/client-ops/reporting.md"
+	assert_path "tools directory synced" "$dest/tools/data-cleanup.md"
+	assert_path "services directory synced" "$dest/services/private-crm.md"
+	assert_path "workflows directory synced" "$dest/workflows/monthly-report.md"
+	assert_path "reference directory synced" "$dest/reference/account-boundaries.md"
+
+	local primary_link="$TEST_HOME/.aidevops/agents/client-ops.md"
+	if [[ -L "$primary_link" && "$(readlink "$primary_link")" == "$dest/client-ops.md" ]]; then
+		print_result "root primary agent registered" 0
+	else
+		print_result "root primary agent registered" 1 "bad link $primary_link"
+	fi
+
+	local command_link="$TEST_HOME/.config/opencode/command/client-report.md"
+	if [[ -L "$command_link" && "$(readlink "$command_link")" == "$dest/scripts/commands/client-report.md" ]]; then
+		print_result "shared slash command registered" 0
+	else
+		print_result "shared slash command registered" 1 "bad link $command_link"
+	fi
+	return 0
+}
+
+test_index_discovers_core_layout() {
+	local output=""
+	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" generate 2>&1)
+	local status=$?
+	if [[ "$status" -ne 0 ]]; then
+		print_result "generate subagent index" 1 "$output"
+		return 0
+	fi
+
+	local index_file="$TEST_HOME/.aidevops/agents/subagent-index.toon"
+	if grep -q '^custom/private-core/,custom/private-core subagents,client-ops$' "$index_file" && \
+		grep -q '^custom/private-core/tools/,custom/private-core/tools subagents,data-cleanup$' "$index_file" && \
+		grep -q '^custom/private-core/workflows/,custom/private-core/workflows subagents,monthly-report$' "$index_file"; then
+		print_result "index includes core-style source tree" 0
+	else
+		print_result "index includes core-style source tree" 1 "expected custom/private-core rows missing"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	test_sync_preserves_core_layout
+	test_index_discovers_core_layout
+
+	echo ""
+	echo "Tests run: $TESTS_RUN"
+	echo "Passed: $TESTS_PASSED"
+	echo "Failed: $TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/templates/agent-source-repo/AGENTS.md
+++ b/.agents/templates/agent-source-repo/AGENTS.md
@@ -66,6 +66,6 @@ Prefer flat files and prefix-based names. Add subdirectories only when a prefix 
 
 ## Sync Contract
 
-Register this repo with `aidevops sources add <path>` for private-agent sync. Mark it in `~/.config/aidevops/repos.json` with `"agent_source": true` or `"role": "agent-source"` so `aidevops init` and `aidevops update` can seed and refresh the framework-owned organization guidance.
+Register this repo with `aidevops sources add <path>` for private-agent sync. Mark it in `~/.config/aidevops/repos.json` with `"agent_source": true` or `"role": "agent-source"` so `aidevops init` and `aidevops update` can seed and refresh the framework-owned organization guidance. Sync preserves the full `.agents/` tree under `~/.aidevops/agents/custom/<source-name>/`, symlinks root `mode: primary` agents into `~/.aidevops/agents/`, and deploys slash commands from `.agents/scripts/commands/`.
 
 <!-- aidevops:agent-source-template:end -->


### PR DESCRIPTION
## Summary

Private agent-source sync now preserves full core-style .agents trees, registers root primary agents, deploys shared scripts/commands slash commands, and documents recommended source layouts.

## Files Changed

.agents/aidevops/agent-sources.md,.agents/scripts/agent-sources-helper.sh,.agents/scripts/tests/test-agent-sources-core-layout.sh,.agents/templates/agent-source-repo/AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-agent-sources-core-layout.sh; shellcheck .agents/scripts/agent-sources-helper.sh .agents/scripts/tests/test-agent-sources-core-layout.sh; .agents/scripts/subagent-index-helper.sh generate && .agents/scripts/subagent-index-helper.sh check

Resolves #22274


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 11m and 319,906 tokens on this as a headless worker.