### PR TITLE
GH#23452: address gh setup review followups

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -131,14 +131,14 @@ setup_git_clis() {
 				echo ""
 				echo "📋 Manual installation:"
 				echo "  macOS: brew install ${missing_packages[*]}"
-				echo "  Ubuntu: install or upgrade gh from the GitHub CLI apt repository"
+				echo "  Ubuntu: sudo apt install ${missing_packages[*]} (Note: for gh >= 2.51.0, use the GitHub CLI apt repository)"
 				echo "  Fedora: sudo dnf install ${missing_packages[*]}"
 			fi
 		else
 			echo ""
 			echo "📋 Manual installation:"
 			echo "  macOS: brew install ${missing_packages[*]}"
-			echo "  Ubuntu: install or upgrade gh from the GitHub CLI apt repository"
+			echo "  Ubuntu: sudo apt install ${missing_packages[*]} (Note: for gh >= 2.51.0, use the GitHub CLI apt repository)"
 			echo "  Fedora: sudo dnf install ${missing_packages[*]}"
 		fi
 	elif [[ "$gh_needs_slurp_upgrade" != "true" ]]; then

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -139,7 +139,11 @@ aidevops_version_at_least() {
 	local minimum_major minimum_minor minimum_patch
 	IFS='.' read -r current_major current_minor current_patch <<<"$current"
 	IFS='.' read -r minimum_major minimum_minor minimum_patch <<<"$minimum"
+	current_major="${current_major:-0}"
+	current_minor="${current_minor:-0}"
 	current_patch="${current_patch:-0}"
+	minimum_major="${minimum_major:-0}"
+	minimum_minor="${minimum_minor:-0}"
 	minimum_patch="${minimum_patch:-0}"
 	[[ "$current_major$current_minor$current_patch$minimum_major$minimum_minor$minimum_patch" =~ ^[0-9]+$ ]] || return 1
 	if ((current_major > minimum_major)); then


### PR DESCRIPTION
## Summary
- Harden `aidevops_version_at_least` so missing semver major/minor/patch components default to `0` before arithmetic comparisons.
- Restore Ubuntu manual install instructions to include all missing packages while preserving the `gh >= 2.51.0` repository note.

## Testing
- `shellcheck .agents/scripts/shared-constants.sh .agents/scripts/setup/modules/tool-install.sh`
- `bash -c 'set -euo pipefail; source .agents/scripts/shared-constants.sh; aidevops_version_at_least 2 1.9.0; aidevops_version_at_least 2.51 2.51.0; if aidevops_version_at_least 2.50 2.51.0; then exit 1; fi; if aidevops_version_at_least "2.beta" 2.51.0; then exit 1; fi'`

## Runtime Testing
- self-assessed: low-risk shell helper bugfix verified with ShellCheck and targeted function tests.

Resolves #23452


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) with gpt-5.5 spent 2m and 91,316 tokens on this with the user in an interactive session.