### PR TITLE
GH#4044: fix no_work prelaunch skip classification

### DIFF
--- a/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
+++ b/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for awardsapp/awardsapp#4044.
+#
+# Canary-preflight and worktree-precreation skips occur before the worker
+# worktree exists and before the model can read the brief. If those launch
+# control outcomes are later forwarded as crash_type=no_work, they must not
+# trip the t2769 no_work NMR breaker. Legitimate no_work failures that happen
+# after worker launch must keep the existing breaker path.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+LIFECYCLE_SCRIPT="${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+APPLY_CALLS=0
+LAST_APPLY_REASON=""
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+# shellcheck source=../worker-lifecycle-common.sh
+source "$LIFECYCLE_SCRIPT"
+
+_apply_no_work_nmr_breaker() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_count="$3"
+	local nmr_threshold="$4"
+	local reason="$5"
+	: "$issue_number" "$repo_slug" "$failure_count" "$nmr_threshold"
+	APPLY_CALLS=$((APPLY_CALLS + 1))
+	LAST_APPLY_REASON="$reason"
+	return 0
+}
+
+reset_observations() {
+	APPLY_CALLS=0
+	LAST_APPLY_REASON=""
+	return 0
+}
+
+test_prelaunch_canary_skip_does_not_apply_breaker() {
+	reset_observations
+	_log_no_work_skip_escalation "4044" "awardsapp/awardsapp" "4" \
+		"worker canary preflight failed before worktree pre-creation; will retry next cycle"
+	if [[ "$APPLY_CALLS" -ne 0 ]]; then
+		fail "prelaunch canary skip does not apply no_work breaker" \
+			"breaker called ${APPLY_CALLS} time(s), reason=${LAST_APPLY_REASON}"
+		return 0
+	fi
+	pass "prelaunch canary skip does not apply no_work breaker"
+	return 0
+}
+
+test_precreation_skip_does_not_apply_breaker() {
+	reset_observations
+	_log_no_work_skip_escalation "4044" "awardsapp/awardsapp" "4" \
+		"worktree pre-creation failed for issue; will retry next cycle"
+	if [[ "$APPLY_CALLS" -ne 0 ]]; then
+		fail "precreation skip does not apply no_work breaker" \
+			"breaker called ${APPLY_CALLS} time(s), reason=${LAST_APPLY_REASON}"
+		return 0
+	fi
+	pass "precreation skip does not apply no_work breaker"
+	return 0
+}
+
+test_legitimate_no_work_still_applies_breaker() {
+	reset_observations
+	_log_no_work_skip_escalation "4044" "awardsapp/awardsapp" "4" \
+		"worker_noop_zero_output"
+	if [[ "$APPLY_CALLS" -ne 1 ]]; then
+		fail "legitimate no_work still applies breaker" \
+			"expected 1 breaker call, got ${APPLY_CALLS}"
+		return 0
+	fi
+	if [[ "$LAST_APPLY_REASON" != "worker_noop_zero_output" ]]; then
+		fail "legitimate no_work preserves reason" \
+			"reason=${LAST_APPLY_REASON}"
+		return 0
+	fi
+	pass "legitimate no_work still applies breaker"
+	return 0
+}
+
+test_prelaunch_canary_skip_does_not_apply_breaker
+test_precreation_skip_does_not_apply_breaker
+test_legitimate_no_work_still_applies_breaker
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -881,6 +881,29 @@ _file_circuit_breaker_meta_no_work() {
 }
 
 #######################################
+# Detect dispatch skips that happened before a worker could start.
+#
+# These reasons are launch-control outcomes, not evidence that a worker read
+# setup context and then produced no actionable work. They must not trip the
+# t2769 no_work breaker even if stale recovery or an older fast-fail record
+# path accidentally forwards them with crash_type=no_work.
+#
+# Args: $1=reason text
+# Returns: 0 when reason is a pre-worker-launch skip, 1 otherwise
+#######################################
+_no_work_reason_is_pre_worker_launch_skip() {
+	local reason="${1:-}"
+	if [[ "$reason" == *"worker canary preflight failed before worktree pre-creation"* \
+		|| "$reason" == *"canary preflight failed before worktree pre-creation"* \
+		|| "$reason" == *"pre-creation failed; will retry next cycle"* \
+		|| "$reason" == *"worktree pre-creation failed"* \
+		|| "$reason" == *"worker_launch_rc_2"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Post an idempotent diagnostic comment when tier escalation is skipped
 # because the worker crashed with crash_type=no_work (infrastructure
 # failure — FD exhaustion, plugin init crash, branch naming race, auth
@@ -972,6 +995,16 @@ _log_no_work_skip_escalation() {
 	[[ -n "$repo_slug" ]] || return 0
 
 	local nmr_threshold="${NO_WORK_NMR_THRESHOLD:-3}"
+
+	# GH#4044: canary/precreation skips before worktree pre-creation are not
+	# productive worker executions. If an older stale-recovery or fast-fail path
+	# forwards such a reason as crash_type=no_work, do not count it as actionable
+	# no_work-loop evidence and do not apply the t2769 NMR breaker.
+	if _no_work_reason_is_pre_worker_launch_skip "$reason"; then
+		printf '[worker-lifecycle][t2769] pre-worker-launch skip ignored for no_work breaker #%s (%s, count=%s, reason=%s)\n' \
+			"$issue_number" "$repo_slug" "$failure_count" "$reason" >&2 || true
+		return 0
+	fi
 
 	# Circuit-breaker path (t2769): when failure_count >= threshold,
 	# apply NMR + file root-cause meta-issue. Auto-approval preserves NMR


### PR DESCRIPTION
## Summary
- Add a pre-worker-launch reason guard in `.agents/scripts/worker-lifecycle-common.sh` so canary-preflight and worktree-precreation skips short-circuit before `_apply_no_work_nmr_breaker`.
- Preserve the existing t2769 NMR breaker for legitimate post-launch `no_work` failures such as `worker_noop_zero_output`.
- Add `.agents/scripts/tests/test-no-work-prelaunch-skip.sh` to reproduce the #4044 false classification path.

## Root cause
`pulse-dispatch-worker-launch.sh::_dlw_canary_preflight` can return `rc=2` before worktree pre-creation with the log reason `worker canary preflight failed before worktree pre-creation; will retry next cycle`. Older stale-recovery / fast-fail paths could later forward that launch-control reason into `worker-lifecycle-common.sh::_log_no_work_skip_escalation` with `crash_type=no_work`, where the function only checked `failure_count >= NO_WORK_NMR_THRESHOLD` and fired `_apply_no_work_nmr_breaker`. That treated a pre-worker-launch skip as actionable repeated worker no-work even though no worker reached the brief.

## Testing
- `shellcheck .agents/scripts/worker-lifecycle-common.sh .agents/scripts/tests/test-no-work-prelaunch-skip.sh`
- `bash .agents/scripts/tests/test-no-work-prelaunch-skip.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`

Resolves awardsapp/awardsapp#4044

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 123,537 tokens on this as a headless worker.


For #4044 in awardsapp/awardsapp.
