### PR TITLE
GH#23399: fix: harden skills helper count cleanup

### DIFF
--- a/.agents/scripts/skills-helper.sh
+++ b/.agents/scripts/skills-helper.sh
@@ -92,10 +92,20 @@ _push_temp_file_cleanup() {
 
 _read_count_file_and_remove() {
 	local count_path="$1"
-	local found
+	local precomputed="${2:-}"
+	local found=""
 
-	found=$(<"$count_path")
-	rm -f "$count_path"
+	if [[ -n "$precomputed" ]]; then
+		found="$precomputed"
+		if [[ -n "$count_path" && -f "$count_path" ]]; then
+			rm -f "$count_path"
+		fi
+	elif [[ -f "$count_path" ]]; then
+		found=$(<"$count_path")
+		rm -f "$count_path"
+	fi
+
+	[[ "$found" =~ ^[0-9]+$ ]] || found=0
 	printf '%s\n' "$found"
 	return 0
 }
@@ -790,7 +800,7 @@ cmd_search() {
 		local scan_result
 		scan_result=$(_search_local_skills "$query_lower" "$json_output")
 		local found results_json
-		found="${scan_result%%	*}"
+		found=$(_read_count_file_and_remove "" "${scan_result%%	*}")
 		results_json="${scan_result#*	}"
 		echo "{\"query\":\"${query//\"/\\\"}\",\"count\":$found,\"results\":[$results_json]}"
 	else
@@ -800,7 +810,6 @@ cmd_search() {
 		echo ""
 		_search_local_skills "$query_lower" "$json_output" "$count_file" "50"
 		found=$(_read_count_file_and_remove "$count_file")
-		[[ "$found" =~ ^[0-9]+$ ]] || found=0
 		if [[ "$found" -eq 0 ]]; then
 			log_warning "No local skills found matching '$query'"
 			echo ""
@@ -844,7 +853,6 @@ cmd_browse() {
 	_push_temp_file_cleanup "$count_file"
 	_list_skills_in_category "$category" "$count_file"
 	found=$(_read_count_file_and_remove "$count_file")
-	[[ "$found" =~ ^[0-9]+$ ]] || found=0
 
 	echo ""
 	if [[ "$found" -eq 0 ]]; then
@@ -1182,7 +1190,6 @@ cmd_recommend() {
 		_push_temp_file_cleanup "$count_file"
 		_list_skills_in_category "$cat" "$count_file" "12"
 		found_in_cat=$(_read_count_file_and_remove "$count_file")
-		[[ "$found_in_cat" =~ ^[0-9]+$ ]] || found_in_cat=0
 		total_found=$((total_found + found_in_cat))
 
 		if [[ "$found_in_cat" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Centralized skills helper count validation/removal in _read_count_file_and_remove and removed duplicated call-site validation.

## Files Changed

.agents/scripts/skills-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/skills-helper.sh; skills-helper.sh search git --json with python3 -m json.tool; skills-helper.sh search git; skills-helper.sh browse tools/git; skills-helper.sh recommend 'github pull request'

Resolves #23399


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 8m and 113,840 tokens on this as a headless worker.