### PR TITLE
GH#23318: align quickfile MCP template paths

### DIFF
--- a/configs/mcp-templates/quickfile.json
+++ b/configs/mcp-templates/quickfile.json
@@ -14,14 +14,14 @@
     }
   },
 
-  "claude_code_command": "claude mcp add quickfile node /path/to/quickfile-mcp/dist/index.js",
+  "claude_code_command": "claude mcp add quickfile node /Users/YOU/Git/mcp/quickfile-mcp/dist/index.js",
 
   "claude_desktop": {
     "_file": "~/Library/Application Support/Claude/claude_desktop_config.json",
     "mcpServers": {
       "quickfile": {
         "command": "node",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"]
+        "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"]
       }
     }
   },
@@ -31,7 +31,7 @@
     "mcpServers": {
       "quickfile": {
         "command": "node",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"]
+        "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"]
       }
     }
   },
@@ -40,7 +40,7 @@
     "_method": "Custom Server UI",
     "quickfile": {
       "command": "node",
-      "args": ["/path/to/quickfile-mcp/dist/index.js"],
+      "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"],
       "env": {}
     }
   },
@@ -51,7 +51,7 @@
       "quickfile": {
         "type": "stdio",
         "command": "node",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"]
+        "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"]
       }
     },
     "inputs": []
@@ -63,7 +63,7 @@
       "quickfile": {
         "command": "node",
         "type": "stdio",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"],
+        "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"],
         "disabled": false,
         "alwaysAllow": ["quickfile_system_get_account", "quickfile_client_search", "quickfile_invoice_search"]
       }
@@ -75,7 +75,7 @@
     "mcpServers": {
       "quickfile": {
         "command": "node",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"],
+        "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"],
         "disabled": false,
         "autoApprove": ["quickfile_system_get_account"]
       }
@@ -87,10 +87,10 @@
     "mcpServers": {
       "quickfile": {
         "command": "node",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"]
+        "args": ["/Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"]
       }
     }
   },
 
-  "droid_command": "droid mcp add quickfile node /path/to/quickfile-mcp/dist/index.js"
+  "droid_command": "droid mcp add quickfile node /Users/YOU/Git/mcp/quickfile-mcp/dist/index.js"
 }


### PR DESCRIPTION
## Summary

Updated all QuickFile MCP template snippets to use the grouped ~/Git/mcp/quickfile-mcp repository path, matching the install command and opencode snippet.

## Files Changed

configs/mcp-templates/quickfile.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m json.tool configs/mcp-templates/quickfile.json; rg -n '/path/to/quickfile-mcp|Git/mcp/quickfile-mcp' configs/mcp-templates/quickfile.json

Resolves #23318


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 36,996 tokens on this as a headless worker.