### PR TITLE
GH#23419: classify PR dispatch targets as benign

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1720,6 +1720,10 @@ classify_dispatch_blocker_reason() {
 			printf 'interactive_review_hold\n'
 			return 0
 			;;
+		*pr_target_not_dispatchable* | *pull*request*not*a*dispatchable*issue* | *target*is*a*pull*request*)
+			printf 'pr_target_not_dispatchable\n'
+			return 0
+			;;
 		*cost_budget_exceeded*)
 			printf 'cost_budget_exceeded\n'
 			return 0

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1512,7 +1512,8 @@ dispatch_with_dedup() {
 	_dispatch_target_is_pull_request "$issue_number" "$repo_slug" || _target_pr_rc=$?
 	if [[ "$_target_pr_rc" -eq 0 ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: target is a pull request, not a dispatchable issue (GH#22948)" >>"$LOGFILE"
-		return 1
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=pr_target_not_dispatchable signal=pr_target_not_dispatchable issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+		return 3
 	fi
 	if [[ "$_target_pr_rc" -ne 1 ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to verify target is not a pull request (GH#22948, rc=${_target_pr_rc})" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -179,6 +179,25 @@ _dispatch_candidate_failure_reason() {
 }
 
 #######################################
+# Return success when a dispatch candidate reason is an expected benign block.
+#
+# Arguments:
+#   $1 - low-cardinality reason token
+# Returns:
+#   0 - benign block reason
+#   1 - not a benign block reason
+#######################################
+_dispatch_candidate_benign_block_reason() {
+	local reason="$1"
+	case "$reason" in
+		interactive_review_hold | pr_target_not_dispatchable)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+#######################################
 # Run a dispatch candidate under the stage watchdog while preserving benign
 # block return codes without emitting generic Stage failed noise.
 #
@@ -1029,9 +1048,9 @@ _dispatch_record_nonzero_dispatch_result() {
 
 	local failure_reason
 	failure_reason=$(_dispatch_candidate_failure_reason "$issue_number" "$repo_slug" "$dispatch_rc")
-	if [[ "$failure_reason" == "interactive_review_hold" ]]; then
-		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) benign dispatch block reason=interactive_review_hold" >>"$LOGFILE"
-		_dispatch_stats_increment "dispatch_candidate_blocked_interactive_review_hold"
+	if _dispatch_candidate_benign_block_reason "$failure_reason"; then
+		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) benign dispatch block reason=${failure_reason}" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_blocked_${failure_reason}"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -22,6 +22,7 @@ assert_reason() {
 assert_reason 'COST_BUDGET_EXCEEDED (spent=123 budget=100)' 'cost_budget_exceeded'
 assert_reason 'DISPATCH_BLOCK_REASON reason=dedup_active_claim signal=assigned to runner' 'dedup_active_claim'
 assert_reason 'DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive review hold label present' 'interactive_review_hold'
+assert_reason 'Dispatch blocked for #4849 in awardsapp/awardsapp: target is a pull request, not a dispatchable issue (GH#22948)' 'pr_target_not_dispatchable'
 assert_reason 'GraphQL budget below circuit-breaker threshold' 'graphql_circuit_breaker'
 assert_reason 'DISPATCH_COOLDOWN_ACTIVE until=2026-05-02T23:00:00Z reason=no_worker_process' 'cooldown_no_worker_process'
 assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — requires cryptographic approval (ever-NMR)' 'ever_nmr_without_approval'

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -176,6 +176,19 @@ test_interactive_hold_reason_is_classified() {
 	return 0
 }
 
+test_pr_target_reason_is_classified_as_benign_block() {
+	reset_guardrail_env
+	printf '%s\n' '[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=pr_target_not_dispatchable signal=pr_target_not_dispatchable issue=#4849 repo=awardsapp/awardsapp' >>"$LOGFILE"
+	local reason
+	reason=$(_dispatch_candidate_failure_reason 4849 awardsapp/awardsapp 3)
+	if [[ "$reason" == "pr_target_not_dispatchable" ]] && _dispatch_candidate_benign_block_reason "$reason"; then
+		print_result "guardrail: PR target classifies as benign block" 0
+	else
+		print_result "guardrail: PR target classifies as benign block" 1 "reason=${reason}"
+	fi
+	return 0
+}
+
 test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
@@ -184,6 +197,7 @@ test_no_dispatchable_evidence_pauses_refill_loop
 test_clean_state_preserves_available_slots
 test_disabled_guardrail_still_updates_available_slots_gauge
 test_interactive_hold_reason_is_classified
+test_pr_target_reason_is_classified_as_benign_block
 
 printf '\n====================\n'
 printf 'Tests run: %s\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -154,6 +154,15 @@ test_interactive_hold_emits_structured_block_reason() {
 	return 0
 }
 
+test_pr_guard_emits_structured_block_reason() {
+	if grep -q 'DISPATCH_BLOCK_REASON reason=pr_target_not_dispatchable' "$CORE_SCRIPT" && grep -q 'target is a pull request, not a dispatchable issue' "$CORE_SCRIPT"; then
+		print_result "PR target guard emits structured benign block reason" 0
+		return 0
+	fi
+	print_result "PR target guard emits structured benign block reason" 1 "expected PR target structured reason in dispatch core"
+	return 0
+}
+
 main() {
 	if ! define_helpers_under_test; then
 		return 1
@@ -166,6 +175,7 @@ main() {
 	test_interactive_hold_allows_auto_dispatch_handoff
 	test_interactive_hold_allows_worker_issue
 	test_interactive_hold_emits_structured_block_reason
+	test_pr_guard_emits_structured_block_reason
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -158,8 +158,12 @@ assert_grep \
 	'_dispatch_stage_rc_adapter' \
 	"$DISPATCH_LIB"
 assert_grep \
-	"10b: interactive review hold is logged as benign block, not pre-launch failure" \
-	'benign dispatch block reason=interactive_review_hold' \
+	"10b: interactive review hold is recognized as a benign block" \
+	'interactive_review_hold \| pr_target_not_dispatchable' \
+	"$DISPATCH_LIB"
+assert_grep \
+	"10b2: PR target is logged as benign block, not pre-launch failure" \
+	'benign dispatch block reason=\$\{failure_reason\}' \
 	"$DISPATCH_LIB"
 
 assert_grep \
@@ -171,8 +175,8 @@ assert_grep \
 	'return "\$raw_rc"' \
 	"$DISPATCH_LIB"
 assert_not_grep \
-	"10e: interactive review hold is not counted as a candidate failure reason" \
-	'dedup_active_claim \| interactive_review_hold \|' \
+	"10e: benign block reasons are not counted as candidate failure reasons" \
+	'dedup_active_claim \| interactive_review_hold \| pr_target_not_dispatchable \|' \
 	"$DISPATCH_LIB"
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

PR-number dispatch candidates now emit a structured pr_target_not_dispatchable block reason, return the benign dispatch rc, and are recorded as benign blocked candidates instead of unclassified pre-launch failures.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh,.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh,.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh; bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; bash .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh; bash .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh; shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh

Resolves #23419


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 72,569 tokens on this as a headless worker.