### PR TITLE
GH#23036: separate worker interruptions from rate limits

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -813,6 +813,21 @@ _handle_run_result() {
 			print_warning "$selected_model activity watchdog timeout (no activity) — classifying as rate_limit for rotation"
 		fi
 	else
+		if [[ "$exit_code" -eq 137 && "$activity_detected" == "1" ]]; then
+			local discovered_session_for_signal_continue
+			discovered_session_for_signal_continue=$(extract_session_id_from_output "$output_file")
+			if [[ "$role" != "pulse" && -n "$discovered_session_for_signal_continue" ]]; then
+				store_session_id "$provider" "$session_key" "$discovered_session_for_signal_continue" "$selected_model"
+			fi
+			_run_result_label="signal_killed_continue"
+			_run_failure_reason="signal_killed_continue"
+			_run_runtime_error_type="sigkill"
+			_run_classification_source="worker_exit_diagnostics"
+			_run_classification_pattern="exit_137_with_activity"
+			rm -f "$output_file"
+			print_warning "$selected_model worker exited with SIGKILL after activity — will attempt session continuation"
+			return 78
+		fi
 		failure_reason=$(classify_failure_reason "$output_file")
 	fi
 	_run_result_label="$failure_reason"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -112,6 +112,70 @@ classify_failure_reason() {
 	_failure_runtime_error_type=""
 	_failure_classification_source="output_pattern"
 	_failure_classification_pattern=""
+	local classification=""
+	local classified_reason="" classified_provider_type="" classified_status="" classified_source="" classified_pattern=""
+	classification=$(
+		python3 - "$file_path" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+trusted_chunks = []
+provider_line = re.compile(r"\b(openai|anthropic|claude|provider|api)\b", re.I)
+runtime_line = re.compile(r"\[(worker_exit_diagnostics|provider_error|runtime_error)\]", re.I)
+
+for raw_line in Path(sys.argv[1]).read_text(errors='ignore').splitlines():
+    line = raw_line.strip()
+    if not line:
+        continue
+    trusted = False
+    if line.startswith("{"):
+        try:
+            obj = json.loads(line)
+        except Exception:
+            obj = None
+        if isinstance(obj, dict):
+            has_provider = bool(obj.get('provider') or obj.get('provider_error_type') or obj.get('provider_status'))
+            has_error_record = any(key in obj for key in ('error', 'status', 'provider_error_type', 'provider_status'))
+            if has_provider and has_error_record:
+                trusted = True
+    elif provider_line.search(line) or runtime_line.search(line):
+        trusted = True
+    if trusted:
+        trusted_chunks.append(line)
+
+text = '\n'.join(trusted_chunks).lower()
+if not text:
+    sys.exit(0)
+
+def emit(reason, provider_type, status, pattern):
+    print('\t'.join([reason, provider_type, status, 'trusted_provider', pattern]))
+
+if any(token in text for token in ('rate limit', 'rate_limit', 'too many requests', 'quota exceeded')) or re.search(r'\b429\b', text):
+    emit('rate_limit', 'rate_limit', '429', 'trusted_rate_limit|429|too_many_requests|quota_exceeded')
+elif re.search(r'\b(500|502|503|504)\b', text) or any(token in text for token in ('server_error', 'internal server error', 'service unavailable', 'bad gateway', 'gateway timeout', 'connection refused', 'connection reset', 'overloaded')):
+    status = '500'
+    if '504' in text or 'gateway timeout' in text:
+        status = '504'
+    elif '503' in text or 'service unavailable' in text:
+        status = '503'
+    elif '502' in text or 'bad gateway' in text:
+        status = '502'
+    emit('provider_error', 'server_error', status, 'trusted_server_error|5xx|connection_failure|overloaded')
+elif re.search(r'\b(401)\b', text) or any(token in text for token in ('unauthorized', 'invalid api key', 'authentication failed', 'token refresh failed', 'invalid_grant', 'invalid refresh token')) or ('auth' in text and 'failed' in text):
+    emit('auth_error', 'auth_error', '401', 'trusted_auth_error|401|token_refresh|invalid_grant')
+PY
+	)
+	if [[ -n "$classification" ]]; then
+		IFS=$'\t' read -r classified_reason classified_provider_type classified_status classified_source classified_pattern <<<"$classification"
+		_failure_provider_error_type="$classified_provider_type"
+		_failure_provider_status="$classified_status"
+		_failure_classification_source="$classified_source"
+		_failure_classification_pattern="$classified_pattern"
+		printf '%s' "$classified_reason"
+		return 0
+	fi
 	local lowered
 	lowered=$(
 		python3 - "$file_path" <<'PY'
@@ -120,13 +184,6 @@ import sys
 print(Path(sys.argv[1]).read_text(errors="ignore").lower())
 PY
 	)
-	if [[ "$lowered" == *"rate limit"* ]] || [[ "$lowered" == *"rate_limit"* ]] || [[ "$lowered" == *"429"* ]] || [[ "$lowered" == *"too many requests"* ]] || [[ "$lowered" == *"quota exceeded"* ]]; then
-		_failure_provider_error_type="rate_limit"
-		_failure_provider_status="429"
-		_failure_classification_pattern="rate_limit|rate_limit|429|too_many_requests|quota_exceeded"
-		printf '%s' "rate_limit"
-		return 0
-	fi
 	if [[ "$lowered" == *"sqliteerror: disk i/o error"* ]] || [[ "$lowered" == *"sqlite_error"* && "$lowered" == *"disk i/o"* ]]; then
 		_failure_runtime_error_type="opencode_sqlite_io"
 		_failure_classification_source="opencode_runtime"
@@ -141,29 +198,9 @@ PY
 		printf '%s' "local_error"
 		return 0
 	fi
-	# Distinguish actual provider errors (5xx, connection refused, timeout)
-	# from local/worker failures (sandbox crash, bad prompt, opencode bug).
-	# Only provider errors should trigger backoff -- local failures don't
-	# mean the provider is unhealthy.
-	if [[ "$lowered" =~ (server_error|500|502|503|504|internal\ server\ error|service\ unavailable|bad\ gateway|gateway\ timeout|connection\ refused|connection.*reset|overloaded) ]]; then
-		_failure_provider_error_type="server_error"
-		case "$lowered" in
-		*"504"* | *"gateway timeout"*) _failure_provider_status="504" ;;
-		*"503"* | *"service unavailable"*) _failure_provider_status="503" ;;
-		*"502"* | *"bad gateway"*) _failure_provider_status="502" ;;
-		*) _failure_provider_status="500" ;;
-		esac
-		_failure_classification_pattern="server_error|5xx|connection_failure|overloaded"
-		printf '%s' "provider_error"
-		return 0
-	fi
-	if [[ "$lowered" =~ (unauthorized|401|invalid\ api\ key|authentication\ failed|token\ refresh\ failed|invalid_grant|invalid\ refresh\ token) ]] || [[ "$lowered" == *"auth"* && "$lowered" == *"failed"* ]]; then
-		_failure_provider_error_type="auth_error"
-		_failure_provider_status="401"
-		_failure_classification_pattern="auth_error|401|token_refresh|invalid_grant"
-		printf '%s' "auth_error"
-		return 0
-	fi
+	# Provider/rate-limit/auth/server classification intentionally uses only
+	# trusted chunks above. Generic tool output, file reads, docs, and skill
+	# content can mention provider failures and must not trigger backoff.
 	# Default: local_error -- do NOT record provider backoff for this
 	_failure_classification_source="default_local"
 	_failure_classification_pattern="default_local"

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -79,18 +79,28 @@ echo "${TEST_BLUE}=== headless runtime failure classification tests ===${TEST_NC
 check_classification \
 	"openai_rate_limit" \
 	'{"provider":"openai","error":{"type":"rate_limit","message":"Too many requests"},"status":429}' \
-	"rate_limit" "rate_limit" "429" "" "output_pattern"
+	"rate_limit" "rate_limit" "429" "" "trusted_provider"
+
+check_classification \
+	"untrusted_tool_output_mentions_rate_limit" \
+	'{"type":"tool-result","part":{"tool":"Read","output":"Documentation says rate limit text appears here"}}' \
+	"local_error" "" "" "" "default_local"
 
 check_classification \
 	"openai_server_error" \
 	'{"provider":"openai","error":{"type":"server_error","message":"The server had an error"},"status":500}
 session.processor error: undefined is not an object' \
-	"provider_error" "server_error" "500" "" "output_pattern"
+	"provider_error" "server_error" "500" "" "trusted_provider"
+
+check_classification \
+	"openai_service_unavailable" \
+	'{"provider":"openai","error":{"type":"server_error","message":"service unavailable"},"status":503}' \
+	"provider_error" "server_error" "503" "" "trusted_provider"
 
 check_classification \
 	"auth_failure" \
 	'OpenAI authentication failed: invalid API key; status 401 unauthorized' \
-	"auth_error" "auth_error" "401" "" "output_pattern"
+	"auth_error" "auth_error" "401" "" "trusted_provider"
 
 check_classification \
 	"opencode_sqlite_crash" \

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -140,6 +140,32 @@ test_startup_no_activity_timeout_returns_watchdog_continue() {
 	return 0
 }
 
+test_sigkill_with_activity_attempts_continuation() {
+	local output_file="${TEST_ROOT}/sigkill-with-activity.jsonl"
+	cat >"$output_file" <<'EOF'
+{"type":"text","text":"I made a change after reading docs that mention rate limit."}
+[WORKER_EXIT_DIAGNOSTICS] exit_code=137 model=openai/gpt-5.5 role=worker session_key=issue-23036
+[WORKER_EXIT_DIAGNOSTICS] cause=SIGKILL (OOM or external kill)
+EOF
+	_run_result_label=""
+	_run_failure_reason=""
+	_run_runtime_error_type=""
+	_run_classification_source=""
+	_run_classification_pattern=""
+
+	local status=0
+	_handle_run_result 137 "$output_file" "worker" "openai" "issue-23036" "openai/gpt-5.5" || status=$?
+
+	if [[ "$status" -eq 78 && "$_run_result_label" == "signal_killed_continue" && "$_run_runtime_error_type" == "sigkill" && ! -f "$output_file" ]]; then
+		print_result "SIGKILL with activity attempts continuation" 0
+		return 0
+	fi
+
+	print_result "SIGKILL with activity attempts continuation" 1 \
+		"status=$status label=${_run_result_label:-<empty>} runtime=${_run_runtime_error_type:-<empty>} output_exists=$([[ -f "$output_file" ]] && printf yes || printf no)"
+	return 0
+}
+
 test_dispatcher_initial_model_can_rotate_after_rate_limit() {
 	local result status action next_model
 	result=$(
@@ -587,7 +613,7 @@ test_failure_classifier_records_provenance() {
 	if [[ "$reason" == "rate_limit" ]] &&
 		[[ "${_failure_provider_error_type:-}" == "rate_limit" ]] &&
 		[[ "${_failure_provider_status:-}" == "429" ]] &&
-		[[ "${_failure_classification_source:-}" == "output_pattern" ]] &&
+		[[ "${_failure_classification_source:-}" == "trusted_provider" ]] &&
 		[[ "${_failure_classification_pattern:-}" == *"too_many_requests"* ]]; then
 		print_result "failure classifier records provider provenance" 0
 		return 0
@@ -1218,6 +1244,7 @@ main() {
 	test_non_full_loop_prompt_unchanged
 	test_parse_initial_model_does_not_set_explicit_override
 	test_startup_no_activity_timeout_returns_watchdog_continue
+	test_sigkill_with_activity_attempts_continuation
 	test_dispatcher_initial_model_can_rotate_after_rate_limit
 	test_explicit_model_override_remains_pinned_on_rate_limit
 	test_issue_worker_env_contract_rejects_missing_env


### PR DESCRIPTION
## Summary

Classify provider failures from trusted evidence only, keep generic tool/read output from causing rate-limit backoff, and continue resumable SIGKILL exits with prior activity.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-failure-classification.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted regression tests passed: test-headless-runtime-failure-classification.sh and test-headless-runtime-helper.sh; ShellCheck passed for changed shell files; linters-local.sh rerun showed no new string-literal regression but existing repository complexity/nesting debt and a transient pulse canary exit 143.

Resolves #23036


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.84 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 18m and 106,282 tokens on this with the user in an interactive session.