### PR TITLE
GH#23549: scope benign dispatch block ledger to cycle

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -421,6 +421,7 @@ dispatch_max() {
 	_DISPATCH_CONSECUTIVE_NO_WORKER=0
 	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
 	_DISPATCH_CANARY_CACHE="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}/canary-last-pass"
+	_dispatch_begin_benign_blocks_cycle >/dev/null
 
 	# t3015: branch on dispatch path (max = parallel, floor = forced-serial).
 	# t3418/t3558: if the minimum worker floor is active, runtime launch
@@ -458,6 +459,7 @@ dispatch_max() {
 	if ! printf '%s' "$candidates_json" | jq -c '.[]' >"$_dispatch_candidate_file" 2>>"$LOGFILE"; then
 		echo "[pulse-wrapper] Dispatch_max: jq failed to enumerate candidates_json — aborting loop with 0 dispatches" >>"$LOGFILE"
 		rm -f "$_dispatch_candidate_file"
+		_dispatch_cleanup_benign_blocks_cycle
 		_dispatch_maybe_engage_throttle
 		echo "[pulse-wrapper] Dispatch_max complete: dispatched=${triage_dispatched} (${triage_dispatched} triage + 0 implementation), processed=0/${candidate_count}, target_available=${available_slots}" >>"$LOGFILE"
 		echo "$triage_dispatched"
@@ -485,6 +487,7 @@ dispatch_max() {
 	[[ "$dispatched_count" =~ ^[0-9]+$ ]] || dispatched_count=0
 	[[ "$processed_count" =~ ^[0-9]+$ ]] || processed_count=0
 	rm -f "$_dispatch_candidate_file"
+	_dispatch_cleanup_benign_blocks_cycle
 
 	echo "[pulse-wrapper] Dispatch path=${_dispatch_path}: loop body finished — processed=${processed_count} dispatched=${dispatched_count} mode=$( ((_dispatch_max_parallel <= 1)) && echo serial || echo "parallel(${_dispatch_max_parallel})")" >>"$LOGFILE"
 	_dispatch_maybe_engage_throttle

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -199,17 +199,52 @@ _dispatch_candidate_benign_block_reason() {
 }
 
 #######################################
-# Return the cycle-local benign block ledger path, creating a default when the
-# orchestrator has not provided one. The file is intentionally process-scoped so
-# repeated dispatch_max refill attempts in the same pulse skip candidates that
-# were already blocked by an active claim (GH#23541).
+# Start a cycle-local benign block ledger. Reinitializing the ledger for every
+# dispatch_max cycle prevents stale active-claim blocks from a long-running
+# pulse-wrapper process from suppressing later cycles after the claim clears.
+#
+# Stdout: file path
+# Returns: 0 always
+#######################################
+_dispatch_begin_benign_blocks_cycle() {
+	local ledger_file=""
+	if [[ -n "${AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE:-}" ]]; then
+		ledger_file="$AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE"
+	else
+		mkdir -p "${HOME}/.aidevops/logs" 2>/dev/null || true
+		ledger_file=$(mktemp "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.XXXXXX" 2>/dev/null || printf '%s\n' "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.$$.$RANDOM")
+	fi
+	mkdir -p "${ledger_file%/*}" 2>/dev/null || true
+	: >"$ledger_file" 2>/dev/null || true
+	_DISPATCH_BENIGN_BLOCKS_FILE="$ledger_file"
+	printf '%s\n' "$_DISPATCH_BENIGN_BLOCKS_FILE"
+	return 0
+}
+
+#######################################
+# Remove the cycle-local benign block ledger once the dispatch loop has read it.
+#
+# Returns: 0 always
+#######################################
+_dispatch_cleanup_benign_blocks_cycle() {
+	local ledger_file="${_DISPATCH_BENIGN_BLOCKS_FILE:-}"
+	if [[ -n "$ledger_file" ]]; then
+		rm -f "$ledger_file" 2>/dev/null || true
+	fi
+	_DISPATCH_BENIGN_BLOCKS_FILE=""
+	return 0
+}
+
+#######################################
+# Return the current cycle-local benign block ledger path, creating a default
+# when the orchestrator has not explicitly started a ledger.
 #
 # Stdout: file path
 # Returns: 0 always
 #######################################
 _dispatch_benign_blocks_file() {
 	if [[ -z "${_DISPATCH_BENIGN_BLOCKS_FILE:-}" ]]; then
-		_DISPATCH_BENIGN_BLOCKS_FILE="${AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE:-${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.$$}"
+		_dispatch_begin_benign_blocks_cycle >/dev/null
 	fi
 	printf '%s\n' "$_DISPATCH_BENIGN_BLOCKS_FILE"
 	return 0

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -189,6 +189,25 @@ test_pr_target_reason_is_classified_as_benign_block() {
 	return 0
 }
 
+test_benign_block_ledger_is_cycle_local_and_cleaned() {
+	reset_guardrail_env
+	local first_ledger second_ledger lingering_reason=""
+	_dispatch_begin_benign_blocks_cycle >/dev/null
+	first_ledger="$_DISPATCH_BENIGN_BLOCKS_FILE"
+	_dispatch_mark_benign_blocked_candidate 23541 marcusquinn/aidevops dedup_active_claim
+	_dispatch_cleanup_benign_blocks_cycle
+	_dispatch_begin_benign_blocks_cycle >/dev/null
+	second_ledger="$_DISPATCH_BENIGN_BLOCKS_FILE"
+	lingering_reason=$(_dispatch_benign_blocked_candidate_reason 23541 marcusquinn/aidevops 2>/dev/null || true)
+	_dispatch_cleanup_benign_blocks_cycle
+	if [[ "$first_ledger" != "$second_ledger" && ! -e "$first_ledger" && ! -e "$second_ledger" && -z "$lingering_reason" ]]; then
+		print_result "guardrail: benign block ledger is cycle-local and cleaned" 0
+	else
+		print_result "guardrail: benign block ledger is cycle-local and cleaned" 1 "first=${first_ledger} second=${second_ledger} lingering=${lingering_reason}"
+	fi
+	return 0
+}
+
 test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
@@ -198,6 +217,7 @@ test_clean_state_preserves_available_slots
 test_disabled_guardrail_still_updates_available_slots_gauge
 test_interactive_hold_reason_is_classified
 test_pr_target_reason_is_classified_as_benign_block
+test_benign_block_ledger_is_cycle_local_and_cleaned
 
 printf '\n====================\n'
 printf 'Tests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Made the benign dispatch block ledger reinitialize per dispatch_max cycle and clean up after the candidate loop so stale active-claim blocks cannot leak across long-running pulse-wrapper cycles.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh; .agents/scripts/linters-local.sh timed out during the later shell portability stage after targeted checks passed and earlier gates reported only advisory pre-existing warnings

Resolves #23549


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 10m and 80,696 tokens on this as a headless worker.