### PR TITLE
GH#23158: reduce CI check polling for merge feedback

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -376,6 +376,29 @@ _ci_actionable_failed_checks_markdown() {
 }
 
 #######################################
+# Return terminal failed check details and names from one jq pass.
+#
+# Args:
+#   $1 - checks_json (array from gh pr checks --json name,bucket,conclusion,link)
+#   $2 - terminal_failed_check_filter (jq select expression)
+#
+# Output: first line is filtered checks JSON, followed by a marker and one
+# check name per line. Callers split this without re-running jq over the same
+# payload.
+#######################################
+_ci_terminal_failed_check_results() {
+	local checks_json="$1"
+	local terminal_failed_check_filter="$2"
+
+	[[ -n "$checks_json" ]] || checks_json="[]"
+	printf '%s' "$checks_json" | jq -r "([.[] | select(${terminal_failed_check_filter}) | {name, conclusion, link}] | tojson), \"__AIDEVOPS_CHECK_NAMES__\", (.[] | select(${terminal_failed_check_filter}) | .name)" 2>/dev/null || {
+		printf '[]\n__AIDEVOPS_CHECK_NAMES__\n'
+		return 0
+	}
+	return 0
+}
+
+#######################################
 # Route CI failure feedback from a worker/trusted PR to its linked issue, close
 # the PR, and set the issue to status:available for re-dispatch.
 #
@@ -388,12 +411,13 @@ _ci_actionable_failed_checks_markdown() {
 # Same pattern as _dispatch_pr_fix_worker (t2093) but for CI failures
 # instead of review CHANGES_REQUESTED.
 #
-# Args: $1=pr_number, $2=repo_slug, $3=linked_issue
+# Args: $1=pr_number, $2=repo_slug, $3=linked_issue, $4=checks_json (optional)
 #######################################
 _dispatch_ci_fix_worker() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local linked_issue="$3"
+	local supplied_checks_json="${4:-}"
 
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
@@ -407,40 +431,51 @@ _dispatch_ci_fix_worker() {
 		--description "Issue carries CI failure feedback routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
 
-	# Collect actionable failed required checks only. Pending/queued/in-progress
+	# Collect actionable failed required checks first. Pending/queued/in-progress
 	# checks are not actionable repair evidence and must not be routed into the
 	# linked issue as stale worker guidance. Likewise, cancelled/timed_out checks
 	# usually reflect CI capacity, superseded runs, or job-budget kills; routing
 	# those as code-fix feedback creates duplicate PR churn instead of retrying or
-	# escalating CI infrastructure. Advisory/non-required failures are also not
-	# redispatch evidence: branch protection is the source of truth for merge
-	# blockers.
+	# escalating CI infrastructure. If required checks contain no actionable
+	# failures and the caller did not provide precomputed checks, fall back to the
+	# full check set so advisory-only terminal failures can still carry
+	# pattern-specific repair guidance.
 	local terminal_failed_check_filter
 	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and ((.conclusion // "") | test("^(failure|action_required)$")) and ((.link // "") != "")'
-	local required_check_jq="" failing_name_jq=""
-	printf -v required_check_jq '[.[] | select(%s) | {name, conclusion, link}]' "$terminal_failed_check_filter"
-	printf -v failing_name_jq '[.[] | select(%s) | .name] | join("\n")' "$terminal_failed_check_filter"
-
-	local failing_checks_json="" failing_checks=""
-	failing_checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
-		--json name,bucket,conclusion,link \
-		--jq "$required_check_jq" \
-		2>/dev/null) || failing_checks_json="[]"
+	local checks_json="$supplied_checks_json" result_marker=$'\n__AIDEVOPS_CHECK_NAMES__'
+	local check_results="" failing_checks_json="" failing_checks="" failing_names="" classification_output=""
+	if [[ -z "$checks_json" ]]; then
+		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
+			--json name,bucket,conclusion,link \
+			2>/dev/null) || checks_json="[]"
+	fi
+	check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
+	failing_checks_json="${check_results%%"$result_marker"*}"
+	failing_names="${check_results#*"$result_marker"}"
+	[[ "$failing_names" != "$check_results" ]] || failing_names=""
+	failing_names="${failing_names#$'\n'}"
 	failing_checks=$(_ci_actionable_failed_checks_markdown "$pr_number" "$repo_slug" "$failing_checks_json")
 
+	if [[ -z "$failing_checks" && -z "$supplied_checks_json" ]]; then
+		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" \
+			--json name,bucket,conclusion,link \
+			2>/dev/null) || checks_json="[]"
+		check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
+		failing_checks_json="${check_results%%"$result_marker"*}"
+		failing_names="${check_results#*"$result_marker"}"
+		[[ "$failing_names" != "$check_results" ]] || failing_names=""
+		failing_names="${failing_names#$'\n'}"
+		failing_checks=$(_ci_actionable_failed_checks_markdown "$pr_number" "$repo_slug" "$failing_checks_json")
+	fi
+
 	if [[ -z "$failing_checks" ]]; then
-		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has no actionable failed required checks with URLs — skipping CI repair routing" >>"$LOGFILE"
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has no actionable failed checks with URLs — skipping CI repair routing" >>"$LOGFILE"
 		return 0
 	fi
 
 	# t3225: Also collect raw failing check NAMES (one per line) for
 	# pattern classification. Failure to collect names is non-fatal — we
 	# fall back to the pre-t3225 behaviour (no pattern guidance block).
-	local failing_names classification_output=""
-	failing_names=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
-		--json name,bucket,conclusion,link \
-		--jq "$failing_name_jq" \
-		2>/dev/null) || failing_names=""
 	if [[ -n "$failing_names" ]]; then
 		classification_output=$(_classify_ci_failures_by_pattern "$failing_names" 2>/dev/null) || classification_output=""
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -72,6 +72,9 @@ fi
 
 if [[ "${1:-} ${2:-}" == "run view" ]]; then
 	case "${TEST_CHECK_SCENARIO:-terminal_failure}" in
+	infra_timeout)
+		printf '%s\n' 'Lint Run timed out after 10m'
+		;;
 	log_exit_143)
 		printf '%s\n' 'Lint Run ##[error]Process completed with exit code 143.'
 		;;
@@ -85,43 +88,24 @@ fi
 	if [[ "${1:-} ${2:-}" == "pr checks" ]]; then
 		_is_required=0
 		[[ "$*" == *" --required "* || "$*" == *" --required"* ]] && _is_required=1
-		if [[ "$*" == *"| .name]"* ]]; then
-			case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-			terminal_failure:1 | log_exit_143:1)
-				printf 'Lint\n'
-				;;
-			infra_timeout:1 | advisory_failure:*)
-				: ;;
-			esac
-			exit 0
-		fi
 	if [[ "$*" == *"name,bucket,conclusion,link"* ]]; then
 		case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
 			terminal_failure:1 | log_exit_143:1)
-				if [[ "$*" == *"{name, conclusion, link}"* ]]; then
-					printf '%s\n' '[{"name":"Lint","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
-				else
-					printf '%s\n' 'Lint'
-				fi
+				printf '%s\n' '[{"name":"Lint","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
 				;;
 			pending_only:*|mixed_pending_pass:*)
-				if [[ "$*" == *"{name, conclusion, link}"* ]]; then
-					printf '[]\n'
-				fi
-				: ;;
-			infra_timeout:1)
-				if [[ "$*" == *"{name, conclusion, link}"* ]]; then
-					printf '[]\n'
-				fi
-				: ;;
-			advisory_failure:0)
-				if [[ "$*" == *"{name, conclusion, link}"* ]]; then
-					printf '%s\n' '[{"name":"Docs","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/789"}]'
-				else
-					printf 'Docs\n'
-				fi
+				printf '[]\n'
 				;;
-		esac
+			infra_timeout:1)
+				printf '%s\n' '[{"name":"Lint","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+				;;
+			advisory_failure:0)
+				printf '%s\n' '[{"name":"Docs","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/789"}]'
+				;;
+			advisory_failure:1)
+				printf '[]\n'
+				;;
+			esac
 		exit 0
 	fi
 	exit 0
@@ -205,6 +189,7 @@ define_feedback_helpers() {
 		_build_ci_feedback_section
 		_ci_check_url_has_infra_timeout_log
 		_ci_actionable_failed_checks_markdown
+		_ci_terminal_failed_check_results
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
 		_close_and_label_feedback_pr
@@ -213,7 +198,7 @@ define_feedback_helpers() {
 	local fn fn_src
 	gh_issue_edit_safe() { gh issue edit "$@"; return $?; }
 	_emit_ci_failure_guidance_blocks() { return 0; }
-	_classify_ci_failures_by_pattern() { return 0; }
+	_classify_ci_failures_by_pattern() { local failing_names="$1"; printf '%s' "$failing_names" >"${TEST_ROOT}/classified-names.txt"; return 0; }
 	for fn in "${fns[@]}"; do
 		fn_src=$(extract_function "$fn" "$FEEDBACK_SCRIPT")
 		[[ -n "$fn_src" ]] || return 1
@@ -271,7 +256,7 @@ test_ci_feedback_skips_pending_only_checks() {
 
 	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
 		print_result "pending-only checks do not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
-	elif ! grep -qF 'no actionable failed required checks with URLs' "$LOGFILE"; then
+	elif ! grep -qF 'no actionable failed checks with URLs' "$LOGFILE"; then
 		print_result "pending-only checks log terminal-failure skip" 1 "Log: $(cat "$LOGFILE")"
 	else
 		print_result "pending-only checks do not emit CI repair feedback" 0
@@ -346,17 +331,19 @@ test_ci_feedback_skips_failed_check_with_exit_143_log() {
 	return 0
 }
 
-test_ci_feedback_skips_advisory_failure_when_not_required() {
+test_ci_feedback_emits_advisory_failure_when_required_clean() {
 	setup_test_env
 	TEST_CHECK_SCENARIO="advisory_failure"
 	define_feedback_helpers || { print_result "defines feedback helpers for advisory failure" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
 
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
 
-	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
-		print_result "advisory-only failure does not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	if ! grep -qF '**Docs**: failure — [check URL](https://github.com/owner/repo/actions/runs/123/job/789)' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "advisory-only failure emits CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	elif ! grep -qF 'Docs' "${TEST_ROOT}/classified-names.txt"; then
+		print_result "advisory-only failure populates classification names" 1 "Names: $(cat "${TEST_ROOT}/classified-names.txt" 2>/dev/null || true)"
 	else
-		print_result "advisory-only failure does not emit CI repair feedback" 0
+		print_result "advisory-only failure emits CI repair feedback with classification names" 0
 	fi
 	teardown_test_env
 	return 0
@@ -370,7 +357,7 @@ main() {
 	test_ci_feedback_emits_terminal_failure_with_conclusion_and_url
 	test_ci_feedback_skips_infra_timeout_checks
 	test_ci_feedback_skips_failed_check_with_exit_143_log
-	test_ci_feedback_skips_advisory_failure_when_not_required
+	test_ci_feedback_emits_advisory_failure_when_required_clean
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Refactored CI repair routing to reuse fetched check JSON, derive failed checks and names in one jq pass, and fall back to advisory terminal failures when required checks are clean.

## Files Changed

.agents/scripts/pulse-merge-feedback.sh,.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; shellcheck .agents/scripts/pulse-merge-feedback.sh .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; .agents/scripts/linters-local.sh (advisory gates progressed, timed out during shell portability after no blocking failures reached)

Resolves #23158


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 9m and 55,658 tokens on this as a headless worker.