### PR TITLE
GH#23557: replace Python body-file examples with heredocs

### DIFF
--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -20,10 +20,9 @@ git add -A && git commit -m 'feat: <what you just did> (<task-id>)'
 git push -u origin HEAD
 gh_issue=$(grep -E '^\s*- \[.\] <task-id> ' TODO.md 2>/dev/null | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
 PR_BODY_FILE=/tmp/aidevops-pr-body.md
-python3 - <<'PY'
-from pathlib import Path
-Path('/tmp/aidevops-pr-body.md').write_text('WIP - incremental commits\n', encoding='utf-8')
-PY
+cat <<'EOF' > "$PR_BODY_FILE"
+WIP - incremental commits
+EOF
 [[ -n "$gh_issue" ]] && printf '\nResolves #%s\n' "$gh_issue" >> "$PR_BODY_FILE"
 ~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" >> "$PR_BODY_FILE"
 ```

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -134,9 +134,8 @@ blocked by the signature gate.
 
 ```bash
 MERGE_SUMMARY_FILE=/tmp/aidevops-merge-summary.md
-python3 - <<'PY'
-from pathlib import Path
-Path('/tmp/aidevops-merge-summary.md').write_text('''<!-- MERGE_SUMMARY -->
+cat <<'EOF' > "$MERGE_SUMMARY_FILE"
+<!-- MERGE_SUMMARY -->
 ## Completion Summary
 
 - **What**: <1-line description of what was done>
@@ -144,8 +143,7 @@ Path('/tmp/aidevops-merge-summary.md').write_text('''<!-- MERGE_SUMMARY -->
 - **Files changed**: <comma-separated list of key files>
 - **Testing**: <what was verified — linter, build, manual, etc.>
 - **Key decisions**: <any notable trade-offs or choices made>
-''', encoding='utf-8')
-PY
+EOF
 ~/.aidevops/agents/scripts/gh-signature-helper.sh footer >> "$MERGE_SUMMARY_FILE"
 ```
 

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -274,11 +274,9 @@ First Bash tool call: create and sign an absolute body file.
 
 ```bash
 BODY_FILE=/tmp/aidevops-issue-body.md
-python3 - <<'PY'
-from pathlib import Path
-Path('/tmp/aidevops-issue-body.md').write_text('''BODY_CONTENT
-''', encoding='utf-8')
-PY
+cat <<'EOF' > "$BODY_FILE"
+BODY_CONTENT
+EOF
 ~/.aidevops/agents/scripts/gh-signature-helper.sh footer >> "$BODY_FILE"
 ```
 


### PR DESCRIPTION
## Summary

Replaced Python snippets that wrote static GitHub body files with Bash heredocs that use the declared file variables.

## Files Changed

.agents/prompts/worker-efficiency-protocol.md,.agents/workflows/full-loop.md,.agents/workflows/log-issue-aidevops.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 .agents/prompts/worker-efficiency-protocol.md .agents/workflows/full-loop.md .agents/workflows/log-issue-aidevops.md

Resolves #23557


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 2m and 40,906 tokens on this as a headless worker.