### PR TITLE
t3419: Relax worker timing recovery gates

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -264,14 +264,12 @@ _validate_run_args() {
 # Caller passes the cmd array elements as positional args after the two file args.
 # Returns: 0 always (exit code written to exit_code_file).
 #
-# Includes an activity watchdog: if no LLM activity appears in the output
-# file within HEADLESS_ACTIVITY_TIMEOUT_SECONDS (default 300s), the opencode
-# process is killed. This catches rate-limited providers that cause the
-# worker to hang indefinitely waiting for an API response. Without this,
-# stalled workers consume slots permanently and rotation never fires
-# (because the retry logic only runs after the process exits).
-# GH#17442: increased from 90s to 300s — with 335 agents in the system
-# prompt, OpenCode needs 60-120s to initialize before first model output.
+# Includes an activity watchdog. The timeout is a recovery backstop, not a
+# success/failure policy: output-active, CPU-active, and CI-wait states are
+# allowed to continue until the hard elapsed cap, while explicit provider
+# failures still recover promptly. Default is 600s because OpenAI/GPT-5.x
+# workers can spend several minutes reasoning before emitting more JSON/log
+# output; 300s caused false no-output kills before implementation/PR creation.
 _invoke_opencode() {
 	local output_file="$1"
 	local exit_code_file="$2"
@@ -614,6 +612,10 @@ _handle_run_result() {
 	#   can resume the session with a continuation prompt before giving up.
 	# - 124 + no activity → rate_limit as before (provider never responded).
 	if [[ "$exit_code" -eq 124 ]]; then
+		if _activity_output_has_provider_rate_limit "$output_file"; then
+			failure_reason="rate_limit"
+			print_warning "$selected_model watchdog saw provider/rate-limit marker — classifying as rate_limit for rotation"
+		else
 		if [[ "$activity_detected" == "1" ]]; then
 			# Worker was making progress, then stalled (stream drop, hung connection).
 			# Store session ID for continuation before deleting output.
@@ -644,6 +646,7 @@ _handle_run_result() {
 		fi
 		failure_reason="rate_limit"
 		print_warning "$selected_model activity watchdog timeout (no activity) — classifying as rate_limit for rotation"
+		fi
 	else
 		failure_reason=$(classify_failure_reason "$output_file")
 	fi

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -616,36 +616,36 @@ _handle_run_result() {
 			failure_reason="rate_limit"
 			print_warning "$selected_model watchdog saw provider/rate-limit marker — classifying as rate_limit for rotation"
 		else
-		if [[ "$activity_detected" == "1" ]]; then
-			# Worker was making progress, then stalled (stream drop, hung connection).
-			# Store session ID for continuation before deleting output.
-			local discovered_session_for_continue
-			discovered_session_for_continue=$(extract_session_id_from_output "$output_file")
-			if [[ "$role" != "pulse" && -n "$discovered_session_for_continue" ]]; then
-				store_session_id "$provider" "$session_key" "$discovered_session_for_continue" "$selected_model"
-			fi
-			# t2956: Hard-kill path — proactive elapsed-time kill from the
-			# watchdog. Skip continuation, free the slot. The flag is set in
-			# _execute_run_attempt when the .watchdog_stall_killed sentinel
-			# was present alongside .watchdog_killed.
-			if [[ "${_run_watchdog_hard_killed:-0}" -eq 1 ]]; then
-				# Local to avoid duplicating the literal across the file
-				# (string-literal ratchet). The pre-existing per-session cap
-				# branch below uses the same label string.
-				local _hk_label="watchdog_stall_killed"
-				_run_result_label="$_hk_label"
-				_run_failure_reason="$_hk_label"
+			if [[ "$activity_detected" == "1" ]]; then
+				# Worker was making progress, then stalled (stream drop, hung connection).
+				# Store session ID for continuation before deleting output.
+				local discovered_session_for_continue
+				discovered_session_for_continue=$(extract_session_id_from_output "$output_file")
+				if [[ "$role" != "pulse" && -n "$discovered_session_for_continue" ]]; then
+					store_session_id "$provider" "$session_key" "$discovered_session_for_continue" "$selected_model"
+				fi
+				# t2956: Hard-kill path — proactive elapsed-time kill from the
+				# watchdog. Skip continuation, free the slot. The flag is set in
+				# _execute_run_attempt when the .watchdog_stall_killed sentinel
+				# was present alongside .watchdog_killed.
+				if [[ "${_run_watchdog_hard_killed:-0}" -eq 1 ]]; then
+					# Local to avoid duplicating the literal across the file
+					# (string-literal ratchet). The pre-existing per-session cap
+					# branch below uses the same label string.
+					local _hk_label="watchdog_stall_killed"
+					_run_result_label="$_hk_label"
+					_run_failure_reason="$_hk_label"
+					rm -f "$output_file"
+					print_warning "$selected_model watchdog hard-kill (elapsed ≥ WORKER_STALL_HARD_KILL_SECONDS) — slot freed for re-dispatch (no continuation)"
+					return 79
+				fi
+				_run_result_label="watchdog_stall_continue"
 				rm -f "$output_file"
-				print_warning "$selected_model watchdog hard-kill (elapsed ≥ WORKER_STALL_HARD_KILL_SECONDS) — slot freed for re-dispatch (no continuation)"
-				return 79
+				print_warning "$selected_model watchdog stall with prior activity — will attempt session continuation"
+				return 78
 			fi
-			_run_result_label="watchdog_stall_continue"
-			rm -f "$output_file"
-			print_warning "$selected_model watchdog stall with prior activity — will attempt session continuation"
-			return 78
-		fi
-		failure_reason="rate_limit"
-		print_warning "$selected_model activity watchdog timeout (no activity) — classifying as rate_limit for rotation"
+			failure_reason="rate_limit"
+			print_warning "$selected_model activity watchdog timeout (no activity) — classifying as rate_limit for rotation"
 		fi
 	else
 		failure_reason=$(classify_failure_reason "$output_file")

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -599,12 +599,32 @@ EOF
 # --- Section 8: Activity Watchdog (inline fallback) ---
 
 #######################################
+# Return whether output contains a known provider/rate-limit marker.
+# Returns: 0 if a marker is present, 1 otherwise.
+#######################################
+_activity_output_has_provider_rate_limit() {
+	local output_file="$1"
+	[[ -f "$output_file" ]] || return 1
+	grep -Eqi 'rate[ -]?limit|too many requests|http[[:space:]]*429|status[=: ][[:space:]]*429|quota exceeded|overloaded_error|provider.*(failed|unavailable)' "$output_file" 2>/dev/null
+}
+
+#######################################
+# Return whether output shows an intentional CI/review wait.
+# Returns: 0 if a marker is present, 1 otherwise.
+#######################################
+_activity_output_has_ci_wait() {
+	local output_file="$1"
+	[[ -f "$output_file" ]] || return 1
+	grep -Eqi 'gh pr checks|review-bot-gate|pre-merge-gate|CI check|checks? (are )?(still )?(running|pending)|waiting (for|on) (CI|checks|review|merge)|merge (is )?(slow|pending)' "$output_file" 2>/dev/null
+}
+
+#######################################
 # Activity watchdog for _invoke_opencode.
 #
-# Runs as a background process alongside the worker. Polls the output
-# file for LLM activity indicators (JSON events from opencode: text,
-# tool, reasoning, step_start). If none appear within the timeout,
-# kills the worker process.
+# Runs as a background process alongside the worker. Polls the output file for
+# growth. Timing thresholds are recovery backstops, not strict success/failure
+# policy: output-active and CI-wait states continue until the hard elapsed cap,
+# while explicit provider failures recover promptly.
 #
 # The initial output always contains the sandbox startup line (~300 bytes).
 # This is NOT activity -- it's just the executor logging. Real activity
@@ -627,7 +647,7 @@ _run_activity_watchdog() {
 	#
 	# Phase 1 (startup, default 180s): any output at all. Zero bytes = dead runtime.
 	# Phase 2 (continuous): monitors file growth. If the output file stops
-	#   growing for stall_timeout seconds, the worker is stalled -- kill it.
+	#   growing for stall_timeout seconds, classify the stall before killing it.
 	#
 	# Previous design (broken): returned 0 after first LLM activity event,
 	# never monitoring again. Workers that stalled mid-session were invisible.
@@ -684,7 +704,7 @@ _run_activity_watchdog() {
 
 		# Phase 2: continuous growth monitoring
 		if [[ "$current_size" -gt "$last_size" ]]; then
-			# File is growing -- worker is alive
+			# File is growing -- worker is output-active
 			last_size="$current_size"
 			stall_seconds=0
 		else
@@ -704,6 +724,17 @@ _run_activity_watchdog() {
 					"hard_kill: stall confirmed and total elapsed ${elapsed_total}s ≥ hard-kill threshold ${hard_kill_seconds}s (stuck at ${current_size}b) -- slot freed for re-dispatch" \
 					"$session_key" "stall_killed"
 				return 0
+			fi
+			if _activity_output_has_provider_rate_limit "$output_file"; then
+				_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
+					"provider_rate_limit: provider/rate-limit marker visible after ${stall_seconds}s stall (stuck at ${current_size}b, total elapsed ${elapsed_total}s)" "$session_key"
+				return 0
+			fi
+			if _activity_output_has_ci_wait "$output_file"; then
+				print_warning "Activity watchdog: CI-wait evidence found after ${stall_seconds}s quiet window -- deferring kill until hard backstop"
+				stall_seconds=0
+				sleep "$poll_interval"
+				continue
 			fi
 			_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
 				"stall: no output growth for ${stall_timeout}s (stuck at ${current_size}b, total elapsed ${elapsed_total}s)" "$session_key"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -619,6 +619,44 @@ _activity_output_has_ci_wait() {
 }
 
 #######################################
+# Handle a Phase 2 quiet-window threshold crossing.
+# Returns: 0 if watchdog action is complete, 1 if caller should defer.
+#######################################
+_activity_watchdog_handle_stall() {
+	local output_file="$1"
+	local worker_pid="$2"
+	local exit_code_file="$3"
+	local session_key="$4"
+	local stall_seconds="$5"
+	local current_size="$6"
+	local start_epoch="$7"
+	local hard_kill_seconds="$8"
+
+	local now_epoch elapsed_total
+	now_epoch=$(date +%s)
+	elapsed_total=$((now_epoch - start_epoch))
+
+	if [[ "$hard_kill_seconds" -gt 0 && "$elapsed_total" -ge "$hard_kill_seconds" ]]; then
+		_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
+			"hard_kill: stall confirmed and total elapsed ${elapsed_total}s ≥ hard-kill threshold ${hard_kill_seconds}s (stuck at ${current_size}b) -- slot freed for re-dispatch" \
+			"$session_key" "stall_killed"
+		return 0
+	fi
+	if _activity_output_has_provider_rate_limit "$output_file"; then
+		_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
+			"provider_rate_limit: provider/rate-limit marker visible after ${stall_seconds}s stall (stuck at ${current_size}b, total elapsed ${elapsed_total}s)" "$session_key"
+		return 0
+	fi
+	if _activity_output_has_ci_wait "$output_file"; then
+		print_warning "Activity watchdog: CI-wait evidence found after ${stall_seconds}s quiet window -- deferring kill until hard backstop"
+		return 1
+	fi
+	_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
+		"stall: no output growth for ${stall_seconds}s (stuck at ${current_size}b, total elapsed ${elapsed_total}s)" "$session_key"
+	return 0
+}
+
+#######################################
 # Activity watchdog for _invoke_opencode.
 #
 # Runs as a background process alongside the worker. Polls the output file for
@@ -713,31 +751,12 @@ _run_activity_watchdog() {
 		fi
 
 		if [[ "$stall_seconds" -ge "$stall_timeout" ]]; then
-			# t2956: Decide between passive kill (legacy → exit 78 →
-			# continuation) vs. proactive hard-kill (new → exit 79 → no
-			# continuation, slot freed) based on total elapsed time.
-			local now_epoch elapsed_total
-			now_epoch=$(date +%s)
-			elapsed_total=$((now_epoch - start_epoch))
-			if [[ "$hard_kill_seconds" -gt 0 && "$elapsed_total" -ge "$hard_kill_seconds" ]]; then
-				_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
-					"hard_kill: stall confirmed and total elapsed ${elapsed_total}s ≥ hard-kill threshold ${hard_kill_seconds}s (stuck at ${current_size}b) -- slot freed for re-dispatch" \
-					"$session_key" "stall_killed"
-				return 0
-			fi
-			if _activity_output_has_provider_rate_limit "$output_file"; then
-				_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
-					"provider_rate_limit: provider/rate-limit marker visible after ${stall_seconds}s stall (stuck at ${current_size}b, total elapsed ${elapsed_total}s)" "$session_key"
-				return 0
-			fi
-			if _activity_output_has_ci_wait "$output_file"; then
-				print_warning "Activity watchdog: CI-wait evidence found after ${stall_seconds}s quiet window -- deferring kill until hard backstop"
+			if ! _activity_watchdog_handle_stall "$output_file" "$worker_pid" "$exit_code_file" \
+				"$session_key" "$stall_seconds" "$current_size" "$start_epoch" "$hard_kill_seconds"; then
 				stall_seconds=0
 				sleep "$poll_interval"
 				continue
 			fi
-			_watchdog_kill "$worker_pid" "$exit_code_file" "$output_file" \
-				"stall: no output growth for ${stall_timeout}s (stuck at ${current_size}b, total elapsed ${elapsed_total}s)" "$session_key"
 			return 0
 		fi
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -138,6 +138,26 @@ test_headless_activity_timeout_default_matches_watchdog() {
 	return 0
 }
 
+test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait() {
+	local output_file="${TEST_ROOT}/activity-classifier.out"
+
+	printf 'OpenAI error: HTTP 429 rate limit exceeded\n' >"$output_file"
+	if _activity_output_has_provider_rate_limit "$output_file"; then
+		print_result "activity watchdog detects provider rate-limit marker" 0
+	else
+		print_result "activity watchdog detects provider rate-limit marker" 1
+	fi
+
+	printf 'waiting for CI checks to finish before merge\n' >"$output_file"
+	if _activity_output_has_ci_wait "$output_file"; then
+		print_result "activity watchdog detects CI-wait marker" 0
+	else
+		print_result "activity watchdog detects CI-wait marker" 1
+	fi
+
+	return 0
+}
+
 test_canary_uses_builtin_agent_without_default_agent() {
 	local canary_root="${TEST_ROOT}/canary-agent"
 	local fake_bin_dir="${canary_root}/bin"
@@ -760,6 +780,7 @@ main() {
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_headless_activity_timeout_default_matches_watchdog
+	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_canary_uses_builtin_agent_without_default_agent
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only

--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -458,15 +458,15 @@ done
 wait 2>/dev/null || true
 
 #######################################
-# Test 23: Runtime — CPU-active quiet worker survives beyond stall timeout
+# Test 23: Runtime — CI-wait quiet worker survives beyond stall timeout
 #######################################
 tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t watchdog-live)
 live_output="${tmp_dir}/worker.out"
 live_exit="${tmp_dir}/worker.exit"
 live_log="${tmp_dir}/lifecycle.log"
-printf 'worker started\n' >"$live_output"
+printf 'waiting for CI checks to finish before merge\n' >"$live_output"
 
-bash -c 'yes >/dev/null & wait' >/dev/null 2>&1 &
+bash -c 'while :; do sleep 1; done' >/dev/null 2>&1 &
 live_worker_pid=$!
 WORKER_LIFECYCLE_LOG="$live_log" \
 	"${SCRIPT_DIR}/worker-activity-watchdog.sh" \
@@ -481,11 +481,11 @@ live_watchdog_pid=$!
 sleep 8
 if kill -0 "$live_worker_pid" 2>/dev/null && [[ ! -f "${live_exit}.watchdog_killed" ]]; then
 	TESTS_RUN=$((TESTS_RUN + 1))
-	echo "${TEST_GREEN}PASS${TEST_NC}: 23. CPU-active quiet worker survives beyond stall timeout (long-but-live path)"
+	echo "${TEST_GREEN}PASS${TEST_NC}: 23. CI-wait quiet worker survives beyond stall timeout (long-but-live path)"
 else
 	TESTS_RUN=$((TESTS_RUN + 1))
 	TESTS_FAILED=$((TESTS_FAILED + 1))
-	echo "${TEST_RED}FAIL${TEST_NC}: 23. CPU-active quiet worker was killed despite live-work evidence"
+	echo "${TEST_RED}FAIL${TEST_NC}: 23. CI-wait quiet worker was killed despite live-work evidence"
 fi
 
 pkill -P "$live_worker_pid" 2>/dev/null || true

--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -165,11 +165,11 @@ assert_contains \
 	"$pulse_wd_source"
 
 #######################################
-# Test 7: pulse-dispatch-engine.sh timeout handler emits [lifecycle] line
+# Test 7: pulse-dispatch-lib.sh timeout handler emits [lifecycle] line
 #######################################
-dispatch_source=$(< "${SCRIPT_DIR}/pulse-dispatch-engine.sh")
+dispatch_source=$(< "${SCRIPT_DIR}/pulse-dispatch-lib.sh")
 assert_contains \
-	"7. pulse-dispatch-engine.sh per-candidate timeout emits [lifecycle] line" \
+	"7. pulse-dispatch-lib.sh per-candidate timeout emits [lifecycle] line" \
 	"reason=wait_loop_timeout_" \
 	"$dispatch_source"
 
@@ -183,7 +183,7 @@ shellcheck_pass=true
 for script in \
 	"${SCRIPT_DIR}/worker-activity-watchdog.sh" \
 	"${SCRIPT_DIR}/pulse-watchdog.sh" \
-	"${SCRIPT_DIR}/pulse-dispatch-engine.sh"; do
+	"${SCRIPT_DIR}/pulse-dispatch-lib.sh"; do
 
 	local_name="$(basename "$script")"
 	if command -v shellcheck >/dev/null 2>&1; then
@@ -220,6 +220,10 @@ assert_contains \
 	"9c. kill_reason class: no_output_stall mapped" \
 	"no_output_stall" \
 	"$watchdog_source"
+assert_contains \
+	"9d. kill_reason class: provider_rate_limit mapped" \
+	"provider_rate_limit" \
+	"$watchdog_source"
 
 #######################################
 # Test 10: Lifecycle log path is configurable via env
@@ -245,6 +249,18 @@ assert_contains \
 assert_contains \
 	"12. Deferred stall seconds tracked cumulatively" \
 	"deferred_stall_seconds=\$((deferred_stall_seconds + stall_seconds))" \
+	"$watchdog_source"
+assert_contains \
+	"12b. CPU-active defers are labeled distinctly" \
+	"reason=cpu_active" \
+	"$watchdog_source"
+assert_contains \
+	"12c. CI-wait defers are labeled distinctly" \
+	"reason=ci_wait" \
+	"$watchdog_source"
+assert_contains \
+	"12d. Output-active path is documented as live work" \
+	"output-active" \
 	"$watchdog_source"
 
 #######################################
@@ -440,6 +456,43 @@ for cleanup_pid in $descendants "$test_root_pid"; do
 	kill "$cleanup_pid" 2>/dev/null || true
 done
 wait 2>/dev/null || true
+
+#######################################
+# Test 23: Runtime — CPU-active quiet worker survives beyond stall timeout
+#######################################
+tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t watchdog-live)
+live_output="${tmp_dir}/worker.out"
+live_exit="${tmp_dir}/worker.exit"
+live_log="${tmp_dir}/lifecycle.log"
+printf 'worker started\n' >"$live_output"
+
+bash -c 'yes >/dev/null & wait' >/dev/null 2>&1 &
+live_worker_pid=$!
+WORKER_LIFECYCLE_LOG="$live_log" \
+	"${SCRIPT_DIR}/worker-activity-watchdog.sh" \
+	--output-file "$live_output" \
+	--worker-pid "$live_worker_pid" \
+	--exit-code-file "$live_exit" \
+	--stall-timeout 1 \
+	--poll-interval 1 \
+	--hard-kill-seconds 0 >/dev/null 2>&1 &
+live_watchdog_pid=$!
+
+sleep 8
+if kill -0 "$live_worker_pid" 2>/dev/null && [[ ! -f "${live_exit}.watchdog_killed" ]]; then
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "${TEST_GREEN}PASS${TEST_NC}: 23. CPU-active quiet worker survives beyond stall timeout (long-but-live path)"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 23. CPU-active quiet worker was killed despite live-work evidence"
+fi
+
+pkill -P "$live_worker_pid" 2>/dev/null || true
+kill "$live_worker_pid" "$live_watchdog_pid" 2>/dev/null || true
+wait "$live_worker_pid" 2>/dev/null || true
+wait "$live_watchdog_pid" 2>/dev/null || true
+rm -rf "$tmp_dir"
 
 #######################################
 # Summary

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -3,8 +3,9 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # worker-activity-watchdog.sh — Standalone activity watchdog for headless workers (GH#17648)
 #
-# Monitors a worker's output file for growth. Kills the worker if output
-# stalls, indicating a dropped API stream or hung runtime.
+# Monitors a worker's output file for growth. Treats timing thresholds as
+# recovery backstops: kills only when there is no evidence of live work, an
+# explicit provider failure is visible, or the hard elapsed cap is reached.
 #
 # This script runs as an INDEPENDENT process (launched via nohup) so it
 # survives the worker subshell's lifecycle changes. The previous design
@@ -13,12 +14,14 @@
 #
 # Two-phase monitoring:
 #   Phase 1 (fast, 0-30s): Any output at all. Zero bytes = dead runtime.
-#   Phase 2 (continuous):   File growth. No growth for stall_timeout = stalled.
+#   Phase 2 (continuous):   File growth. No growth for stall_timeout triggers
+#                            classification (provider failure, CI wait,
+#                            CPU-active, or no-progress) before any kill.
 #
 # On stall:
 #   - Writes WATCHDOG_KILL marker to output file
 #   - Creates .watchdog_killed sentinel (parent reads this)
-#   - Kills worker process tree (TERM, then KILL after 2s)
+#   - Kills worker process tree (TERM, then KILL after 10s)
 #   - Writes exit code 124 to exit_code_file
 #   - Posts CLAIM_RELEASED on GitHub issue (if session_key provided)
 #
@@ -31,7 +34,9 @@
 #   --exit-code-file PATH     File to write exit code 124 into
 #   --session-key KEY         Session key for claim release (optional)
 #   --repo-slug OWNER/REPO    GitHub repo slug for claim release (optional)
-#   --stall-timeout SECS      Seconds without growth before kill (default: 300)
+#   --stall-timeout SECS      Seconds without growth before recovery action
+#                             (default: 600). CPU-active and CI-wait states
+#                             defer the kill until the hard backstop.
 #   --phase1-timeout SECS     Seconds for initial output (default: 30)
 #   --poll-interval SECS      Seconds between checks (default: 10)
 #   --hard-kill-seconds SECS  Total elapsed seconds before forced hard-kill on
@@ -310,6 +315,24 @@ _get_output_size() {
 }
 
 #######################################
+# Return whether the output file contains a known rate-limit/provider-failure marker.
+# Returns: 0 if a marker is present, 1 otherwise.
+#######################################
+_output_has_provider_rate_limit() {
+	[[ -f "$OUTPUT_FILE" ]] || return 1
+	grep -Eqi 'rate[ -]?limit|too many requests|http[[:space:]]*429|status[=: ][[:space:]]*429|quota exceeded|overloaded_error|provider.*(failed|unavailable)' "$OUTPUT_FILE" 2>/dev/null
+}
+
+#######################################
+# Return whether the output file shows the worker is intentionally waiting on CI.
+# Returns: 0 if a CI-wait marker is present, 1 otherwise.
+#######################################
+_output_has_ci_wait() {
+	[[ -f "$OUTPUT_FILE" ]] || return 1
+	grep -Eqi 'gh pr checks|review-bot-gate|pre-merge-gate|CI check|checks? (are )?(still )?(running|pending)|waiting (for|on) (CI|checks|review|merge)|merge (is )?(slow|pending)' "$OUTPUT_FILE" 2>/dev/null
+}
+
+#######################################
 # Push any local-only WIP commits to origin before killing the worker.
 # Best-effort, fail-open — never blocks the kill sequence.
 #
@@ -382,6 +405,7 @@ _kill_worker() {
 	case "$reason" in
 	phase1:*) reason_class="phase1_zero_output" ;;
 	hard_kill:*) reason_class="hard_kill_stall" ;;
+	provider_rate_limit:*) reason_class="provider_rate_limit" ;;
 	stall:*) reason_class="no_output_stall" ;;
 	*) reason_class="other" ;;
 	esac
@@ -541,9 +565,10 @@ _monitor() {
 			continue
 		fi
 
-		# Phase 2: continuous growth monitoring
+		# Phase 2: continuous growth monitoring. Output growth is the cheapest
+		# live-work signal and therefore always resets the stall counter.
 		if [[ "$current_size" -gt "$last_size" ]]; then
-			# File is growing — worker is alive
+			# File is growing — worker is output-active.
 			last_size="$current_size"
 			stall_seconds=0
 		else
@@ -570,6 +595,27 @@ _monitor() {
 				return 0
 			fi
 
+			# Explicit provider failures are not live-work evidence. Rotate/recover
+			# promptly instead of letting a rate-limited process hold a worker slot.
+			if _output_has_provider_rate_limit; then
+				_kill_worker "provider_rate_limit: provider/rate-limit marker visible after ${stall_seconds}s stall (stuck at ${current_size}b, total elapsed ${elapsed_total}s)"
+				return 0
+			fi
+
+			# CI/review waits are intentionally long-lived and often quiet. Defer
+			# these stalls until the hard-kill backstop rather than killing a worker
+			# that is waiting for external checks to settle.
+			if _output_has_ci_wait; then
+				deferred_stall_seconds=$((deferred_stall_seconds + stall_seconds))
+				printf '[lifecycle] worker_stall_deferred pid=%s reason=ci_wait stall_seconds=%ss deferred_total=%ss ts=%s\n' \
+					"$WORKER_PID" "$stall_seconds" "$deferred_stall_seconds" \
+					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+					>>"$LIFECYCLE_LOG" 2>/dev/null || true
+				stall_seconds=0
+				sleep "$POLL_INTERVAL"
+				continue
+			fi
+
 			# t3056 / GH#21781: Semantic stall check — before killing,
 			# check if the worker's process tree has CPU activity. Workers
 			# doing API roundtrips, shellcheck runs, or large file reads
@@ -587,7 +633,7 @@ _monitor() {
 				# at 1500s remained as a real cap). Format aligned with the
 				# `[lifecycle] worker_killed` line emitted by _kill_worker so
 				# Phase 2 aggregation can join defer events alongside kills.
-				printf '[lifecycle] worker_stall_deferred pid=%s cpu=%s%% stall_seconds=%ss deferred_total=%ss ts=%s\n' \
+				printf '[lifecycle] worker_stall_deferred pid=%s reason=cpu_active cpu=%s%% stall_seconds=%ss deferred_total=%ss ts=%s\n' \
 					"$WORKER_PID" "$tree_cpu" "$stall_seconds" \
 					"$deferred_stall_seconds" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 					>>"$LIFECYCLE_LOG" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Treat worker timing thresholds as recovery backstops: provider failures recover promptly, CI/output/CPU-live paths defer, and watchdog reasons are classified for diagnostics.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/scripts/tests/test-watchdog-no-false-kill.sh,.agents/scripts/worker-activity-watchdog.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-watchdog-no-false-kill.sh; shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/worker-activity-watchdog.sh .agents/scripts/pulse-dispatch-lib.sh; .agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --output-md /tmp/complexity-gh22254-postrebase.md

Resolves #22254


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 21m and 330,210 tokens on this as a headless worker.