### PR TITLE
GH#22654: extract quality gate pattern references

### DIFF
--- a/.agents/aidevops/badges.md
+++ b/.agents/aidevops/badges.md
@@ -8,10 +8,15 @@ badges for stats GitHub already exposes, plus a self-hosted SVG for lines
 of code (the only badge that needs custom infrastructure because shields.io's
 tokei endpoint is too unreliable to depend on).
 
-This is **Phase 1** — the framework artifacts. **Phase 2** (filed as a
-follow-up issue) adds the `aidevops badges check|sync|render|install`
-CLI subcommand and an `aidevops init` hook to apply badges automatically
-to every managed repo from `repos.json`.
+Use `aidevops badges render|check|sync|install` to manage README badge blocks
+and LOC badge workflows for repos listed in `repos.json`.
+
+Subcommands:
+
+- `render` — print the badge block that would be inserted.
+- `check` — fail on README badge drift.
+- `sync` — update the README badge block and managed LOC workflow caller.
+- `install` — install managed badge assets for a repo.
 
 ## What you get
 

--- a/.agents/reference/large-file-split.md
+++ b/.agents/reference/large-file-split.md
@@ -199,6 +199,12 @@ justification is complete -- no maintainer intervention required for
 legitimate splits. This mirrors the `new-file-smell-ok` + justification-section
 pattern from `qlty-new-file-gate.yml`.
 
+Primary use case: file splits that trigger identity-key artifacts in
+file-size/function-complexity/bash32-compat gates. Do not use the label to hide
+real complexity growth; the PR body must show the scanner evidence and the
+measurement (`base=N, head=M, new=K` or similar) so the automated validator and
+human reviewer can distinguish a split artifact from new debt.
+
 ### 4.2 Pre-push complexity guard
 
 The client-side `complexity-regression-pre-push.sh` hook rejects on the same

--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -31,7 +31,7 @@ The reusable pattern solves all three at once:
 
 ## Architecture
 
-```
+```text
 aidevops repo (source of truth):
   .github/workflows/issue-sync-reusable.yml       ← on: workflow_call:
                                                      All jobs. All logic. 1300+ lines.
@@ -105,6 +105,10 @@ Keep pinned callers in sync with aidevops releases via:
 aidevops check-workflows        # detect drift
 aidevops sync-workflows --apply # update pins to current aidevops version
 ```
+
+These are the canonical drift tools for managed downstream repos. Use
+`check-workflows` when auditing, and `sync-workflows --apply` when you are ready
+to update caller YAMLs to the current framework template/pin.
 
 See also [`auto-dispatch.md`](auto-dispatch.md) for the `SYNC_PAT` requirement (unchanged under the reusable pattern — still per-repo secret).
 

--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -190,6 +190,73 @@ New pre-commit validators and CI gates should block regressions, not all histori
 - `.agents/scripts/qlty-regression-helper.sh` (t2065)
 - `.agents/scripts/qlty-new-file-gate-helper.sh` (t2068)
 
+## Quality gate pattern reference (t2065/t2068/t2229/t2047)
+
+Quality gates should be narrow, diff-scoped where possible, and paired with a
+documented local check plus an explicit override path. The gate should teach the
+worker what to fix; the override should require evidence, not a maintainer guess.
+
+### Qlty regression gate (t2065, GH#18773)
+
+`.github/workflows/qlty-regression.yml` fails when a PR introduces a net increase
+in `qlty smells` count. Docs-only PRs skip automatically. The helper
+`.agents/scripts/qlty-regression-helper.sh` supports local dry runs and reports
+the per-rule/per-file breakdown so the worker fixes the new regression instead
+of chasing unrelated historical debt.
+
+Override: apply the `ratchet-bump` label only with a PR-body justification that
+explains why the increase is intentional or why the baseline must absorb drift.
+
+### Qlty new-file smell gate (t2068)
+
+`.github/workflows/qlty-new-file-gate.yml` fails when newly-added source files
+ship with qlty smells. This complements t2065: modified existing files are
+covered by the regression delta; brand-new files are held to a zero-smell
+baseline so new subsystems do not import debt on day one.
+
+Local check:
+
+```bash
+.agents/scripts/qlty-new-file-gate-helper.sh new-files --base origin/main --dry-run
+```
+
+Override: apply `new-file-smell-ok` and include a `## New File Smell
+Justification` section in the PR body. Both are required; the label alone should
+not stick.
+
+### Workflow cascade vulnerability lint (t2229)
+
+`.github/workflows/workflow-cascade-lint.yml` flags PRs that modify workflows
+containing the cascade-vulnerable combination: label-like event types (`labeled`,
+`unlabeled`, `assigned`, etc.), `cancel-in-progress: true`, and no mitigation
+such as `paths-ignore` or an event-action guard. The canonical failure mode was
+t2220: 15 cancelled runs in about 2 seconds after label churn retriggered the
+same workflow repeatedly.
+
+Local check:
+
+```bash
+.agents/scripts/workflow-cascade-lint.sh --dry-run
+```
+
+Override: apply `workflow-cascade-ok` and include a `## Workflow Cascade
+Justification` section in the PR body explaining why the event/action mix cannot
+cascade or why the mitigation is equivalent.
+
+### Task-ID collision guard (t2047)
+
+t-IDs in commit subjects must be allocated by `claim-task-id.sh`; invented IDs
+break the audit trail and can collide with already-claimed work. Enforcement is
+two-layered:
+
+- Client-side commit-msg hook installed by
+  `.agents/scripts/install-task-id-guard.sh install`.
+- Server-side CI workflow installed alongside the hook, covering commits made
+  outside the local hook path.
+
+The guard permits cross-references to other tasks when the linked issue title or
+body provides that context, but the primary commit task ID must be real.
+
 ## Self-modifying tooling test discipline (GH#18538 / t2062)
 
 When you edit a script that participates in the test or verification loop you subsequently invoke, the working tree is part of the test environment. Running `full-loop-helper.sh`, `pre-edit-check.sh`, `claim-task-id.sh`, or another wrapper from the same worktree can execute uncommitted changes rather than the version that will ship.

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -229,22 +229,22 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Review Bot Gate (t1382):** Before merging: `review-bot-gate-helper.sh check <PR_NUMBER>` and read bot reviews. Additive bot suggestions become follow-up tasks, not PR scope creep. Full workflow/overrides: `reference/review-bot-gate.md`.
 
-**Qlty Regression Gate (t2065, GH#18773):** CI fails if a PR introduces a net increase in `qlty smells` count. Docs-only PRs skip automatically. Override: add `ratchet-bump` label with justification. Helper: `qlty-regression-helper.sh` (supports `--dry-run`).
+**Qlty Regression Gate (t2065, GH#18773):** CI fails on net `qlty smells` increases; details/override/local check: `reference/shell-style-guide.md` "Quality gate pattern reference".
 
-**Qlty New-File Smell Gate (t2068):** CI fails if newly-added files ship with smells. Complements t2065 (which catches increases in existing files). Override: `new-file-smell-ok` label AND a `## New File Smell Justification` section in the PR body — both required. Local check: `qlty-new-file-gate-helper.sh new-files --base origin/main --dry-run`.
+**Qlty New-File Smell Gate (t2068):** CI fails when brand-new source files ship with smells; details/override/local check: `reference/shell-style-guide.md` "Quality gate pattern reference".
 
 **Cryptographic approval + NMR automation (t2386):** moved to `reference/task-lifecycle.md`; read before approving issues/PRs or clearing/preserving NMR.
 
-**Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`. The commit-msg hook (`install-task-id-guard.sh install`) enforces this client-side; the CI check (`.github/workflows/task-id-collision-check.yml`) enforces it server-side for commits authored outside the hook.
+**Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`; enforcement details live in `reference/shell-style-guide.md` "Quality gate pattern reference".
 
-**Large-file splits (t2368):** When splitting a shell library into sub-libraries (responding to `file-size-debt`, `function-complexity`, or `nesting-depth` scanner issues), read `reference/large-file-split.md` first. It covers the canonical orchestrator + sub-library pattern, identity-key preservation rules, known CI false-positive classes, pre-commit hook gotchas, and a complete PR body template. A worker reading only this doc + the scanner-filed issue body can complete a split PR end-to-end without re-discovering any lesson.
+**Large-file splits (t2368):** file-size/function-complexity/nesting-depth scanner issues start with `reference/large-file-split.md`.
 
-**Complexity Bump Override (t2370):** The `complexity-bump-ok` label overrides the complexity regression gates in `code-quality.yml` (nesting-depth, file-size, function-complexity, bash32-compat). Workers and maintainers may self-apply this label when the PR body contains a validated `## Complexity Bump Justification` section with: (1) at least one `file:line` reference citing the scanner evidence, and (2) at least one numeric measurement (`base=N, head=M, new=K` or similar). Workflow: `.github/workflows/complexity-bump-justification-check.yml` — triggers on `labeled` event, validates the section, and removes the label with a remediation comment if justification is incomplete. This mirrors the `new-file-smell-ok` + justification-section pattern. Primary use case: file splits that trigger nesting-depth false positives from identity-key changes (see `reference/large-file-split.md` section 4.1).
+**Complexity Bump Override (t2370):** `complexity-bump-ok` label requirements live in `reference/large-file-split.md` "Known CI false-positive classes".
 
-**Workflow Cascade Vulnerability Lint (t2229):** `.github/workflows/workflow-cascade-lint.yml` flags PRs that modify workflows containing the cascade-vulnerable combination: label-like event types (`labeled`, `unlabeled`, `assigned`, etc.) + `cancel-in-progress: true` + no mitigation (`paths-ignore` or event-action guard). See t2220 for the failure mode (15 cancelled runs in ~2s). Helper: `.agents/scripts/workflow-cascade-lint.sh` (supports `--dry-run` for local checks). Override: apply `workflow-cascade-ok` label AND add a `## Workflow Cascade Justification` section to the PR body.
+**Workflow Cascade Vulnerability Lint (t2229):** workflow cascade detection/override details live in `reference/shell-style-guide.md` "Quality gate pattern reference".
 
-**Reusable workflows:** downstream repos use thin caller YAMLs that reference aidevops reusable workflows. Drift tools: `aidevops check-workflows`, `aidevops sync-workflows --apply`. Full architecture/pinning: `reference/reusable-workflows.md`.
+**Reusable workflows:** downstream repos use thin caller YAMLs that reference aidevops reusable workflows. Full architecture/pinning/drift tools: `reference/reusable-workflows.md`.
 
-**Badge management (t2975):** `aidevops badges render|check|sync|install` manages README badge blocks and LOC badge workflows. Full docs: `.agents/aidevops/badges.md`.
+**Badge management (t2975):** README badge blocks and LOC badge workflows are managed by `aidevops badges`; full docs: `.agents/aidevops/badges.md`.
 
 Related workflow reference: `reference/session.md`


### PR DESCRIPTION
## Summary
- Extracts detailed quality gate guidance out of the Git workflow reference into focused reference docs.
- Leaves one-line pointers in `.agents/workflows/git-workflow.md` for qlty gates, task-ID guard, large-file splits, complexity overrides, workflow cascade lint, reusable workflows, and badges.

## Testing
- `npx --yes markdownlint-cli2 ".agents/workflows/git-workflow.md" ".agents/reference/shell-style-guide.md" ".agents/reference/large-file-split.md" ".agents/reference/reusable-workflows.md" ".agents/aidevops/badges.md"`

## Runtime Testing
- Risk: Low (documentation-only progressive-disclosure extraction)
- Result: self-assessed; markdownlint passed

## Key decisions
- Kept git-workflow as the entry point and moved gate-specific details to existing reference files.
- Used `For #22616` for the parent task so only the phase issue closes.

Resolves #22654
For #22616

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.20 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 7m and 123,706 tokens on this as a headless worker.
