### PR TITLE
GH#23647: harden supply-chain advisory scan filtering

### DIFF
--- a/.agents/scripts/supply-chain-advisory-helper.sh
+++ b/.agents/scripts/supply-chain-advisory-helper.sh
@@ -27,7 +27,7 @@ is_known_safe_ioc_self_reference() {
 	local hit_path="${hit_line%%:*}"
 
 	case "$hit_path" in
-	*/.agents/reference/npm-supply-chain-response.md | */.agents/scripts/supply-chain-advisory-helper.sh)
+	*.agents/reference/npm-supply-chain-response.md | *.agents/scripts/supply-chain-advisory-helper.sh)
 		return 0
 		;;
 	*)
@@ -123,7 +123,9 @@ scan_path() {
 	echo -e "${BLUE}Scanning:${NC} ${target_path}"
 	if command -v rg >/dev/null 2>&1; then
 		local ioc_output
-		if ioc_output=$(rg -n --hidden --glob '!node_modules/.cache/**' --glob '!dist/**' --glob '!build/**' --glob '!.git/**' "$IOC_PATTERN" "$target_path"); then
+		rg_status=0
+		ioc_output=$(rg -nH --hidden --glob '!node_modules/.cache/**' --glob '!dist/**' --glob '!build/**' --glob '!.git/**' "$IOC_PATTERN" "$target_path") || rg_status=$?
+		if [[ "$rg_status" -eq 0 ]]; then
 			local hit_line
 			while IFS= read -r hit_line; do
 				[[ -z "$hit_line" ]] && continue
@@ -140,21 +142,19 @@ scan_path() {
 			if [[ "$ioc_self_references" -gt 0 ]]; then
 				echo -e "${YELLOW}[INFO]${NC} Ignored ${ioc_self_references} known-safe scanner self-reference IOC match(es)."
 			fi
-		else
-			rg_status=$?
-			if [[ "$rg_status" -gt 1 ]]; then
-				echo -e "${YELLOW}[WARN]${NC} ripgrep IOC scan failed for ${target_path} (exit ${rg_status})."
-				scan_error="$rg_status"
-			fi
+		elif [[ "$rg_status" -gt 1 ]]; then
+			echo -e "${YELLOW}[WARN]${NC} ripgrep IOC scan failed for ${target_path} (exit ${rg_status})."
+			scan_error="$rg_status"
 		fi
-		if rg -n --hidden --glob '!node_modules/**' --glob '!.git/**' --glob 'pnpm-lock.yaml' --glob 'package-lock.json' --glob 'yarn.lock' --glob 'bun.lock*' --glob 'package.json' "$AFFECTED_PATTERN" "$target_path"; then
+		local affected_output
+		rg_status=0
+		affected_output=$(rg -nH --hidden --glob '!node_modules/**' --glob '!.git/**' --glob 'pnpm-lock.yaml' --glob 'package-lock.json' --glob 'yarn.lock' --glob 'bun.lock*' --glob 'package.json' "$AFFECTED_PATTERN" "$target_path") || rg_status=$?
+		if [[ "$rg_status" -eq 0 ]]; then
+			printf '%s\n' "$affected_output"
 			findings=$((findings + 1))
-		else
-			rg_status=$?
-			if [[ "$rg_status" -gt 1 ]]; then
-				echo -e "${YELLOW}[WARN]${NC} ripgrep affected-package scan failed for ${target_path} (exit ${rg_status})."
-				scan_error="$rg_status"
-			fi
+		elif [[ "$rg_status" -gt 1 ]]; then
+			echo -e "${YELLOW}[WARN]${NC} ripgrep affected-package scan failed for ${target_path} (exit ${rg_status})."
+			scan_error="$rg_status"
 		fi
 	else
 		echo -e "${YELLOW}[WARN]${NC} ripgrep not installed; install rg for supply-chain scans."

--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -64,6 +64,58 @@ test_self_reference_only_scan_succeeds() {
 	return 0
 }
 
+test_relative_self_reference_only_scan_succeeds() {
+	local tmpdir
+	tmpdir=$(make_tmpdir) || {
+		print_result "relative self-reference-only scan exits cleanly" 1 "mktemp failed"
+		return 0
+	}
+
+	mkdir -p "${tmpdir}/.agents/reference" "${tmpdir}/.agents/scripts" || return 1
+	printf '%s\n' 'Documented IOC: router_''init.js and gh-token-''monitor.' \
+		>"${tmpdir}/.agents/reference/npm-supply-chain-response.md"
+	printf '%s\n' 'readonly IOC_PATTERN="router_''init.js|gh-token-''monitor"' \
+		>"${tmpdir}/.agents/scripts/supply-chain-advisory-helper.sh"
+
+	local output
+	local status=0
+	output=$(cd "$tmpdir" && HOME="$tmpdir" bash "$HELPER_SCRIPT" scan .agents 2>&1) || status=$?
+	if [[ "$status" -eq 0 ]] \
+		&& [[ "$output" == *"known-safe scanner self-reference"* ]] \
+		&& [[ "$output" != *"Potential supply-chain compromise indicators found"* ]]; then
+		print_result "relative self-reference-only scan exits cleanly" 0
+	else
+		print_result "relative self-reference-only scan exits cleanly" 1 "status=${status} output=${output}"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_single_file_self_reference_only_scan_succeeds() {
+	local tmpdir
+	tmpdir=$(make_tmpdir) || {
+		print_result "single-file self-reference-only scan exits cleanly" 1 "mktemp failed"
+		return 0
+	}
+
+	mkdir -p "${tmpdir}/.agents/scripts" || return 1
+	printf '%s\n' 'readonly IOC_PATTERN="router_''init.js|gh-token-''monitor"' \
+		>"${tmpdir}/.agents/scripts/supply-chain-advisory-helper.sh"
+
+	local output
+	local status=0
+	output=$(HOME="$tmpdir" bash "$HELPER_SCRIPT" scan "${tmpdir}/.agents/scripts/supply-chain-advisory-helper.sh" 2>&1) || status=$?
+	if [[ "$status" -eq 0 ]] \
+		&& [[ "$output" == *"known-safe scanner self-reference"* ]] \
+		&& [[ "$output" != *"Potential supply-chain compromise indicators found"* ]]; then
+		print_result "single-file self-reference-only scan exits cleanly" 0
+	else
+		print_result "single-file self-reference-only scan exits cleanly" 1 "status=${status} output=${output}"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
 test_non_self_ioc_scan_fails() {
 	local tmpdir
 	tmpdir=$(make_tmpdir) || {
@@ -90,6 +142,8 @@ test_non_self_ioc_scan_fails() {
 
 main() {
 	test_self_reference_only_scan_succeeds
+	test_relative_self_reference_only_scan_succeeds
+	test_single_file_self_reference_only_scan_succeeds
 	test_non_self_ioc_scan_fails
 
 	printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Hardened the supply-chain advisory scanner so known-safe self-reference filtering works for relative .agents paths and single-file ripgrep scans, with regression coverage for both cases.

## Files Changed

.agents/scripts/supply-chain-advisory-helper.sh,.agents/scripts/tests/test-supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh; shellcheck .agents/scripts/supply-chain-advisory-helper.sh .agents/scripts/tests/test-supply-chain-advisory-helper.sh

Resolves #23647


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 3m and 54,392 tokens on this as a headless worker.