### PR TITLE
GH#22823: simplify stale open PR activity guard

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -604,7 +604,7 @@ _is_stale_assignment() {
 	if [[ -n "$open_pr_activity" ]]; then
 		open_pr_number="${open_pr_activity%%|*}"
 		open_pr_updated_at="${open_pr_activity#*|}"
-		if [[ -n "$open_pr_number" && -n "$open_pr_updated_at" && "$open_pr_updated_at" != "$open_pr_activity" ]]; then
+		if [[ -n "$open_pr_number" && -n "$open_pr_updated_at" ]]; then
 			open_pr_epoch=$(_ts_to_epoch "$open_pr_updated_at")
 			if [[ "$open_pr_epoch" -gt 0 ]]; then
 				open_pr_age=$((now_epoch - open_pr_epoch))


### PR DESCRIPTION
## Summary

Removed the redundant open PR activity delimiter comparison in .agents/scripts/dispatch-dedup-stale.sh while keeping non-empty timestamp validation before epoch parsing.

## Files Changed

.agents/scripts/dispatch-dedup-stale.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-dedup-stale.sh; .agents/scripts/linters-local.sh; bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh; bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh; bash .agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh

Resolves #22823


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 11m and 37,079 tokens on this as a headless worker.