### PR TITLE
GH#22876: fix: improve setup lock diagnostics

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -267,6 +267,81 @@ test_contention_message_includes_elapsed_and_stage() {
 	return 0
 }
 
+test_default_wait_ceiling_is_longer_than_observed_slow_owner() {
+	local output=""
+
+	output=$(
+		load_lock_functions
+		declare -f _setup_acquire_noninteractive_setup_lock
+		return 0
+	) 2>&1 || true
+
+	if [[ "$output" == *'AIDEVOPS_SETUP_WAIT_TIMEOUT_S:-900'* ]]; then
+		print_result "default lock wait ceiling covers slow setup owners" 0
+		return 0
+	fi
+
+	print_result "default lock wait ceiling covers slow setup owners" 1 "output=${output}"
+	return 0
+}
+
+test_contention_command_redacts_secret_like_values() {
+	local output=""
+
+	output=$(
+		load_lock_functions
+		_setup_redact_secret_like_command_values './setup.sh --non-interactive --token TOKEN_VALUE_PLACEHOLDER password=PASSWORD_VALUE_PLACEHOLDER --api-key API_KEY_VALUE_PLACEHOLDER --safe value'
+		return 0
+	) 2>&1 || true
+
+	if [[ "$output" == *'--token [redacted]'* && "$output" == *'password=[redacted]'* && "$output" == *'--api-key [redacted]'* && "$output" == *'--safe value'* && "$output" != *'TOKEN_VALUE_PLACEHOLDER'* && "$output" != *'PASSWORD_VALUE_PLACEHOLDER'* && "$output" != *'API_KEY_VALUE_PLACEHOLDER'* ]]; then
+		print_result "lock diagnostics redact secret-like command values" 0
+		return 0
+	fi
+
+	print_result "lock diagnostics redact secret-like command values" 1 "output=${output}"
+	return 0
+}
+
+test_periodic_wait_message_preserves_stage_and_command() {
+	local tmp_dir=""
+	local output=""
+	local owner_pid=""
+	local past_epoch=0
+	tmp_dir=$(make_temp_dir)
+	owner_pid=$(start_fake_setup_owner)
+	mkdir -p "$tmp_dir/lock.d" "$tmp_dir/.aidevops/logs"
+	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' './setup.sh --non-interactive --token TOKEN_VALUE_PLACEHOLDER' >"$tmp_dir/lock.d/command"
+	past_epoch=$(( $(date +%s 2>/dev/null || echo "0") - 5 ))
+	printf '%s\n' "$past_epoch" >"$tmp_dir/lock.d/started_at_epoch"
+	printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "deploy_aidevops_agents" "0.00" "RUNNING" >"$tmp_dir/.aidevops/logs/setup-stage-timings.log"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=15
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=3600
+		AIDEVOPS_SETUP_LOCK_DIAG_INTERVAL_S=10
+		HOME="$tmp_dir"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'exit=%s\n' "$?"
+		return 0
+	) 2>&1 || true
+
+	kill "$owner_pid" 2>/dev/null || true
+	wait "$owner_pid" 2>/dev/null || true
+	rm -rf "$tmp_dir"
+
+	if [[ "$output" == *"Still waiting for setup lock"* && "$output" == *"stage: deploy_aidevops_agents"* && "$output" == *"command: ./setup.sh --non-interactive --token [redacted]"* && "$output" == *"setup-stage-timings.log"* && "$output" != *"TOKEN_VALUE_PLACEHOLDER"* ]]; then
+		print_result "periodic lock wait keeps stage and redacted command diagnostics" 0
+		return 0
+	fi
+
+	print_result "periodic lock wait keeps stage and redacted command diagnostics" 1 "output=${output}"
+	return 0
+}
+
 test_signal_cleanup_terminates_registered_children() {
 	local output=""
 
@@ -443,6 +518,9 @@ main() {
 	test_stale_live_owner_past_ceiling_is_reclaimed
 	test_wait_ceiling_prevents_indefinite_block
 	test_contention_message_includes_elapsed_and_stage
+	test_default_wait_ceiling_is_longer_than_observed_slow_owner
+	test_contention_command_redacts_secret_like_values
+	test_periodic_wait_message_preserves_stage_and_command
 	test_signal_cleanup_terminates_registered_children
 	test_signal_cleanup_terminates_unregistered_child_tree
 	test_bounded_noncritical_stage_times_out_child_tree

--- a/setup.sh
+++ b/setup.sh
@@ -839,16 +839,60 @@ _setup_lock_owner_age() {
 	return 0
 }
 
+_setup_command_key_looks_secret() {
+	local key="$1"
+	key="${key#--}"
+	key="${key#-}"
+	case "$key" in
+		*password*|*passwd*|*secret*|*token*|*credential*|*api-key*|*api_key*|*apikey*|*access-key*|*access_key*|*private-key*|*private_key*|bearer)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+_setup_redact_secret_like_command_values() {
+	local command_text="$1"
+	local redacted=""
+	local separator=""
+	local word=""
+	local lower_word=""
+	local key_part=""
+	local redact_next=false
+
+	for word in $command_text; do
+		lower_word=$(printf '%s' "$word" | tr '[:upper:]' '[:lower:]')
+		if [[ "$redact_next" == "true" ]]; then
+			word="[redacted]"
+			redact_next=false
+		elif [[ "$lower_word" == *=* ]]; then
+			key_part="${lower_word%%=*}"
+			if _setup_command_key_looks_secret "$key_part"; then
+				word="${word%%=*}=[redacted]"
+			fi
+		elif _setup_command_key_looks_secret "$lower_word"; then
+			redact_next=true
+		fi
+		redacted="${redacted}${separator}${word}"
+		separator=" "
+	done
+
+	printf '%s' "$redacted"
+	return 0
+}
+
 _setup_acquire_noninteractive_setup_lock() {
 	local lock_dir="${AIDEVOPS_SETUP_LOCK_DIR:-$HOME/.aidevops/locks/setup-noninteractive.lock.d}"
 	# Max seconds to wait for a live, non-stale owner before timing out.
-	local wait_ceiling="${AIDEVOPS_SETUP_WAIT_TIMEOUT_S:-300}"
+	local wait_ceiling="${AIDEVOPS_SETUP_WAIT_TIMEOUT_S:-900}"
 	# Max seconds a live owner may hold the lock before it is treated as
 	# stale and reclaimed (0 disables stale-live reclaim).
 	local stale_ceiling="${AIDEVOPS_SETUP_STALE_TIMEOUT_S:-1800}"
 	local owner_pid="" owner_cmd="" owner_age=0
 	local reclaim_attempts=0 waited=0
 	local _diag_stl="$HOME/.aidevops/logs/setup-stage-timings.log"
+	local _diag_interval_s="${AIDEVOPS_SETUP_LOCK_DIAG_INTERVAL_S:-60}"
+	[[ "$_diag_interval_s" =~ ^[0-9]+$ && "$_diag_interval_s" -gt 0 ]] || _diag_interval_s=60
 	mkdir -p "$(dirname "$lock_dir")" 2>/dev/null || true
 	while true; do
 		if mkdir "$lock_dir" 2>/dev/null; then
@@ -916,6 +960,7 @@ _setup_acquire_noninteractive_setup_lock() {
 		owner_age=$(_setup_lock_owner_age "$lock_dir" "$owner_pid")
 		owner_cmd=""
 		[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
+		[[ -n "$owner_cmd" ]] && owner_cmd=$(_setup_redact_secret_like_command_values "$owner_cmd")
 		local _diag_stage=""
 		if [[ -r "$_diag_stl" ]]; then
 			local _diag_cur_stage=""
@@ -941,11 +986,11 @@ _setup_acquire_noninteractive_setup_lock() {
 			return 75
 		fi
 
-		# Emit diagnostics on first block and every 60 s thereafter.
+		# Emit diagnostics on first block and every diagnostic interval thereafter.
 		if [[ "$waited" -eq 0 ]]; then
 			print_info "Another setup.sh --non-interactive is running (pid ${owner_pid}, age ${owner_age}s${_diag_stage}${owner_cmd:+, command: ${owner_cmd}}). Waiting up to ${wait_ceiling}s (AIDEVOPS_SETUP_WAIT_TIMEOUT_S). Diagnose: ${_diag_stl}"
-		elif [[ $(( waited % 60 )) -eq 0 ]]; then
-			print_info "Still waiting for setup lock (owner pid ${owner_pid}, age ${owner_age}s, waited ${waited}s of ${wait_ceiling}s max)."
+		elif [[ $(( waited % _diag_interval_s )) -eq 0 ]]; then
+			print_info "Still waiting for setup lock (owner pid ${owner_pid}, age ${owner_age}s${_diag_stage}${owner_cmd:+, command: ${owner_cmd}}, waited ${waited}s of ${wait_ceiling}s max). Diagnose: ${_diag_stl}"
 		fi
 
 		sleep 10


### PR DESCRIPTION
## Summary

Raised the non-interactive setup lock wait default, kept stage and redacted command diagnostics on periodic waits, and covered the diagnostics with shell tests.

## Files Changed

.agents/scripts/tests/test-setup-noninteractive-lock.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-setup-noninteractive-lock.sh; bash .agents/scripts/tests/test-setup-stage-timing-observability.sh; shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh .agents/scripts/tests/test-setup-stage-timing-observability.sh; git diff --check

Resolves #22876


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 11m and 69,287 tokens on this as a headless worker.