### PR TITLE
GH#23149: docs: update native auto-merge return docs

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1389,7 +1389,7 @@ _auto_merge_stuck_seconds() {
 # repos where allow_auto_merge=true is bulk-enabled and CI is fast.
 #
 # Args: $1=pr_number, $2=repo_slug
-# Returns: 0=native-auto requested/deferred, 1=fall through, 2=terminal repair
+# Returns: 0=native-auto requested/deferred, 1=fall through
 #######################################
 _set_native_auto_merge_or_skip() {
 	local pr_number="$1"


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-merge-process.sh so _set_native_auto_merge_or_skip return-value documentation no longer mentions obsolete return code 2.

## Files Changed

.agents/scripts/pulse-merge-process.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-merge-process.sh; shellcheck .agents/scripts/pulse-merge-process.sh

Resolves #23149


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 46s and 29,531 tokens on this as a headless worker.