### PR TITLE
GH#22733: preserve signed NMR approvals

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -829,16 +829,9 @@ cmd_verify() {
 	_require_number_arg "$issue_number" "Issue" "Usage: aidevops approve verify <number> [owner/repo]" || return 1
 	slug=$(_resolve_slug_or_fail "$slug" "Could not detect repo slug") || return 1
 
-	# Load public key
-	local pub_key="$HOME/.aidevops/approval-keys/approval.pub"
-	if [[ ! -f "$pub_key" ]]; then
-		echo "NO_KEY"
-		return 1
-	fi
-
 	# Fetch comments looking for approval marker
 	local comments_json
-	comments_json=$(gh api "repos/${slug}/issues/${issue_number}/comments" \
+	comments_json=$(gh api "repos/${slug}/issues/${issue_number}/comments" --paginate \
 		--jq "[.[] | select(.body | contains(\"$APPROVAL_MARKER\"))]" 2>/dev/null || echo "[]")
 
 	local comment_count
@@ -846,6 +839,15 @@ cmd_verify() {
 
 	if [[ "$comment_count" -eq 0 ]]; then
 		echo "NO_APPROVAL"
+		return 1
+	fi
+
+	# Load public key only after proving an approval marker exists. This keeps
+	# callers able to distinguish "no approval" from "approval exists but this
+	# worker cannot verify it" and avoids re-applying NMR over a signed approval.
+	local pub_key="${AIDEVOPS_APPROVAL_PUB:-$APPROVAL_PUB}"
+	if [[ ! -f "$pub_key" ]]; then
+		echo "NO_KEY"
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -622,10 +622,18 @@ _check_external_issue_author_gate() {
 	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
 	local verify_result=""
 	if [[ -f "$approval_helper" ]]; then
-		verify_result=$(bash "$approval_helper" verify "$issue_number" "$repo_slug" 2>/dev/null) || verify_result=""
+		verify_result=$(bash "$approval_helper" verify "$issue_number" "$repo_slug" 2>/dev/null || true)
 		if [[ "$verify_result" == "VERIFIED" ]]; then
 			echo "[dispatch_with_dedup] GH#22399: external/unknown issue author for #${issue_number} in ${repo_slug} has cryptographic approval; allowing dispatch" >>"$LOGFILE"
 			return 1
+		fi
+		# <!-- aidevops:trust-boundary -->
+		# Distinguish an absent approval from an unverifiable approval marker. A
+		# worker missing the approval public key must fail closed for dispatch, but
+		# must not mutate lifecycle labels over a maintainer's signed handoff.
+		if [[ -n "$verify_result" && "$verify_result" != "NO_APPROVAL" ]]; then
+			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: cryptographic approval marker present but verification returned ${verify_result}; not re-applying needs-maintainer-review (GH#22733)" >>"$LOGFILE"
+			return 0
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-approval-helper-verify-state.sh
+++ b/.agents/scripts/tests/test-approval-helper-verify-state.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#22733: approval verification must distinguish an
+# absent approval from an existing approval marker that cannot be verified on
+# the current worker.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+APPROVAL_HELPER="${SCRIPT_DIR}/../approval-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_case() {
+	TEST_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-approval-verify)
+	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/home"
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${GH_COMMENTS_MODE:-empty}" == "marker" ]]; then
+	printf '%s\n' '[{"body":"<!-- aidevops-signed-approval -->"}]'
+	exit 0
+fi
+printf '%s\n' '[]'
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+cleanup_case() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+run_verify() {
+	local comments_mode="$1"
+	HOME="${TEST_ROOT}/home" \
+		PATH="${TEST_ROOT}/bin:$PATH" \
+		GH_COMMENTS_MODE="$comments_mode" \
+		"$APPROVAL_HELPER" verify 22733 owner/repo 2>/dev/null
+	return $?
+}
+
+test_no_marker_reports_no_approval_even_without_key() {
+	setup_case
+	local output rc=0
+	output=$(run_verify empty) || rc=$?
+	if [[ "$rc" -ne 0 && "$output" == "NO_APPROVAL" ]]; then
+		print_result "no marker reports NO_APPROVAL before key check" 0
+		cleanup_case
+		return 0
+	fi
+	print_result "no marker reports NO_APPROVAL before key check" 1 "rc=${rc}, output=${output}"
+	cleanup_case
+	return 0
+}
+
+test_marker_without_key_reports_no_key() {
+	setup_case
+	local output rc=0
+	output=$(run_verify marker) || rc=$?
+	if [[ "$rc" -ne 0 && "$output" == "NO_KEY" ]]; then
+		print_result "marker without key reports NO_KEY" 0
+		cleanup_case
+		return 0
+	fi
+	print_result "marker without key reports NO_KEY" 1 "rc=${rc}, output=${output}"
+	cleanup_case
+	return 0
+}
+
+main() {
+	test_no_marker_reports_no_approval_even_without_key
+	test_marker_without_key_reports_no_key
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh
@@ -90,7 +90,11 @@ if [[ "\${1:-}" == "verify" && "${approval_result}" == "VERIFIED" ]]; then
 	printf 'VERIFIED\n'
 	exit 0
 fi
-printf 'UNVERIFIED\n'
+if [[ "\${1:-}" == "verify" && "${approval_result}" == "NO_KEY" ]]; then
+	printf 'NO_KEY\n'
+	exit 1
+fi
+printf 'NO_APPROVAL\n'
 exit 1
 EOF
 	chmod +x "${AGENTS_DIR}/scripts/approval-helper.sh"
@@ -162,6 +166,23 @@ test_external_author_with_crypto_approval_allows_dispatch() {
 	return 0
 }
 
+test_external_author_with_unverifiable_approval_blocks_without_reapplying_nmr() {
+	setup_case "CONTRIBUTOR" "User" "NO_KEY"
+	if _check_external_issue_author_gate 22733 "owner/repo"; then
+		if grep -q -- '--add-label needs-maintainer-review' "$GH_CALLS_FILE"; then
+			print_result "unverifiable approval marker does not reapply NMR" 1 "NMR label was re-applied: $(<"$GH_CALLS_FILE")"
+			cleanup_case
+			return 0
+		fi
+		print_result "unverifiable approval marker does not reapply NMR" 0
+		cleanup_case
+		return 0
+	fi
+	print_result "unverifiable approval marker does not reapply NMR" 1 "Expected gate to block dispatch while preserving labels"
+	cleanup_case
+	return 0
+}
+
 test_author_lookup_failure_fails_closed() {
 	setup_case "" "" ""
 	rm -f "${TEST_ROOT}/issue-meta.tsv"
@@ -190,6 +211,7 @@ main() {
 	test_owner_author_allows_dispatch
 	test_collaborator_author_allows_dispatch
 	test_external_author_with_crypto_approval_allows_dispatch
+	test_external_author_with_unverifiable_approval_blocks_without_reapplying_nmr
 	test_author_lookup_failure_fails_closed
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Prevents the external-author dispatch gate from mutating needs-maintainer-review when a maintainer approval marker exists but local verification is unavailable, and makes approval verification distinguish NO_APPROVAL from NO_KEY.

## Files Changed

.agents/scripts/approval-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-approval-helper-verify-state.sh,.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused regressions pass: test-pulse-dispatch-core-external-author-gate.sh, test-approval-helper-verify-state.sh; ShellCheck passes on changed scripts; git diff --check passes.

Resolves #22733


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.37 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 43m and 369,039 tokens on this with the user in an interactive session.