### PR TITLE
GH#22687: Bound Claude MCP registration listing

### DIFF
--- a/.agents/scripts/generate-runtime-config-mcp.sh
+++ b/.agents/scripts/generate-runtime-config-mcp.sh
@@ -43,6 +43,12 @@ _generate_mcp_for_runtime() {
 
 	print_info "Registering MCP servers for $display_name..."
 
+	if [[ "$runtime_id" == "claude" || "$runtime_id" == "claude-code" ]]; then
+		if declare -f _mcp_adapter_reset_claude_registration_cache >/dev/null 2>&1; then
+			_mcp_adapter_reset_claude_registration_cache
+		fi
+	fi
+
 	local mcp_count=0
 
 	# Shared MCP definitions -- defined once, registered for each runtime

--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -58,14 +58,23 @@ source "${SCRIPT_DIR}/ai-cli-config.sh"
 _mcp_adapter_run_with_timeout() {
 	local timeout_seconds="$1"
 	shift
+	local kill_after_seconds="${AIDEVOPS_MCP_TIMEOUT_KILL_AFTER_SECONDS:-2}"
 
 	if command -v timeout >/dev/null 2>&1; then
-		timeout "${timeout_seconds}s" "$@"
+		if _mcp_adapter_timeout_supports_kill_after timeout; then
+			timeout -k "${kill_after_seconds}s" "${timeout_seconds}s" "$@"
+		else
+			timeout "${timeout_seconds}s" "$@"
+		fi
 		return $?
 	fi
 
 	if command -v gtimeout >/dev/null 2>&1; then
-		gtimeout "${timeout_seconds}s" "$@"
+		if _mcp_adapter_timeout_supports_kill_after gtimeout; then
+			gtimeout -k "${kill_after_seconds}s" "${timeout_seconds}s" "$@"
+		else
+			gtimeout "${timeout_seconds}s" "$@"
+		fi
 		return $?
 	fi
 
@@ -76,6 +85,68 @@ _mcp_adapter_run_with_timeout() {
 
 	"$@"
 	return $?
+}
+
+_mcp_adapter_timeout_supports_kill_after() {
+	local timeout_cmd="$1"
+
+	"$timeout_cmd" --help 2>&1 | grep -q -- '-k'
+	return $?
+}
+
+_MCP_ADAPTER_CLAUDE_EXISTING_CACHE=""
+_MCP_ADAPTER_CLAUDE_LIST_STATUS_CACHE=""
+_MCP_ADAPTER_CLAUDE_LIST_READY=false
+
+_mcp_adapter_reset_claude_registration_cache() {
+	_MCP_ADAPTER_CLAUDE_EXISTING_CACHE=""
+	_MCP_ADAPTER_CLAUDE_LIST_STATUS_CACHE=""
+	_MCP_ADAPTER_CLAUDE_LIST_READY=false
+	return 0
+}
+
+_mcp_adapter_prepare_claude_registration() {
+	local claude_timeout_seconds="$1"
+	local existing=""
+	local list_status=0
+
+	if [[ "${_MCP_ADAPTER_CLAUDE_LIST_READY:-false}" == true ]]; then
+		return 0
+	fi
+
+	existing=$(_mcp_adapter_run_with_timeout "$claude_timeout_seconds" claude mcp list 2>/dev/null) || list_status=$?
+	_MCP_ADAPTER_CLAUDE_EXISTING_CACHE="$existing"
+	_MCP_ADAPTER_CLAUDE_LIST_STATUS_CACHE="$list_status"
+	_MCP_ADAPTER_CLAUDE_LIST_READY=true
+
+	if [[ "$list_status" -ne 0 ]]; then
+		print_warning "Claude Code MCP list timed out or failed — skipping Claude MCP registration pass"
+	fi
+	return 0
+}
+
+_mcp_adapter_claude_existing_contains() {
+	local mcp_name="$1"
+	local existing="$2"
+	local line
+
+	while IFS= read -r line; do
+		if [[ "${line%%:*}" == "$mcp_name" ]]; then
+			return 0
+		fi
+	done <<<"$existing"
+	return 1
+}
+
+_mcp_adapter_claude_cache_mark_registered() {
+	local mcp_name="$1"
+
+	if [[ -z "${_MCP_ADAPTER_CLAUDE_EXISTING_CACHE:-}" ]]; then
+		_MCP_ADAPTER_CLAUDE_EXISTING_CACHE="${mcp_name}:"
+	else
+		_MCP_ADAPTER_CLAUDE_EXISTING_CACHE+=$'\n'"${mcp_name}:"
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -270,16 +341,13 @@ _register_mcp_claude() {
 		return 0
 	fi
 
-	# Check if already registered
-	# claude mcp list output format: "name: command - status"
-	local existing list_status
-	existing=$(_mcp_adapter_run_with_timeout "$claude_timeout_seconds" claude mcp list 2>/dev/null) || list_status=$?
-	list_status="${list_status:-0}"
-	if [[ "$list_status" -ne 0 ]]; then
-		print_warning "Claude Code MCP list timed out or failed for $mcp_name — skipping"
+	# Check if already registered. The list call can trigger MCP health checks, so
+	# cache it once per registration pass instead of once per server.
+	_mcp_adapter_prepare_claude_registration "$claude_timeout_seconds"
+	if [[ "${_MCP_ADAPTER_CLAUDE_LIST_STATUS_CACHE:-1}" -ne 0 ]]; then
 		return 0
 	fi
-	if echo "$existing" | grep -q "^${mcp_name}:" 2>/dev/null; then
+	if _mcp_adapter_claude_existing_contains "$mcp_name" "${_MCP_ADAPTER_CLAUDE_EXISTING_CACHE:-}"; then
 		print_info "$mcp_name already registered in Claude Code — skipping"
 		return 0
 	fi
@@ -306,6 +374,7 @@ _register_mcp_claude() {
 	fi
 
 	if _mcp_adapter_run_with_timeout "$claude_timeout_seconds" claude mcp add-json "$mcp_name" --scope user "$claude_entry" 2>/dev/null; then
+		_mcp_adapter_claude_cache_mark_registered "$mcp_name"
 		print_success "Registered $mcp_name in Claude Code"
 	else
 		print_warning "Failed or timed out registering $mcp_name in Claude Code"

--- a/.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh
+++ b/.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh
@@ -42,6 +42,14 @@ make_stub_claude() {
 set -euo pipefail
 mode="${mode}"
 if [[ "\${1:-} \${2:-}" == "mcp list" ]]; then
+	if [[ -n "\${CLAUDE_STUB_LIST_COUNT_FILE:-}" ]]; then
+		count=0
+		if [[ -f "\$CLAUDE_STUB_LIST_COUNT_FILE" ]]; then
+			read -r count <"\$CLAUDE_STUB_LIST_COUNT_FILE" || count=0
+		fi
+		count=\$((count + 1))
+		printf '%s\n' "\$count" >"\$CLAUDE_STUB_LIST_COUNT_FILE"
+	fi
 	if [[ "\$mode" == "list-hangs" ]]; then
 		sleep 5
 	fi
@@ -61,6 +69,27 @@ EOF
 	return 0
 }
 
+make_stub_timeout_with_kill_after_log() {
+	local temp_dir="$1"
+
+	cat >"${temp_dir}/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--help" ]]; then
+	printf 'Usage: timeout [-k DURATION] DURATION COMMAND\n'
+	exit 0
+fi
+printf '%s\n' "$*" >"${TIMEOUT_STUB_ARGS_FILE:?}"
+if [[ "${1:-}" == "-k" ]]; then
+	shift 2
+fi
+shift
+"$@"
+EOF
+	chmod +x "${temp_dir}/timeout"
+	return 0
+}
+
 run_claude_registration_with_stub() {
 	local mode="$1"
 	local temp_dir
@@ -74,6 +103,54 @@ run_claude_registration_with_stub() {
 		source "$1"
 		_register_mcp_claude "macos-automator" "{\"command\":\"npx\",\"args\":[\"-y\",\"@example/mcp\"]}"
 	' bash "$ADAPTER"
+	return 0
+}
+
+run_two_claude_registrations_with_stub() {
+	local mode="$1"
+	local temp_dir list_count_file list_count
+	temp_dir="$(mktemp -d)"
+	trap 'rm -rf "$temp_dir"' RETURN
+	list_count_file="${temp_dir}/list-count"
+
+	make_stub_claude "$temp_dir" "$mode"
+
+	PATH="${temp_dir}:$PATH" AIDEVOPS_MCP_CLAUDE_TIMEOUT_SECONDS=1 CLAUDE_STUB_LIST_COUNT_FILE="$list_count_file" bash -c '
+		set -euo pipefail
+		source "$1"
+		_mcp_adapter_reset_claude_registration_cache
+		_register_mcp_claude "context7" "{\"command\":\"npx\",\"args\":[\"-y\",\"@example/context7\"]}"
+		_register_mcp_claude "playwright" "{\"command\":\"npx\",\"args\":[\"-y\",\"@example/playwright\"]}"
+	' bash "$ADAPTER" >/dev/null 2>&1
+
+	list_count=0
+	if [[ -f "$list_count_file" ]]; then
+		read -r list_count <"$list_count_file" || list_count=0
+	fi
+	printf '%s\n' "$list_count"
+	return 0
+}
+
+run_timeout_with_stub() {
+	local temp_dir args_file
+	temp_dir="$(mktemp -d)"
+	trap 'rm -rf "$temp_dir"' RETURN
+	args_file="${temp_dir}/timeout-args"
+
+	make_stub_claude "$temp_dir" "ok"
+	make_stub_timeout_with_kill_after_log "$temp_dir"
+
+	PATH="${temp_dir}:$PATH" TIMEOUT_STUB_ARGS_FILE="$args_file" bash -c '
+		set -euo pipefail
+		source "$1"
+		_mcp_adapter_run_with_timeout 1 claude mcp list >/dev/null
+	' bash "$ADAPTER"
+
+	if [[ -f "$args_file" ]]; then
+		local timeout_args
+		read -r timeout_args <"$args_file" || timeout_args=""
+		printf '%s\n' "$timeout_args"
+	fi
 	return 0
 }
 
@@ -109,9 +186,37 @@ test_claude_mcp_add_timeout_is_non_blocking() {
 	return 0
 }
 
+test_claude_mcp_list_is_cached_per_registration_pass() {
+	local list_count
+	list_count="$(run_two_claude_registrations_with_stub "ok")"
+
+	if [[ "$list_count" -eq 1 ]]; then
+		print_result "Claude MCP list is cached per registration pass" 0
+		return 0
+	fi
+
+	print_result "Claude MCP list is cached per registration pass" 1 "list_count=${list_count}"
+	return 0
+}
+
+test_timeout_uses_kill_after_when_available() {
+	local timeout_args
+	timeout_args="$(run_timeout_with_stub)"
+
+	if [[ "$timeout_args" == "-k 2s 1s claude mcp list" ]]; then
+		print_result "timeout uses kill-after when supported" 0
+		return 0
+	fi
+
+	print_result "timeout uses kill-after when supported" 1 "timeout_args=${timeout_args}"
+	return 0
+}
+
 main() {
 	test_claude_mcp_list_timeout_is_non_blocking
 	test_claude_mcp_add_timeout_is_non_blocking
+	test_claude_mcp_list_is_cached_per_registration_pass
+	test_timeout_uses_kill_after_when_available
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Caches Claude MCP listing once per registration pass, skips Claude registration if listing times out or fails, and uses timeout kill-after semantics where supported.

## Files Changed

.agents/scripts/generate-runtime-config-mcp.sh,.agents/scripts/mcp-config-adapter.sh,.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: bash .agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh; PASS: shellcheck changed shell files; PASS: docker run marcusquinn/aidevops-cloudron-worker:latest bash .agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh; PASS: git diff --check. NOTE: bash .agents/scripts/linters-local.sh still reports pre-existing repo-wide skill frontmatter, Bash compatibility, function complexity, and nesting-depth debt unrelated to this change.

Resolves #22687


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.32 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 20m and 92,127 tokens on this with the user in an interactive session.