### PR TITLE
GH#23398: refine Swift Xcode workflow discovery

### DIFF
--- a/.agents/tools/mobile/swift-xcode-agent-workflow.md
+++ b/.agents/tools/mobile/swift-xcode-agent-workflow.md
@@ -32,17 +32,17 @@ tools:
 
 ## Prework Discovery
 
-Before edits, discover the actual project shape rather than guessing:
+Before edits, discover the actual project shape rather than guessing. Use recursive pathspecs so monorepos and cross-platform apps with nested Apple targets are detected:
 
 ```bash
-git ls-files 'Package.swift' '*.xcodeproj/project.pbxproj' '*.xcworkspace/contents.xcworkspacedata' '**/*.xcworkspace/contents.xcworkspacedata' 'Makefile' 'Package.resolved' 'Podfile' 'Project.swift' 'project.yml'
+git ls-files '**/Package.swift' '**/*.xcodeproj/project.pbxproj' '**/*.xcworkspace/contents.xcworkspacedata' '**/Makefile' '**/Package.resolved' '**/Podfile' '**/Project.swift' '**/project.yml'
 xcodebuild -version
 xcode-select -p
 swift --version
 xcrun simctl list devices available
 ```
 
-Then list schemes with the right container:
+Then list schemes with the right container, quoting placeholders because Xcode project and workspace names commonly contain spaces:
 
 ```bash
 xcodebuild -list -json -workspace "<workspace_name>.xcworkspace"


### PR DESCRIPTION
## Summary

Updated the Swift/Xcode workflow documentation to use recursive project-discovery pathspecs and document why Xcode project/workspace placeholders stay quoted.

## Files Changed

.agents/tools/mobile/swift-xcode-agent-workflow.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/tools/mobile/swift-xcode-agent-workflow.md

Resolves #23398


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 38,653 tokens on this as a headless worker.