### PR TITLE
GH#23074: fix: protect worker worktrees during cleanup

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -11,6 +11,8 @@
 #   # shellcheck source=audit-worktree-removal-helper.sh
 #   source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
 #   log_worktree_removal_event "$_WTAR_REMOVED" "worktree-helper.sh" "/path/to/wt" "branch-merged" "permanent"
+#   log_worktree_removal_event "$_WTAR_SKIPPED" "pulse-cleanup.sh" "/path/to/wt" "owned-skip" "skipped" \
+#     "branch=feature/gh123 issue=123 owner_guard=active pr_state=none recovery_path=none"
 #
 # Event types (use the constants below to avoid repeated literal violations):
 #   _WTAR_REMOVED          "removed"        — worktree was actually removed
@@ -59,9 +61,11 @@ _WTAR_FIXTURE_REMOVED="fixture-removed"
 #   $3  wt_path     — absolute path to the worktree
 #   $4  reason      — short reason string (see Reason values above)
 #   $5  mode        — optional removal mode: trash, permanent, fixture, skipped
+#   $6  context     — optional safe key=value context for guard predicates/recovery
 #
 # Output format (append to AIDEVOPS_CLEANUP_LOG):
 #   [2026-04-27T11:22:33Z] [worktree-helper.sh] worktree-removed: /path/to/wt — branch-merged — mode=permanent
+#   [2026-05-07T12:00:00Z] [pulse-cleanup.sh] worktree-skipped: /path/to/wt — owned-skip — mode=skipped — branch=feature/gh123 issue=123 owner_guard=active
 #
 # Returns 0 always (fail-open).
 # =============================================================================
@@ -71,20 +75,33 @@ log_worktree_removal_event() {
 	local wt_path="$3"
 	local reason="$4"
 	local mode="${5:-unknown}"
+	local context="${6:-}"
 	local log_file="${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}"
 
 	# Ensure log directory exists (silent; don't fail callers on permission errors)
 	mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
 
 	# Write one structured line and swallow any write error (fail-open)
-	printf '[%s] [%s] worktree-%s: %s — %s — mode=%s\n' \
-		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-		"$caller" \
-		"$event_type" \
-		"$wt_path" \
-		"$reason" \
-		"$mode" \
-		>>"$log_file" 2>/dev/null || true
+	if [[ -n "$context" ]]; then
+		printf '[%s] [%s] worktree-%s: %s — %s — mode=%s — %s\n' \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			"$caller" \
+			"$event_type" \
+			"$wt_path" \
+			"$reason" \
+			"$mode" \
+			"$context" \
+			>>"$log_file" 2>/dev/null || true
+	else
+		printf '[%s] [%s] worktree-%s: %s — %s — mode=%s\n' \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			"$caller" \
+			"$event_type" \
+			"$wt_path" \
+			"$reason" \
+			"$mode" \
+			>>"$log_file" 2>/dev/null || true
+	fi
 
 	return 0
 }
@@ -186,6 +203,7 @@ worktree_removal_guard() {
 #   $1  wt_path  — absolute path candidate
 #   $2  caller   — audit caller constant
 #   $3  reason   — audit reason on removal
+#   $4  context  — optional safe key=value guard context
 #
 # Returns 0 when path is gone, 1 on guard/delete failure.
 # =============================================================================
@@ -193,12 +211,13 @@ remove_worktree_path_permanently() {
 	local wt_path="$1"
 	local caller="$2"
 	local reason="$3"
+	local context="${4:-}"
 
 	worktree_removal_guard "$wt_path" "$caller" "$reason" || return 1
 	[[ ! -e "$wt_path" ]] && return 0
 
 	if rm -rf "$wt_path" 2>/dev/null; then
-		log_worktree_removal_event "$_WTAR_REMOVED" "$caller" "$wt_path" "$reason" "permanent"
+		log_worktree_removal_event "$_WTAR_REMOVED" "$caller" "$wt_path" "$reason" "permanent" "$context"
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -75,6 +75,101 @@ unset _PULSE_CLEANUP_SCRIPT_DIR
 # Caller ID constant for audit log calls (avoids repeated literals).
 _WTAR_PC_CALLER="pulse-cleanup.sh"
 
+#######################################
+# Extract a GitHub issue number from worker-style branch names.
+#
+# Args:
+#   $1 - branch name
+# Outputs: issue number when present
+# Returns: 0 when an issue was found, 1 otherwise
+#######################################
+_pc_issue_from_branch() {
+	local branch_name="$1"
+	if [[ "$branch_name" =~ gh[-]?([0-9]+) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Build safe audit context for orphan cleanup decisions.
+#
+# Args:
+#   $1 - branch name
+#   $2 - issue number or empty
+#   $3 - commits ahead
+#   $4 - dirty count
+#   $5 - age seconds
+#   $6 - PR state summary
+#   $7 - owner guard summary
+#   $8 - process guard summary
+#   $9 - recent session guard summary
+#   ${10} - removal/recovery path summary
+# Outputs: space-separated key=value context with no private repo slug
+# Returns 0 always
+#######################################
+_pc_worktree_audit_context() {
+	local branch_name="$1"
+	local issue_number="$2"
+	local commits_ahead="$3"
+	local dirty_count="$4"
+	local wt_age_secs="$5"
+	local pr_state="$6"
+	local owner_guard="$7"
+	local process_guard="$8"
+	local recent_guard="$9"
+	local recovery_path="${10}"
+	local session_key="none"
+	if [[ -n "$issue_number" ]]; then
+		session_key="issue-${issue_number}"
+	fi
+
+	printf 'branch=%s issue=%s session_key=%s owner_guard=%s process_guard=%s recent_session_guard=%s commits=%s dirty=%s pr_state=%s age_secs=%s recovery_path=%s\n' \
+		"${branch_name:-detached}" \
+		"${issue_number:-none}" \
+		"$session_key" \
+		"$owner_guard" \
+		"$process_guard" \
+		"$recent_guard" \
+		"$commits_ahead" \
+		"$dirty_count" \
+		"$pr_state" \
+		"$wt_age_secs" \
+		"$recovery_path"
+	return 0
+}
+
+#######################################
+# Check recent worker runtime metrics for the issue/session key.
+#
+# Args:
+#   $1 - issue number
+#   $2 - now epoch
+#   $3 - grace window seconds
+# Returns: 0 when a recent matching metric exists, 1 otherwise
+#######################################
+_pc_recent_worker_metric_exists() {
+	local issue_number="$1"
+	local now_epoch="$2"
+	local grace_secs="$3"
+	local metrics_file="${AIDEVOPS_HEADLESS_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+
+	[[ -n "$issue_number" ]] || return 1
+	[[ -f "$metrics_file" ]] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+
+	local cutoff_epoch=$((now_epoch - grace_secs))
+	jq -e --arg issue "$issue_number" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
+		select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)
+		| select(
+			((.issue_number // "") | tostring) == $issue
+			or ((.session_key // "") | tostring | test("(^|[^0-9])" + $issue + "([^0-9]|$)"))
+		)
+	' "$metrics_file" >/dev/null 2>&1
+	return $?
+}
+
 # t2859: Config defaults (ORPHAN_WORKTREE_GRACE_SECS, ORPHAN_MAX_AGE,
 # PULSE_IDLE_CPU_THRESHOLD) are owned by pulse-wrapper-config.sh. When
 # this module is sourced standalone (cleanup-worktrees-async-helper.sh,
@@ -702,6 +797,23 @@ _cleanup_single_worktree() {
 
 	local repo_name_age
 	repo_name_age=$(basename "$rp_age")
+	local orphan_issue_num=""
+	orphan_issue_num=$(_pc_issue_from_branch "$wt_branch_age" 2>/dev/null || true)
+	local age_grace="${ORPHAN_WORKTREE_GRACE_SECS:-1800}"
+	local audit_context
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "clear" "clear" "clear" "none")
+	if _pc_recent_worker_metric_exists "$orphan_issue_num" "$now_epoch" "$age_grace"; then
+		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "clear" "clear" "active" "none")
+		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — recent worker runtime metric/session record" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "active-worker-metric" "skipped" "$audit_context"
+		return 1
+	fi
+	if [[ "$commits_ahead" -gt 0 && "$reason" == *"no PR"* ]]; then
+		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "clear" "clear" "clear" "none")
+		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — local commits with no PR are not permanently removable" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "local-commits-no-pr" "skipped" "$audit_context"
+		return 1
+	fi
 	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
 
 	# Step 5a: crash classification for the fast-path "crashed worker" case
@@ -712,9 +824,9 @@ _cleanup_single_worktree() {
 	# Step 5b: perform removal (guarded permanent delete + deregister + branch cleanup)
 	# Age/PR/dirty gates above prove this orphaned worktree is disposable; remove
 	# permanently to avoid growing system Trash.
-	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "age-eligible"; then
+	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "age-eligible" "$audit_context"; then
 		if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
-			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "age-eligible" "permanent"
+			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "age-eligible" "permanent" "$audit_context"
 		else
 			return 1
 		fi

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23074: pulse orphan cleanup must not permanently remove
+# worker-style worktrees that have local commits and no PR while worker ownership
+# signals are active/recent.
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PULSE_CLEANUP="${SCRIPT_DIR}/../pulse-cleanup.sh"
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s %s\n' "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+setup_repo_with_worker_worktree() {
+	local repo_dir="$1"
+	local wt_path="$2"
+	local branch_name="$3"
+
+	mkdir -p "$repo_dir"
+	(
+		cd "$repo_dir" || exit 1
+		git init -q -b main
+		git config user.email "test@example.invalid"
+		git config user.name "Test Worker"
+		printf 'base\n' >README.md
+		git add README.md
+		git commit -q -m "init"
+		git worktree add -q -b "$branch_name" "$wt_path" main
+	)
+	(
+		cd "$wt_path" || exit 1
+		printf 'worker change\n' >worker.txt
+		git add worker.txt
+		git commit -q -m "worker commit"
+	)
+	local old_ts
+	old_ts=$(date -u -v-30H +%Y%m%d%H%M 2>/dev/null \
+		|| date -u -d "30 hours ago" +%Y%m%d%H%M 2>/dev/null \
+		|| printf '202601010000\n')
+	touch -t "$old_ts" "$wt_path/.git"
+	return 0
+}
+
+source_pulse_cleanup_with_stubs() {
+	LOGFILE="${TEST_ROOT}/pulse.log"
+	export LOGFILE
+	AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG
+	ORPHAN_WORKTREE_GRACE_SECS=1800
+	export ORPHAN_WORKTREE_GRACE_SECS
+
+	is_worktree_owned_by_others() { return 1; }
+	unregister_worktree() { local wt_path="$1"; : "$wt_path"; return 0; }
+	gh_pr_list() { return 0; }
+	recover_failed_launch_state() { return 0; }
+	gh_issue_comment() { return 0; }
+
+	unset _PULSE_CLEANUP_LOADED 2>/dev/null || true
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../portable-stat.sh
+	source "${SCRIPT_DIR}/../portable-stat.sh"
+	# shellcheck source=../pulse-cleanup.sh
+	source "$PULSE_CLEANUP"
+	return 0
+}
+
+test_recent_metric_blocks_local_commit_no_pr_removal() {
+	local repo_dir="${TEST_ROOT}/repo"
+	local wt_path="${TEST_ROOT}/worker-wt"
+	local branch_name="feature/auto-20260507-190801-gh23074"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	local metrics_file="${TEST_ROOT}/headless-runtime-metrics.jsonl"
+	printf '{"ts":%s,"issue_number":23074,"session_key":"issue-23074","result":"watchdog_stall_continue"}\n' "$now_epoch" >"$metrics_file"
+	AIDEVOPS_HEADLESS_METRICS_FILE="$metrics_file"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*active-worker-metric.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'recent_session_guard=active' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'commits=1' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "recent metric blocks local commits/no PR permanent cleanup" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_local_commit_no_pr_skips_without_recent_metric() {
+	local repo_dir="${TEST_ROOT}/repo-no-metric"
+	local wt_path="${TEST_ROOT}/worker-wt-no-metric"
+	local branch_name="feature/auto-20260507-190802-gh23075"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*local-commits-no-pr.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'owner_guard=clear' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'process_guard=clear' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'pr_state=none' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'recovery_path=none' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "local commits/no PR skip without safety proof" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap teardown EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+echo "=== test-pulse-cleanup-worker-owned-no-pr.sh ==="
+test_recent_metric_blocks_local_commit_no_pr_removal
+test_local_commit_no_pr_skips_without_recent_metric
+
+echo ""
+echo "Results: $((TESTS_RUN - TESTS_FAILED))/${TESTS_RUN} passed, ${TESTS_FAILED} failed."
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -12,6 +12,7 @@
 #   4. All three event types produce correct type strings in the log
 #   5. should_skip_cleanup emits worktree-skipped when ownership blocks removal
 #   6. Double-sourcing the audit helper is idempotent
+#   7. Optional guard context is appended when supplied
 #
 # All tests run in isolated temp directories; no real ~/.aidevops state is
 # written. Tests do not require git or gh — they exercise the logging functions
@@ -353,6 +354,27 @@ test_permanent_helper_removes_and_logs() {
 }
 
 # =============================================================================
+# Test 10: optional guard context includes predicates needed for safe cleanup audit
+# =============================================================================
+test_optional_guard_context_logged() {
+	local log_file="${TEST_DIR}/t10-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+
+	local context="branch=feature/gh23074 issue=23074 owner_guard=clear process_guard=clear recent_session_guard=clear commits=1 pr_state=none recovery_path=none"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "pulse-cleanup.sh" "/wt/context" "local-commits-no-pr" "skipped" "$context"
+
+	local rc=0
+	assert_file_contains "$log_file" "worktree-skipped.*local-commits-no-pr.*mode=skipped.*branch=feature/gh23074.*owner_guard=clear.*process_guard=clear.*recent_session_guard=clear.*commits=1.*pr_state=none.*recovery_path=none" || rc=1
+	print_result "optional_guard_context_logged" "$rc" \
+		"Expected guard context audit. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -369,6 +391,7 @@ test_idempotent_sourcing
 test_guard_refuses_current_cwd
 test_guard_refuses_other_process_cwd
 test_permanent_helper_removes_and_logs
+test_optional_guard_context_logged
 
 echo ""
 echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed."

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -50,7 +50,8 @@ if [[ -f "${SCRIPT_DIR}/canonical-guard-helper.sh" ]]; then
 	source "${SCRIPT_DIR}/canonical-guard-helper.sh"
 fi
 
-# t2976: canonical audit logger for worktree-removal events (removed / skipped).
+# t2976/GH#23074: canonical audit logger for worktree-removal events
+# (removed / skipped), including optional guard context when callers provide it.
 # Fallback definitions guard against set -u failures when the helper is absent
 # (e.g. older deployments). The source block below overrides these when the file exists.
 # The stub uses command -v so it is only defined when the real function is not yet


### PR DESCRIPTION
## Summary

Strengthened pulse orphan cleanup so worker-style worktrees with local commits and no PR are skipped unless safety is proven, added recent worker metric/session guard checks, and expanded worktree-removal audit context with branch, issue/session, guard, commit, PR, age, mode, and recovery fields.

## Files Changed

.agents/scripts/audit-worktree-removal-helper.sh,.agents/scripts/pulse-cleanup.sh,.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh,.agents/scripts/tests/test-worktree-removal-audit.sh,.agents/scripts/worktree-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh; bash .agents/scripts/tests/test-worktree-removal-audit.sh; bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh; shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/worktree-helper.sh; shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/tests/test-worktree-removal-audit.sh .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh

Resolves #23074


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.90 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 4m and 112,540 tokens on this as a headless worker.