### PR TITLE
GH#23313: Clean up signed GH body-file temp copies

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -174,6 +174,8 @@ _gh_ci_prepare_todo_labels() {
 }
 
 gh_create_issue() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	gh_record_call graphql gh_create_issue 2>/dev/null || true
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
@@ -495,6 +497,8 @@ _gh_create_pr_should_default_draft() {
 }
 
 gh_create_pr() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	gh_record_call graphql gh_create_pr 2>/dev/null || true
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
@@ -578,6 +582,8 @@ _gh_recover_pr_if_exists() {
 # <!-- aidevops:sig --> marker, so callers that build their own footer
 # are not double-signed.
 gh_issue_comment() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	gh_record_call graphql gh_issue_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
@@ -592,6 +598,8 @@ gh_issue_comment() {
 }
 
 gh_pr_comment() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	gh_record_call graphql gh_pr_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -363,15 +363,19 @@ _gh_wrapper_auto_sig() {
 	# signed temp copy and point argv at it so callers using --body-file get the
 	# same footer behaviour as --body without surprising filesystem side effects.
 	if [[ $body_file_idx -ge 0 && -n "$body_file_val" && -f "$body_file_val" ]]; then
-		local file_content
-		file_content=$(<"$body_file_val") || return 0
-		[[ "$file_content" == *"<!-- aidevops:sig -->"* ]] && return 0
+		if grep -q '<!-- aidevops:sig -->' "$body_file_val" 2>/dev/null; then
+			return 0
+		fi
 		local sig_footer
-		sig_footer=$("$sig_helper" footer --body "$file_content" 2>/dev/null || echo "")
+		sig_footer=$("$sig_helper" footer 2>/dev/null || echo "")
 		[[ -z "$sig_footer" ]] && return 0
 		local signed_body_file
 		signed_body_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-gh-body.XXXXXX") || return 0
-		printf '%s%s' "$file_content" "$sig_footer" >"$signed_body_file" || return 0
+		push_cleanup "rm -f \"$signed_body_file\""
+		{
+			cat "$body_file_val"
+			printf '%s' "$sig_footer"
+		} >"$signed_body_file" || return 0
 		if [[ "$bf_is_eq" -eq 1 ]]; then
 			_GH_WRAPPER_SIG_MODIFIED_ARGS[body_file_idx]="--body-file=${signed_body_file}"
 		else

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -250,12 +250,26 @@ cat >"${STUB_DIR}/gh" <<'STUB'
 #!/usr/bin/env bash
 # Record "argv" to a captured-args file for assertions.
 printf '%s\n' "$@" >"${GH_STUB_ARGS_FILE:-/dev/null}"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--body-file)
+		if [[ -n "${2:-}" && -f "$2" && -n "${GH_STUB_BODY_FILE_CONTENT:-}" ]]; then
+			cat "$2" >"$GH_STUB_BODY_FILE_CONTENT"
+		fi
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
 # Simulate success.
 exit 0
 STUB
 chmod +x "${STUB_DIR}/gh"
 export PATH="${STUB_DIR}:$PATH"
 export GH_STUB_ARGS_FILE="${TMPDIR_TEST}/gh-args.txt"
+export GH_STUB_BODY_FILE_CONTENT="${TMPDIR_TEST}/gh-body-file-content.txt"
 
 : >"$GH_STUB_ARGS_FILE"
 gh_issue_comment 19951 --repo "owner/repo" --body "Issue comment body"
@@ -292,6 +306,7 @@ echo "Test 11 (t2393): gh_issue_comment --body-file signs temp copy"
 bf="${TMPDIR_TEST}/issue-body.md"
 printf 'Body from file content' >"$bf"
 : >"$GH_STUB_ARGS_FILE"
+: >"$GH_STUB_BODY_FILE_CONTENT"
 gh_issue_comment 19951 --repo "owner/repo" --body-file "$bf"
 file_content=$(<"$bf")
 assert_not_contains "original file did not get signature footer" "<!-- aidevops:sig -->" "$file_content"
@@ -309,7 +324,14 @@ while IFS= read -r arg; do
 		captured_body_file="pending"
 	fi
 done <<<"$captured"
-captured_file_content=$(<"$captured_body_file")
+	if [[ -e "$captured_body_file" ]]; then
+		FAIL=$((FAIL + 1))
+		echo "  FAIL: temp body-file cleaned up after gh returned"
+	else
+		PASS=$((PASS + 1))
+		echo "  PASS: temp body-file cleaned up after gh returned"
+	fi
+captured_file_content=$(<"$GH_STUB_BODY_FILE_CONTENT")
 assert_contains "gh received temp body-file with signature" "<!-- aidevops:sig -->" "$captured_file_content"
 assert_contains "gh received temp body-file with original content" "Body from file content" "$captured_file_content"
 


### PR DESCRIPTION
## Summary

Preserved body-file content by streaming it into signed temporary copies and registered cleanup around GH wrapper calls so temporary files are removed after gh consumes them.

## Files Changed

.agents/scripts/shared-gh-wrappers-create.sh,.agents/scripts/shared-gh-wrappers-session.sh,.agents/scripts/tests/test-gh-wrapper-auto-sig.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh; shellcheck .agents/scripts/shared-gh-wrappers-session.sh .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-gh-wrapper-auto-sig.sh

Resolves #23313


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 2m and 64,868 tokens on this as a headless worker.