### PR TITLE
GH#22665: paginate dispatch claim comment fetch

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -15,7 +15,7 @@
 # Protocol:
 #   1. Post claim: DISPATCH_CLAIM nonce=UUID runner=LOGIN ts=ISO max_age_s=SECONDS
 #   2. Sleep consensus window (DISPATCH_CLAIM_WINDOW, default 8s)
-#   3. Re-read comments, find all DISPATCH_CLAIM within the window
+#   3. Re-read paginated comments, find all DISPATCH_CLAIM within the window
 #   4. Oldest active claim wins — others back off and delete their claim
 #
 # Usage:
@@ -44,6 +44,11 @@ DISPATCH_CLAIM_WINDOW="${DISPATCH_CLAIM_WINDOW:-8}"
 # GH#17503: Increased from 120s to 1800s (30 min) — claim comments are never
 # deleted (audit trail), so the TTL must cover a full worker lifecycle.
 DISPATCH_CLAIM_MAX_AGE="${DISPATCH_CLAIM_MAX_AGE:-1800}"
+
+# Number of issue comments to request per GitHub REST page when reading claim
+# markers. GitHub defaults to the oldest 30 comments, which misses fresh claims
+# on long issue threads; always paginate with the maximum page size.
+DISPATCH_CLAIM_COMMENT_FETCH_PER_PAGE="${DISPATCH_CLAIM_COMMENT_FETCH_PER_PAGE:-100}"
 
 # GH#15317: Self-reclaim removed. Previously, same-runner stale claims were
 # "reclaimed" after this threshold, creating dispatch loops. Now stale self-
@@ -340,6 +345,48 @@ _delete_comment() {
 }
 
 #######################################
+# Fetch all claim/release marker comments from a GitHub issue.
+#
+# GitHub's issue-comments REST endpoint defaults to page 1 (oldest 30). Long
+# issue threads can place fresh DISPATCH_CLAIM comments beyond that page, making
+# runners unable to see their own just-posted claim. Use per_page=100 plus
+# --paginate/--slurp, then normalize real gh output (array of pages) and test
+# mocks (single array) before filtering.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+# Returns: JSON array of {id, body, created_at} marker comments.
+#######################################
+_fetch_claim_marker_comments() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local raw_comments
+	raw_comments=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=${DISPATCH_CLAIM_COMMENT_FETCH_PER_PAGE}" \
+		--paginate --slurp 2>/dev/null) || {
+		echo "Error: failed to fetch comments for #${issue_number} in ${repo_slug}" >&2
+		return 1
+	}
+
+	printf '%s' "$raw_comments" | jq -c --arg pattern "${CLAIM_MARKER} nonce=|CLAIM_RELEASED" '
+		[ (
+			if (type == "array" and ((.[0]? | type) == "array")) then
+				.[]
+			else
+				.
+			end
+		)[]
+		| select((.body // "") | test($pattern))
+		| {id: .id, body: .body, created_at: .created_at} ]
+	' || {
+		echo "Error: failed to parse comments for #${issue_number} in ${repo_slug}" >&2
+		return 1
+	}
+	return 0
+}
+
+#######################################
 # Fetch recent claim comments on an issue.
 # Returns JSON array of {id, nonce, runner, ts, ts_epoch} objects.
 #
@@ -355,16 +402,11 @@ _fetch_claims() {
 	local now_epoch
 	now_epoch=$(_now_epoch)
 
-	# Fetch last 30 comments — look for both DISPATCH_CLAIM and CLAIM_RELEASED.
+	# Fetch claim/release markers from every issue-comment page.
 	# A CLAIM_RELEASED comment posted after the most recent DISPATCH_CLAIM
 	# invalidates all prior claims (the worker died or completed).
 	local comments_json
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce=|CLAIM_RELEASED")) | {id: .id, body: .body, created_at: .created_at}]' \
-		2>/dev/null) || {
-		echo "Error: failed to fetch comments for #${issue_number} in ${repo_slug}" >&2
-		return 1
-	}
+	comments_json=$(_fetch_claim_marker_comments "$issue_number" "$repo_slug") || return 1
 
 	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
 		printf '[]'

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -91,7 +91,7 @@ if [[ "$endpoint" == "user" ]]; then
 	exit 0
 fi
 
-if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
+if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
 	method="GET"
 	body=""
 	while [[ "$#" -gt 0 ]]; do
@@ -187,7 +187,7 @@ if [[ "$endpoint" == "user" ]]; then
 	exit 0
 fi
 
-if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
+if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
 	method="GET"
 	body=""
 	while [[ "$#" -gt 0 ]]; do
@@ -255,6 +255,99 @@ exit 1
 EOF
 	chmod +x "${mock_bin_dir}/gh"
 	MOCK_TERMINAL_BODY="$terminal_body" printf '%s' "$mock_bin_dir"
+	return 0
+}
+
+#######################################
+# Build a mock gh executable that returns gh --paginate --slurp shaped output:
+# an array of pages. The active claim is only present on the second page, which
+# catches regressions where claim readers inspect only the oldest REST page.
+# Uses env vars:
+#   MOCK_GH_STATE_DIR, MOCK_OLD_CLAIM_CREATED_AT, MOCK_NEW_CLAIM_CREATED_AT
+# Returns: path to mock gh directory via stdout
+#######################################
+create_paginated_mock_gh() {
+	local state_dir="$1"
+	local mock_bin_dir
+	mock_bin_dir="${state_dir}/bin"
+	mkdir -p "$mock_bin_dir"
+
+	cat >"${mock_bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+local_state_dir="${MOCK_GH_STATE_DIR:?}"
+post_body_file="${local_state_dir}/post_body.txt"
+
+if [[ "${1:-}" != "api" ]]; then
+	exit 1
+fi
+shift
+
+endpoint="${1:-}"
+shift || true
+
+if [[ "$endpoint" == "user" ]]; then
+	printf 'mockrunner\n'
+	exit 0
+fi
+
+if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
+	method="GET"
+	body=""
+	while [[ "$#" -gt 0 ]]; do
+		case "$1" in
+		--method)
+			method="$2"
+			shift 2
+			;;
+		--field)
+			if [[ "$2" == body=* ]]; then
+				body="${2#body=}"
+			fi
+			shift 2
+			;;
+		--paginate | --slurp)
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ "$method" == "POST" ]]; then
+		printf '%s' "$body" >"$post_body_file"
+		printf '999\n'
+		exit 0
+	fi
+
+	if [[ -f "$post_body_file" ]]; then
+		new_body=$(<"$post_body_file")
+	else
+		new_body=""
+	fi
+
+	jq -n \
+		--arg old_ts "${MOCK_OLD_CLAIM_CREATED_AT:?}" \
+		--arg new_body "$new_body" \
+		--arg new_ts "${MOCK_NEW_CLAIM_CREATED_AT:?}" \
+		'[
+			[
+				{id: 1, body: "human discussion", created_at: "2026-05-01T00:00:00Z"}
+			],
+			[
+				{id: 2, body: ("DISPATCH_CLAIM nonce=old-nonce runner=mockrunner ts=" + $old_ts + " max_age_s=1800 version=3.14.23"), created_at: $old_ts},
+				{id: 999, body: $new_body, created_at: $new_ts}
+			]
+		]'
+	exit 0
+fi
+
+exit 1
+EOF
+	chmod +x "${mock_bin_dir}/gh"
+	printf '%s' "$mock_bin_dir"
 	return 0
 }
 
@@ -561,6 +654,46 @@ test_claim_rejects_fresh_same_runner_claim() {
 }
 
 #######################################
+# Test: long issue threads still see active claims beyond the first REST page.
+#######################################
+test_claim_reads_paginated_comment_tail() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_paginated_mock_gh "$tmp_dir")"
+
+	local old_created_at new_created_at output exit_code
+	old_created_at="$(iso_seconds_ago 10)"
+	new_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" \
+		MOCK_NEW_CLAIM_CREATED_AT="$new_created_at" \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 1 ]]; then
+		print_result "paginated comments find prior same-runner claim" 0
+	else
+		print_result "paginated comments find prior same-runner claim" 1 "got exit $exit_code output: $output"
+	fi
+
+	if printf '%s' "$output" | grep -q "CLAIM_STALE_SELF:"; then
+		print_result "paginated prior claim emits CLAIM_STALE_SELF" 0
+	else
+		print_result "paginated prior claim emits CLAIM_STALE_SELF" 1 "output: $output"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+#######################################
 # Test: stale worker takeover claims are annotated (GH#22356)
 #######################################
 test_claim_marks_stale_worker_takeover() {
@@ -673,6 +806,7 @@ main() {
 	test_env_var_defaults
 	test_claim_rejects_stale_same_runner_claim
 	test_claim_rejects_fresh_same_runner_claim
+	test_claim_reads_paginated_comment_tail
 	test_claim_marks_stale_worker_takeover
 	test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment
 	test_claim_skips_takeover_reason_after_terminal


### PR DESCRIPTION
## Summary

Fetch dispatch claim/release marker comments with GitHub REST pagination so long issue threads do not hide fresh claims beyond the oldest default page; added a paginated mock regression covering a prior same-runner claim on a later page.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh; bash .agents/scripts/tests/test-dispatch-claim-helper.sh (26 tests, 0 failed)

Resolves #22665


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.24 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 59,539 tokens on this as a headless worker.