### PR TITLE
GH#23469: test: update handover staleness seconds labels

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
+++ b/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
@@ -5,7 +5,7 @@
 # Tests for _interactive_pr_is_stale() and _interactive_pr_trigger_handover()
 # (t2189).
 #
-# An origin:interactive PR that has sat idle past AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS
+# An origin:interactive PR that has sat idle past IDLE_INTERACTIVE_HANDOVER_SECONDS
 # without any active-session signal (no claim stamp, no status:* label on linked
 # issue) must be handover-eligible so the worker pipeline (CI fix, conflict fix,
 # review fix) can drive it to merge. The helpers isolate the staleness signal
@@ -401,10 +401,10 @@ test_K_no_takeover_label_blocks_handover() {
 }
 
 # =============================================================================
-# t2383 Fix 2: invalid HOURS value returns not-stale safely
+# t2383 Fix 2: invalid seconds value returns not-stale safely
 # =============================================================================
 
-test_L_invalid_hours_returns_not_stale() {
+test_L_invalid_seconds_returns_not_stale() {
 	reset_mock_state
 	# "24h" is non-numeric — should not crash bash arithmetic
 	IDLE_INTERACTIVE_HANDOVER_SECONDS="24h" \
@@ -412,59 +412,59 @@ test_L_invalid_hours_returns_not_stale() {
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
 	if [[ "$rc" -ne 1 ]]; then
-		print_result "L: invalid HOURS ('24h') returns not-stale" 1 "Expected 1, got $rc"
+		print_result "L: invalid seconds ('24h') returns not-stale" 1 "Expected 1, got $rc"
 		return 0
 	fi
 	if ! grep -q "invalid IDLE_INTERACTIVE_HANDOVER_SECONDS" "$LOGFILE"; then
-		print_result "L: invalid HOURS logs validation error" 1 \
+		print_result "L: invalid seconds logs validation error" 1 \
 			"Expected validation error in LOGFILE. Got: $(cat "$LOGFILE")"
 		return 0
 	fi
-	print_result "L: invalid HOURS returns not-stale with log message" 0
+	print_result "L: invalid seconds returns not-stale with log message" 0
 	return 0
 }
 
-test_L2_zero_hours_returns_not_stale() {
+test_L2_zero_seconds_returns_not_stale() {
 	reset_mock_state
 	IDLE_INTERACTIVE_HANDOVER_SECONDS="0" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
 	if [[ "$rc" -ne 1 ]]; then
-		print_result "L2: zero HOURS returns not-stale" 1 "Expected 1, got $rc"
+		print_result "L2: zero seconds returns not-stale" 1 "Expected 1, got $rc"
 		return 0
 	fi
-	print_result "L2: zero HOURS returns not-stale" 0
+	print_result "L2: zero seconds returns not-stale" 0
 	return 0
 }
 
-test_L3_empty_hours_uses_default_24() {
+test_L3_empty_seconds_uses_default_14400() {
 	reset_mock_state
-	# Empty HOURS triggers bash's :- default substitution to "24", which is valid.
+	# Empty seconds triggers bash's :- default substitution to "14400", which is valid.
 	# The PR is 48h old (reset_mock_state default), so it should return stale (0).
 	IDLE_INTERACTIVE_HANDOVER_SECONDS="" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
 	if [[ "$rc" -ne 0 ]]; then
-		print_result "L3: empty HOURS falls back to default 24 (stale)" 1 "Expected 0 (stale), got $rc"
+		print_result "L3: empty seconds falls back to default 14400 (stale)" 1 "Expected 0 (stale), got $rc"
 		return 0
 	fi
-	print_result "L3: empty HOURS falls back to default 24 (stale)" 0
+	print_result "L3: empty seconds falls back to default 14400 (stale)" 0
 	return 0
 }
 
-test_L4_negative_hours_returns_not_stale() {
+test_L4_negative_seconds_returns_not_stale() {
 	reset_mock_state
 	IDLE_INTERACTIVE_HANDOVER_SECONDS="-5" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
 	if [[ "$rc" -ne 1 ]]; then
-		print_result "L4: negative HOURS returns not-stale" 1 "Expected 1, got $rc"
+		print_result "L4: negative seconds returns not-stale" 1 "Expected 1, got $rc"
 		return 0
 	fi
-	print_result "L4: negative HOURS returns not-stale" 0
+	print_result "L4: negative seconds returns not-stale" 0
 	return 0
 }
 
@@ -503,10 +503,10 @@ main() {
 	test_I_mode_enforce_applies_label_and_posts_comment
 	test_J_enforce_is_idempotent_when_label_already_present
 	test_K_no_takeover_label_blocks_handover
-	test_L_invalid_hours_returns_not_stale
-	test_L2_zero_hours_returns_not_stale
-	test_L3_empty_hours_uses_default_24
-	test_L4_negative_hours_returns_not_stale
+	test_L_invalid_seconds_returns_not_stale
+	test_L2_zero_seconds_returns_not_stale
+	test_L3_empty_seconds_uses_default_14400
+	test_L4_negative_seconds_returns_not_stale
 
 	printf '\n=== %d test(s), %d failure(s) ===\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Updated pulse merge interactive handover test naming, comments, and result strings to use IDLE_INTERACTIVE_HANDOVER_SECONDS and the 14400-second default.

## Files Changed

.agents/scripts/tests/test-pulse-merge-interactive-handover.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-interactive-handover.sh; shellcheck .agents/scripts/tests/test-pulse-merge-interactive-handover.sh

Resolves #23469


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 55,929 tokens on this as a headless worker.