### PR TITLE
GH#23311: harden body-file auto-signature test

### DIFF
--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -298,10 +298,9 @@ assert_not_contains "original file did not get signature footer" "<!-- aidevops:
 assert_contains "original file still has original content" "Body from file content" "$file_content"
 captured=$(<"$GH_STUB_ARGS_FILE")
 assert_contains "gh received --body-file flag" "--body-file" "$captured"
-assert_not_contains "gh did not receive original body-file path" "$bf" "$captured"
 captured_body_file=""
 while IFS= read -r arg; do
-	if [[ -n "$captured_body_file" ]]; then
+	if [[ "$captured_body_file" == "pending" ]]; then
 		captured_body_file="$arg"
 		break
 	fi
@@ -309,9 +308,20 @@ while IFS= read -r arg; do
 		captured_body_file="pending"
 	fi
 done <<<"$captured"
-captured_file_content=$(<"$captured_body_file")
-assert_contains "gh received temp body-file with signature" "<!-- aidevops:sig -->" "$captured_file_content"
-assert_contains "gh received temp body-file with original content" "Body from file content" "$captured_file_content"
+
+if [[ -z "$captured_body_file" || "$captured_body_file" == "pending" ]]; then
+	echo "  FAIL: gh did not receive --body-file flag or value"
+	FAIL=$((FAIL + 1))
+elif [[ "$captured_body_file" == "$bf" ]]; then
+	echo "  FAIL: gh received original body-file path instead of temp copy"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: gh received a different body-file path"
+	PASS=$((PASS + 1))
+	captured_file_content=$(<"$captured_body_file")
+	assert_contains "gh received temp body-file with signature" "<!-- aidevops:sig -->" "$captured_file_content"
+	assert_contains "gh received temp body-file with original content" "Body from file content" "$captured_file_content"
+fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 12 (t2393): exit code from gh is propagated through the wrapper


### PR DESCRIPTION
## Summary

Updated the gh wrapper auto-signature test to compare the parsed --body-file argument directly instead of scanning all captured gh arguments for the original path.

## Files Changed

.agents/scripts/tests/test-gh-wrapper-auto-sig.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh; shellcheck .agents/scripts/tests/test-gh-wrapper-auto-sig.sh

Resolves #23311


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 38,699 tokens on this as a headless worker.