### PR TITLE
GH#23517: align gh body examples with signature gate

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -90,7 +90,7 @@ gh api -i "repos/SLUG/collaborators/AUTHOR/permission"
 
 # Issue operations — label lifecycle: available -> queued -> in-progress -> in-review -> done
 gh issue edit NUMBER --repo SLUG --add-label "status:queued" --add-assignee USER
-gh issue comment NUMBER --repo SLUG --body "Completed via PR #NNN. DETAILS"  # MANDATORY before close
+gh issue comment NUMBER --repo SLUG --body-file /absolute/path/to/signed-comment.md  # MANDATORY before close
 gh issue close NUMBER --repo SLUG
 
 # Worker monitoring

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -19,13 +19,20 @@ git add -A && git commit -m 'feat: <what you just did> (<task-id>)'
 ```bash
 git push -u origin HEAD
 gh_issue=$(grep -E '^\s*- \[.\] <task-id> ' TODO.md 2>/dev/null | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
-pr_body='WIP - incremental commits'
-[[ -n "$gh_issue" ]] && pr_body="${pr_body}
+PR_BODY_FILE=/tmp/aidevops-pr-body.md
+python3 - <<'PY'
+from pathlib import Path
+Path('/tmp/aidevops-pr-body.md').write_text('WIP - incremental commits\n', encoding='utf-8')
+PY
+[[ -n "$gh_issue" ]] && printf '\nResolves #%s\n' "$gh_issue" >> "$PR_BODY_FILE"
+~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" >> "$PR_BODY_FILE"
+```
 
-Resolves #${gh_issue}"
-SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" 2>/dev/null || echo "")
-pr_body="${pr_body}${SIG_FOOTER}"
-gh pr create --draft --title '<task-id>: <description>' --body "$pr_body"
+Run the GitHub write in the next Bash tool call so the signature gate can read
+the completed body file before execution:
+
+```bash
+gh pr create --draft --title '<task-id>: <description>' --body-file /tmp/aidevops-pr-body.md
 ```
 
 - **ShellCheck before push for `.sh` files (t234).** Do not push violations. If `shellcheck` is missing, skip and note it in the PR body.

--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -22,8 +22,18 @@ For prompt-economy reasons these rules live here rather than in always-on AGENTS
 - The helper auto-detects runtime, version, tokens, and session time. Manual composition gets these wrong.
 - Every `gh issue create`, `gh issue comment`, `gh pr create`, and `gh pr comment` body MUST end with the helper's output.
 - Pass `--issue OWNER/REPO#NUM` on comments to existing issues. Pass `--solved` on closing comments.
-- Correct form (good): `gh issue comment 123 --repo owner/repo --body "..body..$(gh-signature-helper.sh footer)"`
-- Correct form (good, body file): `gh-signature-helper.sh footer >> "$BODY_FILE" && gh issue comment 123 --repo owner/repo --body-file "$BODY_FILE"`
+- Canonical body pattern: create an absolute body file in one Bash tool call,
+  append `gh-signature-helper.sh footer`, then run
+  `gh ... --body-file /absolute/path.md` in a later Bash tool call. This lets
+  the OpenCode pre-exec hook read the finished file before the GitHub write.
+- Wrapper pattern: source `shared-gh-wrappers.sh` and call `gh_issue_comment`,
+  `gh_create_issue`, `gh_pr_comment`, or `gh_create_pr` with `--body-file`;
+  wrappers sign at execution time.
+- ANTI-PATTERN (blocked by t2893 enforcement): same-command heredoc, process
+  substitution, command substitution, or shell-variable body construction such
+  as passing a heredoc through command substitution to `--body`, passing
+  `--body "$body"`, or creating `BODY_FILE` and using
+  `--body-file "$BODY_FILE"` in the same Bash tool call.
 - ANTI-PATTERN (blocked by t2685 enforcement): composing a human-readable signature inline like `--body "... — interactive cleanup from marcusquinn runtime."` or `--body "... [aidevops.sh](https://aidevops.sh) some prose ..."`. The literal string "aidevops.sh" is NOT sufficient evidence of a valid footer — only the canonical HTML marker `<!-- aidevops:sig -->` emitted by `gh-signature-helper.sh footer` counts. Hallucinated footers strip the required runtime/version/model/token/duration metadata that the marker carries.
 - Two enforcement layers will catch unsigned gh writes:
   - (a) `.agents/scripts/gh` PATH shim — transparently injects sig on `--body` / `--body-file` args before exec'ing the real `gh`. Active whenever `~/.aidevops/agents/scripts/` is first in PATH (default for aidevops-installed shells). Bypass: `AIDEVOPS_GH_SHIM_DISABLE=1`.

--- a/.agents/reference/large-file-split.md
+++ b/.agents/reference/large-file-split.md
@@ -259,8 +259,9 @@ If you hit this on a split, do NOT rewrite variable references to deduplicate
 
 ## 6. PR Body Template
 
-Copy this skeleton into `gh pr create --body`. Replace placeholders in
-`<angle brackets>`.
+Write this skeleton to an absolute body file, append
+`gh-signature-helper.sh footer`, then pass it to `gh pr create --body-file` in a
+later Bash tool call. Replace placeholders in `<angle brackets>`.
 
 ````markdown
 ## Summary

--- a/.agents/tools/git/github-cli.md
+++ b/.agents/tools/git/github-cli.md
@@ -38,11 +38,11 @@ gh repo list / create / clone / view / fork
 
 # Issues
 gh issue list --state open --label bug
-gh issue create --title "Bug report" --body "Description"
+gh issue create --title "Bug report" --body-file /absolute/path/to/body.md
 gh issue view 123 && gh issue close 123
 
 # PRs
-gh pr create --title "Feature X" --body "Description"
+gh pr create --title "Feature X" --body-file /absolute/path/to/body.md
 gh pr create --fill          # Auto-fill from commits
 gh pr view 123 && gh pr merge 123 --squash  # Also: --merge, --rebase
 
@@ -54,8 +54,13 @@ gh run list && gh run view 123456 && gh run watch
 gh run rerun 123456 --failed
 
 # API
-gh api repos/owner/repo/issues [-f title="Bug" -f body="Details"]
+gh api repos/owner/repo/issues [-f title="Bug" -F body=@/absolute/path/to/body.md]
 ```
+
+For aidevops-managed GitHub writes, create the body file and append
+`gh-signature-helper.sh footer` before the `gh ... --body-file` command. Do not
+use same-command heredoc or command-substitution bodies; the signature gate
+blocks patterns it cannot inspect safely.
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -128,15 +128,29 @@ Handles: `git add -A`, commit, `git rebase origin/main`, `git push -u`, `gh pr c
 
 **4.2.1 Merge Summary Comment (MANDATORY):** `commit-and-pr` posts automatically. Manual PRs — post immediately after PR creation:
 
+Create and sign the merge-summary body in one Bash tool call, then post it with
+`--body-file` in a later Bash tool call; same-command body-file creation is
+blocked by the signature gate.
+
 ```bash
-gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- MERGE_SUMMARY -->
+MERGE_SUMMARY_FILE=/tmp/aidevops-merge-summary.md
+python3 - <<'PY'
+from pathlib import Path
+Path('/tmp/aidevops-merge-summary.md').write_text('''<!-- MERGE_SUMMARY -->
 ## Completion Summary
 
 - **What**: <1-line description of what was done>
 - **Issue**: #<issue_number>
 - **Files changed**: <comma-separated list of key files>
 - **Testing**: <what was verified — linter, build, manual, etc.>
-- **Key decisions**: <any notable trade-offs or choices made>"
+- **Key decisions**: <any notable trade-offs or choices made>
+''', encoding='utf-8')
+PY
+~/.aidevops/agents/scripts/gh-signature-helper.sh footer >> "$MERGE_SUMMARY_FILE"
+```
+
+```bash
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/aidevops-merge-summary.md
 ```
 
 Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[] | select(.body | test("MERGE_SUMMARY"))] | length'` must return `1`.

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -166,7 +166,7 @@ If the proposal doesn't survive these questions, discuss before filing — it ma
 
 For framework bugs, use this expanded template that includes Evidence Attribution and Reproducer sections:
 
-```markdown
+````markdown
 ## Description
 
 {problem}
@@ -214,7 +214,7 @@ For framework bugs, use this expanded template that includes Evidence Attributio
 ## Additional Context
 
 {errors, session context}
-```
+````
 
 For non-bug reports (enhancements, questions), use the shorter template without Reproducer and Workarounds sections:
 
@@ -270,13 +270,25 @@ documented in GH#20322. Do not skip it even if Step 3 returned no results.
 
 ### Step 6: Create the Issue
 
+First Bash tool call: create and sign an absolute body file.
+
+```bash
+BODY_FILE=/tmp/aidevops-issue-body.md
+python3 - <<'PY'
+from pathlib import Path
+Path('/tmp/aidevops-issue-body.md').write_text('''BODY_CONTENT
+''', encoding='utf-8')
+PY
+~/.aidevops/agents/scripts/gh-signature-helper.sh footer >> "$BODY_FILE"
+```
+
+Second Bash tool call: post the already-created file. Do not combine body-file
+creation and the `gh issue create` write in the same Bash tool call.
+
 ```bash
 gh issue create -R marcusquinn/aidevops \
   --title "TITLE" \
-  --body "$(cat <<'EOF'
-BODY_CONTENT
-EOF
-)" \
+  --body-file /tmp/aidevops-issue-body.md \
   --label "LABEL"
 ```
 

--- a/.agents/workflows/mission-orchestrator.md
+++ b/.agents/workflows/mission-orchestrator.md
@@ -95,7 +95,7 @@ Dirs: `mission.md` (always) · `research/` · `agents/` · `scripts/` · `assets
 
 **Temporary agents**: create when 2+ features need the same specialised knowledge or a worker fails from missing context. Keep under 100 lines; frontmatter: `mode: subagent, status: draft, source: mission/{id}`. Pass path in worker prompts: `Read {mission-dir}/agents/{name}.md before starting.` After completion: move useful agents to `~/.aidevops/agents/draft/`; delete one-off agents.
 
-**Improvement feedback**: at completion, `gh issue create --repo {aidevops_slug} --title "Mission feedback: {desc}" --body "{details}"`. Don't modify aidevops files during a mission or duplicate existing capabilities.
+**Improvement feedback**: at completion, create a signed absolute body file, then `gh issue create --repo {aidevops_slug} --title "Mission feedback: {desc}" --body-file /absolute/path/to/body.md`. Don't modify aidevops files during a mission or duplicate existing capabilities.
 
 ## Research
 

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -54,10 +54,14 @@ tools:
 # GitHub
 git push -u origin HEAD
 gh pr create --fill --draft                            # Draft PR (interactive default)
-gh pr create --title "feat: ..." --body "Resolves #123" --draft  # Custom draft
+gh pr create --title "feat: ..." --body-file /absolute/path/to/body.md --draft  # Custom draft
 gh pr create --fill --reviewer @username,@team         # With reviewers
 # GitLab: glab mr create --fill  |  Gitea: tea pulls create --title "feat: ..."
 ```
+
+For aidevops-managed GitHub PRs, create and sign the body file before the
+`gh pr create --body-file` Bash tool call. Same-command heredoc and
+command-substitution `--body` patterns are blocked by the signature gate.
 
 Interactive aidevops PRs default to draft until the user explicitly asks to finalise/ready the PR or invokes `/pr-loop`. To permit pulse merge throughput after finalisation, also opt in with `allow-auto-merge`, `AIDEVOPS_INTERACTIVE_PR_AUTO_MERGE=1`, global `orchestration.interactive_pr_auto_merge=true`, or per-repo `repos.json` `interactive_pr_auto_merge=true`.
 

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -387,10 +387,10 @@ gh issue list --search "keyword" --state all
 gh pr view 456 --json title,body,files,additions,deletions,author
 gh pr diff 456 --stat
 gh pr checks 456
-gh pr review 456 --comment --body "Comment text"
-gh pr review 456 --request-changes --body "Please address..."
-gh pr review 456 --approve --body "LGTM!"
-gh issue close 123 --comment "Closing because..."
+gh pr review 456 --comment --body-file /absolute/path/to/review.md
+gh pr review 456 --request-changes --body-file /absolute/path/to/review.md
+gh pr review 456 --approve --body-file /absolute/path/to/review.md
+gh issue comment 123 --body-file /absolute/path/to/closing-comment.md && gh issue close 123
 rg "relevant_function" --type js --type ts --type py --type sh
 git log --oneline -20 -- path/to/affected/file
 ```


### PR DESCRIPTION
## Summary

Updated GitHub issue, PR, comment, review, and workflow guidance to prefer signed absolute --body-file patterns over same-command heredoc or shell-variable --body examples.

## Files Changed

.agents/automate.md,.agents/prompts/worker-efficiency-protocol.md,.agents/reference/gh-command-discipline.md,.agents/reference/large-file-split.md,.agents/tools/git/github-cli.md,.agents/workflows/full-loop.md,.agents/workflows/log-issue-aidevops.md,.agents/workflows/mission-orchestrator.md,.agents/workflows/pr.md,.agents/workflows/review-issue-pr.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh; targeted grep for stale blocked gh body examples

Resolves #23517


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.42 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 31m and 132,293 tokens on this with the user in an interactive session.