### PR TITLE
docs: capture session learning guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -39,6 +39,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Every prompt, issue, PR, comment, and brief is mentorship: include file, pattern, and verification context.
 - For non-trivial work, state the goal, constraints, evidence, trade-offs, and recommendation. Ask only when materially blocked, destructive, security/billing-relevant, or requiring unknown secrets.
 - Capture worker-dispatchable fixable findings as tasks immediately. Worker triage and advisory-trap details: `reference/worker-discipline.md`.
+- Preserve valuable session learning: apply relevant lessons now; otherwise capture worker-ready tasks, memory, or reference updates for failures, outliers, duplicate patterns, and "similar but different" hazards. Details: `reference/self-improvement.md`.
 
 ### Task and completion discipline
 

--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -44,6 +44,23 @@ Use `framework-issue-helper.sh`, not `claim-task-id.sh`:
 - Stale blocked tasks or **information gaps (t1416)** (missing tier/branch/diagnosis).
 - Run session miner pulse (`scripts/session-miner-pulse.sh`).
 
+## Session Learning Capture
+
+Treat valuable session learning as system input, not disposable transcript context. Outliers are expensive to find intentionally; when one appears during normal work, convert it into reusable system knowledge before it evaporates.
+
+- **Apply now** when the lesson directly improves the user's requested aim without widening risk.
+- **Brief for workers** when the lesson exposes a fixable bug, missing validator, missing doc, recurring failure mode, or automation gap. Use worker-ready context: files, pattern, evidence, and verification.
+- **Store memory/reference** when the lesson is reusable but not immediately dispatchable, especially diagnostics, edge cases, duplicate patterns, and "similar but different" hazards.
+- **Avoid speculative bloat:** capture observed examples and evidence; do not add global guidance for hypothetical failures.
+
+### Similar-but-different hazards
+
+When two patterns look related but differ in contract, scope, or trust boundary, do not merge them mentally or create a third near-duplicate pattern. Standardize when evidence supports one canonical path; otherwise record the distinction and route cleanup as a task. Good captures name the files/functions, the conflicting conventions, why one path is safer or current, and how to verify the chosen convention.
+
+### Auditable failures
+
+Failure information is valuable when it helps future sessions diagnose and avoid waste. Capture failures with: symptom, command/check evidence, affected file/PR/issue, suspected versus verified cause, next action, and whether the lesson belongs in a hook, validator, worker task, memory, or reference doc. Do not publish blame until diagnostics evidence supports it; see `reference/diagnostics-discipline.md`.
+
 ## Autonomous Operation
 
 "continue"/"monitor"/"keep going" → autonomous mode: sleep/wait loops, perpetual todo for compaction survival. Interrupt only for blocking errors requiring user input.


### PR DESCRIPTION
## Summary
- Adds a short always-loaded pointer requiring valuable session learning to be applied or captured rather than lost in transcript context.
- Expands `reference/self-improvement.md` with guidance for session learning capture, similar-but-different hazards, and auditable failure records.

Resolves #23285
Supersedes #23284

## Verification
- `~/.aidevops/agents/scripts/pre-edit-check.sh` passed in linked worktree `docs/session-learning-capture`.
- `~/.aidevops/agents/scripts/prework-discovery-helper.sh --keywords "session learning similar but different failures auditable diagnosable progressive disclosure" --files ".agents/AGENTS.md .agents/reference/self-improvement.md .agents/reference/worker-discipline.md .agents/reference/diagnostics-discipline.md .agents/reference/progressive-disclosure.md"` completed with no related PR/duplicate findings.
- Targeted docs diff is limited to `.agents/AGENTS.md` and `.agents/reference/self-improvement.md`.
- Always-loaded estimate remains small: `.agents/AGENTS.md` ≈ 4,278 tokens; `prompts/build.txt` ≈ 0 tokens.
- Note: after creating the tracking issue, local `linters-local.sh` began scanning `TODO.md` from the main-branch task-ledger update and reported existing TODO markdown style violations; this clean branch does not change `TODO.md` (`git diff origin/main...HEAD --name-only` lists only the two docs files).

## Progressive-disclosure note
This intentionally adds one short Layer 1 pointer because the learning-capture principle applies before the model knows whether the session contains reusable learning. Detail stays in `reference/self-improvement.md` to avoid always-loaded bloat.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.43 with gpt-5.5 spent 1h 10m and 347,714 tokens on this with the user in an interactive session.
