### PR TITLE
GH#23330: Clarify gh body-file cleanup ownership

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -371,6 +371,9 @@ _gh_wrapper_auto_sig() {
 		[[ -z "$sig_footer" ]] && return 0
 		local signed_body_file
 		signed_body_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-gh-body.XXXXXX") || return 0
+		# Cleanup scope is established by the public gh_* wrappers that call this
+		# helper. Do not set a RETURN trap here: the temp file must remain readable
+		# until the wrapper delegates to gh, then the wrapper-level trap removes it.
 		push_cleanup "rm -f \"$signed_body_file\""
 		{
 			cat "$body_file_val"


### PR DESCRIPTION
## Summary

Documented that signed --body-file temp cleanup is owned by the public gh_* wrapper cleanup scope, preserving temp-file availability until gh reads it while keeping wrapper-level cleanup.

## Files Changed

.agents/scripts/shared-gh-wrappers-session.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-wrapper-auto-sig.sh; shellcheck .agents/scripts/shared-gh-wrappers-session.sh .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-gh-wrapper-auto-sig.sh

Resolves #23330


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 56,816 tokens on this as a headless worker.