### PR TITLE
GH#23079: allow aidevops script references in privacy scanner

### DIFF
--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -430,6 +430,51 @@ privacy_scan_local_paths() {
 # =============================================================================
 
 #######################################
+# Redact aidevops script file references before credential-prefix scanning.
+#
+# Some aidevops helper basenames legitimately contain substrings such as
+# "sk-" when they are written as `.agents/scripts/...` file references. Those
+# are filenames, not credential values. Keep the allowlist narrow by only
+# redacting references to shell helper basenames that actually exist beside this
+# helper (or one directory below it, matching `.agents/scripts/tests/...`).
+# Arguments:
+#   $1 - text content to redact
+# Output:
+#   text with allowed script references replaced by a neutral marker
+#######################################
+_privacy_redact_aidevops_script_references() {
+	local text="$1"
+	local redacted="$text"
+	local source_path="${BASH_SOURCE[0]:-$0}"
+	local script_dir=""
+	local script_path basename
+
+	script_dir=$(cd "$(dirname "$source_path")" 2>/dev/null && pwd -P) || script_dir=""
+	if [[ -z "$script_dir" ]]; then
+		printf '%s' "$redacted"
+		return 0
+	fi
+
+	for script_path in "$script_dir"/*.sh "$script_dir"/*/*.sh; do
+		[[ -f "$script_path" ]] || continue
+		basename="${script_path##*/}"
+		if [[ ! "$basename" =~ (sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,} ]]; then
+			continue
+		fi
+
+		redacted="${redacted//.agents\/scripts\/$basename/[aidevops-script-reference]}"
+		redacted="${redacted//.\/\.agents\/scripts\/$basename/[aidevops-script-reference]}"
+		redacted="${redacted//\`$basename\`/[aidevops-script-reference]}"
+		redacted="${redacted//\"$basename\"/[aidevops-script-reference]}"
+		redacted="${redacted// $basename/ [aidevops-script-reference]}"
+		redacted="${redacted//$'\n'$basename/$'\n'[aidevops-script-reference]}"
+	done
+
+	printf '%s' "$redacted"
+	return 0
+}
+
+#######################################
 # Scan free-form text for private-key material or obvious credential values.
 # Arguments:
 #   $1 - text content to scan
@@ -439,16 +484,21 @@ privacy_scan_local_paths() {
 privacy_scan_secret_material_text() {
 	local text="$1"
 	local hits=0
+	local scan_text
 
 	if [[ -z "$text" ]]; then
 		return 0
 	fi
+	scan_text=$(_privacy_redact_aidevops_script_references "$text")
+	if [[ "$scan_text" != "$text" ]]; then
+		printf '%s\n' '[privacy-scan][ALLOW] aidevops script file reference' >&2
+	fi
 
-	if printf '%s' "$text" | grep -qE -- '-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'; then
+	if printf '%s' "$scan_text" | grep -qE -- '-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'; then
 		printf '%s\n' 'private-key PEM block'
 		hits=$((hits + 1))
 	fi
-	if printf '%s' "$text" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
+	if printf '%s' "$scan_text" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
 		printf '%s\n' 'credential token prefix'
 		hits=$((hits + 1))
 	fi
@@ -497,7 +547,12 @@ privacy_scan_secret_material_diff() {
 		"+"*)
 			[[ "$line" == "+++ "* ]] && continue
 			local added="${line:1}"
-			if [[ "$added" =~ -----BEGIN[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
+			local scan_added
+			scan_added=$(_privacy_redact_aidevops_script_references "$added")
+			if [[ "$scan_added" != "$added" ]]; then
+				printf '%s:%s: [privacy-scan][ALLOW] aidevops script file reference\n' "$current_file" "$line_num" >&2
+			fi
+			if [[ "$scan_added" =~ -----BEGIN[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
 				printf '%s:%s: private-key PEM block\n' "$current_file" "$line_num"
 				hits=$((hits + 1))
 				in_pem=1
@@ -505,10 +560,10 @@ privacy_scan_secret_material_diff() {
 				printf '%s:%s: private-key PEM block content\n' "$current_file" "$line_num"
 				hits=$((hits + 1))
 			fi
-			if [[ "$added" =~ -----END[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
+			if [[ "$scan_added" =~ -----END[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
 				in_pem=0
 			fi
-			if printf '%s' "$added" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
+			if printf '%s' "$scan_added" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
 				printf '%s:%s: credential token prefix\n' "$current_file" "$line_num"
 				hits=$((hits + 1))
 			fi

--- a/.agents/scripts/tests/test-gh-public-privacy-guard.sh
+++ b/.agents/scripts/tests/test-gh-public-privacy-guard.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression tests for public GitHub write privacy secret-material scanning.
+# =============================================================================
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+HELPER_SRC="${SCRIPT_DIR}/../privacy-guard-helper.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf '  PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf '  FAIL: %s\n' "$name"
+	if [[ -n "$detail" ]]; then
+		printf '    %s\n' "$detail"
+	fi
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t gh-public-privacy-guard)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts"
+cp "$HELPER_SRC" "$TMP/scripts/privacy-guard-helper.sh"
+
+# Build the basename in pieces so the test source itself does not contain a
+# token-looking fixture while still reproducing an aidevops helper filename with
+# an embedded credential-prefix-shaped substring.
+ALLOWED_BASENAME="ta""sk-dispatch-helper.sh"
+touch "$TMP/scripts/$ALLOWED_BASENAME"
+
+# shellcheck source=/dev/null
+source "$TMP/scripts/privacy-guard-helper.sh"
+
+printf '=== gh public privacy guard tests ===\n\n'
+
+out=$(privacy_scan_secret_material_text "Worker guidance: edit .agents/scripts/$ALLOWED_BASENAME" 2>"$TMP/allow-path.err")
+rc=$?
+err=$(<"$TMP/allow-path.err")
+if [[ "$rc" -eq 0 && -z "$out" && "$err" == *'[privacy-scan][ALLOW] aidevops script file reference'* ]]; then
+	pass "aidevops script path reference is allowed with allowlist output"
+else
+	fail "aidevops script path reference" "rc=$rc out=$out err=$err"
+fi
+
+out=$(privacy_scan_secret_material_text "Reference basename \`$ALLOWED_BASENAME\` in the issue body" 2>"$TMP/allow-basename.err")
+rc=$?
+err=$(<"$TMP/allow-basename.err")
+if [[ "$rc" -eq 0 && -z "$out" && "$err" == *'[privacy-scan][ALLOW] aidevops script file reference'* ]]; then
+	pass "backticked aidevops script basename is allowed with allowlist output"
+else
+	fail "backticked aidevops script basename" "rc=$rc out=$out err=$err"
+fi
+
+synthetic_token="sk-""abcdefghijklmnopqrstuvwxyz"
+out=$(privacy_scan_secret_material_text "Synthetic secret fixture: $synthetic_token" 2>"$TMP/block-secret.err")
+rc=$?
+if [[ "$rc" -eq 1 && "$out" == *'credential token prefix'* ]]; then
+	pass "synthetic credential-like token remains blocked"
+else
+	fail "synthetic credential-like token" "rc=$rc out=$out"
+fi
+
+out=$(privacy_scan_secret_material_text "Filename-like but undocumented: ${synthetic_token}.sh" 2>"$TMP/block-undocumented.err")
+rc=$?
+if [[ "$rc" -eq 1 && "$out" == *'credential token prefix'* ]]; then
+	pass "undocumented filename-like credential token remains blocked"
+else
+	fail "undocumented filename-like credential token" "rc=$rc out=$out"
+fi
+
+printf '\n'
+if [[ "$FAIL" -eq 0 ]]; then
+	printf '%d/%d tests passed\n' "$PASS" "$PASS"
+	exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

Narrowed the public-write secret scanner so existing aidevops shell helper path and basename references are redacted before credential-prefix matching while real credential-like strings still fail closed. Added a regression test covering allowed .agents/scripts references, blocked synthetic tokens, and allowlist output.

## Files Changed

.agents/scripts/privacy-guard-helper.sh,.agents/scripts/tests/test-gh-public-privacy-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-public-privacy-guard.sh; bash .agents/scripts/test-privacy-guard-shim.sh; bash .agents/scripts/tests/test-gh-shim.sh; shellcheck .agents/scripts/*privacy* .agents/scripts/gh-signature-helper.sh .agents/scripts/tests/test-gh-public-privacy-guard.sh

Resolves #23079


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 4m and 73,601 tokens on this as a headless worker.