### PR TITLE
GH#23455: optimize stale handover checks

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -223,6 +223,8 @@ Every pulse cycle the deterministic merge pass evaluates open PRs with merge con
 _interactive_pr_is_stale() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local precomputed_updated_at="${3:-}"
+	local precomputed_head_ref_oid="${4:-}"
 	local mode="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE:-detect}"
 	[[ "$mode" == "off" ]] && return 1
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
@@ -258,19 +260,29 @@ _interactive_pr_is_stale() {
 		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid IDLE_INTERACTIVE_HANDOVER_SECONDS='${threshold_secs}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
 		return 1
 	fi
-	local head_ref_oid=""
-	head_ref_oid=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // empty')
-	if [[ -n "$head_ref_oid" ]]; then
+	now_epoch=$(date +%s)
+	activity_at="${precomputed_updated_at:-}"
+	if [[ -z "$activity_at" ]]; then
+		activity_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
+	fi
+	if [[ -n "$activity_at" ]]; then
+		updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
+			updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \
+			return 1
+		pr_age_secs=$(( now_epoch - updated_epoch ))
+		[[ "$pr_age_secs" -ge "$threshold_secs" ]] && activity_source="updatedAt"
+	fi
+
+	local head_ref_oid="${precomputed_head_ref_oid:-}"
+	if [[ "$pr_age_secs" -lt "$threshold_secs" && -z "$head_ref_oid" ]]; then
+		head_ref_oid=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // empty')
+	fi
+	if [[ "$pr_age_secs" -lt "$threshold_secs" && -n "$head_ref_oid" ]]; then
 		activity_at=$(gh api "repos/${repo_slug}/commits/${head_ref_oid}" \
 			--jq '.commit.committer.date // .commit.author.date // empty' 2>/dev/null) || activity_at=""
 		[[ -n "$activity_at" ]] && activity_source="head_commit"
 	fi
-	if [[ -z "$activity_at" ]]; then
-		activity_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
-		activity_source="updatedAt"
-	fi
 	[[ -z "$activity_at" ]] && return 1
-	now_epoch=$(date +%s)
 	# Portable epoch parse — GNU date first (Linux CI), BSD date fallback (macOS)
 	updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
 		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \

--- a/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
+++ b/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
@@ -245,6 +245,25 @@ test_D_idle_no_stamp_no_status_returns_stale() {
 	return 0
 }
 
+test_D2_updated_at_stale_skips_head_commit_lookup() {
+	reset_mock_state
+	# Defaults: updatedAt is already 48h old, so the PR is stale without the
+	# additional commit API lookup. This keeps handover scans cheap when the
+	# cheaper PR metadata signal is sufficient.
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce _interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "D2: stale updatedAt returns stale without head commit lookup" 1 "Expected 0, got $rc"
+		return 0
+	fi
+	if grep -q "/commits/" "$GH_LOG"; then
+		print_result "D2: stale updatedAt skips head commit lookup" 1 "Unexpected commit API call: $(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "D2: stale updatedAt skips head commit lookup" 0
+	return 0
+}
+
 test_E_missing_origin_interactive_returns_not_stale() {
 	reset_mock_state
 	printf 'origin:worker,enhancement' >"${TEST_ROOT}/labels.txt"
@@ -440,7 +459,7 @@ test_L2_zero_seconds_returns_not_stale() {
 
 test_L3_empty_seconds_uses_default_14400() {
 	reset_mock_state
-	# Empty seconds triggers bash's :- default substitution to "14400", which is valid.
+	# Empty seconds triggers bash's :- default substitution to "14400" (4h), which is valid.
 	# The PR is 48h old (reset_mock_state default), so it should return stale (0).
 	IDLE_INTERACTIVE_HANDOVER_SECONDS="" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
@@ -495,6 +514,7 @@ main() {
 	test_B_stamp_present_returns_not_stale
 	test_C_active_status_label_returns_not_stale
 	test_D_idle_no_stamp_no_status_returns_stale
+	test_D2_updated_at_stale_skips_head_commit_lookup
 	test_E_missing_origin_interactive_returns_not_stale
 	test_F_mode_off_returns_not_stale_unconditionally
 	test_G_mode_detect_logs_and_returns_stale


### PR DESCRIPTION
## Summary

Optimized interactive PR stale detection to skip head commit API lookups when updatedAt is already stale, while retaining head commit fallback for automation-refreshed PRs. Updated handover tests and stale-threshold wording for the seconds-based default.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/tests/test-pulse-merge-interactive-handover.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-interactive-handover.sh; shellcheck .agents/scripts/pulse-merge-conflict.sh .agents/scripts/tests/test-pulse-merge-interactive-handover.sh .agents/scripts/tests/fixtures/mock-gh-interactive-handover.sh; git diff --check

Resolves #23455


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 101,805 tokens on this as a headless worker.