### PR TITLE
GH#23118: fix: deduplicate linux scheduler backends

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -149,6 +149,35 @@ _get_scheduler_backend() {
 }
 
 #######################################
+# Remove stale auto-update cron entry after a Linux systemd timer is active.
+# Returns: 0 always
+#######################################
+_remove_auto_update_cron_duplicate() {
+	local current_cron=""
+	local filtered_cron=""
+	local temp_cron=""
+
+	command -v crontab >/dev/null 2>&1 || return 0
+	current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+	[[ -n "$current_cron" ]] || return 0
+	printf '%s\n' "$current_cron" | grep -qF "$CRON_MARKER" || return 0
+
+	filtered_cron=$(printf '%s\n' "$current_cron" | grep -vF "$CRON_MARKER" || true)
+	if [[ -n "$filtered_cron" ]]; then
+		temp_cron=$(mktemp)
+		printf '%s\n' "$filtered_cron" >"$temp_cron"
+		crontab "$temp_cron" 2>/dev/null || true
+		rm -f "$temp_cron"
+	else
+		crontab -r 2>/dev/null || true
+	fi
+
+	log_info "Removed duplicate auto-update cron entry; kept systemd user timer"
+	print_info "Removed duplicate auto-update cron entry; kept systemd user timer"
+	return 0
+}
+
+#######################################
 # Check if the auto-update LaunchAgent is loaded
 # Returns: 0 if loaded, 1 if not
 #######################################
@@ -900,6 +929,7 @@ WantedBy=timers.target
 		return $?
 	fi
 
+	_remove_auto_update_cron_duplicate
 	update_state "enable" "$(get_local_version)" "enabled"
 
 	print_success "Auto-update enabled (every ${interval} minutes)"

--- a/.agents/scripts/setup/modules/schedulers-linux.sh
+++ b/.agents/scripts/setup/modules/schedulers-linux.sh
@@ -241,6 +241,112 @@ _install_scheduler_cron() {
 	return 0
 }
 
+# Detect whether a systemd user timer exists for a scheduler routine.
+# Args: $1=service_name (without .timer suffix)
+_scheduler_systemd_timer_present() {
+	local service_name="$1"
+	local timer_name="${service_name}.timer"
+	local timer_file="$HOME/.config/systemd/user/${timer_name}"
+
+	if command -v systemctl >/dev/null 2>&1; then
+		if systemctl --user is-enabled "$timer_name" >/dev/null 2>&1; then
+			return 0
+		fi
+		if systemctl --user is-active "$timer_name" >/dev/null 2>&1; then
+			return 0
+		fi
+	fi
+
+	[[ -f "$timer_file" ]] && return 0
+	return 1
+}
+
+# Remove cron entries matching a scheduler tag while preserving unrelated jobs.
+# Args: $1=cron_tag, $2=routine_label
+_scheduler_remove_cron_tag() {
+	local cron_tag="$1"
+	local routine_label="$2"
+	local current_cron=""
+	local filtered_cron=""
+	local temp_cron=""
+
+	command -v crontab >/dev/null 2>&1 || return 1
+	current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+	[[ -n "$current_cron" ]] || return 1
+	printf '%s\n' "$current_cron" | grep -qF "$cron_tag" || return 1
+
+	filtered_cron=$(printf '%s\n' "$current_cron" | grep -vF "$cron_tag" || true)
+	if [[ -n "$filtered_cron" ]]; then
+		temp_cron=$(mktemp)
+		printf '%s\n' "$filtered_cron" >"$temp_cron"
+		crontab "$temp_cron" 2>/dev/null || true
+		rm -f "$temp_cron"
+	else
+		crontab -r 2>/dev/null || true
+	fi
+
+	print_info "Removed duplicate cron entry for ${routine_label}; kept systemd user timer"
+	return 0
+}
+
+# Reconcile one Linux scheduler routine so systemd and cron are not both active.
+# Systemd user timers are canonical when present; cron-only jobs are preserved.
+# Args: $1=service_name, $2=cron_tag, $3=routine_label
+_reconcile_linux_scheduler_duplicate() {
+	local service_name="$1"
+	local cron_tag="$2"
+	local routine_label="$3"
+	local current_cron=""
+	local has_cron=false
+
+	if command -v crontab >/dev/null 2>&1; then
+		current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+		if [[ -n "$current_cron" ]] && printf '%s\n' "$current_cron" | grep -qF "$cron_tag"; then
+			has_cron=true
+		fi
+	else
+		print_info "Skipped scheduler reconciliation for ${routine_label}: crontab command unavailable"
+		return 0
+	fi
+
+	if _scheduler_systemd_timer_present "$service_name"; then
+		if [[ "$has_cron" == "true" ]]; then
+			_scheduler_remove_cron_tag "$cron_tag" "$routine_label" || true
+		else
+			print_info "Kept ${routine_label} systemd user timer; no duplicate cron entry found"
+		fi
+		return 0
+	fi
+
+	if [[ "$has_cron" == "true" ]]; then
+		print_info "Kept ${routine_label} cron entry; no systemd user timer found"
+	else
+		print_info "Skipped scheduler reconciliation for ${routine_label}: no installed scheduler found"
+	fi
+	return 0
+}
+
+# Reconcile known Linux aidevops routines that may have migrated from cron to systemd.
+_reconcile_linux_scheduler_duplicates() {
+	_reconcile_linux_scheduler_duplicate \
+		"aidevops-auto-update" \
+		"# aidevops-auto-update" \
+		"auto-update"
+	_reconcile_linux_scheduler_duplicate \
+		"aidevops-pulse-merge" \
+		"aidevops: pulse-merge-routine" \
+		"pulse merge"
+	_reconcile_linux_scheduler_duplicate \
+		"aidevops-supervisor-pulse" \
+		"aidevops: supervisor-pulse" \
+		"supervisor pulse"
+	_reconcile_linux_scheduler_duplicate \
+		"aidevops-stats-wrapper" \
+		"aidevops: stats-wrapper" \
+		"stats wrapper"
+	return 0
+}
+
 # Dispatcher: install a scheduler on Linux, preferring systemd over cron.
 # Args:
 #   $1 = service_name   (systemd service name, e.g. "aidevops-stats-wrapper")
@@ -286,14 +392,7 @@ _install_scheduler_linux() {
 			print_info "${success_msg} (systemd user timer)"
 			# After systemd install succeeds, remove any pre-existing cron entry
 			# to prevent dual-execution (GH#17695 Finding A)
-			if command -v crontab >/dev/null 2>&1; then
-				local current_cron
-				current_cron=$(crontab -l 2>/dev/null) || current_cron=""
-				if [[ -n "$current_cron" ]] && echo "$current_cron" | grep -qF "$cron_tag"; then
-					echo "$current_cron" | grep -vF "$cron_tag" | crontab -
-					echo "[schedulers] Removed pre-existing cron entry for $cron_tag (migrated to systemd)"
-				fi
-			fi
+			_reconcile_linux_scheduler_duplicate "$service_name" "$cron_tag" "$cron_tag"
 		else
 			print_warning "systemd enable failed for ${service_name} — falling back to cron"
 			_install_scheduler_cron "$cron_tag" "$cron_schedule" "$exec_command" "$log_file" "$env_vars"

--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -554,6 +554,7 @@ setup_supervisor_pulse() {
 	# Must run before any cron entries are installed so they inherit the PATH.
 	if [[ "$_os" != "Darwin" ]]; then
 		_ensure_cron_path
+		_reconcile_linux_scheduler_duplicates
 	fi
 
 	# Consent model (GH#2926):

--- a/.agents/scripts/tests/test-scheduler-dedup-linux.sh
+++ b/.agents/scripts/tests/test-scheduler-dedup-linux.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SCHEDULERS_LINUX="${REPO_ROOT}/.agents/scripts/setup/modules/schedulers-linux.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_fixture() {
+	TEST_ROOT="$(mktemp -d)"
+	export HOME="${TEST_ROOT}/home"
+	export CRON_FILE="${TEST_ROOT}/crontab"
+	export SYSTEMD_ENABLED_FILE="${TEST_ROOT}/systemd-enabled"
+	local fake_bin="${TEST_ROOT}/bin"
+	mkdir -p "$HOME/.config/systemd/user" "$fake_bin"
+	: >"$CRON_FILE"
+	: >"$SYSTEMD_ENABLED_FILE"
+
+	cat >"${fake_bin}/crontab" <<'CRONTAB_FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+-l)
+	[[ -f "$CRON_FILE" ]] && cat "$CRON_FILE"
+	exit 0
+	;;
+-r)
+	: >"$CRON_FILE"
+	exit 0
+	;;
+-)
+	cat >"$CRON_FILE"
+	exit 0
+	;;
+*)
+	cp "$1" "$CRON_FILE"
+	exit 0
+	;;
+esac
+CRONTAB_FAKE
+	chmod +x "${fake_bin}/crontab"
+
+	cat >"${fake_bin}/systemctl" <<'SYSTEMCTL_FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--user" && ( "${2:-}" == "is-enabled" || "${2:-}" == "is-active" ) ]]; then
+	grep -qxF "${3:-}" "$SYSTEMD_ENABLED_FILE"
+	exit $?
+fi
+if [[ "${1:-}" == "--user" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+exit 0
+SYSTEMCTL_FAKE
+	chmod +x "${fake_bin}/systemctl"
+	export PATH="${fake_bin}:$PATH"
+	return 0
+}
+
+cleanup_fixture() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+load_scheduler_functions() {
+	print_info() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	print_warning() {
+		printf '%s\n' "$*" >&2
+		return 0
+	}
+	# shellcheck source=../setup/modules/schedulers-linux.sh
+	source "$SCHEDULERS_LINUX"
+	return 0
+}
+
+test_duplicate_auto_update_cron_removed() {
+	setup_fixture
+	printf '%s\n' \
+		'*/10 * * * * /home/example/.aidevops/agents/scripts/auto-update-helper.sh check # aidevops-auto-update' \
+		'15 * * * * /usr/bin/true # keep-me' >"$CRON_FILE"
+	printf '%s\n' 'aidevops-auto-update.timer' >"$SYSTEMD_ENABLED_FILE"
+	load_scheduler_functions
+
+	local output=""
+	output="$(_reconcile_linux_scheduler_duplicates)"
+	local after_first=""
+	after_first="$(cat "$CRON_FILE")"
+	_reconcile_linux_scheduler_duplicates >/dev/null
+	local after_second=""
+	after_second="$(cat "$CRON_FILE")"
+
+	if [[ "$after_first" != *'aidevops-auto-update'* && "$after_first" == *'keep-me'* && "$after_first" == "$after_second" && "$output" == *'Removed duplicate cron entry for auto-update'* ]]; then
+		print_result "duplicate auto-update cron is removed and reconciliation is idempotent" 0
+		cleanup_fixture
+		return 0
+	fi
+
+	print_result "duplicate auto-update cron is removed and reconciliation is idempotent" 1 "output=${output} cron=${after_first} second=${after_second}"
+	cleanup_fixture
+	return 0
+}
+
+test_duplicate_pulse_merge_cron_removed() {
+	setup_fixture
+	printf '%s\n' \
+		'* * * * * /home/example/.aidevops/agents/scripts/pulse-merge-routine.sh run # aidevops: pulse-merge-routine' \
+		'0 6 * * * /usr/bin/true # legitimate-cron-only' >"$CRON_FILE"
+	printf '%s\n' 'aidevops-pulse-merge.timer' >"$SYSTEMD_ENABLED_FILE"
+	load_scheduler_functions
+
+	local output=""
+	output="$(_reconcile_linux_scheduler_duplicates)"
+	local cron_after=""
+	cron_after="$(cat "$CRON_FILE")"
+
+	if [[ "$cron_after" != *'pulse-merge-routine'* && "$cron_after" == *'legitimate-cron-only'* && "$output" == *'Removed duplicate cron entry for pulse merge'* ]]; then
+		print_result "duplicate pulse merge cron is removed while preserving unrelated cron" 0
+		cleanup_fixture
+		return 0
+	fi
+
+	print_result "duplicate pulse merge cron is removed while preserving unrelated cron" 1 "output=${output} cron=${cron_after}"
+	cleanup_fixture
+	return 0
+}
+
+test_systemd_only_stats_wrapper_preserved() {
+	setup_fixture
+	printf '%s\n' '30 2 * * * /usr/bin/true # keep-cron-only' >"$CRON_FILE"
+	printf '%s\n' 'aidevops-stats-wrapper.timer' >"$SYSTEMD_ENABLED_FILE"
+	load_scheduler_functions
+
+	local output=""
+	output="$(_reconcile_linux_scheduler_duplicates)"
+	local cron_after=""
+	cron_after="$(cat "$CRON_FILE")"
+
+	if [[ "$cron_after" == *'keep-cron-only'* && "$output" == *'Kept stats wrapper systemd user timer; no duplicate cron entry found'* ]]; then
+		print_result "systemd-only stats wrapper is preserved and logged" 0
+		cleanup_fixture
+		return 0
+	fi
+
+	print_result "systemd-only stats wrapper is preserved and logged" 1 "output=${output} cron=${cron_after}"
+	cleanup_fixture
+	return 0
+}
+
+test_cron_only_scheduler_preserved() {
+	setup_fixture
+	printf '%s\n' '* * * * * /home/example/pulse-wrapper.sh # aidevops: supervisor-pulse' >"$CRON_FILE"
+	load_scheduler_functions
+
+	local output=""
+	output="$(_reconcile_linux_scheduler_duplicates)"
+	local cron_after=""
+	cron_after="$(cat "$CRON_FILE")"
+
+	if [[ "$cron_after" == *'aidevops: supervisor-pulse'* && "$output" == *'Kept supervisor pulse cron entry; no systemd user timer found'* ]]; then
+		print_result "cron-only scheduler is preserved" 0
+		cleanup_fixture
+		return 0
+	fi
+
+	print_result "cron-only scheduler is preserved" 1 "output=${output} cron=${cron_after}"
+	cleanup_fixture
+	return 0
+}
+
+main() {
+	test_duplicate_auto_update_cron_removed
+	test_duplicate_pulse_merge_cron_removed
+	test_systemd_only_stats_wrapper_preserved
+	test_cron_only_scheduler_preserved
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
-SETUP_SCRIPT="${REPO_ROOT}/setup.sh"
+RUNTIME_HELPERS_SCRIPT="${REPO_ROOT}/.agents/scripts/setup/_runtime_helpers.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -40,10 +40,10 @@ load_setup_functions() {
 		/^_should_setup_noninteractive_supervisor_pulse\(\) \{/ { in_fn=1 }
 		in_fn { print }
 		in_fn && /^}/ { exit }
-	' "$SETUP_SCRIPT")"
+	' "$RUNTIME_HELPERS_SCRIPT")"
 
 	if [[ -z "$helper_definition" ]]; then
-		printf 'failed to load helper from %s\n' "$SETUP_SCRIPT" >&2
+		printf 'failed to load helper from %s\n' "$RUNTIME_HELPERS_SCRIPT" >&2
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary

Added Linux scheduler reconciliation so systemd user timers remove duplicate aidevops cron entries while preserving cron-only jobs, including auto-update cleanup and setup-time reconciliation.

## Files Changed

.agents/scripts/auto-update-helper.sh,.agents/scripts/setup/modules/schedulers-linux.sh,.agents/scripts/setup/modules/schedulers-pulse.sh,.agents/scripts/tests/test-scheduler-dedup-linux.sh,.agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh; bash .agents/scripts/tests/test-pulse-routines-cron-extraction.sh; bash .agents/scripts/tests/test-scheduler-dedup-linux.sh; shellcheck .agents/scripts/setup/modules/schedulers-linux.sh .agents/scripts/setup/modules/schedulers-pulse.sh .agents/scripts/auto-update-helper.sh .agents/scripts/tests/test-scheduler-dedup-linux.sh .agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh

Resolves #23118


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.93 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 6m and 61,881 tokens on this as a headless worker.