### PR TITLE
t3586: fix release postflight secretlint pin

### DIFF
--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -210,16 +210,19 @@ jobs:
         echo "## Secret Detection (Secretlint)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Install secretlint (Bun for faster install)
-        bun install -g secretlint @secretlint/secretlint-rule-preset-recommend
+        # Install the repo-pinned secretlint stack. Using the latest global
+        # secretlint can add release-only rules that trip intentional fixture
+        # strings before the repository has opted in to the new major version.
+        bun install --frozen-lockfile
         
         # Run scan. Keep intentional credential-scrubber fixtures out of the
         # release gate while scanning every other production/source path.
         SECRET_LINT_TARGETS=(
           "**/*"
+          "!.agents/scripts/tests/test-credential-sanitizer.sh"
           "!.agents/scripts/tests/test-credential-transcript-scrub.sh"
         )
-        if secretlint "${SECRET_LINT_TARGETS[@]}" --secretlintrc .secretlintrc.json --secretlintignore .secretlintignore --format compact 2>/dev/null; then
+        if bunx --no-install secretlint "${SECRET_LINT_TARGETS[@]}" --secretlintrc .secretlintrc.json --secretlintignore .secretlintignore --format compact 2>/dev/null; then
           echo "**Status**: No secrets detected" >> $GITHUB_STEP_SUMMARY
           echo "secrets_status=passed" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
## Summary

- Pin the release postflight secretlint step to the repository lockfile instead of installing latest global secretlint.
- Exclude the intentional credential-sanitizer fixture alongside the transcript-scrubber fixture.

## Why

Release v3.15.27 postflight failed after global secretlint resolved to a newer major and reported intentional test fixture credentials. The release itself was created, but postflight must stay deterministic.

## Verification

- `bunx --no-install secretlint "**/*" "!.agents/scripts/tests/test-credential-sanitizer.sh" "!.agents/scripts/tests/test-credential-transcript-scrub.sh" --secretlintrc .secretlintrc.json --secretlintignore .secretlintignore --format compact`
- `git diff --check`
- `actionlint .github/workflows/postflight.yml`

Ref: t3586
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.27 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 36m and 321,730 tokens on this with the user in an interactive session.