### PR TITLE
GH#22838: fix: normalize FOSS issue selection fallback

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1205,12 +1205,12 @@ dispatch_foss_workers() {
 			"$repos_json" 2>/dev/null || echo "help wanted")
 		foss_issue=$(gh_issue_list --repo "$foss_slug" --state open \
 			--label "${labels_filter%%,*}" --limit 1 \
-			--json number,title --jq '.[0] | "\(.number)|\(.title)"' 2>/dev/null) || foss_issue=""
+			--json number,title --jq '(.[0] // {}) | "\(.number // "")|\(.title // "")"' 2>/dev/null) || foss_issue=""
 		[[ -n "$foss_issue" ]] || continue
 
 		foss_issue_num="${foss_issue%%|*}"
 		foss_issue_title="${foss_issue#*|}"
-		if [[ ! "$foss_issue_num" =~ ^[0-9]+$ || -z "$foss_issue_title" || "$foss_issue_title" == "null" ]]; then
+		if [[ ! "$foss_issue_num" =~ ^[0-9]+$ || -z "$foss_issue_title" ]]; then
 			echo "[pulse-wrapper] FOSS dispatch skipped invalid issue selection for ${foss_slug}: number='${foss_issue_num}' title='${foss_issue_title}'" >>"$LOGFILE"
 			continue
 		fi


### PR DESCRIPTION
## Summary

Normalized the FOSS issue selection jq output so missing numbers or titles become empty strings, then simplified validation to numeric issue number and non-empty title checks.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-ancillary-dispatch.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh

Resolves #22838


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.60 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 103,868 tokens on this as a headless worker.