### PR TITLE
t3510: Prevent duplicate manual workers on the same issue worktree

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -32,9 +32,10 @@
 # fails closed — write operations abort if the lock cannot be obtained.
 #
 # Usage:
-#   dispatch-ledger-helper.sh register --session-key KEY [--issue NUM] [--repo SLUG] [--pid PID]
+#   dispatch-ledger-helper.sh register --session-key KEY [--issue NUM] [--repo SLUG] [--pid PID] [--worktree PATH]
 #   dispatch-ledger-helper.sh check --session-key KEY
 #   dispatch-ledger-helper.sh check-issue --issue NUM [--repo SLUG]
+#   dispatch-ledger-helper.sh check-issue NUM [SLUG]
 #   dispatch-ledger-helper.sh complete --session-key KEY
 #   dispatch-ledger-helper.sh fail --session-key KEY
 #   dispatch-ledger-helper.sh expire [--ttl SECONDS]
@@ -261,6 +262,7 @@ _iso_to_epoch() {
 #   --issue NUM          (optional) GitHub issue number
 #   --repo SLUG          (optional) owner/repo
 #   --pid PID            (optional) PID of dispatch process, defaults to $$
+#   --worktree PATH      (optional) worker worktree path
 #
 # Exit codes:
 #   0 - registered successfully
@@ -273,6 +275,7 @@ cmd_register() {
 	local dispatch_pid="$$"
 	local dispatch_tier=""
 	local dispatch_model=""
+	local worktree_path=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -290,6 +293,10 @@ cmd_register() {
 			;;
 		--pid)
 			dispatch_pid="${2:-$$}"
+			shift 2
+			;;
+		--worktree)
+			worktree_path="${2:-}"
 			shift 2
 			;;
 		--tier)
@@ -338,7 +345,8 @@ cmd_register() {
 		--arg ts "$now" \
 		--arg tier "$dispatch_tier" \
 		--arg model "$dispatch_model" \
-		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: "in-flight", updated_at: $ts, tier: $tier, model: $model}' \
+		--arg worktree "$worktree_path" \
+		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: "in-flight", updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree}' \
 		>>"$LEDGER_FILE"
 
 	# Append to tier telemetry log (append-only, never pruned)
@@ -422,6 +430,7 @@ cmd_check() {
 # Args:
 #   --issue NUM          (required)
 #   --repo SLUG          (optional) restrict to specific repo
+#   Positional form also supported: check-issue NUM [SLUG]
 #
 # Exit codes:
 #   0 - in-flight entry exists for this issue (do NOT dispatch)
@@ -442,9 +451,20 @@ cmd_check_issue() {
 			repo_slug="${2:-}"
 			shift 2
 			;;
-		*)
+		--*)
 			echo "Error: Unknown option for check-issue: $1" >&2
 			return 1
+			;;
+		*)
+			if [[ -z "$issue_number" ]]; then
+				issue_number="$1"
+			elif [[ -z "$repo_slug" ]]; then
+				repo_slug="$1"
+			else
+				echo "Error: Unexpected positional arg for check-issue: $1" >&2
+				return 1
+			fi
+			shift
 			;;
 		esac
 	done

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -365,7 +365,204 @@ _dsi_register_ledger() {
 		--issue "$issue_number" \
 		--repo "$repo_slug" \
 		--pid "$worker_pid" \
+		--worktree "${_DSI_WORKTREE_PATH:-}" \
 		>/dev/null 2>&1 || _dsi_warn "Dispatch ledger registration failed (non-fatal)"
+	return 0
+}
+
+#######################################
+# Extract a --dir value from a worker command line.
+# Args: $1 - command line
+# Stdout: worktree path, or empty string
+#######################################
+_dsi_extract_worktree_from_cmd() {
+	local cmd="$1"
+	local worktree_path=""
+	if [[ "$cmd" =~ --dir[[:space:]]+([^[:space:]]+) ]]; then
+		worktree_path="${BASH_REMATCH[1]}"
+	fi
+	printf '%s\n' "$worktree_path"
+	return 0
+}
+
+#######################################
+# Resolve a repo slug from a worktree path.
+# Args: $1 - worktree path
+# Stdout: owner/repo slug, or empty string
+#######################################
+_dsi_repo_slug_for_worktree() {
+	local worktree_path="$1"
+	local remote_url=""
+	if [[ -z "$worktree_path" || ! -d "$worktree_path" ]]; then
+		printf '\n'
+		return 0
+	fi
+	remote_url=$(git -C "$worktree_path" remote get-url origin 2>/dev/null || true)
+	if [[ "$remote_url" =~ github\.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	printf '\n'
+	return 0
+}
+
+#######################################
+# Emit active worker process lines for duplicate detection.
+# Tests override this function with fixture output.
+# Stdout: ps rows: "PID STAT COMMAND..."
+#######################################
+_dsi_ps_worker_lines() {
+	ps axwwo pid=,stat=,command= 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Check if a command line belongs to a worker for an issue number.
+# Args: $1 - issue number, $2 - command line
+# Returns: 0 match, 1 no match
+#######################################
+_dsi_cmd_matches_issue() {
+	local issue_number="$1"
+	local cmd="$2"
+	local issue_re="([Ii]ssue[[:space:]]+#|[Ii]ssue[[:space:]]+|GH#)${issue_number}([^0-9]|$)"
+	if [[ "$cmd" =~ $issue_re ]]; then
+		return 0
+	fi
+	if [[ "$cmd" == *"--session-key issue-${issue_number}"* || "$cmd" == *"--session-key manual-cli-${issue_number}-"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Find a manual-dispatch log that names a worker PID.
+# Args: $1 - issue number, $2 - PID
+# Stdout: log path, or "<unknown>"
+#######################################
+_dsi_find_log_for_pid() {
+	local issue_number="$1"
+	local worker_pid="$2"
+	local candidate=""
+	for candidate in "$_DSI_LOG_DIR"/manual-dispatch-"${issue_number}"-*.log; do
+		[[ -f "$candidate" ]] || continue
+		if grep -Fq "Dispatched PID: ${worker_pid}" "$candidate" 2>/dev/null; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	printf '%s\n' "<unknown>"
+	return 0
+}
+
+#######################################
+# Find a live worker by repo+issue and/or exact worktree path.
+# Args: $1 - issue number, $2 - repo slug, $3 - worktree path (optional)
+# Stdout: TSV source, pid, log, worktree, session_key
+# Returns: 0 found, 1 none
+#######################################
+_dsi_find_live_dispatch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local target_worktree="${3:-}"
+	local line pid stat cmd worktree_path worker_repo log_path session_key
+
+	while IFS= read -r line; do
+		[[ -n "$line" ]] || continue
+		pid="${line%%[[:space:]]*}"
+		line="${line#*[[:space:]]}"
+		stat="${line%%[[:space:]]*}"
+		cmd="${line#*[[:space:]]}"
+		[[ "$pid" =~ ^[0-9]+$ ]] || continue
+		[[ "$stat" == *Z* || "$stat" == *T* ]] && continue
+		[[ "$cmd" == *"dispatch-single-issue-helper.sh"* ]] && continue
+
+		worktree_path=$(_dsi_extract_worktree_from_cmd "$cmd")
+		if [[ -n "$target_worktree" && "$worktree_path" == "$target_worktree" ]]; then
+			log_path=$(_dsi_find_log_for_pid "$issue_number" "$pid")
+			session_key=$(printf '%s' "$cmd" | sed -n 's/.*--session-key[[:space:]]\([^[:space:]]*\).*/\1/p' | head -1)
+			printf 'process\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "$worktree_path" "${session_key:-<unknown>}"
+			return 0
+		fi
+
+		_dsi_cmd_matches_issue "$issue_number" "$cmd" || continue
+		worker_repo=$(_dsi_repo_slug_for_worktree "$worktree_path")
+		[[ "$worker_repo" == "$repo_slug" ]] || continue
+		log_path=$(_dsi_find_log_for_pid "$issue_number" "$pid")
+		session_key=$(printf '%s' "$cmd" | sed -n 's/.*--session-key[[:space:]]\([^[:space:]]*\).*/\1/p' | head -1)
+		printf 'process\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "${worktree_path:-<unknown>}" "${session_key:-<unknown>}"
+		return 0
+	done < <(_dsi_ps_worker_lines)
+
+	return 1
+}
+
+#######################################
+# Find a live ledger entry for repo+issue.
+# Args: $1 - issue number, $2 - repo slug
+# Stdout: TSV source, pid, log, worktree, session_key
+# Returns: 0 found, 1 none
+#######################################
+_dsi_find_ledger_dispatch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local entry pid session_key worktree_path log_path
+	entry=$("$_DSI_LEDGER_HELPER" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null) || entry=""
+	[[ -n "$entry" ]] || return 1
+	pid=$(printf '%s' "$entry" | jq -r '.pid // "?"')
+	session_key=$(printf '%s' "$entry" | jq -r '.session_key // "<unknown>"')
+	worktree_path=$(printf '%s' "$entry" | jq -r '.worktree_path // ""')
+	[[ -n "$worktree_path" && "$worktree_path" != "null" ]] || worktree_path="<unknown>"
+	log_path=$(_dsi_find_log_for_pid "$issue_number" "$pid")
+	printf 'ledger\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "$worktree_path" "$session_key"
+	return 0
+}
+
+#######################################
+# Print active dispatch details from a TSV record.
+# Args: TSV source, pid, log, worktree, session_key
+#######################################
+_dsi_print_dispatch_details() {
+	local record="$1"
+	local source pid log_path worktree_path session_key
+	IFS=$'\t' read -r source pid log_path worktree_path session_key <<<"$record"
+	_dsi_info "  Evidence source:  ${source}"
+	_dsi_info "  Existing PID:     ${pid}"
+	_dsi_info "  Existing log:     ${log_path}"
+	_dsi_info "  Existing worktree:${worktree_path}"
+	_dsi_info "  Existing session: ${session_key}"
+	return 0
+}
+
+#######################################
+# Print an existing active dispatch as a blocking duplicate.
+# Args: TSV source, pid, log, worktree, session_key
+#######################################
+_dsi_print_existing_dispatch() {
+	local record="$1"
+	local source="${record%%$'\t'*}"
+	_dsi_err "Active worker already owns this issue or worktree (${source})"
+	_dsi_print_dispatch_details "$record"
+	return 0
+}
+
+#######################################
+# Fail closed if an active dispatch already owns repo+issue or worktree.
+# Args: $1 - issue number, $2 - repo slug, $3 - worktree path (optional)
+# Returns: 0 clear, 1 blocked
+#######################################
+_dsi_guard_no_existing_dispatch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local worktree_path="${3:-}"
+	local record=""
+	if record=$(_dsi_find_ledger_dispatch "$issue_number" "$repo_slug"); then
+		_dsi_print_existing_dispatch "$record"
+		return 1
+	fi
+	if record=$(_dsi_find_live_dispatch "$issue_number" "$repo_slug" "$worktree_path"); then
+		_dsi_print_existing_dispatch "$record"
+		return 1
+	fi
 	return 0
 }
 
@@ -643,12 +840,19 @@ cmd_dispatch() {
 	*) dedup_state="error" ;;
 	esac
 
-	# Step 4: resolve model
+	# Step 4: fail closed if an active manual/pulse worker already owns the
+	# same repo+issue. This closes the gap where labels or ledger entries are
+	# stale/missing but a live worker process is still writing in a worktree.
+	if [[ "$_DSI_ARG_DRYRUN" -ne 1 ]]; then
+		_dsi_guard_no_existing_dispatch "$issue_number" "$repo_slug" || return 1
+	fi
+
+	# Step 5: resolve model
 	_dsi_resolve_model "$_DSI_ISSUE_LABELS" "$_DSI_ARG_MODEL"
 	local session_key
 	session_key="manual-cli-${issue_number}-$(date +%s)"
 
-	# Step 5: dry-run short-circuit
+	# Step 6: dry-run short-circuit
 	if [[ "$_DSI_ARG_DRYRUN" -eq 1 ]]; then
 		_dsi_print_dryrun "$issue_number" "$repo_slug" "$session_key" "$dedup_state" "$dedup_rc" "$dedup_result"
 		return 0
@@ -660,7 +864,7 @@ cmd_dispatch() {
 		_dsi_warn "Skipped: dispatch dedup check blocked"
 		_dsi_info "  Reason: ${dedup_result}"
 		_dsi_info "  Use a separate test issue, or release the existing claim first."
-		return 0
+		return 1
 		;;
 	error)
 		_dsi_err "Dedup check failed (exit ${dedup_rc}) — failing closed, refusing to dispatch"
@@ -679,10 +883,14 @@ cmd_dispatch() {
 			"$self_login" "$_DSI_ISSUE_META_JSON" || true
 	fi
 
-	# Step 6: pre-create worktree
+	# Step 7: pre-create worktree
 	_dsi_create_worktree "$issue_number" || return 1
 
-	# Steps 7-9 + report: launch worker, resolve real PID, register ledger,
+	# Step 7.5: re-check after worktree creation so an existing live process
+	# on the same worktree cannot be joined by a second manual launch.
+	_dsi_guard_no_existing_dispatch "$issue_number" "$repo_slug" "$_DSI_WORKTREE_PATH" || return 1
+
+	# Steps 8-10 + report: launch worker, resolve real PID, register ledger,
 	# print success summary. Extracted to keep cmd_dispatch under the 100-line
 	# function-complexity gate (t3000).
 	_dsi_launch_and_report "$issue_number" "$repo_slug" "$session_key"
@@ -746,49 +954,19 @@ cmd_status() {
 		return 2
 	fi
 
-	local entry
-	entry=$("$_DSI_LEDGER_HELPER" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null) || entry=""
-
-	if [[ -z "$entry" ]]; then
-		_dsi_info "No active dispatch for #${issue_number} in ${repo_slug}"
+	local record=""
+	if record=$(_dsi_find_ledger_dispatch "$issue_number" "$repo_slug"); then
+		_dsi_ok "Active dispatch for #${issue_number} (${repo_slug}):"
+		_dsi_print_dispatch_details "$record"
+		return 0
+	fi
+	if record=$(_dsi_find_live_dispatch "$issue_number" "$repo_slug" ""); then
+		_dsi_ok "Active dispatch for #${issue_number} (${repo_slug}) from live process evidence:"
+		_dsi_print_dispatch_details "$record"
 		return 0
 	fi
 
-	# Extract ledger fields (use actual field names from ledger schema:
-	# session_key, issue_number, repo_slug, pid, dispatched_at, status,
-	# updated_at, tier, model)
-	local pid session_key ledger_status dispatched_at tier model
-	pid=$(printf '%s' "$entry" | jq -r '.pid // "?"')
-	session_key=$(printf '%s' "$entry" | jq -r '.session_key // "?"')
-	ledger_status=$(printf '%s' "$entry" | jq -r '.status // "?"')
-	dispatched_at=$(printf '%s' "$entry" | jq -r '.dispatched_at // "?"')
-	tier=$(printf '%s' "$entry" | jq -r '.tier // "?"')
-	model=$(printf '%s' "$entry" | jq -r '.model // "?"')
-
-	# PID liveness check (kill -0 tests whether the process exists, without
-	# sending a real signal). Mirrors the check in dispatch-ledger-helper.sh
-	# cmd_check_issue so the manual CLI and the pulse agree on liveness.
-	local liveness="unknown"
-	if [[ "$pid" =~ ^[0-9]+$ ]] && [[ "$pid" -gt 0 ]]; then
-		if kill -0 "$pid" 2>/dev/null; then
-			liveness="running"
-		else
-			liveness="dead"
-		fi
-	fi
-
-	_dsi_ok "Dispatch for #${issue_number} (${repo_slug}):"
-	_dsi_info "  PID:          ${pid} (${liveness})"
-	_dsi_info "  Session key:  ${session_key}"
-	_dsi_info "  Ledger status: ${ledger_status}"
-	_dsi_info "  Dispatched:   ${dispatched_at}"
-	_dsi_info "  Tier:         ${tier}"
-	_dsi_info "  Model:        ${model}"
-
-	if [[ "$liveness" == "dead" ]]; then
-		_dsi_warn "Worker PID ${pid} is no longer running — ledger may be stale"
-		_dsi_info "  If no other worker is active, the issue is safe to re-dispatch."
-	fi
+	_dsi_info "No active dispatch for #${issue_number} in ${repo_slug}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -69,7 +69,7 @@ teardown_test_env() {
 test_register_creates_entry() {
 	setup_test_env
 
-	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$ --worktree "/tmp/aidevops-issue-42"
 
 	local entry_count
 	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
@@ -92,7 +92,13 @@ test_register_creates_entry() {
 		result=1
 	fi
 
-	print_result "register creates a ledger entry with correct fields" "$result" "count=${entry_count}, status=${status}, key=${session_key}"
+	local worktree_path
+	worktree_path=$(jq -r '.worktree_path' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$worktree_path" != "/tmp/aidevops-issue-42" ]]; then
+		result=1
+	fi
+
+	print_result "register creates a ledger entry with correct fields" "$result" "count=${entry_count}, status=${status}, key=${session_key}, worktree=${worktree_path}"
 	teardown_test_env
 	return 0
 }
@@ -147,6 +153,25 @@ test_check_issue_detects_inflight() {
 	fi
 
 	print_result "check-issue detects in-flight by issue number" "$result"
+	teardown_test_env
+	return 0
+}
+
+
+#######################################
+# Test: check-issue accepts positional ISSUE REPO syntax
+#######################################
+test_check_issue_positional_syntax() {
+	setup_test_env
+
+	run_helper "$LEDGER_HELPER" register --session-key "issue-56" --issue 56 --repo "owner/repo" --pid $$
+
+	local result=1
+	if "$LEDGER_HELPER" check-issue 56 "owner/repo" >/dev/null 2>&1; then
+		result=0
+	fi
+
+	print_result "check-issue accepts positional issue and repo" "$result"
 	teardown_test_env
 	return 0
 }
@@ -721,6 +746,7 @@ main() {
 	test_check_detects_inflight
 	test_check_returns_1_for_unknown
 	test_check_issue_detects_inflight
+	test_check_issue_positional_syntax
 	test_check_issue_different_repo
 	test_complete_marks_entry
 	test_terminal_state_immutability

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -32,6 +32,8 @@ SET_ISSUE_STATUS_LOG=""
 SET_ORIGIN_LABEL_LOG=""
 MOCK_GH_ISSUE_STATE="OPEN"
 MOCK_GH_FAIL="0"
+MOCK_PS_LINES=""
+MOCK_LEDGER_RECORD=""
 
 print_result() {
 	local test_name="$1"
@@ -118,6 +120,34 @@ gh() {
 	fi
 
 	printf 'unexpected gh call: %s\n' "$*" >&2
+	return 1
+}
+
+
+# shellcheck disable=SC2317
+_dsi_ps_worker_lines() {
+	printf '%s\n' "$MOCK_PS_LINES"
+	return 0
+}
+
+# shellcheck disable=SC2317
+_dsi_repo_slug_for_worktree() {
+	local worktree_path="$1"
+	case "$worktree_path" in
+	/tmp/aidevops-existing | /tmp/aidevops-recovery) printf '%s\n' "owner/repo" ;;
+	*) printf '\n' ;;
+	esac
+	return 0
+}
+
+# shellcheck disable=SC2317
+_dsi_find_ledger_dispatch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	if [[ -n "$MOCK_LEDGER_RECORD" && "$issue_number" == "12345" && "$repo_slug" == "owner/repo" ]]; then
+		printf '%s\n' "$MOCK_LEDGER_RECORD"
+		return 0
+	fi
 	return 1
 }
 
@@ -457,6 +487,62 @@ test_launch_worker_forwards_agent() {
 	return 0
 }
 
+
+
+test_live_dispatch_detects_issue_repo() {
+	MOCK_LEDGER_RECORD=""
+	MOCK_PS_LINES='700 S bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key manual-cli-12345-999 --dir /tmp/aidevops-existing --title Issue #12345 --prompt-file /tmp/prompt'
+
+	local record="" rc=0
+	record=$(_dsi_find_live_dispatch 12345 owner/repo "") || rc=$?
+
+	local found=1
+	[[ "$rc" -eq 0 && "$record" == process$'\t'700$'\t'*$'\t'/tmp/aidevops-existing$'\t'manual-cli-12345-999 ]] && found=0
+	print_result "live process evidence detects active issue/repo worker" "$found" "rc=$rc record=$record"
+	return 0
+}
+
+test_guard_blocks_ledger_duplicate() {
+	MOCK_PS_LINES=""
+	MOCK_LEDGER_RECORD=$'ledger\t888\t/tmp/manual.log\t/tmp/aidevops-existing\tmanual-cli-12345-1'
+
+	local out="" rc=0
+	out=$(_dsi_guard_no_existing_dispatch 12345 owner/repo 2>&1) || rc=$?
+
+	local blocked=1
+	[[ "$rc" -eq 1 && "$out" == *"Existing PID:"* && "$out" == *"888"* && "$out" == *"Existing worktree:"* ]] && blocked=0
+	print_result "duplicate guard blocks active ledger dispatch" "$blocked" "rc=$rc output=$out"
+	return 0
+}
+
+test_guard_blocks_live_worktree_duplicate() {
+	MOCK_LEDGER_RECORD=""
+	MOCK_PS_LINES='701 S opencode run --dir /tmp/aidevops-recovery --title Issue #9999 "/full-loop Implement issue #9999"'
+
+	local out="" rc=0
+	out=$(_dsi_guard_no_existing_dispatch 12345 owner/repo /tmp/aidevops-recovery 2>&1) || rc=$?
+
+	local blocked=1
+	[[ "$rc" -eq 1 && "$out" == *"701"* && "$out" == *"/tmp/aidevops-recovery"* ]] && blocked=0
+	print_result "duplicate guard blocks active worktree owner" "$blocked" "rc=$rc output=$out"
+	return 0
+}
+
+
+
+test_status_reports_live_process_without_ledger() {
+	MOCK_LEDGER_RECORD=""
+	MOCK_PS_LINES='702 S bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key manual-cli-12345-777 --dir /tmp/aidevops-existing --title Issue #12345 --prompt-file /tmp/prompt'
+
+	local out="" rc=0
+	out=$(cmd_status 12345 owner/repo 2>&1) || rc=$?
+
+	local active=1
+	[[ "$rc" -eq 0 && "$out" == *"Active dispatch"* && "$out" == *"live process evidence"* && "$out" == *"702"* ]] && active=0
+	print_result "status reports live process when ledger is missing" "$active" "rc=$rc output=$out"
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Runner
 # -----------------------------------------------------------------------------
@@ -482,6 +568,10 @@ _run_tests() {
 	test_load_issue_meta_blocks_lowercase_closed
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
+	test_live_dispatch_detects_issue_repo
+	test_guard_blocks_ledger_duplicate
+	test_guard_blocks_live_worktree_duplicate
+	test_status_reports_live_process_without_ledger
 
 	echo
 	echo "======================================"


### PR DESCRIPTION
## Summary

Manual worker dispatch now fails closed when ledger or live process evidence shows an active worker for the same repo/issue or worktree, and status reconciles ledger plus live process evidence.

## Files Changed

.agents/scripts/dispatch-ledger-helper.sh,.agents/scripts/dispatch-single-issue-helper.sh,.agents/scripts/tests/test-dispatch-ledger-helper.sh,.agents/scripts/tests/test-dispatch-single-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/dispatch-ledger-helper.sh aidevops.sh; bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh; bash .agents/scripts/tests/test-dispatch-ledger-helper.sh; bash .agents/scripts/tests/test-aidevops-launch-worker-command.sh; bash aidevops.sh launch-worker status 22472 marcusquinn/aidevops

Resolves #22474


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.95 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 310,553 tokens on this as a headless worker.