### PR TITLE
GH#22585: verify pulse merge label fetch behavior

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -4,17 +4,19 @@
 #
 # test-pulse-merge-post-merge-label-fetch.sh — GH#22219 regression guard.
 #
-# Verifies that _handle_post_merge_actions treats a provided empty 5th
-# argument as authoritative "no labels" data instead of refetching PR labels.
+# Verifies _handle_post_merge_actions behaviour around optional PR labels:
+# a provided empty 5th argument is authoritative and must not refetch, while an
+# omitted 5th argument falls back to fetching PR labels before setting solved
+# attribution.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
-MERGE_FILE="${SCRIPTS_DIR}/pulse-merge.sh"
+MERGE_FILE="${SCRIPT_DIR_TEST}/../pulse-merge.sh"
 
 TESTS_RUN=0
 TESTS_FAILED=0
+TEST_ROOT=""
 
 pass() {
 	local name="$1"
@@ -35,22 +37,153 @@ fail() {
 	return 0
 }
 
-if grep -q 'if \[\[ \$# -lt 5 \]\]; then' "$MERGE_FILE"; then
-	pass "provided empty pr_labels skip refetch path"
-else
-	fail "provided empty pr_labels skip refetch path" \
-		"_handle_post_merge_actions should check argument count, not label string emptiness"
-fi
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	export SOLVED_LABEL_LOG="${TEST_ROOT}/solved-labels.log"
+	: >"$LOGFILE"
+	: >"$GH_CALL_LOG"
+	: >"$SOLVED_LABEL_LOG"
 
-if grep -q '_gh_with_timeout read gh pr view "[$]pr_number"' "$MERGE_FILE"; then
-	pass "fallback PR label fetch uses timeout wrapper"
-else
-	fail "fallback PR label fetch uses timeout wrapper" \
-		"fallback gh pr view call should go through _gh_with_timeout read"
-fi
+	export AGENTS_DIR="${TEST_ROOT}"
+	mkdir -p "${AGENTS_DIR}/scripts"
+	cat >"${AGENTS_DIR}/scripts/gh-signature-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${AGENTS_DIR}/scripts/gh-signature-helper.sh"
 
-printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_FAILED" -eq 0 ]]; then
-	exit 0
-fi
-exit 1
+	export PULSE_START_EPOCH
+	PULSE_START_EPOCH=$(date +%s)
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+define_function_under_test() {
+	local fn_src
+	fn_src=$(awk '
+		/^_pm_issue_api\(\) \{/,/^}$/ { print }
+		/^_pm_build_closing_comment\(\) \{/,/^}$/ { print }
+		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
+	' "$MERGE_FILE")
+	if [[ -z "$fn_src" ]]; then
+		printf 'ERROR: could not extract _handle_post_merge_actions from %s\n' "$MERGE_FILE" >&2
+		return 1
+	fi
+	eval "$fn_src"
+	return 0
+}
+
+install_helper_stubs() {
+	gh() {
+		printf '%s\n' "$*" >>"$GH_CALL_LOG"
+		if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
+			printf '[]\n'
+		fi
+		return 0
+	}
+
+	gh_pr_comment() {
+		gh pr comment "$@"
+		return 0
+	}
+	gh_issue_comment() {
+		gh issue comment "$@"
+		return 0
+	}
+	gh_pr_view() {
+		printf 'pr view %s\n' "$*" >>"$GH_CALL_LOG"
+		printf '%s\n' "${TEST_PR_LABELS:-}"
+		return 0
+	}
+	set_solved_label() {
+		local issue="$1"
+		local repo="$2"
+		local actor="$3"
+		printf '%s %s %s\n' "$issue" "$repo" "$actor" >>"$SOLVED_LABEL_LOG"
+		return 0
+	}
+	unlock_issue_after_worker() { return 0; }
+	fast_fail_reset() { return 0; }
+	_release_interactive_claim_on_merge() { return 0; }
+	auto_file_next_phase() { return 0; }
+	_unblock_circuit_breaker_meta_pr() { return 0; }
+	return 0
+}
+
+assert_log_contains() {
+	local file="$1"
+	local pattern="$2"
+	local label="$3"
+	if grep -q -- "$pattern" "$file"; then
+		pass "$label"
+	else
+		fail "$label" "Expected pattern '$pattern' in $file"
+	fi
+	return 0
+}
+
+assert_log_not_contains() {
+	local file="$1"
+	local pattern="$2"
+	local label="$3"
+	if grep -q -- "$pattern" "$file"; then
+		fail "$label" "Unexpected pattern '$pattern' in $file"
+	else
+		pass "$label"
+	fi
+	return 0
+}
+
+test_provided_empty_pr_labels_skip_refetch() {
+	: >"$GH_CALL_LOG"
+	: >"$SOLVED_LABEL_LOG"
+	export TEST_PR_LABELS="origin:worker"
+
+	_handle_post_merge_actions "22585" "marcusquinn/aidevops" "22219" "merged" ""
+
+	assert_log_not_contains "$GH_CALL_LOG" "pr view" \
+		"provided empty pr_labels skips fallback fetch"
+	assert_log_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops interactive" \
+		"provided empty pr_labels keeps interactive solved attribution"
+	return 0
+}
+
+test_omitted_pr_labels_fetches_fallback() {
+	: >"$GH_CALL_LOG"
+	: >"$SOLVED_LABEL_LOG"
+	export TEST_PR_LABELS="origin:worker"
+
+	_handle_post_merge_actions "22585" "marcusquinn/aidevops" "22219" "merged"
+
+	assert_log_contains "$GH_CALL_LOG" "pr view 22585" \
+		"omitted pr_labels fetches fallback labels"
+	assert_log_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops worker" \
+		"fallback labels drive worker solved attribution"
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+	define_function_under_test
+	install_helper_stubs
+
+	test_provided_empty_pr_labels_skip_refetch
+	test_omitted_pr_labels_fetches_fallback
+
+	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Replaced brittle string-matching regression checks with behavioral coverage for provided-empty versus omitted PR label arguments in _handle_post_merge_actions.

## Files Changed

.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh .agents/scripts/pulse-merge.sh; bash .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh

Resolves #22585


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 97,827 tokens on this as a headless worker.