### PR TITLE
GH#23618: fix: simplify OAuth pool token empty check

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -88,7 +88,7 @@ resolve_oauth_pool_token() {
 		| .[0].access // ""
 	' "$pool_file" 2>/dev/null) || return 1
 
-	if [[ -z "$token" || "$token" == "null" ]]; then
+	if [[ -z "$token" ]]; then
 		return 1
 	fi
 	printf '%s\n' "$token"


### PR DESCRIPTION
## Summary

Removed the redundant literal null check from resolve_oauth_pool_token after jq -r already falls back to an empty string.

## Files Changed

.agents/scripts/ai-research-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/ai-research-helper.sh; bash .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh

Resolves #23618


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 32,284 tokens on this as a headless worker.