### PR TITLE
t3535: Fix phase-only parent auto-filing

### DIFF
--- a/.agents/reference/parent-task-lifecycle.md
+++ b/.agents/reference/parent-task-lifecycle.md
@@ -59,6 +59,8 @@ Env override: `PARENT_DECOMPOSITION_ESCALATION_HOURS` (default 168). Capped at `
 
 The sequential phase auto-file mechanism reads phase declarations from the parent-task issue body and files the **next unfiled phase** as a child issue automatically once the prior phase's PR merges.
 
+Parent reconciliation also bootstraps phase-only parents with zero filed children: when a `parent-task` issue has a parseable `## Phases` section but no `## Children`, GraphQL sub-issues, or prose child references, the reconcile pass files the first unfiled phase as a worker-dispatchable child before falling back to advisory decomposition nudges. This prevents phase-only parents from sitting open forever with `parent-task` blocking dispatch and `auto-decomposer-scanner.sh` skipping because a phase plan exists.
+
 **Feature flag:** `AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE` — defaults to `1` (ON) since t2787. Set to `0` to disable.
 
 ### Canonical Phase Formats
@@ -71,6 +73,13 @@ Two formats are supported. Both are parsed by `_extract_sequential_phases` in `s
 - Phase 1 - description [auto-fire:on-prior-merge]
 - Phase 2 - description [auto-fire:on-prior-merge]
 - Phase 3 - description
+```
+
+Bullet-wrapped bold headings are also accepted, which is the common parent-brief style:
+
+```
+- **Phase 1 — description**: optional detail text.
+- **Phase 2 — design CLI `new|list|status` surface**: pipes in CLI prose are text, not child references.
 ```
 
 **Narrative bold-heading format (for prose-style decomposition plans):**
@@ -89,7 +98,7 @@ Detailed implementation notes for Phase 2...
 |--------|-----------|
 | `[auto-fire:on-prior-merge]` | File this phase when the prior phase PR merges (recommended) |
 | `[auto-fire:on]` | File immediately — no wait for prior merge |
-| *(no marker — list format)* | Filed in sequence (same as `on-prior-merge`) |
+| *(no marker — list/bullet-bold format)* | Eligible for the initial zero-child bootstrap; post-merge sequencing still requires an explicit auto-fire marker |
 | *(no marker — narrative format)* | NOT auto-filed unless `<!-- phase-auto-fire:on -->` appears in the issue body |
 
 The `<!-- phase-auto-fire:on -->` HTML comment is the opt-in for narrative phases without per-phase markers. It applies the `on-prior-merge` behaviour to every unmarked narrative phase in the issue.

--- a/.agents/scripts/auto-decomposer-scanner.sh
+++ b/.agents/scripts/auto-decomposer-scanner.sh
@@ -288,6 +288,17 @@ _extract_children_from_body() {
 	return 0
 }
 
+# Return 0 when the parent body has a ## Phases plan but no concrete child
+# references. These parents are not "decomposed" yet; parent reconciliation
+# should bootstrap the first phase child via shared-phase-filing.sh.
+_body_has_phase_plan_without_children() {
+	local body="$1"
+	[[ -n "$body" ]] || return 1
+	printf '%s' "$body" | grep -qE '^##[[:space:]]+Phases?([[:space:]]+.*)?[[:space:]]*$' 2>/dev/null || return 1
+	[[ -z "$(_extract_children_from_body "$body")" ]] || return 1
+	return 0
+}
+
 # GH#21017: Return 0 if the issue has at least one OWNER/MEMBER comment
 # created after the supplied ISO-8601 cutoff timestamp, EXCLUDING
 # framework-automated comments (nudge, ops, provenance markers).
@@ -381,7 +392,7 @@ _decompose_issue_exists() {
 	local title_prefix="Decompose parent-task #${parent_num}:"
 	local count
 	count=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
-		--state all --paginate \
+		--state all --limit 1000 \
 		--json title \
 		| jq --arg prefix "$title_prefix" \
 			'[.[] | select(.title | startswith($prefix))] | length' \
@@ -523,25 +534,32 @@ _create_decompose_issue() {
 # the full check inline-readable in this file.
 #
 # Logic:
-#   1. If parent body declares decomposition (## Children/Phase/prose
+#   1. If parent body declares phase-only decomposition with zero filed refs,
+#      emit "phase-plan-awaiting-reconcile" (the reconcile pass bootstraps it).
+#   2. If parent body declares decomposition (## Children/Phase/prose
 #      ref), emit "has-children".
-#   2. Otherwise, if the parent OR any extracted child has an
+#   3. Otherwise, if the parent OR any extracted child has an
 #      OWNER/MEMBER comment in the last MAINTAINER_ACTIVITY_HOURS
 #      (capped by MAINTAINER_ACTIVITY_CHILD_CAP for the children
 #      sweep), emit "maintainer-activity".
-#   3. Otherwise, emit "" (caller proceeds with existing nudge-age
+#   4. Otherwise, emit "" (caller proceeds with existing nudge-age
 #      gate).
 #
 # Arguments:
 #   $1 - repo slug (owner/repo)
 #   $2 - parent issue number
 #   $3 - parent body (already fetched once by the caller)
-# Stdout: "has-children" | "maintainer-activity" | ""
+# Stdout: "phase-plan-awaiting-reconcile" | "has-children" | "maintainer-activity" | ""
 # Returns: 0 always (caller inspects the printed value).
 _evaluate_gh21017_skip_reason() {
 	local repo="$1"
 	local parent_num="$2"
 	local parent_body="$3"
+
+	if _body_has_phase_plan_without_children "$parent_body"; then
+		printf 'phase-plan-awaiting-reconcile'
+		return 0
+	fi
 
 	if _body_has_decomposition_markers "$parent_body"; then
 		printf 'has-children'
@@ -596,7 +614,7 @@ do_scan() {
 
 	local issues_created=0 total_seen=0 skipped_no_nudge=0 skipped_too_young=0 skipped_existing=0 skipped_refiled=0
 	# GH#21017: counters for the new skip paths.
-	local skipped_has_children=0 skipped_maintainer_activity=0
+	local skipped_has_children=0 skipped_maintainer_activity=0 skipped_phase_reconcile=0
 	while IFS=$'\t' read -r parent_num parent_title; do
 		[[ -z "$parent_num" ]] && continue
 		total_seen=$((total_seen + 1))
@@ -631,6 +649,7 @@ do_scan() {
 		parent_body=$(gh api "repos/${repo}/issues/${parent_num}" --jq '.body // ""' 2>/dev/null || echo "")
 		skip_reason=$(_evaluate_gh21017_skip_reason "$repo" "$parent_num" "$parent_body")
 		case "$skip_reason" in
+			phase-plan-awaiting-reconcile) log "[skip:phase-plan-awaiting-reconcile] parent #${parent_num}: ## Phases has zero child refs; parent reconcile will bootstrap the next phase child"; skipped_phase_reconcile=$((skipped_phase_reconcile + 1)); continue ;;
 			has-children) log "[skip:has-children] parent #${parent_num}: body declares decomposition (## Children/Phase/prose ref)"; skipped_has_children=$((skipped_has_children + 1)); continue ;;
 			maintainer-activity) log "[skip:recent-maintainer-activity] parent #${parent_num}: OWNER/MEMBER comment in last ${MAINTAINER_ACTIVITY_HOURS}h on parent or child"; skipped_maintainer_activity=$((skipped_maintainer_activity + 1)); continue ;;
 		esac
@@ -672,7 +691,7 @@ do_scan() {
 		fi
 	done < <(printf '%s' "$parents_json" | jq -r '.[] | "\(.number)\t\(.title)"')
 
-	log "Scan done. Parents seen: ${total_seen}, created: ${issues_created}, skipped(existing): ${skipped_existing}, skipped(no-nudge): ${skipped_no_nudge}, skipped(too-young): ${skipped_too_young}, skipped(re-file gate): ${skipped_refiled}, skipped(has-children): ${skipped_has_children}, skipped(maintainer-activity): ${skipped_maintainer_activity}"
+	log "Scan done. Parents seen: ${total_seen}, created: ${issues_created}, skipped(existing): ${skipped_existing}, skipped(no-nudge): ${skipped_no_nudge}, skipped(too-young): ${skipped_too_young}, skipped(re-file gate): ${skipped_refiled}, skipped(phase-reconcile): ${skipped_phase_reconcile}, skipped(has-children): ${skipped_has_children}, skipped(maintainer-activity): ${skipped_maintainer_activity}"
 	return 0
 }
 

--- a/.agents/scripts/parent-status-helper.sh
+++ b/.agents/scripts/parent-status-helper.sh
@@ -224,6 +224,10 @@ _parse_phase_lines() {
 			gsub(/[[:space:]]+$/, "", name)
 			gsub(/[[:space:]]+/, " ", name)
 			gsub(/^[[:space:]]*/, "", name)
+			# Output is pipe-delimited; phase prose can contain CLI alternation
+			# examples like `new|list|status`, so neutralize literal pipes before
+			# rendering to avoid shifting fields and hallucinating child refs.
+			gsub(/\|/, "/", name)
 
 			print phase_num "|" name "|" ref_issue
 		}

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -662,6 +662,12 @@ _action_cpt_single() {
 				return 0
 			fi
 		fi
+		if declare -F auto_file_next_unfiled_parent_phase >/dev/null 2>&1; then
+			if auto_file_next_unfiled_parent_phase "$issue_num" "$slug" >>"${LOGFILE:-/dev/null}" 2>&1; then
+				echo "[pulse-wrapper] Reconcile parent-task: phase bootstrap filed next child for #${issue_num} in ${slug} (GH#22534)" >>"${LOGFILE:-/dev/null}"
+				return 0
+			fi
+		fi
 		if [[ "$can_nudge" == "1" ]]; then
 			if _post_parent_decomposition_nudge "$slug" "$issue_num" "$issue_title"; then
 				_SP_CPT_NUDGED=1

--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -13,6 +13,9 @@
 #       Finds the parent-task issue for the closed child, parses its ## Phases
 #       section, and files the next unfiled phase marked [auto-fire:on-prior-merge].
 #       Best-effort; failures are logged but never propagate.
+#   - auto_file_next_unfiled_parent_phase <parent_issue> <repo_slug>
+#       Bootstraps phase-only parent-task issues that have planned phases but
+#       zero filed children by filing the first unfiled phase as a child issue.
 #
 # Feature flag:
 #   AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0|1 (default 1, ON since t2787)
@@ -20,11 +23,13 @@
 #
 # Phase line format in parent issue body's ## Phases section:
 #   - Phase <N> - <description> [auto-fire:on-prior-merge] [#<child_issue>]
+#   - **Phase <N> — <description>** [#<child_issue>]
 #   - Phase <N> - <description> [requires-decision]
 #
 # The marker [auto-fire:on-prior-merge] opts a phase into auto-filing.
 # The marker [requires-decision] explicitly blocks auto-filing.
-# Phases with NO marker are also skipped (conservative default).
+# Sequential post-merge filing requires [auto-fire:on-prior-merge]. Bootstrap
+# filing accepts unmarked phases unless [requires-decision] is present.
 # Phases that already have a #<child_issue> reference are skipped (dedup).
 #
 # Parent discovery:
@@ -187,7 +192,7 @@ _parse_phase_line_list_form() {
 #######################################
 _parse_phase_line_bold_form() {
 	local line="$1" global_auto_fire="${2:-none}"
-	printf '%s' "$line" | grep -qE '^\*\*[Pp]hase[[:space:]]+[0-9]+' || return 0
+	printf '%s' "$line" | grep -qE '^[[:space:]]*([-*+][[:space:]]+)?\*\*[Pp]hase[[:space:]]+[0-9]+' || return 0
 
 	local phase_num description marker child_ref
 	phase_num=$(printf '%s' "$line" | grep -oE '\*\*[Pp]hase[[:space:]]+[0-9]+' | grep -oE '[0-9]+')
@@ -201,9 +206,10 @@ _parse_phase_line_bold_form() {
 	#      the closing `**` (**Phase N — desc [auto-fire:on-prior-merge]**) are
 	#      peeled cleanly.
 	description=$(printf '%s' "$line" \
+		| sed -E 's/^[[:space:]]*[-*+][[:space:]]+//' \
 		| sed -E 's/^\*\*[Pp]hase[[:space:]]+[0-9]+[[:space:]]*//' \
 		| sed -E 's/^[^[:alnum:]]*//' \
-		| sed -E 's/[[:space:]]*#[0-9]+[[:space:]]*\*\*[[:space:]]*$//;s/[[:space:]]*#[0-9]+[[:space:]]*$//;s/\*\*[[:space:]]*$//;s/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\][[:space:]]*$//')
+		| sed -E 's/[[:space:]]*#[0-9]+[[:space:]]*\*\*[[:space:]]*$//;s/[[:space:]]*#[0-9]+[[:space:]]*$//;s/\*\*[[:space:]]*:?[[:space:]]*//;s/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\][[:space:]]*$//')
 
 	marker=$(_phase_marker_for_line "$line" "$global_auto_fire")
 
@@ -285,6 +291,16 @@ _build_phase_child_body() {
 	local phase_num="$3"
 	local phase_desc="$4"
 	local repo_slug="$5"
+	local trigger_reason="${6:-post-merge}"
+	local why_detail="This phase was auto-filed after the prior phase's PR merged successfully.
+Parent task #${parent_issue} (_${parent_title}_) uses sequential phase
+decomposition. Phase $((phase_num - 1)) has been completed and merged."
+	if [[ "$trigger_reason" == "bootstrap" ]]; then
+		why_detail="This phase was auto-filed because parent task #${parent_issue} (_${parent_title}_)
+declares planned phases but had no worker-dispatchable child issue for the next
+phase. Filing Phase ${phase_num} moves the parent out of the parent-task dispatch
+block while preserving the parent as the tracker."
+	fi
 
 	cat <<MD
 <!-- aidevops:generator=phase-autofile parent=${parent_issue} phase=${phase_num} -->
@@ -295,9 +311,7 @@ Implement Phase ${phase_num} of parent-task [#${parent_issue}](https://github.co
 
 ## Why
 
-This phase was auto-filed after the prior phase's PR merged successfully.
-Parent task #${parent_issue} (_${parent_title}_) uses sequential phase
-decomposition. Phase $((phase_num - 1)) has been completed and merged.
+${why_detail}
 
 ## How
 
@@ -349,7 +363,7 @@ _update_parent_phases_section() {
 	# where <N> is exactly $phase_num (word-bounded by whitespace/punctuation),
 	# and appends the child ref only if it's not already present.
 	local updated_body
-	updated_body=$(printf '%s' "$parent_body" | sed -E "/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+${phase_num}([^0-9]|$)/ {
+	updated_body=$(printf '%s' "$parent_body" | sed -E "/^[[:space:]]*[-*+][[:space:]]+(\*\*)?[Pp]hase[[:space:]]+${phase_num}([^0-9]|$)/ {
 		/#${child_issue_num}([^0-9]|$)/!s/[[:space:]]*$/ #${child_issue_num}/
 	}")
 
@@ -425,11 +439,12 @@ _create_phase_child_issue() {
 	local phase_num="$3"
 	local phase_desc="$4"
 	local repo_slug="$5"
+	local trigger_reason="${6:-post-merge}"
 	local _log="${LOGFILE:-/dev/null}"
 
 	local issue_body
 	issue_body=$(_build_phase_child_body \
-		"$parent_issue" "$parent_title" "$phase_num" "$phase_desc" "$repo_slug")
+		"$parent_issue" "$parent_title" "$phase_num" "$phase_desc" "$repo_slug" "$trigger_reason")
 
 	# Append signature footer
 	local _phase_sig=""
@@ -452,6 +467,69 @@ _create_phase_child_issue() {
 		--body "${issue_body}${_phase_sig}" 2>>"$_log")
 
 	printf '%s' "${new_issue_url:-}"
+	return 0
+}
+
+#######################################
+# File the first unfiled phase for a parent-task issue that has a ## Phases
+# plan but no filed children. This is the bootstrap path used by parent-task
+# reconciliation; post-merge sequencing still uses auto_file_next_phase.
+#
+# Args: $1=parent_issue, $2=repo_slug
+# Returns: 0 if a phase child was filed, 1 otherwise
+#######################################
+auto_file_next_unfiled_parent_phase() {
+	local parent_issue="$1"
+	local repo_slug="$2"
+	[[ "$parent_issue" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	[[ "${AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE:-0}" == "1" ]] || return 1
+
+	local parent_api="repos/${repo_slug}/issues/${parent_issue}"
+	local parent_body parent_title parent_labels _parent_json
+	_parent_json=$(gh api "$parent_api" \
+		--jq '{body: (.body // ""), title: (.title // ""), labels: [.labels[].name]}' 2>/dev/null) || _parent_json=""
+	[[ -n "$_parent_json" ]] || return 1
+	parent_body=$(printf '%s' "$_parent_json" | jq -r '.body // ""')
+	parent_title=$(printf '%s' "$_parent_json" | jq -r '.title // ""')
+	parent_labels=$(printf '%s' "$_parent_json" | jq -r '.labels | join(",")')
+	case ",${parent_labels}," in
+	*,no-auto-dispatch,*)
+		_phase_log "Parent #${parent_issue}: carries no-auto-dispatch, skip phase bootstrap"
+		return 1
+		;;
+	esac
+
+	local phases
+	phases=$(_parse_phases_section "$parent_body")
+	[[ -n "$phases" ]] || return 1
+
+	local next_phase_num="" next_desc="" next_marker="" next_child=""
+	while IFS=$'\t' read -r p_num p_desc p_marker p_child; do
+		[[ "$p_num" =~ ^[0-9]+$ ]] || continue
+		[[ -z "$p_child" ]] || continue
+		[[ "$p_marker" != "$_PHASE_MARKER_REQUIRES_DECISION" ]] || continue
+		next_phase_num="$p_num"
+		next_desc="$p_desc"
+		next_marker="$p_marker"
+		next_child="$p_child"
+		break
+	done <<< "$phases"
+	[[ -n "$next_phase_num" && -n "$next_desc" && -z "$next_child" ]] || return 1
+
+	_phase_log "Bootstrapping Phase ${next_phase_num} ('${next_desc}', marker=${next_marker}) for parent #${parent_issue}"
+	local new_issue_url
+	new_issue_url=$(_create_phase_child_issue \
+		"$parent_issue" "$parent_title" "$next_phase_num" "$next_desc" "$repo_slug" "bootstrap")
+	[[ -n "$new_issue_url" ]] || return 1
+
+	local new_issue_num; new_issue_num=$(printf '%s' "$new_issue_url" | grep -oE '[0-9]+$')
+	[[ -n "$new_issue_num" ]] || return 1
+	_update_parent_phases_section "$parent_issue" "$repo_slug" "$next_phase_num" "$new_issue_num"
+	gh_issue_comment "$parent_issue" --repo "$repo_slug" \
+		--body "Phase-only parent bootstrap: auto-filed Phase ${next_phase_num} as #${new_issue_num}: ${next_desc}
+
+_Sequential phase bootstrap by \`shared-phase-filing.sh\` (t2740)._" >/dev/null 2>&1 || true
+	_phase_log "Bootstrapped Phase ${next_phase_num} as #${new_issue_num} for parent #${parent_issue}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-auto-decomposer-scanner.sh
+++ b/.agents/scripts/tests/test-auto-decomposer-scanner.sh
@@ -80,11 +80,12 @@ assert_rc() {
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCANNER="$SCRIPT_DIR/auto-decomposer-scanner.sh"
-WRAPPER="$SCRIPT_DIR/pulse-simplification.sh"
+WRAPPER="$SCRIPT_DIR/pulse-simplification-review.sh"
+SCAN_LIB="$SCRIPT_DIR/pulse-simplification-scan.sh"
 ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
-BOOTSTRAP="$SCRIPT_DIR/pulse-wrapper.sh"
+BOOTSTRAP="$SCRIPT_DIR/pulse-wrapper-config.sh"
 
-for required in "$SCANNER" "$WRAPPER" "$ENGINE" "$BOOTSTRAP"; do
+for required in "$SCANNER" "$WRAPPER" "$SCAN_LIB" "$ENGINE" "$BOOTSTRAP"; do
 	if [[ ! -f "$required" ]]; then
 		echo "${TEST_RED}FATAL${TEST_NC}: $required not found"
 		exit 1
@@ -214,7 +215,7 @@ assert_grep_fixed \
 
 assert_grep \
 	"12: dispatch engine registers _run_auto_decomposer_scanner via run_stage_with_timeout" \
-	'run_stage_with_timeout "auto_decomposer_scanner".*_run_auto_decomposer_scanner' \
+	'_run_optional_stage_with_timeout "auto_decomposer_scanner".*_run_auto_decomposer_scanner' \
 	"$ENGINE"
 
 # --- Constants in pulse-wrapper.sh bootstrap ---
@@ -226,7 +227,7 @@ assert_grep \
 
 assert_grep \
 	"13b: AUTO_DECOMPOSER_INTERVAL constant defined with 604800 default (7d per-parent gate, t2573)" \
-	'^AUTO_DECOMPOSER_INTERVAL="\$\{AUTO_DECOMPOSER_INTERVAL:-604800\}"' \
+	'^AUTO_DECOMPOSER_INTERVAL="\$\{AUTO_DECOMPOSER_INTERVAL:-\$\{PARENT_TASK_REFILE_GATE_SECONDS\}\}"' \
 	"$BOOTSTRAP"
 
 assert_grep \
@@ -239,7 +240,7 @@ assert_grep \
 assert_grep \
 	"14: _pulse_enabled_repo_slugs helper defined (de-dupes jq filter)" \
 	'^_pulse_enabled_repo_slugs\(\) \{' \
-	"$WRAPPER"
+	"$SCAN_LIB"
 
 # --- Shellcheck cleanliness ---
 
@@ -287,11 +288,17 @@ assert_grep_fixed "16g: do_scan emits [skip:has-children] log line" \
 assert_grep_fixed "16h: do_scan emits [skip:recent-maintainer-activity] log line" \
 	'[skip:recent-maintainer-activity]' "$SCANNER"
 
+assert_grep_fixed "16h2: do_scan emits [skip:phase-plan-awaiting-reconcile] log line" \
+	'[skip:phase-plan-awaiting-reconcile]' "$SCANNER"
+
 assert_grep_fixed "16i: do_scan declares skipped_has_children counter" \
 	'skipped_has_children=0' "$SCANNER"
 
 assert_grep_fixed "16j: do_scan declares skipped_maintainer_activity counter" \
 	'skipped_maintainer_activity=0' "$SCANNER"
+
+assert_grep_fixed "16j2: do_scan declares skipped_phase_reconcile counter" \
+	'skipped_phase_reconcile=0' "$SCANNER"
 
 assert_grep_fixed "16k: final summary includes skipped(has-children) counter" \
 	'skipped(has-children): ${skipped_has_children}' "$SCANNER"
@@ -299,8 +306,14 @@ assert_grep_fixed "16k: final summary includes skipped(has-children) counter" \
 assert_grep_fixed "16l: final summary includes skipped(maintainer-activity) counter" \
 	'skipped(maintainer-activity): ${skipped_maintainer_activity}' "$SCANNER"
 
+assert_grep_fixed "16l2: final summary includes skipped(phase-reconcile) counter" \
+	'skipped(phase-reconcile): ${skipped_phase_reconcile}' "$SCANNER"
+
 assert_grep_fixed "16m: help text documents MAINTAINER_ACTIVITY_HOURS" \
 	'MAINTAINER_ACTIVITY_HOURS' "$SCANNER"
+
+assert_grep "16n: _body_has_phase_plan_without_children helper defined" \
+	'^_body_has_phase_plan_without_children\(\) \{' "$SCANNER"
 
 # --- Function-level checks: source the script and exercise pure helpers ---
 #
@@ -403,6 +416,24 @@ if [[ -z "$bare_out" ]]; then
 else
 	TESTS_FAILED=$((TESTS_FAILED + 1))
 	echo "${TEST_RED}FAIL${TEST_NC}: 17k: _extract_children_from_body wrongly extracted: $bare_out"
+fi
+
+# _body_has_phase_plan_without_children — detects phase-only parents that
+# need parent reconciliation rather than a silent has-children skip.
+TESTS_RUN=$((TESTS_RUN + 1))
+if _body_has_phase_plan_without_children $'## Phases\n\n- **Phase 1 — contract**: design `new|list|status`.\n' >/dev/null 2>&1; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 17k2: _body_has_phase_plan_without_children detects zero-child phase plan"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 17k2: _body_has_phase_plan_without_children missed zero-child phase plan"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! _body_has_phase_plan_without_children $'## Phases\n\n- Phase 1 - contract #20001\n' >/dev/null 2>&1; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 17k3: _body_has_phase_plan_without_children rejects phase plan with child refs"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 17k3: _body_has_phase_plan_without_children accepted phase plan with child refs"
 fi
 
 # _iso_cutoff_hours_ago — produces a parseable ISO-8601 UTC timestamp

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -35,6 +35,7 @@
 #   B6. _try_close_parent_tracker accepts parent_body as 5th parameter
 #   B7. Guard skips close when declared_count > child_count
 #   B8. _action_cpt_single passes issue_body to _try_close_parent_tracker
+#   B9. _action_cpt_single bootstraps phase-only parents before advisory nudges
 
 set -u
 
@@ -154,9 +155,10 @@ _parse_phases_section() {
 # --- Locate source file for structural tests ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET="$SCRIPT_DIR/pulse-issue-reconcile.sh"
+ACTIONS_TARGET="$SCRIPT_DIR/pulse-issue-reconcile-actions.sh"
 
-if [[ ! -f "$TARGET" ]]; then
-	echo "${TEST_RED}FATAL${TEST_NC}: $TARGET not found"
+if [[ ! -f "$TARGET" || ! -f "$ACTIONS_TARGET" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: reconcile source files not found"
 	exit 1
 fi
 
@@ -309,43 +311,53 @@ assert_grep_fixed \
 assert_grep \
 	"B2: _post_parent_phases_unfiled_nudge function defined in source" \
 	'^_post_parent_phases_unfiled_nudge\(\) \{' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
 
 # B3: canonical marker present
 assert_grep_fixed \
 	"B3: canonical marker <!-- parent-declared-phases-unfiled --> present" \
 	'<!-- parent-declared-phases-unfiled -->' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
 
 # B4: idempotency check via gh api --paginate
 assert_grep \
 	"B4: nudge function queries comments via gh api --paginate for idempotency" \
 	'gh api --paginate "repos/\$\{slug\}/issues/\$\{parent_num\}/comments"' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
 
 # B5: nudge posts via gh_issue_comment wrapper
 assert_grep \
 	"B5: nudge posts via gh_issue_comment wrapper" \
 	'gh_issue_comment "\$parent_num" --repo "\$slug"' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
 
 # B6: _try_close_parent_tracker accepts 5th param parent_body
 assert_grep_fixed \
 	"B6: _try_close_parent_tracker signature includes parent_body 5th param" \
 	'local slug="$1" parent_num="$2" child_nums="$3" child_source="$4" parent_body="${5:-}"' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
 
 # B7: guard fires when declared_count > child_count
 assert_grep_fixed \
 	'B7: guard skips close when declared_count > child_count' \
 	'if [[ "$_declared_count" -gt "$child_count" ]]; then' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
 
 # B8: call site passes issue_body as 5th arg
 assert_grep_fixed \
 	"B8: _action_cpt_single passes issue_body to _try_close_parent_tracker" \
 	'_try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source" "$issue_body"' \
-	"$TARGET"
+	"$ACTIONS_TARGET"
+
+# B9: phase-only parent bootstrap runs before advisory-only nudge/escalation
+assert_grep_fixed \
+	"B9a: _action_cpt_single calls phase-only bootstrap helper" \
+	'auto_file_next_unfiled_parent_phase "$issue_num" "$slug"' \
+	"$ACTIONS_TARGET"
+assert_grep_fixed \
+	"B9b: shared phase bootstrap helper is defined" \
+	'auto_file_next_unfiled_parent_phase() {' \
+	"$SHARED_TARGET"
 
 # ============================================================
 echo ""

--- a/.agents/scripts/tests/test-shared-phase-filing.sh
+++ b/.agents/scripts/tests/test-shared-phase-filing.sh
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # test-shared-phase-filing.sh — t2740 regression guard.
+# shellcheck disable=SC2016  # test fixtures intentionally contain literal CLI syntax
 #
 # Tests the sequential phase auto-filing logic in shared-phase-filing.sh.
 # Covers:
@@ -577,6 +578,40 @@ if [[ "$gh20871_unfiled_count" -eq 2 ]]; then
 	pass "Unfiled extraction: Phase 1 + Phase 2 unfiled, Phase 3 (with #20768) excluded"
 else
 	fail "Expected 2 unfiled phases, got ${gh20871_unfiled_count}" "Output: ${gh20871_unfiled}"
+fi
+
+# =============================================================================
+# Test 16: _parse_phases_section — bullet-wrapped bold phases with CLI pipes
+#          parse as phases without treating `new|list|status` as references
+#          (GH#22534)
+# =============================================================================
+printf '%s--- Test 16: bullet bold phases and CLI pipes ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+PARENT_BODY_GH22534='## Phases
+
+- **Phase 1 — directory contract**: define `_projects/<project-id>/` layout.
+- **Phase 2 — lifecycle mapping**: model project states.
+- **Phase 3 — CLI surface**: design `aidevops project new|list|status|link|archive`.
+
+## Acceptance
+
+- Something'
+
+gh22534_output=$(_parse_phases_section "$PARENT_BODY_GH22534")
+gh22534_count=$(printf '%s\n' "$gh22534_output" | grep -c '^[0-9]')
+gh22534_p3_desc=$(printf '%s\n' "$gh22534_output" | sed -n '3p' | cut -f2)
+gh22534_p3_child=$(printf '%s\n' "$gh22534_output" | sed -n '3p' | cut -f4)
+
+if [[ "$gh22534_count" -eq 3 ]]; then
+	pass "Bullet-wrapped bold phases parsed: 3 rows"
+else
+	fail "Expected 3 bullet-wrapped bold phases, got ${gh22534_count}" "Output: ${gh22534_output}"
+fi
+
+if [[ "$gh22534_p3_desc" == *'new|list|status|link|archive'* && -z "$gh22534_p3_child" ]]; then
+	pass "CLI pipe prose remains description text, not a child ref"
+else
+	fail "CLI pipe prose parsed incorrectly" "desc='${gh22534_p3_desc}' child='${gh22534_p3_child}'"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Bootstraps phase-only parent-task issues by parsing bullet-wrapped bold phase plans, filing the first unfiled phase before advisory nudges, and making scanner/status output explicit for zero-child phase plans.

## Files Changed

.agents/reference/parent-task-lifecycle.md,.agents/scripts/auto-decomposer-scanner.sh,.agents/scripts/parent-status-helper.sh,.agents/scripts/pulse-issue-reconcile-actions.sh,.agents/scripts/shared-phase-filing.sh,.agents/scripts/tests/test-auto-decomposer-scanner.sh,.agents/scripts/tests/test-parent-task-lifecycle.sh,.agents/scripts/tests/test-shared-phase-filing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shared-phase-filing.sh; bash .agents/scripts/tests/test-parent-task-lifecycle.sh; bash .agents/scripts/tests/test-auto-decomposer-scanner.sh; shellcheck changed shell scripts

Resolves #22534


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 14m and 193,478 tokens on this as a headless worker.