### PR TITLE
GH#23312: normalize function complexity names

### DIFF
--- a/.agents/scripts/linters-local-analysis.sh
+++ b/.agents/scripts/linters-local-analysis.sh
@@ -414,7 +414,7 @@ _scan_function_complexity_file() {
 	awk -v file="$rel_file" -v block="$MAX_FUNCTION_LENGTH_BLOCK" '
 		/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ {
 			fname = $1
-			sub(/\(\)/, "", fname)
+			sub(/\(\).*/, "", fname)
 			start = NR
 			next
 		}
@@ -434,7 +434,7 @@ _scan_function_complexity_git_blob() {
 	git show "${base_ref}:${rel_file}" 2>/dev/null | awk -v file="$rel_file" -v block="$MAX_FUNCTION_LENGTH_BLOCK" '
 		/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ {
 			fname = $1
-			sub(/\(\)/, "", fname)
+			sub(/\(\).*/, "", fname)
 			start = NR
 			next
 		}


### PR DESCRIPTION
## Summary

Updated the function complexity scanners to strip everything after the function parentheses so name(){ formatting does not produce name{ false positives.

## Files Changed

.agents/scripts/linters-local-analysis.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/linters-local-analysis.sh; shellcheck .agents/scripts/linters-local-analysis.sh; bash .agents/scripts/linters-local-analysis.sh

Resolves #23312


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 45,040 tokens on this as a headless worker.