### PR TITLE
fix: initialize fast-fail age-out locals

### DIFF
--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -387,7 +387,7 @@ _fast_fail_record_locked() {
 		fi
 	fi
 
-	local key now state
+	local key="" now="" state=""
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	now=$(date +%s)
 	state=$(_ff_load)
@@ -521,7 +521,7 @@ _fast_fail_age_out_locked() {
 	now=$(date +%s)
 	state=$(_ff_load)
 
-	local existing_ts existing_count existing_reset_count existing_reason existing_crash_type
+	local existing_ts="" existing_count="" existing_reset_count="" existing_reason="" existing_crash_type=""
 	existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
 	existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0
 	existing_reset_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].reset_count // 0' 2>/dev/null) || existing_reset_count=0


### PR DESCRIPTION
## Summary

Initialize fast-fail age-out local variables so set -u safety validators do not flag multi-var declarations from PR #22930.

## Testing

- `.agents/scripts/tests/test-fast-fail-age-out.sh`
- `shellcheck .agents/scripts/pulse-fast-fail.sh`
- `.agents/scripts/pulse-unbound-var-check.sh --fix-hint`

For #22928


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.61 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 9m and 190,253 tokens on this as a headless worker.
