### PR TITLE
GH#23110: recover task counter desync

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -237,6 +237,117 @@ _cas_log_protected_branch_rejection() {
 	return 0
 }
 
+# Emit a stable machine-readable allocation status without contaminating stdout.
+# Stdout is reserved for claim-task-id.sh key=value results; status belongs on
+# stderr via log_info so wrappers can parse it without breaking callers.
+_task_counter_status() {
+	local status="$1"
+	local detail="${2:-}"
+	if [[ -n "$detail" ]]; then
+		log_info "AIDEVOPS_TASK_COUNTER_STATUS=${status} detail=${detail}"
+	else
+		log_info "AIDEVOPS_TASK_COUNTER_STATUS=${status}"
+	fi
+	return 0
+}
+
+# Re-fetch and reconcile a counter branch after CAS contention/desync.
+#
+# Normal CAS failures are retryable, but a non-main counter branch can become
+# desynchronised with the repository's default branch (for example, develop has
+# an older .task-counter than main after release/merge activity).  Before any
+# fallback or fatal outcome, reconcile by pushing a counter-only commit on the
+# configured counter branch with the maximum safe next-ID observed across:
+#   - current counter branch
+#   - default branch (when different and available)
+#   - TODO.md seed (highest tNNN + 1)
+#
+# Returns:
+#   0 — reconciliation pushed or branch already safe
+#   1 — hard/unrecoverable desync (diagnostic emitted)
+#   2 — race/contention while reconciling; caller may retry allocation
+_cas_reconcile_counter_branch() {
+	local repo_path="$1"
+	local default_branch="${2:-main}"
+
+	cd "$repo_path" || return 1
+	_task_counter_status "reconciling" "branch=${REMOTE_NAME}/${COUNTER_BRANCH}"
+
+	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || {
+		log_error "UNRECOVERABLE_COUNTER_DESYNC: cannot fetch ${REMOTE_NAME}/${COUNTER_BRANCH} for reconciliation"
+		_task_counter_status "unrecoverable_desync" "fetch_failed"
+		return 1
+	}
+
+	local counter_ref="${REMOTE_NAME}/${COUNTER_BRANCH}"
+	local pinned_sha=""
+	pinned_sha=$(git rev-parse "$counter_ref" 2>/dev/null) || {
+		log_error "UNRECOVERABLE_COUNTER_DESYNC: cannot resolve ${counter_ref} after fetch"
+		_task_counter_status "unrecoverable_desync" "resolve_failed"
+		return 1
+	}
+
+	local branch_counter=""
+	branch_counter=$(git show "${pinned_sha}:${COUNTER_FILE}" 2>/dev/null | tr -d '[:space:]' || true)
+	if [[ -z "$branch_counter" ]] || ! [[ "$branch_counter" =~ ^[0-9]+$ ]]; then
+		branch_counter=$(_compute_counter_seed "$repo_path")
+	fi
+
+	local default_counter="0"
+	if [[ -n "$default_branch" && "$default_branch" != "$COUNTER_BRANCH" ]]; then
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			fetch -q "$REMOTE_NAME" "$default_branch" >/dev/null || true
+		local default_ref="${REMOTE_NAME}/${default_branch}"
+		default_counter=$(git show "${default_ref}:${COUNTER_FILE}" 2>/dev/null | tr -d '[:space:]' || true)
+		if [[ -z "$default_counter" ]] || ! [[ "$default_counter" =~ ^[0-9]+$ ]]; then
+			default_counter="0"
+		fi
+	fi
+
+	local todo_seed
+	todo_seed=$(_compute_counter_seed "$repo_path")
+	local reconciled_counter="$branch_counter"
+	((10#$default_counter > 10#$reconciled_counter)) && reconciled_counter="$default_counter"
+	((10#$todo_seed > 10#$reconciled_counter)) && reconciled_counter="$todo_seed"
+
+	if [[ "$reconciled_counter" == "$branch_counter" ]]; then
+		_task_counter_status "recovered_contention" "refetched"
+		return 0
+	fi
+
+	local blob_sha tree_sha commit_sha
+	blob_sha=$(printf '%s\n' "$reconciled_counter" | git hash-object -w --stdin 2>/dev/null) || {
+		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to create reconciled counter blob"
+		_task_counter_status "unrecoverable_desync" "blob_failed"
+		return 1
+	}
+	tree_sha=$(git ls-tree "$pinned_sha" | sed "s|[0-9a-f]\{40,64\}	${COUNTER_FILE}$|${blob_sha}	${COUNTER_FILE}|" | git mktree 2>/dev/null) || {
+		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to build reconciled counter tree"
+		_task_counter_status "unrecoverable_desync" "tree_failed"
+		return 1
+	}
+	commit_sha=$(git commit-tree "$tree_sha" -p "$pinned_sha" -m "chore: reconcile task counter (${branch_counter}->${reconciled_counter})" 2>/dev/null) || {
+		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to create reconciliation commit"
+		_task_counter_status "unrecoverable_desync" "commit_failed"
+		return 1
+	}
+
+	local push_rc=0
+	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+	if [[ $push_rc -ne 0 ]]; then
+		log_warn "Counter reconciliation push raced with another allocator; retrying allocation from refreshed branch"
+		_task_counter_status "recovered_contention" "reconcile_raced"
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
+		return 2
+	fi
+
+	_task_counter_status "recovered_contention" "counter=${reconciled_counter}"
+	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
+	return 0
+}
+
 # =============================================================================
 # Machine-local mutex for CAS serialisation (Phase 2 / t2568 / GH#20001)
 # =============================================================================

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -172,10 +172,12 @@ CAS_SSH_FALLBACK_ENABLED=${CAS_SSH_FALLBACK_ENABLED:-1}
 # not for contention failures on a reachable remote.  Set to 0 to restore the
 # legacy silent-fallback behaviour.
 CAS_EXHAUSTION_FATAL=${CAS_EXHAUSTION_FATAL:-1}
+CAS_RECONCILE_RETRY_ON_FAILURE=${CAS_RECONCILE_RETRY_ON_FAILURE:-1}
 COUNTER_FILE=".task-counter"
 # Remote and branch — defaults; overridden by .aidevops.json and/or CLI flags
 REMOTE_NAME="origin"
 COUNTER_BRANCH="main"
+DEFAULT_BRANCH="main"
 # Track whether CLI flags explicitly set these (CLI overrides config file)
 _REMOTE_NAME_SET=false
 _COUNTER_BRANCH_SET=false
@@ -201,9 +203,10 @@ load_project_config() {
 
 	log_info "Loading project config from .aidevops.json"
 
-	local remote_val counter_branch_val
+	local remote_val counter_branch_val default_branch_val
 	remote_val=$(jq -r '.remote // empty' "$config_file" 2>/dev/null || true)
 	counter_branch_val=$(jq -r '.counter_branch // empty' "$config_file" 2>/dev/null || true)
+	default_branch_val=$(jq -r '.default_branch // empty' "$config_file" 2>/dev/null || true)
 
 	# CLI flags take precedence over config file
 	if [[ -n "$remote_val" ]] && [[ "$_REMOTE_NAME_SET" == "false" ]]; then
@@ -214,6 +217,11 @@ load_project_config() {
 	if [[ -n "$counter_branch_val" ]] && [[ "$_COUNTER_BRANCH_SET" == "false" ]]; then
 		COUNTER_BRANCH="$counter_branch_val"
 		log_info "counter_branch set from .aidevops.json: $COUNTER_BRANCH"
+	fi
+
+	if [[ -n "$default_branch_val" ]]; then
+		DEFAULT_BRANCH="$default_branch_val"
+		log_info "default_branch set from .aidevops.json: $DEFAULT_BRANCH"
 	fi
 
 	return 0
@@ -869,6 +877,7 @@ _validate_labels_exist() {
 _main_resolve_allocation() {
 	local first_id_out=""
 	local is_offline_out="false"
+	local allocation_status="normal_success"
 
 	if [[ "$OFFLINE_MODE" == "false" ]]; then
 		if [[ "$DRY_RUN" == "true" ]]; then
@@ -884,22 +893,50 @@ _main_resolve_allocation() {
 			return 0
 		fi
 
+		# Non-main counter branches can lag the default branch after release or
+		# merge activity.  Reconcile before claiming so we do not allocate IDs below
+		# the default branch's observed counter and then rely on manual fallback.
+		if [[ "$CAS_RECONCILE_RETRY_ON_FAILURE" == "1" && "${DEFAULT_BRANCH:-main}" != "$COUNTER_BRANCH" ]]; then
+			_cas_reconcile_counter_branch "$REPO_PATH" "${DEFAULT_BRANCH:-main}" >/dev/null || return 1
+		fi
+
 		if first_id_out=$(_allocate_online_with_collision_check "$REPO_PATH" "$ALLOC_COUNT"); then
 			log_success "Allocated task ID: $(printf 't%03d' "$first_id_out")"
 		else
+			if [[ "$CAS_RECONCILE_RETRY_ON_FAILURE" == "1" ]]; then
+				local _reconcile_rc=0
+				_cas_reconcile_counter_branch "$REPO_PATH" "${DEFAULT_BRANCH:-main}" || _reconcile_rc=$?
+				if [[ $_reconcile_rc -eq 0 || $_reconcile_rc -eq 2 ]]; then
+					if first_id_out=$(_allocate_online_with_collision_check "$REPO_PATH" "$ALLOC_COUNT"); then
+						allocation_status="recovered_contention"
+						log_success "Allocated task ID after counter reconciliation: $(printf 't%03d' "$first_id_out")"
+					else
+						log_error "UNRECOVERABLE_COUNTER_DESYNC: allocation still failed after refetch/reconcile"
+						_task_counter_status "unrecoverable_desync" "post_reconcile_allocation_failed"
+						return 1
+					fi
+				else
+					return 1
+				fi
+			fi
+		fi
+
+		if [[ -z "$first_id_out" ]]; then
 			if [[ "$CAS_EXHAUSTION_FATAL" == "1" ]]; then
 				log_error "CAS_EXHAUSTED: online allocation failed after ${CAS_MAX_RETRIES} attempts"
-				log_error "This is a contention failure, not an offline scenario."
-				log_error "The remote is reachable but concurrent pushes (issue-sync.yml, simplification-state,"
-				log_error "merge commits) outpaced the retry budget.  Recovery: wait a few seconds and retry,"
-				log_error "or set CAS_EXHAUSTION_FATAL=0 to restore the legacy +${OFFLINE_OFFSET} offset fallback."
+				log_error "UNRECOVERABLE_COUNTER_DESYNC: refetch/reconcile did not produce a safe allocation."
+				log_error "The remote is reachable but counter contention or branch desynchronization persisted."
+				_task_counter_status "unrecoverable_desync" "cas_exhausted"
 				return 1
 			fi
-			log_warn "Online allocation failed, falling back to offline mode (CAS_EXHAUSTION_FATAL=0)"
+			log_warn "Online allocation failed; using automatic auditable offline fallback (CAS_EXHAUSTION_FATAL=0)"
+			_task_counter_status "fallback" "offline_offset"
+			allocation_status="fallback"
 			is_offline_out="true"
 		fi
 	else
 		is_offline_out="true"
+		allocation_status="fallback"
 	fi
 
 	if [[ "$is_offline_out" == "true" ]]; then
@@ -914,6 +951,12 @@ _main_resolve_allocation() {
 			log_error "Offline allocation failed"
 			return 1
 		fi
+	fi
+
+	if [[ "$allocation_status" == "normal_success" ]]; then
+		_task_counter_status "normal_success" "task_id=$(printf 't%03d' "$first_id_out")"
+	elif [[ "$allocation_status" == "recovered_contention" ]]; then
+		_task_counter_status "recovered_contention" "task_id=$(printf 't%03d' "$first_id_out")"
 	fi
 
 	# Communicate results back to caller via stdout key=value pairs

--- a/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
+++ b/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23110.
+#
+# A normal, unprotected counter branch can lag the default branch.  The allocator
+# must refetch/reconcile automatically, emit machine-readable recovery status,
+# and allocate from the reconciled counter without duplicate or stranded IDs.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL %s' "$name"
+	[[ -n "$detail" ]] && printf ' — %s' "$detail"
+	printf '\n'
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+setup_desynced_remote() {
+	local base_dir="$1"
+	local bare_dir="${base_dir}/remote.git"
+	local work_dir="${base_dir}/work"
+
+	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || git init --bare "$bare_dir" >/dev/null 2>&1 || return 1
+	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.email "test@test.local" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.name "Test" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config commit.gpgsign false >/dev/null 2>&1 || true
+	git -C "$work_dir" config tag.gpgsign false >/dev/null 2>&1 || true
+
+	printf '1000\n' >"${work_dir}/.task-counter"
+	printf '# Tasks\n\n- [x] t999 seed task\n' >"${work_dir}/TODO.md"
+	git -C "$work_dir" add .task-counter TODO.md >/dev/null 2>&1 || return 1
+	git -C "$work_dir" commit -m "chore: seed develop counter" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" branch develop >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin develop >/dev/null 2>&1 || return 1
+
+	printf '1100\n' >"${work_dir}/.task-counter"
+	git -C "$work_dir" add .task-counter >/dev/null 2>&1 || return 1
+	git -C "$work_dir" commit -m "chore: advance main counter" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin main >/dev/null 2>&1 || return 1
+	printf '%s\n' "$work_dir"
+	return 0
+}
+
+test_counter_branch_desync_reconciles_before_claim() {
+	local name="counter branch desync is reconciled before allocation"
+	local tmpdir work_dir output rc task_id final_counter claim_commits unique_claims
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+
+	work_dir=$(setup_desynced_remote "$tmpdir") || { fail "$name" "repo setup failed"; rm -rf "$tmpdir"; return 0; }
+
+	rc=0
+	output=$(CAS_MAX_RETRIES=3 CAS_WALL_TIMEOUT_S=20 CAS_SSH_FALLBACK_ENABLED=0 "$CLAIM_SCRIPT" \
+		--title "desync recovery test" \
+		--no-issue \
+		--repo-path "$work_dir" \
+		--counter-branch develop 2>&1) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "claim failed: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'AIDEVOPS_TASK_COUNTER_STATUS=recovered_contention'; then
+		fail "$name" "missing recovered_contention status: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	task_id=$(printf '%s\n' "$output" | awk -F= '/^task_id=/{print $2; exit}')
+	if [[ "$task_id" != "t1100" ]]; then
+		fail "$name" "expected t1100 after reconciliation, got ${task_id:-<empty>}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	git -C "$work_dir" fetch origin develop >/dev/null 2>&1 || true
+	final_counter=$(git -C "$work_dir" show origin/develop:.task-counter 2>/dev/null | tr -d '[:space:]')
+	if [[ "$final_counter" != "1101" ]]; then
+		fail "$name" "expected develop counter 1101, got ${final_counter:-<empty>}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	claim_commits=$(git -C "$work_dir" log origin/develop --oneline --grep="chore: claim" | grep -oE 't[0-9]+' | sort || true)
+	unique_claims=$(printf '%s\n' "$claim_commits" | grep -c '^t1100$' || true)
+	if [[ "$unique_claims" -ne 1 ]]; then
+		fail "$name" "expected exactly one t1100 claim commit, got ${unique_claims}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+main() {
+	if [[ ! -x "$CLAIM_SCRIPT" ]]; then
+		fail "claim script executable" "$CLAIM_SCRIPT missing or not executable"
+	else
+		pass "claim script executable"
+	fi
+	test_counter_branch_desync_reconciles_before_claim
+	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+	[[ "$FAIL" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added automatic counter-branch refetch/reconciliation before allocation retry, machine-readable counter allocation statuses, and a regression test for non-main counter branch desynchronization.

## Files Changed

.agents/scripts/claim-task-id-counter.sh,.agents/scripts/claim-task-id.sh,.agents/scripts/tests/test-claim-task-id-counter-desync.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-claim-task-id-counter-desync.sh; bash .agents/scripts/tests/test-claim-task-id-concurrent-cas.sh; bash .agents/scripts/tests/test-claim-task-id-protected-counter-branch.sh; AIDEVOPS_GH_FORCE_REST_READS=0 _GH_SHOULD_FALLBACK_OVERRIDE=0 bash .agents/scripts/tests/test-claim-task-id-rest-routing.sh; bash .agents/scripts/tests/test-claim-task-id-no-orphan.sh; shellcheck .agents/scripts/claim-task-id.sh .agents/scripts/claim-task-id-counter.sh .agents/scripts/tests/test-claim-task-id-counter-desync.sh

Resolves #23110


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.93 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 7m and 116,671 tokens on this as a headless worker.