### PR TITLE
t3524: add feedback retention and sensitivity policy

### DIFF
--- a/.agents/aidevops/feedback.md
+++ b/.agents/aidevops/feedback.md
@@ -13,6 +13,72 @@ For shared plane metadata, use `.agents/configs/data-planes.json` when a registr
 entry exists. This document owns feedback mining, CLI, and routine design; capture
 and retention details stay with the feedback capture and sensitivity contracts.
 
+## Retention and Sensitivity Policy
+
+Raw feedback is evidence, not durable knowledge. Every capture MUST carry a
+sensitivity tier, consent/provenance note, and retention outcome before mining or
+promotion. If Markdoc-style tags are available, tag the capture or sensitive
+region with `{% sensitivity tier="..." /%}` and keep the same value in metadata
+until the tag schema becomes canonical.
+
+### Sensitivity tiers
+
+| Tier | Use for | Default handling |
+|------|---------|------------------|
+| `public` | Already-public comments, public issues, public reviews, or quoted material cleared for reuse | Can be retained long-lived and summarized publicly with source links when provenance allows |
+| `internal` | Operator notes, private team observations, internal support summaries, or non-public product feedback without client identifiers | Retain locally; promote only summarized and provenance-backed excerpts |
+| `client-scoped` | Feedback tied to a named client, account, project, or private engagement | Keep scoped to that client/project/case; public surfaces receive anonymized summaries only |
+| `privileged` | Legal, HR, finance, contract, security-response, or other privileged case notes | Keep local and access-restricted; promotion requires explicit maintainer approval and usually targets `_cases/` only |
+| `personal` | Feedback containing personal data, identifiable health/family/employment details, private contact details, or unique actor identifiers | Anonymize before mining or promotion; delete raw details when no longer needed |
+| `delete-after-review` | Accidental captures, unsupported consent, sensitive one-off reports, or content the source revoked | Review once, record non-sensitive disposition, then delete or retire raw content |
+
+### Retention outcomes
+
+| Outcome | Meaning | Allowed promotion |
+|---------|---------|-------------------|
+| `long-lived` | The capture may remain as evidence with provenance and a stable ID | `_knowledge/`, `_campaigns/`, `_projects/`, `_performance/`, or tasks when review gates pass |
+| `anonymized` | Raw identifying details are removed or replaced with placeholders before reuse | Durable planes receive only redacted excerpts, actor segments, counts, hashes, and source IDs |
+| `client-scoped` | The capture remains inside the relevant client/project/case boundary | `_cases/` or `_projects/` for that scope; public TODO/GitHub tasks get privacy-safe summaries |
+| `privileged-local` | Raw content is retained only in local/private storage for privileged review | `_cases/` only after approval; never copied into public issues, PRs, TODO entries, or shared docs |
+| `deleted` / `retired` | Raw feedback is removed, revoked, obsolete, duplicate, or consent-expired | No raw promotion; keep only a minimal audit note with capture ID, reason, and date when safe |
+
+### Consent, provenance, and promotion constraints
+
+- Promotion into `_knowledge/` requires `public`, `internal`, or already
+  `anonymized` evidence with enough provenance to recheck the source. Personal,
+  client-scoped, and privileged captures must be summarized before becoming
+  reusable knowledge.
+- Promotion into `_campaigns/` may use public language, anonymized themes, or
+  aggregated objections. Do not copy client names, private competitive notes, or
+  personal details into campaign research unless that campaign is scoped to the
+  same authorized audience.
+- Promotion into `_projects/` may preserve client/project context only when the
+  project scope matches the feedback scope. Cross-project requirements use
+  anonymized segments, not actor names.
+- Promotion into `_cases/` can retain client-scoped and privileged context, but
+  must keep provenance, access scope, and approval state visible to authorized
+  reviewers.
+- TODO/GitHub tasks receive the smallest privacy-safe summary: problem, segment,
+  evidence count, severity, affected files or decision surface, and verification.
+  Raw captures, private repo names, personal details, and privileged notes stay in
+  `_feedback/` or the scoped case/project store.
+
+### Placeholder examples
+
+- Public: `public + long-lived` — a public issue comment reports confusion in a
+  setup step; promote a summarized theme with the public issue reference.
+- Client-scoped: `client-scoped + client-scoped` — `[client-a]` asks for a report
+  change in a private delivery call; keep the raw note under that case and create
+  a public task saying "a managed client requested clearer report labels".
+- Personal: `personal + anonymized` — `[user-42]` mentions a family emergency while
+  describing onboarding friction; remove the personal detail and retain only the
+  onboarding theme.
+- Privileged: `privileged + privileged-local` — `[case-id]` includes legal advice
+  about a contract dispute; keep local to `_cases/` and do not mine for general
+  knowledge without explicit approval.
+- Delete after review: `delete-after-review + deleted` — a capture includes
+  revoked consent; record the deletion reason and do not promote the raw content.
+
 ## Mining Loop
 
 Mining MUST be recoverable from cold start. Each stage reads the current capture

--- a/todo/tasks/t3478-brief.md
+++ b/todo/tasks/t3478-brief.md
@@ -45,7 +45,7 @@ This is a parent-task. Initial planning PR uses `For #` keyword (planning only).
 ## Children
 
 - t3523 / #22510 — Phase 1: capture contract and normalized metadata fields.
-- t3524 / #22512 — Phase 2: retention and sensitivity policy.
+- t3524 / #22512 — Phase 2: retention and sensitivity policy (filed; child documents retention outcomes, sensitivity tiers, anonymization, and promotion constraints in `.agents/aidevops/feedback.md`).
 - t3525 / #22515 — Phase 3: mining workflow and evidence thresholds; filed as
   the child that documents clustering, deduplication, review gates, and promotion
   thresholds in `.agents/aidevops/feedback.md`.
@@ -57,7 +57,7 @@ This is a parent-task. Initial planning PR uses `For #` keyword (planning only).
 Decomposition planned as 5 phases:
 
 - **Phase 1 — capture contract**: define `_feedback/captures/` and normalized fields for source, timestamp, actor/segment, context, channel, sentiment, sensitivity, and consent/retention.
-- **Phase 2 — retention and sensitivity policy**: define which feedback can be long-lived, anonymized, privileged, client-scoped, or deleted; align with Markdoc sensitivity tags when available.
+- **Phase 2 — retention and sensitivity policy**: define which feedback can be long-lived, anonymized, privileged, client-scoped, or deleted; align with Markdoc sensitivity tags when available. Child #22512 owns this policy without closing parent #22373.
 - **Phase 3 — mining workflow**: design clustering, deduplication, theme extraction, evidence thresholds, and review gates before promotion.
 - **Phase 4 — promotion paths**: specify when feedback becomes `_knowledge/insights/`, a `_campaigns` research input, a `_projects` requirement, a `_cases` note, or a new TODO/GitHub task.
 - **Phase 5 — CLI and routines**: design `aidevops feedback capture|list|mine|promote|retire` plus recurring mining/reporting cadence; child #22519 owns the design contract without closing parent #22373.


### PR DESCRIPTION
## Summary

Documented _feedback retention outcomes, sensitivity tiers, anonymization rules, promotion constraints, and placeholder examples; linked Phase 2 child #22512 from the parent brief without closing #22373.

## Files Changed

.agents/aidevops/feedback.md,todo/tasks/t3478-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2 .agents/aidevops/feedback.md todo/tasks/t3478-brief.md; rg -n 'retention|anonym|privileged|client-scoped|delete' .agents/aidevops/feedback.md; rg -n 'Phase 2|#22512' todo/tasks/t3478-brief.md

Resolves #22512


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 76,231 tokens on this as a headless worker.