### PR TITLE
fix: keep startup advisories out of chat

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -73,7 +73,7 @@ describe("token cost advisory threshold", () => {
     assert.match(output.system[0], /We're running aidevops v3\.14\.23\./);
   });
 
-  test("includes startup advisory only for warning and error cache lines", async () => {
+  test("keeps startup advisory cache lines out of chat instructions", async () => {
     const { hooks } = createHooks({
       readIfExists: (path) => path.endsWith("session-greeting.txt")
         ? [
@@ -88,13 +88,13 @@ describe("token cost advisory threshold", () => {
 
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
-    assert.match(output.system[0], /After the greeting, include this short startup advisory/);
-    assert.match(output.system[0], /\[SECURITY ADVISORY\] Rotate test credentials/);
-    assert.match(output.system[0], /\[WARN\] Pulse stalled for 12 minutes/);
+    assert.match(output.system[0], /Do not include startup advisory\/status\/cache lines in chat/);
+    assert.doesNotMatch(output.system[0], /\[SECURITY ADVISORY\] Rotate test credentials/);
+    assert.doesNotMatch(output.system[0], /\[WARN\] Pulse stalled for 12 minutes/);
     assert.doesNotMatch(output.system[0], /Security: all protections active/);
   });
 
-  test("omits startup advisory section for clean cache", async () => {
+  test("avoids duplicate greeting after salutation-only launch input", async () => {
     const { hooks } = createHooks({
       readIfExists: (path) => path.endsWith("session-greeting.txt")
         ? [
@@ -107,7 +107,7 @@ describe("token cost advisory threshold", () => {
 
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
-    assert.doesNotMatch(output.system[0], /startup advisory/);
+    assert.match(output.system[0], /do not add another greeting or a second 'what would you like to work on' line/);
   });
 
   test("does not inject session greeting order in headless sessions", async () => {

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -198,25 +198,9 @@ function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
   const version = cacheMatch?.[1] || readIfExists(join(agentsDir, "VERSION")).split("\n")[0] || "X";
   const runtime = cacheMatch?.[2] || "OpenCode";
   const runtimeVersion = cacheMatch?.[3];
-  const advisoryLines = cacheLines.filter((line) =>
-    line.startsWith("[SECURITY ADVISORY]") ||
-    line.startsWith("[ERROR]") ||
-    line.startsWith("[WARN]") ||
-    line.startsWith("[WARNING]") ||
-    line.startsWith("Pulse stalled") ||
-    line.startsWith("[OPENCODE MAINTENANCE]") ||
-    /contribution\(s\) need/i.test(line));
   const versionLine = runtimeVersion
     ? `We're running aidevops v${version} in ${runtime} v${runtimeVersion}.`
     : `We're running aidevops v${version}.`;
-  const advisoryInstruction = advisoryLines.length > 0
-    ? [
-        "",
-        "After the greeting, include this short startup advisory before answering the user's request:",
-        "",
-        ...advisoryLines.map((line) => `- ${line}`),
-      ]
-    : [];
 
   return [
     "## Session-start greeting order",
@@ -229,9 +213,10 @@ function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
     "What would you like to work on?",
     "",
     "Do this before tool calls, status updates, analysis summaries, or task work.",
-    ...advisoryInstruction,
+    "Do not include startup advisory/status/cache lines in chat; those are already shown by the OpenCode toast/sidebar surfaces.",
     "If the user launched the session with an initial message, greet first in the assistant response, then answer that message.",
-    "Do not repeat the greeting after the first assistant turn, and do not duplicate the framework-status toast content.",
+    "If the initial user message is only a greeting/salutation, do not add another greeting or a second 'what would you like to work on' line after the exact greeting above.",
+    "Do not repeat the greeting after the first assistant turn, and do not duplicate the framework-status toast/sidebar content.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Keeps startup advisory/cache lines out of the assistant chat response so they stay on OpenCode toast/sidebar surfaces only.
- Tightens first-turn greeting instructions to avoid a second salutation when the launch input is just a greeting.
- Keeps the concrete cached aidevops/OpenCode version greeting behavior from v3.14.24.

## Testing
- node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
- git diff --check
- setup.sh --non-interactive local deploy completed and deployed the updated ttsr.mjs.

## Runtime Testing
Manual fresh OpenCode verification requested from maintainer; low-risk prompt-only system-transform adjustment with targeted regression coverage.

## Key decisions
- Advisory/status lines remain visible in OpenCode UI surfaces, but not in model-visible assistant chat/context.
- Greeting-only launch input should be satisfied by the exact framework greeting, not a second model-generated greeting.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.25 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1h 1m and 701,147 tokens on this with the user in an interactive session.