### PR TITLE
GH#23526: skip closed parent phase auto-filing

### DIFF
--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -732,8 +732,9 @@ _Sequential phase auto-filing by \`shared-phase-filing.sh\` (t2740)._"
 # Guards:
 #   1. Feature flag AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE must be 1
 #   2. Child issue must reference a parent-task issue
-#   3. Parent must have a ## Phases section
-#   4. Next phase must exist, be marked [auto-fire:on-prior-merge],
+#   3. Parent issue must still be open
+#   4. Parent must have a ## Phases section
+#   5. Next phase must exist, be marked [auto-fire:on-prior-merge],
 #      and not already have a child issue filed
 #
 # Args: $1=child_issue (just closed), $2=repo_slug
@@ -763,16 +764,21 @@ auto_file_next_phase() {
 	fi
 	_phase_log "Child #${child_issue}: found parent-task #${parent_issue}"
 
-	# Read parent issue body and title in a single API call
+	# Read parent issue state, body, and title in a single API call
 	local parent_api="repos/${repo_slug}/issues/${parent_issue}"
-	local parent_body parent_title _parent_json
+	local parent_body parent_title parent_state _parent_json
 	_parent_json=$(gh api "$parent_api" \
-		--jq '{body: (.body // ""), title: (.title // "")}' 2>/dev/null) || _parent_json=""
+		--jq '{body: (.body // ""), title: (.title // ""), state: (.state // "")}' 2>/dev/null) || _parent_json=""
 	[[ -n "$_parent_json" ]] || return 0
 	parent_body=$(printf '%s' "$_parent_json" | jq -r '.body // ""')
 	parent_title=$(printf '%s' "$_parent_json" | jq -r '.title // ""')
+	parent_state=$(printf '%s' "$_parent_json" | jq -r '.state // ""')
+	if [[ "$parent_state" != "open" ]]; then
+		_phase_log "Parent #${parent_issue}: state is '${parent_state}', not open — skip auto-file"
+		return 0
+	fi
 
-	# Guard 3: parse phases
+	# Guard 4: parse phases
 	local phases
 	phases=$(_parse_phases_section "$parent_body")
 	if [[ -z "$phases" ]]; then

--- a/.agents/scripts/tests/test-shared-phase-filing.sh
+++ b/.agents/scripts/tests/test-shared-phase-filing.sh
@@ -639,12 +639,105 @@ fi
 _phase_release_filing_lock "$lock_three"
 
 # =============================================================================
-# Test 18: deterministic-title search reuses an already-open phase child
+# Test 18: closed parent issue cannot drive phase auto-filing (GH#23526)
 # =============================================================================
-printf '%s--- Test 18: deterministic-title open issue dedup ---%s\n' "$TEST_BLUE" "$TEST_NC"
+printf '%s--- Test 18: closed parent blocks auto-file ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+export AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=1
+phase_parent_state="closed"
+phase_child_create_log="${TMP}/phase-child-created.log"
+: > "$phase_child_create_log"
+
+_find_parent_task_for_child() {
+	local child_issue="$1"
+	local repo_slug="$2"
+	: "$child_issue" "$repo_slug"
+	printf '500'
+	return 0
+}
+
+_identify_merged_phase() {
+	local child_issue="$1"
+	local repo_slug="$2"
+	local phases="$3"
+	: "$child_issue" "$repo_slug" "$phases"
+	printf '1'
+	return 0
+}
+
+_create_or_reuse_phase_child_issue() {
+	local parent_issue="$1"
+	local parent_title="$2"
+	local phase_num="$3"
+	local phase_desc="$4"
+	local repo_slug="$5"
+	: "$parent_issue" "$parent_title" "$phase_num" "$phase_desc" "$repo_slug"
+	printf 'created\n' >>"$phase_child_create_log"
+	printf ''
+	return 0
+}
 
 gh() {
-	if [[ " $* " == *" issue list "* ]]; then
+	local args="$*"
+	if [[ " $args " == *" api repos/owner/repo/issues/500 "* ]]; then
+		local parent_body=$'## Phases\n\n- Phase 1 - Complete first phase [auto-fire:on-prior-merge] #123\n- Phase 2 - Second phase [auto-fire:on-prior-merge]'
+		jq -n --arg body "$parent_body" --arg state "$phase_parent_state" \
+			'{body: $body, title: "Parent", state: $state}'
+		return 0
+	fi
+	return 1
+}
+
+: > "$LOGFILE"
+auto_file_next_phase "123" "owner/repo"
+closed_parent_log=""
+[[ -f "$LOGFILE" ]] && closed_parent_log=$(cat "$LOGFILE")
+
+if [[ ! -s "$phase_child_create_log" ]]; then
+	pass "Closed parent does not create a phase child"
+else
+	fail "Closed parent should not create a phase child"
+fi
+
+if printf '%s' "$closed_parent_log" | grep -q "Parent #500: state is 'closed', not open — skip auto-file"; then
+	pass "Closed parent skip reason is logged"
+else
+	fail "Closed parent skip log missing" "Log: ${closed_parent_log}"
+fi
+
+# =============================================================================
+# Test 19: open parent issue still drives phase auto-filing (GH#23526)
+# =============================================================================
+printf '%s--- Test 19: open parent preserves auto-file ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+phase_parent_state="open"
+: > "$phase_child_create_log"
+: > "$LOGFILE"
+auto_file_next_phase "123" "owner/repo"
+open_parent_log=""
+[[ -f "$LOGFILE" ]] && open_parent_log=$(cat "$LOGFILE")
+open_parent_created_count=$(grep -c '^created$' "$phase_child_create_log" || true)
+
+if [[ "$open_parent_created_count" -eq 1 ]]; then
+	pass "Open parent creates a phase child"
+else
+	fail "Open parent should create a phase child" "created=${open_parent_created_count}"
+fi
+
+if printf '%s' "$open_parent_log" | grep -q "Filing Phase 2 ('Second phase') for parent #500"; then
+	pass "Open parent follows existing filing path"
+else
+	fail "Open parent filing log missing" "Log: ${open_parent_log}"
+fi
+
+# =============================================================================
+# Test 20: deterministic-title search reuses an already-open phase child
+# =============================================================================
+printf '%s--- Test 20: deterministic-title open issue dedup ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+gh() {
+	local args="$*"
+	if [[ " $args " == *" issue list "* ]]; then
 		printf '22636\tPhase 4 of #22616: Extract Shell Quality block\n'
 		printf '22637\tPhase 4 of #22616: Extract Shell Quality block\n'
 		printf '22638\tPhase 5 of #22616: Extract gh Command Discipline block\n'


### PR DESCRIPTION
## Summary

Added a parent issue state guard to auto_file_next_phase so closed or superseded parent-task issues cannot create follow-on phase children; added GH#23526 regression coverage for the closed-parent skip path.

## Files Changed

.agents/scripts/shared-phase-filing.sh,.agents/scripts/tests/test-shared-phase-filing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shared-phase-filing.sh; shellcheck .agents/scripts/shared-phase-filing.sh .agents/scripts/tests/test-shared-phase-filing.sh; .agents/scripts/linters-local.sh reached existing quality gates but timed out during Secretlint after reporting no new string-literal debt

Resolves #23526


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.43 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 20m and 99,839 tokens on this as a headless worker.