### PR TITLE
GH#22758: harden TODO sync recovery

### DIFF
--- a/.agents/scripts/pulse-canonical-recovery.sh
+++ b/.agents/scripts/pulse-canonical-recovery.sh
@@ -205,9 +205,6 @@ _pcr_normalise_todo_sync_line() {
 	local line="$1"
 	local normalised="$line"
 	local field=""
-	local words=()
-	local word=""
-	local joined=""
 
 	case "$normalised" in
 		'- [ ] '*) normalised="- [?] ${normalised#'- [ ] '}" ;;
@@ -221,16 +218,20 @@ _pcr_normalise_todo_sync_line() {
 		done
 	done
 
-	read -r -a words <<<"$normalised"
-	for word in "${words[@]}"; do
-		if [[ -z "$joined" ]]; then
-			joined="$word"
-		else
-			joined="${joined} ${word}"
-		fi
+	# Keep this hot-path normalisation pure Bash: TODO sync diffs can contain
+	# many task lines, and spawning sed/awk here would multiply process churn.
+	normalised="${normalised//$'\t'/ }"
+	while [[ "$normalised" == *"  "* ]]; do
+		normalised="${normalised//  / }"
+	done
+	while [[ "$normalised" == " "* ]]; do
+		normalised="${normalised# }"
+	done
+	while [[ "$normalised" == *" " ]]; do
+		normalised="${normalised% }"
 	done
 
-	printf '%s\n' "$joined"
+	printf '%s\n' "$normalised"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-canonical-recovery.sh
+++ b/.agents/scripts/tests/test-canonical-recovery.sh
@@ -366,7 +366,44 @@ git -C "$CANON_DIR" diff --quiet -- TODO.md \
 	|| print_result "todo sync: canonical refreshed to origin HEAD" 1
 
 # =============================================================================
-# Test 3c: human/unknown TODO.md edits block without stashing or discarding.
+# Test 3c: generated TODO.md reset failure files advisory with diagnostics.
+# =============================================================================
+
+make_repo_pair "todo-reset-failure"
+add_todo_to_origin_and_pull "$ORIGIN_DIR" "$CANON_DIR"
+advance_origin "$ORIGIN_DIR"
+printf '%s\n' '- [x] t123 sync metadata fixture #auto-dispatch logged:2026-01-01 pr:#42 completed:2026-01-02' >"${CANON_DIR}/TODO.md"
+reset_call_logs
+reset_stderr="${TEST_ROOT}/todo-reset-failure.stderr"
+
+git() {
+	local arg1="${1:-}" arg2="${2:-}" arg3="${3:-}" arg4="${4:-}"
+	if [[ "$arg1" == "-C" && "$arg2" == "$CANON_DIR" && "$arg3" == "reset" && "$arg4" == "-q" ]]; then
+		printf '%s\n' 'simulated reset failure' >&2
+		return 1
+	fi
+	command git "$@"
+	return $?
+}
+
+if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>"$reset_stderr"; then
+	print_result "todo reset failure: recovery blocks" 1 "unexpected success"
+else
+	print_result "todo reset failure: recovery blocks" 0
+fi
+unset -f git
+grep -q 'simulated reset failure' "$reset_stderr" \
+	&& print_result "todo reset failure: stderr remains visible" 0 \
+	|| print_result "todo reset failure: stderr remains visible" 1
+grep -q 'todo-sync-reset-failed' "$AUDIT_CALL_LOG" \
+	&& print_result "todo reset failure: audit records failure" 0 \
+	|| print_result "todo reset failure: audit records failure" 1
+[[ -f "$(advisory_file_for "$CANON_DIR")" ]] \
+	&& print_result "todo reset failure: advisory filed" 0 \
+	|| print_result "todo reset failure: advisory filed" 1
+
+# =============================================================================
+# Test 3d: human/unknown TODO.md edits block without stashing or discarding.
 # =============================================================================
 
 make_repo_pair "todo-human"


### PR DESCRIPTION
## Summary

Optimised TODO sync diff normalisation to stay on the pure-Bash hot path and added regression coverage proving reset failures preserve stderr, audit the failure, and file an advisory.

## Files Changed

.agents/scripts/pulse-canonical-recovery.sh,.agents/scripts/tests/test-canonical-recovery.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-canonical-recovery.sh .agents/scripts/tests/test-canonical-recovery.sh; bash .agents/scripts/tests/test-canonical-recovery.sh (65 tests, 0 failed); .agents/scripts/linters-local.sh reached existing Sonar/Qlty/string-literal/FD-lock/parity gates before timing out in secretlint at 240s

Resolves #22758


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 9m and 46,002 tokens on this as a headless worker.