### PR TITLE
fix: transfer precreated worker worktree ownership

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -663,6 +663,14 @@ _hrw_worktree_clean_for_owner_reclaim() {
 	return 0
 }
 
+_hrw_is_dispatch_precreate_owner() {
+	local owner_session="$1"
+	case "$owner_session" in
+		dispatch-precreate | dispatch-precreate-*) return 0 ;;
+	esac
+	return 1
+}
+
 _hrw_reclaim_stale_worker_worktree_owner() {
 	local session_key="$1"
 	local work_dir="$2"
@@ -683,6 +691,21 @@ _hrw_reclaim_stale_worker_worktree_owner() {
 
 	_WORKER_PRELAUNCH_FAILURE_REASON="worker_worktree_live_owner"
 	[[ -n "${WORKER_ISSUE_NUMBER:-}" && "$owner_task" == "${WORKER_ISSUE_NUMBER:-}" ]] || return 1
+
+	# Dispatcher worktree pre-creation registers ownership to a live pulse
+	# process before the detached worker starts. That owner is intentionally
+	# short-lived and transferable; otherwise every worker sees a live owner,
+	# exits immediately, and pulse retries the same issue forever.
+	if _hrw_is_dispatch_precreate_owner "$owner_session"; then
+		if ! _hrw_worktree_clean_for_owner_reclaim "$work_dir"; then
+			return 1
+		fi
+		unregister_worktree "$work_dir" 2>/dev/null || true
+		print_info "[lifecycle] worker_worktree_reclaimed_dispatch_precreate_owner session=${session_key} branch=${branch} path=${work_dir} previous_pid=${owner_pid}"
+		unset _WORKER_PRELAUNCH_FAILURE_REASON 2>/dev/null || true
+		return 0
+	fi
+
 	[[ -n "$created_at" ]] || return 1
 
 	local now_epoch="" created_epoch=""

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -672,6 +672,7 @@ _dlw_precreate_worktree() {
 	_DLW_WORKTREE_PATH=""
 	_DLW_WORKTREE_BRANCH=""
 	_DLW_WORKTREE_REUSED=0
+	local _precreate_session="dispatch-precreate-${issue_number}"
 
 	local _wt_helper="${SCRIPT_DIR}/worktree-helper.sh"
 	if [[ ! -x "$_wt_helper" || ! -d "$repo_path" ]]; then
@@ -706,6 +707,11 @@ _dlw_precreate_worktree() {
 		_DLW_WORKTREE_PATH="$_existing_path"
 		_DLW_WORKTREE_BRANCH="$_existing_branch"
 		_DLW_WORKTREE_REUSED=1
+		if declare -F register_worktree >/dev/null 2>&1; then
+			register_worktree "$_DLW_WORKTREE_PATH" "$_DLW_WORKTREE_BRANCH" \
+				--task "$issue_number" \
+				--session "$_precreate_session" 2>/dev/null || true
+		fi
 		# Restore gitignored deps that git clean -fd just wiped
 		_dlw_restore_worktree_deps "$_DLW_WORKTREE_PATH" "$repo_path"
 		echo "[dispatch_with_dedup] Reusing existing worktree for #${issue_number}: ${_DLW_WORKTREE_PATH} (branch: ${_DLW_WORKTREE_BRANCH})" >>"$LOGFILE"
@@ -736,6 +742,11 @@ _dlw_precreate_worktree() {
 	if [[ -n "$_path" && -d "$_path" ]]; then
 		_DLW_WORKTREE_PATH="$_path"
 		_DLW_WORKTREE_BRANCH="$_branch"
+		if declare -F register_worktree >/dev/null 2>&1; then
+			register_worktree "$_DLW_WORKTREE_PATH" "$_DLW_WORKTREE_BRANCH" \
+				--task "$issue_number" \
+				--session "$_precreate_session" 2>/dev/null || true
+		fi
 		# Restore gitignored deps (node_modules) that git doesn't track
 		_dlw_restore_worktree_deps "$_DLW_WORKTREE_PATH" "$repo_path"
 		echo "[dispatch_with_dedup] Pre-created worktree for #${issue_number}: ${_DLW_WORKTREE_PATH} (branch: ${_DLW_WORKTREE_BRANCH})" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -374,6 +374,53 @@ test_worker_worktree_claim_reclaims_stale_live_same_task_owner() {
 	return 0
 }
 
+test_worker_worktree_claim_reclaims_dispatch_precreate_owner() {
+	local worktree_dir="${TEST_ROOT}/claim-dispatch-precreate-owner"
+	mkdir -p "$worktree_dir"
+	init_git_worktree "$worktree_dir"
+	export WORKER_ISSUE_NUMBER="22438"
+	export AIDEVOPS_WORKER_WORKTREE_OWNER_RECLAIM_AGE_SECONDS="900"
+	local claim_calls=0 unregister_called=0
+	local live_pid="$$"
+
+	claim_worktree_ownership() {
+		local claim_path="$1"
+		local claim_branch="$2"
+		shift 2
+		claim_calls=$((claim_calls + 1))
+		[[ -n "$claim_path" && -n "$claim_branch" ]] || return 1
+		[[ "$claim_calls" -gt 1 ]] && return 0
+		return 1
+	}
+	check_worktree_owner() {
+		local check_path="$1"
+		[[ -n "$check_path" ]] || return 1
+		printf '%s|%s|%s|%s|%s\n' "$live_pid" "dispatch-precreate-22438" "" "22438" "2099-01-01T00:00:00Z"
+		return 0
+	}
+	unregister_worktree() {
+		local unregister_path="$1"
+		[[ -n "$unregister_path" ]] || return 1
+		unregister_called=$((unregister_called + 1))
+		return 0
+	}
+
+	local status=0
+	_hrw_claim_worker_worktree "issue-22438" "$worktree_dir" >/dev/null || status=$?
+
+	unset -f claim_worktree_ownership check_worktree_owner unregister_worktree 2>/dev/null || true
+	unset WORKER_ISSUE_NUMBER AIDEVOPS_WORKER_WORKTREE_OWNER_RECLAIM_AGE_SECONDS _WORKER_PRELAUNCH_FAILURE_REASON 2>/dev/null || true
+
+	if [[ "$status" -eq 0 && "$claim_calls" -eq 2 && "$unregister_called" -eq 1 ]]; then
+		print_result "worker worktree claim reclaims dispatch precreate owner" 0
+		return 0
+	fi
+
+	print_result "worker worktree claim reclaims dispatch precreate owner" 1 \
+		"status=$status calls=$claim_calls unregister=$unregister_called"
+	return 0
+}
+
 test_worker_worktree_clean_without_upstream_blocks_local_commits() {
 	local worktree_dir="${TEST_ROOT}/claim-local-commits"
 	mkdir -p "$worktree_dir"
@@ -1373,6 +1420,7 @@ main() {
 	test_issue_worker_env_contract_accepts_valid_precreated_worktree
 	test_worker_worktree_claim_transfers_to_runtime_pid
 	test_worker_worktree_claim_reclaims_stale_live_same_task_owner
+	test_worker_worktree_claim_reclaims_dispatch_precreate_owner
 	test_worker_worktree_clean_without_upstream_blocks_local_commits
 	test_worker_worktree_claim_classifies_unreclaimed_live_owner
 	test_deleted_cwd_recovery_uses_worker_worktree

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -121,6 +121,7 @@ export -f git
 # Stub dependent functions that _dlw_precreate_worktree calls
 # =============================================================================
 _dlw_restore_worktree_deps() { return 0; }
+REGISTERED_WORKTREE_ARGS=""
 
 # =============================================================================
 # Source pulse-stats-helper.sh for pulse_stats_increment
@@ -164,6 +165,31 @@ source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"
 # overwrite it). _dlw_precreate_worktree uses SCRIPT_DIR to find
 # worktree-helper.sh.
 SCRIPT_DIR="$TMP"
+
+# Re-stub register_worktree after sourcing; shared helper libraries may define
+# the real registry function, but this test only needs to assert transferable
+# ownership metadata passed by _dlw_precreate_worktree.
+register_worktree() {
+	local wt_path="$1"
+	local branch="$2"
+	shift 2
+	local task="" session=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--task)
+			task="${2:-}"
+			shift 2
+			;;
+		--session)
+			session="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	REGISTERED_WORKTREE_ARGS="${wt_path}|${branch}|${task}|${session}"
+	return 0
+}
 
 # Re-stub launch-orchestrator dependencies after sourcing; the module defines
 # real implementations when loaded, but this test isolates precreation failure.
@@ -230,6 +256,7 @@ STUB_WT_SUCCESS_PATH="${TMP}/projects/fake-repo-feature"
 export STUB_WT_SUCCESS_PATH
 mkdir -p "$STUB_WT_SUCCESS_PATH"
 : >"$LOGFILE"
+REGISTERED_WORKTREE_ARGS=""
 _dlw_precreate_worktree "88888" "$FAKE_REPO"
 rc=$?
 if [[ $rc -eq 0 ]]; then
@@ -248,6 +275,12 @@ if [[ "${_DLW_WORKTREE_REUSED:-unset}" == "0" ]]; then
 	pass "freshly-created worktree is marked non-reused"
 else
 	fail "freshly-created worktree is marked non-reused" "got: '${_DLW_WORKTREE_REUSED:-unset}', expected: '0'"
+fi
+
+if [[ "$REGISTERED_WORKTREE_ARGS" == "${STUB_WT_SUCCESS_PATH}|${_DLW_WORKTREE_BRANCH}|88888|dispatch-precreate-88888" ]]; then
+	pass "fresh precreated worktree is registered as transferable"
+else
+	fail "fresh precreated worktree is registered as transferable" "got: '$REGISTERED_WORKTREE_ARGS'"
 fi
 
 # =============================================================================
@@ -279,6 +312,7 @@ STUB_EXISTING_BRANCH="feature/auto-20260502-000000-gh66666"
 mkdir -p "$STUB_EXISTING_PATH"
 export STUB_EXISTING_WORKTREE_LINE="${STUB_EXISTING_PATH} abcdef [${STUB_EXISTING_BRANCH}]"
 : >"$LOGFILE"
+REGISTERED_WORKTREE_ARGS=""
 _dlw_precreate_worktree "66666" "$FAKE_REPO"
 rc=$?
 unset STUB_EXISTING_WORKTREE_LINE
@@ -293,6 +327,12 @@ if [[ "${_DLW_WORKTREE_REUSED:-unset}" == "1" ]]; then
 	pass "reused worktree is marked reused"
 else
 	fail "reused worktree is marked reused" "got: '${_DLW_WORKTREE_REUSED:-unset}', expected: '1'"
+fi
+
+if [[ "$REGISTERED_WORKTREE_ARGS" == "${STUB_EXISTING_PATH}|${STUB_EXISTING_BRANCH}|66666|dispatch-precreate-66666" ]]; then
+	pass "reused precreated worktree is registered as transferable"
+else
+	fail "reused precreated worktree is registered as transferable" "got: '$REGISTERED_WORKTREE_ARGS'"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Mark dispatcher-created worker worktrees as transferable with task/session metadata.
- Allow issue workers to reclaim clean same-task `dispatch-precreate-*` ownership immediately instead of exiting with `worker_worktree_live_owner`.
- Add regression coverage for dispatch-precreate ownership transfer and registration.

Resolves #23071

## Verification
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-precreation-failure-skip.sh`
- `shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-headless-runtime-helper.sh .agents/scripts/tests/test-precreation-failure-skip.sh`
- `.agents/scripts/linters-local.sh` (passes; reports pre-existing advisory debt)
