### PR TITLE
GH#22890: consolidate auto-dispatch readiness criteria

### DIFF
--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -46,10 +46,16 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 ## Auto-Dispatch and Completion
 
-- **Auto-dispatch default**: Worker-ready implementation issues/tasks created by main agents or workers default to `#auto-dispatch`; readiness is the gate, not an opt-in. Add the tag once the brief/body has a clear deliverable, referenced files or patterns, automatable verification, and 2+ acceptance criteria beyond generic tests/lint. If readiness is missing, finish the brief first or mark the work `#parent`/blocked instead of filing a non-dispatchable implementation issue. See `workflows/plans.md` "Auto-Dispatch Tagging".
+- **Auto-dispatch default**: Worker-ready implementation issues/tasks created by main agents or workers default to `#auto-dispatch`; readiness is the gate, not an opt-in. Add the tag only when the brief/body has:
+  - a clear deliverable in the `What` section;
+  - referenced files or patterns in the `How` section;
+  - automatable verification; and
+  - 2+ acceptance criteria beyond generic tests/lint.
+
+  If readiness is missing, finish the brief first or mark the work `#parent`/blocked instead of filing a non-dispatchable implementation issue. See `workflows/plans.md` "Auto-Dispatch Tagging".
 - **Exclusions**: Needs credentials, decomposition, research, human preference/approval, unresolved dependencies, or explicit user preference. Dispatch-path files are **not** excluded post-t2920; they auto-dispatch with opus-4-7 elevation. Canonical blocker label set: `reference/dispatch-blockers.md`.
 - **Dispatch-path advisory (t2821, t2832, t2920)**: When a task's `### Files Scope` or `## How` section references any file in `.agents/configs/self-hosting-files.conf` (pulse-wrapper.sh, pulse-dispatch-*, headless-runtime-helper.sh, dispatch-dedup-helper.sh, etc.), use `#auto-dispatch` as normal. The t2819 pre-dispatch detector auto-elevates these workers to `model:opus-4-7`; combined with worker worktree isolation, CI gates, watchdog kills, and the t2690 circuit breaker, the protection cascade replaces the historical t2821 `no-auto-dispatch` default (reverted t2920). **Opt-out (rare):** use `#no-auto-dispatch #interactive` only when you specifically want to implement interactively to observe the running system. Full decision tree: `reference/auto-dispatch.md` "Dispatch-Path Default (t2821 / t2920)".
-- **Quality gate**: 2+ acceptance criteria beyond generic tests/lint, file references in How section, clear deliverable in What section, and automatable verification.
+- **Quality gate**: Same readiness definition as `#auto-dispatch` above; do not maintain a second criteria list.
 - **Interactive workflow**: Add `assignee:` before pushing if working interactively.
 - **Server-side safety net (t2798)**: `.github/workflows/apply-status-available-default.yml` applies `status:available` to issues that carry `auto-dispatch` but have no `status:*` label — catches bypass-path creations (bare `gh issue create`, web UI) that skip `claim-task-id.sh`.
 


### PR DESCRIPTION
## Summary
- Consolidates auto-dispatch readiness criteria into a single bulleted definition in `.agents/reference/task-lifecycle.md`.
- Points the quality gate back to that readiness definition to avoid divergent criteria lists.

## Verification
- `markdownlint .agents/reference/task-lifecycle.md`
- `git diff --check HEAD~1 HEAD`
- `.agents/scripts/linters-local.sh` attempted twice; timed out while running Secretlint after earlier gates passed (SonarCloud PASS, ShellCheck RC parity PASS, string literal gate PASS).

Resolves #22890

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 16m and 52,272 tokens on this as a headless worker.
