### PR TITLE
GH#22842: fix: preserve audit filenames in evidence tables

### DIFF
--- a/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
+++ b/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
@@ -62,7 +62,7 @@ runtime_audit_check() {
 	local entry name d_str dm sm
 	for entry in "${drifted[@]}"; do
 		IFS='|' read -r name d_str dm sm <<<"$entry"
-		evidence_table+=$'\n'"| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$sm") |"
+		evidence_table+=$'\n'"| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' || printf '%s\n' "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' || printf '%s\n' "$sm") |"
 	done
 
 	local first_file
@@ -70,9 +70,9 @@ runtime_audit_check() {
 
 	local title="runtime-audit: deployed script lags source by >$((drift / 3600))h (\`${first_file}\`)"
 	local drift_hours=$((drift / 3600))
-	# Render evidence table with embedded \n escapes resolved
+	# Keep literal newlines intact without printf %b interpreting filename backslashes.
 	local evidence_rendered
-	evidence_rendered=$(printf '%b' "$evidence_table")
+	evidence_rendered="$evidence_table"
 	local body
 	body=$(cat <<MARKDOWN
 ## Task


### PR DESCRIPTION
## Summary

Preserved literal newlines in deployed-vs-source mtime audit evidence without printf %b so backslashes in filenames are not interpreted, and allowed date diagnostics to surface while keeping epoch fallbacks.

## Files Changed

.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh; targeted runtime-audit smoke test with a filename containing a backslash

Resolves #22842


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 1m and 58,364 tokens on this as a headless worker.