### PR TITLE
fix: guard failure recovery on default branch (GH#23243)

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -371,6 +371,41 @@ _preserve_no_activity_output() {
 # =============================================================================
 
 #######################################
+# Resolve the repository default branch for worker-output guards.
+#
+# Args:
+#   $1 - work_dir (worktree root; must be a git repo)
+#######################################
+_hrw_resolve_default_branch() {
+	local work_dir="$1"
+	local default_branch=""
+
+	default_branch=$(git -C "$work_dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+	if [[ "$default_branch" == origin/* ]]; then
+		default_branch="${default_branch#origin/}"
+	fi
+
+	if [[ -z "$default_branch" ]]; then
+		for default_branch in main master; do
+			if git -C "$work_dir" show-ref --verify --quiet "refs/remotes/origin/${default_branch}" 2>/dev/null || \
+				git -C "$work_dir" show-ref --verify --quiet "refs/heads/${default_branch}" 2>/dev/null; then
+				printf '%s' "$default_branch"
+				return 0
+			fi
+		done
+		default_branch=""
+	fi
+
+	if [[ -z "$default_branch" ]]; then
+		default_branch=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+		[[ "$default_branch" == "HEAD" ]] && default_branch=""
+	fi
+
+	printf '%s' "$default_branch"
+	return 0
+}
+
+#######################################
 # Detect whether a worker produced any tangible output.
 #
 # Checks three independent signals. Returns 0 (true — has output) if ANY
@@ -445,15 +480,14 @@ _worker_produced_output() {
 	# (main/master), Signal 2 ALWAYS matches because the default branch exists
 	# on the remote — every worker that exits without checking out a feature
 	# branch was previously misclassified as branch_orphan. Resolve the default
-	# branch via origin/HEAD symbolic-ref (with env + literal fallback) and skip
+	# branch via origin/HEAD, common branch fallbacks, then HEAD, and skip
 	# Signal 2 entirely when branch_name matches it. The signal is meaningless
 	# on default branches: there is no orphan branch to recover.
 	local has_pushed_branch=0
 	local branch_name=""
 	local default_branch=""
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-	default_branch=$(git -C "$work_dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
-		| sed 's|^origin/||' || true)
+	default_branch=$(_hrw_resolve_default_branch "$work_dir")
 	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
 	if [[ -n "$branch_name" && "$branch_name" != "HEAD" && "$branch_name" != "$default_branch" ]]; then
 		local remote_ref=""
@@ -630,7 +664,11 @@ _recover_worker_output_on_failure() {
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 
-	if [[ -n "$repo_slug" && -n "$issue_number" && -n "$branch_name" && "$branch_name" != "HEAD" ]] && \
+	local default_branch=""
+	default_branch=$(_hrw_resolve_default_branch "$work_dir")
+	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
+
+	if [[ -n "$repo_slug" && -n "$issue_number" && -n "$branch_name" && "$branch_name" != "HEAD" && "$branch_name" != "$default_branch" ]] && \
 		declare -F _pr_exists_for_branch_or_issue >/dev/null 2>&1; then
 		local pr_existence=""
 		pr_existence=$(_pr_exists_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -267,6 +267,35 @@ test_feature_branch_with_pr_returns_pr_exists() {
 	return 0
 }
 
+test_failure_recovery_ignores_default_branch_pr_match() {
+	make_repo_pair "case5" || {
+		print_result "case 5: failure recovery ignores default branch PR match" 1 "fixture setup failed"
+		return 0
+	}
+	(
+		cd "$WORK_DIR" || exit 1
+		printf '%s\n' "local change" > local.txt
+		git add local.txt
+		git commit -q -m "local commit on main"
+	) || {
+		print_result "case 5: failure recovery ignores default branch PR match" 1 "commit setup failed"
+		return 0
+	}
+	export STUB_PR_COUNT=1
+	local got="recovered"
+	if _recover_worker_output_on_failure "issue-1005" "$WORK_DIR" >/dev/null 2>&1; then
+		got="recovered"
+	else
+		got="continued_failure"
+	fi
+	if [[ "$got" == "continued_failure" ]]; then
+		print_result "case 5: failure recovery ignores default branch PR match" 0
+	else
+		print_result "case 5: failure recovery ignores default branch PR match" 1 "got: $got (expected continued_failure)"
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Run
 # -----------------------------------------------------------------------------
@@ -275,6 +304,7 @@ test_main_no_commits_no_pr_returns_noop
 test_main_with_local_commits_no_pr_returns_noop_t2899
 test_feature_branch_pushed_no_pr_returns_branch_orphan
 test_feature_branch_with_pr_returns_pr_exists
+test_failure_recovery_ignores_default_branch_pr_match
 
 printf '\nRan %d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary
- Added a shared default-branch resolver for worker output guards using origin/HEAD, main/master, then HEAD fallback.
- Prevented failure-path PR recovery from treating default-branch checkouts as recoverable output.
- Added a regression case for default-branch failure recovery with a PR-list match.

Resolves #23243

## Testing
- bash .agents/scripts/tests/test-worker-output-classification.sh
- shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-worker-output-classification.sh

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2m and 63,482 tokens on this as a headless worker.
