### PR TITLE
fix: retry failures after recovery releases

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -238,6 +238,40 @@ _dlw_zero_output_failure_count() {
 	return 0
 }
 
+_dlw_zero_output_comment_count() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	[[ "${ZERO_OUTPUT_COMMENT_EVIDENCE_ENABLED:-1}" == "1" ]] || { printf '0'; return 0; }
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || { printf '0'; return 0; }
+	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
+
+	local count=""
+	count=$(gh api --paginate "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
+		--jq '[.[] | select(.body | test("CLAIM_RELEASED reason=worker_noop_zero_output"))] | length' 2>/dev/null | \
+		awk '{ total += $1 } END { print total + 0 }') || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	printf '%s' "$count"
+	return 0
+}
+
+_dlw_zero_output_evidence_count() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local state_count="" comment_count=""
+	state_count=$(_dlw_zero_output_failure_count "$issue_number" "$repo_slug")
+	comment_count=$(_dlw_zero_output_comment_count "$issue_number" "$repo_slug")
+	[[ "$state_count" =~ ^[0-9]+$ ]] || state_count=0
+	[[ "$comment_count" =~ ^[0-9]+$ ]] || comment_count=0
+	if [[ "$comment_count" -gt "$state_count" ]]; then
+		printf '%s' "$comment_count"
+	else
+		printf '%s' "$state_count"
+	fi
+	return 0
+}
+
 _dlw_zero_output_fallback_prompt() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -266,7 +300,7 @@ _dlw_prepare_prompt_for_launch() {
 	local original_prompt="$4"
 
 	local zero_count=""
-	zero_count=$(_dlw_zero_output_failure_count "$issue_number" "$repo_slug")
+	zero_count=$(_dlw_zero_output_evidence_count "$issue_number" "$repo_slug")
 	[[ "$zero_count" =~ ^[0-9]+$ ]] || zero_count=0
 	local fallback_threshold="${ZERO_OUTPUT_URL_FALLBACK_THRESHOLD:-2}"
 	[[ "$fallback_threshold" =~ ^[0-9]+$ ]] || fallback_threshold=2
@@ -286,7 +320,7 @@ _dlw_hold_repeated_zero_output() {
 	local repo_slug="$2"
 
 	local zero_count=""
-	zero_count=$(_dlw_zero_output_failure_count "$issue_number" "$repo_slug")
+	zero_count=$(_dlw_zero_output_evidence_count "$issue_number" "$repo_slug")
 	[[ "$zero_count" =~ ^[0-9]+$ ]] || zero_count=0
 	local hold_threshold="${ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD:-4}"
 	[[ "$hold_threshold" =~ ^[0-9]+$ ]] || hold_threshold=4

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -344,6 +344,71 @@ _ff_compute_failure_strategy() {
 	return 0
 }
 
+_ff_current_aidevops_version() {
+	local version_file=""
+	for version_file in \
+		"${AGENTS_DIR:-${HOME}/.aidevops/agents}/VERSION" \
+		"${SCRIPT_DIR:-${BASH_SOURCE[0]%/*}}/../VERSION" \
+		"${SCRIPT_DIR:-${BASH_SOURCE[0]%/*}}/../../VERSION"; do
+		if [[ -f "$version_file" ]]; then
+			tr -d '[:space:]' <"$version_file" 2>/dev/null || true
+			return 0
+		fi
+	done
+	printf '0.0.0'
+	return 0
+}
+
+_ff_version_gt() {
+	local left="$1"
+	local right="$2"
+	python3 - "$left" "$right" <<'PY'
+import re
+import sys
+
+def parts(value):
+    nums = [int(x) for x in re.findall(r"\d+", value or "")[:3]]
+    return tuple((nums + [0, 0, 0])[:3])
+
+sys.exit(0 if parts(sys.argv[1]) > parts(sys.argv[2]) else 1)
+PY
+	return $?
+}
+
+_ff_release_retry_reset_if_newer() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	[[ "${FAST_FAIL_RELEASE_RETRY_RESET_ENABLED:-1}" == "1" ]] || return 1
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$repo_slug" ]] || return 1
+
+	local key="" state="" current_version="" failure_version="" reset_version=""
+	key=$(_ff_key "$issue_number" "$repo_slug")
+	state=$(_ff_load)
+	current_version=$(_ff_current_aidevops_version)
+	failure_version=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].aidevops_version // ""' 2>/dev/null) || failure_version=""
+	reset_version=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].release_retry_reset_version // ""' 2>/dev/null) || reset_version=""
+
+	[[ -n "$failure_version" ]] || failure_version="0.0.0"
+	[[ -n "$current_version" ]] || return 1
+	[[ "$reset_version" != "$current_version" ]] || return 1
+	_ff_version_gt "$current_version" "$failure_version" || return 1
+
+	local now="" updated_state=""
+	now=$(date +%s)
+	updated_state=$(printf '%s' "$state" | jq \
+		--arg k "$key" \
+		--arg current "$current_version" \
+		--arg previous "$failure_version" \
+		--argjson ts "$now" \
+		'.[$k].count = 0 | .[$k].retry_after = 0 | .[$k].release_retry_reset_version = $current | .[$k].release_retry_reset_from = $previous | .[$k].release_retry_reset_ts = $ts' \
+		2>/dev/null) || return 1
+	_ff_save "$updated_state"
+	echo "[pulse-wrapper] fast_fail_release_retry_reset: #${issue_number} (${repo_slug}) reset stale failure from aidevops ${failure_version} under current ${current_version}" >>"$LOGFILE"
+	return 0
+}
+
 #######################################
 # Record a worker failure for an issue with cause-aware retry strategy.
 #
@@ -414,7 +479,8 @@ _fast_fail_record_locked() {
 	fi
 
 	# Write updated state (include crash_type for diagnostics).
-	local updated_state
+	local updated_state aidevops_version
+	aidevops_version=$(_ff_current_aidevops_version)
 	updated_state=$(printf '%s' "$state" | jq \
 		--arg k "$key" \
 		--argjson count "$new_count" \
@@ -423,7 +489,8 @@ _fast_fail_record_locked() {
 		--argjson retry_after "$retry_after" \
 		--argjson backoff_secs "$new_backoff" \
 		--arg crash_type "${crash_type:-}" \
-		'.[$k] = {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type}' 2>/dev/null) || return 0
+		--arg aidevops_version "$aidevops_version" \
+		'.[$k] = {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version}' 2>/dev/null) || return 0
 
 	# Flag for enrichment on first non-rate-limit failure: a thinking-tier worker
 	# will analyze the issue and add implementation guidance before re-dispatch.
@@ -612,6 +679,12 @@ fast_fail_is_skipped() {
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	now=$(date +%s)
 	state=$(_ff_load)
+	if printf '%s' "$state" | jq -e --arg k "$key" '.[$k] != null' >/dev/null 2>&1; then
+		if _ff_release_retry_reset_if_newer "$issue_number" "$repo_slug"; then
+			return 1
+		fi
+		state=$(_ff_load)
+	fi
 
 	existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
 	existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0

--- a/.agents/scripts/tests/test-fast-fail-release-retry-reset.sh
+++ b/.agents/scripts/tests/test-fast-fail-release-retry-reset.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$1"
+	[[ -n "${2:-}" ]] && printf '     %s\n' "$2"
+	return 0
+}
+
+TMP=$(mktemp -d -t fast-fail-release-reset.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+LOGFILE="${TMP}/pulse.log"
+FAST_FAIL_STATE_FILE="${TMP}/fast-fail-counter.json"
+AGENTS_DIR="${TMP}/agents"
+export LOGFILE FAST_FAIL_STATE_FILE AGENTS_DIR
+mkdir -p "$AGENTS_DIR"
+printf '3.14.64\n' >"${AGENTS_DIR}/VERSION"
+
+export FAST_FAIL_SKIP_THRESHOLD=5
+export FAST_FAIL_EXPIRY_SECS=604800
+export FAST_FAIL_INITIAL_BACKOFF_SECS=600
+export FAST_FAIL_MAX_BACKOFF_SECS=604800
+
+print_info() { :; return 0; }
+print_warning() { :; return 0; }
+print_error() { :; return 0; }
+print_success() { :; return 0; }
+log_verbose() { :; return 0; }
+export -f print_info print_warning print_error print_success log_verbose
+
+gh() { return 0; }
+export -f gh
+
+escalate_issue_tier() { return 0; }
+export -f escalate_issue_tier
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1 || true
+# shellcheck source=../pulse-fast-fail.sh
+source "${SCRIPTS_DIR}/pulse-fast-fail.sh" >/dev/null 2>&1 || {
+	printf 'FATAL Could not source pulse-fast-fail.sh\n'
+	exit 1
+}
+
+write_entry() {
+	local issue="$1"
+	local count="$2"
+	local retry_after="$3"
+	local version="$4"
+	printf '{"owner/repo/%s":{"count":%s,"ts":1,"reason":"rate_limit","retry_after":%s,"backoff_secs":600,"crash_type":"","aidevops_version":"%s"}}\n' \
+		"$issue" "$count" "$retry_after" "$version" >"$FAST_FAIL_STATE_FILE"
+	return 0
+}
+
+future=$(( $(date +%s) + 3600 ))
+
+write_entry 123 1 "$future" "3.14.63"
+reset_rc=0
+fast_fail_is_skipped 123 owner/repo || reset_rc=$?
+reset_count=$(jq -r '."owner/repo/123".count' "$FAST_FAIL_STATE_FILE")
+reset_retry=$(jq -r '."owner/repo/123".retry_after' "$FAST_FAIL_STATE_FILE")
+reset_version=$(jq -r '."owner/repo/123".release_retry_reset_version' "$FAST_FAIL_STATE_FILE")
+if [[ "$reset_rc" -eq 1 && "$reset_count" == "0" && "$reset_retry" == "0" && "$reset_version" == "3.14.64" ]]; then
+	pass "new aidevops version clears old-version backoff once"
+else
+	fail "new aidevops version clears old-version backoff once" \
+		"rc=${reset_rc}; count=${reset_count}; retry=${reset_retry}; reset_version=${reset_version}"
+fi
+
+skip_rc=0
+fast_fail_is_skipped 123 owner/repo || skip_rc=$?
+if [[ "$skip_rc" -eq 1 ]]; then
+	pass "release retry reset is not repeatedly reapplied after reset marker"
+else
+	fail "release retry reset is not repeatedly reapplied after reset marker" "rc=${skip_rc}"
+fi
+
+write_entry 124 1 "$future" "3.14.64"
+same_rc=0
+fast_fail_is_skipped 124 owner/repo || same_rc=$?
+if [[ "$same_rc" -eq 0 ]]; then
+	pass "same-version backoff remains respected"
+else
+	fail "same-version backoff remains respected" "rc=${same_rc}"
+fi
+
+fast_fail_record 125 owner/repo worker_noop_zero_output anthropic no_work
+recorded_version=$(jq -r '."owner/repo/125".aidevops_version' "$FAST_FAIL_STATE_FILE")
+if [[ "$recorded_version" == "3.14.64" ]]; then
+	pass "fast_fail_record stores aidevops version metadata"
+else
+	fail "fast_fail_record stores aidevops version metadata" "version=${recorded_version}"
+fi
+
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf 'All %d tests passed\n' "$TESTS_RUN"
+	exit 0
+fi
+printf '%d / %d tests failed\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -32,6 +32,10 @@ FAST_FAIL_STATE_FILE="${TMP}/fast-fail-counter.json"
 export LOGFILE FAST_FAIL_STATE_FILE
 
 gh() {
+	if [[ "${1:-}" == "api" && "${GH_COMMENT_ZERO_COUNT:-0}" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$GH_COMMENT_ZERO_COUNT"
+		return 0
+	fi
 	printf '%s\n' "$*" >>"${TMP}/gh-calls.log"
 	return 0
 }
@@ -62,6 +66,7 @@ else
 fi
 
 write_state 1
+GH_COMMENT_ZERO_COUNT=0
 normal_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
 if [[ "$normal_prompt" == "FULL EMBEDDED BRIEF" ]]; then
 	pass "below fallback threshold keeps embedded prompt"
@@ -69,8 +74,19 @@ else
 	fail "below fallback threshold keeps embedded prompt" "$normal_prompt"
 fi
 
+write_state 1
+GH_COMMENT_ZERO_COUNT=2
+comment_fallback_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
+if printf '%s' "$comment_fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+	&& ! printf '%s' "$comment_fallback_prompt" | grep -q 'FULL EMBEDDED BRIEF'; then
+	pass "comment evidence triggers URL-only fallback when state count is low"
+else
+	fail "comment evidence triggers URL-only fallback when state count is low" "$comment_fallback_prompt"
+fi
+
 : >"${TMP}/gh-calls.log"
 write_state 4
+GH_COMMENT_ZERO_COUNT=0
 _dlw_hold_repeated_zero_output 123 owner/repo
 hold_rc=$?
 gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
@@ -83,7 +99,22 @@ else
 		"rc=${hold_rc}; gh_calls=${gh_calls}"
 fi
 
+: >"${TMP}/gh-calls.log"
+write_state 1
+GH_COMMENT_ZERO_COUNT=4
+_dlw_hold_repeated_zero_output 123 owner/repo
+comment_hold_rc=$?
+comment_gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
+if [[ "$comment_hold_rc" -eq 0 ]] \
+	&& printf '%s' "$comment_gh_calls" | grep -q 'needs-brief-rewrite'; then
+	pass "comment evidence triggers brief-rewrite hold when state count is low"
+else
+	fail "comment evidence triggers brief-rewrite hold when state count is low" \
+		"rc=${comment_hold_rc}; gh_calls=${comment_gh_calls}"
+fi
+
 write_state 4 runtime partial
+GH_COMMENT_ZERO_COUNT=0
 non_zero_count=$(_dlw_zero_output_failure_count 123 owner/repo)
 if [[ "$non_zero_count" == "0" ]]; then
 	pass "non-zero-output failure reasons do not trigger URL-only fallback"


### PR DESCRIPTION
## Summary
- Count zero-output lifecycle comments as dispatch evidence so repeated no-session loops trigger URL-only fallback/brief-rewrite hold even when local fast-fail state is stale.
- Store aidevops version metadata in fast-fail entries and clear old-version retry/backoff once after a newer deployed release.
- Add regression tests for comment-based zero-output evidence and release-aware retry reset.

## Verification
- `.agents/scripts/tests/test-fast-fail-release-retry-reset.sh`
- `.agents/scripts/tests/test-zero-output-url-fallback.sh`
- `shellcheck .agents/scripts/pulse-fast-fail.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-fast-fail-release-retry-reset.sh .agents/scripts/tests/test-zero-output-url-fallback.sh`

Resolves #22940
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.64 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 5h 42m and 3,855,401 tokens on this with the user in an interactive session.