### PR TITLE
t3502: Sync canonical label colors during repo init

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -798,7 +798,7 @@ EOF
 	local remote_url
 	remote_url=$(git -C "$project_root" remote get-url origin 2>/dev/null || true)
 	local repo_slug=""
-	if [[ -n "$remote_url" ]]; then
+	if [[ "$remote_url" == *github.com[:/]* || "$remote_url" == git@github.com:* ]]; then
 		repo_slug=$(echo "$remote_url" | sed 's|.*github\.com[:/]||;s|\.git$||')
 	fi
 	if [[ -n "$remote_url" ]]; then
@@ -1232,10 +1232,16 @@ GITATTRSEOF
 	# block in fresh repos. Both operations are idempotent. Skip for local_only
 	# repos (no remote to host SVGs or run GitHub Actions).
 	local _badges_helper="$AGENTS_DIR/scripts/readme-badges-helper.sh"
+	local _label_sync_helper="$AGENTS_DIR/scripts/label-sync-helper.sh"
 	local _wf_template="$AGENTS_DIR/templates/workflows/loc-badge-caller.yml"
 	local _wf_dest="$project_root/.github/workflows/loc-badge.yml"
 
 	if [[ -n "$repo_slug" ]]; then
+		local _is_local_only
+		_is_local_only=$(jq -r --arg s "$repo_slug" \
+			'.initialized_repos // [] | map(select(.slug == $s)) | if length > 0 then .[0].local_only // false else false end' \
+			"$HOME/.config/aidevops/repos.json" 2>/dev/null || echo "false")
+
 		# Install loc-badge caller workflow if template is available and file is absent
 		if [[ -f "$_wf_template" && ! -f "$_wf_dest" ]]; then
 			mkdir -p "$project_root/.github/workflows"
@@ -1257,11 +1263,20 @@ GITATTRSEOF
 			print_info "No README.md found — skipping badge block injection (create README.md first)"
 		fi
 
+		# Sync the canonical GitHub label palette for this repo. This is a
+		# best-effort external GitHub setup step: warn on auth/API/access issues, but
+		# do not abort repo initialization.
+		if [[ "$_is_local_only" != "true" && -f "$_label_sync_helper" ]]; then
+			if bash "$_label_sync_helper" sync --repo "$repo_slug" >/dev/null; then
+				print_success "Synced canonical GitHub labels for $repo_slug"
+			else
+				print_warning "GitHub label sync failed — run manually: label-sync-helper.sh sync --repo $repo_slug"
+			fi
+		elif [[ "$_is_local_only" == "true" ]]; then
+			print_info "Skipping GitHub label sync for local-only repo"
+		fi
+
 		# Remind about SYNC_PAT if the repo has a remote and isn't local_only
-		local _is_local_only
-		_is_local_only=$(jq -r --arg s "$repo_slug" \
-			'.initialized_repos // [] | map(select(.slug == $s)) | if length > 0 then .[0].local_only // false else false end' \
-			"$HOME/.config/aidevops/repos.json" 2>/dev/null || echo "false")
 		if [[ "$_is_local_only" != "true" ]]; then
 			print_info "Reminder: set SYNC_PAT secret so GitHub Actions can push badge SVGs — see: aidevops --help sync-pat"
 		fi

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -55,7 +55,7 @@ STATUS_LABELS=(
 	"status:in-progress|1D76DB|Worker actively running"
 	"status:in-review|5319E7|PR open, awaiting review/merge"
 	"status:done|6F42C1|Task is complete"
-	"status:blocked|D93F0B|Waiting on blocker task"
+	"status:blocked|D73A4A|Waiting on blocker task"
 )
 
 # --- Status Exceptions (out-of-band, not managed by set_issue_status) ---
@@ -68,8 +68,9 @@ STATUS_EXCEPTION_LABELS=(
 
 # --- Origin Labels ---
 ORIGIN_LABELS=(
-	"origin:worker|C5DEF5|Created by headless/pulse worker session"
-	"origin:interactive|BFD4F2|Created by interactive user session"
+	"origin:worker|1D76DB|Created by headless/pulse worker session"
+	"origin:interactive|1D76DB|Created by interactive user session"
+	"origin:worker-takeover|1D76DB|Worker took over work from another origin"
 )
 
 # --- Tier Labels (model routing) ---
@@ -81,7 +82,7 @@ TIER_LABELS=(
 
 # --- Priority Labels ---
 PRIORITY_LABELS=(
-	"priority:critical|B60205|Critical severity — security or data loss risk"
+	"priority:critical|D73A4A|Critical severity — security or data loss risk"
 	"priority:high|D93F0B|High severity — significant quality issue"
 	"priority:medium|FBCA04|Medium severity — moderate quality issue"
 	"priority:low|0E8A16|Low severity — minor quality issue"
@@ -107,15 +108,18 @@ DISPATCH_LABELS=(
 SYSTEM_LABELS=(
 	"auto-dispatch|0E8A16|Eligible for automated worker dispatch"
 	"no-auto-dispatch|EDEDED|Opt-out: block all auto-dispatch on this issue"
-	"hold-for-review|E99695|Opt-out: block auto-merge — hold PR for maintainer review"
+	"hold-for-review|D73A4A|Opt-out: block auto-merge — hold PR for maintainer review"
 	"needs-credentials|FBCA04|Opt-out: block auto-dispatch — requires credentials or account access"
 	"ai-approved|0E8A16|Issue approved for AI agent processing"
 	"persistent|FBCA04|Persistent issue — do not close"
 	"supervisor|1D76DB|Supervisor health dashboard"
 	"contributor|A2EEEF|Contributor health dashboard"
-	"needs-review|E99695|Flagged for human review by AI supervisor"
-	"needs-maintainer-review|E99695|Requires maintainer approval before work begins"
-	"security-review|D93F0B|Requires security review — suspicious AI request"
+	"critical|D73A4A|Critical human-attention issue"
+	"security|D73A4A|Security-sensitive issue"
+	"security-adjacent|D73A4A|Security-adjacent issue requiring human attention"
+	"needs-review|D73A4A|Flagged for human review by AI supervisor"
+	"needs-maintainer-review|D73A4A|Requires maintainer approval before work begins"
+	"security-review|D73A4A|Requires security review — suspicious AI request"
 	"parent-task|D4C5F9|Parent/meta task — children implement, not this issue"
 	"quality-debt|D93F0B|Unactioned review feedback from merged PRs"
 	"quality-review|7057FF|Daily code quality review"
@@ -133,7 +137,7 @@ SYSTEM_LABELS=(
 	"recheck-simplicity|D4C5F9|File flagged for simplification recheck"
 	"triage-failed|D93F0B|Automated triage could not classify this issue"
 	"circuit-breaker|D93F0B|Circuit breaker tripped — automatic retry paused"
-	"needs-review-fixes|E99695|PR has unaddressed review comments"
+	"needs-review-fixes|D73A4A|PR has unaddressed review comments"
 	"coderabbit-pulse|7057FF|Daily CodeRabbit pulse review tracking"
 	"multi-model|E99695|Cross-provider model routing"
 )
@@ -176,7 +180,7 @@ TAG_CAT_DEVOPS="ci git deploy deployment infrastructure shell setup workflow dev
 TAG_CAT_QUALITY="refactor testing quality cleanup verification shellcheck eslint prettier coderabbit sonarcloud auto-review code-quality qlty test codacy code-review evaluation convention enforcement reliability efficiency"
 
 # Category: Security — peach
-TAG_CAT_SECURITY="security audit encryption auth prompt-injection sandboxing sandbox opsec"
+TAG_CAT_SECURITY="security security-adjacent audit encryption auth prompt-injection sandboxing sandbox opsec"
 
 # Category: UI/Frontend — mint green
 TAG_CAT_UI="ui ux dashboard browser mobile responsive navigation react chrome browser-extension design"
@@ -208,7 +212,7 @@ declare -A TAG_CATEGORY_COLORS=(
 	[enhancement]="A2EEEF"
 	[devops]="BFD4F2"
 	[quality]="D4C5F9"
-	[security]="F9D0C4"
+	[security]="D73A4A"
 	[ui]="C2E0C6"
 	[backend]="FEF2C0"
 	[arch]="BFDADC"

--- a/.agents/scripts/tests/test-init-scope.sh
+++ b/.agents/scripts/tests/test-init-scope.sh
@@ -95,9 +95,21 @@ assert_negative() {
 # We need to find the repo root
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 AIDEVOPS_SH="$REPO_ROOT/aidevops.sh"
+AIDEVOPS_INIT_LIB="$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-init-lib.sh"
+AIDEVOPS_REPOS_LIB="$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
 
 if [[ ! -f "$AIDEVOPS_SH" ]]; then
 	echo "ERROR: Cannot find aidevops.sh at $AIDEVOPS_SH" >&2
+	exit 1
+fi
+
+if [[ ! -f "$AIDEVOPS_INIT_LIB" ]]; then
+	echo "ERROR: Cannot find aidevops-init-lib.sh at $AIDEVOPS_INIT_LIB" >&2
+	exit 1
+fi
+
+if [[ ! -f "$AIDEVOPS_REPOS_LIB" ]]; then
+	echo "ERROR: Cannot find aidevops-repos-lib.sh at $AIDEVOPS_REPOS_LIB" >&2
 	exit 1
 fi
 
@@ -112,7 +124,7 @@ test_scope_includes() {
 
 	# Extract the function from aidevops.sh
 	local func_body
-	func_body=$(sed -n '/_scope_includes() {/,/^}/p' "$AIDEVOPS_SH")
+	func_body=$(sed -n '/_scope_includes() {/,/^}/p' "$AIDEVOPS_REPOS_LIB")
 	eval "$func_body"
 
 	# minimal includes minimal
@@ -158,7 +170,7 @@ test_infer_init_scope() {
 
 	# Extract the function from aidevops.sh
 	local func_body
-	func_body=$(sed -n '/_infer_init_scope() {/,/^}/p' "$AIDEVOPS_SH")
+	func_body=$(sed -n '/_infer_init_scope() {/,/^}/p' "$AIDEVOPS_REPOS_LIB")
 	eval "$func_body"
 
 	# Test 1: .aidevops.json with explicit init_scope takes priority
@@ -201,7 +213,7 @@ _setup_scaffold_test_env() {
 	TEST_ROOT=$(mktemp -d)
 
 	local scope_func
-	scope_func=$(sed -n '/_scope_includes() {/,/^}/p' "$AIDEVOPS_SH")
+	scope_func=$(sed -n '/_scope_includes() {/,/^}/p' "$AIDEVOPS_REPOS_LIB")
 	eval "$scope_func"
 
 	# Stub print functions
@@ -211,15 +223,15 @@ _setup_scaffold_test_env() {
 	export -f print_info print_success print_warning
 
 	local scaffold_func
-	scaffold_func=$(sed -n '/^scaffold_repo_courtesy_files() {/,/^}/p' "$AIDEVOPS_SH")
+	scaffold_func=$(sed -n '/^scaffold_repo_courtesy_files() {/,/^}/p' "$AIDEVOPS_INIT_LIB")
 	local contributing_func
-	contributing_func=$(sed -n '/^_scaffold_contributing() {/,/^}/p' "$AIDEVOPS_SH")
+	contributing_func=$(sed -n '/^_scaffold_contributing() {/,/^}/p' "$AIDEVOPS_INIT_LIB")
 	local security_func
-	security_func=$(sed -n '/^_scaffold_security() {/,/^}/p' "$AIDEVOPS_SH")
+	security_func=$(sed -n '/^_scaffold_security() {/,/^}/p' "$AIDEVOPS_INIT_LIB")
 	local coc_func
-	coc_func=$(sed -n '/^_scaffold_coc() {/,/^}/p' "$AIDEVOPS_SH")
+	coc_func=$(sed -n '/^_scaffold_coc() {/,/^}/p' "$AIDEVOPS_INIT_LIB")
 	local sec_content_func
-	sec_content_func=$(sed -n '/^_generate_security_content() {/,/^}/p' "$AIDEVOPS_SH")
+	sec_content_func=$(sed -n '/^_generate_security_content() {/,/^}/p' "$AIDEVOPS_INIT_LIB")
 
 	eval "$contributing_func" 2>/dev/null || true
 	eval "$security_func" 2>/dev/null || true
@@ -330,7 +342,7 @@ test_backward_compat() {
 
 	# Extract the function
 	local func_body
-	func_body=$(sed -n '/_infer_init_scope() {/,/^}/p' "$AIDEVOPS_SH")
+	func_body=$(sed -n '/_infer_init_scope() {/,/^}/p' "$AIDEVOPS_REPOS_LIB")
 	eval "$func_body"
 
 	TEST_ROOT=$(mktemp -d)
@@ -353,6 +365,40 @@ test_backward_compat() {
 	return 0
 }
 
+# ---- Test GitHub label sync init hook ----
+
+test_label_sync_init_hook() {
+	echo ""
+	echo "=== Testing GitHub label sync init hook ==="
+
+	local init_tail
+	init_tail=$(sed -n '/local _label_sync_helper=/,/register_repo /p' "$AIDEVOPS_INIT_LIB")
+	local rc expected_helper expected_sync expected_local_only expected_warning
+	expected_helper="local _label_sync_helper=\"\$AGENTS_DIR/scripts/label-sync-helper.sh\""
+	expected_sync="bash \"\$_label_sync_helper\" sync --repo \"\$repo_slug\""
+	expected_local_only="\"\$_is_local_only\" != \"true\""
+	expected_warning='print_warning "GitHub label sync failed'
+
+	if [[ "$init_tail" == *"$expected_helper"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init resolves label-sync-helper path" "$rc"
+
+	if [[ "$init_tail" == *"$expected_sync"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init invokes label sync for resolved GitHub repo_slug" "$rc"
+
+	if [[ "$init_tail" == *"$expected_local_only"* && "$init_tail" == *"Skipping GitHub label sync for local-only repo"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init skips label sync for local-only repos" "$rc"
+
+	if [[ "$init_tail" == *"$expected_warning"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init warns instead of aborting when label sync fails" "$rc"
+
+	local repo_slug_block
+	repo_slug_block=$(sed -n '/local repo_slug=""/,/local repo_name/p' "$AIDEVOPS_INIT_LIB")
+	if [[ "$repo_slug_block" == *"github.com"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init only derives repo_slug for GitHub remotes" "$rc"
+
+	return 0
+}
+
 # ---- Run all tests ----
 
 echo "test-init-scope.sh — init_scope scaffolding gate tests (t2265)"
@@ -365,6 +411,7 @@ test_scaffold_standard_scope
 test_scaffold_public_scope
 test_aidevops_json_roundtrip
 test_backward_compat
+test_label_sync_init_hook
 
 echo ""
 echo "============================================================="

--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -49,6 +49,22 @@ print_result() {
 	fi
 }
 
+find_label_color() {
+	local array_name="$1" label_name="$2"
+	local definitions=()
+	local definition name color desc
+
+	eval "definitions=(\"\${${array_name}[@]}\")"
+	for definition in "${definitions[@]}"; do
+		IFS='|' read -r name color desc <<<"$definition"
+		if [[ "$name" == "$label_name" ]]; then
+			printf '%s\n' "$color"
+			return 0
+		fi
+	done
+	return 1
+}
+
 # Sandbox HOME — side-effect-free sourcing + isolate cache writes
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
@@ -62,6 +78,8 @@ export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 # =============================================================================
 # shellcheck source=/dev/null
 source "${TEST_SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/label-sync-helper.sh"
 set +e
 
 if [[ -n "${ISSUE_STATUS_LABEL_PRECEDENCE+x}" ]]; then
@@ -105,6 +123,47 @@ if [[ -n "${ISSUE_TIER_LABEL_RANK+x}" && "${ISSUE_TIER_LABEL_RANK[0]:-}" == "thi
 else
 	print_result "ISSUE_TIER_LABEL_RANK matches dedup-tier-labels.yml order" 1 \
 		"(got: ${ISSUE_TIER_LABEL_RANK[*]:-})"
+fi
+
+attention_labels=(
+	"SYSTEM_LABELS:needs-maintainer-review"
+	"SYSTEM_LABELS:security"
+	"SYSTEM_LABELS:security-adjacent"
+	"SYSTEM_LABELS:critical"
+	"PRIORITY_LABELS:priority:critical"
+	"STATUS_LABELS:status:blocked"
+	"SYSTEM_LABELS:hold-for-review"
+	"SYSTEM_LABELS:security-review"
+	"SYSTEM_LABELS:needs-review"
+	"SYSTEM_LABELS:needs-review-fixes"
+)
+
+for attention_spec in "${attention_labels[@]}"; do
+	attention_array="${attention_spec%%:*}"
+	attention_name="${attention_spec#*:}"
+	attention_color=$(find_label_color "$attention_array" "$attention_name" 2>/dev/null || true)
+	if [[ "$attention_color" == "D73A4A" ]]; then
+		print_result "canonical human-attention label $attention_name is red" 0
+	else
+		print_result "canonical human-attention label $attention_name is red" 1 "(got: '${attention_color:-missing}')"
+	fi
+done
+
+origin_labels=(origin:interactive origin:worker origin:worker-takeover)
+for origin_name in "${origin_labels[@]}"; do
+	origin_color=$(find_label_color "ORIGIN_LABELS" "$origin_name" 2>/dev/null || true)
+	if [[ "$origin_color" == "1D76DB" ]]; then
+		print_result "canonical origin label $origin_name is blue" 0
+	else
+		print_result "canonical origin label $origin_name is blue" 1 "(got: '${origin_color:-missing}')"
+	fi
+done
+
+security_tag_color=$(color_for_tag "security-adjacent")
+if [[ "$security_tag_color" == "D73A4A" ]]; then
+	print_result "security-adjacent TODO tag maps to red" 0
+else
+	print_result "security-adjacent TODO tag maps to red" 1 "(got: '$security_tag_color')"
 fi
 
 # =============================================================================
@@ -489,7 +548,7 @@ fi
 # carries `parent-task` would close the parent — wiping the open-until-
 # terminal-PR contract. Mirror of Part 4's t2137 workflow guard, applied to
 # the parallel bash-helper code path.
-HELPER_FILE="${TEST_SCRIPTS_DIR}/issue-sync-helper.sh"
+HELPER_FILE="${TEST_SCRIPTS_DIR}/issue-sync-helper-close.sh"
 
 if [[ ! -f "$HELPER_FILE" ]]; then
 	print_result "issue-sync-helper.sh exists (for close-gate guard)" 1 "(not found at $HELPER_FILE)"


### PR DESCRIPTION
## Summary

Updated canonical label colors for human-attention and origin labels, wired best-effort label sync into GitHub repo initialization, and added regression coverage for label palette and init invocation.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-init-lib.sh,.agents/scripts/label-sync-helper.sh,.agents/scripts/tests/test-init-scope.sh,.agents/scripts/tests/test-label-invariants.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-label-invariants.sh; bash .agents/scripts/tests/test-init-scope.sh; shellcheck .agents/scripts/label-sync-helper.sh .agents/scripts/aidevops-cli/aidevops-init-lib.sh .agents/scripts/tests/test-label-invariants.sh .agents/scripts/tests/test-init-scope.sh; .agents/scripts/label-sync-helper.sh audit --repo marcusquinn/aidevops

Resolves #22442


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.32 with gpt-5.5 spent 9m and 133,469 tokens on this as a headless worker.