### PR TITLE
GH#23327: cover Tabby OpenCode repair edge cases

### DIFF
--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -260,5 +260,76 @@ class TestGetReposExcludesWorktrees(unittest.TestCase):
         self.assertNotIn(str(wt), paths)
 
 
+class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
+    """Regression coverage for Tabby OpenCode repair edge cases."""
+
+    def test_generated_profile_quotes_opencode_command_arg(self):
+        profile = tabby_profile_sync.build_profile_yaml(
+            name="repo",
+            cwd="/Users/alice/repo",
+            tab_colour="#DA5CD3",
+            scheme={
+                "name": "test",
+                "foreground": "#ffffff",
+                "background": "#000000",
+                "cursor": "#ffffff",
+                "colors": ["#000000"],
+            },
+            group_id="group-1",
+        )
+
+        self.assertIn("        - 'opencode; exec zsh'", profile)
+        self.assertNotIn("        - opencode; exec zsh", profile)
+
+    def test_command_field_with_trailing_comment_is_repaired(self):
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
+            """profiles:
+  - name: repo
+    options:
+      command: /bin/zsh -l -c 'opencode; exec zsh' # legacy Tabby shape
+      args: []
+"""
+        )
+
+        self.assertEqual(repairs, 1)
+        self.assertIn("      command: /bin/zsh", repaired)
+        self.assertIn("        - 'opencode; exec zsh'", repaired)
+
+    def test_inline_args_blank_line_before_env_does_not_duplicate_env(self):
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
+            """profiles:
+  - name: repo
+    options:
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+      args: []
+
+      env: {}
+"""
+        )
+
+        self.assertEqual(repairs, 1)
+        self.assertEqual(repaired.count("      env:"), 1)
+        self.assertIn("        - 'opencode; exec zsh'", repaired)
+
+    def test_block_args_comment_before_env_does_not_duplicate_env(self):
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
+            """profiles:
+  - name: repo
+    options:
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+      args:
+        - '-l'
+        - '-c'
+        - 'opencode; exec zsh'
+      # keep existing env block
+      env: {}
+"""
+        )
+
+        self.assertEqual(repairs, 1)
+        self.assertEqual(repaired.count("      env:"), 1)
+        self.assertIn("      # keep existing env block", repaired)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Added regression coverage for quoted OpenCode args, trailing command comments, blank-line env lookahead, and comment-line env lookahead in Tabby profile repair.

## Files Changed

tests/test-tabby-profile-sync.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest tests/test-tabby-profile-sync.py; python3 -m py_compile .agents/scripts/tabby-profile-sync.py tests/test-tabby-profile-sync.py

Resolves #23327


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 61,010 tokens on this as a headless worker.