### PR TITLE
GH#23164: cache privacy script reference allowlist

### DIFF
--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -45,6 +45,7 @@ PRIVACY_SCAN_GLOBS=(
 	"."
 )
 PRIVACY_SCAN_GLOBS_TEXT="${PRIVACY_SCAN_GLOBS_TEXT:-}"
+PRIVACY_CREDENTIAL_PREFIX_ERE='(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'
 
 # =============================================================================
 # Logging
@@ -430,6 +431,33 @@ privacy_scan_local_paths() {
 # =============================================================================
 
 #######################################
+# List aidevops script basenames that look credential-like and may be redacted.
+# Output:
+#   newline-delimited basenames
+#######################################
+_privacy_aidevops_script_reference_basenames() {
+	local source_path="${BASH_SOURCE[0]:-$0}"
+	local script_dir=""
+	local script_path basename
+
+	script_dir=$(cd "$(dirname "$source_path")" 2>/dev/null && pwd -P) || script_dir=""
+	if [[ -z "$script_dir" ]]; then
+		return 0
+	fi
+
+	for script_path in "$script_dir"/*.sh "$script_dir"/*/*.sh; do
+		[[ -f "$script_path" ]] || continue
+		basename="${script_path##*/}"
+		if [[ ! "$basename" =~ $PRIVACY_CREDENTIAL_PREFIX_ERE ]]; then
+			continue
+		fi
+		printf '%s\n' "$basename"
+	done
+
+	return 0
+}
+
+#######################################
 # Redact aidevops script file references before credential-prefix scanning.
 #
 # Some aidevops helper basenames legitimately contain substrings such as
@@ -439,36 +467,34 @@ privacy_scan_local_paths() {
 # helper (or one directory below it, matching `.agents/scripts/tests/...`).
 # Arguments:
 #   $1 - text content to redact
+#   $2 - optional newline-delimited precomputed basename allowlist
 # Output:
 #   text with allowed script references replaced by a neutral marker
 #######################################
 _privacy_redact_aidevops_script_references() {
 	local text="$1"
+	local basenames_provided="${2+x}"
+	local basenames_text="${2:-}"
 	local redacted="$text"
-	local source_path="${BASH_SOURCE[0]:-$0}"
-	local script_dir=""
-	local script_path basename
+	local basename
 
-	script_dir=$(cd "$(dirname "$source_path")" 2>/dev/null && pwd -P) || script_dir=""
-	if [[ -z "$script_dir" ]]; then
+	if [[ -z "$basenames_provided" ]]; then
+		basenames_text=$(_privacy_aidevops_script_reference_basenames)
+	fi
+	if [[ -z "$basenames_text" ]]; then
 		printf '%s' "$redacted"
 		return 0
 	fi
 
-	for script_path in "$script_dir"/*.sh "$script_dir"/*/*.sh; do
-		[[ -f "$script_path" ]] || continue
-		basename="${script_path##*/}"
-		if [[ ! "$basename" =~ (sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,} ]]; then
-			continue
-		fi
-
+	while IFS= read -r basename || [[ -n "$basename" ]]; do
+		[[ -z "$basename" ]] && continue
 		redacted="${redacted//.agents\/scripts\/$basename/[aidevops-script-reference]}"
 		redacted="${redacted//.\/\.agents\/scripts\/$basename/[aidevops-script-reference]}"
 		redacted="${redacted//\`$basename\`/[aidevops-script-reference]}"
 		redacted="${redacted//\"$basename\"/[aidevops-script-reference]}"
 		redacted="${redacted// $basename/ [aidevops-script-reference]}"
 		redacted="${redacted//$'\n'$basename/$'\n'[aidevops-script-reference]}"
-	done
+	done <<<"$basenames_text"
 
 	printf '%s' "$redacted"
 	return 0
@@ -498,7 +524,7 @@ privacy_scan_secret_material_text() {
 		printf '%s\n' 'private-key PEM block'
 		hits=$((hits + 1))
 	fi
-	if printf '%s' "$scan_text" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
+	if printf '%s' "$scan_text" | grep -qE -- "$PRIVACY_CREDENTIAL_PREFIX_ERE"; then
 		printf '%s\n' 'credential token prefix'
 		hits=$((hits + 1))
 	fi
@@ -535,6 +561,8 @@ privacy_scan_secret_material_diff() {
 	[[ -z "$diff_output" ]] && return 0
 
 	local hits=0 current_file="" line_num=0 in_pem=0
+	local aidevops_script_basenames
+	aidevops_script_basenames=$(_privacy_aidevops_script_reference_basenames)
 	while IFS= read -r line; do
 		case "$line" in
 		"+++ b/"*) current_file="${line#+++ b/}"; line_num=0 ;;
@@ -548,7 +576,7 @@ privacy_scan_secret_material_diff() {
 			[[ "$line" == "+++ "* ]] && continue
 			local added="${line:1}"
 			local scan_added
-			scan_added=$(_privacy_redact_aidevops_script_references "$added")
+			scan_added=$(_privacy_redact_aidevops_script_references "$added" "$aidevops_script_basenames")
 			if [[ "$scan_added" != "$added" ]]; then
 				printf '%s:%s: [privacy-scan][ALLOW] aidevops script file reference\n' "$current_file" "$line_num" >&2
 			fi
@@ -563,7 +591,7 @@ privacy_scan_secret_material_diff() {
 			if [[ "$scan_added" =~ -----END[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
 				in_pem=0
 			fi
-			if printf '%s' "$scan_added" | grep -qE '(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'; then
+			if printf '%s' "$scan_added" | grep -qE -- "$PRIVACY_CREDENTIAL_PREFIX_ERE"; then
 				printf '%s:%s: credential token prefix\n' "$current_file" "$line_num"
 				hits=$((hits + 1))
 			fi

--- a/.agents/scripts/tests/test-gh-public-privacy-guard.sh
+++ b/.agents/scripts/tests/test-gh-public-privacy-guard.sh
@@ -57,6 +57,21 @@ else
 	fail "aidevops script path reference" "rc=$rc out=$out err=$err"
 fi
 
+precomputed_input="Worker guidance: edit .agents/scripts/$ALLOWED_BASENAME"
+redacted=$(_privacy_redact_aidevops_script_references "$precomputed_input" "$ALLOWED_BASENAME")
+if [[ "$redacted" == *'[aidevops-script-reference]'* ]]; then
+	pass "precomputed aidevops script basename allowlist is used"
+else
+	fail "precomputed aidevops script basename allowlist" "redacted=$redacted"
+fi
+
+redacted=$(_privacy_redact_aidevops_script_references "$precomputed_input" "")
+if [[ "$redacted" == "$precomputed_input" ]]; then
+	pass "empty precomputed aidevops script basename allowlist skips fallback discovery"
+else
+	fail "empty precomputed aidevops script basename allowlist" "redacted=$redacted"
+fi
+
 out=$(privacy_scan_secret_material_text "Reference basename \`$ALLOWED_BASENAME\` in the issue body" 2>"$TMP/allow-basename.err")
 rc=$?
 err=$(<"$TMP/allow-basename.err")


### PR DESCRIPTION
## Summary

Refactored privacy credential scanning to share the credential-prefix pattern and precompute aidevops script-reference basenames once for diff scans, preserving fallback discovery for standalone text scans.

## Files Changed

.agents/scripts/privacy-guard-helper.sh,.agents/scripts/tests/test-gh-public-privacy-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-public-privacy-guard.sh; shellcheck .agents/scripts/privacy-guard-helper.sh .agents/scripts/tests/test-gh-public-privacy-guard.sh

Resolves #23164


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 48,747 tokens on this as a headless worker.