### PR TITLE
t3577: Default RTK token optimization setup

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -253,26 +253,31 @@ setup_file_discovery_tools() {
 
 setup_rtk() {
 	# rtk — CLI proxy that reduces LLM token consumption by 60-90% (t1430)
-	# Optional optimization: compresses git/gh/test outputs before they reach LLM context
+	# Opinionated default optimization: compresses git/gh/test outputs before they reach LLM context
 	# Single Rust binary, zero dependencies, <10ms overhead
 	# https://github.com/rtk-ai/rtk
 
 	# Pin to a tagged release for stability and auditability (Gemini review feedback).
 	# Update the tag when upstream-watch detects a new release.
-	local rtk_installer_url="https://raw.githubusercontent.com/rtk-ai/rtk/v0.28.2/install.sh"
+	local rtk_supported_version="0.39.0"
+	local rtk_installer_url="https://raw.githubusercontent.com/rtk-ai/rtk/v${rtk_supported_version}/install.sh"
 
 	if command -v rtk >/dev/null 2>&1; then
 		local rtk_version
 		rtk_version=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
 		print_success "rtk found: v$rtk_version (token optimization proxy)"
+		if [[ "$rtk_version" != "unknown" && "$rtk_version" != "$rtk_supported_version" ]]; then
+			print_info "rtk supported by this aidevops release: v$rtk_supported_version"
+			print_info "Run 'brew upgrade rtk' or re-run setup if you want the pinned aidevops-tested version."
+		fi
 		# Fall through to ensure config is applied (telemetry, tee)
 	else
 		print_info "rtk (Rust Token Killer) reduces LLM token usage by 60-90% on CLI commands"
 		echo "  Compresses git, gh, test runner, and linter outputs before they reach the AI context."
-		echo "  Single binary, zero dependencies, <10ms overhead."
+		echo "  Single binary, zero dependencies, <10ms overhead. Installed by default; answer 'n' to skip."
 		echo ""
 
-		setup_prompt install_rtk "Install rtk for token-optimized CLI output? [y/N]: " "n"
+		setup_prompt install_rtk "Install rtk for token-optimized CLI output? [Y/n]: " "y"
 
 		# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
 		if [[ "$install_rtk" =~ ^[Yy]$ ]]; then
@@ -298,7 +303,7 @@ setup_rtk() {
 				fi
 			fi
 		else
-			print_info "Skipped rtk installation (optional)"
+			print_info "Skipped rtk installation"
 			echo "  Manual install: brew install rtk  OR  curl -fsSL $rtk_installer_url | sh"
 		fi
 	fi

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops
 - Install the `aidevops` CLI command
 - Configure your AI assistants automatically
 - Offer to install Oh My Zsh (optional, opt-in) for enhanced shell experience
+- Install recommended token-efficiency tooling by default, including RTK for compact `git`/`gh`/test/lint command summaries before output reaches AI context
 - Guide you through recommended tools (Tabby, Zed, Git CLIs)
 - Ensure all PATH and alias changes work in both bash, zsh, and fish
 - When Claude Code is installed, add a `claude` alias that runs `claude --dangerously-skip-permissions` (skips per-tool permission prompts). Re-running setup updates the alias automatically. To grant permissions per-session instead, press **Shift-Tab** inside Claude Code to cycle through permission modes (default → skip permissions → auto-approve).
@@ -724,6 +725,7 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 | **Evolve Context** | Learn from sessions | `/remember`, `/recall` with SQLite FTS5 + opt-in semantic search |
 | **Pattern Tracking** | Learn what works/fails | `/patterns` command, `memory-helper.sh` |
 | **Token-Efficient Serialisation** | Minimise context overhead for structured data | [TOON format](https://github.com/marcusquinn/aidevops/blob/main/.agents/toon-format.md) — 20-60% token reduction vs JSON/YAML for agent indexes, registries, and data exchange |
+| **Token-Efficient Tool Output** | Summarise noisy terminal output without hiding evidence | RTK is installed by default during setup for compact `git`/`gh`/test/lint summaries; aidevops bypasses compression for file reads, JSON assertions, exact diffs, security scans, and other verbatim evidence |
 | **Cost-Aware Routing** | Match model to task complexity | `model-routing.md` with provider-aware tier guidance, `/route` command |
 | **Model Comparison** | Compare models side-by-side | `/compare-models` (live data), `/compare-models-free` (offline) |
 | **Response Scoring** | Evaluate actual model outputs | `/score-responses` with structured criteria |


### PR DESCRIPTION
## Summary
- Install the pinned RTK token optimizer by default during setup while preserving explicit opt-out.
- Document the RTK token-efficiency behaviour and evidence-preserving bypasses in README.

## Verification
- `shellcheck .agents/scripts/setup/modules/tool-install.sh`
- `bash -n .agents/scripts/setup/modules/tool-install.sh`
- `git diff --check`

Resolves #23136
Ref #23137


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.97 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2d 3h and 211,011 tokens on this with the user in an interactive session.
