### PR TITLE
GH#23156: fix: handle protected counter reconciliation pushes

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -334,9 +334,26 @@ _cas_reconcile_counter_branch() {
 	}
 
 	local push_rc=0
-	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
-		push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+	local push_stderr=""
+	local push_err_file=""
+	push_err_file=$(mktemp "${TMPDIR:-/tmp}/claim-task-id-reconcile-push.XXXXXX" 2>/dev/null) || push_err_file=""
+	if [[ -n "$push_err_file" ]]; then
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null 2>"$push_err_file" || push_rc=$?
+	else
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+	fi
+	if [[ -n "$push_err_file" ]]; then
+		push_stderr=$(<"$push_err_file")
+		rm -f "$push_err_file" 2>/dev/null || true
+	fi
 	if [[ $push_rc -ne 0 ]]; then
+		if _cas_push_rejection_is_protected_branch "$push_stderr"; then
+			_cas_log_protected_branch_rejection
+			_task_counter_status "unrecoverable_desync" "protected_counter_branch"
+			return 1
+		fi
 		log_warn "Counter reconciliation push raced with another allocator; retrying allocation from refreshed branch"
 		_task_counter_status "recovered_contention" "reconcile_raced"
 		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true

--- a/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
+++ b/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
@@ -60,6 +60,28 @@ setup_desynced_remote() {
 	return 0
 }
 
+protect_counter_branch_pushes() {
+	local work_dir="$1"
+	local bare_dir
+	bare_dir=$(git -C "$work_dir" remote get-url origin 2>/dev/null) || return 1
+	mkdir -p "${bare_dir}/hooks" || return 1
+	cat >"${bare_dir}/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+set -u
+
+while read -r old_sha new_sha ref_name; do
+	if [[ "$ref_name" == "refs/heads/develop" ]]; then
+		printf 'remote: error: GH006: Protected branch update failed for %s.\n' "$ref_name" >&2
+		printf 'remote: error: Changes must be made through a pull request.\n' >&2
+		exit 1
+	fi
+done
+exit 0
+HOOK
+	chmod +x "${bare_dir}/hooks/pre-receive" || return 1
+	return 0
+}
+
 test_counter_branch_desync_reconciles_before_claim() {
 	local name="counter branch desync is reconciled before allocation"
 	local tmpdir work_dir output rc task_id final_counter claim_commits unique_claims
@@ -112,6 +134,47 @@ test_counter_branch_desync_reconciles_before_claim() {
 	return 0
 }
 
+test_reconciliation_protected_branch_rejection_is_unrecoverable() {
+	local name="reconciliation protected branch rejection is unrecoverable"
+	local tmpdir work_dir output rc
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+
+	work_dir=$(setup_desynced_remote "$tmpdir") || { fail "$name" "repo setup failed"; rm -rf "$tmpdir"; return 0; }
+	protect_counter_branch_pushes "$work_dir" || { fail "$name" "hook setup failed"; rm -rf "$tmpdir"; return 0; }
+
+	rc=0
+	output=$(CAS_MAX_RETRIES=3 CAS_WALL_TIMEOUT_S=20 CAS_SSH_FALLBACK_ENABLED=0 "$CLAIM_SCRIPT" \
+		--title "protected reconciliation test" \
+		--no-issue \
+		--repo-path "$work_dir" \
+		--counter-branch develop 2>&1) || rc=$?
+
+	if [[ $rc -eq 0 ]]; then
+		fail "$name" "claim unexpectedly succeeded: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'PROTECTED_COUNTER_BRANCH'; then
+		fail "$name" "missing protected-branch error: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'AIDEVOPS_TASK_COUNTER_STATUS=unrecoverable_desync detail=protected_counter_branch'; then
+		fail "$name" "missing protected-counter status: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	if printf '%s\n' "$output" | grep -q 'reconcile_raced'; then
+		fail "$name" "protected rejection was treated as retriable contention: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
 main() {
 	if [[ ! -x "$CLAIM_SCRIPT" ]]; then
 		fail "claim script executable" "$CLAIM_SCRIPT missing or not executable"
@@ -119,6 +182,7 @@ main() {
 		pass "claim script executable"
 	fi
 	test_counter_branch_desync_reconciles_before_claim
+	test_reconciliation_protected_branch_rejection_is_unrecoverable
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ "$FAIL" -eq 0 ]] || return 1
 	return 0


### PR DESCRIPTION
## Summary

Captured stderr from reconciliation pushes in claim-task-id-counter so GH006/protected-branch policy failures are classified as unrecoverable instead of retriable contention. Added a regression test that simulates a protected counter branch during desync reconciliation.

## Files Changed

.agents/scripts/claim-task-id-counter.sh,.agents/scripts/tests/test-claim-task-id-counter-desync.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-claim-task-id-counter-desync.sh; shellcheck .agents/scripts/claim-task-id-counter.sh .agents/scripts/tests/test-claim-task-id-counter-desync.sh

Resolves #23156


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 79,306 tokens on this as a headless worker.