### PR TITLE
fix: normalize backfill status issue counts

### DIFF
--- a/.agents/scripts/backfill-status-available.sh
+++ b/.agents/scripts/backfill-status-available.sh
@@ -168,6 +168,14 @@ has_tier_label() {
 	return $?
 }
 
+# Normalize gh issue list output to a single compact JSON array.
+# Args: $1 = raw gh issue list JSON output
+normalize_issues_json() {
+	local raw_json="$1"
+	printf '%s' "$raw_json" | jq -c -s 'map(select(type == "array")) | add // []'
+	return $?
+}
+
 # Apply labels to a single issue. Purely additive — never removes labels.
 # Args: $1=repo $2=issue_number $3=add_tier (1=add tier:standard, 0=skip)
 apply_labels() {
@@ -199,9 +207,10 @@ process_repo() {
 		--limit 200 \
 		--search "$search_query" \
 		--json number,title,labels 2>/dev/null) || issues_json="[]"
+	issues_json=$(normalize_issues_json "$issues_json") || issues_json="[]"
 
 	local count
-	count=$(printf '%s' "$issues_json" | jq 'length')
+	count=$(printf '%s' "$issues_json" | jq -r 'length')
 
 	if [[ "$count" -eq 0 ]]; then
 		[[ "$JSON_MODE" -eq 0 ]] && printf '  No candidates found.\n'

--- a/.agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh
+++ b/.agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test: backfill-status-available must collapse multiple JSON
+# documents from gh issue list before using jq length in arithmetic [[ ]].
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+BACKFILL_SCRIPT="${SCRIPT_DIR}/../backfill-status-available.sh"
+
+TEST_ROOT=""
+
+cleanup() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message" >&2
+	return 1
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	printf '[{"number":2,"title":"candidate","labels":[{"name":"auto-dispatch"}]}]\n[]\n'
+	exit 0
+fi
+
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+main() {
+	trap cleanup EXIT
+	setup_test_env
+
+	local output
+	output=$("$BACKFILL_SCRIPT" --dry-run --repo owner/repo 2>&1)
+
+	if [[ "$output" == *"syntax error in expression"* ]]; then
+		fail "arithmetic syntax error leaked for multi-document gh output"
+	fi
+	if [[ "$output" != *"Dry-run summary: 1 candidate(s) found"* ]]; then
+		printf '%s\n' "$output" >&2
+		fail "expected one normalized candidate in dry-run summary"
+	fi
+
+	printf 'PASS backfill-status-available normalizes gh output\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Normalize multi-document `gh issue list` JSON into one compact array before arithmetic comparisons.
- Add a regression test covering the observed `2\n0` count shape so pulse cleanup no longer emits `[[` numeric-expression errors.

## Testing
- `.agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh`
- `shellcheck .agents/scripts/backfill-status-available.sh .agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh`

## Runtime Testing
- self-assessed: shell helper logic covered by stubbed CLI regression test.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 35,185 tokens on this as a headless worker.


Resolves #23519
