### PR TITLE
t3588: surface gh upgrade remediation

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -179,7 +179,7 @@ function cacheGreeting(output) {
  * @param {string} output
  * @returns {{ info: string[], success: string[], warning: string[], error: string[] }}
  */
-function classifyLines(output) {
+export function classifyLines(output) {
   const info = [];
   const success = [];
   const warning = [];
@@ -234,7 +234,7 @@ function classifyLines(output) {
  * @param {{ info: string[], success: string[], warning: string[], error: string[] }} buckets
  * @returns {{ title: string, message: string, variant: "info"|"success"|"warning"|"error", duration: number } | null}
  */
-function buildToast(buckets) {
+export function buildToast(buckets) {
   const lines = [
     ...buckets.error,
     ...buckets.warning,

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-gh-slurp-toast.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-gh-slurp-toast.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildToast, classifyLines } from "../greeting.mjs";
+
+test("old gh prerequisite warning becomes OpenCode warning toast", () => {
+  const warningLine =
+    "[WARN] GitHub CLI (gh) 2.50.0 is too old; gh api --paginate --slurp requires gh >= 2.51.0. Run aidevops setup to upgrade gh.";
+  const buckets = classifyLines(`aidevops v3.15.32 running in OpenCode v1.14.48\n${warningLine}`);
+
+  assert.deepEqual(buckets.warning, [warningLine]);
+  assert.equal(buckets.error.length, 0);
+
+  const toast = buildToast(buckets);
+  assert.equal(toast.variant, "warning");
+  assert.equal(toast.duration, 15000);
+  assert.match(toast.message, /GitHub CLI \(gh\) 2\.50\.0 is too old/);
+  assert.match(toast.message, /aidevops v3\.15\.32 running in OpenCode/);
+});

--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -175,6 +175,20 @@ _update_check_tools() {
 	local stale_count=0 stale_tools=""
 	local key_tool_cmds="opencode gh"
 	local key_tool_pkgs="opencode-ai brew:gh"
+	if declare -F aidevops_gh_slurp_supported >/dev/null 2>&1 && ! aidevops_gh_slurp_supported; then
+		local gh_slurp_message=""
+		if declare -F aidevops_gh_slurp_status_message >/dev/null 2>&1; then
+			gh_slurp_message=$(aidevops_gh_slurp_status_message)
+		else
+			gh_slurp_message="GitHub CLI (gh) is below the aidevops minimum for gh api --paginate --slurp"
+		fi
+		print_warning "$gh_slurp_message"
+		if declare -F aidevops_gh_slurp_remediation_hint >/dev/null 2>&1; then
+			print_info "$(aidevops_gh_slurp_remediation_hint)"
+		else
+			print_info "Run aidevops setup or upgrade gh manually, then rerun aidevops status."
+		fi
+	fi
 	local idx=0
 	for cmd_name in $key_tool_cmds; do
 		local pkg_ref

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -323,6 +323,26 @@ _check_secret_hygiene() {
 }
 
 # -----------------------------------------------------------------------------
+# _check_gh_slurp_prerequisite: warn when gh is too old for pulse pagination.
+# -----------------------------------------------------------------------------
+_check_gh_slurp_prerequisite() {
+	if ! declare -F aidevops_gh_slurp_supported >/dev/null 2>&1; then
+		echo ""
+		return 0
+	fi
+	if aidevops_gh_slurp_supported; then
+		echo ""
+		return 0
+	fi
+	if declare -F aidevops_gh_slurp_warning_line >/dev/null 2>&1; then
+		aidevops_gh_slurp_warning_line
+	else
+		printf '[WARN] GitHub CLI (gh) does not satisfy the aidevops gh api --paginate --slurp prerequisite. Run aidevops status.'
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
 # _check_advisories: surface active security advisories (not yet dismissed).
 # -----------------------------------------------------------------------------
 _check_advisories() {
@@ -894,12 +914,13 @@ _run_session_advisories() {
 
 	local runtime_hint nudge_output session_warning security_posture
 	local secret_hygiene advisories_output contribution_watch origin_notice
-	local signing_nudge script_drift stuck_index hotfix_notice
+	local signing_nudge script_drift stuck_index hotfix_notice gh_slurp_notice
 	runtime_hint=$(_get_runtime_hint "$app_name")
 	nudge_output=$(_check_local_models "$script_dir")
 	session_warning=$(_check_session_count "$script_dir")
 	security_posture=$(_check_security_posture "$script_dir")
 	secret_hygiene=$(_check_secret_hygiene "$script_dir")
+	gh_slurp_notice=$(_check_gh_slurp_prerequisite)
 	advisories_output=$(_check_advisories)
 	contribution_watch=$(_check_contribution_watch)
 	origin_notice=$(_check_origin)
@@ -922,6 +943,7 @@ _run_session_advisories() {
 	[[ -n "$session_warning" ]] && echo "$session_warning"
 	[[ -n "$security_posture" ]] && echo "$security_posture"
 	[[ -n "$secret_hygiene" ]] && echo "$secret_hygiene"
+	[[ -n "$gh_slurp_notice" ]] && echo "$gh_slurp_notice"
 	[[ -n "$advisories_output" ]] && echo "$advisories_output"
 	[[ -n "$contribution_watch" ]] && echo "$contribution_watch"
 	[[ -n "$origin_notice" ]] && echo "$origin_notice"
@@ -933,7 +955,7 @@ _run_session_advisories() {
 
 	_write_cache "$cache_dir" "$output" "$runtime_hint" "$nudge_output" \
 		"$session_warning" "$security_posture" "$secret_hygiene" \
-		"$advisories_output" "$contribution_watch"
+		"${gh_slurp_notice:+$gh_slurp_notice$'\n'}$advisories_output" "$contribution_watch"
 
 	_refresh_oauth_tokens
 
@@ -983,6 +1005,9 @@ main() {
 		if _is_auto_update_active; then
 			echo "AUTO_UPDATE_ENABLED"
 		fi
+		local gh_slurp_notice
+		gh_slurp_notice=$(_check_gh_slurp_prerequisite)
+		[[ -n "$gh_slurp_notice" ]] && echo "$gh_slurp_notice"
 		return 0
 	fi
 

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -11,12 +11,62 @@ IFS=$'\n\t'
 trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
 shopt -s inherit_errexit 2>/dev/null || true
 
+_print_gh_slurp_manual_upgrade() {
+	echo ""
+	echo "📋 GitHub CLI upgrade guidance:"
+	echo "  Required: gh >= ${AIDEVOPS_GH_MIN_SLURP_VERSION:-2.51.0} for gh api --paginate --slurp"
+	echo "  Linux: install or upgrade gh from the official GitHub CLI package source for your distribution"
+	echo "  macOS: brew update && brew upgrade gh"
+	echo "  Verify: gh --version && aidevops status"
+	return 0
+}
+
+_offer_gh_slurp_upgrade() {
+	local pkg_manager="$1"
+	local os_name=""
+	os_name=$(uname -s 2>/dev/null || printf 'unknown')
+
+	if [[ "$os_name" != "Linux" ]]; then
+		_print_gh_slurp_manual_upgrade
+		return 0
+	fi
+
+	echo ""
+	print_warning "Linux GitHub CLI is below the aidevops minimum. Old distro packages can break pulse dispatch."
+	if [[ "$pkg_manager" == "unknown" ]]; then
+		print_warning "No supported package manager detected for an automatic gh upgrade attempt"
+		_print_gh_slurp_manual_upgrade
+		return 0
+	fi
+	setup_prompt upgrade_gh_cli "Try to upgrade GitHub CLI (gh) using ${pkg_manager}? [y/N]: " "N"
+	# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
+	if [[ "$upgrade_gh_cli" =~ ^[Yy]$ ]]; then
+		print_info "Attempting to upgrade gh using ${pkg_manager}..."
+		if install_packages "$pkg_manager" gh; then
+			if declare -F aidevops_gh_slurp_supported >/dev/null 2>&1 && aidevops_gh_slurp_supported; then
+				print_success "GitHub CLI now satisfies the aidevops prerequisite"
+			else
+				print_warning "gh still does not satisfy the aidevops prerequisite after package-manager upgrade"
+				_print_gh_slurp_manual_upgrade
+			fi
+		else
+			print_warning "Package-manager gh upgrade failed or was unavailable"
+			_print_gh_slurp_manual_upgrade
+		fi
+	else
+		print_info "Skipped GitHub CLI upgrade"
+		_print_gh_slurp_manual_upgrade
+	fi
+	return 0
+}
+
 setup_git_clis() {
 	print_info "Setting up Git CLI tools..."
 
 	local cli_tools=()
 	local missing_packages=()
 	local missing_names=()
+	local gh_needs_slurp_upgrade="false"
 
 	# Check for GitHub CLI
 	if ! command -v gh >/dev/null 2>&1; then
@@ -26,8 +76,7 @@ setup_git_clis() {
 		local gh_slurp_message
 		gh_slurp_message=$(aidevops_gh_slurp_status_message)
 		print_warning "$gh_slurp_message"
-		missing_packages+=("gh")
-		missing_names+=("GitHub CLI >= ${AIDEVOPS_GH_MIN_SLURP_VERSION}")
+		gh_needs_slurp_upgrade="true"
 	else
 		cli_tools+=("GitHub CLI")
 	fi
@@ -45,13 +94,17 @@ setup_git_clis() {
 		print_success "Found Git CLI tools: ${cli_tools[*]}"
 	fi
 
+	local pkg_manager
+	pkg_manager=$(detect_package_manager)
+
+	if [[ "$gh_needs_slurp_upgrade" == "true" ]]; then
+		_offer_gh_slurp_upgrade "$pkg_manager"
+	fi
+
 	# Offer to install missing tools
 	if [[ ${#missing_packages[@]} -gt 0 ]]; then
 		print_warning "Missing Git CLI tools: ${missing_names[*]}"
 		echo "  These provide enhanced Git platform integration (repos, PRs, issues)"
-
-		local pkg_manager
-		pkg_manager=$(detect_package_manager)
 
 		if [[ "$pkg_manager" != "unknown" ]]; then
 			echo ""
@@ -88,7 +141,7 @@ setup_git_clis() {
 			echo "  Ubuntu: install or upgrade gh from the GitHub CLI apt repository"
 			echo "  Fedora: sudo dnf install ${missing_packages[*]}"
 		fi
-	else
+	elif [[ "$gh_needs_slurp_upgrade" != "true" ]]; then
 		print_success "All Git CLI tools installed and ready!"
 	fi
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -196,6 +196,30 @@ aidevops_gh_slurp_status_message() {
 	return 0
 }
 
+aidevops_gh_slurp_remediation_hint() {
+	local os_name=""
+	os_name=$(uname -s 2>/dev/null || printf 'unknown')
+	case "$os_name" in
+	Linux)
+		printf 'Run aidevops setup to upgrade gh, or install GitHub CLI from the official package source for your distribution.'
+		;;
+	Darwin)
+		printf 'Run brew update && brew upgrade gh, then rerun aidevops status.'
+		;;
+	*)
+		printf 'Upgrade gh to >= %s, then rerun aidevops status.' "$AIDEVOPS_GH_MIN_SLURP_VERSION"
+		;;
+	esac
+	return 0
+}
+
+aidevops_gh_slurp_warning_line() {
+	local status_message=""
+	status_message=$(aidevops_gh_slurp_status_message)
+	printf '[WARN] %s %s' "$status_message" "$(aidevops_gh_slurp_remediation_hint)"
+	return 0
+}
+
 # =============================================================================
 # HTTP and API Constants
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-slurp-remediation.sh
+++ b/.agents/scripts/tests/test-gh-slurp-remediation.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
+UPDATE_CHECK_SCRIPT="${AGENTS_SCRIPTS}/aidevops-update-check.sh"
+TOOL_INSTALL_SCRIPT="${AGENTS_SCRIPTS}/setup/modules/tool-install.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_PATH="$PATH"
+
+cleanup() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	PATH="$ORIGINAL_PATH"
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local name="$1"
+	local status="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name" >&2
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+make_fake_gh() {
+	local version_line="$1"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/home"
+	cat >"${TEST_ROOT}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '${version_line}'
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	PATH="${TEST_ROOT}/bin:${ORIGINAL_PATH}"
+	return 0
+}
+
+call_update_prereq_check() {
+	HOME="${TEST_ROOT}/home" PATH="$PATH" bash -c "
+		set +e
+		source '${AGENTS_SCRIPTS}/shared-constants.sh'
+		$(sed -n '/_check_gh_slurp_prerequisite()/,/^}/p' "$UPDATE_CHECK_SCRIPT")
+		uname() { printf 'Linux\\n'; return 0; }
+		_check_gh_slurp_prerequisite
+	" 2>/dev/null
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "missing '${needle}' in '${haystack}'"
+	fi
+	return 0
+}
+
+make_fake_gh "gh version 2.50.0"
+old_notice=$(call_update_prereq_check)
+assert_contains "update-check emits warning for old gh" "$old_notice" "[WARN] GitHub CLI (gh) 2.50.0 is too old"
+assert_contains "update-check points Linux users at setup" "$old_notice" "Run aidevops setup to upgrade gh"
+
+make_fake_gh "gh version 2.51.0"
+new_notice=$(call_update_prereq_check)
+if [[ -z "$new_notice" ]]; then
+	print_result "update-check silent when gh supports slurp" 0
+else
+	print_result "update-check silent when gh supports slurp" 1 "got '${new_notice}'"
+fi
+
+setup_offer_output=$(bash -c "
+	set +e
+	print_info() { local msg=\"\$*\"; printf 'INFO:%s\n' \"\$msg\"; return 0; }
+	print_warning() { local msg=\"\$*\"; printf 'WARN:%s\n' \"\$msg\"; return 0; }
+	print_success() { local msg=\"\$*\"; printf 'OK:%s\n' \"\$msg\"; return 0; }
+	setup_prompt() { local var_name=\"\$1\" prompt_text=\"\$2\"; printf '%s' \"\$prompt_text\"; printf -v \"\$var_name\" '%s' 'N'; return 0; }
+	install_packages() { printf 'INSTALL:%s\n' \"\$*\"; return 0; }
+	uname() { printf 'Linux\n'; return 0; }
+	aidevops_gh_slurp_supported() { return 1; }
+	AIDEVOPS_GH_MIN_SLURP_VERSION=2.51.0
+	source '$TOOL_INSTALL_SCRIPT'
+	_offer_gh_slurp_upgrade apt
+")
+assert_contains "setup offers Linux gh upgrade" "$setup_offer_output" "Try to upgrade GitHub CLI (gh) using apt?"
+assert_contains "setup skipped path prints manual guidance" "$setup_offer_output" "official GitHub CLI package source"
+
+setup_yes_output=$(bash -c "
+	set +e
+	print_info() { local msg=\"\$*\"; printf 'INFO:%s\n' \"\$msg\"; return 0; }
+	print_warning() { local msg=\"\$*\"; printf 'WARN:%s\n' \"\$msg\"; return 0; }
+	print_success() { local msg=\"\$*\"; printf 'OK:%s\n' \"\$msg\"; return 0; }
+	setup_prompt() { local var_name=\"\$1\" prompt_text=\"\$2\"; printf '%s' \"\$prompt_text\"; printf -v \"\$var_name\" '%s' 'Y'; return 0; }
+	install_packages() { printf 'INSTALL:%s\n' \"\$*\"; return 0; }
+	uname() { printf 'Linux\n'; return 0; }
+	aidevops_gh_slurp_supported() { return 0; }
+	AIDEVOPS_GH_MIN_SLURP_VERSION=2.51.0
+	source '$TOOL_INSTALL_SCRIPT'
+	_offer_gh_slurp_upgrade apt
+")
+assert_contains "setup accepted path invokes package upgrade" "$setup_yes_output" "INSTALL:apt"
+assert_contains "setup accepted path rechecks prerequisite" "$setup_yes_output" "GitHub CLI now satisfies"
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/TODO.md
+++ b/TODO.md
@@ -961,6 +961,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3584 fix: recover worker output after runtime kills #auto-dispatch #bug ref:GH#23224 pr:#23223 completed:2026-05-08
 
+- [ ] t3588 offer gh upgrade and OpenCode prerequisite toast — follow-up to GH#23427/#23428: setup offers an explicit Linux gh upgrade/remediation path when `gh <2.51.0`, `aidevops update` and session-start update checks warn, and OpenCode greeting toast escalates the prerequisite warning. #bug #framework #no-auto-dispatch ~1h tier:standard ref:GH#23435 source:GH#23427 started:2026-05-12
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Adds a Linux setup remediation path for `gh < 2.51.0` so users can explicitly attempt a package-manager upgrade and get clear manual guidance when distro packages stay stale.
- Surfaces the same prerequisite warning during `aidevops update` and session-start update checks, including update-available paths.
- Ensures OpenCode greeting toasts classify the old-`gh` prerequisite line as a warning.

Resolves #23435
Ref #23427

## Verification
- `shellcheck .agents/scripts/shared-constants.sh .agents/scripts/setup/modules/tool-install.sh .agents/scripts/aidevops-update-check.sh .agents/scripts/aidevops-cli/aidevops-update-lib.sh .agents/scripts/tests/test-gh-slurp-remediation.sh`
- `.agents/scripts/tests/test-gh-slurp-prerequisite.sh`
- `.agents/scripts/tests/test-gh-slurp-remediation.sh`
- `.agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh`
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.32 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 47m and 412,673 tokens on this with the user in an interactive session.
