### PR TITLE
fix: wrap explicit rtk commands

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -158,7 +158,7 @@ Run `aidevops security` for posture/scan/check/dismiss. Advisories arrive via `a
 ## Maintenance
 
 - Self-improvement guidance: `reference/self-improvement.md`.
-- Token-optimized CLI: use `rtk` for `git status/log/diff` and `gh pr list/view` when installed; not for file reads, JSON, assertions, or verbatim diffs.
+- Token-optimized CLI: use `rtk-helper.sh` for `git status/log/diff` and `gh pr list/view` when installed; not for file reads, JSON, assertions, or verbatim diffs.
 - Agent lifecycle: `tools/build-agent/build-agent.md`; OpenCode glob allowlists require `subagent_validation.py` verification.
 - Slash commands resolve through `scripts/commands/<command>.md`, then `workflows/<command>.md`.
 - macOS bash upgrade, platform support, customization, and hot deploys: `reference/bash-compat.md`, `reference/platform-support.md`, `reference/customization.md`, `reference/hot-deploy.md`.

--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# rtk-helper.sh - Run RTK explicit commands without repeated no-hook advisory noise
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+LOG_PREFIX="RTK"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  rtk-helper.sh COMMAND [ARGS...]
+
+Runs `rtk COMMAND [ARGS...]` for explicit token-optimized commands and strips
+RTK's repeated no-hook advisory from output. Exit status is preserved.
+
+Use only for supported noisy summaries such as:
+  rtk-helper.sh git status
+  rtk-helper.sh git log --oneline -20
+  rtk-helper.sh gh pr list --repo owner/repo
+
+Do not use for file reads, JSON assertions, security scans, exact/verbatim diffs,
+or credential-sensitive output.
+EOF
+	return 0
+}
+
+filter_rtk_advisory() {
+	local input_file="$1"
+	python3 - "$input_file" <<'PY'
+import sys
+path = sys.argv[1]
+needle = "[rtk] /!\\ No hook installed — run `rtk init -g` for automatic token savings"
+with open(path, "r", encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        if line.rstrip("\n") == needle:
+            continue
+        sys.stdout.write(line)
+PY
+	return 0
+}
+
+main() {
+	if [[ $# -eq 0 ]]; then
+		usage
+		return 0
+	fi
+
+	case "${1:-}" in
+	--help | -h | help)
+		usage
+		return 0
+		;;
+	esac
+
+	if ! command -v rtk >/dev/null 2>&1; then
+		log_error "rtk not found; run setup.sh or install RTK first"
+		return 127
+	fi
+
+	local tmp_output
+	tmp_output=$(mktemp "${TMPDIR:-/tmp}/aidevops-rtk.XXXXXX")
+	trap 'rm -f "${tmp_output:-}"' EXIT
+
+	local rc=0
+	set +e
+	rtk "$@" >"$tmp_output" 2>&1
+	rc=$?
+	set -e
+
+	filter_rtk_advisory "$tmp_output"
+	return "$rc"
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-rtk-helper.sh
+++ b/.agents/scripts/tests/test-rtk-helper.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../rtk-helper.sh"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass_count=0
+fail_count=0
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL: %s%s\n' "$name" "${detail:+ — $detail}"
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing ${needle}"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "unexpected ${needle}"
+	fi
+	return 0
+}
+
+cat >"${TMPDIR_TEST}/rtk" <<'STUB'
+#!/usr/bin/env bash
+printf '[rtk] /!\ No hook installed — run `rtk init -g` for automatic token savings\n'
+if [[ "${1:-}" == "fail" ]]; then
+  printf 'failure body\n'
+  exit 7
+fi
+printf 'payload: %s\n' "$*"
+STUB
+chmod +x "${TMPDIR_TEST}/rtk"
+
+PATH="${TMPDIR_TEST}:$PATH" output=$("$HELPER" git status)
+assert_not_contains "strips no-hook advisory" "No hook installed" "$output"
+assert_contains "preserves useful output" "payload: git status" "$output"
+
+set +e
+PATH="${TMPDIR_TEST}:$PATH" fail_output=$("$HELPER" fail 2>&1)
+fail_rc=$?
+set -e
+if [[ "$fail_rc" -eq 7 ]]; then
+	pass "preserves rtk exit code"
+else
+	fail "preserves rtk exit code" "got ${fail_rc}"
+fi
+assert_contains "preserves failure output" "failure body" "$fail_output"
+assert_not_contains "strips advisory on failure" "No hook installed" "$fail_output"
+
+printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
+if [[ "$fail_count" -ne 0 ]]; then
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 | **Evolve Context** | Learn from sessions | `/remember`, `/recall` with SQLite FTS5 + opt-in semantic search |
 | **Pattern Tracking** | Learn what works/fails | `/patterns` command, `memory-helper.sh` |
 | **Token-Efficient Serialisation** | Minimise context overhead for structured data | [TOON format](https://github.com/marcusquinn/aidevops/blob/main/.agents/toon-format.md) — 20-60% token reduction vs JSON/YAML for agent indexes, registries, and data exchange |
-| **Token-Efficient Tool Output** | Summarise noisy terminal output without hiding evidence | RTK is installed by default during setup for compact `git`/`gh`/test/lint summaries; aidevops bypasses compression for file reads, JSON assertions, exact diffs, security scans, and other verbatim evidence |
+| **Token-Efficient Tool Output** | Summarise noisy terminal output without hiding evidence | RTK is installed by default during setup; use `rtk-helper.sh` for compact `git`/`gh`/test/lint summaries without RTK hook-advisory noise; aidevops bypasses compression for file reads, JSON assertions, exact diffs, security scans, and other verbatim evidence |
 | **Cost-Aware Routing** | Match model to task complexity | `model-routing.md` with provider-aware tier guidance, `/route` command |
 | **Model Comparison** | Compare models side-by-side | `/compare-models` (live data), `/compare-models-free` (offline) |
 | **Response Scoring** | Evaluate actual model outputs | `/score-responses` with structured criteria |


### PR DESCRIPTION
## Summary
- Add `rtk-helper.sh` for explicit token-optimized RTK commands while stripping only the repeated no-hook advisory.
- Preserve RTK command output and exit status, including failure output, with focused regression coverage.
- Update aidevops guidance to prefer the wrapper for supported noisy `git`/`gh` summaries while keeping verbatim-output bypasses intact.

## Files
- `.agents/scripts/rtk-helper.sh`
- `.agents/scripts/tests/test-rtk-helper.sh`
- `.agents/AGENTS.md`
- `README.md`

## Verification
- `shellcheck .agents/scripts/rtk-helper.sh .agents/scripts/tests/test-rtk-helper.sh`
- `bash -n .agents/scripts/rtk-helper.sh`
- `bash -n .agents/scripts/tests/test-rtk-helper.sh`
- `.agents/scripts/tests/test-rtk-helper.sh`
- `git diff --check origin/main...HEAD`

Resolves #23142

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.0 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2d 4h and 651,391 tokens on this with the user in an interactive session.
