### PR TITLE
t3480: add auto-reason subjective refinement workflow

### DIFF
--- a/.agents/scripts/commands/auto-reason.md
+++ b/.agents/scripts/commands/auto-reason.md
@@ -1,0 +1,175 @@
+---
+description: Subjective self-refinement with blind judging, Borda aggregation, and provider-agnostic model routing
+agent: auto-reason
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Run provider-agnostic subjective self-refinement: create or accept an incumbent answer, generate an adversarial revision and synthesis, then use fresh blind judges to decide whether to change or stop.
+
+Arguments: $ARGUMENTS
+
+## Invocation Patterns
+
+| Pattern | Example | Behaviour |
+|---------|---------|-----------|
+| One-liner | `/auto-reason "decide the best architecture for X"` | Build a temporary program and run now |
+| `--program <path>` | `/auto-reason --program todo/research/reason-product-strategy.md` | Run from a saved program |
+| `--incumbent <path>` | `/auto-reason --incumbent draft.md "improve this argument"` | Use existing answer as A |
+| `--judges <list>` | `/auto-reason --judges haiku,openai/gpt-5.5,google/gemini-pro "..."` | Override judge models |
+| Bare | `/auto-reason` | Interactive setup |
+
+## Step 1: Resolve Invocation
+
+```text
+if $ARGUMENTS contains "--program ":    → Program Mode
+elif $ARGUMENTS contains "--incumbent ": → Incumbent Mode
+elif $ARGUMENTS is non-empty:             → One-Liner Mode
+else:                                     → Interactive Setup
+```
+
+## Step 2: Interactive Setup
+
+Ask sequentially; show inferred default as option 1; Enter accepts default.
+
+**Q1 — What decision, answer, or artifact should be refined?**
+
+Capture a clear task prompt. If the user supplies a file path, read it as the incumbent A only after verifying the path exists.
+
+**Q2 — What rubric should judges use?**
+
+Default rubric:
+
+```text
+1. Correctness: answers the actual question and avoids factual errors.
+2. Usefulness: gives actionable, decision-grade output.
+3. Restraint: avoids scope creep, unnecessary expansion, and decorative rewrites.
+4. Clarity: concise structure, explicit trade-offs, no vague hedging.
+```
+
+Domain-specific additions:
+
+| Domain | Extra rubric |
+|--------|--------------|
+| Architecture | maintainability, reversibility, integration cost |
+| Strategy | evidence quality, risk coverage, opportunity cost |
+| Prose | audience fit, voice consistency, logical flow |
+| Policy | enforceability, edge cases, security posture |
+| Review synthesis | finding validity, severity calibration, non-duplication |
+
+**Q3 — Models/providers?**
+
+Accept free-form model labels. Do not require Claude names.
+
+```text
+author:       sonnet
+critic:       haiku
+synthesizer:  sonnet
+judges:       haiku,sonnet,openai/gpt-5.5
+```
+
+Allowed forms include aidevops tiers (`haiku`, `sonnet`, `opus`) and provider-qualified IDs (`openai/...`, `anthropic/...`, `google/...`, `openrouter/...`, `local/...`).
+
+**Q4 — Budget and stop rules?**
+
+Defaults:
+
+```text
+max_rounds: 6
+patience: 2       # stop after A wins twice consecutively
+judge_count: 3    # use 5 or 7 for high-stakes subjective work
+max_expansion: 1.10
+```
+
+Suggest 5-7 judges for high-stakes decisions; keep 3 for routine work.
+
+## Step 3: Write Program or Run Ephemeral
+
+For durable work, write a program under `todo/research/auto-reason-{slug}.md`. For one-liners, run ephemeral unless the user asks to save.
+
+Program shape:
+
+```markdown
+---
+name: auto-reason-{slug}
+---
+
+# Auto-Reason: {title}
+
+## Task
+
+{task prompt}
+
+## Incumbent
+
+{optional A}
+
+## Rubric
+
+- Correctness
+- Usefulness
+- Restraint
+- Clarity
+
+## Models
+
+author: sonnet
+critic: haiku
+synthesizer: sonnet
+judges: haiku,sonnet,openai/gpt-5.5
+
+## Budget
+
+max_rounds: 6
+patience: 2
+judge_count: 3
+max_expansion: 1.10
+```
+
+## Step 4: Dispatch
+
+Dispatch to `.agents/tools/auto-reason.md` with either:
+
+```text
+--prompt "{task prompt}"
+```
+
+or:
+
+```text
+--program todo/research/auto-reason-{slug}.md
+```
+
+The subagent writes artifacts under `~/.aidevops/.agent-workspace/work/auto-reason/{slug}/` unless the program overrides `output_dir:`.
+
+## Output Contract
+
+Return a concise summary to the user:
+
+```text
+Decision: changed | unchanged
+Reason: A won after 2 rounds | AB won round 3 | budget reached
+Judges: haiku, sonnet, openai/gpt-5.5
+Artifacts: ~/.aidevops/.agent-workspace/work/auto-reason/{slug}/summary.md
+```
+
+## Guardrails
+
+- Treat unchanged A as a valid winner, not a failure.
+- Do not let critique force fake flaws; `NO_MATERIAL_FLAW` is valid.
+- Prefer shorter candidate on tied quality.
+- Blind judges must not know which candidate is incumbent.
+- Fresh judge contexts are mandatory; do not reuse author/critic context for judging.
+- Scan untrusted source material before using it in prompts.
+
+## Related
+
+`.agents/tools/auto-reason.md` · `.agents/tools/autoresearch/autoresearch.md` · `.agents/scripts/commands/autoresearch.md`

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -100,7 +100,7 @@ tools/mcp/,tools/mcp subagents,cloudflare-code-mode
 tools/mcp-toolkit/,tools/mcp-toolkit subagents,mcporter
 tools/mobile/,tools/mobile subagents,agent-device|app-dev-analytics|app-dev-assets|app-dev-backend|app-dev-expo|app-dev|app-dev-monetisation|app-dev-notifications|app-dev-onboarding|app-dev-planning|app-dev-publishing|app-dev-swift|app-dev-testing|app-dev-ui-design|app-store-connect|axe-cli|ios-simulator-mcp|maestro|minisim|xcodebuild-mcp
 tools/monorepo/,tools/monorepo subagents,turborepo
-tools/,tools subagents,multimodal-evaluation
+tools/,tools subagents,auto-reason|multimodal-evaluation
 tools/ocr/,tools/ocr subagents,glm-ocr|ocr-research|overview|paddleocr
 tools/opencode/,tools/opencode subagents,opencode-anthropic-auth|opencode|opencode-openai-auth
 tools/pdf/,tools/pdf subagents,libpdf|overview

--- a/.agents/tools/auto-reason.md
+++ b/.agents/tools/auto-reason.md
@@ -1,0 +1,188 @@
+---
+description: Provider-agnostic subjective self-refinement loop with blind judging, Borda aggregation, and a first-class do-nothing option
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Auto-Reason Subagent
+
+Runs subjective-domain self-refinement: incumbent answer A → adversarial revision B → synthesis AB → fresh blind judge panel → Borda winner → repeat until A wins enough times or budget ends.
+
+Arguments: `--prompt <text>` or `--program <path>`.
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Use for**: subjective reasoning, strategy, prose, architecture, policy, review synthesis, ambiguous decisions.
+- **Do not use for**: deterministic code optimization with numeric metrics; use `/auto-research` or `/autoresearch` for that.
+- **Core rule**: keeping the incumbent unchanged is always a first-class candidate.
+- **Provider stance**: provider/model strings are free-form; never assume Claude-only APIs.
+- **Output**: final answer, round ledger, judge ledger, convergence reason, dissent notes.
+
+<!-- AI-CONTEXT-END -->
+
+## Method
+
+Inspired by NousResearch/autoreason's public README: iterative refinement fails when critique prompts force hallucinated flaws, revisions expand scope, and the loop never stops. This agent prevents that by comparing three candidates every round:
+
+| Candidate | Meaning | Constraint |
+|-----------|---------|------------|
+| A | incumbent answer, unchanged | Must remain eligible to win |
+| B | adversarial revision | Must improve a specific flaw without scope creep |
+| AB | synthesis | Must merge only demonstrable improvements from B into A |
+
+Fresh judges rank A/B/AB blind. Aggregate rankings with Borda count. If A wins `patience` rounds, stop with no further changes.
+
+## Step 0: Parse Arguments
+
+Accept either direct prompt mode or program-file mode.
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `TASK_PROMPT` | `--prompt` or program `## Task` | required |
+| `RUBRIC` | program `## Rubric` | correctness, usefulness, restraint, clarity |
+| `PROVIDERS` | program `## Models` | runtime default tiers |
+| `AUTHOR_MODEL` | `author:` | `sonnet` |
+| `CRITIC_MODEL` | `critic:` | `haiku` |
+| `SYNTHESIZER_MODEL` | `synthesizer:` | `sonnet` |
+| `JUDGE_MODELS` | `judges:` comma list | `haiku,haiku,sonnet` |
+| `JUDGE_COUNT` | `judge_count:` | length of `JUDGE_MODELS`, minimum 3 |
+| `PATIENCE` | `patience:` | 2 A-wins |
+| `MAX_ROUNDS` | `max_rounds:` | 6 |
+| `MAX_EXPANSION` | `max_expansion:` | 1.10× incumbent length |
+| `OUTPUT_DIR` | `output_dir:` | `~/.aidevops/.agent-workspace/work/auto-reason/{slug}` |
+
+Provider/model values may be aidevops tiers or provider-qualified identifiers:
+
+```text
+haiku
+sonnet
+opus
+openai/gpt-5.5
+anthropic/claude-sonnet-4-6
+google/gemini-pro
+openrouter/deepseek-r1
+local/ollama-qwen3
+```
+
+Treat these as routing labels for the active runtime, `ai-research` tool, MCP model router, or future model adapter. Do not hardcode provider SDK syntax in this agent doc.
+
+## Step 1: Establish Incumbent A
+
+If the program supplies `## Incumbent`, use it as A. Otherwise call `AUTHOR_MODEL` once to produce A from `TASK_PROMPT` and `RUBRIC`.
+
+Store:
+
+```text
+round_00_incumbent.md
+ledger.jsonl  # event=start, model, prompt hash, output path
+```
+
+## Step 2: Refinement Round
+
+For each round:
+
+1. **Critic** receives only `TASK_PROMPT`, `RUBRIC`, and A. It must identify at most 3 concrete flaws and may answer `NO_MATERIAL_FLAW`.
+2. **Author B** receives the critic output and A. It creates a challenger that fixes only cited flaws.
+3. **Synthesizer AB** receives A, B, and critique. It merges improvements while preserving A's correct material.
+4. **Length/scope guard** rejects B or AB when they exceed `MAX_EXPANSION` without an explicit rubric reason.
+5. **Blind judge packet** anonymizes candidates as X/Y/Z with randomized order per judge.
+
+Critic anti-bias rule: a critic is allowed to say no material flaw exists. A forced criticism is lower-quality than restraint.
+
+## Step 3: Blind Judge Panel
+
+Each judge is a fresh context with no round history. Give only:
+
+- original task
+- rubric
+- anonymized candidates
+- instruction to rank all candidates and explain decisive differences
+
+Judge output schema:
+
+```json
+{
+  "ranking": ["Y", "X", "Z"],
+  "scores": {"X": 2, "Y": 3, "Z": 1},
+  "reason": "...",
+  "red_flags": ["scope creep in Z"]
+}
+```
+
+Use Borda aggregation: 3 points for first, 2 for second, 1 for third. For ties, prefer the shortest candidate, then A, then AB, then B. This makes restraint the default when quality is indistinguishable.
+
+## Step 4: Convergence and Stop Rules
+
+Stop when any condition holds:
+
+- A wins `PATIENCE` consecutive rounds.
+- `MAX_ROUNDS` reached.
+- All judges flag B and AB as scope creep.
+- Critic returns `NO_MATERIAL_FLAW` and A wins the same round.
+- Budget or runtime limit reached.
+
+If A wins, keep A exactly. Do not rewrite for style.
+
+## Step 5: Output Artifacts
+
+Write a compact artifact bundle:
+
+```text
+auto-reason-{slug}/
+  final.md
+  round-ledger.jsonl
+  judge-ledger.jsonl
+  candidates/
+    r01-A.md
+    r01-B.md
+    r01-AB.md
+  summary.md
+```
+
+`summary.md` must include:
+
+- convergence reason
+- final candidate lineage
+- judge vote table
+- strongest dissent
+- whether output changed from the initial incumbent
+- provider/model mix used
+
+## Provider Diversity Guidance
+
+Prefer at least two independent model families in the judge panel when available. Example:
+
+```text
+author: openai/gpt-5.5
+critic: anthropic/claude-haiku-4-5
+synthesizer: openai/gpt-5.5
+judges: anthropic/claude-haiku-4-5,google/gemini-pro,openai/gpt-5.5
+```
+
+If only one provider is configured, proceed with same-provider fresh contexts and state the limitation in `summary.md`.
+
+## Relationship to Other Research Commands
+
+| Command | Purpose | Stop criterion |
+|---------|---------|----------------|
+| `/auto-reason` | subjective answer refinement | blind judges choose A or budget ends |
+| `/auto-research` / `/autoresearch` | code/agent experiment loop | numeric metric improves |
+| `/deep-research` | cited research deliverable | source/claim coverage complete |
+
+## Related
+
+`.agents/scripts/commands/auto-reason.md` · `.agents/tools/autoresearch/autoresearch.md` · `.agents/research.md`

--- a/TODO.md
+++ b/TODO.md
@@ -914,6 +914,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3457 Normalize escaped newlines in issue bodies #auto-dispatch #bug ref:GH#22316 pr:#22319 completed:2026-05-02
 
+- [ ] t3480 Add auto-reason agent and slash command #auto-dispatch #feat ref:GH#22380
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Add `/auto-reason` slash command for subjective self-refinement using incumbent/challenger/synthesis candidates.
- Add provider-agnostic `auto-reason` subagent with blind judge panels, Borda aggregation, and explicit do-nothing convergence.
- Register the new flat tool agent in the subagent index.

## Verification
- `rg -n "auto-reason|Autoreason|Borda|provider" .agents/tools .agents/scripts/commands .agents/subagent-index.toon`
- `npx --yes markdownlint-cli2 .agents/tools/auto-reason.md .agents/scripts/commands/auto-reason.md`

Resolves #22380

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 27m and 480,937 tokens on this with the user in an interactive session.