### PR TITLE
GH#22797: restore core AGENTS progress guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -74,6 +74,8 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 ### Git workflow
 
 - Git is the audit trail. Use wrapper-created GitHub writes with origin labels, claim interactive issues before work, include task IDs in PR titles, `Resolves #NNN` for leaf PRs, and `For #NNN`/`Ref #NNN` for parent references. Never invent task IDs.
+- Interactive issue pickup: when the user identifies an existing issue or you open a worktree for one, immediately run `interactive-session-helper.sh claim <N> <owner/repo>` to self-assign, apply `status:in-review`, and write the crash-recovery stamp; release with `interactive-session-helper.sh release <N> <owner/repo>` on handoff, abandonment, or task switch. Use `lockdown` when dispatch-only insulation is insufficient.
+- Worker/maintainer gate interpretation: an unassigned issue is not a maintainer blocker for an OWNER/MEMBER interactive session; claim it and continue. For headless workers, work only on the dispatched issue/PR and treat mismatched linked-issue writes as out of scope unless the dispatcher explicitly assigned that target.
 - Interactive sessions: no direct edits on canonical `main`/`master`; all work uses a linked worktree under `~/Git/`, never runtime temp dirs. Headless implementation workers use worktree+PR unless explicitly planning-only.
 - Pre-edit exit codes: 0 proceed, 1 stop on main, 2 create worktree, 3 warn off-main. Do not revert others' changes without explicit request.
 - After each logical change, commit WIP (`git add -A && git commit -m "wip: ..."`) unless generated/temp gitignored. Squash/amend later as needed.
@@ -83,8 +85,9 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 ### GitHub and worker context
 
 - Every issue, PR, and comment that describes work MUST include worker-ready context: files to modify, reference pattern, verification, and explicit note when paths cannot be known. Brief template source: `templates/brief-template.md`.
-- PR/issue/comment bodies must satisfy signature/footer and same-command `--body-file` discipline. Thread-clean reading and non-collaborator body immunity: `reference/gh-command-discipline.md`.
-- Auto-generated issue triage outcomes: falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous → decision-ready comment + `needs-maintainer-review`. Full templates: `reference/worker-discipline.md`.
+- Use GitHub wrappers for issue/PR creation so origin labels and signatures are applied; never hand-compose signature footers. PR/issue/comment bodies must satisfy same-command `--body-file` discipline. Thread-clean reading and non-collaborator body immunity: `reference/gh-command-discipline.md`.
+- Auto-generated issue triage outcomes: verify premise first; falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous only → decision-ready comment + `needs-maintainer-review`. Scope/style uncertainty is not NMR. Full templates: `reference/worker-discipline.md`.
+- Parent/research tasks: `parent-task` is a permanent dispatch block; PRs against parent issues use `For #NNN`/`Ref #NNN` until the final child/phase. New worker-ready tasks default to auto-dispatch; if implementing an auto-dispatch issue interactively, use `interactive-start-helper.sh --issue N --repo owner/repo --task "..." --auto-dispatch`.
 
 ### Quality and diagnostics
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -74,7 +74,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 ### Git workflow
 
 - Git is the audit trail. Use wrapper-created GitHub writes with origin labels, claim interactive issues before work, include task IDs in PR titles, `Resolves #NNN` for leaf PRs, and `For #NNN`/`Ref #NNN` for parent references. Never invent task IDs.
-- Interactive issue pickup: when the user identifies an existing issue or you open a worktree for one, immediately run `interactive-session-helper.sh claim <N> <owner/repo>` to self-assign, apply `status:in-review`, and write the crash-recovery stamp; release with `interactive-session-helper.sh release <N> <owner/repo>` on handoff, abandonment, or task switch. Use `lockdown` when dispatch-only insulation is insufficient.
+- Interactive issue pickup: when the user identifies an existing issue or you open a worktree for one, immediately run `interactive-session-helper.sh claim <N> <owner/repo>` to self-assign, apply `status:in-review`, and write the crash-recovery stamp; release with `interactive-session-helper.sh release <N> <owner/repo>` on handoff, abandonment, or task switch. Use `lockdown` when dispatch-only insulation is insufficient; never remove another claim's worktree because it can destroy an active agent workspace.
 - Worker/maintainer gate interpretation: an unassigned issue is not a maintainer blocker for an OWNER/MEMBER interactive session; claim it and continue. For headless workers, work only on the dispatched issue/PR and treat mismatched linked-issue writes as out of scope unless the dispatcher explicitly assigned that target.
 - Interactive sessions: no direct edits on canonical `main`/`master`; all work uses a linked worktree under `~/Git/`, never runtime temp dirs. Headless implementation workers use worktree+PR unless explicitly planning-only.
 - Pre-edit exit codes: 0 proceed, 1 stop on main, 2 create worktree, 3 warn off-main. Do not revert others' changes without explicit request.
@@ -86,7 +86,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Every issue, PR, and comment that describes work MUST include worker-ready context: files to modify, reference pattern, verification, and explicit note when paths cannot be known. Brief template source: `templates/brief-template.md`.
 - Use GitHub wrappers for issue/PR creation so origin labels and signatures are applied; never hand-compose signature footers. PR/issue/comment bodies must satisfy same-command `--body-file` discipline. Thread-clean reading and non-collaborator body immunity: `reference/gh-command-discipline.md`.
-- Auto-generated issue triage outcomes: verify premise first; falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous only → decision-ready comment + `needs-maintainer-review`. Scope/style uncertainty is not NMR. Full templates: `reference/worker-discipline.md`.
+- Auto-generated issue triage outcomes: verify premise first; falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous → decision-ready comment + `needs-maintainer-review`. Scope/style uncertainty is not NMR. Full templates: `reference/worker-discipline.md`.
 - Parent/research tasks: `parent-task` is a permanent dispatch block; PRs against parent issues use `For #NNN`/`Ref #NNN` until the final child/phase. New worker-ready tasks default to auto-dispatch; if implementing an auto-dispatch issue interactively, use `interactive-start-helper.sh --issue N --repo owner/repo --task "..." --auto-dispatch`.
 
 ### Quality and diagnostics


### PR DESCRIPTION
## Summary
- Restores always-loaded AGENTS guidance for interactive issue claiming, maintainer unassigned-issue handling, worker target scope, GitHub wrapper/signature discipline, auto-generated issue triage, parent-task dispatch blocking, and interactive auto-dispatch takeover.

## Verification
- `bytes=$(wc -c < .agents/AGENTS.md | tr -d ' '); approx=$(( (bytes + 3) / 4 )); printf '.agents/AGENTS.md: %s bytes (~%s tokens)\n' "$bytes" "$approx"; test "$bytes" -le 24000`
- `npx --no-install markdownlint-cli2 .agents/AGENTS.md`
- `git diff --check -- .agents/AGENTS.md`

Resolves #22797


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.45 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 5m and 105,696 tokens on this as a headless worker.
