### PR TITLE
GH#22752: fix: skip no_work NMR for prelaunch skips

### DIFF
--- a/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
+++ b/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#4044 / GH#22752.
+#
+# A canary or worktree-precreation launch-control skip can be reported as a
+# no_work reason before a worker process reaches the issue brief. That reason
+# must not trip the t2769 no_work NMR breaker, while genuine post-launch no_work
+# failures still use the existing threshold behaviour.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+
+# shellcheck source=../worker-lifecycle-common.sh
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+BREAKER_CALLS=0
+COMMENT_CALLS=0
+LAST_BREAKER_PAYLOAD=""
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+reset_observations() {
+	BREAKER_CALLS=0
+	COMMENT_CALLS=0
+	LAST_BREAKER_PAYLOAD=""
+	return 0
+}
+
+_count_issue_comments_containing_marker() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	: "$issue_number" "$repo_slug" "$marker"
+	printf '0'
+	return 0
+}
+
+_apply_no_work_nmr_breaker() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_count="$3"
+	local nmr_threshold="$4"
+	local reason="$5"
+	BREAKER_CALLS=$((BREAKER_CALLS + 1))
+	LAST_BREAKER_PAYLOAD="${issue_number}|${repo_slug}|${failure_count}|${nmr_threshold}|${reason}"
+	return 0
+}
+
+gh_issue_comment() {
+	COMMENT_CALLS=$((COMMENT_CALLS + 1))
+	return 0
+}
+
+test_prelaunch_reason_skips_nmr_breaker() {
+	reset_observations
+	local output=""
+	output=$(_log_no_work_skip_escalation \
+		"4003" "awardsapp/awardsapp" "3" \
+		"worker canary preflight failed before worktree pre-creation; will retry next cycle" 2>&1)
+
+	if [[ "$BREAKER_CALLS" -ne 0 ]]; then
+		fail "prelaunch no_work skip does not apply NMR" "breaker payload: ${LAST_BREAKER_PAYLOAD}"
+		return 0
+	fi
+	if [[ "$COMMENT_CALLS" -ne 0 ]]; then
+		fail "prelaunch no_work skip does not post diagnostic comment" "comment calls: ${COMMENT_CALLS}"
+		return 0
+	fi
+	if [[ "$output" != *"NMR breaker skipped for pre-launch reason"* ]]; then
+		fail "prelaunch no_work skip logs audit line" "output: ${output}"
+		return 0
+	fi
+	pass "prelaunch no_work skip bypasses NMR breaker"
+	return 0
+}
+
+test_postlaunch_noop_still_applies_nmr_breaker() {
+	reset_observations
+	_log_no_work_skip_escalation \
+		"4003" "awardsapp/awardsapp" "3" \
+		"worker_noop_zero_output" >/dev/null 2>&1
+
+	if [[ "$BREAKER_CALLS" -ne 1 ]]; then
+		fail "postlaunch no_work still applies NMR" "breaker calls: ${BREAKER_CALLS}"
+		return 0
+	fi
+	if [[ "$LAST_BREAKER_PAYLOAD" != "4003|awardsapp/awardsapp|3|3|worker_noop_zero_output" ]]; then
+		fail "postlaunch no_work breaker payload is preserved" "payload: ${LAST_BREAKER_PAYLOAD}"
+		return 0
+	fi
+	pass "postlaunch no_work still applies NMR breaker"
+	return 0
+}
+
+test_prelaunch_reason_skips_nmr_breaker
+test_postlaunch_noop_still_applies_nmr_breaker
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -962,6 +962,33 @@ _Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker is reco
 	return 0
 }
 
+#######################################
+# Detect no_work reasons that happened before a worker launch.
+#
+# These launch-control skips are not evidence that a worker reached the brief,
+# so they must not participate in the t2769 per-issue no_work NMR breaker.
+# Legitimate post-launch no_work reasons (for example worker_noop_zero_output)
+# still flow through the existing breaker path unchanged.
+#
+# Args: $1=reason
+# Returns: 0 when reason is a pre-worker-launch skip, 1 otherwise.
+#######################################
+_no_work_reason_is_prelaunch_skip() {
+	local reason="${1:-}"
+
+	case "$reason" in
+	*"before worktree pre-creation"* | \
+	*"worktree pre-creation failed"* | \
+	*"pre-worker-launch"* | \
+	*"pre-launch"*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 _log_no_work_skip_escalation() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -972,6 +999,12 @@ _log_no_work_skip_escalation() {
 	[[ -n "$repo_slug" ]] || return 0
 
 	local nmr_threshold="${NO_WORK_NMR_THRESHOLD:-3}"
+
+	if _no_work_reason_is_prelaunch_skip "$reason"; then
+		printf '[worker-lifecycle][t2769] no_work NMR breaker skipped for pre-launch reason on #%s (%s, count=%s): %s\n' \
+			"$issue_number" "$repo_slug" "$failure_count" "$reason" >&2 || true
+		return 0
+	fi
 
 	# Circuit-breaker path (t2769): when failure_count >= threshold,
 	# apply NMR + file root-cause meta-issue. Auto-approval preserves NMR


### PR DESCRIPTION
## Summary

Added a pre-worker-launch reason guard so canary and worktree-precreation skips do not trip the no_work NMR breaker, while post-launch no_work failures still use the existing t2769 threshold path.

## Files Changed

.agents/scripts/tests/test-no-work-prelaunch-skip.sh,.agents/scripts/worker-lifecycle-common.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worker-lifecycle-common.sh .agents/scripts/tests/test-no-work-prelaunch-skip.sh; bash .agents/scripts/tests/test-no-work-prelaunch-skip.sh; bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh; bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh; .agents/scripts/linters-local.sh timed out after 240s during Secretlint after earlier gates passed

Resolves #22752


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 44,904 tokens on this as a headless worker.