### PR TITLE
fix(GH#23604): extend pulse PR metadata cache

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1799,17 +1799,23 @@ main() {
 		echo "[pulse-wrapper] REST-first read routing enabled for REST-equivalent gh issue/pr list/view calls (GH#22525)" >>"$LOGFILE"
 	fi
 
-	# GH#23433: reuse REST PR view metadata within this pulse cycle. The wrapper
-	# cache is opt-in so standalone tests/debugging keep exact read semantics, but
-	# pulse can avoid re-fetching the same /pulls/{N} object across merge gates.
+	# GH#23433/GH#23604: reuse PR metadata within this pulse cycle. The wrapper
+	# caches are opt-in so standalone tests/debugging keep exact read semantics,
+	# but pulse can avoid re-fetching the same PR list/view data across gates.
+	local _pulse_pr_cache_cleanup_scope=0
 	unset AIDEVOPS_GH_PR_VIEW_CACHE
 	unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
+	unset AIDEVOPS_GH_PR_VIEW_CACHE_TTL
+	unset AIDEVOPS_GH_PR_LIST_CACHE_DIR
+	unset AIDEVOPS_GH_PR_LIST_CACHE_TTL
 	if [[ "${AIDEVOPS_PULSE_PR_VIEW_CACHE:-1}" == "1" ]]; then
 		export AIDEVOPS_GH_PR_VIEW_CACHE=1
 		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-view-cache-${$}"
+		export AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}"
 		_save_cleanup_scope
 		trap '_run_cleanups' RETURN
 		push_cleanup 'release_instance_lock'
+		_pulse_pr_cache_cleanup_scope=1
 		push_cleanup "rm -rf \"${AIDEVOPS_GH_PR_VIEW_CACHE_DIR}\""
 		if ! rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
 			printf '[pulse-wrapper] Failed to reset REST PR view cache directory: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
@@ -1817,7 +1823,26 @@ main() {
 		if ! mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
 			printf '[pulse-wrapper] Failed to create REST PR view cache directory: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
 		fi
-		echo "[pulse-wrapper] Per-cycle REST PR view cache enabled for duplicate repo#PR reads (GH#23433)" >>"$LOGFILE"
+		echo "[pulse-wrapper] Per-cycle PR view cache enabled for duplicate repo#PR reads ttl=${AIDEVOPS_GH_PR_VIEW_CACHE_TTL}s (GH#23433/GH#23604)" >>"$LOGFILE"
+	fi
+
+	if [[ "${AIDEVOPS_PULSE_PR_LIST_CACHE:-1}" == "1" ]]; then
+		export AIDEVOPS_GH_PR_LIST_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-list-cache-${$}"
+		export AIDEVOPS_GH_PR_LIST_CACHE_TTL="${AIDEVOPS_PULSE_PR_LIST_CACHE_TTL:-3600}"
+		if [[ "$_pulse_pr_cache_cleanup_scope" -eq 0 ]]; then
+			_save_cleanup_scope
+			trap '_run_cleanups' RETURN
+			push_cleanup 'release_instance_lock'
+			_pulse_pr_cache_cleanup_scope=1
+		fi
+		push_cleanup "rm -rf \"${AIDEVOPS_GH_PR_LIST_CACHE_DIR}\""
+		if ! rm -rf "$AIDEVOPS_GH_PR_LIST_CACHE_DIR"; then
+			printf '[pulse-wrapper] Failed to reset PR list cache directory: %s\n' "$AIDEVOPS_GH_PR_LIST_CACHE_DIR" >&2
+		fi
+		if ! mkdir -p "$AIDEVOPS_GH_PR_LIST_CACHE_DIR"; then
+			printf '[pulse-wrapper] Failed to create PR list cache directory: %s\n' "$AIDEVOPS_GH_PR_LIST_CACHE_DIR" >&2
+		fi
+		echo "[pulse-wrapper] Per-cycle PR list cache enabled for duplicate repo open-PR reads ttl=${AIDEVOPS_GH_PR_LIST_CACHE_TTL}s (GH#23604)" >>"$LOGFILE"
 	fi
 
 	# --canary short-circuit (GH#18790): sourcing, _pulse_handle_self_check,

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -187,11 +187,39 @@ test_canary_short_circuit_after_lock() {
 	return 0
 }
 
+# Test 5: Static check — pulse enables per-cycle PR list and view cache TTLs.
+#
+# GH#23604: default 15-second wrapper cache windows were too short for a full
+# pulse pass, so late-cycle merge/dispatch gates repeated PR list/view calls.
+# Pulse must set per-cycle cache dirs and longer TTLs before the canary
+# short-circuit so the real cycle inherits them.
+test_pr_cache_ttls_are_per_cycle() {
+	local missing=""
+	if ! grep -q 'AIDEVOPS_GH_PR_VIEW_CACHE_TTL=.*AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600' "$WRAPPER_SCRIPT"; then
+		missing="${missing} view-ttl"
+	fi
+	if ! grep -q 'AIDEVOPS_GH_PR_LIST_CACHE_TTL=.*AIDEVOPS_PULSE_PR_LIST_CACHE_TTL:-3600' "$WRAPPER_SCRIPT"; then
+		missing="${missing} list-ttl"
+	fi
+	if ! grep -q 'AIDEVOPS_GH_PR_LIST_CACHE_DIR=.*aidevops-pulse-pr-list-cache' "$WRAPPER_SCRIPT"; then
+		missing="${missing} list-cache-dir"
+	fi
+
+	if [[ -z "$missing" ]]; then
+		print_result "pulse configures per-cycle PR list/view cache TTLs" 0
+		return 0
+	fi
+	print_result "pulse configures per-cycle PR list/view cache TTLs" 1 \
+		"Missing pulse cache wiring:${missing}"
+	return 0
+}
+
 main_test() {
 	test_canary_exits_zero
 	test_canary_prints_checkpoint
 	test_canary_function_exists
 	test_canary_short_circuit_after_lock
+	test_pr_cache_ttls_are_per_cycle
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Extends pulse PR view cache TTL to a full per-cycle window so late gates can reuse earlier PR metadata.
- Enables a per-cycle PR list cache directory/TTL for duplicate open PR list reads during pulse.
- Adds a pulse canary regression check for the per-cycle PR list/view cache wiring.

Resolves #23604

## Verification

- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh` — 5/5 passed
- `bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh` — 46/46 passed
- pre-commit ShellCheck/ratchet validation passed during commit

## Notes

- Cache directories are PID-scoped under `${TMPDIR:-/tmp}` and registered for pulse cleanup, so separate pulse processes cannot share stale cache files.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 7d 23h and 6,379,475 tokens on this with the user in an interactive session.
