### PR TITLE
GH#22821: resolve SonarCloud quality gate blockers

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -94,7 +94,9 @@ _gh_pr_list_snapshot_key() {
 		_joined="${_joined}${_arg}"$'\034'
 	done
 	if command -v shasum >/dev/null 2>&1; then
-		printf '%s' "$_joined" | shasum | awk '{print $1}'
+		printf '%s' "$_joined" | shasum -a 256 | awk '{print $1}'
+	elif command -v openssl >/dev/null 2>&1; then
+		printf '%s' "$_joined" | openssl dgst -sha256 | awk '{print $NF}'
 	else
 		printf '%s' "$_joined" | cksum | awk '{print $1}'
 	fi

--- a/.agents/scripts/tests/test-oauth-interactive-unaffected.sh
+++ b/.agents/scripts/tests/test-oauth-interactive-unaffected.sh
@@ -110,10 +110,11 @@ JSON
 # Shared pool: the cooldown-marked account carries both email AND access
 # so either lookup path would resolve it. The rotation path exercised
 # here is access-token match (because isolated has no email).
+cooldown_until=$(($(date +%s) * 1000 + 60000))
 cat >"$TMP/pool.json" <<JSON
 {
   "anthropic": [
-    {"email": "marcusquinn@mac.com", "access": "PROD-access-marcusquinn-at-mac-com", "cooldownUntil": $(($(date +%s) * 1000 + 60000)), "status": "rate_limited", "priority": 10},
+    {"email": "marcusquinn@mac.com", "access": "PROD-access-marcusquinn-at-mac-com", "cooldownUntil": ${cooldown_until}, "status": "rate_limited", "priority": 10},
     {"email": "healthy@example.com", "access": "healthy-access-token", "cooldownUntil": 0, "status": "available", "priority": 1}
   ]
 }


### PR DESCRIPTION
## Summary

Replaced the gh PR list cache key's default SHA-1 hash with SHA-256 and moved the OAuth test fixture cooldown arithmetic out of generated JSON to avoid SonarCloud shell findings.

## Files Changed

.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/tests/test-oauth-interactive-unaffected.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-status.sh .agents/scripts/tests/test-oauth-interactive-unaffected.sh; bash .agents/scripts/tests/test-oauth-interactive-unaffected.sh; SonarCloud API still reports the pre-analysis quality gate error until the next analysis.

Resolves #22821


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 14m and 39,379 tokens on this as a headless worker.