### PR TITLE
Clarify task intent routing

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -43,6 +43,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 ### Task and completion discipline
 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
+- Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
 - Drive to verified completion. Run relevant tests/lint/build before claiming done; if not verified, say so.
 - Never present intent as completed work. Every claim needs proof: path, command result, PR/issue number, or metric.
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.

--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -20,7 +20,7 @@ For prompt-economy reasons these rules live here rather than in always-on AGENTS
 1. Define the task: `/define` (interactive interview) or `/new-task` (quick creation)
 2. Brief file at `todo/tasks/{task_id}-brief.md` is MANDATORY (see `templates/brief-template.md`)
 3. Brief must include: session origin, what, why, how, acceptance criteria, context
-4. Ask user: implement now or queue for runner?
+4. Resolve the user's execution intent before stopping: implement now, queue/dispatch in the background, or save for later.
 5. Full-loop: keep canonical repo on `main` → create/use linked worktree → implement → test → verify → commit/PR
 6. Queue: add to TODO.md for supervisor dispatch
 7. Never skip testing. Never declare "done" without verification.
@@ -43,6 +43,43 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 **Brief composition**: All GitHub-written content (issue bodies, briefs, PR descriptions, comments, escalation reports, worker guidance) follows `workflows/brief.md` — the centralised formatting workflow. Load it before publishing; optional seeded draft PRs are governed there, not in this root guide.
 
 **Model tiers and dispatchability**: Use GitHub `tier:*` labels; default to `tier:standard` when uncertain. Before recommending a tier or queueing work, run `task-dispatchability-helper.sh check --task-id tNNN [--issue N]`. Full tier rules live in `reference/task-taxonomy.md`; `tier-simple-body-shape-helper.sh` still enforces high-confidence simple-tier downgrades pre-dispatch.
+
+## Conversation Intent Routing
+
+Natural-language task capture must be as explicit as slash commands. When a user gives work that could become a TODO or issue, first classify the intent:
+
+| User signal | Route | Confirmation |
+|-------------|-------|--------------|
+| `/full-loop ...`, issue/task number after `/full-loop`, "do/work/fix/implement this now", "in this session" | Start `/full-loop` with the instruction or resolved issue/task | Do not ask whether to start; proceed unless blocked by safety/secret/destructive gates |
+| "background", "worker", "auto-dispatch", "have an agent do this" | Compose with `workflows/brief.md`, create TODO/issue with `#auto-dispatch` when readiness passes, and queue/dispatch | Ask only for missing secrets, destructive approval, unknown repo, or unavailable verification |
+| "save", "log", "for later", `/save-todo`, `/aidevops-save-todo` | Compose with `workflows/brief.md`; save as TODO/plan/issue for later | After saving, ask numbered dispatch options |
+| Ambiguous "we need to...", "should add...", "can you note..." | Ask a numbered intent question before creating or executing | Use the shortest option set that disambiguates now/later/background |
+
+Default prompt for ambiguous implementation work:
+
+```text
+Do you want to:
+1. Work on this now with /full-loop
+2. Save as a TODO for later
+3. Save as a TODO and auto-dispatch a background worker
+4. Create a GitHub issue
+5. Create a GitHub issue and auto-dispatch a worker
+
+Reply 1-5.
+```
+
+Default prompt after explicit save/later intent:
+
+```text
+Saved as {task_or_issue} with a worker-ready brief.
+
+Auto-dispatch a worker?
+1. Yes, start now in the background
+2. Later
+3. No, keep it manual
+```
+
+Do not end a save flow with only "start anytime" when the task is worker-ready; offer the numbered dispatch choice. If a brief cannot meet auto-dispatch readiness, state the blocker and the missing information needed.
 
 ## Auto-Dispatch and Completion
 

--- a/.agents/workflows/save-todo.md
+++ b/.agents/workflows/save-todo.md
@@ -7,9 +7,35 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Analyze the current conversation and save appropriately based on complexity.
+Analyze the current conversation, compose a worker-ready brief, and save appropriately based on complexity and execution intent.
 
 Topic/context: $ARGUMENTS
+
+## Core Rule
+
+All TODOs, plans, and issues created by this workflow MUST use `workflows/brief.md` and `templates/brief-template.md` so future workers can execute without the original chat. Saving is not implementation; if the user says `/full-loop`, "work on it now", or equivalent, route to `/full-loop` instead of stopping after capture.
+
+## Intent Routing
+
+| Signal | Action |
+|--------|--------|
+| `/full-loop`, "work on this now", "fix/implement/do this in this session" | Start `/full-loop $ARGUMENTS`; do not ask whether to begin |
+| "background", "worker", "auto-dispatch" | Create a briefed TODO/issue and add `#auto-dispatch` when readiness passes |
+| "save", "log", "for later", `/save-todo`, `/aidevops-save-todo` | Save the briefed task, then ask whether to auto-dispatch now/later/not |
+| Ambiguous "we need to", "should add", "can you note" | Ask the numbered intent prompt before saving or implementing |
+
+Ambiguous prompt:
+
+```text
+Do you want to:
+1. Work on this now with /full-loop
+2. Save as a TODO for later
+3. Save as a TODO and auto-dispatch a background worker
+4. Create a GitHub issue
+5. Create a GitHub issue and auto-dispatch a worker
+
+Reply 1-5.
+```
 
 ## Auto-Detection
 
@@ -25,6 +51,7 @@ Topic/context: $ARGUMENTS
 - **Estimate**: `~Xh (ai:Xh test:Xh read:Xm)`
 - **Tags**: #feature, #bugfix, #enhancement, #docs, etc.
 - **Context**: Decisions, findings, constraints, open questions, links
+- **Brief**: Create `todo/tasks/{task_id}-brief.md` from `templates/brief-template.md` using `workflows/brief.md` pre-composition checks.
 
 ## Step 1b: Dispatch Tags (MANDATORY)
 
@@ -36,10 +63,10 @@ Topic/context: $ARGUMENTS
 
 ## Step 2: Save
 
-**Simple** → add to TODO.md Backlog and confirm:
+**Simple** → create `todo/tasks/{task_id}-brief.md`, add to TODO.md Backlog, and confirm:
 
 ```markdown
-- [ ] {title} #{tag} #auto-dispatch ~{estimate} logged:{YYYY-MM-DD}
+- [ ] t{NNN} {title} #{tag} #auto-dispatch ~{estimate} logged:{YYYY-MM-DD}
 ```
 
 **Complex** → confirm, then:
@@ -76,43 +103,58 @@ Topic/context: $ARGUMENTS
 (To be populated during implementation)
 ```
 
-2. Add reference to TODO.md Backlog:
+2. Create `todo/tasks/{task_id}-brief.md` with implementation context or a plan handoff.
+3. Add reference to TODO.md Backlog:
 
 ```markdown
 - [ ] {title} #plan → [todo/PLANS.md#{slug}] ~{estimate} logged:{YYYY-MM-DD}
 ```
 
-3. Optionally create PRD/tasks files if scope warrants.
+4. Optionally create PRD/tasks files if scope warrants.
 
 ## Confirmation Prompts
 
 **Simple:**
 
 ```text
-Saving to TODO.md: "{title}" ~{estimate}
+Saving to TODO.md: "{title}" ~{estimate} | Creating brief: todo/tasks/{task_id}-brief.md
 1. Confirm  2. Add more details  3. Create full plan instead
 ```
 
 **Complex:**
 
 ```text
-This looks like complex work. Creating execution plan.
+This looks like complex work. Creating execution plan and brief.
 Title: {title} | Estimate: ~{estimate} | Phases: {count}
-1. Confirm and create plan  2. Simplify to TODO.md  3. Add context
+1. Confirm and create plan + brief  2. Simplify to TODO.md + brief  3. Add context
 ```
 
-After saving, respond: `Saved: "{title}" — Start anytime with: "Let's work on {title}"`
+After saving, do not respond with only "Start anytime". Use:
+
+```text
+Saved as {task_id}: "{title}" with brief {brief_path}.
+
+Auto-dispatch a worker?
+1. Yes, start now in the background
+2. Later
+3. No, keep it manual
+```
+
+If the task was created with explicit background/worker intent and dispatch readiness passes, report the queued/dispatch action instead of asking.
 
 ## Example
 
 ```text
 User: We discussed the authentication overhaul with OAuth, session management, and migration
-AI:   Complex work. Title: Authentication Overhaul | ~2w | 4 phases
-      1. Confirm  2. Simplify  3. Add context
+AI:   Complex work. Title: Authentication Overhaul | ~2w | 4 phases | Creating brief: todo/tasks/{task_id}-brief.md
+      1. Confirm and create plan + brief  2. Simplify to TODO.md + brief  3. Add context
 User: 1
-AI:   Saved: "Authentication Overhaul"
+AI:   Saved as t123: "Authentication Overhaul" with brief todo/tasks/t123-brief.md
       - Plan: todo/PLANS.md
       - Reference: TODO.md
       - PRD: todo/tasks/prd-auth-overhaul.md
-      Start anytime with: "Let's work on auth overhaul"
+      Auto-dispatch a worker?
+      1. Yes, start now in the background
+      2. Later
+      3. No, keep it manual
 ```


### PR DESCRIPTION
## Summary

- Add always-loaded pointer for task intent routing so `/full-loop`, background-worker, and save-for-later phrasing resolve consistently.
- Document conversation scenario routing in task lifecycle guidance with numbered prompts for ambiguous and saved tasks.
- Update `/save-todo` workflow knowledge to require `workflows/brief.md`/`brief-template.md` and stop ending worker-ready saves with only a "start anytime" message.

## Testing

- `.agents/scripts/linters-local.sh` (passes; existing warnings reported for Qlty smells, ratchet advisories, repository layout drift, and pre-existing complexity/nesting counts)
- `git diff --check`

## Notes

- Resolves #23028
- Intentional always-loaded AGENTS.md change is a one-line pointer; scenario detail lives in `.agents/reference/task-lifecycle.md` to preserve progressive disclosure.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.82 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 20m and 234,249 tokens on this with the user in an interactive session.
