### PR TITLE
fix: use repo default branch in merge-stuck guidance

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -306,6 +306,21 @@ _pms_hash_fingerprint() {
 	fi
 }
 
+# Resolve a repository's default branch for worker-facing instructions.
+# Falls back to main only when the API is unavailable so generated guidance
+# remains usable offline while preferring repo-specific branches like develop.
+_pms_default_branch() {
+	local repo_slug="$1"
+	local default_branch=""
+
+	if [[ -n "$repo_slug" ]]; then
+		default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch=""
+	fi
+	default_branch="${default_branch:-main}"
+	printf '%s' "$default_branch"
+	return 0
+}
+
 # ── Per-PR escalation (Outcome 3 in brief) ──────────────────────────────────
 
 #######################################
@@ -438,6 +453,8 @@ _handle_stuck_conflict_no_nudge_label() {
 	head_branch=$(gh pr view "$pr_number" --repo "$repo_slug" \
 		--json headRefName --jq '.headRefName' 2>/dev/null) || head_branch="<branch>"
 	[[ -n "$head_branch" ]] || head_branch="<branch>"
+	local default_branch
+	default_branch=$(_pms_default_branch "$repo_slug")
 
 	# Reuse the existing rebase-nudge marker — _gh_idempotent_comment is
 	# keyed on the marker string, so this nudge is mutually exclusive with
@@ -456,7 +473,7 @@ This PR has merge conflicts against the default branch and lacks both \`origin:i
 \`\`\`bash
 git fetch origin
 git checkout ${head_branch}
-git rebase origin/main
+git rebase origin/${default_branch}
 # resolve any conflicts, then:
 git push --force-with-lease
 \`\`\`
@@ -524,7 +541,7 @@ _detect_pattern_outage() {
 				_cur_count=1
 				_cur_prs="$_line_pr"
 			fi
-		done < <(sort "$tmp_lines")
+		done < <(sort -u "$tmp_lines")
 		# Flush the final group.
 		if [[ -n "$_prev_fp" ]]; then
 			printf '%d\t%s\t%s\n' "$_cur_count" "$_prev_fp" "$_cur_prs" >>"$tmp_groups"
@@ -552,6 +569,8 @@ _pms_file_outage_issue() {
 	fp_hash=$(_pms_hash_fingerprint "$fingerprint")
 	local marker_text="merge-stuck:pattern:${fp_hash}"
 	local marker="<!-- ${marker_text} -->"
+	local default_branch
+	default_branch=$(_pms_default_branch "$repo_slug")
 
 	# Dedup: search for an OPEN issue with this marker. If one exists, skip.
 	local existing
@@ -592,18 +611,18 @@ Investigation only — no \`Files Scope\` declared. The fix file set will be det
 
 ### Investigation steps
 
-1. Reproduce the failing check on a fresh worktree off \`origin/main\`:
+1. Reproduce the failing check on a fresh worktree off \`origin/${default_branch}\`:
    \`\`\`bash
    wt switch -c chore/diagnose-merge-stuck-${fp_hash:0:8}
    # Run the same command(s) the failing CI step runs
    \`\`\`
-2. If the failure reproduces on a clean main, the base is broken — locate the most recent commit on main that introduced the regression (\`git log --since=24h --first-parent main\`) and either revert or fix forward.
-3. If the failure does NOT reproduce on clean main, the cluster is a coincidence (rare) — close this issue with the rationale and let each PR be triaged individually.
+2. If the failure reproduces on a clean ${default_branch}, the base is broken — locate the most recent commit on ${default_branch} that introduced the regression (\`git log --since=24h --first-parent ${default_branch}\`) and either revert or fix forward.
+3. If the failure does NOT reproduce on clean ${default_branch}, the cluster is a coincidence (rare) — close this issue with the rationale and let each PR be triaged individually.
 4. Once the base is fixed and pushed, the affected PRs above should auto-merge on their next pulse cycle (or rebase via \`gh pr update-branch\`).
 
 ### Verification
 
-- The failing check listed in the fingerprint passes on a fresh worktree off \`origin/main\`.
+- The failing check listed in the fingerprint passes on a fresh worktree off \`origin/${default_branch}\`.
 - Each affected PR successfully merges or has its remaining failures triaged individually.
 - This issue is closed with the resolution PR linked.
 

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -18,7 +18,8 @@
 #        merged=0 + eligible>0 → gauge incremented by 1
 #   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
 #      read-only merge gates (required checks, worker PR with no linked issue).
-#   8. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
+#   8. _detect_pattern_outage de-duplicates repeated PR observations.
+#   9. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
 # The test never makes real network calls; functions that require gh API
 # (_classify_stuck_pr, _escalate_individual_stuck_pr, full pulse_merge_stuck_run_pass)
@@ -344,9 +345,61 @@ assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "1" "
 echo ""
 
 # ---------------------------------------------------------------------------
-# Section 7: shellcheck cleanliness.
+# Section 7: pattern outage deduplication.
 # ---------------------------------------------------------------------------
-echo "--- Section 7: shellcheck ---"
+echo "--- Section 7: pattern outage deduplication ---"
+
+_pms_failure_fingerprint() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	[[ -n "$repo_slug" ]] || return 1
+	case "$pr_number" in
+	11 | 12) printf 'E2E Shard 1/4,E2E Shard 2/4' ;;
+	*) printf '' ;;
+	esac
+	return 0
+}
+
+PMS_TEST_OUTAGE_ARGS=""
+_pms_file_outage_issue() {
+	local repo_slug="$1"
+	local count="$2"
+	local fingerprint="$3"
+	local prs="$4"
+	PMS_TEST_OUTAGE_ARGS="${repo_slug}|${count}|${fingerprint}|${prs}"
+	return 0
+}
+
+AIDEVOPS_MERGE_PATTERN_MIN_PRS=2
+_detect_pattern_outage "example/repo" $'11\n11\n12\n'
+assert_eq "7a: duplicate PR observations counted once" \
+	"example/repo|2|E2E Shard 1/4,E2E Shard 2/4|11,12" \
+	"$PMS_TEST_OUTAGE_ARGS"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 8: default branch guidance.
+# ---------------------------------------------------------------------------
+echo "--- Section 8: default branch guidance ---"
+
+gh() {
+	local command_name="${1:-}"
+	local path_arg="${2:-}"
+	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/repo" ]]; then
+		printf 'develop'
+		return 0
+	fi
+	return 1
+}
+
+got=$(_pms_default_branch "example/repo")
+assert_eq "8a: default branch resolves from repo API" "develop" "$got"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 9: shellcheck cleanliness.
+# ---------------------------------------------------------------------------
+echo "--- Section 9: shellcheck ---"
 
 run_shellcheck() {
 	local label="$1" file="$2"
@@ -368,8 +421,8 @@ run_shellcheck() {
 	return 0
 }
 
-run_shellcheck "7a: pulse-merge-stuck.sh passes shellcheck" "$MODULE"
-run_shellcheck "7b: pulse-stats-helper.sh passes shellcheck" "$STATS_HELPER"
+run_shellcheck "9a: pulse-merge-stuck.sh passes shellcheck" "$MODULE"
+run_shellcheck "9b: pulse-stats-helper.sh passes shellcheck" "$STATS_HELPER"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Resolve each repository default branch before emitting merge-stuck worker guidance.
- Deduplicate repeated PR observations before filing pattern-outage issues so counts match affected PR lists.
- Add regression coverage for default branch resolution and duplicate PR counting.

Resolves #23070

## Verification
- `.agents/scripts/tests/test-pulse-merge-stuck.sh`
- `shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh`
- `.agents/scripts/linters-local.sh` (passes; reports pre-existing advisory debt)
