### PR TITLE
GH#22780: fix stale recovery escalation for fresh dispatches

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -81,18 +81,88 @@ _stale_recovery_count_ticks() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local _comments_pages _prior_ticks
-	_comments_pages=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--paginate --slurp 2>/dev/null) || _comments_pages=""
+	_comments_pages=$(_stale_recovery_fetch_comments_pages "$issue_number" "$repo_slug") || _comments_pages=""
 	if [[ -z "$_comments_pages" ]]; then
 		printf '0'
 		return 0
 	fi
-	_prior_ticks=$(printf '%s' "$_comments_pages" | jq \
-		'[.[] | .[]? | select(.body | (test("<!-- stale-recovery-tick:[1-9]") and (test("reset") | not)))] | length' \
-		2>/dev/null) || _prior_ticks=0
+	_prior_ticks=$(_stale_recovery_count_ticks_from_pages "$_comments_pages") || _prior_ticks=0
 	[[ "$_prior_ticks" =~ ^[0-9]+$ ]] || _prior_ticks=0
 	printf '%s' "$_prior_ticks"
 	return 0
+}
+
+#######################################
+# Fetch issue comments as one slurped JSON document.
+# Args: $1 = issue number, $2 = repo slug
+# Output: slurped comments pages JSON, or empty on gh failure
+#######################################
+_stale_recovery_fetch_comments_pages() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --slurp 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Count non-reset stale recovery ticks from a slurped comments JSON document.
+# Args: $1 = slurped comments pages JSON
+# Output: integer tick count
+#######################################
+_stale_recovery_count_ticks_from_pages() {
+	local comments_pages="$1"
+	local prior_ticks
+	prior_ticks=$(printf '%s' "$comments_pages" | jq \
+		'[
+			.[] | .[]?
+			| select(.body | (test("<!-- stale-recovery-tick:[1-9]") and (test("reset") | not)))
+		] | length' \
+		2>/dev/null) || prior_ticks=0
+	[[ "$prior_ticks" =~ ^[0-9]+$ ]] || prior_ticks=0
+	printf '%s' "$prior_ticks"
+	return 0
+}
+
+#######################################
+# Find the latest dispatch/claim timestamp in slurped GitHub comments.
+# GitHub comments remain the multi-user/multi-machine coordination source.
+# Args: $1 = slurped comments pages JSON
+# Output: ISO timestamp or empty
+#######################################
+_stale_recovery_latest_dispatch_ts_from_pages() {
+	local comments_pages="$1"
+	printf '%s' "$comments_pages" | jq -r '
+		[
+			.[] | .[]?
+			| select((.body // "") | test("Dispatching worker|DISPATCH_CLAIM|Worker \\(PID|Interactive session claimed"; "i"))
+		] | sort_by(.created_at) | last | .created_at // empty
+	' 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Check for terminal worker-failure evidence after a dispatch timestamp.
+# Stale escalation should not infer failure from GitHub silence alone; in a
+# multi-runner system, the issue comment stream must contain an explicit worker
+# terminal marker before historical stale ticks suspend future dispatch.
+# Args: $1 = slurped comments pages JSON, $2 = dispatch timestamp
+# Returns: 0 if terminal evidence exists, 1 otherwise
+#######################################
+_stale_recovery_has_terminal_evidence_since() {
+	local comments_pages="$1"
+	local since_ts="$2"
+	[[ -z "$since_ts" ]] && return 1
+	if printf '%s' "$comments_pages" | jq -e --arg since "$since_ts" '
+		[
+			.[] | .[]?
+			| select((.created_at // "") > $since)
+			| select((.body // "") | test("CLAIM_RELEASED reason=worker_failed|Worker Watchdog Kill|provider is backed off|reason=rate_limit|headless-runtime state DB"; "i"))
+		] | length > 0
+	' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################
@@ -237,14 +307,17 @@ _This recovery prevents the orphaned-assignment deadlock where offline runners p
 #
 # Decision flow (t2008 escalation check):
 #   1. Load threshold from config (default 2).
-#   2. Count prior non-reset tick comments.
-#   3. Look up any open PR referencing this issue.
+#   2. Count prior non-reset tick comments from the GitHub issue comment log.
+#   3. Find the latest dispatch marker and terminal worker evidence in that same
+#      GitHub comment log (the cross-machine coordination source).
+#   4. Look up any open PR referencing this issue.
 #      - If an open PR exists: reset tick counter (progress is being made),
 #        continue to normal recovery.
-#      - Else if prior_ticks >= threshold: escalate to needs-maintainer-review
-#        and return immediately (no normal recovery).
+#      - Else if prior_ticks >= threshold and the latest dispatch attempt has
+#        terminal evidence: escalate to needs-maintainer-review and return
+#        immediately (no normal recovery).
 #      - Else: increment the tick counter and continue to normal recovery.
-#   4. Normal recovery: unassign stale users, set status:available, post audit.
+#   5. Normal recovery: unassign stale users, set status:available, post audit.
 #
 # Args:
 #   $1 = issue number
@@ -263,9 +336,14 @@ _recover_stale_assignment() {
 	# resetting to status:available and apply needs-maintainer-review instead.
 	# Counter is stored as structured comment markers for cross-runner correctness.
 	# Config: .agents/configs/dispatch-stale-recovery.conf
-	local _threshold _prior_ticks _open_pr
+	local _threshold _prior_ticks _open_pr _comments_pages _latest_dispatch_ts _terminal_evidence=false
 	_threshold=$(_stale_recovery_load_threshold)
-	_prior_ticks=$(_stale_recovery_count_ticks "$issue_number" "$repo_slug")
+	_comments_pages=$(_stale_recovery_fetch_comments_pages "$issue_number" "$repo_slug")
+	_prior_ticks=$(_stale_recovery_count_ticks_from_pages "$_comments_pages")
+	_latest_dispatch_ts=$(_stale_recovery_latest_dispatch_ts_from_pages "$_comments_pages")
+	if _stale_recovery_has_terminal_evidence_since "$_comments_pages" "$_latest_dispatch_ts"; then
+		_terminal_evidence=true
+	fi
 	_open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug")
 
 	if [[ -n "$_open_pr" ]]; then
@@ -276,12 +354,15 @@ _recover_stale_assignment() {
 Stale recovery tick reset — open PR #${_open_pr} detected (t2008)
 <!-- ops:end -->" \
 			2>/dev/null || true
-	elif [[ "$_prior_ticks" -ge "$_threshold" ]]; then
-		# Threshold reached — escalate and bail out (no normal recovery)
+	elif [[ "$_prior_ticks" -ge "$_threshold" && "$_terminal_evidence" == "true" ]]; then
+		# Threshold reached with explicit worker terminal evidence — escalate and
+		# bail out (no normal recovery). GH#22780: Do not suspend a fresh multi-runner
+		# dispatch solely because GitHub has been quiet for one stale window.
 		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_prior_ticks"
 		return 0
 	else
-		# Under threshold — increment tick counter, continue normal recovery
+		# Under threshold, or over threshold without terminal worker evidence —
+		# increment the GitHub-backed counter and continue normal recovery.
 		local _next_tick=$((_prior_ticks + 1))
 		gh_issue_comment "$issue_number" --repo "$repo_slug" \
 			--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard: stale-recovery escalation must use GitHub comments as the
+# multi-runner source of truth, but it must not suspend a freshly dispatched
+# worker from historical stale ticks unless the current attempt has terminal
+# worker-failure evidence in the issue comment stream.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+TMP_HOME="$(mktemp -d -t stale-terminal.XXXXXX)" || exit 1
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+export HOME="$TMP_HOME"
+export LOGFILE="${TMP_HOME}/test.log"
+SCRIPT_DIR="$SCRIPTS_DIR"
+STALE_RECOVERY_THRESHOLD=2
+STALE_ASSIGNMENT_THRESHOLD_SECONDS=600
+
+# shellcheck source=../dispatch-dedup-stale.sh
+source "${SCRIPTS_DIR}/dispatch-dedup-stale.sh"
+
+COMMENTS_JSON='[]'
+ESCALATED=0
+RECOVERED=0
+COMMENT_BODIES="${TMP_HOME}/comments.log"
+: >"$COMMENT_BODIES"
+
+gh() {
+	local cmd="$1"
+	shift || true
+	if [[ "$cmd" == "api" ]]; then
+		printf '%s\n' "$COMMENTS_JSON"
+		return 0
+	fi
+	printf '[]\n'
+	return 0
+}
+
+gh_issue_comment() {
+	local _issue_number="$1"
+	shift || true
+	: "$_issue_number"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--body)
+			printf '%s\n' "${2:-}" >>"$COMMENT_BODIES"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+	return 0
+}
+
+set_issue_status() {
+	return 0
+}
+
+_stale_recovery_find_open_pr() {
+	return 0
+}
+
+_stale_recovery_escalate() {
+	local _issue_number="$1"
+	local _repo_slug="$2"
+	local _stale_assignees="$3"
+	local _reason="$4"
+	local _threshold="$5"
+	local _prior_ticks="$6"
+	: "$_issue_number" "$_repo_slug" "$_stale_assignees" "$_reason" "$_threshold" "$_prior_ticks"
+	ESCALATED=1
+	return 0
+}
+
+_stale_recovery_apply() {
+	local _issue_number="$1"
+	local _repo_slug="$2"
+	local _stale_assignees="$3"
+	local _reason="$4"
+	: "$_issue_number" "$_repo_slug" "$_stale_assignees" "$_reason"
+	RECOVERED=1
+	return 0
+}
+
+COMMENTS_JSON='[[
+  {"created_at":"2026-05-04T10:00:00Z","body":"<!-- stale-recovery-tick:1 -->\nStale recovery tick 1/2"},
+  {"created_at":"2026-05-04T11:00:00Z","body":"<!-- stale-recovery-tick:2 -->\nStale recovery tick 2/2"},
+  {"created_at":"2026-05-04T12:43:16Z","body":"DISPATCH_CLAIM nonce=fresh runner=runner ts=2026-05-04T12:43:16Z"},
+  {"created_at":"2026-05-04T12:43:51Z","body":"Dispatching worker (deterministic).\n- **Worker PID**: 90285"}
+]]'
+
+_recover_stale_assignment 3978 owner/repo runner "dispatch claim 620s old, last activity 620s old (threshold=600s, interactive=false)"
+
+if [[ "$ESCALATED" -eq 0 && "$RECOVERED" -eq 1 ]]; then
+	pass "fresh dispatch without terminal evidence does not escalate"
+else
+	fail "fresh dispatch without terminal evidence does not escalate" "ESCALATED=${ESCALATED} RECOVERED=${RECOVERED}"
+fi
+
+ESCALATED=0
+RECOVERED=0
+COMMENTS_JSON='[[
+  {"created_at":"2026-05-04T10:00:00Z","body":"<!-- stale-recovery-tick:1 -->\nStale recovery tick 1/2"},
+  {"created_at":"2026-05-04T11:00:00Z","body":"<!-- stale-recovery-tick:2 -->\nStale recovery tick 2/2"},
+  {"created_at":"2026-05-04T12:43:16Z","body":"DISPATCH_CLAIM nonce=fresh runner=runner ts=2026-05-04T12:43:16Z"},
+  {"created_at":"2026-05-04T12:50:05Z","body":"## Worker Watchdog Kill\n\n**Reason:** Worker process became idle"}
+]]'
+
+_recover_stale_assignment 3978 owner/repo runner "dispatch claim 620s old, last activity 620s old (threshold=600s, interactive=false)"
+
+if [[ "$ESCALATED" -eq 1 && "$RECOVERED" -eq 0 ]]; then
+	pass "terminal evidence allows threshold escalation"
+else
+	fail "terminal evidence allows threshold escalation" "ESCALATED=${ESCALATED} RECOVERED=${RECOVERED}"
+fi
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- Require explicit GitHub-comment terminal worker evidence before stale recovery escalates historical ticks to needs-maintainer-review.
- Keep the GitHub issue comment stream as the central multi-user/multi-machine coordination record for dispatch claims, stale ticks, and terminal markers.
- Add regression coverage for fresh dispatches without terminal evidence and for terminal evidence permitting escalation.

## Testing
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `.agents/scripts/linters-local.sh` ran; targeted checks passed, repository has pre-existing baseline failures in Bash 3.2 compatibility, function complexity, and nesting depth.

## Runtime Testing
self-assessed: shell coordination logic with deterministic regression tests; no runtime service needed.

## Key decisions
- Do not infer a failed worker from one quiet 600s GitHub window.
- Preserve normal stale recovery/re-dispatch when the threshold is exceeded but the latest dispatch lacks terminal evidence.

Resolves #22780


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.40 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 29m and 395,340 tokens on this with the user in an interactive session.