### PR TITLE
GH#22837: clarify auto-dispatch placeholders

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -87,7 +87,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Every issue, PR, and comment that describes work MUST include worker-ready context: files to modify, reference pattern, verification, and explicit note when paths cannot be known. Brief template source: `templates/brief-template.md`.
 - Use GitHub wrappers for issue/PR creation so origin labels and signatures are applied; never hand-compose signature footers. PR/issue/comment bodies must satisfy same-command `--body-file` discipline. Thread-clean reading and non-collaborator body immunity: `reference/gh-command-discipline.md`.
 - Auto-generated issue triage outcomes: verify premise first; falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous only → decision-ready comment + `needs-maintainer-review`. Scope/style uncertainty is not NMR. Full templates: `reference/worker-discipline.md`.
-- Parent/research tasks: `parent-task` is a permanent dispatch block; PRs against parent issues use `For #NNN`/`Ref #NNN` until the final child/phase. New worker-ready tasks default to auto-dispatch; if implementing an auto-dispatch issue interactively, use `interactive-start-helper.sh --issue N --repo owner/repo --task "..." --auto-dispatch`.
+- Parent/research tasks: `parent-task` is a permanent dispatch block; PRs against parent issues use `For #NNN`/`Ref #NNN` until the final child/phase. New worker-ready tasks default to auto-dispatch; if implementing an auto-dispatch issue interactively, use `interactive-start-helper.sh --issue <N> --repo <owner/repo> --task "..." --auto-dispatch`.
 
 ### Quality and diagnostics
 


### PR DESCRIPTION
## Summary

Clarified the auto-dispatch interactive-start example in .agents/AGENTS.md by marking mandatory issue and repository placeholders with angle brackets.

## Files Changed

.agents/AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; targeted Python placeholder assertion; .agents/scripts/linters-local.sh partially ran but timed out during Secretlint after reporting pre-existing SonarCloud/Qlty findings

Resolves #22837


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 5m and 21,518 tokens on this as a headless worker.

<!-- ci-feedback:PR22906:SHA17cc3656dc83be19bd805b5dd6ea04d5f148b294 -->
## CI Repair Feedback (from PR #22906)

The previous worker's PR #22906 had non-passing required CI checks. The PR has been
closed and this issue re-queued for dispatch. The next worker should address these failures.

### Non-passing required checks

- **ShellCheck (macos-latest)**: pending — [https://github.com/marcusquinn/aidevops/actions/runs/25361380619/job/74361575935](https://github.com/marcusquinn/aidevops/actions/runs/25361380619/job/74361575935)

### Pattern-Specific Resolution Guidance

The failing checks match known patterns with deterministic resolution paths.
Try the auto-fix sequence(s) below FIRST, before falling back to the
generic worker guidance further down.

#### Pattern: TEST_FAILURE

Affected checks: `ShellCheck (macos-latest)`

Test failures are not automatically code regressions. First separate application defects from test-harness and clean-preflight hermeticity failures.

**JS/TS pnpm + Vitest hermeticity triage:**

1. Read the failing check log and identify the first failing package/suite.
2. Re-run the repo gate, then isolate with package filters: `pnpm test` and `pnpm --filter <package> test`.
3. If failures mention missing env variables, import-time env validation, `process.env`, zod/env schemas, or private configuration, fix the test setup so unit tests use safe defaults/mocks. Do NOT require production secrets.
4. If failures mention Vitest mocks (`vi.mock`, `@workspace/*`, missing exports, schema constants), inspect stale mocks and prefer partial mocks with `vi.importActual` where possible.
5. Keep changes test-only unless the log proves a production code regression.
6. Re-run the package-level test and the repo-level test before pushing.

Quick resolution command: `pnpm test and pnpm --filter <package> test`

### Worker guidance

1. Check out a fresh branch from `origin/main` (do NOT reuse the old branch)
2. Read the check URLs above for specific error messages
3. Fix the issues in the code, not in the CI config
4. Ensure all checks pass locally before pushing

_Routed by deterministic merge pass (pulse-merge.sh)._