### PR TITLE
GH#23571: localize worker headless exports

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1565,8 +1565,10 @@ cmd_run() {
 		# The sandbox allowlist already forwards AIDEVOPS_*; legacy generic
 		# HEADLESS/FULL_LOOP_HEADLESS markers are intentionally not required
 		# past the clean-env boundary.
+		local AIDEVOPS_SESSION_ORIGIN
 		AIDEVOPS_SESSION_ORIGIN="${AIDEVOPS_SESSION_ORIGIN:-worker}"
 		export AIDEVOPS_SESSION_ORIGIN
+		local AIDEVOPS_HEADLESS
 		AIDEVOPS_HEADLESS="${AIDEVOPS_HEADLESS:-true}"
 		export AIDEVOPS_HEADLESS
 	fi


### PR DESCRIPTION
## Summary

Declared the worker-origin and headless environment markers as local variables before assignment in cmd_run so the export path follows repository shell-safety conventions.

## Files Changed

.agents/scripts/headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh

Resolves #23571


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 1m and 35,123 tokens on this as a headless worker.