### PR TITLE
GH#22948: fix: block dispatch against pull request targets

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -128,6 +128,35 @@ _dsi_load_issue_meta() {
 }
 
 #######################################
+# Determine whether the target number is a pull request, not a plain Issue.
+#
+# Manual dispatch can be pointed at an arbitrary number, and `gh issue view`
+# accepts PR numbers through the issue facade. Use the REST issue object's
+# `pull_request` marker as a trust-boundary guard before any ceremony writes.
+#
+# Args:
+#   $1 - issue number
+#   $2 - owner/repo slug
+# Returns:
+#   0 target is a PR, 1 target is a plain Issue, 2 unable to verify
+#######################################
+_dsi_target_is_pull_request() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local target_json="" has_pull_request=""
+
+	target_json=$(gh api "repos/${repo_slug}/issues/${issue_number}" 2>/dev/null) || return 2
+	has_pull_request=$(printf '%s' "$target_json" | jq -r 'has("pull_request")' 2>/dev/null) || return 2
+	if [[ "$has_pull_request" == "true" ]]; then
+		return 0
+	fi
+	if [[ "$has_pull_request" == "false" ]]; then
+		return 1
+	fi
+	return 2
+}
+
+#######################################
 # Check parent-task gate. parent-task is always a hard block (never single-dispatch).
 # Args: $1 - labels CSV (from _dsi_load_issue_meta)
 # Returns: 0 not parent-task, 1 IS parent-task (block)
@@ -856,6 +885,16 @@ cmd_dispatch() {
 
 	# Step 1-2: validate + load + parent-task gate
 	_dsi_load_issue_meta "$issue_number" "$repo_slug" || return 1
+	local target_pr_rc=0
+	_dsi_target_is_pull_request "$issue_number" "$repo_slug" || target_pr_rc=$?
+	if [[ "$target_pr_rc" -eq 0 ]]; then
+		_dsi_err "Target #${issue_number} in ${repo_slug} is a pull request, not a dispatchable issue (GH#22948)"
+		return 1
+	fi
+	if [[ "$target_pr_rc" -ne 1 ]]; then
+		_dsi_err "Unable to verify #${issue_number} in ${repo_slug} is not a pull request; refusing dispatch (GH#22948, rc=${target_pr_rc})"
+		return 1
+	fi
 	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
 
 	# Step 3: dedup check (informational under --dry-run, blocking otherwise).

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -798,6 +798,39 @@ _has_committed_to_main_cache_label() {
 }
 
 #######################################
+# Determine whether a GitHub issue-number target is actually a pull request.
+#
+# `gh issue view` intentionally presents PRs through the issue facade, so the
+# dispatch preflight must use the REST issue object and inspect the
+# `pull_request` marker before any label/assignee writes. This is a hard
+# trust-boundary guard: dispatching a worker against a PR number would mutate an
+# interactive review object and can open a competing implementation PR.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug
+# Returns:
+#   0 - target is a PR
+#   1 - target is a plain Issue
+#   2 - unable to verify safely
+#######################################
+_dispatch_target_is_pull_request() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local target_json="" has_pull_request=""
+
+	target_json=$(gh api "repos/${repo_slug}/issues/${issue_number}" 2>/dev/null) || return 2
+	has_pull_request=$(printf '%s' "$target_json" | jq -r 'has("pull_request")' 2>/dev/null) || return 2
+	if [[ "$has_pull_request" == "true" ]]; then
+		return 0
+	fi
+	if [[ "$has_pull_request" == "false" ]]; then
+		return 1
+	fi
+	return 2
+}
+
+#######################################
 # t2955: Apply the `dispatch-blocked:committed-to-main` cache label.
 #
 # Called by `_check_commit_subject_dedup_gate` after the first scan
@@ -1336,6 +1369,21 @@ dispatch_with_dedup() {
 	_ds_record "$issue_number" "$repo_slug" "gh_issue_view" "$_ds_t0"
 	if [[ -z "$issue_meta_json" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to load issue metadata" >>"$LOGFILE"
+		return 1
+	fi
+
+	# GH#22948: hard PR-target guard before any lifecycle mutation. A pull
+	# request shares the Issues API number space, but it is already an
+	# implementation under review; dispatching a worker against it can relabel
+	# origin:interactive to origin:worker and open a competing PR.
+	local _target_pr_rc=0
+	_dispatch_target_is_pull_request "$issue_number" "$repo_slug" || _target_pr_rc=$?
+	if [[ "$_target_pr_rc" -eq 0 ]]; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: target is a pull request, not a dispatchable issue (GH#22948)" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$_target_pr_rc" -ne 1 ]]; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to verify target is not a pull request (GH#22948, rc=${_target_pr_rc})" >>"$LOGFILE"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -32,6 +32,7 @@ SET_ISSUE_STATUS_LOG=""
 SET_ORIGIN_LABEL_LOG=""
 MOCK_GH_ISSUE_STATE="OPEN"
 MOCK_GH_FAIL="0"
+MOCK_GH_TARGET_IS_PR="0"
 MOCK_PS_LINES=""
 MOCK_LEDGER_RECORD=""
 
@@ -109,13 +110,24 @@ _install_mock_set_origin_label() {
 
 # shellcheck disable=SC2317
 gh() {
+	local gh_subcommand="${1:-}"
+	local gh_resource="${2:-}"
 	if [[ "$MOCK_GH_FAIL" == "1" ]]; then
 		return 1
 	fi
 
-	if [[ "$1" == "issue" && "$2" == "view" ]]; then
+	if [[ "$gh_subcommand" == "issue" && "$gh_resource" == "view" ]]; then
 		printf '{"number":%s,"title":"Mock issue","state":"%s","labels":[],"assignees":[],"url":"https://example.invalid/issues/%s"}\n' \
 			"$3" "$MOCK_GH_ISSUE_STATE" "$3"
+		return 0
+	fi
+
+	if [[ "$gh_subcommand" == "api" && "$gh_resource" == repos/*/issues/* ]]; then
+		case "$MOCK_GH_TARGET_IS_PR" in
+		1) printf '{"number":123,"pull_request":{"url":"https://api.example.invalid/pulls/123"}}\n' ;;
+		api_fail) return 1 ;;
+		*) printf '{"number":123}\n' ;;
+		esac
 		return 0
 	fi
 
@@ -478,6 +490,48 @@ test_load_issue_meta_blocks_lowercase_closed() {
 	return 0
 }
 
+test_pr_target_guard_detects_pull_request() {
+	MOCK_GH_FAIL="0"
+	MOCK_GH_TARGET_IS_PR="1"
+
+	local rc=0
+	_dsi_target_is_pull_request 123 owner/repo >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 0 ]] && check=0
+	print_result "PR target guard detects pull_request marker" "$check" \
+		"expected rc=0 for PR-shaped issue, got rc=$rc"
+	return 0
+}
+
+test_pr_target_guard_allows_plain_issue() {
+	MOCK_GH_FAIL="0"
+	MOCK_GH_TARGET_IS_PR="0"
+
+	local rc=0
+	_dsi_target_is_pull_request 123 owner/repo >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 ]] && check=0
+	print_result "PR target guard allows plain issue" "$check" \
+		"expected rc=1 for plain issue, got rc=$rc"
+	return 0
+}
+
+test_pr_target_guard_fails_closed_on_api_error() {
+	MOCK_GH_FAIL="0"
+	MOCK_GH_TARGET_IS_PR="api_fail"
+
+	local rc=0
+	_dsi_target_is_pull_request 123 owner/repo >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 2 ]] && check=0
+	print_result "PR target guard reports verification errors" "$check" \
+		"expected rc=2 for API failure, got rc=$rc"
+	return 0
+}
+
 test_launch_worker_forwards_agent() {
 	local failed=1
 	if grep -Fq "cmd+=(--agent \"\$agent_name\")" "$HELPER_PATH"; then
@@ -587,6 +641,9 @@ _run_tests() {
 	test_no_ceremony_flag_parses_correctly
 	test_load_issue_meta_accepts_lowercase_open
 	test_load_issue_meta_blocks_lowercase_closed
+	test_pr_target_guard_detects_pull_request
+	test_pr_target_guard_allows_plain_issue
+	test_pr_target_guard_fails_closed_on_api_error
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-target-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-target-guard.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for the GH#22948 pulse dispatch guard that refuses to dispatch workers
+# against pull requests in the shared Issues API number space.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+MOCK_GH_TARGET_IS_PR="0"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helper_under_test() {
+	local helper_src=""
+	helper_src=$(awk '
+		/^_dispatch_target_is_pull_request\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _dispatch_target_is_pull_request from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+# shellcheck disable=SC2317
+gh() {
+	local gh_subcommand="${1:-}"
+	local gh_resource="${2:-}"
+	if [[ "$gh_subcommand" == "api" && "$gh_resource" == repos/*/issues/* ]]; then
+		case "$MOCK_GH_TARGET_IS_PR" in
+		1) printf '{"number":456,"pull_request":{"url":"https://api.example.invalid/pulls/456"}}\n' ;;
+		api_fail) return 1 ;;
+		*) printf '{"number":456}\n' ;;
+		esac
+		return 0
+	fi
+	printf 'unexpected gh call: %s\n' "$*" >&2
+	return 1
+}
+
+test_detects_pull_request_target() {
+	MOCK_GH_TARGET_IS_PR="1"
+	local rc=0
+	_dispatch_target_is_pull_request 456 owner/repo >/dev/null 2>&1 || rc=$?
+	local check=1
+	[[ "$rc" -eq 0 ]] && check=0
+	print_result "pulse guard detects pull_request marker" "$check" "rc=$rc"
+	return 0
+}
+
+test_allows_plain_issue_target() {
+	MOCK_GH_TARGET_IS_PR="0"
+	local rc=0
+	_dispatch_target_is_pull_request 456 owner/repo >/dev/null 2>&1 || rc=$?
+	local check=1
+	[[ "$rc" -eq 1 ]] && check=0
+	print_result "pulse guard allows plain issue target" "$check" "rc=$rc"
+	return 0
+}
+
+test_fails_closed_when_verification_errors() {
+	MOCK_GH_TARGET_IS_PR="api_fail"
+	local rc=0
+	_dispatch_target_is_pull_request 456 owner/repo >/dev/null 2>&1 || rc=$?
+	local check=1
+	[[ "$rc" -eq 2 ]] && check=0
+	print_result "pulse guard reports verification error" "$check" "rc=$rc"
+	return 0
+}
+
+test_dispatch_path_calls_guard_before_launch() {
+	local call_line launch_line check=1
+	call_line=$(grep -n '_dispatch_target_is_pull_request' "$CORE_SCRIPT" | tail -n 1 | cut -d: -f1)
+	launch_line=$(grep -n '_dispatch_launch_worker' "$CORE_SCRIPT" | tail -n 1 | cut -d: -f1)
+	if [[ "$call_line" =~ ^[0-9]+$ && "$launch_line" =~ ^[0-9]+$ && "$call_line" -lt "$launch_line" ]]; then
+		check=0
+	fi
+	print_result "dispatch path checks PR guard before worker launch" "$check" \
+		"call_line=${call_line:-missing} launch_line=${launch_line:-missing}"
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_detects_pull_request_target
+	test_allows_plain_issue_target
+	test_fails_closed_when_verification_errors
+	test_dispatch_path_calls_guard_before_launch
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added REST pull_request marker guards before pulse/manual dispatch lifecycle writes so PR numbers cannot be relabelled, assigned, or used to spawn competing worker PRs.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-dispatch-single-issue-helper.sh,.agents/scripts/tests/test-pulse-dispatch-core-pr-target-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh; bash .agents/scripts/tests/test-pulse-dispatch-core-pr-target-guard.sh; shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-target-guard.sh

Resolves #22948


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.69 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 7m and 119,200 tokens on this as a headless worker.