### PR TITLE
fix: preserve active worker worktrees

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -608,6 +608,58 @@ _handle_worker_branch_orphan() {
 # Run lifecycle — prepare, finish, retry, detach
 # =============================================================================
 
+_hrw_current_worktree_branch() {
+	local work_dir="$1"
+	local branch=""
+
+	branch=$(git -C "$work_dir" branch --show-current 2>/dev/null || true)
+	if [[ -z "$branch" ]]; then
+		branch="detached"
+	fi
+	printf '%s\n' "$branch"
+	return 0
+}
+
+_hrw_claim_worker_worktree() {
+	local session_key="$1"
+	local work_dir="$2"
+
+	# Only dispatcher-created issue workers need this transfer. Interactive
+	# sessions already hold either a registry entry or an interactive claim stamp.
+	if [[ -z "${WORKER_ISSUE_NUMBER:-}" || -z "$work_dir" || ! -d "$work_dir" ]]; then
+		return 0
+	fi
+
+	local branch=""
+	branch=$(_hrw_current_worktree_branch "$work_dir")
+
+	# t3550: dispatcher pre-creation registers the worktree to a short-lived
+	# pulse subshell. After that subshell exits, cleanup sees a dead owner and
+	# can remove the worker's cwd while validators/merge-gate fixes still run.
+	# Transfer ownership to the long-lived headless-runtime-helper PID so
+	# worktree cleanup treats the active worker as the canonical owner.
+	if ! claim_worktree_ownership "$work_dir" "$branch" \
+		--session "$session_key" \
+		--task "${WORKER_ISSUE_NUMBER:-}" \
+		--owner-pid "$$"; then
+		print_error "[fatal] worker worktree already has a live owner: $work_dir"
+		return 1
+	fi
+
+	print_info "[lifecycle] worker_worktree_claimed session=${session_key} branch=${branch} path=${work_dir} pid=$$"
+	return 0
+}
+
+_hrw_release_worker_worktree() {
+	local work_dir="$1"
+
+	if [[ -z "${WORKER_ISSUE_NUMBER:-}" || -z "$work_dir" ]]; then
+		return 0
+	fi
+	unregister_worktree "$work_dir" 2>/dev/null || true
+	return 0
+}
+
 _cmd_run_finish() {
 	local session_key="$1"
 	local ledger_status="$2"
@@ -713,6 +765,7 @@ _cmd_run_finish() {
 
 	_update_dispatch_ledger "$session_key" "$ledger_status"
 	_release_session_lock "$session_key"
+	_hrw_release_worker_worktree "$work_dir"
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
 	fi
@@ -770,6 +823,7 @@ _cmd_run_prepare() {
 	# t2923: Expose worktree path to exit trap handler so _push_wip_commits_on_exit
 	# can push any local-only commits before the worker releases its claim.
 	export _WORKER_WORKTREE_PATH="$work_dir"
+	_hrw_claim_worker_worktree "$session_key" "$work_dir" || return 1
 
 	# GH#6696: Register this dispatch in the in-flight ledger so the pulse
 	# can detect workers that haven't created PRs yet. The ledger bridges

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -148,6 +148,55 @@ test_issue_worker_env_contract_accepts_valid_precreated_worktree() {
 	return 0
 }
 
+test_worker_worktree_claim_transfers_to_runtime_pid() {
+	local worktree_dir="${TEST_ROOT}/claim-worktree"
+	mkdir -p "$worktree_dir"
+	export WORKER_ISSUE_NUMBER="22438"
+
+	local claimed_path="" claimed_branch="" claimed_session="" claimed_task="" claimed_pid=""
+	claim_worktree_ownership() {
+		claimed_path="$1"
+		claimed_branch="$2"
+		shift 2
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+			--session)
+				claimed_session="${2:-}"
+				shift 2
+				;;
+			--task)
+				claimed_task="${2:-}"
+				shift 2
+				;;
+			--owner-pid)
+				claimed_pid="${2:-}"
+				shift 2
+				;;
+			*) shift ;;
+			esac
+		done
+		return 0
+	}
+
+	_hrw_claim_worker_worktree "issue-22438" "$worktree_dir" >/dev/null
+
+	unset -f claim_worktree_ownership 2>/dev/null || true
+	unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+
+	if [[ "$claimed_path" == "$worktree_dir" ]] &&
+		[[ "$claimed_branch" == "detached" ]] &&
+		[[ "$claimed_session" == "issue-22438" ]] &&
+		[[ "$claimed_task" == "22438" ]] &&
+		[[ "$claimed_pid" == "$$" ]]; then
+		print_result "worker worktree claim transfers ownership to runtime PID" 0
+		return 0
+	fi
+
+	print_result "worker worktree claim transfers ownership to runtime PID" 1 \
+		"path=$claimed_path branch=$claimed_branch session=$claimed_session task=$claimed_task pid=$claimed_pid"
+	return 0
+}
+
 test_deleted_cwd_recovery_uses_worker_worktree() {
 	local worktree_dir="${TEST_ROOT}/deleted-cwd-worktree"
 	local stale_dir="${TEST_ROOT}/deleted-cwd-stale"
@@ -960,6 +1009,7 @@ main() {
 	test_issue_worker_env_contract_rejects_missing_env
 	test_issue_worker_env_contract_rejects_missing_worktree
 	test_issue_worker_env_contract_accepts_valid_precreated_worktree
+	test_worker_worktree_claim_transfers_to_runtime_pid
 	test_deleted_cwd_recovery_uses_worker_worktree
 	test_cmd_run_aborts_issue_worker_before_canary_when_env_missing
 	test_deleted_launch_cwd_recovers_to_work_dir


### PR DESCRIPTION
## Summary
- Transfer dispatcher-created issue worker worktree ownership to the long-lived headless runtime PID during worker prepare.
- Release worker worktree registry ownership during run finish so cleanup can resume after the worker exits.
- Add regression coverage for the ownership transfer path.

## Verification
- bash .agents/scripts/tests/test-headless-runtime-helper.sh
- shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #22812
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.51 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 21m and 330,453 tokens on this with the user in an interactive session.