### PR TITLE
GH#23491: clarify hotfix commit staging

### DIFF
--- a/.agents/workflows/postflight.md
+++ b/.agents/workflows/postflight.md
@@ -101,8 +101,11 @@ gh release delete v{VERSION} --yes && git tag -d v{VERSION} && git push origin -
 # Option C: Hotfix release from a safe linked worktree
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{VERSION}.1 --base v{VERSION}
 # Critical: cd into the sibling worktree path printed by the helper before editing;
-# otherwise commits land in the canonical checkout and can disrupt active agents.
-git commit -m "fix: resolve critical issue" && ./.agents/scripts/version-manager.sh release patch
+# otherwise commits land in the canonical checkout, which can corrupt main state
+# or disrupt active agents that depend on their own linked worktrees.
+# Example after changing into that linked worktree: stage the intended files first,
+# because `git commit -m` without staging can create an empty or incomplete commit.
+# git add <changed-files> && git commit -m "fix: resolve critical issue" && ./.agents/scripts/version-manager.sh release patch
 ```
 
 Post-rollback: `gh run list --limit=5 && .agents/scripts/linters-local.sh`


### PR DESCRIPTION
## Summary

Clarified the hotfix rollback example so the release command is commented, the linked-worktree consequence is explicit, and staging is required before commit.

## Files Changed

.agents/workflows/postflight.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/workflows/postflight.md

Resolves #23491


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 36,423 tokens on this as a headless worker.