### PR TITLE
GH#22790: fix FOSS dispatch regression test race

### DIFF
--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -100,8 +100,11 @@ available_after_null="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$
 [[ ! -f "$HEADLESS_INVOCATION_LOG" ]] || fail "null selection launched a worker"
 
 GH_ISSUE_LIST_OUTPUT='42|Fix duplicate dispatch'
-available_after_duplicate="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json")" || fail "duplicate selection dispatch failed"
+available_output="${TEST_TMP}/available.out"
+FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json" >"$available_output" || fail "duplicate selection dispatch failed"
+available_after_duplicate="$(<"$available_output")"
 [[ "$available_after_duplicate" == "1" ]] || fail "duplicate selection did not consume exactly one worker slot"
+wait
 
 launch_count="$(wc -l <"$HEADLESS_INVOCATION_LOG" | tr -d ' ')"
 [[ "$launch_count" == "1" ]] || fail "expected one duplicate-guarded launch, got ${launch_count}"


### PR DESCRIPTION
## Summary

Stabilized the FOSS dispatch regression test by avoiding command-substitution subshell execution for the duplicate dispatch case and waiting for the background helper before asserting the invocation log.

## Files Changed

.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

Resolves #22790


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.42 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 6m and 72,860 tokens on this as a headless worker.