### PR TITLE
GH#22849: fix: improve ratchet timeout diagnostics

### DIFF
--- a/.agents/scripts/linters-local-ratchet.sh
+++ b/.agents/scripts/linters-local-ratchet.sh
@@ -51,6 +51,84 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 #   linters-local.sh --strict         # blocking ratchet check
 #   linters-local.sh --update-baseline # re-count and write new baseline
 
+# _ratchet_step_timeout_seconds: read and validate per-ratchet timeout.
+# Returns: timeout seconds via stdout
+_ratchet_step_timeout_seconds() {
+	local configured="${RATCHET_STEP_TIMEOUT_SECONDS:-120}"
+	if [[ ! "$configured" =~ ^[0-9]+$ ]] || [[ "$configured" -lt 1 ]]; then
+		configured=120
+	fi
+	echo "$configured"
+	return 0
+}
+
+# _ratchet_count_with_progress: run one ratchet counter with progress + timeout.
+# Arguments: $1=display_name $2=counter_function $3=scripts_dir_or_empty
+# Returns: counter output via stdout, 1 on timeout/counter failure
+_ratchet_count_with_progress() {
+	local display_name="$1"
+	local counter_function="$2"
+	local scripts_dir="${3:-}"
+	local timeout_seconds
+	timeout_seconds=$(_ratchet_step_timeout_seconds)
+	local progress_interval=30
+	local output_file error_file
+	output_file=$(mktemp "${TMPDIR:-/tmp}/ratchet-count.XXXXXX") || return 1
+	error_file=$(mktemp "${TMPDIR:-/tmp}/ratchet-count.err.XXXXXX") || {
+		rm -f "$output_file"
+		return 1
+	}
+
+	print_info "Ratchets: counting ${display_name} (timeout ${timeout_seconds}s)..." >&2
+	(
+		if [[ -n "$scripts_dir" ]]; then
+			"$counter_function" "$scripts_dir"
+		else
+			"$counter_function"
+		fi
+	) >"$output_file" 2>"$error_file" &
+	local counter_pid="$!"
+	local start_time elapsed now status result
+	start_time=$(date +%s)
+
+	while kill -0 "$counter_pid" 2>"$error_file"; do
+		now=$(date +%s)
+		elapsed=$((now - start_time))
+		if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
+			print_error "Ratchets: ${display_name} timed out after ${timeout_seconds}s; rerun with RATCHET_STEP_TIMEOUT_SECONDS=<seconds> for diagnostics" >&2
+			kill "$counter_pid" 2>"$error_file"
+			if wait "$counter_pid" 2>"$error_file"; then
+				status=0
+			else
+				status=$?
+			fi
+			rm -f "$output_file" "$error_file"
+			return 1
+		fi
+		if [[ "$elapsed" -gt 0 ]] && [[ $((elapsed % progress_interval)) -eq 0 ]]; then
+			print_info "Ratchets: still counting ${display_name} (${elapsed}s elapsed)..." >&2
+		fi
+		sleep 1
+	done
+
+	if wait "$counter_pid"; then
+		status=0
+	else
+		status=$?
+	fi
+	if [[ "$status" -ne 0 ]]; then
+		print_error "Ratchets: ${display_name} counter failed with exit ${status}" >&2
+		rm -f "$output_file" "$error_file"
+		return 1
+	fi
+
+	result=$(tr -d '[:space:]' <"$output_file")
+	rm -f "$output_file" "$error_file"
+	[[ "$result" =~ ^[0-9]+$ ]] || result=0
+	echo "$result"
+	return 0
+}
+
 # _ratchet_count_bare_positional: count $1-$9 in function bodies (not local assignments)
 # Returns: count via stdout
 _ratchet_count_bare_positional() {
@@ -178,11 +256,11 @@ _ratchet_check_pattern() {
 _ratchet_count_all() {
 	local scripts_dir="$1"
 	local count_bare count_hardcoded count_broad count_silent count_missing
-	count_bare=$(_ratchet_count_bare_positional "$scripts_dir")
-	count_hardcoded=$(_ratchet_count_hardcoded_path "$scripts_dir")
-	count_broad=$(_ratchet_count_broad_catch "$scripts_dir")
-	count_silent=$(_ratchet_count_silent_errors "$scripts_dir")
-	count_missing=$(_ratchet_count_missing_return)
+	count_bare=$(_ratchet_count_with_progress "bare_positional_params" "_ratchet_count_bare_positional" "$scripts_dir") || return 1
+	count_hardcoded=$(_ratchet_count_with_progress "hardcoded_aidevops_path" "_ratchet_count_hardcoded_path" "$scripts_dir") || return 1
+	count_broad=$(_ratchet_count_with_progress "broad_catch_or_true" "_ratchet_count_broad_catch" "$scripts_dir") || return 1
+	count_silent=$(_ratchet_count_with_progress "silent_errors" "_ratchet_count_silent_errors" "$scripts_dir") || return 1
+	count_missing=$(_ratchet_count_with_progress "missing_return_files" "_ratchet_count_missing_return" "") || return 1
 	echo "$count_bare $count_hardcoded $count_broad $count_silent $count_missing"
 	return 0
 }
@@ -346,7 +424,10 @@ check_ratchets() {
 
 	# Count current values for all patterns
 	local counts count_bare count_hardcoded count_broad count_silent count_missing
-	counts=$(_ratchet_count_all "$scripts_dir")
+	if ! counts=$(_ratchet_count_all "$scripts_dir"); then
+		print_error "Ratchets: aborted because a ratchet counter failed or timed out"
+		return 1
+	fi
 	read -r count_bare count_hardcoded count_broad count_silent count_missing <<<"$counts"
 
 	# --update-baseline / --init-baseline: write new baseline and exit

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -32,6 +32,7 @@
 #   --update-baseline   Re-count all patterns and write new ratchets.json baseline
 #   --init-baseline     Same as --update-baseline (alias for first-time setup)
 #   --strict            Make ratchet failures blocking (default: advisory)
+#   RATCHET_STEP_TIMEOUT_SECONDS=N bounds each ratchet counter (default: 120)
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit

--- a/.agents/scripts/tests/test-linters-local-ratchet-timeout.sh
+++ b/.agents/scripts/tests/test-linters-local-ratchet-timeout.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-linters-local-ratchet-timeout.sh — ratchet progress/timeout diagnostics.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+RATCHET_SCRIPT="${SCRIPT_DIR}/../linters-local-ratchet.sh"
+RATCHET_SCRIPT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [ "$passed" -eq 0 ]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [ -n "$message" ]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+source_ratchet_helpers() {
+	SCRIPT_DIR="$RATCHET_SCRIPT_DIR"
+	# shellcheck disable=SC1090  # test intentionally sources the helper under test
+	source "$RATCHET_SCRIPT"
+	return 0
+}
+
+slow_ratchet_counter() {
+	sleep 3
+	echo "1"
+	return 0
+}
+
+fast_ratchet_counter() {
+	echo "7"
+	return 0
+}
+
+test_ratchet_counter_times_out_with_diagnostic() {
+	source_ratchet_helpers
+	local out ret=0
+	RATCHET_STEP_TIMEOUT_SECONDS=1 out=$(_ratchet_count_with_progress "slow_test" "slow_ratchet_counter" "" 2>&1) || ret=$?
+
+	if [ "$ret" -ne 0 ] && printf '%s' "$out" | grep -q 'slow_test timed out after 1s'; then
+		print_result "ratchet timeout: counter failure includes pattern name and timeout" 0
+	else
+		print_result "ratchet timeout: counter failure includes pattern name and timeout" 1 \
+			"expected timeout diagnostic, got exit=$ret output=[$out]"
+	fi
+	return 0
+}
+
+test_ratchet_counter_reports_progress_and_value() {
+	source_ratchet_helpers
+	local out ret=0
+	RATCHET_STEP_TIMEOUT_SECONDS=5 out=$(_ratchet_count_with_progress "fast_test" "fast_ratchet_counter" "" 2>&1) || ret=$?
+
+	if [ "$ret" -eq 0 ] && printf '%s' "$out" | grep -q 'Ratchets: counting fast_test' && printf '%s' "$out" | grep -q '7'; then
+		print_result "ratchet progress: counter emits start diagnostic and preserves count" 0
+	else
+		print_result "ratchet progress: counter emits start diagnostic and preserves count" 1 \
+			"expected progress diagnostic and count, got exit=$ret output=[$out]"
+	fi
+	return 0
+}
+
+main() {
+	test_ratchet_counter_times_out_with_diagnostic
+	test_ratchet_counter_reports_progress_and_value
+
+	echo ""
+	if [ "$TESTS_FAILED" -eq 0 ]; then
+		printf '%bAll %d tests passed%b\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+		return 0
+	fi
+
+	printf '%b%d/%d tests failed%b\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added per-ratchet progress output and bounded counter timeouts so long ratchet sub-steps identify the specific pattern before the wrapper times out.

## Files Changed

.agents/scripts/linters-local-ratchet.sh,.agents/scripts/linters-local.sh,.agents/scripts/tests/test-linters-local-ratchet-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: .agents/scripts/tests/test-linters-local-ratchet-timeout.sh; .agents/scripts/tests/test-pre-commit-ratchet.sh; shellcheck on changed shell scripts. Ratchet-only dry run showed progress and timed out missing_return_files at a configured 60s bound; full linters-local still timed out in pre-existing secretlint before ratchets.

Resolves #22849


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 14m and 87,653 tokens on this as a headless worker.