### PR TITLE
GH#22438: enforce headless worker env contract

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -255,6 +255,67 @@ _validate_run_args() {
 	return 0
 }
 
+# _run_looks_like_issue_worker: detect issue-scoped worker dispatches from
+# independent caller-owned signals. The env contract is only mandatory for
+# issue workers; pulse/non-issue runs keep the historical path.
+_run_looks_like_issue_worker() {
+	local role_value="$1"
+	local session_key_value="$2"
+	local title_value="$3"
+	local prompt_value="$4"
+
+	[[ "$role_value" == "worker" ]] || return 1
+	if [[ "$session_key_value" =~ ^issue-[0-9]+$ ]]; then
+		return 0
+	fi
+	if [[ "$title_value" =~ ^Issue[[:space:]]+#[0-9]+ ]]; then
+		return 0
+	fi
+	if [[ "$prompt_value" =~ [Ii]ssue[[:space:]]*#?[0-9]+ ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+# _validate_issue_worker_env_contract: fail before canary/model launch when an
+# issue worker lacks the dispatcher-precreated worktree contract.
+_validate_issue_worker_env_contract() {
+	local role_value="$1"
+	local session_key_value="$2"
+	local work_dir_value="$3"
+	local title_value="$4"
+	local prompt_value="$5"
+
+	if ! _run_looks_like_issue_worker "$role_value" "$session_key_value" "$title_value" "$prompt_value"; then
+		return 0
+	fi
+
+	if [[ -z "${WORKER_ISSUE_NUMBER:-}" ]]; then
+		print_error "[fatal] WORKER_ISSUE_NUMBER unset — issue worker env contract missing; aborting before model launch"
+		return 1
+	fi
+	if [[ -z "${WORKER_WORKTREE_PATH:-}" ]]; then
+		print_error "[fatal] WORKER_WORKTREE_PATH unset — issue worker env contract missing; aborting before model launch"
+		return 1
+	fi
+	if [[ ! -d "${WORKER_WORKTREE_PATH:-}" ]]; then
+		print_error "[fatal] WORKER_WORKTREE_PATH does not exist: ${WORKER_WORKTREE_PATH:-<unset>}"
+		return 1
+	fi
+
+	local env_worktree_real=""
+	local work_dir_real=""
+	env_worktree_real=$(cd "$WORKER_WORKTREE_PATH" 2>/dev/null && pwd -P) || env_worktree_real=""
+	work_dir_real=$(cd "$work_dir_value" 2>/dev/null && pwd -P) || work_dir_real=""
+	if [[ -z "$env_worktree_real" || -z "$work_dir_real" || "$env_worktree_real" != "$work_dir_real" ]]; then
+		print_error "[fatal] worker --dir does not match WORKER_WORKTREE_PATH; aborting before model launch"
+		return 1
+	fi
+
+	return 0
+}
+
 # =============================================================================
 # Runtime invocation — OpenCode and Claude CLI
 # =============================================================================
@@ -1228,6 +1289,7 @@ cmd_run() {
 
 	_parse_run_args "$@" || return 1
 	_validate_run_args || return 1
+	_validate_issue_worker_env_contract "$role" "$session_key" "$work_dir" "$title" "$prompt" || return 1
 
 	if [[ "$detach" -eq 1 ]]; then
 		_detach_worker "$session_key" "$@"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -87,6 +87,89 @@ test_non_full_loop_prompt_unchanged() {
 	return 0
 }
 
+test_issue_worker_env_contract_rejects_missing_env() {
+	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
+	local output=""
+	local status=0
+	output=$(_validate_issue_worker_env_contract \
+		"worker" "issue-22438" "$TEST_ROOT" "Issue #22438: env contract" \
+		"/full-loop Implement issue #22438" 2>&1) || status=$?
+
+	if [[ "$status" -ne 0 && "$output" == *"WORKER_ISSUE_NUMBER unset"* ]]; then
+		print_result "issue worker env contract rejects missing WORKER_ISSUE_NUMBER" 0
+		return 0
+	fi
+
+	print_result "issue worker env contract rejects missing WORKER_ISSUE_NUMBER" 1 \
+		"status=$status output=${output:-<empty>}"
+	return 0
+}
+
+test_issue_worker_env_contract_rejects_missing_worktree() {
+	export WORKER_ISSUE_NUMBER="22438"
+	unset WORKER_WORKTREE_PATH 2>/dev/null || true
+	local output=""
+	local status=0
+	output=$(_validate_issue_worker_env_contract \
+		"worker" "issue-22438" "$TEST_ROOT" "Issue #22438: env contract" \
+		"/full-loop Implement issue #22438" 2>&1) || status=$?
+
+	if [[ "$status" -ne 0 && "$output" == *"WORKER_WORKTREE_PATH unset"* ]]; then
+		print_result "issue worker env contract rejects missing WORKER_WORKTREE_PATH" 0
+		unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+		return 0
+	fi
+
+	print_result "issue worker env contract rejects missing WORKER_WORKTREE_PATH" 1 \
+		"status=$status output=${output:-<empty>}"
+	unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+	return 0
+}
+
+test_issue_worker_env_contract_accepts_valid_precreated_worktree() {
+	local worktree_dir="${TEST_ROOT}/precreated-worktree"
+	mkdir -p "$worktree_dir"
+	export WORKER_ISSUE_NUMBER="22438"
+	export WORKER_WORKTREE_PATH="$worktree_dir"
+
+	if _validate_issue_worker_env_contract \
+		"worker" "issue-22438" "$worktree_dir" "Issue #22438: env contract" \
+		"/full-loop Implement issue #22438"; then
+		print_result "issue worker env contract accepts valid precreated worktree" 0
+		unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
+		return 0
+	fi
+
+	print_result "issue worker env contract accepts valid precreated worktree" 1
+	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
+	return 0
+}
+
+test_cmd_run_aborts_issue_worker_before_canary_when_env_missing() {
+	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
+	local canary_called=0
+	_run_canary_test() { canary_called=1; return 0; }
+
+	local output=""
+	local status=0
+	output=$(cmd_run \
+		--role worker \
+		--session-key issue-22438 \
+		--dir "$TEST_ROOT" \
+		--title "Issue #22438: env contract" \
+		--prompt "/full-loop Implement issue #22438" 2>&1) || status=$?
+
+	unset -f _run_canary_test 2>/dev/null || true
+	if [[ "$status" -ne 0 && "$canary_called" -eq 0 && "$output" == *"WORKER_ISSUE_NUMBER unset"* ]]; then
+		print_result "cmd_run aborts issue worker before canary when env missing" 0
+		return 0
+	fi
+
+	print_result "cmd_run aborts issue worker before canary when env missing" 1 \
+		"status=$status canary_called=$canary_called output=${output:-<empty>}"
+	return 0
+}
+
 test_does_not_double_append() {
 	local prompt='/full-loop Continue issue #14964
 
@@ -777,6 +860,10 @@ main() {
 	setup_test_env
 	test_appends_escalation_contract
 	test_non_full_loop_prompt_unchanged
+	test_issue_worker_env_contract_rejects_missing_env
+	test_issue_worker_env_contract_rejects_missing_worktree
+	test_issue_worker_env_contract_accepts_valid_precreated_worktree
+	test_cmd_run_aborts_issue_worker_before_canary_when_env_missing
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_headless_activity_timeout_default_matches_watchdog


### PR DESCRIPTION
## Summary

Added a pre-launch issue-worker env contract guard so missing WORKER_ISSUE_NUMBER or WORKER_WORKTREE_PATH aborts before canary/model runtime, plus regression coverage for missing and valid env paths.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #22438


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 6m and 113,797 tokens on this as a headless worker.