### PR TITLE
GH#23492: address worktree CLI review followup

### DIFF
--- a/.agents/scripts/tests/test-aidevops-sh-portability.sh
+++ b/.agents/scripts/tests/test-aidevops-sh-portability.sh
@@ -165,7 +165,7 @@ test_approval_helper_still_guarded() {
 test_worktree_command_dispatch() {
 	_info "Test 4: aidevops.sh exposes worktree helper through stable CLI"
 
-	if grep -q 'worktree | wt).*worktree-helper.sh' "${AIDEVOPS_SH}"; then
+	if grep -qE 'worktree[[:space:]]*\|[[:space:]]*wt\).*worktree-helper\.sh' "${AIDEVOPS_SH}"; then
 		_pass "aidevops worktree dispatches to worktree-helper.sh"
 	else
 		_fail "aidevops.sh does not expose the worktree helper via aidevops worktree"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -831,7 +831,7 @@ _help_commands() {
 	echo "  upgrade            Alias for update"
 	echo "  pulse <cmd>        Session-based pulse control (start/stop/status)"
 	echo "  launch-worker      Manually launch headless workers for GitHub issues"
-	echo "  worktree <cmd>     Manage safe linked worktrees (add/list/remove/status/switch/clean)"
+	echo "  worktree <cmd>     Manage safe linked worktrees (add/list/remove/status/switch/clean) — alias: wt"
 	echo "  auto-update <cmd>  Manage automatic update polling (enable/disable/status)"
 	echo "  repo-sync <cmd>    Daily git pull for repos in parent dirs (enable/disable/status/dirs)"
 	echo "  update-tools       Check for outdated tools (--update to auto-update)"


### PR DESCRIPTION
## Summary

Documented the wt alias in aidevops help output and made the worktree dispatch portability test resilient to spacing and literal helper-name matching.

## Files Changed

.agents/scripts/tests/test-aidevops-sh-portability.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-aidevops-sh-portability.sh; shellcheck aidevops.sh .agents/scripts/tests/test-aidevops-sh-portability.sh

Resolves #23492


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 80,023 tokens on this as a headless worker.