### PR TITLE
GH#23621: refresh external pulse benign ledgers

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -51,6 +51,7 @@ _DISPATCH_CONSECUTIVE_NO_WORKER=0
 _DISPATCH_THROTTLE_FILE=""
 _DISPATCH_CANARY_CACHE=""
 _DISPATCH_BENIGN_BLOCKS_FILE=""
+_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
 # Out-parameter set by _dispatch_process_candidate when a successful launch clears
 # the throttle file. The orchestrator loop reads this and restores
 # _effective_slots to the unthrottled available_slots value.
@@ -224,10 +225,10 @@ _dispatch_begin_benign_blocks_cycle() {
 		_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
 		return 0
 	fi
-	if [[ "$ledger_file" == */* ]] && ! mkdir -p "${ledger_file%/*}"; then
+	if [[ "$ledger_managed_by_dispatch" == "0" && "$ledger_file" == */* && -n "${ledger_file%/*}" ]] && ! mkdir -p "${ledger_file%/*}"; then
 		printf 'Failed to create benign block ledger parent directory: %s\n' "${ledger_file%/*}" >&2
 	fi
-	if [[ "$ledger_managed_by_dispatch" == "1" ]] && ! : >"$ledger_file"; then
+	if ! : >"$ledger_file"; then
 		printf 'Failed to initialize benign block ledger file: %s\n' "$ledger_file" >&2
 	fi
 	_DISPATCH_BENIGN_BLOCKS_FILE="$ledger_file"

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -208,7 +208,7 @@ test_benign_block_ledger_is_cycle_local_and_cleaned() {
 	return 0
 }
 
-test_external_benign_block_ledger_is_preserved() {
+test_external_benign_block_ledger_is_preserved_and_refreshed() {
 	reset_guardrail_env
 	local external_ledger="${TEST_ROOT}/external-benign-blocks.tsv"
 	local ledger_path=""
@@ -219,10 +219,10 @@ test_external_benign_block_ledger_is_preserved() {
 	_dispatch_mark_benign_blocked_candidate 23575 marcusquinn/aidevops dedup_active_claim
 	_dispatch_cleanup_benign_blocks_cycle
 	unset AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE
-	if [[ "$ledger_path" == "$external_ledger" ]] && [[ -f "$external_ledger" ]] && grep -q $'^101\tmarcusquinn/aidevops\tcaller_managed$' "$external_ledger" && grep -q $'^23575\tmarcusquinn/aidevops\tdedup_active_claim$' "$external_ledger"; then
-		print_result "guardrail: external benign block ledger is preserved" 0
+	if [[ "$ledger_path" == "$external_ledger" ]] && [[ -f "$external_ledger" ]] && ! grep -q $'^101\tmarcusquinn/aidevops\tcaller_managed$' "$external_ledger" && grep -q $'^23575\tmarcusquinn/aidevops\tdedup_active_claim$' "$external_ledger"; then
+		print_result "guardrail: external benign block ledger is preserved and refreshed" 0
 	else
-		print_result "guardrail: external benign block ledger is preserved" 1 "ledger=${ledger_path}"
+		print_result "guardrail: external benign block ledger is preserved and refreshed" 1 "ledger=${ledger_path}"
 	fi
 	return 0
 }
@@ -381,7 +381,7 @@ test_disabled_guardrail_still_updates_available_slots_gauge
 test_interactive_hold_reason_is_classified
 test_pr_target_reason_is_classified_as_benign_block
 test_benign_block_ledger_is_cycle_local_and_cleaned
-test_external_benign_block_ledger_is_preserved
+test_external_benign_block_ledger_is_preserved_and_refreshed
 test_apply_dispatch_max_preserves_benign_ledger_across_refill
 test_ranked_candidates_prioritise_solvable_work
 test_ranked_candidates_prioritise_low_complexity_over_research


### PR DESCRIPTION
## Summary

Refresh external benign block ledgers at cycle start while preserving caller-owned files during cleanup, and initialize the ownership flag at module load.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-current-state-guardrails.sh; bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh

Resolves #23621


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 1m and 48,876 tokens on this as a headless worker.