### PR TITLE
t3496: Make issue-sync TODO pushes conflict-safe

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Conflict-safe git push helper for Issue Sync workflow TODO.md updates.
+
+set -euo pipefail
+
+issue_sync_git_path() {
+	local rel_path="$1"
+	git rev-parse --git-path "$rel_path"
+	return 0
+}
+
+issue_sync_rebase_in_progress() {
+	local rebase_merge
+	local rebase_apply
+	rebase_merge=$(issue_sync_git_path "rebase-merge")
+	rebase_apply=$(issue_sync_git_path "rebase-apply")
+	[[ -d "$rebase_merge" || -d "$rebase_apply" ]]
+	return $?
+}
+
+issue_sync_abort_rebase_if_needed() {
+	if issue_sync_rebase_in_progress; then
+		echo "::warning::Aborting leftover rebase before retrying TODO.md push"
+		git rebase --abort >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
+issue_sync_reset_to_origin_branch() {
+	local branch="$1"
+	git reset --hard "origin/${branch}"
+	return 0
+}
+
+issue_sync_neutralize_rebase_conflict() {
+	local branch="$1"
+	local attempt="$2"
+	echo "::warning::TODO.md rebase conflict on push attempt ${attempt}; aborting rebase and resetting to origin/${branch}. A later issue-sync run will re-pull missing refs."
+	git rebase --abort >/dev/null 2>&1 || true
+	issue_sync_reset_to_origin_branch "$branch"
+	return 0
+}
+
+issue_sync_push_todo_with_rebase_retry() {
+	local branch="$1"
+	local attempts="$2"
+	local attempt
+
+	for attempt in $(seq 1 "$attempts"); do
+		echo "Push attempt ${attempt}..."
+		issue_sync_abort_rebase_if_needed
+		git fetch origin "$branch" --quiet
+
+		if ! git rebase "origin/${branch}"; then
+			issue_sync_neutralize_rebase_conflict "$branch" "$attempt"
+			return 0
+		fi
+
+		if git push origin "HEAD:${branch}"; then
+			echo "Push succeeded on attempt ${attempt}"
+			return 0
+		fi
+
+		echo "Push failed on attempt ${attempt}; retrying from a clean rebase state"
+		issue_sync_abort_rebase_if_needed
+		sleep $((attempt * 3))
+	done
+
+	echo "::error::Failed to push TODO.md update after ${attempts} attempts"
+	return 1
+}
+
+issue_sync_git_push_usage() {
+	cat <<'EOF'
+Usage: issue-sync-git-push-helper.sh push-todo [branch] [attempts]
+
+Pushes the current TODO.md sync commit after rebasing onto origin/<branch>.
+On rebase conflict, aborts the rebase, resets to origin/<branch>, and exits 0
+to prevent repeated failed workflow notifications from an unresolved index.
+EOF
+	return 0
+}
+
+main() {
+	local command="${1:-}"
+	local branch="${2:-main}"
+	local attempts="${3:-3}"
+
+	case "$command" in
+		push-todo)
+			issue_sync_push_todo_with_rebase_retry "$branch" "$attempts"
+			return $?
+			;;
+		-h|--help|help|"")
+			issue_sync_git_push_usage
+			return 0
+			;;
+		*)
+			echo "Unknown command: $command" >&2
+			issue_sync_git_push_usage >&2
+			return 2
+			;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -32,6 +32,7 @@ git_init_repo() {
 	local repo_dir="$1"
 	git -C "$repo_dir" config user.name "Issue Sync Test"
 	git -C "$repo_dir" config user.email "issue-sync-test@example.invalid"
+	git -C "$repo_dir" config commit.gpgsign false
 	return 0
 }
 

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name" >&2
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="${SCRIPT_DIR}/issue-sync-git-push-helper.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+git_init_repo() {
+	local repo_dir="$1"
+	git -C "$repo_dir" config user.name "Issue Sync Test"
+	git -C "$repo_dir" config user.email "issue-sync-test@example.invalid"
+	return 0
+}
+
+create_origin() {
+	local origin_dir="$1"
+	local seed_dir="$2"
+	git init --bare "$origin_dir" >/dev/null
+	git init "$seed_dir" >/dev/null
+	git_init_repo "$seed_dir"
+	cat >"$seed_dir/TODO.md" <<'EOF'
+## Ready
+
+- [ ] t9001 original task ref:GH#9001
+EOF
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "seed TODO" >/dev/null
+	git -C "$seed_dir" branch -M main
+	git -C "$seed_dir" remote add origin "$origin_dir"
+	git -C "$seed_dir" push -u origin main >/dev/null
+	git --git-dir="$origin_dir" symbolic-ref HEAD refs/heads/main
+	return 0
+}
+
+test_successful_push() {
+	local origin_dir="$TMP/success-origin.git"
+	local seed_dir="$TMP/success-seed"
+	local work_dir="$TMP/success-work"
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	printf '\n- [ ] t9002 new task ref:GH#9002\n' >>"$work_dir/TODO.md"
+	git -C "$work_dir" add TODO.md
+	git -C "$work_dir" commit -m "sync TODO" >/dev/null
+	if (cd "$work_dir" && bash "$HELPER" push-todo main 2 >/tmp/issue-sync-success.log 2>&1); then
+		pass "push helper pushes clean TODO.md commit"
+	else
+		fail "push helper pushes clean TODO.md commit"
+	fi
+	return 0
+}
+
+test_rebase_conflict_neutralizes_cleanly() {
+	local origin_dir="$TMP/conflict-origin.git"
+	local seed_dir="$TMP/conflict-seed"
+	local work_dir="$TMP/conflict-work"
+	local other_dir="$TMP/conflict-other"
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git clone "$origin_dir" "$other_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	git_init_repo "$other_dir"
+	perl -0pi -e 's/original task/original task worker edit/' "$work_dir/TODO.md"
+	git -C "$work_dir" add TODO.md
+	git -C "$work_dir" commit -m "sync TODO worker" >/dev/null
+	perl -0pi -e 's/original task/original task origin edit/' "$other_dir/TODO.md"
+	git -C "$other_dir" add TODO.md
+	git -C "$other_dir" commit -m "sync TODO origin" >/dev/null
+	git -C "$other_dir" push origin main >/dev/null
+
+	if (cd "$work_dir" && bash "$HELPER" push-todo main 2 >/tmp/issue-sync-conflict.log 2>&1); then
+		if git -C "$work_dir" diff --quiet && ! git -C "$work_dir" status --porcelain | grep -q '^UU'; then
+			pass "rebase conflict exits neutral with clean index"
+		else
+			fail "rebase conflict exits neutral with clean index"
+		fi
+	else
+		fail "rebase conflict exits neutral with clean index"
+	fi
+	return 0
+}
+
+test_successful_push
+test_rebase_conflict_neutralizes_cleanly
+
+printf 'Tests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -162,19 +162,7 @@ jobs:
           else
             git add TODO.md
             git commit -m "chore: sync GitHub issue refs to TODO.md [skip ci]"
-            # Retry loop for concurrent pushes
-            for i in 1 2 3; do
-              echo "Push attempt $i..."
-              git pull --rebase origin main || true
-              if git push; then
-                echo "Push succeeded on attempt $i"
-                exit 0
-              fi
-              echo "Push failed, retrying..."
-              sleep $((i * 3))
-            done
-            echo "All push attempts failed"
-            exit 1
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3
           fi
 
       - name: Show sync status
@@ -278,17 +266,7 @@ jobs:
           else
             git add TODO.md
             git commit -m "chore: sync ref:GH#${ISSUE_NUMBER} to TODO.md [skip ci]"
-            for i in 1 2 3; do
-              echo "Push attempt $i..."
-              git pull --rebase origin main || true
-              if git push; then
-                echo "Push succeeded on attempt $i"
-                exit 0
-              fi
-              sleep $((i * 3))
-            done
-            echo "All push attempts failed"
-            exit 1
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3
           fi
 
   # =========================================================================
@@ -513,14 +491,7 @@ jobs:
           else
             git add TODO.md
             git commit -m "chore: manual issue sync ($SYNC_COMMAND) [skip ci]"
-            for i in 1 2 3; do
-              git pull --rebase origin main || true
-              if git push; then
-                exit 0
-              fi
-              sleep $((i * 3))
-            done
-            exit 1
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3
           fi
 
   # =========================================================================
@@ -1102,16 +1073,9 @@ jobs:
           # success even though TODO.md was never pushed — which is exactly
           # how this workflow broke silently for ~3 weeks before t2029.
           PUSH_SUCCEEDED=false
-          for i in 1 2 3; do
-            echo "Push attempt $i..."
-            git pull --rebase origin main || true
-            if git push; then
-              echo "Push succeeded on attempt $i"
-              PUSH_SUCCEEDED=true
-              break
-            fi
-            sleep $((i * 3))
-          done
+          if bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3; then
+            PUSH_SUCCEEDED=true
+          fi
 
           if [[ "$PUSH_SUCCEEDED" != "true" ]]; then
             # t2029: branch protection on personal-account repos cannot


### PR DESCRIPTION
## Summary

Added a reusable issue-sync git push helper that aborts leftover rebases, rebases from origin/main before each push, and neutralizes TODO.md rebase conflicts with a clean reset instead of retrying with unresolved files; wired the Issue Sync workflow push paths to it.

## Files Changed

.agents/scripts/issue-sync-git-push-helper.sh,.agents/scripts/tests/test-issue-sync-git-push-helper.sh,.github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/issue-sync-git-push-helper.sh .agents/scripts/tests/test-issue-sync-git-push-helper.sh; bash .agents/scripts/tests/test-issue-sync-git-push-helper.sh; bash .agents/scripts/test-issue-sync-lib.sh

Resolves #22433


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 3m and 105,850 tokens on this as a headless worker.