### PR TITLE
GH#22703: simplify claim release comment construction

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -77,7 +77,6 @@ _release_dispatch_claim() {
 		return 0
 	fi
 
-	local comment_body
 	local aidevops_version="$AIDEVOPS_UNKNOWN_VERSION" opencode_version="$AIDEVOPS_UNKNOWN_VERSION"
 	if declare -F aidevops_find_version >/dev/null 2>&1; then
 		aidevops_version=$(aidevops_find_version 2>/dev/null || printf '%s' "$AIDEVOPS_UNKNOWN_VERSION")
@@ -86,15 +85,21 @@ _release_dispatch_claim() {
 		opencode_version=$(_detect_opencode_version 2>/dev/null || printf '%s' "")
 		opencode_version="${opencode_version:-$AIDEVOPS_UNKNOWN_VERSION}"
 	fi
-	comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-CLAIM_RELEASED reason=${reason} runner=$(whoami) ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) aidevops_version=${aidevops_version} opencode_version=${opencode_version}"
+
+	local runner_name=""
+	runner_name=$(whoami)
+	local release_ts=""
+	release_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	local machine_readable_part="CLAIM_RELEASED reason=${reason} runner=${runner_name} ts=${release_ts} aidevops_version=${aidevops_version} opencode_version=${opencode_version}"
 	if [[ -n "$exit_code_arg" ]]; then
-		comment_body="${comment_body} exit=${exit_code_arg}"
+		machine_readable_part+=" exit=${exit_code_arg}"
 	fi
 	if [[ -n "$session_count_arg" ]]; then
-		comment_body="${comment_body} session_count=${session_count_arg}"
+		machine_readable_part+=" session_count=${session_count_arg}"
 	fi
-	comment_body="${comment_body}
+
+	local comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+${machine_readable_part}
 <!-- ops:end -->"
 
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \


### PR DESCRIPTION
## Summary

Refactored .agents/scripts/headless-runtime-failure.sh to build the CLAIM_RELEASED machine-readable payload once before wrapping it in the ops comment block, improving readability while preserving existing fields.

## Files Changed

.agents/scripts/headless-runtime-failure.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/headless-runtime-failure.sh; shellcheck .agents/scripts/headless-runtime-failure.sh

Resolves #22703


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 26,083 tokens on this as a headless worker.