### PR TITLE
GH#23379: fix pulse dispatch rc write handling

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -104,7 +104,7 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		dedup_active_claim | interactive_review_hold | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
+		dedup_active_claim | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
 			;;
 		*)
 			reason="unclassified_signal"
@@ -194,7 +194,10 @@ _dispatch_stage_rc_adapter() {
 
 	local raw_rc=0
 	"$@" || raw_rc=$?
-	printf '%s\n' "$raw_rc" >"$rc_file" 2>/dev/null || true
+	if ! printf '%s\n' "$raw_rc" >"$rc_file"; then
+		printf 'Failed to write dispatch rc to %s\n' "$rc_file" >&2
+		return "$raw_rc"
+	fi
 	if [[ "$raw_rc" -eq 3 ]]; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -162,6 +162,19 @@ assert_grep \
 	'benign dispatch block reason=interactive_review_hold' \
 	"$DISPATCH_LIB"
 
+assert_grep \
+	"10c: dispatch stage adapter reports rc-file write failures" \
+	'Failed to write dispatch rc to' \
+	"$DISPATCH_LIB"
+assert_grep \
+	"10d: dispatch stage adapter propagates raw rc after rc-file write failure" \
+	'return "\$raw_rc"' \
+	"$DISPATCH_LIB"
+assert_not_grep \
+	"10e: interactive review hold is not counted as a candidate failure reason" \
+	'dedup_active_claim \| interactive_review_hold \|' \
+	"$DISPATCH_LIB"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

Updated the dispatch stage adapter so rc-file write failures are visible and return the raw dispatch rc, and removed unreachable interactive-review-hold failure telemetry classification.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

Resolves #23379


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 78,740 tokens on this with the user in an interactive session.