### PR TITLE
GH#23045: harden worktree owner pid SQL binding

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -129,7 +129,11 @@ _is_shell_comm() {
 _resolve_worktree_owner_pid() {
 	local explicit_pid="${1:-}"
 	if [[ -n "$explicit_pid" ]]; then
-		printf '%s' "$explicit_pid"
+		if [[ "$explicit_pid" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$explicit_pid"
+		else
+			printf '%s' "$$"
+		fi
 		return 0
 	fi
 
@@ -169,6 +173,13 @@ _resolve_worktree_owner_pid() {
 _wt_sql_escape() {
 	local val="$1"
 	echo "${val//\'/\'\'}"
+}
+
+_wt_sqlite_set_owner_pid_param() {
+	local owner_pid="$1"
+	printf '.parameter init\n'
+	printf '.parameter set :owner_pid %s\n' "$owner_pid"
+	return 0
 }
 
 # Normalize a filesystem path to a stable absolute form.
@@ -305,18 +316,21 @@ register_worktree() {
 	_init_registry_db
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
-	sqlite3 "$WORKTREE_REGISTRY_DB" "
+	{
+		_wt_sqlite_set_owner_pid_param "$owner_pid"
+		printf '%s\n' "
         INSERT OR REPLACE INTO worktree_owners
             (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_dead_seen_at)
         VALUES
 		 ('$(_wt_sql_escape "$wt_path")',
 		  '$(_wt_sql_escape "$branch")',
-		  ${owner_pid},
+		  :owner_pid,
 		  '$(_wt_sql_escape "$session_id")',
 		  '$(_wt_sql_escape "$batch_id")',
 		  '$(_wt_sql_escape "$task_id")',
 		  '');
-    " 2>/dev/null || true
+    "
+	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null || true
 	return 0
 }
 
@@ -378,18 +392,21 @@ claim_worktree_ownership() {
 		fi
 	fi
 
-	sqlite3 "$WORKTREE_REGISTRY_DB" "
+	{
+		_wt_sqlite_set_owner_pid_param "$owner_pid"
+		printf '%s\n' "
         INSERT OR IGNORE INTO worktree_owners
             (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_dead_seen_at)
         VALUES
             ('$(_wt_sql_escape "$wt_path")',
              '$(_wt_sql_escape "$branch")',
-             ${owner_pid},
+             :owner_pid,
              '$(_wt_sql_escape "$session_id")',
              '$(_wt_sql_escape "$batch_id")',
              '$(_wt_sql_escape "$task_id")',
              '');
-    " 2>/dev/null || true
+    "
+	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null || true
 
 	local final_owner_pid
 	final_owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -126,6 +126,26 @@ test_dead_owner_after_cooldown_unregisters() {
 	return 0
 }
 
+test_owner_pid_override_rejects_sql_payload() {
+	local wt_path
+	wt_path=$(make_worktree_dir "owner-pid-sql-payload")
+	register_worktree "$wt_path" "feature/owner-pid-sql-payload" --owner-pid "1); DROP TABLE worktree_owners; --"
+
+	local owner_info=""
+	owner_info=$(check_worktree_owner "$wt_path" 2>/dev/null || true)
+	local owner_pid="${owner_info%%|*}"
+
+	local table_exists=""
+	table_exists=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'worktree_owners';" 2>/dev/null || true)
+
+	local rc=0
+	[[ "$table_exists" == "worktree_owners" ]] || rc=1
+	[[ -n "$owner_info" ]] || rc=1
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || rc=1
+	print_result "owner pid override rejects SQL payload" "$rc" "(owner_info='${owner_info}')"
+	return 0
+}
+
 test_should_skip_cleanup_branch_merged_within_grace() {
 	local wt_path
 	wt_path=$(make_worktree_dir "branch-merged-grace")
@@ -164,6 +184,7 @@ main() {
 	test_dead_owner_first_pass_quarantines
 	test_dead_owner_within_cooldown_keeps_skip
 	test_dead_owner_after_cooldown_unregisters
+	test_owner_pid_override_rejects_sql_payload
 	test_should_skip_cleanup_branch_merged_within_grace
 	printf 'Results: %s/%s passed, %s failed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]] && return 0


### PR DESCRIPTION
## Summary

Validated explicit worktree owner PID overrides and bound owner_pid through sqlite parameters for registry inserts to prevent SQL injection paths.

## Files Changed

.agents/scripts/shared-worktree-registry.sh,.agents/scripts/tests/test-worktree-registry-dead-owner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh .agents/scripts/tests/test-worktree-registry-dead-owner.sh; bash .agents/scripts/tests/test-worktree-registry-dead-owner.sh; .agents/scripts/linters-local.sh reached Secretlint after passing earlier gates but timed out at 240s

Resolves #23045


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.86 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 9m and 51,416 tokens on this as a headless worker.