### PR TITLE
Fix OpenCode session env leaks in headless dispatch

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -519,16 +519,16 @@ _invoke_opencode() {
 			# a temp file and replays it after exit — the watchdog sees nothing
 			# and kills every sandboxed worker at ~93s.
 			if [[ -n "$passthrough_csv" ]]; then
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			else
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else
 			if [[ "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" == "1" ]]; then
 				print_info "AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1 — using bare timeout (no privilege isolation) (GH#20146 audit)"
 			fi
-			timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+			run_without_opencode_session_env timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		fi
 	) &

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -566,6 +566,17 @@ copy_scoped_opencode_auth() {
 	return 0
 }
 
+run_without_opencode_session_env() {
+	env -u OPENCODE_SESSION_ID \
+		-u OPENCODE_PID \
+		-u OPENCODE_RUN_ID \
+		-u OPENCODE_PROCESS_ROLE \
+		-u OPENCODE \
+		-u OPENCODE_SERVER_PASSWORD \
+		"$@"
+	return $?
+}
+
 build_sandbox_passthrough_csv() {
 	local provider="${1:-}"
 	local names=()
@@ -574,10 +585,9 @@ build_sandbox_passthrough_csv() {
 
 	while IFS='=' read -r name _; do
 		case "$name" in
-		# OPENCODE_PID is the pulse's own opencode process PID. Passing it to
-		# workers causes them to attach to the pulse's session instead of
-		# creating independent sessions (GH#6668). Exclude it explicitly.
-		OPENCODE_PID) ;;
+		# Session-bound OpenCode env makes isolated canary/worker runs attach to
+		# the parent TUI session and fail with "Session not found" (GH#23065).
+		OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) ;;
 		OPENAI_* | ANTHROPIC_* | GOOGLE_* | CLAUDE_*)
 			if [[ -n "$provider" ]] && ! _headless_provider_env_allowed "$provider" "$name"; then
 				continue
@@ -1587,7 +1597,7 @@ _run_canary_test() {
 	# $OPENCODE_BIN_DEFAULT directly. Identical to the default in the
 	# happy path; differs only when alternative-path fallback fired.
 	XDG_CONFIG_HOME="$_canary_config_dir" XDG_DATA_HOME="$_canary_data_dir" \
-		"${_canary_timeout_cmd[@]}" \
+		run_without_opencode_session_env "${_canary_timeout_cmd[@]}" \
 		"$_effective_opencode_bin" run --pure "Reply with exactly: CANARY_OK" \
 		-m "$canary_model" --dir "${HOME}" --agent build \
 		${canary_attach_args[@]+"${canary_attach_args[@]}"} \

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -674,6 +674,7 @@ test_canary_uses_builtin_agent_without_default_agent() {
 	local canary_root="${TEST_ROOT}/canary-agent"
 	local fake_bin_dir="${canary_root}/bin"
 	local args_file="${canary_root}/args.txt"
+	local env_file="${canary_root}/env.txt"
 	mkdir -p "$fake_bin_dir"
 
 	cat >"${fake_bin_dir}/opencode" <<'EOF'
@@ -682,7 +683,13 @@ if [[ "${1:-}" == "--version" ]]; then
 	printf '1.14.31\n'
 	exit 0
 fi
+if [[ -n "${OPENCODE_SESSION_ID:-}${OPENCODE_PID:-}${OPENCODE_RUN_ID:-}${OPENCODE_PROCESS_ROLE:-}${OPENCODE:-}${OPENCODE_SERVER_PASSWORD:-}" ]]; then
+	printf 'leaked session env\n' >"$AIDEVOPS_CANARY_ENV_FILE"
+	exit 42
+fi
 printf '%s\n' "$*" >"$AIDEVOPS_CANARY_ARGS_FILE"
+printf 'OPENCODE_BIN=%s\nOPENCODE_DB=%s\n' \
+	"${OPENCODE_BIN:-}" "${OPENCODE_DB:-}" >"$AIDEVOPS_CANARY_ENV_FILE"
 printf 'CANARY_OK\n'
 exit 0
 EOF
@@ -693,25 +700,79 @@ EOF
 		PATH="${fake_bin_dir}:$PATH" \
 		HOME="${canary_root}/home" \
 		OPENCODE_BIN="${fake_bin_dir}/opencode" \
+		OPENCODE_DB="${canary_root}/opencode.db" \
+		OPENCODE_SESSION_ID="ses_parent" \
+		OPENCODE_PID="12345" \
+		OPENCODE_RUN_ID="run_parent" \
+		OPENCODE_PROCESS_ROLE="tui" \
+		OPENCODE="1" \
+		OPENCODE_SERVER_PASSWORD="session-password" \
 		AIDEVOPS_CANARY_ARGS_FILE="$args_file" \
+		AIDEVOPS_CANARY_ENV_FILE="$env_file" \
 		AIDEVOPS_HEADLESS_RUNTIME_DIR="${canary_root}/runtime" \
 		CANARY_CACHE_TTL_SECONDS=0 \
 		CANARY_TIMEOUT_SECONDS=5 \
 		bash -c 'source "$1" help >/dev/null 2>&1; _run_canary_test "anthropic/claude-sonnet-4-6"' _ "$HELPER_SCRIPT"
-	) && [[ -f "$args_file" ]]; then
+	) && [[ -f "$args_file" && -f "$env_file" ]]; then
 		local args
 		args=$(<"$args_file")
-		if [[ "$args" == *'--pure'* && "$args" == *'--agent build'* ]]; then
+		local env_output
+		env_output=$(<"$env_file")
+		if [[ "$args" == *'--pure'* && "$args" == *'--agent build'* ]] &&
+			[[ "$env_output" == *"OPENCODE_BIN=${fake_bin_dir}/opencode"* ]] &&
+			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]]; then
 			print_result "canary uses built-in agent without default_agent" 0
 			return 0
 		fi
 		print_result "canary uses built-in agent without default_agent" 1 \
-			"Expected --pure and --agent build in canary args, got: ${args}"
+			"Expected --pure/--agent build and preserved OpenCode config env, got args: ${args}; env: ${env_output}"
 		return 0
 	fi
 
 	print_result "canary uses built-in agent without default_agent" 1 \
 		"Canary stub did not run successfully: ${output:-<empty>}"
+	return 0
+}
+
+test_opencode_session_env_wrapper_strips_session_vars_only() {
+	local output
+	# shellcheck disable=SC2016 # Inner bash expands these after env stripping.
+	output=$(
+		OPENCODE_SESSION_ID="ses_parent" \
+		OPENCODE_PID="12345" \
+		OPENCODE_RUN_ID="run_parent" \
+		OPENCODE_PROCESS_ROLE="tui" \
+		OPENCODE="1" \
+		OPENCODE_SERVER_PASSWORD="session-password" \
+		OPENCODE_BIN="opencode" \
+		OPENCODE_DB="/tmp/opencode.db" \
+		run_without_opencode_session_env bash -c '
+			printf "%s|%s|%s|%s|%s|%s|%s|%s" \
+				"${OPENCODE_SESSION_ID:-}" "${OPENCODE_PID:-}" "${OPENCODE_RUN_ID:-}" \
+				"${OPENCODE_PROCESS_ROLE:-}" "${OPENCODE:-}" "${OPENCODE_SERVER_PASSWORD:-}" \
+				"${OPENCODE_BIN:-}" "${OPENCODE_DB:-}"
+		'
+	)
+
+	if [[ "$output" == "||||||opencode|/tmp/opencode.db" ]]; then
+		print_result "OpenCode session env wrapper strips only session-bound vars" 0
+		return 0
+	fi
+
+	print_result "OpenCode session env wrapper strips only session-bound vars" 1 \
+		"Expected session vars stripped and config env preserved, got: ${output}"
+	return 0
+}
+
+test_worker_opencode_exec_paths_strip_session_env() {
+	if grep -Fq "run_without_opencode_session_env \"\$SANDBOX_EXEC_HELPER\" run" "$HELPER_SCRIPT" &&
+		grep -Fq "run_without_opencode_session_env timeout \"\$HEADLESS_SANDBOX_TIMEOUT_DEFAULT\"" "$HELPER_SCRIPT"; then
+		print_result "worker OpenCode exec paths strip session env" 0
+		return 0
+	fi
+
+	print_result "worker OpenCode exec paths strip session env" 1 \
+		"Expected sandbox and bare-timeout OpenCode exec paths to use run_without_opencode_session_env"
 	return 0
 }
 
@@ -722,13 +783,27 @@ test_sandbox_passthrough_scopes_provider_env() {
 		ANTHROPIC_API_KEY='anthropic-test' \
 		GOOGLE_API_KEY='google-test' \
 		OPENCODE_BIN='opencode' \
+		OPENCODE_DB='/tmp/opencode.db' \
+		OPENCODE_SESSION_ID='ses_parent' \
+		OPENCODE_PID='12345' \
+		OPENCODE_RUN_ID='run_parent' \
+		OPENCODE_PROCESS_ROLE='tui' \
+		OPENCODE='1' \
+		OPENCODE_SERVER_PASSWORD='session-password' \
 		build_sandbox_passthrough_csv "openai"
 	)
 
 	if [[ "$csv" == *"OPENAI_API_KEY"* ]] &&
 		[[ "$csv" != *"ANTHROPIC_API_KEY"* ]] &&
 		[[ "$csv" != *"GOOGLE_API_KEY"* ]] &&
-		[[ "$csv" == *"OPENCODE_BIN"* ]]; then
+		[[ "$csv" == *"OPENCODE_BIN"* ]] &&
+		[[ "$csv" == *"OPENCODE_DB"* ]] &&
+		[[ "$csv" != *"OPENCODE_SESSION_ID"* ]] &&
+		[[ "$csv" != *"OPENCODE_PID"* ]] &&
+		[[ "$csv" != *"OPENCODE_RUN_ID"* ]] &&
+		[[ "$csv" != *"OPENCODE_PROCESS_ROLE"* ]] &&
+		[[ "$csv" != *"OPENCODE_SERVER_PASSWORD"* ]] &&
+		[[ ",$csv," != *",OPENCODE,"* ]]; then
 		print_result "sandbox passthrough scopes env to selected provider" 0
 		return 0
 	fi
@@ -1311,6 +1386,8 @@ main() {
 	test_failure_classifier_records_provenance
 	test_service_interruption_candidate_uses_separate_path
 	test_canary_uses_builtin_agent_without_default_agent
+	test_opencode_session_env_wrapper_strips_session_vars_only
+	test_worker_opencode_exec_paths_strip_session_env
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
 	test_large_opencode_prompt_uses_file_attachment


### PR DESCRIPTION
## Summary
- Strip session-bound OpenCode environment variables before canary and worker opencode run exec boundaries.
- Keep intentional OpenCode config and runtime environment such as OPENCODE_BIN and OPENCODE_DB available.
- Extend headless runtime helper tests to cover canary stripping, sandbox passthrough filtering, and worker exec path coverage.

Resolves #23065

## Verification
- bash .agents/scripts/tests/test-headless-runtime-helper.sh -> 54 tests, 0 failures
- shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.87 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 10m and 89,386 tokens on this as a headless worker.
