### PR TITLE
GH#23658: refactor: centralize framework issue flag parsing

### DIFF
--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -573,6 +573,31 @@ log_framework_issue() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# _log_option_value FLAG OPTION ARG_COUNT [NEXT_VALUE]
+# ─────────────────────────────────────────────────────────────────────────────
+_log_option_value() {
+	local flag_name="$1"
+	local option="$2"
+	local arg_count="$3"
+	local next_value="${4-}"
+
+	case "$option" in
+	*=*)
+		printf '%s\n' "${option#*=}"
+		return 0
+		;;
+	esac
+
+	if [[ "$arg_count" -lt 2 ]]; then
+		log_error "${flag_name} requires a value"
+		return 1
+	fi
+
+	printf '%s\n' "$next_value"
+	return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # _parse_log_command ARGS...
 # ─────────────────────────────────────────────────────────────────────────────
 _parse_log_command() {
@@ -580,61 +605,36 @@ _parse_log_command() {
 	while [[ $# -gt 0 ]]; do
 		local option="$1"
 		case "$option" in
-		--title=*)
-			title="${option#*=}"
-			shift
-			;;
-		--title)
-			if [[ $# -lt 2 ]]; then
-				log_error "--title requires a value"
-				return 1
-			fi
-			local option_value="$2"
-			title="$option_value"
-			shift 2
-			;;
-		--body=*)
-			body="${option#*=}"
-			shift
-			;;
-		--body)
-			if [[ $# -lt 2 ]]; then
-				log_error "--body requires a value"
-				return 1
-			fi
-			local option_value="$2"
-			body="$option_value"
-			shift 2
-			;;
-		--label=*)
-			label="${option#*=}"
-			shift
-			;;
-		--label)
-			if [[ $# -lt 2 ]]; then
-				log_error "--label requires a value"
-				return 1
-			fi
-			local option_value="$2"
-			label="$option_value"
-			shift 2
+		--title | --title=* | --body | --body=* | --label | --label=* | --tier | --tier=*)
+			local flag_name="${option%%=*}"
+			local option_value
+			option_value="$(_log_option_value "$flag_name" "$option" "$#" "${2-}")" || return 1
+			case "$flag_name" in
+			--title)
+				title="$option_value"
+				;;
+			--body)
+				body="$option_value"
+				;;
+			--label)
+				label="$option_value"
+				;;
+			--tier)
+				tier="$option_value"
+				;;
+			esac
+			case "$option" in
+			*=*)
+				shift
+				;;
+			*)
+				shift 2
+				;;
+			esac
 			;;
 		--auto-dispatch)
 			auto_dispatch="yes"
 			shift
-			;;
-		--tier=*)
-			tier="${option#*=}"
-			shift
-			;;
-		--tier)
-			if [[ $# -lt 2 ]]; then
-				log_error "--tier requires a value"
-				return 1
-			fi
-			local option_value="$2"
-			tier="$option_value"
-			shift 2
 			;;
 		--dry-run)
 			dry_run="true"

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -132,6 +132,22 @@ run_auto_dispatch_equals_case() {
 	return 1
 }
 
+run_flag_value_case() {
+	local stub_dir="$1"
+	local output_file="$2"
+	local trace_file="$3"
+
+	if TEST_DUPLICATE_VALUE="" \
+		TEST_CREATED_URL="https://github.com/marcusquinn/aidevops/issues/9103" \
+		TEST_GH_TRACE="$trace_file" \
+		PATH="${stub_dir}:$PATH" \
+		"$HELPER" log --title "--title-looking value" --body "body with spaces" --label "triage label" --tier "custom-tier" >"$output_file" 2>&1; then
+		return 0
+	fi
+
+	return 1
+}
+
 run_missing_value_case() {
 	local stub_dir="$1"
 	local output_file="$2"
@@ -205,6 +221,20 @@ if run_auto_dispatch_equals_case "${TMP_DIR}" "$auto_dispatch_equals_output" "$a
 	assert_contains "$auto_dispatch_equals_calls" "--label status:available" "auto-dispatch equals case includes worker-ready status label"
 else
 	fail "auto-dispatch equals case creates issue" "helper failed"
+fi
+
+flag_value_output="${TMP_DIR}/flag-value.out"
+flag_value_trace="${TMP_DIR}/flag-value.trace"
+if run_flag_value_case "${TMP_DIR}" "$flag_value_output" "$flag_value_trace"; then
+	flag_value_text=$(<"$flag_value_output")
+	flag_value_calls=$(<"$flag_value_trace")
+	assert_contains "$flag_value_text" "status=created" "space-separated flag values create issue"
+	assert_contains "$flag_value_calls" "--title --title-looking value" "space-separated title preserves leading dash value"
+	assert_contains "$flag_value_calls" "--body body with spaces" "space-separated body preserves spaces"
+	assert_contains "$flag_value_calls" "--label triage label" "space-separated label preserves spaces"
+	assert_contains "$flag_value_calls" "--label tier:custom-tier" "space-separated tier creates tier label"
+else
+	fail "space-separated flag values create issue" "helper failed"
 fi
 
 missing_value_output="${TMP_DIR}/missing-value.out"


### PR DESCRIPTION
## Summary

Centralized framework issue log option value parsing so --title/--body/--label/--tier consistently support --flag=value and --flag value forms, with regression coverage for space-separated values.

## Files Changed

.agents/scripts/framework-issue-helper.sh,.agents/scripts/tests/test-framework-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: .agents/scripts/tests/test-framework-issue-helper.sh; PASS: shellcheck .agents/scripts/framework-issue-helper.sh .agents/scripts/tests/test-framework-issue-helper.sh; NOTE: .agents/scripts/linters-local.sh still reports existing repository-wide markdown/complexity/nesting baseline issues unrelated to these two changed files.

Resolves #23658


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 7m and 104,846 tokens on this as a headless worker.