### PR TITLE
GH#23038: cap worker dispatch by provider capacity and load

### DIFF
--- a/.agents/scripts/pulse-capacity.sh
+++ b/.agents/scripts/pulse-capacity.sh
@@ -45,6 +45,300 @@ get_max_workers_target() {
 }
 
 #######################################
+# Scale a decimal value by 100 for integer comparisons.
+# Arguments:
+#   $1 - decimal value
+#   $2 - fallback decimal value
+# Returns: scaled integer via stdout
+#######################################
+_pulse_capacity_float_scaled() {
+	local float_value="${1:-0}"
+	local fallback="${2:-0}"
+	python3 - "$float_value" "$fallback" <<'PY'
+import sys
+try:
+    print(int(float(sys.argv[1]) * 100))
+except (ValueError, IndexError):
+    print(int(float(sys.argv[2]) * 100))
+PY
+	return 0
+}
+
+#######################################
+# Resolve the provider that should drive round capacity planning.
+# Returns: provider token via stdout, or blank when unknown.
+#######################################
+_pulse_capacity_selected_provider() {
+	local provider_override="${PULSE_DISPATCH_CAPACITY_PROVIDER:-}"
+	if [[ -n "$provider_override" ]]; then
+		printf '%s\n' "$provider_override"
+		return 0
+	fi
+
+	local model="${PULSE_DISPATCH_CAPACITY_MODEL:-${PULSE_MODEL:-}}"
+	if [[ "$model" == */* ]]; then
+		printf '%s\n' "${model%%/*}"
+		return 0
+	fi
+
+	printf '\n'
+	return 0
+}
+
+#######################################
+# Summarise provider account-pool availability without secrets.
+# Arguments:
+#   $1 - provider token
+# Stdout: "<total> <available> <rate_limited> <auth_errors>".
+#         available=-1 means no usable account-pool signal is configured.
+#######################################
+_pulse_capacity_provider_account_counts() {
+	local provider="$1"
+	local unavailable_counts='0 -1 0 0'
+	local pool_file="${PULSE_DISPATCH_OAUTH_POOL_FILE:-${HOME}/.aidevops/oauth-pool.json}"
+	if [[ -z "$provider" || ! -f "$pool_file" ]] || ! command -v jq >/dev/null 2>&1; then
+		printf '%s\n' "$unavailable_counts"
+		return 0
+	fi
+
+	local now_ms counts
+	now_ms=$(($(date +%s) * 1000))
+	counts=$(jq -r --arg provider "$provider" --argjson now "$now_ms" --argjson zero 0 --arg status_empty '' --arg status_auth_error 'auth-error' --arg status_rate_limited 'rate-limited' '
+		def n: tonumber? // 0;
+		def account_status: .status // $status_empty;
+		def available_account:
+			(account_status) as $status
+			| $status != $status_auth_error
+			and (($status != $status_rate_limited) or (((.cooldownUntil // 0) | n) <= $now));
+		(.[$provider] // []) as $accounts
+		| ($accounts | length) as $total
+		| if $total == 0 then
+			[$zero, -1, $zero, $zero] | @tsv
+		else
+			($accounts | map(select(account_status == $status_auth_error)) | length) as $auth
+			| ($accounts | map(select(
+				account_status == $status_rate_limited
+				and (((.cooldownUntil // 0) | n) > $now)
+			)) | length) as $limited
+			| ($accounts | map(select(available_account)) | length) as $available
+			| [$total, $available, $limited, $auth] | @tsv
+		end
+	' "$pool_file" 2>/dev/null) || counts="$unavailable_counts"
+	[[ -n "$counts" ]] || counts="$unavailable_counts"
+	printf '%s\n' "$counts"
+	return 0
+}
+
+#######################################
+# Return host load pressure points for capacity reduction.
+# Stdout: 0, 2, or 4.
+#######################################
+_pulse_capacity_load_pressure_points() {
+	local load_per_cpu="${PULSE_DISPATCH_STAGGER_LOAD_PER_CPU:-}"
+	local metrics_file="${AIDEVOPS_HEADLESS_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+	if [[ -z "$load_per_cpu" && -f "$metrics_file" ]]; then
+		load_per_cpu=$(awk '
+			/"load_per_cpu"[[:space:]]*:/ { line = $0 }
+			END {
+				if (line != "") {
+					sub(/^.*"load_per_cpu"[[:space:]]*:[[:space:]]*/, "", line)
+					sub(/[,}].*$/, "", line)
+					print line
+				}
+			}
+		' "$metrics_file" 2>/dev/null) || load_per_cpu=""
+	fi
+	local load_scaled=0 high_scaled moderate_scaled
+	[[ -n "$load_per_cpu" ]] && load_scaled=$(_pulse_capacity_float_scaled "$load_per_cpu" 0)
+	high_scaled=$(_pulse_capacity_float_scaled "${PULSE_DISPATCH_STAGGER_LOAD_HIGH:-8}" 8)
+	moderate_scaled=$(_pulse_capacity_float_scaled "${PULSE_DISPATCH_STAGGER_LOAD_MODERATE:-4}" 4)
+	if ((load_scaled >= high_scaled && load_scaled > 0)); then
+		printf '4\n'
+		return 0
+	fi
+	if ((load_scaled >= moderate_scaled && load_scaled > 0)); then
+		printf '2\n'
+		return 0
+	fi
+	printf '0\n'
+	return 0
+}
+
+#######################################
+# Count recent provider/load health signals from worker metrics.
+# Stdout: "<failures> <rate_limits> <service_interruptions> <provider_5xx> <progress_heartbeats>".
+#######################################
+_pulse_capacity_recent_health_counts() {
+	local failure_override="${PULSE_DISPATCH_CAPACITY_RECENT_FAILURES:-${PULSE_DISPATCH_STAGGER_RECENT_FAILURES:-}}"
+	local rate_limit_override="${PULSE_DISPATCH_CAPACITY_RECENT_RATE_LIMITS:-${PULSE_DISPATCH_STAGGER_RECENT_RATE_LIMITS:-}}"
+	local service_override="${PULSE_DISPATCH_CAPACITY_RECENT_SERVICE_INTERRUPTS:-}"
+	local provider_5xx_override="${PULSE_DISPATCH_CAPACITY_RECENT_PROVIDER_5XX:-}"
+	local progress_override="${PULSE_DISPATCH_CAPACITY_RECENT_PROGRESS_HEARTBEATS:-}"
+	if [[ "$failure_override" =~ ^[0-9]+$ || "$rate_limit_override" =~ ^[0-9]+$ || "$service_override" =~ ^[0-9]+$ || "$provider_5xx_override" =~ ^[0-9]+$ || "$progress_override" =~ ^[0-9]+$ ]]; then
+		[[ "$failure_override" =~ ^[0-9]+$ ]] || failure_override=0
+		[[ "$rate_limit_override" =~ ^[0-9]+$ ]] || rate_limit_override=0
+		[[ "$service_override" =~ ^[0-9]+$ ]] || service_override=0
+		[[ "$provider_5xx_override" =~ ^[0-9]+$ ]] || provider_5xx_override=0
+		[[ "$progress_override" =~ ^[0-9]+$ ]] || progress_override=0
+		printf '%s %s %s %s %s\n' "$failure_override" "$rate_limit_override" "$service_override" "$provider_5xx_override" "$progress_override"
+		return 0
+	fi
+
+	local metrics_file="${AIDEVOPS_HEADLESS_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+	local ttl_seconds="${PULSE_DISPATCH_CAPACITY_HEALTH_WINDOW_SECONDS:-900}"
+	[[ "$ttl_seconds" =~ ^[0-9]+$ ]] || ttl_seconds=900
+	[[ -f "$metrics_file" ]] || { printf '0 0 0 0 0\n'; return 0; }
+	python3 - "$metrics_file" "$ttl_seconds" <<'PY'
+import json
+import sys
+import time
+
+path, ttl = sys.argv[1], int(sys.argv[2])
+since = time.time() - ttl
+failures = rate_limits = service_interruptions = provider_5xx = progress = 0
+try:
+    with open(path, 'r', encoding='utf-8', errors='replace') as handle:
+        rows = handle.readlines()[-1000:]
+    for raw in rows:
+        try:
+            item = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        try:
+            ts = float(item.get("ts") or 0)
+        except (TypeError, ValueError):
+            ts = 0
+        if ts < since:
+            continue
+        result = str(item.get('result') or '')
+        failure_reason = str(item.get('failure_reason') or '')
+        provider_type = str(item.get('provider_error_type') or '')
+        provider_status = str(item.get('provider_status') or '')
+        exit_code = item.get('exit_code')
+        is_rate_limited = (
+            result in {'rate_limit', 'rate_limit_fast'}
+            or provider_type == 'rate_limit'
+            or provider_status == '429'
+            or 'rate_limit' in failure_reason
+        )
+        is_service_interruption = result == 'service_interruption_continue'
+        is_provider_5xx = provider_type == 'server_error' or provider_status in {'500', '502', '503', '504'}
+        if is_rate_limited:
+            rate_limits += 1
+        if is_service_interruption:
+            service_interruptions += 1
+        if is_provider_5xx:
+            provider_5xx += 1
+        if result in {'watchdog_stall_continue', 'service_interruption_continue'} or str(item.get('activity_detected') or '0') == '1':
+            progress += 1
+        if not (result == 'success' and exit_code == 0) and result not in {'worker_noop', 'no_work', 'noop', 'watchdog_stall_continue', 'service_interruption_continue'}:
+            failures += 1
+except (OSError, ValueError):
+    pass
+print(f"{failures} {rate_limits} {service_interruptions} {provider_5xx} {progress}")
+PY
+	return 0
+}
+
+#######################################
+# Apply a provider/account/load-aware cap to the raw dispatch target.
+# Arguments:
+#   $1 - raw max workers
+#   $2 - active workers
+#   $3 - minimum worker floor
+# Stdout: "<final_max_workers> <floor_active>".
+#######################################
+pulse_apply_provider_load_capacity_cap() {
+	local raw_max_workers="$1"
+	local active_workers="$2"
+	local min_worker_floor="$3"
+	[[ "$raw_max_workers" =~ ^[0-9]+$ ]] || raw_max_workers=1
+	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+	[[ "$min_worker_floor" =~ ^[0-9]+$ ]] || min_worker_floor=6
+
+	local provider account_total account_available account_limited account_auth_errors
+	provider=$(_pulse_capacity_selected_provider)
+	read -r account_total account_available account_limited account_auth_errors <<<"$(_pulse_capacity_provider_account_counts "$provider")"
+	[[ "$account_total" =~ ^[0-9]+$ ]] || account_total=0
+	[[ "$account_available" =~ ^-?[0-9]+$ ]] || account_available=-1
+	[[ "$account_limited" =~ ^[0-9]+$ ]] || account_limited=0
+	[[ "$account_auth_errors" =~ ^[0-9]+$ ]] || account_auth_errors=0
+
+	local load_points failures rate_limits service_interruptions provider_5xx progress_heartbeats
+	load_points=$(_pulse_capacity_load_pressure_points)
+	read -r failures rate_limits service_interruptions provider_5xx progress_heartbeats <<<"$(_pulse_capacity_recent_health_counts)"
+	[[ "$load_points" =~ ^[0-9]+$ ]] || load_points=0
+	[[ "$failures" =~ ^[0-9]+$ ]] || failures=0
+	[[ "$rate_limits" =~ ^[0-9]+$ ]] || rate_limits=0
+	[[ "$service_interruptions" =~ ^[0-9]+$ ]] || service_interruptions=0
+	[[ "$provider_5xx" =~ ^[0-9]+$ ]] || provider_5xx=0
+	[[ "$progress_heartbeats" =~ ^[0-9]+$ ]] || progress_heartbeats=0
+
+	local account_multiplier="${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-2}"
+	[[ "$account_multiplier" =~ ^[0-9]+$ ]] || account_multiplier=2
+	((account_multiplier < 1)) && account_multiplier=1
+	local account_cap=-1
+	if ((account_available >= 0)); then
+		account_cap=$((account_available * account_multiplier))
+	fi
+
+	local floor_allowed=1 final_max="$raw_max_workers" floor_active=0
+	if ((load_points >= 4 || rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
+		floor_allowed=0
+	fi
+	if ((account_cap >= 0 && min_worker_floor > 0 && account_cap < min_worker_floor)); then
+		floor_allowed=0
+	fi
+
+	if ((floor_allowed == 1 && min_worker_floor > 0 && active_workers < min_worker_floor)); then
+		floor_active=1
+		if ((final_max < min_worker_floor)); then
+			final_max="$min_worker_floor"
+		fi
+	fi
+
+	if ((account_cap >= 0 && final_max > account_cap)); then
+		final_max="$account_cap"
+	fi
+	if ((load_points >= 4 && final_max > 1)); then
+		final_max=$(((final_max + 1) / 2))
+	elif ((load_points >= 2 && final_max > 1)); then
+		final_max=$(((final_max * 3 + 3) / 4))
+	fi
+	if ((rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
+		if ((final_max > 1)); then
+			final_max=$(((final_max + 1) / 2))
+		fi
+	fi
+	if ((active_workers > 0 && progress_heartbeats > 0)); then
+		if ((load_points >= 4 || rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
+			if ((final_max > active_workers)); then
+				final_max="$active_workers"
+			fi
+		elif ((load_points >= 2 && final_max > active_workers + 1)); then
+			final_max=$((active_workers + 1))
+		fi
+	fi
+	if ((final_max < 0)); then
+		final_max=0
+	fi
+	if ((floor_active == 1 && final_max < min_worker_floor)); then
+		floor_active=0
+	fi
+
+	if declare -F _dispatch_stats_gauge >/dev/null 2>&1; then
+		_dispatch_stats_gauge "dispatch_capacity_provider_accounts_available" "$((account_available < 0 ? 0 : account_available))"
+		_dispatch_stats_gauge "dispatch_capacity_load_pressure_points" "$load_points"
+		_dispatch_stats_gauge "dispatch_capacity_recent_failures" "$failures"
+		_dispatch_stats_gauge "dispatch_capacity_final_max_workers" "$final_max"
+	fi
+	printf '[pulse-wrapper] Dispatch_capacity: raw_max=%s final_max=%s active=%s provider=%s provider_accounts_total=%s provider_accounts_available=%s account_cap=%s rate_limited_accounts=%s auth_error_accounts=%s load_points=%s failures=%s rate_limits=%s service_interruptions=%s provider_5xx=%s progress_heartbeats=%s min_floor=%s floor_allowed=%s floor_active=%s\n' \
+		"$raw_max_workers" "$final_max" "$active_workers" "${provider:-unknown}" "$account_total" "$account_available" "$account_cap" "$account_limited" "$account_auth_errors" "$load_points" "$failures" "$rate_limits" "$service_interruptions" "$provider_5xx" "$progress_heartbeats" "$min_worker_floor" "$floor_allowed" "$floor_active" >>"${LOGFILE:-/dev/null}" 2>/dev/null || true
+	printf '%s %s\n' "$final_max" "$floor_active"
+	return 0
+}
+
+#######################################
 # Count runnable backlog candidates across pulse scope
 # Heuristic for t1453 utilization loop:
 # - open issues passing default-open candidate filter

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -308,14 +308,9 @@ dispatch_max() {
 	}
 	local max_workers active_workers available_slots
 	read -r max_workers active_workers available_slots <<<"$capacity_line"
-	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
-	local _min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
-	if ! [[ "$_min_worker_floor" =~ ^[0-9]+$ ]]; then
-		_min_worker_floor=6
-	fi
-	if ((_min_worker_floor > 0 && active_workers < _min_worker_floor)); then
-		_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=1
-	fi
+	# _dispatch_compute_capacity owns the pressure-aware floor decision so the
+	# launch-throttle path cannot re-enable the floor after provider/load caps.
+	[[ "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" =~ ^[0-9]+$ ]] || _DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
 	if [[ "$available_slots" -le 0 ]]; then
 		echo "[pulse-wrapper] Dispatch_max skipped: no available worker slots (max=${max_workers}, active=${active_workers}, available=${available_slots})" >>"$LOGFILE"
 		echo 0

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -484,14 +484,22 @@ _dispatch_compute_capacity() {
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 
-	# t3418: Keep a minimum implementation worker floor eligible under CPU/load
-	# throttling. This relaxes soft load posture only; STOP_FLAG and the
-	# GraphQL circuit breaker above remain hard stops.
+	# t3418/GH#23038: Keep a minimum implementation worker floor eligible only
+	# while provider/account health and host load are good enough. The pressure
+	# helper caps the final target by OAuth account availability, recent
+	# provider failures, load, and long-session runway before dispatch slots are
+	# exposed to the candidate loop.
 	local min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
 	if ! [[ "$min_worker_floor" =~ ^[0-9]+$ ]]; then
 		min_worker_floor=6
 	fi
-	if ((min_worker_floor > 0 && active_workers < min_worker_floor)); then
+	if declare -F pulse_apply_provider_load_capacity_cap >/dev/null 2>&1; then
+		local capacity_cap_line=""
+		capacity_cap_line=$(pulse_apply_provider_load_capacity_cap "$max_workers" "$active_workers" "$min_worker_floor") || capacity_cap_line="${max_workers} 0"
+		read -r max_workers _DISPATCH_MIN_WORKER_FLOOR_ACTIVE <<<"$capacity_cap_line"
+		[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
+		[[ "$_DISPATCH_MIN_WORKER_FLOOR_ACTIVE" =~ ^[0-9]+$ ]] || _DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
+	elif ((min_worker_floor > 0 && active_workers < min_worker_floor)); then
 		_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=1
 		if ((max_workers < min_worker_floor)); then
 			echo "[pulse-wrapper] Dispatch_min_floor active: max_workers=${max_workers} raised to ${min_worker_floor} while active=${active_workers}" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -35,6 +35,8 @@ export STOP_FLAG="${HOME}/.aidevops/logs/stop"
 : >"$LOGFILE"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../pulse-capacity.sh
+source "${SCRIPT_DIR}/pulse-capacity.sh"
 # shellcheck source=../pulse-dispatch-engine.sh
 source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 # shellcheck source=../pulse-dispatch-worker-launch.sh
@@ -70,7 +72,21 @@ count_active_workers() {
 	return 0
 }
 
+reset_capacity_pressure_env() {
+	unset PULSE_DISPATCH_CAPACITY_PROVIDER PULSE_DISPATCH_CAPACITY_MODEL PULSE_MODEL || true
+	unset PULSE_DISPATCH_STAGGER_LOAD_PER_CPU PULSE_DISPATCH_STAGGER_RECENT_FAILURES || true
+	unset PULSE_DISPATCH_STAGGER_RECENT_RATE_LIMITS PULSE_DISPATCH_PROVIDER_BACKOFF_ACTIVE || true
+	unset PULSE_DISPATCH_CAPACITY_RECENT_FAILURES PULSE_DISPATCH_CAPACITY_RECENT_RATE_LIMITS || true
+	unset PULSE_DISPATCH_CAPACITY_RECENT_SERVICE_INTERRUPTS || true
+	unset PULSE_DISPATCH_CAPACITY_RECENT_PROVIDER_5XX || true
+	unset PULSE_DISPATCH_CAPACITY_RECENT_PROGRESS_HEARTBEATS || true
+	unset PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER PULSE_DISPATCH_OAUTH_POOL_FILE || true
+	rm -f "${HOME}/.aidevops/oauth-pool.json"
+	return 0
+}
+
 test_capacity_raises_soft_cap_to_floor() {
+	reset_capacity_pressure_env
 	TEST_MAX_WORKERS=1
 	TEST_ACTIVE_WORKERS=2
 	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
@@ -89,6 +105,7 @@ test_capacity_raises_soft_cap_to_floor() {
 }
 
 test_capacity_respects_existing_higher_cap() {
+	reset_capacity_pressure_env
 	TEST_MAX_WORKERS=10
 	TEST_ACTIVE_WORKERS=2
 	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
@@ -106,7 +123,74 @@ test_capacity_respects_existing_higher_cap() {
 	return 0
 }
 
+test_capacity_caps_by_provider_accounts_and_high_load() {
+	reset_capacity_pressure_env
+	TEST_MAX_WORKERS=12
+	TEST_ACTIVE_WORKERS=1
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	PULSE_MODEL="openai/gpt-5.5"
+	PULSE_DISPATCH_STAGGER_LOAD_PER_CPU=9
+	PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=2
+	cat >"${HOME}/.aidevops/oauth-pool.json" <<'JSON'
+{"openai":[{"status":"idle"},{"status":"active"}]}
+JSON
+	unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "2 1 1" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "0" ]]; then
+		print_result "capacity: provider accounts and high load cap below floor" 0
+	else
+		print_result "capacity: provider accounts and high load cap below floor" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+	fi
+	return 0
+}
+
+test_capacity_recent_service_interruptions_reduce_slots() {
+	reset_capacity_pressure_env
+	TEST_MAX_WORKERS=12
+	TEST_ACTIVE_WORKERS=1
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	PULSE_DISPATCH_CAPACITY_RECENT_SERVICE_INTERRUPTS=1
+	unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "6 1 5" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "0" ]]; then
+		print_result "capacity: service interruption pressure halves launch target" 0
+	else
+		print_result "capacity: service interruption pressure halves launch target" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+	fi
+	return 0
+}
+
+test_capacity_recent_progress_gets_runway_under_pressure() {
+	reset_capacity_pressure_env
+	TEST_MAX_WORKERS=12
+	TEST_ACTIVE_WORKERS=4
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	PULSE_DISPATCH_CAPACITY_RECENT_SERVICE_INTERRUPTS=1
+	PULSE_DISPATCH_CAPACITY_RECENT_PROGRESS_HEARTBEATS=2
+	unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "4 4 0" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "0" ]]; then
+		print_result "capacity: progressing active workers get runway under pressure" 0
+	else
+		print_result "capacity: progressing active workers get runway under pressure" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+	fi
+	return 0
+}
+
 test_throttle_does_not_force_serial_under_floor() {
+	reset_capacity_pressure_env
 	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
 	: >"$_DISPATCH_THROTTLE_FILE"
 	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=1
@@ -123,6 +207,7 @@ test_throttle_does_not_force_serial_under_floor() {
 }
 
 test_throttle_forces_serial_above_floor() {
+	reset_capacity_pressure_env
 	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
 	: >"$_DISPATCH_THROTTLE_FILE"
 	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
@@ -281,6 +366,9 @@ EOF
 
 test_capacity_raises_soft_cap_to_floor
 test_capacity_respects_existing_higher_cap
+test_capacity_caps_by_provider_accounts_and_high_load
+test_capacity_recent_service_interruptions_reduce_slots
+test_capacity_recent_progress_gets_runway_under_pressure
 test_throttle_does_not_force_serial_under_floor
 test_throttle_forces_serial_above_floor
 test_canary_preflight_marks_floor_without_cpu_bypass

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -78,6 +78,7 @@ FIXTURE_DIR="$(mktemp -d -t wah-test-XXXXXX)"
 METRICS="$FIXTURE_DIR/headless-runtime-metrics.jsonl"
 STATS="$FIXTURE_DIR/pulse-stats.json"
 PR_CACHE="$FIXTURE_DIR/pr-cache.json"
+OAUTH_POOL="$FIXTURE_DIR/oauth-pool.json"
 
 cleanup() {
 	rm -rf "$FIXTURE_DIR"
@@ -90,6 +91,7 @@ T_5MIN_AGO=$((NOW - 300))
 T_2H_AGO=$((NOW - 7200))
 T_25H_AGO=$((NOW - 90000))
 T_FUTURE_SENTINEL=4102444800
+T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 
 # Build metrics fixture covering every bucket and the regression cases that
 # the original awk implementation handled correctly:
@@ -124,6 +126,20 @@ T_FUTURE_SENTINEL=4102444800
 	printf '{"ts":%d,"role":"worker","session_key":"issue-12","model":"openai/gpt-5.5","provider":"openai","result":"service_interruption_exhausted","failure_reason":"local_error","runtime_error_type":"sigterm","exit_code":81}\n' "$T_2H_AGO"
 } >"$METRICS"
 
+cat >"$OAUTH_POOL" <<EOF
+{
+  "openai": [
+    {"status": "idle"},
+    {"status": "active"},
+    {"status": "auth-error"},
+    {"status": "rate-limited", "cooldownUntil": $T_FUTURE_SENTINEL_MS}
+  ],
+  "anthropic": [
+    {"status": "idle"}
+  ]
+}
+EOF
+
 # Build pulse-stats fixture: counter arrays with timestamps inside and outside window.
 cat >"$STATS" <<EOF
 {
@@ -142,6 +158,8 @@ RUN_ENV=(
 	"WAH_METRICS_FILE=$METRICS"
 	"WAH_PULSE_STATS_FILE=$STATS"
 	"WAH_PR_CACHE_FILE=$PR_CACHE"
+	"WAH_OAUTH_POOL_FILE=$OAUTH_POOL"
+	"PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=2"
 )
 
 echo "${TEST_BLUE}=== t3215: worker-activity-helper.sh tests ===${TEST_NC}"
@@ -297,10 +315,27 @@ assert_contains "5f: human output shows timing summary" "Timing ms" "$OUT"
 assert_contains "5g: human output shows failure groups" "Failure groups" "$OUT"
 
 # ---------------------------------------------------------------------------
-# Section 6: solved:worker attribution query excludes origin-only PR counts.
+# Section 6: provider/account diagnostics expose redacted capacity slots.
 # ---------------------------------------------------------------------------
 echo
-echo "--- Section 6: solved-by attribution query ---"
+echo "--- Section 6: provider/account diagnostics ---"
+
+JSON=$(env "${RUN_ENV[@]}" "$HELPER" providers --since 24h --json 2>&1)
+RC=$?
+assert_rc "6a: providers --json exits 0" 0 "$RC"
+assert_eq "6b: openai available accounts exclude auth-error/rate-limited" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .available')"
+assert_eq "6c: openai capacity_slots uses redacted multiplier" "4" \
+	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
+
+OUT=$(env "${RUN_ENV[@]}" "$HELPER" providers --since 24h 2>&1)
+assert_contains "6d: human provider output shows capacity slots" "capacity_slots=4" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Section 7: solved:worker attribution query excludes origin-only PR counts.
+# ---------------------------------------------------------------------------
+echo
+echo "--- Section 7: solved-by attribution query ---"
 
 GH_STUB_DIR="$FIXTURE_DIR/bin"
 mkdir -p "$GH_STUB_DIR"
@@ -319,18 +354,18 @@ chmod +x "$GH_STUB_DIR/gh"
 JSON=$(env "${RUN_ENV[@]}" "GH_CALL_LOG=$GH_CALL_LOG" "PATH=$GH_STUB_DIR:$PATH" \
 	"$HELPER" summary --since 24h --repo marcusquinn/aidevops --pr-check --json 2>&1)
 RC=$?
-assert_rc "6a: solved attribution query exits 0" 0 "$RC"
-assert_eq "6b: solved worker issue count = 2" "2" \
+assert_rc "7a: solved attribution query exits 0" 0 "$RC"
+assert_eq "7b: solved worker issue count = 2" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.count')"
-assert_contains "6c: gh query uses solved:worker label" "label:solved:worker" \
+assert_contains "7c: gh query uses solved:worker label" "label:solved:worker" \
 	"$(<"$GH_CALL_LOG")"
 if grep -q "label:origin:worker" "$GH_CALL_LOG" 2>/dev/null; then
 	TESTS_RUN=$((TESTS_RUN + 1))
 	TESTS_FAILED=$((TESTS_FAILED + 1))
-	echo "${TEST_RED}FAIL${TEST_NC}: 6d: query must not use origin:worker"
+	echo "${TEST_RED}FAIL${TEST_NC}: 7d: query must not use origin:worker"
 else
 	TESTS_RUN=$((TESTS_RUN + 1))
-	echo "${TEST_GREEN}PASS${TEST_NC}: 6d: query does not use origin:worker"
+	echo "${TEST_GREEN}PASS${TEST_NC}: 7d: query does not use origin:worker"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -215,14 +215,25 @@ _wah_provider_usage_json() {
 	local cutoff_epoch="$1"
 	local metrics="$WAH_METRICS_FILE"
 	local pool="$WAH_OAUTH_POOL_FILE"
-	local now_epoch input_file
+	local now_epoch input_file account_multiplier
 
 	now_epoch=$(date +%s)
 	input_file="/dev/null"
 	[[ -f "$metrics" ]] && input_file="$metrics"
+	account_multiplier="${WAH_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-2}}"
+	[[ "$account_multiplier" =~ ^[0-9]+$ ]] || account_multiplier=2
+	((account_multiplier < 1)) && account_multiplier=1
 
 	if [[ -f "$pool" ]]; then
-		jq -rn --slurpfile pool "$pool" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
+		jq -rn --slurpfile pool "$pool" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson account_multiplier "$account_multiplier" --arg status_empty '' --arg status_auth_error 'auth-error' --arg status_rate_limited 'rate-limited' --arg status_active 'active' --arg status_idle 'idle' '
+			def account_status: .status // $status_empty;
+			def available_account:
+				(account_status) as $status
+				| $status != $status_auth_error
+				and (($status != $status_rate_limited) or ((.cooldownUntil // 0) <= ($now * 1000)));
+			def active_or_idle:
+				(.status // $status_idle) as $status
+				| $status == $status_active or $status == $status_idle;
 			($pool[0] // {}) as $pool_data
 			| [inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 			| {
@@ -251,10 +262,11 @@ _wah_provider_usage_json() {
 					| map({
 						provider: .key,
 						total: (.value | length),
-						available: (.value | map(select(((.cooldownUntil // 0) == 0) or ((.cooldownUntil // 0) <= ($now * 1000)))) | length),
-						active_idle: (.value | map(select((.status // "idle") == "active" or (.status // "idle") == "idle")) | length),
-						rate_limited: (.value | map(select((.status // "") == "rate-limited" and ((.cooldownUntil // 0) > ($now * 1000)))) | length),
-						auth_errors: (.value | map(select((.status // "") == "auth-error")) | length),
+						available: (.value | map(select(available_account)) | length),
+						capacity_slots: ((.value | map(select(available_account)) | length) * $account_multiplier),
+						active_idle: (.value | map(select(active_or_idle)) | length),
+						rate_limited: (.value | map(select(account_status == $status_rate_limited and ((.cooldownUntil // 0) > ($now * 1000)))) | length),
+						auth_errors: (.value | map(select(account_status == $status_auth_error)) | length),
 						latest_last_used: ([.value[]? | .lastUsed? // empty] | max // "")
 					})
 					| sort_by(.provider)
@@ -423,7 +435,7 @@ _wah_emit_providers_human() {
 	printf '%s' "$usage_json" | jq -r '
 		(.account_pool // []) as $rows
 		| if ($rows | length) == 0 then "  (no oauth-pool.json account summary available)"
-		else $rows[] | "  \(.provider): total=\(.total) available=\(.available) active_idle=\(.active_idle) rate_limited=\(.rate_limited) auth_errors=\(.auth_errors) latest_last_used=\(.latest_last_used // "")"
+		else $rows[] | "  \(.provider): total=\(.total) available=\(.available) capacity_slots=\(.capacity_slots // 0) active_idle=\(.active_idle) rate_limited=\(.rate_limited) auth_errors=\(.auth_errors) latest_last_used=\(.latest_last_used // "")"
 		end' 2>/dev/null || printf '  (account pool summary unavailable)\n'
 	printf '\n'
 	printf 'Recent worker samples (bounded to 10):\n'


### PR DESCRIPTION
## Summary
- Add provider/account/load-aware dispatch capacity capping before worker slots are exposed.
- Disable the minimum worker floor under severe provider/load pressure and preserve runway for active workers with recent progress.
- Extend worker activity diagnostics with redacted OAuth account capacity slots.

## Verification
- `bash .agents/scripts/tests/test-dispatch-min-concurrency.sh`
- `.agents/scripts/tests/test-worker-activity-helper.sh`
- `shellcheck .agents/scripts/pulse-capacity.sh .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/worker-activity-helper.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh .agents/scripts/tests/test-worker-activity-helper.sh`
- `.agents/scripts/linters-local.sh`

Resolves #23038
