### PR TITLE
fix: avoid misleading OpenCode install hint

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1987,7 +1987,7 @@ setup_opencode_cli() {
 			echo ""
 		else
 			print_warning "OpenCode installation failed"
-			print_info "Try manually: sudo npm install -g $install_pkg"
+			print_info "Try manually: $installer install -g $install_pkg"
 		fi
 	else
 		print_info "Skipped OpenCode installation"

--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -317,7 +317,7 @@ EOF
 chmod +x "$SANDBOX/bin/npm"
 (
 	source_extracted
-	export PATH="$SANDBOX/bin"
+	export PATH="$SANDBOX/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 	npm_global_install() {
 		return 1
 	}

--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -279,6 +279,60 @@ resolved4=$(tail -1 "$SANDBOX/out4")
 assert_eq "skip-when-valid rc" "rc=0" "$rc4"
 assert_eq "skip-when-valid resolved-path file" "$HOME/.local/bin/opencode" "$resolved4"
 
+# --- Test 4b: valid Homebrew opencode is accepted without npm hint ----------
+echo "Test 4b: setup_opencode_cli accepts valid Homebrew opencode"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved"
+mkdir -p "$SANDBOX/homebrew/bin"
+cp "$SANDBOX/bin/opencode-real" "$SANDBOX/homebrew/bin/opencode"
+(
+	source_extracted
+	export PATH="$SANDBOX/homebrew/bin:$PATH"
+	npm_global_install() {
+		echo "unexpected npm_global_install $*" >&2
+		return 1
+	}
+	export -f npm_global_install 2>/dev/null || true
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+	cat "$HOME/.aidevops/.opencode-bin-resolved" 2>/dev/null || echo "MISSING"
+) >"$SANDBOX/out4b" 2>&1
+rc4b=$(grep '^rc=' "$SANDBOX/out4b" | tail -1)
+resolved4b=$(tail -1 "$SANDBOX/out4b")
+homebrew_install_invoked=$(grep -c "unexpected npm_global_install" "$SANDBOX/out4b" || true)
+homebrew_sudo_hint=$(grep -c "sudo npm install" "$SANDBOX/out4b" || true)
+assert_eq "valid Homebrew opencode rc" "rc=0" "$rc4b"
+assert_eq "valid Homebrew opencode resolved" "$HOME/.local/bin/opencode" "$resolved4b"
+assert_eq "valid Homebrew opencode avoids installer" "0" "$homebrew_install_invoked"
+assert_eq "valid Homebrew opencode avoids sudo npm hint" "0" "$homebrew_sudo_hint"
+
+# --- Test 4c: install failure hint matches selected installer ---------------
+echo "Test 4c: setup_opencode_cli failure hint matches selected installer"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved"
+rm -f "$SANDBOX/homebrew/bin/opencode" "$SANDBOX/bin/opencode" "$SANDBOX/bin/bun"
+cat >"$SANDBOX/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SANDBOX/bin/npm"
+(
+	source_extracted
+	export PATH="$SANDBOX/bin"
+	npm_global_install() {
+		return 1
+	}
+	export -f npm_global_install 2>/dev/null || true
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+) >"$SANDBOX/out4c" 2>&1
+rc4c=$(grep '^rc=' "$SANDBOX/out4c" | tail -1)
+manual_npm_hint=$(grep -c "Try manually: npm install -g opencode-ai@" "$SANDBOX/out4c" || true)
+manual_sudo_hint=$(grep -c "sudo npm install" "$SANDBOX/out4c" || true)
+assert_eq "install failure fail-opens" "rc=0" "$rc4c"
+assert_eq "install failure uses selected installer hint" "1" "$manual_npm_hint"
+assert_eq "install failure avoids sudo npm hint" "0" "$manual_sudo_hint"
+
 # --- Test 5: setup_opencode_cli auto-heal on wrong package -----------------
 # Critical t2891 path: when 'opencode' resolves to claude CLI (rc=1),
 # the function MUST trigger force-heal (calls npm_global_install) and


### PR DESCRIPTION
## Summary
- Accepts an already-valid OpenCode binary without falling through to npm remediation, including Homebrew-style paths.
- Replaces the hard-coded `sudo npm install -g opencode-ai@...` failure hint with the installer actually selected by setup.
- Adds regression coverage for valid Homebrew OpenCode installs and installer-specific failure guidance.

## Verification
- `.agents/scripts/tests/test-tool-install-opencode.sh` — 29 passed, 0 failed
- `shellcheck .agents/scripts/setup/modules/tool-install.sh .agents/scripts/tests/test-tool-install-opencode.sh`
- `.agents/scripts/linters-local.sh`

Resolves #23475

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.35 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1h 39m and 217,789 tokens on this with the user in an interactive session.
