### PR TITLE
fix: initialize reconcile helper locals

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -476,7 +476,7 @@ _normalize_requeue_stale_brief_rewrite_rows() {
 _normalize_clear_stale_feedback_rows() {
 	local slug="$1"
 	local stale_feedback_rows="$2"
-	local stale_pair stale_issue stale_assignees stale_assignee
+	local stale_pair="" stale_issue="" stale_assignees="" stale_assignee=""
 	local origin_worker_label=origin:worker
 	local origin_interactive_label=origin:interactive
 	local origin_takeover_label=origin:worker-takeover


### PR DESCRIPTION
## Summary
- Initializes the extracted reconcile helper's local variables to satisfy the pulse set-u unbound-var gate.
- Keeps the merged pulse stuck-issue recovery behavior intact while removing the new CI blocker from PR #23010.

For #22965.

## Worker context
- File: `.agents/scripts/pulse-issue-reconcile.sh`
- Pattern: initialize multi-variable `local` declarations as `local name=""` when introduced in pulse scripts.
- Verification: `shellcheck .agents/scripts/pulse-issue-reconcile.sh`; `bash .agents/scripts/tests/test-reassign-self-normalization.sh`; `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/complexity-local-init.md`.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 1h 47m and 1,460,277 tokens on this with the user in an interactive session.