### PR TITLE
GH#23394: fix: normalize OpenCode memory recall limit

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs
@@ -96,6 +96,28 @@ describe("aidevops_memory execution", () => {
     assert.match(calls[0], /memory-helper\.sh" recall 'schema' --limit '5'$/);
   });
 
+  test("recall action defaults blank limit values", async () => {
+    for (const limitValue of [null, "", "   "]) {
+      const calls = [];
+      const result = await withMemoryHelper(async (scriptsDir) => {
+        const tools = createTools(scriptsDir, (cmd) => {
+          calls.push(cmd);
+          return "recalled";
+        });
+
+        return tools.aidevops_memory.execute({
+          action: "recall",
+          query: "schema",
+          limit: limitValue,
+        });
+      });
+
+      assert.equal(result, "recalled");
+      assert.equal(calls.length, 1);
+      assert.match(calls[0], /memory-helper\.sh" recall 'schema' --limit '5'$/);
+    }
+  });
+
   test("recall action without a query returns a validation error", async () => {
     const calls = [];
     const result = await withMemoryHelper(async (scriptsDir) => {

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -143,7 +143,7 @@ function createMemoryTool(scriptsDir, run) {
 
       if (action === "recall") {
         const query = args.query.trim();
-        const limit = args.limit === undefined ? "5" : String(args.limit);
+        const limit = String(args.limit ?? "5").trim() || "5";
         const cmd = `bash "${memoryHelper}" recall ${shellEscape(query)} --limit ${shellEscape(limit)}`;
         const result = run(cmd, 10000);
         return result || "No memories found for this query.";


### PR DESCRIPTION
## Summary

Normalized aidevops_memory recall limit handling so null, empty, and whitespace values fall back to the default limit instead of reaching memory-helper.sh as literal invalid values. Added regression coverage for null and blank limits.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs,.agents/plugins/opencode-aidevops/tools.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run typecheck; node --test .agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs

Resolves #23394


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 9m and 79,219 tokens on this as a headless worker.