### PR TITLE
GH#22868: release worker worktree on retry finish

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -666,7 +666,7 @@ _cmd_run_finish() {
 	# work_dir is optional ($3). When present and ledger_status != "fail",
 	# _worker_produced_output() classifies tangible output to distinguish
 	# worker_complete, worker_branch_orphan, and worker_noop (GH#20721, GH#20819).
-	local work_dir="${3:-}"
+	local work_dir="${3:-${_WORKER_WORKTREE_PATH:-}}"
 
 	# Release the dispatch claim so the issue is immediately available for
 	# re-dispatch (next 2-min pulse cycle) instead of waiting for the


### PR DESCRIPTION
## Summary

Added a fallback to the exported worker worktree path so retry-triggered finish paths still unregister the active worktree.

## Files Changed

.agents/scripts/headless-runtime-worker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-worker.sh

Resolves #22868


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 6m and 71,005 tokens on this as a headless worker.