### PR TITLE
GH#23370: isolate pulse dashboards by operator label

### DIFF
--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -63,7 +63,9 @@ _list_health_issues_by_role_label() {
 #######################################
 # List open health issues that belong to one canonical dashboard identity.
 # Matches the new canonical operator label, historical alias labels, and
-# historical [Supervisor:alias]/[Contributor:alias] title prefixes.
+# historical [Supervisor:alias]/[Contributor:alias] title prefixes. Existing
+# operator:* labels are authoritative, so dashboards labelled for another
+# canonical operator are excluded even when an old title prefix matches.
 # Arguments:
 #   $1 - repo slug
 #   $2 - canonical identity
@@ -92,16 +94,38 @@ _list_health_issues_by_canonical_identity() {
 		'[
 			.[]
 			| . as $issue
-			| ((.labels // []) | map(.name) | any(. == $canonical_label or ($aliases | index(.)))) as $label_match
+			| ((.labels // []) | map(.name)) as $label_names
+			| ($label_names | map(select(startswith("operator:")))) as $operator_labels
+			| ($operator_labels | length == 0 or any(. == $canonical_label)) as $operator_label_allowed
+			| ($label_names | any(. == $canonical_label or ($aliases | index(.)))) as $label_match
 			| ((.title | capture("^\\[(Supervisor|Contributor):(?<user>[^]]+)\\]")? | .user // "") as $title_user
 				| ($title_user != "" and ($aliases | index($title_user)))) as $title_match
-			| select($label_match or $title_match)
+			| select($operator_label_allowed and ($label_match or $title_match))
 		] | sort_by(.number) | reverse'
 	return 0
 }
 
 #######################################
-# Validate a cached health-issue number: check it still exists and is OPEN.
+# Return success when issue metadata has no operator label for another identity.
+# Arguments:
+#   $1 - issue JSON with labels
+#   $2 - canonical identity
+#######################################
+_health_issue_operator_label_allows_identity() {
+	local issue_json="$1"
+	local canonical_identity="$2"
+	local canonical_label="operator:${canonical_identity}"
+
+	printf '%s' "${issue_json:-{}}" | jq -e --arg canonical_label "$canonical_label" '
+		((.labels // []) | map(.name) | map(select(startswith("operator:")))) as $operator_labels
+		| ($operator_labels | length == 0 or any(. == $canonical_label))
+	' >/dev/null 2>&1
+	return $?
+}
+
+#######################################
+# Validate a cached health-issue number: check it still exists, is OPEN, and
+# is not labelled for a different canonical operator.
 # Returns (via stdout):
 #   - the cached number if still valid
 #   - empty if the cache entry points to a CLOSED issue (caller should re-resolve)
@@ -112,6 +136,7 @@ _try_cached_health_issue_lookup() {
 	local health_issue_file="$1"
 	local repo_slug="$2"
 	local runner_role="$3"
+	local canonical_identity="${4:-}"
 
 	[[ ! -f "$health_issue_file" ]] && return 0  # empty stdout
 
@@ -124,8 +149,8 @@ _try_cached_health_issue_lookup() {
 		return 0
 	fi
 
-	local issue_state rc=0
-	issue_state=$(gh_issue_view "$cached_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null) || rc=$?
+	local issue_json issue_state rc=0
+	issue_json=$(gh_issue_view "$cached_number" --repo "$repo_slug" --json state,labels 2>/dev/null) || rc=$?
 
 	if [[ $rc -ne 0 ]]; then
 		# Query failed (rate limit, network, API 5xx). Preserve cache and return
@@ -134,6 +159,8 @@ _try_cached_health_issue_lookup() {
 		echo "$cached_number"
 		return 0
 	fi
+
+	issue_state=$(printf '%s' "${issue_json:-{}}" | jq -r '.state // empty' 2>/dev/null || echo "")
 
 	# gh issue view has returned both GraphQL-style uppercase enums (OPEN/CLOSED)
 	# and REST-style lowercase values (open/closed) depending on fallback path.
@@ -156,6 +183,12 @@ _try_cached_health_issue_lookup() {
 		# Unexpected state (empty, unknown enum). Preserve cache defensively.
 		echo "[stats] Health issue: unexpected state '${issue_state}' for #${cached_number} in ${repo_slug} — preserving cache" >>"${LOGFILE:-/dev/null}"
 		echo "$cached_number"
+		return 0
+	fi
+
+	if [[ -n "$canonical_identity" ]] && ! _health_issue_operator_label_allows_identity "$issue_json" "$canonical_identity"; then
+		echo "[stats] Health issue: ignoring cached issue #${cached_number} for ${canonical_identity} in ${repo_slug} because it has a conflicting operator label" >>"${LOGFILE:-/dev/null}"
+		rm -f "$health_issue_file" 2>/dev/null || true
 		return 0
 	fi
 
@@ -263,16 +296,20 @@ _close_health_issue_identity_duplicates() {
 }
 
 #######################################
-# Title-based fallback lookup with label backfill.
+# Title-based fallback lookup with label backfill. Preserves migration for
+# legacy dashboards without operator:* labels, but refuses dashboards already
+# labelled for another canonical operator.
 # Returns issue number if found, empty if not, $_HEALTH_QUERY_FAILED_SENTINEL on failure.
 _try_title_health_issue_fallback() {
 	local runner_prefix="$1" repo_slug="$2" runner_user="$3" role_label="$4" role_display="$5"
+	local canonical_identity="${6:-$runner_user}"
+	local canonical_label="operator:${canonical_identity}"
 
 	local title_result rc=0
 	title_result=$(gh_issue_list --repo "$repo_slug" \
 		--search "in:title ${runner_prefix}" \
-		--state open --json number,title \
-		--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null) || rc=$?
+		--state open --json number,title,labels \
+		--jq "[.[] | select(.title | startswith(\"${runner_prefix}\")) | select(((.labels // []) | map(.name) | map(select(startswith(\"operator:\")))) as \$operator_labels | (\$operator_labels | length == 0 or any(. == \"${canonical_label}\")))][0].number" 2>/dev/null) || rc=$?
 
 	if [[ $rc -ne 0 ]]; then
 		echo "[stats] Health issue: title lookup failed for ${runner_prefix} in ${repo_slug} (rc=${rc}) — abstaining this cycle" >>"${LOGFILE:-/dev/null}"
@@ -304,7 +341,8 @@ _find_health_issue() {
 	local identity_aliases="${9:-$runner_user}"
 
 	local health_issue_number
-	health_issue_number=$(_try_cached_health_issue_lookup "$health_issue_file" "$repo_slug" "$runner_role")
+	health_issue_number=$(_try_cached_health_issue_lookup \
+		"$health_issue_file" "$repo_slug" "$runner_role" "$canonical_identity")
 
 	# Sentinel from cache lookup is defensive only; current behaviour preserves
 	# the cached number on error, but downstream checks still need it to pass
@@ -351,7 +389,8 @@ _find_health_issue() {
 	# Fallback: title-based search with label backfill.
 	if [[ -z "$health_issue_number" ]]; then
 		health_issue_number=$(_try_title_health_issue_fallback \
-			"$runner_prefix" "$repo_slug" "$runner_user" "$role_label" "$role_display")
+			"$runner_prefix" "$repo_slug" "$runner_user" "$role_label" "$role_display" \
+			"$canonical_identity")
 	fi
 
 	echo "$health_issue_number"

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -31,8 +31,24 @@ GH_CALLS="${TMP}/gh-calls.log"
 gh() {
 	local call="$*"
 	printf '%s\n' "$call" >>"$GH_CALLS"
-	case "$call" in
-		*"issue list --repo owner/repo --label source:health-dashboard"*)
+	case "${HEALTH_FIXTURE:-}:$call" in
+		conflicting_operator:*"issue list --repo owner/repo --label source:health-dashboard"*)
+			printf '%s' '[{"number":4643,"title":"[Supervisor:marcusquinn] stale dashboard","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"},{"name":"alex-solovyev"},{"name":"supervisor"}]}]'
+			return 0
+			;;
+		conflicting_operator:*"issue list --repo owner/repo --search in:title [Supervisor:marcusquinn]"*)
+			printf '%s' '[{"number":4643,"title":"[Supervisor:marcusquinn] stale dashboard","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"},{"name":"alex-solovyev"},{"name":"supervisor"}]}]'
+			return 0
+			;;
+		legacy_title:*"issue list --repo owner/repo --label source:health-dashboard"*)
+			printf '%s' '[{"number":555,"title":"[Supervisor:github-user] legacy dashboard","labels":[{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"}]}]'
+			return 0
+			;;
+		cache_conflict:*"issue view 4643 --repo owner/repo --json state,labels"*)
+			printf '%s' '{"state":"OPEN","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"}]}'
+			return 0
+			;;
+		:*"issue list --repo owner/repo --label source:health-dashboard"*)
 			printf '%s' '[{"number":20408,"title":"[Supervisor:github-user] 1 PR at 10:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"}],"createdAt":"2026-05-01T10:00:00Z"},{"number":18669,"title":"[Contributor:local-user] 0 PRs at 09:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"contributor"},{"name":"local-user"}],"createdAt":"2026-04-01T09:00:00Z"}]'
 			return 0
 			;;
@@ -132,6 +148,50 @@ if [[ "$extracted" == "20408" ]]; then
 	pass "extracts one issue number from noisy wrapper output"
 else
 	fail "extracts one issue number from noisy wrapper output" "extracted=${extracted}"
+fi
+
+: >"$GH_CALLS"
+export HEALTH_FIXTURE=conflicting_operator
+result=$(_find_health_issue \
+	"owner/repo" "marcusquinn" "supervisor" "[Supervisor:marcusquinn]" \
+	"supervisor" "Supervisor" "${HOME}/.aidevops/logs/health-issue-marcusquinn-owner-repo" \
+	"marcusquinn" "marcusquinn")
+unset HEALTH_FIXTURE
+
+if [[ -z "$result" ]]; then
+	pass "does not reuse dashboard with conflicting operator label despite matching title"
+else
+	fail "does not reuse dashboard with conflicting operator label despite matching title" "result=${result}; calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+: >"$GH_CALLS"
+export HEALTH_FIXTURE=legacy_title
+result=$(_find_health_issue \
+	"owner/repo" "github-user" "supervisor" "[Supervisor:canonical-operator]" \
+	"supervisor" "Supervisor" "${HOME}/.aidevops/logs/health-issue-legacy-owner-repo" \
+	"canonical-operator" "$aliases")
+unset HEALTH_FIXTURE
+
+if [[ "$result" == "555" ]]; then
+	pass "keeps legacy title migration when no operator label exists"
+else
+	fail "keeps legacy title migration when no operator label exists" "result=${result}; calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+cache_file="${HOME}/.aidevops/logs/health-issue-cache-conflict-owner-repo"
+printf '%s\n' '4643' >"$cache_file"
+: >"$GH_CALLS"
+export HEALTH_FIXTURE=cache_conflict
+result=$(_find_health_issue \
+	"owner/repo" "marcusquinn" "supervisor" "[Supervisor:marcusquinn]" \
+	"supervisor" "Supervisor" "$cache_file" \
+	"marcusquinn" "marcusquinn")
+unset HEALTH_FIXTURE
+
+if [[ -z "$result" && ! -f "$cache_file" ]]; then
+	pass "drops cached dashboard with conflicting operator label"
+else
+	fail "drops cached dashboard with conflicting operator label" "result=${result}; cache_exists=$([[ -f "$cache_file" ]] && printf yes || printf no); calls=$(tr '\n' ';' <"$GH_CALLS")"
 fi
 
 body=$(_build_health_issue_body \


### PR DESCRIPTION
## Summary

Made operator:* labels authoritative during health dashboard identity lookup, cache validation, and title fallback so one operator cannot update another operator's dashboard.

## Files Changed

.agents/scripts/stats-health-dashboard-issue.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; shellcheck .agents/scripts/stats-health-dashboard-issue.sh .agents/scripts/stats-health-dashboard.sh .agents/scripts/stats-shared.sh

Resolves #23370


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 74,166 tokens on this as a headless worker.