### PR TITLE
GH#23622: fix worker headless export overrides

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1565,11 +1565,9 @@ cmd_run() {
 		# The sandbox allowlist already forwards AIDEVOPS_*; legacy generic
 		# HEADLESS/FULL_LOOP_HEADLESS markers are intentionally not required
 		# past the clean-env boundary.
-		local AIDEVOPS_SESSION_ORIGIN
-		AIDEVOPS_SESSION_ORIGIN="${AIDEVOPS_SESSION_ORIGIN:-worker}"
+		local AIDEVOPS_SESSION_ORIGIN="${AIDEVOPS_SESSION_ORIGIN:-worker}"
 		export AIDEVOPS_SESSION_ORIGIN
-		local AIDEVOPS_HEADLESS
-		AIDEVOPS_HEADLESS="${AIDEVOPS_HEADLESS:-true}"
+		local AIDEVOPS_HEADLESS="${AIDEVOPS_HEADLESS:-true}"
 		export AIDEVOPS_HEADLESS
 	fi
 


### PR DESCRIPTION
## Summary
- Preserves caller-provided `AIDEVOPS_SESSION_ORIGIN` and `AIDEVOPS_HEADLESS` values while keeping worker exports local to `cmd_run`.
- Combines `local` declarations with assignments so Bash reads the inherited value before binding the local variable.

## Testing
- `shellcheck .agents/scripts/headless-runtime-helper.sh`
- `bash -n .agents/scripts/headless-runtime-helper.sh`
- `bash -c` probe verifying `custom` / `false` values survive local assignment

Resolves #23622

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 2m and 70,745 tokens on this as a headless worker.
