### PR TITLE
GH#22794: normalize pulse mergeable states

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -65,6 +65,28 @@ readonly _PMP_BACKLOG_OTHER="other"
 # --- Functions ---
 
 #######################################
+# Normalize PR mergeable values from mixed GitHub API paths.
+#
+# gh GraphQL returns MERGEABLE/CONFLICTING/UNKNOWN, while REST fallback and
+# some cached jq paths can surface true/false/null. The merge gate is enum-
+# based, so normalize before comparing to avoid treating boolean `true` as a
+# non-mergeable state.
+#
+# Args: $1=raw mergeable value
+# Stdout: normalized mergeable enum
+#######################################
+_pmp_normalize_mergeable_state() {
+	local raw_state="$1"
+	case "$raw_state" in
+	MERGEABLE|mergeable|true|TRUE) printf 'MERGEABLE' ;;
+	CONFLICTING|conflicting|false|FALSE) printf 'CONFLICTING' ;;
+	UNKNOWN|unknown|''|null|NULL) printf 'UNKNOWN' ;;
+	*) printf '%s' "$raw_state" ;;
+	esac
+	return 0
+}
+
+#######################################
 # Classify one PR object into a scheduling/observability backlog bucket.
 # This is intentionally advisory: it never decides merge eligibility. The
 # existing per-PR gate stack remains authoritative.
@@ -84,6 +106,7 @@ _pmp_classify_pr_backlog_state() {
 			def pending: [.statusCheckRollup[]? | select(up(.status) == "QUEUED" or up(.status) == "IN_PROGRESS" or up(.state) == "PENDING" or up(.state) == "EXPECTED" or ((up(.conclusion) == "") and (up(.state) != "SUCCESS") and (up(.status) != "COMPLETED")))] | length;
 			"\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.isDraft // false)\u001e\([.labels[].name] | join(","))\u001e\(failed)\u001e\(pending)"' 2>/dev/null
 	)
+	mergeable=$(_pmp_normalize_mergeable_state "$mergeable")
 
 	[[ "$failed_count" =~ ^[0-9]+$ ]] || failed_count=0
 	[[ "$pending_count" =~ ^[0-9]+$ ]] || pending_count=0
@@ -426,16 +449,19 @@ _resolve_pr_mergeable_status() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local pr_mergeable="$3"
+	local original_mergeable="$pr_mergeable"
+	pr_mergeable=$(_pmp_normalize_mergeable_state "$pr_mergeable")
 
 	if [[ "$pr_mergeable" == "UNKNOWN" || -z "$pr_mergeable" ]]; then
-		local _was_label="$pr_mergeable"
-		[[ -z "$pr_mergeable" ]] && _was_label="empty"
+		local _was_label="$original_mergeable"
+		[[ -z "$original_mergeable" ]] && _was_label="empty"
 		# Separate local declaration from assignment to preserve exit code (SC2181).
 		local _retry_output _retry_exit
 		_retry_output=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json mergeable --jq '.mergeable // ""')
 		_retry_exit=$?
 		[[ $_retry_exit -eq 0 && -n "$_retry_output" ]] && pr_mergeable="$_retry_output" || pr_mergeable="UNKNOWN"
+		pr_mergeable=$(_pmp_normalize_mergeable_state "$pr_mergeable")
 		if [[ "$pr_mergeable" == "MERGEABLE" ]]; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — mergeable resolved to MERGEABLE after retry" >>"$LOGFILE"
 		else

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -499,6 +499,7 @@ _process_single_ready_pr() {
 		printf '%s' "$pr_obj" | jq -r \
 			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")"'
 	)
+	pr_mergeable=$(_pmp_normalize_mergeable_state "$pr_mergeable")
 
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
 
@@ -544,6 +545,7 @@ _process_single_ready_pr() {
 			_refetched_mergeable=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 				--json mergeable --jq '.mergeable // "UNKNOWN"' 2>/dev/null) || _refetched_mergeable="UNKNOWN"
 			pr_mergeable="$_refetched_mergeable"
+			pr_mergeable=$(_pmp_normalize_mergeable_state "$pr_mergeable")
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch succeeded, refetched mergeable=${pr_mergeable} (t2116)" >>"$LOGFILE"
 			# If still CONFLICTING after a successful update-branch, the
 			# conflict is semantic and unsalvageable. Fall through to close.

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -108,10 +108,11 @@ gh_pr_view() {
 define_helper_under_test() {
 	local helper_src
 	helper_src=$(awk '
+		/^_pmp_normalize_mergeable_state\(\) \{/,/^}$/ { print }
 		/^_attempt_pr_update_branch\(\) \{/,/^}$/ { print }
 		/^_resolve_pr_mergeable_status\(\) \{/,/^}$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$helper_src" || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]]; then
+	if [[ -z "$helper_src" || "$helper_src" != *"_pmp_normalize_mergeable_state"* || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]]; then
 		printf 'ERROR: could not extract pulse-merge-process helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -214,6 +215,50 @@ test_resolve_mergeable_retries_unknown() {
 	fi
 
 	print_result "UNKNOWN mergeable retry can resolve to MERGEABLE" 0
+	return 0
+}
+
+test_resolve_mergeable_accepts_boolean_true() {
+	install_gh_stub
+	: >"$LOGFILE"
+	local rc=0
+	_resolve_pr_mergeable_status "21950" "marcusquinn/aidevops" "true" || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		print_result "boolean true mergeable normalizes to MERGEABLE" 1 \
+			"Expected return 0 for boolean true, got ${rc}"
+		return 0
+	fi
+
+	if [[ -s "$LOGFILE" ]]; then
+		print_result "boolean true mergeable normalizes to MERGEABLE" 1 \
+			"Expected no skip log for boolean true. Contents: $(cat "$LOGFILE")"
+		return 0
+	fi
+
+	print_result "boolean true mergeable normalizes to MERGEABLE" 0
+	return 0
+}
+
+test_resolve_mergeable_retries_boolean_true() {
+	install_gh_stub
+	: >"$LOGFILE"
+	local rc=0
+	GH_VIEW_MERGEABLE=true _resolve_pr_mergeable_status "21950" "marcusquinn/aidevops" "UNKNOWN" || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		print_result "UNKNOWN retry boolean true normalizes to MERGEABLE" 1 \
+			"Expected return 0 after retry emitted true, got ${rc}"
+		return 0
+	fi
+
+	if ! grep -q "mergeable resolved to MERGEABLE after retry" "$LOGFILE"; then
+		print_result "UNKNOWN retry boolean true normalizes to MERGEABLE" 1 \
+			"Expected retry success log. Contents: $(cat "$LOGFILE")"
+		return 0
+	fi
+
+	print_result "UNKNOWN retry boolean true normalizes to MERGEABLE" 0
 	return 0
 }
 
@@ -343,6 +388,8 @@ main() {
 	test_update_branch_failure_returns_one
 	test_update_branch_tags_log_with_task_id
 	test_resolve_mergeable_retries_unknown
+	test_resolve_mergeable_accepts_boolean_true
+	test_resolve_mergeable_retries_boolean_true
 	test_resolve_mergeable_retries_empty_and_logs_empty
 	test_nmr_guard_exists_before_close
 	test_mergeable_refetch_after_update_branch


### PR DESCRIPTION
## Summary

Normalized mixed GitHub mergeable values before pulse merge-gate comparisons so REST/cached boolean true no longer blocks eligible PRs as non-MERGEABLE.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-update-branch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-update-branch.sh; shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-update-branch.sh; linters-local reached Secretlint and timed out after Sonar/Qlty/String/ShellCheck-parity gates

Resolves #22794


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.46 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 22m and 168,262 tokens on this with the user in an interactive session.