### PR TITLE
fix: order dispatch lifecycle comments

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -888,15 +888,15 @@ _dlw_nohup_launch() {
 }
 
 #######################################
-# Post-launch bookkeeping: stagger delay, dispatch-ledger registration, the
-# deterministic "Dispatching worker" comment on the issue, and claim-comment
+# Post-launch bookkeeping: dispatch-ledger registration, the deterministic
+# "Dispatching worker" comment on the issue, stagger delay, and claim-comment
 # retention logging.
 #
 # Stagger (GH#17549): reduces SQLite write contention on opencode.db
 # (busy_timeout=0). Without it, batches of 8+ workers all hit the DB
 # simultaneously, causing SQLITE_BUSY → silent mid-turn death. The stagger
-# gives each worker time to complete its initial DB writes before the next
-# one starts.
+# happens after the dispatch comment is posted so a fast worker failure cannot
+# publish CLAIM_RELEASED before the public "Dispatching worker" audit event.
 #
 # Dispatch comment (GH#15317): posted from the dispatcher, NOT from the
 # worker LLM session. Previously, the worker was responsible for posting
@@ -926,9 +926,6 @@ _dlw_post_launch_hooks() {
 	local session_key="$5"
 	local dispatch_tier="$6"
 	local selected_model="$7"
-
-	local stagger_delay="${PULSE_DISPATCH_STAGGER_SECONDS:-8}"
-	sleep "$stagger_delay"
 
 	# Record in dispatch ledger (with tier telemetry)
 	local ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
@@ -972,6 +969,9 @@ Dispatching worker (deterministic).
 		echo "[dispatch_with_dedup] Claim comment ${_claim_comment_id} retained for audit trail on #${issue_number} (GH#17503)" >>"$LOGFILE"
 		_claim_comment_id=""
 	fi
+
+	local stagger_delay="${PULSE_DISPATCH_STAGGER_SECONDS:-8}"
+	sleep "$stagger_delay"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
+++ b/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
@@ -112,7 +112,7 @@ gh() {
 		local path="${1:-}"
 		shift || true
 		case "$path" in
-		repos/*/issues/*/comments)
+		repos/*/issues/*/comments | repos/*/issues/*/comments\?*)
 			local is_post=0 body="" prev=""
 			local arg
 			for arg in "$@"; do
@@ -130,6 +130,20 @@ gh() {
 				return 0
 			fi
 			_mock_gh_response "$GH_API_COMMENTS_RESPONSE" "$@"
+			;;
+		repos/*/issues/comments/*)
+			local is_delete=0 prev=""
+			local arg
+			for arg in "$@"; do
+				if [[ "$prev" == "--method" && "$arg" == "DELETE" ]]; then
+					is_delete=1
+				fi
+				prev="$arg"
+			done
+			if [[ "$is_delete" -eq 1 ]]; then
+				printf '%s\n' 'DELETE_COMMENT' >>"$GH_COMMENT_LOG"
+			fi
+			printf '{}\n'
 			;;
 		repos/*/branches)
 			_mock_gh_response "$GH_API_BRANCHES_RESPONSE" "$@"
@@ -204,6 +218,11 @@ count_gh_comments() {
 	n=$(grep -c '^---END_COMMENT---$' "$GH_COMMENT_LOG" 2>/dev/null || true)
 	[[ "$n" =~ ^[0-9]+$ ]] || n=0
 	printf '%s' "$n"
+	return 0
+}
+
+sleep() {
+	printf '%s\n' 'SLEEP_CALLED' >>"$GH_COMMENT_LOG"
 	return 0
 }
 
@@ -301,23 +320,36 @@ else
 	print_result "Fix B: no_work on empty repo slug" 1 "got '$crash_type_no_repo'"
 fi
 
-# --- Fix C: post-claim aborts release their dispatch claim ---
+# --- Fix C: pre-launch aborts delete noisy dispatch claims ---
 
 reset_gh_state
 _claim_comment_id="claim-123"
 _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
 count_abort_release=$(count_gh_comments)
-if [[ "$count_abort_release" -eq 1 ]] &&
-	grep -q 'CLAIM_RELEASED reason=dispatch_aborted:worker_launch_rc_2 runner=runner-a' "$GH_COMMENT_LOG"; then
-	print_result "Fix C: post-claim launch abort emits CLAIM_RELEASED" 0
+if [[ "$count_abort_release" -eq 0 ]] &&
+	grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
+	print_result "Fix C: pre-launch abort deletes retained claim" 0
 else
-	print_result "Fix C: post-claim launch abort emits CLAIM_RELEASED" 1 "log: $(cat "$GH_COMMENT_LOG")"
+	print_result "Fix C: pre-launch abort deletes retained claim" 1 "log: $(cat "$GH_COMMENT_LOG")"
 fi
 
 if [[ -z "${_claim_comment_id:-}" ]]; then
 	print_result "Fix C: release helper clears retained claim id" 0
 else
 	print_result "Fix C: release helper clears retained claim id" 1 "claim id still set: ${_claim_comment_id}"
+fi
+
+# --- Fix D: dispatch comment is posted before the stagger window ---
+
+reset_gh_state
+PULSE_DISPATCH_STAGGER_SECONDS=8 \
+	_dlw_post_launch_hooks "12345" "owner/repo" "runner-a" "4242" "worker-owner-repo-12345" "standard" "test-model"
+dispatch_line=$(grep -n 'Dispatching worker (deterministic).' "$GH_COMMENT_LOG" | cut -d: -f1 | head -n 1 || true)
+sleep_line=$(grep -n '^SLEEP_CALLED$' "$GH_COMMENT_LOG" | cut -d: -f1 | head -n 1 || true)
+if [[ -n "$dispatch_line" && -n "$sleep_line" && "$dispatch_line" -lt "$sleep_line" ]]; then
+	print_result "Fix D: posts dispatch comment before stagger sleep" 0
+else
+	print_result "Fix D: posts dispatch comment before stagger sleep" 1 "log: $(cat "$GH_COMMENT_LOG")"
 fi
 
 # Cleanup


### PR DESCRIPTION
## Summary
- Move the post-launch stagger until after the deterministic dispatch comment is posted, preserving claim → worker → release ordering even when a worker exits quickly.
- Extend dispatch lifecycle tests to cover the observed ordering race and current pre-launch claim cleanup behavior.

## Root cause
The dispatcher spawned the worker, then slept for the stagger window before posting `Dispatching worker (deterministic)`. A fast zero-output worker could post `CLAIM_RELEASED` during that window, making issue threads show claim → release → worker.

## Verification
- `bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh`
- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-dispatch-lifecycle-comms.sh`
- `.agents/scripts/linters-local.sh` (passes; reports existing advisory/baseline warnings and current SonarCloud badge blocker)

For #22821
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 16m and 105,190 tokens on this with the user in an interactive session.