### PR TITLE
GH#23657: simplify benign ledger parent handling

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -225,8 +225,10 @@ _dispatch_begin_benign_blocks_cycle() {
 		_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
 		return 0
 	fi
-	if [[ "$ledger_managed_by_dispatch" == "0" && "$ledger_file" == */* && -n "${ledger_file%/*}" ]] && ! mkdir -p "${ledger_file%/*}"; then
-		printf 'Failed to create benign block ledger parent directory: %s\n' "${ledger_file%/*}" >&2
+	local parent_dir
+	parent_dir="${ledger_file%/*}"
+	if [[ "$ledger_managed_by_dispatch" == "0" && "$ledger_file" == */* && -n "$parent_dir" ]] && ! mkdir -p "$parent_dir"; then
+		printf 'Failed to create benign block ledger parent directory: %s\n' "$parent_dir" >&2
 	fi
 	if ! : >"$ledger_file"; then
 		printf 'Failed to initialize benign block ledger file: %s\n' "$ledger_file" >&2


### PR DESCRIPTION
## Summary

Stored the benign block ledger parent directory in a local variable before reuse, improving readability and matching shell local assignment style.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-lib.sh

Resolves #23657


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 35,855 tokens on this as a headless worker.