### PR TITLE
fix: restore direct Tabby OpenCode launch

### DIFF
--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -12,19 +12,22 @@ Powerlevel10k/gitstatus initialize before job control is available and emit
 errors such as `setopt: can't change option: monitor` or `gitstatus failed to
 initialize` before the TUI starts.
 
+Do not use `TABBY_AUTORUN=opencode` for generated profiles. It depends on a
+`.zshrc` startup hook and can fail silently, leaving users in a plain shell.
+
 The safe generated shape is:
 
 ```yaml
 command: /bin/zsh
 args:
   - '-l'
-  - '-i'
-env:
-  TABBY_AUTORUN: opencode
+  - '-c'
+  - 'opencode; exec zsh'
+env: {}
 ```
 
 For manual one-off profiles that should run OpenCode and then leave a shell open,
-use a non-interactive login command instead of mixing `-i` and `-c`:
+use the same non-interactive login command instead of mixing `-i` and `-c`:
 
 ```yaml
 command: /bin/zsh

--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -6,7 +6,7 @@
 # Creates a Tabby profile for each repo in repos.json with:
 # - Unique bright tab colour (dark-mode friendly)
 # - Matching built-in colour scheme (closest hue match)
-# - TABBY_AUTORUN=opencode env var for TUI compatibility
+# - Direct OpenCode launch that leaves a shell open after exit
 # - Grouped under "Projects"
 #
 # Usage:
@@ -364,7 +364,7 @@ cmd_help() {
 	echo "Profiles are created with:"
 	echo "  - Random bright tab colour (dark-mode friendly, HSL L:50-70%, S:60-90%)"
 	echo "  - Matching Tabby colour scheme (closest hue from built-in presets)"
-	echo "  - TABBY_AUTORUN=opencode for OpenCode TUI compatibility"
+	echo "  - Direct OpenCode launch that leaves a shell open after exit"
 	echo "  - Grouped under 'Projects'"
 	echo ""
 	echo "Existing profiles (matched by cwd path) are never overwritten."

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -7,7 +7,7 @@ Sync Tabby terminal profiles from aidevops repos.json.
 Creates a profile for each registered repo with:
 - Unique bright tab colour (dark-mode friendly)
 - Matching built-in Tabby colour scheme (closest hue)
-- TABBY_AUTORUN=opencode env var for TUI compatibility
+- Direct OpenCode launch that leaves a shell open after exit
 - Grouped under "Projects"
 
 Existing profiles (matched by cwd path) are never overwritten.
@@ -122,9 +122,9 @@ def build_profile_yaml(
       command: /bin/zsh
       args:
         - '-l'
-        - '-i'
-      env:
-        TABBY_AUTORUN: opencode
+        - '-c'
+        - opencode; exec zsh
+      env: {{}}
       cwd: {cwd}
     terminalColorScheme:
       name: {scheme['name']}
@@ -178,31 +178,59 @@ def _is_broken_opencode_args(args: list[str]) -> bool:
     return args == ["-l", "-i", "-c", "opencode"]
 
 
-def _safe_opencode_args_block(args_indent: str, include_env: bool) -> list[str]:
-    """Build the safe Tabby args/env block using ``TABBY_AUTORUN``."""
+def _direct_opencode_args_block(args_indent: str, include_env: bool) -> list[str]:
+    """Build the direct Tabby args/env block for OpenCode profiles."""
     child_indent = f"{args_indent}  "
     block = [
         f"{args_indent}args:",
         f"{child_indent}- '-l'",
-        f"{child_indent}- '-i'",
+        f"{child_indent}- '-c'",
+        f"{child_indent}- opencode; exec zsh",
     ]
     if include_env:
-        block.extend(
-            [
-                f"{args_indent}env:",
-                f"{child_indent}TABBY_AUTORUN: opencode",
-            ]
-        )
+        block.append(f"{args_indent}env: {{}}")
     return block
 
 
+def _tabby_autorun_env_end(lines: list[str], start: int, base_indent_len: int) -> int | None:
+    """Return env block end if it only carries ``TABBY_AUTORUN=opencode``."""
+    if start >= len(lines):
+        return None
+    env_line = lines[start]
+    env_indent_len = len(env_line) - len(env_line.lstrip(" "))
+    if env_indent_len != base_indent_len or env_line.strip() != "env:":
+        return None
+
+    block_end = start + 1
+    has_autorun = False
+    has_other_env = False
+    while block_end < len(lines):
+        next_line = lines[block_end]
+        if next_line.strip():
+            next_indent_len = len(next_line) - len(next_line.lstrip(" "))
+            if next_indent_len <= env_indent_len:
+                break
+            stripped = next_line.strip().strip("'").strip('"')
+            if stripped == "TABBY_AUTORUN: opencode":
+                has_autorun = True
+            else:
+                has_other_env = True
+        block_end += 1
+
+    if has_autorun and not has_other_env:
+        return block_end
+    return None
+
+
 def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
-    """Repair Tabby profiles using ``zsh -l -i -c opencode``.
+    """Repair fragile Tabby OpenCode launch profiles.
 
     ``zsh -i -c`` enables interactive startup while executing a command string,
     which can trigger Powerlevel10k/gitstatus job-control errors before the TUI
-    starts. The generated profile shape keeps a login interactive shell and lets
-    shell startup launch OpenCode via ``TABBY_AUTORUN`` instead.
+    starts. The former ``TABBY_AUTORUN`` workaround can also fail silently when
+    shell startup does not run the hook, leaving users in a plain terminal. The
+    stable shape uses a non-interactive login command and leaves zsh open after
+    OpenCode exits.
     """
     lines = config_text.split("\n")
     repaired: list[str] = []
@@ -222,8 +250,16 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
         inline_args = _parse_inline_args(match.group("value"))
         if inline_args is not None:
             if _is_broken_opencode_args(inline_args):
-                repaired.extend(_safe_opencode_args_block(args_indent, include_env=True))
+                repaired.extend(_direct_opencode_args_block(args_indent, include_env=True))
                 repairs += 1
+            elif inline_args == ["-l", "-i"]:
+                env_end = _tabby_autorun_env_end(lines, i + 1, args_indent_len)
+                if env_end is not None:
+                    repaired.extend(_direct_opencode_args_block(args_indent, include_env=True))
+                    repairs += 1
+                    i = env_end
+                    continue
+                repaired.append(line)
             else:
                 repaired.append(line)
             i += 1
@@ -242,8 +278,16 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
         if _is_broken_opencode_args(block_args):
             next_line = lines[block_end] if block_end < len(lines) else ""
             has_env = bool(re.match(rf"^{re.escape(args_indent)}env:\s*$", next_line))
-            repaired.extend(_safe_opencode_args_block(args_indent, include_env=not has_env))
+            repaired.extend(_direct_opencode_args_block(args_indent, include_env=not has_env))
             repairs += 1
+        elif block_args == ["-l", "-i"]:
+            env_end = _tabby_autorun_env_end(lines, block_end, args_indent_len)
+            if env_end is not None:
+                repaired.extend(_direct_opencode_args_block(args_indent, include_env=True))
+                repairs += 1
+                i = env_end
+                continue
+            repaired.extend(lines[i:block_end])
         else:
             repaired.extend(lines[i:block_end])
         i = block_end

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -76,9 +76,11 @@ config = '''profiles:
 '''
 repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
-assert \"- '-c'\" not in repaired, repaired
-assert 'TABBY_AUTORUN: opencode' in repaired, repaired
-assert \"- '-l'\" in repaired and \"- '-i'\" in repaired, repaired
+assert \"- '-i'\" not in repaired, repaired
+assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
+assert \"- '-l'\" in repaired and \"- '-c'\" in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
+assert 'env: {}' in repaired, repaired
 "
 
 _info "Test 2: inline broken args are repaired"
@@ -87,19 +89,43 @@ config = \"\"\"profiles:\n  - name: aidevops\n    options:\n      command: /bin/
 repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"args: ['-l', '-i', '-c', opencode]\" not in repaired, repaired
-assert 'TABBY_AUTORUN: opencode' in repaired, repaired
+assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
 "
 
-_info "Test 3: generated profiles keep safe TABBY_AUTORUN shape"
-run_python_test "generated profile uses safe launch shape" "${load_module_code}
+_info "Test 3: generated profiles keep direct OpenCode launch shape"
+run_python_test "generated profile uses direct launch shape" "${load_module_code}
 scheme = {'name': 'Test', 'foreground': '#fff', 'background': '#000', 'cursor': '#fff', 'colors': ['#000', '#fff']}
 profile = mod.build_profile_yaml('aidevops', '/tmp/aidevops', '#123456', scheme, 'group-1')
-assert \"- '-c'\" not in profile, profile
-assert 'TABBY_AUTORUN: opencode' in profile, profile
-assert \"- '-l'\" in profile and \"- '-i'\" in profile, profile
+assert \"- '-i'\" not in profile, profile
+assert 'TABBY_AUTORUN: opencode' not in profile, profile
+assert \"- '-l'\" in profile and \"- '-c'\" in profile, profile
+assert 'opencode; exec zsh' in profile, profile
+assert 'env: {}' in profile, profile
 "
 
-_info "Test 4: sync repairs existing profiles even when no new profile is needed"
+_info "Test 4: TABBY_AUTORUN profiles are repaired"
+run_python_test "autorun profile repaired" "${load_module_code}
+config = '''profiles:
+  - name: aidevops
+    options:
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-i'
+      env:
+        TABBY_AUTORUN: opencode
+      cwd: /tmp/aidevops
+'''
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count == 1, count
+assert \"- '-i'\" not in repaired, repaired
+assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
+assert 'env: {}' in repaired, repaired
+"
+
+_info "Test 5: sync repairs existing profiles even when no new profile is needed"
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "${tmp_root}"' EXIT
 repo_path="${tmp_root}/aidevops"
@@ -132,7 +158,7 @@ with open(tabby_config, "w") as handle:
 """)
 PY
 sync_output=$(PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${tabby_config}")
-if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}" && ! grep -q -- "- '-c'" "${tabby_config}"; then
+if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "opencode; exec zsh" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
 	_pass "sync repairs existing broken profile"
 else
 	_fail "sync did not repair existing profile: ${sync_output}"


### PR DESCRIPTION
## Summary
- Restore generated Tabby repo profiles to launch OpenCode directly via `zsh -l -c 'opencode; exec zsh'` instead of relying on `TABBY_AUTORUN`.
- Repair both prior broken `zsh -l -i -c opencode` profiles and the newer `TABBY_AUTORUN=opencode` profiles during sync.
- Update Tabby helper docs and regression tests so all repos.json profiles stay consistent.

Resolves #23281

## Verification
- `python3 -m py_compile .agents/scripts/tabby-profile-sync.py`
- `bash .agents/scripts/tests/test-tabby-profile-sync.sh`
- `shellcheck .agents/scripts/tabby-helper.sh .agents/scripts/tests/test-tabby-profile-sync.sh`
- `.agents/scripts/linters-local.sh` (passed; existing advisory warnings only)
- `PYTHONPATH=.agents/scripts python3 .agents/scripts/tabby-profile-sync.py --repos-json "$HOME/.config/aidevops/repos.json" --tabby-config "$HOME/Library/Application Support/tabby/config.yaml"`

## Local recovery
- Repaired local Tabby config profile launch blocks and saved a timestamped backup under `~/Library/Application Support/tabby/`.
