### PR TITLE
GH#23651: harden GitHub cooldown state writes

### DIFF
--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -11,7 +11,8 @@
 _SHARED_GH_SECONDARY_COOLDOWN_LOADED=1
 
 : "${AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS:=300}"
-: "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE:=${HOME:-/tmp}/.aidevops/cache/gh-secondary-cooldown.json}"
+: "${AIDEVOPS_GH_SECONDARY_COOLDOWN_HOME:=${HOME:-/tmp/.aidevops-${USER:-uid-${UID:-unknown}}}}"
+: "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE:=${AIDEVOPS_GH_SECONDARY_COOLDOWN_HOME}/.aidevops/cache/gh-secondary-cooldown.json}"
 
 _GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
 
@@ -39,6 +40,17 @@ _gh_secondary_cooldown_request_id() {
 	return 0
 }
 
+_gh_secondary_cooldown_json_string() {
+	local value="$1"
+	value=${value//\\/\\\\}
+	value=${value//\"/\\\"}
+	value=${value//$'\n'/\\n}
+	value=${value//$'\r'/\\r}
+	value=${value//$'\t'/\\t}
+	printf '"%s"' "$value"
+	return 0
+}
+
 _gh_secondary_cooldown_write() {
 	local reason="$1"
 	local response_text="${2:-}"
@@ -47,6 +59,8 @@ _gh_secondary_cooldown_write() {
 	local file=""
 	local dir=""
 	local request_id=""
+	local reason_json=""
+	local request_id_json=""
 
 	now="$(_gh_secondary_cooldown_now)"
 	expires=$((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS))
@@ -61,10 +75,18 @@ _gh_secondary_cooldown_write() {
 			--arg first_seen "$now" \
 			--arg expires_at "$expires" \
 			--arg request_id "$request_id" \
-			'{reason:$reason, first_seen:($first_seen|tonumber), expires_at:($expires_at|tonumber), last_request_id:$request_id}' >"${file}.tmp" || return 1
+			'{reason:$reason, first_seen:($first_seen|tonumber), expires_at:($expires_at|tonumber), last_request_id:$request_id}' >"${file}.tmp" || {
+			printf 'Failed to write to %s\n' "${file}.tmp" >&2
+			return 1
+		}
 	else
-		printf '{"reason":"%s","first_seen":%s,"expires_at":%s,"last_request_id":"%s"}\n' \
-			"$reason" "$now" "$expires" "$request_id" >"${file}.tmp" || return 1
+		reason_json="$(_gh_secondary_cooldown_json_string "$reason")"
+		request_id_json="$(_gh_secondary_cooldown_json_string "$request_id")"
+		printf '{"reason":%s,"first_seen":%s,"expires_at":%s,"last_request_id":%s}\n' \
+			"$reason_json" "$now" "$expires" "$request_id_json" >"${file}.tmp" || {
+			printf 'Failed to write to %s\n' "${file}.tmp" >&2
+			return 1
+		}
 	fi
 	mv "${file}.tmp" "$file" || return 1
 	printf '[gh-cooldown] secondary-rate-limit active=true expires_at=%s reason=%s\n' "$expires" "$reason" >&2

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -97,6 +97,37 @@ test_override_allows_audited_call() {
 	return 1
 }
 
+test_default_path_without_home_is_user_scoped() {
+	local default_path=""
+	# shellcheck disable=SC2016 # $1 is expanded by the nested bash process.
+	default_path=$(env -u HOME -u AIDEVOPS_GH_SECONDARY_COOLDOWN_HOME -u AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE USER=tester bash -c 'source "$1"; _gh_secondary_cooldown_file' bash "${SCRIPT_DIR}/shared-gh-secondary-cooldown.sh")
+	if [[ "$default_path" == "/tmp/.aidevops-tester/.aidevops/cache/gh-secondary-cooldown.json" ]]; then
+		printf 'PASS default cooldown path without HOME is user scoped\n'
+		return 0
+	fi
+	printf 'FAIL default cooldown path without HOME was not user scoped: %s\n' "$default_path"
+	return 1
+}
+
+test_no_jq_fallback_escapes_json_strings() {
+	reset_case
+	local nojq_bin="${TMP_HOME}/nojq-bin"
+	local tool=""
+	mkdir -p "$nojq_bin"
+	for tool in date mkdir mv sed; do
+		ln -sf "$(command -v "$tool")" "${nojq_bin}/${tool}"
+	done
+	PATH="$nojq_bin" _gh_secondary_cooldown_write 'quote " reason' 'request id: REQ-123' >/dev/null 2>&1
+	if jq -e '.reason == "quote \" reason" and .last_request_id == "REQ-123" and (.expires_at > .first_seen)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS no-jq fallback escapes JSON strings\n'
+		return 0
+	fi
+	printf 'FAIL no-jq fallback wrote malformed JSON\n'
+	return 1
+}
+
 test_secondary_response_writes_cooldown
 test_active_cooldown_skips_without_gh_call
 test_override_allows_audited_call
+test_default_path_without_home_is_user_scoped
+test_no_jq_fallback_escapes_json_strings


### PR DESCRIPTION
## Summary

Hardened the GitHub secondary cooldown state file defaults and no-jq JSON fallback to avoid shared /tmp collisions and malformed fallback JSON.

## Files Changed

.agents/scripts/shared-gh-secondary-cooldown.sh,.agents/scripts/tests/test-gh-secondary-cooldown.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-secondary-cooldown.sh .agents/scripts/tests/test-gh-secondary-cooldown.sh; bash .agents/scripts/tests/test-gh-secondary-cooldown.sh

Resolves #23651


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 2m and 50,173 tokens on this as a headless worker.