### PR TITLE
GH#22762: clarify ops comment body construction

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -237,13 +237,13 @@ _post_claim() {
 		opencode_version="${opencode_version:-$AIDEVOPS_UNKNOWN_VERSION}"
 	fi
 
-	local body
-	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version} opencode_version=${opencode_version}"
+	local machine_readable_part="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version} opencode_version=${opencode_version}"
 	if [[ -n "$reason_fields" ]]; then
-		body+=" ${reason_fields}"
+		machine_readable_part+=" ${reason_fields}"
 	fi
-	body+="
+
+	local body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+${machine_readable_part}
 <!-- ops:end -->"
 
 	local comment_id

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -118,7 +118,7 @@ ${machine_readable_part}
 	# set by authoritative paths. Defensive skip if origin:interactive.
 	# Non-fatal: failure does not block the release comment path.
 	if declare -F clear_active_status_on_release >/dev/null 2>&1; then
-		clear_active_status_on_release "$issue_number" "$repo_slug" "$(whoami)" \
+		clear_active_status_on_release "$issue_number" "$repo_slug" "$runner_name" \
 			|| print_warning "Failed to clear active status on #${issue_number} (non-fatal)"
 	fi
 	return 0


### PR DESCRIPTION
## Summary

Refactored dispatch claim comment assembly to separate machine-readable fields from ops wrapper text, and reused the resolved runner name when releasing headless claims.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/headless-runtime-failure.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/headless-runtime-failure.sh; .agents/scripts/tests/test-dispatch-claim-helper.sh; .agents/scripts/tests/test-headless-runtime-failure-classification.sh; .agents/scripts/linters-local.sh reached Secretlint and timed out after 240s after earlier gates passed

Resolves #22762


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 8m and 50,685 tokens on this as a headless worker.