### PR TITLE
fix: bind zombie reaper to worker ledger repo

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -894,8 +894,9 @@ cleanup_stashes() {
 # workers that are still running after their work is done.
 #
 # Uses the dispatch ledger session keys (issue-{N}) to find the issue
-# number, then checks if a merged PR exists for that issue. If so,
-# sends SIGTERM to the worker process tree.
+# number and the worker's owning repo, then checks if a merged PR exists
+# for that issue in that same repo. If so, sends SIGTERM to the worker
+# process tree.
 #
 # Returns: 0 always (best-effort, never breaks the pulse)
 #######################################
@@ -913,15 +914,31 @@ reap_zombie_workers() {
 		issue_number="${worker_key#issue-}"
 		[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
 
-		# Check dispatch ledger for the repo slug
-		local repo_slug=""
+		# Check dispatch ledger for the live worker's repo slug. Session keys are
+		# issue-number only (issue-{N}), so a repo-less fallback can collide with
+		# a different repository that has the same issue/PR number and kill active
+		# work before the worker reads its brief (t3076 / awardsapp#4081).
+		local repo_slug="" ledger_entry="" ledger_issue="" ledger_pid=""
 		local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 		if [[ -x "$_ledger_helper" ]]; then
-			repo_slug=$("$_ledger_helper" get-repo --session-key "$worker_key" 2>/dev/null) || repo_slug=""
+			ledger_entry=$("$_ledger_helper" check --session-key "$worker_key" 2>/dev/null) || ledger_entry=""
+			if [[ -n "$ledger_entry" ]]; then
+				repo_slug=$(printf '%s' "$ledger_entry" | jq -r '.repo_slug // ""' 2>/dev/null) || repo_slug=""
+				ledger_issue=$(printf '%s' "$ledger_entry" | jq -r '.issue_number // ""' 2>/dev/null) || ledger_issue=""
+				ledger_pid=$(printf '%s' "$ledger_entry" | jq -r '.pid // ""' 2>/dev/null) || ledger_pid=""
+			fi
 		fi
-		# Fallback: check all pulse-enabled repos
 		if [[ -z "$repo_slug" ]]; then
-			repo_slug=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .slug // ""' "$REPOS_JSON" | head -1) || continue
+			echo "[pulse-wrapper] Zombie reap skipped for ${worker_key}: no live ledger repo; refusing repo-less merged-PR lookup" >>"$LOGFILE"
+			continue
+		fi
+		if [[ -n "$ledger_issue" && "$ledger_issue" != "$issue_number" ]]; then
+			echo "[pulse-wrapper] Zombie reap skipped for ${worker_key}: ledger issue ${ledger_issue} does not match session issue ${issue_number}" >>"$LOGFILE"
+			continue
+		fi
+		if [[ -z "$ledger_pid" || ! "$ledger_pid" =~ ^[0-9]+$ ]]; then
+			echo "[pulse-wrapper] Zombie reap skipped for ${worker_key}: no ledger PID; refusing session-key-wide kill" >>"$LOGFILE"
+			continue
 		fi
 		[[ -n "$repo_slug" ]] || continue
 
@@ -932,7 +949,7 @@ reap_zombie_workers() {
 
 		if [[ -n "$merged_pr" ]]; then
 			# Kill the worker process tree
-			worker_pids=$(ps aux | grep "[h]eadless-runtime.*--session-key ${worker_key}" | grep -v grep | awk '{print $2}')
+			worker_pids="$ledger_pid"
 			if [[ -n "$worker_pids" ]]; then
 				echo "[pulse-wrapper] Reaping zombie worker ${worker_key}: PR #${merged_pr} already merged in ${repo_slug}" >>"$LOGFILE"
 				echo "$worker_pids" | xargs kill 2>/dev/null || true

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -893,10 +893,8 @@ cleanup_stashes() {
 # This function runs each pulse cycle (before worker counting) to kill
 # workers that are still running after their work is done.
 #
-# Uses the dispatch ledger session keys (issue-{N}) to find the issue
-# number and the worker's owning repo, then checks if a merged PR exists
-# for that issue in that same repo. If so, sends SIGTERM to the worker
-# process tree.
+# Uses the dispatch ledger session keys (issue-{N}) to bind the issue,
+# repo, and PID before checking for merged PRs and terminating the worker.
 #
 # Returns: 0 always (best-effort, never breaks the pulse)
 #######################################
@@ -904,7 +902,6 @@ reap_zombie_workers() {
 	local reaped=0
 	local worker_pids worker_key issue_number
 
-	# Get unique session keys from active worker processes
 	local session_keys
 	session_keys=$(ps aux | grep '[h]eadless-runtime.*--role worker' | grep -v grep |
 		sed 's/.*--session-key //' | awk '{print $1}' | sort -u) || return 0
@@ -914,10 +911,8 @@ reap_zombie_workers() {
 		issue_number="${worker_key#issue-}"
 		[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
 
-		# Check dispatch ledger for the live worker's repo slug. Session keys are
-		# issue-number only (issue-{N}), so a repo-less fallback can collide with
-		# a different repository that has the same issue/PR number and kill active
-		# work before the worker reads its brief (t3076 / awardsapp#4081).
+		# Session keys are issue-number only, so require the live ledger's repo
+		# and PID to avoid same-number cross-repo PR/issue collisions.
 		local repo_slug="" ledger_entry="" ledger_issue="" ledger_pid=""
 		local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 		if [[ -x "$_ledger_helper" ]]; then
@@ -940,9 +935,6 @@ reap_zombie_workers() {
 			echo "[pulse-wrapper] Zombie reap skipped for ${worker_key}: no ledger PID; refusing session-key-wide kill" >>"$LOGFILE"
 			continue
 		fi
-		[[ -n "$repo_slug" ]] || continue
-
-		# Check if a merged PR exists that closes this issue
 		local merged_pr
 		merged_pr=$(gh pr list --repo "$repo_slug" --state merged --search "closes #${issue_number} OR Closes #${issue_number} OR Resolves #${issue_number} OR resolves #${issue_number}" \
 			--limit 1 --json number --jq '.[0].number // ""' 2>/dev/null) || merged_pr=""

--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -90,7 +90,122 @@ test_orphan_removal_unregisters() {
 	return 0
 }
 
+write_kill_stub() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/kill" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"${KILL_LOG:?}"
+exit 0
+STUB
+	chmod +x "${bin_dir}/kill"
+	return 0
+}
+
+write_ledger_stub() {
+	local scripts_dir="$1"
+	local mode="$2"
+	mkdir -p "$scripts_dir"
+	if [[ "$mode" == "missing" ]]; then
+		cat >"${scripts_dir}/dispatch-ledger-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+	else
+		cat >"${scripts_dir}/dispatch-ledger-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+cmd="${1:-}"
+if [[ "$cmd" == "check" ]]; then
+	printf '%s\n' '{"session_key":"issue-3964","issue_number":"3964","repo_slug":"awardsapp/awardsapp","pid":123,"status":"in-flight"}'
+	exit 0
+fi
+exit 1
+STUB
+	fi
+	chmod +x "${scripts_dir}/dispatch-ledger-helper.sh"
+	return 0
+}
+
+ps() {
+	local subcommand="${1:-}"
+	if [[ "$subcommand" == "aux" ]]; then
+		printf '%s\n' 'runner 123 0.0 0.0 ?? ?? S 0:00 headless-runtime-helper.sh run --role worker --session-key issue-3964 --dir /tmp/wt'
+	fi
+	return 0
+}
+
+gh() {
+	local subcommand="${1:-}"
+	local action="${2:-}"
+	printf '%s\n' "$*" >>"${GH_LOG:?}"
+	if [[ "$subcommand" == "pr" && "$action" == "list" ]]; then
+		printf '%s\n' "${GH_MERGED_PR:-3964}"
+		return 0
+	fi
+	return 1
+}
+
+test_zombie_reaper_requires_ledger_repo() {
+	local original_script_dir="$SCRIPT_DIR"
+	local scripts_dir="${TEST_ROOT}/scripts-no-ledger"
+	local bin_dir="${TEST_ROOT}/bin-no-ledger"
+	local kill_log="${TEST_ROOT}/kill-no-ledger.log"
+	local gh_log="${TEST_ROOT}/gh-no-ledger.log"
+	local old_path="$PATH"
+
+	: >"$kill_log"
+	: >"$gh_log"
+	LOGFILE="${TEST_ROOT}/pulse-no-ledger.log"
+	printf '%s\n' '{"initialized_repos":[{"slug":"marcusquinn/aidevops","pulse":true}]}' >"${TEST_ROOT}/repos.json"
+	REPOS_JSON="${TEST_ROOT}/repos.json"
+	write_ledger_stub "$scripts_dir" "missing"
+	write_kill_stub "$bin_dir"
+
+	SCRIPT_DIR="$scripts_dir"
+	PATH="${bin_dir}:${PATH}"
+	export GH_LOG="$gh_log" KILL_LOG="$kill_log" GH_MERGED_PR="3964"
+	reap_zombie_workers
+	PATH="$old_path"
+	SCRIPT_DIR="$original_script_dir"
+
+	[[ ! -s "$kill_log" ]] || fail "zombie reaper killed a worker without a ledger repo"
+	[[ ! -s "$gh_log" ]] || fail "zombie reaper queried merged PRs without a ledger repo"
+	grep -q 'no live ledger repo' "$LOGFILE" || fail "missing no-ledger skip audit log"
+	pass "zombie reaper refuses repo-less merged-PR lookup"
+	return 0
+}
+
+test_zombie_reaper_uses_ledger_repo_and_pid() {
+	local original_script_dir="$SCRIPT_DIR"
+	local scripts_dir="${TEST_ROOT}/scripts-with-ledger"
+	local bin_dir="${TEST_ROOT}/bin-with-ledger"
+	local kill_log="${TEST_ROOT}/kill-with-ledger.log"
+	local gh_log="${TEST_ROOT}/gh-with-ledger.log"
+	local old_path="$PATH"
+
+	: >"$kill_log"
+	: >"$gh_log"
+	LOGFILE="${TEST_ROOT}/pulse-with-ledger.log"
+	write_ledger_stub "$scripts_dir" "present"
+	write_kill_stub "$bin_dir"
+
+	SCRIPT_DIR="$scripts_dir"
+	PATH="${bin_dir}:${PATH}"
+	export GH_LOG="$gh_log" KILL_LOG="$kill_log" GH_MERGED_PR="5000"
+	reap_zombie_workers
+	PATH="$old_path"
+	SCRIPT_DIR="$original_script_dir"
+
+	grep -Fxq '123' "$kill_log" || fail "zombie reaper did not kill the ledger PID"
+	grep -q -- '--repo awardsapp/awardsapp' "$gh_log" || fail "zombie reaper did not query the ledger repo"
+	grep -q 'PR #5000 already merged in awardsapp/awardsapp' "$LOGFILE" || fail "missing ledger-repo reap audit log"
+	pass "zombie reaper uses ledger repo and PID"
+	return 0
+}
+
 test_current_cwd_skip
 test_orphan_removal_unregisters
+test_zombie_reaper_requires_ledger_repo
+test_zombie_reaper_uses_ledger_repo_and_pid
 
 exit 0


### PR DESCRIPTION
## Summary

- Fixes `.agents/scripts/pulse-cleanup.sh::reap_zombie_workers` so zombie-worker cleanup refuses repo-less merged-PR lookups.
- Binds the cleanup decision to the live dispatch ledger's `repo_slug` and `pid`, preventing same-number issue/PR collisions across repositories.
- Adds regression coverage for both the unsafe no-ledger path and the valid ledger-backed reap path.

## Root cause

`.agents/scripts/pulse-cleanup.sh::reap_zombie_workers` called a non-existent `dispatch-ledger-helper.sh get-repo` command. When that failed, it fell back to the first pulse-enabled repository and searched for merged PRs using the bare issue number. For awardsapp/awardsapp#3964, that matched merged PR #3964 in marcusquinn/aidevops and killed the active awardsapp worker before it could read the brief, feeding the t2769 `no_work` breaker.

## Testing

- `bash .agents/scripts/tests/test-pulse-cleanup-unregister.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-unregister.sh`

Resolves awardsapp/awardsapp#4081
For awardsapp/awardsapp#3964
For #22776

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 13m and 211,949 tokens on this as a headless worker.

