### PR TITLE
GH#23382: clarify generated worktree helper path

### DIFF
--- a/.agents/scripts/generate-opencode-commands-planning.sh
+++ b/.agents/scripts/generate-opencode-commands-planning.sh
@@ -75,7 +75,7 @@ PRD or feature: $ARGUMENTS
 **Output format:**
 ```markdown
 - [ ] 0.0 Create safe linked worktree for the feature
-  - [ ] 0.1 Create safe linked worktree and `cd` into the printed sibling path: `${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/{slug}`
+  - [ ] 0.1 Create safe linked worktree: `${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/{slug}`
 
 - [ ] 1.0 First major task
   - [ ] 1.1 Sub-task


### PR DESCRIPTION
## Summary

- Updated the generated `/generate-tasks` example to use the explicit deployed `worktree-helper.sh` path.
- Kept the checklist wording concise and aligned with the review feedback from PR #23365.

Resolves #23382

## Testing

- `shellcheck .agents/scripts/generate-opencode-commands-planning.sh`
- `bash -n .agents/scripts/generate-opencode-commands-planning.sh`
- `git diff --check`

## Runtime Testing

Not applicable: low-risk generated command text change; static shell validation covers the edited script.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 2m and 55,723 tokens on this with the user in an interactive session.
