### PR TITLE
GH#23397: refine Swift workflow discovery patterns

### DIFF
--- a/.agents/tools/mobile/swift-xcode-agent-workflow.md
+++ b/.agents/tools/mobile/swift-xcode-agent-workflow.md
@@ -42,6 +42,8 @@ swift --version
 xcrun simctl list devices available
 ```
 
+The recursive `**/` pathspecs intentionally cover root-level and nested files with one pattern per project artifact, avoiding duplicate workspace matches while keeping project and workspace discovery consistent.
+
 Then list schemes with the right container, quoting placeholders because Xcode project and workspace names commonly contain spaces:
 
 ```bash


### PR DESCRIPTION
## Summary

Updated the Swift Xcode workflow discovery guidance to explain the recursive pathspecs that remove redundant workspace matching while keeping nested project and workspace discovery consistent.

## Files Changed

.agents/tools/mobile/swift-xcode-agent-workflow.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint/local lint command completed successfully for .agents/tools/mobile/swift-xcode-agent-workflow.md

Resolves #23397


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 44,829 tokens on this as a headless worker.