### PR TITLE
GH#23157: guard git switch dash in canonical checkout

### DIFF
--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -331,6 +331,27 @@ def _get_default_branch(repo_root: str) -> str:
     return "main"
 
 
+def _resolve_previous_branch(repo_root: str) -> str:
+    """Return the branch that ``git switch -`` would restore, or empty on failure."""
+    if not repo_root:
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "@{-1}"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+            if branch and branch != "HEAD":
+                return branch
+    except Exception:
+        pass
+    return ""
+
+
 def _build_canonical_off_default_deny(
     file_path: str, branch: str, default_branch: str
 ) -> dict:
@@ -494,6 +515,8 @@ def _scan_git_switch_args(subcommand: str, args: list[str]) -> tuple[str, bool]:
         elif arg in OPTION_WITH_VALUE:
             index += 2
             continue
+        elif arg == "-":
+            target = arg
         elif arg.startswith("-"):
             index += 1
             continue
@@ -563,8 +586,10 @@ def _check_canonical_branch_switch_command(
     creates_branch = False
     if repo_root and not _is_linked_worktree(repo_root):
         target, creates_branch = _extract_git_switch_target(command)
+        if target == "-":
+            target = _resolve_previous_branch(repo_root)
     default_branch = _get_default_branch(repo_root) if target else ""
-    if not target or target == "-":
+    if not target:
         return None
     if creates_branch or target not in (default_branch, "main", "master"):
         return _canonical_branch_switch_deny(target, default_branch)

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Regression tests for git_safety_guard.py branch-switch protection."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HOOK_PATH = Path(__file__).parent.parent / ".agents" / "hooks" / "git_safety_guard.py"
+
+spec = importlib.util.spec_from_file_location("git_safety_guard", HOOK_PATH)
+git_safety_guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(git_safety_guard)
+
+
+class TestCanonicalBranchSwitchDash(unittest.TestCase):
+    """Protect canonical checkouts from ``git switch -`` bypasses."""
+
+    @mock.patch.object(git_safety_guard, "_branch_target_is_current_turn_authorized")
+    @mock.patch.object(git_safety_guard, "_get_default_branch", return_value="main")
+    @mock.patch.object(git_safety_guard, "_resolve_previous_branch", return_value="feature/work")
+    @mock.patch.object(git_safety_guard, "_is_linked_worktree", return_value=False)
+    @mock.patch.object(git_safety_guard, "_get_repo_root", return_value="/repo")
+    @mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo")
+    def test_git_switch_dash_denies_previous_feature_branch(
+        self,
+        _getcwd,
+        _get_repo_root,
+        _is_linked_worktree,
+        _resolve_previous_branch,
+        _get_default_branch,
+        branch_authorized,
+    ):
+        deny = git_safety_guard._check_canonical_branch_switch_command(
+            "git switch -", "restore the canonical repo"
+        )
+
+        self.assertIsNotNone(deny)
+        reason = deny["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("feature/work", reason)
+        branch_authorized.assert_not_called()
+
+    @mock.patch.object(git_safety_guard, "_branch_target_is_current_turn_authorized")
+    @mock.patch.object(git_safety_guard, "_get_default_branch", return_value="main")
+    @mock.patch.object(git_safety_guard, "_resolve_previous_branch", return_value="main")
+    @mock.patch.object(git_safety_guard, "_is_linked_worktree", return_value=False)
+    @mock.patch.object(git_safety_guard, "_get_repo_root", return_value="/repo")
+    @mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo")
+    def test_git_switch_dash_resolves_default_branch_before_authorization(
+        self,
+        _getcwd,
+        _get_repo_root,
+        _is_linked_worktree,
+        _resolve_previous_branch,
+        _get_default_branch,
+        branch_authorized,
+    ):
+        branch_authorized.return_value = True
+
+        deny = git_safety_guard._check_canonical_branch_switch_command(
+            "git switch -", "restore the canonical repo to main"
+        )
+
+        self.assertIsNone(deny)
+        branch_authorized.assert_called_once_with(
+            "main", "restore the canonical repo to main"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Resolved the canonical workspace bypass by resolving git switch - to the previous branch before applying branch-switch policy, with regression coverage for feature-branch denial and default-branch authorization.

## Files Changed

.agents/hooks/git_safety_guard.py,tests/test-git-safety-guard.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest tests/test-git-safety-guard.py; python3 -m py_compile .agents/hooks/git_safety_guard.py tests/test-git-safety-guard.py

Resolves #23157


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2m and 94,101 tokens on this as a headless worker.