### PR TITLE
GH#23329: Harden body-file signature test assertion

### DIFF
--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -175,14 +175,25 @@ assert_contains "original file keeps original content" "Issue body from file" "$
 signed_body_file=""
 for ((i = 0; i < ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}; i++)); do
 	if [[ "${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]}" == "--body-file" ]]; then
-		signed_body_file="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]}"
+		if ((i + 1 < ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]})); then
+			signed_body_file="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]}"
+		fi
 		break
 	fi
 done
-assert_not_contains "wrapper points gh at a temp body file" "$body_file" "$signed_body_file"
-signed_file_content=$(<"$signed_body_file")
-assert_contains "temp body has signature marker" "<!-- aidevops:sig -->" "$signed_file_content"
-assert_contains "temp body has original content" "Issue body from file" "$signed_file_content"
+if [[ -z "$signed_body_file" ]]; then
+	echo "  FAIL: --body-file flag not found in modified args"
+	FAIL=$((FAIL + 1))
+elif [[ "$signed_body_file" == "$body_file" ]]; then
+	echo "  FAIL: wrapper used original file instead of temp copy"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: wrapper points gh at a temp body file"
+	PASS=$((PASS + 1))
+	signed_file_content=$(<"$signed_body_file")
+	assert_contains "temp body has signature marker" "<!-- aidevops:sig -->" "$signed_file_content"
+	assert_contains "temp body has original content" "Issue body from file" "$signed_file_content"
+fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 5: --body-file with existing signature is NOT modified


### PR DESCRIPTION
## Summary

Replaced substring-based body-file temp path validation with guarded flag extraction and direct equality checks in the gh wrapper auto-signature test.

## Files Changed

.agents/scripts/tests/test-gh-wrapper-auto-sig.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-gh-wrapper-auto-sig.sh; bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh

Resolves #23329


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 58s and 51,400 tokens on this as a headless worker.