### PR TITLE
fix: keep Tabby profiles on direct split launch

### DIFF
--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -15,19 +15,28 @@ initialize` before the TUI starts.
 Do not use `TABBY_AUTORUN=opencode` for generated profiles. It depends on a
 `.zshrc` startup hook and can fail silently, leaving users in a plain shell.
 
-The safe generated shape stores the full launch command in Tabby's command
-field:
+Do not put `/bin/zsh -l -c 'opencode; exec zsh'` in Tabby's `command` field.
+Tabby expects `command` to be the executable path and shell flags to be separate
+`args`; using the whole command string can make profile launches fail.
+
+The safe generated shape is:
 
 ```yaml
-command: /bin/zsh -l -c 'opencode; exec zsh'
-args: []
+command: /bin/zsh
+args:
+  - '-l'
+  - '-c'
+  - 'opencode; exec zsh'
 env: {}
 ```
 
 For manual one-off profiles that should run OpenCode and then leave a shell open,
-use the same command-field value instead of mixing `-i` and `-c`:
+use the same non-interactive login command instead of mixing `-i` and `-c`:
 
 ```yaml
-command: /bin/zsh -l -c 'opencode; exec zsh'
-args: []
+command: /bin/zsh
+args:
+  - '-l'
+  - '-c'
+  - 'opencode; exec zsh'
 ```

--- a/.agents/scripts/setup/modules/post-setup.sh
+++ b/.agents/scripts/setup/modules/post-setup.sh
@@ -74,6 +74,7 @@ setup_auto_update() {
 			echo "Auto-update keeps aidevops current by checking every 10 minutes."
 			echo "Safe to run while AI sessions are active."
 			echo ""
+			local enable_auto=""
 			setup_prompt enable_auto "Enable auto-update? [Y/n]: " "Y"
 			if [[ "$enable_auto" =~ ^[Yy]?$ ]]; then
 				bash "$auto_update_script" enable
@@ -194,7 +195,7 @@ print_final_instructions() {
 
 # Setup Tabby terminal profiles from repos.json.
 # Creates a profile per registered repo with colour-matched themes and
-# the TABBY_AUTORUN hook for OpenCode TUI compatibility.
+# direct split-arg OpenCode launch settings.
 # Skipped if Tabby is not installed.
 setup_tabby() {
 	local tabby_helper="$HOME/.aidevops/agents/scripts/tabby-helper.sh"
@@ -223,11 +224,6 @@ setup_tabby() {
 	# After macOS updates, Tabby can fall back to bash when this is unset.
 	bash "$tabby_helper" fix-shell || true
 
-	# Install zshrc hook (idempotent)
-	if ! bash "$tabby_helper" zshrc; then
-		print_warning "Failed to install Tabby zshrc hook — run manually: aidevops tabby zshrc"
-	fi
-
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
 		# Non-interactive: sync silently, warn on failure
 		if ! bash "$tabby_helper" sync; then
@@ -240,6 +236,7 @@ setup_tabby() {
 	echo ""
 	bash "$tabby_helper" status || true
 	echo ""
+	local sync_tabby=""
 	setup_prompt sync_tabby "Sync Tabby profiles from repos.json? [Y/n]: " "Y"
 	if [[ "$sync_tabby" =~ ^[Yy]?$ ]]; then
 		bash "$tabby_helper" sync
@@ -288,6 +285,7 @@ setup_onboarding_prompt() {
 	echo "  - Get personalized recommendations based on your work"
 	echo "  - Set up API keys and credentials interactively"
 	echo ""
+	local launch_onboarding=""
 	setup_prompt launch_onboarding "Launch ${_onb_name} with /onboarding now? [Y/n]: " "Y"
 	if [[ "$launch_onboarding" =~ ^[Yy]?$ ]]; then
 		echo ""

--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -12,7 +12,7 @@
 # Usage:
 #   tabby-helper.sh sync          # Sync profiles from repos.json (default)
 #   tabby-helper.sh status        # Show current profile status
-#   tabby-helper.sh zshrc         # Install TABBY_AUTORUN hook in .zshrc
+#   tabby-helper.sh zshrc         # Deprecated no-op (TABBY_AUTORUN is unused)
 #   tabby-helper.sh fix-shell     # Ensure default local profile uses /bin/zsh (macOS)
 #   tabby-helper.sh help          # Show usage
 #
@@ -105,34 +105,7 @@ cmd_status() {
 }
 
 cmd_zshrc() {
-	local zshrc="${HOME}/.zshrc"
-	local marker="# Tabby profile autorun"
-
-	if [[ ! -f "$zshrc" ]]; then
-		_warn "No .zshrc found — creating one"
-		touch "$zshrc"
-	fi
-
-	if grep -qF "$marker" "$zshrc" 2>/dev/null; then
-		_success "TABBY_AUTORUN hook already in .zshrc"
-		return 0
-	fi
-
-	cat >>"$zshrc" <<'ZSHRC_BLOCK'
-
-# Tabby profile autorun - launches command after shell is fully interactive
-# This allows TUI apps (opencode) to work with Tabby's custom colour schemes
-_tabby_autorun() {
-  if [[ -n "${TABBY_AUTORUN:-}" ]]; then
-    local cmd="$TABBY_AUTORUN"
-    unset TABBY_AUTORUN
-    eval "$cmd"
-  fi
-}
-_tabby_autorun
-ZSHRC_BLOCK
-
-	_success "Added TABBY_AUTORUN hook to .zshrc"
+	_info "TABBY_AUTORUN is deprecated; Tabby profiles use direct split args"
 	return 0
 }
 
@@ -357,7 +330,7 @@ cmd_help() {
 	echo "Usage:"
 	echo "  tabby-helper.sh sync       Sync profiles from repos.json (create new, skip existing)"
 	echo "  tabby-helper.sh status     Show profile status (which repos have profiles)"
-	echo "  tabby-helper.sh zshrc      Install TABBY_AUTORUN hook in .zshrc"
+	echo "  tabby-helper.sh zshrc      Deprecated no-op (TABBY_AUTORUN is unused)"
 	echo "  tabby-helper.sh fix-shell  Ensure default local profile uses /bin/zsh (macOS)"
 	echo "  tabby-helper.sh help       Show this help"
 	echo ""

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -33,7 +33,7 @@ from tabby_yaml_helpers import (
 )
 
 
-TABBY_OPENCODE_COMMAND = "/bin/zsh -l -c 'opencode; exec zsh'"
+TABBY_COMMAND_FIELD_OPENCODE = "/bin/zsh -l -c 'opencode; exec zsh'"
 
 
 def is_linked_worktree(repo_path: str) -> bool:
@@ -122,8 +122,11 @@ def build_profile_yaml(
     profile = f"""  - name: {name}
     icon: fas fa-terminal
     options:
-      command: {TABBY_OPENCODE_COMMAND}
-      args: []
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-c'
+        - opencode; exec zsh
       env: {{}}
       cwd: {cwd}
     terminalColorScheme:
@@ -178,25 +181,69 @@ def _is_broken_opencode_args(args: list[str]) -> bool:
     return args == ["-l", "-i", "-c", "opencode"]
 
 
-def _is_split_direct_opencode_args(args: list[str]) -> bool:
-    """Return True for split args that launch OpenCode directly."""
-    return args == ["-l", "-c", "opencode; exec zsh"]
+def _is_command_field_opencode(value: str) -> bool:
+    """Return True for the Tabby command-field shape that Tabby cannot exec."""
+    value = value.strip()
+    return (
+        value == TABBY_COMMAND_FIELD_OPENCODE
+        or _normalise_yaml_scalar(value) == TABBY_COMMAND_FIELD_OPENCODE
+    )
 
 
-def _append_opencode_command_field(
-    repaired: list[str], args_indent: str, include_env: bool
-) -> None:
-    """Append/replace the Tabby command-field OpenCode launch shape."""
-    plain_command = f"{args_indent}command: /bin/zsh"
-    full_command = f"{args_indent}command: {TABBY_OPENCODE_COMMAND}"
-    if repaired and repaired[-1] == plain_command:
-        repaired[-1] = full_command
-    else:
-        repaired.append(full_command)
-    repaired.append(f"{args_indent}args: []")
-    has_prior_empty_env = any(line == f"{args_indent}env: {{}}" for line in repaired[-6:])
-    if include_env and not has_prior_empty_env:
-        repaired.append(f"{args_indent}env: {{}}")
+def _direct_opencode_args_block(args_indent: str, include_env: bool) -> list[str]:
+    """Build the direct Tabby args/env block for OpenCode profiles."""
+    child_indent = f"{args_indent}  "
+    block = [
+        f"{args_indent}args:",
+        f"{child_indent}- '-l'",
+        f"{child_indent}- '-c'",
+        f"{child_indent}- opencode; exec zsh",
+    ]
+    if include_env:
+        block.append(f"{args_indent}env: {{}}")
+    return block
+
+
+def _line_indent_len(line: str) -> int:
+    """Return the number of leading spaces in ``line``."""
+    return len(line) - len(line.lstrip(" "))
+
+
+def _option_key_match(line: str) -> tuple[str, str] | None:
+    """Return ``(indent, key)`` for option-level keys we manage."""
+    match = re.match(r"^(?P<indent>\s*)(?P<key>args|command|env):(?:\s|$)", line)
+    if not match:
+        return None
+    return match.group("indent"), match.group("key")
+
+
+def _line_is_option_key(line: str, indent: str, key: str) -> bool:
+    """Return True if ``line`` is ``key`` at ``indent``."""
+    return bool(re.match(rf"^{re.escape(indent)}{re.escape(key)}:(?:\s|$)", line))
+
+
+def _has_prior_option_key(repaired: list[str], indent: str, key: str) -> bool:
+    """Return True if ``key`` already appeared in the current options block."""
+    indent_len = len(indent)
+    for previous in reversed(repaired):
+        if previous.strip() == "options:":
+            return False
+        if previous.strip() and _line_indent_len(previous) < indent_len:
+            return False
+        if _line_is_option_key(previous, indent, key):
+            return True
+    return False
+
+
+def _block_end(lines: list[str], start: int, base_indent_len: int) -> int:
+    """Return the first line after the scalar/list/mapping block at ``start``."""
+    block_end = start + 1
+    while block_end < len(lines):
+        next_line = lines[block_end]
+        if next_line.strip() and _line_indent_len(next_line) <= base_indent_len:
+            break
+        block_end += 1
+    return block_end
 
 
 def _tabby_autorun_env_end(lines: list[str], start: int, base_indent_len: int) -> int | None:
@@ -236,16 +283,60 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
     which can trigger Powerlevel10k/gitstatus job-control errors before the TUI
     starts. The former ``TABBY_AUTORUN`` workaround can also fail silently when
     shell startup does not run the hook, leaving users in a plain terminal. The
-    stable shape stores the full non-interactive login launch in Tabby's command
-    field and leaves zsh open after OpenCode exits.
+    stable shape uses a non-interactive login command and leaves zsh open after
+    OpenCode exits.
     """
     lines = config_text.split("\n")
     repaired: list[str] = []
     repairs = 0
+    pending_command_field_indent: str | None = None
     i = 0
 
     while i < len(lines):
         line = lines[i]
+
+        command_match = re.match(r"^(?P<indent>\s*)command:\s*(?P<value>.*)$", line)
+        if command_match and _is_command_field_opencode(command_match.group("value")):
+            command_indent = command_match.group("indent")
+            if _has_prior_option_key(repaired, command_indent, "command"):
+                i = _block_end(lines, i, len(command_indent))
+                repairs += 1
+                continue
+            repaired.append(f"{command_indent}command: /bin/zsh")
+            pending_command_field_indent = command_indent
+            repairs += 1
+            i += 1
+            continue
+
+        option_key = _option_key_match(line)
+        if option_key is not None:
+            option_indent, key = option_key
+            if key != "args" or pending_command_field_indent != option_indent:
+                if _has_prior_option_key(repaired, option_indent, key):
+                    i = _block_end(lines, i, len(option_indent))
+                    repairs += 1
+                    continue
+
+        if pending_command_field_indent is not None:
+            pending_indent_len = len(pending_command_field_indent)
+            if (
+                line.strip()
+                and _line_indent_len(line) <= pending_indent_len
+                and not _line_is_option_key(line, pending_command_field_indent, "args")
+            ):
+                include_env = not _line_is_option_key(
+                    line, pending_command_field_indent, "env"
+                ) and not _has_prior_option_key(
+                    repaired, pending_command_field_indent, "env"
+                )
+                repaired.extend(
+                    _direct_opencode_args_block(
+                        pending_command_field_indent,
+                        include_env=include_env,
+                    )
+                )
+                pending_command_field_indent = None
+
         match = re.match(r"^(?P<indent>\s*)args:\s*(?P<value>.*)$", line)
         if not match:
             repaired.append(line)
@@ -256,13 +347,31 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
         args_indent_len = len(args_indent)
         inline_args = _parse_inline_args(match.group("value"))
         if inline_args is not None:
-            if _is_broken_opencode_args(inline_args) or _is_split_direct_opencode_args(inline_args):
-                _append_opencode_command_field(repaired, args_indent, include_env=True)
+            if pending_command_field_indent == args_indent:
+                next_line = lines[i + 1] if i + 1 < len(lines) else ""
+                include_env = not _line_is_option_key(
+                    next_line, args_indent, "env"
+                ) and not _has_prior_option_key(repaired, args_indent, "env")
+                repaired.extend(
+                    _direct_opencode_args_block(args_indent, include_env=include_env)
+                )
+                pending_command_field_indent = None
+            elif _is_broken_opencode_args(inline_args):
+                next_line = lines[i + 1] if i + 1 < len(lines) else ""
+                include_env = not _line_is_option_key(
+                    next_line, args_indent, "env"
+                ) and not _has_prior_option_key(repaired, args_indent, "env")
+                repaired.extend(
+                    _direct_opencode_args_block(args_indent, include_env=include_env)
+                )
                 repairs += 1
             elif inline_args == ["-l", "-i"]:
                 env_end = _tabby_autorun_env_end(lines, i + 1, args_indent_len)
                 if env_end is not None:
-                    _append_opencode_command_field(repaired, args_indent, include_env=True)
+                    include_env = not _has_prior_option_key(repaired, args_indent, "env")
+                    repaired.extend(
+                        _direct_opencode_args_block(args_indent, include_env=include_env)
+                    )
                     repairs += 1
                     i = env_end
                     continue
@@ -272,25 +381,28 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
             i += 1
             continue
 
-        block_end = i + 1
-        while block_end < len(lines):
-            next_line = lines[block_end]
-            if next_line.strip():
-                next_indent_len = len(next_line) - len(next_line.lstrip(" "))
-                if next_indent_len <= args_indent_len:
-                    break
-            block_end += 1
+        block_end = _block_end(lines, i, args_indent_len)
 
         block_args = _parse_block_args(lines[i + 1 : block_end])
-        if _is_broken_opencode_args(block_args) or _is_split_direct_opencode_args(block_args):
+        if pending_command_field_indent == args_indent:
             next_line = lines[block_end] if block_end < len(lines) else ""
-            has_env = bool(re.match(rf"^{re.escape(args_indent)}env:\s*$", next_line))
-            _append_opencode_command_field(repaired, args_indent, include_env=not has_env)
+            include_env = not _line_is_option_key(
+                next_line, args_indent, "env"
+            ) and not _has_prior_option_key(repaired, args_indent, "env")
+            repaired.extend(_direct_opencode_args_block(args_indent, include_env=include_env))
+            pending_command_field_indent = None
+        elif _is_broken_opencode_args(block_args):
+            next_line = lines[block_end] if block_end < len(lines) else ""
+            include_env = not _line_is_option_key(
+                next_line, args_indent, "env"
+            ) and not _has_prior_option_key(repaired, args_indent, "env")
+            repaired.extend(_direct_opencode_args_block(args_indent, include_env=include_env))
             repairs += 1
         elif block_args == ["-l", "-i"]:
             env_end = _tabby_autorun_env_end(lines, block_end, args_indent_len)
             if env_end is not None:
-                _append_opencode_command_field(repaired, args_indent, include_env=True)
+                include_env = not _has_prior_option_key(repaired, args_indent, "env")
+                repaired.extend(_direct_opencode_args_block(args_indent, include_env=include_env))
                 repairs += 1
                 i = env_end
                 continue
@@ -298,6 +410,15 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
         else:
             repaired.extend(lines[i:block_end])
         i = block_end
+
+    if pending_command_field_indent is not None:
+        include_env = not _has_prior_option_key(repaired, pending_command_field_indent, "env")
+        repaired.extend(
+            _direct_opencode_args_block(
+                pending_command_field_indent,
+                include_env=include_env,
+            )
+        )
 
     return "\n".join(repaired), repairs
 

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -78,8 +78,8 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"- '-i'\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
-assert 'args: []' in repaired, repaired
+assert \"- '-l'\" in repaired and \"- '-c'\" in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
 assert 'env: {}' in repaired, repaired
 "
 
@@ -90,18 +90,17 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"args: ['-l', '-i', '-c', opencode]\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
-assert 'args: []' in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
 "
 
-_info "Test 3: generated profiles keep command-field OpenCode launch shape"
-run_python_test "generated profile uses command-field launch shape" "${load_module_code}
+_info "Test 3: generated profiles keep direct OpenCode launch shape"
+run_python_test "generated profile uses direct launch shape" "${load_module_code}
 scheme = {'name': 'Test', 'foreground': '#fff', 'background': '#000', 'cursor': '#fff', 'colors': ['#000', '#fff']}
 profile = mod.build_profile_yaml('aidevops', '/tmp/aidevops', '#123456', scheme, 'group-1')
 assert \"- '-i'\" not in profile, profile
 assert 'TABBY_AUTORUN: opencode' not in profile, profile
-assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in profile, profile
-assert 'args: []' in profile, profile
+assert \"- '-l'\" in profile and \"- '-c'\" in profile, profile
+assert 'opencode; exec zsh' in profile, profile
 assert 'env: {}' in profile, profile
 "
 
@@ -122,51 +121,67 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"- '-i'\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
-assert 'args: []' in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
 assert 'env: {}' in repaired, repaired
 "
 
-_info "Test 5: split direct profiles are repaired to command field"
-run_python_test "split direct profile repaired" "${load_module_code}
+_info "Test 5: command-field profiles are repaired"
+run_python_test "command-field profile repaired" "${load_module_code}
 config = '''profiles:
   - name: aidevops
     options:
-      command: /bin/zsh
-      args:
-        - '-l'
-        - '-c'
-        - opencode; exec zsh
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+      args: []
       env: {}
       cwd: /tmp/aidevops
 '''
 repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
-assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
-assert 'args: []' in repaired, repaired
-assert \"- '-c'\" not in repaired, repaired
-"
-
-_info "Test 6: split direct profiles with existing env do not duplicate env"
-run_python_test "split direct profile preserves existing env" "${load_module_code}
-config = '''profiles:
-  - name: aidevops
-    options:
-      env: {}
-      cwd: /tmp/aidevops
-      command: /bin/zsh
-      args:
-        - '-l'
-        - '-c'
-        - opencode; exec zsh
-'''
-repaired, count = mod.repair_broken_opencode_launch_profiles(config)
-assert count == 1, count
-assert \"command: /bin/zsh -l -c 'opencode; exec zsh'\" in repaired, repaired
+assert 'command: /bin/zsh -l -c \'opencode; exec zsh\'' not in repaired, repaired
+assert 'args: []' not in repaired, repaired
+assert \"- '-l'\" in repaired and \"- '-c'\" in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
 assert repaired.count('      env: {}') == 1, repaired
 "
 
-_info "Test 7: sync repairs existing profiles even when no new profile is needed"
+_info "Test 6: command-field duplicate env profiles are repaired"
+run_python_test "command-field duplicate env repaired" "${load_module_code}
+config = '''profiles:
+  - name: aidevops
+    options:
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+      args: []
+      env: {}
+      env: {}
+      cwd: /tmp/aidevops
+'''
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count >= 1, count
+assert 'command: /bin/zsh -l -c \'opencode; exec zsh\'' not in repaired, repaired
+assert repaired.count('      env: {}') == 1, repaired
+"
+
+_info "Test 7: split direct profiles are already valid"
+run_python_test "split direct profile remains unchanged" "${load_module_code}
+config = '''profiles:
+  - name: aidevops
+    options:
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-c'
+        - opencode; exec zsh
+      env: {}
+      cwd: /tmp/aidevops
+'''
+repaired, count = mod.repair_broken_opencode_launch_profiles(config)
+assert count == 0, count
+assert repaired.count('      env: {}') == 1, repaired
+assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
+assert 'opencode; exec zsh' in repaired, repaired
+"
+
+_info "Test 8: sync repairs existing profiles even when no new profile is needed"
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "${tmp_root}"' EXIT
 repo_path="${tmp_root}/aidevops"
@@ -199,7 +214,7 @@ with open(tabby_config, "w") as handle:
 """)
 PY
 sync_output=$(PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${tabby_config}")
-if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "command: /bin/zsh -l -c 'opencode; exec zsh'" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
+if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "opencode; exec zsh" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
 	_pass "sync repairs existing broken profile"
 else
 	_fail "sync did not repair existing profile: ${sync_output}"


### PR DESCRIPTION
## Summary
- Keep generated Tabby OpenCode profiles on the working direct split-args launch shape.
- Repair prior command-field and `TABBY_AUTORUN` profile shapes without duplicating `env` keys.
- Stop setup from installing the deprecated Tabby autorun zshrc hook.

## Verification
- `bash .agents/scripts/tests/test-tabby-profile-sync.sh`
- `python3 -m py_compile .agents/scripts/tabby-profile-sync.py`
- `shellcheck .agents/scripts/tabby-helper.sh .agents/scripts/tests/test-tabby-profile-sync.sh .agents/scripts/setup/modules/post-setup.sh`
- Patched sync tested against a copy of current Tabby config: no duplicate keys, 0 `TABBY_AUTORUN`, 40 direct split-args profiles, 0 command-field profiles.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.24 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 45m and 60,654 tokens on this with the user in an interactive session.


For #23309
