### PR TITLE
GH#22679: sync default branch after remote cleanup

### DIFF
--- a/.agents/scripts/remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/remote-branch-cleanup-helper.sh
@@ -185,6 +185,81 @@ delete_branch() {
 	return 0
 }
 
+print_sync() {
+	local action="$1"
+	local branch="$2"
+	local reason="$3"
+	printf '%-10s %-55s %s\n' "$action" "$branch" "$reason"
+	return 0
+}
+
+sync_default_branch_after_cleanup() {
+	local default="$1"
+	local current upstream expected local_sha remote_sha merge_base
+
+	printf '\nDefault branch sync check:\n'
+	current=$(repo_git symbolic-ref --quiet --short HEAD 2>/dev/null) || current=""
+	if [[ -z "$current" ]]; then
+		print_sync "skip-sync" "$default" "detached HEAD"
+		return 0
+	fi
+	if [[ "$current" != "$default" ]]; then
+		print_sync "skip-sync" "$current" "not default branch (${default})"
+		return 0
+	fi
+
+	upstream=$(repo_git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) || upstream=""
+	expected="${REMOTE_NAME}/${default}"
+	if [[ -z "$upstream" ]]; then
+		print_sync "skip-sync" "$current" "no upstream configured"
+		return 0
+	fi
+	if [[ "$upstream" != "$expected" ]]; then
+		print_sync "skip-sync" "$current" "upstream is ${upstream}, expected ${expected}"
+		return 0
+	fi
+	if ! repo_git diff --quiet || ! repo_git diff --cached --quiet; then
+		print_sync "skip-sync" "$current" "worktree or index is dirty"
+		return 0
+	fi
+
+	local_sha=$(repo_git rev-parse HEAD 2>/dev/null) || local_sha=""
+	remote_sha=$(repo_git rev-parse "$upstream" 2>/dev/null) || remote_sha=""
+	if [[ -z "$local_sha" || -z "$remote_sha" ]]; then
+		print_sync "skip-sync" "$current" "unable to resolve local or upstream SHA"
+		return 0
+	fi
+	if [[ "$local_sha" == "$remote_sha" ]]; then
+		print_sync "up-to-date" "$current" "matches ${upstream}"
+		return 0
+	fi
+	merge_base=$(repo_git merge-base HEAD "$upstream" 2>/dev/null) || merge_base=""
+	if [[ -z "$merge_base" ]]; then
+		print_sync "skip-sync" "$current" "no merge-base with ${upstream}"
+		return 0
+	fi
+	if [[ "$remote_sha" == "$merge_base" ]]; then
+		print_sync "skip-sync" "$current" "local branch is ahead of ${upstream}"
+		return 0
+	fi
+	if [[ "$local_sha" != "$merge_base" ]]; then
+		print_sync "skip-sync" "$current" "local branch has diverged from ${upstream}"
+		return 0
+	fi
+
+	if [[ "$APPLY" != "1" ]]; then
+		print_sync "would-ff" "$current" "behind ${upstream}; dry-run only"
+		return 0
+	fi
+	if repo_git merge --ff-only "$upstream" >/dev/null 2>&1; then
+		remote_sha=$(repo_git rev-parse --short HEAD 2>/dev/null) || remote_sha="unknown"
+		print_sync "fast-fwd" "$current" "updated to ${remote_sha} from ${upstream}"
+	else
+		print_sync "failed" "$current" "git merge --ff-only ${upstream} failed"
+	fi
+	return 0
+}
+
 scan_branches() {
 	if [[ ! -d "$REPO_PATH/.git" && ! -f "$REPO_PATH/.git" ]]; then
 		print_error "Not a git worktree: $REPO_PATH"
@@ -260,6 +335,7 @@ scan_branches() {
 	if [[ "$APPLY" != "1" ]]; then
 		printf 'Dry-run only. Re-run with --apply to delete safe candidates.\n'
 	fi
+	sync_default_branch_after_cleanup "$default"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
@@ -91,6 +91,18 @@ merge_branch_to_main() {
 	return 0
 }
 
+advance_origin_main() {
+	local origin_repo="$1"
+	local update_repo="$2"
+	local update_name="${update_repo##*/}"
+	git clone -q "$origin_repo" "$update_repo"
+	git -C "$update_repo" config user.email test@example.invalid
+	git -C "$update_repo" config user.name "Remote Branch Cleanup Test"
+	make_commit "$update_repo" "${update_name}.txt" "$update_name"
+	git -C "$update_repo" push -q origin main
+	return 0
+}
+
 install_gh_stub() {
 	local bin_dir="$1"
 	mkdir -p "$bin_dir"
@@ -174,10 +186,60 @@ run_apply_assertions() {
 	return 0
 }
 
+run_sync_assertions() {
+	local origin_repo="$TEST_ROOT/sync-origin.git"
+	local repo="$TEST_ROOT/sync-repo"
+	local output ahead_count
+	git init -q --bare "$origin_repo"
+	git clone -q "$origin_repo" "$repo"
+	git -C "$repo" config user.email test@example.invalid
+	git -C "$repo" config user.name "Remote Branch Cleanup Test"
+	make_commit "$repo" base.txt base
+	git -C "$repo" branch -M main
+	git -C "$repo" push -q -u origin main
+	git -C "$origin_repo" symbolic-ref HEAD refs/heads/main
+
+	advance_origin_main "$origin_repo" "$TEST_ROOT/sync-updater"
+	output=$(AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH=1 bash "$HELPER" --repo "$repo")
+	assert_contains "$output" "would-ff" "dry-run reports pending default-branch fast-forward"
+	assert_contains "$output" "behind origin/main; dry-run only" "dry-run explains sync is not applied"
+	ahead_count=$(git -C "$repo" rev-list --count HEAD..origin/main)
+	[[ "$ahead_count" == "1" ]] || fail "dry-run must not fast-forward local main"
+	pass "dry-run leaves local main behind origin/main"
+
+	output=$(AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH=1 bash "$HELPER" --repo "$repo" --apply)
+	assert_contains "$output" "fast-fwd" "apply fast-forwards clean default branch"
+	ahead_count=$(git -C "$repo" rev-list --count HEAD..origin/main)
+	[[ "$ahead_count" == "0" ]] || fail "apply should fast-forward local main"
+	pass "apply reconciles local main with origin/main"
+
+	git -C "$repo" checkout -qb feature-work
+	output=$(AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH=1 bash "$HELPER" --repo "$repo" --apply)
+	assert_contains "$output" "not default branch (main)" "non-default branch sync is skipped"
+
+	git -C "$repo" checkout -q main
+	advance_origin_main "$origin_repo" "$TEST_ROOT/sync-updater-dirty"
+	printf '%s\n' dirty >>"${repo}/base.txt"
+	output=$(AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH=1 bash "$HELPER" --repo "$repo" --apply)
+	assert_contains "$output" "worktree or index is dirty" "dirty default branch sync is skipped"
+	git -C "$repo" reset --hard -q HEAD
+	git -C "$repo" merge --ff-only -q origin/main
+
+	make_commit "$repo" local-ahead.txt local-ahead
+	output=$(AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH=1 bash "$HELPER" --repo "$repo" --apply)
+	assert_contains "$output" "local branch is ahead of origin/main" "ahead default branch sync is skipped"
+
+	advance_origin_main "$origin_repo" "$TEST_ROOT/sync-updater-diverged"
+	output=$(AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH=1 bash "$HELPER" --repo "$repo" --apply)
+	assert_contains "$output" "local branch has diverged from origin/main" "diverged default branch sync is skipped"
+	return 0
+}
+
 main() {
 	setup_repo
 	run_dry_run_assertions "$TEST_ROOT/repo"
 	run_apply_assertions "$TEST_ROOT/repo"
+	run_sync_assertions
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Adds a guarded post-cleanup default-branch sync check that dry-runs by default and fast-forwards only in apply mode when the local default branch is clean, behind, and tracking the expected upstream.

## Files Changed

.agents/scripts/remote-branch-cleanup-helper.sh,.agents/scripts/tests/test-remote-branch-cleanup-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-remote-branch-cleanup-helper.sh; .agents/scripts/tests/test-cleanup-remote-branches-async.sh; shellcheck .agents/scripts/remote-branch-cleanup-helper.sh .agents/scripts/cleanup-remote-branches-async-helper.sh .agents/scripts/tests/test-remote-branch-cleanup-helper.sh

Resolves #22679


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.29 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 16m and 175,917 tokens on this with the user in an interactive session.