### PR TITLE
GH#23431: validate stats runner identity

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -61,6 +61,34 @@ source "${SCRIPT_DIR}/stats-health-dashboard-data.sh"
 # --- Orchestration functions ---
 
 #######################################
+# Resolve current GitHub login, validating gh output before use.
+# Output: validated GitHub login, or a validated local fallback
+#######################################
+_resolve_current_gh_login_or_fallback() {
+	local gh_login=""
+	local fallback_login=""
+
+	gh_login=$(gh api user --jq '.login' 2>/dev/null) || gh_login=""
+	if [[ "$gh_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+		printf '%s' "$gh_login"
+		return 0
+	fi
+
+	fallback_login=$(whoami 2>/dev/null) || fallback_login=""
+	if [[ "$fallback_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+		echo "[stats] GitHub login unavailable or invalid; using local fallback identity: ${fallback_login}" \
+			>>"${LOGFILE:-/dev/null}"
+		printf '%s' "$fallback_login"
+		return 0
+	fi
+
+	echo "[stats] GitHub login unavailable or invalid; using anonymous fallback identity" \
+		>>"${LOGFILE:-/dev/null}"
+	printf '%s' "unknown-runner"
+	return 0
+}
+
+#######################################
 # Activity guard — returns 0 to proceed, 1 to skip.
 # Only runs when the cached health-issue file is absent (would create a new one).
 #######################################
@@ -128,7 +156,7 @@ _update_health_issue_for_repo() {
 	[[ -z "$repo_slug" ]] && return 0
 
 	local runner_user
-	runner_user=$(gh api user --jq '.login' || whoami)
+	runner_user=$(_resolve_current_gh_login_or_fallback)
 
 	local runner_role
 	runner_role=$(_get_runner_role "$runner_user" "$repo_slug")
@@ -148,7 +176,9 @@ _update_health_issue_for_repo() {
 
 	local slug_safe="${repo_slug//\//-}"
 	local cache_dir="${HOME}/.aidevops/logs"
-	local health_issue_file="${cache_dir}/health-issue-${canonical_identity}-${slug_safe}"
+	local canonical_identity_cache_safe
+	canonical_identity_cache_safe=$(_sanitize_runner_identity_for_cache "$canonical_identity")
+	local health_issue_file="${cache_dir}/health-issue-${canonical_identity_cache_safe}-${slug_safe}"
 	mkdir -p "$cache_dir"
 
 	_check_health_issue_activity_guard \

--- a/.agents/scripts/stats-shared.sh
+++ b/.agents/scripts/stats-shared.sh
@@ -40,6 +40,21 @@ _validate_repo_slug() {
 	return 1
 }
 
+#######################################
+# Sanitize a runner/identity token before using it in cache filenames.
+# Arguments:
+#   $1 - identity token
+# Output: filesystem-safe token, bounded to avoid long-path failures
+#######################################
+_sanitize_runner_identity_for_cache() {
+	local identity="$1"
+	identity="${identity//[^a-zA-Z0-9._-]/-}"
+	identity="${identity:0:80}"
+	[[ -n "$identity" ]] || identity="unknown-runner"
+	printf '%s' "$identity"
+	return 0
+}
+
 # check_session_count: now provided by worker-lifecycle-common.sh (sourced by caller).
 # Previously duplicated here (17 lines) — see t1431. Consolidated to eliminate
 # divergence risk and ensure single source of truth.
@@ -103,7 +118,9 @@ _get_runner_role() {
 	# Survives across pulse cycles; prevents API failure from flipping role.
 	local disk_cache_dir="${HOME}/.aidevops/logs"
 	local slug_safe="${repo_slug//\//-}"
-	local disk_cache_file="${disk_cache_dir}/runner-role-${runner_user}-${slug_safe}"
+	local runner_user_cache_safe
+	runner_user_cache_safe=$(_sanitize_runner_identity_for_cache "$runner_user")
+	local disk_cache_file="${disk_cache_dir}/runner-role-${runner_user_cache_safe}-${slug_safe}"
 	if [[ -f "$disk_cache_file" ]]; then
 		local disk_role disk_ts now_ts
 		IFS='|' read -r disk_role disk_ts <"$disk_cache_file" 2>/dev/null || disk_role=""
@@ -172,7 +189,9 @@ _persist_role_cache() {
 	local role="$3"
 	local disk_cache_dir="${HOME}/.aidevops/logs"
 	local slug_safe="${repo_slug//\//-}"
-	local disk_cache_file="${disk_cache_dir}/runner-role-${runner_user}-${slug_safe}"
+	local runner_user_cache_safe
+	runner_user_cache_safe=$(_sanitize_runner_identity_for_cache "$runner_user")
+	local disk_cache_file="${disk_cache_dir}/runner-role-${runner_user_cache_safe}-${slug_safe}"
 	mkdir -p "$disk_cache_dir" 2>/dev/null || true
 	printf '%s|%s\n' "$role" "$(date +%s)" >"$disk_cache_file" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -32,6 +32,10 @@ gh() {
 	local call="$*"
 	printf '%s\n' "$call" >>"$GH_CALLS"
 	case "${HEALTH_FIXTURE:-}:$call" in
+		rate_limit_login:*"api user --jq .login"*)
+			printf '%s' '{"message":"API rate limit exceeded", "status":"403"}' >&2
+			return 1
+			;;
 		conflicting_operator:*"issue list --repo owner/repo --label source:health-dashboard"*)
 			printf '%s' '[{"number":4643,"title":"[Supervisor:marcusquinn] stale dashboard","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"},{"name":"alex-solovyev"},{"name":"supervisor"}]}]'
 			return 0
@@ -206,6 +210,24 @@ if [[ "$body" == *"canonical:"* && "$body" == *"canonical-operator"* && "$body" 
 	pass "dashboard body exposes canonical identity context"
 else
 	fail "dashboard body exposes canonical identity context" "$body"
+fi
+
+: >"$LOGFILE"
+export HEALTH_FIXTURE=rate_limit_login
+resolved_login=$(_resolve_current_gh_login_or_fallback)
+unset HEALTH_FIXTURE
+
+if [[ "$resolved_login" != *"message"* && "$resolved_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+	pass "falls back to validated local identity when gh login is rate limited"
+else
+	fail "falls back to validated local identity when gh login is rate limited" "resolved=${resolved_login}"
+fi
+
+unsafe_cache=$(_sanitize_runner_identity_for_cache '{"message":"API rate limit exceeded", "status":"403"}local-user')
+if [[ "$unsafe_cache" != *"{"* && "$unsafe_cache" != *"message\":"* && ${#unsafe_cache} -le 80 ]]; then
+	pass "sanitizes API error payloads before cache filename use"
+else
+	fail "sanitizes API error payloads before cache filename use" "safe=${unsafe_cache}"
 fi
 
 printf '\n== Summary ==\n'

--- a/.agents/scripts/tests/test-stats-functions-characterization.sh
+++ b/.agents/scripts/tests/test-stats-functions-characterization.sh
@@ -100,13 +100,15 @@ teardown_sandbox() {
 # updated in the same PR. Reviewers: verify the removal is intentional.
 #######################################
 readonly -a EXPECTED_FUNCTIONS=(
-	# Cluster A: stats-shared.sh (3 fns)
+	# Cluster A: stats-shared.sh (4 fns)
 	"_validate_repo_slug"
+	"_sanitize_runner_identity_for_cache"
 	"_get_runner_role"
 	"_persist_role_cache"
-	# Cluster B: stats-health-dashboard.sh (22 fns)
+	# Cluster B: stats-health-dashboard.sh (23 fns)
 	"update_health_issues"
 	"_refresh_person_stats_cache"
+	"_resolve_current_gh_login_or_fallback"
 	"_update_health_issue_for_repo"
 	"_resolve_health_issue_number"
 	"_find_health_issue"


### PR DESCRIPTION
## Summary

Validated gh api user output before using it as the stats runner identity, added safe fallback handling, and sanitized identity tokens used in cache filenames.

## Files Changed

.agents/scripts/stats-health-dashboard.sh,.agents/scripts/stats-shared.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh,.agents/scripts/tests/test-stats-functions-characterization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-stats-functions-characterization.sh; shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/stats-shared.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh .agents/scripts/tests/test-stats-functions-characterization.sh

Resolves #23431


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.32 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 62,419 tokens on this as a headless worker.