### PR TITLE
GH#22495: prevent non-maintainer upstream-watch issue spam

### DIFF
--- a/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
+++ b/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#22495:
+# - non-maintainer upstream-watch contexts write local reports instead of public
+#   issues in marcusquinn/aidevops
+# - maintainer-authorized contexts can still create issues
+# - large scan batches coalesce into a single tracker issue
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+PASS=0
+FAIL=0
+
+check() {
+	local ok="$1"
+	local name="$2"
+	local detail="${3:-}"
+	if [[ "$ok" == "1" ]]; then
+		PASS=$((PASS + 1))
+		printf 'PASS: %s\n' "$name"
+	else
+		FAIL=$((FAIL + 1))
+		printf 'FAIL: %s\n' "$name"
+		[[ -n "$detail" ]] && printf '      %s\n' "$detail"
+	fi
+	return 0
+}
+
+TMP="$(mktemp -d -t upstream-watch-gate.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="${TMP}/home"
+mkdir -p "${HOME}/.config/aidevops" "${HOME}/.aidevops/reports/upstream-watch"
+cat >"${HOME}/.config/aidevops/repos.json" <<'JSON'
+{
+  "initialized_repos": [
+    {"is_framework_dir": true, "slug": "marcusquinn/aidevops"}
+  ]
+}
+JSON
+
+export SCRIPT_DIR="$SCRIPTS_DIR"
+export UPSTREAM_WATCH_LABEL="source:upstream-watch"
+export YELLOW="" BLUE="" GREEN="" NC=""
+
+GH_CREATE_CALLS="${TMP}/gh_create_calls.log"
+GH_EDIT_CALLS="${TMP}/gh_edit_calls.log"
+GH_WARNINGS="${TMP}/warnings.log"
+: >"$GH_CREATE_CALLS"
+: >"$GH_EDIT_CALLS"
+: >"$GH_WARNINGS"
+
+_log_warn() { printf '%s\n' "$*" >>"$GH_WARNINGS"; return 0; }
+_log_info() { return 0; }
+
+gh() {
+	if [[ "$1" == "auth" && "${2:-}" == "status" ]]; then
+		return 0
+	fi
+	if [[ "$1" == "api" && "${2:-}" == "user" ]]; then
+		printf 'test-login\n'
+		return 0
+	fi
+	if [[ "$1" == "api" && "${2:-}" == repos/*/collaborators/*/permission ]]; then
+		printf '%s\n' "${GH_PERMISSION:-read}"
+		return 0
+	fi
+	if [[ "$1" == "issue" && "${2:-}" == "list" ]]; then
+		return 0
+	fi
+	return 0
+}
+
+gh_create_issue() {
+	printf '%s\n' "$*" >>"$GH_CREATE_CALLS"
+	printf 'https://github.com/marcusquinn/aidevops/issues/9999\n'
+	return 0
+}
+
+gh_issue_edit_safe() {
+	printf '%s\n' "$*" >>"$GH_EDIT_CALLS"
+	return 0
+}
+
+export -f _log_warn _log_info gh gh_create_issue gh_issue_edit_safe
+
+# shellcheck source=../upstream-watch-helper-issues.sh
+source "${SCRIPTS_DIR}/upstream-watch-helper-issues.sh"
+
+entry_json='{"slug":"owner/repo","relevance":"test relevance","affects":[".agents/example.md"]}'
+
+# Test 1: non-maintainer individual update writes local report and creates no issue.
+export GH_PERMISSION="read"
+: >"$GH_CREATE_CALLS"
+_file_upstream_update_issue "owner/repo" "release" "v1" "v2" "$entry_json" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+report_count=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
+[[ "$create_count" == "0" && "$report_count" == "1" ]] && ok=1 || ok=0
+check "$ok" "non-maintainer writes local report instead of public issue" "create_count=${create_count} report_count=${report_count}"
+
+# Test 2: maintainer-authorized individual update can create a public issue.
+export GH_PERMISSION="write"
+: >"$GH_CREATE_CALLS"
+_file_upstream_update_issue "owner/repo" "release" "v2" "v3" "$entry_json" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+[[ "$create_count" == "1" ]] && ok=1 || ok=0
+check "$ok" "authorized context creates upstream-watch issue" "create_count=${create_count}"
+
+# Test 3: five queued updates coalesce into one batch issue.
+export GH_PERMISSION="write"
+: >"$GH_CREATE_CALLS"
+queue_file="${TMP}/queue.ndjson"
+: >"$queue_file"
+_UPSTREAM_WATCH_ISSUE_QUEUE_FILE="$queue_file"
+for index in 1 2 3 4 5; do
+	_queue_upstream_update_issue "owner/repo-${index}" "commit" "old${index}" "new${index}" "$entry_json"
+done
+unset _UPSTREAM_WATCH_ISSUE_QUEUE_FILE
+_flush_upstream_update_issue_queue "$queue_file" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+if [[ "$create_count" == "1" ]] && grep -q 'upstream: batch review adoption' "$GH_CREATE_CALLS"; then
+	ok=1
+else
+	ok=0
+fi
+check "$ok" "five queued updates coalesce into one batch issue" "create_count=${create_count}"
+
+# Test 4: unauthorized batch writes another local report and creates no issue.
+export GH_PERMISSION="read"
+: >"$GH_CREATE_CALLS"
+before_reports=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
+queue_file_unauth="${TMP}/queue-unauth.ndjson"
+: >"$queue_file_unauth"
+_UPSTREAM_WATCH_ISSUE_QUEUE_FILE="$queue_file_unauth"
+for index in 1 2 3 4 5; do
+	_queue_upstream_update_issue "owner/unauth-${index}" "commit" "old${index}" "new${index}" "$entry_json"
+done
+unset _UPSTREAM_WATCH_ISSUE_QUEUE_FILE
+_flush_upstream_update_issue_queue "$queue_file_unauth" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+after_reports=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
+if [[ "$create_count" == "0" && "$after_reports" -gt "$before_reports" ]]; then
+	ok=1
+else
+	ok=0
+fi
+check "$ok" "unauthorized batch writes local report without public issue" "create_count=${create_count} reports=${before_reports}->${after_reports}"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	printf '%s test(s) failed, %s passed\n' "$FAIL" "$PASS" >&2
+	exit 1
+fi
+
+printf '%s test(s) passed\n' "$PASS"

--- a/.agents/scripts/upstream-watch-helper-check.sh
+++ b/.agents/scripts/upstream-watch-helper-check.sh
@@ -368,7 +368,7 @@ _check_single_github_repo() {
 			--argjson pending "$new_pending" \
 			'.repos[$slug].last_checked = $now | .repos[$slug].updates_pending = $pending')
 
-		# File GitHub issue on 0->1 transition (t2810)
+		# Queue GitHub issue reporting on 0->1 transition (t2810/t22495)
 		if [[ "$updates_pending_before" != "1" && "$new_pending" == "1" ]]; then
 			local update_kind="commit"
 			local update_old="$last_commit_seen"
@@ -380,7 +380,7 @@ _check_single_github_repo() {
 			fi
 			local config_entry
 			config_entry=$(echo "$config" | jq --arg slug "$slug" '.repos[] | select(.slug == $slug)')
-			_file_upstream_update_issue "$slug" "$update_kind" "$update_old" "$update_new" "$config_entry"
+			_queue_upstream_update_issue "$slug" "$update_kind" "$update_old" "$update_new" "$config_entry"
 		fi
 	else
 		_check_had_probe_failure=true
@@ -488,9 +488,9 @@ _check_non_github_upstreams() {
 				--argjson pending "$ng_new_pending" \
 				'.non_github[$name].last_checked = $now | .non_github[$name].current_value = $current | .non_github[$name].updates_pending = $pending')
 
-			# File GitHub issue on 0->1 transition (t2810)
+			# Queue GitHub issue reporting on 0->1 transition (t2810/t22495)
 			if [[ "$ng_updates_pending_before" != "1" && "$ng_new_pending" == "1" ]]; then
-				_file_upstream_update_issue "$entry_name" "update" "$last_seen_value" "$current_value" "$entry_json"
+				_queue_upstream_update_issue "$entry_name" "update" "$last_seen_value" "$current_value" "$entry_json"
 			fi
 		else
 			_check_had_probe_failure=true
@@ -562,6 +562,9 @@ cmd_check() {
 	# Shared counters updated by sub-functions
 	_check_updates_found=0
 	_check_had_probe_failure=false
+	local issue_queue_file
+	issue_queue_file=$(mktemp -t upstream-watch-issues.XXXXXX)
+	_UPSTREAM_WATCH_ISSUE_QUEUE_FILE="$issue_queue_file"
 	local now
 	now=$(_now_iso)
 
@@ -577,6 +580,10 @@ cmd_check() {
 		[[ "$target_is_non_github" == true ]] && ng_target="$target_slug"
 		_check_non_github_upstreams "$config" "$ng_target" "$now"
 	fi
+
+	_flush_upstream_update_issue_queue "$issue_queue_file"
+	rm -f "$issue_queue_file"
+	unset _UPSTREAM_WATCH_ISSUE_QUEUE_FILE
 
 	# Only advance global last_check if all probes succeeded -- partial failures
 	# should not advance the 24h gate so the caller retries on the next cycle

--- a/.agents/scripts/upstream-watch-helper-issues.sh
+++ b/.agents/scripts/upstream-watch-helper-issues.sh
@@ -43,11 +43,239 @@ fi
 _get_aidevops_slug() {
 	local slug=""
 	if [[ -f "${HOME}/.config/aidevops/repos.json" ]]; then
-		slug=$(jq -r '.initialized_repos[] | select(.is_framework_dir == true) | .slug' \
-			"${HOME}/.config/aidevops/repos.json" 2>/dev/null | head -1) || slug=""
+		slug=$(jq -r 'first(.initialized_repos[] | select(.is_framework_dir == true) | .slug) // ""' \
+			"${HOME}/.config/aidevops/repos.json" 2>/dev/null) || slug=""
 	fi
 	[[ -z "$slug" ]] && slug="marcusquinn/aidevops"
 	printf '%s' "$slug"
+	return 0
+}
+
+#######################################
+# Check whether authenticated gh may write public upstream-watch issues.
+# Arguments:
+#   $1 - aidevops repo slug receiving upstream-watch issues
+# Returns: 0 when issue writes are authorized, 1 otherwise
+#######################################
+_upstream_watch_issue_creation_authorized() {
+	local aidevops_slug="$1"
+
+	if [[ "${AIDEVOPS_UPSTREAM_WATCH_ALLOW_PUBLIC_ISSUES:-}" == "1" ]]; then
+		return 0
+	fi
+
+	local login=""
+	login=$(gh api user --jq '.login // ""' 2>/dev/null) || login=""
+	if [[ -z "$login" ]]; then
+		_log_warn "Unable to resolve gh login -- upstream-watch public issue creation disabled for ${aidevops_slug}"
+		return 1
+	fi
+
+	local permission=""
+	permission=$(gh api "repos/${aidevops_slug}/collaborators/${login}/permission" \
+		--jq '.permission // ""' 2>/dev/null) || permission=""
+
+	case "$permission" in
+		admin | maintain | write)
+			return 0
+			;;
+		*)
+			_log_warn "Skipping public upstream-watch issue creation in ${aidevops_slug}: gh user ${login} has permission '${permission:-none}', not maintainer/collaborator write access"
+			return 1
+			;;
+	esac
+}
+
+#######################################
+# Persist a local upstream-watch report when public issue creation is not
+# authorized. The report is local to the install and avoids public repo spam.
+# Arguments:
+#   $1 - title
+#   $2 - body
+# Outputs: local report path via stdout
+#######################################
+_write_upstream_watch_local_report() {
+	local title="$1"
+	local body="$2"
+	local report_dir="${HOME}/.aidevops/reports/upstream-watch"
+	local stamp
+	stamp=$(date -u +%Y%m%dT%H%M%SZ)
+
+	mkdir -p "$report_dir"
+	local report_file
+	report_file=$(mktemp "${report_dir}/${stamp}.XXXXXX.md")
+	{
+		printf '# %s\n\n' "$title"
+		printf '%s\n' "$body"
+	} >"$report_file"
+	printf '%s' "$report_file"
+	return 0
+}
+
+#######################################
+# Queue a detected upstream update for end-of-run coalescing.
+# Falls back to immediate filing when no queue file is configured.
+# Arguments: same as _file_upstream_update_issue
+#######################################
+_queue_upstream_update_issue() {
+	local slug_or_name="$1"
+	local kind="$2"
+	local old_value="$3"
+	local new_value="$4"
+	local entry_json="$5"
+
+	if [[ -z "${_UPSTREAM_WATCH_ISSUE_QUEUE_FILE:-}" ]]; then
+		_file_upstream_update_issue "$slug_or_name" "$kind" "$old_value" "$new_value" "$entry_json"
+		return 0
+	fi
+
+	jq -nc \
+		--arg slug_or_name "$slug_or_name" \
+		--arg kind "$kind" \
+		--arg old_value "$old_value" \
+		--arg new_value "$new_value" \
+		--argjson entry "$entry_json" \
+		'{slug_or_name:$slug_or_name, kind:$kind, old_value:$old_value, new_value:$new_value, entry:$entry}' \
+		>>"$_UPSTREAM_WATCH_ISSUE_QUEUE_FILE"
+	return 0
+}
+
+#######################################
+# Compose a single batch tracker issue for multiple upstream updates.
+# Arguments:
+#   $1 - queue file containing one JSON object per update
+# Outputs: issue body text via stdout
+#######################################
+_compose_upstream_batch_issue_body() {
+	local queue_file="$1"
+
+	printf '## Summary\n\n'
+	printf 'Multiple upstream-watch sources changed in the same scan run. Review this coalesced tracker instead of one issue per upstream.\n\n'
+	printf '## Updates\n\n'
+	printf '| Upstream | Kind | Previous | Current | Relevance |\n'
+	printf '|----------|------|----------|---------|-----------|\n'
+	while IFS= read -r update_json; do
+		[[ -n "$update_json" ]] || continue
+		local slug_or_name kind old_value new_value relevance
+		slug_or_name=$(printf '%s' "$update_json" | jq -r '.slug_or_name')
+		kind=$(printf '%s' "$update_json" | jq -r '.kind')
+		old_value=$(printf '%s' "$update_json" | jq -r '.old_value // "none"')
+		new_value=$(printf '%s' "$update_json" | jq -r '.new_value')
+		relevance=$(printf '%s' "$update_json" | jq -r '.entry.relevance // .entry.description // "Review upstream changes"')
+		printf "| \`%s\` | %s | \`%s\` | \`%s\` | %s |\n" \
+			"$slug_or_name" "$kind" "${old_value:-none}" "${new_value:0:12}" "$relevance"
+	done <"$queue_file"
+	printf '\n## Action\n\n'
+	printf '1. Review each upstream source above.\n'
+	printf '2. Decide which changes warrant adoption.\n'
+	printf "3. Acknowledge reviewed sources with \`upstream-watch-helper.sh ack <upstream>\`.\n\n"
+	printf '<!-- aidevops:generator=upstream-watch batch=true -->\n'
+	return 0
+}
+
+#######################################
+# File or locally report a coalesced upstream-watch batch issue.
+# Arguments:
+#   $1 - queue file containing one JSON object per update
+# Returns: 0 always for offline/unauthorized paths
+#######################################
+_file_upstream_batch_update_issue() {
+	local queue_file="$1"
+	local title="upstream: batch review adoption"
+	local body
+	body=$(_compose_upstream_batch_issue_body "$queue_file")
+
+	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null; then
+		_log_warn "gh unavailable -- writing local upstream-watch batch report"
+		local offline_report
+		offline_report=$(_write_upstream_watch_local_report "$title" "$body")
+		echo -e "  ${YELLOW}Local upstream-watch report: ${offline_report}${NC}"
+		return 0
+	fi
+
+	local aidevops_slug
+	aidevops_slug=$(_get_aidevops_slug)
+	if ! _upstream_watch_issue_creation_authorized "$aidevops_slug"; then
+		local report_file
+		report_file=$(_write_upstream_watch_local_report "$title" "$body")
+		_log_info "Wrote local upstream-watch batch report: ${report_file}"
+		echo -e "  ${YELLOW}Skipped public issue creation; local report: ${report_file}${NC}"
+		return 0
+	fi
+
+	local existing_number=""
+	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
+		--label "$UPSTREAM_WATCH_LABEL" \
+		--search 'in:title "upstream: batch"' \
+		--paginate \
+		--json number --jq '.[0].number // empty') || existing_number=""
+
+	local sig_footer=""
+	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
+		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer 2>/dev/null || true)
+	fi
+	[[ -n "$sig_footer" ]] && body="${body}
+
+${sig_footer}"
+
+	if [[ -n "$existing_number" ]]; then
+		_log_info "Updating existing upstream-watch batch issue #${existing_number}"
+		gh_issue_edit_safe "$existing_number" --repo "$aidevops_slug" \
+			--title "$title" --body "$body" >/dev/null 2>&1 || {
+			_log_warn "Failed to update upstream-watch batch issue #${existing_number}"
+			return 0
+		}
+		echo -e "  ${BLUE}Updated batch issue #${existing_number}${NC}"
+	else
+		local issue_url=""
+		issue_url=$(gh_create_issue --repo "$aidevops_slug" \
+			--title "$title" \
+			--label "$UPSTREAM_WATCH_LABEL" \
+			--label "auto-dispatch" \
+			--label "tier:standard" \
+			--label "origin:worker" \
+			--body "$body" 2>/dev/null) || {
+			_log_warn "Failed to file upstream-watch batch issue -- will retry next cycle"
+			return 0
+		}
+		[[ -n "$issue_url" ]] && echo -e "  ${BLUE}Filed batch issue: ${issue_url}${NC}"
+	fi
+	return 0
+}
+
+#######################################
+# Flush queued upstream update issue requests, coalescing large batches.
+# Arguments:
+#   $1 - queue file containing one JSON object per update
+# Returns: 0 always for empty queues and handled issue paths
+#######################################
+_flush_upstream_update_issue_queue() {
+	local queue_file="$1"
+
+	if [[ ! -s "$queue_file" ]]; then
+		return 0
+	fi
+
+	local threshold="${UPSTREAM_WATCH_BATCH_THRESHOLD:-5}"
+	local queue_count
+	queue_count=$(wc -l <"$queue_file" | tr -d '[:space:]')
+	[[ "$queue_count" =~ ^[0-9]+$ ]] || queue_count=0
+
+	if [[ "$queue_count" -ge "$threshold" ]]; then
+		_file_upstream_batch_update_issue "$queue_file"
+		return 0
+	fi
+
+	while IFS= read -r update_json; do
+		[[ -n "$update_json" ]] || continue
+		local slug_or_name kind old_value new_value entry_json
+		slug_or_name=$(printf '%s' "$update_json" | jq -r '.slug_or_name')
+		kind=$(printf '%s' "$update_json" | jq -r '.kind')
+		old_value=$(printf '%s' "$update_json" | jq -r '.old_value')
+		new_value=$(printf '%s' "$update_json" | jq -r '.new_value')
+		entry_json=$(printf '%s' "$update_json" | jq -c '.entry')
+		_file_upstream_update_issue "$slug_or_name" "$kind" "$old_value" "$new_value" "$entry_json"
+	done <"$queue_file"
 	return 0
 }
 
@@ -188,6 +416,14 @@ _file_upstream_update_issue() {
 	local body
 	body=$(_compose_upstream_issue_body "$slug_or_name" "$kind" "${old_value:-none}" \
 		"$new_value_short" "$relevance" "$affects" "$compare_url")
+	if ! _upstream_watch_issue_creation_authorized "$aidevops_slug"; then
+		local report_file
+		report_file=$(_write_upstream_watch_local_report "$title" "$body")
+		_log_info "Wrote local upstream-watch report for ${slug_or_name}: ${report_file}"
+		echo -e "  ${YELLOW}Skipped public issue creation; local report: ${report_file}${NC}"
+		return 0
+	fi
+
 	local sig_footer=""
 	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
 		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Added maintainer-permission gating for upstream-watch issue creation, local report fallback for unauthorized installs, and batch coalescing for scan runs with five or more updates.

## Files Changed

.agents/scripts/tests/test-upstream-watch-issue-gate.sh,.agents/scripts/upstream-watch-helper-check.sh,.agents/scripts/upstream-watch-helper-issues.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-upstream-watch-issue-gate.sh && shellcheck .agents/scripts/upstream-watch-helper-issues.sh .agents/scripts/upstream-watch-helper-check.sh .agents/scripts/tests/test-upstream-watch-issue-gate.sh

Resolves #22495


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.3 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 208,808 tokens on this as a headless worker.