### PR TITLE
t3472: Add repository layout policy and drift audit

### DIFF
--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -137,4 +137,18 @@ The `.agents/` directory organizes knowledge along two axes: **strategy** (what 
 
 **Flat files over nested folders:** Prefer prefix-based names over subdirectories. Max depth from `.agents/`: 2 levels. See `tools/build-agent/build-agent.md`.
 
+## Top-Level Repository Layout Policy
+
+The repository root is a public contract, not a scratch space. New top-level files or directories must fit one of these classes and be added to `.agents/configs/repo-layout-policy.conf` with a one-line rationale before they are introduced:
+
+- **Public entrypoints:** user-facing commands and repo metadata such as `setup.sh`, `aidevops.sh`, `README.md`, `LICENSE`, `VERSION`, and governance docs.
+- **Framework internals:** implementation and source-of-truth framework assets such as `.agents/`, `configs/`, `templates/`, `tests/`, `setup-modules/`, and temporary root shell modules pending cleanup.
+- **Runtime and plugin surfaces:** runtime integration packages such as `.claude-plugin/`, `.opencode/`, and editor/runtime config files.
+- **Packaging surfaces:** distribution and package-manager assets such as `bin/`, `scripts/`, `homebrew/`, `package.json`, and lock/dependency files.
+- **Repo-local data planes:** underscore-prefixed local working areas such as `_knowledge/`, `_cases/`, `_campaigns/`, `_inbox/`, `_feedback/`, `_projects/`, and `_performance/`.
+- **Docs and planning:** documentation and task surfaces such as `.wiki/`, `docs/`, `todo/`, `TODO.md`, and model/reference docs.
+- **Generated or ignored tooling surfaces:** intentionally tracked tool config and generated-input files such as `.github/`, `.qlty/`, lint configs, Repomix configs, and scanner config.
+
+Run `.agents/scripts/repo-layout-audit-helper.sh --check` to audit tracked top-level drift. The audit is non-destructive: it reports unknown paths and recommends likely homes, but never moves files.
+
 **Ingested skills** retain the `-skill` suffix as a provenance marker for automated upstream update checks. On ingestion, upstream structure is transposed to `{name}-skill.md` + `{name}-skill/`. See `tools/build-agent/add-skill.md`.

--- a/.agents/configs/repo-layout-policy.conf
+++ b/.agents/configs/repo-layout-policy.conf
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Repository root layout policy.
+# Format: <top-level-path><TAB><class><TAB><rationale>
+# Classes: public-entrypoint, framework-internal, runtime-plugin, packaging,
+# repo-data-plane, docs-planning, tooling-generated.
+
+.agents	framework-internal	Source-of-truth agents, scripts, workflows, reference docs, configs.
+.bandit	tooling-generated	Bandit security scanner configuration.
+.claude-plugin	runtime-plugin	Claude runtime plugin package surface.
+.codacy.yml	tooling-generated	Codacy repository configuration.
+.codefactor.yml	tooling-generated	CodeFactor repository configuration.
+.coderabbit.yaml	tooling-generated	CodeRabbit review bot configuration.
+.gitattributes	tooling-generated	Git attribute policy for repository content.
+.github	tooling-generated	GitHub workflows, issue templates, and repository automation.
+.gitignore	tooling-generated	Git ignore policy for generated and local files.
+.markdownlint-cli2.jsonc	tooling-generated	Markdownlint CLI configuration.
+.markdownlint.json	tooling-generated	Markdownlint compatibility configuration.
+.markdownlintignore	tooling-generated	Markdownlint ignore policy.
+.opencode	runtime-plugin	OpenCode runtime plugin and packaging surface.
+.qlty	tooling-generated	Qlty scanner configuration and plugin metadata.
+.qltyignore	tooling-generated	Qlty ignore policy.
+.repomixignore	tooling-generated	Repomix ignore policy.
+.secretlintignore	tooling-generated	Secretlint ignore policy.
+.secretlintrc.json	tooling-generated	Secretlint scanner configuration.
+.shellcheckrc	tooling-generated	ShellCheck configuration shared by local and CI checks.
+.task-counter	framework-internal	Atomic task ID counter used by task creation helpers.
+.wiki	docs-planning	GitHub wiki source content mirrored in the repository.
+AGENT.md	public-entrypoint	Compatibility entrypoint for runtimes that look for singular agent guidance.
+AGENTS.md	public-entrypoint	Repository-level contributor and AI guidance entrypoint.
+CHANGELOG.md	public-entrypoint	User-facing release history.
+CLAUDE.md	public-entrypoint	Claude-specific runtime guidance entrypoint.
+CODE_OF_CONDUCT.md	public-entrypoint	Community governance document.
+CONTRIBUTING.md	public-entrypoint	Contributor onboarding and contribution policy.
+CREDITS.md	public-entrypoint	Project credits and attribution.
+LICENSE	public-entrypoint	Project license.
+MODELS-PERFORMANCE.md	docs-planning	Model benchmark and performance reference.
+MODELS.md	docs-planning	Model support and routing reference.
+README.md	public-entrypoint	Primary public project documentation.
+SECURITY.md	public-entrypoint	Security reporting and support policy.
+TERMS.md	public-entrypoint	Project terms and usage policy.
+TODO.md	docs-planning	Tracked task and routine ledger.
+VERSION	public-entrypoint	Current framework version marker.
+_campaigns	repo-data-plane	Repo-local campaign data plane for AI-assisted operations.
+_cases	repo-data-plane	Repo-local case data plane for AI-assisted operations.
+_feedback	repo-data-plane	Repo-local feedback data plane placeholder.
+_inbox	repo-data-plane	Repo-local inbox data plane for intake workflows.
+_knowledge	repo-data-plane	Repo-local knowledge ingestion data plane.
+_performance	repo-data-plane	Repo-local performance data plane placeholder.
+_projects	repo-data-plane	Repo-local project data plane placeholder.
+aidevops-init-lib.sh	framework-internal	Root shell module for aidevops CLI initialization pending module cleanup.
+aidevops-repos-lib.sh	framework-internal	Root shell module for repo management pending module cleanup.
+aidevops-skills-plugin-lib.sh	framework-internal	Root shell module for skills/plugin logic pending module cleanup.
+aidevops-status-lib.sh	framework-internal	Root shell module for status reporting pending module cleanup.
+aidevops-update-lib.sh	framework-internal	Root shell module for update flow pending module cleanup.
+aidevops-upgrade-planning-lib.sh	framework-internal	Root shell module for upgrade planning pending module cleanup.
+aidevops.sh	public-entrypoint	Primary user-facing aidevops CLI entrypoint.
+bin	packaging	Executable shims and installed command surfaces.
+biome.json	tooling-generated	Biome formatter/linter configuration.
+bun.lock	packaging	JavaScript package lockfile.
+configs	framework-internal	User-facing config templates copied or referenced by setup flows.
+docs	docs-planning	General documentation surface.
+homebrew	packaging	Homebrew distribution formula and packaging assets.
+package.json	packaging	JavaScript package metadata for plugin/tooling distribution.
+repomix-instruction.md	tooling-generated	Repomix prompt/instruction input.
+repomix.config.json	tooling-generated	Repomix repository packaging configuration.
+requirements-lock.txt	packaging	Python dependency lock surface.
+requirements.txt	packaging	Python dependency declaration surface.
+scripts	packaging	Public or transitional script distribution surface outside `.agents/scripts/`.
+setup-modules	framework-internal	Setup implementation modules split from `setup.sh`.
+setup.sh	public-entrypoint	Primary installer/update entrypoint.
+sonar-project.properties	tooling-generated	SonarCloud project configuration.
+templates	framework-internal	Framework templates consumed by task and setup helpers.
+tests	framework-internal	Repository-level tests outside `.agents/scripts/tests/`.
+todo	docs-planning	Task briefs, plans, and planning artifacts.

--- a/.agents/scripts/linters-local-gates.sh
+++ b/.agents/scripts/linters-local-gates.sh
@@ -174,7 +174,32 @@ _run_gate_checks_static() {
 		echo ""
 	fi
 
+	if ! should_skip_gate "repo-layout"; then
+		check_repo_layout || exit_code=1
+		echo ""
+	fi
+
 	return $exit_code
+}
+
+check_repo_layout() {
+	echo -e "${BLUE}Checking Repository Layout Policy (warn-only drift audit)...${NC}"
+
+	local audit_script="${SCRIPT_DIR}/repo-layout-audit-helper.sh"
+	if [[ ! -x "$audit_script" ]]; then
+		print_warning "repo-layout-audit-helper.sh not found at $audit_script"
+		return 0
+	fi
+
+	local output status=0
+	output=$(bash "$audit_script" --check --warn-only 2>&1) || status=$?
+	printf '%s\n' "$output"
+	if [[ "$status" -ne 0 ]]; then
+		print_warning "Repository layout audit failed to run; not blocking local lint in warn-only mode"
+		return 0
+	fi
+
+	return 0
 }
 
 check_shell_portability() {

--- a/.agents/scripts/repo-layout-audit-helper.sh
+++ b/.agents/scripts/repo-layout-audit-helper.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# repo-layout-audit-helper.sh — non-destructive top-level repository layout audit.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 2
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" || exit 2
+POLICY_FILE="${REPO_ROOT}/.agents/configs/repo-layout-policy.conf"
+MODE="check"
+WARN_ONLY=0
+
+usage() {
+	sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
+	printf '\nUsage: repo-layout-audit-helper.sh [--check] [--warn-only] [--policy FILE] [--repo DIR]\n'
+	return 0
+}
+
+die() {
+	local msg="$1"
+	printf 'repo-layout-audit-helper.sh: ERROR: %s\n' "$msg" >&2
+	exit 2
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--check)
+			MODE="check"
+			shift
+			;;
+		--warn-only)
+			WARN_ONLY=1
+			shift
+			;;
+		--policy)
+			[[ $# -ge 2 ]] || die "--policy requires a file path"
+			POLICY_FILE="$2"
+			shift 2
+			;;
+		--repo)
+			[[ $# -ge 2 ]] || die "--repo requires a directory path"
+			REPO_ROOT="$2"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			die "unknown argument: $arg"
+			;;
+		esac
+	done
+	return 0
+}
+
+load_policy_paths() {
+	local policy="$1"
+	[[ -f "$policy" ]] || die "policy file not found: $policy"
+
+	while IFS=$'\t' read -r path class rationale extra; do
+		[[ -z "${path:-}" || "${path:0:1}" == "#" ]] && continue
+		if [[ -z "${class:-}" || -z "${rationale:-}" || -n "${extra:-}" ]]; then
+			die "invalid policy row for '$path' — expected: path<TAB>class<TAB>rationale"
+		fi
+		printf '%s\n' "$path"
+	done <"$policy"
+	return 0
+}
+
+tracked_top_level_paths() {
+	local repo="$1"
+	git -C "$repo" ls-files | while IFS= read -r tracked_path; do
+		[[ -z "$tracked_path" ]] && continue
+		printf '%s\n' "${tracked_path%%/*}"
+	done | LC_ALL=C sort -u
+	return 0
+}
+
+path_allowed() {
+	local path="$1"
+	local allowed_paths="$2"
+	grep -qxF "$path" <<<"$allowed_paths"
+	return $?
+}
+
+suggest_home() {
+	local path="$1"
+	case "$path" in
+	_* )
+		printf 'repo-local data planes should be documented in .agents/configs/repo-layout-policy.conf if intentional'
+		;;
+	*.md | *.mdx)
+		printf 'docs/ or .agents/reference/ unless this is a public root entrypoint'
+		;;
+	*.sh)
+		printf '.agents/scripts/ for framework helpers, setup-modules/ for setup internals, or root only for public entrypoints'
+		;;
+	*.json | *.jsonc | *.yml | *.yaml | *.toml | *.properties)
+		printf '.agents/configs/ for framework policy, configs/ for user templates, or tool-specific tracked config when required at root'
+		;;
+	*)
+		printf 'choose an existing policy class, then add a rationale to .agents/configs/repo-layout-policy.conf'
+		;;
+	esac
+	return 0
+}
+
+run_check() {
+	local allowed_paths tracked_paths unknown_count=0
+	allowed_paths=$(load_policy_paths "$POLICY_FILE") || return 2
+	tracked_paths=$(tracked_top_level_paths "$REPO_ROOT") || die "git ls-files failed in $REPO_ROOT"
+
+	printf 'Repository layout audit\n'
+	printf 'Policy: %s\n' "$POLICY_FILE"
+	printf 'Repo: %s\n' "$REPO_ROOT"
+	printf '\n'
+
+	local path
+	while IFS= read -r path; do
+		[[ -z "$path" ]] && continue
+		if path_allowed "$path" "$allowed_paths"; then
+			printf 'ALLOW\t%s\n' "$path"
+		else
+			unknown_count=$((unknown_count + 1))
+			printf 'UNKNOWN\t%s\t%s\n' "$path" "$(suggest_home "$path")"
+		fi
+	done <<<"$tracked_paths"
+
+	printf '\n'
+	if [[ "$unknown_count" -eq 0 ]]; then
+		print_success "Repository layout policy covers all tracked top-level paths"
+		return 0
+	fi
+
+	print_warning "Repository layout policy has ${unknown_count} unknown tracked top-level path(s)"
+	print_info "Add intentional paths to .agents/configs/repo-layout-policy.conf with a class and rationale; otherwise move files under an existing surface."
+	if [[ "$WARN_ONLY" -eq 1 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main() {
+	parse_args "$@"
+	case "$MODE" in
+	check)
+		run_check
+		return $?
+		;;
+	*)
+		die "unsupported mode: $MODE"
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-repo-layout-audit-helper.sh
+++ b/.agents/scripts/tests/test-repo-layout-audit-helper.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression tests for repo-layout-audit-helper.sh (GH#22367)
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+HELPER="${REPO_ROOT}/.agents/scripts/repo-layout-audit-helper.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf '  PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf '  FAIL: %s\n' "$name"
+	[[ -n "$detail" ]] && printf '        %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing: $needle"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "unexpected: $needle"
+	fi
+	return 0
+}
+
+assert_exit() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" -eq "$actual" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit $expected, got $actual"
+	fi
+	return 0
+}
+
+make_fixture_repo() {
+	local repo="$1"
+	mkdir -p "$repo/allowed-dir" "$repo/rogue-dir" "$repo/_cases"
+	printf 'ok\n' >"$repo/README.md"
+	printf 'ok\n' >"$repo/allowed-dir/file.txt"
+	printf 'ok\n' >"$repo/rogue.txt"
+	printf 'ok\n' >"$repo/rogue-dir/file.txt"
+	printf 'ok\n' >"$repo/_cases/case.txt"
+	git -C "$repo" init -q
+	git -C "$repo" add README.md allowed-dir rogue.txt rogue-dir _cases
+	git -C "$repo" commit -q -m 'fixture' >/dev/null 2>&1
+	return 0
+}
+
+make_policy() {
+	local policy="$1"
+	{
+		printf '# path\tclass\trationale\n'
+		printf 'README.md\tpublic-entrypoint\tPrimary docs.\n'
+		printf 'allowed-dir\tframework-internal\tKnown framework fixture directory.\n'
+		printf '_cases\trepo-data-plane\tIntentional repo-local data-plane exception.\n'
+	} >"$policy"
+	return 0
+}
+
+main() {
+	if [[ ! -x "$HELPER" ]]; then
+		printf 'helper not executable: %s\n' "$HELPER" >&2
+		exit 1
+	fi
+
+	local tmp repo policy output status warn_output warn_status clean_repo clean_policy clean_output clean_status
+	tmp=$(mktemp -d 2>/dev/null || mktemp -d -t repo-layout-audit)
+	# shellcheck disable=SC2064  # capture the concrete temp path before local tmp goes out of scope
+	trap "rm -rf '$tmp'" EXIT
+	repo="${tmp}/repo"
+	policy="${tmp}/policy.conf"
+	clean_repo="${tmp}/clean-repo"
+	clean_policy="${tmp}/clean-policy.conf"
+
+	mkdir -p "$repo" "$clean_repo"
+	make_fixture_repo "$repo"
+	make_policy "$policy"
+
+	printf '=== repo-layout-audit-helper tests ===\n\n'
+
+	output=$(bash "$HELPER" --check --repo "$repo" --policy "$policy" 2>&1)
+	status=$?
+	assert_exit "unknown top-level paths fail --check" 1 "$status"
+	assert_contains "known root file is allowed" "$output" $'ALLOW\tREADME.md'
+	assert_contains "known root directory is allowed" "$output" $'ALLOW\tallowed-dir'
+	assert_contains "intentional underscore data plane is allowed" "$output" $'ALLOW\t_cases'
+	assert_contains "unknown top-level file is reported" "$output" $'UNKNOWN\trogue.txt'
+	assert_contains "unknown top-level directory is reported" "$output" $'UNKNOWN\trogue-dir'
+	assert_contains "unknown shell/file guidance mentions policy" "$output" '.agents/configs/repo-layout-policy.conf'
+
+	warn_output=$(bash "$HELPER" --check --warn-only --repo "$repo" --policy "$policy" 2>&1)
+	warn_status=$?
+	assert_exit "warn-only mode reports drift without blocking" 0 "$warn_status"
+	assert_contains "warn-only still reports unknown path" "$warn_output" $'UNKNOWN\trogue.txt'
+
+	mkdir -p "$clean_repo/docs"
+	printf 'ok\n' >"$clean_repo/README.md"
+	printf 'ok\n' >"$clean_repo/docs/page.md"
+	git -C "$clean_repo" init -q
+	git -C "$clean_repo" add README.md docs
+	git -C "$clean_repo" commit -q -m 'clean fixture' >/dev/null 2>&1
+	{
+		printf 'README.md\tpublic-entrypoint\tPrimary docs.\n'
+		printf 'docs\tdocs-planning\tDocumentation.\n'
+	} >"$clean_policy"
+	clean_output=$(bash "$HELPER" --check --repo "$clean_repo" --policy "$clean_policy" 2>&1)
+	clean_status=$?
+	assert_exit "fully allowed fixture exits zero" 0 "$clean_status"
+	assert_not_contains "fully allowed fixture has no unknown paths" "$clean_output" 'UNKNOWN'
+
+	printf '\nTests passed: %d\nTests failed: %d\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added a documented top-level repository layout taxonomy, a tab-separated layout policy, a non-destructive audit helper, regression tests, and warn-only local lint integration.

## Files Changed

.agents/aidevops/architecture.md,.agents/configs/repo-layout-policy.conf,.agents/scripts/linters-local-gates.sh,.agents/scripts/repo-layout-audit-helper.sh,.agents/scripts/tests/test-repo-layout-audit-helper.sh,.task-counter

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: .agents/scripts/tests/test-repo-layout-audit-helper.sh; .agents/scripts/repo-layout-audit-helper.sh --check; shellcheck .agents/scripts/repo-layout-audit-helper.sh .agents/scripts/tests/test-repo-layout-audit-helper.sh .agents/scripts/linters-local-gates.sh. Attempted: .agents/scripts/linters-local.sh timed out after 240s during Secretlint after earlier gates ran.

Resolves #22367


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 15m and 237,830 tokens on this as a headless worker.