### PR TITLE
GH#23187: block consolidated issue redispatch

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -859,6 +859,32 @@ _has_committed_to_main_cache_label() {
 }
 
 #######################################
+# Detect terminal consolidated issues before worker dispatch.
+#
+# Consolidated issues are archival handoff/spec records produced by issue
+# consolidation workers. They intentionally carry `consolidated` and
+# `origin:worker` so provenance is preserved, but they are not implementation
+# tasks. Blocking them here prevents stale status labels such as
+# `status:queued` from re-opening a completed consolidation thread.
+#
+# Args:
+#   $1 - issue_meta_json (pre-fetched JSON with a .labels array)
+#
+# Exit codes:
+#   0 - consolidated label is present
+#   1 - consolidated label is absent (or meta_json is empty/invalid)
+#######################################
+_has_consolidated_label() {
+	local issue_meta_json="$1"
+	[[ -n "$issue_meta_json" ]] || return 1
+	if printf '%s' "$issue_meta_json" |
+		jq -e '.labels | map(.name) | index("consolidated")' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Determine whether a GitHub issue-number target is actually a pull request.
 #
 # `gh issue view` intentionally presents PRs through the issue facade, so the
@@ -1138,6 +1164,12 @@ _dispatch_dedup_check_layers() {
 	# code path that skips check_dispatch_dedup). This closes Factor 1 of
 	# the #20161 incident where a parent-task issue was dispatched despite
 	# the label being continuously present.
+	if _has_consolidated_label "$issue_meta_json"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: consolidated issue label present (GH#23187)" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.mgmt_label" "$_dss_t0"
+		return 1
+	fi
+
 	if printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("on hold") or index("blocked") or index("parent-task") or index("meta"))' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.mgmt_label" "$_dss_t0"

--- a/.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _has_consolidated_label() (GH#23187).
+#
+# Consolidated issues are archival records, not implementation tasks. A stale
+# lifecycle label such as status:queued must not make them dispatchable again.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_has_consolidated_label\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _has_consolidated_label from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+test_detects_consolidated_label() {
+	local meta='{"number":23187,"labels":[{"name":"status:queued"},{"name":"origin:worker"},{"name":"consolidated"}]}'
+	if _has_consolidated_label "$meta"; then
+		print_result "detects consolidated label among dispatch labels" 0
+		return 0
+	fi
+	print_result "detects consolidated label among dispatch labels" 1 \
+		"Expected exit 0 when consolidated is present"
+	return 0
+}
+
+test_absent_label_returns_nonzero() {
+	local meta='{"number":23188,"labels":[{"name":"status:queued"},{"name":"origin:worker"},{"name":"tier:standard"}]}'
+	if _has_consolidated_label "$meta"; then
+		print_result "absent consolidated label returns exit 1" 1 \
+			"Expected exit 1 when consolidated is absent"
+		return 0
+	fi
+	print_result "absent consolidated label returns exit 1" 0
+	return 0
+}
+
+test_partial_label_name_does_not_match() {
+	local meta='{"number":23189,"labels":[{"name":"needs-consolidation"},{"name":"consolidation-task"}]}'
+	if _has_consolidated_label "$meta"; then
+		print_result "partial consolidation labels do not match" 1 \
+			"Expected exit 1 for needs-consolidation/consolidation-task"
+		return 0
+	fi
+	print_result "partial consolidation labels do not match" 0
+	return 0
+}
+
+test_empty_or_invalid_meta_returns_nonzero() {
+	if _has_consolidated_label "" || _has_consolidated_label "not json"; then
+		print_result "empty or invalid meta_json returns exit 1" 1 \
+			"Expected exit 1 for empty/invalid metadata"
+		return 0
+	fi
+	print_result "empty or invalid meta_json returns exit 1" 0
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_detects_consolidated_label
+	test_absent_label_returns_nonzero
+	test_partial_label_name_does_not_match
+	test_empty_or_invalid_meta_returns_nonzero
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added a dispatch preflight guard so issues carrying the terminal consolidated label are blocked before worker launch, preventing stale status labels from re-opening archival consolidation records.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh; bash .agents/scripts/tests/test-pulse-dispatch-core-force-dispatch.sh; shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh

Resolves #23187


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 3m and 79,555 tokens on this as a headless worker.