### PR TITLE
GH#23466: document stats fallback identity validation

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -75,7 +75,10 @@ _resolve_current_gh_login_or_fallback() {
 	fi
 
 	fallback_login=$(whoami 2>/dev/null) || fallback_login=""
-	if [[ "$fallback_login" =~ ^[[:alnum:]._-]+$ ]]; then
+	# Local system usernames are not GitHub logins; accept common POSIX-safe
+	# account characters while rejecting whitespace/control characters because
+	# this value is reused in labels, cache keys, and gh CLI arguments.
+	if [[ "$fallback_login" =~ ^[[:alnum:]_.-]+$ ]]; then
 		echo "[stats] GitHub login unavailable or invalid; using local fallback identity: ${fallback_login}" \
 			>>"${LOGFILE:-/dev/null}"
 		printf '%s' "$fallback_login"

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -238,14 +238,25 @@ else
 fi
 
 export HEALTH_FIXTURE=empty_login
-export HEALTH_WHOAMI_FIXTURE="local.user_name"
+export HEALTH_WHOAMI_FIXTURE="local.user-name"
 resolved_login=$(_resolve_current_gh_login_or_fallback)
 unset HEALTH_FIXTURE HEALTH_WHOAMI_FIXTURE
 
-if [[ "$resolved_login" == "local.user_name" ]]; then
-	pass "allows dotted and underscored local fallback identities"
+if [[ "$resolved_login" == "local.user-name" ]]; then
+	pass "allows dotted underscored and hyphenated local fallback identities"
 else
-	fail "allows dotted and underscored local fallback identities" "resolved=${resolved_login}"
+	fail "allows dotted underscored and hyphenated local fallback identities" "resolved=${resolved_login}"
+fi
+
+export HEALTH_FIXTURE=empty_login
+export HEALTH_WHOAMI_FIXTURE="local/user"
+resolved_login=$(_resolve_current_gh_login_or_fallback)
+unset HEALTH_FIXTURE HEALTH_WHOAMI_FIXTURE
+
+if [[ "$resolved_login" == "unknown-runner" ]]; then
+	pass "rejects unsafe local fallback identities before label and cache use"
+else
+	fail "rejects unsafe local fallback identities before label and cache use" "resolved=${resolved_login}"
 fi
 
 unsafe_cache=$(_sanitize_runner_identity_for_cache '{"message":"API rate limit exceeded", "status":"403"}local-user')


### PR DESCRIPTION
## Summary

Clarified local fallback identity validation for stats health dashboards and added regression coverage for POSIX-safe local usernames plus unsafe fallback rejection.

## Files Changed

.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/tests/test-health-dashboard-identity-aliases.sh; shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

Resolves #23466


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 62,423 tokens on this as a headless worker.