### PR TITLE
GH#22980: fix: paginate dashboard freshness alert lookup

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -289,9 +289,9 @@ _open_alert_numbers() {
 	gh auth status &>/dev/null 2>&1 || return 0
 	# Query open issue titles and filter locally. GitHub search is unreliable for
 	# HTML-comment dedup markers, and label prefilters can hide generated alerts.
-	gh issue list --repo "$slug" --state open \
-		--json number,title \
-		--jq '.[] | select(((.title | startswith("'"${stale_title_prefix}"'")) and (.title | endswith("'"${issue_suffix}"'"))) or (.title == "'"${missing_marker_title}"'")) | .number' 2>/dev/null || true
+	gh issue list --repo "$slug" --state open --paginate --json number,title | \
+		jq -r --arg prefix "$stale_title_prefix" --arg suffix "$issue_suffix" --arg marker "$missing_marker_title" \
+			'.[] | select(((.title | startswith($prefix)) and (.title | endswith($suffix))) or (.title == $marker)) | .number' || true
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -202,7 +202,7 @@ run_scan_with_stubs() {
 			# for the three paths the scanner exercises:
 			#   gh auth status       → success
 			#   gh api repos/.../issues/N  → dashboard body (read from fixture)
-			#   gh issue list --json number,title ... → alert dedup/recovery check
+			#   gh issue list --paginate --json number,title ... → alert dedup/recovery check
 			#   gh issue create ...  → URL + 0
 			gh() {
 				printf "%s\n" "$*" >> "$GH_CALLS_LOG"
@@ -221,13 +221,13 @@ run_scan_with_stubs() {
 							list)
 								if [[ "$gh_args" == *" --label "* ]] \
 									|| [[ "$gh_args" == *" --search "* ]] \
-									|| [[ "$gh_args" != *"--json number,title"* ]] \
-									|| [[ "$gh_args" != *"endswith(\"(#424242)\")"* ]]; then
-									printf "\n"
+									|| [[ "$gh_args" != *"--paginate"* ]] \
+									|| [[ "$gh_args" != *"--json number,title"* ]]; then
+									printf "[]\n"
 								elif [[ "$ALERT_EXISTS" == "1" ]]; then
-									printf "99\n"
+									printf "%s\n" "[{\"number\":99,\"title\":\"Supervisor health dashboard stale: test/repo (#424242)\"}]"
 								else
-									printf "\n"
+									printf "[]\n"
 								fi
 								return 0
 								;;
@@ -296,15 +296,17 @@ else
 		"calls:\n$(cat "$calls_file")"
 fi
 
-if grep -q '^issue list ' "$calls_file" \
-	&& ! grep -q -- '--label' "$calls_file" \
-	&& ! grep -q -- '--search' "$calls_file" \
-	&& grep -q -- '--json number,title' "$calls_file" \
-	&& grep -q 'endswith("(#424242)")' "$calls_file"; then
-	pass "dedup lookup filters open titles locally by dashboard suffix"
+issue_list_call="$(grep '^issue list ' "$calls_file" || true)"
+if [[ -n "$issue_list_call" ]] \
+	&& [[ "$issue_list_call" != *"--label"* ]] \
+	&& [[ "$issue_list_call" != *"--search"* ]] \
+	&& [[ "$issue_list_call" == *"--paginate"* ]] \
+	&& [[ "$issue_list_call" == *"--json number,title"* ]] \
+	&& [[ "$issue_list_call" != *"--jq"* ]]; then
+	pass "dedup lookup paginates open titles for local jq filtering"
 else
 	fail "dedup lookup query shape" \
-		"expected title query without --label/--search; calls:\n$(cat "$calls_file")"
+		"expected paginated title query without --label/--search/--jq; calls:\n$(cat "$calls_file")"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updated dashboard freshness alert deduplication to paginate open issue listing, pass jq filters via --arg, and keep jq stderr visible while preserving regression coverage.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh,.agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh; bash .agents/scripts/tests/test-dashboard-freshness-check.sh

Resolves #22980


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 12m and 122,173 tokens on this as a headless worker.