### PR TITLE
t3537: Define _performance KPI result schema

### DIFF
--- a/.agents/aidevops/performance.md
+++ b/.agents/aidevops/performance.md
@@ -1,0 +1,232 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Performance Plane — KPI and Result Schema
+
+The `_performance/` plane is the canonical home for measurable outcomes across
+aidevops-managed work: campaign results, case outcomes, project delivery metrics,
+system health, and future result-bearing domains.
+
+This document defines the Phase 1 KPI/result schema only. Directory layout,
+ingest paths, CLI commands, dashboards, and recurring review workflows are
+deferred to later `_performance/` phases tracked by parent issue #22372.
+
+## Schema Goals
+
+Every performance record must answer six questions without reading surrounding
+prose or the upstream system that produced it:
+
+1. **What metric is this?** Stable metric identity and human-readable label.
+2. **What does it describe?** Subject and dimensions that scope the measurement.
+3. **How is it measured?** Unit, aggregation, precision, and directionality.
+4. **When is it valid?** Observation time, reporting period, and recording time.
+5. **Where did it come from?** Source, evidence, collector, and confidence.
+6. **Compared to what?** Baseline, target, or control value plus delta semantics.
+
+The schema is representation-neutral: later phases may store records as Markdown
+front matter, JSONL, or generated dashboard input. Field names and semantics below
+are the contract those representations must preserve.
+
+## Result Record
+
+```json
+{
+  "schema_version": 1,
+  "metric": {
+    "id": "marketing.leads.qualified",
+    "label": "Qualified leads",
+    "description": "Leads accepted by sales or the campaign owner",
+    "domain": "marketing",
+    "kind": "count",
+    "owner": "campaign-owner",
+    "version": 1
+  },
+  "subject": {
+    "type": "campaign",
+    "id": "campaign-2026-05-launch",
+    "name": "May launch campaign"
+  },
+  "dimensions": {
+    "channel": "linkedin",
+    "audience": "founders",
+    "region": "uk"
+  },
+  "measurement": {
+    "value": 42,
+    "unit": "lead",
+    "aggregation": "sum",
+    "period_start": "2026-05-01T00:00:00Z",
+    "period_end": "2026-05-31T23:59:59Z",
+    "observed_at": "2026-05-31T23:59:59Z",
+    "recorded_at": "2026-06-01T09:00:00Z"
+  },
+  "quality": {
+    "confidence": "high",
+    "source_type": "api_export",
+    "source_ref": "_campaigns/launched/campaign-2026-05-launch/results.md",
+    "collected_by": "campaign-results-import",
+    "evidence": ["export:crm-2026-06-01"],
+    "notes": null
+  },
+  "baseline": {
+    "type": "target",
+    "label": "Monthly qualified-lead target",
+    "value": 35,
+    "unit": "lead",
+    "period_start": "2026-05-01T00:00:00Z",
+    "period_end": "2026-05-31T23:59:59Z",
+    "delta_absolute": 7,
+    "delta_relative": 0.2,
+    "status": "above_target"
+  }
+}
+```
+
+## Metric Identity
+
+Metric identity is stable across subjects and reporting periods. A campaign,
+case, or project may emit many records for the same metric ID over time.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `metric.id` | Yes | Stable dotted ID: `<domain>.<object>.<measure>` |
+| `metric.label` | Yes | Human-readable name used in reports |
+| `metric.description` | Yes | Short definition that disambiguates counting rules |
+| `metric.domain` | Yes | Domain namespace: `marketing`, `case`, `project`, `system`, or future domain |
+| `metric.kind` | Yes | Measurement kind: `count`, `currency`, `duration`, `ratio`, `percentage`, `score`, `boolean`, `status`, `text` |
+| `metric.owner` | Recommended | Role or system responsible for definition quality |
+| `metric.version` | Yes | Integer definition version; increment when counting rules change |
+
+Metric IDs must not encode volatile dimensions such as campaign ID, channel, or
+date. Put those in `subject` and `dimensions` so reports can aggregate the same
+metric across comparable slices.
+
+## Subject and Dimensions
+
+`subject` identifies the entity the result measures. `dimensions` describe the
+slice of that entity.
+
+### Subject Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `subject.type` | Yes | Entity class: `campaign`, `case`, `project`, `system`, `routine`, or future type |
+| `subject.id` | Yes | Stable ID in the source plane |
+| `subject.name` | Recommended | Human-readable label for reports |
+
+### Dimension Rules
+
+- Use lower_snake_case keys and scalar string, number, or boolean values.
+- Keep dimensions orthogonal: `channel` and `region` are separate keys, not
+  `linkedin_uk`.
+- Prefer controlled vocabulary values where the upstream plane already has one.
+- Omit unknown dimensions instead of using `unknown`, `n/a`, or empty strings.
+- Put changing measurement values in `measurement`, never in `dimensions`.
+
+Common dimensions include `channel`, `audience`, `region`, `client`, `case_type`,
+`project_phase`, `environment`, `routine_id`, and `experiment_variant`.
+
+## Units and Measurement Semantics
+
+Measurement fields define how a value should be interpreted and aggregated.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `measurement.value` | Yes | Numeric, boolean, status, or text value matching `metric.kind` |
+| `measurement.unit` | Yes | Canonical unit such as `lead`, `gbp`, `second`, `percent`, or `score` |
+| `measurement.aggregation` | Yes | `sum`, `average`, `min`, `max`, `latest`, `median`, `p95`, `p99`, or `none` |
+| `measurement.precision` | Optional | Decimal precision to preserve when rendering |
+| `measurement.direction` | Optional | `higher_is_better`, `lower_is_better`, or `neutral` |
+
+Unit rules:
+
+- Store currency as decimal major units with ISO currency in `dimensions.currency`
+  when the currency can vary.
+- Store percentages as decimal fractions (`0.42` for 42%) and render as percent in
+  reports.
+- Store durations as seconds unless a later domain contract explicitly narrows the
+  unit.
+- For qualitative status metrics, use `metric.kind: "status"` and
+  `measurement.aggregation: "latest"`.
+
+## Timestamps and Reporting Periods
+
+Time fields separate the measured event, the reporting period, and the act of
+recording the result.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `measurement.observed_at` | Yes | Instant when the measured value was true or extracted |
+| `measurement.period_start` | Required for period metrics | Inclusive start of reporting window |
+| `measurement.period_end` | Required for period metrics | Inclusive end of reporting window |
+| `measurement.recorded_at` | Yes | Time the performance record was written |
+| `measurement.source_event_at` | Optional | Upstream event timestamp when different from observation time |
+
+All timestamps use RFC 3339 UTC strings. Snapshot metrics may set
+`period_start` and `period_end` to `null`; period metrics must set both.
+
+## Confidence, Source, and Evidence
+
+Performance records are decision inputs, so every value needs provenance.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `quality.confidence` | Yes | `low`, `medium`, `high`, or `verified` |
+| `quality.source_type` | Yes | `manual`, `api_export`, `csv_export`, `derived`, `agent_estimate`, or `external_report` |
+| `quality.source_ref` | Yes | Stable file path, export ID, or upstream record reference |
+| `quality.collected_by` | Yes | Human, agent, helper, or integration that produced the record |
+| `quality.evidence` | Recommended | Array of evidence refs, hashes, or source anchors |
+| `quality.notes` | Optional | Short caveat; not a substitute for structured fields |
+
+Confidence ladder:
+
+| Value | Meaning |
+|-------|---------|
+| `low` | Estimate, incomplete data, or unreviewed manual entry |
+| `medium` | Plausible source but not independently checked |
+| `high` | Direct export or deterministic derivation from trusted source |
+| `verified` | Independently checked against source evidence or signed-off report |
+
+Derived records must cite the input metric IDs and source refs in `evidence` so a
+future reporting CLI can explain how the value was produced.
+
+## Baseline and Comparison Model
+
+Baselines make a result meaningful without hardcoding dashboard logic.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `baseline.type` | Optional | `previous_period`, `target`, `control`, `forecast`, `industry`, or `custom` |
+| `baseline.label` | Optional | Human-readable comparison label |
+| `baseline.value` | Required when baseline exists | Baseline value in the same unit as measurement |
+| `baseline.unit` | Required when baseline exists | Must match `measurement.unit` unless conversion is explicit |
+| `baseline.period_start` | Optional | Baseline reporting-window start |
+| `baseline.period_end` | Optional | Baseline reporting-window end |
+| `baseline.source_ref` | Optional | Provenance for target, control, forecast, or external benchmark |
+| `baseline.delta_absolute` | Recommended | `measurement.value - baseline.value` after unit normalization |
+| `baseline.delta_relative` | Recommended | Relative delta as decimal fraction of baseline value |
+| `baseline.status` | Recommended | `above_target`, `below_target`, `on_track`, `regressed`, `improved`, or `neutral` |
+
+Comparison rules:
+
+- Compute deltas only when measurement and baseline units are compatible.
+- Preserve the baseline source; do not overwrite a target with the latest result.
+- Interpret positive or negative delta using `measurement.direction`, not by sign
+  alone.
+- Use `baseline.type: "control"` for experiments and include
+  `dimensions.experiment_variant` on both treatment and control records.
+- Use `baseline.type: "previous_period"` for trend reporting when no explicit
+  target exists.
+
+## Out of Scope for Phase 1
+
+The following are intentionally deferred:
+
+- `_performance/<domain>/` directory layout and file naming.
+- Promotion paths from `_campaigns/`, `_cases/`, and `_projects/`.
+- `aidevops performance ...` CLI commands.
+- Dashboard generation, stale-metric detection, and review cadence.
+- Cross-plane lesson promotion back to `_knowledge/insights/`.
+
+Later phases may extend this schema, but they should keep the Phase 1 record
+fields backwards compatible or document a `schema_version` migration.

--- a/todo/tasks/t3537-brief.md
+++ b/todo/tasks/t3537-brief.md
@@ -1,0 +1,100 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t3537: Define `_performance` KPI/result schema
+
+## Pre-flight
+
+- [x] Memory recall: `_performance KPI schema` → 0 hits — no prior lessons found.
+- [x] Discovery pass: 0 commits / 0 merged PRs / 0 open PRs touch `.agents/aidevops/performance.md` or this brief.
+- [x] File refs verified: `.agents/aidevops/knowledge-plane.md` exists; `.agents/aidevops/performance.md` and this brief were absent before this task; parent #22372 is open and references #22538 under `## Children`.
+- [x] Tier: `tier:thinking` — this is schema design, not a mechanical edit.
+- [x] Seeded draft PR decision recorded: skipped — issue body already contains worker-ready context and this worker is implementing directly.
+
+## Origin
+
+- **Created:** 2026-05-03
+- **Session:** OpenCode headless worker for issue #22538
+- **Created by:** ai-worker
+- **Parent task:** t3477 / #22372
+- **Conversation context:** Parent #22372 decomposes the future `_performance/` plane. This child implements Phase 1 by documenting the KPI/result schema before directory layout, ingest, CLI, or dashboard phases proceed.
+
+## What
+
+Create `.agents/aidevops/performance.md` as the initial `_performance/` plane contract for KPI/result records. The document defines metric identity, subject and dimensions, measurement units, timestamps, confidence/source provenance, and baseline comparison semantics.
+
+## Why
+
+Campaigns, cases, projects, routines, and system health will all emit measurable outcomes. Without a shared result schema, each plane would invent incompatible metric shapes, blocking later ingest paths and dashboard/reporting work.
+
+## Tier
+
+**Selected tier:** `tier:thinking` — the deliverable is a schema contract with design trade-offs. It touches two Markdown files and does not require dispatch-path elevation.
+
+## PR Conventions
+
+This is a leaf child issue. The implementation PR uses `Resolves #22538`. Parent #22372 must remain open until later phases complete.
+
+## How (Approach)
+
+### Files to Modify
+
+- `NEW: .agents/aidevops/performance.md` — initial `_performance/` KPI/result schema contract, modelled on `.agents/aidevops/knowledge-plane.md` document style.
+- `NEW: todo/tasks/t3537-brief.md` — child implementation brief with files scope and verification.
+
+### Implementation Steps
+
+1. Add `.agents/aidevops/performance.md` with a Phase 1-only scope statement.
+2. Define a canonical result-record shape with these top-level groups:
+   - `metric` — stable identity, domain, kind, label, owner, and version.
+   - `subject` and `dimensions` — measured entity plus orthogonal reporting slices.
+   - `measurement` — value, unit, aggregation, precision, direction, and timestamps.
+   - `quality` — confidence, source type/ref, collector, evidence, and caveats.
+   - `baseline` — target/control/previous-period comparisons, deltas, and status.
+3. Explicitly defer directory layout, ingest paths, CLI, dashboards, review cadence, and knowledge-promotion workflows to later phases.
+4. Keep parent #22372 open and verify it references this child under `## Children`.
+
+### Files Scope
+
+- `.agents/aidevops/performance.md`
+- `todo/tasks/t3537-brief.md`
+
+### Verification
+
+- `npx --yes markdownlint-cli2 .agents/aidevops/performance.md todo/tasks/t3537-brief.md`
+- `gh issue view 22372 --repo marcusquinn/aidevops --json state,body --jq '.state + " " + ((.body | contains("#22538")) | tostring)'`
+
+## Acceptance Criteria
+
+- [x] KPI/result schema documented.
+- [x] Metric identity and dimensions documented.
+- [x] Units, timestamps, confidence/source documented.
+- [x] Baseline comparison model documented.
+- [x] Out-of-scope phases explicitly deferred.
+
+## Context & Decisions
+
+- **Representation-neutral schema:** Phase 1 defines field semantics before choosing Markdown, JSONL, or dashboard-specific storage. This prevents the directory-contract phase from hardcoding a premature storage format.
+- **Metric identity separated from dimensions:** IDs stay stable across campaigns, cases, projects, and periods; volatile slices belong in `subject` and `dimensions` so future reports can aggregate correctly.
+- **Baselines included now:** Result values without targets, controls, or previous-period comparisons are weak dashboard inputs. Baseline semantics are foundational enough to belong in Phase 1.
+- **Deferred implementation:** No helper, ingest, dashboard, or CLI code is added in this phase because those depend on later parent phases.
+
+## Relevant Files
+
+- `.agents/aidevops/knowledge-plane.md` — reference document style for plane contracts.
+- `.agents/aidevops/performance.md` — new KPI/result schema contract.
+- `todo/tasks/t3537-brief.md` — this child brief.
+
+## Dependencies
+
+- **Parent:** #22372 tracks the full `_performance/` plane decomposition.
+- **Blocks:** later `_performance/` directory, ingest, reporting CLI, and dashboard/review phases.
+- **External:** none.
+
+## Estimate Breakdown
+
+| Work item | Time | Notes |
+|-----------|------|-------|
+| Schema contract | ~45m | Define fields, examples, and out-of-scope boundaries |
+| Brief and verification | ~15m | Worker-ready context plus markdown lint |
+| **Total** | **~1h** | Design-only child implementation |


### PR DESCRIPTION
## Summary

Defined the initial _performance KPI/result schema and added the child brief with files scope and verification.

## Files Changed

.agents/aidevops/performance.md,todo/tasks/t3537-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2 .agents/aidevops/performance.md todo/tasks/t3537-brief.md; parent #22372 linkage verified from issue body fetched during setup

Resolves #22538


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 107,313 tokens on this as a headless worker.