### PR TITLE
fix: reset failed worker claims to available

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1049,7 +1049,9 @@ clear_active_status_on_release() {
 	# t2746/GH#20520.
 	#
 	# We still remove queued, claimed, and in-progress — those never
-	# outlive the worker process regardless of PR state.
+	# outlive the worker process regardless of PR state. When no linked PR
+	# exists, add status:available in the same edit so failed workers do not
+	# leave issues pinned as assigned-but-queued until the next stale sweep.
 	#
 	# CLOSED-not-merged PRs do NOT trigger preserve: the work didn't
 	# complete, and leaving the assignee on the issue would block
@@ -1081,6 +1083,7 @@ clear_active_status_on_release() {
 
 	if [[ "$has_linked_pr" != "true" ]]; then
 		_flags+=(--remove-label "status:in-review")
+		_flags+=(--add-label "status:available")
 		if [[ -n "$worker_login" ]]; then
 			_flags+=(--remove-assignee "$worker_login")
 		fi

--- a/.agents/scripts/tests/test-claim-release-label-mutation.sh
+++ b/.agents/scripts/tests/test-claim-release-label-mutation.sh
@@ -10,11 +10,12 @@
 #      in-progress, in-review) in a single gh issue edit call
 #   2. Preserves terminal states — NEVER emits --remove-label for
 #      status:done, status:blocked, or status:available
-#   3. Removes the worker_login as assignee when provided
-#   4. Skips assignee mutation when worker_login is empty
-#   5. Defensively skips entirely when origin:interactive is present,
+#   3. Adds status:available when no linked PR owns the issue
+#   4. Removes the worker_login as assignee when provided
+#   5. Skips assignee mutation when worker_login is empty
+#   6. Defensively skips entirely when origin:interactive is present,
 #      preserving interactive-session ownership (t2056)
-#   6. Returns 0 on empty issue_num or repo_slug (idempotent no-op)
+#   7. Returns 0 on empty issue_num or repo_slug (idempotent no-op)
 #
 # Failure history motivating this test: production observation 2026-04-20
 # of #19864 and #19738 pinned as status:queued/claimed for 40+ minutes
@@ -135,6 +136,7 @@ assert_grep "remove-label status:queued" "removes status:queued"
 assert_grep "remove-label status:claimed" "removes status:claimed"
 assert_grep "remove-label status:in-progress" "removes status:in-progress"
 assert_grep "remove-label status:in-review" "removes status:in-review"
+assert_grep "add-label status:available" "adds status:available when no linked PR"
 assert_not_grep "remove-label status:done" "preserves status:done"
 assert_not_grep "remove-label status:blocked" "preserves status:blocked"
 assert_not_grep "remove-label status:available" "preserves status:available"


### PR DESCRIPTION
## Summary
- Ensure `CLAIM_RELEASED reason=worker_failed` restores issues to `status:available` when no linked PR owns the issue.
- Keep preserving assignee / `status:in-review` when an open or merged linked PR exists.
- Extend claim-release label mutation tests to assert the no-PR release path adds `status:available`.

## Verification
- `bash .agents/scripts/tests/test-claim-release-label-mutation.sh`
- `bash .agents/scripts/tests/test-clear-active-status-on-release-no-pr.sh`
- `bash .agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh`
- `bash .agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh`
- `shellcheck .agents/scripts/shared-constants.sh .agents/scripts/headless-runtime-failure.sh .agents/scripts/tests/test-claim-release-label-mutation.sh`

Resolves #22723

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6h 34m and 4,551,451 tokens on this with the user in an interactive session.
