### PR TITLE
GH#22622: clamp OAuth pool Retry-After cooldowns

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -186,6 +186,15 @@ Use this when a runner's dashboard is fresh but **Active Workers = 0**.
    oauth-pool-helper.sh check anthropic
    ```
 
+   Rate-limit cooldowns derived from provider retry hints are capped at 6h by
+   default (`AIDEVOPS_OAUTH_POOL_MAX_RATE_LIMIT_COOLDOWN_SECONDS`) so a stale
+   multi-day `Retry-After` cannot sideline usable accounts for days. Missing or
+   unparseable rate-limit retry hints still fall back to 60s; auth-error
+   cooldowns remain on the separate 1h path. If status shows several accounts
+   stuck behind stale `cooldownUntil` values, run
+   `oauth-pool-helper.sh reset-cooldowns <provider>` after confirming the
+   provider is healthy.
+
 5. Read the dashboard's **Worker Dispatch Diagnostics** section. It is rendered only when Active Workers is 0 and distinguishes:
    - no eligible work (`Assigned Issues=0`, `Total Issues=0`)
    - auth/model unavailable (OpenAI/Anthropic both missing)

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -274,6 +274,33 @@ PY
 	return 0
 }
 
+clamp_rate_limit_retry_seconds() {
+	local reason="$1"
+	local retry_seconds="$2"
+	local max_seconds="${AIDEVOPS_OAUTH_POOL_MAX_RATE_LIMIT_COOLDOWN_SECONDS:-21600}"
+
+	if [[ ! "$retry_seconds" =~ ^[0-9]+$ ]]; then
+		printf '%s' "0"
+		return 0
+	fi
+	if [[ ! "$max_seconds" =~ ^[0-9]+$ ]] || [[ "$max_seconds" -le 0 ]]; then
+		max_seconds=21600
+	fi
+	case "$reason" in
+	rate_limit | provider_error)
+		if [[ "$retry_seconds" -gt "$max_seconds" ]]; then
+			printf '%s' "$max_seconds"
+		else
+			printf '%s' "$retry_seconds"
+		fi
+		;;
+	*)
+		printf '%s' "$retry_seconds"
+		;;
+	esac
+	return 0
+}
+
 attempt_pool_recovery() {
 	local provider="$1"
 	local reason="$2"
@@ -321,6 +348,7 @@ attempt_pool_recovery() {
 		*) retry_seconds=300 ;;
 		esac
 	fi
+	retry_seconds=$(clamp_rate_limit_retry_seconds "$reason" "$retry_seconds")
 
 	# Safe: mark the account as failed in pool metadata (no auth file mutation)
 	"$OAUTH_POOL_HELPER" mark-failure "$provider" "$reason" "$retry_seconds" >/dev/null 2>&1 || true

--- a/.agents/scripts/oauth-pool-lib/pool_ops_mark_failure.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_mark_failure.py
@@ -28,6 +28,8 @@ _REASON_TO_STATUS = {
     "provider_error": "rate-limited",
 }
 
+_DEFAULT_MAX_RATE_LIMIT_COOLDOWN_SECONDS = 6 * 60 * 60
+
 
 def _find_index_by_access(accounts: list[dict], current_access: str) -> int:
     if not current_access:
@@ -61,6 +63,25 @@ def _find_index_by_most_recent(accounts: list[dict]) -> int:
             best_last = last
             best_i = i
     return best_i
+
+
+def _max_rate_limit_cooldown_seconds() -> int:
+    raw = os.environ.get("AIDEVOPS_OAUTH_POOL_MAX_RATE_LIMIT_COOLDOWN_SECONDS", "")
+    try:
+        value = int(raw) if raw else _DEFAULT_MAX_RATE_LIMIT_COOLDOWN_SECONDS
+    except ValueError:
+        return _DEFAULT_MAX_RATE_LIMIT_COOLDOWN_SECONDS
+    if value <= 0:
+        return _DEFAULT_MAX_RATE_LIMIT_COOLDOWN_SECONDS
+    return value
+
+
+def _clamp_retry_seconds(reason: str, retry_seconds: int) -> int:
+    if retry_seconds < 0:
+        return 0
+    if reason not in {"rate_limit", "provider_error"}:
+        return retry_seconds
+    return min(retry_seconds, _max_rate_limit_cooldown_seconds())
 
 
 def _resolve_failed_index(accounts: list[dict], current_auth: dict, provider: str) -> int:
@@ -104,7 +125,7 @@ def cmd_mark_failure() -> None:
     auth_path = os.environ["AUTH_FILE_PATH"]
     provider = os.environ["PROVIDER"]
     reason = os.environ["REASON"]
-    retry_seconds = int(os.environ["RETRY_SECONDS"])
+    retry_seconds = _clamp_retry_seconds(reason, int(os.environ["RETRY_SECONDS"]))
 
     target_status = _REASON_TO_STATUS.get(reason, "rate-limited")
 

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -211,6 +211,82 @@ class MarkFailureTests(PoolOpsTestCase):
         self.assertEqual(a["status"], "rate-limited")
         self.assertGreater(a["cooldownUntil"], int(time.time() * 1000))
 
+    def test_rate_limit_fallback_retry_seconds_remains_short(self) -> None:
+        self._make_pool([{"email": "a@example.com", "access": "tok"}])
+        self._make_auth({"access": "tok"})
+        before = int(time.time() * 1000)
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "rate_limit",
+                "RETRY_SECONDS": "60",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        cooldown_delta = read_json(self.pool_path)["anthropic"][0]["cooldownUntil"] - before
+        self.assertGreaterEqual(cooldown_delta, 55_000)
+        self.assertLess(cooldown_delta, 70_000)
+
+    def test_short_retry_after_is_preserved(self) -> None:
+        self._make_pool([{"email": "a@example.com", "access": "tok"}])
+        self._make_auth({"access": "tok"})
+        before = int(time.time() * 1000)
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "rate_limit",
+                "RETRY_SECONDS": "120",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        cooldown_delta = read_json(self.pool_path)["anthropic"][0]["cooldownUntil"] - before
+        self.assertGreaterEqual(cooldown_delta, 115_000)
+        self.assertLess(cooldown_delta, 130_000)
+
+    def test_over_max_rate_limit_retry_after_is_clamped(self) -> None:
+        self._make_pool([{"email": "a@example.com", "access": "tok"}])
+        self._make_auth({"access": "tok"})
+        before = int(time.time() * 1000)
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "rate_limit",
+                "RETRY_SECONDS": str(2 * 24 * 60 * 60),
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        cooldown_delta = read_json(self.pool_path)["anthropic"][0]["cooldownUntil"] - before
+        self.assertGreaterEqual(cooldown_delta, (6 * 60 * 60 - 5) * 1000)
+        self.assertLess(cooldown_delta, (6 * 60 * 60 + 10) * 1000)
+
+    def test_auth_error_cooldown_is_not_rate_limit_clamped(self) -> None:
+        self._make_pool([{"email": "a@example.com", "access": "tok"}])
+        self._make_auth({"access": "tok"})
+        before = int(time.time() * 1000)
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "auth_error",
+                "RETRY_SECONDS": "3600",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        cooldown_delta = read_json(self.pool_path)["anthropic"][0]["cooldownUntil"] - before
+        self.assertGreaterEqual(cooldown_delta, (60 * 60 - 5) * 1000)
+        self.assertLess(cooldown_delta, (60 * 60 + 10) * 1000)
+
     def test_falls_back_to_openai_account_id(self) -> None:
         write_json(
             self.pool_path,

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -112,6 +112,45 @@ assert_eq "metric provider_status persisted" "500" \
 assert_eq "metric classification_source persisted" "output_pattern" \
 	"$(jq -r '.classification_source' "$METRICS_FILE")"
 
+write_retry_fixture() {
+	local name="$1"
+	local body="$2"
+	local path="$FIXTURE_DIR/$name.retry.log"
+	printf '%s\n' "$body" >"$path"
+	printf '%s' "$path"
+	return 0
+}
+
+check_pool_retry_seconds() {
+	local label="$1"
+	local body="$2"
+	local reason="$3"
+	local expected_seconds="$4"
+	local path
+	path=$(write_retry_fixture "$label" "$body")
+	: >"$FIXTURE_DIR/oauth-pool-helper.calls"
+	attempt_pool_recovery "anthropic" "$reason" "$path" >/dev/null 2>&1
+	assert_eq "$label pool retry seconds" "$expected_seconds" \
+		"$(awk '{print $4}' "$FIXTURE_DIR/oauth-pool-helper.calls")"
+	return 0
+}
+
+cat >"$OAUTH_POOL_HELPER" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FIXTURE_DIR}/oauth-pool-helper.calls"
+exit 0
+STUB
+chmod +x "$OAUTH_POOL_HELPER"
+export FIXTURE_DIR OAUTH_POOL_HELPER
+HOME="$FIXTURE_DIR/home"
+mkdir -p "$HOME/.aidevops"
+export HOME
+
+check_pool_retry_seconds "missing_retry_after" "status 429 with no retry hint" "rate_limit" "60"
+check_pool_retry_seconds "short_retry_after" "retry after 120 seconds" "rate_limit" "120"
+check_pool_retry_seconds "over_max_retry_after" "retry after 2 days" "rate_limit" "21600"
+check_pool_retry_seconds "auth_error_fallback" "authentication failed" "auth_error" "3600"
+
 echo
 echo "${TEST_BLUE}=== Summary ===${TEST_NC}"
 echo "Tests run:    $TESTS_RUN"


### PR DESCRIPTION
## Summary

Clamped OAuth pool rate-limit Retry-After cooldowns to a configurable 6h default with shell-side and pool mark-failure safeguards, plus regression coverage and diagnostics documentation.

## Files Changed

.agents/reference/worker-diagnostics.md,.agents/scripts/headless-runtime-provider.sh,.agents/scripts/oauth-pool-lib/pool_ops_mark_failure.py,.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py,.agents/scripts/tests/test-headless-runtime-failure-classification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-provider.sh .agents/scripts/tests/test-headless-runtime-failure-classification.sh; python3 -m unittest discover -s .agents/scripts/oauth-pool-lib/tests; bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh; markdownlint-cli2 unavailable locally

Resolves #22622


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.15 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 140,292 tokens on this as a headless worker.