### PR TITLE
chore: align package version with 3.14.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.14.32",
+  "version": "3.14.33",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Align `package.json` with the v3.14.33 patch release already recorded in `VERSION` after the cost-breaker approval prompt fix.

## Verification
- `git diff --check`
- `python3 -m json.tool package.json >/dev/null`

For #22691

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 interactive change.
