### PR TITLE
GH#22996: add changelog traceability reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- initialize release retry locals
+- initialize release retry locals (#22940)
 
 ## [3.14.66] - 2026-05-05
 


### PR DESCRIPTION
## Summary

Added the missing source issue reference to the 3.14.67 changelog fix entry so release notes match the review-bot traceability expectation.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check passed; markdownlint-cli2 unavailable in worker PATH (command not found)

Resolves #22996


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 1m and 30,965 tokens on this as a headless worker.