### PR TITLE
GH#22952: let clean-room issues bypass zero-output hold

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -423,6 +423,11 @@ _dlw_hold_repeated_zero_output() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
+	if _dlw_comment_bloat_requires_clean_room "$issue_number" "$repo_slug"; then
+		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: bypassing repeated zero-output brief-rewrite hold for clean-room brief mode" >>"$LOGFILE"
+		return 1
+	fi
+
 	local zero_count=""
 	zero_count=$(_dlw_zero_output_evidence_count "$issue_number" "$repo_slug")
 	[[ "$zero_count" =~ ^[0-9]+$ ]] || zero_count=0

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -116,6 +116,7 @@ GH_ISSUE_BODY=""
 : >"${TMP}/gh-calls.log"
 write_state 4
 GH_COMMENT_ZERO_COUNT=0
+GH_COMMENT_METRICS=""
 _dlw_hold_repeated_zero_output 123 owner/repo
 hold_rc=$?
 gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
@@ -131,6 +132,7 @@ fi
 : >"${TMP}/gh-calls.log"
 write_state 1
 GH_COMMENT_ZERO_COUNT=4
+GH_COMMENT_METRICS=""
 _dlw_hold_repeated_zero_output 123 owner/repo
 comment_hold_rc=$?
 comment_gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
@@ -142,8 +144,24 @@ else
 		"rc=${comment_hold_rc}; gh_calls=${comment_gh_calls}"
 fi
 
+: >"${TMP}/gh-calls.log"
+write_state 4
+GH_COMMENT_ZERO_COUNT=4
+GH_COMMENT_METRICS=$'275\t260\t87\t81500'
+_dlw_hold_repeated_zero_output 123 owner/repo
+clean_room_hold_rc=$?
+clean_room_gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
+if [[ "$clean_room_hold_rc" -eq 1 ]] \
+	&& ! printf '%s' "$clean_room_gh_calls" | grep -q 'needs-brief-rewrite'; then
+	pass "comment-bloated issues bypass repeated zero-output hold"
+else
+	fail "comment-bloated issues bypass repeated zero-output hold" \
+		"rc=${clean_room_hold_rc}; gh_calls=${clean_room_gh_calls}"
+fi
+
 write_state 4 runtime partial
 GH_COMMENT_ZERO_COUNT=0
+GH_COMMENT_METRICS=""
 non_zero_count=$(_dlw_zero_output_failure_count 123 owner/repo)
 if [[ "$non_zero_count" == "0" ]]; then
 	pass "non-zero-output failure reasons do not trigger URL-only fallback"


### PR DESCRIPTION
## Summary

Bypassed repeated zero-output brief-rewrite holds when comment-bloat metrics already require clean-room prompt mode, and added a regression covering the non-held path.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-zero-output-url-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-zero-output-url-fallback.sh; shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-zero-output-url-fallback.sh; bash .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-zero-output-url-fallback.sh

Resolves #22952


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.68 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 1m and 36,398 tokens on this as a headless worker.