### PR TITLE
fix: let clean-room issues bypass zero-output hold

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -423,6 +423,11 @@ _dlw_hold_repeated_zero_output() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
+	if _dlw_comment_bloat_requires_clean_room "$issue_number" "$repo_slug"; then
+		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: bypassing zero-output hold because clean-room brief mode is available" >>"$LOGFILE"
+		return 1
+	fi
+
 	local zero_count=""
 	zero_count=$(_dlw_zero_output_evidence_count "$issue_number" "$repo_slug")
 	[[ "$zero_count" =~ ^[0-9]+$ ]] || zero_count=0

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -116,6 +116,22 @@ GH_ISSUE_BODY=""
 : >"${TMP}/gh-calls.log"
 write_state 4
 GH_COMMENT_ZERO_COUNT=0
+GH_COMMENT_METRICS=$'275\t260\t87\t81500'
+_dlw_hold_repeated_zero_output 123 owner/repo
+clean_room_hold_rc=$?
+clean_room_hold_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
+if [[ "$clean_room_hold_rc" -eq 1 ]] \
+	&& ! printf '%s' "$clean_room_hold_calls" | grep -q 'needs-brief-rewrite'; then
+	pass "comment-bloated issues bypass repeated zero-output hold"
+else
+	fail "comment-bloated issues bypass repeated zero-output hold" \
+		"rc=${clean_room_hold_rc}; gh_calls=${clean_room_hold_calls}"
+fi
+GH_COMMENT_METRICS=""
+
+: >"${TMP}/gh-calls.log"
+write_state 4
+GH_COMMENT_ZERO_COUNT=0
 _dlw_hold_repeated_zero_output 123 owner/repo
 hold_rc=$?
 gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Allow comment-bloated issues to bypass the repeated zero-output brief-rewrite hold when clean-room prompt mode can recover them.
- Add regression coverage proving bloated issues are not relabelled/held while non-bloated repeated zero-output issues still hold.

## Verification
- `.agents/scripts/tests/test-zero-output-url-fallback.sh`
- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-zero-output-url-fallback.sh`
- `.agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-dispatch-worker-launch.sh`
- Private validation: a comment-bloated issue with 275 comments, 273 ops comments, 88 zero-output comments, and 81,500 comment characters returned `hold_rc=1` and logged clean-room hold bypass.

Resolves #22952
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.68 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 8h 17m and 4,951,656 tokens on this with the user in an interactive session.