### PR TITLE
fix: keep dashboard freshness dedup compatible

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -291,6 +291,7 @@ _open_alert_numbers_for_kind() {
 	local missing_marker_title="Supervisor health dashboard missing last_refresh marker (#${dash_issue})"
 	local issue_suffix="(#${dash_issue})"
 	local issue_list_json=""
+	local issue_list_status=0
 	if [[ -n "$open_issues_json" ]]; then
 		issue_list_json="$open_issues_json"
 	else
@@ -298,7 +299,12 @@ _open_alert_numbers_for_kind() {
 		gh auth status &>/dev/null 2>&1 || return 0
 		# Query open issue titles and filter locally. GitHub search is unreliable for
 		# HTML-comment dedup markers, and label prefilters can hide generated alerts.
-		issue_list_json="$(gh issue list --repo "$slug" --state open --paginate --json number,title 2>>"$LOGFILE" || true)"
+		issue_list_json="$(gh issue list --repo "$slug" --state open --limit 1000 --json number,title 2>>"$LOGFILE")"
+		issue_list_status=$?
+		if (( issue_list_status != 0 )); then
+			_log_error "Failed to list open issues for dashboard freshness dedup in ${slug}: gh issue list exited ${issue_list_status}"
+			return 0
+		fi
 	fi
 	[[ -n "$issue_list_json" ]] || return 0
 	printf '%s\n' "$issue_list_json" | \
@@ -319,11 +325,19 @@ _open_alert_numbers_for_kind() {
 
 _open_issue_titles_json() {
 	local slug="$1"
+	local issue_list_json=""
+	local issue_list_status=0
 	command -v gh >/dev/null 2>&1 || return 0
 	gh auth status &>/dev/null 2>&1 || return 0
 	# Query open issue titles and filter locally. GitHub search is unreliable for
 	# HTML-comment dedup markers, and label prefilters can hide generated alerts.
-	gh issue list --repo "$slug" --state open --paginate --json number,title 2>>"$LOGFILE" || true
+	issue_list_json="$(gh issue list --repo "$slug" --state open --limit 1000 --json number,title 2>>"$LOGFILE")"
+	issue_list_status=$?
+	if (( issue_list_status != 0 )); then
+		_log_error "Failed to list open issues for dashboard freshness recovery in ${slug}: gh issue list exited ${issue_list_status}"
+		return 0
+	fi
+	printf '%s\n' "$issue_list_json"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -25,7 +25,9 @@
 #      recovery evidence and closes the alert.
 #  10. scan with a stale dashboard AND a pre-existing missing-marker alert →
 #      closes the recovered missing-marker alert and files a stale alert.
-#  11. source regression: recovered stale and missing-marker alert paths share
+#  11. gh issue list failures are logged instead of silently treated as an
+#      empty dedup result.
+#  12. source regression: recovered stale and missing-marker alert paths share
 #      the parameterized close helper and accept a pre-fetched open issue list.
 #
 # The scanner is expected to use `command -v gh` + `gh auth status` guards
@@ -210,7 +212,7 @@ run_scan_with_stubs() {
 			# for the three paths the scanner exercises:
 			#   gh auth status       → success
 			#   gh api repos/.../issues/N  → dashboard body (read from fixture)
-			#   gh issue list --paginate --json number,title ... → alert dedup/recovery check
+			#   gh issue list --limit 1000 --json number,title ... → alert dedup/recovery check
 			#   gh issue create ...  → URL + 0
 			gh() {
 				printf "%s\n" "$*" >> "$GH_CALLS_LOG"
@@ -227,9 +229,14 @@ run_scan_with_stubs() {
 					issue)
 						case "$2" in
 							list)
+								if [[ "${GH_ISSUE_LIST_FAIL:-0}" == "1" ]]; then
+									printf "simulated gh issue list failure\n" >&2
+									return 1
+								fi
 								if [[ "$gh_args" == *" --label "* ]] \
 									|| [[ "$gh_args" == *" --search "* ]] \
-									|| [[ "$gh_args" != *"--paginate"* ]] \
+									|| [[ "$gh_args" == *"--paginate"* ]] \
+									|| [[ "$gh_args" != *"--limit 1000"* ]] \
 									|| [[ "$gh_args" != *"--json number,title"* ]]; then
 									printf "[]\n"
 								elif [[ "$ALERT_EXISTS" == "1" ]]; then
@@ -312,13 +319,14 @@ issue_list_call="$(grep '^issue list ' "$calls_file" || true)"
 if [[ -n "$issue_list_call" ]] \
 	&& [[ "$issue_list_call" != *"--label"* ]] \
 	&& [[ "$issue_list_call" != *"--search"* ]] \
-	&& [[ "$issue_list_call" == *"--paginate"* ]] \
+	&& [[ "$issue_list_call" != *"--paginate"* ]] \
+	&& [[ "$issue_list_call" == *"--limit 1000"* ]] \
 	&& [[ "$issue_list_call" == *"--json number,title"* ]] \
 	&& [[ "$issue_list_call" != *"--jq"* ]]; then
-	pass "dedup lookup paginates open titles for local jq filtering"
+	pass "dedup lookup limits open titles for gh issue list compatibility"
 else
 	fail "dedup lookup query shape" \
-		"expected paginated title query without --label/--search/--jq; calls:\n$(cat "$calls_file")"
+		"expected --limit 1000 title query without --paginate/--label/--search/--jq; calls:\n$(cat "$calls_file")"
 fi
 
 if grep -q -- 'jq -r --arg prefix' "$SCANNER" \
@@ -420,7 +428,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 11: source shape for shared recovered-alert helper and cached issue list
+# Test 11: failed gh issue list logs an error instead of silent empty dedup
+# ---------------------------------------------------------------------------
+echo "Testing: gh issue list failure logs dedup error"
+run_scan_with_stubs "$STALE_BODY" 0 "export GH_ISSUE_LIST_FAIL=1" >/dev/null
+calls_file="${TMP}/gh-calls.log"
+created_count=$(grep -c '^issue create ' "$calls_file" 2>/dev/null || true)
+[[ "$created_count" =~ ^[0-9]+$ ]] || created_count=0
+
+if (( created_count == 1 )) \
+	&& grep -q 'Failed to list open issues for dashboard freshness dedup in test/repo' \
+		"${HOME_ISO}/.aidevops/logs/dashboard-freshness.log"; then
+	pass "gh issue list failure → logged dedup error before fail-open alert"
+else
+	fail "gh issue list failure logging" \
+		"created=$created_count; calls:\n$(cat "$calls_file"); log:\n$(cat "${HOME_ISO}/.aidevops/logs/dashboard-freshness.log")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: source shape for shared recovered-alert helper and cached issue list
 # ---------------------------------------------------------------------------
 echo "Testing: recovered-alert source shape"
 if grep -q '^_close_recovered_alerts_for_kind()' "$SCANNER" \
@@ -435,7 +461,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 12: missing-marker body → alerts with MISSING title
+# Test 13: missing-marker body → alerts with MISSING title
 # ---------------------------------------------------------------------------
 echo "Testing: missing-marker body files alert"
 run_scan_with_stubs "$MISSING_BODY" 0 "" >/dev/null


### PR DESCRIPTION
## Summary
- Replaces `gh issue list --paginate` with `--limit 1000` for dashboard freshness dedup/recovery queries.
- Logs non-zero `gh issue list` failures so dedup gate failures are visible instead of silently looking like no open alerts.
- Updates dashboard freshness regression tests to reject `--paginate`, require `--limit 1000`, and cover the logged failure path.

## Verification
- `shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh`
- `bash .agents/scripts/tests/test-dashboard-freshness-check.sh`
- `.agents/scripts/linters-local.sh` (passes; existing advisory markdown/complexity/layout warnings remain non-blocking)

Resolves #23103
