### PR TITLE
GH#23152: localize dashboard alias parsing variables

### DIFF
--- a/.agents/scripts/stats-shared.sh
+++ b/.agents/scripts/stats-shared.sh
@@ -236,7 +236,7 @@ _dashboard_identity_aliases() {
 	config_path=$(_dashboard_identity_alias_config_path)
 
 	if [[ -n "$config_path" ]]; then
-		local line lhs rhs alias normalized_lhs normalized_alias
+		local line lhs rhs alias normalized_lhs normalized_alias candidate_aliases _identity_alias_parts
 		while IFS= read -r line || [[ -n "$line" ]]; do
 			line="${line%%#*}"
 			[[ "$line" == *"="* ]] || continue
@@ -244,7 +244,7 @@ _dashboard_identity_aliases() {
 			rhs="${line#*=}"
 			normalized_lhs=$(_normalize_dashboard_identity_token "$lhs")
 			[[ -n "$normalized_lhs" ]] || continue
-			local candidate_aliases="$normalized_lhs"
+			candidate_aliases="$normalized_lhs"
 			IFS=',' read -r -a _identity_alias_parts <<<"$rhs"
 			for alias in "${_identity_alias_parts[@]}"; do
 				normalized_alias=$(_normalize_dashboard_identity_token "$alias")


### PR DESCRIPTION
## Summary

Declared dashboard identity alias parsing temporaries as local and kept assignment separate for exit-code-safe shell style.

## Files Changed

.agents/scripts/stats-shared.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-shared.sh passed; .agents/scripts/linters-local.sh reached Secretlint before the 120s worker command timeout after passing SonarCloud and string literal gates.

Resolves #23152


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2m and 35,399 tokens on this as a headless worker.