### PR TITLE
GH#23157 follow-up: simplify git safety guard mock setup

### DIFF
--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -18,21 +18,28 @@ spec.loader.exec_module(git_safety_guard)
 class TestCanonicalBranchSwitchDash(unittest.TestCase):
     """Protect canonical checkouts from ``git switch -`` bypasses."""
 
-    @mock.patch.object(git_safety_guard, "_branch_target_is_current_turn_authorized")
-    @mock.patch.object(git_safety_guard, "_get_default_branch", return_value="main")
-    @mock.patch.object(git_safety_guard, "_resolve_previous_branch", return_value="feature/work")
-    @mock.patch.object(git_safety_guard, "_is_linked_worktree", return_value=False)
-    @mock.patch.object(git_safety_guard, "_get_repo_root", return_value="/repo")
-    @mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo")
-    def test_git_switch_dash_denies_previous_feature_branch(
-        self,
-        _getcwd,
-        _get_repo_root,
-        _is_linked_worktree,
-        _resolve_previous_branch,
-        _get_default_branch,
-        branch_authorized,
-    ):
+    def _patch_canonical_repo(self, previous_branch):
+        """Patch repository helpers and return the authorization mock."""
+        patchers = [
+            mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo"),
+            mock.patch.object(git_safety_guard, "_get_repo_root", return_value="/repo"),
+            mock.patch.object(git_safety_guard, "_is_linked_worktree", return_value=False),
+            mock.patch.object(
+                git_safety_guard,
+                "_resolve_previous_branch",
+                return_value=previous_branch,
+            ),
+            mock.patch.object(git_safety_guard, "_get_default_branch", return_value="main"),
+            mock.patch.object(git_safety_guard, "_branch_target_is_current_turn_authorized"),
+        ]
+        started = [patcher.start() for patcher in patchers]
+        for patcher in patchers:
+            self.addCleanup(patcher.stop)
+        return started[-1]
+
+    def test_git_switch_dash_denies_previous_feature_branch(self):
+        branch_authorized = self._patch_canonical_repo("feature/work")
+
         deny = git_safety_guard._check_canonical_branch_switch_command(
             "git switch -", "restore the canonical repo"
         )
@@ -42,21 +49,8 @@ class TestCanonicalBranchSwitchDash(unittest.TestCase):
         self.assertIn("feature/work", reason)
         branch_authorized.assert_not_called()
 
-    @mock.patch.object(git_safety_guard, "_branch_target_is_current_turn_authorized")
-    @mock.patch.object(git_safety_guard, "_get_default_branch", return_value="main")
-    @mock.patch.object(git_safety_guard, "_resolve_previous_branch", return_value="main")
-    @mock.patch.object(git_safety_guard, "_is_linked_worktree", return_value=False)
-    @mock.patch.object(git_safety_guard, "_get_repo_root", return_value="/repo")
-    @mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo")
-    def test_git_switch_dash_resolves_default_branch_before_authorization(
-        self,
-        _getcwd,
-        _get_repo_root,
-        _is_linked_worktree,
-        _resolve_previous_branch,
-        _get_default_branch,
-        branch_authorized,
-    ):
+    def test_git_switch_dash_resolves_default_branch_before_authorization(self):
+        branch_authorized = self._patch_canonical_repo("main")
         branch_authorized.return_value = True
 
         deny = git_safety_guard._check_canonical_branch_switch_command(


### PR DESCRIPTION
## Summary
- Removes the qlty function-parameter regression reported on PR #23167 by replacing stacked patch decorators with a shared helper.
- Keeps the git_safety_guard.py regression coverage for resolving git switch - before canonical branch policy checks.

## Testing
- python3 -m unittest tests/test-git-safety-guard.py
- python3 -m py_compile .agents/hooks/git_safety_guard.py tests/test-git-safety-guard.py

For #23157


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 4m and 128,442 tokens on this as a headless worker.