### PR TITLE
GH#22788: fix: guard FOSS dispatch issue selection

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1187,6 +1187,7 @@ dispatch_foss_workers() {
 	local repos_json="${2:-${REPOS_JSON:-~/.config/aidevops/repos.json}}"
 	local foss_count=0
 	local foss_max="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"
+	local foss_session_keys_seen=$'\n'
 
 	[[ "$available" =~ ^[0-9]+$ ]] || available=0
 
@@ -1209,6 +1210,17 @@ dispatch_foss_workers() {
 
 		foss_issue_num="${foss_issue%%|*}"
 		foss_issue_title="${foss_issue#*|}"
+		if [[ ! "$foss_issue_num" =~ ^[0-9]+$ || -z "$foss_issue_title" || "$foss_issue_title" == "null" ]]; then
+			echo "[pulse-wrapper] FOSS dispatch skipped invalid issue selection for ${foss_slug}: number='${foss_issue_num}' title='${foss_issue_title}'" >>"$LOGFILE"
+			continue
+		fi
+
+		local foss_session_key="foss-${foss_slug}-${foss_issue_num}"
+		if [[ "${foss_session_keys_seen}" == *$'\n'"${foss_session_key}"$'\n'* ]]; then
+			echo "[pulse-wrapper] FOSS dispatch skipped duplicate session key ${foss_session_key} in this cycle" >>"$LOGFILE"
+			continue
+		fi
+		foss_session_keys_seen="${foss_session_keys_seen}${foss_session_key}"$'\n'
 
 		local disclosure_flag=""
 		local disclosure
@@ -1219,7 +1231,7 @@ dispatch_foss_workers() {
 
 		"$HEADLESS_RUNTIME_HELPER" run \
 			--role worker \
-			--session-key "foss-${foss_slug}-${foss_issue_num}" \
+			--session-key "$foss_session_key" \
 			--dir "$foss_path" \
 			--title "FOSS: ${foss_slug} #${foss_issue_num}: ${foss_issue_title}" \
 			--prompt "/full-loop Implement issue #${foss_issue_num} (https://github.com/${foss_slug}/issues/${foss_issue_num}) -- ${foss_issue_title}. This is a FOSS contribution.${disclosure_flag} After completion, run: foss-contribution-helper.sh record ${foss_slug} <tokens_used>" \

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Regression coverage for GH#22788: FOSS dispatch must not launch workers for
+# null issue selections, and one cycle must not launch duplicate workers for the
+# same FOSS issue/session key.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+
+TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/foss-dispatch-XXXXXX")"
+
+cleanup() {
+	rm -rf "$TEST_TMP" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+	return 1
+}
+
+write_fixture_scripts() {
+	mkdir -p "${TEST_TMP}/scripts" "${TEST_TMP}/home/.aidevops/logs" || fail "failed to create fixture dirs"
+	cat >"${TEST_TMP}/scripts/foss-contribution-helper.sh" <<'EOS'
+#!/usr/bin/env bash
+exit 0
+EOS
+	cat >"${TEST_TMP}/headless-runtime-helper.sh" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${HEADLESS_INVOCATION_LOG}"
+exit 0
+EOS
+	chmod +x "${TEST_TMP}/scripts/foss-contribution-helper.sh" "${TEST_TMP}/headless-runtime-helper.sh" || fail "failed to chmod fixtures"
+	return 0
+}
+
+write_repos_json() {
+	local repos_json="$1"
+	cat >"$repos_json" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "owner/project",
+      "path": "/tmp/project",
+      "foss": true,
+      "foss_config": {
+        "labels_filter": ["bug"],
+        "disclosure": false
+      }
+    },
+    {
+      "slug": "owner/project",
+      "path": "/tmp/project",
+      "foss": true,
+      "foss_config": {
+        "labels_filter": ["bug"],
+        "disclosure": false
+      }
+    }
+  ]
+}
+JSON
+	return 0
+}
+
+gh_issue_list() {
+	printf '%s\n' "${GH_ISSUE_LIST_OUTPUT:-}"
+	return 0
+}
+
+sleep() {
+	return 0
+}
+
+write_fixture_scripts
+
+SCRIPT_DIR="${TEST_TMP}/scripts"
+HEADLESS_RUNTIME_HELPER="${TEST_TMP}/headless-runtime-helper.sh"
+HEADLESS_INVOCATION_LOG="${TEST_TMP}/headless.log"
+HOME="${TEST_TMP}/home"
+LOGFILE="${TEST_TMP}/pulse.log"
+export HEADLESS_INVOCATION_LOG
+
+# shellcheck source=../pulse-ancillary-dispatch.sh
+source "${SCRIPTS_DIR}/pulse-ancillary-dispatch.sh"
+
+repos_json="${TEST_TMP}/repos.json"
+write_repos_json "$repos_json"
+
+GH_ISSUE_LIST_OUTPUT='null|null'
+available_after_null="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json")" || fail "null selection dispatch failed"
+[[ "$available_after_null" == "2" ]] || fail "null selection changed available worker count"
+[[ ! -f "$HEADLESS_INVOCATION_LOG" ]] || fail "null selection launched a worker"
+
+GH_ISSUE_LIST_OUTPUT='42|Fix duplicate dispatch'
+available_after_duplicate="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json")" || fail "duplicate selection dispatch failed"
+[[ "$available_after_duplicate" == "1" ]] || fail "duplicate selection did not consume exactly one worker slot"
+
+launch_count="$(wc -l <"$HEADLESS_INVOCATION_LOG" | tr -d ' ')"
+[[ "$launch_count" == "1" ]] || fail "expected one duplicate-guarded launch, got ${launch_count}"
+
+if ! grep -q -- '--session-key foss-owner/project-42' "$HEADLESS_INVOCATION_LOG"; then
+	fail "expected FOSS session key was not used"
+fi
+
+printf 'PASS: FOSS null issue selections are skipped\n'
+printf 'PASS: FOSS duplicate session keys are deduplicated per cycle\n'
+exit 0


### PR DESCRIPTION
## Summary

Validated FOSS issue selections before worker launch and deduplicated FOSS session keys within a pulse cycle to prevent null or duplicate workers.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

Resolves #22788


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.42 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 102,418 tokens on this as a headless worker.