### PR TITLE
GH#22640: Preserve OpenAI startup OAuth account

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -150,7 +150,11 @@ export async function selectOpenAIStartupAccount(skipEmail) {
   normalizeExpiredCooldowns("openai", accounts);
   const currentAuth = readCurrentOpenAIAuth();
   const current = accounts.find((a) => a.email !== skipEmail && matchesOpenAIAuth(a, currentAuth));
+  // Startup should preserve a manually rotated, still-valid OpenAI auth entry.
+  // Only fall through to pool priority/LRU selection when that current account
+  // is unavailable or cannot be refreshed.
   if (current && isAvailableAccount(current) && await ensureValidToken("openai", current)) return current;
+  if (current) return selectPoolAccount("openai", current.email);
   return selectPoolAccount("openai", skipEmail);
 }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -138,6 +138,14 @@ test("OpenAI startup injection honors current auth availability", async () => {
 
     assert.equal(rotated.ok, true);
     assert.equal(rotated.authWrites[0].body.accountId, "acct_fresh");
+
+    const authErrorRotated = await injectWithPool({ openai: [
+      { email: "auth-error@example.com", access: "auth-error-token", refresh: "auth-error-refresh", expires: Date.now() + 3600_000, status: "auth-error", cooldownUntil: Date.now() + 86400_000, lastUsed: "2026-01-03T00:00:00Z", accountId: "acct_auth_error" },
+      { email: "fallback@example.com", access: "fallback-token", refresh: "fallback-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_fallback" },
+    ] }, { type: "oauth", access: "auth-error-token", refresh: "auth-error-refresh", expires: Date.now() + 3600_000, accountId: "acct_auth_error" });
+
+    assert.equal(authErrorRotated.ok, true);
+    assert.equal(authErrorRotated.authWrites[0].body.accountId, "acct_fallback");
   `;
   execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
     cwd: join(import.meta.dirname, ".."),


### PR DESCRIPTION
## Summary
- Preserve the current valid OpenAI OAuth pool account during startup instead of falling through to priority/LRU rotation.
- Skip unavailable current accounts during startup fallback so cooldown/auth-error accounts rotate to an eligible alternate.
- Add regression coverage for auth-error fallback alongside current-account preservation.

## Testing
- node --test plugin tests: 203 passing
- qlty smells on changed plugin files: no smells reported
- npm run typecheck: blocked by existing repo setup; TypeScript is available after dependency install, but the repo has no tsconfig/input files so tsc --noEmit prints help instead of checking files

## Runtime Testing
Low-risk plugin startup account-selection logic. Self-assessed with focused Node tests that simulate OpenCode auth and pool storage; no live OAuth credentials or runtime service were required.

## Decisions
- Kept the preservation decision in selectOpenAIStartupAccount to avoid changing generic provider rotation behavior.
- When the current OpenAI auth maps to an unavailable pool account, fallback selection skips that current account and chooses another eligible account.

Resolves #22640


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.26 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 104,729 tokens on this with the user in an interactive session.
