### PR TITLE
fix: preserve gpt-5.5 compaction boundary

### DIFF
--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -105,15 +105,23 @@ export const CLAUDE_MODEL_LIMITS = {
  * Current OpenCode auto-compacts at `limit.input - reserved` when `limit.input`
  * exists, and models.dev supplies a stale 272K input limit. Registering
  * input=420K preserves a 400K usable window with OpenCode's default 20K
- * reserved buffer instead of compacting near 252K. GPT-5.4 mini is registered
- * so OpenAI-backed low-cost tasks (including session-title repair prompts) can
- * select the same model aidevops already routes for haiku/local tiers.
+ * reserved buffer instead of compacting near 252K.
+ *
+ * Compatibility note (OpenCode 1.14.33): config model parsing dropped
+ * limit.input, falling back to `limit.context - maxOutputTokens(model)`. Keep
+ * context at 432K so old OpenCode's 32K output cap still yields a 400K
+ * compaction boundary. When deployed OpenCode versions reliably preserve
+ * config `limit.input`, this patch can be commented out or removed for GPT-5.5;
+ * keep the pattern for future model IDs whose provider metadata is stale.
+ * GPT-5.4 mini is registered so OpenAI-backed low-cost tasks (including
+ * session-title repair prompts) can select the same model aidevops already
+ * routes for haiku/local tiers.
  */
 export const OPENAI_MODEL_LIMITS = {
   "gpt-5.4-mini": { context: 200000, input: 180000, output: 64000 },
-  "gpt-5.5":      { context: 500000, input: 420000, output: 128000 },
-  "gpt-5.5-fast": { context: 500000, input: 420000, output: 128000 },
-  "gpt-5.5-pro":  { context: 500000, input: 420000, output: 128000 },
+  "gpt-5.5":      { context: 432000, input: 420000, output: 128000 },
+  "gpt-5.5-fast": { context: 432000, input: 420000, output: 128000 },
+  "gpt-5.5-pro":  { context: 432000, input: 420000, output: 128000 },
 };
 
 // One-shot warn at module load when the env override changed something.

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -221,13 +221,17 @@ describe("OPENAI_MODEL_LIMITS table", () => {
     assert.equal(limit.output, 64000);
   });
 
-  test("sets GPT-5.5 family input to preserve a 400K OpenCode compaction boundary", () => {
+  test("sets GPT-5.5 family limits to preserve a 400K OpenCode compaction boundary", () => {
     const expected = ["gpt-5.5", "gpt-5.5-fast", "gpt-5.5-pro"];
     for (const id of expected) {
       assert.ok(OPENAI_MODEL_LIMITS[id], `missing OpenAI limit entry for ${id}`);
-      assert.equal(OPENAI_MODEL_LIMITS[id].context, 500000);
+      // OpenCode >= upstream/dev preserves config limit.input, so the modern
+      // boundary is input - reserved. OpenCode 1.14.33 dropped config
+      // limit.input, so keep context - 32K output cap at the same boundary.
+      assert.equal(OPENAI_MODEL_LIMITS[id].context, 432000);
       assert.equal(OPENAI_MODEL_LIMITS[id].input, 420000);
       assert.equal(OPENAI_MODEL_LIMITS[id].input - 20000, 400000);
+      assert.equal(OPENAI_MODEL_LIMITS[id].context - 32000, 400000);
       assert.ok(OPENAI_MODEL_LIMITS[id].output > 0);
     }
   });


### PR DESCRIPTION
## Summary
- Keeps GPT-5.5 family `limit.input=420000` for newer OpenCode builds that preserve config input limits.
- Lowers GPT-5.5 family `limit.context` to 432000 so OpenCode 1.14.33's legacy `context - 32K` fallback also compacts at 400K.
- Documents when this compatibility patch can be removed/commented and preserves the pattern for future stale model metadata.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs`

Ref #22503

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.22 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 19m and 262,230 tokens on this with the user in an interactive session.
