### PR TITLE
fix: avoid read-before-edit TTSR false positives (GH#23226)

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-ttsr-read-before-edit.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-ttsr-read-before-edit.mjs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage for GH#23226: read-before-edit is a tool-history
+// invariant, not a reliable text-output regex.
+//
+//   node --test .agents/plugins/opencode-aidevops/tests/test-ttsr-read-before-edit.mjs
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { BUILTIN_TTSR_RULES, scanForViolations } from "../ttsr-rules.mjs";
+
+function createState() {
+  return {
+    ttsrRules: [...BUILTIN_TTSR_RULES],
+    readIfExists: () => "",
+  };
+}
+
+describe("TTSR read-before-edit rule", () => {
+  test("keeps the read-before-edit instruction in system rules", () => {
+    const rule = BUILTIN_TTSR_RULES.find((candidate) => candidate.id === "read-before-edit");
+
+    assert.ok(rule, "read-before-edit rule must remain available");
+    assert.match(rule.systemPrompt, /ALWAYS Read a file before Edit or Write/);
+  });
+
+  test("does not flag edit intent from plain output text", () => {
+    const violations = scanForViolations(
+      "I'll edit the existing file now that I have read it.",
+      createState(),
+    );
+
+    assert.deepEqual(
+      violations.filter((violation) => violation.rule.id === "read-before-edit"),
+      [],
+      "text-only read-before-edit regex must not fire without tool-history context",
+    );
+  });
+});

--- a/.agents/plugins/opencode-aidevops/ttsr-rules.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr-rules.mjs
@@ -31,7 +31,9 @@ export const BUILTIN_TTSR_RULES = [
   {
     id: "read-before-edit",
     description: "Always Read a file before Edit or Write to existing files",
-    pattern: "(?:I'll edit|Let me edit|I'll write to|Let me write)(?!.*(?:creat|new file|new \\w+ file|generat))(?:(?!I'll read|let me read|I've read|already read).){0,200}$",
+    // Text-only detection cannot know whether a Read tool call already happened,
+    // so keep this as a system-prompt rule and leave enforcement to tool hooks.
+    pattern: "(?!)",
     correction: "ALWAYS Read a file before Edit/Write to an existing file. These tools fail without a prior Read in this conversation. (This rule does not apply when creating new files.)",
     severity: "error",
     systemPrompt: "ALWAYS Read a file before Edit or Write to an existing file. These tools FAIL without a prior Read in this conversation. For NEW files, verify the parent directory exists instead.",


### PR DESCRIPTION
## Summary
- Neutralizes the text-only `read-before-edit` TTSR regex so plain assistant prose no longer creates false-positive error markers.
- Keeps the system-prompt guidance intact so the invariant remains visible while enforcement stays with tool-aware hooks.
- Adds regression coverage for GH#23226.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-ttsr-read-before-edit.mjs` — pass
- `git diff --check` — pass
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs` — unrelated existing failures in `test-memory-tool-schema.mjs` (`z.number is not a function`); new TTSR test passed in that run
- `.agents/scripts/linters-local.sh` — timed out after existing advisory findings; no changed-file shell or secret regressions reported before timeout

Resolves #23226

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.15 plugin for [OpenCode](https://opencode.ai) v1.14.44 with gpt-5.5 spent 3h 37m and 93,629 tokens on this with the user in an interactive session. Solved in 1d 3h.
