### PR TITLE
fix: preserve origin provenance on dispatch

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -360,9 +360,7 @@ _dsi_repo_path_for_slug() {
 #
 #   1. Atomic transition to status:queued (clears sibling status:* labels
 #      via set_issue_status).
-#   2. Apply origin:worker via set_origin_label (t2200 / t3007 mutual
-#      exclusion — atomically strips ALL sibling origin:* labels and calls
-#      ensure_origin_labels_exist before adding origin:worker).
+#   2. Preserve origin:* labels as immutable creation provenance.
 #   3. Add runner as assignee; remove any prior assignees so dedup layer 6
 #      sees a clean single-owner state.
 #
@@ -406,23 +404,7 @@ _dsi_apply_dispatch_ceremony() {
 		return 1
 	fi
 
-	# t2200 / t3007: use set_origin_label to atomically strip ALL sibling
-	# origin:* labels (including any origin:interactive left from an interactive
-	# session) and ensure origin:worker exists before adding it. The former bare
-	# --add-label/--remove-label approach only removed known siblings and skipped
-	# ensure_origin_labels_exist, producing dual-label issues when re-dispatching
-	# an origin:interactive issue (observed: t3005 session, PRs #21451–#21455).
-	if ! set_origin_label "$issue_number" "$repo_slug" "worker" >/dev/null 2>&1; then
-		_dsi_warn "Origin label update failed after REST fallback — dispatch ceremony degraded"
-		if set_issue_status "$issue_number" "$repo_slug" "available" --remove-assignee "$self_login" >/dev/null 2>&1; then
-			_dsi_warn "Ceremony degraded — origin:worker not applied; status/assignment rollback attempted"
-		else
-			_dsi_warn "Ceremony degraded — origin:worker not applied; rollback also failed; manual recovery required"
-		fi
-		return 1
-	fi
-
-	_dsi_info "Ceremony applied — status:queued, origin:worker, assignee=${self_login}"
+	_dsi_info "Ceremony applied — status:queued, assignee=${self_login}"
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -114,12 +114,11 @@ _dlw_assign_and_label() {
 	local self_login="$3"
 	local issue_meta_json="$4"
 
-	# t2200: origin label mutual exclusion — add origin:worker and remove
-	# sibling origin labels atomically in the same gh issue edit call.
+	# Preserve origin:* labels as immutable creation provenance. Worker claim is
+	# represented by status:queued + assignee; origin:worker is only for issues
+	# created by workers, not issues currently being handled by workers.
 	local -a _extra_flags=(--add-assignee "$self_login"
-		--add-label "origin:worker"
-		--remove-label "origin:interactive"
-		--remove-label "origin:worker-takeover")
+	)
 	local _prev_login
 	while IFS= read -r _prev_login; do
 		[[ -n "$_prev_login" && "$_prev_login" != "$self_login" ]] && _extra_flags+=(--remove-assignee "$_prev_login")

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -8,7 +8,7 @@
 #
 # Background: the manual single-issue dispatch CLI was previously launching
 # workers without applying the pre-launch ceremony (status:queued +
-# origin:worker + assignee normalize) that the pulse always applies. This
+# assignee normalize) that the pulse always applies. This
 # created a race window where the next pulse cycle could see the issue in
 # its prior state and dispatch a duplicate worker on top of the running one.
 #
@@ -87,10 +87,9 @@ _install_mock_set_issue_status() {
 	return 0
 }
 
-# t3007: Override set_origin_label (also from shared-gh-wrappers.sh) with a
-# mock that logs every call to SET_ORIGIN_LABEL_LOG. The ceremony now calls
-# set_origin_label separately for origin label mutual exclusion instead of
-# embedding bare --add/--remove-label flags in the set_issue_status call.
+# Override set_origin_label (also from shared-gh-wrappers.sh) with a mock that
+# logs every call to SET_ORIGIN_LABEL_LOG. Dispatch ceremony should not call it:
+# origin:* labels are immutable creation provenance, not worker-claim state.
 MOCK_SET_ORIGIN_LABEL_MODE="success"
 
 # shellcheck disable=SC2317
@@ -188,9 +187,8 @@ test_ceremony_applies_default() {
 	local rc=0
 	_dsi_apply_dispatch_ceremony 12345 owner/repo runner-self "$issue_meta" >/dev/null 2>&1 || rc=$?
 
-	local status_logged origin_logged
+	local status_logged
 	status_logged=$(cat "$SET_ISSUE_STATUS_LOG")
-	origin_logged=$(cat "$SET_ORIGIN_LABEL_LOG")
 
 	# Assert ceremony returned success
 	if [[ "$rc" -ne 0 ]]; then
@@ -217,35 +215,28 @@ test_ceremony_applies_default() {
 	print_result "ceremony passes status:queued (not in-progress)" "$status_check" \
 		"expected 'set_issue_status 12345 owner/repo queued' in: $status_logged"
 
-	# t3007: Assert origin label flip is handled by set_origin_label (NOT bare
-	# flags in set_issue_status). set_origin_label atomically strips all sibling
-	# origin:* labels and calls ensure_origin_labels_exist before adding
-	# origin:worker — preventing dual-label state on re-dispatched interactive issues.
+	# Origin labels are creation provenance and must not be rewritten by worker
+	# claim ceremony.
 	local origin_call_count
 	origin_call_count=$(grep -c '^set_origin_label' "$SET_ORIGIN_LABEL_LOG" 2>/dev/null || true)
 	[[ "$origin_call_count" =~ ^[0-9]+$ ]] || origin_call_count=0
-	if [[ "$origin_call_count" -ne 1 ]]; then
-		print_result "ceremony emits exactly one set_origin_label call" 1 "got $origin_call_count calls"
+	if [[ "$origin_call_count" -ne 0 ]]; then
+		print_result "ceremony preserves origin provenance" 1 "got $origin_call_count set_origin_label calls"
 		return 0
 	fi
-	print_result "ceremony emits exactly one set_origin_label call" 0
-
-	local origin_worker=1
-	[[ "$origin_logged" == *"set_origin_label 12345 owner/repo worker"* ]] && origin_worker=0
-	print_result "ceremony calls set_origin_label with origin:worker" "$origin_worker" \
-		"expected 'set_origin_label 12345 owner/repo worker' in: $origin_logged"
+	print_result "ceremony preserves origin provenance" 0
 
 	# Assert origin:worker NOT embedded in set_issue_status flags (t3007 regression guard)
 	local no_bare_add=0 no_bare_rm_int=0 no_bare_rm_take=0
 	[[ "$status_logged" == *"--add-label origin:worker"* ]] && no_bare_add=1
 	[[ "$status_logged" == *"--remove-label origin:interactive"* ]] && no_bare_rm_int=1
 	[[ "$status_logged" == *"--remove-label origin:worker-takeover"* ]] && no_bare_rm_take=1
-	print_result "origin:worker not embedded in set_issue_status (t3007)" "$no_bare_add" \
-		"bare --add-label origin:worker found in set_issue_status call — should use set_origin_label"
+	print_result "origin:worker not embedded in set_issue_status" "$no_bare_add" \
+		"bare --add-label origin:worker found in set_issue_status call"
 	print_result "origin:interactive removal not in set_issue_status (t3007)" "$no_bare_rm_int" \
-		"bare --remove-label origin:interactive found — should use set_origin_label"
+		"bare --remove-label origin:interactive found"
 	print_result "origin:worker-takeover removal not in set_issue_status (t3007)" "$no_bare_rm_take" \
-		"bare --remove-label origin:worker-takeover found — should use set_origin_label"
+		"bare --remove-label origin:worker-takeover found"
 
 	# Assert assignee normalization still in set_issue_status
 	local add_assignee=1 rm_prior=1
@@ -353,49 +344,6 @@ test_ceremony_handles_set_issue_status_failure() {
 	local rc_check=1
 	[[ "$rc" -eq 1 ]] && rc_check=0
 	print_result "ceremony returns 1 when set_issue_status fails" "$rc_check"
-
-	return 0
-}
-
-# t3470: Verify that a failing set_origin_label is explicit degradation — the
-# ceremony must not claim origin:worker success, and it must attempt to roll
-# back status/assignment so the issue does not sit in a misleading queued state.
-test_ceremony_origin_label_failure_is_nonfatal() {
-	reset_test_state
-	_install_mock_set_issue_status success
-	_install_mock_set_origin_label failure
-
-	local issue_meta='{"assignees":[]}'
-	local rc=0 output=""
-	output=$(_dsi_apply_dispatch_ceremony 42 owner/repo runner-self "$issue_meta" 2>&1) || rc=$?
-
-	# Ceremony must return non-zero when origin:worker was not actually applied.
-	local rc_check=1
-	[[ "$rc" -eq 1 ]] && rc_check=0
-	print_result "ceremony returns 1 when set_origin_label fails (degraded)" "$rc_check" \
-		"expected rc=1, got rc=$rc"
-
-	# Verify set_origin_label was still called (the attempt was made).
-	local origin_call_count
-	origin_call_count=$(grep -c '^set_origin_label' "$SET_ORIGIN_LABEL_LOG" 2>/dev/null || true)
-	[[ "$origin_call_count" =~ ^[0-9]+$ ]] || origin_call_count=0
-	local attempted=1
-	[[ "$origin_call_count" -ge 1 ]] && attempted=0
-	print_result "set_origin_label was attempted despite subsequent failure" "$attempted"
-
-	local rollback_logged=1
-	if grep -q '^set_issue_status 42 owner/repo available --remove-assignee runner-self' "$SET_ISSUE_STATUS_LOG" 2>/dev/null; then
-		rollback_logged=0
-	fi
-	print_result "ceremony attempts status/assignee rollback on origin failure" "$rollback_logged"
-
-	local degraded_msg=1 no_applied_msg=0
-	[[ "$output" == *"Ceremony degraded"* ]] && degraded_msg=0
-	[[ "$output" == *"Ceremony applied"* ]] && no_applied_msg=1
-	print_result "ceremony reports degraded launch when origin update fails" "$degraded_msg" \
-		"output: $output"
-	print_result "ceremony does not claim origin:worker when origin update fails" "$no_applied_msg" \
-		"output: $output"
 
 	return 0
 }
@@ -672,7 +620,6 @@ _run_tests() {
 	test_ceremony_handles_empty_assignees
 	test_ceremony_handles_empty_self_login
 	test_ceremony_handles_set_issue_status_failure
-	test_ceremony_origin_label_failure_is_nonfatal
 	test_no_ceremony_flag_parses_correctly
 	test_load_issue_meta_accepts_lowercase_open
 	test_load_issue_meta_blocks_lowercase_closed


### PR DESCRIPTION
## Summary
- Preserve `origin:*` labels as immutable creation provenance during worker dispatch claims.
- Use `status:queued` plus assignee normalization for mutable worker claim state.
- Update manual dispatch regression tests so origin rewrites fail the focused suite.

## Verification
- `.agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh`

## Context
- Files changed: `.agents/scripts/dispatch-single-issue-helper.sh`, `.agents/scripts/pulse-dispatch-worker-launch.sh`, `.agents/scripts/tests/test-dispatch-single-issue-helper.sh`.
- Reference pattern: worker claim ceremony should mutate `status:*` and assignees only; `origin:*` remains source-of-creation provenance.


For #22964
For #22965
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.74 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 1h 5m and 704,228 tokens on this with the user in an interactive session.