### PR TITLE
GH#23383: clarify task worktree helper path

### DIFF
--- a/.agents/templates/tasks-template.md
+++ b/.agents/templates/tasks-template.md
@@ -40,7 +40,8 @@ Update after completing each sub-task, not just parent tasks.
 
 - [ ] 0.0 Create safe linked worktree for {Feature Name} ~5m (ai:5m)
   - [ ] 0.1 Fetch latest main for worktree base: `git fetch origin main`
-  - [ ] 0.2 Create safe linked worktree and `cd` into the printed sibling path: `${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/{slug}`
+  - [ ] 0.2 Create safe linked worktree: `${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/{slug}`
+  - [ ] 0.3 `cd` into the printed sibling path; this keeps edits off canonical `main`/`master` and preserves an auditable branch/worktree boundary.
 
 - [ ] 1.0 {First Parent Task} ~{Xh} (ai:{Xh} test:{Xh})
   - [ ] 1.1 {Sub-task description} ~{Xm}


### PR DESCRIPTION
## Summary

- Clarifies the task template worktree step so the robust `${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh` command stands alone.
- Adds the safety rationale for changing into the printed linked worktree path after creation.

## Testing

- `.agents/scripts/linters-local.sh`

## Runtime Testing

- self-assessed: documentation/template-only change.

Resolves #23383


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 4m and 39,897 tokens on this as a headless worker.
