### PR TITLE
t3516: fix: respect priority labels in dispatch scoring

### DIFF
--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -82,8 +82,8 @@ TIER_LABELS=(
 
 # --- Priority Labels ---
 PRIORITY_LABELS=(
-	"priority:critical|D73A4A|Critical severity — security or data loss risk"
-	"priority:high|D93F0B|High severity — significant quality issue"
+	"priority:critical|D73A4A|Critical — stopping work completely, security, or data loss risk"
+	"priority:high|D93F0B|High — systemic throughput bottleneck or significant quality issue"
 	"priority:medium|FBCA04|Medium severity — moderate quality issue"
 	"priority:low|0E8A16|Low severity — minor quality issue"
 )

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -237,11 +237,13 @@ build_ranked_dispatch_candidates_json() {
 				score: (
 					(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
 					(if (.labels | index("priority:critical")) != null then 10000
-					 elif (.labels | index("priority:high")) != null then 8000
+					 elif (.labels | index("priority:high")) != null then 9000
+					 elif (.labels | index("priority:medium")) != null then 8000
 					 elif (.labels | index("bug")) != null then 7000
 					 elif (.labels | index("enhancement")) != null then 6000
 					 elif (.labels | index("quality-debt")) != null then 5000
 					 elif ((.labels | index("file-size-debt")) != null or (.labels | index("function-complexity-debt")) != null) then 4000
+					 elif (.labels | index("priority:low")) != null then 3500
 					 else 3000 end)
 				)
 			}

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -836,6 +836,54 @@ JSON
 	return 0
 }
 
+test_build_ranked_dispatch_candidates_json_respects_priority_labels() {
+	local original_repos_json="$REPOS_JSON"
+	cat >"${REPOS_JSON}" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "marcusquinn/aidevops",
+      "path": "/tmp/aidevops",
+      "pulse": true,
+      "priority": "tooling",
+      "maintainer": "marcusquinn"
+    }
+  ]
+}
+JSON
+
+	gh_issue_list() {
+		if [[ "${1:-}" == "--repo" && "${2:-}" == "marcusquinn/aidevops" ]]; then
+			printf '%s\n' '[
+			  {"number":9100,"title":"unlabeled task","url":"#9100","updatedAt":"2026-03-31T00:00:00Z","assignees":[],"labels":[]},
+			  {"number":9101,"title":"low priority task","url":"#9101","updatedAt":"2026-03-31T00:01:00Z","assignees":[],"labels":[{"name":"priority:low"}]},
+			  {"number":9102,"title":"bug task","url":"#9102","updatedAt":"2026-03-31T00:02:00Z","assignees":[],"labels":[{"name":"bug"}]},
+			  {"number":9103,"title":"medium priority task","url":"#9103","updatedAt":"2026-03-31T00:03:00Z","assignees":[],"labels":[{"name":"priority:medium"}]},
+			  {"number":9104,"title":"high priority task","url":"#9104","updatedAt":"2026-03-31T00:04:00Z","assignees":[],"labels":[{"name":"priority:high"}]},
+			  {"number":9105,"title":"critical priority task","url":"#9105","updatedAt":"2026-03-31T00:05:00Z","assignees":[],"labels":[{"name":"priority:critical"}]}
+			]'
+			return 0
+		fi
+		return 1
+	}
+	export -f gh_issue_list
+
+	local ordered_numbers
+	ordered_numbers=$(build_ranked_dispatch_candidates_json 20 | jq -r '.[].number' 2>/dev/null || true)
+
+	unset -f gh_issue_list
+	REPOS_JSON="$original_repos_json"
+
+	if [[ "$ordered_numbers" == $'9105\n9104\n9103\n9102\n9101\n9100' ]]; then
+		print_result "build_ranked_dispatch_candidates_json respects critical/high/medium/low labels" 0
+		return 0
+	fi
+
+	print_result "build_ranked_dispatch_candidates_json respects critical/high/medium/low labels" 1 \
+		"Unexpected order: ${ordered_numbers}"
+	return 0
+}
+
 test_dispatch_max_dispatches_up_to_capacity() {
 	local dispatch_log="${TEST_ROOT}/deterministic-dispatch.log"
 	: >"$dispatch_log"
@@ -1235,6 +1283,7 @@ main() {
 	test_dispatch_with_dedup_detaches_worker_stdio
 	test_dispatch_with_dedup_passes_explicit_model_override
 	test_build_ranked_dispatch_candidates_json_scores_candidates
+	test_build_ranked_dispatch_candidates_json_respects_priority_labels
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_build_ranked_dispatch_candidates_json_accepts_array_pulse_hours
 	test_dispatch_max_dispatches_up_to_capacity

--- a/TODO.md
+++ b/TODO.md
@@ -922,6 +922,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3503 Remove volatile Sonar quality gate README badge and suppress validated S8541 noise #bug ref:GH#22445
 
+- [ ] t3516 Respect all priority labels in dispatch scoring #auto-dispatch #bug ref:GH#22482
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Updated dispatch scoring so critical/high/medium/low priority labels all affect candidate ordering; updated label descriptions for critical work-stoppers and high systemic bottlenecks; added regression coverage for priority ordering.

## Files Changed

.agents/scripts/label-sync-helper.sh,.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/label-sync-helper.sh .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh; bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh (priority-ordering regression passed; unrelated existing dispatch_with_dedup/dispatch_max cases failed in local fixture due config/launch harness setup)

Resolves #22482


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1h 45m and 315,608 tokens on this with the user in an interactive session.