### PR TITLE
GH#23366: Validate OpenCode memory tool payloads

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -49,7 +49,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Never present intent as completed work. Every claim needs proof: path, command result, PR/issue number, or metric.
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.
 - Before declaring completion, scan conversation for unfulfilled commitments, unnotified external parties, and displaced requests.
-- Memory recall is mandatory before non-trivial edits, debugging, PR review, git side effects, or design decisions: `memory-helper.sh recall --query "<task keywords>" --limit 5`. Store fresh lessons immediately after breakthroughs.
+- Memory recall is mandatory before non-trivial edits, debugging, PR review, git side effects, or design decisions: CLI `memory-helper.sh recall --query "<task keywords>" --limit 5`; OpenCode tool `aidevops_memory` with `{action:"recall", query:"<task keywords>", limit:"5"}`. Store only concrete reusable lessons: `{action:"store", content:"<lesson with evidence>", confidence:"medium"}`. Empty `aidevops_memory` calls are invalid; never use them as placeholders.
 - Before non-trivial code changes, run one duplicate/collision check: `prework-discovery-helper.sh --keywords "<task>" --files "<targets>" [--repo owner/repo]`.
 
 ### Automation safety invariants

--- a/.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs
@@ -40,6 +40,22 @@ describe("aidevops_memory tool schema", () => {
 });
 
 describe("aidevops_memory execution", () => {
+  test("empty payload returns actionable validation without invoking helper", async () => {
+    const calls = [];
+    const result = await withMemoryHelper(async (scriptsDir) => {
+      const tools = createTools(scriptsDir, (cmd) => {
+        calls.push(cmd);
+        return "unexpected";
+      });
+
+      return tools.aidevops_memory.execute({});
+    });
+
+    assert.equal(calls.length, 0);
+    assert.match(result, /requires a complete payload/);
+    assert.match(result, /do not use empty calls as placeholders/);
+  });
+
   test("store action invokes memory-helper.sh store", async () => {
     const calls = [];
     const result = await withMemoryHelper(async (scriptsDir) => {
@@ -80,12 +96,28 @@ describe("aidevops_memory execution", () => {
     assert.match(calls[0], /memory-helper\.sh" recall 'schema' --limit '5'$/);
   });
 
+  test("recall action without a query returns a validation error", async () => {
+    const calls = [];
+    const result = await withMemoryHelper(async (scriptsDir) => {
+      const tools = createTools(scriptsDir, (cmd) => {
+        calls.push(cmd);
+        return "unexpected";
+      });
+
+      return tools.aidevops_memory.execute({ action: "recall", limit: 5 });
+    });
+
+    assert.equal(calls.length, 0);
+    assert.match(result, /query is required for memory recall/);
+  });
+
   test("empty store content returns a validation error", async () => {
     const result = await withMemoryHelper(async (scriptsDir) => {
       const tools = createTools(scriptsDir, () => "stored");
       return tools.aidevops_memory.execute({ action: "store", content: "   " });
     });
 
-    assert.equal(result, "Error: content is required to store a memory");
+    assert.match(result, /content is required to store a memory/);
+    assert.match(result, /do not store placeholders/);
   });
 });

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -7,6 +7,7 @@ try {
   ({ tool } = await import("@opencode-ai/plugin"));
 } catch {
   const schemaNode = {
+    _zod: {},
     optional() {
       return this;
     },
@@ -20,6 +21,9 @@ try {
       return schemaNode;
     },
     string() {
+      return schemaNode;
+    },
+    number() {
       return schemaNode;
     },
     union() {
@@ -88,9 +92,10 @@ function createMemoryTool(scriptsDir, run) {
   return tool({
     description:
       'Recall or store memories in the aidevops cross-session memory system. ' +
-      'Args: action ("recall"|"store"), query (string, for recall), ' +
+      'Args: action ("recall"|"store"), query (non-empty string, for recall), ' +
       'limit (string, default "5", for recall), ' +
-      'content (string, for store), confidence ("low"|"medium"|"high", default "medium", for store)',
+      'content (non-empty string, for store), confidence ("low"|"medium"|"high", default "medium", for store). ' +
+      'Do not call with an empty payload; use {action:"recall",query:"...",limit:"5"} or {action:"store",content:"...",confidence:"medium"}.',
     args: {
       action: z.enum(["recall", "store"]).optional().describe('Memory operation to perform; defaults to "recall"'),
       query: z.string().optional().describe("Search query for memory recall"),
@@ -99,15 +104,23 @@ function createMemoryTool(scriptsDir, run) {
       confidence: z.enum(["low", "medium", "high"]).optional().describe('Stored memory confidence; defaults to "medium"'),
     },
     async execute(args) {
+      args = args && typeof args === "object" ? args : {};
       const memoryHelper = join(scriptsDir, "memory-helper.sh");
       if (!existsSync(memoryHelper)) {
         return "Memory system not available (memory-helper.sh not found)";
       }
 
+      if (!args.action && !args.query && !args.content) {
+        return 'Error: aidevops_memory requires a complete payload. Use {action:"recall", query:"<keywords>", limit:"5"} or {action:"store", content:"<lesson>", confidence:"medium"}; do not use empty calls as placeholders.';
+      }
+
       const action = String(args.action || "recall");
 
       if (action === "recall") {
-        const query = args.query || "";
+        const query = typeof args.query === "string" ? args.query.trim() : "";
+        if (!query) {
+          return 'Error: query is required for memory recall. Use {action:"recall", query:"<keywords>", limit:"5"}.';
+        }
         const limit = args.limit === undefined ? "5" : String(args.limit);
         const cmd = `bash "${memoryHelper}" recall ${shellEscape(query)} --limit ${shellEscape(limit)}`;
         const result = run(cmd, 10000);
@@ -117,7 +130,7 @@ function createMemoryTool(scriptsDir, run) {
       if (action === "store") {
         const content = typeof args.content === "string" ? args.content.trim() : "";
         if (!content) {
-          return "Error: content is required to store a memory";
+          return 'Error: content is required to store a memory. Use {action:"store", content:"<lesson>", confidence:"medium"}; do not store placeholders.';
         }
         const confidence = args.confidence || "medium";
         const cmd = `bash "${memoryHelper}" store ${shellEscape(content)} --confidence ${shellEscape(confidence)}`;

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -57,6 +57,30 @@ function isSafeCommand(command) {
 }
 
 /**
+ * Validate memory tool arguments before invoking the shell helper.
+ * @param {object} args
+ * @returns {string}
+ */
+function getMemoryArgsError(args) {
+  const action = String(args.action || "recall");
+  const query = typeof args.query === "string" ? args.query.trim() : "";
+  const content = typeof args.content === "string" ? args.content.trim() : "";
+  let error = "";
+
+  if (!args.action && !query && !content) {
+    error = 'Error: aidevops_memory requires a complete payload. Use {action:"recall", query:"<keywords>", limit:"5"} or {action:"store", content:"<lesson>", confidence:"medium"}; do not use empty calls as placeholders.';
+  } else if (action === "recall" && !query) {
+    error = 'Error: query is required for memory recall. Use {action:"recall", query:"<keywords>", limit:"5"}.';
+  } else if (action === "store" && !content) {
+    error = 'Error: content is required to store a memory. Use {action:"store", content:"<lesson>", confidence:"medium"}; do not store placeholders.';
+  } else if (action !== "recall" && action !== "store") {
+    error = `Unknown action: ${action}. Use "recall" or "store".`;
+  }
+
+  return error;
+}
+
+/**
  * Create the aidevops CLI tool.
  * @param {function} run - Shell command runner
  * @returns {object} Tool definition
@@ -110,17 +134,15 @@ function createMemoryTool(scriptsDir, run) {
         return "Memory system not available (memory-helper.sh not found)";
       }
 
-      if (!args.action && !args.query && !args.content) {
-        return 'Error: aidevops_memory requires a complete payload. Use {action:"recall", query:"<keywords>", limit:"5"} or {action:"store", content:"<lesson>", confidence:"medium"}; do not use empty calls as placeholders.';
+      const validationError = getMemoryArgsError(args);
+      if (validationError) {
+        return validationError;
       }
 
       const action = String(args.action || "recall");
 
       if (action === "recall") {
-        const query = typeof args.query === "string" ? args.query.trim() : "";
-        if (!query) {
-          return 'Error: query is required for memory recall. Use {action:"recall", query:"<keywords>", limit:"5"}.';
-        }
+        const query = args.query.trim();
         const limit = args.limit === undefined ? "5" : String(args.limit);
         const cmd = `bash "${memoryHelper}" recall ${shellEscape(query)} --limit ${shellEscape(limit)}`;
         const result = run(cmd, 10000);
@@ -128,17 +150,14 @@ function createMemoryTool(scriptsDir, run) {
       }
 
       if (action === "store") {
-        const content = typeof args.content === "string" ? args.content.trim() : "";
-        if (!content) {
-          return 'Error: content is required to store a memory. Use {action:"store", content:"<lesson>", confidence:"medium"}; do not store placeholders.';
-        }
+        const content = args.content.trim();
         const confidence = args.confidence || "medium";
         const cmd = `bash "${memoryHelper}" store ${shellEscape(content)} --confidence ${shellEscape(confidence)}`;
         const result = run(cmd, 10000);
         return result || "Memory stored successfully.";
       }
 
-      return `Unknown action: ${action}. Use "recall" or "store".`;
+      return validationError;
     },
   });
 }

--- a/.agents/reference/memory-lookup.md
+++ b/.agents/reference/memory-lookup.md
@@ -16,6 +16,12 @@ every vague reference — match the source to the question.
 ## Tier 1 — Local cached (instant, zero cost)
 
 1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or `aidevops_memory` MCP tool with `action: "recall"` — curated signal, most likely to have the answer. Solutions, decisions, preferences, patterns.
+
+   OpenCode tool payload examples:
+   - Recall: `{ "action": "recall", "query": "deployment rollback pattern", "limit": "5" }`
+   - Store: `{ "action": "store", "content": "Deployment rollback X was fixed by Y; verify with Z.", "confidence": "medium" }`
+
+   Do not call `aidevops_memory` with `{}` or missing required fields. Empty calls are invalid placeholders; if there is no concrete memory to recall/store, continue the task or create a worker-ready follow-up instead.
 2. **TODO.md + completed tasks**: `rg "keyword" TODO.md` — task IDs, PR numbers, completion dates, brief descriptions of all past work.
 
 ## Tier 2 — Local indexed (fast, local I/O)


### PR DESCRIPTION
## Summary

- Added loaded OpenCode guidance examples for valid `aidevops_memory` recall/store payloads.
- Added runtime validation so empty or incomplete memory calls return actionable errors before invoking `memory-helper.sh`.
- Added regression coverage for empty payloads, missing recall queries, and empty store content.

## Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs`
- `npm test` in `.agents/plugins/opencode-aidevops`
- `npm run typecheck`

## Runtime Testing

Self-assessed: low-risk framework guidance and OpenCode plugin validation change covered by automated tests.

Resolves #23366


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 2m and 73,191 tokens on this with the user in an interactive session.
