### PR TITLE
GH#22871: remove duplicate CI test failure patterns

### DIFF
--- a/.agents/configs/ci-failure-patterns.conf
+++ b/.agents/configs/ci-failure-patterns.conf
@@ -66,9 +66,5 @@ TYPECHECK_FAILURE | *mypy* | <code change required> | mypy errors require code c
 # --- TEST_FAILURE: diagnose hermeticity before code changes ---
 TEST_FAILURE | *[Tt]est* | pnpm test and pnpm --filter <package> test | Test failures are not automatically code regressions. First separate application defects from test-harness and clean-preflight hermeticity failures.\n\n**JS/TS pnpm + Vitest hermeticity triage:**\n\n1. Read the failing check log and identify the first failing package/suite.\n2. Re-run the repo gate, then isolate with package filters: `pnpm test` and `pnpm --filter <package> test`.\n3. If failures mention missing env variables, import-time env validation, `process.env`, zod/env schemas, or private configuration, fix the test setup so unit tests use safe defaults/mocks. Do NOT require production secrets.\n4. If failures mention Vitest mocks (`vi.mock`, `@workspace/*`, missing exports, schema constants), inspect stale mocks and prefer partial mocks with `vi.importActual` where possible.\n5. Keep changes test-only unless the log proves a production code regression.\n6. Re-run the package-level test and the repo-level test before pushing.
 
-TEST_FAILURE | *Vitest* | pnpm --filter <package> test | Vitest failures in pnpm workspaces often need package-scoped isolation. Use the TEST_FAILURE triage above, with special attention to import-time env validation and stale `vi.mock` workspace mocks.
-
-TEST_FAILURE | *pnpm*test* | pnpm test | A failing pnpm test gate should remain hermetic from a clean preflight environment. Use the TEST_FAILURE triage above and avoid adding requirements for private local secrets.
-
 # --- OTHER: catch-all (NO guidance emitted) ---
 OTHER | * | <see failing check URLs> | Generic CI failure — no specific auto-fix pattern matched. Read the failing-check URLs in the failing-checks list above and follow the standard worker guidance below.


### PR DESCRIPTION
## Summary

Removed redundant Vitest and pnpm test CI failure pattern entries so the canonical TEST_FAILURE guidance is the single reachable source while preserving matching via the generic test pattern.

## Files Changed

.agents/configs/ci-failure-patterns.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-ci-failure-pattern-detection.sh; git diff --check; .agents/scripts/linters-local.sh timed out after target-relevant gates passed and existing advisory Qlty smells were reported

Resolves #22871


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 9m and 39,471 tokens on this as a headless worker.