### PR TITLE
Fix issue-sync blocker prose false positives

### DIFF
--- a/.agents/scripts/tests/test-planning-pr-guard.sh
+++ b/.agents/scripts/tests/test-planning-pr-guard.sh
@@ -98,6 +98,14 @@ should_skip_prooflog() {
 	return 1  # proceed
 }
 
+should_skip_closing_hygiene_for_task() {
+	local task_line="$1"
+	if echo "$task_line" | grep -qE '^[[:space:]]*- \[ \] .*blocked-by:[^[:space:]]+'; then
+		return 0
+	fi
+	return 1
+}
+
 header "Path 2: TODO.md proof-log guard (t2252)"
 
 # Test 1: Planning-only PR — For/Ref only, no Closes
@@ -133,6 +141,19 @@ if should_skip_prooflog "19778" "" "- [ ] t900 blocked task tier:standard blocke
 	pass "4b. Explicit close + blocked-by TODO marker → proof-log skipped"
 else
 	fail "4b. Explicit close + blocked-by TODO marker → should skip but proceeded"
+fi
+
+if should_skip_closing_hygiene_for_task "- [ ] t900 blocked task tier:standard blocked-by:t899"; then
+	pass "4c. Current TODO task-line blocked-by marker → closing hygiene skipped"
+else
+	fail "4c. Current TODO task-line blocked-by marker → should skip closing hygiene"
+fi
+
+issue_body_example='Issue reproducer mentions blocked-by:t899 in prose, not on the current TODO task line.'
+if should_skip_closing_hygiene_for_task "$issue_body_example"; then
+	fail "4d. Issue-body prose blocked-by mention → should not skip closing hygiene"
+else
+	pass "4d. Issue-body prose blocked-by mention → closing hygiene proceeds"
 fi
 
 # -------------------------------------------------------------------

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -706,9 +706,12 @@ jobs:
               echo "Issue #$ISSUE_NUM has rejection label '$REJECTION_MATCH' — using 'Referenced by' instead of 'Completed via'"
             fi
 
-            ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.body // ""' 2>/dev/null || echo "")
-            if echo "$ISSUE_BODY" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
-              echo "Issue #$ISSUE_NUM has unresolved blocked-by marker — skipping closing hygiene (GH#23516)"
+            TASK_LINE=""
+            if [[ -n "${TASK_ID:-}" && -f TODO.md ]]; then
+              TASK_LINE=$(grep -E "^[[:space:]]*- \[ \] ${TASK_ID} " TODO.md | head -1 || true)
+            fi
+            if echo "$TASK_LINE" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
+              echo "Task $TASK_ID has unresolved blocked-by marker — skipping closing hygiene for #$ISSUE_NUM (GH#23516)"
               continue
             fi
 


### PR DESCRIPTION
## Summary
- Move the workflow blocked-task veto from issue body prose to the current TODO task line.
- Preserve the GH#23516 blocker guard without false positives from issue descriptions or reproducer examples.
- Add regression coverage showing issue-body `blocked-by:*` prose does not suppress closing hygiene.

## Verification
- `bash .agents/scripts/tests/test-planning-pr-guard.sh`
- `bash .agents/scripts/tests/test-issue-sync-completion-evidence.sh`
- `shellcheck .agents/scripts/tests/test-planning-pr-guard.sh .agents/scripts/tests/test-issue-sync-completion-evidence.sh`
- `actionlint .github/workflows/issue-sync-reusable.yml`
- `git diff --check`

Follow-up for #23516

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.40 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 1h 10m and 198,167 tokens on this with the user in an interactive session.