### PR TITLE
fix: resolve worker worktree paths outside Git roots

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -677,8 +677,13 @@ _dlw_precreate_worktree() {
 	# to be inside the repo. The pulse-wrapper's cwd is typically / (launchd).
 	_wt_output=$(cd "$repo_path" && WORKTREE_NODE_MODULES_RESTORE_ENABLED=0 "$_wt_helper" add "$_branch" 2>&1) || true
 	_wt_output=$(printf '%s' "$_wt_output" | sed $'s/\x1b\\[[0-9;]*m//g')
-	local _path
-	_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _path=""
+	local _path _path_source="porcelain"
+	_path=$(_dlw_worktree_path_for_branch "$repo_path" "$_branch") || _path=""
+	if [[ -z "$_path" ]]; then
+		_path_source="helper-output"
+		_path=$(_dlw_extract_worktree_path_from_output "$_wt_output") || _path=""
+	fi
+	echo "[dispatch_with_dedup] Worktree path resolution for #${issue_number}: source=${_path_source} branch=${_branch} path='${_path:-<empty>}' exists=$([[ -n "$_path" && -d "$_path" ]] && printf '1' || printf '0')" >>"$LOGFILE"
 	if [[ -n "$_path" && -d "$_path" ]]; then
 		_DLW_WORKTREE_PATH="$_path"
 		_DLW_WORKTREE_BRANCH="$_branch"
@@ -695,6 +700,23 @@ _dlw_precreate_worktree() {
 		echo "[dispatch_with_dedup] Warning: worktree pre-creation failed for #${issue_number} — dispatch will be skipped this cycle (extracted: '${_path:-<empty>}', wt_helper stdout head: '${_wt_output:0:120}')" >>"$LOGFILE"
 		return 1
 	fi
+	return 0
+}
+
+_dlw_worktree_path_for_branch() {
+	local repo_path="$1"
+	local branch_name="$2"
+	local _path=""
+	_path=$(git -C "$repo_path" worktree list --porcelain 2>/dev/null | awk -v branch="refs/heads/${branch_name}" '/^worktree / { path = substr($0, 10) } /^branch / { line_branch = substr($0, 8); if (line_branch == branch) { print path; exit } }') || _path=""
+	printf '%s' "$_path"
+	return 0
+}
+
+_dlw_extract_worktree_path_from_output() {
+	local wt_output="$1"
+	local _path=""
+	_path=$(printf '%s' "$wt_output" | awk '/^Path:[[:space:]]*\// { sub(/^Path:[[:space:]]*/, ""); print; exit } /^[[:space:]]*cd[[:space:]]+\// { sub(/^[[:space:]]*cd[[:space:]]+/, ""); print; exit } /^Created worktree at[[:space:]]*\// { sub(/^Created worktree at[[:space:]]*/, ""); print; exit }') || _path=""
+	printf '%s' "$_path"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -68,7 +68,7 @@ FAKE_REPO="${TMP}/fake-repo"
 mkdir -p "$FAKE_REPO"
 
 # =============================================================================
-# Stub: worktree-helper.sh that emits unparseable output
+# Stub: worktree-helper.sh that emits configurable output
 # =============================================================================
 STUB_WT_HELPER="${TMP}/worktree-helper.sh"
 cat >"$STUB_WT_HELPER" <<'STUB_EOF'
@@ -80,7 +80,8 @@ case "${STUB_WT_MODE:-fail}" in
 		exit 1
 		;;
 	success)
-		# Emit output with a parseable Git path
+		# Emit output with a parseable path. Tests intentionally use both
+		# /Git/ and non-/Git/ paths to guard path-root assumptions.
 		echo "Created worktree at ${STUB_WT_SUCCESS_PATH}"
 		exit 0
 		;;
@@ -92,8 +93,14 @@ chmod +x "$STUB_WT_HELPER"
 # Stub: git (for worktree list — returns empty by default)
 # =============================================================================
 git() {
-	# For worktree list, return nothing (no existing worktrees)
+	# For worktree list, return configured worktrees or nothing.
 	if [[ "${1:-}" == "-C" && "${3:-}" == "worktree" && "${4:-}" == "list" ]]; then
+		if [[ "${5:-}" == "--porcelain" && -n "${STUB_PORCELAIN_WORKTREE_PATH:-}" && -n "${STUB_PORCELAIN_WORKTREE_BRANCH:-}" ]]; then
+			printf 'worktree %s\n' "$STUB_PORCELAIN_WORKTREE_PATH"
+			printf 'HEAD abcdef0123456789\n'
+			printf 'branch refs/heads/%s\n' "$STUB_PORCELAIN_WORKTREE_BRANCH"
+			return 0
+		fi
 		if [[ -n "${STUB_EXISTING_WORKTREE_LINE:-}" ]]; then
 			printf '%s\n' "$STUB_EXISTING_WORKTREE_LINE"
 		fi
@@ -214,7 +221,7 @@ fi
 # Test 2: _dlw_precreate_worktree returns 0 when creation succeeds
 # =============================================================================
 export STUB_WT_MODE="success"
-STUB_WT_SUCCESS_PATH="${TMP}/Git/fake-repo-feature"
+STUB_WT_SUCCESS_PATH="${TMP}/projects/fake-repo-feature"
 export STUB_WT_SUCCESS_PATH
 mkdir -p "$STUB_WT_SUCCESS_PATH"
 : >"$LOGFILE"
@@ -236,6 +243,26 @@ if [[ "${_DLW_WORKTREE_REUSED:-unset}" == "0" ]]; then
 	pass "freshly-created worktree is marked non-reused"
 else
 	fail "freshly-created worktree is marked non-reused" "got: '${_DLW_WORKTREE_REUSED:-unset}', expected: '0'"
+fi
+
+# =============================================================================
+# Test 2b: _dlw_precreate_worktree prefers git porcelain path resolution
+# =============================================================================
+export STUB_WT_MODE="success"
+STUB_WT_SUCCESS_PATH="${TMP}/helper-output-should-not-win"
+STUB_PORCELAIN_WORKTREE_PATH="${TMP}/projects/fake-repo-porcelain"
+STUB_PORCELAIN_WORKTREE_BRANCH="feature/auto-$(date +%Y%m%d-%H%M%S)-gh77777"
+export STUB_WT_SUCCESS_PATH STUB_PORCELAIN_WORKTREE_PATH STUB_PORCELAIN_WORKTREE_BRANCH
+mkdir -p "$STUB_WT_SUCCESS_PATH" "$STUB_PORCELAIN_WORKTREE_PATH"
+: >"$LOGFILE"
+_dlw_precreate_worktree "77777" "$FAKE_REPO"
+rc=$?
+unset STUB_PORCELAIN_WORKTREE_PATH STUB_PORCELAIN_WORKTREE_BRANCH
+
+if [[ $rc -eq 0 && "$_DLW_WORKTREE_PATH" == "${TMP}/projects/fake-repo-porcelain" ]]; then
+	pass "precreate resolves non-/Git/ path from git porcelain"
+else
+	fail "precreate resolves non-/Git/ path from git porcelain" "rc=$rc path='$_DLW_WORKTREE_PATH'"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Resolve pulse worker worktree paths from `git worktree list --porcelain` instead of assuming paths contain `/Git/`.
- Keep helper-output fallback parsing for `Path:`, `cd`, and test helper formats, with diagnostic path-resolution logging.
- Add regression coverage for non-`/Git/` worktree roots.

## Verification
- `bash -n .agents/scripts/pulse-dispatch-worker-launch.sh`
- `.agents/scripts/tests/test-precreation-failure-skip.sh`
- Hotfixed installed copy manually launched worker issues from non-`/Git/` project-root worktree paths.

Resolves #22983
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 1d 10h and 5,202,931 tokens on this with the user in an interactive session.