### PR TITLE
GH#22730: fix headless GraphQL fallback guidance

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -570,7 +570,7 @@ append_worker_headless_contract() {
 	local contract
 	contract=$(
 		cat <<'EOF'
-[HEADLESS_CONTINUATION_CONTRACT_V7]
+[HEADLESS_CONTINUATION_CONTRACT_V8]
 This is a HEADLESS worker session. No user is present. No user input is available.
 You must drive autonomously to completion or an evidence-backed BLOCKED outcome.
 
@@ -622,6 +622,18 @@ output for 300 seconds, you will be killed. Therefore:
   - If a CI check or merge is slow, emit a status message between waits to keep
     the watchdog alive. Any tool call or text output resets the 300s timer.
   - Prefer short poll intervals (30-60s) with status output between iterations.
+
+GitHub API fallback discipline:
+If a command reports `GraphQL: API rate limit already exceeded`, do NOT stop
+immediately and do NOT keep retrying GraphQL-backed `gh issue/pr list/view`
+commands. First run `gh api rate_limit`. If REST core budget remains, continue
+with REST-backed `gh api -X GET repos/...` requests for issues, comments, PRs,
+checks, and labels where possible. If GraphQL reset is soon, wait in bounded
+chunks (sleep <= 240s) with status output before each wait; otherwise continue
+implementation from the issue body already supplied by the dispatcher and local
+repo state. Commit safe local changes before waiting/retrying PR creation. Exit
+BLOCKED only when the required remaining operation is GraphQL-only and the reset
+time exceeds the safe worker runtime budget.
 
 Pre-exit self-check -- MANDATORY:
 Before ending your session, verify ALL of these:

--- a/.agents/scripts/tests/test-headless-contract-clarity.sh
+++ b/.agents/scripts/tests/test-headless-contract-clarity.sh
@@ -72,17 +72,17 @@ export AIDEVOPS_BASH_REEXECED=1
 source "$LIB_FILE"
 
 # ---------------------------------------------------------------------------
-# Case 1: Contract marker is V7 (not the contradictory V6)
+# Case 1: Contract marker is V8 (not the contradictory V6)
 # ---------------------------------------------------------------------------
-test_contract_version_is_v7() {
+test_contract_version_is_v8() {
 	local output
 	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
 
-	if [[ "$output" == *"HEADLESS_CONTINUATION_CONTRACT_V7"* ]]; then
-		_pass "contract_version_is_v7"
+	if [[ "$output" == *"HEADLESS_CONTINUATION_CONTRACT_V8"* ]]; then
+		_pass "contract_version_is_v8"
 	else
-		_fail "contract_version_is_v7" \
-			"Expected HEADLESS_CONTINUATION_CONTRACT_V7 in output, not found"
+		_fail "contract_version_is_v8" \
+			"Expected HEADLESS_CONTINUATION_CONTRACT_V8 in output, not found"
 	fi
 	return 0
 }
@@ -213,15 +213,36 @@ test_opt_out_env_var() {
 }
 
 # ---------------------------------------------------------------------------
+# Case 8: GraphQL exhaustion guidance preserves autonomous progress
+# ---------------------------------------------------------------------------
+test_graphql_rate_limit_fallback_guidance() {
+	local output
+	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
+
+	if [[ "$output" == *"GraphQL: API rate limit already exceeded"* ]] && \
+		[[ "$output" == *"gh api rate_limit"* ]] && \
+		[[ "$output" == *"REST-backed"* ]] && \
+		[[ "$output" == *"sleep <= 240s"* ]] && \
+		[[ "$output" == *"Commit safe local changes before waiting/retrying PR creation"* ]]; then
+		_pass "graphql_rate_limit_fallback_guidance"
+	else
+		_fail "graphql_rate_limit_fallback_guidance" \
+			"Expected bounded wait, REST fallback, and commit-before-wait guidance"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
-test_contract_version_is_v7
+test_contract_version_is_v8
 test_no_worktree_creation_fallback
 test_unconditional_do_not_call_worktree_helper
 test_no_simultaneous_prohibit_and_permit
 test_non_fullloop_passthrough
 test_no_double_injection
 test_opt_out_env_var
+test_graphql_rate_limit_fallback_guidance
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Resolves #22730

## Summary
- Adds headless worker contract guidance for GitHub GraphQL rate-limit exhaustion.
- Directs workers to check `gh api rate_limit`, use REST-backed `gh api` alternatives, wait only in watchdog-safe chunks, and commit safe local changes before delayed PR creation.
- Updates headless contract clarity coverage for the V8 contract marker and GraphQL fallback guidance.

## Verification
- `.agents/scripts/tests/test-headless-contract-clarity.sh`
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-contract-clarity.sh`
- `.agents/scripts/version-manager.sh validate`

## Release
- Patch hotfix dry-run verified: `v3.14.34 -> v3.14.35`, `hotfix-v3.14.35`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.34 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6h 47m and 5,006,926 tokens on this with the user in an interactive session.
