### PR TITLE
GH#22737: reduce bash compatibility baseline debt

### DIFF
--- a/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
+++ b/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
@@ -58,11 +58,11 @@ runtime_audit_check() {
 		return 0
 	fi
 
-	local evidence_table="| File | Drift | Deployed mtime | Source mtime |\n| --- | --- | --- | --- |"
+	local evidence_table="| File | Drift | Deployed mtime | Source mtime |"$'\n'"| --- | --- | --- | --- |"
 	local entry name d_str dm sm
 	for entry in "${drifted[@]}"; do
 		IFS='|' read -r name d_str dm sm <<<"$entry"
-		evidence_table+="\n| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$sm") |"
+		evidence_table+=$'\n'"| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$sm") |"
 	done
 
 	local first_file

--- a/.agents/scripts/runtime-audit-rules/log-pattern-novelty.sh
+++ b/.agents/scripts/runtime-audit-rules/log-pattern-novelty.sh
@@ -91,7 +91,7 @@ runtime_audit_check() {
 		return 0
 	fi
 
-	local evidence_table="| Recent count | Normalised template |\n| --- | --- |"
+	local evidence_table="| Recent count | Normalised template |"$'\n'"| --- | --- |"
 	local entry c t
 	for entry in "${novel[@]}"; do
 		IFS='|' read -r c t <<<"$entry"
@@ -99,7 +99,7 @@ runtime_audit_check() {
 		[[ ${#t} -gt 200 ]] && t="${t:0:200}..."
 		# Escape pipes inside template for markdown
 		t="${t//|/\\|}"
-		evidence_table+="\n| ${c} | \`${t}\` |"
+		evidence_table+=$'\n'"| ${c} | \`${t}\` |"
 	done
 
 	local title="runtime-audit: ${#novel[@]} novel high-frequency log pattern(s) in last ${recent} lines"


### PR DESCRIPTION
## Summary

Replaced literal newline escape concatenation in two runtime audit rules with Bash 3.2-safe ANSI-C newline concatenation, and recorded the broader baseline decomposition on the tracking issue.

## Files Changed

.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh,.agents/scripts/runtime-audit-rules/log-pattern-novelty.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n and shellcheck pass for changed scripts; linters-local.sh --strict shows Bash 3.2 compatibility baseline reduced from 19 to 15 violations, with unrelated baseline debt still present.

Resolves #22737


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.39 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 49m and 122,598 tokens on this with the user in an interactive session.