### PR TITLE
GH#23654: reuse extracted task line for blocker checks

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -51,7 +51,7 @@ _has_evidence() {
 	task_line=$(_task_line_from_block "$text" "$task_id")
 	# Cancelled/deferred/declined tasks need no PR or verified: evidence
 	_is_cancelled_or_deferred "$task_line" && return 0
-	if _has_unresolved_blocker "$task_line" "$task_id"; then
+	if _has_unresolved_blocker "$text" "$task_id" "$task_line"; then
 		return 1
 	fi
 	echo "$text" | grep -qE 'verified:[0-9]{4}-[0-9]{2}-[0-9]{2}|pr:#[0-9]+' && return 0
@@ -73,9 +73,13 @@ _task_line_from_block() {
 }
 
 _has_unresolved_blocker() {
-	local text="$1" task_id="${2:-}"
+	local text="$1" task_id="${2:-}" task_line="${3:-}"
 	local candidate
-	candidate=$(_task_line_from_block "$text" "$task_id")
+	if [[ -n "$task_line" ]]; then
+		candidate="$task_line"
+	else
+		candidate=$(_task_line_from_block "$text" "$task_id")
+	fi
 	echo "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
 	return 1
 }
@@ -195,7 +199,7 @@ _do_close() {
 		print_info "Skipping #$issue_number ($task_id): parent-task label set — parent issues close via terminal-phase PR with explicit Closes #NNN, not TODO [x] (GH#20828)"
 		return 0
 	fi
-	if ! _is_cancelled_or_deferred "$task_line" && _has_unresolved_blocker "$task_line"; then
+	if ! _is_cancelled_or_deferred "$task_line" && _has_unresolved_blocker "$task_line" "" "$task_line"; then
 		print_info "Skipping #$issue_number ($task_id): unresolved blocked-by marker present — completion evidence must wait for dependencies (GH#23516)"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -103,6 +103,22 @@ else
 	fail "unexpected task marker should accept proof on the task line"
 fi
 
+precomputed_clean_task_line='- [ ] t9008 fixed implementation pr:#81 tier:standard'
+precomputed_note_block='- [ ] t9008 fixed implementation pr:#81 tier:standard
+  - Historical note: earlier attempt was blocked-by:t9007 before the dependency landed.'
+if _has_unresolved_blocker "$precomputed_note_block" "t9008" "$precomputed_clean_task_line"; then
+	fail "precomputed clean task line skips blocker mentions in notes"
+else
+	pass "precomputed clean task line skips blocker mentions in notes"
+fi
+
+precomputed_blocked_task_line='- [ ] t9009 fixed implementation pr:#82 tier:standard blocked-by:t9008'
+if _has_unresolved_blocker "- [ ] t9009 fixed implementation pr:#82 tier:standard" "t9009" "$precomputed_blocked_task_line"; then
+	pass "precomputed blocked task line still vetoes completion"
+else
+	fail "precomputed blocked task line should veto completion"
+fi
+
 if [[ "$FAIL" -eq 0 ]]; then
 	printf 'All %d tests passed\n' "$PASS"
 	exit 0


### PR DESCRIPTION
## Summary

Refactored issue-sync blocker detection to accept a precomputed task line so evidence checks do not re-extract the same line, while preserving fallback extraction for other callers.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh,.agents/scripts/tests/test-issue-sync-completion-evidence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-completion-evidence.sh; shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-completion-evidence.sh

Resolves #23654


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 46,526 tokens on this as a headless worker.