### PR TITLE
t3470: Make manual worker origin-label ceremony REST-backed

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -332,7 +332,13 @@ _dsi_apply_dispatch_ceremony() {
 	# ensure_origin_labels_exist, producing dual-label issues when re-dispatching
 	# an origin:interactive issue (observed: t3005 session, PRs #21451–#21455).
 	if ! set_origin_label "$issue_number" "$repo_slug" "worker" >/dev/null 2>&1; then
-		_dsi_warn "Origin label update failed (non-fatal — worker will still launch; fix origin label manually if needed)"
+		_dsi_warn "Origin label update failed after REST fallback — dispatch ceremony degraded"
+		if set_issue_status "$issue_number" "$repo_slug" "available" --remove-assignee "$self_login" >/dev/null 2>&1; then
+			_dsi_warn "Ceremony degraded — origin:worker not applied; status/assignment rollback attempted"
+		else
+			_dsi_warn "Ceremony degraded — origin:worker not applied; rollback also failed; manual recovery required"
+		fi
+		return 1
 	fi
 
 	_dsi_info "Ceremony applied — status:queued, origin:worker, assignee=${self_login}"

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -394,6 +394,43 @@ fi
 #   set_origin_label 19638 owner/repo worker \
 #       --add-assignee "$worker_login"
 #######################################
+_set_origin_label_should_rest_fallback() {
+	local err_file="$1"
+	if [[ -f "$err_file" ]] && grep -qiE 'GraphQL: API rate limit( already)? exceeded|rateLimitExceeded' "$err_file" 2>/dev/null; then
+		return 0
+	fi
+	if command -v _rest_should_fallback >/dev/null 2>&1 && _rest_should_fallback; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Apply origin label mutual exclusion via REST labels endpoints.
+# Args: $1=issue/pr num, $2=repo slug, $3=new origin, $4..=extra edit flags
+#######################################
+_set_origin_label_rest() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local new_origin="$3"
+	shift 3
+	local _label
+	for _label in "${ORIGIN_LABELS[@]}"; do
+		[[ "$_label" == "$new_origin" ]] && continue
+		gh api -X DELETE "/repos/${repo_slug}/issues/${issue_num}/labels/origin:${_label}" >/dev/null 2>&1 || true
+	done
+	gh api -X POST "/repos/${repo_slug}/issues/${issue_num}/labels" \
+		-f "labels[]=origin:${new_origin}" >/dev/null 2>&1 || return 1
+	if [[ $# -gt 0 ]]; then
+		if command -v _rest_issue_edit >/dev/null 2>&1; then
+			_rest_issue_edit "$issue_num" --repo "$repo_slug" "$@" || return 1
+		else
+			return 1
+		fi
+	fi
+	return 0
+}
+
 set_origin_label() {
 	local issue_num="$1"
 	local repo_slug="$2"
@@ -456,7 +493,25 @@ set_origin_label() {
 		_flags+=("${extra_flags[@]}")
 	fi
 
-	gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
+	local _err_file
+	_err_file=$(mktemp -t aidevops-origin-label.XXXXXX) || {
+		gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
+		return $?
+	}
+	local _gh_rc=0
+	if gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>"$_err_file"; then
+		rm -f "$_err_file"
+		return 0
+	else
+		_gh_rc=$?
+	fi
+	if _set_origin_label_should_rest_fallback "$_err_file" && \
+		_set_origin_label_rest "$issue_num" "$repo_slug" "$new_origin" "${extra_flags[@]}"; then
+		rm -f "$_err_file"
+		return 0
+	fi
+	rm -f "$_err_file"
+	return "$_gh_rc"
 }
 
 #######################################

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -310,23 +310,23 @@ test_ceremony_handles_set_issue_status_failure() {
 	return 0
 }
 
-# t3007: Verify that a failing set_origin_label is non-fatal — the ceremony
-# still returns 0 and the worker launches. This mirrors the best-effort design
-# of the ceremony itself (gh API flakiness must not block dispatch).
+# t3470: Verify that a failing set_origin_label is explicit degradation — the
+# ceremony must not claim origin:worker success, and it must attempt to roll
+# back status/assignment so the issue does not sit in a misleading queued state.
 test_ceremony_origin_label_failure_is_nonfatal() {
 	reset_test_state
 	_install_mock_set_issue_status success
 	_install_mock_set_origin_label failure
 
 	local issue_meta='{"assignees":[]}'
-	local rc=0
-	_dsi_apply_dispatch_ceremony 42 owner/repo runner-self "$issue_meta" >/dev/null 2>&1 || rc=$?
+	local rc=0 output=""
+	output=$(_dsi_apply_dispatch_ceremony 42 owner/repo runner-self "$issue_meta" 2>&1) || rc=$?
 
-	# Ceremony must return 0 even when set_origin_label fails.
+	# Ceremony must return non-zero when origin:worker was not actually applied.
 	local rc_check=1
-	[[ "$rc" -eq 0 ]] && rc_check=0
-	print_result "ceremony returns 0 when set_origin_label fails (non-fatal)" "$rc_check" \
-		"expected rc=0, got rc=$rc"
+	[[ "$rc" -eq 1 ]] && rc_check=0
+	print_result "ceremony returns 1 when set_origin_label fails (degraded)" "$rc_check" \
+		"expected rc=1, got rc=$rc"
 
 	# Verify set_origin_label was still called (the attempt was made).
 	local origin_call_count
@@ -335,6 +335,20 @@ test_ceremony_origin_label_failure_is_nonfatal() {
 	local attempted=1
 	[[ "$origin_call_count" -ge 1 ]] && attempted=0
 	print_result "set_origin_label was attempted despite subsequent failure" "$attempted"
+
+	local rollback_logged=1
+	if grep -q '^set_issue_status 42 owner/repo available --remove-assignee runner-self' "$SET_ISSUE_STATUS_LOG" 2>/dev/null; then
+		rollback_logged=0
+	fi
+	print_result "ceremony attempts status/assignee rollback on origin failure" "$rollback_logged"
+
+	local degraded_msg=1 no_applied_msg=0
+	[[ "$output" == *"Ceremony degraded"* ]] && degraded_msg=0
+	[[ "$output" == *"Ceremony applied"* ]] && no_applied_msg=1
+	print_result "ceremony reports degraded launch when origin update fails" "$degraded_msg" \
+		"output: $output"
+	print_result "ceremony does not claim origin:worker when origin update fails" "$no_applied_msg" \
+		"output: $output"
 
 	return 0
 }

--- a/.agents/scripts/tests/test-origin-label-exclusion.sh
+++ b/.agents/scripts/tests/test-origin-label-exclusion.sh
@@ -53,8 +53,15 @@ MOCK_BIN_DIR="${TEST_ROOT}/mockbin"
 mkdir -p "$MOCK_BIN_DIR"
 cat >"${MOCK_BIN_DIR}/gh" <<'MOCK'
 #!/usr/bin/env bash
-# Mock gh: record all arguments and exit 0
+# Mock gh: record all arguments and optionally fail selected calls.
 printf '%s\n' "$*" >> "${GH_RECORD_FILE}"
+if [[ "${GH_FAIL_ISSUE_EDIT:-0}" == "1" && "$1" == "issue" && "$2" == "edit" ]]; then
+	printf 'GraphQL: API rate limit already exceeded for user ID 99999\n' >&2
+	exit 1
+fi
+if [[ "$1" == "api" ]] && grep -q 'issues/801/labels' "${GH_RECORD_FILE}" 2>/dev/null && grep -q 'api -X POST' "${GH_RECORD_FILE}" 2>/dev/null; then
+	exit 1
+fi
 exit 0
 MOCK
 chmod +x "${MOCK_BIN_DIR}/gh"
@@ -204,7 +211,44 @@ else
 fi
 
 # =============================================================================
-# Part 9 — Structural check: pulse-dispatch-worker-launch.sh includes sibling
+# Part 9 — GraphQL failure falls back to REST label endpoints
+# =============================================================================
+: >"$GH_RECORD_FILE"
+export GH_FAIL_ISSUE_EDIT=1 GH_FAIL_REST_LABEL_POST=0
+set_origin_label 800 "owner/repo" "worker" >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 0 ]] &&
+	grep -q 'api -X DELETE /repos/owner/repo/issues/800/labels/origin:interactive' "$GH_RECORD_FILE" 2>/dev/null &&
+	grep -q 'api -X DELETE /repos/owner/repo/issues/800/labels/origin:worker-takeover' "$GH_RECORD_FILE" 2>/dev/null &&
+	grep -q 'api -X POST /repos/owner/repo/issues/800/labels -f labels\[\]=origin:worker' "$GH_RECORD_FILE" 2>/dev/null; then
+	print_result "set_origin_label GraphQL exhaustion: REST DELETE/POST fallback succeeds" 0
+else
+	print_result "set_origin_label GraphQL exhaustion: REST DELETE/POST fallback succeeds" 1 \
+		"(rc=$rc calls: $(tr '\n' ';' <"$GH_RECORD_FILE"))"
+fi
+unset GH_FAIL_ISSUE_EDIT GH_FAIL_REST_LABEL_POST
+
+# =============================================================================
+# Part 10 — GraphQL failure + REST failure stays failed
+# =============================================================================
+: >"$GH_RECORD_FILE"
+_set_origin_label_rest() {
+	printf '%s\n' "rest fallback forced failure $*" >>"$GH_RECORD_FILE"
+	return 1
+}
+export GH_FAIL_ISSUE_EDIT=1 GH_FAIL_REST_LABEL_POST=1
+set_origin_label 801 "owner/repo" "worker" >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result "set_origin_label GraphQL exhaustion: REST failure returns non-zero" 0
+else
+	print_result "set_origin_label GraphQL exhaustion: REST failure returns non-zero" 1 \
+		"(expected non-zero, calls: $(tr '\n' ';' <"$GH_RECORD_FILE"))"
+fi
+unset GH_FAIL_ISSUE_EDIT GH_FAIL_REST_LABEL_POST
+
+# =============================================================================
+# Part 11 — Structural check: pulse-dispatch-worker-launch.sh includes sibling
 #           removal flags inline (t2200 compliance)
 # =============================================================================
 launch_file="${TEST_SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"


### PR DESCRIPTION
## Summary

REST-backed set_origin_label fallback now replaces origin labels when gh issue edit hits GraphQL exhaustion, and manual dispatch ceremony reports/rolls back degraded origin-label failures instead of claiming origin:worker.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-dispatch-single-issue-helper.sh,.agents/scripts/tests/test-origin-label-exclusion.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-origin-label-exclusion.sh; .agents/scripts/tests/test-dispatch-single-issue-helper.sh; shellcheck .agents/scripts/shared-gh-wrappers.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-origin-label-exclusion.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh

Resolves #22365


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 21m and 240,636 tokens on this as a headless worker.