### PR TITLE
GH#23433: reduce duplicate pulse PR polling

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1799,6 +1799,19 @@ main() {
 		echo "[pulse-wrapper] REST-first read routing enabled for REST-equivalent gh issue/pr list/view calls (GH#22525)" >>"$LOGFILE"
 	fi
 
+	# GH#23433: reuse REST PR view metadata within this pulse cycle. The wrapper
+	# cache is opt-in so standalone tests/debugging keep exact read semantics, but
+	# pulse can avoid re-fetching the same /pulls/{N} object across merge gates.
+	unset AIDEVOPS_GH_PR_VIEW_CACHE
+	unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
+	if [[ "${AIDEVOPS_PULSE_PR_VIEW_CACHE:-1}" == "1" ]]; then
+		export AIDEVOPS_GH_PR_VIEW_CACHE=1
+		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-view-cache-${$}"
+		rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" 2>/dev/null || true
+		mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" 2>/dev/null || true
+		echo "[pulse-wrapper] Per-cycle REST PR view cache enabled for duplicate repo#PR reads (GH#23433)" >>"$LOGFILE"
+	fi
+
 	# --canary short-circuit (GH#18790): sourcing, _pulse_handle_self_check,
 	# and acquire_instance_lock have all passed cleanly. The EXIT trap releases
 	# the lock. Return 0 without entering the pulse loop, session gate, dedup,

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -63,6 +63,76 @@ _GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-3000}"
 _GH_REST_FALLBACK_RATE_LIMIT_CACHE=""
 _GH_REST_FALLBACK_RATE_LIMIT_CACHE_TS=0
 _GH_LAST_GRAPHQL_REMAINING=""
+_GH_REST_PR_VIEW_CACHE_DIR=""
+
+#######################################
+# Return 0 when REST PR view responses may be reused within this shell.
+# The cache is intentionally process-scoped: pulse stages that source the shared
+# wrappers reuse duplicate REST reads during one cycle, while later cycles start
+# with fresh state. Callers can bypass before mutation-sensitive reads with
+# AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1.
+# Returns: 0 when enabled, 1 otherwise.
+#######################################
+_rest_pr_view_cache_enabled() {
+	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE:-0}" == "1" ]] || return 1
+	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" == "1" ]] && return 1
+	command -v jq >/dev/null 2>&1 || return 1
+	return 0
+}
+
+#######################################
+# Resolve the per-process REST PR view cache directory.
+# Returns: path on stdout; 0 on success, 1 on mkdir failure.
+#######################################
+_rest_pr_view_cache_dir() {
+	if [[ -n "${AIDEVOPS_GH_PR_VIEW_CACHE_DIR:-}" ]]; then
+		mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" 2>/dev/null || return 1
+		printf '%s' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"
+		return 0
+	fi
+	if [[ -z "$_GH_REST_PR_VIEW_CACHE_DIR" ]]; then
+		_GH_REST_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-gh-pr-view-cache-${$}"
+	fi
+	mkdir -p "$_GH_REST_PR_VIEW_CACHE_DIR" 2>/dev/null || return 1
+	printf '%s' "$_GH_REST_PR_VIEW_CACHE_DIR"
+	return 0
+}
+
+#######################################
+# Build a filesystem-safe REST PR view cache path for repo+PR.
+# Args: $1=repo_slug $2=pr_number
+# Returns: path on stdout; 0 on success, 1 on mkdir failure.
+#######################################
+_rest_pr_view_cache_path() {
+	local repo="$1"
+	local num="$2"
+	local dir=""
+	dir="$(_rest_pr_view_cache_dir)" || return 1
+	local safe_repo=""
+	safe_repo="$(printf '%s' "$repo" | tr '/: ' '___')"
+	printf '%s/%s__%s.json' "$dir" "$safe_repo" "$num"
+	return 0
+}
+
+#######################################
+# Emit a cached/raw REST PR object using gh-pr-view-compatible projection args.
+# Args: $1=raw_json $2=json_fields $3=jq_expr
+# Returns: jq exit code, or 0 for raw output.
+#######################################
+_rest_pr_view_emit_json() {
+	local raw_json="$1"
+	local json_fields="$2"
+	local jq_expr="$3"
+	if [[ -n "$json_fields" ]]; then
+		jq_expr="$(_rest_pr_object_json_jq "$json_fields" "$jq_expr")"
+	fi
+	if [[ -n "$jq_expr" ]]; then
+		printf '%s\n' "$raw_json" | jq -r "$jq_expr"
+		return $?
+	fi
+	printf '%s\n' "$raw_json"
+	return 0
+}
 
 #######################################
 # Execute a gh api command with optional wall-clock timeout (t2913).
@@ -937,7 +1007,6 @@ _rest_issue_object_json_jq() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_pr_view() {
-	gh_record_call rest _rest_pr_view 2>/dev/null || true
 	local num_or_url=""
 	local repo=""
 	local jq_expr=""
@@ -974,8 +1043,32 @@ _rest_pr_view() {
 		return 1
 	fi
 
+	local cache_path=""
+	local raw_json=""
+	if _rest_pr_view_cache_enabled; then
+		cache_path="$(_rest_pr_view_cache_path "$repo" "$num")" || cache_path=""
+		if [[ -n "$cache_path" && -s "$cache_path" ]]; then
+			raw_json="$(jq -c '.' "$cache_path" 2>/dev/null)" || raw_json=""
+			if [[ -n "$raw_json" ]]; then
+				_rest_pr_view_emit_json "$raw_json" "$json_fields" "$jq_expr"
+				return $?
+			fi
+		fi
+	fi
+
+	gh_record_call rest _rest_pr_view 2>/dev/null || true
 	local _path="/repos/${repo}/pulls/${num}"
 	local _gh_cmd=(gh api "$_path")
+	if [[ -n "$cache_path" ]]; then
+		raw_json="$(_rest_api_call read "${_gh_cmd[@]}")"
+		local _rc=$?
+		if [[ $_rc -ne 0 ]]; then
+			return $_rc
+		fi
+		printf '%s\n' "$raw_json" >"$cache_path" 2>/dev/null || true
+		_rest_pr_view_emit_json "$raw_json" "$json_fields" "$jq_expr"
+		return $?
+	fi
 	if [[ -n "$json_fields" ]]; then
 		jq_expr="$(_rest_pr_object_json_jq "$json_fields" "$jq_expr")"
 	fi

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -59,6 +59,7 @@
 #      preserve search semantics
 #  31. AIDEVOPS_GH_REST_FIRST_READS routes REST-equivalent reads without a
 #      rate-limit probe while leaving GraphQL-only PR list fields on GraphQL
+#  32. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate REST PR view reads
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -936,6 +937,31 @@ else
 		"output=${pr_view_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_VIEW_FIXTURE
+
+# =============================================================================
+# Test 25e: PR view cache coalesces duplicate REST reads for the same repo#PR
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"cached title","mergeable":true}'
+export AIDEVOPS_GH_PR_VIEW_CACHE=1
+export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMP}/pr_view_cache"
+rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"
+
+pr_view_cached_title=$(gh_pr_view 123 --repo "owner/repo" --json title --jq '.title' 2>/dev/null || true)
+pr_view_cached_mergeable=$(gh_pr_view 123 --repo "owner/repo" --json mergeable --jq '.mergeable' 2>/dev/null || true)
+pr_view_rest_calls=$(grep -cE '^api /repos/owner/repo/pulls/123$' "$GH_CALLS" 2>/dev/null || true)
+
+if [[ "$pr_view_cached_title" == "cached title" && "$pr_view_cached_mergeable" == "MERGEABLE" && "$pr_view_rest_calls" == "1" ]]; then
+	pass "gh_pr_view cache coalesces duplicate REST reads for same repo#PR"
+else
+	fail "gh_pr_view cache coalesces duplicate REST reads for same repo#PR" \
+		"title=${pr_view_cached_title} mergeable=${pr_view_cached_mergeable} rest_calls=${pr_view_rest_calls} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_PR_VIEW_FIXTURE
+unset AIDEVOPS_GH_PR_VIEW_CACHE
+unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
 
 # =============================================================================
 # Test 25c: REST PR list normalizes REST boolean mergeable to gh GraphQL enum

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -31,6 +31,8 @@ setup_env() {
 	export PULSE_BATCH_PREFETCH_CACHE_DIR="$TEST_ROOT/cache"
 	export LOGFILE="$TEST_ROOT/pulse.log"
 	export PULSE_EVENTS_TICKLE_ENABLED=0
+	unset AIDEVOPS_GH_FORCE_REST_READS
+	unset AIDEVOPS_GH_REST_FIRST_READS
 	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
 	cat >"$REPOS_JSON" <<'JSON'
 {"initialized_repos":[{"slug":"owner/repo","pulse":true,"local_only":false}],"git_parent_dirs":[]}


### PR DESCRIPTION
## Summary

Enabled a pulse-scoped REST PR view cache so duplicate repo#PR metadata reads reuse one fetched object during a cycle, and made the conditional REST prefetch test hermetic against inherited routing env.

## Files Changed

.agents/scripts/pulse-wrapper.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh,.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh && bash .agents/scripts/tests/test-pulse-merge-rest-readiness.sh && bash .agents/scripts/tests/test-pulse-current-state-helper.sh && bash .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh && bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/pulse-batch-prefetch-helper.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

Resolves #23433


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.32 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 96,817 tokens on this as a headless worker.