### PR TITLE
GH#22660: wrap operational GitHub comments

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -211,10 +211,13 @@ _post_claim() {
 	version=$(_resolve_version)
 
 	local body
-	body="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version}"
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version}"
 	if [[ -n "$reason_fields" ]]; then
 		body+=" ${reason_fields}"
 	fi
+	body+="
+<!-- ops:end -->"
 
 	local comment_id
 	comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \

--- a/.agents/scripts/dispatch-dedup-cost.sh
+++ b/.agents/scripts/dispatch-dedup-cost.sh
@@ -186,7 +186,8 @@ _apply_cost_breaker_side_effects() {
 	local _budget_k=$((budget / 1000))
 
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
-		--body "<!-- cost-circuit-breaker:fired tier=${tier} spent=${spent} budget=${budget} -->
+		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- cost-circuit-breaker:fired tier=${tier} spent=${spent} budget=${budget} -->
 🛑 **Cost circuit breaker fired** (t2007)
 
 Cumulative spend **${_spent_k}K tokens** across **${attempts}** worker attempt(s) exceeds \`tier:${tier}\` budget of **${_budget_k}K tokens**.
@@ -201,7 +202,8 @@ Maintainer review required before further dispatch. Possible causes:
 
 Remove \`needs-maintainer-review\` after investigating the root cause to re-enable dispatch.
 
-_This is the cost-runaway fail-safe from t2007 (paired with t1986 parent-task guard and t2008 stale-recovery escalation)._" 2>/dev/null || true
+_This is the cost-runaway fail-safe from t2007 (paired with t1986 parent-task guard and t2008 stale-recovery escalation)._
+<!-- ops:end -->" 2>/dev/null || true
 
 	# t3076: file root-cause meta-issue with forensics and dispatch a
 	# tier:thinking worker against it. Idempotent — second trip on the

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -147,7 +147,8 @@ _stale_recovery_escalate() {
 
 	# Post escalation comment explaining the suspension
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
-		--body "<!-- stale-recovery-tick:escalated (threshold=${_threshold}) -->
+		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- stale-recovery-tick:escalated (threshold=${_threshold}) -->
 **Stale recovery threshold reached** (t2008)
 
 This issue has been stale-recovered **${_prior_ticks}** consecutive time(s) without producing a PR. Further automated dispatch is suspended until a human reviews the root cause.
@@ -158,7 +159,8 @@ Recovery count: ${_prior_ticks} (threshold: ${_threshold})
 
 Marked \`needs-maintainer-review\`. Remove this label after investigating why workers keep failing (wrong brief, unimplementable scope, missing dependency, etc.) to re-enable dispatch.
 
-_This escalation is the \"no-progress fail-safe\" from t2008 (paired with t1986 parent-task guard and t2007 cost circuit breaker)._" \
+_This escalation is the \"no-progress fail-safe\" from t2008 (paired with t1986 parent-task guard and t2007 cost circuit breaker)._
+<!-- ops:end -->" \
 		2>/dev/null || true
 	printf 'STALE_ESCALATED: issue #%s in %s — unassigned %s, applied needs-maintainer-review (threshold %s reached after %s ticks)\n' \
 		"$issue_number" "$repo_slug" "$stale_assignees" "$_threshold" "$_prior_ticks"
@@ -206,7 +208,8 @@ _stale_recovery_apply() {
 	local _now_ts
 	_now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
-		--body "<!-- WORKER_SUPERSEDED runners=${stale_assignees} ts=${_now_ts} -->
+		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- WORKER_SUPERSEDED runners=${stale_assignees} ts=${_now_ts} -->
 **Stale assignment recovered** (GH#15060)
 
 Previously assigned to: ${stale_assignees}
@@ -215,7 +218,8 @@ Threshold: ${STALE_ASSIGNMENT_THRESHOLD_SECONDS}s
 
 The assigned runner had no active worker process and produced no progress within the threshold. Unassigned and relabeled \`status:available\` for re-dispatch.
 
-_This recovery prevents the orphaned-assignment deadlock where offline runners permanently block all dispatch._" 2>/dev/null || true
+_This recovery prevents the orphaned-assignment deadlock where offline runners permanently block all dispatch._
+<!-- ops:end -->" 2>/dev/null || true
 
 	printf 'STALE_RECOVERED: issue #%s in %s — unassigned %s (%s)\n' \
 		"$issue_number" "$repo_slug" "$stale_assignees" "$reason"
@@ -261,8 +265,10 @@ _recover_stale_assignment() {
 	if [[ -n "$_open_pr" ]]; then
 		# Open PR exists — counter resets; post a reset marker and allow normal recovery
 		gh_issue_comment "$issue_number" --repo "$repo_slug" \
-			--body "<!-- stale-recovery-tick:0 (reset: open PR #${_open_pr} detected) -->
-Stale recovery tick reset — open PR #${_open_pr} detected (t2008)" \
+			--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- stale-recovery-tick:0 (reset: open PR #${_open_pr} detected) -->
+Stale recovery tick reset — open PR #${_open_pr} detected (t2008)
+<!-- ops:end -->" \
 			2>/dev/null || true
 	elif [[ "$_prior_ticks" -ge "$_threshold" ]]; then
 		# Threshold reached — escalate and bail out (no normal recovery)
@@ -272,8 +278,10 @@ Stale recovery tick reset — open PR #${_open_pr} detected (t2008)" \
 		# Under threshold — increment tick counter, continue normal recovery
 		local _next_tick=$((_prior_ticks + 1))
 		gh_issue_comment "$issue_number" --repo "$repo_slug" \
-			--body "<!-- stale-recovery-tick:${_next_tick} -->
-Stale recovery tick ${_next_tick}/${_threshold} (t2008)" \
+			--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- stale-recovery-tick:${_next_tick} -->
+Stale recovery tick ${_next_tick}/${_threshold} (t2008)
+<!-- ops:end -->" \
 			2>/dev/null || true
 	fi
 	# ── End stale-recovery escalation check ──────────────────────────────

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -66,13 +66,16 @@ _release_dispatch_claim() {
 	fi
 
 	local comment_body
-	comment_body="CLAIM_RELEASED reason=${reason} runner=$(whoami) ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=${reason} runner=$(whoami) ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	if [[ -n "$exit_code_arg" ]]; then
 		comment_body="${comment_body} exit=${exit_code_arg}"
 	fi
 	if [[ -n "$session_count_arg" ]]; then
 		comment_body="${comment_body} session_count=${session_count_arg}"
 	fi
+	comment_body="${comment_body}
+<!-- ops:end -->"
 
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--method POST \

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -622,7 +622,9 @@ _record_orphan_crash_classification() {
 	# the worker is dead. "Worker failed" is a recognised completion
 	# signal in dispatch-dedup-helper.sh has_dispatch_comment().
 	gh_issue_comment "$orphan_issue_num" --repo "$repo_slug_age" \
-		--body "Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 commits). Cleared for re-dispatch." \
+		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 commits). Cleared for re-dispatch.
+<!-- ops:end -->" \
 		>/dev/null 2>&1 || true
 
 	return 0
@@ -985,7 +987,8 @@ _post_launch_recovery_claim_released() {
 	local failure_reason="$4"
 
 	local body
-	body="CLAIM_RELEASED reason=launch_recovery:${failure_reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=launch_recovery:${failure_reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 	# t2814: append worker-log tail when available so the failure is
 	# diagnosable from the audit trail alone (no log-file forensics needed).
@@ -1013,6 +1016,8 @@ ${_WORKER_LOG_TAIL_CONTENT}
 </details>"
 		fi
 	fi
+	body="${body}
+<!-- ops:end -->"
 
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--method POST \

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1235,7 +1235,9 @@ _release_dispatch_claim_on_abort() {
 	fi
 
 	local body
-	body="CLAIM_RELEASED reason=dispatch_aborted:${reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=dispatch_aborted:${reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+<!-- ops:end -->"
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--method POST \
 		--field body="$body" \

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -127,12 +127,15 @@ if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
 		new_body=""
 	fi
 
-	printf '[{"id":1,"body":"DISPATCH_CLAIM nonce=old-nonce runner=%s ts=%s max_age_s=120","created_at":"%s"},{"id":999,"body":"%s","created_at":"%s"}]\n' \
-		"${MOCK_OLD_CLAIM_RUNNER:?}" \
-		"${MOCK_OLD_CLAIM_CREATED_AT:?}" \
-		"${MOCK_OLD_CLAIM_CREATED_AT:?}" \
-		"$new_body" \
-		"${MOCK_NEW_CLAIM_CREATED_AT:?}"
+	jq -n \
+		--arg runner "${MOCK_OLD_CLAIM_RUNNER:?}" \
+		--arg old_ts "${MOCK_OLD_CLAIM_CREATED_AT:?}" \
+		--arg new_body "$new_body" \
+		--arg new_ts "${MOCK_NEW_CLAIM_CREATED_AT:?}" \
+		'[
+			{id: 1, body: ("DISPATCH_CLAIM nonce=old-nonce runner=" + $runner + " ts=" + $old_ts + " max_age_s=120"), created_at: $old_ts},
+			{id: 999, body: $new_body, created_at: $new_ts}
+		]'
 	exit 0
 fi
 
@@ -221,26 +224,30 @@ if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
 	fi
 
 	if [[ -n "$terminal_body" ]]; then
-		printf '[{"id":10,"body_start":"%s","body":"%s","created_at":"%s"},{"id":11,"body_start":"%s","body":"%s","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
-			"$dispatch_body" \
-			"$dispatch_body" \
-			"${MOCK_DISPATCH_CREATED_AT:?}" \
-			"$terminal_body" \
-			"$terminal_body" \
-			"${MOCK_TERMINAL_CREATED_AT:?}" \
-			"$new_body" \
-			"$new_body" \
-			"${MOCK_CLAIM_CREATED_AT:?}"
+		jq -n \
+			--arg dispatch_body "$dispatch_body" \
+			--arg dispatch_ts "${MOCK_DISPATCH_CREATED_AT:?}" \
+			--arg terminal_body "$terminal_body" \
+			--arg terminal_ts "${MOCK_TERMINAL_CREATED_AT:?}" \
+			--arg new_body "$new_body" \
+			--arg claim_ts "${MOCK_CLAIM_CREATED_AT:?}" \
+			'[
+				{id: 10, body_start: $dispatch_body, body: $dispatch_body, created_at: $dispatch_ts},
+				{id: 11, body_start: $terminal_body, body: $terminal_body, created_at: $terminal_ts},
+				{id: 999, body_start: $new_body, body: $new_body, created_at: $claim_ts}
+			]'
 		exit 0
 	fi
 
-	printf '[{"id":10,"body_start":"%s","body":"%s","created_at":"%s"},{"id":999,"body_start":"%s","body":"%s","created_at":"%s"}]\n' \
-		"$dispatch_body" \
-		"$dispatch_body" \
-		"${MOCK_DISPATCH_CREATED_AT:?}" \
-		"$new_body" \
-		"$new_body" \
-		"${MOCK_CLAIM_CREATED_AT:?}"
+	jq -n \
+		--arg dispatch_body "$dispatch_body" \
+		--arg dispatch_ts "${MOCK_DISPATCH_CREATED_AT:?}" \
+		--arg new_body "$new_body" \
+		--arg claim_ts "${MOCK_CLAIM_CREATED_AT:?}" \
+		'[
+			{id: 10, body_start: $dispatch_body, body: $dispatch_body, created_at: $dispatch_ts},
+			{id: 999, body_start: $new_body, body: $new_body, created_at: $claim_ts}
+		]'
 	exit 0
 fi
 
@@ -263,7 +270,7 @@ test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment() {
 	local dispatch_created_at claim_created_at output exit_code dispatch_body
 	dispatch_created_at="$(iso_seconds_ago 120)"
 	claim_created_at="$(iso_seconds_ago 1)"
-	dispatch_body='<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\nDispatching worker (deterministic).'
+	dispatch_body=$'<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\nDispatching worker (deterministic).'
 
 	set +e
 	output=$(PATH="${mock_path}:$PATH" \
@@ -292,6 +299,11 @@ test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment() {
 		print_result "ops-wrapped stale worker takeover claim includes reason" 0
 	else
 		print_result "ops-wrapped stale worker takeover claim includes reason" 1 "body: ${post_body:-none}"
+	fi
+	if printf '%s' "$post_body" | grep -q '<!-- ops:start' && printf '%s' "$post_body" | grep -q '<!-- ops:end -->'; then
+		print_result "claim comments are ops-wrapped" 0
+	else
+		print_result "claim comments are ops-wrapped" 1 "body: ${post_body:-none}"
 	fi
 
 	rm -rf "$tmp_dir"
@@ -600,7 +612,9 @@ test_claim_skips_takeover_reason_after_terminal() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
 	local mock_path
-	mock_path="$(create_stale_worker_mock_gh "$tmp_dir" "CLAIM_RELEASED reason=worker_complete")"
+	mock_path="$(create_stale_worker_mock_gh "$tmp_dir" "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=worker_complete
+<!-- ops:end -->")"
 
 	local dispatch_created_at terminal_created_at claim_created_at output exit_code
 	dispatch_created_at="$(iso_seconds_ago 120)"
@@ -612,7 +626,9 @@ test_claim_skips_takeover_reason_after_terminal() {
 		MOCK_GH_STATE_DIR="$tmp_dir" \
 		MOCK_DISPATCH_CREATED_AT="$dispatch_created_at" \
 		MOCK_TERMINAL_CREATED_AT="$terminal_created_at" \
-		MOCK_TERMINAL_BODY="CLAIM_RELEASED reason=worker_complete" \
+		MOCK_TERMINAL_BODY="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=worker_complete
+<!-- ops:end -->" \
 		MOCK_CLAIM_CREATED_AT="$claim_created_at" \
 		DISPATCH_CLAIM_WINDOW=0 \
 		DISPATCH_CLAIM_MAX_AGE=300 \

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -493,7 +493,9 @@ _release_claim() {
 	fi
 
 	local comment_body
-	comment_body="CLAIM_RELEASED reason=watchdog_kill:${reason} runner=$(whoami) ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=watchdog_kill:${reason} runner=$(whoami) ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+<!-- ops:end -->"
 
 	# Best-effort — don't fail the watchdog if gh is unavailable
 	if command -v gh >/dev/null 2>&1; then

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -972,7 +972,8 @@ _log_no_work_skip_escalation() {
 	local safe_reason
 	safe_reason=$(_sanitize_markdown "$reason")
 
-	local comment_body="${marker}
+	local comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+${marker}
 ## Tier Escalation Skipped: Infrastructure Failure (no_work)
 
 **Trigger:** ${failure_count} worker failure(s) classified as \`no_work\` — the worker exited during setup without reading any target files.
@@ -983,7 +984,8 @@ _log_no_work_skip_escalation() {
 
 After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`needs-maintainer-review\` with a \`cost-circuit-breaker:no_work_loop\` marker that \`_nmr_application_is_circuit_breaker_trip\` (t2386) recognises, so auto-approval correctly preserves NMR.
 
-_Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_"
+_Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_
+<!-- ops:end -->"
 
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
 		--body "$comment_body" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Wrapped machine-generated dispatch, stale recovery, cleanup, watchdog, and cost/no-work comments in ops:start/ops:end markers while preserving existing machine-readable markers.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/dispatch-dedup-cost.sh,.agents/scripts/dispatch-dedup-stale.sh,.agents/scripts/headless-runtime-failure.sh,.agents/scripts/pulse-cleanup.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh,.agents/scripts/worker-activity-watchdog.sh,.agents/scripts/worker-lifecycle-common.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on changed scripts; test-dispatch-claim-helper.sh; test-dispatch-dedup-helper-is-assigned.sh; test-worker-branch-orphan-loop.sh

Resolves #22660


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.22 plugin for [OpenCode](https://opencode.ai) v1.14.33 with claude-opus-4-7 spent 3h 53m and 2,176,337 tokens on this with the user in an interactive session.