### PR TITLE
GH#23037: add service interruption continuation budget

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -837,6 +837,25 @@ _handle_run_result() {
 	_run_classification_source="${_failure_classification_source:-}"
 	_run_classification_pattern="${_failure_classification_pattern:-}"
 
+	# GH#23037: Transient provider/runtime interruptions after work has begun
+	# should resume the existing session from disk instead of consuming the
+	# premature-exit or watchdog-stall continuation budgets. Require activity or
+	# session evidence so startup failures still follow normal backoff paths.
+	if [[ "$role" == "worker" && "$session_key" == issue-* ]] && \
+		service_interruption_continue_candidate \
+			"$failure_reason" "$exit_code" "$activity_detected" "$discovered_session" \
+			"${_failure_provider_error_type:-}"; then
+		if [[ -n "$discovered_session" ]]; then
+			store_session_id "$provider" "$session_key" "$discovered_session" "$selected_model"
+		fi
+		local _sic_label="service_interruption_continue"
+		_run_result_label="$_sic_label"
+		_run_failure_reason="provider_error"
+		rm -f "$output_file"
+		print_warning "$selected_model service interruption after activity/session evidence — will attempt session continuation"
+		return 81
+	fi
+
 	if attempt_pool_recovery "$provider" "$failure_reason" "$output_file"; then
 		_run_should_retry=1
 		rm -f "$output_file"
@@ -1471,6 +1490,8 @@ cmd_run() {
 	# instead of starting fresh with a different provider.
 	local max_watchdog_continue_retries="${HEADLESS_WATCHDOG_CONTINUE_MAX_RETRIES:-2}"
 	local watchdog_continue_count=0
+	local max_service_interruption_continue_retries="${HEADLESS_SERVICE_INTERRUPTION_CONTINUE_MAX_RETRIES:-2}"
+	local service_interruption_continue_count=0
 
 	# GH#20681: Per-session stall caps — count and cumulative time.
 	# Prevents unbounded token burn from repeated stall-continue events.
@@ -1530,6 +1551,21 @@ cmd_run() {
 			# repeated-string-literal ratchet gate (threshold: >=3 distinct occurrences).
 			_cmd_run_finish "$session_key" "$_run_result_label"
 			return 0
+		fi
+
+		# GH#23037: Handle transient service interruptions separately from
+		# premature exits and watchdog stalls. The session/worktree evidence was
+		# validated by _handle_run_result; resume the same session without
+		# consuming provider-rotation attempts until this dedicated budget is spent.
+		if [[ "$attempt_exit" -eq 81 ]]; then
+			if [[ "$service_interruption_continue_count" -lt "$max_service_interruption_continue_retries" ]]; then
+				service_interruption_continue_count=$((service_interruption_continue_count + 1))
+				print_warning "service_interruption_continue attempt=${service_interruption_continue_count}/${max_service_interruption_continue_retries} — resuming existing session/worktree"
+				prompt="A transient provider/service interruption stopped the previous run after work had begun. Resume the existing session and worktree; do not restart exploration. Check git status, existing todos, and prior changes, then continue through implementation, verification, commit, PR, merge summary, review, merge, release, closing comments, deploy, and cleanup. Do not stop until FULL_LOOP_COMPLETE or BLOCKED with evidence."
+				continue
+			fi
+
+			print_warning "Exhausted ${max_service_interruption_continue_retries} service-interruption continuations — falling through to normal failure handling"
 		fi
 
 		# GH#17436: Handle premature exit (exit 77) — worker had activity but

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -208,6 +208,30 @@ PY
 	return 0
 }
 
+service_interruption_continue_candidate() {
+	local failure_reason="$1"
+	local exit_code="$2"
+	local activity_detected="$3"
+	local session_id="$4"
+	: "${5:-}"
+
+	if [[ "$failure_reason" == "provider_error" ]]; then
+		if [[ "$activity_detected" == "1" || -n "$session_id" ]]; then
+			return 0
+		fi
+	fi
+
+	if [[ "$activity_detected" == "1" ]]; then
+		case "$exit_code" in
+		137 | 143)
+			return 0
+			;;
+		esac
+	fi
+
+	return 1
+}
+
 extract_session_id_from_output() {
 	local file_path="$1"
 	python3 - "$file_path" <<'PY'

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -624,6 +624,38 @@ test_failure_classifier_records_provenance() {
 	return 0
 }
 
+test_service_interruption_candidate_uses_separate_path() {
+	local output_file="${TEST_ROOT}/service-interruption.out"
+	printf '%s\n' '{"type":"text","sessionID":"ses_23037","text":"editing files"}' 'OpenAI 503 service unavailable after tool activity' >"$output_file"
+	_run_result_label=""
+	_run_failure_reason=""
+	_run_should_retry=0
+
+	local status=0
+	_handle_run_result 1 "$output_file" "worker" "openai" "issue-23037" "openai/gpt-5.5" || status=$?
+
+	if [[ "$status" -eq 81 && "$_run_result_label" == "service_interruption_continue" ]]; then
+		print_result "service interruption uses dedicated continuation path" 0
+	else
+		print_result "service interruption uses dedicated continuation path" 1 \
+			"status=$status label=${_run_result_label:-<empty>} reason=${_run_failure_reason:-<empty>}"
+	fi
+
+	if ! service_interruption_continue_candidate "rate_limit" "1" "1" "" "rate_limit"; then
+		print_result "rate limits do not consume service interruption budget" 0
+	else
+		print_result "rate limits do not consume service interruption budget" 1
+	fi
+
+	if service_interruption_continue_candidate "local_error" "137" "1" "" ""; then
+		print_result "SIGKILL with activity can resume as interruption" 0
+	else
+		print_result "SIGKILL with activity can resume as interruption" 1
+	fi
+
+	return 0
+}
+
 test_canary_uses_builtin_agent_without_default_agent() {
 	local canary_root="${TEST_ROOT}/canary-agent"
 	local fake_bin_dir="${canary_root}/bin"
@@ -1263,6 +1295,7 @@ main() {
 	test_headless_activity_timeout_default_matches_watchdog
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
+	test_service_interruption_candidate_uses_separate_path
 	test_canary_uses_builtin_agent_without_default_agent
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -106,6 +106,7 @@ T_FUTURE_SENTINEL=4102444800
 #   issue-9          — synthetic future sentinel timestamp (year 2100); must
 #                      be excluded from bounded-window metrics and examples.
 #   issue-10         — missing timestamp; must not appear in bounded windows.
+#   issue-11         — service_interruption_continue heartbeat, not terminal.
 {
 	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
@@ -117,6 +118,7 @@ T_FUTURE_SENTINEL=4102444800
 	printf '{"ts":%d,"role":"worker","session_key":"issue-8","result":"watchdog_stall_continue","exit_code":124}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-9","result":"success","exit_code":0}\n' "$T_FUTURE_SENTINEL"
 	printf '{"role":"worker","session_key":"issue-10","result":"success","exit_code":0}\n'
+	printf '{"ts":%d,"role":"worker","session_key":"issue-11","model":"openai/gpt-5.5","provider":"openai","result":"service_interruption_continue","failure_reason":"provider_error","provider_error_type":"server_error","provider_status":"503","exit_code":81}\n' "$T_2H_AGO"
 } >"$METRICS"
 
 # Build pulse-stats fixture: counter arrays with timestamps inside and outside window.
@@ -185,20 +187,22 @@ else
 	echo "  output: $(printf '%q' "${JSON:0:300}")"
 fi
 
-# Assert exact counts. 24h window: events 1-6 + 8, excludes 7 (25h ago).
+# Assert exact counts. 24h window: events 1-6 + 8 + 11, excludes 7 (25h ago).
 # issue-8 (watchdog_stall_continue with exit_code=124) tests the t3215
 # regression case — must count as wc, not of, despite non-zero exit.
-assert_eq "2c: total = 7" "7" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2c: total = 8" "8" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
 assert_eq "2d: succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
+assert_eq "2f2: service_interrupted = 1 (heartbeat)" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.service_interrupted')"
 assert_eq "2g: rate_limited = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.rate_limited')"
 assert_eq "2h: other_failure = 1 (NOT 2 — heartbeat exclusion lock)" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
 assert_eq "2h2: rich result_counts includes success bucket" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.success')"
-assert_eq "2h3: timing summary includes samples" "7" \
+assert_eq "2h3: timing summary includes samples" "8" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
 assert_eq "2h4: recent example carries load context" "2.0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
@@ -217,7 +221,7 @@ assert_eq "2h10: failure groups expose provider status" "500" \
 assert_eq "2h10b: failure groups expose classification pattern" "server_error|5xx|connection_failure|overloaded" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-6") | .classification_pattern')"
 assert_eq "2h11: recent examples carry provider evidence" "openai/gpt-5.5" \
-	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-5") | .model')"
+	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-11") | .model')"
 
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \
@@ -283,6 +287,8 @@ assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
 assert_contains "5c: human output shows succeeded count" "Succeeded:                   2" "$OUT"
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
+assert_contains "5d2: human output shows service interruption resumes" \
+	"Service interruption resumed" "$OUT"
 assert_contains "5e: human output shows pr-check opt-in note" "use --pr-check" "$OUT"
 assert_contains "5f: human output shows timing summary" "Timing ms" "$OUT"
 assert_contains "5g: human output shows failure groups" "Failure groups" "$OUT"

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -45,6 +45,7 @@ WAH_PULSE_STATS_FILE="${WAH_PULSE_STATS_FILE:-${HOME}/.aidevops/logs/pulse-stats
 WAH_PR_CACHE_FILE="${WAH_PR_CACHE_FILE:-${HOME}/.aidevops/cache/worker-activity-prs.json}"
 WAH_OAUTH_POOL_FILE="${WAH_OAUTH_POOL_FILE:-${HOME}/.aidevops/oauth-pool.json}"
 WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
+WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 
 #######################################
 # Convert short window spec to seconds. Caller owns the cutoff math.
@@ -73,8 +74,8 @@ _wah_parse_since() {
 #
 # $1 — cutoff_epoch (entries with ts < cutoff are dropped).
 # $2 — optional now_epoch (entries with ts > now are dropped).
-# stdout — six space-separated integers:
-#   total succeeded watchdog_killed watchdog_continued rate_limited other_failure
+# stdout — seven space-separated integers:
+#   total succeeded watchdog_killed watchdog_continued service_interrupted rate_limited other_failure
 #######################################
 _wah_aggregate_metrics() {
 	local cutoff_epoch="$1"
@@ -82,7 +83,7 @@ _wah_aggregate_metrics() {
 	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
-		printf '0 0 0 0 0 0\n'
+		printf '0 0 0 0 0 0 0\n'
 		return 0
 	fi
 	now_epoch="${2:-$(date +%s)}"
@@ -91,30 +92,35 @@ _wah_aggregate_metrics() {
 	#   succ — result=="success" AND exit_code==0
 	#   wk   — result=="watchdog_stall_killed"   (terminal)
 	#   wc   — result=="watchdog_stall_continue" (heartbeat, NOT terminal)
+	#   sic  — result=="service_interruption_continue" (heartbeat, NOT terminal)
 	#   rl   — result=="rate_limit"
 	#   of   — everything else (catches "premature_exit" and any new
 	#          failure result-name not yet enumerated; explicitly excludes
-	#          watchdog_stall_continue heartbeats even when their exit_code
+	#          watchdog_stall_continue and service_interruption_continue
+	#          heartbeats even when their exit_code
 	#          is nonzero)
 	# Fail-open to zeros if jq fails (stale/corrupt jsonl).
-	local result
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
+	local result service_result
+	service_result="$WAH_SERVICE_INTERRUPTION_RESULT"
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" '
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w | {
 			total:  ($w | length),
 			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
 			wk:     ([$w[] | select(.result == "watchdog_stall_killed")] | length),
 			wc:     ([$w[] | select(.result == "watchdog_stall_continue")] | length),
+			sic:    ([$w[] | select(.result == $service_result)] | length),
 			rl:     ([$w[] | select(.result == "rate_limit")] | length),
 			of:     ([$w[] | select(
 				(.result != "success" or .exit_code != 0)
 				and .result != "watchdog_stall_killed"
 				and .result != "watchdog_stall_continue"
+				and .result != $service_result
 				and .result != "rate_limit"
 			)] | length)
-		} | "\(.total) \(.succ) \(.wk) \(.wc) \(.rl) \(.of)"
-	' <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0"
+		} | "\(.total) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
+	' <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0"
 
-	[[ -n "$result" ]] || result="0 0 0 0 0 0"
+	[[ -n "$result" ]] || result="0 0 0 0 0 0 0"
 	printf '%s\n' "$result"
 	return 0
 }
@@ -343,10 +349,10 @@ _wah_solved_worker_count() {
 #######################################
 _wah_emit_human() {
 	local since_label="$1" cutoff_iso="$2"
-	local total="$3" succ="$4" wk="$5" wc="$6" rl="$7" of="$8"
-	local cb="$9" gqlow="${10}" db_skip="${11}" nwbreaker="${12}"
-	local solved_count="${13}" pr_check_state="${14}" repo_label="${15}"
-	local details_json="${16}"
+	local total="$3" succ="$4" wk="$5" wc="$6" sic="$7" rl="$8" of="$9"
+	local cb="${10}" gqlow="${11}" db_skip="${12}" nwbreaker="${13}"
+	local solved_count="${14}" pr_check_state="${15}" repo_label="${16}"
+	local details_json="${17}"
 
 	local divider="==========================================================="
 
@@ -368,6 +374,7 @@ _wah_emit_human() {
 	printf '  Succeeded:                   %d  (%s of terminal)\n' "$succ" "$rate_pct"
 	printf '  Watchdog stall-killed:       %d\n' "$wk"
 	printf '  Watchdog stall-continued:    %d  (heartbeat, not terminal)\n' "$wc"
+	printf '  Service interruption resumed:%d  (heartbeat, not terminal)\n' "$sic"
 	printf '  Rate-limited:                %d\n' "$rl"
 	printf '  Other failure:               %d\n' "$of"
 	printf '  Result classes:              %s\n' "$(printf '%s' "$details_json" | jq -c '.result_counts' 2>/dev/null || printf '{}')"
@@ -434,10 +441,10 @@ _wah_emit_providers_human() {
 #######################################
 _wah_emit_json() {
 	local since_label="$1" cutoff_iso="$2" cutoff_epoch="$3"
-	local total="$4" succ="$5" wk="$6" wc="$7" rl="$8" of="$9"
-	local cb="${10}" gqlow="${11}" db_skip="${12}" nwbreaker="${13}"
-	local solved_count="${14}" pr_check_state="${15}" repo_label="${16}"
-	local details_json="${17}"
+	local total="$4" succ="$5" wk="$6" wc="$7" sic="$8" rl="$9" of="${10}"
+	local cb="${11}" gqlow="${12}" db_skip="${13}" nwbreaker="${14}"
+	local solved_count="${15}" pr_check_state="${16}" repo_label="${17}"
+	local details_json="${18}"
 
 	# solved_count may be "?" on gh failure — coerce to null in JSON.
 	local solved_json="$solved_count"
@@ -451,6 +458,7 @@ _wah_emit_json() {
 		--argjson succ "$succ" \
 		--argjson wk "$wk" \
 		--argjson wc "$wc" \
+		--argjson sic "$sic" \
 		--argjson rl "$rl" \
 		--argjson of "$of" \
 		--argjson cb "$cb" \
@@ -469,6 +477,7 @@ _wah_emit_json() {
 				succeeded: $succ,
 				watchdog_killed: $wk,
 				watchdog_continued: $wc,
+				service_interrupted: $sic,
 				rate_limited: $rl,
 				other_failure: $of,
 				result_counts: $details.result_counts,
@@ -542,9 +551,9 @@ cmd_summary() {
 		cutoff_iso="(unknown)"
 
 	# Aggregate metrics (single jq+awk pass).
-	local agg total succ wk wc rl of details_json
+	local agg total succ wk wc sic rl of details_json
 	agg=$(_wah_aggregate_metrics "$cutoff_epoch" "$now_epoch")
-	read -r total succ wk wc rl of <<<"$agg"
+	read -r total succ wk wc sic rl of <<<"$agg"
 	details_json=$(_wah_metric_details_json "$cutoff_epoch" "$now_epoch")
 
 	# Pulse-stats counters.
@@ -566,12 +575,12 @@ cmd_summary() {
 
 	if [[ $emit_json -eq 1 ]]; then
 		_wah_emit_json "$since_label" "$cutoff_iso" "$cutoff_epoch" \
-			"$total" "$succ" "$wk" "$wc" "$rl" "$of" \
+			"$total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
 			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
 	else
 		_wah_emit_human "$since_label" "$cutoff_iso" \
-			"$total" "$succ" "$wk" "$wc" "$rl" "$of" \
+			"$total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
 			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
 	fi


### PR DESCRIPTION
## Summary

Adds a dedicated service interruption continuation path and metrics bucket so transient provider/runtime drops resume the existing worker session without consuming premature-exit or watchdog-stall budgets.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worker-activity-helper.sh && bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck changed shell files; .agents/scripts/linters-local.sh

Resolves #23037


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.85 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 19m and 179,030 tokens on this with the user in an interactive session.