### PR TITLE
GH#23572: guard phase parent mock JSON

### DIFF
--- a/.agents/scripts/tests/test-shared-phase-filing.sh
+++ b/.agents/scripts/tests/test-shared-phase-filing.sh
@@ -708,6 +708,12 @@ gh() {
 	return 1
 }
 
+if gh api repos/owner/repo/issues/500 | jq -e '.body and .title == "Parent" and .state == "closed"' >/dev/null; then
+	pass "Parent issue mock returns realistic JSON"
+else
+	fail "Parent issue mock should return realistic JSON"
+fi
+
 : > "$LOGFILE"
 auto_file_next_phase "123" "owner/repo"
 closed_parent_log=""


### PR DESCRIPTION
## Summary

Added an explicit regression assertion that the phase parent gh mock returns realistic JSON while preserving jq-filtered API behavior.

## Files Changed

.agents/scripts/tests/test-shared-phase-filing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shared-phase-filing.sh; shellcheck .agents/scripts/tests/test-shared-phase-filing.sh

Resolves #23572


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 2m and 80,468 tokens on this as a headless worker.