### PR TITLE
GH#23080: restore OpenCode memory args schema

### DIFF
--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -22,9 +22,7 @@
     "opencode-ai": ">=1.3.0"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.0.0"
-  },
-  "devDependencies": {
+    "@bufbuild/protobuf": "^2.0.0",
     "@opencode-ai/plugin": "^1.3.13"
   }
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage for the OpenCode aidevops_memory tool args schema.
+// OpenCode exposes tools without an `args` schema as no-argument functions,
+// preventing the model from passing action/content/query fields.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createTools } from "../tools.mjs";
+
+const SCRIPTS_DIR = "/tmp/aidevops-test-scripts";
+
+function withMemoryHelper(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "aidevops-memory-tool-"));
+  writeFileSync(join(dir, "memory-helper.sh"), "#!/usr/bin/env bash\n", { mode: 0o755 });
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("aidevops_memory tool schema", () => {
+  test("exposes a non-empty Zod args schema", () => {
+    const tools = createTools(SCRIPTS_DIR, () => "");
+    const schema = tools.aidevops_memory.args;
+
+    assert.ok(schema, "memory tool must expose args");
+    assert.ok(schema.action?._zod, "action must be a Zod schema");
+    assert.ok(schema.query?._zod, "query must be a Zod schema");
+    assert.ok(schema.limit?._zod, "limit must be a Zod schema");
+    assert.ok(schema.content?._zod, "content must be a Zod schema");
+    assert.ok(schema.confidence?._zod, "confidence must be a Zod schema");
+  });
+});
+
+describe("aidevops_memory execution", () => {
+  test("store action invokes memory-helper.sh store", async () => {
+    const calls = [];
+    const result = await withMemoryHelper(async (scriptsDir) => {
+      const tools = createTools(scriptsDir, (cmd) => {
+        calls.push(cmd);
+        return "stored";
+      });
+
+      return tools.aidevops_memory.execute({
+        action: "store",
+        content: "Remember this",
+        confidence: "high",
+      });
+    });
+
+    assert.equal(result, "stored");
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /memory-helper\.sh" store 'Remember this' --confidence 'high'$/);
+  });
+
+  test("recall action invokes memory-helper.sh recall", async () => {
+    const calls = [];
+    const result = await withMemoryHelper(async (scriptsDir) => {
+      const tools = createTools(scriptsDir, (cmd) => {
+        calls.push(cmd);
+        return "recalled";
+      });
+
+      return tools.aidevops_memory.execute({
+        action: "recall",
+        query: "schema",
+        limit: 5,
+      });
+    });
+
+    assert.equal(result, "recalled");
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /memory-helper\.sh" recall 'schema' --limit '5'$/);
+  });
+
+  test("empty store content returns a validation error", async () => {
+    const result = await withMemoryHelper(async (scriptsDir) => {
+      const tools = createTools(scriptsDir, () => "stored");
+      return tools.aidevops_memory.execute({ action: "store", content: "   " });
+    });
+
+    assert.equal(result, "Error: content is required to store a memory");
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,6 +1,9 @@
 import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
+import { tool } from "@opencode-ai/plugin";
+
+const z = tool.schema;
 
 /**
  * Escape a string for safe interpolation into a shell command.
@@ -57,12 +60,19 @@ function createAidevopsTool(run) {
  * @returns {object} Tool definition
  */
 function createMemoryTool(scriptsDir, run) {
-  return {
+  return tool({
     description:
       'Recall or store memories in the aidevops cross-session memory system. ' +
       'Args: action ("recall"|"store"), query (string, for recall), ' +
       'limit (string, default "5", for recall), ' +
       'content (string, for store), confidence ("low"|"medium"|"high", default "medium", for store)',
+    args: {
+      action: z.enum(["recall", "store"]).optional().describe('Memory operation to perform; defaults to "recall"'),
+      query: z.string().optional().describe("Search query for memory recall"),
+      limit: z.union([z.string(), z.number()]).optional().describe('Maximum recall results; defaults to "5"'),
+      content: z.string().optional().describe("Memory content to store"),
+      confidence: z.enum(["low", "medium", "high"]).optional().describe('Stored memory confidence; defaults to "medium"'),
+    },
     async execute(args) {
       const memoryHelper = join(scriptsDir, "memory-helper.sh");
       if (!existsSync(memoryHelper)) {
@@ -73,7 +83,7 @@ function createMemoryTool(scriptsDir, run) {
 
       if (action === "recall") {
         const query = args.query || "";
-        const limit = args.limit || "5";
+        const limit = args.limit === undefined ? "5" : String(args.limit);
         const cmd = `bash "${memoryHelper}" recall ${shellEscape(query)} --limit ${shellEscape(limit)}`;
         const result = run(cmd, 10000);
         return result || "No memories found for this query.";
@@ -92,7 +102,7 @@ function createMemoryTool(scriptsDir, run) {
 
       return `Unknown action: ${action}. Use "recall" or "store".`;
     },
-  };
+  });
 }
 
 /**
@@ -153,10 +163,8 @@ function createPreEditCheckTool(scriptsDir) {
  * code for a task the LLM can perform directly via the Bash tool.
  *
  * NOTE: opencode 1.1.56+ uses Zod v4 to validate tool args schemas.
- * Plain `{ type: "string" }` objects are NOT valid Zod schemas and cause:
- *   TypeError: undefined is not an object (evaluating 'schema._zod.def')
- * Fix: omit `args` entirely and document parameters in `description`.
- * The LLM passes args as a plain object; we extract fields defensively.
+ * Use `tool.schema` from `@opencode-ai/plugin` for args definitions; plain
+ * JSON schema objects are not valid here because OpenCode expects Zod objects.
  *
  * @param {string} scriptsDir - Path to scripts directory
  * @param {function} run - Shell command runner


### PR DESCRIPTION
## Summary

Restored a Zod-backed args schema for the OpenCode aidevops_memory tool so recall/store parameters are exposed to the model, and added regression coverage for schema metadata plus recall/store execution command construction.

## Files Changed

.agents/plugins/opencode-aidevops/package.json,.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs,.agents/plugins/opencode-aidevops/tools.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test tests/test-memory-tool-schema.mjs; npm test in .agents/plugins/opencode-aidevops; .agents/scripts/linters-local.sh (completed; repository-wide pre-existing complexity/markdown advisory output, final local checks passed)

Resolves #23080


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 14m and 95,465 tokens on this as a headless worker.