### PR TITLE
GH#23198: reconcile missing task counter files

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -316,17 +316,35 @@ _cas_reconcile_counter_branch() {
 		return 0
 	fi
 
-	local blob_sha tree_sha commit_sha
+	local blob_sha existing_tree tree_sha commit_sha
 	blob_sha=$(printf '%s\n' "$reconciled_counter" | git hash-object -w --stdin 2>/dev/null) || {
 		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to create reconciled counter blob"
 		_task_counter_status "unrecoverable_desync" "blob_failed"
 		return 1
 	}
-	tree_sha=$(git ls-tree "$pinned_sha" | sed "s|[0-9a-f]\{40,64\}	${COUNTER_FILE}$|${blob_sha}	${COUNTER_FILE}|" | git mktree 2>/dev/null) || {
-		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to build reconciled counter tree"
-		_task_counter_status "unrecoverable_desync" "tree_failed"
+	existing_tree=$(git ls-tree "$pinned_sha") || {
+		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to inspect reconciled counter tree"
+		_task_counter_status "unrecoverable_desync" "tree_read_failed"
 		return 1
 	}
+	if printf '%s\n' "$existing_tree" | grep -q "${COUNTER_FILE}$"; then
+		tree_sha=$(printf '%s\n' "$existing_tree" | sed "s|[0-9a-f]\{40,64\}	${COUNTER_FILE}$|${blob_sha}	${COUNTER_FILE}|" | git mktree) || {
+			log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to replace reconciled counter tree entry"
+			_task_counter_status "unrecoverable_desync" "tree_replace_failed"
+			return 1
+		}
+	else
+		tree_sha=$(
+			{
+				[[ -n "$existing_tree" ]] && printf '%s\n' "$existing_tree"
+				printf '100644 blob %s\t%s\n' "$blob_sha" "$COUNTER_FILE"
+			} | git mktree
+		) || {
+			log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to add reconciled counter tree entry"
+			_task_counter_status "unrecoverable_desync" "tree_add_failed"
+			return 1
+		}
+	fi
 	commit_sha=$(git commit-tree "$tree_sha" -p "$pinned_sha" -m "chore: reconcile task counter (${branch_counter}->${reconciled_counter})" 2>/dev/null) || {
 		log_error "UNRECOVERABLE_COUNTER_DESYNC: failed to create reconciliation commit"
 		_task_counter_status "unrecoverable_desync" "commit_failed"

--- a/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
+++ b/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
@@ -60,6 +60,32 @@ setup_desynced_remote() {
 	return 0
 }
 
+setup_missing_counter_remote() {
+	local base_dir="$1"
+	local bare_dir="${base_dir}/remote.git"
+	local work_dir="${base_dir}/work"
+
+	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || git init --bare "$bare_dir" >/dev/null 2>&1 || return 1
+	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.email "test@test.local" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.name "Test" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config commit.gpgsign false >/dev/null 2>&1 || true
+	git -C "$work_dir" config tag.gpgsign false >/dev/null 2>&1 || true
+
+	printf '# Tasks\n\n- [x] t999 seed task\n' >"${work_dir}/TODO.md"
+	git -C "$work_dir" add TODO.md >/dev/null 2>&1 || return 1
+	git -C "$work_dir" commit -m "chore: seed develop without counter" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" branch develop >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin develop >/dev/null 2>&1 || return 1
+
+	printf '1100\n' >"${work_dir}/.task-counter"
+	git -C "$work_dir" add .task-counter >/dev/null 2>&1 || return 1
+	git -C "$work_dir" commit -m "chore: add main counter" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin main >/dev/null 2>&1 || return 1
+	printf '%s\n' "$work_dir"
+	return 0
+}
+
 protect_counter_branch_pushes() {
 	local work_dir="$1"
 	local bare_dir
@@ -175,6 +201,45 @@ test_reconciliation_protected_branch_rejection_is_unrecoverable() {
 	return 0
 }
 
+test_reconciliation_adds_missing_counter_file() {
+	local name="reconciliation adds missing counter file"
+	local tmpdir work_dir output rc task_id final_counter
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+
+	work_dir=$(setup_missing_counter_remote "$tmpdir") || { fail "$name" "repo setup failed"; rm -rf "$tmpdir"; return 0; }
+
+	rc=0
+	output=$(CAS_MAX_RETRIES=3 CAS_WALL_TIMEOUT_S=20 CAS_SSH_FALLBACK_ENABLED=0 "$CLAIM_SCRIPT" \
+		--title "missing counter reconciliation test" \
+		--no-issue \
+		--repo-path "$work_dir" \
+		--counter-branch develop 2>&1) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "claim failed: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	task_id=$(printf '%s\n' "$output" | awk -F= '/^task_id=/{print $2; exit}')
+	if [[ "$task_id" != "t1100" ]]; then
+		fail "$name" "expected t1100 after reconciliation, got ${task_id:-<empty>}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	git -C "$work_dir" fetch origin develop >/dev/null 2>&1 || true
+	final_counter=$(git -C "$work_dir" show origin/develop:.task-counter 2>/dev/null | tr -d '[:space:]')
+	if [[ "$final_counter" != "1101" ]]; then
+		fail "$name" "expected develop counter 1101, got ${final_counter:-<empty>}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
 main() {
 	if [[ ! -x "$CLAIM_SCRIPT" ]]; then
 		fail "claim script executable" "$CLAIM_SCRIPT missing or not executable"
@@ -183,6 +248,7 @@ main() {
 	fi
 	test_counter_branch_desync_reconciles_before_claim
 	test_reconciliation_protected_branch_rejection_is_unrecoverable
+	test_reconciliation_adds_missing_counter_file
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ "$FAIL" -eq 0 ]] || return 1
 	return 0


### PR DESCRIPTION
## Summary

Updated task counter reconciliation to add the counter file when the target branch tree is missing it, while preserving the existing protected-branch rejection handling.

## Files Changed

.agents/scripts/claim-task-id-counter.sh,.agents/scripts/tests/test-claim-task-id-counter-desync.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/claim-task-id-counter.sh .agents/scripts/tests/test-claim-task-id-counter-desync.sh; .agents/scripts/tests/test-claim-task-id-counter-desync.sh

Resolves #23198


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.1 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 1m and 54,557 tokens on this as a headless worker.