### PR TITLE
GH#23578: centralize pulse merge PR fields

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -385,7 +385,7 @@ _merge_ready_prs_for_repo() {
 	local pr_json pr_merge_err
 	pr_merge_err=$(mktemp)
 	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json number,mergeable,reviewDecision,author,title,isDraft,labels,updatedAt,headRefOid,createdAt \
+		--json "$(_pulse_merge_ready_pr_json_fields)" \
 		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json="[]"
 	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -94,6 +94,14 @@ _pm_issue_api() {
 	return 0
 }
 
+# Standard PR JSON fields consumed by _process_single_ready_pr. Keep every
+# caller that builds a PR object on this helper so draft/label/staleness
+# metadata cannot drift between list-based and webhook-triggered merge paths.
+_pulse_merge_ready_pr_json_fields() {
+	printf '%s' 'number,mergeable,reviewDecision,author,title,isDraft,labels,updatedAt,headRefOid,createdAt'
+	return 0
+}
+
 # Source shared claim-lifecycle helpers (t2429). The _release_interactive_claim_on_merge
 # function was extracted to shared-claim-lifecycle.sh so that both pulse-merge.sh and
 # full-loop-helper.sh can call it after a successful PR merge. SCRIPT_DIR may not be set
@@ -839,12 +847,13 @@ process_pr() {
 		return 1
 	fi
 
-	# Fetch the PR JSON in the same shape _merge_ready_prs_for_repo uses
-	# (number, mergeable, reviewDecision, author, title) and synthesize a
-	# single-PR object. _process_single_ready_pr expects a compact JSON object.
+	# Fetch the PR JSON in the same shape _merge_ready_prs_for_repo uses and
+	# synthesize a single-PR object. _process_single_ready_pr expects a compact
+	# JSON object with metadata used by draft, label, stale, and repair-routing
+	# gates.
 	local pr_obj
 	pr_obj=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json number,mergeable,reviewDecision,author,title 2>/dev/null) || pr_obj=""
+		--json "$(_pulse_merge_ready_pr_json_fields)" 2>/dev/null) || pr_obj=""
 
 	if [[ -z "$pr_obj" || "$pr_obj" == "null" ]]; then
 		echo "[pulse-merge] process_pr: gh pr view failed for ${repo_slug}#${pr_number}" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+MERGE_PROCESS="${SCRIPT_DIR}/../pulse-merge-process.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '     %s\n' "$detail"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+file_contains() {
+	local file_path="$1"
+	local needle="$2"
+	grep -Fq -- "$needle" "$file_path"
+	return $?
+}
+
+test_ready_pr_fields_include_process_metadata() {
+	local helper_src fields
+	helper_src=$(awk '
+		/^_pulse_merge_ready_pr_json_fields\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		print_result "ready PR field helper exists" 1 "missing _pulse_merge_ready_pr_json_fields"
+		return 0
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	fields="$(_pulse_merge_ready_pr_json_fields)"
+
+	local required missing=""
+	for required in number mergeable reviewDecision author title isDraft labels updatedAt headRefOid createdAt; do
+		if [[ ",${fields}," != *",${required},"* ]]; then
+			missing="${missing:+${missing},}${required}"
+		fi
+	done
+	if [[ -n "$missing" ]]; then
+		print_result "ready PR fields include process metadata" 1 "missing=${missing}; fields=${fields}"
+		return 0
+	fi
+	print_result "ready PR fields include process metadata" 0
+	return 0
+}
+
+test_callers_use_shared_field_helper() {
+	local shared_field_arg="--json \"\$(_pulse_merge_ready_pr_json_fields)\""
+	if ! file_contains "$MERGE_SCRIPT" "$shared_field_arg"; then
+		print_result "process_pr uses shared PR field helper" 1 "process_pr still has an inline --json field list"
+		return 0
+	fi
+	if ! file_contains "$MERGE_PROCESS" "$shared_field_arg"; then
+		print_result "merge-ready list uses shared PR field helper" 1 "_merge_ready_prs_for_repo still has an inline --json field list"
+		return 0
+	fi
+	print_result "PR JSON callers use shared field helper" 0
+	return 0
+}
+
+main() {
+	test_ready_pr_fields_include_process_metadata
+	test_callers_use_shared_field_helper
+
+	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Centralized the PR JSON field list consumed by pulse merge processing so process_pr and merge-ready list paths both fetch draft, label, updated-at, and head SHA metadata.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh; bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh

Resolves #23578


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 5m and 75,725 tokens on this as a headless worker.