### PR TITLE
t3463: fix gh pr list REST fallback head filtering

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -331,7 +331,11 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# objects plus jq filtering, so rewriting --json calls is not semantically
 		# equivalent. Preserve gate safety by leaving those calls on GraphQL and
 		# let current-state telemetry count them as unavoidable read pressure.
-		_shim_read_has_json_flag "$@" && return 1
+		# Exception: _rest_pr_list now maps the common `gh pr list --json` contract
+		# (including --head filtering) onto REST, so it remains safe to rewrite.
+		if [[ "$_SHIM_READ_REWRITE" != "pr:list" ]]; then
+			_shim_read_has_json_flag "$@" && return 1
+		fi
 
 		# Check GraphQL budget. If above threshold, return 1 to fall through.
 		_rest_should_fallback || return 1

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -863,12 +863,43 @@ _rest_pr_view() {
 #
 # Returns the underlying gh api exit code.
 #######################################
+_rest_pr_list_json_jq() {
+	local fields="$1"
+	local user_jq="$2"
+	local projection=""
+	local field=""
+	while IFS= read -r field; do
+		[[ -z "$field" ]] && continue
+		case "$field" in
+		number) projection="${projection}${projection:+,}number: .number" ;;
+		state) projection="${projection}${projection:+,}state: .state" ;;
+		mergedAt) projection="${projection}${projection:+,}mergedAt: .merged_at" ;;
+		url) projection="${projection}${projection:+,}url: .html_url" ;;
+		title) projection="${projection}${projection:+,}title: .title" ;;
+		body) projection="${projection}${projection:+,}body: .body" ;;
+		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
+		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
+		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
+		baseRefName) projection="${projection}${projection:+,}baseRefName: .base.ref" ;;
+		headRefName) projection="${projection}${projection:+,}headRefName: .head.ref" ;;
+		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
+		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	[[ -z "$projection" ]] && projection="number: .number"
+	local jq_expr="[.[] | {${projection}}]"
+	[[ -n "$user_jq" ]] && jq_expr="${jq_expr} | ${user_jq}"
+	printf '%s' "$jq_expr"
+	return 0
+}
+
 _rest_pr_list() {
 	gh_record_call rest _rest_pr_list 2>/dev/null || true
 	local repo=""
 	local state="open"
 	local limit=30
 	local jq_expr=""
+	local json_fields=""
 	local head_branch=""
 	local base_branch=""
 
@@ -885,8 +916,8 @@ _rest_pr_list() {
 		--base=*) base_branch="${_arg#--base=}"; shift ;;
 		--limit) limit="${2:-}"; shift 2 ;;
 		--limit=*) limit="${_arg#--limit=}"; shift ;;
-		--json) shift 2 ;;
-		--json=*) shift ;;
+		--json) json_fields="${2:-}"; shift 2 ;;
+		--json=*) json_fields="${_arg#--json=}"; shift ;;
 		--jq) jq_expr="${2:-}"; shift 2 ;;
 		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
 		-q) jq_expr="${2:-}"; shift 2 ;;
@@ -903,6 +934,9 @@ _rest_pr_list() {
 	local _query="state=${state}&per_page=${limit}"
 	if [[ -n "$head_branch" ]]; then
 		local _head_encoded
+		if [[ "$head_branch" != *:* ]]; then
+			head_branch="${repo%%/*}:${head_branch}"
+		fi
 		_head_encoded=$(jq -rn --arg v "$head_branch" '$v | @uri')
 		_query="${_query}&head=${_head_encoded}"
 	fi
@@ -914,6 +948,9 @@ _rest_pr_list() {
 
 	local _path="/repos/${repo}/pulls?${_query}"
 	local _gh_cmd=(gh api "$_path")
+	if [[ -n "$json_fields" ]]; then
+		jq_expr="$(_rest_pr_list_json_jq "$json_fields" "$jq_expr")"
+	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"
 	return $?

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -62,6 +62,32 @@ cat >"$TMP/bin/gh" <<'EOF'
 for arg in "$@"; do
 	printf '%s\n' "$arg" >>"$STUB_GH_LOG"
 done
+if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+	printf '%s\n' "${STUB_RATE_LIMIT_REMAINING:-5000}"
+	exit 0
+fi
+if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
+	jq_filter=""
+	i=3
+	while [[ $i -le $# ]]; do
+		if [[ "${!i}" == "--jq" ]]; then
+			next=$((i + 1))
+			jq_filter="${!next:-}"
+			break
+		fi
+		i=$((i + 1))
+	done
+	fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337"},{"number":22343,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22343"}]'
+	if [[ "$2" == *"head=owner%3Afeature%2Fauto-20260502-135611-gh22289"* ]]; then
+		fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337"}]'
+	fi
+	if [[ -n "$jq_filter" ]]; then
+		printf '%s\n' "$fixture" | jq -c "$jq_filter"
+	else
+		printf '%s\n' "$fixture"
+	fi
+	exit 0
+fi
 EOF
 chmod +x "$TMP/bin/gh"
 
@@ -80,6 +106,7 @@ chmod +x "$TMP/scripts/gh-signature-helper.sh"
 cp "$SHIM" "$TMP/scripts/gh"
 chmod +x "$TMP/scripts/gh"
 cp "$REPO_DIR/.agents/scripts/gh-api-instrument.sh" "$TMP/scripts/gh-api-instrument.sh"
+cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-fallback.sh" "$TMP/scripts/shared-gh-wrappers-rest-fallback.sh"
 
 # Put stub gh in PATH (for shim's REAL_GH discovery) and the shim in
 # $TMP/scripts (for direct invocation in tests).
@@ -296,6 +323,26 @@ if [[ "$argv" == $'pr\nview\n123\n--repo\nowner/repo\n--json\nnumber,statusCheck
 	_pass "--json read stays on GraphQL with operation label"
 else
 	_fail "--json read GraphQL preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+# =============================================================================
+# Test 13: gh pr list --json can REST rewrite while preserving head and JSON shape
+# =============================================================================
+echo ""
+echo "Test 13: gh pr list --json REST rewrite preserves --head"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-json-pr-list.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(STUB_RATE_LIMIT_REMAINING=0 "$SHIM_RUN" pr list --repo owner/repo \
+	--head feature/auto-20260502-135611-gh22289 --state all \
+	--json number,state,mergedAt,url --jq '.[].number' 2>/dev/null || true)
+argv=$(_read_argv)
+if [[ "$output" == "22337" ]] &&
+	[[ "$argv" == *"head=owner%3Afeature%2Fauto-20260502-135611-gh22289"* ]] &&
+	grep -q $'\tgh_pr_list\trest' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "gh pr list --json uses REST fallback with qualified --head"
+else
+	_fail "gh pr list --json REST fallback" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -171,6 +171,28 @@ gh() {
 		printf '{"number":123,"title":"stub PR"}\n'
 		return 0
 	fi
+	if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
+		local jq_filter=""
+		local i=3
+		while [[ $i -le $# ]]; do
+			if [[ "${!i}" == "--jq" ]]; then
+				local next=$((i + 1))
+				jq_filter="${!next:-}"
+				break
+			fi
+			i=$((i + 1))
+		done
+		local fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337","head":{"ref":"feature/auto-20260502-135611-gh22289"},"base":{"ref":"main"}},{"number":22343,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22343","head":{"ref":"other"},"base":{"ref":"main"}}]'
+		if [[ "$2" == *"head=owner%3Afeature%2Fauto-20260502-135611-gh22289"* ]]; then
+			fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337","head":{"ref":"feature/auto-20260502-135611-gh22289"},"base":{"ref":"main"}}]'
+		fi
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$fixture" | jq -c "$jq_filter"
+		else
+			printf '%s\n' "$fixture"
+		fi
+		return 0
+	fi
 	if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+$ ]]; then
 		printf '%s\n' "${STUB_REPO_DEFAULT_BRANCH:-main}"
 		return 0
@@ -688,6 +710,25 @@ if grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null &&
 else
 	fail "gh_pr_list proactively routes to REST when GraphQL budget is low" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+# =============================================================================
+# Test 23b: gh_pr_list REST fallback preserves --head and gh-shaped JSON output
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+
+pr_list_numbers=$(gh_pr_list --repo "owner/repo" --head "feature/auto-20260502-135611-gh22289" \
+	--state all --json number,state,mergedAt,url --jq '.[].number' 2>/dev/null || true)
+
+if [[ "$pr_list_numbers" == "22337" ]] &&
+	grep -qE '^api /repos/owner/repo/pulls\?state=all&per_page=30&head=owner%3Afeature%2Fauto-20260502-135611-gh22289' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^pr list' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list REST fallback preserves --head and compact --json/--jq shape"
+else
+	fail "gh_pr_list REST fallback preserves --head and compact --json/--jq shape" \
+		"output=${pr_list_numbers} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Allows the gh shim to rewrite `gh pr list --json` through the REST fallback path when GraphQL is exhausted.
- Preserves `--head` by qualifying local branch names as `owner:branch` for the REST pulls endpoint.
- Projects REST PR fields back to the requested GitHub CLI `--json` shape before applying `--jq`.

## Verification
- `shellcheck .agents/scripts/gh .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-shim.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh`
- `.agents/scripts/tests/test-gh-shim.sh`
- `.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh`

Resolves #22344