### PR TITLE
GH#22356: clarify dispatch claim ownership

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -26,6 +26,23 @@ Pulse cycle (every 3 min, configurable)
     → On failure: CLAIM_RELEASED posted, issue available for re-dispatch
 ```
 
+### Dispatch claim comment states
+
+Use the issue timeline to distinguish expected dispatch ownership from noisy
+claim loops:
+
+| Signal | Meaning | Expected next evidence |
+|---|---|---|
+| `DISPATCH_CLAIM ...` | A runner entered the cross-runner claim window. | Either `CLAIM_WON` in pulse logs followed by a `Dispatching worker` comment, or a later `CLAIM_DEFERRED` / `CLAIM_LOST` diagnostic. |
+| `Dispatching worker ...` with no later terminal marker | Active worker ownership. It blocks re-dispatch for the normal dispatch TTL, then for the extended non-terminal worker window (`DISPATCH_ACTIVE_WORKER_MAX_AGE`, default 7200s). | Worker log growth, PR creation, `MERGE_SUMMARY`, `CLAIM_RELEASED`, `Worker failed`, or watchdog output. |
+| `DISPATCH_CLAIM ... reason=stale_worker_takeover prior_dispatch_age_s=<n> no_terminal=true` | A later runner is deliberately taking over after the extended non-terminal worker window expired. This is not a bare duplicate claim. | A fresh `Dispatching worker` comment or a deterministic skip/failure reason. |
+| `CLAIM_RELEASED ...` / `MERGE_SUMMARY` / `Worker failed` / `Worker Watchdog Kill` / `BLOCKED` | Terminal ownership marker. Prior dispatch comments no longer block. | Re-dispatch is safe if the issue remains open and eligible. |
+
+A repeated bare `DISPATCH_CLAIM` without `Dispatching worker`, `CLAIM_DEFERRED`,
+`reason=stale_worker_takeover`, or a terminal marker is still a claim lifecycle
+bug. Diagnose with `dispatch-dedup-helper.sh is-assigned <issue> <slug>
+<runner>` and the pulse dispatch stage ledger before attributing a worker outage.
+
 ## Manual Worker Launch
 
 Use `aidevops launch-worker` when an operator needs a controlled headless

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -193,6 +193,7 @@ _resolve_version() {
 #   $3 = runner login
 #   $4 = nonce
 #   $5 = ISO timestamp
+#   $6 = optional reason fields (space-separated key=value tokens)
 # Returns:
 #   exit 0 + comment ID on stdout if posted
 #   exit 1 on failure
@@ -203,6 +204,7 @@ _post_claim() {
 	local runner="$3"
 	local nonce="$4"
 	local ts="$5"
+	local reason_fields="${6:-}"
 
 	# t2401: include framework version so peers can filter claims from older runners.
 	local version
@@ -210,6 +212,9 @@ _post_claim() {
 
 	local body
 	body="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version}"
+	if [[ -n "$reason_fields" ]]; then
+		body+=" ${reason_fields}"
+	fi
 
 	local comment_id
 	comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
@@ -226,6 +231,89 @@ _post_claim() {
 	fi
 
 	printf '%s' "$comment_id"
+	return 0
+}
+
+#######################################
+# Detect whether a new claim would be taking over a non-terminal worker.
+#
+# A dispatch comment without a later terminal marker is active ownership for
+# DISPATCH_ACTIVE_WORKER_MAX_AGE seconds. The dedup layer suppresses those
+# claims. If that extended window has expired, annotate the next claim so the
+# public issue thread shows a stale-worker takeover instead of a bare claim.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+# Returns: reason key=value tokens on stdout, or empty string.
+#######################################
+_detect_stale_worker_takeover_reason() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local active_worker_max_age="${DISPATCH_ACTIVE_WORKER_MAX_AGE:-7200}"
+	[[ "$active_worker_max_age" =~ ^[0-9]+$ ]] || active_worker_max_age=7200
+
+	local comments_json
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--jq '[.[] | {body_start: (.body[:300]), created_at: .created_at}]' \
+		2>/dev/null) || {
+		printf '%s' ""
+		return 0
+	}
+
+	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
+		printf '%s' ""
+		return 0
+	fi
+
+	local last_dispatch_json dispatch_created_at
+	last_dispatch_json=$(printf '%s' "$comments_json" | jq -c '
+		[.[] | select((.body_start // "") | startswith("Dispatching worker"))]
+		| sort_by(.created_at) | reverse | first // empty
+	' 2>/dev/null) || last_dispatch_json=""
+	if [[ -z "$last_dispatch_json" || "$last_dispatch_json" == "null" ]]; then
+		printf '%s' ""
+		return 0
+	fi
+
+	dispatch_created_at=$(printf '%s' "$last_dispatch_json" | jq -r '.created_at // ""' 2>/dev/null) || dispatch_created_at=""
+	[[ -n "$dispatch_created_at" ]] || { printf '%s' ""; return 0; }
+
+	local has_terminal
+	has_terminal=$(printf '%s' "$comments_json" | jq -r --arg dispatch_ts "$dispatch_created_at" '
+		[.[] | select(
+			.created_at > $dispatch_ts and (
+				(.body_start | test("TASK_COMPLETE"; "i")) or
+				(.body_start | test("FULL_LOOP_COMPLETE"; "i")) or
+				(.body_start | test("Worker failed"; "i")) or
+				(.body_start | test("Worker Watchdog Kill"; "i")) or
+				(.body_start | test("BLOCKED"; "i")) or
+				(.body_start | test("Kill signal sent"; "i")) or
+				(.body_start | test("Closes #"; "i")) or
+				(.body_start | test("gh pr merge"; "i")) or
+				(.body_start | test("MERGE_SUMMARY"; "i")) or
+				(.body_start | test("Stale assignment recovered"; "i")) or
+				(.body_start | test("CLAIM_RELEASED"; "i"))
+			)
+		)] | length
+	' 2>/dev/null) || has_terminal=0
+	if [[ "$has_terminal" -gt 0 ]]; then
+		printf '%s' ""
+		return 0
+	fi
+
+	local dispatch_epoch now_epoch age
+	dispatch_epoch=$(_iso_to_epoch "$dispatch_created_at")
+	now_epoch=$(_now_epoch)
+	[[ "$dispatch_epoch" =~ ^[0-9]+$ ]] || dispatch_epoch=0
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+	age=$((now_epoch - dispatch_epoch))
+	if [[ "$age" -ge "$active_worker_max_age" ]]; then
+		printf 'reason=stale_worker_takeover prior_dispatch_age_s=%s no_terminal=true' "$age"
+		return 0
+	fi
+
+	printf '%s' ""
 	return 0
 }
 
@@ -730,7 +818,10 @@ cmd_claim() {
 
 	# Step 1: Post claim
 	local comment_id
-	comment_id=$(_post_claim "$issue_number" "$repo_slug" "$runner" "$nonce" "$ts") || {
+	local claim_reason
+	claim_reason=$(_detect_stale_worker_takeover_reason "$issue_number" "$repo_slug")
+
+	comment_id=$(_post_claim "$issue_number" "$repo_slug" "$runner" "$nonce" "$ts" "$claim_reason") || {
 		echo "CLAIM_ERROR: failed to post claim — proceeding (fail-open)" >&2
 		return 2
 	}

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1355,8 +1355,7 @@ enumerate_blockers() {
 # PR evidence dedup check functions are in dispatch-dedup-pr.sh (GH#18916).
 
 #######################################
-# Check whether a single dispatch comment is still active (within TTL and
-# backed by a live local worker process).
+# Check whether a single dispatch comment is still active.
 #
 # GH#16626: Process liveness check — if the comment is within TTL but no
 # worker process is running for this issue locally, the worker completed or
@@ -1407,6 +1406,8 @@ _is_dispatch_comment_active() {
 	local issue_number="$3"
 	local now_epoch="$4"
 	local max_age="$5"
+	local active_worker_max_age="${DISPATCH_ACTIVE_WORKER_MAX_AGE:-7200}"
+	[[ "$active_worker_max_age" =~ ^[0-9]+$ ]] || active_worker_max_age=7200
 
 	[[ -z "$created_at" ]] && return 1
 
@@ -1416,11 +1417,19 @@ _is_dispatch_comment_active() {
 		printf '%s' "0")
 	local age=$((now_epoch - comment_epoch))
 
-	# GH#17503: Straight TTL check — no pgrep escape hatch, no grace period.
-	# The dispatch comment blocks re-dispatch for the full TTL duration.
-	# Comments are never deleted (audit trail); they just stop blocking
-	# after max_age expires, allowing a fresh dispatch attempt.
-	[[ "$age" -ge "$max_age" ]] && return 1
+	# GH#22356: the soft dispatch-comment TTL is only the normal claim window.
+	# A deterministic dispatch comment with no later terminal marker still means
+	# a worker may be live on another runner. Keep blocking until the extended
+	# non-terminal worker window expires; after that, a later claim path can emit
+	# an explicit stale-worker takeover reason instead of a bare DISPATCH_CLAIM.
+	if [[ "$age" -ge "$max_age" ]]; then
+		if [[ "$age" -lt "$active_worker_max_age" ]]; then
+			printf 'non-terminal dispatch comment by %s posted %ds ago on issue #%s (soft TTL expired; active-worker window: %ds remaining)\n' \
+				"$author" "$age" "$issue_number" "$((active_worker_max_age - age))"
+			return 0
+		fi
+		return 1
+	fi
 
 	printf 'dispatch comment by %s posted %ds ago on issue #%s (TTL: %ds remaining)\n' \
 		"$author" "$age" "$issue_number" "$((max_age - age))"

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -149,6 +149,103 @@ EOF
 	return 0
 }
 
+#######################################
+# Build a mock gh executable for stale-worker takeover claim tests.
+# Uses env vars:
+#   MOCK_GH_STATE_DIR, MOCK_DISPATCH_CREATED_AT, MOCK_CLAIM_CREATED_AT
+# Returns: path to mock gh directory via stdout
+#######################################
+create_stale_worker_mock_gh() {
+	local state_dir="$1"
+	local terminal_body="${2:-}"
+	local mock_bin_dir
+	mock_bin_dir="${state_dir}/bin"
+	mkdir -p "$mock_bin_dir"
+
+	cat >"${mock_bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+local_state_dir="${MOCK_GH_STATE_DIR:?}"
+post_body_file="${local_state_dir}/post_body.txt"
+terminal_body="${MOCK_TERMINAL_BODY:-}"
+
+if [[ "${1:-}" != "api" ]]; then
+	exit 1
+fi
+shift
+
+endpoint="${1:-}"
+shift || true
+
+if [[ "$endpoint" == "user" ]]; then
+	printf 'mockrunner\n'
+	exit 0
+fi
+
+if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
+	method="GET"
+	body=""
+	while [[ "$#" -gt 0 ]]; do
+		case "$1" in
+		--method)
+			method="$2"
+			shift 2
+			;;
+		--field)
+			if [[ "$2" == body=* ]]; then
+				body="${2#body=}"
+			fi
+			shift 2
+			;;
+		--jq)
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ "$method" == "POST" ]]; then
+		printf '%s' "$body" >"$post_body_file"
+		printf '999\n'
+		exit 0
+	fi
+
+	if [[ -f "$post_body_file" ]]; then
+		new_body=$(<"$post_body_file")
+	else
+		new_body=""
+	fi
+
+	if [[ -n "$terminal_body" ]]; then
+		printf '[{"id":10,"body_start":"Dispatching worker (PID 12345)","body":"Dispatching worker (PID 12345)","created_at":"%s"},{"id":11,"body_start":"%s","body":"%s","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
+			"${MOCK_DISPATCH_CREATED_AT:?}" \
+			"$terminal_body" \
+			"$terminal_body" \
+			"${MOCK_TERMINAL_CREATED_AT:?}" \
+			"$new_body" \
+			"$new_body" \
+			"${MOCK_CLAIM_CREATED_AT:?}"
+		exit 0
+	fi
+
+	printf '[{"id":10,"body_start":"Dispatching worker (PID 12345)","body":"Dispatching worker (PID 12345)","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
+		"${MOCK_DISPATCH_CREATED_AT:?}" \
+		"$new_body" \
+		"$new_body" \
+		"${MOCK_CLAIM_CREATED_AT:?}"
+	exit 0
+fi
+
+exit 1
+EOF
+	chmod +x "${mock_bin_dir}/gh"
+	MOCK_TERMINAL_BODY="$terminal_body" printf '%s' "$mock_bin_dir"
+	return 0
+}
+
 print_result() {
 	local test_name="$1"
 	local passed="$2"
@@ -327,15 +424,16 @@ test_claim_rejects_stale_same_runner_claim() {
 		print_result "stale same-runner claim emits CLAIM_STALE_SELF" 1 "output: $output"
 	fi
 
-	# Both the stale claim (id=1) and fresh claim (id=999) should be deleted
-	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -q '^1$' "${tmp_dir}/delete_ids.log" && grep -q '^999$' "${tmp_dir}/delete_ids.log"; then
-		print_result "stale self-claim deletes both stale and fresh claims" 0
+	# GH#17503: claim comments are retained for audit; stale same-runner claims
+	# are rejected without deleting either the old or the fresh comment.
+	if [[ ! -f "${tmp_dir}/delete_ids.log" ]]; then
+		print_result "stale self-claim retains audit comments" 0
 	else
 		local delete_log=""
 		if [[ -f "${tmp_dir}/delete_ids.log" ]]; then
 			delete_log=$(<"${tmp_dir}/delete_ids.log")
 		fi
-		print_result "stale self-claim deletes both stale and fresh claims" 1 "deleted: ${delete_log:-none}"
+		print_result "stale self-claim retains audit comments" 1 "deleted: ${delete_log:-none}"
 	fi
 
 	rm -rf "$tmp_dir"
@@ -384,16 +482,110 @@ test_claim_rejects_fresh_same_runner_claim() {
 		print_result "fresh same-runner claim emits CLAIM_STALE_SELF" 1 "output: $output"
 	fi
 
-	# Both claims should be deleted
-	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -q '^1$' "${tmp_dir}/delete_ids.log" && grep -q '^999$' "${tmp_dir}/delete_ids.log"; then
-		print_result "fresh same-runner deletes both claims" 0
+	# GH#17503: claim comments are retained for audit; duplicate same-runner
+	# claims are rejected without deleting either comment.
+	if [[ ! -f "${tmp_dir}/delete_ids.log" ]]; then
+		print_result "fresh same-runner retains audit comments" 0
 	else
 		local delete_log=""
 		if [[ -f "${tmp_dir}/delete_ids.log" ]]; then
 			delete_log=$(<"${tmp_dir}/delete_ids.log")
 		fi
-		print_result "fresh same-runner deletes both claims" 1 "deleted: ${delete_log:-none}"
+		print_result "fresh same-runner retains audit comments" 1 "deleted: ${delete_log:-none}"
 	fi
+	return 0
+}
+
+#######################################
+# Test: stale worker takeover claims are annotated (GH#22356)
+#######################################
+test_claim_marks_stale_worker_takeover() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_stale_worker_mock_gh "$tmp_dir")"
+
+	local dispatch_created_at claim_created_at output exit_code
+	dispatch_created_at="$(iso_seconds_ago 120)"
+	claim_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_DISPATCH_CREATED_AT="$dispatch_created_at" \
+		MOCK_CLAIM_CREATED_AT="$claim_created_at" \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_ACTIVE_WORKER_MAX_AGE=60 \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "stale worker takeover claim exits 0" 0
+	else
+		print_result "stale worker takeover claim exits 0" 1 "got exit $exit_code output: $output"
+	fi
+
+	local post_body=""
+	if [[ -f "${tmp_dir}/post_body.txt" ]]; then
+		post_body=$(<"${tmp_dir}/post_body.txt")
+	fi
+	if printf '%s' "$post_body" | grep -q 'reason=stale_worker_takeover'; then
+		print_result "stale worker takeover claim includes reason" 0
+	else
+		print_result "stale worker takeover claim includes reason" 1 "body: ${post_body:-none}"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+#######################################
+# Test: terminal worker comments suppress stale takeover annotation (GH#22356)
+#######################################
+test_claim_skips_takeover_reason_after_terminal() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_stale_worker_mock_gh "$tmp_dir" "CLAIM_RELEASED reason=worker_complete")"
+
+	local dispatch_created_at terminal_created_at claim_created_at output exit_code
+	dispatch_created_at="$(iso_seconds_ago 120)"
+	terminal_created_at="$(iso_seconds_ago 30)"
+	claim_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_DISPATCH_CREATED_AT="$dispatch_created_at" \
+		MOCK_TERMINAL_CREATED_AT="$terminal_created_at" \
+		MOCK_TERMINAL_BODY="CLAIM_RELEASED reason=worker_complete" \
+		MOCK_CLAIM_CREATED_AT="$claim_created_at" \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_ACTIVE_WORKER_MAX_AGE=60 \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "terminal worker claim exits 0" 0
+	else
+		print_result "terminal worker claim exits 0" 1 "got exit $exit_code output: $output"
+	fi
+
+	local post_body=""
+	if [[ -f "${tmp_dir}/post_body.txt" ]]; then
+		post_body=$(<"${tmp_dir}/post_body.txt")
+	fi
+	if printf '%s' "$post_body" | grep -q 'reason=stale_worker_takeover'; then
+		print_result "terminal worker claim omits takeover reason" 1 "body: $post_body"
+	else
+		print_result "terminal worker claim omits takeover reason" 0
+	fi
+
+	rm -rf "$tmp_dir"
 	return 0
 }
 
@@ -413,6 +605,8 @@ main() {
 	test_env_var_defaults
 	test_claim_rejects_stale_same_runner_claim
 	test_claim_rejects_fresh_same_runner_claim
+	test_claim_marks_stale_worker_takeover
+	test_claim_skips_takeover_reason_after_terminal
 
 	echo ""
 	echo "Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed"

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -45,6 +45,7 @@ setup_test_env() {
 
 	mkdir -p "${TEST_ROOT}/bin"
 	mkdir -p "${TEST_ROOT}/config/aidevops"
+	export HOME="$TEST_ROOT"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 
 	# Create a repos.json with a known maintainer
@@ -143,6 +144,32 @@ if [[ "\${1:-}" == "issue" && ("\${2:-}" == "edit" || "\${2:-}" == "comment") ]]
 fi
 
 printf 'unsupported gh invocation in test stub: %s\n' "\$*" >&2
+exit 1
+GHEOF
+
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+create_dispatch_comment_gh_stub() {
+	local dispatch_created_at="$1"
+	local terminal_body="${2:-}"
+	local terminal_created_at="${3:-}"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -q '/comments'; then
+	if [[ -n "${terminal_body}" ]]; then
+		printf '%s\n' '[{"created_at":"${dispatch_created_at}","author":"runner1","body_start":"Dispatching worker (PID 12345)"},{"created_at":"${terminal_created_at}","author":"runner1","body_start":"${terminal_body}"}]'
+		exit 0
+	fi
+	printf '%s\n' '[{"created_at":"${dispatch_created_at}","author":"runner1","body_start":"Dispatching worker (PID 12345)"}]'
+	exit 0
+fi
+
+printf 'unsupported gh invocation in dispatch-comment test stub: %s\n' "\$*" >&2
 exit 1
 GHEOF
 
@@ -431,6 +458,55 @@ test_owner_assigned_no_status_no_origin_allows_dispatch() {
 	return 0
 }
 
+test_dispatch_comment_blocks_inside_active_worker_window() {
+	local dispatch_created_at output
+	dispatch_created_at=$(date -u -v-120S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '120 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+	create_dispatch_comment_gh_stub "$dispatch_created_at"
+
+	if output=$(DISPATCH_COMMENT_MAX_AGE=60 DISPATCH_ACTIVE_WORKER_MAX_AGE=300 "$HELPER_SCRIPT" has-dispatch-comment 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'active-worker window'*)
+			print_result "dispatch comment blocks inside active-worker window" 0
+			return 0
+			;;
+		esac
+		print_result "dispatch comment blocks inside active-worker window" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "dispatch comment blocks inside active-worker window" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+test_dispatch_comment_expires_after_active_worker_window() {
+	local dispatch_created_at
+	dispatch_created_at=$(date -u -v-400S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '400 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+	create_dispatch_comment_gh_stub "$dispatch_created_at"
+
+	if DISPATCH_COMMENT_MAX_AGE=60 DISPATCH_ACTIVE_WORKER_MAX_AGE=300 "$HELPER_SCRIPT" has-dispatch-comment 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "dispatch comment expires after active-worker window" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "dispatch comment expires after active-worker window" 0
+	return 0
+}
+
+test_dispatch_comment_terminal_marker_allows() {
+	local dispatch_created_at terminal_created_at
+	dispatch_created_at=$(date -u -v-120S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '120 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+	terminal_created_at=$(date -u -v-30S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '30 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+	create_dispatch_comment_gh_stub "$dispatch_created_at" "CLAIM_RELEASED reason=worker_complete" "$terminal_created_at"
+
+	if DISPATCH_COMMENT_MAX_AGE=60 DISPATCH_ACTIVE_WORKER_MAX_AGE=300 "$HELPER_SCRIPT" has-dispatch-comment 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "terminal marker supersedes dispatch comment" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "terminal marker supersedes dispatch comment" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -451,6 +527,9 @@ main() {
 	test_owner_assigned_with_origin_interactive_blocks
 	test_maintainer_assigned_with_origin_interactive_blocks
 	test_owner_assigned_no_status_no_origin_allows_dispatch
+	test_dispatch_comment_blocks_inside_active_worker_window
+	test_dispatch_comment_expires_after_active_worker_window
+	test_dispatch_comment_terminal_marker_allows
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Keeps non-terminal worker dispatch comments active through an extended worker window so TTL expiry does not create bare duplicate claims.
- Annotates deliberate stale-worker takeover claims with `reason=stale_worker_takeover` once the extended window expires.
- Adds regression coverage and worker diagnostics docs for claim/comment states.

## Verification
- `shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh`
- `.agents/scripts/tests/test-dispatch-claim-helper.sh && .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh`
- `npx --yes markdownlint-cli2 .agents/reference/worker-diagnostics.md`

Resolves #22356
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 25m and 188,678 tokens on this as a headless worker.