### PR TITLE
fix: register manual dispatch worktrees

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -310,6 +310,11 @@ _dsi_create_worktree() {
 			_DSI_WORKTREE_PATH=$(git -C "$repo_path" worktree list --porcelain | awk -v b="$branch" '/^worktree / {p=$0;sub(/^worktree /,"",p)} $0 == "branch refs/heads/" b {print p; exit}')
 			_DSI_WORKTREE_BRANCH="$branch"
 			if [[ -n "$_DSI_WORKTREE_PATH" && -d "$_DSI_WORKTREE_PATH" ]]; then
+				if declare -F register_worktree >/dev/null 2>&1; then
+					register_worktree "$_DSI_WORKTREE_PATH" "$_DSI_WORKTREE_BRANCH" \
+						--task "$issue_number" \
+						--session "dispatch-precreate-${issue_number}" 2>/dev/null || true
+				fi
 				return 0
 			fi
 			_dsi_warn "Worktree path unresolvable after add (attempt ${attempt}/${max_attempts}, branch=${branch})"

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -545,6 +545,17 @@ test_create_worktree_uses_target_repo_path() {
 	return 0
 }
 
+test_create_worktree_registers_dispatch_owner() {
+	local failed=1
+	if grep -Fq "register_worktree \"\$_DSI_WORKTREE_PATH\" \"\$_DSI_WORKTREE_BRANCH\"" "$HELPER_PATH" &&
+		grep -Fq -- "--task \"\$issue_number\"" "$HELPER_PATH" &&
+		grep -Fq -- "--session \"dispatch-precreate-\${issue_number}\"" "$HELPER_PATH"; then
+		failed=0
+	fi
+	print_result "worktree creation registers dispatch owner metadata" "$failed"
+	return 0
+}
+
 
 test_readiness_accepts_worker_started_marker() {
 	MOCK_LEDGER_RECORD=""
@@ -699,6 +710,7 @@ _run_tests() {
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract
 	test_create_worktree_uses_target_repo_path
+	test_create_worktree_registers_dispatch_owner
 	test_readiness_accepts_worker_started_marker
 	test_readiness_rejects_live_child_without_ready_signal
 	test_readiness_rejects_ledger_without_worker_started


### PR DESCRIPTION
## Summary
- Register manual single-issue dispatch worktrees with issue task metadata and dispatch-precreate session ownership.
- Add a regression check so future dispatch helper edits keep owner-transfer metadata wired.

## Verification
- `bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `.agents/scripts/linters-local.sh` timed out during later portability checks after passing targeted gates; surfaced only pre-existing/advisory markdown/ratchet/layout warnings before timeout.

Resolves #23636

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.51 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 32m and 70,853 tokens on this with the user in an interactive session.
