### PR TITLE
GH#23097: deduplicate health dashboards by identity aliases

### DIFF
--- a/.agents/configs/identity-aliases.conf
+++ b/.agents/configs/identity-aliases.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Health dashboard identity aliases.
+#
+# Format:
+#   canonical-operator=alias-one,alias-two
+#
+# The canonical operator is the dashboard identity used for issue cache files,
+# `operator:<canonical>` labels, and cross-alias duplicate detection. Keep this
+# file free of private/local-only identities in public commits; deployments can
+# override it with AIDEVOPS_IDENTITY_ALIASES_CONF.

--- a/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
+++ b/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
@@ -13,11 +13,12 @@
 #   - Iterate ~/.config/aidevops/repos.json `initialized_repos[]` entries
 #     where `pulse: true` and not `local_only`.
 #   - For each repo, list open issues with label `source:health-dashboard`.
-#   - Group by (runner_user, role_label). Runner_user is extracted from
-#     the issue title via the `[Supervisor:user]` / `[Contributor:user]`
-#     prefix. Role is derived from the `supervisor` or `contributor` label.
-#   - Keep the newest issue per group (by createdAt).
-#   - Close the older ones with an explanatory comment linking to GH#20301.
+#   - Group by canonical operator. Runner_user is extracted from the issue
+#     title via the `[Supervisor:user]` / `[Contributor:user]` prefix, then
+#     folded through identity-aliases.conf. Role is preserved for audit output
+#     but is no longer a grouping dimension.
+#   - Keep the newest issue per canonical operator group (by createdAt).
+#   - Close the older ones with an explanatory comment linking to GH#23097.
 #   - Backfill `origin:worker` on every surviving health-dashboard issue
 #     that is missing it. Remove `origin:interactive` / `origin:worker-takeover`
 #     on the same call (origin labels are mutually exclusive).
@@ -32,6 +33,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=./stats-shared.sh
+source "${SCRIPT_DIR}/stats-shared.sh"
 # shellcheck disable=SC2034  # referenced via setup log prefix below
 MARKER_FILE="${HOME}/.aidevops/logs/.migrated-health-issue-duplicates-t2687"
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
@@ -222,17 +225,18 @@ _close_duplicate_groups() {
 	local grp
 	while IFS= read -r grp; do
 		[[ -z "$grp" ]] && continue
-		local role user keep close_list
+		local role user canonical keep close_list
 		role=$(printf '%s' "$grp" | jq -r '.role')
 		user=$(printf '%s' "$grp" | jq -r '.user')
+		canonical=$(printf '%s' "$grp" | jq -r '.canonical')
 		keep=$(printf '%s' "$grp" | jq -r '.issues[0].number')
 		close_list=$(printf '%s' "$grp" | jq -r '.issues[1:] | .[].number')
-		log_info "  dedup group role=${role} user=${user}: keep #${keep}, close $(echo "$close_list" | wc -w | tr -d ' ')"
+		log_info "  dedup group canonical=${canonical} first_role=${role} first_user=${user}: keep #${keep}, close $(echo "$close_list" | wc -w | tr -d ' ')"
 
 		local close_num
 		while IFS= read -r close_num; do
 			[[ -z "$close_num" ]] && continue
-			local comment="Closing duplicate ${role} health issue — superseded by #${keep}. Root cause: GraphQL rate-limit window on 2026-04-21 (t2574 REST fallback covered CREATE but not READ paths). See GH#20301 for the systemic fix."
+			local comment="Closing duplicate health dashboard for canonical operator ${canonical} — superseded by #${keep}. Identity aliases map the stale dashboard to the same operator across local/GitHub usernames and Supervisor/Contributor role prefixes. See GH#23097."
 			_unpin_duplicate_issue "$close_num" "$repo"
 			# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
 			# job does not reopen the duplicate (GH#20326). That job blocks USER-initiated
@@ -265,36 +269,40 @@ process_repo() {
 	fi
 	log_info "  found ${total} health-dashboard issue(s) in ${slug}"
 
-	# Enrich every issue with a grouping key "<role>:<runner_user>" so we
-	# can group via jq. Issues missing role or runner_user get "UNGROUPED"
-	# and are skipped (but still reported).
-	local enriched
-	enriched=$(printf '%s' "$issues_json" | jq -c '.[] | {
-		number: .number,
-		title: .title,
-		labels: .labels,
-		createdAt: .createdAt,
-		role: (
-			if (.labels | map(.name) | index("supervisor")) then "supervisor"
-			elif (.labels | map(.name) | index("contributor")) then "contributor"
-			else "" end
-		),
-		user: (
-			(.title | capture("^\\[(?<role>Supervisor|Contributor):(?<user>[^]]+)\\]").user) // ""
-		)
-	}')
+	# Enrich every issue with a canonical operator key. Issues missing a
+	# dashboard title prefix are skipped (but still included in total count).
+	local enriched=""
+	local issue_line
+	while IFS= read -r issue_line; do
+		[[ -z "$issue_line" ]] && continue
+		local title user role canonical aliases labels_json
+		title=$(printf '%s' "$issue_line" | jq -r '.title // ""')
+		user=$(printf '%s' "$title" | sed -En 's/^\[(Supervisor|Contributor):([^]]+)\].*/\2/p')
+		role=$(printf '%s' "$title" | sed -En 's/^\[(Supervisor|Contributor):([^]]+)\].*/\1/p' | tr '[:upper:]' '[:lower:]')
+		[[ -n "$user" ]] || continue
+		aliases=$(_dashboard_identity_aliases "$user")
+		canonical=$(printf '%s\n' "$aliases" | sed -n '1p')
+		labels_json=$(printf '%s' "$issue_line" | jq -c '.labels')
+		enriched="${enriched}$(printf '%s' "$issue_line" | jq -c \
+			--arg role "$role" \
+			--arg user "$user" \
+			--arg canonical "$canonical" \
+			--argjson labels "$labels_json" \
+			'{number: .number, title: .title, labels: $labels, createdAt: .createdAt, role: $role, user: $user, canonical: $canonical}')"$'\n'
+	done < <(printf '%s' "$issues_json" | jq -c '.[]')
 
 	_backfill_origin_worker_labels "$enriched" "$slug"
 
-	# Group by (role, user). For each group with >1 members, keep the
-	# newest by createdAt and close the rest.
+	# Group by canonical operator. For each group with >1 members, keep the
+	# newest by createdAt and close the rest, including cross-role aliases.
 	local groups_summary
 	groups_summary=$(printf '%s' "$enriched" |
-		jq -sc 'group_by(.role + "\u0001" + .user) | .[] | {
+		jq -sc 'group_by(.canonical) | .[] | {
 			role: .[0].role,
 			user: .[0].user,
+			canonical: .[0].canonical,
 			issues: (sort_by(.createdAt) | reverse)
-		} | select(.role != "" and .user != "") | select(.issues | length > 1)')
+		} | select(.canonical != "") | select(.issues | length > 1)')
 
 	if [[ -z "$groups_summary" ]]; then
 		log_info "  no duplicates in ${slug}"

--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -506,7 +506,7 @@ PY
 #######################################
 # Build the health issue body markdown.
 #
-# Arguments: 32 positional parameters (see inline locals below)
+# Arguments: 34 positional parameters (see inline locals below)
 # Output: body markdown to stdout
 #######################################
 _build_health_issue_body() {
@@ -530,19 +530,27 @@ _build_health_issue_body() {
 	local sys_memory="${25}" sys_procs="${26}" runner_role="${27}"
 	local worker_success_rate_24h="${28}" worker_success_rate_7d="${29}" worker_total_runs_24h="${30}" worker_total_runs_7d="${31}"
 	local worker_zero_diagnostics_md="${32}"
+	local canonical_identity="${33:-$runner_user}"
+	local identity_aliases="${34:-$runner_user}"
 	local _worker_rate_section; _worker_rate_section=$(_format_worker_rate_section \
 		"$worker_success_rate_24h" "$worker_success_rate_7d" \
 		"$worker_total_runs_24h" "$worker_total_runs_7d")
+	local identity_aliases_display
+	identity_aliases_display=$(printf '%s\n' "$identity_aliases" | paste -sd ', ' -)
 
 	cat <<BODY
 ## Queue Health Dashboard
 
 **Last pulse**: \`${now_iso}\`
 **${role_display}**: \`${runner_user}\`
+**Canonical operator**: \`${canonical_identity}\`
+**Identity aliases**: \`${identity_aliases_display}\`
 **Repo**: \`${repo_slug}\`
 
 <!-- aidevops:dashboard-freshness -->
 last_refresh: ${now_iso}
+canonical_operator: ${canonical_identity}
+identity_aliases: ${identity_aliases_display}
 
 ### Summary
 
@@ -731,6 +739,8 @@ _read_person_stats_cache() {
 #   $8  - cross_repo_md
 #   $9  - cross_repo_session_time_md
 #   $10 - cross_repo_person_stats_md
+#   $11 - canonical identity
+#   $12 - identity aliases (newline-delimited)
 # Output: body markdown to stdout
 #######################################
 _assemble_health_issue_body() {
@@ -744,6 +754,8 @@ _assemble_health_issue_body() {
 	local cross_repo_md="$8"
 	local cross_repo_session_time_md="$9"
 	local cross_repo_person_stats_md="${10}"
+	local canonical_identity="${11:-$runner_user}"
+	local identity_aliases="${12:-$runner_user}"
 
 	# Gather live stats via temp file (avoids subshell variable loss)
 	local stats_tmp
@@ -807,7 +819,7 @@ _assemble_health_issue_body() {
 		"$sys_memory" "$sys_procs" "$runner_role" \
 		"$worker_success_rate_24h" "$worker_success_rate_7d" \
 		"$worker_total_runs_24h" "$worker_total_runs_7d" \
-		"$worker_zero_diagnostics_md"
+		"$worker_zero_diagnostics_md" "$canonical_identity" "$identity_aliases"
 	return 0
 }
 

--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -530,27 +530,19 @@ _build_health_issue_body() {
 	local sys_memory="${25}" sys_procs="${26}" runner_role="${27}"
 	local worker_success_rate_24h="${28}" worker_success_rate_7d="${29}" worker_total_runs_24h="${30}" worker_total_runs_7d="${31}"
 	local worker_zero_diagnostics_md="${32}"
-	local canonical_identity="${33:-$runner_user}"
-	local identity_aliases="${34:-$runner_user}"
-	local _worker_rate_section; _worker_rate_section=$(_format_worker_rate_section \
-		"$worker_success_rate_24h" "$worker_success_rate_7d" \
-		"$worker_total_runs_24h" "$worker_total_runs_7d")
-	local identity_aliases_display
-	identity_aliases_display=$(printf '%s\n' "$identity_aliases" | paste -sd ', ' -)
+	local canonical_identity="${33:-$runner_user}" identity_aliases="${34:-$runner_user}"
+	local _worker_rate_section; _worker_rate_section=$(_format_worker_rate_section "$worker_success_rate_24h" "$worker_success_rate_7d" "$worker_total_runs_24h" "$worker_total_runs_7d")
+	local identity_aliases_display; identity_aliases_display=$(printf '%s\n' "$identity_aliases" | paste -sd ', ' -)
 
 	cat <<BODY
 ## Queue Health Dashboard
 
 **Last pulse**: \`${now_iso}\`
-**${role_display}**: \`${runner_user}\`
-**Canonical operator**: \`${canonical_identity}\`
-**Identity aliases**: \`${identity_aliases_display}\`
+**${role_display}**: \`${runner_user}\` (canonical: \`${canonical_identity}\`; aliases: \`${identity_aliases_display}\`)
 **Repo**: \`${repo_slug}\`
 
 <!-- aidevops:dashboard-freshness -->
 last_refresh: ${now_iso}
-canonical_operator: ${canonical_identity}
-identity_aliases: ${identity_aliases_display}
 
 ### Summary
 

--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -61,6 +61,46 @@ _list_health_issues_by_role_label() {
 }
 
 #######################################
+# List open health issues that belong to one canonical dashboard identity.
+# Matches the new canonical operator label, historical alias labels, and
+# historical [Supervisor:alias]/[Contributor:alias] title prefixes.
+# Arguments:
+#   $1 - repo slug
+#   $2 - canonical identity
+#   $3 - newline-delimited aliases
+# Output: JSON array sorted newest-first (by number desc).
+#######################################
+_list_health_issues_by_canonical_identity() {
+	local repo_slug="$1"
+	local canonical_identity="$2"
+	local identity_aliases="$3"
+
+	local issues_json rc=0
+	issues_json=$(gh_issue_list --repo "$repo_slug" \
+		--label "source:health-dashboard" \
+		--state open --json number,title,labels --limit 100 2>/dev/null) || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		return "$rc"
+	fi
+
+	local aliases_json
+	aliases_json=$(printf '%s\n%s\n' "$canonical_identity" "$identity_aliases" | jq -R 'select(length > 0)' | jq -s 'unique')
+	local canonical_label="operator:${canonical_identity}"
+	printf '%s' "${issues_json:-[]}" | jq \
+		--argjson aliases "$aliases_json" \
+		--arg canonical_label "$canonical_label" \
+		'[
+			.[]
+			| . as $issue
+			| ((.labels // []) | map(.name) | any(. == $canonical_label or ($aliases | index(.)))) as $label_match
+			| ((.title | capture("^\\[(Supervisor|Contributor):(?<user>[^]]+)\\]")? | .user // "") as $title_user
+				| ($title_user != "" and ($aliases | index($title_user)))) as $title_match
+			| select($label_match or $title_match)
+		] | sort_by(.number) | reverse'
+	return 0
+}
+
+#######################################
 # Validate a cached health-issue number: check it still exists and is OPEN.
 # Returns (via stdout):
 #   - the cached number if still valid
@@ -94,18 +134,20 @@ _try_cached_health_issue_lookup() {
 	# and REST-style lowercase values (open/closed) depending on fallback path.
 	# Normalize before branching so REST fallback cache validation does not log
 	# healthy open dashboards as "unexpected state" every stats-wrapper cycle.
+	local closed_state="CLOSED"
+	local open_state="OPEN"
 	case "$issue_state" in
-		[Oo][Pp][Ee][Nn]) issue_state="OPEN" ;;
-		[Cc][Ll][Oo][Ss][Ee][Dd]) issue_state="CLOSED" ;;
+		[Oo][Pp][Ee][Nn]) issue_state="$open_state" ;;
+		[Cc][Ll][Oo][Ss][Ee][Dd]) issue_state="$closed_state" ;;
 	esac
 
-	if [[ "$issue_state" == "CLOSED" ]]; then
+	if [[ "$issue_state" == "$closed_state" ]]; then
 		[[ "$runner_role" == "$_ROLE_SUPERVISOR" ]] && _unpin_health_issue "$cached_number" "$repo_slug"
 		rm -f "$health_issue_file" 2>/dev/null || true
 		return 0  # empty → caller re-resolves
 	fi
 
-	if [[ "$issue_state" != "OPEN" ]]; then
+	if [[ "$issue_state" != "$open_state" ]]; then
 		# Unexpected state (empty, unknown enum). Preserve cache defensively.
 		echo "[stats] Health issue: unexpected state '${issue_state}' for #${cached_number} in ${repo_slug} — preserving cache" >>"${LOGFILE:-/dev/null}"
 		echo "$cached_number"
@@ -153,6 +195,34 @@ _close_health_issue_duplicates() {
 }
 
 #######################################
+# Close duplicate health issues across aliases and role prefixes.
+# Arguments: results_json keep_number repo_slug canonical_identity runner_user
+#######################################
+_close_health_issue_identity_duplicates() {
+	local identity_results="$1"
+	local keep_number="$2"
+	local repo_slug="$3"
+	local canonical_identity="$4"
+	local runner_user="$5"
+
+	local dup_count
+	dup_count=$(printf '%s' "$identity_results" | jq 'length' 2>/dev/null || echo "0")
+	[[ "${dup_count:-0}" -le 1 || -z "$keep_number" ]] && return 0
+
+	local dup_numbers
+	dup_numbers=$(printf '%s' "$identity_results" | jq -r --arg keep "$keep_number" \
+		'.[] | select((.number | tostring) != $keep) | .number' 2>/dev/null || echo "")
+	while IFS= read -r dup_num; do
+		[[ -z "$dup_num" ]] && continue
+		_unpin_health_issue "$dup_num" "$repo_slug"
+		_strip_persistent_label_before_close "$dup_num" "$repo_slug"
+		gh issue close "$dup_num" --repo "$repo_slug" \
+			--comment "Closing duplicate health dashboard for canonical operator ${canonical_identity} (current runner ${runner_user}) — superseded by #${keep_number}. Identity aliases map this dashboard to the same operator across local/GitHub usernames and role prefixes." 2>/dev/null || true
+	done <<<"$dup_numbers"
+	return 0
+}
+
+#######################################
 # Title-based fallback lookup with label backfill.
 # Returns issue number if found, empty if not, $_HEALTH_QUERY_FAILED_SENTINEL on failure.
 _try_title_health_issue_fallback() {
@@ -189,6 +259,8 @@ _find_health_issue() {
 	local role_label="$5"
 	local role_display="$6"
 	local health_issue_file="$7"
+	local canonical_identity="${8:-$runner_user}"
+	local identity_aliases="${9:-$runner_user}"
 
 	local health_issue_number
 	health_issue_number=$(_try_cached_health_issue_lookup "$health_issue_file" "$repo_slug" "$runner_role")
@@ -201,7 +273,22 @@ _find_health_issue() {
 		return 0
 	fi
 
-	# Search by labels (more reliable than title search) if cache gave nothing.
+	# Search by canonical identity across aliases/roles if cache gave nothing.
+	if [[ -z "$health_issue_number" ]]; then
+		local identity_results identity_rc=0
+		identity_results=$(_list_health_issues_by_canonical_identity \
+			"$repo_slug" "$canonical_identity" "$identity_aliases" 2>/dev/null) || identity_rc=$?
+		if [[ $identity_rc -ne 0 ]]; then
+			echo "[stats] Health issue: identity lookup failed for ${canonical_identity} in ${repo_slug} (rc=${identity_rc}) — abstaining this cycle" >>"${LOGFILE:-/dev/null}"
+			echo "$_HEALTH_QUERY_FAILED_SENTINEL"
+			return 0
+		fi
+		identity_results="${identity_results:-[]}"
+		health_issue_number=$(printf '%s' "$identity_results" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
+		_close_health_issue_identity_duplicates "$identity_results" "$health_issue_number" "$repo_slug" "$canonical_identity" "$runner_user"
+	fi
+
+	# Legacy role+runner label search if canonical identity found nothing.
 	if [[ -z "$health_issue_number" ]]; then
 		local label_results rc=0
 		label_results=$(_list_health_issues_by_role_label \
@@ -253,11 +340,17 @@ _create_health_issue() {
 	local role_label_color="$6"
 	local role_label_desc="$7"
 	local role_display="$8"
+	local canonical_identity="${9:-$runner_user}"
+	local identity_aliases="${10:-$runner_user}"
+	local runner_label_color="0E8A16"
+	local operator_label="operator:${canonical_identity}"
 
 	gh label create "$role_label" --repo "$repo_slug" --color "$role_label_color" \
 		--description "$role_label_desc" --force 2>/dev/null || true
-	gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" \
+	gh label create "$runner_user" --repo "$repo_slug" --color "$runner_label_color" \
 		--description "${role_display} runner: ${runner_user}" --force 2>/dev/null || true
+	gh label create "$operator_label" --repo "$repo_slug" --color "$runner_label_color" \
+		--description "Canonical dashboard operator: ${canonical_identity}" --force 2>/dev/null || true
 	gh label create "source:health-dashboard" --repo "$repo_slug" --color "C2E0C6" \
 		--description "Auto-created by stats-functions.sh health dashboard" --force 2>/dev/null || true
 	# t1890: health dashboard issues are management issues that should never be
@@ -266,7 +359,9 @@ _create_health_issue() {
 	gh label create "persistent" --repo "$repo_slug" --color "FBCA04" \
 		--description "Persistent issue — do not close" --force 2>/dev/null || true
 
-	local health_body="Live ${runner_role} status for **${runner_user}**. Updated each pulse. Pin this issue for at-a-glance monitoring."
+	local aliases_csv
+	aliases_csv=$(printf '%s\n' "$identity_aliases" | paste -sd ', ' -)
+	local health_body="Live ${runner_role} status for **${runner_user}**. Canonical operator: **${canonical_identity}**. Identity aliases: ${aliases_csv}. Updated each pulse. Pin this issue for at-a-glance monitoring."
 	local sig_footer=""
 	sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$health_body" 2>/dev/null || true)
 	health_body="${health_body}${sig_footer}"
@@ -281,7 +376,7 @@ _create_health_issue() {
 	health_issue_number=$(AIDEVOPS_SESSION_ORIGIN=worker gh_create_issue --repo "$repo_slug" \
 		--title "${runner_prefix} starting..." \
 		--body "$health_body" \
-		--label "$role_label" --label "$runner_user" --label "source:health-dashboard" --label "persistent" 2>/dev/null | grep -oE '[0-9]+$' || echo "")
+		--label "$role_label" --label "$runner_user" --label "$operator_label" --label "source:health-dashboard" --label "persistent" 2>/dev/null | grep -oE '[0-9]+$' || echo "")
 
 	if [[ -z "$health_issue_number" ]]; then
 		echo "[stats] Health issue: could not create for ${repo_slug}" >>"$LOGFILE"
@@ -337,11 +432,14 @@ _resolve_health_issue_number() {
 	local role_label_desc="$7"
 	local role_display="$8"
 	local health_issue_file="$9"
+	local canonical_identity="${10:-$runner_user}"
+	local identity_aliases="${11:-$runner_user}"
 
 	local health_issue_number
 	health_issue_number=$(_find_health_issue \
 		"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \
-		"$role_label" "$role_display" "$health_issue_file")
+		"$role_label" "$role_display" "$health_issue_file" \
+		"$canonical_identity" "$identity_aliases")
 
 	# t2687: honour the query-failed sentinel from _find_health_issue.
 	# When the API was unreachable for the dedup lookups, abstain from
@@ -356,7 +454,8 @@ _resolve_health_issue_number() {
 	if [[ -z "$health_issue_number" ]]; then
 		health_issue_number=$(_create_health_issue \
 			"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \
-			"$role_label" "$role_label_color" "$role_label_desc" "$role_display")
+			"$role_label" "$role_label_color" "$role_label_desc" "$role_display" \
+			"$canonical_identity" "$identity_aliases")
 	fi
 
 	echo "$health_issue_number"
@@ -398,12 +497,19 @@ _periodic_health_issue_dedup() {
 	local role_label="$4"
 	local role_display="$5"
 	local current_issue="$6"
+	local use_identity_dedup=0
+	[[ $# -ge 7 ]] && use_identity_dedup=1
+	local canonical_identity="${7:-$runner_user}"
+	local identity_aliases="${8:-$runner_user}"
 
 	[[ -z "$repo_slug" || -z "$runner_user" || -z "$role_label" || -z "$current_issue" ]] && return 0
 
 	local slug_safe="${repo_slug//\//-}"
 	local cache_dir="${HOME}/.aidevops/logs"
-	local state_file="${cache_dir}/health-dedup-last-scan-${runner_user}-${role_label}-${slug_safe}"
+	local state_file="${cache_dir}/health-dedup-last-scan-${canonical_identity}-${slug_safe}"
+	if [[ $use_identity_dedup -eq 0 ]]; then
+		state_file="${cache_dir}/health-dedup-last-scan-${runner_user}-${role_label}-${slug_safe}"
+	fi
 	local interval="${HEALTH_DEDUP_INTERVAL:-3600}"
 
 	# Throttle: skip if last scan was recent
@@ -420,8 +526,13 @@ _periodic_health_issue_dedup() {
 	mkdir -p "$cache_dir" 2>/dev/null || true
 
 	local label_results rc=0
-	label_results=$(_list_health_issues_by_role_label \
-		"$repo_slug" "$role_label" "$runner_user" "$role_display" 2>/dev/null) || rc=$?
+	if [[ $use_identity_dedup -eq 1 ]]; then
+		label_results=$(_list_health_issues_by_canonical_identity \
+			"$repo_slug" "$canonical_identity" "$identity_aliases" 2>/dev/null) || rc=$?
+	else
+		label_results=$(_list_health_issues_by_role_label \
+			"$repo_slug" "$role_label" "$runner_user" "$role_display" 2>/dev/null) || rc=$?
+	fi
 
 	if [[ $rc -ne 0 ]]; then
 		# Leave state_file alone — retry next pulse cycle.
@@ -436,7 +547,7 @@ _periodic_health_issue_dedup() {
 
 	if [[ "${total_count:-0}" -gt 1 ]]; then
 		local dup_numbers
-		# Close every issue in the label-match set except the one we're
+		# Close every issue in the identity-match set except the one we're
 		# currently using. The cached/resolved issue is the canonical one
 		# because its body+title are up-to-date with this pulse.
 		dup_numbers=$(printf '%s' "$label_results" | jq -r --arg keep "$current_issue" \
@@ -450,7 +561,7 @@ _periodic_health_issue_dedup() {
 			_unpin_health_issue "$dup_num" "$repo_slug"
 			_strip_persistent_label_before_close "$dup_num" "$repo_slug"
 			gh issue close "$dup_num" --repo "$repo_slug" \
-				--comment "Closing duplicate ${runner_role} health issue — superseded by #${current_issue} (t2687 periodic dedup). Root cause likely a past GraphQL rate-limit window; see GH#20301." 2>/dev/null || true
+				--comment "Closing duplicate health dashboard for canonical operator ${canonical_identity} — superseded by #${current_issue} (alias/role periodic dedup for current runner ${runner_user})." 2>/dev/null || true
 			echo "[stats] Health issue: periodic dedup closed #${dup_num} in ${repo_slug} (kept #${current_issue})" >>"${LOGFILE:-/dev/null}"
 		done <<<"$dup_numbers"
 	fi

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -21,7 +21,7 @@
 #   - stats-health-dashboard-data.sh   (data gathering, body formatting, person stats)
 #
 # Dependencies on other stats modules:
-#   - stats-shared.sh (calls _get_runner_role)
+#   - stats-shared.sh (calls _get_runner_role, _dashboard_identity_aliases)
 #
 # Globals read:
 #   - LOGFILE, REPOS_JSON, PERSON_STATS_INTERVAL, PERSON_STATS_LAST_RUN,
@@ -102,8 +102,9 @@ _check_health_issue_activity_guard() {
 #   - System resources (CPU, RAM)
 #   - Last pulse timestamp
 #
-# One issue per runner (GitHub user) per repo. Uses labels
-# "supervisor" or "contributor" + "$runner_user" for dedup.
+# One issue per canonical dashboard operator per repo. Uses labels
+# "supervisor" or "contributor" plus "operator:<canonical>" for dedup,
+# with configured local/GitHub aliases folded into that canonical identity.
 # Issue number cached in ~/.aidevops/logs/ to avoid repeated lookups.
 #
 # Maintainers get [Supervisor:user] issues; non-maintainers get
@@ -132,14 +133,21 @@ _update_health_issue_for_repo() {
 	local runner_role
 	runner_role=$(_get_runner_role "$runner_user" "$repo_slug")
 
+	local identity_lines canonical_identity identity_aliases
+	identity_lines=$(_dashboard_identity_aliases "$runner_user")
+	canonical_identity=$(printf '%s\n' "$identity_lines" | sed -n '1p')
+	identity_aliases=$(printf '%s\n' "$identity_lines" | sed '1d')
+	[[ -n "$canonical_identity" ]] || canonical_identity="$runner_user"
+	[[ -n "$identity_aliases" ]] || identity_aliases="$runner_user"
+
 	local role_config runner_prefix role_label role_label_color role_label_desc role_display
-	role_config=$(_resolve_runner_role_config "$runner_user" "$runner_role")
+	role_config=$(_resolve_runner_role_config "$canonical_identity" "$runner_role")
 	IFS='|' read -r runner_prefix role_label role_label_color role_label_desc role_display \
 		<<<"$role_config"
 
 	local slug_safe="${repo_slug//\//-}"
 	local cache_dir="${HOME}/.aidevops/logs"
-	local health_issue_file="${cache_dir}/health-issue-${runner_user}-${role_label}-${slug_safe}"
+	local health_issue_file="${cache_dir}/health-issue-${canonical_identity}-${slug_safe}"
 	mkdir -p "$cache_dir"
 
 	_check_health_issue_activity_guard \
@@ -149,7 +157,8 @@ _update_health_issue_for_repo() {
 	health_issue_number=$(_resolve_health_issue_number \
 		"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \
 		"$role_label" "$role_label_color" "$role_label_desc" \
-		"$role_display" "$health_issue_file")
+		"$role_display" "$health_issue_file" \
+		"$canonical_identity" "$identity_aliases")
 	[[ -z "$health_issue_number" ]] && return 0
 
 	# t2687: periodic dedup scan (at most once per HEALTH_DEDUP_INTERVAL
@@ -158,7 +167,8 @@ _update_health_issue_for_repo() {
 	# was valid so the label-scan inside _find_health_issue never ran.
 	_periodic_health_issue_dedup \
 		"$repo_slug" "$runner_user" "$runner_role" \
-		"$role_label" "$role_display" "$health_issue_number"
+		"$role_label" "$role_display" "$health_issue_number" \
+		"$canonical_identity" "$identity_aliases"
 
 	if [[ "$runner_role" == "supervisor" ]]; then
 		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
@@ -173,7 +183,8 @@ _update_health_issue_for_repo() {
 	body=$(_assemble_health_issue_body \
 		"$repo_slug" "$repo_path" "$runner_user" "$slug_safe" \
 		"$now_iso" "$role_display" "$runner_role" \
-		"$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md")
+		"$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" \
+		"$canonical_identity" "$identity_aliases")
 
 	local body_edit_stderr
 	# Use gh_issue_edit_safe (not bare `gh issue edit`) so the REST fallback

--- a/.agents/scripts/stats-shared.sh
+++ b/.agents/scripts/stats-shared.sh
@@ -177,3 +177,101 @@ _persist_role_cache() {
 	printf '%s|%s\n' "$role" "$(date +%s)" >"$disk_cache_file" 2>/dev/null || true
 	return 0
 }
+
+#######################################
+# Normalize a dashboard identity token for alias comparisons.
+# Arguments:
+#   $1 - identity token
+# Output: lower-case trimmed token
+#######################################
+_normalize_dashboard_identity_token() {
+	local token="$1"
+	token="${token#"${token%%[![:space:]]*}"}"
+	token="${token%"${token##*[![:space:]]}"}"
+	printf '%s' "$token" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+#######################################
+# Resolve the identity-alias config path.
+# Output: config path, or empty when no config exists
+#######################################
+_dashboard_identity_alias_config_path() {
+	local configured_path="${AIDEVOPS_IDENTITY_ALIASES_CONF:-}"
+	if [[ -n "$configured_path" && -f "$configured_path" ]]; then
+		printf '%s' "$configured_path"
+		return 0
+	fi
+
+	local repo_config=""
+	if [[ -n "${SCRIPT_DIR:-}" ]]; then
+		repo_config="${SCRIPT_DIR%/scripts}/configs/identity-aliases.conf"
+		if [[ -f "$repo_config" ]]; then
+			printf '%s' "$repo_config"
+			return 0
+		fi
+	fi
+
+	local deployed_config="${HOME}/.aidevops/agents/configs/identity-aliases.conf"
+	if [[ -f "$deployed_config" ]]; then
+		printf '%s' "$deployed_config"
+	fi
+	return 0
+}
+
+#######################################
+# Print canonical identity and aliases for a dashboard runner.
+# Config format: canonical=alias-one,alias-two
+# Arguments:
+#   $1 - runner user/login
+# Output: canonical on line 1, aliases one per following line
+#######################################
+_dashboard_identity_aliases() {
+	local runner_user="$1"
+	local normalized_runner
+	normalized_runner=$(_normalize_dashboard_identity_token "$runner_user")
+	local canonical="$normalized_runner"
+	local aliases="$normalized_runner"
+	local config_path
+	config_path=$(_dashboard_identity_alias_config_path)
+
+	if [[ -n "$config_path" ]]; then
+		local line lhs rhs alias normalized_lhs normalized_alias
+		while IFS= read -r line || [[ -n "$line" ]]; do
+			line="${line%%#*}"
+			[[ "$line" == *"="* ]] || continue
+			lhs="${line%%=*}"
+			rhs="${line#*=}"
+			normalized_lhs=$(_normalize_dashboard_identity_token "$lhs")
+			[[ -n "$normalized_lhs" ]] || continue
+			local candidate_aliases="$normalized_lhs"
+			IFS=',' read -r -a _identity_alias_parts <<<"$rhs"
+			for alias in "${_identity_alias_parts[@]}"; do
+				normalized_alias=$(_normalize_dashboard_identity_token "$alias")
+				[[ -n "$normalized_alias" ]] || continue
+				candidate_aliases="${candidate_aliases}"$'\n'"${normalized_alias}"
+			done
+			if printf '%s\n' "$candidate_aliases" | grep -Fx -- "$normalized_runner" >/dev/null 2>&1; then
+				canonical="$normalized_lhs"
+				aliases="$candidate_aliases"
+				break
+			fi
+		done <"$config_path"
+	fi
+
+	printf '%s\n' "$canonical"
+	printf '%s\n' "$aliases" | awk 'NF && !seen[$0]++'
+	return 0
+}
+
+#######################################
+# Resolve a runner to the canonical dashboard identity only.
+# Arguments:
+#   $1 - runner user/login
+# Output: canonical identity
+#######################################
+_resolve_dashboard_canonical_identity() {
+	local runner_user="$1"
+	_dashboard_identity_aliases "$runner_user" | sed -n '1p'
+	return 0
+}

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -100,7 +100,7 @@ body=$(_build_health_issue_body \
 	"0" "4" "0.00" "0.00" "low" "100" "supervisor" \
 	"—" "—" "0" "0" "_No diagnostics_" "$canonical" "$aliases")
 
-if [[ "$body" == *"Canonical operator"* && "$body" == *"canonical-operator"* && "$body" == *"local-user"* ]]; then
+if [[ "$body" == *"canonical:"* && "$body" == *"canonical-operator"* && "$body" == *"local-user"* ]]; then
 	pass "dashboard body exposes canonical identity context"
 else
 	fail "dashboard body exposes canonical identity context" "$body"

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); printf '  PASS %s\n' "$1"; return 0; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); printf '  FAIL %s\n       %s\n' "$1" "${2:-}"; return 0; }
+
+TMP=$(mktemp -d -t health-identity.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="${TMP}/home"
+export LOGFILE="${TMP}/stats.log"
+export AIDEVOPS_IDENTITY_ALIASES_CONF="${TMP}/identity-aliases.conf"
+mkdir -p "${HOME}/.aidevops/logs"
+: >"$LOGFILE"
+
+printf '%s\n' 'canonical-operator=local-user,github-user' >"$AIDEVOPS_IDENTITY_ALIASES_CONF"
+
+GH_CALLS="${TMP}/gh-calls.log"
+: >"$GH_CALLS"
+
+# shellcheck disable=SC2317
+gh() {
+	local call="$*"
+	printf '%s\n' "$call" >>"$GH_CALLS"
+	case "$call" in
+		*"issue list --repo owner/repo --label source:health-dashboard"*)
+			printf '%s' '[{"number":20408,"title":"[Supervisor:github-user] 1 PR at 10:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"}],"createdAt":"2026-05-01T10:00:00Z"},{"number":18669,"title":"[Contributor:local-user] 0 PRs at 09:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"contributor"},{"name":"local-user"}],"createdAt":"2026-04-01T09:00:00Z"}]'
+			return 0
+			;;
+		*) return 0 ;;
+	esac
+	return 0
+}
+
+# shellcheck disable=SC2317
+gh_issue_list() { gh issue list "$@" && return 0; return 1; }
+# shellcheck disable=SC2317
+gh_issue_view() { gh issue view "$@" && return 0; return 1; }
+# shellcheck disable=SC2317
+gh_create_issue() { gh issue create "$@" && return 0; return 1; }
+# shellcheck disable=SC2317
+gh_issue_edit_safe() { gh issue edit "$@" && return 0; return 1; }
+
+# shellcheck source=../portable-stat.sh
+source "${SCRIPTS_DIR}/portable-stat.sh"
+# shellcheck source=../stats-shared.sh
+source "${SCRIPTS_DIR}/stats-shared.sh"
+# shellcheck source=../stats-health-dashboard.sh
+source "${SCRIPTS_DIR}/stats-health-dashboard.sh"
+
+# shellcheck disable=SC2317
+_unpin_health_issue() { printf 'unpin %s\n' "$*" >>"$GH_CALLS"; return 0; }
+
+identity_lines=$(_dashboard_identity_aliases "github-user")
+canonical=$(printf '%s\n' "$identity_lines" | sed -n '1p')
+aliases=$(printf '%s\n' "$identity_lines" | sed '1d')
+
+if [[ "$canonical" == "canonical-operator" ]]; then
+	pass "resolves GitHub username to canonical operator"
+else
+	fail "resolves GitHub username to canonical operator" "canonical=${canonical}"
+fi
+
+result=$(_find_health_issue "owner/repo" "github-user" "supervisor" "[Supervisor:canonical-operator]" \
+	"supervisor" "Supervisor" "${HOME}/.aidevops/logs/health-issue-canonical-owner-repo" \
+	"$canonical" "$aliases")
+
+if [[ "$result" == "20408" ]]; then
+	pass "keeps deterministic newest dashboard across aliases and roles"
+else
+	fail "keeps deterministic newest dashboard across aliases and roles" "result=${result}"
+fi
+
+if grep -q 'issue close 18669' "$GH_CALLS"; then
+	pass "closes stale alias dashboard"
+else
+	fail "closes stale alias dashboard" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+if grep -q 'canonical operator canonical-operator' "$GH_CALLS"; then
+	pass "dedup close comment names canonical identity"
+else
+	fail "dedup close comment names canonical identity" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+body=$(_build_health_issue_body \
+	"2026-05-08T00:00:00Z" "Supervisor" "github-user" "owner/repo" \
+	"0" "0" "0" "0" "4" "1" "0" "" \
+	"_No open PRs_" "_No active workers_" "_Person stats_" "_Cross stats_" \
+	"_Session time_" "_Cross session_" "_Activity_" "_Cross activity_" \
+	"0" "4" "0.00" "0.00" "low" "100" "supervisor" \
+	"—" "—" "0" "0" "_No diagnostics_" "$canonical" "$aliases")
+
+if [[ "$body" == *"Canonical operator"* && "$body" == *"canonical-operator"* && "$body" == *"local-user"* ]]; then
+	pass "dashboard body exposes canonical identity context"
+else
+	fail "dashboard body exposes canonical identity context" "$body"
+fi
+
+printf '\n== Summary ==\n'
+if ((TESTS_FAILED > 0)); then
+	printf '  %d failed of %d tests\n' "$TESTS_FAILED" "$TESTS_RUN"
+	exit 1
+fi
+printf '  All %d tests passed\n' "$TESTS_RUN"
+exit 0


### PR DESCRIPTION
## Summary

- Added canonical health dashboard identity alias resolution so local and GitHub usernames can map to one operator dashboard.
- Updated health dashboard lookup, periodic dedup, and migration logic to close stale duplicates across Supervisor/Contributor role prefixes.
- Added identity-alias config documentation and regression coverage for local-user/github-user alias consolidation.

## Testing

- `bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh`
- `bash .agents/scripts/tests/test-find-health-issue-rate-limit.sh`
- `bash .agents/scripts/tests/test-stats-functions-characterization.sh`
- `shellcheck .agents/scripts/stats-health-dashboard-issue.sh .agents/scripts/stats-health-dashboard-data.sh .agents/scripts/stats-shared.sh .agents/scripts/migrate-health-issue-duplicates-t2687.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh`

## Decisions

- Configured aliases consolidate across Supervisor and Contributor prefixes into one canonical operator dashboard.
- The newest matching issue is kept deterministically; duplicate close comments and dashboard bodies expose the canonical identity context.

Resolves #23097

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.93 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 9m and 243,772 tokens on this with the user in an interactive session.
