### PR TITLE
GH#22948 follow-up: block interactive hold dispatch

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -157,6 +157,21 @@ _dsi_target_is_pull_request() {
 }
 
 #######################################
+# Block manual dispatch when interactive/review hold labels are present.
+# Args: $1 - labels CSV
+# Returns: 0 when safe, 1 when held
+#######################################
+_dsi_guard_no_interactive_hold() {
+	local labels_csv="$1"
+	local labels_with_commas=",${labels_csv},"
+	if [[ "$labels_with_commas" == *",status:in-review,"* || "$labels_with_commas" == *",origin:interactive,"* ]]; then
+		_dsi_err "Target carries an interactive review hold label; refusing worker dispatch (GH#22948)"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Check parent-task gate. parent-task is always a hard block (never single-dispatch).
 # Args: $1 - labels CSV (from _dsi_load_issue_meta)
 # Returns: 0 not parent-task, 1 IS parent-task (block)
@@ -895,6 +910,7 @@ cmd_dispatch() {
 		_dsi_err "Unable to verify #${issue_number} in ${repo_slug} is not a pull request; refusing dispatch (GH#22948, rc=${target_pr_rc})"
 		return 1
 	fi
+	_dsi_guard_no_interactive_hold "$_DSI_ISSUE_LABELS" || return 1
 	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
 
 	# Step 3: dedup check (informational under --dry-run, blocking otherwise).

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -27,6 +27,8 @@
 #   - _has_force_dispatch_label
 #   - _is_bot_generated_cleanup_issue
 #   - _is_task_committed_to_main
+#   - _dispatch_target_is_pull_request
+#   - _dispatch_has_interactive_hold
 #   - _dispatch_dedup_check_layers  (t1999: extracted from dispatch_with_dedup)
 #   - dispatch_with_dedup           (t1999: thin orchestrator, <80 lines)
 #   - _ensure_issue_body_has_brief
@@ -949,6 +951,27 @@ _is_task_committed_to_main() {
 }
 
 #######################################
+# Detect labels that mean a human/review workflow owns the target.
+#
+# status:in-review is the interactive hold label applied by full-loop and
+# interactive-session-helper. origin:interactive is equivalent protection for
+# PRs/issues created by a human session. These labels must block dispatch even
+# when the assignee is the same runner login, otherwise a maintainer's local
+# pulse can race their own interactive PR/worktree (GH#22948).
+#
+# Args:
+#   $1 - issue metadata JSON with .labels[].name
+# Returns: 0 when an interactive hold label is present, 1 otherwise
+#######################################
+_dispatch_has_interactive_hold() {
+	local issue_meta_json="$1"
+	[[ -n "$issue_meta_json" ]] || return 1
+	printf '%s' "$issue_meta_json" |
+		jq -e '.labels | map(.name) | (index("status:in-review") or index("origin:interactive"))' >/dev/null 2>&1
+	return $?
+}
+
+#######################################
 # Pre-dispatch validation + dedup check layers for dispatch_with_dedup.
 # Extracted from dispatch_with_dedup (t1999, Phase 12) to reduce the
 # parent function to a thin orchestrator.
@@ -999,6 +1022,17 @@ _dispatch_dedup_check_layers() {
 	# GraphQL is exhausted, silently blocking all dispatch for 30+ min.
 	target_state=$(printf '%s' "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null | tr '[:lower:]' '[:upper:]')
 	target_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
+
+	# GH#22948: interactive/review hold guard independent of assignee identity.
+	# The Layer 6 assignment guard intentionally lets self-assignment through;
+	# status:in-review/origin:interactive must still prevent worker dispatch.
+	_dss_t0=$(_ds_now_ns)
+	if _dispatch_has_interactive_hold "$issue_meta_json"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: interactive review hold label present (GH#22948)" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.interactive_hold" "$_dss_t0"
+		return 1
+	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.interactive_hold" "$_dss_t0"
 
 	# GH#18987: Disk-space pre-check — refuse dispatch if /home filesystem
 	# has less than 5 GB available. Prevents cascading failures where workers
@@ -1127,7 +1161,7 @@ _dispatch_dedup_check_layers() {
 	# t2996: pass meta_json through so the gate skips its `gh issue view --json
 	# labels` AND `--json title` calls (both derived from the bundled JSON).
 	_dss_t0=$(_ds_now_ns)
-	if _issue_targets_large_files "$issue_number" "$repo_slug" "$_dispatch_issue_body" "$repo_path" "false" "$issue_meta_json"; then
+	if _issue_targets_large_files "$issue_number" "$repo_slug" "$_dispatch_issue_body" "$repo_path" "" "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch deferred for #${issue_number} in ${repo_slug}: targets large file(s), simplification gate" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.large_file" "$_dss_t0"
 		return 1
@@ -1763,14 +1797,14 @@ _apply_terminal_blocker() {
 	existing_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || existing_labels=""
 
-	local already_blocked=false
+	local already_blocked=0
 	if [[ ",${existing_labels}," == *",status:blocked,"* ]]; then
-		already_blocked=true
+		already_blocked=1
 	fi
 
 	# Add label if not already present (t2033: use set_issue_status to atomically
 	# clear all sibling status:* labels, not just available/queued)
-	if [[ "$already_blocked" == "false" ]]; then
+	if [[ "$already_blocked" -eq 0 ]]; then
 		set_issue_status "$issue_number" "$repo_slug" "blocked" || true
 	fi
 

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -122,6 +122,11 @@ gh() {
 		return 0
 	fi
 
+	if [[ "$gh_subcommand" == "api" && "$gh_resource" == "user" ]]; then
+		printf '%s\n' 'runner-self'
+		return 0
+	fi
+
 	if [[ "$gh_subcommand" == "api" && "$gh_resource" == repos/*/issues/* ]]; then
 		case "$MOCK_GH_TARGET_IS_PR" in
 		1) printf '{"number":123,"pull_request":{"url":"https://api.example.invalid/pulls/123"}}\n' ;;
@@ -532,6 +537,26 @@ test_pr_target_guard_fails_closed_on_api_error() {
 	return 0
 }
 
+test_interactive_hold_guard_blocks_review_label() {
+	local rc=0
+	_dsi_guard_no_interactive_hold "bug,status:in-review,auto-dispatch" >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 ]] && check=0
+	print_result "interactive hold guard blocks status:in-review" "$check" "rc=$rc"
+	return 0
+}
+
+test_interactive_hold_guard_blocks_origin_interactive() {
+	local rc=0
+	_dsi_guard_no_interactive_hold "bug,origin:interactive,auto-dispatch" >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 ]] && check=0
+	print_result "interactive hold guard blocks origin:interactive" "$check" "rc=$rc"
+	return 0
+}
+
 test_launch_worker_forwards_agent() {
 	local failed=1
 	if grep -Fq "cmd+=(--agent \"\$agent_name\")" "$HELPER_PATH"; then
@@ -644,6 +669,8 @@ _run_tests() {
 	test_pr_target_guard_detects_pull_request
 	test_pr_target_guard_allows_plain_issue
 	test_pr_target_guard_fails_closed_on_api_error
+	test_interactive_hold_guard_blocks_review_label
+	test_interactive_hold_guard_blocks_origin_interactive
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for GH#22948 dispatch guards: PR objects and interactive/review hold
+# labels must block worker dispatch before label/assignee mutation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+MOCK_GH_TARGET_IS_PR="0"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helpers_under_test() {
+	local helper_src
+	helper_src=$(python3 - "$CORE_SCRIPT" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+for name in ("_dispatch_target_is_pull_request", "_dispatch_has_interactive_hold"):
+    start = text.index(f"{name}() {{")
+    depth = 0
+    end = None
+    for offset, char in enumerate(text[start:]):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                end = start + offset + 1
+                break
+    if end is None:
+        raise SystemExit(f"could not extract {name}")
+    print(text[start:end])
+PY
+	)
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract dispatch guard helpers from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+# shellcheck disable=SC2317
+gh() {
+	if [[ "${1:-}" == "api" && "${2:-}" == repos/*/issues/* ]]; then
+		case "$MOCK_GH_TARGET_IS_PR" in
+		1) printf '{"number":1108,"pull_request":{"url":"https://api.github.invalid/pulls/1108"}}\n' ;;
+		api_fail) return 1 ;;
+		*) printf '{"number":22948}\n' ;;
+		esac
+		return 0
+	fi
+	printf 'unexpected gh call: %s\n' "$*" >&2
+	return 1
+}
+
+test_pr_guard_uses_rest_issue_object() {
+	MOCK_GH_TARGET_IS_PR="1"
+	if _dispatch_target_is_pull_request 1108 owner/repo; then
+		print_result "PR guard blocks REST pull_request objects" 0
+		return 0
+	fi
+	print_result "PR guard blocks REST pull_request objects" 1 "expected PR detection from gh api"
+	return 0
+}
+
+test_pr_guard_allows_plain_issue() {
+	MOCK_GH_TARGET_IS_PR="0"
+	if _dispatch_target_is_pull_request 22948 owner/repo; then
+		print_result "PR guard allows plain issue objects" 1 "plain issue was classified as PR"
+		return 0
+	fi
+	print_result "PR guard allows plain issue objects" 0
+	return 0
+}
+
+test_interactive_hold_blocks_in_review() {
+	local meta='{"labels":[{"name":"auto-dispatch"},{"name":"status:in-review"}]}'
+	if _dispatch_has_interactive_hold "$meta"; then
+		print_result "interactive hold blocks status:in-review" 0
+		return 0
+	fi
+	print_result "interactive hold blocks status:in-review" 1 "expected status:in-review to block"
+	return 0
+}
+
+test_interactive_hold_blocks_origin_interactive() {
+	local meta='{"labels":[{"name":"origin:interactive"},{"name":"bug"}]}'
+	if _dispatch_has_interactive_hold "$meta"; then
+		print_result "interactive hold blocks origin:interactive" 0
+		return 0
+	fi
+	print_result "interactive hold blocks origin:interactive" 1 "expected origin:interactive to block"
+	return 0
+}
+
+test_interactive_hold_allows_worker_issue() {
+	local meta='{"labels":[{"name":"auto-dispatch"},{"name":"origin:worker"}]}'
+	if _dispatch_has_interactive_hold "$meta"; then
+		print_result "interactive hold allows worker-labelled issue" 1 "origin:worker should not block this guard"
+		return 0
+	fi
+	print_result "interactive hold allows worker-labelled issue" 0
+	return 0
+}
+
+main() {
+	if ! define_helpers_under_test; then
+		return 1
+	fi
+
+	test_pr_guard_uses_rest_issue_object
+	test_pr_guard_allows_plain_issue
+	test_interactive_hold_blocks_in_review
+	test_interactive_hold_blocks_origin_interactive
+	test_interactive_hold_allows_worker_issue
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds an explicit status:in-review/origin:interactive dispatch hold so worker dispatch cannot proceed even when the runner is self-assigned.
- Extends manual dispatch tests and adds pulse guard coverage for the interactive hold path.

## Runtime Testing

- Risk level: Low (dispatch shell guards)
- Verified: `bash .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh`
- Verified: `bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- Verified: `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- Verified: `.agents/scripts/linters-local.sh`
- Known unrelated: `bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh` still has the two pre-existing dispatch-comment failures noted during review.

For #22948


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.71 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 55m and 372,195 tokens on this with the user in an interactive session.