### PR TITLE
GH#22379: classify provider and runtime worker failures

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -540,6 +540,10 @@ _handle_run_result() {
 	activity_detected=$(output_has_activity "$output_file")
 	_run_activity_detected="$activity_detected"
 	_run_result_label="failed"
+	_run_provider_error_type=""
+	_run_provider_status=""
+	_run_runtime_error_type=""
+	_run_classification_source=""
 
 	if [[ "$exit_code" -eq 0 ]]; then
 		if [[ "$activity_detected" != "1" ]]; then
@@ -612,8 +616,8 @@ _handle_run_result() {
 	#   can resume the session with a continuation prompt before giving up.
 	# - 124 + no activity → rate_limit as before (provider never responded).
 	if [[ "$exit_code" -eq 124 ]]; then
-		if _activity_output_has_provider_rate_limit "$output_file"; then
-			failure_reason="rate_limit"
+		failure_reason=$(classify_failure_reason "$output_file")
+		if [[ "$failure_reason" == "rate_limit" ]]; then
 			print_warning "$selected_model watchdog saw provider/rate-limit marker — classifying as rate_limit for rotation"
 		else
 			if [[ "$activity_detected" == "1" ]]; then
@@ -645,12 +649,19 @@ _handle_run_result() {
 				return 78
 			fi
 			failure_reason="rate_limit"
+			_failure_provider_error_type="rate_limit"
+			_failure_provider_status="429"
+			_failure_classification_source="watchdog_no_activity"
 			print_warning "$selected_model activity watchdog timeout (no activity) — classifying as rate_limit for rotation"
 		fi
 	else
 		failure_reason=$(classify_failure_reason "$output_file")
 	fi
 	_run_result_label="$failure_reason"
+	_run_provider_error_type="${_failure_provider_error_type:-}"
+	_run_provider_status="${_failure_provider_status:-}"
+	_run_runtime_error_type="${_failure_runtime_error_type:-}"
+	_run_classification_source="${_failure_classification_source:-}"
 
 	if attempt_pool_recovery "$provider" "$failure_reason" "$output_file"; then
 		_run_should_retry=1
@@ -1071,6 +1082,10 @@ _execute_run_attempt() {
 		# avoids the repeated-string-literal ratchet gate (threshold: >=3).
 		_run_result_label="rate_limit_fast"
 		_run_failure_reason="$_run_result_label"
+		_run_provider_error_type="rate_limit"
+		_run_provider_status="429"
+		_run_runtime_error_type=""
+		_run_classification_source="rate_limit_fast_monitor"
 		local _rl_end_ms
 		_rl_end_ms=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
 		local _rl_duration_ms=0
@@ -1085,7 +1100,8 @@ _execute_run_attempt() {
 			rm -f "$resource_stop_file" "$resource_result_file" 2>/dev/null || true
 		fi
 		append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "$_run_result_label" "0" "$_run_failure_reason" "0" "$_rl_duration_ms" \
-			"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_rl_metric_output_file" "$_rl_metric_session_id"
+			"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_rl_metric_output_file" "$_rl_metric_session_id" \
+			"${_run_provider_error_type:-}" "${_run_provider_status:-}" "${_run_runtime_error_type:-}" "${_run_classification_source:-}"
 		return 80
 	fi
 
@@ -1146,7 +1162,8 @@ _execute_run_attempt() {
 		_metric_output_file=""
 	fi
 	append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "${_run_result_label:-failed}" "$handle_exit" "${_run_failure_reason:-}" "${_run_activity_detected:-0}" "$duration_ms" \
-		"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_metric_output_file" "$_metric_session_id"
+		"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_metric_output_file" "$_metric_session_id" \
+		"${_run_provider_error_type:-}" "${_run_provider_status:-}" "${_run_runtime_error_type:-}" "${_run_classification_source:-}"
 	return "$handle_exit"
 }
 

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -107,6 +107,10 @@ source "${SCRIPT_DIR}/headless-runtime-provider.sh"
 
 classify_failure_reason() {
 	local file_path="$1"
+	_failure_provider_error_type=""
+	_failure_provider_status=""
+	_failure_runtime_error_type=""
+	_failure_classification_source="output_pattern"
 	local lowered
 	lowered=$(
 		python3 - "$file_path" <<'PY'
@@ -115,23 +119,47 @@ import sys
 print(Path(sys.argv[1]).read_text(errors="ignore").lower())
 PY
 	)
-	if [[ "$lowered" == *"rate limit"* ]] || [[ "$lowered" == *"429"* ]] || [[ "$lowered" == *"too many requests"* ]]; then
+	if [[ "$lowered" == *"rate limit"* ]] || [[ "$lowered" == *"rate_limit"* ]] || [[ "$lowered" == *"429"* ]] || [[ "$lowered" == *"too many requests"* ]] || [[ "$lowered" == *"quota exceeded"* ]]; then
+		_failure_provider_error_type="rate_limit"
+		_failure_provider_status="429"
 		printf '%s' "rate_limit"
 		return 0
 	fi
-	if [[ "$lowered" =~ (unauthorized|401|invalid\ api\ key|authentication|token\ refresh\ failed|invalid_grant|invalid\ refresh\ token) ]] || [[ "$lowered" == *"auth"* && "$lowered" == *"failed"* ]]; then
-		printf '%s' "auth_error"
+	if [[ "$lowered" == *"sqliteerror: disk i/o error"* ]] || [[ "$lowered" == *"sqlite_error"* && "$lowered" == *"disk i/o"* ]]; then
+		_failure_runtime_error_type="opencode_sqlite_io"
+		_failure_classification_source="opencode_runtime"
+		printf '%s' "local_error"
+		return 0
+	fi
+	if [[ "$lowered" == *"failed to list snapshot files"* ]] || { [[ "$lowered" == *"fatal: not a git repository"* ]] && [[ "$lowered" == *"snapshot"* ]]; }; then
+		_failure_runtime_error_type="opencode_snapshot_git"
+		_failure_classification_source="opencode_runtime"
+		printf '%s' "local_error"
 		return 0
 	fi
 	# Distinguish actual provider errors (5xx, connection refused, timeout)
 	# from local/worker failures (sandbox crash, bad prompt, opencode bug).
 	# Only provider errors should trigger backoff -- local failures don't
 	# mean the provider is unhealthy.
-	if [[ "$lowered" =~ (500|502|503|504|internal\ server\ error|service\ unavailable|gateway|connection\ refused|connection.*reset|overloaded) ]]; then
+	if [[ "$lowered" =~ (server_error|500|502|503|504|internal\ server\ error|service\ unavailable|bad\ gateway|gateway\ timeout|connection\ refused|connection.*reset|overloaded) ]]; then
+		_failure_provider_error_type="server_error"
+		case "$lowered" in
+		*"504"* | *"gateway timeout"*) _failure_provider_status="504" ;;
+		*"503"* | *"service unavailable"*) _failure_provider_status="503" ;;
+		*"502"* | *"bad gateway"*) _failure_provider_status="502" ;;
+		*) _failure_provider_status="500" ;;
+		esac
 		printf '%s' "provider_error"
 		return 0
 	fi
+	if [[ "$lowered" =~ (unauthorized|401|invalid\ api\ key|authentication\ failed|token\ refresh\ failed|invalid_grant|invalid\ refresh\ token) ]] || [[ "$lowered" == *"auth"* && "$lowered" == *"failed"* ]]; then
+		_failure_provider_error_type="auth_error"
+		_failure_provider_status="401"
+		printf '%s' "auth_error"
+		return 0
+	fi
 	# Default: local_error -- do NOT record provider backoff for this
+	_failure_classification_source="default_local"
 	printf '%s' "local_error"
 	return 0
 }
@@ -276,12 +304,18 @@ append_runtime_metric() {
 	local work_dir="${12:-}"
 	local output_file="${13:-}"
 	local session_id="${14:-}"
+	local provider_error_type="${15:-}"
+	local provider_status="${16:-}"
+	local runtime_error_type="${17:-}"
+	local classification_source="${18:-}"
 	mkdir -p "$METRICS_DIR" 2>/dev/null || true
 	ROLE="$role" SESSION_KEY="$session_key" MODEL="$model" PROVIDER="$provider" \
 		RESULT="$result" EXIT_CODE="$exit_code" FAILURE_REASON="$failure_reason" \
 		ACTIVITY="$activity" DURATION_MS="$duration_ms" ISSUE_NUMBER="$issue_number" \
 		REPO_SLUG="$repo_slug" WORK_DIR="$work_dir" OUTPUT_FILE="$output_file" \
-		SESSION_ID="$session_id" METRICS_PATH="$METRICS_FILE" python3 - <<'PY' >/dev/null 2>&1 || true
+		SESSION_ID="$session_id" PROVIDER_ERROR_TYPE="$provider_error_type" \
+		PROVIDER_STATUS="$provider_status" RUNTIME_ERROR_TYPE="$runtime_error_type" \
+		CLASSIFICATION_SOURCE="$classification_source" METRICS_PATH="$METRICS_FILE" python3 - <<'PY' >/dev/null 2>&1 || true
 import json
 import os
 import time
@@ -304,6 +338,10 @@ optional_fields = {
     "work_dir": os.environ.get("WORK_DIR", ""),
     "output_file": os.environ.get("OUTPUT_FILE", ""),
     "session_id": os.environ.get("SESSION_ID", ""),
+    "provider_error_type": os.environ.get("PROVIDER_ERROR_TYPE", ""),
+    "provider_status": os.environ.get("PROVIDER_STATUS", ""),
+    "runtime_error_type": os.environ.get("RUNTIME_ERROR_TYPE", ""),
+    "classification_source": os.environ.get("CLASSIFICATION_SOURCE", ""),
 }
 for key, value in optional_fields.items():
     if value:

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -61,9 +61,11 @@ write_fixture() {
 check_classification() {
 	local label="$1" body="$2" expected_reason="$3" expected_provider_type="$4"
 	local expected_status="$5" expected_runtime_type="$6" expected_source="$7"
-	local path reason
+	local path reason reason_file
 	path=$(write_fixture "$label" "$body")
-	reason=$(classify_failure_reason "$path")
+	reason_file="$FIXTURE_DIR/$label.reason"
+	classify_failure_reason "$path" >"$reason_file"
+	reason=$(<"$reason_file")
 	assert_eq "$label reason" "$expected_reason" "$reason"
 	assert_eq "$label provider_error_type" "$expected_provider_type" "${_failure_provider_error_type:-}"
 	assert_eq "$label provider_status" "$expected_status" "${_failure_provider_status:-}"
@@ -82,6 +84,7 @@ check_classification \
 check_classification \
 	"openai_server_error" \
 	'{"provider":"openai","error":{"type":"server_error","message":"The server had an error"},"status":500}
+session.processor error: undefined is not an object' \
 	"provider_error" "server_error" "500" "" "output_pattern"
 
 check_classification \

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-headless-runtime-failure-classification.sh — provider/runtime subtype fixtures.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: $(printf '%q' "$expected")"
+		echo "  got:      $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_DIR="$(mktemp -d -t hrf-classify-XXXXXX)"
+STATE_DIR="$FIXTURE_DIR/state"
+STATE_DB="$STATE_DIR/headless-runtime-state.sqlite3"
+METRICS_DIR="$FIXTURE_DIR/metrics"
+METRICS_FILE="$METRICS_DIR/headless-runtime-metrics.jsonl"
+OPENCODE_AUTH_FILE="$FIXTURE_DIR/auth.json"
+OAUTH_POOL_HELPER="$FIXTURE_DIR/oauth-pool-helper.sh"
+
+cleanup() {
+	rm -rf "$FIXTURE_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+# shellcheck source=../headless-runtime-lib.sh
+source "$SCRIPT_DIR/headless-runtime-lib.sh"
+
+write_fixture() {
+	local name="$1" body="$2"
+	local path="$FIXTURE_DIR/$name.log"
+	printf '%s\n' "$body" >"$path"
+	printf '%s' "$path"
+	return 0
+}
+
+check_classification() {
+	local label="$1" body="$2" expected_reason="$3" expected_provider_type="$4"
+	local expected_status="$5" expected_runtime_type="$6" expected_source="$7"
+	local path reason
+	path=$(write_fixture "$label" "$body")
+	reason=$(classify_failure_reason "$path")
+	assert_eq "$label reason" "$expected_reason" "$reason"
+	assert_eq "$label provider_error_type" "$expected_provider_type" "${_failure_provider_error_type:-}"
+	assert_eq "$label provider_status" "$expected_status" "${_failure_provider_status:-}"
+	assert_eq "$label runtime_error_type" "$expected_runtime_type" "${_failure_runtime_error_type:-}"
+	assert_eq "$label classification_source" "$expected_source" "${_failure_classification_source:-}"
+	return 0
+}
+
+echo "${TEST_BLUE}=== headless runtime failure classification tests ===${TEST_NC}"
+
+check_classification \
+	"openai_rate_limit" \
+	'{"provider":"openai","error":{"type":"rate_limit","message":"Too many requests"},"status":429}' \
+	"rate_limit" "rate_limit" "429" "" "output_pattern"
+
+check_classification \
+	"openai_server_error" \
+	'{"provider":"openai","error":{"type":"server_error","message":"The server had an error"},"status":500}
+	"provider_error" "server_error" "500" "" "output_pattern"
+
+check_classification \
+	"auth_failure" \
+	'OpenAI authentication failed: invalid API key; status 401 unauthorized' \
+	"auth_error" "auth_error" "401" "" "output_pattern"
+
+check_classification \
+	"opencode_sqlite_crash" \
+	'failed to list snapshot files in /tmp/opencode/snapshot
+fatal: not a git repository
+SQLiteError: disk I/O error' \
+	"local_error" "" "" "opencode_sqlite_io" "opencode_runtime"
+
+mkdir -p "$METRICS_DIR"
+append_runtime_metric "worker" "issue-22379" "openai/gpt-5.5" "openai" \
+	"provider_error" "1" "provider_error" "1" "1234" "22379" "marcusquinn/aidevops" \
+	"$FIXTURE_DIR/work" "$FIXTURE_DIR/openai_server_error.log" "ses_test" \
+	"server_error" "500" "" "output_pattern"
+
+assert_eq "metric provider_error_type persisted" "server_error" \
+	"$(jq -r '.provider_error_type' "$METRICS_FILE")"
+assert_eq "metric provider_status persisted" "500" \
+	"$(jq -r '.provider_status' "$METRICS_FILE")"
+assert_eq "metric classification_source persisted" "output_pattern" \
+	"$(jq -r '.classification_source' "$METRICS_FILE")"
+
+echo
+echo "${TEST_BLUE}=== Summary ===${TEST_NC}"
+echo "Tests run:    $TESTS_RUN"
+echo "Tests failed: $TESTS_FAILED"
+
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	echo "${TEST_GREEN}All tests passed.${TEST_NC}"
+	exit 0
+else
+	echo "${TEST_RED}$TESTS_FAILED test(s) failed.${TEST_NC}"
+	exit 1
+fi

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -111,8 +111,8 @@ T_FUTURE_SENTINEL=4102444800
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-3","session_id":"ses_3","issue_number":22349,"repo_slug":"marcusquinn/aidevops","work_dir":"/tmp/wt-3","output_file":"/tmp/excerpt-3.log","result":"watchdog_stall_killed","failure_reason":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-4","result":"watchdog_stall_continue","exit_code":0}\n' "$T_5MIN_AGO"
-	printf '{"ts":%d,"role":"worker","session_key":"issue-5","result":"rate_limit","exit_code":1}\n' "$T_2H_AGO"
-	printf '{"ts":%d,"role":"worker","session_key":"issue-6","result":"unknown_failure","exit_code":2}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-5","model":"openai/gpt-5.5","provider":"openai","result":"rate_limit","failure_reason":"rate_limit","provider_error_type":"rate_limit","provider_status":"429","classification_source":"output_pattern","exit_code":1}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-6","model":"openai/gpt-5.5","provider":"openai","result":"provider_error","failure_reason":"provider_error","provider_error_type":"server_error","provider_status":"500","classification_source":"output_pattern","exit_code":2}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-7","result":"success","exit_code":0}\n' "$T_25H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-8","result":"watchdog_stall_continue","exit_code":124}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-9","result":"success","exit_code":0}\n' "$T_FUTURE_SENTINEL"
@@ -210,6 +210,12 @@ assert_eq "2h7: failure groups carry issue evidence" "22349" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-3") | .issue_number')"
 assert_eq "2h8: failure groups include repo evidence" "marcusquinn/aidevops" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-3") | .repo_slug')"
+assert_eq "2h9: failure groups expose provider subtype" "server_error" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-6") | .provider_error_type')"
+assert_eq "2h10: failure groups expose provider status" "500" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-6") | .provider_status')"
+assert_eq "2h11: recent examples carry provider evidence" "openai/gpt-5.5" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-5") | .model')"
 
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -143,15 +143,21 @@ _wah_metric_details_json() {
 				avg: (if ($durations | length) > 0 then (($durations | add) / ($durations | length) | floor) else 0 end),
 				max: (if ($durations | length) > 0 then ($durations | max) else 0 end)
 			},
-			recent_examples: ($w | sort_by(.ts // 0) | reverse | .[0:5] | map({
+				recent_examples: ($w | sort_by(.ts // 0) | reverse | .[0:5] | map({
 				ts,
 				session_key,
 				session_id,
 				issue_number,
 				repo_slug,
+				model,
+				provider,
 				result,
 				exit_code,
 				failure_reason,
+				provider_error_type,
+				provider_status,
+				runtime_error_type,
+				classification_source,
 				duration_ms,
 				work_dir,
 				output_file,
@@ -160,16 +166,22 @@ _wah_metric_details_json() {
 			})),
 			failure_groups: ([
 				$failures
-				| group_by([.result // "unknown", .failure_reason // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
+				| group_by([.result // "unknown", .failure_reason // "", .provider_error_type // "", .provider_status // "", .runtime_error_type // "", .classification_source // "", .provider // "", .model // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
 				| .[]
 				| {
 					result: (.[0].result // "unknown"),
 					failure_reason: (.[0].failure_reason // ""),
+					provider_error_type: (.[0].provider_error_type // ""),
+					provider_status: (.[0].provider_status // ""),
+					runtime_error_type: (.[0].runtime_error_type // ""),
+					classification_source: (.[0].classification_source // ""),
+					provider: (.[0].provider // ""),
+					model: (.[0].model // ""),
 					session_key: (.[0].session_key // ""),
 					issue_number: (.[0].issue_number // null),
 					repo_slug: (.[0].repo_slug // ""),
 					count: length,
-					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_id, work_dir, output_file, exit_code, duration_ms}))
+					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_id, work_dir, output_file, exit_code, duration_ms, provider_error_type, provider_status, runtime_error_type, classification_source}))
 				}
 			] | sort_by(.count) | reverse | .[0:10])
 		}' <"$metrics" 2>/dev/null || \


### PR DESCRIPTION
## Summary

Added provider/runtime failure subtype metadata, metric persistence, summary grouping, and fixtures for OpenAI rate limits, server errors, auth failures, and OpenCode SQLite/snapshot crashes.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-failure-classification.sh,.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-headless-runtime-failure-classification.sh; .agents/scripts/tests/test-worker-activity-helper.sh; shellcheck modified scripts/tests; worker-activity-helper.sh summary --since 1h --json --no-pr-check --repo marcusquinn/aidevops

Resolves #22379


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 9m and 110,682 tokens on this as a headless worker.