### PR TITLE
GH#22561: add fine-grained PAT scrub coverage

### DIFF
--- a/.agents/scripts/contributor-insight-helper.sh
+++ b/.agents/scripts/contributor-insight-helper.sh
@@ -89,7 +89,7 @@ sanitize_text() {
 	# Word-boundary anchor — see shared-constants.sh::scrub_credentials for the
 	# t2892 rationale. Mid-word matches like `task-failure-handler` must not be
 	# corrupted into `ta[redacted-credential]`.
-	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
+	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
 
 	# 4. Strip email addresses
 	text=$(printf '%s' "$text" | sed -E 's/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/[email]/g')

--- a/.agents/scripts/tests/test-contributor-insight-helper.sh
+++ b/.agents/scripts/tests/test-contributor-insight-helper.sh
@@ -172,6 +172,12 @@ assert_contains "credential replacement present" "[redacted-credential]" "$resul
 result=$(bash "$HELPER" sanitize "Use ghp_1234567890abcdefghijklmnop for auth")
 assert_not_contains "GH token redacted" "ghp_1234567890" "$result"
 
+# Test 4b: Fine-grained GitHub PATs are redacted
+fake_fine_grained_pat="github_pat_abcdefghij1234567890"
+result=$(bash "$HELPER" sanitize "Use ${fake_fine_grained_pat} for auth")
+assert_not_contains "fine-grained GH token redacted" "$fake_fine_grained_pat" "$result"
+assert_contains "fine-grained GH replacement present" "[redacted-credential]" "$result"
+
 # Test 5: Email addresses are redacted
 result=$(bash "$HELPER" sanitize "Contact user@company.com for access")
 assert_not_contains "email redacted" "user@company.com" "$result"


### PR DESCRIPTION
## Summary

Added github_pat_ to contributor insight credential scrubbing and covered it with a focused sanitizer regression test.

## Files Changed

.agents/scripts/contributor-insight-helper.sh,.agents/scripts/tests/test-contributor-insight-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/contributor-insight-helper.sh .agents/scripts/tests/test-contributor-insight-helper.sh; bash .agents/scripts/tests/test-contributor-insight-helper.sh

Resolves #22561


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 72,152 tokens on this as a headless worker.