### PR TITLE
GH#22761: trim fallback greeting version

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -73,6 +73,18 @@ describe("token cost advisory threshold", () => {
     assert.match(output.system[0], /We're running aidevops v3\.14\.23\./);
   });
 
+  test("trims fallback aidevops version whitespace", async () => {
+    const { hooks } = createHooks({
+      readIfExists: (path) => path.endsWith("VERSION") ? "3.14.23\r\n" : "",
+    });
+    const output = { system: ["base system prompt"] };
+
+    await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.match(output.system[0], /We're running aidevops v3\.14\.23\./);
+    assert.doesNotMatch(output.system[0], /v3\.14\.23\r/);
+  });
+
   test("keeps startup advisory cache lines out of chat instructions", async () => {
     const { hooks } = createHooks({
       readIfExists: (path) => path.endsWith("session-greeting.txt")

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -195,7 +195,7 @@ function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
   const cacheLines = readIfExists(cachePath).split("\n").map((line) => line.trim()).filter(Boolean);
   const cacheLine = cacheLines[0] || "";
   const cacheMatch = cacheLine.match(/^aidevops v(\S+) running in (.+?) v(\S+)(?:\s|$)/);
-  const version = cacheMatch?.[1] || readIfExists(join(agentsDir, "VERSION")).split("\n")[0] || "X";
+  const version = cacheMatch?.[1] || readIfExists(join(agentsDir, "VERSION")).trim().split("\n")[0] || "X";
   const runtime = cacheMatch?.[2] || "OpenCode";
   const runtimeVersion = cacheMatch?.[3];
   const versionLine = runtimeVersion


### PR DESCRIPTION
## Summary

Trim whitespace from the VERSION-file fallback used by the OpenCode session-start greeting and add regression coverage for CRLF input.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs,.agents/plugins/opencode-aidevops/ttsr.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs; node --test .agents/plugins/opencode-aidevops/tests/*.mjs; npm run typecheck attempted but repository has no root tsconfig, so tsc exits with help text.

Resolves #22761


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 87,476 tokens on this as a headless worker.