### PR TITLE
GH#23147: perf: consolidate review gate list jq lookups

### DIFF
--- a/.agents/scripts/review-gate-config-helper.sh
+++ b/.agents/scripts/review-gate-config-helper.sh
@@ -277,13 +277,15 @@ cmd_list() {
 	while IFS= read -r slug; do
 		[[ -z "$slug" ]] && continue
 
-		local rate_limit_val completion_val
-		rate_limit_val=$(jq -r --arg slug "$slug" --arg field "$RATE_LIMIT_BEHAVIOR_FIELD" \
-			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate[$field] // empty' \
-			"$REPOS_JSON" 2>/dev/null) || rate_limit_val=""
-		completion_val=$(jq -r --arg slug "$slug" --arg field "$COMPLETION_BEHAVIOR_FIELD" \
-			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate[$field] // empty' \
-			"$REPOS_JSON" 2>/dev/null) || completion_val=""
+		local rate_limit_val completion_val repo_values
+		repo_values=$(jq -r --arg slug "$slug" --arg rate_field "$RATE_LIMIT_BEHAVIOR_FIELD" --arg completion_field "$COMPLETION_BEHAVIOR_FIELD" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) // {} | [(.review_gate[$rate_field] // ""), (.review_gate[$completion_field] // "")] | @tsv' \
+			"$REPOS_JSON" 2>/dev/null) || repo_values=$'\t'
+		rate_limit_val="${repo_values%%$'\t'*}"
+		completion_val="${repo_values#*$'\t'}"
+		if [[ "$completion_val" == "$repo_values" ]]; then
+			completion_val=""
+		fi
 
 		local rate_effective completion_effective
 		rate_effective=$(_resolve_effective_behavior "$slug" "" "$RATE_LIMIT_BEHAVIOR_FIELD")


### PR DESCRIPTION
## Summary

Consolidated the per-repository rate-limit and completion behavior lookups in review-gate-config-helper.sh into a single jq pass while preserving unset fallback handling.

## Files Changed

.agents/scripts/review-gate-config-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/review-gate-config-helper.sh; shellcheck .agents/scripts/review-gate-config-helper.sh; .agents/scripts/review-gate-config-helper.sh list >/tmp/review-gate-config-list.out

Resolves #23147


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2m and 22,967 tokens on this as a headless worker.