### PR TITLE
fix: let auto-dispatch clear interactive active claims

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -494,8 +494,8 @@ _get_repo_maintainer() {
 # is_assigned(). An issue is actively claimed when EITHER:
 #   - a lifecycle status label is set: status:queued, status:in-progress,
 #     status:in-review, or status:claimed, OR
-#   - the origin:interactive label is present (a live human session is
-#     driving the work regardless of status label state), OR
+#   - the origin:interactive label is present without auto-dispatch (a live
+#     human session is driving the work regardless of status label state), OR
 #   - the consolidation-in-progress label is present (t2151 — a cross-
 #     runner advisory lock held by a pulse runner that is mid-way through
 #     creating a consolidation-task child issue; treat as an active claim
@@ -524,7 +524,7 @@ _has_active_claim() {
 	local issue_meta_json="$1"
 	local result
 	result=$(printf '%s' "$issue_meta_json" | jq -r '
-		.labels? // [] | any(.[].name; . == "status:queued" or . == "status:in-progress" or . == "status:in-review" or . == "status:claimed" or . == "origin:interactive" or . == "consolidation-in-progress")
+		.labels? // [] | map(.name) | (any(.[]; . == "status:queued" or . == "status:in-progress" or . == "status:in-review" or . == "status:claimed" or . == "consolidation-in-progress") or ((index("origin:interactive") != null) and (index("auto-dispatch") == null)))
 	' 2>/dev/null) || result="false"
 	[[ "$result" == "true" || "$result" == "false" ]] || result="false"
 	printf '%s' "$result"
@@ -563,11 +563,14 @@ _has_active_claim() {
 #     (a) the issue has an active claim status label — status:queued,
 #         status:in-progress, status:in-review, or status:claimed
 #         (full active lifecycle, not just the worker-set states), OR
-#     (b) the issue has the origin:interactive label — a human session
-#         is actively driving the work regardless of status label state
+#     (b) the issue has the origin:interactive label without auto-dispatch —
+#         a human session is actively driving the work regardless of status
+#         label state
 #         (GH#18352 — closes the race where an interactive claim used
 #         status:claimed, which was not recognised as an active state,
 #         so the pulse dispatched a duplicate worker mid-flight)
+# - auto-dispatch is an explicit handoff signal: origin:interactive remains
+#   provenance but no longer bypasses owner/maintainer passive assignment.
 # - any other assignee blocks dispatch — UNLESS the assignment is stale
 #   (no active worker, dispatch claim >1h old, no recent progress).
 #   Stale assignments are auto-recovered (GH#15060).

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -474,6 +474,30 @@ test_maintainer_assigned_with_origin_interactive_blocks() {
 	return 0
 }
 
+test_owner_assigned_with_origin_interactive_auto_dispatch_allows() {
+	create_gh_stub "marcusquinn" "origin:interactive,auto-dispatch,bug"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "owner + origin:interactive + auto-dispatch allows handoff" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "owner + origin:interactive + auto-dispatch allows handoff" 0
+	return 0
+}
+
+test_maintainer_assigned_with_origin_interactive_auto_dispatch_allows() {
+	create_gh_stub "marcusquinn-bot" "origin:interactive,auto-dispatch,bug"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "maintainer + origin:interactive + auto-dispatch allows handoff" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "maintainer + origin:interactive + auto-dispatch allows handoff" 0
+	return 0
+}
+
 # Regression: the original owner-passive exemption must still work when
 # neither an active status label nor origin:interactive is present.
 # A bare owner-assignment from auto-triage workflows must not block dispatch
@@ -623,6 +647,8 @@ main() {
 	test_owner_assigned_with_status_in_review_blocks
 	test_owner_assigned_with_origin_interactive_blocks
 	test_maintainer_assigned_with_origin_interactive_blocks
+	test_owner_assigned_with_origin_interactive_auto_dispatch_allows
+	test_maintainer_assigned_with_origin_interactive_auto_dispatch_allows
 	test_owner_assigned_no_status_no_origin_allows_dispatch
 	test_override_ignore_preserves_self_assignee
 	test_peer_quarantine_preserves_self_assignee


### PR DESCRIPTION
## Summary
- Extend the auto-dispatch handoff semantics into the assignment dedup layer.
- Keep `origin:interactive` as an active claim when no handoff exists, but stop treating it as active when `auto-dispatch` is present.
- Add assignment-layer regressions for owner/maintainer assignees with `origin:interactive + auto-dispatch`.

## Verification
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh`
- `.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh` confirmed the new owner/maintainer auto-dispatch handoff assertions pass; existing dispatch-comment assertions in that file still report pre-existing unrelated failures.

For #22964
For #22965
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.73 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 34m and 400,991 tokens on this with the user in an interactive session.