### PR TITLE
fix: stop seeding pending pool auth

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-constants.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-constants.mjs
@@ -108,6 +108,3 @@ export const OAUTH_CALLBACK_PORT = 1455;
 
 /** Timeout for OAuth callback server (ms) */
 export const OAUTH_CALLBACK_TIMEOUT_MS = 300_000;
-
-/** Pool provider IDs for auth entry seeding */
-export const POOL_PROVIDER_IDS = ["anthropic-pool", "openai-pool", "cursor-pool", "google-pool"];

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -34,7 +34,6 @@
 
 import {
   CURSOR_PROXY_HOST, CURSOR_PROXY_DEFAULT_PORT, CURSOR_PROXY_BASE_URL,
-  POOL_PROVIDER_IDS,
 } from "./oauth-pool-constants.mjs";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -300,14 +299,7 @@ export function resolveInjectFn(provider) {
 // Auth hook initialization
 // ---------------------------------------------------------------------------
 
-async function seedPoolAuthEntry(client, providerId) {
-  const body = { type: "pending", refresh: "", access: "", expires: 0 };
-  try { await client.auth.set({ path: { id: providerId }, body }); }
-  catch { /* already exists or no auth API */ }
-}
-
 export async function initPoolAuth(client) {
-  for (const id of POOL_PROVIDER_IDS) await seedPoolAuthEntry(client, id);
   await injectPoolToken(client);
   await injectOpenAIPoolToken(client);
   await injectCursorPoolToken(client);

--- a/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
@@ -8,7 +8,8 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -52,5 +53,44 @@ test("config-hook.mjs skips optional provider discovery until proxy ports are ac
     src,
     /const \{ getCursorModels \} = await import\("\.\/cursor\/models\.js"\);\s*const \{ discoverGoogleModels \} = await import\("\.\/google-proxy\.mjs"\);/,
     "Config hook must not unconditionally import both optional provider discovery modules.",
+  );
+});
+
+test("initPoolAuth does not seed unsupported pending auth entries", async () => {
+  const tempHome = mkdtempSync(resolve(tmpdir(), "aidevops-oauth-pool-"));
+  const previousHome = process.env.HOME;
+  const previousXdgDataHome = process.env.XDG_DATA_HOME;
+  process.env.HOME = tempHome;
+  process.env.XDG_DATA_HOME = resolve(tempHome, ".local", "share");
+
+  const authWrites = [];
+  const client = {
+    auth: {
+      async set(args) {
+        authWrites.push(args);
+      },
+    },
+  };
+
+  try {
+    const { initPoolAuth } = await import(`../oauth-pool.mjs?test=${Date.now()}`);
+    await initPoolAuth(client);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = previousXdgDataHome;
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(
+    authWrites.filter((write) => write?.body?.type === "pending"),
+    [],
+    "Startup must not pass aidevops pending pool state to OpenCode auth.set().",
+  );
+  assert.deepEqual(
+    authWrites.filter((write) => !["oauth", "api"].includes(write?.body?.type)),
+    [],
+    "Startup auth writes must use OpenCode-supported auth body types only.",
   );
 });


### PR DESCRIPTION
## Summary
- Stop startup from seeding synthetic OAuth pool provider entries into OpenCode auth state with unsupported `type: "pending"` bodies.
- Keep `initPoolAuth()` focused on real credential injection paths (`oauth`/`api`) and remove the now-unused pool provider ID constant.
- Add regression coverage that fails if startup writes pending or unsupported auth body types.

## Verification
- `node --check .agents/plugins/opencode-aidevops/oauth-pool.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs`
- `npm test` in `.agents/plugins/opencode-aidevops`
- `.agents/scripts/linters-local.sh` (passed; historical/advisory markdown, ratchet, layout, complexity warnings unchanged for this JS-only patch)

Resolves #23597

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 46m and 80,221 tokens on this with the user in an interactive session. Overall, 2h 14m since this issue was created.
