### PR TITLE
GH#23373: suppress empty claim release warnings

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -292,6 +292,14 @@ _release_dispatch_claim() {
 	# Try to get repo slug from the dispatch ledger or env
 	repo_slug="${DISPATCH_REPO_SLUG:-}"
 
+	# Supervisor/pulse cleanup paths can source this module and run the generic
+	# EXIT cleanup without ever having claimed a worker issue. With no issue and
+	# no repo there is no real claim to release; treat that exact empty-context
+	# case as a benign caller-boundary no-op. Keep warning on partial context
+	# because issue-without-repo or repo-without-issue can strand a real claim.
+	if [[ -z "$issue_number" && -z "$repo_slug" ]]; then
+		return 0
+	fi
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		print_warning "Cannot release claim: missing issue=$issue_number repo=$repo_slug"
 		return 0

--- a/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
+++ b/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
@@ -84,6 +84,16 @@ gh() {
 # shellcheck source=../headless-runtime-failure.sh
 source "${SCRIPT_DIR}/headless-runtime-failure.sh"
 
+unset DISPATCH_REPO_SLUG WORKER_ISSUE_NUMBER
+_release_dispatch_claim "supervisor-pulse" "process_exit" "1" "0"
+if grep -q 'Cannot release claim: missing issue= repo=' "$CALL_LOG"; then
+	printf 'FAIL empty non-worker claim release emitted warning\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+printf 'PASS empty non-worker claim release is a silent no-op\n'
+: >"$CALL_LOG"
+
 export DISPATCH_REPO_SLUG="owner/repo"
 _release_dispatch_claim "issue-12345" "worker_noop" "0" "0"
 


### PR DESCRIPTION
## Summary
- Suppresses benign empty issue/repo claim-release cleanup warnings for non-worker supervisor/pulse paths.
- Preserves warnings for partial claim context so real stranded claim risks remain visible.
- Adds regression coverage for the empty-context no-op while keeping valid worker release lifecycle coverage.

## Testing
- bash .agents/scripts/tests/test-headless-runtime-release-unlock.sh
- bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh
- bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh
- shellcheck .agents/scripts/headless-runtime-failure.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-release-unlock.sh

## Runtime Testing
- self-assessed: low-risk shell cleanup guard and regression tests.

Resolves #23373


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 12m and 104,107 tokens on this as a headless worker.
