### PR TITLE
GH#23001: harden pulse retry reset and evidence metrics

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -362,6 +362,12 @@ _dlw_zero_output_evidence_count() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local precomputed_comment_count="${3:-}"
+	local precomputed_evidence_count="${4:-}"
+
+	if [[ "$precomputed_evidence_count" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$precomputed_evidence_count"
+		return 0
+	fi
 
 	local state_count="" comment_count=""
 	if [[ "$precomputed_comment_count" =~ ^[0-9]+$ ]]; then
@@ -406,11 +412,13 @@ _dlw_prepare_prompt_for_launch() {
 	local repo_slug="$2"
 	local issue_title="$3"
 	local original_prompt="$4"
+	local precomputed_comment_metrics="${5:-}"
 	local comment_metrics=""
 	local comments ops metrics_zero_count chars
 	local precomputed_zero_count=""
 
-	comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
+	comment_metrics="$precomputed_comment_metrics"
+	[[ -n "$comment_metrics" ]] || comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
 	IFS=$'\t' read -r comments ops metrics_zero_count chars <<<"$comment_metrics"
 	if [[ "${CLEAN_ROOM_COMMENT_EVIDENCE_ENABLED:-1}" == "1" && "$metrics_zero_count" =~ ^[0-9]+$ ]]; then
 		precomputed_zero_count="$metrics_zero_count"
@@ -442,11 +450,13 @@ _dlw_prepare_prompt_for_launch() {
 _dlw_hold_repeated_zero_output() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local precomputed_comment_metrics="${3:-}"
 	local comment_metrics=""
 	local comments ops metrics_zero_count chars
 	local precomputed_zero_count=""
 
-	comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
+	comment_metrics="$precomputed_comment_metrics"
+	[[ -n "$comment_metrics" ]] || comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
 	IFS=$'\t' read -r comments ops metrics_zero_count chars <<<"$comment_metrics"
 	if [[ "${CLEAN_ROOM_COMMENT_EVIDENCE_ENABLED:-1}" == "1" && "$metrics_zero_count" =~ ^[0-9]+$ ]]; then
 		precomputed_zero_count="$metrics_zero_count"
@@ -1475,7 +1485,9 @@ _dispatch_launch_worker() {
 	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"
 	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
-	if _dlw_hold_repeated_zero_output "$issue_number" "$repo_slug"; then
+	local zero_output_comment_metrics=""
+	zero_output_comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
+	if _dlw_hold_repeated_zero_output "$issue_number" "$repo_slug" "$zero_output_comment_metrics"; then
 		return 2
 	fi
 
@@ -1513,7 +1525,7 @@ _dispatch_launch_worker() {
 	_ds_t0=$(_ds_now_ns)
 	local worker_pid
 	local launch_prompt=""
-	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt")
+	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
 	worker_pid=$(_dlw_nohup_launch "$issue_number" "$dispatch_title" "$issue_title" \
 		"$session_key" "$worker_log" "$launch_prompt" "$repo_path" \
 		"$dispatch_model_tier" "$selected_model" \

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -364,31 +364,73 @@ _ff_current_aidevops_version() {
 _ff_version_gt() {
 	local left="$1"
 	local right="$2"
-	python3 - "$left" "$right" <<'PY'
-import re
-import sys
+	local left_rest="$left"
+	local right_rest="$right"
+	local left_parts=(0 0 0)
+	local right_parts=(0 0 0)
+	local i=0
 
-def parts(value):
-    nums = [int(x) for x in re.findall(r"\d+", value or "")[:3]]
-    return tuple((nums + [0, 0, 0])[:3])
+	while [[ "$i" -lt 3 && "$left_rest" =~ ([0-9]+) ]]; do
+		left_parts[$i]="${BASH_REMATCH[1]}"
+		left_rest="${left_rest#*"${BASH_REMATCH[1]}"}"
+		i=$((i + 1))
+	done
 
-sys.exit(0 if parts(sys.argv[1]) > parts(sys.argv[2]) else 1)
-PY
-	return $?
+	i=0
+	while [[ "$i" -lt 3 && "$right_rest" =~ ([0-9]+) ]]; do
+		right_parts[$i]="${BASH_REMATCH[1]}"
+		right_rest="${right_rest#*"${BASH_REMATCH[1]}"}"
+		i=$((i + 1))
+	done
+
+	for i in 0 1 2; do
+		if [[ $((10#${left_parts[$i]})) -gt $((10#${right_parts[$i]})) ]]; then
+			return 0
+		fi
+		if [[ $((10#${left_parts[$i]})) -lt $((10#${right_parts[$i]})) ]]; then
+			return 1
+		fi
+	done
+	return 1
 }
 
 _ff_release_retry_reset_if_newer() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local precomputed_state="${3:-}"
+	local precomputed_current_version="${4:-}"
 
 	[[ "${FAST_FAIL_RELEASE_RETRY_RESET_ENABLED:-1}" == "1" ]] || return 1
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
 	[[ -n "$repo_slug" ]] || return 1
 
+	if [[ -n "$precomputed_state" ]]; then
+		local precheck_key="" precheck_current_version="" precheck_failure_version="" precheck_reset_version=""
+		precheck_key=$(_ff_key "$issue_number" "$repo_slug")
+		precheck_current_version="$precomputed_current_version"
+		[[ -n "$precheck_current_version" ]] || precheck_current_version=$(_ff_current_aidevops_version)
+		precheck_failure_version=$(printf '%s' "$precomputed_state" | jq -r --arg k "$precheck_key" '.[$k].aidevops_version // ""' 2>/dev/null) || precheck_failure_version=""
+		precheck_reset_version=$(printf '%s' "$precomputed_state" | jq -r --arg k "$precheck_key" '.[$k].release_retry_reset_version // ""' 2>/dev/null) || precheck_reset_version=""
+		[[ -n "$precheck_failure_version" ]] || precheck_failure_version="0.0.0"
+		[[ -n "$precheck_current_version" ]] || return 1
+		[[ "$precheck_reset_version" != "$precheck_current_version" ]] || return 1
+		_ff_version_gt "$precheck_current_version" "$precheck_failure_version" || return 1
+	fi
+
+	_ff_with_lock _ff_release_retry_reset_if_newer_locked "$issue_number" "$repo_slug" "$precomputed_current_version"
+	return $?
+}
+
+_ff_release_retry_reset_if_newer_locked() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local precomputed_current_version="${3:-}"
+
 	local key="" state="" current_version="" failure_version="" reset_version=""
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	state=$(_ff_load)
-	current_version=$(_ff_current_aidevops_version)
+	current_version="$precomputed_current_version"
+	[[ -n "$current_version" ]] || current_version=$(_ff_current_aidevops_version)
 	failure_version=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].aidevops_version // ""' 2>/dev/null) || failure_version=""
 	reset_version=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].release_retry_reset_version // ""' 2>/dev/null) || reset_version=""
 
@@ -682,7 +724,7 @@ fast_fail_is_skipped() {
 	now=$(date +%s)
 	state=$(_ff_load)
 	if printf '%s' "$state" | jq -e --arg k "$key" '.[$k] != null' >/dev/null 2>&1; then
-		if _ff_release_retry_reset_if_newer "$issue_number" "$repo_slug"; then
+		if _ff_release_retry_reset_if_newer "$issue_number" "$repo_slug" "$state"; then
 			return 1
 		fi
 		state=$(_ff_load)

--- a/.agents/scripts/tests/test-fast-fail-release-retry-reset.sh
+++ b/.agents/scripts/tests/test-fast-fail-release-retry-reset.sh
@@ -72,17 +72,23 @@ write_entry() {
 
 future=$(( $(date +%s) + 3600 ))
 
+if _ff_version_gt "v3.14.64" "3.14.63" && ! _ff_version_gt "3.14.64" "3.14.64" && ! _ff_version_gt "3.14.63" "v3.14.64"; then
+	pass "pure bash version comparison handles prefixed aidevops versions"
+else
+	fail "pure bash version comparison handles prefixed aidevops versions"
+fi
+
 write_entry 123 1 "$future" "3.14.63"
 reset_rc=0
 fast_fail_is_skipped 123 owner/repo || reset_rc=$?
 reset_count=$(jq -r '."owner/repo/123".count' "$FAST_FAIL_STATE_FILE")
 reset_retry=$(jq -r '."owner/repo/123".retry_after' "$FAST_FAIL_STATE_FILE")
 reset_version=$(jq -r '."owner/repo/123".release_retry_reset_version' "$FAST_FAIL_STATE_FILE")
-if [[ "$reset_rc" -eq 1 && "$reset_count" == "0" && "$reset_retry" == "0" && "$reset_version" == "3.14.64" ]]; then
+if [[ "$reset_rc" -eq 1 && "$reset_count" == "0" && "$reset_retry" == "0" && "$reset_version" == "3.14.64" && ! -d "${FAST_FAIL_STATE_FILE}.lockdir" ]]; then
 	pass "new aidevops version clears old-version backoff once"
 else
 	fail "new aidevops version clears old-version backoff once" \
-		"rc=${reset_rc}; count=${reset_count}; retry=${reset_retry}; reset_version=${reset_version}"
+		"rc=${reset_rc}; count=${reset_count}; retry=${reset_retry}; reset_version=${reset_version}; lockdir=$([[ -d "${FAST_FAIL_STATE_FILE}.lockdir" ]] && printf present || printf absent)"
 fi
 
 skip_rc=0

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -74,7 +74,22 @@ if [[ ! -L "${wt_dir}/node_modules/.bin" ]]; then
 	fail "root node_modules .bin tooling link was not created"
 fi
 
+_dlw_zero_output_comment_count() {
+	fail "precomputed zero-output evidence count should skip comment API lookup"
+	return 1
+}
+
+_dlw_zero_output_failure_count() {
+	fail "precomputed zero-output evidence count should skip state lookup"
+	return 1
+}
+
+if [[ "$(_dlw_zero_output_evidence_count 123 owner/repo "" 7)" != "7" ]]; then
+	fail "precomputed zero-output evidence count was not returned directly"
+fi
+
 printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
 printf 'PASS: root node_modules payload is skipped by default\n'
 printf 'PASS: root node_modules .bin tooling is linked by default\n'
+printf 'PASS: precomputed zero-output evidence count skips redundant lookups\n'
 exit 0


### PR DESCRIPTION
## Summary

Wrapped release retry reset writes in the fast-fail lock, replaced per-comparison Python spawning with Bash version comparison, and reused/preaccepted zero-output evidence metrics to avoid redundant lookups.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/pulse-fast-fail.sh,.agents/scripts/tests/test-fast-fail-release-retry-reset.sh,.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-fast-fail.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-fast-fail-release-retry-reset.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh; bash .agents/scripts/tests/test-fast-fail-release-retry-reset.sh; bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh

Resolves #23001


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 4m and 104,069 tokens on this as a headless worker.