### PR TITLE
GH#23154: fix: guard pulse duplicate issue label lookup

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -637,7 +637,10 @@ _close_superseded_duplicate_issue_if_verified() {
 
 	local issue_api issue_labels parent_or_research=0
 	issue_api="repos/${repo_slug}/issues/${linked_issue}"
-	issue_labels=$(gh api "$issue_api" --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+	if ! issue_labels=$(gh api "$issue_api" --jq '[.labels[]?.name] | join(",")'); then
+		echo "[pulse-wrapper] Superseded duplicate check: failed to fetch labels for issue #${linked_issue} — skipping issue closure to be safe" >>"$LOGFILE"
+		return 0
+	fi
 	case ",${issue_labels}," in
 	*,parent-task,* | *,research,* | *,research-task,*) parent_or_research=1 ;;
 	esac
@@ -1025,7 +1028,7 @@ _close_conflicting_pr() {
 	if [[ "$_CCPR_WORK_ON_MAIN" == "true" ]]; then
 		local pr_labels_csv
 		pr_labels_csv=$(gh pr view "$pr_number" --repo "$repo_slug" \
-			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels_csv=""
+			--json labels --jq '[.labels[]?.name] | join(",")') || pr_labels_csv=""
 		_close_conflicting_pr_comment_landed \
 			"$pr_number" "$repo_slug" "$pr_title" \
 			"$task_id_from_pr" "$_CCPR_MERGING_PR" \

--- a/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
+++ b/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
@@ -14,6 +14,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 TEST_VERIFY_RC=0
 TEST_OVERLAP_RC=0
+TEST_ISSUE_LABELS_RC=0
 TEST_PARENT_LABELS=""
 TEST_COMMIT_SUBJECT="t3571: merged equivalent fix (#9001)"
 TEST_LINKED_ISSUE="23105"
@@ -103,6 +104,10 @@ install_stubs() {
 		fi
 		if [[ "$1" == "api" && "$2" == *"/issues/"* ]]; then
 			if [[ "$*" == *"--jq"* ]]; then
+				if [[ "${TEST_ISSUE_LABELS_RC:-0}" -ne 0 ]]; then
+					printf 'label lookup failed\n' >&2
+					return "$TEST_ISSUE_LABELS_RC"
+				fi
 				printf '%s\n' "$TEST_PARENT_LABELS"
 			else
 				printf '{"labels":[]}\n'
@@ -151,6 +156,7 @@ reset_case() {
 	: >"$SOLVED_LABEL_LOG"
 	export TEST_VERIFY_RC=0
 	export TEST_OVERLAP_RC=0
+	export TEST_ISSUE_LABELS_RC=0
 	export TEST_PARENT_LABELS=""
 	export TEST_COMMIT_SUBJECT="t3571: merged equivalent fix (#9001)"
 	export TEST_LINKED_ISSUE="23105"
@@ -227,6 +233,15 @@ test_parent_research_comment_avoids_closing_keywords() {
 	return 0
 }
 
+test_label_lookup_failure_skips_issue_closure() {
+	reset_case
+	TEST_ISSUE_LABELS_RC=1
+	_close_conflicting_pr "4560" "marcusquinn/aidevops" "t3571: label lookup failure"
+	assert_log_not_contains "$GH_CALL_LOG" "issue close 23105" "label lookup failure skips linked issue close"
+	assert_log_contains "$LOGFILE" "failed to fetch labels for issue #23105" "label lookup failure is logged"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -238,6 +253,7 @@ main() {
 	test_empty_branch_after_upstream_fix_closes_issue
 	test_ambiguous_same_file_change_routes_worker
 	test_parent_research_comment_avoids_closing_keywords
+	test_label_lookup_failure_skips_issue_closure
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Updated pulse superseded duplicate cleanup to fail closed when linked issue labels cannot be fetched, preserving parent/research issue safeguards, and made label jq filters tolerate missing label arrays.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh; shellcheck .agents/scripts/pulse-merge-conflict.sh .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

Resolves #23154


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 82,036 tokens on this as a headless worker.