### PR TITLE
fix: use Tabby command field for OpenCode launch

### DIFF
--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -15,24 +15,19 @@ initialize` before the TUI starts.
 Do not use `TABBY_AUTORUN=opencode` for generated profiles. It depends on a
 `.zshrc` startup hook and can fail silently, leaving users in a plain shell.
 
-The safe generated shape is:
+The safe generated shape stores the full launch command in Tabby's command
+field:
 
 ```yaml
-command: /bin/zsh
-args:
-  - '-l'
-  - '-c'
-  - 'opencode; exec zsh'
+command: /bin/zsh -l -c 'opencode; exec zsh'
+args: []
 env: {}
 ```
 
 For manual one-off profiles that should run OpenCode and then leave a shell open,
-use the same non-interactive login command instead of mixing `-i` and `-c`:
+use the same command-field value instead of mixing `-i` and `-c`:
 
 ```yaml
-command: /bin/zsh
-args:
-  - '-l'
-  - '-c'
-  - 'opencode; exec zsh'
+command: /bin/zsh -l -c 'opencode; exec zsh'
+args: []
 ```

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -33,6 +33,9 @@ from tabby_yaml_helpers import (
 )
 
 
+TABBY_OPENCODE_COMMAND = "/bin/zsh -l -c 'opencode; exec zsh'"
+
+
 def is_linked_worktree(repo_path: str) -> bool:
     """Return True iff ``repo_path`` is a linked git worktree (not the main one).
 
@@ -119,11 +122,8 @@ def build_profile_yaml(
     profile = f"""  - name: {name}
     icon: fas fa-terminal
     options:
-      command: /bin/zsh
-      args:
-        - '-l'
-        - '-c'
-        - opencode; exec zsh
+      command: {TABBY_OPENCODE_COMMAND}
+      args: []
       env: {{}}
       cwd: {cwd}
     terminalColorScheme:
@@ -178,18 +178,25 @@ def _is_broken_opencode_args(args: list[str]) -> bool:
     return args == ["-l", "-i", "-c", "opencode"]
 
 
-def _direct_opencode_args_block(args_indent: str, include_env: bool) -> list[str]:
-    """Build the direct Tabby args/env block for OpenCode profiles."""
-    child_indent = f"{args_indent}  "
-    block = [
-        f"{args_indent}args:",
-        f"{child_indent}- '-l'",
-        f"{child_indent}- '-c'",
-        f"{child_indent}- opencode; exec zsh",
-    ]
-    if include_env:
-        block.append(f"{args_indent}env: {{}}")
-    return block
+def _is_split_direct_opencode_args(args: list[str]) -> bool:
+    """Return True for split args that launch OpenCode directly."""
+    return args == ["-l", "-c", "opencode; exec zsh"]
+
+
+def _append_opencode_command_field(
+    repaired: list[str], args_indent: str, include_env: bool
+) -> None:
+    """Append/replace the Tabby command-field OpenCode launch shape."""
+    plain_command = f"{args_indent}command: /bin/zsh"
+    full_command = f"{args_indent}command: {TABBY_OPENCODE_COMMAND}"
+    if repaired and repaired[-1] == plain_command:
+        repaired[-1] = full_command
+    else:
+        repaired.append(full_command)
+    repaired.append(f"{args_indent}args: []")
+    has_prior_empty_env = any(line == f"{args_indent}env: {{}}" for line in repaired[-6:])
+    if include_env and not has_prior_empty_env:
+        repaired.append(f"{args_indent}env: {{}}")
 
 
 def _tabby_autorun_env_end(lines: list[str], start: int, base_indent_len: int) -> int | None:
@@ -229,8 +236,8 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
     which can trigger Powerlevel10k/gitstatus job-control errors before the TUI
     starts. The former ``TABBY_AUTORUN`` workaround can also fail silently when
     shell startup does not run the hook, leaving users in a plain terminal. The
-    stable shape uses a non-interactive login command and leaves zsh open after
-    OpenCode exits.
+    stable shape stores the full non-interactive login launch in Tabby's command
+    field and leaves zsh open after OpenCode exits.
     """
     lines = config_text.split("\n")
     repaired: list[str] = []
@@ -249,13 +256,13 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
         args_indent_len = len(args_indent)
         inline_args = _parse_inline_args(match.group("value"))
         if inline_args is not None:
-            if _is_broken_opencode_args(inline_args):
-                repaired.extend(_direct_opencode_args_block(args_indent, include_env=True))
+            if _is_broken_opencode_args(inline_args) or _is_split_direct_opencode_args(inline_args):
+                _append_opencode_command_field(repaired, args_indent, include_env=True)
                 repairs += 1
             elif inline_args == ["-l", "-i"]:
                 env_end = _tabby_autorun_env_end(lines, i + 1, args_indent_len)
                 if env_end is not None:
-                    repaired.extend(_direct_opencode_args_block(args_indent, include_env=True))
+                    _append_opencode_command_field(repaired, args_indent, include_env=True)
                     repairs += 1
                     i = env_end
                     continue
@@ -275,15 +282,15 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
             block_end += 1
 
         block_args = _parse_block_args(lines[i + 1 : block_end])
-        if _is_broken_opencode_args(block_args):
+        if _is_broken_opencode_args(block_args) or _is_split_direct_opencode_args(block_args):
             next_line = lines[block_end] if block_end < len(lines) else ""
             has_env = bool(re.match(rf"^{re.escape(args_indent)}env:\s*$", next_line))
-            repaired.extend(_direct_opencode_args_block(args_indent, include_env=not has_env))
+            _append_opencode_command_field(repaired, args_indent, include_env=not has_env)
             repairs += 1
         elif block_args == ["-l", "-i"]:
             env_end = _tabby_autorun_env_end(lines, block_end, args_indent_len)
             if env_end is not None:
-                repaired.extend(_direct_opencode_args_block(args_indent, include_env=True))
+                _append_opencode_command_field(repaired, args_indent, include_env=True)
                 repairs += 1
                 i = env_end
                 continue

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -78,8 +78,8 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"- '-i'\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert \"- '-l'\" in repaired and \"- '-c'\" in repaired, repaired
-assert 'opencode; exec zsh' in repaired, repaired
+assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
+assert 'args: []' in repaired, repaired
 assert 'env: {}' in repaired, repaired
 "
 
@@ -90,17 +90,18 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"args: ['-l', '-i', '-c', opencode]\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert 'opencode; exec zsh' in repaired, repaired
+assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
+assert 'args: []' in repaired, repaired
 "
 
-_info "Test 3: generated profiles keep direct OpenCode launch shape"
-run_python_test "generated profile uses direct launch shape" "${load_module_code}
+_info "Test 3: generated profiles keep command-field OpenCode launch shape"
+run_python_test "generated profile uses command-field launch shape" "${load_module_code}
 scheme = {'name': 'Test', 'foreground': '#fff', 'background': '#000', 'cursor': '#fff', 'colors': ['#000', '#fff']}
 profile = mod.build_profile_yaml('aidevops', '/tmp/aidevops', '#123456', scheme, 'group-1')
 assert \"- '-i'\" not in profile, profile
 assert 'TABBY_AUTORUN: opencode' not in profile, profile
-assert \"- '-l'\" in profile and \"- '-c'\" in profile, profile
-assert 'opencode; exec zsh' in profile, profile
+assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in profile, profile
+assert 'args: []' in profile, profile
 assert 'env: {}' in profile, profile
 "
 
@@ -121,11 +122,51 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"- '-i'\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert 'opencode; exec zsh' in repaired, repaired
+assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
+assert 'args: []' in repaired, repaired
 assert 'env: {}' in repaired, repaired
 "
 
-_info "Test 5: sync repairs existing profiles even when no new profile is needed"
+_info "Test 5: split direct profiles are repaired to command field"
+run_python_test "split direct profile repaired" "${load_module_code}
+config = '''profiles:
+  - name: aidevops
+    options:
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-c'
+        - opencode; exec zsh
+      env: {}
+      cwd: /tmp/aidevops
+'''
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count == 1, count
+assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
+assert 'args: []' in repaired, repaired
+assert \"- '-c'\" not in repaired, repaired
+"
+
+_info "Test 6: split direct profiles with existing env do not duplicate env"
+run_python_test "split direct profile preserves existing env" "${load_module_code}
+config = '''profiles:
+  - name: aidevops
+    options:
+      env: {}
+      cwd: /tmp/aidevops
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-c'
+        - opencode; exec zsh
+'''
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count == 1, count
+assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
+assert repaired.count('      env: {}') == 1, repaired
+"
+
+_info "Test 7: sync repairs existing profiles even when no new profile is needed"
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "${tmp_root}"' EXIT
 repo_path="${tmp_root}/aidevops"
@@ -158,7 +199,7 @@ with open(tabby_config, "w") as handle:
 """)
 PY
 sync_output=$(PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${tabby_config}")
-if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "opencode; exec zsh" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
+if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "command: /bin/zsh -l -c 'opencode; exec zsh'" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
 	_pass "sync repairs existing broken profile"
 else
 	_fail "sync did not repair existing profile: ${sync_output}"


### PR DESCRIPTION
## Summary
- Store generated Tabby OpenCode launches directly in the profile command field as `/bin/zsh -l -c 'opencode; exec zsh'`.
- Repair older split `command: /bin/zsh` + `args` profiles and `TABBY_AUTORUN` profiles into the command-field shape.
- Add regression coverage for split direct profiles, existing env placement, and repos.json sync repair.

Resolves #23282

## Verification
- `python3 -m py_compile .agents/scripts/tabby-profile-sync.py`
- `bash .agents/scripts/tests/test-tabby-profile-sync.sh`
- `shellcheck .agents/scripts/tabby-helper.sh .agents/scripts/tests/test-tabby-profile-sync.sh`
- `.agents/scripts/linters-local.sh` (passed; existing advisory warnings only)
- `PYTHONPATH=.agents/scripts python3 .agents/scripts/tabby-profile-sync.py --repos-json "$HOME/.config/aidevops/repos.json" --tabby-config "$HOME/Library/Application Support/tabby/config.yaml"`

## Local recovery
- Updated local Tabby project profiles to command field `/bin/zsh -l -c 'opencode; exec zsh'` and `args: []`.
- Backup saved under `~/Library/Application Support/tabby/`.
