### PR TITLE
GH#22310: scope contributor insights to repo sessions

### DIFF
--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -165,6 +165,60 @@ run_compression() {
 	return $?
 }
 
+run_repo_scoped_extraction() {
+	local db_path="$1"
+	local output_dir="$2"
+	local repo_dir="$3"
+
+	if [[ ! -f "${EXTRACTOR}" ]]; then
+		log_error "Extractor not found at ${EXTRACTOR}"
+		return 1
+	fi
+
+	log_info "Running repo-scoped extraction from ${db_path} for ${repo_dir}..."
+	python3 "${EXTRACTOR}" --db "${db_path}" --format chunks --output "${output_dir}" --repo-dir "${repo_dir}" 2>&1
+	return $?
+}
+
+run_repo_scoped_pipeline() {
+	local db_path="$1"
+	local repo_dir="$2"
+	local slug="$3"
+
+	local slug_safe
+	slug_safe="${slug//\//_}"
+	local scoped_output_dir="${_output_dir}/contributor_${slug_safe}"
+	mkdir -p "${scoped_output_dir}"
+
+	local extract_output
+	extract_output=$(run_repo_scoped_extraction "${db_path}" "${scoped_output_dir}" "${repo_dir}" 2>&1) || {
+		log_error "Repo-scoped extraction failed for ${slug}: ${extract_output}"
+		return 1
+	}
+
+	local chunks_dir
+	chunks_dir=$(find "${scoped_output_dir}" -maxdepth 1 -type d -name "chunks_*" | head -1)
+	if [[ -z "${chunks_dir}" ]]; then
+		log_error "No repo-scoped chunks directory found for ${slug} in ${scoped_output_dir}"
+		return 1
+	fi
+
+	local compression_output
+	compression_output=$(run_compression "${chunks_dir}" 2>&1) || {
+		log_error "Repo-scoped compression failed for ${slug}: ${compression_output}"
+		return 1
+	}
+
+	local scoped_compressed_file="${scoped_output_dir}/compressed_signals.json"
+	if [[ ! -f "${scoped_compressed_file}" ]]; then
+		log_error "Repo-scoped compressed signals file not produced for ${slug}"
+		return 1
+	fi
+
+	printf '%s\n' "${scoped_compressed_file}"
+	return 0
+}
+
 # _summary_print_header prints the pulse summary header with steerage and error counts.
 _summary_print_header() {
 	local compressed_file="$1"
@@ -814,8 +868,9 @@ output_results() {
 }
 
 # file_contributor_insights files sanitized upstream issues for repos where
-# the user is a contributor (role != maintainer). Uses compressed signals
-# from the current pulse run. Skips if no contributor-role repos found.
+# the user is a contributor (role != maintainer). It re-extracts a repo-scoped
+# compressed signal file for each target so unrelated project sessions cannot
+# leak into contributor insight issues. Skips if no contributor-role repos found.
 # Arguments: $1 — dry_run (true/false)
 file_contributor_insights() {
 	local dry_run="$1"
@@ -843,6 +898,13 @@ file_contributor_insights() {
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
 
+		local repo_dir
+		repo_dir=$(jq -r --arg s "$slug" '.initialized_repos[] | select(.slug == $s) | .path // empty' "$repos_json" 2>/dev/null) || repo_dir=""
+		if [[ -z "$repo_dir" || ! -d "$repo_dir" ]]; then
+			log_info "Skipping contributor insights for ${slug}: local repo path missing"
+			continue
+		fi
+
 		# Check explicit role first
 		local explicit_role
 		explicit_role=$(jq -r --arg s "$slug" '.initialized_repos[] | select(.slug == $s) | .role // ""' "$repos_json" 2>/dev/null) || explicit_role=""
@@ -859,11 +921,13 @@ file_contributor_insights() {
 		fi
 
 		if [[ "$is_contributor" == true ]]; then
-			log_info "Filing contributor insights for ${slug}..."
+			log_info "Filing contributor insights for ${slug} scoped to ${repo_dir}..."
+			local scoped_compressed_file
+			scoped_compressed_file=$(run_repo_scoped_pipeline "${_db_path}" "${repo_dir}" "${slug}") || continue
 			local dr_flag=""
 			[[ "$dry_run" == true ]] && dr_flag="--dry-run"
 			# shellcheck disable=SC2086
-			"$insight_helper" file $dr_flag "${_compressed_file}" "$slug" 2>&1 || true
+			"$insight_helper" file $dr_flag "${scoped_compressed_file}" "$slug" 2>&1 || true
 		fi
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
@@ -902,6 +966,7 @@ main() {
 	# Find and validate database
 	local db_path
 	db_path=$(detect_db "${_db_override}") || return 1
+	_db_path="${db_path}"
 	log_info "Using database: ${db_path}"
 
 	validate_db_size "${db_path}" || {

--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -38,7 +38,7 @@ from typing import Any, Optional
 from extract_chunking import ChunkConfig, build_chunks
 from extract_errors import extract_error_stats, extract_errors
 from extract_git import extract_git_correlation
-from extract_shared import sanitize_path as _sanitize_path
+from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path as _sanitize_path
 from extract_steerage import (
     STEERAGE_PATTERNS,
     extract_steerage,
@@ -190,7 +190,7 @@ def classify_instruction_candidate(text: str) -> Optional[dict[str, Any]]:
     }
 
 
-def _build_instruction_candidate_query(limit: Optional[int]) -> str:
+def _build_instruction_candidate_query(limit: Optional[int], repo_dir: Optional[str] = None) -> str:
     """Return the SQL query used to scan user messages for instructions."""
     query = """
     SELECT
@@ -203,8 +203,9 @@ def _build_instruction_candidate_query(limit: Optional[int]) -> str:
     FROM message m
     JOIN session s ON m.session_id = s.id
     WHERE json_extract(m.data, '$.role') = 'user'
-    ORDER BY m.time_created ASC
     """
+    query += repo_scope_clause(repo_dir)
+    query += "\n    ORDER BY m.time_created ASC\n    "
     if limit:
         query += f" LIMIT {int(limit) * 10}"
     return query
@@ -260,7 +261,7 @@ def _extract_message_instruction_candidates(
 
 
 def extract_instruction_candidates(
-    conn: sqlite3.Connection, limit: Optional[int] = None,
+    conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
 ) -> list[dict]:
     """Extract instruction candidate signals from user messages.
 
@@ -279,7 +280,7 @@ def extract_instruction_candidates(
     candidates: list[dict] = []
     seen_texts: set[int] = set()
 
-    for row in conn.execute(_build_instruction_candidate_query(limit)):
+    for row in conn.execute(_build_instruction_candidate_query(limit, repo_dir), repo_scope_params(repo_dir)):
         candidates.extend(
             _extract_message_instruction_candidates(conn, row, seen_texts),
         )
@@ -353,6 +354,8 @@ def main():
                         help=f"Output directory (default: {OUTPUT_DIR})")
     parser.add_argument("--no-git", action="store_true",
                         help="Skip git correlation extraction")
+    parser.add_argument("--repo-dir", type=str, default=None,
+                        help="Only extract sessions whose directory is this repo or a subdirectory")
     args = parser.parse_args()
 
     print(f"Session Miner — Extracting from {args.db}", file=sys.stderr)
@@ -360,26 +363,28 @@ def main():
         print(f"Error: Database not found at {args.db}", file=sys.stderr)
         sys.exit(1)
     print(f"  DB size: {args.db.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
+    if args.repo_dir:
+        print(f"  Repo scope: {args.repo_dir}", file=sys.stderr)
 
     conn = connect_db(args.db)
 
     try:
         # Phase 1a: Extract steerage
-        steerage = extract_steerage(conn, limit=args.limit)
+        steerage = extract_steerage(conn, limit=args.limit, repo_dir=args.repo_dir)
 
         # Phase 1b: Extract errors
-        errors = extract_errors(conn, limit=args.limit)
+        errors = extract_errors(conn, limit=args.limit, repo_dir=args.repo_dir)
 
         # Phase 1c: Aggregate stats
-        stats = extract_error_stats(conn)
+        stats = extract_error_stats(conn, repo_dir=args.repo_dir)
 
         # Phase 1d: Extract git correlation (unless disabled)
         git_correlations = None
         if not args.no_git:
-            git_correlations = extract_git_correlation(conn, limit=args.limit)
+            git_correlations = extract_git_correlation(conn, limit=args.limit, repo_dir=args.repo_dir)
 
         # Phase 1e: Extract instruction candidates
-        instruction_candidates = extract_instruction_candidates(conn, limit=args.limit)
+        instruction_candidates = extract_instruction_candidates(conn, limit=args.limit, repo_dir=args.repo_dir)
 
         # Phase 2: Build chunks for model analysis
         if args.format == "chunks":

--- a/.agents/scripts/session-miner/extract_errors.py
+++ b/.agents/scripts/session-miner/extract_errors.py
@@ -10,7 +10,7 @@ import sys
 from collections import defaultdict
 from typing import Any, Optional
 
-from extract_shared import sanitize_path, summarize_tool_input
+from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path, summarize_tool_input
 
 
 ERROR_CATEGORIES = {
@@ -99,7 +99,9 @@ def _find_user_response_after(
     return user_after["text"][:500]
 
 
-def extract_errors(conn: sqlite3.Connection, limit: Optional[int] = None) -> list[dict]:
+def extract_errors(
+    conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
+) -> list[dict]:
     """Extract tool error sequences with surrounding context."""
     print("Extracting error sequences...", file=sys.stderr)
 
@@ -120,13 +122,14 @@ def extract_errors(conn: sqlite3.Connection, limit: Optional[int] = None) -> lis
     JOIN session s ON p.session_id = s.id
     WHERE json_extract(p.data, '$.type') = 'tool'
       AND json_extract(p.data, '$.state.status') = 'error'
-    ORDER BY p.time_created DESC
     """
+    query += repo_scope_clause(repo_dir)
+    query += "\n    ORDER BY p.time_created DESC\n    "
     if limit:
         query += f" LIMIT {int(limit)}"
 
     records = []
-    for row in conn.execute(query):
+    for row in conn.execute(query, repo_scope_params(repo_dir)):
         error_text = row["error_text"] or ""
         tool_name = row["tool_name"] or "unknown"
         tool_input = _parse_json_safe(row["tool_input_json"])
@@ -148,20 +151,23 @@ def extract_errors(conn: sqlite3.Connection, limit: Optional[int] = None) -> lis
     return records
 
 
-def extract_error_stats(conn: sqlite3.Connection) -> dict:
+def extract_error_stats(conn: sqlite3.Connection, repo_dir: Optional[str] = None) -> dict:
     """Extract aggregate error statistics for the summary."""
     stats = {}
 
+    params = repo_scope_params(repo_dir)
     tool_rows = conn.execute("""
         SELECT
-            json_extract(data, '$.tool') as tool,
+            json_extract(p.data, '$.tool') as tool,
             COUNT(*) as total,
-            SUM(CASE WHEN json_extract(data, '$.state.status') = 'error' THEN 1 ELSE 0 END) as errors
-        FROM part
-        WHERE json_extract(data, '$.type') = 'tool'
+            SUM(CASE WHEN json_extract(p.data, '$.state.status') = 'error' THEN 1 ELSE 0 END) as errors
+        FROM part p
+        JOIN session s ON p.session_id = s.id
+        WHERE json_extract(p.data, '$.type') = 'tool'
+    """ + repo_scope_clause(repo_dir) + """
         GROUP BY tool
         ORDER BY total DESC
-    """).fetchall()
+    """, params).fetchall()
     stats["tool_error_rates"] = {
         row["tool"]: {
             "total": row["total"],
@@ -173,32 +179,36 @@ def extract_error_stats(conn: sqlite3.Connection) -> dict:
     }
 
     error_rows = conn.execute("""
-        SELECT json_extract(data, '$.state.error') as err
-        FROM part
-        WHERE json_extract(data, '$.type') = 'tool'
-          AND json_extract(data, '$.state.status') = 'error'
-    """).fetchall()
+        SELECT json_extract(p.data, '$.state.error') as err
+        FROM part p
+        JOIN session s ON p.session_id = s.id
+        WHERE json_extract(p.data, '$.type') = 'tool'
+          AND json_extract(p.data, '$.state.status') = 'error'
+    """ + repo_scope_clause(repo_dir), params).fetchall()
     category_counts = defaultdict(int)
     for row in error_rows:
         category_counts[classify_error(row["err"] or "")] += 1
     stats["error_categories"] = dict(sorted(category_counts.items(), key=lambda item: -item[1]))
 
     model_rows = conn.execute("""
-        SELECT json_extract(data, '$.modelID') as model, COUNT(*) as cnt
-        FROM message
-        WHERE json_extract(data, '$.role') = 'assistant'
+        SELECT json_extract(m.data, '$.modelID') as model, COUNT(*) as cnt
+        FROM message m
+        JOIN session s ON m.session_id = s.id
+        WHERE json_extract(m.data, '$.role') = 'assistant'
+    """ + repo_scope_clause(repo_dir) + """
         GROUP BY model
         ORDER BY cnt DESC
         LIMIT 10
-    """).fetchall()
+    """, params).fetchall()
     stats["model_usage"] = {row["model"]: row["cnt"] for row in model_rows if row["model"]}
 
     session_row = conn.execute("""
         SELECT COUNT(*) as cnt,
                MIN(time_created) as earliest,
                MAX(time_created) as latest
-        FROM session
-    """).fetchone()
+        FROM session s
+        WHERE 1 = 1
+    """ + repo_scope_clause(repo_dir), params).fetchone()
     stats["sessions"] = {
         "total": session_row["cnt"],
         "earliest": session_row["earliest"],

--- a/.agents/scripts/session-miner/extract_git.py
+++ b/.agents/scripts/session-miner/extract_git.py
@@ -11,7 +11,7 @@ import sys
 from datetime import datetime
 from typing import Optional
 
-from extract_shared import sanitize_path
+from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path
 
 
 def _find_git_root(directory: str) -> Optional[str]:
@@ -146,7 +146,7 @@ def _build_correlation_record(row: sqlite3.Row, commits: list[dict]) -> dict:
 
 
 def extract_git_correlation(
-    conn: sqlite3.Connection, limit: Optional[int] = None,
+    conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
 ) -> list[dict]:
     """Extract git-commit correlation data for sessions."""
     print("Extracting git correlation data...", file=sys.stderr)
@@ -163,6 +163,9 @@ def extract_git_correlation(
     FROM session s
     LEFT JOIN message m ON m.session_id = s.id
     WHERE s.directory IS NOT NULL AND s.directory != ''
+    """
+    query += repo_scope_clause(repo_dir)
+    query += """
     GROUP BY s.id
     ORDER BY s.time_created DESC
     """
@@ -173,7 +176,7 @@ def extract_git_correlation(
     correlations = []
     skipped = 0
 
-    for row in conn.execute(query):
+    for row in conn.execute(query, repo_scope_params(repo_dir)):
         session_dir = row["session_dir"]
         if not session_dir or not os.path.isdir(session_dir):
             skipped += 1

--- a/.agents/scripts/session-miner/extract_shared.py
+++ b/.agents/scripts/session-miner/extract_shared.py
@@ -4,7 +4,31 @@
 """Shared helpers for session-miner extraction scripts."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
+
+
+def normalize_repo_dir(repo_dir: Optional[str]) -> Optional[str]:
+    """Return a normalized repository directory for session scoping."""
+    if not repo_dir:
+        return None
+
+    normalized = str(Path(repo_dir).expanduser().absolute()).rstrip("/")
+    return normalized or None
+
+
+def repo_scope_clause(repo_dir: Optional[str], column: str = "s.directory") -> str:
+    """Return a SQL fragment that scopes sessions to *repo_dir* when set."""
+    if normalize_repo_dir(repo_dir) is None:
+        return ""
+    return f" AND ({column} = :repo_dir OR {column} LIKE :repo_dir_prefix)"
+
+
+def repo_scope_params(repo_dir: Optional[str]) -> dict[str, str]:
+    """Return SQLite parameters for repository-directory session scoping."""
+    normalized = normalize_repo_dir(repo_dir)
+    if normalized is None:
+        return {}
+    return {"repo_dir": normalized, "repo_dir_prefix": f"{normalized}/%"}
 
 
 def sanitize_path(path: str) -> str:

--- a/.agents/scripts/session-miner/extract_steerage.py
+++ b/.agents/scripts/session-miner/extract_steerage.py
@@ -8,7 +8,7 @@ import sqlite3
 import sys
 from typing import Any, Optional
 
-from extract_shared import sanitize_path
+from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path
 
 
 STEERAGE_PATTERNS = {
@@ -159,7 +159,9 @@ def _collect_steerage_from_message(
     return records
 
 
-def extract_steerage(conn: sqlite3.Connection, limit: Optional[int] = None) -> list[dict]:
+def extract_steerage(
+    conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
+) -> list[dict]:
     """Extract user steerage signals from sessions."""
     print("Extracting user steerage signals...", file=sys.stderr)
 
@@ -175,14 +177,15 @@ def extract_steerage(conn: sqlite3.Connection, limit: Optional[int] = None) -> l
     FROM message m
     JOIN session s ON m.session_id = s.id
     WHERE json_extract(m.data, '$.role') = 'user'
-    ORDER BY m.time_created ASC
     """
+    query += repo_scope_clause(repo_dir)
+    query += "\n    ORDER BY m.time_created ASC\n    "
     if limit:
         query += f" LIMIT {int(limit) * 10}"
 
     records: list[dict] = []
     seen_texts: set[int] = set()
-    for row in conn.execute(query):
+    for row in conn.execute(query, repo_scope_params(repo_dir)):
         records.extend(_collect_steerage_from_message(conn, row, seen_texts))
         if limit and len(records) >= limit:
             records = records[:limit]

--- a/.agents/scripts/tests/test-session-miner-repo-scope.sh
+++ b/.agents/scripts/tests/test-session-miner-repo-scope.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+DB_PATH="${TMP_DIR}/opencode.db"
+TARGET_REPO="${TMP_DIR}/target-repo"
+OTHER_REPO="${TMP_DIR}/other-project"
+OUTPUT_DIR="${TMP_DIR}/out"
+
+mkdir -p "${TARGET_REPO}/subdir" "${OTHER_REPO}" "${OUTPUT_DIR}"
+
+sqlite3 "${DB_PATH}" <<SQL
+CREATE TABLE session (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  directory TEXT,
+  time_created INTEGER,
+  time_updated INTEGER
+);
+CREATE TABLE message (
+  id TEXT PRIMARY KEY,
+  session_id TEXT,
+  data TEXT,
+  time_created INTEGER
+);
+CREATE TABLE part (
+  id TEXT PRIMARY KEY,
+  session_id TEXT,
+  message_id TEXT,
+  data TEXT,
+  time_created INTEGER
+);
+INSERT INTO session VALUES ('s-target', 'target session', '${TARGET_REPO}/subdir', 1000, 2000);
+INSERT INTO session VALUES ('s-other', 'other session', '${OTHER_REPO}', 3000, 4000);
+INSERT INTO message VALUES ('m-target', 's-target', '{"role":"user","modelID":"test-model"}', 1100);
+INSERT INTO message VALUES ('m-other', 's-other', '{"role":"user","modelID":"test-model"}', 3100);
+INSERT INTO part VALUES ('p-target', 's-target', 'm-target', '{"type":"text","text":"Always use target repo scoped insights for contributor reports."}', 1100);
+INSERT INTO part VALUES ('p-other', 's-other', 'm-other', '{"type":"text","text":"Always use unrelated other project insights for contributor reports."}', 3100);
+SQL
+
+python3 "${REPO_ROOT}/.agents/scripts/session-miner/extract.py" \
+  --db "${DB_PATH}" \
+  --format jsonl \
+  --output "${OUTPUT_DIR}" \
+  --repo-dir "${TARGET_REPO}" \
+  --no-git >/dev/null
+
+extraction_file=$(printf '%s\n' "${OUTPUT_DIR}"/extraction_*.jsonl)
+
+python3 - "${extraction_file}" "${TARGET_REPO}" "${OTHER_REPO}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+records = [json.loads(line) for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()]
+target_repo = Path(sys.argv[2]).name
+other_repo = Path(sys.argv[3]).name
+payload = json.dumps(records)
+
+assert target_repo in payload, payload
+assert other_repo not in payload, payload
+assert "target repo scoped insights" in payload, payload
+assert "unrelated other project insights" not in payload, payload
+PY
+
+printf 'session-miner repo scope test passed\n'


### PR DESCRIPTION
## Summary

Adds repo-directory scoping to session-miner extraction and re-extracts contributor insight signals per target repo so unrelated sessions are not filed upstream.

## Files Changed

.agents/scripts/session-miner-pulse.sh,.agents/scripts/session-miner/extract.py,.agents/scripts/session-miner/extract_errors.py,.agents/scripts/session-miner/extract_git.py,.agents/scripts/session-miner/extract_shared.py,.agents/scripts/session-miner/extract_steerage.py,.agents/scripts/tests/test-session-miner-repo-scope.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-session-miner-repo-scope.sh; bash .agents/scripts/tests/test-session-miner-instruction-redaction.sh; bash .agents/scripts/tests/test-contributor-insight-helper.sh; python3 -m py_compile .agents/scripts/session-miner/*.py; shellcheck .agents/scripts/session-miner-pulse.sh .agents/scripts/contributor-insight-helper.sh

Resolves #22310


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.1 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 11m and 193,357 tokens on this with the user in an interactive session.