### PR TITLE
GH#22629: trigger phase autofile after REST fallback merge

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -14,6 +14,7 @@
 #   - shared-constants.sh (print_error, print_info, print_success, print_warning,
 #     gh_pr_comment, release_interactive_claim_on_merge)
 #   - shared-claim-lifecycle.sh (release_interactive_claim_on_merge)
+#   - shared-phase-filing.sh (auto_file_next_phase)
 #   - full-loop-helper-commit.sh (cmd_pre_merge_gate)
 #   - Globals: SCRIPT_DIR
 #
@@ -33,6 +34,11 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
 	unset _lib_path
 fi
+
+# Sequential phase auto-filing parity with pulse-merge.sh (t2740/GH#22629).
+# shellcheck source=./shared-phase-filing.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/shared-phase-filing.sh"
 
 # --- Repo Resolution ---
 
@@ -437,6 +443,15 @@ cmd_merge() {
 		grep -oE '[0-9]+' | head -1) || _linked_issue_for_release=""
 	if [[ -n "$_linked_issue_for_release" ]]; then
 		release_interactive_claim_on_merge "$pr_number" "$repo" "$_linked_issue_for_release" || true
+	fi
+
+	# Sequential phase auto-filing parity with pulse-merge.sh. Worker self-merge
+	# bypasses the deterministic pulse post-merge hook, so trigger the shared
+	# best-effort phase filer here after any immediate merge path succeeds,
+	# including the REST merge fallback used when GraphQL quota is exhausted.
+	# Do not fire for --auto: the PR is only queued, not merged yet.
+	if [[ "$has_auto" -eq 0 && -n "$_linked_issue_for_release" ]]; then
+		auto_file_next_phase "$_linked_issue_for_release" "$repo" || true
 	fi
 
 	_merge_unlock_resources "$pr_number" "$repo"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -120,6 +120,15 @@ if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
 	fi
 fi
 
+if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
+	if [[ "\$*" == *"--json body"* ]]; then
+		echo 'Resolves #22621'
+		exit 0
+	fi
+	echo '{}'
+	exit 0
+fi
+
 if [[ "\$_gh_cmd" == "api" ]]; then
 	echo "gh api \$*" >> "${TEST_ROOT}/logs/gh-api-calls.txt"
 	if [[ "\$*" == *"repos/testorg/testrepo/pulls/42/merge"* ]]; then
@@ -209,6 +218,7 @@ source '${scripts_dir}/full-loop-helper-merge.sh'
 cmd_pre_merge_gate() { return '${gate_rc}'; }
 _retarget_stacked_children_interactive() { return 0; }
 release_interactive_claim_on_merge() { return 0; }
+auto_file_next_phase() { printf '%s %s\n' "\$1" "\$2" >> "${TEST_ROOT}/logs/phase-autofile.txt"; return 0; }
 cmd_merge '$pr_number' '$repo'
 RUNNER_EOF
 	chmod +x "$tmp_runner"
@@ -346,7 +356,27 @@ test_graphql_rate_limit_rest_fallback() {
 	return 0
 }
 
-# Test 5: REST fallback is not used for --auto because it would merge immediately.
+# Test 5: GraphQL REST fallback through cmd_merge triggers sequential phase auto-filing.
+test_graphql_rate_limit_cmd_merge_phase_autofile() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "graphql-rate-limit"
+
+	local exit_code=0
+	run_cmd_merge_with_gate "42" "testorg/testrepo" "0" >/dev/null 2>&1 || exit_code=$?
+	print_result "GraphQL rate-limit cmd_merge: REST fallback succeeds" "$exit_code"
+
+	local phase_called=0
+	if [[ -f "${TEST_ROOT}/logs/phase-autofile.txt" ]] &&
+		grep -q "22621 testorg/testrepo" "${TEST_ROOT}/logs/phase-autofile.txt"; then
+		phase_called=1
+	fi
+	print_result "GraphQL rate-limit cmd_merge: phase autofile called for linked issue" "$((1 - phase_called))"
+
+	return 0
+}
+
+# Test 6: REST fallback is not used for --auto because it would merge immediately.
 test_graphql_rate_limit_auto_no_rest_fallback() {
 	rm -f "${TEST_ROOT}/logs/"*.txt
 
@@ -363,7 +393,7 @@ test_graphql_rate_limit_auto_no_rest_fallback() {
 	return 0
 }
 
-# Test 6: Review-bot gate failure prevents both gh pr merge and REST fallback.
+# Test 7: Review-bot gate failure prevents both gh pr merge and REST fallback.
 test_review_gate_failure_blocks_rest_fallback() {
 	rm -f "${TEST_ROOT}/logs/"*.txt
 
@@ -397,6 +427,7 @@ main() {
 	test_explicit_admin_no_signaling
 	test_other_error_no_fallback
 	test_graphql_rate_limit_rest_fallback
+	test_graphql_rate_limit_cmd_merge_phase_autofile
 	test_graphql_rate_limit_auto_no_rest_fallback
 	test_review_gate_failure_blocks_rest_fallback
 


### PR DESCRIPTION
## Summary

- Source shared phase-filing from the full-loop merge helper.
- Call auto_file_next_phase after immediate worker self-merges, including REST fallback merges after GraphQL quota exhaustion.
- Add a cmd_merge regression proving REST fallback invokes phase auto-filing for the linked issue.

## Testing

- .agents/scripts/tests/test-full-loop-merge.sh
- bash .agents/scripts/tests/test-full-loop-merge-flag-conflict.sh
- bash .agents/scripts/tests/test-shared-phase-filing.sh
- shellcheck .agents/scripts/full-loop-helper-merge.sh .agents/scripts/tests/test-full-loop-merge.sh

Resolves #22629
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.15 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 226,691 tokens on this as a headless worker.