### PR TITLE
GH#22939: fix: suppress completed PR salvage recoveries

### DIFF
--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -23,6 +23,7 @@
 #   2. The branch still exists on the remote (code is recoverable)
 #   3. The branch has commits ahead of the default branch (actual code)
 #   4. No replacement PR exists (open PR targeting the same issue)
+#   5. No closed recovery issue already documents completed salvage for the PR
 #
 # Author: AI DevOps Framework
 # Version: 1.0.0
@@ -116,6 +117,40 @@ has_replacement_pr() {
 	open_count=$(gh pr list --repo "$slug" --state open \
 		--head "$branch" --json number --jq 'length' 2>/dev/null) || open_count="0"
 	if [[ "${open_count:-0}" -gt 0 ]]; then
+		echo "true"
+	else
+		echo "false"
+	fi
+	return 0
+}
+
+#######################################
+# Check if a closed issue already completed recovery for a closed PR.
+# Arguments:
+#   $1 - repo slug (owner/repo)
+#   $2 - PR number
+# Output: "true" or "false" to stdout
+#######################################
+has_completed_recovery_issue() {
+	local slug="$1"
+	local pr_number="$2"
+	local issues
+	issues=$(gh issue list --repo "$slug" --state closed \
+		--search "\"PR #${pr_number}\" recover" \
+		--json number,title,body,state,closedAt --limit 50 2>/dev/null) || issues="[]"
+
+	local match_count
+	match_count=$(echo "$issues" | jq --arg pr "PR #${pr_number}" '
+		[
+			.[]
+			| ((.title // "") + "\n" + (.body // "")) as $text
+			| ($text | ascii_downcase) as $lower
+			| select($text | contains($pr))
+			| select($lower | test("recover|recovery|salvage|restore|cherry-pick|cherrypick"))
+		] | length
+	') || match_count="0"
+
+	if [[ "${match_count:-0}" -gt 0 ]]; then
 		echo "true"
 	else
 		echo "false"
@@ -238,9 +273,15 @@ scan_repo() {
 	local salvageable="[]"
 	local pr_json
 	while IFS= read -r pr_json; do
-		local branch additions branch_exists risk entry
+		local pr_number branch additions branch_exists risk entry
+		pr_number=$(echo "$pr_json" | jq -r '.number')
 		branch=$(echo "$pr_json" | jq -r '.headRefName')
 		additions=$(echo "$pr_json" | jq -r '.additions')
+
+		# Skip PRs whose salvage has already been completed and documented in a closed issue.
+		if [[ "$(has_completed_recovery_issue "$slug" "$pr_number")" == "true" ]]; then
+			continue
+		fi
 
 		# Skip PRs that already have a replacement open
 		if [[ "$(has_replacement_pr "$slug" "$branch")" == "true" ]]; then

--- a/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
+++ b/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local message="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	local details="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$message"
+	[[ -n "$details" ]] && printf '     %s\n' "$details"
+	return 0
+}
+
+gh() {
+	local area="${1:-}"
+	local command="${2:-}"
+	shift 2 || true
+
+	if [[ "$area" == "pr" && "$command" == "list" ]]; then
+		local args=" $* "
+		if [[ "$args" == *" --state closed "* ]]; then
+			cat <<'JSON'
+[
+  {
+    "number": 53,
+    "title": "Add buffalo logo favicon",
+    "headRefName": "buffalo-logo-favicon",
+    "closedAt": "2026-05-01T00:00:00Z",
+    "mergedAt": null,
+    "additions": 7,
+    "deletions": 0,
+    "author": {"login": "contributor"},
+    "labels": []
+  },
+  {
+    "number": 54,
+    "title": "Add recoverable feature",
+    "headRefName": "recoverable-feature",
+    "closedAt": "2026-05-02T00:00:00Z",
+    "mergedAt": null,
+    "additions": 120,
+    "deletions": 1,
+    "author": {"login": "contributor"},
+    "labels": []
+  }
+]
+JSON
+			return 0
+		fi
+		if [[ "$args" == *" --state open "* ]]; then
+			printf '0\n'
+			return 0
+		fi
+		printf '[]\n'
+		return 0
+	fi
+
+	if [[ "$area" == "issue" && "$command" == "list" ]]; then
+		local args=" $* "
+		if [[ "$args" == *'"PR #53" recover'* ]]; then
+			cat <<'JSON'
+[
+  {
+    "number": 60,
+    "title": "Recover buffalo logo favicon from closed PR #53",
+    "body": "Worker completion audit trail: completed recovery.",
+    "state": "CLOSED",
+    "closedAt": "2026-05-03T00:00:00Z"
+  }
+]
+JSON
+			return 0
+		fi
+		printf '[]\n'
+		return 0
+	fi
+
+	if [[ "$area" == "api" ]]; then
+		printf '{"name":"%s"}\n' "${1##*/}"
+		return 0
+	fi
+
+	return 1
+}
+export -f gh
+
+# shellcheck source=../pr-salvage-helper.sh
+source "${SCRIPTS_DIR}/pr-salvage-helper.sh" >/dev/null 2>&1 || {
+	printf 'FATAL Could not source pr-salvage-helper.sh\n'
+	exit 1
+}
+
+results=$(scan_repo "owner/repo" 7)
+if printf '%s' "$results" | jq -e 'length == 1 and .[0].number == 54' >/dev/null; then
+	pass "completed recovery issue suppresses matching closed PR"
+else
+	fail "completed recovery issue suppresses matching closed PR" "$results"
+fi
+
+prefetch_output=$(cmd_prefetch "owner/repo" "/tmp/repo")
+if ! printf '%s' "$prefetch_output" | grep -q 'PR #53' \
+	&& printf '%s' "$prefetch_output" | grep -q 'PR #54'; then
+	pass "prefetch omits already completed recovery PRs"
+else
+	fail "prefetch omits already completed recovery PRs" "$prefetch_output"
+fi
+
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf 'All %d tests passed\n' "$TESTS_RUN"
+	exit 0
+fi
+printf '%d / %d tests failed\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1


### PR DESCRIPTION
## Summary

Updated pr-salvage-helper.sh to skip closed-unmerged PRs when a closed recovery issue already documents completed recovery for the same PR, and added a mocked regression test for the PR #53-style scenario.

## Files Changed

.agents/scripts/pr-salvage-helper.sh,.agents/scripts/tests/test-pr-salvage-completed-recovery.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh; shellcheck .agents/scripts/pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-completed-recovery.sh

Resolves #22939


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.64 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 42,597 tokens on this as a headless worker.