### PR TITLE
awardsapp#4011: fix no_work false trips without worker evidence

### DIFF
--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -95,7 +95,7 @@ _classify_stale_recovery_crash_type() {
 #######################################
 # Decide whether a stale-recovery event is evidence of a worker failure.
 #
-# t4012/GH#4012: pre-launch abort cleanup can leave an old active label +
+# GH#4011/GH#4012: pre-launch abort cleanup can leave an old active label +
 # assignee without any dispatch claim comment because no worker ever started
 # and the claim comment was deleted as audit noise. Stale recovery should clean
 # that orphaned state, but it must not feed the no_work fast-fail counter: a
@@ -275,7 +275,7 @@ _dedup_layer6_assignee_and_stale() {
 		# with 0 PRs and 0 fast-fail entries (GH#17700, GH#17701, GH#17702).
 		if [[ "$assigned_output" == *STALE_RECOVERED* ]]; then
 			if ! _stale_recovery_has_worker_evidence "$assigned_output"; then
-				echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} without worker evidence — skipping fast-fail record (t4012)" >>"$LOGFILE"
+				echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} without worker evidence — skipping fast-fail record (GH#4011/GH#4012)" >>"$LOGFILE"
 				return 1
 			fi
 			# t2042: classify what (if anything) the dead worker produced

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -11,6 +11,7 @@
 #
 # Functions in this module (in source order):
 #   - _classify_stale_recovery_crash_type
+#   - _stale_recovery_has_worker_evidence
 #   - _dedup_layer1_ledger_check
 #   - _dedup_layer2_process_match
 #   - _dedup_layer3_title_match
@@ -88,6 +89,25 @@ _classify_stale_recovery_crash_type() {
 	# artifact. Classify as no_work so the cascade tier escalation
 	# comment renders the "Likely infrastructure/transient failure" line.
 	printf 'no_work'
+	return 0
+}
+
+#######################################
+# Decide whether a stale-recovery event is evidence of a worker failure.
+#
+# t4012/GH#4012: pre-launch abort cleanup can leave an old active label +
+# assignee without any dispatch claim comment because no worker ever started
+# and the claim comment was deleted as audit noise. Stale recovery should clean
+# that orphaned state, but it must not feed the no_work fast-fail counter: a
+# missing dispatch claim proves there is no worker artifact to classify.
+#
+# Args: $1 - captured dispatch-dedup-helper output
+# Returns: 0 if stale recovery found worker evidence, 1 otherwise
+#######################################
+_stale_recovery_has_worker_evidence() {
+	local assigned_output="$1"
+	[[ "$assigned_output" == *STALE_RECOVERED* ]] || return 1
+	[[ "$assigned_output" != *"no dispatch claim comment found"* ]] || return 1
 	return 0
 }
 
@@ -229,7 +249,8 @@ _dedup_layer5_dispatch_comment() {
 #######################################
 # Layer 6 (GH#6891): cross-machine assignee guard + stale recovery.
 # Prevents runners from dispatching workers for issues already assigned to
-# another login. On STALE_RECOVERED, records fast-fail (t1927/t2042).
+# another login. On STALE_RECOVERED with worker evidence, records fast-fail
+# (t1927/t2042).
 # Arguments: issue_number, repo_slug, self_login
 # Exit: 0 = blocked, 1 = continue
 #######################################
@@ -253,6 +274,10 @@ _dedup_layer6_assignee_and_stale() {
 		# dispatch→timeout→stale-recovery cycles. Observed: 8+ dispatches in 6h
 		# with 0 PRs and 0 fast-fail entries (GH#17700, GH#17701, GH#17702).
 		if [[ "$assigned_output" == *STALE_RECOVERED* ]]; then
+			if ! _stale_recovery_has_worker_evidence "$assigned_output"; then
+				echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} without worker evidence — skipping fast-fail record (t4012)" >>"$LOGFILE"
+				return 1
+			fi
 			# t2042: classify what (if anything) the dead worker produced
 			# before stalling so the cascade tier escalation comment can
 			# render a "Crash type: no_work | partial" diagnostic line

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression guard for GH#4012 / t2769 no_work false trips.
+# Regression guard for GH#4011/GH#4012 / t2769 no_work false trips.
 #
 # A stale active label + assignee with no dispatch claim comment can be cleaned
 # up by stale recovery, but it is not evidence that a worker ever started. That

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#4012 / t2769 no_work false trips.
+#
+# A stale active label + assignee with no dispatch claim comment can be cleaned
+# up by stale recovery, but it is not evidence that a worker ever started. That
+# recovery must not record stale_timeout/no_work fast-fails, or pre-launch
+# canary failures can trip the t2769 no_work circuit breaker without worker
+# evidence.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+TMP_DIR="$(mktemp -d -t stale-no-worker.XXXXXX)" || exit 1
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+export LOGFILE="${TMP_DIR}/pulse.log"
+SCRIPT_DIR="$TMP_DIR"
+HELPER_PATH="${TMP_DIR}/dispatch-dedup-helper.sh"
+
+cat >"$HELPER_PATH" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+cmd="${1:-}"
+shift || true
+
+if [[ "$cmd" == "is-assigned" ]]; then
+	case "${TEST_STALE_MODE:-no_worker}" in
+	no_worker)
+		printf '%s\n' 'STALE_RECOVERED: issue #2905 in awardsapp/awardsapp - unassigned runner (no dispatch claim comment found, no recent activity (threshold=600s, interactive=false))'
+		exit 1
+		;;
+	worker)
+		printf '%s\n' 'STALE_RECOVERED: issue #2905 in awardsapp/awardsapp - unassigned runner (dispatch claim 900s old, last activity 900s old (threshold=600s, interactive=false))'
+		exit 1
+		;;
+	*)
+		printf '%s\n' 'ASSIGNED: issue #2905 in awardsapp/awardsapp is assigned to runner'
+		exit 0
+		;;
+	esac
+fi
+
+if [[ "$cmd" == "classify-blocker" ]]; then
+	printf 'assigned\n'
+	exit 0
+fi
+
+exit 1
+EOF
+chmod +x "$HELPER_PATH"
+
+# shellcheck source=../pulse-dispatch-dedup-layers.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-dedup-layers.sh"
+
+FAST_FAIL_CALLS=0
+LAST_FAST_FAIL=""
+CLASSIFY_LOG="${TMP_DIR}/classify.log"
+
+reset_observations() {
+	FAST_FAIL_CALLS=0
+	LAST_FAST_FAIL=""
+	: >"$LOGFILE"
+	: >"$CLASSIFY_LOG"
+	return 0
+}
+
+fast_fail_record() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local provider="$4"
+	local crash_type="$5"
+	FAST_FAIL_CALLS=$((FAST_FAIL_CALLS + 1))
+	LAST_FAST_FAIL="${issue_number}|${repo_slug}|${reason}|${provider}|${crash_type}"
+	return 0
+}
+
+_classify_stale_recovery_crash_type() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	: "$issue_number" "$repo_slug"
+	printf '%s|%s\n' "$issue_number" "$repo_slug" >>"$CLASSIFY_LOG"
+	printf 'no_work'
+	return 0
+}
+
+test_stale_recovery_without_claim_skips_fast_fail() {
+	export TEST_STALE_MODE="no_worker"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "awardsapp/awardsapp" "runner" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		fail "no-worker stale recovery continues dispatch" "expected rc=1, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$FAST_FAIL_CALLS" -ne 0 ]]; then
+		fail "no-worker stale recovery skips fast-fail" "fast_fail_record called ${FAST_FAIL_CALLS} time(s): ${LAST_FAST_FAIL}"
+		return 0
+	fi
+	if [[ -s "$CLASSIFY_LOG" ]]; then
+		fail "no-worker stale recovery skips classifier" "classifier log: $(tr '\n' ' ' <"$CLASSIFY_LOG")"
+		return 0
+	fi
+	if ! grep -q 'without worker evidence' "$LOGFILE" 2>/dev/null; then
+		fail "no-worker stale recovery logs skip reason" "log: $(tr '\n' ' ' <"$LOGFILE")"
+		return 0
+	fi
+	pass "no-worker stale recovery skips no_work fast-fail"
+	return 0
+}
+
+test_stale_recovery_with_dispatch_claim_records_fast_fail() {
+	export TEST_STALE_MODE="worker"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "awardsapp/awardsapp" "runner" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		fail "worker stale recovery continues dispatch" "expected rc=1, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$(tr '\n' ' ' <"$CLASSIFY_LOG")" != "2905|awardsapp/awardsapp " ]]; then
+		fail "worker stale recovery classifies crash type" "classifier log: $(tr '\n' ' ' <"$CLASSIFY_LOG")"
+		return 0
+	fi
+	if [[ "$FAST_FAIL_CALLS" -ne 1 ]]; then
+		fail "worker stale recovery records fast-fail" "fast_fail_record called ${FAST_FAIL_CALLS} time(s)"
+		return 0
+	fi
+	if [[ "$LAST_FAST_FAIL" != "2905|awardsapp/awardsapp|stale_timeout||no_work" ]]; then
+		fail "worker stale recovery fast-fail payload" "payload: ${LAST_FAST_FAIL}"
+		return 0
+	fi
+	pass "worker stale recovery still records no_work fast-fail"
+	return 0
+}
+
+test_stale_recovery_without_claim_skips_fast_fail
+test_stale_recovery_with_dispatch_claim_records_fast_fail
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

- Prevent stale assignment cleanup without dispatch-claim evidence from incrementing the `no_work` fast-fail counter.
- Add a regression test that proves no-worker stale recovery continues dispatch cleanup but skips classifier/fast-fail recording.

## Root cause

The t2769 breaker was fed by `.agents/scripts/pulse-dispatch-dedup-layers.sh::_dedup_layer6_assignee_and_stale`. Pre-launch canary abort cleanup can leave an active label and assignee after deleting the dispatch claim as audit noise. Stale recovery correctly cleans that orphaned state, but the previous path treated every `STALE_RECOVERED` result as a worker timeout and recorded `stale_timeout` with `crash_type=no_work`. When `dispatch-dedup-helper.sh is-assigned` reports `no dispatch claim comment found`, there is no worker artifact to classify, so the event must not count toward the no_work circuit breaker.

## Testing

- `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `shellcheck .agents/scripts/pulse-dispatch-dedup-layers.sh .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`

## Runtime Testing

Self-assessed: shell dispatch control-flow change covered by deterministic regression tests and ShellCheck.

Resolves awardsapp/awardsapp#4011
Refs awardsapp/awardsapp#4012

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 177,589 tokens on this as a headless worker.