### PR TITLE
GH#22434: make release creation idempotent

### DIFF
--- a/.agents/scripts/github-release-helper.sh
+++ b/.agents/scripts/github-release-helper.sh
@@ -162,6 +162,7 @@ _create_flag_notes_file=""
 _create_flag_generate_notes=false
 _create_flag_draft=false
 _create_flag_prerelease=false
+_create_already_exists=false
 # Resolved values (set by _resolve_create_inputs)
 _create_repo=""
 _create_tag=""
@@ -262,8 +263,9 @@ _resolve_create_inputs() {
 
 	# Guard: duplicate release
 	if release_exists "$_create_repo" "$_create_tag"; then
-		print_error "Release '$_create_tag' already exists on $_create_repo. Use a different version or delete the existing release first."
-		return 1
+		print_warning "Release '$_create_tag' already exists on $_create_repo — treating as already complete"
+		_create_already_exists=true
+		return 0
 	fi
 	return 0
 }
@@ -271,6 +273,10 @@ _resolve_create_inputs() {
 # Build gh CLI arguments and execute the release creation.
 # Reads _create_* variables set by earlier phases.
 _execute_release_create() {
+	if [[ "$_create_already_exists" == true ]]; then
+		return 0
+	fi
+
 	local gh_args=()
 	gh_args+=("$_create_tag")
 	gh_args+=("--repo" "$_create_repo")
@@ -300,6 +306,10 @@ _execute_release_create() {
 		print_success "Release '$_create_tag' created on $_create_repo"
 		return 0
 	else
+		if release_exists "$_create_repo" "$_create_tag"; then
+			print_warning "Release '$_create_tag' now exists on $_create_repo — treating duplicate create as already complete"
+			return 0
+		fi
 		print_error "Failed to create release '$_create_tag' on $_create_repo"
 		return 1
 	fi
@@ -320,6 +330,7 @@ cmd_create() {
 	_create_flag_generate_notes=false
 	_create_flag_draft=false
 	_create_flag_prerelease=false
+	_create_already_exists=false
 
 	_parse_create_args "$@" || return 1
 	_resolve_create_inputs || return 1

--- a/.agents/scripts/tests/test-github-release-helper-idempotent.sh
+++ b/.agents/scripts/tests/test-github-release-helper-idempotent.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-github-release-helper-idempotent.sh — GH#22434 regression guard.
+#
+# Asserts that duplicate GitHub release creation is treated as already complete
+# instead of failing the release flow.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${TEST_ROOT}/bin"
+
+cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+log_file="${FAKE_GH_LOG:?}"
+marker_file="${FAKE_GH_RELEASE_MARKER:?}"
+printf '%s\n' "$*" >>"$log_file"
+
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+	printf 'marcusquinn/aidevops\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
+	if [[ "${FAKE_RELEASE_EXISTS:-0}" == "1" || -f "$marker_file" ]]; then
+		printf 'release %s exists\n' "${3:-}"
+		exit 0
+	fi
+	exit 1
+fi
+
+if [[ "${1:-}" == "release" && "${2:-}" == "create" ]]; then
+	if [[ "${FAKE_CREATE_DUPLICATES:-0}" == "1" ]]; then
+		: >"$marker_file"
+		printf 'HTTP 422: Validation Failed (Release.tag_name already exists)\n' >&2
+		exit 1
+	fi
+	: >"$marker_file"
+	printf 'created %s\n' "${3:-}"
+	exit 0
+fi
+
+exit 1
+EOF
+chmod +x "${TEST_ROOT}/bin/gh"
+export PATH="${TEST_ROOT}/bin:${PATH}"
+export FAKE_GH_LOG="${TEST_ROOT}/gh.log"
+export FAKE_GH_RELEASE_MARKER="${TEST_ROOT}/release-created.marker"
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_RELEASE_EXISTS=1
+export FAKE_CREATE_DUPLICATES=0
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"already exists"* ]]; then
+	print_result 'existing release exits successfully' 0
+else
+	print_result 'existing release exits successfully' 1 "rc=$rc output=$output"
+fi
+
+if ! grep -q 'release create' "$FAKE_GH_LOG" 2>/dev/null; then
+	print_result 'existing release does not call create' 0
+else
+	print_result 'existing release does not call create' 1 'unexpected release create call'
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_RELEASE_EXISTS=0
+export FAKE_CREATE_DUPLICATES=1
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"duplicate create"* ]]; then
+	print_result 'duplicate create race exits successfully' 0
+else
+	print_result 'duplicate create race exits successfully' 1 "rc=$rc output=$output"
+fi
+
+if grep -q 'release view v1.2.4 --repo marcusquinn/aidevops' "$FAKE_GH_LOG" 2>/dev/null && grep -q 'release create v1.2.4' "$FAKE_GH_LOG" 2>/dev/null; then
+	print_result 'duplicate create race verifies release after create failure' 0
+else
+	print_result 'duplicate create race verifies release after create failure' 1 'missing expected gh calls'
+fi
+
+printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --notes "${{ steps.changelog.outputs.body }}"
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; updating metadata"
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "${{ steps.changelog.outputs.body }}"
+          else
+            if gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "${{ steps.changelog.outputs.body }}"; then
+              echo "Release $GITHUB_REF_NAME created"
+            elif gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+              echo "Release $GITHUB_REF_NAME appeared after create failed; updating metadata"
+              gh release edit "$GITHUB_REF_NAME" \
+                --title "$GITHUB_REF_NAME" \
+                --notes "${{ steps.changelog.outputs.body }}"
+            else
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
## Summary

Made the tag-triggered GitHub release workflow and release helper treat an existing release as already complete, including duplicate-create race recovery.

## Files Changed

.agents/scripts/github-release-helper.sh,.agents/scripts/tests/test-github-release-helper-idempotent.sh,.github/workflows/release.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/github-release-helper.sh .agents/scripts/tests/test-github-release-helper-idempotent.sh .agents/scripts/tests/test-version-manager-release-rest-fallback.sh; bash .agents/scripts/tests/test-github-release-helper-idempotent.sh; bash .agents/scripts/tests/test-version-manager-release-rest-fallback.sh; actionlint .github/workflows/release.yml

Resolves #22434


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 2m and 82,401 tokens on this as a headless worker.