### PR TITLE
GH#23490: reject hyphen-leading stats fallback identity

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -78,7 +78,7 @@ _resolve_current_gh_login_or_fallback() {
 	# Local system usernames are not GitHub logins; accept common POSIX-safe
 	# account characters while rejecting whitespace/control characters because
 	# this value is reused in labels, cache keys, and gh CLI arguments.
-	if [[ "$fallback_login" =~ ^[[:alnum:]_.-]+$ ]]; then
+	if [[ "$fallback_login" =~ ^[[:alnum:]_][[:alnum:]_.-]*$ ]]; then
 		echo "[stats] GitHub login unavailable or invalid; using local fallback identity: ${fallback_login}" \
 			>>"${LOGFILE:-/dev/null}"
 		printf '%s' "$fallback_login"

--- a/.agents/scripts/tests/test-stats-functions-characterization.sh
+++ b/.agents/scripts/tests/test-stats-functions-characterization.sh
@@ -268,6 +268,28 @@ test_validate_repo_slug() {
 }
 
 #######################################
+# Test 2b: _resolve_current_gh_login_or_fallback rejects fallback identities
+# that could be parsed as flags when reused in CLI arguments.
+#######################################
+test_resolve_current_gh_login_rejects_leading_hyphen_fallback() {
+	gh() {
+		return 1
+	}
+
+	whoami() {
+		printf '%s' "-runner"
+		return 0
+	}
+
+	local output
+	output=$(_resolve_current_gh_login_or_fallback 2>/dev/null)
+	assert_equals "_resolve_current_gh_login_or_fallback rejects leading hyphen fallback" "unknown-runner" "$output"
+
+	unset -f gh whoami
+	return 0
+}
+
+#######################################
 # Test 3: _persist_role_cache -- writes role to a deterministic file path.
 # Signature: _persist_role_cache runner_user repo_slug role
 # Verify the file is created with expected content in the sandbox.
@@ -357,6 +379,7 @@ main() {
 
 	test_source_and_function_existence
 	test_validate_repo_slug
+	test_resolve_current_gh_login_rejects_leading_hyphen_fallback
 	test_persist_role_cache
 	test_sourcing_idempotency
 	test_sweep_state_round_trip


### PR DESCRIPTION
## Summary

Tightened stats fallback identity validation so local fallback names must start with an alphanumeric character or underscore before they can be reused in labels, cache keys, or gh arguments.

## Files Changed

.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-stats-functions-characterization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-health-dashboard.sh

Resolves #23490


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 84,141 tokens on this with the user in an interactive session.