### PR TITLE
GH#22928: fix: recover stale pulse dispatch blockers

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1367,6 +1367,19 @@ enumerate_blockers() {
 # PR evidence dedup check functions are in dispatch-dedup-pr.sh (GH#18916).
 
 #######################################
+# Check whether a local process currently covers an issue.
+#######################################
+_dd_has_local_worker_for_issue() {
+	local issue_number="$1"
+	local running_keys=""
+	running_keys=$(list_running_keys 2>/dev/null || true)
+	if printf '%s\n' "$running_keys" | grep -Eq "\|(issue|ref)-${issue_number}$"; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Check whether a single dispatch comment is still active.
 #
 # GH#16626: Process liveness check — if the comment is within TTL but no
@@ -1381,6 +1394,7 @@ enumerate_blockers() {
 #   $3 = issue number (for process search)
 #   $4 = now_epoch (seconds since epoch)
 #   $5 = max_age (seconds)
+#   $6 = self login (optional, for local stale-worker reconciliation)
 # Returns: exit 0 if comment is active (blocks dispatch), exit 1 if stale/expired
 # Outputs: reason string on stdout when active
 #
@@ -1418,6 +1432,7 @@ _is_dispatch_comment_active() {
 	local issue_number="$3"
 	local now_epoch="$4"
 	local max_age="$5"
+	local self_login="${6:-}"
 	local active_worker_max_age="${DISPATCH_ACTIVE_WORKER_MAX_AGE:-7200}"
 	[[ "$active_worker_max_age" =~ ^[0-9]+$ ]] || active_worker_max_age=7200
 
@@ -1435,6 +1450,11 @@ _is_dispatch_comment_active() {
 	# non-terminal worker window expires; after that, a later claim path can emit
 	# an explicit stale-worker takeover reason instead of a bare DISPATCH_CLAIM.
 	if [[ "$age" -ge "$max_age" ]]; then
+		if [[ -n "$self_login" && "$author" == "$self_login" ]]; then
+			if ! _dd_has_local_worker_for_issue "$issue_number"; then
+				return 1
+			fi
+		fi
 		if [[ "$age" -lt "$active_worker_max_age" ]]; then
 			printf 'non-terminal dispatch comment by %s posted %ds ago on issue #%s (soft TTL expired; active-worker window: %ds remaining)\n' \
 				"$author" "$age" "$issue_number" "$((active_worker_max_age - age))"
@@ -1573,7 +1593,7 @@ has_dispatch_comment() {
 	dispatch_author=$(printf '%s' "$last_dispatch_json" | jq -r '.author // ""' 2>/dev/null) || dispatch_author=""
 
 	# Check if the dispatch comment is within TTL
-	if ! _is_dispatch_comment_active "$dispatch_created_at" "$dispatch_author" "$issue_number" "$now_epoch" "$max_age"; then
+	if ! _is_dispatch_comment_active "$dispatch_created_at" "$dispatch_author" "$issue_number" "$now_epoch" "$max_age" "${3:-}"; then
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1220,7 +1220,7 @@ _release_dispatch_claim_on_abort() {
 	# audit comment is preserved.
 	local _is_pre_launch_abort=0
 	case "$reason" in
-		worker_launch_rc_2 | predispatch_validator_closed | eligibility_gate)
+		worker_launch_rc_* | predispatch_validator_closed | eligibility_gate)
 			_is_pre_launch_abort=1
 			;;
 	esac

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -151,6 +151,11 @@ _dispatch_candidate_failure_reason() {
 		' "$LOGFILE" 2>/dev/null) || recent_lines=""
 	fi
 
+	if [[ "$recent_lines" == *"has active dispatch comment"* || "$recent_lines" == *"active claim"* ]]; then
+		printf 'dedup_active_claim\n'
+		return 0
+	fi
+
 	if [[ "$recent_lines" == *"DISPATCH_BLOCK_REASON reason="* ]]; then
 		reason=$(printf '%s\n' "$recent_lines" | awk '
 			match($0, /DISPATCH_BLOCK_REASON reason=[a-z_]+/) {

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -521,10 +521,12 @@ _fast_fail_age_out_locked() {
 	now=$(date +%s)
 	state=$(_ff_load)
 
-	local existing_ts existing_count existing_reset_count
+	local existing_ts existing_count existing_reset_count existing_reason existing_crash_type
 	existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
 	existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0
 	existing_reset_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].reset_count // 0' 2>/dev/null) || existing_reset_count=0
+	existing_reason=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].reason // ""' 2>/dev/null) || existing_reason=""
+	existing_crash_type=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].crash_type // ""' 2>/dev/null) || existing_crash_type=""
 	[[ "$existing_ts" =~ ^[0-9]+$ ]] || existing_ts=0
 	[[ "$existing_count" =~ ^[0-9]+$ ]] || existing_count=0
 	[[ "$existing_reset_count" =~ ^[0-9]+$ ]] || existing_reset_count=0
@@ -536,7 +538,15 @@ _fast_fail_age_out_locked() {
 	fi
 
 	# Quiet-period check: last failure must be >= AGE_OUT_SECONDS ago.
+	# Infra/no-work hard stops are cheaper to retry once the runner/provider
+	# recovers. Use a shorter default so review-cleanup issues do not remain
+	# stranded behind stale runtime failures for a full operator cycle.
 	local age_out_secs="${FAST_FAIL_AGE_OUT_SECONDS:-3600}"
+	case "${existing_reason}:${existing_crash_type}" in
+	no_worker_process:* | worker_noop_zero_output:* | rate_limit*:* | backoff:* | stale_timeout:no_work)
+		age_out_secs="${FAST_FAIL_INFRA_AGE_OUT_SECONDS:-900}"
+		;;
+	esac
 	local age
 	age=$((now - existing_ts))
 	if [[ "$age" -lt "$age_out_secs" ]]; then

--- a/.agents/scripts/tests/test-dispatch-recovery-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-recovery-blockers.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$1"
+	[[ -n "${2:-}" ]] && printf '     %s\n' "$2"
+	return 0
+}
+
+TMP=$(mktemp -d -t dispatch-recovery.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+old_epoch=$(($(date -u +%s) - 1200))
+old_iso=$(date -u -r "$old_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@${old_epoch}" +%Y-%m-%dT%H:%M:%SZ)
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/gh" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"issues/123/comments"* ]]; then
+  cat <<JSON
+[
+  {
+    "body": "<!-- ops:start -->\nDispatching worker (deterministic).\n- **Worker PID**: 99999\n- **Issue**: #123\n<!-- ops:end -->",
+    "user": {"login": "self-runner"},
+    "created_at": "${old_iso}"
+  }
+]
+JSON
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "${TMP}/bin/gh"
+
+PATH="${TMP}/bin:${PATH}" \
+	DISPATCH_COMMENT_MAX_AGE=600 \
+	DISPATCH_ACTIVE_WORKER_MAX_AGE=7200 \
+	"${SCRIPTS_DIR}/dispatch-dedup-helper.sh" has-dispatch-comment 123 owner/repo self-runner \
+	>"${TMP}/dispatch.out" 2>"${TMP}/dispatch.err"
+dispatch_rc=$?
+
+if [[ "$dispatch_rc" -eq 1 ]]; then
+	pass "self-authored non-terminal dispatch comment is ignored after soft TTL when no local worker exists"
+else
+	fail "self-authored non-terminal dispatch comment is ignored after soft TTL when no local worker exists" \
+		"expected rc=1, got rc=${dispatch_rc}; out=$(cat "${TMP}/dispatch.out" 2>/dev/null); err=$(cat "${TMP}/dispatch.err" 2>/dev/null)"
+fi
+
+if grep -q 'worker_launch_rc_\*' "${SCRIPTS_DIR}/pulse-dispatch-core.sh"; then
+	pass "all worker_launch_rc pre-launch aborts delete/release dispatch claims"
+else
+	fail "all worker_launch_rc pre-launch aborts delete/release dispatch claims" \
+		"expected worker_launch_rc_* pattern in pulse-dispatch-core.sh"
+fi
+
+active_line=$(grep -n 'has active dispatch comment.*active claim' "${SCRIPTS_DIR}/pulse-dispatch-lib.sh" | cut -d: -f1 | head -1)
+block_line=$(grep -n 'DISPATCH_BLOCK_REASON reason=' "${SCRIPTS_DIR}/pulse-dispatch-lib.sh" | cut -d: -f1 | head -1)
+if [[ -n "$active_line" && -n "$block_line" && "$active_line" -lt "$block_line" ]]; then
+	pass "dedup-active evidence takes precedence over stale historical block reasons"
+else
+	fail "dedup-active evidence takes precedence over stale historical block reasons" \
+		"active_line=${active_line:-missing}, block_line=${block_line:-missing}"
+fi
+
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf 'All %d tests passed\n' "$TESTS_RUN"
+	exit 0
+fi
+printf '%d / %d tests failed\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1

--- a/.agents/scripts/tests/test-fast-fail-age-out.sh
+++ b/.agents/scripts/tests/test-fast-fail-age-out.sh
@@ -14,7 +14,7 @@
 #   CI flakes). Manual recovery required touching the counter file — operators
 #   rarely do this, leaving issues permanently stuck.
 #
-# Tests (7):
+# Tests (8):
 #   1. HARD STOP + age > 24h → counter reset to 0
 #   2. HARD STOP + age < 24h → NOT reset (quiet-period guard)
 #   3. count < HARD STOP (below threshold) → NOT affected
@@ -22,6 +22,7 @@
 #   5. reset_count increments on each age-out
 #   6. After FAST_FAIL_AGE_OUT_MAX_RESETS resets, NMR label applied (not reset again)
 #   7. Issue comment posted once per age-out event
+#   8. Infra/no_work hard stops use FAST_FAIL_INFRA_AGE_OUT_SECONDS
 #
 # Stub strategy:
 #   - Set FAST_FAIL_STATE_FILE to a tmpdir path so tests are hermetic.
@@ -133,12 +134,14 @@ _write_ff_entry() {
 	local count="$2"
 	local ts_offset="$3"
 	local rcount="${4:-0}"
+	local reason="${5:-crash}"
+	local crash_type="${6:-}"
 	local slug="test/repo"
 	local now
 	now=$(date +%s)
 	local ts=$((now - ts_offset))
-	printf '{"test/repo/%s":{"count":%s,"ts":%s,"reason":"crash","retry_after":0,"backoff_secs":600,"crash_type":"","reset_count":%s}}\n' \
-		"$issue" "$count" "$ts" "$rcount" >"$FAST_FAIL_STATE_FILE"
+	printf '{"test/repo/%s":{"count":%s,"ts":%s,"reason":"%s","retry_after":0,"backoff_secs":600,"crash_type":"%s","reset_count":%s}}\n' \
+		"$issue" "$count" "$ts" "$reason" "$crash_type" "$rcount" >"$FAST_FAIL_STATE_FILE"
 	return 0
 }
 
@@ -260,6 +263,23 @@ if printf '%s' "$gh_calls_content" | grep -q "issue comment"; then
 else
 	fail "age-out fires → issue comment posted" \
 		"expected 'issue comment' in gh calls: ${gh_calls_content}"
+fi
+
+# =============================================================================
+# Test 8 — infra/no_work hard stops use shorter recovery age
+# =============================================================================
+export FAST_FAIL_INFRA_AGE_OUT_SECONDS=5
+export FAST_FAIL_AGE_OUT_SECONDS=100
+_write_ff_entry "107" "6" "20" "0" "stale_timeout" "no_work"
+
+fast_fail_age_out "107" "test/repo" 2>/dev/null || true
+
+result_count=$(jq -r '."test/repo/107".count // -1' "$FAST_FAIL_STATE_FILE" 2>/dev/null) || result_count="-1"
+if [[ "$result_count" == "0" ]]; then
+	pass "infra/no_work HARD STOP uses shorter age-out threshold"
+else
+	fail "infra/no_work HARD STOP uses shorter age-out threshold" \
+		"expected count=0, got count=${result_count}"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Shortened infra/no-work fast-fail age-out, ignored stale self-authored dispatch comments without a local worker, released all worker-launch prelaunch claims, and prioritized active claim/comment blockers over stale historical gate reasons.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/pulse-fast-fail.sh,.agents/scripts/tests/test-dispatch-recovery-blockers.sh,.agents/scripts/tests/test-fast-fail-age-out.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-fast-fail-age-out.sh; .agents/scripts/tests/test-dispatch-recovery-blockers.sh; shellcheck .agents/scripts/pulse-fast-fail.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-fast-fail-age-out.sh .agents/scripts/tests/test-dispatch-recovery-blockers.sh

Resolves #22928


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.61 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 4m and 73,703 tokens on this as a headless worker.