### PR TITLE
GH#23372: prevent non-git worktree cleanup noise

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -266,13 +266,17 @@ _cleanup_merged_prs_for_all_repos() {
 		# a git directory, not just pulse-enabled ones. Workers can create
 		# worktrees in any managed repo. Skip local_only repos since
 		# worktree-helper.sh uses gh pr list for squash-merge detection.
-		local repo_paths
-		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" || echo "")
+		local repo_records
+		repo_records=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | [.path // "", .slug // "unknown"] | @tsv' "$repos_json" || echo "")
 
 		local repo_path
-		while IFS= read -r repo_path; do
+		local repo_slug
+		while IFS=$'\t' read -r repo_path repo_slug; do
 			[[ -z "$repo_path" ]] && continue
-			[[ ! -d "$repo_path/.git" ]] && continue
+			if ! git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
+				echo "[pulse-cleanup] stage=merged-pr repo=${repo_slug:-unknown} skipping cleanup — invalid repo path configured" >>"${LOGFILE:-/dev/null}"
+				continue
+			fi
 
 			local wt_count
 			wt_count=$(git -C "$repo_path" worktree list | wc -l | tr -d ' ')
@@ -293,9 +297,15 @@ _cleanup_merged_prs_for_all_repos() {
 				echo "[pulse-wrapper] Worktree cleanup ($repo_name): $count worktree(s) removed" >>"$LOGFILE"
 				total_removed=$((total_removed + count))
 			fi
-		done <<<"$repo_paths"
+		done <<<"$repo_records"
 	else
 		# Fallback: just clean the current repo (legacy behaviour)
+		if ! git rev-parse --git-dir >/dev/null 2>&1; then
+			echo "[pulse-cleanup] stage=merged-pr repo=unknown skipping cleanup — current directory is not a git repository" >>"${LOGFILE:-/dev/null}"
+			echo 0
+			return 0
+		fi
+
 		local clean_result
 		clean_result=$(bash "$helper" clean --auto --force-merged 2>&1) || true
 		local fallback_count

--- a/.agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#23372: pulse/worktree cleanup must not emit raw
+# git fatal output when invoked from a non-git scheduler or temp directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+LOGFILE="${TEST_ROOT}/pulse.log"
+export LOGFILE
+HOME="${TEST_ROOT}/home"
+export HOME
+mkdir -p "${HOME}/.config/aidevops"
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# shellcheck source=../pulse-cleanup.sh
+source "${SCRIPT_DIR}/pulse-cleanup.sh"
+_PULSE_CLEANUP_SCRIPT_DIR="$SCRIPT_DIR"
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message"
+	exit 1
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+test_pulse_fallback_skips_non_git_cwd() {
+	local non_git_dir="${TEST_ROOT}/scheduler-cwd"
+	mkdir -p "$non_git_dir"
+
+	local output
+	output=$(cd "$non_git_dir" && _cleanup_merged_prs_for_all_repos 2>&1) || true
+
+	[[ "$output" == "0" ]] || fail "pulse fallback returned unexpected output: $output"
+	[[ "$output" != *"fatal: not a git repository"* ]] || fail "pulse fallback emitted raw git fatal output"
+	grep -q 'stage=merged-pr repo=unknown skipping cleanup — current directory is not a git repository' "$LOGFILE" \
+		|| fail "pulse fallback did not log structured non-git skip"
+	pass "pulse cleanup fallback skips non-git cwd without raw git fatal output"
+	return 0
+}
+
+test_worktree_helper_skips_non_git_cwd() {
+	local non_git_dir="${TEST_ROOT}/helper-cwd"
+	mkdir -p "$non_git_dir"
+
+	local output
+	output=$(cd "$non_git_dir" && bash "${SCRIPT_DIR}/worktree-helper.sh" clean --auto --force-merged 2>&1) || true
+
+	[[ "$output" != *"fatal: not a git repository"* ]] || fail "worktree helper emitted raw git fatal output"
+	[[ "$output" == *"Warning: skipping worktree cleanup — current directory is not a git repository"* ]] \
+		|| fail "worktree helper did not emit structured non-git warning: $output"
+	pass "worktree helper skips non-git cwd without raw git fatal output"
+	return 0
+}
+
+test_pulse_fallback_skips_non_git_cwd
+test_worktree_helper_skips_non_git_cwd
+
+exit 0

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -719,8 +719,13 @@ _clean_preflight_main_worktree() {
 	# worktree. Avoid piping through head — with set -o pipefail and many
 	# worktrees, head closes the pipe early → git SIGPIPE (exit 141) →
 	# pipefail → set -e abort.
+	if ! git rev-parse --git-dir >/dev/null 2>&1; then
+		echo -e "${YELLOW}Warning: skipping worktree cleanup — current directory is not a git repository${NC}" >&2
+		return 1
+	fi
+
 	local _porcelain main_worktree_path
-	_porcelain=$(git worktree list --porcelain)
+	_porcelain=$(git worktree list --porcelain 2>/dev/null)
 	if [[ -z "$_porcelain" ]]; then
 		echo -e "${RED}FATAL: 'git worktree list --porcelain' returned empty — refusing cleanup${NC}" >&2
 		return 1


### PR DESCRIPTION
## Summary

Added non-git cwd guards for pulse/worktree cleanup so scheduler cleanup skips with structured warnings instead of raw git fatal output; added regression coverage for both pulse fallback and helper entrypoint.

## Files Changed

.agents/scripts/pulse-cleanup.sh,.agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh,.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh; bash .agents/scripts/tests/test-pulse-cleanup-unregister.sh; bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh; shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh

Resolves #23372


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 12m and 71,407 tokens on this as a headless worker.