### PR TITLE
GH#22566: add campaign asset safety checks

### DIFF
--- a/todo/tasks/t2870-brief.md
+++ b/todo/tasks/t2870-brief.md
@@ -50,7 +50,7 @@ Decomposition planned as 6 phases (children filed when t2840 MVP exits):
 - Phase 1 — `_campaigns/` directory contract + sub-folder structure (`lib/`, `intel/`, `active/`, `launched/`)
 - Phase 2 — campaign CLI surface (`aidevops campaign new|list|status|launch|archive`) + campaign-id provisioning
 - Phase 3 — sensitivity tier integration (`competitive` tier added to P0.5a sensitivity classifier; intel sub-folder enforces local-LLM-only)
-- Phase 4 — asset binary integration (large files routed to `~/.aidevops/.agent-workspace/knowledge-blobs/`; thumbnail/preview generation)
+- Phase 4 — asset binary integration (large files routed to `~/.aidevops/.agent-workspace/knowledge-blobs/` with path traversal validation and filename collision avoidance to prevent writes outside the managed workspace or accidental data loss; thumbnail/preview generation)
 - Phase 5 — AI creative agent (`aidevops campaign draft <id> --channel <name>`) — RAG-grounded in `lib/brand/`, human-gated, channel-aware
 - Phase 6 — performance integration + learnings promotion (`launched/<id>/results.md` → `_performance/marketing/`; `learnings.md` → `_knowledge/insights/marketing/`)
 


### PR DESCRIPTION
## Summary

Updated the t2870 campaign-plane parent brief so Phase 4 explicitly requires path traversal validation and filename collision avoidance for knowledge-blob asset routing.

## Files Changed

todo/tasks/t2870-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2 todo/tasks/t2870-brief.md

Resolves #22566


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 62,788 tokens on this as a headless worker.