### PR TITLE
GH#22655: dedupe TODO auto-mark completions

### DIFF
--- a/.agents/scripts/tests/test-version-manager-auto-mark-dedupe.sh
+++ b/.agents/scripts/tests/test-version-manager-auto-mark-dedupe.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-version-manager-auto-mark-dedupe.sh — GH#22655 regression guard.
+#
+# Asserts that release task auto-marking collapses duplicate completed TODO.md
+# entries for the same task ID instead of preserving release-sync duplicates.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_count() {
+	local name="$1" expected="$2" pattern="$3" file="$4"
+	local actual
+	actual=$(grep -Ec "$pattern" "$file" || true)
+	if [[ "$actual" == "$expected" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "expected [$expected], got [$actual]"
+	fi
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+REPO_DIR="${TEST_ROOT}/repo"
+mkdir -p "$REPO_DIR"
+cd "$REPO_DIR" || exit 1
+
+git init -q -b main
+git config user.email 'test@example.com'
+git config user.name 'Test Runner'
+git config commit.gpgsign false
+
+printf 'initial\n' >README.md
+git add README.md
+git commit -q -m 'initial commit'
+
+SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+REPO_ROOT="$REPO_DIR"
+VERSION_FILE="${REPO_DIR}/VERSION"
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager-git.sh"
+set +e
+
+TODO_FILE="${REPO_DIR}/TODO.md"
+today_short="2026-05-03"
+
+cat >"$TODO_FILE" <<'TODO'
+# Tasks
+
+- [ ] t9999 Release auto-mark duplicate prevention #bug
+- [x] t9999 Release auto-mark duplicate prevention #bug pr:#123 completed:2026-05-02
+- [x] t8888 Already completed duplicate #bug pr:#124 completed:2026-05-02
+- [x] t8888 Already completed duplicate #bug pr:#124 completed:2026-05-02
+TODO
+
+rc=0
+_mark_single_task_complete 't9999' "$TODO_FILE" "$today_short" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result '_mark_single_task_complete: marks unchecked duplicate task' 0
+else
+	print_result '_mark_single_task_complete: marks unchecked duplicate task' 1 "expected rc=0, got rc=$rc"
+fi
+assert_count '_mark_single_task_complete: keeps one t9999 TODO line' 1 '^[[:space:]]*- \[[ x]\] t9999[[:space:]]' "$TODO_FILE"
+assert_count '_mark_single_task_complete: leaves t9999 completed' 1 '^[[:space:]]*- \[x\] t9999[[:space:]]' "$TODO_FILE"
+
+rc=0
+_mark_single_task_complete 't8888' "$TODO_FILE" "$today_short" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result '_mark_single_task_complete: cleans already-completed duplicates' 0
+else
+	print_result '_mark_single_task_complete: cleans already-completed duplicates' 1 "expected rc=0, got rc=$rc"
+fi
+assert_count '_mark_single_task_complete: keeps one t8888 TODO line' 1 '^[[:space:]]*- \[[ x]\] t8888[[:space:]]' "$TODO_FILE"
+
+printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -251,10 +251,48 @@ find_pr_for_task_from_commits() {
 # Changes [ ] to [x], adds proof-log (pr:#NNN or verified:date) and completed: timestamp.
 # Arguments: task_id todo_file today_short
 # Returns: 0 if marked, 1 if already complete, 2 if not found
+_dedupe_completed_task_lines() {
+	local task_id="$1"
+	local todo_file="$2"
+	local escaped_id completed_pattern duplicate_count tmp_file
+
+	escaped_id=$(echo "$task_id" | sed 's/\./\\./g')
+	completed_pattern="^[[:space:]]*- \\[x\\] ${escaped_id}[[:space:]]"
+	duplicate_count=$(grep -Ec "$completed_pattern" "$todo_file" 2>/dev/null || true)
+
+	if [[ "$duplicate_count" -le 1 ]]; then
+		return 1
+	fi
+
+	tmp_file=$(mktemp "${todo_file}.dedupe.XXXXXX") || return 2
+	if ! awk -v task_pattern="$escaped_id" '
+		BEGIN { pattern = "^[[:space:]]*- \\[x\\] " task_pattern "[[:space:]]" }
+		$0 ~ pattern {
+			seen += 1
+			if (seen > 1) {
+				next
+			}
+		}
+		{ print }
+	' "$todo_file" >"$tmp_file"; then
+		rm -f "$tmp_file"
+		return 2
+	fi
+
+	if ! mv "$tmp_file" "$todo_file"; then
+		rm -f "$tmp_file"
+		return 2
+	fi
+
+	print_warning "Removed duplicate completed TODO.md entries for $task_id"
+	return 0
+}
+
 _mark_single_task_complete() {
 	local task_id="$1"
 	local todo_file="$2"
 	local today_short="$3"
+	local dedupe_rc=0
 
 	# Build regex patterns (avoids shellcheck SC1087 false positive with [[:space:]])
 	local unchecked_pattern="^[[:space:]]*- \\[ \\] ${task_id}[[:space:]]"
@@ -285,9 +323,22 @@ _mark_single_task_complete() {
 			sed_inplace "s/^\\([[:space:]]*\\)- \\[ \\] \\(${escaped_id}[[:space:]].*\\)\$/\\1- [x] \\2${proof_log} completed:$today_short/" "$todo_file"
 		fi
 
+		_dedupe_completed_task_lines "$task_id" "$todo_file" || dedupe_rc=$?
+		if [[ "$dedupe_rc" -eq 2 ]]; then
+			print_error "Failed to remove duplicate completed TODO.md entries for $task_id"
+			return 2
+		fi
+
 		print_success "Marked $task_id as complete (${proof_log# })"
 		return 0
 	elif grep -qE "$checked_pattern" "$todo_file"; then
+		_dedupe_completed_task_lines "$task_id" "$todo_file" || dedupe_rc=$?
+		if [[ "$dedupe_rc" -eq 0 ]]; then
+			return 0
+		elif [[ "$dedupe_rc" -eq 2 ]]; then
+			print_error "Failed to remove duplicate completed TODO.md entries for $task_id"
+			return 2
+		fi
 		print_info "Task $task_id already marked complete"
 		return 1
 	else

--- a/TODO.md
+++ b/TODO.md
@@ -4168,8 +4168,6 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t3558 Remove CPU-based canary throttling #auto-dispatch #bug ref:GH#22634 pr:#22639 completed:2026-05-03
 
-- [x] t3560 Add /goals mission command ref:GH#22649 pr:#22650 completed:2026-05-03
-
 - [ ] t3562 Audit ops markers for machine-generated GitHub comments #auto-dispatch #bug ref:GH#22660
 
 - [ ] t3561 Fix duplicate TODO entry after release auto-mark #auto-dispatch #bug ref:GH#22655


### PR DESCRIPTION
## Summary
- Collapses duplicate completed TODO.md entries for the task ID being processed by release auto-marking.
- Removes the duplicate completed `t3560` TODO.md line so one completed entry remains.
- Adds a regression test for unchecked+completed and already-completed duplicate cases.

## Runtime Testing
- Risk: Low (shell helper + regression test + TODO cleanup).
- Runtime status: self-assessed; targeted shell tests executed.

## Testing
- PASS: `bash .agents/scripts/tests/test-version-manager-task-id-extraction.sh && bash .agents/scripts/tests/test-version-manager-auto-mark-dedupe.sh`
- PASS: `shellcheck .agents/scripts/version-manager-git.sh .agents/scripts/tests/test-version-manager-auto-mark-dedupe.sh`
- PASS: `git diff --check`
- PARTIAL: `.agents/scripts/linters-local.sh` reached pre-existing/non-scope failures in TODO.md markdownlint, skill frontmatter, pulse canary, Bash 3.2 audit before timeout.

## Decisions
- Dedupe is scoped to completed checkbox lines for the task currently being auto-marked.
- The first completed entry is preserved to avoid broad TODO.md reordering.

Resolves #22655

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.28 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 15m and 201,190 tokens on this with the user in an interactive session.