### PR TITLE
t3508: split CI repair routing test mock

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -47,7 +47,12 @@ setup_test_env() {
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
 	printf 'Original issue body.\n' >"${TEST_ROOT}/issue-body.txt"
+	write_gh_mock
+	return 0
+}
 
+
+write_gh_mock() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"


### PR DESCRIPTION
## Summary
- Split the CI repair routing test mock setup out of setup_test_env so the merged t3508 regression test stays below the function-complexity gate.

## Testing
- shellcheck .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
- .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
- .agents/scripts/complexity-regression-helper.sh check --base origin/main --metric function-complexity --output-md /tmp/aidevops-followup-complexity.md

For #22472