### PR TITLE
t3557: reset pulse blockers when eligible work exists

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -253,9 +253,14 @@ except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
     pass
 dispatch_api_blocked = (
     graphql_budget_status.startswith('TRIPPED:')
-    or graphql_budget['skipped_low_count'] > 0
-    or graphql_budget['circuit_broken_count'] > 0
-    or pre_launch_blockers.get('graphql_circuit_breaker', 0) > 0
+    or (
+        not graphql_budget_status.startswith('OK:')
+        and (
+            graphql_budget['skipped_low_count'] > 0
+            or graphql_budget['circuit_broken_count'] > 0
+            or pre_launch_blockers.get('graphql_circuit_breaker', 0) > 0
+        )
+    )
 )
 
 api_consumers = []

--- a/.agents/scripts/pulse-idle-backoff-helper.sh
+++ b/.agents/scripts/pulse-idle-backoff-helper.sh
@@ -76,6 +76,11 @@
 #   AIDEVOPS_SKIP_PULSE_IDLE_BACKOFF         (default 0;   set to 1 to disable
 #                                              all backoff — should-skip always
 #                                              exits 1 / proceed)
+#   AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK       (default 0;   set to 1 when the
+#                                              caller has already observed
+#                                              eligible auto-dispatch work;
+#                                              should-skip resets state and
+#                                              exits 1 / proceed)
 #
 # Failure mode:
 #   Fail-OPEN. Any I/O error, malformed JSON, missing jq, etc. → should-skip
@@ -251,6 +256,13 @@ cmd_should_skip() {
 		return 1
 	fi
 
+	if [[ "${AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK:-0}" == "1" ]]; then
+		cmd_reset >/dev/null 2>&1 || true
+		printf 'decision=proceed reason=available_work effective_interval_s=%s consecutive_idle=0 elapsed_s=unknown\n' \
+			"$_PIB_BASE_INTERVAL_S"
+		return 1
+	fi
+
 	local _last_run="${1:-0}"
 	[[ "$_last_run" =~ ^[0-9]+$ ]] || _last_run=0
 
@@ -386,6 +398,7 @@ ENVIRONMENT (overrides for backoff schedule):
   AIDEVOPS_PULSE_IDLE_BACKOFF_THRESHOLD_30 (default 30)
   AIDEVOPS_PULSE_IDLE_BACKOFF_STEP_30_S    (default 1800)
   AIDEVOPS_SKIP_PULSE_IDLE_BACKOFF         (default 0; set 1 to disable)
+  AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK       (default 0; set 1 when eligible work exists)
   AIDEVOPS_PULSE_IDLE_STATE_FILE           (default ~/.aidevops/cache/pulse-idle-state.json)
 EOF
 	return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1130,9 +1130,49 @@ is_no_work_rate_acceptable() {
 #
 # Counter side effect: increments _PULSE_HEALTH_IDLE_CYCLE_SKIPPED on skip.
 # ---------------------------------------------------------------------------
+_pulse_scope_repos_for_available_work_gate() {
+	local _scope="${PULSE_SCOPE_REPOS:-}"
+	if [[ -z "$_scope" && -f "${SCOPE_FILE:-}" ]]; then
+		read -r _scope <"$SCOPE_FILE" 2>/dev/null || _scope=""
+	fi
+	if [[ -z "$_scope" && -f "${REPOS_JSON:-}" ]]; then
+		_scope=$(jq -r '[.initialized_repos[]? | select(.pulse == true and (.local_only // false) == false and (.slug // "") != "") | .slug] | join(",")' "$REPOS_JSON" 2>/dev/null) || _scope=""
+	fi
+	local _slug=""
+	while IFS= read -r _slug; do
+		_slug="${_slug// /}"
+		[[ -n "$_slug" ]] || continue
+		printf '%s\n' "$_slug"
+	done < <(printf '%s\n' "$_scope" | tr ',' '\n')
+	return 0
+}
+
+_pulse_available_auto_dispatch_work_exists() {
+	[[ "${AIDEVOPS_SKIP_PULSE_IDLE_AVAILABLE_WORK_CHECK:-0}" == "1" ]] && return 1
+	local _slug=""
+	while IFS= read -r _slug; do
+		[[ -n "$_slug" ]] || continue
+		local _count=""
+		_count=$(gh api -X GET search/issues \
+			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available no:assignee" \
+			-f per_page=1 \
+			--jq '.total_count // 0' 2>/dev/null) || _count=""
+		[[ "$_count" =~ ^[0-9]+$ ]] || _count=0
+		if [[ "$_count" -gt 0 ]]; then
+			echo "[pulse-wrapper] Idle backoff bypass: eligible auto-dispatch work is visible in ${_slug} (GH#22631)" >>"$WRAPPER_LOGFILE"
+			return 0
+		fi
+	done < <(_pulse_scope_repos_for_available_work_gate)
+	return 1
+}
+
 _pulse_check_idle_backoff_gate() {
 	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
 	[[ -x "$_ib_helper" ]] || return 0
+	local _ib_available_work=0
+	if _pulse_available_auto_dispatch_work_exists; then
+		_ib_available_work=1
+	fi
 	local _ib_ts_file="${HOME}/.aidevops/logs/pulse-wrapper-last-run.ts"
 	local _ib_last=0
 	if [[ -f "$_ib_ts_file" ]]; then
@@ -1142,7 +1182,7 @@ _pulse_check_idle_backoff_gate() {
 	# Helper convention: exit 0 = "skip this cycle", exit 1 = "proceed".
 	# Mirrors should-skip semantics so the helper composes naturally with
 	# `if helper should-skip; then return; fi` at the call site.
-	if "$_ib_helper" should-skip "$_ib_last" >/dev/null 2>&1; then
+	if AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK="$_ib_available_work" "$_ib_helper" should-skip "$_ib_last" >/dev/null 2>&1; then
 		local _ib_state="" _ib_count="" _ib_interval=""
 		_ib_state=$("$_ib_helper" state 2>/dev/null || echo '{}')
 		_ib_count=$(echo "$_ib_state" | jq -r '.consecutive_idle // 0' 2>/dev/null || echo "0")
@@ -1154,6 +1194,19 @@ _pulse_check_idle_backoff_gate() {
 		fi
 		return 1
 	fi
+	return 0
+}
+
+_pulse_refresh_supervisor_circuit_breaker() {
+	local _cb_helper="${SCRIPT_DIR}/circuit-breaker-helper.sh"
+	[[ -x "$_cb_helper" ]] || return 0
+	local _cb_rc=0
+	"$_cb_helper" check >/dev/null 2>>"$WRAPPER_LOGFILE" || _cb_rc=$?
+	if [[ "$_cb_rc" -eq 0 ]]; then
+		echo "[pulse-wrapper] Supervisor circuit breaker check passed or auto-reset completed (GH#22631)" >>"$WRAPPER_LOGFILE"
+		return 0
+	fi
+	echo "[pulse-wrapper] Supervisor circuit breaker remains open after check (rc=${_cb_rc}) (GH#22631)" >>"$WRAPPER_LOGFILE"
 	return 0
 }
 
@@ -1754,6 +1807,11 @@ main() {
 		printf 'canary: ok (sourcing + _pulse_handle_self_check + acquire_instance_lock passed)\n'
 		return 0
 	fi
+
+	# GH#22631: `circuit-breaker-helper.sh status` can report an overdue
+	# supervisor breaker until `check` is invoked. Refresh once per real pulse
+	# cycle so expired cooldowns auto-close without manual operator action.
+	_pulse_refresh_supervisor_circuit_breaker || true
 
 	if ! check_session_gate; then
 		return 0

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -62,6 +62,14 @@ open(os.path.join(root, 'pulse-wrapper.log'), 'w').write('[pulse] useful activit
 PY
 
 output="$TMP_DIR/out.txt"
+export AIDEVOPS_PULSE_RATE_LIMIT_CACHE="$TMP_DIR/rate-limit-cache.json"
+python3 - "$AIDEVOPS_PULSE_RATE_LIMIT_CACHE" <<'PY'
+import json, sys, time
+json.dump({
+    'ts': int(time.time()),
+    'rate': {'resources': {'graphql': {'remaining': 4980, 'limit': 5000, 'reset': int(time.time()) + 3600}}},
+}, open(sys.argv[1], 'w'))
+PY
 "$HELPER" --log-dir "$TMP_DIR" --repo-path "$PWD" --window 15m >"$output"
 
 grep -q 'Dispatch alive: true' "$output"
@@ -69,7 +77,7 @@ grep -q 'Worker terminal events: 4' "$output"
 grep -q 'dispatch_backoff_skipped' "$output"
 grep -q 'GraphQL budget:' "$output"
 grep -q 'Top pre-launch blockers:' "$output"
-grep -q 'Dispatch API blocked by GraphQL: true' "$output"
+grep -q 'Dispatch API blocked by GraphQL: false' "$output"
 grep -q 'API call pressure:' "$output"
 grep -q 'Prefetch cache:' "$output"
 grep -q 'worker_launch_total' "$output"
@@ -86,7 +94,7 @@ jq -e '.worker_outcomes.no_op == 1' "$json_output" >/dev/null
 jq -e '.worker_outcomes.canary_failed == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.skipped_low_count == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.force_rest_reads_count == 1' "$json_output" >/dev/null
-jq -e '.dispatch_api_blocked == true' "$json_output" >/dev/null
+jq -e '.dispatch_api_blocked == false' "$json_output" >/dev/null
 jq -e '.graphql_budget.reserve_mode_count == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.deferred_stage_count == 2' "$json_output" >/dev/null
 jq -e '.graphql_budget.deferred_stages.dashboard_freshness_check == 1' "$json_output" >/dev/null

--- a/.agents/scripts/tests/test-pulse-idle-backoff.sh
+++ b/.agents/scripts/tests/test-pulse-idle-backoff.sh
@@ -232,6 +232,13 @@ rc=0
 AIDEVOPS_SKIP_PULSE_IDLE_BACKOFF=1 "$HELPER" should-skip "$((now - 100))" >/dev/null 2>&1 || rc=$?
 assert_exit "deep backoff with disable flag → proceed (exit 1)" "1" "$rc"
 
+# With visible eligible work — should PROCEED and reset stale idle state.
+rc=0
+AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK=1 "$HELPER" should-skip "$((now - 100))" >/dev/null 2>&1 || rc=$?
+assert_exit "deep backoff with available work → proceed (exit 1)" "1" "$rc"
+post_available_count=$("$HELPER" state | jq -r '.consecutive_idle')
+assert_eq "available work resets consecutive_idle" "0" "$post_available_count"
+
 # -----------------------------------------------------------------------------
 # Test 7: state file is always valid JSON after writes
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
@@ -179,11 +179,40 @@ test_dry_run_short_circuit_present() {
 	return 0
 }
 
+# Test 5: Static check — pulse refreshes overdue supervisor circuit breaker.
+#
+# Guards GH#22631: a normal pulse cycle must invoke circuit-breaker-helper.sh
+# check so overdue cooldowns reset without manual operator action.
+test_supervisor_circuit_breaker_refresh_present() {
+	if grep -q '_pulse_refresh_supervisor_circuit_breaker' "$WRAPPER_SCRIPT" && \
+		grep -q 'circuit-breaker-helper.sh' "$WRAPPER_SCRIPT"; then
+		print_result "supervisor circuit breaker refresh present in pulse-wrapper.sh" 0
+		return 0
+	fi
+	print_result "supervisor circuit breaker refresh present in pulse-wrapper.sh" 1 \
+		"Expected _pulse_refresh_supervisor_circuit_breaker and circuit-breaker-helper.sh reference in $WRAPPER_SCRIPT"
+	return 0
+}
+
+# Test 6: Static check — idle backoff observes eligible auto-dispatch work.
+test_idle_backoff_available_work_bypass_present() {
+	if grep -q '_pulse_available_auto_dispatch_work_exists' "$WRAPPER_SCRIPT" && \
+		grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK' "$WRAPPER_SCRIPT"; then
+		print_result "idle backoff available-work bypass present in pulse-wrapper.sh" 0
+		return 0
+	fi
+	print_result "idle backoff available-work bypass present in pulse-wrapper.sh" 1 \
+		"Expected available-work check and env bridge in $WRAPPER_SCRIPT"
+	return 0
+}
+
 main_test() {
 	test_dry_run_exits_zero_quickly
 	test_dry_run_prints_ok_line
 	test_include_guard_present
 	test_dry_run_short_circuit_present
+	test_supervisor_circuit_breaker_refresh_present
+	test_idle_backoff_available_work_bypass_present
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Reset idle-backoff state when eligible auto-dispatch status:available work is visible, so available work is not suppressed by a stale idle counter.
- Refresh the supervisor circuit breaker during normal pulse cycles so overdue cooldowns auto-reset without manual check.
- Treat healthy cached GraphQL quota as authoritative in current-state so stale blocker counters do not report dispatch blocked.

## Testing
- shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/pulse-idle-backoff-helper.sh .agents/scripts/tests/test-pulse-idle-backoff.sh .agents/scripts/tests/test-pulse-current-state-helper.sh .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
- bash .agents/scripts/tests/test-pulse-idle-backoff.sh
- bash .agents/scripts/tests/test-pulse-current-state-helper.sh
- bash .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
- bash .agents/scripts/tests/test-circuit-breaker.sh

Resolves #22631
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.15 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 8m and 233,326 tokens on this as a headless worker.