### PR TITLE
GH#23255: fix CodeRabbit init YAML edge cases

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -725,18 +725,23 @@ desired = sys.argv[2]
 
 text = path.read_text() if path.exists() else ""
 
-line = f"  abort_on_close: {desired}"
+line = f"abort_on_close: {desired}"
 
 if not text.strip():
-    text = f"reviews:\n{line}\n"
-elif re.search(r"(?m)^\s*abort_on_close:", text):
-    text = re.sub(r"(?m)^(\s*abort_on_close:\s*)\S+(.*)$", rf"\g<1>{desired}\g<2>", text, count=1)
-elif re.search(r"(?m)^\s*reviews:", text):
-    text = re.sub(r"(?m)^(\s*reviews:.*)$", rf"\g<1>\n{line}", text, count=1)
+    text = f"reviews:\n  {line}\n"
+elif re.search(r"(?m)^[ \t]*abort_on_close:", text):
+    text = re.sub(
+        r"(?m)^([ \t]*abort_on_close:)[ \t]*[^\s#]*(?:[ \t]*(#.*))?[ \t]*$",
+        lambda match: f"{match.group(1)} {desired}{f' {match.group(2)}' if match.group(2) else ''}",
+        text,
+        count=1,
+    )
+elif re.search(r"(?m)^[ \t]*reviews:", text):
+    text = re.sub(r"(?m)^([ \t]*)(reviews:.*)$", rf"\g<1>\g<2>\n\g<1>  {line}", text, count=1)
 else:
     if not text.endswith("\n"):
         text += "\n"
-    text += f"\nreviews:\n{line}\n"
+    text += f"\nreviews:\n  {line}\n"
 
 path.write_text(text)
 PY

--- a/.agents/scripts/tests/test-init-coderabbit.sh
+++ b/.agents/scripts/tests/test-init-coderabbit.sh
@@ -74,6 +74,36 @@ test_existing_abort_preserves_trailing_comment() {
 	return 0
 }
 
+test_empty_abort_value_is_updated() {
+	TEST_ROOT=$(mktemp -d)
+	local project_root="$TEST_ROOT/project"
+	mkdir -p "$project_root"
+	printf 'reviews:\n  abort_on_close:  # keep empty note\n' > "$project_root/.coderabbit.yaml"
+
+	AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE=false _init_configure_coderabbit_abort_on_close "$project_root" "true"
+
+	assert_contains_once "$project_root/.coderabbit.yaml" '^  abort_on_close: false # keep empty note$' "updates empty abort_on_close value"
+	cleanup
+	TEST_ROOT=""
+	return 0
+}
+
+test_indented_reviews_preserves_child_indentation() {
+	TEST_ROOT=$(mktemp -d)
+	local project_root="$TEST_ROOT/project"
+	mkdir -p "$project_root"
+	printf 'root:\n  reviews: # nested settings\n    auto_review: true\n' > "$project_root/.coderabbit.yaml"
+
+	AIDEVOPS_CODERABBIT_ABORT_ON_CLOSE=false _init_configure_coderabbit_abort_on_close "$project_root" "true"
+
+	assert_contains_once "$project_root/.coderabbit.yaml" '^    abort_on_close: false$' "adds abort_on_close using reviews indentation"
+	cleanup
+	TEST_ROOT=""
+	return 0
+}
+
 load_coderabbit_function
 test_reviews_with_inline_comment_is_reused
 test_existing_abort_preserves_trailing_comment
+test_empty_abort_value_is_updated
+test_indented_reviews_preserves_child_indentation


### PR DESCRIPTION
## Summary

Updated the CodeRabbit init updater to handle empty abort_on_close values and preserve nested reviews indentation, with regression tests for both review follow-up cases.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-init-lib.sh,.agents/scripts/tests/test-init-coderabbit.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-init-coderabbit.sh; shellcheck .agents/scripts/aidevops-cli/aidevops-init-lib.sh .agents/scripts/tests/test-init-coderabbit.sh; .agents/scripts/linters-local.sh timed out after reporting pre-existing/advisory repository-wide findings

Resolves #23255


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 7m and 67,850 tokens on this as a headless worker.