### PR TITLE
GH#23661: fix(GH#23661): use portable canary grep

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1642,7 +1642,7 @@ _run_canary_test() {
 	#
 	# GH#23598: match the benign probe answer case-insensitively with the
 	# portable whole-word mode supported by GNU and BSD grep.
-	if grep -iwq 'four' "$canary_output" 2>/dev/null; then
+	if grep -qwi 'four' "$canary_output"; then
 		# Cache the pass timestamp
 		mkdir -p "${STATE_DIR}" 2>/dev/null || true
 		date +%s >"$cache_file"


### PR DESCRIPTION
## Summary

Updated the OpenCode canary success check to use grep's portable whole-word option ordering and allow file diagnostics to surface instead of suppressing stderr.

## Files Changed

.agents/scripts/headless-runtime-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh

Resolves #23661


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 31,782 tokens on this as a headless worker.