### PR TITLE
fix: preserve profile README worker counts

### DIFF
--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -313,29 +313,32 @@ _generate_session_time_vars() {
 	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0)')")
 	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	day_total=$(_format_hours "$(echo "$day_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
-	day_interactive=$(_format_number "$(echo "$day_json" | jq -r '(.interactive_sessions // 0)')")
-	day_workers=$(_format_number "$(echo "$day_json" | jq -r '(.worker_sessions // 0)')")
+	# Keep counts raw here; _generate_work_with_ai_table formats them once.
+	# Pre-formatting creates comma strings that _format_number later rejects as
+	# non-numeric, turning 1,000+ session counts into 0.
+	day_interactive=$(echo "$day_json" | jq -r '(.interactive_sessions // 0)')
+	day_workers=$(echo "$day_json" | jq -r '(.worker_sessions // 0)')
 
 	local week_human week_worker week_total week_interactive week_workers
 	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0)')")
 	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	week_total=$(_format_hours "$(echo "$week_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
-	week_interactive=$(_format_number "$(echo "$week_json" | jq -r '(.interactive_sessions // 0)')")
-	week_workers=$(_format_number "$(echo "$week_json" | jq -r '(.worker_sessions // 0)')")
+	week_interactive=$(echo "$week_json" | jq -r '(.interactive_sessions // 0)')
+	week_workers=$(echo "$week_json" | jq -r '(.worker_sessions // 0)')
 
 	local month_human month_worker month_total month_interactive month_workers
 	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0)')")
 	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	month_total=$(_format_hours "$(echo "$month_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
-	month_interactive=$(_format_number "$(echo "$month_json" | jq -r '(.interactive_sessions // 0)')")
-	month_workers=$(_format_number "$(echo "$month_json" | jq -r '(.worker_sessions // 0)')")
+	month_interactive=$(echo "$month_json" | jq -r '(.interactive_sessions // 0)')
+	month_workers=$(echo "$month_json" | jq -r '(.worker_sessions // 0)')
 
 	local year_human year_worker year_total year_interactive year_workers
 	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0)')")
 	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	year_total=$(_format_hours "$(echo "$year_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
-	year_interactive=$(_format_number "$(echo "$year_json" | jq -r '(.interactive_sessions // 0)')")
-	year_workers=$(_format_number "$(echo "$year_json" | jq -r '(.worker_sessions // 0)')")
+	year_interactive=$(echo "$year_json" | jq -r '(.interactive_sessions // 0)')
+	year_workers=$(echo "$year_json" | jq -r '(.worker_sessions // 0)')
 
 	# Emit as shell variable assignments for eval
 	printf 'day_human=%q day_worker=%q day_total=%q day_interactive=%q day_workers=%q\n' \

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -636,6 +636,45 @@ test_session_time_vars_default_missing_null_values() {
 	return 0
 }
 
+test_work_with_ai_worker_counts_above_thousand() {
+	local test_name="work with AI worker counts above one thousand render"
+
+	TEST_DIR=$(mktemp -d)
+	mkdir -p "${TEST_DIR}/home"
+
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "${SOURCE_DATA_LIB}"
+	# shellcheck source=../profile-readme-render-lib.sh
+	source "${SOURCE_RENDER_LIB}"
+
+	local screen_json day_json week_json month_json year_json output_file
+	screen_json='{"today_hours":1,"week_hours":2,"month_hours":3,"year_hours":4}'
+	day_json='{"interactive_human_hours":1,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":22,"worker_sessions":55}'
+	week_json='{"interactive_human_hours":10,"worker_human_hours":20,"worker_machine_hours":30,"total_human_hours":40,"total_machine_hours":50,"interactive_sessions":183,"worker_sessions":1080}'
+	month_json='{"interactive_human_hours":100,"worker_human_hours":200,"worker_machine_hours":300,"total_human_hours":400,"total_machine_hours":500,"interactive_sessions":497,"worker_sessions":1518}'
+	year_json="${month_json}"
+	output_file="${TEST_DIR}/work-with-ai.md"
+
+	if ! HOME="${TEST_DIR}/home" _generate_work_with_ai_table \
+		"${screen_json}" "${day_json}" "${week_json}" "${month_json}" "${year_json}" >"${output_file}"; then
+		print_result "${test_name}" 1 "Work with AI table generation failed"
+		return 0
+	fi
+
+	if ! grep -qF '| Worker sessions | 55 | 1,080 | 1,518 | 1,518 |' "${output_file}"; then
+		print_result "${test_name}" 1 "four-digit worker session counts were not preserved and comma-formatted"
+		return 0
+	fi
+
+	if grep -qF '| Worker sessions | 55 | 0 | 0 | 0 |' "${output_file}"; then
+		print_result "${test_name}" 1 "worker session counts regressed to zero after double-formatting"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 main() {
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
 		echo "Helper script not found or not executable: ${SOURCE_HELPER}" >&2
@@ -653,6 +692,8 @@ main() {
 	test_default_template_with_existing_markers_replaced
 	teardown
 	test_session_time_vars_default_missing_null_values
+	teardown
+	test_work_with_ai_worker_counts_above_thousand
 	teardown
 
 	echo ""


### PR DESCRIPTION
## Summary
- Keep profile README session counts raw until final table rendering so counts above 999 do not become zero after double-formatting.
- Add a regression test for Work with AI worker session counts over 1,000.

## Verification
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh`
- `shellcheck .agents/scripts/profile-readme-render-lib.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `git diff --check`

For #22305

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.20 plugin for [OpenCode](https://opencode.ai) v1.14.44 with gpt-5.5 spent 10m and 259,861 tokens on this with the user in an interactive session.
