### PR TITLE
GH#23395: clarify hotfix worktree safety

### DIFF
--- a/.agents/workflows/bug-fixing.md
+++ b/.agents/workflows/bug-fixing.md
@@ -79,7 +79,8 @@ For bugs requiring immediate release, create a safe linked worktree from the lat
 ```bash
 git tag -l "v*" --sort=-v:refname
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{VERSION} --base v{LATEST_TAG}
-# Then cd into the sibling worktree path printed by the helper before editing.
+# Critical: cd into the sibling worktree path printed by the helper before editing;
+# otherwise commits land in the canonical checkout and can disrupt active agents.
 # Apply minimal fix, bump PATCH, commit, tag, push
 # Merge back to main after release
 ```

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -27,10 +27,10 @@ tools:
 **Pre-Edit Gate** (MANDATORY before ANY file edit/write/create):
 
 ```bash
-git status --short --branch  # If this is the canonical `main` checkout → STOP
+${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/pre-edit-check.sh  # Verifies branch and canonical-checkout safety
 ```
 
-If in the canonical `main` checkout: STOP and create a safe linked worktree for the task before editing. Exception: proceed for an approved release/version-manager command after verifying the working tree is clean and up to date with `origin/main`.
+If the gate reports the canonical `main` checkout: STOP and create a safe linked worktree for the task before editing. This technical gate checks both branch and worktree location; `git status` alone cannot prove the checkout is the canonical repo versus a linked worktree. Exception: proceed for an approved release/version-manager command after verifying the working tree is clean and up to date with `origin/main`.
 
 **First Actions** (before any code changes):
 

--- a/.agents/workflows/postflight.md
+++ b/.agents/workflows/postflight.md
@@ -99,8 +99,9 @@ git revert <release-commit-hash> && git push origin main
 # Option B: Delete tag+release (if not widely distributed)
 gh release delete v{VERSION} --yes && git tag -d v{VERSION} && git push origin --delete v{VERSION}
 # Option C: Hotfix release from a safe linked worktree
-${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{VERSION}.1
-# Then cd into the sibling worktree path printed by the helper before editing.
+${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{VERSION}.1 --base v{VERSION}
+# Critical: cd into the sibling worktree path printed by the helper before editing;
+# otherwise commits land in the canonical checkout and can disrupt active agents.
 git commit -m "fix: resolve critical issue" && ./.agents/scripts/version-manager.sh release patch
 ```
 


### PR DESCRIPTION
## Summary

Clarified hotfix rollback guidance to include explicit worktree cd warnings, correct hotfix base tag usage, and pre-edit-check as the mandatory safety gate.

## Files Changed

.agents/workflows/bug-fixing.md,.agents/workflows/git-workflow.md,.agents/workflows/postflight.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint .agents/workflows/bug-fixing.md .agents/workflows/git-workflow.md .agents/workflows/postflight.md .agents/workflows/release.md passed; .agents/scripts/linters-local.sh reached Secretlint then exceeded 240s watchdog-safe timeout after earlier gates passed

Resolves #23395


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 11m and 34,361 tokens on this as a headless worker.