### PR TITLE
GH#22521: clarify setup postflight advisory noise

### DIFF
--- a/.agents/scripts/setup/modules/agent-runtime.sh
+++ b/.agents/scripts/setup/modules/agent-runtime.sh
@@ -281,7 +281,10 @@ _deploy_agents_to_runtimes_bounded() {
 		sleep 1
 	done
 
-	wait "$_pid" 2>/dev/null
-	_rc=$?
-	return "$_rc"
+	wait "$_pid" 2>/dev/null || _rc=$?
+	if [[ "$_rc" -ne 0 ]]; then
+		print_warning "Runtime agent deployment exited non-zero (${_rc}) — skipping (non-critical)"
+		return 0
+	fi
+	return 0
 }

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -248,7 +248,12 @@ _install_complexity_scan_launchd() {
 CS_PLIST
 	)
 
-	if _launchd_install_if_changed "$cs_label" "$cs_plist" "$cs_plist_content"; then
+	if [[ -f "$cs_plist" ]] && [[ "$(<"$cs_plist")" == "$cs_plist_content" ]] && _launchd_has_agent "$cs_label"; then
+		# Best-effort hourly job already registered. Avoid forcing launchd recovery
+		# during every setup run; long-running background jobs can transiently report
+		# xpcproxy even while launchd will continue the scheduled interval normally.
+		print_info "Complexity scan enabled (launchd, hourly run)"
+	elif _launchd_install_if_changed "$cs_label" "$cs_plist" "$cs_plist_content"; then
 		print_info "Complexity scan enabled (launchd, hourly run)"
 	else
 		print_warning "Failed to load complexity scan LaunchAgent"
@@ -1021,7 +1026,12 @@ _install_peer_productivity_monitor_launchd() {
 PPM_PLIST
 	)
 
-	if _launchd_install_if_changed "$ppm_label" "$ppm_plist" "$ppm_plist_content"; then
+	if [[ -f "$ppm_plist" ]] && [[ "$(<"$ppm_plist")" == "$ppm_plist_content" ]] && _launchd_has_agent "$ppm_label"; then
+		# Best-effort interval job already registered. Avoid forcing setup-time
+		# launchd recovery for transient xpcproxy states; the monitor remains
+		# scheduled and any real install/update failure is still surfaced below.
+		print_info "Peer productivity monitor enabled (launchd, every 30 min)"
+	elif _launchd_install_if_changed "$ppm_label" "$ppm_plist" "$ppm_plist_content"; then
 		print_info "Peer productivity monitor enabled (launchd, every 30 min)"
 	else
 		print_warning "Failed to load peer-productivity-monitor LaunchAgent"

--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -286,6 +286,7 @@ test_bounded_wrapper_child_failure_is_noncritical_without_err_trap_noise() {
 	{
 		printf '%s\n' '#!/usr/bin/env bash'
 		printf '%s\n' 'set -Eeuo pipefail'
+		# shellcheck disable=SC2016  # generated script must expand trap variables at runtime
 		printf '%s\n' 'trap '\''rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2'\'' ERR'
 		printf '%s\n' 'print_warning() { printf "[WARNING] %s\n" "$*"; return 0; }'
 		printf '%s\n' 'deploy_agents_to_runtimes() { return 7; }'

--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -109,9 +109,12 @@ _deploy_agents_to_runtimes_bounded() {
 		sleep 1
 	done
 
-	wait "\$_pid" 2>/dev/null
-	_rc=\$?
-	return "\$_rc"
+	wait "\$_pid" 2>/dev/null || _rc=\$?
+	if [[ "\$_rc" -ne 0 ]]; then
+		print_warning "bounded: exited non-zero (\${_rc}) — non-critical"
+		return 0
+	fi
+	return 0
 }
 
 _deploy_agents_to_runtimes_bounded
@@ -262,6 +265,49 @@ test_bounded_wrapper_timeout_env_respected() {
 	return 0
 }
 
+test_bounded_wrapper_child_failure_is_noncritical_without_err_trap_noise() {
+	local test_tmp_dir
+	test_tmp_dir=$(make_test_tmp_dir)
+	local script="${test_tmp_dir}/child_failure.sh"
+	local wrapper_definition=""
+
+	wrapper_definition=$(awk '
+		/^_deploy_agents_to_runtimes_bounded\(\)/{found=1; depth=0}
+		found {print}
+		found && /\{/{depth++}
+		found && /\}/{depth--; if(depth<=0){exit}}
+	' "$AGENT_RUNTIME_SH")
+
+	if [[ -z "$wrapper_definition" ]]; then
+		print_result "child failure wrapper extraction succeeds" 1 "function not found in ${AGENT_RUNTIME_SH}"
+		return 0
+	fi
+
+	{
+		printf '%s\n' '#!/usr/bin/env bash'
+		printf '%s\n' 'set -Eeuo pipefail'
+		printf '%s\n' 'trap '\''rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2'\'' ERR'
+		printf '%s\n' 'print_warning() { printf "[WARNING] %s\n" "$*"; return 0; }'
+		printf '%s\n' 'deploy_agents_to_runtimes() { return 7; }'
+		printf '%s\n' 'AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=5'
+		printf '%s\n' "$wrapper_definition"
+		printf '%s\n' '_deploy_agents_to_runtimes_bounded'
+	} >"$script"
+	chmod +x "$script"
+
+	local output=""
+	local rc=0
+	output=$(bash "$script" 2>&1) || rc=$?
+
+	if [[ "$rc" -eq 0 && "$output" == *"non-critical"* && "$output" != *"[ERROR]"* ]]; then
+		print_result "child deploy failure is non-critical without ERR trap noise" 0
+	else
+		print_result "child deploy failure is non-critical without ERR trap noise" 1 \
+			"rc=$rc output=${output}"
+	fi
+	return 0
+}
+
 test_real_bounded_wrapper_timeout_returns_zero() {
 	local test_tmp_dir
 	test_tmp_dir=$(make_test_tmp_dir)
@@ -316,6 +362,7 @@ main() {
 	test_bounded_wrapper_fast_path
 	test_bounded_wrapper_kills_slow_deployment_without_failing_setup
 	test_bounded_wrapper_timeout_env_respected
+	test_bounded_wrapper_child_failure_is_noncritical_without_err_trap_noise
 	test_real_bounded_wrapper_timeout_returns_zero
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-launchd-install-if-changed.sh
+++ b/.agents/scripts/tests/test-launchd-install-if-changed.sh
@@ -873,6 +873,151 @@ PROFILE_PLIST
 	return 0
 }
 
+test_interval_jobs_skip_unchanged_loaded_recovery() {
+	local fake_home="$TEST_DIR/home_interval_jobs"
+	mkdir -p "$fake_home/Library/LaunchAgents" "$fake_home/logs"
+	local complexity_plist="$fake_home/Library/LaunchAgents/sh.aidevops.complexity-scan.plist"
+	local peer_plist="$fake_home/Library/LaunchAgents/sh.aidevops.peer-productivity-monitor.plist"
+	local stderr_file="$TEST_DIR/interval-jobs-stderr.log"
+	local install_count=0
+
+	_launchd_has_agent() { return 0; }
+	_launchd_install_if_changed() { install_count=$((install_count + 1)); return 1; }
+
+	local orig_home="$HOME"
+	HOME="$fake_home"
+
+	local complexity_content peer_content
+	complexity_content=$(_install_complexity_scan_launchd_render_fixture "sh.aidevops.complexity-scan" "/fake/complexity-scan-runner.sh" "$fake_home/logs")
+	peer_content=$(_install_peer_productivity_monitor_launchd_render_fixture "sh.aidevops.peer-productivity-monitor" "/fake/peer-productivity-monitor.sh" "$fake_home/logs")
+	printf '%s\n' "$complexity_content" >"$complexity_plist"
+	printf '%s\n' "$peer_content" >"$peer_plist"
+
+	local rc=0
+	_install_complexity_scan_launchd "sh.aidevops.complexity-scan" "/fake/complexity-scan-runner.sh" "$fake_home/logs" 2>"$stderr_file" || rc=$?
+	_install_peer_productivity_monitor_launchd "sh.aidevops.peer-productivity-monitor" "/fake/peer-productivity-monitor.sh" "$fake_home/logs" 2>>"$stderr_file" || rc=$?
+
+	HOME="$orig_home"
+	unset -f _launchd_has_agent _launchd_install_if_changed
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "interval_jobs_skip_unchanged_loaded_recovery" 1 "expected install return 0, got $rc"
+		return 0
+	fi
+	if [[ "$install_count" -ne 0 ]]; then
+		print_result "interval_jobs_skip_unchanged_loaded_recovery" 1 "expected unchanged loaded jobs to skip install, got $install_count"
+		return 0
+	fi
+	if grep -q '\[WARN\]' "$stderr_file"; then
+		print_result "interval_jobs_skip_unchanged_loaded_recovery" 1 \
+			"interval launchd install emitted warning: $(tr '\n' ' ' <"$stderr_file")"
+		return 0
+	fi
+
+	print_result "interval_jobs_skip_unchanged_loaded_recovery" 0
+	return 0
+}
+
+_install_complexity_scan_launchd_render_fixture() {
+	local cs_label="$1"
+	local cs_script="$2"
+	local _cs_log_dir="$3"
+	local _xml_cs_script _xml_cs_home _xml_cs_log_dir
+	_xml_cs_script=$(_xml_escape "$cs_script")
+	_xml_cs_home=$(_xml_escape "$HOME")
+	_xml_cs_log_dir=$(_xml_escape "$_cs_log_dir")
+	cat <<CS_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${cs_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$(_xml_escape "$(_resolve_modern_bash)")</string>
+		<string>${_xml_cs_script}</string>
+		<string>run</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>3600</integer>
+	<key>StandardOutPath</key>
+	<string>${_xml_cs_log_dir}/complexity-scan-runner.log</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_cs_log_dir}/complexity-scan-runner.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>$(aidevops_launchd_sanitized_path)</string>
+		<key>HOME</key>
+		<string>${_xml_cs_home}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+CS_PLIST
+	return 0
+}
+
+_install_peer_productivity_monitor_launchd_render_fixture() {
+	local ppm_label="$1"
+	local ppm_script="$2"
+	local _ppm_log_dir="$3"
+	local _xml_ppm_script _xml_ppm_home _xml_ppm_log_dir
+	_xml_ppm_script=$(_xml_escape "$ppm_script")
+	_xml_ppm_home=$(_xml_escape "$HOME")
+	_xml_ppm_log_dir=$(_xml_escape "$_ppm_log_dir")
+	cat <<PPM_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${ppm_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$(_xml_escape "$(_resolve_modern_bash)")</string>
+		<string>${_xml_ppm_script}</string>
+		<string>observe</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>1800</integer>
+	<key>StandardOutPath</key>
+	<string>${_xml_ppm_log_dir}/peer-productivity-launchd.log</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_ppm_log_dir}/peer-productivity-launchd.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>$(aidevops_launchd_sanitized_path)</string>
+		<key>HOME</key>
+		<string>${_xml_ppm_home}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+PPM_PLIST
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -900,6 +1045,7 @@ main() {
 
 	_load_schedulers_platform_functions
 	test_profile_readme_install_does_not_kickstart
+	test_interval_jobs_skip_unchanged_loaded_recovery
 
 	# Test (b) needs _install_pulse_launchd from schedulers.sh
 	_load_schedulers_functions


### PR DESCRIPTION
## Summary

Treat runtime agent deploy child failures as non-critical warnings without ERR trap noise, and skip recovery for unchanged loaded complexity-scan and peer-productivity-monitor LaunchAgents to avoid transient xpcproxy warning churn.

## Files Changed

.agents/scripts/setup/modules/agent-runtime.sh,.agents/scripts/setup/modules/schedulers-platform.sh,.agents/scripts/tests/test-deploy-runtimes-bounded.sh,.agents/scripts/tests/test-launchd-install-if-changed.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-deploy-runtimes-bounded.sh; bash .agents/scripts/tests/test-launchd-install-if-changed.sh; shellcheck changed setup scripts; ./setup.sh --non-interactive reached deploy_agents_to_runtimes, setup_complexity_scan, and setup_peer_productivity_monitor with exit=0 and no target ERROR/xpcproxy warnings before later external timeout during profile README setup.

Resolves #22521


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.10 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 13m and 236,533 tokens on this as a headless worker.