### PR TITLE
t3507: Clarify launch-worker current repo default

### DIFF
--- a/.agents/scripts/commands/launch-worker.md
+++ b/.agents/scripts/commands/launch-worker.md
@@ -9,6 +9,9 @@ mode: subagent
 
 Args: `$ARGUMENTS` — `<issue|issue,issue> [owner/repo] [--model <id>] [--agent <name>] [--batch <list>] [--dry-run]`
 
+`owner/repo` is optional. When omitted, `aidevops launch-worker` resolves the
+current git repository from `origin` and dispatches against that repo.
+
 ## What this does
 
 Runs the first-class manual worker launcher:
@@ -24,21 +27,30 @@ dispatch blocker, or launching a controlled batch with a specific model.
 ## Syntax
 
 ```bash
-# Preview one dispatch without launching
+# Preview one dispatch without launching, using the current git repo
+aidevops launch-worker 22259 --dry-run
+
+# Preview one dispatch without launching, using an explicit repo
 aidevops launch-worker 22259 marcusquinn/aidevops --dry-run
 
-# Launch one issue with default agent Build+
-aidevops launch-worker 22259 marcusquinn/aidevops
+# Launch one issue with default agent Build+ in the current repo
+aidevops launch-worker 22259
+
+# Launch multiple issues in the current repo with repeated issue arguments
+aidevops launch-worker 22259 22260 22261
+
+# Batch launch multiple issues in the current repo
+aidevops launch-worker --batch 22259,22260 --dry-run
 
 # Force a model and agent
 aidevops launch-worker 22259 marcusquinn/aidevops \
   --model anthropic/claude-opus-4-7 --agent Build+
 
-# Batch launch
+# Batch launch against an explicit repo
 aidevops launch-worker --batch 22259,22260 marcusquinn/aidevops --dry-run
 
-# Status
-aidevops launch-worker status 22259 marcusquinn/aidevops
+# Status for the current repo
+aidevops launch-worker status 22259
 ```
 
 ## Safety expectations

--- a/.agents/scripts/tests/test-aidevops-launch-worker-command.sh
+++ b/.agents/scripts/tests/test-aidevops-launch-worker-command.sh
@@ -47,8 +47,8 @@ test_launch_worker_help() {
 	local out rc=0
 	out=$(bash "$AIDEVOPS_SH" launch-worker --help 2>&1) || rc=$?
 	local failed=1
-	[[ "$rc" -eq 0 && "$out" == *"Usage: aidevops launch-worker"* && "$out" == *"--batch"* ]] && failed=0
-	_result "launch-worker help exposes batch syntax" "$failed" "rc=$rc out=$out"
+	[[ "$rc" -eq 0 && "$out" == *"Usage: aidevops launch-worker"* && "$out" == *"--batch"* && "$out" == *"defaults to the current git repository"* ]] && failed=0
+	_result "launch-worker help exposes batch syntax and default repo" "$failed" "rc=$rc out=$out"
 	return 0
 }
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1061,6 +1061,7 @@ Usage: aidevops launch-worker <issue|issue,issue> [owner/repo] [options]
        aidevops launch-worker status <issue> [owner/repo]
 
 Launch one or more headless workers manually without waiting for the pulse.
+If owner/repo is omitted, it defaults to the current git repository's origin.
 
 Options:
   --model <id>      Override model (for example, anthropic/claude-opus-4-7).


### PR DESCRIPTION
## Summary

Documented that launch-worker defaults owner/repo to the current git origin, added current-repo single/multiple issue examples, and updated CLI help regression coverage.

## Files Changed

.agents/scripts/commands/launch-worker.md,.agents/scripts/tests/test-aidevops-launch-worker-command.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-aidevops-launch-worker-command.sh; shellcheck aidevops.sh .agents/scripts/tests/test-aidevops-launch-worker-command.sh

Resolves #22471


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.1 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 79,954 tokens on this as a headless worker.