### PR TITLE
GH#22830: fix: classify review bot notice categories

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -466,6 +466,27 @@ bot_has_non_rate_limit_non_review_notice() {
 	return 1
 }
 
+bot_get_notice_category() {
+	# Classify a bot's non-review notice state once so do_check() cannot drift
+	# from tests that stub only one half of the decision bucket. Non-rate-limit
+	# notices take precedence over rate-limit notices from the same bot.
+	local pr_number="$1"
+	local repo="$2"
+	local bot_login="$3"
+
+	if bot_has_non_rate_limit_non_review_notice "$pr_number" "$repo" "$bot_login"; then
+		echo "non-rate-limit"
+		return 0
+	fi
+	if bot_has_rate_limit_notice "$pr_number" "$repo" "$bot_login"; then
+		echo "rate-limit"
+		return 0
+	fi
+
+	echo "none"
+	return 1
+}
+
 bot_has_real_review() {
 	# t2139 (GH#19251): Check if a bot has posted at least one comment that
 	# is BOTH (a) not a known non-review notice AND (b) "settled" — meaning
@@ -631,20 +652,24 @@ do_check() {
 	local found_bots=""
 	local rate_limited_bots=""
 	local non_review_bots=""
+	local notice_category
 	for bot in "${KNOWN_BOTS[@]}"; do
 		if echo "$all_commenters" | grep -qi "$bot"; then
 			# Bot commented — but is it a real review or a non-review notice?
 			if bot_has_real_review "$pr_number" "$repo" "$bot"; then
 				found_bots="${found_bots}${bot} "
-			elif bot_has_non_rate_limit_non_review_notice "$pr_number" "$repo" "$bot"; then
-				non_review_bots="${non_review_bots}${bot} "
-				echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
-			elif bot_has_rate_limit_notice "$pr_number" "$repo" "$bot"; then
-				rate_limited_bots="${rate_limited_bots}${bot} "
-				echo "rate-limit notice (not a real review): ${bot}" >&2
 			else
-				non_review_bots="${non_review_bots}${bot} "
-				echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
+				notice_category=$(bot_get_notice_category "$pr_number" "$repo" "$bot" || echo "none")
+				case "$notice_category" in
+					rate-limit)
+						rate_limited_bots="${rate_limited_bots}${bot} "
+						echo "rate-limit notice (not a real review): ${bot}" >&2
+						;;
+					non-rate-limit | none | *)
+						non_review_bots="${non_review_bots}${bot} "
+						echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
+						;;
+				esac
 			fi
 		fi
 	done

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -435,8 +435,7 @@ test_do_check_passes_true_rate_limit_only() {
 	check_for_skip_label() { return 1; }
 	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
 	bot_has_real_review() { return 1; }
-	bot_has_non_rate_limit_non_review_notice() { return 1; }
-	bot_has_rate_limit_notice() { return 0; }
+	bot_get_notice_category() { echo "rate-limit"; return 0; }
 	any_bot_has_success_status() { return 1; }
 
 	local output status
@@ -459,8 +458,7 @@ test_do_check_blocks_non_rate_limit_non_review_states() {
 	check_for_skip_label() { return 1; }
 	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
 	bot_has_real_review() { return 1; }
-	bot_has_non_rate_limit_non_review_notice() { return 0; }
-	bot_has_rate_limit_notice() { return 0; }
+	bot_get_notice_category() { echo "non-rate-limit"; return 0; }
 	any_bot_has_success_status() { return 1; }
 
 	local output status


### PR DESCRIPTION
## Summary

Added bot_get_notice_category as the single do_check notice classifier and updated the regression tests to stub that combined category function for rate-limit and non-rate-limit paths.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh,.agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh (25 tests, 0 failures); shellcheck .agents/scripts/review-bot-gate-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh (no output); .agents/scripts/linters-local.sh attempted with 240s timeout, reached Secretlint and timed out after reporting a pre-existing SonarCloud quality gate failure: new_security_hotspots_reviewed actual=0.0 required LT 100

Resolves #22830


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.34 with gpt-5.5 spent 6m and 48,284 tokens on this as a headless worker.