### PR TITLE
GH#22562: harden opencode install validation

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1642,7 +1642,7 @@ _setup_validate_opencode_binary() {
 	[[ "$v" == *"(Claude Code)"* ]] && return 1
 
 	# opencode is at 1.x; any 2.x+ is wrong (claude CLI is 2.1.x).
-	[[ "$v" =~ ^[2-9][0-9]*\. ]] && return 1
+	[[ "$v" =~ ^([2-9]|[1-9][[:digit:]]+)\. ]] && return 1
 
 	# Sanity: must look like a semver (X.Y.Z).
 	[[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || return 1
@@ -1674,7 +1674,9 @@ _setup_opencode_force_heal() {
 	fi
 
 	local install_timeout="${AIDEVOPS_OPENCODE_INSTALL_TIMEOUT:-180}"
-	if run_with_spinner "Reinstalling OpenCode (heal)" _setup_opencode_timeout_cmd "$install_timeout" npm_global_install "$install_pkg"; then
+	# npm_global_install is the shared generic helper; despite its historic
+	# name, it uses bun when available and falls back to npm.
+	if run_with_spinner "Reinstalling OpenCode via $installer (heal)" _setup_opencode_timeout_cmd "$install_timeout" npm_global_install "$install_pkg"; then
 		print_success "OpenCode reinstalled via $installer"
 	else
 		print_warning "Heal install failed via $installer"
@@ -1692,8 +1694,11 @@ _setup_opencode_force_heal() {
 		printf '%s\n' "$new_bin" >"${HOME}/.aidevops/.opencode-bin-resolved" 2>/dev/null || true
 	else
 		local v_after
-		v_after=$(_setup_opencode_first_line "$(_setup_opencode_version_output "$new_bin" 2>/dev/null || printf '<missing>')")
-		print_warning "Post-heal validation still failing: '$new_bin' returns '$v_after'"
+		v_after="<missing>"
+		if [[ -n "$new_bin" ]] && [[ -x "$new_bin" ]]; then
+			v_after=$(_setup_opencode_first_line "$(_setup_opencode_version_output "$new_bin" 2>/dev/null || printf 'unknown')")
+		fi
+		print_warning "Post-heal validation still failing: '${new_bin:-opencode}' returns '$v_after'"
 		print_info "Check PATH: 'which -a opencode' — npm/bun global bin dir must come first"
 	fi
 	return 0
@@ -1716,11 +1721,7 @@ setup_opencode_cli() {
 	local current_bin
 	current_bin=$(command -v opencode 2>/dev/null || echo "")
 	local validate_rc=0
-	if [[ -n "$current_bin" ]]; then
-		_setup_validate_opencode_binary "$current_bin" || validate_rc=$?
-	else
-		validate_rc=2
-	fi
+	_setup_validate_opencode_binary "$current_bin" || validate_rc=$?
 
 	# Already valid → record + early return.
 	if [[ $validate_rc -eq 0 ]]; then

--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -76,7 +76,14 @@ source_extracted() {
 	# shellcheck disable=SC2317
 	print_warning() { echo "WARN: $*"; return 0; }
 	# shellcheck disable=SC2317
-	setup_prompt() { local _var="$1" _prompt="$2" _default="$3"; eval "$_var='$_default'"; return 0; }
+	setup_prompt() {
+		local _var="$1"
+		local _prompt="$2"
+		local _default="$3"
+		: "$_prompt"
+		printf -v "$_var" '%s' "$_default"
+		return $?
+	}
 	# shellcheck disable=SC2317
 	run_with_spinner() { shift; "$@"; return $?; }
 	# shellcheck disable=SC2317
@@ -126,6 +133,21 @@ chmod +x "$SANDBOX/bin/opencode-claude"
 	echo "$rc"
 ) >"$SANDBOX/out2" 2>&1
 assert_eq "claude shim -> rc=1" "1" "$(tail -1 "$SANDBOX/out2")"
+
+# --- Test 2b: validator rejects multi-digit non-opencode majors ------------
+echo "Test 2b: _setup_validate_opencode_binary rejects major >=10"
+cat >"$SANDBOX/bin/opencode-major10" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "10.0.0"
+EOF
+chmod +x "$SANDBOX/bin/opencode-major10"
+(
+	source_extracted
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/opencode-major10" || rc=$?
+	echo "$rc"
+) >"$SANDBOX/out2b" 2>&1
+assert_eq "major 10 shim -> rc=1" "1" "$(tail -1 "$SANDBOX/out2b")"
 
 # --- Test 3: validator on missing path -------------------------------------
 echo "Test 3: _setup_validate_opencode_binary on missing path"


### PR DESCRIPTION
## Summary

Addressed valid OpenCode install review followups: removed eval from the setup_prompt test stub, rejected multi-digit non-opencode major versions, clarified bun/npm installer use, guarded post-heal version probing, and simplified validation while preserving set -e safety.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh,.agents/scripts/tests/test-tool-install-opencode.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-tool-install-opencode.sh .agents/scripts/setup/modules/tool-install.sh; bash .agents/scripts/tests/test-tool-install-opencode.sh

Resolves #22562


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 82,872 tokens on this as a headless worker.