### PR TITLE
GH#23646: use portable grep alternation in pulse test

### DIFF
--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -171,7 +171,7 @@ test_orphan_crash_skips_closed_issue_comment() {
 	_record_orphan_crash_classification "feature/auto-20260515-123456-gh23379" 0 "owner/repo"
 
 	grep -q 'issue view 23379 --repo owner/repo' "$gh_log" || fail "closed orphan did not check issue state"
-	if grep -q 'gh_issue_comment\|recover_failed_launch_state\|issues/23379/comments' "$gh_log"; then
+	if grep -Eq 'gh_issue_comment|recover_failed_launch_state|issues/23379/comments' "$gh_log"; then
 		fail "closed orphan posted or recovered issue state"
 	fi
 	grep -q 'Orphan cleanup skipped for #23379 (owner/repo): issue state=CLOSED' "$LOGFILE" || fail "closed orphan skip was not audited"


### PR DESCRIPTION
## Summary

Updated the pulse cleanup unregister test to use grep -E with standard alternation for BSD/GNU portability.

## Files Changed

.agents/scripts/tests/test-pulse-cleanup-unregister.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-cleanup-unregister.sh; shellcheck .agents/scripts/tests/test-pulse-cleanup-unregister.sh

Resolves #23646


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 36,335 tokens on this as a headless worker.