### PR TITLE
GH#22417: make verified worktree cleanup remove permanently

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -545,8 +545,9 @@ See also `reference/pre-commit-hooks.md` for the full playbook and "Stale-sympto
 
 **Worktree removal safety:**
 
-- `worktree-helper.sh remove` and `wt clean` move the worktree directory to system trash before deregistering from git. Accidental removal (e.g. by cleanup routines) is recoverable — restore from trash and `git worktree add` on the same branch.
-- If trash is unavailable, falls back to permanent `git worktree remove`.
+- Manual `worktree-helper.sh remove` stays trash-backed for operator recoverability.
+- Verified cleanup paths (`wt clean --auto --force-merged`, pulse orphan cleanup, empty skill-update worktrees) use guarded permanent removal after current-cwd, canonical repo, ownership, claim, PR, dirty-state, and grace checks pass.
+- Every removal or skip writes `cleanup_worktrees.log` with caller, path, reason, and `mode=trash|permanent|fixture|skipped`. Fixture-only test worktrees must keep explicit path-shape assertions before direct deletion.
 
 **Pulse restart after deploying pulse script fixes (MANDATORY):**
 

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -10,7 +10,7 @@
 # Usage (source this file, then call the function):
 #   # shellcheck source=audit-worktree-removal-helper.sh
 #   source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
-#   log_worktree_removal_event "$_WTAR_REMOVED" "worktree-helper.sh" "/path/to/wt" "branch-merged"
+#   log_worktree_removal_event "$_WTAR_REMOVED" "worktree-helper.sh" "/path/to/wt" "branch-merged" "permanent"
 #
 # Event types (use the constants below to avoid repeated literal violations):
 #   _WTAR_REMOVED          "removed"        — worktree was actually removed
@@ -55,9 +55,10 @@ _WTAR_FIXTURE_REMOVED="fixture-removed"
 #   $2  caller      — basename of the calling script (e.g. "worktree-helper.sh")
 #   $3  wt_path     — absolute path to the worktree
 #   $4  reason      — short reason string (see Reason values above)
+#   $5  mode        — optional removal mode: trash, permanent, fixture, skipped
 #
 # Output format (append to AIDEVOPS_CLEANUP_LOG):
-#   [2026-04-27T11:22:33Z] [worktree-helper.sh] worktree-removed: /path/to/wt — branch-merged
+#   [2026-04-27T11:22:33Z] [worktree-helper.sh] worktree-removed: /path/to/wt — branch-merged — mode=permanent
 #
 # Returns 0 always (fail-open).
 # =============================================================================
@@ -66,19 +67,95 @@ log_worktree_removal_event() {
 	local caller="$2"
 	local wt_path="$3"
 	local reason="$4"
+	local mode="${5:-unknown}"
 	local log_file="${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}"
 
 	# Ensure log directory exists (silent; don't fail callers on permission errors)
 	mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
 
 	# Write one structured line and swallow any write error (fail-open)
-	printf '[%s] [%s] worktree-%s: %s — %s\n' \
+	printf '[%s] [%s] worktree-%s: %s — %s — mode=%s\n' \
 		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 		"$caller" \
 		"$event_type" \
 		"$wt_path" \
 		"$reason" \
+		"$mode" \
 		>>"$log_file" 2>/dev/null || true
 
 	return 0
+}
+
+# =============================================================================
+# worktree_removal_guard — shared destructive-path guard for production cleanup
+#
+# Args:
+#   $1  wt_path  — absolute path candidate
+#   $2  caller   — audit caller constant
+#   $3  reason   — reason to log on skip
+#
+# Refuses registered canonical repos and the caller's current working directory.
+# Returns 0 when callers may continue, 1 when removal must be skipped.
+# =============================================================================
+worktree_removal_guard() {
+	local wt_path="$1"
+	local caller="$2"
+	local reason="$3"
+
+	if [[ -z "$wt_path" ]]; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "empty-path" "skipped"
+		return 1
+	fi
+
+	if command -v is_registered_canonical >/dev/null 2>&1; then
+		if is_registered_canonical "$wt_path"; then
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "canonical-skip" "skipped"
+			return 1
+		fi
+	fi
+
+	local wt_path_real="$wt_path"
+	if [[ -e "$wt_path" ]]; then
+		wt_path_real=$(cd "$wt_path" 2>/dev/null && pwd -P) || wt_path_real="$wt_path"
+	fi
+
+	local current_dir=""
+	current_dir=$(pwd -P 2>/dev/null || true)
+	if [[ -n "$current_dir" ]]; then
+		case "$current_dir" in
+		"$wt_path" | "$wt_path"/* | "$wt_path_real" | "$wt_path_real"/*)
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "current-worktree" "skipped"
+			return 1
+			;;
+		esac
+	fi
+
+	: "$reason"
+	return 0
+}
+
+# =============================================================================
+# remove_worktree_path_permanently — guarded direct delete for verified cleanup
+#
+# Args:
+#   $1  wt_path  — absolute path candidate
+#   $2  caller   — audit caller constant
+#   $3  reason   — audit reason on removal
+#
+# Returns 0 when path is gone, 1 on guard/delete failure.
+# =============================================================================
+remove_worktree_path_permanently() {
+	local wt_path="$1"
+	local caller="$2"
+	local reason="$3"
+
+	worktree_removal_guard "$wt_path" "$caller" "$reason" || return 1
+	[[ ! -e "$wt_path" ]] && return 0
+
+	if rm -rf "$wt_path" 2>/dev/null; then
+		log_worktree_removal_event "$_WTAR_REMOVED" "$caller" "$wt_path" "$reason" "permanent"
+		return 0
+	fi
+
+	return 1
 }

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -49,7 +49,7 @@
 _PULSE_CLEANUP_LOADED=1
 
 # t2559: canonical-guard-helper.sh provides is_registered_canonical and
-# assert_git_available, used by _trash_or_remove and
+# assert_git_available, used by guarded removal helpers and
 # _cleanup_merged_prs_for_all_repos below. Guarded missing-file so older
 # deployments fail open.
 _PULSE_CLEANUP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || _PULSE_CLEANUP_SCRIPT_DIR=""
@@ -232,7 +232,7 @@ _worktree_owner_alive() {
 	if pgrep -f "$wt_path" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch:-detached} ($wt_path) — pgrep matched active process" >>"$LOGFILE"
 		# t2976: audit log — orphan cleanup blocked, pgrep found active owner
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "owned-skip"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "owned-skip" "skipped"
 		return 0
 	fi
 
@@ -241,7 +241,7 @@ _worktree_owner_alive() {
 	if is_worktree_owned_by_others "$wt_path"; then
 		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch:-detached} ($wt_path) — registered owner alive in registry" >>"$LOGFILE"
 		# t2976: audit log — orphan cleanup blocked, registry owner is alive
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "owned-skip"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "owned-skip" "skipped"
 		return 0
 	fi
 
@@ -262,7 +262,7 @@ _worktree_owner_alive() {
 		if [[ -n "$_isc_helper" ]]; then
 			if "$_isc_helper" branch-has-active-claim "$wt_branch" --worktree "$wt_path" >/dev/null 2>&1; then
 				echo "[pulse-wrapper] Orphan cleanup: skipping $wt_branch ($wt_path) — active interactive claim stamp" >>"$LOGFILE"
-				log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "active-claim"
+				log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "active-claim" "skipped"
 				return 0
 			fi
 		fi
@@ -672,6 +672,10 @@ _cleanup_single_worktree() {
 	dirty_count=$(git -C "$wt_path_age" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || dirty_count=0
 
 	# Step 3: skip if an active owner still holds the worktree (GH#18346, GH#18021)
+	if ! worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "age-eligible"; then
+		return 1
+	fi
+
 	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
 		return 1
 	fi
@@ -694,10 +698,16 @@ _cleanup_single_worktree() {
 		_record_orphan_crash_classification "$wt_branch_age" "$dirty_count" "$repo_slug_age"
 	fi
 
-	# Step 5b: perform removal (trash worktree dir + deregister + branch cleanup)
-	# Move to trash first for recoverability (macOS: trash CLI, Linux: gio trash).
-	# Then deregister from git. Falls back to git worktree remove if trash fails.
-	_trash_or_remove "$wt_path_age" || git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null || true
+	# Step 5b: perform removal (guarded permanent delete + deregister + branch cleanup)
+	# Age/PR/dirty gates above prove this orphaned worktree is disposable; remove
+	# permanently to avoid growing system Trash.
+	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "age-eligible"; then
+		if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
+			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "age-eligible" "permanent"
+		else
+			return 1
+		fi
+	fi
 	# Prune git's worktree registry for the now-missing directory
 	git -C "$rp_age" worktree prune 2>/dev/null || true
 	# t2860: deregister from SQLite ownership registry to prevent stale entries.
@@ -706,8 +716,6 @@ _cleanup_single_worktree() {
 	# Mirrors the pattern in worktree-helper.sh:1224 (cmd_remove path).
 	# Fail-open: registry deregistration must never block cleanup.
 	unregister_worktree "$wt_path_age" 2>/dev/null || true
-	# t2976: audit log — orphan worktree removed by pulse cleanup
-	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "age-eligible"
 	if [[ -n "$wt_branch_age" ]]; then
 		git -C "$rp_age" branch -D "$wt_branch_age" 2>/dev/null || true
 		git -C "$rp_age" push origin --delete "$wt_branch_age" 2>/dev/null || true

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -769,12 +769,12 @@ _dps_rebase_in_ephemeral() {
 	# destroying, and log the skip so the unexpected state is visible.
 	if is_registered_canonical "$ephemeral"; then
 		_dps_log "PR #$pr_number ($repo_slug): refusing to remove canonical path $ephemeral — registry hit"
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_DPS_CALLER" "$ephemeral" "canonical-skip"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_DPS_CALLER" "$ephemeral" "canonical-skip" "skipped"
 	else
 		git -C "$repo_path" worktree remove --force "$ephemeral" >/dev/null 2>&1 || true
 		git -C "$repo_path" branch -D "$ephemeral_branch" >/dev/null 2>&1 || true
 		rm -rf "$ephemeral" 2>/dev/null || true
-		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_DPS_CALLER" "$ephemeral" "fixture"
+		log_worktree_removal_event "$_WTAR_FIXTURE_REMOVED" "$_WTAR_DPS_CALLER" "$ephemeral" "fixture" "fixture"
 	fi
 
 	if [[ "$rebase_ok" -ne 0 ]]; then

--- a/.agents/scripts/skill-update-pr-lib.sh
+++ b/.agents/scripts/skill-update-pr-lib.sh
@@ -676,15 +676,21 @@ _cleanup_worktree() {
 		if is_worktree_owned_by_others "$wt_path"; then
 			log_warning "Skipping removal of worktree owned by another session: $wt_path"
 			# t2976: audit log — skill worktree removal blocked by ownership registry
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_SU_CALLER" "$wt_path" "owned-skip"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_SU_CALLER" "$wt_path" "owned-skip" "skipped"
+			return 0
+		fi
+		if ! worktree_removal_guard "$wt_path" "$_WTAR_SU_CALLER" "manual"; then
+			log_warning "Skipping removal of guarded worktree path: $wt_path"
 			return 0
 		fi
 		log_info "Cleaning up empty worktree: $wt_path"
-		git worktree remove "$wt_path" --force 2>/dev/null || true
+		if ! remove_worktree_path_permanently "$wt_path" "$_WTAR_SU_CALLER" "manual"; then
+			if git worktree remove "$wt_path" --force 2>/dev/null; then
+				log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_SU_CALLER" "$wt_path" "manual" "permanent"
+			fi
+		fi
 		git branch -D "$branch" 2>/dev/null || true
 		unregister_worktree "$wt_path"
-		# t2976: audit log — empty skill worktree removed on failure cleanup
-		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_SU_CALLER" "$wt_path" "manual"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh
+++ b/.agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh
@@ -40,7 +40,7 @@ mkdir -p "$FAKE_REPO"
 git -C "$FAKE_REPO" init -q -b main || fail "init fake repo"
 printf '#!/usr/bin/env bash\nprintf '\''ok\\n'\''\n' >"${FAKE_REPO}/ok.sh"
 git -C "$FAKE_REPO" add ok.sh || fail "stage fake script"
-git -C "$FAKE_REPO" -c user.email=t@t -c user.name=t commit -q -m init || fail "commit fake repo"
+git -C "$FAKE_REPO" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m init || fail "commit fake repo"
 
 git -C "$FAKE_REPO" worktree add -q -b feature/gh22154-current "$FAKE_WT" main || fail "create linked worktree"
 

--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for pulse cleanup permanent removal guards:
+# - current-cwd worktrees are skipped before deletion
+# - eligible orphan worktrees are removed permanently and unregistered
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+LOGFILE="${TEST_ROOT}/pulse.log"
+export AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup_worktrees.log"
+UNREGISTER_LOG="${TEST_ROOT}/unregister.log"
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+is_worktree_owned_by_others() { return 1; }
+unregister_worktree() {
+	local wt_path="$1"
+	printf '%s\n' "$wt_path" >>"$UNREGISTER_LOG"
+	return 0
+}
+
+# shellcheck source=../pulse-cleanup.sh
+source "${SCRIPT_DIR}/pulse-cleanup.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message"
+	exit 1
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+make_repo_with_worktree() {
+	local repo_path="$1"
+	local wt_path="$2"
+	local branch="$3"
+
+	mkdir -p "$repo_path"
+	git -C "$repo_path" init -q -b main
+	printf 'base\n' >"${repo_path}/README.md"
+	git -C "$repo_path" add README.md
+	git -C "$repo_path" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m init
+	git -C "$repo_path" worktree add -q -b "$branch" "$wt_path" main
+	touch -t 202001010000 "${wt_path}/.git"
+	return 0
+}
+
+test_current_cwd_skip() {
+	local repo_path="${TEST_ROOT}/repo-cwd"
+	local wt_path="${TEST_ROOT}/wt-cwd"
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/cwd"
+
+	(
+		cd "$wt_path"
+		if _cleanup_single_worktree "$repo_path" "$wt_path" "feature/cwd" "$(date +%s)" "" "main"; then
+			exit 1
+		fi
+	)
+
+	[[ -d "$wt_path" ]] || fail "current cwd worktree was removed"
+	grep -q 'current-worktree.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" || fail "current-cwd skip was not audited"
+	pass "pulse cleanup skips current cwd worktree"
+	return 0
+}
+
+test_orphan_removal_unregisters() {
+	local repo_path="${TEST_ROOT}/repo-remove"
+	local wt_path="${TEST_ROOT}/wt-remove"
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/remove"
+
+	_cleanup_single_worktree "$repo_path" "$wt_path" "feature/remove" "$(date +%s)" "" "main" \
+		|| fail "eligible orphan worktree was not removed"
+
+	[[ ! -e "$wt_path" ]] || fail "eligible orphan worktree still exists"
+	grep -Fxq "$wt_path" "$UNREGISTER_LOG" || fail "worktree unregister was not called"
+	grep -q 'age-eligible.*mode=permanent' "$AIDEVOPS_CLEANUP_LOG" || fail "permanent removal was not audited"
+	pass "pulse cleanup permanently removes and unregisters eligible orphan"
+	return 0
+}
+
+test_current_cwd_skip
+test_orphan_removal_unregisters
+
+exit 0

--- a/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
@@ -66,7 +66,7 @@ make_commit() {
 	local content="$3"
 	printf '%s\n' "$content" >"${repo}/${file}"
 	git -C "$repo" add "$file"
-	git -C "$repo" commit -qm "add ${file}"
+	git -C "$repo" -c commit.gpgsign=false commit -qm "add ${file}"
 	return 0
 }
 
@@ -86,7 +86,7 @@ merge_branch_to_main() {
 	local repo="$1"
 	local branch="$2"
 	git -C "$repo" checkout -q main
-	git -C "$repo" merge -q --no-ff "$branch" -m "merge ${branch}"
+	git -C "$repo" -c commit.gpgsign=false merge -q --no-ff "$branch" -m "merge ${branch}"
 	git -C "$repo" push -q origin main
 	return 0
 }
@@ -123,7 +123,6 @@ setup_repo() {
 	git clone -q "$TEST_ROOT/origin.git" "$TEST_ROOT/repo"
 	git -C "$TEST_ROOT/repo" config user.email test@example.invalid
 	git -C "$TEST_ROOT/repo" config user.name "Remote Branch Cleanup Test"
-	git -C "$TEST_ROOT/repo" config commit.gpgsign false
 	make_commit "$TEST_ROOT/repo" base.txt base
 	git -C "$TEST_ROOT/repo" branch -M main
 	git -C "$TEST_ROOT/repo" push -q -u origin main

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -7,7 +7,7 @@
 #
 # Tests cover:
 #   1. log_worktree_removal_event writes exactly one structured line per call
-#   2. Log format: [ISO8601] [caller] worktree-{removed|skipped}: <path> — <reason>
+#   2. Log format: [ISO8601] [caller] worktree-{removed|skipped}: <path> — <reason> — mode=<mode>
 #   3. Custom AIDEVOPS_CLEANUP_LOG env var is honoured
 #   4. All three event types produce correct type strings in the log
 #   5. should_skip_cleanup emits worktree-skipped when ownership blocks removal
@@ -101,7 +101,7 @@ test_log_writes_one_line() {
 	# shellcheck source=../audit-worktree-removal-helper.sh
 	source "$AUDIT_HELPER"
 
-	log_worktree_removal_event "$_WTAR_REMOVED" "test-caller.sh" "/tmp/test-wt" "manual"
+	log_worktree_removal_event "$_WTAR_REMOVED" "test-caller.sh" "/tmp/test-wt" "manual" "trash"
 
 	local rc=0
 	assert_line_count "$log_file" 1 || rc=$?
@@ -120,9 +120,9 @@ test_log_format_correct() {
 	# shellcheck source=../audit-worktree-removal-helper.sh
 	source "$AUDIT_HELPER"
 
-	log_worktree_removal_event "$_WTAR_SKIPPED" "worktree-helper.sh" "/some/path" "owned-skip"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "worktree-helper.sh" "/some/path" "owned-skip" "skipped"
 
-	local pattern='^\[20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\] \[worktree-helper\.sh\] worktree-skipped: /some/path — owned-skip$'
+	local pattern='^\[20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\] \[worktree-helper\.sh\] worktree-skipped: /some/path — owned-skip — mode=skipped$'
 	local rc=0
 	assert_file_contains "$log_file" "$pattern" || rc=$?
 	print_result "log_format_correct" "$rc" "Log line does not match expected format. Content: $(cat "$log_file" 2>/dev/null)"
@@ -140,7 +140,7 @@ test_custom_log_path() {
 	# shellcheck source=../audit-worktree-removal-helper.sh
 	source "$AUDIT_HELPER"
 
-	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt/path" "age-eligible"
+	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt/path" "age-eligible" "permanent"
 
 	local rc=0
 	if [[ -f "$custom_log" ]]; then
@@ -164,15 +164,15 @@ test_all_event_types() {
 	# shellcheck source=../audit-worktree-removal-helper.sh
 	source "$AUDIT_HELPER"
 
-	log_worktree_removal_event "$_WTAR_REMOVED" "s.sh" "/p1" "manual"
-	log_worktree_removal_event "$_WTAR_SKIPPED" "s.sh" "/p2" "grace-period"
-	log_worktree_removal_event "$_WTAR_FIXTURE_REMOVED" "s.sh" "/p3" "fixture"
+	log_worktree_removal_event "$_WTAR_REMOVED" "s.sh" "/p1" "manual" "trash"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "s.sh" "/p2" "grace-period" "skipped"
+	log_worktree_removal_event "$_WTAR_FIXTURE_REMOVED" "s.sh" "/p3" "fixture" "fixture"
 
 	local rc=0
 	assert_line_count "$log_file" 3 || rc=1
-	assert_file_contains "$log_file" "worktree-removed.*p1" || rc=1
-	assert_file_contains "$log_file" "worktree-skipped.*p2.*grace-period" || rc=1
-	assert_file_contains "$log_file" "worktree-fixture-removed.*p3.*fixture" || rc=1
+	assert_file_contains "$log_file" "worktree-removed.*p1.*mode=trash" || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*p2.*grace-period.*mode=skipped" || rc=1
+	assert_file_contains "$log_file" "worktree-fixture-removed.*p3.*fixture.*mode=fixture" || rc=1
 	print_result "all_event_types_logged" "$rc" "Not all event types written correctly"
 	return 0
 }
@@ -219,7 +219,7 @@ test_should_skip_cleanup_owned_skip_logs() {
 				echo "    $wt_path_sc"
 				echo ""
 				log_worktree_removal_event "$_WTAR_SKIPPED" "worktree-helper.sh" \
-					"$wt_path_sc" "owned-skip"
+					"$wt_path_sc" "owned-skip" "skipped"
 				return 0
 			fi
 			return 1
@@ -248,11 +248,63 @@ test_idempotent_sourcing() {
 	# shellcheck source=../audit-worktree-removal-helper.sh
 	source "$AUDIT_HELPER"  # second source — guard makes this a no-op
 
-	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt" "manual"
+	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt" "manual" "trash"
 
 	local rc=0
 	assert_line_count "$log_file" 1 || rc=$?
 	print_result "idempotent_sourcing" "$rc" "Double-sourcing produced unexpected output"
+	return 0
+}
+
+# =============================================================================
+# Test 7: shared guard refuses current working directory removals
+# =============================================================================
+test_guard_refuses_current_cwd() {
+	local log_file="${TEST_DIR}/t7-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	local wt_path="${TEST_DIR}/current-wt"
+	mkdir -p "$wt_path"
+
+	local rc=0
+	(
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		cd "$wt_path" || exit 2
+		if worktree_removal_guard "$wt_path" "test.sh" "manual"; then
+			exit 1
+		fi
+	) || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		assert_file_contains "$log_file" "worktree-skipped.*current-worktree.*mode=skipped" || rc=$?
+	fi
+	print_result "guard_refuses_current_cwd" "$rc" \
+		"Expected current-worktree skip. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# Test 8: permanent helper removes only after guard passes and logs mode
+# =============================================================================
+test_permanent_helper_removes_and_logs() {
+	local log_file="${TEST_DIR}/t8-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	local wt_path="${TEST_DIR}/old-wt"
+	mkdir -p "$wt_path"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+
+	local rc=0
+	remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible" || rc=$?
+	[[ ! -e "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-removed.*age-eligible.*mode=permanent" || rc=1
+	print_result "permanent_helper_removes_and_logs" "$rc" \
+		"Expected permanent removal audit. Log: $(cat "$log_file" 2>/dev/null)"
 	return 0
 }
 
@@ -270,6 +322,8 @@ test_custom_log_path
 test_all_event_types
 test_should_skip_cleanup_owned_skip_logs
 test_idempotent_sourcing
+test_guard_refuses_current_cwd
+test_permanent_helper_removes_and_logs
 
 echo ""
 echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed."

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -195,7 +195,7 @@ should_skip_cleanup() {
 			echo "    $wt_path"
 			echo ""
 			# t2976: audit log — cleanup skipped, caller is inside this worktree
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "current-worktree"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "current-worktree" "skipped"
 			return 0
 			;;
 		esac
@@ -211,7 +211,7 @@ should_skip_cleanup() {
 		echo "    $wt_path"
 		echo ""
 		# t2976: audit log — cleanup skipped, interactive claim active
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "active-claim"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "active-claim" "skipped"
 		return 0
 	fi
 
@@ -225,7 +225,7 @@ should_skip_cleanup() {
 		echo "    $wt_path"
 		echo ""
 		# t2976: audit log — cleanup skipped, registry owner is alive
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip" "skipped"
 		return 0
 	fi
 
@@ -240,7 +240,7 @@ should_skip_cleanup() {
 		echo "    $wt_path"
 		echo ""
 		# t2976: audit log — cleanup skipped, within grace period
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "grace-period"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "grace-period" "skipped"
 		return 0
 	fi
 
@@ -252,7 +252,7 @@ should_skip_cleanup() {
 		echo "    $wt_path"
 		echo ""
 		# t2976: audit log — cleanup skipped, open PR exists
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "open-pr"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "open-pr" "skipped"
 		return 0
 	fi
 
@@ -265,7 +265,7 @@ should_skip_cleanup() {
 		echo "    $wt_path"
 		echo ""
 		# t2976: audit log — cleanup skipped, zero-commit+dirty safety check
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "zero-commit-dirty"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "zero-commit-dirty" "skipped"
 		return 0
 	fi
 
@@ -277,7 +277,7 @@ should_skip_cleanup() {
 			echo "    $wt_path"
 			echo ""
 			# t2976: audit log — cleanup skipped, uncommitted changes present
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "dirty-skip"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "dirty-skip" "skipped"
 			return 0
 		fi
 		# force_merged=true: dirty state is abandoned WIP, safe to force-remove
@@ -501,16 +501,22 @@ _clean_remove_merged() {
 					if worktree_has_changes "$worktree_path" && [[ "$force_merged" == "true" ]]; then
 						use_force=true
 					fi
-				echo -e "${BLUE}Removing $worktree_branch...${NC}" >&2
-				# Clean up heavy reproducible directories first to speed up removal
+					echo -e "${BLUE}Removing $worktree_branch...${NC}" >&2
+					if ! worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "branch-merged"; then
+						echo -e "${YELLOW}Skipped $worktree_branch - removal guard refused path${NC}" >&2
+						worktree_path=""
+						worktree_branch=""
+						continue
+					fi
+					# Clean up heavy reproducible directories first to speed up removal
 					# (node_modules, .next, .turbo can have 100k+ files — rm -rf is faster than trash)
 					rm -rf "$worktree_path/node_modules" 2>/dev/null || true
 					rm -rf "$worktree_path/.next" 2>/dev/null || true
 					rm -rf "$worktree_path/.turbo" 2>/dev/null || true
-					# Move entire worktree to trash for recoverability, then prune git's registry.
-					# Falls back to git worktree remove if trash is unavailable.
+					# Safety gates above prove the completed worktree is disposable; remove
+					# permanently to avoid growing system Trash, then prune git's registry.
 					local removed=false
-					if trash_path "$worktree_path"; then
+					if remove_worktree_path_permanently "$worktree_path" "$_WTAR_WH_CALLER" "branch-merged"; then
 						git worktree prune 2>/dev/null || true
 						removed=true
 					else
@@ -520,16 +526,15 @@ _clean_remove_merged() {
 						fi
 						# shellcheck disable=SC2086
 						if git worktree remove $remove_flag "$worktree_path" 2>/dev/null; then
+							log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "branch-merged" "permanent"
 							removed=true
 						fi
 					fi
-				if [[ "$removed" != "true" ]]; then
-					echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}" >&2
-				else
+					if [[ "$removed" != "true" ]]; then
+						echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}" >&2
+					else
 						# Unregister ownership (t189)
 						unregister_worktree "$worktree_path"
-						# t2976: audit log — merged/closed branch worktree removed
-						log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "branch-merged"
 						# Localdev integration (t1224.8): auto-remove branch route
 						localdev_auto_branch_rm "$worktree_branch"
 						# Also delete the local branch

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -132,7 +132,7 @@ _remove_validate_path() {
 		_remove_show_owner_error "$path_to_remove"
 		if [[ "${WORKTREE_FORCE_REMOVE:-}" != "1" ]]; then
 			# t2976: audit log — removal blocked by ownership registry
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "owned-skip"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "owned-skip" "skipped"
 			return 1
 		fi
 		echo -e "${YELLOW}--force specified, proceeding with removal${NC}"
@@ -176,7 +176,7 @@ _remove_cleanup_and_execute() {
 	echo -e "${GREEN}Worktree removed successfully${NC}"
 
 	# t2976: audit log — manual removal completed
-	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "manual"
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "manual" "trash"
 
 	# Localdev integration (t1224.8): auto-remove branch subdomain route
 	if [[ -n "$removed_branch" ]]; then


### PR DESCRIPTION
## Summary

- Adds shared worktree removal guards and permanent deletion helper with audit mode metadata.
- Routes verified cleanup paths through guarded permanent removal while keeping manual removal trash-backed.
- Adds regression coverage for audit modes, pulse current-cwd skip, unregister on removal, and signed-commit-disabled test fixtures.

## Testing

- `.agents/scripts/tests/test-worktree-removal-audit.sh`
- `.agents/scripts/tests/test-pulse-cleanup-unregister.sh`
- `bash .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh`
- `bash .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh`
- `bash .agents/scripts/tests/test-canonical-trash-guard.sh`
- `bash .agents/scripts/tests/test-remote-branch-cleanup-helper.sh`
- `shellcheck .agents/scripts/worktree-helper-add.sh .agents/scripts/worktree-helper-cmds.sh .agents/scripts/worktree-clean-lib.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/skill-update-pr-lib.sh .agents/scripts/pulse-dirty-pr-sweep.sh .agents/scripts/tests/test-worktree-removal-audit.sh .agents/scripts/tests/test-pulse-cleanup-unregister.sh .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh .agents/scripts/tests/test-remote-branch-cleanup-helper.sh`

Resolves #22417


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.94 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 18m and 301,677 tokens on this as a headless worker.
