### PR TITLE
fix: preserve peer-runner circuit breakers

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -490,33 +490,30 @@ _nmr_applied_by_maintainer() {
 	nmr_actor=$(printf '%s' "$nmr_event_json" | jq -r '.actor // ""' 2>/dev/null) || nmr_actor=""
 	nmr_at=$(printf '%s' "$nmr_event_json" | jq -r '.at // ""' 2>/dev/null) || nmr_at=""
 
-	if [[ "$nmr_actor" != "$maintainer" ]]; then
-		return 1
-	fi
-
-	# Actor matches the maintainer. Three possibilities:
-	#   1. Creation-default signature (scanner applied NMR at creation
-	#      time) → auto-approve OK, return 1.
-	#   2. Circuit-breaker trip signature (t2007/t2008 fired) →
-	#      PRESERVE NMR, return 0 with distinct log line so operators
-	#      see it was a breaker trip, not a manual hold.
-	#   3. No signature → genuine manual hold, return 0.
+	# Breaker signatures are authoritative regardless of the token actor. Pulse can
+	# run under any trusted maintainer/member account, so actor-gating this check
+	# lets a peer runner's dispatch-infrastructure/no_work breaker be auto-cleared
+	# by maintainer auto-approval and re-enter the loop.
 	if [[ -n "$nmr_at" ]]; then
-		# GH#20758: Circuit-breaker check FIRST — a co-temporal breaker
-		# marker is a stronger signal than label persistence. Scanner-
-		# labelled issues that trip a breaker MUST preserve NMR regardless
-		# of creation provenance. The prior order (automation-signature
-		# first) let the label-based branch of _nmr_application_has_
-		# automation_signature short-circuit the breaker check because
-		# scanner labels persist for the issue's lifetime.
 		if _nmr_application_is_circuit_breaker_trip "$issue_num" "$slug" "$nmr_at"; then
-			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — circuit breaker tripped — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}' (t2386/GH#20758)" >>"$LOGFILE"
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — circuit breaker tripped by actor=${nmr_actor:-unknown} — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}' (t2386/t3566)" >>"$LOGFILE"
 			# t3049: check if a subsequent worker produced a clean approved PR
 			# that resolves the stale-recovery false positive. Posts a one-shot
 			# notification to the maintainer if so. Does NOT clear NMR.
 			_notify_stale_recovery_resolved_by_pr "$issue_num" "$slug" "$nmr_at" || true
 			return 0
 		fi
+	fi
+
+	if [[ "$nmr_actor" != "$maintainer" ]]; then
+		return 1
+	fi
+
+	# Actor matches the maintainer. Two remaining possibilities:
+	#   1. Creation-default signature (scanner applied NMR at creation
+	#      time) → auto-approve OK, return 1.
+	#   2. No signature → genuine manual hold, return 0.
+	if [[ -n "$nmr_at" ]]; then
 		if _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
 			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — actor=${maintainer} but creation-default signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
 			return 1

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -538,6 +538,23 @@ test_non_maintainer_actor_auto_approves() {
 	return 0
 }
 
+test_peer_runner_breaker_trip_preserves_nmr() {
+	# Private-project incident pattern: a peer maintainer/member runner applies NMR as part
+	# of a dispatch-infrastructure breaker. The actor is not the configured owner
+	# token, but the breaker marker is authoritative and must prevent maintainer
+	# auto-approval from clearing NMR and re-dispatching into the same loop.
+	set_timeline '[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"peer-runner"},"created_at":"2026-05-06T16:54:57Z"}]'
+	set_comments '[{"created_at":"2026-05-06T16:54:59Z","body":"<!-- dispatch-infrastructure-failure -->\n## Dispatch infrastructure failure detected\nThis issue has accumulated 9 zero-output worker launches."}]'
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"origin:worker"},{"name":"auto-dispatch"}]}'
+	if _nmr_applied_by_maintainer 4248 owner/repo owner-runner; then
+		print_result "peer runner breaker trip preserves NMR" 0
+		return 0
+	fi
+	print_result "peer runner breaker trip preserves NMR" 1 \
+		"Expected exit 0 — breaker marker must preserve NMR regardless of actor"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -578,6 +595,7 @@ main() {
 	test_scanner_default_still_auto_approves
 	test_manual_hold_still_preserves_nmr
 	test_non_maintainer_actor_auto_approves
+	test_peer_runner_breaker_trip_preserves_nmr
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Preserves circuit-breaker NMR holds before actor checks, so peer-runner infrastructure breakers cannot be auto-cleared by maintainer approval.
- Adds a regression covering the zero-output dispatch-infrastructure breaker loop where the NMR label actor differs from the configured maintainer.

For #22965

## Verification
- `shellcheck .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh`
- `bash .agents/scripts/tests/test-pulse-nmr-automation-signature.sh`
- `bash .agents/scripts/tests/test-zero-output-url-fallback.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.80 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 4h 58m and 3,538,090 tokens on this with the user in an interactive session.