### PR TITLE
fix: skip launch preflight fast-fail accrual

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -614,6 +614,16 @@ _report_failure_to_fast_fail() {
 		return 0
 	fi
 
+	# Launch/preflight aborts happen before a worker reaches the brief. They are
+	# useful launch diagnostics, but they must not accrue as per-issue fast-fail
+	# / no_work circuit-breaker evidence.
+	if declare -F _worker_failure_reason_is_launch_preflight >/dev/null 2>&1; then
+		if _worker_failure_reason_is_launch_preflight "$reason"; then
+			print_info "[fast-fail] skipped launch/preflight failure #${issue_number} (${repo_slug}) reason=${reason}"
+			return 0
+		fi
+	fi
+
 	local state_file="${HOME}/.aidevops/.agent-workspace/supervisor/fast-fail-counter.json"
 	local state_dir
 	state_dir=$(dirname "$state_file")

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -376,6 +376,17 @@ _fast_fail_record_locked() {
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 
+	# Pre-launch/preflight failures (for example worker_launch_rc_2 and canary
+	# preflight aborts) do not prove a worker reached the issue brief. Keep them
+	# out of the per-issue fast-fail state so they cannot cascade into no_work or
+	# stale_timeout circuit-breaker trips.
+	if declare -F _worker_failure_reason_is_launch_preflight >/dev/null 2>&1; then
+		if _worker_failure_reason_is_launch_preflight "$reason"; then
+			echo "[pulse-wrapper] fast_fail_record: #${issue_number} (${repo_slug}) skipped launch/preflight reason=${reason}" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+
 	local key now state
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	now=$(date +%s)

--- a/.agents/scripts/tests/test-canonical-recovery.sh
+++ b/.agents/scripts/tests/test-canonical-recovery.sh
@@ -376,22 +376,27 @@ printf '%s\n' '- [x] t123 sync metadata fixture #auto-dispatch logged:2026-01-01
 reset_call_logs
 reset_stderr="${TEST_ROOT}/todo-reset-failure.stderr"
 
-git() {
-	local arg1="${1:-}" arg2="${2:-}" arg3="${3:-}" arg4="${4:-}"
-	if [[ "$arg1" == "-C" && "$arg2" == "$CANON_DIR" && "$arg3" == "reset" && "$arg4" == "-q" ]]; then
-		printf '%s\n' 'simulated reset failure' >&2
-		return 1
-	fi
-	command git "$@"
-	return $?
-}
+REAL_GIT_BIN=$(command -v git)
+GIT_STUB_DIR="${TEST_ROOT}/git-reset-failure-stub"
+mkdir -p "$GIT_STUB_DIR"
+cat >"${GIT_STUB_DIR}/git" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "-C" && "\${2:-}" == "$CANON_DIR" && "\${3:-}" == "reset" && "\${4:-}" == "-q" ]]; then
+	printf '%s\n' 'simulated reset failure' >&2
+	exit 1
+fi
+exec "$REAL_GIT_BIN" "\$@"
+STUB
+chmod +x "${GIT_STUB_DIR}/git"
+OLD_PATH="$PATH"
+PATH="${GIT_STUB_DIR}:${PATH}"
 
 if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>"$reset_stderr"; then
 	print_result "todo reset failure: recovery blocks" 1 "unexpected success"
 else
 	print_result "todo reset failure: recovery blocks" 0
 fi
-unset -f git
+PATH="$OLD_PATH"
 grep -q 'simulated reset failure' "$reset_stderr" \
 	&& print_result "todo reset failure: stderr remains visible" 0 \
 	|| print_result "todo reset failure: stderr remains visible" 1

--- a/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
+++ b/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
@@ -16,12 +16,18 @@ SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
 
 # shellcheck source=../worker-lifecycle-common.sh
 source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=../pulse-fast-fail.sh
+source "${SCRIPTS_DIR}/pulse-fast-fail.sh"
 
 TESTS_RUN=0
 TESTS_FAILED=0
 BREAKER_CALLS=0
 COMMENT_CALLS=0
 LAST_BREAKER_PAYLOAD=""
+TMP_DIR="$(mktemp -d -t no-work-prelaunch.XXXXXX)" || exit 1
+trap 'rm -rf "$TMP_DIR"' EXIT
+export LOGFILE="${TMP_DIR}/pulse.log"
+export FAST_FAIL_STATE_FILE="${TMP_DIR}/fast-fail-counter.json"
 
 pass() {
 	local name="$1"
@@ -95,6 +101,47 @@ test_prelaunch_reason_skips_nmr_breaker() {
 	return 0
 }
 
+test_worker_launch_rc_2_skips_nmr_breaker() {
+	reset_observations
+	local output=""
+	output=$(_log_no_work_skip_escalation \
+		"4003" "awardsapp/awardsapp" "3" \
+		"dispatch_aborted:worker_launch_rc_2" 2>&1)
+
+	if [[ "$BREAKER_CALLS" -ne 0 ]]; then
+		fail "worker_launch_rc_2 skip does not apply NMR" "breaker payload: ${LAST_BREAKER_PAYLOAD}"
+		return 0
+	fi
+	if [[ "$output" != *"NMR breaker skipped for pre-launch reason"* ]]; then
+		fail "worker_launch_rc_2 skip logs audit line" "output: ${output}"
+		return 0
+	fi
+	pass "worker_launch_rc_2 bypasses no_work NMR breaker"
+	return 0
+}
+
+test_launch_preflight_reason_skips_fast_fail_state() {
+	reset_observations
+	: >"$LOGFILE"
+	printf '{"awardsapp/awardsapp/4003":{"count":2,"ts":1,"reason":"prior","retry_after":1,"backoff_secs":600}}\n' >"$FAST_FAIL_STATE_FILE"
+
+	_fast_fail_record_locked "4003" "awardsapp/awardsapp" \
+		"worker_launch_rc_2" "anthropic" "no_work"
+
+	local count=""
+	count=$(jq -r '."awardsapp/awardsapp/4003".count' "$FAST_FAIL_STATE_FILE" 2>/dev/null) || count=""
+	if [[ "$count" != "2" ]]; then
+		fail "launch/preflight fast-fail skip preserves counter" "count: ${count:-unset}"
+		return 0
+	fi
+	if ! grep -q 'skipped launch/preflight reason=worker_launch_rc_2' "$LOGFILE" 2>/dev/null; then
+		fail "launch/preflight fast-fail skip logs reason" "log: $(tr '\n' ' ' <"$LOGFILE")"
+		return 0
+	fi
+	pass "launch/preflight failures do not accrue fast-fail state"
+	return 0
+}
+
 test_postlaunch_noop_still_applies_nmr_breaker() {
 	reset_observations
 	_log_no_work_skip_escalation \
@@ -114,6 +161,8 @@ test_postlaunch_noop_still_applies_nmr_breaker() {
 }
 
 test_prelaunch_reason_skips_nmr_breaker
+test_worker_launch_rc_2_skips_nmr_breaker
+test_launch_preflight_reason_skips_fast_fail_state
 test_postlaunch_noop_still_applies_nmr_breaker
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -963,7 +963,8 @@ _Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker is reco
 }
 
 #######################################
-# Detect no_work reasons that happened before a worker launch.
+# Detect failures that happened before a worker launch or during launch
+# preflight.
 #
 # These launch-control skips are not evidence that a worker reached the brief,
 # so they must not participate in the t2769 per-issue no_work NMR breaker.
@@ -971,14 +972,21 @@ _Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker is reco
 # still flow through the existing breaker path unchanged.
 #
 # Args: $1=reason
-# Returns: 0 when reason is a pre-worker-launch skip, 1 otherwise.
+# Returns: 0 when reason is a pre-worker-launch/preflight skip, 1 otherwise.
 #######################################
-_no_work_reason_is_prelaunch_skip() {
+_worker_failure_reason_is_launch_preflight() {
 	local reason="${1:-}"
 
 	case "$reason" in
+	worker_launch_rc_2 | \
+	dispatch_aborted:worker_launch_rc_2 | \
+	canary_preflight | \
+	*"canary preflight failed"* | \
 	*"before worktree pre-creation"* | \
 	*"worktree pre-creation failed"* | \
+	*"precreation failed"* | \
+	*"predispatch_validator_closed"* | \
+	*"eligibility_gate"* | \
 	*"pre-worker-launch"* | \
 	*"pre-launch"*)
 		return 0
@@ -987,6 +995,12 @@ _no_work_reason_is_prelaunch_skip() {
 		return 1
 		;;
 	esac
+}
+
+_no_work_reason_is_prelaunch_skip() {
+	local reason="${1:-}"
+	_worker_failure_reason_is_launch_preflight "$reason"
+	return $?
 }
 
 _log_no_work_skip_escalation() {


### PR DESCRIPTION
## Summary
- Adds a shared launch/preflight failure classifier for worker launch-control aborts such as worker_launch_rc_2 and canary preflight failures.
- Skips per-issue fast-fail state writes for those pre-launch/preflight reasons in both pulse and headless runtime reporting paths.
- Extends the no_work prelaunch regression test to prove worker_launch_rc_2 does not trip NMR and does not increment fast-fail state.

## Testing
- bash .agents/scripts/tests/test-no-work-prelaunch-skip.sh
- bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
- bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh
- shellcheck .agents/scripts/worker-lifecycle-common.sh .agents/scripts/headless-runtime-failure.sh .agents/scripts/pulse-fast-fail.sh .agents/scripts/tests/test-no-work-prelaunch-skip.sh

Fixes awardsapp/awardsapp#4050


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 7m and 96,012 tokens on this as a headless worker.

For #22774