### PR TITLE
GH#22839: harden REST mergeable normalization

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -994,7 +994,7 @@ _rest_pr_object_json_jq() {
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
 		state) projection="${projection}${projection:+,}state: .state" ;;
-		mergeable) projection="${projection}${projection:+,}mergeable: (if .mergeable == true then \"MERGEABLE\" elif .mergeable == false then \"CONFLICTING\" elif .mergeable == null then \"UNKNOWN\" else .mergeable end)" ;;
+		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable | if . == true then \"MERGEABLE\" elif . == false then \"CONFLICTING\" else (. // \"UNKNOWN\") end)" ;;
 		reviewDecision) projection="${projection}${projection:+,}reviewDecision: (.reviewDecision // \"\")" ;;
 		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
 		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
@@ -1039,7 +1039,7 @@ _rest_pr_list_json_jq() {
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
 		state) projection="${projection}${projection:+,}state: .state" ;;
-		mergeable) projection="${projection}${projection:+,}mergeable: (if .mergeable == true then \"MERGEABLE\" elif .mergeable == false then \"CONFLICTING\" elif .mergeable == null then \"UNKNOWN\" else .mergeable end)" ;;
+		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable | if . == true then \"MERGEABLE\" elif . == false then \"CONFLICTING\" else (. // \"UNKNOWN\") end)" ;;
 		reviewDecision) projection="${projection}${projection:+,}reviewDecision: (.reviewDecision // \"\")" ;;
 		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
 		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -920,6 +920,24 @@ fi
 unset STUB_PR_VIEW_FIXTURE
 
 # =============================================================================
+# Test 25d: REST PR view normalizes null mergeable to UNKNOWN
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PR_VIEW_FIXTURE='{"number":123,"mergeable":null}'
+
+pr_view_mergeable=$(gh_pr_view 123 --repo "owner/repo" --json mergeable --jq '.mergeable' 2>/dev/null || true)
+
+if [[ "$pr_view_mergeable" == "UNKNOWN" ]]; then
+	pass "gh_pr_view REST fallback normalizes mergeable=null to UNKNOWN"
+else
+	fail "gh_pr_view REST fallback normalizes mergeable=null to UNKNOWN" \
+		"output=${pr_view_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_PR_VIEW_FIXTURE
+
+# =============================================================================
 # Test 25c: REST PR list normalizes REST boolean mergeable to gh GraphQL enum
 # =============================================================================
 : >"$GH_CALLS"
@@ -933,6 +951,24 @@ if [[ "$pr_list_mergeable" == "CONFLICTING" || "$pr_list_mergeable" == '"CONFLIC
 	pass "gh_pr_list REST fallback normalizes mergeable=false to CONFLICTING"
 else
 	fail "gh_pr_list REST fallback normalizes mergeable=false to CONFLICTING" \
+		"output=${pr_list_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_PR_LIST_FIXTURE
+
+# =============================================================================
+# Test 25e: REST PR list normalizes missing mergeable to UNKNOWN
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PR_LIST_FIXTURE='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337","head":{"ref":"feature/rest-mergeable"},"base":{"ref":"main"}}]'
+
+pr_list_mergeable=$(gh_pr_list --repo "owner/repo" --state open --json mergeable --jq '.[0].mergeable' 2>/dev/null || true)
+
+if [[ "$pr_list_mergeable" == "UNKNOWN" || "$pr_list_mergeable" == '"UNKNOWN"' ]]; then
+	pass "gh_pr_list REST fallback normalizes missing mergeable to UNKNOWN"
+else
+	fail "gh_pr_list REST fallback normalizes missing mergeable to UNKNOWN" \
 		"output=${pr_list_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_LIST_FIXTURE


### PR DESCRIPTION
## Summary

Updated REST fallback PR view/list jq projections to normalize mergeable via a single field pipe with null fallback to UNKNOWN, and added regression coverage for null/missing mergeable values.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh (44/44 passed)

Resolves #22839


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.60 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 4m and 42,664 tokens on this as a headless worker.