### PR TITLE
GH#23482: Add React Doctor guidance

### DIFF
--- a/.agents/tools/ui/frontend-debugging.md
+++ b/.agents/tools/ui/frontend-debugging.md
@@ -25,6 +25,7 @@ tools:
 - **Hydration errors**: Server/client mismatch or invalid component types
 - **Monorepo gotchas**: Webpack loaders (SVGR, etc.) don't cross package boundaries
 - **Browser tool**: `dev-browser` agent for visual verification
+- **React quality review**: `tools/ui/react-doctor.md` covers advisory staged/diff scans and CI annotations
 
 **When to use**: React/Next.js errors, blank pages, hydration mismatches, monorepo `packages/` work, curl returns 200 but user reports errors.
 
@@ -160,5 +161,6 @@ See `tools/ui/tailwind-css.md` for the Tailwind fix pattern.
 ## Related
 
 - **Browser automation**: `tools/browser/dev-browser.md`
+- **React quality checks**: `tools/ui/react-doctor.md`
 - **React patterns**: `tools/ui/shadcn.md`
 - **Build debugging**: `workflows/bug-fixing.md`

--- a/.agents/tools/ui/react-doctor.md
+++ b/.agents/tools/ui/react-doctor.md
@@ -1,0 +1,61 @@
+---
+description: React Doctor advisory quality checks for React, Next.js, and React Native
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# React Doctor
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Use when**: reviewing React, Next.js, or React Native changes for correctness, state/effects, accessibility, security, performance, architecture, or dead code risks.
+- **Default posture**: advisory-first. Treat findings as review signals until the project baseline, false positives, and suppressions are triaged.
+- **Local scans**: prefer staged or diff-limited scans during implementation so feedback matches the change under review.
+- **CI scans**: pin React Doctor versions and action refs; use annotations/comments before enforcing failures.
+
+<!-- AI-CONTEXT-END -->
+
+## When To Run
+
+Run React Doctor on React-family projects when a change touches components, hooks, state/effect logic, shared UI packages, accessibility behaviour, rendering performance, or dead-code cleanup. It is especially useful before PR creation when normal lint/type checks pass but a React-specific quality review is still valuable.
+
+Do not run it for non-React projects, docs-only changes, or framework code where installing project tooling would add risk or noise.
+
+## Local Workflow
+
+- Use staged or diff mode when available so the scan focuses on the current change instead of historical project debt.
+- Keep the normal project gates first: typecheck, lint, tests, and browser verification still own correctness for the implemented fix.
+- Review findings manually before editing. Do not apply automated suggestions verbatim.
+- Capture unrelated baseline findings as follow-up tasks instead of expanding the PR scope.
+
+## CI Workflow
+
+- Pin the React Doctor CLI or GitHub Action version in CI. Avoid floating tags and malformed action refs such as missing owner/repo, missing `@version`, or shell commands embedded where an action ref is expected.
+- Start CI usage as advisory annotations or PR comments so teams can evaluate signal quality without blocking unrelated work.
+- Do not make React Doctor a hard required gate until baseline findings are triaged, intentional suppressions are documented, and the team has verified the check is stable on representative PRs.
+- If enabling a blocking gate later, scope it to changed files or new findings where possible.
+
+## Interpreting Findings
+
+Prioritise findings that identify defects introduced by the current change: invalid hook usage, stale effects, unsafe rendering paths, inaccessible controls, security-sensitive data exposure, or performance regressions on hot paths.
+
+Treat broad architecture, dead-code, or style findings as advisory unless they are directly caused by the PR. Convert valuable but out-of-scope items into worker-ready follow-up tasks with file paths, finding text, and the verification command used.
+
+## Related
+
+- `tools/ui/ui-skills.md` -- implementation constraints for accessible, performant UI.
+- `tools/ui/frontend-debugging.md` -- browser verification and React hydration debugging.
+- `workflows/full-loop.md` -- PR loop completion and verification gates.

--- a/.agents/tools/ui/ui-skills.md
+++ b/.agents/tools/ui/ui-skills.md
@@ -25,6 +25,7 @@ tools:
 - **Stack**: Tailwind CSS, `motion/react`, `tw-animate-css`, `cn` (`clsx` + `tailwind-merge`)
 - **Apply when**: Building React/Next.js UIs, Tailwind components, animation, accessibility, or UI performance
 - **Defaults**: Tailwind defaults first; accessible primitives; no animation unless requested; respect `prefers-reduced-motion`; never block paste
+- **React quality**: For React/Next.js/React Native review checks, see `tools/ui/react-doctor.md`
 
 <!-- AI-CONTEXT-END -->
 
@@ -86,3 +87,4 @@ These rules are **implementation constraints** that apply regardless of which DE
 
 - [UI Skills](https://www.ui-skills.com/) · [Base UI](https://base-ui.com/react/components) · [React Aria](https://react-spectrum.adobe.com/react-aria/) · [Radix Primitives](https://www.radix-ui.com/primitives)
 - [motion/react](https://motion.dev/) · [tw-animate-css](https://github.com/Wombosvideo/tw-animate-css) · [shadcn/ui](https://ui.shadcn.com/) — see `tools/ui/shadcn.md`
+- `tools/ui/react-doctor.md` -- advisory React quality scans for local diffs and CI annotations.


### PR DESCRIPTION
## Summary
- Added focused React Doctor guidance under .agents/tools/ui/ for React, Next.js, and React Native quality reviews.
- Documented advisory-first local staged/diff scans, CI annotations/comments, version pinning, malformed action-ref avoidance, and hard-gate prerequisites.
- Added short pointers from existing UI and frontend debugging docs without expanding always-loaded AGENTS.md.

## Verification
- .agents/scripts/linters-local.sh --fast

## Runtime Testing
- Docs-only change; runtime testing not applicable.

Resolves #23482


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 15m and 60,265 tokens on this with the user in an interactive session.