### PR TITLE
GH#22430: reduce GraphQL list-call pressure

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -333,11 +333,15 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# objects plus jq filtering, so rewriting --json calls is not semantically
 		# equivalent. Preserve gate safety by leaving those calls on GraphQL and
 		# let current-state telemetry count them as unavoidable read pressure.
-		# Exception: _rest_pr_list now maps the common `gh pr list --json` contract
-		# (including --head filtering) onto REST, so it remains safe to rewrite.
-		if [[ "$_SHIM_READ_REWRITE" != "pr:list" ]]; then
+		# Exceptions: _rest_pr_list and _rest_issue_list map the common
+		# `gh * list --json` contracts onto REST, so high-volume pulse polling
+		# can move off GraphQL while preserving compact list output.
+		case "$_SHIM_READ_REWRITE" in
+		pr:list | issue:list) ;;
+		*)
 			_shim_read_has_json_flag "$@" && return 1
-		fi
+			;;
+		esac
 
 		# Check GraphQL budget. If above threshold, return 1 to fall through.
 		_rest_should_fallback || return 1
@@ -355,7 +359,13 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		pr:view)    _rest_pr_view "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
 		issue:view) _rest_issue_view "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
 		pr:list)    _rest_pr_list "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
-		issue:list) _rest_issue_list "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
+		issue:list)
+			if _rest_args_have_search "${_SHIM_REST_ARGS[@]}"; then
+				_rest_issue_search "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO"
+			else
+				_rest_issue_list "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO"
+			fi
+			;;
 		*) return 1 ;;
 		esac
 		return $?

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -992,17 +992,49 @@ _rest_pr_list() {
 # `?labels=` query parameter (GitHub REST AND semantics — same as gh CLI).
 # The --search flag is not supported by this REST translator and is silently
 # skipped; callers that require full-text search semantics must use the
-# GraphQL / Search API path. --json FIELDS is accepted for parity but
-# ignored (the REST endpoint returns the full object; use --jq to select).
+# GraphQL / Search API path. --json FIELDS maps common gh field names onto
+# REST field names so low-budget list polling can avoid GraphQL without
+# breaking compact JSON callers.
 #
 # Returns the underlying gh api exit code.
 #######################################
+_rest_issue_list_json_jq() {
+	local fields="$1"
+	local user_jq="$2"
+	local projection=""
+	local field=""
+	while IFS= read -r field; do
+		[[ -z "$field" ]] && continue
+		case "$field" in
+		number) projection="${projection}${projection:+,}number: .number" ;;
+		state) projection="${projection}${projection:+,}state: .state" ;;
+		url) projection="${projection}${projection:+,}url: .html_url" ;;
+		title) projection="${projection}${projection:+,}title: .title" ;;
+		body) projection="${projection}${projection:+,}body: .body" ;;
+		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
+		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
+		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
+		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
+		assignees) projection="${projection}${projection:+,}assignees: (.assignees // [])" ;;
+		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
+		comments) projection="${projection}${projection:+,}comments: .comments" ;;
+		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	[[ -z "$projection" ]] && projection="number: .number"
+	local jq_expr="[.[] | {${projection}}]"
+	[[ -n "$user_jq" ]] && jq_expr="${jq_expr} | ${user_jq}"
+	printf '%s' "$jq_expr"
+	return 0
+}
+
 _rest_issue_list() {
 	gh_record_call rest _rest_issue_list 2>/dev/null || true
 	local repo=""
 	local state="open"
 	local limit=30
 	local jq_expr=""
+	local json_fields=""
 	local assignee=""
 	local -a labels
 	local _tok
@@ -1021,10 +1053,12 @@ _rest_issue_list() {
 		--assignee=*) assignee="${_arg#--assignee=}"; shift ;;
 		--limit) limit="${2:-}"; shift 2 ;;
 		--limit=*) limit="${_arg#--limit=}"; shift ;;
-		--json) shift 2 ;;
-		--json=*) shift ;;
+		--json) json_fields="${2:-}"; shift 2 ;;
+		--json=*) json_fields="${_arg#--json=}"; shift ;;
 		--jq) jq_expr="${2:-}"; shift 2 ;;
 		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
+		-q) jq_expr="${2:-}"; shift 2 ;;
+		-q=*) jq_expr="${_arg#*=}"; shift ;;
 		--search) shift 2 ;;
 		--search=*) shift ;;
 		*) shift ;;
@@ -1055,6 +1089,9 @@ _rest_issue_list() {
 
 	local _path="/repos/${repo}/issues?${_query}"
 	local _gh_cmd=(gh api "$_path")
+	if [[ -n "$json_fields" ]]; then
+		jq_expr="$(_rest_issue_list_json_jq "$json_fields" "$jq_expr")"
+	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"
 	return $?

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -88,6 +88,25 @@ if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
 	fi
 	exit 0
 fi
+if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/issues\? ]]; then
+	jq_filter=""
+	i=3
+	while [[ $i -le $# ]]; do
+		if [[ "${!i}" == "--jq" ]]; then
+			next=$((i + 1))
+			jq_filter="${!next:-}"
+			break
+		fi
+		i=$((i + 1))
+	done
+	fixture='[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure","html_url":"https://github.com/owner/repo/issues/22430","updated_at":"2026-05-02T17:52:48Z","labels":[{"name":"auto-dispatch"}],"assignees":[{"login":"worker"}]}]'
+	if [[ -n "$jq_filter" ]]; then
+		printf '%s\n' "$fixture" | jq -c "$jq_filter"
+	else
+		printf '%s\n' "$fixture"
+	fi
+	exit 0
+fi
 EOF
 chmod +x "$TMP/bin/gh"
 
@@ -310,10 +329,10 @@ else
 fi
 
 # =============================================================================
-# Test 12: --json read calls stay on GraphQL to preserve gh-shaped fields
+# Test 12: --json view calls stay on GraphQL to preserve gh-shaped fields
 # =============================================================================
 echo ""
-echo "Test 12: --json read calls do not REST rewrite"
+echo "Test 12: --json view calls do not REST rewrite"
 _reset_log
 export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-json.log"
 rm -f "$AIDEVOPS_GH_API_LOG"
@@ -343,6 +362,25 @@ if [[ "$output" == "22337" ]] &&
 	_pass "gh pr list --json uses REST fallback with qualified --head"
 else
 	_fail "gh pr list --json REST fallback" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+# =============================================================================
+# Test 14: gh issue list --json can REST rewrite while preserving JSON shape
+# =============================================================================
+echo ""
+echo "Test 14: gh issue list --json REST rewrite preserves compact output"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-json-issue-list.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(STUB_RATE_LIMIT_REMAINING=0 "$SHIM_RUN" issue list --repo owner/repo \
+	--state open --json number,title,url,assignees,labels,updatedAt --jq '.[0].title' 2>/dev/null || true)
+argv=$(_read_argv)
+if [[ "$output" == '"Reduce GraphQL list-call pressure"' ]] &&
+	[[ "$argv" == *"/repos/owner/repo/issues?state=open&per_page=30"* ]] &&
+	grep -q $'\tgh_issue_list\trest' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "gh issue list --json uses REST fallback with compact issue fields"
+else
+	_fail "gh issue list --json REST fallback" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -169,6 +169,25 @@ gh() {
 		printf '%s\n' "${STUB_CURRENT_LABELS:-bug}"
 		return 0
 	fi
+	if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/issues\? ]]; then
+		local jq_filter=""
+		local i=3
+		while [[ $i -le $# ]]; do
+			if [[ "${!i}" == "--jq" ]]; then
+				local next=$((i + 1))
+				jq_filter="${!next:-}"
+				break
+			fi
+			i=$((i + 1))
+		done
+		local fixture='[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure","html_url":"https://github.com/owner/repo/issues/22430","updated_at":"2026-05-02T17:52:48Z","labels":[{"name":"auto-dispatch"}],"assignees":[{"login":"worker"}],"user":{"login":"maintainer"}}]'
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$fixture" | jq -c "$jq_filter"
+		else
+			printf '%s\n' "$fixture"
+		fi
+		return 0
+	fi
 
 	# gh api /repos/{owner}/{repo} (GET, no -X, no /issues suffix) — default branch lookup
 	# STUB_REPO_DEFAULT_BRANCH controls the returned value (default: main).
@@ -800,6 +819,25 @@ if [[ "$pr_list_numbers" == "22337" ]] &&
 else
 	fail "gh_pr_list REST fallback preserves --head and compact --json/--jq shape" \
 		"output=${pr_list_numbers} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+# =============================================================================
+# Test 23c: gh_issue_list REST fallback preserves gh-shaped JSON output
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+
+issue_list_title=$(gh_issue_list --repo "owner/repo" --state open \
+	--json number,title,url,assignees,labels,updatedAt --jq '.[0].title' 2>/dev/null || true)
+
+if [[ "$issue_list_title" == '"Reduce GraphQL list-call pressure"' ]] &&
+	grep -qE '^api /repos/owner/repo/issues\?state=open&per_page=30' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^issue list' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_list REST fallback preserves compact --json/--jq shape"
+else
+	fail "gh_issue_list REST fallback preserves compact --json/--jq shape" \
+		"output=${issue_list_title} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Mapped gh issue list --json fields onto the REST fallback path and let the gh shim route low-budget issue list polling, including search-aware calls, away from GraphQL.

## Files Changed

.agents/scripts/gh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-shim.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted REST fallback tests passed; gh shim tests passed; shellcheck passed for modified scripts; linters-local reported pre-existing SonarCloud/skill-frontmatter failures and timed out during Bash 3.2 compatibility; pulse-current-state-helper --window 15m showed GraphQL remaining 3976/5000.

Resolves #22430


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 9m and 130,810 tokens on this as a headless worker.