### PR TITLE
GH#23451: propagate fix-the-fixer mtime failures

### DIFF
--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -113,7 +113,13 @@ _file_mtime() {
 		printf 'missing\n'
 		return 0
 	}
-	_file_mtime_epoch "$path" 2>/dev/null || printf 'unknown'
+	local mtime
+	mtime=$(_file_mtime_epoch "$path" 2>/dev/null) || {
+		local rc=$?
+		printf 'unknown\n'
+		return "$rc"
+	}
+	printf '%s\n' "$mtime"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
+++ b/.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
@@ -90,9 +90,45 @@ run_detector() {
 	return 0
 }
 
+assert_file_mtime_helpers() {
+	# shellcheck source=/dev/null
+	source "${PWD}/.agents/scripts/pulse-fix-the-fixer-detector.sh"
+
+	if declare -f _file_mtime_epoch >/dev/null 2>&1; then
+		print_result "detector imports portable mtime helper" 0
+	else
+		print_result "detector imports portable mtime helper" 1 "_file_mtime_epoch unavailable"
+	fi
+
+	local missing_stamp
+	missing_stamp=$(_file_mtime "${TEST_ROOT}/missing-config")
+	if [[ "$missing_stamp" == "missing" ]]; then
+		print_result "missing config stamp is explicit" 0
+	else
+		print_result "missing config stamp is explicit" 1 "stamp=${missing_stamp}"
+	fi
+
+	_file_mtime_epoch() {
+		return 42
+	}
+
+	local existing_file="${TEST_ROOT}/existing-config"
+	: >"$existing_file"
+	local failed_stamp=""
+	local rc=0
+	failed_stamp=$(_file_mtime "$existing_file") || rc=$?
+	if [[ "$rc" -eq 42 && "$failed_stamp" == "unknown" ]]; then
+		print_result "mtime helper failures propagate" 0
+	else
+		print_result "mtime helper failures propagate" 1 "rc=${rc} stamp=${failed_stamp}"
+	fi
+	return 0
+}
+
 main() {
 	setup_sandbox
 	trap teardown_sandbox EXIT
+	assert_file_mtime_helpers
 
 	local first_log="${TEST_ROOT}/first.log"
 	local second_log="${TEST_ROOT}/second.log"


### PR DESCRIPTION
## Summary

- Propagates `_file_mtime_epoch` failures from the fix-the-fixer detector mtime wrapper instead of masking them.
- Adds regression coverage proving the detector imports the portable mtime helper, keeps missing files as deterministic `missing` stamps, and returns `unknown` with the helper failure code for real mtime errors.

## Testing

- `shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`
- `.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`

## Runtime Testing

Self-assessed: shell helper bugfix covered by focused shell regression test; no long-running runtime service required.

Resolves #23451


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 113,525 tokens on this with the user in an interactive session.
