### PR TITLE
fix: clean up Tabby title lint

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -129,7 +129,7 @@ assertEq(
 );
 assertEq(
   "control characters are stripped from titles",
-  "Issue #123  injected title",
+  "Issue #123 injected title",
   sanitizeTerminalTitle("Issue #123\u0007\u001Binjected\ntitle"),
 );
 assertEq("empty sanitized title emits no OSC", "", terminalTitleSequence("\n\t"));

--- a/.opencode/lib/terminal-title.ts
+++ b/.opencode/lib/terminal-title.ts
@@ -27,7 +27,24 @@ export function isTerminalTitleEnabled(env: TerminalTitleEnv = process.env): boo
  * extra terminal control sequences into the OSC payload.
  */
 export function sanitizeTerminalTitle(title: string): string {
-  return title.replace(/[\u0000-\u001F\u007F]/g, " ").trim()
+  let sanitizedTitle = ""
+  let previousWasControl = false
+
+  for (const character of title) {
+    const codePoint = character.charCodeAt(0)
+    if (codePoint <= 31 || codePoint === 127) {
+      if (!previousWasControl) {
+        sanitizedTitle += " "
+      }
+      previousWasControl = true
+      continue
+    }
+
+    sanitizedTitle += character
+    previousWasControl = false
+  }
+
+  return sanitizedTitle.trim()
 }
 
 /**
@@ -44,7 +61,8 @@ export function terminalTitleSequence(title: string): string {
 /**
  * Best-effort terminal title update. Prefer /dev/tty so the sequence reaches
  * the controlling terminal even if a tool framework captures stdout; fall back
- * to stdout for runtimes where /dev/tty is unavailable.
+ * to stderr for runtimes where /dev/tty is unavailable so tool return payloads
+ * are not polluted with terminal control sequences.
  */
 export function emitTerminalTitle(title: string): boolean {
   if (!isTerminalTitleEnabled()) {
@@ -66,7 +84,7 @@ export function emitTerminalTitle(title: string): boolean {
     }
   } catch {
     try {
-      return process.stdout.write(sequence)
+      return process.stderr.write(sequence)
     } catch {
       return false
     }

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -1,7 +1,7 @@
-import { tool } from "@opencode-ai/plugin"
 import { Database } from "bun:sqlite"
-import { homedir } from "os"
-import { join } from "path"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { tool } from "@opencode-ai/plugin"
 import { isDefaultBranchTitle, isTitleOverwritable } from "../lib/session-rename-guards"
 import { emitTerminalTitle } from "../lib/terminal-title"
 


### PR DESCRIPTION
## Summary
- Clean up the Tabby title sync implementation after PR #23296 so Biome stays green.
- Switch the fallback OSC write from stdout to stderr to avoid polluting tool return payloads when `/dev/tty` is unavailable.
- Avoid control-character regex literals while preserving terminal-title sanitization coverage.

## Verification
- `npx @biomejs/biome check .opencode/lib/terminal-title.ts .opencode/tool/session-rename.ts`
- `bun .agents/scripts/tests/test-session-rename-ts.mjs`
- `bun build --target=bun --outfile=/dev/null .opencode/lib/terminal-title.ts`
- `bun build --target=bun --external=@opencode-ai/plugin --outfile=/dev/null .opencode/tool/session-rename.ts`
- `bash .agents/scripts/tests/test-terminal-title-helper.sh`
- `bash .agents/scripts/tests/test-session-rename-helper.sh`
- `git diff --check`

For #23296
