### PR TITLE
GH#22648: correct signature footer session mode

### DIFF
--- a/.agents/scripts/gh-signature-helper-session.sh
+++ b/.agents/scripts/gh-signature-helper-session.sh
@@ -458,20 +458,47 @@ _detect_session_model() {
 }
 
 # =============================================================================
-# Detect session type: "interactive" (>1 user messages) or "worker" (0-1)
+# Detect session type: explicit headless markers, then interactive runtime,
+# then legacy DB heuristic ("interactive" >1 user messages, "worker" 0-1).
 # =============================================================================
 
+_gh_sig_env_truthy() {
+	local value="$1"
+	case "$value" in
+	"" | "0" | "false" | "FALSE" | "no" | "NO") return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
+_detect_explicit_session_type() {
+	if _gh_sig_env_truthy "${FULL_LOOP_HEADLESS:-}" ||
+		_gh_sig_env_truthy "${AIDEVOPS_HEADLESS:-}" ||
+		_gh_sig_env_truthy "${OPENCODE_HEADLESS:-}"; then
+		echo "worker"
+		return 0
+	fi
+
+	if [[ "${OPENCODE:-}" == "1" ]] || [[ -n "${OPENCODE_SESSION_ID:-}" ]] ||
+		[[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+		echo "interactive"
+		return 0
+	fi
+
+	echo ""
+	return 0
+}
+
 _detect_session_type() {
+	local explicit_type
+	explicit_type=$(_detect_explicit_session_type)
+	if [[ -n "$explicit_type" ]]; then
+		echo "$explicit_type"
+		return 0
+	fi
+
 	# Guard: only query OpenCode DB in OpenCode runtime (GH#17689)
 	if ! _is_opencode_runtime; then
-		# Claude Code: infer session type from environment
-		if [[ "${FULL_LOOP_HEADLESS:-}" == "true" ]] || [[ -n "${AIDEVOPS_HEADLESS:-}" ]]; then
-			echo "worker"
-		elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
-			echo "interactive"
-		else
-			echo ""
-		fi
+		echo ""
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -285,7 +285,7 @@ VALUES
 "
 
 	if [[ -n "$issue_created_iso" ]]; then
-		result=$(HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_created_iso")
+		result=$(XDG_DATA_HOME="${tmp_home}/.local/share" HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_created_iso")
 		assert_contains "issue window uses scoped tokens" "220 tokens on this" "$result"
 		assert_not_contains "issue window excludes pre-issue tokens" "330 tokens on this" "$result"
 
@@ -293,7 +293,7 @@ VALUES
 		issue_after_iso=$(date -u -r "$issue_after_epoch" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
 			date -u -d "@${issue_after_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 		if [[ -n "$issue_after_iso" ]]; then
-			result=$(HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_after_iso")
+			result=$(XDG_DATA_HOME="${tmp_home}/.local/share" HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_after_iso")
 			assert_not_contains "post-window excludes pre-issue fallback" "330 tokens on this" "$result"
 			assert_not_contains "post-window omits scoped zero token phrase" "0 tokens on this" "$result"
 		else
@@ -479,6 +479,29 @@ else
 fi
 
 rm -rf "$tmp_home_19"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 20: session-mode footer detection uses explicit mode markers only
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 20: session-mode footer detection"
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+	OPENCODE=1 AIDEVOPS_HEADLESS_VARIANT_SONNET="high" \
+	"$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
+assert_contains "variant config alone remains interactive" "with the user in an interactive session" "$result"
+assert_not_contains "variant config does not imply worker" "as a headless worker" "$result"
+
+result=$(env -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS FULL_LOOP_HEADLESS=true \
+	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
+assert_contains "FULL_LOOP_HEADLESS marks worker" "as a headless worker" "$result"
+
+result=$(env -u FULL_LOOP_HEADLESS -u OPENCODE_HEADLESS AIDEVOPS_HEADLESS=true \
+	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
+assert_contains "AIDEVOPS_HEADLESS marks worker" "as a headless worker" "$result"
+
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS OPENCODE_HEADLESS=true \
+	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
+assert_contains "OPENCODE_HEADLESS marks worker" "as a headless worker" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary


### PR DESCRIPTION
## Summary

Updated signature session-mode detection so explicit headless markers classify worker comments while interactive OpenCode/Claude contexts remain interactive; added regression coverage for headless variant configuration and explicit headless markers.

## Files Changed

.agents/scripts/gh-signature-helper-session.sh,.agents/scripts/tests/test-gh-signature-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-signature-helper.sh; shellcheck .agents/scripts/gh-signature-helper-session.sh .agents/scripts/tests/test-gh-signature-helper.sh

Resolves #22648


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.24 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 104,915 tokens on this as a headless worker.