### PR TITLE
GH#23386: clarify hotfix rollback worktree base

### DIFF
--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -63,8 +63,9 @@ git push origin main && git push origin --tags
 ```bash
 git log --oneline -10
 git diff v{PREVIOUS} v{CURRENT}
-${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{NEW_PATCH}
-# Then cd into the sibling worktree path printed by the helper before editing.
+${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{NEW_PATCH} --base v{CURRENT}
+# Critical: cd into the sibling worktree path printed by the helper before editing;
+# otherwise commits land in the canonical checkout and can disrupt active agents.
 # Fix, then:
 git commit -m "fix: resolve critical issue"
 # or: git revert --no-commit <commit-hash> && git commit -m "revert: rollback v{CURRENT}"


### PR DESCRIPTION
## Summary

Updated the release rollback workflow to create hotfix worktrees from the current release tag and warn maintainers to change into the linked worktree before editing.

## Files Changed

.agents/workflows/release.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh

Resolves #23386


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 6m and 67,386 tokens on this as a headless worker.