### PR TITLE
GH#23323: validate screenshot output paths

### DIFF
--- a/.agents/tools/vision/create-screenshots.md
+++ b/.agents/tools/vision/create-screenshots.md
@@ -47,7 +47,7 @@ Ask when browser access, target state, dimensions, or privacy expectations are u
 3. Set deterministic viewport, theme, timezone, locale, feature flags, and seeded data where possible.
 4. Capture the smallest useful region: selector screenshot, component screenshot, modal, card, chart, or window. Capture full viewport only when the composition requires it.
 5. Avoid `fullPage: true` for AI review or draft inspection; use bounded captures and resize large images before analysis.
-6. Save raw captures under `screenshots/raw/` or the user's requested asset path, then compose final images under `screenshots/final/` or the requested output path.
+6. Save raw captures under `screenshots/raw/` or the user's requested asset path, then compose final images under `screenshots/final/` or the requested output path. For any user-provided destination, resolve the real path after creating or checking the parent directory and confirm it remains within the project or another explicitly allowed asset directory; this prevents path traversal through `..` segments or symlinks.
 
 ## Composition Rules
 


### PR DESCRIPTION
## Summary
- Adds path validation guidance for user-provided screenshot output destinations.
- Requires resolved real paths to stay inside the project or another explicitly allowed asset directory to prevent traversal via `..` segments or symlinks.

## Verification
- `npx --no-install markdownlint-cli2 ".agents/tools/vision/create-screenshots.md"`
- `.agents/scripts/linters-local.sh` progressed through SonarCloud, Secretlint, Markdown, TOON, skill frontmatter, secret safety, and pulse canary successfully, then timed out in existing ratchet counting after 300s.

Resolves #23323

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 9m and 37,365 tokens on this as a headless worker.
