### PR TITLE
GH#23422: unblock stale interactive PR takeover

### DIFF
--- a/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
+++ b/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
@@ -127,7 +127,9 @@ _dispatch_apply_current_state_guardrails() {
 
 	local capped_slots="$available_slots" reason=""
 	if ((empty_threshold > 0 && no_dispatchable >= empty_threshold && successes == 0)); then
-		capped_slots=0
+		# Keep one probe slot alive. Otherwise stale "no dispatchable" evidence can
+		# self-lock the refill loop just as new review/conflict work becomes eligible.
+		capped_slots=1
 		reason="no_dispatchable_evidence"
 	elif ((rl_threshold > 0 && rate_limits >= rl_threshold && successes == 0)); then
 		capped_slots=0

--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -227,10 +227,12 @@ _interactive_pr_is_stale() {
 	[[ "$mode" == "off" ]] && return 1
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
 
-	# Fetch PR metadata once
+	# Fetch PR metadata once. For staleness, prefer the head commit timestamp
+	# over PR updatedAt: automated comments/labels refresh updatedAt and can keep
+	# idle conflicted PRs out of worker handover indefinitely.
 	local pr_meta
 	pr_meta=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json labels,updatedAt 2>/dev/null) || return 1
+		--json labels,updatedAt,headRefOid 2>/dev/null) || return 1
 
 	# Gate 1: must have origin:interactive
 	printf '%s' "$pr_meta" | jq -e \
@@ -248,7 +250,7 @@ _interactive_pr_is_stale() {
 
 	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
 	local threshold_secs="${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}"  # default 4h (t2948; was 24h)
-	local updated_at="" now_epoch=0 updated_epoch=0 pr_age_secs=0
+	local activity_at="" activity_source="updatedAt" now_epoch=0 updated_epoch=0 pr_age_secs=0
 	# t2383 Fix 2: validate threshold is a positive integer before arithmetic.
 	# A non-numeric value (e.g. "4h", empty, negative) triggers bash
 	# "value too great for base" and silently breaks stale detection.
@@ -256,12 +258,22 @@ _interactive_pr_is_stale() {
 		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid IDLE_INTERACTIVE_HANDOVER_SECONDS='${threshold_secs}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
 		return 1
 	fi
-	updated_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
-	[[ -z "$updated_at" ]] && return 1
+	local head_ref_oid=""
+	head_ref_oid=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // empty')
+	if [[ -n "$head_ref_oid" ]]; then
+		activity_at=$(gh api "repos/${repo_slug}/commits/${head_ref_oid}" \
+			--jq '.commit.committer.date // .commit.author.date // empty' 2>/dev/null) || activity_at=""
+		[[ -n "$activity_at" ]] && activity_source="head_commit"
+	fi
+	if [[ -z "$activity_at" ]]; then
+		activity_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
+		activity_source="updatedAt"
+	fi
+	[[ -z "$activity_at" ]] && return 1
 	now_epoch=$(date +%s)
 	# Portable epoch parse — GNU date first (Linux CI), BSD date fallback (macOS)
-	updated_epoch=$(date -d "$updated_at" +%s 2>/dev/null) || \
-		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null) || \
+	updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
+		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \
 		return 1
 	pr_age_secs=$(( now_epoch - updated_epoch ))
 	[[ "$pr_age_secs" -lt "$threshold_secs" ]] && return 1
@@ -288,7 +300,7 @@ _interactive_pr_is_stale() {
 
 	# All gates passed — PR is stale. Log in detect mode.
 	if [[ "$mode" == "detect" ]]; then
-		echo "[pulse-wrapper] would-handover: PR #${pr_number} in ${repo_slug} (idle $((pr_age_secs / 3600))h >= $((threshold_secs / 3600))h, linked issue #${linked_issue})" >>"$LOGFILE"
+		echo "[pulse-wrapper] would-handover: PR #${pr_number} in ${repo_slug} (idle $((pr_age_secs / 3600))h via ${activity_source} >= $((threshold_secs / 3600))h, linked issue #${linked_issue})" >>"$LOGFILE"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/fixtures/mock-gh-interactive-handover.sh
+++ b/.agents/scripts/tests/fixtures/mock-gh-interactive-handover.sh
@@ -45,6 +45,12 @@ _maybe_jq() {
 
 case "$_subcmd" in
 "pr view")
+	if [[ "$*" == *"--json labels,updatedAt,headRefOid"* ]]; then
+		_arr_json=$(_labels_to_json_array)
+		_updated=$(cat "${TEST_ROOT}/updated.txt")
+		printf '{"labels":%s,"updatedAt":"%s","headRefOid":"abc123"}' "$_arr_json" "$_updated" | _maybe_jq
+		exit 0
+	fi
 	if [[ "$*" == *"--json labels,updatedAt"* ]]; then
 		_arr_json=$(_labels_to_json_array)
 		_updated=$(cat "${TEST_ROOT}/updated.txt")
@@ -86,6 +92,12 @@ esac
 
 # `gh api` paths
 if [[ "${1:-}" == "api" ]]; then
+	# repos/OWNER/REPO/commits/SHA — head commit lookup
+	if [[ "$*" == *"/commits/"* ]]; then
+		_head_date=$(cat "${TEST_ROOT}/head-commit.txt")
+		printf '{"commit":{"committer":{"date":"%s"},"author":{"date":"%s"}}}' "$_head_date" "$_head_date" | _maybe_jq
+		exit 0
+	fi
 	# repos/OWNER/REPO/issues/NNN — linked issue lookup
 	if [[ "$*" == *"/issues/"* && "$*" != *"/comments"* ]]; then
 		_state=$(cat "${TEST_ROOT}/issue-state.txt")

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -126,14 +126,14 @@ test_healthy_pr_backlog_rations_new_launches() {
 	return 0
 }
 
-test_no_dispatchable_evidence_pauses_refill_loop() {
+test_no_dispatchable_evidence_keeps_probe_slot() {
 	reset_guardrail_env
 	local slots
 	slots=$(guardrail_slots "0 0 0 0 2" 8)
-	if [[ "$slots" == "0" ]] && grep -q 'no_dispatchable_evidence' "$LOGFILE"; then
-		print_result "guardrail: no-dispatchable evidence prevents empty refill loops" 0
+	if [[ "$slots" == "1" ]] && grep -q 'no_dispatchable_evidence' "$LOGFILE"; then
+		print_result "guardrail: no-dispatchable evidence keeps one probe slot" 0
 	else
-		print_result "guardrail: no-dispatchable evidence prevents empty refill loops" 1 "slots=${slots}"
+		print_result "guardrail: no-dispatchable evidence keeps one probe slot" 1 "slots=${slots}"
 	fi
 	return 0
 }
@@ -193,7 +193,7 @@ test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
 test_healthy_pr_backlog_rations_new_launches
-test_no_dispatchable_evidence_pauses_refill_loop
+test_no_dispatchable_evidence_keeps_probe_slot
 test_clean_state_preserves_available_slots
 test_disabled_guardrail_still_updates_available_slots_gauge
 test_interactive_hold_reason_is_classified

--- a/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
+++ b/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
@@ -59,6 +59,7 @@ print_result() {
 # produce canned responses; tests mutate them to drive scenarios.
 #   labels.txt            — pr labels (comma-separated, newline-terminated)
 #   updated.txt           — PR updatedAt ISO timestamp
+#   head-commit.txt       — head commit ISO timestamp used for idle age
 #   issue-state.txt       — "open" or "closed"
 #   issue-labels-json.txt — JSON array of label names on linked issue
 #   title.txt             — PR title (used by _extract_linked_issue fallback)
@@ -72,8 +73,10 @@ reset_mock_state() {
 	# Portable ISO-8601 UTC emit
 	if date -u -r "$epoch_48h" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1; then
 		date -u -r "$epoch_48h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/updated.txt"
+		date -u -r "$epoch_48h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/head-commit.txt"
 	else
 		date -u -d "@$epoch_48h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/updated.txt"
+		date -u -d "@$epoch_48h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/head-commit.txt"
 	fi
 	printf 'open' >"${TEST_ROOT}/issue-state.txt"
 	printf '[]' >"${TEST_ROOT}/issue-labels-json.txt"
@@ -115,6 +118,11 @@ teardown_test_env() {
 
 # Extract helpers under test and eval them in this shell.
 define_helpers_under_test() {
+	gh_pr_view() {
+		gh pr view "$@"
+		return $?
+	}
+
 	local is_stale_src
 	is_stale_src=$(awk '/^_interactive_pr_is_stale\(\) \{/,/^\}$/ { print }' "$CONFLICT_SCRIPT")
 	if [[ -z "$is_stale_src" ]]; then
@@ -161,8 +169,10 @@ test_A_fresh_pr_returns_not_stale() {
 	epoch_2h=$(( $(date +%s) - 2 * 3600 ))
 	if date -u -r "$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1; then
 		date -u -r "$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/updated.txt"
+		date -u -r "$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/head-commit.txt"
 	else
 		date -u -d "@$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/updated.txt"
+		date -u -d "@$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/head-commit.txt"
 	fi
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce _interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -170,6 +180,27 @@ test_A_fresh_pr_returns_not_stale() {
 		print_result "A: fresh PR (2h old) returns not-stale" 0
 	else
 		print_result "A: fresh PR (2h old) returns not-stale" 1 "Expected 1, got $rc"
+	fi
+	return 0
+}
+
+test_A2_automation_updated_pr_uses_idle_head_commit() {
+	reset_mock_state
+	# Simulate an automated comment/label touching PR updatedAt while the branch
+	# itself has not changed. Handover must key off the head commit age.
+	local epoch_2h
+	epoch_2h=$(( $(date +%s) - 2 * 3600 ))
+	if date -u -r "$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1; then
+		date -u -r "$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/updated.txt"
+	else
+		date -u -d "@$epoch_2h" "+%Y-%m-%dT%H:%M:%SZ" >"${TEST_ROOT}/updated.txt"
+	fi
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce _interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "A2: fresh automation updatedAt does not mask idle head commit" 0
+	else
+		print_result "A2: fresh automation updatedAt does not mask idle head commit" 1 "Expected 0, got $rc"
 	fi
 	return 0
 }
@@ -376,7 +407,7 @@ test_K_no_takeover_label_blocks_handover() {
 test_L_invalid_hours_returns_not_stale() {
 	reset_mock_state
 	# "24h" is non-numeric — should not crash bash arithmetic
-	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="24h" \
+	IDLE_INTERACTIVE_HANDOVER_SECONDS="24h" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -384,7 +415,7 @@ test_L_invalid_hours_returns_not_stale() {
 		print_result "L: invalid HOURS ('24h') returns not-stale" 1 "Expected 1, got $rc"
 		return 0
 	fi
-	if ! grep -q "invalid AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS" "$LOGFILE"; then
+	if ! grep -q "invalid IDLE_INTERACTIVE_HANDOVER_SECONDS" "$LOGFILE"; then
 		print_result "L: invalid HOURS logs validation error" 1 \
 			"Expected validation error in LOGFILE. Got: $(cat "$LOGFILE")"
 		return 0
@@ -395,7 +426,7 @@ test_L_invalid_hours_returns_not_stale() {
 
 test_L2_zero_hours_returns_not_stale() {
 	reset_mock_state
-	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="0" \
+	IDLE_INTERACTIVE_HANDOVER_SECONDS="0" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -411,7 +442,7 @@ test_L3_empty_hours_uses_default_24() {
 	reset_mock_state
 	# Empty HOURS triggers bash's :- default substitution to "24", which is valid.
 	# The PR is 48h old (reset_mock_state default), so it should return stale (0).
-	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="" \
+	IDLE_INTERACTIVE_HANDOVER_SECONDS="" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -425,7 +456,7 @@ test_L3_empty_hours_uses_default_24() {
 
 test_L4_negative_hours_returns_not_stale() {
 	reset_mock_state
-	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="-5" \
+	IDLE_INTERACTIVE_HANDOVER_SECONDS="-5" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -460,6 +491,7 @@ main() {
 	}
 
 	test_A_fresh_pr_returns_not_stale
+	test_A2_automation_updated_pr_uses_idle_head_commit
 	test_B_stamp_present_returns_not_stale
 	test_C_active_status_label_returns_not_stale
 	test_D_idle_no_stamp_no_status_returns_stale


### PR DESCRIPTION
## Summary

- Use PR head commit age, not automation-mutated `updatedAt`, to decide stale `origin:interactive` worker handover eligibility.
- Keep one dispatch probe slot when `no_dispatchable_evidence` fires so stale empty-queue evidence cannot self-lock workers.
- Extend handover and current-state guardrail tests for both behaviours.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-interactive-handover.sh` — 17/17 passed
- `bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh` — 9/9 passed
- `shellcheck .agents/scripts/pulse-merge-conflict.sh .agents/scripts/pulse-dispatch-current-state-guardrails.sh .agents/scripts/tests/test-pulse-merge-interactive-handover.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh .agents/scripts/tests/fixtures/mock-gh-interactive-handover.sh` — passed
- `git diff --check` — passed
- `.agents/scripts/linters-local.sh` — core checks passed through secret/pulse/ratchet stages; timed out later in portability after advisory-only pre-existing markdown/ratchet warnings

Resolves #23422
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 48m and 353,316 tokens on this with the user in an interactive session.