### PR TITLE
GH#23541: classify active claim dispatch blocks as benign

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -193,8 +193,13 @@ check_dispatch_dedup() {
 	_dedup_layer2_process_match "$issue_number" "$repo_slug" && return 0
 	_dedup_layer3_title_match "$title" && return 0
 	_dedup_layer4_pr_evidence "$issue_number" "$repo_slug" "$issue_title" && return 0
-	_dedup_layer5_dispatch_comment "$issue_number" "$repo_slug" "$self_login" && return 0
-	_dedup_layer6_assignee_and_stale "$issue_number" "$repo_slug" "$self_login" && return 0
+	# Active dispatch comments and assignment/claim guards are expected
+	# cross-runner locks, not launch failures. Preserve the block while giving
+	# dispatch_max a distinct benign rc so the stage wrapper suppresses generic
+	# "Stage failed" noise and refill loops can skip this candidate for the
+	# current pulse cycle (GH#23541).
+	_dedup_layer5_dispatch_comment "$issue_number" "$repo_slug" "$self_login" && return 3
+	_dedup_layer6_assignee_and_stale "$issue_number" "$repo_slug" "$self_login" && return 3
 
 	return 1
 }
@@ -1292,9 +1297,12 @@ _dispatch_dedup_check_layers() {
 	local _dedup_rc=0
 	ISSUE_META_JSON="$issue_meta_json" \
 		check_dispatch_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" "$self_login" || _dedup_rc=$?
-	if [[ "$_dedup_rc" -eq 0 ]]; then
+	if [[ "$_dedup_rc" -eq 0 || "$_dedup_rc" -eq 3 ]]; then
 		echo "[dispatch_with_dedup] Dedup guard blocked #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.7_layers" "$_dss_t0"
+		if [[ "$_dedup_rc" -eq 3 ]]; then
+			return 3
+		fi
 		return 1
 	fi
 	_ds_record "$issue_number" "$repo_slug" "dedup.7_layers" "$_dss_t0"
@@ -1525,10 +1533,15 @@ dispatch_with_dedup() {
 	# _claim_comment_id is set by check_dispatch_dedup inside this call via
 	# bash dynamic scoping — accessible below because it was declared local above.
 	_ds_t0=$(_ds_now_ns)
-	if ! _dispatch_dedup_check_layers \
+	local _dedup_check_rc=0
+	_dispatch_dedup_check_layers \
 		"$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
-		"$self_login" "$repo_path" "$issue_meta_json"; then
+		"$self_login" "$repo_path" "$issue_meta_json" || _dedup_check_rc=$?
+	if [[ "$_dedup_check_rc" -ne 0 ]]; then
 		_ds_record "$issue_number" "$repo_slug" "dedup_check" "$_ds_t0"
+		if [[ "$_dedup_check_rc" -eq 3 ]]; then
+			return 3
+		fi
 		return 1
 	fi
 	_ds_record "$issue_number" "$repo_slug" "dedup_check" "$_ds_t0"

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -50,6 +50,7 @@ _DISPATCH_ROUND_NO_WORKER_FAILURES=0
 _DISPATCH_CONSECUTIVE_NO_WORKER=0
 _DISPATCH_THROTTLE_FILE=""
 _DISPATCH_CANARY_CACHE=""
+_DISPATCH_BENIGN_BLOCKS_FILE=""
 # Out-parameter set by _dispatch_process_candidate when a successful launch clears
 # the throttle file. The orchestrator loop reads this and restores
 # _effective_slots to the unthrottled available_slots value.
@@ -104,7 +105,7 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		dedup_active_claim | cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
+		cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
 			;;
 		*)
 			reason="unclassified_signal"
@@ -190,11 +191,75 @@ _dispatch_candidate_failure_reason() {
 _dispatch_candidate_benign_block_reason() {
 	local reason="$1"
 	case "$reason" in
-		interactive_review_hold | pr_target_not_dispatchable)
+		dedup_active_claim | interactive_review_hold | pr_target_not_dispatchable)
 			return 0
 			;;
 	esac
 	return 1
+}
+
+#######################################
+# Return the cycle-local benign block ledger path, creating a default when the
+# orchestrator has not provided one. The file is intentionally process-scoped so
+# repeated dispatch_max refill attempts in the same pulse skip candidates that
+# were already blocked by an active claim (GH#23541).
+#
+# Stdout: file path
+# Returns: 0 always
+#######################################
+_dispatch_benign_blocks_file() {
+	if [[ -z "${_DISPATCH_BENIGN_BLOCKS_FILE:-}" ]]; then
+		_DISPATCH_BENIGN_BLOCKS_FILE="${AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE:-${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.$$}"
+	fi
+	printf '%s\n' "$_DISPATCH_BENIGN_BLOCKS_FILE"
+	return 0
+}
+
+#######################################
+# Record a candidate that hit a benign dispatch block in the current pulse.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug
+#   $3 - benign reason token
+# Returns: 0 always
+#######################################
+_dispatch_mark_benign_blocked_candidate() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local ledger_file
+	ledger_file=$(_dispatch_benign_blocks_file)
+	mkdir -p "${ledger_file%/*}" 2>/dev/null || true
+	printf '%s\t%s\t%s\n' "$issue_number" "$repo_slug" "$reason" >>"$ledger_file" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Check whether a candidate already hit a benign dispatch block this pulse.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug
+# Stdout: benign reason token when present
+# Returns:
+#   0 - candidate is blocked for this pulse
+#   1 - candidate is not blocked
+#######################################
+_dispatch_benign_blocked_candidate_reason() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local ledger_file
+	local reason=""
+	ledger_file=$(_dispatch_benign_blocks_file)
+	[[ -f "$ledger_file" ]] || return 1
+	reason=$(awk -F '\t' -v issue="$issue_number" -v repo="$repo_slug" '
+		$1 == issue && $2 == repo { reason = $3 }
+		END { if (reason != "") { print reason } }
+	' "$ledger_file" 2>/dev/null) || return 1
+	[[ -n "$reason" ]] || return 1
+	printf '%s\n' "$reason"
+	return 0
 }
 
 #######################################
@@ -619,6 +684,13 @@ _dispatch_should_skip_candidate() {
 	local repo_slug="$2"
 
 	pulse_dispatch_debug_log "evaluating skip checks for #${issue_number} (${repo_slug})"
+
+	local benign_block_reason=""
+	if benign_block_reason=$(_dispatch_benign_blocked_candidate_reason "$issue_number" "$repo_slug"); then
+		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — skip:already_assigned blocked:${benign_block_reason} from current pulse cycle" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_blocked_${benign_block_reason}"
+		return 0
+	fi
 
 	# GH#18804: previously this call used `>/dev/null 2>&1` which suppressed
 	# the helper's own log lines AND, more dangerously, masked silent
@@ -1049,7 +1121,8 @@ _dispatch_record_nonzero_dispatch_result() {
 	local failure_reason
 	failure_reason=$(_dispatch_candidate_failure_reason "$issue_number" "$repo_slug" "$dispatch_rc")
 	if _dispatch_candidate_benign_block_reason "$failure_reason"; then
-		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) benign dispatch block reason=${failure_reason}" >>"$LOGFILE"
+		_dispatch_mark_benign_blocked_candidate "$issue_number" "$repo_slug" "$failure_reason"
+		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) blocked:${failure_reason} benign dispatch block" >>"$LOGFILE"
 		_dispatch_stats_increment "dispatch_candidate_blocked_${failure_reason}"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -61,6 +61,7 @@ assert_not_grep() {
 # Resolve paths relative to this test file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
+CORE="$SCRIPT_DIR/pulse-dispatch-core.sh"
 DISPATCH_LIB="$SCRIPT_DIR/pulse-dispatch-lib.sh"
 
 echo "=== t2443 + t2903: pulse-dispatch-engine stage wiring regression tests ==="
@@ -159,11 +160,19 @@ assert_grep \
 	"$DISPATCH_LIB"
 assert_grep \
 	"10b: interactive review hold is recognized as a benign block" \
-	'interactive_review_hold \| pr_target_not_dispatchable' \
+	'dedup_active_claim \| interactive_review_hold \| pr_target_not_dispatchable' \
 	"$DISPATCH_LIB"
 assert_grep \
-	"10b2: PR target is logged as benign block, not pre-launch failure" \
-	'benign dispatch block reason=\$\{failure_reason\}' \
+	"10b2: benign blocks are logged distinctly, not as pre-launch failures" \
+	'blocked:\$\{failure_reason\} benign dispatch block' \
+	"$DISPATCH_LIB"
+assert_grep \
+	"10b3: active claim dedup returns benign rc=3 to suppress Stage failed" \
+	'_dedup_layer6_assignee_and_stale.*&& return 3' \
+	"$CORE"
+assert_grep \
+	"10b4: refill skips candidates blocked by active claim in current cycle" \
+	'skip:already_assigned blocked:' \
 	"$DISPATCH_LIB"
 
 assert_grep \
@@ -176,7 +185,7 @@ assert_grep \
 	"$DISPATCH_LIB"
 assert_not_grep \
 	"10e: benign block reasons are not counted as candidate failure reasons" \
-	'dedup_active_claim \| interactive_review_hold \| pr_target_not_dispatchable \|' \
+	'dedup_active_claim \| cost_budget_exceeded' \
 	"$DISPATCH_LIB"
 
 # --- Summary ---

--- a/.agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh
@@ -23,6 +23,24 @@ return_seven() {
 	return 7
 }
 
+dispatch_with_dedup() {
+	return 3
+}
+
+run_stage_with_timeout() {
+	local stage_name="$1"
+	local timeout_seconds="$2"
+	shift 2
+
+	local stage_rc=0
+	"$@" || stage_rc=$?
+	if [[ "$stage_rc" -ne 0 ]]; then
+		printf '[pulse-wrapper] Stage failed: %s exited with %s (%ss)\n' "$stage_name" "$stage_rc" "$timeout_seconds" >>"$LOGFILE"
+		return "$stage_rc"
+	fi
+	return 0
+}
+
 assert_adapter_rc() {
 	local expected_rc="$1"
 	local rc_file="$2"
@@ -60,5 +78,20 @@ assert_file_content 7 "$failure_rc_file"
 
 unwritable_rc_file="/dev/null/dispatch.rc"
 assert_adapter_rc 3 "$unwritable_rc_file" return_three
+
+LOGFILE="$TMP_DIR/pulse.log"
+DISPATCH_PER_CANDIDATE_TIMEOUT=1
+DISPATCH_PER_CANDIDATE_TIMEOUT_FLOOR=1
+DISPATCH_TIMING_ADAPTIVE=0
+_dispatch_with_timeout "123" "owner/repo" "Issue #123" "Assigned issue" "runner" "/tmp/repo" "/full-loop Implement issue #123" "issue-123" "" || dispatch_timeout_rc=$?
+dispatch_timeout_rc="${dispatch_timeout_rc:-0}"
+if [[ "$dispatch_timeout_rc" -ne 3 ]]; then
+	printf 'FAIL expected dispatch timeout rc=3 actual=%s\n' "$dispatch_timeout_rc" >&2
+	exit 1
+fi
+if grep -q 'Stage failed: dispatch_candidate_123' "$LOGFILE" 2>/dev/null; then
+	printf 'FAIL benign dispatch rc=3 emitted Stage failed log\n' >&2
+	exit 1
+fi
 
 printf 'PASS pulse-dispatch-stage-rc-adapter\n'


### PR DESCRIPTION
## Summary

Classified dedup_active_claim dispatch blocks as benign rc=3 outcomes so per-candidate stage wrappers do not log Stage failed, added a cycle-local ledger so refill attempts skip already-blocked active-claim candidates, and added regression coverage for the adapter/logging behavior.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh,.agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh && .agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh && .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh; bash .agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh && bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh && bash .agents/scripts/tests/test-dispatch-max-parallel.sh; bash .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh; shellcheck modified shell files. Note: bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh has existing local fixture metadata failures where gh_issue_view returns empty metadata before dispatch.

Resolves #23541


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 12m and 166,872 tokens on this as a headless worker.