### PR TITLE
GH#23086: preserve prelaunch worker failure reasons

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -130,6 +130,47 @@ source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-dispa
 _PULSE_LAST_LAUNCH_FAILURE=""
 
 #######################################
+# Extract a trusted prelaunch failure reason from a worker log.
+#
+# Args:
+#   $1 - worker log path
+# Stdout: allowlisted reason token, or blank when unavailable.
+# Returns: 0 always; diagnostics must never block dispatch cleanup.
+#######################################
+_pulse_worker_log_prelaunch_failure_reason() {
+	local log_path="$1"
+	local reason=""
+
+	[[ -f "$log_path" ]] || { printf '\n'; return 0; }
+
+	reason=$(awk '
+		/\[exit-trap\] using prelaunch failure reason:/ {
+			line = $0
+			sub(/^.*\[exit-trap\] using prelaunch failure reason:[[:space:]]*/, "", line)
+			split(line, parts, /[[:space:]]+/)
+			reason = parts[1]
+		}
+		/\[exit-trap\] session=/ && / reason=/ {
+			line = $0
+			sub(/^.* reason=/, "", line)
+			split(line, parts, /[[:space:]]+/)
+			reason = parts[1]
+		}
+		END { if (reason != "") { print reason } }
+	' "$log_path" 2>/dev/null) || reason=""
+
+	case "$reason" in
+	worker_worktree_live_owner)
+		printf '%s\n' "$reason"
+		;;
+	*)
+		printf '\n'
+		;;
+	esac
+	return 0
+}
+
+#######################################
 # Launch validation gate for pulse dispatches (t1453)
 #
 # Arguments:
@@ -164,9 +205,19 @@ check_worker_launch() {
 
 	local elapsed=0
 	local poll_seconds=2
+	local candidate=""
+	local prelaunch_failure_reason=""
 	while [[ "$elapsed" -lt "$grace_seconds" ]]; do
+		for candidate in "${log_candidates[@]}"; do
+			prelaunch_failure_reason=$(_pulse_worker_log_prelaunch_failure_reason "$candidate")
+			if [[ -n "$prelaunch_failure_reason" ]]; then
+				recover_failed_launch_state "$issue_number" "$repo_slug" "$prelaunch_failure_reason"
+				echo "[pulse-wrapper] Launch validation failed for issue #${issue_number} (${repo_slug}) — prelaunch failure reason=${prelaunch_failure_reason} detected in ${candidate}" >>"$LOGFILE"
+				_PULSE_LAST_LAUNCH_FAILURE="$prelaunch_failure_reason"
+				return 1
+			fi
+		done
 		if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
-			local candidate
 			for candidate in "${log_candidates[@]}"; do
 				if [[ -f "$candidate" ]] && rg -q '^opencode run \[message\.\.\]|^run opencode with a message|^Options:' "$candidate"; then
 					recover_failed_launch_state "$issue_number" "$repo_slug" "cli_usage_output"
@@ -185,6 +236,15 @@ check_worker_launch() {
 		fi
 		sleep "$poll_seconds"
 		elapsed=$((elapsed + poll_seconds))
+	done
+	for candidate in "${log_candidates[@]}"; do
+		prelaunch_failure_reason=$(_pulse_worker_log_prelaunch_failure_reason "$candidate")
+		if [[ -n "$prelaunch_failure_reason" ]]; then
+			recover_failed_launch_state "$issue_number" "$repo_slug" "$prelaunch_failure_reason"
+			echo "[pulse-wrapper] Launch validation failed for issue #${issue_number} (${repo_slug}) — prelaunch failure reason=${prelaunch_failure_reason} detected in ${candidate}" >>"$LOGFILE"
+			_PULSE_LAST_LAUNCH_FAILURE="$prelaunch_failure_reason"
+			return 1
+		fi
 	done
 
 	recover_failed_launch_state "$issue_number" "$repo_slug" "no_worker_process"

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -38,6 +38,8 @@ AGENT_SCRIPT_DIR="${SCRIPT_DIR}/.."
 PULSE_CLEANUP="${AGENT_SCRIPT_DIR}/pulse-cleanup.sh"
 WORKER_LAUNCH="${AGENT_SCRIPT_DIR}/pulse-dispatch-worker-launch.sh"
 HEADLESS_LIB="${AGENT_SCRIPT_DIR}/headless-runtime-lib.sh"
+PULSE_ENGINE="${AGENT_SCRIPT_DIR}/pulse-dispatch-engine.sh"
+WORKER_LIFECYCLE="${AGENT_SCRIPT_DIR}/worker-lifecycle-common.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -459,9 +461,9 @@ test_negative_cache_behavioural() {
 }
 
 # ---------------------------------------------------------------------------
-# t3210: System overload pre-check — distinct failure class with longer TTL.
-# Without this, overloaded systems trigger the canary timeout cycle that
-# trips the supervisor circuit breaker (GH#21919, GH#21556, GH#4360, ...).
+# t3210/t3558: System overload compatibility — load/CPU remains advisory-only.
+# The env knobs remain for compatibility, but the canary must not gate dispatch
+# on synthetic CPU/load overload signals.
 # ---------------------------------------------------------------------------
 
 test_overload_constants_present() {
@@ -477,48 +479,48 @@ test_overload_constants_present() {
 
 test_overload_helper_present() {
 	if grep -q '^_check_system_overload()' "$HEADLESS_LIB" \
-		&& grep -q 'system overloaded' "$HEADLESS_LIB"; then
-		print_result "t3210: _check_system_overload helper defined" 0
+		&& grep -q 'CPU/load/saturation must never gate dispatch' "$HEADLESS_LIB"; then
+		print_result "t3558: _check_system_overload compatibility stub defined" 0
 		return 0
 	fi
-	print_result "t3210: _check_system_overload helper defined" 1 \
-		"Expected _check_system_overload function + 'system overloaded' message in $HEADLESS_LIB"
+	print_result "t3558: _check_system_overload compatibility stub defined" 1 \
+		"Expected _check_system_overload compatibility stub in $HEADLESS_LIB"
 	return 0
 }
 
 test_overload_check_wired_into_canary() {
-	# Pre-canary check must run before binary validation and stamp
-	# overload reason on rc=1.
+	# t3558: overload/load checks must not run before binary validation or stamp
+	# overload negative-cache reasons. Runtime/model health is still checked below.
 	local lib_text
 	lib_text=$(cat "$HEADLESS_LIB")
 	# shellcheck disable=SC2016  # matching literal source text
-	if [[ "$lib_text" == *'_check_system_overload'* ]] \
-		&& [[ "$lib_text" == *"printf 'overload"* ]]; then
-		print_result "t3210: overload check wired into _run_canary_test" 0
+	if [[ "$lib_text" == *'no CPU/load/saturation preflight'* ]] \
+		&& [[ "$lib_text" != *"printf 'overload"* ]]; then
+		print_result "t3558: overload check is not wired into _run_canary_test" 0
 		return 0
 	fi
-	print_result "t3210: overload check wired into _run_canary_test" 1 \
-		"Expected _check_system_overload call + overload reason write in $HEADLESS_LIB"
+	print_result "t3558: overload check is not wired into _run_canary_test" 1 \
+		"Expected no overload negative-cache write in $HEADLESS_LIB"
 	return 0
 }
 
 test_overload_ttl_in_case_selector() {
-	# The TTL selector must handle the new overload reason via a case
-	# branch, not the old if/else.
+	# t3558: overload is no longer a distinct TTL class; keep config_error only.
 	local lib_text
 	lib_text=$(cat "$HEADLESS_LIB")
 	# shellcheck disable=SC2016  # matching literal source text
-	if [[ "$lib_text" == *'overload) active_ttl="$CANARY_OVERLOAD_TTL_SECONDS"'* ]]; then
-		print_result "t3210: TTL case selector includes overload branch" 0
+	if [[ "$lib_text" == *'config_error) active_ttl="$CANARY_CONFIG_ERROR_TTL_SECONDS"'* ]] \
+		&& [[ "$lib_text" != *'overload) active_ttl="$CANARY_OVERLOAD_TTL_SECONDS"'* ]]; then
+		print_result "t3558: TTL case selector excludes overload branch" 0
 		return 0
 	fi
-	print_result "t3210: TTL case selector includes overload branch" 1 \
-		"Expected 'overload) active_ttl=\"\$CANARY_OVERLOAD_TTL_SECONDS\"' in $HEADLESS_LIB"
+	print_result "t3558: TTL case selector excludes overload branch" 1 \
+		"Expected config_error TTL branch and no overload TTL branch in $HEADLESS_LIB"
 	return 0
 }
 
-# Behavioural: extract the helper and verify it returns 1 on synthetic
-# overload (very low multiplier) and 0 when guarded against (very high).
+# Behavioural: extract the compatibility helper and verify it returns 0 even
+# when legacy overload multiplier env vars request synthetic blocking.
 test_overload_helper_behavioural() {
 	local sandbox helper_extract
 	sandbox=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-t3210-test.XXXXXX")
@@ -557,11 +559,11 @@ test_overload_helper_behavioural() {
 			"Expected rc=0, got '$rc_high'"
 	fi
 
-	if [[ "$rc_low" == "1" ]]; then
-		print_result "t3210: low multiplier (0.0001) — helper returns 1 (skip canary)" 0
+	if [[ "$rc_low" == "0" ]]; then
+		print_result "t3558: low multiplier (0.0001) — helper returns 0 (proceed)" 0
 	else
-		print_result "t3210: low multiplier (0.0001) — helper returns 1 (skip canary)" 1 \
-			"Expected rc=1, got '$rc_low'"
+		print_result "t3558: low multiplier (0.0001) — helper returns 0 (proceed)" 1 \
+			"Expected rc=0, got '$rc_low'"
 	fi
 
 	return 0
@@ -578,15 +580,47 @@ test_failure_classification_distinct() {
 	# argument distinct from generic worker-failure paths. Specifically:
 	# - "no_worker_process" — never spawned (infra)
 	# - "cli_usage_output" — spawned but invoked wrong (config bug)
+	# - "worker_worktree_live_owner" — exited during prelaunch ownership guard
 	# These are wired in pulse-dispatch-engine.sh check_worker_launch.
-	local engine="${AGENT_SCRIPT_DIR}/pulse-dispatch-engine.sh"
-	if grep -q '"no_worker_process"' "$engine" \
-		&& grep -q '"cli_usage_output"' "$engine"; then
+	if grep -q '"no_worker_process"' "$PULSE_ENGINE" \
+		&& grep -q '"cli_usage_output"' "$PULSE_ENGINE" \
+		&& grep -q 'worker_worktree_live_owner' "$PULSE_ENGINE"; then
 		print_result "invariant: launch failures classified distinctly (no_worker_process vs cli_usage_output)" 0
 		return 0
 	fi
 	print_result "invariant: launch failures classified distinctly (no_worker_process vs cli_usage_output)" 1 \
-		"Expected both 'no_worker_process' and 'cli_usage_output' classifications in $engine"
+		"Expected 'no_worker_process', 'cli_usage_output', and 'worker_worktree_live_owner' classifications in $PULSE_ENGINE"
+	return 0
+}
+
+test_worker_worktree_live_owner_skips_fast_fail_state() {
+	if grep -q 'worker_worktree_live_owner' "$WORKER_LIFECYCLE"; then
+		print_result "invariant: worker_worktree_live_owner is treated as prelaunch control failure" 0
+		return 0
+	fi
+	print_result "invariant: worker_worktree_live_owner is treated as prelaunch control failure" 1 \
+		"Expected worker_worktree_live_owner in _worker_failure_reason_is_launch_preflight"
+	return 0
+}
+
+test_prelaunch_reason_parser_behavioural() {
+	local sandbox helper_extract log_file reason
+	sandbox=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-prelaunch-reason-test.XXXXXX")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$sandbox' 2>/dev/null || true" RETURN
+	helper_extract="${sandbox}/helper.sh"
+	log_file="${sandbox}/worker.log"
+
+	awk '/^_pulse_worker_log_prelaunch_failure_reason\(\) \{/,/^\}/' "$PULSE_ENGINE" >"$helper_extract"
+	printf '[exit-trap] using prelaunch failure reason: worker_worktree_live_owner\n' >"$log_file"
+	reason=$(bash -c "source '$helper_extract'; _pulse_worker_log_prelaunch_failure_reason '$log_file'" 2>/dev/null)
+
+	if [[ "$reason" == "worker_worktree_live_owner" ]]; then
+		print_result "invariant: worker log prelaunch reason parser preserves live-owner reason" 0
+		return 0
+	fi
+	print_result "invariant: worker log prelaunch reason parser preserves live-owner reason" 1 \
+		"Expected worker_worktree_live_owner, got '${reason:-<empty>}'"
 	return 0
 }
 
@@ -597,7 +631,7 @@ test_failure_classification_distinct() {
 main_test() {
 	# Verify the target files exist before running tests
 	local f
-	for f in "$PULSE_CLEANUP" "$WORKER_LAUNCH" "$HEADLESS_LIB"; do
+	for f in "$PULSE_CLEANUP" "$WORKER_LAUNCH" "$HEADLESS_LIB" "$PULSE_ENGINE" "$WORKER_LIFECYCLE"; do
 		if [[ ! -f "$f" ]]; then
 			printf 'FATAL: target file missing: %s\n' "$f" >&2
 			return 2
@@ -634,6 +668,8 @@ main_test() {
 
 	# Cross-cutting invariant
 	test_failure_classification_distinct
+	test_worker_worktree_live_owner_skips_fast_fail_state
+	test_prelaunch_reason_parser_behavioural
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -979,6 +979,7 @@ _worker_failure_reason_is_launch_preflight() {
 
 	case "$reason" in
 	worker_launch_rc_2 | \
+	worker_worktree_live_owner | \
 	dispatch_aborted:worker_launch_rc_2 | \
 	canary_preflight | \
 	*"canary preflight failed"* | \


### PR DESCRIPTION
## Summary

Diagnosed awardsapp/awardsapp#4447 as an early headless worker prelaunch exit (worker_worktree_live_owner) that pulse later collapsed into no_worker_process, then taught launch validation to preserve that allowlisted worker-log reason and treat it as launch-preflight state instead of a no-worker circuit-breaker signal.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-no-worker-process-fix.sh,.agents/scripts/worker-lifecycle-common.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/worker-lifecycle-common.sh .agents/scripts/tests/test-no-worker-process-fix.sh; .agents/scripts/tests/test-no-worker-process-fix.sh; git diff --check; .agents/scripts/linters-local.sh ran through core gates but timed out during shell portability after advisory markdown/ratchet warnings

Resolves #23086


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 12m and 180,277 tokens on this as a headless worker.