### PR TITLE
fix: allow auto-dispatch interactive handoff

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -157,14 +157,18 @@ _dsi_target_is_pull_request() {
 }
 
 #######################################
-# Block manual dispatch when interactive/review hold labels are present.
+# Block manual dispatch when live interactive/review hold labels are present.
 # Args: $1 - labels CSV
 # Returns: 0 when safe, 1 when held
 #######################################
 _dsi_guard_no_interactive_hold() {
 	local labels_csv="$1"
 	local labels_with_commas=",${labels_csv},"
-	if [[ "$labels_with_commas" == *",status:in-review,"* || "$labels_with_commas" == *",origin:interactive,"* ]]; then
+	if [[ "$labels_with_commas" == *",status:in-review,"* ]]; then
+		_dsi_err "Target carries an interactive review hold label; refusing worker dispatch (GH#22948)"
+		return 1
+	fi
+	if [[ "$labels_with_commas" == *",origin:interactive,"* && "$labels_with_commas" != *",auto-dispatch,"* ]]; then
 		_dsi_err "Target carries an interactive review hold label; refusing worker dispatch (GH#22948)"
 		return 1
 	fi

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -953,11 +953,11 @@ _is_task_committed_to_main() {
 #######################################
 # Detect labels that mean a human/review workflow owns the target.
 #
-# status:in-review is the interactive hold label applied by full-loop and
-# interactive-session-helper. origin:interactive is equivalent protection for
-# PRs/issues created by a human session. These labels must block dispatch even
-# when the assignee is the same runner login, otherwise a maintainer's local
-# pulse can race their own interactive PR/worktree (GH#22948).
+# status:in-review is the live interactive hold label applied by full-loop and
+# interactive-session-helper. origin:interactive is provenance: it blocks only
+# while the issue is not explicitly worker-dispatchable. auto-dispatch is the
+# handoff signal for issues left by an interactive session after the human has
+# moved on, so it must not strand work forever (GH#22964/GH#22965).
 #
 # Args:
 #   $1 - issue metadata JSON with .labels[].name
@@ -967,7 +967,7 @@ _dispatch_has_interactive_hold() {
 	local issue_meta_json="$1"
 	[[ -n "$issue_meta_json" ]] || return 1
 	printf '%s' "$issue_meta_json" |
-		jq -e '.labels | map(.name) | (index("status:in-review") or index("origin:interactive"))' >/dev/null 2>&1
+		jq -e '.labels | map(.name) | (index("status:in-review") or (index("origin:interactive") and (index("auto-dispatch") | not)))' >/dev/null 2>&1
 	return $?
 }
 
@@ -1023,9 +1023,10 @@ _dispatch_dedup_check_layers() {
 	target_state=$(printf '%s' "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null | tr '[:lower:]' '[:upper:]')
 	target_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
 
-	# GH#22948: interactive/review hold guard independent of assignee identity.
-	# The Layer 6 assignment guard intentionally lets self-assignment through;
-	# status:in-review/origin:interactive must still prevent worker dispatch.
+	# GH#22948/GH#22964: interactive/review hold guard independent of assignee
+	# identity. The Layer 6 assignment guard intentionally lets self-assignment
+	# through. status:in-review remains a live human lock; origin:interactive is
+	# provenance only when auto-dispatch explicitly hands the issue to workers.
 	_dss_t0=$(_ds_now_ns)
 	if _dispatch_has_interactive_hold "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: interactive review hold label present (GH#22948)" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -547,13 +547,23 @@ test_interactive_hold_guard_blocks_review_label() {
 	return 0
 }
 
-test_interactive_hold_guard_blocks_origin_interactive() {
+test_interactive_hold_guard_blocks_origin_interactive_without_handoff() {
+	local rc=0
+	_dsi_guard_no_interactive_hold "bug,origin:interactive" >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 ]] && check=0
+	print_result "interactive hold guard blocks origin:interactive without handoff" "$check" "rc=$rc"
+	return 0
+}
+
+test_interactive_hold_guard_allows_auto_dispatch_handoff() {
 	local rc=0
 	_dsi_guard_no_interactive_hold "bug,origin:interactive,auto-dispatch" >/dev/null 2>&1 || rc=$?
 
 	local check=1
-	[[ "$rc" -eq 1 ]] && check=0
-	print_result "interactive hold guard blocks origin:interactive" "$check" "rc=$rc"
+	[[ "$rc" -eq 0 ]] && check=0
+	print_result "interactive hold guard allows auto-dispatch handoff" "$check" "rc=$rc"
 	return 0
 }
 
@@ -670,7 +680,8 @@ _run_tests() {
 	test_pr_target_guard_allows_plain_issue
 	test_pr_target_guard_fails_closed_on_api_error
 	test_interactive_hold_guard_blocks_review_label
-	test_interactive_hold_guard_blocks_origin_interactive
+	test_interactive_hold_guard_blocks_origin_interactive_without_handoff
+	test_interactive_hold_guard_allows_auto_dispatch_handoff
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -125,6 +125,16 @@ test_interactive_hold_blocks_origin_interactive() {
 	return 0
 }
 
+test_interactive_hold_allows_auto_dispatch_handoff() {
+	local meta='{"labels":[{"name":"origin:interactive"},{"name":"auto-dispatch"},{"name":"bug"}]}'
+	if _dispatch_has_interactive_hold "$meta"; then
+		print_result "interactive hold allows auto-dispatch handoff" 1 "auto-dispatch should override provenance-only origin:interactive"
+		return 0
+	fi
+	print_result "interactive hold allows auto-dispatch handoff" 0
+	return 0
+}
+
 test_interactive_hold_allows_worker_issue() {
 	local meta='{"labels":[{"name":"auto-dispatch"},{"name":"origin:worker"}]}'
 	if _dispatch_has_interactive_hold "$meta"; then
@@ -144,6 +154,7 @@ main() {
 	test_pr_guard_allows_plain_issue
 	test_interactive_hold_blocks_in_review
 	test_interactive_hold_blocks_origin_interactive
+	test_interactive_hold_allows_auto_dispatch_handoff
 	test_interactive_hold_allows_worker_issue
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary
- Treat `origin:interactive` as provenance once `auto-dispatch` is present, so interactive-created tasks can be picked up after handoff.
- Keep `status:in-review` as the live human lock and preserve `origin:interactive` blocking when no auto-dispatch handoff exists.
- Add pulse/manual-dispatch regressions for `origin:interactive + auto-dispatch`.

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh`
- `.agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh`

For #22964
For #22965

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.72 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 7m and 171,204 tokens on this with the user in an interactive session.
