### PR TITLE
GH#23602: fix: tolerate review gate status permission errors

### DIFF
--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -233,6 +233,7 @@ jobs:
             DESC="Review bot gate WAITING — no real bot review yet"
           fi
 
+          STATUS_EXIT=0
           gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
             --method POST \
             -f state="${STATE}" \
@@ -242,10 +243,16 @@ jobs:
             --method POST \
             -f state="${STATE}" \
             -f context="review-bot-gate" \
-            -f description="${DESC}"; } || {
+            -f description="${DESC}"; } || STATUS_EXIT=$?
+
+          if [[ "${STATUS_EXIT}" -ne 0 ]]; then
+            if [[ "${STATE}" == "success" ]]; then
+              echo "::warning::Review bot gate passed, but commit-status posting is unavailable in this token context; continuing with the workflow check as the gate signal."
+              exit 0
+            fi
             echo "::error::Failed to post review-bot-gate commit status after retry"
             exit 1
-          }
+          fi
           echo "Posted review-bot-gate status: ${STATE} (${DESC})"
 
       - name: Summary


### PR DESCRIPTION
## Summary

Allow the review-bot-gate reusable workflow to keep a successful helper PASS green when commit status posting is unavailable in read-only fork token contexts, while preserving status-post failures for blocking gate states.

## Files Changed

.github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; actionlint .github/workflows/review-bot-gate-reusable.yml; fallback text assertion

Resolves #23602


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 1m and 62,354 tokens on this as a headless worker.