### PR TITLE
fix: ignore routine telemetry in label invariant triage

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-normalize.sh
+++ b/.agents/scripts/pulse-issue-reconcile-normalize.sh
@@ -183,6 +183,7 @@ _fetch_label_invariant_rows() {
 			([.labels[].name | select(startswith("tier:"))   | sub("^tier:";   "")] | join(" ")),
 			((.labels | map(.name) | index("origin:interactive")) != null | tostring),
 			((.labels | map(.name) | index("auto-dispatch"))      != null | tostring),
+			((.labels | map(.name) | any(. as $label | ["supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold"] | index($label))) | tostring),
 			(.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime | tostring),
 			(([.labels[].name | select(startswith("status:"))] | length) | tostring)
 		] | join("|")
@@ -210,8 +211,8 @@ _normalize_label_invariants_for_repo() {
 	rows=$(_fetch_label_invariant_rows "$slug") || return 0
 	[[ -n "$rows" ]] || return 0
 
-	local issue_num="" status_list="" tier_list="" has_origin_i="" has_auto="" created_epoch="" all_status_count=""
-	while IFS='|' read -r issue_num status_list tier_list has_origin_i has_auto created_epoch all_status_count; do
+	local issue_num="" status_list="" tier_list="" has_origin_i="" has_auto="" is_non_task="" created_epoch="" all_status_count=""
+	while IFS='|' read -r issue_num status_list tier_list has_origin_i has_auto is_non_task created_epoch all_status_count; do
 		[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 		_LI_CHECKED=$((_LI_CHECKED + 1))
 
@@ -241,11 +242,13 @@ _normalize_label_invariants_for_repo() {
 		# + no tier + no auto-dispatch + no status:* AT ALL (including
 		# exception labels like needs-info/verify-failed/stale — an issue
 		# in those states is actively managed, not awaiting triage) +
+		# no non-task label (routine-tracking/supervisor/etc.) +
 		# created >30min ago = maintainer-intended issue not briefed into
 		# the dispatch pipeline.
 		if [[ "$has_origin_i" == "true" &&
 			-z "$tier_list" &&
 			"$has_auto" == "false" &&
+			"$is_non_task" == "false" &&
 			"$all_status_count" == "0" &&
 			"$created_epoch" =~ ^[0-9]+$ &&
 			"$created_epoch" -lt "$triage_cutoff" ]]; then

--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -284,6 +284,7 @@ export PULSE_QUEUED_SCAN_LIMIT=100
 #   #6: triage-missing (origin:interactive, no tier, no auto-dispatch, no status, old)
 #   #7: triage-missing-but-recent → not counted
 #   #8: triage-missing-but-has-tier → not counted
+#   #9: triage-missing shape but routine-tracking non-task → not counted
 OLD_ISO=$(date -u -d '-1 hour' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
 	TZ=UTC date -v-1H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "2026-04-13T00:00:00Z")
 NEW_ISO=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -298,7 +299,8 @@ ISSUES_JSON=$(
 	{"number":5,"labels":[{"name":"status:available"},{"name":"tier:standard"}],"createdAt":"${OLD_ISO}"},
 	{"number":6,"labels":[{"name":"origin:interactive"}],"createdAt":"${OLD_ISO}"},
 	{"number":7,"labels":[{"name":"origin:interactive"}],"createdAt":"${NEW_ISO}"},
-	{"number":8,"labels":[{"name":"origin:interactive"},{"name":"tier:standard"}],"createdAt":"${OLD_ISO}"}
+	{"number":8,"labels":[{"name":"origin:interactive"},{"name":"tier:standard"}],"createdAt":"${OLD_ISO}"},
+	{"number":9,"labels":[{"name":"origin:interactive"},{"name":"routine-tracking"}],"createdAt":"${OLD_ISO}"}
 ]
 JSON
 )
@@ -401,14 +403,15 @@ else
 	print_result "reconciler #5 single-label no-op" 1 "(edit calls: $n5)"
 fi
 
-# Issue #6, #7, #8: triage-missing count-only (no edits)
+# Issue #6, #7, #8, #9: triage-missing count-only/non-task (no edits)
 n6=$(count_edits_for 6)
 n7=$(count_edits_for 7)
 n8=$(count_edits_for 8)
-if [[ "$n6" -eq 0 && "$n7" -eq 0 && "$n8" -eq 0 ]]; then
+n9=$(count_edits_for 9)
+if [[ "$n6" -eq 0 && "$n7" -eq 0 && "$n8" -eq 0 && "$n9" -eq 0 ]]; then
 	print_result "reconciler does not auto-fix triage-missing issues" 0
 else
-	print_result "reconciler does not auto-fix triage-missing issues" 1 "(edits: #6=$n6 #7=$n7 #8=$n8)"
+	print_result "reconciler does not auto-fix triage-missing issues" 1 "(edits: #6=$n6 #7=$n7 #8=$n8 #9=$n9)"
 fi
 
 # Counter file must be written with exact numbers
@@ -438,11 +441,11 @@ if [[ -f "$COUNTER_FILE" ]]; then
 		print_result "counter tier_fixed=1 (issue #3)" 1 "(got: $tier_fixed)"
 	fi
 
-	# triage_missing: #6 only (#7 is recent, #8 has a tier)
+	# triage_missing: #6 only (#7 is recent, #8 has a tier, #9 is routine-tracking)
 	if [[ "$triage_missing" -eq 1 ]]; then
-		print_result "counter triage_missing=1 (only #6 matches all criteria)" 0
+		print_result "counter triage_missing=1 (only #6 matches all criteria; routine-tracking ignored)" 0
 	else
-		print_result "counter triage_missing=1 (only #6 matches all criteria)" 1 "(got: $triage_missing)"
+		print_result "counter triage_missing=1 (only #6 matches all criteria; routine-tracking ignored)" 1 "(got: $triage_missing)"
 	fi
 fi
 
@@ -533,16 +536,16 @@ else
 		in_block { print }
 	' "$WORKFLOW_FILE")
 
-	# Skip signature: parent-task label probe inside the find-issue step AND
-	# (within the same step) an `echo "found_issues="` that emits empty output
-	# when the probe matches. Both indicators together prove the skip path
-	# exists and is wired into GITHUB_OUTPUT correctly.
-	if echo "$find_block" | grep -qE 'parent-task' &&
-		echo "$find_block" | grep -qE 'echo[[:space:]]+"found_issues="'; then
-		print_result "find-issue step skips parent-task title-fallback matches (t2137)" 0
+	# Skip signature: either the original parent-task label probe exists, or the
+	# stronger GH#23516 explicit-link gate disables title fallback entirely. In
+	# both cases an `echo "found_issues="` must emit empty output to GITHUB_OUTPUT.
+	if echo "$find_block" | grep -qE 'echo[[:space:]]+"found_issues="' &&
+		{ echo "$find_block" | grep -qE 'parent-task' ||
+			echo "$find_block" | grep -qE 'No explicit closing issue'; }; then
+		print_result "find-issue step skips unsafe title-fallback matches (t2137/GH#23516)" 0
 	else
-		print_result "find-issue step skips parent-task title-fallback matches (t2137)" 1 \
-			"(expected parent-task label probe + empty found_issues emission)"
+		print_result "find-issue step skips unsafe title-fallback matches (t2137/GH#23516)" 1 \
+			"(expected parent-task probe or explicit-link gate + empty found_issues emission)"
 	fi
 fi
 


### PR DESCRIPTION
## Summary
- Ignore non-task telemetry labels when computing pulse label-invariant `triage_missing` counts.
- Add regression coverage for `routine-tracking` issues that otherwise match the `origin:interactive`/missing-metadata shape.
- Refresh the existing title-fallback guard to accept the stronger explicit-link gate already present in the workflow.

## Evidence
- Local pulse counter showed `triage_missing=2` at `2026-05-15T06:55:54Z`.
- Cached issue records showed the two matching records were routine-tracking telemetry, not worker-dispatchable tasks.
- Current issue-create wrappers already add a default `status:available`, so this fixes the remaining false-positive reconciler path.

## Testing
- `bash .agents/scripts/tests/test-label-invariants.sh` → All 43 tests passed
- `shellcheck .agents/scripts/pulse-issue-reconcile-normalize.sh .agents/scripts/tests/test-label-invariants.sh`
- `git diff --check`

## Runtime Testing
- self-assessed: shell-only reconciler counter logic with stubbed regression coverage.

Resolves #23625

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 5m and 119,412 tokens on this as a headless worker.

