### PR TITLE
GH#23652: align headless runtime local declarations

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1533,19 +1533,32 @@ _discover_actual_worktree_dir() {
 # =============================================================================
 
 cmd_run() {
-	local role="worker"
-	local session_key=""
-	local work_dir=""
-	local title=""
-	local prompt=""
-	local prompt_file=""
-	local model_override=""
-	local initial_model=""
-	local tier_override=""
-	local variant_override=""
-	local agent_name=""
-	local headless_runtime=""
-	local detach=0
+	local role
+	role="worker"
+	local session_key
+	session_key=""
+	local work_dir
+	work_dir=""
+	local title
+	title=""
+	local prompt
+	prompt=""
+	local prompt_file
+	prompt_file=""
+	local model_override
+	model_override=""
+	local initial_model
+	initial_model=""
+	local tier_override
+	tier_override=""
+	local variant_override
+	variant_override=""
+	local agent_name
+	agent_name=""
+	local headless_runtime
+	headless_runtime=""
+	local detach
+	detach=0
 	local -a extra_args=()
 
 	_parse_run_args "$@" || return 1
@@ -1580,7 +1593,8 @@ cmd_run() {
 	print_info "[lifecycle] pre_model_select session=$session_key role=$role tier=${tier_override:-auto} pid=$$"
 	local selected_model
 	selected_model=$(choose_model "$role" "${model_override:-$initial_model}" "$tier_override") || {
-		local choose_exit=$?
+		local choose_exit
+		choose_exit=$?
 		_cmd_run_finish "$session_key" "fail"
 		return "$choose_exit"
 	}
@@ -1609,7 +1623,8 @@ cmd_run() {
 	# the EXIT trap is armed) so it is always available to _release_dispatch_claim.
 	# _cmd_run_prepare is called immediately below; the export no longer needs to
 	# live in _execute_run_attempt (which runs after the trap is already set).
-	local prepare_exit=0
+	local prepare_exit
+	prepare_exit=0
 	print_info "[lifecycle] pre_worker_prepare session=$session_key work_dir=$work_dir pid=$$"
 	_cmd_run_prepare "$session_key" "$work_dir" || prepare_exit=$?
 	if [[ "$prepare_exit" -eq 2 ]]; then


### PR DESCRIPTION
## Summary

Separated cmd_run local declarations from assignments in the headless runtime helper so the worker-origin marker area follows the repository shell style consistently.

## Files Changed

.agents/scripts/headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh; bash -n .agents/scripts/headless-runtime-helper.sh; .agents/scripts/linters-local.sh twice reached existing advisory checks but timed out at the pulse wrapper canary after no targeted shell failures

Resolves #23652


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 8m and 44,751 tokens on this as a headless worker.