### PR TITLE
GH#23554: optimize systemd PID parsing

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -844,33 +844,30 @@ _dlw_systemd_unit_name() {
 	return 0
 }
 
-_dlw_systemd_unit_property() {
-	local snapshot="$1"
-	local property_name="$2"
-	local line=""
-
-	while IFS= read -r line; do
-		case "$line" in
-			"${property_name}="*)
-				printf '%s\n' "${line#*=}"
-				return 0
-				;;
-		esac
-	done <<<"$snapshot"
-
-	return 1
-}
-
 _dlw_systemd_resolve_main_pid() {
 	local unit_name="$1"
 	local issue_number="$2"
-	local wait_i=0 snapshot="" main_pid="" active_state="" sub_state=""
+	local wait_i=0 snapshot="" main_pid="" active_state="" sub_state="" key="" value=""
 
 	while [[ "$wait_i" -lt 15 ]]; do
 		snapshot=$(systemctl --user show "$unit_name" -p MainPID -p ActiveState -p SubState 2>/dev/null || true)
-		main_pid=$(_dlw_systemd_unit_property "$snapshot" "MainPID" || true)
-		active_state=$(_dlw_systemd_unit_property "$snapshot" "ActiveState" || true)
-		sub_state=$(_dlw_systemd_unit_property "$snapshot" "SubState" || true)
+		main_pid=""
+		active_state=""
+		sub_state=""
+
+		while IFS='=' read -r key value; do
+			case "$key" in
+				MainPID)
+					main_pid="$value"
+					;;
+				ActiveState)
+					active_state="$value"
+					;;
+				SubState)
+					sub_state="$value"
+					;;
+			esac
+		done <<<"$snapshot"
 
 		if [[ "$main_pid" =~ ^[1-9][0-9]*$ ]]; then
 			echo "[dispatch_worker_launch] WARNING: systemd worker PID handoff missing for unit ${unit_name}; resolved MainPID=${main_pid} state=${active_state:-unknown}/${sub_state:-unknown} via systemctl, not launching fallback" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Refactored systemd MainPID resolution to parse systemctl key-value output once per poll iteration and removed the repeated property helper lookups.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-dispatch-worker-launch.sh; shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh; bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh; bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh; bash tests/test-pulse-systemd-timeout.sh; .agents/scripts/linters-local.sh (timed out after targeted checks passed; only pre-existing/advisory output before timeout)

Resolves #23554


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 6m and 86,998 tokens on this as a headless worker.