### PR TITLE
GH#22938: dedup dashboard freshness alerts

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -19,8 +19,8 @@
 # Design principles:
 #   - Single-pass, cheap: one gh API call per tracked dashboard.
 #   - Cadence-gated: default one check per hour, throttled via state file.
-#   - Idempotent alerting: one open alert per stale dashboard, dedup'd by
-#     title prefix "Supervisor health dashboard stale:".
+#   - Idempotent alerting: one open alert per dashboard, dedup'd by generated
+#     alert title plus dashboard issue suffix.
 #   - Fail-open: any error (gh offline, cache missing, body missing marker)
 #     logs and exits 0 — never blocks the pulse.
 #
@@ -282,14 +282,16 @@ _resolve_slug_from_dashed() {
 _open_alert_numbers() {
 	local slug="$1"
 	local dash_issue="$2"
-	local marker="<!-- aidevops:dashboard-freshness:${slug}:${dash_issue} -->"
+	local stale_title_prefix="Supervisor health dashboard stale:"
+	local missing_marker_title="Supervisor health dashboard missing last_refresh marker (#${dash_issue})"
+	local issue_suffix="(#${dash_issue})"
 	command -v gh >/dev/null 2>&1 || return 0
 	gh auth status &>/dev/null 2>&1 || return 0
-	# Search only open review-followup issues with the exact freshness marker.
+	# Query open issue titles and filter locally. GitHub search is unreliable for
+	# HTML-comment dedup markers, and label prefilters can hide generated alerts.
 	gh issue list --repo "$slug" --state open \
-		--label "review-followup" \
-		--search "in:body \"${marker}\"" \
-		--json number --jq '.[].number' 2>/dev/null || true
+		--json number,title \
+		--jq '.[] | select(((.title | startswith("'"${stale_title_prefix}"'")) and (.title | endswith("'"${issue_suffix}"'"))) or (.title == "'"${missing_marker_title}"'")) | .number' 2>/dev/null || true
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -15,7 +15,7 @@
 #      via the stubbed `gh` invocation (label & title format asserted).
 #   5. scan with a stale dashboard AND a pre-existing open alert → files
 #      NO second alert (dedup via <!-- aidevops:dashboard-freshness:*:* -->
-#      marker match).
+#      generated-title match scoped to the dashboard issue suffix).
 #   6. scan with a fresh dashboard → files no alert.
 #   7. cadence gate: a second scan within the interval is short-circuited
 #      without calling `gh`.
@@ -202,10 +202,11 @@ run_scan_with_stubs() {
 			# for the three paths the scanner exercises:
 			#   gh auth status       → success
 			#   gh api repos/.../issues/N  → dashboard body (read from fixture)
-			#   gh issue list --search ... → alert dedup/recovery check
+			#   gh issue list --json number,title ... → alert dedup/recovery check
 			#   gh issue create ...  → URL + 0
 			gh() {
 				printf "%s\n" "$*" >> "$GH_CALLS_LOG"
+				local gh_args="$*"
 				case "$1" in
 					auth)
 						return 0
@@ -218,7 +219,12 @@ run_scan_with_stubs() {
 					issue)
 						case "$2" in
 							list)
-								if [[ "$ALERT_EXISTS" == "1" ]]; then
+								if [[ "$gh_args" == *" --label "* ]] \
+									|| [[ "$gh_args" == *" --search "* ]] \
+									|| [[ "$gh_args" != *"--json number,title"* ]] \
+									|| [[ "$gh_args" != *"endswith(\"(#424242)\")"* ]]; then
+									printf "\n"
+								elif [[ "$ALERT_EXISTS" == "1" ]]; then
 									printf "99\n"
 								else
 									printf "\n"
@@ -288,6 +294,17 @@ if (( created_count == 0 )); then
 else
 	fail "dedup violated: created $created_count alerts" \
 		"calls:\n$(cat "$calls_file")"
+fi
+
+if grep -q '^issue list ' "$calls_file" \
+	&& ! grep -q -- '--label' "$calls_file" \
+	&& ! grep -q -- '--search' "$calls_file" \
+	&& grep -q -- '--json number,title' "$calls_file" \
+	&& grep -q 'endswith("(#424242)")' "$calls_file"; then
+	pass "dedup lookup filters open titles locally by dashboard suffix"
+else
+	fail "dedup lookup query shape" \
+		"expected title query without --label/--search; calls:\n$(cat "$calls_file")"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix dashboard-freshness alert lookup to query open issue titles locally, scoped by dashboard issue suffix, so generated stale/missing-marker alerts are found without fragile body search or label prefilters.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh,.agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dashboard-freshness-check.sh (11 passed); shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh; .agents/scripts/linters-local.sh (passed with pre-existing advisory markdown/complexity warnings).

Resolves #22938


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.64 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 20m and 59,577 tokens on this with the user in an interactive session.