### PR TITLE
t3498: Reduce benign workflow cancellation noise

### DIFF
--- a/.github/workflows/apply-status-available-default.yml
+++ b/.github/workflows/apply-status-available-default.yml
@@ -17,9 +17,19 @@ permissions:
 
 jobs:
   apply-default:
+    # Label churn on auto-dispatch issues used to start this workflow for every
+    # label application. Only issue creation and the auto-dispatch label can
+    # make status:available newly applicable, so all other label events skip
+    # before occupying the per-issue concurrency slot below.
+    if: >
+      github.event.action == 'opened' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'auto-dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 2
     concurrency:
+      # Per issue: two legitimate triggers (opened + auto-dispatch labeled) must
+      # not race each other into duplicate label mutations, but unrelated issues
+      # should never cancel or queue behind each other.
       group: apply-status-default-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -67,7 +67,7 @@ jobs:
       github.event_name == 'pull_request_target'
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 3
-    # t3213 / GH#21947: cancel-in-progress is INTENTIONALLY true here.
+    # t3213 / GH#21947 / GH#22436: cancel-in-progress is INTENTIONALLY true here.
     #
     # check-pr is a READ-ONLY verdict job — it computes pass/fail from PR state
     # at runtime (labels, linked issues, assignees) and writes a single status
@@ -92,6 +92,10 @@ jobs:
     # the original race-condition concern was that cancelled runs might be
     # mistaken for failures, but in practice GitHub's status-resolution always
     # picks the newest run for the same context.
+    #
+    # GH#22436: the key is deliberately per PR, not repository-wide. Rapid
+    # synchronize/edit/label events on one PR supersede older verdicts for that
+    # same PR, while unrelated PRs continue independently and are not cancelled.
     #
     # Related rules: t2229 / `workflow-cascade-lint.yml` flags the OPPOSITE
     # anti-pattern (cancel-in-progress:true with cascade-vulnerable triggers

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -19,7 +19,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
-# Rate limiting: only one AI agent run at a time, queue others
+# Rate limiting: only one real AI agent run at a time, queue others.
+# The group is intentionally global because the OpenCode action can mutate the
+# repository; no-op comments are filtered at the job layer before they enter
+# this queue so ordinary discussion does not create noisy queued/cancelled runs.
 concurrency:
   group: opencode-agent
   cancel-in-progress: false
@@ -34,6 +37,7 @@ jobs:
     # but GitHub requires manual approval for workflow runs triggered by bot
     # accounts, causing permanent action_required status on PRs.
     if: >
+      (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       github.actor != 'coderabbitai' &&
       github.actor != 'gemini-code-assist[bot]' &&
       github.actor != 'augment-code[bot]' &&

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -53,7 +53,18 @@ jobs:
       (
         github.event_name == 'pull_request' ||
         github.event_name == 'pull_request_review' ||
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          (
+            github.actor == 'coderabbitai' ||
+            github.actor == 'gemini-code-assist[bot]' ||
+            github.actor == 'augment-code[bot]' ||
+            github.actor == 'augmentcode[bot]' ||
+            github.actor == 'copilot[bot]' ||
+            github.actor == 'github-actions[bot]'
+          )
+        )
       ) && !(
         github.event_name == 'pull_request_review' && (
           github.actor == 'coderabbitai' ||

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -41,5 +41,21 @@ concurrency:
 
 jobs:
   gate:
+    # issue_comment fires for every PR comment/edit. Only bot review comments can
+    # change this gate's verdict; maintainer/user discussion should be skipped
+    # before the reusable workflow starts so it does not create mobile run noise.
+    if: >
+      github.event_name != 'issue_comment' ||
+      (
+        github.event.issue.pull_request &&
+        (
+          github.actor == 'coderabbitai' ||
+          github.actor == 'gemini-code-assist[bot]' ||
+          github.actor == 'augment-code[bot]' ||
+          github.actor == 'augmentcode[bot]' ||
+          github.actor == 'copilot[bot]' ||
+          github.actor == 'github-actions[bot]'
+        )
+      )
     uses: ./.github/workflows/review-bot-gate-reusable.yml
     secrets: inherit


### PR DESCRIPTION
## Summary

Added job-level guards so no-op issue comments and irrelevant label events skip before high-churn workflows occupy concurrency queues, and documented the maintainer-gate per-PR concurrency key.

## Files Changed

.github/workflows/apply-status-available-default.yml,.github/workflows/maintainer-gate-reusable.yml,.github/workflows/opencode-agent.yml,.github/workflows/review-bot-gate-reusable.yml,.github/workflows/review-bot-gate.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** actionlint on edited workflows; workflow-cascade-lint --dry-run on edited workflows; sampled current cancelled workflow baseline with gh run list

Resolves #22436


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 6m and 102,655 tokens on this as a headless worker.