### PR TITLE
GH#22399: block external issue dispatch race

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -576,6 +576,70 @@ _check_nmr_approval_gate() {
 }
 
 #######################################
+# GH#22399: Fail-closed external issue author gate.
+#
+# GitHub Actions issue-triage-gate.yml applies needs-maintainer-review to
+# non-collaborator issues, but Actions can sit queued while the pulse keeps
+# dispatching. This gate repeats the trust-boundary check in the dispatch path
+# immediately before worker launch. OWNER/MEMBER/COLLABORATOR and bot-created
+# issues keep the existing fast path. External or unknown authors must carry a
+# valid cryptographic approval; otherwise the pulse applies NMR and blocks this
+# candidate in the current cycle.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo)
+#
+# Exit codes:
+#   0 - gate blocks dispatch (external/unknown author without approval)
+#   1 - gate allows dispatch
+#######################################
+_check_external_issue_author_gate() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local issue_author_meta=""
+	issue_author_meta=$(gh api "repos/${repo_slug}/issues/${issue_number}" \
+		--jq '[.author_association // "NONE", .user.type // ""] | @tsv' 2>/dev/null) || issue_author_meta=""
+
+	local author_association="NONE"
+	local author_type=""
+	if [[ -n "$issue_author_meta" ]]; then
+		IFS=$'\t' read -r author_association author_type <<<"$issue_author_meta"
+	fi
+	[[ -n "$author_association" ]] || author_association="NONE"
+
+	case "$author_association" in
+		OWNER | MEMBER | COLLABORATOR)
+			return 1
+			;;
+	esac
+	if [[ "$author_type" == "Bot" ]]; then
+		return 1
+	fi
+
+	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	local verify_result=""
+	if [[ -f "$approval_helper" ]]; then
+		verify_result=$(bash "$approval_helper" verify "$issue_number" "$repo_slug" 2>/dev/null) || verify_result=""
+		if [[ "$verify_result" == "VERIFIED" ]]; then
+			echo "[dispatch_with_dedup] GH#22399: external/unknown issue author for #${issue_number} in ${repo_slug} has cryptographic approval; allowing dispatch" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
+	echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: author_association=${author_association}, author_type=${author_type:-unknown}; applying needs-maintainer-review until cryptographic approval lands (GH#22399)" >>"$LOGFILE"
+	if declare -F gh_issue_edit_safe >/dev/null 2>&1; then
+		gh_issue_edit_safe "$issue_number" --repo "$repo_slug" \
+			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+	else
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
+#######################################
 # GH#17574 + GH#18644: Combined commit-subject dedup gate with
 # force-dispatch maintainer override.
 #
@@ -850,13 +914,14 @@ _is_task_committed_to_main() {
 # Runs all pre-dispatch safety gates in order:
 #   1. Issue state (must be OPEN)
 #   2. Management labels (supervisor/contributor/persistent/etc.)
-#   3. Cryptographic approval gate (t1894, ever-NMR)
-#   4. Supervisor telemetry title guard
-#   5. Main-commit check (GH#17574 — task already done)
-#   6. Blocked-by dependency enforcement (t1927)
-#   7. Issue consolidation pre-check
-#   8. Large-file simplification gate
-#   9. 7-layer check_dispatch_dedup chain (Layers 1–7)
+#   3. External issue author gate (GH#22399 — Actions queue race)
+#   4. Cryptographic approval gate (t1894, ever-NMR)
+#   5. Supervisor telemetry title guard
+#   6. Main-commit check (GH#17574 — task already done)
+#   7. Blocked-by dependency enforcement (t1927)
+#   8. Issue consolidation pre-check
+#   9. Large-file simplification gate
+#   10. 7-layer check_dispatch_dedup chain (Layers 1–7)
 #
 # Arguments:
 #   $1 - issue_number
@@ -951,6 +1016,16 @@ _dispatch_dedup_check_layers() {
 		return 1
 	fi
 	_ds_record "$issue_number" "$repo_slug" "dedup.label_checks" "$_dss_t0"
+
+	# GH#22399: fail closed for external/unknown issue authors before the
+	# historical ever-NMR gate. The ever-NMR gate allows never-labeled issues;
+	# this gate closes the race where GitHub Actions has not applied NMR yet.
+	_dss_t0=$(_ds_now_ns)
+	if _check_external_issue_author_gate "$issue_number" "$repo_slug"; then
+		_ds_record "$issue_number" "$repo_slug" "dedup.external_author_gate" "$_dss_t0"
+		return 1
+	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.external_author_gate" "$_dss_t0"
 
 	# t1894/GH#18648: Cryptographic approval gate (ever-NMR) with
 	# review-followup exemption for bot-generated cleanup issues.

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -183,6 +183,10 @@ _preflight_early_dispatch() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag present — skipping early dispatch_max" >>"$LOGFILE"
 	else
+		# GH#22399: dispatch_max ultimately calls dispatch_with_dedup(), whose
+		# external-author gate applies needs-maintainer-review fail-closed before
+		# worker launch. Keep that trust-boundary check in the dispatch path rather
+		# than depending on the asynchronous issue-triage GitHub Actions workflow.
 		echo "[pulse-wrapper] Early dispatch_max: dispatching workers before housekeeping" >>"$LOGFILE"
 		apply_dispatch_max
 	fi

--- a/.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#22399: external issue authors must not dispatch while
+# the asynchronous issue-triage GitHub Actions workflow is queued.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+GH_CALLS_FILE=""
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_check_external_issue_author_gate\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _check_external_issue_author_gate from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+setup_case() {
+	local association="$1"
+	local author_type="${2:-User}"
+	local approval_result="${3:-}"
+
+	TEST_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-gh22399)
+	GH_CALLS_FILE="${TEST_ROOT}/gh-calls.log"
+	LOGFILE="${TEST_ROOT}/pulse.log"
+	AGENTS_DIR="${TEST_ROOT}/agents"
+	export TEST_ROOT GH_CALLS_FILE LOGFILE AGENTS_DIR
+	mkdir -p "${AGENTS_DIR}/scripts" "${TEST_ROOT}/bin"
+	: >"$GH_CALLS_FILE"
+	: >"$LOGFILE"
+
+	cat >"${TEST_ROOT}/issue-meta.tsv" <<EOF
+${association}	${author_type}
+EOF
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "gh $*" >>"$GH_CALLS_FILE"
+if [[ "${1:-}" == "api" ]]; then
+	cat "${TEST_ROOT}/issue-meta.tsv"
+	exit 0
+fi
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	PATH="${TEST_ROOT}/bin:$PATH"
+	export PATH
+
+	cat >"${AGENTS_DIR}/scripts/approval-helper.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "verify" && "${approval_result}" == "VERIFIED" ]]; then
+	printf 'VERIFIED\n'
+	exit 0
+fi
+printf 'UNVERIFIED\n'
+exit 1
+EOF
+	chmod +x "${AGENTS_DIR}/scripts/approval-helper.sh"
+	return 0
+}
+
+cleanup_case() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+gh_issue_edit_safe() {
+	printf 'gh_issue_edit_safe %s\n' "$*" >>"$GH_CALLS_FILE"
+	return 0
+}
+
+test_external_author_without_approval_blocks_and_applies_nmr() {
+	setup_case "CONTRIBUTOR" "User" ""
+	if _check_external_issue_author_gate 22390 "owner/repo"; then
+		if grep -q -- '--add-label needs-maintainer-review' "$GH_CALLS_FILE"; then
+			print_result "external author without approval blocks and applies NMR" 0
+			cleanup_case
+			return 0
+		fi
+		print_result "external author without approval blocks and applies NMR" 1 "NMR label was not applied: $(<"$GH_CALLS_FILE")"
+		cleanup_case
+		return 0
+	fi
+	print_result "external author without approval blocks and applies NMR" 1 "Expected gate to block"
+	cleanup_case
+	return 0
+}
+
+test_owner_author_allows_dispatch() {
+	setup_case "OWNER" "User" ""
+	if _check_external_issue_author_gate 1 "owner/repo"; then
+		print_result "OWNER author bypasses external gate" 1 "Expected gate to allow OWNER"
+		cleanup_case
+		return 0
+	fi
+	print_result "OWNER author bypasses external gate" 0
+	cleanup_case
+	return 0
+}
+
+test_collaborator_author_allows_dispatch() {
+	setup_case "COLLABORATOR" "User" ""
+	if _check_external_issue_author_gate 2 "owner/repo"; then
+		print_result "COLLABORATOR author bypasses external gate" 1 "Expected gate to allow COLLABORATOR"
+		cleanup_case
+		return 0
+	fi
+	print_result "COLLABORATOR author bypasses external gate" 0
+	cleanup_case
+	return 0
+}
+
+test_external_author_with_crypto_approval_allows_dispatch() {
+	setup_case "CONTRIBUTOR" "User" "VERIFIED"
+	if _check_external_issue_author_gate 3 "owner/repo"; then
+		print_result "external author with cryptographic approval dispatches" 1 "Expected verified approval to allow dispatch"
+		cleanup_case
+		return 0
+	fi
+	print_result "external author with cryptographic approval dispatches" 0
+	cleanup_case
+	return 0
+}
+
+test_author_lookup_failure_fails_closed() {
+	setup_case "" "" ""
+	rm -f "${TEST_ROOT}/issue-meta.tsv"
+	if _check_external_issue_author_gate 4 "owner/repo"; then
+		if grep -q -- '--add-label needs-maintainer-review' "$GH_CALLS_FILE"; then
+			print_result "author lookup failure fails closed with NMR" 0
+			cleanup_case
+			return 0
+		fi
+		print_result "author lookup failure fails closed with NMR" 1 "NMR label was not applied"
+		cleanup_case
+		return 0
+	fi
+	print_result "author lookup failure fails closed with NMR" 1 "Expected gate to block on lookup failure"
+	cleanup_case
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_external_author_without_approval_blocks_and_applies_nmr
+	test_owner_author_allows_dispatch
+	test_collaborator_author_allows_dispatch
+	test_external_author_with_crypto_approval_allows_dispatch
+	test_author_lookup_failure_fails_closed
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added a fail-closed dispatch-path author-association gate that applies needs-maintainer-review to external or unknown issue authors unless cryptographic approval verifies, closing the Actions queue race before worker launch.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-preflight-lib.sh,.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-preflight-lib.sh .agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh; .agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh

Resolves #22399


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 7m and 149,779 tokens on this as a headless worker.