### PR TITLE
fix: skip pulse recovery comments on closed issues

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -640,6 +640,40 @@ MARKER_EOF
 }
 
 #######################################
+# Verify a pulse cleanup issue target is still open before writing to it.
+#
+# Orphan worktree cleanup can run long after the original issue completed. In
+# that state there is no dispatch dedup guard to clear, and posting recovery
+# audit comments only creates notification noise on closed work. Fail closed on
+# lookup errors: cleanup still removes the local orphan, but skips GitHub writes.
+#
+# Args:
+#   $1 - issue_number: GitHub issue number
+#   $2 - repo_slug:    owner/repo slug
+#   $3 - context:      log context for the skipped write
+# Returns: 0 if issue is open, 1 otherwise
+#######################################
+_pulse_cleanup_issue_open_for_write() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local context="${3:-pulse cleanup write}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	local issue_state=""
+	issue_state=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state --jq '.state // ""' 2>/dev/null) || issue_state=""
+	if [[ "$issue_state" != "OPEN" ]]; then
+		echo "[pulse-wrapper] ${context} skipped for #${issue_number} (${repo_slug}): issue state=${issue_state:-unknown}; no closed-issue recovery comment posted" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+#######################################
 # Record crash classification for an orphaned worker worktree.
 #
 # Extracts the issue number from the branch name (pattern: gh[-]?NNN),
@@ -684,6 +718,9 @@ _record_orphan_crash_classification() {
 	# Since GH#19042, new feature/auto-* branches include gh<N>, but
 	# legacy ones (pre-fix) still lack it — skip those gracefully.
 	if [[ -z "$orphan_issue_num" ]]; then
+		return 0
+	fi
+	if ! _pulse_cleanup_issue_open_for_write "$orphan_issue_num" "$repo_slug_age" "Orphan cleanup"; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -138,11 +138,73 @@ gh() {
 	local subcommand="${1:-}"
 	local action="${2:-}"
 	printf '%s\n' "$*" >>"${GH_LOG:?}"
+	if [[ "$subcommand" == "issue" && "$action" == "view" ]]; then
+		printf '%s\n' "${GH_ISSUE_STATE:-OPEN}"
+		return 0
+	fi
 	if [[ "$subcommand" == "pr" && "$action" == "list" ]]; then
 		printf '%s\n' "${GH_MERGED_PR:-3964}"
 		return 0
 	fi
 	return 1
+}
+
+gh_issue_comment() {
+	printf 'gh_issue_comment %s\n' "$*" >>"${GH_LOG:?}"
+	return 0
+}
+
+recover_failed_launch_state() {
+	printf 'recover_failed_launch_state %s\n' "$*" >>"${GH_LOG:?}"
+	return 0
+}
+
+test_orphan_crash_skips_closed_issue_comment() {
+	local gh_log="${TEST_ROOT}/gh-closed-orphan.log"
+	local old_state="${GH_ISSUE_STATE:-}"
+	: >"$gh_log"
+	LOGFILE="${TEST_ROOT}/pulse-closed-orphan.log"
+	GH_LOG="$gh_log"
+	GH_ISSUE_STATE="CLOSED"
+	export GH_LOG GH_ISSUE_STATE
+
+	_record_orphan_crash_classification "feature/auto-20260515-123456-gh23379" 0 "owner/repo"
+
+	grep -q 'issue view 23379 --repo owner/repo' "$gh_log" || fail "closed orphan did not check issue state"
+	if grep -q 'gh_issue_comment\|recover_failed_launch_state\|issues/23379/comments' "$gh_log"; then
+		fail "closed orphan posted or recovered issue state"
+	fi
+	grep -q 'Orphan cleanup skipped for #23379 (owner/repo): issue state=CLOSED' "$LOGFILE" || fail "closed orphan skip was not audited"
+	if [[ -n "$old_state" ]]; then
+		GH_ISSUE_STATE="$old_state"
+	else
+		unset GH_ISSUE_STATE
+	fi
+	pass "orphan cleanup skips recovery comments on closed issues"
+	return 0
+}
+
+test_orphan_crash_keeps_open_issue_recovery() {
+	local gh_log="${TEST_ROOT}/gh-open-orphan.log"
+	local old_state="${GH_ISSUE_STATE:-}"
+	: >"$gh_log"
+	LOGFILE="${TEST_ROOT}/pulse-open-orphan.log"
+	GH_LOG="$gh_log"
+	GH_ISSUE_STATE="OPEN"
+	export GH_LOG GH_ISSUE_STATE
+
+	_record_orphan_crash_classification "feature/auto-20260515-123456-gh23380" 0 "owner/repo"
+
+	grep -q 'issue view 23380 --repo owner/repo' "$gh_log" || fail "open orphan did not check issue state"
+	grep -q 'recover_failed_launch_state 23380 owner/repo premature_exit no_work' "$gh_log" || fail "open orphan did not recover launch state"
+	grep -q 'gh_issue_comment 23380 --repo owner/repo --body' "$gh_log" || fail "open orphan did not post recovery comment"
+	if [[ -n "$old_state" ]]; then
+		GH_ISSUE_STATE="$old_state"
+	else
+		unset GH_ISSUE_STATE
+	fi
+	pass "orphan cleanup preserves recovery comments on open issues"
+	return 0
 }
 
 test_zombie_reaper_requires_ledger_repo() {
@@ -205,6 +267,8 @@ test_zombie_reaper_uses_ledger_repo_and_pid() {
 
 test_current_cwd_skip
 test_orphan_removal_unregisters
+test_orphan_crash_skips_closed_issue_comment
+test_orphan_crash_keeps_open_issue_recovery
 test_zombie_reaper_requires_ledger_repo
 test_zombie_reaper_uses_ledger_repo_and_pid
 


### PR DESCRIPTION
## Summary

- Prevent pulse orphan cleanup from posting recovery/audit comments to issues that are already closed.
- Keep the open-issue recovery path intact so stale dispatch dedup guards are still cleared for active work.
- Add regression coverage for both closed and open orphan cleanup targets.

## Root cause

Pulse orphan cleanup extracted an issue number from stale worker worktree branches and unconditionally posted the "Worker failed: orphan worktree detected" audit comment after local cleanup. Issue #23379 was already closed, so the comment was unnecessary: there was no active dispatch dedup guard to clear, and the write only triggered notifications.

## Testing

- `.agents/scripts/tests/test-pulse-cleanup-unregister.sh`
- `shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-unregister.sh`
- `bash -n .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-unregister.sh`

## Notes

For #23379

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.53 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 45m and 139,671 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent cleanup operations from posting recovery information to closed GitHub issues. Closed issues are now safely skipped during orphan-crash recovery.

* **Tests**
  * Added regression tests to validate orphan-crash handling behavior with both open and closed GitHub issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/aidevops/pull/23642)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->