### PR TITLE
GH#22349: close worker failure feedback loop

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -778,6 +778,42 @@ _t3077_write_preflight_sentinel() {
 	return 0
 }
 
+#######################################
+# Preserve a small worker output excerpt for failure-metric forensics.
+#
+# Args:
+#   $1 - output file path
+#   $2 - session key
+# stdout: excerpt path, or empty on failure/no file
+# Returns: 0 always (observability must fail open)
+#######################################
+_metric_failure_excerpt_path() {
+	local output_file="$1"
+	local session_key="$2"
+	if [[ -z "$output_file" || ! -f "$output_file" ]]; then
+		return 0
+	fi
+	local excerpt_dir="${HOME}/.aidevops/logs/worker-failure-excerpts"
+	mkdir -p "$excerpt_dir" 2>/dev/null || return 0
+	local safe_key timestamp excerpt_path
+	safe_key=$(printf '%s' "$session_key" | tr -c 'A-Za-z0-9._-' '_')
+	timestamp=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || printf '%s' "unknown")
+	excerpt_path="${excerpt_dir}/${safe_key:-unknown}-${timestamp}-$$.log"
+	python3 - "$output_file" "$excerpt_path" <<'PY' >/dev/null 2>&1 || return 0
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+try:
+    with open(src, "rb") as f:
+        data = f.read()[-65536:]
+    with open(dst, "wb") as f:
+        f.write(data)
+except OSError:
+    sys.exit(0)
+PY
+	[[ -s "$excerpt_path" ]] && printf '%s' "$excerpt_path"
+	return 0
+}
+
 # _execute_run_attempt: run one headless invocation and handle the result.
 # Dispatches to OpenCode (default) or Claude CLI (when --runtime claude specified).
 # Args: role session_key work_dir title prompt selected_model variant_override agent_name
@@ -1022,6 +1058,11 @@ _execute_run_attempt() {
 	# Route as exit 80 so cmd_run can release the dispatch claim without
 	# incrementing the fast-fail counter or triggering NMR backoff on the issue.
 	if [[ -f "$_rl_fast_sentinel" ]]; then
+		local _rl_metric_output_file="" _rl_metric_session_id=""
+		if [[ -f "$output_file" ]]; then
+			_rl_metric_session_id=$(extract_session_id_from_output "$output_file" 2>/dev/null || true)
+			_rl_metric_output_file=$(_metric_failure_excerpt_path "$output_file" "$session_key")
+		fi
 		rm -f "$_rl_fast_sentinel" "$output_file" 2>/dev/null || true
 		# One literal here; _cmd_run_finish elif is a second. Keeping total at 2
 		# avoids the repeated-string-literal ratchet gate (threshold: >=3).
@@ -1040,7 +1081,8 @@ _execute_run_attempt() {
 			wait "$resource_sampler_pid" 2>/dev/null || true
 			rm -f "$resource_stop_file" "$resource_result_file" 2>/dev/null || true
 		fi
-		append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "$_run_result_label" "0" "$_run_failure_reason" "0" "$_rl_duration_ms"
+		append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "$_run_result_label" "0" "$_run_failure_reason" "0" "$_rl_duration_ms" \
+			"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_rl_metric_output_file" "$_rl_metric_session_id"
 		return 80
 	fi
 
@@ -1048,9 +1090,13 @@ _execute_run_attempt() {
 	# session state to the output file so the worker log captures it.
 	# OpenCode exits silently on API errors; this is our only visibility.
 	# Extract session ID BEFORE the append block to avoid SC2094 (read+write same file).
-	local _diag_session_id="" _diag_incomplete_msgs="0"
-	if [[ "$exit_code" -eq 0 && -f "$output_file" ]]; then
-		_diag_session_id=$(extract_session_id_from_output "$output_file" 2>/dev/null || true)
+	local _diag_session_id="" _diag_incomplete_msgs="0" _metric_session_id="" _metric_output_file=""
+	if [[ -f "$output_file" ]]; then
+		_metric_session_id=$(extract_session_id_from_output "$output_file" 2>/dev/null || true)
+		_metric_output_file=$(_metric_failure_excerpt_path "$output_file" "$session_key")
+	fi
+	if [[ "$exit_code" -eq 0 && -n "$_metric_session_id" ]]; then
+		_diag_session_id="$_metric_session_id"
 		if [[ -n "$_diag_session_id" ]]; then
 			_diag_incomplete_msgs=$(sqlite3 ~/.local/share/opencode/opencode.db \
 				"SELECT count(*) FROM message WHERE session_id='${_diag_session_id}' AND json_extract(data, '$.role')='assistant' AND json_extract(data, '$.time.completed') IS NULL" 2>/dev/null || echo "0")
@@ -1093,7 +1139,11 @@ _execute_run_attempt() {
 		wait "$resource_sampler_pid" 2>/dev/null || true
 		rm -f "$resource_stop_file" "$resource_result_file" 2>/dev/null || true
 	fi
-	append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "${_run_result_label:-failed}" "$handle_exit" "${_run_failure_reason:-}" "${_run_activity_detected:-0}" "$duration_ms"
+	if [[ "${_run_result_label:-failed}" == "success" ]]; then
+		_metric_output_file=""
+	fi
+	append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "${_run_result_label:-failed}" "$handle_exit" "${_run_failure_reason:-}" "${_run_activity_detected:-0}" "$duration_ms" \
+		"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_metric_output_file" "$_metric_session_id"
 	return "$handle_exit"
 }
 

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -271,10 +271,17 @@ append_runtime_metric() {
 	local failure_reason="$7"
 	local activity="$8"
 	local duration_ms="$9"
+	local issue_number="${10:-}"
+	local repo_slug="${11:-}"
+	local work_dir="${12:-}"
+	local output_file="${13:-}"
+	local session_id="${14:-}"
 	mkdir -p "$METRICS_DIR" 2>/dev/null || true
 	ROLE="$role" SESSION_KEY="$session_key" MODEL="$model" PROVIDER="$provider" \
 		RESULT="$result" EXIT_CODE="$exit_code" FAILURE_REASON="$failure_reason" \
-		ACTIVITY="$activity" DURATION_MS="$duration_ms" METRICS_PATH="$METRICS_FILE" python3 - <<'PY' >/dev/null 2>&1 || true
+		ACTIVITY="$activity" DURATION_MS="$duration_ms" ISSUE_NUMBER="$issue_number" \
+		REPO_SLUG="$repo_slug" WORK_DIR="$work_dir" OUTPUT_FILE="$output_file" \
+		SESSION_ID="$session_id" METRICS_PATH="$METRICS_FILE" python3 - <<'PY' >/dev/null 2>&1 || true
 import json
 import os
 import time
@@ -291,6 +298,22 @@ record = {
     "activity": os.environ.get("ACTIVITY", "0") == "1",
     "duration_ms": int(os.environ.get("DURATION_MS", "0") or 0),
 }
+optional_fields = {
+    "issue_number": os.environ.get("ISSUE_NUMBER", ""),
+    "repo_slug": os.environ.get("REPO_SLUG", ""),
+    "work_dir": os.environ.get("WORK_DIR", ""),
+    "output_file": os.environ.get("OUTPUT_FILE", ""),
+    "session_id": os.environ.get("SESSION_ID", ""),
+}
+for key, value in optional_fields.items():
+    if value:
+        if key == "issue_number":
+            try:
+                record[key] = int(value)
+            except ValueError:
+                record[key] = value
+        else:
+            record[key] = value
 try:
     load_1min, _load_5min, _load_15min = os.getloadavg()
     cpu_count = os.cpu_count() or 0

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -109,7 +109,7 @@ T_FUTURE_SENTINEL=4102444800
 {
 	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
-	printf '{"ts":%d,"role":"worker","session_key":"issue-3","result":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-3","session_id":"ses_3","issue_number":22349,"repo_slug":"marcusquinn/aidevops","work_dir":"/tmp/wt-3","output_file":"/tmp/excerpt-3.log","result":"watchdog_stall_killed","failure_reason":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-4","result":"watchdog_stall_continue","exit_code":0}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-5","result":"rate_limit","exit_code":1}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-6","result":"unknown_failure","exit_code":2}\n' "$T_2H_AGO"
@@ -206,6 +206,10 @@ assert_eq "2h5: future sentinel excluded from examples" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-9")] | length')"
 assert_eq "2h6: missing timestamp excluded from examples" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-10")] | length')"
+assert_eq "2h7: failure groups carry issue evidence" "22349" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-3") | .issue_number')"
+assert_eq "2h8: failure groups include repo evidence" "marcusquinn/aidevops" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-3") | .repo_slug')"
 
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \
@@ -273,6 +277,7 @@ assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
 assert_contains "5e: human output shows pr-check opt-in note" "use --pr-check" "$OUT"
 assert_contains "5f: human output shows timing summary" "Timing ms" "$OUT"
+assert_contains "5g: human output shows failure groups" "Failure groups" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Section 6: solved:worker attribution query excludes origin-only PR counts.

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -127,7 +127,7 @@ _wah_metric_details_json() {
 	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
-		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[]}'
+		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[]}'
 		return 0
 	fi
 	now_epoch=$(date +%s)
@@ -135,6 +135,7 @@ _wah_metric_details_json() {
 	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 		| ($w | map(.duration_ms // 0)) as $durations
+		| ($w | map(select((.result // "") != "success" or (.exit_code // 1) != 0))) as $failures
 		| {
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
 			timing_ms: {
@@ -145,15 +146,34 @@ _wah_metric_details_json() {
 			recent_examples: ($w | sort_by(.ts // 0) | reverse | .[0:5] | map({
 				ts,
 				session_key,
+				session_id,
+				issue_number,
+				repo_slug,
 				result,
 				exit_code,
 				failure_reason,
 				duration_ms,
+				work_dir,
+				output_file,
 				load_1min,
 				load_per_cpu
-			}))
+			})),
+			failure_groups: ([
+				$failures
+				| group_by([.result // "unknown", .failure_reason // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
+				| .[]
+				| {
+					result: (.[0].result // "unknown"),
+					failure_reason: (.[0].failure_reason // ""),
+					session_key: (.[0].session_key // ""),
+					issue_number: (.[0].issue_number // null),
+					repo_slug: (.[0].repo_slug // ""),
+					count: length,
+					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_id, work_dir, output_file, exit_code, duration_ms}))
+				}
+			] | sort_by(.count) | reverse | .[0:10])
 		}' <"$metrics" 2>/dev/null || \
-		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[]}'
+		printf '{"result_counts":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[]}'
 	return 0
 }
 
@@ -266,6 +286,7 @@ _wah_emit_human() {
 		"$(printf '%s' "$details_json" | jq -r '.timing_ms.avg // 0' 2>/dev/null || printf '0')" \
 		"$(printf '%s' "$details_json" | jq -r '.timing_ms.max // 0' 2>/dev/null || printf '0')" \
 		"$(printf '%s' "$details_json" | jq -r '.timing_ms.samples // 0' 2>/dev/null || printf '0')"
+	printf '  Failure groups:             %s\n' "$(printf '%s' "$details_json" | jq -c '.failure_groups // []' 2>/dev/null || printf '[]')"
 	printf '\n'
 	printf 'pulse-stats.json (dispatch-side counters):\n'
 	printf '  pulse_dispatch_circuit_broken:           %d\n' "$cb"
@@ -326,7 +347,8 @@ _wah_emit_json() {
 				other_failure: $of,
 				result_counts: $details.result_counts,
 				timing_ms: $details.timing_ms,
-				recent_examples: $details.recent_examples
+				recent_examples: $details.recent_examples,
+				failure_groups: ($details.failure_groups // [])
 			},
 			pulse_stats: {
 				pulse_dispatch_circuit_broken: $cb,

--- a/.agents/scripts/worker-failure-feedback-helper.sh
+++ b/.agents/scripts/worker-failure-feedback-helper.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# worker-failure-feedback-helper.sh - Mine worker runtime failures into feedback tasks
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
+
+DEFAULT_SINCE_HOURS=24
+DEFAULT_THRESHOLD=3
+DEFAULT_LIMIT=5
+DEFAULT_METRICS_FILE="${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl"
+
+print_usage() {
+	cat <<'EOF'
+worker-failure-feedback-helper.sh - Mine non-success worker metrics into feedback tasks
+
+Usage:
+  worker-failure-feedback-helper.sh report [--since-hours N] [--threshold N] [--metrics-file PATH]
+  worker-failure-feedback-helper.sh create-issues [--since-hours N] [--threshold N] [--limit N] [--dry-run]
+
+The miner groups recent non-success headless-runtime-metrics.jsonl rows by
+result, failure_reason, session_key, issue_number, and repo_slug. Repeated
+classes become worker-ready issue bodies with evidence and verification steps.
+EOF
+	return 0
+}
+
+die() {
+	local message="$1"
+	printf '[ERROR] %s\n' "$message" >&2
+	return 1
+}
+
+require_positive_integer() {
+	local option_name="$1"
+	local value="$2"
+	if [[ ! "$value" =~ ^[0-9]+$ || "$value" -eq 0 ]]; then
+		die "${option_name} must be a positive integer"
+		return 1
+	fi
+	return 0
+}
+
+parse_common_args() {
+	SINCE_HOURS="$DEFAULT_SINCE_HOURS"
+	THRESHOLD="$DEFAULT_THRESHOLD"
+	LIMIT="$DEFAULT_LIMIT"
+	METRICS_FILE="$DEFAULT_METRICS_FILE"
+	DRY_RUN=0
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--since-hours) SINCE_HOURS="${2:-}"; require_positive_integer "$arg" "$SINCE_HOURS" || return 2; shift 2 ;;
+		--threshold) THRESHOLD="${2:-}"; require_positive_integer "$arg" "$THRESHOLD" || return 2; shift 2 ;;
+		--limit) LIMIT="${2:-}"; require_positive_integer "$arg" "$LIMIT" || return 2; shift 2 ;;
+		--metrics-file) METRICS_FILE="${2:-}"; [[ -n "$METRICS_FILE" ]] || return 2; shift 2 ;;
+		--dry-run) DRY_RUN=1; shift ;;
+		-h | --help) print_usage; return 64 ;;
+		*) die "unknown flag: $arg"; return 2 ;;
+		esac
+	done
+	return 0
+}
+
+mine_failure_groups_json() {
+	local since_hours="$1"
+	local threshold="$2"
+	local metrics_file="$3"
+	if [[ ! -f "$metrics_file" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	local cutoff_epoch
+	cutoff_epoch=$(( $(date +%s) - (since_hours * 3600) ))
+	jq -s --argjson cutoff "$cutoff_epoch" --argjson threshold "$threshold" '
+    map(select((.ts // 0) >= $cutoff))
+    | map(select((.result // "") != "success" or (.exit_code // 1) != 0))
+    | group_by([.result // "unknown", .failure_reason // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
+    | map({
+        result: (.[0].result // "unknown"),
+        failure_reason: (.[0].failure_reason // ""),
+        session_key: (.[0].session_key // ""),
+        issue_number: (.[0].issue_number // null),
+        repo_slug: (.[0].repo_slug // ""),
+        count: length,
+        first_ts: (map(.ts // 0) | min),
+        last_ts: (map(.ts // 0) | max),
+        examples: (sort_by(.ts // 0) | reverse | .[0:5] | map({ts, model, provider, exit_code, duration_ms, session_id, work_dir, output_file}))
+      })
+    | map(select(.count >= $threshold))
+    | sort_by(.count) | reverse
+  ' "$metrics_file" 2>/dev/null || printf '[]\n'
+	return 0
+}
+
+cmd_report() {
+	parse_common_args "$@"
+	local parse_rc=$?
+	[[ "$parse_rc" -eq 64 ]] && return 0
+	[[ "$parse_rc" -eq 0 ]] || return "$parse_rc"
+	mine_failure_groups_json "$SINCE_HOURS" "$THRESHOLD" "$METRICS_FILE"
+	return 0
+}
+
+issue_body_for_group() {
+	local group_json="$1"
+	jq -r '
+    "## Task\nFix repeated headless worker failure class: " + (.result // "unknown") + " / " + (.failure_reason // "unspecified") + "\n\n" +
+    "## Why\nThe worker failure feedback miner observed " + (.count|tostring) + " matching non-success runtime metric rows. Repeated failures consume tokens/CPU without producing merged work; this task should turn the evidence into a durable fix.\n\n" +
+    "## Files to modify\n- EDIT: .agents/scripts/headless-runtime-helper.sh — inspect worker lifecycle handling for this failure class.\n- EDIT: .agents/scripts/headless-runtime-lib.sh — adjust metric classification if the row is misclassified.\n- EDIT: .agents/scripts/worker-activity-helper.sh — keep failure detail visible if presentation needs improvement.\n\n" +
+    "## Evidence\n- result: " + (.result // "unknown") + "\n" +
+    "- failure_reason: " + (.failure_reason // "") + "\n" +
+    "- session_key: " + (.session_key // "") + "\n" +
+    "- issue_number: " + ((.issue_number // "")|tostring) + "\n" +
+    "- repo_slug: " + (.repo_slug // "") + "\n" +
+    "- count: " + (.count|tostring) + "\n" +
+    "- examples: `" + ((.examples // []) | tostring) + "`\n\n" +
+    "## Acceptance criteria\n- The cited failure class is either fixed or explicitly reclassified with evidence.\n- A regression test or fixture covers the observed row shape.\n- New non-success rows retain issue/repo/session/log evidence for future mining.\n\n" +
+    "## Verification\n- shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/worker-activity-helper.sh\n- .agents/scripts/worker-failure-feedback-helper.sh report --since-hours 24 --threshold 1\n"
+  ' <<<"$group_json"
+	return 0
+}
+
+cmd_create_issues() {
+	parse_common_args "$@"
+	local parse_rc=$?
+	[[ "$parse_rc" -eq 64 ]] && return 0
+	[[ "$parse_rc" -eq 0 ]] || return "$parse_rc"
+	local groups_json
+	groups_json=$(mine_failure_groups_json "$SINCE_HOURS" "$THRESHOLD" "$METRICS_FILE")
+	local created=0
+	while IFS= read -r group; do
+		[[ -n "$group" ]] || continue
+		[[ "$created" -lt "$LIMIT" ]] || break
+		local title body
+		title=$(jq -r '"Fix repeated worker failure: " + (.result // "unknown") + " / " + (.failure_reason // "unspecified")' <<<"$group")
+		body=$(issue_body_for_group "$group")
+		if [[ "$DRY_RUN" -eq 1 ]]; then
+			printf 'DRY_RUN title=%s\n%s\n' "$title" "$body"
+		else
+			claim-task-id.sh --title "$title" --description "$body" --labels "auto-dispatch,tier:standard,bug,worker-failure-feedback"
+		fi
+		created=$((created + 1))
+	done < <(jq -c '.[]' <<<"$groups_json")
+	printf 'created=%d\n' "$created"
+	return 0
+}
+
+main() {
+	local cmd="${1:-help}"
+	[[ $# -gt 0 ]] && shift
+	case "$cmd" in
+	report) cmd_report "$@" ;;
+	create-issues) cmd_create_issues "$@" ;;
+	help | -h | --help) print_usage ;;
+	*) die "unknown command: $cmd"; print_usage >&2; return 2 ;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Enriched non-success runtime metrics with issue/repo/worktree/session/log evidence, exposed grouped failure details in worker-activity-helper, and added worker-failure-feedback-helper to mine repeated failures into worker-ready tasks.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh,.agents/scripts/worker-failure-feedback-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/worker-activity-helper.sh .agents/scripts/worker-failure-feedback-helper.sh; .agents/scripts/tests/test-worker-activity-helper.sh; .agents/scripts/worker-failure-feedback-helper.sh report/create-issues dry-run synthetic smoke test; git diff --check

Resolves #22349


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 234,495 tokens on this as a headless worker.