### PR TITLE
GH#23279: document grouped ecosystem repo paths

### DIFF
--- a/.agents/workflows/branch.md
+++ b/.agents/workflows/branch.md
@@ -21,7 +21,7 @@ tools:
 - Resume existing work first: `git worktree list` or `wt list`
 - Start from canonical repo on `main`: `wt switch -c {type}/{name}`
 - Fallback: `worktree-helper.sh add {type}/{name}`
-- Keep `~/Git/{repo}/` on `main`; do task work in the linked worktree path
+- Keep `~/Git/{repo}/` or grouped `~/Git/{ecosystem}/{repo}/` on `main`; do task work in a sibling linked worktree path
 
 | Task Type | Branch Prefix | Subagent |
 |-----------|---------------|----------|
@@ -61,7 +61,7 @@ Commits: conventional (`feat:` `fix:` `refactor:` `docs:` `chore:` `test:`). Inc
 ## Worktree Rules
 
 - Prefer worktrees over `git checkout -b`; the next session must inherit `main`, not a task branch.
-- Reference the worktree path (`~/Git/{repo}-{type}-{slug}/`), not "switching the main repo to a branch".
+- Reference the sibling worktree path (`~/Git/{repo}-{type}-{slug}/` or `~/Git/{ecosystem}/{repo}-{type}-{slug}/`), not "switching the main repo to a branch".
 - After switching to a worktree, re-read files at the worktree path before editing.
 - Never remove a worktree you did not create unless the user explicitly asked.
 

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -43,11 +43,11 @@ Remote has new commits → pull/rebase first. Uncommitted local changes → stas
 
 **Worktrees** (DEFAULT for all feature work):
 
-Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. All work in worktree directories under `~/Git/`; do not create durable implementation worktrees in runtime temp paths such as macOS `/var/folders/.../T/opencode/`.
+Main repo (`~/Git/{repo}/` or grouped `~/Git/{ecosystem}/{repo}/`) ALWAYS stays on `main`. Create linked worktrees as siblings of the canonical clone in the same parent; do not create durable implementation worktrees in runtime temp paths such as macOS `/var/folders/.../T/opencode/`.
 
 ```bash
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/my-feature
-# Creates: ~/Git/{repo}-feature-my-feature/
+# Creates a sibling, e.g. ~/Git/{repo}-feature-my-feature/ or ~/Git/mcp/{repo}-feature-my-feature/
 ```
 
 Non-git artifacts (`.venv/`, `node_modules/`, `dist/`, `.env`) don't transfer between worktrees — recreate in each. See `workflows/worktree.md`.

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -15,7 +15,7 @@ Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (St
 # After gh pr merge --squash succeeds:
 WORKTREE_PATH="$(pwd)"
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
-CANONICAL_DIR="${WORKTREE_PATH%%.*}"
+CANONICAL_DIR="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
 
 cd "$CANONICAL_DIR" || cd "$HOME"
 git pull origin main 2>/dev/null || true
@@ -41,7 +41,8 @@ Cleanup failures are non-fatal — the PR is already merged.
 gh pr merge --squash
 
 # Return to canonical repo and pull
-cd ~/Git/$(basename "$PWD" | cut -d. -f1)
+CANONICAL_DIR="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+cd "$CANONICAL_DIR"
 git pull origin main
 
 # Remove merged worktrees

--- a/configs/mcp-templates/quickfile.json
+++ b/configs/mcp-templates/quickfile.json
@@ -1,7 +1,7 @@
 {
   "_comment": "QuickFile MCP server configuration snippets for various AI tools",
   "_documentation": "https://github.com/marcusquinn/quickfile-mcp",
-  "_install": "cd ~/Git && git clone https://github.com/marcusquinn/quickfile-mcp.git && cd quickfile-mcp && npm install && npm run build",
+  "_install": "mkdir -p ~/Git/mcp && git clone https://github.com/marcusquinn/quickfile-mcp.git ~/Git/mcp/quickfile-mcp && cd ~/Git/mcp/quickfile-mcp && npm install && npm run build",
   "_credentials": "~/.config/.quickfile-mcp/credentials.json",
 
   "opencode": {
@@ -9,7 +9,7 @@
     "_section": "mcp",
     "quickfile": {
       "type": "local",
-      "command": ["node", "/Users/YOU/Git/quickfile-mcp/dist/index.js"],
+      "command": ["node", "/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"],
       "enabled": true
     }
   },

--- a/configs/quickfile-mcp-config.json.txt
+++ b/configs/quickfile-mcp-config.json.txt
@@ -6,8 +6,8 @@
   "prerequisites": {
     "node_version": "18+",
     "install_commands": [
-      "cd ~/Git && git clone https://github.com/marcusquinn/quickfile-mcp.git",
-      "cd quickfile-mcp && npm install && npm run build"
+      "mkdir -p ~/Git/mcp && git clone https://github.com/marcusquinn/quickfile-mcp.git ~/Git/mcp/quickfile-mcp",
+      "cd ~/Git/mcp/quickfile-mcp && npm install && npm run build"
     ],
     "credentials_setup": "mkdir -p ~/.config/.quickfile-mcp && chmod 700 ~/.config/.quickfile-mcp",
     "credentials_location": "~/.config/.quickfile-mcp/credentials.json",
@@ -78,7 +78,7 @@
       "agent_tools": {
         "quickfile_*": true
       },
-      "notes": "Replace /path/to with actual path (e.g., ~/Git/quickfile-mcp)"
+      "notes": "Replace /path/to with actual path (e.g., ~/Git/mcp/quickfile-mcp)"
     },
     "claude_code": {
       "method": "cli",
@@ -204,7 +204,7 @@
     },
     "mcp_not_responding": {
       "issue": "MCP server not responding",
-      "solution": "Rebuild: cd quickfile-mcp && npm run build. Restart AI tool."
+      "solution": "Rebuild: cd ~/Git/mcp/quickfile-mcp && npm run build. Restart AI tool."
     }
   },
   "debug": {


### PR DESCRIPTION
## Summary

Document grouped repository parents for worktree guidance and align QuickFile MCP setup templates with the ~/Git/mcp parent.

## Files Changed

.agents/workflows/branch.md,.agents/workflows/git-workflow.md,.agents/workflows/worktree-cleanup.md,configs/mcp-templates/quickfile.json,configs/quickfile-mcp-config.json.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; shellcheck .agents/scripts/setup/modules/mcp-setup.sh .agents/scripts/quickfile-helper.sh .agents/scripts/ocr-receipt-helper.sh; jq empty configs/quickfile-mcp-config.json.txt configs/mcp-templates/quickfile.json; ./setup.sh --non-interactive; Runtime Testing: low-risk docs/config change, self-assessed with setup deployment verification.

Resolves #23279


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.19 plugin for [OpenCode](https://opencode.ai) v1.14.44 with gpt-5.5 spent 8m and 180,407 tokens on this with the user in an interactive session.