### PR TITLE
feat: add RTK adoption reporting

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -159,7 +159,7 @@ Run `aidevops security` for posture/scan/check/dismiss. Advisories arrive via `a
 ## Maintenance
 
 - Self-improvement guidance: `reference/self-improvement.md`.
-- Token-optimized CLI: start with `rtk-helper.sh` for supported noisy summaries, then rerun raw/direct commands when filtered output is insufficient; bypass for exact evidence. Full rules: `reference/context-efficient-output.md`.
+- Token-optimized CLI: for interactive discovery, use `rtk-helper.sh gh issue/pr list` before raw list commands; rerun raw/direct when filtered output is insufficient; bypass exact evidence. Full rules: `reference/context-efficient-output.md`.
 - Agent lifecycle: `tools/build-agent/build-agent.md`; OpenCode glob allowlists require `subagent_validation.py` verification.
 - Slash commands resolve through `scripts/commands/<command>.md`, then `workflows/<command>.md`.
 - macOS bash upgrade, platform support, customization, and hot deploys: `reference/bash-compat.md`, `reference/platform-support.md`, `reference/customization.md`, `reference/hot-deploy.md`.

--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -14,6 +14,8 @@ over token savings.
    - `rtk-helper.sh git log --oneline -20`
    - `rtk-helper.sh gh pr list --repo owner/repo --limit N`
    - `rtk-helper.sh gh issue list --repo owner/repo --limit N`
+   - In interactive discovery, use these RTK forms instead of raw `gh pr list`
+     or `gh issue list` unless the command needs structured/exact output.
 2. **Assess sufficiency**: proceed only if the filtered output contains every
    fact needed for the next decision.
 3. **Broaden immediately** when output is incomplete, ambiguous, expanded rather
@@ -36,6 +38,16 @@ The comparison reports raw vs RTK-filtered exit codes, bytes, approximate token
 counts, line counts, and a first-pass recommendation. It intentionally omits the
 command output to avoid copying noisy or sensitive data into diagnostics. Rerun
 the raw command directly when exact evidence is needed.
+
+To verify adoption in recent OpenCode sessions, run:
+
+```bash
+rtk-helper.sh --adoption-report
+```
+
+The report counts sessions, Bash tool calls, RTK helper calls, raw eligible list
+commands that should have started through RTK, and structured/exact list commands
+that correctly bypass RTK.
 
 Use comparison results to classify a command:
 

--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -16,6 +16,7 @@ usage() {
 Usage:
   rtk-helper.sh COMMAND [ARGS...]
   rtk-helper.sh --compare COMMAND [ARGS...]
+  rtk-helper.sh --adoption-report [SINCE_ISO]
 
 Runs `rtk COMMAND [ARGS...]` for explicit token-optimized commands and strips
 RTK's repeated no-hook advisory from output. Exit status is preserved.
@@ -23,6 +24,9 @@ RTK's repeated no-hook advisory from output. Exit status is preserved.
 `--compare` runs both raw and RTK-filtered forms, then prints a diagnostic
 summary with exit codes, bytes, approximate token counts, and reduction. It does
 not print command output; rerun the raw command when exact evidence is needed.
+
+`--adoption-report` audits recent OpenCode sessions for RTK helper use versus raw
+eligible GitHub discovery list commands. SINCE_ISO defaults to 24 hours ago.
 
 Use only for supported noisy summaries such as:
   rtk-helper.sh git status
@@ -128,6 +132,114 @@ PY
 	return "$rtk_rc"
 }
 
+adoption_report() {
+	local since_iso="${1:-}"
+	local db_path="${OPENCODE_DB_PATH:-${HOME}/.local/share/opencode/opencode.db}"
+
+	if [[ -z "$since_iso" ]]; then
+		since_iso=$(python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%d %H:%M:%S"))
+PY
+)
+	fi
+
+	if [[ ! -f "$db_path" ]]; then
+		log_error "OpenCode session DB not found: $db_path"
+		return 1
+	fi
+
+	python3 - "$db_path" "$since_iso" <<'PY'
+import json
+import shlex
+import sqlite3
+import sys
+
+db_path, since_iso = sys.argv[1:]
+
+def command_kind(command):
+    if not command:
+        return None
+    if "sqlite3" in command:
+        return None
+    if "rtk-helper.sh --adoption-report" in command or "rtk-helper.sh adoption-report" in command:
+        return None
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+
+    has_gh_list = any(
+        parts[idx : idx + 3] in (["gh", "pr", "list"], ["gh", "issue", "list"])
+        for idx in range(max(len(parts) - 2, 0))
+    )
+    if "rtk-helper.sh" in command:
+        return "rtk_helper" if has_gh_list else None
+    if not has_gh_list:
+        return None
+    structured = any(part in ("--json", "--jq", "-q") or part.startswith("--jq=") for part in parts)
+    if structured:
+        return "structured_bypass"
+    return "raw_eligible"
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+since_ms = int(conn.execute("select strftime('%s', ?) * 1000", (since_iso,)).fetchone()[0])
+sessions = conn.execute("select count(*) from session where time_created >= ?", (since_ms,)).fetchone()[0]
+rows = conn.execute(
+    """
+    select s.title, p.data
+    from part p join session s on s.id = p.session_id
+    where p.time_created >= ?
+    order by p.time_created asc
+    """,
+    (since_ms,),
+).fetchall()
+
+counts = {"bash": 0, "rtk_helper": 0, "raw_eligible": 0, "structured_bypass": 0}
+samples = []
+for row in rows:
+    try:
+        data = json.loads(row["data"])
+    except Exception:
+        continue
+    if data.get("type") != "tool" or data.get("tool") != "bash":
+        continue
+    counts["bash"] += 1
+    command = (((data.get("state") or {}).get("input") or {}).get("command") or "")
+    kind = command_kind(command)
+    if not kind:
+        continue
+    counts[kind] += 1
+    if kind == "raw_eligible" and len(samples) < 5:
+        samples.append((row["title"], command))
+
+eligible_total = counts["rtk_helper"] + counts["raw_eligible"]
+adoption = (counts["rtk_helper"] / eligible_total * 100.0) if eligible_total else 0.0
+
+print("## RTK adoption report")
+print("")
+print(f"Since: `{since_iso}`")
+print("")
+print("| Metric | Count |")
+print("|---|---:|")
+print(f"| Sessions | {sessions} |")
+print(f"| Bash tool calls | {counts['bash']} |")
+print(f"| RTK helper calls | {counts['rtk_helper']} |")
+print(f"| Raw eligible `gh issue/pr list` calls | {counts['raw_eligible']} |")
+print(f"| Structured/exact list bypasses | {counts['structured_bypass']} |")
+print(f"| RTK adoption for eligible list commands | {adoption:.1f}% |")
+print("")
+if counts["raw_eligible"]:
+    print("Raw eligible samples to convert on future runs:")
+    for title, command in samples:
+        print(f"- {title}: `{command}`")
+else:
+    print("No raw eligible list commands found in this window.")
+PY
+	return 0
+}
+
 main() {
 	if [[ $# -eq 0 ]]; then
 		usage
@@ -139,6 +251,11 @@ main() {
 	--help | -h | help)
 		usage
 		return 0
+		;;
+	--adoption-report | adoption-report)
+		shift
+		adoption_report "${1:-}"
+		return $?
 		;;
 	esac
 

--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -132,23 +132,17 @@ PY
 	return "$rtk_rc"
 }
 
-adoption_report() {
-	local since_iso="${1:-}"
-	local db_path="${OPENCODE_DB_PATH:-${HOME}/.local/share/opencode/opencode.db}"
-
-	if [[ -z "$since_iso" ]]; then
-		since_iso=$(python3 - <<'PY'
+default_since_iso() {
+	python3 - <<'PY'
 from datetime import datetime, timedelta, timezone
 print((datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%d %H:%M:%S"))
 PY
-)
-	fi
+	return 0
+}
 
-	if [[ ! -f "$db_path" ]]; then
-		log_error "OpenCode session DB not found: $db_path"
-		return 1
-	fi
-
+adoption_report_python() {
+	local db_path="$1"
+	local since_iso="$2"
 	python3 - "$db_path" "$since_iso" <<'PY'
 import json
 import shlex
@@ -237,6 +231,23 @@ if counts["raw_eligible"]:
 else:
     print("No raw eligible list commands found in this window.")
 PY
+	return 0
+}
+
+adoption_report() {
+	local since_iso="${1:-}"
+	local db_path="${OPENCODE_DB_PATH:-${HOME}/.local/share/opencode/opencode.db}"
+
+	if [[ -z "$since_iso" ]]; then
+		since_iso=$(default_since_iso)
+	fi
+
+	if [[ ! -f "$db_path" ]]; then
+		log_error "OpenCode session DB not found: $db_path"
+		return 1
+	fi
+
+	adoption_report_python "$db_path" "$since_iso"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-rtk-helper.sh
+++ b/.agents/scripts/tests/test-rtk-helper.sh
@@ -72,6 +72,29 @@ printf 'long raw payload with extra diagnostic detail\n'
 STUB
 chmod +x "${TMPDIR_TEST}/samplecmd"
 
+session_db="${TMPDIR_TEST}/opencode.db"
+python3 - "$session_db" <<'PY'
+import json
+import sqlite3
+import sys
+
+db = sys.argv[1]
+conn = sqlite3.connect(db)
+conn.execute("create table session (id text primary key, title text, time_created integer)")
+conn.execute("create table part (id text primary key, session_id text, time_created integer, data text)")
+now = 1778340000000
+conn.execute("insert into session values ('s1', 'adoption test', ?)", (now,))
+commands = [
+    "rtk-helper.sh gh issue list --repo owner/repo --limit 5",
+    "gh issue list --repo owner/repo --limit 5",
+    "gh pr list --repo owner/repo --json number,title",
+]
+for idx, command in enumerate(commands):
+    data = {"type": "tool", "tool": "bash", "state": {"input": {"command": command}}}
+    conn.execute("insert into part values (?, 's1', ?, ?)", (f"p{idx}", now + idx, json.dumps(data)))
+conn.commit()
+PY
+
 PATH="${TMPDIR_TEST}:$PATH" output=$("$HELPER" git status)
 assert_not_contains "strips no-hook advisory" "No hook installed" "$output"
 assert_contains "preserves useful output" "payload: git status" "$output"
@@ -93,6 +116,15 @@ assert_contains "compare emits diagnostic heading" "RTK output comparison" "$com
 assert_contains "compare records same exit code" "Same exit code: yes" "$compare_output"
 assert_contains "compare emits decision guidance" "Decision guidance" "$compare_output"
 assert_not_contains "compare strips advisory" "No hook installed" "$compare_output"
+
+export OPENCODE_DB_PATH="$session_db"
+adoption_output=$("$HELPER" --adoption-report "2026-05-08 00:00:00")
+unset OPENCODE_DB_PATH
+assert_contains "adoption report heading" "RTK adoption report" "$adoption_output"
+assert_contains "adoption counts rtk helper" "| RTK helper calls | 1 |" "$adoption_output"
+raw_eligible_needle="Raw eligible \`gh issue/pr list\` calls | 1"
+assert_contains "adoption counts raw eligible" "$raw_eligible_needle" "$adoption_output"
+assert_contains "adoption counts structured bypass" "| Structured/exact list bypasses | 1 |" "$adoption_output"
 
 printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
 if [[ "$fail_count" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Strengthen always-loaded RTK guidance so interactive GitHub discovery uses `rtk-helper.sh gh issue/pr list` before raw list commands unless structured/exact output is needed.
- Add `rtk-helper.sh --adoption-report [SINCE_ISO]` to audit OpenCode sessions for RTK helper adoption versus raw eligible list commands.
- Extend RTK helper tests with fixture OpenCode session data covering RTK helper use, raw eligible commands, and structured bypasses.

## Evidence
- Live adoption report after the change identified raw eligible samples and separated structured/exact bypasses from commands that should start through RTK.

## Verification
- `shellcheck .agents/scripts/rtk-helper.sh .agents/scripts/tests/test-rtk-helper.sh`
- `bash -n .agents/scripts/rtk-helper.sh`
- `bash -n .agents/scripts/tests/test-rtk-helper.sh`
- `.agents/scripts/tests/test-rtk-helper.sh`
- `npx markdownlint-cli2 .agents/reference/context-efficient-output.md`
- `git diff --check`
- `.agents/scripts/rtk-helper.sh --adoption-report "2026-05-08 17:00:00"`

Resolves #23276

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.10 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 3d 17h and 1,764,952 tokens on this with the user in an interactive session.
