### PR TITLE
GH#23048: skip fresh claim orphan issue fetch

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -531,6 +531,14 @@ _filter_orphan_prelaunch_claims() {
 	fi
 	[[ "$DISPATCH_CLAIM_ORPHAN_GRACE" =~ ^[0-9]+$ ]] || DISPATCH_CLAIM_ORPHAN_GRACE=120
 
+	# Most active claims are still inside the pre-launch grace window. Avoid an
+	# issue details request unless at least one claim is old enough to be a
+	# recoverable orphan candidate.
+	if ! printf '%s' "$parsed_claims" | jq -e --argjson grace "$DISPATCH_CLAIM_ORPHAN_GRACE" 'any(.age_seconds > $grace)' >/dev/null 2>&1; then
+		printf '%s' "$parsed_claims"
+		return 0
+	fi
+
 	local assignee_count
 	assignee_count=$(gh api "repos/${repo_slug}/issues/${issue_number}" --jq '.assignees | length' 2>/dev/null) || {
 		printf '%s' "$parsed_claims"

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -312,6 +312,7 @@ set -euo pipefail
 
 local_state_dir="${MOCK_GH_STATE_DIR:?}"
 release_body_file="${local_state_dir}/release_body.txt"
+issue_call_file="${local_state_dir}/issue_calls.txt"
 
 if [[ "${1:-}" != "api" ]]; then
 	exit 1
@@ -327,6 +328,7 @@ if [[ "$endpoint" == "user" ]]; then
 fi
 
 if [[ "$endpoint" == repos/*/issues/[0-9]* && "$endpoint" != */comments* ]]; then
+	printf '1\n' >>"$issue_call_file"
 	jq -n --argjson count "${MOCK_ASSIGNEE_COUNT:-0}" '
 		{assignees: [range(0; $count) | {login: ("runner" + tostring)}]}
 	'
@@ -745,6 +747,11 @@ test_check_preserves_fresh_claim_only_marker() {
 		print_result "fresh claim-only marker does not post release" 0
 	else
 		print_result "fresh claim-only marker does not post release" 1 "body=$(<"${tmp_dir}/release_body.txt")"
+	fi
+	if [[ ! -f "${tmp_dir}/issue_calls.txt" ]]; then
+		print_result "fresh claim-only marker skips issue details fetch" 0
+	else
+		print_result "fresh claim-only marker skips issue details fetch" 1 "calls=$(<"${tmp_dir}/issue_calls.txt")"
 	fi
 	rm -rf "$tmp_dir"
 	return 0


### PR DESCRIPTION
## Summary

Skip the issue details API request when all active dispatch claims are still inside the orphan grace window, and cover the fresh-claim fast path with a regression assertion.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-dispatch-claim-helper.sh (45 tests, 0 failed); shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh

Resolves #23048


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.86 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 2m and 41,063 tokens on this as a headless worker.