### PR TITLE
fix: sync Tabby title on session rename

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -23,6 +23,9 @@ import { join } from "node:path";
 const { isDefaultBranchTitle, isTitleOverwritable } = await import(
   "../../../.opencode/lib/session-rename-guards.ts"
 );
+const { isTerminalTitleEnabled, sanitizeTerminalTitle, terminalTitleSequence } = await import(
+  "../../../.opencode/lib/terminal-title.ts"
+);
 
 let pass = 0;
 let fail = 0;
@@ -116,6 +119,31 @@ try {
 } finally {
   rmSync(tmp, { recursive: true, force: true });
 }
+
+// --- terminal title OSC helpers ---------------------------------------------
+console.log("\nGroup 3: terminal title OSC helpers");
+assertEq(
+  "OSC 0 sequence wraps the title",
+  "\u001B]0;Issue #123: fix Tabby title\u0007",
+  terminalTitleSequence("Issue #123: fix Tabby title"),
+);
+assertEq(
+  "control characters are stripped from titles",
+  "Issue #123  injected title",
+  sanitizeTerminalTitle("Issue #123\u0007\u001Binjected\ntitle"),
+);
+assertEq("empty sanitized title emits no OSC", "", terminalTitleSequence("\n\t"));
+assertEq(
+  "TERMINAL_TITLE_ENABLED=false disables title emit",
+  false,
+  isTerminalTitleEnabled({ TERMINAL_TITLE_ENABLED: "false" }),
+);
+assertEq(
+  "AIDEVOPS_TABBY_ENABLED=false disables title emit",
+  false,
+  isTerminalTitleEnabled({ AIDEVOPS_TABBY_ENABLED: "false" }),
+);
+assertEq("terminal title emit defaults to enabled", true, isTerminalTitleEnabled({}));
 
 console.log("\n=== Results ===");
 console.log(`PASS: ${pass}`);

--- a/.opencode/lib/terminal-title.ts
+++ b/.opencode/lib/terminal-title.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Terminal title helpers for OpenCode tools.
+//
+// The shell-side terminal-title-helper.sh updates Tabby/iTerm/etc. when a
+// normal shell hook runs. OpenCode session-rename tools bypass that shell hook
+// and write the session title directly to SQLite, so they must emit OSC 0
+// themselves to keep the terminal/tab title in sync.
+
+import { closeSync, openSync, writeSync } from "node:fs"
+
+const OSC_TITLE_PREFIX = "\u001B]0;"
+const OSC_TITLE_SUFFIX = "\u0007"
+
+type TerminalTitleEnv = Record<string, string | undefined>
+
+/**
+ * Honour the same opt-out environment variables as terminal-title-helper.sh.
+ */
+export function isTerminalTitleEnabled(env: TerminalTitleEnv = process.env): boolean {
+  return env.TERMINAL_TITLE_ENABLED !== "false" && env.AIDEVOPS_TABBY_ENABLED !== "false"
+}
+
+/**
+ * Remove C0 control characters so arbitrary LLM/session titles cannot inject
+ * extra terminal control sequences into the OSC payload.
+ */
+export function sanitizeTerminalTitle(title: string): string {
+  return title.replace(/[\u0000-\u001F\u007F]/g, " ").trim()
+}
+
+/**
+ * Build an OSC 0 title sequence for terminals such as Tabby.
+ */
+export function terminalTitleSequence(title: string): string {
+  const sanitizedTitle = sanitizeTerminalTitle(title)
+  if (!sanitizedTitle) {
+    return ""
+  }
+  return `${OSC_TITLE_PREFIX}${sanitizedTitle}${OSC_TITLE_SUFFIX}`
+}
+
+/**
+ * Best-effort terminal title update. Prefer /dev/tty so the sequence reaches
+ * the controlling terminal even if a tool framework captures stdout; fall back
+ * to stdout for runtimes where /dev/tty is unavailable.
+ */
+export function emitTerminalTitle(title: string): boolean {
+  if (!isTerminalTitleEnabled()) {
+    return false
+  }
+
+  const sequence = terminalTitleSequence(title)
+  if (!sequence) {
+    return false
+  }
+
+  try {
+    const fd = openSync("/dev/tty", "w")
+    try {
+      writeSync(fd, sequence)
+      return true
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    try {
+      return process.stdout.write(sequence)
+    } catch {
+      return false
+    }
+  }
+}

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -3,6 +3,7 @@ import { Database } from "bun:sqlite"
 import { homedir } from "os"
 import { join } from "path"
 import { isDefaultBranchTitle, isTitleOverwritable } from "../lib/session-rename-guards"
+import { emitTerminalTitle } from "../lib/terminal-title"
 
 /**
  * Resolve the OpenCode SQLite database path.
@@ -121,6 +122,7 @@ export default tool({
     const result = renameSession(sessionID, title)
 
     if (result.success) {
+      emitTerminalTitle(result.message)
       return `Session renamed to: ${result.message}`
     }
     return `Failed to rename session: ${result.message}`
@@ -154,6 +156,7 @@ export const sync_branch = tool({
 
     switch (result.outcome) {
       case "renamed":
+        emitTerminalTitle(result.message)
         return `Session synced with branch: ${result.message}`
       case "skipped":
         return result.message


### PR DESCRIPTION
## Summary
- Emit sanitized OSC 0 terminal-title updates when OpenCode session rename succeeds, keeping Tabby tabs aligned with OpenCode titles.
- Add a small reusable terminal-title helper and regression coverage for OSC formatting, sanitization, and opt-out environment variables.

## Verification
- `bun .agents/scripts/tests/test-session-rename-ts.mjs`
- `bun build --target=bun --outfile=/dev/null .opencode/lib/terminal-title.ts`
- `bun build --target=bun --external=@opencode-ai/plugin --outfile=/dev/null .opencode/tool/session-rename.ts`
- `bash .agents/scripts/tests/test-terminal-title-helper.sh`
- `bash .agents/scripts/tests/test-session-rename-helper.sh`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.20 plugin for [OpenCode](https://opencode.ai) v1.14.44 with gpt-5.5 spent 11m and 191,370 tokens on this with the user in an interactive session.
