### PR TITLE
GH#23155: docs: clarify automation safety invariants

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -53,10 +53,10 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 ### Automation safety invariants
 
-- Pending or expected CI is not failure; repair feedback only follows terminal failed checks. See `reference/worker-diagnostics.md` and `reference/review-bot-gate.md`.
+- Treat pending or expected CI as non-failure; provide repair feedback only after terminal failed checks to prevent redundant processing and noise. See `reference/worker-diagnostics.md` and `reference/review-bot-gate.md`.
 - Before redispatch, dedupe against recently merged PRs and verified merged fixes. See `reference/worker-discipline.md` and `reference/task-lifecycle.md`.
-- If rate-limit releases repeat, pause instead of comment-storming. See `reference/gh-command-discipline.md` and `reference/worker-diagnostics.md`.
-- Superseded duplicate PRs close against the verified merged fix. See `reference/review-bot-gate.md` and `workflows/git-workflow.md`.
+- If rate-limit resets repeat, pause instead of comment-storming; violating this can result in API suspension or account flags. See `reference/gh-command-discipline.md` and `reference/worker-diagnostics.md`.
+- Close superseded duplicate PRs against the verified merged fix. See `reference/review-bot-gate.md` and `workflows/git-workflow.md`.
 
 ### Tool and file discipline
 


### PR DESCRIPTION
## Summary

Updated .agents/AGENTS.md automation safety invariants to use imperative wording, clarify CI feedback timing, describe rate-limit reset consequences, and align duplicate PR closure guidance with review feedback.

## Files Changed

.agents/AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/linters-local.sh (Markdown, Secretlint, TOON, Skill frontmatter, and other early gates passed before ratchet phase exceeded 240s watchdog-safe timeout); ran markdownlint-diff-helper/AGENTS.md size check command with size 16433 bytes under the 24000-byte limit.

Resolves #23155


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 5m and 68,717 tokens on this as a headless worker.