### PR TITLE
GH#22706: correct goals mission routing

### DIFF
--- a/.agents/scripts/commands/goals.md
+++ b/.agents/scripts/commands/goals.md
@@ -32,11 +32,14 @@ Goal request: $ARGUMENTS
    pass it through to the mission dashboard helper:
 
    ```bash
-   ~/.aidevops/agents/scripts/mission-dashboard-helper.sh $ARGUMENTS
+   cmd=(~/.aidevops/agents/scripts/mission-dashboard-helper.sh "$ARGUMENTS")
+   "${cmd[@]}"
    ```
 
 3. Otherwise, treat `$ARGUMENTS` as the objective for a new mission and follow
-   `scripts/commands/mission.md` from Step 1 onward. Say explicitly:
+   `.agents/workflows/mission.md` from Step 0 onward. Step 0 initializes the
+   mission state, including argument parsing, headless mode handling,
+   decomposition, `MISSION_ID`, and `MISSION_DIR`. Say explicitly:
 
    ```text
    I'll track this as a mission goal so it has milestones, budget, and completion evidence.
@@ -78,7 +81,7 @@ Before marking a goal completed:
 
 ## Related
 
-- `scripts/commands/mission.md` — Mission creation and decomposition
+- `.agents/workflows/mission.md` — Mission creation and decomposition
 - `workflows/mission-orchestrator.md` — Active goal execution engine
 - `scripts/commands/dashboard.md` — Mission dashboard
 - `templates/mission-template.md` — Durable goal state file


### PR DESCRIPTION
## Summary

Updated /goals routing documentation to use the mission workflow from Step 0 and documented safe argument forwarding for dashboard modes.

## Files Changed

.agents/scripts/commands/goals.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/scripts/commands/goals.md; .agents/scripts/linters-local.sh reached Markdown checks with no style issues before unrelated pre-existing skill frontmatter errors and later timeout

Resolves #22706


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 8m and 29,480 tokens on this as a headless worker.