### PR TITLE
GH#22699: harden pulse TODO sync recovery

### DIFF
--- a/.agents/scripts/pulse-canonical-recovery.sh
+++ b/.agents/scripts/pulse-canonical-recovery.sh
@@ -203,8 +203,34 @@ _pcr_only_todo_dirty() {
 
 _pcr_normalise_todo_sync_line() {
 	local line="$1"
-	printf '%s\n' "$line" \
-		| sed -E 's/^- \[[ xX]\] /- [?] /; s/[[:space:]]+(assignee|started|completed|logged|pr|actual|dispatched|origin|status):[^[:space:]]+//g; s/[[:space:]]+/ /g; s/[[:space:]]$//'
+	local normalised="$line"
+	local field=""
+	local words=()
+	local word=""
+	local joined=""
+
+	case "$normalised" in
+		'- [ ] '*) normalised="- [?] ${normalised#'- [ ] '}" ;;
+		'- [x] '*) normalised="- [?] ${normalised#'- [x] '}" ;;
+		'- [X] '*) normalised="- [?] ${normalised#'- [X] '}" ;;
+	esac
+
+	for field in assignee started completed logged pr actual dispatched origin status; do
+		while [[ "$normalised" =~ ^(.*)[[:space:]]${field}:[^[:space:]]+(.*)$ ]]; do
+			normalised="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+		done
+	done
+
+	read -r -a words <<<"$normalised"
+	for word in "${words[@]}"; do
+		if [[ -z "$joined" ]]; then
+			joined="$word"
+		else
+			joined="${joined} ${word}"
+		fi
+	done
+
+	printf '%s\n' "$joined"
 	return 0
 }
 
@@ -270,8 +296,12 @@ _pcr_recover_todo_sync_dirty_state() {
 
 	_pcr_audit "todo-sync-reset" "$repo_path" "ok:generated-metadata-only"
 	_pcr_log "discarding generated TODO.md sync metadata before canonical refresh"
-	git -C "$repo_path" reset -q -- TODO.md >/dev/null 2>&1 || return 2
-	git -C "$repo_path" checkout -- TODO.md >/dev/null 2>&1 || return 2
+	if ! git -C "$repo_path" reset -q -- TODO.md || ! git -C "$repo_path" checkout -- TODO.md; then
+		_pcr_audit "todo-sync-reset-failed" "$repo_path" "advisory:reset-failed"
+		_pcr_log "failed to reset TODO.md sync metadata — filing advisory"
+		_pcr_file_advisory "$repo_path" "todo-sync-reset-failed"
+		return 2
+	fi
 	if git -C "$repo_path" fetch --quiet origin >>"${LOGFILE:-/dev/null}" 2>&1 \
 		&& git -C "$repo_path" pull --ff-only --no-rebase >>"${LOGFILE:-/dev/null}" 2>&1; then
 		_pcr_audit "todo-sync-refresh" "$repo_path" "ok:no-stash"


### PR DESCRIPTION
## Summary

Replaced per-diff-line sed normalisation with pure Bash and files a local advisory when TODO.md reset/checkout fails during canonical recovery.

## Files Changed

.agents/scripts/pulse-canonical-recovery.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-canonical-recovery.sh; shellcheck .agents/scripts/pulse-canonical-recovery.sh; sourced _pcr_normalise_todo_sync_line examples; .agents/scripts/linters-local.sh reached Secretlint and timed out after 240s

Resolves #22699


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 7m and 52,476 tokens on this as a headless worker.