### PR TITLE
GH#22697: propagate consolidation comment API failures

### DIFF
--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -370,11 +370,11 @@ _consolidation_dispatch_comment_exists() {
 	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 1
 
 	local marker_count
-	marker_count=$(gh api "repos/${repo_slug}/issues/${parent_num}/comments?per_page=100" \
-		--paginate --slurp 2>/dev/null | jq -r '
+	marker_count=$(set -o pipefail; gh api "repos/${repo_slug}/issues/${parent_num}/comments?per_page=100" \
+		--paginate --slurp | jq -r '
 			[ (if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end)[]
 			| select((.body // "") | contains("## Issue Consolidation Dispatched")) ] | length
-	' 2>/dev/null) || return 1
+	') || return 1
 	[[ "$marker_count" =~ ^[0-9]+$ ]] || marker_count=0
 	if [[ "$marker_count" -gt 0 ]]; then
 		return 0


### PR DESCRIPTION
## Summary

Updated the consolidation dispatch-comment check so GitHub API failures propagate through the pipeline and stderr remains visible for troubleshooting.

## Files Changed

.agents/scripts/pulse-triage-evaluation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-triage-evaluation.sh

Resolves #22697


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 21,189 tokens on this as a headless worker.