### PR TITLE
GH#23575: preserve external pulse benign ledger

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -208,15 +208,30 @@ _dispatch_candidate_benign_block_reason() {
 #######################################
 _dispatch_begin_benign_blocks_cycle() {
 	local ledger_file=""
+	local ledger_managed_by_dispatch="0"
 	if [[ -n "${AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE:-}" ]]; then
 		ledger_file="$AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE"
 	else
-		mkdir -p "${HOME}/.aidevops/logs" 2>/dev/null || true
-		ledger_file=$(mktemp "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.XXXXXX" 2>/dev/null || printf '%s\n' "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.$$.$RANDOM")
+		ledger_managed_by_dispatch="1"
+		if ! mkdir -p "${HOME}/.aidevops/logs"; then
+			printf 'Failed to create benign block ledger directory: %s\n' "${HOME}/.aidevops/logs" >&2
+		fi
+		ledger_file=$(mktemp "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.XXXXXX" || printf '%s\n' "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.$$.$RANDOM")
 	fi
-	mkdir -p "${ledger_file%/*}" 2>/dev/null || true
-	: >"$ledger_file" 2>/dev/null || true
+	if [[ -z "$ledger_file" ]]; then
+		printf 'Failed to resolve benign block ledger file path\n' >&2
+		_DISPATCH_BENIGN_BLOCKS_FILE=""
+		_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
+		return 0
+	fi
+	if [[ "$ledger_file" == */* ]] && ! mkdir -p "${ledger_file%/*}"; then
+		printf 'Failed to create benign block ledger parent directory: %s\n' "${ledger_file%/*}" >&2
+	fi
+	if [[ "$ledger_managed_by_dispatch" == "1" ]] && ! : >"$ledger_file"; then
+		printf 'Failed to initialize benign block ledger file: %s\n' "$ledger_file" >&2
+	fi
 	_DISPATCH_BENIGN_BLOCKS_FILE="$ledger_file"
+	_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="$ledger_managed_by_dispatch"
 	printf '%s\n' "$_DISPATCH_BENIGN_BLOCKS_FILE"
 	return 0
 }
@@ -228,10 +243,12 @@ _dispatch_begin_benign_blocks_cycle() {
 #######################################
 _dispatch_cleanup_benign_blocks_cycle() {
 	local ledger_file="${_DISPATCH_BENIGN_BLOCKS_FILE:-}"
-	if [[ -n "$ledger_file" ]]; then
-		rm -f "$ledger_file" 2>/dev/null || true
+	local ledger_owned="${_DISPATCH_BENIGN_BLOCKS_FILE_OWNED:-0}"
+	if [[ -n "$ledger_file" && "$ledger_owned" == "1" ]] && ! rm -f "$ledger_file"; then
+		printf 'Failed to remove benign block ledger file: %s\n' "$ledger_file" >&2
 	fi
 	_DISPATCH_BENIGN_BLOCKS_FILE=""
+	_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -208,6 +208,25 @@ test_benign_block_ledger_is_cycle_local_and_cleaned() {
 	return 0
 }
 
+test_external_benign_block_ledger_is_preserved() {
+	reset_guardrail_env
+	local external_ledger="${TEST_ROOT}/external-benign-blocks.tsv"
+	local ledger_path=""
+	printf '%s\t%s\t%s\n' 101 marcusquinn/aidevops caller_managed >"$external_ledger"
+	export AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE="$external_ledger"
+	_dispatch_begin_benign_blocks_cycle >/dev/null
+	ledger_path="$_DISPATCH_BENIGN_BLOCKS_FILE"
+	_dispatch_mark_benign_blocked_candidate 23575 marcusquinn/aidevops dedup_active_claim
+	_dispatch_cleanup_benign_blocks_cycle
+	unset AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE
+	if [[ "$ledger_path" == "$external_ledger" ]] && [[ -f "$external_ledger" ]] && grep -q $'^101\tmarcusquinn/aidevops\tcaller_managed$' "$external_ledger" && grep -q $'^23575\tmarcusquinn/aidevops\tdedup_active_claim$' "$external_ledger"; then
+		print_result "guardrail: external benign block ledger is preserved" 0
+	else
+		print_result "guardrail: external benign block ledger is preserved" 1 "ledger=${ledger_path}"
+	fi
+	return 0
+}
+
 test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
@@ -218,6 +237,7 @@ test_disabled_guardrail_still_updates_available_slots_gauge
 test_interactive_hold_reason_is_classified
 test_pr_target_reason_is_classified_as_benign_block
 test_benign_block_ledger_is_cycle_local_and_cleaned
+test_external_benign_block_ledger_is_preserved
 
 printf '\n====================\n'
 printf 'Tests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Preserved caller-managed AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE ledgers by tracking whether the dispatch cycle owns the ledger before truncating or deleting it. Added a regression test covering external ledger preservation while still appending benign block records.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh; .agents/scripts/tests/test-pulse-current-state-guardrails.sh

Resolves #23575


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 4m and 51,405 tokens on this as a headless worker.