### PR TITLE
GH#22918: fix: narrow pulse zero-progress candidates

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -920,16 +920,57 @@ Filed automatically by \`pulse-merge-stuck.sh\` (t3193). The detector resets the
 
 #######################################
 # Count PRs in $repo_slug that are eligible-but-unmerged this cycle —
-# APPROVED + MERGEABLE + !draft + !hold-for-review (NOT age-gated).
+# APPROVED + MERGEABLE + !draft + !hold-for-review, then narrowed to PRs
+# that are not known to be blocked by the read-only merge gates (NOT age-gated).
 # Used by pulse-merge.sh to feed the zero-progress signal across all repos.
 #
 # Distinct from pulse_merge_stuck_run_pass which adds the AIDEVOPS_MERGE_STUCK_AGE_MINUTES
 # age gate — zero-progress detection wants the wider population (any cycle
 # with eligible-unmerged > 0 + zero merges is a candidate, regardless of age).
+# It must still exclude PRs that the merge pass already proved are not mergeable
+# in this cycle (for example failing required checks or origin:worker PRs with
+# no linked issue), otherwise a legitimate skip becomes a false zero-progress
+# structural-block signal.
 #
 # Args: $1 = repo_slug
 # Stdout: integer count
 #######################################
+#######################################
+# Decide whether a basic eligible PR should contribute to the zero-progress
+# denominator. This is intentionally read-only and narrower than the full
+# _check_pr_merge_gates stack because that stack can route workers/comments.
+#
+# Args: $1=repo_slug, $2=pr_number, $3=labels_str (comma-separated)
+# Returns: 0=count it, 1=exclude it from the zero-progress signal
+#######################################
+_pms_pr_counts_for_zero_progress() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local labels_str="$3"
+
+	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+
+	if declare -F _check_required_checks_passing >/dev/null 2>&1; then
+		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — required checks are not provably passing" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
+	if [[ ",${labels_str}," == *",origin:worker,"* ]]; then
+		local linked_issue=""
+		if declare -F _extract_linked_issue >/dev/null 2>&1; then
+			linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked_issue=""
+		fi
+		if [[ -z "$linked_issue" ]]; then
+			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — origin:worker PR has no linked issue" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
 _pms_count_eligible_unmerged_for_repo() {
 	local repo_slug="$1"
 	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
@@ -940,12 +981,12 @@ _pms_count_eligible_unmerged_for_repo() {
 		--limit 50 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
 
-	# Count PRs matching the eligibility criteria via jq. .mergeable and
+	# Enumerate PRs matching the basic eligibility criteria via jq. .mergeable and
 	# .reviewDecision are already upper-case in the GraphQL response — no
 	# ascii_upcase needed (the FAILURE selector keeps it because legacy
 	# commit-status `.state` values can be lower-case).
-	local count
-	count=$(printf '%s' "$pr_json" | jq -r '
+	local candidates
+	candidates=$(printf '%s' "$pr_json" | jq -r '
 		[ .[]
 		  | select(
 			(.mergeable // "") == "MERGEABLE"
@@ -953,8 +994,20 @@ _pms_count_eligible_unmerged_for_repo() {
 			and (.isDraft // false) == false
 			and (([.labels[].name] | index("hold-for-review")) == null)
 		  )
-		] | length' 2>/dev/null)
-	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+		  | "\(.number // "")\u001e\([.labels[].name] | join(","))"
+		] | .[]' 2>/dev/null) || candidates=""
+
+	local count=0
+	local _RS=$'\x1e'
+	local pr_number=""
+	local labels_str=""
+	while IFS="$_RS" read -r pr_number labels_str; do
+		[[ -n "$pr_number" ]] || continue
+		if _pms_pr_counts_for_zero_progress "$repo_slug" "$pr_number" "$labels_str"; then
+			count=$((count + 1))
+		fi
+	done <<<"$candidates"
+
 	printf '%s' "$count"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -16,11 +16,13 @@
 #        merged>0 → gauge reset to 0
 #        merged=0 + eligible=0 → gauge reset to 0 (streak broken)
 #        merged=0 + eligible>0 → gauge incremented by 1
-#   7. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
+#   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
+#      read-only merge gates (required checks, worker PR with no linked issue).
+#   8. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
 # The test never makes real network calls; functions that require gh API
-# (_classify_stuck_pr, _escalate_individual_stuck_pr, pulse_merge_stuck_run_pass,
-# _pms_count_eligible_unmerged_for_repo) are intentionally not exercised here —
+# (_classify_stuck_pr, _escalate_individual_stuck_pr, full pulse_merge_stuck_run_pass)
+# are intentionally not exercised here —
 # they're integration-level and would need a live fixture repo.
 
 set -u
@@ -265,9 +267,55 @@ assert_eq "5e: merge during stuck-streak resets cycles to 0" "0" "$got"
 echo ""
 
 # ---------------------------------------------------------------------------
-# Section 6: shellcheck cleanliness.
+# Section 6: zero-progress eligible count gate parity.
 # ---------------------------------------------------------------------------
-echo "--- Section 6: shellcheck ---"
+echo "--- Section 6: zero-progress count gate parity ---"
+
+gh() {
+	local command_name="${1:-}"
+	local subcommand="${2:-}"
+	if [[ "$command_name" == "pr" && "$subcommand" == "list" ]]; then
+		printf '%s\n' '[
+{"number":101,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[]},
+{"number":102,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}]},
+{"number":103,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}]},
+{"number":104,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"hold-for-review"}]},
+{"number":105,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[]},
+{"number":106,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[]}
+]'
+		return 0
+	fi
+	return 1
+}
+
+_check_required_checks_passing() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	[[ -n "$repo_slug" ]] || return 1
+	case "$pr_number" in
+	101) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
+_extract_linked_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	[[ -n "$repo_slug" ]] || return 1
+	case "$pr_number" in
+	102) return 0 ;;
+	*) printf '77'; return 0 ;;
+	esac
+}
+
+got=$(_pms_count_eligible_unmerged_for_repo "example/repo")
+assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "1" "$got"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 7: shellcheck cleanliness.
+# ---------------------------------------------------------------------------
+echo "--- Section 7: shellcheck ---"
 
 run_shellcheck() {
 	local label="$1" file="$2"
@@ -289,8 +337,8 @@ run_shellcheck() {
 	return 0
 }
 
-run_shellcheck "6a: pulse-merge-stuck.sh passes shellcheck" "$MODULE"
-run_shellcheck "6b: pulse-stats-helper.sh passes shellcheck" "$STATS_HELPER"
+run_shellcheck "7a: pulse-merge-stuck.sh passes shellcheck" "$MODULE"
+run_shellcheck "7b: pulse-stats-helper.sh passes shellcheck" "$STATS_HELPER"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adjusted pulse zero-progress counting to exclude PRs already blocked by read-only merge gates, including non-passing required checks and origin:worker PRs without a linked issue. Added a regression fixture covering the false-positive candidate mix from the merge-stuck incident.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-stuck.sh; shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh; bash -n .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh

Resolves #22918


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.61 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 17m and 316,440 tokens on this as a headless worker.