### PR TITLE
GH#22744: align git safety hook branch self-test

### DIFF
--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -131,8 +131,11 @@ DESTRUCTIVE_PATTERNS = [
 
 # Patterns that are safe even if they match above (allowlist)
 SAFE_PATTERNS = [
-    r"git\s+checkout\s+-b\s+",  # Creating new branch
-    r"git\s+checkout\s+--orphan\s+",  # Creating orphan branch
+    # Branch creation is only safe inside linked worktrees. The canonical
+    # workspace branch-switch guard runs before this allowlist and denies these
+    # commands there; linked worktrees skip that guard and keep these safe.
+    r"git\s+checkout\s+-b\s+",  # Creating new branch in linked worktree
+    r"git\s+checkout\s+--orphan\s+",  # Creating orphan branch in linked worktree
     # Unstaging is safe, BUT NOT if --worktree/-W is also present
     r"git\s+restore\s+--staged\s+(?!.*--worktree)(?!.*-W\b)",
     r"git\s+restore\s+-S\s+(?!.*--worktree)(?!.*-W\b)",
@@ -358,8 +361,16 @@ def _build_canonical_off_default_deny(
     }
 
 
-TAKES_BRANCH_ARG = {"-b", "-B", "-c", "-C", "--create", "--force-create"}
-OPTION_WITH_VALUE = {"-t", "--track", "--orphan", "--conflict", "--pathspec-from-file"}
+TAKES_BRANCH_ARG = {
+    "-b",
+    "-B",
+    "-c",
+    "-C",
+    "--create",
+    "--force-create",
+    "--orphan",
+}
+OPTION_WITH_VALUE = {"-t", "--track", "--conflict", "--pathspec-from-file"}
 
 
 def _split_git_switch_command(command: str) -> tuple[str, list[str]]:

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -1271,12 +1271,30 @@ test_hook() {
 
 	local pass=0
 	local fail=0
+	local test_root=""
+	test_root=$(mktemp -d) || return 1
+	test_root=$(cd "$test_root" && pwd -P) || return 1
+	git -C "$test_root" init -b main >/dev/null 2>&1 || {
+		git -C "$test_root" init >/dev/null 2>&1
+		git -C "$test_root" checkout -b main >/dev/null 2>&1
+	}
+	git -C "$test_root" config user.name "Aidevops Hook Test"
+	git -C "$test_root" config user.email "test@example.com"
+	git -C "$test_root" config commit.gpgsign false
+	printf 'seed\n' >"${test_root}/README.md"
+	git -C "$test_root" add README.md >/dev/null 2>&1
+	git -C "$test_root" commit -m "test: seed hook self-test" >/dev/null 2>&1
+
+	local linked_worktree="${test_root}/linked-wt"
+	git -C "$test_root" worktree add "$linked_worktree" -b feature/hook-linked-test >/dev/null 2>&1
 
 	# Test blocked commands
 	local -a blocked_cmds=(
 		"git checkout -- test.txt"
 		"git reset --hard"
 		"git clean -f"
+		"git checkout -b new-branch"
+		"git checkout --orphan gh-pages"
 		"git push --force origin main"
 		"git push -f origin main"
 		"git branch -D old-branch"
@@ -1289,7 +1307,7 @@ test_hook() {
 
 	for cmd in "${blocked_cmds[@]}"; do
 		local result
-		result=$(echo "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
+		result=$(cd "$test_root" && printf '%s\n' "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
 		if echo "$result" | grep -q "permissionDecision.*deny" 2>/dev/null; then
 			pass=$((pass + 1))
 		else
@@ -1301,7 +1319,6 @@ test_hook() {
 	# Test allowed commands
 	local -a allowed_cmds=(
 		"git status"
-		"git checkout -b new-branch"
 		"git restore --staged file.txt"
 		"git clean -fn"
 		"git clean --dry-run"
@@ -1313,7 +1330,7 @@ test_hook() {
 
 	for cmd in "${allowed_cmds[@]}"; do
 		local result
-		result=$(echo "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
+		result=$(cd "$test_root" && printf '%s\n' "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
 		if [[ -z "$result" ]]; then
 			pass=$((pass + 1))
 		else
@@ -1321,6 +1338,25 @@ test_hook() {
 			fail=$((fail + 1))
 		fi
 	done
+
+	local -a linked_allowed_cmds=(
+		"git checkout -b linked-branch"
+		"git checkout --orphan linked-pages"
+	)
+
+	for cmd in "${linked_allowed_cmds[@]}"; do
+		local result
+		result=$(cd "$linked_worktree" && printf '%s\n' "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
+		if [[ -z "$result" ]]; then
+			pass=$((pass + 1))
+		else
+			print_error "  FAIL: should allow in linked worktree: $cmd"
+			fail=$((fail + 1))
+		fi
+	done
+
+	git -C "$test_root" worktree remove "$linked_worktree" >/dev/null 2>&1 || rm -rf "$linked_worktree"
+	rm -rf "$test_root"
 
 	if [[ "$fail" -eq 0 ]]; then
 		print_success "All $pass tests passed"

--- a/.agents/scripts/install-hooks.sh
+++ b/.agents/scripts/install-hooks.sh
@@ -74,9 +74,10 @@ run_case() {
 	local description="$1"
 	local input_json="$2"
 	local expect_blocked="$3"
+	local run_cwd="${4:-${_TEST_CANONICAL_CWD:-$PWD}}"
 
 	local result
-	result=$(echo "${input_json}" | python3 "${_TEST_HOOK_PATH}" 2>/dev/null) || true
+	result=$(cd "${run_cwd}" && printf '%s\n' "${input_json}" | python3 "${_TEST_HOOK_PATH}" 2>/dev/null) || true
 
 	local is_blocked="false"
 	if echo "${result}" | grep -q '"permissionDecision".*"deny"' 2>/dev/null; then
@@ -139,10 +140,10 @@ _run_blocked_cases() {
 _run_allowed_cases() {
 	run_case "git status (safe)" \
 		'{"tool_name":"Bash","tool_input":{"command":"git status"}}' "false"
-	run_case "git checkout -b new-branch (safe)" \
-		'{"tool_name":"Bash","tool_input":{"command":"git checkout -b new-branch"}}' "false"
-	run_case "git checkout --orphan gh-pages (safe)" \
-		'{"tool_name":"Bash","tool_input":{"command":"git checkout --orphan gh-pages"}}' "false"
+	run_case "git checkout -b new-branch (blocked in canonical workspace)" \
+		'{"tool_name":"Bash","tool_input":{"command":"git checkout -b new-branch"}}' "true"
+	run_case "git checkout --orphan gh-pages (blocked in canonical workspace)" \
+		'{"tool_name":"Bash","tool_input":{"command":"git checkout --orphan gh-pages"}}' "true"
 	run_case "git restore --staged file.txt (safe)" \
 		'{"tool_name":"Bash","tool_input":{"command":"git restore --staged file.txt"}}' "false"
 	run_case "git clean -n (safe dry run)" \
@@ -172,16 +173,60 @@ _run_allowed_cases() {
 	return 0
 }
 
+# _run_linked_worktree_cases - Verify branch creation remains allowed in linked worktrees.
+_run_linked_worktree_cases() {
+	run_case "git checkout -b linked-branch (safe in linked worktree)" \
+		'{"tool_name":"Bash","tool_input":{"command":"git checkout -b linked-branch"}}' "false" "${_TEST_LINKED_CWD}"
+	run_case "git checkout --orphan linked-pages (safe in linked worktree)" \
+		'{"tool_name":"Bash","tool_input":{"command":"git checkout --orphan linked-pages"}}' "false" "${_TEST_LINKED_CWD}"
+	return 0
+}
+
+# _prepare_test_repo - Create deterministic canonical and linked-worktree contexts.
+_prepare_test_repo() {
+	_TEST_REPO_ROOT=$(mktemp -d) || return 1
+	_TEST_REPO_ROOT=$(cd "${_TEST_REPO_ROOT}" && pwd -P) || return 1
+	git -C "${_TEST_REPO_ROOT}" init -b main >/dev/null 2>&1 || {
+		git -C "${_TEST_REPO_ROOT}" init >/dev/null 2>&1
+		git -C "${_TEST_REPO_ROOT}" checkout -b main >/dev/null 2>&1
+	}
+	git -C "${_TEST_REPO_ROOT}" config user.name "Aidevops Hook Test"
+	git -C "${_TEST_REPO_ROOT}" config user.email "test@example.com"
+	git -C "${_TEST_REPO_ROOT}" config commit.gpgsign false
+	printf 'seed\n' >"${_TEST_REPO_ROOT}/README.md"
+	git -C "${_TEST_REPO_ROOT}" add README.md >/dev/null 2>&1
+	git -C "${_TEST_REPO_ROOT}" commit -m "test: seed hook self-test" >/dev/null 2>&1
+	_TEST_CANONICAL_CWD="${_TEST_REPO_ROOT}"
+	_TEST_LINKED_CWD="${_TEST_REPO_ROOT}/linked-wt"
+	git -C "${_TEST_REPO_ROOT}" worktree add "${_TEST_LINKED_CWD}" -b feature/hook-linked-test >/dev/null 2>&1
+	return 0
+}
+
+# _cleanup_test_repo - Remove deterministic test contexts.
+_cleanup_test_repo() {
+	if [[ -n "${_TEST_REPO_ROOT:-}" && -d "${_TEST_REPO_ROOT}" ]]; then
+		git -C "${_TEST_REPO_ROOT}" worktree remove "${_TEST_LINKED_CWD}" >/dev/null 2>&1 || rm -rf "${_TEST_LINKED_CWD}"
+		rm -rf "${_TEST_REPO_ROOT}"
+	fi
+	return 0
+}
+
 run_test() {
 	local hook_path="${1:-${HOOK_SOURCE}}"
 	_TEST_HOOK_PATH="${hook_path}"
 	_TEST_PASS=0
 	_TEST_FAIL=0
+	_TEST_REPO_ROOT=""
+	_TEST_CANONICAL_CWD=""
+	_TEST_LINKED_CWD=""
 
 	printf "${BLUE}Testing git_safety_guard.py...${NC}\n\n"
 
+	_prepare_test_repo || return 1
 	_run_blocked_cases
 	_run_allowed_cases
+	_run_linked_worktree_cases
+	_cleanup_test_repo
 
 	printf "\n${BLUE}Results: ${GREEN}%d passed${NC}, ${RED}%d failed${NC}\n" \
 		"${_TEST_PASS}" "${_TEST_FAIL}"

--- a/.agents/scripts/tests/test-git-safety-guard.sh
+++ b/.agents/scripts/tests/test-git-safety-guard.sh
@@ -282,7 +282,7 @@ test_bash_destructive_commands_blocked() {
 		passed=1
 	fi
 
-	# git checkout -b in the canonical workspace should be denied; branch work
+	# Branch creation in the canonical workspace should be denied; branch work
 	# must happen in a linked worktree.
 	json='{"tool_name":"Bash","tool_input":{"command":"git checkout -b feature/new-branch"}}'
 	output=$(run_hook "$TEST_ROOT" "$json") || true
@@ -291,11 +291,26 @@ test_bash_destructive_commands_blocked() {
 		passed=1
 	fi
 
+	json='{"tool_name":"Bash","tool_input":{"command":"git checkout --orphan gh-pages"}}'
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+	if ! hook_is_deny "$output" "Canonical workspace cannot switch"; then
+		print_result "git checkout --orphan blocked in canonical workspace" 1 "output=${output}"
+		passed=1
+	fi
+
 	local worktree_path="${TEST_ROOT}/bash-linked-wt"
 	git -C "$TEST_ROOT" worktree add "$worktree_path" -b feature/bash-linked-base >/dev/null 2>&1
+	json='{"tool_name":"Bash","tool_input":{"command":"git checkout -b feature/new-branch"}}'
 	output=$(run_hook "$worktree_path" "$json") || true
 	if [[ -n "$output" ]]; then
 		print_result "git checkout -b allowed inside linked worktree" 1 "output=${output}"
+		passed=1
+	fi
+
+	json='{"tool_name":"Bash","tool_input":{"command":"git checkout --orphan gh-pages"}}'
+	output=$(run_hook "$worktree_path" "$json") || true
+	if [[ -n "$output" ]]; then
+		print_result "git checkout --orphan allowed inside linked worktree" 1 "output=${output}"
 		passed=1
 	fi
 	git -C "$TEST_ROOT" worktree remove "$worktree_path" 2>/dev/null || rm -rf "$worktree_path"


### PR DESCRIPTION
## Summary

Updated git safety guard parsing and hook self-tests so canonical branch creation is denied while linked worktree branch creation remains allowed.

## Files Changed

.agents/hooks/git_safety_guard.py,.agents/scripts/install-hooks-helper.sh,.agents/scripts/install-hooks.sh,.agents/scripts/tests/test-git-safety-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./setup.sh --non-interactive; .agents/scripts/tests/test-git-safety-guard.sh; python3 -m py_compile .agents/hooks/git_safety_guard.py; shellcheck .agents/scripts/install-hooks.sh .agents/scripts/install-hooks-helper.sh .agents/scripts/tests/test-git-safety-guard.sh; .agents/scripts/install-hooks.sh --test; .agents/scripts/install-hooks-helper.sh test

Resolves #22744


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 13m and 92,501 tokens on this as a headless worker.