### PR TITLE
t3568: fix: require terminal CI failures for repair feedback

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -249,7 +249,7 @@ _close_and_label_feedback_pr() {
 #
 # Args:
 #   $1 - pr_number
-#   $2 - failing_checks       (markdown list of failing check names/URLs)
+#   $2 - failing_checks       (markdown list of terminal failed check names/conclusions/URLs)
 #   $3 - classification_output (optional, t3225 — multi-line "CLASS names";
 #        triggers a Pattern-Specific Resolution Guidance subsection BEFORE
 #        the generic worker guidance when any non-OTHER class is present)
@@ -267,14 +267,14 @@ _build_ci_feedback_section() {
 	local conf_file
 	conf_file="${BASH_SOURCE[0]%/*}/../configs/ci-failure-patterns.conf"
 
-	# Lead with header + non-passing checks list (always present).
+	# Lead with header + terminal failed checks list (always present).
 	cat <<-EOF
 		## CI Repair Feedback (from PR #${pr_number})
 
-		The previous worker's PR #${pr_number} had non-passing required CI checks. The PR has been
+		The previous worker's PR #${pr_number} had terminal failed CI checks. The PR has been
 		closed and this issue re-queued for dispatch. The next worker should address these failures.
 
-		### Non-passing required checks
+		### Terminal failed checks
 
 		${failing_checks}
 	EOF
@@ -290,7 +290,7 @@ _build_ci_feedback_section() {
 		### Worker guidance
 
 		1. Check out a fresh branch from \`origin/main\` (do NOT reuse the old branch)
-		2. Read the check URLs above for specific error messages
+		2. Read the terminal check URLs above for specific error messages
 		3. Fix the issues in the code, not in the CI config
 		4. Ensure all checks pass locally before pushing
 
@@ -331,19 +331,31 @@ _dispatch_ci_fix_worker() {
 		--description "Issue carries CI failure feedback routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
 
-	# Collect non-green required checks: name, status, URL. Include pending
-	# required checks as actionable repair/backlog context; the caller only
-	# reaches this path after merge/security/review gates have passed.
+	# Collect terminal failed required checks only. Pending/queued/in-progress
+	# checks are not actionable repair evidence and must not be routed into the
+	# linked issue as stale worker guidance.
+	local terminal_failed_check_filter
+	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and ((.conclusion // "") | test("^(failure|cancelled|timed_out|action_required)$")) and ((.link // "") != "")'
+	local required_check_jq advisory_check_jq failing_name_jq
+	printf -v required_check_jq '[.[] | select(%s) | "- **\(.name)**: \(.conclusion) — [check URL](\(.link))"] | join("\n")' "$terminal_failed_check_filter"
+	printf -v advisory_check_jq '[.[] | select(%s) | "- **\(.name)** (advisory, not merge-blocking): \(.conclusion) — [check URL](\(.link))"] | join("\n")' "$terminal_failed_check_filter"
+	printf -v failing_name_jq '[.[] | select(%s) | .name] | join("\n")' "$terminal_failed_check_filter"
+
 	local failing_checks
 	failing_checks=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
-		--json name,bucket,link \
-		--jq '[.[] | select(.bucket == "fail" or .bucket == "cancel" or .bucket == "pending")
-			| "- **\(.name)**: \(.bucket) — [\(.link // "no link")](\(.link // ""))"]
-			| join("\n")' \
+		--json name,bucket,conclusion,link \
+		--jq "$required_check_jq" \
 		2>/dev/null) || failing_checks=""
 
 	if [[ -z "$failing_checks" ]]; then
-		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has non-passing checks but could not collect details — skipping routing" >>"$LOGFILE"
+		failing_checks=$(gh pr checks "$pr_number" --repo "$repo_slug" \
+			--json name,bucket,conclusion,link \
+			--jq "$advisory_check_jq" \
+			2>/dev/null) || failing_checks=""
+	fi
+
+	if [[ -z "$failing_checks" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has no terminal failed checks with URLs — skipping routing" >>"$LOGFILE"
 		return 0
 	fi
 
@@ -352,9 +364,8 @@ _dispatch_ci_fix_worker() {
 	# fall back to the pre-t3225 behaviour (no pattern guidance block).
 	local failing_names classification_output=""
 	failing_names=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
-		--json name,bucket \
-		--jq '[.[] | select(.bucket == "fail" or .bucket == "cancel" or .bucket == "pending") | .name]
-			| join("\n")' \
+		--json name,bucket,conclusion,link \
+		--jq "$failing_name_jq" \
 		2>/dev/null) || failing_names=""
 	if [[ -n "$failing_names" ]]; then
 		classification_output=$(_classify_ci_failures_by_pattern "$failing_names" 2>/dev/null) || classification_output=""
@@ -391,10 +402,10 @@ _dispatch_ci_fix_worker() {
 	_close_and_label_feedback_pr "$pr_number" "$repo_slug" \
 		"## CI repair feedback routed to issue #${linked_issue}
 
-This worker PR had non-passing required CI checks. The check details have been appended
+This worker PR had terminal failed CI checks. The check details have been appended
 to the linked issue body so the next worker can address them.
 
-Non-passing required checks:
+Terminal failed checks:
 ${failing_checks}
 
 _Closed by deterministic merge pass (pulse-merge.sh)._" \

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -46,6 +46,7 @@ setup_test_env() {
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
+	export TEST_CHECK_SCENARIO="terminal_failure"
 	printf 'Original issue body.\n' >"${TEST_ROOT}/issue-body.txt"
 	write_gh_mock
 	return 0
@@ -70,12 +71,27 @@ if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 fi
 
 if [[ "${1:-} ${2:-}" == "pr checks" ]]; then
-	if [[ "$*" == *"name,bucket,link"* ]]; then
-		printf '%s\n' '- **Lint**: fail — [https://example.invalid/check](https://example.invalid/check)'
+	_is_required=0
+	[[ "$*" == *" --required "* || "$*" == *" --required"* ]] && _is_required=1
+	if [[ "$*" == *"| .name]"* ]]; then
+		case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
+		terminal_failure:1)
+			printf 'Lint\n'
+			;;
+		esac
 		exit 0
 	fi
-	if [[ "$*" == *"name,bucket"* ]]; then
-		printf 'Lint\n'
+	if [[ "$*" == *"name,bucket,conclusion,link"* ]]; then
+		case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
+		terminal_failure:1)
+			printf '%s\n' '- **Lint**: failure — [check URL](https://example.invalid/check)'
+			;;
+		pending_only:*|mixed_pending_pass:*)
+			: ;;
+		advisory_failure:0)
+			printf '%s\n' '- **Docs** (advisory, not merge-blocking): failure — [check URL](https://example.invalid/advisory)'
+			;;
+		esac
 		exit 0
 	fi
 	exit 0
@@ -216,9 +232,79 @@ test_ci_feedback_dedupes_by_pr_head_sha() {
 	return 0
 }
 
+test_ci_feedback_skips_pending_only_checks() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="pending_only"
+	define_feedback_helpers || { print_result "defines feedback helpers for pending-only" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "pending-only checks do not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	elif ! grep -qF 'no terminal failed checks with URLs' "$LOGFILE"; then
+		print_result "pending-only checks log terminal-failure skip" 1 "Log: $(cat "$LOGFILE")"
+	else
+		print_result "pending-only checks do not emit CI repair feedback" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_skips_mixed_pending_pass_checks() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="mixed_pending_pass"
+	define_feedback_helpers || { print_result "defines feedback helpers for mixed pending/pass" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "mixed pending/pass checks do not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	else
+		print_result "mixed pending/pass checks do not emit CI repair feedback" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_emits_terminal_failure_with_conclusion_and_url() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="terminal_failure"
+	define_feedback_helpers || { print_result "defines feedback helpers for terminal failure" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if ! grep -qF '**Lint**: failure — [check URL](https://example.invalid/check)' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "terminal failure emits conclusion and check URL" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	else
+		print_result "terminal failure emits conclusion and check URL" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_labels_advisory_failure_when_not_required() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="advisory_failure"
+	define_feedback_helpers || { print_result "defines feedback helpers for advisory failure" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if ! grep -qF '**Docs** (advisory, not merge-blocking): failure — [check URL](https://example.invalid/advisory)' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "advisory failure is labeled not merge-blocking" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	else
+		print_result "advisory failure is labeled not merge-blocking" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_red_pr_passes_gates_before_repair_route
 	test_ci_feedback_dedupes_by_pr_head_sha
+	test_ci_feedback_skips_pending_only_checks
+	test_ci_feedback_skips_mixed_pending_pass_checks
+	test_ci_feedback_emits_terminal_failure_with_conclusion_and_url
+	test_ci_feedback_labels_advisory_failure_when_not_required
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -103,12 +103,12 @@ case "$_subcmd" in
 	exit 0
 	;;
 "pr checks")
-	if [[ "$*" == *"--json name,bucket,link"* ]]; then
-		printf '%s\n' '- **Lint**: fail — [https://example.invalid/check](https://example.invalid/check)'
+	if [[ "$*" == *"| .name]"* ]]; then
+		printf '%s\n' 'Lint'
 		exit 0
 	fi
-	if [[ "$*" == *"--json name,bucket"* ]]; then
-		printf '%s\n' 'Lint'
+	if [[ "$*" == *"--json name,bucket,conclusion,link"* ]]; then
+		printf '%s\n' '- **Lint**: failure — [check URL](https://example.invalid/check)'
 		exit 0
 	fi
 	exit 0


### PR DESCRIPTION
## Summary

Filtered CI repair routing to checks with terminal failure conclusions and URLs, with advisory-only failures labeled as non-blocking. Added regression coverage for pending-only, mixed pending/pass, terminal failure, and advisory failure scenarios.

## Files Changed

.agents/scripts/pulse-merge-feedback.sh,.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh,.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh; shellcheck .agents/scripts/pulse-merge-feedback.sh .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh; bash .agents/scripts/linters-local.sh (timed out at shell portability after passing targeted gates and reporting only advisory pre-existing repository issues)

Resolves #23100


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.92 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 19m and 67,656 tokens on this as a headless worker.