### PR TITLE
GH#22420: redact session-miner instruction snippets

### DIFF
--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -272,7 +272,22 @@ _summary_print_instruction_candidates() {
 	local compressed_file="$1"
 	python3 -c "
 import json
+import re
 from pathlib import Path
+
+REDACTION_PLACEHOLDER = '[REDACTED secret-adjacent instruction candidate]'
+SECRET_ADJACENT_PATTERN = re.compile(
+    r'\\b(credential(?:s)?|password(?:s)?|token(?:s)?|api\\s*key(?:s)?|secret(?:s)?|'
+    r'authorization|bearer|private\\s+key(?:s)?)\\b',
+    re.IGNORECASE,
+)
+
+def display_text(candidate):
+    text = candidate.get('display_text') or candidate.get('text', '')
+    if SECRET_ADJACENT_PATTERN.search(text):
+        return REDACTION_PLACEHOLDER
+    return text
+
 data = json.loads(Path('${compressed_file}').read_text())
 instruction_candidates = data.get('instruction_candidates', {})
 total_candidates = sum(len(v) for v in instruction_candidates.values())
@@ -289,7 +304,7 @@ for target_file, candidates in sorted(instruction_candidates.items()):
     for c in candidates[:5]:
         conf = c.get('confidence', 0)
         cat = c.get('category', 'general')
-        text = c.get('text', '')[:120].replace('\n', ' ')
+        text = display_text(c)[:120].replace('\n', ' ')
         session = c.get('session_title', '')[:40]
         print(f'    [{conf:.0%} {cat}] \"{text}\"')
         if session:
@@ -332,8 +347,23 @@ generate_feedback_actions() {
 	python3 - "${compressed_file}" "${actions_file}" "${report_file}" "${metrics_file}" <<'PY'
 import json
 import sys
+import re
 from datetime import datetime, timezone
 from pathlib import Path
+
+REDACTION_PLACEHOLDER = "[REDACTED secret-adjacent instruction candidate]"
+SECRET_ADJACENT_PATTERN = re.compile(
+    r"\b(credential(?:s)?|password(?:s)?|token(?:s)?|api\s*key(?:s)?|secret(?:s)?|"
+    r"authorization|bearer|private\s+key(?:s)?)\b",
+    re.IGNORECASE,
+)
+
+
+def display_instruction_candidate_text(candidate):
+    text = candidate.get("display_text") or candidate.get("text", "")
+    if SECRET_ADJACENT_PATTERN.search(text):
+        return REDACTION_PLACEHOLDER
+    return text
 
 compressed_path = Path(sys.argv[1])
 actions_path = Path(sys.argv[2])
@@ -511,7 +541,7 @@ if total_candidates > 0:
         for c in candidates[:10]:
             conf = c.get("confidence", 0)
             cat = c.get("category", "general")
-            text = c.get("text", "")[:200].replace("\n", " ")
+            text = display_instruction_candidate_text(c)[:200].replace("\n", " ")
             session = c.get("session_title", "")[:60]
             lines.append(f"- [{conf:.0%} / {cat}] {text}")
             if session:

--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -29,6 +29,19 @@ from typing import Optional
 
 DEFAULT_CHUNKS_DIR = Path.home() / ".aidevops/.agent-workspace/work/session-miner"
 DEFAULT_OUTPUT_NAME = "compressed_signals.json"
+INSTRUCTION_REDACTION_PLACEHOLDER = "[REDACTED secret-adjacent instruction candidate]"
+INSTRUCTION_SECRET_ADJACENT_PATTERN = re.compile(
+    r"\b(credential(?:s)?|password(?:s)?|token(?:s)?|api\s*key(?:s)?|secret(?:s)?|"
+    r"authorization|bearer|private\s+key(?:s)?)\b",
+    re.IGNORECASE,
+)
+
+
+def redact_instruction_candidate_text(text: str) -> str:
+    """Return display-safe text for instruction-candidate snippets."""
+    if INSTRUCTION_SECRET_ADJACENT_PATTERN.search(text):
+        return INSTRUCTION_REDACTION_PLACEHOLDER
+    return text
 
 
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
@@ -335,8 +348,11 @@ def _extract_instruction_candidate(record: dict, seen: set[str]):
     seen.add(norm)
 
     target_file = record.get("target_file", ".agents/AGENTS.md")
+    raw_display_text = record.get("display_text") or raw_text
+    display_text = redact_instruction_candidate_text(raw_display_text[:800])
     return target_file, {
         "text": raw_text[:800],
+        "display_text": display_text,
         "confidence": record.get("confidence", 0.5),
         "category": record.get("category", "general"),
         "session_title": record.get("session_title", "")[:80],

--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -58,6 +58,20 @@ OUTPUT_DIR = Path.home() / ".aidevops/.agent-workspace/work/session-miner"
 # with false positives. Only flag generalizable patterns, not task-specific
 # directions that reference particular files, PRs, or one-off commands.
 
+INSTRUCTION_REDACTION_PLACEHOLDER = "[REDACTED secret-adjacent instruction candidate]"
+INSTRUCTION_SECRET_ADJACENT_PATTERN = re.compile(
+    r"\b(credential(?:s)?|password(?:s)?|token(?:s)?|api\s*key(?:s)?|secret(?:s)?|"
+    r"authorization|bearer|private\s+key(?:s)?)\b",
+    re.IGNORECASE,
+)
+
+
+def redact_instruction_candidate_text(text: str) -> str:
+    """Return display-safe text for instruction-candidate snippets."""
+    if INSTRUCTION_SECRET_ADJACENT_PATTERN.search(text):
+        return INSTRUCTION_REDACTION_PLACEHOLDER
+    return text
+
 # Patterns that signal persistent/generalizable guidance
 INSTRUCTION_SIGNAL_PATTERNS = [
     # Explicit save-to-instructions requests
@@ -220,6 +234,7 @@ def _build_instruction_candidate_record(
         "session_dir": _sanitize_path(row["session_dir"] or ""),
         "timestamp": row["msg_time"],
         "text": text[:2000],
+        "display_text": redact_instruction_candidate_text(text[:2000]),
         "confidence": classification["confidence"],
         "target_file": classification["target_file"],
         "category": classification["category"],

--- a/.agents/scripts/tests/test-session-miner-instruction-redaction.sh
+++ b/.agents/scripts/tests/test-session-miner-instruction-redaction.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+CHUNKS_DIR="${TMP_DIR}/chunks"
+mkdir -p "${CHUNKS_DIR}"
+
+cat >"${CHUNKS_DIR}/instruction_candidate_001.json" <<'JSON'
+{
+  "records": [
+    {
+      "text": "Always store token rotation instructions in the team runbook.",
+      "confidence": 0.91,
+      "category": "workflow",
+      "target_file": ".agents/AGENTS.md",
+      "session_title": "credential hygiene"
+    },
+    {
+      "text": "Always prefer small focused helpers over nested inline logic.",
+      "confidence": 0.87,
+      "category": "code-style",
+      "target_file": ".agents/AGENTS.md",
+      "session_title": "style guidance"
+    }
+  ]
+}
+JSON
+
+python3 "${REPO_ROOT}/.agents/scripts/session-miner/compress.py" "${CHUNKS_DIR}" --output "${TMP_DIR}/compressed_signals.json" >/dev/null
+
+python3 - "${TMP_DIR}/compressed_signals.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+candidates = data["instruction_candidates"][".agents/AGENTS.md"]
+redacted = next(c for c in candidates if c["category"] == "workflow")
+plain = next(c for c in candidates if c["category"] == "code-style")
+
+placeholder = "[REDACTED secret-adjacent instruction candidate]"
+assert redacted["text"] == "Always store token rotation instructions in the team runbook."
+assert redacted["display_text"] == placeholder
+assert plain["display_text"] == plain["text"]
+PY
+
+summary_output=$(bash -c '
+  set -euo pipefail
+  source <(python3 - "$0" <<'"'"'PY'"'"'
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1]).read_text(encoding="utf-8")
+print(script.rsplit("\nmain \"$@\"", 1)[0])
+PY
+  )
+  generate_summary "$1"
+' "${REPO_ROOT}/.agents/scripts/session-miner-pulse.sh" "${TMP_DIR}/compressed_signals.json")
+
+if [[ "${summary_output}" != *"[REDACTED secret-adjacent instruction candidate]"* ]]; then
+  printf 'expected redaction placeholder in summary output\n' >&2
+  exit 1
+fi
+
+if [[ "${summary_output}" == *"token rotation instructions"* ]]; then
+  printf 'summary output leaked secret-adjacent candidate text\n' >&2
+  exit 1
+fi
+
+if [[ "${summary_output}" != *"Always prefer small focused helpers over nested inline logic."* ]]; then
+  printf 'summary output did not preserve non-sensitive candidate text\n' >&2
+  exit 1
+fi
+
+cat >"${TMP_DIR}/compressed_signals.json" <<'JSON'
+{
+  "metadata": {"generated_at": "2026-05-02T00:00:00Z", "source_sessions": 2},
+  "categories": {},
+  "error_patterns": {},
+  "git_correlation": {},
+  "instruction_candidates": {
+    ".agents/AGENTS.md": [
+      {
+        "text": "Always store token rotation instructions in the team runbook.",
+        "confidence": 0.91,
+        "category": "workflow",
+        "session_title": "credential hygiene"
+      },
+      {
+        "text": "Always prefer small focused helpers over nested inline logic.",
+        "confidence": 0.87,
+        "category": "code-style",
+        "session_title": "style guidance"
+      }
+    ]
+  }
+}
+JSON
+
+CURRENT_COMPRESSED_FILE="${TMP_DIR}/compressed_signals.json" bash -c '
+  set -euo pipefail
+  source <(python3 - "$0" <<'"'"'PY'"'"'
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1]).read_text(encoding="utf-8")
+print(script.rsplit("\nmain \"$@\"", 1)[0])
+PY
+  )
+  generate_feedback_actions "$CURRENT_COMPRESSED_FILE" "$1" "$2" "$3"
+' "${REPO_ROOT}/.agents/scripts/session-miner-pulse.sh" "${TMP_DIR}/feedback_actions.json" "${TMP_DIR}/feedback_report.md" "${TMP_DIR}/feedback_metrics.json" >/dev/null
+
+report_output=$(<"${TMP_DIR}/feedback_report.md")
+
+if [[ "${report_output}" != *"[REDACTED secret-adjacent instruction candidate]"* ]]; then
+  printf 'expected redaction placeholder in feedback report\n' >&2
+  exit 1
+fi
+
+if [[ "${report_output}" == *"token rotation instructions"* ]]; then
+  printf 'feedback report leaked secret-adjacent candidate text\n' >&2
+  exit 1
+fi
+
+if [[ "${report_output}" != *"Always prefer small focused helpers over nested inline logic."* ]]; then
+  printf 'feedback report did not preserve non-sensitive candidate text\n' >&2
+  exit 1
+fi
+
+printf 'session-miner instruction redaction test passed\n'


### PR DESCRIPTION
## Summary

Redacts secret-adjacent instruction-candidate display text in compressed JSON display fields, stdout summaries, and feedback reports while preserving raw extraction semantics and metadata.

## Files Changed

.agents/scripts/session-miner-pulse.sh,.agents/scripts/session-miner/compress.py,.agents/scripts/session-miner/extract.py,.agents/scripts/tests/test-session-miner-instruction-redaction.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/session-miner-pulse.sh .agents/scripts/tests/test-session-miner-instruction-redaction.sh; python3 -m py_compile .agents/scripts/session-miner/extract.py .agents/scripts/session-miner/compress.py; .agents/scripts/tests/test-session-miner-instruction-redaction.sh

Resolves #22420


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 7m and 88,666 tokens on this as a headless worker.