### PR TITLE
GH#23316: satisfy biome for terminal title sanitizer

### DIFF
--- a/.opencode/lib/terminal-title.ts
+++ b/.opencode/lib/terminal-title.ts
@@ -15,6 +15,9 @@ const OSC_TITLE_SUFFIX = "\u0007"
 
 type TerminalTitleEnv = Record<string, string | undefined>
 
+// biome-ignore lint/complexity/useRegexLiterals: regex literals trigger noControlCharactersInRegex for this C0/DEL sanitizer range.
+const CONTROL_CHARACTERS_PATTERN = new RegExp("[\\x00-\\x1F\\x7F]+", "g")
+
 /**
  * Honour the same opt-out environment variables as terminal-title-helper.sh.
  */
@@ -27,7 +30,7 @@ export function isTerminalTitleEnabled(env: TerminalTitleEnv = process.env): boo
  * extra terminal control sequences into the OSC payload.
  */
 export function sanitizeTerminalTitle(title: string): string {
-  return title.replace(/[\x00-\x1F\x7F]+/g, " ").trim()
+  return title.replace(CONTROL_CHARACTERS_PATTERN, " ").trim()
 }
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #23346 / #23316: keep regex-based terminal title sanitization while satisfying Biome.
- Moves the escaped C0/DEL range into a documented RegExp constructor and suppresses only the regex-literal preference rule because the literal form triggers Biome's control-character rule.

## Runtime Testing
- npx --yes @biomejs/biome@2.4.12 check .opencode/lib/terminal-title.ts
- bun sanitizer smoke test
- git diff --check

## Notes
- Does not close #23316 because it was already closed by #23346.
- npm run typecheck remains a baseline validator issue: tsc has no tsconfig/input set in this repository.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 6m and 52,898 tokens on this as a headless worker.
