### PR TITLE
GH#23087: respect repository rulesets during pulse merge

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -991,13 +991,14 @@ Closing this stale zero-progress meta-issue so auto-dispatch does not spend work
 # denominator. This is intentionally read-only and narrower than the full
 # _check_pr_merge_gates stack because that stack can route workers/comments.
 #
-# Args: $1=repo_slug, $2=pr_number, $3=labels_str (comma-separated)
+# Args: $1=repo_slug, $2=pr_number, $3=labels_str (comma-separated), $4=pr_author
 # Returns: 0=count it, 1=exclude it from the zero-progress signal
 #######################################
 _pms_pr_counts_for_zero_progress() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local labels_str="$3"
+	local pr_author="${4:-}"
 
 	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
 
@@ -1005,6 +1006,21 @@ _pms_pr_counts_for_zero_progress() {
 		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — required checks are not provably passing" >>"$LOGFILE"
 			return 1
+		fi
+	fi
+
+	# Keep the zero-progress denominator aligned with the deterministic merge
+	# pass trust gate. A MERGEABLE+APPROVED PR authored by a non-collaborator is
+	# intentionally skipped unless a maintainer crypto-approval exists; counting
+	# it as eligible creates a false structural-stuck signal when every real merge
+	# candidate is already drained.
+	if [[ -n "$pr_author" ]] && declare -F _is_collaborator_author >/dev/null 2>&1; then
+		if ! _is_collaborator_author "$pr_author" "$repo_slug"; then
+			if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 \
+				|| ! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+				echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
+				return 1
+			fi
 		fi
 	fi
 
@@ -1028,7 +1044,7 @@ _pms_count_eligible_unmerged_for_repo() {
 
 	local pr_json
 	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--json number,mergeable,reviewDecision,isDraft,labels \
+		--json number,mergeable,reviewDecision,isDraft,labels,author \
 		--limit 50 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
 
@@ -1045,16 +1061,17 @@ _pms_count_eligible_unmerged_for_repo() {
 			and (.isDraft // false) == false
 			and (([.labels[].name] | index("hold-for-review")) == null)
 		  )
-		  | "\(.number // "")\u001e\([.labels[].name] | join(","))"
+		  | "\(.number // "")\u001e\([.labels[].name] | join(","))\u001e\(.author.login // "")"
 		] | .[]' 2>/dev/null) || candidates=""
 
 	local count=0
 	local _RS=$'\x1e'
 	local pr_number=""
 	local labels_str=""
-	while IFS="$_RS" read -r pr_number labels_str; do
+	local pr_author=""
+	while IFS="$_RS" read -r pr_number labels_str pr_author; do
 		[[ -n "$pr_number" ]] || continue
-		if _pms_pr_counts_for_zero_progress "$repo_slug" "$pr_number" "$labels_str"; then
+		if _pms_pr_counts_for_zero_progress "$repo_slug" "$pr_number" "$labels_str" "$pr_author"; then
 			count=$((count + 1))
 		fi
 	done <<<"$candidates"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -750,10 +750,20 @@ _process_single_ready_pr() {
 			;;
 	esac
 
-	# Merge
+	# Merge. Prefer the historical admin path for owned repos, but fall back to
+	# a protection-respecting merge when repository rulesets reject admin bypass.
+	# GitHub reports ruleset blocks as a generic GraphQL error; retrying the same
+	# --admin call every pulse cycle creates a zero-progress loop even when the PR
+	# is otherwise green. The non-admin retry lets rulesets/merge queue evaluate
+	# the PR normally instead of counting it as a deterministic merge failure.
 	local merge_output _merge_exit
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)
 	_merge_exit=$?
+	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
+		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying without --admin (GH#23087): ${merge_output}" >>"$LOGFILE"
+		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash 2>&1)
+		_merge_exit=$?
+	fi
 
 	# Rate-limit: 1 second between merges to avoid GitHub API abuse
 	sleep 1

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23087: when GitHub rulesets reject the historical
+# `gh pr merge --admin` path, deterministic merge retries a normal squash merge
+# instead of recording another failed zero-progress cycle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+_OW_LABEL_PAT=",origin:worker,"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	export TEST_ROOT GH_LOG
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
+	printf '%s\n' 'GraphQL: Repository rule violations found' >&2
+	exit 1
+fi
+
+if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+	exit 0
+fi
+
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+define_function_under_test() {
+	local src_process
+	src_process=$(awk '
+		/^_process_single_ready_pr\(\) \{/,/^\}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$src_process" ]]; then
+		printf 'ERROR: could not extract _process_single_ready_pr from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$src_process"
+	return 0
+}
+
+_pmp_normalize_mergeable_state_into() {
+	local __var_name="$1"
+	local __value="$2"
+	printf -v "$__var_name" '%s' "$__value"
+	return 0
+}
+
+_resolve_pr_mergeable_status() { return 0; }
+_extract_linked_issue() { printf '123'; return 0; }
+_check_pr_merge_gates() { return 0; }
+_pr_required_checks_pass() { return 0; }
+approve_collaborator_pr() { return 0; }
+_extract_merge_summary() { printf 'summary'; return 0; }
+_retarget_stacked_children() { return 0; }
+_pulse_merge_admin_safety_check() { return 0; }
+_set_native_auto_merge_or_skip() { return 1; }
+_handle_post_merge_actions() { return 0; }
+gh_pr_view() { printf '{"labels":[]}'; return 0; }
+
+test_ruleset_violation_retries_without_admin() {
+	setup_test_env
+	define_function_under_test || { teardown_test_env; return 0; }
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "ruleset violation fallback returns merged" 1 "Expected 0, got ${result}; log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'gh pr merge 77 --repo owner/repo --squash --admin' "$GH_LOG"; then
+		print_result "ruleset violation fallback tries admin first" 1 "gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'gh pr merge 77 --repo owner/repo --squash$' "$GH_LOG"; then
+		print_result "ruleset violation fallback retries without admin" 1 "gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'retrying without --admin.*GH#23087' "$LOGFILE"; then
+		print_result "ruleset violation fallback writes audit log" 1 "pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "ruleset violation fallback retries without admin and succeeds" 0
+	teardown_test_env
+	return 0
+}
+
+main() {
+	test_ruleset_violation_retries_without_admin
+
+	printf '\n=================================\n'
+	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	printf '=================================\n'
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -17,7 +17,8 @@
 #        merged=0 + eligible=0 → gauge reset to 0 (streak broken)
 #        merged=0 + eligible>0 → gauge incremented by 1
 #   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
-#      read-only merge gates (required checks, worker PR with no linked issue).
+#      read-only merge gates (required checks, worker PR with no linked issue,
+#      and non-collaborator author without maintainer crypto-approval).
 #   8. _detect_pattern_outage de-duplicates repeated PR observations.
 #   9. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
@@ -308,12 +309,14 @@ gh() {
 	local subcommand="${2:-}"
 	if [[ "$command_name" == "pr" && "$subcommand" == "list" ]]; then
 		printf '%s\n' '[
-{"number":101,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[]},
-{"number":102,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}]},
-{"number":103,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}]},
-{"number":104,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"hold-for-review"}]},
-{"number":105,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[]},
-{"number":106,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[]}
+{"number":101,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
+{"number":102,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"author":{"login":"trusted"}},
+{"number":103,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"author":{"login":"trusted"}},
+{"number":104,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"hold-for-review"}],"author":{"login":"trusted"}},
+{"number":105,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
+{"number":106,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
+{"number":107,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"external"}},
+{"number":108,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}}
 ]'
 		return 0
 	fi
@@ -340,8 +343,25 @@ _extract_linked_issue() {
 	esac
 }
 
+_is_collaborator_author() {
+	local pr_author="$1"
+	local repo_slug="$2"
+	[[ -n "$repo_slug" ]] || return 1
+	if [[ "$pr_author" == "trusted" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_has_maintainer_crypto_approval() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	[[ -n "$pr_number" && -n "$repo_slug" ]] || return 1
+	return 1
+}
+
 got=$(_pms_count_eligible_unmerged_for_repo "example/repo")
-assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "1" "$got"
+assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "2" "$got"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updated the pulse deterministic merge path to retry a normal squash merge when GitHub rejects the admin path with repository rule violations, preventing eligible green PRs from repeatedly counting as zero-progress failures. Added a focused regression test for the ruleset fallback.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; ran shellcheck on .agents/scripts/pulse-merge.sh and .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; spot-ran pulse-merge-routine.sh run --repo awardsapp/awardsapp --pr 4567 and observed PR #4570 merged with pulse_merge_zero_progress_cycles=0.

Resolves #23087


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 6m and 130,639 tokens on this with the user in an interactive session.