### PR TITLE
GH#23553: consolidate phase parent metadata parsing

### DIFF
--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -722,30 +722,34 @@ _Sequential phase auto-filing by \`shared-phase-filing.sh\` (t2740)._"
 }
 
 #######################################
-# Read parent issue metadata and ensure it is still open before it can drive
-# next-phase auto-filing.
+# Read parent issue metadata in one jq pass and ensure it is still open before
+# it can drive next-phase auto-filing.
 #
 # Args: $1=parent_issue, $2=repo_slug
-# Output: parent JSON when open; empty otherwise
+# Globals: _PHASE_PARENT_BODY, _PHASE_PARENT_TITLE
 # Returns: 0 always
 #######################################
-_read_open_phase_parent_json() {
+_read_open_phase_parent_fields() {
 	local parent_issue="$1"
 	local repo_slug="$2"
 	local parent_api="repos/${repo_slug}/issues/${parent_issue}"
-	local parent_state _parent_json
+	local parent_state _parent_assignments
 
-	_parent_json=$(gh api "$parent_api" \
-		--jq '{body: (.body // ""), title: (.title // ""), state: (.state // "")}' 2>/dev/null) || _parent_json=""
-	[[ -n "$_parent_json" ]] || return 0
+	_PHASE_PARENT_BODY=""
+	_PHASE_PARENT_TITLE=""
+	_parent_assignments=$(gh api "$parent_api" \
+		--jq '@sh "parent_state=\(.state // \"\") _PHASE_PARENT_TITLE=\(.title // \"\") _PHASE_PARENT_BODY=\(.body // \"\")"' 2>/dev/null) || _parent_assignments=""
+	[[ -n "$_parent_assignments" ]] || return 0
 
-	parent_state=$(printf '%s' "$_parent_json" | jq -r '.state // ""')
+	# jq @sh emits safely quoted shell assignments for GitHub-controlled text.
+	eval "$_parent_assignments"
 	if [[ "$parent_state" != "open" ]]; then
 		_phase_log "Parent #${parent_issue}: state is '${parent_state}', not open — skip auto-file"
+		_PHASE_PARENT_BODY=""
+		_PHASE_PARENT_TITLE=""
 		return 0
 	fi
 
-	printf '%s' "$_parent_json"
 	return 0
 }
 
@@ -793,11 +797,11 @@ auto_file_next_phase() {
 	_phase_log "Child #${child_issue}: found parent-task #${parent_issue}"
 
 	# Read parent issue metadata and ensure the parent is still open.
-	local parent_body parent_title _parent_json
-	_parent_json=$(_read_open_phase_parent_json "$parent_issue" "$repo_slug")
-	[[ -n "$_parent_json" ]] || return 0
-	parent_body=$(printf '%s' "$_parent_json" | jq -r '.body // ""')
-	parent_title=$(printf '%s' "$_parent_json" | jq -r '.title // ""')
+	local parent_body parent_title
+	_read_open_phase_parent_fields "$parent_issue" "$repo_slug"
+	parent_body="$_PHASE_PARENT_BODY"
+	parent_title="$_PHASE_PARENT_TITLE"
+	[[ -n "$parent_body" ]] || return 0
 
 	# Guard 4: parse phases
 	local phases

--- a/.agents/scripts/tests/test-shared-phase-filing.sh
+++ b/.agents/scripts/tests/test-shared-phase-filing.sh
@@ -681,8 +681,8 @@ gh() {
 	local args="$*"
 	if [[ " $args " == *" api repos/owner/repo/issues/500 "* ]]; then
 		local parent_body=$'## Phases\n\n- Phase 1 - Complete first phase [auto-fire:on-prior-merge] #123\n- Phase 2 - Second phase [auto-fire:on-prior-merge]'
-		jq -n --arg body "$parent_body" --arg state "$phase_parent_state" \
-			'{body: $body, title: "Parent", state: $state}'
+		printf 'parent_state=%q _PHASE_PARENT_TITLE=%q _PHASE_PARENT_BODY=%q\n' \
+			"$phase_parent_state" "Parent" "$parent_body"
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
## Summary

Consolidated open-parent phase metadata extraction so state, title, and body are parsed in one jq pass before next-phase auto-filing continues.

## Files Changed

.agents/scripts/shared-phase-filing.sh,.agents/scripts/tests/test-shared-phase-filing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-phase-filing.sh .agents/scripts/tests/test-shared-phase-filing.sh; bash .agents/scripts/tests/test-shared-phase-filing.sh

Resolves #23553


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 4m and 59,685 tokens on this as a headless worker.