### PR TITLE
t3541: fix: add REST fallback for GraphQL-limited full-loop merge

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -115,6 +115,60 @@ ${_sig_footer}"
 
 # --- Merge Execution ---
 
+# _merge_output_is_graphql_rate_limit — classify GitHub CLI GraphQL quota failures.
+#
+# Args: merge_output
+# Returns: 0 when the failure is specifically a GraphQL rate-limit/transport
+# exhaustion class; 1 for policy, checks, conflict, and generic merge errors.
+_merge_output_is_graphql_rate_limit() {
+	local merge_output="$1"
+
+	printf '%s' "$merge_output" | grep -qiE 'GraphQL:.*API rate limit|GraphQL.*rate limit|rateLimitExceeded'
+	return $?
+}
+
+# _merge_rest_fallback — squash/merge/rebase a PR via the REST pull merge endpoint.
+#
+# This is a transport fallback only. It is called after review-bot-gate has
+# passed and only when `gh pr merge` failed because its GraphQL path was rate
+# limited. The REST endpoint still enforces branch protection and mergeability;
+# failures remain failures.
+#
+# Args: pr_number repo merge_method
+# Returns: 0 = merged, 1 = REST merge failed
+_merge_rest_fallback() {
+	local pr_number="$1"
+	local repo="$2"
+	local merge_method="$3"
+	local rest_method="${merge_method#--}"
+	local rest_out="" rest_rc=0
+
+	case "$rest_method" in
+	squash | merge | rebase) ;;
+	*)
+		print_error "Unsupported merge method for REST fallback: ${merge_method}"
+		return 1
+		;;
+	esac
+
+	print_info "GraphQL rate limit blocked gh pr merge; retrying via REST pull merge endpoint..."
+	if rest_out=$(gh api -X PUT "repos/${repo}/pulls/${pr_number}/merge" \
+		-f "merge_method=${rest_method}" 2>&1); then
+		rest_rc=0
+	else
+		rest_rc=$?
+	fi
+
+	printf '%s\n' "$rest_out"
+	if [[ $rest_rc -eq 0 ]]; then
+		print_success "PR #${pr_number} merged via REST fallback (${rest_method})"
+		return 0
+	fi
+
+	print_error "REST merge fallback failed for PR #${pr_number}"
+	return 1
+}
+
 # _merge_execute — attempt `gh pr merge` with optional --admin fallback on branch-protection errors.
 #
 # GH#18538: branch protection that requires an approving review rejects plain
@@ -158,8 +212,14 @@ _merge_execute() {
 
 	if [[ $_merge_rc -ne 0 ]]; then
 		printf '%s\n' "$_merge_out"
+		# Only use REST fallback for GraphQL quota transport failures after the
+		# caller reached the merge execution stage (cmd_merge runs review-bot-gate
+		# first). Do not turn --auto into an immediate REST merge.
+		if [[ $has_auto -eq 0 ]] && _merge_output_is_graphql_rate_limit "$_merge_out"; then
+			_merge_rest_fallback "$pr_number" "$repo" "$merge_method" && return 0
+			return 1
 		# Only fall back to --admin when caller passed neither --admin nor --auto.
-		if [[ $has_admin -eq 0 && $has_auto -eq 0 ]] &&
+		elif [[ $has_admin -eq 0 && $has_auto -eq 0 ]] &&
 			printf '%s' "$_merge_out" | grep -qE 'base branch policy prohibits|Required status checks? (is|are) expected|At least [0-9]+ approving review'; then
 			print_info "Branch protection blocked plain merge; retrying with --admin (workers share the maintainer's gh auth per GH#18538)..."
 			if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin 2>&1; then

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -7,6 +7,8 @@
 #   1. Admin fallback fires all three signaling artifacts (PR comment, audit log, label)
 #   2. Explicit --admin caller does NOT trigger extra signaling (back-compat)
 #   3. Non-branch-protection errors do NOT trigger fallback
+#   4. GraphQL rate-limit errors fall back to REST pull merge after the gate
+#   5. Review-gate failures prevent both CLI merge and REST fallback
 #
 # Strategy: stub gh, audit-log-helper.sh, and gh-signature-helper.sh in a temp
 # directory prepended to PATH, then source the functions from full-loop-helper.sh.
@@ -78,6 +80,8 @@ teardown_test_env() {
 #   $1 = "fallback" — first merge fails with branch-protection error, --admin succeeds
 #   $2 = "explicit-admin" — merge with --admin succeeds immediately (no fallback)
 #   $3 = "other-error" — merge fails with non-branch-protection error
+#   $4 = "graphql-rate-limit" — gh pr merge fails with GraphQL quota, REST succeeds
+#   $5 = "graphql-rate-limit-rest-fail" — gh pr merge fails with GraphQL quota, REST fails
 create_gh_stub() {
 	local mode="$1"
 
@@ -111,7 +115,20 @@ if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
 	elif [[ "$mode" == "other-error" ]]; then
 		echo "Something completely different went wrong" >&2
 		exit 1
+	elif [[ "$mode" == "graphql-rate-limit" || "$mode" == "graphql-rate-limit-rest-fail" ]]; then
+		echo "GraphQL: API rate limit already exceeded for user ID 12345. (rateLimitExceeded)" >&2
+		exit 1
 	fi
+fi
+
+if [[ "\$_gh_cmd" == "api" ]]; then
+	echo "gh api \$*" >> "${TEST_ROOT}/logs/gh-api-calls.txt"
+	if [[ "$mode" == "graphql-rate-limit-rest-fail" ]]; then
+		echo "REST merge failed" >&2
+		exit 1
+	fi
+	echo '{"merged":true,"message":"Pull Request successfully merged"}'
+	exit 0
 fi
 
 if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "comment" ]]; then
@@ -132,9 +149,8 @@ GHSTUB
 }
 
 # Run _merge_execute in an isolated subprocess.
-# Sources full-loop-helper.sh with init lines stripped (SCRIPT_DIR assignment,
-# shared-constants source, readonly SCRIPT_DIR, and main "$@" call) so we get
-# all function definitions without side effects.
+# Sources the full-loop merge sub-library directly with shared constants loaded
+# so we get merge functions without invoking the full-loop main entrypoint.
 # Args: pr_number repo merge_method has_admin has_auto
 run_merge_execute() {
 	local pr_number="$1"
@@ -145,7 +161,7 @@ run_merge_execute() {
 
 	local scripts_dir="${SCRIPT_DIR}/.."
 
-	# Build a temporary script that sources the helper with init lines stripped.
+	# Build a temporary script that sources the merge helper in isolation.
 	# Using a temp file avoids heredoc/process-substitution escaping issues with $.
 	local tmp_runner=""
 	tmp_runner=$(mktemp)
@@ -154,13 +170,42 @@ run_merge_execute() {
 set -euo pipefail
 SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
-# Strip: line 10 (SCRIPT_DIR=), line 11 (source shared-constants), line 13 (readonly SCRIPT_DIR), last line (main "\$@")
-source <(sed -e '10d' -e '11d' -e '13d' -e '\$d' '${HELPER_SCRIPT}')
+source '${scripts_dir}/full-loop-helper-merge.sh'
 _merge_execute '$pr_number' '$repo' '$merge_method' '$has_admin' '$has_auto'
 RUNNER_EOF
 	chmod +x "$tmp_runner"
 
 	# Run in a subprocess with our stubs on PATH
+	local rc=0
+	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
+		AIDEVOPS_MODEL="test-model" \
+		bash "$tmp_runner" 2>&1 || rc=$?
+	rm -f "$tmp_runner"
+	return $rc
+}
+
+# Run cmd_merge in an isolated subprocess with a controlled review-bot gate.
+# Args: pr_number repo gate_rc
+run_cmd_merge_with_gate() {
+	local pr_number="$1"
+	local repo="$2"
+	local gate_rc="$3"
+	local scripts_dir="${SCRIPT_DIR}/.."
+	local tmp_runner=""
+	tmp_runner=$(mktemp)
+	cat >"$tmp_runner" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${scripts_dir}'
+source '${scripts_dir}/shared-constants.sh'
+source '${scripts_dir}/full-loop-helper-merge.sh'
+cmd_pre_merge_gate() { return '${gate_rc}'; }
+_retarget_stacked_children_interactive() { return 0; }
+release_interactive_claim_on_merge() { return 0; }
+cmd_merge '$pr_number' '$repo'
+RUNNER_EOF
+	chmod +x "$tmp_runner"
+
 	local rc=0
 	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
 		AIDEVOPS_MODEL="test-model" \
@@ -274,6 +319,67 @@ test_other_error_no_fallback() {
 	return 0
 }
 
+# Test 4: GraphQL rate-limit failures use the REST pull merge endpoint.
+test_graphql_rate_limit_rest_fallback() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "graphql-rate-limit"
+
+	local exit_code=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "0" "0" >/dev/null 2>&1 || exit_code=$?
+	print_result "GraphQL rate-limit: REST fallback succeeds" "$exit_code"
+
+	local rest_called=0
+	if [[ -f "${TEST_ROOT}/logs/gh-api-calls.txt" ]] &&
+		grep -q "repos/testorg/testrepo/pulls/42/merge" "${TEST_ROOT}/logs/gh-api-calls.txt" &&
+		grep -q "merge_method=squash" "${TEST_ROOT}/logs/gh-api-calls.txt"; then
+		rest_called=1
+	fi
+	print_result "GraphQL rate-limit: REST pull merge endpoint called" "$((1 - rest_called))"
+
+	return 0
+}
+
+# Test 5: REST fallback is not used for --auto because it would merge immediately.
+test_graphql_rate_limit_auto_no_rest_fallback() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "graphql-rate-limit"
+
+	local exit_code=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "0" "1" >/dev/null 2>&1 || exit_code=$?
+	print_result "GraphQL rate-limit with --auto: merge fails without immediate REST merge" "$((exit_code == 0 ? 1 : 0))"
+
+	local rest_called=0
+	[[ -f "${TEST_ROOT}/logs/gh-api-calls.txt" ]] && rest_called=1
+	print_result "GraphQL rate-limit with --auto: REST fallback not called" "$rest_called"
+
+	return 0
+}
+
+# Test 6: Review-bot gate failure prevents both gh pr merge and REST fallback.
+test_review_gate_failure_blocks_rest_fallback() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "graphql-rate-limit"
+
+	local exit_code=0
+	run_cmd_merge_with_gate "42" "testorg/testrepo" "1" >/dev/null 2>&1 || exit_code=$?
+	print_result "review gate failure: cmd_merge exits non-zero" "$((exit_code == 0 ? 1 : 0))"
+
+	local merge_called=0
+	if [[ -f "${TEST_ROOT}/logs/gh-calls.txt" ]] && grep -q "pr merge" "${TEST_ROOT}/logs/gh-calls.txt"; then
+		merge_called=1
+	fi
+	print_result "review gate failure: gh pr merge not called" "$merge_called"
+
+	local rest_called=0
+	[[ -f "${TEST_ROOT}/logs/gh-api-calls.txt" ]] && rest_called=1
+	print_result "review gate failure: REST fallback not called" "$rest_called"
+
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -284,6 +390,9 @@ main() {
 	test_admin_fallback_signals
 	test_explicit_admin_no_signaling
 	test_other_error_no_fallback
+	test_graphql_rate_limit_rest_fallback
+	test_graphql_rate_limit_auto_no_rest_fallback
+	test_review_gate_failure_blocks_rest_fallback
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Added a REST pull-merge fallback for GraphQL rate-limit failures after the full-loop review gate has passed, while preserving policy/conflict/check failure behavior.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh,.agents/scripts/tests/test-full-loop-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-full-loop-merge.sh; shellcheck .agents/scripts/full-loop-helper-merge.sh .agents/scripts/tests/test-full-loop-merge.sh

Resolves #22556


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 118,350 tokens on this as a headless worker.