### PR TITLE
docs: clarify RTK adaptive fallback

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -158,7 +158,7 @@ Run `aidevops security` for posture/scan/check/dismiss. Advisories arrive via `a
 ## Maintenance
 
 - Self-improvement guidance: `reference/self-improvement.md`.
-- Token-optimized CLI: use `rtk-helper.sh` for `git status/log/diff` and `gh pr list/view` when installed; not for file reads, JSON, assertions, or verbatim diffs.
+- Token-optimized CLI: start with `rtk-helper.sh` for supported noisy summaries, then rerun raw/direct commands when filtered output is insufficient; bypass for exact evidence. Full rules: `reference/context-efficient-output.md`.
 - Agent lifecycle: `tools/build-agent/build-agent.md`; OpenCode glob allowlists require `subagent_validation.py` verification.
 - Slash commands resolve through `scripts/commands/<command>.md`, then `workflows/<command>.md`.
 - macOS bash upgrade, platform support, customization, and hot deploys: `reference/bash-compat.md`, `reference/platform-support.md`, `reference/customization.md`, `reference/hot-deploy.md`.

--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -1,0 +1,41 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Context-Efficient Tool Output
+
+RTK reduces context load for noisy terminal summaries. It is an efficiency layer,
+not an evidence boundary: capability, correctness, and exact output take priority
+over token savings.
+
+## Default workflow
+
+1. **Start narrow** with `rtk-helper.sh` for supported summary commands:
+   - `rtk-helper.sh git status`
+   - `rtk-helper.sh git log --oneline -20`
+   - `rtk-helper.sh gh pr list --repo owner/repo --limit N`
+   - `rtk-helper.sh gh issue list --repo owner/repo --limit N`
+2. **Assess sufficiency**: proceed only if the filtered output contains every
+   fact needed for the next decision.
+3. **Broaden immediately** when output is incomplete, ambiguous, expanded rather
+   than reduced, or exact evidence is needed:
+   - rerun the raw/direct command;
+   - use a narrower raw command with explicit fields;
+   - read exact files with the Read tool;
+   - request logs/check output directly for terminal failures.
+
+## Always bypass RTK
+
+- File reads and source inspection.
+- JSON used for assertions, parsing, or automation decisions.
+- Exact/verbatim diffs, patches, or blame output.
+- Security scans, credential-sensitive output, or prompt-injection checks.
+- Terminal failures where omitted lines could change diagnosis.
+- Any command whose output must be cited byte-for-byte in an issue, PR, review,
+  or audit trail.
+
+## Validation notes
+
+Initial validation for GH#23212 found RTK useful for list-style GitHub context
+(`gh issue list`, `gh pr list`) and not useful for tiny `git status`, already
+compact `git log --oneline`, or full issue bodies. Prefer RTK for discovery and
+triage summaries; prefer raw output or structured fields for exact task briefs.

--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 | **Evolve Context** | Learn from sessions | `/remember`, `/recall` with SQLite FTS5 + opt-in semantic search |
 | **Pattern Tracking** | Learn what works/fails | `/patterns` command, `memory-helper.sh` |
 | **Token-Efficient Serialisation** | Minimise context overhead for structured data | [TOON format](https://github.com/marcusquinn/aidevops/blob/main/.agents/toon-format.md) — 20-60% token reduction vs JSON/YAML for agent indexes, registries, and data exchange |
-| **Token-Efficient Tool Output** | Summarise noisy terminal output without hiding evidence | RTK is installed by default during setup; use `rtk-helper.sh` for compact `git`/`gh`/test/lint summaries without RTK hook-advisory noise; aidevops bypasses compression for file reads, JSON assertions, exact diffs, security scans, and other verbatim evidence |
+| **Token-Efficient Tool Output** | Summarise noisy terminal output without hiding evidence | RTK is installed by default during setup; start with `rtk-helper.sh` for compact supported summaries, then rerun raw/direct commands when filtered output is insufficient; bypass compression for file reads, JSON assertions, exact diffs, security scans, and other verbatim evidence |
 | **Cost-Aware Routing** | Match model to task complexity | `model-routing.md` with provider-aware tier guidance, `/route` command |
 | **Model Comparison** | Compare models side-by-side | `/compare-models` (live data), `/compare-models-free` (offline) |
 | **Response Scoring** | Evaluate actual model outputs | `/score-responses` with structured criteria |


### PR DESCRIPTION
## Summary
- Add `reference/context-efficient-output.md` with RTK-first, raw-fallback decision rules.
- Update always-loaded guidance to point to the progressive-disclosure reference instead of carrying detailed rules inline.
- Document the narrow-first/broaden-on-insufficient-output behavior in README context-efficiency guidance.

## Testing results
- Created tracking issue #23212.
- Posted initial raw vs `rtk-helper.sh` benchmark results on #23212.
- Early results: RTK helps list-style GitHub discovery (`gh issue list`, `gh pr list`) but not tiny status, compact logs, or full issue bodies.

## Verification
- `git diff --cached --check`
- `npx markdownlint-cli2 .agents/reference/context-efficient-output.md README.md`

For #23212

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.2 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2d 14h and 904,104 tokens on this with the user in an interactive session.
