### PR TITLE
GH#22888: require lint warning cleanup dependency

### DIFF
--- a/.agents/scripts/lint-warning-helper.sh
+++ b/.agents/scripts/lint-warning-helper.sh
@@ -14,7 +14,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 readonly SCRIPT_DIR
 # shellcheck source=/dev/null
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/shared-constants.sh"
 
 usage() {
 	printf 'Usage:\n'


### PR DESCRIPTION
## Summary

Made shared-constants.sh a mandatory dependency for lint-warning-helper.sh so cleanup helpers fail loudly when unavailable.

## Files Changed

.agents/scripts/lint-warning-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/lint-warning-helper.sh; .agents/scripts/lint-warning-helper.sh analyze smoke test

Resolves #22888


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 4m and 19,290 tokens on this as a headless worker.