### PR TITLE
GH#23153: tighten review-feedback supersession matching

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -582,17 +582,17 @@ _rf_extract_file_paths_from_text() {
 	fi
 
 	# shellcheck disable=SC2016 # Literal backtick regex, not shell expansion.
-	backtick_files=$(printf '%s' "$text" | grep -oE '`[a-zA-Z0-9._/-]+\.(sh|ts|js|py|md|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp)(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
+	backtick_files=$(printf '%s' "$text" | grep -oE '`[a-zA-Z0-9._/-]+\.(sh|ts|js|py|md|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp|cs|dart|jl|kt|m|mm|r|scala|swift)(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
 	if [[ -n "$backtick_files" ]]; then
 		paths="${paths}${backtick_files}"$'\n'
 	fi
 
-	bare_files=$(printf '%s' "$text" | grep -oE '\b[a-zA-Z0-9_-]+\.(sh|ts|js|py|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp)\b' | sort -u || true)
+	bare_files=$(printf '%s' "$text" | grep -oE '\b[a-zA-Z0-9_-]+\.(sh|ts|js|py|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp|cs|dart|jl|kt|m|mm|r|scala|swift)\b' | sort -u || true)
 	if [[ -n "$bare_files" ]]; then
 		paths="${paths}${bare_files}"$'\n'
 	fi
 
-	printf '%s' "$paths" | sort -u | grep -v '^$' | grep -vE '^v?[0-9]+\.[0-9]+\.[0-9]+' || true
+	printf '%s' "$paths" | sort -u | grep -v '^$' | grep -vE '^v?[0-9]+\.[0-9]+\.[0-9]+$' || true
 	return 0
 }
 
@@ -741,7 +741,7 @@ _rf_score_keywords() {
 	evidence_lc=$(printf '%s' "$evidence" | tr '[:upper:]' '[:lower:]')
 	while IFS= read -r keyword; do
 		[[ -z "$keyword" ]] && continue
-		if printf '%s' "$evidence_lc" | grep -qF "$keyword"; then
+		if printf '%s' "$evidence_lc" | grep -qwF "$keyword"; then
 			score=$((score + 1))
 			matched="${matched}${keyword}"$'\n'
 		fi

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -212,6 +212,91 @@ setup_scan_stub_at_helper_path() {
 	return 0
 }
 
+create_gh_stub_review_feedback() {
+	local mode="$1"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="\$*"
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	if printf '%s' "\$args" | grep -qF '.body // ""'; then
+		case "${mode}" in
+			extended-extension)
+				printf 'quality debt kotlin coroutine MainActivity.kt\n'
+				;;
+			whole-word)
+				printf 'quality debt rate cache worker.sh\n'
+				;;
+			*)
+				printf 'unsupported review-feedback mode: %s\n' "${mode}" >&2
+				exit 1
+				;;
+		esac
+		exit 0
+	fi
+	printf '2026-05-07T00:00:00Z\tquality-debt supersession test\tquality-debt,source:review-feedback\n'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qF 'search/issues'; then
+	printf '99\n'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qE 'pulls/99/files'; then
+	case "${mode}" in
+		extended-extension)
+			if printf '%s' "\$args" | grep -qF '.[].filename'; then
+				printf 'app/src/MainActivity.kt\n'
+			else
+				printf 'app/src/MainActivity.kt\nfix kotlin coroutine reliability\n'
+			fi
+			;;
+		whole-word)
+			if printf '%s' "\$args" | grep -qF '.[].filename'; then
+				printf 'worker.sh\n'
+			else
+				printf 'worker.sh\ngenerate cache output\n'
+			fi
+			;;
+		*)
+			printf 'unsupported review-feedback mode: %s\n' "${mode}" >&2
+			exit 1
+			;;
+	esac
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/99\$'; then
+	case "${mode}" in
+		extended-extension)
+			printf '2026-05-08T00:00:00Z\tfix kotlin coroutine reliability\tUpdates mobile handling\n'
+			;;
+		whole-word)
+			printf '2026-05-08T00:00:00Z\tgenerate cache output\tUpdates cache handling\n'
+			;;
+		*)
+			printf 'unsupported review-feedback mode: %s\n' "${mode}" >&2
+			exit 1
+			;;
+	esac
+	exit 0
+fi
+
+if [[ "\${1:-}" == "issue" ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -319,6 +404,40 @@ test_bypass_env_var() {
 	return 0
 }
 
+test_review_feedback_extended_extensions() {
+	setup_test_env
+	create_gh_stub_review_feedback "extended-extension"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "47" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "review_feedback detects extended file extensions" 0
+	else
+		print_result "review_feedback detects extended file extensions" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_review_feedback_keyword_scoring_whole_words() {
+	setup_test_env
+	create_gh_stub_review_feedback "whole-word"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "48" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "review_feedback keyword scoring uses whole words" 0
+	else
+		print_result "review_feedback keyword scoring uses whole words" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -336,6 +455,8 @@ main() {
 	test_unregistered_generator
 	test_validator_error
 	test_bypass_env_var
+	test_review_feedback_extended_extensions
+	test_review_feedback_keyword_scoring_whole_words
 
 	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary

Tightened review-feedback supersession path extraction and keyword scoring to reduce false negatives and false positives.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh,.agents/scripts/tests/test-pre-dispatch-validator.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-pre-dispatch-validator.sh; .agents/scripts/tests/test-pre-dispatch-validator.sh; .agents/scripts/linters-local.sh timed out during later advisory portability checks after passing targeted gates and secret scan

Resolves #23153


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 10m and 98,705 tokens on this as a headless worker.