### PR TITLE
GH#22784: optimize pulse API efficiency and diagnostics

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1721,13 +1721,29 @@ classify_dispatch_blocker_reason() {
 			printf 'launch_error\n'
 			return 0
 			;;
+		*missing*worker*context* | *needs-brief* | *missing*implementation*context*)
+			printf 'missing_worker_context\n'
+			return 0
+			;;
+		*worktree*cap* | *max*worktree* | *disk*space* | *large*file*)
+			printf 'local_capacity_gate\n'
+			return 0
+			;;
+		*no-auto-dispatch* | *external*author*gate* | *nmr*gate* | *approval*required*)
+			printf 'policy_gate\n'
+			return 0
+			;;
 		*assigned* | *claim* | *ledger* | *has-open-pr* | *pr*evidence* | *duplicate* | *stale_recovered*)
 			printf 'dedup_active_claim\n'
 			return 0
 			;;
+		"")
+			printf 'no_recent_log_evidence\n'
+			return 0
+			;;
 	esac
 
-	printf 'unknown\n'
+	printf 'unclassified_signal\n'
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -104,10 +104,10 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		dedup_active_claim | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | unknown)
+		dedup_active_claim | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | unclassified_signal)
 			;;
 		*)
-			reason="unknown"
+			reason="unclassified_signal"
 			;;
 	esac
 	_dispatch_stats_increment "dispatch_candidate_failed"
@@ -129,7 +129,7 @@ _dispatch_candidate_failure_reason() {
 	local repo_slug="$2"
 	local dispatch_rc="$3"
 	local recent_lines=""
-	local reason="unknown"
+	local reason="no_recent_log_evidence"
 
 	if [[ "$dispatch_rc" -eq 124 ]]; then
 		printf 'launch_error\n'
@@ -158,15 +158,15 @@ _dispatch_candidate_failure_reason() {
 				sub(/^DISPATCH_BLOCK_REASON reason=/, "", reason)
 			}
 			END { if (reason != "") { print reason } }
-		') || reason="unknown"
-		[[ -n "$reason" ]] || reason="unknown"
+		') || reason="unclassified_signal"
+		[[ -n "$reason" ]] || reason="unclassified_signal"
 		printf '%s\n' "$reason"
 		return 0
 	fi
 
 	if [[ -x "${SCRIPT_DIR:-}/dispatch-dedup-helper.sh" && -n "$recent_lines" ]]; then
-		reason=$("${SCRIPT_DIR}/dispatch-dedup-helper.sh" classify-blocker "$recent_lines" 2>/dev/null) || reason="unknown"
-		[[ -n "$reason" ]] || reason="unknown"
+		reason=$("${SCRIPT_DIR}/dispatch-dedup-helper.sh" classify-blocker "$recent_lines" 2>/dev/null) || reason="unclassified_signal"
+		[[ -n "$reason" ]] || reason="unclassified_signal"
 	fi
 
 	printf '%s\n' "$reason"

--- a/.agents/scripts/pulse-log-runaway-detector.sh
+++ b/.agents/scripts/pulse-log-runaway-detector.sh
@@ -239,6 +239,7 @@ _check_repetition_pattern() {
 			dominant_line=$(tail -n 1000 "$WRAPPER_LOGFILE" 2>/dev/null | sort | uniq -c | sort -rn | head -1 | sed 's/^[[:space:]]*[0-9]* //' 2>/dev/null || echo "unknown")
 			_log "RUNAWAY DETECTED: ${unique_pct}% unique lines in last 1000 (threshold: ${PULSE_WRAPPER_LOG_REPETITION_THRESHOLD}%). Dominant line: ${dominant_line:0:200}"
 			_write_advisory "Runaway repetition detected: ${unique_pct}% unique lines. Dominant: ${dominant_line:0:200}"
+			_rotate_wrapper_log
 			_RUNAWAY_DETECTED=1
 		fi
 	fi

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -59,6 +59,92 @@ _filter_non_task_issues() {
 	return 0
 }
 
+#######################################
+# Return 0 when a gh_pr_list argv shape is safe to serve from the short-lived
+# cross-process PR snapshot cache. The cache is deliberately scoped to open PR
+# list reads because those dominate pulse dedup/merge pressure and can tolerate
+# a small freshness window while keeping dispatch pipelines full.
+# Args: gh-style argv
+#######################################
+_gh_pr_list_snapshot_cacheable() {
+	_rest_args_have_search "$@" && return 1
+	_rest_pr_list_can_preserve_args "$@" || return 1
+	local _state="open"
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--state) _state="${2:-open}"; shift 2 ;;
+		--state=*) _state="${_arg#--state=}"; shift ;;
+		*) shift ;;
+		esac
+	done
+	[[ "$_state" == "open" ]] && return 0
+	return 1
+}
+
+#######################################
+# Build a filesystem-safe key for an exact gh_pr_list argv shape.
+# Args: gh-style argv
+# Stdout: cache key
+#######################################
+_gh_pr_list_snapshot_key() {
+	local _joined=""
+	local _arg
+	for _arg in "$@"; do
+		_joined="${_joined}${_arg}"$'\034'
+	done
+	if command -v shasum >/dev/null 2>&1; then
+		printf '%s' "$_joined" | shasum | awk '{print $1}'
+	else
+		printf '%s' "$_joined" | cksum | awk '{print $1}'
+	fi
+	return 0
+}
+
+#######################################
+# Read a cached gh_pr_list snapshot when present and fresh.
+# Args: gh-style argv
+# Stdout: cached command output
+#######################################
+_gh_pr_list_snapshot_get() {
+	local _ttl="${AIDEVOPS_GH_PR_LIST_CACHE_TTL:-15}"
+	[[ "${AIDEVOPS_GH_PR_LIST_CACHE_DISABLE:-0}" == "1" ]] && return 1
+	[[ "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]] || return 1
+	_gh_pr_list_snapshot_cacheable "$@" || return 1
+	local _key _path _now _mtime _age
+	_key="$(_gh_pr_list_snapshot_key "$@")"
+	_path="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}/${_key}.json"
+	[[ -f "$_path" ]] || return 1
+	_now=$(date +%s 2>/dev/null || printf '0')
+	_mtime=$(perl -e 'print((stat($ARGV[0]))[9] || 0)' "$_path" 2>/dev/null || printf '0')
+	[[ "$_now" =~ ^[0-9]+$ && "$_mtime" =~ ^[0-9]+$ ]] || return 1
+	_age=$(( _now - _mtime ))
+	[[ "$_age" -ge 0 && "$_age" -le "$_ttl" ]] || return 1
+	printf '%s' "$(<"$_path")"
+	return 0
+}
+
+#######################################
+# Store a successful gh_pr_list snapshot for a short freshness window.
+# Args: $1 = command output, $2.. = gh-style argv
+#######################################
+_gh_pr_list_snapshot_put() {
+	local _body="$1"; shift
+	local _ttl="${AIDEVOPS_GH_PR_LIST_CACHE_TTL:-15}"
+	[[ "${AIDEVOPS_GH_PR_LIST_CACHE_DISABLE:-0}" == "1" ]] && return 0
+	[[ "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]] || return 0
+	_gh_pr_list_snapshot_cacheable "$@" || return 0
+	local _dir _key _path _tmp
+	_dir="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}"
+	mkdir -p "$_dir" 2>/dev/null || return 0
+	_key="$(_gh_pr_list_snapshot_key "$@")"
+	_path="${_dir}/${_key}.json"
+	_tmp=$(mktemp "${_dir}/.pr-list-${_key}.XXXXXX" 2>/dev/null) || return 0
+	printf '%s' "$_body" >"$_tmp" 2>/dev/null || { rm -f "$_tmp"; return 0; }
+	mv "$_tmp" "$_path" 2>/dev/null || rm -f "$_tmp"
+	return 0
+}
+
 # Ensure all core status:* labels exist on a repo (idempotent, cached per-process).
 # The helper relies on --remove-label being idempotent for *unset* labels (gh
 # returns exit 0 when a label exists in the repo but isn't applied to the issue),
@@ -237,23 +323,43 @@ gh_issue_view() {
 gh_pr_list() {
 	local _has_search=1
 	_rest_args_have_search "$@" || _has_search=0
+	local _cached_output=""
+	if _cached_output=$(_gh_pr_list_snapshot_get "$@" 2>/dev/null); then
+		printf '%s' "$_cached_output"
+		return 0
+	fi
+	local _out="" _rc=0
 	if [[ $_has_search -eq 0 ]] && _rest_read_first_enabled && _rest_pr_list_can_preserve_args "$@"; then
 		print_info "[INFO] gh-wrapper: REST-first read mode, routing pr list to REST"
-		_rest_pr_list "$@"
-		return $?
+		_out=$(_rest_pr_list "$@")
+		_rc=$?
+		if [[ $_rc -eq 0 ]]; then
+			_gh_pr_list_snapshot_put "$_out" "$@"
+			printf '%s' "$_out"
+		fi
+		return $_rc
 	fi
 	if [[ $_has_search -eq 0 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_list; } || _rest_should_fallback; }; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr list to REST"
-		_rest_pr_list "$@"
-		return $?
+		_out=$(_rest_pr_list "$@")
+		_rc=$?
+		if [[ $_rc -eq 0 ]]; then
+			_gh_pr_list_snapshot_put "$_out" "$@"
+			printf '%s' "$_out"
+		fi
+		return $_rc
 	fi
 	gh_record_call graphql gh_pr_list 2>/dev/null || true
-	_gh_with_timeout read gh pr list "$@"
+	_out=$(_gh_with_timeout read gh pr list "$@")
 	local rc=$?
 	if [[ $rc -ne 0 && $_has_search -eq 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr list"
-		_rest_pr_list "$@"
+		_out=$(_rest_pr_list "$@")
 		rc=$?
+	fi
+	if [[ $rc -eq 0 ]]; then
+		_gh_pr_list_snapshot_put "$_out" "$@"
+		printf '%s' "$_out"
 	fi
 	return $rc
 }

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -24,5 +24,10 @@ assert_reason 'DISPATCH_BLOCK_REASON reason=dedup_active_claim signal=assigned t
 assert_reason 'GraphQL budget below circuit-breaker threshold' 'graphql_circuit_breaker'
 assert_reason 'DISPATCH_COOLDOWN_ACTIVE until=2026-05-02T23:00:00Z reason=no_worker_process' 'cooldown_no_worker_process'
 assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — requires cryptographic approval (ever-NMR)' 'ever_nmr_without_approval'
+assert_reason 'pre-dispatch validator failed: missing worker context; needs-brief label present' 'missing_worker_context'
+assert_reason 'dedup.worktree_cap blocked by max worktree count' 'local_capacity_gate'
+assert_reason 'external_author_gate blocked no-auto-dispatch policy' 'policy_gate'
+assert_reason '' 'no_recent_log_evidence'
+assert_reason 'new blocker shape not yet classified' 'unclassified_signal'
 
 printf 'PASS dispatch-candidate-failure-reasons\n'

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -937,6 +937,22 @@ else
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export AIDEVOPS_GH_PR_LIST_CACHE_DIR="$TMP/pr-list-cache"
+export AIDEVOPS_GH_PR_LIST_CACHE_TTL=30
+gh_pr_list --repo "owner/repo" --state open --json number --jq length --limit 200 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --state open --json number --jq length --limit 200 >/dev/null 2>&1 || true
+
+pr_pull_calls=$(grep -cE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$pr_pull_calls" == "1" ]]; then
+	pass "gh_pr_list short-lived snapshot cache coalesces identical open PR reads"
+else
+	fail "gh_pr_list short-lived snapshot cache coalesces identical open PR reads" \
+		"pull_calls=${pr_pull_calls} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+unset AIDEVOPS_GH_PR_LIST_CACHE_DIR AIDEVOPS_GH_PR_LIST_CACHE_TTL
+
 unset AIDEVOPS_GH_REST_FIRST_READS
 
 # =============================================================================

--- a/.agents/scripts/tests/test-pulse-log-runaway-detector.sh
+++ b/.agents/scripts/tests/test-pulse-log-runaway-detector.sh
@@ -148,11 +148,18 @@ test_repetition_pattern_hit() {
 
 	bash "$DETECTOR" check-and-heal 2>/dev/null
 
-	# Check that advisory was written (repetition detection is advisory-only,
-	# doesn't necessarily rotate on its own if under size cap)
+	# Check that advisory was written and the repeated log was rotated.
 	local advisory_result=1
 	[[ -f "${HOME}/.aidevops/cache/pulse-wrapper-log-runaway-advisory.txt" ]] && advisory_result=0
 	_assert "advisory written on repetition pattern" "$advisory_result"
+
+	local after_size=0
+	after_size=$(wc -c <"$WRAPPER_LOGFILE" 2>/dev/null || echo "999999999")
+	after_size="${after_size//[[:space:]]/}"
+	[[ "$after_size" =~ ^[0-9]+$ ]] || after_size=999999999
+	local rotation_result=1
+	[[ "$after_size" -lt 1024 ]] && rotation_result=0
+	_assert "wrapper log rotated on repetition pattern" "$rotation_result"
 
 	_teardown
 	return 0


### PR DESCRIPTION
## Summary
- Rotate runaway pulse wrapper logs when repetition is detected, not only on size/growth thresholds.
- Add a 15s exact-argv cache for open PR list reads to reduce repeated dispatch/merge API calls without long stale snapshots.
- Replace unknown dispatch failure counters with stable blocker classes for worker context, local capacity, policy gates, missing evidence, and unclassified signals.

## Testing
- shellcheck -x on changed shell files
- .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
- .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
- .agents/scripts/tests/test-pulse-log-runaway-detector.sh
- .agents/scripts/linters-local.sh ran until the Bash compatibility phase timed out after 600s; prior gates passed or reported advisory pre-existing debt.

## Runtime Testing
self-assessed: shell helper changes covered by focused unit tests and ShellCheck; pulse health will be monitored after deploy.

## Key decisions
- Kept PR list cache TTL short (default 15s) and limited to open PR list shapes that REST fallback can preserve.
- Preserved multi-machine safety by using exact argv cache keys and avoiding long-lived shared state.

Resolves #22784

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.41 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 33m and 662,803 tokens on this with the user in an interactive session.