### PR TITLE
GH#23558: fix: align worker origin detection

### DIFF
--- a/.agents/scripts/gh-signature-helper-session.sh
+++ b/.agents/scripts/gh-signature-helper-session.sh
@@ -484,7 +484,8 @@ _detect_explicit_session_type() {
 
 	if _gh_sig_env_truthy "${FULL_LOOP_HEADLESS:-}" ||
 		_gh_sig_env_truthy "${AIDEVOPS_HEADLESS:-}" ||
-		_gh_sig_env_truthy "${OPENCODE_HEADLESS:-}"; then
+		_gh_sig_env_truthy "${OPENCODE_HEADLESS:-}" ||
+		_gh_sig_env_truthy "${GITHUB_ACTIONS:-}"; then
 		echo "worker"
 		return 0
 	fi

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1565,8 +1565,10 @@ cmd_run() {
 		# The sandbox allowlist already forwards AIDEVOPS_*; legacy generic
 		# HEADLESS/FULL_LOOP_HEADLESS markers are intentionally not required
 		# past the clean-env boundary.
-		export AIDEVOPS_SESSION_ORIGIN="worker"
-		export AIDEVOPS_HEADLESS="true"
+		AIDEVOPS_SESSION_ORIGIN="${AIDEVOPS_SESSION_ORIGIN:-worker}"
+		export AIDEVOPS_SESSION_ORIGIN
+		AIDEVOPS_HEADLESS="${AIDEVOPS_HEADLESS:-true}"
+		export AIDEVOPS_HEADLESS
 	fi
 
 	print_info "[lifecycle] pre_model_select session=$session_key role=$role tier=${tier_override:-auto} pid=$$"

--- a/.agents/scripts/tests/test-gh-signature-session-origin.sh
+++ b/.agents/scripts/tests/test-gh-signature-session-origin.sh
@@ -34,7 +34,7 @@ _is_opencode_runtime() { return 1; }
 # shellcheck source=../gh-signature-helper-session.sh
 source "${SCRIPTS_DIR}/gh-signature-helper-session.sh" || exit 1
 
-unset FULL_LOOP_HEADLESS AIDEVOPS_HEADLESS OPENCODE_HEADLESS OPENCODE OPENCODE_SESSION_ID
+unset FULL_LOOP_HEADLESS AIDEVOPS_HEADLESS OPENCODE_HEADLESS GITHUB_ACTIONS OPENCODE OPENCODE_SESSION_ID
 export AIDEVOPS_SESSION_ORIGIN=worker
 detected="$(_detect_explicit_session_type)"
 if [[ "$detected" == "worker" ]]; then
@@ -50,6 +50,15 @@ if [[ "$detected" == "interactive" ]]; then
 	print_result "AIDEVOPS_SESSION_ORIGIN=interactive overrides headless marker" 0
 else
 	print_result "AIDEVOPS_SESSION_ORIGIN=interactive overrides headless marker" 1 "got '${detected}'"
+fi
+
+unset AIDEVOPS_SESSION_ORIGIN AIDEVOPS_HEADLESS
+export GITHUB_ACTIONS=true
+detected="$(_detect_explicit_session_type)"
+if [[ "$detected" == "worker" ]]; then
+	print_result "GITHUB_ACTIONS=true -> worker" 0
+else
+	print_result "GITHUB_ACTIONS=true -> worker" 1 "got '${detected}'"
 fi
 
 echo

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -534,6 +534,45 @@ test_cmd_run_aborts_issue_worker_before_canary_when_env_missing() {
 	return 0
 }
 
+test_cmd_run_preserves_worker_origin_overrides_before_canary() {
+	local worktree_dir="${TEST_ROOT}/origin-override-worktree"
+	mkdir -p "$worktree_dir"
+	init_git_worktree "$worktree_dir"
+	export WORKER_ISSUE_NUMBER=23558
+	export WORKER_WORKTREE_PATH="$worktree_dir"
+	export AIDEVOPS_SESSION_ORIGIN=interactive
+	export AIDEVOPS_HEADLESS=already-set
+
+	choose_model() { printf '%s' 'openai/gpt-5.5'; return 0; }
+	_enforce_opencode_version_pin() { return 0; }
+	_run_canary_test() {
+		if [[ "${AIDEVOPS_SESSION_ORIGIN:-}" == "interactive" && "${AIDEVOPS_HEADLESS:-}" == "already-set" ]]; then
+			printf '%s\n' 'canary_saw_origin_overrides'
+		fi
+		return 1
+	}
+
+	local output=""
+	local status=0
+	output=$(cmd_run \
+		--role worker \
+		--session-key issue-23558 \
+		--dir "$worktree_dir" \
+		--title "Issue #23558: origin overrides" \
+		--prompt "/full-loop Implement issue #23558" 2>&1) || status=$?
+
+	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH AIDEVOPS_SESSION_ORIGIN AIDEVOPS_HEADLESS 2>/dev/null || true
+	unset -f choose_model _enforce_opencode_version_pin _run_canary_test 2>/dev/null || true
+	if [[ "$status" -eq 1 && "$output" == *"canary_saw_origin_overrides"* && "$output" == *"Canary failed"* ]]; then
+		print_result "cmd_run preserves worker origin env overrides before canary" 0
+		return 0
+	fi
+
+	print_result "cmd_run preserves worker origin env overrides before canary" 1 \
+		"status=$status output=${output:-<empty>}"
+	return 0
+}
+
 test_deleted_launch_cwd_recovers_to_work_dir() {
 	local stale_dir="${TEST_ROOT}/stale-cwd"
 	local worktree_dir="${TEST_ROOT}/worker-worktree"
@@ -1454,6 +1493,7 @@ main() {
 	test_worker_worktree_claim_classifies_unreclaimed_live_owner
 	test_deleted_cwd_recovery_uses_worker_worktree
 	test_cmd_run_aborts_issue_worker_before_canary_when_env_missing
+	test_cmd_run_preserves_worker_origin_overrides_before_canary
 	test_deleted_launch_cwd_recovers_to_work_dir
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id


### PR DESCRIPTION
## Summary

Aligned signature footer session detection with the canonical GitHub wrapper worker signals by recognizing GITHUB_ACTIONS, and preserved existing AIDEVOPS worker-origin overrides during headless runtime startup.

## Files Changed

.agents/scripts/gh-signature-helper-session.sh,.agents/scripts/headless-runtime-helper.sh,.agents/scripts/tests/test-gh-signature-session-origin.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-signature-helper-session.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-gh-signature-session-origin.sh .agents/scripts/tests/test-headless-runtime-helper.sh; .agents/scripts/tests/test-gh-signature-session-origin.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #23558


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 6m and 64,273 tokens on this as a headless worker.