### PR TITLE
GH#23199: cover dash branch restoration guard

### DIFF
--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -49,6 +49,28 @@ class TestCanonicalBranchSwitchDash(unittest.TestCase):
         self.assertIn("feature/work", reason)
         branch_authorized.assert_not_called()
 
+    def test_git_checkout_dash_denies_previous_feature_branch(self):
+        branch_authorized = self._patch_canonical_repo("feature/work")
+
+        deny = git_safety_guard._check_canonical_branch_switch_command(
+            "git checkout -", "restore the canonical repo"
+        )
+
+        self.assertIsNotNone(deny)
+        reason = deny["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("feature/work", reason)
+        branch_authorized.assert_not_called()
+
+    def test_git_switch_dash_without_previous_branch_is_ignored(self):
+        branch_authorized = self._patch_canonical_repo("")
+
+        deny = git_safety_guard._check_canonical_branch_switch_command(
+            "git switch -", "restore the canonical repo"
+        )
+
+        self.assertIsNone(deny)
+        branch_authorized.assert_not_called()
+
     def test_git_switch_dash_resolves_default_branch_before_authorization(self):
         branch_authorized = self._patch_canonical_repo("main")
         branch_authorized.return_value = True


### PR DESCRIPTION
## Summary

Added regression coverage proving canonical checkout protection resolves dash branch restoration for both git switch - and git checkout -, and ignores dash restoration only when no previous branch can be resolved.

## Files Changed

tests/test-git-safety-guard.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest tests/test-git-safety-guard.py

Resolves #23199


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 39,515 tokens on this as a headless worker.