### PR TITLE
GH#23453: reuse linked issue during conflict routing

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -628,9 +628,7 @@ _process_single_ready_pr() {
 			# PRs to fix workers before the protected-close precheck. Active
 			# interactive PRs remain protected because _route_pr_to_fix_worker only
 			# accepts origin:interactive after _interactive_pr_is_stale passes.
-			local _conf_linked_issue
-			_conf_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
-			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_conf_linked_issue" "conflict" "" "$pr_title"; then
+			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "" "$pr_title"; then
 				return 2
 			fi
 


### PR DESCRIPTION
## Summary

Reused the already-extracted linked issue when routing conflicting PRs to fix workers, avoiding a redundant _extract_linked_issue call and extra GitHub API reads.

## Files Changed

.agents/scripts/pulse-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge.sh; bash .agents/tests/test-pulse-merge-conflict.sh; bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh (pre-existing harness failure: _ci_terminal_failed_check_results not found)

Resolves #23453


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 46,595 tokens on this as a headless worker.