### PR TITLE
GH#23617: harden headless canary review follow-up

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1565,9 +1565,11 @@ cmd_run() {
 		# The sandbox allowlist already forwards AIDEVOPS_*; legacy generic
 		# HEADLESS/FULL_LOOP_HEADLESS markers are intentionally not required
 		# past the clean-env boundary.
-		local AIDEVOPS_SESSION_ORIGIN="${AIDEVOPS_SESSION_ORIGIN:-worker}"
+		local _worker_session_origin="${AIDEVOPS_SESSION_ORIGIN:-worker}"
+		local AIDEVOPS_SESSION_ORIGIN="$_worker_session_origin"
 		export AIDEVOPS_SESSION_ORIGIN
-		local AIDEVOPS_HEADLESS="${AIDEVOPS_HEADLESS:-true}"
+		local _worker_headless_marker="${AIDEVOPS_HEADLESS:-true}"
+		local AIDEVOPS_HEADLESS="$_worker_headless_marker"
 		export AIDEVOPS_HEADLESS
 	fi
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1565,11 +1565,15 @@ cmd_run() {
 		# The sandbox allowlist already forwards AIDEVOPS_*; legacy generic
 		# HEADLESS/FULL_LOOP_HEADLESS markers are intentionally not required
 		# past the clean-env boundary.
-		local _worker_session_origin="${AIDEVOPS_SESSION_ORIGIN:-worker}"
-		local AIDEVOPS_SESSION_ORIGIN="$_worker_session_origin"
+		local _worker_session_origin
+		_worker_session_origin="${AIDEVOPS_SESSION_ORIGIN:-worker}"
+		local AIDEVOPS_SESSION_ORIGIN
+		AIDEVOPS_SESSION_ORIGIN="$_worker_session_origin"
 		export AIDEVOPS_SESSION_ORIGIN
-		local _worker_headless_marker="${AIDEVOPS_HEADLESS:-true}"
-		local AIDEVOPS_HEADLESS="$_worker_headless_marker"
+		local _worker_headless_marker
+		_worker_headless_marker="${AIDEVOPS_HEADLESS:-true}"
+		local AIDEVOPS_HEADLESS
+		AIDEVOPS_HEADLESS="$_worker_headless_marker"
 		export AIDEVOPS_HEADLESS
 	fi
 

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1637,9 +1637,9 @@ _run_canary_test() {
 	# because the expected token can only appear if the model actually
 	# processed the prompt and generated a response.
 	#
-	# GH#23598: match the benign probe answer case-insensitively with a
-	# portable word boundary rather than relying on GNU grep `\b` semantics.
-	if grep -Eiq '(^|[^[:alnum:]_])four([^[:alnum:]_]|$)' "$canary_output" 2>/dev/null; then
+	# GH#23598: match the benign probe answer case-insensitively with the
+	# portable whole-word mode supported by GNU and BSD grep.
+	if grep -iwq 'four' "$canary_output" 2>/dev/null; then
 		# Cache the pass timestamp
 		mkdir -p "${STATE_DIR}" 2>/dev/null || true
 		date +%s >"$cache_file"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1557,9 +1557,12 @@ _run_canary_test() {
 	local _canary_config_dir=""
 	_canary_config_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-canary-config.XXXXXX")
 	mkdir -p "${_canary_config_dir}/opencode"
-	local _canary_plugin_path="${AIDEVOPS_PLUGIN_INDEX:-${HOME}/.aidevops/agents/plugins/opencode-aidevops/index.mjs}"
+	local _canary_plugin_path
+	_canary_plugin_path="${AIDEVOPS_PLUGIN_INDEX:-${HOME}/.aidevops/agents/plugins/opencode-aidevops/index.mjs}"
 	local _canary_plugin_url=""
-	[[ -f "$_canary_plugin_path" ]] && _canary_plugin_url="file://${_canary_plugin_path}"
+	if [[ -f "$_canary_plugin_path" ]]; then
+		_canary_plugin_url=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).absolute().as_uri())' "$_canary_plugin_path" 2>/dev/null || printf 'file://%s' "$_canary_plugin_path")
+	fi
 	jq -n --arg plugin_url "$_canary_plugin_url" \
 		'{"$schema":"https://opencode.ai/config.json"} + (if $plugin_url == "" then {} else {plugin: [$plugin_url]} end)' \
 		>"${_canary_config_dir}/opencode/opencode.json"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -810,7 +810,8 @@ EOF
 		args=$(<"$args_file")
 		local env_output
 		env_output=$(<"$env_file")
-		local expected_plugin_url="file://${plugin_path}"
+		local expected_plugin_url
+		expected_plugin_url=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).absolute().as_uri())' "$plugin_path")
 		if [[ "$args" == *'What is two plus two?'* && "$args" != *'--pure'* && "$args" != *'--agent build'* ]] &&
 			[[ "$env_output" == *"OPENCODE_BIN=${fake_bin_dir}/opencode"* ]] &&
 			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]] &&

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -755,12 +755,15 @@ test_service_interruption_candidate_uses_separate_path() {
 	return 0
 }
 
-test_canary_uses_builtin_agent_without_default_agent() {
+test_canary_uses_isolated_plugin_config_without_pure() {
 	local canary_root="${TEST_ROOT}/canary-agent"
 	local fake_bin_dir="${canary_root}/bin"
+	local plugin_dir="${canary_root}/plugin path"
+	local plugin_path="${plugin_dir}/index.mjs"
 	local args_file="${canary_root}/args.txt"
 	local env_file="${canary_root}/env.txt"
-	mkdir -p "$fake_bin_dir"
+	mkdir -p "$fake_bin_dir" "$plugin_dir"
+	printf '%s\n' 'export default {};' >"$plugin_path"
 
 	cat >"${fake_bin_dir}/opencode" <<'EOF'
 #!/usr/bin/env bash
@@ -773,9 +776,12 @@ if [[ -n "${OPENCODE_SESSION_ID:-}${OPENCODE_PID:-}${OPENCODE_RUN_ID:-}${OPENCOD
 	exit 42
 fi
 printf '%s\n' "$*" >"$AIDEVOPS_CANARY_ARGS_FILE"
-printf 'OPENCODE_BIN=%s\nOPENCODE_DB=%s\n' \
-	"${OPENCODE_BIN:-}" "${OPENCODE_DB:-}" >"$AIDEVOPS_CANARY_ENV_FILE"
-printf 'CANARY_OK\n'
+printf 'OPENCODE_BIN=%s\nOPENCODE_DB=%s\nAIDEVOPS_HEADLESS=%s\n' \
+	"${OPENCODE_BIN:-}" "${OPENCODE_DB:-}" "${AIDEVOPS_HEADLESS:-}" >"$AIDEVOPS_CANARY_ENV_FILE"
+if [[ -f "${XDG_CONFIG_HOME:-}/opencode/opencode.json" ]]; then
+	printf 'CONFIG=%s\n' "$(<"${XDG_CONFIG_HOME}/opencode/opencode.json")" >>"$AIDEVOPS_CANARY_ENV_FILE"
+fi
+printf 'The answer is Four.\n'
 exit 0
 EOF
 	chmod +x "${fake_bin_dir}/opencode"
@@ -792,6 +798,7 @@ EOF
 		OPENCODE_PROCESS_ROLE="tui" \
 		OPENCODE="1" \
 		OPENCODE_SERVER_PASSWORD="session-password" \
+		AIDEVOPS_PLUGIN_INDEX="$plugin_path" \
 		AIDEVOPS_CANARY_ARGS_FILE="$args_file" \
 		AIDEVOPS_CANARY_ENV_FILE="$env_file" \
 		AIDEVOPS_HEADLESS_RUNTIME_DIR="${canary_root}/runtime" \
@@ -803,18 +810,21 @@ EOF
 		args=$(<"$args_file")
 		local env_output
 		env_output=$(<"$env_file")
-		if [[ "$args" == *'--pure'* && "$args" == *'--agent build'* ]] &&
+		local expected_plugin_url="file://${plugin_path}"
+		if [[ "$args" == *'What is two plus two?'* && "$args" != *'--pure'* && "$args" != *'--agent build'* ]] &&
 			[[ "$env_output" == *"OPENCODE_BIN=${fake_bin_dir}/opencode"* ]] &&
-			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]]; then
-			print_result "canary uses built-in agent without default_agent" 0
+			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]] &&
+			[[ "$env_output" == *"AIDEVOPS_HEADLESS=1"* ]] &&
+			[[ "$env_output" == *"$expected_plugin_url"* ]]; then
+			print_result "canary uses isolated plugin config without pure" 0
 			return 0
 		fi
-		print_result "canary uses built-in agent without default_agent" 1 \
-			"Expected --pure/--agent build and preserved OpenCode config env, got args: ${args}; env: ${env_output}"
+		print_result "canary uses isolated plugin config without pure" 1 \
+			"Expected benign prompt, no --pure/--agent build, headless env, plugin config, and preserved OpenCode config env; got args: ${args}; env: ${env_output}"
 		return 0
 	fi
 
-	print_result "canary uses built-in agent without default_agent" 1 \
+	print_result "canary uses isolated plugin config without pure" 1 \
 		"Canary stub did not run successfully: ${output:-<empty>}"
 	return 0
 }
@@ -1503,7 +1513,7 @@ main() {
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
 	test_service_interruption_candidate_uses_separate_path
-	test_canary_uses_builtin_agent_without_default_agent
+	test_canary_uses_isolated_plugin_config_without_pure
 	test_opencode_session_env_wrapper_strips_session_vars_only
 	test_worker_opencode_exec_paths_strip_session_env
 	test_sandbox_passthrough_scopes_provider_env


### PR DESCRIPTION
## Summary

Applied the PR #23599 review follow-up by switching the canary answer check to portable grep -w, preserving worker origin/headless overrides before canary startup, and addressing PR #23632 review feedback with two-step local declarations plus python3-generated plugin file URIs for paths with spaces.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #23617


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 resumed interactively after a transient provider interruption.