### PR TITLE
GH#23240: fix: refresh pulse guardrail telemetry

### DIFF
--- a/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
+++ b/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
@@ -30,13 +30,14 @@ _dispatch_recent_current_state_counts() {
 import json
 import sys
 import time
+from collections import deque
 
 metrics_path, log_path, window = sys.argv[1], sys.argv[2], int(sys.argv[3])
 since = time.time() - window
 successes = failures = rate_limits = 0
 try:
     with open(metrics_path, "r", encoding="utf-8", errors="replace") as handle:
-        for raw in handle.readlines()[-2000:]:
+        for raw in deque(handle, 2000):
             try:
                 item = json.loads(raw)
             except json.JSONDecodeError:
@@ -63,7 +64,7 @@ try:
     # pulse.log lines usually do not carry machine timestamps, so use the recent tail
     # as a bounded local current-state proxy rather than issuing API reads.
     with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
-        lines = handle.readlines()[-2000:]
+        lines = deque(handle, 2000)
     for raw in lines:
         line = raw.lower()
         if "pr opened" in line or "opened pr" in line or "pr merged" in line or "merged pr" in line:
@@ -144,8 +145,8 @@ _dispatch_apply_current_state_guardrails() {
 		echo "[pulse-wrapper] Dispatch current-state guardrail: reason=${reason} capped_available=${capped_slots}/${available_slots} successes=${successes} failures=${failures} rate_limits=${rate_limits} healthy_prs=${healthy_prs} no_dispatchable=${no_dispatchable}" >>"$LOGFILE"
 		_dispatch_stats_increment "pulse_dispatch_current_state_guardrail_applied"
 		_dispatch_stats_increment_candidate_failed "$reason"
-		_dispatch_stats_gauge "pulse_dispatch_guardrail_available_slots" "$capped_slots"
 	fi
+	_dispatch_stats_gauge "pulse_dispatch_guardrail_available_slots" "$capped_slots"
 
 	printf '%s %s %s\n' "$max_workers" "$active_workers" "$capped_slots"
 	return 0

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -209,12 +209,13 @@ _dispatch_latest_metric_value() {
 	python3 - "$metrics_file" "$metric_key" <<'PY'
 import json
 import sys
+from collections import deque
 
 path, key = sys.argv[1], sys.argv[2]
 value = ""
 try:
     with open(path, "r", encoding="utf-8", errors="replace") as handle:
-        for raw in handle.readlines()[-1000:]:
+        for raw in deque(handle, 1000):
             try:
                 item = json.loads(raw)
             except json.JSONDecodeError:
@@ -252,6 +253,7 @@ _dispatch_recent_worker_pressure_counts() {
 import json
 import sys
 import time
+from collections import deque
 
 path, ttl = sys.argv[1], int(sys.argv[2])
 since = time.time() - ttl
@@ -259,7 +261,7 @@ failures = 0
 rate_limits = 0
 try:
     with open(path, "r", encoding="utf-8", errors="replace") as handle:
-        for raw in handle.readlines()[-1000:]:
+        for raw in deque(handle, 1000):
             try:
                 item = json.loads(raw)
             except json.JSONDecodeError:

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -142,7 +142,7 @@ test_clean_state_preserves_available_slots() {
 	reset_guardrail_env
 	local slots
 	slots=$(guardrail_slots "3 1 0 0 0" 8)
-	if [[ "$slots" == "8" ]]; then
+	if [[ "$slots" == "8" ]] && grep -q '^pulse_dispatch_guardrail_available_slots=8$' "$STATS_GAUGE_FILE"; then
 		print_result "guardrail: clean current state preserves safe slots" 0
 	else
 		print_result "guardrail: clean current state preserves safe slots" 1 "slots=${slots}"


### PR DESCRIPTION
## Summary

Use bounded deque tails for pulse dispatch metrics/log parsing and refresh the current-state guardrail available-slots gauge even when no cap is active.

## Files Changed

.agents/scripts/pulse-dispatch-current-state-guardrails.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: .agents/scripts/tests/test-pulse-current-state-guardrails.sh; PASS: shellcheck .agents/scripts/pulse-dispatch-current-state-guardrails.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh; WARN: .agents/scripts/linters-local.sh reports pre-existing/advisory repository-wide issues and pulse canary exit 143 unrelated to touched files

Resolves #23240


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 11m and 68,841 tokens on this as a headless worker.