### PR TITLE
GH#23488: initialize pulse PR metadata locals

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -557,7 +557,7 @@ _process_single_ready_pr() {
 	local repo_slug="$1"
 	local pr_obj="$2"
 
-	local pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_labels
+	local pr_number="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at="" pr_head_ref_oid="" pr_labels=""
 	# Consolidate into a single jq pass to reduce process-spawn overhead.
 	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
 	# instead of \t. Bash read collapses consecutive IFS whitespace chars


### PR DESCRIPTION
## Summary

Initializes the newly added pulse PR metadata variables at declaration time so the merged label reuse optimization remains safe under set -u and the pulse unbound-var guard.

## Files Changed

.agents/scripts/pulse-merge.sh

## Runtime Testing

- **Risk level:** Low (shell helper safety fix)
- **Verification:** shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-conflict.sh; bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; bash .agents/scripts/tests/test-pulse-merge-update-branch.sh; bash .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh; diff check confirmed no added multi-var local declaration without initialization

Follow-up for #23488 and #23498.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 6m and 75,523 tokens on this as a headless worker.
