### PR TITLE
fix(GH#23594): use OAuth pool as 4th Anthropic credential source in ai-research-helper.sh + key auth-error off rc=2

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -316,7 +316,12 @@ BASH32_COMPAT_THRESHOLD=63
 # Qlty Smell Regression passed/skipped for this shell-only PR, confirming no net new qlty
 # smells from the cost-breaker change. 40 actual + 2 buffer = 42. ratchet-post-merge.yml
 # will reset toward actual after the next smell-reducing merge.
-QLTY_SMELL_THRESHOLD=42
+# GH#23594/PR #23595: pre-existing drift on main — 43 smells vs threshold 42;
+# Qlty Smell Regression passed for this PR and local `qlty smells --all --sarif`
+# reports the same 43 smells on main and head, confirming no net new qlty smells
+# from the shell/test fix. 43 actual + 2 buffer = 45. ratchet-post-merge.yml will
+# reset toward actual after the next smell-reducing merge.
+QLTY_SMELL_THRESHOLD=45
 
 # Qlty smell-count → grade mapping (t2066, GH#18774)
 #

--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -14,6 +14,11 @@
 #
 # Environment:
 #   ANTHROPIC_API_KEY — set directly, or resolved from gopass/credentials.sh
+#   OAuth pool — falls back to ~/.aidevops/oauth-pool.json when the three
+#                static sources above miss. Uses the first active/idle
+#                Anthropic account's access token as x-api-key (Anthropic
+#                accepts the OAuth access token in both `x-api-key` and
+#                `Authorization: Bearer` schemes on /v1/messages).
 #
 # Exit codes: 0=success (response on stdout), 1=error, 2=no API key
 
@@ -42,8 +47,57 @@ resolve_model_id() {
 }
 
 #######################################
+# Resolve a fresh, non-expired access token from the OAuth pool.
+# Reads ~/.aidevops/oauth-pool.json directly (no shelling to oauth-pool-helper)
+# so this stays callable from detached pulse contexts where the helper might
+# be missing or not on PATH.
+#
+# Honoured fields per pool account:
+#   .access          — access token string (used as x-api-key)
+#   .status          — must be "active" or "idle"
+#   .expires         — millisecond epoch; entries already past expiry are
+#                      skipped (Anthropic returns 401 anyway and refresh
+#                      requires the dedicated helper).
+#   .cooldownUntil   — millisecond epoch; entries still cooling down are skipped.
+#
+# Output: access token on stdout when a usable entry exists.
+# Returns: 0 if a token was emitted, 1 otherwise.
+#######################################
+resolve_oauth_pool_token() {
+	local pool_file="${HOME}/.aidevops/oauth-pool.json"
+	[[ -f "$pool_file" ]] || return 1
+	command -v jq &>/dev/null || return 1
+
+	local now_ms
+	now_ms=$(date +%s%3N 2>/dev/null) || now_ms="0"
+	# date +%s%3N is GNU-only; fall back to seconds-only when unavailable.
+	[[ "$now_ms" =~ ^[0-9]+$ ]] || now_ms=0
+	if [[ "${#now_ms}" -lt 10 ]]; then
+		now_ms=$(($(date +%s) * 1000))
+	fi
+
+	local token
+	token=$(jq -r --argjson now "$now_ms" '
+		(.anthropic // [])
+		| map(select(
+			(.access // "") != ""
+			and ((.status // "") == "active" or (.status // "") == "idle")
+			and ((.expires // 0) > $now)
+			and ((.cooldownUntil // 0) <= $now)
+		))
+		| .[0].access // ""
+	' "$pool_file" 2>/dev/null) || return 1
+
+	if [[ -z "$token" || "$token" == "null" ]]; then
+		return 1
+	fi
+	printf '%s\n' "$token"
+	return 0
+}
+
+#######################################
 # Resolve Anthropic API key from available sources
-# Priority: env var > gopass > credentials.sh
+# Priority: env var > gopass > credentials.sh > OAuth pool
 # Output: API key on stdout
 # Returns: 0 if found, 1 if not
 #######################################
@@ -75,6 +129,16 @@ resolve_api_key() {
 		fi
 	fi
 
+	# 4. OAuth pool (managed aidevops Anthropic accounts).
+	# GH#23594: detached pulse contexts often have no static key but a
+	# healthy OAuth pool — fall back to it so fix-the-fixer-detector and
+	# other AI-judgement callers keep working.
+	local oauth_token
+	if oauth_token=$(resolve_oauth_pool_token); then
+		printf '%s\n' "$oauth_token"
+		return 0
+	fi
+
 	return 1
 }
 
@@ -94,7 +158,7 @@ call_anthropic() {
 
 	local api_key
 	api_key=$(resolve_api_key) || {
-		log_error "No Anthropic API key found (env, gopass, or credentials.sh)"
+		log_error "No Anthropic API key found (env, gopass, credentials.sh, or OAuth pool)"
 		return 2
 	}
 
@@ -209,4 +273,10 @@ main() {
 	return $?
 }
 
-main "$@"
+# Run main only when invoked as a script — allows tests and other helpers
+# to source this file and call resolve_api_key / resolve_oauth_pool_token
+# directly. Matches the pattern used by pulse-fix-the-fixer-detector.sh and
+# other helpers in this repo.
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -61,7 +61,10 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly FIX_THE_FIXER_LABEL="fix-the-fixer"
 readonly FIX_THE_FIXER_MARKER="<!-- aidevops:fix-the-fixer-detector -->"
-readonly AI_RESEARCH_HELPER="${SCRIPT_DIR}/ai-research-helper.sh"
+# GH#23594: test override path. Production callers leave the env var unset
+# and pick up the sibling helper; regression tests can point at a stub that
+# deterministically returns a specific exit code.
+readonly AI_RESEARCH_HELPER="${PULSE_AI_RESEARCH_HELPER_OVERRIDE:-${SCRIPT_DIR}/ai-research-helper.sh}"
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 readonly AUTH_COOLDOWN_FILE="${HOME}/.aidevops/cache/fix-the-fixer-detector-auth.cooldown"
 readonly AUTH_COOLDOWN_SECONDS_DEFAULT=21600
@@ -284,8 +287,17 @@ _classify_via_llm() {
 			local err_snippet=""
 			[[ -s "$err_log" ]] && err_snippet=$(head -c 200 "$err_log" | tr '\n' ' ')
 			rm -f "$err_log"
-			if _is_auth_error "$err_snippet"; then
-				_record_auth_cooldown "$err_snippet"
+			# GH#23594: rc=2 is ai-research-helper's documented exit code for
+			# "no API key resolved locally" — treat it as an auth class signal
+			# regardless of the error message, so the cooldown trips even when
+			# the prose message doesn't match _is_auth_error()'s API-response
+			# patterns (which are tuned for invalid x-api-key / 401 responses).
+			if [[ "$helper_rc" -eq 2 ]] || _is_auth_error "$err_snippet"; then
+				local cooldown_reason="$err_snippet"
+				if [[ "$helper_rc" -eq 2 && -z "$cooldown_reason" ]]; then
+					cooldown_reason="ai-research-helper rc=2: no Anthropic credentials resolvable"
+				fi
+				_record_auth_cooldown "$cooldown_reason"
 				RATIONALE="auth_error: ${AUTH_ERROR_REASON}"
 				_log_warn "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
 				printf 'SKIP_AUTH\n'

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -3,38 +3,28 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # Regression test for GH#23594:
-#   1. ai-research-helper.sh::resolve_api_key() must fall back to the OAuth
-#      pool when env/gopass/credentials.sh all miss.
-#   2. pulse-fix-the-fixer-detector.sh must classify helper rc=2 as an
-#      auth-class failure and record the cooldown — regardless of whether
-#      the prose stderr message matches the API-response substring patterns
-#      in _is_auth_error().
+# - ai-research-helper.sh falls back to OAuth pool credentials when static
+#   Anthropic key sources miss.
+# - pulse-fix-the-fixer-detector.sh treats ai-research-helper rc=2 as an auth
+#   class signal even when stderr prose does not match API error substrings.
 
 set -euo pipefail
-
-readonly TEST_RED='\033[0;31m'
-readonly TEST_GREEN='\033[0;32m'
-readonly TEST_RESET='\033[0m'
 
 TEST_ROOT=""
 TESTS_RUN=0
 TESTS_FAILED=0
 
-print_result() {
-	local test_name="$1"
-	local passed="$2"
-	local message="${3:-}"
+record_result() {
+	local name="$1"
+	local failed="$2"
+	local detail="${3:-}"
 	TESTS_RUN=$((TESTS_RUN + 1))
-
-	if [[ "$passed" -eq 0 ]]; then
-		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+	if [[ "$failed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
 		return 0
 	fi
-
-	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
-	if [[ -n "$message" ]]; then
-		printf '       %s\n' "$message"
-	fi
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
 	TESTS_FAILED=$((TESTS_FAILED + 1))
 	return 0
 }
@@ -43,29 +33,23 @@ setup_sandbox() {
 	TEST_ROOT=$(mktemp -d)
 	export HOME="${TEST_ROOT}/home"
 	mkdir -p "${HOME}/.aidevops/cache" "${TEST_ROOT}/bin"
-	# Ensure we don't accidentally inherit a real key or pollute gopass.
 	unset ANTHROPIC_API_KEY || true
-	# Mask gopass so the env-var-empty test cannot hit a real credential store.
-	cat >"${TEST_ROOT}/bin/gopass" <<'STUB'
-#!/usr/bin/env bash
-exit 1
-STUB
+	printf '#!/usr/bin/env bash\nexit 1\n' >"${TEST_ROOT}/bin/gopass"
 	chmod +x "${TEST_ROOT}/bin/gopass"
-	# Prepend our stub PATH; keep real bash/jq/sed/etc by appending the prior PATH.
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	return 0
 }
 
 teardown_sandbox() {
-	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
-		rm -rf "$TEST_ROOT"
-	fi
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
 	return 0
 }
 
-write_pool_with_active_anthropic() {
+write_pool() {
 	local token="$1"
 	local expires_ms="$2"
+	local status="${3:-active}"
+	local cooldown="${4:-null}"
 	local pool_file="${HOME}/.aidevops/oauth-pool.json"
 	cat >"$pool_file" <<EOF
 {
@@ -75,10 +59,8 @@ write_pool_with_active_anthropic() {
       "access": "${token}",
       "refresh": "rt_test",
       "expires": ${expires_ms},
-      "added": "2026-05-14T00:00:00Z",
-      "lastUsed": "2026-05-14T00:00:00Z",
-      "status": "active",
-      "cooldownUntil": null
+      "status": "${status}",
+      "cooldownUntil": ${cooldown}
     }
   ]
 }
@@ -87,192 +69,115 @@ EOF
 	return 0
 }
 
-write_pool_with_expired_anthropic() {
-	local token="$1"
-	local pool_file="${HOME}/.aidevops/oauth-pool.json"
-	cat >"$pool_file" <<EOF
-{
-  "anthropic": [
-    {
-      "email": "test@example.com",
-      "access": "${token}",
-      "refresh": "rt_test",
-      "expires": 1,
-      "added": "2026-05-14T00:00:00Z",
-      "lastUsed": "2026-05-14T00:00:00Z",
-      "status": "active",
-      "cooldownUntil": null
-    }
-  ]
-}
-EOF
-	chmod 600 "$pool_file"
-	return 0
-}
-
-# -----------------------------------------------------------------------------
-# Test 1: resolve_oauth_pool_token returns active token; resolve_api_key
-#         delegates to it when env/gopass/credentials.sh all miss.
-# -----------------------------------------------------------------------------
-test_oauth_pool_fallback() {
-	local expected_token="sk-ant-oat01-from-pool-DEADBEEF"
-	# 1h from now in milliseconds.
-	local one_hour_ms=$(( ( $(date +%s) + 3600 ) * 1000 ))
-	write_pool_with_active_anthropic "$expected_token" "$one_hour_ms"
-
-	# Source the helper to access resolve_api_key directly.
-	# shellcheck source=/dev/null
+probe_resolver() {
+	local env_token="${1:-}"
 	(
 		set +e
+		[[ -n "$env_token" ]] && export ANTHROPIC_API_KEY="$env_token"
+		# shellcheck source=/dev/null
 		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" 2>/dev/null
+		local actual=""
 		actual=$(resolve_api_key 2>/dev/null)
-		rc=$?
+		local rc=$?
 		printf 'rc=%s\ntoken=%s\n' "$rc" "$actual"
 	) >"${TEST_ROOT}/probe.out" 2>/dev/null || true
-
-	local rc token
-	rc=$(grep '^rc=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2 || true)
-	token=$(grep '^token=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true)
-
-	if [[ "$rc" == "0" && "$token" == "$expected_token" ]]; then
-		print_result "OAuth pool token is returned when static sources miss" 0
-	else
-		print_result "OAuth pool token is returned when static sources miss" 1 \
-			"rc=${rc} token=${token} expected=${expected_token}"
-	fi
 	return 0
 }
 
-# -----------------------------------------------------------------------------
-# Test 2: expired OAuth pool entries are skipped (no token returned).
-# -----------------------------------------------------------------------------
-test_oauth_pool_expired_skipped() {
-	write_pool_with_expired_anthropic "sk-ant-oat01-expired-XXX"
-
-	(
-		set +e
-		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" 2>/dev/null
-		actual=$(resolve_api_key 2>/dev/null)
-		rc=$?
-		printf 'rc=%s\ntoken=%s\n' "$rc" "$actual"
-	) >"${TEST_ROOT}/probe.out" 2>/dev/null || true
-
-	local rc token
-	rc=$(grep '^rc=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2 || true)
-	token=$(grep '^token=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true)
-
-	if [[ "$rc" == "1" && -z "$token" ]]; then
-		print_result "expired OAuth pool entries are skipped" 0
-	else
-		print_result "expired OAuth pool entries are skipped" 1 \
-			"rc=${rc} token=${token} — expected rc=1 empty token"
-	fi
+probe_value() {
+	local key="$1"
+	grep "^${key}=" "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true
 	return 0
 }
 
-# -----------------------------------------------------------------------------
-# Test 3: env var still wins over OAuth pool (precedence preserved).
-# -----------------------------------------------------------------------------
-test_env_var_precedence_preserved() {
-	local one_hour_ms=$(( ( $(date +%s) + 3600 ) * 1000 ))
-	write_pool_with_active_anthropic "sk-ant-oat01-from-pool" "$one_hour_ms"
-
-	(
-		set +e
-		export ANTHROPIC_API_KEY="sk-ant-api03-static-WINS"
-		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" 2>/dev/null
-		actual=$(resolve_api_key 2>/dev/null)
-		rc=$?
-		printf 'rc=%s\ntoken=%s\n' "$rc" "$actual"
-	) >"${TEST_ROOT}/probe.out" 2>/dev/null || true
-
-	local token
-	token=$(grep '^token=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true)
-
-	if [[ "$token" == "sk-ant-api03-static-WINS" ]]; then
-		print_result "env var wins over OAuth pool" 0
-	else
-		print_result "env var wins over OAuth pool" 1 "got token=${token}"
+assert_probe() {
+	local name="$1"
+	local expected_rc="$2"
+	local expected_token="$3"
+	local actual_rc actual_token
+	actual_rc=$(probe_value rc)
+	actual_token=$(probe_value token)
+	if [[ "$actual_rc" == "$expected_rc" && "$actual_token" == "$expected_token" ]]; then
+		record_result "$name" 0
+		return 0
 	fi
+	record_result "$name" 1 "rc=${actual_rc} token=${actual_token}"
 	return 0
 }
 
-# -----------------------------------------------------------------------------
-# Test 4: detector treats helper rc=2 as auth-error (records cooldown),
-#         even when stderr message does not match _is_auth_error() patterns.
-# -----------------------------------------------------------------------------
-test_detector_rc2_records_cooldown() {
-	# Stub gh to return one auto-dispatch issue.
+test_oauth_pool_fallbacks() {
+	local pool_token="[redacted-pool-token]"
+	local env_token="[redacted-env-token]"
+	local future_ms=$((($(date +%s) + 3600) * 1000))
+
+	write_pool "$pool_token" "$future_ms"
+	probe_resolver
+	assert_probe "OAuth pool token is returned when static sources miss" 0 "$pool_token"
+
+	write_pool "$pool_token" 1
+	probe_resolver
+	assert_probe "expired OAuth pool entries are skipped" 1 ""
+
+	write_pool "$pool_token" "$future_ms"
+	probe_resolver "$env_token"
+	assert_probe "env var wins over OAuth pool" 0 "$env_token"
+	return 0
+}
+
+write_detector_stubs() {
 	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
-	printf '[{"number":1,"labels":[{"name":"auto-dispatch"}]}]\n'
-	exit 0
-fi
-if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
-	printf '{"title":"fix dispatch path","body":"Touches pulse-wrapper.sh dispatch behaviour.","labels":[{"name":"auto-dispatch"}],"state":"OPEN"}\n'
-	exit 0
-fi
-printf 'unexpected gh invocation: %s\n' "$*" >&2
-exit 1
+case "${1:-} ${2:-}" in
+"issue list") printf '[{"number":1,"labels":[{"name":"auto-dispatch"}]}]\n' ;;
+"issue view") printf '{"title":"fix dispatch path","body":"Touches pulse-wrapper.sh dispatch behaviour.","labels":[{"name":"auto-dispatch"}],"state":"OPEN"}\n' ;;
+*) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 1 ;;
+esac
 STUB
 	chmod +x "${TEST_ROOT}/bin/gh"
 
-	# Stub ai-research-helper.sh to return rc=2 with a prose message that
-	# does NOT match _is_auth_error() patterns — proves we trip on exit
-	# code, not substring matching.
-	local helper_dir="${TEST_ROOT}/helper-shim"
-	mkdir -p "$helper_dir"
-	cat >"${helper_dir}/ai-research-helper.sh" <<'STUB'
+	mkdir -p "${TEST_ROOT}/helper-shim"
+	cat >"${TEST_ROOT}/helper-shim/ai-research-helper.sh" <<'STUB'
 #!/usr/bin/env bash
 printf '[AI-RESEARCH] No Anthropic API key found (env, gopass, credentials.sh, or OAuth pool)\n' >&2
 exit 2
 STUB
-	chmod +x "${helper_dir}/ai-research-helper.sh"
+	chmod +x "${TEST_ROOT}/helper-shim/ai-research-helper.sh"
+	return 0
+}
 
-	# Run detector with helper override.
+test_detector_rc2_records_cooldown() {
+	write_detector_stubs
 	(
 		set +e
-		export PULSE_AI_RESEARCH_HELPER_OVERRIDE="${helper_dir}/ai-research-helper.sh"
+		export PULSE_AI_RESEARCH_HELPER_OVERRIDE="${TEST_ROOT}/helper-shim/ai-research-helper.sh"
 		export AIDEVOPS_FIX_THE_FIXER_DETECTOR_AUTH_COOLDOWN_SECONDS=3600
 		"${REPO_ROOT}/.agents/scripts/pulse-fix-the-fixer-detector.sh" run \
-			--repo example/repo --limit 1 \
-			>"${TEST_ROOT}/detector.log" 2>&1
+			--repo example/repo --limit 1 >"${TEST_ROOT}/detector.log" 2>&1
 	)
 
 	local cooldown_file="${HOME}/.aidevops/cache/fix-the-fixer-detector-auth.cooldown"
 	if [[ -f "$cooldown_file" ]]; then
-		print_result "rc=2 records auth cooldown state file" 0
+		record_result "rc=2 records auth cooldown state file" 0
 	else
-		print_result "rc=2 records auth cooldown state file" 1 \
-			"cooldown file missing — detector.log: $(tr '\n' ' ' <"${TEST_ROOT}/detector.log" | head -c 400)"
+		record_result "rc=2 records auth cooldown state file" 1 \
+			"cooldown file missing; log=$(tr '\n' ' ' <"${TEST_ROOT}/detector.log" | head -c 400)"
 	fi
-
 	if grep -q 'skipped:auth-error=1' "${TEST_ROOT}/detector.log"; then
-		print_result "rc=2 surfaces as skipped:auth-error in run summary" 0
+		record_result "rc=2 surfaces as skipped:auth-error in run summary" 0
 	else
-		print_result "rc=2 surfaces as skipped:auth-error in run summary" 1 \
-			"detector.log tail: $(tail -c 400 "${TEST_ROOT}/detector.log" | tr '\n' ' ')"
+		record_result "rc=2 surfaces as skipped:auth-error in run summary" 1 \
+			"summary missing; log=$(tr '\n' ' ' <"${TEST_ROOT}/detector.log" | tail -c 400)"
 	fi
 	return 0
 }
 
-# -----------------------------------------------------------------------------
 main() {
 	REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-
 	setup_sandbox
 	trap teardown_sandbox EXIT
-
-	test_oauth_pool_fallback
-	test_oauth_pool_expired_skipped
-	test_env_var_precedence_preserved
-	# Note: test 4 requires PULSE_AI_RESEARCH_HELPER_OVERRIDE support in the
-	# detector. If the detector hard-codes the helper path, this test will
-	# fail and the env override needs to be added (see PR description).
+	test_oauth_pool_fallbacks
 	test_detector_rc2_records_cooldown
-
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23594:
+#   1. ai-research-helper.sh::resolve_api_key() must fall back to the OAuth
+#      pool when env/gopass/credentials.sh all miss.
+#   2. pulse-fix-the-fixer-detector.sh must classify helper rc=2 as an
+#      auth-class failure and record the cooldown — regardless of whether
+#      the prose stderr message matches the API-response substring patterns
+#      in _is_auth_error().
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/cache" "${TEST_ROOT}/bin"
+	# Ensure we don't accidentally inherit a real key or pollute gopass.
+	unset ANTHROPIC_API_KEY || true
+	# Mask gopass so the env-var-empty test cannot hit a real credential store.
+	cat >"${TEST_ROOT}/bin/gopass" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+	chmod +x "${TEST_ROOT}/bin/gopass"
+	# Prepend our stub PATH; keep real bash/jq/sed/etc by appending the prior PATH.
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	return 0
+}
+
+teardown_sandbox() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+write_pool_with_active_anthropic() {
+	local token="$1"
+	local expires_ms="$2"
+	local pool_file="${HOME}/.aidevops/oauth-pool.json"
+	cat >"$pool_file" <<EOF
+{
+  "anthropic": [
+    {
+      "email": "test@example.com",
+      "access": "${token}",
+      "refresh": "rt_test",
+      "expires": ${expires_ms},
+      "added": "2026-05-14T00:00:00Z",
+      "lastUsed": "2026-05-14T00:00:00Z",
+      "status": "active",
+      "cooldownUntil": null
+    }
+  ]
+}
+EOF
+	chmod 600 "$pool_file"
+	return 0
+}
+
+write_pool_with_expired_anthropic() {
+	local token="$1"
+	local pool_file="${HOME}/.aidevops/oauth-pool.json"
+	cat >"$pool_file" <<EOF
+{
+  "anthropic": [
+    {
+      "email": "test@example.com",
+      "access": "${token}",
+      "refresh": "rt_test",
+      "expires": 1,
+      "added": "2026-05-14T00:00:00Z",
+      "lastUsed": "2026-05-14T00:00:00Z",
+      "status": "active",
+      "cooldownUntil": null
+    }
+  ]
+}
+EOF
+	chmod 600 "$pool_file"
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 1: resolve_oauth_pool_token returns active token; resolve_api_key
+#         delegates to it when env/gopass/credentials.sh all miss.
+# -----------------------------------------------------------------------------
+test_oauth_pool_fallback() {
+	local expected_token="sk-ant-oat01-from-pool-DEADBEEF"
+	# 1h from now in milliseconds.
+	local one_hour_ms=$(( ( $(date +%s) + 3600 ) * 1000 ))
+	write_pool_with_active_anthropic "$expected_token" "$one_hour_ms"
+
+	# Source the helper to access resolve_api_key directly.
+	# shellcheck source=/dev/null
+	(
+		set +e
+		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" 2>/dev/null
+		actual=$(resolve_api_key 2>/dev/null)
+		rc=$?
+		printf 'rc=%s\ntoken=%s\n' "$rc" "$actual"
+	) >"${TEST_ROOT}/probe.out" 2>/dev/null || true
+
+	local rc token
+	rc=$(grep '^rc=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2 || true)
+	token=$(grep '^token=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true)
+
+	if [[ "$rc" == "0" && "$token" == "$expected_token" ]]; then
+		print_result "OAuth pool token is returned when static sources miss" 0
+	else
+		print_result "OAuth pool token is returned when static sources miss" 1 \
+			"rc=${rc} token=${token} expected=${expected_token}"
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 2: expired OAuth pool entries are skipped (no token returned).
+# -----------------------------------------------------------------------------
+test_oauth_pool_expired_skipped() {
+	write_pool_with_expired_anthropic "sk-ant-oat01-expired-XXX"
+
+	(
+		set +e
+		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" 2>/dev/null
+		actual=$(resolve_api_key 2>/dev/null)
+		rc=$?
+		printf 'rc=%s\ntoken=%s\n' "$rc" "$actual"
+	) >"${TEST_ROOT}/probe.out" 2>/dev/null || true
+
+	local rc token
+	rc=$(grep '^rc=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2 || true)
+	token=$(grep '^token=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true)
+
+	if [[ "$rc" == "1" && -z "$token" ]]; then
+		print_result "expired OAuth pool entries are skipped" 0
+	else
+		print_result "expired OAuth pool entries are skipped" 1 \
+			"rc=${rc} token=${token} — expected rc=1 empty token"
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 3: env var still wins over OAuth pool (precedence preserved).
+# -----------------------------------------------------------------------------
+test_env_var_precedence_preserved() {
+	local one_hour_ms=$(( ( $(date +%s) + 3600 ) * 1000 ))
+	write_pool_with_active_anthropic "sk-ant-oat01-from-pool" "$one_hour_ms"
+
+	(
+		set +e
+		export ANTHROPIC_API_KEY="sk-ant-api03-static-WINS"
+		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" 2>/dev/null
+		actual=$(resolve_api_key 2>/dev/null)
+		rc=$?
+		printf 'rc=%s\ntoken=%s\n' "$rc" "$actual"
+	) >"${TEST_ROOT}/probe.out" 2>/dev/null || true
+
+	local token
+	token=$(grep '^token=' "${TEST_ROOT}/probe.out" 2>/dev/null | head -1 | cut -d= -f2- || true)
+
+	if [[ "$token" == "sk-ant-api03-static-WINS" ]]; then
+		print_result "env var wins over OAuth pool" 0
+	else
+		print_result "env var wins over OAuth pool" 1 "got token=${token}"
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 4: detector treats helper rc=2 as auth-error (records cooldown),
+#         even when stderr message does not match _is_auth_error() patterns.
+# -----------------------------------------------------------------------------
+test_detector_rc2_records_cooldown() {
+	# Stub gh to return one auto-dispatch issue.
+	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	printf '[{"number":1,"labels":[{"name":"auto-dispatch"}]}]\n'
+	exit 0
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	printf '{"title":"fix dispatch path","body":"Touches pulse-wrapper.sh dispatch behaviour.","labels":[{"name":"auto-dispatch"}],"state":"OPEN"}\n'
+	exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+STUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	# Stub ai-research-helper.sh to return rc=2 with a prose message that
+	# does NOT match _is_auth_error() patterns — proves we trip on exit
+	# code, not substring matching.
+	local helper_dir="${TEST_ROOT}/helper-shim"
+	mkdir -p "$helper_dir"
+	cat >"${helper_dir}/ai-research-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '[AI-RESEARCH] No Anthropic API key found (env, gopass, credentials.sh, or OAuth pool)\n' >&2
+exit 2
+STUB
+	chmod +x "${helper_dir}/ai-research-helper.sh"
+
+	# Run detector with helper override.
+	(
+		set +e
+		export PULSE_AI_RESEARCH_HELPER_OVERRIDE="${helper_dir}/ai-research-helper.sh"
+		export AIDEVOPS_FIX_THE_FIXER_DETECTOR_AUTH_COOLDOWN_SECONDS=3600
+		"${REPO_ROOT}/.agents/scripts/pulse-fix-the-fixer-detector.sh" run \
+			--repo example/repo --limit 1 \
+			>"${TEST_ROOT}/detector.log" 2>&1
+	)
+
+	local cooldown_file="${HOME}/.aidevops/cache/fix-the-fixer-detector-auth.cooldown"
+	if [[ -f "$cooldown_file" ]]; then
+		print_result "rc=2 records auth cooldown state file" 0
+	else
+		print_result "rc=2 records auth cooldown state file" 1 \
+			"cooldown file missing — detector.log: $(tr '\n' ' ' <"${TEST_ROOT}/detector.log" | head -c 400)"
+	fi
+
+	if grep -q 'skipped:auth-error=1' "${TEST_ROOT}/detector.log"; then
+		print_result "rc=2 surfaces as skipped:auth-error in run summary" 0
+	else
+		print_result "rc=2 surfaces as skipped:auth-error in run summary" 1 \
+			"detector.log tail: $(tail -c 400 "${TEST_ROOT}/detector.log" | tr '\n' ' ')"
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+main() {
+	REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+	setup_sandbox
+	trap teardown_sandbox EXIT
+
+	test_oauth_pool_fallback
+	test_oauth_pool_expired_skipped
+	test_env_var_precedence_preserved
+	# Note: test 4 requires PULSE_AI_RESEARCH_HELPER_OVERRIDE support in the
+	# detector. If the detector hard-codes the helper path, this test will
+	# fail and the env override needs to be added (see PR description).
+	test_detector_rc2_records_cooldown
+
+	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds the OAuth pool as a 4th Anthropic credential source in `ai-research-helper.sh` and keys `pulse-fix-the-fixer-detector.sh` auth-error detection off the helper's documented `rc=2` exit code so the cooldown engages even when the prose error message doesn't match `_is_auth_error()`'s API-response substring patterns.

## Why

Reported in #23594: when `pulse-wrapper.sh` runs detached (long-lived background process started before the interactive shell exported `ANTHROPIC_API_KEY`), `resolve_api_key()` fell through env > gopass > credentials.sh and returned 1 even when the aidevops OAuth pool held a healthy active Anthropic account. Symptom in `pulse-wrapper.log`:

```
[fix-the-fixer-detector] WARN: LLM call failed (model=haiku, rc=2): [AI-RESEARCH] No Anthropic API key found (env, gopass, or credentials.sh)
[fix-the-fixer-detector] WARN: processed 6 issue(s) across 10 repo(s) — classified=0, skipped:auth-error=0, skipped:LLM-failure=6
```

Note `skipped:auth-error=0` — the #23434 cooldown was bypassed because `_is_auth_error()` only matches Anthropic API response strings (`invalid x-api-key`, `unauthorized`, `authentication_error`), not the local-side "No Anthropic API key found" message.

## Changes

### `ai-research-helper.sh`

- **New `resolve_oauth_pool_token()`**: reads `~/.aidevops/oauth-pool.json` directly. Does **not** shell to `oauth-pool-helper.sh` — keeps the dependency chain shallow for detached contexts where the helper might not be on `PATH`. Filters on `status` ∈ {active, idle} + non-expired + not in cooldown, returns first usable `access` token.
- **Anthropic accepts the OAuth access token in `x-api-key` as well as `Authorization: Bearer`** on `/v1/messages` (verified with both schemes returning HTTP 200), so the existing call path works unchanged.
- **`resolve_api_key()`** now consults the pool as a 4th source after env, gopass, credentials.sh. Precedence preserved: env still wins.
- **Sourcing guard** (`BASH_SOURCE` check around `main "$@"`) — lets tests source the helper and call resolvers directly. Matches the convention used by `pulse-fix-the-fixer-detector.sh` and other helpers in this repo.
- Docstring + "no key" error message updated to reflect 4 sources.

### `pulse-fix-the-fixer-detector.sh`

- `cmd_check` classifies helper `rc=2` as an auth-class signal regardless of stderr substring matching. `rc=2` is `ai-research-helper.sh`'s **documented exit code** for "no API key" (see its header comment) — a stable contract.
- `AI_RESEARCH_HELPER` constant becomes overridable via `PULSE_AI_RESEARCH_HELPER_OVERRIDE` for test injection. Production callers leave the env var unset.

### `tests/test-ai-research-helper-oauth-pool.sh` (new)

Five test cases:
1. OAuth pool token returned when static sources miss.
2. Expired pool entries skipped.
3. `$ANTHROPIC_API_KEY` env var still wins over pool (precedence preserved).
4. `rc=2` records the auth-cooldown state file.
5. `rc=2` surfaces as `skipped:auth-error=1` in the run summary — proves we trip on exit code, not substring matching.

## Verification

```
$ bash .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
PASS OAuth pool token is returned when static sources miss
PASS expired OAuth pool entries are skipped
PASS env var wins over OAuth pool
PASS rc=2 records auth cooldown state file
PASS rc=2 surfaces as skipped:auth-error in run summary
Tests run: 5, failed: 0

$ bash .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
Tests run: 6, failed: 0   # no regression on existing cooldown path

$ bash .agents/scripts/tests/test-fix-the-fixer-observability.sh
tests run:    30 — tests failed: 0
OK: all tests passed       # shellcheck clean on all touched scripts

$ shellcheck .agents/scripts/ai-research-helper.sh \
             .agents/scripts/pulse-fix-the-fixer-detector.sh \
             .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
# (no findings)
```

**Live end-to-end on an OAuth-only host** (no static `$ANTHROPIC_API_KEY`):

```
$ unset ANTHROPIC_API_KEY
$ ./.agents/scripts/ai-research-helper.sh --prompt 'Reply with exactly OK.' --max-tokens 20
OK

$ ./.agents/scripts/pulse-fix-the-fixer-detector.sh run --repo Ultimate-Multisite/superdav-ai-agent --limit 1
[fix-the-fixer-detector] INFO: Ultimate-Multisite/superdav-ai-agent#1406 verdict=NO
[fix-the-fixer-detector] INFO: processed 1 issue(s) across 1 repo(s) — classified=1, skipped:auth-error=0, skipped:LLM-failure=0
```

## Runtime Testing

- **Risk level**: Low — additive credential source + a more permissive auth-error classifier. Existing static-key paths are unchanged.
- **Verification**: shell helper behaviour verified by mocked oauth-pool + real Anthropic API call against the OAuth pool token; existing PR #23434 cooldown test still passes.

## Key Decisions

- **Read the pool file directly rather than calling `oauth-pool-helper.sh`**: keeps the dependency chain shallow for detached contexts and avoids a fork/exec on every classifier call. Schema is small and stable.
- **Trip auth-cooldown on `rc=2` rather than extending `_is_auth_error()` substring patterns**: exit code is a stable contract documented at `ai-research-helper.sh:18`; the prose message can drift safely.
- **Did not add token refresh in this helper**: refresh requires the dedicated helper (`oauth-pool-helper.sh refresh anthropic`) and is out of scope. Expired entries are skipped, the cooldown engages, and the user (or a separate scheduled refresh task) is left to remediate.

Resolves #23594

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.49 with claude-opus-4-7 spent 11h 14m and 196,866 tokens on this with the user in an interactive session.
