### PR TITLE
GH#22672: dedupe consolidation dispatch on long threads

### DIFF
--- a/.agents/scripts/pulse-triage-cache.sh
+++ b/.agents/scripts/pulse-triage-cache.sh
@@ -222,8 +222,14 @@ _gh_idempotent_comment() {
 		existing_comments=$(gh pr view "$entity_number" --repo "$repo_slug" \
 			--json comments --jq '.comments[].body' 2>/dev/null)
 	else
-		existing_comments=$(gh api "repos/${repo_slug}/issues/${entity_number}/comments" \
-			--jq '.[].body' 2>/dev/null)
+		# t3565: GitHub's issue-comments REST endpoint defaults to the oldest
+		# 30 comments. Long-running issues can have idempotency markers beyond
+		# page 1, so normalize paginated gh output before grepping for markers.
+		existing_comments=$(gh api "repos/${repo_slug}/issues/${entity_number}/comments?per_page=100" \
+			--paginate --slurp 2>/dev/null | jq -r '
+				(if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end)[]
+				| .body // ""
+			' 2>/dev/null)
 	fi
 	local api_exit=$?
 

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -363,6 +363,25 @@ _reevaluate_simplification_labels() {
 # Returns: 0 if an open-or-recently-closed child exists OR lock label is
 #          present, 1 otherwise.
 #######################################
+_consolidation_dispatch_comment_exists() {
+	local parent_num="$1"
+	local repo_slug="$2"
+
+	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 1
+
+	local marker_count
+	marker_count=$(gh api "repos/${repo_slug}/issues/${parent_num}/comments?per_page=100" \
+		--paginate --slurp 2>/dev/null | jq -r '
+			[ (if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end)[]
+			| select((.body // "") | contains("## Issue Consolidation Dispatched")) ] | length
+	' 2>/dev/null) || return 1
+	[[ "$marker_count" =~ ^[0-9]+$ ]] || marker_count=0
+	if [[ "$marker_count" -gt 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
 _consolidation_child_exists() {
 	local parent_num="$1"
 	local repo_slug="$2"
@@ -370,12 +389,24 @@ _consolidation_child_exists() {
 
 	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 1
 
+	# t3565: Parent pointer comments are an idempotency signal too. Search API
+	# can time out or lag on large repos; a previously posted dispatch comment
+	# means a child was already created, so block repeat child creation.
+	if _consolidation_dispatch_comment_exists "$parent_num" "$repo_slug"; then
+		return 0
+	fi
+
 	# Fast path: any open child immediately owns the parent.
-	local open_count
+	local open_count open_exit=0
 	open_count=$(gh_issue_list --repo "$repo_slug" --state open \
 		--label "consolidation-task" \
 		--search "in:body \"Consolidation target: #${parent_num}\"" \
-		--json number --jq 'length' --limit 5 2>/dev/null) || open_count=0
+		--json number --jq 'length' --limit 5 2>/dev/null) || open_exit=$?
+	if [[ "$open_exit" -ne 0 ]]; then
+		# Fail closed: creating a duplicate consolidation child is worse than
+		# retrying after a transient GitHub search/API issue.
+		return 0
+	fi
 	[[ "$open_count" =~ ^[0-9]+$ ]] || open_count=0
 	if [[ "$open_count" -gt 0 ]]; then
 		return 0

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -102,6 +102,9 @@ issue-view)
 	esac
 	;;
 issue-list)
+	if [[ "${GH_ISSUE_LIST_FAIL:-0}" == "1" ]]; then
+		exit 1
+	fi
 	# t2144: --state dispatch so tests can fixture open and closed child
 	# lists independently (grace-window regression tests).
 	eval "$(_stub_parse_args "$@")"
@@ -201,6 +204,7 @@ teardown_gh_stub() {
 	GH_LOG=""
 	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
 	unset GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON GH_ISSUE_CREATE_URL
+	unset GH_ISSUE_LIST_FAIL
 	unset GH_PR_LIST_RESOLVING_JSON
 	unset CONSOLIDATION_RECENT_CLOSE_GRACE_MIN
 	return 0
@@ -348,6 +352,62 @@ test_consolidation_child_exists_detects_existing() {
 			"returned 0 with empty child list"
 	else
 		print_result "_consolidation_child_exists returns 1 when no child" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+test_consolidation_child_exists_detects_parent_dispatch_comment_on_later_page() {
+	setup_gh_stub
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	GH_API_COMMENTS_JSON=$(jq -n '[[{"body":"old operational comment"}],[{"body":"## Issue Consolidation Dispatched\n\nA consolidation task has been filed as **#9005**."}]]')
+	export GH_ISSUE_LIST_CHILD_JSON GH_API_COMMENTS_JSON
+
+	if _consolidation_child_exists 123 "owner/repo"; then
+		print_result "_consolidation_child_exists blocks when parent dispatch marker is paginated" 0
+	else
+		print_result "_consolidation_child_exists blocks when parent dispatch marker is paginated" 1 \
+			"returned non-zero despite existing parent dispatch comment"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+test_consolidation_child_exists_fails_closed_on_search_error() {
+	setup_gh_stub
+	GH_API_COMMENTS_JSON="[]"
+	GH_ISSUE_LIST_FAIL=1
+	export GH_API_COMMENTS_JSON GH_ISSUE_LIST_FAIL
+
+	if _consolidation_child_exists 123 "owner/repo"; then
+		print_result "_consolidation_child_exists fails closed on child search error" 0
+	else
+		print_result "_consolidation_child_exists fails closed on child search error" 1 \
+			"returned non-zero despite child search API failure"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+test_idempotent_comment_reads_paginated_issue_comments() {
+	setup_gh_stub
+	GH_API_COMMENTS_JSON=$(jq -n '[[{"body":"older page"}],[{"body":"## Issue Consolidation Dispatched\n\nA consolidation task exists."}]]')
+	export GH_API_COMMENTS_JSON
+
+	_gh_idempotent_comment 123 "owner/repo" \
+		"## Issue Consolidation Dispatched" \
+		"## Issue Consolidation Dispatched
+
+Duplicate body should not post."
+
+	if grep -q 'issue comment' "$GH_LOG" 2>/dev/null; then
+		print_result "_gh_idempotent_comment skips marker on paginated issue comments" 1 \
+			"gh issue comment was invoked despite marker on later page"
+	else
+		print_result "_gh_idempotent_comment skips marker on paginated issue comments" 0
 	fi
 
 	teardown_gh_stub
@@ -772,6 +832,9 @@ main() {
 	test_child_body_contains_parent_content_and_authors
 	test_dedup_skips_when_child_exists
 	test_consolidation_child_exists_detects_existing
+	test_consolidation_child_exists_detects_parent_dispatch_comment_on_later_page
+	test_consolidation_child_exists_fails_closed_on_search_error
+	test_idempotent_comment_reads_paginated_issue_comments
 	test_needs_consolidation_skips_with_child
 
 	# t2144 regression suite


### PR DESCRIPTION
## Summary
- Paginate issue-comment marker reads in `_gh_idempotent_comment` so long threads do not repost existing consolidation notices.
- Treat existing parent `Issue Consolidation Dispatched` comments as consolidation-child dedup evidence.
- Fail closed when the consolidation child search errors, avoiding duplicate child creation during transient GitHub/search failures.

## Verification
- `shellcheck .agents/scripts/pulse-triage-cache.sh .agents/scripts/pulse-triage-evaluation.sh .agents/scripts/tests/test-consolidation-dispatch.sh`
- `bash .agents/scripts/tests/test-consolidation-dispatch.sh`

Resolves #22672
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.25 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 50m and 308,176 tokens on this with the user in an interactive session.