### PR TITLE
GH#22815: expose pulse zero-progress gauges

### DIFF
--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -21,6 +21,7 @@
 # Usage (standalone CLI):
 #   pulse-stats-helper.sh increment <counter_name>
 #   pulse-stats-helper.sh get-24h <counter_name>
+#   pulse-stats-helper.sh get-gauge <gauge_name>
 #   pulse-stats-helper.sh status           — human-readable summary
 #   pulse-stats-helper.sh reset <counter_name>  — clear a counter
 
@@ -158,6 +159,36 @@ pulse_stats_status() {
 }
 
 #######################################
+# Print a human-readable summary of all gauges.
+#######################################
+pulse_stats_gauge_status() {
+	if [[ ! -f "$PULSE_STATS_FILE" ]]; then
+		echo "  No pulse gauges recorded yet."
+		return 0
+	fi
+
+	local names
+	names=$(jq -r '(.gauges // {}) | keys[]' "$PULSE_STATS_FILE" 2>/dev/null) || names=""
+
+	if [[ -z "$names" ]]; then
+		echo "  No pulse gauges recorded yet."
+		return 0
+	fi
+
+	local name value ts
+	while IFS= read -r name; do
+		[[ -z "$name" ]] && continue
+		value=$(jq -r --arg name "$name" '(.gauges[$name].value // 0) | tostring' \
+			"$PULSE_STATS_FILE" 2>/dev/null) || value="0"
+		ts=$(jq -r --arg name "$name" '(.gauges[$name].ts // 0) | tostring' \
+			"$PULSE_STATS_FILE" 2>/dev/null) || ts="0"
+		printf '  %-40s %s (ts=%s)\n' "${name}:" "${value:-0}" "${ts:-0}"
+	done <<<"$names"
+
+	return 0
+}
+
+#######################################
 # Set a named gauge to an absolute integer value (t3193).
 #
 # Gauges are distinct from counters: they store the LATEST observation,
@@ -278,9 +309,21 @@ _main() {
 			pulse_stats_get_24h "$get24h_counter"
 			return 0
 			;;
+		get-gauge)
+			if [[ $# -lt 1 ]]; then
+				echo "Usage: pulse-stats-helper.sh get-gauge <gauge_name>" >&2
+				return 1
+			fi
+			local get_gauge_name="$1"
+			pulse_stats_get_gauge "$get_gauge_name"
+			return 0
+			;;
 		status)
 			echo "Pulse Stats (last 24h):"
 			pulse_stats_status
+			echo ""
+			echo "Pulse Gauges:"
+			pulse_stats_gauge_status
 			return 0
 			;;
 		reset)
@@ -298,6 +341,7 @@ _main() {
 			echo "Usage:"
 			echo "  pulse-stats-helper.sh increment <counter>   Add event to counter"
 			echo "  pulse-stats-helper.sh get-24h <counter>     Count events last 24h"
+			echo "  pulse-stats-helper.sh get-gauge <gauge>     Read current gauge value"
 			echo "  pulse-stats-helper.sh status                Human-readable summary"
 			echo "  pulse-stats-helper.sh reset <counter>       Clear a counter"
 			echo ""

--- a/.agents/scripts/tests/test-pulse-stats-helper.sh
+++ b/.agents/scripts/tests/test-pulse-stats-helper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../pulse-stats-helper.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+export PULSE_STATS_FILE="${TMP_DIR}/pulse-stats.json"
+
+python3 - "$PULSE_STATS_FILE" <<'PY'
+import json
+import sys
+
+json.dump({
+    'counters': {'pulse_merge_branchprotect_404_skips': [1, 2]},
+    'gauges': {
+        'pulse_merge_zero_progress_cycles': {'value': 0, 'ts': 123},
+        'pulse_merge_eligible_stuck_pr_count': {'value': 4, 'ts': 124},
+    },
+}, open(sys.argv[1], 'w'))
+PY
+
+gauge_value="$("$HELPER" get-gauge pulse_merge_zero_progress_cycles)"
+[[ "$gauge_value" == "0" ]]
+
+missing_gauge_value="$("$HELPER" get-gauge missing_gauge)"
+[[ "$missing_gauge_value" == "0" ]]
+
+status_output="${TMP_DIR}/status.txt"
+"$HELPER" status >"$status_output"
+grep -q 'Pulse Gauges:' "$status_output"
+grep -q 'pulse_merge_zero_progress_cycles' "$status_output"
+grep -q 'pulse_merge_eligible_stuck_pr_count' "$status_output"
+
+help_output="${TMP_DIR}/help.txt"
+"$HELPER" help >"$help_output"
+grep -q 'get-gauge <gauge>' "$help_output"
+
+printf 'PASS pulse-stats-helper\n'


### PR DESCRIPTION
## Summary

Added a pulse-stats get-gauge command and gauge section in status output so merge-stuck zero-progress recovery can be verified directly. Investigation showed the reported collapse was stale: PR #22817 has merged and pulse_merge_zero_progress_cycles is currently 0.

## Files Changed

.agents/scripts/pulse-stats-helper.sh,.agents/scripts/tests/test-pulse-stats-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-stats-helper.sh .agents/scripts/tests/test-pulse-stats-helper.sh; .agents/scripts/tests/test-pulse-stats-helper.sh; npx secretlint changed scripts; pulse-stats-helper.sh get-gauge pulse_merge_zero_progress_cycles returned 0; linters-local.sh reached Secretlint but timed out there after existing SonarCloud quality gate failure warning

Resolves #22815


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.54 plugin for [OpenCode](https://opencode.ai) v1.14.34 with gpt-5.5 spent 12m and 149,534 tokens on this with the user in an interactive session.