### PR TITLE
GH#23454: bound Tabby profile repair blocks

### DIFF
--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -313,12 +313,7 @@ def _profile_mentions_opencode_launch(profile_lines: list[str]) -> bool:
 
 def _profile_block_end(lines: list[str], start: int) -> int:
     """Return the first line after the Tabby profile block at ``start``."""
-    block_end = start + 1
-    while block_end < len(lines):
-        if lines[block_end].startswith("  - name:"):
-            break
-        block_end += 1
-    return block_end
+    return _block_end(lines, start, 2)
 
 
 def _repair_broken_opencode_launch_profile_block(config_text: str) -> tuple[str, int]:

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -330,6 +330,27 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
         self.assertEqual(repaired.count("      env:"), 1)
         self.assertIn("      # keep existing env block", repaired)
 
+    def test_last_opencode_profile_does_not_swallow_top_level_sections(self):
+        original = """profiles:
+  - name: repo
+    options:
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+      args: []
+terminal:
+  searchOptions:
+    # opencode in a top-level section must not make it profile repair input
+    regex: opencode
+"""
+
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
+            original
+        )
+
+        self.assertEqual(repairs, 1)
+        self.assertIn("terminal:\n", repaired)
+        self.assertIn("    regex: opencode", repaired)
+        self.assertTrue(repaired.endswith("    regex: opencode\n"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Changed Tabby profile block detection to stop at top-level YAML keys so only the matching OpenCode profile is repaired, and added regression coverage for a final profile followed by terminal settings mentioning opencode.

## Files Changed

.agents/scripts/tabby-profile-sync.py,tests/test-tabby-profile-sync.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/tabby-profile-sync.py tests/test-tabby-profile-sync.py; GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false python3 -m unittest tests/test-tabby-profile-sync.py

Resolves #23454


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 51,059 tokens on this as a headless worker.