### PR TITLE
GH#22656: fix dispatch dedup for ops-wrapped comments

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -268,7 +268,7 @@ _detect_stale_worker_takeover_reason() {
 
 	local last_dispatch_json dispatch_created_at
 	last_dispatch_json=$(printf '%s' "$comments_json" | jq -c '
-		[.[] | select((.body_start // "") | startswith("Dispatching worker"))]
+		[.[] | select((.body_start // "") | test("(^|\\n)Dispatching worker"))]
 		| sort_by(.created_at) | reverse | first // empty
 	' 2>/dev/null) || last_dispatch_json=""
 	if [[ -z "$last_dispatch_json" || "$last_dispatch_json" == "null" ]]; then

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1548,7 +1548,7 @@ has_dispatch_comment() {
 	# Find the most recent dispatch comment (newest first)
 	local last_dispatch_json
 	last_dispatch_json=$(printf '%s' "$comments_json" | jq -c '
-		[.[] | select((.body_start // "") | startswith("Dispatching worker"))]
+		[.[] | select((.body_start // "") | test("(^|\\n)Dispatching worker"))]
 		| sort_by(.created_at) | reverse | first // empty
 	' 2>/dev/null) || last_dispatch_json=""
 

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -219,14 +219,21 @@ _dsi_resolve_model() {
 #######################################
 # Pre-create the worker worktree. Sets _DSI_WORKTREE_PATH and _DSI_WORKTREE_BRANCH.
 # Args:
-#   $1 - issue number
+#   $1 - issue number, $2 - repo slug
 # Returns: 0 success, 1 failure (worktree creation failed after all retries)
 #######################################
 _dsi_create_worktree() {
 	local issue_number="$1"
+	local repo_slug="$2"
+	local repo_path
+	repo_path=$(_dsi_repo_path_for_slug "$repo_slug") || repo_path=""
+	if [[ -z "$repo_path" || ! -d "$repo_path" ]]; then
+		_dsi_err "Cannot resolve local repo path for ${repo_slug}; check ~/.config/aidevops/repos.json"
+		return 1
+	fi
 	local ts
 	ts=$(date -u +%Y%m%d-%H%M%S)
-	local branch="auto-${ts}-gh${issue_number}"
+	local branch="feature/auto-${ts}-gh${issue_number}"
 
 	local attempt max_attempts
 	max_attempts=3
@@ -237,14 +244,14 @@ _dsi_create_worktree() {
 	for attempt in 1 2 3; do
 		# worktree-helper.sh add: outputs creation messages to stderr; the
 		# branch name is what we passed in.
-		if AIDEVOPS_SKIP_AUTO_CLAIM=1 "$_DSI_WORKTREE_HELPER" add "$branch" \
-			--base "origin/$(_dsi_default_branch)" --issue "$issue_number" >&2; then
+		if (cd "$repo_path" && AIDEVOPS_SKIP_AUTO_CLAIM=1 "$_DSI_WORKTREE_HELPER" add "$branch" \
+			--base "origin/$(_dsi_default_branch "$repo_path")" --issue "$issue_number") >&2; then
 			# Query git for the actual worktree path. worktree-helper.sh uses its
 			# own slug logic (lowercases, parent dir from get_repo_root) — recomputing
 			# that here is fragile. Read it back from `git worktree list` instead.
 			# Awk inlined to one line to avoid tripping the positional-ratchet (its
 			# single-quote-strip is line-local; multi-line awk scripts get false-positives).
-			_DSI_WORKTREE_PATH=$(git worktree list --porcelain | awk -v b="$branch" '/^worktree / {p=$0;sub(/^worktree /,"",p)} $0 == "branch refs/heads/" b {print p; exit}')
+			_DSI_WORKTREE_PATH=$(git -C "$repo_path" worktree list --porcelain | awk -v b="$branch" '/^worktree / {p=$0;sub(/^worktree /,"",p)} $0 == "branch refs/heads/" b {print p; exit}')
 			_DSI_WORKTREE_BRANCH="$branch"
 			if [[ -n "$_DSI_WORKTREE_PATH" && -d "$_DSI_WORKTREE_PATH" ]]; then
 				return 0
@@ -267,9 +274,27 @@ _dsi_create_worktree() {
 # Resolve repo's default branch (cached per call). Falls back to "main".
 #######################################
 _dsi_default_branch() {
+	local repo_path="$1"
 	local b
-	b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
+	b=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
 	echo "${b:-main}"
+	return 0
+}
+
+#######################################
+# Resolve a repo slug to its registered canonical local path.
+# Args: $1 - repo slug (owner/repo)
+# Outputs: canonical path, if registered
+#######################################
+_dsi_repo_path_for_slug() {
+	local repo_slug="$1"
+	local repos_file="${AIDEVOPS_REPOS_FILE:-$HOME/.config/aidevops/repos.json}"
+	[[ -n "$repo_slug" && -f "$repos_file" ]] || return 1
+	jq -r --arg slug "$repo_slug" '
+		.initialized_repos[]?
+		| select((.slug // "") == $slug and (.local_only // false) == false)
+		| .path
+	' "$repos_file" 2>/dev/null | head -n 1
 	return 0
 }
 
@@ -627,6 +652,7 @@ _dsi_build_prompt() {
 #   $7 - agent_name
 #   $8 - worker_log path
 #   $9 - issue_number
+#   $10 - repo_slug
 # Stdout (on success): worker PID (single line)
 # Returns: 0 launched, 1 failed
 #######################################
@@ -640,6 +666,7 @@ _dsi_launch_worker() {
 	local agent_name="$7"
 	local worker_log="$8"
 	local issue_number="$9"
+	local repo_slug="${10:-}"
 
 	local -a cmd=(
 		env
@@ -647,6 +674,8 @@ _dsi_launch_worker() {
 		FULL_LOOP_HEADLESS=true
 		WORKER_ISSUE_NUMBER="$issue_number"
 		WORKER_WORKTREE_PATH="$worktree_path"
+		WORKER_REPO_SLUG="$repo_slug"
+		GITHUB_REPOSITORY="$repo_slug"
 		"$_DSI_HEADLESS" run
 		--role worker
 		--session-key "$session_key"
@@ -884,7 +913,7 @@ cmd_dispatch() {
 	fi
 
 	# Step 7: pre-create worktree
-	_dsi_create_worktree "$issue_number" || return 1
+	_dsi_create_worktree "$issue_number" "$repo_slug" || return 1
 
 	# Step 7.5: re-check after worktree creation so an existing live process
 	# on the same worktree cannot be joined by a second manual launch.
@@ -918,7 +947,7 @@ _dsi_launch_and_report() {
 	launch_pid=$(_dsi_launch_worker \
 		"$session_key" "$_DSI_WORKTREE_PATH" "$_DSI_ISSUE_TITLE" \
 		"$prompt" "$_DSI_TIER" "$_DSI_SELECTED_MODEL" \
-		"$_DSI_ARG_AGENT" "$worker_log" "$issue_number") || return 1
+		"$_DSI_ARG_AGENT" "$worker_log" "$issue_number" "$repo_slug") || return 1
 
 	local worker_pid
 	worker_pid=$(_dsi_resolve_worker_pid "$worker_log" "$launch_pid")

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -344,6 +344,17 @@ _validate_issue_worker_env_contract() {
 		return 1
 	fi
 
+	if [[ -n "${WORKER_REPO_SLUG:-}" ]]; then
+		local remote_url=""
+		local actual_slug=""
+		remote_url=$(git -C "$WORKER_WORKTREE_PATH" remote get-url origin 2>/dev/null) || remote_url=""
+		actual_slug=$(printf '%s' "$remote_url" | sed 's|.*github\.com[:/]||;s|\.git$||') || actual_slug=""
+		if [[ -z "$actual_slug" || "$actual_slug" != "$WORKER_REPO_SLUG" ]]; then
+			print_error "[fatal] worker worktree repo mismatch: expected ${WORKER_REPO_SLUG}, got ${actual_slug:-<unknown>}"
+			return 1
+		fi
+	fi
+
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -169,6 +169,7 @@ set -euo pipefail
 local_state_dir="${MOCK_GH_STATE_DIR:?}"
 post_body_file="${local_state_dir}/post_body.txt"
 terminal_body="${MOCK_TERMINAL_BODY:-}"
+dispatch_body="${MOCK_DISPATCH_BODY:-Dispatching worker (PID 12345)}"
 
 if [[ "${1:-}" != "api" ]]; then
 	exit 1
@@ -220,7 +221,9 @@ if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
 	fi
 
 	if [[ -n "$terminal_body" ]]; then
-		printf '[{"id":10,"body_start":"Dispatching worker (PID 12345)","body":"Dispatching worker (PID 12345)","created_at":"%s"},{"id":11,"body_start":"%s","body":"%s","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
+		printf '[{"id":10,"body_start":"%s","body":"%s","created_at":"%s"},{"id":11,"body_start":"%s","body":"%s","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
+			"$dispatch_body" \
+			"$dispatch_body" \
 			"${MOCK_DISPATCH_CREATED_AT:?}" \
 			"$terminal_body" \
 			"$terminal_body" \
@@ -231,7 +234,9 @@ if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
 		exit 0
 	fi
 
-	printf '[{"id":10,"body_start":"Dispatching worker (PID 12345)","body":"Dispatching worker (PID 12345)","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
+	printf '[{"id":10,"body_start":"%s","body":"%s","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
+		"$dispatch_body" \
+		"$dispatch_body" \
 		"${MOCK_DISPATCH_CREATED_AT:?}" \
 		"$new_body" \
 		"$new_body" \
@@ -243,6 +248,53 @@ exit 1
 EOF
 	chmod +x "${mock_bin_dir}/gh"
 	MOCK_TERMINAL_BODY="$terminal_body" printf '%s' "$mock_bin_dir"
+	return 0
+}
+
+#######################################
+# Test: ops-wrapped dispatch comments still annotate stale takeover (t355x)
+#######################################
+test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_stale_worker_mock_gh "$tmp_dir")"
+
+	local dispatch_created_at claim_created_at output exit_code dispatch_body
+	dispatch_created_at="$(iso_seconds_ago 120)"
+	claim_created_at="$(iso_seconds_ago 1)"
+	dispatch_body='<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\nDispatching worker (deterministic).'
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_DISPATCH_CREATED_AT="$dispatch_created_at" \
+		MOCK_DISPATCH_BODY="$dispatch_body" \
+		MOCK_CLAIM_CREATED_AT="$claim_created_at" \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_ACTIVE_WORKER_MAX_AGE=60 \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "ops-wrapped stale worker takeover claim exits 0" 0
+	else
+		print_result "ops-wrapped stale worker takeover claim exits 0" 1 "got exit $exit_code output: $output"
+	fi
+
+	local post_body=""
+	if [[ -f "${tmp_dir}/post_body.txt" ]]; then
+		post_body=$(<"${tmp_dir}/post_body.txt")
+	fi
+	if printf '%s' "$post_body" | grep -q 'reason=stale_worker_takeover'; then
+		print_result "ops-wrapped stale worker takeover claim includes reason" 0
+	else
+		print_result "ops-wrapped stale worker takeover claim includes reason" 1 "body: ${post_body:-none}"
+	fi
+
+	rm -rf "$tmp_dir"
 	return 0
 }
 
@@ -606,6 +658,7 @@ main() {
 	test_claim_rejects_stale_same_runner_claim
 	test_claim_rejects_fresh_same_runner_claim
 	test_claim_marks_stale_worker_takeover
+	test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment
 	test_claim_skips_takeover_reason_after_terminal
 
 	echo ""

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -155,6 +155,7 @@ create_dispatch_comment_gh_stub() {
 	local dispatch_created_at="$1"
 	local terminal_body="${2:-}"
 	local terminal_created_at="${3:-}"
+	local dispatch_body="${4:-Dispatching worker (PID 12345)}"
 
 	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
 #!/usr/bin/env bash
@@ -162,10 +163,10 @@ set -euo pipefail
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -q '/comments'; then
 	if [[ -n "${terminal_body}" ]]; then
-		printf '%s\n' '[{"created_at":"${dispatch_created_at}","author":"runner1","body_start":"Dispatching worker (PID 12345)"},{"created_at":"${terminal_created_at}","author":"runner1","body_start":"${terminal_body}"}]'
+		printf '%s\n' '[{"created_at":"${dispatch_created_at}","author":"runner1","body_start":"${dispatch_body}"},{"created_at":"${terminal_created_at}","author":"runner1","body_start":"${terminal_body}"}]'
 		exit 0
 	fi
-	printf '%s\n' '[{"created_at":"${dispatch_created_at}","author":"runner1","body_start":"Dispatching worker (PID 12345)"}]'
+	printf '%s\n' '[{"created_at":"${dispatch_created_at}","author":"runner1","body_start":"${dispatch_body}"}]'
 	exit 0
 fi
 
@@ -478,6 +479,27 @@ test_dispatch_comment_blocks_inside_active_worker_window() {
 	return 0
 }
 
+test_ops_wrapped_dispatch_comment_blocks_inside_active_worker_window() {
+	local dispatch_created_at output dispatch_body
+	dispatch_created_at=$(date -u -v-120S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '120 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+	dispatch_body='<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\nDispatching worker (deterministic).'
+	create_dispatch_comment_gh_stub "$dispatch_created_at" "" "" "$dispatch_body"
+
+	if output=$(DISPATCH_COMMENT_MAX_AGE=60 DISPATCH_ACTIVE_WORKER_MAX_AGE=300 "$HELPER_SCRIPT" has-dispatch-comment 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'active-worker window'*)
+			print_result "ops-wrapped dispatch comment blocks inside active-worker window" 0
+			return 0
+			;;
+		esac
+		print_result "ops-wrapped dispatch comment blocks inside active-worker window" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "ops-wrapped dispatch comment blocks inside active-worker window" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
 test_dispatch_comment_expires_after_active_worker_window() {
 	local dispatch_created_at
 	dispatch_created_at=$(date -u -v-400S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '400 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
@@ -528,6 +550,7 @@ main() {
 	test_maintainer_assigned_with_origin_interactive_blocks
 	test_owner_assigned_no_status_no_origin_allows_dispatch
 	test_dispatch_comment_blocks_inside_active_worker_window
+	test_ops_wrapped_dispatch_comment_blocks_inside_active_worker_window
 	test_dispatch_comment_expires_after_active_worker_window
 	test_dispatch_comment_terminal_marker_allows
 

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -489,8 +489,8 @@ test_launch_worker_forwards_agent() {
 
 test_launch_worker_forwards_repo_contract() {
 	local failed=1
-	if grep -Fq 'WORKER_REPO_SLUG="$repo_slug"' "$HELPER_PATH" &&
-		grep -Fq 'GITHUB_REPOSITORY="$repo_slug"' "$HELPER_PATH"; then
+	if grep -Fq "WORKER_REPO_SLUG=\"\$repo_slug\"" "$HELPER_PATH" &&
+		grep -Fq "GITHUB_REPOSITORY=\"\$repo_slug\"" "$HELPER_PATH"; then
 		failed=0
 	fi
 	print_result "worker launch forwards target repo contract" "$failed"
@@ -499,9 +499,9 @@ test_launch_worker_forwards_repo_contract() {
 
 test_create_worktree_uses_target_repo_path() {
 	local failed=1
-	if grep -Fq 'repo_path=$(_dsi_repo_path_for_slug "$repo_slug")' "$HELPER_PATH" &&
-		grep -Fq 'cd "$repo_path" && AIDEVOPS_SKIP_AUTO_CLAIM=1' "$HELPER_PATH" &&
-		grep -Fq 'git -C "$repo_path" worktree list --porcelain' "$HELPER_PATH"; then
+	if grep -Fq "repo_path=\$(_dsi_repo_path_for_slug \"\$repo_slug\")" "$HELPER_PATH" &&
+		grep -Fq "cd \"\$repo_path\" && AIDEVOPS_SKIP_AUTO_CLAIM=1" "$HELPER_PATH" &&
+		grep -Fq "git -C \"\$repo_path\" worktree list --porcelain" "$HELPER_PATH"; then
 		failed=0
 	fi
 	print_result "worktree creation uses target repo path" "$failed"

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -487,6 +487,27 @@ test_launch_worker_forwards_agent() {
 	return 0
 }
 
+test_launch_worker_forwards_repo_contract() {
+	local failed=1
+	if grep -Fq 'WORKER_REPO_SLUG="$repo_slug"' "$HELPER_PATH" &&
+		grep -Fq 'GITHUB_REPOSITORY="$repo_slug"' "$HELPER_PATH"; then
+		failed=0
+	fi
+	print_result "worker launch forwards target repo contract" "$failed"
+	return 0
+}
+
+test_create_worktree_uses_target_repo_path() {
+	local failed=1
+	if grep -Fq 'repo_path=$(_dsi_repo_path_for_slug "$repo_slug")' "$HELPER_PATH" &&
+		grep -Fq 'cd "$repo_path" && AIDEVOPS_SKIP_AUTO_CLAIM=1' "$HELPER_PATH" &&
+		grep -Fq 'git -C "$repo_path" worktree list --porcelain' "$HELPER_PATH"; then
+		failed=0
+	fi
+	print_result "worktree creation uses target repo path" "$failed"
+	return 0
+}
+
 
 
 test_live_dispatch_detects_issue_repo() {
@@ -568,6 +589,8 @@ _run_tests() {
 	test_load_issue_meta_blocks_lowercase_closed
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
+	test_launch_worker_forwards_repo_contract
+	test_create_worktree_uses_target_repo_path
 	test_live_dispatch_detects_issue_repo
 	test_guard_blocks_ledger_duplicate
 	test_guard_blocks_live_worktree_duplicate


### PR DESCRIPTION
## Summary
- Recognize deterministic dispatch comments even when wrapped by the ops audit HTML marker, restoring the active-worker dedup block.
- Bind manual single-issue dispatch worktree creation to the target repo from `repos.json` and abort workers if the worktree remote mismatches the target repo.
- Add regressions for ops-wrapped dispatch comments, stale-worker takeover annotation, and manual dispatch target-repo contract.

## Verification
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/dispatch-claim-helper.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh .agents/scripts/tests/test-dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh`
- `bash .agents/scripts/tests/test-dispatch-claim-helper.sh`
- `bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh`

Resolves #22656
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.20 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-opus-4-7 spent 3h 12m and 1,743,709 tokens on this with the user in an interactive session.