### PR TITLE
GH#23166: fix: preserve explicit prelaunch failure reasons

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -150,7 +150,7 @@ _pulse_worker_log_prelaunch_failure_reason() {
 			split(line, parts, /[[:space:]]+/)
 			reason = parts[1]
 		}
-		/\[exit-trap\] session=/ && / reason=/ {
+		/\[exit-trap\] session=/ && / reason=/ && reason == "" {
 			line = $0
 			sub(/^.* reason=/, "", line)
 			split(line, parts, /[[:space:]]+/)

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -624,6 +624,30 @@ test_prelaunch_reason_parser_behavioural() {
 	return 0
 }
 
+test_prelaunch_reason_parser_preserves_explicit_reason() {
+	local sandbox helper_extract log_file reason
+	sandbox=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-prelaunch-reason-priority-test.XXXXXX")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$sandbox' 2>/dev/null || true" RETURN
+	helper_extract="${sandbox}/helper.sh"
+	log_file="${sandbox}/worker.log"
+
+	awk '/^_pulse_worker_log_prelaunch_failure_reason\(\) \{/,/^\}/' "$PULSE_ENGINE" >"$helper_extract"
+	{
+		printf '[exit-trap] using prelaunch failure reason: worker_worktree_live_owner\n'
+		printf '[exit-trap] session=abc reason=no_worker_process status=1\n'
+	} >"$log_file"
+	reason=$(bash -c "source '$helper_extract'; _pulse_worker_log_prelaunch_failure_reason '$log_file'" 2>/dev/null)
+
+	if [[ "$reason" == "worker_worktree_live_owner" ]]; then
+		print_result "invariant: explicit prelaunch reason is not overwritten by generic session reason" 0
+		return 0
+	fi
+	print_result "invariant: explicit prelaunch reason is not overwritten by generic session reason" 1 \
+		"Expected worker_worktree_live_owner, got '${reason:-<empty>}'"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main runner
 # ---------------------------------------------------------------------------
@@ -670,6 +694,7 @@ main_test() {
 	test_failure_classification_distinct
 	test_worker_worktree_live_owner_skips_fast_fail_state
 	test_prelaunch_reason_parser_behavioural
+	test_prelaunch_reason_parser_preserves_explicit_reason
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Updated the pulse dispatch prelaunch reason parser so explicit prelaunch failure reasons are not overwritten by later generic session reason lines, and added regression coverage for mixed log records.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-no-worker-process-fix.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-no-worker-process-fix.sh; shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-no-worker-process-fix.sh

Resolves #23166


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 43,699 tokens on this as a headless worker.