### PR TITLE
t3483: set GPT-5.5 context cap for OpenCode compaction

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -12,7 +12,7 @@ import { getCursorProxyPort, registerCursorProvider } from "./cursor-proxy.mjs";
 import { getGoogleProxyPort, registerGoogleProvider } from "./google-proxy.mjs";
 import { getClaudeProxyPort, registerClaudeProvider } from "./claude-proxy.mjs";
 import { checkOpenCodeVersionDrift } from "./version-tracking.mjs";
-import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
+import { CLAUDE_MODEL_LIMITS, OPENAI_MODEL_LIMITS } from "./model-limits.mjs";
 
 /**
  * Shared model definition template for Claude models managed by aidevops.
@@ -27,6 +27,25 @@ function claudeModelDef(overrides) {
     reasoning: true,
     modalities: { input: ["text", "image"], output: ["text"] },
     cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+    ...overrides,
+  };
+}
+
+/**
+ * Shared model definition template for OpenAI models whose limits aidevops
+ * must override from OpenCode/provider defaults.
+ * @param {object} overrides
+ * @returns {object}
+ */
+function openaiModelDef(overrides) {
+  return {
+    attachment: true,
+    tool_call: true,
+    temperature: true,
+    reasoning: true,
+    modalities: { input: ["text", "image"], output: ["text"] },
+    cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+    family: "openai",
     ...overrides,
   };
 }
@@ -71,6 +90,13 @@ const CLAUDECLI_MODELS = buildClaudeModelMap({
   "claude-opus-4-7":   "Claude Opus 4.7 (via CLI)",
 });
 
+const OPENAI_MODELS = Object.fromEntries(
+  Object.entries(OPENAI_MODEL_LIMITS).map(([id, limit]) => [
+    id,
+    openaiModelDef({ name: `OpenAI ${id}`, limit }),
+  ]),
+);
+
 /**
  * Upsert aidevops-managed models into the anthropic and claudecli providers.
  * Preserves any user options already set on the providers.
@@ -113,6 +139,27 @@ function registerAnthropicModels(config) {
     if (!existing) count++;
   }
 
+  return count;
+}
+
+/**
+ * Upsert aidevops-managed OpenAI model limits into the built-in openai provider.
+ * This preserves user provider options while correcting context metadata that
+ * drives OpenCode's 80% auto-compaction threshold.
+ * @param {object} config - OpenCode Config object (mutable)
+ * @returns {number} number of model entries upserted
+ */
+function registerOpenAIModels(config) {
+  if (!config.provider) config.provider = {};
+  if (!config.provider.openai) config.provider.openai = {};
+  if (!config.provider.openai.models) config.provider.openai.models = {};
+
+  let count = 0;
+  for (const [id, def] of Object.entries(OPENAI_MODELS)) {
+    const existing = config.provider.openai.models[id];
+    config.provider.openai.models[id] = { ...existing, ...def };
+    if (!existing) count++;
+  }
   return count;
 }
 
@@ -249,7 +296,7 @@ function registerClaudeCliModels(config) {
 
 /**
  * Log a summary of config hook changes (silent when nothing changed).
- * @param {object} counts - { agents, mcps, agentTools, poolCleaned, anthropic, cursor, google, claude }
+ * @param {object} counts - { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude }
  * @param {string|null} versionDrift
  */
 function logConfigSummary(counts, versionDrift) {
@@ -259,6 +306,7 @@ function logConfigSummary(counts, versionDrift) {
     [counts.agentTools, "agent tool perms"],
     [counts.poolCleaned, `cleaned ${counts.poolCleaned} stale pool provider${counts.poolCleaned === 1 ? "" : "s"}`],
     [counts.anthropic, "anthropic models"],
+    [counts.openai, "OpenAI models"],
     [counts.cursor, "Cursor models"],
     [counts.google, "Google models"],
     [counts.claude, "Claude CLI models"],
@@ -298,6 +346,7 @@ export function createConfigHook(deps) {
     const agentTools = applyAgentMcpTools(config);
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
+    const openai = registerOpenAIModels(config);
 
     // Discover and register proxy provider models only when a proxy listener is
     // already active. The normal startup path intentionally leaves these ports
@@ -333,7 +382,7 @@ export function createConfigHook(deps) {
     const claude = registerClaudeCliModels(config);
 
     logConfigSummary(
-      { agents, mcps, agentTools, poolCleaned, anthropic, cursor, google, claude },
+      { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude },
       checkOpenCodeVersionDrift(pluginDir),
     );
   };

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 //
-// model-limits.mjs — single source of truth for Claude model context/output
-// limits, with optional user override for the opus-4-7 context window.
+// model-limits.mjs — single source of truth for aidevops-managed model
+// context/output limits, with optional user override for the opus-4-7 context
+// window.
 //
 // Why this module exists (t2435):
 //   The opus-4-7 context window is intentionally capped at 250K (not the 1M
@@ -93,6 +94,18 @@ export const CLAUDE_MODEL_LIMITS = {
   // AIDEVOPS_OPUS_47_CONTEXT=<integer> if you understand the MRCR tradeoff.
   // See tools/ai-assistants/models-opus.md for the full rationale.
   "claude-opus-4-7":   { context: resolveOpus47Context(), output: 64000 },
+};
+
+/**
+ * OpenAI GPT-5.5 models report a 1M API context window, but Codex/OpenCode
+ * sessions are effectively bounded at 400K. OpenCode auto-compacts at 80% of
+ * the configured context limit, so registering 500K makes compaction trigger at
+ * 400K instead of waiting until the runtime/provider rejects the request.
+ */
+export const OPENAI_MODEL_LIMITS = {
+  "gpt-5.5":      { context: 500000, output: 128000 },
+  "gpt-5.5-fast": { context: 500000, output: 128000 },
+  "gpt-5.5-pro":  { context: 500000, output: 128000 },
 };
 
 // One-shot warn at module load when the env override changed something.

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -20,6 +20,7 @@ import {
   OPUS_47_CONTEXT_DEFAULT,
   OPUS_47_CONTEXT_MAX,
   CLAUDE_MODEL_LIMITS,
+  OPENAI_MODEL_LIMITS,
 } from "../model-limits.mjs";
 
 // ---------------------------------------------------------------------------
@@ -203,5 +204,21 @@ describe("CLAUDE_MODEL_LIMITS table", () => {
     // hard-coded limits regardless.
     assert.equal(CLAUDE_MODEL_LIMITS["claude-opus-4-6"].context, 1000000);
     assert.equal(CLAUDE_MODEL_LIMITS["claude-haiku-4-5"].context, 1000000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPENAI_MODEL_LIMITS — GPT-5.5 compaction-boundary regression guard
+// ---------------------------------------------------------------------------
+
+describe("OPENAI_MODEL_LIMITS table", () => {
+  test("sets GPT-5.5 family context to 500000 so 80% compaction lands at 400000", () => {
+    const expected = ["gpt-5.5", "gpt-5.5-fast", "gpt-5.5-pro"];
+    for (const id of expected) {
+      assert.ok(OPENAI_MODEL_LIMITS[id], `missing OpenAI limit entry for ${id}`);
+      assert.equal(OPENAI_MODEL_LIMITS[id].context, 500000);
+      assert.equal(OPENAI_MODEL_LIMITS[id].context * 0.8, 400000);
+      assert.ok(OPENAI_MODEL_LIMITS[id].output > 0);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Registers aidevops-managed OpenAI GPT-5.5 model metadata in OpenCode config.
- Sets GPT-5.5, GPT-5.5-fast, and GPT-5.5-pro context to 500,000 tokens so OpenCode's 80% auto-compact threshold lands at 400,000.
- Adds regression coverage for the GPT-5.5 context cap.

## Verification
- node --test .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs .agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
- node --check .agents/plugins/opencode-aidevops/config-hook.mjs && node --check .agents/plugins/opencode-aidevops/model-limits.mjs
- Inline config hook check produced {\"gpt-5.5\":500000,\"gpt-5.5-fast\":500000,\"gpt-5.5-pro\":500000}

Resolves #22393

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 20m and 232,101 tokens on this with the user in an interactive session.