### PR TITLE
GH#23425: allow stale interactive merge handover

### DIFF
--- a/.agents/scripts/pulse-merge-author-checks.sh
+++ b/.agents/scripts/pulse-merge-author-checks.sh
@@ -175,6 +175,12 @@ _interactive_pr_auto_merge_allowed() {
 		return 0
 	fi
 
+	if declare -F _interactive_pr_is_stale >/dev/null 2>&1 \
+		&& _interactive_pr_is_stale "$pr_number" "$repo_slug"; then
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — stale origin:interactive PR has no active claim; allowing automated merge throughput (GH#23425)" >>"$LOGFILE"
+		return 0
+	fi
+
 	echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — origin:interactive PR requires manual merge by current preference (add allow-auto-merge, set repos.json interactive_pr_auto_merge=true, or set orchestration.interactive_pr_auto_merge=true) (GH#23238)" >>"$LOGFILE"
 	return 1
 }

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -624,6 +624,16 @@ _process_single_ready_pr() {
 		fi
 
 		if [[ "$pr_mergeable" == "CONFLICTING" ]]; then
+			# Conflict resolution feedback: route worker PRs and stale interactive
+			# PRs to fix workers before the protected-close precheck. Active
+			# interactive PRs remain protected because _route_pr_to_fix_worker only
+			# accepts origin:interactive after _interactive_pr_is_stale passes.
+			local _conf_linked_issue
+			_conf_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
+			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_conf_linked_issue" "conflict" "" "$pr_title"; then
+				return 2
+			fi
+
 			# GH#23371: some PRs are already known to be protected from
 			# automated close handling from the PR list metadata (draft,
 			# origin:interactive, no-auto-dispatch, external-contributor).
@@ -633,14 +643,6 @@ _process_single_ready_pr() {
 				return 1
 			fi
 
-			# Conflict resolution feedback: route worker PRs to fix worker
-			# (t2203: consolidated in helper). If routed, return 2 to skip
-			# the close path; otherwise fall through to _close_conflicting_pr.
-			local _conf_linked_issue
-			_conf_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
-			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_conf_linked_issue" "conflict" "" "$pr_title"; then
-				return 2
-			fi
 			_close_conflicting_pr "$pr_number" "$repo_slug" "$pr_title"
 			return 2
 		fi

--- a/.agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh
+++ b/.agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh
@@ -17,6 +17,7 @@
 #   Case 9: per-repo repos.json override opts in
 #   Case 10: environment false overrides repo/global preferences
 #   Case 11: allow-auto-merge label remains a PR-specific opt-in
+#   Case 12: stale interactive PR without active claim passes automation
 #
 # No real repository is touched. The gh binary is replaced with a mock stub
 # that serves canned responses from TEST_ROOT fixture files.
@@ -412,6 +413,38 @@ test_case11_label_overrides_env_false() {
 }
 
 # =============================================================================
+# Case 12: stale interactive PR without active claim passes automation.
+# =============================================================================
+test_case12_stale_interactive_without_claim_passes() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	_interactive_pr_is_stale() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		[[ "$pr_number" == "110" && "$repo_slug" == "owner/repo" ]]
+		return $?
+	}
+
+	local labels="origin:interactive"
+	local result=0
+	_check_interactive_pr_gates "110" "owner/repo" "$labels" "false" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case 12: stale interactive PR without active claim passes" 1 \
+			"Expected exit 0, got ${result}"
+	elif ! grep -q "stale origin:interactive PR has no active claim" "$LOGFILE" 2>/dev/null; then
+		print_result "Case 12: stale interactive PR without active claim passes" 1 \
+			"Expected stale handover merge log in ${LOGFILE}"
+	else
+		print_result "Case 12: stale interactive PR without active claim passes" 0
+	fi
+	unset -f _interactive_pr_is_stale
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
 # Run all cases
 # =============================================================================
 main() {
@@ -431,6 +464,7 @@ main() {
 	test_case9_repo_override_passes
 	test_case10_env_false_blocks_preferences
 	test_case11_label_overrides_env_false
+	test_case12_stale_interactive_without_claim_passes
 
 	echo ""
 	printf 'Results: %d/%d passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -358,7 +358,7 @@ test_nmr_guard_exists_before_close() {
 	return 0
 }
 
-test_protected_precheck_exists_before_close() {
+test_stale_route_runs_before_protected_precheck() {
 	local block
 	block=$(awk '
 		/^_process_single_ready_pr\(\) \{/ { in_fn=1 }
@@ -373,18 +373,18 @@ test_protected_precheck_exists_before_close() {
 	route_pos=$(printf '%s\n' "$block" | awk '/_route_pr_to_fix_worker/ { print NR; exit }')
 
 	if [[ -z "$precheck_pos" || -z "$close_pos" || -z "$route_pos" ]]; then
-		print_result "protected PR precheck runs before close-conflict metadata" 1 \
+		print_result "stale route runs before protected PR precheck" 1 \
 			"Expected precheck, route, and close calls in CONFLICTING block (precheck=${precheck_pos}, route=${route_pos}, close=${close_pos})"
 		return 0
 	fi
 
-	if [[ "$precheck_pos" -ge "$route_pos" || "$precheck_pos" -ge "$close_pos" ]]; then
-		print_result "protected PR precheck runs before close-conflict metadata" 1 \
-			"Precheck must appear before route and close (precheck=${precheck_pos}, route=${route_pos}, close=${close_pos})"
+	if [[ "$route_pos" -ge "$precheck_pos" || "$precheck_pos" -ge "$close_pos" ]]; then
+		print_result "stale route runs before protected PR precheck" 1 \
+			"Route must appear before protected precheck, and precheck before close (route=${route_pos}, precheck=${precheck_pos}, close=${close_pos})"
 		return 0
 	fi
 
-	print_result "protected PR precheck runs before close-conflict metadata" 0
+	print_result "stale route runs before protected PR precheck" 0
 	return 0
 }
 
@@ -424,7 +424,7 @@ main() {
 	test_resolve_mergeable_retries_boolean_true
 	test_resolve_mergeable_retries_empty_and_logs_empty
 	test_nmr_guard_exists_before_close
-	test_protected_precheck_exists_before_close
+	test_stale_route_runs_before_protected_precheck
 	test_mergeable_refetch_after_update_branch
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Allow stale, unclaimed `origin:interactive` PRs to pass the manual merge preference using the existing `_interactive_pr_is_stale` safety gate.
- Route conflicted stale interactive PRs to conflict-fix workers before the protected-close precheck blocks all interactive PRs.
- Extend origin-interactive merge and update-branch tests for stale handover ordering.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh` — 12/12 passed
- `bash .agents/scripts/tests/test-pulse-merge-update-branch.sh` — 10/10 passed
- `shellcheck .agents/scripts/pulse-merge-author-checks.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh .agents/scripts/tests/test-pulse-merge-update-branch.sh` — passed
- `git diff --check` — passed

Resolves #23425
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.31 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2h 32m and 832,897 tokens on this with the user in an interactive session.