### PR TITLE
GH#22527: recover headless launch from deleted cwd

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -316,6 +316,39 @@ _validate_issue_worker_env_contract() {
 	return 0
 }
 
+# _recover_deleted_cwd_before_launch: ensure runtime launch starts from a real cwd.
+# A parent shell can dispatch a worker after its current directory has been
+# removed (for example after worktree cleanup). OpenCode fails before reading the
+# prompt in that state, even when --dir points at a valid worker worktree.
+_recover_deleted_cwd_before_launch() {
+	local work_dir_value="$1"
+	local reason_value="${2:-prelaunch}"
+	local recovery_dir=""
+
+	if pwd -P >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ -n "${WORKER_WORKTREE_PATH:-}" && -d "${WORKER_WORKTREE_PATH:-}" ]]; then
+		recovery_dir="$WORKER_WORKTREE_PATH"
+	elif [[ -n "$work_dir_value" && -d "$work_dir_value" ]]; then
+		recovery_dir="$work_dir_value"
+	fi
+
+	if [[ -z "$recovery_dir" ]]; then
+		print_error "[lifecycle] deleted_cwd_recovery_failed reason=$reason_value target=none"
+		return 1
+	fi
+
+	if ! cd "$recovery_dir"; then
+		print_error "[lifecycle] deleted_cwd_recovery_failed reason=$reason_value target=$recovery_dir"
+		return 1
+	fi
+
+	print_warning "[lifecycle] recovered_deleted_cwd reason=$reason_value dir=$recovery_dir"
+	return 0
+}
+
 # =============================================================================
 # Runtime invocation — OpenCode and Claude CLI
 # =============================================================================
@@ -909,6 +942,8 @@ _execute_run_attempt() {
 	shift 8
 	local -a extra_args=("$@")
 
+	_recover_deleted_cwd_before_launch "$work_dir" "execute_run_attempt" || return 1
+
 	# Determine which runtime to use. Default is opencode unless explicitly overridden.
 	local runtime="${headless_runtime:-opencode}"
 	local prompt_arg="$prompt"
@@ -1290,6 +1325,7 @@ cmd_run() {
 	_parse_run_args "$@" || return 1
 	_validate_run_args || return 1
 	_validate_issue_worker_env_contract "$role" "$session_key" "$work_dir" "$title" "$prompt" || return 1
+	_recover_deleted_cwd_before_launch "$work_dir" "cmd_run" || return 1
 
 	if [[ "$detach" -eq 1 ]]; then
 		_detach_worker "$session_key" "$@"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -145,6 +145,35 @@ test_issue_worker_env_contract_accepts_valid_precreated_worktree() {
 	return 0
 }
 
+test_deleted_cwd_recovery_uses_worker_worktree() {
+	local worktree_dir="${TEST_ROOT}/deleted-cwd-worktree"
+	local stale_dir="${TEST_ROOT}/deleted-cwd-stale"
+	local output=""
+	local status=0
+	mkdir -p "$worktree_dir" "$stale_dir"
+	export WORKER_WORKTREE_PATH="$worktree_dir"
+
+	set +e
+	output=$(
+		cd "$stale_dir" || exit 20
+		rmdir "$stale_dir" || exit 21
+		_recover_deleted_cwd_before_launch "$TEST_ROOT" "test" 2>&1 || exit $?
+		pwd -P
+	)
+	status=$?
+	set -e
+
+	unset WORKER_WORKTREE_PATH 2>/dev/null || true
+	if [[ "$status" -eq 0 && "$output" == *"recovered_deleted_cwd"* && "$output" == *"$worktree_dir"* ]]; then
+		print_result "deleted cwd recovery cd's to worker worktree before launch" 0
+		return 0
+	fi
+
+	print_result "deleted cwd recovery cd's to worker worktree before launch" 1 \
+		"status=$status output=${output:-<empty>}"
+	return 0
+}
+
 test_cmd_run_aborts_issue_worker_before_canary_when_env_missing() {
 	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
 	local canary_called=0
@@ -863,6 +892,7 @@ main() {
 	test_issue_worker_env_contract_rejects_missing_env
 	test_issue_worker_env_contract_rejects_missing_worktree
 	test_issue_worker_env_contract_accepts_valid_precreated_worktree
+	test_deleted_cwd_recovery_uses_worker_worktree
 	test_cmd_run_aborts_issue_worker_before_canary_when_env_missing
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id


### PR DESCRIPTION
## Summary

Added a pre-launch cwd recovery guard so headless workers cd to the precreated worker worktree before invoking OpenCode or Claude when the inherited cwd was deleted.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh (36 tests)

Resolves #22527


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.10 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 99,074 tokens on this as a headless worker.