### PR TITLE
t3476: verify projects parent planning state

### DIFF
--- a/todo/tasks/t3476-brief.md
+++ b/todo/tasks/t3476-brief.md
@@ -83,10 +83,15 @@ This parent ships:
 
 ## Acceptance Criteria
 
-- [ ] `_projects/` has a parent issue/brief defining lifecycle, directory contract goals, and relation to TODO/full-loop.
-- [ ] TODO entry includes `ref:GH#22371`, `#parent`, and this brief link.
-- [ ] Phase children are not filed prematurely.
-- [ ] Cross-plane links to `_knowledge`, `_cases`, `_performance`, and `_feedback` are documented.
+- [x] `_projects/` has a parent issue/brief defining lifecycle, directory contract goals, and relation to TODO/full-loop.
+- [x] TODO entry includes `ref:GH#22371`, `#parent`, and this brief link.
+- [x] Phase children are not filed prematurely.
+- [x] Cross-plane links to `_knowledge`, `_cases`, `_performance`, and `_feedback` are documented.
+
+## Parent State
+
+- **Verified:** 2026-05-03 — parent issue GH#22371 exists with `parent-task`, TODO.md contains the canonical linked entry, and this brief defines the future phase sequence.
+- **Closure policy:** keep GH#22371 open while it is a planning parent; child implementation tasks should reference it with `For #22371` until the final phase is ready to close the parent.
 
 ## Context & Decisions
 


### PR DESCRIPTION
## Summary

Verified the _projects parent brief acceptance criteria and documented that GH#22371 remains an open planning parent until child phases are ready.

## Files Changed

todo/tasks/t3476-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2 todo/tasks/t3476-brief.md

For #22371


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.4 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 80,302 tokens on this as a headless worker.