### PR TITLE
t3538: Fix interactive issue origin labels

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -47,6 +47,39 @@ function getModelId(input) {
 }
 
 /**
+ * Env vars that mark a shell as headless worker context. Shell commands run by
+ * an interactive OpenCode TUI may inherit stale worker-origin env from a parent
+ * process; the plugin must stamp the intended session origin explicitly so
+ * issue/PR creation helpers do not mislabel maintainer-directed work.
+ */
+const HEADLESS_ENV_VARS = [
+  "FULL_LOOP_HEADLESS",
+  "AIDEVOPS_HEADLESS",
+  "OPENCODE_HEADLESS",
+  "GITHUB_ACTIONS",
+];
+
+/**
+ * @param {string | undefined} value
+ * @returns {boolean}
+ */
+function isTruthyEnv(value) {
+  return !!value && value !== "0" && value !== "false";
+}
+
+/**
+ * Determine the origin label intent for shell subprocesses.
+ * @param {object} env
+ * @returns {"worker" | "interactive"}
+ */
+function shellSessionOrigin(env) {
+  const headless = HEADLESS_ENV_VARS.some((key) =>
+    isTruthyEnv(env?.[key] || process.env[key]),
+  );
+  return headless ? "worker" : "interactive";
+}
+
+/**
  * Create the shell environment hook.
  * @param {object} deps - { agentsDir, scriptsDir, workspaceDir }
  * @returns {Function} Shell env hook function
@@ -71,6 +104,7 @@ export function createShellEnvHook(deps) {
     // Set aidevops workspace directory
     output.env.AIDEVOPS_AGENTS_DIR = agentsDir;
     output.env.AIDEVOPS_WORKSPACE_DIR = workspaceDir;
+    output.env.AIDEVOPS_SESSION_ORIGIN = shellSessionOrigin(output.env);
 
     // Set aidevops version if available
     const version = readIfExists(join(agentsDir, "..", "version"));

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage for t3538: interactive OpenCode shells must stamp
+// AIDEVOPS_SESSION_ORIGIN=interactive even when a stale worker-origin value is
+// inherited by the shell environment. Without this, gh_create_issue labels
+// maintainer-created issues as origin:worker.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createShellEnvHook } from "../shell-env.mjs";
+
+function makeHook() {
+  return createShellEnvHook({
+    agentsDir: "/tmp/aidevops-agents",
+    scriptsDir: "/tmp/aidevops-scripts",
+    workspaceDir: "/tmp/aidevops-workspace",
+  });
+}
+
+test("interactive OpenCode shell overrides stale worker origin", async () => {
+  const hook = makeHook();
+  const output = {
+    env: {
+      PATH: "/usr/bin:/bin",
+      AIDEVOPS_SESSION_ORIGIN: "worker",
+    },
+  };
+
+  await hook({ sessionID: "interactive-session" }, output);
+
+  assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "interactive");
+});
+
+test("headless OpenCode shell stamps worker origin", async () => {
+  const hook = makeHook();
+  const output = {
+    env: {
+      PATH: "/usr/bin:/bin",
+      OPENCODE_HEADLESS: "true",
+      AIDEVOPS_SESSION_ORIGIN: "interactive",
+    },
+  };
+
+  await hook({ sessionID: "worker-session" }, output);
+
+  assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "worker");
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -18,18 +18,34 @@ function makeHook() {
   });
 }
 
+async function withCleanHeadlessProcessEnv(fn) {
+  const keys = ["FULL_LOOP_HEADLESS", "AIDEVOPS_HEADLESS", "OPENCODE_HEADLESS", "GITHUB_ACTIONS"];
+  const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  try {
+    for (const key of keys) delete process.env[key];
+    await fn();
+  } finally {
+    for (const key of keys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+}
+
 test("interactive OpenCode shell overrides stale worker origin", async () => {
-  const hook = makeHook();
-  const output = {
-    env: {
-      PATH: "/usr/bin:/bin",
-      AIDEVOPS_SESSION_ORIGIN: "worker",
-    },
-  };
+  await withCleanHeadlessProcessEnv(async () => {
+    const hook = makeHook();
+    const output = {
+      env: {
+        PATH: "/usr/bin:/bin",
+        AIDEVOPS_SESSION_ORIGIN: "worker",
+      },
+    };
 
-  await hook({ sessionID: "interactive-session" }, output);
+    await hook({ sessionID: "interactive-session" }, output);
 
-  assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "interactive");
+    assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "interactive");
+  });
 });
 
 test("headless OpenCode shell stamps worker origin", async () => {


### PR DESCRIPTION
## Summary
- Stamps `AIDEVOPS_SESSION_ORIGIN` in OpenCode shell env so interactive sessions override stale worker-origin env before GitHub issue/PR helpers run.
- Preserves worker-origin stamping for headless OpenCode shells.
- Adds regression coverage for both interactive stale-env and headless worker paths.

## Root cause
Issue #22524 was authored in an interactive OpenCode session (signature footer evidence) but received `origin:worker`. The shell env hook did not explicitly set session origin, so GitHub helpers trusted inherited worker-origin env when composing labels.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs` — 191 pass before worktree cleanup interruption; repeated targeted suite after recovery.
- `node --test .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs .agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs` — 53 pass after final rebase.
- `.agents/scripts/linters-local.sh` — timed out in ratchet phase after reporting pre-existing markdown/skill-frontmatter findings; no secrets detected and targeted plugin tests passed.

Filed cleanup follow-up for the active-worktree deletion observed during verification: #22544.

Resolves #22539
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 11m and 292,477 tokens on this as a headless worker.