### PR TITLE
Recover PR #23352 test output isolation

### DIFF
--- a/.agents/scripts/tests/test-linters-local-complexity-gates.sh
+++ b/.agents/scripts/tests/test-linters-local-complexity-gates.sh
@@ -138,7 +138,7 @@ test_historical_function_debt_is_advisory() {
 	(
 		cd "$TEST_ROOT" || exit 1
 		ALL_SH_FILES=(a.sh)
-		check_function_complexity >/tmp/linters-local-function-advisory.out 2>&1
+		check_function_complexity >"${TEST_ROOT}/linters-local-function-advisory.out" 2>&1
 	)
 	local rc=$?
 	if [[ "$rc" -eq 0 ]]; then
@@ -161,7 +161,7 @@ test_changed_function_regression_blocks() {
 	(
 		cd "$TEST_ROOT" || exit 1
 		ALL_SH_FILES=(a.sh)
-		check_function_complexity >/tmp/linters-local-function-regression.out 2>&1
+		check_function_complexity >"${TEST_ROOT}/linters-local-function-regression.out" 2>&1
 	) || rc=$?
 	if [[ "$rc" -eq 1 ]]; then
 		print_result "changed function complexity regression blocks" 0
@@ -204,7 +204,7 @@ test_historical_nesting_debt_is_advisory() {
 	(
 		cd "$TEST_ROOT" || exit 1
 		ALL_SH_FILES=(a.sh b.sh)
-		check_nesting_depth >/tmp/linters-local-nesting-advisory.out 2>&1
+		check_nesting_depth >"${TEST_ROOT}/linters-local-nesting-advisory.out" 2>&1
 	)
 	local rc=$?
 	if [[ "$rc" -eq 0 ]]; then
@@ -226,7 +226,7 @@ test_changed_nesting_regression_blocks() {
 	(
 		cd "$TEST_ROOT" || exit 1
 		ALL_SH_FILES=(a.sh)
-		check_nesting_depth >/tmp/linters-local-nesting-regression.out 2>&1
+		check_nesting_depth >"${TEST_ROOT}/linters-local-nesting-regression.out" 2>&1
 	) || rc=$?
 	if [[ "$rc" -eq 1 ]]; then
 		print_result "changed nesting-depth regression blocks" 0


### PR DESCRIPTION
## Summary

- Recovered the remaining low-risk test-output isolation from closed-unmerged PR #23352.
- Left the compact shell function complexity-name coverage as-is because it is already present/superseded by #23334, #23362, and #23412.
- Avoids fixed `/tmp/linters-local-*.out` paths in the complexity gate tests so parallel/local runs stay isolated under each test repo.

## Provenance

- Source: closed-unmerged PR #23352 (`GH#23328: cover compact shell function complexity names`).
- Assessment: `.agents/scripts/linters-local-analysis.sh` already uses `sub(/\(\).*/, "", fname)` for both current-file and git-blob scans; `.agents/scripts/tests/test-linters-local-complexity-gates.sh` already has equivalent compact-brace regression coverage.
- This PR intentionally does not use a closing keyword because issue #23328 is already closed. For #23328.

## Runtime Testing

- Risk level: Low (test-only shell hygiene).
- `bash .agents/scripts/tests/test-linters-local-complexity-gates.sh`
- `shellcheck .agents/scripts/tests/test-linters-local-complexity-gates.sh .agents/scripts/linters-local-analysis.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 5m and 63,772 tokens on this as a headless worker.

