### PR TITLE
fix: classify bash workdir access failures

### DIFF
--- a/.agents/scripts/contributor-insight-helper.sh
+++ b/.agents/scripts/contributor-insight-helper.sh
@@ -159,13 +159,37 @@ _compose_error_pattern_issue() {
 	count=$(printf '%s' "$patterns_json" | jq -r 'length' 2>/dev/null) || count=0
 	local i=0
 	while [[ "$i" -lt "$count" && "$i" -lt 10 ]]; do
-		local tool category pcount models
+		local tool category pcount models examples_len recovery_len
 		tool=$(printf '%s' "$patterns_json" | jq -r ".[$i].tool // \"unknown\"" 2>/dev/null) || tool="unknown"
 		category=$(printf '%s' "$patterns_json" | jq -r ".[$i].error_category // \"other\"" 2>/dev/null) || category="other"
 		pcount=$(printf '%s' "$patterns_json" | jq -r ".[$i].count // 0" 2>/dev/null) || pcount=0
 		models=$(printf '%s' "$patterns_json" | jq -r ".[$i].model_count // 0" 2>/dev/null) || models=0
 
 		body+="- \`${tool}:${category}\` — ${pcount}x across ${models} model(s)"$'\n'
+		examples_len=$(printf '%s' "$patterns_json" | jq -r ".[$i].examples | length // 0" 2>/dev/null) || examples_len=0
+		if [[ "$examples_len" -gt 0 ]]; then
+			local example_error example_input example_user
+			example_error=$(printf '%s' "$patterns_json" | jq -r ".[$i].examples[0].error // \"\"" 2>/dev/null) || example_error=""
+			example_input=$(printf '%s' "$patterns_json" | jq -r ".[$i].examples[0].input // \"\"" 2>/dev/null) || example_input=""
+			example_user=$(printf '%s' "$patterns_json" | jq -r ".[$i].examples[0].user_response // \"\"" 2>/dev/null) || example_user=""
+			example_error=$(sanitize_text "$example_error")
+			example_input=$(sanitize_text "$example_input")
+			example_user=$(sanitize_text "$example_user")
+			[[ ${#example_error} -gt 240 ]] && example_error="${example_error:0:240}..."
+			[[ ${#example_input} -gt 240 ]] && example_input="${example_input:0:240}..."
+			[[ ${#example_user} -gt 240 ]] && example_user="${example_user:0:240}..."
+			[[ -n "$example_error" ]] && body+="  - sanitized error: \`${example_error}\`"$'\n'
+			[[ -n "$example_input" ]] && body+="  - summarized command: \`${example_input}\`"$'\n'
+			[[ -n "$example_user" && "$example_user" != "null" ]] && body+="  - observed user recovery: ${example_user}"$'\n'
+		fi
+		recovery_len=$(printf '%s' "$patterns_json" | jq -r ".[$i].recovery_patterns | length // 0" 2>/dev/null) || recovery_len=0
+		if [[ "$recovery_len" -gt 0 ]]; then
+			local recovery
+			recovery=$(printf '%s' "$patterns_json" | jq -r ".[$i].recovery_patterns[0] // \"\"" 2>/dev/null) || recovery=""
+			recovery=$(sanitize_text "$recovery")
+			[[ ${#recovery} -gt 240 ]] && recovery="${recovery:0:240}..."
+			[[ -n "$recovery" ]] && body+="  - expected recovery: ${recovery}"$'\n'
+		fi
 		i=$((i + 1))
 	done
 

--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -191,6 +191,7 @@ _SEVERITY_RANK = {
     "edit_stale_read": "medium",
     "edit_mismatch": "medium",
     "edit_multiple": "medium",
+    "workdir_not_found": "medium",
     "file_not_found": "medium",
     "timeout": "low",
     "exit_code": "low",

--- a/.agents/scripts/session-miner/extract_errors.py
+++ b/.agents/scripts/session-miner/extract_errors.py
@@ -14,6 +14,7 @@ from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path, 
 
 
 ERROR_CATEGORIES = {
+    "workdir_not_found": re.compile(r"NotFound:\s*FileSystem\.access\s*\(", re.IGNORECASE),
     "file_not_found": re.compile(r"(file not found|no such file|ENOENT)", re.IGNORECASE),
     "edit_stale_read": re.compile(r"modified since.*(last read|was read)", re.IGNORECASE),
     "edit_mismatch": re.compile(r"(oldString|could not find).*in (the )?file", re.IGNORECASE),

--- a/.agents/scripts/tests/test-contributor-insight-helper.sh
+++ b/.agents/scripts/tests/test-contributor-insight-helper.sh
@@ -124,11 +124,21 @@ cat >"$TEST_SIGNALS" <<'JSON'
       },
       {
         "tool": "bash",
-        "error_category": "file_not_found",
+        "error_category": "workdir_not_found",
         "count": 200,
         "model_count": 4,
         "models": ["sonnet", "haiku", "opus", "gpt-4o"],
-        "severity": "medium"
+        "severity": "medium",
+        "examples": [
+          {
+            "error": "NotFound: FileSystem.access (/Users/testuser/Git/secret-corp/private-api)",
+            "input": "bash: git status --short --branch in /Users/testuser/Git/secret-corp/private-api",
+            "user_response": "Ran git worktree list and retried from /Users/testuser/Git/aidevops"
+          }
+        ],
+        "recovery_patterns": [
+          "bash: git worktree list"
+        ]
       },
       {
         "tool": "glob",
@@ -211,7 +221,12 @@ echo "=== Error Pattern Tests ==="
 
 # Test 11: high-frequency error patterns are included
 assert_contains "edit:not_read_first in output" "not_read_first" "$output"
-assert_contains "bash:file_not_found in output" "file_not_found" "$output"
+assert_contains "bash:workdir_not_found in output" "workdir_not_found" "$output"
+assert_contains "sanitized example error included" "sanitized error" "$output"
+assert_contains "summarized command included" "summarized command" "$output"
+assert_contains "expected recovery included" "expected recovery" "$output"
+assert_not_contains "error example has no private path" "/Users/testuser" "$output"
+assert_not_contains "error example has no private slug" "secret-corp/private-api" "$output"
 
 # Test 12: low-frequency errors filtered (count < 20 or model_count < 2)
 assert_not_contains "low-freq glob:other filtered" "glob:other" "$output"

--- a/.agents/scripts/tests/test-session-miner-error-classification.sh
+++ b/.agents/scripts/tests/test-session-miner-error-classification.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-session-miner-error-classification.sh — Unit tests for session-miner error categories.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SESSION_MINER_DIR="${SCRIPT_DIR}/../session-miner"
+
+python3 - "$SESSION_MINER_DIR" <<'PY'
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
+from extract_errors import classify_error
+
+
+cases = {
+    "NotFound: FileSystem.access ([local-worktree])": "workdir_not_found",
+    "ENOENT: no such file or directory, open 'missing.txt'": "file_not_found",
+    "Error: must Read before Edit": "not_read_first",
+}
+
+for raw_error, expected in cases.items():
+    actual = classify_error(raw_error)
+    if actual != expected:
+        raise SystemExit(f"expected {expected!r} for {raw_error!r}, got {actual!r}")
+
+print("session-miner error classification tests passed")
+PY


### PR DESCRIPTION
## Summary
- Classifies OpenCode Bash `NotFound: FileSystem.access (...)` failures as `workdir_not_found` before generic file-not-found handling.
- Adds medium severity metadata and preserves sanitized contributor-insight examples for recurring error-pattern issues.
- Adds regression coverage for classification and public issue-body sanitization.

Resolves #22814

## Runtime Testing
Self-assessed. This is a low-risk classifier/reporting change with shell and Python regression tests.

## Testing
- `bash .agents/scripts/tests/test-session-miner-error-classification.sh`
- `bash .agents/scripts/tests/test-contributor-insight-helper.sh`
- `shellcheck .agents/scripts/contributor-insight-helper.sh .agents/scripts/session-miner-pulse.sh .agents/scripts/tests/test-session-miner-error-classification.sh .agents/scripts/tests/test-contributor-insight-helper.sh`
- `python3 -m py_compile .agents/scripts/session-miner/extract_errors.py .agents/scripts/session-miner/compress.py`
- Fixture run: `python3 .agents/scripts/session-miner/compress.py <fixture> --output <tmp>/compressed_signals.json` plus `jq` assertion for `bash:workdir_not_found` medium severity

## Key decisions
- Kept the specific OpenCode workdir-access pattern ahead of generic file-not-found categories.
- Included only the first sanitized example/recovery per pattern to keep generated public issues actionable without leaking paths or private slugs.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.52 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 4m and 98,591 tokens on this with the user in an interactive session.

