### PR TITLE
t3434: file future-plane parent tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -914,6 +914,12 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3457 Normalize escaped newlines in issue bodies #auto-dispatch #bug ref:GH#22316 pr:#22319 completed:2026-05-02
 
+- [ ] t3476 _projects plane parent — structured project lifecycle and TODO/full-loop integration #feat #framework #parent ref:GH#22371 -> [todo/tasks/t3476-brief.md]
+
+- [ ] t3477 _performance plane parent — KPI schemas dashboards and result ingest #feat #framework #parent ref:GH#22372 -> [todo/tasks/t3477-brief.md]
+
+- [ ] t3478 _feedback plane parent — capture retention mining and promotion paths #feat #framework #parent ref:GH#22373 -> [todo/tasks/t3478-brief.md]
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/tasks/t3476-brief.md
+++ b/todo/tasks/t3476-brief.md
@@ -1,0 +1,114 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t3476: `_projects/` plane parent — structured project lifecycle and TODO/full-loop integration
+
+## Pre-flight
+
+- [x] Memory recall: `issue 22285 full-loop` — no prior lesson found.
+- [x] Discovery pass: related t2840/t2870/t2874 parent-plane work found; no existing `_projects/` parent task found.
+- [x] File refs verified: model on `todo/tasks/t2870-brief.md` and `todo/tasks/t2874-brief.md`.
+- [x] Tier: `tier:thinking` — architecture-level decomposition; child phases should generally be `tier:standard` once contracts are concrete.
+
+## Origin
+
+- **Created:** 2026-05-02
+- **Session:** Headless worker for GH#22285 / t3434
+- **Created by:** ai-worker
+- **Parent task:** none (this IS a parent)
+- **Conversation context:** t2840 established `_knowledge/` and `_cases/` as the MVP planes and explicitly named `_projects/`, `_performance/`, and `_feedback` as post-MVP planes. Later work references these planes, but they lacked dedicated trackers.
+
+## What
+
+Establish `_projects/` as the canonical user-data plane for structured project state: goals, plans, milestones, decisions, risks, links to TODO/full-loop tasks, and post-completion outcomes.
+
+**This is a planning-only parent.** No code changes ship from this issue directly — children file individual implementation tasks once the MVP plane foundation is stable and this decomposition is ready to execute.
+
+## Why
+
+Project work has a distinct shape:
+
+- **Different lifecycle:** `intake → scope → plan → implement → verify → release → learn → archive`.
+- **Different audit needs:** every project should link to TODO entries, GitHub issues, PRs, releases, verification evidence, and post-completion decisions.
+- **Different granularity:** a project may span multiple repos and multiple task IDs, while TODO entries remain atomic execution units.
+- **Different consumers:** project managers, implementation agents, review agents, reporting routines, and future performance dashboards all need stable references.
+
+Without a dedicated plane, project state either bloats TODO.md, gets buried in repo-local notes, or fragments across issues and PRs with no durable project-level index.
+
+## Tier
+
+**Selected tier:** `tier:thinking` — this is decomposition design. Implementation children will be smaller, mechanical tasks once the contract is pinned.
+
+## PR Conventions
+
+This is a parent-task. Initial planning PR uses `For #` keyword (planning only). Children's PRs use `For #THIS-ISSUE` until the final phase, which uses a closing keyword for this parent.
+
+## Phases
+
+Decomposition planned as 5 phases:
+
+- **Phase 1 — directory contract**: define `_projects/<project-id>/` layout, required files, ID rules, and relation to existing repo-local `TODO.md` / `todo/` planning files.
+- **Phase 2 — lifecycle mapping**: model project states from intake through planning, implementation, verification, completion, archive, and revival; define how state maps to GitHub issues, TODO entries, PRs, and full-loop evidence.
+- **Phase 3 — CLI surface**: design `aidevops project new|list|status|link|archive` and the minimal project registry needed for cross-repo references.
+- **Phase 4 — task and evidence links**: define durable references from project milestones to task IDs, GitHub issues, PRs, releases, verification commands, and worker outcomes.
+- **Phase 5 — cross-plane integration**: specify when project outputs promote to `_knowledge/`, when client-facing work links to `_cases/`, and when results feed `_performance/`.
+
+Children are NOT pre-filed. File them when the t2840 MVP foundation is stable and each phase has concrete file scopes.
+
+## Out of Scope (for this parent)
+
+- Building project management UI or dashboards — separate child/parent once schema exists.
+- Replacing TODO.md or GitHub issues — `_projects/` links to execution artefacts; it does not become the execution queue.
+- Cross-repo billing, capacity planning, or client reporting — likely `_performance/` / business-ops work.
+
+## Cross-Plane Connections
+
+- `_knowledge/insights/` receives durable project lessons and reusable decisions.
+- `_cases/<id>/projects/` can link client-specific project work without duplicating project state.
+- `_performance/projects/` receives outcome metrics after completion.
+- `_feedback/` can promote mined themes into project requirements or risks.
+- TODO.md and GitHub remain the execution/audit layer; `_projects/` is the project-level context layer.
+
+## How (decomposition only — no code changes)
+
+This parent ships:
+
+- Decomposition plan in this brief.
+- A parent GitHub issue with `## Phases` so parent-task automation can understand the tracker.
+- TODO entry with `#parent` and `ref:GH#22371`.
+
+### Files Scope
+
+- `todo/tasks/t3476-brief.md` (this file — for the planning PR)
+- `TODO.md` (parent entry only)
+
+## Acceptance Criteria
+
+- [ ] `_projects/` has a parent issue/brief defining lifecycle, directory contract goals, and relation to TODO/full-loop.
+- [ ] TODO entry includes `ref:GH#22371`, `#parent`, and this brief link.
+- [ ] Phase children are not filed prematurely.
+- [ ] Cross-plane links to `_knowledge`, `_cases`, `_performance`, and `_feedback` are documented.
+
+## Context & Decisions
+
+- **Why separate from TODO.md:** TODO.md tracks executable work; `_projects/` tracks context and lifecycle across many work items.
+- **Why not a child of t2840:** t2840 already scoped the MVP data-plane foundation. `_projects/` is post-MVP and needs its own decomposition to avoid scope creep.
+- **Why children not pre-filed:** phase file scopes depend on the data-plane registry and directory contract work now in flight.
+
+## Relevant Files
+
+- `todo/tasks/t2870-brief.md` — peer parent pattern for `_campaigns/`.
+- `todo/tasks/t2874-brief.md` — peer parent pattern for structured tags.
+- `TODO.md` — execution task index and audit references.
+
+## Dependencies
+
+- **Blocked by:** enough t2840/data-plane foundation to reuse directory and indexing conventions.
+- **Coordinates with:** future `_performance/` and `_feedback/` parents.
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| This planning PR | ~20m | brief + issue + TODO |
+| Future Phase 1-5 children | TBD | size after data-plane registry lands |
+| **Planning total** | **~20m** | |

--- a/todo/tasks/t3477-brief.md
+++ b/todo/tasks/t3477-brief.md
@@ -1,0 +1,115 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t3477: `_performance/` plane parent — KPI schemas, dashboards, and result ingest
+
+## Pre-flight
+
+- [x] Memory recall: `issue 22285 full-loop` — no prior lesson found.
+- [x] Discovery pass: related t2840/t2870/t2874 parent-plane work found; no existing `_performance/` parent task found.
+- [x] File refs verified: model on `todo/tasks/t2870-brief.md` and `todo/tasks/t2874-brief.md`.
+- [x] Tier: `tier:thinking` — schema and reporting architecture; child phases should generally be `tier:standard`.
+
+## Origin
+
+- **Created:** 2026-05-02
+- **Session:** Headless worker for GH#22285 / t3434
+- **Created by:** ai-worker
+- **Parent task:** none (this IS a parent)
+- **Conversation context:** `_campaigns` planning routes launched results to `_performance/`, while t2840 named `_performance/` as a post-MVP plane. A dedicated parent keeps metrics, reporting, and ingest contracts visible.
+
+## What
+
+Establish `_performance/` as the canonical plane for measurable outcomes: KPIs, result snapshots, experiment metrics, dashboard inputs, trend reports, and promotion paths from campaign launches, case outcomes, and project completions.
+
+**This is a planning-only parent.** No ingest or dashboard code ships from this issue directly.
+
+## Why
+
+Results data has a distinct shape:
+
+- **Numeric + temporal:** metrics need units, timestamps, windows, baselines, and confidence/source metadata.
+- **Cross-plane ingest:** campaigns, cases, projects, and system routines all produce outcomes that should compare cleanly.
+- **Reporting consumers:** dashboards and recurring reviews need stable schemas, not ad hoc Markdown tables.
+- **Learning loop:** metric deltas should promote lessons back to `_knowledge/insights/` and trigger follow-up tasks when thresholds are missed.
+
+Without a dedicated plane, every source plane will invent its own result format and dashboards will become brittle scrapers.
+
+## Tier
+
+**Selected tier:** `tier:thinking` — this is decomposition design. Children will be smaller schema/helper/dashboard tasks.
+
+## PR Conventions
+
+This is a parent-task. Initial planning PR uses `For #` keyword (planning only). Children's PRs use `For #THIS-ISSUE` until the final phase, which uses a closing keyword for this parent.
+
+## Phases
+
+Decomposition planned as 5 phases:
+
+- **Phase 1 — KPI/result schema**: define metric identity, dimensions, units, timestamps, confidence/source, and comparison baselines.
+- **Phase 2 — directory contract**: define `_performance/<domain>/` layout for marketing, cases, projects, system health, and future domains.
+- **Phase 3 — ingest paths**: specify how `_campaigns/launched/<id>/results.md`, `_cases/<id>/outcomes/`, and `_projects/<id>/outcomes/` promote into performance records.
+- **Phase 4 — reporting CLI**: design `aidevops performance ingest|list|report|dashboard` and JSON/Markdown outputs suitable for agents and humans.
+- **Phase 5 — dashboard and review workflow**: define recurring reporting cadence, stale-metric detection, threshold alerts, and promotion of lessons back to `_knowledge/insights/`.
+
+Children are NOT pre-filed. File them when upstream plane contracts and the data-plane registry make file scopes concrete.
+
+## Out of Scope (for this parent)
+
+- External analytics API integrations (Google Ads, Meta Ads, GA4, Stripe, etc.) — separate children after local schema exists.
+- BI frontend selection — defer until schema and CLI reporting prove the data shape.
+- Automated business decisions from metrics — reporting first, automation later.
+
+## Cross-Plane Connections
+
+- `_campaigns/launched/<id>/results.md` promotes marketing performance.
+- `_cases/<id>/outcomes/` promotes client/case results.
+- `_projects/<id>/outcomes/` promotes delivery outcomes.
+- `_knowledge/insights/` receives lessons and interpretation from metric review.
+- `_feedback/` can provide qualitative context for metric movements.
+
+## How (decomposition only — no code changes)
+
+This parent ships:
+
+- Decomposition plan in this brief.
+- A parent GitHub issue with `## Phases` so parent-task automation can understand the tracker.
+- TODO entry with `#parent` and `ref:GH#22372`.
+
+### Files Scope
+
+- `todo/tasks/t3477-brief.md` (this file — for the planning PR)
+- `TODO.md` (parent entry only)
+
+## Acceptance Criteria
+
+- [ ] `_performance/` has a parent issue/brief defining KPI/result schemas.
+- [ ] Dashboard/reporting goals and review cadence are documented.
+- [ ] Ingest paths from campaigns, cases, and projects are explicit.
+- [ ] TODO entry includes `ref:GH#22372`, `#parent`, and this brief link.
+- [ ] Phase children are not filed prematurely.
+
+## Context & Decisions
+
+- **Why separate from `_knowledge/`:** metrics are operational records and time-series evidence; `_knowledge/` stores durable insights after interpretation.
+- **Why separate from `_campaigns/`:** campaign results are one input domain; the performance plane must also handle cases, projects, and system outcomes.
+- **Why dashboard later:** dashboard choice should follow stable schemas, not drive them.
+
+## Relevant Files
+
+- `todo/tasks/t2870-brief.md` — `_campaigns` parent; phase 6 routes results here.
+- `todo/tasks/t3476-brief.md` — `_projects` parent; project outcomes route here.
+- `todo/tasks/t3478-brief.md` — `_feedback` parent; qualitative context for metric interpretation.
+
+## Dependencies
+
+- **Blocked by:** data-plane directory/registry foundation and upstream plane contracts.
+- **Coordinates with:** `_campaigns`, `_projects`, `_cases`, `_feedback`, and `_knowledge` insights promotion.
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| This planning PR | ~20m | brief + issue + TODO |
+| Future Phase 1-5 children | TBD | size after upstream result producers are concrete |
+| **Planning total** | **~20m** | |

--- a/todo/tasks/t3478-brief.md
+++ b/todo/tasks/t3478-brief.md
@@ -1,0 +1,117 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t3478: `_feedback/` plane parent — capture, retention, mining, and promotion paths
+
+## Pre-flight
+
+- [x] Memory recall: `issue 22285 full-loop` — no prior lesson found.
+- [x] Discovery pass: related t2840/t2870/t2874 parent-plane work found; no existing `_feedback/` parent task found.
+- [x] File refs verified: model on `todo/tasks/t2870-brief.md` and `todo/tasks/t2874-brief.md`.
+- [x] Tier: `tier:thinking` — retention, sensitivity, and mining policy design; child phases should generally be `tier:standard`.
+
+## Origin
+
+- **Created:** 2026-05-02
+- **Session:** Headless worker for GH#22285 / t3434
+- **Created by:** ai-worker
+- **Parent task:** none (this IS a parent)
+- **Conversation context:** t2840 named `_feedback/` as a post-MVP plane, and `_campaigns` planning expects feedback insights to feed campaign research. A dedicated parent keeps raw signal, mining, and promotion workflows separate from durable knowledge.
+
+## What
+
+Establish `_feedback/` as the canonical plane for raw and processed qualitative signal: user comments, client feedback, support pain, survey responses, social comments, sales objections, product notes, and retrospective observations.
+
+**This is a planning-only parent.** No ingestion, mining, or promotion code ships from this issue directly.
+
+## Why
+
+Feedback has a distinct lifecycle:
+
+- **Raw signal first:** preserve the original statement, source, context, actor/segment, channel, and timestamp before interpretation.
+- **Sensitivity-heavy:** feedback can contain personal, client, privileged, or reputationally sensitive content with different retention rules.
+- **Mining required:** one comment is evidence; repeated themes become insight or work.
+- **Promotion fan-out:** mined feedback can become `_knowledge/insights/`, `_campaigns` research, `_projects` requirements, `_cases` notes, or TODO/GitHub tasks.
+
+Without a dedicated plane, feedback scatters across inbox notes, case files, campaign research, and memories, losing provenance and retention control.
+
+## Tier
+
+**Selected tier:** `tier:thinking` — this is decomposition design. Children will be smaller capture/mining/promotion implementation tasks.
+
+## PR Conventions
+
+This is a parent-task. Initial planning PR uses `For #` keyword (planning only). Children's PRs use `For #THIS-ISSUE` until the final phase, which uses a closing keyword for this parent.
+
+## Phases
+
+Decomposition planned as 5 phases:
+
+- **Phase 1 — capture contract**: define `_feedback/captures/` and normalized fields for source, timestamp, actor/segment, context, channel, sentiment, sensitivity, and consent/retention.
+- **Phase 2 — retention and sensitivity policy**: define which feedback can be long-lived, anonymized, privileged, client-scoped, or deleted; align with Markdoc sensitivity tags when available.
+- **Phase 3 — mining workflow**: design clustering, deduplication, theme extraction, evidence thresholds, and review gates before promotion.
+- **Phase 4 — promotion paths**: specify when feedback becomes `_knowledge/insights/`, a `_campaigns` research input, a `_projects` requirement, a `_cases` note, or a new TODO/GitHub task.
+- **Phase 5 — CLI and routines**: design `aidevops feedback capture|list|mine|promote|retire` plus recurring mining/reporting cadence.
+
+Children are NOT pre-filed. File them when capture formats and sensitivity policy can be scoped against the data-plane registry and Markdoc tag work.
+
+## Out of Scope (for this parent)
+
+- Direct integrations with every feedback source (email, forms, app reviews, socials) — start with local capture contract.
+- Fully automated task creation from single comments — mined themes need evidence thresholds and review gates.
+- Sentiment-model vendor selection — defer until capture and retention contracts exist.
+
+## Cross-Plane Connections
+
+- `_knowledge/insights/` receives durable themes after mining and review.
+- `_campaigns/active/<id>/research/` receives audience pain points and objections.
+- `_projects/<id>/requirements/` receives validated product/project requirements.
+- `_cases/<id>/feedback/` or case notes receive client-specific signal.
+- `_performance/` receives qualitative context around metric movements.
+
+## How (decomposition only — no code changes)
+
+This parent ships:
+
+- Decomposition plan in this brief.
+- A parent GitHub issue with `## Phases` so parent-task automation can understand the tracker.
+- TODO entry with `#parent` and `ref:GH#22373`.
+
+### Files Scope
+
+- `todo/tasks/t3478-brief.md` (this file — for the planning PR)
+- `TODO.md` (parent entry only)
+
+## Acceptance Criteria
+
+- [ ] `_feedback/` has a parent issue/brief defining capture formats and required metadata.
+- [ ] Retention and sensitivity policy goals are documented.
+- [ ] Mining workflow and evidence thresholds are explicit.
+- [ ] Promotion paths to `_knowledge`, `_campaigns`, `_projects`, `_cases`, and TODO/GitHub task creation are documented.
+- [ ] TODO entry includes `ref:GH#22373`, `#parent`, and this brief link.
+- [ ] Phase children are not filed prematurely.
+
+## Context & Decisions
+
+- **Why separate from `_knowledge/`:** raw feedback is not durable knowledge until mined, reviewed, and promoted.
+- **Why separate from `_inbox/`:** `_inbox/` is staging/triage; `_feedback/` is the retained signal plane after classification.
+- **Why evidence thresholds:** one complaint may be important, but automatic task creation needs repeatability or explicit human/agent review to avoid noise.
+
+## Relevant Files
+
+- `todo/tasks/t2870-brief.md` — `_campaigns` parent; feedback insights feed campaign research.
+- `todo/tasks/t2874-brief.md` — Markdoc tag parent; likely structured annotation layer for feedback sensitivity/provenance.
+- `todo/tasks/t3476-brief.md` — `_projects` parent; mined themes can become project requirements.
+- `todo/tasks/t3477-brief.md` — `_performance` parent; feedback contextualizes results.
+
+## Dependencies
+
+- **Blocked by:** data-plane directory/registry foundation and sensitivity/Markdoc conventions for retained qualitative signal.
+- **Coordinates with:** `_knowledge`, `_campaigns`, `_projects`, `_cases`, and `_performance`.
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| This planning PR | ~20m | brief + issue + TODO |
+| Future Phase 1-5 children | TBD | size after capture/retention contract is accepted |
+| **Planning total** | **~20m** | |


### PR DESCRIPTION
## Summary

Filed parent issues and briefs for the future _projects, _performance, and _feedback data planes, and linked each from TODO.md with #parent and ref:GH# markers.

## Files Changed

TODO.md,todo/tasks/t3476-brief.md,todo/tasks/t3477-brief.md,todo/tasks/t3478-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 structural check verified the three new briefs, TODO refs, #parent markers, and GitHub parent issues; npx markdownlint-cli2 attempted but timed out before producing results.

Resolves #22285


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 302,740 tokens on this as a headless worker.