### PR TITLE
GH#22460: route failing verification badges to tasks

### DIFF
--- a/.agents/aidevops/badges.md
+++ b/.agents/aidevops/badges.md
@@ -105,11 +105,11 @@ Available variables (computed from `repos.json` + live `gh` probes):
 To add or remove a badge, edit the template — never edit the rendered
 block in any README directly.
 
-Public badge blocks should show deterministic, repo-owned health signals.
-Avoid volatile third-party quality-gate badges unless they are backed by a
-repo-owned ratchet gate and a current remediation loop; otherwise analyzer
-rule churn or delayed reindexing can make the project look broken after the
-merge authority has already accepted the code.
+Public badge blocks may show third-party quality gates when the framework owns
+the remediation loop. A failing public badge is treated as a dispatchable
+quality blocker: the quality sweep should capture the failing gate condition,
+deduplicate it, and create a worker-ready task so the underlying cause is fixed
+or explicitly classified instead of hidden.
 
 ## Local development
 

--- a/.agents/scripts/stats-quality-sweep-issues.sh
+++ b/.agents/scripts/stats-quality-sweep-issues.sh
@@ -261,6 +261,91 @@ _ensure_quality_issue() {
 }
 
 #######################################
+# Ensure an actionable issue exists for a failing SonarCloud quality gate.
+#
+# Public README badges are useful confidence signals only when failures route
+# to work automatically. This helper deduplicates one open badge-blocker issue
+# per repo and keeps the persistent dashboard as the summary surface.
+#
+# Arguments:
+#   $1 - repo slug
+#   $2 - gate status
+#   $3 - SonarCloud markdown section with failing-condition diagnostics
+# Returns: 0 always (best-effort; quality sweep should still finish)
+#######################################
+_ensure_sonar_gate_blocker_issue() {
+	local repo_slug="$1"
+	local gate_status="$2"
+	local sonar_section="$3"
+
+	case "$gate_status" in
+	ERROR | WARN) ;;
+	*) return 0 ;;
+	esac
+
+	local issue_title="quality gate: resolve SonarCloud badge blockers"
+	local existing_count existing_output
+	if ! existing_output=$(gh issue list --repo "$repo_slug" \
+		--label "sonarcloud" --label "quality-gate-blocker" --state open \
+		--search "in:title \"$issue_title\"" \
+		--json number --jq 'length' 2>/dev/null); then
+		echo "[stats] SonarCloud quality gate issue search failed for ${repo_slug}; skipping create" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+	existing_count="$existing_output"
+	[[ "$existing_count" =~ ^[0-9]+$ ]] || existing_count=0
+	if [[ "$existing_count" -gt 0 ]]; then
+		echo "[stats] SonarCloud quality gate issue already open for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	gh label create "sonarcloud" --repo "$repo_slug" --color "4E9BCD" \
+		--description "SonarCloud quality findings" --force 2>/dev/null || true
+	gh label create "quality-gate-blocker" --repo "$repo_slug" --color "D93F0B" \
+		--description "Public quality badge or gate is failing" --force 2>/dev/null || true
+
+	local issue_body="## What
+SonarCloud reports a failing quality gate for this repository, which makes the public README quality badge show a failure state.
+
+## Why
+Public verification badges are user-confidence signals. When one goes red, the framework should route the cause to implementation work automatically instead of hiding the badge or leaving the failure as dashboard noise.
+
+## How
+Files to inspect:
+- EDIT: sonar-project.properties — check whether the failing rule is a validated false positive that belongs in project-level exclusions.
+- EDIT: cited source files from the SonarCloud diagnostics below — fix real vulnerabilities, bugs, smells, duplication, or hotspot review gaps.
+
+Reference pattern:
+- Model config-level false-positive handling on the existing \`sonar.issue.ignore.multicriteria.*\` entries in \`sonar-project.properties\`.
+- Model real code fixes on neighbouring functions in the cited source files.
+
+Verification:
+- Run the SonarCloud API check: \`curl -s \"https://sonarcloud.io/api/qualitygates/project_status?projectKey=<project-key>\" | jq '.projectStatus'\`.
+- The failing condition should clear after the next SonarCloud analysis.
+- The README Quality Gate badge should return to passing.
+
+## Current diagnostics
+
+${sonar_section}"
+
+	local gate_sig=""
+	gate_sig=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$issue_body" 2>/dev/null || true)
+	issue_body="${issue_body}${gate_sig}"
+
+	if gh_create_issue --repo "$repo_slug" \
+		--title "$issue_title" \
+		--body "$issue_body" \
+		--label "auto-dispatch" --label "tier:standard" --label "quality-debt" \
+		--label "source:quality-sweep" --label "sonarcloud" --label "quality-gate-blocker" >/dev/null 2>&1; then
+		echo "[stats] Created SonarCloud quality gate blocker issue for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+	else
+		echo "[stats] Failed to create SonarCloud quality gate blocker issue for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+	fi
+
+	return 0
+}
+
+#######################################
 # Load previous quality sweep state for a repo
 #
 # Reads gate_status, total_issues, high_critical, and qlty_smells from the

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -466,6 +466,7 @@ _run_sweep_tools() {
 		sonar_section="${sonar_raw%%|*}"
 		IFS='|' read -r sweep_gate_status sweep_total_issues sweep_high_critical sweep_sev_inline <<<"${sonar_raw#*|}"
 		[[ -n "$sonar_section" ]] && tool_count=$((tool_count + 1))
+		_ensure_sonar_gate_blocker_issue "$repo_slug" "$sweep_gate_status" "$sonar_section"
 	fi
 
 	local codacy_section=""

--- a/.agents/scripts/tests/test-stats-quality-sweep-issues.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-issues.sh
@@ -335,6 +335,55 @@ else
 fi
 
 # =============================================================================
+# Test (d): Sonar gate blocker issue is created only for failing gates
+# =============================================================================
+printf '\n%s[d] sonar-gate-blocker-create-on-failure%s\n' "$TEST_BLUE" "$TEST_NC"
+
+true >"$CREATE_CALLS"
+true >"$GH_CALLS"
+
+gh() {
+	echo "gh $*" >>"$GH_CALLS"
+	case "$*" in
+	*"issue list"*"quality-gate-blocker"*)
+		printf '0\n'
+		return 0
+		;;
+	*"label create"*)
+		return 0
+		;;
+	esac
+	return 0
+}
+export -f gh
+
+_ensure_sonar_gate_blocker_issue "test/repo" "ERROR" "### SonarCloud Quality Gate" 2>/dev/null
+
+if grep -q "quality gate: resolve SonarCloud badge blockers" "$CREATE_CALLS" 2>/dev/null; then
+	pass "sonar-gate-error-creates-issue"
+else
+	fail "sonar-gate-error-creates-issue" "gh_create_issue not called: $(cat "$CREATE_CALLS" 2>/dev/null)"
+fi
+
+if grep -q "quality-gate-blocker" "$CREATE_CALLS" 2>/dev/null; then
+	pass "sonar-gate-error-applies-blocker-label"
+else
+	fail "sonar-gate-error-applies-blocker-label" "quality-gate-blocker label missing: $(cat "$CREATE_CALLS" 2>/dev/null)"
+fi
+
+printf '\n%s[e] sonar-gate-blocker-skip-on-ok%s\n' "$TEST_BLUE" "$TEST_NC"
+
+true >"$CREATE_CALLS"
+
+_ensure_sonar_gate_blocker_issue "test/repo" "OK" "### SonarCloud Quality Gate" 2>/dev/null
+
+if [[ ! -s "$CREATE_CALLS" ]]; then
+	pass "sonar-gate-ok-no-create"
+else
+	fail "sonar-gate-ok-no-create" "gh_create_issue was called: $(cat "$CREATE_CALLS")"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n'

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The result: an AI operations platform that manages projects across every busines
 
 <!-- Build & Quality Status -->
 [![GitHub Actions](https://github.com/marcusquinn/aidevops/workflows/Code%20Quality%20Analysis/badge.svg)](https://github.com/marcusquinn/aidevops/actions)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)
 [![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)
 [![Maintainability](https://qlty.sh/gh/marcusquinn/projects/aidevops/maintainability.svg)](https://qlty.sh/gh/marcusquinn/projects/aidevops)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2b1adbd66c454dae92234341e801b984)](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)


### PR DESCRIPTION
## Summary
- Recovered the closed conflict PR implementation onto the worker branch.
- Added SonarCloud failing-gate routing to create one deduplicated `quality-gate-blocker` issue per repo.
- Kept public verification badges visible and added regression coverage for ERROR/WARN versus OK gate states.

## Testing
- `shellcheck .agents/scripts/stats-quality-sweep.sh .agents/scripts/stats-quality-sweep-issues.sh .agents/scripts/tests/test-stats-quality-sweep-issues.sh`
- `bash .agents/scripts/tests/test-stats-quality-sweep-issues.sh`
- `npx --yes markdownlint-cli2 .agents/aidevops/badges.md`
- `git diff --check origin/main...HEAD`

## Decisions
- Cherry-picked the original non-merge implementation commit from PR #22460.
- Resolved the stale `TODO.md` conflict by preserving current `main`; this PR contains only implementation/docs changes.

Resolves #22460

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.10 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 85,690 tokens on this as a headless worker.
