### PR TITLE
docs: remove duplicate 3.14.70 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - qualify Anthropic OAuth requests for plan usage (#22956)
 
-## [3.14.70] - 2026-05-05
-
-### Fixed
-
-- qualify Anthropic OAuth requests for plan usage (#22956)
-
 ## [3.14.69] - 2026-05-05
 
 ### Changed


### PR DESCRIPTION
## Summary
- Remove the duplicate 3.14.70 changelog section flagged after the release PR merged.

## Verification
- `.agents/scripts/version-manager.sh validate`

Ref #22777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.69 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 3h 53m and 768,561 tokens on this with the user in an interactive session.
