### PR TITLE
GH#23450: harden stats runner identity fallback

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -68,14 +68,14 @@ _resolve_current_gh_login_or_fallback() {
 	local gh_login=""
 	local fallback_login=""
 
-	gh_login=$(gh api user --jq '.login' 2>/dev/null) || gh_login=""
+	gh_login=$(gh api user --jq '.login // ""') || gh_login=""
 	if [[ "$gh_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
 		printf '%s' "$gh_login"
 		return 0
 	fi
 
 	fallback_login=$(whoami 2>/dev/null) || fallback_login=""
-	if [[ "$fallback_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+	if [[ "$fallback_login" =~ ^[[:alnum:]._-]+$ ]]; then
 		echo "[stats] GitHub login unavailable or invalid; using local fallback identity: ${fallback_login}" \
 			>>"${LOGFILE:-/dev/null}"
 		printf '%s' "$fallback_login"

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -32,6 +32,10 @@ gh() {
 	local call="$*"
 	printf '%s\n' "$call" >>"$GH_CALLS"
 	case "${HEALTH_FIXTURE:-}:$call" in
+		empty_login:*"api user --jq .login"*)
+			printf '%s' ''
+			return 0
+			;;
 		rate_limit_login:*"api user --jq .login"*)
 			printf '%s' '{"message":"API rate limit exceeded", "status":"403"}' >&2
 			return 1
@@ -59,6 +63,16 @@ gh() {
 		*) return 0 ;;
 	esac
 	return 0
+}
+
+# shellcheck disable=SC2317
+whoami() {
+	if [[ -n "${HEALTH_WHOAMI_FIXTURE:-}" ]]; then
+		printf '%s' "$HEALTH_WHOAMI_FIXTURE"
+		return 0
+	fi
+	command whoami "$@"
+	return $?
 }
 
 # shellcheck disable=SC2317
@@ -221,6 +235,17 @@ if [[ "$resolved_login" != *"message"* && "$resolved_login" =~ ^[A-Za-z0-9]([A-Z
 	pass "falls back to validated local identity when gh login is rate limited"
 else
 	fail "falls back to validated local identity when gh login is rate limited" "resolved=${resolved_login}"
+fi
+
+export HEALTH_FIXTURE=empty_login
+export HEALTH_WHOAMI_FIXTURE="local.user_name"
+resolved_login=$(_resolve_current_gh_login_or_fallback)
+unset HEALTH_FIXTURE HEALTH_WHOAMI_FIXTURE
+
+if [[ "$resolved_login" == "local.user_name" ]]; then
+	pass "allows dotted and underscored local fallback identities"
+else
+	fail "allows dotted and underscored local fallback identities" "resolved=${resolved_login}"
 fi
 
 unsafe_cache=$(_sanitize_runner_identity_for_cache '{"message":"API rate limit exceeded", "status":"403"}local-user')


### PR DESCRIPTION
## Summary

Hardened stats health dashboard runner identity resolution so null GitHub logins become empty fallbacks and dotted/underscored local identities are accepted.

## Files Changed

.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

Resolves #23450


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 90,426 tokens on this as a headless worker.