### PR TITLE
GH#23220: add CodeRabbit post-merge init option

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -679,6 +679,78 @@ _init_scaffold_scope_gated_files() {
 	return 0
 }
 
+# Offer CodeRabbit's post-merge review completion setting during code-quality init.
+# CodeRabbit reads this from the repository's .coderabbit.yaml, so this is repo
+# policy rather than a personal aidevops preference.
+_init_configure_coderabbit_abort_on_close() {
+	local project_root="$1"
+	local enable_code_quality="$2"
+	local config_file="$project_root/.coderabbit.yaml"
+	local desired="${AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE:-}"
+
+	[[ "$enable_code_quality" == "true" ]] || return 0
+
+	if [[ -z "$desired" && -t 0 && "${AIDEVOPS_NON_INTERACTIVE:-false}" != "true" ]]; then
+		printf '%b' "${BLUE}[INFO]${NC} CodeRabbit option: keep reviews running after merge so aidevops can turn useful findings into follow-up issues? [y/N] "
+		local reply=""
+		read -r reply || reply=""
+		case "$reply" in
+		[yY] | [yY][eE][sS]) desired="false" ;;
+		*) desired="" ;;
+		esac
+	fi
+
+	if [[ -z "$desired" ]]; then
+		print_info "CodeRabbit post-merge review completion not changed (set AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE=false to enable during init)"
+		return 0
+	fi
+
+	case "$desired" in
+	true | false) ;;
+	*)
+		print_warning "Ignoring invalid AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE='$desired' (expected true or false)"
+		return 0
+		;;
+	esac
+
+	if ! command -v python3 >/dev/null 2>&1; then
+		print_warning "Python 3 unavailable; skipping CodeRabbit .coderabbit.yaml update"
+		return 0
+	fi
+
+	python3 - "$config_file" "$desired" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+desired = sys.argv[2]
+
+if path.exists():
+    text = path.read_text()
+else:
+    text = ""
+
+line = f"  abort_on_close: {desired}"
+
+if not text.strip():
+    text = f"reviews:\n{line}\n"
+elif re.search(r"(?m)^\s*abort_on_close:\s*(true|false)\s*$", text):
+    text = re.sub(r"(?m)^(\s*abort_on_close:\s*)(true|false)(\s*)$", rf"\g<1>{desired}\g<3>", text, count=1)
+elif re.search(r"(?m)^reviews:\s*$", text):
+    text = re.sub(r"(?m)^reviews:\s*$", f"reviews:\n{line}", text, count=1)
+else:
+    if not text.endswith("\n"):
+        text += "\n"
+    text += f"\nreviews:\n{line}\n"
+
+path.write_text(text)
+PY
+
+	print_success "Set CodeRabbit reviews.abort_on_close: $desired in .coderabbit.yaml"
+	return 0
+}
+
 # Init command - initialize aidevops in a project
 cmd_init() {
 	local features="${1:-all}"
@@ -1227,6 +1299,11 @@ GITATTRSEOF
 	# nesting depth and function length (t2265).
 	_init_scaffold_scope_gated_files "$project_root" "$init_scope" "$repo_name"
 
+	# Offer CodeRabbit's repo-level post-merge review completion setting when
+	# code-quality support is enabled. This lets merged-PR findings become
+	# aidevops follow-up issues instead of being aborted by CodeRabbit.
+	_init_configure_coderabbit_abort_on_close "$project_root" "$enable_code_quality"
+
 	# ─── Badge initialization (t2975) ────────────────────────────────────────
 	# Install the loc-badge caller workflow and seed the canonical README badge
 	# block in fresh repos. Both operations are idempotent. Skip for local_only
@@ -1342,6 +1419,7 @@ GITATTRSEOF
 	[[ -f "$project_root/.cursorrules" ]] && init_files+=(".cursorrules")
 	[[ -f "$project_root/.windsurfrules" ]] && init_files+=(".windsurfrules")
 	[[ -f "$project_root/.clinerules" ]] && init_files+=(".clinerules")
+	[[ -f "$project_root/.coderabbit.yaml" ]] && init_files+=(".coderabbit.yaml")
 	[[ -d "$project_root/.github" ]] && init_files+=(".github/")
 	[[ -f "$project_root/.sops.yaml" ]] && init_files+=(".sops.yaml")
 	[[ -d "$project_root/schemas" ]] && init_files+=("schemas/")

--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -679,9 +679,6 @@ _init_scaffold_scope_gated_files() {
 	return 0
 }
 
-# Offer CodeRabbit's post-merge review completion setting during code-quality init.
-# CodeRabbit reads this from the repository's .coderabbit.yaml, so this is repo
-# policy rather than a personal aidevops preference.
 _init_configure_coderabbit_abort_on_close() {
 	local project_root="$1"
 	local enable_code_quality="$2"
@@ -726,10 +723,7 @@ import sys
 path = Path(sys.argv[1])
 desired = sys.argv[2]
 
-if path.exists():
-    text = path.read_text()
-else:
-    text = ""
+text = path.read_text() if path.exists() else ""
 
 line = f"  abort_on_close: {desired}"
 
@@ -1299,9 +1293,6 @@ GITATTRSEOF
 	# nesting depth and function length (t2265).
 	_init_scaffold_scope_gated_files "$project_root" "$init_scope" "$repo_name"
 
-	# Offer CodeRabbit's repo-level post-merge review completion setting when
-	# code-quality support is enabled. This lets merged-PR findings become
-	# aidevops follow-up issues instead of being aborted by CodeRabbit.
 	_init_configure_coderabbit_abort_on_close "$project_root" "$enable_code_quality"
 
 	# ─── Badge initialization (t2975) ────────────────────────────────────────

--- a/.agents/scripts/tests/test-init-scope.sh
+++ b/.agents/scripts/tests/test-init-scope.sh
@@ -399,6 +399,30 @@ test_label_sync_init_hook() {
 	return 0
 }
 
+test_coderabbit_abort_on_close_init_hook() {
+	echo ""
+	echo "=== Testing CodeRabbit abort_on_close init hook ==="
+
+	local init_body
+	init_body=$(sed -n '/_init_configure_coderabbit_abort_on_close() {/,/^}/p' "$AIDEVOPS_INIT_LIB")
+	local init_tail
+	init_tail=$(sed -n '/_init_scaffold_scope_gated_files/,/Badge initialization/p' "$AIDEVOPS_INIT_LIB")
+	local init_files
+	init_files=$(sed -n '/local init_files=()/,/local committed=false/p' "$AIDEVOPS_INIT_LIB")
+	local rc
+
+	if [[ "$init_body" == *"AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE"* && "$init_body" == *"abort_on_close"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init exposes CodeRabbit abort_on_close option" "$rc"
+
+	if [[ "$init_tail" == *"_init_configure_coderabbit_abort_on_close \"\$project_root\" \"\$enable_code_quality\""* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init calls CodeRabbit abort_on_close hook" "$rc"
+
+	if [[ "$init_files" == *".coderabbit.yaml"* ]]; then rc=0; else rc=1; fi
+	print_result "cmd_init includes .coderabbit.yaml in init commit" "$rc"
+
+	return 0
+}
+
 # ---- Run all tests ----
 
 echo "test-init-scope.sh — init_scope scaffolding gate tests (t2265)"
@@ -412,6 +436,7 @@ test_scaffold_public_scope
 test_aidevops_json_roundtrip
 test_backward_compat
 test_label_sync_init_hook
+test_coderabbit_abort_on_close_init_hook
 
 echo ""
 echo "============================================================="

--- a/.agents/tools/code-review/coderabbit.md
+++ b/.agents/tools/code-review/coderabbit.md
@@ -28,6 +28,17 @@ tools:
 - **Rate limits**: Free 2/hr, Pro 8/hr (learnings-powered)
 - **Docs**: https://docs.coderabbit.ai/cli/overview
 
+## Repository Config Interest
+
+If the user wants CodeRabbit findings to keep arriving after an aidevops-managed PR is merged, suggest the repo-level `.coderabbit.yaml` setting:
+
+```yaml
+reviews:
+  abort_on_close: false
+```
+
+Trade-off: this can surface useful post-merge findings for aidevops to file as follow-up issues, but may add comments on already-merged PRs. Keep aidevops review-bot gate protections unless verified noise/latency data shows they should be relaxed.
+
 ## CLI Usage
 
 | Mode | Command | Use Case |


### PR DESCRIPTION
## Summary

- Documents when to use CodeRabbit `reviews.abort_on_close: false` so post-merge findings can become aidevops follow-up issues.
- Adds an opt-in `aidevops init` CodeRabbit config prompt/env path for code-quality repos.
- Covers the init hook and `.coderabbit.yaml` commit inclusion in regression tests.

## Verification

- `bash .agents/scripts/tests/test-init-scope.sh`
- `shellcheck .agents/scripts/aidevops-cli/aidevops-init-lib.sh .agents/scripts/tests/test-init-scope.sh`
- Smoke-tested `_init_configure_coderabbit_abort_on_close` with `AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE=false`.

Resolves #23220
