### PR TITLE
GH#23524: fix systemd worker PID handoff fallback

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -844,6 +844,55 @@ _dlw_systemd_unit_name() {
 	return 0
 }
 
+_dlw_systemd_unit_property() {
+	local snapshot="$1"
+	local property_name="$2"
+	local line=""
+
+	while IFS= read -r line; do
+		case "$line" in
+			"${property_name}="*)
+				printf '%s\n' "${line#*=}"
+				return 0
+				;;
+		esac
+	done <<<"$snapshot"
+
+	return 1
+}
+
+_dlw_systemd_resolve_main_pid() {
+	local unit_name="$1"
+	local issue_number="$2"
+	local wait_i=0 snapshot="" main_pid="" active_state="" sub_state=""
+
+	while [[ "$wait_i" -lt 15 ]]; do
+		snapshot=$(systemctl --user show "$unit_name" -p MainPID -p ActiveState -p SubState 2>/dev/null || true)
+		main_pid=$(_dlw_systemd_unit_property "$snapshot" "MainPID" || true)
+		active_state=$(_dlw_systemd_unit_property "$snapshot" "ActiveState" || true)
+		sub_state=$(_dlw_systemd_unit_property "$snapshot" "SubState" || true)
+
+		if [[ "$main_pid" =~ ^[1-9][0-9]*$ ]]; then
+			echo "[dispatch_worker_launch] WARNING: systemd worker PID handoff missing for unit ${unit_name}; resolved MainPID=${main_pid} state=${active_state:-unknown}/${sub_state:-unknown} via systemctl, not launching fallback" >>"$LOGFILE"
+			printf '%s\n' "$main_pid"
+			return 0
+		fi
+
+		case "${active_state:-unknown}" in
+			inactive|failed)
+				echo "[dispatch_worker_launch] systemd unit ${unit_name} has no live MainPID state=${active_state:-unknown}/${sub_state:-unknown}; falling back to setsid/nohup for #${issue_number}" >>"$LOGFILE"
+				return 1
+				;;
+		esac
+
+		sleep 0.2
+		wait_i=$((wait_i + 1))
+	done
+
+	echo "[dispatch_worker_launch] ERROR: systemd-run launched ${unit_name} for #${issue_number} but no child PID or live MainPID was reported" >>"$LOGFILE"
+	return 1
+}
+
 _dlw_exec_systemd_user_service() {
 	local unit_prefix="$1"
 	local worker_log="$2"
@@ -888,12 +937,13 @@ _dlw_exec_systemd_user_service() {
 	rm -f "$pid_file" 2>/dev/null || true
 
 	if [[ "$service_pid" =~ ^[0-9]+$ ]]; then
+		echo "[dispatch_worker_launch] systemd unit ${unit_name} reported child PID=${service_pid} for #${issue_number}" >>"$LOGFILE"
 		printf '%s\n' "$service_pid"
 		return 0
 	fi
 
-	echo "[dispatch_worker_launch] ERROR: systemd-run launched ${unit_name} for #${issue_number} but no child PID was reported" >>"$LOGFILE"
-	return 1
+	_dlw_systemd_resolve_main_pid "$unit_name" "$issue_number"
+	return $?
 }
 
 # Execute a worker command via systemd-run (Linux user services) or setsid +

--- a/tests/test-systemd-worker-service-launch.sh
+++ b/tests/test-systemd-worker-service-launch.sh
@@ -20,6 +20,14 @@ cat >"${TMP_DIR}/bin/systemctl" <<'STUB_SYSTEMCTL'
 if [[ "${1:-}" == "--user" && "${2:-}" == "status" ]]; then
 	exit 0
 fi
+
+if [[ "${1:-}" == "--user" && "${2:-}" == "show" ]]; then
+	printf '%s\n' "MainPID=${STUB_SYSTEMCTL_MAINPID:-0}"
+	printf '%s\n' "ActiveState=${STUB_SYSTEMCTL_ACTIVE_STATE:-active}"
+	printf '%s\n' "SubState=${STUB_SYSTEMCTL_SUB_STATE:-running}"
+	exit 0
+fi
+
 exit 1
 STUB_SYSTEMCTL
 chmod +x "${TMP_DIR}/bin/systemctl"
@@ -45,8 +53,8 @@ for arg in "$@"; do
 	prev="$arg"
 done
 
-if [[ -n "$pid_file" ]]; then
-	printf '424242\n' >"$pid_file"
+if [[ "${STUB_SYSTEMD_RUN_WRITE_PID:-1}" == "1" && -n "$pid_file" ]]; then
+	printf '%s\n' "${STUB_SYSTEMD_RUN_PID:-424242}" >"$pid_file"
 fi
 exit 0
 STUB_SYSTEMD_RUN
@@ -54,34 +62,93 @@ chmod +x "${TMP_DIR}/bin/systemd-run"
 
 cat >"${TMP_DIR}/bin/setsid" <<'STUB_SETSID'
 #!/usr/bin/env bash
-printf 'setsid should not be used when systemd-run is available\n' >&2
-exit 1
+printf '%s\n' "$*" >>"${STUB_SETSID_LOG:?}"
+"$@"
+exit $?
 STUB_SETSID
 chmod +x "${TMP_DIR}/bin/setsid"
 
 export PATH="${TMP_DIR}/bin:${PATH}"
 export STUB_SYSTEMD_RUN_LOG="${TMP_DIR}/systemd-run.log"
+export STUB_SETSID_LOG="${TMP_DIR}/setsid.log"
 export LOGFILE="${TMP_DIR}/pulse.log"
 export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=0
 
 # shellcheck source=.agents/scripts/pulse-dispatch-worker-launch.sh
 source "${REPO_ROOT}/.agents/scripts/pulse-dispatch-worker-launch.sh"
 
-pid="$(_dlw_exec_detached "${TMP_DIR}/worker.log" "23073" /bin/true)"
+reset_logs() {
+	: >"$STUB_SYSTEMD_RUN_LOG"
+	: >"$STUB_SETSID_LOG"
+	: >"$LOGFILE"
+	return 0
+}
+
+assert_contains() {
+	local file_path="$1"
+	local expected="$2"
+	local message="$3"
+	if ! grep -q -- "$expected" "$file_path"; then
+		printf 'FAIL %s\n' "$message" >&2
+		exit 1
+	fi
+	return 0
+}
+
+assert_empty_file() {
+	local file_path="$1"
+	local message="$2"
+	if [[ -s "$file_path" ]]; then
+		printf 'FAIL %s\n' "$message" >&2
+		exit 1
+	fi
+	return 0
+}
+
+reset_logs
+export STUB_SYSTEMD_RUN_WRITE_PID=1
+export STUB_SYSTEMD_RUN_PID=424242
+pid="$(_dlw_exec_detached "${TMP_DIR}/worker-happy.log" "23073" /bin/true)"
 
 if [[ "$pid" != "424242" ]]; then
 	printf 'FAIL expected systemd child pid 424242, got %s\n' "$pid" >&2
 	exit 1
 fi
 
-if ! grep -q -- '--unit=aidevops-worker-23073-' "$STUB_SYSTEMD_RUN_LOG"; then
-	printf 'FAIL expected worker transient unit launch\n' >&2
+assert_contains "$STUB_SYSTEMD_RUN_LOG" '--unit=aidevops-worker-23073-' 'expected worker transient unit launch'
+assert_contains "$LOGFILE" 'systemd-run transient user service outside pulse cgroup' 'expected systemd launch diagnostic in pulse log'
+assert_contains "$LOGFILE" 'systemd unit aidevops-worker-23073-' 'expected systemd unit in launch diagnostic'
+assert_empty_file "$STUB_SETSID_LOG" 'setsid should not be used on pid-file systemd success'
+
+reset_logs
+export STUB_SYSTEMD_RUN_WRITE_PID=0
+export STUB_SYSTEMCTL_MAINPID=525252
+export STUB_SYSTEMCTL_ACTIVE_STATE=active
+export STUB_SYSTEMCTL_SUB_STATE=running
+pid="$(_dlw_exec_detached "${TMP_DIR}/worker-mainpid.log" "23524" /bin/true)"
+
+if [[ "$pid" != "525252" ]]; then
+	printf 'FAIL expected resolved systemd MainPID 525252, got %s\n' "$pid" >&2
 	exit 1
 fi
 
-if ! grep -q 'systemd-run transient user service outside pulse cgroup' "$LOGFILE"; then
-	printf 'FAIL expected systemd launch diagnostic in pulse log\n' >&2
+assert_contains "$LOGFILE" 'resolved MainPID=525252' 'expected MainPID recovery diagnostic in pulse log'
+assert_empty_file "$STUB_SETSID_LOG" 'setsid should not be used when systemctl resolves MainPID'
+
+reset_logs
+export STUB_SYSTEMD_RUN_WRITE_PID=0
+export STUB_SYSTEMCTL_MAINPID=0
+export STUB_SYSTEMCTL_ACTIVE_STATE=inactive
+export STUB_SYSTEMCTL_SUB_STATE=dead
+pid="$(_dlw_exec_detached "${TMP_DIR}/worker-fallback.log" "23524" /bin/true)"
+
+if [[ ! "$pid" =~ ^[0-9]+$ ]]; then
+	printf 'FAIL expected numeric fallback pid, got %s\n' "$pid" >&2
 	exit 1
 fi
 
-printf 'PASS %s\n' "worker launch uses systemd-run transient user service when available"
+assert_contains "$LOGFILE" 'falling back to setsid/nohup' 'expected fallback diagnostic when unit has no MainPID'
+assert_contains "$LOGFILE" 'systemd unit aidevops-worker-23524-' 'expected systemd unit in fallback diagnostic'
+assert_contains "$STUB_SETSID_LOG" 'nohup /bin/true' 'expected setsid fallback when unit has no MainPID'
+
+printf 'PASS %s\n' "worker launch resolves systemd MainPID before setsid fallback"


### PR DESCRIPTION
## Summary

Poll systemctl MainPID after successful systemd-run when the child pid-file handoff is missing, avoiding duplicate setsid fallback while the transient service is still active. Added regression coverage for pid-file success, MainPID recovery, and failed-unit fallback diagnostics.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,tests/test-systemd-worker-service-launch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** tests/test-systemd-worker-service-launch.sh; shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh tests/test-systemd-worker-service-launch.sh

Resolves #23524


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.43 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 10m and 77,235 tokens on this as a headless worker.