### PR TITLE
fix: slurp stale assignment comments

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -404,7 +404,7 @@ _is_stale_assignment() {
 	# overall activity timestamp. Use --paginate --slurp so gh combines all
 	# pages before jq sorts them; `gh api --paginate --jq ...` applies jq per
 	# page, which can leave page-1 timestamps ahead of newer activity on long
-	# issue threads and trigger false stale recovery (GH#3894 / #3911).
+	# issue threads and trigger false stale recovery (GH#3894 / t2769 incident).
 	#
 	# GH#18816: fail-CLOSED on API failure. A transient gh error is NOT evidence
 	# that the assignment is stale — block this pulse cycle and retry next cycle.

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -80,9 +80,15 @@ _stale_recovery_load_threshold() {
 _stale_recovery_count_ticks() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	local _prior_ticks
-	_prior_ticks=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | select(.body | (test("<!-- stale-recovery-tick:[1-9]") and (test("reset") | not)))] | length' \
+	local _comments_pages _prior_ticks
+	_comments_pages=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --slurp 2>/dev/null) || _comments_pages=""
+	if [[ -z "$_comments_pages" ]]; then
+		printf '0'
+		return 0
+	fi
+	_prior_ticks=$(printf '%s' "$_comments_pages" | jq \
+		'[.[] | .[]? | select(.body | (test("<!-- stale-recovery-tick:[1-9]") and (test("reset") | not)))] | length' \
 		2>/dev/null) || _prior_ticks=0
 	[[ "$_prior_ticks" =~ ^[0-9]+$ ]] || _prior_ticks=0
 	printf '%s' "$_prior_ticks"
@@ -395,16 +401,21 @@ _is_stale_assignment() {
 	_issue_too_young_for_staleness "$issue_created_at" "$effective_threshold" "$now_epoch" && return 1
 
 	# Fetch issue comments to find the most recent dispatch claim and
-	# overall activity timestamp. Use --paginate to catch all comments
-	# on issues with long histories, but cap with --jq to only extract
-	# what we need (timestamp + body snippet for matching).
+	# overall activity timestamp. Use --paginate --slurp so gh combines all
+	# pages before jq sorts them; `gh api --paginate --jq ...` applies jq per
+	# page, which can leave page-1 timestamps ahead of newer activity on long
+	# issue threads and trigger false stale recovery (GH#3894 / #3911).
 	#
 	# GH#18816: fail-CLOSED on API failure. A transient gh error is NOT evidence
 	# that the assignment is stale — block this pulse cycle and retry next cycle.
-	local comments_json _comments_rc=0
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate \
-		--jq '[.[] | {created_at: .created_at, author: .user.login, body_start: (.body[:200])}] | sort_by(.created_at) | reverse' \
-		2>/dev/null) || _comments_rc=$?
+	local comments_json _comments_pages _comments_rc=0
+	_comments_pages=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --slurp 2>/dev/null) || _comments_rc=$?
+	if [[ "$_comments_rc" -eq 0 ]]; then
+		comments_json=$(printf '%s' "$_comments_pages" | jq \
+			'[.[] | .[]? | {created_at: .created_at, author: .user.login, body_start: ((.body // "")[:200])}] | sort_by(.created_at) | reverse' \
+			2>/dev/null) || _comments_rc=$?
+	fi
 
 	if [[ "$_comments_rc" -ne 0 ]]; then
 		# Cannot fetch comments — cannot determine staleness. Fail-CLOSED:

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
@@ -4,10 +4,10 @@
 #
 # Regression guard for GH#3894 / t2769 no_work false trips.
 #
-# _is_stale_assignment must paginate issue comments. Without --paginate, long
-# issue threads can return only the first page of old dispatch comments; the
-# stale-recovery path then ignores recent activity, unassigns a live issue, and
-# records a stale_timeout no_work fast-fail that can trip the t2769 breaker.
+# _is_stale_assignment must paginate and slurp issue comments. Without --slurp,
+# `gh api --paginate --jq ...` runs jq per page; long issue threads can leave the
+# first page of old dispatch comments before newer page-2 activity, causing stale
+# recovery to record stale_timeout/no_work fast-fails that trip t2769.
 
 set -uo pipefail
 
@@ -82,11 +82,16 @@ gh() {
 	fi
 
 	local has_paginate=0
+	local has_slurp=0
 	local jq_filter=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--paginate)
 			has_paginate=1
+			shift
+			;;
+		--slurp)
+			has_slurp=1
 			shift
 			;;
 		--jq)
@@ -99,10 +104,15 @@ gh() {
 		esac
 	done
 
+	local recent_ts
+	recent_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	local response
-	if [[ "$has_paginate" -eq 1 ]]; then
-		printf 'comments_paginated\n' >>"$GH_CALL_LOG"
-		response=$(printf '[{"created_at":"2020-01-01T00:00:00Z","user":{"login":"runner"},"body":"Dispatching worker (deterministic)."},{"created_at":"%s","user":{"login":"runner"},"body":"CLAIM_RELEASED reason=clean runner=runner exit=0 session_count=1"}]\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+	if [[ "$has_paginate" -eq 1 && "$has_slurp" -eq 1 ]]; then
+		printf 'comments_slurped\n' >>"$GH_CALL_LOG"
+		response=$(printf '[[{"created_at":"2020-01-01T00:00:00Z","user":{"login":"runner"},"body":"Dispatching worker (deterministic)."}],[{"created_at":"%s","user":{"login":"runner"},"body":"CLAIM_RELEASED reason=clean runner=runner exit=0 session_count=1"}]]\n' "$recent_ts")
+	elif [[ "$has_paginate" -eq 1 ]]; then
+		printf 'comments_paginated_per_page\n' >>"$GH_CALL_LOG"
+		response=$(printf '[{"created_at":"2020-01-01T00:00:00Z","author":"runner","body_start":"Dispatching worker (deterministic)."}]\n[{"created_at":"%s","author":"runner","body_start":"CLAIM_RELEASED reason=clean runner=runner exit=0 session_count=1"}]\n' "$recent_ts")
 	else
 		printf 'comments_unpaginated\n' >>"$GH_CALL_LOG"
 		response='[{"created_at":"2020-01-01T00:00:00Z","user":{"login":"runner"},"body":"Dispatching worker (deterministic)."}]'
@@ -126,10 +136,10 @@ else
 	fi
 fi
 
-if grep -q '^comments_paginated$' "$GH_CALL_LOG" 2>/dev/null; then
-	pass "comments API is called with --paginate"
+if grep -q '^comments_slurped$' "$GH_CALL_LOG" 2>/dev/null; then
+	pass "comments API is called with --paginate --slurp"
 else
-	fail "comments API is called with --paginate" "mock observed a non-paginated comments request"
+	fail "comments API is called with --paginate --slurp" "mock did not observe a slurped comments request"
 fi
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Flatten slurped GitHub comment pages before stale-assignment timestamp selection so long issue threads do not use page-local ordering.
- Paginate and slurp stale-recovery tick counting so long threads do not miss breaker audit comments.
- Strengthen the stale-pagination regression test to emulate `gh api --paginate --jq` returning one result per page.

## Root cause

`dispatch-dedup-stale.sh::_is_stale_assignment` used `gh api --paginate --jq`. GitHub CLI applies `--jq` once per page, so multi-page comment threads produced multiple page-local arrays. The stale-assignment code then parsed the first page's old timestamps as the latest activity, recorded `stale_timeout` with `crash_type=no_work`, and allowed the t2769 no-work breaker to trip falsely.

## Testing

- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`

## Notes

- A broader local dispatch lifecycle test still has pre-existing unrelated fixture failures in its communication-helper sections; this diff does not touch those paths.
- Related to a private downstream circuit-breaker meta-issue; omitted here to avoid exposing private repository details in a public PR.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 11m and 143,707 tokens on this as a headless worker.