### PR TITLE
fix: include stale recovery in no_work meta guidance

### DIFF
--- a/.agents/scripts/circuit-breaker-meta-filer.sh
+++ b/.agents/scripts/circuit-breaker-meta-filer.sh
@@ -242,6 +242,7 @@ Treat the original (#${issue_number}) as evidence, not as the work to do. The wo
 ### Files to inspect first
 
 - \`EDIT: .agents/scripts/dispatch-dedup-cost.sh\` — t2007 cost breaker definition and trip site.
+- \`EDIT: .agents/scripts/dispatch-dedup-stale.sh\` — stale-assignment recovery; false stale recovery can record \`stale_timeout\` / \`no_work\` fast-fails without a worker reaching the brief.
 - \`EDIT: .agents/scripts/worker-lifecycle-common.sh\` — t2769 no_work breaker definition and trip site (around the \`no_work_loop\` marker).
 - \`EDIT: .agents/scripts/headless-runtime-failure.sh\` — worker exit classifier (the prime suspect for misclassification).
 - \`EDIT: .agents/scripts/circuit-breaker-meta-filer.sh\` — this filer; if it filed too eagerly, fix the trip-detection upstream rather than the filer.
@@ -250,6 +251,7 @@ Treat the original (#${issue_number}) as evidence, not as the work to do. The wo
 ### Reference pattern
 
 - Existing breaker NMR application paths in \`worker-lifecycle-common.sh\` (no_work) and \`dispatch-dedup-cost.sh\` (cost) for the trip → label → comment flow that this filer hooks into.
+- \`dispatch-dedup-stale.sh::_is_stale_assignment\` for the comment-activity pagination path; it must aggregate all pages before sorting activity timestamps.
 - \`pulse-nmr-approval.sh::_nmr_application_is_circuit_breaker_trip\` for the marker-recognition pattern (this filer's marker \`${_CB_META_MARKER}\` is also recognised).
 
 ### Forensics: pulse log slice (last ${max_lines} lines mentioning the issue)
@@ -296,6 +298,7 @@ _cb_meta_body_tail() {
 ## Files Scope
 
 - `.agents/scripts/dispatch-dedup-cost.sh`
+- `.agents/scripts/dispatch-dedup-stale.sh`
 - `.agents/scripts/worker-lifecycle-common.sh`
 - `.agents/scripts/headless-runtime-failure.sh`
 - `.agents/scripts/headless-runtime-helper.sh`

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -404,7 +404,7 @@ _is_stale_assignment() {
 	# overall activity timestamp. Use --paginate --slurp so gh combines all
 	# pages before jq sorts them; `gh api --paginate --jq ...` applies jq per
 	# page, which can leave page-1 timestamps ahead of newer activity on long
-	# issue threads and trigger false stale recovery (GH#3894 / t2769 incident).
+	# issue threads and trigger false stale recovery in the t2769 no_work path.
 	#
 	# GH#18816: fail-CLOSED on API failure. A transient gh error is NOT evidence
 	# that the assignment is stale — block this pulse cycle and retry next cycle.

--- a/.agents/scripts/tests/test-circuit-breaker-meta-filer.sh
+++ b/.agents/scripts/tests/test-circuit-breaker-meta-filer.sh
@@ -190,6 +190,13 @@ else
 	print_result "first-trip: created exactly 1 issue" 1 "got count=$CREATE_COUNT"
 fi
 
+if grep -q 'dispatch-dedup-stale.sh' "$STUB_LOG" 2>/dev/null; then
+	print_result "first-trip: no_work guidance includes stale recovery path" 0
+else
+	print_result "first-trip: no_work guidance includes stale recovery path" 1 \
+		"meta body did not mention dispatch-dedup-stale.sh"
+fi
+
 # =============================================================================
 # Test 2: Idempotency — second trip with marker present returns existing
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `dispatch-dedup-stale.sh` to no_work circuit-breaker meta-issue guidance and file scope.
- Adds regression coverage that generated no_work meta briefs point workers at the stale-recovery path.
- Keeps stale-recovery comments incident-neutral while preserving the root-cause context.

## Root cause

`dispatch-dedup-stale.sh::_is_stale_assignment` is the relevant failure path for this class of t2769 `no_work` trip: stale recovery can record `stale_timeout` / `no_work` fast-fails when comment activity is aggregated incorrectly on long issue threads. The slurped comment-page aggregation fix is already present; this PR closes the remaining brief-quality gap so future meta issues route workers to the correct file/function instead of only exit-classifier and breaker code.

## Testing

- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/circuit-breaker-meta-filer.sh .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `git diff --check origin/main...HEAD`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 15m and 147,139 tokens on this as a headless worker.