### PR TITLE
GH#23551: harden canonical sweep cwd change

### DIFF
--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -342,7 +342,7 @@ _stale_worktree_sweep_single_repo() {
 	# so operators can still diagnose sweep failures.
 	local sweep_rc=0
 	(
-		cd "$repo_path" || exit 125
+		cd -- "$repo_path" || exit 125
 		_canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" "$worktree_helper" clean --auto --force-merged
 	) >>"${LOGFILE:-/dev/null}" 2>&1 || sweep_rc=$?
 	if [[ "$sweep_rc" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Updated the canonical worktree sweep subshell to use cd -- for variable repo paths, addressing the verified review-followup robustness issue.

## Files Changed

.agents/scripts/pulse-canonical-maintenance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-canonical-maintenance.sh; bash .agents/scripts/tests/test-pulse-canonical-maintenance.sh (12 passed)

Resolves #23551


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 1m and 37,364 tokens on this as a headless worker.