### PR TITLE
GH#23616: test: isolate USERPROFILE in pool auth startup test

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
@@ -60,8 +60,10 @@ test("initPoolAuth does not seed unsupported pending auth entries", async () => 
   const tempHome = mkdtempSync(resolve(tmpdir(), "aidevops-oauth-pool-"));
   const previousHome = process.env.HOME;
   const previousXdgDataHome = process.env.XDG_DATA_HOME;
+  const previousUserProfile = process.env.USERPROFILE;
   process.env.HOME = tempHome;
   process.env.XDG_DATA_HOME = resolve(tempHome, ".local", "share");
+  process.env.USERPROFILE = tempHome;
 
   const authWrites = [];
   const client = {
@@ -80,6 +82,8 @@ test("initPoolAuth does not seed unsupported pending auth entries", async () => 
     else process.env.HOME = previousHome;
     if (previousXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = previousXdgDataHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
     rmSync(tempHome, { recursive: true, force: true });
   }
 


### PR DESCRIPTION
## Summary

Backed up, overrode, and restored USERPROFILE alongside HOME and XDG_DATA_HOME so the initPoolAuth startup regression test isolates os.homedir() consistently across platforms.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs

Resolves #23616


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 36,649 tokens on this as a headless worker.