### PR TITLE
GH#22894: surface stale PR activity lookup errors

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -196,7 +196,7 @@ _stale_recovery_find_open_pr_activity() {
 	local _open_pr
 	_open_pr=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number} in:body" --limit 1 \
-		--json number,updatedAt --jq '.[0] | if . then "\(.number)|\(.updatedAt // "")" else "" end' 2>/dev/null) || _open_pr=""
+		--json number,updatedAt --jq '.[0] | if . then "\(.number)|\(.updatedAt // "")" else "" end') || _open_pr=""
 	printf '%s' "$_open_pr"
 	return 0
 }


### PR DESCRIPTION
## Summary

Removed stderr suppression from the stale recovery open PR activity lookup so optional lookup failures still leave syntax and system errors visible while preserving the existing fallback behavior.

## Files Changed

.agents/scripts/dispatch-dedup-stale.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-dedup-stale.sh passed; .agents/scripts/linters-local.sh reached Secretlint but timed out after 240s with prior gates passing

Resolves #22894


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 9m and 21,399 tokens on this as a headless worker.