### PR TITLE
GH#23449: harden pulse PR view cache lifecycle

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1807,8 +1807,16 @@ main() {
 	if [[ "${AIDEVOPS_PULSE_PR_VIEW_CACHE:-1}" == "1" ]]; then
 		export AIDEVOPS_GH_PR_VIEW_CACHE=1
 		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-view-cache-${$}"
-		rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" 2>/dev/null || true
-		mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" 2>/dev/null || true
+		_save_cleanup_scope
+		trap '_run_cleanups' RETURN
+		push_cleanup 'release_instance_lock'
+		push_cleanup "rm -rf \"${AIDEVOPS_GH_PR_VIEW_CACHE_DIR}\""
+		if ! rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
+			printf '[pulse-wrapper] Failed to reset REST PR view cache directory: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
+		fi
+		if ! mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
+			printf '[pulse-wrapper] Failed to create REST PR view cache directory: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
+		fi
 		echo "[pulse-wrapper] Per-cycle REST PR view cache enabled for duplicate repo#PR reads (GH#23433)" >>"$LOGFILE"
 	fi
 

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1065,7 +1065,23 @@ _rest_pr_view() {
 		if [[ $_rc -ne 0 ]]; then
 			return $_rc
 		fi
-		printf '%s\n' "$raw_json" >"$cache_path" 2>/dev/null || true
+		local _tmp_cache="${cache_path}.tmp.$$"
+		if printf '%s\n' "$raw_json" >"$_tmp_cache"; then
+			:
+		else
+			_rc=$?
+			printf '_rest_pr_view: failed to write temporary cache file: %s\n' "$_tmp_cache" >&2
+			rm -f "$_tmp_cache"
+			return $_rc
+		fi
+		if mv "$_tmp_cache" "$cache_path"; then
+			:
+		else
+			_rc=$?
+			printf '_rest_pr_view: failed to move temporary cache file %s to cache path: %s\n' "$_tmp_cache" "$cache_path" >&2
+			rm -f "$_tmp_cache"
+			return $_rc
+		fi
 		_rest_pr_view_emit_json "$raw_json" "$json_fields" "$jq_expr"
 		return $?
 	fi


### PR DESCRIPTION
## Summary

Uses the shared cleanup stack to remove the per-cycle pulse PR view cache directory and writes REST PR view cache entries via a temporary file plus atomic mv with path-specific diagnostics.

## Files Changed

.agents/scripts/pulse-wrapper.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh; env -u AIDEVOPS_GH_PR_VIEW_CACHE -u AIDEVOPS_GH_PR_VIEW_CACHE_DIR bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; AIDEVOPS_PULSE_PR_VIEW_CACHE=1 .agents/scripts/pulse-wrapper.sh --canary

Resolves #23449


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 216,610 tokens on this as a headless worker.