### PR TITLE
GH#22981: fix: reduce PR salvage recovery issue lookups

### DIFF
--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -125,19 +125,41 @@ has_replacement_pr() {
 }
 
 #######################################
+# Fetch closed issues that may document completed PR recovery.
+#
+# Arguments:
+#   $1 - repo slug (owner/repo)
+# Output: JSON array of matching closed issues
+#######################################
+fetch_completed_recovery_issues() {
+	local slug="$1"
+	local issues
+	issues=$(gh issue list --repo "$slug" --state closed \
+		--search "recover OR recovery OR salvage OR restore OR cherry-pick OR cherrypick" \
+		--json number,title,body,state,closedAt --limit 100 2>/dev/null) || issues="[]"
+
+	echo "$issues"
+	return 0
+}
+
+#######################################
 # Check if a closed issue already completed recovery for a closed PR.
 # Arguments:
 #   $1 - repo slug (owner/repo)
 #   $2 - PR number
+#   $3 - optional pre-fetched closed recovery issues JSON array
 # Output: "true" or "false" to stdout
 #######################################
 has_completed_recovery_issue() {
 	local slug="$1"
 	local pr_number="$2"
+	local prefetched_issues="${3:-}"
 	local issues
-	issues=$(gh issue list --repo "$slug" --state closed \
-		--search "\"PR #${pr_number}\" recover" \
-		--json number,title,body,state,closedAt --limit 50 2>/dev/null) || issues="[]"
+	if [[ -n "$prefetched_issues" ]]; then
+		issues="$prefetched_issues"
+	else
+		issues=$(fetch_completed_recovery_issues "$slug")
+	fi
 
 	local match_count
 	match_count=$(echo "$issues" | jq --arg pr "PR #${pr_number}" '
@@ -271,15 +293,15 @@ scan_repo() {
 
 	# For each unmerged PR, check recoverability and build salvage entries
 	local salvageable="[]"
+	local completed_recovery_issues
+	completed_recovery_issues=$(fetch_completed_recovery_issues "$slug")
 	local pr_json
 	while IFS= read -r pr_json; do
 		local pr_number branch additions branch_exists risk entry
-		pr_number=$(echo "$pr_json" | jq -r '.number')
-		branch=$(echo "$pr_json" | jq -r '.headRefName')
-		additions=$(echo "$pr_json" | jq -r '.additions')
+		read -r pr_number branch additions < <(echo "$pr_json" | jq -r '[.number, .headRefName, .additions] | @tsv')
 
 		# Skip PRs whose salvage has already been completed and documented in a closed issue.
-		if [[ "$(has_completed_recovery_issue "$slug" "$pr_number")" == "true" ]]; then
+		if [[ "$(has_completed_recovery_issue "$slug" "$pr_number" "$completed_recovery_issues")" == "true" ]]; then
 			continue
 		fi
 

--- a/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
+++ b/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
@@ -73,7 +73,7 @@ JSON
 
 	if [[ "$area" == "issue" && "$command" == "list" ]]; then
 		local args=" $* "
-		if [[ "$args" == *'"PR #53" recover'* ]]; then
+		if [[ "$args" == *' recover OR recovery '* ]]; then
 			cat <<'JSON'
 [
   {

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -52,7 +52,7 @@ gh() {
 		fi
 		;;
 	issue)
-		if [[ " ${*} " == *"PR #53"* ]]; then
+		if [[ " ${*} " == *" recover OR recovery "* ]]; then
 			printf '%s\n' '[{"number":60,"title":"Recover buffalo logo favicon from closed PR #53","body":"Worker completion audit: completed recovery.","state":"CLOSED","labels":[{"name":"status:done"}]}]'
 			return 0
 		fi


### PR DESCRIPTION
## Summary

Prefetched closed recovery issues once per salvage scan and reused that JSON for each PR candidate while batching PR number, branch, and additions extraction through one jq call.

## Files Changed

.agents/scripts/pr-salvage-helper.sh,.agents/scripts/tests/test-pr-salvage-completed-recovery.sh,.agents/scripts/tests/test-pr-salvage-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-completed-recovery.sh; bash .agents/scripts/tests/test-pr-salvage-helper.sh && bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh

Resolves #22981


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 3m and 49,349 tokens on this as a headless worker.