### PR TITLE
GH#23332: refine Swift Xcode workflow examples

### DIFF
--- a/.agents/tools/mobile/swift-xcode-agent-workflow.md
+++ b/.agents/tools/mobile/swift-xcode-agent-workflow.md
@@ -35,7 +35,7 @@ tools:
 Before edits, discover the actual project shape rather than guessing:
 
 ```bash
-git ls-files 'Package.swift' '*.xcodeproj/project.pbxproj' '*.xcworkspace' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
+git ls-files 'Package.swift' '*.xcodeproj/project.pbxproj' '*.xcworkspace/contents.xcworkspacedata' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
 xcodebuild -version
 xcode-select -p
 swift --version
@@ -45,8 +45,8 @@ xcrun simctl list devices available
 Then list schemes with the right container:
 
 ```bash
-xcodebuild -list -json -workspace MyApp.xcworkspace
-xcodebuild -list -json -project MyApp.xcodeproj
+xcodebuild -list -json -workspace <workspace_name>.xcworkspace
+xcodebuild -list -json -project <project_name>.xcodeproj
 ```
 
 If there are multiple schemes or destinations, prefer an existing documented command in `Makefile`, `README`, CI, or project scripts. Ask only when the scheme/destination choice changes product behaviour or signing/billing/security state.


### PR DESCRIPTION
## Summary

- Updated Swift/Xcode workspace discovery to target `.xcworkspace/contents.xcworkspacedata`, which identifies the actual workspace definition file.
- Replaced literal `MyApp` xcodebuild examples with `<workspace_name>` and `<project_name>` placeholders to prevent copy-paste execution against nonexistent containers.

## Testing

- `markdownlint-cli2 .agents/tools/mobile/swift-xcode-agent-workflow.md`
- `git diff --check`

## Runtime Testing

- Not applicable: documentation-only change.

Resolves #23332


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 71,313 tokens on this with the user in an interactive session.
