### PR TITLE
Fix recoverable no-activity worker stalls

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -159,7 +159,7 @@ HEADLESS_ACTIVITY_TIMEOUT_SECONDS="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-600}"
 
 # _parse_run_args: parse cmd_run flags into caller-scoped variables.
 # Caller must declare: role session_key work_dir title prompt prompt_file
-#                      model_override tier_override variant_override agent_name extra_args
+#                      model_override initial_model tier_override variant_override agent_name extra_args
 # Returns 1 on unknown flag.
 _parse_run_args() {
 	while [[ $# -gt 0 ]]; do
@@ -190,6 +190,10 @@ _parse_run_args() {
 			;;
 		--model)
 			model_override="${2:-}"
+			shift 2
+			;;
+		--initial-model)
+			initial_model="${2:-}"
 			shift 2
 			;;
 		--tier)
@@ -759,7 +763,9 @@ _handle_run_result() {
 	#   (t2956 / Issue #21231)
 	# - 124 + activity → return 78 (watchdog_stall_continue) so the retry loop
 	#   can resume the session with a continuation prompt before giving up.
-	# - 124 + no activity → rate_limit as before (provider never responded).
+	# - 124 + startup output but no activity → return 78 so the retry loop can
+	#   try a bounded fresh continuation before provider backoff/rotation.
+	# - 124 + no output or explicit provider marker → rate_limit as before.
 	if [[ "$exit_code" -eq 124 ]]; then
 		failure_reason=$(classify_failure_reason "$output_file")
 		if [[ "$failure_reason" == "rate_limit" ]]; then
@@ -791,6 +797,12 @@ _handle_run_result() {
 				_run_result_label="watchdog_stall_continue"
 				rm -f "$output_file"
 				print_warning "$selected_model watchdog stall with prior activity — will attempt session continuation"
+				return 78
+			fi
+			if [[ -s "$output_file" && "$role" != "pulse" ]]; then
+				_run_result_label="watchdog_startup_continue"
+				rm -f "$output_file"
+				print_warning "$selected_model watchdog startup stall without model activity — will attempt bounded continuation before provider backoff"
 				return 78
 			fi
 			failure_reason="rate_limit"
@@ -1369,6 +1381,7 @@ cmd_run() {
 	local prompt=""
 	local prompt_file=""
 	local model_override=""
+	local initial_model=""
 	local tier_override=""
 	local variant_override=""
 	local agent_name=""
@@ -1388,7 +1401,7 @@ cmd_run() {
 	fi
 
 	local selected_model
-	selected_model=$(choose_model "$role" "$model_override" "$tier_override") || {
+	selected_model=$(choose_model "$role" "${model_override:-$initial_model}" "$tier_override") || {
 		local choose_exit=$?
 		_cmd_run_finish "$session_key" "fail"
 		return "$choose_exit"
@@ -1666,7 +1679,7 @@ headless-runtime-helper.sh - Model-aware headless runtime (OpenCode default, Cla
 Usage:
   headless-runtime-helper.sh select [--role pulse|worker] [--model provider/model]
   headless-runtime-helper.sh canary [--role pulse|worker] [--model provider/model] [--tier haiku|sonnet|opus|...]
-  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--tier haiku|sonnet|opus|...] [--variant NAME] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
+  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model | --initial-model provider/model] [--tier haiku|sonnet|opus|...] [--variant NAME] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
   headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING] [--fast-threshold N]

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -879,7 +879,10 @@ _dlw_nohup_launch() {
 		--prompt "$prompt"
 	)
 	if [[ -n "$selected_model" ]]; then
-		worker_cmd+=(--model "$selected_model")
+		# Dispatcher-selected models are initial preferences, not user-pinned
+		# overrides. Let headless-runtime-helper.sh retry/rotate on transient
+		# no-activity/provider failures while preserving explicit --model pins.
+		worker_cmd+=(--initial-model "$selected_model")
 	fi
 
 	# t2757: Detach worker via setsid (extracted to helper)

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -93,6 +93,97 @@ test_non_full_loop_prompt_unchanged() {
 	return 0
 }
 
+test_parse_initial_model_does_not_set_explicit_override() {
+	local role="worker" session_key="issue-22862" work_dir="$TEST_ROOT" title="Issue #22862" prompt="/full-loop test" prompt_file=""
+	local model_override="" initial_model="" tier_override="" variant_override="" agent_name="" headless_runtime="" detach=0
+	local -a extra_args=()
+
+	_parse_run_args --initial-model openai/gpt-5.5 --tier sonnet --opencode-arg --print-logs
+
+	if [[ "$initial_model" == "openai/gpt-5.5" && -z "$model_override" && "$tier_override" == "sonnet" ]]; then
+		print_result "--initial-model does not set explicit model override" 0
+		return 0
+	fi
+
+	print_result "--initial-model does not set explicit model override" 1 \
+		"initial_model=${initial_model:-<empty>} model_override=${model_override:-<empty>} tier=${tier_override:-<empty>}"
+	return 0
+}
+
+test_startup_no_activity_timeout_returns_watchdog_continue() {
+	local output_file="${TEST_ROOT}/startup-stall.log"
+	printf '%s\n' 'sqlite-migration:done' >"$output_file"
+	_run_result_label=""
+	_run_failure_reason=""
+	_run_should_retry=0
+
+	local status=0
+	_handle_run_result 124 "$output_file" "worker" "openai" "issue-22862" "openai/gpt-5.5" || status=$?
+
+	if [[ "$status" -eq 78 && "$_run_result_label" == "watchdog_startup_continue" && ! -f "$output_file" ]]; then
+		print_result "startup no-activity timeout attempts bounded continuation" 0
+		return 0
+	fi
+
+	print_result "startup no-activity timeout attempts bounded continuation" 1 \
+		"status=$status label=${_run_result_label:-<empty>} output_exists=$([[ -f "$output_file" ]] && printf yes || printf no)"
+	return 0
+}
+
+test_dispatcher_initial_model_can_rotate_after_rate_limit() {
+	local result status action next_model
+	result=$(
+		cmd_run_action=""
+		cmd_run_next_model=""
+		_run_failure_reason="rate_limit"
+		_run_should_retry=0
+		_HRW_STATUS_FAIL="fail"
+		print_warning() { return 0; }
+		choose_model() { printf '%s' 'anthropic/claude-sonnet-4-6'; return 0; }
+		_cmd_run_finish() { return 0; }
+		local retry_status=0
+		_cmd_run_prepare_retry "worker" "issue-22862" "" 1 3 "openai/gpt-5.5" 124 || retry_status=$?
+		printf '%s|%s|%s' "$retry_status" "$cmd_run_action" "$cmd_run_next_model"
+	)
+	IFS='|' read -r status action next_model <<<"$result"
+
+	if [[ "$status" -eq 0 && "$action" == "switch" && "$next_model" == "anthropic/claude-sonnet-4-6" ]]; then
+		print_result "dispatcher-selected initial model can rotate after rate limit" 0
+		return 0
+	fi
+
+	print_result "dispatcher-selected initial model can rotate after rate limit" 1 \
+		"status=$status action=${action:-<empty>} next=${next_model:-<empty>}"
+	return 0
+}
+
+test_explicit_model_override_remains_pinned_on_rate_limit() {
+	local result status finished_status action
+	result=$(
+		cmd_run_action=""
+		cmd_run_next_model=""
+		_run_failure_reason="rate_limit"
+		_run_should_retry=0
+		_HRW_STATUS_FAIL="fail"
+		print_warning() { return 0; }
+		local finished_inner=""
+		_cmd_run_finish() { local status_arg="$2"; finished_inner="$status_arg"; return 0; }
+		local retry_status=0
+		_cmd_run_prepare_retry "worker" "issue-22862" "openai/gpt-5.5" 1 3 "openai/gpt-5.5" 124 || retry_status=$?
+		printf '%s|%s|%s' "$retry_status" "$finished_inner" "$cmd_run_action"
+	)
+	IFS='|' read -r status finished_status action <<<"$result"
+
+	if [[ "$status" -eq 124 && "$finished_status" == "fail" && "$action" == "retry" ]]; then
+		print_result "explicit model override remains pinned on rate limit" 0
+		return 0
+	fi
+
+	print_result "explicit model override remains pinned on rate limit" 1 \
+		"status=$status finish=${finished_status:-<empty>} action=${action:-<empty>}"
+	return 0
+}
+
 test_issue_worker_env_contract_rejects_missing_env() {
 	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
 	local output=""
@@ -1009,6 +1100,10 @@ main() {
 	setup_test_env
 	test_appends_escalation_contract
 	test_non_full_loop_prompt_unchanged
+	test_parse_initial_model_does_not_set_explicit_override
+	test_startup_no_activity_timeout_returns_watchdog_continue
+	test_dispatcher_initial_model_can_rotate_after_rate_limit
+	test_explicit_model_override_remains_pinned_on_rate_limit
 	test_issue_worker_env_contract_rejects_missing_env
 	test_issue_worker_env_contract_rejects_missing_worktree
 	test_issue_worker_env_contract_accepts_valid_precreated_worktree


### PR DESCRIPTION
## Summary

- Added `--initial-model` for dispatcher-selected models so workers can retry/rotate instead of treating the selection as a user-pinned `--model` override.
- Startup watchdog timeouts with runtime output but no model activity now attempt bounded continuation before provider-backoff classification.
- Added regression coverage for initial-model parsing, startup no-activity continuation, retry/rotation, and explicit model pinning.

Resolves #22862

## Verification

- `bash .agents/scripts/tests/test-headless-runtime-helper.sh` — 44 pass / 0 fail
- `shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-headless-runtime-helper.sh` — clean
- `.agents/scripts/linters-local.sh` — completed with final `ALL LOCAL CHECKS PASSED`; pre-existing/advisory Sonar/Qlty/Markdown/ratchet complexity messages shown by the suite

## Notes

The incident evidence was sanitized in the public issue/PR body to avoid private repo references. Provider-marker timeouts still classify as rate-limit immediately; this only changes local/runtime startup stalls that produced output but no model JSON activity.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 34m and 323,872 tokens on this with the user in an interactive session.