### PR TITLE
GH#23581: respect TODO-derived issue status labels

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -223,7 +223,7 @@ gh_create_issue() {
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 	fi
 
-	_gh_ci_prepare_status_label "$@"
+	_gh_ci_prepare_status_label "$@" "${_todo_label_args[@]}"
 
 	# Build command arrays safely; avoid empty-arg injection (GH#22056).
 	local -a _issue_cmd=(gh issue create "$@")

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -121,10 +121,17 @@ _gh_auto_link_sub_issue() { return 0; }
 # the simple path — assignee logic isn't under test)
 _gh_wrapper_auto_assignee() { return 0; }
 
-# Stub _gh_wrapper_extract_task_id_from_title (returns empty — TODO label
-# derivation isn't under test)
-_gh_wrapper_extract_task_id_from_title() { return 0; }
-_gh_wrapper_derive_todo_labels() { return 0; }
+# Stub TODO derivation hooks. Most tests leave these empty; B'9 sets env vars
+# to simulate TODO.md-derived labels without depending on a repository TODO.md.
+_gh_wrapper_extract_task_id_from_title() {
+	[[ -n "${TEST_TODO_TASK_ID:-}" ]] && printf '%s' "$TEST_TODO_TASK_ID"
+	return 0
+}
+_gh_wrapper_derive_todo_labels() {
+	local task_id="$1"
+	[[ -n "$task_id" && -n "${TEST_TODO_DERIVED_LABELS:-}" ]] && printf '%s' "$TEST_TODO_DERIVED_LABELS"
+	return 0
+}
 
 # Stub session_origin_label so we can deterministically control what the
 # wrapper would self-inject. Tests call it via env var SESSION_ORIGIN_OVERRIDE.
@@ -508,6 +515,25 @@ else
 	print_result "B'8: gh_create_issue preserves caller status without concatenation" 1 \
 		"status_count=$status_n line: $last"
 fi
+
+# B'9: TODO-derived status wins — default status must inspect derived labels.
+# Regression for GH#23581: gh_create_issue filtered --todo-task-id from argv,
+# then checked only the filtered caller args for status labels. A status derived
+# from TODO.md was appended later, so the wrapper also injected status:available.
+reset_recorder
+TEST_TODO_TASK_ID="t999" TEST_TODO_DERIVED_LABELS="status:queued,origin:worker" \
+	SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --repo o/r --title "t999: advisory" --body "body" \
+	--todo-task-id t999 >/dev/null 2>&1
+status_n=$(count_status_labels_in_log)
+last=$(tail -1 "$GH_RECORD_FILE")
+if [[ "$status_n" == "1" && "$last" == *"status:queued"* && "$last" != *"status:available"* ]]; then
+	print_result "B'9: gh_create_issue preserves TODO-derived status" 0
+else
+	print_result "B'9: gh_create_issue preserves TODO-derived status" 1 \
+		"status_count=$status_n line: $last"
+fi
+unset TEST_TODO_TASK_ID TEST_TODO_DERIVED_LABELS
 
 # ---------------------------------------------------------------------------
 # Layer C: structural checks on full-loop-helper-commit.sh


### PR DESCRIPTION
## Summary

Updated gh_create_issue default status handling to inspect TODO-derived label arguments before adding status:available, preventing duplicate lifecycle labels.

## Files Changed

.agents/scripts/shared-gh-wrappers-create.sh,.agents/scripts/tests/test-origin-label-mutex-create.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-origin-label-mutex-create.sh; shellcheck .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-origin-label-mutex-create.sh

Resolves #23581


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 3m and 53,710 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status label handling when creating issues with pre-computed TODO-derived labels.

* **Tests**
  * Added regression test coverage for status label preservation during issue creation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/aidevops/pull/23586)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->