### PR TITLE
GH#23489: fix handover test isolation

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -115,7 +115,7 @@ pw-route-review-fix|pulse-merge-feedback.sh|574|_dispatch_pr_fix_worker: routed 
 pw-route-review-empty|pulse-merge-feedback.sh|536|_dispatch_pr_fix_worker: PR #.*CHANGES_REQUESTED but no substantive|Review fix skipped — CHANGES_REQUESTED but no substantive review content
 pw-feedback-routed|pulse-merge-feedback.sh|153|already has routed feedback marker|Feedback routing skipped — already routed for this PR
 pw-feedback-body-fail|pulse-merge-feedback.sh|145|failed to fetch issue.*body.*skipping body edit|Feedback routing skipped — failed to fetch issue body
-pmc-handover|pulse-merge-conflict.sh|308|handover: PR #.*handed over to worker pipeline|Interactive PR handed over to worker pipeline (idle >IDLE_INTERACTIVE_HANDOVER_SECONDS, default 4h)
+pmc-handover|pulse-merge-conflict.sh|308|handover: PR #.*handed over to worker pipeline|Interactive PR handed over to worker pipeline (idle >AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS, default 4h)
 pmc-would-handover|pulse-merge-conflict.sh|212|would-handover: PR #|Would-handover detected (detect mode — not acting)
 pmc-handover-no-takeover|pulse-merge-conflict.sh|166|_interactive_pr_is_stale: PR #.*has no-takeover label|Handover skipped — PR has no-takeover label
 pmc-skip-interactive-close|pulse-merge-conflict.sh|583|Deterministic merge: skipping auto-close of origin:interactive PR|Skipped auto-close of origin:interactive PR — maintainer work never auto-closed

--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -46,9 +46,9 @@ _PULSE_MERGE_CONFLICT_LOADED=1
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
 
 # t2948: Idle interactive PR handover threshold in seconds (default 4h).
-# Override via IDLE_INTERACTIVE_HANDOVER_SECONDS env var.
+# Override via AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS env var.
 # See _interactive_pr_is_stale / _interactive_pr_trigger_handover.
-: "${IDLE_INTERACTIVE_HANDOVER_SECONDS:=14400}"
+: "${AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS:=${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}}"
 
 #######################################
 # GH#18650 (Fix 4): Post a one-time rebase nudge on an origin:interactive
@@ -206,7 +206,7 @@ Every pulse cycle the deterministic merge pass evaluates open PRs with merge con
 #      in-review, claimed) — an active status means a human is driving it
 #   3. No live claim stamp file in $CLAIM_STAMP_DIR for the linked issue
 #      (session is gone; no interactive-session-helper.sh claim active)
-#   4. PR updatedAt older than IDLE_INTERACTIVE_HANDOVER_SECONDS (default 14400 = 4h)
+#   4. PR updatedAt older than AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS (default 14400 = 4h)
 #   5. Linked issue is open (don't touch PRs whose issue was already closed)
 #
 # Env controls:
@@ -214,7 +214,7 @@ Every pulse cycle the deterministic merge pass evaluates open PRs with merge con
 #     off:     returns 1 unconditionally (feature disabled)
 #     detect:  evaluates signal and logs would-handover decisions; still returns signal
 #     enforce: evaluates signal and returns it; caller acts
-#   IDLE_INTERACTIVE_HANDOVER_SECONDS — age threshold seconds, default 14400 (4h; t2948)
+#   AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS — age threshold seconds, default 14400 (4h; t2948)
 #
 # Args: $1 = pr_number, $2 = repo_slug, $3 = updated_at (optional),
 #       $4 = head_ref_oid (optional), $5 = head_commit_at (optional)
@@ -253,13 +253,13 @@ _interactive_pr_is_stale() {
 	fi
 
 	# Gate 4: age threshold (check updatedAt before commit lookup — cheapest filter)
-	local threshold_secs="${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}"  # default 4h (t2948; was 24h)
+	local threshold_secs="${AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS:-${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}}"  # default 4h (t2948; was 24h)
 	local activity_at="" activity_source="updatedAt" now_epoch=0 updated_epoch=0 pr_age_secs=0
 	# t2383 Fix 2: validate threshold is a positive integer before arithmetic.
 	# A non-numeric value (e.g. "4h", empty, negative) triggers bash
 	# "value too great for base" and silently breaks stale detection.
 	if [[ ! "$threshold_secs" =~ ^[0-9]+$ ]] || [[ "$threshold_secs" -eq 0 ]]; then
-		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid IDLE_INTERACTIVE_HANDOVER_SECONDS='${threshold_secs}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
+		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS='${threshold_secs}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
 		return 1
 	fi
 	local updated_at=""
@@ -391,7 +391,7 @@ _interactive_pr_trigger_handover() {
 	# Post one-time handover comment via _gh_idempotent_comment
 	if declare -F _gh_idempotent_comment >/dev/null 2>&1; then
 		local marker="<!-- pulse-interactive-handover -->"
-		local threshold_h=$(( ${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400} / 3600 ))
+		local threshold_h=$(( ${AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS:-${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}} / 3600 ))
 		local body
 		body="${marker}
 ## Worker takeover — no interactive session activity for ${threshold_h}h

--- a/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
+++ b/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
@@ -5,7 +5,7 @@
 # Tests for _interactive_pr_is_stale() and _interactive_pr_trigger_handover()
 # (t2189).
 #
-# An origin:interactive PR that has sat idle past IDLE_INTERACTIVE_HANDOVER_SECONDS
+# An origin:interactive PR that has sat idle past AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS
 # without any active-session signal (no claim stamp, no status:* label on linked
 # issue) must be handover-eligible so the worker pipeline (CI fix, conflict fix,
 # review fix) can drive it to merge. The helpers isolate the staleness signal
@@ -66,6 +66,7 @@ print_result() {
 #   body.txt              — PR body (used by _extract_linked_issue primary)
 reset_mock_state() {
 	: >"$GH_LOG"
+	: >"$LOGFILE"
 	printf 'origin:interactive' >"${TEST_ROOT}/labels.txt"
 	# Default: 48h ago → idle
 	local epoch_48h
@@ -426,7 +427,7 @@ test_K_no_takeover_label_blocks_handover() {
 test_L_invalid_seconds_returns_not_stale() {
 	reset_mock_state
 	# "24h" is non-numeric — should not crash bash arithmetic
-	IDLE_INTERACTIVE_HANDOVER_SECONDS="24h" \
+	AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS="24h" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -434,7 +435,7 @@ test_L_invalid_seconds_returns_not_stale() {
 		print_result "L: invalid seconds ('24h') returns not-stale" 1 "Expected 1, got $rc"
 		return 0
 	fi
-	if ! grep -q "invalid IDLE_INTERACTIVE_HANDOVER_SECONDS" "$LOGFILE"; then
+	if ! grep -q "invalid AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS" "$LOGFILE"; then
 		print_result "L: invalid seconds logs validation error" 1 \
 			"Expected validation error in LOGFILE. Got: $(cat "$LOGFILE")"
 		return 0
@@ -445,7 +446,7 @@ test_L_invalid_seconds_returns_not_stale() {
 
 test_L2_zero_seconds_returns_not_stale() {
 	reset_mock_state
-	IDLE_INTERACTIVE_HANDOVER_SECONDS="0" \
+	AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS="0" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -461,7 +462,7 @@ test_L3_empty_seconds_uses_default_14400() {
 	reset_mock_state
 	# Empty seconds triggers bash's :- default substitution to "14400" (4h), which is valid.
 	# The PR is 48h old (reset_mock_state default), so it should return stale (0).
-	IDLE_INTERACTIVE_HANDOVER_SECONDS="" \
+	AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS="" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?
@@ -475,7 +476,7 @@ test_L3_empty_seconds_uses_default_14400() {
 
 test_L4_negative_seconds_returns_not_stale() {
 	reset_mock_state
-	IDLE_INTERACTIVE_HANDOVER_SECONDS="-5" \
+	AIDEVOPS_IDLE_INTERACTIVE_HANDOVER_SECONDS="-5" \
 	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
 		_interactive_pr_is_stale "100" "owner/repo"
 	local rc=$?


### PR DESCRIPTION
## Summary

Cleared pulse LOGFILE during handover test resets and moved the handover threshold override to the AIDEVOPS-prefixed environment variable while retaining legacy fallback.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh,.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/tests/test-pulse-merge-interactive-handover.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-interactive-handover.sh; shellcheck .agents/scripts/tests/test-pulse-merge-interactive-handover.sh .agents/scripts/pulse-merge-conflict.sh .agents/scripts/pulse-diagnose-helper.sh

Resolves #23489


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 74,347 tokens on this as a headless worker.