### PR TITLE
GH#23580: align oauth pool fallback schema

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-tool.mjs
@@ -39,6 +39,9 @@ try {
     number() {
       return schemaNode;
     },
+    union() {
+      return schemaNode;
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Added the missing union() fallback schema method to the OAuth pool OpenCode tool so it remains consistent with the main plugin tool fallback and future schema expansions.

## Files Changed

.agents/plugins/opencode-aidevops/oauth-pool-tool.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/plugins/opencode-aidevops/oauth-pool-tool.mjs; node --check .agents/plugins/opencode-aidevops/tools.mjs; node .agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs; npm test in .agents/plugins/opencode-aidevops; .agents/scripts/linters-local.sh ran with pre-existing advisory markdown/ratchet/layout warnings before timing out during later portability checks

Resolves #23580


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 9m and 54,378 tokens on this as a headless worker.