### PR TITLE
feat: add branded screenshot video agents

### DIFF
--- a/.agents/tools/video/create-onboarding-video.md
+++ b/.agents/tools/video/create-onboarding-video.md
@@ -1,0 +1,113 @@
+---
+name: create-onboarding-video
+description: Create short branded onboarding, app preview, and feature-demo videos from screenshots or browser-captured UI slices, using Remotion, DESIGN.md branding, and clean wallpaper-style backgrounds.
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  grep: true
+  webfetch: true
+  task: true
+model: sonnet
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Create Onboarding Video
+
+Produce short, punchy onboarding videos that show one feature working. The output should feel like a polished App Store preview or product-launch clip: isolated UI moments, branded motion, clean desktop-like backgrounds, and windowed foreground screenshots or animations with soft drop shadows.
+
+## Quick Reference
+
+- **Use when**: the user asks to create an onboarding video, app preview, feature demo clip, product walkthrough snippet, launch animation, or short UI-first video.
+- **Output**: Remotion project rendering MP4, plus optional portrait, landscape, and social variants.
+- **Default format**: 1080×1920 portrait, 30fps, 3–8 seconds per beat, rarely over 30 seconds total.
+- **Core style**: crop, mask, or extract the UI component that proves the feature works; avoid full-screen tours unless the user explicitly needs whole-screen context.
+- **Related agents**: `tools/video/remotion.md`, `tools/browser/browser-automation.md`, `tools/design/design-md.md`, `tools/vision/image-generation.md`, `tools/vision/create-screenshots.md`.
+
+## Intake
+
+Do not start building until the evidence and intent are clear. Collect:
+
+1. **Feature intent** — one or two sentences describing what the screen does and what user outcome the video should prove.
+2. **Flow order** — the sequence of screens, interactions, or states.
+3. **Source UI** — supplied screenshots, a local app URL, a staging URL from the user, or a browser session the user authorises you to inspect.
+4. **State coverage** — 2–4 stills or captured states per beat: resting, interaction, result, and any important variants.
+5. **Brand source** — project `DESIGN.md` first; otherwise ask for brand colour/accent, logo, font, and tone.
+6. **Output target** — aspect ratio, duration, platform, file path, and whether an end card or CTA is needed.
+
+Ask a focused question when stills, browser access, feature intent, or branding are missing. Do not invent proprietary UI from a description when screenshots or browser capture are required.
+
+## Source and Brand Discovery
+
+1. **Read `DESIGN.md`** in the project root when present. Extract colours, typography, radius, elevation, spacing, product tone, and agent prompt guidance.
+2. If `DESIGN.md` is absent, use `tools/design/design-md.md` to create or derive a lightweight design brief before composing visuals.
+3. Use browser automation only from authorised user-provided app URLs or local dev servers. Prefer `tools/browser/browser-automation.md` to choose Playwright, dev-browser, Chrome DevTools, or Stagehand.
+4. Capture assets at render-friendly dimensions. Prefer UI slices, DOM elements, and state screenshots over full-page images. Avoid `fullPage: true` unless explicitly needed for the deliverable.
+5. Store source stills under `public/<flow-or-screen>/<state>.png` and document the selector, viewport, state setup, and capture command in the project README or notes.
+
+## Visual Direction
+
+- **Show the feature in action**: button tap, toggle flip, row reorder, modal reveal, chart fill, search completion, or success state.
+- **Use UI pieces, not a screen recording**: isolate cards, sheets, rows, inputs, charts, or nav sections. Blur, crop, mask, or omit the rest.
+- **Use clean wallpaper backgrounds**: generate or render brand-complementary gradients, soft mesh fields, subtle grain, abstract shapes, or light desktop-like surfaces that do not compete with the UI.
+- **Foreground treatment**: place the cropped UI or windowed screenshot on the wallpaper with rounded corners, realistic drop shadow, soft border, and optional subtle reflection or ambient glow. Think CleanShot, Xnapper, Shottr, and modern product screenshots.
+- **Wallpaper palette**: start from `DESIGN.md` primary/accent colours; add complementary hues, lower saturation for backgrounds, and preserve WCAG contrast for captions.
+- **Motion**: prefer springs, masked reveals, shared-element swaps, crossfades, slides, scale, parallax, and depth. Avoid linear, generic slideshow motion.
+
+## Shot Planning
+
+For each beat, write a compact shot plan before code:
+
+```text
+Beat: <name>
+Intent: <what this proves>
+Source: public/<screen>/<state>.png or browser selector
+Focal element: <button/card/input/etc.>
+Motion: <cursor/tap/reveal/transition>
+Caption: <short line or none>
+Duration: <frames>
+Transition out: <shared element/crossfade/etc.>
+```
+
+Rules:
+
+- One feature per video. If the user lists unrelated features, propose separate videos.
+- One clear idea per beat. Remove supporting UI that does not advance the proof.
+- Captions, if used, are short headline callouts. Let the UI motion carry the message.
+- Match the product's design language from `DESIGN.md` and source screenshots; do not restyle the app chrome arbitrarily.
+
+## Remotion Build Rules
+
+Load `tools/video/remotion.md` before authoring or modifying the composition. Apply these constraints:
+
+- Use `spring()`, `interpolate()`, `useCurrentFrame()`, and `<Sequence>`/`<Series>`; never CSS transitions, timers, or React state for animation values.
+- One `<Composition>` per onboarding flow; one sequence per beat.
+- Put scene components in `src/scenes/`, reusable motion in `src/transitions/`, brand tokens in `src/brand.ts`, and wallpaper utilities in `src/wallpaper/` or equivalent.
+- Load stills via `staticFile()` from `public/`.
+- Crop with CSS masks, `overflow: hidden`, `clip-path`, object positioning, or pre-cropped assets.
+- Expose width, height, fps, theme, and asset paths as props where practical.
+
+## Caption and Pointer Rules
+
+- Captions stay at a consistent top-of-frame position and remain visible for the whole beat.
+- Captions rise from below with opacity in the first 10–14 frames; continuation beats with identical caption text keep the caption static to avoid flicker.
+- Interactive beats need a visible pointer or tap indicator that leads the action. The pointer fades in near the focal center, moves in a single straight line to the target, taps, and only resets when the UI context changes.
+- Multiple taps on the same UI should keep the pointer visible and glide directly from one target to the next.
+
+## Verification
+
+Before claiming completion:
+
+1. Run the relevant Remotion build/render command and capture the output path.
+2. Render at least one representative preview frame or short draft.
+3. Verify visual alignment against `DESIGN.md`: colours, type, radius, elevation, and spacing.
+4. Check readability at target platform size.
+5. Ask the user which beats need slower timing, stronger crop, different wallpaper, or restaging.
+
+## Provenance
+
+Adapted from the public `create-onboarding-video` skill referenced by the user, with aidevops additions for `DESIGN.md`, authorised browser capture, and branded wallpaper-style foreground composition.

--- a/.agents/tools/vision/create-screenshots.md
+++ b/.agents/tools/vision/create-screenshots.md
@@ -1,0 +1,86 @@
+---
+name: create-screenshots
+description: Create polished branded static PNG screenshots from supplied or browser-captured UI, using DESIGN.md branding, clean wallpaper backgrounds, and windowed foreground treatments.
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  grep: true
+  webfetch: true
+  task: true
+model: sonnet
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Create Screenshots
+
+Create static, production-ready PNG screenshots for launch pages, docs, app stores, social posts, and PR/demo assets. Use the same brand-aware capture and composition approach as onboarding videos, but optimize for a single clear image.
+
+## Quick Reference
+
+- **Use when**: the user asks for static product screenshots, branded app screenshots, demo images, launch visuals, or PNG exports.
+- **Output**: `.png` image files, plus optional source project or composition files when generated programmatically.
+- **Style**: clean wallpaper-style background with a crisp UI slice or windowed screenshot in the foreground, rounded corners, soft shadow, subtle border, and brand-complementary colour treatment.
+- **Related agents**: `tools/browser/browser-automation.md`, `tools/design/design-md.md`, `tools/vision/image-generation.md`, `tools/vision/image-editing.md`, `tools/video/create-onboarding-video.md`.
+
+## Intake
+
+Collect before creating assets:
+
+1. **Purpose and placement** — website hero, docs, app store, social, README, PR evidence, or investor deck.
+2. **Source UI** — uploaded screenshot, local file, user-provided URL, local dev server, or authorised live browser session.
+3. **Target state** — what data, page, modal, component, or interaction state must be visible.
+4. **Brand source** — `DESIGN.md` first; otherwise ask for brand colours, typography, logo, and mood.
+5. **Dimensions** — exact canvas size, aspect ratio, dark/light mode, and safe areas.
+6. **Privacy** — confirm whether real data is acceptable. Prefer seeded, anonymised, or demo data.
+
+Ask when browser access, target state, dimensions, or privacy expectations are unclear.
+
+## Capture Workflow
+
+1. Read project `DESIGN.md` when present. Extract palette, background, surface, radius, shadows/elevation, typography, and tone.
+2. Use `tools/browser/browser-automation.md` for authorised browser capture. Choose Playwright or dev-browser for repeatable captures; use Chrome DevTools or Stagehand when inspection is needed.
+3. Set deterministic viewport, theme, timezone, locale, feature flags, and seeded data where possible.
+4. Capture the smallest useful region: selector screenshot, component screenshot, modal, card, chart, or window. Capture full viewport only when the composition requires it.
+5. Avoid `fullPage: true` for AI review or draft inspection; use bounded captures and resize large images before analysis.
+6. Save raw captures under `screenshots/raw/` or the user's requested asset path, then compose final images under `screenshots/final/` or the requested output path.
+
+## Composition Rules
+
+- **Focal element first**: the foreground UI must communicate the product value without requiring a caption.
+- **Wallpaper background**: generate a brand-complementary gradient, mesh, abstract surface, or clean desktop-like background from `DESIGN.md` tokens. Keep contrast low enough that the foreground remains dominant.
+- **Foreground treatment**: apply rounded corners, subtle border, soft drop shadow, and optional ambient glow. Match source UI radius and elevation where possible.
+- **Brand consistency**: use `DESIGN.md` colours, typography, spacing, and tone. If generating a wallpaper, derive it from primary/accent/neutral tokens and add complementary hues sparingly.
+- **Data hygiene**: remove secrets, personal data, private repo names, tokens, internal URLs, and customer information unless the user explicitly confirms publication scope.
+- **No fake UI**: do not invent product screens when a real capture is expected. If a designed mock is desired, label it as a mockup.
+
+## Recommended Variants
+
+Offer variants when useful:
+
+- **Hero**: 16:9 or 3:2 canvas, large windowed screenshot, spacious brand wallpaper.
+- **Social**: 1200×630, 1080×1080, or 1080×1350, headline-safe margin, strong contrast.
+- **Docs/README**: transparent or neutral background, minimal shadow, compressed but readable.
+- **App Store / mobile**: portrait device or cropped app screen, platform-safe margins, no misleading device chrome.
+- **PR evidence**: unstyled factual screenshot plus optional polished marketing variant.
+
+## Tooling Guidance
+
+- For browser capture, prefer selector screenshots and explicit viewport setup.
+- For image generation, use `tools/vision/image-generation.md` only for non-product backgrounds or abstract wallpaper, not for factual UI.
+- For editing/compositing, use deterministic scripts or a checked-in source file when the result must be reproducible.
+- For animated variants, hand off to `tools/video/create-onboarding-video.md`.
+
+## Verification
+
+Before claiming completion:
+
+1. Confirm final PNG paths and dimensions.
+2. Inspect the image for cropped content, blurry scaling, unreadable text, or over-strong shadows.
+3. Verify brand fit against `DESIGN.md` or the user's supplied brand guidance.
+4. Verify sensitive data is absent or intentionally present.
+5. Provide the raw capture path, final path, and command or source method used.


### PR DESCRIPTION
## Summary
- Add create-onboarding-video subagent for Remotion-based onboarding/app-preview videos from UI screenshots or authorised browser captures.
- Add create-screenshots subagent for branded static PNG compositions with DESIGN.md guidance, browser capture, privacy checks, and wallpaper-style backgrounds.
- Include verification expectations for frontmatter, subagent discovery, visual brand fit, and final render/output paths.

## Verification
- Frontmatter/SPDX validation passed for both new agent markdown files.
- Subagent discovery validation confirms both new agents are discoverable.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.16 plugin for [OpenCode](https://opencode.ai) v1.14.44 with gpt-5.5 spent 3h 24m and 218,779 tokens on this with the user in an interactive session.
