### PR TITLE
t3559: preserve current OpenAI OAuth account on startup

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -113,11 +113,10 @@ export function readCurrentOpenAIAuth() {
 
 function matchesOpenAIAuth(account, auth) {
   if (!auth) return false;
-  return Boolean(
-    (auth.accountId && account.accountId && auth.accountId === account.accountId) ||
-    (auth.access && account.access && auth.access === account.access) ||
-    (auth.refresh && account.refresh && auth.refresh === account.refresh),
-  );
+  const same = (left, right) => Boolean(left && right && left === right);
+  if (same(auth.accountId, account.accountId)) return true;
+  if (same(auth.access, account.access)) return true;
+  return same(auth.refresh, account.refresh);
 }
 
 function isAvailableAccount(account, now = Date.now()) {

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -36,6 +36,9 @@ import {
   CURSOR_PROXY_HOST, CURSOR_PROXY_DEFAULT_PORT, CURSOR_PROXY_BASE_URL,
   POOL_PROVIDER_IDS,
 } from "./oauth-pool-constants.mjs";
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 import { getAccounts, patchAccount } from "./oauth-pool-storage.mjs";
 import { ensureValidToken, normalizeExpiredCooldowns } from "./oauth-pool-refresh.mjs";
 
@@ -93,6 +96,34 @@ function compareAccountPriority(a, b) {
   return new Date(a.lastUsed || 0).getTime() - new Date(b.lastUsed || 0).getTime();
 }
 
+function openCodeAuthPath() {
+  const dataHome = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(dataHome, "opencode", "auth.json");
+}
+
+export function readCurrentOpenAIAuth() {
+  const authPath = openCodeAuthPath();
+  if (!existsSync(authPath)) return null;
+  try {
+    return JSON.parse(readFileSync(authPath, "utf-8")).openai || null;
+  } catch {
+    return null;
+  }
+}
+
+function matchesOpenAIAuth(account, auth) {
+  if (!auth) return false;
+  return Boolean(
+    (auth.accountId && account.accountId && auth.accountId === account.accountId) ||
+    (auth.access && account.access && auth.access === account.access) ||
+    (auth.refresh && account.refresh && auth.refresh === account.refresh),
+  );
+}
+
+function isAvailableAccount(account, now = Date.now()) {
+  return ["active", "idle"].includes(account.status) && (!account.cooldownUntil || account.cooldownUntil <= now);
+}
+
 /**
  * Generic pool account selection (shared by all inject functions).
  * Finds the best available account with a valid token.
@@ -102,18 +133,26 @@ async function selectPoolAccount(provider, skipEmail) {
   if (accounts.length === 0) return null;
   normalizeExpiredCooldowns(provider, accounts);
   const now = Date.now();
-  const isAvailable = (a) =>
-    ["active", "idle"].includes(a.status) && (!a.cooldownUntil || a.cooldownUntil <= now);
   const sorted = [...accounts]
-    .filter((a) => isAvailable(a) && a.email !== skipEmail)
+    .filter((a) => isAvailableAccount(a, now) && a.email !== skipEmail)
     .sort(compareAccountPriority);
   for (const c of sorted) {
     if (await ensureValidToken(provider, c)) return c;
     console.error(`[aidevops] OAuth pool: skipping invalid ${provider} token for ${c.email}`);
   }
-  const fb = accounts.find((a) => isAvailable(a) && a.email !== skipEmail);
+  const fb = accounts.find((a) => isAvailableAccount(a, now) && a.email !== skipEmail);
   if (fb && await ensureValidToken(provider, fb)) return fb;
   return null;
+}
+
+export async function selectOpenAIStartupAccount(skipEmail) {
+  const accounts = getAccounts("openai");
+  if (accounts.length === 0) return null;
+  normalizeExpiredCooldowns("openai", accounts);
+  const currentAuth = readCurrentOpenAIAuth();
+  const current = accounts.find((a) => a.email !== skipEmail && matchesOpenAIAuth(a, currentAuth));
+  if (current && isAvailableAccount(current) && await ensureValidToken("openai", current)) return current;
+  return selectPoolAccount("openai", skipEmail);
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +194,10 @@ export async function rotateOpenAIPoolToken(client, skipEmail) {
 }
 
 export async function injectOpenAIPoolToken(client, skipEmail) {
-  return !!(await rotateOpenAIPoolToken(client, skipEmail));
+  const account = await selectOpenAIStartupAccount(skipEmail);
+  if (!account) return false;
+  await applyOpenAIPoolAccount(client, account);
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -98,8 +98,8 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
   });
 });
 
-test("OpenAI startup injection preserves current auth when available", async () => {
-  const home = mkdtempSync(join(tmpdir(), "aidevops-openai-startup-preserve-"));
+test("OpenAI startup injection honors current auth availability", async () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-openai-startup-"));
   const script = String.raw`
     import assert from "node:assert/strict";
     import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -113,48 +113,31 @@ test("OpenAI startup injection preserves current auth when available", async () 
     const poolPath = join(aidevopsDir, "oauth-pool.json");
     const authPath = join(opencodeDir, "auth.json");
 
-    writeFileSync(poolPath, JSON.stringify({ openai: [
+    async function injectWithPool(pool, auth) {
+      writeFileSync(poolPath, JSON.stringify(pool));
+      writeFileSync(authPath, JSON.stringify({ openai: auth }));
+      const authWrites = [];
+      const { injectOpenAIPoolToken } = await import("./oauth-pool.mjs?case=" + Math.random());
+      const ok = await injectOpenAIPoolToken({ auth: { set: async (entry) => authWrites.push(entry) } });
+      return { ok, authWrites, pool: JSON.parse(readFileSync(poolPath, "utf-8")) };
+    }
+
+    const preserved = await injectWithPool({ openai: [
       { email: "old@example.com", access: "old-token", refresh: "old-refresh", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_old" },
       { email: "current@example.com", access: "current-token", refresh: "current-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z", accountId: "acct_current" },
-    ] }));
-    writeFileSync(authPath, JSON.stringify({ openai: { type: "oauth", access: "current-token", refresh: "current-refresh", expires: Date.now() + 3600_000, accountId: "acct_current" } }));
+    ] }, { type: "oauth", access: "current-token", refresh: "current-refresh", expires: Date.now() + 3600_000, accountId: "acct_current" });
 
-    const authWrites = [];
-    const { injectOpenAIPoolToken } = await import("./oauth-pool.mjs?case=" + Math.random());
-    assert.equal(await injectOpenAIPoolToken({ auth: { set: async (entry) => authWrites.push(entry) } }), true);
-    assert.equal(authWrites[0].body.accountId, "acct_current");
-    const pool = JSON.parse(readFileSync(poolPath, "utf-8"));
-    assert.equal(pool.openai[1].status, "active");
-  `;
-  execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
-    cwd: join(import.meta.dirname, ".."),
-    env: { ...process.env, HOME: home, XDG_DATA_HOME: join(home, ".local", "share") },
-    stdio: "pipe",
-  });
-});
+    assert.equal(preserved.ok, true);
+    assert.equal(preserved.authWrites[0].body.accountId, "acct_current");
+    assert.equal(preserved.pool.openai[1].status, "active");
 
-test("OpenAI startup injection rotates away from unavailable current auth", async () => {
-  const home = mkdtempSync(join(tmpdir(), "aidevops-openai-startup-rotate-"));
-  const script = String.raw`
-    import assert from "node:assert/strict";
-    import { mkdirSync, writeFileSync } from "node:fs";
-    import { join } from "node:path";
-
-    const home = process.env.HOME;
-    const aidevopsDir = join(home, ".aidevops");
-    const opencodeDir = join(home, ".local", "share", "opencode");
-    mkdirSync(aidevopsDir, { recursive: true });
-    mkdirSync(opencodeDir, { recursive: true });
-    writeFileSync(join(aidevopsDir, "oauth-pool.json"), JSON.stringify({ openai: [
+    const rotated = await injectWithPool({ openai: [
       { email: "cooldown@example.com", access: "cooldown-token", refresh: "cooldown-refresh", expires: Date.now() + 3600_000, status: "rate-limited", cooldownUntil: Date.now() + 86400_000, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_cooldown" },
       { email: "fresh@example.com", access: "fresh-token", refresh: "fresh-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z", accountId: "acct_fresh" },
-    ] }));
-    writeFileSync(join(opencodeDir, "auth.json"), JSON.stringify({ openai: { type: "oauth", access: "cooldown-token", refresh: "cooldown-refresh", expires: Date.now() + 3600_000, accountId: "acct_cooldown" } }));
+    ] }, { type: "oauth", access: "cooldown-token", refresh: "cooldown-refresh", expires: Date.now() + 3600_000, accountId: "acct_cooldown" });
 
-    const authWrites = [];
-    const { injectOpenAIPoolToken } = await import("./oauth-pool.mjs?case=" + Math.random());
-    assert.equal(await injectOpenAIPoolToken({ auth: { set: async (entry) => authWrites.push(entry) } }), true);
-    assert.equal(authWrites[0].body.accountId, "acct_fresh");
+    assert.equal(rotated.ok, true);
+    assert.equal(rotated.authWrites[0].body.accountId, "acct_fresh");
   `;
   execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
     cwd: join(import.meta.dirname, ".."),

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -97,3 +97,68 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
     stdio: "pipe",
   });
 });
+
+test("OpenAI startup injection preserves current auth when available", async () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-openai-startup-preserve-"));
+  const script = String.raw`
+    import assert from "node:assert/strict";
+    import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+    import { join } from "node:path";
+
+    const home = process.env.HOME;
+    const aidevopsDir = join(home, ".aidevops");
+    const opencodeDir = join(home, ".local", "share", "opencode");
+    mkdirSync(aidevopsDir, { recursive: true });
+    mkdirSync(opencodeDir, { recursive: true });
+    const poolPath = join(aidevopsDir, "oauth-pool.json");
+    const authPath = join(opencodeDir, "auth.json");
+
+    writeFileSync(poolPath, JSON.stringify({ openai: [
+      { email: "old@example.com", access: "old-token", refresh: "old-refresh", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_old" },
+      { email: "current@example.com", access: "current-token", refresh: "current-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z", accountId: "acct_current" },
+    ] }));
+    writeFileSync(authPath, JSON.stringify({ openai: { type: "oauth", access: "current-token", refresh: "current-refresh", expires: Date.now() + 3600_000, accountId: "acct_current" } }));
+
+    const authWrites = [];
+    const { injectOpenAIPoolToken } = await import("./oauth-pool.mjs?case=" + Math.random());
+    assert.equal(await injectOpenAIPoolToken({ auth: { set: async (entry) => authWrites.push(entry) } }), true);
+    assert.equal(authWrites[0].body.accountId, "acct_current");
+    const pool = JSON.parse(readFileSync(poolPath, "utf-8"));
+    assert.equal(pool.openai[1].status, "active");
+  `;
+  execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, HOME: home, XDG_DATA_HOME: join(home, ".local", "share") },
+    stdio: "pipe",
+  });
+});
+
+test("OpenAI startup injection rotates away from unavailable current auth", async () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-openai-startup-rotate-"));
+  const script = String.raw`
+    import assert from "node:assert/strict";
+    import { mkdirSync, writeFileSync } from "node:fs";
+    import { join } from "node:path";
+
+    const home = process.env.HOME;
+    const aidevopsDir = join(home, ".aidevops");
+    const opencodeDir = join(home, ".local", "share", "opencode");
+    mkdirSync(aidevopsDir, { recursive: true });
+    mkdirSync(opencodeDir, { recursive: true });
+    writeFileSync(join(aidevopsDir, "oauth-pool.json"), JSON.stringify({ openai: [
+      { email: "cooldown@example.com", access: "cooldown-token", refresh: "cooldown-refresh", expires: Date.now() + 3600_000, status: "rate-limited", cooldownUntil: Date.now() + 86400_000, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_cooldown" },
+      { email: "fresh@example.com", access: "fresh-token", refresh: "fresh-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z", accountId: "acct_fresh" },
+    ] }));
+    writeFileSync(join(opencodeDir, "auth.json"), JSON.stringify({ openai: { type: "oauth", access: "cooldown-token", refresh: "cooldown-refresh", expires: Date.now() + 3600_000, accountId: "acct_cooldown" } }));
+
+    const authWrites = [];
+    const { injectOpenAIPoolToken } = await import("./oauth-pool.mjs?case=" + Math.random());
+    assert.equal(await injectOpenAIPoolToken({ auth: { set: async (entry) => authWrites.push(entry) } }), true);
+    assert.equal(authWrites[0].body.accountId, "acct_fresh");
+  `;
+  execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, HOME: home, XDG_DATA_HOME: join(home, ".local", "share") },
+    stdio: "pipe",
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve the current OpenCode OpenAI auth account during startup when it maps to an active/idle pool account.
- Rotate away from the current account only when it is unavailable, on cooldown, skipped, or has invalid credentials.
- Add regression coverage for both preserving the manually rotated account and rotating away from a cooldown account.

## Tests
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs`
- `qlty smells .agents/plugins/opencode-aidevops/oauth-pool.mjs .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs`

Resolves #22640

$(gh-signature-helper.sh footer --model openai/gpt-5.5)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.16 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1h 18m and 1,048,872 tokens on this with the user in an interactive session.