### PR TITLE
fix: keep failed review bots blocking

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -400,6 +400,72 @@ is_rate_limit_only_comment() {
 	return 1
 }
 
+bot_has_rate_limit_notice() {
+	# Return success only when the bot posted a true rate-limit/quota notice.
+	# Broader non-review states ("Review failed", "Review skipped", closed
+	# during review) must keep blocking instead of entering PASS_RATE_LIMITED.
+	local pr_number="$1"
+	local repo="$2"
+	local bot_login="$3"
+
+	local jq_filter
+	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\")) | (.body // \"\" | @base64)"
+
+	local api_endpoints=(
+		"repos/${repo}/pulls/${pr_number}/reviews"
+		"repos/${repo}/issues/${pr_number}/comments"
+		"repos/${repo}/pulls/${pr_number}/comments"
+	)
+
+	local endpoint records encoded body
+	for endpoint in "${api_endpoints[@]}"; do
+		records=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
+		[[ -z "$records" ]] && continue
+		while IFS= read -r encoded; do
+			[[ -z "$encoded" ]] && continue
+			body=$(echo "$encoded" | base64 -d 2>/dev/null || echo "")
+			[[ -z "$body" ]] && continue
+			if is_rate_limit_only_comment "$body"; then
+				return 0
+			fi
+		done <<<"$records"
+	done
+	return 1
+}
+
+bot_has_non_rate_limit_non_review_notice() {
+	# Return success when the bot posted a known non-review notice that is not a
+	# true rate-limit/quota notice. This takes precedence over older rate-limit
+	# notices from the same bot so failed/skipped states keep blocking.
+	local pr_number="$1"
+	local repo="$2"
+	local bot_login="$3"
+
+	local jq_filter
+	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\")) | (.body // \"\" | @base64)"
+
+	local api_endpoints=(
+		"repos/${repo}/pulls/${pr_number}/reviews"
+		"repos/${repo}/issues/${pr_number}/comments"
+		"repos/${repo}/pulls/${pr_number}/comments"
+	)
+
+	local endpoint records encoded body
+	for endpoint in "${api_endpoints[@]}"; do
+		records=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
+		[[ -z "$records" ]] && continue
+		while IFS= read -r encoded; do
+			[[ -z "$encoded" ]] && continue
+			body=$(echo "$encoded" | base64 -d 2>/dev/null || echo "")
+			[[ -z "$body" ]] && continue
+			if is_non_review_comment "$body" && ! is_rate_limit_only_comment "$body"; then
+				return 0
+			fi
+		done <<<"$records"
+	done
+	return 1
+}
+
 bot_has_real_review() {
 	# t2139 (GH#19251): Check if a bot has posted at least one comment that
 	# is BOTH (a) not a known non-review notice AND (b) "settled" — meaning
@@ -564,19 +630,21 @@ do_check() {
 
 	local found_bots=""
 	local rate_limited_bots=""
+	local non_review_bots=""
 	for bot in "${KNOWN_BOTS[@]}"; do
 		if echo "$all_commenters" | grep -qi "$bot"; then
 			# Bot commented — but is it a real review or a non-review notice?
-			# t2799: "rate_limited_bots" is a legacy variable name — it covers
-			# all bots without a real review (rate-limited, "Review failed",
-			# "Review skipped", etc.). The grace-period / pass behaviour is the
-			# same for all non-review states; the semantic split lives in the
-			# pattern arrays (RATE_LIMIT_PATTERNS vs NON_REVIEW_PATTERNS).
 			if bot_has_real_review "$pr_number" "$repo" "$bot"; then
 				found_bots="${found_bots}${bot} "
-			else
+			elif bot_has_non_rate_limit_non_review_notice "$pr_number" "$repo" "$bot"; then
+				non_review_bots="${non_review_bots}${bot} "
+				echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
+			elif bot_has_rate_limit_notice "$pr_number" "$repo" "$bot"; then
 				rate_limited_bots="${rate_limited_bots}${bot} "
-				echo "non-review notice (not a real review): ${bot}" >&2
+				echo "rate-limit notice (not a real review): ${bot}" >&2
+			else
+				non_review_bots="${non_review_bots}${bot} "
+				echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
 			fi
 		fi
 	done
@@ -585,6 +653,15 @@ do_check() {
 		echo "PASS" # nice — at least one bot posted a real review
 		echo "found: ${found_bots}" >&2
 		return 0
+	elif [[ -n "$non_review_bots" ]]; then
+		# GH#22802: Failed/skipped/placeholder bot states are not capacity
+		# constraints and must not inherit the user preference for true rate
+		# limits. Keep waiting so a follow-up issue or human decision can happen
+		# from the actual non-review state instead of silently merging.
+		echo "WAITING"
+		echo "Bots posted non-review states that are not rate limits: ${non_review_bots}" >&2
+		echo "Gate will keep polling; review_gate.rate_limit_behavior only applies to true rate-limit notices." >&2
+		return 1
 	elif [[ -n "$rate_limited_bots" ]] && any_bot_has_success_status "$pr_number" "$repo"; then
 		# GH#3005: All bots are rate-limited in comments, but at least one
 		# posted a SUCCESS commit status check. Treat as reviewed.

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -429,6 +429,56 @@ test_two_phase_env_override_respected_non_two_phase() {
 	return 0
 }
 
+# ---------- Integration tests: do_check decision buckets (GH#22802) ----------
+
+test_do_check_passes_true_rate_limit_only() {
+	check_for_skip_label() { return 1; }
+	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
+	bot_has_real_review() { return 1; }
+	bot_has_non_rate_limit_non_review_notice() { return 1; }
+	bot_has_rate_limit_notice() { return 0; }
+	any_bot_has_success_status() { return 1; }
+
+	local output status
+	if output=$(do_check 123 'testorg/otherrepo' 2>/dev/null); then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [[ "$status" -eq 0 && "$output" == "PASS_RATE_LIMITED" ]]; then
+		print_result "do_check passes true rate-limit notices by default" 0
+	else
+		print_result "do_check passes true rate-limit notices by default" 1 \
+			"status=${status} output=${output}"
+	fi
+	return 0
+}
+
+test_do_check_blocks_non_rate_limit_non_review_states() {
+	check_for_skip_label() { return 1; }
+	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
+	bot_has_real_review() { return 1; }
+	bot_has_non_rate_limit_non_review_notice() { return 0; }
+	bot_has_rate_limit_notice() { return 0; }
+	any_bot_has_success_status() { return 1; }
+
+	local output status
+	if output=$(do_check 123 'testorg/otherrepo' 2>/dev/null); then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [[ "$status" -eq 1 && "$output" == "WAITING" ]]; then
+		print_result "do_check blocks non-rate-limit non-review states" 0
+	else
+		print_result "do_check blocks non-rate-limit non-review states" 1 \
+			"status=${status} output=${output}"
+	fi
+	return 0
+}
+
 # ---------- Run ----------
 
 main() {
@@ -472,6 +522,11 @@ main() {
 	test_two_phase_coderabbitai_any_edit_settled
 	test_two_phase_unknown_bot_or_semantics_preserved
 	test_two_phase_env_override_respected_non_two_phase
+
+	echo ""
+	echo "=== do_check decision buckets (GH#22802) ==="
+	test_do_check_passes_true_rate_limit_only
+	test_do_check_blocks_non_rate_limit_non_review_states
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}, failed: ${TESTS_FAILED}"

--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ See `.agents/tools/terminal/terminal-title.md` for customization options.
 **Quality Control & Monitoring:**
 
 - **Multi-Platform Analysis**: SonarCloud, CodeFactor, Codacy, CodeRabbit, Qlty, Gemini Code Assist, Snyk
+- **Review gate preferences**: choose whether true review-bot rate limits block merges (`aidevops review-gate owner/repo wait`) or allow merge with follow-up quality coverage (`aidevops review-gate owner/repo pass`, the default). Per-tool overrides are supported, for example `aidevops review-gate owner/repo --tool coderabbitai wait`. Failed, skipped, or placeholder bot states are not treated as rate limits and continue to block until a real review/status appears or a human resolves them.
 - **Performance Auditing**: PageSpeed Insights, Lighthouse, WebPageTest, Core Web Vitals (`/performance` command)
 - **SEO Toolchain**: 40+ SEO subagents including Semrush, Ahrefs, ContentKing, Screaming Frog, Bing Webmaster Tools, Rich Results Test, programmatic SEO, analytics tracking, schema validation, content analysis, keyword mapping, and AI readiness
 - **SEO Debugging**: Open Graph validation, favicon checker, social preview testing


### PR DESCRIPTION
## Summary
- Split true review-bot rate-limit notices from failed/skipped/placeholder non-review states.
- Keep `PASS_RATE_LIMITED` limited to capacity/quota failures while non-review bot states continue blocking.
- Document `aidevops review-gate owner/repo pass|wait` and per-tool preference options in README.

## Verification
- `bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh` (25/25 passed)
- `shellcheck .agents/scripts/review-bot-gate-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh`

Resolves #22802

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.48 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 14m and 167,398 tokens on this with the user in an interactive session.
