### PR TITLE
t3481: Preserve TODO refs after fallback issue creation

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -605,7 +605,8 @@ _insert_todo_line() {
 # - Labels with status:, tier:, origin:, dispatched:, implemented: prefixes
 #   are skipped — they are not TODO-file-format tags.
 # GH#21473: 3rd arg is TITLE (one-line summary), not DESCRIPTION (full body).
-# Returns 0 always (non-fatal; the issue is already created).
+# Returns 0 only when the target TODO ref is present after the write attempt.
+# Returns 1 when TODO.md exists but the ref could not be written/verified.
 _ensure_todo_entry_written() {
 	local task_id="$1"
 	local issue_num="$2"
@@ -622,7 +623,8 @@ _ensure_todo_entry_written() {
 		if declare -F add_gh_ref_to_todo >/dev/null 2>&1; then
 			add_gh_ref_to_todo "$task_id" "$issue_num" "$todo_file" 2>/dev/null || true
 		fi
-		return 0
+		_todo_entry_has_gh_ref "$task_id" "$issue_num" "$todo_file" && return 0
+		return 1
 	fi
 
 	# Build tag suffix from labels (skip reserved-prefix labels applied
@@ -677,7 +679,20 @@ _ensure_todo_entry_written() {
 	if declare -F log_info >/dev/null 2>&1; then
 		log_info "t2548: appended TODO entry for ${task_id} (ref:GH#${issue_num})"
 	fi
-	return 0
+	_todo_entry_has_gh_ref "$task_id" "$issue_num" "$todo_file" && return 0
+	return 1
+}
+
+# _todo_entry_has_gh_ref TASK_ID ISSUE_NUM TODO_FILE
+# Verify a task line outside code fences contains the expected GH ref.
+_todo_entry_has_gh_ref() {
+	local task_id="$1"
+	local issue_num="$2"
+	local todo_file="$3"
+	local task_id_ere
+	task_id_ere=$(_escape_ere "$task_id")
+	strip_code_fences <"$todo_file" | grep -qE "^[[:space:]]*- \\[.\\] ${task_id_ere} .*ref:GH#${issue_num}([[:space:]]|$)"
+	return $?
 }
 
 # =============================================================================

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -521,6 +521,15 @@ create_github_issue() {
 
 	# Dedup check before bare creation (t1446)
 	if issue_num=$(_check_duplicate_issue "$title"); then
+		# GH#22381: issue-sync-helper.sh push can create the issue but emit no
+		# parseable number. The duplicate lookup then recovers the issue number;
+		# stamp/verify TODO.md before reporting success so dispatchability sees
+		# the same state as the returned issue number.
+		if ! _ensure_todo_entry_written \
+			"$_task_id_for_todo" "$issue_num" "$title" "$labels" "$repo_path"; then
+			log_warn "Recovered issue #${issue_num}, but failed to write TODO ref for ${_task_id_for_todo}"
+			return 1
+		fi
 		echo "$issue_num"
 		return 0
 	fi
@@ -634,8 +643,11 @@ create_github_issue() {
 	# through issue-sync-helper.sh, so _push_process_task never runs and
 	# the TODO entry is never written. This call closes that gap idempotently.
 	# GH#21473: pass $title (one-liner), not $description (full body).
-	_ensure_todo_entry_written \
-		"$_task_id_for_todo" "$issue_num" "$title" "$labels" "$repo_path"
+	if ! _ensure_todo_entry_written \
+		"$_task_id_for_todo" "$issue_num" "$title" "$labels" "$repo_path"; then
+		log_warn "Created issue #${issue_num}, but failed to write TODO ref for ${_task_id_for_todo}"
+		return 1
+	fi
 
 	echo "$issue_num"
 	return 0

--- a/.agents/scripts/tests/test-claim-task-id-no-orphan.sh
+++ b/.agents/scripts/tests/test-claim-task-id-no-orphan.sh
@@ -30,6 +30,8 @@
 #   6. `bug` / `enhancement` labels map to `#bug` / `#feat` tags
 #   7. No TODO.md file → silent no-op (non-fatal)
 #   8. Empty task_id or issue_num → silent no-op (non-fatal)
+#   9. Existing entry with a different GH ref returns failure
+#   10. issue-sync no-number + duplicate recovery stamps TODO ref
 
 set -u
 
@@ -304,6 +306,78 @@ test_empty_task_id() {
 	return 0
 }
 test_empty_task_id
+
+# ---------------------------------------------------------------------------
+# Test 9 — Existing entry with a different GH ref must fail verification
+# ---------------------------------------------------------------------------
+test_existing_wrong_ref_fails() {
+	local name="9: existing entry with different GH ref → returns failure"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	cat >"${tmpdir}/TODO.md" <<'EOF'
+# Tasks
+
+- [ ] t2548 fix orphan bug ref:GH#99999
+EOF
+
+	local rc=0
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" "" "$tmpdir" || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected non-zero when ref:GH#20180 could not be verified"
+	fi
+	return 0
+}
+test_existing_wrong_ref_fails
+
+# ---------------------------------------------------------------------------
+# Test 10 — issue-sync creates but emits no number; duplicate recovery still
+# stamps TODO.md with the recovered issue number before create_github_issue
+# reports success (GH#22381).
+# ---------------------------------------------------------------------------
+test_issue_sync_no_number_duplicate_recovery_stamps_ref() {
+	local name="10: issue-sync no-number duplicate recovery stamps TODO ref"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	cat >"${tmpdir}/TODO.md" <<'EOF'
+# Project TODO
+
+## Backlog
+
+- [ ] t3481 Preserve TODO refs after fallback issue creation #bug #auto-dispatch
+EOF
+
+	_try_issue_sync_delegation() {
+		return 1
+	}
+	_check_duplicate_issue() {
+		printf '22370'
+		return 0
+	}
+
+	local issue_num rc=0
+	issue_num=$(create_github_issue \
+		"t3481: Preserve TODO refs after fallback issue creation" \
+		"description not used on duplicate recovery" \
+		"bug,auto-dispatch" \
+		"$tmpdir") || rc=$?
+
+	if [[ $rc -eq 0 && "$issue_num" == "22370" ]] && \
+		grep -qE '^- \[ \] t3481 .*ref:GH#22370$' "${tmpdir}/TODO.md"; then
+		pass "$name"
+	else
+		fail "$name" "rc=${rc} issue=${issue_num:-<empty>} line=$(grep 't3481' "${tmpdir}/TODO.md" || echo '(none)')"
+	fi
+	return 0
+}
+test_issue_sync_no_number_duplicate_recovery_stamps_ref
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

Verified TODO ref stamping when issue-sync creates an issue without emitting a parseable number and duplicate recovery supplies the issue number; fallback issue creation now fails if the TODO ref cannot be verified.

## Files Changed

.agents/scripts/claim-task-id-issue.sh,.agents/scripts/claim-task-id.sh,.agents/scripts/tests/test-claim-task-id-no-orphan.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-claim-task-id-no-orphan.sh; shellcheck .agents/scripts/claim-task-id.sh .agents/scripts/claim-task-id-issue.sh .agents/scripts/tests/test-claim-task-id-no-orphan.sh; .agents/scripts/task-dispatchability-helper.sh check --task-id t3475 --issue 22370

Resolves #22381


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 12m and 218,535 tokens on this as a headless worker.