### PR TITLE
GH#23577: fix: validate contribution watch prerequisites before scan jq

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -1007,7 +1007,7 @@ cmd_scan() {
 		return 1
 	fi
 
-	_check_jq_prerequisite || return 1
+	_check_prerequisites || return 1
 
 	_scan_init_globals
 
@@ -1019,8 +1019,6 @@ cmd_scan() {
 		_log_info "Scan skipped — no prior seed"
 		return 0
 	fi
-
-	_check_prerequisites || return 1
 
 	local username
 	username=$(_get_username) || return 1


### PR DESCRIPTION
## Summary

Moved contribution-watch scan to run the full prerequisite helper before scan state jq parsing, removing the later duplicate prerequisite call so jq is validated through the canonical path before use.

## Files Changed

.agents/scripts/contribution-watch-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/contribution-watch-helper.sh; shellcheck .agents/scripts/contribution-watch-helper.sh

Resolves #23577


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 2m and 40,283 tokens on this as a headless worker.