### PR TITLE
fix: dedupe circuit breaker comments

### DIFF
--- a/.agents/scripts/dispatch-dedup-cost.sh
+++ b/.agents/scripts/dispatch-dedup-cost.sh
@@ -13,6 +13,7 @@
 # Functions in this module (in source order):
 #   - _get_cost_budget_for_tier
 #   - _sum_issue_token_spend
+#   - _issue_has_cost_breaker_comment
 #   - _apply_cost_breaker_side_effects
 #   - _check_cost_budget
 
@@ -25,9 +26,8 @@ _DISPATCH_DEDUP_COST_LOADED=1
 # Tracks cumulative token spend across all worker attempts on an issue
 # by parsing signature-footer patterns ("spent N tokens" / "has used N
 # tokens") from comments. When spend exceeds the tier-appropriate budget
-# the breaker fires: applies needs-maintainer-review label, posts an
-# explanatory comment (idempotent on the label), and emits the
-# COST_BUDGET_EXCEEDED signal.
+# the breaker fires: applies needs-maintainer-review label, posts one
+# explanatory comment per issue, and emits the COST_BUDGET_EXCEEDED signal.
 #
 # Design (paired with t1986 parent-task guard and t2008 stale escalation):
 #   1. The breaker check runs in is_assigned() AFTER the parent-task
@@ -40,9 +40,9 @@ _DISPATCH_DEDUP_COST_LOADED=1
 #   3. Failure mode: fail-open. If we can't compute spend (gh failure,
 #      no comments, jq error), allow dispatch. The breaker is a safety
 #      net, not a hard gate. The other dedup layers still apply.
-#   4. Side effects are idempotent on the needs-maintainer-review label.
-#      If the label is already present, the signal is still emitted but
-#      no comment/edit is performed (no double-comment on every cycle).
+#   4. Side effects are idempotent on both the needs-maintainer-review label
+#      and prior cost-circuit-breaker:fired marker. If the label is missing
+#      after an approval loop, re-apply NMR but do not post another comment.
 #######################################
 
 #######################################
@@ -152,7 +152,50 @@ _sum_issue_token_spend() {
 }
 
 #######################################
-# Apply cost-breaker side effects: label + explanatory comment.
+# Check whether a cost-breaker explanatory comment already exists.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+#
+# Returns:
+#   0 = prior cost-circuit-breaker:fired marker found
+#   1 = no marker found or comments could not be inspected (fail-open)
+#######################################
+_issue_has_cost_breaker_comment() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	local comments_json
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate --slurp 2>/dev/null) || return 1
+	if [[ -z "$comments_json" || "$comments_json" == "null" ]]; then
+		return 1
+	fi
+
+	local marker_count
+	marker_count=$(printf '%s' "$comments_json" | jq -r '
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		elif type == "array" then .
+		else [] end)
+		| [.[] | select((.body // "") | test("cost-circuit-breaker:fired"))]
+		| length
+	' 2>/dev/null) || return 1
+	if ! [[ "$marker_count" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	if [[ "$marker_count" -gt 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Apply cost-breaker side effects: label + at most one explanatory comment.
 # Idempotent — if needs-maintainer-review is already present, no-op.
 #
 # Args:
@@ -185,8 +228,14 @@ _apply_cost_breaker_side_effects() {
 	local _spent_k=$((spent / 1000))
 	local _budget_k=$((budget / 1000))
 
-	gh_issue_comment "$issue_number" --repo "$repo_slug" \
-		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+	local already_commented="false"
+	if _issue_has_cost_breaker_comment "$issue_number" "$repo_slug"; then
+		already_commented="true"
+	fi
+
+	if [[ "$already_commented" != "true" ]]; then
+		gh_issue_comment "$issue_number" --repo "$repo_slug" \
+			--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 <!-- cost-circuit-breaker:fired tier=${tier} spent=${spent} budget=${budget} -->
 🛑 **Cost circuit breaker fired** (t2007)
 
@@ -204,6 +253,7 @@ Remove \`needs-maintainer-review\` after investigating the root cause to re-enab
 
 _This is the cost-runaway fail-safe from t2007 (paired with t1986 parent-task guard and t2008 stale-recovery escalation)._
 <!-- ops:end -->" 2>/dev/null || true
+	fi
 
 	# t3076: file root-cause meta-issue with forensics and dispatch a
 	# tier:thinking worker against it. Idempotent — second trip on the

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -402,13 +402,36 @@ _nmr_application_is_circuit_breaker_trip() {
 	# the marker comment immediately after applying the NMR label,
 	# so the two events are always co-temporal.
 	#
+	# Use --slurp with paginated comment reads. Without flattening all pages,
+	# gh --paginate --jq can emit one count per page; shell numeric coercion then
+	# turns "0\n1" into 0 and misses breaker markers on later pages.
+	#
 	# t3076: the meta-filer posts its `circuit-breaker-meta-filed` marker
 	# as a sibling comment on the same trip-cycle, so it falls inside the
 	# same ±60s window — no separate query needed.
+	local comments_json
+	comments_json=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate --slurp 2>/dev/null) || comments_json="[]"
+	if [[ -z "$comments_json" || "$comments_json" == "null" ]]; then
+		comments_json="[]"
+	fi
+
+	local breaker_pattern='stale-recovery-tick:escalated|cost-circuit-breaker:fired|cost-circuit-breaker:no_work_loop|circuit-breaker-escalated|circuit-breaker-meta-filed'
 	local has_breaker_trip
-	has_breaker_trip=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate \
-		--jq "[.[] | select((.created_at | fromdateiso8601) >= ((\"${label_at}\" | fromdateiso8601) - 5) and (.created_at | fromdateiso8601) <= ((\"${label_at}\" | fromdateiso8601) + 60)) | .body | select(test(\"stale-recovery-tick:escalated|cost-circuit-breaker:fired|cost-circuit-breaker:no_work_loop|circuit-breaker-escalated|circuit-breaker-meta-filed\"))] | length" \
-		2>/dev/null) || has_breaker_trip=0
+	has_breaker_trip=$(printf '%s' "$comments_json" | jq -r \
+		--arg label_at "$label_at" \
+		--arg breaker_pattern "$breaker_pattern" '
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		elif type == "array" then .
+		else [] end)
+		| [
+			.[]
+			| select(.created_at != null)
+			| select((.created_at | fromdateiso8601) >= (($label_at | fromdateiso8601) - 5)
+				and (.created_at | fromdateiso8601) <= (($label_at | fromdateiso8601) + 60))
+			| select((.body // "") | test($breaker_pattern))
+		]
+		| length
+	' 2>/dev/null) || has_breaker_trip=0
 	[[ "$has_breaker_trip" =~ ^[0-9]+$ ]] || has_breaker_trip=0
 
 	if [[ "$has_breaker_trip" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-cost-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-cost-circuit-breaker.sh
@@ -147,6 +147,16 @@ write_fixture_comments() {
 	printf '[%s]' "$comments" >"$FIXTURE_COMMENTS_JSON"
 }
 
+write_fixture_comments_with_existing_cost_marker() {
+	local spends="$1"
+	write_fixture_comments "$spends"
+	local tmp_json="${TEST_ROOT}/comments-with-cost-marker.json"
+	jq '. + [{"body":"<!-- cost-circuit-breaker:fired tier=standard spent=900000 budget=800000 -->\nCost circuit breaker fired already."}]' \
+		<"$FIXTURE_COMMENTS_JSON" >"$tmp_json"
+	mv "$tmp_json" "$FIXTURE_COMMENTS_JSON"
+	return 0
+}
+
 write_stub_gh
 OLD_PATH="$PATH"
 export PATH="${STUB_DIR}:${PATH}"
@@ -282,12 +292,43 @@ else
 fi
 
 # =============================================================================
-# Assertion 8 — unknown tier falls back to default budget (800K)
+# Assertion 8 — side-effect idempotency: when the NMR label was removed after a
+# prior cost-breaker trip, re-apply the label but do NOT post another
+# explanatory comment.
+# =============================================================================
+: >"$STUB_LOG"
+write_fixture_issue '[{"name":"tier:standard"},{"name":"pulse"}]'
+write_fixture_comments_with_existing_cost_marker "500000,400000"
+run_check_cost_budget 18008 "owner/repo" "standard"
+if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* ]]; then
+	prior_marker_signal_ok=0
+else
+	prior_marker_signal_ok=1
+fi
+if grep -qE '^issue edit ' "$STUB_LOG"; then
+	prior_marker_label_ok=0
+else
+	prior_marker_label_ok=1
+fi
+if grep -qE '^issue comment ' "$STUB_LOG"; then
+	prior_marker_no_comment_ok=1
+else
+	prior_marker_no_comment_ok=0
+fi
+if [[ "$prior_marker_signal_ok" -eq 0 && "$prior_marker_label_ok" -eq 0 && "$prior_marker_no_comment_ok" -eq 0 ]]; then
+	print_result "side-effect idempotency (prior marker → relabel without double-comment)" 0
+else
+	print_result "side-effect idempotency (prior marker → relabel without double-comment)" 1 \
+		"(signal_ok=$prior_marker_signal_ok label_ok=$prior_marker_label_ok no_comment_ok=$prior_marker_no_comment_ok output='$output')"
+fi
+
+# =============================================================================
+# Assertion 9 — unknown tier falls back to default budget (800K)
 # =============================================================================
 # Spend 900K on an issue with no tier:* label → should block (default = 800K).
 write_fixture_issue '[{"name":"pulse"}]'
 write_fixture_comments "450000,450000"
-run_check_cost_budget 18008 "owner/repo" "unknown-tier-name"
+run_check_cost_budget 18009 "owner/repo" "unknown-tier-name"
 if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* ]]; then
 	print_result "unknown-tier falls back to default budget (900K > 800K default)" 0
 else
@@ -296,10 +337,10 @@ else
 fi
 
 # =============================================================================
-# Assertion 9 — sum-issue-token-spend CLI returns parseable spent|attempts
+# Assertion 10 — sum-issue-token-spend CLI returns parseable spent|attempts
 # =============================================================================
 write_fixture_comments "10000,20000,30000"
-sum_output=$("$DEDUP_HELPER" sum-issue-token-spend 18009 "owner/repo" 2>/dev/null)
+sum_output=$("$DEDUP_HELPER" sum-issue-token-spend 18010 "owner/repo" 2>/dev/null)
 if [[ "$sum_output" == "60000|3" ]]; then
 	print_result "sum-issue-token-spend CLI returns 'spent|attempts'" 0
 else
@@ -307,7 +348,7 @@ else
 fi
 
 # =============================================================================
-# Assertion 10 — historical "has used N tokens" pattern still aggregated
+# Assertion 11 — historical "has used N tokens" pattern still aggregated
 # =============================================================================
 # Write fixture with the older signature footer wording.
 cat >"$FIXTURE_COMMENTS_JSON" <<'JSON'
@@ -316,7 +357,7 @@ cat >"$FIXTURE_COMMENTS_JSON" <<'JSON'
   {"body":"Newer worker.\n---\nclaude-sonnet-4-6 spent 70000 tokens on this."}
 ]
 JSON
-sum_output=$("$DEDUP_HELPER" sum-issue-token-spend 18010 "owner/repo" 2>/dev/null)
+sum_output=$("$DEDUP_HELPER" sum-issue-token-spend 18011 "owner/repo" 2>/dev/null)
 if [[ "$sum_output" == "120000|2" ]]; then
 	print_result "historical 'has used' pattern aggregated alongside 'spent'" 0
 else

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -79,6 +79,7 @@ if [[ "${1:-}" == "api" ]]; then
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 			--paginate) shift ;;
+			--slurp) shift ;;
 			--jq) jq_filter="$2"; shift 2 ;;
 			*) shift ;;
 		esac
@@ -385,6 +386,21 @@ test_breaker_trip_detects_cost_circuit_breaker_marker() {
 	return 0
 }
 
+test_breaker_trip_detects_paginated_marker_on_later_page() {
+	# GH paginates issue comments. Pre-fix, `gh api --paginate --jq` emitted one
+	# count per page (for example "0\n1"), failed numeric coercion, and missed
+	# breaker markers outside the first page — allowing repeated auto-approval
+	# comments after a cost/no_work circuit breaker.
+	set_comments '[[{"created_at":"2026-05-03T19:18:00Z","body":"regular earlier comment"}],[{"created_at":"2026-05-03T19:19:38Z","body":"<!-- cost-circuit-breaker:no_work_loop count=3 threshold=3 -->\nPer-issue no_work circuit breaker fired."}]]'
+	if _nmr_application_is_circuit_breaker_trip 3778 awardsapp/awardsapp "2026-05-03T19:19:36Z"; then
+		print_result "breaker_trip detects marker on later paginated page" 0
+		return 0
+	fi
+	print_result "breaker_trip detects marker on later paginated page" 1 \
+		"Expected exit 0 — paginated breaker marker within window must preserve NMR"
+	return 0
+}
+
 test_breaker_trip_detects_legacy_escalated_marker() {
 	set_comments '[{"created_at":"2026-04-13T05:00:00Z","body":"<!-- circuit-breaker-escalated -->"}]'
 	if _nmr_application_is_circuit_breaker_trip 18641 marcusquinn/aidevops "2026-04-13T05:00:00Z"; then
@@ -521,6 +537,7 @@ main() {
 	# _nmr_application_is_circuit_breaker_trip (breaker trips only)
 	test_breaker_trip_detects_stale_recovery_escalation_marker
 	test_breaker_trip_detects_cost_circuit_breaker_marker
+	test_breaker_trip_detects_paginated_marker_on_later_page
 	test_breaker_trip_detects_legacy_escalated_marker
 	test_breaker_trip_rejects_source_review_scanner_marker
 	test_breaker_trip_ignores_marker_outside_window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- dedupe circuit breaker comments after NMR approval loops (#22689)
+
 ## [3.14.31] - 2026-05-03
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Preserve circuit-breaker NMR when breaker markers appear on later paginated issue-comment pages.
- Make cost breaker side effects post at most one explanatory `cost-circuit-breaker:fired` comment per issue, even if approval loops remove/reapply NMR.
- Add regression coverage for paginated breaker marker detection and prior-marker relabel idempotency.

Resolves #22689

## Verification
- `shellcheck .agents/scripts/dispatch-dedup-cost.sh .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-cost-circuit-breaker.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh .agents/scripts/tests/test-pulse-nmr-approval.sh`
- `.agents/scripts/tests/test-cost-circuit-breaker.sh`
- `.agents/scripts/tests/test-pulse-nmr-automation-signature.sh`
- `bash .agents/scripts/tests/test-pulse-nmr-approval.sh`
- `git diff --check`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.31 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 11m and 248,541 tokens on this with the user in an interactive session.
