### PR TITLE
GH#22802: require merge evidence before reconcile close

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -153,15 +153,17 @@ _gh_pr_list_merged() {
 # prefix-substring false matches (e.g. lookup `|10=`, search `|1=` — the
 # required `=` after the issue number anchors the match boundary).
 #
-# Body-keyword check is built into the lookup itself: the jq scan only
-# emits pairs from PR bodies actually containing Resolves|Closes|Fixes #N.
+# Body-keyword and merge-evidence checks are built into the lookup itself: the
+# jq scan only emits pairs from PRs that have a non-empty mergedAt/merged_at and
+# bodies actually containing Resolves|Closes|Fixes #N.
 # This collapses what was previously two gh API calls per issue (search +
 # pr view --json body) into the single per-repo prefetch.
 #
-# Limit 200 most-recent merged PRs per repo. Sufficient for the typical
-# case (open issue resolved by a PR within days/weeks of merge); a 6-month
-# old open-but-already-merged-by-an-old-PR is degenerate and falls
-# through to next-cycle retry without harm (issue stays open).
+# Limit 200 most-recent closed PRs per repo, then filter to mergedAt locally.
+# GH#22802: REST fallback cannot represent gh's synthetic --state merged; it
+# can return closed-but-unmerged/open-adjacent data. Requiring mergedAt in the
+# jq filter fails closed and prevents the reconciler from closing issues while
+# their linked PR is still open or merely closed-unmerged.
 #
 # Args:    $1 = slug (owner/repo)
 # Returns: prints lookup string on stdout (may be empty); exit 0 always.
@@ -174,8 +176,8 @@ _build_oimp_lookup_for_slug() {
 	# --json body costs more bytes per call but the trip count goes from
 	# ~200/cycle to 8/cycle — net ~30x reduction in API round-trips.
 	local merged_prs_json
-	merged_prs_json=$(_gh_pr_list_merged --repo "$slug" --state merged \
-		--json number,body --limit 200 2>/dev/null) || merged_prs_json="[]"
+	merged_prs_json=$(_gh_pr_list_merged --repo "$slug" --state closed \
+		--json number,body,mergedAt --limit 200 2>/dev/null) || merged_prs_json="[]"
 	[[ -n "$merged_prs_json" && "$merged_prs_json" != "null" ]] || return 0
 
 	# jq scan() with one capture group returns ["issue_num"] per match.
@@ -185,6 +187,7 @@ _build_oimp_lookup_for_slug() {
 	printf '%s' "$merged_prs_json" | jq -r '
 		[
 			.[] | . as $pr |
+			select(($pr.mergedAt // $pr.merged_at // "") != "") |
 			(.body // "") |
 			scan("(?i)(?:resolves|closes|fixes)\\s+#([0-9]+)") |
 			"\(.[0])=\($pr.number)"

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -187,7 +187,7 @@ _build_oimp_lookup_for_slug() {
 	printf '%s' "$merged_prs_json" | jq -r '
 		[
 			.[] | . as $pr |
-			select(($pr.mergedAt // $pr.merged_at // "") != "") |
+			select((.mergedAt // .merged_at // "") != "") |
 			(.body // "") |
 			scan("(?i)(?:resolves|closes|fixes)\\s+#([0-9]+)") |
 			"\(.[0])=\($pr.number)"

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -498,7 +498,8 @@ test_t2984_budget_env_validation() {
 # Verifies the per-repo prefetch helper that replaces _action_oimp_single's
 # per-issue `gh pr list --search` calls. The helper:
 #   1. Calls _gh_pr_list_merged for the slug (stubbed in test).
-#   2. jq scan() extracts (issue_num, pr_num) pairs from PR bodies that
+#   2. Filters to PRs with mergedAt evidence, then jq scan() extracts
+#      (issue_num, pr_num) pairs from PR bodies that
 #      contain Resolves|Closes|Fixes #N (case-insensitive).
 #   3. Returns a "|num=pr|...|" string for grep-based lookup downstream.
 #
@@ -508,15 +509,17 @@ test_t2984_budget_env_validation() {
 #   - PRs with no closing keyword (must be skipped).
 #   - PRs with null body (must not crash).
 #   - Case-insensitivity (resolves/RESOLVES/Resolves all match).
+#   - PRs without mergedAt evidence (must be skipped; GH#22802).
 # ---------------------------------------------------------------------------
 test_t2985_oimp_lookup_builder() {
-	# Fixture: 4 PRs covering the cases above.
+	# Fixture: 5 PRs covering the cases above.
 	local fixture_json
 	fixture_json=$(jq -nc '[
-		{number: 1234, body: "Resolves #42\nFixes #99\nCloses #50"},
-		{number: 5678, body: "closes #100"},
-		{number: 9999, body: "merge candidate, no keyword"},
-		{number: 1111, body: null}
+		{number: 1234, mergedAt: "2026-05-04T12:00:00Z", body: "Resolves #42\nFixes #99\nCloses #50"},
+		{number: 5678, mergedAt: "2026-05-04T12:01:00Z", body: "closes #100"},
+		{number: 9999, mergedAt: "2026-05-04T12:02:00Z", body: "merge candidate, no keyword"},
+		{number: 1111, mergedAt: "2026-05-04T12:03:00Z", body: null},
+		{number: 22806, mergedAt: null, body: "Resolves #22802"}
 	]')
 
 	# Extract the helper definition from RECONCILE_SH.
@@ -538,12 +541,46 @@ test_t2985_oimp_lookup_builder() {
 
 	# Expected output: pipe-delimited |num=pr| pairs, one per scan match.
 	# PR 1234 contributes 3 pairs (42, 99, 50); PR 5678 contributes 1 (100);
-	# PRs 9999 and 1111 contribute 0.
+	# PRs 9999, 1111, and unmerged 22806 contribute 0.
 	local expected="|42=1234|99=1234|50=1234|100=5678|"
 	if [[ "$result" == "$expected" ]]; then
 		_pass "t2985: lookup builder extracts 4 pairs from 2 keyword-bearing PRs"
 	else
 		_fail "t2985: lookup builder — expected '${expected}', got '${result}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 13b (GH#22802): open/closed-unmerged PRs never enter OIMP lookup
+# ---------------------------------------------------------------------------
+test_gh22802_oimp_lookup_requires_merged_at() {
+	local fixture_json
+	fixture_json=$(jq -nc '[
+		{number: 22806, state: "OPEN", mergedAt: null, body: "Resolves #22802"},
+		{number: 22807, state: "CLOSED", mergedAt: "", body: "Fixes #22803"},
+		{number: 22808, state: "MERGED", mergedAt: "2026-05-04T12:04:00Z", body: "Closes #22804"}
+	]')
+
+	local helper_def
+	helper_def=$(sed -n '/^_build_oimp_lookup_for_slug()/,/^}$/p' "${RECONCILE_SH}")
+	if [[ -z "$helper_def" ]]; then
+		_fail "GH#22802: _build_oimp_lookup_for_slug not found in ${RECONCILE_SH}"
+		return 0
+	fi
+
+	local result
+	result=$(bash -c "
+		${helper_def}
+		_gh_pr_list_merged() { printf '%s' '${fixture_json}'; return 0; }
+		_build_oimp_lookup_for_slug 'test/repo'
+	" 2>/dev/null)
+
+	local expected="|22804=22808|"
+	if [[ "$result" == "$expected" ]]; then
+		_pass "GH#22802: OIMP lookup requires mergedAt and skips open/closed-unmerged PRs"
+	else
+		_fail "GH#22802: expected '${expected}', got '${result}'"
 	fi
 	return 0
 }
@@ -720,6 +757,7 @@ test_batched_field_extraction_parity
 test_t2984_time_budget_present
 test_t2984_budget_env_validation
 test_t2985_oimp_lookup_builder
+test_gh22802_oimp_lookup_requires_merged_at
 test_t2985_oimp_lookup_no_prefix_collision
 test_t2985_action_oimp_single_signature
 test_available_feedback_worker_issue_not_assigned


### PR DESCRIPTION
## Summary
- Require non-empty mergedAt/merged_at evidence before the open-issue merged-PR reconciler can close linked issues.
- Query closed PRs and filter locally so REST fallback cannot misclassify open or closed-unmerged PRs as merged.
- Add GH#22802 regression coverage for open/closed-unmerged linked PR bodies.

## Verification
- `bash .agents/scripts/tests/test-pulse-issue-reconcile.sh` (21/21 passed)
- `shellcheck .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/tests/test-pulse-issue-reconcile.sh`

## Runtime Testing
- self-assessed: deterministic shell reconciler guard and focused unit regression; no live close operation performed.

Closes #22802


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.49 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 22m and 308,369 tokens on this with the user in an interactive session.