### PR TITLE
GH#23043: log dashboard freshness issue-list errors

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -298,7 +298,7 @@ _open_alert_numbers_for_kind() {
 		gh auth status &>/dev/null 2>&1 || return 0
 		# Query open issue titles and filter locally. GitHub search is unreliable for
 		# HTML-comment dedup markers, and label prefilters can hide generated alerts.
-		issue_list_json="$(gh issue list --repo "$slug" --state open --paginate --json number,title || true)"
+		issue_list_json="$(gh issue list --repo "$slug" --state open --paginate --json number,title 2>>"$LOGFILE" || true)"
 	fi
 	[[ -n "$issue_list_json" ]] || return 0
 	printf '%s\n' "$issue_list_json" | \
@@ -323,7 +323,7 @@ _open_issue_titles_json() {
 	gh auth status &>/dev/null 2>&1 || return 0
 	# Query open issue titles and filter locally. GitHub search is unreliable for
 	# HTML-comment dedup markers, and label prefilters can hide generated alerts.
-	gh issue list --repo "$slug" --state open --paginate --json number,title || true
+	gh issue list --repo "$slug" --state open --paginate --json number,title 2>>"$LOGFILE" || true
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Redirected dashboard freshness open-issue list stderr to the script log so background worker API/network failures are captured without console noise.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dashboard-freshness-check.sh

Resolves #23043


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.86 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 2m and 18,993 tokens on this as a headless worker.