### PR TITLE
GH#22919: bound pulse final dispatch wait

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1323,11 +1323,31 @@ _dispatch_max_loop() {
 		_pids+=($!)
 	done <"$candidate_file"
 
-	# Wait for all in-flight dispatches to complete
-	wait
+	# Wait only for tracked in-flight dispatches. A bare wait can repeat
+	# stale child diagnostics into pulse-wrapper.log after another wait site
+	# has already reaped a child (GH#22919).
+	_dispatch_max_wait_tracked_pids "${_pids[@]+${_pids[@]}}"
+	_pids=()
 	local dispatched_count
 	dispatched_count=$(_dispatch_max_count_outcomes "$outcomes_file")
 	printf '%d %d\n' "$dispatched_count" "$processed_count"
+	return 0
+}
+
+#######################################
+# t3005/GH#22919: Wait only for tracked parallel-dispatch children.
+#
+# Avoids bare `wait`, which can emit repeated "pid is not a child" diagnostics
+# when tracked PIDs were already reaped by earlier cap-loop cleanup.
+#
+# Arguments: $@ - pids to wait for
+#######################################
+_dispatch_max_wait_tracked_pids() {
+	local pid
+	for pid in "$@"; do
+		[[ -n "$pid" ]] || continue
+		wait "$pid" 2>/dev/null || true
+	done
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -163,6 +163,26 @@ test_count_outcomes_empty_file() {
 	return 0
 }
 
+test_wait_tracked_pids_suppresses_stale_child() {
+	local stale_pid stderr_file rc stderr_output
+	stderr_file=$(mktemp)
+	(
+		exit 0
+	) &
+	stale_pid=$!
+	wait "$stale_pid" 2>/dev/null || true
+	rc=0
+	_dispatch_max_wait_tracked_pids "$stale_pid" 2>"$stderr_file" || rc=$?
+	stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
+	rm -f "$stderr_file"
+	if [[ "$rc" -eq 0 && -z "$stderr_output" ]]; then
+		print_result "wait_tracked_pids: suppresses stale child stderr" 0
+	else
+		print_result "wait_tracked_pids: suppresses stale child stderr" 1 "rc=${rc} stderr=${stderr_output}"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Test 3: _dispatch_max_aggregate_outcomes populates module-globals + invalidates cache
 # =============================================================================
@@ -539,6 +559,7 @@ test_compute_max_parallel_throttle_forces_serial
 test_compute_max_parallel_invalid_var
 test_count_outcomes_success_and_fail
 test_count_outcomes_empty_file
+test_wait_tracked_pids_suppresses_stale_child
 test_aggregate_outcomes_basic
 test_aggregate_outcomes_invalidates_canary_cache
 test_aggregate_outcomes_clears_throttle_on_success


### PR DESCRIPTION
## Summary

Replaces the final bare pulse dispatch wait with tracked-PID cleanup so stale/reaped children cannot spam wrapper stderr.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-max-parallel.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-dispatch-max-parallel.sh (20 passed, 0 failed); shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-dispatch-max-parallel.sh

Resolves #22919


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.60 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 32m and 161,457 tokens on this with the user in an interactive session.