### PR TITLE
t3583: fix consolidated label predicate

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -877,10 +877,10 @@ _has_consolidated_label() {
 	[[ -n "$issue_meta_json" ]] || return 1
 	if printf '%s' "$issue_meta_json" | jq -e '
 		(.labels | map(.name)) as $labels
-		| ($labels | index("consolidated"))
-		and (($labels | index("quality-debt")) | not)
-		and (($labels | index("source:review-feedback")) | not)
-		and (($labels | index("source:ci-feedback")) | not)
+		| (($labels | index("consolidated")) != null)
+		and (($labels | index("quality-debt")) == null)
+		and (($labels | index("source:review-feedback")) == null)
+		and (($labels | index("source:ci-feedback")) == null)
 	' >/dev/null 2>&1; then
 		return 0
 	fi


### PR DESCRIPTION
## Summary
- fix the consolidated-label predicate to treat `jq index()` results with explicit null checks
- preserve the intended behavior from #23218: archival consolidated issues stay blocked, review/CI feedback consolidated specs remain dispatchable

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-consolidated-label.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh`

Ref #23217

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.5 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 16h 2m and 4,779,645 tokens on this with the user in an interactive session.
