### PR TITLE
GH#23606: support auto-dispatch framework issue labels

### DIFF
--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -24,6 +24,8 @@
 #                        --title TEXT      Issue title (required)
 #                        --body TEXT       Issue body (optional, auto-generated if omitted)
 #                        --label LABEL     GitHub label (default: "bug")
+#                        --auto-dispatch   Add worker-ready auto-dispatch labels
+#                        --tier TIER       Add tier label for auto-dispatch (for example: standard)
 #                        --dry-run         Print what would be created, don't create
 #
 #   check-repo         Check if the current repo is the aidevops framework repo.
@@ -353,6 +355,31 @@ _find_duplicate_issue() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# _extract_issue_url ISSUE_OUTPUT
+#
+# Extracts the canonical GitHub issue URL from wrapper output that may include
+# informational log lines before the actual URL.
+# ─────────────────────────────────────────────────────────────────────────────
+_extract_issue_url() {
+	local issue_output="$1"
+	local issue_line=""
+	local line
+
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^https://github\.com/[^[:space:]]+/[^[:space:]]+/issues/[0-9]+$ ]]; then
+			issue_line="$line"
+		fi
+	done <<<"$issue_output"
+
+	if [[ -n "$issue_line" ]]; then
+		printf '%s\n' "$issue_line"
+		return 0
+	fi
+
+	return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # _extract_issue_number ISSUE_URL
 #
 # Extracts and validates a numeric issue number from an issue URL.
@@ -427,7 +454,9 @@ _append_signature_footer() {
 # Extracts the issue number from ISSUE_URL and prints structured output.
 # ─────────────────────────────────────────────────────────────────────────────
 _emit_issue_result() {
-	local issue_url="$1"
+	local issue_output="$1"
+	local issue_url
+	issue_url=$(_extract_issue_url "$issue_output" || printf '%s' "$issue_output")
 	local issue_num
 	issue_num=$(_extract_issue_number "$issue_url" || true)
 
@@ -446,7 +475,28 @@ _emit_issue_result() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# log_framework_issue TITLE BODY LABEL DRY_RUN
+# _normalise_tier_label TIER
+#
+# Normalises a tier value to the canonical tier:* label shape.
+# ─────────────────────────────────────────────────────────────────────────────
+_normalise_tier_label() {
+	local tier="$1"
+
+	if [[ -z "$tier" ]]; then
+		return 1
+	fi
+
+	if [[ "$tier" == tier:* ]]; then
+		printf '%s\n' "$tier"
+	else
+		printf 'tier:%s\n' "$tier"
+	fi
+
+	return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# log_framework_issue TITLE BODY LABEL DRY_RUN AUTO_DISPATCH TIER
 #
 # Creates an issue on marcusquinn/aidevops. Deduplicates by title.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -455,6 +505,8 @@ log_framework_issue() {
 	local body="$2"
 	local label="${3:-bug}"
 	local dry_run="${4:-false}"
+	local auto_dispatch="${5:-false}"
+	local tier="${6:-}"
 
 	_validate_gh_prereqs "$title" || return 1
 
@@ -476,10 +528,23 @@ log_framework_issue() {
 
 	body=$(_append_signature_footer "$body")
 
+	local -a issue_labels=("$label")
+	if [[ "$auto_dispatch" == "yes" ]]; then
+		issue_labels+=("auto-dispatch")
+	fi
+	if [[ -n "$tier" ]]; then
+		local tier_label
+		tier_label=$(_normalise_tier_label "$tier") || {
+			log_error "Invalid tier: $tier"
+			return 1
+		}
+		issue_labels+=("$tier_label")
+	fi
+
 	if [[ "$dry_run" == "true" ]]; then
 		log_info "DRY RUN — would create issue on ${AIDEVOPS_SLUG}:"
 		log_info "  Title: $title"
-		log_info "  Label: $label"
+		log_info "  Labels: ${issue_labels[*]}"
 		log_info "  Body preview: ${body:0:200}..."
 		echo "status=dry_run"
 		return 2
@@ -487,12 +552,18 @@ log_framework_issue() {
 
 	log_info "Creating issue on ${AIDEVOPS_SLUG}: $title"
 
-	local issue_url
-	issue_url=$(gh_create_issue \
+	local -a create_args=(
 		--repo "$AIDEVOPS_SLUG" \
 		--title "$title" \
-		--body "$body" \
-		--label "$label" 2>&1) || {
+		--body "$body"
+	)
+	local create_label
+	for create_label in "${issue_labels[@]}"; do
+		create_args+=(--label "$create_label")
+	done
+
+	local issue_url
+	issue_url=$(gh_create_issue "${create_args[@]}" 2>&1) || {
 		log_error "Failed to create issue: $issue_url"
 		return 1
 	}
@@ -520,19 +591,32 @@ parse_and_run() {
 		;;
 
 	log)
-		local title="" body="" label="bug" dry_run="false"
+		local title="" body="" label="bug" dry_run="false" auto_dispatch="no" tier=""
 		while [[ $# -gt 0 ]]; do
-			case "$1" in
+			local option="$1"
+			case "$option" in
 			--title)
-				title="$2"
+				local option_value="${2:-}"
+				title="$option_value"
 				shift 2
 				;;
 			--body)
-				body="$2"
+				local option_value="${2:-}"
+				body="$option_value"
 				shift 2
 				;;
 			--label)
-				label="$2"
+				local option_value="${2:-}"
+				label="$option_value"
+				shift 2
+				;;
+			--auto-dispatch)
+				auto_dispatch="yes"
+				shift
+				;;
+			--tier)
+				local option_value="${2:-}"
+				tier="$option_value"
 				shift 2
 				;;
 			--dry-run)
@@ -545,7 +629,7 @@ parse_and_run() {
 				;;
 			esac
 		done
-		log_framework_issue "$title" "$body" "$label" "$dry_run"
+		log_framework_issue "$title" "$body" "$label" "$dry_run" "$auto_dispatch" "$tier"
 		return $?
 		;;
 

--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -573,6 +573,52 @@ log_framework_issue() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# _parse_log_command ARGS...
+# ─────────────────────────────────────────────────────────────────────────────
+_parse_log_command() {
+	local title="" body="" label="bug" dry_run="false" auto_dispatch="no" tier=""
+	while [[ $# -gt 0 ]]; do
+		local option="$1"
+		case "$option" in
+		--title)
+			local option_value="${2:-}"
+			title="$option_value"
+			shift 2
+			;;
+		--body)
+			local option_value="${2:-}"
+			body="$option_value"
+			shift 2
+			;;
+		--label)
+			local option_value="${2:-}"
+			label="$option_value"
+			shift 2
+			;;
+		--auto-dispatch)
+			auto_dispatch="yes"
+			shift
+			;;
+		--tier)
+			local option_value="${2:-}"
+			tier="$option_value"
+			shift 2
+			;;
+		--dry-run)
+			dry_run="true"
+			shift
+			;;
+		*)
+			log_error "Unknown option: $option"
+			return 1
+			;;
+		esac
+	done
+	log_framework_issue "$title" "$body" "$label" "$dry_run" "$auto_dispatch" "$tier"
+	return $?
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # parse_and_run ARGS...
 # ─────────────────────────────────────────────────────────────────────────────
 parse_and_run() {
@@ -591,45 +637,7 @@ parse_and_run() {
 		;;
 
 	log)
-		local title="" body="" label="bug" dry_run="false" auto_dispatch="no" tier=""
-		while [[ $# -gt 0 ]]; do
-			local option="$1"
-			case "$option" in
-			--title)
-				local option_value="${2:-}"
-				title="$option_value"
-				shift 2
-				;;
-			--body)
-				local option_value="${2:-}"
-				body="$option_value"
-				shift 2
-				;;
-			--label)
-				local option_value="${2:-}"
-				label="$option_value"
-				shift 2
-				;;
-			--auto-dispatch)
-				auto_dispatch="yes"
-				shift
-				;;
-			--tier)
-				local option_value="${2:-}"
-				tier="$option_value"
-				shift 2
-				;;
-			--dry-run)
-				dry_run="true"
-				shift
-				;;
-			*)
-				log_error "Unknown option: $1"
-				return 1
-				;;
-			esac
-		done
-		log_framework_issue "$title" "$body" "$label" "$dry_run" "$auto_dispatch" "$tier"
+		_parse_log_command "$@"
 		return $?
 		;;
 

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -32,7 +32,7 @@ assert_contains() {
 	local expected="$2"
 	local name="$3"
 
-	if grep -Fq "$expected" <<<"$output"; then
+	if grep -Fq -- "$expected" <<<"$output"; then
 		pass "$name"
 	else
 		fail "$name" "expected ${expected}; got: ${output}"
@@ -45,7 +45,7 @@ assert_not_contains() {
 	local unexpected="$2"
 	local name="$3"
 
-	if grep -Fq "$unexpected" <<<"$output"; then
+	if grep -Fq -- "$unexpected" <<<"$output"; then
 		fail "$name" "unexpected ${unexpected}; got: ${output}"
 	else
 		pass "$name"
@@ -62,6 +62,10 @@ run_case() {
 	cat >"${stub_dir}/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [[ -n "${TEST_GH_TRACE:-}" ]]; then
+	printf '%s\n' "$*" >>"$TEST_GH_TRACE"
+fi
 
 if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
 	exit 0
@@ -90,6 +94,22 @@ EOF
 		TEST_CREATED_URL="$created_url" \
 		PATH="${stub_dir}:$PATH" \
 		"$HELPER" log --title "fix: duplicate parser regression" --body "body" >"$output_file" 2>&1; then
+		return 0
+	fi
+
+	return 1
+}
+
+run_auto_dispatch_case() {
+	local stub_dir="$1"
+	local output_file="$2"
+	local trace_file="$3"
+
+	if TEST_DUPLICATE_VALUE="" \
+		TEST_CREATED_URL="https://github.com/marcusquinn/aidevops/issues/9100" \
+		TEST_GH_TRACE="$trace_file" \
+		PATH="${stub_dir}:$PATH" \
+		"$HELPER" log --title "fix: auto dispatch labels" --body "body" --label bug --auto-dispatch --tier standard >"$output_file" 2>&1; then
 		return 0
 	fi
 
@@ -126,6 +146,28 @@ else
 	invalid_create_text=$(<"$invalid_create_output")
 	assert_not_contains "$invalid_create_text" "issue_url=https://github.com/marcusquinn/aidevops/issues/[]" "invalid created issue URL is not emitted"
 fi
+
+auto_dispatch_output="${TMP_DIR}/auto-dispatch.out"
+auto_dispatch_trace="${TMP_DIR}/auto-dispatch.trace"
+if run_auto_dispatch_case "${TMP_DIR}" "$auto_dispatch_output" "$auto_dispatch_trace"; then
+	auto_dispatch_text=$(<"$auto_dispatch_output")
+	auto_dispatch_calls=$(<"$auto_dispatch_trace")
+	assert_contains "$auto_dispatch_text" "status=created" "auto-dispatch case creates issue"
+	assert_contains "$auto_dispatch_calls" "issue create" "auto-dispatch case uses issue creation"
+	assert_contains "$auto_dispatch_calls" "--label bug" "auto-dispatch case preserves requested label"
+	assert_contains "$auto_dispatch_calls" "--label auto-dispatch" "auto-dispatch case passes auto-dispatch at create time"
+	assert_contains "$auto_dispatch_calls" "--label tier:standard" "auto-dispatch case passes tier at create time"
+	assert_contains "$auto_dispatch_calls" "--label status:available" "auto-dispatch case includes worker-ready status label"
+	assert_not_contains "$auto_dispatch_calls" "issue edit" "auto-dispatch case avoids post-create issue edits"
+else
+	fail "auto-dispatch case creates issue" "helper failed"
+fi
+
+help_output="${TMP_DIR}/help.out"
+"$HELPER" help >"$help_output" 2>&1
+help_text=$(<"$help_output")
+assert_contains "$help_text" "--auto-dispatch" "usage documents auto-dispatch flag"
+assert_contains "$help_text" "--tier TIER" "usage documents tier flag"
 
 printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Added framework-issue-helper log flags for auto-dispatch and tier labels, passing labels through issue creation while preserving duplicate detection and robust URL parsing.

## Files Changed

.agents/scripts/framework-issue-helper.sh,.agents/scripts/tests/test-framework-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-framework-issue-helper.sh; shellcheck .agents/scripts/framework-issue-helper.sh .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-framework-issue-helper.sh

Resolves #23606


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 5m and 79,900 tokens on this as a headless worker.