### PR TITLE
test: cover prelaunch canary stale recovery

### DIFF
--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression guard for GH#4011/GH#4012 / t2769 no_work false trips.
+# Regression guard for GH#4011/GH#4012 and a private app meta issue's t2769
+# no_work false trips.
 #
 # A stale active label + assignee with no dispatch claim comment can be cleaned
 # up by stale recovery, but it is not evidence that a worker ever started. That
@@ -53,6 +54,10 @@ if [[ "$cmd" == "is-assigned" ]]; then
 	case "${TEST_STALE_MODE:-no_worker}" in
 	no_worker)
 		printf '%s\n' 'STALE_RECOVERED: issue #2905 in awardsapp/awardsapp - unassigned runner (no dispatch claim comment found, no recent activity (threshold=600s, interactive=false))'
+		exit 1
+		;;
+	prelaunch_canary)
+		printf '%s\n' 'STALE_RECOVERED: issue #2905 in owner/repo - unassigned runner (no dispatch claim comment found, worker canary preflight failed before worktree pre-creation; will retry next cycle)'
 		exit 1
 		;;
 	worker)
@@ -136,6 +141,32 @@ test_stale_recovery_without_claim_skips_fast_fail() {
 	return 0
 }
 
+test_prelaunch_canary_stale_recovery_skips_fast_fail() {
+	export TEST_STALE_MODE="prelaunch_canary"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "awardsapp/awardsapp" "runner" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		fail "prelaunch canary stale recovery continues dispatch" "expected rc=1, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$FAST_FAIL_CALLS" -ne 0 ]]; then
+		fail "prelaunch canary stale recovery skips fast-fail" "fast_fail_record called ${FAST_FAIL_CALLS} time(s): ${LAST_FAST_FAIL}"
+		return 0
+	fi
+	if [[ -s "$CLASSIFY_LOG" ]]; then
+		fail "prelaunch canary stale recovery skips classifier" "classifier log: $(tr '\n' ' ' <"$CLASSIFY_LOG")"
+		return 0
+	fi
+	if ! grep -q 'without worker evidence' "$LOGFILE" 2>/dev/null; then
+		fail "prelaunch canary stale recovery logs skip reason" "log: $(tr '\n' ' ' <"$LOGFILE")"
+		return 0
+	fi
+	pass "prelaunch canary stale recovery skips no_work fast-fail"
+	return 0
+}
+
 test_stale_recovery_with_dispatch_claim_records_fast_fail() {
 	export TEST_STALE_MODE="worker"
 	reset_observations
@@ -163,6 +194,7 @@ test_stale_recovery_with_dispatch_claim_records_fast_fail() {
 }
 
 test_stale_recovery_without_claim_skips_fast_fail
+test_prelaunch_canary_stale_recovery_skips_fast_fail
 test_stale_recovery_with_dispatch_claim_records_fast_fail
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Add an explicit regression case for a private app meta issue where stale recovery observes a canary-preflight skip before worktree pre-creation and no dispatch claim comment, ensuring it does not record a `stale_timeout` / `no_work` fast-fail.

## Root Cause

The framework race was split across the dispatch and lifecycle paths: `_dispatch_launch_worker` in `.agents/scripts/pulse-dispatch-worker-launch.sh` can return `worker_launch_rc_2` after `_dlw_canary_preflight` fails before worktree pre-creation, and stale recovery in `.agents/scripts/pulse-dispatch-dedup-layers.sh::_dedup_layer6_assignee_and_stale` must treat the resulting no-claim cleanup as pre-worker evidence, not a productive worker no-work failure. The existing fixes in `worker-lifecycle-common.sh::_worker_failure_reason_is_launch_preflight` and `pulse-fast-fail.sh::_fast_fail_record_locked` keep launch/preflight reasons out of the t2769 no_work breaker; this PR locks the exact canary-preflight stale-recovery sequence.

## Files Changed

- `.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`

## Runtime Testing

- **Risk level:** Low (shell regression test only)
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `bash .agents/scripts/tests/test-no-work-prelaunch-skip.sh`
- `bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh`
- `shellcheck .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh .agents/scripts/pulse-dispatch-dedup-layers.sh .agents/scripts/worker-lifecycle-common.sh .agents/scripts/pulse-fast-fail.sh`
- Post-rebase/sanitization: `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- Post-rebase/sanitization: `shellcheck .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh .agents/scripts/pulse-dispatch-dedup-layers.sh`

For #22800.
Linked private app meta issue: #4044.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.45 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 11m and 172,111 tokens on this with the user in an interactive session.