### PR TITLE
GH#23579: fix(issue-sync): scope close state checks to task line

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -47,9 +47,12 @@ _is_cancelled_or_deferred() {
 
 _has_evidence() {
 	local text="$1" task_id="$2" repo="$3"
+	local task_line
+	task_line=$(printf '%s\n' "$text" | grep -E '^[[:space:]]*- \[[ x-]\] ' | head -1 || true)
+	[[ -z "$task_line" ]] && task_line="$text"
 	# Cancelled/deferred/declined tasks need no PR or verified: evidence
-	_is_cancelled_or_deferred "$text" && return 0
-	if _has_unresolved_blocker "$text"; then
+	_is_cancelled_or_deferred "$task_line" && return 0
+	if _has_unresolved_blocker "$task_line"; then
 		return 1
 	fi
 	echo "$text" | grep -qE 'verified:[0-9]{4}-[0-9]{2}-[0-9]{2}|pr:#[0-9]+' && return 0
@@ -182,7 +185,7 @@ _do_close() {
 		print_info "Skipping #$issue_number ($task_id): parent-task label set — parent issues close via terminal-phase PR with explicit Closes #NNN, not TODO [x] (GH#20828)"
 		return 0
 	fi
-	if ! _is_cancelled_or_deferred "$task_with_notes" && _has_unresolved_blocker "$task_with_notes"; then
+	if ! _is_cancelled_or_deferred "$task_line" && _has_unresolved_blocker "$task_line"; then
 		print_info "Skipping #$issue_number ($task_id): unresolved blocked-by marker present — completion evidence must wait for dependencies (GH#23516)"
 		return 0
 	fi
@@ -216,12 +219,12 @@ _do_close() {
 	fi
 	# Cancelled/deferred/declined tasks close as "not planned"; completed tasks use default reason
 	local close_args=("issue" "close" "$issue_number" "--repo" "$repo" "--comment" "$comment")
-	if _is_cancelled_or_deferred "$task_with_notes"; then
+	if _is_cancelled_or_deferred "$task_line"; then
 		close_args+=("--reason" "not planned")
 		gh_create_label "$repo" "not-planned" "E4E669" "Closed as not planned"
 	fi
 	if gh "${close_args[@]}" 2>/dev/null; then
-		if _is_cancelled_or_deferred "$task_with_notes"; then
+		if _is_cancelled_or_deferred "$task_line"; then
 			_gh_edit_labels "add" "$repo" "$issue_number" "not-planned"
 		fi
 		_mark_issue_done "$repo" "$issue_number"

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -79,6 +79,14 @@ else
 	fail "blocked-by mention in task notes should not veto current task line"
 fi
 
+historical_cancelled_note_task='- [ ] t9005 incomplete implementation tier:standard
+  - Historical note: earlier scope was cancelled:2026-01-01 before being reopened.'
+if _has_evidence "$historical_cancelled_note_task" "t9005" "owner/repo"; then
+	fail "cancelled marker in task notes is not accepted as completion evidence"
+else
+	pass "cancelled marker in task notes is not accepted as completion evidence"
+fi
+
 if [[ "$FAIL" -eq 0 ]]; then
 	printf 'All %d tests passed\n' "$PASS"
 	exit 0


### PR DESCRIPTION
## Summary

Scoped issue-sync close blocker and cancellation state checks to the primary TODO task line while preserving task notes for PR and verified evidence lookup. Added regression coverage for historical cancellation notes.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh,.agents/scripts/tests/test-issue-sync-completion-evidence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-completion-evidence.sh; shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-completion-evidence.sh; .agents/scripts/linters-local.sh (timed out after advisory checks and before completion)

Resolves #23579


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 7m and 46,814 tokens on this as a headless worker.