### PR TITLE
GH#22896: test: cover contributor insight review followup

### DIFF
--- a/.agents/scripts/tests/test-contributor-insight-helper.sh
+++ b/.agents/scripts/tests/test-contributor-insight-helper.sh
@@ -147,6 +147,22 @@ cat >"$TEST_SIGNALS" <<'JSON'
         "model_count": 1,
         "models": ["sonnet"],
         "severity": "low"
+      },
+      {
+        "tool": "bash",
+        "error_category": "timeout",
+        "count": 25,
+        "model_count": 2,
+        "models": ["sonnet", "opus"],
+        "severity": "medium",
+        "examples": [
+          {
+            "error": "Command timed out",
+            "input": "bash: long-running verification",
+            "user_response": null
+          }
+        ],
+        "recovery_patterns": []
       }
     ]
   },
@@ -227,6 +243,8 @@ assert_contains "summarized command included" "summarized command" "$output"
 assert_contains "expected recovery included" "expected recovery" "$output"
 assert_not_contains "error example has no private path" "/Users/testuser" "$output"
 assert_not_contains "error example has no private slug" "secret-corp/private-api" "$output"
+assert_contains "null user recovery pattern included" "bash:timeout" "$output"
+assert_not_contains "null user recovery omitted" "observed user recovery: null" "$output"
 
 # Test 12: low-frequency errors filtered (count < 20 or model_count < 2)
 assert_not_contains "low-freq glob:other filtered" "glob:other" "$output"


### PR DESCRIPTION
## Summary

Added regression coverage for contributor insight error pattern rendering when jq returns null user recovery fields, preserving the existing consolidated extraction and preloaded sanitization behavior that addressed the review feedback.

## Files Changed

.agents/scripts/tests/test-contributor-insight-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-contributor-insight-helper.sh; shellcheck .agents/scripts/contributor-insight-helper.sh .agents/scripts/tests/test-contributor-insight-helper.sh

Resolves #22896


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 3m and 74,029 tokens on this as a headless worker.