### PR TITLE
GH#23619: fix issue-sync task-line evidence extraction

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -48,11 +48,10 @@ _is_cancelled_or_deferred() {
 _has_evidence() {
 	local text="$1" task_id="$2" repo="$3"
 	local task_line
-	task_line=$(printf '%s\n' "$text" | grep -E '^[[:space:]]*- \[[ x-]\] ' | head -1 || true)
-	[[ -z "$task_line" ]] && task_line="$text"
+	task_line=$(_task_line_from_block "$text" "$task_id")
 	# Cancelled/deferred/declined tasks need no PR or verified: evidence
 	_is_cancelled_or_deferred "$task_line" && return 0
-	if _has_unresolved_blocker "$task_line"; then
+	if _has_unresolved_blocker "$task_line" "$task_id"; then
 		return 1
 	fi
 	echo "$text" | grep -qE 'verified:[0-9]{4}-[0-9]{2}-[0-9]{2}|pr:#[0-9]+' && return 0
@@ -61,11 +60,22 @@ _has_evidence() {
 	return 1
 }
 
+_task_line_from_block() {
+	local text="$1" task_id="${2:-}"
+	local task_line
+	if [[ -n "$task_id" ]]; then
+		task_line=$(printf '%s\n' "$text" | grep -F " $task_id " | grep -E '^[[:space:]]*- \[.\] ' | head -1 || true)
+	fi
+	[[ -z "$task_line" ]] && task_line=$(printf '%s\n' "$text" | grep -E '^[[:space:]]*- \[.\] ' | head -1 || true)
+	[[ -z "$task_line" ]] && task_line=$(printf '%s\n' "$text" | head -1)
+	printf '%s\n' "$task_line"
+	return 0
+}
+
 _has_unresolved_blocker() {
-	local text="$1"
+	local text="$1" task_id="${2:-}"
 	local candidate
-	candidate=$(printf '%s\n' "$text" | grep -E '^[[:space:]]*- \[[ x-]\] ' | head -1 || true)
-	[[ -z "$candidate" ]] && candidate="$text"
+	candidate=$(_task_line_from_block "$text" "$task_id")
 	echo "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
 	return 1
 }

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -87,6 +87,22 @@ else
 	pass "cancelled marker in task notes is not accepted as completion evidence"
 fi
 
+unexpected_marker_cancelled_note_task='- [~] t9006 incomplete implementation tier:standard
+  - Historical note: earlier scope was cancelled:2026-01-01 before being reopened.'
+if _has_evidence "$unexpected_marker_cancelled_note_task" "t9006" "owner/repo"; then
+	fail "unexpected task marker still ignores cancelled marker in task notes"
+else
+	pass "unexpected task marker still ignores cancelled marker in task notes"
+fi
+
+unexpected_marker_proof_task='- [~] t9007 fixed implementation pr:#80 tier:standard
+  - Historical note: earlier attempt was blocked-by:t9006 before the dependency landed.'
+if _has_evidence "$unexpected_marker_proof_task" "t9007" "owner/repo"; then
+	pass "unexpected task marker accepts proof on the task line"
+else
+	fail "unexpected task marker should accept proof on the task line"
+fi
+
 if [[ "$FAIL" -eq 0 ]]; then
 	printf 'All %d tests passed\n' "$PASS"
 	exit 0


### PR DESCRIPTION
## Summary

Updated issue-sync close evidence checks to extract task lines with the task id, support any checkbox marker, and fall back only to the first line so historical notes cannot supply cancellation/blocker false positives.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh,.agents/scripts/tests/test-issue-sync-completion-evidence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-completion-evidence.sh; .agents/scripts/tests/test-issue-sync-completion-evidence.sh

Resolves #23619


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 2m and 44,162 tokens on this as a headless worker.