### PR TITLE
GH#23078: reject invalid duplicate issue numbers

### DIFF
--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -268,7 +268,7 @@ gather_diagnostics() {
 	# Minimal fallback diagnostics
 	local version="unknown"
 	if [[ -f "${HOME}/.aidevops/agents/VERSION" ]]; then
-		version=$(cat "${HOME}/.aidevops/agents/VERSION" 2>/dev/null | tr -d '[:space:]' || echo "unknown")
+		version=$(tr -d '[:space:]' <"${HOME}/.aidevops/agents/VERSION" 2>/dev/null || echo "unknown")
 	fi
 
 	cat <<EOF
@@ -309,6 +309,21 @@ _validate_gh_prereqs() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# _is_valid_issue_number ISSUE_NUMBER
+#
+# Returns 0 when ISSUE_NUMBER is a positive numeric GitHub issue number.
+# ─────────────────────────────────────────────────────────────────────────────
+_is_valid_issue_number() {
+	local issue_number="$1"
+
+	if [[ "$issue_number" =~ ^[1-9][0-9]*$ ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # _find_duplicate_issue TITLE
 #
 # Searches for an existing issue with a similar title on the aidevops repo.
@@ -329,8 +344,26 @@ _find_duplicate_issue() {
 		--state all --search "\"$search_terms\" in:title is:issue" \
 		--json number --limit 1 -q '.[0].number' 2>/dev/null || echo "")
 
-	if [[ -n "$existing_issue" && "$existing_issue" != "null" ]]; then
+	if _is_valid_issue_number "$existing_issue"; then
 		echo "$existing_issue"
+		return 0
+	fi
+
+	return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _extract_issue_number ISSUE_URL
+#
+# Extracts and validates a numeric issue number from an issue URL.
+# ─────────────────────────────────────────────────────────────────────────────
+_extract_issue_number() {
+	local issue_url="$1"
+	local issue_number
+	issue_number=$(printf '%s' "$issue_url" | grep -oE '[0-9]+$' || true)
+
+	if _is_valid_issue_number "$issue_number"; then
+		printf '%s\n' "$issue_number"
 		return 0
 	fi
 
@@ -396,18 +429,17 @@ _append_signature_footer() {
 _emit_issue_result() {
 	local issue_url="$1"
 	local issue_num
-	issue_num=$(printf '%s' "$issue_url" | grep -oE '[0-9]+$' || echo "")
+	issue_num=$(_extract_issue_number "$issue_url" || true)
 
-	if [[ -n "$issue_num" ]]; then
+	if _is_valid_issue_number "$issue_num"; then
 		log_success "Created framework issue: ${AIDEVOPS_SLUG}#${issue_num}"
 		log_success "URL: $issue_url"
 		echo "issue_url=${issue_url}"
 		echo "issue_num=${issue_num}"
 		echo "status=created"
 	else
-		log_warn "Issue created but could not extract number from: $issue_url"
-		echo "issue_url=${issue_url}"
-		echo "status=created"
+		log_error "Issue created but could not extract a valid numeric issue number from: $issue_url"
+		return 1
 	fi
 
 	return 0
@@ -429,7 +461,7 @@ log_framework_issue() {
 	# Deduplication: search for existing issues with similar title
 	local existing_issue
 	existing_issue=$(_find_duplicate_issue "$title" 2>/dev/null || echo "")
-	if [[ -n "$existing_issue" ]]; then
+	if _is_valid_issue_number "$existing_issue"; then
 		log_warn "Existing issue found: ${AIDEVOPS_SLUG}#${existing_issue} — skipping duplicate creation"
 		echo "issue_url=https://github.com/${AIDEVOPS_SLUG}/issues/${existing_issue}"
 		echo "issue_num=${existing_issue}"

--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -186,6 +186,13 @@ search_issues() {
 	return 0
 }
 
+is_valid_issue_number() {
+	local issue_number="$1"
+
+	[[ "$issue_number" =~ ^[1-9][0-9]*$ ]]
+	return $?
+}
+
 # =============================================================================
 # Issue Fingerprint Deduplication (GH#20322)
 # =============================================================================
@@ -241,7 +248,7 @@ check_recent_filing() {
 
 	if [[ -n "$match" ]]; then
 		read -r filed_epoch issue_num < <(sed -E 's/.*"issue":([0-9]+).*"filed_epoch":([0-9]+).*/\2 \1/' <<< "$match" || true)
-		if [[ "$filed_epoch" =~ ^[0-9]+$ ]] && [[ "$filed_epoch" -gt "$cutoff" ]]; then
+		if [[ "$filed_epoch" =~ ^[0-9]+$ ]] && is_valid_issue_number "$issue_num" && [[ "$filed_epoch" -gt "$cutoff" ]]; then
 			age=$(( now - filed_epoch ))
 			echo "DUPLICATE:${issue_num}:${age}"
 			return 1
@@ -273,7 +280,10 @@ record_filing() {
 	local iso_ts
 	iso_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
 
-	[[ "$issue_number" =~ ^[0-9]+$ ]] || issue_number=0
+	if ! is_valid_issue_number "$issue_number"; then
+		echo "ERROR: invalid issue number for fingerprint: ${issue_number}" >&2
+		return 1
+	fi
 
 	printf '{"hash":"%s","issue":%s,"filed_at":"%s","filed_epoch":%s}\n' \
 		"$fingerprint" "$issue_number" "$iso_ts" "$now" >> "$fp_file"

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for framework-issue-helper.sh duplicate issue parsing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../framework-issue-helper.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s — %s\n' "$name" "$detail"
+	return 0
+}
+
+assert_contains() {
+	local output="$1"
+	local expected="$2"
+	local name="$3"
+
+	if grep -Fq "$expected" <<<"$output"; then
+		pass "$name"
+	else
+		fail "$name" "expected ${expected}; got: ${output}"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local output="$1"
+	local unexpected="$2"
+	local name="$3"
+
+	if grep -Fq "$unexpected" <<<"$output"; then
+		fail "$name" "unexpected ${unexpected}; got: ${output}"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+run_case() {
+	local duplicate_value="$1"
+	local created_url="$2"
+	local stub_dir="$3"
+	local output_file="$4"
+
+	cat >"${stub_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	printf '%s\n' "${TEST_DUPLICATE_VALUE:-}"
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+	printf '%s\n' "${TEST_CREATED_URL:-https://github.com/marcusquinn/aidevops/issues/9001}"
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+	printf '"testuser"\n'
+	exit 0
+fi
+
+exit 0
+EOF
+	chmod +x "${stub_dir}/gh"
+
+	if TEST_DUPLICATE_VALUE="$duplicate_value" \
+		TEST_CREATED_URL="$created_url" \
+		PATH="${stub_dir}:$PATH" \
+		"$HELPER" log --title "fix: duplicate parser regression" --body "body" >"$output_file" 2>&1; then
+		return 0
+	fi
+
+	return 1
+}
+
+TMP_DIR=$(mktemp -d -t framework-issue-helper-test.XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+empty_output="${TMP_DIR}/empty.out"
+run_case "[]" "https://github.com/marcusquinn/aidevops/issues/9001" "${TMP_DIR}" "$empty_output"
+empty_text=$(<"$empty_output")
+assert_contains "$empty_text" "status=created" "empty array result continues to issue creation"
+assert_not_contains "$empty_text" "status=duplicate" "empty array result is not duplicate"
+assert_not_contains "$empty_text" "issue_num=[]" "empty array result never emits issue_num=[]"
+
+malformed_output="${TMP_DIR}/malformed.out"
+run_case "not-a-number" "https://github.com/marcusquinn/aidevops/issues/9002" "${TMP_DIR}" "$malformed_output"
+malformed_text=$(<"$malformed_output")
+assert_contains "$malformed_text" "status=created" "malformed duplicate result continues to issue creation"
+assert_not_contains "$malformed_text" "status=duplicate" "malformed duplicate result is not duplicate"
+
+valid_output="${TMP_DIR}/valid.out"
+run_case "12345" "https://github.com/marcusquinn/aidevops/issues/9003" "${TMP_DIR}" "$valid_output"
+valid_text=$(<"$valid_output")
+assert_contains "$valid_text" "status=duplicate" "valid duplicate result skips creation"
+assert_contains "$valid_text" "issue_num=12345" "valid duplicate result emits numeric issue number"
+assert_contains "$valid_text" "issue_url=https://github.com/marcusquinn/aidevops/issues/12345" "valid duplicate result emits valid issue URL"
+
+invalid_create_output="${TMP_DIR}/invalid-create.out"
+if run_case "" "https://github.com/marcusquinn/aidevops/issues/[]" "${TMP_DIR}" "$invalid_create_output"; then
+	fail "invalid created issue URL is rejected" "helper succeeded for invalid created URL"
+else
+	invalid_create_text=$(<"$invalid_create_output")
+	assert_not_contains "$invalid_create_text" "issue_url=https://github.com/marcusquinn/aidevops/issues/[]" "invalid created issue URL is not emitted"
+fi
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Reject empty, malformed, null, and non-numeric duplicate issue numbers before emitting duplicate machine output; reject invalid created issue URLs before emitting issue_url; add regression coverage for empty, malformed, valid, and invalid-created URL paths.

## Files Changed

.agents/scripts/framework-issue-helper.sh,.agents/scripts/log-issue-helper.sh,.agents/scripts/tests/test-framework-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-framework-issue-helper.sh; shellcheck .agents/scripts/framework-issue-helper.sh .agents/scripts/log-issue-helper.sh .agents/scripts/tests/test-framework-issue-helper.sh

Resolves #23078


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 3m and 89,923 tokens on this as a headless worker.