### PR TITLE
GH#3894: paginate stale assignment comments

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -402,7 +402,7 @@ _is_stale_assignment() {
 	# GH#18816: fail-CLOSED on API failure. A transient gh error is NOT evidence
 	# that the assignment is stale — block this pulse cycle and retry next cycle.
 	local comments_json _comments_rc=0
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate \
 		--jq '[.[] | {created_at: .created_at, author: .user.login, body_start: (.body[:200])}] | sort_by(.created_at) | reverse' \
 		2>/dev/null) || _comments_rc=$?
 

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#3894 / t2769 no_work false trips.
+#
+# _is_stale_assignment must paginate issue comments. Without --paginate, long
+# issue threads can return only the first page of old dispatch comments; the
+# stale-recovery path then ignores recent activity, unassigns a live issue, and
+# records a stale_timeout no_work fast-fail that can trip the t2769 breaker.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+TMP_HOME="$(mktemp -d -t stale-pagination.XXXXXX)" || exit 1
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+export HOME="$TMP_HOME"
+export LOGFILE="${TMP_HOME}/test.log"
+SCRIPT_DIR="$SCRIPTS_DIR"
+
+# shellcheck source=../dispatch-dedup-stale.sh
+source "${SCRIPTS_DIR}/dispatch-dedup-stale.sh"
+
+RECOVERY_CALLED=0
+GH_CALL_LOG="${TMP_HOME}/gh-calls.log"
+: >"$GH_CALL_LOG"
+
+_resolve_stale_threshold() {
+	local _issue_number="$1"
+	local _repo_slug="$2"
+	: "$_issue_number" "$_repo_slug"
+	printf 'false\n600\n2020-01-01T00:00:00Z\n'
+	return 0
+}
+
+_recover_stale_assignment() {
+	local _issue_number="$1"
+	local _repo_slug="$2"
+	local _stale_assignees="$3"
+	local _reason="$4"
+	: "$_issue_number" "$_repo_slug" "$_stale_assignees" "$_reason"
+	RECOVERY_CALLED=1
+	return 0
+}
+
+gh() {
+	local cmd="${1:-}"
+	shift || true
+	if [[ "$cmd" != "api" ]]; then
+		printf '{}\n'
+		return 0
+	fi
+
+	local path="${1:-}"
+	shift || true
+	if [[ "$path" != "repos/owner/repo/issues/123/comments" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+
+	local has_paginate=0
+	local jq_filter=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--paginate)
+			has_paginate=1
+			shift
+			;;
+		--jq)
+			jq_filter="${2:-}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local response
+	if [[ "$has_paginate" -eq 1 ]]; then
+		printf 'comments_paginated\n' >>"$GH_CALL_LOG"
+		response=$(printf '[{"created_at":"2020-01-01T00:00:00Z","user":{"login":"runner"},"body":"Dispatching worker (deterministic)."},{"created_at":"%s","user":{"login":"runner"},"body":"CLAIM_RELEASED reason=clean runner=runner exit=0 session_count=1"}]\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+	else
+		printf 'comments_unpaginated\n' >>"$GH_CALL_LOG"
+		response='[{"created_at":"2020-01-01T00:00:00Z","user":{"login":"runner"},"body":"Dispatching worker (deterministic)."}]'
+	fi
+
+	if [[ -n "$jq_filter" ]]; then
+		printf '%s' "$response" | jq -r "$jq_filter"
+	else
+		printf '%s\n' "$response"
+	fi
+	return 0
+}
+
+if _is_stale_assignment "123" "owner/repo" "runner"; then
+	fail "recent paginated activity prevents stale recovery" "_is_stale_assignment returned stale; RECOVERY_CALLED=${RECOVERY_CALLED}"
+else
+	if [[ "$RECOVERY_CALLED" -eq 0 ]]; then
+		pass "recent paginated activity prevents stale recovery"
+	else
+		fail "recent paginated activity prevents stale recovery" "recovery hook was called"
+	fi
+fi
+
+if grep -q '^comments_paginated$' "$GH_CALL_LOG" 2>/dev/null; then
+	pass "comments API is called with --paginate"
+else
+	fail "comments API is called with --paginate" "mock observed a non-paginated comments request"
+fi
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- Root cause: `.agents/scripts/dispatch-dedup-stale.sh::_is_stale_assignment` documented paginated comment reads but omitted `--paginate`, so long issue histories could see only old dispatch comments, stale-recover a live assignment, and feed `stale_timeout`/`no_work` into the t2769 breaker.
- Added `--paginate` to the stale-assignment comments fetch.
- Added a regression test that fails when recent activity is only visible through paginated comment results.

## Testing
- `shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- Observed existing unrelated failures in `bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh` (Fix A idempotency and Fix C pre-claim abort expectations already diverge from current main behavior).

Resolves awardsapp/awardsapp#3894


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.31 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 10m and 135,153 tokens on this as a headless worker.