### PR TITLE
GH#23540: fix: skip unconfigured optional pulse routines

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -1002,6 +1002,17 @@ cmd_scan() {
 		return 1
 	fi
 
+	_scan_init_globals
+
+	local last_scan
+	last_scan=$(echo "$_SCAN_STATE" | jq -r '.last_scan // ""')
+
+	if [[ -z "$last_scan" ]]; then
+		echo -e "${YELLOW}[contribution-watch] skipped — no previous scan found; run aidevops contribution-watch seed to enable${NC}"
+		_log_info "Scan skipped — no prior seed"
+		return 0
+	fi
+
 	_check_prerequisites || return 1
 
 	local username
@@ -1012,17 +1023,6 @@ cmd_scan() {
 
 	# Remove PID file on exit (normal, Ctrl+C, or SIGTERM)
 	trap 'rm -f "$PID_FILE"; trap - EXIT INT TERM' EXIT INT TERM
-
-	_scan_init_globals
-
-	local last_scan
-	last_scan=$(echo "$_SCAN_STATE" | jq -r '.last_scan // ""')
-
-	if [[ -z "$last_scan" ]]; then
-		echo -e "${YELLOW}No previous scan found. Run 'seed' first.${NC}"
-		_log_warn "Scan attempted with no prior seed"
-		return 1
-	fi
 
 	_scan_maybe_auto_backfill
 	_log_info "Scan started (last_scan: ${last_scan})"

--- a/.agents/scripts/document-enrich-helper.sh
+++ b/.agents/scripts/document-enrich-helper.sh
@@ -665,10 +665,13 @@ cmd_tick() {
 		esac
 	done
 
-	_require_jq || return 1
-
 	local knowledge_root
-	knowledge_root=$(_resolve_knowledge_root "$knowledge_root_override") || return 1
+	if ! knowledge_root=$(_resolve_knowledge_root "$knowledge_root_override" 2>/dev/null); then
+		print_info "tick: skipped — knowledge plane not initialized; run aidevops knowledge init repo to enable"
+		return 0
+	fi
+
+	_require_jq || return 1
 
 	local sources_dir="${knowledge_root}/sources"
 	if [[ ! -d "$sources_dir" ]]; then

--- a/.agents/scripts/email-poll-helper.sh
+++ b/.agents/scripts/email-poll-helper.sh
@@ -113,10 +113,8 @@ _release_lock() {
 cmd_tick() {
 	local config_path
 	if ! config_path=$(_find_config 2>&1); then
-		log_error "$_ERR_NO_CONFIG"
-		log_error "Create $_REPO_CONFIG or $_GLOBAL_CONFIG"
-		log_error "Template: aidevops email mailbox add"
-		return 1
+		log_info "skipped — no mailboxes configured; run aidevops email mailbox add to enable"
+		return 0
 	fi
 
 	_require_python3 || return 1

--- a/.agents/tests/test-document-enrich.sh
+++ b/.agents/tests/test-document-enrich.sh
@@ -151,6 +151,24 @@ test_schema_files() {
 	return 0
 }
 
+test_tick_missing_knowledge_skips() {
+	setup
+	local name="tick: missing knowledge plane skips cleanly"
+	local tmpdir="${TEST_TMPDIR}/missing-knowledge"
+	mkdir -p "$tmpdir/home" "$tmpdir/repo"
+
+	local output exit_rc=0
+	output=$(cd "$tmpdir/repo" && HOME="$tmpdir/home" REPOS_FILE="$tmpdir/missing-repos.json" bash "$HELPER" tick 2>&1) || exit_rc=$?
+
+	if [[ "$exit_rc" -eq 0 ]] && [[ "$output" == *"skipped"* ]] && [[ "$output" == *"aidevops knowledge init repo"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "exit=$exit_rc output=$output"
+	fi
+	teardown
+	return 0
+}
+
 test_regex_extraction() {
 	setup
 	local text_file="${TEST_TMPDIR}/test.txt"
@@ -428,6 +446,7 @@ test_dry_run() {
 run_tests() {
 	test_shellcheck
 	test_schema_files
+	test_tick_missing_knowledge_skips
 	test_regex_extraction
 	test_regex_no_match
 	test_llm_mock_absent

--- a/.agents/tests/test-email-poll.sh
+++ b/.agents/tests/test-email-poll.sh
@@ -154,6 +154,26 @@ PYEOF
 }
 
 # ---------------------------------------------------------------------------
+# Test: missing config skips optional pulse tick
+# ---------------------------------------------------------------------------
+
+test_tick_missing_config_skips() {
+	local name="tick: missing mailbox config skips cleanly"
+	local tmpdir="${TEST_TMPDIR}/missing-config"
+	mkdir -p "$tmpdir"
+
+	local output exit_rc=0
+	output=$(cd "$tmpdir" && HOME="$tmpdir/home" bash "$POLL_HELPER" tick 2>&1) || exit_rc=$?
+
+	if [[ "$exit_rc" -eq 0 ]] && [[ "$output" == *"skipped"* ]] && [[ "$output" == *"aidevops email mailbox add"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "exit=$exit_rc output=$output"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Test: Python syntax check
 # ---------------------------------------------------------------------------
 
@@ -434,6 +454,7 @@ main() {
 	setup
 
 	test_python_syntax
+	test_tick_missing_config_skips
 	test_tick_happy_path
 	test_missing_credentials
 	test_connection_failure

--- a/tests/test-contribution-watch-pid-guard.sh
+++ b/tests/test-contribution-watch-pid-guard.sh
@@ -142,8 +142,11 @@ test_stop_invalid_pid_file() {
 }
 
 test_scan_duplicate_prevention() {
-	# Simulate a running scan by writing our own PID to the PID file
-	echo $$ >"$PID_FILE_PATH"
+	# Simulate a running scan with a process command line that matches the
+	# command-aware PID liveness guard.
+	bash -c 'while :; do sleep 1; done' contribution-watch-helper >/dev/null 2>&1 &
+	local fake_scan_pid=$!
+	echo "$fake_scan_pid" >"$PID_FILE_PATH"
 
 	# Attempting to start another scan should fail with exit 1
 	local exit_code=0
@@ -161,7 +164,30 @@ test_scan_duplicate_prevention() {
 	fi
 
 	# Clean up
+	kill "$fake_scan_pid" 2>/dev/null || true
+	wait "$fake_scan_pid" 2>/dev/null || true
 	rm -f "$PID_FILE_PATH"
+	return 0
+}
+
+test_scan_without_seed_skips() {
+	rm -f "$PID_FILE_PATH"
+	echo '{"last_scan":"","items":{}}' >"$HOME/.aidevops/cache/contribution-watch.json"
+
+	local exit_code=0
+	local output
+	output=$(bash "$SCRIPT_UNDER_TEST" scan 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]]; then
+		pass "scan with no seed exits 0"
+	else
+		fail "scan with no seed exits 0" "Got exit code $exit_code"
+	fi
+	if echo "$output" | grep -q "skipped" && echo "$output" | grep -q "seed"; then
+		pass "scan with no seed prints skipped enablement message"
+	else
+		fail "scan with no seed prints skipped enablement message" "Output: $output"
+	fi
+	echo '{"last_scan":"2026-01-01T00:00:00Z","items":{}}' >"$HOME/.aidevops/cache/contribution-watch.json"
 	return 0
 }
 
@@ -186,6 +212,7 @@ test_stop_no_pid_file
 test_stop_stale_pid_file
 test_stop_invalid_pid_file
 test_scan_duplicate_prevention
+test_scan_without_seed_skips
 test_stale_pid_allows_new_scan
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Optional email polling, document enrichment, and contribution-watch pulse entries now return success with concise skip messages when their required local config or seed state is absent. Focused regression coverage verifies the unconfigured skip paths and preserves operational failures for configured/runtime error cases.

## Files Changed

.agents/scripts/contribution-watch-helper.sh,.agents/scripts/document-enrich-helper.sh,.agents/scripts/email-poll-helper.sh,.agents/tests/test-document-enrich.sh,.agents/tests/test-email-poll.sh,tests/test-contribution-watch-pid-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-email-poll.sh; bash .agents/tests/test-document-enrich.sh; bash tests/test-contribution-watch-pid-guard.sh; shellcheck .agents/scripts/email-poll-helper.sh .agents/scripts/document-enrich-helper.sh .agents/scripts/contribution-watch-helper.sh .agents/tests/test-email-poll.sh .agents/tests/test-document-enrich.sh tests/test-contribution-watch-pid-guard.sh

Resolves #23540


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 8m and 103,594 tokens on this as a headless worker.