### PR TITLE
Fix manual dispatch readiness (#23444)

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -661,6 +661,81 @@ _dsi_resolve_worker_pid() {
 }
 
 #######################################
+# Return the detached runtime log path used by headless-runtime-helper.sh.
+# Args: $1 - session_key
+# Stdout: absolute log path
+#######################################
+_dsi_detached_runtime_log() {
+	local session_key="$1"
+	printf '/tmp/worker-%s.log' "$session_key"
+	return 0
+}
+
+#######################################
+# Wait until a detached worker reaches an observable readiness signal.
+#
+# The outer nohup wrapper can exit successfully before model selection,
+# canary, and worker preparation complete. Treat launch as ready only when the
+# real child is alive and has emitted the canonical worker-start marker, has
+# registered in the dispatch ledger, or has exited/failed with inspectable log
+# evidence. This prevents silent success when pre-worker setup blocks.
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug
+#   $3 - session_key
+#   $4 - worker_pid
+#   $5 - launcher_log path
+# Returns: 0 ready, 1 failed/not-ready before timeout
+#######################################
+_dsi_wait_for_worker_readiness() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local session_key="$3"
+	local worker_pid="$4"
+	local launcher_log="$5"
+	local runtime_log
+	runtime_log=$(_dsi_detached_runtime_log "$session_key")
+	local timeout_s="${AIDEVOPS_DSI_READY_TIMEOUT_SECONDS:-20}"
+	local attempts=0
+	local max_attempts=200
+
+	if ! [[ "$timeout_s" =~ ^[0-9]+$ ]]; then
+		timeout_s=20
+	fi
+	max_attempts=$((timeout_s * 10))
+
+	while [[ "$attempts" -le "$max_attempts" ]]; do
+		if [[ -s "$runtime_log" ]] &&
+			(grep -Fq "worker_started" "$runtime_log" 2>/dev/null || grep -Fq "worker_start session=${session_key}" "$runtime_log" 2>/dev/null); then
+			return 0
+		fi
+
+		if _dsi_find_ledger_dispatch "$issue_number" "$repo_slug" >/dev/null 2>&1; then
+			return 0
+		fi
+
+		if [[ -n "$worker_pid" ]] && ! kill -0 "$worker_pid" 2>/dev/null; then
+			_dsi_err "Worker launch failed — detached child exited before readiness"
+			_dsi_info "  Launcher log: ${launcher_log}"
+			_dsi_info "  Runtime log:  ${runtime_log}"
+			return 1
+		fi
+
+		if [[ "$attempts" -eq "$max_attempts" ]]; then
+			break
+		fi
+		sleep 0.1
+		attempts=$((attempts + 1))
+	done
+
+	_dsi_err "Worker launch did not reach readiness within ${timeout_s}s"
+	_dsi_info "  Worker PID:   ${worker_pid}"
+	_dsi_info "  Launcher log: ${launcher_log}"
+	_dsi_info "  Runtime log:  ${runtime_log}"
+	return 1
+}
+
+#######################################
 # Build the worker prompt.  Headless-runtime-lib auto-appends
 # HEADLESS_CONTINUATION_CONTRACT_V6 when it sees "/full-loop" — see
 # headless-runtime-lib.sh:437-509.
@@ -1049,6 +1124,7 @@ _dsi_launch_and_report() {
 
 	local worker_pid
 	worker_pid=$(_dsi_resolve_worker_pid "$worker_log" "$launch_pid")
+	_dsi_wait_for_worker_readiness "$issue_number" "$repo_slug" "$session_key" "$worker_pid" "$worker_log" || return 1
 
 	_dsi_register_ledger "$issue_number" "$repo_slug" "$session_key" "$worker_pid"
 

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -676,9 +676,10 @@ _dsi_detached_runtime_log() {
 #
 # The outer nohup wrapper can exit successfully before model selection,
 # canary, and worker preparation complete. Treat launch as ready only when the
-# real child is alive and has emitted the canonical worker-start marker, has
-# registered in the dispatch ledger, or has exited/failed with inspectable log
-# evidence. This prevents silent success when pre-worker setup blocks.
+# real child is alive and has emitted the canonical worker-start marker, or has
+# exited/failed with inspectable log evidence. Ledger registration happens
+# before the worker-start marker, so it is progress evidence but not readiness.
+# This prevents silent success when pre-worker setup blocks.
 # Args:
 #   $1 - issue_number
 #   $2 - repo_slug
@@ -707,10 +708,6 @@ _dsi_wait_for_worker_readiness() {
 	while [[ "$attempts" -le "$max_attempts" ]]; do
 		if [[ -s "$runtime_log" ]] &&
 			(grep -Fq "worker_started" "$runtime_log" 2>/dev/null || grep -Fq "worker_start session=${session_key}" "$runtime_log" 2>/dev/null); then
-			return 0
-		fi
-
-		if _dsi_find_ledger_dispatch "$issue_number" "$repo_slug" >/dev/null 2>&1; then
 			return 0
 		fi
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1559,12 +1559,14 @@ cmd_run() {
 		return 0
 	fi
 
+	print_info "[lifecycle] pre_model_select session=$session_key role=$role tier=${tier_override:-auto} pid=$$"
 	local selected_model
 	selected_model=$(choose_model "$role" "${model_override:-$initial_model}" "$tier_override") || {
 		local choose_exit=$?
 		_cmd_run_finish "$session_key" "fail"
 		return "$choose_exit"
 	}
+	print_info "[lifecycle] post_model_select session=$session_key model=$selected_model pid=$$"
 
 	# GH#17549: Version guard — runs on EVERY dispatch (not cached).
 	# Something keeps upgrading opencode to 1.3.17 between canary checks.
@@ -1574,10 +1576,12 @@ cmd_run() {
 	# _cmd_run_prepare so a canary failure never posts a dispatch claim or
 	# increments the fast-fail counter. Cached for CANARY_CACHE_TTL_SECONDS
 	# (default 30 min) so it runs at most once per pulse cycle.
+	print_info "[lifecycle] pre_canary session=$session_key model=$selected_model pid=$$"
 	if ! _run_canary_test "$selected_model"; then
 		print_warning "Canary failed — aborting dispatch for session $session_key (no claim posted)"
 		return 1
 	fi
+	print_info "[lifecycle] post_canary session=$session_key model=$selected_model pid=$$"
 
 	if [[ "$role" == "worker" ]]; then
 		prompt=$(append_worker_headless_contract "$prompt")
@@ -1588,6 +1592,7 @@ cmd_run() {
 	# _cmd_run_prepare is called immediately below; the export no longer needs to
 	# live in _execute_run_attempt (which runs after the trap is already set).
 	local prepare_exit=0
+	print_info "[lifecycle] pre_worker_prepare session=$session_key work_dir=$work_dir pid=$$"
 	_cmd_run_prepare "$session_key" "$work_dir" || prepare_exit=$?
 	if [[ "$prepare_exit" -eq 2 ]]; then
 		return 0
@@ -1595,6 +1600,7 @@ cmd_run() {
 	if [[ "$prepare_exit" -ne 0 ]]; then
 		return "$prepare_exit"
 	fi
+	print_info "[lifecycle] post_worker_prepare session=$session_key work_dir=$work_dir pid=$$"
 
 	if [[ -z "$variant_override" ]]; then
 		variant_override=$(resolve_headless_variant "$role" "$tier_override" "$selected_model")

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -580,6 +580,24 @@ test_readiness_rejects_live_child_without_ready_signal() {
 	return 0
 }
 
+test_readiness_rejects_ledger_without_worker_started() {
+	MOCK_LEDGER_RECORD=$'ledger\t888\t/tmp/manual.log\t/tmp/aidevops-existing\tmanual-cli-12345-ledger'
+	local session_key="manual-cli-ledger-only-$$"
+	local runtime_log=""
+	runtime_log=$(_dsi_detached_runtime_log "$session_key")
+	rm -f "$runtime_log"
+
+	local out="" rc=0
+	out=$(AIDEVOPS_DSI_READY_TIMEOUT_SECONDS=0 _dsi_wait_for_worker_readiness 12345 owner/repo "$session_key" "$$" /tmp/manual-ledger-only.log 2>&1) || rc=$?
+	rm -f "$runtime_log"
+	MOCK_LEDGER_RECORD=""
+
+	local passed=1
+	[[ "$rc" -eq 1 && "$out" == *"did not reach readiness"* ]] && passed=0
+	print_result "readiness gate rejects ledger without worker_started" "$passed" "rc=$rc output=$out"
+	return 0
+}
+
 test_launch_report_waits_before_success_message() {
 	local wait_line="" ok_line=""
 	wait_line=$(grep -n '_dsi_wait_for_worker_readiness' "$HELPER_PATH" | tail -1 | cut -d: -f1)
@@ -683,6 +701,7 @@ _run_tests() {
 	test_create_worktree_uses_target_repo_path
 	test_readiness_accepts_worker_started_marker
 	test_readiness_rejects_live_child_without_ready_signal
+	test_readiness_rejects_ledger_without_worker_started
 	test_launch_report_waits_before_success_message
 	test_live_dispatch_detects_issue_repo
 	test_guard_blocks_ledger_duplicate

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -546,6 +546,54 @@ test_create_worktree_uses_target_repo_path() {
 }
 
 
+test_readiness_accepts_worker_started_marker() {
+	MOCK_LEDGER_RECORD=""
+	local session_key="manual-cli-ready-$$"
+	local runtime_log=""
+	runtime_log=$(_dsi_detached_runtime_log "$session_key")
+	printf '%s\n' "[lifecycle] worker_started session=${session_key}" >"$runtime_log"
+
+	local out="" rc=0
+	out=$(AIDEVOPS_DSI_READY_TIMEOUT_SECONDS=0 _dsi_wait_for_worker_readiness 12345 owner/repo "$session_key" "$$" /tmp/manual-ready.log 2>&1) || rc=$?
+	rm -f "$runtime_log"
+
+	local passed=1
+	[[ "$rc" -eq 0 && -z "$out" ]] && passed=0
+	print_result "readiness gate accepts worker_started marker" "$passed" "rc=$rc output=$out"
+	return 0
+}
+
+test_readiness_rejects_live_child_without_ready_signal() {
+	MOCK_LEDGER_RECORD=""
+	local session_key="manual-cli-not-ready-$$"
+	local runtime_log=""
+	runtime_log=$(_dsi_detached_runtime_log "$session_key")
+	rm -f "$runtime_log"
+
+	local out="" rc=0
+	out=$(AIDEVOPS_DSI_READY_TIMEOUT_SECONDS=0 _dsi_wait_for_worker_readiness 12345 owner/repo "$session_key" "$$" /tmp/manual-not-ready.log 2>&1) || rc=$?
+	rm -f "$runtime_log"
+
+	local passed=1
+	[[ "$rc" -eq 1 && "$out" == *"did not reach readiness"* && "$out" == *"Runtime log:"* ]] && passed=0
+	print_result "readiness gate rejects live child without ready signal" "$passed" "rc=$rc output=$out"
+	return 0
+}
+
+test_launch_report_waits_before_success_message() {
+	local wait_line="" ok_line=""
+	wait_line=$(grep -n '_dsi_wait_for_worker_readiness' "$HELPER_PATH" | tail -1 | cut -d: -f1)
+	ok_line=$(grep -n '_dsi_ok "Worker launched"' "$HELPER_PATH" | tail -1 | cut -d: -f1)
+
+	local passed=1
+	if [[ -n "$wait_line" && -n "$ok_line" && "$wait_line" -lt "$ok_line" ]]; then
+		passed=0
+	fi
+	print_result "launch report waits for readiness before Worker launched" "$passed" "wait_line=$wait_line ok_line=$ok_line"
+	return 0
+}
+
+
 
 test_live_dispatch_detects_issue_repo() {
 	MOCK_LEDGER_RECORD=""
@@ -633,6 +681,9 @@ _run_tests() {
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract
 	test_create_worktree_uses_target_repo_path
+	test_readiness_accepts_worker_started_marker
+	test_readiness_rejects_live_child_without_ready_signal
+	test_launch_report_waits_before_success_message
 	test_live_dispatch_detects_issue_repo
 	test_guard_blocks_ledger_duplicate
 	test_guard_blocks_live_worktree_duplicate


### PR DESCRIPTION
## Summary
- Add a manual-dispatch readiness gate so `Worker launched` is only printed after the detached runtime emits `worker_started`/`worker_start`.
- Add lifecycle checkpoints around model selection, canary, and worker preparation for diagnosing pre-worker stalls.
- Cover ready, not-ready, and ledger-only false-positive cases in `test-dispatch-single-issue-helper.sh`.

## Verification
- `.agents/scripts/tests/test-dispatch-single-issue-helper.sh` → 41/41 passed
- `shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh` → passed
- `.agents/scripts/linters-local.sh` → ALL LOCAL CHECKS PASSED (with pre-existing advisory markdown/complexity warnings)

Resolves #23444
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.35 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1h 36m and 223,785 tokens on this with the user in an interactive session.