### PR TITLE
fix: default issue create status labels

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -196,11 +196,7 @@ gh_create_issue() {
 		return 1
 	fi
 
-	# t3088: defence-in-depth — only auto-inject the session origin label when
-	# the caller has NOT already specified one. Prevents the dual-origin-label
-	# bug (t2200 violation) where a caller's --label "origin:X" plus the
-	# wrapper's --label "$session_origin_label" produces two distinct origin
-	# labels on the resulting issue. Mirrors gh_create_pr (canonical failure: PR #21825).
+	# t3088: inject session origin only when the caller has not supplied one.
 	local -a _origin_label_args=()
 	if ! _gh_wrapper_args_have_origin_label "$@"; then
 		local origin_label
@@ -229,10 +225,7 @@ gh_create_issue() {
 
 	_gh_ci_prepare_status_label "$@"
 
-	# Build command arrays safely — avoids empty-arg injection from
-	# "${arr[@]+...}" on empty arrays when no TODO task ID is present and/or
-	# the caller already provided an origin label (GH#22056, mirrors PR #22043).
-	# _issue_cmd: full gh invocation; _rest_args: same flags for REST fallback.
+	# Build command arrays safely; avoid empty-arg injection (GH#22056).
 	local -a _issue_cmd=(gh issue create "$@")
 	local -a _rest_args=("$@")
 	if [[ ${#_GH_CI_STATUS_LABEL_ARGS[@]} -gt 0 ]]; then
@@ -248,20 +241,11 @@ gh_create_issue() {
 		_rest_args+=("${_origin_label_args[@]}")
 	fi
 
-	# t2028: auto-assign to the current user when the session is interactive
-	# and the caller did not pass an explicit --assignee. Reaches parity with
-	# the t1970 auto-assign already applied on the claim-task-id.sh path so
-	# the maintainer gate's assignee check passes on first PR open for
-	# interactively-created issues.
-	# t2406: skip self-assignment when auto-dispatch label is present (t2157).
-	# The origin:interactive label is still applied (t2200 — origin and
-	# assignment are independent axes).
+	# t2028/t2406: auto-assign interactive issues unless auto-dispatch is present.
 	local issue_output rc
 	if ! _gh_wrapper_args_have_assignee "$@"; then
 		if _gh_wrapper_args_have_label "auto-dispatch" "$@"; then
-			# t2157/t2406: auto-dispatch means "let a worker handle this" —
-			# skip self-assignment. Mirrors issue-sync-helper.sh
-			# _push_auto_assign_interactive() skip logic.
+			# t2157/t2406: auto-dispatch means worker-owned; skip self-assignment.
 			print_info "[INFO] auto-dispatch label present — skipping self-assignment per t2157"
 		else
 			local auto_assignee

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -214,12 +214,26 @@ gh_create_issue() {
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 	fi
 
+	# t3099: Always give newly-created issues a lifecycle status unless the
+	# caller already supplied one. gh_create_issue already injects origin labels;
+	# without this companion status label an interactive-origin issue can sit in
+	# the label-invariant reconciler's triage-missing bucket forever when the
+	# caller also omits tier:auto-dispatch metadata.
+	local -a _status_label_args=()
+	if ! _gh_wrapper_args_have_label_prefix "status:" "$@"; then
+		_status_label_args=(--label "status:available")
+	fi
+
 	# Build command arrays safely — avoids empty-arg injection from
 	# "${arr[@]+...}" on empty arrays when no TODO task ID is present and/or
 	# the caller already provided an origin label (GH#22056, mirrors PR #22043).
 	# _issue_cmd: full gh invocation; _rest_args: same flags for REST fallback.
 	local -a _issue_cmd=(gh issue create "$@")
 	local -a _rest_args=("$@")
+	if [[ ${#_status_label_args[@]} -gt 0 ]]; then
+		_issue_cmd+=("${_status_label_args[@]}")
+		_rest_args+=("${_status_label_args[@]}")
+	fi
 	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
 		_issue_cmd+=("${_todo_label_args[@]}")
 		_rest_args+=("${_todo_label_args[@]}")

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -173,6 +173,19 @@ _gh_ci_prepare_todo_labels() {
 	return 0
 }
 
+# t3099: Prepare the default issue lifecycle label. gh_create_issue already
+# injects an origin label when absent; this companion default prevents newly
+# created origin-labelled issues from entering the reconciler's triage-missing
+# bucket when callers also omit tier/auto-dispatch metadata.
+_GH_CI_STATUS_LABEL_ARGS=()
+_gh_ci_prepare_status_label() {
+	_GH_CI_STATUS_LABEL_ARGS=()
+	if ! _gh_wrapper_args_have_label_prefix "status:" "$@"; then
+		_GH_CI_STATUS_LABEL_ARGS=(--label "status:available")
+	fi
+	return 0
+}
+
 gh_create_issue() {
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
@@ -214,15 +227,7 @@ gh_create_issue() {
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 	fi
 
-	# t3099: Always give newly-created issues a lifecycle status unless the
-	# caller already supplied one. gh_create_issue already injects origin labels;
-	# without this companion status label an interactive-origin issue can sit in
-	# the label-invariant reconciler's triage-missing bucket forever when the
-	# caller also omits tier:auto-dispatch metadata.
-	local -a _status_label_args=()
-	if ! _gh_wrapper_args_have_label_prefix "status:" "$@"; then
-		_status_label_args=(--label "status:available")
-	fi
+	_gh_ci_prepare_status_label "$@"
 
 	# Build command arrays safely — avoids empty-arg injection from
 	# "${arr[@]+...}" on empty arrays when no TODO task ID is present and/or
@@ -230,9 +235,9 @@ gh_create_issue() {
 	# _issue_cmd: full gh invocation; _rest_args: same flags for REST fallback.
 	local -a _issue_cmd=(gh issue create "$@")
 	local -a _rest_args=("$@")
-	if [[ ${#_status_label_args[@]} -gt 0 ]]; then
-		_issue_cmd+=("${_status_label_args[@]}")
-		_rest_args+=("${_status_label_args[@]}")
+	if [[ ${#_GH_CI_STATUS_LABEL_ARGS[@]} -gt 0 ]]; then
+		_issue_cmd+=("${_GH_CI_STATUS_LABEL_ARGS[@]}")
+		_rest_args+=("${_GH_CI_STATUS_LABEL_ARGS[@]}")
 	fi
 	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
 		_issue_cmd+=("${_todo_label_args[@]}")

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -232,6 +232,44 @@ _gh_wrapper_args_have_label() {
 	return 1
 }
 
+# t3099: Internal — check if argv contains any label with the given prefix in
+# any --label arg. Supports comma-separated label lists (e.g.
+# --label "bug,status:available"). Used by gh_create_issue to avoid creating
+# origin-labelled issues with no lifecycle status while preserving caller-owned
+# status labels.
+# Returns 0 if a matching label is found, 1 otherwise.
+_gh_wrapper_args_have_label_prefix() {
+	local prefix="$1"
+	shift
+	while [[ $# -gt 0 ]]; do
+		local cur="$1"
+		local label_val=""
+		case "$cur" in
+		--label)
+			label_val="${2:-}"
+			[[ $# -gt 1 ]] && shift
+			;;
+		--label=*)
+			label_val="${cur#--label=}"
+			;;
+		esac
+		if [[ -n "$label_val" ]]; then
+			local _saved_ifs="$IFS"
+			IFS=','
+			local _label_part
+			for _label_part in $label_val; do
+				if [[ "$_label_part" == "${prefix}"* ]]; then
+					IFS="$_saved_ifs"
+					return 0
+				fi
+			done
+			IFS="$_saved_ifs"
+		fi
+		shift
+	done
+	return 1
+}
+
 # t3088: Internal — check if argv already contains any origin:* label.
 # Defence-in-depth for gh_create_issue / gh_create_pr session-origin self-injection:
 # when a caller has explicitly passed an origin label (e.g. parent-task-helper.sh

--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -30,6 +30,12 @@
 
 set -uo pipefail
 
+# Keep the gh_issue_list-backed reconciler fixture on the mocked GraphQL path.
+# Developer shells may export REST-first read mode; that bypasses this test's
+# minimal `gh issue list` stub and makes the invariant rows appear empty.
+unset AIDEVOPS_GH_REST_FIRST_READS
+unset AIDEVOPS_GH_FORCE_REST_READS
+
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_RED=$'\033[0;31m'
 TEST_GREEN=$'\033[0;32m'

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -166,6 +166,25 @@ count_origin_labels_in_log() {
 	printf '%d' "$count"
 }
 
+count_status_labels_in_log() {
+	local last
+	last=$(tail -1 "${GH_RECORD_FILE}" 2>/dev/null || true)
+	[[ -z "$last" ]] && {
+		printf '0'
+		return 0
+	}
+	local normalised="${last//,/ }"
+	local count=0
+	# shellcheck disable=SC2206
+	local tokens=($normalised)
+	local tok
+	for tok in "${tokens[@]}"; do
+		[[ "$tok" == status:* ]] && count=$((count + 1))
+	done
+	printf '%d' "$count"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Layer A: _gh_wrapper_args_have_origin_label
 # ---------------------------------------------------------------------------
@@ -460,6 +479,35 @@ else
 	print_result "B'6: gh_create_issue todo-only filter passes no empty argv element" 0
 fi
 unset GH_ARGV_RECORD_FILE
+
+# B'7: no caller status → wrapper injects status:available with origin.
+# Regression guard for pulse hygiene anomalies where gh_create_issue could
+# create origin:interactive issues missing tier/auto-dispatch/status metadata.
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --repo o/r --title "advisory" --body "body" >/dev/null 2>&1
+status_n=$(count_status_labels_in_log)
+last=$(tail -1 "$GH_RECORD_FILE")
+if [[ "$status_n" == "1" && "$last" == *"status:available"* && "$last" == *"origin:interactive"* ]]; then
+	print_result "B'7: gh_create_issue adds status:available with injected origin" 0
+else
+	print_result "B'7: gh_create_issue adds status:available with injected origin" 1 \
+		"status_count=$status_n line: $last"
+fi
+
+# B'8: caller status wins — wrapper must not concatenate an extra status label.
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --repo o/r --title "advisory" --body "body" \
+	--label "status:blocked,origin:interactive" >/dev/null 2>&1
+status_n=$(count_status_labels_in_log)
+last=$(tail -1 "$GH_RECORD_FILE")
+if [[ "$status_n" == "1" && "$last" == *"status:blocked"* && "$last" != *"status:available"* ]]; then
+	print_result "B'8: gh_create_issue preserves caller status without concatenation" 0
+else
+	print_result "B'8: gh_create_issue preserves caller status without concatenation" 1 \
+		"status_count=$status_n line: $last"
+fi
 
 # ---------------------------------------------------------------------------
 # Layer C: structural checks on full-loop-helper-commit.sh


### PR DESCRIPTION
## Summary
- Adds a `status:available` default in `gh_create_issue` when callers omit any `status:*` label, closing the origin-labelled/no-status write path that feeds pulse hygiene anomalies.
- Adds prefix-aware label detection so caller-owned status labels are preserved without concatenating an extra status.
- Extends create-path and label-invariant tests, including environment isolation for the reconciler fixture.

## Testing
- `.agents/scripts/tests/test-origin-label-mutex-create.sh`
- `.agents/scripts/tests/test-label-invariants.sh`
- `shellcheck .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/shared-gh-wrappers-session.sh .agents/scripts/tests/test-origin-label-mutex-create.sh .agents/scripts/tests/test-label-invariants.sh`

Resolves #23522

## Notes
- No public comment includes private issue titles.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 12m and 301,222 tokens on this as a headless worker.