### PR TITLE
Fix issue-sync completion evidence

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -60,7 +60,10 @@ _has_evidence() {
 
 _has_unresolved_blocker() {
 	local text="$1"
-	echo "$text" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
+	local candidate
+	candidate=$(printf '%s\n' "$text" | grep -E '^[[:space:]]*- \[[ x-]\] ' | head -1 || true)
+	[[ -z "$candidate" ]] && candidate="$text"
+	echo "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
 	return 1
 }
 

--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -49,9 +49,18 @@ _has_evidence() {
 	local text="$1" task_id="$2" repo="$3"
 	# Cancelled/deferred/declined tasks need no PR or verified: evidence
 	_is_cancelled_or_deferred "$text" && return 0
+	if _has_unresolved_blocker "$text"; then
+		return 1
+	fi
 	echo "$text" | grep -qE 'verified:[0-9]{4}-[0-9]{2}-[0-9]{2}|pr:#[0-9]+' && return 0
 	echo "$text" | grep -qiE 'PR #[0-9]+ merged|PR.*merged' && return 0
-	[[ -n "$repo" ]] && [[ -n "$(gh_find_merged_pr "$repo" "$task_id")" ]] && return 0
+	[[ -n "$repo" && -n "$task_id" ]] && return 1
+	return 1
+}
+
+_has_unresolved_blocker() {
+	local text="$1"
+	echo "$text" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
 	return 1
 }
 
@@ -63,23 +72,7 @@ _find_closing_pr() {
 		echo "${pr}|https://github.com/${repo}/pull/${pr}"
 		return 0
 	}
-	if [[ -n "$repo" ]]; then
-		local info
-		info=$(gh_find_merged_pr "$repo" "$task_id")
-		[[ -n "$info" ]] && {
-			echo "$info"
-			return 0
-		}
-		local parent
-		parent=$(echo "$task_id" | grep -oE '^t[0-9]+' || echo "")
-		[[ -n "$parent" && "$parent" != "$task_id" ]] && {
-			info=$(gh_find_merged_pr "$repo" "$parent")
-			[[ -n "$info" ]] && {
-				echo "$info"
-				return 0
-			}
-		}
-	fi
+	[[ -n "$repo" && -n "$task_id" ]] && return 1
 	return 1
 }
 
@@ -184,6 +177,10 @@ _do_close() {
 	issue_labels=$(gh api "repos/${repo}/issues/${issue_number}" --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
 	if echo "$issue_labels" | grep -qw "parent-task"; then
 		print_info "Skipping #$issue_number ($task_id): parent-task label set — parent issues close via terminal-phase PR with explicit Closes #NNN, not TODO [x] (GH#20828)"
+		return 0
+	fi
+	if ! _is_cancelled_or_deferred "$task_with_notes" && _has_unresolved_blocker "$task_with_notes"; then
+		print_info "Skipping #$issue_number ($task_id): unresolved blocked-by marker present — completion evidence must wait for dependencies (GH#23516)"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#23516: issue-sync must not treat a merged PR whose
+# title merely starts with a task ID as completion evidence. Completion requires
+# explicit proof in TODO.md (`pr:#NNN`, `verified:YYYY-MM-DD`, cancellation state)
+# and unresolved `blocked-by:*` markers veto close/proof-log automation.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() {
+	local msg="$1"
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$msg"
+	return 0
+}
+
+fail() {
+	local msg="$1"
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s\n' "$msg"
+	return 0
+}
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_PATH="${TEST_DIR}/../issue-sync-helper-close.sh"
+
+print_warning() { return 0; }
+print_info() { return 0; }
+print_error() { return 0; }
+print_success() { return 0; }
+log_verbose() { return 0; }
+gh_find_merged_pr() {
+	local repo="$1" task_id="$2"
+	: "$task_id"
+	printf '%s\n' "42|https://github.com/${repo}/pull/42"
+	return 0
+}
+export -f print_warning print_info print_error print_success log_verbose gh_find_merged_pr
+
+# shellcheck source=../issue-sync-helper-close.sh
+source "$HELPER_PATH"
+
+metadata_only_task='- [ ] t9001 keep closeout open tier:standard'
+if _has_evidence "$metadata_only_task" "t9001" "owner/repo"; then
+	fail "title-only merged PR lookup is not accepted as evidence"
+else
+	pass "title-only merged PR lookup is not accepted as evidence"
+fi
+
+if _find_closing_pr "$metadata_only_task" "t9001" "owner/repo" >/dev/null; then
+	fail "title-only merged PR lookup is not returned as closing PR"
+else
+	pass "title-only merged PR lookup is not returned as closing PR"
+fi
+
+explicit_task='- [ ] t9002 fixed implementation pr:#77 tier:standard'
+if _has_evidence "$explicit_task" "t9002" "owner/repo"; then
+	pass "explicit pr proof remains valid evidence"
+else
+	fail "explicit pr proof should remain valid evidence"
+fi
+
+blocked_task='- [ ] t9003 blocked implementation pr:#78 tier:standard blocked-by:t9002'
+if _has_evidence "$blocked_task" "t9003" "owner/repo"; then
+	fail "blocked-by marker vetoes otherwise explicit PR evidence"
+else
+	pass "blocked-by marker vetoes otherwise explicit PR evidence"
+fi
+
+if [[ "$FAIL" -eq 0 ]]; then
+	printf 'All %d tests passed\n' "$PASS"
+	exit 0
+fi
+
+exit 1

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -71,6 +71,14 @@ else
 	pass "blocked-by marker vetoes otherwise explicit PR evidence"
 fi
 
+historical_note_task='- [ ] t9004 fixed implementation pr:#79 tier:standard
+  - Historical note: earlier attempt was blocked-by:t9003 before the dependency landed.'
+if _has_evidence "$historical_note_task" "t9004" "owner/repo"; then
+	pass "blocked-by mention in task notes does not veto current task line"
+else
+	fail "blocked-by mention in task notes should not veto current task line"
+fi
+
 if [[ "$FAIL" -eq 0 ]]; then
 	printf 'All %d tests passed\n' "$PASS"
 	exit 0

--- a/.agents/scripts/tests/test-planning-pr-guard.sh
+++ b/.agents/scripts/tests/test-planning-pr-guard.sh
@@ -28,9 +28,9 @@
 #   1. Planning-only PR (For/Ref only, no Closes) → proof-log skipped
 #   2. Implementation PR (Closes #NNN) → proof-log proceeds
 #   3. Mixed PR (Closes + For/Ref) → proof-log proceeds (closing signal wins)
-#   4. No references at all → proof-log proceeds (fallback behavior)
+#   4. No references at all → proof-log skipped (metadata-only title)
 #   5. Title-fallback: For/Ref issue in list → title-fallback skipped
-#   6. Title-fallback: issue NOT in For/Ref list → title-fallback proceeds
+#   6. Title-fallback: issue NOT in For/Ref list → title-fallback skipped
 #
 # Strategy: test the decision logic extracted from issue-sync.yml inline
 # bash. The workflow is CI-only; these tests validate the branching
@@ -85,6 +85,13 @@ header() {
 should_skip_prooflog() {
 	local linked_issues="$1"
 	local for_ref_issues="$2"
+	local task_line="${3:-}"
+	if [[ -z "${linked_issues:-}" ]]; then
+		return 0  # skip (no explicit closing intent)
+	fi
+	if echo "$task_line" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
+		return 0  # skip (blocked task)
+	fi
 	if [[ -z "${linked_issues:-}" ]] && [[ -n "${for_ref_issues:-}" ]]; then
 		return 0  # skip (planning-only)
 	fi
@@ -116,9 +123,16 @@ fi
 
 # Test 4: No references at all — fallback behavior
 if should_skip_prooflog "" ""; then
-	fail "4. No references → should proceed (fallback) but skipped"
+	pass "4. No references → proof-log skipped (metadata-only title)"
 else
-	pass "4. No references → proof-log proceeds (fallback)"
+	fail "4. No references → should skip metadata-only title but proceeded"
+fi
+
+# Test 4b: Explicit Closes but TODO task remains blocked
+if should_skip_prooflog "19778" "" "- [ ] t900 blocked task tier:standard blocked-by:t899"; then
+	pass "4b. Explicit close + blocked-by TODO marker → proof-log skipped"
+else
+	fail "4b. Explicit close + blocked-by TODO marker → should skip but proceeded"
 fi
 
 # -------------------------------------------------------------------
@@ -134,6 +148,9 @@ fi
 should_skip_title_fallback() {
 	local found="$1"
 	local for_ref_issues="$2"
+	if [[ -n "$found" ]]; then
+		return 0  # skip: title-only fallback is metadata, not completion intent
+	fi
 	if [[ " $for_ref_issues " == *" $found "* ]]; then
 		return 0  # skip
 	fi
@@ -151,16 +168,16 @@ fi
 
 # Test 6: Found issue NOT in For/Ref list → proceed
 if should_skip_title_fallback "19999" "19778 19779 19780"; then
-	fail "6. Found issue not in For/Ref list → should proceed but skipped"
+	pass "6. Found issue not in For/Ref list → title-fallback skipped (metadata-only)"
 else
-	pass "6. Found issue not in For/Ref list → title-fallback proceeds"
+	fail "6. Found issue not in For/Ref list → should skip metadata-only fallback"
 fi
 
 # Test 7: Empty For/Ref list → proceed (no planning references)
 if should_skip_title_fallback "19778" ""; then
-	fail "7. Empty For/Ref list → should proceed but skipped"
+	pass "7. Empty For/Ref list → title-fallback skipped (metadata-only)"
 else
-	pass "7. Empty For/Ref list → title-fallback proceeds"
+	fail "7. Empty For/Ref list → should skip metadata-only fallback"
 fi
 
 # -------------------------------------------------------------------

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -632,41 +632,19 @@ jobs:
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # If no explicit Closes #NNN in PR body, search for the issue by task ID in title.
-          # t2137: skip title-fallback matches on parent-task issues. Explicit
-          # Closes/Fixes/Resolves is respected (either a legitimate terminal-phase
-          # close or a maintainer override); title-matching alone is too weak a
-          # signal to flip a parent's status:done — it fires on every planning PR
-          # whose title shares the parent's task ID prefix (t2046 For/Ref
-          # convention makes this the common case).
+          # GH#23516: title-only task IDs are metadata, not completion intent.
+          # Only explicit Closes/Fixes/Resolves links may drive status:done.
+          # If no explicit closing issue exists, leave found_issues empty so a
+          # metadata-only title like `tNNN: sync blocker metadata` cannot close
+          # the matching task issue or add status:done.
           if [[ -z "$LINKED_ISSUES" ]]; then
-            FOUND=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 \
-              | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty')
-            if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
-              # t2137: probe parent-task label before accepting the fallback match.
-              FOUND_LABELS=$(gh api "repos/${REPO}/issues/${FOUND}" --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
-              if echo "$FOUND_LABELS" | grep -qw "parent-task"; then
-                echo "found_issues=" >> "$GITHUB_OUTPUT"
-                echo "Found issue #$FOUND for task $TASK_ID is a parent-task — skipping title-fallback hygiene (use explicit Closes #NNN on the terminal-phase PR to close a parent)"
-              # t2219: skip title-fallback when the issue was explicitly referenced
-              # via 'For #NNN' or 'Ref #NNN' in the PR body. The t2046 planning
-              # convention says these references mean "this PR does NOT close that
-              # issue" — extend the same semantics to status:done auto-application.
-              elif [[ " $FOR_REF_ISSUES " == *" $FOUND "* ]]; then
-                echo "found_issues=" >> "$GITHUB_OUTPUT"
-                echo "Found issue #$FOUND for task $TASK_ID is referenced via For/Ref in PR body — skipping title-fallback hygiene (t2219)"
-              else
-                echo "found_issues=$FOUND" >> "$GITHUB_OUTPUT"
-                echo "Found issue #$FOUND for task $TASK_ID"
-              fi
-            else
-              echo "found_issues=" >> "$GITHUB_OUTPUT"
-              echo "No issue found for task $TASK_ID"
-            fi
-          else
             echo "found_issues=" >> "$GITHUB_OUTPUT"
-            echo "Using linked issues from PR body: $LINKED_ISSUES"
+            echo "No explicit closing issue for task $TASK_ID — skipping title-fallback hygiene (GH#23516)"
+            exit 0
           fi
+
+          echo "found_issues=" >> "$GITHUB_OUTPUT"
+          echo "Using explicit linked issues from PR body: $LINKED_ISSUES"
 
       - name: Apply closing hygiene to linked issues
         if: steps.extract.outputs.has_work == 'true'
@@ -726,6 +704,12 @@ jobs:
 
             if [[ "$IS_REJECTED" == "true" ]]; then
               echo "Issue #$ISSUE_NUM has rejection label '$REJECTION_MATCH' — using 'Referenced by' instead of 'Completed via'"
+            fi
+
+            ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.body // ""' 2>/dev/null || echo "")
+            if echo "$ISSUE_BODY" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
+              echo "Issue #$ISSUE_NUM has unresolved blocked-by marker — skipping closing hygiene (GH#23516)"
+              continue
             fi
 
             # Post closing comment if none exists from this PR
@@ -1067,6 +1051,17 @@ jobs:
           if ! grep -qE "^[[:space:]]*- \[ \] ${TASK_ID} " TODO.md; then
             echo "Task $TASK_ID not found as unchecked in TODO.md — skipping proof-log"
             # May already be [x], or may not exist in this repo's TODO.md
+            exit 0
+          fi
+
+          if [[ -z "${LINKED_ISSUES:-}" ]]; then
+            echo "::notice::PR title task ID without explicit closing issue is metadata only — skipping TODO.md proof-log (GH#23516)"
+            exit 0
+          fi
+
+          TASK_LINE=$(grep -E "^[[:space:]]*- \[ \] ${TASK_ID} " TODO.md | head -1 || true)
+          if echo "$TASK_LINE" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
+            echo "::notice::Task $TASK_ID has unresolved blocked-by marker — skipping TODO.md proof-log (GH#23516)"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- Require explicit closing intent before issue-sync applies `status:done` or TODO proof-log completion.
- Stop title-only task IDs from acting as merged-PR evidence in workflow and bash helper close paths.
- Add blocked-task vetoes and regression coverage for metadata-only PR titles and `blocked-by:*` markers.

## Verification
- `bash .agents/scripts/tests/test-issue-sync-completion-evidence.sh`
- `bash .agents/scripts/tests/test-planning-pr-guard.sh`
- `shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-completion-evidence.sh .agents/scripts/tests/test-planning-pr-guard.sh`
- `actionlint .github/workflows/issue-sync-reusable.yml`
- `git diff --check`
- `.agents/scripts/linters-local.sh` (completed; advisory/pre-existing markdown, ratchet, layout, complexity warnings reported while final summary was ALL LOCAL CHECKS PASSED)

Resolves #23516
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 44m and 123,059 tokens on this with the user in an interactive session.