### PR TITLE
t3520: fix GPT-5.5 compaction input limit

### DIFF
--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -98,14 +98,15 @@ export const CLAUDE_MODEL_LIMITS = {
 
 /**
  * OpenAI GPT-5.5 models report a 1M API context window, but Codex/OpenCode
- * sessions are effectively bounded at 400K. OpenCode auto-compacts at 80% of
- * the configured context limit, so registering 500K makes compaction trigger at
- * 400K instead of waiting until the runtime/provider rejects the request.
+ * sessions are effectively bounded at 400K. Current OpenCode auto-compacts at
+ * `limit.input - reserved` when `limit.input` exists, and models.dev supplies a
+ * stale 272K input limit. Registering input=420K preserves a 400K usable window
+ * with OpenCode's default 20K reserved buffer instead of compacting near 252K.
  */
 export const OPENAI_MODEL_LIMITS = {
-  "gpt-5.5":      { context: 500000, output: 128000 },
-  "gpt-5.5-fast": { context: 500000, output: 128000 },
-  "gpt-5.5-pro":  { context: 500000, output: 128000 },
+  "gpt-5.5":      { context: 500000, input: 420000, output: 128000 },
+  "gpt-5.5-fast": { context: 500000, input: 420000, output: 128000 },
+  "gpt-5.5-pro":  { context: 500000, input: 420000, output: 128000 },
 };
 
 // One-shot warn at module load when the env override changed something.

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -212,12 +212,13 @@ describe("CLAUDE_MODEL_LIMITS table", () => {
 // ---------------------------------------------------------------------------
 
 describe("OPENAI_MODEL_LIMITS table", () => {
-  test("sets GPT-5.5 family context to 500000 so 80% compaction lands at 400000", () => {
+  test("sets GPT-5.5 family input to preserve a 400K OpenCode compaction boundary", () => {
     const expected = ["gpt-5.5", "gpt-5.5-fast", "gpt-5.5-pro"];
     for (const id of expected) {
       assert.ok(OPENAI_MODEL_LIMITS[id], `missing OpenAI limit entry for ${id}`);
       assert.equal(OPENAI_MODEL_LIMITS[id].context, 500000);
-      assert.equal(OPENAI_MODEL_LIMITS[id].context * 0.8, 400000);
+      assert.equal(OPENAI_MODEL_LIMITS[id].input, 420000);
+      assert.equal(OPENAI_MODEL_LIMITS[id].input - 20000, 400000);
       assert.ok(OPENAI_MODEL_LIMITS[id].output > 0);
     }
   });


### PR DESCRIPTION
## Summary
- Add explicit `input: 420000` limits for the GPT-5.5 OpenAI model family so OpenCode's current compaction logic uses a 400K usable boundary after its 20K reserved buffer.
- Update the model-limits regression test to pin the context, input, output, and derived compaction threshold.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs` — 22 pass, 0 fail.
- Runtime smoke after hot-deploy: `gpt-5.5`, `gpt-5.5-fast`, and `gpt-5.5-pro` report `context=500000 input=420000 output=128000 threshold=400000`.

## Follow-up
- Filed #22506 for the setup deploy-staleness guard observed during runtime verification.

Resolves #22503
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.4 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 25m and 584,918 tokens on this with the user in an interactive session.