### PR TITLE
GH#23428: detect unsupported gh slurp prerequisite

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -105,7 +105,15 @@ cmd_status() {
 	echo ""
 	_status_recommended_tools
 	print_header "Git CLI Tools"
-	check_cmd gh && print_success "GitHub CLI (gh)" || print_warning "GitHub CLI (gh) - not installed"
+	if ! check_cmd gh; then
+		print_warning "GitHub CLI (gh) - not installed"
+	elif declare -F aidevops_gh_slurp_supported >/dev/null 2>&1 && aidevops_gh_slurp_supported; then
+		print_success "$(aidevops_gh_slurp_status_message)"
+	elif declare -F aidevops_gh_slurp_status_message >/dev/null 2>&1; then
+		print_warning "$(aidevops_gh_slurp_status_message)"
+	else
+		print_success "GitHub CLI (gh)"
+	fi
 	check_cmd glab && print_success "GitLab CLI (glab)" || print_warning "GitLab CLI (glab) - not installed"
 	check_cmd tea && print_success "Gitea CLI (tea)" || print_warning "Gitea CLI (tea) - not installed"
 	echo ""

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1845,19 +1845,29 @@ _match_terminal_blocker_pattern() {
 	local blocker_reason=""
 	local user_action=""
 
-	# Pattern 1: workflow scope missing
-	if echo "$all_bodies" | grep -qiE 'workflow scope|refusing to allow an OAuth App to create or update workflow|token lacks.*workflow'; then
+	# Pattern 1: GitHub CLI too old for gh api --paginate --slurp
+	if echo "$all_bodies" | grep -qiE 'unknown flag: --slurp'; then
+		local gh_slurp_message=""
+		if declare -F aidevops_gh_slurp_status_message >/dev/null 2>&1; then
+			gh_slurp_message=$(aidevops_gh_slurp_status_message)
+		else
+			gh_slurp_message="GitHub CLI (gh) is too old for gh api --paginate --slurp; upgrade gh to >= 2.51.0."
+		fi
+		blocker_reason="GitHub CLI prerequisite failed — ${gh_slurp_message}"
+		user_action="Upgrade GitHub CLI to a version that supports \`gh api --paginate --slurp\` (minimum gh ${AIDEVOPS_GH_MIN_SLURP_VERSION:-2.51.0}), then remove the \`status:blocked\` label."
+	# Pattern 2: workflow scope missing
+	elif echo "$all_bodies" | grep -qiE 'workflow scope|refusing to allow an OAuth App to create or update workflow|token lacks.*workflow'; then
 		blocker_reason="GitHub token lacks \`workflow\` scope — workers cannot push workflow file changes"
 		user_action="Run \`gh auth refresh -s workflow\` to add the workflow scope to your token, then remove the \`status:blocked\` label."
-	# Pattern 2: generic token/auth scope issues
+	# Pattern 3: generic token/auth scope issues
 	elif echo "$all_bodies" | grep -qiE 'token lacks.*scope|missing.*scope.*token|token.*missing.*scope'; then
 		blocker_reason="GitHub token is missing a required scope — workers cannot complete this task"
 		user_action="Check the error details in the comments above, run \`gh auth refresh -s <missing-scope>\` to add the required scope, then remove the \`status:blocked\` label."
-	# Pattern 3: ACTION REQUIRED (supervisor-posted)
+	# Pattern 4: ACTION REQUIRED (supervisor-posted)
 	elif echo "$all_bodies" | grep -qF 'ACTION REQUIRED'; then
 		blocker_reason="A previous supervisor comment flagged this issue as requiring user action"
 		user_action="Read the ACTION REQUIRED comment above, complete the requested action, then remove the \`status:blocked\` label."
-	# Pattern 4: persistent authentication/permission failures
+	# Pattern 5: persistent authentication/permission failures
 	elif echo "$all_bodies" | grep -qiE 'authentication required.*workflow|permission denied.*workflow|push declined.*workflow'; then
 		blocker_reason="Persistent authentication or permission failure for workflow files"
 		user_action="Check your GitHub token scopes with \`gh auth status\`, refresh if needed with \`gh auth refresh -s workflow\`, then remove the \`status:blocked\` label."

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -22,6 +22,12 @@ setup_git_clis() {
 	if ! command -v gh >/dev/null 2>&1; then
 		missing_packages+=("gh")
 		missing_names+=("GitHub CLI")
+	elif declare -F aidevops_gh_slurp_supported >/dev/null 2>&1 && ! aidevops_gh_slurp_supported; then
+		local gh_slurp_message
+		gh_slurp_message=$(aidevops_gh_slurp_status_message)
+		print_warning "$gh_slurp_message"
+		missing_packages+=("gh")
+		missing_names+=("GitHub CLI >= ${AIDEVOPS_GH_MIN_SLURP_VERSION}")
 	else
 		cli_tools+=("GitHub CLI")
 	fi
@@ -72,14 +78,14 @@ setup_git_clis() {
 				echo ""
 				echo "📋 Manual installation:"
 				echo "  macOS: brew install ${missing_packages[*]}"
-				echo "  Ubuntu: sudo apt install ${missing_packages[*]}"
+				echo "  Ubuntu: install or upgrade gh from the GitHub CLI apt repository"
 				echo "  Fedora: sudo dnf install ${missing_packages[*]}"
 			fi
 		else
 			echo ""
 			echo "📋 Manual installation:"
 			echo "  macOS: brew install ${missing_packages[*]}"
-			echo "  Ubuntu: sudo apt install ${missing_packages[*]}"
+			echo "  Ubuntu: install or upgrade gh from the GitHub CLI apt repository"
 			echo "  Fedora: sudo dnf install ${missing_packages[*]}"
 		fi
 	else

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -113,6 +113,89 @@ fi
 # Upstream context: https://github.com/anomalyco/opencode/issues/21215
 readonly OPENCODE_PINNED_VERSION="latest"
 
+# Minimum GitHub CLI version required for `gh api --paginate --slurp`.
+# Older distro packages can parse `gh` as installed while dispatch paths fail
+# closed with `unknown flag: --slurp`.
+readonly AIDEVOPS_GH_MIN_SLURP_VERSION="2.51.0"
+
+aidevops_parse_semver() {
+	local input="$1"
+	local parsed=""
+	parsed=$(printf '%s\n' "$input" | grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 || true)
+	if [[ -z "$parsed" ]]; then
+		return 1
+	fi
+	if [[ "$parsed" =~ ^[0-9]+\.[0-9]+$ ]]; then
+		parsed="${parsed}.0"
+	fi
+	printf '%s\n' "$parsed"
+	return 0
+}
+
+aidevops_version_at_least() {
+	local current="$1"
+	local minimum="$2"
+	local current_major current_minor current_patch
+	local minimum_major minimum_minor minimum_patch
+	IFS='.' read -r current_major current_minor current_patch <<<"$current"
+	IFS='.' read -r minimum_major minimum_minor minimum_patch <<<"$minimum"
+	current_patch="${current_patch:-0}"
+	minimum_patch="${minimum_patch:-0}"
+	[[ "$current_major$current_minor$current_patch$minimum_major$minimum_minor$minimum_patch" =~ ^[0-9]+$ ]] || return 1
+	if ((current_major > minimum_major)); then
+		return 0
+	fi
+	if ((current_major < minimum_major)); then
+		return 1
+	fi
+	if ((current_minor > minimum_minor)); then
+		return 0
+	fi
+	if ((current_minor < minimum_minor)); then
+		return 1
+	fi
+	if ((current_patch >= minimum_patch)); then
+		return 0
+	fi
+	return 1
+}
+
+aidevops_gh_installed_version() {
+	local output=""
+	if ! command -v gh >/dev/null 2>&1; then
+		return 1
+	fi
+	output=$(gh --version 2>/dev/null || true)
+	aidevops_parse_semver "$output"
+	return $?
+}
+
+aidevops_gh_slurp_supported() {
+	local installed=""
+	installed=$(aidevops_gh_installed_version) || return 1
+	aidevops_version_at_least "$installed" "$AIDEVOPS_GH_MIN_SLURP_VERSION"
+	return $?
+}
+
+aidevops_gh_slurp_status_message() {
+	local installed=""
+	if ! command -v gh >/dev/null 2>&1; then
+		printf 'GitHub CLI (gh) is not installed; gh api --paginate --slurp requires gh >= %s' "$AIDEVOPS_GH_MIN_SLURP_VERSION"
+		return 0
+	fi
+	installed=$(aidevops_gh_installed_version) || installed="unknown"
+	if [[ "$installed" == "unknown" ]]; then
+		printf 'GitHub CLI (gh) version could not be parsed; gh api --paginate --slurp requires gh >= %s; gh --version output is malformed or empty' "$AIDEVOPS_GH_MIN_SLURP_VERSION"
+		return 0
+	fi
+	if aidevops_version_at_least "$installed" "$AIDEVOPS_GH_MIN_SLURP_VERSION"; then
+		printf 'GitHub CLI (gh) %s supports gh api --paginate --slurp' "$installed"
+		return 0
+	fi
+	printf 'GitHub CLI (gh) %s is too old; gh api --paginate --slurp requires gh >= %s. Upgrade gh from the GitHub CLI package source rather than an old distro package.' "$installed" "$AIDEVOPS_GH_MIN_SLURP_VERSION"
+	return 0
+}
+
 # =============================================================================
 # HTTP and API Constants
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-slurp-prerequisite.sh
+++ b/.agents/scripts/tests/test-gh-slurp-prerequisite.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../shared-constants.sh
+source "${AGENTS_SCRIPTS}/shared-constants.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_PATH="$PATH"
+
+cleanup() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	PATH="$ORIGINAL_PATH"
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local name="$1"
+	local status="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name" >&2
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_supported() {
+	local version="$1"
+	if aidevops_version_at_least "$version" "$AIDEVOPS_GH_MIN_SLURP_VERSION"; then
+		print_result "gh ${version} supports --slurp" 0
+	else
+		print_result "gh ${version} supports --slurp" 1 "expected >= ${AIDEVOPS_GH_MIN_SLURP_VERSION} to pass"
+	fi
+	return 0
+}
+
+assert_not_supported() {
+	local version="$1"
+	if aidevops_version_at_least "$version" "$AIDEVOPS_GH_MIN_SLURP_VERSION"; then
+		print_result "gh ${version} rejected below minimum" 1 "expected version to fail minimum check"
+	else
+		print_result "gh ${version} rejected below minimum" 0
+	fi
+	return 0
+}
+
+assert_parse() {
+	local label="$1"
+	local input="$2"
+	local expected="$3"
+	local got=""
+	got=$(aidevops_parse_semver "$input" 2>/dev/null || true)
+	if [[ "$got" == "$expected" ]]; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "got='${got}' expected='${expected}'"
+	fi
+	return 0
+}
+
+assert_parse_fails() {
+	local label="$1"
+	local input="$2"
+	if aidevops_parse_semver "$input" >/dev/null 2>&1; then
+		print_result "$label" 1 "expected parse failure"
+	else
+		print_result "$label" 0
+	fi
+	return 0
+}
+
+with_fake_gh() {
+	local body="$1"
+	TEST_ROOT=$(mktemp -d)
+	cat >"${TEST_ROOT}/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '${body}'
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/gh"
+	PATH="${TEST_ROOT}:$ORIGINAL_PATH"
+	return 0
+}
+
+assert_status_contains() {
+	local label="$1"
+	local expected="$2"
+	local got=""
+	got=$(aidevops_gh_slurp_status_message)
+	if [[ "$got" == *"$expected"* ]]; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "got='${got}' expected substring='${expected}'"
+	fi
+	return 0
+}
+
+assert_not_supported "2.50.9"
+assert_supported "2.51.0"
+assert_supported "2.52.0"
+assert_parse "parse gh --version output" "gh version 2.51.0 (2024-05-29)" "2.51.0"
+assert_parse "parse two-component output" "gh version 2.51" "2.51.0"
+assert_parse_fails "malformed gh output fails clearly" "gh version unknown"
+assert_parse_fails "empty gh output fails clearly" ""
+with_fake_gh "gh version unknown"
+assert_status_contains "malformed gh version emits clear warning" "version could not be parsed"
+with_fake_gh "gh version 2.50.0"
+assert_status_contains "old gh version emits minimum warning" "requires gh >= 2.51.0"
+with_fake_gh "gh version 2.51.0"
+assert_status_contains "minimum gh version passes status" "supports gh api --paginate --slurp"
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh
@@ -262,6 +262,24 @@ test_missing_scope_variant() {
 }
 
 #######################################
+# Test: old gh prerequisite blocker detected with slurp guidance
+#######################################
+test_gh_slurp_prerequisite_blocker() {
+	reset_mock_state
+	GH_API_OUTPUT='[{"body":"gh: unknown flag: --slurp\nUsage: gh api <endpoint> [flags]","created_at":"2026-03-16T00:03:00Z"}]'
+	GH_ISSUE_VIEW_OUTPUT='none'
+	local exit_code=0
+	check_terminal_blockers "57" "owner/repo" 2>/dev/null || exit_code=$?
+	print_result "gh --slurp prerequisite blocker detected (exit 0)" $((exit_code == 0 ? 0 : 1)) "got exit $exit_code"
+	local guidance_check=1
+	if [[ "$GH_ISSUE_COMMENT_BODY" == *"GitHub CLI prerequisite failed"* && "$GH_ISSUE_COMMENT_BODY" == *"gh api --paginate --slurp"* && "$GH_ISSUE_COMMENT_BODY" == *"2.51.0"* ]]; then
+		guidance_check=0
+	fi
+	print_result "gh --slurp blocker includes prerequisite guidance" "$guidance_check" "body: $GH_ISSUE_COMMENT_BODY"
+	return 0
+}
+
+#######################################
 # Main
 #######################################
 main() {
@@ -279,6 +297,7 @@ main() {
 	test_action_required
 	test_idempotent_no_double_post
 	test_missing_scope_variant
+	test_gh_slurp_prerequisite_blocker
 
 	teardown_test_env
 

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -422,7 +422,14 @@ check_tool() {
 	local icon="✓"
 	local color="$GREEN"
 
-	if [[ "$installed" == "not installed" ]]; then
+	if [[ "$cmd" == "gh" && "$installed" != "not installed" ]] && ! aidevops_gh_slurp_supported; then
+		status="minimum_required"
+		icon="!"
+		color="$RED"
+		latest=">=${AIDEVOPS_GH_MIN_SLURP_VERSION}"
+		((++OUTDATED_COUNT))
+		OUTDATED_PACKAGES+=("$update_cmd")
+	elif [[ "$installed" == "not installed" ]]; then
 		status="not_installed"
 		icon="○"
 		color="$YELLOW"
@@ -476,6 +483,9 @@ check_tool() {
 			;;
 		unknown)
 			echo -e "${color}${icon}  $name: $installed (could not check latest)${NC}"
+			;;
+		minimum_required)
+			echo -e "${color}${icon}  $name: $installed (requires >= ${AIDEVOPS_GH_MIN_SLURP_VERSION} for gh api --paginate --slurp)${NC}"
 			;;
 		up_to_date)
 			echo -e "${color}${icon}  $name: $installed${NC}"


### PR DESCRIPTION
## Summary

Added a shared gh >= 2.51.0 prerequisite probe for gh api --paginate --slurp, surfaced it in status/setup/tool-version diagnostics, and classified unknown flag: --slurp as a pulse terminal prerequisite blocker.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-status-lib.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/setup/modules/tool-install.sh,.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-gh-slurp-prerequisite.sh,.agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh,.agents/scripts/tool-version-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-constants.sh .agents/scripts/tool-version-check.sh .agents/scripts/aidevops-cli/aidevops-status-lib.sh .agents/scripts/setup/modules/tool-install.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-gh-slurp-prerequisite.sh .agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh; bash .agents/scripts/tests/test-gh-slurp-prerequisite.sh; bash .agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh; .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh; .agents/scripts/tests/test-worker-lifecycle-marker-pagination.sh

Resolves #23428


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.32 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 98,778 tokens on this as a headless worker.