### PR TITLE
Fix linters-local changed-file complexity gates

### DIFF
--- a/.agents/scripts/linters-local-analysis.sh
+++ b/.agents/scripts/linters-local-analysis.sh
@@ -377,6 +377,182 @@ check_toon_syntax() {
 # the same issues before code reaches Codacy, preventing quality gate failures.
 # Aligned with Codacy's ShellCheck + complexity engine.
 
+_COMPLEXITY_METRIC_FUNCTION="function-complexity"
+_COMPLEXITY_METRIC_NESTING="nesting-depth"
+
+_complexity_merge_base() {
+	local base_ref="${LINTERS_LOCAL_COMPLEXITY_BASE_REF:-origin/main}"
+	local head_ref="${LINTERS_LOCAL_COMPLEXITY_HEAD_REF:-HEAD}"
+
+	git merge-base "$head_ref" "$base_ref" 2>/dev/null
+	return $?
+}
+
+_complexity_changed_shell_files() {
+	local base_ref="$1"
+	local changed_files_buffer=""
+	local chunk=""
+
+	[[ -n "$base_ref" ]] && chunk=$(git diff --name-only "$base_ref"...HEAD 2>/dev/null || true)
+	changed_files_buffer="$chunk"
+
+	chunk=$(git diff --name-only 2>/dev/null || true)
+	[[ -n "$chunk" ]] && changed_files_buffer=$(printf '%s\n%s\n' "$changed_files_buffer" "$chunk")
+
+	chunk=$(git diff --cached --name-only 2>/dev/null || true)
+	[[ -n "$chunk" ]] && changed_files_buffer=$(printf '%s\n%s\n' "$changed_files_buffer" "$chunk")
+
+	printf '%s\n' "$changed_files_buffer" | grep -E '\.sh$' | grep -Ev '_archive/' | sort -u || true
+	return 0
+}
+
+_scan_function_complexity_file() {
+	local file="$1"
+	local rel_file="$2"
+	local out_file="$3"
+
+	awk -v file="$rel_file" -v block="$MAX_FUNCTION_LENGTH_BLOCK" '
+		/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ {
+			fname = $1
+			sub(/\(\)/, "", fname)
+			start = NR
+			next
+		}
+		fname && /^[[:space:]]*\}[[:space:]]*$/ {
+			lines = NR - start; if (lines > block) { printf "%s\t%s\t%d\n", file, fname, lines }
+			fname = ""
+		}
+	' "$file" >>"$out_file"
+	return 0
+}
+
+_scan_function_complexity_git_blob() {
+	local base_ref="$1"
+	local rel_file="$2"
+	local out_file="$3"
+
+	git show "${base_ref}:${rel_file}" 2>/dev/null | awk -v file="$rel_file" -v block="$MAX_FUNCTION_LENGTH_BLOCK" '
+		/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ {
+			fname = $1
+			sub(/\(\)/, "", fname)
+			start = NR
+			next
+		}
+		fname && /^[[:space:]]*\}[[:space:]]*$/ {
+			lines = NR - start; if (lines > block) { printf "%s\t%s\t%d\n", file, fname, lines }
+			fname = ""
+		}
+	' >>"$out_file"
+	return 0
+}
+
+_scan_nesting_depth_file() {
+	local file="$1"
+	local rel_file="$2"
+	local out_file="$3"
+
+	awk -v file="$rel_file" -v block="$MAX_NESTING_DEPTH_BLOCK" '
+		BEGIN { depth = 0; max_depth = 0; max_line = 0 }
+		/^[[:space:]]*#/ { next }
+		/^[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; max_depth = (depth > max_depth ? depth : max_depth); max_line = (depth == max_depth ? NR : max_line) }
+		/^[[:space:]]*(fi|done|esac)($|[[:space:]])/ { if (depth > 0) depth-- }
+		END { if (max_depth > block) { printf "%s\tNEST\t%d\n", file, max_depth } }
+	' "$file" >>"$out_file"
+	return 0
+}
+
+_scan_nesting_depth_git_blob() {
+	local base_ref="$1"
+	local rel_file="$2"
+	local out_file="$3"
+
+	git show "${base_ref}:${rel_file}" 2>/dev/null | awk -v file="$rel_file" -v block="$MAX_NESTING_DEPTH_BLOCK" '
+		BEGIN { depth = 0; max_depth = 0; max_line = 0 }
+		/^[[:space:]]*#/ { next }
+		/^[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; max_depth = (depth > max_depth ? depth : max_depth); max_line = (depth == max_depth ? NR : max_line) }
+		/^[[:space:]]*(fi|done|esac)($|[[:space:]])/ { if (depth > 0) depth-- }
+		END { if (max_depth > block) { printf "%s\tNEST\t%d\n", file, max_depth } }
+	' >>"$out_file"
+	return 0
+}
+
+_print_new_complexity_regressions() {
+	local new_file="$1"
+	local label="$2"
+	local count
+	count=$(safe_grep_count '.' "$new_file")
+	count=${count//[^0-9]/}
+	count=${count:-0}
+
+	[[ "$count" -eq 0 ]] && return 0
+
+	print_error "$label: $count new changed-file blocking regression(s)"
+	awk -F '\t' '{ printf "  %s:%s %s\n", $1, $2, $3 }' "$new_file" | head -10
+	[[ "$count" -gt 10 ]] && echo "  ... and $((count - 10)) more"
+	return 1
+}
+
+_scan_changed_complexity_base_file() {
+	local metric="$1"
+	local base_ref="$2"
+	local rel_file="$3"
+	local base_scan="$4"
+
+	git cat-file -e "${base_ref}:${rel_file}" 2>/dev/null || return 0
+
+	[[ "$metric" == "$_COMPLEXITY_METRIC_FUNCTION" ]] && _scan_function_complexity_git_blob "$base_ref" "$rel_file" "$base_scan"
+	[[ "$metric" == "$_COMPLEXITY_METRIC_NESTING" ]] && _scan_nesting_depth_git_blob "$base_ref" "$rel_file" "$base_scan"
+	return 0
+}
+
+_scan_changed_complexity_head_file() {
+	local metric="$1"
+	local rel_file="$2"
+	local head_scan="$3"
+
+	[[ -f "$rel_file" ]] || return 0
+
+	[[ "$metric" == "$_COMPLEXITY_METRIC_FUNCTION" ]] && _scan_function_complexity_file "$rel_file" "$rel_file" "$head_scan"
+	[[ "$metric" == "$_COMPLEXITY_METRIC_NESTING" ]] && _scan_nesting_depth_file "$rel_file" "$rel_file" "$head_scan"
+	return 0
+}
+
+_check_changed_file_complexity_regressions() {
+	local metric="$1"
+	local label="$2"
+	local base_ref changed_files base_scan head_scan new_scan
+	base_ref=$(_complexity_merge_base) || base_ref=""
+
+	[[ -n "$base_ref" ]] || {
+		print_warning "$label: no merge-base with origin/main; treating total scan as advisory"
+		return 0
+	}
+
+	changed_files=$(_complexity_changed_shell_files "$base_ref")
+	[[ -n "$changed_files" ]] || {
+		print_info "$label: no changed shell files; historical debt is advisory"
+		return 0
+	}
+
+	base_scan=$(mktemp)
+	head_scan=$(mktemp)
+	new_scan=$(mktemp)
+	push_cleanup "rm -f '${base_scan}' '${head_scan}' '${new_scan}'"
+
+	local rel_file
+	printf '%s\n' "$changed_files" | while IFS= read -r rel_file; do
+		[[ -n "$rel_file" ]] || continue
+		_scan_changed_complexity_base_file "$metric" "$base_ref" "$rel_file" "$base_scan"
+		_scan_changed_complexity_head_file "$metric" "$rel_file" "$head_scan"
+	done
+
+	awk -F '\t' 'FILENAME == ARGV[1] { seen[$1 "\t" $2] = 1; next } !seen[$1 "\t" $2] { print }' \
+		"$base_scan" "$head_scan" >"$new_scan"
+
+	_print_new_complexity_regressions "$new_scan" "$label"
+	return $?
+}
+
 check_function_complexity() {
 	echo -e "${BLUE}Checking Function Complexity (Codacy alignment)...${NC}"
 
@@ -436,14 +612,18 @@ check_function_complexity() {
 		fi
 	fi
 
-	if [[ "$block_violations" -le "$MAX_FUNCTION_LENGTH_VIOLATIONS" ]]; then
-		local total=$((block_violations + warn_violations))
-		print_success "Function complexity: $total oversized functions ($block_violations blocking, $warn_violations advisory)"
+	local total=$((block_violations + warn_violations))
+	if ! _check_changed_file_complexity_regressions "$_COMPLEXITY_METRIC_FUNCTION" "Function complexity"; then
+		return 1
+	fi
+
+	if [[ "$block_violations" -gt "$MAX_FUNCTION_LENGTH_VIOLATIONS" ]]; then
+		print_warning "Function complexity: $block_violations historical blocking violations exceed baseline threshold $MAX_FUNCTION_LENGTH_VIOLATIONS (advisory unless changed-file regression)"
 		return 0
 	fi
 
-	print_error "Function complexity: $block_violations blocking violations (threshold: $MAX_FUNCTION_LENGTH_VIOLATIONS)"
-	return 1
+	print_success "Function complexity: $total oversized functions ($block_violations blocking, $warn_violations advisory)"
+	return 0
 }
 
 # =============================================================================
@@ -506,14 +686,18 @@ check_nesting_depth() {
 		fi
 	fi
 
-	if [[ "$block_violations" -le "$MAX_NESTING_VIOLATIONS" ]]; then
-		local total=$((block_violations + warn_violations))
-		print_success "Nesting depth: $total files with deep nesting ($block_violations blocking, $warn_violations advisory)"
+	local total=$((block_violations + warn_violations))
+	if ! _check_changed_file_complexity_regressions "$_COMPLEXITY_METRIC_NESTING" "Nesting depth"; then
+		return 1
+	fi
+
+	if [[ "$block_violations" -gt "$MAX_NESTING_VIOLATIONS" ]]; then
+		print_warning "Nesting depth: $block_violations historical blocking violations exceed baseline threshold $MAX_NESTING_VIOLATIONS (advisory unless changed-file regression)"
 		return 0
 	fi
 
-	print_error "Nesting depth: $block_violations blocking violations (threshold: $MAX_NESTING_VIOLATIONS)"
-	return 1
+	print_success "Nesting depth: $total files with deep nesting ($block_violations blocking, $warn_violations advisory)"
+	return 0
 }
 
 append_file_size_result() {
@@ -874,10 +1058,18 @@ check_pulse_canary() {
 		return 1
 	fi
 
-	local sandbox rc output
+	local sandbox rc output sandbox_home defaults_source defaults_target
 	sandbox=$(mktemp -d)
+	sandbox_home="${sandbox}/home"
+	defaults_source=".agents/configs/aidevops.defaults.jsonc"
+	defaults_target="${sandbox_home}/.aidevops/agents/configs/aidevops.defaults.jsonc"
+	mkdir -p "${sandbox_home}/.aidevops/agents/configs"
+	if [[ -f "$defaults_source" ]]; then
+		cp "$defaults_source" "$defaults_target"
+	fi
+
 	output=$(
-		HOME="${sandbox}/home" \
+		HOME="$sandbox_home" \
 			FULL_LOOP_HEADLESS=1 \
 			timeout_sec 30 bash "$wrapper_script" --canary 2>&1
 	)
@@ -886,6 +1078,12 @@ check_pulse_canary() {
 
 	if [[ "$rc" -eq 0 ]]; then
 		print_success "Pulse canary: ok (sourcing + _pulse_handle_self_check + acquire_instance_lock)"
+		return 0
+	fi
+
+	if [[ "$rc" -eq 124 || "$rc" -eq 143 ]]; then
+		print_warning "Pulse canary infrastructure timeout/interruption (exit $rc). Output: ${output}"
+		print_info "Canary source-code regression classification is reserved for non-timeout exits; rerun bash .agents/scripts/tests/test-pulse-wrapper-canary.sh for the focused runtime check."
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-linters-local-complexity-gates.sh
+++ b/.agents/scripts/tests/test-linters-local-complexity-gates.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-linters-local-complexity-gates.sh — local complexity gate classification tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+
+# shellcheck source=../shared-constants.sh
+source "${REPO_ROOT}/.agents/scripts/shared-constants.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_repo() {
+	TEST_ROOT=$(mktemp -d)
+	git -C "$TEST_ROOT" init -q
+	git -C "$TEST_ROOT" config user.email "test@example.invalid"
+	git -C "$TEST_ROOT" config user.name "Test Runner"
+	git -C "$TEST_ROOT" config commit.gpgsign false
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+make_sh_function() {
+	local file="$1"
+	local function_name="$2"
+	local lines="$3"
+	local i=0
+
+	printf '%s() {\n' "$function_name" >>"$file"
+	while [[ "$i" -lt "$lines" ]]; do
+		printf '  : # line %d\n' "$i" >>"$file"
+		i=$((i + 1))
+	done
+	printf '}\n' >>"$file"
+	return 0
+}
+
+make_deep_nesting() {
+	local file="$1"
+	local depth="$2"
+	local i=0
+	local indent=""
+
+	printf '#!/usr/bin/env bash\n' >"$file"
+	while [[ "$i" -lt "$depth" ]]; do
+		printf '%sif true; then\n' "$indent" >>"$file"
+		indent="${indent}  "
+		i=$((i + 1))
+	done
+	printf '%s:\n' "$indent" >>"$file"
+	while [[ "$i" -gt 0 ]]; do
+		i=$((i - 1))
+		indent="${indent#  }"
+		printf '%sfi\n' "$indent" >>"$file"
+	done
+	return 0
+}
+
+source_linter_analysis() {
+	SCRIPT_DIR="${REPO_ROOT}/.agents/scripts"
+	MAX_FUNCTION_LENGTH_WARN=50
+	MAX_FUNCTION_LENGTH_BLOCK=100
+	MAX_FUNCTION_LENGTH_VIOLATIONS=1
+	MAX_NESTING_DEPTH_WARN=5
+	MAX_NESTING_DEPTH_BLOCK=8
+	MAX_NESTING_VIOLATIONS=1
+	MAX_FILE_LINES_WARN=800
+	MAX_FILE_LINES_BLOCK=1500
+	# shellcheck source=../linters-local-analysis.sh
+	source "${REPO_ROOT}/.agents/scripts/linters-local-analysis.sh"
+	return 0
+}
+
+mark_origin_main() {
+	git -C "$TEST_ROOT" add .
+	git -C "$TEST_ROOT" commit -q -m "baseline"
+	git -C "$TEST_ROOT" branch -M main
+	git -C "$TEST_ROOT" update-ref refs/remotes/origin/main HEAD
+	return 0
+}
+
+test_historical_function_debt_is_advisory() {
+	setup_repo
+	printf '#!/usr/bin/env bash\n' >"${TEST_ROOT}/a.sh"
+	make_sh_function "${TEST_ROOT}/a.sh" "big_one" 105
+	make_sh_function "${TEST_ROOT}/a.sh" "big_two" 105
+	mark_origin_main
+	source_linter_analysis
+	(
+		cd "$TEST_ROOT" || exit 1
+		ALL_SH_FILES=(a.sh)
+		check_function_complexity >/tmp/linters-local-function-advisory.out 2>&1
+	)
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "historical function debt is advisory" 0
+	else
+		print_result "historical function debt is advisory" 1 "got exit $rc"
+	fi
+	teardown
+	return 0
+}
+
+test_changed_function_regression_blocks() {
+	setup_repo
+	printf '#!/usr/bin/env bash\n' >"${TEST_ROOT}/a.sh"
+	make_sh_function "${TEST_ROOT}/a.sh" "small" 10
+	mark_origin_main
+	make_sh_function "${TEST_ROOT}/a.sh" "new_big" 105
+	source_linter_analysis
+	local rc=0
+	(
+		cd "$TEST_ROOT" || exit 1
+		ALL_SH_FILES=(a.sh)
+		check_function_complexity >/tmp/linters-local-function-regression.out 2>&1
+	) || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		print_result "changed function complexity regression blocks" 0
+	else
+		print_result "changed function complexity regression blocks" 1 "got exit $rc"
+	fi
+	teardown
+	return 0
+}
+
+test_historical_nesting_debt_is_advisory() {
+	setup_repo
+	make_deep_nesting "${TEST_ROOT}/a.sh" 9
+	cp "${TEST_ROOT}/a.sh" "${TEST_ROOT}/b.sh"
+	mark_origin_main
+	source_linter_analysis
+	(
+		cd "$TEST_ROOT" || exit 1
+		ALL_SH_FILES=(a.sh b.sh)
+		check_nesting_depth >/tmp/linters-local-nesting-advisory.out 2>&1
+	)
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "historical nesting debt is advisory" 0
+	else
+		print_result "historical nesting debt is advisory" 1 "got exit $rc"
+	fi
+	teardown
+	return 0
+}
+
+test_changed_nesting_regression_blocks() {
+	setup_repo
+	printf '#!/usr/bin/env bash\n:\n' >"${TEST_ROOT}/a.sh"
+	mark_origin_main
+	make_deep_nesting "${TEST_ROOT}/a.sh" 9
+	source_linter_analysis
+	local rc=0
+	(
+		cd "$TEST_ROOT" || exit 1
+		ALL_SH_FILES=(a.sh)
+		check_nesting_depth >/tmp/linters-local-nesting-regression.out 2>&1
+	) || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		print_result "changed nesting-depth regression blocks" 0
+	else
+		print_result "changed nesting-depth regression blocks" 1 "got exit $rc"
+	fi
+	teardown
+	return 0
+}
+
+main() {
+	test_historical_function_debt_is_advisory
+	test_changed_function_regression_blocks
+	test_historical_nesting_debt_is_advisory
+	test_changed_nesting_regression_blocks
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Treat repo-wide historical function-complexity and nesting-depth debt as advisory unless changed shell files introduce new blocking regressions.
- Classify pulse canary timeout/interruption exits (`124`/`143`) separately from source-code canary regressions and seed the sandbox config path.
- Add focused regression coverage for historical-debt advisory behavior and changed-file regression blocking.

## Verification
- `bash .agents/scripts/tests/test-linters-local-complexity-gates.sh`
- `shellcheck .agents/scripts/linters-local-analysis.sh .agents/scripts/tests/test-linters-local-complexity-gates.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh`
- `.agents/scripts/linters-local.sh`

Resolves #23303
