### PR TITLE
GH#23046: flatten paginated NMR timeline events

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -481,9 +481,18 @@ _nmr_applied_by_maintainer() {
 	[[ -n "$issue_num" && -n "$slug" && -n "$maintainer" ]] || return 1
 
 	# Fetch both actor and creation timestamp of the latest NMR label event.
+	# Use --slurp for paginated timeline reads, then flatten page arrays before
+	# selecting the latest event. Without this, long timelines emit one result per
+	# page and can pass malformed multi-line timestamps into the breaker checks.
 	local nmr_event_json
-	nmr_event_json=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate \
-		--jq '[.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")] | last | {actor:(.actor.login // ""),at:(.created_at // "")}' \
+	nmr_event_json=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate --slurp \
+		2>/dev/null | jq -c '
+			(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+			elif type == "array" then .
+			else [] end)
+			| [.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")]
+			| last
+			| {actor:(.actor.login // ""),at:(.created_at // "")}' \
 		2>/dev/null) || nmr_event_json=""
 
 	local nmr_actor nmr_at

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -555,6 +555,22 @@ test_peer_runner_breaker_trip_preserves_nmr() {
 	return 0
 }
 
+test_paginated_timeline_latest_nmr_event_preserves_breaker_trip() {
+	# Long-lived issues can paginate timeline events. The latest NMR event can be on
+	# a later page; _nmr_applied_by_maintainer must flatten slurped pages before
+	# extracting nmr_at so breaker detection receives one valid ISO8601 timestamp.
+	set_timeline '[[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"marcusquinn"},"created_at":"2026-05-06T10:00:00Z"}],[{"event":"unlabeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"marcusquinn"},"created_at":"2026-05-06T10:05:00Z"},{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"peer-runner"},"created_at":"2026-05-06T16:54:57Z"}]]'
+	set_comments '[{"created_at":"2026-05-06T16:54:59Z","body":"<!-- dispatch-infrastructure-failure -->\n## Dispatch infrastructure failure detected"}]'
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"origin:worker"},{"name":"auto-dispatch"}]}'
+	if _nmr_applied_by_maintainer 4249 owner/repo owner-runner; then
+		print_result "paginated timeline latest NMR event preserves breaker trip" 0
+		return 0
+	fi
+	print_result "paginated timeline latest NMR event preserves breaker trip" 1 \
+		"Expected exit 0 — slurped timeline pages must flatten before extracting latest NMR"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -596,6 +612,7 @@ main() {
 	test_manual_hold_still_preserves_nmr
 	test_non_maintainer_actor_auto_approves
 	test_peer_runner_breaker_trip_preserves_nmr
+	test_paginated_timeline_latest_nmr_event_preserves_breaker_trip
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh
@@ -121,6 +121,7 @@ EOF
 	printf '[]\n' >"$COMMENTS_FIXTURE"
 	printf '{"labels":[]}\n' >"$ISSUE_META_FIXTURE"
 	printf '[]\n' >"$TIMELINE_FIXTURE"
+	_notify_stale_recovery_resolved_by_pr() { return 0; }
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Flattened slurped timeline pages before selecting the latest needs-maintainer-review label event so circuit-breaker checks receive a single valid timestamp on long-lived issues.

## Files Changed

.agents/scripts/pulse-nmr-approval.sh,.agents/scripts/tests/test-pulse-nmr-automation-signature.sh,.agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh .agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh; .agents/scripts/tests/test-pulse-nmr-automation-signature.sh; .agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh

Resolves #23046


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.86 plugin for [OpenCode](https://opencode.ai) v1.14.39 with gpt-5.5 spent 1m and 61,930 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for automated review handling with multi-page timelines

* **Chores**
  * Improved timeline event processing to correctly handle paginated timeline data in approval workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->