### PR TITLE
GH#22702: align skill frontmatter names

### DIFF
--- a/.agents/services/communications/convos.md
+++ b/.agents/services/communications/convos.md
@@ -1,4 +1,5 @@
 ---
+name: convos
 description: Convos — encrypted messaging on XMTP with CLI agent mode, ndjson bridge protocol, group management, behavioural principles for AI group participation
 mode: subagent
 tools:

--- a/.agents/services/hosting/cloudflare-platform-skill.md
+++ b/.agents/services/hosting/cloudflare-platform-skill.md
@@ -1,5 +1,5 @@
 ---
-name: cloudflare-platform
+name: cloudflare-platform-skill
 description: "Cloudflare platform development guidance — patterns, gotchas, decision trees, SDK usage for Workers, Pages, KV, D1, R2, AI, Durable Objects, and 60+ products. Use when building or developing ON the Cloudflare platform. For managing Cloudflare resources (DNS, WAF, DDoS, R2 buckets, Workers deployments), use the Cloudflare Code Mode MCP server instead."
 mode: subagent
 imported_from: external

--- a/.agents/tools/ui/nothing-design-skill.md
+++ b/.agents/tools/ui/nothing-design-skill.md
@@ -1,4 +1,5 @@
 ---
+name: nothing-design
 mode: subagent
 description: >
   Nothing-inspired UI/UX design system. Use when user explicitly says "Nothing style",


### PR DESCRIPTION
## Summary

Fixed the three blocking skill frontmatter validation errors by adding missing name fields and aligning the Cloudflare skill name with the filename-derived validator expectation. Created follow-up issues #22725, #22726, and #22727 for the remaining repo-wide Bash compatibility, function complexity, and nesting-depth baseline debt.

## Files Changed

.agents/services/communications/convos.md,.agents/services/hosting/cloudflare-platform-skill.md,.agents/tools/ui/nothing-design-skill.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/linters-local.sh now passes Skill Frontmatter; remaining blocking failures are pre-existing Bash 3.2 compatibility (38), function complexity (59), and nesting-depth (85) debt tracked in follow-up issues. git diff --check passed.

Resolves #22702


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 44m and 84,360 tokens on this with the user in an interactive session.