### PR TITLE
t3524: add feedback retention and sensitivity policy

### DIFF
--- a/.agents/aidevops/feedback.md
+++ b/.agents/aidevops/feedback.md
@@ -72,6 +72,72 @@ Capture files MAY add optional routing fields (`case`, `project`, `campaign`,
 `tags`, `language`, `import_batch`) when known. Optional fields must not replace
 the required provenance, consent, sensitivity, and retention metadata above.
 
+## Retention and Sensitivity Policy
+
+Raw feedback is evidence, not durable knowledge. Every retained capture MUST have
+a sensitivity tier, consent/provenance note, and retention outcome before mining
+or promotion. When Markdoc-style tags become available, stamp the capture or
+region with `{% sensitivity tier="..." /%}` and keep the metadata value aligned
+until the tag schema becomes canonical.
+
+### Sensitivity Tiers
+
+| Tier | Use for | Default handling |
+|------|---------|------------------|
+| `public` | Already-public comments, public issues, public reviews, or quoted material cleared for reuse. | May be retained long-lived and summarized publicly when provenance allows. |
+| `internal` | Operator notes, private team observations, internal support summaries, or non-public product feedback without client identifiers. | Retain locally; promote only summarized, provenance-backed excerpts. |
+| `client-scoped` | Feedback tied to a named client, account, project, private engagement, or case. | Keep scoped to that client/project/case; public surfaces receive anonymized summaries only. |
+| `privileged` | Legal, HR, finance, contract, security-response, or other privileged case notes. | Keep local and access-restricted; promotion requires explicit approval and usually targets `_cases/` only. |
+| `personal` | Personal data, private contact details, health/family/employment details, or unique actor identifiers. | Anonymize before mining or promotion; delete raw details when no longer needed. |
+| `delete-after-review` | Accidental captures, unsupported consent, sensitive one-off reports, or content the source revoked. | Review once, record a non-sensitive disposition, then delete or retire raw content. |
+
+### Retention Outcomes
+
+| Outcome | Meaning | Allowed promotion |
+|---------|---------|-------------------|
+| `long-lived` | Capture may remain as evidence with provenance and a stable ID. | `_knowledge/`, `_campaigns/`, `_projects/`, `_performance/`, or tasks when review gates pass. |
+| `anonymized` | Raw identifying details are removed or replaced with placeholders before reuse. | Durable planes receive only redacted excerpts, actor segments, counts, hashes, and source IDs. |
+| `client-scoped` | Capture remains inside the relevant client/project/case boundary. | `_cases/` or `_projects/` for that scope; public TODO/GitHub tasks get privacy-safe summaries. |
+| `privileged-local` | Raw content is retained only in local/private storage for privileged review. | `_cases/` only after approval; never public issues, PRs, TODO entries, or shared docs. |
+| `deleted` / `retired` | Raw feedback is removed, revoked, obsolete, duplicate, or consent-expired. | No raw promotion; keep only a minimal audit note with capture ID, reason, and date when safe. |
+
+### Consent, Provenance, and Promotion Constraints
+
+- Promotion into `_knowledge/` requires `public`, `internal`, or already
+  `anonymized` evidence with enough provenance to recheck the source. Personal,
+  client-scoped, and privileged captures must be summarized before they become
+  reusable knowledge.
+- Promotion into `_campaigns/` may use public language, anonymized themes, or
+  aggregated objections. Do not copy client names, private competitive notes, or
+  personal details into campaign research unless the campaign plane is scoped to
+  the same authorized audience.
+- Promotion into `_projects/` may preserve client/project context only when the
+  project scope matches the feedback scope. Cross-project requirements use
+  anonymized segments, not actor names.
+- Promotion into `_cases/` can retain client-scoped and privileged context, but
+  must keep provenance, access scope, and approval state visible to authorized
+  reviewers.
+- TODO/GitHub tasks receive the smallest privacy-safe summary: problem, segment,
+  evidence count, severity, affected files or decision surface, and verification.
+  Raw captures, private repo names, personal details, and privileged notes stay in
+  `_feedback/` or the scoped case/project store.
+
+### Placeholder Examples
+
+- `public + long-lived`: a public issue comment reports confusion in a setup step;
+  promote a summarized theme with the public issue reference.
+- `client-scoped + client-scoped`: `<client>` asks for clearer report labels in a
+  private delivery call; keep the raw note under that case and create only a
+  public-safe task summary.
+- `personal + anonymized`: `<user-segment>` mentions a personal circumstance while
+  describing onboarding friction; remove the personal detail and retain only the
+  onboarding theme.
+- `privileged + privileged-local`: `<case-id>` includes legal advice about a
+  contract dispute; keep it local to `_cases/` and do not mine it for general
+  knowledge without explicit approval.
+- `delete-after-review + deleted`: a capture has revoked consent; record the
+  deletion reason and do not promote the raw content.
+
 ## Mining Loop
 
 Mining MUST be recoverable from cold start. Each stage reads the current capture

--- a/todo/tasks/t3478-brief.md
+++ b/todo/tasks/t3478-brief.md
@@ -48,7 +48,9 @@ This is a parent-task. Initial planning PR uses `For #` keyword (planning only).
   filed child owns `_feedback/captures/` and the required source/timestamp/
   actor/context/channel/sentiment/sensitivity/consent/retention/provenance
   capture metadata in `.agents/aidevops/feedback.md`.
-- t3524 / #22512 — Phase 2: retention and sensitivity policy.
+- t3524 / #22512 — Phase 2: retention and sensitivity policy; filed child owns
+  retention outcomes, sensitivity tiers, anonymization requirements, and
+  cross-plane promotion constraints in `.agents/aidevops/feedback.md`.
 - t3525 / #22515 — Phase 3: mining workflow and evidence thresholds; filed as
   the child that documents clustering, deduplication, review gates, and promotion
   thresholds in `.agents/aidevops/feedback.md`.
@@ -64,7 +66,7 @@ This is a parent-task. Initial planning PR uses `For #` keyword (planning only).
 Decomposition planned as 5 phases:
 
 - **Phase 1 — capture contract**: define `_feedback/captures/` and normalized fields for source, timestamp, actor/segment, context, channel, sentiment, sensitivity, and consent/retention.
-- **Phase 2 — retention and sensitivity policy**: define which feedback can be long-lived, anonymized, privileged, client-scoped, or deleted; align with Markdoc sensitivity tags when available.
+- **Phase 2 — retention and sensitivity policy**: define which feedback can be long-lived, anonymized, privileged, client-scoped, or deleted; align with Markdoc sensitivity tags when available. Child #22512 owns this policy without closing parent #22373.
 - **Phase 3 — mining workflow**: design clustering, deduplication, theme extraction, evidence thresholds, and review gates before promotion.
 - **Phase 4 — promotion paths**: specify when feedback becomes `_knowledge/insights/`, a `_campaigns` research input, a `_projects` requirement, a `_cases` note, or a new TODO/GitHub task.
 - **Phase 5 — CLI and routines**: design `aidevops feedback capture|list|mine|promote|retire` plus recurring mining/reporting cadence; child #22519 owns the design contract without closing parent #22373.


### PR DESCRIPTION
## Summary

Added feedback retention and sensitivity policy sections covering tiers, outcomes, anonymization requirements, consent/provenance constraints, and placeholder examples; updated the parent brief to link Phase 2 child #22512.

## Files Changed

.agents/aidevops/feedback.md,todo/tasks/t3478-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n 'retention|anonym|privileged|client-scoped|delete' .agents/aidevops/feedback.md; rg -n 'Phase 2|#22512' todo/tasks/t3478-brief.md; npx --yes markdownlint-cli2 .agents/aidevops/feedback.md todo/tasks/t3478-brief.md

Resolves #22512


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33