### PR TITLE
GH#23321: fix: harden canonical guard default branch detection

### DIFF
--- a/.agents/hooks/canonical-on-main-guard.sh
+++ b/.agents/hooks/canonical-on-main-guard.sh
@@ -51,7 +51,7 @@ detect_default_branch() {
 		default_branch="master"
 	fi
 	if [[ -z "$default_branch" ]]; then
-		default_branch="main"
+		default_branch="HEAD"
 	fi
 	printf '%s' "$default_branch"
 	return 0
@@ -60,7 +60,7 @@ detect_default_branch() {
 restore_default_branch() {
 	local default_branch="$1"
 	local status_output=""
-	status_output=$(git status --porcelain 2>/dev/null) || status_output=""
+	status_output=$(git status --porcelain -uno 2>/dev/null) || status_output=""
 	if [[ -n "$status_output" ]]; then
 		printf 'Refusing automatic restore because the working tree is not clean.\n' >&2
 		printf 'Run: git status --short, then manually restore the canonical repo to %s.\n' "$default_branch" >&2

--- a/.agents/scripts/test-canonical-guard.sh
+++ b/.agents/scripts/test-canonical-guard.sh
@@ -16,7 +16,9 @@
 #   5. Canonical on main → exit 0, no stderr banner
 #   6. Canonical off main + repo NOT in repos.json → exit 0 (fail-open)
 #   7. Canonical off main + repo IN repos.json, interactive → restore main
-#   8. Canonical off main + repo IN repos.json, strict → restore main + exit 1
+#   8. Canonical off main + repo IN repos.json + untracked file → restore main
+#   9. Canonical off main + repo IN repos.json, strict → restore main + exit 1
+#   10. Worktree (non-canonical) → exit 0, no stderr banner
 #
 # Exit 0 = all tests pass, 1 = at least one failure.
 
@@ -209,7 +211,24 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Test 7: canonical off main + IN repos.json, strict → restore main + exit 1
+# Test 7: canonical off main + IN repos.json + untracked file → restore main
+# -----------------------------------------------------------------------------
+pushd "$REPO" >/dev/null || exit 1
+git checkout feature-branch --quiet
+printf 'scratch\n' >untracked-scratch.txt
+popd >/dev/null || exit 1
+_run_hook 1
+rc=$?
+current_after_untracked=$(git -C "$REPO" branch --show-current)
+rm -f "$REPO/untracked-scratch.txt"
+if [[ "$rc" -eq 0 ]] && [[ "$HOOK_STDERR" == *"canonical-on-main-guard"* ]] && [[ "$current_after_untracked" == "main" ]]; then
+	pass "canonical off main + untracked file: restored main"
+else
+	fail "untracked file: expected restore to main, got rc=$rc branch=$current_after_untracked"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 8: canonical off main + IN repos.json, strict → restore main + exit 1
 # -----------------------------------------------------------------------------
 pushd "$REPO" >/dev/null || exit 1
 git checkout feature-branch --quiet
@@ -224,7 +243,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Test 8: canonical off main + warn mode → no restore
+# Test 9: canonical off main + warn mode → no restore
 # -----------------------------------------------------------------------------
 pushd "$REPO" >/dev/null || exit 1
 git checkout feature-branch --quiet
@@ -239,7 +258,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Test 9: worktree (non-canonical) → no warning
+# Test 10: worktree (non-canonical) → no warning
 # -----------------------------------------------------------------------------
 # Create a worktree of the fake repo
 WORKTREE="${TMP}/fake-worktree"


### PR DESCRIPTION
## Summary

Updated the canonical-on-main guard to fall back through origin/HEAD, local main/master, then HEAD, and to ignore untracked files when deciding whether automatic restore is safe.

## Files Changed

.agents/hooks/canonical-on-main-guard.sh,.agents/scripts/test-canonical-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/test-canonical-guard.sh; shellcheck .agents/hooks/canonical-on-main-guard.sh .agents/scripts/test-canonical-guard.sh

Resolves #23321


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 87,667 tokens on this as a headless worker.