### PR TITLE
GH#23556: respect no-auto-dispatch in phase sequencing

### DIFF
--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -733,12 +733,12 @@ _read_open_phase_parent_fields() {
 	local parent_issue="$1"
 	local repo_slug="$2"
 	local parent_api="repos/${repo_slug}/issues/${parent_issue}"
-	local parent_state _parent_assignments
+	local parent_state parent_labels _parent_assignments
 
 	_PHASE_PARENT_BODY=""
 	_PHASE_PARENT_TITLE=""
 	_parent_assignments=$(gh api "$parent_api" \
-		--jq '@sh "parent_state=\(.state // \"\") _PHASE_PARENT_TITLE=\(.title // \"\") _PHASE_PARENT_BODY=\(.body // \"\")"' 2>/dev/null) || _parent_assignments=""
+		--jq '@sh "parent_state=\(.state // \"\") parent_labels=\([(.labels // [])[].name] | join(\",\")) _PHASE_PARENT_TITLE=\(.title // \"\") _PHASE_PARENT_BODY=\(.body // \"\")"' 2>/dev/null) || _parent_assignments=""
 	[[ -n "$_parent_assignments" ]] || return 0
 
 	# jq @sh emits safely quoted shell assignments for GitHub-controlled text.
@@ -749,6 +749,14 @@ _read_open_phase_parent_fields() {
 		_PHASE_PARENT_TITLE=""
 		return 0
 	fi
+	case ",${parent_labels}," in
+	*,no-auto-dispatch,*)
+		_phase_log "Parent #${parent_issue}: carries no-auto-dispatch, skip auto-file"
+		_PHASE_PARENT_BODY=""
+		_PHASE_PARENT_TITLE=""
+		return 0
+		;;
+	esac
 
 	return 0
 }
@@ -764,7 +772,7 @@ _read_open_phase_parent_fields() {
 # Guards:
 #   1. Feature flag AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE must be 1
 #   2. Child issue must reference a parent-task issue
-#   3. Parent issue must still be open
+#   3. Parent issue must still be open and not carry no-auto-dispatch
 #   4. Parent must have a ## Phases section
 #   5. Next phase must exist, be marked [auto-fire:on-prior-merge],
 #      and not already have a child issue filed

--- a/.agents/scripts/tests/test-shared-phase-filing.sh
+++ b/.agents/scripts/tests/test-shared-phase-filing.sh
@@ -645,6 +645,7 @@ printf '%s--- Test 18: closed parent blocks auto-file ---%s\n' "$TEST_BLUE" "$TE
 
 export AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=1
 phase_parent_state="closed"
+phase_parent_labels=""
 phase_child_create_log="${TMP}/phase-child-created.log"
 : > "$phase_child_create_log"
 
@@ -681,8 +682,8 @@ gh() {
 	local args="$*"
 	if [[ " $args " == *" api repos/owner/repo/issues/500 "* ]]; then
 		local parent_body=$'## Phases\n\n- Phase 1 - Complete first phase [auto-fire:on-prior-merge] #123\n- Phase 2 - Second phase [auto-fire:on-prior-merge]'
-		printf 'parent_state=%q _PHASE_PARENT_TITLE=%q _PHASE_PARENT_BODY=%q\n' \
-			"$phase_parent_state" "Parent" "$parent_body"
+		printf 'parent_state=%q parent_labels=%q _PHASE_PARENT_TITLE=%q _PHASE_PARENT_BODY=%q\n' \
+			"$phase_parent_state" "$phase_parent_labels" "Parent" "$parent_body"
 		return 0
 	fi
 	return 1
@@ -711,6 +712,7 @@ fi
 printf '%s--- Test 19: open parent preserves auto-file ---%s\n' "$TEST_BLUE" "$TEST_NC"
 
 phase_parent_state="open"
+phase_parent_labels=""
 : > "$phase_child_create_log"
 : > "$LOGFILE"
 auto_file_next_phase "123" "owner/repo"
@@ -731,9 +733,34 @@ else
 fi
 
 # =============================================================================
-# Test 20: deterministic-title search reuses an already-open phase child
+# Test 20: no-auto-dispatch parent issue cannot drive phase auto-filing
 # =============================================================================
-printf '%s--- Test 20: deterministic-title open issue dedup ---%s\n' "$TEST_BLUE" "$TEST_NC"
+printf '%s--- Test 20: no-auto-dispatch parent blocks auto-file ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+phase_parent_state="open"
+phase_parent_labels="parent-task,no-auto-dispatch"
+: > "$phase_child_create_log"
+: > "$LOGFILE"
+auto_file_next_phase "123" "owner/repo"
+no_auto_log=""
+[[ -f "$LOGFILE" ]] && no_auto_log=$(cat "$LOGFILE")
+
+if [[ ! -s "$phase_child_create_log" ]]; then
+	pass "no-auto-dispatch parent does not create a phase child"
+else
+	fail "no-auto-dispatch parent should not create a phase child"
+fi
+
+if printf '%s' "$no_auto_log" | grep -q "Parent #500: carries no-auto-dispatch, skip auto-file"; then
+	pass "no-auto-dispatch skip reason is logged"
+else
+	fail "no-auto-dispatch skip log missing" "Log: ${no_auto_log}"
+fi
+
+# =============================================================================
+# Test 21: deterministic-title search reuses an already-open phase child
+# =============================================================================
+printf '%s--- Test 21: deterministic-title open issue dedup ---%s\n' "$TEST_BLUE" "$TEST_NC"
 
 gh() {
 	local args="$*"


### PR DESCRIPTION
## Summary

Auto-file sequencing now reads parent labels and skips parents carrying no-auto-dispatch; tests cover the skipped path and updated parent metadata mock.

## Files Changed

.agents/scripts/shared-phase-filing.sh,.agents/scripts/tests/test-shared-phase-filing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shared-phase-filing.sh (44/44 passed); shellcheck .agents/scripts/shared-phase-filing.sh .agents/scripts/tests/test-shared-phase-filing.sh

Resolves #23556


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 3m and 50,859 tokens on this as a headless worker.