### PR TITLE
feat: add RTK output comparison diagnostics

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -23,6 +23,29 @@ over token savings.
    - read exact files with the Read tool;
    - request logs/check output directly for terminal failures.
 
+## Diagnostics workflow
+
+When RTK output seems misleading, too large, too small, or insufficient for a
+decision, record a comparison before changing guidance:
+
+```bash
+rtk-helper.sh --compare gh pr list --repo owner/repo --limit 10
+```
+
+The comparison reports raw vs RTK-filtered exit codes, bytes, approximate token
+counts, line counts, and a first-pass recommendation. It intentionally omits the
+command output to avoid copying noisy or sensitive data into diagnostics. Rerun
+the raw command directly when exact evidence is needed.
+
+Use comparison results to classify a command:
+
+- **Good first-pass RTK candidate**: exit codes match, output shrinks, and the
+  summary preserves all facts needed for the next decision.
+- **Raw or narrower command preferred**: output expands, output is unchanged, or
+  structured fields can answer the question more precisely.
+- **Unsafe for RTK**: exit codes differ, omitted lines could alter diagnosis, or
+  exact evidence/security/JSON/diff semantics are required.
+
 ## Always bypass RTK
 
 - File reads and source inspection.
@@ -39,3 +62,11 @@ Initial validation for GH#23212 found RTK useful for list-style GitHub context
 (`gh issue list`, `gh pr list`) and not useful for tiny `git status`, already
 compact `git log --oneline`, or full issue bodies. Prefer RTK for discovery and
 triage summaries; prefer raw output or structured fields for exact task briefs.
+
+For future regressions, capture:
+
+1. the exact command;
+2. `rtk-helper.sh --compare ...` output;
+3. whether the RTK-filtered response was sufficient, required fallback, or was
+   unsafe for RTK;
+4. the raw command output only when it is safe and necessary to prove the issue.

--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -15,9 +15,14 @@ usage() {
 	cat <<'EOF'
 Usage:
   rtk-helper.sh COMMAND [ARGS...]
+  rtk-helper.sh --compare COMMAND [ARGS...]
 
 Runs `rtk COMMAND [ARGS...]` for explicit token-optimized commands and strips
 RTK's repeated no-hook advisory from output. Exit status is preserved.
+
+`--compare` runs both raw and RTK-filtered forms, then prints a diagnostic
+summary with exit codes, bytes, approximate token counts, and reduction. It does
+not print command output; rerun the raw command when exact evidence is needed.
 
 Use only for supported noisy summaries such as:
   rtk-helper.sh git status
@@ -45,16 +50,97 @@ PY
 	return 0
 }
 
+compare_rtk_output() {
+	if [[ $# -eq 0 ]]; then
+		usage
+		return 2
+	fi
+
+	local tmp_raw=""
+	local tmp_rtk=""
+	local tmp_filtered=""
+	tmp_raw=$(mktemp "${TMPDIR:-/tmp}/aidevops-rtk-raw.XXXXXX")
+	tmp_rtk=$(mktemp "${TMPDIR:-/tmp}/aidevops-rtk-proxied.XXXXXX")
+	tmp_filtered=$(mktemp "${TMPDIR:-/tmp}/aidevops-rtk-filtered.XXXXXX")
+
+	local raw_rc=0
+	local rtk_rc=0
+	set +e
+	"$@" >"$tmp_raw" 2>&1
+	raw_rc=$?
+	rtk "$@" >"$tmp_rtk" 2>&1
+	rtk_rc=$?
+	set -e
+
+	filter_rtk_advisory "$tmp_rtk" >"$tmp_filtered"
+
+	python3 - "$tmp_raw" "$tmp_filtered" "$raw_rc" "$rtk_rc" "$*" <<'PY'
+import math
+import sys
+
+raw_path, rtk_path, raw_rc, rtk_rc, command = sys.argv[1:]
+
+def stats(path):
+    with open(path, "rb") as fh:
+        data = fh.read()
+    text = data.decode("utf-8", errors="replace")
+    return {
+        "bytes": len(data),
+        "lines": 0 if not text else len(text.splitlines()),
+        "approx_tokens": int(math.ceil(len(data) / 4.0)),
+    }
+
+raw = stats(raw_path)
+rtk = stats(rtk_path)
+delta = raw["bytes"] - rtk["bytes"]
+percent = (delta / raw["bytes"] * 100.0) if raw["bytes"] else 0.0
+same_rc = "yes" if raw_rc == rtk_rc else "no"
+
+print("## RTK output comparison")
+print("")
+print(f"Command: `{command}`")
+print("")
+print("| Form | Exit | Bytes | Approx tokens | Lines |")
+print("|---|---:|---:|---:|---:|")
+print(f"| Raw | {raw_rc} | {raw['bytes']} | {raw['approx_tokens']} | {raw['lines']} |")
+print(f"| RTK-filtered | {rtk_rc} | {rtk['bytes']} | {rtk['approx_tokens']} | {rtk['lines']} |")
+print("")
+print(f"Reduction: {delta} bytes ({percent:.1f}%). Same exit code: {same_rc}.")
+print("")
+print("Decision guidance:")
+if raw_rc != rtk_rc:
+    print("- Broaden immediately: exit codes differ, so use the raw command for diagnosis.")
+elif delta <= 0:
+    print("- Prefer raw or a narrower structured command: RTK did not reduce this output.")
+else:
+    print("- RTK is useful for first-pass discovery if all decision facts are present.")
+print("- For exact evidence, JSON assertions, diffs, security scans, or terminal failures, rerun raw/direct commands.")
+PY
+
+	rm -f "$tmp_raw" "$tmp_rtk" "$tmp_filtered"
+	return 0
+}
+
 main() {
 	if [[ $# -eq 0 ]]; then
 		usage
 		return 0
 	fi
 
-	case "${1:-}" in
+	local mode="${1:-}"
+	case "$mode" in
 	--help | -h | help)
 		usage
 		return 0
+		;;
+	--compare | compare)
+		shift
+		if ! command -v rtk >/dev/null 2>&1; then
+			log_error "rtk not found; run setup.sh or install RTK first"
+			return 127
+		fi
+		compare_rtk_output "$@"
+		return $?
 		;;
 	esac
 

--- a/.agents/scripts/tests/test-rtk-helper.sh
+++ b/.agents/scripts/tests/test-rtk-helper.sh
@@ -58,9 +58,19 @@ if [[ "${1:-}" == "fail" ]]; then
   printf 'failure body\n'
   exit 7
 fi
+if [[ "${1:-}" == "samplecmd" ]]; then
+  printf 'short\n'
+  exit 0
+fi
 printf 'payload: %s\n' "$*"
 STUB
 chmod +x "${TMPDIR_TEST}/rtk"
+
+cat >"${TMPDIR_TEST}/samplecmd" <<'STUB'
+#!/usr/bin/env bash
+printf 'long raw payload with extra diagnostic detail\n'
+STUB
+chmod +x "${TMPDIR_TEST}/samplecmd"
 
 PATH="${TMPDIR_TEST}:$PATH" output=$("$HELPER" git status)
 assert_not_contains "strips no-hook advisory" "No hook installed" "$output"
@@ -77,6 +87,12 @@ else
 fi
 assert_contains "preserves failure output" "failure body" "$fail_output"
 assert_not_contains "strips advisory on failure" "No hook installed" "$fail_output"
+
+PATH="${TMPDIR_TEST}:$PATH" compare_output=$("$HELPER" --compare samplecmd)
+assert_contains "compare emits diagnostic heading" "RTK output comparison" "$compare_output"
+assert_contains "compare records same exit code" "Same exit code: yes" "$compare_output"
+assert_contains "compare emits decision guidance" "Decision guidance" "$compare_output"
+assert_not_contains "compare strips advisory" "No hook installed" "$compare_output"
 
 printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
 if [[ "$fail_count" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Add `rtk-helper.sh --compare` so future RTK diagnostics can compare raw vs RTK-filtered exit codes, bytes, approximate tokens, and line counts without dumping command output.
- Extend focused RTK helper tests to cover the comparison path and advisory stripping.
- Expand `reference/context-efficient-output.md` with diagnostic capture rules for future regressions.

## Why
This keeps enough guidance and tooling in aidevops for future issues: agents can prove whether RTK helped, required fallback, or was unsafe for a command without relying on anecdotal session notes.

## Verification
- `shellcheck .agents/scripts/rtk-helper.sh .agents/scripts/tests/test-rtk-helper.sh`
- `bash -n .agents/scripts/rtk-helper.sh`
- `bash -n .agents/scripts/tests/test-rtk-helper.sh`
- `.agents/scripts/tests/test-rtk-helper.sh`
- `npx markdownlint-cli2 .agents/reference/context-efficient-output.md`
- `git diff --check`

For #23212

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.7 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2d 19h and 1,430,067 tokens on this with the user in an interactive session.
