### PR TITLE
GH#22855: fix: classify review bot notices in one pass

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -400,6 +400,16 @@ is_rate_limit_only_comment() {
 	return 1
 }
 
+bot_body_base64_jq_filter() {
+	local bot_login="$1"
+
+	printf '%s%s%s\n' \
+		'.[] | select(.user.login | ascii_downcase | test("' \
+		"$bot_login" \
+		'")) | (.body // "" | @base64)'
+	return 0
+}
+
 bot_has_rate_limit_notice() {
 	# Return success only when the bot posted a true rate-limit/quota notice.
 	# Broader non-review states ("Review failed", "Review skipped", closed
@@ -409,7 +419,7 @@ bot_has_rate_limit_notice() {
 	local bot_login="$3"
 
 	local jq_filter
-	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\")) | (.body // \"\" | @base64)"
+	jq_filter=$(bot_body_base64_jq_filter "$bot_login")
 
 	local api_endpoints=(
 		"repos/${repo}/pulls/${pr_number}/reviews"
@@ -442,7 +452,7 @@ bot_has_non_rate_limit_non_review_notice() {
 	local bot_login="$3"
 
 	local jq_filter
-	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\")) | (.body // \"\" | @base64)"
+	jq_filter=$(bot_body_base64_jq_filter "$bot_login")
 
 	local api_endpoints=(
 		"repos/${repo}/pulls/${pr_number}/reviews"
@@ -467,24 +477,49 @@ bot_has_non_rate_limit_non_review_notice() {
 }
 
 bot_get_notice_category() {
-	# Classify a bot's non-review notice state once so do_check() cannot drift
-	# from tests that stub only one half of the decision bucket. Non-rate-limit
-	# notices take precedence over rate-limit notices from the same bot.
+	# Classify a bot's non-review notice state in one pass over the three GitHub
+	# comment sources. Non-rate-limit notices take precedence over rate-limit
+	# notices from the same bot, even when an older rate-limit notice appears
+	# first in another stream.
 	local pr_number="$1"
 	local repo="$2"
 	local bot_login="$3"
 
-	if bot_has_non_rate_limit_non_review_notice "$pr_number" "$repo" "$bot_login"; then
-		echo "non-rate-limit"
-		return 0
-	fi
-	if bot_has_rate_limit_notice "$pr_number" "$repo" "$bot_login"; then
-		echo "rate-limit"
-		return 0
-	fi
+	local jq_filter
+	jq_filter=$(bot_body_base64_jq_filter "$bot_login")
 
-	echo "none"
-	return 1
+	local api_endpoints=(
+		"repos/${repo}/pulls/${pr_number}/reviews"
+		"repos/${repo}/issues/${pr_number}/comments"
+		"repos/${repo}/pulls/${pr_number}/comments"
+	)
+
+	local category="none"
+	local endpoint records rc encoded body
+	for endpoint in "${api_endpoints[@]}"; do
+		if records=$(gh api "$endpoint" --paginate --jq "$jq_filter"); then
+			:
+		else
+			rc=$?
+			return "$rc"
+		fi
+		[[ -z "$records" ]] && continue
+		while IFS= read -r encoded; do
+			[[ -z "$encoded" ]] && continue
+			body=$(echo "$encoded" | base64 -d 2>/dev/null || echo "")
+			[[ -z "$body" ]] && continue
+			if is_non_review_comment "$body" && ! is_rate_limit_only_comment "$body"; then
+				echo "non-rate-limit"
+				return 0
+			fi
+			if is_rate_limit_only_comment "$body"; then
+				category="rate-limit"
+			fi
+		done <<<"$records"
+	done
+
+	echo "$category"
+	return 0
 }
 
 bot_has_real_review() {
@@ -652,14 +687,19 @@ do_check() {
 	local found_bots=""
 	local rate_limited_bots=""
 	local non_review_bots=""
-	local notice_category
+	local notice_category notice_rc
 	for bot in "${KNOWN_BOTS[@]}"; do
 		if echo "$all_commenters" | grep -qi "$bot"; then
 			# Bot commented — but is it a real review or a non-review notice?
 			if bot_has_real_review "$pr_number" "$repo" "$bot"; then
 				found_bots="${found_bots}${bot} "
 			else
-				notice_category=$(bot_get_notice_category "$pr_number" "$repo" "$bot" || echo "none")
+				if notice_category=$(bot_get_notice_category "$pr_number" "$repo" "$bot"); then
+					:
+				else
+					notice_rc=$?
+					return "$notice_rc"
+				fi
 				case "$notice_category" in
 					rate-limit)
 						rate_limited_bots="${rate_limited_bots}${bot} "

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -429,6 +429,123 @@ test_two_phase_env_override_respected_non_two_phase() {
 	return 0
 }
 
+# ---------- Unit tests: notice category classification (GH#22855) ----------
+
+install_notice_category_gh_stub() {
+	local scenario="$1"
+	local gh_stub="${TEST_ROOT}/bin/gh"
+
+	cat >"$gh_stub" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+count_file="${REVIEW_BOT_GATE_GH_COUNT_FILE:?}"
+scenario="${REVIEW_BOT_GATE_GH_SCENARIO:?}"
+count="0"
+if [[ -f "$count_file" ]]; then
+	IFS= read -r count <"$count_file" || count="0"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$count_file"
+
+if [[ "${1:-}" != "api" ]]; then
+	exit 2
+fi
+
+endpoint="${2:-}"
+case "$scenario:$endpoint" in
+	precedence:repos/testorg/otherrepo/pulls/123/reviews)
+		printf '%s\n' 'UmV2aWV3IHNraXBwZWQgZHVlIHRvIHJhdGUgbGltaXQgZXhjZWVkZWQ='
+		;;
+	precedence:repos/testorg/otherrepo/issues/123/comments)
+		;;
+	precedence:repos/testorg/otherrepo/pulls/123/comments)
+		printf '%s\n' 'UmV2aWV3IGZhaWxlZCDigJQgUHVsbCByZXF1ZXN0IHdhcyBjbG9zZWQgb3IgbWVyZ2VkIGR1cmluZyByZXZpZXcu'
+		;;
+	none:*)
+		;;
+	failure:*)
+		exit 42
+		;;
+	*)
+		;;
+esac
+EOF
+	chmod +x "$gh_stub"
+	printf '0\n' >"${TEST_ROOT}/gh-count"
+	export REVIEW_BOT_GATE_GH_COUNT_FILE="${TEST_ROOT}/gh-count"
+	export REVIEW_BOT_GATE_GH_SCENARIO="$scenario"
+	return 0
+}
+
+read_notice_category_gh_count() {
+	local count="0"
+	if [[ -f "${TEST_ROOT}/gh-count" ]]; then
+		IFS= read -r count <"${TEST_ROOT}/gh-count" || count="0"
+	fi
+	printf '%s\n' "$count"
+	return 0
+}
+
+test_notice_category_single_pass_prefers_non_rate_limit() {
+	install_notice_category_gh_stub "precedence"
+
+	local output status calls
+	if output=$(bot_get_notice_category 123 'testorg/otherrepo' 'coderabbitai'); then
+		status=0
+	else
+		status=$?
+	fi
+	calls=$(read_notice_category_gh_count)
+
+	if [[ "$status" -eq 0 && "$output" == "non-rate-limit" && "$calls" == "3" ]]; then
+		print_result "notice category uses one pass and prefers non-rate-limit" 0
+	else
+		print_result "notice category uses one pass and prefers non-rate-limit" 1 \
+			"status=${status} output=${output} calls=${calls}"
+	fi
+	return 0
+}
+
+test_notice_category_none_is_successful_default() {
+	install_notice_category_gh_stub "none"
+
+	local output status calls
+	if output=$(bot_get_notice_category 123 'testorg/otherrepo' 'coderabbitai'); then
+		status=0
+	else
+		status=$?
+	fi
+	calls=$(read_notice_category_gh_count)
+
+	if [[ "$status" -eq 0 && "$output" == "none" && "$calls" == "3" ]]; then
+		print_result "notice category returns successful none default" 0
+	else
+		print_result "notice category returns successful none default" 1 \
+			"status=${status} output=${output} calls=${calls}"
+	fi
+	return 0
+}
+
+test_notice_category_propagates_api_failure() {
+	install_notice_category_gh_stub "failure"
+
+	local output status
+	if output=$(bot_get_notice_category 123 'testorg/otherrepo' 'coderabbitai'); then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [[ "$status" -eq 42 && -z "$output" ]]; then
+		print_result "notice category propagates API failure" 0
+	else
+		print_result "notice category propagates API failure" 1 \
+			"status=${status} output=${output}"
+	fi
+	return 0
+}
+
 # ---------- Integration tests: do_check decision buckets (GH#22802) ----------
 
 test_do_check_passes_true_rate_limit_only() {
@@ -520,6 +637,12 @@ main() {
 	test_two_phase_coderabbitai_any_edit_settled
 	test_two_phase_unknown_bot_or_semantics_preserved
 	test_two_phase_env_override_respected_non_two_phase
+
+	echo ""
+	echo "=== Notice category classification (GH#22855) ==="
+	test_notice_category_single_pass_prefers_non_rate_limit
+	test_notice_category_none_is_successful_default
+	test_notice_category_propagates_api_failure
 
 	echo ""
 	echo "=== do_check decision buckets (GH#22802) ==="


### PR DESCRIPTION
## Summary

Refactored review bot notice classification to query each GitHub comment stream once, return a successful none default, and propagate API failures without the caller fallback.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh,.agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/review-bot-gate-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh; bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh (28 tests); .agents/scripts/linters-local.sh reached existing Sonar/Qlty warnings and no new string-literal regressions but timed out twice at Secretlint

Resolves #22855


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 23m and 84,391 tokens on this as a headless worker.