### PR TITLE
t3489: automate safe remote branch cleanup

### DIFF
--- a/.agents/scripts/cleanup-remote-branches-async-helper.sh
+++ b/.agents/scripts/cleanup-remote-branches-async-helper.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# cleanup-remote-branches-async-helper.sh — Async background remote branch cleanup runner (GH#22415).
+#
+# Invoked from pulse preflight so remote branch audits and optional safe deletes
+# never block dispatch. Default mode is dry-run. Deletion requires the explicit
+# AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY=1 opt-in and still delegates safety
+# classification to remote-branch-cleanup-helper.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly LOG_DIR="${HOME}/.aidevops/logs"
+readonly LOGFILE="${LOG_DIR}/cleanup_remote_branches.log"
+readonly LOCK_DIR="${LOG_DIR}/cleanup_remote_branches.lock"
+readonly PID_FILE="${LOCK_DIR}/pid"
+readonly LAST_RUN_FILE="${LOG_DIR}/cleanup_remote_branches.last-run"
+
+CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN="${CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN:-360}"
+CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN="${CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN//[!0-9]/}"
+[[ -n "$CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN" ]] || CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN=360
+
+AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING="${AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING:-1000}"
+AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING="${AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING//[!0-9]/}"
+[[ -n "$AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING" ]] || AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING=1000
+
+mkdir -p "$LOG_DIR"
+
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	# shellcheck source=shared-constants.sh
+	source "${SCRIPT_DIR}/shared-constants.sh"
+else
+	printf '[cleanup-remote-branches-async] ERROR: shared-constants.sh not found at %s\n' "${SCRIPT_DIR}" >>"$LOGFILE"
+	exit 1
+fi
+
+_lock_release() {
+	rm -rf "$LOCK_DIR" 2>/dev/null || true
+	return 0
+}
+
+_is_pid_alive() {
+	local pid="$1"
+	[[ -z "$pid" ]] && return 1
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+
+	if ! kill -0 "$pid" 2>/dev/null; then
+		return 1
+	fi
+
+	local comm
+	comm=$(ps -p "$pid" -o comm= 2>/dev/null || true)
+	[[ -n "$comm" ]] || return 1
+	return 0
+}
+
+_lock_acquire() {
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
+		# shellcheck disable=SC2064
+		trap "_lock_release" EXIT INT TERM
+		return 0
+	fi
+
+	if [[ -f "$PID_FILE" ]]; then
+		local lock_pid
+		IFS= read -r lock_pid <"$PID_FILE" 2>/dev/null || lock_pid=""
+		if [[ -n "$lock_pid" ]] && ! _is_pid_alive "$lock_pid"; then
+			printf '[cleanup-remote-branches-async] Reclaiming stale lock (PID %s no longer alive)\n' "$lock_pid" >>"$LOGFILE"
+			rm -rf "$LOCK_DIR" 2>/dev/null || true
+			if mkdir "$LOCK_DIR" 2>/dev/null; then
+				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
+				# shellcheck disable=SC2064
+				trap "_lock_release" EXIT INT TERM
+				return 0
+			fi
+		fi
+	fi
+
+	return 1
+}
+
+_cadence_ok() {
+	if [[ ! -f "$LAST_RUN_FILE" ]]; then
+		return 0
+	fi
+
+	local last_run now elapsed cadence_secs
+	IFS= read -r last_run <"$LAST_RUN_FILE" 2>/dev/null || last_run=""
+	if ! [[ "$last_run" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+
+	now=$(date +%s)
+	elapsed=$((now - last_run))
+	cadence_secs=$((CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN * 60))
+
+	if [[ "$elapsed" -lt "$cadence_secs" ]]; then
+		printf '[cleanup-remote-branches-async] Cadence gate: last run %ss ago (threshold %ss). Skipping.\n' \
+			"$elapsed" "$cadence_secs" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+_update_last_run() {
+	date +%s >"$LAST_RUN_FILE" 2>/dev/null || true
+	return 0
+}
+
+_gh_budget_ok() {
+	if [[ "${AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT:-0}" == "1" ]]; then
+		return 0
+	fi
+	if [[ "${AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH:-0}" == "1" ]]; then
+		return 0
+	fi
+	if ! command -v gh >/dev/null 2>&1; then
+		printf '[cleanup-remote-branches-async] gh unavailable; skipping to avoid unsafe open-PR classification gaps\n' >>"$LOGFILE"
+		return 1
+	fi
+
+	local remaining_core remaining_graphql min_remaining
+	min_remaining="$AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING"
+	remaining_core=$(gh api rate_limit --jq '.resources.core.remaining // 0' 2>/dev/null || printf '0\n')
+	remaining_graphql=$(gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null || printf '0\n')
+	[[ "$remaining_core" =~ ^[0-9]+$ ]] || remaining_core=0
+	[[ "$remaining_graphql" =~ ^[0-9]+$ ]] || remaining_graphql=0
+
+	if [[ "$remaining_core" -lt "$min_remaining" || "$remaining_graphql" -lt "$min_remaining" ]]; then
+		printf '[cleanup-remote-branches-async] GitHub API budget low (core=%s graphql=%s min=%s); skipping.\n' \
+			"$remaining_core" "$remaining_graphql" "$min_remaining" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+_repo_paths() {
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ -f "$repos_json" && -x "$(command -v jq 2>/dev/null || true)" ]]; then
+		jq -r '.initialized_repos[]? | select(.local_only != true) | (.path // .repo_path // empty)' "$repos_json" 2>/dev/null |
+			while IFS= read -r repo_path; do
+				[[ -z "$repo_path" ]] && continue
+				repo_path="${repo_path/#\~/$HOME}"
+				[[ -d "$repo_path/.git" || -f "$repo_path/.git" ]] || continue
+				printf '%s\n' "$repo_path"
+			done
+		return 0
+	fi
+
+	if git rev-parse --show-toplevel >/dev/null 2>&1; then
+		git rev-parse --show-toplevel
+	fi
+	return 0
+}
+
+_run_cleanup_for_repo() {
+	local repo_path="$1"
+	local helper="${SCRIPT_DIR}/remote-branch-cleanup-helper.sh"
+	local apply_args=()
+
+	if [[ ! -x "$helper" ]]; then
+		printf '[cleanup-remote-branches-async] ERROR: helper not executable at %s\n' "$helper" >>"$LOGFILE"
+		return 1
+	fi
+
+	if [[ "${AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY:-0}" == "1" ]]; then
+		apply_args+=(--apply)
+	fi
+	if [[ "${AIDEVOPS_REMOTE_BRANCH_CLEANUP_INCLUDE_CLOSED_PR:-0}" == "1" ]]; then
+		apply_args+=(--include-closed-pr)
+	fi
+
+	printf '[cleanup-remote-branches-async] Auditing repo=%s mode=%s\n' \
+		"$repo_path" "$([[ "${AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY:-0}" == "1" ]] && printf apply || printf dry-run)" >>"$LOGFILE"
+	"$helper" --repo "$repo_path" "${apply_args[@]}" >>"$LOGFILE" 2>&1
+	return $?
+}
+
+main() {
+	printf '[cleanup-remote-branches-async] PID=%s starting at %s\n' "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$LOGFILE"
+
+	if ! _lock_acquire; then
+		printf '[cleanup-remote-branches-async] Lock held by live instance — skipping this invocation\n' >>"$LOGFILE"
+		return 0
+	fi
+
+	if ! _cadence_ok; then
+		return 0
+	fi
+
+	if ! _gh_budget_ok; then
+		return 0
+	fi
+
+	local repo_path rc failures scanned
+	rc=0
+	failures=0
+	scanned=0
+	while IFS= read -r repo_path; do
+		[[ -z "$repo_path" ]] && continue
+		scanned=$((scanned + 1))
+		if ! _run_cleanup_for_repo "$repo_path"; then
+			failures=$((failures + 1))
+			rc=1
+		fi
+	done < <(_repo_paths)
+
+	if [[ "$rc" -eq 0 ]]; then
+		_update_last_run
+		printf '[cleanup-remote-branches-async] Completed successfully at %s. repos=%s last-run updated.\n' \
+			"$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$scanned" >>"$LOGFILE"
+	else
+		printf '[cleanup-remote-branches-async] Completed with failures=%s repos=%s — last-run NOT updated\n' \
+			"$failures" "$scanned" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -78,6 +78,17 @@ _preflight_cleanup_and_ledger() {
 		# Fallback: synchronous with the standard pre-run stage timeout.
 		run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
 	fi
+	# GH#22415: Remote branch cleanup is moved to an async background job so
+	# cross-repo branch audits and optional safe deletes do not block preflight.
+	# The helper is dry-run by default, enforces a single-runner lock/cadence gate,
+	# and skips when GitHub API budget is below the configured floor.
+	# Progress: ~/.aidevops/logs/cleanup_remote_branches.*
+	local _cleanup_remote_branches_async_helper="${SCRIPT_DIR}/cleanup-remote-branches-async-helper.sh"
+	if [[ -x "$_cleanup_remote_branches_async_helper" ]]; then
+		nohup "$_cleanup_remote_branches_async_helper" \
+			>>"${HOME}/.aidevops/logs/cleanup_remote_branches.log" 2>&1 &
+		disown $! 2>/dev/null || true
+	fi
 
 	# GH#17549: Archive old OpenCode sessions to keep the active DB small.
 	# Concurrent workers hit SQLITE_BUSY on a bloated DB (busy_timeout=0).

--- a/.agents/scripts/tests/test-cleanup-remote-branches-async.sh
+++ b/.agents/scripts/tests/test-cleanup-remote-branches-async.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-cleanup-remote-branches-async.sh — Unit tests for cleanup-remote-branches-async-helper.sh (GH#22415)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../cleanup-remote-branches-async-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		if [[ -n "$message" ]]; then
+			printf '  %s\n' "$message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+write_stub_helper() {
+	local stub_dir="$1"
+	local marker_file="$2"
+	mkdir -p "$stub_dir"
+	cat >"${stub_dir}/shared-constants.sh" <<'STUB'
+# stub shared-constants.sh
+STUB
+	cat >"${stub_dir}/remote-branch-cleanup-helper.sh" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >>"${marker_file}"
+for arg in "\$@"; do
+	if [[ "\$arg" == "--apply" ]]; then
+		printf '%s\n' "APPLY" >>"${marker_file}"
+	fi
+done
+STUB
+	chmod +x "${stub_dir}/remote-branch-cleanup-helper.sh"
+	return 0
+}
+
+copy_helper_to_stub_dir() {
+	local stub_dir="$1"
+	cp "$HELPER" "${stub_dir}/cleanup-remote-branches-async-helper.sh"
+	chmod +x "${stub_dir}/cleanup-remote-branches-async-helper.sh"
+	return 0
+}
+
+make_repo() {
+	local repo_path="$1"
+	mkdir -p "$repo_path"
+	git init -q "$repo_path"
+	git -C "$repo_path" config user.email test@example.invalid
+	git -C "$repo_path" config user.name "Remote Branch Async Test"
+	printf 'base\n' >"${repo_path}/base.txt"
+	git -C "$repo_path" add base.txt
+	git -C "$repo_path" commit -qm base
+	return 0
+}
+
+run_helper_in_isolation() {
+	local extra_env_name="${1:-}"
+	local extra_env_value="${2:-}"
+	local stub_dir="${TEST_DIR}/scripts"
+	local marker_file="${TEST_DIR}/mock-ran"
+	write_stub_helper "$stub_dir" "$marker_file"
+	copy_helper_to_stub_dir "$stub_dir"
+
+	if [[ -n "$extra_env_name" ]]; then
+		env HOME="$TEST_DIR" \
+			CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN="${CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN:-10}" \
+			AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT="${AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT:-1}" \
+			AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY="${AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY:-0}" \
+			"$extra_env_name"="$extra_env_value" \
+			bash "${stub_dir}/cleanup-remote-branches-async-helper.sh" 2>/dev/null || true
+	else
+		env HOME="$TEST_DIR" \
+			CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN="${CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN:-10}" \
+			AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT="${AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT:-1}" \
+			AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY="${AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY:-0}" \
+			bash "${stub_dir}/cleanup-remote-branches-async-helper.sh" 2>/dev/null || true
+	fi
+	return 0
+}
+
+test_cold_start_dry_run() {
+	local repo_path="${TEST_DIR}/repo"
+	local marker_file="${TEST_DIR}/mock-ran"
+	make_repo "$repo_path"
+	rm -f "$marker_file"
+
+	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 run_helper_in_isolation "PWD" "$repo_path"
+
+	if [[ -f "$marker_file" ]] && grep -q -- "--repo ${repo_path}" "$marker_file" && ! grep -q "APPLY" "$marker_file"; then
+		print_result "cold-start: audits current repo in dry-run mode" 0
+	else
+		print_result "cold-start: audits current repo in dry-run mode" 1 "mock marker missing or apply flag present"
+	fi
+	return 0
+}
+
+test_apply_requires_explicit_flag() {
+	local repo_path="${TEST_DIR}/repo-apply"
+	local marker_file="${TEST_DIR}/mock-ran"
+	make_repo "$repo_path"
+	rm -f "$marker_file"
+
+	AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY=1 AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 \
+		run_helper_in_isolation "PWD" "$repo_path"
+
+	if [[ -f "$marker_file" ]] && grep -q "APPLY" "$marker_file"; then
+		print_result "apply mode: passes --apply only when explicitly enabled" 0
+	else
+		print_result "apply mode: passes --apply only when explicitly enabled" 1 "--apply was not passed"
+	fi
+	return 0
+}
+
+test_cadence_gate() {
+	local repo_path="${TEST_DIR}/repo-cadence"
+	local logs_dir="${TEST_DIR}/.aidevops/logs"
+	local marker_file="${TEST_DIR}/mock-ran"
+	make_repo "$repo_path"
+	mkdir -p "$logs_dir"
+	printf '%s\n' "$(( $(date +%s) - 30 ))" >"${logs_dir}/cleanup_remote_branches.last-run"
+	rm -f "$marker_file"
+
+	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN=10 \
+		run_helper_in_isolation "PWD" "$repo_path"
+
+	if [[ ! -f "$marker_file" ]]; then
+		print_result "cadence-gate: skips when last run is recent" 0
+	else
+		print_result "cadence-gate: skips when last run is recent" 1 "cleanup ran despite recent last-run"
+	fi
+	return 0
+}
+
+test_lock_held() {
+	local repo_path="${TEST_DIR}/repo-lock"
+	local logs_dir="${TEST_DIR}/.aidevops/logs"
+	local lock_dir="${logs_dir}/cleanup_remote_branches.lock"
+	local marker_file="${TEST_DIR}/mock-ran"
+	make_repo "$repo_path"
+	mkdir -p "$lock_dir"
+	printf '%s\n' "$$" >"${lock_dir}/pid"
+	rm -f "$marker_file"
+
+	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 run_helper_in_isolation "PWD" "$repo_path"
+
+	if [[ ! -f "$marker_file" ]]; then
+		print_result "lock-held: skips when live lock exists" 0
+	else
+		print_result "lock-held: skips when live lock exists" 1 "cleanup ran despite live lock"
+	fi
+	rm -rf "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
+test_low_rate_limit_skip() {
+	local repo_path="${TEST_DIR}/repo-rate"
+	local stub_dir="${TEST_DIR}/scripts"
+	local marker_file="${TEST_DIR}/mock-ran"
+	make_repo "$repo_path"
+	write_stub_helper "$stub_dir" "$marker_file"
+	cat >"${stub_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "api" ]]; then
+	printf '%s\n' '0'
+fi
+STUB
+	chmod +x "${stub_dir}/gh"
+	copy_helper_to_stub_dir "$stub_dir"
+	rm -f "$marker_file"
+
+	env HOME="$TEST_DIR" PATH="$stub_dir:$PATH" PWD="$repo_path" \
+		AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=0 \
+		AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING=100 \
+		bash "${stub_dir}/cleanup-remote-branches-async-helper.sh" 2>/dev/null || true
+
+	if [[ ! -f "$marker_file" ]]; then
+		print_result "rate-limit: skips cleanup when API budget is low" 0
+	else
+		print_result "rate-limit: skips cleanup when API budget is low" 1 "cleanup ran despite low rate limit"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	test_cold_start_dry_run
+	test_apply_requires_explicit_flag
+	test_cadence_gate
+	test_lock_held
+	test_low_rate_limit_skip
+
+	printf '\nTests run: %s, passed: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-cleanup-remote-branches-async.sh
+++ b/.agents/scripts/tests/test-cleanup-remote-branches-async.sh
@@ -142,9 +142,10 @@ test_cold_start_dry_run() {
 test_apply_requires_explicit_flag() {
 	local repo_path="${TEST_DIR}/repo-apply"
 	local marker_file="${TEST_DIR}/mock-ran"
+	local last_run_file="${TEST_DIR}/.aidevops/logs/cleanup_remote_branches.last-run"
 	make_repo "$repo_path"
 	write_repos_config "$repo_path"
-	rm -f "$marker_file"
+	rm -f "$marker_file" "$last_run_file"
 
 	AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY=1 AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 \
 		run_helper_in_isolation

--- a/.agents/scripts/tests/test-cleanup-remote-branches-async.sh
+++ b/.agents/scripts/tests/test-cleanup-remote-branches-async.sh
@@ -80,9 +80,20 @@ make_repo() {
 	git init -q "$repo_path"
 	git -C "$repo_path" config user.email test@example.invalid
 	git -C "$repo_path" config user.name "Remote Branch Async Test"
+	git -C "$repo_path" config commit.gpgsign false
 	printf 'base\n' >"${repo_path}/base.txt"
 	git -C "$repo_path" add base.txt
 	git -C "$repo_path" commit -qm base
+	return 0
+}
+
+write_repos_config() {
+	local repo_path="$1"
+	local config_dir="${TEST_DIR}/.config/aidevops"
+	mkdir -p "$config_dir"
+	cat >"${config_dir}/repos.json" <<JSON
+{"initialized_repos":[{"path":"${repo_path}","local_only":false}],"git_parent_dirs":[]}
+JSON
 	return 0
 }
 
@@ -115,9 +126,10 @@ test_cold_start_dry_run() {
 	local repo_path="${TEST_DIR}/repo"
 	local marker_file="${TEST_DIR}/mock-ran"
 	make_repo "$repo_path"
+	write_repos_config "$repo_path"
 	rm -f "$marker_file"
 
-	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 run_helper_in_isolation "PWD" "$repo_path"
+	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 run_helper_in_isolation
 
 	if [[ -f "$marker_file" ]] && grep -q -- "--repo ${repo_path}" "$marker_file" && ! grep -q "APPLY" "$marker_file"; then
 		print_result "cold-start: audits current repo in dry-run mode" 0
@@ -131,10 +143,11 @@ test_apply_requires_explicit_flag() {
 	local repo_path="${TEST_DIR}/repo-apply"
 	local marker_file="${TEST_DIR}/mock-ran"
 	make_repo "$repo_path"
+	write_repos_config "$repo_path"
 	rm -f "$marker_file"
 
 	AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY=1 AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 \
-		run_helper_in_isolation "PWD" "$repo_path"
+		run_helper_in_isolation
 
 	if [[ -f "$marker_file" ]] && grep -q "APPLY" "$marker_file"; then
 		print_result "apply mode: passes --apply only when explicitly enabled" 0
@@ -149,12 +162,13 @@ test_cadence_gate() {
 	local logs_dir="${TEST_DIR}/.aidevops/logs"
 	local marker_file="${TEST_DIR}/mock-ran"
 	make_repo "$repo_path"
+	write_repos_config "$repo_path"
 	mkdir -p "$logs_dir"
 	printf '%s\n' "$(( $(date +%s) - 30 ))" >"${logs_dir}/cleanup_remote_branches.last-run"
 	rm -f "$marker_file"
 
 	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN=10 \
-		run_helper_in_isolation "PWD" "$repo_path"
+		run_helper_in_isolation
 
 	if [[ ! -f "$marker_file" ]]; then
 		print_result "cadence-gate: skips when last run is recent" 0
@@ -170,11 +184,12 @@ test_lock_held() {
 	local lock_dir="${logs_dir}/cleanup_remote_branches.lock"
 	local marker_file="${TEST_DIR}/mock-ran"
 	make_repo "$repo_path"
+	write_repos_config "$repo_path"
 	mkdir -p "$lock_dir"
 	printf '%s\n' "$$" >"${lock_dir}/pid"
 	rm -f "$marker_file"
 
-	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 run_helper_in_isolation "PWD" "$repo_path"
+	AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=1 run_helper_in_isolation
 
 	if [[ ! -f "$marker_file" ]]; then
 		print_result "lock-held: skips when live lock exists" 0
@@ -190,6 +205,7 @@ test_low_rate_limit_skip() {
 	local stub_dir="${TEST_DIR}/scripts"
 	local marker_file="${TEST_DIR}/mock-ran"
 	make_repo "$repo_path"
+	write_repos_config "$repo_path"
 	write_stub_helper "$stub_dir" "$marker_file"
 	cat >"${stub_dir}/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -202,7 +218,7 @@ STUB
 	copy_helper_to_stub_dir "$stub_dir"
 	rm -f "$marker_file"
 
-	env HOME="$TEST_DIR" PATH="$stub_dir:$PATH" PWD="$repo_path" \
+	env HOME="$TEST_DIR" PATH="$stub_dir:$PATH" \
 		AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT=0 \
 		AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING=100 \
 		bash "${stub_dir}/cleanup-remote-branches-async-helper.sh" 2>/dev/null || true

--- a/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
@@ -123,6 +123,7 @@ setup_repo() {
 	git clone -q "$TEST_ROOT/origin.git" "$TEST_ROOT/repo"
 	git -C "$TEST_ROOT/repo" config user.email test@example.invalid
 	git -C "$TEST_ROOT/repo" config user.name "Remote Branch Cleanup Test"
+	git -C "$TEST_ROOT/repo" config commit.gpgsign false
 	make_commit "$TEST_ROOT/repo" base.txt base
 	git -C "$TEST_ROOT/repo" branch -M main
 	git -C "$TEST_ROOT/repo" push -q -u origin main


### PR DESCRIPTION
## Summary

Added a cadence-gated async remote branch cleanup runner, wired it into pulse preflight, and kept deletion behind an explicit apply flag while preserving the existing helper safety policy.

## Files Changed

.agents/scripts/cleanup-remote-branches-async-helper.sh,.agents/scripts/pulse-dispatch-preflight-lib.sh,.agents/scripts/tests/test-cleanup-remote-branches-async.sh,.agents/scripts/tests/test-remote-branch-cleanup-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/remote-branch-cleanup-helper.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/pulse-dispatch-preflight-lib.sh .agents/scripts/cleanup-remote-branches-async-helper.sh; .agents/scripts/tests/test-cleanup-remote-branches-async.sh; .agents/scripts/tests/test-remote-branch-cleanup-helper.sh; .agents/scripts/tests/test-cleanup-worktrees-async.sh; .agents/scripts/remote-branch-cleanup-helper.sh --repo . dry-run (safe=29 skipped=2 review=582, no deletion)

Resolves #22415


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.94 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 6m and 113,516 tokens on this as a headless worker.