### PR TITLE
GH#23019: enforce ruleset required checks in pulse merge gate

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -950,15 +950,121 @@ _attempt_worker_briefed_auto_merge() {
 # Returns: 0=all required contexts passing, 1=some not passing or API error
 #######################################
 #######################################
+# Return whether a repository-ruleset ref pattern applies to the default branch.
+# Rulesets may use exact refs, GitHub tokens, or simple branch globs.
+#
+# Args: $1=pattern, $2=default_branch
+# Returns: 0=matches default branch, 1=does not match
+#######################################
+_ruleset_ref_matches_default_branch() {
+	local pattern="$1"
+	local default_branch="$2"
+	local default_ref="refs/heads/${default_branch}"
+
+	case "$pattern" in
+	"~ALL" | "~DEFAULT_BRANCH" | "$default_ref")
+		return 0
+		;;
+	esac
+
+	case "$pattern" in
+	refs/heads/*\**)
+		# shellcheck disable=SC2254 # Intentionally treat ruleset branch globs as patterns.
+		case "$default_ref" in
+		$pattern)
+			return 0
+			;;
+		esac
+		;;
+	esac
+
+	return 1
+}
+
+#######################################
+# Resolve newline-delimited required status check contexts from active
+# repository rulesets matching the default branch. This supplements classic
+# branch protection because rulesets can enforce required checks even when
+# the branch-protection required_status_checks endpoint returns HTTP 404.
+#
+# Args: $1=repo_slug, $2=default_branch
+# Stdout: required ruleset contexts (one per line). Empty when no active
+#         matching rulesets require status checks.
+# Returns: 0=resolved, 1=rulesets API/parse error (caller fails closed)
+#######################################
+_required_contexts_from_rulesets_for_default_branch() {
+	local repo_slug="$1"
+	local default_branch="$2"
+
+	local rulesets_json=""
+	rulesets_json=$(gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
+		echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$LOGFILE"
+		return 1
+	}
+	[[ -n "$rulesets_json" && "$rulesets_json" != "[]" && "$rulesets_json" != "null" ]] || return 0
+
+	local active_ids=""
+	active_ids=$(printf '%s' "$rulesets_json" | jq -r '.[]? | select(.enforcement == "active") | .id // empty' 2>/dev/null) || {
+		echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$LOGFILE"
+		return 1
+	}
+	[[ -n "$active_ids" ]] || return 0
+
+	local contexts_tmp=""
+	contexts_tmp=$(mktemp) || {
+		echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: mktemp failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$LOGFILE"
+		return 1
+	}
+
+	local id="" detail="" include_patterns="" pattern="" matches_default=0 contexts=""
+	while IFS= read -r id; do
+		[[ -n "$id" ]] || continue
+		detail=$(gh api "repos/${repo_slug}/rulesets/${id}" 2>/dev/null) || {
+			echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$LOGFILE"
+			rm -f "$contexts_tmp"
+			return 1
+		}
+
+		include_patterns=$(printf '%s' "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || {
+			echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: ruleset detail ${id} parse failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$LOGFILE"
+			rm -f "$contexts_tmp"
+			return 1
+		}
+
+		matches_default=0
+		while IFS= read -r pattern; do
+			[[ -n "$pattern" ]] || continue
+			if _ruleset_ref_matches_default_branch "$pattern" "$default_branch"; then
+				matches_default=1
+				break
+			fi
+		done <<<"$include_patterns"
+		[[ "$matches_default" -eq 1 ]] || continue
+
+		contexts=$(printf '%s' "$detail" | jq -r '.rules[]? | select(.type == "required_status_checks") | (.parameters.required_status_checks // [])[]? | .context // empty' 2>/dev/null) || {
+			echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: required-check parse failed for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#23019)" >>"$LOGFILE"
+			rm -f "$contexts_tmp"
+			return 1
+		}
+		[[ -n "$contexts" ]] && printf '%s\n' "$contexts" >>"$contexts_tmp"
+	done <<<"$active_ids"
+
+	if [[ -s "$contexts_tmp" ]]; then
+		sort -u "$contexts_tmp"
+	fi
+	rm -f "$contexts_tmp"
+	return 0
+}
+
+#######################################
 # Resolve the newline-delimited list of required status check contexts
 # for $repo_slug's default branch. Extracted from _check_required_checks_passing
 # (t3193) to keep that function under the 100-line complexity gate.
 #
 # Args: $1=repo_slug
-# Stdout: required contexts (one per line). Empty when the default branch
-#         has no protection (HTTP 404) or no required contexts configured —
-#         BOTH cases are "no enforcement required" and the caller treats them
-#         as PASS (t3193 supersedes t2922 fail-closed for the 404 case).
+# Stdout: required contexts from classic branch protection plus active matching
+#         repository rulesets (one per line). Empty when neither mechanism
+#         requires checks; the caller treats that as PASS.
 # Returns:
 #   0 — contexts resolved (may be empty per above)
 #   1 — real error (default branch resolve failed, or non-404 API error) —
@@ -987,12 +1093,17 @@ _required_contexts_for_default_branch() {
 		2>&1)
 	_rc_exit=$?
 	if [[ $_rc_exit -ne 0 ]]; then
-		# HTTP 404 = the default branch has no protection rules. Print empty
-		# and return success so the caller's rollup gate runs instead of
-		# fail-closed.
+		# HTTP 404 = the default branch has no classic protection rules. Rulesets
+		# can still enforce required checks, so inspect them before allowing.
 		if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
-			echo "[pulse-merge] _required_contexts_for_default_branch: no branch protection on ${repo_slug} default branch (HTTP 404) — empty contexts (t3193)" >>"$LOGFILE"
-			printf ''
+			local ruleset_contexts_404=""
+			ruleset_contexts_404=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || return 1
+			if [[ -n "$ruleset_contexts_404" ]]; then
+				echo "[pulse-merge] _required_contexts_for_default_branch: no classic branch protection on ${repo_slug} (HTTP 404), but active rulesets require contexts (GH#23019)" >>"$LOGFILE"
+				printf '%s\n' "$ruleset_contexts_404"
+				return 0
+			fi
+			echo "[pulse-merge] _required_contexts_for_default_branch: no classic branch protection or required ruleset contexts on ${repo_slug} default branch (HTTP 404) — empty contexts (t3193, GH#23019)" >>"$LOGFILE"
 			return 0
 		fi
 		# Any other failure (401, 403, 5xx, network) is a real error — keep
@@ -1002,9 +1113,23 @@ _required_contexts_for_default_branch() {
 		return 1
 	fi
 
-	# Extract required contexts from the JSON response.
-	printf '%s' "$protection_resp" \
-		| jq -r '.contexts // [] | .[]' 2>/dev/null || true
+	# Extract required contexts from the JSON response, then supplement with
+	# active matching repository rulesets so rulesets-only required checks do not
+	# pass the gate and fail later at mergePullRequest (GH#23019).
+	local classic_contexts="" ruleset_contexts=""
+	classic_contexts=$(printf '%s' "$protection_resp" \
+		| jq -r '.contexts // [] | .[]' 2>/dev/null) || classic_contexts=""
+	ruleset_contexts=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || return 1
+	if [[ -n "$ruleset_contexts" ]]; then
+		echo "[pulse-merge] _required_contexts_for_default_branch: active rulesets add required contexts for ${repo_slug} (GH#23019)" >>"$LOGFILE"
+	fi
+
+	if [[ -n "$classic_contexts" ]]; then
+		printf '%s\n' "$classic_contexts"
+	fi
+	if [[ -n "$ruleset_contexts" ]]; then
+		printf '%s\n' "$ruleset_contexts"
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+++ b/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
@@ -9,11 +9,11 @@
 # `gh pr checks --required` to fail-closed via an API quirk, blocking auto-merge
 # of origin:worker PRs whose branch-protection-required checks all passed.
 #
-# Fix: _check_required_checks_passing fetches required contexts directly from
-# the branch protection API (authoritative), then cross-references the PR's
-# REST check-runs (GH#21799 migration). If all required-by-protection contexts
-# pass, the function returns 0, allowing the origin:worker bypass path to
-# proceed.
+# Fix: _check_required_checks_passing fetches required contexts from classic
+# branch protection plus active matching repository rulesets, then cross-
+# references the PR's REST check-runs (GH#21799 migration). If all required
+# contexts pass, the function returns 0, allowing the origin:worker bypass
+# path to proceed.
 #
 # Scenarios tested:
 #   1. all_required_pass — all required contexts SUCCESS, including the
@@ -21,28 +21,34 @@
 #   2. phantom_pending_only — required pass + non-required null/pending → return 0
 #   3. one_required_failing — one required FAILURE → return 1
 #   4. required_context_absent — required context not in rollup (NOT_FOUND) → return 1
-#   5. no_required_contexts — branch protection has empty contexts list → return 0
-#   6. default_branch_api_error — can't get default branch → return 1 (fail-closed)
-#   7. branch_protection_api_error — can't get branch protection → return 1 (fail-closed)
-#   8. checks_api_error — can't get REST check-runs → return 1 (fail-closed)
+#   5. no_required_contexts — no classic/ruleset contexts → return 0
+#   6. rulesets_required_on_404 — rulesets-only required check failing → return 1
+#   7. rulesets_required_on_404_pass — rulesets-only required check passing → return 0
+#   8. rulesets_non_matching_branch — non-default ruleset ignored → return 0
+#   9. default_branch_api_error — can't get default branch → return 1 (fail-closed)
+#   10. branch_protection_api_error — can't get branch protection → return 1 (fail-closed)
+#   11. checks_api_error — can't get REST check-runs → return 1 (fail-closed)
 #
 # Strategy: source shared-gh-wrappers-checks.sh for `gh_pr_check_runs_rest`,
 # extract _check_required_checks_passing from pulse-merge-process.sh, eval it,
 # and exercise against a mock `gh` stub keyed on MOCK_*_MODE env vars.
 #
-# The mock handles five gh invocations (post GH#21799 migration):
+# The mock handles seven gh invocations (post GH#21799 migration):
 #   1. gh api repos/SLUG                              → default branch
 #   2. gh api repos/SLUG/branches/.../protection/...  → required_status_checks
-#   3. gh pr view NUM --json headRefOid               → PR HEAD SHA
-#   4. gh api repos/SLUG/commits/SHA/check-runs       → check-run states
-#   5. gh api repos/SLUG/commits/SHA/status           → legacy status contexts
+#   3. gh api repos/SLUG/rulesets                    → repository ruleset list
+#   4. gh api repos/SLUG/rulesets/ID                 → repository ruleset detail
+#   5. gh pr view NUM --json headRefOid              → PR HEAD SHA
+#   6. gh api repos/SLUG/commits/SHA/check-runs      → check-run states
+#   7. gh api repos/SLUG/commits/SHA/status          → legacy status contexts
 #      (t3250: includes `Maintainer Review & Assignee Gate` alias for repos
 #      whose branch protection still requires the pre-reusable workflow name)
 #
 # Mode variables:
-#   MOCK_REPO_MODE   — controls gh api repos/<slug> response
-#   MOCK_BP_MODE     — controls branch protection required_status_checks response
-#   MOCK_ROLLUP_MODE — controls REST check-runs/status response (legacy name retained)
+#   MOCK_REPO_MODE     — controls gh api repos/<slug> response
+#   MOCK_BP_MODE       — controls branch protection required_status_checks response
+#   MOCK_RULESETS_MODE — controls repository ruleset list/detail responses
+#   MOCK_ROLLUP_MODE   — controls REST check-runs/status response (legacy name retained)
 
 set -euo pipefail
 
@@ -86,6 +92,7 @@ setup_test_env() {
 	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
 	export MOCK_REPO_MODE="ok"
 	export MOCK_BP_MODE="three_required"
+	export MOCK_RULESETS_MODE="none"
 	export MOCK_ROLLUP_MODE="all_required_pass"
 	: >"$LOGFILE"
 	: >"$GH_CALL_LOG"
@@ -93,16 +100,19 @@ setup_test_env() {
 	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 # Mock gh for test-pulse-merge-phantom-pending-checks.sh
-# Records every invocation and returns canned responses for three call types:
+# Records every invocation and returns canned responses for several call types:
 #   1. gh api repos/SLUG                → default branch
 #   2. gh api repos/SLUG/branches/...  → required_status_checks contexts
-#   3. gh pr view NUM --json statusCheckRollup → PR check states
+#   3. gh api repos/SLUG/rulesets       → repository ruleset list/detail
+#   4. gh pr view NUM --json statusCheckRollup → PR check states
 #
 # Mode env vars:
-#   MOCK_REPO_MODE   — ok | error
-#   MOCK_BP_MODE     — three_required | no_required | error
-#   MOCK_ROLLUP_MODE — all_required_pass | phantom_pending | one_required_failing |
-#                      required_absent | error
+#   MOCK_REPO_MODE     — ok | error
+#   MOCK_BP_MODE       — three_required | no_required | not_found | error
+#   MOCK_RULESETS_MODE — none | active_required | active_required_other_branch |
+#                        error | detail_error
+#   MOCK_ROLLUP_MODE   — all_required_pass | phantom_pending | one_required_failing |
+#                        required_absent | error
 printf '%s\n' "$*" >> "${GH_CALL_LOG}"
 
 # Helper: apply --jq expression from args if present
@@ -126,13 +136,53 @@ apply_jq() {
 	return 0
 }
 
+# Match: gh api repos/SLUG/rulesets/ID (repository ruleset detail)
+if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
+	case "${MOCK_RULESETS_MODE:-none}" in
+	active_required)
+		apply_jq '{"conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		exit 0
+		;;
+	active_required_other_branch)
+		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/release"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		exit 0
+		;;
+	detail_error)
+		printf 'gh: mock ruleset detail API error\n' >&2
+		exit 1
+		;;
+	*)
+		apply_jq '{"conditions":{"ref_name":{"include":[]}},"rules":[]}' "$@"
+		exit 0
+		;;
+	esac
+fi
+
+# Match: gh api repos/SLUG/rulesets (repository ruleset list)
+if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
+	case "${MOCK_RULESETS_MODE:-none}" in
+	none)
+		apply_jq '[]' "$@"
+		exit 0
+		;;
+	active_required | active_required_other_branch | detail_error)
+		apply_jq '[{"id":101,"enforcement":"active"}]' "$@"
+		exit 0
+		;;
+	error)
+		printf 'gh: mock rulesets API error\n' >&2
+		exit 1
+		;;
+	esac
+fi
+
 # Match: gh api repos/SLUG  (repo info — default branch)
 # Detected by: $1 == api, $2 starts with "repos/", no other path segments.
 # Must exclude /commits/ for the GH#21799 REST check-runs/status branches
 # below to be reachable.
 if [[ "$1" == "api" && "$2" == repos/* && "$*" != *"/branches/"* \
 	&& "$*" != *"/issues/"* && "$*" != *"/pulls/"* \
-	&& "$*" != *"/commits/"* ]]; then
+	&& "$*" != *"/commits/"* && "$*" != *"/rulesets"* ]]; then
 	case "${MOCK_REPO_MODE:-ok}" in
 	ok)
 		apply_jq '{"default_branch":"main"}' "$@"
@@ -154,6 +204,10 @@ if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
 		;;
 	no_required)
 		local_json='{"contexts":[]}'
+		;;
+	not_found)
+		printf 'gh: HTTP 404: Not Found\n' >&2
+		exit 1
 		;;
 	error)
 		printf 'gh: mock branch-protection API error\n' >&2
@@ -251,8 +305,8 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract _required_contexts_for_default_branch and _check_required_checks_passing
-# from pulse-merge-process.sh and eval them.
+# Extract the required-context helpers and _check_required_checks_passing from
+# pulse-merge-process.sh and eval them.
 define_function_under_test() {
 	# Source the REST check-runs helper so the extracted function can call
 	# `gh_pr_check_runs_rest` (GH#21799 migration). Sub-library only — avoids
@@ -265,6 +319,36 @@ define_function_under_test() {
 	fi
 	# shellcheck disable=SC1090  # dynamic source from sibling lib
 	source "$checks_lib"
+	gh_pr_view() {
+		if gh pr view "$@"; then
+			return 0
+		fi
+		return 1
+	}
+
+	local ref_match_src
+	ref_match_src=$(awk '
+		/^_ruleset_ref_matches_default_branch\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$ref_match_src" ]]; then
+		printf 'ERROR: could not extract _ruleset_ref_matches_default_branch from %s\n' \
+			"$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$ref_match_src"
+
+	local rulesets_src
+	rulesets_src=$(awk '
+		/^_required_contexts_from_rulesets_for_default_branch\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$rulesets_src" ]]; then
+		printf 'ERROR: could not extract _required_contexts_from_rulesets_for_default_branch from %s\n' \
+			"$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$rulesets_src"
 
 	local helper_src
 	helper_src=$(awk '
@@ -319,6 +403,10 @@ assert_log_contains() {
 reset_logs() {
 	: >"$LOGFILE"
 	: >"$GH_CALL_LOG"
+	export MOCK_REPO_MODE="ok"
+	export MOCK_BP_MODE="three_required"
+	export MOCK_RULESETS_MODE="none"
+	export MOCK_ROLLUP_MODE="all_required_pass"
 	return 0
 }
 
@@ -375,14 +463,56 @@ test_required_context_absent_from_rollup() {
 }
 
 test_no_required_contexts() {
-	# Repo has no required checks in branch protection — nothing can be failing.
+	# Repo has no required checks in classic branch protection or rulesets.
 	reset_logs
 	export MOCK_REPO_MODE="ok"
 	export MOCK_BP_MODE="no_required"
 	export MOCK_ROLLUP_MODE="all_required_pass"
-	assert_returns 0 "no required contexts in branch protection → allowed"
+	assert_returns 0 "no required contexts in branch protection or rulesets → allowed"
 	assert_log_contains "no required contexts" \
 		"no_required: pass message logged"
+	return 0
+}
+
+test_rulesets_required_on_branch_protection_404_block() {
+	# GH#23019: rulesets-only required checks must be enforced even when the
+	# classic branch-protection endpoint returns 404.
+	reset_logs
+	export MOCK_REPO_MODE="ok"
+	export MOCK_BP_MODE="not_found"
+	export MOCK_RULESETS_MODE="active_required"
+	export MOCK_ROLLUP_MODE="one_required_failing"
+	assert_returns 1 "branch protection 404 + failing ruleset-required check → blocked"
+	assert_log_contains "active rulesets require contexts" \
+		"rulesets_404_block: ruleset context logged"
+	assert_log_contains "required context(s) not passing" \
+		"rulesets_404_block: block message logged"
+	return 0
+}
+
+test_rulesets_required_on_branch_protection_404_pass() {
+	reset_logs
+	export MOCK_REPO_MODE="ok"
+	export MOCK_BP_MODE="not_found"
+	export MOCK_RULESETS_MODE="active_required"
+	export MOCK_ROLLUP_MODE="all_required_pass"
+	assert_returns 0 "branch protection 404 + passing ruleset-required check → allowed"
+	assert_log_contains "active rulesets require contexts" \
+		"rulesets_404_pass: ruleset context logged"
+	assert_log_contains "all required contexts passing" \
+		"rulesets_404_pass: pass message logged"
+	return 0
+}
+
+test_rulesets_non_matching_branch_ignored() {
+	reset_logs
+	export MOCK_REPO_MODE="ok"
+	export MOCK_BP_MODE="not_found"
+	export MOCK_RULESETS_MODE="active_required_other_branch"
+	export MOCK_ROLLUP_MODE="one_required_failing"
+	assert_returns 0 "branch protection 404 + non-default ruleset → allowed"
+	assert_log_contains "no classic branch protection or required ruleset contexts" \
+		"rulesets_non_default: empty-context message logged"
 	return 0
 }
 
@@ -435,6 +565,9 @@ main() {
 	test_one_required_failing
 	test_required_context_absent_from_rollup
 	test_no_required_contexts
+	test_rulesets_required_on_branch_protection_404_block
+	test_rulesets_required_on_branch_protection_404_pass
+	test_rulesets_non_matching_branch_ignored
 	test_default_branch_api_error
 	test_branch_protection_api_error
 	test_rollup_api_error

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Tests for t2104 / GH#19040: pulse-merge.sh _pr_required_checks_pass must
-# query `gh pr checks --required --json bucket` (branch-protection-required
-# checks only) rather than `gh pr view --json statusCheckRollup` (all checks
+# Tests for t2104 / GH#19040 and t3514: pulse-merge-process.sh
+# _pr_required_checks_pass must delegate to REST-backed required-context
+# verification rather than `gh pr view --json statusCheckRollup` (all checks
 # attached to the PR head), so that:
 #
 #   1. Post-merge advisory failures (e.g. "Sync Issue Hygiene on PR Merge"
@@ -12,8 +12,8 @@
 #      do NOT block the merge pass.
 #   2. Non-required advisory checks are ignored.
 #   3. Required failures still correctly block the merge.
-#   4. Pending / skipping required checks still allow the merge (preserves
-#      pre-t2104 semantics — --admin handles pending, skipping is not an error).
+#   4. Pending required checks block until provably passing; skipped required
+#      checks still allow the merge.
 #   5. API errors fail-closed (a bubbling gh failure must never auto-merge).
 #
 # Regression root cause: PR #19023 (GH#18787) had all required checks green
@@ -21,9 +21,9 @@
 # "Sync Issue Hygiene on PR Merge" workflow — the deterministic merge pass
 # skipped the PR and required manual maintainer intervention.
 #
-# Strategy: extract _pr_required_checks_pass from pulse-merge.sh, eval it,
-# and exercise it against a mock `gh` stub that records every invocation
-# and returns canned responses keyed on $MOCK_GH_MODE.
+# Strategy: extract _pr_required_checks_pass plus its required-context helpers
+# from pulse-merge-process.sh, eval them, and exercise against a mock `gh` stub
+# keyed on $MOCK_GH_MODE.
 
 set -euo pipefail
 
@@ -59,15 +59,15 @@ print_result() {
 	return 0
 }
 
-# Prepare a mock `gh` on PATH that records every invocation and returns
-# canned JSON keyed on $MOCK_GH_MODE:
-#   all_pass        — [{bucket:"pass"},{bucket:"pass"}]
-#   one_fail        — [{bucket:"pass"},{bucket:"fail"}]
-#   one_cancel      — [{bucket:"pass"},{bucket:"cancel"}]
-#   empty_required  — []
-#   pending_only    — [{bucket:"pending"}]
-#   skipping_only   — [{bucket:"skipping"}]
-#   error           — exit 1 with no output
+# Prepare a mock `gh` on PATH that records every invocation and returns canned
+# REST branch-protection/check-run responses keyed on $MOCK_GH_MODE:
+#   all_pass        — required check-runs conclude success
+#   one_fail        — one required check-run concludes failure
+#   one_cancel      — one required check-run concludes cancelled
+#   empty_required  — branch protection has no required contexts
+#   pending_only    — required check-run has no conclusion yet
+#   skipping_only   — required check-run concludes skipped
+#   error           — branch-protection API exits non-zero
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	mkdir -p "${TEST_ROOT}/bin"
@@ -81,32 +81,13 @@ setup_test_env() {
 	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 # Mock gh for test-pulse-merge-required-checks-filter.sh
-# Records every top-level invocation and returns canned responses for
-# `gh pr checks <N> --repo <slug> --required --json bucket [--jq EXPR]`.
-#
-# Applies --jq via the real jq binary so the function under test sees the
-# same filtered output it would see from the real gh CLI.
+# Records every top-level invocation and returns canned REST responses for
+# branch-protection required-context verification.
 printf '%s\n' "$*" >>"${GH_CALL_LOG}"
 
-# Only handle `gh pr checks ... --required --json bucket`
-if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* && "$*" == *"--json bucket"* ]]; then
-	# Resolve the canned JSON for the current mode
-	local_json=""
-	case "${MOCK_GH_MODE:-all_pass}" in
-	all_pass) local_json='[{"bucket":"pass"},{"bucket":"pass"}]' ;;
-	one_fail) local_json='[{"bucket":"pass"},{"bucket":"fail"}]' ;;
-	one_cancel) local_json='[{"bucket":"pass"},{"bucket":"cancel"}]' ;;
-	empty_required) local_json='[]' ;;
-	pending_only) local_json='[{"bucket":"pending"}]' ;;
-	skipping_only) local_json='[{"bucket":"skipping"}]' ;;
-	error)
-		printf 'gh: mock error\n' >&2
-		exit 1
-		;;
-	*) local_json='[]' ;;
-	esac
-
-	# If --jq EXPR is present, apply it via the real jq binary.
+apply_jq() {
+	local json="$1"
+	shift
 	jq_expr=""
 	prev=""
 	for arg in "$@"; do
@@ -117,10 +98,95 @@ if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* && "$*" == *"--
 		prev="$arg"
 	done
 	if [[ -n "$jq_expr" ]]; then
-		printf '%s' "$local_json" | jq -r "$jq_expr"
-		exit 0
+		printf '%s' "$json" | jq -r "$jq_expr"
+		return 0
 	fi
-	printf '%s\n' "$local_json"
+	printf '%s\n' "$json"
+	return 0
+}
+
+if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
+	apply_jq '{"conditions":{"ref_name":{"include":[]}},"rules":[]}' "$@"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
+	apply_jq '[]' "$@"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == repos/* && "$*" != *"/branches/"* \
+	&& "$*" != *"/commits/"* && "$*" != *"/rulesets"* ]]; then
+	apply_jq '{"default_branch":"main"}' "$@"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
+	case "${MOCK_GH_MODE:-all_pass}" in
+	empty_required)
+		apply_jq '{"contexts":[]}' "$@"
+		exit 0
+		;;
+	error)
+		printf 'gh: mock branch-protection error\n' >&2
+		exit 1
+		;;
+	*)
+		apply_jq '{"contexts":["required-a","required-b"]}' "$@"
+		exit 0
+		;;
+	esac
+fi
+
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"headRefOid"* ]]; then
+	apply_jq '{"headRefOid":"abc123def456789000000000000000000000abcd"}' "$@"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
+	local_json=""
+	case "${MOCK_GH_MODE:-all_pass}" in
+	all_pass | empty_required)
+		local_json='{"check_runs":[
+			{"name":"required-a","conclusion":"success","status":"completed"},
+			{"name":"required-b","conclusion":"success","status":"completed"},
+			{"name":"Sync Issue Hygiene on PR Merge","conclusion":"failure","status":"completed"}
+		]}'
+		;;
+	one_fail)
+		local_json='{"check_runs":[
+			{"name":"required-a","conclusion":"success","status":"completed"},
+			{"name":"required-b","conclusion":"failure","status":"completed"}
+		]}'
+		;;
+	one_cancel)
+		local_json='{"check_runs":[
+			{"name":"required-a","conclusion":"success","status":"completed"},
+			{"name":"required-b","conclusion":"cancelled","status":"completed"}
+		]}'
+		;;
+	pending_only)
+		local_json='{"check_runs":[
+			{"name":"required-a","conclusion":null,"status":"in_progress"},
+			{"name":"required-b","conclusion":"success","status":"completed"}
+		]}'
+		;;
+	skipping_only)
+		local_json='{"check_runs":[
+			{"name":"required-a","conclusion":"skipped","status":"completed"},
+			{"name":"required-b","conclusion":"success","status":"completed"}
+		]}'
+		;;
+	*)
+		local_json='{"check_runs":[]}'
+		;;
+	esac
+	apply_jq "$local_json" "$@"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$*" == *"/commits/"* && "$*" == *"/status"* ]]; then
+	apply_jq '{"statuses":[]}' "$@"
 	exit 0
 fi
 
@@ -138,9 +204,66 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract _pr_required_checks_pass from pulse-merge.sh and eval it into
-# the current shell so we can invoke it directly.
+# Extract _pr_required_checks_pass plus its helper stack into the current shell.
 define_function_under_test() {
+	local checks_lib="${SCRIPT_DIR}/../shared-gh-wrappers-checks.sh"
+	if [[ ! -f "$checks_lib" ]]; then
+		printf 'ERROR: shared-gh-wrappers-checks.sh not found at %s\n' "$checks_lib" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from sibling lib
+	source "$checks_lib"
+	gh_pr_view() {
+		if gh pr view "$@"; then
+			return 0
+		fi
+		return 1
+	}
+
+	local ref_match_src
+	ref_match_src=$(awk '
+		/^_ruleset_ref_matches_default_branch\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$ref_match_src" ]]; then
+		printf 'ERROR: could not extract _ruleset_ref_matches_default_branch from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$ref_match_src"
+
+	local rulesets_src
+	rulesets_src=$(awk '
+		/^_required_contexts_from_rulesets_for_default_branch\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$rulesets_src" ]]; then
+		printf 'ERROR: could not extract _required_contexts_from_rulesets_for_default_branch from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$rulesets_src"
+
+	local required_src
+	required_src=$(awk '
+		/^_required_contexts_for_default_branch\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$required_src" ]]; then
+		printf 'ERROR: could not extract _required_contexts_for_default_branch from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$required_src"
+
+	local checks_src
+	checks_src=$(awk '
+		/^_check_required_checks_passing\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$checks_src" ]]; then
+		printf 'ERROR: could not extract _check_required_checks_passing from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$checks_src"
+
 	local fn_src
 	fn_src=$(awk '
 		/^_pr_required_checks_pass\(\) \{/,/^}$/ { print }
@@ -190,12 +313,12 @@ assert_log_empty() {
 	return 0
 }
 
-assert_gh_call_uses_required_flag() {
+assert_gh_call_uses_rest_check_runs() {
 	local label="$1"
-	if grep -q -- "--required" "$GH_CALL_LOG" 2>/dev/null; then
+	if grep -q -- "/check-runs" "$GH_CALL_LOG" 2>/dev/null; then
 		print_result "$label" 0
 	else
-		print_result "$label" 1 "Expected 'gh pr checks ... --required' invocation"
+		print_result "$label" 1 "Expected REST check-runs invocation"
 	fi
 	return 0
 }
@@ -205,16 +328,17 @@ test_all_pass_allows_merge() {
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="all_pass"
 	assert_function_returns 0 "all required checks passing → merge allowed"
-	assert_gh_call_uses_required_flag "all_pass: gh pr checks called with --required"
-	assert_log_empty "all_pass: no skip log emitted"
+	assert_gh_call_uses_rest_check_runs "all_pass: REST check-runs called"
+	assert_log_contains "all required contexts passing" \
+		"all_pass: pass message logged"
 	return 0
 }
 
 test_post_merge_advisory_failure_ignored() {
 	# Simulates the GH#18787 regression: statusCheckRollup would have
 	# flagged "Sync Issue Hygiene on PR Merge" as FAILURE, but
-	# `gh pr checks --required` only returns branch-protection-required
-	# checks so the post-merge advisory workflow is invisible here.
+	# branch-protection required contexts exclude that advisory workflow, so it
+	# is invisible to the required-context gate.
 	# all_pass mock represents that state: two required checks, both pass.
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -227,10 +351,11 @@ test_required_failure_blocks_merge() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="one_fail"
-	assert_function_returns 1 "one required check in bucket=fail → merge blocked"
-	assert_log_contains "1 required status check(s) failing" \
-		"one_fail: skip reason logged"
-	assert_log_contains "t2104" "one_fail: log tagged with t2104"
+	assert_function_returns 1 "one required check-run failure → merge blocked"
+	assert_log_contains "required context(s) not passing" \
+		"one_fail: required-context failure logged"
+	assert_log_contains "REST required checks not provably passing" \
+		"one_fail: wrapper skip reason logged"
 	return 0
 }
 
@@ -238,9 +363,9 @@ test_required_cancel_blocks_merge() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="one_cancel"
-	assert_function_returns 1 "required check in bucket=cancel → merge blocked"
-	assert_log_contains "1 required status check(s) failing" \
-		"one_cancel: skip reason logged"
+	assert_function_returns 1 "required check-run cancelled → merge blocked"
+	assert_log_contains "required context(s) not passing" \
+		"one_cancel: required-context failure logged"
 	return 0
 }
 
@@ -251,17 +376,20 @@ test_empty_required_set_allows_merge() {
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="empty_required"
 	assert_function_returns 0 "empty required-checks set → merge allowed"
-	assert_log_empty "empty_required: no skip log emitted"
+	assert_log_contains "no required contexts" \
+		"empty_required: empty-context pass logged"
 	return 0
 }
 
-test_pending_required_allows_merge() {
-	# Pre-t2104 semantics: pending required checks are not counted as
-	# failures. --admin merges past them. The gate preserves this.
+test_pending_required_blocks_merge() {
+	# t3514 semantics: pending required checks are not provably passing, so the
+	# deterministic gate blocks until GitHub reports a successful conclusion.
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="pending_only"
-	assert_function_returns 0 "pending required check → merge allowed (pre-t2104 semantics)"
+	assert_function_returns 1 "pending required check → merge blocked"
+	assert_log_contains "required context(s) not passing" \
+		"pending_required: required-context failure logged"
 	return 0
 }
 
@@ -282,10 +410,11 @@ test_gh_api_error_fails_closed() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="error"
-	assert_function_returns 1 "gh pr checks error → merge blocked (fail-closed)"
-	assert_log_contains "required checks fetch failed" \
+	assert_function_returns 1 "required-context API error → merge blocked (fail-closed)"
+	assert_log_contains "branch protection API failed" \
 		"error: skip reason logged"
-	assert_log_contains "t2104" "error: log tagged with t2104"
+	assert_log_contains "REST required checks not provably passing" \
+		"error: wrapper skip reason logged"
 	return 0
 }
 
@@ -303,7 +432,7 @@ main() {
 	test_required_failure_blocks_merge
 	test_required_cancel_blocks_merge
 	test_empty_required_set_allows_merge
-	test_pending_required_allows_merge
+	test_pending_required_blocks_merge
 	test_skipping_required_allows_merge
 	test_gh_api_error_fails_closed
 


### PR DESCRIPTION
## Summary

Root cause: the pulse merge gate treated classic branch-protection HTTP 404 as no required checks, but repository rulesets can still enforce required status checks. Added ruleset context discovery to the REST required-check gate and updated regression tests for rulesets-only protection.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh,.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; bash .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh; bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; bash .agents/scripts/tests/test-pulse-merge-stuck.sh; bash .agents/scripts/tests/test-pulse-merge-rest-readiness.sh; git diff --check

Resolves #23019


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.79 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 13m and 309,365 tokens on this as a headless worker.