### PR TITLE
fix: restore canonical checkout after branch switches

### DIFF
--- a/.agents/hooks/canonical-on-main-guard.sh
+++ b/.agents/hooks/canonical-on-main-guard.sh
@@ -4,9 +4,10 @@
 #
 # canonical-on-main-guard.sh — git post-checkout hook.
 #
-# Warns when the canonical repo directory is switched off main/master in an
-# interactive session. Complements t1990's edit-time check in pre-edit-check.sh
-# by catching the branch switch itself, not just the first edit that follows.
+# Repairs the canonical repo directory back to the default branch when it is
+# switched off default in an interactive session. Complements t1990's edit-time
+# check in pre-edit-check.sh by catching the branch switch itself, not just the
+# first edit that follows.
 #
 # Install: see .agents/scripts/install-canonical-guard.sh
 #
@@ -16,15 +17,16 @@
 #   $3 = flag (1 = branch checkout, 0 = file checkout)
 #
 # Environment:
-#   AIDEVOPS_CANONICAL_GUARD=strict   — block the checkout (exit 1)
+#   AIDEVOPS_CANONICAL_GUARD=repair   — default: restore the default branch
+#   AIDEVOPS_CANONICAL_GUARD=strict   — restore the default branch and exit 1
 #   AIDEVOPS_CANONICAL_GUARD=bypass   — suppress the warning entirely
-#   AIDEVOPS_CANONICAL_GUARD=warn     — default: warn loudly but don't block
+#   AIDEVOPS_CANONICAL_GUARD=warn     — warn loudly but do not restore
 #
 # Fail-open cases (exit 0, no warning):
 #   - Headless session (FULL_LOOP_HEADLESS / AIDEVOPS_HEADLESS / OPENCODE_HEADLESS / GITHUB_ACTIONS set)
 #   - File-level checkout ($3 != 1)
 #   - Current working copy is a linked worktree (not canonical)
-#   - Current branch is main or master (not a violation)
+#   - Current branch is the detected default branch (not a violation)
 #   - Detached HEAD
 #   - repos.json missing or working copy not in initialized_repos[]
 
@@ -34,9 +36,39 @@ set -u
 [[ "${3:-0}" == "1" ]] || exit 0
 
 # Explicit bypass
-if [[ "${AIDEVOPS_CANONICAL_GUARD:-warn}" == "bypass" ]]; then
+if [[ "${AIDEVOPS_CANONICAL_GUARD:-repair}" == "bypass" ]]; then
 	exit 0
 fi
+
+detect_default_branch() {
+	local default_branch=""
+	default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || default_branch=""
+	default_branch="${default_branch#origin/}"
+	if [[ -z "$default_branch" ]] && git show-ref --verify --quiet refs/heads/main; then
+		default_branch="main"
+	fi
+	if [[ -z "$default_branch" ]] && git show-ref --verify --quiet refs/heads/master; then
+		default_branch="master"
+	fi
+	if [[ -z "$default_branch" ]]; then
+		default_branch="main"
+	fi
+	printf '%s' "$default_branch"
+	return 0
+}
+
+restore_default_branch() {
+	local default_branch="$1"
+	local status_output=""
+	status_output=$(git status --porcelain 2>/dev/null) || status_output=""
+	if [[ -n "$status_output" ]]; then
+		printf 'Refusing automatic restore because the working tree is not clean.\n' >&2
+		printf 'Run: git status --short, then manually restore the canonical repo to %s.\n' "$default_branch" >&2
+		return 1
+	fi
+	AIDEVOPS_CANONICAL_GUARD=bypass git checkout "$default_branch" --quiet 2>/dev/null
+	return $?
+}
 
 # Headless session: skip the check — workers know what they're doing
 if [[ "${FULL_LOOP_HEADLESS:-}" == "true" ]] ||
@@ -50,9 +82,10 @@ fi
 current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 [[ -z "$current_branch" ]] && exit 0 # detached HEAD — not our concern
 
-# If new branch IS main/master, nothing to warn about
+# If new branch IS the default branch, nothing to warn about
+default_branch=$(detect_default_branch)
 case "$current_branch" in
-main | master)
+"$default_branch")
 	exit 0
 	;;
 esac
@@ -134,29 +167,44 @@ fi
 	printf '\n'
 	printf 'The canonical repo directory %s%s%s has been switched to\n' \
 		"$YELLOW" "$repo_root" "$NC"
-	printf 'branch %s%s%s, which is NOT main/master.\n' "$YELLOW" "$current_branch" "$NC"
+	printf 'branch %s%s%s, which is NOT the default branch (%s%s%s).\n' \
+		"$YELLOW" "$current_branch" "$NC" "$YELLOW" "$default_branch" "$NC"
 	printf '\n'
 	printf 'aidevops convention (t1990): canonical directories stay on main.\n'
 	printf 'Worktrees are used for all non-main work.\n'
 	printf '\n'
-	printf 'To recover:\n'
-	printf '  git checkout main\n'
+	printf 'To recover manually:\n'
+	printf '  git checkout %s\n' "$default_branch"
 	printf '  wt add <type>/%s        # if you want to keep the branch\n' "$current_branch"
 	printf '\n'
 	printf 'To bypass this warning entirely:\n'
 	printf '  AIDEVOPS_CANONICAL_GUARD=bypass git checkout <branch>\n'
 	printf '\n'
-	printf 'To enforce strict mode (fail the checkout):\n'
+	printf 'To warn without restoring:\n'
+	printf '  AIDEVOPS_CANONICAL_GUARD=warn git checkout <branch>\n'
+	printf '\n'
+	printf 'To enforce strict mode (restore, then fail the checkout):\n'
 	printf '  AIDEVOPS_CANONICAL_GUARD=strict git checkout <branch>\n'
 	printf '\n'
 	printf '%s============================================================%s\n' "$RED" "$NC"
 	printf '\n'
 } >&2
 
-# Strict mode: fail the checkout
-if [[ "${AIDEVOPS_CANONICAL_GUARD:-warn}" == "strict" ]]; then
+case "${AIDEVOPS_CANONICAL_GUARD:-repair}" in
+warn)
+	exit 0
+	;;
+strict)
+	restore_default_branch "$default_branch" || true
 	exit 1
-fi
+	;;
+repair | *)
+	if restore_default_branch "$default_branch"; then
+		printf '[canonical-on-main-guard] Restored canonical repo to %s. Use a linked worktree for branch work.\n' "$default_branch" >&2
+	else
+		exit 1
+	fi
+	;;
+esac
 
-# Default: warn-only, don't block
 exit 0

--- a/.agents/scripts/test-canonical-guard.sh
+++ b/.agents/scripts/test-canonical-guard.sh
@@ -15,8 +15,8 @@
 #   4. Worktree (non-canonical) → exit 0, no stderr banner
 #   5. Canonical on main → exit 0, no stderr banner
 #   6. Canonical off main + repo NOT in repos.json → exit 0 (fail-open)
-#   7. Canonical off main + repo IN repos.json, interactive → exit 0 with warning
-#   8. Canonical off main + repo IN repos.json, strict → exit 1 with warning
+#   7. Canonical off main + repo IN repos.json, interactive → restore main
+#   8. Canonical off main + repo IN repos.json, strict → restore main + exit 1
 #
 # Exit 0 = all tests pass, 1 = at least one failure.
 
@@ -194,29 +194,52 @@ fi
 mv "$HOME/.config/aidevops/repos.json.bak" "$HOME/.config/aidevops/repos.json"
 
 # -----------------------------------------------------------------------------
-# Test 6: canonical off main + IN repos.json, interactive → warn, exit 0
+# Test 6: canonical off main + IN repos.json, interactive → restore main
 # -----------------------------------------------------------------------------
+pushd "$REPO" >/dev/null || exit 1
+git checkout feature-branch --quiet
+popd >/dev/null || exit 1
 _run_hook 1
 rc=$?
-if [[ "$rc" -eq 0 ]] && [[ "$HOOK_STDERR" == *"canonical-on-main-guard"* ]]; then
-	pass "canonical off main + known repo, interactive: exit 0 + warning"
+current_after_repair=$(git -C "$REPO" branch --show-current)
+if [[ "$rc" -eq 0 ]] && [[ "$HOOK_STDERR" == *"canonical-on-main-guard"* ]] && [[ "$current_after_repair" == "main" ]]; then
+	pass "canonical off main + known repo, interactive: restored main"
 else
-	fail "interactive violation: expected exit 0 + warning, got rc=$rc stderr_present=$([[ -n $HOOK_STDERR ]] && echo yes || echo no)"
+	fail "interactive violation: expected restore to main, got rc=$rc branch=$current_after_repair stderr_present=$([[ -n $HOOK_STDERR ]] && echo yes || echo no)"
 fi
 
 # -----------------------------------------------------------------------------
-# Test 7: canonical off main + IN repos.json, strict → warn, exit 1
+# Test 7: canonical off main + IN repos.json, strict → restore main + exit 1
 # -----------------------------------------------------------------------------
+pushd "$REPO" >/dev/null || exit 1
+git checkout feature-branch --quiet
+popd >/dev/null || exit 1
 _run_hook 1 "AIDEVOPS_CANONICAL_GUARD=strict"
 rc=$?
-if [[ "$rc" -eq 1 ]] && [[ "$HOOK_STDERR" == *"canonical-on-main-guard"* ]]; then
-	pass "canonical off main + strict: exit 1 + warning"
+current_after_strict=$(git -C "$REPO" branch --show-current)
+if [[ "$rc" -eq 1 ]] && [[ "$HOOK_STDERR" == *"canonical-on-main-guard"* ]] && [[ "$current_after_strict" == "main" ]]; then
+	pass "canonical off main + strict: restored main + exit 1"
 else
-	fail "strict violation: expected exit 1 + warning, got rc=$rc"
+	fail "strict violation: expected exit 1 and restore to main, got rc=$rc branch=$current_after_strict"
 fi
 
 # -----------------------------------------------------------------------------
-# Test 8: worktree (non-canonical) → no warning
+# Test 8: canonical off main + warn mode → no restore
+# -----------------------------------------------------------------------------
+pushd "$REPO" >/dev/null || exit 1
+git checkout feature-branch --quiet
+popd >/dev/null || exit 1
+_run_hook 1 "AIDEVOPS_CANONICAL_GUARD=warn"
+rc=$?
+current_after_warn=$(git -C "$REPO" branch --show-current)
+if [[ "$rc" -eq 0 ]] && [[ "$HOOK_STDERR" == *"canonical-on-main-guard"* ]] && [[ "$current_after_warn" == "feature-branch" ]]; then
+	pass "canonical off main + warn: exit 0 without restore"
+else
+	fail "warn mode: expected branch to remain feature-branch, got rc=$rc branch=$current_after_warn"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 9: worktree (non-canonical) → no warning
 # -----------------------------------------------------------------------------
 # Create a worktree of the fake repo
 WORKTREE="${TMP}/fake-worktree"


### PR DESCRIPTION
## Summary
- Change the canonical-on-main post-checkout guard from warn-only to default restore mode for interactive sessions.
- Detect the default branch instead of hard-coding main/master in the guard path.
- Expand guard tests to prove default restore, strict restore, warn-only, bypass, headless, unknown repo, and linked worktree behaviours.

Resolves #23290

## Verification
- `bash .agents/scripts/test-canonical-guard.sh`
- `shellcheck .agents/hooks/canonical-on-main-guard.sh .agents/scripts/test-canonical-guard.sh`
- `bash .agents/scripts/tests/test-git-safety-guard.sh`
- `.agents/scripts/linters-local.sh` (ran; targeted checks passed, full suite still reports unrelated existing/advisory failures including pulse canary fixture/config failure and existing complexity/markdown debt)

## Notes
The canonical checkout at `/Users/marcusquinn/Git/aidevops` was restored to `main` before this change. Future accidental branch switches in canonical repos are repaired back to the default branch unless explicitly run with `AIDEVOPS_CANONICAL_GUARD=warn` or `bypass`.
