### PR TITLE
GH#22368: block secret file reads before model context

### DIFF
--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -59,13 +59,20 @@ CREDENTIAL_PATTERN = re.compile(
     re.ASCII,
 )
 
+PEM_PRIVATE_KEY_PATTERN = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+
 REDACTION_TOKEN = "[redacted-credential]"
+PEM_REDACTION_TOKEN = "[redacted-private-key]"
 
 
 def scrub_credentials(text: str) -> tuple[str, int]:
     """Replace credential tokens in text. Returns (scrubbed_text, match_count)."""
-    result, count = CREDENTIAL_PATTERN.subn(REDACTION_TOKEN, text)
-    return result, count
+    result, pem_count = PEM_PRIVATE_KEY_PATTERN.subn(PEM_REDACTION_TOKEN, text)
+    result, token_count = CREDENTIAL_PATTERN.subn(REDACTION_TOKEN, result)
+    return result, pem_count + token_count
 
 
 def scrub_value(value):
@@ -91,8 +98,8 @@ def main() -> None:
 
     tool_response = data.get("tool_response", "")
 
-    # Fast path: no credential pattern anywhere in the raw payload.
-    if not CREDENTIAL_PATTERN.search(raw):
+    # Fast path: no credential/private-key pattern anywhere in the raw payload.
+    if not CREDENTIAL_PATTERN.search(raw) and not PEM_PRIVATE_KEY_PATTERN.search(raw):
         return
 
     # Scrub the tool_response field (may be str or nested JSON object).

--- a/.agents/hooks/privacy-guard-pre-push.sh
+++ b/.agents/hooks/privacy-guard-pre-push.sh
@@ -93,8 +93,7 @@ if ! privacy_enumerate_private_slugs "$slugs_file"; then
 fi
 
 if [[ ! -s "$slugs_file" ]]; then
-	[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "no private slugs to guard against"
-	exit 0
+	[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "no private slugs to guard against; secret-material scan still active"
 fi
 
 # ---------------------------------------------------------------------------
@@ -128,7 +127,61 @@ if [[ -n "$remote_name" ]]; then
 	fi
 fi
 
-[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "scanning push diff for private references"
+_watchlist_present=0
+for _ref_entry in "${_all_refs[@]}"; do
+	read -r _lr _ls _rr _rs <<<"$_ref_entry"
+	[[ -z "$_ls" ]] && continue
+	[[ "$_ls" =~ ^0+$ ]] && continue
+	# Determine base for diff: use remote sha when known, merge-base otherwise.
+	# Use the ref's own local SHA ($_ls) instead of HEAD so multi-ref pushes
+	# compute the correct base for each ref being pushed (GH#20177).
+	_base=""
+	if [[ -n "$_rs" ]] && ! [[ "$_rs" =~ ^0+$ ]]; then
+		_base="$_rs"
+	else
+		_base=$(git merge-base "$_ls" "$_default_remote_head" 2>/dev/null || echo "")
+	fi
+	[[ -z "$_base" ]] && _watchlist_present=1 && break
+	if git diff --name-only "$_base" "$_ls" 2>/dev/null \
+		| grep -qE '^(TODO\.md|README\.md|todo/|\.github/ISSUE_TEMPLATE/)'; then
+		_watchlist_present=1
+		break
+	fi
+done
+
+# Secret-material scan is global for public pushes. Unlike private-repo slug
+# scanning, it is not limited to planning/docs paths because private-key blocks
+# are unsafe in any public commit.
+secret_exit_code=0
+for _ref_entry in "${_all_refs[@]}"; do
+	read -r _lr _ls _rr _rs <<<"$_ref_entry"
+	[[ -z "$_ls" ]] && continue
+	[[ "$_ls" =~ ^0+$ ]] && continue
+	_secret_base="$_rs"
+	if [[ -z "$_secret_base" || "$_secret_base" =~ ^0+$ ]]; then
+		_secret_base=$(git merge-base "$_ls" "$_default_remote_head" 2>/dev/null || printf '')
+		[[ -z "$_secret_base" ]] && _secret_base="0000000000000000000000000000000000000000"
+	fi
+	secret_hits=$(privacy_scan_secret_material_diff "$_secret_base" "$_ls")
+	secret_rc=$?
+	if [[ "$secret_rc" -ne 0 ]]; then
+		printf '\n[privacy-guard][BLOCK] Push to %s contains secret/private-key material:\n\n' "$remote_name" >&2
+		printf '%s\n\n' "$secret_hits" >&2
+		printf '  Remove the secret material from committed content and amend/rewrite before pushing.\n' >&2
+		printf '  Use synthetic fixtures in tests; never commit real private keys or credential values.\n\n' >&2
+		secret_exit_code=1
+	fi
+done
+if [[ "$secret_exit_code" -ne 0 ]]; then
+	exit "$secret_exit_code"
+fi
+
+if [[ "$_watchlist_present" -eq 0 ]]; then
+	[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "no watchlist files (TODO.md, todo/**, README.md, .github/ISSUE_TEMPLATE/**) in push diff — private-reference scan skipped"
+	exit 0
+fi
+
+[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "watchlist files present — scanning push diff for private references"
 
 # Walk each ref in the push (re-iterate over collected refs)
 exit_code=0

--- a/.agents/hooks/secret_file_read_guard.py
+++ b/.agents/hooks/secret_file_read_guard.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Claude Code PreToolUse guard: block secret/private-key file reads."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+SECRET_BASENAME_RE = re.compile(
+    r"^(id_(rsa|dsa|ecdsa|ed25519)|\.env(\..*)?|credentials(\.sh|\.json|\.ya?ml)?|service-account(\.json)?|kubeconfig|config\.json|op-vault-export.*|.*password.*|.*passwd.*|.*secret.*)$",
+    re.IGNORECASE,
+)
+SECRET_EXTENSION_RE = re.compile(r"\.(pem|key|p12|pfx|kdbx|age|asc|gpg)$", re.IGNORECASE)
+PUBLIC_KEY_RE = re.compile(r"\.pub$", re.IGNORECASE)
+SECRET_PATH_RE = re.compile(
+    r"(^|[/\\])(\.ssh|\.gnupg|\.aws|\.azure|\.config[/\\]gcloud|\.kube|1password|op-vault|password-store)([/\\]|$)",
+    re.IGNORECASE,
+)
+READ_TOOLS = {"Read", "read", "Glob", "glob", "NotebookRead", "notebook_read"}
+
+
+def extract_path(tool_input: dict) -> str:
+    """Extract a path-like argument from a Claude Code read tool payload."""
+    return str(
+        tool_input.get("filePath")
+        or tool_input.get("file_path")
+        or tool_input.get("path")
+        or tool_input.get("pattern")
+        or ""
+    )
+
+
+def secret_read_block_reason(path: str) -> str:
+    """Return a deny reason for high-risk secret paths, or empty string."""
+    if not path:
+        return ""
+    normalized = os.path.normpath(path)
+    base = os.path.basename(normalized)
+    if PUBLIC_KEY_RE.search(base):
+        return ""
+    if SECRET_BASENAME_RE.search(base):
+        return "secret-bearing basename"
+    if SECRET_EXTENSION_RE.search(base):
+        return "secret-bearing file extension"
+    if SECRET_PATH_RE.search(normalized):
+        return "credential-store path"
+    return ""
+
+
+def deny(path: str, reason: str) -> dict:
+    """Build a Claude Code PreToolUse deny response."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "BLOCKED by secret_file_read_guard.py (aidevops)\n\n"
+                f"Reason: {reason}\n\n"
+                f"Path: {path}\n\n"
+                "Secret/private-key files must not be read into model context. "
+                "Use a synthetic fixture or ask the user to inspect the file locally. "
+                "Public key files ending .pub are allowed."
+            ),
+        }
+    }
+
+
+def main() -> None:
+    """Read Claude hook payload from stdin and deny unsafe file reads."""
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return
+
+    tool_name = data.get("tool_name", "")
+    if tool_name not in READ_TOOLS:
+        return
+
+    tool_input = data.get("tool_input") or {}
+    path = extract_path(tool_input)
+    reason = secret_read_block_reason(path)
+    if reason:
+        print(json.dumps(deny(path, reason)))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+// Secret/private-key pre-read guard for OpenCode file-read tools.
+
+import { basename, normalize } from "path";
+
+const SECRET_BASENAME_RE = /^(id_(rsa|dsa|ecdsa|ed25519)|\.env(\..*)?|credentials(\.sh|\.json|\.ya?ml)?|service-account(\.json)?|kubeconfig|config\.json|op-vault-export.*|.*password.*|.*passwd.*|.*secret.*)$/i;
+const SECRET_EXTENSION_RE = /\.(pem|key|p12|pfx|kdbx|age|asc|gpg)$/i;
+const PUBLIC_KEY_RE = /\.pub$/i;
+const SECRET_PATH_RE = /(^|[/\\])(\.ssh|\.gnupg|\.aws|\.azure|\.config[/\\]gcloud|\.kube|1password|op-vault|password-store)([/\\]|$)/i;
+
+/**
+ * Check if a tool name is a file read operation.
+ * @param {string} tool
+ * @returns {boolean}
+ */
+export function isReadTool(tool) {
+  return ["Read", "read", "Glob", "glob", "NotebookRead", "notebook_read"].includes(tool || "");
+}
+
+/**
+ * Extract a path-like argument from a file-read tool payload.
+ * @param {object} args
+ * @returns {string}
+ */
+export function extractReadPath(args = {}) {
+  return args.filePath || args.file_path || args.path || args.pattern || "";
+}
+
+/**
+ * Return a block reason for high-risk secret paths, or empty string when safe.
+ * @param {string} filePath
+ * @returns {string}
+ */
+export function secretReadBlockReason(filePath) {
+  if (!filePath || typeof filePath !== "string") return "";
+  const normalized = normalize(filePath);
+  const base = basename(normalized);
+  if (PUBLIC_KEY_RE.test(base)) return "";
+  if (SECRET_BASENAME_RE.test(base)) return "secret-bearing basename";
+  if (SECRET_EXTENSION_RE.test(base)) return "secret-bearing file extension";
+  if (SECRET_PATH_RE.test(normalized)) return "credential-store path";
+  return "";
+}
+
+/**
+ * Block OpenCode file-read tools before secret content enters model context.
+ * @param {string} tool
+ * @param {object} args
+ * @param {Function} log
+ */
+export function checkSecretReadGate(tool, args, log = () => {}) {
+  if (!isReadTool(tool)) return;
+  const filePath = extractReadPath(args);
+  const reason = secretReadBlockReason(filePath);
+  if (!reason) return;
+  const message = `[secret-read-guard] blocked ${tool} of ${filePath}: ${reason}`;
+  log("WARN", message);
+  throw new Error(`${message}\n\nUse a non-secret fixture or ask the user to inspect the file locally. Public key files ending .pub are allowed.`);
+}

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -12,9 +12,11 @@ import { extractAndStoreIntent, consumeIntent } from "./intent-tracing.mjs";
 import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
 import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enrichment.mjs";
+import { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs";
 
 // Re-export for consumers that import from this module
 export { scanForSecrets } from "./quality-logging.mjs";
+export { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs";
 
 // ---------------------------------------------------------------------------
 // Credential transcript scrub (GH#20207, Layer 4 of t2458)
@@ -250,6 +252,8 @@ function handleToolBefore(ctx, log, input, output) {
     // output.args.command) or block (throw) as appropriate.
     checkSignatureFooterGate(output.args?.command || "", log, ctx.scriptsDir, output);
   }
+
+  checkSecretReadGate(input.tool, output.args || {}, log);
 
   if (!isWriteOrEditTool(input.tool)) return;
 

--- a/.agents/reference/secret-handling.md
+++ b/.agents/reference/secret-handling.md
@@ -53,6 +53,16 @@ Rules for preventing credential exposure in AI agent sessions. Extracted from `A
   - Do NOT repeat, echo, or reference the pasted value in your response
   - Continue with a placeholder like `<YOUR_API_KEY>` instead
 
+### Layered secret-read and egress controls (GH#22368)
+
+Secret protection is deliberately layered so one missed path does not expose raw material:
+
+1. **Pre-read deny:** OpenCode file-read tools are blocked by `quality-hooks-secret-read.mjs`; Claude Code `Read|Glob|NotebookRead` calls are blocked by `secret_file_read_guard.py`. Obvious secret paths include private SSH key names, `.pem`, `.key`, `.env`, credentials files, cloud/kube credential stores, and password-manager exports. Public key files ending `.pub` remain allowed.
+2. **Command guard:** `sandbox-exec-helper.sh` blocks shell reads of the same high-risk paths unless the caller explicitly uses the audited local bypass for a user-approved operation.
+3. **Transcript scrub:** `credential-transcript-scrub.py` redacts known token prefixes and PEM/private-key blocks if upstream prevention misses a result.
+4. **GitHub egress guard:** the `gh` PATH shim scans issue/PR/comment body text and body files before writes to public repositories, blocking private-key material and credential-token patterns.
+5. **Pre-push guard:** `privacy-guard-pre-push.sh` blocks public pushes that introduce synthetic or real private-key material. Tests must use synthetic fixtures only; never read or commit real credential files.
+
 ---
 
 ## 8.3 Secret as Command Argument Exposure (t4939)

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -626,6 +626,80 @@ _shim_privacy_scan() {
 		return 0
 	fi
 
+	# Build content blob from --body / --body-file / --title args plus
+	# `-f body=...` / `-F body=@...` forms used by gh api. Secret-material
+	# egress scan runs before private-slug enumeration so it remains active even
+	# when the user has no private repos configured.
+	local _blob="" _bf _kv
+	_idx=0
+	while [[ $_idx -lt ${#_modified_args[@]} ]]; do
+		case "${_modified_args[$_idx]}" in
+		--body)
+			_blob+="${_modified_args[_idx + 1]:-}"$'\n'
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--body=*) _blob+="${_modified_args[$_idx]#--body=}"$'\n' ;;
+		--body-file)
+			_bf="${_modified_args[_idx + 1]:-}"
+			[[ -n "$_bf" && -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--body-file=*)
+			_bf="${_modified_args[$_idx]#--body-file=}"
+			[[ -n "$_bf" && -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+			;;
+		--title)
+			_blob+="${_modified_args[_idx + 1]:-}"$'\n'
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--title=*) _blob+="${_modified_args[$_idx]#--title=}"$'\n' ;;
+		-f | --field | -F | --raw-field)
+			_kv="${_modified_args[_idx + 1]:-}"
+			case "$_kv" in
+			body=@*)
+				_bf="${_kv#body=@}"
+				[[ -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+				;;
+			body=*) _blob+="${_kv#body=}"$'\n' ;;
+			title=*) _blob+="${_kv#title=}"$'\n' ;;
+			esac
+			_idx=$((_idx + 2))
+			continue
+			;;
+		-f* | -F* | --field=* | --raw-field=*)
+			case "${_modified_args[$_idx]}" in
+			-f*) _kv="${_modified_args[$_idx]#-f}" ;;
+			-F*) _kv="${_modified_args[$_idx]#-F}" ;;
+			--field=*) _kv="${_modified_args[$_idx]#--field=}" ;;
+			--raw-field=*) _kv="${_modified_args[$_idx]#--raw-field=}" ;;
+			esac
+			case "$_kv" in
+			body=@*)
+				_bf="${_kv#body=@}"
+				[[ -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+				;;
+			body=*) _blob+="${_kv#body=}"$'\n' ;;
+			title=*) _blob+="${_kv#title=}"$'\n' ;;
+			esac
+			;;
+		esac
+		_idx=$((_idx + 1))
+	done
+
+	local _secret_hits
+	_secret_hits=$(privacy_scan_secret_material_text "$_blob")
+	local _secret_scan_rc=$?
+	if [[ $_secret_scan_rc -eq 1 ]]; then
+		printf '\n[aidevops][privacy-scan][BLOCK] Write to public %s contains secret/private-key material:\n\n' "$target_url" >&2
+		printf '%s\n' "$_secret_hits" | sed 's/^/  /' >&2
+		printf '\n  Remove secret material before posting. Use synthetic fixtures only; never paste private keys or credential values.\n' >&2
+		printf '  Bypass (audit-logged): AIDEVOPS_GH_PRIVACY_BYPASS=1 gh ...\n\n' >&2
+		return 1
+	fi
+
 	# Enumerate private slugs.
 	local _slugs_file
 	_slugs_file=$(mktemp 2>/dev/null) || return 0
@@ -635,7 +709,7 @@ _shim_privacy_scan() {
 	fi
 	# Build content blob from --body / --body-file / --title args plus
 	# `-f body=...` / `-F body=@...` forms used by gh api.
-	local _blob="" _bf _kv
+	_blob=""
 	_idx=0
 	while [[ $_idx -lt ${#_modified_args[@]} ]]; do
 		case "${_modified_args[$_idx]}" in

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -31,11 +31,13 @@ HOOKS_DIR="$HOME/.aidevops/hooks"
 HOOK_SCRIPT="$HOOKS_DIR/git_safety_guard.py"
 POST_HOOK_SCRIPT="$HOOKS_DIR/mcp_task_post_hook.py"
 CREDENTIAL_SCRUB_SCRIPT="$HOOKS_DIR/credential-transcript-scrub.py"
+SECRET_READ_GUARD_SCRIPT="$HOOKS_DIR/secret_file_read_guard.py"
 COMPLEXITY_ADVISORY_SCRIPT="$HOOKS_DIR/complexity_advisory_pre_edit.py"
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
 HOOK_COMMAND="\$HOME/.aidevops/hooks/git_safety_guard.py"
 POST_HOOK_COMMAND="\$HOME/.aidevops/hooks/mcp_task_post_hook.py"
 CREDENTIAL_SCRUB_COMMAND="\$HOME/.aidevops/hooks/credential-transcript-scrub.py"
+SECRET_READ_GUARD_COMMAND="\$HOME/.aidevops/hooks/secret_file_read_guard.py"
 COMPLEXITY_ADVISORY_COMMAND="\$HOME/.aidevops/hooks/complexity_advisory_pre_edit.py"
 
 # gh-wrapper-guard pre-push hook (t2113)
@@ -587,6 +589,8 @@ install_hook() {
 	source_post_hook=$(find_source_hook "mcp_task_post_hook.py") || return 1
 	local source_credential_scrub_hook
 	source_credential_scrub_hook=$(find_source_hook "credential-transcript-scrub.py") || return 1
+	local source_secret_read_guard_hook
+	source_secret_read_guard_hook=$(find_source_hook "secret_file_read_guard.py") || return 1
 	local source_complexity_advisory_hook
 	source_complexity_advisory_hook=$(find_source_hook "complexity_advisory_pre_edit.py") || return 1
 
@@ -606,6 +610,9 @@ install_hook() {
 	cp "$source_credential_scrub_hook" "$CREDENTIAL_SCRUB_SCRIPT"
 	chmod +x "$CREDENTIAL_SCRUB_SCRIPT"
 	print_success "Installed $CREDENTIAL_SCRUB_SCRIPT"
+	cp "$source_secret_read_guard_hook" "$SECRET_READ_GUARD_SCRIPT"
+	chmod +x "$SECRET_READ_GUARD_SCRIPT"
+	print_success "Installed $SECRET_READ_GUARD_SCRIPT"
 	cp "$source_complexity_advisory_hook" "$COMPLEXITY_ADVISORY_SCRIPT"
 	chmod +x "$COMPLEXITY_ADVISORY_SCRIPT"
 	print_success "Installed $COMPLEXITY_ADVISORY_SCRIPT"
@@ -658,6 +665,15 @@ settings = {
                     {
                         'type': 'command',
                         'command': '$HOOK_COMMAND'
+                    }
+                ]
+            },
+            {
+                'matcher': 'Read|Glob|NotebookRead',
+                'hooks': [
+                    {
+                        'type': 'command',
+                        'command': '$SECRET_READ_GUARD_COMMAND'
                     }
                 ]
             },
@@ -722,6 +738,7 @@ hooks = d.get('hooks', {})
 has_guard_bash = False
 has_guard_edit_write = False
 has_complexity = False
+has_secret_read_guard = False
 for h in hooks.get('PreToolUse', []):
     matcher = h.get('matcher', '')
     for sub in h.get('hooks', []):
@@ -733,6 +750,8 @@ for h in hooks.get('PreToolUse', []):
                 has_guard_edit_write = True
         if 'complexity_advisory' in cmd:
             has_complexity = True
+        if 'secret_file_read_guard' in cmd:
+            has_secret_read_guard = True
 
 has_post = False
 has_scrub = False
@@ -743,7 +762,7 @@ for h in hooks.get('PostToolUse', []):
         if 'credential-transcript-scrub' in sub.get('command', ''):
             has_scrub = True
 
-if has_guard_bash and has_guard_edit_write and has_complexity and has_post and has_scrub:
+if has_guard_bash and has_guard_edit_write and has_complexity and has_secret_read_guard and has_post and has_scrub:
     sys.exit(0)
 sys.exit(1)
 " 2>/dev/null; then
@@ -814,6 +833,16 @@ complexity_advisory_entry = {
     ]
 }
 
+secret_read_guard_entry = {
+    'matcher': 'Read|Glob|NotebookRead',
+    'hooks': [
+        {
+            'type': 'command',
+            'command': '$SECRET_READ_GUARD_COMMAND'
+        }
+    ]
+}
+
 post_hook_entry = {
     'matcher': 'Task',
     'hooks': [
@@ -835,7 +864,7 @@ credential_scrub_entry = {
 }
 
 if 'PreToolUse' not in settings['hooks']:
-    settings['hooks']['PreToolUse'] = [hook_entry, complexity_advisory_entry]
+    settings['hooks']['PreToolUse'] = [hook_entry, secret_read_guard_entry, complexity_advisory_entry]
 else:
     if not has_hook(settings['hooks']['PreToolUse'], 'git_safety_guard'):
         settings['hooks']['PreToolUse'].append(hook_entry)
@@ -843,6 +872,8 @@ else:
     ensure_hook_in_matcher(settings['hooks']['PreToolUse'], 'Edit|Write', '$HOOK_COMMAND')
     if not has_hook(settings['hooks']['PreToolUse'], 'complexity_advisory'):
         settings['hooks']['PreToolUse'].append(complexity_advisory_entry)
+    if not has_hook(settings['hooks']['PreToolUse'], 'secret_file_read_guard'):
+        settings['hooks']['PreToolUse'].append(secret_read_guard_entry)
 
 if 'PostToolUse' not in settings['hooks']:
     settings['hooks']['PostToolUse'] = [post_hook_entry, credential_scrub_entry]
@@ -890,6 +921,12 @@ uninstall_hook() {
 	else
 		print_info "Credential scrub hook not found (already removed)"
 	fi
+	if [[ -f "$SECRET_READ_GUARD_SCRIPT" ]]; then
+		rm "$SECRET_READ_GUARD_SCRIPT"
+		print_success "Removed $SECRET_READ_GUARD_SCRIPT"
+	else
+		print_info "Secret read guard hook not found (already removed)"
+	fi
 	if [[ -f "$COMPLEXITY_ADVISORY_SCRIPT" ]]; then
 		rm "$COMPLEXITY_ADVISORY_SCRIPT"
 		print_success "Removed $COMPLEXITY_ADVISORY_SCRIPT"
@@ -909,7 +946,7 @@ hooks = settings.get('hooks', {}).get('PreToolUse', [])
 filtered = []
 for h in hooks:
     sub_hooks = h.get('hooks', [])
-    sub_filtered = [s for s in sub_hooks if 'git_safety_guard' not in s.get('command', '') and 'complexity_advisory' not in s.get('command', '')]
+    sub_filtered = [s for s in sub_hooks if 'git_safety_guard' not in s.get('command', '') and 'complexity_advisory' not in s.get('command', '') and 'secret_file_read_guard' not in s.get('command', '')]
     if sub_filtered:
         h['hooks'] = sub_filtered
         filtered.append(h)
@@ -1107,6 +1144,34 @@ sys.exit(1)
 	return 0
 }
 
+_check_status_secret_read_guard_hook() {
+	if [[ -f "$SECRET_READ_GUARD_SCRIPT" ]] && [[ -x "$SECRET_READ_GUARD_SCRIPT" ]]; then
+		print_success "secret-file-read-guard: $SECRET_READ_GUARD_SCRIPT"
+	elif [[ -f "$SECRET_READ_GUARD_SCRIPT" ]]; then
+		print_warning "secret-file-read-guard: installed but not executable"
+		return 1
+	else
+		print_warning "secret-file-read-guard: not installed (run: install-hooks-helper.sh install)"
+		return 1
+	fi
+	if [[ -f "$CLAUDE_SETTINGS" ]] && python3 -c "
+import json, sys
+with open('$CLAUDE_SETTINGS') as f:
+    d = json.load(f)
+for h in d.get('hooks', {}).get('PreToolUse', []):
+    for sub in h.get('hooks', []):
+        if 'secret_file_read_guard' in sub.get('command', ''):
+            sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+		print_success "  PreToolUse registration: present"
+	else
+		print_warning "  PreToolUse registration: missing (run: install-hooks-helper.sh install)"
+		return 1
+	fi
+	return 0
+}
+
 _check_status_precommit_hook() {
 	local common_dir pc_hook_path
 	if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
@@ -1160,6 +1225,11 @@ check_status() {
 	echo "Credential Transcript Scrub Hook (GH#20207)"
 	echo "--------------------------------------------"
 	_check_status_credential_scrub_hook || all_ok=false
+
+	echo ""
+	echo "Secret File Read Guard Hook (GH#22368)"
+	echo "----------------------------------------"
+	_check_status_secret_read_guard_hook || all_ok=false
 
 	echo ""
 	echo "GH Wrapper Guard (pre-push)"

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -426,6 +426,105 @@ privacy_scan_local_paths() {
 }
 
 # =============================================================================
+# Secret-material scanning (private-key / credential content)
+# =============================================================================
+
+#######################################
+# Scan free-form text for private-key material or obvious credential values.
+# Arguments:
+#   $1 - text content to scan
+# Output: one finding label per hit class
+# Returns: 0 no hits, 1 hit(s)
+#######################################
+privacy_scan_secret_material_text() {
+	local text="$1"
+	local hits=0
+
+	if [[ -z "$text" ]]; then
+		return 0
+	fi
+
+	if printf '%s' "$text" | grep -qE -- '-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'; then
+		printf '%s\n' 'private-key PEM block'
+		hits=$((hits + 1))
+	fi
+	if printf '%s' "$text" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
+		printf '%s\n' 'credential token prefix'
+		hits=$((hits + 1))
+	fi
+
+	if [[ "$hits" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Scan all added diff lines for private-key material.
+# Arguments:
+#   $1 - base SHA (remote tip); may be all zeros for a new branch push
+#   $2 - head SHA (local tip)
+# Writes: "file:line: finding" lines to stdout
+# Returns: 0 no hits, 1 hit(s)
+#######################################
+privacy_scan_secret_material_diff() {
+	local base_sha="$1"
+	local head_sha="$2"
+	local diff_base="$base_sha"
+
+	if [[ "$base_sha" =~ ^0+$ ]]; then
+		local default_branch
+		default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||') || default_branch=""
+		[[ -z "$default_branch" ]] && default_branch="main"
+		diff_base=$(git merge-base "$head_sha" "origin/${default_branch}" 2>/dev/null) || diff_base=""
+		[[ -z "$diff_base" ]] && diff_base=$(git hash-object -t tree /dev/null)
+	fi
+
+	local diff_output
+	diff_output=$(git diff --unified=0 --no-color "$diff_base" "$head_sha" 2>/dev/null) || return 0
+	[[ -z "$diff_output" ]] && return 0
+
+	local hits=0 current_file="" line_num=0 in_pem=0
+	while IFS= read -r line; do
+		case "$line" in
+		"+++ b/"*) current_file="${line#+++ b/}"; line_num=0 ;;
+		"--- "*) ;;
+		"@@ "*)
+			local rest="${line#@@ -*+}"
+			local new_start="${rest%% *}"
+			line_num="${new_start%,*}"
+			;;
+		"+"*)
+			[[ "$line" == "+++ "* ]] && continue
+			local added="${line:1}"
+			if [[ "$added" =~ -----BEGIN[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
+				printf '%s:%s: private-key PEM block\n' "$current_file" "$line_num"
+				hits=$((hits + 1))
+				in_pem=1
+			elif [[ "$in_pem" -eq 1 ]]; then
+				printf '%s:%s: private-key PEM block content\n' "$current_file" "$line_num"
+				hits=$((hits + 1))
+			fi
+			if [[ "$added" =~ -----END[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
+				in_pem=0
+			fi
+			if printf '%s' "$added" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
+				printf '%s:%s: credential token prefix\n' "$current_file" "$line_num"
+				hits=$((hits + 1))
+			fi
+			line_num=$((line_num + 1))
+			;;
+		" "*) line_num=$((line_num + 1)) ;;
+		esac
+	done <<<"$diff_output"
+
+	if [[ "$hits" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# =============================================================================
 # Diff scanning
 # =============================================================================
 

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -118,8 +118,13 @@ _sandbox_secret_block_reason() {
 		return 0
 	fi
 
-	if [[ "$normalized" =~ (^|[[:space:];|&])cat[[:space:]]+([^[:space:]]*/)?(\.env([^[:space:]]*)?|credentials\.sh|[^[:space:]]*secret[^[:space:]]*)($|[[:space:];|&]) ]]; then
+	if [[ "$normalized" =~ (^|[[:space:];|&])(cat|less|more|tail|head|sed|awk)[[:space:]].*(^|[[:space:]/])((id_(rsa|dsa|ecdsa|ed25519))|\.env([^[:space:]]*)?|credentials\.(sh|json|ya?ml)|[^[:space:]]*secret[^[:space:]]*|[^[:space:]]*password[^[:space:]]*|[^[:space:]]*passwd[^[:space:]]*|[^[:space:]]*\.(pem|key|p12|pfx|kdbx|age|asc|gpg))($|[[:space:];|&]) ]]; then
 		echo "file read command targeting likely secret material"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])(cat|less|more|tail|head|sed|awk)[[:space:]].*(^|[[:space:]/])(\.ssh|\.gnupg|\.aws|\.azure|\.kube|password-store|1password|op-vault)(/|[[:space:];|&]) ]] && [[ ! "$normalized" =~ \.pub($|[[:space:];|&]) ]]; then
+		echo "file read command targeting credential-store path"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh
+++ b/.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh
@@ -85,6 +85,40 @@ test_allows_safe_command() {
 	return 0
 }
 
+test_blocks_private_key_file_read_command() {
+	local output
+	local exit_code
+
+	set +e
+	output="$(timeout 10 "$HELPER" run "cat /tmp/.ssh/id_ed25519" 2>&1)"
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 126 ]] && [[ "$output" == *"Blocked command due to secret leak risk"* ]]; then
+		print_result "blocks private key file read command" 0
+	else
+		print_result "blocks private key file read command" 1 "exit=$exit_code output=$output"
+	fi
+	return 0
+}
+
+test_allows_public_key_file_reference() {
+	local output
+	local exit_code
+
+	set +e
+	output="$(timeout 10 "$HELPER" run "cat /tmp/.ssh/id_ed25519.pub" 2>&1)"
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -ne 126 ]]; then
+		print_result "allows harmless public key reference path" 0
+	else
+		print_result "allows harmless public key reference path" 1 "exit=$exit_code output=$output"
+	fi
+	return 0
+}
+
 test_stream_stdout_returns_after_child_exit() {
 	local output
 	local exit_code
@@ -125,7 +159,9 @@ main() {
 	trap teardown_test_env EXIT
 
 	test_blocks_risky_env_print_command
+	test_blocks_private_key_file_read_command
 	test_allows_safe_command
+	test_allows_public_key_file_reference
 	test_stream_stdout_returns_after_child_exit
 	test_override_flag_allows_blocked_pattern
 

--- a/.agents/scripts/tests/test-secret-read-guards.sh
+++ b/.agents/scripts/tests/test-secret-read-guards.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '     %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+test_opencode_guard_blocks_private_key_paths() {
+	local output
+	set +e
+	output=$(node --input-type=module <<'NODE' 2>&1
+import { secretReadBlockReason } from './.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs';
+if (!secretReadBlockReason('/tmp/.ssh/id_ed25519')) process.exit(1);
+if (!secretReadBlockReason('/tmp/private.pem')) process.exit(2);
+if (secretReadBlockReason('/tmp/id_ed25519.pub')) process.exit(3);
+NODE
+)
+	local rc=$?
+	set -e
+	if [[ "$rc" -eq 0 ]]; then
+		pass "opencode guard blocks private-key paths and allows .pub"
+	else
+		fail "opencode guard blocks private-key paths and allows .pub" "exit=$rc output=$output"
+	fi
+	return 0
+}
+
+test_claude_guard_denies_read_payload() {
+	local output
+	output=$(printf '%s' '{"tool_name":"Read","tool_input":{"filePath":"/tmp/id_rsa"}}' | python3 "$REPO_DIR/.agents/hooks/secret_file_read_guard.py")
+	if [[ "$output" == *'"permissionDecision": "deny"'* ]]; then
+		pass "claude guard denies private-key read payload"
+	else
+		fail "claude guard denies private-key read payload" "$output"
+	fi
+	return 0
+}
+
+test_claude_guard_allows_public_key_payload() {
+	local output
+	output=$(printf '%s' '{"tool_name":"Read","tool_input":{"filePath":"/tmp/id_rsa.pub"}}' | python3 "$REPO_DIR/.agents/hooks/secret_file_read_guard.py")
+	if [[ -z "$output" ]]; then
+		pass "claude guard allows public-key read payload"
+	else
+		fail "claude guard allows public-key read payload" "$output"
+	fi
+	return 0
+}
+
+test_transcript_scrub_redacts_pem_blocks() {
+	local payload output
+	payload='{"tool_response":"before -----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY----- after"}'
+	output=$(printf '%s' "$payload" | python3 "$REPO_DIR/.agents/hooks/credential-transcript-scrub.py")
+	if [[ "$output" == *'[redacted-private-key]'* ]] && [[ "$output" != *'fake'* ]]; then
+		pass "transcript scrub redacts private-key PEM blocks"
+	else
+		fail "transcript scrub redacts private-key PEM blocks" "$output"
+	fi
+	return 0
+}
+
+test_privacy_helper_detects_secret_material() {
+	# shellcheck source=/dev/null
+	source "$REPO_DIR/.agents/scripts/privacy-guard-helper.sh"
+	local output
+	set +e
+	output=$(privacy_scan_secret_material_text $'-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----')
+	local rc=$?
+	set -e
+	if [[ "$rc" -eq 1 && "$output" == *"private-key PEM block"* ]]; then
+		pass "privacy helper detects private-key material"
+	else
+		fail "privacy helper detects private-key material" "exit=$rc output=$output"
+	fi
+	return 0
+}
+
+test_privacy_helper_detects_secret_material_diff() {
+	# shellcheck source=/dev/null
+	source "$REPO_DIR/.agents/scripts/privacy-guard-helper.sh"
+	local tmp old_pwd output rc
+	tmp=$(mktemp -d)
+	old_pwd=$(pwd)
+	trap 'cd "$old_pwd"; rm -rf "$tmp"' RETURN
+	cd "$tmp"
+	git init -q
+	git config user.email test@example.invalid
+	git config user.name Test
+	git config commit.gpgsign false
+	printf 'safe\n' >sample.txt
+	git add sample.txt
+	git commit -q -m init
+	local base
+	base=$(git rev-parse HEAD)
+	printf '%s\n' '-----BEGIN PRIVATE KEY-----' 'fake' '-----END PRIVATE KEY-----' >leak.txt
+	git add leak.txt
+	git commit -q -m leak
+	set +e
+	output=$(privacy_scan_secret_material_diff "$base" HEAD)
+	rc=$?
+	set -e
+	cd "$old_pwd"
+	rm -rf "$tmp"
+	trap - RETURN
+	if [[ "$rc" -eq 1 && "$output" == *"leak.txt"* && "$output" == *"private-key PEM block"* ]]; then
+		pass "privacy diff scan detects private-key material for pre-push"
+	else
+		fail "privacy diff scan detects private-key material for pre-push" "exit=$rc output=$output"
+	fi
+	return 0
+}
+
+main() {
+	test_opencode_guard_blocks_private_key_paths
+	test_claude_guard_denies_read_payload
+	test_claude_guard_allows_public_key_payload
+	test_transcript_scrub_redacts_pem_blocks
+	test_privacy_helper_detects_secret_material
+	test_privacy_helper_detects_secret_material_diff
+
+	printf '\nTests passed: %d\nTests failed: %d\n' "$PASS" "$FAIL"
+	[[ "$FAIL" -eq 0 ]]
+	return $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added pre-read guards for OpenCode and Claude Code, expanded sandbox/GitHub/pre-push egress protections, and documented the layered secret-handling model.

## Files Changed

.agents/hooks/credential-transcript-scrub.py,.agents/hooks/privacy-guard-pre-push.sh,.agents/hooks/secret_file_read_guard.py,.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs,.agents/plugins/opencode-aidevops/quality-hooks.mjs,.agents/reference/secret-handling.md,.agents/scripts/gh,.agents/scripts/install-hooks-helper.sh,.agents/scripts/privacy-guard-helper.sh,.agents/scripts/sandbox-exec-helper.sh,.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh,.agents/scripts/tests/test-secret-read-guards.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck targeted scripts; python3 -m py_compile credential hooks; node --check quality hook modules; test-secret-read-guards.sh; test-sandbox-sensitive-output-guard.sh; test-gh-shim.sh

Resolves #22368


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.93 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 21m and 356,264 tokens on this as a headless worker.