### PR TITLE
fix: anchor JS credential scrub pattern (#23091)

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -26,7 +26,7 @@ export { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs
 // ---------------------------------------------------------------------------
 
 const CREDENTIAL_PATTERN =
-  /(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+  /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 
 const REDACTION_TOKEN = "[redacted-credential]";
 
@@ -35,11 +35,11 @@ const REDACTION_TOKEN = "[redacted-credential]";
  * @param {string} text
  * @returns {{ scrubbed: string, count: number }}
  */
-function scrubCredentials(text) {
+export function scrubCredentials(text) {
   let count = 0;
-  const scrubbed = text.replace(CREDENTIAL_PATTERN, () => {
+  const scrubbed = text.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
     count++;
-    return REDACTION_TOKEN;
+    return `${boundary}${REDACTION_TOKEN}`;
   });
   return { scrubbed, count };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression tests for the OpenCode plugin credential transcript scrubber.
+// ---------------------------------------------------------------------------
+// The JS hook must mirror the Python and shell scrubbers' boundary invariant:
+// credential prefixes embedded mid-word are not credentials, but credentials
+// at start-of-string or after non-identifier boundaries are redacted.
+//
+//   node --test .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+// ---------------------------------------------------------------------------
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { scrubCredentials } from "../quality-hooks.mjs";
+
+const REDACTION_TOKEN = "[redacted-credential]";
+
+function assertScrub(input, expected, expectedCount) {
+  const { scrubbed, count } = scrubCredentials(input);
+  assert.equal(scrubbed, expected);
+  assert.equal(count, expectedCount);
+}
+
+describe("credential transcript scrub boundary", () => {
+  test("does not redact credential prefix embedded mid-word", () => {
+    assertScrub("module task-syntheticfixture", "module task-syntheticfixture", 0);
+  });
+
+  test("does not redact embedded prefix with long suffix past token length gate", () => {
+    assertScrub(
+      "url https://example.invalid/vendor-ghp_syntheticIdentifierSuffix",
+      "url https://example.invalid/vendor-ghp_syntheticIdentifierSuffix",
+      0,
+    );
+  });
+
+  test("redacts credential after whitespace boundary", () => {
+    assertScrub(`API key sk-${"a".repeat(10)} invalid`, `API key ${REDACTION_TOKEN} invalid`, 1);
+  });
+
+  test("redacts credential at start of string", () => {
+    assertScrub(`ghp_${"b".repeat(10)}`, REDACTION_TOKEN, 1);
+  });
+
+  test("redacts credential after colon boundary", () => {
+    assertScrub(`token:glpat-${"c".repeat(10)}`, `token:${REDACTION_TOKEN}`, 1);
+  });
+
+  test("redacts credential after equals boundary", () => {
+    assertScrub(`token=xoxb-${"d".repeat(10)}`, `token=${REDACTION_TOKEN}`, 1);
+  });
+
+  test("redacts credential after parenthesis boundary", () => {
+    assertScrub(`(${"xoxp-"}${"e".repeat(10)})`, `(${REDACTION_TOKEN})`, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Restores the OpenCode JS credential scrubber boundary invariant so credential prefixes embedded mid-word are not redacted as false positives.
- Preserves the boundary character in redactions to keep whitespace/punctuation intact.
- Adds focused Node regression coverage for mid-word non-redaction plus start/space/colon/equals/paren redaction controls.

Resolves #23091

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs` — 7 passed.
- `.agents/scripts/tests/test-credential-transcript-scrub.sh` — 35 passed.
- `node --check .agents/plugins/opencode-aidevops/quality-hooks.mjs && node --check .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs`
- `.agents/scripts/linters-local.sh` partially completed with Secretlint and other gates passing; timed out later in shell portability after advisory markdown/ratchet warnings unrelated to these JS changes.

## Notes
- `npm test` on the merged PR head was blocked by an existing `@opencode-ai/plugin` dependency-resolution issue in `tests/test-memory-tool-schema.mjs`; the new credential scrub test passed before that unrelated failure.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.94 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 34m and 135,030 tokens on this with the user in an interactive session. Overall, 17m since this issue was created.