### PR TITLE
GH#22594: extract all release completion task IDs

### DIFF
--- a/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
+++ b/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
@@ -77,6 +77,14 @@ printf 'prefix-boundary\n' >>work.txt
 git add work.txt
 git commit -q -m 'chore: at9876 complete should stay ignored'
 
+printf 'multi-after-keyword\n' >>work.txt
+git add work.txt
+git commit -q -m 'chore: complete t124 and closes t125'
+
+printf 'multi-before-keyword\n' >>work.txt
+git add work.txt
+git commit -q -m 'chore: t126 complete and t127 done'
+
 SCRIPT_DIR="$TEST_SCRIPTS_DIR"
 REPO_ROOT="$REPO_DIR"
 VERSION_FILE="${REPO_DIR}/VERSION"
@@ -84,7 +92,7 @@ VERSION_FILE="${REPO_DIR}/VERSION"
 source "${TEST_SCRIPTS_DIR}/version-manager-git.sh"
 
 actual=$(extract_task_ids_from_commits)
-expected=$'t123\nt3375\nt3376\nt3377.2'
+expected=$'t123\nt124\nt125\nt126\nt127\nt3375\nt3376\nt3377.2'
 assert_lines_equal 'extract_task_ids_from_commits: supports four digit and dotted task IDs' "$expected" "$actual"
 
 if [[ "$actual" != *$'t337\n'* && "$actual" != "t337" ]]; then

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -179,15 +179,25 @@ extract_task_ids_from_commits() {
 
 		# Pattern 3: "complete/completes/closes tXXX" - task ID immediately after keyword
 		# e.g., "complete t037", "closes t001"
-		if [[ "$commit" =~ (^|[^[:alnum:]_])(completes?|closes?)[[:space:]]+(t[0-9]+(\.[0-9]+)*)([^[:alnum:]_]|$) ]]; then
-			task_ids+=("${BASH_REMATCH[3]}")
-		fi
+		local completion_match
+		while IFS= read -r completion_match; do
+			[[ -n "$completion_match" ]] || continue
+			local id
+			id=$(printf '%s\n' "$completion_match" | grep -oE 't[0-9]+(\.[0-9]+)*' || true)
+			[[ -n "$id" ]] || continue
+			task_ids+=("$id")
+		done < <(printf '%s\n' "$commit" | grep -oE '(^|[^[:alnum:]_])(completes?|closes?)[[:space:]]+t[0-9]+(\.[0-9]+)*([^[:alnum:]_]|$)' || true)
 
 		# Pattern 4: "tXXX complete/done/finished" - task ID before completion word
 		# e.g., "t001 complete", "t002 done"
-		if [[ "$commit" =~ (^|[^[:alnum:]_])(t[0-9]+(\.[0-9]+)*)[[:space:]]+(complete|done|finished)($|[^[:alnum:]_]) ]]; then
-			task_ids+=("${BASH_REMATCH[2]}")
-		fi
+		local task_before_completion_match
+		while IFS= read -r task_before_completion_match; do
+			[[ -n "$task_before_completion_match" ]] || continue
+			local id
+			id=$(printf '%s\n' "$task_before_completion_match" | grep -oE 't[0-9]+(\.[0-9]+)*' || true)
+			[[ -n "$id" ]] || continue
+			task_ids+=("$id")
+		done < <(printf '%s\n' "$commit" | grep -oE '(^|[^[:alnum:]_])t[0-9]+(\.[0-9]+)*[[:space:]]+(complete|done|finished)($|[^[:alnum:]_])' || true)
 
 	done <<<"$commits"
 


### PR DESCRIPTION
## Summary

Updated release task ID extraction to collect every completion-style task ID match per commit message for keyword-before-task and task-before-keyword patterns, with regression coverage for multiple IDs in one subject.

## Files Changed

.agents/scripts/tests/test-version-manager-task-id-extraction.sh,.agents/scripts/version-manager-git.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager-git.sh .agents/scripts/tests/test-version-manager-task-id-extraction.sh; bash .agents/scripts/tests/test-version-manager-task-id-extraction.sh

Resolves #22594


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 72,726 tokens on this as a headless worker.