### PR TITLE
GH#22312: guard pulse wrapper bash-only sourcing

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -64,6 +64,11 @@
 #
 # Called by launchd every 180s via the supervisor-pulse plist.
 
+if [[ -z "${BASH_VERSION:-}" ]]; then
+	printf '[pulse-wrapper] must be run by bash; use: bash -lc '\''source ~/.aidevops/agents/scripts/pulse-wrapper.sh; <command>'\''\n' >&2
+	return 2 2>/dev/null || exit 2
+fi
+
 set -euo pipefail
 
 #######################################
@@ -149,7 +154,9 @@ fi
 # acquire_instance_lock handles stale-lock reclaim properly.
 # Early source: _file_mtime_epoch needed before shared-constants.sh is loaded.
 # shellcheck source=./portable-stat.sh
-source "${BASH_SOURCE[0]%/*}/portable-stat.sh"
+_pw_source_path="${BASH_SOURCE[0]:-$0}"
+source "${_pw_source_path%/*}/portable-stat.sh"
+unset _pw_source_path
 if [[ "$_pulse_skip_jitter" -eq 0 ]]; then
 	_pw_ffjit_lockdir="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
 	_pw_ffjit_pid_file="${_pw_ffjit_lockdir}/pid"

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -38,13 +38,19 @@ If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep
 
 ### 1. Normalise PATH and check capacity
 
+`pulse-wrapper.sh` is a bash library. If the host tool shell is zsh, run
+wrapper-backed snippets in a bash subshell, not by sourcing the wrapper directly
+from zsh. Example: `bash -lc 'source ~/.aidevops/agents/scripts/pulse-wrapper.sh; list_active_worker_processes'`.
+
 ```bash
 export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
 ~/.aidevops/agents/scripts/circuit-breaker-helper.sh check  # exit 1 = stop
 
 MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
+[[ "$MAX_WORKERS" =~ ^[0-9]+$ ]] || MAX_WORKERS=4
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d ' ')
+[[ "$WORKER_COUNT" =~ ^[0-9]+$ ]] || WORKER_COUNT=0
 AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
 RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
 ```
@@ -154,7 +160,9 @@ After initial dispatch, enter a monitoring loop. Each cycle:
    ```bash
    source ~/.aidevops/agents/scripts/pulse-wrapper.sh
    MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
+   [[ "$MAX_WORKERS" =~ ^[0-9]+$ ]] || MAX_WORKERS=4
    WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d ' ')
+   [[ "$WORKER_COUNT" =~ ^[0-9]+$ ]] || WORKER_COUNT=0
    AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
    ```
 


### PR DESCRIPTION
## Summary
- Guard `pulse-wrapper.sh` with an explicit bash-only failure message when sourced from zsh.
- Add a portable early-source fallback for `portable-stat.sh` and numeric fallbacks in the pulse workflow capacity snippets.

## Verification
- `shellcheck .agents/scripts/pulse-wrapper.sh`
- `bash -n .agents/scripts/pulse-wrapper.sh`
- `npx --yes markdownlint-cli2 .agents/workflows/pulse.md`
- `bash -lc 'source .agents/scripts/pulse-wrapper.sh; MAX_WORKERS=notnum; [[ "$MAX_WORKERS" =~ ^[0-9]+$ ]] || MAX_WORKERS=4; WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d " "); [[ "$WORKER_COUNT" =~ ^[0-9]+$ ]] || WORKER_COUNT=0; AVAILABLE=$((MAX_WORKERS - WORKER_COUNT)); [[ "$MAX_WORKERS" == 4 && "$WORKER_COUNT" =~ ^[0-9]+$ && "$AVAILABLE" =~ ^-?[0-9]+$ ]]'

Resolves #22312


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 26m and 269,338 tokens on this with the user in an interactive session.
