### PR TITLE
GH#23487: Address routine systemd review followups

### DIFF
--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -236,12 +236,10 @@ parse_cron_to_oncalendar() {
 	local cal_min="00"
 	[[ "$minute" != "*" ]] && cal_min=$(printf '%02d' "$minute")
 
-	if [[ "$cal_dow" == "*" ]]; then
-		printf '*-%s-%s %s:%s:00' "$cal_month" "$cal_day" "$cal_hour" "$cal_min"
-	else
-		printf '%s *-%s-%s %s:%s:00' "$cal_dow" "$cal_month" "$cal_day" "$cal_hour" "$cal_min"
-	fi
-	return 0
+	local prefix=""
+	[[ "$cal_dow" != "*" ]] && prefix="${cal_dow} "
+	printf '%s*-%s-%s %s:%s:00' "$prefix" "$cal_month" "$cal_day" "$cal_hour" "$cal_min"
+	return $?
 }
 
 parse_common_args() {

--- a/.agents/scripts/tests/test-routine-systemd-calendar.sh
+++ b/.agents/scripts/tests/test-routine-systemd-calendar.sh
@@ -9,6 +9,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit
 ROUTINE_HELPER="${REPO_SCRIPTS_DIR}/routine-helper.sh"
 
+# shellcheck source=../shared-constants.sh
+source "${REPO_SCRIPTS_DIR}/shared-constants.sh"
+
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -32,20 +35,29 @@ print_result() {
 }
 
 run_install_systemd() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	local schedule="$1"
 	local tmp_home=""
 	tmp_home=$(mktemp -d)
+	push_cleanup "rm -rf \"${tmp_home}\""
 
 	local output=""
-	output=$(HOME="$tmp_home" "$ROUTINE_HELPER" install-systemd \
+	local rc=0
+	if output=$(HOME="$tmp_home" "$ROUTINE_HELPER" install-systemd \
 		--name test \
 		--schedule "$schedule" \
 		--dir "$tmp_home" \
-		--prompt 'test prompt' 2>&1)
+		--prompt 'test prompt' 2>&1); then
+		rc=0
+	else
+		rc=$?
+	fi
 
 	rm -rf "$tmp_home"
+	tmp_home=""
 	printf '%s' "$output"
-	return 0
+	return "$rc"
 }
 
 test_wildcard_weekday_omits_prefix() {


### PR DESCRIPTION
## Summary

Simplified routine OnCalendar formatting and updated the systemd calendar test helper to use scoped cleanup while preserving installer exit codes.

## Files Changed

.agents/scripts/routine-helper.sh,.agents/scripts/tests/test-routine-systemd-calendar.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/routine-helper.sh .agents/scripts/tests/test-routine-systemd-calendar.sh; bash .agents/scripts/tests/test-routine-systemd-calendar.sh

Resolves #23487


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 51,835 tokens on this as a headless worker.