### PR TITLE
GH#23475: fix OpenCode Homebrew install hint

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1724,6 +1724,54 @@ _setup_opencode_first_line() {
 	return 0
 }
 
+_setup_opencode_homebrew_owner_action() {
+	local bin="${1:-}"
+	local brew_bin=""
+	local brew_prefix=""
+	local bin_real=""
+	local prefix_real=""
+
+	[[ -n "$bin" ]] || return 1
+	command -v brew >/dev/null 2>&1 || return 1
+	brew_bin=$(command -v brew 2>/dev/null || printf '')
+	[[ -n "$brew_bin" ]] || return 1
+	brew_prefix=$(brew --prefix opencode 2>/dev/null || printf '')
+	[[ -n "$brew_prefix" ]] || brew_prefix=$(brew --prefix 2>/dev/null || printf '')
+	[[ -n "$brew_prefix" ]] || return 1
+
+	bin_real=$(cd "$(dirname "$bin")" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$(basename "$bin")") || return 1
+	prefix_real=$(cd "$brew_prefix" 2>/dev/null && pwd -P) || return 1
+
+	case "$bin_real" in
+		"$prefix_real"/*)
+			printf '%s\n' "brew reinstall opencode"
+			return 0
+			;;
+	esac
+
+	return 1
+}
+
+_setup_opencode_print_manual_install_hint() {
+	local installer="${1:-}"
+	local install_pkg="${2:-opencode-ai@latest}"
+	local current_bin="${3:-}"
+	local brew_action=""
+	local manual_cmd=""
+
+	if brew_action=$(_setup_opencode_homebrew_owner_action "$current_bin" 2>/dev/null); then
+		print_info "OpenCode appears to be managed by Homebrew; try manually: $brew_action"
+		return 0
+	fi
+
+	case "$installer" in
+		bun) manual_cmd="bun install -g $install_pkg" ;;
+		npm | *) manual_cmd="npm install -g $install_pkg" ;;
+	esac
+	print_info "Try manually: $manual_cmd"
+	return 0
+}
+
 _setup_opencode_node_path_for_binary() {
 	local bin="$1"
 	local bin_dir=""
@@ -1870,7 +1918,7 @@ _setup_opencode_force_heal() {
 		print_success "OpenCode reinstalled via $installer"
 	else
 		print_warning "Heal install failed via $installer"
-		print_info "Try manually: $installer install -g $install_pkg"
+		_setup_opencode_print_manual_install_hint "$installer" "$install_pkg" "$wrong_bin"
 	fi
 
 	# Re-validate post-heal.
@@ -1987,7 +2035,7 @@ setup_opencode_cli() {
 			echo ""
 		else
 			print_warning "OpenCode installation failed"
-			print_info "Try manually: sudo npm install -g $install_pkg"
+			_setup_opencode_print_manual_install_hint "$installer" "$install_pkg" "$current_bin"
 		fi
 	else
 		print_info "Skipped OpenCode installation"

--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -57,6 +57,8 @@ extract_functions() {
 		/^_setup_opencode_help_output\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_help_identifies_opencode\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_first_line\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_homebrew_owner_action\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_print_manual_install_hint\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_node_path_for_binary\(\)/, /^}$/ { print; next }
 		/^_setup_clear_canary_negative_cache\(\)/, /^}$/ { print; next }
 		/^_setup_ensure_opencode_stable_shim\(\)/, /^}$/ { print; next }
@@ -360,6 +362,73 @@ if [[ "$elapsed7" =~ ^[0-9]+$ ]] && [[ "$elapsed7" -le 12 ]]; then
 else
 	assert_eq "hanging auto-heal returns within bound" "elapsed<=12" "elapsed=${elapsed7}"
 fi
+
+# --- Test 8: install failure hint matches selected installer -----------------
+echo "Test 8: setup_opencode_cli install failure omits hard-coded sudo npm hint"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved" "$SANDBOX/bin/opencode" "$SANDBOX/bin/bun"
+cat >"$SANDBOX/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SANDBOX/bin/npm"
+(
+	source_extracted
+	npm_global_install() {
+		printf '%s\n' "installer failed: permission denied" >&2
+		return 1
+	}
+	export -f npm_global_install 2>/dev/null || true
+	export PATH="$SANDBOX/bin:/usr/bin:/bin"
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+) >"$SANDBOX/out8" 2>&1
+rc8=$(grep '^rc=' "$SANDBOX/out8" | tail -1)
+sudo_hint8=$(grep -c "sudo npm install" "$SANDBOX/out8" || true)
+npm_hint8=$(grep -c "Try manually: npm install -g opencode-ai" "$SANDBOX/out8" || true)
+assert_eq "install failure rc" "rc=0" "$rc8"
+assert_eq "install failure has no sudo npm hint" "0" "$sudo_hint8"
+assert_eq "install failure uses npm hint" "1" "$npm_hint8"
+
+# --- Test 9: Homebrew-owned invalid binary gets brew remediation ------------
+echo "Test 9: setup_opencode_cli failure hint respects Homebrew ownership"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved" "$SANDBOX/bin/opencode"
+mkdir -p "$SANDBOX/homebrew/bin" "$SANDBOX/homebrew/Cellar/opencode/1.0.0/bin"
+cat >"$SANDBOX/homebrew/bin/opencode" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "not-a-version"
+[[ "${1:-}" == "--help" ]] && echo "not opencode"
+exit 0
+EOF
+chmod +x "$SANDBOX/homebrew/bin/opencode"
+cat >"$SANDBOX/bin/brew" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--prefix" && "\${2:-}" == "opencode" ]]; then
+	printf '%s\n' "$SANDBOX/homebrew"
+	exit 0
+fi
+if [[ "\${1:-}" == "--prefix" ]]; then
+	printf '%s\n' "$SANDBOX/homebrew"
+	exit 0
+fi
+exit 1
+EOF
+chmod +x "$SANDBOX/bin/brew"
+(
+	source_extracted
+	npm_global_install() { return 1; }
+	export -f npm_global_install 2>/dev/null || true
+	export PATH="$SANDBOX/homebrew/bin:$SANDBOX/bin:/usr/bin:/bin"
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+) >"$SANDBOX/out9" 2>&1
+rc9=$(grep '^rc=' "$SANDBOX/out9" | tail -1)
+brew_hint9=$(grep -c "brew reinstall opencode" "$SANDBOX/out9" || true)
+sudo_hint9=$(grep -c "sudo npm install" "$SANDBOX/out9" || true)
+assert_eq "homebrew remediation rc" "rc=0" "$rc9"
+assert_eq "homebrew remediation uses brew" "1" "$brew_hint9"
+assert_eq "homebrew remediation has no sudo npm hint" "0" "$sudo_hint9"
 
 echo ""
 echo "===== Results: $PASS passed, $FAIL failed ====="


### PR DESCRIPTION
## Summary

Adjusted OpenCode setup remediation so failed installs no longer emit a hard-coded sudo npm command and Homebrew-owned OpenCode binaries get Homebrew-specific recovery guidance.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh,.agents/scripts/tests/test-tool-install-opencode.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-tool-install-opencode.sh; shellcheck .agents/scripts/setup/modules/tool-install.sh .agents/scripts/tests/test-tool-install-opencode.sh; .agents/scripts/linters-local.sh (passed blocking gates; timed out during shell portability after advisory-only markdown/ratchet warnings)

Resolves #23475


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.36 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 20m and 81,538 tokens on this as a headless worker.