### PR TITLE
t3514: use REST-first PR readiness checks

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -112,6 +112,23 @@ _pmp_classify_pr_backlog_state() {
 	return 0
 }
 
+_pmp_enrich_prs_with_rest_check_status() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local status_json=""
+	status_json=$(gh_pr_check_status_rest_batch "$repo_slug" "$pr_json" 2>/dev/null) || status_json="[]"
+	[[ -n "$status_json" && "$status_json" != "null" ]] || status_json="[]"
+	jq -n --argjson prs "$pr_json" --argjson statuses "$status_json" '
+		def rollup($s):
+			if $s == "PASS" then [{status:"COMPLETED", conclusion:"SUCCESS", state:"SUCCESS"}]
+			elif $s == "FAIL" then [{status:"COMPLETED", conclusion:"FAILURE", state:"FAILURE"}]
+			elif $s == "PENDING" then [{status:"IN_PROGRESS", conclusion:null, state:"PENDING"}]
+			else [] end;
+		$prs | map(. as $pr | ($statuses | map(select(.number == $pr.number)) | last | .status // "none") as $s | $pr + {statusCheckRollup: rollup($s)})' \
+		2>/dev/null || printf '%s' "$pr_json"
+	return 0
+}
+
 #######################################
 # Convert a backlog bucket to a numeric scheduling priority.
 # Lower number runs first. Merge-ready and fix-needed PRs are processed before
@@ -309,14 +326,13 @@ _merge_ready_prs_for_repo() {
 	local closed=0
 	local failed=0
 
-	# Fetch open PRs with the status rollup needed for backlog-first scheduling.
-	# Safety still lives in _process_single_ready_pr; this list only determines
-	# which PRs receive merge/fix attention before dispatch_max consumes worker
-	# and API budget on unrelated new tasks.
+	# Fetch open PRs without GraphQL statusCheckRollup. Backlog scheduling is
+	# enriched below from REST check-suites so merge polling preserves GraphQL
+	# budget for dispatch.
 	local pr_json pr_merge_err
 	pr_merge_err=$(mktemp)
 	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json number,mergeable,reviewDecision,author,title,isDraft,labels,statusCheckRollup \
+		--json number,mergeable,reviewDecision,author,title,isDraft,labels,headRefOid \
 		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json="[]"
 	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg
@@ -334,6 +350,8 @@ _merge_ready_prs_for_repo() {
 		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"
 		return 0
 	fi
+
+	pr_json=$(_pmp_enrich_prs_with_rest_check_status "$repo_slug" "$pr_json")
 
 	_pmp_log_pr_backlog_counts "$repo_slug" "$pr_json"
 	pr_json=$(_pmp_sort_prs_by_backlog_priority "$pr_json")
@@ -414,7 +432,7 @@ _resolve_pr_mergeable_status() {
 		[[ -z "$pr_mergeable" ]] && _was_label="empty"
 		# Separate local declaration from assignment to preserve exit code (SC2181).
 		local _retry_output _retry_exit
-		_retry_output=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		_retry_output=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json mergeable --jq '.mergeable // ""')
 		_retry_exit=$?
 		[[ $_retry_exit -eq 0 && -n "$_retry_output" ]] && pr_mergeable="$_retry_output" || pr_mergeable="UNKNOWN"
@@ -489,8 +507,8 @@ _pulse_merge_dismiss_coderabbit_nits() {
 # Skips PRs with failing CI even when the merge would use --admin
 # (which bypasses branch protection).
 #
-# t2104 (GH#19040): switch to `gh pr checks --required` which consults
-# branch protection and returns ONLY checks that gate the merge.
+# t3514: delegate to REST-backed branch-protection context verification so
+# merge readiness does not spend GraphQL on `gh pr checks --required`.
 #
 # An empty result (no required checks defined in branch protection) is
 # treated as "nothing is failing" → merge allowed. Fail-closed on API
@@ -502,22 +520,8 @@ _pulse_merge_dismiss_coderabbit_nits() {
 _pr_required_checks_pass() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local failing _gh_exit
-	# Separate declaration from assignment to preserve exit code (SC2181).
-	failing=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json bucket \
-		--jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' \
-		2>/dev/null)
-	_gh_exit=$?
-	# Fail-closed: if the API call itself fails, skip the merge rather than
-	# silently allowing it (t2092 — --admin bypasses branch protection).
-	if [[ $_gh_exit -ne 0 ]]; then
-		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — required checks fetch failed (exit ${_gh_exit}) (t2104)" >>"$LOGFILE"
-		return 1
-	fi
-	# Empty string = no required checks; normalise to 0.
-	[[ -z "$failing" ]] && failing=0
-	if [[ "$failing" -gt 0 ]]; then
-		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — ${failing} required status check(s) failing (t2104)" >>"$LOGFILE"
+	if ! _check_required_checks_passing "$repo_slug" "$pr_number"; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — REST required checks not provably passing (t3514)" >>"$LOGFILE"
 		return 1
 	fi
 	return 0
@@ -543,9 +547,9 @@ _attempt_pr_ci_rebase_retry() {
 	local pr_number="$1"
 	local repo_slug="$2"
 
-	# Fetch baseRefName and headRefOid in a single gh pr view call.
+	# Fetch baseRefName and headRefOid in a single REST-first PR view call.
 	local _pr_info _base_branch _head_oid
-	_pr_info=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	_pr_info=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json baseRefName,headRefOid --jq '(.baseRefName // "") + " " + (.headRefOid // "")' 2>/dev/null) || _pr_info=""
 	read -r _base_branch _head_oid <<< "$_pr_info"
 
@@ -609,7 +613,7 @@ _route_pr_to_fix_worker() {
 
 	# Fetch labels if not provided by caller
 	if [[ -z "$pr_labels" ]]; then
-		pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels=""
 	fi
 
@@ -681,7 +685,7 @@ _retarget_stacked_children() {
 	local parent_pr_number="$1"
 	local repo_slug="$2"
 	local parent_head_ref
-	parent_head_ref=$(gh pr view "$parent_pr_number" --repo "$repo_slug" --json headRefName -q '.headRefName' 2>/dev/null) || parent_head_ref=""
+	parent_head_ref=$(gh_pr_view "$parent_pr_number" --repo "$repo_slug" --json headRefName -q '.headRefName' 2>/dev/null) || parent_head_ref=""
 	if [[ -z "$parent_head_ref" ]]; then
 		return 0
 	fi
@@ -976,7 +980,7 @@ _check_required_checks_passing() {
 	# (~111KB/PR) but exposes per-context .name fields needed for matching
 	# branch-protection required_status_checks. Single-PR path → cost is fine.
 	local pr_sha=""
-	pr_sha=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json headRefOid --jq '.headRefOid' 2>/dev/null) || pr_sha=""
 	if [[ -z "$pr_sha" ]]; then
 		echo "[pulse-merge] _check_required_checks_passing: headRefOid fetch failed for PR #${pr_number} in ${repo_slug} — failing closed (t2922, GH#21799)" >>"$LOGFILE"
@@ -1099,7 +1103,7 @@ _repo_allows_auto_merge() {
 # Threshold defaults to 300s, overridable via
 # AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS.
 #
-# Args: $1=pr_number, $2=repo_slug, $3=raw JSON from gh pr view
+# Args: $1=pr_number, $2=repo_slug, $3=raw JSON from gh_pr_view
 # Stdout: stuck-seconds count when stuck (caller logs it)
 # Returns: 0=stuck, safe to fall through to --admin; 1=defer to GitHub
 #######################################
@@ -1135,11 +1139,7 @@ _auto_merge_stuck_seconds() {
 	# every required check to be in `pass` or `skipping` bucket — anything
 	# else means the PR has a legitimate reason to stay blocked, and
 	# falling through to --admin would bypass that signal.
-	local non_ok_count
-	non_ok_count=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json bucket \
-		--jq '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length' 2>/dev/null)
-	[[ "$non_ok_count" =~ ^[0-9]+$ ]] || non_ok_count=99
-	[[ "$non_ok_count" -eq 0 ]] || return 1
+	_check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1 || return 1
 
 	printf '%s' "$stuck_seconds"
 	return 0
@@ -1187,7 +1187,7 @@ _set_native_auto_merge_or_skip() {
 	# Fetch auto_merge metadata + merge state in one call so the stuck-state
 	# check (t3192) does not require an extra round trip.
 	local _pr_state
-	_pr_state=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	_pr_state=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json autoMergeRequest,mergeStateStatus,mergeable,reviewDecision 2>/dev/null)
 
 	local _existing_auto=""
@@ -1209,10 +1209,10 @@ _set_native_auto_merge_or_skip() {
 		# the same stuck threshold, stop silently deferring every pulse cycle.
 		# Return 2 so the caller can route a bounded CI repair worker/comment keyed
 		# by the linked issue/PR marker instead of attempting an admin bypass.
-		local _pending_count=""
-		_pending_count=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json bucket \
-			--jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null) || _pending_count="0"
-		[[ "$_pending_count" =~ ^[0-9]+$ ]] || _pending_count=0
+		local _pending_count=0
+		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+			_pending_count=1
+		fi
 		if [[ "$_pending_count" -gt 0 ]]; then
 			local _enabled_at="" _enabled_epoch="0" _now_epoch="0" _age_seconds="0"
 			_enabled_at=$(printf '%s' "$_pr_state" | jq -r '.autoMergeRequest.enabledAt // ""' 2>/dev/null) || _enabled_at=""
@@ -1241,16 +1241,10 @@ _set_native_auto_merge_or_skip() {
 	# already done (success/skipped — failures filtered upstream by
 	# _pr_required_checks_pass), the immediate --admin path is faster than
 	# round-tripping through GitHub's auto-merge engine.
-	local pending_count=""
-	local _pc_exit=0
-	pending_count=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json bucket \
-		--jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null)
-	_pc_exit=$?
-	if [[ $_pc_exit -ne 0 ]]; then
-		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: gh pr checks --required failed (exit ${_pc_exit}), falling through to immediate merge (t3070)" >>"$LOGFILE"
-		return 1
+	local pending_count=0
+	if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+		pending_count=1
 	fi
-	[[ "$pending_count" =~ ^[0-9]+$ ]] || pending_count=0
 
 	if [[ "$pending_count" -eq 0 ]]; then
 		# No pending required checks — immediate --admin merge is faster.

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -161,7 +161,7 @@ _check_pr_merge_gates() {
 		# Fetch labels once — reused by both the nits-ok check and the
 		# worker-routing block below.
 		local _cr_pr_labels
-		_cr_pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		_cr_pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
 
 		# t2179: coderabbit-nits-ok path.
@@ -235,7 +235,7 @@ _check_pr_merge_gates() {
 	# ── External contributor gate (t1958) ──
 	# Requires linked issue + crypto approval (defence-in-depth after _is_collaborator_author).
 	local pr_labels_for_ext
-	pr_labels_for_ext=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels \
+	pr_labels_for_ext=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels \
 		--jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels_for_ext=""
 	if [[ "$pr_labels_for_ext" == *"external-contributor"* ]]; then
 		if ! _external_pr_has_linked_issue "$pr_number" "$repo_slug"; then
@@ -256,7 +256,7 @@ _check_pr_merge_gates() {
 	# COLLABORATOR). COLLABORATORs that pass these checks still go through the
 	# review bot gate and normal merge path without an ownership fast-path.
 	local _oi_info_json _oi_labels_str _oi_is_draft
-	_oi_info_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	_oi_info_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json labels,isDraft 2>/dev/null) || _oi_info_json=""
 	_oi_labels_str=$(printf '%s' "$_oi_info_json" \
 		| jq -r '[.labels[].name] | join(",")' 2>/dev/null) || _oi_labels_str=""
@@ -400,7 +400,7 @@ _handle_post_merge_actions() {
 
 		if [[ "$_parent_task_guard" -eq 0 ]]; then
 			if [[ $# -lt 5 ]]; then
-				pr_labels=$(_gh_with_timeout read gh pr view "$pr_number" --repo "$repo_slug" \
+				pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 					--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels=""
 			fi
 			local _solved_actor="interactive"
@@ -541,7 +541,7 @@ _process_single_ready_pr() {
 			# moment to recompute it. _resolve_pr_mergeable_status already
 			# has a UNKNOWN-retry loop so we reuse it.
 			local _refetched_mergeable
-			_refetched_mergeable=$(gh pr view "$pr_number" --repo "$repo_slug" \
+			_refetched_mergeable=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 				--json mergeable --jq '.mergeable // "UNKNOWN"' 2>/dev/null) || _refetched_mergeable="UNKNOWN"
 			pr_mergeable="$_refetched_mergeable"
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch succeeded, refetched mergeable=${pr_mergeable} (t2116)" >>"$LOGFILE"
@@ -603,7 +603,7 @@ _process_single_ready_pr() {
 		# (external contributors, interactive sessions) take the normal
 		# CI-failure routing path, preserving the contributor security gate.
 		local _rcl_labels
-		_rcl_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		_rcl_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _rcl_labels=""
 		if [[ ",${_rcl_labels}," == *"${_OW_LABEL_PAT}"* ]] \
 			&& _check_required_checks_passing "$repo_slug" "$pr_number"; then
@@ -673,7 +673,7 @@ _process_single_ready_pr() {
 			# threshold. Route bounded CI repair feedback rather than silently
 			# deferring forever or attempting an admin bypass through pending CI.
 			local _native_labels
-			_native_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+			_native_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 				--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _native_labels=""
 			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$_native_labels" || true
 			return 1
@@ -692,7 +692,7 @@ _process_single_ready_pr() {
 		echo "[pulse-wrapper] Deterministic merge: merged PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
 		# t2411: emit audit log for origin:interactive auto-merges
 		local _ipr_labels
-		_ipr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		_ipr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _ipr_labels=""
 		if [[ "$_ipr_labels" == *"origin:interactive"* ]]; then
 			local _ipr_role="collaborator"
@@ -750,7 +750,7 @@ process_pr() {
 	# (number, mergeable, reviewDecision, author, title) and synthesize a
 	# single-PR object. _process_single_ready_pr expects a compact JSON object.
 	local pr_obj
-	pr_obj=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	pr_obj=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json number,mergeable,reviewDecision,author,title 2>/dev/null) || pr_obj=""
 
 	if [[ -z "$pr_obj" || "$pr_obj" == "null" ]]; then
@@ -760,7 +760,7 @@ process_pr() {
 
 	# Verify state is OPEN — closed/merged PRs should not be re-processed.
 	local pr_state
-	pr_state=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	pr_state=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json state --jq '.state // ""' 2>/dev/null) || pr_state=""
 	if [[ "$pr_state" != "OPEN" ]]; then
 		echo "[pulse-merge] process_pr: PR ${repo_slug}#${pr_number} is not OPEN (state=${pr_state}) — skipping" >>"$LOGFILE"
@@ -789,8 +789,8 @@ _extract_linked_issue() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local pr_title pr_body
-	pr_title=$(gh pr view "$pr_number" --repo "$repo_slug" --json title --jq '.title // empty' 2>/dev/null) || pr_title=""
-	pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body // empty' 2>/dev/null) || pr_body=""
+	pr_title=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json title --jq '.title // empty' 2>/dev/null) || pr_title=""
+	pr_body=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json body --jq '.body // empty' 2>/dev/null) || pr_body=""
 
 	# Match GitHub-native close keywords in the PR body only (case-insensitive).
 	# Matches: close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
@@ -860,7 +860,7 @@ _extract_merge_summary() {
 	# Workers skip the MERGE_SUMMARY comment ~65% of the time, but the PR body
 	# always contains a useful description of what was done (GH#17503).
 	local pr_body
-	pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	pr_body=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json body --jq '.body // empty' 2>/dev/null) || pr_body=""
 
 	if [[ -z "$pr_body" ]]; then

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -837,6 +837,7 @@ _rest_pr_view() {
 	local num_or_url=""
 	local repo=""
 	local jq_expr=""
+	local json_fields=""
 
 	local _first="${1:-}"
 	if [[ $# -gt 0 && "$_first" != --* ]]; then
@@ -849,8 +850,8 @@ _rest_pr_view() {
 		case "$_arg" in
 		--repo) repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--json) shift 2 ;;
-		--json=*) shift ;;
+		--json) json_fields="${2:-}"; shift 2 ;;
+		--json=*) json_fields="${_arg#--json=}"; shift ;;
 		--jq | -q) jq_expr="${2:-}"; shift 2 ;;
 		--jq=* | -q=*) jq_expr="${_arg#*=}"; shift ;;
 		*) shift ;;
@@ -871,9 +872,44 @@ _rest_pr_view() {
 
 	local _path="/repos/${repo}/pulls/${num}"
 	local _gh_cmd=(gh api "$_path")
+	if [[ -n "$json_fields" ]]; then
+		jq_expr="$(_rest_pr_object_json_jq "$json_fields" "$jq_expr")"
+	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
+}
+
+_rest_pr_object_json_jq() {
+	local fields="$1"
+	local user_jq="$2"
+	local projection=""
+	local field=""
+	while IFS= read -r field; do
+		[[ -z "$field" ]] && continue
+		case "$field" in
+		number) projection="${projection}${projection:+,}number: .number" ;;
+		state) projection="${projection}${projection:+,}state: .state" ;;
+		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable // \"UNKNOWN\")" ;;
+		reviewDecision) projection="${projection}${projection:+,}reviewDecision: (.reviewDecision // \"\")" ;;
+		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
+		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
+		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
+		title) projection="${projection}${projection:+,}title: (.title // \"\")" ;;
+		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
+		baseRefName) projection="${projection}${projection:+,}baseRefName: (.base.ref // \"\")" ;;
+		headRefName) projection="${projection}${projection:+,}headRefName: (.head.ref // \"\")" ;;
+		headRefOid) projection="${projection}${projection:+,}headRefOid: (.head.sha // \"\")" ;;
+		autoMergeRequest) projection="${projection}${projection:+,}autoMergeRequest: (.autoMergeRequest // null)" ;;
+		mergeStateStatus) projection="${projection}${projection:+,}mergeStateStatus: (.mergeStateStatus // \"\")" ;;
+		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	[[ -z "$projection" ]] && projection="number: .number"
+	local jq_expr="{${projection}}"
+	[[ -n "$user_jq" ]] && jq_expr="${jq_expr} | ${user_jq}"
+	printf '%s' "$jq_expr"
+	return 0
 }
 
 #######################################
@@ -899,6 +935,10 @@ _rest_pr_list_json_jq() {
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
 		state) projection="${projection}${projection:+,}state: .state" ;;
+		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable // \"UNKNOWN\")" ;;
+		reviewDecision) projection="${projection}${projection:+,}reviewDecision: (.reviewDecision // \"\")" ;;
+		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
+		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
 		mergedAt) projection="${projection}${projection:+,}mergedAt: .merged_at" ;;
 		url) projection="${projection}${projection:+,}url: .html_url" ;;
 		title) projection="${projection}${projection:+,}title: .title" ;;
@@ -908,6 +948,7 @@ _rest_pr_list_json_jq() {
 		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
 		baseRefName) projection="${projection}${projection:+,}baseRefName: .base.ref" ;;
 		headRefName) projection="${projection}${projection:+,}headRefName: .head.ref" ;;
+		headRefOid) projection="${projection}${projection:+,}headRefOid: .head.sha" ;;
 		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
 		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
 		esac

--- a/.agents/scripts/tests/test-pulse-merge-rest-readiness.sh
+++ b/.agents/scripts/tests/test-pulse-merge-rest-readiness.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_PROCESS="${SCRIPT_DIR}/../pulse-merge-process.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local ok="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$ok" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '     %s\n' "$detail"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_functions_under_test() {
+	local fn_src
+	fn_src=$(awk '
+		/^_pmp_enrich_prs_with_rest_check_status\(\) \{/,/^}$/ { print }
+	' "$MERGE_PROCESS")
+	[[ -n "$fn_src" ]] || return 1
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+	return 0
+}
+
+gh_pr_check_status_rest_batch() {
+	local slug="$1"
+	local pr_json="$2"
+	[[ "$slug" == "owner/repo" && -n "$pr_json" ]] || return 1
+	printf '%s\n' '[{"number":1,"status":"PASS"},{"number":2,"status":"FAIL"},{"number":3,"status":"PENDING"},{"number":4,"status":"none"}]'
+	return 0
+}
+
+assert_rollup() {
+	local name="$1"
+	local number="$2"
+	local expected="$3"
+	local output="$4"
+	local actual
+	actual=$(printf '%s' "$output" | jq -r --argjson n "$number" '.[] | select(.number == $n) | (.statusCheckRollup[0].conclusion // .statusCheckRollup[0].status // "none")') || actual=""
+	[[ "$actual" == "$expected" ]]
+	print_result "$name" "$?" "expected=${expected} actual=${actual}"
+	return 0
+}
+
+main() {
+	define_functions_under_test || { printf 'failed to load function\n' >&2; return 1; }
+	local prs output
+	prs='[{"number":1,"headRefOid":"a"},{"number":2,"headRefOid":"b"},{"number":3,"headRefOid":"c"},{"number":4,"headRefOid":"d"}]'
+	output=$(_pmp_enrich_prs_with_rest_check_status "owner/repo" "$prs")
+	assert_rollup "green REST check maps to success rollup" 1 "SUCCESS" "$output"
+	assert_rollup "failing REST check maps to failure rollup" 2 "FAILURE" "$output"
+	assert_rollup "pending REST check maps to in-progress rollup" 3 "IN_PROGRESS" "$output"
+	assert_rollup "missing REST check stays ambiguous/empty" 4 "none" "$output"
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Moved pulse merge-readiness polling away from GraphQL-heavy statusCheckRollup and gh pr checks by enriching PR lists with REST check-suite status and verifying required contexts through REST-backed branch protection/check-run helpers. Extended REST PR translators so gh-shaped PR fields used by merge paths work on REST.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-pulse-merge-rest-readiness.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-pulse-merge-rest-readiness.sh; bash .agents/scripts/tests/test-pulse-merge-rest-readiness.sh

Resolves #22480


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.0 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 212,458 tokens on this as a headless worker.