### PR TITLE
GH#22739: fix worker throughput guards

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -74,7 +74,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 ### Git workflow
 
 - Git is the audit trail. Use wrapper-created GitHub writes with origin labels, claim interactive issues before work, include task IDs in PR titles, `Resolves #NNN` for leaf PRs, and `For #NNN`/`Ref #NNN` for parent references. Never invent task IDs.
-- Interactive sessions: no direct edits on canonical `main`/`master`; all work uses a linked worktree. Headless implementation workers use worktree+PR unless explicitly planning-only.
+- Interactive sessions: no direct edits on canonical `main`/`master`; all work uses a linked worktree under `~/Git/`, never runtime temp dirs. Headless implementation workers use worktree+PR unless explicitly planning-only.
 - Pre-edit exit codes: 0 proceed, 1 stop on main, 2 create worktree, 3 warn off-main. Do not revert others' changes without explicit request.
 - After each logical change, commit WIP (`git add -A && git commit -m "wip: ..."`) unless generated/temp gitignored. Squash/amend later as needed.
 - Hook self-block: verify self-block cause, request explicit `--no-verify` authorization, include a regression test, and file sibling validator bugs separately.

--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -358,57 +358,59 @@ def _build_canonical_off_default_deny(
     }
 
 
-def _extract_git_switch_target(command: str) -> str:
-    """Return the target branch for a git switch/checkout command, if obvious.
+TAKES_BRANCH_ARG = {"-b", "-B", "-c", "-C", "--create", "--force-create"}
+OPTION_WITH_VALUE = {"-t", "--track", "--orphan", "--conflict", "--pathspec-from-file"}
 
-    This is intentionally conservative: path checkouts and unrecognised option
-    layouts return an empty string rather than guessing.
-    """
+
+def _split_git_switch_command(command: str) -> tuple[str, list[str]]:
+    """Return the git switch/checkout subcommand and args, or empty values."""
+    subcommand = ""
+    args: list[str] = []
     try:
         tokens = shlex.split(command)
     except ValueError:
-        return ""
-    if len(tokens) < 3 or tokens[0] != "git" or tokens[1] not in ("switch", "checkout"):
-        return ""
-    subcommand = tokens[1]
-    args = tokens[2:]
-    if "--" in args:
-        return ""
+        tokens = []
+    if len(tokens) >= 3 and tokens[0] == "git" and tokens[1] in ("switch", "checkout"):
+        subcommand = tokens[1]
+        args = tokens[2:]
+    return subcommand, args
 
-    takes_branch_arg = {"-b", "-B", "-c", "-C", "--create", "--force-create"}
-    option_with_value = {"-t", "--track", "--orphan", "--conflict", "--pathspec-from-file"}
+
+def _scan_git_switch_args(subcommand: str, args: list[str]) -> str:
+    """Return the first branch-like target in git switch/checkout args."""
+    target = ""
     index = 0
-    while index < len(args):
+    while index < len(args) and not target:
         arg = args[index]
-        if arg in takes_branch_arg:
+        if arg in TAKES_BRANCH_ARG:
             if index + 1 < len(args):
-                return args[index + 1]
-            return ""
-        if arg in option_with_value:
+                target = args[index + 1]
+        elif arg in OPTION_WITH_VALUE:
             index += 2
             continue
-        if arg.startswith("-"):
+        elif arg.startswith("-"):
             index += 1
             continue
-        if subcommand == "checkout" and any(ch in arg for ch in ("/", ".")):
+        elif subcommand == "checkout" and any(ch in arg for ch in ("/", ".")):
             # Likely a file/path checkout, not a branch switch.
-            return ""
-        return arg
-    return ""
+            target = ""
+        else:
+            target = arg
+        index += 1
+    return target
 
 
-def _check_canonical_branch_switch_command(command: str) -> "dict | None":
-    """Deny git switch/checkout to non-default refs in the canonical checkout."""
-    cwd = os.getcwd()
-    repo_root = _get_repo_root(cwd)
-    if not repo_root or _is_linked_worktree(repo_root):
-        return None
-    target = _extract_git_switch_target(command)
-    if not target:
-        return None
-    default_branch = _get_default_branch(repo_root)
-    if target in (default_branch, "main", "master", "-"):
-        return None
+def _extract_git_switch_target(command: str) -> str:
+    """Return the target branch for a git switch/checkout command, if obvious."""
+    subcommand, args = _split_git_switch_command(command)
+    target = ""
+    if subcommand and "--" not in args:
+        target = _scan_git_switch_args(subcommand, args)
+    return target
+
+
+def _canonical_branch_switch_deny(target: str, default_branch: str) -> dict:
+    """Return a deny payload for canonical workspace branch switches."""
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
@@ -423,6 +425,19 @@ def _check_canonical_branch_switch_command(command: str) -> "dict | None":
             ),
         }
     }
+
+
+def _check_canonical_branch_switch_command(command: str) -> "dict | None":
+    """Deny git switch/checkout to non-default refs in the canonical checkout."""
+    cwd = os.getcwd()
+    repo_root = _get_repo_root(cwd)
+    target = ""
+    if repo_root and not _is_linked_worktree(repo_root):
+        target = _extract_git_switch_target(command)
+    default_branch = _get_default_branch(repo_root) if target else ""
+    if target and target not in (default_branch, "main", "master", "-"):
+        return _canonical_branch_switch_deny(target, default_branch)
+    return None
 
 
 def _check_main_branch_allowlist(file_path: str) -> "dict | None":

--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -35,6 +35,7 @@ Environment overrides:
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -357,6 +358,73 @@ def _build_canonical_off_default_deny(
     }
 
 
+def _extract_git_switch_target(command: str) -> str:
+    """Return the target branch for a git switch/checkout command, if obvious.
+
+    This is intentionally conservative: path checkouts and unrecognised option
+    layouts return an empty string rather than guessing.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return ""
+    if len(tokens) < 3 or tokens[0] != "git" or tokens[1] not in ("switch", "checkout"):
+        return ""
+    subcommand = tokens[1]
+    args = tokens[2:]
+    if "--" in args:
+        return ""
+
+    takes_branch_arg = {"-b", "-B", "-c", "-C", "--create", "--force-create"}
+    option_with_value = {"-t", "--track", "--orphan", "--conflict", "--pathspec-from-file"}
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in takes_branch_arg:
+            if index + 1 < len(args):
+                return args[index + 1]
+            return ""
+        if arg in option_with_value:
+            index += 2
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        if subcommand == "checkout" and any(ch in arg for ch in ("/", ".")):
+            # Likely a file/path checkout, not a branch switch.
+            return ""
+        return arg
+    return ""
+
+
+def _check_canonical_branch_switch_command(command: str) -> "dict | None":
+    """Deny git switch/checkout to non-default refs in the canonical checkout."""
+    cwd = os.getcwd()
+    repo_root = _get_repo_root(cwd)
+    if not repo_root or _is_linked_worktree(repo_root):
+        return None
+    target = _extract_git_switch_target(command)
+    if not target:
+        return None
+    default_branch = _get_default_branch(repo_root)
+    if target in (default_branch, "main", "master", "-"):
+        return None
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "BLOCKED by git_safety_guard.py (aidevops t1990)\n\n"
+                f"Reason: Canonical workspace cannot switch to or create branch '{target}'.\n\n"
+                "Per t1990, the canonical repo directory must stay on the default branch. "
+                "Create or use a linked worktree under the configured workspace root instead:\n"
+                f"  wt switch -c {target}\n\n"
+                f"To restore canonical state, run: git switch {default_branch}"
+            ),
+        }
+    }
+
+
 def _check_main_branch_allowlist(file_path: str) -> "dict | None":
     """Check if an Edit/Write to file_path is allowed on the current branch.
 
@@ -471,6 +539,11 @@ def main():
 
     original_command = command
     command = _normalize_absolute_paths(command)
+
+    branch_switch_deny = _check_canonical_branch_switch_command(command)
+    if branch_switch_deny:
+        print(json.dumps(branch_switch_deny))
+        sys.exit(0)
 
     # Check safe patterns first (allowlist)
     for pattern in SAFE_PATTERNS:

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -728,6 +728,14 @@ _handle_run_result() {
 				print_warning "$selected_model worker exited with activity but no completion signal (premature exit — will attempt continuation)"
 				return 77
 			fi
+			if output_has_blocked_signal "$output_file"; then
+				_run_result_label="blocked"
+				_run_failure_reason="blocked"
+				_run_classification_source="model_blocked_signal"
+				rm -f "$output_file"
+				print_warning "$selected_model worker reported BLOCKED terminal state — recording blocked instead of success"
+				return 0
+			fi
 		fi
 
 		_run_result_label="success"

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -629,3 +629,41 @@ sys.exit(1)
 PY
 	return $?
 }
+
+# output_has_blocked_signal: check if the model explicitly ended with BLOCKED.
+# This is a valid terminal state for unattended workers, but it is not a
+# successful implementation and must not inflate PR-throughput success metrics.
+#
+# Args: $1 = output file path
+# Returns: 0 if the model emitted BLOCKED, 1 otherwise
+output_has_blocked_signal() {
+	local file_path="$1"
+	[[ -f "$file_path" ]] || return 1
+	python3 - "$file_path" <<'PY'
+import sys, json
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_text(errors="ignore")
+model_text_parts = []
+for line in raw.splitlines():
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        obj = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        continue
+    if obj.get("type", "") != "text":
+        continue
+    part = obj.get("part", {})
+    text = obj.get("text") or part.get("text") or ""
+    if text:
+        model_text_parts.append(text)
+
+model_text = "\n".join(model_text_parts)
+if model_text.strip():
+    sys.exit(0 if "BLOCKED" in model_text else 1)
+sys.exit(0 if "BLOCKED" in raw else 1)
+PY
+	return $?
+}

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -636,8 +636,43 @@ _dispatch_should_skip_candidate() {
 		_dispatch_stats_increment "dispatch_candidate_skipped_empty_body"
 		return 0
 	fi
+	if _dispatch_issue_body_missing_worker_context "$issue_body"; then
+		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — missing Worker Guidance/How implementation context, needs enrichment before dispatch" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_skipped_missing_worker_context"
+		return 0
+	fi
 
 	pulse_dispatch_debug_log "#${issue_number}: passed all skip checks — proceeding to dispatch"
+	return 1
+}
+
+#######################################
+# Detect issue bodies that explicitly say implementation context is missing and
+# would therefore deterministically make /full-loop stop with BLOCKED before
+# implementation. Do not reject every body that lacks Worker Guidance here:
+# dispatch_with_dedup has a later brief-enrichment layer that can repair older
+# issue bodies when a local task brief exists.
+#
+# Arguments:
+#   $1 - issue body
+# Returns:
+#   0 - body is missing worker implementation context
+#   1 - body appears dispatchable
+#######################################
+_dispatch_issue_body_missing_worker_context() {
+	local issue_body="$1"
+
+	if [[ -z "$issue_body" ]]; then
+		return 0
+	fi
+	case "$issue_body" in
+	*"missing implementation context"* | *"Missing implementation context"* | \
+		*"needs implementation context"* | *"Needs implementation context"* | \
+		*"no implementation details"* | *"No implementation details"* | \
+		*"no worker guidance"* | *"No worker guidance"*)
+		return 0
+		;;
+	esac
 	return 1
 }
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -140,7 +140,7 @@ _dlw_assign_and_label() {
 _dlw_setup_worker_log() {
 	local repo_slug="$1"
 	local issue_number="$2"
-	local safe_slug worker_log worker_log_fallback
+	local safe_slug="" worker_log="" worker_log_fallback=""
 	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
 	worker_log="/tmp/pulse-${safe_slug}-${issue_number}.log"
 	worker_log_fallback="/tmp/pulse-${issue_number}.log"
@@ -279,7 +279,7 @@ _dlw_node_modules_restore_acquire_lock() {
 	mkdir -p "${lock_dir%/*}" 2>/dev/null || return 1
 	while ! mkdir "$lock_dir" 2>/dev/null; do
 		if [[ -d "$lock_dir" ]]; then
-			local lock_mtime now_epoch age_s
+			local lock_mtime="" now_epoch="" age_s=""
 			lock_mtime=$(_file_mtime_epoch "$lock_dir")
 			now_epoch=$(date +%s)
 			age_s=$((now_epoch - lock_mtime))
@@ -305,6 +305,27 @@ _dlw_node_modules_restore_release_lock() {
 	local lock_dir="$1"
 	rm -f "${lock_dir}/pid" 2>/dev/null || true
 	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
+_dlw_restore_root_node_tool_links() {
+	local worktree_path="$1"
+	local repo_path="$2"
+	[[ "${WORKTREE_NODE_MODULES_BIN_LINK_ENABLED:-1}" == "1" ]] || return 0
+
+	local _src_bin="${repo_path}/node_modules/.bin"
+	local _dst_nm="${worktree_path}/node_modules"
+	local _dst_bin="${_dst_nm}/.bin"
+	[[ -d "$_src_bin" ]] || return 0
+	if [[ -e "$_dst_bin" || -L "$_dst_bin" ]]; then
+		return 0
+	fi
+	if [[ -e "$_dst_nm" && ! -d "$_dst_nm" ]]; then
+		return 0
+	fi
+	mkdir -p "$_dst_nm" 2>/dev/null || return 0
+	ln -s "$_src_bin" "$_dst_bin" 2>/dev/null || return 0
+	echo "[dispatch_with_dedup] Linked root node_modules/.bin tooling for ${worktree_path} without copying root node_modules" >>"$LOGFILE"
 	return 0
 }
 
@@ -341,6 +362,7 @@ _dlw_restore_worktree_deps() {
 		_rel_dir="${_dir#"$worktree_path"}" || continue
 		# _rel_dir is now e.g. "/.opencode" or "" (for root package.json)
 		if [[ -z "$_rel_dir" && "$_restore_root" != "1" ]]; then
+			_dlw_restore_root_node_tool_links "$worktree_path" "$repo_path"
 			echo "[dispatch_with_dedup] Skipping root node_modules restore for ${worktree_path} (set WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED=1 to enable)" >>"$LOGFILE"
 			continue
 		fi
@@ -519,7 +541,7 @@ _dlw_exec_detached() {
 		setsid nohup "$@" </dev/null >>"$worker_log" 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
 		worker_pid="$!"
 		# Log the detached PGID for diagnostics (should differ from pulse PGID)
-		local worker_pgid pulse_pgid
+		local worker_pgid="" pulse_pgid=""
 		worker_pgid=$(ps -o pgid= -p "$worker_pid" 2>/dev/null | tr -d ' ')
 		[[ -n "$worker_pgid" ]] || worker_pgid="unknown"
 		pulse_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')
@@ -988,7 +1010,7 @@ _dlw_check_worker_branch_orphan_loop() {
 }
 
 _dlw_min_worker_floor_active() {
-	local active_workers min_worker_floor
+	local active_workers="" min_worker_floor=""
 	active_workers=$(count_active_workers 2>/dev/null || echo 0)
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 	min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
@@ -1005,7 +1027,7 @@ _dlw_headless_state_dir() {
 }
 
 _dlw_canary_last_failure_reason() {
-	local state_dir reason_file reason
+	local state_dir="" reason_file="" reason=""
 	state_dir=$(_dlw_headless_state_dir)
 	reason_file="${state_dir}/canary-last-fail.reason"
 	reason=$(cat "$reason_file" 2>/dev/null || printf '%s' "transient")
@@ -1024,7 +1046,7 @@ _dlw_canary_failure_is_soft() {
 }
 
 _dlw_recent_worker_evidence() {
-	local ttl ledger_file
+	local ttl="" ledger_file=""
 	ttl="${CANARY_SOFT_FAILURE_RECENT_SUCCESS_TTL_SECONDS:-900}"
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=900
 	ledger_file="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/dispatch-ledger.jsonl"

--- a/.agents/scripts/tests/test-git-safety-guard.sh
+++ b/.agents/scripts/tests/test-git-safety-guard.sh
@@ -282,16 +282,27 @@ test_bash_destructive_commands_blocked() {
 		passed=1
 	fi
 
-	# git checkout -b (safe branch creation) should be allowed
+	# git checkout -b in the canonical workspace should be denied; branch work
+	# must happen in a linked worktree.
 	json='{"tool_name":"Bash","tool_input":{"command":"git checkout -b feature/new-branch"}}'
 	output=$(run_hook "$TEST_ROOT" "$json") || true
-	if [[ -n "$output" ]]; then
-		print_result "git checkout -b allowed by Bash matcher (safe)" 1 "output=${output}"
+	if ! hook_is_deny "$output" "Canonical workspace cannot switch"; then
+		print_result "git checkout -b blocked in canonical workspace" 1 "output=${output}"
 		passed=1
 	fi
 
+	local worktree_path="${TEST_ROOT}/bash-linked-wt"
+	git -C "$TEST_ROOT" worktree add "$worktree_path" -b feature/bash-linked-base >/dev/null 2>&1
+	output=$(run_hook "$worktree_path" "$json") || true
+	if [[ -n "$output" ]]; then
+		print_result "git checkout -b allowed inside linked worktree" 1 "output=${output}"
+		passed=1
+	fi
+	git -C "$TEST_ROOT" worktree remove "$worktree_path" 2>/dev/null || rm -rf "$worktree_path"
+	git -C "$TEST_ROOT" branch -D feature/bash-linked-base 2>/dev/null || true
+
 	if [[ "$passed" -eq 0 ]]; then
-		print_result "Bash matcher unchanged: destructive blocked, safe allowed" 0
+		print_result "Bash matcher: destructive blocked and branch creation requires worktree" 0
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -60,7 +60,7 @@ test_appends_escalation_contract() {
 	local output
 	output=$(append_worker_headless_contract "$prompt")
 
-	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V7'* ]] &&
+	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V8'* ]] &&
 		[[ "$output" == *'Read the issue body FIRST'* ]] &&
 		[[ "$output" == *'Look for a "Worker Guidance" or "How" section'* ]] &&
 		[[ "$output" == *'Never ask for user confirmation, approval, or next steps. No user will respond.'* ]] &&
@@ -226,7 +226,7 @@ test_deleted_launch_cwd_recovers_to_work_dir() {
 test_does_not_double_append() {
 	local prompt='/full-loop Continue issue #14964
 
-[HEADLESS_CONTINUATION_CONTRACT_V7]
+[HEADLESS_CONTINUATION_CONTRACT_V8]
 This worker run is unattended.'
 	local output
 	output=$(append_worker_headless_contract "$prompt")
@@ -257,6 +257,25 @@ EOF
 	fi
 
 	print_result "extract_session_id_from_output returns latest session id" 1 "Expected ses_latest, got ${session_id:-<empty>}"
+	return 0
+}
+
+test_blocked_completion_records_blocked_label() {
+	local output_file="${TEST_ROOT}/blocked-output.jsonl"
+	cat >"$output_file" <<'EOF'
+{"type":"text","sessionID":"ses_blocked","text":"BLOCKED: missing implementation context"}
+EOF
+
+	local rc=0
+	_handle_run_result 0 "$output_file" "worker" "openai" "issue-456" "openai/gpt-5.5" || rc=$?
+
+	if [[ "$rc" -eq 0 && "${_run_result_label:-}" == "blocked" && "${_run_failure_reason:-}" == "blocked" && "${_run_classification_source:-}" == "model_blocked_signal" ]]; then
+		print_result "BLOCKED terminal signal records blocked label" 0
+		return 0
+	fi
+
+	print_result "BLOCKED terminal signal records blocked label" 1 \
+		"rc=$rc label=${_run_result_label:-<unset>} reason=${_run_failure_reason:-<unset>} source=${_run_classification_source:-<unset>}"
 	return 0
 }
 
@@ -920,6 +939,7 @@ main() {
 	test_deleted_launch_cwd_recovers_to_work_dir
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
+	test_blocked_completion_records_blocked_label
 	test_headless_activity_timeout_default_matches_watchdog
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_canary_uses_builtin_agent_without_default_agent

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -52,10 +52,12 @@ fi
 
 repo_dir="${TEST_TMP}/repo"
 wt_dir="${TEST_TMP}/worktree"
-mkdir -p "${repo_dir}/node_modules/example" "$wt_dir" || fail "failed to create restore fixture dirs"
+mkdir -p "${repo_dir}/node_modules/example" "${repo_dir}/node_modules/.bin" "${repo_dir}/node_modules/prettier/bin" "$wt_dir" || fail "failed to create restore fixture dirs"
 printf '{}\n' >"${repo_dir}/package.json" || fail "failed to create repo package.json"
 printf '{}\n' >"${wt_dir}/package.json" || fail "failed to create worktree package.json"
 printf 'fixture\n' >"${repo_dir}/node_modules/example/file.txt" || fail "failed to create node_modules fixture"
+printf '#!/usr/bin/env node\n' >"${repo_dir}/node_modules/prettier/bin/prettier.cjs" || fail "failed to create prettier fixture"
+ln -s ../prettier/bin/prettier.cjs "${repo_dir}/node_modules/.bin/prettier" || fail "failed to create prettier bin symlink"
 
 LOGFILE="${TEST_TMP}/pulse.log" \
 	AIDEVOPS_WORKSPACE_DIR="$TEST_TMP" \
@@ -64,10 +66,15 @@ LOGFILE="${TEST_TMP}/pulse.log" \
 	WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S=1 \
 	_dlw_restore_worktree_deps "$wt_dir" "$repo_dir"
 
-if [[ -d "${wt_dir}/node_modules" ]]; then
-	fail "root node_modules restore was not skipped"
+if [[ -d "${wt_dir}/node_modules/example" ]]; then
+	fail "root node_modules payload was copied"
+fi
+
+if [[ ! -L "${wt_dir}/node_modules/.bin" ]]; then
+	fail "root node_modules .bin tooling link was not created"
 fi
 
 printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
-printf 'PASS: root node_modules restore is skipped by default\n'
+printf 'PASS: root node_modules payload is skipped by default\n'
+printf 'PASS: root node_modules .bin tooling is linked by default\n'
 exit 0

--- a/.agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh
@@ -143,14 +143,12 @@ test_empty_body_skip_logs() {
 	reset_logfile
 	check_terminal_blockers() { return 1; }
 	fast_fail_is_skipped() { return 1; }
-	# Mock gh issue view to return empty body.
+	# Mock gh REST read to return empty body.
 	gh() {
 		case "$1" in
-		issue)
-			[[ "$2" == "view" ]] && {
-				printf '\n'
-				return 0
-			}
+		api)
+			printf '\n'
+			return 0
 			;;
 		esac
 		return 0
@@ -179,11 +177,9 @@ test_stub_body_skip_logs() {
 	fast_fail_is_skipped() { return 1; }
 	gh() {
 		case "$1" in
-		issue)
-			[[ "$2" == "view" ]] && {
-				printf 'placeholder body — no description provided — enrich before dispatch\n'
-				return 0
-			}
+		api)
+			printf 'placeholder body — no description provided — enrich before dispatch\n'
+			return 0
 			;;
 		esac
 		return 0
@@ -204,7 +200,38 @@ test_stub_body_skip_logs() {
 }
 
 #######################################
-# Test 5: malformed candidate JSON in _dispatch_process_candidate logs the skip
+# Test 5: missing worker context skip writes per-candidate log line.
+#######################################
+test_missing_worker_context_skip_logs() {
+	reset_logfile
+	check_terminal_blockers() { return 1; }
+	fast_fail_is_skipped() { return 1; }
+	gh() {
+		case "$1" in
+		api)
+			printf 'Brief summary only; no implementation details for a worker.\n'
+			return 0
+			;;
+		esac
+		return 0
+	}
+
+	local rc=0
+	_dispatch_should_skip_candidate "45679" "owner/repo" || rc=$?
+	unset -f check_terminal_blockers fast_fail_is_skipped gh
+
+	local skip_logged=1
+	if grep -q "skipping #45679 (owner/repo) — missing Worker Guidance/How implementation context" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "missing worker context skip writes per-candidate log line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	print_result "missing worker context skip returns 0 (skip)" $((rc == 0 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 6: malformed candidate JSON in _dispatch_process_candidate logs the skip
 # instead of returning silently. Pre-GH#18804 this was a silent return 1.
 #######################################
 test_malformed_candidate_logs_skip() {
@@ -226,7 +253,7 @@ test_malformed_candidate_logs_skip() {
 }
 
 #######################################
-# Test 6: missing repo_path in _dispatch_process_candidate logs the skip.
+# Test 7: missing repo_path in _dispatch_process_candidate logs the skip.
 #######################################
 test_missing_repo_path_logs_skip() {
 	reset_logfile
@@ -247,7 +274,7 @@ test_missing_repo_path_logs_skip() {
 }
 
 #######################################
-# Test 7: PULSE_DEBUG=1 produces DFF DEBUG: lines for every candidate.
+# Test 8: PULSE_DEBUG=1 produces DFF DEBUG: lines for every candidate.
 #######################################
 test_pulse_debug_emits_per_candidate_logs() {
 	reset_logfile
@@ -256,11 +283,9 @@ test_pulse_debug_emits_per_candidate_logs() {
 	fast_fail_is_skipped() { return 1; }
 	gh() {
 		case "$1" in
-		issue)
-			[[ "$2" == "view" ]] && {
-				printf 'a real implementation context\n'
-				return 0
-			}
+		api)
+			printf '## Worker Guidance\nImplement the requested change.\n\n## Verification\nRun tests.\n'
+			return 0
 			;;
 		esac
 		return 0
@@ -286,7 +311,7 @@ test_pulse_debug_emits_per_candidate_logs() {
 }
 
 #######################################
-# Test 8: PULSE_DEBUG unset = no DFF DEBUG: lines (default behaviour).
+# Test 9: PULSE_DEBUG unset = no DFF DEBUG: lines (default behaviour).
 #######################################
 test_pulse_debug_unset_quiet_default() {
 	reset_logfile
@@ -295,11 +320,9 @@ test_pulse_debug_unset_quiet_default() {
 	fast_fail_is_skipped() { return 1; }
 	gh() {
 		case "$1" in
-		issue)
-			[[ "$2" == "view" ]] && {
-				printf 'a real implementation context\n'
-				return 0
-			}
+		api)
+			printf '## Worker Guidance\nImplement the requested change.\n\n## Verification\nRun tests.\n'
+			return 0
 			;;
 		esac
 		return 0
@@ -329,6 +352,7 @@ main() {
 	test_fast_fail_skip_logs
 	test_empty_body_skip_logs
 	test_stub_body_skip_logs
+	test_missing_worker_context_skip_logs
 	test_malformed_candidate_logs_skip
 	test_missing_repo_path_logs_skip
 	test_pulse_debug_emits_per_candidate_logs

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -43,7 +43,7 @@ Remote has new commits → pull/rebase first. Uncommitted local changes → stas
 
 **Worktrees** (DEFAULT for all feature work):
 
-Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. All work in worktree directories.
+Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. All work in worktree directories under `~/Git/`; do not create durable implementation worktrees in runtime temp paths such as macOS `/var/folders/.../T/opencode/`.
 
 ```bash
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/my-feature

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -22,7 +22,7 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Separate working directories per branch — no branch-switching conflicts
-- **Core principle**: Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. **Never `git checkout -b` in the main repo** — the next session inherits wrong state.
+- **Core principle**: Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. Create durable worktrees under `~/Git/`, not runtime temp dirs. **Never `git checkout -b` in the main repo** — the next session inherits wrong state.
 - **Preferred tool**: [Worktrunk](https://worktrunk.dev) (`brew install max-sixty/worktrunk/wt`) — full docs: `tools/git/worktrunk.md`
 - **Fallback**: `~/.aidevops/agents/scripts/worktree-helper.sh`
 


### PR DESCRIPTION
## Summary
- Classifies model-emitted `BLOCKED` worker outcomes as `blocked` instead of `success` so throughput metrics reflect PR-producing work.
- Skips explicitly missing-context issue bodies before worker launch while preserving later brief enrichment for older task bodies.
- Links root `node_modules/.bin` into worker worktrees without copying full root `node_modules`, and documents the configured workspace root for durable worktrees.

Resolves #22739

## Verification
- `.agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh`
- `.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/tests/test-headless-runtime-failure-classification.sh`
- `.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh`
- `.agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-dispatch-worker-launch.sh`
- `shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-model.sh .agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.37 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 8h 28m and 6,179,930 tokens on this with the user in an interactive session.
