### PR TITLE
t3534: release dispatch claims on pre-launch aborts

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1171,6 +1171,47 @@ _run_eligibility_gate_or_abort() {
 }
 
 #######################################
+# Release a dispatch claim when a post-claim pre-launch step aborts.
+#
+# dispatch-claim-helper.sh posts DISPATCH_CLAIM before later gates and launch
+# sub-stages run. When those later steps abort before the worker wrapper starts,
+# neither the worker EXIT trap nor _dlw_post_launch_hooks can emit lifecycle
+# evidence. Post CLAIM_RELEASED here so peer runners see a terminal marker and
+# the issue thread records why no worker comment appeared.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug
+#   $3 - self_login
+#   $4 - reason suffix for dispatch_aborted:<reason>
+#######################################
+_release_dispatch_claim_on_abort() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local reason="$4"
+
+	[[ -n "${_claim_comment_id:-}" ]] || return 0
+	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 0
+	[[ -n "$self_login" ]] || self_login="$(whoami 2>/dev/null || printf '%s' unknown)"
+	case "$reason" in
+	*[^A-Za-z0-9_.:-]* | "") reason="unknown" ;;
+	esac
+
+	local body
+	body="CLAIM_RELEASED reason=dispatch_aborted:${reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--method POST \
+		--field body="$body" \
+		>/dev/null 2>>"$LOGFILE" || {
+		echo "[dispatch_with_dedup] Warning: failed to release dispatch claim for aborted #${issue_number} (${reason})" >>"$LOGFILE"
+	}
+	echo "[dispatch_with_dedup] Released dispatch claim ${_claim_comment_id} for aborted #${issue_number} (${reason})" >>"$LOGFILE"
+	_claim_comment_id=""
+	return 0
+}
+
+#######################################
 # Dispatch a worker for the given issue, guarded by all dedup and
 # pre-dispatch safety layers. Thin orchestrator: delegates to
 # _dispatch_dedup_check_layers (decision) and _dispatch_launch_worker
@@ -1290,6 +1331,7 @@ dispatch_with_dedup() {
 	_ds_record "$issue_number" "$repo_slug" "predispatch_validator" "$_ds_t0"
 	if [[ "$_validator_rc" -eq 10 ]]; then
 		echo "[dispatch_with_dedup] Pre-dispatch validator falsified premise for #${issue_number} in ${repo_slug} — issue closed, not dispatching" >>"$LOGFILE"
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "predispatch_validator_closed"
 		return 1
 	fi
 	if [[ "$_validator_rc" -eq 20 ]]; then
@@ -1300,6 +1342,7 @@ dispatch_with_dedup() {
 	_ds_t0=$(_ds_now_ns)
 	if ! _run_eligibility_gate_or_abort "$issue_number" "$repo_slug" "$issue_meta_json"; then
 		_ds_record "$issue_number" "$repo_slug" "eligibility_gate" "$_ds_t0"
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "eligibility_gate"
 		return 1
 	fi
 	_ds_record "$issue_number" "$repo_slug" "eligibility_gate" "$_ds_t0"
@@ -1312,6 +1355,9 @@ dispatch_with_dedup() {
 		"$self_login" "$repo_path" "$prompt" "$session_key" \
 		"$model_override" "$issue_meta_json" || _launch_rc=$?
 	_ds_record "$issue_number" "$repo_slug" "worker_launch_total" "$_ds_t0"
+	if [[ "$_launch_rc" -ne 0 ]]; then
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "worker_launch_rc_${_launch_rc}"
+	fi
 
 	# t3034: record total ceremony time
 	_ds_record "$issue_number" "$repo_slug" "ceremony_total" "$_ds_ceremony_t0"

--- a/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
+++ b/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
@@ -22,8 +22,9 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+SCRIPT_DIR="$SCRIPTS_DIR"
 
 # Isolated environment
 TMP_HOME=$(mktemp -d)
@@ -112,6 +113,22 @@ gh() {
 		shift || true
 		case "$path" in
 		repos/*/issues/*/comments)
+			local is_post=0 body="" prev=""
+			local arg
+			for arg in "$@"; do
+				if [[ "$prev" == "--method" && "$arg" == "POST" ]]; then
+					is_post=1
+				fi
+				if [[ "$arg" == body=* ]]; then
+					body="${arg#body=}"
+				fi
+				prev="$arg"
+			done
+			if [[ "$is_post" -eq 1 ]]; then
+				printf '%s\n---END_COMMENT---\n' "$body" >>"$GH_COMMENT_LOG"
+				printf '{"id":123456}\n'
+				return 0
+			fi
 			_mock_gh_response "$GH_API_COMMENTS_RESPONSE" "$@"
 			;;
 		repos/*/branches)
@@ -282,6 +299,25 @@ if [[ "$crash_type_no_repo" == "no_work" ]]; then
 	print_result "Fix B: no_work on empty repo slug" 0
 else
 	print_result "Fix B: no_work on empty repo slug" 1 "got '$crash_type_no_repo'"
+fi
+
+# --- Fix C: post-claim aborts release their dispatch claim ---
+
+reset_gh_state
+_claim_comment_id="claim-123"
+_release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
+count_abort_release=$(count_gh_comments)
+if [[ "$count_abort_release" -eq 1 ]] &&
+	grep -q 'CLAIM_RELEASED reason=dispatch_aborted:worker_launch_rc_2 runner=runner-a' "$GH_COMMENT_LOG"; then
+	print_result "Fix C: post-claim launch abort emits CLAIM_RELEASED" 0
+else
+	print_result "Fix C: post-claim launch abort emits CLAIM_RELEASED" 1 "log: $(cat "$GH_COMMENT_LOG")"
+fi
+
+if [[ -z "${_claim_comment_id:-}" ]]; then
+	print_result "Fix C: release helper clears retained claim id" 0
+else
+	print_result "Fix C: release helper clears retained claim id" 1 "claim id still set: ${_claim_comment_id}"
 fi
 
 # Cleanup


### PR DESCRIPTION
## Summary

- Add a post-claim abort release path so DISPATCH_CLAIM comments get a terminal CLAIM_RELEASED reason when dispatch aborts before worker startup can post worker lifecycle comments.
- Cover the failure with dispatch lifecycle regression tests and fix that test harness's SCRIPT_DIR collision so it can source pulse sub-libraries correctly.

## Testing

- shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-dispatch-lifecycle-comms.sh
- bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh

## Root cause

The claim race writes DISPATCH_CLAIM before later pre-launch gates and launch sub-stages run. When those later steps returned non-zero, no worker wrapper existed yet and _dlw_post_launch_hooks had not posted the deterministic worker comment, so neither path could publish a failure reason.

Resolves #22531
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.9 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 7m and 147,293 tokens on this as a headless worker.