### PR TITLE
GH#23035: close recovered merge-stuck meta issues

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -916,6 +916,38 @@ Filed automatically by \`pulse-merge-stuck.sh\` (t3193). The detector resets the
 	return 0
 }
 
+_pms_close_zero_progress_meta_issue_if_recovered() {
+	local reason="$1"
+	local meta_repo="marcusquinn/aidevops"
+	local marker_text="merge-stuck:zero-progress"
+
+	[[ -n "$reason" ]] || reason="merge progress recovered"
+
+	local existing
+	existing=$(gh issue list --repo "$meta_repo" --state open --search "$marker_text" \
+		--limit 1 --json number --jq '.[0].number' 2>/dev/null) || existing=""
+	if [[ -z "$existing" || "$existing" == "$_PMS_JQ_NULL_GUARD" ]]; then
+		return 0
+	fi
+	[[ "$existing" =~ ^[0-9]+$ ]] || return 0
+
+	local body
+	body="## Recovery detected
+
+The pulse merge zero-progress detector recovered automatically: ${reason}.
+
+Evidence:
+- pulse_merge_zero_progress_cycles was reset to 0.
+- The next detector cycle can file a fresh issue if throughput collapses again.
+
+Closing this stale zero-progress meta-issue so auto-dispatch does not spend worker capacity on an already-recovered incident."
+
+	gh issue comment "$existing" --repo "$meta_repo" --body "$body" >/dev/null 2>&1 || true
+	gh issue close "$existing" --repo "$meta_repo" --reason completed >/dev/null 2>&1 || true
+	echo "[pulse-merge-stuck] _pms_close_zero_progress_meta_issue_if_recovered: closed #${existing} — ${reason}" >>"$LOGFILE"
+	return 0
+}
+
 # ── Module entry point — called once per pulse cycle, per repo ─────────────
 
 #######################################
@@ -1236,9 +1268,16 @@ pulse_merge_zero_progress_record() {
 	[[ "$eligible_unmerged" =~ ^[0-9]+$ ]] || eligible_unmerged=0
 	[[ "$merged_count" =~ ^[0-9]+$ ]] || merged_count=0
 
+	local cur_before
+	cur_before=$(pulse_stats_get_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES")
+	[[ "$cur_before" =~ ^[0-9]+$ ]] || cur_before=0
+
 	# Successful merge resets the counter.
 	if [[ "$merged_count" -gt 0 ]]; then
 		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
+		if [[ "$cur_before" -gt 0 ]]; then
+			_pms_close_zero_progress_meta_issue_if_recovered "${merged_count} PR(s) merged after a ${cur_before}-cycle zero-progress streak"
+		fi
 		return 0
 	fi
 
@@ -1247,6 +1286,9 @@ pulse_merge_zero_progress_record() {
 	# idle cycles and file a stale throughput-collapse issue later.
 	if [[ "$eligible_unmerged" -le 0 ]]; then
 		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
+		if [[ "$cur_before" -gt 0 ]]; then
+			_pms_close_zero_progress_meta_issue_if_recovered "eligible-unmerged dropped to 0 after a ${cur_before}-cycle zero-progress streak"
+		fi
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -234,6 +234,27 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "--- Section 5: zero_progress_record transitions ---"
 
+GH_CALLS="$TEST_TMPDIR/gh-calls.log"
+: >"$GH_CALLS"
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
+export GH_CALLS PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE
+
+gh() {
+	local command_name="$1"
+	local subcommand="$2"
+	if [[ "$command_name" == "issue" && "$subcommand" == "list" ]]; then
+		if [[ -n "${PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE:-}" ]]; then
+			printf '%s\n' "$PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE"
+		fi
+		return 0
+	fi
+	if [[ "$command_name" == "issue" && ( "$subcommand" == "comment" || "$subcommand" == "close" ) ]]; then
+		printf '%s\n' "gh $*" >>"$GH_CALLS"
+		return 0
+	fi
+	return 1
+}
+
 # Reset gauge for a clean state.
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
 
@@ -261,9 +282,19 @@ got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
 assert_eq "5d: second consecutive zero-progress → 1→2" "2" "$got"
 
 # 5e: a successful merge then resets the streak to 0.
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE="23035"
 pulse_merge_zero_progress_record 4 1 >/dev/null 2>&1
 got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
 assert_eq "5e: merge during stuck-streak resets cycles to 0" "0" "$got"
+if grep -q 'gh issue close 23035 --repo marcusquinn/aidevops --reason completed' "$GH_CALLS"; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5f: recovered zero-progress meta-issue is auto-closed"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5f: recovered zero-progress meta-issue is auto-closed"
+	echo "  gh calls: $(cat "$GH_CALLS")"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added zero-progress recovery handling so a successful merge or idle reset comments on and closes the stale merge-stuck meta issue instead of leaving it available for dispatch.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-stuck.sh; shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh; .agents/scripts/linters-local.sh progressed through core gates but timed out during later portability audit after prior gates passed/advisory-only warnings

Resolves #23035


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.83 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 11m and 198,165 tokens on this with the user in an interactive session.