### PR TITLE
GH#23542: skip unsafe pulse repo refreshes

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -67,6 +67,58 @@ fi
 # Returns: always 0 (failures are logged but never fatal — callers proceed
 #   with current checkout, same as the previous git pull || { warn; } pattern)
 #######################################
+_pulse_refresh_should_skip_repo() {
+	local repo_path="$1"
+	local default_branch=""
+	local current_branch=""
+	local upstream_ref=""
+	local upstream_remote=""
+	local upstream_branch=""
+
+	if declare -F _get_default_branch_for_repo >/dev/null 2>&1; then
+		default_branch=$(_get_default_branch_for_repo "$repo_path" 2>/dev/null) || default_branch=""
+	else
+		default_branch=$(git -C "$repo_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || default_branch=""
+		default_branch="${default_branch#origin/}"
+	fi
+
+	if [[ -z "$default_branch" ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — no origin/HEAD set" >>"$LOGFILE"
+		return 0
+	fi
+
+	current_branch=$(git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null) || current_branch=""
+	if [[ -z "$current_branch" ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — detached HEAD" >>"$LOGFILE"
+		return 0
+	fi
+
+	if [[ "$current_branch" != "$default_branch" ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — on ${current_branch}, expected ${default_branch}" >>"$LOGFILE"
+		return 0
+	fi
+
+	upstream_ref=$(git -C "$repo_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null) || upstream_ref=""
+	if [[ -z "$upstream_ref" || "$upstream_ref" != */* ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — upstream is not configured" >>"$LOGFILE"
+		return 0
+	fi
+
+	upstream_remote="${upstream_ref%%/*}"
+	upstream_branch="${upstream_ref#*/}"
+	if [[ "$upstream_remote" != "origin" || "$upstream_branch" != "$default_branch" ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — upstream ${upstream_ref} is not origin/${default_branch}" >>"$LOGFILE"
+		return 0
+	fi
+
+	if ! git -C "$repo_path" ls-remote --exit-code "$upstream_remote" "refs/heads/${upstream_branch}" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — upstream ${upstream_ref} does not exist" >>"$LOGFILE"
+		return 0
+	fi
+
+	return 1
+}
+
 _pulse_refresh_repo() {
 	local repo_path="$1"
 	[[ -n "$repo_path" ]] || return 0
@@ -80,6 +132,9 @@ _pulse_refresh_repo() {
 
 	if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 		echo "[pulse-wrapper] _pulse_refresh_repo: ${repo_path} is not a git work-tree — skipping" >>"$LOGFILE"
+		return 0
+	fi
+	if _pulse_refresh_should_skip_repo "$repo_path"; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-refresh-repo-guard.sh
+++ b/.agents/scripts/tests/test-pulse-refresh-repo-guard.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for pulse preflight repo refresh guard (GH#23542).
+
+set -euo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s %s\n' "$name" "$extra"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+	touch "$LOGFILE"
+	git config --global commit.gpgsign false >/dev/null 2>&1 || true
+	git config --global tag.gpgsign false >/dev/null 2>&1 || true
+	git config --global init.defaultBranch main >/dev/null 2>&1 || true
+	export GIT_CONFIG_NOSYSTEM=1
+	export GIT_AUTHOR_NAME="Test"
+	export GIT_AUTHOR_EMAIL="test@example.com"
+	export GIT_COMMITTER_NAME="Test"
+	export GIT_COMMITTER_EMAIL="test@example.com"
+	return 0
+}
+
+teardown_sandbox() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+setup_deleted_upstream_repo() {
+	local bare_dir="${TEST_ROOT}/origin.git"
+	local clone_dir="${TEST_ROOT}/repo"
+	git init --bare "$bare_dir" >/dev/null 2>&1
+	git clone "$bare_dir" "$clone_dir" >/dev/null 2>&1
+	(
+		cd "$clone_dir" || exit 1
+		git checkout -b main >/dev/null 2>&1
+		printf 'initial\n' >file.txt
+		git add file.txt
+		git commit -m "initial" >/dev/null 2>&1
+		git push -u origin main >/dev/null 2>&1
+		git checkout -b deleted-branch >/dev/null 2>&1
+		printf 'feature\n' >feature.txt
+		git add feature.txt
+		git commit -m "feature" >/dev/null 2>&1
+		git push -u origin deleted-branch >/dev/null 2>&1
+		git push origin --delete deleted-branch >/dev/null 2>&1
+		git remote set-head origin main >/dev/null 2>&1
+	)
+	git --git-dir="$bare_dir" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1
+	printf '%s\n' "$clone_dir"
+	return 0
+}
+
+test_refresh_skips_deleted_noncanonical_upstream() {
+	local clone_dir=""
+	clone_dir=$(setup_deleted_upstream_repo)
+	true >"$LOGFILE"
+	_pulse_refresh_repo "$clone_dir"
+
+	if grep -Fq "refresh skipped: noncanonical or missing upstream" "$LOGFILE" && \
+	   ! grep -Fq "attempting canonical-recovery" "$LOGFILE" && \
+	   ! grep -Fq "git pull --ff-only failed" "$LOGFILE"; then
+		print_result "deleted upstream refresh is skipped without recovery" 0
+		return 0
+	fi
+	print_result "deleted upstream refresh is skipped without recovery" 1 "$(tr '\n' ' ' <"$LOGFILE")"
+	return 0
+}
+
+main() {
+	setup_sandbox
+	trap teardown_sandbox EXIT
+	# shellcheck source=/dev/null
+	source "${TEST_SCRIPTS_DIR}/pulse-canonical-maintenance.sh"
+	# shellcheck source=/dev/null
+	source "${TEST_SCRIPTS_DIR}/pulse-wrapper-cycle.sh"
+	declare -g -A _PULSE_REFRESHED_THIS_CYCLE=()
+	test_refresh_skips_deleted_noncanonical_upstream
+	printf 'Tests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds a pre-pull guard to `_pulse_refresh_repo` so pulse refresh skips noncanonical branches, detached checkouts, missing upstreams, and upstream refs that no longer resolve before running `git pull --ff-only`.
- Reuses the canonical-maintenance default-branch detector when available so pulse preflight and canonical maintenance agree on default-branch safety.
- Adds a regression test that creates a branch tracking a deleted upstream and verifies refresh skips without pull failure or canonical recovery.

Resolves #23542

## Testing

- PASS: `bash .agents/scripts/tests/test-pulse-refresh-repo-guard.sh`
- PASS: `shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/tests/test-pulse-refresh-repo-guard.sh`
- PASS: `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh`
- PASS: `.agents/scripts/linters-local.sh` completed with existing advisory markdown/ratchet/complexity output and final success
- OBSERVED: `bash .agents/scripts/tests/test-pulse-canonical-maintenance.sh` still fails existing `skip-on-session-active`; this is unrelated to the changed refresh guard

## Runtime Testing

Self-assessed shell helper regression coverage. The new test exercises the deleted-upstream failure mode in a sandboxed git origin/clone pair.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.45 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 9m and 82,690 tokens on this as a headless worker.
