### PR TITLE
GH#22731: fix pulse REST dispatch fallback

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -459,9 +459,9 @@ _dispatch_compute_capacity() {
 		return 1
 	fi
 
-	# t2690: Proactive rate-limit circuit breaker — pause dispatch when GraphQL
-	# budget is nearly exhausted. One cheap API call (free endpoint) prevents
-	# spawning workers that would fail at step 1 and burn $0.05-$0.25 each.
+	# t2690/t3424: Proactive rate-limit circuit breaker — pause dispatch when
+	# GraphQL budget is nearly exhausted unless REST-backed dispatch fallback is
+	# active and REST core has enough headroom for issue/comment/label calls.
 	if declare -F is_graphql_budget_sufficient >/dev/null 2>&1; then
 		local _cb_rc=0
 		is_graphql_budget_sufficient || _cb_rc=$?

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -355,7 +355,7 @@ _dispatch_provider_pressure_points() {
 }
 
 _dispatch_graphql_pressure_points() {
-	local graphql_remaining graphql_low graphql_critical
+	local graphql_remaining="" graphql_low="" graphql_critical=""
 	graphql_remaining=$(_dispatch_graphql_remaining_cached)
 	graphql_low="${PULSE_DISPATCH_STAGGER_GRAPHQL_LOW:-1250}"
 	graphql_critical="${PULSE_DISPATCH_STAGGER_GRAPHQL_CRITICAL:-750}"
@@ -385,7 +385,7 @@ _dispatch_finalize_stagger_delay() {
 		printf '0\n'
 		return 0
 	fi
-	local issue_number jitter_max jitter delay cap
+	local issue_number="" jitter_max="" jitter="" delay="" cap=""
 	issue_number=$(printf '%s' "$candidate_json" | jq -r '.number // 0' 2>/dev/null)
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || issue_number=0
 	jitter_max="${PULSE_DISPATCH_STAGGER_JITTER_MAX_SECONDS:-3}"
@@ -428,7 +428,7 @@ _dispatch_inter_launch_delay() {
 
 	local pressure_points=0
 	pressure_points=$((pressure_points + $(_dispatch_load_pressure_points)))
-	local recent_failures recent_rate_limits pressure_line
+	local recent_failures="" recent_rate_limits="" pressure_line=""
 	pressure_line=$(_dispatch_recent_worker_pressure_counts)
 	read -r recent_failures recent_rate_limits <<<"$pressure_line"
 	[[ "$recent_failures" =~ ^[0-9]+$ ]] || recent_failures=0

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -102,7 +102,7 @@ _CB_RL_UNKNOWN="?"
 #######################################
 _cb_rate_limit_json() {
 	local mode="${1:-normal}"
-	local now cached_ts age rate_json tmp
+	local now="" cached_ts="" age="" rate_json="" tmp=""
 	now=$(date +%s 2>/dev/null) || now=0
 
 	if [[ -f "$_CB_RL_CACHE_FILE" ]]; then
@@ -154,7 +154,7 @@ _cb_allow_dispatch_with_rest_fallback() {
 		return 1
 	fi
 
-	local core_remaining core_limit min_core
+	local core_remaining="" core_limit="" min_core=""
 	core_remaining=$(printf '%s' "$rate_json" | jq -r '.resources.core.remaining // ""') || core_remaining=""
 	core_limit=$(printf '%s' "$rate_json" | jq -r '.resources.core.limit // ""') || core_limit=""
 	min_core="${AIDEVOPS_PULSE_REST_DISPATCH_MIN_CORE_REMAINING:-250}"
@@ -208,7 +208,7 @@ is_graphql_budget_sufficient() {
 		return 2
 	fi
 
-	local remaining limit
+	local remaining="" limit=""
 	remaining=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.remaining // ""') || remaining=""
 	limit=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.limit // ""') || limit=""
 
@@ -319,7 +319,7 @@ _circuit_breaker_status() {
 		return 0
 	fi
 
-	local remaining limit reset_epoch
+	local remaining="" limit="" reset_epoch=""
 	remaining=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.remaining // \"${_CB_RL_UNKNOWN}\"") || remaining="$_CB_RL_UNKNOWN"
 	limit=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.limit // \"${_CB_RL_UNKNOWN}\"") || limit="$_CB_RL_UNKNOWN"
 	reset_epoch=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.reset // \"${_CB_RL_UNKNOWN}\"") || reset_epoch="$_CB_RL_UNKNOWN"

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -132,16 +132,58 @@ _cb_rate_limit_json() {
 }
 
 #######################################
+# Allow degraded dispatch when only GraphQL is exhausted.
+#
+# Args:
+#   $1 - rate_limit JSON
+#   $2 - GraphQL remaining count
+#   $3 - GraphQL limit count
+#   $4 - GraphQL threshold count
+#   $5 - configured GraphQL threshold string
+#
+# Returns: 0 if REST fallback is active and dispatch may proceed, 1 otherwise.
+#######################################
+_cb_allow_dispatch_with_rest_fallback() {
+	local rate_json="$1"
+	local graphql_remaining="$2"
+	local graphql_limit="$3"
+	local graphql_threshold_count="$4"
+	local threshold="$5"
+
+	if [[ "${AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK:-1}" != "1" ]]; then
+		return 1
+	fi
+
+	local core_remaining core_limit min_core
+	core_remaining=$(printf '%s' "$rate_json" | jq -r '.resources.core.remaining // ""') || core_remaining=""
+	core_limit=$(printf '%s' "$rate_json" | jq -r '.resources.core.limit // ""') || core_limit=""
+	min_core="${AIDEVOPS_PULSE_REST_DISPATCH_MIN_CORE_REMAINING:-250}"
+
+	if [[ ! "$core_remaining" =~ ^[0-9]+$ ]] || [[ ! "$core_limit" =~ ^[0-9]+$ ]] || [[ ! "$min_core" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	if [[ "$core_remaining" -lt "$min_core" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: core remaining=${core_remaining}/${core_limit} < min_core=${min_core}" >>"$LOGFILE"
+		return 1
+	fi
+
+	export AIDEVOPS_GH_FORCE_REST_READS=1
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE=1
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_CORE_REMAINING="$core_remaining"
+	echo "${_CB_RL_LOG_PREFIX} GraphQL budget EXHAUSTED: remaining=${graphql_remaining}/${graphql_limit} (threshold=${graphql_threshold_count}, configured=${threshold}) — dispatch_rest_fallback=true; proceeding with REST-backed dispatch reads (core=${core_remaining}/${core_limit}, min_core=${min_core})" >>"$LOGFILE"
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "pulse_dispatch_rest_fallback" 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
 # Check whether the GitHub GraphQL rate-limit budget is sufficient for dispatch.
+# Falls back to REST-backed dispatch when GraphQL is exhausted but REST core has
+# enough headroom for issue/comment/label operations.
 #
-# Queries `gh api rate_limit` (free endpoint — does not consume quota),
-# extracts GraphQL remaining and limit, computes the ratio, and compares
-# against the configured threshold.
-#
-# Exit codes:
-#   0 — budget sufficient; dispatch may proceed
-#   1 — budget exhausted or below threshold; dispatch should be deferred
-#   2 — API error (fail-open: dispatch proceeds with warning)
+# Returns: 0 when dispatch may proceed, 1 when dispatch should defer, 2 on API error.
 #######################################
 is_graphql_budget_sufficient() {
 	# Emergency bypass.
@@ -186,6 +228,10 @@ is_graphql_budget_sufficient() {
 	threshold_count=$(_compute_threshold_count "$threshold" "$limit") || threshold_count=0
 
 	if [[ "$remaining" -le "$threshold_count" ]]; then
+		if _cb_allow_dispatch_with_rest_fallback "$rate_json" "$remaining" "$limit" "$threshold_count" "$threshold"; then
+			return 0
+		fi
+
 		# Breaker trips.
 		echo "${_CB_RL_LOG_PREFIX} GraphQL budget EXHAUSTED: remaining=${remaining}/${limit} (threshold=${threshold_count}, configured=${threshold}) — deferring dispatch until next cycle" >>"$LOGFILE"
 

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -82,6 +82,7 @@ export -f pulse_stats_increment pulse_stats_get_24h
 # Configurable stub behaviour per test via env vars:
 #   STUB_GH_REMAINING — GraphQL remaining value (default 5000)
 #   STUB_GH_LIMIT     — GraphQL limit value (default 5000)
+#   STUB_GH_CORE_REMAINING — REST core remaining value (unset omits core budget)
 #   STUB_GH_RESET     — GraphQL reset epoch (default: now+3600)
 #   STUB_GH_FAIL      — 1 to make gh api rate_limit fail entirely
 gh() {
@@ -91,6 +92,10 @@ gh() {
 		fi
 		local remaining="${STUB_GH_REMAINING:-5000}"
 		local limit="${STUB_GH_LIMIT:-5000}"
+		local core_json=""
+		if [[ -n "${STUB_GH_CORE_REMAINING:-}" ]]; then
+			core_json=",\"core\":{\"remaining\":${STUB_GH_CORE_REMAINING},\"limit\":${STUB_GH_CORE_LIMIT:-5000}}"
+		fi
 		local reset="${STUB_GH_RESET:-$(($(date +%s) + 3600))}"
 		# Handle --jq flag for direct extraction
 		if [[ "${3:-}" == "--jq" ]]; then
@@ -101,8 +106,8 @@ gh() {
 			fi
 		fi
 		# Full JSON response
-		printf '{"resources":{"graphql":{"remaining":%s,"limit":%s,"reset":%s}}}\n' \
-			"$remaining" "$limit" "$reset"
+		printf '{"resources":{"graphql":{"remaining":%s,"limit":%s,"reset":%s}%s}}\n' \
+			"$remaining" "$limit" "$reset" "$core_json"
 		return 0
 	fi
 	# Default: succeed silently for unknown calls
@@ -143,6 +148,11 @@ reset_test_state() {
 	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER 2>/dev/null || true
 	unset AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL 2>/dev/null || true
+	unset AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK 2>/dev/null || true
+	unset AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE 2>/dev/null || true
+	unset AIDEVOPS_GH_FORCE_REST_READS 2>/dev/null || true
+	unset STUB_GH_CORE_REMAINING 2>/dev/null || true
+	unset STUB_GH_CORE_LIMIT 2>/dev/null || true
 	unset STUB_GH_FAIL 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
@@ -383,6 +393,38 @@ test_log_message_on_trip() {
 		pass "log message emitted on trip"
 	else
 		fail "should emit 'GraphQL budget EXHAUSTED' log message on trip"
+	fi
+	return 0
+}
+
+# --- Test 15: GraphQL exhausted proceeds with REST fallback when core is healthy ---
+test_graphql_exhausted_rest_core_healthy_allows_dispatch() {
+	reset_test_state
+	STUB_GH_REMAINING=0
+	STUB_GH_CORE_REMAINING=4994
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	local fallback_count
+	fallback_count=$(grep -c "^pulse_dispatch_rest_fallback$" "$STATS_COUNTER_FILE" 2>/dev/null) || fallback_count=0
+	if [[ "$rc" -eq 0 && "${AIDEVOPS_GH_FORCE_REST_READS:-0}" == "1" && "${AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE:-0}" == "1" && "$fallback_count" -eq 1 ]]; then
+		pass "GraphQL exhausted with healthy REST core enables dispatch_rest_fallback"
+	else
+		fail "REST fallback should allow dispatch" "rc=$rc force_rest=${AIDEVOPS_GH_FORCE_REST_READS:-unset} active=${AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE:-unset} fallback_count=$fallback_count"
+	fi
+	return 0
+}
+
+# --- Test 16: GraphQL exhausted still blocks when REST core is low ---
+test_graphql_exhausted_rest_core_low_blocks_dispatch() {
+	reset_test_state
+	STUB_GH_REMAINING=0
+	STUB_GH_CORE_REMAINING=10
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 && "${AIDEVOPS_GH_FORCE_REST_READS:-0}" != "1" ]]; then
+		pass "GraphQL exhausted with low REST core still blocks dispatch"
+	else
+		fail "low REST core should not allow fallback" "rc=$rc force_rest=${AIDEVOPS_GH_FORCE_REST_READS:-unset}"
 	fi
 	return 0
 }
@@ -696,6 +738,8 @@ test_status_output_ok
 test_status_output_tripped
 test_status_cached_only_uses_cache
 test_log_message_on_trip
+test_graphql_exhausted_rest_core_healthy_allows_dispatch
+test_graphql_exhausted_rest_core_low_blocks_dispatch
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
Resolves #22731

## Summary
- Allows pulse dispatch to continue in REST-backed degraded mode when GraphQL is exhausted but REST core budget is healthy.
- Exports `AIDEVOPS_GH_FORCE_REST_READS` and `AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE` for the dispatch cycle so REST-equivalent reads avoid GraphQL.
- Keeps the circuit breaker closed when REST core budget is too low, preserving the existing fail-safe behavior.

## Verification
- `.agents/scripts/tests/test-rate-limit-circuit-breaker.sh`
- `shellcheck .agents/scripts/pulse-rate-limit-circuit-breaker.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-rate-limit-circuit-breaker.sh`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.35 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 7h 19m and 5,154,991 tokens on this with the user in an interactive session.
