### PR TITLE
t3550: register parent task for AGENTS.md progressive disclosure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -938,6 +938,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3548 fix: initialise multi-var locals in _compose_unfiled_phases_note (t3547 regression) #bug ref:GH#22610
 
+- [ ] t3550 AGENTS.md progressive disclosure — slim ~26.5K tokens to ~5K via 8-phase extraction #parent #docs #self-improvement #aidevops #interactive ref:GH#22616
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Registers parent task **t3550** for AGENTS.md progressive-disclosure decomposition.

For #22616

## Context

Audit traced "hi" turn cost of 64K tokens (26% of opus-4.7 250K window) to `.agents/AGENTS.md` weighing ~26.5K tokens — accumulated through t2878 consolidation and subsequent always-on additions (t2204, t3215, t3222, t2685, t2893, etc.). Issue #22616 contains the 8-phase decomposition plan with per-phase token estimates, file scopes, and acceptance criteria. Each phase will be its own auto-dispatched implementation PR.

## What this PR does

- Adds `t3550` entry to `TODO.md` linking to issue #22616
- Uses `For #22616` (not `Closes`) per the parent-task PR keyword rule — parent stays open until the final phase PR

## What this PR does NOT do

- No edits to `.agents/AGENTS.md` itself (each phase PR will trim its own section)
- No new reference files yet (Phase 1+ will create them)

## Verification

```bash
grep -n 't3550' TODO.md
gh issue view 22616 --repo marcusquinn/aidevops --json labels --jq '.labels[].name' | grep parent-task
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.12 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-opus-4-7 spent 10m and 23,188 tokens on this with the user in an interactive session.
