### PR TITLE
GH#23650: normalize changelog spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- prioritise low-complexity pulse dispatch (#23612)
-- prioritise solvable pulse dispatch candidates (#23610)
+- prioritize low-complexity pulse dispatch (#23612)
+- prioritize solvable pulse dispatch candidates (#23610)
 
 ### Changed
 
@@ -57,8 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- prioritise low-complexity pulse dispatch (#23612)
-- prioritise solvable pulse dispatch candidates (#23610)
+- prioritize low-complexity pulse dispatch (#23612)
+- prioritize solvable pulse dispatch candidates (#23610)
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Normalized the affected CHANGELOG.md pulse dispatch entries to use American English spelling consistently.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; grep verification found no remaining targeted British-English entries

Resolves #23650


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 2m and 30,128 tokens on this as a headless worker.