### PR TITLE
GH#23387: refine Swift Xcode discovery patterns

### DIFF
--- a/.agents/tools/mobile/swift-xcode-agent-workflow.md
+++ b/.agents/tools/mobile/swift-xcode-agent-workflow.md
@@ -32,10 +32,12 @@ tools:
 
 ## Prework Discovery
 
-Before edits, discover the actual project shape rather than guessing:
+Before edits, discover the actual project shape rather than guessing. Use recursive
+Xcode project/workspace patterns so nested iOS/macOS modules are visible in
+monorepos and sample app directories:
 
 ```bash
-git ls-files 'Package.swift' '*.xcodeproj/project.pbxproj' '*.xcworkspace/contents.xcworkspacedata' '**/*.xcworkspace/contents.xcworkspacedata' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
+git ls-files 'Package.swift' '**/*.xcodeproj/project.pbxproj' '**/*.xcworkspace/contents.xcworkspacedata' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
 xcodebuild -version
 xcode-select -p
 swift --version


### PR DESCRIPTION
## Summary

Updated the Swift/Xcode workflow discovery command to use recursive Xcode project and workspace patterns while documenting why recursive discovery matters for nested modules.

## Files Changed

.agents/tools/mobile/swift-xcode-agent-workflow.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh (passed; advisory historical warnings only)

Resolves #23387


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 6m and 41,965 tokens on this with the user in an interactive session.