### PR TITLE
t3517: gate compaction advisory

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -227,6 +227,7 @@ export async function AidevopsPlugin({ directory, client }) {
     qualityLog,
     run,
     intentField: INTENT_FIELD,
+    isHeadless,
   });
 
   // Lazy-start dispatch table for local proxies. Keys are OpenCode

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -13,7 +13,7 @@ import { join } from "node:path";
 
 import { createTtsrHooks } from "../ttsr.mjs";
 
-function createHooks() {
+function createHooks(options = {}) {
   const logs = [];
   const tempPrefix = `${Date.now()}-${process.pid}-${randomUUID()}-aidevops-token-advisory-test`;
   const hooks = createTtsrHooks({
@@ -23,6 +23,7 @@ function createHooks() {
     qualityLog: (level, message) => logs.push({ level, message }),
     run: () => "",
     intentField: "agent__intent",
+    isHeadless: options.isHeadless || (() => false),
   });
   return { hooks, logs };
 }
@@ -65,6 +66,33 @@ describe("token cost advisory threshold", () => {
     assert.equal(advisories.length, 1);
     assert.match(advisories[0].parts[0].text, /approximately 250k tokens/);
     assert.deepEqual(logs, [{ level: "INFO", message: "Token advisory: session token-advisory-test-session at ~250k tokens" }]);
+  });
+
+  test("does not inject advisory in headless sessions", async () => {
+    const { hooks } = createHooks({ isHeadless: () => true });
+    const output = outputForTokens(250_000);
+
+    await hooks.messagesTransformHook({}, output);
+
+    assert.equal(advisoryMessages(output).length, 0);
+  });
+
+  test("does not inject advisory for GPT-5.5 family models", async () => {
+    const { hooks } = createHooks();
+    const output = outputForTokens(250_000);
+
+    await hooks.messagesTransformHook({ model: { modelID: "gpt-5.5-fast" } }, output);
+
+    assert.equal(advisoryMessages(output).length, 0);
+  });
+
+  test("does not inject advisory for models newer than GPT-5.5", async () => {
+    const { hooks } = createHooks();
+    const output = outputForTokens(250_000);
+
+    await hooks.messagesTransformHook({ model: { modelID: "gpt-6" } }, output);
+
+    assert.equal(advisoryMessages(output).length, 0);
   });
 
   test("does not repeat at the same threshold for a session", async () => {

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -48,11 +48,15 @@ function getTokenTotal(tokens) {
 function isGpt55OrNewer(input) {
   const modelID = String(input?.model?.modelID || input?.modelID || input?.model || "").toLowerCase();
   const match = modelID.match(/(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?/);
-  if (!match) return false;
+  let result = false;
 
-  const major = Number.parseInt(match[1], 10);
-  const minor = Number.parseInt(match[2] || "0", 10);
-  return major > 5 || (major === 5 && minor >= 5);
+  if (match) {
+    const major = Number.parseInt(match[1], 10);
+    const minor = Number.parseInt(match[2] || "0", 10);
+    result = major > 5 || (major === 5 && minor >= 5);
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -12,16 +12,16 @@ import {
 // ---------------------------------------------------------------------------
 // Token Cost Advisory
 // ---------------------------------------------------------------------------
-// Injects a synthetic message when session context exceeds a token threshold,
-// prompting the LLM to advise the user to run /compact. Fires at 250k tokens,
-// then every 50k above that (300k, 350k, ...). Uses the last assistant
-// message's token counts — which represent the full context sent to the model
-// on that turn — so the number tracks real cost, not model capacity.
+// Injects a synthetic message for interactive sessions when session context
+// exceeds a token threshold, prompting the LLM to advise the user to run
+// /compact. Fires at 250k tokens, then every 50k above that (300k, 350k, ...).
+// Uses the last assistant message's token counts — which represent the full
+// context sent to the model on that turn — so the number tracks real cost, not
+// model capacity.
 //
-// For headless sessions: autocompact already fires at ~(limit - 20k), so
-// this advisory primarily helps interactive sessions on large-context models
-// (Gemini 1M+, future models) where autocompact is far above 250k, or when
-// autocompact is disabled.
+// Headless sessions and GPT-5.5+ models are excluded: headless workers should
+// not spend output budget on user-facing cost advice, and GPT-5.5+ models are
+// registered with a 500k context limit so OpenCode auto-compacts around 400k.
 
 const TOKEN_ADVISORY_INITIAL = 250_000;
 const TOKEN_ADVISORY_INTERVAL = 50_000;
@@ -38,6 +38,21 @@ function getTokenTotal(tokens) {
     (tokens.reasoning || 0) +
     (tokens.cache?.read || 0) +
     (tokens.cache?.write || 0);
+}
+
+/**
+ * Check whether the active model is GPT-5.5 or newer.
+ * @param {object} input
+ * @returns {boolean}
+ */
+function isGpt55OrNewer(input) {
+  const modelID = String(input?.model?.modelID || input?.modelID || input?.model || "").toLowerCase();
+  const match = modelID.match(/(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?/);
+  if (!match) return false;
+
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2] || "0", 10);
+  return major > 5 || (major === 5 && minor >= 5);
 }
 
 // ---------------------------------------------------------------------------
@@ -81,9 +96,14 @@ function pruneAdvisoryState(tokenAdvisoryState) {
  * Check whether the token cost advisory should fire for this message set.
  * @param {Array<object>} messages
  * @param {Map<string, number>} tokenAdvisoryState
+ * @param {object} input
+ * @param {() => boolean} isHeadless
  * @returns {{ sessionID: string, totalK: number, total: number } | null}
  */
-function checkTokenAdvisory(messages, tokenAdvisoryState) {
+function checkTokenAdvisory(messages, tokenAdvisoryState, input, isHeadless) {
+  if (isHeadless()) return null;
+  if (isGpt55OrNewer(input)) return null;
+
   for (let i = messages.length - 1; i >= 0; i--) {
     const info = messages[i].info;
     if (info?.role !== "assistant" || !info.tokens) continue;
@@ -195,10 +215,10 @@ async function ttsrSystemTransform(input, output, state, intentField) {
 /**
  * messages.transform hook: inject token advisory and TTSR violation corrections.
  */
-async function ttsrMessagesTransform(_input, output, state, qualityLog) {
+async function ttsrMessagesTransform(input, output, state, qualityLog, isHeadless) {
   if (!output.messages || output.messages.length === 0) return;
 
-  const advisory = checkTokenAdvisory(output.messages, state.tokenAdvisoryState);
+  const advisory = checkTokenAdvisory(output.messages, state.tokenAdvisoryState, input, isHeadless);
   if (advisory) {
     output.messages.push(buildTokenAdvisoryMessage(advisory));
     qualityLog("INFO", `Token advisory: session ${advisory.sessionID} at ~${advisory.totalK}k tokens`);
@@ -283,6 +303,7 @@ async function ttsrTextComplete(input, output, state, execDeps, qualityLog) {
  */
 export function createTtsrHooks(deps) {
   const { agentsDir, scriptsDir, readIfExists, qualityLog, run, intentField } = deps;
+  const isHeadless = deps.isHeadless || (() => false);
   const ttsrRulesPath = join(agentsDir, "configs", "ttsr-rules.json");
   const state = createTtsrState(ttsrRulesPath, readIfExists);
   const execDeps = { scriptsDir, run };
@@ -290,7 +311,7 @@ export function createTtsrHooks(deps) {
   return {
     loadTtsrRules: () => loadTtsrRules(state),
     systemTransformHook: (input, output) => ttsrSystemTransform(input, output, state, intentField),
-    messagesTransformHook: (_input, output) => ttsrMessagesTransform(_input, output, state, qualityLog),
+    messagesTransformHook: (_input, output) => ttsrMessagesTransform(_input, output, state, qualityLog, isHeadless),
     textCompleteHook: (input, output) => ttsrTextComplete(input, output, state, execDeps, qualityLog),
   };
 }

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -105,28 +105,32 @@ function pruneAdvisoryState(tokenAdvisoryState) {
  * @returns {{ sessionID: string, totalK: number, total: number } | null}
  */
 function checkTokenAdvisory(messages, tokenAdvisoryState, input, isHeadless) {
-  if (isHeadless()) return null;
-  if (isGpt55OrNewer(input)) return null;
+  let result = null;
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const info = messages[i].info;
-    if (info?.role !== "assistant" || !info.tokens) continue;
+  if (!isHeadless() && !isGpt55OrNewer(input)) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const info = messages[i].info;
+      if (info?.role !== "assistant" || !info.tokens) continue;
 
-    const total = getTokenTotal(info.tokens);
-    if (total < TOKEN_ADVISORY_INITIAL) return null;
+      const total = getTokenTotal(info.tokens);
+      if (total >= TOKEN_ADVISORY_INITIAL) {
+        const sessionID = info.sessionID || "";
+        const lastWarned = tokenAdvisoryState.get(sessionID) || 0;
+        const stepsAboveInitial = Math.floor((total - TOKEN_ADVISORY_INITIAL) / TOKEN_ADVISORY_INTERVAL);
+        const currentThreshold = TOKEN_ADVISORY_INITIAL + stepsAboveInitial * TOKEN_ADVISORY_INTERVAL;
 
-    const sessionID = info.sessionID || "";
-    const lastWarned = tokenAdvisoryState.get(sessionID) || 0;
-    const stepsAboveInitial = Math.floor((total - TOKEN_ADVISORY_INITIAL) / TOKEN_ADVISORY_INTERVAL);
-    const currentThreshold = TOKEN_ADVISORY_INITIAL + stepsAboveInitial * TOKEN_ADVISORY_INTERVAL;
+        if (currentThreshold > lastWarned) {
+          tokenAdvisoryState.set(sessionID, currentThreshold);
+          pruneAdvisoryState(tokenAdvisoryState);
+          result = { sessionID, totalK: Math.round(total / 1000), total };
+        }
+      }
 
-    if (currentThreshold <= lastWarned) return null;
-
-    tokenAdvisoryState.set(sessionID, currentThreshold);
-    pruneAdvisoryState(tokenAdvisoryState);
-    return { sessionID, totalK: Math.round(total / 1000), total };
+      break;
+    }
   }
-  return null;
+
+  return result;
 }
 
 /**

--- a/TODO.md
+++ b/TODO.md
@@ -928,6 +928,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3519 Investigate setup launchd xpcproxy recovery warnings #auto-dispatch #bug ref:GH#22500
 
+- [ ] t3517 Gate OpenCode compaction advisory ref:GH#22496
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22
@@ -4072,9 +4074,6 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [ ] t3516 Respect all priority labels in dispatch scoring #auto-dispatch #bug ref:GH#22482
 
 - [ ] t3518 Investigate setup postflight degraded stages #auto-dispatch #bug ref:GH#22499
-
-- [ ] t3517 Gate OpenCode compaction advisory ref:GH#22496
-
 - [ ] t3520 Fix GPT-5.5 auto-compaction limit input override #auto-dispatch #bug ref:GH#22503
 
 - [ ] t3521 Detect stale OpenCode plugin deploy after setup #auto-dispatch #bug ref:GH#22506


### PR DESCRIPTION
## Summary
- Restricts the OpenCode token cost advisory to interactive sessions only.
- Suppresses the advisory for GPT-5.5+ models because their registered context limit already auto-compacts around 400k.
- Adds regression tests for headless and GPT-5.5+ skip behavior.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs` — 29 pass, 0 fail.

Resolves #22496
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.3 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 12m and 200,803 tokens on this with the user in an interactive session.