### PR TITLE
t3484: repair Tabby OpenCode launch profiles

### DIFF
--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -1,0 +1,35 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Tabby profiles
+
+Use `.agents/scripts/tabby-profile-sync.py` to generate aidevops project profiles
+from `repos.json`.
+
+OpenCode profiles must not launch with `zsh -i -c opencode`. That shape runs an
+interactive zsh startup while executing a command string, which can make
+Powerlevel10k/gitstatus initialize before job control is available and emit
+errors such as `setopt: can't change option: monitor` or `gitstatus failed to
+initialize` before the TUI starts.
+
+The safe generated shape is:
+
+```yaml
+command: /bin/zsh
+args:
+  - '-l'
+  - '-i'
+env:
+  TABBY_AUTORUN: opencode
+```
+
+For manual one-off profiles that should run OpenCode and then leave a shell open,
+use a non-interactive login command instead of mixing `-i` and `-c`:
+
+```yaml
+command: /bin/zsh
+args:
+  - '-l'
+  - '-c'
+  - 'opencode; exec zsh'
+```

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import uuid
 from pathlib import Path
@@ -146,6 +147,110 @@ def build_group_yaml(group_id: str) -> str:
     name: Projects"""
 
 
+def _normalise_yaml_scalar(value: str) -> str:
+    """Return a plain scalar value from a simple YAML string/list item."""
+    return value.strip().strip("'").strip('"')
+
+
+def _parse_inline_args(value: str) -> list[str] | None:
+    """Parse a simple inline YAML list such as ``['-l', '-i']``."""
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return None
+    inner = value[1:-1].strip()
+    if not inner:
+        return []
+    return [_normalise_yaml_scalar(part) for part in inner.split(",")]
+
+
+def _parse_block_args(lines: list[str]) -> list[str]:
+    """Parse simple ``- value`` YAML list entries from an args block."""
+    args: list[str] = []
+    for line in lines:
+        match = re.match(r"^\s*-\s*(.+?)\s*$", line)
+        if match:
+            args.append(_normalise_yaml_scalar(match.group(1)))
+    return args
+
+
+def _is_broken_opencode_args(args: list[str]) -> bool:
+    """Return True for the Tabby launch shape that breaks zsh job control."""
+    return args == ["-l", "-i", "-c", "opencode"]
+
+
+def _safe_opencode_args_block(args_indent: str, include_env: bool) -> list[str]:
+    """Build the safe Tabby args/env block using ``TABBY_AUTORUN``."""
+    child_indent = f"{args_indent}  "
+    block = [
+        f"{args_indent}args:",
+        f"{child_indent}- '-l'",
+        f"{child_indent}- '-i'",
+    ]
+    if include_env:
+        block.extend(
+            [
+                f"{args_indent}env:",
+                f"{child_indent}TABBY_AUTORUN: opencode",
+            ]
+        )
+    return block
+
+
+def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
+    """Repair Tabby profiles using ``zsh -l -i -c opencode``.
+
+    ``zsh -i -c`` enables interactive startup while executing a command string,
+    which can trigger Powerlevel10k/gitstatus job-control errors before the TUI
+    starts. The generated profile shape keeps a login interactive shell and lets
+    shell startup launch OpenCode via ``TABBY_AUTORUN`` instead.
+    """
+    lines = config_text.split("\n")
+    repaired: list[str] = []
+    repairs = 0
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        match = re.match(r"^(?P<indent>\s*)args:\s*(?P<value>.*)$", line)
+        if not match:
+            repaired.append(line)
+            i += 1
+            continue
+
+        args_indent = match.group("indent")
+        args_indent_len = len(args_indent)
+        inline_args = _parse_inline_args(match.group("value"))
+        if inline_args is not None:
+            if _is_broken_opencode_args(inline_args):
+                repaired.extend(_safe_opencode_args_block(args_indent, include_env=True))
+                repairs += 1
+            else:
+                repaired.append(line)
+            i += 1
+            continue
+
+        block_end = i + 1
+        while block_end < len(lines):
+            next_line = lines[block_end]
+            if next_line.strip():
+                next_indent_len = len(next_line) - len(next_line.lstrip(" "))
+                if next_indent_len <= args_indent_len:
+                    break
+            block_end += 1
+
+        block_args = _parse_block_args(lines[i + 1 : block_end])
+        if _is_broken_opencode_args(block_args):
+            next_line = lines[block_end] if block_end < len(lines) else ""
+            has_env = bool(re.match(rf"^{re.escape(args_indent)}env:\s*$", next_line))
+            repaired.extend(_safe_opencode_args_block(args_indent, include_env=not has_env))
+            repairs += 1
+        else:
+            repaired.extend(lines[i:block_end])
+        i = block_end
+
+    return "\n".join(repaired), repairs
+
+
 def ensure_groups_section(config_text: str, group_id: str) -> str:
     """Ensure the groups section exists with a Projects group."""
     if re.search(r"^groups:", config_text, re.MULTILINE):
@@ -260,17 +365,25 @@ def sync_profiles(args: argparse.Namespace) -> None:
     config_text = load_yaml_simple(args.tabby_config)
     existing_cwds = extract_existing_cwds(config_text)
 
+    config_text, repaired_count = repair_broken_opencode_launch_profiles(config_text)
+
     config_text, group_id = ensure_group(config_text)
     new_profiles = build_new_profiles(repos, existing_cwds, group_id)
 
     if not new_profiles:
-        print("All repos already have Tabby profiles. Nothing to do.")
+        if repaired_count:
+            save_yaml(args.tabby_config, config_text)
+            print(f"Repaired {repaired_count} existing Tabby profile(s).")
+        else:
+            print("All repos already have Tabby profiles. Nothing to do.")
         return
 
     new_block = "\n".join(p[1] for p in new_profiles)
     config_text = insert_profiles_block(config_text, new_block)
     save_yaml(args.tabby_config, config_text)
 
+    if repaired_count:
+        print(f"Repaired {repaired_count} existing Tabby profile(s).")
     print(f"Created {len(new_profiles)} new Tabby profile(s):")
     for repo, _, colour, scheme_name in new_profiles:
         print(f"  + {repo['name']} (colour: {colour}, scheme: {scheme_name})")

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-tabby-profile-sync.sh — Regression tests for GH#22397.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+HELPER="${REPO_ROOT}/.agents/scripts/tabby-profile-sync.py"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
+readonly TEST_NC='\033[0m'
+
+pass_count=0
+fail_count=0
+
+_pass() {
+	local msg="$1"
+	printf '%b  PASS:%b %s\n' "${TEST_GREEN}" "${TEST_NC}" "${msg}"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+_fail() {
+	local msg="$1"
+	printf '%b  FAIL:%b %s\n' "${TEST_RED}" "${TEST_NC}" "${msg}" >&2
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+_info() {
+	local msg="$1"
+	printf '%b[INFO]%b %s\n' "${TEST_YELLOW}" "${TEST_NC}" "${msg}"
+	return 0
+}
+
+run_python_test() {
+	local label="$1"
+	local code="$2"
+	local output
+
+	set +e
+	output=$(HELPER="${HELPER}" PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 -c "${code}" 2>&1)
+	local rc=$?
+	set -e
+
+	if ((rc == 0)); then
+		_pass "${label}"
+	else
+		_fail "${label}: ${output}"
+	fi
+	return 0
+}
+
+load_module_code='import importlib.util, os
+spec = importlib.util.spec_from_file_location("tabby_profile_sync", os.environ["HELPER"])
+mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mod)'
+
+_info "Test 1: block-list zsh -l -i -c opencode profile is repaired"
+run_python_test "block-list broken args repaired" "${load_module_code}
+config = '''profiles:
+  - name: aidevops
+    options:
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-i'
+        - '-c'
+        - opencode
+      cwd: /tmp/aidevops
+'''
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count == 1, count
+assert \"- '-c'\" not in repaired, repaired
+assert 'TABBY_AUTORUN: opencode' in repaired, repaired
+assert \"- '-l'\" in repaired and \"- '-i'\" in repaired, repaired
+"
+
+_info "Test 2: inline broken args are repaired"
+run_python_test "inline broken args repaired" "${load_module_code}
+config = \"\"\"profiles:\n  - name: aidevops\n    options:\n      command: /bin/zsh\n      args: ['-l', '-i', '-c', opencode]\n      cwd: /tmp/aidevops\n\"\"\"
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count == 1, count
+assert \"args: ['-l', '-i', '-c', opencode]\" not in repaired, repaired
+assert 'TABBY_AUTORUN: opencode' in repaired, repaired
+"
+
+_info "Test 3: generated profiles keep safe TABBY_AUTORUN shape"
+run_python_test "generated profile uses safe launch shape" "${load_module_code}
+scheme = {'name': 'Test', 'foreground': '#fff', 'background': '#000', 'cursor': '#fff', 'colors': ['#000', '#fff']}
+profile = mod.build_profile_yaml('aidevops', '/tmp/aidevops', '#123456', scheme, 'group-1')
+assert \"- '-c'\" not in profile, profile
+assert 'TABBY_AUTORUN: opencode' in profile, profile
+assert \"- '-l'\" in profile and \"- '-i'\" in profile, profile
+"
+
+_info "Test 4: sync repairs existing profiles even when no new profile is needed"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "${tmp_root}"' EXIT
+repo_path="${tmp_root}/aidevops"
+mkdir -p "${repo_path}"
+repos_json="${tmp_root}/repos.json"
+tabby_config="${tmp_root}/config.yaml"
+python3 - "${repos_json}" "${repo_path}" <<'PY'
+import json
+import sys
+
+repos_json, repo_path = sys.argv[1:]
+with open(repos_json, "w") as handle:
+    json.dump({"initialized_repos": [{"path": repo_path}]}, handle)
+PY
+python3 - "${tabby_config}" "${repo_path}" <<'PY'
+import sys
+
+tabby_config, repo_path = sys.argv[1:]
+with open(tabby_config, "w") as handle:
+    handle.write(f"""profiles:
+  - name: aidevops
+    options:
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-i'
+        - '-c'
+        - opencode
+      cwd: {repo_path}
+""")
+PY
+sync_output=$(PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${tabby_config}")
+if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}" && ! grep -q -- "- '-c'" "${tabby_config}"; then
+	_pass "sync repairs existing broken profile"
+else
+	_fail "sync did not repair existing profile: ${sync_output}"
+fi
+
+echo ""
+if ((fail_count == 0)); then
+	printf '%bAll %d tests passed.%b\n' "${TEST_GREEN}" "${pass_count}" "${TEST_NC}"
+	exit 0
+else
+	printf '%b%d test(s) failed, %d passed.%b\n' \
+		"${TEST_RED}" "${fail_count}" "${pass_count}" "${TEST_NC}" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Hardened Tabby profile sync to repair existing zsh -l -i -c opencode profiles to the safe TABBY_AUTORUN launch shape, added regression coverage, and documented the Powerlevel10k/gitstatus failure mode.

## Files Changed

.agents/reference/tabby-profiles.md,.agents/scripts/tabby-profile-sync.py,.agents/scripts/tests/test-tabby-profile-sync.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/tabby-profile-sync.py; .agents/scripts/tests/test-tabby-profile-sync.sh; shellcheck .agents/scripts/tests/test-tabby-profile-sync.sh

Resolves #22397


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 6m and 92,283 tokens on this as a headless worker.