### PR TITLE
GH#22525: reduce pulse GraphQL read pressure

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1657,7 +1657,7 @@ _apply_terminal_blocker() {
 
 	# Check if already labelled
 	local existing_labels
-	existing_labels=$(gh issue view "$issue_number" --repo "$repo_slug" \
+	existing_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || existing_labels=""
 
 	local already_blocked=false

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -125,7 +125,7 @@ _large_file_gate_precheck_labels() {
 	# status label hasn't been applied yet (race window between assign and label).
 	if [[ ",$issue_labels," == *",origin:worker,"* ]]; then
 		local assignee_count
-		assignee_count=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		assignee_count=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 			--json assignees --jq '.assignees | length' 2>/dev/null) || assignee_count="0"
 		if [[ "$assignee_count" -gt 0 ]]; then
 			return 1
@@ -332,7 +332,7 @@ _large_file_gate_verify_prior_reduced_size() {
 	# Skip wc -l entirely when the label is present.
 	if [[ -n "$repo_slug" && -n "$existing_issue" ]]; then
 		local _sc_labels=""
-		_sc_labels=$(gh issue view "$existing_issue" --repo "$repo_slug" \
+		_sc_labels=$(gh_issue_view "$existing_issue" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _sc_labels=""
 		if [[ ",$_sc_labels," == *",simplification-incomplete,"* ]]; then
 			echo "[pulse-wrapper] Large-file gate: prior issue #${existing_issue} has simplification-incomplete label; filing fresh debt (outcome-check short-circuit) (t2169)" >>"$LOGFILE"
@@ -810,7 +810,7 @@ _issue_targets_large_files() {
 		&& printf '%s' "$pre_fetched_json" | jq -e '.labels' >/dev/null 2>&1; then
 		issue_labels=$(printf '%s' "$pre_fetched_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
 	else
-		issue_labels=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		issue_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
 	fi
 
@@ -849,7 +849,7 @@ _issue_targets_large_files() {
 		&& printf '%s' "$pre_fetched_json" | jq -e '.title' >/dev/null 2>&1; then
 		_surgical_title=$(printf '%s' "$pre_fetched_json" | jq -r '.title // ""' 2>/dev/null) || _surgical_title=""
 	else
-		_surgical_title=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		_surgical_title=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 			--json title --jq '.title // ""' 2>/dev/null) || _surgical_title=""
 	fi
 	if _large_file_gate_check_surgical_brief \

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1686,6 +1686,18 @@ main() {
 		return 0
 	fi
 
+	# GH#22525: enable REST-first read routing before any post-lock pulse gate
+	# runs. GH#22507 originally flipped this after session/dedup gates, leaving
+	# early-cycle issue/pr list/view reads on GraphQL and visible as top pressure
+	# callers in pulse-current-state-helper. The env var is inherited by raw gh
+	# shim invocations and sourced gh_* wrappers; semantic-safety checks still
+	# keep GraphQL-only fields on GraphQL.
+	unset AIDEVOPS_GH_REST_FIRST_READS
+	if [[ "${AIDEVOPS_PULSE_REST_FIRST_READS:-1}" == "1" ]]; then
+		export AIDEVOPS_GH_REST_FIRST_READS=1
+		echo "[pulse-wrapper] REST-first read routing enabled for REST-equivalent gh issue/pr list/view calls (GH#22525)" >>"$LOGFILE"
+	fi
+
 	# --canary short-circuit (GH#18790): sourcing, _pulse_handle_self_check,
 	# and acquire_instance_lock have all passed cleanly. The EXIT trap releases
 	# the lock. Return 0 without entering the pulse loop, session gate, dedup,
@@ -1708,17 +1720,6 @@ main() {
 	# defer in reserve mode. The t2690 dispatch breaker still fail-closes actual
 	# worker launch at the emergency floor.
 	_pulse_set_graphql_budget_priority
-
-	# GH#22507: prefer REST-equivalent read/list wrappers for pulse cycles even
-	# while GraphQL is healthy. This is quota-pool sharing, not a synthetic lower
-	# GraphQL budget: GraphQL-only operations and safety gates stay on GraphQL,
-	# while issue/pr list/view reads with REST parity preserve GraphQL availability
-	# for the operations that actually need it.
-	unset AIDEVOPS_GH_REST_FIRST_READS
-	if [[ "${AIDEVOPS_PULSE_REST_FIRST_READS:-1}" == "1" ]]; then
-		export AIDEVOPS_GH_REST_FIRST_READS=1
-		echo "[pulse-wrapper] REST-first read routing enabled for REST-equivalent gh issue/pr list/view calls (GH#22507)" >>"$LOGFILE"
-	fi
 
 	# GH#22478: if GraphQL headroom is already inside the REST fallback reserve,
 	# force all supported read/list wrappers through REST for the whole pulse

--- a/.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh
@@ -33,6 +33,9 @@
 #      stays at zero (all calls are now in `dispatch_with_dedup` itself).
 #   7. The t2996 marker is present at every threading site so future
 #      auditors can `rg t2996` to find the budget invariant.
+#   8. Fallback metadata reads in dispatch helpers use gh_issue_view wrappers,
+#      not raw `gh issue view`, so REST-first routing is explicit when metadata
+#      is not available in the canonical bundle (GH#22525).
 #
 # Why static checks instead of mocking and counting live invocations:
 # the dispatch path depends on disk-space probes, git fetches, signal
@@ -287,6 +290,24 @@ test_dispatch_skip_candidate_body_uses_rest() {
 	return 0
 }
 
+# ---------------------------------------------------------------------------
+# Test 10: fallback metadata reads in dispatch helpers use the gh_issue_view
+# wrapper instead of raw `gh issue view`, so AIDEVOPS_GH_REST_FIRST_READS can
+# route them through REST and reduce GraphQL pressure (GH#22525).
+# ---------------------------------------------------------------------------
+test_dispatch_fallback_reads_use_wrapper() {
+	local offending
+	offending=$(grep -RInE 'gh issue view ' "$CORE_SH" "$LARGE_FILE_GATE_SH" 2>/dev/null \
+		| grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' || true)
+	if [[ -z "$offending" ]]; then
+		_print_result "dispatch fallback metadata reads avoid raw gh issue view" 1
+	else
+		_print_result "dispatch fallback metadata reads avoid raw gh issue view" 0 \
+			"raw GraphQL-prone call sites: ${offending}"
+	fi
+	return 0
+}
+
 main() {
 	test_canonical_bundle_includes_body || true
 	test_dispatch_with_dedup_single_gh_call || true
@@ -297,6 +318,7 @@ main() {
 	test_check_dispatch_dedup_passes_meta_env || true
 	test_t2996_markers_present || true
 	test_dispatch_skip_candidate_body_uses_rest || true
+	test_dispatch_fallback_reads_use_wrapper || true
 
 	printf '\n--- Tests run: %d, failed: %d ---\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -20,6 +20,11 @@
 
 set -euo pipefail
 
+# Keep the harness hermetic: production pulse sessions may export REST-first
+# routing globally, but tests opt into that per scenario below.
+unset AIDEVOPS_GH_REST_FIRST_READS
+unset AIDEVOPS_GH_FORCE_REST_READS
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
 SHIM="${REPO_DIR}/.agents/scripts/gh"

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -67,6 +67,11 @@
 
 set -uo pipefail
 
+# Keep the harness hermetic: production pulse sessions may export REST-first
+# routing globally, but this test enables it only in the dedicated scenarios.
+unset AIDEVOPS_GH_REST_FIRST_READS
+unset AIDEVOPS_GH_FORCE_REST_READS
+
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
 


### PR DESCRIPTION
## Summary

Enabled pulse REST-first read routing before post-lock gates and routed dispatch fallback metadata reads through gh_issue_view wrappers so safe issue/pr list/view calls can use REST instead of GraphQL.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-large-file-gate.sh,.agents/scripts/pulse-wrapper.sh,.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh,.agents/scripts/tests/test-gh-shim.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/pulse-dispatch-large-file-gate.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh .agents/scripts/tests/test-gh-shim.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-shim.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh; pulse-current-state-helper.sh --window 15m; worker-activity-helper.sh summary --since 24h

Resolves #22525


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 10m and 193,191 tokens on this as a headless worker.