### PR TITLE
GH#22816: verify worktree edits before completion

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -581,9 +581,10 @@ Key file paths (use these directly, do NOT search for them):
 - All agent scripts live under .agents/scripts/ (not scripts/ at root)
 
 Implementation approach:
-1. Read the issue body FIRST (gh issue view $WORKER_ISSUE_NUMBER). Look for a "Worker Guidance" or "How" section -- it contains the files to modify, reference patterns, and verification commands. Follow these directly instead of exploring the codebase broadly.
-2. Budget discipline: spend at most 25% of your effort on reading/exploring. After reading the issue body + 2-3 reference files mentioned in it, start writing code. Do not read entire helper scripts -- read only the sections you will modify.
-3. If the issue body lacks file paths and implementation steps, exit BLOCKED with reason "missing implementation context" so the dispatcher can enrich the body. Do NOT explore broadly to compensate for a vague issue.
+1. Read the issue body FIRST (gh issue view $WORKER_ISSUE_NUMBER). Look for a "Worker Guidance" or "How" section -- it contains the files to modify, reference patterns, and verification commands. Follow these directly when present.
+2. If Worker Guidance/How is missing or incomplete, do bounded discovery instead of stopping: use the issue title/body, exact error text, nearby helper names, tests, and git history to identify likely target files. Proceed when expected behavior, target area, and safe verification are clear.
+3. Budget discipline: spend at most 25% of your effort on reading/exploring. After reading the issue body + 2-3 likely reference files, start writing code. Do not read entire helper scripts -- read only the sections you will modify.
+4. Exit BLOCKED with reason "missing implementation context" only after bounded discovery still cannot identify expected behavior, target area, or safe verification. Include what you searched and why it remains unsafe.
 
 Progressive context loading:
 - Treat the issue body's Worker Guidance / How section as the authoritative plan.
@@ -595,6 +596,9 @@ Progressive context loading:
 
 Empty tool results:
 If a tool call returns empty output, it usually means the path or pattern was wrong, not that the resource is missing. Common causes: missing .agents/ prefix on paths, wrong glob pattern, file moved/renamed. Retry with corrected paths before giving up. If retries also fail, log what you tried and continue with the next step. Do NOT stop the session over one empty result.
+
+Worktree edit verification (GH#22816):
+After any file edit in the pre-created linked worktree, verify the worktree path still exists and the change is visible before claiming success or pushing. Minimum evidence: git status --short --branch from $WORKER_WORKTREE_PATH plus a diff/stat or commit containing the edited files. If the worktree or edits disappeared, reconstruct from available evidence before reporting completion.
 EOF
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -63,6 +63,9 @@ test_appends_escalation_contract() {
 	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V9'* ]] &&
 		[[ "$output" == *'Read the issue body FIRST'* ]] &&
 		[[ "$output" == *'Look for a "Worker Guidance" or "How" section'* ]] &&
+		[[ "$output" == *'do bounded discovery instead of stopping'* ]] &&
+		[[ "$output" == *'Exit BLOCKED with reason "missing implementation context" only after bounded discovery'* ]] &&
+		[[ "$output" == *'Worktree edit verification (GH#22816)'* ]] &&
 		[[ "$output" == *'Progressive context loading'* ]] &&
 		[[ "$output" == *'Load only referenced workflow/reference docs'* ]] &&
 		[[ "$output" == *'Stop reading once target files, reference pattern, constraints, and verification are clear.'* ]] &&

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -32,7 +32,7 @@ Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NO
 
 Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d+` via TODO.md or `gh issue list`. Extract issue number: `sed -En 's/.*[Ii]ssue[[:space:]]*#*([0-9]+).*/\1/p'`.
 
-**Implementation context (t1901):** Read issue body's "Worker Guidance"/"How" section — follow file paths, implementation steps, and verification commands directly. Read only referenced files. If absent, exit BLOCKED: "missing implementation context". Do NOT explore broadly to compensate.
+**Implementation context (t1901):** Read issue body's "Worker Guidance"/"How" section first. When present, follow file paths, implementation steps, and verification commands directly. When absent or incomplete, do not stop by default: do bounded discovery from the issue title/body, search exact error terms, inspect likely target files, and proceed if the problem is actionable. Exit `BLOCKED` for "missing implementation context" only when the issue is too vague to identify expected behaviour, target area, or safe verification after bounded discovery.
 
 - **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. This applies `status:in-review` + self-assigns + posts a claim comment, blocking pulse dispatch for the entire window between start and PR creation. No agent action required; the helper handles it.
 - **Maintainer gate pre-check (GH#17810 — MANDATORY):** Verify issue lacks `needs-maintainer-review` and has an assignee. `full-loop-helper.sh start` enforces this — exit BLOCKED if either fails.
@@ -70,6 +70,7 @@ Iterate until emitting `<promise>TASK_COMPLETE</promise>`.
 5. **Commit+PR gate (GH#5317 — MANDATORY):** Commit all changes, push, ensure PR exists. Do NOT emit `TASK_COMPLETE` with uncommitted changes or no PR.
 6. **Signature footer gate (GH#12805 — MANDATORY):** PR body and issue closing comment MUST contain `aidevops.sh` signature footer.
 7. **Pre-close verification gate (GH#17372 — MANDATORY):** NEVER close an issue citing an existing PR unless: (a) the PR was created by this session, OR (b) `verify-issue-close-helper.sh check <issue> <pr> <slug>` returns exit 0. If verification fails, leave the issue open and comment with your analysis.
+8. **Worktree edit verification gate (GH#22816):** After file edits in a linked worktree, verify the worktree still exists and the changes are visible before reporting completion or asking to push. Minimum evidence: `git status --short --branch` from the worktree plus a diff/stat or the intended commit. If the worktree vanished or the files are not visible, stop, reconstruct from evidence, and do not claim the edit succeeded.
 
 ### Runtime Testing Gate (t1660.7 — MANDATORY)
 


### PR DESCRIPTION
## Summary

Updated full-loop/headless guidance so missing Worker Guidance triggers bounded discovery instead of an immediate blocker, and added a worktree edit verification gate before completion/push claims.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/workflows/full-loop.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh: 40 pass; .agents/scripts/shellcheck-wrapper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh: pass; git diff --check: pass; .agents/scripts/linters-local.sh reached existing SonarCloud gate failure then timed out during shell portability after non-regression gates passed.

Resolves #22816


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.57 plugin for [OpenCode](https://opencode.ai) v1.14.34 with gpt-5.5 spent 25m and 139,622 tokens on this with the user in an interactive session.