### PR TITLE
GH#23488: reuse pulse PR labels during routing

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -282,9 +282,11 @@ _interactive_pr_is_stale() {
 	fi
 
 	local head_ref_oid=""
-	head_ref_oid="$precomputed_head_ref_oid"
-	if [[ -z "$head_ref_oid" ]]; then
-		head_ref_oid=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // empty')
+	if [[ -z "$activity_at" ]]; then
+		head_ref_oid="$precomputed_head_ref_oid"
+		if [[ -z "$head_ref_oid" ]]; then
+			head_ref_oid=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // empty')
+		fi
 	fi
 	if [[ -n "$head_ref_oid" ]]; then
 		if [[ -z "$activity_at" && -n "$precomputed_head_commit_at" ]]; then
@@ -298,9 +300,11 @@ _interactive_pr_is_stale() {
 		fi
 	fi
 	[[ -z "$activity_at" ]] && return 1
-	updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
-		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \
-		return 1
+	if [[ "$activity_at" != "$updated_at" ]]; then
+		updated_epoch=$(date -d "$activity_at" +%s 2>/dev/null) || \
+			updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$activity_at" +%s 2>/dev/null) || \
+			return 1
+	fi
 	pr_age_secs=$(( now_epoch - updated_epoch ))
 	[[ "$pr_age_secs" -lt "$threshold_secs" ]] && return 1
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -557,7 +557,7 @@ _process_single_ready_pr() {
 	local repo_slug="$1"
 	local pr_obj="$2"
 
-	local pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid
+	local pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_labels
 	# Consolidate into a single jq pass to reduce process-spawn overhead.
 	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
 	# instead of \t. Bash read collapses consecutive IFS whitespace chars
@@ -567,9 +567,9 @@ _process_single_ready_pr() {
 	# caused pr_author to receive the PR title, breaking the collaborator
 	# check and blocking ALL merges across every repo (observed downstream).
 	local _RS=$'\x1e'
-	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid < <(
+	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_labels < <(
 		printf '%s' "$pr_obj" | jq -r \
-			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")"'
+			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\([(.labels // [])[].name] | join(","))"'
 	)
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 
@@ -628,7 +628,7 @@ _process_single_ready_pr() {
 			# PRs to fix workers before the protected-close precheck. Active
 			# interactive PRs remain protected because _route_pr_to_fix_worker only
 			# accepts origin:interactive after _interactive_pr_is_stale passes.
-			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid"; then
+			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid"; then
 				return 2
 			fi
 
@@ -686,8 +686,7 @@ _process_single_ready_pr() {
 		# (external contributors, interactive sessions) take the normal
 		# CI-failure routing path, preserving the contributor security gate.
 		local _rcl_labels
-		_rcl_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _rcl_labels=""
+		_rcl_labels="$pr_labels"
 		if [[ ",${_rcl_labels}," == *"${_OW_LABEL_PAT}"* ]] \
 			&& _check_required_checks_passing "$repo_slug" "$pr_number"; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for origin:worker — branch-protection required contexts all pass (t2922)" >>"$LOGFILE"
@@ -701,7 +700,7 @@ _process_single_ready_pr() {
 				return 1
 			fi
 			# CI failure: route to fix worker if applicable (t2203: consolidated).
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "" "" "$pr_updated_at" "$pr_head_ref_oid" || true
+			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || true
 			return 1
 		fi
 	fi
@@ -755,10 +754,7 @@ _process_single_ready_pr() {
 			# t3508: auto-merge has been stuck on required pending checks past
 			# threshold. Route bounded CI repair feedback rather than silently
 			# deferring forever or attempting an admin bypass through pending CI.
-			local _native_labels
-			_native_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-				--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _native_labels=""
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$_native_labels" || true
+			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || true
 			return 1
 			;;
 	esac


### PR DESCRIPTION
## Summary

Reused labels already present in pulse PR metadata for fix-worker routing and skipped stale interactive PR date/head lookups when updatedAt is sufficient.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/pulse-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-conflict.sh; bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; bash .agents/scripts/tests/test-pulse-merge-update-branch.sh; bash .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

Resolves #23488


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 57,278 tokens on this as a headless worker.