### PR TITLE
GH#23311: harden body-file auto-signature test

### DIFF
--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -313,10 +313,9 @@ assert_not_contains "original file did not get signature footer" "<!-- aidevops:
 assert_contains "original file still has original content" "Body from file content" "$file_content"
 captured=$(<"$GH_STUB_ARGS_FILE")
 assert_contains "gh received --body-file flag" "--body-file" "$captured"
-assert_not_contains "gh did not receive original body-file path" "$bf" "$captured"
 captured_body_file=""
 while IFS= read -r arg; do
-	if [[ -n "$captured_body_file" ]]; then
+	if [[ "$captured_body_file" == "pending" ]]; then
 		captured_body_file="$arg"
 		break
 	fi
@@ -324,6 +323,16 @@ while IFS= read -r arg; do
 		captured_body_file="pending"
 	fi
 done <<<"$captured"
+
+if [[ -z "$captured_body_file" || "$captured_body_file" == "pending" ]]; then
+	echo "  FAIL: gh did not receive --body-file flag or value"
+	FAIL=$((FAIL + 1))
+elif [[ "$captured_body_file" == "$bf" ]]; then
+	echo "  FAIL: gh received original body-file path instead of temp copy"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: gh received a different body-file path"
+	PASS=$((PASS + 1))
 	if [[ -e "$captured_body_file" ]]; then
 		FAIL=$((FAIL + 1))
 		echo "  FAIL: temp body-file cleaned up after gh returned"
@@ -331,9 +340,10 @@ done <<<"$captured"
 		PASS=$((PASS + 1))
 		echo "  PASS: temp body-file cleaned up after gh returned"
 	fi
-captured_file_content=$(<"$GH_STUB_BODY_FILE_CONTENT")
-assert_contains "gh received temp body-file with signature" "<!-- aidevops:sig -->" "$captured_file_content"
-assert_contains "gh received temp body-file with original content" "Body from file content" "$captured_file_content"
+	captured_file_content=$(<"$GH_STUB_BODY_FILE_CONTENT")
+	assert_contains "gh received temp body-file with signature" "<!-- aidevops:sig -->" "$captured_file_content"
+	assert_contains "gh received temp body-file with original content" "Body from file content" "$captured_file_content"
+fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 12 (t2393): exit code from gh is propagated through the wrapper


### PR DESCRIPTION
## Summary
- Hardened the auto-signature `--body-file` test by extracting the exact `--body-file` value passed to the gh stub before comparing it with the original path.
- Preserved current temp-file cleanup coverage and content verification through the stub-captured body-file payload.

## Testing
- `bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh` — 36 passed, 0 failed
- `shellcheck .agents/scripts/tests/test-gh-wrapper-auto-sig.sh` — clean

Resolves #23311

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 4m and 60,878 tokens on this as a headless worker.
