### PR TITLE
GH#23601: refresh tier metadata after validator

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1565,8 +1565,13 @@ dispatch_with_dedup() {
 	# keywords) and swaps tier:simple → tier:standard + posts feedback on hit.
 	# Always returns 0. Dispatch proceeds at the corrected tier on hit, or
 	# unchanged tier on miss. See .agents/reference/task-taxonomy.md.
+	# GH#23601: because the helper mutates labels on GitHub after the bundled
+	# t2996 metadata snapshot, refresh the bundle only for pre-check tier:simple
+	# candidates so eligibility/model resolution observe any tier upgrade.
 	_ds_t0=$(_ds_now_ns)
 	_run_tier_simple_body_shape_check "$issue_number" "$repo_slug"
+	issue_meta_json=$(_refresh_issue_meta_after_tier_body_shape_check \
+		"$issue_number" "$repo_slug" "$issue_meta_json")
 	_ds_record "$issue_number" "$repo_slug" "tier_body_shape" "$_ds_t0"
 
 	# GH#19118: Pre-dispatch validator — runs after dedup, before worker spawn.
@@ -1806,6 +1811,48 @@ _run_tier_simple_body_shape_check() {
 	# Always pass regardless of helper exit code. The helper itself is
 	# documented non-blocking, but this wrapper is defensive.
 	"$check_helper" check "$issue_number" "$repo_slug" >>"$LOGFILE" 2>&1 || true
+	return 0
+}
+
+#######################################
+# Refresh bundled issue metadata after tier:simple body-shape validation.
+#
+# The validator may swap tier:simple → tier:standard on GitHub. The dispatch
+# pipeline otherwise forwards the pre-validator t2996 metadata bundle to the
+# eligibility gate and worker launch, causing label-derived model resolution to
+# use stale tier labels. Keep the extra API call limited to candidates whose
+# original snapshot included tier:simple, and fail open with the original bundle.
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo)
+#   $3 - current issue_meta_json bundle
+#
+# Output:
+#   refreshed issue_meta_json when available; otherwise the original bundle
+# Exit codes:
+#   0 — always (fail-open metadata refresh)
+#######################################
+_refresh_issue_meta_after_tier_body_shape_check() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_meta_json="$3"
+
+	if ! printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | index("tier:simple")' >/dev/null 2>&1; then
+		printf '%s' "$issue_meta_json"
+		return 0
+	fi
+
+	local refreshed_issue_meta_json
+	refreshed_issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+		--json number,title,state,labels,assignees,body 2>/dev/null) || refreshed_issue_meta_json=""
+	if [[ -z "$refreshed_issue_meta_json" ]]; then
+		echo "[dispatch_with_dedup] GH#23601: unable to refresh issue metadata after tier:simple body-shape check for #${issue_number} in ${repo_slug}; continuing with original snapshot" >>"$LOGFILE"
+		printf '%s' "$issue_meta_json"
+		return 0
+	fi
+
+	printf '%s' "$refreshed_issue_meta_json"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-dispatch-core-tier-refresh.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-tier-refresh.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#23601.
+#
+# The tier:simple body-shape validator can mutate labels on GitHub after
+# dispatch_with_dedup has captured the t2996 issue_meta_json bundle. These tests
+# exercise the refresh helper in isolation so downstream gates receive the
+# updated tier labels without needing a live GitHub issue or worker launch.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+GH_ISSUE_VIEW_CALLS_FILE=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_refresh_issue_meta_after_tier_body_shape_check\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _refresh_issue_meta_after_tier_body_shape_check from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+gh_issue_view() {
+	local issue_number="$1"
+	shift
+	if [[ -n "$GH_ISSUE_VIEW_CALLS_FILE" ]]; then
+		printf 'call\n' >>"$GH_ISSUE_VIEW_CALLS_FILE"
+	fi
+	if [[ "$issue_number" != "23601" ]]; then
+		return 1
+	fi
+	printf '%s' '{"number":23601,"title":"stale tier","state":"OPEN","labels":[{"name":"tier:standard"},{"name":"auto-dispatch"}],"assignees":[],"body":"brief"}'
+	return 0
+}
+
+reset_gh_issue_view_calls() {
+	: >"$GH_ISSUE_VIEW_CALLS_FILE"
+	return 0
+}
+
+count_gh_issue_view_calls() {
+	local calls
+	calls=$(wc -l <"$GH_ISSUE_VIEW_CALLS_FILE") || calls=0
+	printf '%s' "$calls"
+	return 0
+}
+
+test_refreshes_precheck_tier_simple_snapshot() {
+	local initial_meta='{"number":23601,"title":"stale tier","state":"OPEN","labels":[{"name":"tier:simple"},{"name":"auto-dispatch"}],"assignees":[],"body":"brief"}'
+	local refreshed_meta
+	reset_gh_issue_view_calls
+	refreshed_meta=$(_refresh_issue_meta_after_tier_body_shape_check "23601" "marcusquinn/aidevops" "$initial_meta")
+
+	local resolved_tier
+	local calls
+	resolved_tier=$(printf '%s' "$refreshed_meta" | jq -r '.labels | map(.name) | join(",")')
+	calls=$(count_gh_issue_view_calls)
+	if [[ "$resolved_tier" == "tier:standard,auto-dispatch" && "$calls" -eq 1 ]]; then
+		print_result "refreshes original tier:simple metadata to post-validator labels" 0
+		return 0
+	fi
+	print_result "refreshes original tier:simple metadata to post-validator labels" 1 \
+		"Expected refreshed tier:standard labels and one gh_issue_view call; got labels='${resolved_tier}' calls=${calls}"
+	return 0
+}
+
+test_skips_refresh_when_original_snapshot_not_tier_simple() {
+	local initial_meta='{"number":23601,"title":"standard tier","state":"OPEN","labels":[{"name":"tier:standard"},{"name":"auto-dispatch"}],"assignees":[],"body":"brief"}'
+	local refreshed_meta
+	reset_gh_issue_view_calls
+	refreshed_meta=$(_refresh_issue_meta_after_tier_body_shape_check "23601" "marcusquinn/aidevops" "$initial_meta")
+
+	local calls
+	calls=$(count_gh_issue_view_calls)
+	if [[ "$refreshed_meta" == "$initial_meta" && "$calls" -eq 0 ]]; then
+		print_result "skips gh refresh for non-tier:simple snapshots" 0
+		return 0
+	fi
+	print_result "skips gh refresh for non-tier:simple snapshots" 1 \
+		"Expected original metadata and zero gh_issue_view calls; calls=${calls}"
+	return 0
+}
+
+main() {
+	LOGFILE="$(mktemp)"
+	GH_ISSUE_VIEW_CALLS_FILE="$(mktemp)"
+	export LOGFILE
+	export GH_ISSUE_VIEW_CALLS_FILE
+
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_refreshes_precheck_tier_simple_snapshot
+	test_skips_refresh_when_original_snapshot_not_tier_simple
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Refresh the bundled `issue_meta_json` after the tier:simple body-shape validator runs so downstream eligibility and worker launch see label upgrades.
- Limit the extra metadata fetch to original `tier:simple` candidates and fail open with the original snapshot if refresh is unavailable.
- Add a regression test covering refresh-on-simple and no-refresh-on-standard paths.

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-tier-refresh.sh`
- `.agents/scripts/tests/test-tier-simple-body-shape.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-pulse-dispatch-core-tier-refresh.sh`
- `.agents/scripts/linters-local.sh`
- `git diff --check`

Resolves #23601
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.49 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 24m and 116,534 tokens on this with the user in an interactive session.