### PR TITLE
fix: stop watchdog killing quiet workers

### DIFF
--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -13,7 +13,8 @@
 #   5. Hard-kill fires regardless of CPU (safety net)
 #   6. pulse-watchdog.sh kill sites emit [lifecycle] lines
 #   7. pulse-dispatch-engine.sh timeout handler emits [lifecycle] line
-#   8. All modified scripts pass ShellCheck
+#   8. worker-watchdog.sh does not auto-kill quiet long-running workers
+#   9. All modified scripts pass ShellCheck
 #
 # Tests are structural — no live worker processes required.
 
@@ -96,6 +97,8 @@ echo ""
 # Test 1: _watchdog_tree_cpu function exists
 #######################################
 watchdog_source=$(< "${SCRIPT_DIR}/worker-activity-watchdog.sh")
+worker_watchdog_source=$(< "${SCRIPT_DIR}/worker-watchdog.sh")
+worker_watchdog_cmd_source=$(< "${SCRIPT_DIR}/worker-watchdog-cmd.sh")
 assert_contains \
 	"1. _watchdog_tree_cpu function exists in worker-activity-watchdog.sh" \
 	"_watchdog_tree_cpu()" \
@@ -174,7 +177,31 @@ assert_contains \
 	"$dispatch_source"
 
 #######################################
-# Test 8: All modified scripts pass ShellCheck
+# Test 8: legacy worker watchdog quiet signals are advisory only
+#######################################
+assert_contains \
+	"8a. worker-watchdog runtime cap disabled by default" \
+	'WORKER_MAX_RUNTIME="${WORKER_MAX_RUNTIME:-0}"' \
+	"$worker_watchdog_source"
+assert_contains \
+	"8b. worker-watchdog emits idle advisory instead of kill" \
+	"IDLE ADVISORY" \
+	"$worker_watchdog_cmd_source"
+assert_not_contains \
+	"8c. worker-watchdog no longer kills on idle" \
+	'kill_worker "$pid" "idle"' \
+	"$worker_watchdog_cmd_source"
+assert_not_contains \
+	"8d. worker-watchdog no longer kills on stall" \
+	'kill_worker "$pid" "stall"' \
+	"$worker_watchdog_cmd_source"
+assert_not_contains \
+	"8e. worker-watchdog no longer kills on runtime" \
+	'kill_worker "$pid" "runtime"' \
+	"$worker_watchdog_cmd_source"
+
+#######################################
+# Test 9: All modified scripts pass ShellCheck
 #######################################
 echo ""
 echo "${TEST_BLUE}--- ShellCheck validation ---${TEST_NC}"
@@ -182,6 +209,8 @@ echo "${TEST_BLUE}--- ShellCheck validation ---${TEST_NC}"
 shellcheck_pass=true
 for script in \
 	"${SCRIPT_DIR}/worker-activity-watchdog.sh" \
+	"${SCRIPT_DIR}/worker-watchdog.sh" \
+	"${SCRIPT_DIR}/worker-watchdog-cmd.sh" \
 	"${SCRIPT_DIR}/pulse-watchdog.sh" \
 	"${SCRIPT_DIR}/pulse-dispatch-lib.sh"; do
 
@@ -191,16 +220,16 @@ for script in \
 		if [[ -n "$sc_out" ]]; then
 			TESTS_RUN=$((TESTS_RUN + 1))
 			TESTS_FAILED=$((TESTS_FAILED + 1))
-			echo "${TEST_RED}FAIL${TEST_NC}: 8. ShellCheck ${local_name}"
+			echo "${TEST_RED}FAIL${TEST_NC}: 9. ShellCheck ${local_name}"
 			echo "  $sc_out"
 			shellcheck_pass=false
 		else
 			TESTS_RUN=$((TESTS_RUN + 1))
-			echo "${TEST_GREEN}PASS${TEST_NC}: 8. ShellCheck ${local_name}"
+			echo "${TEST_GREEN}PASS${TEST_NC}: 9. ShellCheck ${local_name}"
 		fi
 	else
 		TESTS_RUN=$((TESTS_RUN + 1))
-		echo "${TEST_GREEN}PASS${TEST_NC}: 8. ShellCheck ${local_name} (skipped — shellcheck not installed)"
+		echo "${TEST_GREEN}PASS${TEST_NC}: 9. ShellCheck ${local_name} (skipped — shellcheck not installed)"
 	fi
 done
 

--- a/.agents/scripts/worker-watchdog-cmd.sh
+++ b/.agents/scripts/worker-watchdog-cmd.sh
@@ -124,44 +124,32 @@ _check_single_worker() {
 		return 0
 	fi
 
-	# Check 2: Runtime ceiling candidate (transcript gate decides kill/defer)
-	if [[ "$elapsed_seconds" -ge "$WORKER_MAX_RUNTIME" ]]; then
-		if ! transcript_allows_intervention "runtime" "$cmd" "$elapsed_seconds"; then
-			return 1
-		fi
-		log_msg "RUNTIME CEILING: PID=${pid} elapsed=${duration} (max=$(_format_duration "$WORKER_MAX_RUNTIME"))"
-		kill_worker "$pid" "runtime" "$cmd" "$elapsed_seconds" "$INTERVENTION_EVIDENCE_SUMMARY"
-		return 0
+	# Check 2: Runtime ceiling advisory. Quiet/long-running workers may be doing
+	# legitimate wait work for hours or days, so runtime never kills by itself.
+	if [[ "$WORKER_MAX_RUNTIME" -gt 0 && "$elapsed_seconds" -ge "$WORKER_MAX_RUNTIME" ]]; then
+		log_msg "RUNTIME ADVISORY: PID=${pid} elapsed=${duration} (max=$(_format_duration "$WORKER_MAX_RUNTIME"))"
 	fi
 
-	# Check 3: zero-commit high-message thrash detection
+	# Check 3: zero-commit high-message thrash advisory. This is useful evidence
+	# for humans, but it is not explicit fatal evidence and must not kill workers.
 	if check_zero_commit_thrashing "$pid" "$cmd" "$elapsed_seconds"; then
-		_check_single_worker_thrash "$pid" "$cmd" "$elapsed_seconds" "$duration"
-		return $?
+		log_msg "THRASH ADVISORY: PID=${pid} elapsed=${duration} commits=${THRASH_COMMITS} messages=${THRASH_MESSAGES} ratio=${THRASH_RATIO}"
 	fi
 
-	# Check 4: CPU idle detection
+	# Check 4: CPU idle advisory. Low CPU is normal while waiting on provider,
+	# network, tools, or file IO; never kill solely because the worker is quiet.
 	if check_idle "$pid" "$tree_cpu"; then
-		if ! transcript_allows_intervention "idle" "$cmd" "$elapsed_seconds"; then
-			return 1
-		fi
-		log_msg "IDLE DETECTED: PID=${pid} cpu=${tree_cpu}% elapsed=${duration}"
-		kill_worker "$pid" "idle" "$cmd" "$elapsed_seconds" "$INTERVENTION_EVIDENCE_SUMMARY"
-		return 0
+		log_msg "IDLE ADVISORY: PID=${pid} cpu=${tree_cpu}% elapsed=${duration} action=defer"
 	fi
 
-	# Check 5: Progress stall detection
+	# Check 5: Progress stall advisory. Transcript/session growth can lag or be
+	# absent while real work is happening, so a stall is not a kill reason.
 	if check_progress_stall "$pid" "$cmd" "$elapsed_seconds"; then
-		if ! transcript_allows_intervention "stall" "$cmd" "$elapsed_seconds"; then
-			return 1
-		fi
 		local sanitized_evidence=""
 		if [[ -n "$STALL_EVIDENCE_SUMMARY" ]]; then
 			sanitized_evidence=$(_sanitize_log_field "$STALL_EVIDENCE_SUMMARY")
 		fi
-		log_msg "PROGRESS STALL: PID=${pid} elapsed=${duration}${sanitized_evidence:+ evidence=${sanitized_evidence}}"
-		kill_worker "$pid" "stall" "$cmd" "$elapsed_seconds" "$STALL_EVIDENCE_SUMMARY"
-		return 0
+		log_msg "PROGRESS STALL ADVISORY: PID=${pid} elapsed=${duration}${sanitized_evidence:+ evidence=${sanitized_evidence}} action=defer"
 	fi
 
 	return 1

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -7,17 +7,15 @@
 # have no monitoring. Workers that crash, hang, or enter the OpenCode idle-state
 # bug sit indefinitely consuming resources and blocking issue re-dispatch.
 #
-# Five failure modes detected:
-#   1. CPU idle: Worker completed but sits in file-watcher (OpenCode idle bug).
-#      Signal: tree CPU < WORKER_IDLE_CPU_THRESHOLD for WORKER_IDLE_TIMEOUT.
-#   2. Progress stall: Worker is running but producing no output (stuck on API,
-#      rate-limited, spinning). Signal: no log growth for WORKER_PROGRESS_TIMEOUT,
-#      then inspect recent transcript tail evidence before killing.
-#   3. Zero-commit thrash: Worker runs for long time with heavy message volume
-#      but no commits. Signal: elapsed >= WORKER_THRASH_ELAPSED_THRESHOLD,
-#      commits == 0, messages >= WORKER_THRASH_MESSAGE_THRESHOLD.
-#   4. Runtime ceiling: Worker has been running too long regardless of activity.
-#      Signal: elapsed > WORKER_MAX_RUNTIME. Prevents infinite loops.
+# Five signals detected:
+#   1. CPU idle advisory: Worker may be quiet or waiting. This is diagnostic
+#      only; quiet workers are not killed automatically.
+#   2. Progress stall advisory: Worker is running but producing no output. This
+#      is diagnostic only because long-running workers may wait legitimately.
+#   3. Zero-commit thrash advisory: Worker runs for long time with heavy message
+#      volume but no commits. This is diagnostic only.
+#   4. Runtime ceiling advisory: Disabled by default. Set WORKER_MAX_RUNTIME to
+#      a positive value for local diagnostics; it still does not kill workers.
 #   5. Provider backoff stall (GH#5650): Worker's provider hit auth_error or
 #      rate-limit and is backed off in headless-runtime state DB. Worker process
 #      stays alive but makes no progress. Signal: provider_backoff table has an
@@ -27,8 +25,8 @@
 # On kill:
 #   - Posts a comment on the associated GitHub issue explaining the kill reason
 #   - Removes the worker's status:in-progress label
-#   - Adds status:available for recoverable exits (idle, stall, runtime, backoff)
-#   - Adds status:blocked for zero-commit thrash to prevent blind relaunch loops
+#   - Adds status:available for recoverable exits (backoff)
+#   - Leaves quiet, stalled, long-running, and thrashing workers alive
 #   - Logs the action to the watchdog log file
 #
 # Usage:
@@ -40,14 +38,14 @@
 #   worker-watchdog.sh --help           # Show usage
 #
 # Environment:
-#   WORKER_IDLE_TIMEOUT          Seconds of low CPU before kill (default: 300)
-#   WORKER_IDLE_CPU_THRESHOLD    CPU% below this = idle (default: 5)
-#   WORKER_PROGRESS_TIMEOUT      Seconds without log growth = stuck (default: 600)
+#   WORKER_IDLE_TIMEOUT          Seconds of low CPU before quiet advisory (default: 300)
+#   WORKER_IDLE_CPU_THRESHOLD    CPU% below this = quiet/idle advisory (default: 5)
+#   WORKER_PROGRESS_TIMEOUT      Seconds without log growth before advisory (default: 600)
 #   WORKER_THRASH_ELAPSED_THRESHOLD  Minimum runtime before thrash check (default: 3600)
 #   WORKER_THRASH_MESSAGE_THRESHOLD  Minimum messages for thrash check (default: 120)
 #   WORKER_THRASH_RATIO_THRESHOLD    Struggle ratio threshold for time-weighted check (default: 10)
 #   WORKER_THRASH_RATIO_ELAPSED      Minimum elapsed seconds for ratio-only thrash (default: 25200 = 7h)
-#   WORKER_MAX_RUNTIME           Hard ceiling in seconds (default: 10800 = 3h)
+#   WORKER_MAX_RUNTIME           Runtime advisory in seconds (default: 0 = disabled)
 #   WORKER_DRY_RUN               Set to "true" to log but not kill (default: false)
 #   WORKER_WATCHDOG_NOTIFY       Set to "false" to disable macOS notifications
 #   WORKER_PROCESS_PATTERN       CLI name to match (default: opencode)
@@ -77,14 +75,14 @@ source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 readonly SCRIPT_NAME="worker-watchdog"
 readonly SCRIPT_VERSION="1.0.0"
 
-WORKER_IDLE_TIMEOUT="${WORKER_IDLE_TIMEOUT:-300}"                          # 5 min idle = completed, sitting in file watcher
-WORKER_IDLE_CPU_THRESHOLD="${WORKER_IDLE_CPU_THRESHOLD:-5}"                # CPU% below this = idle
-WORKER_PROGRESS_TIMEOUT="${WORKER_PROGRESS_TIMEOUT:-600}"                  # 10 min no log output = stuck
+WORKER_IDLE_TIMEOUT="${WORKER_IDLE_TIMEOUT:-300}"                          # 5 min low CPU before quiet advisory
+WORKER_IDLE_CPU_THRESHOLD="${WORKER_IDLE_CPU_THRESHOLD:-5}"                # CPU% below this = quiet advisory
+WORKER_PROGRESS_TIMEOUT="${WORKER_PROGRESS_TIMEOUT:-600}"                  # 10 min no log output before advisory
 WORKER_THRASH_ELAPSED_THRESHOLD="${WORKER_THRASH_ELAPSED_THRESHOLD:-3600}" # 1h minimum runtime before zero-commit thrash checks (GH#4400: lowered from 2h)
 WORKER_THRASH_MESSAGE_THRESHOLD="${WORKER_THRASH_MESSAGE_THRESHOLD:-120}"  # ~2 messages/min over 1h before thrash checks (GH#4400: lowered from 180)
 WORKER_THRASH_RATIO_THRESHOLD="${WORKER_THRASH_RATIO_THRESHOLD:-10}"       # Struggle ratio threshold for time-weighted check (GH#5650)
 WORKER_THRASH_RATIO_ELAPSED="${WORKER_THRASH_RATIO_ELAPSED:-25200}"        # 7h: ratio-only thrash check for long-running zero-commit workers (GH#5650)
-WORKER_MAX_RUNTIME="${WORKER_MAX_RUNTIME:-10800}"                          # 3 hour hard ceiling
+WORKER_MAX_RUNTIME="${WORKER_MAX_RUNTIME:-0}"                              # disabled by default; quiet workers can run indefinitely
 WORKER_DRY_RUN="${WORKER_DRY_RUN:-false}"
 WORKER_WATCHDOG_NOTIFY="${WORKER_WATCHDOG_NOTIFY:-true}"
 WORKER_PROCESS_PATTERN="${WORKER_PROCESS_PATTERN:-opencode}" # CLI name to match (update if CLI changes)
@@ -97,7 +95,7 @@ WORKER_THRASH_ELAPSED_THRESHOLD=$(_validate_int WORKER_THRASH_ELAPSED_THRESHOLD 
 WORKER_THRASH_MESSAGE_THRESHOLD=$(_validate_int WORKER_THRASH_MESSAGE_THRESHOLD "$WORKER_THRASH_MESSAGE_THRESHOLD" 120 30)
 WORKER_THRASH_RATIO_THRESHOLD=$(_validate_int WORKER_THRASH_RATIO_THRESHOLD "$WORKER_THRASH_RATIO_THRESHOLD" 10 1)
 WORKER_THRASH_RATIO_ELAPSED=$(_validate_int WORKER_THRASH_RATIO_ELAPSED "$WORKER_THRASH_RATIO_ELAPSED" 25200 3600)
-WORKER_MAX_RUNTIME=$(_validate_int WORKER_MAX_RUNTIME "$WORKER_MAX_RUNTIME" 10800 600)
+WORKER_MAX_RUNTIME=$(_validate_int WORKER_MAX_RUNTIME "$WORKER_MAX_RUNTIME" 0)
 
 # Paths
 readonly LOG_DIR="${HOME}/.aidevops/logs"


### PR DESCRIPTION
Resolves #22779

## Summary
- Changes the legacy worker watchdog so CPU idle, progress stall, runtime, and zero-commit thrash are advisory signals only.
- Keeps provider backoff as the explicit auto-kill path because backed-off provider requests cannot progress.
- Extends the watchdog no-false-kill regression test to assert quiet-worker signals no longer call `kill_worker`.

## Testing
- `.agents/scripts/tests/test-watchdog-no-false-kill.sh` — 55 tests, 0 failures
- `shellcheck -S error .agents/scripts/worker-watchdog.sh .agents/scripts/worker-watchdog-cmd.sh .agents/scripts/tests/test-watchdog-no-false-kill.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh` — completed with unrelated pre-existing Bash 3.2/function complexity/nesting failures; targeted checks passed

## Decisions
- Avoided adding a complex wait detector because quiet long-running workers should not be killed without explicit fatal evidence.
- Left provider backoff kill behavior intact as explicit failure evidence.

<!-- MERGE_SUMMARY -->
## Completion Summary

- **What**: Made quiet-worker watchdog signals advisory-only to avoid killing real long-running work.
- **Issue**: #22779
- **Files changed**: `.agents/scripts/worker-watchdog.sh`, `.agents/scripts/worker-watchdog-cmd.sh`, `.agents/scripts/tests/test-watchdog-no-false-kill.sh`
- **Testing**: Watchdog regression test, targeted ShellCheck, diff whitespace check, full linter with pre-existing unrelated blockers.
- **Key decisions**: Provider backoff remains killable; CPU/quiet/runtime/thrash no longer kill.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.40 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 33m and 269,300 tokens on this with the user in an interactive session.
