### PR TITLE
GH#22995: share dispatch zero-output comment metrics

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -37,6 +37,10 @@ if [[ -r "${_DLW_SCRIPT_DIR}/gh-signature-helper-detect.sh" ]]; then
 fi
 unset _DLW_SCRIPT_DIR
 : "${AIDEVOPS_UNKNOWN_VERSION:=unknown}"
+if [[ -z "${_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN+x}" ]]; then
+	# shellcheck disable=SC2016  # The backticks are literal review text matched in comments.
+	_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN='CLAIM_RELEASED reason=worker_noop_zero_output|worker_noop_zero_output|zero[- ]output|classified as `no_work`'
+fi
 
 _dlw_display_version_or_unknown() {
 	local raw_version="$1"
@@ -257,6 +261,7 @@ _dlw_zero_output_failure_count() {
 _dlw_zero_output_comment_count() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local zero_output_pattern="${_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN}"
 
 	[[ "${ZERO_OUTPUT_COMMENT_EVIDENCE_ENABLED:-1}" == "1" ]] || { printf '0'; return 0; }
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || { printf '0'; return 0; }
@@ -265,7 +270,7 @@ _dlw_zero_output_comment_count() {
 	local count=""
 	# shellcheck disable=SC2016  # jq program is intentionally single-quoted.
 	count=$(gh api --paginate "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
-		--jq '[.[] | select((.body // "") | test("CLAIM_RELEASED reason=worker_noop_zero_output|worker_noop_zero_output|zero[- ]output|classified as `no_work`"; "i"))] | length' 2>/dev/null | \
+		--jq '[.[] | select((.body // "") | test("'"${zero_output_pattern}"'"; "i"))] | length' 2>/dev/null | \
 		awk '{ if ($1 ~ /^[0-9]+$/) { total += $1 } } END { printf "%d", total + 0 }') || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	printf '%s' "$count"
@@ -275,6 +280,7 @@ _dlw_zero_output_comment_count() {
 _dlw_comment_bloat_metrics() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local zero_output_pattern="${_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN}"
 
 	[[ "${CLEAN_ROOM_COMMENT_EVIDENCE_ENABLED:-1}" == "1" ]] || { printf '0\t0\t0\t0'; return 0; }
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || { printf '0\t0\t0\t0'; return 0; }
@@ -283,7 +289,7 @@ _dlw_comment_bloat_metrics() {
 	local metrics=""
 	# shellcheck disable=SC2016  # jq program is intentionally single-quoted.
 	metrics=$(gh api --paginate "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
-		--jq '[.[] | {body: (.body // "")}] | {comments: length, ops: ([.[] | select(.body | test("ops:start|DISPATCH_CLAIM|CLAIM_RELEASED|dispatch-cooldown|Worker Watchdog Kill"; "i"))] | length), zero: ([.[] | select(.body | test("CLAIM_RELEASED reason=worker_noop_zero_output|worker_noop_zero_output|zero[- ]output|classified as `no_work`"; "i"))] | length), chars: ([.[].body | length] | add // 0)} | [.comments, .ops, .zero, .chars] | @tsv' \
+		--jq '[.[] | {body: (.body // "")}] | {comments: length, ops: ([.[] | select(.body | test("ops:start|DISPATCH_CLAIM|CLAIM_RELEASED|dispatch-cooldown|Worker Watchdog Kill"; "i"))] | length), zero: ([.[] | select(.body | test("'"${zero_output_pattern}"'"; "i"))] | length), chars: ([.[].body | length] | add // 0)} | [.comments, .ops, .zero, .chars] | @tsv' \
 		2>/dev/null | awk -F '\t' '{c+=$1; o+=$2; z+=$3; ch+=$4} END {printf "%d\t%d\t%d\t%d", c+0, o+0, z+0, ch+0}') || metrics="0	0	0	0"
 	[[ -n "$metrics" ]] || metrics=$'0\t0\t0\t0'
 	printf '%s' "$metrics"

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Regression tests for dispatch prompt comment metrics reuse and zero-output
+# evidence pattern consistency.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+
+# shellcheck source=../pulse-dispatch-worker-launch.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"
+
+TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/dlw-comment-metrics-XXXXXX")"
+FAKE_BIN="${TEST_TMP}/bin"
+GH_CALLS_FILE="${TEST_TMP}/gh-calls"
+mkdir -p "$FAKE_BIN" || exit 1
+
+cleanup() {
+	rm -rf "$TEST_TMP" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+cat >"${FAKE_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >>"${GH_CALLS_FILE:?}"
+case "$*" in
+*'issues/123/comments'*'@tsv'*)
+	printf '3\t0\t1\t120\n'
+	;;
+*'issues/123/comments'*)
+	printf '1\n'
+	;;
+*)
+	printf 'unexpected gh call: %s\n' "$*" >&2
+	exit 1
+	;;
+esac
+EOF
+chmod +x "${FAKE_BIN}/gh" || fail "failed to make fake gh executable"
+
+PATH="${FAKE_BIN}:${PATH}"
+export GH_CALLS_FILE
+
+LOGFILE="${TEST_TMP}/pulse.log" \
+	CLEAN_ROOM_COMMENT_THRESHOLD=100 \
+	CLEAN_ROOM_OPS_COMMENT_THRESHOLD=50 \
+	CLEAN_ROOM_ZERO_OUTPUT_COMMENT_THRESHOLD=10 \
+	CLEAN_ROOM_COMMENT_CHARS_THRESHOLD=50000 \
+	ZERO_OUTPUT_URL_FALLBACK_THRESHOLD=1 \
+	FAST_FAIL_STATE_FILE="" \
+	_dlw_prepare_prompt_for_launch "123" "owner/repo" "Metric test" "original prompt" >"${TEST_TMP}/prompt"
+
+if [[ "$(<"${TEST_TMP}/prompt")" != *"Previous dispatch attempts"* ]]; then
+	fail "prepare prompt did not use precomputed zero-output evidence"
+fi
+
+gh_calls="$(wc -l <"$GH_CALLS_FILE" | tr -d '[:space:]')"
+if [[ "$gh_calls" != "1" ]]; then
+	fail "prepare prompt made ${gh_calls} GitHub calls instead of reusing one metrics fetch"
+fi
+
+if [[ "$_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN" != *"worker_noop_zero_output"* || "$_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN" != *"zero[- ]output"* ]]; then
+	fail "shared zero-output evidence pattern lost expected alternatives"
+fi
+
+printf 'PASS: dispatch prompt reuses comment metrics for zero-output fallback\n'
+printf 'PASS: zero-output evidence detection uses one shared pattern\n'
+exit 0


### PR DESCRIPTION
## Summary

Shared the zero-output evidence pattern used by dispatch comment metrics and added a regression test proving prompt preparation reuses the single comment metrics fetch for zero-output fallback.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh; bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh; .agents/scripts/linters-local.sh reached existing advisory markdown/ratchet findings and timed out in shell portability after 240s

Resolves #22995


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 8m and 106,122 tokens on this as a headless worker.