### PR TITLE
fix: harden pulse stuck author parsing

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1014,7 +1014,7 @@ _pms_pr_counts_for_zero_progress() {
 	# intentionally skipped unless a maintainer crypto-approval exists; counting
 	# it as eligible creates a false structural-stuck signal when every real merge
 	# candidate is already drained.
-	if [[ -n "$pr_author" ]] && declare -F _is_collaborator_author >/dev/null 2>&1; then
+	if declare -F _is_collaborator_author >/dev/null 2>&1; then
 		if ! _is_collaborator_author "$pr_author" "$repo_slug"; then
 			if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 \
 				|| ! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
@@ -1059,9 +1059,9 @@ _pms_count_eligible_unmerged_for_repo() {
 			(.mergeable // "") == "MERGEABLE"
 			and (.reviewDecision // "") == "APPROVED"
 			and (.isDraft // false) == false
-			and (([.labels[].name] | index("hold-for-review")) == null)
+			and (([.labels[]?.name] | index("hold-for-review")) == null)
 		  )
-		  | "\(.number // "")\u001e\([.labels[].name] | join(","))\u001e\(.author.login // "")"
+		  | "\(.number // "")\u001e\([.labels[]?.name] | join(","))\u001e\(.author.login? // "unknown")"
 		] | .[]' 2>/dev/null) || candidates=""
 
 	local count=0

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -18,7 +18,8 @@
 #        merged=0 + eligible>0 → gauge incremented by 1
 #   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
 #      read-only merge gates (required checks, worker PR with no linked issue,
-#      and non-collaborator author without maintainer crypto-approval).
+#      non-collaborator author without maintainer crypto-approval, and unknown
+#      authors that must not bypass the collaborator check).
 #   8. _detect_pattern_outage de-duplicates repeated PR observations.
 #   9. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
@@ -316,7 +317,9 @@ gh() {
 {"number":105,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
 {"number":106,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
 {"number":107,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"external"}},
-{"number":108,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}}
+{"number":108,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
+{"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null},
+{"number":110,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":null,"author":{"login":"external"}}
 ]'
 		return 0
 	fi


### PR DESCRIPTION
## Summary
- Hardens the pulse merge stuck detector so missing/deleted PR authors are treated as unknown instead of bypassing the collaborator trust gate.
- Makes the jq candidate parser tolerate null label arrays while preserving hold-for-review filtering.
- Adds regression fixtures for null authors and null labels.

## Verification
- `.agents/scripts/tests/test-pulse-merge-stuck.sh`
- `shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh`

Ref #23090

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 3m and 89,022 tokens on this with the user in an interactive session.