### PR TITLE
GH#22841: cover watchdog thrash advisory

### DIFF
--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -187,17 +187,29 @@ assert_contains \
 	"8b. worker-watchdog emits idle advisory instead of kill" \
 	"IDLE ADVISORY" \
 	"$worker_watchdog_cmd_source"
+assert_contains \
+	"8c. worker-watchdog emits stall advisory instead of kill" \
+	"PROGRESS STALL ADVISORY" \
+	"$worker_watchdog_cmd_source"
+assert_contains \
+	"8d. worker-watchdog emits thrash advisory instead of kill" \
+	"THRASH ADVISORY" \
+	"$worker_watchdog_cmd_source"
 assert_not_contains \
-	"8c. worker-watchdog no longer kills on idle" \
+	"8e. worker-watchdog no longer kills on idle" \
 	'kill_worker "$pid" "idle"' \
 	"$worker_watchdog_cmd_source"
 assert_not_contains \
-	"8d. worker-watchdog no longer kills on stall" \
+	"8f. worker-watchdog no longer kills on stall" \
 	'kill_worker "$pid" "stall"' \
 	"$worker_watchdog_cmd_source"
 assert_not_contains \
-	"8e. worker-watchdog no longer kills on runtime" \
+	"8g. worker-watchdog no longer kills on runtime" \
 	'kill_worker "$pid" "runtime"' \
+	"$worker_watchdog_cmd_source"
+assert_not_contains \
+	"8h. worker-watchdog no longer kills on thrash" \
+	'kill_worker "$pid" "thrash"' \
 	"$worker_watchdog_cmd_source"
 
 #######################################

--- a/.agents/scripts/worker-watchdog-cmd.sh
+++ b/.agents/scripts/worker-watchdog-cmd.sh
@@ -12,7 +12,7 @@
 #   cmd_help      — print usage
 #
 # Internal helpers for the check loop, status display, and scheduler install:
-#   _check_single_worker_thrash, _check_single_worker,
+#   _check_single_worker,
 #   _cleanup_stale_tracking_files, _status_print_*, _install_launchd,
 #   _install_cron, _install_systemd
 #
@@ -55,44 +55,6 @@ fi
 # =============================================================================
 # Check Loop Helpers
 # =============================================================================
-
-#######################################
-# Handle thrash detection signal for a single worker
-#
-# Called when check_zero_commit_thrashing returns 0.
-# Applies transcript gate and kills if confirmed.
-#
-# Arguments:
-#   $1 - PID
-#   $2 - command line
-#   $3 - elapsed seconds
-#   $4 - formatted duration
-# Returns: 0 if worker was killed, 1 if deferred
-#######################################
-_check_single_worker_thrash() {
-	local pid="$1"
-	local cmd="$2"
-	local elapsed_seconds="$3"
-	local duration="$4"
-
-	if ! transcript_allows_intervention "thrash" "$cmd" "$elapsed_seconds"; then
-		return 1
-	fi
-
-	local thrash_evidence="ratio=${THRASH_RATIO} messages=${THRASH_MESSAGES} commits=${THRASH_COMMITS} flag=${THRASH_FLAG:-none}"
-	local session_title
-	session_title=$(_extract_session_title "$cmd")
-	if [[ -n "$session_title" ]]; then
-		thrash_evidence="${thrash_evidence}; objective=${session_title}"
-	fi
-	if [[ -n "$INTERVENTION_EVIDENCE_SUMMARY" ]]; then
-		thrash_evidence="${thrash_evidence}; transcript=${INTERVENTION_EVIDENCE_SUMMARY}"
-	fi
-
-	log_msg "THRASH DETECTED: PID=${pid} elapsed=${duration} ${thrash_evidence}"
-	kill_worker "$pid" "thrash" "$cmd" "$elapsed_seconds" "$thrash_evidence"
-	return 0
-}
 
 #######################################
 # Apply all detection signals to a single worker


### PR DESCRIPTION
## Summary

Removed the stale worker-watchdog thrash kill helper and expanded no-false-kill regression coverage for stall and thrash advisories.

## Files Changed

.agents/scripts/tests/test-watchdog-no-false-kill.sh,.agents/scripts/worker-watchdog-cmd.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-watchdog-no-false-kill.sh; shellcheck -S error .agents/scripts/worker-watchdog-cmd.sh .agents/scripts/tests/test-watchdog-no-false-kill.sh

Resolves #22841


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 7m and 78,480 tokens on this as a headless worker.