### PR TITLE
GH#23335: test: cover terminal title control range

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -142,6 +142,11 @@ assertEq(
   "\u001B]0;Issue #123 injected title\u0007",
   terminalTitleSequence("Issue #123\u0007\u001B\n\tinjected\u0000\u007Ftitle"),
 );
+assertEq(
+  "C0 and DEL control runs collapse without touching printable punctuation",
+  "Issue #123 — injected: title",
+  sanitizeTerminalTitle("Issue #123 —\u0000\u0001\u001F\u007Finjected: title"),
+);
 assertEq("empty sanitized title emits no OSC", "", terminalTitleSequence("\n\t"));
 assertEq(
   "TERMINAL_TITLE_ENABLED=false disables title emit",


### PR DESCRIPTION
## Summary

Added regression coverage proving the terminal title sanitizer collapses C0/DEL control-character runs while preserving printable punctuation, matching the regex cleanup already present in .opencode/lib/terminal-title.ts.

## Files Changed

.agents/scripts/tests/test-session-rename-ts.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun run .agents/scripts/tests/test-session-rename-ts.mjs; npx @biomejs/biome check .opencode/lib/terminal-title.ts .agents/scripts/tests/test-session-rename-ts.mjs

Resolves #23335


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 2m and 66,985 tokens on this as a headless worker.