### PR TITLE
GH#22982: fix PR salvage recovery test mock

### DIFF
--- a/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
+++ b/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
@@ -73,7 +73,7 @@ JSON
 
 	if [[ "$area" == "issue" && "$command" == "list" ]]; then
 		local args=" $* "
-		if [[ "$args" == *' recover OR recovery '* ]]; then
+		if [[ "$args" == *' recover OR recovery '* || "$args" == *'"PR #53"'* ]]; then
 			cat <<'JSON'
 [
   {


### PR DESCRIPTION
## Summary

- Updated the PR salvage completed-recovery test mock to recognise the quoted PR-number search form while preserving the current broader recovery prefetch query.

## Testing

- bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh

- shellcheck .agents/scripts/tests/test-pr-salvage-completed-recovery.sh

Resolves #22982

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 8m and 90,315 tokens on this as a headless worker.