### PR TITLE
GH#23468: perf: reduce stale interactive PR lookup overhead

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -216,7 +216,8 @@ Every pulse cycle the deterministic merge pass evaluates open PRs with merge con
 #     enforce: evaluates signal and returns it; caller acts
 #   IDLE_INTERACTIVE_HANDOVER_SECONDS — age threshold seconds, default 14400 (4h; t2948)
 #
-# Args: $1 = pr_number, $2 = repo_slug
+# Args: $1 = pr_number, $2 = repo_slug, $3 = updated_at (optional),
+#       $4 = head_ref_oid (optional), $5 = head_commit_at (optional)
 # Returns: 0 if stale (handover-eligible), 1 otherwise
 # Side effect: logs "would-handover" line to $LOGFILE when mode=detect and stale
 #######################################
@@ -225,14 +226,15 @@ _interactive_pr_is_stale() {
 	local repo_slug="$2"
 	local precomputed_updated_at="${3:-}"
 	local precomputed_head_ref_oid="${4:-}"
+	local precomputed_head_commit_at="${5:-}"
 	local mode="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE:-detect}"
 	[[ "$mode" == "off" ]] && return 1
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
 
-	# Fetch PR metadata once. For staleness, prefer the head commit timestamp
-	# over PR updatedAt: automated comments/labels refresh updatedAt and can keep
-	# idle conflicted PRs out of worker handover indefinitely.
-	local pr_meta
+	# Fetch PR metadata once. updatedAt can prove staleness without an extra
+	# commit lookup; fresh updatedAt still falls through to the head commit
+	# timestamp because automated comments/labels can mask an idle branch.
+	local pr_meta=""
 	pr_meta=$(gh pr view "$pr_number" --repo "$repo_slug" \
 		--json labels,updatedAt,headRefOid 2>/dev/null) || return 1
 
@@ -250,7 +252,7 @@ _interactive_pr_is_stale() {
 		return 1
 	fi
 
-	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
+	# Gate 4: age threshold (check updatedAt before commit lookup — cheapest filter)
 	local threshold_secs="${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}"  # default 4h (t2948; was 24h)
 	local activity_at="" activity_source="updatedAt" now_epoch=0 updated_epoch=0 pr_age_secs=0
 	# t2383 Fix 2: validate threshold is a positive integer before arithmetic.
@@ -260,30 +262,42 @@ _interactive_pr_is_stale() {
 		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid IDLE_INTERACTIVE_HANDOVER_SECONDS='${threshold_secs}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
 		return 1
 	fi
-	now_epoch=$(date +%s)
-	activity_at="${precomputed_updated_at:-}"
-	if [[ -z "$activity_at" ]]; then
-		activity_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
+	local updated_at=""
+	updated_at="$precomputed_updated_at"
+	if [[ -z "$updated_at" ]]; then
+		updated_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
 	fi
-	if [[ -n "$activity_at" ]]; then
-		updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
-			updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \
-			return 1
-		pr_age_secs=$(( now_epoch - updated_epoch ))
-		[[ "$pr_age_secs" -ge "$threshold_secs" ]] && activity_source="updatedAt"
+	[[ -z "$updated_at" ]] && return 1
+	now_epoch=$(date +%s)
+	# Portable epoch parse — GNU date first (Linux CI), BSD date fallback (macOS)
+	updated_epoch=$(date -d "$updated_at" +%s 2>/dev/null) || \
+		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null) || \
+		return 1
+	pr_age_secs=$(( now_epoch - updated_epoch ))
+	if [[ "$pr_age_secs" -ge "$threshold_secs" ]]; then
+		activity_at="$updated_at"
+		activity_source="updatedAt"
+	else
+		pr_age_secs=0
 	fi
 
-	local head_ref_oid="${precomputed_head_ref_oid:-}"
-	if [[ "$pr_age_secs" -lt "$threshold_secs" && -z "$head_ref_oid" ]]; then
+	local head_ref_oid=""
+	head_ref_oid="$precomputed_head_ref_oid"
+	if [[ -z "$head_ref_oid" ]]; then
 		head_ref_oid=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // empty')
 	fi
-	if [[ "$pr_age_secs" -lt "$threshold_secs" && -n "$head_ref_oid" ]]; then
-		activity_at=$(gh api "repos/${repo_slug}/commits/${head_ref_oid}" \
-			--jq '.commit.committer.date // .commit.author.date // empty' 2>/dev/null) || activity_at=""
-		[[ -n "$activity_at" ]] && activity_source="head_commit"
+	if [[ -n "$head_ref_oid" ]]; then
+		if [[ -z "$activity_at" && -n "$precomputed_head_commit_at" ]]; then
+			activity_at="$precomputed_head_commit_at"
+			activity_source="head_commit"
+		fi
+		if [[ -z "$activity_at" ]]; then
+			activity_at=$(gh api "repos/${repo_slug}/commits/${head_ref_oid}" \
+				--jq '.commit.committer.date // .commit.author.date // empty' 2>/dev/null) || activity_at=""
+			[[ -n "$activity_at" ]] && activity_source="head_commit"
+		fi
 	fi
 	[[ -z "$activity_at" ]] && return 1
-	# Portable epoch parse — GNU date first (Linux CI), BSD date fallback (macOS)
 	updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
 		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \
 		return 1

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -385,7 +385,7 @@ _merge_ready_prs_for_repo() {
 	local pr_json pr_merge_err
 	pr_merge_err=$(mktemp)
 	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json number,mergeable,reviewDecision,author,title,isDraft,labels,headRefOid,createdAt \
+		--json number,mergeable,reviewDecision,author,title,isDraft,labels,updatedAt,headRefOid,createdAt \
 		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json="[]"
 	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg
@@ -658,6 +658,8 @@ _attempt_pr_ci_rebase_retry() {
 #   $4 = kind          (review | conflict | ci)
 #   $5 = pr_labels     (optional — comma-separated; fetched if empty)
 #   $6 = pr_title      (optional — passed to conflict dispatch)
+#   $7 = updated_at    (optional — passed to staleness check)
+#   $8 = head_ref_oid  (optional — passed to staleness check)
 #
 # Returns: 0 if dispatched, 1 if not routable (no match or excluded)
 #
@@ -673,6 +675,8 @@ _route_pr_to_fix_worker() {
 	local kind="$4"
 	local pr_labels="${5:-}"
 	local pr_title="${6:-}"
+	local updated_at="${7:-}"
+	local head_ref_oid="${8:-}"
 
 	# No linked issue → nothing to route to
 	[[ -z "$linked_issue" ]] && return 1
@@ -719,7 +723,7 @@ _route_pr_to_fix_worker() {
 
 	# Stale interactive PRs: handover first, then dispatch
 	if [[ ",${pr_labels}," == *",origin:interactive,"* ]] \
-		&& _interactive_pr_is_stale "$pr_number" "$repo_slug"; then
+		&& _interactive_pr_is_stale "$pr_number" "$repo_slug" "$updated_at" "$head_ref_oid"; then
 		_interactive_pr_trigger_handover "$pr_number" "$repo_slug" || true
 		case "$kind" in
 			review)   _dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || true ;;

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -557,7 +557,7 @@ _process_single_ready_pr() {
 	local repo_slug="$1"
 	local pr_obj="$2"
 
-	local pr_number pr_mergeable pr_review pr_author pr_title
+	local pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid
 	# Consolidate into a single jq pass to reduce process-spawn overhead.
 	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
 	# instead of \t. Bash read collapses consecutive IFS whitespace chars
@@ -567,9 +567,9 @@ _process_single_ready_pr() {
 	# caused pr_author to receive the PR title, breaking the collaborator
 	# check and blocking ALL merges across every repo (observed downstream).
 	local _RS=$'\x1e'
-	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title < <(
+	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid < <(
 		printf '%s' "$pr_obj" | jq -r \
-			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")"'
+			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")"'
 	)
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 
@@ -628,7 +628,7 @@ _process_single_ready_pr() {
 			# PRs to fix workers before the protected-close precheck. Active
 			# interactive PRs remain protected because _route_pr_to_fix_worker only
 			# accepts origin:interactive after _interactive_pr_is_stale passes.
-			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "" "$pr_title"; then
+			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid"; then
 				return 2
 			fi
 
@@ -701,7 +701,7 @@ _process_single_ready_pr() {
 				return 1
 			fi
 			# CI failure: route to fix worker if applicable (t2203: consolidated).
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" || true
+			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "" "" "$pr_updated_at" "$pr_head_ref_oid" || true
 			return 1
 		fi
 	fi


### PR DESCRIPTION
## Summary

Refactored stale interactive PR handover checks to accept and propagate precomputed PR activity metadata, preserving the head-commit fallback only when cheaper updatedAt metadata is not enough.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-conflict.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-interactive-handover.sh; bash .agents/scripts/tests/test-pulse-merge-interactive-handover.sh; bash .agents/scripts/tests/test-pulse-merge-update-branch.sh; bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh

Resolves #23468


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 16m and 320,438 tokens on this as a headless worker.