### PR TITLE
GH#23151: cache dashboard identity aliases for migration

### DIFF
--- a/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
+++ b/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
@@ -269,6 +269,13 @@ process_repo() {
 	fi
 	log_info "  found ${total} health-dashboard issue(s) in ${slug}"
 
+	local identity_aliases_config=""
+	local identity_aliases_config_path
+	identity_aliases_config_path=$(_dashboard_identity_alias_config_path)
+	if [[ -n "$identity_aliases_config_path" ]]; then
+		identity_aliases_config=$(<"$identity_aliases_config_path")
+	fi
+
 	# Enrich every issue with a canonical operator key. Issues missing a
 	# dashboard title prefix are skipped (but still included in total count).
 	local enriched=""
@@ -280,7 +287,7 @@ process_repo() {
 		user=$(printf '%s' "$title" | sed -En 's/^\[(Supervisor|Contributor):([^]]+)\].*/\2/p')
 		role=$(printf '%s' "$title" | sed -En 's/^\[(Supervisor|Contributor):([^]]+)\].*/\1/p' | tr '[:upper:]' '[:lower:]')
 		[[ -n "$user" ]] || continue
-		aliases=$(_dashboard_identity_aliases "$user")
+		aliases=$(_dashboard_identity_aliases "$user" "$identity_aliases_config")
 		canonical=$(printf '%s\n' "$aliases" | sed -n '1p')
 		labels_json=$(printf '%s' "$issue_line" | jq -c '.labels')
 		enriched="${enriched}$(printf '%s' "$issue_line" | jq -c \

--- a/.agents/scripts/stats-shared.sh
+++ b/.agents/scripts/stats-shared.sh
@@ -224,18 +224,32 @@ _dashboard_identity_alias_config_path() {
 # Config format: canonical=alias-one,alias-two
 # Arguments:
 #   $1 - runner user/login
+#   $2 - optional preloaded identity-aliases.conf content
 # Output: canonical on line 1, aliases one per following line
 #######################################
 _dashboard_identity_aliases() {
 	local runner_user="$1"
+	local preloaded_config="${2:-}"
+	local has_preloaded_config=0
+	if [[ $# -ge 2 ]]; then
+		has_preloaded_config=1
+	fi
 	local normalized_runner
 	normalized_runner=$(_normalize_dashboard_identity_token "$runner_user")
 	local canonical="$normalized_runner"
 	local aliases="$normalized_runner"
-	local config_path
-	config_path=$(_dashboard_identity_alias_config_path)
+	local config_content=""
+	if ((has_preloaded_config)); then
+		config_content="$preloaded_config"
+	else
+		local config_path
+		config_path=$(_dashboard_identity_alias_config_path)
+		if [[ -n "$config_path" ]]; then
+			config_content=$(<"$config_path")
+		fi
+	fi
 
-	if [[ -n "$config_path" ]]; then
+	if [[ -n "$config_content" ]]; then
 		local line lhs rhs alias normalized_lhs normalized_alias
 		while IFS= read -r line || [[ -n "$line" ]]; do
 			line="${line%%#*}"
@@ -256,7 +270,7 @@ _dashboard_identity_aliases() {
 				aliases="$candidate_aliases"
 				break
 			fi
-		done <"$config_path"
+		done <<<"$config_content"
 	fi
 
 	printf '%s\n' "$canonical"

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -70,6 +70,15 @@ else
 	fail "resolves GitHub username to canonical operator" "canonical=${canonical}"
 fi
 
+preloaded_identity_lines=$(_dashboard_identity_aliases "github-user" \
+	'canonical-operator=local-user,github-user')
+preloaded_canonical=$(printf '%s\n' "$preloaded_identity_lines" | sed -n '1p')
+if [[ "$preloaded_canonical" == "canonical-operator" ]]; then
+	pass "resolves aliases from preloaded config content"
+else
+	fail "resolves aliases from preloaded config content" "canonical=${preloaded_canonical}"
+fi
+
 result=$(_find_health_issue "owner/repo" "github-user" "supervisor" "[Supervisor:canonical-operator]" \
 	"supervisor" "Supervisor" "${HOME}/.aidevops/logs/health-issue-canonical-owner-repo" \
 	"$canonical" "$aliases")


### PR DESCRIPTION
## Summary

Cached identity alias configuration once per migration repo scan and taught the alias resolver to accept preloaded config content, avoiding repeated config file reads inside the issue enrichment loop.

## Files Changed

.agents/scripts/migrate-health-issue-duplicates-t2687.sh,.agents/scripts/stats-shared.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; shellcheck .agents/scripts/stats-shared.sh .agents/scripts/migrate-health-issue-duplicates-t2687.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

Resolves #23151


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 58,952 tokens on this with the user in an interactive session.