### PR TITLE
t3461: Add user-owned GitHub App auth and API routing

### DIFF
--- a/.agents/configs/github-app-auth.json.txt
+++ b/.agents/configs/github-app-auth.json.txt
@@ -1,0 +1,23 @@
+{
+  "_comment": "GitHub App auth configuration. Copy to ~/.config/aidevops/github-app-auth.json and fill non-secret IDs only.",
+  "_security": "Do not put private key material in this file or in any repo. Store the PEM under ~/.config/aidevops/keys/ with chmod 600, or store only the key path via aidevops secret set GITHUB_APP_PRIVATE_KEY_PATH.",
+  "enabled": false,
+  "app_id": "",
+  "installation_id": "",
+  "private_key_path": "",
+  "private_key_path_secret": "GITHUB_APP_PRIVATE_KEY_PATH",
+  "routing": {
+    "rest_first_when_app_configured": true,
+    "graphql_reserve_threshold": 3000,
+    "rate_limit_cache_ttl_seconds": 20
+  },
+  "permissions_required": {
+    "metadata": "read",
+    "contents": "read/write only if workers push through app-scoped automation; read is enough for most issue/PR routing",
+    "issues": "read/write",
+    "pull_requests": "read/write",
+    "checks": "read",
+    "statuses": "read",
+    "actions": "read when workflow runs/check logs are queried"
+  }
+}

--- a/.agents/reference/github-app-auth.md
+++ b/.agents/reference/github-app-auth.md
@@ -1,0 +1,83 @@
+# GitHub App Auth and API Budget Routing
+
+## Goal
+
+User-owned GitHub Apps give aidevops a separate GitHub auth principal per installation. The framework uses that principal for REST-equivalent reads/searches while preserving PAT/`gh` auth for native GitHub CLI operations and GraphQL-only semantics.
+
+## Configuration
+
+Copy `.agents/configs/github-app-auth.json.txt` to `~/.config/aidevops/github-app-auth.json` and fill only non-secret identifiers:
+
+```json
+{
+  "enabled": true,
+  "app_id": "123456",
+  "installation_id": "987654",
+  "private_key_path": "$HOME/.config/aidevops/keys/github-app.pem"
+}
+```
+
+Private key material must never be committed. Store the PEM outside repositories with `chmod 600`, or store only the key path with `aidevops secret set GITHUB_APP_PRIVATE_KEY_PATH` and set `private_key_path_secret` in the JSON template.
+
+Environment overrides are available for automation:
+
+- `AIDEVOPS_GITHUB_APP_ENABLED=1`
+- `AIDEVOPS_GITHUB_APP_ID=<app-id>`
+- `AIDEVOPS_GITHUB_APP_INSTALLATION_ID=<installation-id>`
+- `AIDEVOPS_GITHUB_APP_PRIVATE_KEY_PATH=<pem-path>`
+- `AIDEVOPS_GITHUB_APP_REST_FIRST=0|1`
+
+## Permission matrix
+
+Use least privilege and add scopes only when a workflow proves it needs them.
+
+| Permission | Minimum | Used for |
+| --- | --- | --- |
+| Metadata | Read | Repository identity and installation lookup |
+| Issues | Read/write | Issue list/view/comment/edit/status label routes |
+| Pull requests | Read/write | PR list/view/create metadata routes |
+| Contents | Read by default; write only for app-scoped push automation | Repository metadata, future app-scoped content writes |
+| Checks | Read | Check suites and check runs |
+| Commit statuses | Read | Status contexts |
+| Actions | Read when enabled | Workflow run/check log inspection |
+
+## Routing policy
+
+`github-app-auth-helper.sh` classifies operations by semantics before choosing a pool:
+
+| Operation class | Examples | Pool | Auth preference |
+| --- | --- | --- | --- |
+| GraphQL-only | node IDs, sub-issue mutation, Project v2 | GraphQL | `gh`/PAT unless a caller explicitly uses an app token |
+| REST core | issue/pr view/list, labels, comments, statuses, checks | REST core | GitHub App when configured; otherwise `gh`/PAT REST fallback |
+| REST search | issue search/list with `--search` | REST search | GitHub App when configured; otherwise `gh`/PAT search fallback |
+| Native `gh` fallback | high-level create/edit/merge flows | `gh`/PAT | Existing `gh` auth first, REST fallback on GraphQL exhaustion |
+
+Default policy is REST-first for REST-equivalent operations when app auth is configured. Set `AIDEVOPS_GITHUB_APP_REST_FIRST=0` to route through REST only when the live GraphQL budget is below `AIDEVOPS_GH_REST_FALLBACK_THRESHOLD`.
+
+## Runtime behavior
+
+- Installation tokens are cached under `~/.aidevops/cache/github-app/` with `0600` files and refreshed before expiry.
+- Rate-limit snapshots are cached per auth principal and pool for `AIDEVOPS_GITHUB_APP_RATE_LIMIT_CACHE_TTL` seconds.
+- `gh-api-instrument.sh` records path, caller, auth mode, API pool, route decision, and remaining budget.
+- When no app is configured, all existing PAT/`gh` behavior remains unchanged.
+
+## Commands
+
+```bash
+aidevops github-app-auth status --json
+aidevops github-app-auth route issue-list --json
+aidevops github-app-auth rate-limit --json
+```
+
+Status and route commands never print tokens or private key material. The `token` subcommand refuses to print an installation token unless `AIDEVOPS_GITHUB_APP_ALLOW_TOKEN_STDOUT=1` is set for an automation context that captures stdout.
+
+## Verification
+
+Run the focused tests after changing this area:
+
+```bash
+bash .agents/scripts/tests/test-github-app-auth-helper.sh
+bash .agents/scripts/tests/test-gh-api-instrument.sh
+bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+shellcheck .agents/scripts/github-app-auth-helper.sh .agents/scripts/gh-api-instrument.sh .agents/scripts/shared-gh-wrappers.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/shared-gh-wrappers-status.sh
+```

--- a/.agents/scripts/gh-api-aggregate.awk
+++ b/.agents/scripts/gh-api-aggregate.awk
@@ -3,7 +3,8 @@
 # =============================================================================
 # gh-api-aggregate.awk -- Aggregate gh API call records into JSON (t2902)
 # =============================================================================
-# Reads tab-separated log lines `<unix_ts>\t<caller>\t<path>` and writes a
+# Reads tab-separated log lines `<unix_ts>\t<caller>\t<path>` (legacy) or
+# `<unix_ts>\t<caller>\t<path>\t<auth>\t<pool>\t<decision>\t<budget>` and writes a
 # JSON report keyed by caller. Designed for BSD awk (macOS default) — does
 # not use systime() or other gawk extensions; receives `now` from the caller.
 #
@@ -22,16 +23,49 @@
 
 BEGIN { total = 0 }
 
+function emit_count_section(title, keys, counts,    n, i, j, tmp, key, swap) {
+	printf "  \"%s\": {\n", title
+	n = 0
+	for (key in keys) tmp[++n] = key
+	for (i = 2; i <= n; i++) {
+		for (j = i; j > 1 && tmp[j-1] > tmp[j]; j--) {
+			swap = tmp[j]; tmp[j] = tmp[j-1]; tmp[j-1] = swap
+		}
+	}
+	for (i = 1; i <= n; i++) {
+		key = tmp[i]
+		if (i > 1) print ","
+		printf "    \"%s\": {\"total\": %d}", key, counts[key] + 0
+	}
+	if (n > 0) print ""
+	print "  }"
+}
+
 # Sanity: skip lines that do not parse as <int>\t<caller>\t<path>
-$1 ~ /^[0-9]+$/ && NF == 3 && $1 >= cutoff {
+$1 ~ /^[0-9]+$/ && NF >= 3 && $1 >= cutoff {
 	caller = $2
 	path = $3
+	auth = (NF >= 4 && $4 != "") ? $4 : "unknown"
+	pool = (NF >= 5 && $5 != "") ? $5 : path
+	decision = (NF >= 6 && $6 != "") ? $6 : "unspecified"
+	budget = (NF >= 7) ? $7 : ""
 	callers[caller] = 1
+	auth_keys[auth] = 1
+	pool_keys[pool] = 1
+	decision_keys[decision] = 1
 	if      (path == "graphql")        graphql[caller]++
 	else if (path == "rest")           rest[caller]++
 	else if (path == "search-graphql") sg[caller]++
 	else if (path == "search-rest")    sr[caller]++
 	else                                other[caller]++
+	auth_counts[auth]++
+	pool_counts[pool]++
+	decision_counts[decision]++
+	if (budget ~ /^[0-9]+$/) {
+		budget_keys[pool] = 1
+		budget_last[pool] = budget
+		if (!(pool in budget_min) || budget + 0 < budget_min[pool] + 0) budget_min[pool] = budget
+	}
 	total++
 }
 
@@ -70,6 +104,27 @@ END {
 		printf "    }"
 	}
 	if (n > 0) print ""
+	print "  },"
+	emit_count_section("by_auth_mode", auth_keys, auth_counts)
+	print ","
+	emit_count_section("by_api_pool", pool_keys, pool_counts)
+	print ","
+	emit_count_section("by_route_decision", decision_keys, decision_counts)
+	print ","
+	print "  \"budget_by_pool\": {"
+	nb = 0
+	for (b in budget_keys) bkeys[++nb] = b
+	for (i = 2; i <= nb; i++) {
+		for (j = i; j > 1 && bkeys[j-1] > bkeys[j]; j--) {
+			t = bkeys[j]; bkeys[j] = bkeys[j-1]; bkeys[j-1] = t
+		}
+	}
+	for (i = 1; i <= nb; i++) {
+		b = bkeys[i]
+		if (i > 1) print ","
+		printf "    \"%s\": {\"min_remaining\": %d, \"last_remaining\": %d}", b, budget_min[b] + 0, budget_last[b] + 0
+	}
+	if (nb > 0) print ""
 	print "  }"
 	print "}"
 }

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -5,7 +5,8 @@
 # gh-api-instrument.sh -- Lightweight gh API call instrumentation (t2902)
 # =============================================================================
 # Records every routed gh CLI / gh api call partitioned by path (graphql, rest,
-# search-graphql, search-rest, other) and caller script. Aggregation produces
+# search-graphql, search-rest, other), auth mode, API pool, route decision, and
+# caller script. Aggregation produces
 # a JSON report at ~/.aidevops/logs/gh-api-calls-by-stage.json so heavy
 # GraphQL consumers can be identified and routed through the separate REST
 # core pool (t2574, t2689) or the Search API bucket where applicable.
@@ -29,7 +30,7 @@
 #
 # CLI usage:
 #
-#     gh-api-instrument.sh record <path> [caller]   # append a record
+#     gh-api-instrument.sh record <path> [caller] [auth] [pool] [decision] [budget]
 #     gh-api-instrument.sh report [out_path]        # aggregate to JSON
 #     gh-api-instrument.sh trim                     # rotate log if oversize
 #     gh-api-instrument.sh clear                    # wipe log + report
@@ -42,7 +43,7 @@
 #   other          — anything not covered above (counted but not partitioned)
 #
 # Log format (TSV, append-only):
-#   <unix_ts>\t<caller_basename>\t<path>
+#   <unix_ts>\t<caller_basename>\t<path>\t<auth_mode>\t<api_pool>\t<route_decision>\t<budget_remaining>
 #
 # Override env vars:
 #   AIDEVOPS_GH_API_LOG          — path to the log file (default
@@ -68,7 +69,7 @@ GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${HOME}/.aidevops/logs/gh-api-calls.log}"
 GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${HOME}/.aidevops/logs/gh-api-calls-by-stage.json}"
 GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 
-# --- gh_record_call <path> [caller] ---------------------------------------
+# --- gh_record_call <path> [caller] [auth] [pool] [decision] [budget] ------
 # Append a record to the log. Cheapest possible: one open+append.
 # Failure is silent — instrumentation must never break the host script.
 #
@@ -76,12 +77,20 @@ GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 #   $1 path   — one of: graphql | rest | search-graphql | search-rest | other
 #   $2 caller — optional; defaults to BASH_SOURCE[1] basename. Pass an
 #               explicit caller when wrapping is multiple frames deep.
+#   $3 auth   — optional auth mode: github-app | gh-pat | unknown.
+#   $4 pool   — optional API pool: graphql | rest-core | rest-search | other.
+#   $5 route  — optional route decision string.
+#   $6 budget — optional remaining budget for the route's limiting pool.
 #
 # Returns: 0 always.
 gh_record_call() {
 	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	local path="${1:-other}"
 	local caller="${2:-}"
+	local auth_mode="${3:-${AIDEVOPS_GH_AUTH_MODE:-}}"
+	local api_pool="${4:-${AIDEVOPS_GH_API_POOL:-}}"
+	local route_decision="${5:-${AIDEVOPS_GH_ROUTE_DECISION:-}}"
+	local budget_remaining="${6:-${AIDEVOPS_GH_BUDGET_REMAINING:-${_GH_LAST_GRAPHQL_REMAINING:-}}}"
 	if [[ -z "$caller" ]]; then
 		# Default: name of the script that called us. Walk up until we find
 		# a frame outside this file (tests sometimes source us; we want the
@@ -98,6 +107,28 @@ gh_record_call() {
 		[[ -z "$caller" ]] && caller="${0##*/}"
 		[[ -z "$caller" || "$caller" == "-bash" || "$caller" == "bash" ]] && caller="unknown"
 	fi
+	if [[ -z "$api_pool" ]]; then
+		case "$path" in
+		graphql | search-graphql) api_pool="graphql" ;;
+		rest) api_pool="rest-core" ;;
+		search-rest) api_pool="rest-search" ;;
+		*) api_pool="other" ;;
+		esac
+	fi
+	if [[ -z "$auth_mode" ]]; then
+		case "$api_pool" in
+		rest-core | rest-search)
+			if command -v github_app_is_configured >/dev/null 2>&1 && github_app_is_configured; then
+				auth_mode="github-app"
+			else
+				auth_mode="gh-pat"
+			fi
+			;;
+		*) auth_mode="gh-pat" ;;
+		esac
+	fi
+	[[ -z "$route_decision" ]] && route_decision="${api_pool}-selected"
+	[[ "$budget_remaining" =~ ^[0-9]+$ ]] || budget_remaining=""
 	local ts
 	# Use bash builtin printf for timestamp when available (bash 4.2+) to avoid
 	# forking a date subprocess on every call in this high-frequency path.
@@ -108,7 +139,9 @@ gh_record_call() {
 	# AIDEVOPS_GH_API_LOG="gh.log" would expand ${GH_API_LOG%/*} to "gh.log").
 	[[ "$GH_API_LOG" == */* ]] && mkdir -p "${GH_API_LOG%/*}" 2>/dev/null || true
 	# Tab-separated; printf is atomic for short lines on POSIX file systems.
-	printf '%s\t%s\t%s\n' "$ts" "$caller" "$path" >>"$GH_API_LOG" 2>/dev/null || true
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$ts" "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" "$budget_remaining" \
+		>>"$GH_API_LOG" 2>/dev/null || true
 	return 0
 }
 
@@ -220,7 +253,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 gh-api-instrument.sh — gh API call instrumentation (t2902)
 
 Subcommands:
-  record <path> [caller]   Append one record to ${GH_API_LOG##*/}
+  record <path> [caller] [auth] [pool] [decision] [budget]
+                          Append one record to ${GH_API_LOG##*/}
   report [out] [window_s]  Aggregate to JSON (default ${GH_API_REPORT##*/}, 24h)
   trim                     Rotate log if larger than \$AIDEVOPS_GH_API_LOG_MAX_LINES
   clear                    Remove log + report

--- a/.agents/scripts/github-app-auth-helper.sh
+++ b/.agents/scripts/github-app-auth-helper.sh
@@ -1,0 +1,602 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# github-app-auth-helper.sh -- User-owned GitHub App auth + API routing
+# =============================================================================
+# Provides a sourceable library and CLI for GitHub App installation tokens,
+# per-principal rate-limit cache, and semantic route decisions. Secret values are
+# never printed by status/route commands; installation tokens are only written to
+# stdout by the sourceable github_app_token* functions or when the explicit
+# AIDEVOPS_GITHUB_APP_ALLOW_TOKEN_STDOUT=1 escape hatch is set for automation.
+# =============================================================================
+
+if [[ -n "${_GITHUB_APP_AUTH_HELPER_LOADED:-}" ]]; then
+	return 0 2>/dev/null || exit 0
+fi
+_GITHUB_APP_AUTH_HELPER_LOADED=1
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+if ! command -v print_info >/dev/null 2>&1; then
+	print_info() { printf '[INFO] %s\n' "$*" >&2; return 0; }
+fi
+if ! command -v print_warning >/dev/null 2>&1; then
+	print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
+fi
+if ! command -v print_error >/dev/null 2>&1; then
+	print_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
+fi
+
+: "${AIDEVOPS_GITHUB_APP_CONFIG:=${HOME}/.config/aidevops/github-app-auth.json}"
+: "${AIDEVOPS_GITHUB_APP_CACHE_DIR:=${HOME}/.aidevops/cache/github-app}"
+: "${AIDEVOPS_GITHUB_APP_RATE_LIMIT_CACHE_TTL:=20}"
+: "${AIDEVOPS_GITHUB_APP_REST_FIRST:=1}"
+
+_github_app_bool_true() {
+	local value="${1:-}"
+	value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+	case "$value" in
+	1 | true | yes | on | enabled) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+_github_app_bool_false() {
+	local value="${1:-}"
+	value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+	case "$value" in
+	0 | false | no | off | disabled) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+_github_app_config_value() {
+	local key="$1"
+	local env_primary="${2:-}"
+	local env_secondary="${3:-}"
+	local value=""
+	if [[ -n "$env_primary" && -n "${!env_primary:-}" ]]; then
+		printf '%s\n' "${!env_primary}"
+		return 0
+	fi
+	if [[ -n "$env_secondary" && -n "${!env_secondary:-}" ]]; then
+		printf '%s\n' "${!env_secondary}"
+		return 0
+	fi
+	if [[ -f "$AIDEVOPS_GITHUB_APP_CONFIG" ]] && command -v jq >/dev/null 2>&1; then
+		value=$(jq -r --arg key "$key" '.[$key] // empty' "$AIDEVOPS_GITHUB_APP_CONFIG" 2>/dev/null || true)
+		[[ -n "$value" && "$value" != "null" ]] && printf '%s\n' "$value"
+	fi
+	return 0
+}
+
+github_app_app_id() {
+	_github_app_config_value "app_id" "AIDEVOPS_GITHUB_APP_ID" "GITHUB_APP_ID"
+	return 0
+}
+
+github_app_installation_id() {
+	_github_app_config_value "installation_id" "AIDEVOPS_GITHUB_APP_INSTALLATION_ID" "GITHUB_APP_INSTALLATION_ID"
+	return 0
+}
+
+github_app_private_key_path() {
+	local value=""
+	value=$(_github_app_config_value "private_key_path" "AIDEVOPS_GITHUB_APP_PRIVATE_KEY_PATH" "GITHUB_APP_PRIVATE_KEY_PATH")
+	if [[ -z "$value" ]]; then
+		local secret_name=""
+		secret_name=$(_github_app_config_value "private_key_path_secret" "AIDEVOPS_GITHUB_APP_PRIVATE_KEY_PATH_SECRET" "GITHUB_APP_PRIVATE_KEY_PATH_SECRET")
+		if [[ -n "$secret_name" ]] && command -v gopass >/dev/null 2>&1; then
+			value=$(gopass show -o "aidevops/${secret_name}" 2>/dev/null || true)
+		fi
+	fi
+	[[ -n "$value" ]] && printf '%s\n' "$value"
+	return 0
+}
+
+github_app_enabled() {
+	local enabled=""
+	enabled=$(_github_app_config_value "enabled" "AIDEVOPS_GITHUB_APP_ENABLED" "GITHUB_APP_ENABLED")
+	if [[ -n "$enabled" ]]; then
+		_github_app_bool_false "$enabled" && return 1
+		_github_app_bool_true "$enabled" && return 0
+	fi
+	[[ -n "$(github_app_app_id)" ]] && return 0
+	return 1
+}
+
+_github_app_cache_dir() {
+	mkdir -p "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || true
+	chmod 700 "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || true
+	printf '%s\n' "$AIDEVOPS_GITHUB_APP_CACHE_DIR"
+	return 0
+}
+
+_github_app_cache_slug() {
+	local raw="${1:-default}"
+	printf '%s\n' "$raw" | tr -c 'A-Za-z0-9_.-' '_'
+	return 0
+}
+
+_github_app_token_cache_path() {
+	local installation_id="${1:-}"
+	local cache_dir slug
+	cache_dir=$(_github_app_cache_dir)
+	slug=$(_github_app_cache_slug "${installation_id:-default}")
+	printf '%s/token-%s.json\n' "$cache_dir" "$slug"
+	return 0
+}
+
+_github_app_rate_cache_path() {
+	local auth_mode="${1:-gh-pat}"
+	local principal="${2:-default}"
+	local cache_dir mode_slug principal_slug
+	cache_dir=$(_github_app_cache_dir)
+	mode_slug=$(_github_app_cache_slug "$auth_mode")
+	principal_slug=$(_github_app_cache_slug "$principal")
+	printf '%s/rate-limit-%s-%s.json\n' "$cache_dir" "$mode_slug" "$principal_slug"
+	return 0
+}
+
+_github_app_cached_token() {
+	local installation_id="$1"
+	local cache_file token expiry now
+	cache_file=$(_github_app_token_cache_path "$installation_id")
+	[[ -f "$cache_file" ]] || return 1
+	token=$(jq -r '.token // empty' "$cache_file" 2>/dev/null || true)
+	expiry=$(jq -r '.expires_at_epoch // 0' "$cache_file" 2>/dev/null || printf '0')
+	now=$(date +%s)
+	[[ -n "$token" && "$expiry" =~ ^[0-9]+$ && $((now + 60)) -lt "$expiry" ]] || return 1
+	printf '%s\n' "$token"
+	return 0
+}
+
+_github_app_iso_to_epoch() {
+	local iso="${1:-}"
+	[[ -z "$iso" ]] && return 1
+	if command -v python3 >/dev/null 2>&1; then
+		python3 - "$iso" <<'PY' 2>/dev/null || return 1
+import datetime
+import sys
+
+value = sys.argv[1].replace('Z', '+00:00')
+print(int(datetime.datetime.fromisoformat(value).timestamp()))
+PY
+		return 0
+	fi
+	return 1
+}
+
+_github_app_cache_token() {
+	local installation_id="$1"
+	local token="$2"
+	local expires_at="${3:-}"
+	local cache_file now expiry tmp
+	cache_file=$(_github_app_token_cache_path "$installation_id")
+	now=$(date +%s)
+	expiry=$(_github_app_iso_to_epoch "$expires_at" 2>/dev/null || true)
+	[[ "$expiry" =~ ^[0-9]+$ ]] || expiry=$((now + 3300))
+	tmp="${cache_file}.$$"
+	jq -n --arg token "$token" --arg expires_at "$expires_at" --argjson expires_at_epoch "$expiry" \
+		'{token:$token, expires_at:$expires_at, expires_at_epoch:$expires_at_epoch}' >"$tmp" || return 1
+	chmod 600 "$tmp" 2>/dev/null || true
+	mv "$tmp" "$cache_file"
+	return 0
+}
+
+_github_app_base64url() {
+	base64 | tr '+/' '-_' | tr -d '=\n'
+	return 0
+}
+
+github_app_create_jwt() {
+	local app_id key_path now iat exp header payload signing_input signature
+	app_id=$(github_app_app_id)
+	key_path=$(github_app_private_key_path)
+	if [[ -z "$app_id" || -z "$key_path" || ! -r "$key_path" ]]; then
+		return 1
+	fi
+	if ! command -v openssl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+		return 1
+	fi
+	now=$(date +%s)
+	iat=$((now - 60))
+	exp=$((now + 540))
+	header=$(printf '{"alg":"RS256","typ":"JWT"}' | _github_app_base64url)
+	payload=$(jq -nc --argjson iat "$iat" --argjson exp "$exp" --arg iss "$app_id" '{iat:$iat,exp:$exp,iss:$iss}' | _github_app_base64url)
+	signing_input="${header}.${payload}"
+	signature=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$key_path" -binary 2>/dev/null | _github_app_base64url) || return 1
+	[[ -n "$signature" ]] || return 1
+	printf '%s.%s\n' "$signing_input" "$signature"
+	return 0
+}
+
+github_app_has_private_key_source() {
+	local key_path=""
+	key_path=$(github_app_private_key_path)
+	[[ -n "$key_path" && -r "$key_path" ]] && return 0
+	return 1
+}
+
+github_app_is_configured() {
+	github_app_enabled || return 1
+	[[ -n "$(github_app_app_id)" ]] || return 1
+	if github_app_has_private_key_source; then
+		return 0
+	fi
+	local installation_id=""
+	installation_id=$(github_app_installation_id)
+	[[ -n "$installation_id" ]] && _github_app_cached_token "$installation_id" >/dev/null 2>&1 && return 0
+	return 1
+}
+
+github_app_installation_id_for_repo() {
+	local repo="${1:-}"
+	local installation_id jwt
+	installation_id=$(github_app_installation_id)
+	if [[ -n "$installation_id" ]]; then
+		printf '%s\n' "$installation_id"
+		return 0
+	fi
+	[[ -n "$repo" ]] || return 1
+	jwt=$(github_app_create_jwt) || return 1
+	installation_id=$(gh api "/repos/${repo}/installation" \
+		-H "Authorization: Bearer ${jwt}" \
+		-H "Accept: application/vnd.github+json" \
+		--jq '.id // empty' 2>/dev/null || true)
+	[[ -n "$installation_id" ]] || return 1
+	printf '%s\n' "$installation_id"
+	return 0
+}
+
+github_app_exchange_token() {
+	local repo="${1:-}"
+	local installation_id jwt response token expires_at
+	installation_id=$(github_app_installation_id_for_repo "$repo") || return 1
+	jwt=$(github_app_create_jwt) || return 1
+	response=$(gh api -X POST "/app/installations/${installation_id}/access_tokens" \
+		-H "Authorization: Bearer ${jwt}" \
+		-H "Accept: application/vnd.github+json" 2>/dev/null) || return 1
+	token=$(printf '%s\n' "$response" | jq -r '.token // empty' 2>/dev/null || true)
+	expires_at=$(printf '%s\n' "$response" | jq -r '.expires_at // empty' 2>/dev/null || true)
+	[[ -n "$token" ]] || return 1
+	_github_app_cache_token "$installation_id" "$token" "$expires_at" || true
+	printf '%s\n' "$token"
+	return 0
+}
+
+github_app_token_for_repo() {
+	local repo="${1:-}"
+	local installation_id token
+	github_app_enabled || return 1
+	installation_id=$(github_app_installation_id_for_repo "$repo" 2>/dev/null || true)
+	if [[ -n "$installation_id" ]]; then
+		token=$(_github_app_cached_token "$installation_id" 2>/dev/null || true)
+		if [[ -n "$token" ]]; then
+			printf '%s\n' "$token"
+			return 0
+		fi
+	fi
+	github_app_exchange_token "$repo"
+	return $?
+}
+
+github_app_token() {
+	github_app_token_for_repo "${1:-}"
+	return $?
+}
+
+_github_app_extract_repo_from_api_args() {
+	local arg owner repo
+	for arg in "$@"; do
+		if [[ "$arg" =~ ^/repos/([^/]+/[^/?#]+)($|[/?#]) ]]; then
+			printf '%s\n' "${BASH_REMATCH[1]}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+github_app_api_call() {
+	local timeout_class="$1"
+	local api_pool="$2"
+	shift 2
+	local repo token old_token token_was_set old_auth auth_was_set old_pool pool_was_set old_route route_was_set rc
+	repo=$(_github_app_extract_repo_from_api_args "$@" 2>/dev/null || true)
+	token=$(github_app_token_for_repo "$repo" 2>/dev/null || true)
+	if [[ -z "$token" ]]; then
+		if command -v _gh_with_timeout >/dev/null 2>&1; then
+			_gh_with_timeout "$timeout_class" "$@"
+		else
+			"$@"
+		fi
+		return $?
+	fi
+	old_token="${GH_TOKEN:-}"; token_was_set="${GH_TOKEN+x}"
+	old_auth="${AIDEVOPS_GH_AUTH_MODE:-}"; auth_was_set="${AIDEVOPS_GH_AUTH_MODE+x}"
+	old_pool="${AIDEVOPS_GH_API_POOL:-}"; pool_was_set="${AIDEVOPS_GH_API_POOL+x}"
+	old_route="${AIDEVOPS_GH_ROUTE_DECISION:-}"; route_was_set="${AIDEVOPS_GH_ROUTE_DECISION+x}"
+	GH_TOKEN="$token"
+	AIDEVOPS_GH_AUTH_MODE="github-app"
+	AIDEVOPS_GH_API_POOL="$api_pool"
+	AIDEVOPS_GH_ROUTE_DECISION="${api_pool}-github-app"
+	export GH_TOKEN AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION
+	if command -v _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout "$timeout_class" "$@"
+		rc=$?
+	else
+		"$@"
+		rc=$?
+	fi
+	if [[ -n "$token_was_set" ]]; then GH_TOKEN="$old_token"; else unset GH_TOKEN; fi
+	if [[ -n "$auth_was_set" ]]; then AIDEVOPS_GH_AUTH_MODE="$old_auth"; else unset AIDEVOPS_GH_AUTH_MODE; fi
+	if [[ -n "$pool_was_set" ]]; then AIDEVOPS_GH_API_POOL="$old_pool"; else unset AIDEVOPS_GH_API_POOL; fi
+	if [[ -n "$route_was_set" ]]; then AIDEVOPS_GH_ROUTE_DECISION="$old_route"; else unset AIDEVOPS_GH_ROUTE_DECISION; fi
+	return "$rc"
+}
+
+github_app_rate_limit_json() {
+	local repo="${1:-}"
+	local requested_mode="${2:-auto}"
+	local auth_mode="gh-pat"
+	local principal="default"
+	local token=""
+	local cache_file now cached_ts response tmp
+	if [[ "$requested_mode" == "github-app" || "$requested_mode" == "auto" ]]; then
+		token=$(github_app_token_for_repo "$repo" 2>/dev/null || true)
+		if [[ -n "$token" ]]; then
+			auth_mode="github-app"
+			principal=$(github_app_installation_id_for_repo "$repo" 2>/dev/null || printf 'default')
+		fi
+	fi
+	cache_file=$(_github_app_rate_cache_path "$auth_mode" "$principal")
+	now=$(date +%s)
+	if [[ -f "$cache_file" ]]; then
+		cached_ts=$(jq -r '._aidevops_cached_at // 0' "$cache_file" 2>/dev/null || printf '0')
+		if [[ "$cached_ts" =~ ^[0-9]+$ && $((now - cached_ts)) -le "$AIDEVOPS_GITHUB_APP_RATE_LIMIT_CACHE_TTL" ]]; then
+			cat "$cache_file"
+			return 0
+		fi
+	fi
+	if [[ "$auth_mode" == "github-app" ]]; then
+		response=$(GH_TOKEN="$token" gh api rate_limit 2>/dev/null) || return 1
+	else
+		response=$(gh api rate_limit 2>/dev/null) || return 1
+	fi
+	if [[ "$response" =~ ^[0-9]+$ ]]; then
+		response=$(jq -n --argjson remaining "$response" \
+			'{resources:{graphql:{remaining:$remaining},core:{remaining:5000},search:{remaining:30}}}')
+	fi
+	tmp="${cache_file}.$$"
+	printf '%s\n' "$response" | jq --arg auth_mode "$auth_mode" --arg principal "$principal" --argjson cached_at "$now" \
+		'. + {_aidevops_auth_mode:$auth_mode, _aidevops_principal:$principal, _aidevops_cached_at:$cached_at}' >"$tmp" || return 1
+	chmod 600 "$tmp" 2>/dev/null || true
+	mv "$tmp" "$cache_file"
+	cat "$cache_file"
+	return 0
+}
+
+github_app_rate_limit_remaining() {
+	local pool="${1:-graphql}"
+	local repo="${2:-}"
+	local mode="${3:-auto}"
+	local json jq_path value
+	json=$(github_app_rate_limit_json "$repo" "$mode") || return 1
+	case "$pool" in
+	graphql) jq_path='.resources.graphql.remaining // empty' ;;
+	rest-core | core | rest) jq_path='.resources.core.remaining // empty' ;;
+	rest-search | search) jq_path='.resources.search.remaining // empty' ;;
+	*) jq_path='.resources.graphql.remaining // empty' ;;
+	esac
+	value=$(printf '%s\n' "$json" | jq -r "$jq_path" 2>/dev/null || true)
+	[[ "$value" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$value"
+	return 0
+}
+
+github_app_classify_operation() {
+	local operation="${1:-}"
+	case "$operation" in
+	graphql | graphql-only | mutation | node-id | subissue | project-v2) printf 'graphql\n' ;;
+	issue-search | search | search-issues | issue-list-search) printf 'rest-search\n' ;;
+	issue-view | issue-list | pr-view | pr-list | checks | statuses | labels | comments | read) printf 'rest-core\n' ;;
+	issue-create | issue-edit | issue-comment | pr-create | pr-merge | gh-cli | native-gh | write) printf 'gh-pat-fallback\n' ;;
+	*) printf 'gh-pat-fallback\n' ;;
+	esac
+	return 0
+}
+
+github_app_should_route_rest() {
+	local api_pool="${1:-rest-core}"
+	local operation="${2:-read}"
+	local remaining=""
+	[[ "${AIDEVOPS_GITHUB_APP_DISABLE_ROUTING:-0}" == "1" ]] && return 1
+	case "$api_pool" in
+	rest-core | rest-search) ;;
+	*) return 1 ;;
+	esac
+	if github_app_is_configured; then
+		if _github_app_bool_true "${AIDEVOPS_GITHUB_APP_REST_FIRST:-1}"; then
+			return 0
+		fi
+		remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || true)
+		if [[ "$remaining" =~ ^[0-9]+$ && "$remaining" -le "${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-3000}" ]]; then
+			return 0
+		fi
+	fi
+	[[ -n "$operation" ]] || return 1
+	return 1
+}
+
+github_app_route_json() {
+	local operation="${1:-read}"
+	local repo="${2:-}"
+	local semantic selected_pool auth_mode decision graphql_remaining core_remaining search_remaining configured
+	semantic=$(github_app_classify_operation "$operation")
+	selected_pool="$semantic"
+	auth_mode="gh-pat"
+	decision="${semantic}-selected"
+	configured=false
+	if github_app_is_configured; then
+		configured=true
+	fi
+	if [[ "$semantic" == "rest-core" || "$semantic" == "rest-search" ]]; then
+		if [[ "$configured" == "true" ]]; then
+			auth_mode="github-app"
+			decision="${semantic}-github-app-rest-first"
+		else
+			auth_mode="gh-pat"
+			decision="${semantic}-gh-rest-fallback"
+		fi
+	elif [[ "$semantic" == "graphql" ]]; then
+		decision="graphql-required"
+	else
+		selected_pool="gh-pat-fallback"
+		decision="native-gh-fallback"
+	fi
+	graphql_remaining=$(github_app_rate_limit_remaining graphql "$repo" "$auth_mode" 2>/dev/null || true)
+	core_remaining=$(github_app_rate_limit_remaining rest-core "$repo" "$auth_mode" 2>/dev/null || true)
+	search_remaining=$(github_app_rate_limit_remaining rest-search "$repo" "$auth_mode" 2>/dev/null || true)
+	jq -n \
+		--arg operation "$operation" \
+		--arg semantic "$semantic" \
+		--arg selected_pool "$selected_pool" \
+		--arg auth_mode "$auth_mode" \
+		--arg decision "$decision" \
+		--arg graphql_remaining "$graphql_remaining" \
+		--arg core_remaining "$core_remaining" \
+		--arg search_remaining "$search_remaining" \
+		--argjson configured "$configured" \
+		'{operation:$operation, semantic:$semantic, selected_pool:$selected_pool, auth_mode:$auth_mode, route_decision:$decision, configured:$configured, budgets:{graphql_remaining:$graphql_remaining, rest_core_remaining:$core_remaining, rest_search_remaining:$search_remaining}}'
+	return 0
+}
+
+github_app_status_json() {
+	local repo="${1:-}"
+	local app_id installation_id key_path configured rate_json graphql_remaining core_remaining search_remaining auth_mode
+	app_id=$(github_app_app_id)
+	installation_id=$(github_app_installation_id)
+	key_path=$(github_app_private_key_path)
+	configured=false
+	github_app_is_configured && configured=true
+	rate_json=$(github_app_rate_limit_json "$repo" auto 2>/dev/null || true)
+	auth_mode=$(printf '%s\n' "$rate_json" | jq -r '._aidevops_auth_mode // "gh-pat"' 2>/dev/null || printf 'gh-pat')
+	graphql_remaining=$(printf '%s\n' "$rate_json" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || true)
+	core_remaining=$(printf '%s\n' "$rate_json" | jq -r '.resources.core.remaining // empty' 2>/dev/null || true)
+	search_remaining=$(printf '%s\n' "$rate_json" | jq -r '.resources.search.remaining // empty' 2>/dev/null || true)
+	jq -n \
+		--arg configured "$configured" \
+		--arg app_id "$app_id" \
+		--arg installation_id "$installation_id" \
+		--arg private_key_source "$([[ -n "$key_path" ]] && printf 'file' || printf 'missing')" \
+		--arg auth_mode "$auth_mode" \
+		--arg graphql_remaining "$graphql_remaining" \
+		--arg core_remaining "$core_remaining" \
+		--arg search_remaining "$search_remaining" \
+		'{configured:($configured == "true"), app_id:$app_id, installation_id:$installation_id, private_key_source:$private_key_source, active_auth_mode:$auth_mode, budgets:{graphql_remaining:$graphql_remaining, rest_core_remaining:$core_remaining, rest_search_remaining:$search_remaining}}'
+	return 0
+}
+
+_github_app_print_status() {
+	local repo="${1:-}"
+	local json
+	json=$(github_app_status_json "$repo") || return 1
+	printf 'GitHub App auth: %s\n' "$(printf '%s\n' "$json" | jq -r 'if .configured then "configured" else "not configured" end')"
+	printf 'Active auth mode: %s\n' "$(printf '%s\n' "$json" | jq -r '.active_auth_mode')"
+	printf 'App ID: %s\n' "$(printf '%s\n' "$json" | jq -r '.app_id // empty')"
+	printf 'Installation ID: %s\n' "$(printf '%s\n' "$json" | jq -r '.installation_id // empty')"
+	printf 'Private key source: %s\n' "$(printf '%s\n' "$json" | jq -r '.private_key_source')"
+	printf 'Budgets: graphql=%s rest-core=%s rest-search=%s\n' \
+		"$(printf '%s\n' "$json" | jq -r '.budgets.graphql_remaining // "unknown"')" \
+		"$(printf '%s\n' "$json" | jq -r '.budgets.rest_core_remaining // "unknown"')" \
+		"$(printf '%s\n' "$json" | jq -r '.budgets.rest_search_remaining // "unknown"')"
+	return 0
+}
+
+_github_app_usage() {
+	cat <<'EOF'
+github-app-auth-helper.sh — GitHub App auth and API routing
+
+Subcommands:
+  status [--json] [--repo owner/repo]     Show configured auth mode and budgets
+  route <operation> [--json] [--repo r]   Show route decision for an operation
+  rate-limit [--json] [--repo owner/repo] Show cached per-pool rate-limit state
+  clear-cache                             Remove cached app tokens/rate limits
+  token [--repo owner/repo]               Print token only when AIDEVOPS_GITHUB_APP_ALLOW_TOKEN_STDOUT=1
+  help                                    Show this help
+
+Operations: issue-view, issue-list, issue-search, pr-view, pr-list,
+graphql-only, issue-create, issue-edit, issue-comment, pr-create.
+
+Configuration: copy .agents/configs/github-app-auth.json.txt to
+~/.config/aidevops/github-app-auth.json or set AIDEVOPS_GITHUB_APP_* env vars.
+EOF
+	return 0
+}
+
+_github_app_cli() {
+	local cmd="${1:-help}"
+	shift || true
+	local repo=""
+	local json=0
+	local operation=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo) repo="${2:-}"; shift 2 ;;
+		--repo=*) repo="${arg#--repo=}"; shift ;;
+		--json) json=1; shift ;;
+		*) if [[ -z "$operation" ]]; then operation="$arg"; fi; shift ;;
+		esac
+	done
+	case "$cmd" in
+	status)
+		if [[ "$json" -eq 1 ]]; then github_app_status_json "$repo"; else _github_app_print_status "$repo"; fi
+		return $?
+		;;
+	route)
+		operation="${operation:-read}"
+		if [[ "$json" -eq 1 ]]; then
+			github_app_route_json "$operation" "$repo"
+		else
+			github_app_route_json "$operation" "$repo" | jq -r '"\(.operation): \(.auth_mode) → \(.selected_pool) (\(.route_decision))"'
+		fi
+		return $?
+		;;
+	rate-limit)
+		if [[ "$json" -eq 1 ]]; then
+			github_app_rate_limit_json "$repo" auto
+		else
+			github_app_status_json "$repo" | jq -r '"graphql=\(.budgets.graphql_remaining // "unknown") rest-core=\(.budgets.rest_core_remaining // "unknown") rest-search=\(.budgets.rest_search_remaining // "unknown")"'
+		fi
+		return $?
+		;;
+	clear-cache)
+		rm -f "${AIDEVOPS_GITHUB_APP_CACHE_DIR}"/token-*.json "${AIDEVOPS_GITHUB_APP_CACHE_DIR}"/rate-limit-*.json 2>/dev/null || true
+		printf 'GitHub App auth cache cleared\n'
+		return 0
+		;;
+	token)
+		if [[ "${AIDEVOPS_GITHUB_APP_ALLOW_TOKEN_STDOUT:-0}" != "1" ]]; then
+			print_error "Refusing to print installation token without AIDEVOPS_GITHUB_APP_ALLOW_TOKEN_STDOUT=1"
+			return 2
+		fi
+		github_app_token_for_repo "$repo"
+		return $?
+		;;
+	help | --help | -h)
+		_github_app_usage
+		return 0
+		;;
+	*)
+		print_error "Unknown subcommand: $cmd"
+		_github_app_usage
+		return 2
+		;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	_github_app_cli "$@"
+fi

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -62,6 +62,7 @@ _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 _GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-3000}"
 _GH_REST_FALLBACK_RATE_LIMIT_CACHE=""
 _GH_REST_FALLBACK_RATE_LIMIT_CACHE_TS=0
+_GH_LAST_GRAPHQL_REMAINING=""
 
 #######################################
 # Execute a gh api command with optional wall-clock timeout (t2913).
@@ -72,6 +73,18 @@ _GH_REST_FALLBACK_RATE_LIMIT_CACHE_TS=0
 #######################################
 _rest_api_call() {
 	local _class="$1"; shift
+	local _pool="rest-core"
+	local _arg
+	for _arg in "$@"; do
+		case "$_arg" in
+		/search/*) _pool="rest-search" ;;
+		*) ;;
+		esac
+	done
+	if command -v github_app_api_call >/dev/null 2>&1; then
+		github_app_api_call "$_class" "$_pool" "$@"
+		return $?
+	fi
 	if command -v _gh_with_timeout >/dev/null 2>&1; then
 		_gh_with_timeout "$_class" "$@"
 	else
@@ -187,6 +200,7 @@ _rest_should_fallback() {
 		fi
 	fi
 	[[ "$remaining" =~ ^[0-9]+$ ]] || return 1
+	_GH_LAST_GRAPHQL_REMAINING="$remaining"
 	if [[ "$remaining" -le "$_GH_REST_FALLBACK_THRESHOLD" ]]; then
 		return 0
 	fi
@@ -1026,7 +1040,7 @@ _rest_issue_list() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_issue_search() {
-	gh_record_call rest _rest_issue_search 2>/dev/null || true
+	gh_record_call search-rest _rest_issue_search 2>/dev/null || true
 	local repo=""
 	local state=""
 	local search=""

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -199,7 +199,7 @@ set_issue_status() {
 #######################################
 gh_issue_view() {
 	local _first_num="${1:-}"
-	if _rest_should_fallback; then
+	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_issue_view; } || _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue view #${_first_num} to REST"
 		_rest_issue_view "$@"
 		return $?
@@ -232,7 +232,7 @@ gh_issue_view() {
 gh_pr_list() {
 	local _has_search=1
 	_rest_args_have_search "$@" || _has_search=0
-	if [[ $_has_search -eq 0 ]] && _rest_should_fallback; then
+	if [[ $_has_search -eq 0 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_list; } || _rest_should_fallback; }; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr list to REST"
 		_rest_pr_list "$@"
 		return $?
@@ -264,7 +264,7 @@ gh_pr_list() {
 #######################################
 gh_pr_view() {
 	local _first_num="${1:-}"
-	if _rest_should_fallback; then
+	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_view; } || _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr view #${_first_num} to REST"
 		_rest_pr_view "$@"
 		return $?
@@ -307,7 +307,9 @@ gh_pr_view() {
 gh_issue_list() {
 	local _has_search=1
 	_rest_args_have_search "$@" || _has_search=0
-	if _rest_should_fallback; then
+	local _pool="rest-core"
+	[[ $_has_search -eq 1 ]] && _pool="rest-search"
+	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_issue_list; } || _rest_should_fallback; then
 		if [[ $_has_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue list to /search/issues (--search preserved, t2995)"
 			_rest_issue_search "$@"

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -50,6 +50,10 @@ if ! command -v print_warning >/dev/null 2>&1; then
 	print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
 fi
 
+# t3461: optional user-owned GitHub App auth and route decisions. Source this
+# before the REST translators so _rest_api_call can use installation tokens for
+# REST core/search pools while native gh/PAT remains the fallback path.
+# Fail-open when missing so older deployed checkouts keep working.
 # t2574: REST fallback for GraphQL-exhausted gh issue wrappers (GH#20243).
 # t2689: Extended to READ paths — _rest_issue_view, _rest_issue_list.
 # t2743: Fixed CSV tokenisation for zsh compat (replaced read -ra with _rest_split_csv).
@@ -73,6 +77,10 @@ elif [[ -n "${_SC_SELF:-}" ]]; then
 	_SHARED_GH_WRAPPERS_DIR="${_SC_SELF%/*}"
 else
 	_SHARED_GH_WRAPPERS_DIR=""
+fi
+if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/github-app-auth-helper.sh" ]]; then
+	# shellcheck source=github-app-auth-helper.sh
+	source "$_SHARED_GH_WRAPPERS_DIR/github-app-auth-helper.sh"
 fi
 if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh" ]]; then
 	# shellcheck source=shared-gh-wrappers-rest-fallback.sh

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -74,11 +74,12 @@ gh_record_call graphql test-instrument
 gh_record_call search-graphql test-instrument
 gh_record_call search-rest test-instrument
 gh_record_call rest test-instrument
+gh_record_call rest test-instrument github-app rest-core rest-preferred 4999
 
 assert_file_exists "log file created" "$AIDEVOPS_GH_API_LOG"
 
 line_count=$(wc -l <"$AIDEVOPS_GH_API_LOG" | tr -d ' ')
-assert_eq "log has 5 lines" "5" "$line_count"
+assert_eq "log has 6 lines" "6" "$line_count"
 
 # --- Test 2: aggregate and validate JSON shape -------------------------
 gh_aggregate_calls
@@ -94,10 +95,10 @@ else
 fi
 
 total_calls=$(jq -r '._meta.total_calls' "$AIDEVOPS_GH_API_REPORT")
-assert_eq "report total_calls = 5" "5" "$total_calls"
+assert_eq "report total_calls = 6" "6" "$total_calls"
 
 rest_count=$(jq -r '.by_caller["test-instrument"].rest_calls' "$AIDEVOPS_GH_API_REPORT")
-assert_eq "rest_calls = 2" "2" "$rest_count"
+assert_eq "rest_calls = 3" "3" "$rest_count"
 
 graphql_count=$(jq -r '.by_caller["test-instrument"].graphql_calls' "$AIDEVOPS_GH_API_REPORT")
 assert_eq "graphql_calls = 1" "1" "$graphql_count"
@@ -108,8 +109,17 @@ assert_eq "search_graphql_calls = 1" "1" "$search_graphql_count"
 search_rest_count=$(jq -r '.by_caller["test-instrument"].search_rest_calls' "$AIDEVOPS_GH_API_REPORT")
 assert_eq "search_rest_calls = 1" "1" "$search_rest_count"
 
+app_auth_count=$(jq -r '.by_auth_mode["github-app"].total' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "github-app auth count = 1" "1" "$app_auth_count"
+
+rest_core_count=$(jq -r '.by_api_pool["rest-core"].total' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "rest-core pool count = 3" "3" "$rest_core_count"
+
+budget_min=$(jq -r '.budget_by_pool["rest-core"].min_remaining' "$AIDEVOPS_GH_API_REPORT")
+assert_eq "rest-core budget min recorded" "4999" "$budget_min"
+
 # --- Test 3: trim respects max-lines threshold ------------------------
-# Set a tiny max so we trigger a trim with our 5-line log.
+# Set a tiny max so we trigger a trim with our 6-line log.
 export AIDEVOPS_GH_API_LOG_MAX_LINES=4
 # Re-source so the env override is picked up by the GH_API_LOG_MAX_LINES
 # constant (it's evaluated at source time).

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -99,6 +99,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 GH_CALLS="${TMP}/gh_calls.log"
 GH_INFO_OUTPUT="${TMP}/info_output.log"
+GH_APP_TOKEN_CALLS="${TMP}/gh_app_token_calls.log"
 
 # Configurable stub behaviour per test via env vars:
 #   STUB_RATE_LIMIT_REMAINING  — what gh api rate_limit returns (default: 5000)
@@ -144,6 +145,7 @@ export -f _gh_with_timeout
 # Post-source stubs. Shell functions beat PATH binaries.
 gh() {
 	printf '%s\n' "$*" >>"${GH_CALLS}"
+	[[ -n "${GH_TOKEN:-}" ]] && printf '%s\n' "$GH_TOKEN" >>"${GH_APP_TOKEN_CALLS}"
 
 	# gh api rate_limit - always succeeds, returns configurable value
 	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
@@ -746,6 +748,32 @@ fi
 
 unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 27: GitHub App auth routes REST-equivalent reads through app token
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+: >"$GH_APP_TOKEN_CALLS"
+export AIDEVOPS_GITHUB_APP_CACHE_DIR="$TMP/app-cache"
+export AIDEVOPS_GITHUB_APP_ENABLED=1
+export AIDEVOPS_GITHUB_APP_ID=123
+export AIDEVOPS_GITHUB_APP_INSTALLATION_ID=456
+export AIDEVOPS_GITHUB_APP_REST_FIRST=1
+_github_app_cache_token "456" "cached-app-token" "2099-01-01T00:00:00Z"
+
+gh_issue_view 4243 --repo "owner/repo" --json number --jq '.number' >/dev/null 2>&1 || true
+
+if grep -qE '^api /repos/owner/repo/issues/4243' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^issue view 4243' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'cached-app-token' "$GH_APP_TOKEN_CALLS" 2>/dev/null; then
+	pass "GitHub App auth routes REST-equivalent issue view through app token"
+else
+	fail "GitHub App auth routes REST-equivalent issue view through app token" \
+		"GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
+fi
+
+unset AIDEVOPS_GITHUB_APP_ENABLED AIDEVOPS_GITHUB_APP_ID AIDEVOPS_GITHUB_APP_INSTALLATION_ID AIDEVOPS_GITHUB_APP_REST_FIRST
 
 # =============================================================================
 # Summary

--- a/.agents/scripts/tests/test-github-app-auth-helper.sh
+++ b/.agents/scripts/tests/test-github-app-auth-helper.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression tests for GH#22324 / t3461 GitHub App auth and routing helper.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+PASS=0
+FAIL=0
+TMP=$(mktemp -d -t github-app-auth.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+export AIDEVOPS_GITHUB_APP_CONFIG="$TMP/github-app-auth.json"
+export AIDEVOPS_GITHUB_APP_CACHE_DIR="$TMP/cache"
+export AIDEVOPS_GITHUB_APP_RATE_LIMIT_CACHE_TTL=30
+GH_CALLS="$TMP/gh-calls.log"
+
+pass() {
+	local label="$1"
+	PASS=$((PASS + 1))
+	printf '  PASS %s\n' "$label"
+	return 0
+}
+
+fail() {
+	local label="$1"
+	local detail="${2:-}"
+	FAIL=$((FAIL + 1))
+	printf '  FAIL %s\n' "$label"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	return 0
+}
+
+assert_eq() {
+	local label="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$label"
+	else
+		fail "$label" "expected=${expected} actual=${actual}"
+	fi
+	return 0
+}
+
+gh() {
+	local args="$*"
+	local first="${1:-}"
+	local second="${2:-}"
+	local fourth="${4:-}"
+	printf '%s|token=%s\n' "$args" "${GH_TOKEN:-}" >>"$GH_CALLS"
+	if [[ "$first" == "api" && "$second" == "rate_limit" ]]; then
+		printf '{"resources":{"graphql":{"remaining":4321},"core":{"remaining":4999},"search":{"remaining":29}}}\n'
+		return 0
+	fi
+	if [[ "$first" == "api" && "$second" == "/repos/owner/repo/installation" ]]; then
+		printf '{"id":456}\n'
+		return 0
+	fi
+	if [[ "$first" == "api" && "$second" == "-X" && "$fourth" =~ /app/installations/.*/access_tokens ]]; then
+		printf '{"token":"exchanged-token","expires_at":"2099-01-01T00:00:00Z"}\n'
+		return 0
+	fi
+	printf '{}\n'
+	return 0
+}
+export -f gh
+
+# shellcheck source=../github-app-auth-helper.sh
+source "${SCRIPTS_DIR}/github-app-auth-helper.sh"
+
+printf 'Running GitHub App auth helper tests\n'
+
+route_auth=$(github_app_route_json issue-list owner/repo | jq -r '.auth_mode')
+assert_eq "no app configured falls back to gh/PAT auth" "gh-pat" "$route_auth"
+
+cat >"$AIDEVOPS_GITHUB_APP_CONFIG" <<'JSON'
+{
+  "enabled": true,
+  "app_id": "123",
+  "installation_id": "456",
+  "private_key_path": ""
+}
+JSON
+
+_github_app_cache_token "456" "cached-token" "2099-01-01T00:00:00Z"
+
+if github_app_is_configured; then
+	pass "cached installation token makes app auth configured without exposing key material"
+else
+	fail "cached installation token makes app auth configured without exposing key material"
+fi
+
+token=$(github_app_token_for_repo owner/repo)
+assert_eq "token lookup returns cached token" "cached-token" "$token"
+
+status_auth=$(github_app_status_json owner/repo | jq -r '.active_auth_mode')
+assert_eq "status uses app auth when token is available" "github-app" "$status_auth"
+
+search_pool=$(github_app_route_json issue-search owner/repo | jq -r '.selected_pool')
+search_auth=$(github_app_route_json issue-search owner/repo | jq -r '.auth_mode')
+assert_eq "issue search routes to REST search pool" "rest-search" "$search_pool"
+assert_eq "issue search prefers GitHub App auth" "github-app" "$search_auth"
+
+: >"$GH_CALLS"
+github_app_api_call read rest-core gh api /repos/owner/repo/issues >/dev/null
+if grep -q 'api /repos/owner/repo/issues|token=cached-token' "$GH_CALLS" 2>/dev/null; then
+	pass "github_app_api_call injects installation token for REST API call"
+else
+	fail "github_app_api_call injects installation token for REST API call" "GH_CALLS=$(<"$GH_CALLS")"
+fi
+
+if _github_app_cli token >/dev/null 2>&1; then
+	fail "token CLI refuses stdout by default"
+else
+	pass "token CLI refuses stdout by default"
+fi
+
+printf '\nResult: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -766,6 +766,7 @@ _help_commands() {
 	echo "  email [cmd]        Email mailbox management (mailbox add/list/test/remove)"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  review-gate <cmd>  Configure review_gate.rate_limit_behavior (list/set/unset)"
+	echo "  github-app-auth    GitHub App auth setup/status and API route decisions"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
 	echo "  knowledge <cmd>    Knowledge plane management (init/status/provision)"
@@ -841,6 +842,11 @@ _help_detailed_sections() {
 	echo "  aidevops secret init         # Initialize gopass encrypted store"
 	echo "  aidevops secret import       # Import from credentials.sh to gopass"
 	echo "  aidevops secret status       # Show backend status"
+	echo ""
+	echo "GitHub App Auth:"
+	echo "  aidevops github-app-auth status --json       # Show active auth mode and budgets"
+	echo "  aidevops github-app-auth route issue-list    # Explain route decision"
+	echo "  aidevops github-app-auth rate-limit --json   # Show cached per-pool budgets"
 	echo ""
 	echo "Feature Toggles:"
 	echo "  aidevops config list         # List all toggles with current values"
@@ -1500,6 +1506,7 @@ main() {
 		esac
 		;;
 	client-format) _cmd_client_format "$@" ;;
+	github-app-auth | github-app | gh-auth) _dispatch_helper "github-app-auth-helper.sh" "github-app-auth-helper.sh" "$@" ;;
 	opencode-db | oc-db) _dispatch_helper "opencode-db-maintenance-helper.sh" "opencode-db-maintenance-helper.sh" "$@" ;;
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary

Added GitHub App installation-token auth, per-principal rate-limit caching, REST/search routing integration, CLI/status docs, and route instrumentation metadata.

## Files Changed

.agents/configs/github-app-auth.json.txt,.agents/reference/github-app-auth.md,.agents/scripts/gh-api-aggregate.awk,.agents/scripts/gh-api-instrument.sh,.agents/scripts/github-app-auth-helper.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-gh-api-instrument.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh,.agents/scripts/tests/test-github-app-auth-helper.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on changed shell files; test-github-app-auth-helper.sh; test-gh-api-instrument.sh; test-gh-wrapper-rest-fallback.sh; github-app-auth-helper.sh status --json smoke; git diff --check

Resolves #22324


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 30m and 283,863 tokens on this as a headless worker.