### PR TITLE
GH#23371: skip protected conflicting PR close metadata fetch

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -805,6 +805,56 @@ _close_conflicting_pr_check_ownership_guard() {
 }
 
 #######################################
+# Fast pre-close guard for CONFLICTING PRs that are clearly protected.
+#
+# Uses the PR object already fetched by the merge pass, before the heavier
+# _close_conflicting_pr ownership metadata path. This avoids repeated noisy
+# metadata fetches for draft / interactive / contributor PRs that are never
+# eligible for auto-close.
+#
+# Args: $1=pr_number, $2=repo_slug, $3=pr_obj JSON from gh pr list
+# Returns:
+#   0 — caller must skip close-conflict handling
+#   1 — no protected signal found; caller may continue normal conflict flow
+#######################################
+_close_conflicting_pr_skip_protected_precheck() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_obj="${3:-}"
+
+	local labels_csv=""
+	local is_draft="false"
+	if [[ -n "$pr_obj" ]]; then
+		labels_csv=$(printf '%s' "$pr_obj" \
+			| jq -r '[.labels[]?.name] | join(",")' 2>/dev/null) || labels_csv=""
+		is_draft=$(printf '%s' "$pr_obj" \
+			| jq -r '(.isDraft // false | tostring)' 2>/dev/null) || is_draft="false"
+	fi
+
+	if [[ "$is_draft" == "true" ]]; then
+		echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — draft PR is protected before close-conflict metadata fetch (GH#23371)" >>"$LOGFILE"
+		return 0
+	fi
+
+	case ",${labels_csv}," in
+	*,origin:interactive,*)
+		echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — origin:interactive PR is protected before close-conflict metadata fetch (GH#23371)" >>"$LOGFILE"
+		return 0
+		;;
+	*,no-auto-dispatch,*)
+		echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — no-auto-dispatch PR is protected before close-conflict metadata fetch (GH#23371)" >>"$LOGFILE"
+		return 0
+		;;
+	*,external-contributor,*)
+		echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — external-contributor PR is protected before close-conflict metadata fetch (GH#23371)" >>"$LOGFILE"
+		return 0
+		;;
+	esac
+
+	return 1
+}
+
+#######################################
 # Gate 2 of _close_conflicting_pr: classify whether the work has
 # already landed on main.
 #

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -624,6 +624,15 @@ _process_single_ready_pr() {
 		fi
 
 		if [[ "$pr_mergeable" == "CONFLICTING" ]]; then
+			# GH#23371: some PRs are already known to be protected from
+			# automated close handling from the PR list metadata (draft,
+			# origin:interactive, no-auto-dispatch, external-contributor).
+			# Skip them before the close-conflict ownership guard so pulse
+			# does not repeatedly hit the noisy metadata-fetch path.
+			if _close_conflicting_pr_skip_protected_precheck "$pr_number" "$repo_slug" "$pr_obj"; then
+				return 1
+			fi
+
 			# Conflict resolution feedback: route worker PRs to fix worker
 			# (t2203: consolidated in helper). If routed, return 2 to skip
 			# the close path; otherwise fall through to _close_conflicting_pr.

--- a/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
+++ b/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
@@ -74,6 +74,7 @@ define_functions_under_test() {
 		/^_close_superseded_duplicate_issue_if_verified\(\) \{/,/^}$/ { print }
 		/^_find_task_id_match_on_main\(\) \{/,/^}$/ { print }
 		/^_close_conflicting_pr_check_ownership_guard\(\) \{/,/^}$/ { print }
+		/^_close_conflicting_pr_skip_protected_precheck\(\) \{/,/^}$/ { print }
 		/^_close_conflicting_pr_classify_landed\(\) \{/,/^}$/ { print }
 		/^_close_conflicting_pr_comment_landed\(\) \{/,/^}$/ { print }
 		/^_close_conflicting_pr_comment_not_landed\(\) \{/,/^}$/ { print }
@@ -242,6 +243,20 @@ test_label_lookup_failure_skips_issue_closure() {
 	return 0
 }
 
+test_protected_precheck_skips_draft_interactive_without_metadata_fetch() {
+	reset_case
+	local pr_obj
+	pr_obj='{"number":4265,"isDraft":true,"labels":[{"name":"origin:interactive"},{"name":"no-auto-dispatch"}]}'
+	if _close_conflicting_pr_skip_protected_precheck "4265" "awardsapp/awardsapp" "$pr_obj"; then
+		pass "protected draft interactive PR precheck skips close"
+	else
+		fail "protected draft interactive PR precheck skips close" "Expected precheck to return 0 for draft origin:interactive no-auto-dispatch PR"
+	fi
+	assert_log_not_contains "$GH_CALL_LOG" "pr view 4265" "protected precheck uses existing PR object without gh metadata fetch"
+	assert_log_not_contains "$LOGFILE" "failed to fetch metadata" "protected precheck avoids noisy metadata-fetch failure log"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -254,6 +269,7 @@ main() {
 	test_ambiguous_same_file_change_routes_worker
 	test_parent_research_comment_avoids_closing_keywords
 	test_label_lookup_failure_skips_issue_closure
+	test_protected_precheck_skips_draft_interactive_without_metadata_fetch
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -303,6 +303,7 @@ test_resolve_mergeable_retries_empty_and_logs_empty() {
 #   2. `_attempt_pr_update_branch` is called from the CONFLICTING branch
 #      before close.
 #   3. After update-branch, mergeable state is re-fetched.
+#   4. Protected PRs are skipped before _close_conflicting_pr.
 # ---------------------------------------------------------------
 
 test_nmr_guard_exists_before_close() {
@@ -357,6 +358,36 @@ test_nmr_guard_exists_before_close() {
 	return 0
 }
 
+test_protected_precheck_exists_before_close() {
+	local block
+	block=$(awk '
+		/^_process_single_ready_pr\(\) \{/ { in_fn=1 }
+		in_fn && /_attempt_pr_update_branch/ { capturing=1 }
+		capturing { print }
+		capturing && /^[[:space:]]*_close_conflicting_pr "/ { exit }
+	' "$MERGE_SCRIPT")
+
+	local precheck_pos close_pos route_pos
+	precheck_pos=$(printf '%s\n' "$block" | awk '/_close_conflicting_pr_skip_protected_precheck/ { print NR; exit }')
+	close_pos=$(printf '%s\n' "$block" | awk '/^[[:space:]]*_close_conflicting_pr "/ { print NR; exit }')
+	route_pos=$(printf '%s\n' "$block" | awk '/_route_pr_to_fix_worker/ { print NR; exit }')
+
+	if [[ -z "$precheck_pos" || -z "$close_pos" || -z "$route_pos" ]]; then
+		print_result "protected PR precheck runs before close-conflict metadata" 1 \
+			"Expected precheck, route, and close calls in CONFLICTING block (precheck=${precheck_pos}, route=${route_pos}, close=${close_pos})"
+		return 0
+	fi
+
+	if [[ "$precheck_pos" -ge "$route_pos" || "$precheck_pos" -ge "$close_pos" ]]; then
+		print_result "protected PR precheck runs before close-conflict metadata" 1 \
+			"Precheck must appear before route and close (precheck=${precheck_pos}, route=${route_pos}, close=${close_pos})"
+		return 0
+	fi
+
+	print_result "protected PR precheck runs before close-conflict metadata" 0
+	return 0
+}
+
 test_mergeable_refetch_after_update_branch() {
 	# After update-branch succeeds the code must re-read pr_mergeable
 	# via another `gh pr view --json mergeable` call, otherwise the
@@ -393,6 +424,7 @@ main() {
 	test_resolve_mergeable_retries_boolean_true
 	test_resolve_mergeable_retries_empty_and_logs_empty
 	test_nmr_guard_exists_before_close
+	test_protected_precheck_exists_before_close
 	test_mergeable_refetch_after_update_branch
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Added a PR-list metadata precheck so draft, origin:interactive, no-auto-dispatch, and external-contributor conflicting PRs skip close-conflict handling before the heavier ownership metadata path.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh,.agents/scripts/tests/test-pulse-merge-update-branch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-update-branch.sh; bash .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-conflict.sh .agents/scripts/tests/test-pulse-merge-update-branch.sh .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

Resolves #23371


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 112,541 tokens on this as a headless worker.