### PR TITLE
GH#22700: respect false signature runtime markers

### DIFF
--- a/.agents/scripts/gh-signature-helper-session.sh
+++ b/.agents/scripts/gh-signature-helper-session.sh
@@ -478,8 +478,8 @@ _detect_explicit_session_type() {
 		return 0
 	fi
 
-	if [[ "${OPENCODE:-}" == "1" ]] || [[ -n "${OPENCODE_SESSION_ID:-}" ]] ||
-		[[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+	if _gh_sig_env_truthy "${OPENCODE:-}" || [[ -n "${OPENCODE_SESSION_ID:-}" ]] ||
+		_gh_sig_env_truthy "${CLAUDE_CODE:-}" || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
 		echo "interactive"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -491,6 +491,21 @@ result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
 assert_contains "variant config alone remains interactive" "with the user in an interactive session" "$result"
 assert_not_contains "variant config does not imply worker" "as a headless worker" "$result"
 
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+	OPENCODE=true AIDEVOPS_HEADLESS_VARIANT_SONNET="high" \
+	"$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
+assert_contains "truthy OPENCODE marks interactive" "with the user in an interactive session" "$result"
+
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+	-u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID OPENCODE=false CLAUDE_CODE=0 \
+	"$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
+assert_not_contains "false runtime markers do not imply interactive" "with the user in an interactive session" "$result"
+
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+	-u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID OPENCODE=0 CLAUDE_CODE=true \
+	"$HELPER" generate --cli "Claude Code" --model "m" --tokens 1 --time 60)
+assert_contains "truthy CLAUDE_CODE marks interactive" "with the user in an interactive session" "$result"
+
 result=$(env -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS FULL_LOOP_HEADLESS=true \
 	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_contains "FULL_LOOP_HEADLESS marks worker" "as a headless worker" "$result"


### PR DESCRIPTION
## Summary

Updated signature session detection to use the shared truthy helper for OPENCODE and CLAUDE_CODE so false-like values do not imply interactive mode; added regression coverage for truthy and false-like runtime markers.

## Files Changed

.agents/scripts/gh-signature-helper-session.sh,.agents/scripts/tests/test-gh-signature-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-signature-helper-session.sh .agents/scripts/tests/test-gh-signature-helper.sh; .agents/scripts/tests/test-gh-signature-helper.sh (73 passed)

Resolves #22700


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 45,897 tokens on this as a headless worker.