### PR TITLE
GH#23613: fix: normalize pulse dispatch labels

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -299,27 +299,28 @@ build_ranked_dispatch_candidates_json() {
 				repo_path: $path,
 				repo_priority: $priority,
 				score: (
+					((.labels // []) | map(.name? // .)) as $labels |
 					(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
 					# Mission m-20260504-1e325d feature 3.4: when capacity is
 					# constrained, rank worker-ready/low-complexity issues above
 					# broad raw backlog so pulse fills slots with solvable work first.
-					(if ((.labels | index("tier:simple")) != null or (.labels | index("low-complexity")) != null) then 2500
-					 elif (.labels | index("tier:standard")) != null then 1200
+					(if (($labels | index("tier:simple")) != null or ($labels | index("low-complexity")) != null) then 2500
+					 elif ($labels | index("tier:standard")) != null then 1200
 					 else 0 end) +
-					(if ((.labels | index("worker-ready")) != null or (.labels | index("status:available")) != null) then 1000 else 0 end) +
-					(if ((.labels | index("good first issue")) != null or (.labels | index("quick-win")) != null) then 800 else 0 end) +
-					(if (.labels | index("auto-dispatch")) != null then 300 else 0 end) -
-					(if (.labels | index("tier:thinking")) != null then 1200 else 0 end) -
-					(if ((.labels | index("research")) != null or (.labels | index("needs-design")) != null) then 800 else 0 end) +
-					(if ((.labels | index("quality-debt")) != null and (.labels | index("security")) != null) then 500 else 0 end) +
-					(if (.labels | index("priority:critical")) != null then 10000
-					 elif (.labels | index("priority:high")) != null then 9000
-					 elif (.labels | index("priority:medium")) != null then 8000
-					 elif (.labels | index("bug")) != null then 7000
-					 elif (.labels | index("enhancement")) != null then 6000
-					 elif (.labels | index("quality-debt")) != null then 5000
-					 elif ((.labels | index("file-size-debt")) != null or (.labels | index("function-complexity-debt")) != null) then 4000
-					 elif (.labels | index("priority:low")) != null then 3500
+					(if (($labels | index("worker-ready")) != null or ($labels | index("status:available")) != null) then 1000 else 0 end) +
+					(if (($labels | index("good first issue")) != null or ($labels | index("quick-win")) != null) then 800 else 0 end) +
+					(if ($labels | index("auto-dispatch")) != null then 300 else 0 end) -
+					(if ($labels | index("tier:thinking")) != null then 1200 else 0 end) -
+					(if (($labels | index("research")) != null or ($labels | index("needs-design")) != null) then 800 else 0 end) +
+					(if (($labels | index("quality-debt")) != null and ($labels | index("security")) != null) then 500 else 0 end) +
+					(if ($labels | index("priority:critical")) != null then 10000
+					 elif ($labels | index("priority:high")) != null then 9000
+					 elif ($labels | index("priority:medium")) != null then 8000
+					 elif ($labels | index("bug")) != null then 7000
+					 elif ($labels | index("enhancement")) != null then 6000
+					 elif ($labels | index("quality-debt")) != null then 5000
+					 elif (($labels | index("file-size-debt")) != null or ($labels | index("function-complexity-debt")) != null) then 4000
+					 elif ($labels | index("priority:low")) != null then 3500
 					 else 3000 end)
 				)
 			}

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -306,9 +306,9 @@ JSON
 		printf '%s %s\n' "$repo_slug" "$limit" >/dev/null
 		cat <<'JSON'
 [
-  {"number": 10, "title": "broad enhancement", "updatedAt": "2026-05-01T00:00:00Z", "labels": ["enhancement", "tier:thinking"], "assignees": []},
-  {"number": 11, "title": "small worker-ready fix", "updatedAt": "2026-05-02T00:00:00Z", "labels": ["enhancement", "tier:simple", "worker-ready", "auto-dispatch"], "assignees": []},
-  {"number": 12, "title": "plain bug", "updatedAt": "2026-05-03T00:00:00Z", "labels": ["bug"], "assignees": []}
+  {"number": 10, "title": "broad enhancement", "updatedAt": "2026-05-01T00:00:00Z", "labels": [{"name": "enhancement"}, {"name": "tier:thinking"}], "assignees": []},
+  {"number": 11, "title": "small worker-ready fix", "updatedAt": "2026-05-02T00:00:00Z", "labels": [{"name": "enhancement"}, {"name": "tier:simple"}, {"name": "worker-ready"}, {"name": "auto-dispatch"}], "assignees": []},
+  {"number": 12, "title": "plain bug", "updatedAt": "2026-05-03T00:00:00Z", "labels": [{"name": "bug"}], "assignees": []}
 ]
 JSON
 		return 0
@@ -354,8 +354,8 @@ JSON
 		printf '%s %s\n' "$repo_slug" "$limit" >/dev/null
 		cat <<'JSON'
 [
-  {"number": 20, "title": "broad research priority", "updatedAt": "2026-05-01T00:00:00Z", "labels": ["priority:high", "research", "tier:thinking"], "assignees": []},
-  {"number": 21, "title": "low complexity actionable fix", "updatedAt": "2026-05-02T00:00:00Z", "labels": ["enhancement", "low-complexity", "status:available"], "assignees": []}
+  {"number": 20, "title": "broad research priority", "updatedAt": "2026-05-01T00:00:00Z", "labels": [{"name": "priority:high"}, {"name": "research"}, {"name": "tier:thinking"}], "assignees": []},
+  {"number": 21, "title": "low complexity actionable fix", "updatedAt": "2026-05-02T00:00:00Z", "labels": [{"name": "enhancement"}, {"name": "low-complexity"}, {"name": "status:available"}], "assignees": []}
 ]
 JSON
 		return 0


### PR DESCRIPTION
## Summary

Normalized pulse dispatch scoring labels before jq index checks so candidate ranking handles string, object, or missing label arrays; updated guardrail mocks to use GitHub-style label objects.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh; .agents/scripts/tests/test-pulse-current-state-guardrails.sh

Resolves #23613


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 85,627 tokens on this as a headless worker.