### PR TITLE
GH#23073: isolate systemd pulse workers from oneshot cgroup

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -16,6 +16,7 @@
 #   - _dlw_precreate_worktree
 #   - _dlw_prewarm_opencode_db
 #   - _dlw_exec_detached
+#   - _dlw_exec_systemd_user_service
 #   - _dlw_spawn_early_exit_monitor
 #   - _dlw_spawn_lifecycle_observer (t3055/GH#21870)
 #   - _dlw_nohup_launch
@@ -820,11 +821,85 @@ _dlw_prewarm_opencode_db() {
 }
 
 #######################################
-# Execute a worker command via setsid + nohup, detaching it from the
-# pulse's process group (t2757). Without setsid, workers inherit pulse's
-# PGID. Any PG-scoped signal (launchd unload, pkill -PGRP, restart chain)
-# kills in-flight workers. setsid creates a new session, so pulse signals
-# cannot propagate.
+# Return 0 when a Linux systemd user manager is available for transient
+# services. `setsid` detaches workers from the pulse process group, but it
+# does NOT move them out of the systemd service cgroup. On systemd pulse
+# timers, long-lived children therefore remain visible as leftovers after the
+# oneshot exits (GH#23073). A transient user service gives each worker an
+# intentional lifecycle owner outside aidevops-supervisor-pulse.service.
+_dlw_systemd_user_service_available() {
+	[[ "${AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE:-0}" == "1" ]] && return 1
+	[[ "$(uname -s 2>/dev/null || printf '%s' unknown)" == "Linux" ]] || return 1
+	command -v systemd-run >/dev/null 2>&1 || return 1
+	command -v systemctl >/dev/null 2>&1 || return 1
+	systemctl --user status >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_dlw_systemd_unit_name() {
+	local unit_prefix="$1"
+	local issue_number="$2"
+	local suffix="${RANDOM:-0}"
+	printf '%s-%s-%s-%s' "$unit_prefix" "${issue_number:-unknown}" "$$" "$suffix"
+	return 0
+}
+
+_dlw_exec_systemd_user_service() {
+	local unit_prefix="$1"
+	local worker_log="$2"
+	local issue_number="$3"
+	shift 3
+
+	local pid_file=""
+	pid_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-systemd-worker.XXXXXX") || return 1
+	rm -f "$pid_file" 2>/dev/null || true
+
+	local unit_name=""
+	unit_name=$(_dlw_systemd_unit_name "$unit_prefix" "$issue_number")
+	local runner_script
+	# shellcheck disable=SC2016  # Expanded by the child bash launched by systemd-run.
+	runner_script='
+		_dlw_systemd_child() {
+			local pid_file="$1" out_log="$2"
+			shift 2
+			printf "%s\n" "$$" >"$pid_file" 2>/dev/null || true
+			exec "$@" </dev/null >>"$out_log" 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&-
+		}
+		_dlw_systemd_child "$@"
+	'
+
+	if ! systemd-run --user --unit="$unit_name" --collect --quiet \
+		--description="aidevops worker ${issue_number:-unknown}" \
+		/bin/bash -lc "$runner_script" _ "$pid_file" "$worker_log" "$@" \
+		>/dev/null 2>>"$LOGFILE"; then
+		rm -f "$pid_file" 2>/dev/null || true
+		return 1
+	fi
+
+	local wait_i=0 service_pid=""
+	while [[ "$wait_i" -lt 25 ]]; do
+		if [[ -s "$pid_file" ]]; then
+			read -r service_pid <"$pid_file" || service_pid=""
+			break
+		fi
+		sleep 0.2
+		wait_i=$((wait_i + 1))
+	done
+	rm -f "$pid_file" 2>/dev/null || true
+
+	if [[ "$service_pid" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$service_pid"
+		return 0
+	fi
+
+	echo "[dispatch_worker_launch] ERROR: systemd-run launched ${unit_name} for #${issue_number} but no child PID was reported" >>"$LOGFILE"
+	return 1
+}
+
+# Execute a worker command via systemd-run (Linux user services) or setsid +
+# nohup fallback, detaching it from the pulse's process group (t2757) and, on
+# systemd, from the pulse oneshot cgroup (GH#23073). Without this, workers
+# either die with the pulse cgroup or survive as ambiguous leftover children.
 #
 # macOS ships /usr/bin/setsid on recent versions (12+). Older macOS or
 # systems without setsid fall back to nohup-only with a log warning.
@@ -855,7 +930,15 @@ _dlw_exec_detached() {
 	# codebase and can be added if measurement justifies it.
 
 	local worker_pid
-	if command -v setsid >/dev/null 2>&1; then
+	if _dlw_systemd_user_service_available; then
+		if worker_pid=$(_dlw_exec_systemd_user_service "aidevops-worker" "$worker_log" "$issue_number" "$@"); then
+			echo "[dispatch_worker_launch] Issue #${issue_number}: worker PID=$worker_pid launched via systemd-run transient user service outside pulse cgroup" >>"$LOGFILE"
+		else
+			echo "[dispatch_worker_launch] WARNING: systemd-run worker launch failed for #${issue_number}; falling back to setsid/nohup" >>"$LOGFILE"
+		fi
+	fi
+
+	if [[ -z "${worker_pid:-}" ]] && command -v setsid >/dev/null 2>&1; then
 		setsid nohup "$@" </dev/null >>"$worker_log" 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
 		worker_pid="$!"
 		# Log the detached PGID for diagnostics (should differ from pulse PGID)
@@ -865,7 +948,7 @@ _dlw_exec_detached() {
 		pulse_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')
 		[[ -n "$pulse_pgid" ]] || pulse_pgid="unknown"
 		echo "[dispatch_worker_launch] Issue #${issue_number}: worker PID=$worker_pid PGID=$worker_pgid (setsid detached from pulse PGID=$pulse_pgid; FDs 3-9 closed for t2814)" >>"$LOGFILE"
-	else
+	elif [[ -z "${worker_pid:-}" ]]; then
 		echo "[dispatch_worker_launch] ERROR: setsid missing — worker isolation broken; worker shares pulse PGID and will be killed on next pulse restart. Run: aidevops update (GH#21102)" >>"$LOGFILE"
 		nohup "$@" </dev/null >>"$worker_log" 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
 		worker_pid="$!"
@@ -961,6 +1044,14 @@ _dlw_spawn_early_exit_monitor() {
 		}
 		_dlw_monitor_body "$@"
 	'
+
+	if _dlw_systemd_user_service_available; then
+		_dlw_exec_systemd_user_service "aidevops-worker-monitor" "/dev/null" "$issue_number" \
+			bash -c "$monitor_script" _dlw_monitor \
+			"$worker_pid" "$worker_log" "$issue_number" \
+			"$window" "$poll_interval" \
+			>/dev/null 2>&1 && return 0
+	fi
 
 	if command -v setsid >/dev/null 2>&1; then
 		setsid nohup bash -c "$monitor_script" _dlw_monitor \
@@ -1064,6 +1155,14 @@ _dlw_spawn_lifecycle_observer() {
 		}
 		_dlw_observer_body "$@"
 	'
+
+	if _dlw_systemd_user_service_available; then
+		_dlw_exec_systemd_user_service "aidevops-worker-observer" "/dev/null" "$issue_number" \
+			bash -c "$observer_script" _dlw_observer \
+			"$worker_pid" "$issue_number" "$logfile" \
+			"$max_seconds" "$poll_interval" \
+			>/dev/null 2>&1 && return 0
+	fi
 
 	if command -v setsid >/dev/null 2>&1; then
 		setsid nohup bash -c "$observer_script" _dlw_observer \

--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -387,7 +387,8 @@ _build_pulse_linux_env() {
 	# runtime. No model env vars embedded in cron/systemd.
 	local opencode_bin="${1:-}"
 	local _pulse_env="PULSE_DIR=${HOME}/.aidevops/.agent-workspace
-PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
+PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}
+AIDEVOPS_PULSE_ASYNC_POST_DISPATCH_HOUSEKEEPING=0"
 
 	# GH#18439 Bug 2: embed resolved runtime binary path so pulse-wrapper.sh
 	# and headless-runtime-helper.sh find the correct binary under systemd's

--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -90,6 +90,11 @@ if ! grep -q '^Environment=PULSE_STALE_THRESHOLD="1800"$' "$SERVICE_FILE"; then
 	exit 1
 fi
 
+if ! grep -q '^Environment=AIDEVOPS_PULSE_ASYNC_POST_DISPATCH_HOUSEKEEPING="0"$' "$SERVICE_FILE"; then
+	echo "expected async post-dispatch housekeeping disabled in ${SERVICE_FILE}" >&2
+	exit 1
+fi
+
 printf 'PASS %s\n' "pulse systemd service timeout exceeds watchdog threshold"
 
 # GH#18439 Bug 1 regression: _scheduler_systemd_env_lines() emits a trailing

--- a/tests/test-systemd-worker-service-launch.sh
+++ b/tests/test-systemd-worker-service-launch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+
+cat >"${TMP_DIR}/bin/systemctl" <<'STUB_SYSTEMCTL'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--user" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+exit 1
+STUB_SYSTEMCTL
+chmod +x "${TMP_DIR}/bin/systemctl"
+
+cat >"${TMP_DIR}/bin/uname" <<'STUB_UNAME'
+#!/usr/bin/env bash
+printf 'Linux\n'
+exit 0
+STUB_UNAME
+chmod +x "${TMP_DIR}/bin/uname"
+
+cat >"${TMP_DIR}/bin/systemd-run" <<'STUB_SYSTEMD_RUN'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${STUB_SYSTEMD_RUN_LOG:?}"
+
+prev=""
+pid_file=""
+for arg in "$@"; do
+	if [[ "$prev" == "_" ]]; then
+		pid_file="$arg"
+		break
+	fi
+	prev="$arg"
+done
+
+if [[ -n "$pid_file" ]]; then
+	printf '424242\n' >"$pid_file"
+fi
+exit 0
+STUB_SYSTEMD_RUN
+chmod +x "${TMP_DIR}/bin/systemd-run"
+
+cat >"${TMP_DIR}/bin/setsid" <<'STUB_SETSID'
+#!/usr/bin/env bash
+printf 'setsid should not be used when systemd-run is available\n' >&2
+exit 1
+STUB_SETSID
+chmod +x "${TMP_DIR}/bin/setsid"
+
+export PATH="${TMP_DIR}/bin:${PATH}"
+export STUB_SYSTEMD_RUN_LOG="${TMP_DIR}/systemd-run.log"
+export LOGFILE="${TMP_DIR}/pulse.log"
+export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=0
+
+# shellcheck source=.agents/scripts/pulse-dispatch-worker-launch.sh
+source "${REPO_ROOT}/.agents/scripts/pulse-dispatch-worker-launch.sh"
+
+pid="$(_dlw_exec_detached "${TMP_DIR}/worker.log" "23073" /bin/true)"
+
+if [[ "$pid" != "424242" ]]; then
+	printf 'FAIL expected systemd child pid 424242, got %s\n' "$pid" >&2
+	exit 1
+fi
+
+if ! grep -q -- '--unit=aidevops-worker-23073-' "$STUB_SYSTEMD_RUN_LOG"; then
+	printf 'FAIL expected worker transient unit launch\n' >&2
+	exit 1
+fi
+
+if ! grep -q 'systemd-run transient user service outside pulse cgroup' "$LOGFILE"; then
+	printf 'FAIL expected systemd launch diagnostic in pulse log\n' >&2
+	exit 1
+fi
+
+printf 'PASS %s\n' "worker launch uses systemd-run transient user service when available"


### PR DESCRIPTION
## Summary

- Launch Linux systemd pulse workers, early-exit monitors, and lifecycle observers through transient `systemd-run --user` services so intentional long-lived processes have their own lifecycle owner outside `aidevops-supervisor-pulse.service`.
- Keep the existing `setsid`/`nohup` fallback for non-systemd and failure cases to preserve the GH#17438 worker-survival invariant.
- Disable async post-dispatch housekeeping in the Linux supervisor pulse unit so bounded housekeeping does not remain as a child of the stopped oneshot service.

## Testing

- `tests/test-systemd-worker-service-launch.sh`
- `bash tests/test-pulse-systemd-timeout.sh`
- `bash .agents/scripts/tests/test-precreation-failure-skip.sh`
- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/setup/modules/schedulers-pulse.sh tests/test-systemd-worker-service-launch.sh tests/test-pulse-systemd-timeout.sh`
- `bash -n .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/setup/modules/schedulers-pulse.sh tests/test-systemd-worker-service-launch.sh tests/test-pulse-systemd-timeout.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

self-assessed: this OpenCode session is running on macOS, so a real Linux `systemctl --user status aidevops-supervisor-pulse.service` / `journalctl --user -u aidevops-supervisor-pulse.service` cycle was not available. The regression coverage stubs a Linux systemd user manager, verifies transient `systemd-run` worker launch, verifies Linux pulse unit environment generation, and keeps fallback behaviour covered by existing worker launch tests.

## Key decisions

- Did not revert `KillMode=process`, preserving the prior fix for GH#17438 where `KillMode=control-group` killed active workers.
- Moved intentional long-lived worker/observer ownership to transient user services, and made short-lived Linux pulse housekeeping synchronous instead of ambiguous background work.

Resolves #23073

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.90 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 21m and 197,525 tokens on this with the user in an interactive session.