### PR TITLE
fix: keep pulse OpenCode resolver product-strict

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -230,10 +230,9 @@ _sweep_nvm_volta_fnm_for_opencode() {
 
 # t2954: Legacy fixed-install-paths sweep for an opencode binary. Used as
 # a last-resort discovery when persistence, runtime registry, live PATH,
-# and the Node-version-manager sweep all came up empty. Each candidate
-# is product-validated when the validator is in scope; the claude entries
-# remain in the list for documentation but always fail validation and
-# are skipped (they were the alex-solovyev silent-product-swap source).
+# and the Node-version-manager sweep all came up empty. Every candidate
+# is an OpenCode path only and is product-validated when the validator is
+# in scope; Claude paths must never be returned as OPENCODE_BIN.
 # $1 = "1" if _setup_validate_opencode_binary is callable, else "0".
 # Returns 0 + prints path on hit, 1 on miss.
 _sweep_legacy_install_paths_for_opencode() {
@@ -245,10 +244,7 @@ _sweep_legacy_install_paths_for_opencode() {
 		/home/linuxbrew/.linuxbrew/bin/opencode \
 		"$HOME/.npm-global/bin/opencode" \
 		"$HOME/.local/bin/opencode" \
-		"$HOME/.bun/bin/opencode" \
-		/opt/homebrew/bin/claude \
-		/usr/local/bin/claude \
-		"$HOME/.local/bin/claude"; do
+		"$HOME/.bun/bin/opencode"; do
 		[[ -x "$_candidate" ]] || continue
 		if [[ "$_have_validator" -eq 1 ]] && \
 			! _setup_validate_opencode_binary "$_candidate"; then
@@ -258,6 +254,17 @@ _sweep_legacy_install_paths_for_opencode() {
 		return 0
 	done
 	return 1
+}
+
+_pulse_validate_opencode_candidate() {
+	local _candidate="${1:-}" _have_validator="${2:-0}"
+	[[ -n "$_candidate" ]] && [[ -x "$_candidate" ]] || return 1
+	if [[ "$_have_validator" -eq 1 ]] && \
+		! _setup_validate_opencode_binary "$_candidate"; then
+		return 1
+	fi
+	printf '%s' "$_candidate"
+	return 0
 }
 
 # t2954: Persist a resolved runtime path with product validation. Persisting
@@ -342,23 +349,23 @@ _resolve_pulse_runtime_binary() {
 		while IFS= read -r _sched_rt_id; do
 			_sched_bin=$(rt_binary "$_sched_rt_id") || continue
 			if [[ -n "$_sched_bin" ]] && command -v "$_sched_bin" &>/dev/null; then
-				opencode_bin=$(command -v "$_sched_bin")
-				break
+				opencode_bin=$(_pulse_validate_opencode_candidate "$(command -v "$_sched_bin")" "$_have_validator" || true)
+				[[ -n "$opencode_bin" ]] && break
 			fi
 		done < <(rt_list_headless)
 	fi
 
-	# 3. Direct PATH lookup.
-	[[ -z "$opencode_bin" ]] && opencode_bin=$(command -v opencode 2>/dev/null || true)
+	# 3. Direct PATH lookup. Wrong-product binaries are rejected so discovery
+	# can continue to Node-version-manager and fixed OpenCode-only paths.
+	if [[ -z "$opencode_bin" ]] && command -v opencode &>/dev/null; then
+		opencode_bin=$(_pulse_validate_opencode_candidate "$(command -v opencode)" "$_have_validator" || true)
+	fi
 
 	# 4a. Node version manager sweep (nvm, volta, fnm). Linux-friendly.
 	[[ -z "$opencode_bin" ]] && opencode_bin=$(_sweep_nvm_volta_fnm_for_opencode "$_have_validator" || true)
 
 	# 4b. Legacy fixed-install-paths sweep (Homebrew, npm-global, bun, .local/bin).
 	[[ -z "$opencode_bin" ]] && opencode_bin=$(_sweep_legacy_install_paths_for_opencode "$_have_validator" || true)
-
-	# 5. Last-resort legacy fallback (pre-GH#18439 behaviour).
-	[[ -z "$opencode_bin" ]] && opencode_bin="/opt/homebrew/bin/opencode"
 
 	# Prefer the daemon-visible stable shim when setup can create/validate it.
 	# This keeps systemd workers off nvm/fnm/volta internals while preserving

--- a/.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh
+++ b/.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh
@@ -156,6 +156,15 @@ run_resolver() {
 	)
 }
 
+run_resolver_with_path() {
+	local _fixture_home="$1" _path_prefix="$2"
+	(
+		export HOME="$_fixture_home"
+		export PATH="$_path_prefix:/usr/bin:/bin"
+		_resolve_pulse_runtime_binary
+	)
+}
+
 # --- Source the resolver and validator ---
 # tool-install.sh defines _setup_validate_opencode_binary;
 # schedulers.sh defines _resolve_pulse_runtime_binary and the helpers.
@@ -234,24 +243,19 @@ fi
 rm -rf "$fixture4"
 
 # Test 5: Claude rejection at sweep-time. nvm contains a claude-stub
-# (wrong product) — resolver must skip it and fall through to step 5
-# (/opt/homebrew/bin/opencode), which doesn't exist in the fixture.
-# Result: step 5 default returned but NOT persisted (validator rejects
-# the stub, and step 5's hardcoded path also fails -x check in persistence).
+# (wrong product) — resolver must skip it and return empty when no real
+# OpenCode exists. Empty is safer than a fake legacy fallback because it
+# fails clear instead of persisting or launching the wrong runtime.
 fixture5=$(mktemp -d 2>/dev/null || mktemp -d -t t2954e)
 build_fixture_node_install "$fixture5" "claude" "nvm" "v24.13.1" >/dev/null
 result5=$(run_resolver "$fixture5")
-# Resolver returns the step-5 default ("/opt/homebrew/bin/opencode")
-# even though it doesn't exist — that's the documented last-resort.
-# The test we care about: the claude path was NOT returned and NOT
-# persisted.
 persisted_file5="$fixture5/.config/aidevops/scheduler-runtime-bin"
 claude_path5="$fixture5/.nvm/versions/node/v24.13.1/bin/opencode"
-if [[ "$result5" != "$claude_path5" ]]; then
-	print_result "claude binary in nvm path — rejected by validator, not returned" 0
+if [[ -z "$result5" ]]; then
+	print_result "claude binary in nvm path — rejected; resolver returns empty" 0
 else
-	print_result "claude binary in nvm path — rejected by validator, not returned" 1 \
-		"resolver returned the claude path: $result5"
+	print_result "claude binary in nvm path — rejected; resolver returns empty" 1 \
+		"expected empty result, got: $result5"
 fi
 if [[ ! -f "$persisted_file5" ]] || \
 	[[ "$(cat "$persisted_file5" 2>/dev/null)" != "$claude_path5" ]]; then
@@ -261,6 +265,18 @@ else
 		"persisted file contains claude path"
 fi
 rm -rf "$fixture5"
+
+# Test 5b: Claude fixed path must not be considered an OpenCode fallback.
+fixture5b=$(mktemp -d 2>/dev/null || mktemp -d -t t2954e2)
+claude_path5b=$(build_fixture_fixed_path "$fixture5b" "claude" ".local/bin/claude")
+result5b=$(run_resolver "$fixture5b")
+if [[ -z "$result5b" ]]; then
+	print_result "claude fixed path — not returned as OpenCode fallback" 0
+else
+	print_result "claude fixed path — not returned as OpenCode fallback" 1 \
+		"expected empty result, got=$result5b claude=$claude_path5b"
+fi
+rm -rf "$fixture5b"
 
 # Test 6: Stale wrong-product persisted file — validator drops it and
 # resolver re-resolves to the real opencode binary present in nvm.
@@ -336,6 +352,20 @@ else
 		"result=$result9 expected=$expected9"
 fi
 rm -rf "$fixture9"
+
+# Test 10: Wrong-product direct PATH hit is rejected so discovery continues.
+fixture10=$(mktemp -d 2>/dev/null || mktemp -d -t t2954j)
+build_fixture_fixed_path "$fixture10" "claude" ".path/bin/opencode" >/dev/null
+build_fixture_node_install "$fixture10" "opencode" "nvm" "v24.13.1" >/dev/null
+expected10="$fixture10/.local/bin/opencode"
+result10=$(run_resolver_with_path "$fixture10" "$fixture10/.path/bin")
+if [[ "$result10" == "$expected10" ]]; then
+	print_result "direct PATH claude hit — rejected, continues to nvm OpenCode" 0
+else
+	print_result "direct PATH claude hit — rejected, continues to nvm OpenCode" 1 \
+		"expected=$expected10 got=$result10"
+fi
+rm -rf "$fixture10"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary
- Reject wrong-product `opencode` hits from runtime registry and PATH so discovery can continue to real OpenCode installs.
- Remove Claude fixed paths and the fake `/opt/homebrew/bin/opencode` last-resort from the OpenCode scheduler resolver.
- Add regression coverage for empty fail-clear resolution, Claude fixed-path rejection, and PATH-shadowed Claude continuing to nvm OpenCode.

## Verification
- `.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh` — 14 passed, 0 failed
- `.agents/scripts/tests/test-setup-opencode-cli.sh` — 15 passed, 0 failed
- `shellcheck .agents/scripts/setup/modules/tool-install.sh .agents/scripts/setup/modules/schedulers-pulse.sh .agents/scripts/setup/modules/schedulers-linux.sh .agents/scripts/tests/test-setup-opencode-cli.sh .agents/scripts/tests/test-resolve-pulse-runtime-binary.sh`

Resolves #23012

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.80 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 14h 53m and 902,892 tokens on this with the user in an interactive session.
