### PR TITLE
GH#22564: tighten external content spam detector followups

### DIFF
--- a/.agents/scripts/external-content-spam-detector.sh
+++ b/.agents/scripts/external-content-spam-detector.sh
@@ -141,14 +141,20 @@ _priv_extract_external_hosts() {
 	local h
 	for h in $EXCLUDE_HOSTS_RAW; do
 		[[ -z "$h" ]] && continue
-		# Escape dots in the literal host before assembling the alternation.
-		local escaped="${h//./\\.}"
+		# Match extraction's lowercase hosts, then escape dots in the literal host.
+		local h_lower
+		h_lower=$(printf '%s' "$h" | tr '[:upper:]' '[:lower:]')
+		local escaped="${h_lower//./\\.}"
 		if [[ -z "$excl_re" ]]; then
 			excl_re="(^|\.)${escaped}\$"
 		else
 			excl_re="${excl_re}|(^|\.)${escaped}\$"
 		fi
 	done
+	local grep_exclude=(cat)
+	if [[ -n "$excl_re" ]]; then
+		grep_exclude=(grep -vE "$excl_re")
+	fi
 
 	# Extract URLs (http/https), strip scheme, take the host portion (up to
 	# first / : ? # ), lowercase, then drop excluded hosts.
@@ -156,7 +162,7 @@ _priv_extract_external_hosts() {
 		grep -oEi 'https?://[A-Za-z0-9.-]+' 2>/dev/null |
 		sed -E 's|^https?://||I' |
 		tr '[:upper:]' '[:lower:]' |
-		grep -vE "${excl_re}" 2>/dev/null || true
+		"${grep_exclude[@]}" 2>/dev/null || true
 	return 0
 }
 
@@ -210,7 +216,9 @@ _priv_get_author_association() {
 	*) endpoint="repos/${slug}/issues/${num}" ;;
 	esac
 	local assoc
-	assoc=$(gh api "$endpoint" --jq ".author_association // \"${ECSD_UNKNOWN_ASSOC}\"" 2>/dev/null || echo "$ECSD_UNKNOWN_ASSOC")
+	if ! assoc=$(gh api "$endpoint" --jq ".author_association // \"${ECSD_UNKNOWN_ASSOC}\"" 2>/dev/null); then
+		assoc="$ECSD_UNKNOWN_ASSOC"
+	fi
 	[[ -z "$assoc" ]] && assoc="$ECSD_UNKNOWN_ASSOC"
 	echo "$assoc"
 	return 0
@@ -275,13 +283,16 @@ _priv_get_body() {
 }
 
 # Compose composite score and pipe-delimited breakdown.
-# Args: $1 = body, $2 = type, $3 = number, $4 = slug
+# Args: $1 = body, $2 = type, $3 = number, $4 = slug, $5 = optional precomputed author_association
 # Output: score|verdict|assoc=X|domain_max=N|patterns=N|fileline=N
 _priv_compute_score() {
 	local body="$1" type="$2" num="$3" slug="$4"
 
 	local assoc
-	assoc=$(_priv_get_author_association "$type" "$num" "$slug")
+	assoc="${5:-}"
+	if [[ -z "$assoc" ]]; then
+		assoc=$(_priv_get_author_association "$type" "$num" "$slug")
+	fi
 	local non_collab
 	non_collab=$(_priv_is_non_collaborator "$assoc")
 
@@ -441,16 +452,24 @@ cmd_score() {
 	result=$(_priv_compute_score "$body" "$type" "$num" "$slug")
 
 	if [[ "$json" -eq 1 ]]; then
-		# Convert pipe-delimited output to JSON object for programmatic use.
-		local score verdict assoc domain patterns fileline
-		score=$(printf '%s' "$result" | cut -d'|' -f1)
-		verdict=$(printf '%s' "$result" | cut -d'|' -f2)
-		assoc=$(printf '%s' "$result" | cut -d'|' -f3 | cut -d'=' -f2)
-		domain=$(printf '%s' "$result" | cut -d'|' -f4 | cut -d'=' -f2)
-		patterns=$(printf '%s' "$result" | cut -d'|' -f5 | cut -d'=' -f2)
-		fileline=$(printf '%s' "$result" | cut -d'|' -f6 | cut -d'=' -f2)
-		printf '{"type":"%s","number":%d,"repo":"%s","score":%d,"verdict":"%s","author_association":"%s","domain_max":%d,"patterns":%d,"fileline_refs":%d}\n' \
-			"$type" "$num" "$slug" "$score" "$verdict" "$assoc" "$domain" "$patterns" "$fileline"
+		# Use jq to keep JSON valid if string fields contain special characters.
+		local score verdict assoc_raw domain_raw patterns_raw fileline_raw
+		IFS='|' read -r score verdict assoc_raw domain_raw patterns_raw fileline_raw <<<"$result"
+		local assoc="${assoc_raw#*=}"
+		local domain="${domain_raw#*=}"
+		local patterns="${patterns_raw#*=}"
+		local fileline="${fileline_raw#*=}"
+		jq -n \
+			--arg type "$type" \
+			--argjson number "$num" \
+			--arg repo "$slug" \
+			--argjson score "$score" \
+			--arg verdict "$verdict" \
+			--arg author_association "$assoc" \
+			--argjson domain_max "$domain" \
+			--argjson patterns "$patterns" \
+			--argjson fileline_refs "$fileline" \
+			'{type: $type, number: $number, repo: $repo, score: $score, verdict: $verdict, author_association: $author_association, domain_max: $domain_max, patterns: $patterns, fileline_refs: $fileline_refs}'
 	else
 		printf '%s\n' "$result"
 	fi
@@ -486,27 +505,32 @@ cmd_batch() {
 
 	_ecsd_log_info "Scanning open issues with label=${label} in ${slug} (dry-run=$([[ $apply -eq 0 ]] && echo yes || echo no))"
 
-	# Use shared wrapper so REST fallback kicks in under GraphQL pressure.
+	# Fetch body + author association in one REST sweep, avoiding per-issue API calls.
+	local label_q
+	label_q=$(jq -rn --arg label "$label" '$label | @uri')
 	local issues
-	issues=$(gh_issue_list --repo "$slug" --state open --label "$label" \
-		--limit 200 --json number --jq '.[].number' 2>/dev/null || true)
+	issues=$(gh api --paginate "repos/${slug}/issues?state=open&labels=${label_q}&per_page=100" \
+		--jq '.[] | select(.pull_request | not) | {number, body: (.body // ""), author_association: (.author_association // "UNKNOWN")} | @base64' \
+		2>/dev/null || true)
 
 	if [[ -z "$issues" ]]; then
 		_ecsd_log_info "No open issues with label=${label}"
 		return 0
 	fi
 
-	local n
-	while IFS= read -r n; do
-		[[ -z "$n" ]] && continue
-		local body
-		body=$(_priv_get_body "issue" "$n" "$slug")
+	local row
+	while IFS= read -r row; do
+		[[ -z "$row" ]] && continue
+		local n body assoc
+		n=$(jq -rn --arg row "$row" '$row | @base64d | fromjson | .number')
+		body=$(jq -rn --arg row "$row" '$row | @base64d | fromjson | .body // ""')
+		assoc=$(jq -rn --arg row "$row" '$row | @base64d | fromjson | .author_association // "UNKNOWN"')
 		if [[ -z "$body" ]]; then
 			printf 'issue#%s\tERROR\tcould not fetch body\n' "$n"
 			continue
 		fi
 		local result
-		result=$(_priv_compute_score "$body" "issue" "$n" "$slug")
+		result=$(_priv_compute_score "$body" "issue" "$n" "$slug" "$assoc")
 		local verdict
 		verdict=$(printf '%s' "$result" | cut -d'|' -f2)
 		printf 'issue#%s\t%s\t%s\n' "$n" "$verdict" "$result"
@@ -536,7 +560,7 @@ EXIT CODES (check):
   3  error               could not fetch body / resolve repo / parse args
 
 SCORING (composed):
-  +3  non-collaborator author     (author_association not OWNER/MEMBER/COLLABORATOR)
+  +2  non-collaborator author     (author_association not OWNER/MEMBER/COLLABORATOR)
   +2  any external host appears >=ECSD_DOMAIN_REPEAT_MIN times (default 3)
   +1  per pattern match in unsolicited_disclosure_marketing category
   +1  >=ECSD_FILELINE_MIN evidence-styled file:line refs (default 3)

--- a/.agents/scripts/tests/test-external-content-spam-detector.sh
+++ b/.agents/scripts/tests/test-external-content-spam-detector.sh
@@ -131,64 +131,110 @@ test_C_max_host_repetition_zero_when_only_github() {
 	return 0
 }
 
-test_D_count_fileline_refs_counts_known_extensions() {
+test_D_extract_external_hosts_handles_empty_exclusions() {
+	EXCLUDE_HOSTS_RAW=""
+
+	local body="https://github.com/foo https://example.com/bar"
+	local hosts
+	hosts=$(_priv_extract_external_hosts "$body")
+
+	local github_present
+	github_present=$(printf '%s\n' "$hosts" | grep -c '^github\.com$' || true)
+	[[ "$github_present" =~ ^[0-9]+$ ]] || github_present=0
+	local example_present
+	example_present=$(printf '%s\n' "$hosts" | grep -c '^example\.com$' || true)
+	[[ "$example_present" =~ ^[0-9]+$ ]] || example_present=0
+
+	if [[ "$github_present" -eq 1 && "$example_present" -eq 1 ]]; then
+		print_result "D: extract_external_hosts keeps hosts when exclusion list is empty" 0
+	else
+		print_result "D: extract_external_hosts keeps hosts when exclusion list is empty" 1 \
+			"github_present=$github_present example_present=$example_present (wanted 1/1)"
+	fi
+	return 0
+}
+
+test_E_extract_external_hosts_lowercases_exclusions() {
+	EXCLUDE_HOSTS_RAW="GitHub.COM"
+
+	local body="https://github.com/foo https://api.github.com/bar https://example.com/baz"
+	local hosts
+	hosts=$(_priv_extract_external_hosts "$body")
+
+	local github_present
+	github_present=$(printf '%s\n' "$hosts" | grep -c 'github\.com$' || true)
+	[[ "$github_present" =~ ^[0-9]+$ ]] || github_present=0
+	local example_present
+	example_present=$(printf '%s\n' "$hosts" | grep -c '^example\.com$' || true)
+	[[ "$example_present" =~ ^[0-9]+$ ]] || example_present=0
+
+	if [[ "$github_present" -eq 0 && "$example_present" -eq 1 ]]; then
+		print_result "E: extract_external_hosts lowercases exclusion hosts" 0
+	else
+		print_result "E: extract_external_hosts lowercases exclusion hosts" 1 \
+			"github_present=$github_present example_present=$example_present (wanted 0/1)"
+	fi
+	return 0
+}
+
+test_F_count_fileline_refs_counts_known_extensions() {
 	local body="See foo.sh:42, bar/baz.py:100, qux.json:7. Also random text. Not a ref: 1.2.3"
 	local count
 	count=$(_priv_count_fileline_refs "$body")
 
 	if [[ "$count" -eq 3 ]]; then
-		print_result "D: count_fileline_refs counts file:line for known extensions only" 0
+		print_result "F: count_fileline_refs counts file:line for known extensions only" 0
 	else
-		print_result "D: count_fileline_refs counts file:line for known extensions only" 1 \
+		print_result "F: count_fileline_refs counts file:line for known extensions only" 1 \
 			"count=$count (wanted 3)"
 	fi
 	return 0
 }
 
-test_E_count_fileline_refs_zero_for_no_refs() {
+test_G_count_fileline_refs_zero_for_no_refs() {
 	local body="A plain narrative bug report with no file references at all."
 	local count
 	count=$(_priv_count_fileline_refs "$body")
 
 	if [[ "$count" -eq 0 ]]; then
-		print_result "E: count_fileline_refs returns 0 for narrative text" 0
+		print_result "G: count_fileline_refs returns 0 for narrative text" 0
 	else
-		print_result "E: count_fileline_refs returns 0 for narrative text" 1 \
+		print_result "G: count_fileline_refs returns 0 for narrative text" 1 \
 			"count=$count (wanted 0)"
 	fi
 	return 0
 }
 
-test_F_is_non_collaborator_treats_owner_as_trusted() {
+test_H_is_non_collaborator_treats_owner_as_trusted() {
 	# TRUSTED_ASSOCIATIONS must be in scope for the helper.
 	TRUSTED_ASSOCIATIONS=("OWNER" "MEMBER" "COLLABORATOR")
 
 	local result
 	result=$(_priv_is_non_collaborator "OWNER")
 	if [[ "$result" -eq 0 ]]; then
-		print_result "F: is_non_collaborator returns 0 (trusted) for OWNER" 0
+		print_result "H: is_non_collaborator returns 0 (trusted) for OWNER" 0
 	else
-		print_result "F: is_non_collaborator returns 0 (trusted) for OWNER" 1 \
+		print_result "H: is_non_collaborator returns 0 (trusted) for OWNER" 1 \
 			"result=$result (wanted 0)"
 	fi
 	return 0
 }
 
-test_G_is_non_collaborator_treats_none_as_untrusted() {
+test_I_is_non_collaborator_treats_none_as_untrusted() {
 	TRUSTED_ASSOCIATIONS=("OWNER" "MEMBER" "COLLABORATOR")
 
 	local result
 	result=$(_priv_is_non_collaborator "NONE")
 	if [[ "$result" -eq 1 ]]; then
-		print_result "G: is_non_collaborator returns 1 (untrusted) for NONE" 0
+		print_result "I: is_non_collaborator returns 1 (untrusted) for NONE" 0
 	else
-		print_result "G: is_non_collaborator returns 1 (untrusted) for NONE" 1 \
+		print_result "I: is_non_collaborator returns 1 (untrusted) for NONE" 1 \
 			"result=$result (wanted 1)"
 	fi
 	return 0
 }
 
-test_H_is_non_collaborator_treats_contributor_as_untrusted() {
+test_J_is_non_collaborator_treats_contributor_as_untrusted() {
 	TRUSTED_ASSOCIATIONS=("OWNER" "MEMBER" "COLLABORATOR")
 
 	# Per the brief: only OWNER/MEMBER/COLLABORATOR are trusted; CONTRIBUTOR
@@ -196,9 +242,9 @@ test_H_is_non_collaborator_treats_contributor_as_untrusted() {
 	local result
 	result=$(_priv_is_non_collaborator "CONTRIBUTOR")
 	if [[ "$result" -eq 1 ]]; then
-		print_result "H: is_non_collaborator returns 1 (untrusted) for CONTRIBUTOR" 0
+		print_result "J: is_non_collaborator returns 1 (untrusted) for CONTRIBUTOR" 0
 	else
-		print_result "H: is_non_collaborator returns 1 (untrusted) for CONTRIBUTOR" 1 \
+		print_result "J: is_non_collaborator returns 1 (untrusted) for CONTRIBUTOR" 1 \
 			"result=$result (wanted 1)"
 	fi
 	return 0
@@ -208,36 +254,48 @@ test_H_is_non_collaborator_treats_contributor_as_untrusted() {
 # CLI smoke tests — no network
 # ============================================================
 
-test_I_help_command_succeeds() {
+test_K_help_command_succeeds() {
 	"$SCRIPT_UNDER_TEST" help >/dev/null 2>&1
 	local rc=$?
 	if [[ $rc -eq 0 ]]; then
-		print_result "I: help command exits 0" 0
+		print_result "K: help command exits 0" 0
 	else
-		print_result "I: help command exits 0" 1 "rc=$rc (wanted 0)"
+		print_result "K: help command exits 0" 1 "rc=$rc (wanted 0)"
 	fi
 	return 0
 }
 
-test_J_unknown_command_returns_error() {
+test_L_help_lists_non_collaborator_weight_two() {
+	local help_text
+	help_text=$("$SCRIPT_UNDER_TEST" help 2>/dev/null)
+	if printf '%s\n' "$help_text" | grep -q '^  +2  non-collaborator author'; then
+		print_result "L: help text lists non-collaborator weight as +2" 0
+	else
+		print_result "L: help text lists non-collaborator weight as +2" 1 \
+			"help text did not contain expected +2 scoring line"
+	fi
+	return 0
+}
+
+test_M_unknown_command_returns_error() {
 	"$SCRIPT_UNDER_TEST" not-a-real-command >/dev/null 2>&1
 	local rc=$?
 	# Helper exit 3 = error.
 	if [[ $rc -eq 3 ]]; then
-		print_result "J: unknown command exits 3 (error)" 0
+		print_result "M: unknown command exits 3 (error)" 0
 	else
-		print_result "J: unknown command exits 3 (error)" 1 "rc=$rc (wanted 3)"
+		print_result "M: unknown command exits 3 (error)" 1 "rc=$rc (wanted 3)"
 	fi
 	return 0
 }
 
-test_K_check_without_args_returns_error() {
+test_N_check_without_args_returns_error() {
 	"$SCRIPT_UNDER_TEST" check >/dev/null 2>&1
 	local rc=$?
 	if [[ $rc -eq 3 ]]; then
-		print_result "K: check without args exits 3" 0
+		print_result "N: check without args exits 3" 0
 	else
-		print_result "K: check without args exits 3" 1 "rc=$rc (wanted 3)"
+		print_result "N: check without args exits 3" 1 "rc=$rc (wanted 3)"
 	fi
 	return 0
 }
@@ -262,14 +320,17 @@ main() {
 	test_A_extract_external_hosts_strips_github
 	test_B_max_host_repetition_finds_top_host
 	test_C_max_host_repetition_zero_when_only_github
-	test_D_count_fileline_refs_counts_known_extensions
-	test_E_count_fileline_refs_zero_for_no_refs
-	test_F_is_non_collaborator_treats_owner_as_trusted
-	test_G_is_non_collaborator_treats_none_as_untrusted
-	test_H_is_non_collaborator_treats_contributor_as_untrusted
-	test_I_help_command_succeeds
-	test_J_unknown_command_returns_error
-	test_K_check_without_args_returns_error
+	test_D_extract_external_hosts_handles_empty_exclusions
+	test_E_extract_external_hosts_lowercases_exclusions
+	test_F_count_fileline_refs_counts_known_extensions
+	test_G_count_fileline_refs_zero_for_no_refs
+	test_H_is_non_collaborator_treats_owner_as_trusted
+	test_I_is_non_collaborator_treats_none_as_untrusted
+	test_J_is_non_collaborator_treats_contributor_as_untrusted
+	test_K_help_command_succeeds
+	test_L_help_lists_non_collaborator_weight_two
+	test_M_unknown_command_returns_error
+	test_N_check_without_args_returns_error
 
 	printf '\n=== %d test(s), %d failure(s) ===\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Fixed valid review followups in external-content-spam-detector: robust host exclusion handling, jq-based JSON output, batch REST bulk fetch with precomputed author associations, help text scoring weight, and gh api fallback handling.

## Files Changed

.agents/scripts/external-content-spam-detector.sh,.agents/scripts/tests/test-external-content-spam-detector.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/external-content-spam-detector.sh .agents/scripts/tests/test-external-content-spam-detector.sh; .agents/scripts/tests/test-external-content-spam-detector.sh; .agents/scripts/external-content-spam-detector.sh score issue 22564 --repo marcusquinn/aidevops --json

Resolves #22564


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 112,490 tokens on this as a headless worker.