### PR TITLE
t3478: decompose feedback plane parent

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -930,6 +930,12 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3517 Gate OpenCode compaction advisory ref:GH#22496
 
+- [ ] t3525 feedback plane Phase 3 mining workflow and evidence thresholds #auto-dispatch #feat #framework ref:GH#22515
+
+- [ ] t3527 feedback plane Phase 4 promotion paths #auto-dispatch #feat #framework ref:GH#22518
+
+- [ ] t3528 feedback plane Phase 5 CLI and routines design #auto-dispatch #feat #framework ref:GH#22519
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/tasks/t3478-brief.md
+++ b/todo/tasks/t3478-brief.md
@@ -42,6 +42,14 @@ Without a dedicated plane, feedback scatters across inbox notes, case files, cam
 
 This is a parent-task. Initial planning PR uses `For #` keyword (planning only). Children's PRs use `For #THIS-ISSUE` until the final phase, which uses a closing keyword for this parent.
 
+## Children
+
+- t3523 / #22510 — Phase 1: capture contract and normalized metadata fields.
+- t3524 / #22512 — Phase 2: retention and sensitivity policy.
+- t3525 / #22515 — Phase 3: mining workflow and evidence thresholds.
+- t3527 / #22518 — Phase 4: promotion paths into knowledge, campaigns, projects, cases, performance, and tasks.
+- t3528 / #22519 — Phase 5: CLI and routines design.
+
 ## Phases
 
 Decomposition planned as 5 phases:
@@ -52,7 +60,7 @@ Decomposition planned as 5 phases:
 - **Phase 4 — promotion paths**: specify when feedback becomes `_knowledge/insights/`, a `_campaigns` research input, a `_projects` requirement, a `_cases` note, or a new TODO/GitHub task.
 - **Phase 5 — CLI and routines**: design `aidevops feedback capture|list|mine|promote|retire` plus recurring mining/reporting cadence.
 
-Children are NOT pre-filed. File them when capture formats and sensitivity policy can be scoped against the data-plane registry and Markdoc tag work.
+Children are filed above so parent-task automation can track progress. Each child remains independently scoped and may block on the data-plane registry or Markdoc tag work when implementation begins.
 
 ## Out of Scope (for this parent)
 
@@ -74,6 +82,7 @@ This parent ships:
 
 - Decomposition plan in this brief.
 - A parent GitHub issue with `## Phases` so parent-task automation can understand the tracker.
+- Child issue links for each phase so the parent no longer stalls as an undecomposed tracker.
 - TODO entry with `#parent` and `ref:GH#22373`.
 
 ### Files Scope
@@ -88,7 +97,7 @@ This parent ships:
 - [ ] Mining workflow and evidence thresholds are explicit.
 - [ ] Promotion paths to `_knowledge`, `_campaigns`, `_projects`, `_cases`, and TODO/GitHub task creation are documented.
 - [ ] TODO entry includes `ref:GH#22373`, `#parent`, and this brief link.
-- [ ] Phase children are not filed prematurely.
+- [ ] Phase children are filed and linked from this parent brief.
 
 ## Context & Decisions
 


### PR DESCRIPTION
## Summary
- Decomposes the `_feedback/` parent into five phase child issues.
- Adds explicit child links to `todo/tasks/t3478-brief.md` so parent-task automation has a trackable child set.
- Adds missing TODO entries for the child tasks created during decomposition.

For #22373

## Testing
- `git diff --check origin/main..HEAD`
- `rg -n "## Children|t3523|t3524|t3525|t3527|t3528|22510|22512|22515|22518|22519" todo/tasks/t3478-brief.md TODO.md`
- `for tid in t3523 t3524 t3525 t3527 t3528; do n=$(rg -n "^- \[ \] ${tid} " TODO.md | wc -l | tr -d ' '); printf '%s=%s\n' "$tid" "$n"; done`
- `gh api graphql ... subIssues(first:20) ...` returned 5 child issues.

## Runtime Testing
Low risk — planning/docs/TODO-only change. Self-assessed with file checks plus GitHub sub-issue graph verification.

## Key decisions
- Kept #22373 open as a parent tracker; this PR intentionally uses `For #22373`, not a closing keyword.
- Filed child issues rather than removing `parent-task`, because the parent describes five independent implementation phases.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.6 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 132,953 tokens on this as a headless worker.