### PR TITLE
t3570: fix: pause transient rate-limit release storms

### DIFF
--- a/.agents/scripts/dispatch-backoff-helper.sh
+++ b/.agents/scripts/dispatch-backoff-helper.sh
@@ -79,6 +79,7 @@ DISPATCH_BACKOFF_NMR_THRESHOLD="${DISPATCH_BACKOFF_NMR_THRESHOLD:-4}"       # 4+
 DISPATCH_PROVIDER_BACKOFF_WINDOW_SECS="${DISPATCH_PROVIDER_BACKOFF_WINDOW_SECS:-900}"
 DISPATCH_PROVIDER_BACKOFF_THRESHOLD="${DISPATCH_PROVIDER_BACKOFF_THRESHOLD:-6}"
 DISPATCH_PROVIDER_BACKOFF_COOLDOWN_SECS="${DISPATCH_PROVIDER_BACKOFF_COOLDOWN_SECS:-300}"
+: "${AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_OVERRIDE:=0}"
 
 # Backoff intervals in seconds (indexed by failure count; index 0 unused).
 # Index >= NMR_THRESHOLD uses the last entry (86400 = 24h).
@@ -246,6 +247,78 @@ _db_check_provider_pressure_backoff() {
 }
 
 #######################################
+# Check comment-based transient rate-limit release circuit state.
+#
+# The release path posts a consolidated marker after repeated
+# `CLAIM_RELEASED reason=rate_limit_transient` comments. This dispatch-side
+# gate honours that marker so the issue is paused until cooldown expiry or an
+# explicit maintainer override comment.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug
+#   $3 - now epoch
+# Returns: 0 clear, 1 cooldown active, 2 error/fail-open.
+#######################################
+_db_check_rate_limit_release_circuit_comment() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local now="$3"
+
+	if [[ "$AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_OVERRIDE" == "1" ]]; then
+		return 0
+	fi
+
+	local comments_json=""
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
+		--jq '[.[] | {created_at: .created_at, body: (.body // "")}]' 2>/dev/null) || return 2
+	[[ -n "$comments_json" ]] || return 0
+
+	local marker_json=""
+	marker_json=$(printf '%s' "$comments_json" | jq -c '
+		[.[] | select((.body // "") | contains("rate-limit-release-circuit-breaker"))] | last // empty
+	' 2>/dev/null) || marker_json=""
+	[[ -n "$marker_json" ]] || return 0
+
+	local latest_override=""
+	latest_override=$(printf '%s' "$comments_json" | jq -r '
+		[.[] | select((.body // "") | test("rate-limit-release-circuit-breaker:override")) | .created_at] | max // ""
+	' 2>/dev/null) || latest_override=""
+
+	local marker_created=""
+	marker_created=$(printf '%s' "$marker_json" | jq -r '.created_at // ""' 2>/dev/null) || marker_created=""
+	if [[ -n "$latest_override" && -n "$marker_created" && "$latest_override" > "$marker_created" ]]; then
+		return 0
+	fi
+
+	local marker_line=""
+	marker_line=$(printf '%s' "$marker_json" | jq -r '.body // ""' 2>/dev/null | grep -oE '<!-- rate-limit-release-circuit-breaker[^>]*-->' | tail -1) || marker_line=""
+	[[ -n "$marker_line" ]] || return 0
+
+	local next_epoch=""
+	next_epoch=$(printf '%s' "$marker_line" | grep -oE 'next_epoch=[0-9]+' | cut -d= -f2 || true)
+	[[ "$next_epoch" =~ ^[0-9]+$ ]] || return 0
+
+	if [[ "$now" -ge "$next_epoch" ]]; then
+		return 0
+	fi
+
+	local wait_remaining=$(( next_epoch - now ))
+	local next_human
+	next_human=$(date -r "$next_epoch" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || \
+		date -d "@${next_epoch}" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || \
+		printf 'epoch:%s' "$next_epoch")
+
+	printf 'BACKOFF_ACTIVE reason=rate_limit_release_circuit wait=%ss next=%s\n' \
+		"$wait_remaining" "$next_human" >&2
+	echo "${_DB_LOG_PREFIX} BACKOFF_ACTIVE #${issue_number} (${repo_slug}) rate_limit_release_circuit wait=${wait_remaining}s next=${next_human}" >>"$LOGFILE"
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "dispatch_backoff_skipped" 2>/dev/null || true
+	fi
+	return 1
+}
+
+#######################################
 # Check whether dispatch backoff is active for an issue.
 #
 # Reads headless-runtime-metrics.jsonl for recent rate_limit events,
@@ -294,6 +367,15 @@ check_dispatch_backoff() {
 	_db_check_provider_pressure_backoff "$now" || provider_pressure_rc=$?
 	if [[ "$provider_pressure_rc" -eq 1 ]]; then
 		return 1
+	fi
+
+	local release_circuit_rc=0
+	_db_check_rate_limit_release_circuit_comment "$issue_number" "$repo_slug" "$now" || release_circuit_rc=$?
+	if [[ "$release_circuit_rc" -eq 1 ]]; then
+		return 1
+	fi
+	if [[ "$release_circuit_rc" -eq 2 ]]; then
+		echo "${_DB_LOG_PREFIX} WARNING: rate-limit release circuit comment check failed for #${issue_number} (${repo_slug}) — proceeding (fail-open)" >>"$LOGFILE"
 	fi
 
 	# Count recent rate_limit events.

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -47,6 +47,197 @@ unset _HRFF_SCRIPT_DIR
 # authoritative regardless of reason value.
 readonly _HRFF_FALLBACK_EXIT="process_exit"
 
+# Per-issue transient rate-limit release circuit breaker (t3570 / GH#23102).
+# These defaults intentionally keep the first transient failures visible while
+# suppressing repeated CLAIM_RELEASED storms during provider capacity outages.
+: "${AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_THRESHOLD:=3}"
+: "${AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_LOOKBACK_SECS:=86400}"
+: "${AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_COOLDOWN_SECS:=1800}"
+
+#######################################
+# Convert an epoch to a UTC-ish human timestamp for audit comments.
+#
+# Args:
+#   $1 = epoch seconds
+#######################################
+_hrff_epoch_to_utc() {
+	local epoch="$1"
+	date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+		date -u -d "@${epoch}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+		printf 'epoch:%s' "$epoch"
+	return 0
+}
+
+#######################################
+# Return recent issue comments needed by the rate-limit release breaker.
+#
+# Args:
+#   $1 = issue_number
+#   $2 = repo_slug
+#######################################
+_hrff_rate_limit_release_comments_json() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
+		--jq '[.[] | {created_at: .created_at, body: (.body // "")}]' 2>/dev/null || return 1
+	return 0
+}
+
+#######################################
+# Check whether the transient rate-limit release breaker is currently active.
+#
+# Args:
+#   $1 = issue_number
+#   $2 = repo_slug
+#   $3 = now_epoch
+#   $4 = comments_json
+# Returns: 0 active, 1 inactive.
+#######################################
+_hrff_rate_limit_release_circuit_active() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local now_epoch="$3"
+	local comments_json="$4"
+
+	if [[ "${AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_OVERRIDE:-0}" == "1" ]]; then
+		return 1
+	fi
+
+	local latest_override=""
+	latest_override=$(printf '%s' "$comments_json" | jq -r \
+		'[.[] | select((.body // "") | test("rate-limit-release-circuit-breaker:override")) | .created_at] | max // ""' \
+		2>/dev/null) || latest_override=""
+
+	local marker_line=""
+	marker_line=$(printf '%s' "$comments_json" | jq -r \
+		'[.[] | select((.body // "") | contains("rate-limit-release-circuit-breaker")) | .body] | last // ""' \
+		2>/dev/null | grep -oE '<!-- rate-limit-release-circuit-breaker[^>]*-->' | tail -1) || marker_line=""
+
+	[[ -n "$marker_line" ]] || return 1
+
+	local next_epoch=""
+	next_epoch=$(printf '%s' "$marker_line" | grep -oE 'next_epoch=[0-9]+' | cut -d= -f2 || true)
+	[[ "$next_epoch" =~ ^[0-9]+$ ]] || return 1
+
+	if [[ -n "$latest_override" ]]; then
+		local marker_created=""
+		marker_created=$(printf '%s' "$comments_json" | jq -r --arg marker "$marker_line" \
+			'[.[] | select((.body // "") | contains($marker)) | .created_at] | last // ""' \
+			2>/dev/null) || marker_created=""
+		if [[ -n "$marker_created" && "$latest_override" > "$marker_created" ]]; then
+			return 1
+		fi
+	fi
+
+	if [[ "$now_epoch" -lt "$next_epoch" ]]; then
+		print_info "Transient rate-limit release circuit active for #${issue_number} (${repo_slug}); suppressing duplicate CLAIM_RELEASED until $(_hrff_epoch_to_utc "$next_epoch")"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
+# Count recent transient rate-limit release comments for an issue.
+#
+# Args:
+#   $1 = comments_json
+#   $2 = since_epoch
+#######################################
+_hrff_count_recent_rate_limit_releases() {
+	local comments_json="$1"
+	local since_epoch="$2"
+
+	printf '%s' "$comments_json" | jq -r --argjson since "$since_epoch" '
+		[.[]
+		 | select((.body // "") | contains("CLAIM_RELEASED reason=rate_limit_transient"))
+		 | select(((.created_at // "1970-01-01T00:00:00Z") | fromdateiso8601? // 0) >= $since)
+		] | length' 2>/dev/null || printf '0'
+	return 0
+}
+
+#######################################
+# Post one consolidated audit comment once the threshold is crossed.
+#
+# Args:
+#   $1 = issue_number
+#   $2 = repo_slug
+#   $3 = count_after_increment
+#   $4 = next_epoch
+#######################################
+_hrff_post_rate_limit_release_circuit_comment() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local count_after_increment="$3"
+	local next_epoch="$4"
+
+	local next_human=""
+	next_human=$(_hrff_epoch_to_utc "$next_epoch")
+	local cooldown_secs="$AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_COOLDOWN_SECS"
+	local body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- rate-limit-release-circuit-breaker issue=${issue_number} count=${count_after_increment} next_epoch=${next_epoch} -->
+RATE_LIMIT_RELEASE_CIRCUIT active=true count=${count_after_increment} cooldown=${cooldown_secs}s next=${next_human}
+
+Repeated transient provider rate-limit releases for this issue reached the circuit-breaker threshold. Further duplicate \`CLAIM_RELEASED reason=rate_limit_transient\` audit comments are suppressed until ${next_human} to reduce comment storms and wasted dispatch cycles.
+
+Dispatch resumes after the cooldown expires. Maintainers can override early by posting a comment containing \`rate-limit-release-circuit-breaker:override\`.
+<!-- ops:end -->"
+
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--method POST \
+		--field body="$body" \
+		>/dev/null 2>&1 || print_warning "Failed to post rate-limit release circuit comment on #${issue_number} (non-fatal)"
+	return 0
+}
+
+#######################################
+# Evaluate the transient rate-limit release breaker before posting a release.
+#
+# Args:
+#   $1 = issue_number
+#   $2 = repo_slug
+# Returns: 0 post normal release, 1 suppress duplicate release comment.
+#######################################
+_hrff_handle_rate_limit_release_circuit() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local now_epoch=""
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+
+	local comments_json=""
+	comments_json=$(_hrff_rate_limit_release_comments_json "$issue_number" "$repo_slug") || comments_json=""
+	[[ -n "$comments_json" ]] || return 0
+
+	if _hrff_rate_limit_release_circuit_active "$issue_number" "$repo_slug" "$now_epoch" "$comments_json"; then
+		return 1
+	fi
+
+	local threshold="$AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_THRESHOLD"
+	local lookback="$AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_LOOKBACK_SECS"
+	local cooldown="$AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_COOLDOWN_SECS"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=3
+	[[ "$lookback" =~ ^[0-9]+$ ]] || lookback=86400
+	[[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=1800
+	[[ "$threshold" -gt 0 ]] || return 0
+
+	local since_epoch=$(( now_epoch - lookback ))
+	[[ "$since_epoch" -lt 0 ]] && since_epoch=0
+	local previous_count=""
+	previous_count=$(_hrff_count_recent_rate_limit_releases "$comments_json" "$since_epoch") || previous_count=0
+	[[ "$previous_count" =~ ^[0-9]+$ ]] || previous_count=0
+	local count_after_increment=$(( previous_count + 1 ))
+
+	if [[ "$count_after_increment" -ge "$threshold" ]]; then
+		local next_epoch=$(( now_epoch + cooldown ))
+		_hrff_post_rate_limit_release_circuit_comment "$issue_number" "$repo_slug" "$count_after_increment" "$next_epoch"
+	fi
+
+	return 0
+}
+
 #######################################
 # Unlock the issue once a worker releases its dispatch claim.
 #
@@ -98,6 +289,22 @@ _release_dispatch_claim() {
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		print_warning "Cannot release claim: missing issue=$issue_number repo=$repo_slug"
 		return 0
+	fi
+
+	if [[ "$reason" == "rate_limit_transient" ]]; then
+		if ! _hrff_handle_rate_limit_release_circuit "$issue_number" "$repo_slug"; then
+			# The per-issue breaker is already active. Keep state cleanup so the
+			# GitHub issue is not stranded in an active lifecycle state, but skip
+			# the duplicate CLAIM_RELEASED audit comment that caused storms.
+			local _rl_runner_name=""
+			_rl_runner_name=$(whoami)
+			if declare -F clear_active_status_on_release >/dev/null 2>&1; then
+				clear_active_status_on_release "$issue_number" "$repo_slug" "$_rl_runner_name" \
+					|| print_warning "Failed to clear active status on #${issue_number} (non-fatal)"
+			fi
+			_unlock_issue_after_dispatch_release "$issue_number" "$repo_slug"
+			return 0
+		fi
 	fi
 
 	local aidevops_version="$AIDEVOPS_UNKNOWN_VERSION" opencode_version="$AIDEVOPS_UNKNOWN_VERSION"

--- a/.agents/scripts/tests/test-dispatch-rate-limit-release-circuit.sh
+++ b/.agents/scripts/tests/test-dispatch-rate-limit-release-circuit.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for t3570 / GH#23102 dispatch-side handling of the
+# comment-based transient rate-limit release circuit breaker.
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)"
+TMP="$(mktemp -d -t t3570-dispatch.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+export LOGFILE="${TMP}/test-pulse.log"
+export HOME="${TMP}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+COMMENTS_JSON="${TMP}/comments.json"
+FIXTURE_METRICS="${TMP}/headless-runtime-metrics.jsonl"
+STATS_COUNTER_FILE="${TMP}/stats-counter.log"
+printf '[]\n' >"$COMMENTS_JSON"
+: >"$FIXTURE_METRICS"
+: >"$STATS_COUNTER_FILE"
+export DISPATCH_BACKOFF_METRICS_FILE="$FIXTURE_METRICS"
+
+pulse_stats_increment() {
+	local counter_name="$1"
+	printf '%s\n' "$counter_name" >>"$STATS_COUNTER_FILE"
+	return 0
+}
+export -f pulse_stats_increment
+
+gh() {
+	local cmd="${1:-}"
+	shift || true
+	if [[ "$cmd" == "api" ]]; then
+		jq -c '.' "$COMMENTS_JSON"
+	fi
+	return 0
+}
+export -f gh
+
+# shellcheck source=../dispatch-backoff-helper.sh
+source "${SCRIPTS_DIR}/dispatch-backoff-helper.sh"
+
+# Re-override after sourcing the real pulse-stats helper.
+# shellcheck disable=SC2317
+pulse_stats_increment() {
+	local counter_name="$1"
+	printf '%s\n' "$counter_name" >>"$STATS_COUNTER_FILE"
+	return 0
+}
+
+iso_offset() {
+	local seconds_delta="$1"
+	local epoch
+	epoch=$(($(date +%s) + seconds_delta))
+	date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d "@${epoch}" '+%Y-%m-%dT%H:%M:%SZ'
+	return 0
+}
+
+epoch_offset() {
+	local seconds_delta="$1"
+	printf '%s\n' "$(($(date +%s) + seconds_delta))"
+	return 0
+}
+
+append_comment_fixture() {
+	local created_at="$1"
+	local body="$2"
+	local tmp="${COMMENTS_JSON}.tmp"
+	jq --arg created_at "$created_at" --arg body "$body" \
+		'. + [{created_at: $created_at, body: $body}]' \
+		"$COMMENTS_JSON" >"$tmp"
+	mv "$tmp" "$COMMENTS_JSON"
+	return 0
+}
+
+reset_case() {
+	printf '[]\n' >"$COMMENTS_JSON"
+	: >"$FIXTURE_METRICS"
+	: >"$STATS_COUNTER_FILE"
+	: >"$LOGFILE"
+	unset AIDEVOPS_SKIP_DISPATCH_BACKOFF 2>/dev/null || true
+	export AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_OVERRIDE=0
+	export DISPATCH_PROVIDER_BACKOFF_THRESHOLD=999
+	return 0
+}
+
+test_active_marker_blocks_dispatch() {
+	reset_case
+	local next_epoch
+	next_epoch=$(epoch_offset 600)
+	append_comment_fixture "$(iso_offset -60)" "<!-- rate-limit-release-circuit-breaker issue=12345 count=3 next_epoch=${next_epoch} -->"
+
+	local output="" rc=0
+	output=$(check_dispatch_backoff 12345 owner/repo 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 1 ]] && printf '%s' "$output" | grep -q 'BACKOFF_ACTIVE reason=rate_limit_release_circuit' && \
+		grep -q '^dispatch_backoff_skipped$' "$STATS_COUNTER_FILE"; then
+		printf 'PASS active release circuit blocks dispatch\n'
+		return 0
+	fi
+	printf 'FAIL active release circuit did not block dispatch (rc=%s output=%s)\n' "$rc" "$output"
+	return 1
+}
+
+test_expired_marker_allows_dispatch() {
+	reset_case
+	local next_epoch
+	next_epoch=$(epoch_offset -60)
+	append_comment_fixture "$(iso_offset -900)" "<!-- rate-limit-release-circuit-breaker issue=12345 count=3 next_epoch=${next_epoch} -->"
+
+	local output="" rc=0
+	output=$(check_dispatch_backoff 12345 owner/repo 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 0 ]] && ! printf '%s' "$output" | grep -q 'BACKOFF_ACTIVE'; then
+		printf 'PASS expired release circuit allows dispatch\n'
+		return 0
+	fi
+	printf 'FAIL expired release circuit blocked dispatch (rc=%s output=%s)\n' "$rc" "$output"
+	return 1
+}
+
+test_override_comment_allows_dispatch() {
+	reset_case
+	local next_epoch
+	next_epoch=$(epoch_offset 600)
+	append_comment_fixture "$(iso_offset -60)" "<!-- rate-limit-release-circuit-breaker issue=12345 count=3 next_epoch=${next_epoch} -->"
+	append_comment_fixture "$(iso_offset -30)" 'rate-limit-release-circuit-breaker:override'
+
+	local output="" rc=0
+	output=$(check_dispatch_backoff 12345 owner/repo 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 0 ]] && ! printf '%s' "$output" | grep -q 'BACKOFF_ACTIVE'; then
+		printf 'PASS override comment allows dispatch\n'
+		return 0
+	fi
+	printf 'FAIL override comment did not allow dispatch (rc=%s output=%s)\n' "$rc" "$output"
+	return 1
+}
+
+test_no_marker_allows_dispatch() {
+	reset_case
+	local output="" rc=0
+	output=$(check_dispatch_backoff 12345 owner/repo 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 0 ]] && ! printf '%s' "$output" | grep -q 'BACKOFF_ACTIVE'; then
+		printf 'PASS no release circuit marker allows dispatch\n'
+		return 0
+	fi
+	printf 'FAIL missing release circuit marker blocked dispatch (rc=%s output=%s)\n' "$rc" "$output"
+	return 1
+}
+
+test_active_marker_blocks_dispatch
+test_expired_marker_allows_dispatch
+test_override_comment_allows_dispatch
+test_no_marker_allows_dispatch

--- a/.agents/scripts/tests/test-rate-limit-release-circuit.sh
+++ b/.agents/scripts/tests/test-rate-limit-release-circuit.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for t3570 / GH#23102: repeated transient rate-limit claim
+# releases should trip a per-issue circuit breaker, post one consolidated audit
+# comment, and suppress duplicate CLAIM_RELEASED comment storms while active.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_HOME="$(mktemp -d)"
+CALL_LOG="${TMP_HOME}/gh-calls.log"
+COMMENTS_JSON="${TMP_HOME}/comments.json"
+: >"$CALL_LOG"
+printf '[]\n' >"$COMMENTS_JSON"
+
+cleanup() {
+	rm -rf "$TMP_HOME"
+	return 0
+}
+trap cleanup EXIT
+
+print_warning() {
+	local message="$1"
+	printf 'WARN %s\n' "$message" >>"$CALL_LOG"
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf 'INFO %s\n' "$message" >>"$CALL_LOG"
+	return 0
+}
+
+clear_active_status_on_release() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local runner_name="$3"
+	printf 'CLEAR issue=%s repo=%s runner=%s\n' "$issue_number" "$repo_slug" "$runner_name" >>"$CALL_LOG"
+	return 0
+}
+
+append_comment_fixture() {
+	local created_at="$1"
+	local body="$2"
+	local tmp="${COMMENTS_JSON}.tmp"
+	jq --arg created_at "$created_at" --arg body "$body" \
+		'. + [{created_at: $created_at, body: $body}]' \
+		"$COMMENTS_JSON" >"$tmp"
+	mv "$tmp" "$COMMENTS_JSON"
+	return 0
+}
+
+reset_case() {
+	: >"$CALL_LOG"
+	printf '[]\n' >"$COMMENTS_JSON"
+	unset AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_OVERRIDE 2>/dev/null || true
+	export AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_THRESHOLD=3
+	export AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_LOOKBACK_SECS=86400
+	export AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_COOLDOWN_SECS=600
+	return 0
+}
+
+gh() {
+	local cmd="${1:-}"
+	shift || true
+	case "$cmd" in
+	api)
+		local path="${1:-}"
+		shift || true
+		local method="GET" body="" prev=""
+		local arg
+		for arg in "$@"; do
+			if [[ "$prev" == "--method" ]]; then
+				method="$arg"
+			fi
+			if [[ "$arg" == body=* ]]; then
+				body="${arg#body=}"
+			fi
+			prev="$arg"
+		done
+		printf 'API method=%s path=%s body=%s\n' "$method" "$path" "$body" >>"$CALL_LOG"
+		if [[ "$method" == "POST" ]]; then
+			append_comment_fixture "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$body"
+			printf '{}\n'
+		else
+			jq -c '.' "$COMMENTS_JSON"
+		fi
+		;;
+	issue)
+		local subcmd="${1:-}"
+		shift || true
+		if [[ "$subcmd" == "unlock" ]]; then
+			local issue_number="${1:-}"
+			shift || true
+			local repo_slug="" prev=""
+			local arg
+			for arg in "$@"; do
+				if [[ "$prev" == "--repo" ]]; then
+					repo_slug="$arg"
+				fi
+				prev="$arg"
+			done
+			printf 'UNLOCK issue=%s repo=%s\n' "$issue_number" "$repo_slug" >>"$CALL_LOG"
+		fi
+		;;
+	*) ;;
+	esac
+	return 0
+}
+
+# shellcheck source=../headless-runtime-failure.sh
+source "${SCRIPT_DIR}/headless-runtime-failure.sh"
+
+export DISPATCH_REPO_SLUG="owner/repo"
+
+iso_offset() {
+	local seconds_delta="$1"
+	local epoch
+	epoch=$(($(date +%s) + seconds_delta))
+	date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d "@${epoch}" '+%Y-%m-%dT%H:%M:%SZ'
+	return 0
+}
+
+epoch_offset() {
+	local seconds_delta="$1"
+	printf '%s\n' "$(($(date +%s) + seconds_delta))"
+	return 0
+}
+
+test_threshold_posts_audit_and_release() {
+	reset_case
+	append_comment_fixture "$(iso_offset -120)" '<!-- ops:start -->
+CLAIM_RELEASED reason=rate_limit_transient runner=test ts=x
+<!-- ops:end -->'
+	append_comment_fixture "$(iso_offset -60)" '<!-- ops:start -->
+CLAIM_RELEASED reason=rate_limit_transient runner=test ts=x
+<!-- ops:end -->'
+
+	_release_dispatch_claim "issue-12345" "rate_limit_transient" "1" "0"
+
+	if grep -q 'RATE_LIMIT_RELEASE_CIRCUIT active=true count=3' "$CALL_LOG" && \
+		grep -q 'CLAIM_RELEASED reason=rate_limit_transient' "$CALL_LOG"; then
+		printf 'PASS threshold crossing posts consolidated audit and current release\n'
+		return 0
+	fi
+	printf 'FAIL threshold crossing missing audit or release\n'
+	sed 's/^/  /' "$CALL_LOG"
+	return 1
+}
+
+test_active_circuit_suppresses_duplicate_release() {
+	reset_case
+	local next_epoch
+	next_epoch=$(epoch_offset 600)
+	append_comment_fixture "$(iso_offset -30)" "<!-- ops:start -->
+<!-- rate-limit-release-circuit-breaker issue=12345 count=3 next_epoch=${next_epoch} -->
+RATE_LIMIT_RELEASE_CIRCUIT active=true count=3
+<!-- ops:end -->"
+
+	_release_dispatch_claim "issue-12345" "rate_limit_transient" "1" "0"
+
+	if grep -q 'suppressing duplicate CLAIM_RELEASED' "$CALL_LOG" && \
+		! grep -q 'CLAIM_RELEASED reason=rate_limit_transient' "$CALL_LOG" && \
+		grep -q 'CLEAR issue=12345 repo=owner/repo' "$CALL_LOG" && \
+		grep -q 'UNLOCK issue=12345 repo=owner/repo' "$CALL_LOG"; then
+		printf 'PASS active circuit suppresses duplicate release while cleaning state\n'
+		return 0
+	fi
+	printf 'FAIL active circuit did not suppress duplicate release cleanly\n'
+	sed 's/^/  /' "$CALL_LOG"
+	return 1
+}
+
+test_cooldown_expiry_allows_release() {
+	reset_case
+	local next_epoch
+	next_epoch=$(epoch_offset -60)
+	append_comment_fixture "$(iso_offset -900)" "<!-- rate-limit-release-circuit-breaker issue=12345 count=3 next_epoch=${next_epoch} -->"
+
+	_release_dispatch_claim "issue-12345" "rate_limit_transient" "1" "0"
+
+	if grep -q 'CLAIM_RELEASED reason=rate_limit_transient' "$CALL_LOG"; then
+		printf 'PASS expired circuit allows release after cooldown\n'
+		return 0
+	fi
+	printf 'FAIL expired circuit did not allow release\n'
+	sed 's/^/  /' "$CALL_LOG"
+	return 1
+}
+
+test_non_rate_limit_release_unchanged() {
+	reset_case
+	local next_epoch
+	next_epoch=$(epoch_offset 600)
+	append_comment_fixture "$(iso_offset -30)" "<!-- rate-limit-release-circuit-breaker issue=12345 count=3 next_epoch=${next_epoch} -->"
+
+	_release_dispatch_claim "issue-12345" "worker_failed" "1" "0"
+
+	if grep -q 'CLAIM_RELEASED reason=worker_failed' "$CALL_LOG" && \
+		! grep -q 'suppressing duplicate CLAIM_RELEASED' "$CALL_LOG"; then
+		printf 'PASS non-rate-limit release handling unchanged\n'
+		return 0
+	fi
+	printf 'FAIL non-rate-limit release path changed unexpectedly\n'
+	sed 's/^/  /' "$CALL_LOG"
+	return 1
+}
+
+test_threshold_posts_audit_and_release
+test_active_circuit_suppresses_duplicate_release
+test_cooldown_expiry_allows_release
+test_non_rate_limit_release_unchanged


### PR DESCRIPTION
## Summary

Added a per-issue transient rate-limit release circuit breaker that counts recent rate_limit_transient claim releases, posts one consolidated audit marker with a cooldown window, suppresses duplicate release comments while active, and blocks dispatch until cooldown expiry or maintainer override.

## Files Changed

.agents/scripts/dispatch-backoff-helper.sh,.agents/scripts/headless-runtime-failure.sh,.agents/scripts/tests/test-dispatch-rate-limit-release-circuit.sh,.agents/scripts/tests/test-rate-limit-release-circuit.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-rate-limit-release-circuit.sh; .agents/scripts/tests/test-dispatch-rate-limit-release-circuit.sh; bash .agents/scripts/tests/test-dispatch-backoff-helper.sh; bash .agents/scripts/tests/test-headless-runtime-release-unlock.sh; shellcheck .agents/scripts/headless-runtime-failure.sh .agents/scripts/dispatch-backoff-helper.sh .agents/scripts/tests/test-rate-limit-release-circuit.sh .agents/scripts/tests/test-dispatch-rate-limit-release-circuit.sh

Resolves #23102


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.92 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 6m and 121,595 tokens on this as a headless worker.