### PR TITLE
GH#23430: back off fix-the-fixer auth failures

### DIFF
--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -63,6 +63,9 @@ readonly FIX_THE_FIXER_LABEL="fix-the-fixer"
 readonly FIX_THE_FIXER_MARKER="<!-- aidevops:fix-the-fixer-detector -->"
 readonly AI_RESEARCH_HELPER="${SCRIPT_DIR}/ai-research-helper.sh"
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+readonly AUTH_COOLDOWN_FILE="${HOME}/.aidevops/cache/fix-the-fixer-detector-auth.cooldown"
+readonly AUTH_COOLDOWN_SECONDS_DEFAULT=21600
+readonly AUTH_ERROR_REASON="AI research credentials invalid"
 # Sentinels used by the GitHub issue API. Extracted as constants so the
 # literal strings appear once (codebase ratchet flags repeated literals).
 readonly ISSUE_STATE_OPEN="OPEN"
@@ -85,6 +88,99 @@ _log_info() {
 _log_warn() {
 	_log "$_LL_WARN" "$@"
 	return 0
+}
+
+_auth_cooldown_seconds() {
+	local configured="${AIDEVOPS_FIX_THE_FIXER_DETECTOR_AUTH_COOLDOWN_SECONDS:-$AUTH_COOLDOWN_SECONDS_DEFAULT}"
+	[[ "$configured" =~ ^[0-9]+$ && "$configured" -gt 0 ]] || configured="$AUTH_COOLDOWN_SECONDS_DEFAULT"
+	printf '%s\n' "$configured"
+	return 0
+}
+
+_hash_text() {
+	local value="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		printf '%s' "$value" | sha256sum | awk '{ print $1 }'
+		return 0
+	fi
+	printf '%s' "$value" | shasum -a 256 | awk '{ print $1 }'
+	return 0
+}
+
+_file_mtime() {
+	local path="$1"
+	[[ -e "$path" ]] || {
+		printf 'missing\n'
+		return 0
+	}
+	_file_mtime_epoch "$path" 2>/dev/null || printf 'unknown'
+	return 0
+}
+
+_auth_config_stamp() {
+	local creds_file="${HOME}/.config/aidevops/credentials.sh"
+	local env_state="unset"
+	[[ -n "${ANTHROPIC_API_KEY:-}" ]] && env_state="set:$(_hash_text "$ANTHROPIC_API_KEY")"
+	printf 'env=%s;creds=%s;helper=%s\n' \
+		"$env_state" \
+		"$(_file_mtime "$creds_file")" \
+		"$(_file_mtime "$AI_RESEARCH_HELPER")"
+	return 0
+}
+
+_is_auth_error() {
+	local message="$1"
+	local normalized
+	normalized=$(printf '%s' "$message" | tr '[:upper:]' '[:lower:]')
+	case "$normalized" in
+		*"invalid x-api-key"*|*"invalid api key"*|*"authentication_error"*|*"unauthorized"*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+_record_auth_cooldown() {
+	local reason="$1"
+	local now
+	now=$(date +%s 2>/dev/null || printf '0')
+	mkdir -p "$(dirname "$AUTH_COOLDOWN_FILE")" 2>/dev/null || return 0
+	{
+		printf 'created_at=%s\n' "$now"
+		printf 'cooldown_seconds=%s\n' "$(_auth_cooldown_seconds)"
+		printf 'config_stamp=%s\n' "$(_auth_config_stamp)"
+		printf 'reason=%s\n' "$reason"
+	} >"$AUTH_COOLDOWN_FILE" 2>/dev/null || true
+	return 0
+}
+
+_auth_cooldown_active() {
+	[[ -f "$AUTH_COOLDOWN_FILE" ]] || return 1
+	local created_at=""
+	local cooldown_seconds=""
+	local config_stamp=""
+	local line=""
+	while IFS= read -r line; do
+		case "$line" in
+			created_at=*) created_at="${line#created_at=}" ;;
+			cooldown_seconds=*) cooldown_seconds="${line#cooldown_seconds=}" ;;
+			config_stamp=*) config_stamp="${line#config_stamp=}" ;;
+		esac
+	done <"$AUTH_COOLDOWN_FILE"
+
+	[[ "$created_at" =~ ^[0-9]+$ ]] || return 1
+	[[ "$cooldown_seconds" =~ ^[0-9]+$ ]] || cooldown_seconds="$(_auth_cooldown_seconds)"
+	if [[ "$config_stamp" != "$(_auth_config_stamp)" ]]; then
+		rm -f "$AUTH_COOLDOWN_FILE" 2>/dev/null || true
+		return 1
+	fi
+
+	local now
+	now=$(date +%s 2>/dev/null || printf '0')
+	[[ "$now" =~ ^[0-9]+$ ]] || return 1
+	if [[ $((now - created_at)) -lt "$cooldown_seconds" ]]; then
+		return 0
+	fi
+	rm -f "$AUTH_COOLDOWN_FILE" 2>/dev/null || true
+	return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -152,6 +248,13 @@ _classify_via_llm() {
 	local prompt
 	prompt=$(_compose_classification_prompt "$issue_title" "$issue_body")
 
+	if _auth_cooldown_active; then
+		RATIONALE="auth_error: ${AUTH_ERROR_REASON}; cooldown active"
+		_log_warn "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
+		printf 'SKIP_AUTH\n'
+		return 0
+	fi
+
 	if [[ ! -x "$AI_RESEARCH_HELPER" ]]; then
 		_log_warn "ai-research-helper.sh not executable — cannot classify"
 		return 1
@@ -175,6 +278,13 @@ _classify_via_llm() {
 			local err_snippet=""
 			[[ -s "$err_log" ]] && err_snippet=$(head -c 200 "$err_log" | tr '\n' ' ')
 			rm -f "$err_log"
+			if _is_auth_error "$err_snippet"; then
+				_record_auth_cooldown "$err_snippet"
+				RATIONALE="auth_error: ${AUTH_ERROR_REASON}"
+				_log_warn "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
+				printf 'SKIP_AUTH\n'
+				return 0
+			fi
 			RATIONALE="LLM call failed (model=${model}, rc=${helper_rc}): ${err_snippet:-no stderr}"
 			_log_warn "${RATIONALE}"
 			printf 'SKIP\n'
@@ -350,6 +460,11 @@ cmd_check() {
 	RATIONALE=""
 	local verdict
 	verdict=$(_classify_via_llm "$title" "$body")
+	if [[ "$verdict" == "SKIP_AUTH" ]]; then
+		[[ -n "$RATIONALE" ]] || RATIONALE="auth_error: ${AUTH_ERROR_REASON}"
+		_log_warn "${slug}#${issue_num} classification skipped — ${RATIONALE}"
+		return 3
+	fi
 	if [[ "$verdict" == "SKIP" ]]; then
 		_log_warn "${slug}#${issue_num} classification skipped — ${RATIONALE}"
 		return 2
@@ -417,6 +532,7 @@ cmd_run() {
 	local processed=0
 	local classified=0
 	local skipped_llm=0
+	local skipped_auth=0
 	local slug
 	for slug in "${target_repos[@]}"; do
 		[[ "$processed" -ge "$limit" ]] && break
@@ -442,6 +558,7 @@ cmd_run() {
 			local rc=0
 			cmd_check "$issue_num" "$slug" || rc=$?
 			case "$rc" in
+				3) skipped_auth=$((skipped_auth + 1)) ;;
 				2) skipped_llm=$((skipped_llm + 1)) ;;
 				*) classified=$((classified + 1)) ;;
 			esac
@@ -449,12 +566,14 @@ cmd_run() {
 		done <<<"$nums"
 	done
 
-	if [[ "$skipped_llm" -gt 0 ]]; then
+	if [[ "$skipped_auth" -gt 0 ]]; then
+		_log_warn "processed ${processed} issue(s) across ${#target_repos[@]} repo(s) — classified=${classified}, skipped:auth-error=${skipped_auth}, skipped:LLM-failure=${skipped_llm} (detector observability degraded; ${AUTH_ERROR_REASON})"
+	elif [[ "$skipped_llm" -gt 0 ]]; then
 		# Loud signal — the original t3223 incident was a 6h silent LLM
 		# outage. WARN level so it surfaces in the dashboards/log filters.
-		_log_warn "processed ${processed} issue(s) across ${#target_repos[@]} repo(s) — classified=${classified}, skipped:LLM-failure=${skipped_llm} (detector observability degraded; check ai-research-helper.sh / API credentials)"
+		_log_warn "processed ${processed} issue(s) across ${#target_repos[@]} repo(s) — classified=${classified}, skipped:auth-error=0, skipped:LLM-failure=${skipped_llm} (detector observability degraded; check ai-research-helper.sh / API credentials)"
 	else
-		_log_info "processed ${processed} issue(s) across ${#target_repos[@]} repo(s) — classified=${classified}, skipped:LLM-failure=0"
+		_log_info "processed ${processed} issue(s) across ${#target_repos[@]} repo(s) — classified=${classified}, skipped:auth-error=0, skipped:LLM-failure=0"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
+++ b/.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23430: deterministic AI research auth failures should
+# trip a local cooldown so pulse does not call the LLM classifier every cycle.
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/cache" "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export ANTHROPIC_API_KEY="test-invalid-key"
+	export AIDEVOPS_FIX_THE_FIXER_DETECTOR_AUTH_COOLDOWN_SECONDS=3600
+	export CURL_COUNT_FILE="${TEST_ROOT}/curl-count"
+	printf '0\n' >"$CURL_COUNT_FILE"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	printf '[{"number":1,"labels":[{"name":"auto-dispatch"}]}]\n'
+	exit 0
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	printf '{"title":"fix dispatch path","body":"Touches pulse-wrapper.sh dispatch behaviour.","labels":[{"name":"auto-dispatch"}],"state":"OPEN"}\n'
+	exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+STUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	cat >"${TEST_ROOT}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+count="0"
+if [[ -f "${CURL_COUNT_FILE}" ]]; then
+	count=$(tr -cd '0-9' <"${CURL_COUNT_FILE}")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"${CURL_COUNT_FILE}"
+printf '{"error":{"message":"invalid x-api-key"}}\n'
+exit 0
+STUB
+	chmod +x "${TEST_ROOT}/bin/curl"
+	return 0
+}
+
+teardown_sandbox() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+run_detector() {
+	local output_file="$1"
+	"${PWD}/.agents/scripts/pulse-fix-the-fixer-detector.sh" run \
+		--repo example/repo --limit 1 >"$output_file" 2>&1
+	return 0
+}
+
+main() {
+	setup_sandbox
+	trap teardown_sandbox EXIT
+
+	local first_log="${TEST_ROOT}/first.log"
+	local second_log="${TEST_ROOT}/second.log"
+	run_detector "$first_log"
+	run_detector "$second_log"
+
+	local curl_count
+	curl_count=$(tr -cd '0-9' <"$CURL_COUNT_FILE")
+	if [[ "$curl_count" == "1" ]]; then
+		print_result "invalid credentials trigger cooldown after one LLM call" 0
+	else
+		print_result "invalid credentials trigger cooldown after one LLM call" 1 "curl calls=${curl_count}"
+	fi
+
+	if [[ -f "${HOME}/.aidevops/cache/fix-the-fixer-detector-auth.cooldown" ]]; then
+		print_result "auth cooldown state file recorded" 0
+	else
+		print_result "auth cooldown state file recorded" 1 "cooldown file missing"
+	fi
+
+	if grep -q 'skipped:auth-error=1' "$second_log" && grep -q 'AI research credentials invalid' "$second_log"; then
+		print_result "subsequent run reports concise auth skip" 0
+	else
+		print_result "subsequent run reports concise auth skip" 1 "second log: $(tr '\n' ' ' <"$second_log")"
+	fi
+
+	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Classifies invalid AI research credentials as an auth-error in `pulse-fix-the-fixer-detector.sh`.
- Records a local cooldown under `~/.aidevops/cache/` and skips repeated classifier calls while active.
- Adds a focused regression test proving the second detector run does not invoke the LLM helper again.

Resolves #23430

## Testing
- `bash .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh`
- `shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/ai-research-helper.sh .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`

## Runtime Testing
self-assessed: shell helper behavior verified by mocked `gh` and `curl` regression test; no live credentials or production pulse state required.

## Key decisions
- Cooldown state stores non-secret config metadata only and expires after a conservative interval.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.32 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 77,752 tokens on this as a headless worker.
