### PR TITLE
docs: harden onboarding video asset path guidance

### DIFF
--- a/.agents/tools/video/create-onboarding-video.md
+++ b/.agents/tools/video/create-onboarding-video.md
@@ -47,7 +47,7 @@ Ask a focused question when stills, browser access, feature intent, or branding 
 2. If `DESIGN.md` is absent, use `tools/design/design-md.md` to create or derive a lightweight design brief before composing visuals.
 3. Use browser automation only from authorised user-provided app URLs or local dev servers. Prefer `tools/browser/browser-automation.md` to choose Playwright, dev-browser, Chrome DevTools, or Stagehand.
 4. Capture assets at render-friendly dimensions. Prefer UI slices, DOM elements, and state screenshots over full-page images. Avoid `fullPage: true` unless explicitly needed for the deliverable.
-5. Store source stills under `public/<flow-or-screen>/<state>.png` and document the selector, viewport, state setup, and capture command in the project README or notes.
+5. Store source stills under `public/<flow-or-screen>/<state>.png`. Treat `<flow-or-screen>` and `<state>` as user-provided path components: sanitize directory and file names, then validate that the resolved real path stays inside `public/` before writing. This prevents path traversal vulnerabilities. Document the selector, viewport, state setup, and capture command in the project README or notes.
 
 ## Visual Direction
 


### PR DESCRIPTION
## Summary
- Require sanitized user-derived still path components in `.agents/tools/video/create-onboarding-video.md`.
- Require resolved real-path validation inside `public/` before writing generated stills.
- Add the explicit path traversal prevention rationale requested by review feedback.

## Testing
- `.agents/scripts/linters-local.sh` (passed)
- `git diff --check -- .agents/tools/video/create-onboarding-video.md` (passed)

Resolves #23322

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 6m and 39,521 tokens on this with the user in an interactive session.
