### PR TITLE
fix: reject Qwen OpenCode shim candidates

### DIFF
--- a/.agents/scripts/setup/_services.sh
+++ b/.agents/scripts/setup/_services.sh
@@ -112,6 +112,16 @@ _setup_opencode_version_output() {
 	return $?
 }
 
+_setup_opencode_help_output() {
+	local bin="$1"
+	local help_timeout="${AIDEVOPS_OPENCODE_VERSION_TIMEOUT:-5}"
+	local help_path=""
+
+	help_path=$(_setup_opencode_node_path_for_binary "$bin")
+	PATH="${help_path}:${PATH:-}" _setup_opencode_timeout_cmd "$help_timeout" "$bin" --help
+	return $?
+}
+
 _setup_opencode_first_line() {
 	local input="$1"
 	local first_line=""
@@ -188,6 +198,9 @@ _setup_validate_opencode_binary() {
 	local version_output
 	version_output=$(_setup_opencode_version_output "$bin" 2>/dev/null || printf '')
 	[[ -n "$version_output" ]] || return 2
+	local help_output
+	help_output=$(_setup_opencode_help_output "$bin" 2>/dev/null || printf '')
+	[[ -n "$help_output" ]] || return 2
 
 	# Anthropic claude CLI signature -- highest-confidence rejection
 	[[ "$version_output" == *"(Claude Code)"* ]] && return 1
@@ -197,6 +210,13 @@ _setup_validate_opencode_binary() {
 
 	# Sanity check: must look like a semver (X.Y.Z)
 	[[ "$version_output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || return 1
+
+	# Positive OpenCode identity check. Qwen and other CLIs can return a
+	# semver-compatible --version (for example 0.2.1), so version shape alone is
+	# not enough. Require OpenCode's command surface before writing/accepting the
+	# stable ~/.local/bin/opencode shim used by Tabby and workers.
+	[[ "$help_output" == *"opencode run [message..]"* ]] || return 1
+	[[ "$help_output" == *"run opencode with a message"* ]] || return 1
 
 	return 0
 }

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1616,6 +1616,16 @@ _setup_opencode_version_output() {
 	return $?
 }
 
+_setup_opencode_help_output() {
+	local bin="$1"
+	local help_timeout="${AIDEVOPS_OPENCODE_VERSION_TIMEOUT:-5}"
+	local help_path=""
+
+	help_path=$(_setup_opencode_node_path_for_binary "$bin")
+	PATH="${help_path}:${PATH:-}" _setup_opencode_timeout_cmd "$help_timeout" "$bin" --help
+	return $?
+}
+
 _setup_opencode_first_line() {
 	local input="$1"
 	local first_line=""
@@ -1692,6 +1702,9 @@ _setup_validate_opencode_binary() {
 	local v
 	v=$(_setup_opencode_version_output "$bin" 2>/dev/null || printf '')
 	[[ -n "$v" ]] || return 2
+	local help_output
+	help_output=$(_setup_opencode_help_output "$bin" 2>/dev/null || printf '')
+	[[ -n "$help_output" ]] || return 2
 
 	# Anthropic claude CLI signature — highest-confidence rejection.
 	[[ "$v" == *"(Claude Code)"* ]] && return 1
@@ -1701,6 +1714,13 @@ _setup_validate_opencode_binary() {
 
 	# Sanity: must look like a semver (X.Y.Z).
 	[[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || return 1
+
+	# Positive OpenCode identity check. Qwen and other CLIs can return a
+	# semver-compatible --version (for example 0.2.1), so version shape alone is
+	# not enough. Require OpenCode's command surface before writing/accepting the
+	# stable ~/.local/bin/opencode shim used by Tabby and workers.
+	[[ "$help_output" == *"opencode run [message..]"* ]] || return 1
+	[[ "$help_output" == *"run opencode with a message"* ]] || return 1
 
 	return 0
 }

--- a/.agents/scripts/tests/test-setup-opencode-cli.sh
+++ b/.agents/scripts/tests/test-setup-opencode-cli.sh
@@ -71,6 +71,8 @@ echo "Test 1: _setup_validate_opencode_binary on real opencode shim"
 cat >"$SANDBOX/bin/opencode-real" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "1.14.25"
+[[ "${1:-}" == "--help" ]] && echo "opencode run [message..]     run opencode with a message"
+exit 0
 EOF
 chmod +x "$SANDBOX/bin/opencode-real"
 
@@ -88,6 +90,7 @@ echo "Test 2: _setup_validate_opencode_binary on claude CLI shim"
 cat >"$SANDBOX/bin/opencode-claude" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "2.1.119 (Claude Code)"
+[[ "${1:-}" == "--help" ]] && echo "Claude Code"
 EOF
 chmod +x "$SANDBOX/bin/opencode-claude"
 
@@ -99,6 +102,24 @@ chmod +x "$SANDBOX/bin/opencode-claude"
 ) >"$SANDBOX/out2" 2>&1
 rc2=$(tail -1 "$SANDBOX/out2")
 assert_eq "claude shim -> rc=1" "1" "$rc2"
+
+# --- Test 2b: validator rc for Qwen Code shim -------------------------------
+echo "Test 2b: _setup_validate_opencode_binary rejects qwen CLI shim"
+cat >"$SANDBOX/bin/opencode-qwen" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "0.2.1"
+[[ "${1:-}" == "--help" ]] && echo "Qwen Code - Launch an interactive CLI"
+EOF
+chmod +x "$SANDBOX/bin/opencode-qwen"
+
+(
+	source_lib
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/opencode-qwen" || rc=$?
+	echo "$rc"
+) >"$SANDBOX/out2b" 2>&1
+rc2b=$(tail -1 "$SANDBOX/out2b")
+assert_eq "qwen shim -> rc=1" "1" "$rc2b"
 
 # --- Test 3: validator rc for missing binary --------------------------------
 echo "Test 3: _setup_validate_opencode_binary on missing path"
@@ -116,6 +137,7 @@ echo "Test 4: _setup_validate_opencode_binary on garbage shim"
 cat >"$SANDBOX/bin/opencode-garbage" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "not-a-version"
+[[ "${1:-}" == "--help" ]] && echo "not opencode"
 EOF
 chmod +x "$SANDBOX/bin/opencode-garbage"
 
@@ -136,6 +158,7 @@ if [[ "${1:-}" == "--version" ]]; then
 	sleep 5
 	echo "1.14.25"
 fi
+[[ "${1:-}" == "--help" ]] && echo "opencode run [message..]     run opencode with a message"
 EOF
 chmod +x "$SANDBOX/bin/opencode-slow"
 

--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -54,7 +54,9 @@ extract_functions() {
 	awk '
 		/^_setup_opencode_timeout_cmd\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_version_output\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_help_output\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_first_line\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_node_path_for_binary\(\)/, /^}$/ { print; next }
 		/^_setup_validate_opencode_binary\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_force_heal\(\)/, /^}$/ { print; next }
 		/^setup_opencode_cli\(\)/, /^}$/ { print; next }
@@ -94,6 +96,8 @@ source_extracted() {
 		cat >"$SANDBOX/bin/opencode" <<'INNER_EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "1.14.25"
+[[ "${1:-}" == "--help" ]] && echo "opencode run [message..]     run opencode with a message"
+exit 0
 INNER_EOF
 		chmod +x "$SANDBOX/bin/opencode"
 		return 0
@@ -109,6 +113,8 @@ echo "Test 1: _setup_validate_opencode_binary on real opencode shim"
 cat >"$SANDBOX/bin/opencode-real" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "1.14.25"
+[[ "${1:-}" == "--help" ]] && echo "opencode run [message..]     run opencode with a message"
+exit 0
 EOF
 chmod +x "$SANDBOX/bin/opencode-real"
 (
@@ -124,6 +130,7 @@ echo "Test 2: _setup_validate_opencode_binary on claude CLI shim"
 cat >"$SANDBOX/bin/opencode-claude" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "2.1.119 (Claude Code)"
+[[ "${1:-}" == "--help" ]] && echo "Claude Code"
 EOF
 chmod +x "$SANDBOX/bin/opencode-claude"
 (
@@ -139,6 +146,7 @@ echo "Test 2b: _setup_validate_opencode_binary rejects major >=10"
 cat >"$SANDBOX/bin/opencode-major10" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "--version" ]] && echo "10.0.0"
+[[ "${1:-}" == "--help" ]] && echo "opencode run [message..]     run opencode with a message"
 EOF
 chmod +x "$SANDBOX/bin/opencode-major10"
 (
@@ -148,6 +156,22 @@ chmod +x "$SANDBOX/bin/opencode-major10"
 	echo "$rc"
 ) >"$SANDBOX/out2b" 2>&1
 assert_eq "major 10 shim -> rc=1" "1" "$(tail -1 "$SANDBOX/out2b")"
+
+# --- Test 2c: validator rejects Qwen Code semver-compatible output ----------
+echo "Test 2c: _setup_validate_opencode_binary rejects qwen CLI shim"
+cat >"$SANDBOX/bin/opencode-qwen" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "0.2.1"
+[[ "${1:-}" == "--help" ]] && echo "Qwen Code - Launch an interactive CLI"
+EOF
+chmod +x "$SANDBOX/bin/opencode-qwen"
+(
+	source_extracted
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/opencode-qwen" || rc=$?
+	echo "$rc"
+) >"$SANDBOX/out2c" 2>&1
+assert_eq "qwen shim -> rc=1" "1" "$(tail -1 "$SANDBOX/out2c")"
 
 # --- Test 3: validator on missing path -------------------------------------
 echo "Test 3: _setup_validate_opencode_binary on missing path"
@@ -167,6 +191,7 @@ if [[ "${1:-}" == "--version" ]]; then
 	sleep 5
 	echo "1.14.25"
 fi
+[[ "${1:-}" == "--help" ]] && echo "opencode run [message..]     run opencode with a message"
 EOF
 chmod +x "$SANDBOX/bin/opencode-slow"
 (


### PR DESCRIPTION
## Summary
- Add positive OpenCode help-surface validation before accepting or writing the stable ~/.local/bin/opencode shim.
- Reject Qwen-style semver-compatible CLI output so Tabby/OpenCode shortcuts do not launch Qwen by mistake.
- Cover both active setup paths with Qwen regression tests.

Resolves #23098

## Verification
- `.agents/scripts/tests/test-tool-install-opencode.sh`
- `.agents/scripts/tests/test-setup-opencode-cli.sh`
- `shellcheck .agents/scripts/setup/modules/tool-install.sh .agents/scripts/setup/_services.sh .agents/scripts/tests/test-tool-install-opencode.sh .agents/scripts/tests/test-setup-opencode-cli.sh`
- `.agents/scripts/linters-local.sh`
