### PR TITLE
fix: preserve startup greeting advisories

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -19,7 +19,7 @@ function createHooks(options = {}) {
   const hooks = createTtsrHooks({
     agentsDir: join(tmpdir(), `${tempPrefix}-agents`),
     scriptsDir: join(tmpdir(), `${tempPrefix}-scripts`),
-    readIfExists: () => "",
+    readIfExists: options.readIfExists || (() => ""),
     qualityLog: (level, message) => logs.push({ level, message }),
     run: () => "",
     intentField: "agent__intent",
@@ -47,6 +47,89 @@ function advisoryMessages(output) {
 }
 
 describe("token cost advisory threshold", () => {
+  test("prepends session greeting order to system prompt", async () => {
+    const { hooks } = createHooks({
+      readIfExists: (path) => path.endsWith("session-greeting.txt")
+        ? "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main"
+        : "",
+    });
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.match(output.system[0], /Session-start greeting order/);
+    assert.match(output.system[0], /this exact aidevops greeting/);
+    assert.match(output.system[0], /We're running aidevops v3\.14\.23 in OpenCode v1\.14\.33\./);
+  });
+
+  test("falls back to aidevops version when greeting cache is missing", async () => {
+    const { hooks } = createHooks({
+      readIfExists: (path) => path.endsWith("VERSION") ? "3.14.23\n" : "",
+    });
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.match(output.system[0], /We're running aidevops v3\.14\.23\./);
+  });
+
+  test("includes startup advisory only for warning and error cache lines", async () => {
+    const { hooks } = createHooks({
+      readIfExists: (path) => path.endsWith("session-greeting.txt")
+        ? [
+            "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main",
+            "Security: all protections active",
+            "[SECURITY ADVISORY] Rotate test credentials",
+            "[WARN] Pulse stalled for 12 minutes",
+          ].join("\n")
+        : "",
+    });
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.match(output.system[0], /After the greeting, include this short startup advisory/);
+    assert.match(output.system[0], /\[SECURITY ADVISORY\] Rotate test credentials/);
+    assert.match(output.system[0], /\[WARN\] Pulse stalled for 12 minutes/);
+    assert.doesNotMatch(output.system[0], /Security: all protections active/);
+  });
+
+  test("omits startup advisory section for clean cache", async () => {
+    const { hooks } = createHooks({
+      readIfExists: (path) => path.endsWith("session-greeting.txt")
+        ? [
+            "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main",
+            "Security: all protections active",
+          ].join("\n")
+        : "",
+    });
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.doesNotMatch(output.system[0], /startup advisory/);
+  });
+
+  test("does not inject session greeting order in headless sessions", async () => {
+    const { hooks } = createHooks({ isHeadless: () => true });
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.equal(output.system[0], "base system prompt");
+  });
+
+  test("keeps Anthropic identity prefix separate from greeting order", async () => {
+    const { hooks } = createHooks();
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "anthropic" } }, output);
+
+    assert.match(output.system[0], /Session-start greeting order/);
+    assert.equal(output.system[1], "You are Claude Code, Anthropic's official CLI for Claude.");
+    assert.match(output.system[2], /^You are Claude Code, Anthropic's official CLI for Claude\.\n\nbase system prompt/);
+  });
+
   test("does not inject advisory below 250k tokens", async () => {
     const { hooks } = createHooks();
     const output = outputForTokens(249_999);

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -190,14 +190,64 @@ function buildCorrectionMessage(violations, sessionID) {
 // Hook implementations (module-level, accept state + deps as parameters)
 // ---------------------------------------------------------------------------
 
+function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
+  const cachePath = join(agentsDir, "..", "cache", "session-greeting.txt");
+  const cacheLines = readIfExists(cachePath).split("\n").map((line) => line.trim()).filter(Boolean);
+  const cacheLine = cacheLines[0] || "";
+  const cacheMatch = cacheLine.match(/^aidevops v(\S+) running in (.+?) v(\S+)(?:\s|$)/);
+  const version = cacheMatch?.[1] || readIfExists(join(agentsDir, "VERSION")).split("\n")[0] || "X";
+  const runtime = cacheMatch?.[2] || "OpenCode";
+  const runtimeVersion = cacheMatch?.[3];
+  const advisoryLines = cacheLines.filter((line) =>
+    line.startsWith("[SECURITY ADVISORY]") ||
+    line.startsWith("[ERROR]") ||
+    line.startsWith("[WARN]") ||
+    line.startsWith("[WARNING]") ||
+    line.startsWith("Pulse stalled") ||
+    line.startsWith("[OPENCODE MAINTENANCE]") ||
+    /contribution\(s\) need/i.test(line));
+  const versionLine = runtimeVersion
+    ? `We're running aidevops v${version} in ${runtime} v${runtimeVersion}.`
+    : `We're running aidevops v${version}.`;
+  const advisoryInstruction = advisoryLines.length > 0
+    ? [
+        "",
+        "After the greeting, include this short startup advisory before answering the user's request:",
+        "",
+        ...advisoryLines.map((line) => `- ${line}`),
+      ]
+    : [];
+
+  return [
+    "## Session-start greeting order",
+    "On the first assistant turn of an interactive session, the first visible text in the assistant response MUST be this exact aidevops greeting:",
+    "",
+    "Hi!",
+    "",
+    versionLine,
+    "",
+    "What would you like to work on?",
+    "",
+    "Do this before tool calls, status updates, analysis summaries, or task work.",
+    ...advisoryInstruction,
+    "If the user launched the session with an initial message, greet first in the assistant response, then answer that message.",
+    "Do not repeat the greeting after the first assistant turn, and do not duplicate the framework-status toast content.",
+  ].join("\n");
+}
+
 /**
- * system.transform hook: prepend identity prefix and inject quality rules.
+ * system.transform hook: prepend session-start greeting order, identity prefix,
+ * and quality rules.
  */
-async function ttsrSystemTransform(input, output, state, intentField) {
+async function ttsrSystemTransform(input, output, state, intentField, isHeadless, agentsDir, readIfExists) {
   if (input.model?.providerID === "anthropic") {
     const prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
     output.system.unshift(prefix);
     if (output.system[1]) output.system[1] = prefix + "\n\n" + output.system[1];
+  }
+
+  if (!isHeadless()) {
+    output.system.unshift(buildSessionStartGreetingInstruction(agentsDir, readIfExists));
   }
 
   const rules = loadTtsrRules(state);
@@ -318,7 +368,7 @@ export function createTtsrHooks(deps) {
 
   return {
     loadTtsrRules: () => loadTtsrRules(state),
-    systemTransformHook: (input, output) => ttsrSystemTransform(input, output, state, intentField),
+    systemTransformHook: (input, output) => ttsrSystemTransform(input, output, state, intentField, isHeadless, agentsDir, readIfExists),
     messagesTransformHook: (_input, output) => ttsrMessagesTransform(_input, output, state, qualityLog, isHeadless),
     textCompleteHook: (input, output) => ttsrTextComplete(input, output, state, execDeps, qualityLog),
   };

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -120,7 +120,7 @@ NOT repeat toast content in the chat.
 **On interactive conversation start** (skip for headless sessions like \`/pulse\`, \`/full-loop\`):
 
 1. Read line 1 of \`${cache_path}\`. Format: \`aidevops v{X} running in ${display_name} v{Y} | ...\`. Extract \`{X}\` and \`{Y}\`.
-2. Greet with exactly this template — no extra prose, no status dump:
+2. Before any tool call or task work, make the first visible text in your first assistant response exactly this template — no extra prose, no status dump:
 
        Hi!
 
@@ -129,7 +129,7 @@ NOT repeat toast content in the chat.
        What would you like to work on?
 
 3. If the cache file is missing, read \`~/.aidevops/agents/VERSION\` for \`{X}\` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
-4. Then respond to the user's actual message.
+4. Then respond to the user's actual message. If the user launched the session with an initial message, that user message may appear first in the transcript; still put the greeting first in your assistant response.
 
 If the user later asks about aidevops updates, direct them to run \`aidevops update\` in a terminal session (or type \`!aidevops update\` below). Do not announce updates unprompted — the toast already did.
 


### PR DESCRIPTION
## Summary
- Ensures the first assistant response uses the cached concrete aidevops/OpenCode versions instead of placeholder text.
- Preserves warning/error startup advisories in chat after the greeting while keeping clean sessions quiet.
- Clarifies generated OpenCode AGENTS wording for launch-screen initial messages.

## Testing
- node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
- shellcheck .agents/scripts/generate-runtime-config-agents.sh
- bash -n .agents/scripts/generate-runtime-config-agents.sh
- git diff --check
- Manual fresh OpenCode tab verified greeting order and version interpolation.

## Runtime Testing
self-assessed + manual fresh OpenCode tab verification; low-risk prompt/plugin system-transform change.

## Key decisions
- Keep chat clean for healthy sessions.
- Add a short chat advisory only for warning/error cache lines so critical startup notices remain visible.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.23 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 39m and 473,205 tokens on this with the user in an interactive session.