### PR TITLE
GH#23653: use python URL quoting in headless canary test

### DIFF
--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -811,7 +811,7 @@ EOF
 		local env_output
 		env_output=$(<"$env_file")
 		local expected_plugin_url
-		expected_plugin_url=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).absolute().as_uri())' "$plugin_path")
+		expected_plugin_url=$(python3 -c 'import pathlib, sys, urllib.parse; print("file://" + urllib.parse.quote(str(pathlib.Path(sys.argv[1]).absolute())))' "$plugin_path")
 		if [[ "$args" == *'What is two plus two?'* && "$args" != *'--pure'* && "$args" != *'--agent build'* ]] &&
 			[[ "$env_output" == *"OPENCODE_BIN=${fake_bin_dir}/opencode"* ]] &&
 			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]] &&


### PR DESCRIPTION
## Summary
- Updated the headless runtime canary test to build the expected plugin file URL with `python3` and `urllib.parse.quote`.
- Keeps the change scoped to `.agents/scripts/tests/test-headless-runtime-helper.sh` so paths with spaces and unicode are encoded without jq compatibility concerns.

## Testing
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/tests/test-headless-runtime-helper.sh`

## Runtime Testing
- self-assessed; test-only quality-debt follow-up.

Resolves #23653

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 2m and 50,854 tokens on this as a headless worker.
