### PR TITLE
GH#22757: lock startup greeting prompt wording

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -85,7 +85,7 @@ describe("token cost advisory threshold", () => {
     assert.doesNotMatch(output.system[0], /v3\.14\.23\r/);
   });
 
-  test("keeps startup advisory cache lines out of chat instructions", async () => {
+  test("keeps startup advisory messages out of chat instructions", async () => {
     const { hooks } = createHooks({
       readIfExists: (path) => path.endsWith("session-greeting.txt")
         ? [
@@ -101,6 +101,7 @@ describe("token cost advisory threshold", () => {
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
     assert.match(output.system[0], /Do not include startup status or advisory messages in chat/);
+    assert.doesNotMatch(output.system[0], /cache lines/);
     assert.doesNotMatch(output.system[0], /\[SECURITY ADVISORY\] Rotate test credentials/);
     assert.doesNotMatch(output.system[0], /\[WARN\] Pulse stalled for 12 minutes/);
     assert.doesNotMatch(output.system[0], /Security: all protections active/);
@@ -120,6 +121,7 @@ describe("token cost advisory threshold", () => {
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
     assert.match(output.system[0], /do not add any additional salutations, greetings, introductory questions, or equivalent help prompts/);
+    assert.doesNotMatch(output.system[0], /How can I help you\?/);
   });
 
   test("does not inject session greeting order in headless sessions", async () => {


### PR DESCRIPTION
## Summary
- Adds regression coverage for OpenCode startup greeting instructions so ambiguous \"cache lines\" wording stays out of chat guidance.
- Locks the salutation-only launch instruction against synonymous extra help prompts.

## Testing
- npm test in .agents/plugins/opencode-aidevops: passed (204 tests)
- .agents/scripts/linters-local.sh: SonarCloud/String Literals/FD lock/ShellCheck RC gates passed, then Secretlint exceeded bounded 120s and 240s timeouts
- npm run typecheck: blocked by repository-wide TypeScript configuration; after installing local dev dependencies, tsc --noEmit exits 1 because no tsconfig/input files are present

## Runtime Testing
- self-assessed: prompt/test-only regression coverage; no runtime surface required

Resolves #22757


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 12m and 84,387 tokens on this as a headless worker.