### PR TITLE
t3526: Fix setup noninteractive stale-lock false reclaim

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -177,36 +177,39 @@ test_reclaims_reused_owner_pid_lock() {
 	return 0
 }
 
-test_reclaims_stale_started_at_with_reused_setup_pid() {
+test_preserves_live_setup_owner_with_old_lock_timestamp() {
 	local tmp_dir=""
 	local output=""
 	local owner_pid=""
+	local stale_epoch=0
 	tmp_dir=$(make_temp_dir)
 	owner_pid=$(start_fake_setup_owner)
 	mkdir -p "$tmp_dir/lock.d"
 	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
 	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
+	stale_epoch=$(( $(date +%s 2>/dev/null || echo "0") - 10000 ))
+	printf '%s\n' "$stale_epoch" >"$tmp_dir/lock.d/started_at_epoch"
 	printf '%s\n' '2000-01-01T00:00:00Z' >"$tmp_dir/lock.d/started_at"
 
 	output=$(
 		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=1800
 		load_lock_functions
 		_setup_acquire_noninteractive_setup_lock --non-interactive
-		printf 'held=%s owner=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" "$(tr -d '[:space:]' <"$tmp_dir/lock.d/owner.pid")"
-		_setup_release_noninteractive_setup_lock
-		printf 'exists=%s\n' "$([[ -d "$tmp_dir/lock.d" ]] && printf yes || printf no)"
+		printf 'held=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}"
 		return 0
 	) 2>&1 || true
 
 	kill "$owner_pid" 2>/dev/null || true
 	wait "$owner_pid" 2>/dev/null || true
 	rm -rf "$tmp_dir"
-	if [[ "$output" == *"lock age "* && "$output" == *"older than owner pid ${owner_pid} runtime"* && "$output" == *"held=true owner="* && "$output" == *"exists=no"* ]]; then
-		print_result "stale started_at with reused setup pid is reclaimed" 0
+	if [[ "$output" == *"Timed out"* && "$output" == *"held=false"* && "$output" != *"Removing stale setup.sh --non-interactive lock"* ]]; then
+		print_result "live setup owner with old lock timestamp is preserved" 0
 		return 0
 	fi
 
-	print_result "stale started_at with reused setup pid is reclaimed" 1 "output=${output}"
+	print_result "live setup owner with old lock timestamp is preserved" 1 "output=${output}"
 	return 0
 }
 
@@ -355,16 +358,17 @@ test_stale_live_owner_past_ceiling_is_reclaimed() {
 	mkdir -p "$tmp_dir/lock.d"
 
 	# Use a fake setup owner so kill -0 reports it alive and the command shape
-	# matches setup.sh --non-interactive, then set started_at_epoch far in the
-	# past to simulate a hung setup.
+	# matches setup.sh --non-interactive, then wait long enough for its PID
+	# runtime to exceed a deliberately low stale-live ceiling.
 	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
-	stale_epoch=$(( $(date +%s 2>/dev/null || echo "0") - 10000 ))
+	sleep 2
+	stale_epoch=$(( $(date +%s 2>/dev/null || echo "0") - 2 ))
 	printf '%s\n' "$stale_epoch" >"$tmp_dir/lock.d/started_at_epoch"
 	printf '%s\n' './setup.sh --non-interactive (simulated stale)' >"$tmp_dir/lock.d/command"
 
 	output=$(
 		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
-		AIDEVOPS_SETUP_STALE_TIMEOUT_S=1800
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=1
 		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=300
 		load_lock_functions
 		_setup_acquire_noninteractive_setup_lock --non-interactive
@@ -435,7 +439,7 @@ main() {
 	test_blocks_concurrent_live_owner
 	test_reclaims_stale_lock
 	test_reclaims_reused_owner_pid_lock
-	test_reclaims_stale_started_at_with_reused_setup_pid
+	test_preserves_live_setup_owner_with_old_lock_timestamp
 	test_stale_live_owner_past_ceiling_is_reclaimed
 	test_wait_ceiling_prevents_indefinite_block
 	test_contention_message_includes_elapsed_and_stage

--- a/setup.sh
+++ b/setup.sh
@@ -807,18 +807,25 @@ _setup_noninteractive_signal_exit() {
 	exit "$exit_code"
 }
 
-# Compute how many seconds the lock owner PID has been running.
-# Uses started_at_epoch (most accurate) falling back to ps etimes.
+# Compute how many seconds the live lock owner has held the setup lock.
+# Uses started_at_epoch when it agrees with the owner PID runtime; falls back to
+# the PID runtime when an old lock timestamp points at a newer live setup owner.
 # Prints the age in seconds on stdout; prints 0 when unknown.
 _setup_lock_owner_age() {
 	local lock_dir="$1"
 	local owner_pid="$2"
-	local _start_epoch="" _now_epoch="" _age_tmp=""
+	local _start_epoch="" _now_epoch="" _age_tmp="" _pid_age=""
 	if [[ -r "$lock_dir/started_at_epoch" ]]; then
 		_start_epoch=$(tr -d '[:space:]' <"$lock_dir/started_at_epoch" 2>/dev/null || true)
 		_now_epoch=$(date +%s 2>/dev/null || printf '0')
 		if [[ "$_start_epoch" =~ ^[0-9]+$ && "$_now_epoch" =~ ^[0-9]+$ && "$_now_epoch" -ge "$_start_epoch" ]]; then
-			printf '%s' "$((_now_epoch - _start_epoch))"
+			_age_tmp="$((_now_epoch - _start_epoch))"
+			_pid_age=$(_setup_pid_elapsed_seconds "$owner_pid" 2>/dev/null || true)
+			if [[ "$_pid_age" =~ ^[0-9]+$ && "$_age_tmp" -gt $((_pid_age + 300)) ]]; then
+				printf '%s' "$_pid_age"
+				return 0
+			fi
+			printf '%s' "$_age_tmp"
 			return 0
 		fi
 	fi
@@ -900,17 +907,6 @@ _setup_acquire_noninteractive_setup_lock() {
 				return 75
 			fi
 			print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}; owner pid ${owner_pid} no longer appears to be setup.sh --non-interactive (age ${_owner_lock_age}s)"
-			rm -rf "$lock_dir" 2>/dev/null || true
-			reclaim_attempts=$((reclaim_attempts + 1))
-			continue
-		fi
-
-		local _owner_started_age=""
-		local _owner_pid_age=""
-		_owner_started_age=$(_setup_lock_started_age_seconds "$lock_dir" 2>/dev/null || true)
-		_owner_pid_age=$(_setup_pid_elapsed_seconds "$owner_pid" 2>/dev/null || true)
-		if [[ "$_owner_started_age" =~ ^[0-9]+$ && "$_owner_pid_age" =~ ^[0-9]+$ && "$_owner_started_age" -gt 300 && "$_owner_started_age" -gt $((_owner_pid_age + 300)) ]]; then
-			print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}; lock age ${_owner_started_age}s is older than owner pid ${owner_pid} runtime ${_owner_pid_age}s"
 			rm -rf "$lock_dir" 2>/dev/null || true
 			reclaim_attempts=$((reclaim_attempts + 1))
 			continue


### PR DESCRIPTION
## Summary

Preserved live setup.sh --non-interactive lock owners when lock timestamps are older than PID runtime, while retaining dead-owner and stale-live reclaim paths.

## Files Changed

.agents/scripts/tests/test-setup-noninteractive-lock.sh,.claude-plugin/marketplace.json,.task-counter,CHANGELOG.md,VERSION,aidevops.sh,package.json,setup.sh,sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh; bash .agents/scripts/tests/test-setup-noninteractive-lock.sh; real ./setup.sh --non-interactive live-lock fixture timed out without deleting the lock

Resolves #22517


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33