### PR TITLE
GH#23512: Clarify React Doctor read-only scope

### DIFF
--- a/.agents/tools/ui/react-doctor.md
+++ b/.agents/tools/ui/react-doctor.md
@@ -25,7 +25,7 @@ tools:
 - **Default posture**: advisory-first. Treat findings as review signals until the project baseline, false positives, and suppressions are triaged.
 - **Local scans**: prefer staged or diff-limited scans during implementation so feedback matches the change under review.
 - **CI scans**: pin React Doctor versions and action refs; use annotations/comments before enforcing failures.
-- **Tool scope**: read-only advisory agent; implementation edits stay with the primary worker after manual triage.
+- **Tool scope**: read-only advisory agent; `write`/`edit` stay disabled because React Doctor should inspect findings without changing project files. Implementation edits stay with the primary worker after manual triage.
 
 <!-- AI-CONTEXT-END -->
 


### PR DESCRIPTION
## Summary

- Clarifies that React Doctor remains a read-only advisory agent because findings should be inspected before project files are edited.
- Keeps implementation edits with the primary worker after manual triage.

## Testing

- `.agents/scripts/linters-local.sh` passed.

## Runtime Testing

- self-assessed: docs-only agent guidance update.

Resolves #23512


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 7m and 104,568 tokens on this as a headless worker.