### PR TITLE
fix: ignore local case alarm config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,13 @@
 # Templates use .json.txt extension and are safe to commit
 configs/*.json
 
+# Ignore local per-repo runtime config files
+# Templates use .json.txt extension and are safe to commit
+_config/*.json
+
 # Allow template files (.json.txt) to be committed for spacebar preview
 !configs/*.json.txt
+!_config/*.json.txt
 !configs/mcp-templates/
 
 # Allow agent directory to be committed

--- a/_config/case-alarms.json.txt
+++ b/_config/case-alarms.json.txt
@@ -1,0 +1,12 @@
+{
+  "_comment": "Case deadline alarm configuration. Copy to <repo>/_config/case-alarms.json to customise.",
+  "stages_days": [30, 7],
+  "channels": ["gh-issue", "ntfy"],
+  "ntfy_topic": "aidevops-case-alarms",
+  "per_case_overrides": {
+    "_example-case-id": {
+      "stages_days": [60, 14, 3],
+      "_comment": "Remove this example block and add real case-IDs if per-case thresholds are needed."
+    }
+  }
+}


### PR DESCRIPTION
For #20892

## Summary
- Ignore local `_config/*.json` runtime config files while allowing committed `.json.txt` templates.
- Add `_config/case-alarms.json.txt` so the case alarm config follows the existing safe-template convention.

## Verification
- `jq . _config/case-alarms.json.txt >/dev/null`
- `cmp -s _config/case-alarms.json.txt .agents/templates/case-alarms-config.json`
- `git check-ignore -v _config/case-alarms.json`
- `git check-ignore --no-index -v _config/case-alarms.json.txt`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.72 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 47m and 117,673 tokens on this with the user in an interactive session.