### PR TITLE
GH#23024: Quarantine dead worktree owner PIDs

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -26,6 +26,7 @@ _SHARED_WORKTREE_REGISTRY_LOADED=1
 
 WORKTREE_REGISTRY_DIR="${WORKTREE_REGISTRY_DIR:-${HOME}/.aidevops/.agent-workspace}"
 WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DB:-${WORKTREE_REGISTRY_DIR}/worktree-registry.db}"
+WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES="${WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES:-60}"
 
 # Get the command name (basename) for a given PID.
 # Returns empty string if the PID does not exist or info is unavailable.
@@ -242,9 +243,22 @@ _init_registry_db() {
             owner_session TEXT DEFAULT '',
             owner_batch   TEXT DEFAULT '',
             task_id       TEXT DEFAULT '',
+            owner_dead_seen_at TEXT DEFAULT '',
             created_at    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
         );
     " 2>/dev/null || true
+
+	local has_dead_seen_column
+	has_dead_seen_column=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        SELECT 1 FROM pragma_table_info('worktree_owners')
+        WHERE name = 'owner_dead_seen_at';
+    " 2>/dev/null || echo "")
+	if [[ -z "$has_dead_seen_column" ]]; then
+		sqlite3 "$WORKTREE_REGISTRY_DB" "
+            ALTER TABLE worktree_owners
+            ADD COLUMN owner_dead_seen_at TEXT DEFAULT '';
+        " 2>/dev/null || true
+	fi
 	return 0
 }
 
@@ -293,14 +307,15 @@ register_worktree() {
 
 	sqlite3 "$WORKTREE_REGISTRY_DB" "
         INSERT OR REPLACE INTO worktree_owners
-            (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id)
+            (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_dead_seen_at)
         VALUES
 		 ('$(_wt_sql_escape "$wt_path")',
 		  '$(_wt_sql_escape "$branch")',
 		  ${owner_pid},
 		  '$(_wt_sql_escape "$session_id")',
 		  '$(_wt_sql_escape "$batch_id")',
-		  '$(_wt_sql_escape "$task_id")');
+		  '$(_wt_sql_escape "$task_id")',
+		  '');
     " 2>/dev/null || true
 	return 0
 }
@@ -365,14 +380,15 @@ claim_worktree_ownership() {
 
 	sqlite3 "$WORKTREE_REGISTRY_DB" "
         INSERT OR IGNORE INTO worktree_owners
-            (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id)
+            (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_dead_seen_at)
         VALUES
             ('$(_wt_sql_escape "$wt_path")',
              '$(_wt_sql_escape "$branch")',
              ${owner_pid},
              '$(_wt_sql_escape "$session_id")',
              '$(_wt_sql_escape "$batch_id")',
-             '$(_wt_sql_escape "$task_id")');
+             '$(_wt_sql_escape "$task_id")',
+             '');
     " 2>/dev/null || true
 
 	local final_owner_pid
@@ -387,7 +403,8 @@ claim_worktree_ownership() {
             SET branch = '$(_wt_sql_escape "$branch")',
                 owner_session = '$(_wt_sql_escape "$session_id")',
                 owner_batch = '$(_wt_sql_escape "$batch_id")',
-                task_id = '$(_wt_sql_escape "$task_id")'
+                task_id = '$(_wt_sql_escape "$task_id")',
+                owner_dead_seen_at = ''
             WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
         " 2>/dev/null || true
 		return 0
@@ -437,10 +454,72 @@ check_worktree_owner() {
 	return 1
 }
 
-# Check if a worktree is owned by a DIFFERENT process (still alive)
+# Return the timestamp when a dead owner PID was first observed.
 # Arguments:
 #   $1 - worktree path
-# Returns: 0 if owned by another live process, 1 if safe to remove
+# Output: ISO timestamp or empty
+worktree_owner_dead_seen_at() {
+	local wt_path="$1"
+
+	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
+
+	local dead_seen_at
+	dead_seen_at=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        SELECT COALESCE(owner_dead_seen_at, '')
+        FROM worktree_owners
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+    " 2>/dev/null || echo "")
+	printf '%s' "$dead_seen_at"
+	return 0
+}
+
+_wt_owner_dead_cooldown_minutes() {
+	local cooldown_minutes="${WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES:-60}"
+	if [[ ! "$cooldown_minutes" =~ ^[0-9]+$ ]] || [[ "$cooldown_minutes" -lt 1 ]]; then
+		cooldown_minutes=60
+	fi
+	printf '%s' "$cooldown_minutes"
+	return 0
+}
+
+_wt_mark_owner_dead_seen() {
+	local wt_path="$1"
+
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET owner_dead_seen_at = CASE
+            WHEN COALESCE(owner_dead_seen_at, '') = '' THEN strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+            ELSE owner_dead_seen_at
+        END
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+    " 2>/dev/null || true
+	return 0
+}
+
+_wt_owner_dead_cooldown_expired() {
+	local wt_path="$1"
+	local cooldown_minutes
+	cooldown_minutes=$(_wt_owner_dead_cooldown_minutes)
+
+	local expired
+	expired=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        SELECT CASE
+            WHEN COALESCE(owner_dead_seen_at, '') != ''
+             AND datetime(replace(replace(owner_dead_seen_at, 'T', ' '), 'Z', ''), '+${cooldown_minutes} minutes') <= datetime('now')
+            THEN 1 ELSE 0 END
+        FROM worktree_owners
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+    " 2>/dev/null || echo "0")
+	[[ "$expired" == "1" ]] && return 0
+	return 1
+}
+
+# Check if a worktree is owned by a DIFFERENT process or quarantined stale owner.
+# Arguments:
+#   $1 - worktree path
+# Returns: 0 if owned by another live process or within stale-owner cooldown,
+#          1 if safe to remove
 is_worktree_owned_by_others() {
 	local wt_path="$1"
 
@@ -465,12 +544,25 @@ is_worktree_owned_by_others() {
 	my_pid=$(_resolve_worktree_owner_pid "")
 	[[ "$owner_pid" == "$my_pid" ]] && return 1
 
-	# Owner process is dead — stale entry, safe to remove
+	# Owner process is dead. Keep the ownership row quarantined for a cooldown
+	# window so cleanup never treats one failed PID probe as immediate abandon.
 	if ! kill -0 "$owner_pid" 2>/dev/null; then
-		# Clean up stale entry
-		unregister_worktree "$wt_path"
-		return 1
+		_wt_mark_owner_dead_seen "$wt_path"
+		if _wt_owner_dead_cooldown_expired "$wt_path"; then
+			unregister_worktree "$wt_path"
+			return 1
+		fi
+		return 0
 	fi
+
+	# Owner recovered or PID was reused while still registered; clear any stale
+	# marker so a later dead observation gets a fresh cooldown window.
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET owner_dead_seen_at = ''
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
+          AND COALESCE(owner_dead_seen_at, '') != '';
+    " 2>/dev/null || true
 
 	# Owner process is alive and it's not us — NOT safe to remove
 	return 0

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worktree-registry-dead-owner.sh — GH#23024 regression guard.
+#
+# Verifies that a dead registry owner PID is quarantined before cleanup may
+# unregister it, preventing a single stale PID probe from deleting active
+# worktrees after an AI runtime crash/restart.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REGISTRY_LIB="${SCRIPT_DIR}/../shared-worktree-registry.sh"
+CLEAN_LIB="${SCRIPT_DIR}/../worktree-clean-lib.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s %s\n' "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_ROOT=$(mktemp -d)
+	export WORKTREE_REGISTRY_DIR="${TEST_ROOT}/registry"
+	export WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
+	export WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES=60
+	# shellcheck source=../shared-worktree-registry.sh
+	source "$REGISTRY_LIB"
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+make_worktree_dir() {
+	local name="$1"
+	local wt_path="${TEST_ROOT}/${name}"
+	mkdir -p "$wt_path"
+	printf '%s' "$wt_path"
+	return 0
+}
+
+assert_owner_exists() {
+	local wt_path="$1"
+	local owner_info=""
+	owner_info=$(check_worktree_owner "$wt_path" 2>/dev/null || true)
+	[[ -n "$owner_info" ]] && return 0
+	return 1
+}
+
+assert_owner_missing() {
+	local wt_path="$1"
+	local owner_info=""
+	owner_info=$(check_worktree_owner "$wt_path" 2>/dev/null || true)
+	[[ -z "$owner_info" ]] && return 0
+	return 1
+}
+
+test_dead_owner_first_pass_quarantines() {
+	local wt_path
+	wt_path=$(make_worktree_dir "dead-owner-first")
+	register_worktree "$wt_path" "feature/dead-owner-first" --owner-pid 999999
+
+	local rc=0
+	if ! is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_exists "$wt_path" || rc=1
+	[[ -n "$(worktree_owner_dead_seen_at "$wt_path")" ]] || rc=1
+	print_result "dead owner first pass is quarantined" "$rc"
+	return 0
+}
+
+test_dead_owner_within_cooldown_keeps_skip() {
+	local wt_path
+	wt_path=$(make_worktree_dir "dead-owner-cooldown")
+	register_worktree "$wt_path" "feature/dead-owner-cooldown" --owner-pid 999999
+	is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1
+
+	local rc=0
+	if ! is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_exists "$wt_path" || rc=1
+	print_result "dead owner within cooldown still blocks cleanup" "$rc"
+	return 0
+}
+
+test_dead_owner_after_cooldown_unregisters() {
+	local wt_path
+	wt_path=$(make_worktree_dir "dead-owner-expired")
+	register_worktree "$wt_path" "feature/dead-owner-expired" --owner-pid 999999
+	is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1
+	local registry_path
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET owner_dead_seen_at = '2020-01-01T00:00:00Z'
+        WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+    "
+	export WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES=1
+
+	local rc=0
+	if is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_missing "$wt_path" || rc=1
+	print_result "dead owner after cooldown unregisters" "$rc"
+	return 0
+}
+
+test_should_skip_cleanup_branch_merged_within_grace() {
+	local wt_path
+	wt_path=$(make_worktree_dir "branch-merged-grace")
+	local rc
+	rc=$(
+		set +e
+		is_worktree_owned_by_others() { return 1; }
+		check_worktree_owner() { printf '%s\n' ''; return 0; }
+		worktree_is_in_grace_period() { return 0; }
+		get_validated_grace_hours() { printf '%s\n' '4'; return 0; }
+		worktree_has_changes() { return 1; }
+		branch_has_zero_commits_ahead() { return 1; }
+		_branch_has_active_interactive_claim() { return 1; }
+		log_worktree_removal_event() { return 0; }
+		: "${RED:=}" "${GREEN:=}" "${YELLOW:=}" "${BLUE:=}" "${BOLD:=}" "${NC:=}"
+		_WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"
+		_WTAR_WH_CALLER="${_WTAR_WH_CALLER:-test}"
+		export RED GREEN YELLOW BLUE BOLD NC _WTAR_SKIPPED _WTAR_WH_CALLER
+		# shellcheck source=../worktree-clean-lib.sh
+		source "$CLEAN_LIB" >/dev/null 2>&1 || exit 9
+		should_skip_cleanup "$wt_path" "feature/branch-merged-grace" "main" "" "false" >/dev/null 2>&1
+		printf '%s' "$?"
+	)
+	if [[ "$rc" == "0" ]]; then
+		print_result "branch-merged worktree within grace still skips" 0
+	else
+		print_result "branch-merged worktree within grace still skips" 1 "(rc=$rc)"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	trap teardown EXIT
+	printf 'Running worktree registry dead-owner tests\n'
+	test_dead_owner_first_pass_quarantines
+	test_dead_owner_within_cooldown_keeps_skip
+	test_dead_owner_after_cooldown_unregisters
+	test_should_skip_cleanup_branch_merged_within_grace
+	printf 'Results: %s/%s passed, %s failed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]] && return 0
+	return 1
+}
+
+main "$@"

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -221,6 +221,18 @@ should_skip_cleanup() {
 		owner_info=$(check_worktree_owner "$wt_path")
 		local owner_pid
 		owner_pid="${owner_info%%|*}"
+		local owner_dead_seen_at=""
+		if declare -F worktree_owner_dead_seen_at >/dev/null 2>&1; then
+			owner_dead_seen_at=$(worktree_owner_dead_seen_at "$wt_path")
+		fi
+		if [[ -n "$owner_dead_seen_at" ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+			echo -e "  ${RED}$wt_branch${NC} (dead owner PID $owner_pid in cooldown since $owner_dead_seen_at - skipping)"
+			echo "    $wt_path"
+			echo ""
+			# GH#23024: audit log — cleanup skipped, stale owner is quarantined
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owner-pid-dead" "skipped"
+			return 0
+		fi
 		echo -e "  ${RED}$wt_branch${NC} (owned by active session PID $owner_pid - skipping)"
 		echo "    $wt_path"
 		echo ""


### PR DESCRIPTION
## Summary

Adds a dead-owner cooldown marker to the worktree registry so cleanup skips stale owner PIDs for a recheck window before unregistering them.

## Files Changed

.agents/scripts/shared-worktree-registry.sh,.agents/scripts/tests/test-worktree-registry-dead-owner.sh,.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-registry-dead-owner.sh; bash .agents/scripts/tests/test-worktree-removal-audit.sh; bash .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh; shellcheck modified scripts; .agents/scripts/linters-local.sh

Resolves #23024


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.81 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 22m and 143,025 tokens on this with the user in an interactive session.