### PR TITLE
Fix supply-chain scanner self-reference false positives

### DIFF
--- a/.agents/scripts/supply-chain-advisory-helper.sh
+++ b/.agents/scripts/supply-chain-advisory-helper.sh
@@ -22,6 +22,20 @@ readonly IOC_PATTERN='@tanstack/setup|github:tanstack/router#79ac49eedf774dd4b0c
 readonly AFFECTED_PATTERN='(@tanstack/(router-utils|router-core|arktype-adapter|eslint-plugin-router|eslint-plugin-start|history|nitro-v2-vite-plugin|react-router|react-router-devtools|react-router-ssr-query|react-start|react-start-client|react-start-rsc|react-start-server|router-cli|router-devtools|router-devtools-core|router-generator|router-plugin|router-ssr-query-core|router-vite-plugin|solid-router|solid-router-devtools|solid-router-ssr-query|solid-start|solid-start-client|solid-start-server|start-client-core|start-fn-stubs|start-plugin-core|start-server-core|start-static-server-functions|start-storage-context|valibot-adapter|virtual-file-routes|vue-router|vue-router-devtools|vue-router-ssr-query|vue-start|vue-start-client|vue-start-server|zod-adapter)|@opensearch-project/opensearch|@mistralai/mistralai|safe-action|cmux-agent-mcp|nextmove-mcp|git-git-git|git-branch-selector)@?(1\.161\.11|1\.161\.14|1\.169\.5|1\.169\.8|1\.166\.12|1\.166\.15|1\.161\.9|1\.161\.12|0\.0\.4|0\.0\.7|1\.154\.12|1\.154\.15|1\.166\.16|1\.166\.19|1\.166\.18|1\.167\.68|1\.167\.71|1\.166\.51|1\.166\.54|0\.0\.47|0\.0\.50|1\.166\.55|1\.166\.58|1\.166\.46|1\.166\.49|1\.167\.6|1\.167\.9|1\.166\.45|1\.166\.48|1\.167\.38|1\.167\.41|1\.168\.3|1\.168\.6|1\.166\.53|1\.166\.56|1\.167\.65|1\.167\.33|1\.167\.36|1\.166\.44|1\.166\.47|1\.166\.38|1\.166\.41|1\.161\.10|1\.161\.13|1\.167\.61|1\.167\.64|1\.166\.50|1\.166\.57|3\.6\.2|2\.2\.3|2\.2\.4|0\.8\.3|0\.8\.4|0\.1\.[3-8]|1\.0\.(8|9|10|12)|1\.3\.(3|4|5|7))([^0-9]|$)'
 SCAN_PATH_FINDINGS=0
 
+is_known_safe_ioc_self_reference() {
+	local hit_line="$1"
+	local hit_path="${hit_line%%:*}"
+
+	case "$hit_path" in
+	*/.agents/reference/npm-supply-chain-response.md | */.agents/scripts/supply-chain-advisory-helper.sh)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 print_usage() {
 	cat <<EOF
 Usage: $(basename "$0") <command> [path...]
@@ -96,6 +110,8 @@ collect_default_paths() {
 scan_path() {
 	local target_path="$1"
 	local findings=0
+	local ioc_findings=0
+	local ioc_self_references=0
 	local rg_status=0
 	local scan_error=0
 	SCAN_PATH_FINDINGS=0
@@ -106,8 +122,24 @@ scan_path() {
 
 	echo -e "${BLUE}Scanning:${NC} ${target_path}"
 	if command -v rg >/dev/null 2>&1; then
-		if rg -n --hidden --glob '!node_modules/.cache/**' --glob '!dist/**' --glob '!build/**' --glob '!.git/**' "$IOC_PATTERN" "$target_path"; then
-			findings=$((findings + 1))
+		local ioc_output
+		if ioc_output=$(rg -n --hidden --glob '!node_modules/.cache/**' --glob '!dist/**' --glob '!build/**' --glob '!.git/**' "$IOC_PATTERN" "$target_path"); then
+			local hit_line
+			while IFS= read -r hit_line; do
+				[[ -z "$hit_line" ]] && continue
+				if is_known_safe_ioc_self_reference "$hit_line"; then
+					ioc_self_references=$((ioc_self_references + 1))
+					continue
+				fi
+				printf '%s\n' "$hit_line"
+				ioc_findings=$((ioc_findings + 1))
+			done <<<"$ioc_output"
+			if [[ "$ioc_findings" -gt 0 ]]; then
+				findings=$((findings + 1))
+			fi
+			if [[ "$ioc_self_references" -gt 0 ]]; then
+				echo -e "${YELLOW}[INFO]${NC} Ignored ${ioc_self_references} known-safe scanner self-reference IOC match(es)."
+			fi
 		else
 			rg_status=$?
 			if [[ "$rg_status" -gt 1 ]]; then

--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#23640.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../supply-chain-advisory-helper.sh"
+
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+make_tmpdir() {
+	local tmpdir
+	tmpdir=$(mktemp -d) || return 1
+	printf '%s\n' "$tmpdir"
+	return 0
+}
+
+test_self_reference_only_scan_succeeds() {
+	local tmpdir
+	tmpdir=$(make_tmpdir) || {
+		print_result "self-reference-only scan exits cleanly" 1 "mktemp failed"
+		return 0
+	}
+
+	mkdir -p "${tmpdir}/.agents/reference" "${tmpdir}/.agents/scripts" || return 1
+	printf '%s\n' 'Documented IOC: router_''init.js and gh-token-''monitor.' \
+		>"${tmpdir}/.agents/reference/npm-supply-chain-response.md"
+	printf '%s\n' 'readonly IOC_PATTERN="router_''init.js|gh-token-''monitor"' \
+		>"${tmpdir}/.agents/scripts/supply-chain-advisory-helper.sh"
+
+	local output
+	local status=0
+	output=$(HOME="$tmpdir" bash "$HELPER_SCRIPT" scan "$tmpdir" 2>&1) || status=$?
+	if [[ "$status" -eq 0 ]] \
+		&& [[ "$output" == *"known-safe scanner self-reference"* ]] \
+		&& [[ "$output" != *"Potential supply-chain compromise indicators found"* ]]; then
+		print_result "self-reference-only scan exits cleanly" 0
+	else
+		print_result "self-reference-only scan exits cleanly" 1 "status=${status} output=${output}"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_non_self_ioc_scan_fails() {
+	local tmpdir
+	tmpdir=$(make_tmpdir) || {
+		print_result "non-self IOC scan still fails" 1 "mktemp failed"
+		return 0
+	}
+
+	mkdir -p "${tmpdir}/docs" || return 1
+	printf '%s\n' 'Suspicious artifact: router_''init.js' >"${tmpdir}/docs/evidence.md"
+
+	local output
+	local status=0
+	output=$(HOME="$tmpdir" bash "$HELPER_SCRIPT" scan "$tmpdir" 2>&1) || status=$?
+	if [[ "$status" -eq 1 ]] \
+		&& [[ "$output" == *"docs/evidence.md"* ]] \
+		&& [[ "$output" == *"Potential supply-chain compromise indicators found"* ]]; then
+		print_result "non-self IOC scan still fails" 0
+	else
+		print_result "non-self IOC scan still fails" 1 "status=${status} output=${output}"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
+main() {
+	test_self_reference_only_scan_succeeds
+	test_non_self_ioc_scan_fails
+
+	printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Classifies aidevops scanner/advisory IOC matches as known-safe self-references instead of compromise findings.
- Keeps non-self IOC matches failing with the existing compromise warning.
- Adds regression coverage for GH#23640 self-reference-only and real IOC cases.

Resolves #23640

## Verification
- `bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh`
- `bash .agents/scripts/supply-chain-advisory-helper.sh scan <aidevops checkout>`
- `bash -n .agents/scripts/supply-chain-advisory-helper.sh .agents/scripts/tests/test-supply-chain-advisory-helper.sh`
- `shellcheck .agents/scripts/supply-chain-advisory-helper.sh .agents/scripts/tests/test-supply-chain-advisory-helper.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.52 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 22m and 106,989 tokens on this with the user in an interactive session.
