### PR TITLE
GH#23374: fix: classify interactive review holds as benign

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1716,6 +1716,10 @@ classify_dispatch_blocker_reason() {
 	lower_signal=$(printf '%s' "$signal" | tr '[:upper:]' '[:lower:]')
 
 	case "$lower_signal" in
+		*interactive_review_hold* | *interactive*review*hold*)
+			printf 'interactive_review_hold\n'
+			return 0
+			;;
 		*cost_budget_exceeded*)
 			printf 'cost_budget_exceeded\n'
 			return 0

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1089,6 +1089,7 @@ _dispatch_has_interactive_hold() {
 # Exit codes:
 #   0 - all gates passed; safe to dispatch
 #   1 - blocked (reason logged to LOGFILE by the failing gate)
+#   3 - expected benign dispatch block with structured DISPATCH_BLOCK_REASON
 #######################################
 _dispatch_dedup_check_layers() {
 	local issue_number="$1"
@@ -1119,8 +1120,9 @@ _dispatch_dedup_check_layers() {
 	_dss_t0=$(_ds_now_ns)
 	if _dispatch_has_interactive_hold "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: interactive review hold label present (GH#22948)" >>"$LOGFILE"
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive_review_hold issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.interactive_hold" "$_dss_t0"
-		return 1
+		return 3
 	fi
 	_ds_record "$issue_number" "$repo_slug" "dedup.interactive_hold" "$_dss_t0"
 

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -104,7 +104,7 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		dedup_active_claim | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
+		dedup_active_claim | interactive_review_hold | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
 			;;
 		*)
 			reason="unclassified_signal"
@@ -176,6 +176,29 @@ _dispatch_candidate_failure_reason() {
 
 	printf '%s\n' "$reason"
 	return 0
+}
+
+#######################################
+# Run a dispatch candidate under the stage watchdog while preserving benign
+# block return codes without emitting generic Stage failed noise.
+#
+# Arguments:
+#   $1 - file path where the raw dispatch rc should be written
+#   $2.. - command and arguments to execute
+# Returns:
+#   0 for success or benign expected block rc=3; otherwise the command rc.
+#######################################
+_dispatch_stage_rc_adapter() {
+	local rc_file="$1"
+	shift
+
+	local raw_rc=0
+	"$@" || raw_rc=$?
+	printf '%s\n' "$raw_rc" >"$rc_file" 2>/dev/null || true
+	if [[ "$raw_rc" -eq 3 ]]; then
+		return 0
+	fi
+	return "$raw_rc"
 }
 
 #######################################
@@ -809,9 +832,17 @@ _dispatch_with_timeout() {
 	fi
 
 	local start_ms dispatch_rc=0 outcome elapsed_ms
+	local stage_rc=0 raw_rc_file=""
+	raw_rc_file=$(mktemp 2>/dev/null || printf '/tmp/aidevops-dispatch-raw-rc.%s.%s' "$$" "$issue_number")
 	start_ms=$(_dispatch_now_ms)
 	run_stage_with_timeout "dispatch_candidate_${issue_number}" "$timeout_seconds" \
-		dispatch_with_dedup "$@" || dispatch_rc=$?
+		_dispatch_stage_rc_adapter "$raw_rc_file" dispatch_with_dedup "$@" || stage_rc=$?
+	if [[ -s "$raw_rc_file" ]]; then
+		read -r dispatch_rc <"$raw_rc_file" || dispatch_rc="$stage_rc"
+	else
+		dispatch_rc="$stage_rc"
+	fi
+	rm -f "$raw_rc_file" 2>/dev/null || true
 	elapsed_ms=$(($(_dispatch_now_ms) - start_ms))
 	echo "[pulse-wrapper] Dispatch_max: dispatch_with_dedup returned rc=${dispatch_rc} for #${issue_number} elapsed_ms=${elapsed_ms} timeout_used_ms=${timeout_ms}" >>"$LOGFILE"
 
@@ -1063,6 +1094,11 @@ _dispatch_process_candidate() {
 		else
 			local failure_reason
 			failure_reason=$(_dispatch_candidate_failure_reason "$issue_number" "$repo_slug" "$dispatch_rc")
+			if [[ "$failure_reason" == "interactive_review_hold" ]]; then
+				echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) benign dispatch block reason=interactive_review_hold" >>"$LOGFILE"
+				_dispatch_stats_increment "dispatch_candidate_blocked_interactive_review_hold"
+				return 1
+			fi
 			echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) pre-launch failure reason=${failure_reason}" >>"$LOGFILE"
 			_dispatch_stats_increment_candidate_failed "$failure_reason"
 		fi

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -21,6 +21,7 @@ assert_reason() {
 
 assert_reason 'COST_BUDGET_EXCEEDED (spent=123 budget=100)' 'cost_budget_exceeded'
 assert_reason 'DISPATCH_BLOCK_REASON reason=dedup_active_claim signal=assigned to runner' 'dedup_active_claim'
+assert_reason 'DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive review hold label present' 'interactive_review_hold'
 assert_reason 'GraphQL budget below circuit-breaker threshold' 'graphql_circuit_breaker'
 assert_reason 'DISPATCH_COOLDOWN_ACTIVE until=2026-05-02T23:00:00Z reason=no_worker_process' 'cooldown_no_worker_process'
 assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — requires cryptographic approval (ever-NMR)' 'ever_nmr_without_approval'

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -163,6 +163,19 @@ test_disabled_guardrail_still_updates_available_slots_gauge() {
 	return 0
 }
 
+test_interactive_hold_reason_is_classified() {
+	reset_guardrail_env
+	printf '%s\n' '[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive_review_hold issue=#4772 repo=awardsapp/awardsapp' >>"$LOGFILE"
+	local reason
+	reason=$(_dispatch_candidate_failure_reason 4772 awardsapp/awardsapp 3)
+	if [[ "$reason" == "interactive_review_hold" ]]; then
+		print_result "guardrail: interactive review hold classifies as benign block" 0
+	else
+		print_result "guardrail: interactive review hold classifies as benign block" 1 "reason=${reason}"
+	fi
+	return 0
+}
+
 test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
@@ -170,6 +183,7 @@ test_healthy_pr_backlog_rations_new_launches
 test_no_dispatchable_evidence_pauses_refill_loop
 test_clean_state_preserves_available_slots
 test_disabled_guardrail_still_updates_available_slots_gauge
+test_interactive_hold_reason_is_classified
 
 printf '\n====================\n'
 printf 'Tests run: %s\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -145,6 +145,15 @@ test_interactive_hold_allows_worker_issue() {
 	return 0
 }
 
+test_interactive_hold_emits_structured_block_reason() {
+	if grep -q 'DISPATCH_BLOCK_REASON reason=interactive_review_hold' "$CORE_SCRIPT" && grep -q 'return 3' "$CORE_SCRIPT"; then
+		print_result "interactive hold emits structured benign block reason" 0
+		return 0
+	fi
+	print_result "interactive hold emits structured benign block reason" 1 "expected structured reason and benign rc=3 in dispatch core"
+	return 0
+}
+
 main() {
 	if ! define_helpers_under_test; then
 		return 1
@@ -156,6 +165,7 @@ main() {
 	test_interactive_hold_blocks_origin_interactive
 	test_interactive_hold_allows_auto_dispatch_handoff
 	test_interactive_hold_allows_worker_issue
+	test_interactive_hold_emits_structured_block_reason
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -61,6 +61,7 @@ assert_not_grep() {
 # Resolve paths relative to this test file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
+DISPATCH_LIB="$SCRIPT_DIR/pulse-dispatch-lib.sh"
 
 echo "=== t2443 + t2903: pulse-dispatch-engine stage wiring regression tests ==="
 echo "Engine: $ENGINE"
@@ -149,6 +150,17 @@ assert_grep \
 	"9: async post-dispatch housekeeping uses _pflt_timeout" \
 	'_pulse_start_post_dispatch_housekeeping "\$_pflt_timeout"' \
 	"$ENGINE"
+
+# --- Benign expected dispatch blocks must not be surfaced as generic stage failures ---
+
+assert_grep \
+	"10a: dispatch stage adapter preserves benign block rc" \
+	'_dispatch_stage_rc_adapter' \
+	"$DISPATCH_LIB"
+assert_grep \
+	"10b: interactive review hold is logged as benign block, not pre-launch failure" \
+	'benign dispatch block reason=interactive_review_hold' \
+	"$DISPATCH_LIB"
 
 # --- Summary ---
 


### PR DESCRIPTION
## Summary

Classified interactive review holds with a structured benign dispatch block reason, preserved the raw dispatch return code without emitting generic stage failures, and skipped failure metrics for that expected state.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh,.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh,.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh; bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; bash .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh; bash .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh; shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/dispatch-dedup-helper.sh

Resolves #23374


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 13m and 68,740 tokens on this as a headless worker.