### PR TITLE
GH#23032: simplify stale brief rewrite requeue labels

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -444,10 +444,6 @@ _normalize_requeue_stale_brief_rewrite_rows() {
 			"$add_label_flag" "$_PIR_STATUS_AVAILABLE"
 			"$remove_label_flag" "$_PIR_NEEDS_BRIEF_REWRITE"
 		)
-		local status_label=""
-		for status_label in "$_PIR_STATUS_QUEUED" "$_PIR_STATUS_CLAIMED" "$_PIR_STATUS_IN_PROGRESS" "$_PIR_STATUS_IN_REVIEW" "$_PIR_STATUS_BLOCKED" "$_PIR_STATUS_DONE"; do
-			brief_flags+=("$remove_label_flag" "$status_label")
-		done
 		IFS=',' read -r -a brief_assignee_array <<<"$brief_assignees"
 		for brief_assignee in "${brief_assignee_array[@]}"; do
 			[[ -n "$brief_assignee" ]] && brief_flags+=("$remove_assignee_flag" "$brief_assignee")


### PR DESCRIPTION
## Summary

Simplified stale brief-rewrite requeue flags by removing redundant status label removals that are excluded by row selection.

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-issue-reconcile.sh; shellcheck .agents/scripts/pulse-issue-reconcile.sh

Resolves #23032


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.83 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 3m and 75,088 tokens on this as a headless worker.