### PR TITLE
GH#22736: add Open Design peripheral workflow

### DIFF
--- a/.agents/scripts/commands/design-artifact.md
+++ b/.agents/scripts/commands/design-artifact.md
@@ -1,0 +1,39 @@
+---
+description: Route artifact-first design requests across aidevops and optional Open Design
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Design Artifact Routing
+
+Request: $ARGUMENTS
+
+## Decision Tree
+
+1. If the project lacks `DESIGN.md`, create/lint it first via `tools/design/design-md.md`.
+2. If the task is implementation in an existing codebase, use aidevops UI agents directly.
+3. If the task is artifact-first preview/export (deck, poster, carousel, mobile mock, email, one-off HTML), consider `/open-design route "$ARGUMENTS"`.
+4. If Open Design is used, keep generated files in its `.od/` workspace until selected outputs are reviewed.
+5. Run verification: `workflows/ui-verification.md`, `email-design-test-helper.sh`, or media/deck export checks.
+
+## Recommended Outputs
+
+| Artifact | Primary route | Verification |
+|----------|---------------|--------------|
+| Landing page prototype | aidevops or Open Design `web-prototype` | Playwright screenshots + contrast |
+| SaaS/pricing page | Open Design candidate, then aidevops implementation | CRO review + UI verification |
+| HTML deck/PPT | Open Design deck skill | PDF/PPTX export + fidelity audit |
+| Email creative | Open Design candidate + aidevops email workflow | local render + Email on Acid when needed |
+| Mobile app mock | Open Design mobile skill | mobile/tablet screenshots + accessibility |
+| Social carousel/poster | Open Design candidate | dimensions, brand, export QA |
+| Production UI code | aidevops native | tests, lint, browser verification |
+
+## Related
+
+- `tools/design/open-design.md`
+- `tools/design/design-md.md`
+- `product/ui-design.md`
+- `workflows/ui-verification.md`

--- a/.agents/scripts/commands/open-design.md
+++ b/.agents/scripts/commands/open-design.md
@@ -1,0 +1,50 @@
+---
+description: Manage optional Open Design peripheral integration and local preview workflow
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Open Design Peripheral
+
+Arguments: $ARGUMENTS
+
+## Workflow
+
+Open Design is an optional companion studio, not an aidevops dependency. Keep aidevops `.agents/` and Google `DESIGN.md` canonical.
+
+| Argument | Action |
+|----------|--------|
+| empty / `help` | Show this command and key examples |
+| `status` | `open-design-helper.sh status` |
+| `install` | Print safe optional install commands |
+| `install --execute` | Clone/update Open Design under the peripheral directory and install deps |
+| `start` | Start Open Design with its normal local dev command |
+| `start --https-local open-design` | Start via `localdev-helper.sh` for `https://open-design.local` |
+| `skills` | Show aidevops ingestion recommendations |
+| `route <artifact brief>` | Recommend aidevops-native vs Open Design workflow |
+
+## Examples
+
+```bash
+open-design-helper.sh status
+open-design-helper.sh install
+open-design-helper.sh install --execute
+open-design-helper.sh start --https-local open-design
+```
+
+## Rules
+
+- Do not symlink Open Design skills into aidevops as a source of truth.
+- Ingest selected skills through `tools/build-agent/build-agent.md` and `tools/build-agent/add-skill.md` methodology.
+- Convert design systems to Google `DESIGN.md` and lint before reuse.
+- Verify generated artifacts with aidevops UI/email/video checks before shipping.
+
+## Related
+
+- `tools/design/open-design.md`
+- `tools/design/open-design-ingestion.md`
+- `services/hosting/local-hosting.md`
+- `workflows/ui-verification.md`

--- a/.agents/scripts/open-design-helper.sh
+++ b/.agents/scripts/open-design-helper.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# open-design-helper.sh — Optional Open Design peripheral management
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+if [[ -z "${GREEN+x}" ]]; then GREEN=""; fi
+if [[ -z "${YELLOW+x}" ]]; then YELLOW=""; fi
+if [[ -z "${RED+x}" ]]; then RED=""; fi
+if [[ -z "${BLUE+x}" ]]; then BLUE=""; fi
+if [[ -z "${NC+x}" ]]; then NC=""; fi
+
+OPEN_DESIGN_REPO="https://github.com/nexu-io/open-design.git"
+DEFAULT_OPEN_DESIGN_DIR="${HOME}/.aidevops/peripherals/open-design"
+
+info() {
+	local message="$1"
+	printf '%b[INFO]%b %s\n' "$BLUE" "$NC" "$message"
+	return 0
+}
+
+ok() {
+	local message="$1"
+	printf '%b[OK]%b %s\n' "$GREEN" "$NC" "$message"
+	return 0
+}
+
+warn() {
+	local message="$1"
+	printf '%b[WARN]%b %s\n' "$YELLOW" "$NC" "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf '%b[ERROR]%b %s\n' "$RED" "$NC" "$message" >&2
+	return 1
+}
+
+usage() {
+	cat <<'EOF'
+Usage: open-design-helper.sh <command> [options]
+
+Commands:
+  status                         Check optional Open Design peripheral status
+  install [--execute] [--dir D]   Print install plan, or execute with --execute
+  start [--dir D] [--https-local NAME]
+                                 Start Open Design directly or via localdev HTTPS
+  skills                         Print aidevops ingestion recommendation summary
+  route <brief>                  Recommend route for an artifact request
+  help                           Show this help
+
+Environment:
+  OPEN_DESIGN_DIR                Override install directory
+
+Notes:
+  Open Design is optional. aidevops remains self-contained and keeps .agents/
+  plus Google DESIGN.md as the canonical agent/design surfaces.
+EOF
+	return 0
+}
+
+command_exists() {
+	local command_name="$1"
+	command -v "$command_name" >/dev/null 2>&1
+	return $?
+}
+
+detect_open_design_cli() {
+	if ! command_exists od; then
+		return 1
+	fi
+
+	local od_path
+	od_path="$(command -v od)"
+	case "$od_path" in
+	/bin/od|/usr/bin/od)
+		return 1
+		;;
+	*)
+		printf '%s\n' "$od_path"
+		return 0
+		;;
+	esac
+}
+
+resolve_dir() {
+	local requested_dir="$1"
+	if [[ -n "$requested_dir" ]]; then
+		printf '%s\n' "$requested_dir"
+	else
+		printf '%s\n' "${OPEN_DESIGN_DIR:-$DEFAULT_OPEN_DESIGN_DIR}"
+	fi
+	return 0
+}
+
+cmd_status() {
+	local install_dir="${1:-}"
+	local resolved_dir
+	resolved_dir="$(resolve_dir "$install_dir")"
+
+	info "Open Design peripheral status"
+	printf 'Install dir: %s\n' "$resolved_dir"
+
+	if [[ -d "$resolved_dir/.git" ]]; then
+		ok "Repository present"
+	else
+		warn "Repository not installed"
+	fi
+
+	local open_design_cli
+	if open_design_cli="$(detect_open_design_cli)"; then
+		ok "Open Design od command found: $open_design_cli"
+	else
+		warn "Open Design od command not found on PATH (ignoring system /usr/bin/od)"
+	fi
+
+	if command_exists node; then
+		printf 'node: %s\n' "$(node --version 2>/dev/null || true)"
+	else
+		warn "node not found; Open Design expects Node ~24"
+	fi
+
+	if command_exists corepack; then
+		ok "corepack found"
+	else
+		warn "corepack not found"
+	fi
+
+	if command_exists pnpm; then
+		printf 'pnpm: %s\n' "$(pnpm --version 2>/dev/null || true)"
+	else
+		warn "pnpm not found directly; corepack can provide it"
+	fi
+
+	if command_exists localdev-helper.sh; then
+		ok "localdev-helper.sh found for HTTPS .local routing"
+	else
+		warn "localdev-helper.sh not found on PATH; use ~/.aidevops/agents/scripts/localdev-helper.sh if deployed"
+	fi
+
+	return 0
+}
+
+cmd_install() {
+	local execute="false"
+	local install_dir=""
+	local ref=""
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--execute)
+			execute="true"
+			shift
+			;;
+		--dir)
+			install_dir="$2"
+			shift 2
+			;;
+		--ref)
+			ref="$2"
+			shift 2
+			;;
+		*)
+			fail "Unknown install option: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	local resolved_dir
+	resolved_dir="$(resolve_dir "$install_dir")"
+
+	if [[ "$execute" != "true" ]]; then
+		cat <<EOF
+Optional Open Design install plan (not executed):
+
+  mkdir -p "$(dirname "$resolved_dir")"
+  git clone "$OPEN_DESIGN_REPO" "$resolved_dir"
+  cd "$resolved_dir"
+  corepack enable
+  corepack pnpm install
+
+Run with --execute to perform these steps. Use --ref <tag-or-commit> to pin.
+EOF
+		return 0
+	fi
+
+	command_exists git || return 1
+	command_exists corepack || return 1
+
+	mkdir -p "$(dirname "$resolved_dir")"
+	if [[ -d "$resolved_dir/.git" ]]; then
+		info "Updating existing Open Design checkout"
+		git -C "$resolved_dir" fetch --tags origin
+	else
+		git clone "$OPEN_DESIGN_REPO" "$resolved_dir"
+	fi
+
+	if [[ -n "$ref" ]]; then
+		git -C "$resolved_dir" checkout "$ref"
+	fi
+
+	(cd "$resolved_dir" && corepack enable && corepack pnpm install)
+	ok "Open Design installed at $resolved_dir"
+	return 0
+}
+
+cmd_start() {
+	local install_dir=""
+	local https_name=""
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--dir)
+			install_dir="$2"
+			shift 2
+			;;
+		--https-local)
+			https_name="$2"
+			shift 2
+			;;
+		*)
+			fail "Unknown start option: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	local resolved_dir
+	resolved_dir="$(resolve_dir "$install_dir")"
+	[[ -d "$resolved_dir" ]] || fail "Open Design directory not found: $resolved_dir" || return 1
+
+	if [[ -n "$https_name" ]]; then
+		if command_exists localdev-helper.sh; then
+			(cd "$resolved_dir" && localdev-helper.sh run --name "$https_name" corepack pnpm tools-dev run web)
+		else
+			(cd "$resolved_dir" && "${HOME}/.aidevops/agents/scripts/localdev-helper.sh" run --name "$https_name" corepack pnpm tools-dev run web)
+		fi
+		return $?
+	fi
+
+	(cd "$resolved_dir" && corepack pnpm tools-dev run web)
+	return $?
+}
+
+cmd_skills() {
+	cat <<'EOF'
+Open Design ingestion summary:
+
+Adopt first:
+  web-prototype, wireframe-sketch, saas-landing, pricing-page, dashboard,
+  mobile-app, mobile-onboarding, social-carousel, magazine-poster,
+  guizang-ppt, html-ppt-pitch-deck, html-ppt-product-launch,
+  html-ppt-tech-sharing, pptx-html-fidelity-audit
+
+Adapt with aidevops verification/tooling:
+  email-marketing, motion-frames, hyperframes, video-shortform, image-poster,
+  weekly-update, html-ppt, html-ppt-presenter-mode-reveal
+
+Combine into existing agents:
+  critique, tweaks, design-brief, blog-post, eng-runbook, invoice,
+  meeting-notes, pm-spec, team-okrs
+
+Full matrix: .agents/tools/design/open-design-ingestion.md
+EOF
+	return 0
+}
+
+cmd_route() {
+	local brief="$*"
+	[[ -n "$brief" ]] || fail "route requires an artifact brief" || return 1
+
+	case "$brief" in
+	*deck*|*slides*|*PPT*|*presentation*|*keynote*)
+		printf 'Route: Open Design deck skill candidate, then aidevops export/fidelity verification.\n'
+		;;
+	*email*|*newsletter*)
+		printf 'Route: Open Design email-marketing candidate, then email-design-test-helper.sh verification.\n'
+		;;
+	*mobile*|*app*|*onboarding*)
+		printf 'Route: Open Design mobile prototype candidate, then aidevops UI verification.\n'
+		;;
+	*carousel*|*poster*|*social*)
+		printf 'Route: Open Design marketing artifact candidate, then brand/export QA.\n'
+		;;
+	*production*|*implement*|*code*)
+		printf 'Route: aidevops native implementation; use Open Design only for preview exploration.\n'
+		;;
+	*)
+		printf 'Route: start with aidevops DESIGN.md/design-agent workflow; use Open Design if live artifact preview/export is valuable.\n'
+		;;
+	esac
+	return 0
+}
+
+main() {
+	local command_name="${1:-help}"
+	if [[ $# -gt 0 ]]; then
+		shift
+	fi
+
+	case "$command_name" in
+	help|-h|--help)
+		usage
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	install)
+		cmd_install "$@"
+		;;
+	start)
+		cmd_start "$@"
+		;;
+	skills)
+		cmd_skills
+		;;
+	route)
+		cmd_route "$@"
+		;;
+	*)
+		fail "Unknown command: $command_name"
+		usage
+		return 1
+		;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/tools/design/open-design-ingestion.md
+++ b/.agents/tools/design/open-design-ingestion.md
@@ -1,0 +1,121 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Open Design Skill Ingestion Plan
+
+Source: [nexu-io/open-design](https://github.com/nexu-io/open-design) (Apache-2.0). This plan treats Open Design as an optional peripheral and evaluates each upstream skill for aidevops value before any import.
+
+## Classification
+
+| Action | Meaning |
+|--------|---------|
+| **Adopt** | High standalone value; ingest as a focused `*-skill.md` after compression and provenance capture |
+| **Adapt** | Valuable but must be reshaped around aidevops `DESIGN.md`, verification, or domain agents |
+| **Combine** | Merge into existing aidevops agent/workflow instead of adding a new skill |
+| **Reference** | Keep as external inspiration or optional Open Design-only surface |
+| **Defer** | Low priority, niche, duplicate, or dependent on unverified runtime assets |
+
+## High-Value Ingestion Targets
+
+| Skill | Upstream mode/scenario | aidevops action | Why |
+|-------|------------------------|-----------------|-----|
+| `web-prototype` | prototype/design | Adopt | General artifact-first web prototype entry point |
+| `saas-landing` | prototype/marketing | Adopt | Strong overlap with marketing/CRO landing-page work |
+| `dashboard` | prototype/operations | Adopt | Useful for admin, analytics, and ops UI mockups |
+| `mobile-app` | prototype/design | Adopt | Extends mobile UI design with framed artifact generation |
+| `mobile-onboarding` | prototype/design | Adopt | Common app growth/onboarding deliverable |
+| `email-marketing` | prototype/marketing | Adapt | Pair with aidevops email testing and client-render checks |
+| `social-carousel` | prototype/marketing | Adopt | Useful for social-media agent deliverables |
+| `magazine-poster` | prototype/marketing | Adopt | Reusable poster/one-pager creative surface |
+| `motion-frames` | prototype/marketing | Adapt | Bridge to Remotion/HyperFrames/video workflows |
+| `wireframe-sketch` | prototype/design | Adopt | Cheap first-pass ideation before higher-fidelity work |
+| `critique` | prototype/design | Combine | Fold into aidevops design review and UI verification rubrics |
+| `tweaks` | prototype/design | Combine | Fold into iterative design refinement workflow |
+| `guizang-ppt` | deck/marketing | Adopt | Proven magazine-style HTML deck skill with preserved license |
+| `html-ppt` | deck/marketing | Adapt | Broad deck studio; convert to smaller style-specific aidevops skills |
+| `html-ppt-pitch-deck` | deck/finance | Adopt | Direct business/fundraising value |
+| `html-ppt-product-launch` | deck/marketing | Adopt | Useful launch/keynote deliverable |
+| `html-ppt-tech-sharing` | deck/engineering | Adopt | Strong developer education/presentation fit |
+| `weekly-update` | deck/operations | Adapt | Pair with reporting/routine agents |
+| `hyperframes` | video/video | Adapt | Bridge with Remotion and video agents; verify toolchain first |
+| `video-shortform` | video/marketing | Adapt | Valuable for social/video workflows after verification |
+| `image-poster` | image/design | Adapt | Useful if connected to existing image-generation rules |
+
+## Full Skill Matrix
+
+| Skill | Recommended action | Notes |
+|-------|--------------------|-------|
+| `audio-jingle` | Defer | Potential brand/audio value; needs audio toolchain and rights review |
+| `blog-post` | Combine | Existing content/SEO agents cover prose; use visual article layout patterns only |
+| `critique` | Combine | Extract 5-dimensional critique into design verification prompts |
+| `dashboard` | Adopt | Add as artifact skill with accessibility and dense-data checks |
+| `dating-web` | Reference | Niche personal/consumer example; useful as pattern inspiration |
+| `design-brief` | Combine | Fold discovery questions into brand identity and DESIGN.md creation |
+| `digital-eguide` | Adapt | Useful for lead magnets; align with document/content agents |
+| `docs-page` | Adapt | Merge with docs-site and developer documentation workflows |
+| `email-marketing` | Adapt | Require `email-design-test-helper.sh` verification before completion |
+| `eng-runbook` | Combine | Existing incident/runbook agents should own operational correctness |
+| `finance-report` | Adapt | Pair with accounts/business agents and data provenance checks |
+| `gamified-app` | Reference | Good mobile interaction inspiration; lower broad demand |
+| `guizang-ppt` | Adopt | Keep upstream license; flatten assets/references per build-agent rules |
+| `hatch-pet` | Defer | Codex pet spritesheet niche; import only if user demand appears |
+| `hr-onboarding` | Adapt | Useful document artifact; combine with HR/process templates |
+| `html-ppt-course-module` | Adapt | Good education/training deck variant |
+| `html-ppt-dir-key-nav-minimal` | Reference | Style variant; absorb into deck style catalogue |
+| `html-ppt-graphify-dark-graph` | Reference | Style variant for dev-tool/keynote decks |
+| `html-ppt-hermes-cyber-terminal` | Reference | Style variant for CLI/review decks |
+| `html-ppt-knowledge-arch-blueprint` | Reference | Style variant for architecture decks |
+| `html-ppt-obsidian-claude-gradient` | Reference | Style variant for developer workflow decks |
+| `html-ppt-pitch-deck` | Adopt | High-value fundraising deck surface |
+| `html-ppt-presenter-mode-reveal` | Adapt | Presenter notes and speaker mode useful; verify popup/export behaviour |
+| `html-ppt-product-launch` | Adopt | High-value launch/keynote surface |
+| `html-ppt-taste-brutalist` | Reference | Convert to DESIGN.md/style archetype rather than skill |
+| `html-ppt-taste-editorial` | Reference | Convert to DESIGN.md/style archetype rather than skill |
+| `html-ppt-tech-sharing` | Adopt | High-value technical presentation surface |
+| `html-ppt-testing-safety-alert` | Adapt | Useful security/risk deck style; pair with security agents |
+| `html-ppt-weekly-report` | Adapt | Good routine/status reporting output |
+| `html-ppt-xhs-pastel-card` | Reference | Social-style deck variant; keep as style reference |
+| `html-ppt-xhs-post` | Adapt | Useful social carousel/deck hybrid for marketing agent |
+| `html-ppt-xhs-white-editorial` | Reference | Style variant; fold into social/deck style catalogue |
+| `html-ppt` | Adapt | Split into concise aidevops deck subskills instead of one broad prompt |
+| `hyperframes` | Adapt | Integrate only after local render/lint smoke checks |
+| `image-poster` | Adapt | Needs image-generation provider/toolchain mapping |
+| `invoice` | Combine | Existing accounts/document agents own invoice correctness |
+| `kanban-board` | Reference | Visual snapshot only; project systems remain source of truth |
+| `magazine-poster` | Adopt | High-value one-page marketing artifact |
+| `meeting-notes` | Combine | Existing productivity/workflow agents own meeting record correctness |
+| `mobile-app` | Adopt | Strong product design fit |
+| `mobile-onboarding` | Adopt | Strong growth/product design fit |
+| `motion-frames` | Adapt | Bridge to Remotion/video verification |
+| `pm-spec` | Combine | Existing PRD/spec templates should remain canonical |
+| `pptx-html-fidelity-audit` | Adopt | Strong utility for deck export verification |
+| `pricing-page` | Adopt | Useful sales/CRO page artifact |
+| `replit-deck` | Reference | Product-deck style variant |
+| `saas-landing` | Adopt | High-value marketing surface |
+| `simple-deck` | Adapt | Useful baseline deck skill; avoid overlap with `html-ppt` |
+| `social-carousel` | Adopt | Strong social-media deliverable |
+| `sprite-animation` | Reference | Niche; keep as animation inspiration |
+| `team-okrs` | Combine | Existing planning/business agents own OKR semantics |
+| `tweaks` | Combine | Fold into design iteration workflow |
+| `video-shortform` | Adapt | Pair with video prompt design, Remotion, and platform specs |
+| `web-prototype-taste-brutalist` | Reference | Convert style to DESIGN.md archetype |
+| `web-prototype-taste-editorial` | Reference | Convert style to DESIGN.md archetype |
+| `web-prototype-taste-soft` | Reference | Convert style to DESIGN.md archetype |
+| `web-prototype` | Adopt | Core preview/prototype surface |
+| `weekly-update` | Adapt | Useful reporting deck once wired to routines |
+| `wireframe-sketch` | Adopt | Low-cost design discovery artifact |
+
+## Ingestion Order
+
+1. **Design artifact MVP**: `web-prototype`, `wireframe-sketch`, `critique`, `tweaks`.
+2. **Marketing surfaces**: `saas-landing`, `pricing-page`, `social-carousel`, `magazine-poster`, `email-marketing`.
+3. **Decks**: `guizang-ppt`, `html-ppt-pitch-deck`, `html-ppt-product-launch`, `html-ppt-tech-sharing`, `pptx-html-fidelity-audit`.
+4. **Mobile/product**: `mobile-app`, `mobile-onboarding`, `dashboard`.
+5. **Media**: `motion-frames`, `hyperframes`, `video-shortform`, `image-poster` after toolchain verification.
+
+## Optimisation Rules
+
+- Keep each imported skill below ~100 always-read instructions; move examples/assets into side files.
+- Replace Open Design UI-only metadata with aidevops routing notes unless needed by `/open-design`.
+- Add verification commands to every adopted skill: UI screenshot, accessibility, email, deck export, or render smoke test.
+- Prefer existing aidevops agents for semantics; imported skills should improve artifact craft, not duplicate domain reasoning.

--- a/.agents/tools/design/open-design.md
+++ b/.agents/tools/design/open-design.md
@@ -1,0 +1,103 @@
+---
+description: Optional Open Design integration for artifact-first design workflows
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Open Design Integration
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Source**: [nexu-io/open-design](https://github.com/nexu-io/open-design) — Apache-2.0, local-first design artifact studio
+- **Role in aidevops**: optional peripheral for sandboxed previews, design artifacts, decks, and media surfaces
+- **Source of truth**: aidevops remains self-contained; `.agents/` and Google `DESIGN.md` stay canonical
+- **Commands**: `/open-design`, `/design-artifact`, `open-design-helper.sh`
+- **Local HTTPS**: prefer `localdev-helper.sh run --name open-design <command>` when Open Design only exposes localhost
+- **Ingestion plan**: `tools/design/open-design-ingestion.md`
+
+<!-- AI-CONTEXT-END -->
+
+## Integration Model
+
+Open Design is valuable as an **optional artifact studio** beside aidevops, not as a framework dependency. Keep the boundary explicit:
+
+| Layer | Owner | Rule |
+|-------|-------|------|
+| Agent/source registry | aidevops | `.agents/` remains canonical; no Open Design symlink registry as source of truth |
+| Design system | aidevops | Google `DESIGN.md` with YAML tokens, linted via `@google/design.md` |
+| Preview/runtime | Open Design optional | Use for live iframe preview, exports, and artifact workspaces |
+| Local HTTPS | aidevops | Use `localdev-helper.sh` when `.local` HTTPS is needed |
+| Verification | aidevops | Run UI/accessibility/design verification after artifact generation |
+
+## When to Use
+
+- User asks for design artifacts: landing prototypes, decks, mobile screens, posters, carousels, HTML/PDF/PPTX exports.
+- User wants a browser-based design studio with live preview and file workspace.
+- Design task benefits from typed discovery forms, visual direction picking, or sandboxed iteration.
+- Generated output should be reviewed with aidevops Playwright/accessibility gates before shipping.
+
+Do not use for normal code changes, backend work, or any task where aidevops agents can directly implement and verify faster.
+
+## Workflow
+
+1. Check status: `open-design-helper.sh status`.
+2. If missing and user opts in: `open-design-helper.sh install --execute`.
+3. Ensure project has a valid Google `DESIGN.md`; create/lint via `tools/design/design-md.md`.
+4. Start Open Design through local hosting if HTTPS is required:
+   `open-design-helper.sh start --https-local open-design`.
+5. Generate artifacts in Open Design, keeping work under its `.od/` workspace.
+6. Copy selected outputs back into the project deliberately; do not import generated runtime state.
+7. Verify with `workflows/ui-verification.md`, `email-design-test-helper.sh`, or relevant media checks.
+
+## Skill Ingestion Methodology
+
+Use build-agent rules before importing any Open Design skill:
+
+1. **Deduplicate** against existing `.agents/` design, UI, email, video, and marketing agents.
+2. **Classify** as adopt, adapt, combine, reference-only, or defer.
+3. **Compress** to aidevops shape: `{name}-skill.md` plus flat `{name}-skill/` references, not nested runtime folders.
+4. **Preserve provenance** with upstream URL, license, commit, and source notes in `configs/skill-sources.json` when imported.
+5. **Keep tokens out of always-loaded docs**; point to focused references instead.
+6. **Verify** with Markdown lint plus an artifact smoke test where practical.
+
+## DESIGN.md Bridge
+
+Open Design accepts broad Markdown design systems; aidevops uses the Google `DESIGN.md` standard with YAML tokens. Bridge rules:
+
+- Convert Open Design systems into Google `DESIGN.md` before reuse.
+- Run `npx @google/design.md lint DESIGN.md` and resolve errors.
+- Use aidevops library examples as canonical where duplicates exist.
+- Preserve educational/trademark disclaimers for third-party brand examples.
+
+## Local Hosting Bridge
+
+Open Design may print a localhost URL. For browser-safe HTTPS `.local` previews:
+
+```bash
+localdev-helper.sh init
+localdev-helper.sh run --name open-design corepack pnpm tools-dev run web
+```
+
+Expected result: `https://open-design.local` proxies to the Open Design dev server with mkcert TLS.
+
+## Related
+
+- `tools/design/open-design-ingestion.md` — all Open Design skills classified for aidevops value
+- `tools/design/design-md.md` — Google DESIGN.md workflow
+- `tools/design/library/` — aidevops design-system library
+- `workflows/ui-verification.md` — screenshot/accessibility verification
+- `services/hosting/local-hosting.md` — localdev HTTPS proxy
+- `tools/build-agent/build-agent.md` — ingestion and agent optimisation rules

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The result: an AI operations platform that manages projects across every busines
 - `aidevops secret` - Manage secrets (gopass encrypted, AI-safe)
 - `aidevops security` - Full security assessment (posture, secrets, supply chain)
 - `/onboarding` - Interactive setup wizard (in AI assistant)
+- `/design-artifact` - Route artifact-first UI, deck, email, poster, and mobile mockup work
+- `/open-design` - Manage the optional Open Design companion studio
 
 ### Agent Structure
 
@@ -216,6 +218,34 @@ aidevops upgrade-planning # Upgrade TODO.md/PLANS.md to latest templates
 aidevops update-tools     # Check and update installed tools
 aidevops uninstall        # Remove aidevops
 ```
+
+### Optional Design Artifact Studio
+
+aidevops now treats design as a self-contained stack with optional peripherals:
+
+- **Google `DESIGN.md` standard**: AI-readable design systems with YAML tokens, linting, previews, and brand/style libraries (`.agents/tools/design/design-md.md`).
+- **Design agents and skills**: brand identity, palettes, UI inspiration, product UI rules, shadcn/Tailwind/UI skills, Nothing-style design, email rendering, Remotion/video, and browser-based UI verification.
+- **Artifact routing commands**: `/design-artifact` decides whether to use aidevops-native implementation or a companion artifact studio; `/open-design` manages optional Open Design workflows.
+- **Verification gates**: Playwright screenshots, accessibility/contrast checks, email rendering, deck export/fidelity checks, and media smoke tests before generated artifacts are accepted.
+
+Optional companion: [Open Design](https://github.com/nexu-io/open-design) by nexu-io (Apache-2.0) is supported as a **peripheral** for live sandboxed previews, design-skill pickers, `.od/` artifact workspaces, and HTML/PDF/PPTX/ZIP-style exports. aidevops remains canonical for agents, skill ingestion, Google `DESIGN.md`, local hosting, and verification.
+
+```bash
+# Inspect optional companion status
+open-design-helper.sh status
+
+# Print safe install plan only
+open-design-helper.sh install
+
+# Install alongside aidevops only after opting in
+open-design-helper.sh install --execute
+
+# Start through aidevops local HTTPS if Open Design only prints localhost
+open-design-helper.sh start --https-local open-design
+# → https://open-design.local when localdev is configured
+```
+
+Imported Open Design skills are not copied verbatim. They are evaluated through aidevops build-agent methodology, deduplicated against existing agents, flattened into aidevops `*-skill.md` structure, attributed to upstream, and given verification commands. See `.agents/tools/design/open-design-ingestion.md` for the full skill-value matrix.
 
 **Project tracking:** When you run `aidevops init`, the project is automatically registered in `~/.config/aidevops/repos.json`. Running `aidevops update` checks all registered projects for version updates.
 
@@ -1141,6 +1171,15 @@ The setup script offers to install these tools automatically.
 - **[Langflow](https://langflow.org/)**: Visual drag-and-drop builder for AI workflows (MIT, localhost:7860)
 - **[CrewAI](https://crewai.com/)**: Multi-agent teams with role-based orchestration (MIT, localhost:8501)
 - **[AutoGen](https://microsoft.github.io/autogen/)**: Microsoft's agentic AI framework with MCP support (MIT, localhost:8081)
+
+### **Design, UI & Artifact Creation**
+
+- **Google `DESIGN.md` standard**: Canonical AI-readable design systems with YAML tokens, Markdown rationale, linting, Tailwind/DTCG export, and preview generation. aidevops keeps `DESIGN.md` as the source of truth for UI agents.
+- **Design library**: 54 brand examples and 12 original style archetypes for agent-ready visual direction, plus palette, brand identity, and UI inspiration workflows.
+- **Artifact commands**: `/design-artifact` routes prototype, deck, email, poster, social carousel, and mobile mockup requests; `/open-design` manages optional Open Design companion workflows.
+- **[Open Design](https://github.com/nexu-io/open-design)** *Optional peripheral*: Local-first design artifact studio by nexu-io (Apache-2.0) for sandboxed previews, design-skill pickers, `.od/` workspaces, and exports. It installs alongside aidevops only when requested; selected skills are ingested via aidevops build-agent optimisation, not imported verbatim.
+- **Local HTTPS previews**: `localdev-helper.sh` can wrap Open Design or other dev servers with mkcert-backed `.local` routes when tools only expose localhost.
+- **Verification**: `workflows/ui-verification.md`, `email-design-test-helper.sh`, design preview screenshots, and deck/media smoke tests provide evidence before generated artifacts ship.
 
 ### **Video Creation**
 


### PR DESCRIPTION
## Summary
- Add optional Open Design peripheral command docs and helper for status/install/start/route workflows.
- Document how aidevops keeps Google DESIGN.md and .agents canonical while using Open Design for optional artifact previews/exports.
- Add a full Open Design skill ingestion matrix using aidevops build-agent methodology.

Resolves #22736

## Testing
- `bash -n .agents/scripts/open-design-helper.sh`
- `shellcheck .agents/scripts/open-design-helper.sh`
- `.agents/scripts/open-design-helper.sh help && .agents/scripts/open-design-helper.sh route "make a seed pitch deck" && .agents/scripts/open-design-helper.sh skills`
- `.agents/scripts/open-design-helper.sh status`
- `bunx markdownlint-cli2 "README.md" ".agents/tools/design/open-design.md" ".agents/tools/design/open-design-ingestion.md" ".agents/scripts/commands/open-design.md" ".agents/scripts/commands/design-artifact.md"`
- `.agents/scripts/linters-local.sh` (fails on existing repository-wide Bash 3.2, function complexity, and nesting-depth baseline issues outside this change; changed-file ShellCheck/Markdown/Secretlint checks passed)

## Runtime Testing
Self-assessed docs/helper workflow. The helper was smoke-tested locally; optional Open Design install/start was not executed because it clones and installs an external peripheral.

## Decisions
- Keep Open Design as an optional peripheral, not a dependency or canonical skill registry.
- Use localdev for HTTPS .local previews when Open Design only exposes localhost.
- Classify every upstream Open Design skill before future ingestion instead of importing verbatim.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.36 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 33m and 352,389 tokens on this with the user in an interactive session.