### PR TITLE
GH#22593: guard NMR timestamp jq parsing

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -617,23 +617,25 @@ _find_qualifying_pr_for_stale_recovery() {
 		--repo "$slug" --json number,reviewDecision,headRefOid,authorAssociation,labels,createdAt \
 		--limit 10 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "null" ]] || pr_json="[]"
+	[[ -n "$nmr_at" ]] || return 0
 
 	local candidate_prs
 	candidate_prs=$(printf '%s' "$pr_json" | jq -r \
 		--arg nmr_at "$nmr_at" \
-		--arg blank "" \
 		--arg approved "APPROVED" \
 		--arg owner "OWNER" \
 		--arg member "MEMBER" \
 		--arg origin_worker "origin:worker" \
 		--arg origin_interactive "origin:interactive" '
+		($nmr_at | fromdateiso8601) as $target_ts
+		|
 		.[]?
-		| select((.createdAt // $blank) != $blank)
-		| select((.createdAt | fromdateiso8601) > ($nmr_at | fromdateiso8601))
+		| select(.createdAt != null)
+		| select((.createdAt | fromdateiso8601) > $target_ts)
 		| select(.reviewDecision == $approved)
 		| select(.authorAssociation == $owner or .authorAssociation == $member)
 		| select([.labels[]?.name] | any(. == $origin_worker or . == $origin_interactive))
-		| select((.headRefOid // $blank) != $blank)
+		| select(.headRefOid != null and .headRefOid != "")
 		| [.number, .headRefOid]
 		| @tsv
 	' 2>/dev/null) || candidate_prs=""

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -201,6 +201,14 @@ gh_issue_comment() {
 }
 export -f gh_issue_comment
 
+# Keep the finder test isolated from any ambient gh_pr_list wrapper loaded by
+# the developer shell; this fixture wants the local gh stub above.
+gh_pr_list() {
+	gh pr list "$@"
+	return $?
+}
+export -f gh_pr_list
+
 # Extract the functions under test from the source file.
 define_helper_under_test() {
 	# GH#21799: source the REST check-runs helper sub-library so the extracted
@@ -445,6 +453,24 @@ test_h_idempotency_no_duplicate() {
 	return 0
 }
 
+# Case I: missing NMR timestamp -> no jq date parse error and no candidate PR
+test_i_empty_nmr_timestamp_no_candidate() {
+	reset_posted_comment
+	local pr_data candidate
+	pr_data=$(build_pr_json 21716 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	candidate=$(_find_qualifying_pr_for_stale_recovery 21699 "marcusquinn/aidevops" "")
+
+	if [[ -n "$candidate" ]]; then
+		print_result "Case I: empty NMR timestamp -> no candidate" 1 \
+			"Expected no candidate when NMR timestamp is empty, got: ${candidate}"
+	else
+		print_result "Case I: empty NMR timestamp -> no candidate" 0
+	fi
+	return 0
+}
+
 # ============================================================
 # Main
 # ============================================================
@@ -466,6 +492,7 @@ main() {
 	test_f_failing_quality_check_no_notification
 	test_g_cost_breaker_no_notification
 	test_h_idempotency_no_duplicate
+	test_i_empty_nmr_timestamp_no_candidate
 
 	printf '\n%d tests run, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Precomputed the NMR timestamp once in the stale-recovery PR jq filter, added an empty timestamp guard, simplified null checks, and pinned regression coverage for the empty timestamp path.

## Files Changed

.agents/scripts/pulse-nmr-approval.sh,.agents/scripts/tests/test-pulse-nmr-approval.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-approval.sh; bash .agents/scripts/tests/test-pulse-nmr-approval.sh

Resolves #22593


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 100,407 tokens on this as a headless worker.