### PR TITLE
GH#23552: preserve optional helper diagnostics

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -121,12 +121,17 @@ _check_prerequisites() {
 		echo -e "${RED}Error: gh CLI not found. Install from https://cli.github.com/${NC}" >&2
 		return 1
 	fi
-	if ! command -v jq &>/dev/null; then
-		echo -e "${RED}Error: jq not found. Install with: brew install jq${NC}" >&2
-		return 1
-	fi
+	_check_jq_prerequisite || return 1
 	if ! gh auth status &>/dev/null 2>&1; then
 		echo -e "${RED}Error: gh not authenticated. Run: gh auth login${NC}" >&2
+		return 1
+	fi
+	return 0
+}
+
+_check_jq_prerequisite() {
+	if ! command -v jq &>/dev/null; then
+		echo -e "${RED}Error: jq not found. Install with: brew install jq${NC}" >&2
 		return 1
 	fi
 	return 0
@@ -1001,6 +1006,8 @@ cmd_scan() {
 		_log_warn "Scan skipped — already running (PID ${running_pid})"
 		return 1
 	fi
+
+	_check_jq_prerequisite || return 1
 
 	_scan_init_globals
 

--- a/.agents/scripts/document-enrich-helper.sh
+++ b/.agents/scripts/document-enrich-helper.sh
@@ -666,12 +666,10 @@ cmd_tick() {
 	done
 
 	local knowledge_root
-	if ! knowledge_root=$(_resolve_knowledge_root "$knowledge_root_override" 2>/dev/null); then
+	if ! knowledge_root=$(_resolve_knowledge_root "$knowledge_root_override"); then
 		print_info "tick: skipped — knowledge plane not initialized; run aidevops knowledge init repo to enable"
 		return 0
 	fi
-
-	_require_jq || return 1
 
 	local sources_dir="${knowledge_root}/sources"
 	if [[ ! -d "$sources_dir" ]]; then


### PR DESCRIPTION
## Summary
- Ensure contribution-watch validates jq before parsing scan state while preserving the unseeded skip path.
- Let document-enrich tick surface knowledge-root resolution diagnostics and rely on the resolver instead of a duplicate jq gate.

## Testing
- `shellcheck .agents/scripts/contribution-watch-helper.sh .agents/scripts/document-enrich-helper.sh`
- `bash .agents/tests/test-document-enrich.sh`
- `bash tests/test-contribution-watch-pid-guard.sh`

## Runtime Testing
Self-assessed: shell helper control-flow change covered by targeted shell tests.

Resolves #23552

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 7m and 72,436 tokens on this as a headless worker.
