### PR TITLE
GH#22507: optimize GitHub reader routing

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -327,24 +327,24 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# shellcheck source=/dev/null
 		source "$_rest_helper" 2>/dev/null || return 1
 
-		# `gh * view/list --json ...` returns GraphQL-shaped field names and
-		# may include GraphQL-only safety-gate fields (reviews, statusCheckRollup,
-		# mergeStateStatus). The REST translators intentionally expose raw REST
-		# objects plus jq filtering, so rewriting --json calls is not semantically
-		# equivalent. Preserve gate safety by leaving those calls on GraphQL and
-		# let current-state telemetry count them as unavoidable read pressure.
-		# Exceptions: _rest_pr_list and _rest_issue_list map the common
-		# `gh * list --json` contracts onto REST, so high-volume pulse polling
-		# can move off GraphQL while preserving compact list output.
+		# `gh * view/list --json ...` can include GraphQL-only safety-gate fields
+		# (reviews, statusCheckRollup, reviewDecision). Preserve gate safety by
+		# leaving non-equivalent reads on GraphQL. REST translators map common
+		# issue/pr list/view fields onto gh-shaped output, and REST-first mode may
+		# use them while GraphQL is healthy when the args are semantically safe.
 		case "$_SHIM_READ_REWRITE" in
-		pr:list | issue:list) ;;
+		pr:list) _rest_pr_list_can_preserve_args "$@" || return 1 ;;
+		pr:view) _rest_pr_view_can_preserve_args "$@" || return 1 ;;
+		issue:list | issue:view) ;;
 		*)
 			_shim_read_has_json_flag "$@" && return 1
 			;;
 		esac
 
-		# Check GraphQL budget. If above threshold, return 1 to fall through.
-		_rest_should_fallback || return 1
+		# Prefer REST in pulse/workflow REST-first mode; otherwise use the legacy
+		# low-GraphQL-budget fallback. This shares native GitHub quota pools instead
+		# of imposing a synthetic lower GraphQL budget.
+		_rest_read_first_enabled || _rest_should_fallback || return 1
 
 		# Extract repo and build stripped args.
 		_shim_extract_repo_and_args "$@" || return 1

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1709,12 +1709,21 @@ main() {
 	# worker launch at the emergency floor.
 	_pulse_set_graphql_budget_priority
 
-	# GH#22478: if the circuit breaker has not tripped but GraphQL headroom is
-	# already inside the REST fallback reserve, force supported read/list wrappers
-	# to use REST for the whole pulse cycle. This avoids every stage/subprocess
-	# spending a fresh GraphQL list call before discovering the same low-budget
-	# state. GraphQL-only operations and security gates still run through their
-	# existing paths; this only affects wrappers with REST-equivalent translators.
+	# GH#22507: prefer REST-equivalent read/list wrappers for pulse cycles even
+	# while GraphQL is healthy. This is quota-pool sharing, not a synthetic lower
+	# GraphQL budget: GraphQL-only operations and safety gates stay on GraphQL,
+	# while issue/pr list/view reads with REST parity preserve GraphQL availability
+	# for the operations that actually need it.
+	unset AIDEVOPS_GH_REST_FIRST_READS
+	if [[ "${AIDEVOPS_PULSE_REST_FIRST_READS:-1}" == "1" ]]; then
+		export AIDEVOPS_GH_REST_FIRST_READS=1
+		echo "[pulse-wrapper] REST-first read routing enabled for REST-equivalent gh issue/pr list/view calls (GH#22507)" >>"$LOGFILE"
+	fi
+
+	# GH#22478: if GraphQL headroom is already inside the REST fallback reserve,
+	# force all supported read/list wrappers through REST for the whole pulse
+	# cycle. This remains as a stronger low-budget fallback for paths not covered
+	# by REST-first semantic-safety checks.
 	unset AIDEVOPS_GH_FORCE_REST_READS
 	if [[ "${AIDEVOPS_PULSE_FORCE_REST_READS_ON_LOW_GRAPHQL:-1}" == "1" ]] && declare -F _cb_rate_limit_json >/dev/null 2>&1; then
 		local _gh22478_rate_json="" _gh22478_remaining="" _gh22478_threshold="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-3000}"

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -226,6 +226,72 @@ _rest_args_have_search() {
 }
 
 #######################################
+# Return 0 when pulse/workflow routing should prefer REST for semantically
+# equivalent read calls even while GraphQL is healthy. This is not a lower
+# synthetic budget; it shares traffic across GitHub's native REST and GraphQL
+# pools so GraphQL remains available for GraphQL-only operations.
+#######################################
+_rest_read_first_enabled() {
+	[[ "${AIDEVOPS_GH_REST_FIRST_READS:-0}" == "1" ]] && return 0
+	return 1
+}
+
+#######################################
+# Extract the gh-style --json field list from argv. Emits empty when absent.
+# Args: gh-style argv
+#######################################
+_rest_args_json_fields() {
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--json) printf '%s' "${2:-}"; return 0 ;;
+		--json=*) printf '%s' "${_arg#--json=}"; return 0 ;;
+		*) shift ;;
+		esac
+	done
+	return 0
+}
+
+#######################################
+# Return 0 when gh pr list argv is safe to translate to REST proactively.
+# Search and GraphQL-only fields stay on GraphQL unless budget exhaustion forces
+# legacy fallback, preserving workflow correctness over read redistribution.
+# Args: gh-style argv
+#######################################
+_rest_pr_list_can_preserve_args() {
+	_rest_args_have_search "$@" && return 1
+	local fields
+	fields="$(_rest_args_json_fields "$@")"
+	[[ -z "$fields" ]] && return 0
+	local field
+	while IFS= read -r field; do
+		case "$field" in
+		mergeable|reviewDecision|statusCheckRollup|reviews|latestReviews|comments|autoMergeRequest|mergeStateStatus) return 1 ;;
+		*) ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+#######################################
+# Return 0 when gh pr view argv is safe to translate to REST proactively.
+# Args: gh-style argv
+#######################################
+_rest_pr_view_can_preserve_args() {
+	local fields
+	fields="$(_rest_args_json_fields "$@")"
+	[[ -z "$fields" ]] && return 0
+	local field
+	while IFS= read -r field; do
+		case "$field" in
+		statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files) return 1 ;;
+		*) ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+#######################################
 # Internal: If first arg looks like a GitHub issue URL, extract the repo slug
 # and issue number. Returns via stdout on two lines (repo, then num) so we
 # stay bash 3.2-compatible (nameref `local -n` is bash 4.3+).
@@ -768,10 +834,10 @@ _rest_pr_create() {
 # Parses gh-style args (positional number or URL, --repo, --json, --jq)
 # and returns the issue JSON or a jq-filtered value. Mirrors `gh issue view`.
 #
-# The --json FIELDS flag is accepted for interface parity but ignored — the
-# REST endpoint always returns the full issue object. Use --jq to extract
-# specific fields. Field names align with `gh issue view --json` for all
-# common fields (state, title, body, labels, assignees, createdAt).
+# The --json FIELDS flag maps common gh field names onto REST fields so
+# proactive REST-first routing can preserve compact gh-shaped output. Field
+# names align with `gh issue view --json` for common fields (state, title,
+# body, labels, assignees, createdAt).
 # Exception: `id` maps to the numeric issue id in REST, not the GraphQL
 # node_id — see the file header for the benign impact of this discrepancy.
 #
@@ -782,6 +848,7 @@ _rest_issue_view() {
 	local num_or_url=""
 	local repo=""
 	local jq_expr=""
+	local json_fields=""
 
 	local _first="${1:-}"
 	if [[ $# -gt 0 && "$_first" != --* ]]; then
@@ -794,8 +861,8 @@ _rest_issue_view() {
 		case "$_arg" in
 		--repo) repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--json) shift 2 ;;
-		--json=*) shift ;;
+		--json) json_fields="${2:-}"; shift 2 ;;
+		--json=*) json_fields="${_arg#--json=}"; shift ;;
 		# t3027: accept -q as gh's documented shorthand for --jq. Without this,
 		# callers using `gh issue view ... -q '.field'` (the idiomatic gh form)
 		# silently lost the jq filter on REST fallback and got the full issue
@@ -820,9 +887,42 @@ _rest_issue_view() {
 
 	local _path="/repos/${repo}/issues/${num}"
 	local _gh_cmd=(gh api "$_path")
+	if [[ -n "$json_fields" ]]; then
+		jq_expr="$(_rest_issue_object_json_jq "$json_fields" "$jq_expr")"
+	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
+}
+
+_rest_issue_object_json_jq() {
+	local fields="$1"
+	local user_jq="$2"
+	local projection=""
+	local field=""
+	while IFS= read -r field; do
+		[[ -z "$field" ]] && continue
+		case "$field" in
+		number) projection="${projection}${projection:+,}number: .number" ;;
+		state) projection="${projection}${projection:+,}state: .state" ;;
+		url) projection="${projection}${projection:+,}url: .html_url" ;;
+		title) projection="${projection}${projection:+,}title: (.title // \"\")" ;;
+		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
+		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
+		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
+		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
+		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
+		assignees) projection="${projection}${projection:+,}assignees: (.assignees // [])" ;;
+		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
+		comments) projection="${projection}${projection:+,}comments: .comments" ;;
+		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	[[ -z "$projection" ]] && projection="number: .number"
+	local jq_expr="{${projection}}"
+	[[ -n "$user_jq" ]] && jq_expr="${jq_expr} | ${user_jq}"
+	printf '%s' "$jq_expr"
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -199,6 +199,11 @@ set_issue_status() {
 #######################################
 gh_issue_view() {
 	local _first_num="${1:-}"
+	if _rest_read_first_enabled; then
+		print_info "[INFO] gh-wrapper: REST-first read mode, routing issue view #${_first_num} to REST"
+		_rest_issue_view "$@"
+		return $?
+	fi
 	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_issue_view; } || _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue view #${_first_num} to REST"
 		_rest_issue_view "$@"
@@ -232,6 +237,11 @@ gh_issue_view() {
 gh_pr_list() {
 	local _has_search=1
 	_rest_args_have_search "$@" || _has_search=0
+	if [[ $_has_search -eq 0 ]] && _rest_read_first_enabled && _rest_pr_list_can_preserve_args "$@"; then
+		print_info "[INFO] gh-wrapper: REST-first read mode, routing pr list to REST"
+		_rest_pr_list "$@"
+		return $?
+	fi
 	if [[ $_has_search -eq 0 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_list; } || _rest_should_fallback; }; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr list to REST"
 		_rest_pr_list "$@"
@@ -264,7 +274,12 @@ gh_pr_list() {
 #######################################
 gh_pr_view() {
 	local _first_num="${1:-}"
-	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_view; } || _rest_should_fallback; then
+	if _rest_read_first_enabled && _rest_pr_view_can_preserve_args "$@"; then
+		print_info "[INFO] gh-wrapper: REST-first read mode, routing pr view #${_first_num} to REST"
+		_rest_pr_view "$@"
+		return $?
+	fi
+	if _rest_pr_view_can_preserve_args "$@" && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_view; } || _rest_should_fallback; }; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr view #${_first_num} to REST"
 		_rest_pr_view "$@"
 		return $?
@@ -309,6 +324,16 @@ gh_issue_list() {
 	_rest_args_have_search "$@" || _has_search=0
 	local _pool="rest-core"
 	[[ $_has_search -eq 1 ]] && _pool="rest-search"
+	if _rest_read_first_enabled; then
+		if [[ $_has_search -eq 1 ]]; then
+			print_info "[INFO] gh-wrapper: REST-first read mode, routing issue list to /search/issues (--search preserved, t2995)"
+			_rest_issue_search "$@"
+		else
+			print_info "[INFO] gh-wrapper: REST-first read mode, routing issue list to REST"
+			_rest_issue_list "$@"
+		fi
+		return $?
+	fi
 	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_issue_list; } || _rest_should_fallback; then
 		if [[ $_has_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue list to /search/issues (--search preserved, t2995)"

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -384,6 +384,39 @@ else
 fi
 
 # =============================================================================
+# Test 15: REST-first mode rewrites safe reads without low GraphQL budget
+# =============================================================================
+echo ""
+echo "Test 15: REST-first read routing"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-rest-first.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(AIDEVOPS_GH_REST_FIRST_READS=1 STUB_RATE_LIMIT_REMAINING=5000 "$SHIM_RUN" issue list --repo owner/repo \
+	--state open --json number,title --jq '.[0].number' 2>/dev/null || true)
+argv=$(_read_argv)
+if [[ "$output" == "22430" ]] &&
+	[[ "$argv" == *"/repos/owner/repo/issues?state=open&per_page=30"* ]] &&
+	grep -q $'\tgh_issue_list\trest' "$AIDEVOPS_GH_API_LOG" &&
+	! grep -q $'\tgh_issue_list\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "REST-first rewrites equivalent issue list without GraphQL"
+else
+	_fail "REST-first equivalent issue list rewrite" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-rest-first-unsafe.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+AIDEVOPS_GH_REST_FIRST_READS=1 "$SHIM_RUN" pr list --repo owner/repo \
+	--state open --json number,reviewDecision,headRefOid 2>/dev/null || true
+argv=$(_read_argv)
+if [[ "$argv" == $'pr\nlist\n--repo\nowner/repo\n--state\nopen\n--json\nnumber,reviewDecision,headRefOid' ]] &&
+	grep -q $'\tgh_pr_list\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "REST-first leaves GraphQL-only pr list fields on GraphQL"
+else
+	_fail "REST-first GraphQL-only pr list preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo ""

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -57,6 +57,8 @@
 #      a rate-limit probe
 #  30. gh_pr_list does NOT fall back for --search because REST pulls cannot
 #      preserve search semantics
+#  31. AIDEVOPS_GH_REST_FIRST_READS routes REST-equivalent reads without a
+#      rate-limit probe while leaving GraphQL-only PR list fields on GraphQL
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -898,7 +900,42 @@ fi
 unset AIDEVOPS_GH_FORCE_REST_READS
 
 # =============================================================================
-# Test 27: gh_pr_list --search → no non-equivalent REST fallback
+# Test 27: REST-first read mode shares pools without probing GraphQL budget
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=5000
+export AIDEVOPS_GH_REST_FIRST_READS=1
+
+gh_issue_list --repo "owner/repo" --state open --json number --jq length >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --state all --json createdAt --limit 200 >/dev/null 2>&1 || true
+
+if grep -qE '^api /repos/owner/repo/issues\?' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^(issue|pr) list' "$GH_CALLS" 2>/dev/null; then
+	pass "AIDEVOPS_GH_REST_FIRST_READS routes REST-equivalent reads without rate_limit probe"
+else
+	fail "AIDEVOPS_GH_REST_FIRST_READS routes REST-equivalent reads without rate_limit probe" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+gh_pr_list --repo "owner/repo" --state open --json number,reviewDecision,headRefOid --limit 30 >/dev/null 2>&1 || true
+
+if grep -qE '^pr list' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/pulls' "$GH_CALLS" 2>/dev/null; then
+	pass "AIDEVOPS_GH_REST_FIRST_READS leaves GraphQL-only pr list fields on GraphQL"
+else
+	fail "AIDEVOPS_GH_REST_FIRST_READS leaves GraphQL-only pr list fields on GraphQL" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+unset AIDEVOPS_GH_REST_FIRST_READS
+
+# =============================================================================
+# Test 28: gh_pr_list --search → no non-equivalent REST fallback
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"


### PR DESCRIPTION
## Summary

Enable REST-first routing for semantically equivalent issue/PR list/view reads during pulse cycles, while keeping GraphQL-only PR fields and search semantics on their required paths.

## Files Changed

.agents/scripts/gh,.agents/scripts/pulse-wrapper.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/tests/test-gh-shim.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-shim.sh; .agents/scripts/tests/test-pulse-current-state-helper.sh; .agents/scripts/tests/test-pulse-graphql-budget-priority.sh; shellcheck changed shell scripts

Resolves #22507


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.5 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 13m and 265,202 tokens on this with the user in an interactive session.