### PR TITLE
fix: retry OpenAI overloaded streams in OpenCode plugin

### DIFF
--- a/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const DEFAULT_OVERLOAD_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+const OVERLOAD_MARKERS = ["service_unavailable_error", "server_is_overloaded", "servers are currently overloaded"];
+const STREAM_CONTENT_MARKERS = [
+  "response.output_text.delta",
+  "response.function_call_arguments.delta",
+  "response.code_interpreter_call_code.delta",
+  "response.reasoning_summary_text.delta",
+];
+
+export function overloadRetryDelaysMs() {
+  const raw = process.env.AIDEVOPS_OPENAI_OVERLOAD_RETRY_DELAYS_MS || "";
+  const parsed = raw
+    .split(",")
+    .map((part) => Number.parseInt(part.trim(), 10))
+    .filter((value) => Number.isFinite(value) && value >= 0);
+  return parsed.length > 0 ? parsed : DEFAULT_OVERLOAD_RETRY_DELAYS_MS;
+}
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function isOpenAIOverloadText(text) {
+  const lowered = String(text || "").toLowerCase();
+  return OVERLOAD_MARKERS.some((marker) => lowered.includes(marker));
+}
+
+function isOpenAIStreamContentText(text) {
+  return STREAM_CONTENT_MARKERS.some((marker) => String(text || "").includes(marker));
+}
+
+function enqueueChunks(controller, chunks) {
+  for (const chunk of chunks) controller.enqueue(chunk);
+}
+
+async function pipeRemainingStream(reader, controller) {
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return controller.close();
+    controller.enqueue(value);
+  }
+}
+
+async function inspectStreamPrefix(reader, controller, decoder, retryAvailable) {
+  const buffered = [];
+  let bufferedText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      enqueueChunks(controller, buffered);
+      controller.close();
+      return "closed";
+    }
+
+    buffered.push(value);
+    bufferedText += decoder.decode(value, { stream: true });
+
+    if (isOpenAIOverloadText(bufferedText)) {
+      if (!retryAvailable) {
+        enqueueChunks(controller, buffered);
+        return "pipe";
+      }
+      await reader.cancel().catch(() => {});
+      return "retry";
+    }
+
+    if (isOpenAIStreamContentText(bufferedText) || bufferedText.length > 65_536) {
+      enqueueChunks(controller, buffered);
+      return "pipe";
+    }
+  }
+}
+
+async function retryOpenAIOverloadStream(ctx) {
+  const { originalFetch, response, retryInput, init, controller, retryDelays, buildRetryRequest } = ctx;
+  const decoder = new TextDecoder();
+  let currentResponse = response;
+
+  for (let attempt = 0; ; attempt += 1) {
+    const reader = currentResponse.body.getReader();
+    const outcome = await inspectStreamPrefix(reader, controller, decoder, attempt < retryDelays.length);
+    if (outcome === "closed") return;
+    if (outcome === "pipe") return pipeRemainingStream(reader, controller);
+
+    const delayMs = retryDelays[attempt];
+    console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt + 1}/${retryDelays.length})`);
+    if (delayMs > 0) await sleep(delayMs);
+    currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
+    if (!currentResponse.body) return controller.close();
+  }
+}
+
+export function wrapOpenAIOverloadStream(ctx) {
+  const { response } = ctx;
+  if (!response.body) return response;
+  const contentType = response.headers?.get?.("content-type") || "";
+  if (!contentType.includes("text/event-stream")) return response;
+
+  const retryDelays = overloadRetryDelaysMs();
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        await retryOpenAIOverloadStream({ ...ctx, controller, retryDelays });
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -11,6 +11,18 @@ import { getAccounts, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.m
 const OPENAI_API_HOST = "api.openai.com";
 const OPENAI_API_PREFIX = "/v1/";
 const DEFAULT_OPENAI_COOLDOWN_MS = 300_000;
+const DEFAULT_OVERLOAD_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+const OVERLOAD_MARKERS = [
+  "service_unavailable_error",
+  "server_is_overloaded",
+  "servers are currently overloaded",
+];
+const STREAM_CONTENT_MARKERS = [
+  "response.output_text.delta",
+  "response.function_call_arguments.delta",
+  "response.code_interpreter_call_code.delta",
+  "response.reasoning_summary_text.delta",
+];
 const USAGE_LIMIT_MARKERS = [
   "usage limit",
   "rate limit",
@@ -30,6 +42,28 @@ export function parseRetryAfterMs(response) {
   const date = Date.parse(raw);
   if (Number.isFinite(date)) return Math.max(date - Date.now(), DEFAULT_OPENAI_COOLDOWN_MS);
   return DEFAULT_OPENAI_COOLDOWN_MS;
+}
+
+function overloadRetryDelaysMs() {
+  const raw = process.env.AIDEVOPS_OPENAI_OVERLOAD_RETRY_DELAYS_MS || "";
+  const parsed = raw
+    .split(",")
+    .map((part) => Number.parseInt(part.trim(), 10))
+    .filter((value) => Number.isFinite(value) && value >= 0);
+  return parsed.length > 0 ? parsed : DEFAULT_OVERLOAD_RETRY_DELAYS_MS;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function isOpenAIOverloadText(text) {
+  const lowered = String(text || "").toLowerCase();
+  return OVERLOAD_MARKERS.some((marker) => lowered.includes(marker));
+}
+
+function isOpenAIStreamContentText(text) {
+  return STREAM_CONTENT_MARKERS.some((marker) => String(text || "").includes(marker));
 }
 
 function requestUrl(input) {
@@ -62,6 +96,13 @@ export async function isOpenAIUsageLimitResponse(response) {
   const code = String(error?.code || error?.type || "").toLowerCase();
   const message = String(error?.message || "").toLowerCase();
   return [code, message].some((text) => USAGE_LIMIT_MARKERS.some((marker) => text.includes(marker)));
+}
+
+export async function isOpenAIOverloadResponse(response) {
+  if (![500, 502, 503, 504, 529].includes(response.status)) return false;
+  const payload = await readOpenAIErrorPayload(response);
+  const error = payload?.error || payload;
+  return isOpenAIOverloadText([error?.code, error?.type, error?.message].join(" "));
 }
 
 function headersFrom(input, init) {
@@ -122,6 +163,105 @@ async function handleOpenAIUsageLimit(ctx) {
   return originalFetch(retryInput, retryInit);
 }
 
+async function handleOpenAIOverload(ctx) {
+  const { originalFetch, retryInput, init, response } = ctx;
+  const retryDelays = overloadRetryDelaysMs();
+  let lastResponse = response;
+  for (const delayMs of retryDelays) {
+    if (delayMs > 0) await sleep(delayMs);
+    lastResponse = await originalFetch(buildRetryRequest(retryInput), init);
+    if (!(await isOpenAIOverloadResponse(lastResponse))) return lastResponse;
+  }
+  return lastResponse;
+}
+
+function wrapOpenAIOverloadStream(ctx) {
+  const { originalFetch, response, retryInput, init } = ctx;
+  if (!response.body) return response;
+  const contentType = response.headers?.get?.("content-type") || "";
+  if (!contentType.includes("text/event-stream")) return response;
+
+  const retryDelays = overloadRetryDelaysMs();
+  const decoder = new TextDecoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let currentResponse = response;
+      let attempt = 0;
+
+      while (true) {
+        const reader = currentResponse.body.getReader();
+        const buffered = [];
+        let bufferedText = "";
+        let shouldRetry = false;
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              for (const chunk of buffered) controller.enqueue(chunk);
+              controller.close();
+              return;
+            }
+
+            const text = decoder.decode(value, { stream: true });
+            buffered.push(value);
+            bufferedText += text;
+
+            if (isOpenAIOverloadText(bufferedText)) {
+              shouldRetry = attempt < retryDelays.length;
+              if (!shouldRetry) {
+                for (const chunk of buffered) controller.enqueue(chunk);
+                buffered.length = 0;
+                bufferedText = "";
+                break;
+              }
+              await reader.cancel().catch(() => {});
+              break;
+            }
+
+            if (isOpenAIStreamContentText(bufferedText) || bufferedText.length > 65_536) {
+              for (const chunk of buffered) controller.enqueue(chunk);
+              buffered.length = 0;
+              bufferedText = "";
+              break;
+            }
+          }
+
+          if (!shouldRetry) {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) {
+                controller.close();
+                return;
+              }
+              controller.enqueue(value);
+            }
+          }
+        } catch (err) {
+          controller.error(err);
+          return;
+        }
+
+        const delayMs = retryDelays[attempt++];
+        console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt}/${retryDelays.length})`);
+        if (delayMs > 0) await sleep(delayMs);
+        currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
+        if (!currentResponse.body) {
+          controller.close();
+          return;
+        }
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 async function maybeRotateBeforeOpenAIFetch(client, input, init) {
   const current = resolveOpenAIAccount(extractBearerToken(input, init));
   if (!isUnavailableAccount(current)) return init;
@@ -141,8 +281,17 @@ export function installOpenAIProviderFetchRotation(client) {
     const retryInput = openaiRequest ? buildRetryRequest(input) : input;
     const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
     const response = await originalFetch(input, firstInit);
-    if (!openaiRequest || !(await isOpenAIUsageLimitResponse(response))) return response;
-    return handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
+    if (!openaiRequest) return response;
+    if (await isOpenAIUsageLimitResponse(response)) {
+      return handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
+    }
+    if (await isOpenAIOverloadResponse(response)) {
+      return handleOpenAIOverload({ originalFetch, init: firstInit, response, retryInput });
+    }
+    if (response.ok) {
+      return wrapOpenAIOverloadStream({ originalFetch, response, retryInput, init: firstInit });
+    }
+    return response;
   };
   return true;
 }

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -7,22 +7,13 @@
  */
 
 import { getAccounts, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
+import { isOpenAIOverloadText, overloadRetryDelaysMs, sleep, wrapOpenAIOverloadStream } from "./openai-overload-retry.mjs";
+
+export { isOpenAIOverloadText } from "./openai-overload-retry.mjs";
 
 const OPENAI_API_HOST = "api.openai.com";
 const OPENAI_API_PREFIX = "/v1/";
 const DEFAULT_OPENAI_COOLDOWN_MS = 300_000;
-const DEFAULT_OVERLOAD_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
-const OVERLOAD_MARKERS = [
-  "service_unavailable_error",
-  "server_is_overloaded",
-  "servers are currently overloaded",
-];
-const STREAM_CONTENT_MARKERS = [
-  "response.output_text.delta",
-  "response.function_call_arguments.delta",
-  "response.code_interpreter_call_code.delta",
-  "response.reasoning_summary_text.delta",
-];
 const USAGE_LIMIT_MARKERS = [
   "usage limit",
   "rate limit",
@@ -42,28 +33,6 @@ export function parseRetryAfterMs(response) {
   const date = Date.parse(raw);
   if (Number.isFinite(date)) return Math.max(date - Date.now(), DEFAULT_OPENAI_COOLDOWN_MS);
   return DEFAULT_OPENAI_COOLDOWN_MS;
-}
-
-function overloadRetryDelaysMs() {
-  const raw = process.env.AIDEVOPS_OPENAI_OVERLOAD_RETRY_DELAYS_MS || "";
-  const parsed = raw
-    .split(",")
-    .map((part) => Number.parseInt(part.trim(), 10))
-    .filter((value) => Number.isFinite(value) && value >= 0);
-  return parsed.length > 0 ? parsed : DEFAULT_OVERLOAD_RETRY_DELAYS_MS;
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-export function isOpenAIOverloadText(text) {
-  const lowered = String(text || "").toLowerCase();
-  return OVERLOAD_MARKERS.some((marker) => lowered.includes(marker));
-}
-
-function isOpenAIStreamContentText(text) {
-  return STREAM_CONTENT_MARKERS.some((marker) => String(text || "").includes(marker));
 }
 
 function requestUrl(input) {
@@ -175,100 +144,6 @@ async function handleOpenAIOverload(ctx) {
   return lastResponse;
 }
 
-function enqueueChunks(controller, chunks) {
-  for (const chunk of chunks) controller.enqueue(chunk);
-}
-
-async function pipeRemainingStream(reader, controller) {
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      controller.close();
-      return;
-    }
-    controller.enqueue(value);
-  }
-}
-
-async function inspectStreamPrefix(reader, controller, decoder, retryAvailable) {
-  const buffered = [];
-  let bufferedText = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      enqueueChunks(controller, buffered);
-      controller.close();
-      return "closed";
-    }
-
-    const text = decoder.decode(value, { stream: true });
-    buffered.push(value);
-    bufferedText += text;
-
-    if (isOpenAIOverloadText(bufferedText)) {
-      if (retryAvailable) {
-        await reader.cancel().catch(() => {});
-        return "retry";
-      }
-      enqueueChunks(controller, buffered);
-      return "pipe";
-    }
-
-    if (isOpenAIStreamContentText(bufferedText) || bufferedText.length > 65_536) {
-      enqueueChunks(controller, buffered);
-      return "pipe";
-    }
-  }
-}
-
-async function retryOpenAIOverloadStream(ctx) {
-  const { originalFetch, response, retryInput, init, controller, retryDelays } = ctx;
-  const decoder = new TextDecoder();
-  let currentResponse = response;
-
-  for (let attempt = 0; ; attempt += 1) {
-    const reader = currentResponse.body.getReader();
-    const outcome = await inspectStreamPrefix(reader, controller, decoder, attempt < retryDelays.length);
-    if (outcome === "closed") return;
-    if (outcome === "pipe") return pipeRemainingStream(reader, controller);
-
-    const delayMs = retryDelays[attempt];
-    console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt + 1}/${retryDelays.length})`);
-    if (delayMs > 0) await sleep(delayMs);
-    currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
-    if (!currentResponse.body) {
-      controller.close();
-      return;
-    }
-  }
-}
-
-function wrapOpenAIOverloadStream(ctx) {
-  const { originalFetch, response, retryInput, init } = ctx;
-  if (!response.body) return response;
-  const contentType = response.headers?.get?.("content-type") || "";
-  if (!contentType.includes("text/event-stream")) return response;
-
-  const retryDelays = overloadRetryDelaysMs();
-
-  const stream = new ReadableStream({
-    async start(controller) {
-      try {
-        await retryOpenAIOverloadStream({ originalFetch, response, retryInput, init, controller, retryDelays });
-      } catch (err) {
-        controller.error(err);
-      }
-    },
-  });
-
-  return new Response(stream, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
-}
-
 async function maybeRotateBeforeOpenAIFetch(client, input, init) {
   const current = resolveOpenAIAccount(extractBearerToken(input, init));
   if (!isUnavailableAccount(current)) return init;
@@ -296,7 +171,7 @@ export function installOpenAIProviderFetchRotation(client) {
       return handleOpenAIOverload({ originalFetch, init: firstInit, response, retryInput });
     }
     if (response.ok) {
-      return wrapOpenAIOverloadStream({ originalFetch, response, retryInput, init: firstInit });
+      return wrapOpenAIOverloadStream({ originalFetch, response, retryInput, init: firstInit, buildRetryRequest });
     }
     return response;
   };

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -154,26 +154,32 @@ async function maybeRotateBeforeOpenAIFetch(client, input, init) {
   return buildRetryInit(input, init, rotated.access);
 }
 
+async function handleOpenAIFetchRequest(ctx) {
+  const { client, originalFetch, input, init } = ctx;
+  const openaiRequest = isOpenAIProviderRequest(input);
+  const retryInput = openaiRequest ? buildRetryRequest(input) : input;
+  const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
+  const response = await originalFetch(input, firstInit);
+
+  if (!openaiRequest) return response;
+  if (await isOpenAIUsageLimitResponse(response)) {
+    return handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
+  }
+  if (await isOpenAIOverloadResponse(response)) {
+    return handleOpenAIOverload({ originalFetch, init: firstInit, response, retryInput });
+  }
+  if (response.ok) {
+    return wrapOpenAIOverloadStream({ originalFetch, response, retryInput, init: firstInit, buildRetryRequest });
+  }
+  return response;
+}
+
 export function installOpenAIProviderFetchRotation(client) {
   if (installed || typeof globalThis.fetch !== "function") return false;
   installed = true;
   const originalFetch = globalThis.fetch.bind(globalThis);
   globalThis.fetch = async (input, init) => {
-    const openaiRequest = isOpenAIProviderRequest(input);
-    const retryInput = openaiRequest ? buildRetryRequest(input) : input;
-    const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
-    const response = await originalFetch(input, firstInit);
-    if (!openaiRequest) return response;
-    if (await isOpenAIUsageLimitResponse(response)) {
-      return handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
-    }
-    if (await isOpenAIOverloadResponse(response)) {
-      return handleOpenAIOverload({ originalFetch, init: firstInit, response, retryInput });
-    }
-    if (response.ok) {
-      return wrapOpenAIOverloadStream({ originalFetch, response, retryInput, init: firstInit, buildRetryRequest });
-    }
-    return response;
+    return handleOpenAIFetchRequest({ client, originalFetch, input, init });
   };
   return true;
 }

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -175,6 +175,75 @@ async function handleOpenAIOverload(ctx) {
   return lastResponse;
 }
 
+function enqueueChunks(controller, chunks) {
+  for (const chunk of chunks) controller.enqueue(chunk);
+}
+
+async function pipeRemainingStream(reader, controller) {
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      controller.close();
+      return;
+    }
+    controller.enqueue(value);
+  }
+}
+
+async function inspectStreamPrefix(reader, controller, decoder, retryAvailable) {
+  const buffered = [];
+  let bufferedText = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      enqueueChunks(controller, buffered);
+      controller.close();
+      return "closed";
+    }
+
+    const text = decoder.decode(value, { stream: true });
+    buffered.push(value);
+    bufferedText += text;
+
+    if (isOpenAIOverloadText(bufferedText)) {
+      if (retryAvailable) {
+        await reader.cancel().catch(() => {});
+        return "retry";
+      }
+      enqueueChunks(controller, buffered);
+      return "pipe";
+    }
+
+    if (isOpenAIStreamContentText(bufferedText) || bufferedText.length > 65_536) {
+      enqueueChunks(controller, buffered);
+      return "pipe";
+    }
+  }
+}
+
+async function retryOpenAIOverloadStream(ctx) {
+  const { originalFetch, response, retryInput, init, controller, retryDelays } = ctx;
+  const decoder = new TextDecoder();
+  let currentResponse = response;
+
+  for (let attempt = 0; ; attempt += 1) {
+    const reader = currentResponse.body.getReader();
+    const outcome = await inspectStreamPrefix(reader, controller, decoder, attempt < retryDelays.length);
+    if (outcome === "closed") return;
+    if (outcome === "pipe") return pipeRemainingStream(reader, controller);
+
+    const delayMs = retryDelays[attempt];
+    console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt + 1}/${retryDelays.length})`);
+    if (delayMs > 0) await sleep(delayMs);
+    currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
+    if (!currentResponse.body) {
+      controller.close();
+      return;
+    }
+  }
+}
+
 function wrapOpenAIOverloadStream(ctx) {
   const { originalFetch, response, retryInput, init } = ctx;
   if (!response.body) return response;
@@ -182,75 +251,13 @@ function wrapOpenAIOverloadStream(ctx) {
   if (!contentType.includes("text/event-stream")) return response;
 
   const retryDelays = overloadRetryDelaysMs();
-  const decoder = new TextDecoder();
 
   const stream = new ReadableStream({
     async start(controller) {
-      let currentResponse = response;
-      let attempt = 0;
-
-      while (true) {
-        const reader = currentResponse.body.getReader();
-        const buffered = [];
-        let bufferedText = "";
-        let shouldRetry = false;
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              for (const chunk of buffered) controller.enqueue(chunk);
-              controller.close();
-              return;
-            }
-
-            const text = decoder.decode(value, { stream: true });
-            buffered.push(value);
-            bufferedText += text;
-
-            if (isOpenAIOverloadText(bufferedText)) {
-              shouldRetry = attempt < retryDelays.length;
-              if (!shouldRetry) {
-                for (const chunk of buffered) controller.enqueue(chunk);
-                buffered.length = 0;
-                bufferedText = "";
-                break;
-              }
-              await reader.cancel().catch(() => {});
-              break;
-            }
-
-            if (isOpenAIStreamContentText(bufferedText) || bufferedText.length > 65_536) {
-              for (const chunk of buffered) controller.enqueue(chunk);
-              buffered.length = 0;
-              bufferedText = "";
-              break;
-            }
-          }
-
-          if (!shouldRetry) {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) {
-                controller.close();
-                return;
-              }
-              controller.enqueue(value);
-            }
-          }
-        } catch (err) {
-          controller.error(err);
-          return;
-        }
-
-        const delayMs = retryDelays[attempt++];
-        console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt}/${retryDelays.length})`);
-        if (delayMs > 0) await sleep(delayMs);
-        currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
-        if (!currentResponse.body) {
-          controller.close();
-          return;
-        }
+      try {
+        await retryOpenAIOverloadStream({ originalFetch, response, retryInput, init, controller, retryDelays });
+      } catch (err) {
+        controller.error(err);
       }
     },
   });

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -26,6 +26,17 @@ test("detects OpenAI usage-limit responses", async () => {
   assert.equal(await isOpenAIUsageLimitResponse(new Response("ok", { status: 200 })), false);
 });
 
+test("detects OpenAI overloaded responses and stream chunks", async () => {
+  const { isOpenAIOverloadResponse, isOpenAIOverloadText } = await loadModule();
+  const overloaded = new Response(
+    JSON.stringify({ error: { type: "service_unavailable_error", code: "server_is_overloaded" } }),
+    { status: 503, headers: { "content-type": "application/json" } },
+  );
+  assert.equal(await isOpenAIOverloadResponse(overloaded), true);
+  assert.equal(isOpenAIOverloadText('{"type":"error","error":{"code":"server_is_overloaded"}}'), true);
+  assert.equal(await isOpenAIOverloadResponse(new Response("ok", { status: 200 })), false);
+});
+
 test("installed fetch guard rotates on response failures and pre-request cooldowns", async () => {
   const home = mkdtempSync(join(tmpdir(), "aidevops-openai-rotation-"));
   const script = String.raw`
@@ -90,10 +101,34 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
 
     assert.equal(cooldownPreflight.response.status, 200);
     assert.deepEqual(cooldownPreflight.calls, ["Bearer fresh-token"]);
+
+    const streamRetry = await withInstalledGuard({
+      openai: [
+        { email: "active@example.com", access: "active-token", refresh: "active-refresh", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z" },
+      ],
+    }, async (input, init, calls) => {
+      calls.push(new Headers(init?.headers).get("authorization"));
+      if (calls.length === 1) {
+        return new Response('data: {"type":"error","sequence_number":2,"error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","param":null}}\n\n', {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response('data: {"type":"response.output_text.delta","delta":"ok"}\n\n', {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }, {
+      url: "https://api.openai.com/v1/responses",
+      init: { method: "POST", headers: { authorization: "Bearer active-token" }, body: "{}" },
+    });
+
+    assert.equal(await streamRetry.response.text(), 'data: {"type":"response.output_text.delta","delta":"ok"}\n\n');
+    assert.deepEqual(streamRetry.calls, ["Bearer active-token", "Bearer active-token"]);
   `;
   execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
     cwd: join(import.meta.dirname, ".."),
-    env: { ...process.env, HOME: home },
+    env: { ...process.env, HOME: home, AIDEVOPS_OPENAI_OVERLOAD_RETRY_DELAYS_MS: "0,0" },
     stdio: "pipe",
   });
 });


### PR DESCRIPTION
## Summary
- Retry transient OpenAI overload failures in the OpenCode aidevops plugin before OpenCode surfaces a terminal stream error.
- Detect both HTTP 5xx overload responses and early SSE error chunks containing `service_unavailable_error` / `server_is_overloaded`.
- Add regression tests for overload detection and stream retry behaviour.

Resolves #22793

## Worker-ready context
Files changed:
- `.agents/plugins/opencode-aidevops/openai-provider-auth.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs`

Reference pattern:
- Existing OpenAI OAuth pool fetch wrapper and rotation tests in the same files.

Verification:
- `node --test .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs`
- `git diff --check -- .agents/plugins/opencode-aidevops/openai-provider-auth.mjs .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs`

## Related upstream work
- OpenCode upstream issue: anomalyco/opencode#25731
- OpenCode upstream PR: anomalyco/opencode#25732

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.42 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1h 3m and 698,549 tokens on this with the user in an interactive session.
