### PR TITLE
GH#23077: fix: handle protected counter branch allocation

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -208,6 +208,35 @@ _run_git_with_ssh_fallback() {
 	return $rc
 }
 
+# Detect GitHub protected-branch rejections in git push stderr.
+# These are policy failures, not CAS contention, so retrying only burns the
+# wall-clock budget and hides the actionable remediation.
+_cas_push_rejection_is_protected_branch() {
+	local stderr_text="${1:-}"
+
+	[[ -z "$stderr_text" ]] && return 1
+	if [[ "$stderr_text" == *"Protected branch update failed"* ]]; then
+		return 0
+	fi
+	if [[ "$stderr_text" == *"GH006"* && "$stderr_text" == *"Changes must be made through a pull request"* ]]; then
+		return 0
+	fi
+	if [[ "$stderr_text" == *"Changes must be made through a pull request"* && "$stderr_text" == *"refs/heads/${COUNTER_BRANCH}"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Emit protected-branch guidance without exposing full remote URLs or stderr.
+_cas_log_protected_branch_rejection() {
+	log_error "PROTECTED_COUNTER_BRANCH: ${REMOTE_NAME}/${COUNTER_BRANCH} rejects direct counter pushes"
+	log_error "Task ID allocation cannot advance ${COUNTER_FILE} by direct CAS push on a protected branch."
+	log_error "Recovery: configure .aidevops.json counter_branch to an unprotected counter branch,"
+	log_error "or relax protection for the dedicated counter branch before retrying."
+	log_error "The CAS helper used git plumbing only; no working-tree changes or local commits were created."
+	return 0
+}
+
 # =============================================================================
 # Machine-local mutex for CAS serialisation (Phase 2 / t2568 / GH#20001)
 # =============================================================================
@@ -589,10 +618,25 @@ _cas_build_and_push() {
 	# returns the same exit codes as a direct push, so the conflict (rc=1)
 	# vs success (rc=0) handling below is unchanged.
 	local push_rc=0
-	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
-		-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
-		push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+	local push_stderr=""
+	local push_err_file=""
+	push_err_file=$(mktemp "${TMPDIR:-/tmp}/claim-task-id-push.XXXXXX" 2>/dev/null) || push_err_file=""
+	if [[ -n "$push_err_file" ]]; then
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+			push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null 2>"$push_err_file" || push_rc=$?
+		push_stderr=$(<"$push_err_file")
+		rm -f "$push_err_file" 2>/dev/null || true
+	else
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+			push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+	fi
 	if [[ $push_rc -ne 0 ]]; then
+		if _cas_push_rejection_is_protected_branch "$push_stderr"; then
+			_cas_log_protected_branch_rejection
+			return 1
+		fi
 		if [[ $push_rc -eq 124 ]]; then
 			log_warn "Push timed out (HTTPS + SSH fallback both unavailable) — treating as retriable conflict"
 		else

--- a/.agents/scripts/tests/test-claim-label-auto-create.sh
+++ b/.agents/scripts/tests/test-claim-label-auto-create.sh
@@ -11,8 +11,8 @@
 # Cases covered:
 #   1. blocked-by:t999 missing, gh label create succeeds   → label created in cache,
 #                                                             _validate_labels_exist returns 0
-#   2. blocked-by:t999 missing, gh label create fails       → warning only, returns 0
-#                                                             (best-effort / fail-open)
+#   2. blocked-by:t999 missing, gh label create fails       → returns 1 before counter allocation
+#                                                             (prevents stranded task IDs)
 #   3. tier:standrad (typo) missing                         → still aborts with return 1
 #                                                             (t2800 typo-protection preserved)
 #   4. blocked-by:#999 (issue-number variant) missing,
@@ -184,7 +184,7 @@ STUB
 }
 
 # ---------------------------------------------------------------------------
-# Test 2: blocked-by:t999 missing, gh create fails → still returns 0 (best-effort)
+# Test 2: blocked-by:t999 missing, gh create fails → returns 1 before allocation
 # ---------------------------------------------------------------------------
 _run_test2() {
 	local stub_dir
@@ -217,7 +217,7 @@ STUB
 	PATH="$saved_path"
 	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
 
-	assert_return "test2_blocked_by_create_fails_still_returns_0" "$rc" "0"
+	assert_return "test2_blocked_by_create_fails_aborts_before_counter" "$rc" "1"
 
 	return 0
 }

--- a/.agents/scripts/tests/test-claim-task-id-concurrent-cas.sh
+++ b/.agents/scripts/tests/test-claim-task-id-concurrent-cas.sh
@@ -19,6 +19,7 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+COUNTER_LIB="${SCRIPT_DIR}/../claim-task-id-counter.sh"
 
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
@@ -102,7 +103,7 @@ _launch_concurrent_claims() {
 	for ((i = 1; i <= num_concurrent; i++)); do
 		(
 			local output
-			output=$("$CLAIM_SCRIPT" \
+			output=$(CAS_MAX_RETRIES=100 CAS_WALL_TIMEOUT_S=120 "$CLAIM_SCRIPT" \
 				--title "concurrent test $i" \
 				--no-issue \
 				--repo-path "$work_dir" \
@@ -213,7 +214,7 @@ test_pinned_sha_in_source() {
 	# After refactoring (GH#19689), the git plumbing lives in _cas_build_and_push.
 	# Verify it uses the pinned_sha parameter, not the ref name.
 	local build_body
-	build_body=$(sed -n '/^_cas_build_and_push()/,/^}/p' "$CLAIM_SCRIPT")
+	build_body=$(sed -n '/^_cas_build_and_push()/,/^}/p' "$COUNTER_LIB")
 
 	# Check that git ls-tree uses the first parameter (pinned_sha)
 	if echo "$build_body" | grep -q 'git ls-tree.*pinned_sha'; then
@@ -233,7 +234,7 @@ test_pinned_sha_in_source() {
 
 	# Verify _cas_fetch_and_pin exists and does the pinning
 	local fetch_body
-	fetch_body=$(sed -n '/^_cas_fetch_and_pin()/,/^}/p' "$CLAIM_SCRIPT")
+	fetch_body=$(sed -n '/^_cas_fetch_and_pin()/,/^}/p' "$COUNTER_LIB")
 	if [[ -z "$fetch_body" ]]; then
 		fail "$name" "_cas_fetch_and_pin function not found"
 		return 0
@@ -242,7 +243,7 @@ test_pinned_sha_in_source() {
 	# Verify allocate_counter_cas does NOT contain git ls-tree or rev-parse
 	# (all plumbing delegated to helpers)
 	local cas_body
-	cas_body=$(sed -n '/^allocate_counter_cas()/,/^}/p' "$CLAIM_SCRIPT")
+	cas_body=$(sed -n '/^allocate_counter_cas()/,/^}/p' "$COUNTER_LIB")
 	if echo "$cas_body" | grep -q 'git ls-tree'; then
 		fail "$name" "allocate_counter_cas still contains git ls-tree — should be in helper"
 		return 0

--- a/.agents/scripts/tests/test-claim-task-id-discovery.sh
+++ b/.agents/scripts/tests/test-claim-task-id-discovery.sh
@@ -277,7 +277,7 @@ test_case_d_noninteractive_warns() {
 	PATH="$saved_path"
 
 	local has_warn=false
-	if printf '%s' "$stderr_output" | grep -q '\[claim-task-id\] WARN: similar PR found:'; then
+	if printf '%s' "$stderr_output" | grep -q '\[claim-task-id\] WARN: similar issue or PR found:'; then
 		has_warn=true
 	fi
 

--- a/.agents/scripts/tests/test-claim-task-id-protected-counter-branch.sh
+++ b/.agents/scripts/tests/test-claim-task-id-protected-counter-branch.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23077.
+#
+# A protected counter branch rejects direct CAS pushes. The allocator must
+# classify that as a policy failure, not retriable CAS contention, and leave the
+# working tree unchanged.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL %s' "$name"
+	[[ -n "$detail" ]] && printf ' — %s' "$detail"
+	printf '\n'
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+setup_protected_remote() {
+	local base_dir="$1"
+	local bare_dir="${base_dir}/remote.git"
+	local work_dir="${base_dir}/work"
+
+	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || git init --bare "$bare_dir" >/dev/null 2>&1 || return 1
+	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.email "test@test.local" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.name "Test" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config commit.gpgsign false >/dev/null 2>&1 || true
+	printf '1000\n' >"${work_dir}/.task-counter"
+	printf '# Tasks\n\n' >"${work_dir}/TODO.md"
+	git -C "$work_dir" add .task-counter TODO.md >/dev/null 2>&1 || return 1
+	git -C "$work_dir" commit -m "chore: seed protected counter" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin main >/dev/null 2>&1 || return 1
+
+	mkdir -p "${bare_dir}/hooks" || return 1
+	cat >"${bare_dir}/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+while read -r _old _new ref; do
+	if [[ "$ref" == "refs/heads/main" ]]; then
+		printf 'remote: error: GH006: Protected branch update failed for %s.\n' "$ref" >&2
+		printf 'remote: error: Changes must be made through a pull request.\n' >&2
+		exit 1
+	fi
+done
+exit 0
+HOOK
+	chmod +x "${bare_dir}/hooks/pre-receive" || return 1
+	printf '%s\n' "$work_dir"
+	return 0
+}
+
+test_protected_counter_branch_fast_fail() {
+	local name="protected counter branch rejection is non-retriable and clean"
+	local tmpdir work_dir before_head output rc after_head status remote_counter
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+
+	work_dir=$(setup_protected_remote "$tmpdir") || { fail "$name" "repo setup failed"; return 0; }
+	before_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || { fail "$name" "missing initial HEAD"; return 0; }
+
+	rc=0
+	output=$(CAS_MAX_RETRIES=5 CAS_WALL_TIMEOUT_S=20 CAS_SSH_FALLBACK_ENABLED=0 "$CLAIM_SCRIPT" \
+		--title "protected counter branch" \
+		--no-issue \
+		--repo-path "$work_dir" \
+		--counter-branch main 2>&1) || rc=$?
+
+	if [[ $rc -eq 0 ]]; then
+		fail "$name" "claim unexpectedly succeeded"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'PROTECTED_COUNTER_BRANCH'; then
+		fail "$name" "missing protected-branch diagnostic: $output"
+		return 0
+	fi
+	if printf '%s\n' "$output" | grep -q 'Retry attempt'; then
+		fail "$name" "protected rejection was retried: $output"
+		return 0
+	fi
+
+	after_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || { fail "$name" "missing final HEAD"; return 0; }
+	if [[ "$after_head" != "$before_head" ]]; then
+		fail "$name" "local HEAD changed"
+		return 0
+	fi
+	status=$(git -C "$work_dir" status --short 2>/dev/null)
+	if [[ -n "$status" ]]; then
+		fail "$name" "working tree dirty: $status"
+		return 0
+	fi
+	git -C "$work_dir" fetch origin main >/dev/null 2>&1 || true
+	remote_counter=$(git -C "$work_dir" show origin/main:.task-counter 2>/dev/null | tr -d '[:space:]')
+	if [[ "$remote_counter" != "1000" ]]; then
+		fail "$name" "remote counter changed to ${remote_counter:-<empty>}"
+		return 0
+	fi
+
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+main() {
+	if [[ ! -x "$CLAIM_SCRIPT" ]]; then
+		fail "claim script executable" "$CLAIM_SCRIPT missing or not executable"
+	else
+		pass "claim script executable"
+	fi
+	test_protected_counter_branch_fast_fail
+	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+	[[ "$FAIL" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-claim-task-id-rest-routing.sh
+++ b/.agents/scripts/tests/test-claim-task-id-rest-routing.sh
@@ -97,6 +97,7 @@ export AIDEVOPS_SESSION_USER=testuser
 # Lock REST threshold to 10 so the tests exercise the logic without
 # requiring a real rate_limit call (matching test-gh-wrapper-rest-fallback.sh).
 export AIDEVOPS_GH_REST_FALLBACK_THRESHOLD=10
+export AIDEVOPS_GH_REST_FALLBACK_DISABLE_CACHE=1
 
 # shellcheck source=../shared-constants.sh
 source "${SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Detected protected-branch push rejections in the task counter CAS path as non-retriable policy failures, added actionable diagnostics, and added a protected-counter regression test while refreshing stale claim test expectations.

## Files Changed

.agents/scripts/claim-task-id-counter.sh,.agents/scripts/tests/test-claim-label-auto-create.sh,.agents/scripts/tests/test-claim-task-id-concurrent-cas.sh,.agents/scripts/tests/test-claim-task-id-discovery.sh,.agents/scripts/tests/test-claim-task-id-protected-counter-branch.sh,.agents/scripts/tests/test-claim-task-id-rest-routing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-claim-*.sh; shellcheck .agents/scripts/claim-*.sh .agents/scripts/tests/test-claim-*.sh

Resolves #23077


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 16m and 114,474 tokens on this as a headless worker.