### PR TITLE
GH#22565: filter maintainer comments by since

### DIFF
--- a/.agents/scripts/auto-decomposer-scanner.sh
+++ b/.agents/scripts/auto-decomposer-scanner.sh
@@ -340,7 +340,7 @@ _has_recent_maintainer_comment() {
 
 	local count api_path
 	api_path=$(_issue_comments_api_path "$repo" "$issue_num")
-	count=$(gh api --paginate "$api_path" \
+	count=$(gh api --method GET --paginate "$api_path" -f since="$cutoff_iso" \
 		--jq "[.[] | select(.created_at > \"${cutoff_iso}\")
 			| select(.author_association == \"OWNER\" or .author_association == \"MEMBER\")
 			| select(.body | contains(\"<!-- parent-needs-decomposition -->\") | not)
@@ -350,7 +350,10 @@ _has_recent_maintainer_comment() {
 		] | length" \
 		2>/dev/null || echo "0")
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
-	[[ "$count" -gt 0 ]]
+	if [[ "$count" -gt 0 ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # GH#21017: Compute the ISO-8601 UTC timestamp `lookback_hours` ago.

--- a/.agents/scripts/tests/test-auto-decomposer-scanner.sh
+++ b/.agents/scripts/tests/test-auto-decomposer-scanner.sh
@@ -279,6 +279,12 @@ assert_grep "16d: _extract_children_from_body helper defined" \
 assert_grep "16e: _has_recent_maintainer_comment helper defined" \
 	'^_has_recent_maintainer_comment\(\) \{' "$SCANNER"
 
+assert_grep_fixed "16e2: recent maintainer comment API uses server-side since filter" \
+	'gh api --method GET --paginate "$api_path" -f since="$cutoff_iso"' "$SCANNER"
+
+assert_grep_fixed "16e3: recent maintainer comment preserves created_at cutoff semantics" \
+	'| select(.created_at > \"${cutoff_iso}\")' "$SCANNER"
+
 assert_grep "16f: _iso_cutoff_hours_ago helper defined" \
 	'^_iso_cutoff_hours_ago\(\) \{' "$SCANNER"
 


### PR DESCRIPTION
## Summary

Optimized auto-decomposer maintainer-comment lookups by adding a GitHub API since query while preserving the existing created_at cutoff semantics, with regression coverage.

## Files Changed

.agents/scripts/auto-decomposer-scanner.sh,.agents/scripts/tests/test-auto-decomposer-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/auto-decomposer-scanner.sh .agents/scripts/tests/test-auto-decomposer-scanner.sh; .agents/scripts/tests/test-auto-decomposer-scanner.sh

Resolves #22565


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 73,772 tokens on this as a headless worker.