### PR TITLE
GH#23116: add scoped setup deploy commands

### DIFF
--- a/.agents/aidevops/setup.md
+++ b/.agents/aidevops/setup.md
@@ -21,11 +21,35 @@ tools:
 - **Script**: `~/Git/aidevops/setup.sh`
 - **Run**: `cd ~/Git/aidevops && ./setup.sh`
 - **Update**: `git pull && ./setup.sh` (backs up existing configs automatically)
+- **Scoped deploy**: `./setup.sh --stage agents` or `aidevops setup --scope agents`
 - **Agents**: `~/.aidevops/agents/` | **Backups**: `~/.aidevops/config-backups/` | **Credentials**: `~/.config/aidevops/credentials.sh`
 
 **What setup.sh does**: checks required deps (`jq`, `curl`, `ssh`, `sqlite3`) and optional deps (`sshpass`, `gh`, `glab`, `tea`); copies `.agents/` → `~/.aidevops/agents/` with timestamped config backups; injects AGENTS.md pointer into `~/.opencode/AGENTS.md`, `~/.cursor/AGENTS.md`, `~/.claude/AGENTS.md`, `~/.config/cursor/AGENTS.md`; updates OpenCode agent paths in `~/.config/opencode/opencode.json`.
 
 **Deployed structure**: `~/.aidevops/agents/` (AGENTS.md, aidevops/, tools/, services/, workflows/, scripts/) + `~/.aidevops/config-backups/[YYYYMMDD_HHMMSS]/`
+
+## Scoped Setup / Deploy
+
+Use full setup for first installs, migrations, config schema changes, or broad release validation:
+
+```bash
+./setup.sh --non-interactive
+aidevops setup --scope full
+```
+
+Use scoped setup when the change is isolated and a full deploy would add avoidable time or lock-wait surface:
+
+| Change type | Minimal command |
+|---|---|
+| Agent/script-only change | `./setup.sh --stage agents` or `aidevops setup --scope agents` |
+| OpenCode CLI/shim/setup logic | `./setup.sh --stage opencode` or `aidevops setup --scope opencode` |
+| Hook change | `./setup.sh --stage hooks` or `aidevops setup --scope hooks` |
+| Tabby profile change | `./setup.sh --stage tabby` or `aidevops setup --scope tabby` |
+| launchd/routine/pulse plist change | `./setup.sh --stage pulse` or `aidevops setup --scope pulse` |
+
+`./setup.sh --stage` also accepts the canonical stage names: `setup_opencode_cli`,
+`deploy_aidevops_agents`, `setup_safety_hooks`, `setup_tabby`, and
+`setup_supervisor_pulse`. Unknown stages fail non-zero and print the valid list.
 
 ## Manual Configuration
 

--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="${SCRIPT_DIR}/../../.."
+SETUP_SH="${REPO_ROOT}/setup.sh"
+AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '     %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_contains() {
+	local test_name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		print_result "$test_name" 0
+		return 0
+	fi
+	print_result "$test_name" 1 "missing: $needle"
+	return 0
+}
+
+file_text() {
+	local path="$1"
+	python3 - "$path" <<'PY'
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).read_text())
+PY
+	return $?
+}
+
+test_setup_stage_contract() {
+	local text=""
+	text="$(file_text "$SETUP_SH")" || {
+		print_result "setup.sh is readable" 1 "$SETUP_SH"
+		return 0
+	}
+
+	assert_contains "setup.sh accepts --stage" "$text" "--stage <name>"
+	assert_contains "opencode scope maps to setup_opencode_cli" "$text" "opencode | \"\$SETUP_STAGE_OPENCODE\") printf '%s' \"\$SETUP_STAGE_OPENCODE\""
+	assert_contains "agents scope maps to deploy_aidevops_agents" "$text" "agents | \"\$SETUP_STAGE_AGENTS\") printf '%s' \"\$SETUP_STAGE_AGENTS\""
+	assert_contains "hooks scope maps to setup_safety_hooks" "$text" "hooks | \"\$SETUP_STAGE_HOOKS\") printf '%s' \"\$SETUP_STAGE_HOOKS\""
+	assert_contains "tabby scope maps to setup_tabby" "$text" "tabby | \"\$SETUP_STAGE_TABBY\") printf '%s' \"\$SETUP_STAGE_TABBY\""
+	assert_contains "pulse scope maps to setup_supervisor_pulse" "$text" "pulse | \"\$SETUP_STAGE_PULSE\") printf '%s' \"\$SETUP_STAGE_PULSE\""
+	assert_contains "unknown stages print actionable help" "$text" "Unknown setup stage/scope"
+	return 0
+}
+
+test_cli_scope_contract() {
+	local text=""
+	text="$(file_text "$AIDEVOPS_SH")" || {
+		print_result "aidevops.sh is readable" 1 "$AIDEVOPS_SH"
+		return 0
+	}
+
+	assert_contains "aidevops exposes setup command" "$text" "setup) cmd_setup \"\$@\" ;;"
+	assert_contains "aidevops setup requires scope" "$text" "Usage: aidevops setup --scope <scope>"
+	assert_contains "aidevops setup passes scope to setup.sh" "$text" "bash \"\$setup_script\" --stage \"\$scope\""
+	assert_contains "aidevops setup full preserves full setup" "$text" "bash \"\$setup_script\" --non-interactive"
+	return 0
+}
+
+main() {
+	test_setup_stage_contract
+	test_cli_scope_contract
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -749,11 +749,76 @@ cmd_detect() {
 	return 0
 }
 
+_cmd_setup_help() {
+	printf '%s\n' "Usage: aidevops setup --scope <scope>"
+	printf '%s\n' ""
+	printf '%s\n' "Scopes:"
+	printf '%s\n' "  opencode  Repair/install the OpenCode CLI only"
+	printf '%s\n' "  agents    Deploy aidevops agents/scripts only"
+	printf '%s\n' "  hooks     Install safety hooks only"
+	printf '%s\n' "  tabby     Sync Tabby terminal profiles only"
+	printf '%s\n' "  pulse     Install/refresh the pulse scheduler only"
+	printf '%s\n' "  full      Run ./setup.sh --non-interactive"
+	return 0
+}
+
+cmd_setup() {
+	local scope=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--scope)
+			if [[ -z "${2:-}" ]]; then
+				print_error "--scope requires a value"
+				_cmd_setup_help
+				return 1
+			fi
+			scope="$2"
+			shift 2
+			;;
+		--scope=*)
+			scope="${arg#--scope=}"
+			shift
+			;;
+		help | --help | -h)
+			_cmd_setup_help
+			return 0
+			;;
+		*)
+			print_error "Unknown setup option: $arg"
+			_cmd_setup_help
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$scope" ]]; then
+		print_error "Missing required --scope value"
+		_cmd_setup_help
+		return 1
+	fi
+
+	local setup_script="${INSTALL_DIR}/setup.sh"
+	if [[ ! -f "$setup_script" ]]; then
+		print_error "setup.sh not found at $setup_script"
+		return 1
+	fi
+
+	if [[ "$scope" == "full" ]]; then
+		bash "$setup_script" --non-interactive
+		return $?
+	fi
+
+	bash "$setup_script" --stage "$scope"
+	return $?
+}
+
 
 # Help text helpers (extracted for complexity reduction)
 _help_commands() {
 	echo "Commands:"
 	echo "  init [features]    Initialize aidevops in current project"
+	echo "  setup --scope <s>  Run scoped setup/deploy (opencode, agents, hooks, tabby, pulse, full)"
 	echo "  init-routines      Scaffold private routines repo (--org <name> | --local)"
 	echo "  upgrade-planning   Upgrade TODO.md/PLANS.md to latest templates"
 	echo "  features           List available features for init"
@@ -1408,6 +1473,7 @@ main() {
 	shift || true
 	case "$command" in
 	init | i) cmd_init "$@" ;;
+	setup) cmd_setup "$@" ;;
 	features | f) cmd_features ;;
 	status | s) cmd_status ;;
 	update | upgrade | u) cmd_update "$@" ;;

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,13 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
+SETUP_STAGE=""
+SETUP_STAGE_OPENCODE="setup_opencode_cli"
+SETUP_STAGE_AGENTS="deploy_aidevops_agents"
+SETUP_STAGE_HOOKS="setup_safety_hooks"
+SETUP_STAGE_TABBY="setup_tabby"
+SETUP_STAGE_PULSE="setup_supervisor_pulse"
+SETUP_OS_DARWIN="Darwin"
 # Python compatibility floor used by setup checks and skill/tool gating.
 # Keep in sync with .agents/scripts/setup/modules/plugins.sh requirements.
 PYTHON_REQUIRED_MAJOR=3
@@ -38,7 +45,7 @@ PYTHON_REQUIRED_MINOR=10
 export PYTHON_REQUIRED_MAJOR PYTHON_REQUIRED_MINOR
 # Platform constants — exported for sourced .agents/scripts/setup/modules (shell-env.sh,
 # tool-install.sh) that reference them at runtime.
-PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
+PLATFORM_MACOS=$([[ "$(uname -s)" == "$SETUP_OS_DARWIN" ]] && echo true || echo false)
 PLATFORM_ARM64=$([[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]] && echo true || echo false)
 export PLATFORM_MACOS PLATFORM_ARM64
 readonly PLATFORM_MACOS PLATFORM_ARM64
@@ -236,7 +243,7 @@ if [[ ! -d "$_setup_script_dir/.agents/scripts/setup/modules" ]]; then
 
 	# Auto-install git if missing
 	if ! command -v git >/dev/null 2>&1; then
-		if [[ "$(uname)" == "Darwin" ]]; then
+		if [[ "$(uname)" == "$SETUP_OS_DARWIN" ]]; then
 			print_info "Installing Xcode Command Line Tools (includes git)..."
 			xcode-select --install 2>/dev/null || true
 			xcode_wait=0
@@ -346,6 +353,26 @@ parse_args() {
 			UPDATE_TOOLS_MODE=true
 			shift
 			;;
+		--stage)
+			if [[ -z "${2:-}" ]]; then
+				print_error "--stage requires a value"
+				_setup_print_stage_help
+				exit 1
+			fi
+			SETUP_STAGE="$2"
+			NON_INTERACTIVE=true
+			shift 2
+			;;
+		--stage=*)
+			SETUP_STAGE="${_opt#--stage=}"
+			if [[ -z "$SETUP_STAGE" ]]; then
+				print_error "--stage requires a value"
+				_setup_print_stage_help
+				exit 1
+			fi
+			NON_INTERACTIVE=true
+			shift
+			;;
 		--help | -h)
 			echo "Usage: ./setup.sh [OPTIONS]"
 			echo ""
@@ -353,6 +380,7 @@ parse_args() {
 			echo "  --clean            Remove stale files before deploying (cleans ~/.aidevops/agents/)"
 			echo "  --interactive, -i  Ask confirmation before each step"
 			echo "  --non-interactive, -n  Deploy agents only, skip all optional installs (no prompts)"
+			echo "  --stage <name>     Run one supported setup stage/scope without full setup"
 			echo "  --update, -u       Check for and offer to update outdated tools after setup"
 			echo "  --help             Show this help message"
 			echo ""
@@ -360,6 +388,8 @@ parse_args() {
 			echo "Use --clean after removing or renaming agents to sync deletions."
 			echo "Use --interactive to control each step individually."
 			echo "Use --non-interactive for CI/CD or AI agent shells (no stdin required)."
+			echo "Use --stage for targeted updates: opencode, agents, hooks, tabby, pulse, full."
+			echo "Stage aliases: ${SETUP_STAGE_OPENCODE}, ${SETUP_STAGE_AGENTS}, ${SETUP_STAGE_HOOKS}, ${SETUP_STAGE_TABBY}, ${SETUP_STAGE_PULSE}."
 			echo "Use --update to check for tool updates after setup completes."
 			exit 0
 			;;
@@ -370,7 +400,45 @@ parse_args() {
 			;;
 		esac
 	done
+	if [[ -n "$SETUP_STAGE" ]]; then
+		_setup_validate_stage "$SETUP_STAGE" || exit $?
+	fi
 	return 0
+}
+
+_setup_print_stage_help() {
+	printf '%s\n' "Supported setup stages/scopes:"
+	printf '  opencode | %s          Repair/install OpenCode CLI only\n' "$SETUP_STAGE_OPENCODE"
+	printf '  agents   | %s     Deploy .agents scripts/prompts only\n' "$SETUP_STAGE_AGENTS"
+	printf '  hooks    | %s          Install safety hooks only\n' "$SETUP_STAGE_HOOKS"
+	printf '  tabby    | %s                 Sync Tabby profiles only\n' "$SETUP_STAGE_TABBY"
+	printf '  pulse    | %s      Install/refresh pulse scheduler only\n' "$SETUP_STAGE_PULSE"
+	printf '%s\n' "  full                                  Run the default full setup path"
+	return 0
+}
+
+_setup_canonical_stage() {
+	local stage="$1"
+	case "$stage" in
+	opencode | "$SETUP_STAGE_OPENCODE") printf '%s' "$SETUP_STAGE_OPENCODE" ;;
+	agents | "$SETUP_STAGE_AGENTS") printf '%s' "$SETUP_STAGE_AGENTS" ;;
+	hooks | "$SETUP_STAGE_HOOKS") printf '%s' "$SETUP_STAGE_HOOKS" ;;
+	tabby | "$SETUP_STAGE_TABBY") printf '%s' "$SETUP_STAGE_TABBY" ;;
+	pulse | "$SETUP_STAGE_PULSE") printf '%s' "$SETUP_STAGE_PULSE" ;;
+	full) printf '%s' "full" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_setup_validate_stage() {
+	local stage="$1"
+	if _setup_canonical_stage "$stage" >/dev/null; then
+		return 0
+	fi
+	print_error "Unknown setup stage/scope: $stage"
+	_setup_print_stage_help
+	return 1
 }
 
 # Initialize ~/.config/aidevops/settings.json with documented defaults.
@@ -614,7 +682,7 @@ _setup_lock_pid_is_noninteractive_setup() {
 	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
 	owner_args=$(ps -p "$pid" -o args= 2>/dev/null || true)
 	[[ -n "$owner_args" ]] || return 0
-	[[ "$owner_args" == *"setup.sh"* && "$owner_args" == *"--non-interactive"* ]]
+	[[ "$owner_args" == *"setup.sh"* && ( "$owner_args" == *"--non-interactive"* || "$owner_args" == *"--stage"* ) ]]
 	return $?
 }
 
@@ -628,7 +696,7 @@ _setup_lock_dir_age_seconds() {
 	fi
 	if type _file_mtime_epoch >/dev/null 2>&1; then
 		lock_mtime=$(_file_mtime_epoch "$lock_dir" 2>/dev/null || true)
-	elif [[ "$(uname -s 2>/dev/null || true)" == "Darwin" || "$(uname -s 2>/dev/null || true)" == "FreeBSD" ]]; then
+	elif [[ "$(uname -s 2>/dev/null || true)" == "$SETUP_OS_DARWIN" || "$(uname -s 2>/dev/null || true)" == "FreeBSD" ]]; then
 		lock_mtime=$(stat -f %m "$lock_dir" 2>/dev/null || true)
 	else
 		lock_mtime=$(stat -c %Y "$lock_dir" 2>/dev/null || true)
@@ -1002,9 +1070,7 @@ _setup_acquire_noninteractive_setup_lock() {
 # GH#21060 / t2911: Every direct function call is wrapped with _time_step so
 # that a one-line-per-stage TSV timing record is appended to
 # $HOME/.aidevops/logs/setup-stage-timings.log for post-run diagnostics.
-_setup_run_non_interactive() {
-	print_info "Non-interactive mode: deploying agents and running safe migrations only"
-
+_setup_init_stage_timing_log() {
 	# GH#21060: Initialise per-stage timing log; rotate if over 10K lines / 1MB.
 	local _stl
 	_stl="$HOME/.aidevops/logs/setup-stage-timings.log"
@@ -1021,6 +1087,51 @@ _setup_run_non_interactive() {
 			print_info "setup-stage-timings.log rotated (was ${_stl_lines} lines / ${_stl_bytes} bytes)"
 		fi
 	fi
+	return 0
+}
+
+_setup_run_scoped_stage() {
+	local os="$1"
+	local stage
+	stage="$(_setup_canonical_stage "$SETUP_STAGE")" || return 1
+
+	if [[ "$stage" == "full" ]]; then
+		_setup_run_non_interactive
+		_setup_post_setup_steps "$os"
+		return 0
+	fi
+
+	print_info "Scoped setup mode: running ${stage} only"
+	_setup_init_stage_timing_log
+	case "$stage" in
+	"$SETUP_STAGE_OPENCODE")
+		_time_step "$SETUP_STAGE_OPENCODE" setup_opencode_cli
+		;;
+	"$SETUP_STAGE_AGENTS")
+		_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
+		_time_step "_deploy_hotfix_config" _deploy_hotfix_config
+		;;
+	"$SETUP_STAGE_HOOKS")
+		_time_step "$SETUP_STAGE_HOOKS" setup_safety_hooks
+		;;
+	"$SETUP_STAGE_TABBY")
+		_time_step "$SETUP_STAGE_TABBY" setup_tabby
+		;;
+	"$SETUP_STAGE_PULSE")
+		_time_step "$SETUP_STAGE_PULSE" setup_supervisor_pulse "$os"
+		;;
+	*)
+		print_error "Unsupported canonical setup stage: $stage"
+		return 1
+		;;
+	esac
+	return 0
+}
+
+_setup_run_non_interactive() {
+	print_info "Non-interactive mode: deploying agents and running safe migrations only"
+
+	_setup_init_stage_timing_log
 
 	_time_step "protect_current_setup_worktree" protect_current_setup_worktree
 	_time_step "verify_location" verify_location
@@ -1051,16 +1162,16 @@ _setup_run_non_interactive() {
 	# collision with @anthropic-ai/claude-code or similar). Skipping this
 	# in non-interactive mode is the bug PR #20189 introduced and what
 	# alex-solovyev's runner spam stemmed from.
-	_time_step "setup_opencode_cli" setup_opencode_cli
+	_time_step "$SETUP_STAGE_OPENCODE" setup_opencode_cli
 	_time_step "validate_opencode_config" validate_opencode_config
-	_time_step "deploy_aidevops_agents" deploy_aidevops_agents
+	_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
 	_time_step "_setup_install_pulse_plist_early" _setup_install_pulse_plist_early
 	_time_step "_deploy_hotfix_config" _deploy_hotfix_config
 	_time_step "sync_agent_sources" sync_agent_sources
 	_time_step "install_aidevops_cli" install_aidevops_cli
 	_time_step "setup_shellcheck_wrapper" setup_shellcheck_wrapper
 	if is_feature_enabled safety_hooks 2>/dev/null; then
-		_time_step "setup_safety_hooks" setup_safety_hooks
+		_time_step "$SETUP_STAGE_HOOKS" setup_safety_hooks
 	fi
 	_time_step "init_settings_json" init_settings_json
 
@@ -1248,7 +1359,7 @@ _setup_noninteractive_schedulers() {
 	# Auto-update handles non-interactive internally (systemd detection fixed in GH#17861)
 	_time_step "setup_auto_update" setup_auto_update
 	if _should_setup_noninteractive_supervisor_pulse; then
-		_time_step "setup_supervisor_pulse" setup_supervisor_pulse "$os"
+		_time_step "$SETUP_STAGE_PULSE" setup_supervisor_pulse "$os"
 	fi
 	# t2939: pulse-watchdog (independent revival mechanism). Always installed
 	# alongside the pulse — it is a no-op when pulse is disabled. Skipping the
@@ -1308,7 +1419,7 @@ _setup_noninteractive_schedulers() {
 	_time_step "setup_opencode_db_maintenance" setup_opencode_db_maintenance
 	# Migrate cron entries to systemd after schedulers are installed (GH#17695 Finding D)
 	_time_step "migrate_cron_to_systemd" migrate_cron_to_systemd
-	_time_step "setup_tabby" setup_tabby
+	_time_step "$SETUP_STAGE_TABBY" setup_tabby
 	return 0
 }
 
@@ -1469,13 +1580,17 @@ main() {
 	# never blocks setup even if bash install fails.
 	_setup_check_bash_upgrade
 
-	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+	if [[ -n "$SETUP_STAGE" ]]; then
+		_setup_run_scoped_stage "$_os"
+	elif [[ "$NON_INTERACTIVE" == "true" ]]; then
 		_setup_run_non_interactive
 	else
 		_setup_run_interactive
 	fi
 
-	_setup_post_setup_steps "$_os"
+	if [[ -z "$SETUP_STAGE" ]]; then
+		_setup_post_setup_steps "$_os"
+	fi
 
 	_setup_restart_pulse_if_running
 


### PR DESCRIPTION
## Summary

Added supported setup stage dispatch in setup.sh, exposed aidevops setup --scope, documented when scoped deploy is sufficient, and added a scoped dispatch regression test.

## Files Changed

.agents/aidevops/setup.md,.agents/scripts/tests/test-setup-scoped-dispatch.sh,aidevops.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-setup-scoped-dispatch.sh; shellcheck setup.sh aidevops.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh; ./setup.sh --help; ./setup.sh --stage definitely-not-valid exits 1; .agents/scripts/linters-local.sh attempted but hit pre-existing/advisory repository gates (pulse canary config fixture timeout and global complexity/nesting/file-size debt).

Resolves #23116


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 21m and 224,034 tokens on this as a headless worker.