### PR TITLE
GH#22979: fix: align pulse fast-fail header

### DIFF
--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -18,7 +18,7 @@
 #   - _ff_load
 #   - _ff_current_aidevops_version
 #   - _ff_version_gt
-#   - _ff_entry_is_from_older_release
+#   - _ff_release_retry_reset_if_newer
 #   - _ff_query_pool_retry_seconds
 #   - _ff_with_lock
 #   - _ff_save


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-fast-fail.sh header to list the implemented _ff_release_retry_reset_if_newer helper instead of the obsolete name.

## Files Changed

.agents/scripts/pulse-fast-fail.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-fast-fail.sh

Resolves #22979


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 29,033 tokens on this as a headless worker.