### PR TITLE
GH#22677: keep dispatch overrides peer-only

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -283,13 +283,20 @@ _detect_stale_worker_takeover_reason() {
 	local active_worker_max_age="${DISPATCH_ACTIVE_WORKER_MAX_AGE:-7200}"
 	[[ "$active_worker_max_age" =~ ^[0-9]+$ ]] || active_worker_max_age=7200
 
-	local comments_json
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | {body_start: (.body[:300]), created_at: .created_at}]' \
+	local raw_comments comments_json
+	raw_comments=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=${DISPATCH_CLAIM_COMMENT_FETCH_PER_PAGE}" \
+		--paginate --slurp \
 		2>/dev/null) || {
 		printf '%s' ""
 		return 0
 	}
+	comments_json=$(printf '%s' "$raw_comments" | jq -c '[ (
+		if (type == "array" and ((.[0]? | type) == "array")) then
+			.[]
+		else
+			.
+		end
+	)[] | {body_start: ((.body // "")[:300]), created_at: .created_at}]' 2>/dev/null) || comments_json="[]"
 
 	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
 		printf '%s' ""
@@ -420,6 +427,7 @@ _fetch_claim_marker_comments() {
 _fetch_claims() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local self_runner="${3:-}"
 
 	local now_epoch
 	now_epoch=$(_now_epoch)
@@ -492,7 +500,7 @@ _fetch_claims() {
 
 	# t2400: Apply runtime override filter (extracted to keep _fetch_claims
 	# under the 100-line complexity threshold — same behaviour, separate fn).
-	parsed=$(_apply_ignore_filter "$parsed" "$issue_number" "$repo_slug")
+	parsed=$(_apply_ignore_filter "$parsed" "$issue_number" "$repo_slug" "$self_runner")
 
 	printf '%s' "$parsed"
 	return 0
@@ -540,15 +548,19 @@ _version_below() {
 _filter_below_version() {
 	local parsed="$1"
 	local floor="$2"
+	local self_runner="${3:-}"
 
 	# Collect IDs of claims strictly below the floor.
 	local below_ids=""
 	local claim_rows
-	claim_rows=$(printf '%s' "$parsed" | jq -r '.[] | [.id, (.version // "unknown")] | @tsv' 2>/dev/null) || return 0
+	claim_rows=$(printf '%s' "$parsed" | jq -r '.[] | [.id, (.runner // ""), (.version // "unknown")] | @tsv' 2>/dev/null) || return 0
 
-	local id version
-	while IFS=$'\t' read -r id version; do
+	local id runner version
+	while IFS=$'\t' read -r id runner version; do
 		[[ -z "$id" ]] && continue
+		if [[ -n "$self_runner" && "$runner" == "$self_runner" ]]; then
+			continue
+		fi
 		if _version_below "$version" "$floor"; then
 			below_ids+="${id}"$'\n'
 		fi
@@ -627,6 +639,7 @@ _structured_filter_classify_claims() {
 	local rows="$1"
 	local issue_number="$2"
 	local repo_slug="$3"
+	local self_runner="${4:-}"
 
 	# Iterate via IFS=newline `for` rather than `while read <<<"$rows"` — the
 	# complexity-regression scanner's nesting-depth heuristic treats
@@ -641,6 +654,10 @@ _structured_filter_classify_claims() {
 		[[ -z "$line" ]] && { IFS=$'\n'; continue; }
 		IFS=$'\t' read -r id runner version <<<"$line"
 		[[ -z "$id" ]] && { IFS=$'\n'; continue; }
+		if [[ -n "$self_runner" && "$runner" == "$self_runner" ]]; then
+			IFS=$'\n'
+			continue
+		fi
 		action=$(_override_resolve "$runner" "$version" 2>/dev/null) || action="honour"
 		case "$action" in
 		ignore) printf '%s\n' "$id" ;;
@@ -663,6 +680,7 @@ _apply_structured_filter() {
 	local parsed="$1"
 	local issue_number="$2"
 	local repo_slug="$3"
+	local self_runner="${4:-}"
 
 	# No-op fast paths: master switch off, resolver missing, or no config.
 	if [[ "${DISPATCH_OVERRIDE_ENABLED:-true}" != "true" ]] \
@@ -678,7 +696,7 @@ _apply_structured_filter() {
 		printf '%s' "$parsed"
 		return 0
 	}
-	to_strip_newline=$(_structured_filter_classify_claims "$rows" "$issue_number" "$repo_slug")
+	to_strip_newline=$(_structured_filter_classify_claims "$rows" "$issue_number" "$repo_slug" "$self_runner")
 
 	if [[ -z "$to_strip_newline" ]]; then
 		printf '%s' "$parsed"
@@ -735,6 +753,7 @@ _apply_ignore_filter() {
 	local parsed="$1"
 	local issue_number="$2"
 	local repo_slug="$3"
+	local self_runner="${4:-}"
 
 	if [[ "$DISPATCH_OVERRIDE_ENABLED" != "true" ]]; then
 		printf '%s' "$parsed"
@@ -770,8 +789,8 @@ _apply_ignore_filter() {
 		ignored_json=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ' | tr -s ' ' '\n' | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || ignored_json="[]"
 		if [[ "$ignored_json" != "[]" ]]; then
 			local filtered_login
-			filtered_login=$(printf '%s' "$parsed" | jq -c --argjson ignored "$ignored_json" '
-				map(select(.runner as $r | $ignored | index($r) | not))
+			filtered_login=$(printf '%s' "$parsed" | jq -c --argjson ignored "$ignored_json" --arg self_runner "$self_runner" '
+				map(select((.runner == $self_runner and $self_runner != "") or (.runner as $r | $ignored | index($r) | not)))
 			' 2>/dev/null)
 			if [[ -n "$filtered_login" ]]; then
 				parsed="$filtered_login"
@@ -781,11 +800,11 @@ _apply_ignore_filter() {
 
 	# Version filter (t2401, deprecated — still supported for backward compat)
 	if [[ -n "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
-		parsed=$(_filter_below_version "$parsed" "$DISPATCH_CLAIM_MIN_VERSION")
+		parsed=$(_filter_below_version "$parsed" "$DISPATCH_CLAIM_MIN_VERSION" "$self_runner")
 	fi
 
 	# Structured per-runner filter (t2422)
-	parsed=$(_apply_structured_filter "$parsed" "$issue_number" "$repo_slug")
+	parsed=$(_apply_structured_filter "$parsed" "$issue_number" "$repo_slug" "$self_runner")
 
 	local post_count
 	post_count=$(printf '%s' "$parsed" | jq 'length' 2>/dev/null || echo 0)
@@ -898,7 +917,7 @@ cmd_claim() {
 
 	# Step 3: Fetch all claims
 	local claims
-	claims=$(_fetch_claims "$issue_number" "$repo_slug") || {
+	claims=$(_fetch_claims "$issue_number" "$repo_slug" "$runner") || {
 		echo "CLAIM_ERROR: failed to fetch claims — proceeding (fail-open)" >&2
 		return 2
 	}

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1186,6 +1186,18 @@ is_assigned() {
 		local _a _upper _override_val _now_epoch _q_until _q_until_epoch
 		_now_epoch=$(date -u '+%s')
 		for _a in "${_override_array[@]}"; do
+			# Overrides and quarantine are peer-only. The current runner's own
+			# assignment remains authoritative so a worker never ignores its own
+			# in-flight claim state because its login appears in local override
+			# config.
+			if [[ -n "$self_login" && "$_a" == "$self_login" ]]; then
+				if [[ -n "$_filtered_assignees" ]]; then
+					_filtered_assignees="${_filtered_assignees},${_a}"
+				else
+					_filtered_assignees="$_a"
+				fi
+				continue
+			fi
 			# Slug normalisation matches pulse-peer-quarantine-helper.sh's
 			# _pq_login_to_var: dash/dot/@ → underscore, uppercase.
 			_upper="$(printf '%s' "$_a" | tr 'a-z\-.@' 'A-Z___')"

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -173,6 +173,7 @@ local_state_dir="${MOCK_GH_STATE_DIR:?}"
 post_body_file="${local_state_dir}/post_body.txt"
 terminal_body="${MOCK_TERMINAL_BODY:-}"
 dispatch_body="${MOCK_DISPATCH_BODY:-Dispatching worker (PID 12345)}"
+paginated_comments="${MOCK_PAGINATED_COMMENTS:-false}"
 
 if [[ "${1:-}" != "api" ]]; then
 	exit 1
@@ -224,6 +225,24 @@ if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
 	fi
 
 	if [[ -n "$terminal_body" ]]; then
+		if [[ "$paginated_comments" == "true" ]]; then
+			jq -n \
+				--arg dispatch_body "$dispatch_body" \
+				--arg dispatch_ts "${MOCK_DISPATCH_CREATED_AT:?}" \
+				--arg terminal_body "$terminal_body" \
+				--arg terminal_ts "${MOCK_TERMINAL_CREATED_AT:?}" \
+				--arg new_body "$new_body" \
+				--arg claim_ts "${MOCK_CLAIM_CREATED_AT:?}" \
+				'[
+					[{id: 1, body_start: "human discussion", body: "human discussion", created_at: "2026-05-01T00:00:00Z"}],
+					[
+						{id: 10, body_start: $dispatch_body, body: $dispatch_body, created_at: $dispatch_ts},
+						{id: 11, body_start: $terminal_body, body: $terminal_body, created_at: $terminal_ts},
+						{id: 999, body_start: $new_body, body: $new_body, created_at: $claim_ts}
+					]
+				]'
+			exit 0
+		fi
 		jq -n \
 			--arg dispatch_body "$dispatch_body" \
 			--arg dispatch_ts "${MOCK_DISPATCH_CREATED_AT:?}" \
@@ -235,6 +254,22 @@ if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
 				{id: 10, body_start: $dispatch_body, body: $dispatch_body, created_at: $dispatch_ts},
 				{id: 11, body_start: $terminal_body, body: $terminal_body, created_at: $terminal_ts},
 				{id: 999, body_start: $new_body, body: $new_body, created_at: $claim_ts}
+			]'
+		exit 0
+	fi
+
+	if [[ "$paginated_comments" == "true" ]]; then
+		jq -n \
+			--arg dispatch_body "$dispatch_body" \
+			--arg dispatch_ts "${MOCK_DISPATCH_CREATED_AT:?}" \
+			--arg new_body "$new_body" \
+			--arg claim_ts "${MOCK_CLAIM_CREATED_AT:?}" \
+			'[
+				[{id: 1, body_start: "human discussion", body: "human discussion", created_at: "2026-05-01T00:00:00Z"}],
+				[
+					{id: 10, body_start: $dispatch_body, body: $dispatch_body, created_at: $dispatch_ts},
+					{id: 999, body_start: $new_body, body: $new_body, created_at: $claim_ts}
+				]
 			]'
 		exit 0
 	fi
@@ -695,6 +730,90 @@ test_claim_reads_paginated_comment_tail() {
 }
 
 #######################################
+# Test: override filters are peer-only and preserve this runner's own claim.
+#######################################
+test_claim_ignore_filter_preserves_self_claim() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_mock_gh "$tmp_dir")"
+
+	local old_created_at new_created_at output exit_code
+	old_created_at="$(iso_seconds_ago 10)"
+	new_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" \
+		MOCK_NEW_CLAIM_CREATED_AT="$new_created_at" \
+		MOCK_OLD_CLAIM_RUNNER="mockrunner" \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_CLAIM_IGNORE_RUNNERS="mockrunner" \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 1 ]]; then
+		print_result "legacy ignore filter preserves self claim" 0
+	else
+		print_result "legacy ignore filter preserves self claim" 1 "got exit $exit_code output: $output"
+	fi
+
+	if printf '%s' "$output" | grep -q "CLAIM_STALE_SELF:"; then
+		print_result "self-preserved ignored claim remains authoritative" 0
+	else
+		print_result "self-preserved ignored claim remains authoritative" 1 "output: $output"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+#######################################
+# Test: structured dispatch overrides are peer-only for this runner's claim.
+#######################################
+test_claim_structured_override_preserves_self_claim() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_mock_gh "$tmp_dir")"
+
+	local old_created_at new_created_at output exit_code
+	old_created_at="$(iso_seconds_ago 10)"
+	new_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" \
+		MOCK_NEW_CLAIM_CREATED_AT="$new_created_at" \
+		MOCK_OLD_CLAIM_RUNNER="mockrunner" \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_OVERRIDE_MOCKRUNNER="ignore" \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 1 ]]; then
+		print_result "structured override preserves self claim" 0
+	else
+		print_result "structured override preserves self claim" 1 "got exit $exit_code output: $output"
+	fi
+
+	if printf '%s' "$output" | grep -q "CLAIM_STALE_SELF:"; then
+		print_result "self-preserved structured claim remains authoritative" 0
+	else
+		print_result "self-preserved structured claim remains authoritative" 1 "output: $output"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+#######################################
 # Test: stale worker takeover claims are annotated (GH#22356)
 #######################################
 test_claim_marks_stale_worker_takeover() {
@@ -744,6 +863,52 @@ test_claim_marks_stale_worker_takeover() {
 		print_result "claim includes OpenCode version" 0
 	else
 		print_result "claim includes OpenCode version" 1 "body: ${post_body:-none}"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+#######################################
+# Test: stale takeover detection scans every paginated issue-comment page.
+#######################################
+test_claim_marks_paginated_stale_worker_takeover() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local mock_path
+	mock_path="$(create_stale_worker_mock_gh "$tmp_dir")"
+
+	local dispatch_created_at claim_created_at output exit_code
+	dispatch_created_at="$(iso_seconds_ago 120)"
+	claim_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_DISPATCH_CREATED_AT="$dispatch_created_at" \
+		MOCK_CLAIM_CREATED_AT="$claim_created_at" \
+		MOCK_PAGINATED_COMMENTS=true \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_ACTIVE_WORKER_MAX_AGE=60 \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "paginated stale worker takeover claim exits 0" 0
+	else
+		print_result "paginated stale worker takeover claim exits 0" 1 "got exit $exit_code output: $output"
+	fi
+
+	local post_body=""
+	if [[ -f "${tmp_dir}/post_body.txt" ]]; then
+		post_body=$(<"${tmp_dir}/post_body.txt")
+	fi
+	if printf '%s' "$post_body" | grep -q 'reason=stale_worker_takeover'; then
+		print_result "paginated stale worker takeover includes reason" 0
+	else
+		print_result "paginated stale worker takeover includes reason" 1 "body: ${post_body:-none}"
 	fi
 
 	rm -rf "$tmp_dir"
@@ -819,7 +984,10 @@ main() {
 	test_claim_rejects_stale_same_runner_claim
 	test_claim_rejects_fresh_same_runner_claim
 	test_claim_reads_paginated_comment_tail
+	test_claim_ignore_filter_preserves_self_claim
+	test_claim_structured_override_preserves_self_claim
 	test_claim_marks_stale_worker_takeover
+	test_claim_marks_paginated_stale_worker_takeover
 	test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment
 	test_claim_skips_takeover_reason_after_terminal
 

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -94,7 +94,7 @@ create_gh_stub() {
 	local assignees_csv="$1"
 	local labels_csv="${2:-}"
 	local state="${3:-OPEN}"
-	local assignees_json labels_json recent_ts
+	local assignees_json labels_json recent_ts issue_created_ts
 
 	assignees_json=$(
 		ASSIGNEES_CSV="$assignees_csv" python3 - <<'PY'
@@ -116,6 +116,7 @@ PY
 	# Fresh UTC timestamp so the synthetic comment is always "recent"
 	# regardless of when the test runs.
 	recent_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	issue_created_ts=$(date -u -v-120S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '120 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
 
 	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
 #!/usr/bin/env bash
@@ -123,6 +124,36 @@ set -euo pipefail
 
 if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
 	printf '%s\n' '{"state":"${state}","assignees":${assignees_json},"labels":${labels_json}}'
+	exit 0
+fi
+
+# REST-fallback issue view path used when shared-gh-wrappers routes reads away
+# from GraphQL: gh api /repos/<slug>/issues/<num> --jq '<projection>'.
+if [[ "\${1:-}" == "api" ]] && [[ "\${2:-}" == /repos/*/issues/* || "\${2:-}" == repos/*/issues/* ]]; then
+	endpoint="\${2:-}"
+	shift 2
+	jq_expr=""
+	while [[ "\$#" -gt 0 ]]; do
+		case "\$1" in
+		--jq | -q)
+			jq_expr="\${2:-}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+	issue_json='{"state":"${state}","assignees":${assignees_json},"labels":${labels_json},"created_at":"${issue_created_ts}"}'
+	if [[ "\$endpoint" == */comments* ]]; then
+		printf '%s\n' '[{"created_at":"${recent_ts}","author":"runner1","body_start":"Dispatching worker (PID 12345)"}]'
+		exit 0
+	fi
+	if [[ -n "\$jq_expr" ]]; then
+		printf '%s\n' "\$issue_json" | jq -c "\$jq_expr"
+		exit 0
+	fi
+	printf '%s\n' "\$issue_json"
 	exit 0
 fi
 
@@ -459,6 +490,50 @@ test_owner_assigned_no_status_no_origin_allows_dispatch() {
 	return 0
 }
 
+test_override_ignore_preserves_self_assignee() {
+	create_gh_stub "runner1" "status:queued"
+	cat >"${TEST_ROOT}/config/aidevops/dispatch-override.conf" <<'EOF'
+DISPATCH_OVERRIDE_RUNNER1="ignore"
+EOF
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'runner1'*)
+			print_result "override ignore preserves self assignee" 0
+			return 0
+			;;
+		esac
+		print_result "override ignore preserves self assignee" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "override ignore preserves self assignee" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+test_peer_quarantine_preserves_self_assignee() {
+	create_gh_stub "runner1" "status:queued"
+	cat >"${TEST_ROOT}/config/aidevops/dispatch-override.conf" <<'EOF'
+DISPATCH_OVERRIDE_RUNNER1="peer-quarantine-until=2999-01-01T00:00:00Z"
+EOF
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'runner1'*)
+			print_result "peer quarantine preserves self assignee" 0
+			return 0
+			;;
+		esac
+		print_result "peer quarantine preserves self assignee" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "peer quarantine preserves self assignee" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
 test_dispatch_comment_blocks_inside_active_worker_window() {
 	local dispatch_created_at output
 	dispatch_created_at=$(date -u -v-120S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '120 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
@@ -549,6 +624,8 @@ main() {
 	test_owner_assigned_with_origin_interactive_blocks
 	test_maintainer_assigned_with_origin_interactive_blocks
 	test_owner_assigned_no_status_no_origin_allows_dispatch
+	test_override_ignore_preserves_self_assignee
+	test_peer_quarantine_preserves_self_assignee
 	test_dispatch_comment_blocks_inside_active_worker_window
 	test_ops_wrapped_dispatch_comment_blocks_inside_active_worker_window
 	test_dispatch_comment_expires_after_active_worker_window


### PR DESCRIPTION
## Summary

Made dispatch override and quarantine filters peer-only so a runner never strips its own claim or assignee, and paginated stale-worker takeover scans across long issue threads.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh,.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh; bash .agents/scripts/tests/test-dispatch-claim-helper.sh; bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh

Resolves #22677


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.30 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 121,923 tokens on this as a headless worker.