### PR TITLE
t3548: initialise multi-var locals in _compose_unfiled_phases_note

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -310,7 +310,7 @@ _compose_unfiled_phases_note() {
 	_phases_section=$(_parse_phases_section "$parent_body")
 	[[ -n "$_phases_section" ]] || return 0
 
-	local _declared_count _unfiled_phases _unfiled_count
+	local _declared_count="" _unfiled_phases="" _unfiled_count=""
 	_declared_count=$(printf '%s\n' "$_phases_section" | safe_grep_count -E '^[0-9]+	')
 	_unfiled_phases=$(printf '%s\n' "$_phases_section" | \
 		awk -F'\t' '$1 ~ /^[0-9]+$/ && $4 == "" { printf "- Phase %s: %s\n", $1, $2 }')

--- a/TODO.md
+++ b/TODO.md
@@ -936,6 +936,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3528 feedback plane Phase 5 CLI and routines design #auto-dispatch #feat #framework ref:GH#22519
 
+- [ ] t3548 fix: initialise multi-var locals in _compose_unfiled_phases_note (t3547 regression) #bug ref:GH#22610
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Fix multi-var `local` without init regression on line 313 of `pulse-issue-reconcile-actions.sh`. Pattern banned by t2863 / canonical t2841 — under `set -u`, any branch that fails to assign one of the vars aborts subsequent reads.

## Root cause

PR #22609 (t3547) introduced `_compose_unfiled_phases_note` helper with:

```bash
local _declared_count _unfiled_phases _unfiled_count
```

`Pulse Unbound-Var Lint` workflow flagged it as a FAILURE on the merge run. The check is non-required so #22609 merged with the failure visible, leaving the bug on main.

## Fix

One-line: `local _declared_count="" _unfiled_phases="" _unfiled_count=""` — matches the t2841 reference fix at commit `e05bcae1f`.

## Verification

```text
$ .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-issue-reconcile-actions.sh
No violations found.
exit=0

$ shellcheck .agents/scripts/pulse-issue-reconcile-actions.sh
(clean)

$ .agents/scripts/tests/test-parent-task-lifecycle.sh
=== Results: 32 tests, 0 failed ===
```

## Files Scope

- `.agents/scripts/pulse-issue-reconcile-actions.sh`

Resolves #22610
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.11 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-opus-4-7 spent 1h 17m and 155,718 tokens on this with the user in an interactive session.