### PR TITLE
GH#22587: address data plane review followup

### DIFF
--- a/.agents/scripts/inbox-helper.sh
+++ b/.agents/scripts/inbox-helper.sh
@@ -1044,7 +1044,7 @@ _triage_run_classification() {
 		printf 'Classify this _inbox item into the correct aidevops plane. Return JSON with target_plane, sub_folder, confidence, and reasoning.\n\n'
 		if [[ -f "$DATA_PLANES_REGISTRY" ]] && command -v jq >/dev/null 2>&1; then
 			printf 'Canonical data-plane registry excerpt (JSON):\n'
-			jq -c '{planes: .planes | with_entries({key, value: {purpose: .value.purpose, helper: .value.helper, sensitivity_default: .value.sensitivity_default, ingress: .value.ingress, egress: .value.egress, index_retrieval_surface: .value.index_retrieval_surface, routing_notes: .value.routing_notes}})}' "$DATA_PLANES_REGISTRY" 2>/dev/null || true
+			jq -c '{planes: (.planes | map_values({purpose, helper, sensitivity_default, ingress, egress, index_retrieval_surface, routing_notes}))}' "$DATA_PLANES_REGISTRY" 2>/dev/null || true
 			printf '\n'
 		fi
 		if [[ -n "$examples" ]]; then

--- a/.agents/scripts/tests/test-data-planes-registry.sh
+++ b/.agents/scripts/tests/test-data-planes-registry.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
 REGISTRY="$REPO_ROOT/.agents/configs/data-planes.json"
 
+# shellcheck source=../shared-constants.sh
+source "$SCRIPT_DIR/../shared-constants.sh"
+
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -103,7 +106,10 @@ test_registry_contract_valid() {
 
 test_missing_required_field_fails() {
 	local tmp_registry
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	tmp_registry="$(mktemp)"
+	push_cleanup "rm -f '${tmp_registry}'"
 	python3 - "$REGISTRY" "$tmp_registry" <<'PY'
 import json
 import sys
@@ -120,6 +126,7 @@ PY
 		print_result "missing required registry field fails validation" 0
 	fi
 	rm -f "$tmp_registry"
+	tmp_registry=""
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Simplified the inbox data-plane registry jq excerpt with map_values and added robust cleanup handling to the registry contract test.

## Files Changed

.agents/scripts/inbox-helper.sh,.agents/scripts/tests/test-data-planes-registry.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/inbox-helper.sh .agents/scripts/tests/test-data-planes-registry.sh && .agents/scripts/tests/test-data-planes-registry.sh

Resolves #22587


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 131,745 tokens on this as a headless worker.