### PR TITLE
GH#22892: include OpenAI retry missing body status

### DIFF
--- a/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-overload-retry.mjs
@@ -90,7 +90,7 @@ async function retryOpenAIOverloadStream(ctx) {
     console.error(`[aidevops] OpenAI provider: overloaded stream error — retrying request (${attempt + 1}/${retryDelays.length})`);
     if (delayMs > 0) await sleep(delayMs);
     currentResponse = await originalFetch(buildRetryRequest(retryInput), init);
-    if (!currentResponse.body) return controller.error(new Error("OpenAI provider: retry response missing body"));
+    if (!currentResponse.body) return controller.error(new Error(`OpenAI provider: retry response missing body (status: ${currentResponse.status})`));
   }
 }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -147,7 +147,7 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
       init: { method: "POST", headers: { authorization: "Bearer active-token" }, body: "{}" },
     });
 
-    await assert.rejects(() => missingBodyRetry.response.text(), /retry response missing body/);
+    await assert.rejects(() => missingBodyRetry.response.text(), /retry response missing body \(status: 204\)/);
     assert.deepEqual(missingBodyRetry.calls, ["Bearer active-token", "Bearer active-token"]);
   `;
   execFileSync(process.execPath, ["--input-type=module", "--eval", script], {


### PR DESCRIPTION
## Summary

Included the retry HTTP status in OpenAI missing-body stream errors and tightened the regression assertion for 204 responses.

## Files Changed

.agents/plugins/opencode-aidevops/openai-overload-retry.mjs,.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs; node --test .agents/plugins/opencode-aidevops/tests/*.mjs; npm run typecheck (blocked by repository missing tsconfig and tsc emits help with nonzero status)

Resolves #22892


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 7m and 74,132 tokens on this as a headless worker.