### PR TITLE
GH#22964: close original issues for superseding PR merges

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -342,6 +342,36 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 	return 0
 }
 
+#######################################
+# Resolve the original issue behind a superseded PR reference.
+#
+# When PR B resolves PR A, GitHub treats PR A as an issue number. The normal
+# linked-issue extractor therefore returns PR A's number, not the issue that PR A
+# originally resolved. If PR A is actually a pull request, inspect PR A and return
+# its own linked issue so deterministic merge can close the original task too.
+#
+# Args: $1=merged_pr_number, $2=repo_slug, $3=candidate_issue_number
+# Stdout: original issue number, or empty when candidate is not a PR chain
+# Returns: 0 always
+#######################################
+_pm_resolve_superseded_original_issue() {
+	local merged_pr_number="$1" repo_slug="$2" candidate_issue="$3"
+	local original_issue
+
+	[[ -z "$candidate_issue" ]] && return 0
+	if ! gh api "repos/${repo_slug}/pulls/${candidate_issue}" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	original_issue=$(_extract_linked_issue "$candidate_issue" "$repo_slug" 2>/dev/null) || original_issue=""
+	if [[ -z "$original_issue" || "$original_issue" == "$candidate_issue" || "$original_issue" == "$merged_pr_number" ]]; then
+		return 0
+	fi
+
+	printf '%s' "$original_issue"
+	return 0
+}
+
 _handle_post_merge_actions() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -413,6 +443,44 @@ _handle_post_merge_actions() {
 			fast_fail_reset "$linked_issue" "$repo_slug" || true
 			# t1934: Unlock the issue (locked at dispatch time)
 			unlock_issue_after_worker "$linked_issue" "$repo_slug"
+		fi
+
+		# GH#22964: if the merged PR resolved a superseded worker PR, also close
+		# the original issue that the superseded PR was created to resolve.
+		local _superseded_original_issue
+		_superseded_original_issue=$(_pm_resolve_superseded_original_issue \
+			"$pr_number" "$repo_slug" "$linked_issue") || _superseded_original_issue=""
+		if [[ -n "$_superseded_original_issue" ]]; then
+			local _sup_api _sup_labels _sup_parent_guard=0 _sup_dedup_count
+			_sup_api=$(_pm_issue_api "$repo_slug" "$_superseded_original_issue")
+			_sup_labels=$(gh api "${_sup_api}" \
+				--jq '[.labels[].name] | join(",")' 2>/dev/null) || _sup_labels=""
+			if [[ ",${_sup_labels}," == *",parent-task,"* ]]; then
+				_sup_parent_guard=1
+				echo "[pulse-wrapper] Deterministic merge: skipping close of parent-task original issue #${_superseded_original_issue} via superseded PR #${linked_issue} (merged PR #${pr_number}) — GH#22964" >>"$LOGFILE"
+			fi
+
+			_sup_dedup_count=$(gh api "${_sup_api}/comments" \
+				2>/dev/null | jq --arg prnum "PR #${pr_number}" \
+				'[.[] | select(.body | contains($prnum))] | length' 2>/dev/null) || _sup_dedup_count=0
+			[[ "$_sup_dedup_count" =~ ^[0-9]+$ ]] || _sup_dedup_count=0
+			if [[ "$_sup_dedup_count" -gt 0 ]]; then
+				echo "[pulse-wrapper] Deterministic merge: skipped duplicate closing comment on original issue #${_superseded_original_issue} via superseded PR #${linked_issue} — PR #${pr_number} already referenced (GH#22964)" >>"$LOGFILE"
+			else
+				gh_issue_comment "$_superseded_original_issue" --repo "$repo_slug" \
+					--body "$closing_comment" 2>/dev/null || true
+			fi
+
+			if [[ "$_sup_parent_guard" -eq 0 ]]; then
+				local _sup_solved_actor="interactive"
+				case ",${pr_labels}," in
+				*,origin:worker,* | *,origin:worker-takeover,*) _sup_solved_actor="worker" ;;
+				esac
+				set_solved_label "$_superseded_original_issue" "$repo_slug" "$_sup_solved_actor" || true
+				gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null || true
+				fast_fail_reset "$_superseded_original_issue" "$repo_slug" || true
+				unlock_issue_after_worker "$_superseded_original_issue" "$repo_slug"
+			fi
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh
+++ b/.agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh
@@ -99,6 +99,11 @@ EOF
 	return 0
 }
 
+gh_pr_view() {
+	gh pr view "$@"
+	return 0
+}
+
 teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -71,7 +71,9 @@ define_function_under_test() {
 	fn_src=$(awk '
 		/^_pm_issue_api\(\) \{/,/^}$/ { print }
 		/^_pm_build_closing_comment\(\) \{/,/^}$/ { print }
+		/^_pm_resolve_superseded_original_issue\(\) \{/,/^}$/ { print }
 		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
+		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
 	' "$MERGE_FILE")
 	if [[ -z "$fn_src" ]]; then
 		printf 'ERROR: could not extract _handle_post_merge_actions from %s\n' "$MERGE_FILE" >&2
@@ -84,6 +86,13 @@ define_function_under_test() {
 install_helper_stubs() {
 	gh() {
 		printf '%s\n' "$*" >>"$GH_CALL_LOG"
+		if [[ "$1" == "api" && "$2" == "repos/marcusquinn/aidevops/pulls/33333" ]]; then
+			printf '{"number":33333}\n'
+			return 0
+		fi
+		if [[ "$1" == "api" && "$2" == "repos/marcusquinn/aidevops/pulls/"* ]]; then
+			return 1
+		fi
 		if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
 			printf '[]\n'
 		fi
@@ -100,6 +109,14 @@ install_helper_stubs() {
 	}
 	gh_pr_view() {
 		printf 'pr view %s\n' "$*" >>"$GH_CALL_LOG"
+		if [[ "$1" == "33333" && "$*" == *"--json body"* ]]; then
+			printf 'Resolves #22219\n'
+			return 0
+		fi
+		if [[ "$1" == "33333" && "$*" == *"--json title"* ]]; then
+			printf 'GH#22219: original worker PR\n'
+			return 0
+		fi
 		printf '%s\n' "${TEST_PR_LABELS:-}"
 		return 0
 	}
@@ -170,6 +187,22 @@ test_omitted_pr_labels_fetches_fallback() {
 	return 0
 }
 
+test_superseded_pr_closes_original_issue() {
+	: >"$GH_CALL_LOG"
+	: >"$SOLVED_LABEL_LOG"
+	export TEST_PR_LABELS="origin:worker"
+
+	_handle_post_merge_actions "44444" "marcusquinn/aidevops" "33333" "merged" "origin:worker"
+
+	assert_log_contains "$GH_CALL_LOG" "repos/marcusquinn/aidevops/pulls/33333" \
+		"superseded chain checks whether linked issue is a PR"
+	assert_log_contains "$GH_CALL_LOG" "issue close 22219" \
+		"superseded chain closes original issue"
+	assert_log_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops worker" \
+		"superseded chain marks original issue solved by worker"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -178,6 +211,7 @@ main() {
 
 	test_provided_empty_pr_labels_skip_refetch
 	test_omitted_pr_labels_fetches_fallback
+	test_superseded_pr_closes_original_issue
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Updated deterministic pulse merge post-merge handling so a merged superseding PR that resolves an intermediate worker PR also resolves and closes the original linked issue, with parent-task and duplicate-comment guards preserved.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh,.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh; bash .agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh .agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh; .agents/scripts/linters-local.sh timed out during later portability checks after targeted checks passed and advisory-only pre-existing markdown/ratchet warnings

Resolves #22964


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.74 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 6m and 59,296 tokens on this as a headless worker.