### PR TITLE
GH#22982: fix PR salvage recovery test mock

### DIFF
--- a/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
+++ b/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
@@ -73,7 +73,7 @@ JSON
 
 	if [[ "$area" == "issue" && "$command" == "list" ]]; then
 		local args=" $* "
-		if [[ "$args" == *'"PR #53" recover'* ]]; then
+		if [[ "$args" == *'"PR #53"'* ]]; then
 			cat <<'JSON'
 [
   {


### PR DESCRIPTION
## Summary

Updated the completed-recovery test mock so it matches the helper's quoted PR-number search query without depending on the trailing recovery term.

## Files Changed

.agents/scripts/tests/test-pr-salvage-completed-recovery.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh; shellcheck .agents/scripts/tests/test-pr-salvage-completed-recovery.sh

Resolves #22982


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 39,552 tokens on this as a headless worker.