### PR TITLE
GH#23195: refine required-check terminal classification

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -28,7 +28,7 @@ _check_required_checks_has_terminal_failure() {
 
 	local pr_sha=""
 	pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid --jq '.headRefOid' 2>/dev/null) || pr_sha=""
+		--json headRefOid --jq '.headRefOid // ""') || true
 	if [[ -z "$pr_sha" ]]; then
 		echo "[pulse-merge] _check_required_checks_has_terminal_failure: headRefOid fetch failed for PR #${pr_number} in ${repo_slug} — failing closed (t3567)" >>"$LOGFILE"
 		return 2
@@ -54,7 +54,7 @@ _check_required_checks_has_terminal_failure() {
 			($checks | map(select((.name // "") == $ctx)) | last) as $c |
 			if $c == null then false
 			elif (($c.conclusion // "" | ascii_downcase)
-				| . == "failure" or . == "cancelled" or . == "timed_out" or . == "action_required") then true
+				| . == "failure" or . == "cancelled" or . == "timed_out") then true
 			else false
 			end
 		) | map(select(.)) | length' 2>/dev/null)

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -401,13 +401,13 @@ test_required_cancel_blocks_merge() {
 	return 0
 }
 
-test_required_action_required_blocks_merge() {
+test_required_action_required_is_non_terminal() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="action_required"
-	assert_function_returns 1 "required check-run action_required → merge blocked"
-	assert_log_contains "terminal failed required context" \
-		"action_required: required-context failure logged"
+	assert_function_returns 0 "required check-run action_required → no CI repair routing"
+	assert_log_contains "no terminal failed required contexts" \
+		"action_required: non-terminal classification logged"
 	return 0
 }
 
@@ -493,7 +493,7 @@ main() {
 	test_post_merge_advisory_failure_ignored
 	test_required_failure_blocks_merge
 	test_required_cancel_blocks_merge
-	test_required_action_required_blocks_merge
+	test_required_action_required_is_non_terminal
 	test_empty_required_set_allows_merge
 	test_pending_required_blocks_merge
 	test_queued_required_is_non_terminal


### PR DESCRIPTION
## Summary

Refined required-check terminal failure classification so action_required does not trigger CI repair routing, and made the headRefOid lookup null-safe without suppressing lookup errors.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh,.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; git diff --check

Resolves #23195


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 67,569 tokens on this as a headless worker.