### PR TITLE
t3506: Fix commit-and-pr REST fallback PR-number stdout

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -835,7 +835,7 @@ _create_pr() {
 	local -a extra_labels=("$@")
 
 	print_info "Creating PR..."
-	local pr_url="" rc=0
+	local pr_url="" pr_error="" rc=0
 	# t2115/t3088: gh_create_pr auto-appends origin label and signature footer.
 	# Previously we passed --label "$origin_label" here too, with the comment
 	# "GitHub deduplicates". That claim is FALSE for non-identical labels: when
@@ -853,7 +853,8 @@ _create_pr() {
 		pr_cmd+=(--label "$lbl")
 	done
 
-	pr_url=$("${pr_cmd[@]}" 2>&1) || rc=$?
+	pr_error=$(mktemp -t aidevops-pr-create-error.XXXXXX) || return 1
+	pr_url=$("${pr_cmd[@]}" 2>"$pr_error") || rc=$?
 
 	if [[ $rc -ne 0 ]]; then
 		# t2767: Partial-success recovery.
@@ -869,13 +870,21 @@ _create_pr() {
 			print_info "PR creation command returned non-zero but PR exists — recovering (t2767): ${recovered_url}"
 			pr_url="$recovered_url"
 		else
-			print_error "PR creation failed: ${pr_url}"
+			print_error "PR creation failed: $(<"$pr_error")"
+			rm -f "$pr_error"
 			return 1
 		fi
 	fi
+	rm -f "$pr_error"
 
 	local pr_number=""
-	pr_number=$(printf '%s' "$pr_url" | grep -oE '[0-9]+$' || echo "")
+	local pr_candidates=""
+	pr_candidates=$(printf '%s\n' "$pr_url" | grep -oE 'github\.com/[^[:space:]]+/[^[:space:]]+/pull/[0-9]+' | grep -oE '[0-9]+$' || true)
+	pr_number="${pr_candidates##*$'\n'}"
+	if [[ -z "$pr_number" ]]; then
+		pr_candidates=$(printf '%s\n' "$pr_url" | grep -oE '[0-9]+$' || true)
+		pr_number="${pr_candidates##*$'\n'}"
+	fi
 	if [[ -z "$pr_number" ]]; then
 		print_error "Could not extract PR number from: ${pr_url}"
 		return 1

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -550,9 +550,9 @@ _rebase_and_push() {
 	local push_rc
 	push_rc=0
 	if command -v timeout >/dev/null 2>&1; then
-		timeout "$push_timeout" git push "${_push_args[@]}" || push_rc=$?
+		timeout "$push_timeout" git push "${_push_args[@]}" 1>&2 || push_rc=$?
 	else
-		git push "${_push_args[@]}" || push_rc=$?
+		git push "${_push_args[@]}" 1>&2 || push_rc=$?
 	fi
 
 	if [[ "$push_rc" -eq 124 ]]; then

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -147,6 +147,14 @@ export -f git
 
 _check_and_handle_shallow_clone() { return 0; }
 
+timeout() {
+	local _duration="${1:-}"
+	: "$_duration"
+	shift || return 1
+	"$@"
+	return $?
+}
+
 # Control variable: set to 1 to simulate gh_create_pr partial success
 GH_CREATE_PR_FAIL=0
 # Control variable: the URL to return from gh_create_pr on success

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -115,6 +115,10 @@ eval "$(sed -n '/^_create_pr() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit
 # shellcheck disable=SC2312
 eval "$(sed -n '/^_post_merge_summary() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
+# Extract _rebase_and_push
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_rebase_and_push() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
+
 # =============================================================================
 # Post-extraction stubs (override PATH binaries and define missing deps).
 # Defined after eval so they take precedence over any stubs extracted from helper.
@@ -126,10 +130,22 @@ git() {
 		printf 'feature/t2767-test\n'
 		return 0
 	fi
+	if [[ "${1:-}" == "fetch" ]]; then
+		return 0
+	fi
+	if [[ "${1:-}" == "rebase" ]]; then
+		return 0
+	fi
+	if [[ "${1:-}" == "push" ]]; then
+		printf "branch 'feature/t2767-test' set up to track 'origin/feature/t2767-test'.\n"
+		return 0
+	fi
 	command git "$@"
 	return $?
 }
 export -f git
+
+_check_and_handle_shallow_clone() { return 0; }
 
 # Control variable: set to 1 to simulate gh_create_pr partial success
 GH_CREATE_PR_FAIL=0
@@ -319,6 +335,30 @@ else
 fi
 
 GH_CREATE_PR_STDERR_LOG=""
+
+# =============================================================================
+# Test 3c: _rebase_and_push keeps git push setup noise off stdout
+# git push -u may print "branch ... set up to track ..." on stdout. Expected:
+# helper redirects that to stderr so commit-and-pr stdout remains only PR_NUMBER.
+# =============================================================================
+: >"$STUB_LOG"
+rebase_push_output=""
+rebase_push_rc=0
+rebase_push_output=$(_rebase_and_push "feature/t2767-test" 0 2>/dev/null) || rebase_push_rc=$?
+
+if [[ "$rebase_push_rc" -eq 0 ]]; then
+	pass "push stdout hygiene: _rebase_and_push succeeds"
+else
+	fail "push stdout hygiene: _rebase_and_push succeeds" \
+		"got exit $rebase_push_rc; output '${rebase_push_output}'"
+fi
+
+if [[ -z "$rebase_push_output" ]]; then
+	pass "push stdout hygiene: _rebase_and_push emits no stdout"
+else
+	fail "push stdout hygiene: _rebase_and_push emits no stdout" \
+		"got '${rebase_push_output}'"
+fi
 
 # =============================================================================
 # Test 4: _post_merge_summary idempotency — skip when comment already exists

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -109,11 +109,11 @@ _SOURCING_FOR_TEST=1
 
 # Extract _create_pr
 # shellcheck disable=SC2312
-eval "$(sed -n '/^_create_pr() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper.sh")"
+eval "$(sed -n '/^_create_pr() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
 # Extract _post_merge_summary
 # shellcheck disable=SC2312
-eval "$(sed -n '/^_post_merge_summary() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper.sh")"
+eval "$(sed -n '/^_post_merge_summary() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
 # =============================================================================
 # Post-extraction stubs (override PATH binaries and define missing deps).
@@ -135,6 +135,8 @@ export -f git
 GH_CREATE_PR_FAIL=0
 # Control variable: the URL to return from gh_create_pr on success
 GH_CREATE_PR_URL="https://github.com/owner/repo/pull/999"
+# Control variable: optional stderr emitted by gh_create_pr on success
+GH_CREATE_PR_STDERR_LOG=""
 
 # Stub: gh_create_pr — honours GH_CREATE_PR_FAIL
 # On failure, outputs an error message (like real gh does) and returns 1.
@@ -143,6 +145,9 @@ gh_create_pr() {
 	if [[ "$GH_CREATE_PR_FAIL" -eq 1 ]]; then
 		printf 'pull request update failed: GraphQL: Something went wrong\n' >&2
 		return 1
+	fi
+	if [[ -n "$GH_CREATE_PR_STDERR_LOG" ]]; then
+		printf '%s\n' "$GH_CREATE_PR_STDERR_LOG" >&2
 	fi
 	printf '%s\n' "$GH_CREATE_PR_URL"
 	return 0
@@ -252,6 +257,7 @@ fi
 GH_CREATE_PR_FAIL=0
 GH_RECOVER_PR_URL=""
 GH_CREATE_PR_URL="https://github.com/owner/repo/pull/888"
+GH_CREATE_PR_STDERR_LOG=""
 
 success_pr_number=""
 success_rc=0
@@ -270,6 +276,49 @@ else
 	fail "normal success: _create_pr outputs correct PR number (888)" \
 		"got '${success_pr_number}'"
 fi
+
+# =============================================================================
+# Test 3b: _create_pr REST fallback logs do not pollute machine stdout
+# gh_create_pr succeeds via wrapper REST fallback but writes GraphQL/fallback
+# diagnostics mentioning the issue number to stderr. Expected: _create_pr
+# outputs only the actual PR number, so commit-and-pr posts MERGE_SUMMARY there.
+# =============================================================================
+: >"$STUB_LOG"
+GH_CREATE_PR_FAIL=0
+GH_RECOVER_PR_URL=""
+GH_CREATE_PR_URL="https://github.com/owner/repo/pull/22459"
+GH_CREATE_PR_STDERR_LOG=$'[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create\nhttps://github.com/owner/repo/issues/22437'
+
+rest_fallback_pr_number=""
+rest_fallback_rc=0
+rest_fallback_pr_number=$(_create_pr "owner/repo" "t2767: test" "body text" "origin:worker") || rest_fallback_rc=$?
+
+if [[ "$rest_fallback_rc" -eq 0 ]]; then
+	pass "REST fallback success: _create_pr returns 0 when wrapper succeeds"
+else
+	fail "REST fallback success: _create_pr returns 0 when wrapper succeeds" \
+		"got exit $rest_fallback_rc; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if [[ "$rest_fallback_pr_number" == "22459" ]]; then
+	pass "REST fallback success: _create_pr outputs only actual PR number (22459)"
+else
+	fail "REST fallback success: _create_pr outputs only actual PR number (22459)" \
+		"got '${rest_fallback_pr_number}'; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+GH_EXISTING_MERGE_SUMMARY_COUNT=0
+_post_merge_summary "$rest_fallback_pr_number" "owner/repo" "22437" "impl" "file.sh" "shellcheck" "none" >/dev/null 2>&1
+
+if grep -q "gh_pr_comment pr=22459" "$STUB_LOG" 2>/dev/null &&
+	! grep -q "gh_pr_comment pr=22437" "$STUB_LOG" 2>/dev/null; then
+	pass "REST fallback success: MERGE_SUMMARY targets the actual PR number"
+else
+	fail "REST fallback success: MERGE_SUMMARY targets the actual PR number" \
+		"stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+GH_CREATE_PR_STDERR_LOG=""
 
 # =============================================================================
 # Test 4: _post_merge_summary idempotency — skip when comment already exists


### PR DESCRIPTION
## Summary

Separated gh_create_pr stderr diagnostics from PR URL parsing and added a regression for REST fallback logs that mention the issue number, ensuring commit-and-pr emits only the actual PR number.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh,.agents/scripts/tests/test-commit-and-pr-partial-success.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/full-loop-helper.sh .agents/scripts/full-loop-helper-commit.sh .agents/scripts/tests/test-commit-and-pr-partial-success.sh; bash .agents/scripts/tests/test-commit-and-pr-partial-success.sh

Resolves #22463


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 6m and 101,031 tokens on this as a headless worker.