### PR TITLE
t3467: Make memory audit opportunities actionable

### DIFF
--- a/.agents/reference/memory.md
+++ b/.agents/reference/memory.md
@@ -117,7 +117,9 @@ Graduate validated local memories (`confidence = "high"` OR `access_count >= 3`)
 
 ## Memory Audit Pulse
 
-Phase 9 of supervisor pulse cycle (self-throttled to once per 24h). Phases: Dedup → Prune → Graduate → Consolidate → Scan → Report. Commands: `memory-audit-pulse.sh run [--force|--dry-run]`, `memory-audit-pulse.sh status`.
+Phase 9 of supervisor pulse cycle (self-throttled to once per 24h). Phases: Dedup → Prune → Graduate → Consolidate → Scan → File opportunities → Report. Commands: `memory-audit-pulse.sh run [--force|--dry-run]`, `memory-audit-pulse.sh status`.
+
+The opportunity scan is actionable in live mode: repeated failures, popular low-confidence memories, untagged-memory debt, superseded-memory cleanup, high growth, and session-metadata noise are converted into worker-ready tasks through `claim-task-id.sh`. Dry-run is report-only and records `would-file` actions without creating issues. Duplicate suppression uses source-detail fingerprints in `~/.aidevops/.agent-workspace/work/memory-audit/opportunity-state.tsv`, so the same opportunity is not filed every 24h. Inspect `last-opportunity-details.txt`, `last-opportunity-actions.txt`, `opportunity-state.tsv`, and `audit-*.txt` in that directory to see what was found, filed, skipped, or failed.
 
 ## Memory Consolidation
 

--- a/.agents/scripts/memory-audit-pulse.sh
+++ b/.agents/scripts/memory-audit-pulse.sh
@@ -37,9 +37,12 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly MEMORY_DIR="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memory}"
 readonly MEMORY_DB="$MEMORY_DIR/memory.db"
-readonly AUDIT_LOG_DIR="$HOME/.aidevops/.agent-workspace/work/memory-audit"
+readonly AUDIT_LOG_DIR="${AIDEVOPS_MEMORY_AUDIT_LOG_DIR:-$HOME/.aidevops/.agent-workspace/work/memory-audit}"
 readonly AUDIT_MARKER="$MEMORY_DIR/.last_audit_pulse"
 readonly AUDIT_INTERVAL_HOURS=24
+readonly OPPORTUNITY_STATE_FILE="$AUDIT_LOG_DIR/opportunity-state.tsv"
+readonly OPPORTUNITY_DETAILS_FILE="$AUDIT_LOG_DIR/last-opportunity-details.txt"
+readonly OPPORTUNITY_ACTIONS_FILE="$AUDIT_LOG_DIR/last-opportunity-actions.txt"
 
 # Minimum interval between audit pulses (prevents redundant runs)
 readonly AUDIT_INTERVAL_SECONDS=$((AUDIT_INTERVAL_HOURS * 3600))
@@ -689,11 +692,173 @@ EOF
 }
 
 #######################################
+# Calculate a stable fingerprint for an opportunity detail.
+#######################################
+_opportunity_fingerprint() {
+	local detail="$1"
+	local fingerprint=""
+
+	if command -v shasum >/dev/null 2>&1; then
+		fingerprint=$(printf '%s' "$detail" | shasum -a 256)
+		fingerprint="${fingerprint%% *}"
+	elif command -v sha256sum >/dev/null 2>&1; then
+		fingerprint=$(printf '%s' "$detail" | sha256sum)
+		fingerprint="${fingerprint%% *}"
+	else
+		fingerprint=$(printf '%s' "$detail" | cksum)
+		fingerprint="cksum-${fingerprint%% *}"
+	fi
+
+	printf '%s\n' "$fingerprint"
+	return 0
+}
+
+#######################################
+# Check whether an opportunity fingerprint has already filed work.
+#######################################
+_opportunity_state_has() {
+	local fingerprint="$1"
+
+	[[ -f "$OPPORTUNITY_STATE_FILE" ]] || return 1
+	grep -Fq "${fingerprint}"$'\t' "$OPPORTUNITY_STATE_FILE"
+	return $?
+}
+
+#######################################
+# Record that an opportunity fingerprint has filed work.
+#######################################
+_opportunity_state_record() {
+	local fingerprint="$1"
+	local task_ref="$2"
+	local detail="$3"
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	mkdir -p "$AUDIT_LOG_DIR"
+	printf '%s\t%s\t%s\t%s\n' "$fingerprint" "$timestamp" "$task_ref" "$detail" >>"$OPPORTUNITY_STATE_FILE"
+	return 0
+}
+
+#######################################
+# Build a concise title from an opportunity detail.
+#######################################
+_opportunity_task_title() {
+	local detail="$1"
+	local clean
+	clean="${detail#  - }"
+	clean="${clean#- }"
+	clean="${clean%% (*}"
+	clean="${clean:0:90}"
+
+	printf 'Memory audit: %s\n' "$clean"
+	return 0
+}
+
+#######################################
+# Build a worker-ready issue body for an opportunity.
+#######################################
+_opportunity_task_body() {
+	local detail="$1"
+	local fingerprint="$2"
+
+	cat <<EOF
+## Task
+Investigate and fix this memory audit self-improvement opportunity:
+
+> ${detail}
+
+## Why
+memory-audit-pulse.sh detected this pattern during Phase 5. Filing it as work keeps the self-improvement loop actionable instead of leaving it in report-only audit logs.
+
+## Files to modify
+- EDIT: .agents/scripts/memory-audit-pulse.sh — source detector and fingerprint: ${fingerprint}
+- EDIT: the framework file implicated by the queried memories or detector category
+- EDIT: .agents/reference/memory.md if the fix changes the memory audit contract
+- ADD/EDIT: .agents/scripts/tests/ — cover the implemented fix or detector refinement
+
+## Reference pattern
+Use the Phase 5 detector output and inspect the matching memory rows in the local memory DB. Prefer a focused code/doc/test fix over broad cleanup. If the premise is stale or already fixed, close with a premise-falsified rationale.
+
+## Verification
+- Run the focused test added for this fix.
+- Run shellcheck on any edited shell scripts.
+- Run memory-audit-pulse.sh run --dry-run --force and confirm the same opportunity is either resolved or remains intentionally tracked.
+
+## Source fingerprint
+${fingerprint}
+EOF
+	return 0
+}
+
+#######################################
+# File or preview tasks for opportunity details.
+#######################################
+_opportunities_action_details() {
+	local dry_run="$1"
+	local quiet="$2"
+	local opportunity_details="$3"
+	local task_cmd="${AIDEVOPS_MEMORY_AUDIT_TASK_CMD:-claim-task-id.sh}"
+
+	mkdir -p "$AUDIT_LOG_DIR"
+	: >"$OPPORTUNITY_ACTIONS_FILE"
+
+	local detail
+	while IFS= read -r detail; do
+		[[ -n "$detail" ]] || continue
+
+		local fingerprint
+		fingerprint=$(_opportunity_fingerprint "$detail")
+
+		if _opportunity_state_has "$fingerprint"; then
+			printf 'skipped-duplicate\t%s\t%s\n' "$fingerprint" "$detail" >>"$OPPORTUNITY_ACTIONS_FILE"
+			continue
+		fi
+
+		local title
+		title=$(_opportunity_task_title "$detail")
+
+		if [[ "$dry_run" == "true" ]]; then
+			printf 'would-file\t%s\t%s\n' "$fingerprint" "$title" >>"$OPPORTUNITY_ACTIONS_FILE"
+			[[ "$quiet" != "true" ]] && log_info "Opportunity dry-run: would file task for $fingerprint"
+			continue
+		fi
+
+		if ! command -v "$task_cmd" >/dev/null 2>&1 && [[ ! -x "$task_cmd" ]]; then
+			printf 'not-filed\t%s\ttask command unavailable: %s\n' "$fingerprint" "$task_cmd" >>"$OPPORTUNITY_ACTIONS_FILE"
+			[[ "$quiet" != "true" ]] && log_warn "Opportunity filing unavailable: $task_cmd"
+			continue
+		fi
+
+		local body output status task_ref
+		body=$(_opportunity_task_body "$detail" "$fingerprint")
+		status=0
+		output=$("$task_cmd" \
+			--title "$title" \
+			--description "$body" \
+			--labels "auto-dispatch,tier:standard,self-improvement" 2>&1) || status=$?
+
+		if [[ "$status" -ne 0 ]]; then
+			printf 'file-failed\t%s\t%s\n' "$fingerprint" "$output" >>"$OPPORTUNITY_ACTIONS_FILE"
+			[[ "$quiet" != "true" ]] && log_warn "Opportunity filing failed for $fingerprint"
+			continue
+		fi
+
+		task_ref="${output//$'\n'/ }"
+		_opportunity_state_record "$fingerprint" "$task_ref" "$detail"
+		printf 'filed\t%s\t%s\n' "$fingerprint" "$task_ref" >>"$OPPORTUNITY_ACTIONS_FILE"
+		[[ "$quiet" != "true" ]] && log_success "Opportunity filed: $task_ref"
+	done <<<"$opportunity_details"
+
+	return 0
+}
+
+#######################################
 # Phase 5: Opportunity scan
 # Identifies patterns that suggest self-improvement opportunities
 #######################################
 phase_opportunities() {
 	local quiet="$1"
+	local dry_run="${2:-false}"
 
 	[[ "$quiet" != "true" ]] && log_info "Phase 5: Scanning for improvement opportunities..."
 
@@ -701,6 +866,10 @@ phase_opportunities() {
 		echo "0"
 		return 0
 	fi
+
+	mkdir -p "$AUDIT_LOG_DIR"
+	: >"$OPPORTUNITY_DETAILS_FILE"
+	: >"$OPPORTUNITY_ACTIONS_FILE"
 
 	local opportunities=0
 	local opportunity_details=""
@@ -728,6 +897,11 @@ phase_opportunities() {
 			log_success "No improvement opportunities found"
 		fi
 	}
+
+	printf '%s' "$opportunity_details" >"$OPPORTUNITY_DETAILS_FILE"
+	if [[ "$opportunities" -gt 0 ]]; then
+		_opportunities_action_details "$dry_run" "$quiet" "$opportunity_details"
+	fi
 
 	echo "$opportunities"
 	return 0
@@ -774,6 +948,22 @@ phase_report() {
 	report+="  Memories graduated: $graduate_count"$'\n'
 	report+="  Consolidations generated: $consolidate_count"$'\n'
 	report+="  Opportunities found: $opportunity_count"$'\n'
+	if [[ -s "$OPPORTUNITY_DETAILS_FILE" ]]; then
+		report+=$'\n'
+		report+="Opportunity details:"$'\n'
+		while IFS= read -r detail_line; do
+			[[ -n "$detail_line" ]] || continue
+			report+="${detail_line}"$'\n'
+		done <"$OPPORTUNITY_DETAILS_FILE"
+	fi
+	if [[ -s "$OPPORTUNITY_ACTIONS_FILE" ]]; then
+		report+=$'\n'
+		report+="Opportunity filing actions:"$'\n'
+		while IFS= read -r action_line; do
+			[[ -n "$action_line" ]] || continue
+			report+="  ${action_line}"$'\n'
+		done <"$OPPORTUNITY_ACTIONS_FILE"
+	fi
 	report+=$'\n'
 	report+="Database:"$'\n'
 	report+="  Total memories: $total_memories"$'\n'
@@ -842,7 +1032,7 @@ cmd_run() {
 	prune_count=$(phase_prune "$dry_run" "$quiet")
 	graduate_count=$(phase_graduate "$dry_run" "$quiet")
 	consolidate_count=$(phase_consolidate "$dry_run" "$quiet")
-	opportunity_count=$(phase_opportunities "$quiet")
+	opportunity_count=$(phase_opportunities "$quiet" "$dry_run")
 
 	# Generate report
 	phase_report "$dedup_count" "$prune_count" "$graduate_count" "$consolidate_count" "$opportunity_count" "$dry_run" "$quiet"

--- a/.agents/scripts/tests/test-memory-audit-opportunities-actionable.sh
+++ b/.agents/scripts/tests/test-memory-audit-opportunities-actionable.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export AIDEVOPS_MEMORY_DIR="$TEST_DIR/memory"
+export AIDEVOPS_MEMORY_AUDIT_LOG_DIR="$TEST_DIR/audit"
+mkdir -p "$AIDEVOPS_MEMORY_DIR" "$AIDEVOPS_MEMORY_AUDIT_LOG_DIR"
+
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+AUDIT_PULSE="$REPO_ROOT/.agents/scripts/memory-audit-pulse.sh"
+MOCK_TASK_CMD="$TEST_DIR/mock-claim-task-id.sh"
+MOCK_LOG="$TEST_DIR/mock-claims.log"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+seed_repeated_failures() {
+	"$MEMORY_HELPER" stats >/dev/null
+	local test_db="$AIDEVOPS_MEMORY_DIR/memory.db"
+	local i
+	for i in 1 2 3; do
+		sqlite3 "$test_db" \
+			"INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source) VALUES ('mem_20260502_action_${i}', 'test-session', 'actionable failure pattern ${i}', 'FAILED_APPROACH', 'memory-audit,test', 'medium', datetime('now'), datetime('now'), '', 'test');"
+	done
+	return 0
+}
+
+write_mock_task_cmd() {
+	cat >"$MOCK_TASK_CMD" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+title=""
+description=""
+labels=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--title)
+		title="$2"
+		shift 2
+		;;
+	--description)
+		description="$2"
+		shift 2
+		;;
+	--labels)
+		labels="$2"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+
+{
+	printf 'title=%s\n' "$title"
+	printf 'labels=%s\n' "$labels"
+	printf 'description_has_files=%s\n' "$([[ "$description" == *"## Files to modify"* ]] && printf yes || printf no)"
+} >>"${MOCK_LOG:?}"
+printf 'Created issue GH#999 for %s\n' "$title"
+MOCK
+	chmod +x "$MOCK_TASK_CMD"
+	return 0
+}
+
+seed_repeated_failures
+write_mock_task_cmd
+export AIDEVOPS_MEMORY_AUDIT_TASK_CMD="$MOCK_TASK_CMD"
+export MOCK_LOG
+
+dry_output="$($AUDIT_PULSE run --force --dry-run 2>&1)" || fail "dry-run audit exited non-zero: $dry_output"
+
+if [[ ! "$dry_output" =~ Found[[:space:]]+1[[:space:]]+improvement[[:space:]]+opportunities ]]; then
+	fail "dry-run did not detect repeated failure opportunity: $dry_output"
+fi
+
+if [[ -f "$MOCK_LOG" ]]; then
+	fail "dry-run invoked task creation command"
+fi
+
+if ! grep -Fq 'would-file' "$AIDEVOPS_MEMORY_AUDIT_LOG_DIR/last-opportunity-actions.txt"; then
+	fail "dry-run did not record would-file action"
+fi
+
+live_output="$($AUDIT_PULSE run --force 2>&1)" || fail "live audit exited non-zero: $live_output"
+
+if [[ ! -f "$MOCK_LOG" ]]; then
+	fail "live audit did not invoke task creation command"
+fi
+
+claim_count=$(grep -c '^title=' "$MOCK_LOG" 2>/dev/null || true)
+[[ "$claim_count" =~ ^[0-9]+$ ]] || claim_count=0
+if [[ "$claim_count" -ne 1 ]]; then
+	fail "expected one live task creation, got $claim_count"
+fi
+
+if ! grep -Fq 'description_has_files=yes' "$MOCK_LOG"; then
+	fail "mock task body was not worker-ready"
+fi
+
+second_output="$($AUDIT_PULSE run --force 2>&1)" || fail "second live audit exited non-zero: $second_output"
+claim_count=$(grep -c '^title=' "$MOCK_LOG" 2>/dev/null || true)
+[[ "$claim_count" =~ ^[0-9]+$ ]] || claim_count=0
+if [[ "$claim_count" -ne 1 ]]; then
+	fail "duplicate suppression failed; task creations: $claim_count"
+fi
+
+if ! grep -Fq 'skipped-duplicate' "$AIDEVOPS_MEMORY_AUDIT_LOG_DIR/last-opportunity-actions.txt"; then
+	fail "second live audit did not record duplicate suppression: $second_output"
+fi
+
+if ! grep -Fq 'Opportunity filing actions:' "$AIDEVOPS_MEMORY_AUDIT_LOG_DIR"/audit-*.txt; then
+	fail "saved audit report did not include filing actions"
+fi
+
+printf 'PASS: memory audit opportunities are actionable and deduplicated\n'
+exit 0


### PR DESCRIPTION
## Summary

Memory audit opportunity scans now preserve details, preview would-file actions in dry-run, file worker-ready self-improvement tasks in live mode, and suppress duplicate filings by fingerprint.

## Files Changed

.agents/reference/memory.md,.agents/scripts/memory-audit-pulse.sh,.agents/scripts/tests/test-memory-audit-opportunities-actionable.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/memory-audit-pulse.sh .agents/scripts/tests/test-memory-audit-opportunities-actionable.sh; .agents/scripts/tests/test-memory-audit-opportunities-actionable.sh; .agents/scripts/tests/test-memory-dedup-dry-run.sh; memory-audit-pulse.sh run --dry-run --force with isolated audit log showed would-file actions and created no issues

Resolves #22351


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 12m and 131,371 tokens on this as a headless worker.