### PR TITLE
GH#22832: support older git in bash32 gate test

### DIFF
--- a/.agents/scripts/tests/test-linters-local-bash32-gate.sh
+++ b/.agents/scripts/tests/test-linters-local-bash32-gate.sh
@@ -42,7 +42,10 @@ teardown() {
 make_feature_repo() {
 	local repo_dir="$1"
 	mkdir -p "$repo_dir" || return 1
-	git -C "$repo_dir" init -q -b main || return 1
+	git -C "$repo_dir" init -q || return 1
+	if [[ "$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null)" != "main" ]]; then
+		git -C "$repo_dir" checkout -q -b main || git -C "$repo_dir" checkout -q -b master || return 1
+	fi
 	printf '#!/usr/bin/env bash\nprintf '\''base\\n'\''\n' >"${repo_dir}/example.sh"
 	git -C "$repo_dir" add example.sh || return 1
 	git -C "$repo_dir" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q -m init || return 1


### PR DESCRIPTION
## Summary

Updated the Bash 3.2 linter gate regression test to avoid git init -b while still explicitly preparing a main-branch fixture with a master fallback.

## Files Changed

.agents/scripts/tests/test-linters-local-bash32-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-linters-local-bash32-gate.sh; shellcheck .agents/scripts/tests/test-linters-local-bash32-gate.sh

Resolves #22832


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.60 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 39,382 tokens on this as a headless worker.