### PR TITLE
GH#22626: extract Git Workflow body to workflow reference

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -376,35 +376,7 @@ Log security ops: `audit-log-helper.sh log <type> <message>`. NEVER log credenti
 
 ### Git Workflow
 
-Git is the audit trail. Procedures: see the "## Git Workflow" section below.
-
-**Origin labelling (MANDATORY):**
-
-- NEVER use raw `gh pr create` or `gh issue create` directly. Always use the wrappers: `gh_create_pr` and `gh_create_issue` (defined in `shared-constants.sh`, sourced via PATH). The wrappers automatically apply `origin:interactive` or `origin:worker` based on the session context. Raw `gh` calls produce unlabelled PRs that the pulse may auto-close.
-- If `gh_create_pr` is unavailable (e.g. not sourced), pass `--label origin:interactive` explicitly when creating PRs in an interactive session.
-
-**Interactive issue ownership (MANDATORY — AI-driven, t2056):**
-
-When an interactive session engages with a GitHub issue — opening a worktree, claiming a task, or user identifies one — you MUST IMMEDIATELY call `interactive-session-helper.sh claim <N> <slug>`. Applies `status:in-review` + self-assign + crash-recovery stamp. No worker will dispatch while set. Do NOT assume `origin:interactive` alone is enough.
-
-**Eager stamp creation (t2943):** `claim-task-id.sh` now atomically writes the crash-recovery stamp immediately when it self-assigns a newly created interactive task (via `_auto_assign_issue` → `interactive-session-helper.sh write-stamp`). This eliminates the historical stampless-claim window where `_auto_assign_issue` self-assigned but the subsequent `interactive-session-helper.sh claim` call failed. The explicit `interactive-session-helper.sh claim` call is still needed when picking up an EXISTING issue mid-lifecycle (the eager stamp only fires on new task creation); the claim step is now only mandatory for mid-lifecycle pickup, not immediately after `claim-task-id.sh`.
-
-SCOPE LIMITATION (GH#19861): `claim` blocks dispatch path ONLY — not enrich, completion-sweep, or other pulse paths. For full insulation, use `lockdown` instead: `no-auto-dispatch` + `status:in-review` + conversation lock + audit comment.
-
-- Release is YOUR responsibility, not the user's. When the user signals completion ("ship it", "I'm done", "moving on", "let a worker take over"), or when they switch to a different issue, call `interactive-session-helper.sh release <N> <slug>`. Never make the user type a release command. **PR merge auto-release (t2413):** when `pulse-merge.sh` merges an `origin:interactive` PR with a `Resolves #NNN` link and a claim stamp exists, `_release_interactive_claim_on_merge` fires automatically — no manual release required on merge. Manual release is still needed for task abandonment or mid-stream task switches.
-- On every interactive session start, run `interactive-session-helper.sh scan-stale` and, if any dead claims surface, prompt the user to release them. Act on confirmation.
-- Offline `gh` → the helper warns once and exits 0. Continue the session. A collision with a worker is harmless — the interactive work naturally becomes its own issue/PR.
-- `/release-issue <N>` and `aidevops issue release <N>` exist as fallbacks only; the agent should never punt to them. Detect intent and act.
-
-**Traceability (MANDATORY):**
-
-- PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
-- NEVER invent task ID suffixes or variants — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output. For follow-up work on a merged task, claim a FRESH task ID via `claim-task-id.sh` — don't extend the old one. NEVER prefix `--title` with a `tNNN:` when calling `claim-task-id.sh` — always let the helper inject the claimed ID. Titles must describe the work, not assert an ID.
-- **PR bodies MUST use `Resolves #NNN`** to link the PR to its issue. GitHub only creates the sidebar "Development" link (PR↔issue) when the PR body contains a closing keyword (`Closes`, `Fixes`, `Resolves`). Without it, the audit trail is broken — you can navigate from issue→commit but not issue↔PR. `Resolves` only triggers closure when the PR *merges*, so there is no risk of premature closure.
-- **Planning-only commits** (TODO entries, briefs, docs) must use `For #NNN` or `Ref #NNN` — these reference the issue without triggering GitHub's auto-close. NEVER use `Closes`/`Fixes` in commits that only touch TODO.md or todo/*.
-- **Code fix commit messages** may use `Fixes #NNN` — auto-closes when merged to the default branch. The dedup system checks commit messages to detect in-progress work.
-- **Markdown formatting is INVISIBLE to the extraction regex (t2204).** `_extract_linked_issue` in `pulse-merge.sh` runs a plain `grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#[0-9]+'` against the raw PR body. Backticks, code fences, blockquotes, HTML comments, and link text DO NOT shield closing keywords from the match. Writing `` `Closes #NNN` `` (as reference text), `> Resolves #NNN` (in a quote), or `[Fixes #NNN](url)` (as link text) in a planning-PR body will auto-close the issue on merge — the regex sees the literal string, not the formatting. If you must reference a closing keyword in narrative prose, rephrase: "the fix PR will use a closing keyword", "will resolve with a Closes-keyword", or split the `#` from the number. Canonical foot-gun: t2190 session PR #19680.
-- Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref:GH#NNN`.
+Git is the audit trail. Hard rules: use wrapper-created GitHub writes with origin labels, claim interactive issues before work, include task IDs in PR titles, use `Resolves #NNN` for leaf issue PRs, use `For #NNN`/`Ref #NNN` for parent-task references, and never invent task IDs. Full claim/release lifecycle, traceability details, origin-label rules, parent-task PR keyword rule, and markdown keyword foot-guns live in `workflows/git-workflow.md`.
 
 ### Worker-Ready Implementation Context (t1900 — MANDATORY)
 
@@ -640,55 +612,7 @@ Task creation, briefs/tiers/dispatchability, auto-dispatch and completion, routi
 
 ## Git Workflow
 
-Worktree naming prefixes: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
-
-PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for debt/issue-only work). Examples: `t1702: integrate FOSS scanning`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. NEVER invent suffixes or variants either — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output; for follow-up work, claim a FRESH ID. Create TODO entry first for unplanned work.
-
-Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees. **Auto-claim on creation (GH#20102):** when a worktree is created via `worktree-helper.sh add|switch` or `full-loop-helper.sh start`, the framework automatically calls `interactive-session-helper.sh claim <N> <slug>` if the branch name encodes a task ID (`feature/tNNN-*` with `ref:GH#NNN` in TODO.md) or a direct issue number (`feature/gh-<N>-*`). This closes the race window between worktree creation and manual claim. Opt out for bulk scripted operations with `AIDEVOPS_SKIP_AUTO_CLAIM=1`. Headless workers (`FULL_LOOP_HEADLESS`, `AIDEVOPS_HEADLESS`, `Claude_HEADLESS`, `GITHUB_ACTIONS`) are skipped automatically.
-
-**Preview proxy (GH#21560):** `worktree-helper.sh add` automatically allocates a preview port and (if configured) registers a local proxy route so every worktree dev server gets its own subdomain (`https://<branch-slug>.<repo>.local`). On remove, the port and route are freed. Both best-effort and non-fatal. Config: `~/.config/aidevops/preview-proxy.json`. Per-project dev hints: `.aidevops.json` `preview` block. Full setup and backend docs: `reference/preview-proxy.md`.
-
-**Worktree/session isolation (MANDATORY):** exactly one active session may own a writable worktree path at a time. Never reuse a live worktree across sessions (interactive or headless). If ownership conflict is detected, create a fresh worktree for the current task/session instead of continuing in the contested path.
-
-**Interactive issue ownership:** Mandatory claim/release rules live in Framework Rules > Git Workflow. Use `interactive-session-helper.sh claim <N> <slug>` for existing issues, `--implementing` for interactive takeover of `auto-dispatch` issues, `lockdown` for full pulse insulation, and `release` on handoff/abandonment. Session-start stale-claim details and idle handover: `reference/session.md`.
-
-**Traceability and signature footer:** Hard rules: see "Framework Rules > Git Workflow > Traceability" and "Framework Rules > Signature footer hallucination" above. Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
-
-**Stacked PRs (t2412):** Stacked PRs (`--base feature/<other-branch>`) are auto-retargeted to default branch before the parent merges — handled automatically by `pulse-merge.sh` and `full-loop-helper.sh merge`. For bare `gh pr merge` calls, retarget manually first: `gh pr list --base <head-ref> --state open --json number -q '.[].number' | xargs -I{} gh pr edit {} --base main`. Only direct children are retargeted; grandchildren handled when their own parent merges.
-
-**Parent-task PR keyword rule (t2046 — MANDATORY).** When a PR delivers ANY work for a `parent-task`-labeled issue — including the initial plan-filing PR — use `For #NNN` or `Ref #NNN` in the PR body, NEVER `Closes`/`Resolves`/`Fixes`. The parent issue must stay open until ALL phase children merge; only the final phase PR uses `Closes #NNN`. `full-loop-helper.sh commit-and-pr` enforces this automatically (see `.github/workflows/parent-task-keyword-check.yml`). For leaf (non-parent) issues, use `Resolves #NNN` as normal. See `templates/brief-template.md` "PR Conventions" for the full rule.
-
-**Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
-
-**Pulse scope (t1405):** `PULSE_SCOPE_REPOS` limits code changes. Issues allowed anywhere. Empty/unset = no restriction.
-
-**Cross-runner overrides (t2422):** Per-runner claim filtering lives in `~/.config/aidevops/dispatch-override.conf` (structured `DISPATCH_OVERRIDE_<LOGIN>=honour|ignore|warn|honour-only-above:V`). Preferred over the deprecated flat `DISPATCH_CLAIM_IGNORE_RUNNERS` — structured overrides auto-sunset on peer upgrade and compose with the global `DISPATCH_CLAIM_MIN_VERSION` floor. Simultaneous-claim races are resolved via deterministic `sort_by([.created_at, .nonce])` tiebreaker; close-window losses (<=`DISPATCH_TIEBREAKER_WINDOW`, default 5s) emit `CLAIM_DEFERRED` audit comments. Full config grammar and diagnosis in `reference/cross-runner-coordination.md` §8.
-
-**External Repo Issue/PR Submission (t1407):** Check templates and CONTRIBUTING.md first. Bots auto-close non-conforming submissions. Full guide: `reference/external-repo-submissions.md`.
-
-**Git-readiness:** Non-git project with ongoing development? Flag: "No git tracking. Consider `git init` + `aidevops init`."
-
-**Review Bot Gate (t1382):** Before merging: `review-bot-gate-helper.sh check <PR_NUMBER>` and read bot reviews. Additive bot suggestions become follow-up tasks, not PR scope creep. Full workflow/overrides: `reference/review-bot-gate.md`.
-
-**Qlty Regression Gate (t2065, GH#18773):** CI fails if a PR introduces a net increase in `qlty smells` count. Docs-only PRs skip automatically. Override: add `ratchet-bump` label with justification. Helper: `qlty-regression-helper.sh` (supports `--dry-run`).
-
-**Qlty New-File Smell Gate (t2068):** CI fails if newly-added files ship with smells. Complements t2065 (which catches increases in existing files). Override: `new-file-smell-ok` label AND a `## New File Smell Justification` section in the PR body — both required. Local check: `qlty-new-file-gate-helper.sh new-files --base origin/main --dry-run`.
-
-**Cryptographic approval + NMR automation (t2386):** moved to `reference/task-lifecycle.md`; read before approving issues/PRs or clearing/preserving NMR.
-
-**Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`. The commit-msg hook (`install-task-id-guard.sh install`) enforces this client-side; the CI check (`.github/workflows/task-id-collision-check.yml`) enforces it server-side for commits authored outside the hook.
-
-**Large-file splits (t2368):** When splitting a shell library into sub-libraries (responding to `file-size-debt`, `function-complexity`, or `nesting-depth` scanner issues), read `reference/large-file-split.md` first. It covers the canonical orchestrator + sub-library pattern, identity-key preservation rules, known CI false-positive classes, pre-commit hook gotchas, and a complete PR body template. A worker reading only this doc + the scanner-filed issue body can complete a split PR end-to-end without re-discovering any lesson.
-
-**Complexity Bump Override (t2370):** The `complexity-bump-ok` label overrides the complexity regression gates in `code-quality.yml` (nesting-depth, file-size, function-complexity, bash32-compat). Workers and maintainers may self-apply this label when the PR body contains a validated `## Complexity Bump Justification` section with: (1) at least one `file:line` reference citing the scanner evidence, and (2) at least one numeric measurement (`base=N, head=M, new=K` or similar). Workflow: `.github/workflows/complexity-bump-justification-check.yml` — triggers on `labeled` event, validates the section, and removes the label with a remediation comment if justification is incomplete. This mirrors the `new-file-smell-ok` + justification-section pattern. Primary use case: file splits that trigger nesting-depth false positives from identity-key changes (see `reference/large-file-split.md` section 4.1).
-
-**Workflow Cascade Vulnerability Lint (t2229):** `.github/workflows/workflow-cascade-lint.yml` flags PRs that modify workflows containing the cascade-vulnerable combination: label-like event types (`labeled`, `unlabeled`, `assigned`, etc.) + `cancel-in-progress: true` + no mitigation (`paths-ignore` or event-action guard). See t2220 for the failure mode (15 cancelled runs in ~2s). Helper: `.agents/scripts/workflow-cascade-lint.sh` (supports `--dry-run` for local checks). Override: apply `workflow-cascade-ok` label AND add a `## Workflow Cascade Justification` section to the PR body.
-
-**Reusable workflows:** downstream repos use thin caller YAMLs that reference aidevops reusable workflows. Drift tools: `aidevops check-workflows`, `aidevops sync-workflows --apply`. Full architecture/pinning: `reference/reusable-workflows.md`.
-
-**Badge management (t2975):** `aidevops badges render|check|sync|install` manages README badge blocks and LOC badge workflows. Full docs: `.agents/aidevops/badges.md`.
-
-Full workflow: `workflows/git-workflow.md`, `reference/session.md`
+Hard rules: work in linked worktrees, keep the canonical repo on `main`, use task IDs in PR titles, link PRs with `Resolves #NNN` for leaf issues, use `For #NNN`/`Ref #NNN` for parent-task references, and preserve traceability/signature footer rules. Full worktree naming, claim/release lifecycle, stacked PRs, parent-task PR keyword rule, auto-merge/origin-label details, cross-runner overrides, review-bot gate, quality gates, and cleanup workflow live in `workflows/git-workflow.md` and `reference/session.md`.
 
 ---
 

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -160,3 +160,91 @@ See `workflows/sql-migrations.md`. **Critical rules**: Never modify pushed/deplo
 | `tools/security/opsec.md` | CI/CD AI agent security |
 
 **Platform CLIs**: GitHub (`gh`), GitLab (`glab`), Gitea (`tea`). See `tools/git.md` for detailed usage.
+
+## Extracted AGENTS.md Git Workflow Rules
+
+Source: extracted from `.agents/AGENTS.md` Framework Rules and User Guide Git Workflow sections (Phase 3 of #22616 — progressive-disclosure decomposition). Read this section before creating worktrees/branches, claiming or releasing issues, writing PR bodies, handling parent-task PR keywords, reasoning about origin labels, or diagnosing auto-merge / dispatch-dedup behaviour.
+
+## AGENTS.md Framework Rules Git Workflow
+
+Git is the audit trail. Procedures: see the "## Git Workflow" section below.
+
+**Origin labelling (MANDATORY):**
+
+- NEVER use raw `gh pr create` or `gh issue create` directly. Always use the wrappers: `gh_create_pr` and `gh_create_issue` (defined in `shared-constants.sh`, sourced via PATH). The wrappers automatically apply `origin:interactive` or `origin:worker` based on the session context. Raw `gh` calls produce unlabelled PRs that the pulse may auto-close.
+- If `gh_create_pr` is unavailable (e.g. not sourced), pass `--label origin:interactive` explicitly when creating PRs in an interactive session.
+
+**Interactive issue ownership (MANDATORY — AI-driven, t2056):**
+
+When an interactive session engages with a GitHub issue — opening a worktree, claiming a task, or user identifies one — you MUST IMMEDIATELY call `interactive-session-helper.sh claim <N> <slug>`. Applies `status:in-review` + self-assign + crash-recovery stamp. No worker will dispatch while set. Do NOT assume `origin:interactive` alone is enough.
+
+**Eager stamp creation (t2943):** `claim-task-id.sh` now atomically writes the crash-recovery stamp immediately when it self-assigns a newly created interactive task (via `_auto_assign_issue` → `interactive-session-helper.sh write-stamp`). This eliminates the historical stampless-claim window where `_auto_assign_issue` self-assigned but the subsequent `interactive-session-helper.sh claim` call failed. The explicit `interactive-session-helper.sh claim` call is still needed when picking up an EXISTING issue mid-lifecycle (the eager stamp only fires on new task creation); the claim step is now only mandatory for mid-lifecycle pickup, not immediately after `claim-task-id.sh`.
+
+SCOPE LIMITATION (GH#19861): `claim` blocks dispatch path ONLY — not enrich, completion-sweep, or other pulse paths. For full insulation, use `lockdown` instead: `no-auto-dispatch` + `status:in-review` + conversation lock + audit comment.
+
+- Release is YOUR responsibility, not the user's. When the user signals completion ("ship it", "I'm done", "moving on", "let a worker take over"), or when they switch to a different issue, call `interactive-session-helper.sh release <N> <slug>`. Never make the user type a release command. **PR merge auto-release (t2413):** when `pulse-merge.sh` merges an `origin:interactive` PR with a `Resolves #NNN` link and a claim stamp exists, `_release_interactive_claim_on_merge` fires automatically — no manual release required on merge. Manual release is still needed for task abandonment or mid-stream task switches.
+- On every interactive session start, run `interactive-session-helper.sh scan-stale` and, if any dead claims surface, prompt the user to release them. Act on confirmation.
+- Offline `gh` → the helper warns once and exits 0. Continue the session. A collision with a worker is harmless — the interactive work naturally becomes its own issue/PR.
+- `/release-issue <N>` and `aidevops issue release <N>` exist as fallbacks only; the agent should never punt to them. Detect intent and act.
+
+**Traceability (MANDATORY):**
+
+- PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
+- NEVER invent task ID suffixes or variants — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output. For follow-up work on a merged task, claim a FRESH task ID via `claim-task-id.sh` — don't extend the old one. NEVER prefix `--title` with a `tNNN:` when calling `claim-task-id.sh` — always let the helper inject the claimed ID. Titles must describe the work, not assert an ID.
+- **PR bodies MUST use `Resolves #NNN`** to link the PR to its issue. GitHub only creates the sidebar "Development" link (PR↔issue) when the PR body contains a closing keyword (`Closes`, `Fixes`, `Resolves`). Without it, the audit trail is broken — you can navigate from issue→commit but not issue↔PR. `Resolves` only triggers closure when the PR *merges*, so there is no risk of premature closure.
+- **Planning-only commits** (TODO entries, briefs, docs) must use `For #NNN` or `Ref #NNN` — these reference the issue without triggering GitHub's auto-close. NEVER use `Closes`/`Fixes` in commits that only touch TODO.md or todo/*.
+- **Code fix commit messages** may use `Fixes #NNN` — auto-closes when merged to the default branch. The dedup system checks commit messages to detect in-progress work.
+- **Markdown formatting is INVISIBLE to the extraction regex (t2204).** `_extract_linked_issue` in `pulse-merge.sh` runs a plain `grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#[0-9]+'` against the raw PR body. Backticks, code fences, blockquotes, HTML comments, and link text DO NOT shield closing keywords from the match. Writing `` `Closes #NNN` `` (as reference text), `> Resolves #NNN` (in a quote), or `[Fixes #NNN](url)` (as link text) in a planning-PR body will auto-close the issue on merge — the regex sees the literal string, not the formatting. If you must reference a closing keyword in narrative prose, rephrase: "the fix PR will use a closing keyword", "will resolve with a Closes-keyword", or split the `#` from the number. Canonical foot-gun: t2190 session PR #19680.
+- Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref:GH#NNN`.
+
+## AGENTS.md User Guide Git Workflow
+
+Worktree naming prefixes: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
+
+PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for debt/issue-only work). Examples: `t1702: integrate FOSS scanning`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. NEVER invent suffixes or variants either — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output; for follow-up work, claim a FRESH ID. Create TODO entry first for unplanned work.
+
+Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees. **Auto-claim on creation (GH#20102):** when a worktree is created via `worktree-helper.sh add|switch` or `full-loop-helper.sh start`, the framework automatically calls `interactive-session-helper.sh claim <N> <slug>` if the branch name encodes a task ID (`feature/tNNN-*` with `ref:GH#NNN` in TODO.md) or a direct issue number (`feature/gh-<N>-*`). This closes the race window between worktree creation and manual claim. Opt out for bulk scripted operations with `AIDEVOPS_SKIP_AUTO_CLAIM=1`. Headless workers (`FULL_LOOP_HEADLESS`, `AIDEVOPS_HEADLESS`, `Claude_HEADLESS`, `GITHUB_ACTIONS`) are skipped automatically.
+
+**Preview proxy (GH#21560):** `worktree-helper.sh add` automatically allocates a preview port and (if configured) registers a local proxy route so every worktree dev server gets its own subdomain (`https://<branch-slug>.<repo>.local`). On remove, the port and route are freed. Both best-effort and non-fatal. Config: `~/.config/aidevops/preview-proxy.json`. Per-project dev hints: `.aidevops.json` `preview` block. Full setup and backend docs: `reference/preview-proxy.md`.
+
+**Worktree/session isolation (MANDATORY):** exactly one active session may own a writable worktree path at a time. Never reuse a live worktree across sessions (interactive or headless). If ownership conflict is detected, create a fresh worktree for the current task/session instead of continuing in the contested path.
+
+**Interactive issue ownership:** Mandatory claim/release rules live in Framework Rules > Git Workflow. Use `interactive-session-helper.sh claim <N> <slug>` for existing issues, `--implementing` for interactive takeover of `auto-dispatch` issues, `lockdown` for full pulse insulation, and `release` on handoff/abandonment. Session-start stale-claim details and idle handover: `reference/session.md`.
+
+**Traceability and signature footer:** Hard rules: see "Framework Rules > Git Workflow > Traceability" and "Framework Rules > Signature footer hallucination" above. Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+
+**Stacked PRs (t2412):** Stacked PRs (`--base feature/<other-branch>`) are auto-retargeted to default branch before the parent merges — handled automatically by `pulse-merge.sh` and `full-loop-helper.sh merge`. For bare `gh pr merge` calls, retarget manually first: `gh pr list --base <head-ref> --state open --json number -q '.[].number' | xargs -I{} gh pr edit {} --base main`. Only direct children are retargeted; grandchildren handled when their own parent merges.
+
+**Parent-task PR keyword rule (t2046 — MANDATORY).** When a PR delivers ANY work for a `parent-task`-labeled issue — including the initial plan-filing PR — use `For #NNN` or `Ref #NNN` in the PR body, NEVER `Closes`/`Resolves`/`Fixes`. The parent issue must stay open until ALL phase children merge; only the final phase PR uses `Closes #NNN`. `full-loop-helper.sh commit-and-pr` enforces this automatically (see `.github/workflows/parent-task-keyword-check.yml`). For leaf (non-parent) issues, use `Resolves #NNN` as normal. See `templates/brief-template.md` "PR Conventions" for the full rule.
+
+**Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
+
+**Pulse scope (t1405):** `PULSE_SCOPE_REPOS` limits code changes. Issues allowed anywhere. Empty/unset = no restriction.
+
+**Cross-runner overrides (t2422):** Per-runner claim filtering lives in `~/.config/aidevops/dispatch-override.conf` (structured `DISPATCH_OVERRIDE_<LOGIN>=honour|ignore|warn|honour-only-above:V`). Preferred over the deprecated flat `DISPATCH_CLAIM_IGNORE_RUNNERS` — structured overrides auto-sunset on peer upgrade and compose with the global `DISPATCH_CLAIM_MIN_VERSION` floor. Simultaneous-claim races are resolved via deterministic `sort_by([.created_at, .nonce])` tiebreaker; close-window losses (<=`DISPATCH_TIEBREAKER_WINDOW`, default 5s) emit `CLAIM_DEFERRED` audit comments. Full config grammar and diagnosis in `reference/cross-runner-coordination.md` §8.
+
+**External Repo Issue/PR Submission (t1407):** Check templates and CONTRIBUTING.md first. Bots auto-close non-conforming submissions. Full guide: `reference/external-repo-submissions.md`.
+
+**Git-readiness:** Non-git project with ongoing development? Flag: "No git tracking. Consider `git init` + `aidevops init`."
+
+**Review Bot Gate (t1382):** Before merging: `review-bot-gate-helper.sh check <PR_NUMBER>` and read bot reviews. Additive bot suggestions become follow-up tasks, not PR scope creep. Full workflow/overrides: `reference/review-bot-gate.md`.
+
+**Qlty Regression Gate (t2065, GH#18773):** CI fails if a PR introduces a net increase in `qlty smells` count. Docs-only PRs skip automatically. Override: add `ratchet-bump` label with justification. Helper: `qlty-regression-helper.sh` (supports `--dry-run`).
+
+**Qlty New-File Smell Gate (t2068):** CI fails if newly-added files ship with smells. Complements t2065 (which catches increases in existing files). Override: `new-file-smell-ok` label AND a `## New File Smell Justification` section in the PR body — both required. Local check: `qlty-new-file-gate-helper.sh new-files --base origin/main --dry-run`.
+
+**Cryptographic approval + NMR automation (t2386):** moved to `reference/task-lifecycle.md`; read before approving issues/PRs or clearing/preserving NMR.
+
+**Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`. The commit-msg hook (`install-task-id-guard.sh install`) enforces this client-side; the CI check (`.github/workflows/task-id-collision-check.yml`) enforces it server-side for commits authored outside the hook.
+
+**Large-file splits (t2368):** When splitting a shell library into sub-libraries (responding to `file-size-debt`, `function-complexity`, or `nesting-depth` scanner issues), read `reference/large-file-split.md` first. It covers the canonical orchestrator + sub-library pattern, identity-key preservation rules, known CI false-positive classes, pre-commit hook gotchas, and a complete PR body template. A worker reading only this doc + the scanner-filed issue body can complete a split PR end-to-end without re-discovering any lesson.
+
+**Complexity Bump Override (t2370):** The `complexity-bump-ok` label overrides the complexity regression gates in `code-quality.yml` (nesting-depth, file-size, function-complexity, bash32-compat). Workers and maintainers may self-apply this label when the PR body contains a validated `## Complexity Bump Justification` section with: (1) at least one `file:line` reference citing the scanner evidence, and (2) at least one numeric measurement (`base=N, head=M, new=K` or similar). Workflow: `.github/workflows/complexity-bump-justification-check.yml` — triggers on `labeled` event, validates the section, and removes the label with a remediation comment if justification is incomplete. This mirrors the `new-file-smell-ok` + justification-section pattern. Primary use case: file splits that trigger nesting-depth false positives from identity-key changes (see `reference/large-file-split.md` section 4.1).
+
+**Workflow Cascade Vulnerability Lint (t2229):** `.github/workflows/workflow-cascade-lint.yml` flags PRs that modify workflows containing the cascade-vulnerable combination: label-like event types (`labeled`, `unlabeled`, `assigned`, etc.) + `cancel-in-progress: true` + no mitigation (`paths-ignore` or event-action guard). See t2220 for the failure mode (15 cancelled runs in ~2s). Helper: `.agents/scripts/workflow-cascade-lint.sh` (supports `--dry-run` for local checks). Override: apply `workflow-cascade-ok` label AND add a `## Workflow Cascade Justification` section to the PR body.
+
+**Reusable workflows:** downstream repos use thin caller YAMLs that reference aidevops reusable workflows. Drift tools: `aidevops check-workflows`, `aidevops sync-workflows --apply`. Full architecture/pinning: `reference/reusable-workflows.md`.
+
+**Badge management (t2975):** `aidevops badges render|check|sync|install` manages README badge blocks and LOC badge workflows. Full docs: `.agents/aidevops/badges.md`.
+
+Full workflow: `workflows/git-workflow.md`, `reference/session.md`

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -167,7 +167,7 @@ Source: extracted from `.agents/AGENTS.md` Framework Rules and User Guide Git Wo
 
 ## AGENTS.md Framework Rules Git Workflow
 
-Git is the audit trail. Procedures: see the "## Git Workflow" section below.
+Git is the audit trail. Procedures: see the "## AGENTS.md User Guide Git Workflow" section below.
 
 **Origin labelling (MANDATORY):**
 
@@ -211,7 +211,7 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Interactive issue ownership:** Mandatory claim/release rules live in Framework Rules > Git Workflow. Use `interactive-session-helper.sh claim <N> <slug>` for existing issues, `--implementing` for interactive takeover of `auto-dispatch` issues, `lockdown` for full pulse insulation, and `release` on handoff/abandonment. Session-start stale-claim details and idle handover: `reference/session.md`.
 
-**Traceability and signature footer:** Hard rules: see "Framework Rules > Git Workflow > Traceability" and "Framework Rules > Signature footer hallucination" above. Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+**Traceability and signature footer:** Hard rules: see "Traceability" above and "Framework Rules > Signature footer hallucination" in `.agents/AGENTS.md`. Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Stacked PRs (t2412):** Stacked PRs (`--base feature/<other-branch>`) are auto-retargeted to default branch before the parent merges — handled automatically by `pulse-merge.sh` and `full-loop-helper.sh merge`. For bare `gh pr merge` calls, retarget manually first: `gh pr list --base <head-ref> --state open --json number -q '.[].number' | xargs -I{} gh pr edit {} --base main`. Only direct children are retargeted; grandchildren handled when their own parent merges.
 
@@ -247,4 +247,4 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Badge management (t2975):** `aidevops badges render|check|sync|install` manages README badge blocks and LOC badge workflows. Full docs: `.agents/aidevops/badges.md`.
 
-Full workflow: `workflows/git-workflow.md`, `reference/session.md`
+Related workflow reference: `reference/session.md`


### PR DESCRIPTION
## Summary

Phase 3 of the AGENTS.md progressive-disclosure decomposition. Moves detailed Git Workflow rules from .agents/AGENTS.md into .agents/workflows/git-workflow.md, including origin labelling, interactive claim/release lifecycle, traceability rules, markdown closing-keyword foot-gun, worktree naming, stacked PRs, parent-task PR keyword rule, cross-runner overrides, review-bot gate, quality gates, and cleanup pointers. Keeps compact hard-rule pointers in AGENTS.md. For #22616 (parent stays open).

## Files Changed

.agents/AGENTS.md,.agents/workflows/git-workflow.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2 .agents/AGENTS.md .agents/workflows/git-workflow.md passed with 0 errors. Extraction verification passed: Framework Git Workflow block matches origin/main after H3->H2 title rename; User Guide Git Workflow block matches origin/main after H2 title rename. AGENTS.md reduced by 13,726 bytes from current origin/main baseline.

Resolves #22626


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.15 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-opus-4-7 spent 1h 26m and 424,520 tokens on this with the user in an interactive session.