### PR TITLE
t3491: ensure setup restarts pulse after updates

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -328,9 +328,9 @@ fi
 if [[ -f "${HOME}/.config/aidevops/credentials.sh" ]]; then
 	# shellcheck source=/dev/null
 	if . "${HOME}/.config/aidevops/credentials.sh" 2>/dev/null; then
-		if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-			printf '[pulse-wrapper] WARN: credentials.sh sourced but ANTHROPIC_API_KEY is empty; LLM-dependent pulse helpers may fail\n' >&2
-		fi
+		# API-key env vars are optional when the OAuth account pool supplies
+		# provider credentials. Only sourcing failures are actionable here.
+		:
 	else
 		printf '[pulse-wrapper] WARN: credentials.sh exists but failed to source; API keys may be unavailable\n' >&2
 	fi

--- a/.agents/scripts/tests/test-setup-pulse-ensure-running.sh
+++ b/.agents/scripts/tests/test-setup-pulse-ensure-running.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SETUP_SCRIPT="${REPO_ROOT}/setup.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+
+	printf 'FAIL %s\n' "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '     %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+extract_setup_restart_function() {
+	awk '
+		/^_setup_restart_pulse_if_running\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^}/ { exit }
+	' "$SETUP_SCRIPT"
+	return 0
+}
+
+test_setup_restart_path_restarts_then_starts() {
+	local helper_definition=""
+	helper_definition="$(extract_setup_restart_function)"
+
+	if [[ -z "$helper_definition" ]]; then
+		print_result "setup pulse restart function is discoverable" 1 \
+			"missing _setup_restart_pulse_if_running in setup.sh"
+		return 0
+	fi
+
+	if ! printf '%s\n' "$helper_definition" | grep -Fq 'restart-if-running'; then
+		print_result "setup pulse path refreshes running pulse" 1 \
+			"missing restart-if-running call"
+		return 0
+	fi
+
+	# shellcheck disable=SC2016 # checking literal setup.sh source text
+	if ! printf '%s\n' "$helper_definition" | grep -Fq '"$_pulse_helper" start'; then
+		print_result "setup pulse path starts dead pulse idempotently" 1 \
+			"missing start call after restart-if-running"
+		return 0
+	fi
+
+	print_result "setup pulse path restarts running pulse then starts dead pulse" 0
+	return 0
+}
+
+main() {
+	test_setup_restart_path_restarts_then_starts
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1332,7 +1332,12 @@ _setup_post_setup_steps() {
 
 _setup_restart_pulse_if_running() {
 	# t2579: restart pulse if running, so newly-deployed scripts take effect.
-	# No-op if pulse is not running, or if AIDEVOPS_SKIP_PULSE_RESTART=1.
+	# t3491: then call the idempotent start path so setup.sh-driven auto-updates
+	# recover a dead pulse too. This matters for auto-update-helper.sh, which
+	# invokes setup.sh directly rather than aidevops.sh::cmd_update's final
+	# ensure-running call. start is a no-op after a successful restart, so this
+	# preserves duplicate-process safety while closing the dead-pulse gap.
+	# No-op if AIDEVOPS_SKIP_PULSE_RESTART=1.
 	# Uses the deployed helper (not the repo-local one) so the restart runs
 	# against the agents directory setup.sh just populated.
 	# GH#22012: bounded 120 s timeout prevents setup.sh hanging here when the
@@ -1343,8 +1348,10 @@ _setup_restart_pulse_if_running() {
 	if [[ -x "$_pulse_helper" ]]; then
 		if command -v timeout >/dev/null 2>&1; then
 			timeout 120 "$_pulse_helper" restart-if-running || print_warning "Pulse restart failed (non-fatal)"
+			timeout 120 "$_pulse_helper" start || print_warning "Pulse start failed (non-fatal)"
 		else
 			"$_pulse_helper" restart-if-running || print_warning "Pulse restart failed (non-fatal)"
+			"$_pulse_helper" start || print_warning "Pulse start failed (non-fatal)"
 		fi
 	fi
 	return 0


### PR DESCRIPTION
## Summary
- Ensures `setup.sh --non-interactive` restarts an already-running pulse and then calls idempotent `start` so dead pulses recover after auto-update-driven releases.
- Adds a regression test for the setup ensure-running contract.
- Removes the misleading `ANTHROPIC_API_KEY` empty warning because OAuth pool credentials are valid for Anthropic workers.

## Verification
- `shellcheck setup.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-setup-pulse-ensure-running.sh`
- `bash .agents/scripts/tests/test-setup-pulse-ensure-running.sh`
- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh`

Resolves #22418
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.94 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 19m and 138,588 tokens on this with the user in an interactive session.