### PR TITLE
GH#22859: docs align auto-dispatch exclusions

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -142,7 +142,25 @@ Narrative phases without a per-phase marker are NOT auto-filed unless `<!-- phas
 
 `#{origin}`: `#interactive` (user present) or `#worker` (headless). Detect via `detect_session_origin` from `shared-constants.sh`. Maps to `origin:interactive` / `origin:worker` GitHub labels on issue sync.
 
-**Auto-dispatch default:** Worker-ready implementation tasks default to `#auto-dispatch`. Readiness means the brief has: (1) 2+ acceptance criteria beyond "tests pass"/"lint clean", (2) non-empty "How" with file references, (3) clear deliverable in "What", and (4) automatable verification. If any readiness element is missing, finish the brief before filing/queueing; if the work needs decomposition, research, human preference/approval, credentials, or unresolved dependencies, mark it `#parent`/blocked instead. Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.
+**Auto-dispatch default:** Worker-ready implementation tasks default to `#auto-dispatch`, including issues created by interactive agents or workers.
+
+The readiness gate is:
+
+- 2+ acceptance criteria beyond "tests pass"/"lint clean"
+- Non-empty "How" with file references
+- Clear deliverable in "What"
+- Automatable verification
+
+If any readiness element is missing, finish the brief before filing/queueing; if the task fails the gate, mark it `#parent`/blocked instead. Omit `#auto-dispatch` only for:
+
+- Credentials, accounts, or purchases
+- Decomposition or human-decision work
+- Hardware or external service setup
+- Investigation/evaluation without a clear deliverable
+- Incomplete dependencies
+- Explicit user preference for interactive/manual handling
+
+Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.
 
 ### Step 5: Label, Commit, Push
 


### PR DESCRIPTION
## Summary

Bulletized the new-task auto-dispatch readiness gate and synchronized the exclusion guidance with canonical planning rules.

## Files Changed

.agents/workflows/new-task.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint .agents/workflows/new-task.md

Resolves #22859


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 3m and 33,713 tokens on this as a headless worker.