### PR TITLE
GH#23604: dedupe pulse PR view cache reads

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -111,6 +111,19 @@ _gh_pr_list_snapshot_key() {
 }
 
 #######################################
+# Record a lightweight cache decision in the same instrumentation stream as API
+# calls. These records use path=other so cache hit/miss/stale decisions are
+# visible without inflating REST/GraphQL call counts.
+# Args: $1 = cache name, $2 = decision
+#######################################
+_gh_read_cache_record() {
+	local _cache_name="$1"
+	local _decision="$2"
+	gh_record_call other "${_cache_name}" unknown other "${_decision}" 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Read a cached gh_pr_list snapshot when present and fresh.
 # Args: gh-style argv
 # Stdout: cached command output
@@ -119,16 +132,17 @@ _gh_pr_list_snapshot_get() {
 	local _ttl="${AIDEVOPS_GH_PR_LIST_CACHE_TTL:-15}"
 	[[ "${AIDEVOPS_GH_PR_LIST_CACHE_DISABLE:-0}" == "1" ]] && return 1
 	[[ "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]] || return 1
-	_gh_pr_list_snapshot_cacheable "$@" || return 1
+	_gh_pr_list_snapshot_cacheable "$@" || { _gh_read_cache_record gh_pr_list_cache bypass; return 1; }
 	local _key _path _now _mtime _age
 	_key="$(_gh_pr_list_snapshot_key "$@")"
 	_path="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}/${_key}.json"
-	[[ -f "$_path" ]] || return 1
+	[[ -f "$_path" ]] || { _gh_read_cache_record gh_pr_list_cache miss; return 1; }
 	_now=$(date +%s 2>/dev/null || printf '0')
 	_mtime=$(perl -e 'print((stat($ARGV[0]))[9] || 0)' "$_path" 2>/dev/null || printf '0')
 	[[ "$_now" =~ ^[0-9]+$ && "$_mtime" =~ ^[0-9]+$ ]] || return 1
 	_age=$(( _now - _mtime ))
-	[[ "$_age" -ge 0 && "$_age" -le "$_ttl" ]] || return 1
+	[[ "$_age" -ge 0 && "$_age" -le "$_ttl" ]] || { _gh_read_cache_record gh_pr_list_cache stale; return 1; }
+	_gh_read_cache_record gh_pr_list_cache hit
 	printf '%s' "$(<"$_path")"
 	return 0
 }
@@ -151,6 +165,83 @@ _gh_pr_list_snapshot_put() {
 	_tmp=$(mktemp "${_dir}/.pr-list-${_key}.XXXXXX" 2>/dev/null) || return 0
 	printf '%s' "$_body" >"$_tmp" 2>/dev/null || { rm -f "$_tmp"; return 0; }
 	mv "$_tmp" "$_path" 2>/dev/null || rm -f "$_tmp"
+	_gh_read_cache_record gh_pr_list_cache store
+	return 0
+}
+
+#######################################
+# Return 0 when gh_pr_view exact-output caching is enabled. This cache is scoped
+# to pulse cycles (or explicit callers) through AIDEVOPS_GH_PR_VIEW_CACHE and is
+# keyed by the full argv, so different field sets never share projected output.
+#######################################
+_gh_pr_view_snapshot_enabled() {
+	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE:-0}" == "1" ]] || return 1
+	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" == "1" ]] && return 1
+	local _ttl="${AIDEVOPS_GH_PR_VIEW_CACHE_TTL:-15}"
+	[[ "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]] || return 1
+	return 0
+}
+
+#######################################
+# Build a filesystem-safe key for an exact gh_pr_view argv shape.
+# Args: gh-style argv
+# Stdout: cache key
+#######################################
+_gh_pr_view_snapshot_key() {
+	_gh_pr_list_snapshot_key "$@"
+	return $?
+}
+
+#######################################
+# Resolve the exact-output gh_pr_view cache path for the given argv.
+# Args: gh-style argv
+# Stdout: cache file path
+#######################################
+_gh_pr_view_snapshot_path() {
+	local _dir="${AIDEVOPS_GH_PR_VIEW_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-view-snapshots}"
+	mkdir -p "$_dir" 2>/dev/null || return 1
+	local _key
+	_key="$(_gh_pr_view_snapshot_key "$@")" || return 1
+	printf '%s/argv-%s.out' "$_dir" "$_key"
+	return 0
+}
+
+#######################################
+# Read a cached gh_pr_view exact-output snapshot when present and fresh.
+# Args: gh-style argv
+# Stdout: cached command output
+#######################################
+_gh_pr_view_snapshot_get() {
+	_gh_pr_view_snapshot_enabled || return 1
+	local _ttl="${AIDEVOPS_GH_PR_VIEW_CACHE_TTL:-15}"
+	local _path _now _mtime _age
+	_path="$(_gh_pr_view_snapshot_path "$@")" || { _gh_read_cache_record gh_pr_view_cache bypass; return 1; }
+	[[ -f "$_path" ]] || { _gh_read_cache_record gh_pr_view_cache miss; return 1; }
+	_now=$(date +%s 2>/dev/null || printf '0')
+	_mtime=$(perl -e 'print((stat($ARGV[0]))[9] || 0)' "$_path" 2>/dev/null || printf '0')
+	[[ "$_now" =~ ^[0-9]+$ && "$_mtime" =~ ^[0-9]+$ ]] || return 1
+	_age=$(( _now - _mtime ))
+	[[ "$_age" -ge 0 && "$_age" -le "$_ttl" ]] || { _gh_read_cache_record gh_pr_view_cache stale; return 1; }
+	_gh_read_cache_record gh_pr_view_cache hit
+	printf '%s' "$(<"$_path")"
+	return 0
+}
+
+#######################################
+# Store a successful gh_pr_view exact-output snapshot.
+# Args: $1 = command output, $2.. = gh-style argv
+#######################################
+_gh_pr_view_snapshot_put() {
+	local _body="$1"
+	shift
+	_gh_pr_view_snapshot_enabled || return 0
+	local _path _dir _tmp
+	_path="$(_gh_pr_view_snapshot_path "$@")" || return 0
+	_dir="${_path%/*}"
+	_tmp=$(mktemp "${_dir}/.pr-view-argv.XXXXXX" 2>/dev/null) || return 0
+	printf '%s' "$_body" >"$_tmp" 2>/dev/null || { rm -f "$_tmp"; return 0; }
+	mv "$_tmp" "$_path" 2>/dev/null || rm -f "$_tmp"
+	_gh_read_cache_record gh_pr_view_cache store
 	return 0
 }
 
@@ -389,23 +480,43 @@ gh_pr_list() {
 #######################################
 gh_pr_view() {
 	local _first_num="${1:-}"
+	local _cached_output=""
+	if _cached_output=$(_gh_pr_view_snapshot_get "$@" 2>/dev/null); then
+		printf '%s' "$_cached_output"
+		return 0
+	fi
+	local _out="" _rc=0
 	if _rest_read_first_enabled && _rest_pr_view_can_preserve_args "$@"; then
 		print_info "[INFO] gh-wrapper: REST-first read mode, routing pr view #${_first_num} to REST"
-		_rest_pr_view "$@"
-		return $?
+		_out=$(_rest_pr_view "$@")
+		_rc=$?
+		if [[ $_rc -eq 0 ]]; then
+			_gh_pr_view_snapshot_put "$_out" "$@"
+			printf '%s' "$_out"
+		fi
+		return $_rc
 	fi
 	if _rest_pr_view_can_preserve_args "$@" && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_view; } || _rest_should_fallback; }; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr view #${_first_num} to REST"
-		_rest_pr_view "$@"
-		return $?
+		_out=$(_rest_pr_view "$@")
+		_rc=$?
+		if [[ $_rc -eq 0 ]]; then
+			_gh_pr_view_snapshot_put "$_out" "$@"
+			printf '%s' "$_out"
+		fi
+		return $_rc
 	fi
 	gh_record_call graphql gh_pr_view 2>/dev/null || true
-	_gh_with_timeout read gh pr view "$@"
+	_out=$(_gh_with_timeout read gh pr view "$@")
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr view #${_first_num}"
-		_rest_pr_view "$@"
+		_out=$(_rest_pr_view "$@")
 		rc=$?
+	fi
+	if [[ $rc -eq 0 ]]; then
+		_gh_pr_view_snapshot_put "$_out" "$@"
+		printf '%s' "$_out"
 	fi
 	return $rc
 }

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -60,6 +60,7 @@
 #  31. AIDEVOPS_GH_REST_FIRST_READS routes REST-equivalent reads without a
 #      rate-limit probe while leaving GraphQL-only PR list fields on GraphQL
 #  32. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate REST PR view reads
+#  33. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate GraphQL-only PR view reads
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -72,6 +73,9 @@ set -uo pipefail
 # routing globally, but this test enables it only in the dedicated scenarios.
 unset AIDEVOPS_GH_REST_FIRST_READS
 unset AIDEVOPS_GH_FORCE_REST_READS
+unset AIDEVOPS_GH_PR_VIEW_CACHE
+unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
+unset AIDEVOPS_GH_PR_VIEW_CACHE_TTL
 
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
@@ -1067,6 +1071,23 @@ else
 		"pull_calls=${pr_pull_calls} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 unset AIDEVOPS_GH_PR_LIST_CACHE_DIR AIDEVOPS_GH_PR_LIST_CACHE_TTL
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export AIDEVOPS_GH_PR_VIEW_CACHE=1
+export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="$TMP/pr-view-cache"
+export AIDEVOPS_GH_PR_VIEW_CACHE_TTL=30
+gh_pr_view 123 --repo "owner/repo" --json statusCheckRollup --jq '.number // 0' >/dev/null 2>&1 || true
+gh_pr_view 123 --repo "owner/repo" --json statusCheckRollup --jq '.number // 0' >/dev/null 2>&1 || true
+
+pr_view_calls=$(grep -cE '^pr view 123 --repo owner/repo --json statusCheckRollup' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$pr_view_calls" == "1" ]]; then
+	pass "gh_pr_view exact-output cache coalesces identical GraphQL-only PR reads"
+else
+	fail "gh_pr_view exact-output cache coalesces identical GraphQL-only PR reads" \
+		"pr_view_calls=${pr_view_calls} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIEW_CACHE_TTL
 
 unset AIDEVOPS_GH_REST_FIRST_READS
 


### PR DESCRIPTION
## Summary

Added exact-argv PR view caching for same-cycle pulse reads, cache hit/miss/stale instrumentation, and regression coverage for duplicate GraphQL-only PR view suppression.

## Files Changed

.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-status.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; bash .agents/scripts/tests/test-pulse-wrapper-canary.sh; bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

Resolves #23604


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 5m and 100,695 tokens on this as a headless worker.