### PR TITLE
GH#22226: address setup and model probe review feedback

### DIFF
--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -684,25 +684,75 @@ _parse_rate_limits() {
 # must override before any cache-positive lookup marks a model available.
 # Canonical config: .agents/configs/model-routing-table.json chatgpt_oauth_restrictions.
 
-# Known-unsupported model IDs under OpenAI ChatGPT OAuth (Codex auth).
-# Source: OpenCode CLI smoke tests (2026-04-30 session, GH#21990).
-# Update this list only after a live ChatGPT OAuth smoke test confirms support.
-_CHATGPT_OAUTH_UNSUPPORTED_MODELS=(
-	"gpt-5.5-pro"
-	"gpt-5.4-pro"
-	"gpt-5.2-pro"
-	"o3-pro"
-)
+# ChatGPT OAuth restriction settings are loaded lazily from the model routing
+# table so the config remains the single source of truth.
+_CHATGPT_OAUTH_UNSUPPORTED_MODELS_CACHE=""
+_OPENAI_OAUTH_AUTH_FILE_CACHE=""
+_OPENAI_OAUTH_AUTH_TYPE_CACHE=""
+
+_model_routing_table_path() {
+	printf '%s\n' "${SCRIPT_DIR}/../configs/model-routing-table.json"
+	return 0
+}
+
+_expand_config_path() {
+	local path="$1"
+	case "$path" in
+	~/*) printf '%s/%s\n' "$HOME" "${path#~/}" ;;
+	*) printf '%s\n' "$path" ;;
+	esac
+	return 0
+}
+
+_openai_oauth_auth_file() {
+	if [[ -n "$_OPENAI_OAUTH_AUTH_FILE_CACHE" ]]; then
+		printf '%s\n' "$_OPENAI_OAUTH_AUTH_FILE_CACHE"
+		return 0
+	fi
+
+	local routing_table
+	routing_table=$(_model_routing_table_path)
+	local configured_path=""
+	if [[ -r "$routing_table" ]] && command -v jq >/dev/null 2>&1; then
+		configured_path=$(jq -r '.providers.openai.oauth_auth_file // empty' "$routing_table" 2>/dev/null || true)
+	fi
+	[[ -n "$configured_path" ]] || configured_path="${HOME}/.local/share/opencode/auth.json"
+	_OPENAI_OAUTH_AUTH_FILE_CACHE=$(_expand_config_path "$configured_path")
+	printf '%s\n' "$_OPENAI_OAUTH_AUTH_FILE_CACHE"
+	return 0
+}
+
+_chatgpt_oauth_unsupported_models() {
+	if [[ -n "$_CHATGPT_OAUTH_UNSUPPORTED_MODELS_CACHE" ]]; then
+		printf '%s\n' "$_CHATGPT_OAUTH_UNSUPPORTED_MODELS_CACHE"
+		return 0
+	fi
+
+	local routing_table
+	routing_table=$(_model_routing_table_path)
+	if [[ -r "$routing_table" ]] && command -v jq >/dev/null 2>&1; then
+		_CHATGPT_OAUTH_UNSUPPORTED_MODELS_CACHE=$(jq -r '.chatgpt_oauth_restrictions.openai_unsupported[]? // empty' "$routing_table" 2>/dev/null || true)
+	fi
+	printf '%s\n' "$_CHATGPT_OAUTH_UNSUPPORTED_MODELS_CACHE"
+	return 0
+}
 
 # Returns 0 if the OpenAI provider is authenticated via ChatGPT OAuth (Codex).
-# Checks ~/.local/share/opencode/auth.json for openai.type == "oauth".
+# Checks the configured OpenCode auth file for openai.type == "oauth".
 # Returns 1 if using an API key, auth.json is absent, or jq is unavailable.
 _is_openai_chatgpt_oauth() {
-	local auth_file="${HOME}/.local/share/opencode/auth.json"
+	if [[ -n "$_OPENAI_OAUTH_AUTH_TYPE_CACHE" ]]; then
+		[[ "$_OPENAI_OAUTH_AUTH_TYPE_CACHE" == "oauth" ]]
+		return $?
+	fi
+
+	local auth_file
+	auth_file=$(_openai_oauth_auth_file)
 	[[ -f "$auth_file" ]] || return 1
 
 	local auth_type
 	auth_type=$(jq -r '.openai.type // empty' "$auth_file" 2>/dev/null) || auth_type=""
+	_OPENAI_OAUTH_AUTH_TYPE_CACHE="$auth_type"
 	[[ "$auth_type" == "oauth" ]]
 	return $?
 }
@@ -725,11 +775,12 @@ _chatgpt_oauth_denylist_check() {
 
 	# Check if model_id is in the unsupported list
 	local denied
-	for denied in "${_CHATGPT_OAUTH_UNSUPPORTED_MODELS[@]}"; do
+	while IFS= read -r denied; do
+		[[ -n "$denied" ]] || continue
 		if [[ "$model_id" == "$denied" ]]; then
 			return 0 # denied
 		fi
-	done
+	done < <(_chatgpt_oauth_unsupported_models)
 	return 1 # allowed
 }
 
@@ -781,7 +832,6 @@ check_model_available() {
 	# in /v1/models but fail at inference under ChatGPT OAuth (Codex auth).
 	# Must run before DB cache to override stale "available" entries. GH#21990.
 	if _chatgpt_oauth_denylist_check "$provider" "$model_id"; then
-		_record_model_availability "$model_id" "$provider" 0
 		[[ "$quiet" != "true" ]] && print_warning "$model_spec: unavailable (ChatGPT OAuth denylist — not supported with Codex account, GH#21990)"
 		return 1
 	fi
@@ -1048,4 +1098,3 @@ resolve_tier_chain() {
 	[[ "$quiet" != "true" ]] && print_error "No available model for tier: $tier (fallback chain exhausted)"
 	return 1
 }
-

--- a/.agents/scripts/setup/modules/agent-runtime.sh
+++ b/.agents/scripts/setup/modules/agent-runtime.sh
@@ -270,7 +270,7 @@ _deploy_agents_to_runtimes_bounded() {
 	_pid=$!
 
 	while kill -0 "$_pid" 2>/dev/null; do
-		if (( SECONDS - _start_s >= timeout_s )); then
+		if (( ${SECONDS:-0} - ${_start_s:-0} >= ${timeout_s:-0} )); then
 			kill -TERM "$_pid" 2>/dev/null || true
 			sleep 2
 			kill -KILL "$_pid" 2>/dev/null || true

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -202,7 +202,11 @@ gh_create_issue() {
 	# t2436: Derive creation-time labels from TODO.md tags + filter --todo-task-id.
 	# Helper writes _GH_CI_FILTERED_ARGS and _GH_CI_TODO_LABEL_ARGS globals.
 	_gh_ci_prepare_todo_labels "$@"
-	set -- "${_GH_CI_FILTERED_ARGS[@]+"${_GH_CI_FILTERED_ARGS[@]}"}"
+	if [[ ${#_GH_CI_FILTERED_ARGS[@]} -gt 0 ]]; then
+		set -- "${_GH_CI_FILTERED_ARGS[@]}"
+	else
+		set --
+	fi
 	local -a _todo_label_args=()
 	if [[ ${#_GH_CI_TODO_LABEL_ARGS[@]} -gt 0 ]]; then
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")

--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -27,6 +27,7 @@ readonly TEST_RESET='\033[0m'
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_TMP_DIR=""
+TEST_TMP_DIRS=()
 
 print_result() {
 	local test_name="$1"
@@ -48,9 +49,23 @@ print_result() {
 }
 
 cleanup() {
+	local tmp_dir
+	for tmp_dir in "${TEST_TMP_DIRS[@]}"; do
+		if [[ -n "$tmp_dir" && -d "$tmp_dir" ]]; then
+			rm -rf "$tmp_dir"
+		fi
+	done
 	if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
 		rm -rf "$TEST_TMP_DIR"
 	fi
+	return 0
+}
+
+make_test_tmp_dir() {
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	TEST_TMP_DIRS+=("$tmp_dir")
+	printf '%s\n' "$tmp_dir"
 	return 0
 }
 
@@ -83,7 +98,7 @@ _deploy_agents_to_runtimes_bounded() {
 	_pid=\$!
 
 	while kill -0 "\$_pid" 2>/dev/null; do
-		if (( SECONDS - _start_s >= timeout_s )); then
+		if (( \${SECONDS:-0} - \${_start_s:-0} >= \${timeout_s:-0} )); then
 			kill -TERM "\$_pid" 2>/dev/null || true
 			sleep 2
 			kill -KILL "\$_pid" 2>/dev/null || true
@@ -177,8 +192,9 @@ ${bg_usages}"
 }
 
 test_bounded_wrapper_fast_path() {
-	TEST_TMP_DIR="$(mktemp -d)"
-	local script="${TEST_TMP_DIR}/fast.sh"
+	local test_tmp_dir
+	test_tmp_dir=$(make_test_tmp_dir)
+	local script="${test_tmp_dir}/fast.sh"
 
 	_write_bounded_wrapper_script "$script" "  return 0" "5"
 
@@ -195,8 +211,9 @@ test_bounded_wrapper_fast_path() {
 }
 
 test_bounded_wrapper_kills_slow_deployment_without_failing_setup() {
-	TEST_TMP_DIR="$(mktemp -d)"
-	local script="${TEST_TMP_DIR}/slow.sh"
+	local test_tmp_dir
+	test_tmp_dir=$(make_test_tmp_dir)
+	local script="${test_tmp_dir}/slow.sh"
 
 	_write_bounded_wrapper_script "$script" "  sleep 30; return 0" "3"
 
@@ -223,8 +240,9 @@ test_bounded_wrapper_kills_slow_deployment_without_failing_setup() {
 }
 
 test_bounded_wrapper_timeout_env_respected() {
-	TEST_TMP_DIR="$(mktemp -d)"
-	local script="${TEST_TMP_DIR}/env_check.sh"
+	local test_tmp_dir
+	test_tmp_dir=$(make_test_tmp_dir)
+	local script="${test_tmp_dir}/env_check.sh"
 
 	# Deploy that sleeps 10s; AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=2 should terminate it
 	# without failing setup's non-interactive path.
@@ -245,8 +263,9 @@ test_bounded_wrapper_timeout_env_respected() {
 }
 
 test_real_bounded_wrapper_timeout_returns_zero() {
-	TEST_TMP_DIR="$(mktemp -d)"
-	local script="${TEST_TMP_DIR}/real_wrapper_timeout.sh"
+	local test_tmp_dir
+	test_tmp_dir=$(make_test_tmp_dir)
+	local script="${test_tmp_dir}/real_wrapper_timeout.sh"
 	local wrapper_definition=""
 
 	wrapper_definition=$(awk '

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -403,6 +403,22 @@ else
 fi
 unset GH_ARGV_RECORD_FILE
 
+# B'6: only --todo-task-id filtered out → no empty argv element
+# Regression for shared-gh-wrappers-create.sh:203 where an empty filtered arg
+# array could become a single "" argument after set --.
+reset_recorder
+export GH_ARGV_RECORD_FILE="${TEST_ROOT}/gh_argv_issue_todo_only.log"
+: >"$GH_ARGV_RECORD_FILE"
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --todo-task-id t999 >/dev/null 2>&1
+if grep -qx '<>' "$GH_ARGV_RECORD_FILE"; then
+	print_result "B'6: gh_create_issue todo-only filter passes no empty argv element" 1 \
+		"empty argv element reached gh: $(tr '\n' ' ' <"$GH_ARGV_RECORD_FILE")"
+else
+	print_result "B'6: gh_create_issue todo-only filter passes no empty argv element" 0
+fi
+unset GH_ARGV_RECORD_FILE
+
 # ---------------------------------------------------------------------------
 # Layer C: structural checks on full-loop-helper-commit.sh
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -237,6 +237,7 @@ test_contention_message_includes_elapsed_and_stage() {
 		cp "$fake_stl" "$tmp_dir/.aidevops/logs/setup-stage-timings.log"
 		load_lock_functions
 		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'exit=%s\n' "$?"
 		return 0
 	) 2>&1 || true
 
@@ -251,6 +252,8 @@ test_contention_message_includes_elapsed_and_stage() {
 	[[ "$output" == *"stage: deploy_aidevops_agents"* ]] || passed=3
 	# Diagnose log path hint must appear.
 	[[ "$output" == *"setup-stage-timings.log"* ]] || passed=4
+	# The contention path must preserve the expected timeout exit code.
+	[[ "$output" == *"exit=75"* ]] || passed=5
 
 	if [[ "$passed" -eq 1 ]]; then
 		print_result "lock contention message includes age and stage" 0

--- a/setup.sh
+++ b/setup.sh
@@ -650,7 +650,7 @@ _setup_lock_started_age_seconds() {
 	if [[ -r "$lock_dir/started_at" ]]; then
 		started_str=$(tr -d '[:space:]' <"$lock_dir/started_at" 2>/dev/null || true)
 		started_epoch=$(date -d "$started_str" +%s 2>/dev/null || \
-			date -jf '%Y-%m-%dT%H:%M:%SZ' "$started_str" +%s 2>/dev/null || true)
+			date -u -jf '%Y-%m-%dT%H:%M:%SZ' "$started_str" +%s 2>/dev/null || true)
 		now_epoch=$(date +%s 2>/dev/null || true)
 		if [[ "$started_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$started_epoch" ]]; then
 			printf '%s\n' $((now_epoch - started_epoch))
@@ -1048,7 +1048,7 @@ _setup_run_non_interactive() {
 	# Use the bounded wrapper so a slow file-system traversal across many agent
 	# files does not consume the remaining postflight budget and trip the outer
 	# timeout (GH#22087). AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT controls the deadline.
-	_time_step "deploy_agents_to_runtimes" _deploy_agents_to_runtimes_bounded
+	_time_step "deploy_agents_to_runtimes" _deploy_agents_to_runtimes_bounded || true
 	_time_step "update_opencode_config" _setup_run_noncritical_stage_bounded "OpenCode config update" "${AIDEVOPS_UPDATE_OPENCODE_CONFIG_TIMEOUT:-60}" update_opencode_config
 	_time_step "update_claude_config" update_claude_config
 	_time_step "update_codex_config" update_codex_config


### PR DESCRIPTION
## Summary
- Load ChatGPT OAuth restrictions and OpenAI OAuth auth path from the routing table, cache auth detection, and avoid persisting OAuth-denylist failures into the global availability cache.
- Make runtime deployment timeout handling non-critical under setup set -e, fix UTC parsing, harden bounded timeout arithmetic, and add regression coverage for setup locks, temp cleanup, and empty argv filtering.

## Testing
- shellcheck setup.sh .agents/scripts/model-availability-probe-lib.sh .agents/scripts/setup/modules/agent-runtime.sh .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh .agents/scripts/tests/test-deploy-runtimes-bounded.sh .agents/scripts/tests/test-origin-label-mutex-create.sh
- bash .agents/scripts/tests/test-setup-noninteractive-lock.sh
- bash .agents/scripts/tests/test-deploy-runtimes-bounded.sh
- bash .agents/scripts/tests/test-origin-label-mutex-create.sh

## Runtime Testing
Low risk: shell/test/framework helper changes verified with focused regression tests; no live runtime required.

## Linked Issues
Resolves #22226
Resolves #22228
Resolves #22229
Resolves #22232
Resolves #22233

## Key Decisions
- Treated the ChatGPT OAuth denylist as auth-context-specific: it still overrides stale positive cache entries while OAuth is active, but no longer writes a global negative cache row that can affect API-key users.
- Fixed the create wrapper empty-filter case directly alongside the new regression test because the issue premise targeted the same call site.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.4 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 216,862 tokens on this as a headless worker.