### PR TITLE
GH#23257: use label constants in feedback backfill

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -86,6 +86,7 @@ fi
 [[ -n "${_PIR_BOOL_FALSE+x}" ]] || _PIR_BOOL_FALSE=false
 [[ -n "${_PIR_AUTO_DISPATCH_LABEL+x}" ]] || _PIR_AUTO_DISPATCH_LABEL="auto-dispatch"
 [[ -n "${_PIR_NMR_LABEL+x}" ]] || _PIR_NMR_LABEL="needs-maintainer-review"
+[[ -n "${_PIR_TIER_STANDARD+x}" ]] || _PIR_TIER_STANDARD="tier:standard"
 
 #######################################
 # t2773: Read cached open issue list for a slug from PULSE_PREFETCH_CACHE_FILE.
@@ -482,6 +483,8 @@ _normalize_get_feedback_backfill_rows() {
 		--arg origin_worker_label "origin:worker" \
 		--arg consolidated_label "consolidated" \
 		--arg auto_dispatch_label "$_PIR_AUTO_DISPATCH_LABEL" \
+		--arg status_available_label "$_PIR_STATUS_AVAILABLE" \
+		--arg tier_standard_label "$_PIR_TIER_STANDARD" \
 		--arg no_auto_label "no-auto-dispatch" \
 		--arg parent_label "parent-task" \
 		--arg ci_label "source:ci-feedback" \
@@ -490,15 +493,15 @@ _normalize_get_feedback_backfill_rows() {
 		--arg blocked_label "$_PIR_STATUS_BLOCKED" \
 		--arg done_label "$_PIR_STATUS_DONE" '
 		.[]
-		| (.labels | map(.name)) as $labels
+		| ((.labels // []) | map(.name)) as $labels
 		| ([$labels[] | select(startswith("status:"))]) as $status_labels
 		| ([$labels[] | select(startswith("tier:"))]) as $tier_labels
 		| select($labels | index($origin_worker_label))
 		| select($labels | index($consolidated_label))
 		| select(($labels | index($ci_label)) or ($labels | index($conflict_label)) or ($labels | index($review_label)))
 		| select(($labels | index($auto_dispatch_label) | not) or ($status_labels | length) == 0 or ($tier_labels | length) == 0)
-		| select(([$status_labels[] | select(. != "status:available")] | length) == 0)
-		| select(([$tier_labels[] | select(. != "tier:standard")] | length) == 0)
+		| select(all($status_labels[]; . == $status_available_label))
+		| select(all($tier_labels[]; . == $tier_standard_label))
 		| select($labels | index($no_auto_label) | not)
 		| select($labels | index($parent_label) | not)
 		| select($labels | index($blocked_label) | not)
@@ -528,7 +531,7 @@ _normalize_backfill_feedback_rows() {
 		if gh issue edit "$feedback_issue" --repo "$slug" \
 			"$_PIR_ADD_LABEL_FLAG" "$_PIR_STATUS_AVAILABLE" \
 			"$_PIR_ADD_LABEL_FLAG" "$_PIR_AUTO_DISPATCH_LABEL" \
-			"$_PIR_ADD_LABEL_FLAG" "tier:standard" >/dev/null 2>&1; then
+			"$_PIR_ADD_LABEL_FLAG" "$_PIR_TIER_STANDARD" >/dev/null; then
 			echo "[pulse-wrapper] Assignment normalization: backfilled dispatch labels on consolidated feedback #${feedback_issue} in ${slug}" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] Assignment normalization: skipped consolidated feedback #${feedback_issue} in ${slug} — failed to backfill dispatch labels" >>"$LOGFILE"
@@ -1101,8 +1104,8 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 		add_args=("$_PIR_ADD_LABEL_FLAG" "origin:worker"
 			"$_PIR_REMOVE_LABEL_FLAG" "origin:interactive"
 			"$_PIR_REMOVE_LABEL_FLAG" "origin:worker-takeover"
-			"$_PIR_ADD_LABEL_FLAG" "tier:standard")
-		labels_csv_lia="origin:worker,tier:standard"
+			"$_PIR_ADD_LABEL_FLAG" "$_PIR_TIER_STANDARD")
+		labels_csv_lia="origin:worker,$_PIR_TIER_STANDARD"
 		comment_template_use="$comment_template"
 	fi
 	if [[ -n "$body_tags" ]]; then

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -742,6 +742,85 @@ test_available_feedback_worker_issue_not_assigned() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 17 (GH#23257): consolidated feedback backfill uses label constants.
+# ---------------------------------------------------------------------------
+test_feedback_backfill_uses_label_constants() {
+	local tmp_dir ops_log
+	tmp_dir=$(mktemp -d)
+	ops_log="${tmp_dir}/ops.log"
+
+	local fixture_json
+	fixture_json=$(jq -nc '[
+		{
+			number: 404,
+			assignees: [],
+			labels: [
+				{name:"origin:worker"},
+				{name:"consolidated"},
+				{name:"source:review-feedback"},
+				{name:"status:ready"},
+				{name:"tier:custom"}
+			]
+		},
+		{
+			number: 505,
+			assignees: [],
+			labels: [
+				{name:"origin:worker"},
+				{name:"consolidated"},
+				{name:"source:review-feedback"},
+				{name:"status:available"},
+				{name:"tier:standard"}
+			]
+		}
+	]')
+
+	local result
+	result=$(bash -c '
+		fixture_json=$1
+		ops_log=$2
+		RECONCILE_SH=$3
+		LOGFILE="${ops_log}.pulse"
+		_PIR_STATUS_AVAILABLE="status:ready"
+		_PIR_TIER_STANDARD="tier:custom"
+
+		gh() {
+			if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+				printf "%s\n" "$*" >>"$ops_log"
+				return 0
+			fi
+			return 1
+		}
+
+		# shellcheck source=/dev/null
+		source "$RECONCILE_SH"
+		rows=$(_normalize_get_feedback_backfill_rows "$fixture_json")
+		printf "rows=%s\n" "$rows"
+		_normalize_backfill_feedback_rows "owner/repo" "$rows"
+		cat "$ops_log" 2>/dev/null || true
+	' _ "$fixture_json" "$ops_log" "$RECONCILE_SH" 2>/dev/null)
+
+	rm -rf "$tmp_dir"
+
+	local all_ok=1
+	if ! printf '%s\n' "$result" | grep -q '^rows=404$'; then
+		_fail "GH#23257: custom status/tier labels were not selected for backfill"
+		all_ok=0
+	fi
+	if printf '%s\n' "$result" | grep -q '^rows=505$'; then
+		_fail "GH#23257: hardcoded status/tier labels were selected despite overridden constants"
+		all_ok=0
+	fi
+	if ! printf '%s\n' "$result" | grep -q 'edit 404 .*--add-label status:ready .*--add-label auto-dispatch .*--add-label tier:custom'; then
+		_fail "GH#23257: backfill edit did not use status/auto-dispatch/tier constants"
+		all_ok=0
+	fi
+
+	[[ "$all_ok" == "1" ]] && _pass "GH#23257: consolidated feedback backfill uses label constants"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_cache_miss_no_file
@@ -761,6 +840,7 @@ test_gh22802_oimp_lookup_requires_merged_at
 test_t2985_oimp_lookup_no_prefix_collision
 test_t2985_action_oimp_single_signature
 test_available_feedback_worker_issue_not_assigned
+test_feedback_backfill_uses_label_constants
 
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"


### PR DESCRIPTION
## Summary

Added a standard tier label constant, passed lifecycle label constants into the feedback backfill jq filter, preserved stderr for label edit failures, and covered custom label overrides with a regression test.

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh,.agents/scripts/tests/test-pulse-issue-reconcile.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/tests/test-pulse-issue-reconcile.sh; bash .agents/scripts/tests/test-pulse-issue-reconcile.sh

Resolves #23257


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 4m and 101,981 tokens on this as a headless worker.