### PR TITLE
t3583: fix worker recovery follow-through

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -750,7 +750,11 @@ _exit_trap_handler() {
 	# work is reported distinctly to avoid zero-output brief-rewrite holds.
 	_push_wip_commits_on_exit
 	if [[ "${_WORKER_DIRTY_WORK_PRESERVED:-0}" == "1" ]]; then
-		reason="worker_dirty_work_preserved"
+		if _recover_dirty_worker_pr "$session_key"; then
+			reason="worker_complete"
+		else
+			reason="worker_dirty_work_preserved"
+		fi
 	fi
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
@@ -759,6 +763,24 @@ _exit_trap_handler() {
 	_release_session_lock "$session_key"
 	_update_dispatch_ledger "$session_key" "fail"
 	return 0
+}
+
+_recover_dirty_worker_pr() {
+	local session_key="$1"
+	local work_dir="${_WORKER_WORKTREE_PATH:-}"
+	local repo_slug="${DISPATCH_REPO_SLUG:-}"
+	local branch_name=""
+
+	[[ -n "$work_dir" && -d "$work_dir" && -n "$repo_slug" ]] || return 1
+	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	case "$branch_name" in
+	HEAD | main | master | "") return 1 ;;
+	esac
+	if declare -F _attempt_orphan_recovery_pr >/dev/null 2>&1; then
+		_attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug"
+		return $?
+	fi
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -861,11 +861,9 @@ _has_committed_to_main_cache_label() {
 #######################################
 # Detect terminal consolidated issues before worker dispatch.
 #
-# Consolidated issues are archival handoff/spec records produced by issue
-# consolidation workers. They intentionally carry `consolidated` and
-# `origin:worker` so provenance is preserved, but they are not implementation
-# tasks. Blocking them here prevents stale status labels such as
-# `status:queued` from re-opening a completed consolidation thread.
+# Consolidated issues are archival handoff/spec records when they only carry
+# the provenance label. Review-feedback consolidation issues are dispatchable
+# implementation specs and carry quality/source labels; do not block those.
 #
 # Args:
 #   $1 - issue_meta_json (pre-fetched JSON with a .labels array)
@@ -877,8 +875,13 @@ _has_committed_to_main_cache_label() {
 _has_consolidated_label() {
 	local issue_meta_json="$1"
 	[[ -n "$issue_meta_json" ]] || return 1
-	if printf '%s' "$issue_meta_json" |
-		jq -e '.labels | map(.name) | index("consolidated")' >/dev/null 2>&1; then
+	if printf '%s' "$issue_meta_json" | jq -e '
+		(.labels | map(.name)) as $labels
+		| ($labels | index("consolidated"))
+		and (($labels | index("quality-debt")) | not)
+		and (($labels | index("source:review-feedback")) | not)
+		and (($labels | index("source:ci-feedback")) | not)
+	' >/dev/null 2>&1; then
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1268,6 +1268,7 @@ _dlw_nohup_launch() {
 		HEADLESS=1
 		FULL_LOOP_HEADLESS=true
 		WORKER_ISSUE_NUMBER="$issue_number"
+		AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1
 	)
 	if _dlw_min_worker_floor_active; then
 		worker_cmd+=(

--- a/.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh
@@ -74,6 +74,17 @@ test_absent_label_returns_nonzero() {
 	return 0
 }
 
+test_review_feedback_consolidated_is_dispatchable() {
+	local meta='{"number":4648,"labels":[{"name":"status:available"},{"name":"origin:worker"},{"name":"consolidated"},{"name":"quality-debt"},{"name":"source:review-feedback"}]}'
+	if _has_consolidated_label "$meta"; then
+		print_result "review-feedback consolidated issues are dispatchable" 1 \
+			"Expected exit 1 for consolidated review-feedback implementation specs"
+		return 0
+	fi
+	print_result "review-feedback consolidated issues are dispatchable" 0
+	return 0
+}
+
 test_partial_label_name_does_not_match() {
 	local meta='{"number":23189,"labels":[{"name":"needs-consolidation"},{"name":"consolidation-task"}]}'
 	if _has_consolidated_label "$meta"; then
@@ -103,6 +114,7 @@ main() {
 
 	test_detects_consolidated_label
 	test_absent_label_returns_nonzero
+	test_review_feedback_consolidated_is_dispatchable
 	test_partial_label_name_does_not_match
 	test_empty_or_invalid_meta_returns_nonzero
 

--- a/TODO.md
+++ b/TODO.md
@@ -957,6 +957,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3582 Make pulse self-heal awardsapp blockers ref:GH#23215 pr:#23216 completed:2026-05-08
 
+- [ ] t3583 Improve pulse recovery for orphaned worker output ref:GH#23217
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- pass worker worktree owner-transfer intent through pulse-launched workers to stop `worker_worktree_live_owner` loops
- recover preserved dirty worker output by attempting the orphan PR path before releasing as unresolved dirty work
- allow review/CI feedback consolidated issues to dispatch while keeping archival consolidated records blocked

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh`
- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/headless-runtime-failure.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD`

## Notes
- `.agents/scripts/linters-local.sh` was run; targeted checks passed, with unrelated TODO markdownlint noise and pulse canary/ratchet timeouts observed during the broad gate.

Resolves #23217

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.4 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 15h 48m and 4,767,602 tokens on this with the user in an interactive session.
