### PR TITLE
GH#23261: refresh pulse current-state telemetry

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -54,7 +54,7 @@ import os
 import subprocess
 import sys
 import time
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 
 log_dir, repo_path, window_s, as_json, script_dir = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4] == '1', sys.argv[5]
 now = time.time()
@@ -65,7 +65,7 @@ def recent_lines(path, limit=2000):
     if not os.path.exists(path):
         return []
     with open(path, 'r', encoding='utf-8', errors='replace') as handle:
-        lines = handle.readlines()[-limit:]
+        lines = deque(handle, maxlen=limit)
     return [line.rstrip('\n') for line in lines]
 
 

--- a/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
+++ b/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
@@ -97,6 +97,7 @@ _dispatch_apply_current_state_guardrails() {
 	[[ "$available_slots" =~ ^-?[0-9]+$ ]] || available_slots=0
 
 	if [[ "${AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS:-0}" == "1" || "$available_slots" -le 0 ]]; then
+		_dispatch_stats_gauge "pulse_dispatch_guardrail_available_slots" "$available_slots"
 		printf '%s %s %s\n' "$max_workers" "$active_workers" "$available_slots"
 		return 0
 	fi
@@ -109,6 +110,11 @@ _dispatch_apply_current_state_guardrails() {
 	[[ "$rate_limits" =~ ^[0-9]+$ ]] || rate_limits=0
 	[[ "$healthy_prs" =~ ^[0-9]+$ ]] || healthy_prs=0
 	[[ "$no_dispatchable" =~ ^[0-9]+$ ]] || no_dispatchable=0
+	_dispatch_stats_gauge "pulse_dispatch_guardrail_successes" "$successes"
+	_dispatch_stats_gauge "pulse_dispatch_guardrail_failures" "$failures"
+	_dispatch_stats_gauge "pulse_dispatch_guardrail_rate_limits" "$rate_limits"
+	_dispatch_stats_gauge "pulse_dispatch_guardrail_healthy_prs" "$healthy_prs"
+	_dispatch_stats_gauge "pulse_dispatch_guardrail_no_dispatchable" "$no_dispatchable"
 
 	local rl_threshold="${PULSE_DISPATCH_GUARDRAIL_RATE_LIMIT_THRESHOLD:-4}"
 	local failure_threshold="${PULSE_DISPATCH_GUARDRAIL_FAILURE_THRESHOLD:-6}"

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -142,10 +142,23 @@ test_clean_state_preserves_available_slots() {
 	reset_guardrail_env
 	local slots
 	slots=$(guardrail_slots "3 1 0 0 0" 8)
-	if [[ "$slots" == "8" ]] && grep -q '^pulse_dispatch_guardrail_available_slots=8$' "$STATS_GAUGE_FILE"; then
+	if [[ "$slots" == "8" ]] && grep -q '^pulse_dispatch_guardrail_available_slots=8$' "$STATS_GAUGE_FILE" && grep -q '^pulse_dispatch_guardrail_successes=3$' "$STATS_GAUGE_FILE"; then
 		print_result "guardrail: clean current state preserves safe slots" 0
 	else
 		print_result "guardrail: clean current state preserves safe slots" 1 "slots=${slots}"
+	fi
+	return 0
+}
+
+test_disabled_guardrail_still_updates_available_slots_gauge() {
+	reset_guardrail_env
+	export AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS=1
+	local slots
+	slots=$(guardrail_slots "0 0 0 0 0" 5)
+	if [[ "$slots" == "5" ]] && grep -q '^pulse_dispatch_guardrail_available_slots=5$' "$STATS_GAUGE_FILE"; then
+		print_result "guardrail: disabled current-state path still refreshes slot gauge" 0
+	else
+		print_result "guardrail: disabled current-state path still refreshes slot gauge" 1 "slots=${slots}"
 	fi
 	return 0
 }
@@ -156,6 +169,7 @@ test_repeated_failures_pause_without_success
 test_healthy_pr_backlog_rations_new_launches
 test_no_dispatchable_evidence_pauses_refill_loop
 test_clean_state_preserves_available_slots
+test_disabled_guardrail_still_updates_available_slots_gauge
 
 printf '\n====================\n'
 printf 'Tests run: %s\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -112,5 +112,13 @@ jq -e '.api_call_pressure.read_rest_ratio == 0.4706' "$json_output" >/dev/null
 jq -e '.prefetch_cache.conditional_304 == 3' "$json_output" >/dev/null
 jq -e '.prefetch_cache.conditional_refreshes == 2' "$json_output" >/dev/null
 jq -e '.prefetch_cache.conditional_misses == 1' "$json_output" >/dev/null
+python3 - "$HELPER" <<'PY'
+import pathlib
+import sys
+source = pathlib.Path(sys.argv[1]).read_text()
+assert 'from collections import Counter, defaultdict, deque' in source
+assert 'readlines()[-limit:]' not in source
+assert 'deque(handle, maxlen=limit)' in source
+PY
 
 printf 'PASS pulse-current-state-helper\n'


### PR DESCRIPTION
## Summary

Replaced current-state log tail reads with deque-based bounded reads and refresh current-state guardrail gauges on every dispatch-capacity cycle, including skipped guardrail paths.

## Files Changed

.agents/scripts/pulse-current-state-helper.sh,.agents/scripts/pulse-dispatch-current-state-guardrails.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh,.agents/scripts/tests/test-pulse-current-state-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-current-state-helper.sh; .agents/scripts/tests/test-pulse-current-state-guardrails.sh; shellcheck changed pulse current-state scripts and tests

Resolves #23261


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 2m and 58,272 tokens on this as a headless worker.