### PR TITLE
fix: requeue available brief-rewrite holds

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -391,7 +391,6 @@ _normalize_get_stale_brief_rewrite_rows() {
 		--arg ai_approved_label "ai-approved" \
 		--arg brief_label "$_PIR_NEEDS_BRIEF_REWRITE" \
 		--arg nmr_label "needs-maintainer-review" \
-		--arg available_label "$_PIR_STATUS_AVAILABLE" \
 		--arg queued_label "$_PIR_STATUS_QUEUED" \
 		--arg claimed_label "$_PIR_STATUS_CLAIMED" \
 		--arg progress_label "$_PIR_STATUS_IN_PROGRESS" \
@@ -405,7 +404,6 @@ _normalize_get_stale_brief_rewrite_rows() {
 		| select($labels | index($ai_approved_label))
 		| select($labels | index($brief_label))
 		| select(($labels | index($nmr_label)) | not)
-		| select(($labels | index($available_label)) | not)
 		| select(($labels | index($queued_label)) | not)
 		| select(($labels | index($claimed_label)) | not)
 		| select(($labels | index($progress_label)) | not)

--- a/.agents/scripts/tests/test-reassign-self-normalization.sh
+++ b/.agents/scripts/tests/test-reassign-self-normalization.sh
@@ -438,7 +438,8 @@ test_fresh_scanner_issue_skips() {
 test_stale_auto_approved_brief_rewrite_requeues() {
 	setup_test_env
 	local json='[
-		{"number": 4246, "assignees": [{"login": "marcusquinn"}], "labels": [{"name": "auto-dispatch"}, {"name": "origin:worker"}, {"name": "tier:standard"}, {"name": "ai-approved"}, {"name": "needs-brief-rewrite"}]}
+		{"number": 4246, "assignees": [{"login": "marcusquinn"}], "labels": [{"name": "auto-dispatch"}, {"name": "origin:worker"}, {"name": "tier:standard"}, {"name": "ai-approved"}, {"name": "needs-brief-rewrite"}]},
+		{"number": 4248, "assignees": [{"login": "marcusquinn"}], "labels": [{"name": "auto-dispatch"}, {"name": "origin:worker"}, {"name": "tier:standard"}, {"name": "ai-approved"}, {"name": "status:available"}, {"name": "needs-brief-rewrite"}]}
 	]'
 	create_gh_stub "$json"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
@@ -452,6 +453,8 @@ test_stale_auto_approved_brief_rewrite_requeues() {
 	if [[ "$calls" == *"--add-label status:available"* \
 		&& "$calls" == *"--remove-label needs-brief-rewrite"* \
 		&& "$calls" == *"--remove-assignee marcusquinn"* \
+		&& "$calls" == *"issue edit 4246"* \
+		&& "$calls" == *"issue edit 4248"* \
 		&& -z "$assigned" ]]; then
 		print_result "stale auto-approved brief-rewrite infra hold → requeued" 0
 	else


### PR DESCRIPTION
## Summary
- Requeues stale auto-approved `needs-brief-rewrite` infra holds even when `status:available` was already restored.
- Extends the regression fixture to cover the observed private-project stale-hold state shape after the release.

For #22965.

## Worker context
- Files: `.agents/scripts/pulse-issue-reconcile.sh`, `.agents/scripts/tests/test-reassign-self-normalization.sh`
- Pattern: stale zero-output infra holds should remove `needs-brief-rewrite` and stale assignees so pulse can reconsider them.
- Verification: `shellcheck .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/tests/test-reassign-self-normalization.sh`; `bash .agents/scripts/tests/test-reassign-self-normalization.sh`; `.agents/scripts/linters-local.sh`.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.76 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 2h 31m and 2,153,220 tokens on this with the user in an interactive session.