### PR TITLE
GH#23066: add opt-in strict review gate completion

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -43,6 +43,12 @@
 #                              Override per-repo or per-tool in repos.json:
 #                              { "review_gate": { "rate_limit_behavior": "pass",
 #                                "tools": { "coderabbitai": { "rate_limit_behavior": "wait" } } } }
+#   REVIEW_GATE_COMPLETION_BEHAVIOR — Global default for bot completion:
+#                              "fast" (default, accept settled comments) or
+#                              "strict" (require bot success status when needed).
+#                              Override per-repo or per-tool in repos.json:
+#                              { "review_gate": { "completion_behavior": "strict",
+#                                "tools": { "coderabbitai": { "completion_behavior": "fast" } } } }
 #
 # t1382: https://github.com/marcusquinn/aidevops/issues/2735
 # GH#3827: Rate-limit grace period — pass gate after timeout when bots are
@@ -120,6 +126,12 @@ RATE_LIMIT_GRACE_SECONDS="${RATE_LIMIT_GRACE_SECONDS:-1800}"
 # Override per-repo or per-tool via repos.json review_gate config.
 REVIEW_GATE_RATE_LIMIT_BEHAVIOR="${REVIEW_GATE_RATE_LIMIT_BEHAVIOR:-pass}"
 
+# GH#23066: Global default for completion evidence behavior.
+# Values: "fast" keeps high-throughput settled-comment semantics; "strict"
+# requires bot-specific terminal success evidence for two-phase bots such as
+# CodeRabbit. Override per-repo or per-tool via repos.json review_gate config.
+REVIEW_GATE_COMPLETION_BEHAVIOR="${REVIEW_GATE_COMPLETION_BEHAVIOR:-fast}"
+
 # t2139 (GH#19251): Minimum seconds a bot comment must have been "settled"
 # (either edited via updated_at > created_at, or simply old enough since
 # created_at) before it counts as a completed review. Defeats the two-phase
@@ -192,6 +204,49 @@ _get_rate_limit_behavior() {
 	# Fall through to global env (which defaults to "pass")
 	printf '%s' "$REVIEW_GATE_RATE_LIMIT_BEHAVIOR"
 	return 0
+}
+
+_get_completion_behavior() {
+	# GH#23066: Resolve completion behavior for a specific bot on a specific repo.
+	# Resolution order: per-tool > per-repo default > global env > hardcoded "fast".
+	#
+	# repos.json schema:
+	#   "review_gate": {
+	#     "completion_behavior": "strict",        // per-repo default
+	#     "tools": {
+	#       "coderabbitai": { "completion_behavior": "fast" }
+	#     }
+	#   }
+	local repo_slug="$1"
+	local bot_login="$2"
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+
+	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
+		local behavior=""
+		behavior=$(jq -r --arg slug "$repo_slug" --arg bot "$bot_login" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | (.review_gate.tools[$bot].completion_behavior // .review_gate.completion_behavior // empty)' \
+			"$repos_json" 2>/dev/null) || behavior=""
+		if [[ -n "$behavior" ]]; then
+			printf '%s' "$behavior"
+			return 0
+		fi
+	fi
+
+	printf '%s' "$REVIEW_GATE_COMPLETION_BEHAVIOR"
+	return 0
+}
+
+_requires_success_status_completion() {
+	# GH#23066: Strict completion is opt-in so high-throughput repos keep the
+	# existing fast path by default. Limit the stricter requirement to two-phase
+	# bots because they are the observed comment-before-status race.
+	local repo_slug="$1"
+	local bot_login="$2"
+	local behavior
+	behavior=$(_get_completion_behavior "$repo_slug" "$bot_login")
+	[[ "$behavior" != "strict" ]] && return 1
+	_is_two_phase_bot "$bot_login" && return 0
+	return 1
 }
 
 _get_min_edit_lag() {
@@ -572,6 +627,15 @@ bot_has_real_review() {
 			if ! _comment_is_settled "$created_at" "$updated_at" "$min_lag" "$bot_login"; then
 				continue
 			fi
+			# GH#23066: Strict completion is an opt-in local/repo preference.
+			# #aidevops:trust-boundary — a two-phase bot's edited comment is not
+			# trusted as terminal completion unless the bot's own status/check has
+			# reached success. Default fast mode intentionally preserves throughput.
+			if _requires_success_status_completion "$repo" "$bot_login" && \
+				! bot_has_success_status "$pr_number" "$repo" "$bot_login"; then
+				echo "Strict completion: ${bot_login} settled comment lacks SUCCESS status/check" >&2
+				continue
+			fi
 			return 0
 		done <<<"$records"
 	done
@@ -580,13 +644,10 @@ bot_has_real_review() {
 	return 1
 }
 
-any_bot_has_success_status() {
+_get_success_status_contexts() {
 	# GH#3005: When bots are rate-limited in comments but still post a formal
 	# GitHub status check, treat the PR as reviewed.
 	# GH#3007: The status context name may differ from the bot login.
-	# E.g., bot login "coderabbitai" but status context "CodeRabbit".
-	# Match bidirectionally: bot_base starts with context OR context
-	# starts with bot_base (case-insensitive).
 	local pr_number="$1"
 	local repo="$2"
 
@@ -620,22 +681,66 @@ any_bot_has_success_status() {
 		return 1
 	fi
 
+	printf '%s\n' "${head_sha}" "$statuses"
+	return 0
+}
+
+_status_contexts_match_bot() {
+	# GH#3007: Match bidirectionally — the status context may be a prefix
+	# of the bot login (e.g., "coderabbit" vs "coderabbitai") or vice versa.
+	# Input shape: first line is head SHA, remaining lines are success contexts.
+	local bot_login="$1"
+	local status_contexts="$2"
+
+	if [[ -z "$status_contexts" ]]; then
+		return 1
+	fi
+
+	local head_sha statuses
+	head_sha=$(printf '%s\n' "$status_contexts" | sed -n '1p')
+	statuses=$(printf '%s\n' "$status_contexts" | sed '1d')
+	if [[ -z "$head_sha" || -z "$statuses" ]]; then
+		return 1
+	fi
+
 	local statuses_lower
 	statuses_lower=$(echo "$statuses" | tr '[:upper:]' '[:lower:]')
 
-	# GH#3007: Match bidirectionally — the status context may be a prefix
-	# of the bot login (e.g., "coderabbit" vs "coderabbitai") or vice versa.
-	local bot bot_base ctx
+	local bot_base ctx
+	bot_base=$(echo "$bot_login" | tr '[:upper:]' '[:lower:]')
+	while IFS= read -r ctx; do
+		[[ -z "$ctx" ]] && continue
+		# Bidirectional prefix match: either string starts with the other
+		if [[ "$bot_base" == "$ctx"* ]] || [[ "$ctx" == "$bot_base"* ]]; then
+			echo "Bot '${bot_login}' has SUCCESS status check on commit ${head_sha:0:8} (context: '${ctx}')" >&2
+			return 0
+		fi
+	done <<<"$statuses_lower"
+	return 1
+}
+
+bot_has_success_status() {
+	local pr_number="$1"
+	local repo="$2"
+	local bot_login="$3"
+
+	local status_contexts
+	status_contexts=$(_get_success_status_contexts "$pr_number" "$repo") || return 1
+	_status_contexts_match_bot "$bot_login" "$status_contexts" && return 0
+	return 1
+}
+
+any_bot_has_success_status() {
+	local pr_number="$1"
+	local repo="$2"
+	local status_contexts
+	status_contexts=$(_get_success_status_contexts "$pr_number" "$repo") || return 1
+
+	local bot
 	for bot in "${KNOWN_BOTS[@]}"; do
-		bot_base=$(echo "$bot" | tr '[:upper:]' '[:lower:]')
-		while IFS= read -r ctx; do
-			[[ -z "$ctx" ]] && continue
-			# Bidirectional prefix match: either string starts with the other
-			if [[ "$bot_base" == "$ctx"* ]] || [[ "$ctx" == "$bot_base"* ]]; then
-				echo "Bot '${bot}' has SUCCESS status check on commit ${head_sha:0:8} (context: '${ctx}')" >&2
-				return 0
-			fi
-		done <<<"$statuses_lower"
+		if _status_contexts_match_bot "$bot" "$status_contexts"; then
+			return 0
+		fi
 	done
 	return 1
 }

--- a/.agents/scripts/review-gate-config-helper.sh
+++ b/.agents/scripts/review-gate-config-helper.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # -----------------------------------------------------------------------------
-# review-gate-config-helper.sh — CLI for configuring review_gate.rate_limit_behavior
+# review-gate-config-helper.sh — CLI for configuring review_gate merge policies
 # in ~/.config/aidevops/repos.json without hand-editing JSON.
 #
 # Usage:
@@ -11,15 +11,19 @@
 #   aidevops review-gate <slug>                       Show config for one repo
 #   aidevops review-gate <slug> pass|wait|unset       Set per-repo default
 #   aidevops review-gate <slug> --tool <bot> pass|wait|unset  Per-tool override
+#   aidevops review-gate <slug> --completion fast|strict|unset  Completion policy
+#   aidevops review-gate <slug> --tool <bot> --completion fast|strict|unset
 #   aidevops review-gate --help                       Show this help
 #
 # Schema written to ~/.config/aidevops/repos.json under the matching
 # initialized_repos entry:
 #   { "review_gate": { "rate_limit_behavior": "pass",
-#                      "tools": { "coderabbitai": { "rate_limit_behavior": "wait" } } } }
+#                      "completion_behavior": "fast",
+#                      "tools": { "coderabbitai": { "rate_limit_behavior": "wait",
+#                                                     "completion_behavior": "strict" } } } }
 #
-# Resolution order (unchanged): per-tool > per-repo > env var > "pass".
-# This helper only edits repos.json. Env var and default are untouched.
+# Resolution order: per-tool > per-repo > env var > hardcoded default.
+# This helper only edits repos.json. Env vars and defaults are untouched.
 # -----------------------------------------------------------------------------
 
 set -euo pipefail
@@ -36,6 +40,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -z "${NC+x}" ]]     && NC='\033[0m'
 
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+readonly RATE_LIMIT_BEHAVIOR_FIELD="rate_limit_behavior"
+readonly COMPLETION_BEHAVIOR_FIELD="completion_behavior"
 
 # Known bot logins for --tool validation. New bots warn but are not rejected
 # (forward-compat: new bots should work without a helper update).
@@ -85,12 +91,24 @@ _require_repos_json() {
 }
 
 # Validate a rate_limit_behavior value.
-_validate_behavior() {
+_validate_rate_limit_behavior() {
 	local value="$1"
 	case "$value" in
 	pass | wait | unset) return 0 ;;
 	*)
 		_print_error "Invalid value '${value}'. Must be: pass, wait, or unset"
+		return 1
+		;;
+	esac
+}
+
+# Validate a completion_behavior value.
+_validate_completion_behavior() {
+	local value="$1"
+	case "$value" in
+	fast | strict | unset) return 0 ;;
+	*)
+		_print_error "Invalid completion value '${value}'. Must be: fast, strict, or unset"
 		return 1
 		;;
 	esac
@@ -147,23 +165,27 @@ _resolve_slug() {
 _resolve_effective_behavior() {
 	local slug="$1"
 	local bot="${2:-}"
+	local field="${3:-$RATE_LIMIT_BEHAVIOR_FIELD}"
 
 	local per_tool_val=""
 	local per_repo_val=""
 
 	if [[ -f "$REPOS_JSON" ]] && command -v jq &>/dev/null; then
-		per_repo_val=$(jq -r --arg slug "$slug" \
-			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate.rate_limit_behavior // empty' \
+		per_repo_val=$(jq -r --arg slug "$slug" --arg field "$field" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate[$field] // empty' \
 			"$REPOS_JSON" 2>/dev/null) || per_repo_val=""
 
 		if [[ -n "$bot" ]]; then
-			per_tool_val=$(jq -r --arg slug "$slug" --arg bot "$bot" \
-				'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate.tools[$bot].rate_limit_behavior // empty' \
+			per_tool_val=$(jq -r --arg slug "$slug" --arg bot "$bot" --arg field "$field" \
+				'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate.tools[$bot][$field] // empty' \
 				"$REPOS_JSON" 2>/dev/null) || per_tool_val=""
 		fi
 	fi
 
 	local global_env="${REVIEW_GATE_RATE_LIMIT_BEHAVIOR:-pass}"
+	if [[ "$field" == "$COMPLETION_BEHAVIOR_FIELD" ]]; then
+		global_env="${REVIEW_GATE_COMPLETION_BEHAVIOR:-fast}"
+	fi
 
 	# Resolution order: per-tool > per-repo > env > "pass"
 	if [[ -n "$bot" && -n "$per_tool_val" ]]; then
@@ -255,37 +277,49 @@ cmd_list() {
 	while IFS= read -r slug; do
 		[[ -z "$slug" ]] && continue
 
-		local per_repo_val
-		per_repo_val=$(jq -r --arg slug "$slug" \
-			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate.rate_limit_behavior // empty' \
-			"$REPOS_JSON" 2>/dev/null) || per_repo_val=""
+		local rate_limit_val completion_val
+		rate_limit_val=$(jq -r --arg slug "$slug" --arg field "$RATE_LIMIT_BEHAVIOR_FIELD" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate[$field] // empty' \
+			"$REPOS_JSON" 2>/dev/null) || rate_limit_val=""
+		completion_val=$(jq -r --arg slug "$slug" --arg field "$COMPLETION_BEHAVIOR_FIELD" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate[$field] // empty' \
+			"$REPOS_JSON" 2>/dev/null) || completion_val=""
 
-		local effective
-		effective=$(_resolve_effective_behavior "$slug")
+		local rate_effective completion_effective
+		rate_effective=$(_resolve_effective_behavior "$slug" "" "$RATE_LIMIT_BEHAVIOR_FIELD")
+		completion_effective=$(_resolve_effective_behavior "$slug" "" "$COMPLETION_BEHAVIOR_FIELD")
 
 		printf "  %s\n" "$slug"
-		if [[ -n "$per_repo_val" ]]; then
-			printf "    per-repo: %-6s  effective: %s\n" "$per_repo_val" "$effective"
+		if [[ -n "$rate_limit_val" ]]; then
+			printf "    rate-limit per-repo: %-6s  effective: %s\n" "$rate_limit_val" "$rate_effective"
 		else
-			printf "    per-repo: %-6s  effective: %s\n" "(unset)" "$effective"
+			printf "    rate-limit per-repo: %-6s  effective: %s\n" "(unset)" "$rate_effective"
+		fi
+		if [[ -n "$completion_val" ]]; then
+			printf "    completion per-repo: %-6s  effective: %s\n" "$completion_val" "$completion_effective"
+		else
+			printf "    completion per-repo: %-6s  effective: %s\n" "(unset)" "$completion_effective"
 		fi
 
 		# List per-tool overrides if present
 		local tools_json
-		tools_json=$(jq -r --arg slug "$slug" \
-			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate.tools // empty | to_entries[]? | "\(.key)=\(.value.rate_limit_behavior // "(unset)")"' \
+		tools_json=$(jq -r --arg slug "$slug" --arg rate_field "$RATE_LIMIT_BEHAVIOR_FIELD" --arg completion_field "$COMPLETION_BEHAVIOR_FIELD" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate.tools // empty | to_entries[]? | "\(.key)=\(.value[$rate_field] // "(unset)")|\(.value[$completion_field] // "(unset)")"' \
 			"$REPOS_JSON" 2>/dev/null) || tools_json=""
 
 		if [[ -n "$tools_json" ]]; then
 			local tool_entry
 			while IFS= read -r tool_entry; do
 				[[ -z "$tool_entry" ]] && continue
-				local tool_name tool_val tool_effective
+				local tool_name rest tool_rate_val tool_completion_val tool_rate_effective tool_completion_effective
 				tool_name="${tool_entry%%=*}"
-				tool_val="${tool_entry#*=}"
-				tool_effective=$(_resolve_effective_behavior "$slug" "$tool_name")
-				printf "    tool %-24s per-tool: %-6s  effective: %s\n" \
-					"${tool_name}:" "$tool_val" "$tool_effective"
+				rest="${tool_entry#*=}"
+				tool_rate_val="${rest%%|*}"
+				tool_completion_val="${rest#*|}"
+				tool_rate_effective=$(_resolve_effective_behavior "$slug" "$tool_name" "$RATE_LIMIT_BEHAVIOR_FIELD")
+				tool_completion_effective=$(_resolve_effective_behavior "$slug" "$tool_name" "$COMPLETION_BEHAVIOR_FIELD")
+				printf "    tool %-24s rate-limit: %-6s effective: %-6s completion: %-6s effective: %s\n" \
+					"${tool_name}:" "$tool_rate_val" "$tool_rate_effective" "$tool_completion_val" "$tool_completion_effective"
 			done <<<"$tools_json"
 		fi
 
@@ -301,12 +335,17 @@ cmd_set() {
 	local slug="$1"
 	local tool_login="${2:-}"
 	local value="$3"
+	local field="${4:-$RATE_LIMIT_BEHAVIOR_FIELD}"
 
 	_require_jq || return 1
 	_require_repos_json || return 1
 
 	# Validate the value
-	_validate_behavior "$value" || return 1
+	if [[ "$field" == "$COMPLETION_BEHAVIOR_FIELD" ]]; then
+		_validate_completion_behavior "$value" || return 1
+	else
+		_validate_rate_limit_behavior "$value" || return 1
+	fi
 
 	# Resolve and validate the slug
 	local resolved_slug
@@ -332,7 +371,8 @@ cmd_set() {
 			new_json=$(printf '%s' "$current_json" | jq \
 				--arg slug "$resolved_slug" \
 				--arg bot "$tool_login" \
-				'(.initialized_repos[] | select(.slug == $slug) | .review_gate.tools[$bot]) |= del(.rate_limit_behavior)' \
+				--arg field "$field" \
+				'(.initialized_repos[] | select(.slug == $slug) | .review_gate.tools[$bot]) |= del(.[$field])' \
 				2>/dev/null) || { _jq_mutation_failed; return 1; }
 			# Clean up empty tools entries
 			new_json=$(printf '%s' "$new_json" | jq \
@@ -342,7 +382,8 @@ cmd_set() {
 		else
 			new_json=$(printf '%s' "$current_json" | jq \
 				--arg slug "$resolved_slug" \
-				'(.initialized_repos[] | select(.slug == $slug) | .review_gate) |= del(.rate_limit_behavior)' \
+				--arg field "$field" \
+				'(.initialized_repos[] | select(.slug == $slug) | .review_gate) |= del(.[$field])' \
 				2>/dev/null) || { _jq_mutation_failed; return 1; }
 		fi
 	else
@@ -351,14 +392,16 @@ cmd_set() {
 			new_json=$(printf '%s' "$current_json" | jq \
 				--arg slug "$resolved_slug" \
 				--arg bot "$tool_login" \
+				--arg field "$field" \
 				--arg val "$value" \
-				'(.initialized_repos[] | select(.slug == $slug) | .review_gate.tools[$bot].rate_limit_behavior) |= $val' \
+				'(.initialized_repos[] | select(.slug == $slug) | .review_gate.tools[$bot][$field]) |= $val' \
 				2>/dev/null) || { _jq_mutation_failed; return 1; }
 		else
 			new_json=$(printf '%s' "$current_json" | jq \
 				--arg slug "$resolved_slug" \
+				--arg field "$field" \
 				--arg val "$value" \
-				'(.initialized_repos[] | select(.slug == $slug) | .review_gate.rate_limit_behavior) |= $val' \
+				'(.initialized_repos[] | select(.slug == $slug) | .review_gate[$field]) |= $val' \
 				2>/dev/null) || { _jq_mutation_failed; return 1; }
 		fi
 	fi
@@ -368,19 +411,19 @@ cmd_set() {
 	# Report what changed
 	if [[ "$value" == "unset" ]]; then
 		if [[ -n "$tool_login" ]]; then
-			_print_ok "Removed per-tool override for '${tool_login}' on ${resolved_slug}"
-			_print_info "Effective value now: $(_resolve_effective_behavior "$resolved_slug" "$tool_login")"
+			_print_ok "Removed per-tool ${field} override for '${tool_login}' on ${resolved_slug}"
+			_print_info "Effective value now: $(_resolve_effective_behavior "$resolved_slug" "$tool_login" "$field")"
 		else
-			_print_ok "Removed per-repo override for ${resolved_slug}"
-			_print_info "Effective value now: $(_resolve_effective_behavior "$resolved_slug")"
+			_print_ok "Removed per-repo ${field} override for ${resolved_slug}"
+			_print_info "Effective value now: $(_resolve_effective_behavior "$resolved_slug" "" "$field")"
 		fi
 	else
 		if [[ -n "$tool_login" ]]; then
-			_print_ok "Set review_gate.tools.${tool_login}.rate_limit_behavior = ${value} for ${resolved_slug}"
+			_print_ok "Set review_gate.tools.${tool_login}.${field} = ${value} for ${resolved_slug}"
 		else
-			_print_ok "Set review_gate.rate_limit_behavior = ${value} for ${resolved_slug}"
+			_print_ok "Set review_gate.${field} = ${value} for ${resolved_slug}"
 		fi
-		_print_info "Effective value: $(_resolve_effective_behavior "$resolved_slug" "$tool_login")"
+		_print_info "Effective value: $(_resolve_effective_behavior "$resolved_slug" "$tool_login" "$field")"
 	fi
 
 	return 0
@@ -389,16 +432,22 @@ cmd_set() {
 # ── Help ─────────────────────────────────────────────────────────────────────
 
 cmd_help() {
-	echo "review-gate-config-helper.sh — Configure review_gate.rate_limit_behavior"
+	echo "review-gate-config-helper.sh — Configure review_gate merge policies"
 	echo ""
 	echo "Controls what happens when a review bot is rate-limited during a merge check:"
 	echo "  pass  (default) — treat rate-limit as a pass, preserve merge velocity"
 	echo "  wait            — keep polling until the bot responds (strict review-before-merge)"
 	echo ""
+	echo "Controls whether settled bot comments need terminal bot status/check evidence:"
+	echo "  fast   (default) — accept settled comments, preserve merge velocity"
+	echo "  strict           — require bot SUCCESS status/check for two-phase bots"
+	echo ""
 	echo "Commands:"
 	echo "  list [<slug>]                          Show config for all repos (or one)"
 	echo "  <slug> pass|wait|unset                 Set per-repo default"
 	echo "  <slug> --tool <bot> pass|wait|unset    Set per-tool override"
+	echo "  <slug> --completion fast|strict|unset  Set completion default"
+	echo "  <slug> --tool <bot> --completion fast|strict|unset"
 	echo "  help                                   Show this help"
 	echo ""
 	echo "Arguments:"
@@ -414,9 +463,12 @@ cmd_help() {
 	echo "  aidevops review-gate marcusquinn/myrepo unset    # remove per-repo override"
 	echo "  aidevops review-gate marcusquinn/myrepo --tool coderabbitai wait"
 	echo "  aidevops review-gate marcusquinn/myrepo --tool coderabbitai unset"
+	echo "  aidevops review-gate marcusquinn/myrepo --completion strict"
+	echo "  aidevops review-gate marcusquinn/myrepo --tool coderabbitai --completion strict"
 	echo ""
 	echo "Resolution order (per-tool wins):"
-	echo "  per-tool config > per-repo config > REVIEW_GATE_RATE_LIMIT_BEHAVIOR env > pass"
+	echo "  rate-limit: per-tool > per-repo > REVIEW_GATE_RATE_LIMIT_BEHAVIOR env > pass"
+	echo "  completion: per-tool > per-repo > REVIEW_GATE_COMPLETION_BEHAVIOR env > fast"
 	echo ""
 	echo "Reference: .agents/reference/repos-json-fields.md"
 	return 0
@@ -438,6 +490,8 @@ main() {
 	# Handle: <slug>                → show one repo
 	# Handle: <slug> pass|wait|unset
 	# Handle: <slug> --tool <bot> pass|wait|unset
+	# Handle: <slug> --completion fast|strict|unset
+	# Handle: <slug> --tool <bot> --completion fast|strict|unset
 
 	case "$command" in
 	list)
@@ -454,21 +508,39 @@ main() {
 			return $?
 		fi
 
+		# slug --completion fast|strict|unset
+		if [[ "$subcommand" == "--completion" ]]; then
+			local value="${2:-}"
+			if [[ -z "$value" ]]; then
+				_print_error "Missing value after --completion. Expected: fast, strict, or unset"
+				cmd_help
+				return 1
+			fi
+			cmd_set "$slug" "" "$value" "$COMPLETION_BEHAVIOR_FIELD"
+			return $?
+		fi
+
 		# slug --tool <bot> pass|wait|unset
+		# slug --tool <bot> --completion fast|strict|unset
 		if [[ "$subcommand" == "--tool" ]]; then
 			local tool_login="${2:-}"
 			local value="${3:-}"
+			local field="$RATE_LIMIT_BEHAVIOR_FIELD"
 			if [[ -z "$tool_login" ]]; then
 				_print_error "Missing bot login after --tool"
 				cmd_help
 				return 1
 			fi
+			if [[ "$value" == "--completion" ]]; then
+				field="$COMPLETION_BEHAVIOR_FIELD"
+				value="${4:-}"
+			fi
 			if [[ -z "$value" ]]; then
-				_print_error "Missing value after --tool ${tool_login}. Expected: pass, wait, or unset"
+				_print_error "Missing value after --tool ${tool_login}. Expected: pass, wait, unset, or --completion fast|strict|unset"
 				cmd_help
 				return 1
 			fi
-			cmd_set "$slug" "$tool_login" "$value"
+			cmd_set "$slug" "$tool_login" "$value" "$field"
 			return $?
 		fi
 

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -85,6 +85,14 @@ setup_test_env() {
       "path": "/tmp/otherrepo",
       "slug": "testorg/otherrepo",
       "pulse": true
+    },
+    {
+      "path": "/tmp/strictrepo",
+      "slug": "testorg/strictrepo",
+      "pulse": true,
+      "review_gate": {
+        "completion_behavior": "strict"
+      }
     }
   ]
 }
@@ -429,6 +437,103 @@ test_two_phase_env_override_respected_non_two_phase() {
 	return 0
 }
 
+# ---------- Unit/integration tests: opt-in strict completion (GH#23066) ----------
+
+install_strict_completion_gh_stub() {
+	local scenario="$1"
+	local gh_stub="${TEST_ROOT}/bin/gh"
+
+	cat >"$gh_stub" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${REVIEW_BOT_GATE_GH_SCENARIO:?}"
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	printf '%s\n' 'abc123def456'
+	exit 0
+fi
+
+if [[ "${1:-}" != "api" ]]; then
+	exit 2
+fi
+
+endpoint="${2:-}"
+case "$endpoint" in
+	repos/testorg/strictrepo/pulls/123/reviews)
+		;;
+	repos/testorg/strictrepo/issues/123/comments)
+		printf '%s\t%s\t%s\n' \
+			'2026-05-07T00:00:00Z' \
+			'2026-05-07T00:00:05Z' \
+			'UmV2aWV3IGNvbXBsZXRlZC4gTG9va3MgZ29vZC4='
+		;;
+	repos/testorg/strictrepo/pulls/123/comments)
+		;;
+	repos/testorg/strictrepo/commits/abc123def456/status?per_page=100)
+		if [[ "$scenario" == "strict-success" ]]; then
+			printf '%s\n' 'CodeRabbit'
+		fi
+		;;
+	repos/testorg/strictrepo/commits/abc123def456/check-runs?per_page=100)
+		;;
+	*)
+		;;
+esac
+EOF
+	chmod +x "$gh_stub"
+	export REVIEW_BOT_GATE_GH_SCENARIO="$scenario"
+	return 0
+}
+
+test_get_completion_behavior_strict_repo() {
+	local behavior
+	behavior=$(_get_completion_behavior 'testorg/strictrepo' 'coderabbitai')
+	if [[ "$behavior" == "strict" ]]; then
+		print_result "completion_behavior resolves strict repo preference" 0
+	else
+		print_result "completion_behavior resolves strict repo preference" 1 \
+			"got '${behavior}', expected 'strict'"
+	fi
+	return 0
+}
+
+test_get_completion_behavior_defaults_fast() {
+	local behavior
+	behavior=$(_get_completion_behavior 'testorg/otherrepo' 'coderabbitai')
+	if [[ "$behavior" == "fast" ]]; then
+		print_result "completion_behavior defaults to fast throughput mode" 0
+	else
+		print_result "completion_behavior defaults to fast throughput mode" 1 \
+			"got '${behavior}', expected 'fast'"
+	fi
+	return 0
+}
+
+test_strict_coderabbit_pending_status_blocks_edited_comment() {
+	install_strict_completion_gh_stub "strict-pending"
+
+	if ! bot_has_real_review 123 'testorg/strictrepo' 'coderabbitai' 2>/dev/null; then
+		print_result "strict CodeRabbit edited comment waits for SUCCESS status" 0
+	else
+		print_result "strict CodeRabbit edited comment waits for SUCCESS status" 1 \
+			"expected strict mode to reject edited-comment evidence without CodeRabbit SUCCESS status"
+	fi
+	return 0
+}
+
+test_strict_coderabbit_success_status_passes_edited_comment() {
+	install_strict_completion_gh_stub "strict-success"
+
+	if bot_has_real_review 123 'testorg/strictrepo' 'coderabbitai' 2>/dev/null; then
+		print_result "strict CodeRabbit accepts edited comment with SUCCESS status" 0
+	else
+		print_result "strict CodeRabbit accepts edited comment with SUCCESS status" 1 \
+			"expected strict mode to accept CodeRabbit SUCCESS status evidence"
+	fi
+	return 0
+}
+
 # ---------- Unit tests: notice category classification (GH#22855) ----------
 
 install_notice_category_gh_stub() {
@@ -660,6 +765,13 @@ main() {
 	test_two_phase_coderabbitai_any_edit_settled
 	test_two_phase_unknown_bot_or_semantics_preserved
 	test_two_phase_env_override_respected_non_two_phase
+
+	echo ""
+	echo "=== Opt-in strict completion (GH#23066) ==="
+	test_get_completion_behavior_strict_repo
+	test_get_completion_behavior_defaults_fast
+	test_strict_coderabbit_pending_status_blocks_edited_comment
+	test_strict_coderabbit_success_status_passes_edited_comment
 
 	echo ""
 	echo "=== Notice category classification (GH#22855) ==="

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -783,7 +783,7 @@ _help_commands() {
 	echo "  inbox [cmd]        Capture transit zone (bare: status | provision/add/find/digest/help)"
 	echo "  email [cmd]        Email mailbox management (mailbox add/list/test/remove)"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
-	echo "  review-gate <cmd>  Configure review_gate.rate_limit_behavior (list/set/unset)"
+	echo "  review-gate <cmd>  Configure review_gate merge policies (rate-limit/completion)"
 	echo "  github-app-auth    GitHub App auth setup/status and API route decisions"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"


### PR DESCRIPTION
## Summary
- Adds `review_gate.completion_behavior` / `REVIEW_GATE_COMPLETION_BEHAVIOR` with default `fast` mode so high-throughput repos remain opt-out from strict review response gating.
- Lets repos or individual bots opt into `strict` completion, requiring two-phase bots such as CodeRabbit to have a SUCCESS status/check before an edited comment counts as a real review.
- Extends `aidevops review-gate` configuration UX and regression coverage for CodeRabbit pending-vs-success status behavior.

## Verification
- `bash -n aidevops.sh .agents/scripts/review-bot-gate-helper.sh .agents/scripts/review-gate-config-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh`
- `shellcheck aidevops.sh .agents/scripts/review-bot-gate-helper.sh .agents/scripts/review-gate-config-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh`
- `bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh` — 33 passed
- Review-gate completion config smoke test against temporary repos.json
- `.agents/scripts/linters-local.sh` progressed through string-literal, secret, TOON, skill, portability gates after fixing the initial string-literal regression; command timed out in the broad repository gates with pre-existing/advisory findings.

Resolves #23066
