### PR TITLE
GH#23485: fix: harden supply-chain advisory scanner

### DIFF
--- a/.agents/scripts/supply-chain-advisory-helper.sh
+++ b/.agents/scripts/supply-chain-advisory-helper.sh
@@ -19,7 +19,7 @@ readonly ADVISORY_ID="tanstack-minishaihulud-2026-05"
 readonly ADVISORIES_DIR="${HOME}/.aidevops/advisories"
 readonly DISMISSED_FILE="${ADVISORIES_DIR}/dismissed.txt"
 readonly IOC_PATTERN='@tanstack/setup|github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c|router_init\.js|tanstack_runner\.js|gh-token-monitor|com\.user\.gh-token-monitor|IfYouRevokeThisTokenItWillWipeTheComputerOfTheOwner|api\.masscan\.cloud|git-tanstack\.com|filev2\.getsession\.org|seed[123]\.getsession\.org'
-readonly AFFECTED_PATTERN='(@tanstack/(router-utils|router-core|arktype-adapter|eslint-plugin-router|eslint-plugin-start|history|nitro-v2-vite-plugin|react-router|react-router-devtools|react-router-ssr-query|react-start|react-start-client|react-start-rsc|react-start-server|router-cli|router-devtools|router-devtools-core|router-generator|router-plugin|router-ssr-query-core|router-vite-plugin|solid-router|solid-router-devtools|solid-router-ssr-query|solid-start|solid-start-client|solid-start-server|start-client-core|start-fn-stubs|start-plugin-core|start-server-core|start-static-server-functions|start-storage-context|valibot-adapter|virtual-file-routes|vue-router|vue-router-devtools|vue-router-ssr-query|vue-start|vue-start-client|vue-start-server|zod-adapter)|@opensearch-project/opensearch|@mistralai/mistralai|safe-action|cmux-agent-mcp|nextmove-mcp|git-git-git|git-branch-selector)@?(1\.161\.11|1\.161\.14|1\.169\.5|1\.169\.8|1\.166\.12|1\.166\.15|1\.161\.9|1\.161\.12|0\.0\.4|0\.0\.7|1\.154\.12|1\.154\.15|1\.166\.16|1\.166\.19|1\.166\.18|1\.167\.68|1\.167\.71|1\.166\.51|1\.166\.54|0\.0\.47|0\.0\.50|1\.166\.55|1\.166\.58|1\.166\.46|1\.166\.49|1\.167\.6|1\.167\.9|1\.166\.45|1\.166\.48|1\.167\.38|1\.167\.41|1\.168\.3|1\.168\.6|1\.166\.53|1\.166\.56|1\.167\.65|1\.167\.33|1\.167\.36|1\.166\.44|1\.166\.47|1\.166\.38|1\.166\.41|1\.161\.10|1\.161\.13|1\.167\.61|1\.167\.64|1\.166\.50|1\.166\.57|3\.6\.2|2\.2\.3|2\.2\.4|0\.8\.3|0\.8\.4|0\.1\.[3-8]|1\.0\.(8|9|10|12)|1\.3\.(3|4|5|7))'
+readonly AFFECTED_PATTERN='(@tanstack/(router-utils|router-core|arktype-adapter|eslint-plugin-router|eslint-plugin-start|history|nitro-v2-vite-plugin|react-router|react-router-devtools|react-router-ssr-query|react-start|react-start-client|react-start-rsc|react-start-server|router-cli|router-devtools|router-devtools-core|router-generator|router-plugin|router-ssr-query-core|router-vite-plugin|solid-router|solid-router-devtools|solid-router-ssr-query|solid-start|solid-start-client|solid-start-server|start-client-core|start-fn-stubs|start-plugin-core|start-server-core|start-static-server-functions|start-storage-context|valibot-adapter|virtual-file-routes|vue-router|vue-router-devtools|vue-router-ssr-query|vue-start|vue-start-client|vue-start-server|zod-adapter)|@opensearch-project/opensearch|@mistralai/mistralai|safe-action|cmux-agent-mcp|nextmove-mcp|git-git-git|git-branch-selector)@?(1\.161\.11|1\.161\.14|1\.169\.5|1\.169\.8|1\.166\.12|1\.166\.15|1\.161\.9|1\.161\.12|0\.0\.4|0\.0\.7|1\.154\.12|1\.154\.15|1\.166\.16|1\.166\.19|1\.166\.18|1\.167\.68|1\.167\.71|1\.166\.51|1\.166\.54|0\.0\.47|0\.0\.50|1\.166\.55|1\.166\.58|1\.166\.46|1\.166\.49|1\.167\.6|1\.167\.9|1\.166\.45|1\.166\.48|1\.167\.38|1\.167\.41|1\.168\.3|1\.168\.6|1\.166\.53|1\.166\.56|1\.167\.65|1\.167\.33|1\.167\.36|1\.166\.44|1\.166\.47|1\.166\.38|1\.166\.41|1\.161\.10|1\.161\.13|1\.167\.61|1\.167\.64|1\.166\.50|1\.166\.57|3\.6\.2|2\.2\.3|2\.2\.4|0\.8\.3|0\.8\.4|0\.1\.[3-8]|1\.0\.(8|9|10|12)|1\.3\.(3|4|5|7))([^0-9]|$)'
 
 print_usage() {
 	cat <<EOF
@@ -86,6 +86,8 @@ collect_default_paths() {
 		fd -td -d 2 '^\.git$' "${HOME}/Git" 2>/dev/null | while IFS= read -r git_dir; do
 			printf '%s\n' "${git_dir%/.git}"
 		done
+	elif [[ -d "${HOME}/Git" ]]; then
+		echo -e "${YELLOW}[WARN]${NC} fd not installed; skipping automatic ~/Git repository discovery." >&2
 	fi
 	return 0
 }
@@ -93,6 +95,8 @@ collect_default_paths() {
 scan_path() {
 	local target_path="$1"
 	local findings=0
+	local rg_status=0
+	local scan_error=0
 	if [[ ! -e "$target_path" ]]; then
 		echo -e "${YELLOW}[WARN]${NC} Missing path: ${target_path}"
 		return 0
@@ -102,15 +106,33 @@ scan_path() {
 	if command -v rg >/dev/null 2>&1; then
 		if rg -n --hidden --glob '!node_modules/.cache/**' --glob '!dist/**' --glob '!build/**' --glob '!.git/**' "$IOC_PATTERN" "$target_path"; then
 			findings=$((findings + 1))
+		else
+			rg_status=$?
+			if [[ "$rg_status" -gt 1 ]]; then
+				echo -e "${YELLOW}[WARN]${NC} ripgrep IOC scan failed for ${target_path} (exit ${rg_status})."
+				scan_error="$rg_status"
+			fi
 		fi
 		if rg -n --hidden --glob '!node_modules/**' --glob '!.git/**' --glob 'pnpm-lock.yaml' --glob 'package-lock.json' --glob 'yarn.lock' --glob 'bun.lock*' --glob 'package.json' "$AFFECTED_PATTERN" "$target_path"; then
 			findings=$((findings + 1))
+		else
+			rg_status=$?
+			if [[ "$rg_status" -gt 1 ]]; then
+				echo -e "${YELLOW}[WARN]${NC} ripgrep affected-package scan failed for ${target_path} (exit ${rg_status})."
+				scan_error="$rg_status"
+			fi
 		fi
 	else
 		echo -e "${YELLOW}[WARN]${NC} ripgrep not installed; install rg for supply-chain scans."
+		return 127
+	fi
+	if [[ "$scan_error" -ne 0 ]]; then
+		return "$scan_error"
+	fi
+	if [[ "$findings" -gt 0 ]]; then
 		return 1
 	fi
-	return "$findings"
+	return 0
 }
 
 check_home_persistence() {
@@ -132,6 +154,8 @@ check_home_persistence() {
 cmd_scan() {
 	ensure_advisory
 	local total_findings=0
+	local scan_errors=0
+	local scan_status=0
 	local paths=()
 	if [[ "$#" -gt 0 ]]; then
 		paths=("$@")
@@ -144,13 +168,24 @@ cmd_scan() {
 	check_home_persistence || total_findings=$((total_findings + $?))
 	local path
 	for path in "${paths[@]}"; do
-		scan_path "$path" || total_findings=$((total_findings + $?))
+		scan_path "$path" || {
+			scan_status=$?
+			if [[ "$scan_status" -eq 1 ]]; then
+				total_findings=$((total_findings + 1))
+			else
+				scan_errors=$((scan_errors + 1))
+			fi
+		}
 	done
 
 	if [[ "$total_findings" -gt 0 ]]; then
 		echo -e "${RED}Potential supply-chain compromise indicators found.${NC}"
 		echo "Isolate affected hosts before revoking tokens; then rotate credentials from a trusted machine."
 		return 1
+	fi
+	if [[ "$scan_errors" -gt 0 ]]; then
+		echo -e "${YELLOW}[WARN]${NC} Supply-chain scan incomplete due to ${scan_errors} scan error(s)."
+		return 2
 	fi
 
 	echo -e "${GREEN}No TanStack/Mini Shai-Hulud indicators found in scanned paths.${NC}"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1330,8 +1330,15 @@ _cmd_security() {
 		echo ""
 		_dispatch_helper "supply-chain-advisory-helper.sh" "supply-chain-advisory-helper.sh" scan || true
 		;;
-	scan | scan-secrets | scan-pth | scan-deps | dismiss)
+	scan | scan-secrets | scan-pth | scan-deps)
 		_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" "$@"
+		;;
+	dismiss)
+		if [[ "${2:-}" == "tanstack-minishaihulud-2026-05" ]]; then
+			_dispatch_helper "supply-chain-advisory-helper.sh" "supply-chain-advisory-helper.sh" dismiss
+		else
+			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" "$@"
+		fi
 		;;
 	hygiene)
 		shift
@@ -1346,6 +1353,8 @@ _cmd_security() {
 		_dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" status || true
 		echo ""
 		_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" startup-check || true
+		echo ""
+		_dispatch_helper "supply-chain-advisory-helper.sh" "supply-chain-advisory-helper.sh" startup-check || true
 		;;
 	supply-chain)
 		shift || true


### PR DESCRIPTION
## Summary

Hardened the supply-chain advisory scanner by adding affected-version boundaries, surfacing reduced ~/Git discovery coverage when fd is missing, distinguishing ripgrep execution failures from findings, and routing supply-chain advisory status/dismiss through the security command.

## Files Changed

.agents/scripts/supply-chain-advisory-helper.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/supply-chain-advisory-helper.sh aidevops.sh; targeted supply-chain scanner fixture tests for affected-version true/false positives and advisory dismissal routing; .agents/scripts/linters-local.sh ran until timeout after passing Sonar, Secretlint, ShellCheck RC parity, TOON, skill frontmatter, secret safety, pulse canary, and Bash 3.2 checks with only pre-existing/advisory markdown/ratchet/layout warnings before shell portability timeout

Resolves #23485


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 7m and 61,412 tokens on this as a headless worker.