### PR TITLE
GH#23446: fix: preserve empty FOSS issue selections

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1205,7 +1205,7 @@ dispatch_foss_workers() {
 			"$repos_json" 2>/dev/null || echo "help wanted")
 		foss_issue=$(gh_issue_list --repo "$foss_slug" --state open \
 			--label "${labels_filter%%,*}" --limit 1 \
-			--json number,title --jq '(.[0] // {}) | "\(.number // "")|\(.title // "")"' 2>/dev/null) || foss_issue=""
+			--json number,title --jq '.[] | "\(.number // "")|\(.title // "")"') || foss_issue=""
 		if [[ -z "$foss_issue" ]]; then
 			echo "[pulse-wrapper] FOSS dispatch skipped no issue selection for ${foss_slug}: gh_issue_list returned empty output" >>"$LOGFILE"
 			continue


### PR DESCRIPTION
## Summary

Updated FOSS issue selection to emit no output for empty gh_issue_list results so the existing no-selection audit log path runs.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-ancillary-dispatch.sh

Resolves #23446


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 99,052 tokens on this as a headless worker.