### PR TITLE
GH#22544: prevent active worktree cleanup during verification

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -86,6 +86,42 @@ log_worktree_removal_event() {
 	return 0
 }
 
+# Return 0 when any live process has its current working directory inside the
+# candidate worktree. `pgrep -f "$path"` only sees argv; commands such as
+# linters often run with cwd inside the worktree while their argv contains no
+# path, so deletion would make them fail with getcwd/uv_cwd ENOENT.
+_worktree_has_process_cwd() {
+	local wt_path="$1"
+	local wt_path_real="$2"
+
+	if [[ -d /proc ]]; then
+		local cwd_link=""
+		local cwd_target=""
+		for cwd_link in /proc/[0-9]*/cwd; do
+			[[ -e "$cwd_link" ]] || continue
+			cwd_target=$(readlink "$cwd_link" 2>/dev/null || true)
+			[[ -n "$cwd_target" ]] || continue
+			case "$cwd_target" in
+			"$wt_path" | "$wt_path"/* | "$wt_path_real" | "$wt_path_real"/*)
+				return 0
+				;;
+			esac
+		done
+	fi
+
+	if command -v lsof >/dev/null 2>&1; then
+		local lsof_output=""
+		lsof_output=$(lsof -n -F f +D "$wt_path_real" 2>/dev/null || true)
+		case "$lsof_output" in
+			fcwd | fcwd$'\n'* | *$'\n'fcwd | *$'\n'fcwd$'\n'*)
+				return 0
+				;;
+		esac
+	fi
+
+	return 1
+}
+
 # =============================================================================
 # worktree_removal_guard — shared destructive-path guard for production cleanup
 #
@@ -94,7 +130,8 @@ log_worktree_removal_event() {
 #   $2  caller   — audit caller constant
 #   $3  reason   — reason to log on skip
 #
-# Refuses registered canonical repos and the caller's current working directory.
+# Refuses registered canonical repos, the caller's current working directory,
+# and worktrees that still have any live process cwd inside them.
 # Returns 0 when callers may continue, 1 when removal must be skipped.
 # =============================================================================
 worktree_removal_guard() {
@@ -128,6 +165,11 @@ worktree_removal_guard() {
 			return 1
 			;;
 		esac
+	fi
+
+	if _worktree_has_process_cwd "$wt_path" "$wt_path_real"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "active-cwd" "skipped"
+		return 1
 	fi
 
 	: "$reason"

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -286,10 +286,54 @@ test_guard_refuses_current_cwd() {
 }
 
 # =============================================================================
-# Test 8: permanent helper removes only after guard passes and logs mode
+# Test 8: shared guard refuses another live process with cwd in worktree
+# =============================================================================
+test_guard_refuses_other_process_cwd() {
+	local log_file="${TEST_DIR}/t8-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	local wt_path="${TEST_DIR}/active-process-wt"
+	mkdir -p "$wt_path"
+
+	local sleeper_pid=""
+	(
+		cd "$wt_path" || exit 2
+		sleep 30
+	) &
+	sleeper_pid=$!
+
+	local rc=0
+	local attempts=0
+	while [[ "$attempts" -lt 20 ]]; do
+		(
+			unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+			# shellcheck source=../audit-worktree-removal-helper.sh
+			source "$AUDIT_HELPER"
+			if worktree_removal_guard "$wt_path" "test.sh" "manual"; then
+				exit 1
+			fi
+		) && break
+		rc=$?
+		attempts=$((attempts + 1))
+		sleep 0.1
+	done
+
+	kill "$sleeper_pid" 2>/dev/null || true
+	wait "$sleeper_pid" 2>/dev/null || true
+
+	if [[ "$rc" -eq 0 ]]; then
+		assert_file_contains "$log_file" "worktree-skipped.*active-cwd.*mode=skipped" || rc=$?
+	fi
+	print_result "guard_refuses_other_process_cwd" "$rc" \
+		"Expected active-cwd skip. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# Test 9: permanent helper removes only after guard passes and logs mode
 # =============================================================================
 test_permanent_helper_removes_and_logs() {
-	local log_file="${TEST_DIR}/t8-cleanup.log"
+	local log_file="${TEST_DIR}/t9-cleanup.log"
 	export AIDEVOPS_CLEANUP_LOG="$log_file"
 
 	local wt_path="${TEST_DIR}/old-wt"
@@ -323,6 +367,7 @@ test_all_event_types
 test_should_skip_cleanup_owned_skip_logs
 test_idempotent_sourcing
 test_guard_refuses_current_cwd
+test_guard_refuses_other_process_cwd
 test_permanent_helper_removes_and_logs
 
 echo ""


### PR DESCRIPTION
## Summary

Added a shared cleanup guard that refuses worktree removal when any live process has cwd inside the candidate worktree, preserving active verification commands.

## Files Changed

.agents/scripts/audit-worktree-removal-helper.sh,.agents/scripts/tests/test-worktree-removal-audit.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-removal-audit.sh; bash .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh; shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/tests/test-worktree-removal-audit.sh; dry-run cleanup guard logged active-cwd skip.

Resolves #22544


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 96,801 tokens on this as a headless worker.