### PR TITLE
GH#22696: preserve comment fetch API errors

### DIFF
--- a/.agents/scripts/pulse-triage-cache.sh
+++ b/.agents/scripts/pulse-triage-cache.sh
@@ -220,16 +220,16 @@ _gh_idempotent_comment() {
 	local existing_comments=""
 	if [[ "$entity_type" == "pr" ]]; then
 		existing_comments=$(gh pr view "$entity_number" --repo "$repo_slug" \
-			--json comments --jq '.comments[].body' 2>/dev/null)
+			--json comments --jq '.comments[].body')
 	else
 		# t3565: GitHub's issue-comments REST endpoint defaults to the oldest
 		# 30 comments. Long-running issues can have idempotency markers beyond
 		# page 1, so normalize paginated gh output before grepping for markers.
-		existing_comments=$(gh api "repos/${repo_slug}/issues/${entity_number}/comments?per_page=100" \
-			--paginate --slurp 2>/dev/null | jq -r '
+		existing_comments=$(set -o pipefail; gh api "repos/${repo_slug}/issues/${entity_number}/comments?per_page=100" \
+			--paginate --slurp | jq -r '
 				(if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end)[]
 				| .body // ""
-			' 2>/dev/null)
+			')
 	fi
 	local api_exit=$?
 


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-triage-cache.sh so idempotent issue comment fetches fail closed when gh api fails by enabling pipefail in the command substitution, and kept gh/jq diagnostics visible instead of suppressing stderr.

## Files Changed

.agents/scripts/pulse-triage-cache.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-triage-cache.sh; shellcheck .agents/scripts/pulse-triage-cache.sh

Resolves #22696


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 23,512 tokens on this as a headless worker.