### PR TITLE
GH#22698: clarify OpenCode startup greeting guidance

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -88,7 +88,7 @@ describe("token cost advisory threshold", () => {
 
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
-    assert.match(output.system[0], /Do not include startup advisory\/status\/cache lines in chat/);
+    assert.match(output.system[0], /Do not include startup status or advisory messages in chat/);
     assert.doesNotMatch(output.system[0], /\[SECURITY ADVISORY\] Rotate test credentials/);
     assert.doesNotMatch(output.system[0], /\[WARN\] Pulse stalled for 12 minutes/);
     assert.doesNotMatch(output.system[0], /Security: all protections active/);
@@ -107,7 +107,7 @@ describe("token cost advisory threshold", () => {
 
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
-    assert.match(output.system[0], /do not add another greeting or a second 'what would you like to work on' line/);
+    assert.match(output.system[0], /do not add any additional salutations, greetings, introductory questions, or equivalent help prompts/);
   });
 
   test("does not inject session greeting order in headless sessions", async () => {

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -213,9 +213,9 @@ function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
     "What would you like to work on?",
     "",
     "Do this before tool calls, status updates, analysis summaries, or task work.",
-    "Do not include startup advisory/status/cache lines in chat; those are already shown by the OpenCode toast/sidebar surfaces.",
+    "Do not include startup status or advisory messages in chat; those are already shown by the OpenCode toast/sidebar surfaces.",
     "If the user launched the session with an initial message, greet first in the assistant response, then answer that message.",
-    "If the initial user message is only a greeting/salutation, do not add another greeting or a second 'what would you like to work on' line after the exact greeting above.",
+    "If the initial user message is only a greeting/salutation, do not add any additional salutations, greetings, introductory questions, or equivalent help prompts after the exact greeting above.",
     "Do not repeat the greeting after the first assistant turn, and do not duplicate the framework-status toast/sidebar content.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Clarifies the OpenCode TTSR session-start instruction so startup status/advisory messages are not described as ambiguous cache lines.
- Broadens the salutation-only launch constraint to forbid equivalent duplicate salutations, introductory questions, and help prompts.
- Updates the existing Node regression assertions in .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs.

Resolves #22698

## Testing
- `node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs` — 13 passing.
- `.agents/scripts/linters-local.sh` — attempted twice; timed out at Secretlint after 120s and 240s.
- `npm run typecheck` — project validator blocked by existing root TypeScript configuration issue: `tsc --noEmit` prints compiler help because no root tsconfig/input is configured.

## Runtime Testing
self-assessed: prompt-string-only change to OpenCode system-transform guidance; covered by Node regression assertions.

## Decisions
- Limited scope to the review-feedback target strings in .agents/plugins/opencode-aidevops/ttsr.mjs and the matching regression assertions.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 41,656 tokens on this as a headless worker.