### PR TITLE
GH#23194: cover cached dashboard identity aliases

### DIFF
--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -71,12 +71,12 @@ else
 fi
 
 preloaded_identity_lines=$(_dashboard_identity_aliases "github-user" \
-	'canonical-operator=local-user,github-user')
+	'preloaded-operator=github-user')
 preloaded_canonical=$(printf '%s\n' "$preloaded_identity_lines" | sed -n '1p')
-if [[ "$preloaded_canonical" == "canonical-operator" ]]; then
-	pass "resolves aliases from preloaded config content"
+if [[ "$preloaded_canonical" == "preloaded-operator" ]]; then
+	pass "resolves aliases from preloaded config content without rereading disk config"
 else
-	fail "resolves aliases from preloaded config content" "canonical=${preloaded_canonical}"
+	fail "resolves aliases from preloaded config content without rereading disk config" "canonical=${preloaded_canonical}"
 fi
 
 result=$(_find_health_issue "owner/repo" "github-user" "supervisor" "[Supervisor:canonical-operator]" \


### PR DESCRIPTION
## Summary

Added regression coverage proving preloaded dashboard identity alias config is used instead of rereading the disk config, covering the already-applied review follow-up fix.

## Files Changed

.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-shared.sh .agents/scripts/migrate-health-issue-duplicates-t2687.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

Resolves #23194


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 42,562 tokens on this as a headless worker.