### PR TITLE
GH#23550: clarify pulse upstream verification failures

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -111,8 +111,14 @@ _pulse_refresh_should_skip_repo() {
 		return 0
 	fi
 
-	if ! git -C "$repo_path" ls-remote --exit-code "$upstream_remote" "refs/heads/${upstream_branch}" >/dev/null 2>&1; then
+	local ls_remote_exit=0
+	git -C "$repo_path" ls-remote --exit-code "$upstream_remote" "refs/heads/${upstream_branch}" >/dev/null 2>&1 || ls_remote_exit=$?
+	if [[ "$ls_remote_exit" -eq 2 ]]; then
 		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: noncanonical or missing upstream for ${repo_path} — upstream ${upstream_ref} does not exist" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$ls_remote_exit" -ne 0 ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: refresh skipped: could not verify upstream ${upstream_ref} for ${repo_path} — git ls-remote exited ${ls_remote_exit}" >>"$LOGFILE"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-refresh-repo-guard.sh
+++ b/.agents/scripts/tests/test-pulse-refresh-repo-guard.sh
@@ -91,6 +91,29 @@ test_refresh_skips_deleted_noncanonical_upstream() {
 	return 0
 }
 
+test_refresh_distinguishes_unverifiable_upstream() {
+	local clone_dir=""
+	clone_dir=$(setup_deleted_upstream_repo)
+	(
+		cd "$clone_dir" || exit 1
+		git checkout main >/dev/null 2>&1
+		git remote set-url origin "${TEST_ROOT}/missing-origin.git" >/dev/null 2>&1
+	)
+	_PULSE_REFRESHED_THIS_CYCLE=()
+	true >"$LOGFILE"
+	_pulse_refresh_repo "$clone_dir"
+
+	if grep -Fq "could not verify upstream origin/main" "$LOGFILE" && \
+	   grep -Fq "git ls-remote exited" "$LOGFILE" && \
+	   ! grep -Fq "upstream origin/main does not exist" "$LOGFILE" && \
+	   ! grep -Fq "git pull --ff-only failed" "$LOGFILE"; then
+		print_result "unverifiable upstream is not logged as missing" 0
+		return 0
+	fi
+	print_result "unverifiable upstream is not logged as missing" 1 "$(tr '\n' ' ' <"$LOGFILE")"
+	return 0
+}
+
 main() {
 	setup_sandbox
 	trap teardown_sandbox EXIT
@@ -100,6 +123,7 @@ main() {
 	source "${TEST_SCRIPTS_DIR}/pulse-wrapper-cycle.sh"
 	declare -g -A _PULSE_REFRESHED_THIS_CYCLE=()
 	test_refresh_skips_deleted_noncanonical_upstream
+	test_refresh_distinguishes_unverifiable_upstream
 	printf 'Tests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1


### PR DESCRIPTION
## Summary

Distinguish missing upstream refs from git ls-remote verification errors in pulse repo refresh guards and cover the unverifiable-upstream path with a regression test.

## Files Changed

.agents/scripts/pulse-wrapper-cycle.sh,.agents/scripts/tests/test-pulse-refresh-repo-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/tests/test-pulse-refresh-repo-guard.sh; .agents/scripts/tests/test-pulse-refresh-repo-guard.sh

Resolves #23550


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 2m and 48,035 tokens on this as a headless worker.