### PR TITLE
GH#23511: fix: count supply-chain scan findings consistently

### DIFF
--- a/.agents/scripts/supply-chain-advisory-helper.sh
+++ b/.agents/scripts/supply-chain-advisory-helper.sh
@@ -20,6 +20,7 @@ readonly ADVISORIES_DIR="${HOME}/.aidevops/advisories"
 readonly DISMISSED_FILE="${ADVISORIES_DIR}/dismissed.txt"
 readonly IOC_PATTERN='@tanstack/setup|github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c|router_init\.js|tanstack_runner\.js|gh-token-monitor|com\.user\.gh-token-monitor|IfYouRevokeThisTokenItWillWipeTheComputerOfTheOwner|api\.masscan\.cloud|git-tanstack\.com|filev2\.getsession\.org|seed[123]\.getsession\.org'
 readonly AFFECTED_PATTERN='(@tanstack/(router-utils|router-core|arktype-adapter|eslint-plugin-router|eslint-plugin-start|history|nitro-v2-vite-plugin|react-router|react-router-devtools|react-router-ssr-query|react-start|react-start-client|react-start-rsc|react-start-server|router-cli|router-devtools|router-devtools-core|router-generator|router-plugin|router-ssr-query-core|router-vite-plugin|solid-router|solid-router-devtools|solid-router-ssr-query|solid-start|solid-start-client|solid-start-server|start-client-core|start-fn-stubs|start-plugin-core|start-server-core|start-static-server-functions|start-storage-context|valibot-adapter|virtual-file-routes|vue-router|vue-router-devtools|vue-router-ssr-query|vue-start|vue-start-client|vue-start-server|zod-adapter)|@opensearch-project/opensearch|@mistralai/mistralai|safe-action|cmux-agent-mcp|nextmove-mcp|git-git-git|git-branch-selector)@?(1\.161\.11|1\.161\.14|1\.169\.5|1\.169\.8|1\.166\.12|1\.166\.15|1\.161\.9|1\.161\.12|0\.0\.4|0\.0\.7|1\.154\.12|1\.154\.15|1\.166\.16|1\.166\.19|1\.166\.18|1\.167\.68|1\.167\.71|1\.166\.51|1\.166\.54|0\.0\.47|0\.0\.50|1\.166\.55|1\.166\.58|1\.166\.46|1\.166\.49|1\.167\.6|1\.167\.9|1\.166\.45|1\.166\.48|1\.167\.38|1\.167\.41|1\.168\.3|1\.168\.6|1\.166\.53|1\.166\.56|1\.167\.65|1\.167\.33|1\.167\.36|1\.166\.44|1\.166\.47|1\.166\.38|1\.166\.41|1\.161\.10|1\.161\.13|1\.167\.61|1\.167\.64|1\.166\.50|1\.166\.57|3\.6\.2|2\.2\.3|2\.2\.4|0\.8\.3|0\.8\.4|0\.1\.[3-8]|1\.0\.(8|9|10|12)|1\.3\.(3|4|5|7))([^0-9]|$)'
+SCAN_PATH_FINDINGS=0
 
 print_usage() {
 	cat <<EOF
@@ -97,6 +98,7 @@ scan_path() {
 	local findings=0
 	local rg_status=0
 	local scan_error=0
+	SCAN_PATH_FINDINGS=0
 	if [[ ! -e "$target_path" ]]; then
 		echo -e "${YELLOW}[WARN]${NC} Missing path: ${target_path}"
 		return 0
@@ -129,6 +131,7 @@ scan_path() {
 	if [[ "$scan_error" -ne 0 ]]; then
 		return "$scan_error"
 	fi
+	SCAN_PATH_FINDINGS="$findings"
 	if [[ "$findings" -gt 0 ]]; then
 		return 1
 	fi
@@ -171,7 +174,7 @@ cmd_scan() {
 		scan_path "$path" || {
 			scan_status=$?
 			if [[ "$scan_status" -eq 1 ]]; then
-				total_findings=$((total_findings + 1))
+				total_findings=$((total_findings + SCAN_PATH_FINDINGS))
 			else
 				scan_errors=$((scan_errors + 1))
 			fi


### PR DESCRIPTION
## Summary

Made supply-chain scanner aggregate the actual finding count reported by scan_path instead of treating every positive path as one finding.

## Files Changed

.agents/scripts/supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/supply-chain-advisory-helper.sh; bash -n .agents/scripts/supply-chain-advisory-helper.sh; targeted clean and indicator scan fixtures

Resolves #23511


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 83,921 tokens on this as a headless worker.