### PR TITLE
GH#4007: fix no_work marker pagination

### DIFF
--- a/.agents/scripts/tests/test-worker-lifecycle-marker-pagination.sh
+++ b/.agents/scripts/tests/test-worker-lifecycle-marker-pagination.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for awardsapp/awardsapp#4007 / t2769 no_work loops.
+# Long issue threads push breaker markers onto later GitHub comment pages;
+# worker-lifecycle marker idempotency must slurp all pages before counting.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+LIFECYCLE_SCRIPT="${REPO_ROOT}/.agents/scripts/worker-lifecycle-common.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_TMP=""
+GH_CALL_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '  %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_TMP="$(mktemp -d -t worker-marker-pagination.XXXXXX)"
+	GH_CALL_LOG="${TEST_TMP}/gh-calls.log"
+	: >"$GH_CALL_LOG"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_TMP" && -d "$TEST_TMP" ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+	return 0
+}
+
+define_marker_counter() {
+	local helper_src=""
+	helper_src=$(awk '
+		/^_count_issue_comments_containing_marker\(\) \{/,/^\}/ { print }
+	' "$LIFECYCLE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _count_issue_comments_containing_marker\n' >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+gh() {
+	local cmd="${1:-}"
+	shift || true
+	if [[ "$cmd" != "api" ]]; then
+		printf '{}\n'
+		return 0
+	fi
+
+	local api_path="${1:-}"
+	shift || true
+	if [[ "$api_path" != "repos/owner/repo/issues/4007/comments" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+
+	local has_paginate=0
+	local has_slurp=0
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--paginate)
+			has_paginate=1
+			shift
+			;;
+		--slurp)
+			has_slurp=1
+			shift
+			;;
+		--jq)
+			shift 2 || true
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ "$has_paginate" -eq 1 && "$has_slurp" -eq 1 ]]; then
+		printf 'comments_slurped\n' >>"$GH_CALL_LOG"
+		printf '[[{"body":"old dispatch claim"}],[{"body":"<!-- cost-circuit-breaker:no_work_loop -->\\n## no_work Circuit Breaker Fired"}]]\n'
+		return 0
+	fi
+
+	if [[ "$has_paginate" -eq 1 ]]; then
+		printf 'comments_paginated_without_slurp\n' >>"$GH_CALL_LOG"
+		printf '[{"body":"old dispatch claim"}]\n[{"body":"<!-- cost-circuit-breaker:no_work_loop -->"}]\n'
+		return 0
+	fi
+
+	printf 'comments_unpaginated\n' >>"$GH_CALL_LOG"
+	printf '[{"body":"old dispatch claim"}]\n'
+	return 0
+}
+
+test_marker_count_slurps_paginated_comments() {
+	local marker="cost-circuit-breaker:no_work_loop"
+	local count=""
+	count=$(_count_issue_comments_containing_marker "4007" "owner/repo" "$marker") || count=""
+
+	if [[ "$count" != "1" ]]; then
+		print_result "marker count sees page-2 no_work marker" 1 \
+			"expected count=1, got '${count:-empty}'"
+		return 0
+	fi
+
+	if ! grep -q '^comments_slurped$' "$GH_CALL_LOG" 2>/dev/null; then
+		print_result "marker count requests paginated slurp" 1 \
+			"gh mock did not observe --paginate --slurp"
+		return 0
+	fi
+
+	print_result "marker count sees page-2 no_work marker" 0
+	print_result "marker count requests paginated slurp" 0
+	return 0
+}
+
+test_marker_count_returns_zero_when_absent() {
+	local marker="missing-marker"
+	local count=""
+	: >"$GH_CALL_LOG"
+	count=$(_count_issue_comments_containing_marker "4007" "owner/repo" "$marker") || count=""
+
+	if [[ "$count" != "0" ]]; then
+		print_result "marker count returns zero when absent" 1 \
+			"expected count=0, got '${count:-empty}'"
+		return 0
+	fi
+
+	print_result "marker count returns zero when absent" 0
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+
+	if ! define_marker_counter; then
+		return 1
+	fi
+
+	test_marker_count_slurps_paginated_comments
+	test_marker_count_returns_zero_when_absent
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-worker-reliability-self-heal.sh
+++ b/.agents/scripts/tests/test-worker-reliability-self-heal.sh
@@ -38,6 +38,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 # auto-update-helper.sh was split in GH#20343.
 AUTO_UPDATE_SCRIPT="${REPO_ROOT}/.agents/scripts/auto-update-freshness-lib.sh"
 HEADLESS_SCRIPT="${REPO_ROOT}/.agents/scripts/headless-runtime-helper.sh"
+HEADLESS_WORKER_SCRIPT="${REPO_ROOT}/.agents/scripts/headless-runtime-worker.sh"
 LIFECYCLE_SCRIPT="${REPO_ROOT}/.agents/scripts/worker-lifecycle-common.sh"
 SCHEDULERS_SCRIPT="${REPO_ROOT}/.agents/scripts/setup/modules/schedulers.sh"
 
@@ -129,8 +130,14 @@ define_preserve_helper() {
 	helper_src=$(awk '
 		/^_preserve_no_activity_output\(\) \{/,/^}$/ { print }
 	' "$HEADLESS_SCRIPT")
+	if [[ -z "$helper_src" && -f "$HEADLESS_WORKER_SCRIPT" ]]; then
+		helper_src=$(awk '
+			/^_preserve_no_activity_output\(\) \{/,/^}$/ { print }
+		' "$HEADLESS_WORKER_SCRIPT")
+	fi
 	if [[ -z "$helper_src" ]]; then
-		printf 'ERROR: could not extract _preserve_no_activity_output\n' >&2
+		printf 'ERROR: could not extract _preserve_no_activity_output from %s or %s\n' \
+			"$HEADLESS_SCRIPT" "$HEADLESS_WORKER_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090
@@ -395,7 +402,7 @@ NMR_APPROVAL_SCRIPT="${NMR_APPROVAL_SCRIPT:-$(dirname "$LIFECYCLE_SCRIPT")/pulse
 
 test_no_work_circuit_breaker_threshold_guard() {
 	# _log_no_work_skip_escalation must reference NO_WORK_NMR_THRESHOLD
-	# and apply needs-maintainer-review when the threshold is reached.
+	# and delegate to the NMR breaker when the threshold is reached.
 
 	# Assertion 1: NO_WORK_NMR_THRESHOLD is referenced in the function body.
 	local fn_src
@@ -412,17 +419,17 @@ test_no_work_circuit_breaker_threshold_guard() {
 		return 0
 	fi
 
-	# Assertion 2: the function applies needs-maintainer-review.
-	if ! printf '%s\n' "$fn_src" | grep -q 'needs-maintainer-review'; then
+	# Assertion 2: the function delegates to the dedicated NMR breaker helper.
+	if ! printf '%s\n' "$fn_src" | grep -q '_apply_no_work_nmr_breaker'; then
 		print_result "t2769: no_work circuit breaker threshold guard" 1 \
-			"needs-maintainer-review label not applied in _log_no_work_skip_escalation"
+			"_apply_no_work_nmr_breaker not called in _log_no_work_skip_escalation"
 		return 0
 	fi
 
 	# Assertion 3: the NMR path appears BEFORE the below-threshold diagnostic path
 	# (threshold check is the first branch; diagnostic is the fallthrough).
 	local nmr_line diag_line
-	nmr_line=$(printf '%s\n' "$fn_src" | grep -n 'needs-maintainer-review' | head -1 | cut -d: -f1)
+	nmr_line=$(printf '%s\n' "$fn_src" | grep -n '_apply_no_work_nmr_breaker' | head -1 | cut -d: -f1)
 	diag_line=$(printf '%s\n' "$fn_src" | grep -n 'no-work-escalation-skip' | head -1 | cut -d: -f1)
 	if [[ -z "$nmr_line" || -z "$diag_line" ]]; then
 		print_result "t2769: no_work circuit breaker threshold guard" 1 \

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -19,6 +19,7 @@
 #   _sanitize_log_field()     Strip control characters from log fields
 #   _sanitize_markdown()      Strip @ mentions and backticks from markdown
 #   _validate_int()           Validate and sanitize integer config values
+#   _count_issue_comments_containing_marker() Pagination-safe comment marker count
 #   _count_worker_commits()   Count commits in a worktree since elapsed seconds ago
 #   _count_worker_messages()  Count session DB messages for a worker
 #   _determine_struggle_flag() Determine struggle flag from ratio/commit/elapsed metrics
@@ -825,6 +826,36 @@ _Automated by \`escalate_issue_tier()\` body quality gate (t1900) in worker-life
 }
 
 #######################################
+# Count issue comments containing a marker across all paginated comment pages.
+#
+# Root cause fixed for awardsapp/awardsapp#4007: long issue threads can push
+# breaker markers onto page 2+. `gh api --paginate --jq ...` applies jq per
+# page instead of across the full comment stream, so a page-local count can
+# miss existing t2769 markers and re-file/noise a no_work breaker. Slurping
+# all pages before jq keeps marker idempotency consistent with the stale
+# activity detector's pagination fix.
+#
+# Args: $1=issue_number, $2=repo_slug, $3=marker substring
+# Stdout: numeric count, or empty on gh/jq failure
+# Returns: 0 on count success, 1 on gh/jq failure
+#######################################
+_count_issue_comments_containing_marker() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local comments_pages=""
+	local count=""
+
+	comments_pages=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --slurp 2>/dev/null) || return 1
+	count=$(printf '%s' "$comments_pages" | jq --arg marker "$marker" \
+		'[.[] | .[]? | select((.body // "") | contains($marker))] | length' \
+		2>/dev/null) || return 1
+	printf '%s' "$count"
+	return 0
+}
+
+#######################################
 # t3076: file a root-cause meta-issue with forensics when the no_work
 # breaker fires. Idempotent — second trip on the same original is a
 # no-op (filer self-checks via marker comment). Best-effort: failures
@@ -888,9 +919,8 @@ _apply_no_work_nmr_breaker() {
 	local nmr_marker='cost-circuit-breaker:no_work_loop'
 
 	local existing_nmr=""
-	existing_nmr=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate \
-		--jq "[.[] | select(.body | contains(\"${nmr_marker}\"))] | length" \
-		2>/dev/null) || existing_nmr=""
+	existing_nmr=$(_count_issue_comments_containing_marker \
+		"$issue_number" "$repo_slug" "$nmr_marker") || existing_nmr=""
 	if [[ "$existing_nmr" =~ ^[1-9][0-9]*$ ]]; then
 		printf '[worker-lifecycle][t2769] no_work NMR circuit breaker already applied for #%s (%s, count=%s)\n' \
 			"$issue_number" "$repo_slug" "$failure_count" >&2 || true
@@ -911,13 +941,14 @@ _apply_no_work_nmr_breaker() {
 **Action:** Applied \`needs-maintainer-review\`. Further automated dispatch is suspended.
 **Last failure reason:** ${safe_reason}
 
-**Why this class of failure does not cascade tiers:** \`no_work\` means the worker crashed during runtime setup before reading any target files (FD exhaustion, plugin init failure, auth refresh race). A more expensive model cannot fix an infrastructure problem it never reached.
+**Why this class of failure does not cascade tiers:** \`no_work\` usually means the worker crashed during runtime setup before reading any target files (FD exhaustion, plugin init failure, auth refresh race) or stale-recovery falsely concluded no progress. A more expensive model cannot fix an infrastructure problem it never reached.
 
 **Possible causes:**
 - Brief not yet merged or branch missing at dispatch time
 - Auth token stale or missing
 - Plugin init crash (FD exhaustion, env pollution)
 - Branch naming race at dispatch time
+- Stale-recovery false positive on long issue threads (check dispatch-dedup-stale comment pagination and recent-activity aggregation)
 
 Remove \`needs-maintainer-review\` after investigating the root cause to re-enable dispatch.
 
@@ -958,9 +989,8 @@ _log_no_work_skip_escalation() {
 	# Best-effort — if gh api fails, fall through and post (better to repeat
 	# once than to lose the diagnostic entirely).
 	local existing=""
-	existing=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq "[.[] | select(.body | contains(\"${marker}\"))] | length" \
-		2>/dev/null) || existing=""
+	existing=$(_count_issue_comments_containing_marker \
+		"$issue_number" "$repo_slug" "$marker") || existing=""
 	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
 		# Already posted once — nothing more to do. Still emit a one-line
 		# log so operators can track the skip rate if they're tailing logs.
@@ -980,7 +1010,7 @@ ${marker}
 **Action:** Tier escalation **skipped**. The issue stays at its current tier so the next retry can succeed cheaply once the infrastructure issue resolves.
 **Reason:** ${safe_reason}
 
-**Why no cascade:** \`no_work\` means the worker never engaged with the brief — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race). A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would burn opus tokens on a problem sonnet (or haiku) will handle once the infra clears.
+**Why no cascade:** \`no_work\` means the worker never produced reliable implementation evidence — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race) or stale-recovery falsely concluded no progress. A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would burn opus tokens on a problem sonnet (or haiku) will handle once the infra clears.
 
 After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`needs-maintainer-review\` with a \`cost-circuit-breaker:no_work_loop\` marker that \`_nmr_application_is_circuit_breaker_trip\` (t2386) recognises, so auto-approval correctly preserves NMR.
 


### PR DESCRIPTION
## Summary
- Counts no_work and skip-escalation markers across all paginated GitHub issue comments before deciding whether to post another breaker comment.
- Adds a regression test that mocks a marker appearing on a later comment page and updates the worker reliability guard to assert delegation through the shared marker counter path.

## Root Cause
`worker-lifecycle-common.sh::_apply_no_work_nmr_breaker` and `worker-lifecycle-common.sh::_log_no_work_skip_escalation` used page-local or unpaginated comment marker checks. Long issue threads can push the existing `cost-circuit-breaker:no_work_loop` / `no-work-escalation-skip` markers past the first returned page, so idempotency missed the prior marker and treated a stale no_work loop as a new breaker event.

## Testing
- `bash .agents/scripts/tests/test-worker-lifecycle-marker-pagination.sh`
- `bash .agents/scripts/tests/test-worker-reliability-self-heal.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `bash -n .agents/scripts/worker-lifecycle-common.sh .agents/scripts/tests/test-worker-reliability-self-heal.sh .agents/scripts/tests/test-worker-lifecycle-marker-pagination.sh`
- `shellcheck .agents/scripts/worker-lifecycle-common.sh .agents/scripts/tests/test-worker-reliability-self-heal.sh .agents/scripts/tests/test-worker-lifecycle-marker-pagination.sh`
- `git diff --check`

Resolves awardsapp/awardsapp#4007


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 107,305 tokens on this as a headless worker.
