### PR TITLE
GH#23574: preserve dispatch benign block ledger across refills

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -421,7 +421,11 @@ dispatch_max() {
 	_DISPATCH_CONSECUTIVE_NO_WORKER=0
 	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
 	_DISPATCH_CANARY_CACHE="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}/canary-last-pass"
-	_dispatch_begin_benign_blocks_cycle >/dev/null
+	local _dispatch_owns_benign_blocks_cycle=0
+	if [[ -z "${_DISPATCH_BENIGN_BLOCKS_FILE:-}" ]]; then
+		_dispatch_begin_benign_blocks_cycle >/dev/null
+		_dispatch_owns_benign_blocks_cycle=1
+	fi
 
 	# t3015: branch on dispatch path (max = parallel, floor = forced-serial).
 	# t3418/t3558: if the minimum worker floor is active, runtime launch
@@ -459,7 +463,9 @@ dispatch_max() {
 	if ! printf '%s' "$candidates_json" | jq -c '.[]' >"$_dispatch_candidate_file" 2>>"$LOGFILE"; then
 		echo "[pulse-wrapper] Dispatch_max: jq failed to enumerate candidates_json — aborting loop with 0 dispatches" >>"$LOGFILE"
 		rm -f "$_dispatch_candidate_file"
-		_dispatch_cleanup_benign_blocks_cycle
+		if [[ "$_dispatch_owns_benign_blocks_cycle" == "1" ]]; then
+			_dispatch_cleanup_benign_blocks_cycle
+		fi
 		_dispatch_maybe_engage_throttle
 		echo "[pulse-wrapper] Dispatch_max complete: dispatched=${triage_dispatched} (${triage_dispatched} triage + 0 implementation), processed=0/${candidate_count}, target_available=${available_slots}" >>"$LOGFILE"
 		echo "$triage_dispatched"
@@ -487,7 +493,9 @@ dispatch_max() {
 	[[ "$dispatched_count" =~ ^[0-9]+$ ]] || dispatched_count=0
 	[[ "$processed_count" =~ ^[0-9]+$ ]] || processed_count=0
 	rm -f "$_dispatch_candidate_file"
-	_dispatch_cleanup_benign_blocks_cycle
+	if [[ "$_dispatch_owns_benign_blocks_cycle" == "1" ]]; then
+		_dispatch_cleanup_benign_blocks_cycle
+	fi
 
 	echo "[pulse-wrapper] Dispatch path=${_dispatch_path}: loop body finished — processed=${processed_count} dispatched=${dispatched_count} mode=$( ((_dispatch_max_parallel <= 1)) && echo serial || echo "parallel(${_dispatch_max_parallel})")" >>"$LOGFILE"
 	_dispatch_maybe_engage_throttle
@@ -815,6 +823,8 @@ apply_dispatch_max() {
 		return 0
 	fi
 
+	_dispatch_begin_benign_blocks_cycle >/dev/null
+
 	local fill_dispatched
 	fill_dispatched=$(dispatch_max) || fill_dispatched=0
 	[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
@@ -847,6 +857,7 @@ apply_dispatch_max() {
 			echo "[pulse-wrapper] Dispatch_max Phase 2: consolidation child created but slots full (active=${_p2_active}, max=${_p2_max}) — skipping (t2749)" >>"$LOGFILE"
 		fi
 	fi
+	_dispatch_cleanup_benign_blocks_cycle
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -227,6 +227,55 @@ test_external_benign_block_ledger_is_preserved() {
 	return 0
 }
 
+test_apply_dispatch_max_preserves_benign_ledger_across_refill() {
+	reset_guardrail_env
+	export AIDEVOPS_MIN_WORKER_CONCURRENCY=2
+	local dispatch_calls_file="${TEST_ROOT}/dispatch-calls"
+	local refill_reason_file="${TEST_ROOT}/refill-seen-reason"
+	printf '0\n' >"$dispatch_calls_file"
+	: >"$refill_reason_file"
+	local dispatch_calls=""
+	local refill_seen_reason=""
+	local ledger_after=""
+
+	dispatch_max() {
+		local current_calls=""
+		current_calls=$(<"$dispatch_calls_file")
+		[[ "$current_calls" =~ ^[0-9]+$ ]] || current_calls=0
+		current_calls=$((current_calls + 1))
+		printf '%s\n' "$current_calls" >"$dispatch_calls_file"
+		if [[ "$current_calls" -eq 1 ]]; then
+			_dispatch_mark_benign_blocked_candidate 23541 marcusquinn/aidevops dedup_active_claim
+			printf '1\n'
+		else
+			_dispatch_benign_blocked_candidate_reason 23541 marcusquinn/aidevops >"$refill_reason_file" 2>/dev/null || true
+			printf '0\n'
+		fi
+		return 0
+	}
+
+	count_active_workers() {
+		printf '0\n'
+		return 0
+	}
+
+	_adaptive_launch_settle_wait() {
+		return 0
+	}
+
+	apply_dispatch_max
+	dispatch_calls=$(<"$dispatch_calls_file")
+	refill_seen_reason=$(<"$refill_reason_file")
+	ledger_after="${_DISPATCH_BENIGN_BLOCKS_FILE:-}"
+	unset AIDEVOPS_MIN_WORKER_CONCURRENCY
+	if [[ "$dispatch_calls" -ge 2 && "$refill_seen_reason" == "dedup_active_claim" && -z "$ledger_after" ]]; then
+		print_result "guardrail: apply_dispatch_max preserves benign block ledger across refill" 0
+	else
+		print_result "guardrail: apply_dispatch_max preserves benign block ledger across refill" 1 "calls=${dispatch_calls} reason=${refill_seen_reason} ledger_after=${ledger_after}"
+	fi
+	return 0
+}
+
 test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
@@ -238,6 +287,7 @@ test_interactive_hold_reason_is_classified
 test_pr_target_reason_is_classified_as_benign_block
 test_benign_block_ledger_is_cycle_local_and_cleaned
 test_external_benign_block_ledger_is_preserved
+test_apply_dispatch_max_preserves_benign_ledger_across_refill
 
 printf '\n====================\n'
 printf 'Tests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Kept the benign dispatch block ledger alive for the full apply_dispatch_max pulse, while preserving direct dispatch_max cleanup, so refill and Phase 2 re-enumerations reuse active-claim block state.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh; .agents/scripts/linters-local.sh progressed through required shell and security gates but timed out during existing ratchet counting after reporting advisory markdown debt

Resolves #23574


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 11m and 71,326 tokens on this as a headless worker.