### PR TITLE
GH#23648: expose dispatch worktree registration failures

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -42,6 +42,8 @@ set -euo pipefail
 _DSI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source dependencies (order matters: shared-constants first, then GH wrappers).
+# shared-constants.sh also sources shared-worktree-registry.sh when present,
+# which defines register_worktree for the manual dispatch precreated worktree.
 # NOTE: dispatch-dedup-helper.sh is NOT sourced — it has no source guard and
 # would execute its main() with our $@. We invoke it as an external command
 # instead via _DSI_DEDUP_HELPER below.
@@ -310,10 +312,12 @@ _dsi_create_worktree() {
 			_DSI_WORKTREE_PATH=$(git -C "$repo_path" worktree list --porcelain | awk -v b="$branch" '/^worktree / {p=$0;sub(/^worktree /,"",p)} $0 == "branch refs/heads/" b {print p; exit}')
 			_DSI_WORKTREE_BRANCH="$branch"
 			if [[ -n "$_DSI_WORKTREE_PATH" && -d "$_DSI_WORKTREE_PATH" ]]; then
-				if declare -F register_worktree >/dev/null 2>&1; then
+				if declare -F register_worktree >/dev/null; then
 					register_worktree "$_DSI_WORKTREE_PATH" "$_DSI_WORKTREE_BRANCH" \
 						--task "$issue_number" \
-						--session "dispatch-precreate-${issue_number}" 2>/dev/null || true
+						--session "dispatch-precreate-${issue_number}" || _dsi_warn "Worktree registration failed (non-fatal)"
+				else
+					_dsi_warn "Worktree registry helper unavailable; ownership registration skipped"
 				fi
 				return 0
 			fi

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -556,6 +556,17 @@ test_create_worktree_registers_dispatch_owner() {
 	return 0
 }
 
+test_create_worktree_registration_warns_on_failure() {
+	local failed=1
+	if grep -Fq "register_worktree \"\$_DSI_WORKTREE_PATH\" \"\$_DSI_WORKTREE_BRANCH\"" "$HELPER_PATH" &&
+		grep -Fq "|| _dsi_warn \"Worktree registration failed (non-fatal)\"" "$HELPER_PATH" &&
+		! grep -Fq -- "--session \"dispatch-precreate-\${issue_number}\" 2>/dev/null || true" "$HELPER_PATH"; then
+		failed=0
+	fi
+	print_result "worktree registration failure stays visible" "$failed"
+	return 0
+}
+
 
 test_readiness_accepts_worker_started_marker() {
 	MOCK_LEDGER_RECORD=""
@@ -711,6 +722,7 @@ _run_tests() {
 	test_launch_worker_forwards_repo_contract
 	test_create_worktree_uses_target_repo_path
 	test_create_worktree_registers_dispatch_owner
+	test_create_worktree_registration_warns_on_failure
 	test_readiness_accepts_worker_started_marker
 	test_readiness_rejects_live_child_without_ready_signal
 	test_readiness_rejects_ledger_without_worker_started


### PR DESCRIPTION
## Summary

Made manual dispatch worktree ownership registration self-documenting and fail-visible instead of suppressing stderr, with a regression test covering visible registration failures.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh,.agents/scripts/tests/test-dispatch-single-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh; shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh

Resolves #23648


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 2m and 56,159 tokens on this as a headless worker.