### PR TITLE
GH#23076: fix: protect owned worktrees from branch-merged cleanup

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -247,8 +247,13 @@ _cleanup_merged_prs_for_all_repos() {
 		fi
 	fi
 
-	local helper="${HOME}/.aidevops/agents/scripts/worktree-helper.sh"
-	if [[ ! -x "$helper" ]]; then
+	local helper=""
+	if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -x "$_PULSE_CLEANUP_SCRIPT_DIR/worktree-helper.sh" ]]; then
+		helper="$_PULSE_CLEANUP_SCRIPT_DIR/worktree-helper.sh"
+	elif [[ -x "${HOME}/.aidevops/agents/scripts/worktree-helper.sh" ]]; then
+		helper="${HOME}/.aidevops/agents/scripts/worktree-helper.sh"
+	fi
+	if [[ -z "$helper" ]]; then
 		echo 0
 		return 0
 	fi

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#23076: branch-merged cleanup must not remove a
+# worktree already classified as protected in the same cleanup pass, and PR or
+# branch metadata must not produce permanent deletion without merge-base proof.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CLEAN_LIB_PATH="${TEST_SCRIPTS_DIR}/worktree-clean-lib.sh"
+AUDIT_HELPER_PATH="${TEST_SCRIPTS_DIR}/audit-worktree-removal-helper.sh"
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "$HOME/.aidevops/logs"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_file_contains() {
+	local file_path="$1"
+	local pattern="$2"
+	grep -Eq "$pattern" "$file_path" 2>/dev/null
+	return $?
+}
+
+setup_repo() {
+	local repo_path="$1"
+	mkdir -p "$repo_path" || return 1
+	git -C "$repo_path" init -q -b main || return 1
+	git -C "$repo_path" config user.email "test@test.local" || return 1
+	git -C "$repo_path" config user.name "Test" || return 1
+	git -C "$repo_path" remote add origin "https://github.com/testowner/testrepo.git" || return 1
+	printf 'init\n' >"$repo_path/README.md" || return 1
+	git -C "$repo_path" add README.md || return 1
+	git -C "$repo_path" commit -q -m "init" || return 1
+	return 0
+}
+
+source_clean_lib_with_stubs() {
+	: "${RED:=}" "${GREEN:=}" "${YELLOW:=}" "${BLUE:=}" "${BOLD:=}" "${NC:=}"
+	_WTAR_REMOVED="${_WTAR_REMOVED:-removed}"
+	_WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"
+	_WTAR_WH_CALLER="${_WTAR_WH_CALLER:-worktree-helper.sh}"
+	
+	is_registered_canonical() { return 1; }
+	_branch_has_active_interactive_claim() { return 1; }
+	is_worktree_owned_by_others() { return 1; }
+	check_worktree_owner() { printf '\n'; return 0; }
+	worktree_is_in_grace_period() { return 1; }
+	worktree_has_changes() { return 1; }
+	branch_has_zero_commits_ahead() { return 1; }
+	branch_was_pushed() { return 1; }
+	_branch_exists_on_any_remote() { return 0; }
+	trash_path() { return 0; }
+	get_default_branch() { printf '%s\n' "main"; return 0; }
+	localdev_auto_branch_rm() { return 0; }
+	assert_git_available() { return 0; }
+	assert_main_worktree_sane() { return 0; }
+	gh_pr_list() { return 0; }
+
+	# shellcheck source=/dev/null
+	source "$AUDIT_HELPER_PATH" || return 1
+	# shellcheck source=/dev/null
+	source "$CLEAN_LIB_PATH" || return 1
+	return 0
+}
+
+test_protected_pass_set_blocks_branch_merged_removal() {
+	local repo_path="${TEST_ROOT}/repo-protected"
+	local wt_path="${TEST_ROOT}/wt-protected"
+	local log_file="${TEST_ROOT}/protected-cleanup.log"
+	local branch="feature/gh-99021-protected"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'merged\n' >"$repo_path/merged.txt" || rc=1
+	git -C "$repo_path" add merged.txt || rc=1
+	git -C "$repo_path" commit -q -m "merged branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" merge -q --no-ff "$branch" -m "merge branch" || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_protected_mark "$wt_path"
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "" "" "false" "" >/dev/null
+	) || rc=1
+
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*protected-pass-skip.*mode=skipped.*protected_status=pass-local" || rc=1
+	print_result "protected pass-local set blocks branch-merged removal" "$rc" \
+		"Expected worktree to survive and protected audit entry in $log_file"
+	return 0
+}
+
+test_merged_pr_without_ancestor_proof_skips() {
+	local repo_path="${TEST_ROOT}/repo-unproven"
+	local wt_path="${TEST_ROOT}/wt-unproven"
+	local log_file="${TEST_ROOT}/unproven-cleanup.log"
+	local branch="feature/gh-99022-unproven"
+	local classification=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'not ancestor\n' >"$repo_path/unproven.txt" || rc=1
+	git -C "$repo_path" add unproven.txt || rc=1
+	git -C "$repo_path" commit -q -m "unmerged branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	classification=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "$branch" "" "false" ""
+	) || rc=1
+
+	[[ -z "$classification" ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*branch-merged-unproven.*mode=skipped.*merge_proof_result=not-ancestor" || rc=1
+	print_result "merged PR metadata without ancestor proof skips" "$rc" \
+		"Expected empty classification, surviving worktree, and unproven audit entry"
+	return 0
+}
+
+echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
+test_protected_pass_set_blocks_branch_merged_removal
+test_merged_pr_without_ancestor_proof_skips
+
+printf '\nResults: %d/%d passed, %d failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -366,9 +366,12 @@ test_optional_guard_context_logged() {
 
 	local context="branch=feature/gh23074 issue=23074 owner_guard=clear process_guard=clear recent_session_guard=clear commits=1 pr_state=none recovery_path=none"
 	log_worktree_removal_event "$_WTAR_SKIPPED" "pulse-cleanup.sh" "/wt/context" "local-commits-no-pr" "skipped" "$context"
+	local branch_merged_context="target_branch=main merge_proof=merge-base-is-ancestor merge_proof_result=ancestor branch=feature/gh23076 owner_guard=clear protected_status=clear"
+	log_worktree_removal_event "$_WTAR_REMOVED" "worktree-helper.sh" "/wt/merged" "branch-merged" "permanent" "$branch_merged_context"
 
 	local rc=0
 	assert_file_contains "$log_file" "worktree-skipped.*local-commits-no-pr.*mode=skipped.*branch=feature/gh23074.*owner_guard=clear.*process_guard=clear.*recent_session_guard=clear.*commits=1.*pr_state=none.*recovery_path=none" || rc=1
+	assert_file_contains "$log_file" "worktree-removed.*branch-merged.*mode=permanent.*target_branch=main.*merge_proof=merge-base-is-ancestor.*merge_proof_result=ancestor.*protected_status=clear" || rc=1
 	print_result "optional_guard_context_logged" "$rc" \
 		"Expected guard context audit. Log: $(cat "$log_file" 2>/dev/null)"
 	return 0

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -399,11 +399,59 @@ _clean_build_closed_pr_branches() {
 	return 0
 }
 
+_WT_CLEAN_PROTECTED_PATHS="${_WT_CLEAN_PROTECTED_PATHS:-}"
+_WT_CLEAN_LAST_MERGE_TYPE="${_WT_CLEAN_LAST_MERGE_TYPE:-}"
+_WT_CLEAN_LAST_AUDIT_CONTEXT="${_WT_CLEAN_LAST_AUDIT_CONTEXT:-}"
+
+_clean_protected_mark() {
+	local wt_path="$1"
+	[[ -z "$wt_path" ]] && return 0
+	case $'\n'"$_WT_CLEAN_PROTECTED_PATHS"$'\n' in
+	*$'\n'"$wt_path"$'\n'*) ;;
+	*) _WT_CLEAN_PROTECTED_PATHS="${_WT_CLEAN_PROTECTED_PATHS}${wt_path}"$'\n' ;;
+	esac
+	return 0
+}
+
+_clean_protected_contains() {
+	local wt_path="$1"
+	[[ -z "$wt_path" ]] && return 1
+	case $'\n'"$_WT_CLEAN_PROTECTED_PATHS"$'\n' in
+	*$'\n'"$wt_path"$'\n'*) return 0 ;;
+	esac
+	return 1
+}
+
+_clean_branch_head() {
+	local wt_branch="$1"
+	git rev-parse --verify "refs/heads/${wt_branch}" 2>/dev/null
+	return $?
+}
+
+_clean_branch_merge_proof_context() {
+	local wt_branch="$1"
+	local default_br="$2"
+	local head_sha="${3:-unknown}"
+	local proof_result="${4:-unknown}"
+	printf 'target_branch=%s merge_proof=merge-base-is-ancestor merge_proof_result=%s head=%s branch=%s owner_guard=clear protected_status=clear' \
+		"$default_br" "$proof_result" "$head_sha" "$wt_branch"
+	return 0
+}
+
+_clean_branch_head_is_ancestor() {
+	local wt_branch="$1"
+	local default_br="$2"
+	local head_sha
+	head_sha=$(_clean_branch_head "$wt_branch") || return 1
+	git merge-base --is-ancestor "$head_sha" "$default_br" 2>/dev/null
+	return $?
+}
+
 # Determine if a worktree entry is merged, and print it if so.
 # Args: $1=wt_path, $2=wt_branch, $3=default_branch, $4=remote_state_unknown,
 #       $5=merged_pr_branches, $6=open_pr_branches, $7=force_merged,
 #       $8=closed_pr_branches
-# Outputs the merge_type to stdout if merged (caller checks non-empty).
+# Outputs merge_type<TAB>audit_context to stdout if safely merged.
 _clean_classify_worktree() {
 	local wt_path="$1"
 	local wt_branch="$2"
@@ -416,6 +464,17 @@ _clean_classify_worktree() {
 
 	local is_merged=false
 	local merge_type=""
+	local head_sha="unknown"
+	local proof_result="unavailable"
+	local audit_context=""
+	_WT_CLEAN_LAST_MERGE_TYPE=""
+	_WT_CLEAN_LAST_AUDIT_CONTEXT=""
+
+	if _clean_protected_contains "$wt_path"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "protected-pass-skip" "skipped" \
+			"branch=$wt_branch target_branch=$default_br owner_guard=protected protected_status=pass-local"
+		return 0
+	fi
 
 	# Check 1: Traditional merge detection
 	# t3545/GH#22606: require ≥1 commit ahead of default. git branch --merged
@@ -454,17 +513,32 @@ _clean_classify_worktree() {
 		return 0
 	fi
 
-	# Apply safety checks using shared helper
-	if should_skip_cleanup "$wt_path" "$wt_branch" "$default_br" "$open_prs" "$force_merged"; then
+	head_sha=$(_clean_branch_head "$wt_branch" 2>/dev/null || printf '%s' "unknown")
+	if _clean_branch_head_is_ancestor "$wt_branch" "$default_br"; then
+		proof_result="ancestor"
+	else
+		proof_result="not-ancestor"
+		audit_context=$(_clean_branch_merge_proof_context "$wt_branch" "$default_br" "$head_sha" "$proof_result")
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "branch-merged-unproven" "skipped" "$audit_context"
 		return 0
 	fi
+
+	# Apply safety checks using shared helper
+	if should_skip_cleanup "$wt_path" "$wt_branch" "$default_br" "$open_prs" "$force_merged"; then
+		_clean_protected_mark "$wt_path"
+		return 0
+	fi
+
+	audit_context=$(_clean_branch_merge_proof_context "$wt_branch" "$default_br" "$head_sha" "$proof_result")
 
 	if worktree_has_changes "$wt_path" && [[ "$force_merged" == "true" ]]; then
 		# PR is confirmed merged — dirty state is abandoned WIP, safe to force-remove
 		merge_type="$merge_type, dirty (force)"
 	fi
 
-	echo "$merge_type"
+	_WT_CLEAN_LAST_MERGE_TYPE="$merge_type"
+	_WT_CLEAN_LAST_AUDIT_CONTEXT="$audit_context"
+	printf '%s\t%s\n' "$merge_type" "$audit_context"
 	return 0
 }
 
@@ -493,7 +567,8 @@ _clean_scan_merged() {
 		elif [[ -z "$line" ]]; then
 			if [[ -n "$worktree_branch" ]] && [[ "$worktree_branch" != "$default_br" ]] && [[ "$worktree_path" != "$main_wt_path" ]]; then
 				local merge_type
-				merge_type=$(_clean_classify_worktree "$worktree_path" "$worktree_branch" "$default_br" "$remote_unknown" "$merged_prs" "$open_prs" "$force_merged" "$closed_prs")
+				_clean_classify_worktree "$worktree_path" "$worktree_branch" "$default_br" "$remote_unknown" "$merged_prs" "$open_prs" "$force_merged" "$closed_prs" >/dev/null
+				merge_type="$_WT_CLEAN_LAST_MERGE_TYPE"
 				if [[ -n "$merge_type" ]]; then
 					found_any=true
 					echo -e "  ${YELLOW}$worktree_branch${NC} ($merge_type)" >&2
@@ -536,14 +611,32 @@ _clean_remove_merged() {
 			worktree_branch="${BASH_REMATCH[1]}"
 		elif [[ -z "$line" ]]; then
 			if [[ -n "$worktree_branch" ]] && [[ "$worktree_branch" != "$default_br" ]] && [[ "$worktree_path" != "$main_wt_path" ]]; then
+				if _clean_protected_contains "$worktree_path"; then
+					log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "protected-pass-skip" "skipped" \
+						"branch=$worktree_branch target_branch=$default_br owner_guard=protected protected_status=pass-local"
+					worktree_path=""
+					worktree_branch=""
+					continue
+				fi
 				local merge_type
-				merge_type=$(_clean_classify_worktree "$worktree_path" "$worktree_branch" "$default_br" "$remote_unknown" "$merged_prs" "$open_prs" "$force_merged" "$closed_prs")
+				local audit_context
+				_clean_classify_worktree "$worktree_path" "$worktree_branch" "$default_br" "$remote_unknown" "$merged_prs" "$open_prs" "$force_merged" "$closed_prs" >/dev/null
+				merge_type="$_WT_CLEAN_LAST_MERGE_TYPE"
+				audit_context="$_WT_CLEAN_LAST_AUDIT_CONTEXT"
 				if [[ -n "$merge_type" ]]; then
 					local use_force=false
 					if worktree_has_changes "$worktree_path" && [[ "$force_merged" == "true" ]]; then
 						use_force=true
 					fi
 					echo -e "${BLUE}Removing $worktree_branch...${NC}" >&2
+					if _clean_protected_contains "$worktree_path"; then
+						log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "protected-pass-skip" "skipped" \
+							"branch=$worktree_branch target_branch=$default_br owner_guard=protected protected_status=pass-local"
+						echo -e "${YELLOW}Skipped $worktree_branch - protected earlier in this cleanup pass${NC}" >&2
+						worktree_path=""
+						worktree_branch=""
+						continue
+					fi
 					if ! worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "branch-merged"; then
 						echo -e "${YELLOW}Skipped $worktree_branch - removal guard refused path${NC}" >&2
 						worktree_path=""
@@ -558,7 +651,7 @@ _clean_remove_merged() {
 					# Safety gates above prove the completed worktree is disposable; remove
 					# permanently to avoid growing system Trash, then prune git's registry.
 					local removed=false
-					if remove_worktree_path_permanently "$worktree_path" "$_WTAR_WH_CALLER" "branch-merged"; then
+					if remove_worktree_path_permanently "$worktree_path" "$_WTAR_WH_CALLER" "branch-merged" "$audit_context"; then
 						git worktree prune 2>/dev/null || true
 						removed=true
 					else
@@ -568,7 +661,7 @@ _clean_remove_merged() {
 						fi
 						# shellcheck disable=SC2086
 						if git worktree remove $remove_flag "$worktree_path" 2>/dev/null; then
-							log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "branch-merged" "permanent"
+							log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "branch-merged" "permanent" "$audit_context"
 							removed=true
 						fi
 					fi

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -34,7 +34,8 @@
 #   worktree-helper-git.sh          git utilities + stale remote handling
 #   worktree-helper-add.sh          path utils + cmd_add and all its helpers
 #   worktree-helper-cmds.sh         cmd_list, remove, status, switch, registry, help
-#   worktree-clean-lib.sh           cmd_clean (existing split, GH#21409)
+#   worktree-clean-lib.sh           cmd_clean (existing split, GH#21409),
+#                                   including branch-merged safety proof gates
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit


### PR DESCRIPTION
## Summary

Added pass-local protected worktree tracking, explicit merge-base proof for branch-merged permanent cleanup, safer pulse helper resolution, and regression coverage for protected/unproven branch-merged paths.

## Files Changed

.agents/scripts/pulse-cleanup.sh,.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh,.agents/scripts/tests/test-worktree-removal-audit.sh,.agents/scripts/worktree-clean-lib.sh,.agents/scripts/worktree-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh; bash .agents/scripts/tests/test-worktree-removal-audit.sh; bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh; shellcheck .agents/scripts/worktree-helper.sh .agents/scripts/worktree-clean-lib.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh .agents/scripts/tests/test-worktree-removal-audit.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh

Resolves #23076


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.90 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 17m and 83,372 tokens on this as a headless worker.