### PR TITLE
t3576: fix: avoid redispatch for CI infra-only blockers

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -331,14 +331,18 @@ _dispatch_ci_fix_worker() {
 		--description "Issue carries CI failure feedback routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
 
-	# Collect terminal failed required checks only. Pending/queued/in-progress
+	# Collect actionable failed required checks only. Pending/queued/in-progress
 	# checks are not actionable repair evidence and must not be routed into the
-	# linked issue as stale worker guidance.
+	# linked issue as stale worker guidance. Likewise, cancelled/timed_out checks
+	# usually reflect CI capacity, superseded runs, or job-budget kills; routing
+	# those as code-fix feedback creates duplicate PR churn instead of retrying or
+	# escalating CI infrastructure. Advisory/non-required failures are also not
+	# redispatch evidence: branch protection is the source of truth for merge
+	# blockers.
 	local terminal_failed_check_filter
-	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and ((.conclusion // "") | test("^(failure|cancelled|timed_out|action_required)$")) and ((.link // "") != "")'
-	local required_check_jq advisory_check_jq failing_name_jq
+	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and ((.conclusion // "") | test("^(failure|action_required)$")) and ((.link // "") != "")'
+	local required_check_jq failing_name_jq
 	printf -v required_check_jq '[.[] | select(%s) | "- **\(.name)**: \(.conclusion) — [check URL](\(.link))"] | join("\n")' "$terminal_failed_check_filter"
-	printf -v advisory_check_jq '[.[] | select(%s) | "- **\(.name)** (advisory, not merge-blocking): \(.conclusion) — [check URL](\(.link))"] | join("\n")' "$terminal_failed_check_filter"
 	printf -v failing_name_jq '[.[] | select(%s) | .name] | join("\n")' "$terminal_failed_check_filter"
 
 	local failing_checks
@@ -348,14 +352,7 @@ _dispatch_ci_fix_worker() {
 		2>/dev/null) || failing_checks=""
 
 	if [[ -z "$failing_checks" ]]; then
-		failing_checks=$(gh pr checks "$pr_number" --repo "$repo_slug" \
-			--json name,bucket,conclusion,link \
-			--jq "$advisory_check_jq" \
-			2>/dev/null) || failing_checks=""
-	fi
-
-	if [[ -z "$failing_checks" ]]; then
-		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has no terminal failed checks with URLs — skipping routing" >>"$LOGFILE"
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has no actionable failed required checks with URLs — skipping CI repair routing" >>"$LOGFILE"
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -341,7 +341,7 @@ _dispatch_ci_fix_worker() {
 	# blockers.
 	local terminal_failed_check_filter
 	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and ((.conclusion // "") | test("^(failure|action_required)$")) and ((.link // "") != "")'
-	local required_check_jq failing_name_jq
+	local required_check_jq="" failing_name_jq=""
 	printf -v required_check_jq '[.[] | select(%s) | "- **\(.name)**: \(.conclusion) — [check URL](\(.link))"] | join("\n")' "$terminal_failed_check_filter"
 	printf -v failing_name_jq '[.[] | select(%s) | .name] | join("\n")' "$terminal_failed_check_filter"
 

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -70,27 +70,31 @@ if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 	exit 0
 fi
 
-if [[ "${1:-} ${2:-}" == "pr checks" ]]; then
-	_is_required=0
-	[[ "$*" == *" --required "* || "$*" == *" --required"* ]] && _is_required=1
-	if [[ "$*" == *"| .name]"* ]]; then
-		case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-		terminal_failure:1)
-			printf 'Lint\n'
-			;;
-		esac
-		exit 0
-	fi
+	if [[ "${1:-} ${2:-}" == "pr checks" ]]; then
+		_is_required=0
+		[[ "$*" == *" --required "* || "$*" == *" --required"* ]] && _is_required=1
+		if [[ "$*" == *"| .name]"* ]]; then
+			case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
+			terminal_failure:1)
+				printf 'Lint\n'
+				;;
+			infra_timeout:1 | advisory_failure:*)
+				: ;;
+			esac
+			exit 0
+		fi
 	if [[ "$*" == *"name,bucket,conclusion,link"* ]]; then
 		case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-		terminal_failure:1)
-			printf '%s\n' '- **Lint**: failure — [check URL](https://example.invalid/check)'
-			;;
-		pending_only:*|mixed_pending_pass:*)
-			: ;;
-		advisory_failure:0)
-			printf '%s\n' '- **Docs** (advisory, not merge-blocking): failure — [check URL](https://example.invalid/advisory)'
-			;;
+			terminal_failure:1)
+				printf '%s\n' '- **Lint**: failure — [check URL](https://example.invalid/check)'
+				;;
+			pending_only:*|mixed_pending_pass:*)
+				: ;;
+			infra_timeout:1)
+				: ;;
+			advisory_failure:0)
+				printf '%s\n' '- **Docs** (advisory, not merge-blocking): failure — [check URL](https://example.invalid/advisory)'
+				;;
 		esac
 		exit 0
 	fi
@@ -165,6 +169,7 @@ define_process_helper() {
 	_route_pr_to_fix_worker() { local pr_number="$1" repo_slug="$2" linked_issue="$3" mode="$4"; ROUTE_CALLS=$((ROUTE_CALLS + 1)); ROUTE_ARGS="${pr_number}|${repo_slug}|${linked_issue}|${mode}"; return 0; }
 	_attempt_pr_update_branch() { return 1; }
 	_close_conflicting_pr() { return 0; }
+	_pmp_normalize_mergeable_state_into() { return 0; }
 	printf -v PR_OBJECT '%s' '{"number":100,"mergeable":"MERGEABLE","reviewDecision":"","author":{"login":"worker-bot"},"title":"t1: fix"}'
 
 	# shellcheck disable=SC1090
@@ -241,7 +246,7 @@ test_ci_feedback_skips_pending_only_checks() {
 
 	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
 		print_result "pending-only checks do not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
-	elif ! grep -qF 'no terminal failed checks with URLs' "$LOGFILE"; then
+	elif ! grep -qF 'no actionable failed required checks with URLs' "$LOGFILE"; then
 		print_result "pending-only checks log terminal-failure skip" 1 "Log: $(cat "$LOGFILE")"
 	else
 		print_result "pending-only checks do not emit CI repair feedback" 0
@@ -282,17 +287,33 @@ test_ci_feedback_emits_terminal_failure_with_conclusion_and_url() {
 	return 0
 }
 
-test_ci_feedback_labels_advisory_failure_when_not_required() {
+test_ci_feedback_skips_infra_timeout_checks() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="infra_timeout"
+	define_feedback_helpers || { print_result "defines feedback helpers for infra timeout" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "infra timeout checks do not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	else
+		print_result "infra timeout checks do not emit CI repair feedback" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_skips_advisory_failure_when_not_required() {
 	setup_test_env
 	TEST_CHECK_SCENARIO="advisory_failure"
 	define_feedback_helpers || { print_result "defines feedback helpers for advisory failure" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
 
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
 
-	if ! grep -qF '**Docs** (advisory, not merge-blocking): failure — [check URL](https://example.invalid/advisory)' "${TEST_ROOT}/issue-body.txt"; then
-		print_result "advisory failure is labeled not merge-blocking" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "advisory-only failure does not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
 	else
-		print_result "advisory failure is labeled not merge-blocking" 0
+		print_result "advisory-only failure does not emit CI repair feedback" 0
 	fi
 	teardown_test_env
 	return 0
@@ -304,7 +325,8 @@ main() {
 	test_ci_feedback_skips_pending_only_checks
 	test_ci_feedback_skips_mixed_pending_pass_checks
 	test_ci_feedback_emits_terminal_failure_with_conclusion_and_url
-	test_ci_feedback_labels_advisory_failure_when_not_required
+	test_ci_feedback_skips_infra_timeout_checks
+	test_ci_feedback_skips_advisory_failure_when_not_required
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/TODO.md
+++ b/TODO.md
@@ -952,6 +952,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3560 Add /goals mission command ref:GH#22649 pr:#22650 completed:2026-05-03
 
+- [ ] t3576 Avoid redispatch for CI infra-only blockers #auto-dispatch #bug #framework #pulse #mission:m-20260508-0e27c3 ~2h ref:GH#23135
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/missions/m-20260508-0e27c3/mission.md
+++ b/todo/missions/m-20260508-0e27c3/mission.md
@@ -1,0 +1,204 @@
+---
+id: "m-20260508-0e27c3"
+title: "Make awardsapp issue solving converge to green merged PRs"
+status: active
+mode: full
+repo: "/Users/marcusquinn/Git/aidevops"
+created: "2026-05-08"
+started: "2026-05-08"
+completed: ""
+
+budget:
+  time_hours: 336
+  money_usd: 500
+  token_limit: 0
+  alert_threshold_pct: 80
+
+model_routing:
+  orchestrator: opus
+  workers: sonnet
+  research: haiku
+  validation: sonnet
+
+preferences:
+  tech_stack: [bash, github-actions, typescript, turbo, pnpm]
+  deploy_target: "aidevops local deployment plus awardsapp GitHub CI"
+  test_framework: "ShellCheck, aidevops script tests, awardsapp CI"
+  ci_provider: "GitHub Actions"
+  coding_style: "Follow aidevops AGENTS.md and awardsapp AGENTS.md per repo"
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Make awardsapp issue solving converge to green merged PRs
+
+> Keep improving aidevops and awardsapp until open awardsapp issues can be solved by workers as green PRs that merge, with duplicate/red PR churn systematically reduced.
+
+## Origin
+
+- **Created:** 2026-05-08
+- **Created by:** Marcus Quinn
+- **Session:** OpenCode interactive session
+- **Context:** After aidevops v3.14.97 restored breaker-held issue retries, awardsapp workers produced useful PRs but many issues still had multiple sibling PRs and red CI. The observed blockers are a mix of aidevops orchestration gaps and awardsapp CI/repo policy gaps.
+
+## Scope
+
+**Goal:** awardsapp open issues should steadily converge to one healthy candidate PR per issue, required checks should distinguish code failures from infrastructure/advisory failures, aidevops should avoid duplicate worker churn, and green approved PRs should merge and close issues with evidence.
+
+**Success criteria:**
+
+- Aidevops classifies CI timeouts/kills and advisory E2E failures distinctly from PR-specific code failures.
+- Aidevops suppresses duplicate dispatch when an approved or healthiest PR already exists for the same issue.
+- Aidevops can consolidate/supersede sibling PRs against the verified newest/healthiest candidate.
+- awardsapp CI exposes required vs advisory outcomes clearly enough for workers and merge automation.
+- awardsapp affected lint/typecheck no longer routinely dies by timeout/kill without actionable error output.
+- Open awardsapp worker issues trend toward green merged PRs, verified by PR/issue metrics and sampled check evidence.
+
+**Mode:** full
+
+**Non-goals:**
+
+- Do not bypass security checks or merge untrusted code.
+- Do not hide genuine PR-specific code failures behind advisory labels.
+- Do not force-push or destructively rewrite user work.
+- Do not expose private repo/local paths in public GitHub comments.
+
+**Constraints:**
+
+- Use worktree + PR flow for aidevops and awardsapp code changes.
+- Release/deploy aidevops changes after merge before relying on them operationally.
+- Confirm terminal failed checks before repair feedback; pending CI is not failure.
+- Budget: 2 weeks / $500 cap, pause new dispatch if budget reaches 80%.
+
+## Milestones
+
+### Milestone 1: Establish blocker taxonomy and live dashboard
+
+**Status:** active
+**Estimate:** ~6h
+**Validation:** A repeatable report groups awardsapp open PRs/issues by blocker class: duplicate PR, pending CI, code failure, timeout/kill, advisory E2E, approved merge candidate, needs maintainer/security gate.
+
+| # | Feature | Task ID | Status | Estimate | Worker | PR |
+|---|---------|---------|--------|----------|--------|----|
+| 1.1 | Capture current awardsapp PR/issue blocker inventory and baseline metrics | pending | pending | ~1h | interactive | |
+| 1.2 | Add or improve aidevops reporting for duplicate PR groups and CI blocker classes | pending | pending | ~3h | worker | |
+| 1.3 | Publish mission status summaries with evidence and next recommended action | pending | pending | ~2h | interactive | |
+
+### Milestone 2: Aidevops orchestration fixes
+
+**Status:** pending
+**Estimate:** ~18h
+**Validation:** aidevops no longer treats known CI infra/advisory failures as worker-code failures, avoids duplicate redispatch where a healthy candidate exists, and can close superseded sibling PRs safely.
+
+| # | Feature | Task ID | Status | Estimate | Worker | PR |
+|---|---------|---------|--------|----------|--------|----|
+| 2.1 | Classify CI timeout/kill results such as 143/124/137 as infra-timeout, not implementation failure | pending | pending | ~4h | worker | |
+| 2.2 | Model E2E-only shard failures as advisory/quarantine when repo policy marks core gates green | pending | pending | ~4h | worker | |
+| 2.3 | Deduplicate dispatch against existing approved/mergeable sibling PRs for the same issue | pending | pending | ~5h | worker | |
+| 2.4 | Add safe superseded-PR consolidation against the newest/healthiest verified candidate | pending | pending | ~5h | worker | |
+
+### Milestone 3: awardsapp CI and repo policy fixes
+
+**Status:** pending
+**Estimate:** ~24h
+**Validation:** awardsapp PR checks provide actionable failures, affected lint/typecheck complete reliably, and E2E advisory/required policy is explicit in CI summaries and branch protection behaviour.
+
+| # | Feature | Task ID | Status | Estimate | Worker | PR |
+|---|---------|---------|--------|----------|--------|----|
+| 3.1 | Split awardsapp required core checks from advisory/quarantined E2E with clear CI summary output | pending | pending | ~8h | worker | |
+| 3.2 | Reduce affected turbo lint/typecheck timeout deaths with narrower package/path routing or higher targeted timeout | pending | pending | ~8h | worker | |
+| 3.3 | Add CI failure summaries that distinguish code error, timeout, infrastructure, and advisory E2E | pending | pending | ~5h | worker | |
+| 3.4 | Document awardsapp worker merge policy for approved PRs with core gates green and advisory E2E red | pending | pending | ~3h | worker | |
+
+### Milestone 4: Consolidate current awardsapp backlog
+
+**Status:** pending
+**Estimate:** ~24h
+**Validation:** existing duplicate PR groups are reduced to one active candidate per issue, obsolete siblings are closed with evidence, and ready candidates are merged or converted into actionable follow-up tasks.
+
+| # | Feature | Task ID | Status | Estimate | Worker | PR |
+|---|---------|---------|--------|----------|--------|----|
+| 4.1 | Consolidate duplicate PR groups for issues with multiple sibling PRs | pending | pending | ~8h | interactive/worker | |
+| 4.2 | Repair top red PRs whose failures are PR-specific and actionable | pending | pending | ~10h | worker | |
+| 4.3 | Rerun/escalate CI-only timeout/advisory blockers instead of redispatching new code workers | pending | pending | ~4h | interactive/automation | |
+| 4.4 | Merge approved green candidates and verify linked issues close | pending | pending | ~2h | pulse/interactive | |
+
+### Milestone 5: Monitor convergence and iterate
+
+**Status:** pending
+**Estimate:** ~16h
+**Validation:** dashboard shows decreasing duplicate groups/red PRs, increasing merged worker PRs, and fewer worker failures caused by timeout/rate-limit/no-work loops.
+
+| # | Feature | Task ID | Status | Estimate | Worker | PR |
+|---|---------|---------|--------|----------|--------|----|
+| 5.1 | Monitor worker starts, PR creation, CI outcomes, merges, and issue closures after each release/deploy | pending | pending | ~6h | interactive | |
+| 5.2 | Store lessons and update aidevops worker discipline/configs from observed failure modes | pending | pending | ~4h | interactive/worker | |
+| 5.3 | Repeat release/deploy/monitor loop until remaining blockers are maintainer/security/business decisions | pending | pending | ~6h | interactive | |
+
+## Resources
+
+| Name | Type | Purpose | Status | Notes |
+|------|------|---------|--------|-------|
+| GitHub CLI access | credential | Read/write PRs/issues/checks in aidevops and awardsapp | configured | Use gh wrappers/signature discipline for writes |
+| aidevops release pipeline | infrastructure | Ship systemic orchestration fixes | configured | version-manager release patch/hotfix after merge |
+| awardsapp CI | infrastructure | Validate worker PRs and classify blockers | active | GitHub Actions |
+
+## Budget Tracking
+
+| Category | Budget | Spent | Remaining | % Used |
+|----------|--------|-------|-----------|--------|
+| Time (hours) | 336h | 0h | 336h | 0% |
+| Money (USD)  | $500 | $0 | $500 | 0% |
+| Tokens       | unlimited | tracked per session | unlimited | n/a |
+
+| Date | Category | Amount | Description | Milestone |
+|------|----------|--------|-------------|-----------|
+| 2026-05-08 | time | initial | Mission created and scoped from current awardsapp/aidevops evidence | 1 |
+
+## Decision Log
+
+| # | Date | Decision | Rationale | Alternatives Considered |
+|---|------|----------|-----------|------------------------|
+| 1 | 2026-05-08 | Treat this as a mixed aidevops + awardsapp mission | Evidence shows both orchestration duplicate/red-PR churn and awardsapp CI timeout/advisory ambiguity | Only fix aidevops; only fix awardsapp |
+| 2 | 2026-05-08 | Prioritize required/advisory CI clarity before broad worker redispatch | Duplicate workers burn tokens when the existing PR is approved but blocked by CI semantics | Continue redispatching until one PR happens to pass |
+
+## Mission Agents
+
+| Agent | Purpose | Path | Promote? |
+|-------|---------|------|----------|
+| | | | pending |
+
+## Research
+
+| Topic | Summary | Source | Date |
+|-------|---------|--------|------|
+| awardsapp PR blocker sample | Multiple issues have sibling PRs; many failures are E2E shard or timeout/kill rather than code errors. Examples include PRs #4594/#4595 timeout/kill and #4596 merging after core gates passed. | gh PR/check queries in current session | 2026-05-08 |
+
+## Progress Log
+
+| Timestamp | Event | Details |
+|-----------|-------|---------|
+| 2026-05-08T00:00:00Z | Mission created | Goal: keep improving aidevops and awardsapp until open issues converge to green merged PRs. |
+
+## Retrospective
+
+_Completed after mission finishes._
+
+- **Outcomes:** pending
+- **Lessons learned:** pending
+- **Framework improvements:** pending
+
+### Budget Accuracy
+
+| Category | Budgeted | Actual | Variance |
+|----------|----------|--------|----------|
+| Time | 336h | | |
+| Money | $500 | | |
+| Tokens | unlimited | | |
+
+### Skill Learning
+
+| Artifact | Type | Score | Promoted To | Notes |
+|----------|------|-------|-------------|-------|
+| | | | | |

--- a/todo/missions/m-20260508-0e27c3/mission.md
+++ b/todo/missions/m-20260508-0e27c3/mission.md
@@ -81,8 +81,8 @@ preferences:
 
 | # | Feature | Task ID | Status | Estimate | Worker | PR |
 |---|---------|---------|--------|----------|--------|----|
-| 1.1 | Capture current awardsapp PR/issue blocker inventory and baseline metrics | pending | pending | ~1h | interactive | |
-| 1.2 | Add or improve aidevops reporting for duplicate PR groups and CI blocker classes | pending | pending | ~3h | worker | |
+| 1.1 | Capture current awardsapp PR/issue blocker inventory and baseline metrics | pending | active | ~1h | interactive | |
+| 1.2 | Add or improve aidevops reporting for duplicate PR groups and CI blocker classes | pending | active | ~3h | interactive | |
 | 1.3 | Publish mission status summaries with evidence and next recommended action | pending | pending | ~2h | interactive | |
 
 ### Milestone 2: Aidevops orchestration fixes
@@ -93,8 +93,8 @@ preferences:
 
 | # | Feature | Task ID | Status | Estimate | Worker | PR |
 |---|---------|---------|--------|----------|--------|----|
-| 2.1 | Classify CI timeout/kill results such as 143/124/137 as infra-timeout, not implementation failure | pending | pending | ~4h | worker | |
-| 2.2 | Model E2E-only shard failures as advisory/quarantine when repo policy marks core gates green | pending | pending | ~4h | worker | |
+| 2.1 | Classify CI timeout/kill results such as 143/124/137 as infra-timeout, not implementation failure | pending | active | ~4h | interactive | |
+| 2.2 | Model E2E-only shard failures as advisory/quarantine when repo policy marks core gates green | pending | active | ~4h | interactive | |
 | 2.3 | Deduplicate dispatch against existing approved/mergeable sibling PRs for the same issue | pending | pending | ~5h | worker | |
 | 2.4 | Add safe superseded-PR consolidation against the newest/healthiest verified candidate | pending | pending | ~5h | worker | |
 
@@ -162,6 +162,7 @@ preferences:
 |---|------|----------|-----------|------------------------|
 | 1 | 2026-05-08 | Treat this as a mixed aidevops + awardsapp mission | Evidence shows both orchestration duplicate/red-PR churn and awardsapp CI timeout/advisory ambiguity | Only fix aidevops; only fix awardsapp |
 | 2 | 2026-05-08 | Prioritize required/advisory CI clarity before broad worker redispatch | Duplicate workers burn tokens when the existing PR is approved but blocked by CI semantics | Continue redispatching until one PR happens to pass |
+| 3 | 2026-05-08 | First aidevops change should stop CI repair redispatch for infra/advisory failures | `pulse-merge-feedback.sh` routed advisory/non-required and timed-out/cancelled checks as CI repair feedback, which closes PRs and requeues duplicate workers | Start with awardsapp CI changes only |
 
 ## Mission Agents
 
@@ -174,12 +175,14 @@ preferences:
 | Topic | Summary | Source | Date |
 |-------|---------|--------|------|
 | awardsapp PR blocker sample | Multiple issues have sibling PRs; many failures are E2E shard or timeout/kill rather than code errors. Examples include PRs #4594/#4595 timeout/kill and #4596 merging after core gates passed. | gh PR/check queries in current session | 2026-05-08 |
+| current open PR sample | Open approved/mergeable PRs include #4594, #4595, #4599, #4584 and others; several have Lint/Typecheck pending while prior logs showed timeout/kill symptoms. | `gh pr view/list` in current session | 2026-05-08 |
 
 ## Progress Log
 
 | Timestamp | Event | Details |
 |-----------|-------|---------|
 | 2026-05-08T00:00:00Z | Mission created | Goal: keep improving aidevops and awardsapp until open issues converge to green merged PRs. |
+| 2026-05-08T01:10:00Z | First systemic fix implemented locally | Updated `pulse-merge-feedback.sh` so CI repair feedback only re-dispatches actionable failed required checks; timed_out/cancelled/advisory-only failures now skip CI repair routing. Verified with `test-pulse-merge-ci-repair-routing.sh` and ShellCheck. |
 
 ## Retrospective
 

--- a/todo/tasks/t3576-brief.md
+++ b/todo/tasks/t3576-brief.md
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t3576: Avoid redispatch for CI infra-only blockers
+
+## Goal
+
+Reduce duplicate worker PR churn by ensuring aidevops only routes CI repair feedback when a PR has actionable failed required checks. CI timeout/cancellation/advisory-only failures should remain blocked for retry/escalation/monitoring rather than closing the PR and redispatching another implementation worker.
+
+## Context
+
+The awardsapp convergence mission found many approved worker PRs blocked by CI timeout, kill, or advisory E2E failures rather than PR-specific code defects. Existing `pulse-merge-feedback.sh` treated `cancelled`, `timed_out`, and advisory/non-required failures as CI repair evidence, which closed PRs and requeued issues for duplicate worker attempts.
+
+## Files
+
+- `.agents/scripts/pulse-merge-feedback.sh`
+- `.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
+- `todo/missions/m-20260508-0e27c3/mission.md`
+
+## Implementation Notes
+
+- Keep pending/queued/in-progress checks non-terminal.
+- Treat only actionable failed required checks (`failure`, `action_required`) as CI repair feedback.
+- Skip repair routing for `timed_out`, `cancelled`, and advisory/non-required failures.
+- Preserve fail-open behavior: if no actionable failed required check URL is available, do not close the PR.
+
+## Verification
+
+- `.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
+- `shellcheck .agents/scripts/pulse-merge-feedback.sh .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
+- `.agents/scripts/linters-local.sh` for broader gates; note any repo-wide timeout separately.


### PR DESCRIPTION
## Summary
- Adds mission state for the awardsapp green-PR convergence goal with milestones, budget, and evidence tracking.
- Narrows CI repair feedback routing so aidevops only re-dispatches on actionable failed required checks.
- Skips CI repair redispatch for timed-out/cancelled infra blockers and advisory/non-required failures, reducing duplicate PR churn.

## Verification
- `.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
- `shellcheck .agents/scripts/pulse-merge-feedback.sh .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
- `.agents/scripts/linters-local.sh` progressed through core gates and later timed out during repository-wide portability checks; no changed-file ShellCheck/Bash 3.2 regressions were reported before timeout.

Resolves #23135

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.97 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2h 20m and 1,202,043 tokens on this with the user in an interactive session.
