### PR TITLE
GH#23447: deduplicate gh slurp prerequisite guidance

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-gh-prereq-toast.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-gh-prereq-toast.mjs
@@ -8,7 +8,7 @@ import { classifyLines, buildToast } from "../greeting.mjs";
 test("gh prerequisite warnings become OpenCode warning toasts", () => {
   const buckets = classifyLines([
     "aidevops v3.15.32 running in OpenCode v1.14.48",
-    "[WARN] GitHub CLI prerequisite: GitHub CLI (gh) detected version 2.45.0 is too old; gh api --paginate --slurp requires gh >= 2.51.0.",
+    "[WARN] GitHub CLI prerequisite: GitHub CLI (gh) detected version 2.45.0 is too old; gh api --paginate --slurp requires gh >= 2.51.0. On Ubuntu/Debian, avoid apt-pinned Ubuntu universe gh packages such as 2.45.0; install or upgrade from the official GitHub CLI package repository, then rerun aidevops status.",
   ].join("\n"));
 
   const toast = buildToast(buckets);

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -187,7 +187,7 @@ aidevops_gh_slurp_status_message() {
 	installed=$(aidevops_gh_installed_version) || installed="unknown"
 	if [[ "$installed" == "unknown" ]]; then
 		printf 'GitHub CLI (gh) version could not be parsed; gh api --paginate --slurp requires gh >= %s; gh --version output is malformed or empty. %s' \
-			"$AIDEVOPS_GH_MIN_SLURP_VERSION" "$(aidevops_gh_slurp_remediation_guidance)"
+			"$AIDEVOPS_GH_MIN_SLURP_VERSION" "$(aidevops_gh_slurp_remediation_guidance "$installed")"
 		return 0
 	fi
 	if aidevops_version_at_least "$installed" "$AIDEVOPS_GH_MIN_SLURP_VERSION"; then
@@ -202,12 +202,13 @@ aidevops_gh_slurp_status_message() {
 
 aidevops_gh_slurp_remediation_guidance() {
 	local installed="${1:-}"
-	if [[ -n "$installed" ]]; then
-		printf 'Upgrade gh to >= %s. On Ubuntu/Debian, avoid apt-pinned Ubuntu universe gh packages such as %s; install or upgrade from the official GitHub CLI package repository, then rerun aidevops status.' \
-			"$AIDEVOPS_GH_MIN_SLURP_VERSION" "$installed"
+	if [[ "$installed" == "unknown" ]]; then
+		printf 'On Ubuntu/Debian, fix or upgrade the existing gh installation from the official GitHub CLI package repository rather than the Ubuntu universe package, then rerun aidevops status.'
+	elif [[ -n "$installed" ]]; then
+		printf 'On Ubuntu/Debian, avoid apt-pinned Ubuntu universe gh packages such as %s; install or upgrade from the official GitHub CLI package repository, then rerun aidevops status.' \
+			"$installed"
 	else
-		printf 'Install gh >= %s. On Ubuntu/Debian, use the official GitHub CLI package repository rather than the Ubuntu universe package, then rerun aidevops status.' \
-			"$AIDEVOPS_GH_MIN_SLURP_VERSION"
+		printf 'On Ubuntu/Debian, use the official GitHub CLI package repository rather than the Ubuntu universe package, then rerun aidevops status.'
 	fi
 	return 0
 }
@@ -232,7 +233,7 @@ aidevops_gh_slurp_remediation_hint() {
 aidevops_gh_slurp_warning_line() {
 	local status_message=""
 	status_message=$(aidevops_gh_slurp_status_message)
-	printf '[WARN] GitHub CLI prerequisite: %s %s' "$status_message" "$(aidevops_gh_slurp_remediation_hint)"
+	printf '[WARN] GitHub CLI prerequisite: %s' "$status_message"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Reduced duplicated GitHub CLI slurp prerequisite remediation text, preserved existing-install guidance for malformed gh output, and aligned the OpenCode toast fixture with real warning output.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-greeting-gh-prereq-toast.mjs,.agents/scripts/shared-constants.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-constants.sh .agents/scripts/tests/test-gh-slurp-prerequisite.sh; bash .agents/scripts/tests/test-gh-slurp-prerequisite.sh; node --test .agents/plugins/opencode-aidevops/tests/test-greeting-gh-prereq-toast.mjs

Resolves #23447


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 117,350 tokens on this as a headless worker.