### PR TITLE
GH#22589: tolerate missing preflight log matches

### DIFF
--- a/.agents/scripts/orchestration-efficiency-collector.sh
+++ b/.agents/scripts/orchestration-efficiency-collector.sh
@@ -303,7 +303,7 @@ collect_speed() {
 	# Preflight duration from pulse log (grep for preflight timing lines)
 	if [[ -f "$PULSE_LOG" ]]; then
 		local preflight_times
-		preflight_times=$(grep -a "preflight.*duration\|preflight.*seconds\|preflight.*elapsed" "$PULSE_LOG" 2>/dev/null |
+		preflight_times=$(grep -a "preflight.*duration\|preflight.*seconds\|preflight.*elapsed" "$PULSE_LOG" |
 			awk -v date="$date" '$0 ~ date {
 				line = $0
 				while (match(line, /[0-9][0-9.]*s/)) {
@@ -312,7 +312,7 @@ collect_speed() {
 					line = substr(line, RSTART + RLENGTH)
 				}
 			}' |
-			sort -n)
+			sort -n || true)
 		if [[ -n "$preflight_times" ]]; then
 			local pf_count
 			pf_count=$(echo "$preflight_times" | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary

Adjusted orchestration efficiency preflight timing collection so empty grep results do not terminate the script under set -euo pipefail, while leaving grep stderr visible for real errors.

## Files Changed

.agents/scripts/orchestration-efficiency-collector.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/orchestration-efficiency-collector.sh; HOME=temp fixture .agents/scripts/orchestration-efficiency-collector.sh --date 2026-05-03 --output report.json with a pulse log containing no preflight matches

Resolves #22589


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 65,992 tokens on this as a headless worker.