### PR TITLE
GH#22526: preserve validator cwd during amend

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -330,10 +330,33 @@ _detect_node_project() {
 # Sets caller-scope `fix_changes` to 1 if amend happened, 0 otherwise.
 # Args: $1=pm (npm|pnpm|yarn) $2=timeout_secs $3=timeout_available (0|1)
 # Returns 0 on success, 1 if amend failed.
+_restore_validator_repo_root() {
+	local repo_root="$1"
+	local phase="$2"
+
+	if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+		print_error "[validators] repository root disappeared during ${phase}: ${repo_root:-<unknown>}"
+		print_error "[validators] refusing to run git amend from a missing working directory"
+		return 1
+	fi
+	if ! cd "$repo_root" 2>/dev/null; then
+		print_error "[validators] failed to restore repository root after ${phase}: $repo_root"
+		return 1
+	fi
+	return 0
+}
+
 _run_node_auto_fix() {
 	local pm="$1"
 	local t="$2"
 	local timeout_available="${3:-0}"
+	local repo_root=""
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P 2>/dev/null || echo "")
+	if [[ -z "$repo_root" ]]; then
+		print_error "[validators] cannot determine repository root before auto-fix"
+		return 1
+	fi
+	_restore_validator_repo_root "$repo_root" "startup" || return 1
 	# Build a timeout prefix array; empty when timeout(1) is not available.
 	local -a timeout_prefix=()
 	[[ "$timeout_available" == "1" ]] && timeout_prefix=("timeout" "$t")
@@ -343,6 +366,7 @@ _run_node_auto_fix() {
 		if jq -e --arg s "$script_name" '.scripts[$s] // empty' package.json >/dev/null 2>&1; then
 			print_info "[validators] $pm run $script_name (auto-fix)"
 			"${timeout_prefix[@]}" "$pm" run "$script_name" >/dev/null 2>&1 || true
+			_restore_validator_repo_root "$repo_root" "$script_name" || return 1
 			break
 		fi
 	done
@@ -352,9 +376,11 @@ _run_node_auto_fix() {
 		if jq -e --arg s "$script_name" '.scripts[$s] // empty' package.json >/dev/null 2>&1; then
 			print_info "[validators] $pm run $script_name (auto-fix)"
 			"${timeout_prefix[@]}" "$pm" run "$script_name" >/dev/null 2>&1 || true
+			_restore_validator_repo_root "$repo_root" "$script_name" || return 1
 			break
 		fi
 	done
+	_restore_validator_repo_root "$repo_root" "auto-fix" || return 1
 	if git diff --quiet 2>/dev/null; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
+++ b/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
@@ -61,6 +61,13 @@ mkdir -p "$FAKE_BIN"
 cat >"${FAKE_BIN}/npm" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "npm should not run for shell-only diffs" >>"${NPM_CALL_LOG:?}"
+if [[ "${NPM_FAKE_ACTION:-}" == "delete-cwd-after-edit" ]]; then
+	printf '%s\n' 'fixed' >>"${NPM_FIX_TARGET:?}"
+	if [[ -n "${NPM_DELETE_DIR:-}" ]]; then
+		rm -rf "$NPM_DELETE_DIR"
+	fi
+	exit 0
+fi
 exit "${NPM_FAKE_RC:-2}"
 EOF
 chmod +x "${FAKE_BIN}/npm"
@@ -71,6 +78,8 @@ make_repo() {
 	(
 		cd "$repo_dir" || exit 1
 		git init -q
+		git config commit.gpgsign false
+		git config tag.gpgsign false
 		cat >package.json <<'EOF'
 {"scripts":{"typecheck":"tsc --noEmit"}}
 EOF
@@ -119,6 +128,39 @@ if [[ "$case2_rc" -ne 0 && -s "$NPM_CALL_LOG" ]]; then
 	print_result "TypeScript diff runs failing typecheck" 0
 else
 	print_result "TypeScript diff runs failing typecheck" 1 "rc=${case2_rc}, npm_log=$(wc -c <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
+fi
+
+# Case 3: if an auto-fix command removes the process' current subdirectory,
+# the validator restores the repository root before running git diff/add/amend.
+# This guards the GH#22526 failure class where amend hit getcwd() from a stale
+# cwd and reported: fatal: Unable to read current working directory.
+CWD_REPO="${TEST_ROOT}/cwd-restore"
+make_repo "$CWD_REPO"
+mkdir -p "${CWD_REPO}/vanishing"
+(
+	cd "$CWD_REPO" || exit 1
+	cat >package.json <<'EOF'
+{"scripts":{"format:fix":"node scripts/fix.js"}}
+EOF
+	printf '%s\n' 'before' >tracked.txt
+	git add package.json tracked.txt
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'node project'
+)
+NPM_CALL_LOG="${TEST_ROOT}/npm-cwd.log"
+NPM_FIX_TARGET="${CWD_REPO}/tracked.txt"
+NPM_DELETE_DIR="${CWD_REPO}/vanishing"
+export NPM_CALL_LOG NPM_FIX_TARGET NPM_DELETE_DIR NPM_FAKE_ACTION=delete-cwd-after-edit NPM_FAKE_RC=0
+(
+	cd "${CWD_REPO}/vanishing" || exit 1
+	PATH="${FAKE_BIN}:$PATH" fix_changes=0 _run_node_auto_fix npm 30 0
+)
+case3_rc=$?
+case3_head_subject=$(git -C "$CWD_REPO" log -1 --format=%s 2>/dev/null || printf '')
+case3_file=$(git -C "$CWD_REPO" show HEAD:tracked.txt 2>/dev/null || printf '')
+if [[ "$case3_rc" -eq 0 && "$case3_head_subject" == "node project" && "$case3_file" == $'before\nfixed' ]]; then
+	print_result "auto-fix restores repo root before amend when cwd disappears" 0
+else
+	print_result "auto-fix restores repo root before amend when cwd disappears" 1 "rc=${case3_rc}, subject=${case3_head_subject}, file=${case3_file}"
 fi
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Restore the repository root after auto-fix validators before git diff/add/amend so a removed cwd cannot break commit-and-pr.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh,.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/full-loop-helper-commit.sh .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh; bash .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh; bash .agents/scripts/tests/test-commit-and-pr-partial-success.sh

Resolves #22526


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.9 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 98,360 tokens on this as a headless worker.