### PR TITLE
GH#22835: test: align stale recovery mock repo slug

### DIFF
--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -57,7 +57,7 @@ if [[ "$cmd" == "is-assigned" ]]; then
 		exit 1
 		;;
 	prelaunch_canary)
-		printf '%s\n' 'STALE_RECOVERED: issue #2905 in owner/repo - unassigned runner (no dispatch claim comment found, worker canary preflight failed before worktree pre-creation; will retry next cycle)'
+		printf '%s\n' 'STALE_RECOVERED: issue #2905 in awardsapp/awardsapp - unassigned runner (no dispatch claim comment found, worker canary preflight failed before worktree pre-creation; will retry next cycle)'
 		exit 1
 		;;
 	worker)


### PR DESCRIPTION
## Summary

Aligned the prelaunch-canary stale recovery mock repository slug with the test invocation so the fixture is internally consistent.

## Files Changed

.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh; shellcheck .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh

Resolves #22835


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 2m and 16,828 tokens on this as a headless worker.