### PR TITLE
GH#22827: release worker worktree on retry finish

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -765,7 +765,7 @@ _cmd_run_finish() {
 
 	_update_dispatch_ledger "$session_key" "$ledger_status"
 	_release_session_lock "$session_key"
-	_hrw_release_worker_worktree "$work_dir"
+	_hrw_release_worker_worktree "${work_dir:-${_WORKER_WORKTREE_PATH:-}}"
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
 	fi


### PR DESCRIPTION
## Summary

Added a fallback to the exported worker worktree path so retry-triggered finish paths still unregister the active worktree.

## Files Changed

.agents/scripts/headless-runtime-worker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-worker.sh

Resolves #22827


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 2m and 20,203 tokens on this as a headless worker.