### PR TITLE
GH#22527: fix headless worker launch from deleted cwd

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -255,6 +255,37 @@ _validate_run_args() {
 	return 0
 }
 
+# _ensure_valid_launch_cwd: recover from callers whose inherited cwd was deleted.
+#
+# OpenCode validates the process cwd before it processes --dir. When the pulse
+# starts a worker from a worktree that cleanup removed, OpenCode exits with
+# "The current working directory was deleted" before reading the launch prompt.
+# Move the helper itself into the worker worktree early so canary, sandbox, and
+# runtime startup all inherit a valid cwd.
+_ensure_valid_launch_cwd() {
+	local work_dir_value="$1"
+	local fallback_dir="${HOME:-/tmp}"
+
+	if pwd -P >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ -n "$work_dir_value" && -d "$work_dir_value" ]]; then
+		if cd "$work_dir_value" 2>/dev/null; then
+			print_warning "Recovered deleted launch cwd by switching to worker directory: $work_dir_value"
+			return 0
+		fi
+	fi
+
+	if [[ -d "$fallback_dir" ]] && cd "$fallback_dir" 2>/dev/null; then
+		print_warning "Recovered deleted launch cwd by switching to fallback directory: $fallback_dir"
+		return 0
+	fi
+
+	print_error "[fatal] launch cwd is deleted and no valid fallback directory is available"
+	return 1
+}
+
 # _run_looks_like_issue_worker: detect issue-scoped worker dispatches from
 # independent caller-owned signals. The env contract is only mandatory for
 # issue workers; pulse/non-issue runs keep the historical path.
@@ -1289,6 +1320,7 @@ cmd_run() {
 
 	_parse_run_args "$@" || return 1
 	_validate_run_args || return 1
+	_ensure_valid_launch_cwd "$work_dir" || return 1
 	_validate_issue_worker_env_contract "$role" "$session_key" "$work_dir" "$title" "$prompt" || return 1
 
 	if [[ "$detach" -eq 1 ]]; then

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -170,6 +170,30 @@ test_cmd_run_aborts_issue_worker_before_canary_when_env_missing() {
 	return 0
 }
 
+test_deleted_launch_cwd_recovers_to_work_dir() {
+	local stale_dir="${TEST_ROOT}/stale-cwd"
+	local worktree_dir="${TEST_ROOT}/worker-worktree"
+	mkdir -p "$stale_dir" "$worktree_dir"
+
+	local output=""
+	local status=0
+	output=$(
+		cd "$stale_dir" || exit 1
+		rmdir "$stale_dir" || exit 1
+		_ensure_valid_launch_cwd "$worktree_dir" || exit $?
+		pwd -P
+	) 2>&1 || status=$?
+
+	if [[ "$status" -eq 0 && "$output" == *"$worktree_dir"* ]]; then
+		print_result "deleted launch cwd recovers to worker worktree before runtime startup" 0
+		return 0
+	fi
+
+	print_result "deleted launch cwd recovers to worker worktree before runtime startup" 1 \
+		"status=$status output=${output:-<empty>}"
+	return 0
+}
+
 test_does_not_double_append() {
 	local prompt='/full-loop Continue issue #14964
 
@@ -864,6 +888,7 @@ main() {
 	test_issue_worker_env_contract_rejects_missing_worktree
 	test_issue_worker_env_contract_accepts_valid_precreated_worktree
 	test_cmd_run_aborts_issue_worker_before_canary_when_env_missing
+	test_deleted_launch_cwd_recovers_to_work_dir
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_headless_activity_timeout_default_matches_watchdog


### PR DESCRIPTION
## Summary

Recover headless worker launches by switching out of a deleted inherited cwd before canary/runtime startup, so OpenCode can receive the launch prompt.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #22527


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.10 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1h 8m and 240,632 tokens on this with the user in an interactive session.