### PR TITLE
GH#22994: avoid duplicate comment metrics fetches

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -232,14 +232,14 @@ _dlw_zero_output_failure_count() {
 
 	local key="${repo_slug}/${issue_number}"
 	local result=""
-	result=$(jq -r --arg k "$key" 'def s: . // ""; .[$k] | if . then [(.reason | s), (.crash_type | s), (.count // 0 | tostring)] | @tsv else empty end' "$FAST_FAIL_STATE_FILE") || result=""
+	result=$(jq -r --arg k "$key" 'def s: . // ""; .[$k] | if . then [(.count // 0 | tostring), (.reason | s), (.crash_type | s)] | @tsv else empty end' "$FAST_FAIL_STATE_FILE") || result=""
 	if [[ -z "$result" ]]; then
 		printf '%s' "$comment_count"
 		return 0
 	fi
 
 	local reason="" crash_type="" count=""
-	IFS=$'\t' read -r reason crash_type count <<<"$result"
+	IFS=$'\t' read -r count reason crash_type <<<"$result"
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 
 	case "${reason}:${crash_type}" in

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -34,6 +34,10 @@ export LOGFILE FAST_FAIL_STATE_FILE
 gh() {
 	local command_name="${1:-}"
 	shift || true
+	local subcommand_name="${1:-}"
+	if [[ "$command_name" == "api" ]]; then
+		printf '%s\n' "$command_name $*" >>"${TMP}/gh-api-calls.log"
+	fi
 	if [[ "$command_name" == "api" && -n "${GH_COMMENT_METRICS:-}" ]]; then
 		printf '%s\n' "$GH_COMMENT_METRICS"
 		return 0
@@ -42,7 +46,7 @@ gh() {
 		printf '%s\n' "$GH_COMMENT_ZERO_COUNT"
 		return 0
 	fi
-	if [[ "$command_name" == "issue" && "${1:-}" == "view" && -n "${GH_ISSUE_BODY:-}" ]]; then
+	if [[ "$command_name" == "issue" && "$subcommand_name" == "view" && -n "${GH_ISSUE_BODY:-}" ]]; then
 		printf '%s\n' "$GH_ISSUE_BODY"
 		return 0
 	fi
@@ -88,13 +92,27 @@ fi
 
 write_state 1
 GH_COMMENT_ZERO_COUNT=2
-GH_COMMENT_METRICS=""
+GH_COMMENT_METRICS=$'0\t0\t2\t0'
 comment_fallback_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
 if printf '%s' "$comment_fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
 	&& ! printf '%s' "$comment_fallback_prompt" | grep -q 'FULL EMBEDDED BRIEF'; then
 	pass "comment evidence triggers URL-only fallback when state count is low"
 else
 	fail "comment evidence triggers URL-only fallback when state count is low" "$comment_fallback_prompt"
+fi
+
+: >"${TMP}/gh-api-calls.log"
+write_state 1
+GH_COMMENT_ZERO_COUNT=0
+GH_COMMENT_METRICS=$'50\t0\t2\t1000'
+shared_metrics_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
+prepare_api_calls=$(wc -l <"${TMP}/gh-api-calls.log" | tr -d '[:space:]')
+if printf '%s' "$shared_metrics_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+	&& [[ "$prepare_api_calls" == "1" ]]; then
+	pass "prepare prompt reuses comment bloat metrics for zero-output evidence"
+else
+	fail "prepare prompt reuses comment bloat metrics for zero-output evidence" \
+		"prompt=${shared_metrics_prompt}; api_calls=${prepare_api_calls}"
 fi
 
 write_state 1
@@ -132,7 +150,7 @@ fi
 : >"${TMP}/gh-calls.log"
 write_state 1
 GH_COMMENT_ZERO_COUNT=4
-GH_COMMENT_METRICS=""
+GH_COMMENT_METRICS=$'0\t0\t4\t0'
 _dlw_hold_repeated_zero_output 123 owner/repo
 comment_hold_rc=$?
 comment_gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
@@ -142,6 +160,24 @@ if [[ "$comment_hold_rc" -eq 0 ]] \
 else
 	fail "comment evidence triggers brief-rewrite hold when state count is low" \
 		"rc=${comment_hold_rc}; gh_calls=${comment_gh_calls}"
+fi
+
+: >"${TMP}/gh-api-calls.log"
+: >"${TMP}/gh-calls.log"
+write_state 1
+GH_COMMENT_ZERO_COUNT=0
+GH_COMMENT_METRICS=$'50\t0\t4\t1000'
+_dlw_hold_repeated_zero_output 123 owner/repo
+shared_metrics_hold_rc=$?
+shared_metrics_hold_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
+hold_api_calls=$(wc -l <"${TMP}/gh-api-calls.log" | tr -d '[:space:]')
+if [[ "$shared_metrics_hold_rc" -eq 0 ]] \
+	&& printf '%s' "$shared_metrics_hold_calls" | grep -q 'needs-brief-rewrite' \
+	&& [[ "$hold_api_calls" == "1" ]]; then
+	pass "zero-output hold reuses comment bloat metrics for evidence count"
+else
+	fail "zero-output hold reuses comment bloat metrics for evidence count" \
+		"rc=${shared_metrics_hold_rc}; gh_calls=${shared_metrics_hold_calls}; api_calls=${hold_api_calls}"
 fi
 
 : >"${TMP}/gh-calls.log"


### PR DESCRIPTION
## Summary

Validated the review finding by adding regression coverage that clean-room comment metrics are reused for zero-output evidence, and fixed state-count TSV parsing so empty crash types do not erase recorded zero-output counts.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-zero-output-url-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-zero-output-url-fallback.sh; shellcheck .agents/scripts/tests/test-zero-output-url-fallback.sh .agents/scripts/pulse-dispatch-worker-launch.sh

Resolves #22994


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 4m and 130,507 tokens on this as a headless worker.