### PR TITLE
GH#22824: docs: align auto-dispatch exclusions

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -142,7 +142,25 @@ Narrative phases without a per-phase marker are NOT auto-filed unless `<!-- phas
 
 `#{origin}`: `#interactive` (user present) or `#worker` (headless). Detect via `detect_session_origin` from `shared-constants.sh`. Maps to `origin:interactive` / `origin:worker` GitHub labels on issue sync.
 
-**Auto-dispatch default:** Worker-ready implementation tasks default to `#auto-dispatch`. Readiness means the brief has: (1) 2+ acceptance criteria beyond "tests pass"/"lint clean", (2) non-empty "How" with file references, (3) clear deliverable in "What", and (4) automatable verification. If any readiness element is missing, finish the brief before filing/queueing; if the work needs decomposition, research, human preference/approval, credentials, or unresolved dependencies, mark it `#parent`/blocked instead. Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.
+**Auto-dispatch default:** Worker-ready implementation tasks default to `#auto-dispatch`, including issues created by interactive agents or workers.
+
+The readiness gate is:
+
+- 2+ acceptance criteria beyond "tests pass"/"lint clean"
+- Non-empty "How" with file references
+- Clear deliverable in "What"
+- Automatable verification
+
+If any readiness element is missing, finish the brief before filing/queueing; if the task fails the gate, mark it `#parent`/blocked instead. Omit `#auto-dispatch` only for:
+
+- Credentials, accounts, or purchases
+- Decomposition or human-decision work
+- Hardware or external service setup
+- Investigation/evaluation without a clear deliverable
+- Incomplete dependencies
+- Explicit user preference for interactive/manual handling
+
+Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.
 
 ### Step 5: Label, Commit, Push
 


### PR DESCRIPTION
## Summary

Updated .agents/workflows/new-task.md so the auto-dispatch readiness gate and exclusion list are bulletized and synchronized with the canonical planning guidance.

## Files Changed

.agents/workflows/new-task.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified git diff is limited to .agents/workflows/new-task.md; markdownlint-cli2 was unavailable locally, so markdown lint could not be run.

Resolves #22824


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 6m and 69,851 tokens on this as a headless worker.

<!-- ci-feedback:PR22882:SHA24a74e56a66c098beb21639a859513c6f7e1fc92 -->
## CI Repair Feedback (from PR #22882)

The previous worker's PR #22882 had non-passing required CI checks. The PR has been
closed and this issue re-queued for dispatch. The next worker should address these failures.

### Non-passing required checks

- **review-bot-gate**: fail — []()
### Worker guidance

1. Check out a fresh branch from `origin/main` (do NOT reuse the old branch)
2. Read the check URLs above for specific error messages
3. Fix the issues in the code, not in the CI config
4. Ensure all checks pass locally before pushing

_Routed by deterministic merge pass (pulse-merge.sh)._