### PR TITLE
GH#22592: make gh timeout function detection zsh-compatible

### DIFF
--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -140,7 +140,7 @@ _gh_with_timeout() {
 	*) secs=30 ;;
 	esac
 	local cmd="${1:-}"
-	if [[ -n "$cmd" && "$(type -t "$cmd" 2>/dev/null || true)" == "function" ]]; then
+	if [[ -n "$cmd" ]] && declare -f "$cmd" >/dev/null; then
 		"$@"
 		return $?
 	fi

--- a/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
@@ -145,7 +145,36 @@ else
 fi
 
 # =============================================================================
-# Scenario 2 — source guard: no `local -n` anywhere in the two functions
+# Scenario 2 — _gh_with_timeout detects zsh shell functions directly
+# =============================================================================
+#
+# PR #22359 taught _gh_with_timeout to bypass coreutils timeout when the wrapped
+# command is a shell function (test stubs cannot be exec'd by timeout). The first
+# implementation used bash-only `type -t`, which silently failed under zsh and
+# routed function stubs through timeout anyway. Keep a zsh regression guard for
+# the direct function-dispatch path.
+
+{
+	extract_function _gh_with_timeout "$WRAPPERS_FILE"
+	printf '\n'
+	# shellcheck disable=SC2016 # Intentional: emit zsh function definitions literally.
+	printf '%s\n' 'fake_gh(){ echo "fake-gh-called:$*"; return 0; }'
+	# shellcheck disable=SC2016 # If function detection regresses, this captures the timeout route.
+	printf '%s\n' 'timeout(){ echo "timeout-called:$*"; return 88; }'
+	printf '%s\n' '_gh_with_timeout write fake_gh issue edit 123'
+} >"$TMPFILE"
+
+zsh_timeout_output=$(zsh "$TMPFILE" 2>&1)
+
+msg_2="2: _gh_with_timeout calls zsh function stubs directly"
+if [[ "$zsh_timeout_output" == "fake-gh-called:issue edit 123" ]]; then
+	print_result "$msg_2" 0
+else
+	print_result "$msg_2" 1 "(expected direct function call, got: '${zsh_timeout_output}')"
+fi
+
+# =============================================================================
+# Scenario 3 — source guard: no `local -n` anywhere in the two functions
 # =============================================================================
 #
 # Syntactic guard — prevents a future edit from re-introducing namerefs.
@@ -153,16 +182,16 @@ fi
 # `local -n` usages elsewhere in the file (if any ever appeared) wouldn't
 # affect this assertion.
 
-msg_2="2: no 'local -n' in _gh_wrapper_extract_task_id_from_title{,_step}"
+msg_3="3: no 'local -n' in _gh_wrapper_extract_task_id_from_title{,_step}"
 if awk '
 	/^_gh_wrapper_extract_task_id_from_title(_step)?\(\) \{/ { in_fn=1 }
 	in_fn && /[[:space:]]local -n / { found=1 }
 	in_fn && /^}$/ { in_fn=0 }
 	END { exit (found ? 1 : 0) }
 ' "$WRAPPERS_FILE"; then
-	print_result "$msg_2" 0
+	print_result "$msg_3" 0
 else
-	print_result "$msg_2" 1 "(found 'local -n' — fix regressed)"
+	print_result "$msg_3" 1 "(found 'local -n' — fix regressed)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
@@ -92,8 +92,15 @@ fi
 # no `=~` / BASH_REMATCH — so it works identically under bash and zsh.
 
 WRAPPERS_FILE="${TEST_SCRIPTS_DIR}/shared-gh-wrappers.sh"
+WRAPPERS_CREATE_FILE="${TEST_SCRIPTS_DIR}/shared-gh-wrappers-create.sh"
 if [[ ! -f "$WRAPPERS_FILE" ]]; then
 	print_result "t2688: shared-gh-wrappers.sh exists" 1 "(missing: $WRAPPERS_FILE)"
+	printf '\n%sTests run: %d, failed: %d%s\n' \
+		"$TEST_RED" "$TESTS_RUN" "$TESTS_FAILED" "$TEST_RESET"
+	exit 1
+fi
+if [[ ! -f "$WRAPPERS_CREATE_FILE" ]]; then
+	print_result "t2688: shared-gh-wrappers-create.sh exists" 1 "(missing: $WRAPPERS_CREATE_FILE)"
 	printf '\n%sTests run: %d, failed: %d%s\n' \
 		"$TEST_RED" "$TESTS_RUN" "$TESTS_FAILED" "$TEST_RESET"
 	exit 1
@@ -116,9 +123,9 @@ TMPFILE=$(mktemp "${TMPDIR:-/tmp}/t2688-zsh-snippet.XXXXXX")
 trap 'rm -f "$TMPFILE"' EXIT
 
 {
-	extract_function _gh_wrapper_extract_task_id_from_title "$WRAPPERS_FILE"
+	extract_function _gh_wrapper_extract_task_id_from_title "$WRAPPERS_CREATE_FILE"
 	printf '\n'
-	extract_function _gh_wrapper_extract_task_id_from_title_step "$WRAPPERS_FILE"
+	extract_function _gh_wrapper_extract_task_id_from_title_step "$WRAPPERS_CREATE_FILE"
 	printf '\n'
 	# shellcheck disable=SC2016 # Intentional: emit literal $() / $result for zsh to evaluate.
 	printf '%s\n' 'result=$(_gh_wrapper_extract_task_id_from_title --todo-task-id t2688 2>&1)'
@@ -188,7 +195,7 @@ if awk '
 	in_fn && /[[:space:]]local -n / { found=1 }
 	in_fn && /^}$/ { in_fn=0 }
 	END { exit (found ? 1 : 0) }
-' "$WRAPPERS_FILE"; then
+' "$WRAPPERS_CREATE_FILE"; then
 	print_result "$msg_3" 0
 else
 	print_result "$msg_3" 1 "(found 'local -n' — fix regressed)"


### PR DESCRIPTION
## Summary

Replaced bash-only type -t function detection in _gh_with_timeout with declare -f and added a zsh regression guard for shell function stubs.

## Files Changed

.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers.sh .agents/scripts/tests/test-gh-wrapper-zsh-compat.sh; .agents/scripts/tests/test-shared-gh-wrappers-source.sh; .agents/scripts/tests/test-shared-gh-wrappers-standalone.sh; .agents/scripts/tests/test-gh-wrapper-zsh-compat.sh

Resolves #22592


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 76,305 tokens on this as a headless worker.