### PR TITLE
GH#22935: fallback after zero-output worker launches

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -212,6 +212,100 @@ _dlw_resolve_tier_and_model() {
 	return 0
 }
 
+_dlw_zero_output_failure_count() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || { printf '0'; return 0; }
+	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
+	[[ -n "${FAST_FAIL_STATE_FILE:-}" && -f "$FAST_FAIL_STATE_FILE" ]] || { printf '0'; return 0; }
+
+	local key="${repo_slug}/${issue_number}"
+	local entry=""
+	entry=$(jq -r --arg k "$key" '.[$k] // empty' "$FAST_FAIL_STATE_FILE" 2>/dev/null) || entry=""
+	[[ -n "$entry" ]] || { printf '0'; return 0; }
+
+	local reason="" crash_type="" count=""
+	reason=$(printf '%s' "$entry" | jq -r '.reason // ""' 2>/dev/null) || reason=""
+	crash_type=$(printf '%s' "$entry" | jq -r '.crash_type // ""' 2>/dev/null) || crash_type=""
+	count=$(printf '%s' "$entry" | jq -r '.count // 0' 2>/dev/null) || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+	case "${reason}:${crash_type}" in
+	worker_noop_zero_output:* | *:no_work | no_work:*) printf '%s' "$count" ;;
+	*) printf '0' ;;
+	esac
+	return 0
+}
+
+_dlw_zero_output_fallback_prompt() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_title="$3"
+
+	cat <<EOF
+You are assigned to work on issue #${issue_number} in ${repo_slug}.
+
+Previous dispatch attempts for this issue launched a worker but produced zero session output. Do not rely on embedded issue content from the dispatcher.
+
+First actions:
+1. Read the issue directly with: gh issue view ${issue_number} --repo ${repo_slug}
+2. Ignore ops/provenance/audit comments as implementation context.
+3. Summarize the actionable task, files, and verification before editing.
+4. If the issue brief is malformed, too broad, or not worker-ready, rewrite the brief or split it into smaller worker-ready issues instead of attempting a speculative implementation.
+
+Issue title: ${issue_title:-Issue #${issue_number}}
+EOF
+	return 0
+}
+
+_dlw_prepare_prompt_for_launch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_title="$3"
+	local original_prompt="$4"
+
+	local zero_count=""
+	zero_count=$(_dlw_zero_output_failure_count "$issue_number" "$repo_slug")
+	[[ "$zero_count" =~ ^[0-9]+$ ]] || zero_count=0
+	local fallback_threshold="${ZERO_OUTPUT_URL_FALLBACK_THRESHOLD:-2}"
+	[[ "$fallback_threshold" =~ ^[0-9]+$ ]] || fallback_threshold=2
+
+	if [[ "$zero_count" -ge "$fallback_threshold" ]]; then
+		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: using URL-only bootstrap prompt after ${zero_count} zero-output launches" >>"$LOGFILE"
+		_dlw_zero_output_fallback_prompt "$issue_number" "$repo_slug" "$issue_title"
+		return 0
+	fi
+
+	printf '%s' "$original_prompt"
+	return 0
+}
+
+_dlw_hold_repeated_zero_output() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local zero_count=""
+	zero_count=$(_dlw_zero_output_failure_count "$issue_number" "$repo_slug")
+	[[ "$zero_count" =~ ^[0-9]+$ ]] || zero_count=0
+	local hold_threshold="${ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD:-4}"
+	[[ "$hold_threshold" =~ ^[0-9]+$ ]] || hold_threshold=4
+
+	if [[ "$zero_count" -lt "$hold_threshold" ]]; then
+		return 1
+	fi
+
+	echo "[dispatch_with_dedup] Holding #${issue_number} in ${repo_slug}: ${zero_count} zero-output launches; applying brief-rewrite triage labels" >>"$LOGFILE"
+	gh label create "needs-brief-rewrite" --repo "$repo_slug" \
+		--description "Issue brief should be rewritten or split before redispatch" \
+		--color "FBCA04" --force >/dev/null 2>&1 || true
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "needs-brief-rewrite" \
+		--add-label "needs-maintainer-review" \
+		--remove-label "status:queued" >/dev/null 2>&1 || true
+	return 0
+}
+
 #######################################
 # Pre-create a worker worktree so the worker can start coding immediately
 # instead of spending 5-8 tool calls on worktree setup. Populates two
@@ -1187,6 +1281,10 @@ _dispatch_launch_worker() {
 	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"
 	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
+	if _dlw_hold_repeated_zero_output "$issue_number" "$repo_slug"; then
+		return 2
+	fi
+
 	# t1894/t1934: Lock issue and linked PRs during worker execution
 	_ds_t0=$(_ds_now_ns)
 	lock_issue_for_worker "$issue_number" "$repo_slug"
@@ -1220,8 +1318,10 @@ _dispatch_launch_worker() {
 
 	_ds_t0=$(_ds_now_ns)
 	local worker_pid
+	local launch_prompt=""
+	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt")
 	worker_pid=$(_dlw_nohup_launch "$issue_number" "$dispatch_title" "$issue_title" \
-		"$session_key" "$worker_log" "$prompt" "$repo_path" \
+		"$session_key" "$worker_log" "$launch_prompt" "$repo_path" \
 		"$dispatch_model_tier" "$selected_model" \
 		"$worker_worktree_path" "$worker_worktree_branch")
 	_ds_record "$issue_number" "$repo_slug" "worker_spawn" "$_ds_t0"

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$1"
+	[[ -n "${2:-}" ]] && printf '     %s\n' "$2"
+	return 0
+}
+
+TMP=$(mktemp -d -t zero-output-url-fallback.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+LOGFILE="${TMP}/pulse.log"
+FAST_FAIL_STATE_FILE="${TMP}/fast-fail-counter.json"
+export LOGFILE FAST_FAIL_STATE_FILE
+
+gh() {
+	printf '%s\n' "$*" >>"${TMP}/gh-calls.log"
+	return 0
+}
+export -f gh
+
+# shellcheck source=../pulse-dispatch-worker-launch.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh" >/dev/null 2>&1 || {
+	printf 'FATAL Could not source pulse-dispatch-worker-launch.sh\n'
+	exit 1
+}
+
+write_state() {
+	local count="$1"
+	local reason="${2:-worker_noop_zero_output}"
+	local crash_type="${3:-}"
+	printf '{"owner/repo/123":{"count":%s,"ts":1,"reason":"%s","retry_after":0,"backoff_secs":600,"crash_type":"%s"}}\n' \
+		"$count" "$reason" "$crash_type" >"$FAST_FAIL_STATE_FILE"
+	return 0
+}
+
+write_state 2
+fallback_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
+if printf '%s' "$fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+	&& ! printf '%s' "$fallback_prompt" | grep -q 'FULL EMBEDDED BRIEF'; then
+	pass "repeated zero-output launches switch to URL-only bootstrap prompt"
+else
+	fail "repeated zero-output launches switch to URL-only bootstrap prompt" "$fallback_prompt"
+fi
+
+write_state 1
+normal_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
+if [[ "$normal_prompt" == "FULL EMBEDDED BRIEF" ]]; then
+	pass "below fallback threshold keeps embedded prompt"
+else
+	fail "below fallback threshold keeps embedded prompt" "$normal_prompt"
+fi
+
+: >"${TMP}/gh-calls.log"
+write_state 4
+_dlw_hold_repeated_zero_output 123 owner/repo
+hold_rc=$?
+gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
+if [[ "$hold_rc" -eq 0 ]] \
+	&& printf '%s' "$gh_calls" | grep -q 'needs-brief-rewrite' \
+	&& printf '%s' "$gh_calls" | grep -q 'needs-maintainer-review'; then
+	pass "continued zero-output launches hold dispatch for brief rewrite"
+else
+	fail "continued zero-output launches hold dispatch for brief rewrite" \
+		"rc=${hold_rc}; gh_calls=${gh_calls}"
+fi
+
+write_state 4 runtime partial
+non_zero_count=$(_dlw_zero_output_failure_count 123 owner/repo)
+if [[ "$non_zero_count" == "0" ]]; then
+	pass "non-zero-output failure reasons do not trigger URL-only fallback"
+else
+	fail "non-zero-output failure reasons do not trigger URL-only fallback" \
+		"count=${non_zero_count}"
+fi
+
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf 'All %d tests passed\n' "$TESTS_RUN"
+	exit 0
+fi
+printf '%d / %d tests failed\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1


### PR DESCRIPTION
## Summary

Switch repeated zero-output worker launches to a minimal issue bootstrap prompt and hold continued loops for brief rewrite triage instead of redispatching malformed embedded briefs.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-zero-output-url-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-zero-output-url-fallback.sh; shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-zero-output-url-fallback.sh

Resolves #22935


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.62 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 4m and 141,780 tokens on this as a headless worker.