### PR TITLE
GH#23442: filter pulse dispatch candidates to issues

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1206,7 +1206,10 @@ dispatch_foss_workers() {
 		foss_issue=$(gh_issue_list --repo "$foss_slug" --state open \
 			--label "${labels_filter%%,*}" --limit 1 \
 			--json number,title --jq '(.[0] // {}) | "\(.number // "")|\(.title // "")"' 2>/dev/null) || foss_issue=""
-		[[ -n "$foss_issue" ]] || continue
+		if [[ -z "$foss_issue" ]]; then
+			echo "[pulse-wrapper] FOSS dispatch skipped no issue selection for ${foss_slug}: gh_issue_list returned empty output" >>"$LOGFILE"
+			continue
+		fi
 
 		foss_issue_num="${foss_issue%%|*}"
 		foss_issue_title="${foss_issue#*|}"

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -224,6 +224,11 @@ list_dispatchable_issue_candidates_json() {
 			.[] |
 			(.labels | map(.name)) as $labels |
 			(.assignees | map(.login)) as $assignees |
+			# GH#23442: REST /repos/{owner}/{repo}/issues can include pull
+			# requests. Keep dispatch candidate enumeration issue-only when
+			# gh_issue_list falls back to REST or a wrapper returns mixed results.
+			select((.pullRequest // .pull_request // null) == null) |
+			select((((.url // "") | tostring | contains("/pull/"))) | not) |
 			select(($labels | index("status:blocked")) == null) |
 			select(([$labels[] | select(startswith("needs-"))] | length) == 0) |
 			select(($labels | index("supervisor")) == null) |

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1260,7 +1260,10 @@ _rest_issue_list_json_jq() {
 		esac
 	done < <(_rest_split_csv "$fields")
 	[[ -z "$projection" ]] && projection="number: .number"
-	local jq_expr="[.[] | {${projection}}]"
+	# GH#23442: /repos/{owner}/{repo}/issues returns issues and pull requests;
+	# gh issue list returns issues only. Preserve gh-compatible semantics in the
+	# REST fallback so dispatch candidate enumeration cannot surface PR targets.
+	local jq_expr="[.[] | select(.pull_request == null) | {${projection}}]"
 	[[ -n "$user_jq" ]] && jq_expr="${jq_expr} | ${user_jq}"
 	printf '%s' "$jq_expr"
 	return 0

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -26,15 +26,16 @@
 #   6. _rest_issue_list → includes label filter in query string
 #   7. _rest_issue_list → handles multiple --label flags (comma-joined)
 #   8. _rest_issue_list → applies --jq expression
-#   9. _rest_issue_list → includes --assignee in query string
-#  10. _rest_issue_list → returns error when --repo is missing
-#  11. gh_issue_view falls back to REST when primary fails AND GraphQL exhausted
-#  12. gh_issue_view does NOT fall back when primary succeeds
-#  13. gh_issue_view does NOT fall back when primary fails but GraphQL healthy
-#  14. gh_issue_list falls back to REST when primary fails AND GraphQL exhausted
-#  15. gh_issue_list does NOT fall back when primary succeeds
-#  16. gh_issue_list does NOT fall back when primary fails but GraphQL healthy
-#  17. _rest_issue_list handles --search flag without error (silently skipped)
+#   9. _rest_issue_list → filters pull requests returned by REST /issues
+#  10. _rest_issue_list → includes --assignee in query string
+#  11. _rest_issue_list → returns error when --repo is missing
+#  12. gh_issue_view falls back to REST when primary fails AND GraphQL exhausted
+#  13. gh_issue_view does NOT fall back when primary succeeds
+#  14. gh_issue_view does NOT fall back when primary fails but GraphQL healthy
+#  15. gh_issue_list falls back to REST when primary fails AND GraphQL exhausted
+#  16. gh_issue_list does NOT fall back when primary succeeds
+#  17. gh_issue_list does NOT fall back when primary fails but GraphQL healthy
+#  18. _rest_issue_list handles --search flag without error (silently skipped)
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -336,7 +337,23 @@ fi
 unset STUB_REST_LIST_RESULT
 
 # =============================================================================
-# Test 9: _rest_issue_list includes --assignee in query string
+# Test 9: _rest_issue_list filters pull requests returned by REST /issues
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REST_LIST_RESULT='[{"number":7,"title":"Issue","html_url":"https://github.com/owner/repo/issues/7"},{"number":8,"title":"PR","html_url":"https://github.com/owner/repo/pull/8","pull_request":{"url":"https://api.github.com/repos/owner/repo/pulls/8"}}]'
+
+result=$(_rest_issue_list --repo "owner/repo" --state open --json number,title,url --jq 'map(.number) | join(",")' 2>/dev/null)
+
+if [[ "$result" == "7" ]]; then
+	pass "_rest_issue_list filters pull requests returned by REST /issues"
+else
+	fail "_rest_issue_list filters pull requests returned by REST /issues" \
+		"expected '7', got '${result}'"
+fi
+unset STUB_REST_LIST_RESULT
+
+# =============================================================================
+# Test 10: _rest_issue_list includes --assignee in query string
 # =============================================================================
 : >"$GH_CALLS"
 
@@ -350,7 +367,7 @@ else
 fi
 
 # =============================================================================
-# Test 10: _rest_issue_list returns error when --repo is missing
+# Test 11: _rest_issue_list returns error when --repo is missing
 # =============================================================================
 _err_output=$(_rest_issue_list --state open 2>&1)
 _rc=$?

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -99,6 +99,14 @@ available_after_null="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$
 [[ "$available_after_null" == "2" ]] || fail "null selection changed available worker count"
 [[ ! -f "$HEADLESS_INVOCATION_LOG" ]] || fail "null selection launched a worker"
 
+GH_ISSUE_LIST_OUTPUT=''
+available_after_empty="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json")" || fail "empty selection dispatch failed"
+[[ "$available_after_empty" == "2" ]] || fail "empty selection changed available worker count"
+[[ ! -f "$HEADLESS_INVOCATION_LOG" ]] || fail "empty selection launched a worker"
+if ! grep -q 'FOSS dispatch skipped no issue selection for owner/project' "$LOGFILE"; then
+	fail "empty selection did not log an auditable no-work reason"
+fi
+
 GH_ISSUE_LIST_OUTPUT='42|Fix duplicate dispatch'
 available_output="${TEST_TMP}/available.out"
 FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json" >"$available_output" || fail "duplicate selection dispatch failed"
@@ -114,5 +122,6 @@ if ! grep -q -- '--session-key foss-owner/project-42' "$HEADLESS_INVOCATION_LOG"
 fi
 
 printf 'PASS: FOSS null issue selections are skipped\n'
+printf 'PASS: FOSS empty issue selections are logged as no work\n'
 printf 'PASS: FOSS duplicate session keys are deduplicated per cycle\n'
 exit 0

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -928,6 +928,50 @@ JSON
 	return 0
 }
 
+test_build_ranked_dispatch_candidates_json_excludes_pull_requests() {
+	local original_repos_json="$REPOS_JSON"
+	cat >"${REPOS_JSON}" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "marcusquinn/aidevops",
+      "path": "/tmp/aidevops",
+      "pulse": true,
+      "priority": "tooling",
+      "maintainer": "marcusquinn"
+    }
+  ]
+}
+JSON
+
+	gh_issue_list() {
+		if [[ "${1:-}" == "--repo" && "${2:-}" == "marcusquinn/aidevops" ]]; then
+			printf '%s\n' '[
+			  {"number":9301,"title":"pull request target","url":"https://github.com/marcusquinn/aidevops/pull/9301","updatedAt":"2026-03-31T00:01:00Z","assignees":[],"labels":[{"name":"bug"}],"pull_request":{"url":"https://api.github.com/repos/marcusquinn/aidevops/pulls/9301"}},
+			  {"number":9302,"title":"issue target","url":"https://github.com/marcusquinn/aidevops/issues/9302","updatedAt":"2026-03-31T00:02:00Z","assignees":[],"labels":[{"name":"bug"}]}
+			]'
+			return 0
+		fi
+		return 1
+	}
+	export -f gh_issue_list
+
+	local ordered_numbers
+	ordered_numbers=$(build_ranked_dispatch_candidates_json 20 | jq -r '.[].number' 2>/dev/null || true)
+
+	unset -f gh_issue_list
+	REPOS_JSON="$original_repos_json"
+
+	if [[ "$ordered_numbers" == "9302" ]]; then
+		print_result "build_ranked_dispatch_candidates_json excludes pull requests from implementation dispatch" 0
+		return 0
+	fi
+
+	print_result "build_ranked_dispatch_candidates_json excludes pull requests from implementation dispatch" 1 \
+		"Unexpected candidate numbers: ${ordered_numbers}"
+	return 0
+}
+
 test_dispatch_max_dispatches_up_to_capacity() {
 	local dispatch_log="${TEST_ROOT}/deterministic-dispatch.log"
 	: >"$dispatch_log"
@@ -1329,6 +1373,7 @@ main() {
 	test_build_ranked_dispatch_candidates_json_scores_candidates
 	test_build_ranked_dispatch_candidates_json_respects_priority_labels
 	test_build_ranked_dispatch_candidates_json_prioritizes_security_quality_debt
+	test_build_ranked_dispatch_candidates_json_excludes_pull_requests
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_build_ranked_dispatch_candidates_json_accepts_array_pulse_hours
 	test_dispatch_max_dispatches_up_to_capacity


### PR DESCRIPTION
## Summary

Filtered REST/mixed issue-list results so pulse implementation dispatch only ranks issue targets, and made empty FOSS issue selections log an auditable no-work reason.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/pulse-repo-meta.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh,.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh,.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; bash .agents/scripts/tests/test-gh-issue-read-rest-fallback.sh (new REST PR-filter case passed; existing REST-first expectation failures remain); bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh (new PR-exclusion case passed; existing dispatch launch fixture failures remain); shellcheck modified shell files; focused list_dispatchable_issue_candidates_json issue-only check

Resolves #23442


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 194,531 tokens on this as a headless worker.