### PR TITLE
GH#23525: skip draft PRs before pulse merge writes

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -557,7 +557,7 @@ _process_single_ready_pr() {
 	local repo_slug="$1"
 	local pr_obj="$2"
 
-	local pr_number="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at="" pr_head_ref_oid="" pr_labels=""
+	local pr_number="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at="" pr_head_ref_oid="" pr_labels="" pr_is_draft="false"
 	# Consolidate into a single jq pass to reduce process-spawn overhead.
 	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
 	# instead of \t. Bash read collapses consecutive IFS whitespace chars
@@ -567,13 +567,17 @@ _process_single_ready_pr() {
 	# caused pr_author to receive the PR title, breaking the collaborator
 	# check and blocking ALL merges across every repo (observed downstream).
 	local _RS=$'\x1e'
-	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_labels < <(
+	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_labels pr_is_draft < <(
 		printf '%s' "$pr_obj" | jq -r \
-			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\([(.labels // [])[].name] | join(","))"'
+			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\([(.labels // [])[].name] | join(","))\u001e\(.isDraft // false | tostring)"'
 	)
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	if [[ "$pr_is_draft" == "true" ]]; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — draft PR not eligible for auto-merge (GH#23525)" >>"$LOGFILE"
+		return 1
+	fi
 
 	# CONFLICTING handling (t2116): before closing, attempt to salvage the
 	# PR via `gh pr update-branch` which fast-forwards the base branch into

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -140,8 +140,37 @@ test_ruleset_violation_retries_without_admin() {
 	return 0
 }
 
+test_draft_pr_without_origin_labels_skips_merge_write() {
+	setup_test_env
+	define_function_under_test || { teardown_test_env; return 0; }
+
+	local pr_obj='{"number":88,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"draft test","labels":[],"isDraft":true}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "draft PR without origin labels skips merge" 1 "Expected 1, got ${result}; log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	if grep -qE 'gh pr merge 88' "$GH_LOG"; then
+		print_result "draft PR without origin labels makes no merge write" 1 "gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'draft PR not eligible for auto-merge.*GH#23525' "$LOGFILE"; then
+		print_result "draft PR without origin labels writes skip log" 1 "pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "draft PR without origin labels is blocked before gh pr merge" 0
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_ruleset_violation_retries_without_admin
+	test_draft_pr_without_origin_labels_skips_merge_write
 
 	printf '\n=================================\n'
 	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Added a label-independent isDraft guard in the deterministic pulse merge path before any approval, native auto-merge, or gh pr merge write; covered the missing-origin-label draft case with a regression test.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

Resolves #23525


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.41 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 14m and 70,374 tokens on this with the user in an interactive session.