### PR TITLE
GH#23493: simplify memory limit fallback

### DIFF
--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -143,7 +143,7 @@ function createMemoryTool(scriptsDir, run) {
 
       if (action === "recall") {
         const query = args.query.trim();
-        const limit = String(args.limit ?? "5").trim() || "5";
+        const limit = String(args.limit ?? "").trim() || "5";
         const cmd = `bash "${memoryHelper}" recall ${shellEscape(query)} --limit ${shellEscape(limit)}`;
         const result = run(cmd, 10000);
         return result || "No memories found for this query.";


### PR DESCRIPTION
## Summary
- Simplifies OpenCode `aidevops_memory` recall limit fallback to coalesce null/undefined through an empty string before trimming/defaulting.
- Keeps the existing behavior for blank values and numeric limits while addressing the review-followup readability suggestion.

## Testing
- `node --test .agents/plugins/opencode-aidevops/tests/test-memory-tool-schema.mjs`
- `npm test` in `.agents/plugins/opencode-aidevops`
- `npm run typecheck`

## Runtime Testing
- self-assessed: low-risk one-line JavaScript normalization change covered by existing regression tests.

Resolves #23493

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 8m and 137,868 tokens on this as a headless worker.
