### PR TITLE
GH#23190: perf: reuse prepared review gate status contexts

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -593,6 +593,7 @@ bot_has_real_review() {
 	local repo="$2"
 	local bot_login="$3"
 	local success_status_contexts="${4-}"
+	local success_status_contexts_prepared="${5:-false}"
 	local has_success_status_contexts="false"
 	[[ $# -ge 4 ]] && has_success_status_contexts="true"
 
@@ -637,7 +638,7 @@ bot_has_real_review() {
 			# reached success. Default fast mode intentionally preserves throughput.
 			if _requires_success_status_completion "$repo" "$bot_login"; then
 				if [[ "$has_success_status_contexts" == "true" ]]; then
-					bot_has_success_status "$pr_number" "$repo" "$bot_login" "$success_status_contexts" || {
+					bot_has_success_status "$pr_number" "$repo" "$bot_login" "$success_status_contexts" "$success_status_contexts_prepared" || {
 						echo "Strict completion: ${bot_login} settled comment lacks SUCCESS status/check" >&2
 						continue
 					}
@@ -758,12 +759,14 @@ bot_has_success_status() {
 	local repo="$2"
 	local bot_login="$3"
 	local status_contexts="${4-}"
+	local contexts_are_prepared="${5:-false}"
 
 	if [[ $# -lt 4 ]]; then
 		status_contexts=$(_get_success_status_contexts "$pr_number" "$repo") || return 1
+		contexts_are_prepared="false"
 	fi
 	[[ -z "$status_contexts" ]] && return 1
-	_status_contexts_match_bot "$bot_login" "$status_contexts" && return 0
+	_status_contexts_match_bot "$bot_login" "$status_contexts" "$contexts_are_prepared" && return 0
 	return 1
 }
 
@@ -771,14 +774,20 @@ any_bot_has_success_status() {
 	local pr_number="$1"
 	local repo="$2"
 	local status_contexts="${3-}"
+	local contexts_are_prepared="${4:-false}"
 
 	if [[ $# -lt 3 ]]; then
 		status_contexts=$(_get_success_status_contexts "$pr_number" "$repo") || return 1
+		contexts_are_prepared="false"
 	fi
 	[[ -z "$status_contexts" ]] && return 1
 
 	local prepared_contexts
-	prepared_contexts=$(_prepare_success_status_contexts "$status_contexts") || return 1
+	if [[ "$contexts_are_prepared" == "true" ]]; then
+		prepared_contexts="$status_contexts"
+	else
+		prepared_contexts=$(_prepare_success_status_contexts "$status_contexts") || return 1
+	fi
 
 	local bot
 	for bot in "${KNOWN_BOTS[@]}"; do
@@ -835,6 +844,10 @@ do_check() {
 
 	local status_contexts
 	status_contexts=$(_get_success_status_contexts "$pr_number" "$repo" || true)
+	local prepared_status_contexts=""
+	if [[ -n "$status_contexts" ]]; then
+		prepared_status_contexts=$(_prepare_success_status_contexts "$status_contexts" || true)
+	fi
 
 	local found_bots=""
 	local rate_limited_bots=""
@@ -844,7 +857,7 @@ do_check() {
 	for bot in "${KNOWN_BOTS[@]}"; do
 		if echo "$all_commenters" | grep -qi "$bot"; then
 			# Bot commented — but is it a real review or a non-review notice?
-			if bot_has_real_review "$pr_number" "$repo" "$bot" "$status_contexts"; then
+			if bot_has_real_review "$pr_number" "$repo" "$bot" "$prepared_status_contexts" true; then
 				found_bots="${found_bots}${bot} "
 			else
 				if notice_category=$(bot_get_notice_category "$pr_number" "$repo" "$bot"); then
@@ -871,7 +884,7 @@ do_check() {
 		echo "$pass_result" # nice — at least one bot posted a real review
 		echo "found: ${found_bots}" >&2
 		return 0
-	elif [[ -n "$non_review_bots" ]] && any_bot_has_success_status "$pr_number" "$repo" "$status_contexts"; then
+	elif [[ -n "$non_review_bots" ]] && any_bot_has_success_status "$pr_number" "$repo" "$prepared_status_contexts" true; then
 		# GH#22884: Some bots expose review completion only through a SUCCESS
 		# commit status after leaving a placeholder/non-review issue comment. Do
 		# not bridge to a raw skip; require the bot-authored success status before
@@ -888,7 +901,7 @@ do_check() {
 		echo "Bots posted non-review states that are not rate limits: ${non_review_bots}" >&2
 		echo "Gate will keep polling; review_gate.rate_limit_behavior only applies to true rate-limit notices." >&2
 		return 1
-	elif [[ -n "$rate_limited_bots" ]] && any_bot_has_success_status "$pr_number" "$repo" "$status_contexts"; then
+	elif [[ -n "$rate_limited_bots" ]] && any_bot_has_success_status "$pr_number" "$repo" "$prepared_status_contexts" true; then
 		# GH#3005: All bots are rate-limited in comments, but at least one
 		# posted a SUCCESS commit status check. Treat as reviewed.
 		echo "$pass_result"

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -553,6 +553,25 @@ test_any_bot_success_status_reuses_provided_contexts() {
 	return 0
 }
 
+test_any_bot_success_status_reuses_prepared_contexts() {
+	local prepare_calls=0
+	_prepare_success_status_contexts() {
+		prepare_calls=$((prepare_calls + 1))
+		return 1
+	}
+
+	local contexts
+	contexts=$'abc123def456\ncoderabbit'
+	if any_bot_has_success_status 123 'testorg/strictrepo' "$contexts" true 2>/dev/null && \
+		[[ "$prepare_calls" -eq 0 ]]; then
+		print_result "status fallback reuses prepared success contexts" 0
+	else
+		print_result "status fallback reuses prepared success contexts" 1 \
+			"prepare_calls=${prepare_calls}"
+	fi
+	return 0
+}
+
 # ---------- Unit tests: notice category classification (GH#22855) ----------
 
 install_notice_category_gh_stub() {
@@ -831,6 +850,7 @@ main() {
 	test_strict_coderabbit_pending_status_blocks_edited_comment
 	test_strict_coderabbit_success_status_passes_edited_comment
 	test_any_bot_success_status_reuses_provided_contexts
+	test_any_bot_success_status_reuses_prepared_contexts
 
 	echo ""
 	echo "=== Notice category classification (GH#22855) ==="


### PR DESCRIPTION
## Summary

Prepared review gate success status contexts once in do_check and reused them across strict completion and status fallback checks to avoid repeated parsing.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh,.agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/review-bot-gate-helper.sh .agents/scripts/review-gate-config-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh; bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh

Resolves #23190


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2m and 55,662 tokens on this as a headless worker.