### PR TITLE
GH#23332: address Swift workflow review refinements

### DIFF
--- a/.agents/tools/mobile/swift-xcode-agent-workflow.md
+++ b/.agents/tools/mobile/swift-xcode-agent-workflow.md
@@ -35,7 +35,7 @@ tools:
 Before edits, discover the actual project shape rather than guessing:
 
 ```bash
-git ls-files 'Package.swift' '*.xcodeproj/project.pbxproj' '*.xcworkspace/contents.xcworkspacedata' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
+git ls-files 'Package.swift' '*.xcodeproj/project.pbxproj' '*.xcworkspace/contents.xcworkspacedata' '**/*.xcworkspace/contents.xcworkspacedata' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
 xcodebuild -version
 xcode-select -p
 swift --version
@@ -45,8 +45,8 @@ xcrun simctl list devices available
 Then list schemes with the right container:
 
 ```bash
-xcodebuild -list -json -workspace <workspace_name>.xcworkspace
-xcodebuild -list -json -project <project_name>.xcodeproj
+xcodebuild -list -json -workspace "<workspace_name>.xcworkspace"
+xcodebuild -list -json -project "<project_name>.xcodeproj"
 ```
 
 If there are multiple schemes or destinations, prefer an existing documented command in `Makefile`, `README`, CI, or project scripts. Ask only when the scheme/destination choice changes product behaviour or signing/billing/security state.


### PR DESCRIPTION
## Summary

- Follow-up to PR #23360: include recursive `.xcworkspace/contents.xcworkspacedata` discovery for nested workspaces.
- Quote placeholder workspace/project names in `xcodebuild -list` examples so filenames with spaces remain safe.

## Testing

- `markdownlint-cli2 .agents/tools/mobile/swift-xcode-agent-workflow.md`
- `git diff --check`

## Runtime Testing

- Not applicable: documentation-only change.

Closes #23332


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 7m and 113,496 tokens on this with the user in an interactive session.

