### PR TITLE
GH#22664: avoid TODO sync stashes during cleanup

### DIFF
--- a/.agents/scripts/pulse-canonical-recovery.sh
+++ b/.agents/scripts/pulse-canonical-recovery.sh
@@ -184,6 +184,104 @@ _pcr_detect_state() {
 	return 0
 }
 
+_pcr_only_todo_dirty() {
+	local repo_path="$1"
+	local status_line path
+	while IFS= read -r status_line; do
+		[[ -n "$status_line" ]] || continue
+		path="${status_line#?? }"
+		case "$path" in
+			TODO.md)
+				;;
+			*)
+				return 1
+				;;
+		esac
+	done < <(git -C "$repo_path" status --porcelain --untracked-files=all 2>/dev/null)
+	return 0
+}
+
+_pcr_normalise_todo_sync_line() {
+	local line="$1"
+	printf '%s\n' "$line" \
+		| sed -E 's/^- \[[ xX]\] /- [?] /; s/[[:space:]]+(assignee|started|completed|logged|pr|actual|dispatched|origin|status):[^[:space:]]+//g; s/[[:space:]]+/ /g; s/[[:space:]]$//'
+	return 0
+}
+
+_pcr_todo_line_is_task() {
+	local line="$1"
+	if [[ "$line" =~ ^-\ \[[xX\ ]\]\ [tr][0-9] ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_pcr_todo_diff_is_generated_sync() {
+	local repo_path="$1"
+	local old_tmp new_tmp diff_line content saw_change=0 ok=1
+	old_tmp=$(mktemp "${TMPDIR:-/tmp}/pcr-todo-old.XXXXXX") || return 1
+	new_tmp=$(mktemp "${TMPDIR:-/tmp}/pcr-todo-new.XXXXXX") || { rm -f "$old_tmp"; return 1; }
+
+	while IFS= read -r diff_line; do
+		case "$diff_line" in
+			---*|+++*|@@*)
+				continue
+				;;
+			-*)
+				content="${diff_line#-}"
+				if ! _pcr_todo_line_is_task "$content"; then
+					ok=0
+					break
+				fi
+				_pcr_normalise_todo_sync_line "$content" >>"$old_tmp"
+				saw_change=1
+				;;
+			+*)
+				content="${diff_line#+}"
+				if ! _pcr_todo_line_is_task "$content"; then
+					ok=0
+					break
+				fi
+				_pcr_normalise_todo_sync_line "$content" >>"$new_tmp"
+				saw_change=1
+				;;
+		esac
+	done < <({ git -C "$repo_path" diff -- TODO.md; git -C "$repo_path" diff --cached -- TODO.md; } 2>/dev/null)
+
+	if [[ "$ok" -eq 1 && "$saw_change" -eq 1 ]] && cmp -s "$old_tmp" "$new_tmp"; then
+		rm -f "$old_tmp" "$new_tmp"
+		return 0
+	fi
+	rm -f "$old_tmp" "$new_tmp"
+	return 1
+}
+
+_pcr_recover_todo_sync_dirty_state() {
+	local repo_path="$1"
+	if ! _pcr_only_todo_dirty "$repo_path"; then
+		return 1
+	fi
+	if ! _pcr_todo_diff_is_generated_sync "$repo_path"; then
+		_pcr_audit "todo-dirty-blocked" "$repo_path" "advisory:human-or-unknown"
+		_pcr_log "TODO.md is dirty but does not match generated sync metadata — filing advisory without stashing"
+		_pcr_file_advisory "$repo_path" "todo-dirty-blocked"
+		return 2
+	fi
+
+	_pcr_audit "todo-sync-reset" "$repo_path" "ok:generated-metadata-only"
+	_pcr_log "discarding generated TODO.md sync metadata before canonical refresh"
+	git -C "$repo_path" reset -q -- TODO.md >/dev/null 2>&1 || return 2
+	git -C "$repo_path" checkout -- TODO.md >/dev/null 2>&1 || return 2
+	if git -C "$repo_path" fetch --quiet origin >>"${LOGFILE:-/dev/null}" 2>&1 \
+		&& git -C "$repo_path" pull --ff-only --no-rebase >>"${LOGFILE:-/dev/null}" 2>&1; then
+		_pcr_audit "todo-sync-refresh" "$repo_path" "ok:no-stash"
+		return 0
+	fi
+	_pcr_audit "todo-sync-refresh-failed" "$repo_path" "advisory:no-stash"
+	_pcr_file_advisory "$repo_path" "todo-sync-refresh-failed"
+	return 2
+}
+
 # Count attempts in the hot window for this repo. Echoes integer.
 # When jq is missing, returns MAX_ATTEMPTS so the caller's threshold check
 # trips and we escalate straight to advisory rather than silently looping
@@ -465,6 +563,25 @@ pulse_canonical_recover() {
 
 	_pcr_record_attempt "$repo_path"
 	_pcr_log "recovering ${repo_path} (state=${state})"
+
+	# Generated TODO.md sync metadata can appear in the canonical checkout while
+	# a worker is cleaning up from a linked worktree. Do not create a long-lived
+	# stash for that bookkeeping diff: either reset metadata-only generated state
+	# and refresh, or fail closed with a local advisory when TODO.md looks
+	# human-authored/unknown (GH#22664).
+	if [[ "$state" == "uncommitted" ]]; then
+		local todo_recovery_rc=0
+		_pcr_recover_todo_sync_dirty_state "$repo_path"
+		todo_recovery_rc=$?
+		case "$todo_recovery_rc" in
+			0)
+				return 0
+				;;
+			2)
+				return 1
+				;;
+		esac
+	fi
 
 	# Step 1: clear unmerged state if present.
 	if [[ "$state" == "unmerged" ]]; then

--- a/.agents/scripts/tests/test-canonical-recovery.sh
+++ b/.agents/scripts/tests/test-canonical-recovery.sh
@@ -205,6 +205,18 @@ advance_origin() {
 	return 0
 }
 
+add_todo_to_origin_and_pull() {
+	local origin="$1" canon="$2"
+	(
+		cd "$origin" || exit 1
+		printf '%s\n' '- [ ] t123 sync metadata fixture #auto-dispatch logged:2026-01-01' >TODO.md
+		git add TODO.md
+		git commit -qm "add TODO"
+	)
+	git -C "$canon" pull --ff-only --no-rebase >/dev/null 2>&1
+	return 0
+}
+
 reset_call_logs() {
 	: >"$GH_CALL_LOG"
 	: >"$AUDIT_CALL_LOG"
@@ -326,6 +338,57 @@ grep -q "operation.verify" "$AUDIT_CALL_LOG" \
 grep -q "canonical-recovery.success" "$AUDIT_CALL_LOG" \
 	&& print_result "recover: audit log records canonical-recovery.success" 0 \
 	|| print_result "recover: audit log records canonical-recovery.success" 1
+
+# =============================================================================
+# Test 3b: generated TODO.md sync metadata is reset before refresh without stash.
+# =============================================================================
+
+make_repo_pair "todo-generated"
+add_todo_to_origin_and_pull "$ORIGIN_DIR" "$CANON_DIR"
+advance_origin "$ORIGIN_DIR"
+printf '%s\n' '- [x] t123 sync metadata fixture #auto-dispatch logged:2026-01-01 pr:#42 completed:2026-01-02' >"${CANON_DIR}/TODO.md"
+reset_call_logs
+
+if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
+	print_result "todo sync: generated metadata recovers without stash" 0
+else
+	print_result "todo sync: generated metadata recovers without stash" 1 "exit nonzero"
+fi
+stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
+[[ "$stash_count" == "0" ]] \
+	&& print_result "todo sync: no stash created" 0 \
+	|| print_result "todo sync: no stash created" 1 "count: $stash_count"
+git -C "$CANON_DIR" diff --quiet -- TODO.md \
+	&& print_result "todo sync: TODO.md returned to clean HEAD" 0 \
+	|| print_result "todo sync: TODO.md returned to clean HEAD" 1
+[[ "$(git -C "$CANON_DIR" rev-parse HEAD)" == "$(git -C "$ORIGIN_DIR" rev-parse HEAD)" ]] \
+	&& print_result "todo sync: canonical refreshed to origin HEAD" 0 \
+	|| print_result "todo sync: canonical refreshed to origin HEAD" 1
+
+# =============================================================================
+# Test 3c: human/unknown TODO.md edits block without stashing or discarding.
+# =============================================================================
+
+make_repo_pair "todo-human"
+add_todo_to_origin_and_pull "$ORIGIN_DIR" "$CANON_DIR"
+printf '%s\n' '- [ ] t123 human-edited task description #auto-dispatch logged:2026-01-01' >"${CANON_DIR}/TODO.md"
+reset_call_logs
+
+if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
+	print_result "todo human: recovery blocks unknown TODO edit" 1 "unexpected success"
+else
+	print_result "todo human: recovery blocks unknown TODO edit" 0
+fi
+stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
+[[ "$stash_count" == "0" ]] \
+	&& print_result "todo human: no stash created" 0 \
+	|| print_result "todo human: no stash created" 1 "count: $stash_count"
+grep -q 'human-edited task description' "${CANON_DIR}/TODO.md" \
+	&& print_result "todo human: edit preserved" 0 \
+	|| print_result "todo human: edit preserved" 1
+[[ -f "$(advisory_file_for "$CANON_DIR")" ]] \
+	&& print_result "todo human: advisory filed" 0 \
+	|| print_result "todo human: advisory filed" 1
 
 # =============================================================================
 # Test 4: unmerged path — merge --abort suffices


### PR DESCRIPTION
## Summary

Canonical recovery now handles TODO.md-only sync metadata without creating persistent stashes, and blocks human/unknown TODO edits with an advisory instead of stashing or discarding them.

## Files Changed

.agents/scripts/pulse-canonical-recovery.sh,.agents/scripts/tests/test-canonical-recovery.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-canonical-recovery.sh (61 tests, 0 failed); shellcheck .agents/scripts/pulse-canonical-recovery.sh .agents/scripts/tests/test-canonical-recovery.sh; git diff --check. .agents/scripts/linters-local.sh reached pre-existing skill-frontmatter errors and timed out later in the Bash 3.2 gate after Secretlint passed.

Resolves #22664


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.25 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 12m and 109,249 tokens on this as a headless worker.