### PR TITLE
GH#22803: harden OpenCode security-validation deny writes

### DIFF
--- a/.agents/scripts/tests/test-opencode-agent-workflow-security.sh
+++ b/.agents/scripts/tests/test-opencode-agent-workflow-security.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-opencode-agent-workflow-security.sh — Regression tests for OpenCode Agent deny-path hardening
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+WORKFLOW="${REPO_ROOT}/.github/workflows/opencode-agent.yml"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local message="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s: %s\n' "$name" "$message"
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local needle="$2"
+
+	if grep -Fq "$needle" "$WORKFLOW"; then
+		pass "$name"
+		return 0
+	fi
+
+	fail "$name" "missing ${needle}"
+	return 0
+}
+
+test_security_check_permissions_are_explicit() {
+	local name="test_security_check_permissions_are_explicit"
+
+	assert_contains "${name}_contents_read" "      contents: read"
+	assert_contains "${name}_pull_requests_write" "      pull-requests: write"
+	assert_contains "${name}_issues_write" "      issues: write"
+	return 0
+}
+
+test_deny_writes_use_safe_helper() {
+	local name="test_deny_writes_use_safe_helper"
+	local direct_writes
+
+	direct_writes=$(grep -E 'await github\.rest\.(issues|pulls)\.(createComment|createReplyForReviewComment|addLabels)' "$WORKFLOW" || true)
+	if [[ -z "$direct_writes" ]]; then
+		pass "$name"
+		return 0
+	fi
+
+	fail "$name" "found direct throwing deny-path writes: ${direct_writes}"
+	return 0
+}
+
+test_safe_helper_catches_permission_denials() {
+	local name="test_safe_helper_catches_permission_denials"
+
+	assert_contains "${name}_helper" "const safeGitHubWrite = async (description, fn) => {"
+	assert_contains "${name}_403" "error.status === 403"
+	assert_contains "${name}_404" "error.status === 404"
+	# shellcheck disable=SC2016 # Intentionally matching a JavaScript template literal.
+	assert_contains "${name}_warning" 'core.warning(`${description} skipped: ${error.message}`)'
+	return 0
+}
+
+main() {
+	if [[ ! -f "$WORKFLOW" ]]; then
+		fail "workflow_exists" "missing ${WORKFLOW}"
+		return 1
+	fi
+
+	test_security_check_permissions_are_explicit
+	test_deny_writes_use_safe_helper
+	test_safe_helper_catches_permission_denials
+
+	printf 'Tests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ $TESTS_FAILED -eq 0 ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+main "$@"

--- a/.agents/tools/git/opencode-github-security.md
+++ b/.agents/tools/git/opencode-github-security.md
@@ -31,7 +31,7 @@ tools:
 | Pattern detection | Blocks prompt injection attempts |
 | Audit logging | All invocations logged |
 | Timeout | 15 minute max execution |
-| Permissions | Minimal required only |
+| Permissions | Minimal required only; denial notices are best-effort |
 
 <!-- AI-CONTEXT-END -->
 
@@ -116,6 +116,8 @@ View: Repository > Actions > OpenCode AI Agent > Select run > audit-log job.
 External contributors (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE) cannot trigger the agent.
 
 **Maintainers — approving issues**: Review content for safety, check raw markdown for hidden content, add `ai-approved` label. For `security-review` alerts: check Actions log, review triggering comment, remove label or take action.
+
+Denied-command comments, review replies, and `security-review` labels are best-effort. A 403/404 from GitHub must log a warning, but must not fail the security-validation job after `allowed=false` has already blocked agent execution.
 
 ## Monitoring
 

--- a/.agents/tools/git/opencode-github.md
+++ b/.agents/tools/git/opencode-github.md
@@ -155,7 +155,7 @@ if: |
    github.event.comment.author_association == 'COLLABORATOR')
 ```
 
-**Full security implementation** (trusted user validation, `ai-approved` label gates, prompt injection detection, audit logging): see `git/opencode-github-security.md`.
+**Full security implementation** (trusted user validation, `ai-approved` label gates, prompt injection detection, best-effort denial notices, audit logging): see `git/opencode-github-security.md`.
 
 Quick setup with max security:
 

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -45,10 +45,11 @@ jobs:
       github.actor != 'copilot[bot]' &&
       github.actor != 'github-actions[bot]' &&
       github.actor != 'dependabot[bot]'
-    # Needs write permissions to post rejection replies on untrusted comments.
-    # Without this, the GITHUB_TOKEN defaults to read-only and the
-    # createReplyForReviewComment/createComment calls fail with 403. GH#2973.
+    # Needs read access for context plus write access for best-effort rejection
+    # replies/labels on denied commands. Comment/label failures must not turn a
+    # safe deny into a failed workflow. GH#2973, GH#22803.
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     outputs:
@@ -67,6 +68,18 @@ jobs:
             // For pull_request_review_comment: context.payload.pull_request exists, issue is undefined
             const issue = context.payload.issue || context.payload.pull_request;
             const isPRReviewComment = context.eventName === 'pull_request_review_comment';
+
+            const safeGitHubWrite = async (description, fn) => {
+              try {
+                await fn();
+              } catch (error) {
+                if (error.status === 403 || error.status === 404) {
+                  core.warning(`${description} skipped: ${error.message}`);
+                  return;
+                }
+                throw error;
+              }
+            };
             
             // Must contain /oc or /opencode trigger at start of line or after whitespace.
             // The previous regex /\/(oc|opencode)\b/ matched file paths in bot review
@@ -88,20 +101,20 @@ jobs:
               
               // Post warning comment (use appropriate API based on event type)
               if (isPRReviewComment) {
-                await github.rest.pulls.createReplyForReviewComment({
+                await safeGitHubWrite('Security notice PR review reply', () => github.rest.pulls.createReplyForReviewComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: issue.number,
                   comment_id: comment.id,
                   body: `> **Security Notice**: AI agent commands are restricted to repository collaborators.\n\n@${sender.login} your request was not processed. If you believe this is an error, please contact a maintainer.`
-                });
+                }));
               } else {
-                await github.rest.issues.createComment({
+                await safeGitHubWrite('Security notice issue comment', () => github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
                   body: `> **Security Notice**: AI agent commands are restricted to repository collaborators.\n\n@${sender.login} your request was not processed. If you believe this is an error, please contact a maintainer.`
-                });
+                }));
               }
               return;
             }
@@ -115,12 +128,12 @@ jobs:
                 core.setOutput('allowed', 'false');
                 core.setOutput('reason', `Issue missing 'ai-approved' label. Add label first for security.`);
                 
-                await github.rest.issues.createComment({
+                await safeGitHubWrite('AI approval security notice issue comment', () => github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
                   body: `> **Security Notice**: AI agent requires the \`ai-approved\` label on issues before processing.\n\nA maintainer must add this label to confirm the issue content is safe for AI processing.`
-                });
+                }));
                 return;
               }
             }
@@ -151,28 +164,28 @@ jobs:
                 
                 // Post warning (use appropriate API based on event type)
                 if (isPRReviewComment) {
-                  await github.rest.pulls.createReplyForReviewComment({
+                  await safeGitHubWrite('Suspicious command PR review reply', () => github.rest.pulls.createReplyForReviewComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: issue.number,
                     comment_id: comment.id,
                     body: `> **Security Notice**: AI agent detected potentially unsafe content in the command and has blocked execution.\n\nPlease review your request and try again with a clearer, safer instruction.`
-                  });
+                  }));
                 } else {
-                  await github.rest.issues.createComment({
+                  await safeGitHubWrite('Suspicious command issue comment', () => github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
                     body: `> **Security Notice**: AI agent detected potentially unsafe content in the command and has blocked execution.\n\nPlease review your request and try again with a clearer, safer instruction.`
-                  });
+                  }));
                   
                   // Also create a security alert for maintainers (only for issues, not PR comments)
-                  await github.rest.issues.addLabels({
+                  await safeGitHubWrite('Suspicious command security-review label', () => github.rest.issues.addLabels({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
                     labels: ['security-review']
-                  });
+                  }));
                 }
                 return;
               }


### PR DESCRIPTION
## Summary

Hardened the reusable OpenCode Agent security-check job with explicit read permission, best-effort GitHub deny-path writes, docs updates, and a regression test covering the workflow contract.

## Files Changed

.agents/scripts/tests/test-opencode-agent-workflow-security.sh,.agents/tools/git/opencode-github-security.md,.agents/tools/git/opencode-github.md,.github/workflows/opencode-agent.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-opencode-agent-workflow-security.sh; shellcheck .agents/scripts/tests/test-opencode-agent-workflow-security.sh; bash .agents/scripts/lint-workflows-helper.sh .github/workflows/opencode-agent.yml; PyYAML parse of .github/workflows/opencode-agent.yml; npx --yes secretlint on changed files. .agents/scripts/linters-local.sh was attempted twice but timed out during the Secretlint phase after reporting the existing SonarCloud quality gate failure.

Resolves #22803


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.49 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 34m and 169,563 tokens on this with the user in an interactive session.