### PR TITLE
GH#22833: preserve OpenAI retry failure signals

### DIFF
--- a/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
@@ -90,7 +90,7 @@ async function retryOpenAIOverloadStream(ctx) {
     console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt + 1}/${retryDelays.length})`);
     if (delayMs > 0) await sleep(delayMs);
     currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
-    if (!currentResponse.body) return controller.close();
+    if (!currentResponse.body) return controller.error(new Error("OpenAI provider: retry response missing body"));
   }
 }
 

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -129,7 +129,7 @@ async function handleOpenAIUsageLimit(ctx) {
   const rotated = await rotateOpenAIPoolToken(client, current?.email);
   if (!rotated?.access) return response;
   const retryInit = buildRetryInit(input, init, rotated.access);
-  return originalFetch(retryInput, retryInit);
+  return originalFetch(buildRetryRequest(retryInput), retryInit);
 }
 
 async function handleOpenAIOverload(ctx) {

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -125,6 +125,30 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
 
     assert.equal(await streamRetry.response.text(), 'data: {"type":"response.output_text.delta","delta":"ok"}\n\n');
     assert.deepEqual(streamRetry.calls, ["Bearer active-token", "Bearer active-token"]);
+
+    const missingBodyRetry = await withInstalledGuard({
+      openai: [
+        { email: "active@example.com", access: "active-token", refresh: "active-refresh", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z" },
+      ],
+    }, async (input, init, calls) => {
+      calls.push(new Headers(init?.headers).get("authorization"));
+      if (calls.length === 1) {
+        return new Response('data: {"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded"}}\n\n', {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response(null, {
+        status: 204,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }, {
+      url: "https://api.openai.com/v1/responses",
+      init: { method: "POST", headers: { authorization: "Bearer active-token" }, body: "{}" },
+    });
+
+    await assert.rejects(() => missingBodyRetry.response.text(), /retry response missing body/);
+    assert.deepEqual(missingBodyRetry.calls, ["Bearer active-token", "Bearer active-token"]);
   `;
   execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
     cwd: join(import.meta.dirname, ".."),


### PR DESCRIPTION
## Summary
- Clone OpenAI retry `Request` inputs before usage-limit retry fetches so retry chains do not consume the preserved request.
- Surface missing retry stream bodies as consumer-visible errors instead of silently closing streams.
- Add regression coverage for the missing-body retry stream path.

## Testing
- `npm test` in `.agents/plugins/opencode-aidevops` (206 passed)
- `node --check .agents/plugins/opencode-aidevops/openai-provider-auth.mjs && node --check .agents/plugins/opencode-aidevops/openai-overload-retry.mjs`
- `.agents/scripts/linters-local.sh` reached existing SonarCloud/advisory gates but timed out during ratchet checks; no changed-file secret or JS syntax failures observed before timeout.

## Runtime Testing
- runtime-verified: Node tests execute the OpenAI provider fetch guard and stream retry path with simulated `fetch`, event-stream responses, overload retry, and missing retry response body handling.

## Files changed
- `.agents/plugins/opencode-aidevops/openai-provider-auth.mjs`
- `.agents/plugins/opencode-aidevops/openai-overload-retry.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs`

## Key decisions
- Kept changes scoped to the two review-bot findings from PR #22792.
- Treated missing retry bodies as stream errors so callers see the retry failure.

Resolves #22833


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.54 plugin for [OpenCode](https://opencode.ai) v1.14.34 with gpt-5.5 spent 11m and 87,641 tokens on this with the user in an interactive session.
