### PR TITLE
GH#23336: cover sanitized Tabby title sequences

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -137,6 +137,11 @@ assertEq(
   "Issue #123 injected title",
   sanitizeTerminalTitle("Issue #123\u0007\u001B\n\tinjected\u0000\u007Ftitle"),
 );
+assertEq(
+  "OSC 0 sequence uses collapsed sanitized title",
+  "\u001B]0;Issue #123 injected title\u0007",
+  terminalTitleSequence("Issue #123\u0007\u001B\n\tinjected\u0000\u007Ftitle"),
+);
 assertEq("empty sanitized title emits no OSC", "", terminalTitleSequence("\n\t"));
 assertEq(
   "TERMINAL_TITLE_ENABLED=false disables title emit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "types": ["bun"]
+  },
+  "include": [".opencode/lib/session-rename-guards.ts", ".opencode/lib/terminal-title.ts"]
+}


### PR DESCRIPTION
## Summary

Added regression coverage that OSC 0 terminal title sequences use the collapsed sanitized title, and added a focused TypeScript config so the existing project typecheck validator exercises the touched terminal-title libraries.

## Files Changed

.agents/scripts/tests/test-session-rename-ts.mjs,tsconfig.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun run .agents/scripts/tests/test-session-rename-ts.mjs; bunx biome check .agents/scripts/tests/test-session-rename-ts.mjs .opencode/lib/terminal-title.ts; npm run typecheck

Resolves #23336


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 3m and 81,236 tokens on this as a headless worker.