### PR TITLE
GH#23316: simplify terminal title sanitization

### DIFF
--- a/.opencode/lib/terminal-title.ts
+++ b/.opencode/lib/terminal-title.ts
@@ -27,24 +27,7 @@ export function isTerminalTitleEnabled(env: TerminalTitleEnv = process.env): boo
  * extra terminal control sequences into the OSC payload.
  */
 export function sanitizeTerminalTitle(title: string): string {
-  let sanitizedTitle = ""
-  let previousWasControl = false
-
-  for (const character of title) {
-    const codePoint = character.charCodeAt(0)
-    if (codePoint <= 31 || codePoint === 127) {
-      if (!previousWasControl) {
-        sanitizedTitle += " "
-      }
-      previousWasControl = true
-      continue
-    }
-
-    sanitizedTitle += character
-    previousWasControl = false
-  }
-
-  return sanitizedTitle.trim()
+  return title.replace(/[\x00-\x1F\x7F]+/g, " ").trim()
 }
 
 /**


### PR DESCRIPTION
## Summary

Simplified terminal title control-character sanitization to a concise regex while preserving collapsed-space behavior.

## Files Changed

.opencode/lib/terminal-title.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun sanitizer smoke test passed; git diff --check passed; bun test reported no matching test files; npm run typecheck is a baseline repo validator issue: tsc is unavailable before dependency install and prints help after install because no tsconfig/input set exists

Resolves #23316


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 3m and 36,284 tokens on this as a headless worker.