### PR TITLE
GH#22831: preserve bash32 helper output printing

### DIFF
--- a/.agents/scripts/linters-local-analysis.sh
+++ b/.agents/scripts/linters-local-analysis.sh
@@ -1020,9 +1020,7 @@ _bash32_run_helper() {
 _bash32_print_helper_output() {
 	local output_file="$1"
 	if [[ -s "$output_file" ]]; then
-		while IFS= read -r line; do
-			printf '%s\n' "$line"
-		done <"$output_file"
+		cat "$output_file"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Replaced the line-by-line helper-output replay in .agents/scripts/linters-local-analysis.sh with direct file output so the final unterminated line is preserved.

## Files Changed

.agents/scripts/linters-local-analysis.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/linters-local-analysis.sh; shellcheck .agents/scripts/linters-local-analysis.sh; .agents/scripts/linters-local.sh

Resolves #22831


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.60 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 8m and 83,216 tokens on this as a headless worker.