### PR TITLE
GH#23605: enforce GitHub secondary cooldown

### DIFF
--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Shared GitHub secondary-rate-limit cooldown guard (GH#23605)
+# =============================================================================
+# Sourced by shared-gh-wrappers.sh. Provides a small shared state file that all
+# gh wrapper call sites can consult before starting noncritical GitHub work.
+
+[[ -n "${_SHARED_GH_SECONDARY_COOLDOWN_LOADED:-}" ]] && return 0
+_SHARED_GH_SECONDARY_COOLDOWN_LOADED=1
+
+: "${AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS:=300}"
+: "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE:=${HOME:-/tmp}/.aidevops/cache/gh-secondary-cooldown.json}"
+
+_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
+
+_gh_secondary_cooldown_now() {
+	date +%s
+	return 0
+}
+
+_gh_secondary_cooldown_file() {
+	printf '%s' "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}"
+	return 0
+}
+
+_gh_secondary_cooldown_detect() {
+	local text="$1"
+	printf '%s' "$text" | grep -Eqi 'secondary rate limit|abuse detection mechanism|You have exceeded a secondary rate limit' || return 1
+	return 0
+}
+
+_gh_secondary_cooldown_request_id() {
+	local text="$1"
+	local request_id=""
+	request_id=$(printf '%s\n' "$text" | sed -nE 's/.*([Xx]-[Gg]it[Hh]ub-[Rr]equest-[Ii]d|request[_ -]?id)[=: ]+([A-Za-z0-9:-]+).*/\2/p' | sed -n '1p')
+	printf '%s' "$request_id"
+	return 0
+}
+
+_gh_secondary_cooldown_write() {
+	local reason="$1"
+	local response_text="${2:-}"
+	local now=""
+	local expires=""
+	local file=""
+	local dir=""
+	local request_id=""
+
+	now="$(_gh_secondary_cooldown_now)"
+	expires=$((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS))
+	file="$(_gh_secondary_cooldown_file)"
+	dir="${file%/*}"
+	request_id="$(_gh_secondary_cooldown_request_id "$response_text")"
+	mkdir -p "$dir" 2>/dev/null || return 1
+
+	if command -v jq >/dev/null 2>&1; then
+		jq -n \
+			--arg reason "$reason" \
+			--arg first_seen "$now" \
+			--arg expires_at "$expires" \
+			--arg request_id "$request_id" \
+			'{reason:$reason, first_seen:($first_seen|tonumber), expires_at:($expires_at|tonumber), last_request_id:$request_id}' >"${file}.tmp" || return 1
+	else
+		printf '{"reason":"%s","first_seen":%s,"expires_at":%s,"last_request_id":"%s"}\n' \
+			"$reason" "$now" "$expires" "$request_id" >"${file}.tmp" || return 1
+	fi
+	mv "${file}.tmp" "$file" || return 1
+	printf '[gh-cooldown] secondary-rate-limit active=true expires_at=%s reason=%s\n' "$expires" "$reason" >&2
+	return 0
+}
+
+_gh_secondary_cooldown_expires_at() {
+	local file=""
+	file="$(_gh_secondary_cooldown_file)"
+	[[ -f "$file" ]] || return 1
+	if command -v jq >/dev/null 2>&1; then
+		jq -r '.expires_at // 0' "$file" 2>/dev/null
+		return 0
+	fi
+	sed -nE 's/.*"expires_at"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$file" | sed -n '1p'
+	return 0
+}
+
+_gh_secondary_cooldown_active() {
+	local expires=""
+	local now=""
+	expires="$(_gh_secondary_cooldown_expires_at 2>/dev/null || true)"
+	[[ "$expires" =~ ^[0-9]+$ ]] || return 1
+	now="$(_gh_secondary_cooldown_now)"
+	[[ "$expires" -gt "$now" ]] || return 1
+	return 0
+}
+
+_gh_secondary_cooldown_log_active_once() {
+	local op_class="$1"
+	local expires=""
+	if [[ "$_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE" -eq 1 ]]; then
+		return 0
+	fi
+	expires="$(_gh_secondary_cooldown_expires_at 2>/dev/null || printf 'unknown')"
+	printf '[gh-cooldown] secondary-rate-limit active=true skip=%s expires_at=%s\n' "$op_class" "$expires" >&2
+	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=1
+	return 0
+}
+
+_gh_secondary_cooldown_preflight() {
+	local op_class="${1:-read}"
+	if ! _gh_secondary_cooldown_active; then
+		return 0
+	fi
+	if [[ "${AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE:-0}" == "1" ]]; then
+		printf '[gh-cooldown] secondary-rate-limit override=true op=%s actor=%s\n' \
+			"$op_class" "${GITHUB_ACTOR:-${USER:-unknown}}" >&2
+		return 0
+	fi
+	_gh_secondary_cooldown_log_active_once "$op_class"
+	return 75
+}
+
+_gh_secondary_cooldown_record_if_needed() {
+	local rc="$1"
+	local response_text="${2:-}"
+	[[ "$rc" -ne 0 ]] || return 0
+	_gh_secondary_cooldown_detect "$response_text" || return 0
+	_gh_secondary_cooldown_write "github-secondary-rate-limit" "$response_text" || true
+	return 0
+}

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -269,7 +269,7 @@ set_issue_status() {
 	# Pass through any extra flags the caller wants to apply in the same edit
 	_flags+=("$@")
 
-	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
+	_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
 	local _rc=$?
 	if [[ $_rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for set_issue_status"

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -82,6 +82,10 @@ if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/github-app-a
 	# shellcheck source=github-app-auth-helper.sh
 	source "$_SHARED_GH_WRAPPERS_DIR/github-app-auth-helper.sh"
 fi
+if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-secondary-cooldown.sh" ]]; then
+	# shellcheck source=shared-gh-secondary-cooldown.sh
+	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-secondary-cooldown.sh"
+fi
 if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh" ]]; then
 	# shellcheck source=shared-gh-wrappers-rest-fallback.sh
 	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh"
@@ -133,6 +137,9 @@ fi
 _gh_with_timeout() {
 	local op_class="${1:-read}"
 	shift
+	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
+		_gh_secondary_cooldown_preflight "$op_class" || return $?
+	fi
 	local secs
 	case "$op_class" in
 	read) secs="${AIDEVOPS_GH_READ_TIMEOUT:-15}" ;;
@@ -140,16 +147,48 @@ _gh_with_timeout() {
 	*) secs=30 ;;
 	esac
 	local cmd="${1:-}"
+	local err_file=""
+	local rc=0
 	if [[ -n "$cmd" ]] && declare -f "$cmd" >/dev/null; then
-		"$@"
-		return $?
+		err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || {
+			"$@"
+			return $?
+		}
+		"$@" 2>"$err_file"
+		rc=$?
+		cat "$err_file" >&2 2>/dev/null || true
+		if command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1; then
+			_gh_secondary_cooldown_record_if_needed "$rc" "$(cat "$err_file" 2>/dev/null || true)"
+		fi
+		rm -f "$err_file"
+		return $rc
 	fi
+	err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || err_file=""
 	if command -v timeout >/dev/null 2>&1; then
-		timeout "$secs" "$@"
-		return $?
+		if [[ -n "$err_file" ]]; then
+			timeout "$secs" "$@" 2>"$err_file"
+			rc=$?
+		else
+			timeout "$secs" "$@"
+			rc=$?
+		fi
+	else
+		if [[ -n "$err_file" ]]; then
+			"$@" 2>"$err_file"
+			rc=$?
+		else
+			"$@"
+			rc=$?
+		fi
 	fi
-	"$@"
-	return $?
+	if [[ -n "$err_file" ]]; then
+		cat "$err_file" >&2 2>/dev/null || true
+		if command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1; then
+			_gh_secondary_cooldown_record_if_needed "$rc" "$(cat "$err_file" 2>/dev/null || true)"
+		fi
+		rm -f "$err_file"
+	fi
+	return $rc
 }
 
 # =============================================================================

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -68,7 +68,7 @@ _resolve_current_gh_login_or_fallback() {
 	local gh_login=""
 	local fallback_login=""
 
-	gh_login=$(gh api user --jq '.login // ""') || gh_login=""
+	gh_login=$(_gh_with_timeout read gh api user --jq '.login // ""') || gh_login=""
 	if [[ "$gh_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
 		printf '%s' "$gh_login"
 		return 0
@@ -104,7 +104,7 @@ _check_health_issue_activity_guard() {
 	[[ -f "$health_issue_file" ]] && return 0
 
 	local guard_pr_count guard_assigned_count guard_worker_count
-	guard_pr_count=$(gh pr list --repo "$repo_slug" --state open \
+	guard_pr_count=$(gh_pr_list --repo "$repo_slug" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
 	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
 		--assignee "$runner_user" --state open \

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23605: GitHub secondary-rate-limit responses create a
+# shared cooldown state and subsequent noncritical gh calls skip without
+# invoking gh until the cooldown expires or an explicit override is present.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_HOME="$(mktemp -d)"
+CALL_LOG="${TMP_HOME}/gh-calls.log"
+ERR_LOG="${TMP_HOME}/stderr.log"
+: >"$CALL_LOG"
+: >"$ERR_LOG"
+
+cleanup() {
+	rm -rf "$TMP_HOME"
+	return 0
+}
+trap cleanup EXIT
+
+export HOME="$TMP_HOME"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${TMP_HOME}/.aidevops/cache/gh-secondary-cooldown.json"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS=600
+
+gh() {
+	printf 'GH %s\n' "$*" >>"$CALL_LOG"
+	if [[ "${GH_SECONDARY_FAIL:-0}" == "1" ]]; then
+		printf '{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}\n' >&2
+		return 1
+	fi
+	printf '{"ok":true}\n'
+	return 0
+}
+
+# shellcheck source=../shared-gh-wrappers.sh
+source "${SCRIPT_DIR}/shared-gh-wrappers.sh"
+
+reset_case() {
+	: >"$CALL_LOG"
+	: >"$ERR_LOG"
+	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
+	unset GH_SECONDARY_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE 2>/dev/null || true
+	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
+	return 0
+}
+
+test_secondary_response_writes_cooldown() {
+	reset_case
+	export GH_SECONDARY_FAIL=1
+	set +e
+	_gh_with_timeout read gh api repos/owner/repo/issues >"${TMP_HOME}/out.json" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL expected wrapped gh rc=1, got %s\n' "$rc"
+		return 1
+	fi
+	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
+		jq -e '.reason == "github-secondary-rate-limit" and (.expires_at > .first_seen)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS secondary response writes cooldown file\n'
+		return 0
+	fi
+	printf 'FAIL cooldown file missing or malformed\n'
+	return 1
+}
+
+test_active_cooldown_skips_without_gh_call() {
+	reset_case
+	_gh_secondary_cooldown_write "test-secondary" "fixture" >/dev/null 2>&1
+	set +e
+	_gh_with_timeout read gh issue list --repo owner/repo >"${TMP_HOME}/skip.json" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -eq 75 ]] && [[ ! -s "$CALL_LOG" ]] && grep -q 'secondary-rate-limit active=true skip=read' "$ERR_LOG"; then
+		printf 'PASS active cooldown skips noncritical gh call\n'
+		return 0
+	fi
+	printf 'FAIL active cooldown did not skip as expected\n'
+	sed 's/^/  /' "$CALL_LOG"
+	sed 's/^/  /' "$ERR_LOG"
+	return 1
+}
+
+test_override_allows_audited_call() {
+	reset_case
+	_gh_secondary_cooldown_write "test-secondary" "fixture" >/dev/null 2>&1
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE=1
+	_gh_with_timeout write gh issue comment 123 --repo owner/repo --body ok >"${TMP_HOME}/override.json" 2>"$ERR_LOG"
+	if grep -q 'GH issue comment 123' "$CALL_LOG" && grep -q 'secondary-rate-limit override=true op=write' "$ERR_LOG"; then
+		printf 'PASS explicit override allows audited critical call\n'
+		return 0
+	fi
+	printf 'FAIL override did not invoke gh with audit log\n'
+	return 1
+}
+
+test_secondary_response_writes_cooldown
+test_active_cooldown_skips_without_gh_call
+test_override_allows_audited_call


### PR DESCRIPTION
## Summary

Added a shared secondary-rate-limit cooldown detector/guard for gh wrapper calls, routed stats dashboard reads through guarded wrappers, and added regression coverage for cooldown creation, skipping, and audited override behavior.

## Files Changed

.agents/scripts/shared-gh-secondary-cooldown.sh,.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-gh-secondary-cooldown.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-secondary-cooldown.sh; bash .agents/scripts/tests/test-rate-limit-release-circuit.sh; bash .agents/scripts/tests/test-dispatch-rate-limit-release-circuit.sh; bash .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh; shellcheck .agents/scripts/shared-gh-secondary-cooldown.sh .agents/scripts/shared-gh-wrappers*.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/stats-health-dashboard*.sh .agents/scripts/tests/test-gh-secondary-cooldown.sh; .agents/scripts/linters-local.sh timed out during shell portability after earlier checks passed/advisory warnings

Resolves #23605


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 8m and 86,768 tokens on this as a headless worker.