### PR TITLE
GH#23150: fix: streamline linux scheduler cron reconciliation

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-linux.sh
+++ b/.agents/scripts/setup/modules/schedulers-linux.sh
@@ -262,20 +262,34 @@ _scheduler_systemd_timer_present() {
 }
 
 # Remove cron entries matching a scheduler tag while preserving unrelated jobs.
-# Args: $1=cron_tag, $2=routine_label
+# Args: $1=cron_tag, $2=routine_label, $3=current_cron(optional), $4=defer_write(optional)
 _scheduler_remove_cron_tag() {
 	local cron_tag="$1"
 	local routine_label="$2"
+	local provided_cron="${3-}"
+	local defer_write="${4:-false}"
 	local current_cron=""
 	local filtered_cron=""
 	local temp_cron=""
 
 	command -v crontab >/dev/null 2>&1 || return 1
-	current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+	if [[ "$#" -ge 3 ]]; then
+		current_cron="$provided_cron"
+	else
+		current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+	fi
 	[[ -n "$current_cron" ]] || return 1
 	printf '%s\n' "$current_cron" | grep -qF "$cron_tag" || return 1
 
 	filtered_cron=$(printf '%s\n' "$current_cron" | grep -vF "$cron_tag" || true)
+	_SCHEDULER_RECONCILED_CRON_RESULT="$filtered_cron"
+	_SCHEDULER_RECONCILED_CRON_CHANGED=true
+	if [[ "$defer_write" == "true" ]]; then
+		_SCHEDULER_RECONCILED_LABELS="${_SCHEDULER_RECONCILED_LABELS}${routine_label}
+"
+		return 0
+	fi
+
 	if [[ -n "$filtered_cron" ]]; then
 		temp_cron=$(mktemp)
 		printf '%s\n' "$filtered_cron" >"$temp_cron"
@@ -291,59 +305,121 @@ _scheduler_remove_cron_tag() {
 
 # Reconcile one Linux scheduler routine so systemd and cron are not both active.
 # Systemd user timers are canonical when present; cron-only jobs are preserved.
-# Args: $1=service_name, $2=cron_tag, $3=routine_label
+# Args: $1=service_name, $2=cron_tag, $3=routine_label, $4=current_cron(optional), $5=defer_write(optional)
 _reconcile_linux_scheduler_duplicate() {
 	local service_name="$1"
 	local cron_tag="$2"
 	local routine_label="$3"
+	local provided_cron="${4-}"
+	local defer_write="${5:-false}"
 	local current_cron=""
 	local has_cron=false
 
 	if command -v crontab >/dev/null 2>&1; then
-		current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+		if [[ "$#" -ge 4 ]]; then
+			current_cron="$provided_cron"
+		else
+			current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+		fi
 		if [[ -n "$current_cron" ]] && printf '%s\n' "$current_cron" | grep -qF "$cron_tag"; then
 			has_cron=true
 		fi
 	else
-		print_info "Skipped scheduler reconciliation for ${routine_label}: crontab command unavailable"
 		return 0
 	fi
 
 	if _scheduler_systemd_timer_present "$service_name"; then
 		if [[ "$has_cron" == "true" ]]; then
-			_scheduler_remove_cron_tag "$cron_tag" "$routine_label" || true
-		else
-			print_info "Kept ${routine_label} systemd user timer; no duplicate cron entry found"
+			_scheduler_remove_cron_tag "$cron_tag" "$routine_label" "$current_cron" "$defer_write" || true
 		fi
 		return 0
 	fi
 
-	if [[ "$has_cron" == "true" ]]; then
-		print_info "Kept ${routine_label} cron entry; no systemd user timer found"
-	else
-		print_info "Skipped scheduler reconciliation for ${routine_label}: no installed scheduler found"
-	fi
 	return 0
 }
 
 # Reconcile known Linux aidevops routines that may have migrated from cron to systemd.
 _reconcile_linux_scheduler_duplicates() {
+	local current_cron=""
+	local reconciled_cron=""
+	local routine_label=""
+	local temp_cron=""
+	local changed=false
+
+	command -v crontab >/dev/null 2>&1 || return 0
+	current_cron=$(crontab -l 2>/dev/null) || current_cron=""
+	_SCHEDULER_RECONCILED_LABELS=""
+
+	_SCHEDULER_RECONCILED_CRON_RESULT=""
+	_SCHEDULER_RECONCILED_CRON_CHANGED=false
 	_reconcile_linux_scheduler_duplicate \
 		"aidevops-auto-update" \
 		"# aidevops-auto-update" \
-		"auto-update"
+		"auto-update" \
+		"$current_cron" \
+		true
+	if [[ "$_SCHEDULER_RECONCILED_CRON_CHANGED" == "true" ]]; then
+		current_cron="$_SCHEDULER_RECONCILED_CRON_RESULT"
+		changed=true
+	fi
+
+	_SCHEDULER_RECONCILED_CRON_RESULT=""
+	_SCHEDULER_RECONCILED_CRON_CHANGED=false
 	_reconcile_linux_scheduler_duplicate \
 		"aidevops-pulse-merge" \
 		"aidevops: pulse-merge-routine" \
-		"pulse merge"
+		"pulse merge" \
+		"$current_cron" \
+		true
+	if [[ "$_SCHEDULER_RECONCILED_CRON_CHANGED" == "true" ]]; then
+		current_cron="$_SCHEDULER_RECONCILED_CRON_RESULT"
+		changed=true
+	fi
+
+	_SCHEDULER_RECONCILED_CRON_RESULT=""
+	_SCHEDULER_RECONCILED_CRON_CHANGED=false
 	_reconcile_linux_scheduler_duplicate \
 		"aidevops-supervisor-pulse" \
 		"aidevops: supervisor-pulse" \
-		"supervisor pulse"
+		"supervisor pulse" \
+		"$current_cron" \
+		true
+	if [[ "$_SCHEDULER_RECONCILED_CRON_CHANGED" == "true" ]]; then
+		current_cron="$_SCHEDULER_RECONCILED_CRON_RESULT"
+		changed=true
+	fi
+
+	_SCHEDULER_RECONCILED_CRON_RESULT=""
+	_SCHEDULER_RECONCILED_CRON_CHANGED=false
 	_reconcile_linux_scheduler_duplicate \
 		"aidevops-stats-wrapper" \
 		"aidevops: stats-wrapper" \
-		"stats wrapper"
+		"stats wrapper" \
+		"$current_cron" \
+		true
+	if [[ "$_SCHEDULER_RECONCILED_CRON_CHANGED" == "true" ]]; then
+		current_cron="$_SCHEDULER_RECONCILED_CRON_RESULT"
+		changed=true
+	fi
+
+	if [[ "$changed" != "true" ]]; then
+		return 0
+	fi
+
+	if [[ -n "$current_cron" ]]; then
+		temp_cron=$(mktemp)
+		printf '%s\n' "$current_cron" >"$temp_cron"
+		crontab "$temp_cron" 2>/dev/null || true
+		rm -f "$temp_cron"
+	else
+		crontab -r 2>/dev/null || true
+	fi
+
+	reconciled_cron="$_SCHEDULER_RECONCILED_LABELS"
+	while IFS= read -r routine_label; do
+		[[ -n "$routine_label" ]] || continue
+		print_info "Removed duplicate cron entry for ${routine_label}; kept systemd user timer"
+	done <<<"$reconciled_cron"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-scheduler-dedup-linux.sh
+++ b/.agents/scripts/tests/test-scheduler-dedup-linux.sh
@@ -39,10 +39,14 @@ setup_fixture() {
 	TEST_ROOT="$(mktemp -d)"
 	export HOME="${TEST_ROOT}/home"
 	export CRON_FILE="${TEST_ROOT}/crontab"
+	export CRON_LIST_COUNT_FILE="${TEST_ROOT}/crontab-list-count"
+	export CRON_WRITE_COUNT_FILE="${TEST_ROOT}/crontab-write-count"
 	export SYSTEMD_ENABLED_FILE="${TEST_ROOT}/systemd-enabled"
 	local fake_bin="${TEST_ROOT}/bin"
 	mkdir -p "$HOME/.config/systemd/user" "$fake_bin"
 	: >"$CRON_FILE"
+	printf '0\n' >"$CRON_LIST_COUNT_FILE"
+	printf '0\n' >"$CRON_WRITE_COUNT_FILE"
 	: >"$SYSTEMD_ENABLED_FILE"
 
 	cat >"${fake_bin}/crontab" <<'CRONTAB_FAKE'
@@ -50,10 +54,16 @@ setup_fixture() {
 set -euo pipefail
 case "${1:-}" in
 -l)
+	list_count=0
+	[[ -f "$CRON_LIST_COUNT_FILE" ]] && read -r list_count <"$CRON_LIST_COUNT_FILE"
+	printf '%s\n' "$((list_count + 1))" >"$CRON_LIST_COUNT_FILE"
 	[[ -f "$CRON_FILE" ]] && cat "$CRON_FILE"
 	exit 0
 	;;
 -r)
+	write_count=0
+	[[ -f "$CRON_WRITE_COUNT_FILE" ]] && read -r write_count <"$CRON_WRITE_COUNT_FILE"
+	printf '%s\n' "$((write_count + 1))" >"$CRON_WRITE_COUNT_FILE"
 	: >"$CRON_FILE"
 	exit 0
 	;;
@@ -62,6 +72,9 @@ case "${1:-}" in
 	exit 0
 	;;
 *)
+	write_count=0
+	[[ -f "$CRON_WRITE_COUNT_FILE" ]] && read -r write_count <"$CRON_WRITE_COUNT_FILE"
+	printf '%s\n' "$((write_count + 1))" >"$CRON_WRITE_COUNT_FILE"
 	cp "$1" "$CRON_FILE"
 	exit 0
 	;;
@@ -119,17 +132,19 @@ test_duplicate_auto_update_cron_removed() {
 	output="$(_reconcile_linux_scheduler_duplicates)"
 	local after_first=""
 	after_first="$(cat "$CRON_FILE")"
+	local list_count_after_first=""
+	list_count_after_first="$(cat "$CRON_LIST_COUNT_FILE")"
 	_reconcile_linux_scheduler_duplicates >/dev/null
 	local after_second=""
 	after_second="$(cat "$CRON_FILE")"
 
-	if [[ "$after_first" != *'aidevops-auto-update'* && "$after_first" == *'keep-me'* && "$after_first" == "$after_second" && "$output" == *'Removed duplicate cron entry for auto-update'* ]]; then
+	if [[ "$after_first" != *'aidevops-auto-update'* && "$after_first" == *'keep-me'* && "$after_first" == "$after_second" && "$output" == *'Removed duplicate cron entry for auto-update'* && "$list_count_after_first" == "1" ]]; then
 		print_result "duplicate auto-update cron is removed and reconciliation is idempotent" 0
 		cleanup_fixture
 		return 0
 	fi
 
-	print_result "duplicate auto-update cron is removed and reconciliation is idempotent" 1 "output=${output} cron=${after_first} second=${after_second}"
+	print_result "duplicate auto-update cron is removed and reconciliation is idempotent" 1 "output=${output} cron=${after_first} second=${after_second} list_count=${list_count_after_first}"
 	cleanup_fixture
 	return 0
 }
@@ -158,6 +173,35 @@ test_duplicate_pulse_merge_cron_removed() {
 	return 0
 }
 
+test_multiple_duplicate_cron_entries_removed_with_single_crontab_write() {
+	setup_fixture
+	printf '%s\n' \
+		'*/10 * * * * /home/example/.aidevops/agents/scripts/auto-update-helper.sh check # aidevops-auto-update' \
+		'* * * * * /home/example/.aidevops/agents/scripts/pulse-merge-routine.sh run # aidevops: pulse-merge-routine' \
+		'0 6 * * * /usr/bin/true # keep-me' >"$CRON_FILE"
+	printf '%s\n' 'aidevops-auto-update.timer' 'aidevops-pulse-merge.timer' >"$SYSTEMD_ENABLED_FILE"
+	load_scheduler_functions
+
+	local output=""
+	output="$(_reconcile_linux_scheduler_duplicates)"
+	local cron_after=""
+	cron_after="$(cat "$CRON_FILE")"
+	local list_count=""
+	list_count="$(cat "$CRON_LIST_COUNT_FILE")"
+	local write_count=""
+	write_count="$(cat "$CRON_WRITE_COUNT_FILE")"
+
+	if [[ "$cron_after" != *'aidevops-auto-update'* && "$cron_after" != *'pulse-merge-routine'* && "$cron_after" == *'keep-me'* && "$output" == *'Removed duplicate cron entry for auto-update'* && "$output" == *'Removed duplicate cron entry for pulse merge'* && "$list_count" == "1" && "$write_count" == "1" ]]; then
+		print_result "multiple duplicate cron entries are removed with one read and one write" 0
+		cleanup_fixture
+		return 0
+	fi
+
+	print_result "multiple duplicate cron entries are removed with one read and one write" 1 "output=${output} cron=${cron_after} list_count=${list_count} write_count=${write_count}"
+	cleanup_fixture
+	return 0
+}
+
 test_systemd_only_stats_wrapper_preserved() {
 	setup_fixture
 	printf '%s\n' '30 2 * * * /usr/bin/true # keep-cron-only' >"$CRON_FILE"
@@ -169,13 +213,13 @@ test_systemd_only_stats_wrapper_preserved() {
 	local cron_after=""
 	cron_after="$(cat "$CRON_FILE")"
 
-	if [[ "$cron_after" == *'keep-cron-only'* && "$output" == *'Kept stats wrapper systemd user timer; no duplicate cron entry found'* ]]; then
-		print_result "systemd-only stats wrapper is preserved and logged" 0
+	if [[ "$cron_after" == *'keep-cron-only'* && -z "$output" ]]; then
+		print_result "systemd-only stats wrapper is preserved without no-op logging" 0
 		cleanup_fixture
 		return 0
 	fi
 
-	print_result "systemd-only stats wrapper is preserved and logged" 1 "output=${output} cron=${cron_after}"
+	print_result "systemd-only stats wrapper is preserved without no-op logging" 1 "output=${output} cron=${cron_after}"
 	cleanup_fixture
 	return 0
 }
@@ -190,7 +234,7 @@ test_cron_only_scheduler_preserved() {
 	local cron_after=""
 	cron_after="$(cat "$CRON_FILE")"
 
-	if [[ "$cron_after" == *'aidevops: supervisor-pulse'* && "$output" == *'Kept supervisor pulse cron entry; no systemd user timer found'* ]]; then
+	if [[ "$cron_after" == *'aidevops: supervisor-pulse'* && -z "$output" ]]; then
 		print_result "cron-only scheduler is preserved" 0
 		cleanup_fixture
 		return 0
@@ -204,6 +248,7 @@ test_cron_only_scheduler_preserved() {
 main() {
 	test_duplicate_auto_update_cron_removed
 	test_duplicate_pulse_merge_cron_removed
+	test_multiple_duplicate_cron_entries_removed_with_single_crontab_write
 	test_systemd_only_stats_wrapper_preserved
 	test_cron_only_scheduler_preserved
 


### PR DESCRIPTION
## Summary

Refactored Linux scheduler cron duplicate reconciliation to reuse preloaded crontab content, defer bulk writes to a single crontab update, and suppress no-op reconciliation logs. Updated scheduler dedup tests to verify single read/write behaviour and quiet no-op paths.

## Files Changed

.agents/scripts/setup/modules/schedulers-linux.sh,.agents/scripts/tests/test-scheduler-dedup-linux.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - .agents/scripts/tests/test-scheduler-dedup-linux.sh\n- shellcheck .agents/scripts/setup/modules/schedulers-linux.sh .agents/scripts/tests/test-scheduler-dedup-linux.sh\n- .agents/scripts/linters-local.sh (timed out during shell portability after earlier gates passed; markdown/ratchet/layout warnings were advisory/pre-existing)

Resolves #23150


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 6m and 95,791 tokens on this as a headless worker.