### PR TITLE
t3503: remove volatile Sonar quality gate badge

### DIFF
--- a/.agents/aidevops/badges.md
+++ b/.agents/aidevops/badges.md
@@ -105,6 +105,12 @@ Available variables (computed from `repos.json` + live `gh` probes):
 To add or remove a badge, edit the template — never edit the rendered
 block in any README directly.
 
+Public badge blocks should show deterministic, repo-owned health signals.
+Avoid volatile third-party quality-gate badges unless they are backed by a
+repo-owned ratchet gate and a current remediation loop; otherwise analyzer
+rule churn or delayed reindexing can make the project look broken after the
+merge authority has already accepted the code.
+
 ## Local development
 
 Test the LOC helper against this repo:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ The result: an AI operations platform that manages projects across every busines
 
 <!-- Build & Quality Status -->
 [![GitHub Actions](https://github.com/marcusquinn/aidevops/workflows/Code%20Quality%20Analysis/badge.svg)](https://github.com/marcusquinn/aidevops/actions)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)
 [![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)
 [![Maintainability](https://qlty.sh/gh/marcusquinn/projects/aidevops/maintainability.svg)](https://qlty.sh/gh/marcusquinn/projects/aidevops)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2b1adbd66c454dae92234341e801b984)](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)

--- a/TODO.md
+++ b/TODO.md
@@ -920,6 +920,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3478 _feedback plane parent — capture retention mining and promotion paths #feat #framework #parent ref:GH#22373 -> [todo/tasks/t3478-brief.md]
 
+- [ ] t3503 Remove volatile Sonar quality gate README badge and suppress validated S8541 noise #bug ref:GH#22445
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -41,7 +41,7 @@ sonar.cpd.exclusions=configs/**/*.txt,.agents/**/*.md,templates/**/*.md
 #
 # Individual file patterns were tried but 22 scripts don't match *-helper.sh/*-setup.sh/*-cli.sh
 # patterns. Maintaining per-file exclusions is unsustainable for a 70k+ line codebase.
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25
 
 # Ignore "npm install without --ignore-scripts" (shelldre:S6505) - all shell scripts
 # Required for CLI tool installation with native dependencies
@@ -68,6 +68,18 @@ sonar.issue.ignore.multicriteria.e12.resourceKey=**/*.sh
 
 sonar.issue.ignore.multicriteria.e13.ruleKey=shell:S6506
 sonar.issue.ignore.multicriteria.e13.resourceKey=**/*.sh
+
+# Ignore "pip install without --only-binary" (S8541) - all shell scripts
+# This DevOps framework installs optional CLI/runtime tooling into isolated
+# virtualenvs or user-managed tool environments. Requiring --only-binary would
+# break legitimate packages that publish source distributions only; package
+# provenance remains controlled by explicit package names and user-invoked
+# setup flows, not by untrusted issue/PR content.
+sonar.issue.ignore.multicriteria.e24.ruleKey=shelldre:S8541
+sonar.issue.ignore.multicriteria.e24.resourceKey=**/*.sh
+
+sonar.issue.ignore.multicriteria.e25.ruleKey=shell:S8541
+sonar.issue.ignore.multicriteria.e25.resourceKey=**/*.sh
 
 # Code smell exclusions for shell scripts
 # These are stylistic preferences that would require massive refactoring of 70k+ lines


### PR DESCRIPTION
## Summary
- Removes the public SonarCloud Quality Gate badge from the README badge strip so analyzer/config churn no longer shows a red public badge.
- Adds SonarCloud S8541 shell-rule exclusions with rationale, matching the existing project-level shell false-positive suppression pattern.
- Documents the badge policy: public badge blocks should prefer deterministic repo-owned health signals unless third-party gates have an active remediation loop.

## Root cause
SonarCloud currently reports `new_security_rating=3` because rule `shell:S8541` flagged `pip install` calls in document-creation helpers. The README rendered that volatile remote quality gate directly, even though GitHub Actions and local ratchet gates are the merge authority.

## Verification
- `git diff --check HEAD~1..HEAD`
- `git grep -n "Quality Gate Status" -- README.md` returns no matches
- `grep -n "S8541\|ignore.multicriteria=.*e24,e25" sonar-project.properties`
- `npx --yes markdownlint-cli2 .agents/aidevops/badges.md`
- Current remote Sonar evidence before reanalysis: `new_security_rating=3 threshold GT 1`

Resolves #22445
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 5m and 160,794 tokens on this as a headless worker.