### PR TITLE
fix: unblock review cleanup dispatch

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -828,11 +828,11 @@ _apply_committed_to_main_cache_label() {
 #######################################
 # GH#18648 (Fix 3a): Detect bot-generated cleanup issues.
 #
-# Bot-generated cleanup issues carry either `review-followup` (from
-# post-merge-review-scanner.sh) or `source:review-scanner` (the
-# provenance marker the scanner applies alongside it). Both labels
-# indicate: "this issue was auto-created from already-merged PR
-# review comments, no new maintainer decision is required".
+# Bot-generated cleanup issues carry `review-followup` (from
+# post-merge-review-scanner.sh), `source:review-scanner`, or
+# `source:review-feedback` (from quality-feedback-helper.sh scan-merged).
+# These labels indicate: "this issue was auto-created from already-merged
+# PR review comments, no new maintainer decision is required".
 #
 # Callers use this to exempt the issue from the ever-NMR permanence
 # trap — historical NMR labels applied by automated escalation paths
@@ -855,7 +855,7 @@ _is_bot_generated_cleanup_issue() {
 	local issue_meta_json="$1"
 	[[ -n "$issue_meta_json" ]] || return 1
 	printf '%s' "$issue_meta_json" |
-		jq -e '.labels | map(.name) | (index("review-followup") != null or index("source:review-scanner") != null)' >/dev/null 2>&1
+		jq -e '.labels | map(.name) | (index("review-followup") != null or index("source:review-scanner") != null or index("source:review-feedback") != null)' >/dev/null 2>&1
 }
 
 #######################################

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -666,10 +666,14 @@ _dispatch_issue_body_missing_worker_context() {
 		return 0
 	fi
 	case "$issue_body" in
-	*"missing implementation context"* | *"Missing implementation context"* | \
-		*"needs implementation context"* | *"Needs implementation context"* | \
-		*"no implementation details"* | *"No implementation details"* | \
-		*"no worker guidance"* | *"No worker guidance"*)
+	*"needs enrichment before dispatch"* | *"Needs enrichment before dispatch"* | \
+		*"missing Worker Guidance/How implementation context"* | \
+		*"Missing Worker Guidance/How implementation context"* | \
+		*"needs implementation context before dispatch"* | \
+		*"Needs implementation context before dispatch"* | \
+		*"no implementation details provided"* | \
+		*"No implementation details provided"* | \
+		*"no worker guidance provided"* | *"No worker guidance provided"*)
 		return 0
 		;;
 	esac

--- a/.agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh
@@ -77,6 +77,17 @@ test_detects_source_review_scanner_label() {
 	return 0
 }
 
+test_detects_source_review_feedback_label() {
+	local meta='{"number":22832,"labels":[{"name":"quality-debt"},{"name":"source:review-feedback"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "detects source:review-feedback label" 0
+		return 0
+	fi
+	print_result "detects source:review-feedback label" 1 \
+		"Expected exit 0 when source:review-feedback is present"
+	return 0
+}
+
 test_detects_both_labels() {
 	local meta='{"number":2294,"labels":[{"name":"review-followup"},{"name":"source:review-scanner"}]}'
 	if _is_bot_generated_cleanup_issue "$meta"; then
@@ -160,6 +171,7 @@ main() {
 
 	test_detects_review_followup_label
 	test_detects_source_review_scanner_label
+	test_detects_source_review_feedback_label
 	test_detects_both_labels
 	test_ignores_non_cleanup_issue
 	test_empty_labels_array

--- a/.agents/scripts/tests/test-pulse-dispatch-missing-context.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-missing-context.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for _dispatch_issue_body_missing_worker_context().
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+LIB_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-lib.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_dispatch_issue_body_missing_worker_context\(\) \{/,/^}$/ { print }
+	' "$LIB_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _dispatch_issue_body_missing_worker_context from %s\n' "$LIB_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+test_empty_body_is_missing_context() {
+	if _dispatch_issue_body_missing_worker_context ""; then
+		print_result "empty body is missing context" 0
+		return 0
+	fi
+	print_result "empty body is missing context" 1
+	return 0
+}
+
+test_explicit_enrichment_marker_is_missing_context() {
+	local body="Placeholder task — needs enrichment before dispatch."
+	if _dispatch_issue_body_missing_worker_context "$body"; then
+		print_result "explicit enrichment marker is missing context" 0
+		return 0
+	fi
+	print_result "explicit enrichment marker is missing context" 1
+	return 0
+}
+
+test_review_followup_instruction_is_dispatchable() {
+	local body
+	printf -v body '%s\n' \
+		'### Worker Guidance' \
+		'' \
+		'**Files to modify:**' \
+		'' \
+		'- .agents/workflows/full-loop.md:35' \
+		'' \
+		'Exit BLOCKED for "missing implementation context" only when the issue is too vague to identify expected behavior.'
+	if _dispatch_issue_body_missing_worker_context "$body"; then
+		print_result "review followup instruction is dispatchable" 1 \
+			"Instructional mention of missing implementation context must not block dispatch"
+		return 0
+	fi
+	print_result "review followup instruction is dispatchable" 0
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_empty_body_is_missing_context
+	test_explicit_enrichment_marker_is_missing_context
+	test_review_followup_instruction_is_dispatchable
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Include `source:review-feedback` cleanup issues in the ever-NMR dispatch exemption so approved quality-debt followups can launch workers.
- Narrow missing-worker-context detection to explicit enrichment markers so instructional mentions of `missing implementation context` do not block valid Worker Guidance.
- Add regression tests for both stuck-queue patterns observed on #22832 and #22889.

For #22832.

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh`
- `.agents/scripts/tests/test-pulse-dispatch-missing-context.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh .agents/scripts/tests/test-pulse-dispatch-missing-context.sh`
- Live helper checks: #22832 now classifies as cleanup-exempt; #22889 now classifies as dispatchable.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 20m and 280,540 tokens on this with the user in an interactive session.
