### PR TITLE
GH#23645: fix: preserve FOSS label arrays during dispatch

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1209,7 +1209,7 @@ dispatch_foss_workers() {
 
 	[[ "$available" =~ ^[0-9]+$ ]] || available=0
 
-	while IFS='|' read -r foss_slug foss_path; do
+	while IFS=$'\t' read -r foss_slug foss_path disclosure labels_filter_json; do
 		[[ -n "$foss_slug" && -n "$foss_path" ]] || continue
 		[[ "$available" -gt 0 && "$foss_count" -lt "$foss_max" ]] || break
 
@@ -1217,13 +1217,13 @@ dispatch_foss_workers() {
 		"${SCRIPT_DIR}/foss-contribution-helper.sh" check "$foss_slug" >/dev/null || continue
 
 		# Scan for a suitable issue
-		local labels_filter foss_issue foss_issue_num foss_issue_title
+		local foss_issue foss_issue_num foss_issue_title
 		local foss_label_candidates=()
 		local foss_label
-		labels_filter=$(jq -r --arg slug "$foss_slug" \
-			'.initialized_repos[] | select(.slug == $slug) | .foss_config.labels_filter // ["help wanted","good first issue","bug"] | join(",")' \
-			"$repos_json" 2>/dev/null || echo "help wanted")
-		IFS=',' read -r -a foss_label_candidates <<<"$labels_filter"
+		while IFS= read -r foss_label; do
+			[[ -n "$foss_label" ]] || continue
+			foss_label_candidates+=("$foss_label")
+		done < <(jq -r '.[]' <<<"$labels_filter_json" 2>/dev/null || printf '%s\n' 'help wanted' 'good first issue' 'bug')
 		for foss_label in "${foss_label_candidates[@]}"; do
 			[[ -n "$foss_label" ]] || continue
 			foss_issue=$(gh_issue_list --repo "$foss_slug" --state open \
@@ -1251,10 +1251,6 @@ dispatch_foss_workers() {
 		foss_session_keys_seen="${foss_session_keys_seen}${foss_session_key}"$'\n'
 
 		local disclosure_flag=""
-		local disclosure
-		disclosure=$(jq -r --arg slug "$foss_slug" \
-			'.initialized_repos[] | select(.slug == $slug) | .foss_config.disclosure // true' \
-			"$repos_json" 2>/dev/null || echo "true")
 		[[ "$disclosure" == "true" ]] && disclosure_flag=" Include AI disclosure note in the PR."
 		local foss_path_expanded
 		foss_path_expanded=$(_expand_foss_repo_path "$foss_path")
@@ -1270,7 +1266,15 @@ dispatch_foss_workers() {
 
 		foss_count=$((foss_count + 1))
 		available=$((available - 1))
-	done < <(jq -r '.initialized_repos[] | select(.foss == true and (.foss_config.blocklist // false) == false) | "\(.slug)|\(.path)"' \
+	done < <(jq -r '.initialized_repos[]
+		| select(.foss == true and (.foss_config.blocklist // false) == false)
+		| [
+			.slug,
+			.path,
+			((.foss_config.disclosure // true) | tostring),
+			((.foss_config.labels_filter // ["help wanted","good first issue","bug"]) | @json)
+		]
+		| @tsv' \
 		"$repos_json" 2>/dev/null || true)
 
 	printf '%d\n' "$available"

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -51,7 +51,7 @@ write_repos_json() {
       "path": "~/Git/project",
       "foss": true,
       "foss_config": {
-        "labels_filter": ["help wanted", "bug"],
+        "labels_filter": ["help wanted", "needs, triage", "bug"],
         "disclosure": false
       }
     }
@@ -79,6 +79,9 @@ gh_issue_list() {
 	case "$label" in
 	"help wanted")
 		printf '%s\n' "${GH_ISSUE_LIST_OUTPUT_HELP_WANTED-${GH_ISSUE_LIST_OUTPUT:-}}"
+		;;
+	"needs, triage")
+		printf '%s\n' "${GH_ISSUE_LIST_OUTPUT_NEEDS_TRIAGE-${GH_ISSUE_LIST_OUTPUT:-}}"
 		;;
 	bug)
 		printf '%s\n' "${GH_ISSUE_LIST_OUTPUT_BUG-${GH_ISSUE_LIST_OUTPUT:-}}"
@@ -141,6 +144,7 @@ fi
 : >"$GH_ISSUE_LIST_LABEL_LOG"
 : >"$HEADLESS_INVOCATION_LOG"
 GH_ISSUE_LIST_OUTPUT_HELP_WANTED=''
+GH_ISSUE_LIST_OUTPUT_NEEDS_TRIAGE=''
 GH_ISSUE_LIST_OUTPUT_BUG='88|Fallback label issue'
 fallback_output="${TEST_TMP}/fallback.out"
 FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json" >"$fallback_output" || fail "label fallback dispatch failed"
@@ -149,9 +153,13 @@ available_after_fallback="$(<"$fallback_output")"
 wait
 launch_count_fallback="$(wc -l <"$HEADLESS_INVOCATION_LOG" | tr -d ' ')"
 [[ "$launch_count_fallback" == "1" ]] || fail "expected one fallback launch, got ${launch_count_fallback}"
-label_attempts="$(tr '\n' ',' <"$GH_ISSUE_LIST_LABEL_LOG")"
-label_attempts="${label_attempts%,}"
-[[ "$label_attempts" == "help wanted,bug" ]] || fail "label fallback did not try configured labels in order"
+expected_label_attempts="${TEST_TMP}/expected-labels.log"
+cat >"$expected_label_attempts" <<'EOF'
+help wanted
+needs, triage
+bug
+EOF
+diff -u "$expected_label_attempts" "$GH_ISSUE_LIST_LABEL_LOG" || fail "label fallback did not try configured labels in order"
 
 : >"$HEADLESS_INVOCATION_LOG"
 tilde_output="${TEST_TMP}/tilde.out"


### PR DESCRIPTION
## Summary

Consolidated FOSS repo config loading into the dispatch query and parses labels from JSON so labels containing commas remain intact.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

Resolves #23645


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 2m and 56,513 tokens on this as a headless worker.