### PR TITLE
GH#22977: remove duplicate changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Maintenance: update simplification state registry
-- Documentation: remove duplicate 3.14.70 changelog entry (#22960)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Removed the repeated CHANGELOG.md entry for the duplicate 3.14.70 changelog fix so the release note appears once.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified CHANGELOG.md contains one 3.14.70 heading and one duplicate-fix entry with a targeted python3 check.

Resolves #22977


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 53,039 tokens on this as a headless worker.