### PR TITLE
GH#23000: fix PR salvage recovery matching

### DIFF
--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -167,7 +167,7 @@ has_completed_recovery_issue() {
 			.[]
 			| ((.title // "") + "\n" + (.body // "")) as $text
 			| ($text | ascii_downcase) as $lower
-			| select($text | contains($pr))
+			| select($text | test($pr + "\\b"))
 			| select($lower | test("recover|recovery|salvage|restore|cherry-pick|cherrypick"))
 		] | length
 	') || match_count="0"

--- a/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
+++ b/.agents/scripts/tests/test-pr-salvage-completed-recovery.sh
@@ -38,6 +38,17 @@ gh() {
 			cat <<'JSON'
 [
   {
+    "number": 5,
+    "title": "Add compact salvage note",
+    "headRefName": "compact-salvage-note",
+    "closedAt": "2026-05-01T00:00:00Z",
+    "mergedAt": null,
+    "additions": 8,
+    "deletions": 0,
+    "author": {"login": "contributor"},
+    "labels": []
+  },
+  {
     "number": 53,
     "title": "Add buffalo logo favicon",
     "headRefName": "buffalo-logo-favicon",
@@ -107,7 +118,7 @@ source "${SCRIPTS_DIR}/pr-salvage-helper.sh" >/dev/null 2>&1 || {
 }
 
 results=$(scan_repo "owner/repo" 7)
-if printf '%s' "$results" | jq -e 'length == 1 and .[0].number == 54' >/dev/null; then
+if printf '%s' "$results" | jq -e 'length == 2 and ([.[].number] | sort) == [5, 54]' >/dev/null; then
 	pass "completed recovery issue suppresses matching closed PR"
 else
 	fail "completed recovery issue suppresses matching closed PR" "$results"


### PR DESCRIPTION
## Summary

Tightened completed recovery issue matching so PR #5 no longer matches PR #53, while keeping closed recovery issue prefetching for scan efficiency.

## Files Changed

.agents/scripts/pr-salvage-helper.sh,.agents/scripts/tests/test-pr-salvage-completed-recovery.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-completed-recovery.sh; bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh

Resolves #23000


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2m and 47,317 tokens on this as a headless worker.