### PR TITLE
GH#22848: include OpenAI retry missing body status

### DIFF
--- a/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
@@ -90,7 +90,7 @@ async function retryOpenAIOverloadStream(ctx) {
     console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt + 1}/${retryDelays.length})`);
     if (delayMs > 0) await sleep(delayMs);
     currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
-    if (!currentResponse.body) return controller.error(new Error("OpenAI provider: retry response missing body"));
+    if (!currentResponse.body) return controller.error(new Error(`OpenAI provider: retry response missing body (status: ${currentResponse.status})`));
   }
 }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-overload-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-overload-retry.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+function streamResponse(text, init = {}) {
+  return new Response(new Blob([text]).stream(), {
+    status: init.status || 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+async function readStreamFailure(response) {
+  const reader = response.body.getReader();
+  await assert.rejects(async () => {
+    while (true) {
+      const { done } = await reader.read();
+      if (done) return;
+    }
+  }, /OpenAI provider: retry response missing body \(status: 204\)/);
+}
+
+test("retry missing-body errors include retry response status", async () => {
+  process.env.AIDEVOPS_OPENAI_OVERLOAD_RETRY_DELAYS_MS = "0";
+  const { wrapOpenAIOverloadStream } = await import(`../openai-overload-retry.mjs?test=${Date.now()}-${Math.random()}`);
+  const response = streamResponse('{"type":"error","error":{"code":"server_is_overloaded"}}');
+  const wrapped = wrapOpenAIOverloadStream({
+    response,
+    originalFetch: async () => new Response(null, { status: 204 }),
+    retryInput: "https://api.openai.example/v1/responses",
+    init: {},
+    buildRetryRequest: (input) => input,
+  });
+
+  await readStreamFailure(wrapped);
+});


### PR DESCRIPTION
## Summary
- Include the retry HTTP status in OpenAI overload retry missing-body errors.
- Add a regression test covering the stream error path for a 204 retry response.

## Testing
- `npm test` in `.agents/plugins/opencode-aidevops` passed.
- `npm run typecheck` at repo root does not complete because the repo has no TypeScript project config and `tsc --noEmit` prints compiler help.
- `.agents/scripts/linters-local.sh` reported the existing SonarCloud quality gate failure and timed out during Secretlint after 240s.

## Runtime Testing
- self-assessed: low-risk diagnostic message/test change; no live OpenAI runtime required.

Resolves #22848


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 9m and 65,549 tokens on this as a headless worker.
