### PR TITLE
chore: mark t3566 complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4193,7 +4193,7 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t3573 fix: block unrequested canonical branch switches #auto-dispatch #bug #framework #git-safety #interactive ref:GH#23109 pr:#23113 completed:2026-05-07
 
-- [ ] t3566 Allow breaker-held issues to retry after aidevops upgrades #bug ref:GH#23128
+- [x] t3566 Allow breaker-held issues to retry after aidevops upgrades #bug ref:GH#23128 pr:#23127 completed:2026-05-07
 
 - [x] t3574 design `/auto-browse` agent factory for browser operations and web data mining #enhancement #framework ref:GH#23132 pr:#23131 completed:2026-05-08
 


### PR DESCRIPTION
## Summary
- Mark t3566 complete in TODO.md after merged PR #23127 closed issue #23128.

## Verification
- git diff --check
- bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh

For #23128

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.2 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 4m and 199,615 tokens on this as a headless worker.
