### PR TITLE
GH#23317: collapse terminal title control runs

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -132,6 +132,11 @@ assertEq(
   "Issue #123 injected title",
   sanitizeTerminalTitle("Issue #123\u0007\u001Binjected\ntitle"),
 );
+assertEq(
+  "consecutive control characters collapse to one space",
+  "Issue #123 injected title",
+  sanitizeTerminalTitle("Issue #123\u0007\u001B\n\tinjected\u0000\u007Ftitle"),
+);
 assertEq("empty sanitized title emits no OSC", "", terminalTitleSequence("\n\t"));
 assertEq(
   "TERMINAL_TITLE_ENABLED=false disables title emit",

--- a/.opencode/lib/terminal-title.ts
+++ b/.opencode/lib/terminal-title.ts
@@ -27,24 +27,7 @@ export function isTerminalTitleEnabled(env: TerminalTitleEnv = process.env): boo
  * extra terminal control sequences into the OSC payload.
  */
 export function sanitizeTerminalTitle(title: string): string {
-  let sanitizedTitle = ""
-  let previousWasControl = false
-
-  for (const character of title) {
-    const codePoint = character.charCodeAt(0)
-    if (codePoint <= 31 || codePoint === 127) {
-      if (!previousWasControl) {
-        sanitizedTitle += " "
-      }
-      previousWasControl = true
-      continue
-    }
-
-    sanitizedTitle += character
-    previousWasControl = false
-  }
-
-  return sanitizedTitle.trim()
+  return title.replace(/[\x00-\x1F\x7F]+/g, " ").trim()
 }
 
 /**

--- a/.opencode/lib/terminal-title.ts
+++ b/.opencode/lib/terminal-title.ts
@@ -27,24 +27,7 @@ export function isTerminalTitleEnabled(env: TerminalTitleEnv = process.env): boo
  * extra terminal control sequences into the OSC payload.
  */
 export function sanitizeTerminalTitle(title: string): string {
-  let sanitizedTitle = ""
-  let previousWasControl = false
-
-  for (const character of title) {
-    const codePoint = character.charCodeAt(0)
-    if (codePoint <= 31 || codePoint === 127) {
-      if (!previousWasControl) {
-        sanitizedTitle += " "
-      }
-      previousWasControl = true
-      continue
-    }
-
-    sanitizedTitle += character
-    previousWasControl = false
-  }
-
-  return sanitizedTitle.trim()
+  return title.replace(/[\u0000-\u001F\u007F]+/g, " ").trim()
 }
 
 /**


### PR DESCRIPTION
## Summary

Collapsed consecutive terminal title control characters through the sanitizer regex and added regression coverage for the collapsed-space expectation.

## Files Changed

.agents/scripts/tests/test-session-rename-ts.mjs,.opencode/lib/terminal-title.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun run .agents/scripts/tests/test-session-rename-ts.mjs (PASS: 26). npm run typecheck is blocked by baseline project configuration: first tsc was unavailable; after locked dependencies were installed without committing lockfile changes, tsc reports no project config / unrelated baseline errors.

Resolves #23317


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 4m and 58,314 tokens on this as a headless worker.