### PR TITLE
GH#23256: fix rtk helper cleanup followup

### DIFF
--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -125,7 +125,7 @@ print("- For exact evidence, JSON assertions, diffs, security scans, or terminal
 PY
 
 	rm -f "$tmp_raw" "$tmp_filtered"
-	return 0
+	return "$rtk_rc"
 }
 
 main() {
@@ -155,9 +155,12 @@ main() {
 		;;
 	esac
 
-	local tmp_output
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+
+	local tmp_output=""
 	tmp_output=$(mktemp "${TMPDIR:-/tmp}/aidevops-rtk.XXXXXX")
-	trap 'rm -f "${tmp_output:-}"' EXIT
+	push_cleanup "rm -f '${tmp_output}'"
 
 	local rc=0
 	set +e


### PR DESCRIPTION
## Summary

Applied cleanup-stack handling in rtk-helper main and preserved compare-mode exit propagation so review follow-up diagnostics do not mask failures.

## Files Changed

.agents/scripts/rtk-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/rtk-helper.sh; bash -n .agents/scripts/rtk-helper.sh; fake-rtk regression checks for main and --compare exit-code propagation

Resolves #23256


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 3m and 43,090 tokens on this as a headless worker.