### PR TITLE
GH#23396: isolate function spacing test output

### DIFF
--- a/.agents/scripts/tests/test-linters-local-complexity-gates.sh
+++ b/.agents/scripts/tests/test-linters-local-complexity-gates.sh
@@ -184,7 +184,7 @@ test_function_brace_spacing_change_is_not_regression() {
 	(
 		cd "$TEST_ROOT" || exit 1
 		ALL_SH_FILES=(a.sh)
-		check_function_complexity >/tmp/linters-local-function-spacing.out 2>&1
+		check_function_complexity >"${TEST_ROOT}/linters-local-function-spacing.out" 2>&1
 	) || rc=$?
 	if [[ "$rc" -eq 0 ]]; then
 		print_result "function brace spacing change is not regression" 0


### PR DESCRIPTION
## Summary
- Moves the function-spacing complexity test output into the per-test `TEST_ROOT` workspace to avoid shared `/tmp` filename collisions.

## Verification
- `bash .agents/scripts/tests/test-linters-local-complexity-gates.sh`
- `shellcheck .agents/scripts/tests/test-linters-local-complexity-gates.sh`

Resolves #23396

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 49,419 tokens on this as a headless worker.
