### PR TITLE
GH#23049: harden gh issue label parsing

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -816,56 +816,62 @@ _modified_args=("$@")
 _shim_arg_labels_contain() {
 	local labels="$1"
 	local needle="$2"
-	local old_ifs="$IFS"
 	local label=""
-	IFS=,
-	for label in $labels; do
+	local label_array=()
+	local IFS=,
+	read -ra label_array <<< "$labels"
+	for label in "${label_array[@]}"; do
 		label="${label#"${label%%[![:space:]]*}"}"
 		label="${label%"${label##*[![:space:]]}"}"
 		if [[ "$label" == "$needle" ]]; then
-			IFS="$old_ifs"
 			return 0
 		fi
 	done
-	IFS="$old_ifs"
 	return 1
 }
 
 _shim_arg_labels_have_prefix() {
 	local labels="$1"
 	local prefix="$2"
-	local old_ifs="$IFS"
 	local label=""
-	IFS=,
-	for label in $labels; do
+	local label_array=()
+	local IFS=,
+	read -ra label_array <<< "$labels"
+	for label in "${label_array[@]}"; do
 		label="${label#"${label%%[![:space:]]*}"}"
 		label="${label%"${label##*[![:space:]]}"}"
 		if [[ "$label" == "${prefix}"* ]]; then
-			IFS="$old_ifs"
 			return 0
 		fi
 	done
-	IFS="$old_ifs"
 	return 1
 }
 
 _shim_issue_create_get_title() {
 	local idx=0
 	local arg=""
+	local title=""
 	while [[ $idx -lt ${#_modified_args[@]} ]]; do
 		arg="${_modified_args[$idx]}"
 		case "$arg" in
-		--title)
-			printf '%s\n' "${_modified_args[idx + 1]:-}"
-			return 0
+		--title | -t)
+			title="${_modified_args[idx + 1]:-}"
+			idx=$((idx + 2))
+			continue
 			;;
 		--title=*)
-			printf '%s\n' "${arg#--title=}"
-			return 0
+			title="${arg#--title=}"
+			;;
+		-t*)
+			title="${arg#-t}"
 			;;
 		esac
 		idx=$((idx + 1))
 	done
+	if [[ -n "$title" ]]; then
+		printf '%s\n' "$title"
+		return 0
+	fi
 	return 1
 }
 

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -24,6 +24,10 @@ set -euo pipefail
 # routing globally, but tests opt into that per scenario below.
 unset AIDEVOPS_GH_REST_FIRST_READS
 unset AIDEVOPS_GH_FORCE_REST_READS
+unset FULL_LOOP_HEADLESS
+unset AIDEVOPS_HEADLESS
+unset OPENCODE_HEADLESS
+unset GITHUB_ACTIONS
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
@@ -458,6 +462,25 @@ if [[ "$argv" != *"origin:interactive"* ]] && [[ "$argv" != *"status:in-review"*
 	_pass "headless issue creation is not normalized as interactive"
 else
 	_fail "headless label normalization bypass" "argv: $argv"
+fi
+
+_reset_log
+touch "$TMP/literal-status-star"
+"$SHIM_RUN" issue create --repo owner/repo -t "t3565: Short title flag" --label "status:*, origin:worker" --body "tracking body" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" != *"literal-status-star"* ]] && [[ "$argv" != *"status:in-review"* ]] && [[ "$argv" == *$'--label\nbug'* ]]; then
+	_pass "label parsing avoids globbing and short title flag normalizes"
+else
+	_fail "label glob safety and short title handling" "argv: $argv"
+fi
+
+_reset_log
+"$SHIM_RUN" issue create --repo owner/repo --title "not-a-task" -t "GH#23049: Follow-up labels" --body "tracking body" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'--label\norigin:interactive'* ]] && [[ "$argv" == *$'--label\nstatus:in-review'* ]]; then
+	_pass "last title flag wins during normalization"
+else
+	_fail "multiple title flag handling" "argv: $argv"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Hardened the gh shim's raw issue-create label parsing to avoid IFS side effects/globbing and made title detection honor short and repeated title flags.

## Files Changed

.agents/scripts/gh,.agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-shim.sh; shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh

Resolves #23049


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.86 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 4m and 93,273 tokens on this as a headless worker.