### PR TITLE
t3491: ensure release deploy starts pulse

### DIFF
--- a/.agents/scripts/tests/test-release-ensures-pulse-running.sh
+++ b/.agents/scripts/tests/test-release-ensures-pulse-running.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SETUP_SCRIPT="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+cleanup() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+load_setup_restart_helper() {
+	local helper_definition=""
+	helper_definition="$(awk '
+		/^_setup_restart_pulse_if_running\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^}/ { exit }
+	' "$SETUP_SCRIPT")"
+
+	if [[ -z "$helper_definition" ]]; then
+		printf 'failed to load helper from %s\n' "$SETUP_SCRIPT" >&2
+		return 1
+	fi
+
+	eval "$helper_definition"
+	return 0
+}
+
+write_pulse_helper_stub() {
+	local helper_path="$1"
+	local log_path="$2"
+	mkdir -p "$(dirname "$helper_path")"
+	cat >"$helper_path" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >>"${log_path}"
+exit 0
+STUB
+	chmod +x "$helper_path"
+	return 0
+}
+
+run_restart_helper_with_stub() {
+	local skip_value="$1"
+	local output_dir="$2"
+	local log_path="${output_dir}/pulse-helper.log"
+	local helper_path="${output_dir}/.aidevops/agents/scripts/pulse-lifecycle-helper.sh"
+
+	write_pulse_helper_stub "$helper_path" "$log_path"
+
+	(
+		HOME="$output_dir"
+		AIDEVOPS_SKIP_PULSE_RESTART="$skip_value"
+		print_warning() { printf 'warning: %s\n' "$*"; return 0; }
+		load_setup_restart_helper
+		_setup_restart_pulse_if_running
+	)
+
+	if [[ -f "$log_path" ]]; then
+		tr '\n' ' ' <"$log_path"
+	fi
+	return 0
+}
+
+test_release_path_starts_stopped_pulse() {
+	local output=""
+	output="$(run_restart_helper_with_stub "0" "${TEST_DIR}/start-stopped")"
+
+	if [[ "$output" == *"restart-if-running start "* ]]; then
+		print_result "release deploy restarts if running then starts if stopped" 0
+		return 0
+	fi
+
+	print_result "release deploy restarts if running then starts if stopped" 1 "helper calls=${output}"
+	return 0
+}
+
+test_skip_flag_suppresses_restart_and_start() {
+	local output=""
+	output="$(run_restart_helper_with_stub "1" "${TEST_DIR}/skip-flag")"
+
+	if [[ -z "$output" ]]; then
+		print_result "skip flag suppresses release pulse restart and start" 0
+		return 0
+	fi
+
+	print_result "skip flag suppresses release pulse restart and start" 1 "helper calls=${output}"
+	return 0
+}
+
+main() {
+	TEST_DIR="$(mktemp -d)"
+	trap cleanup EXIT
+
+	test_release_path_starts_stopped_pulse
+	test_skip_flag_suppresses_restart_and_start
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1332,7 +1332,9 @@ _setup_post_setup_steps() {
 
 _setup_restart_pulse_if_running() {
 	# t2579: restart pulse if running, so newly-deployed scripts take effect.
-	# No-op if pulse is not running, or if AIDEVOPS_SKIP_PULSE_RESTART=1.
+	# t3491/GH#22418: then call idempotent start so a release deploy also
+	# recovers a stopped pulse instead of leaving dispatch dead until manual
+	# intervention. Honour AIDEVOPS_SKIP_PULSE_RESTART=1 for both operations.
 	# Uses the deployed helper (not the repo-local one) so the restart runs
 	# against the agents directory setup.sh just populated.
 	# GH#22012: bounded 120 s timeout prevents setup.sh hanging here when the
@@ -1343,8 +1345,10 @@ _setup_restart_pulse_if_running() {
 	if [[ -x "$_pulse_helper" ]]; then
 		if command -v timeout >/dev/null 2>&1; then
 			timeout 120 "$_pulse_helper" restart-if-running || print_warning "Pulse restart failed (non-fatal)"
+			timeout 120 "$_pulse_helper" start || print_warning "Pulse start failed (non-fatal)"
 		else
 			"$_pulse_helper" restart-if-running || print_warning "Pulse restart failed (non-fatal)"
+			"$_pulse_helper" start || print_warning "Pulse start failed (non-fatal)"
 		fi
 	fi
 	return 0

--- a/setup.sh
+++ b/setup.sh
@@ -1341,6 +1341,10 @@ _setup_restart_pulse_if_running() {
 	# pulse helper takes unusually long to stop a stalled instance. Falls back
 	# to an unbounded call on platforms without timeout(1) (old macOS w/o
 	# coreutils, embedded shells).
+	if [[ "${AIDEVOPS_SKIP_PULSE_RESTART:-0}" == "1" ]]; then
+		return 0
+	fi
+
 	local _pulse_helper="${HOME}/.aidevops/agents/scripts/pulse-lifecycle-helper.sh"
 	if [[ -x "$_pulse_helper" ]]; then
 		if command -v timeout >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Updated setup.sh release/deploy completion to call pulse-lifecycle-helper.sh start after restart-if-running so stopped pulse instances are recovered while preserving restart behavior for running instances. Added regression coverage for the start call and skip flag.

## Files Changed

.agents/scripts/tests/test-release-ensures-pulse-running.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup.sh .agents/scripts/tests/test-release-ensures-pulse-running.sh; bash .agents/scripts/tests/test-release-ensures-pulse-running.sh; bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh

Resolves #22418


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.94 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 7m and 102,612 tokens on this as a headless worker.