### PR TITLE
fix(pulse-cleanup): preserve dirty worktrees and reflog-only WIP (#23677)

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -677,6 +677,11 @@ If a tool call returns empty output, it usually means the path or pattern was wr
 
 Worktree edit verification (GH#22816):
 After any file edit in the pre-created linked worktree, verify the worktree path still exists and the change is visible before claiming success or pushing. Minimum evidence: git status --short --branch from $WORKER_WORKTREE_PATH plus a diff/stat or commit containing the edited files. If the worktree or edits disappeared, reconstruct from available evidence before reporting completion.
+
+Incremental WIP commits (GH#23677):
+- Make a local WIP commit as soon as the first meaningful edit is coherent, then after each logical change. Use conventional WIP subjects such as `wip: preserve cleanup safety` until the final squash/PR commit.
+- Do not leave valuable work only as dirty files while continuing to explore. A first WIP commit makes the worktree cleanup-visible as active real work even before a PR exists, and gives the runtime/watchdog a reachable commit to push or recover.
+- If a commit hook blocks a WIP commit, fix the issue when practical; otherwise preserve the diff with a clear BLOCKED outcome rather than resetting or continuing with unprotected dirty state.
 EOF
 	return 0
 }

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -70,7 +70,14 @@ if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/gh-signa
 	# shellcheck source=gh-signature-helper-detect.sh
 	source "$_PULSE_CLEANUP_SCRIPT_DIR/gh-signature-helper-detect.sh"
 fi
-unset _PULSE_CLEANUP_SCRIPT_DIR
+# GH#23677 / t3700: Do NOT `unset _PULSE_CLEANUP_SCRIPT_DIR`. The previous
+# version unset this immediately after sourcing the four sibling helpers,
+# but _cleanup_merged_prs_for_all_repos() (line ~251) reads it later to
+# locate worktree-helper.sh. Under `set -u` (the standard pulse-wrapper
+# orchestrator setting) that read aborts the cleanup pass with
+# `_PULSE_CLEANUP_SCRIPT_DIR: unbound variable`. The variable already uses
+# the module-private `_PULSE_` prefix and survives the include guard on
+# line 49 unset-free, so keeping it bound is consistent.
 : "${AIDEVOPS_UNKNOWN_VERSION:=unknown}"
 # Caller ID constant for audit log calls (avoids repeated literals).
 _WTAR_PC_CALLER="pulse-cleanup.sh"
@@ -424,11 +431,18 @@ _worktree_creation_epoch() {
 #######################################
 # Decide whether a worktree is eligible for orphan cleanup.
 #
-# Applies the age/commit/PR thresholds from GH#16830 and t1884:
-#   0 commits, no open PR, >grace → crashed worker (fast-path)
-#   0 commits, clean,      >3h    → empty, safe to remove
-#   0 commits, dirty,      >6h    → worker died mid-edit
-#   any commits, no PR,    >24h   → abandoned, will be re-dispatched
+# Applies the age/commit/PR thresholds from GH#16830, t1884, GH#23677:
+#   0 commits, clean, no open PR, >grace → crashed worker (fast-path)
+#   0 commits, clean,             >3h    → empty, safe to remove
+#   0 commits, dirty,             >6h    → worker died mid-edit
+#                                          (refused by _cleanup_single_worktree,
+#                                           but reason is still emitted for audit
+#                                           logs and manual triage)
+#   any commits, no PR,           >24h   → abandoned, will be re-dispatched
+# GH#23677 / t3700: the fast-path now requires dirty_count == 0; without
+# that guard a worktree being actively edited by an interactive
+# OpenCode/Claude Code session (path not in pgrep argv) was permanently
+# destroyed at age 30m, losing uncommitted work with no recovery path.
 #
 # GitHub queries are only attempted when both repo_slug and branch are
 # non-empty. On eligibility the reason string is written to stdout so the
@@ -461,13 +475,24 @@ _evaluate_worktree_removal() {
 	local age_24h=$((24 * 3600))
 
 	# The branches below are mutually exclusive via an elif chain — once the
-	# fast-path's outer condition matches (0 commits + past grace), the later
-	# branches MUST NOT be checked even if the fast-path decides "not
-	# eligible" (e.g. an open PR protects the worktree). Preserving this
-	# short-circuit is what keeps worktrees with active PRs alive past 3h.
+	# fast-path's outer condition matches (0 commits + clean + past grace),
+	# the later branches MUST NOT be checked even if the fast-path decides
+	# "not eligible" (e.g. an open PR protects the worktree). Preserving
+	# this short-circuit is what keeps worktrees with active PRs alive
+	# past 3h. Dirty worktrees skip the fast-path entirely and fall
+	# through to the explicit 6h rule (GH#23677 / t3700).
 
-	# Fast-path: 0 commits + past grace period → crashed worker candidate (t1884)
-	if [[ "$commits_ahead" -eq 0 && "$wt_age_secs" -ge "$age_grace" ]]; then
+	# Fast-path: 0 commits + CLEAN + past grace period → crashed worker candidate (t1884)
+	#
+	# GH#23677 / t3700: the fast-path MUST require dirty_count == 0. A
+	# worktree with uncommitted edits represents work-in-progress from an
+	# interactive editor session (OpenCode/Claude Code/VS Code/etc) where
+	# the path does not appear in pgrep argv and is not registered in the
+	# SQLite worktree-owner registry. Removing it permanently destroys the
+	# user's dirty files with no recovery path (mode=permanent, branch
+	# deleted, no trash backing). Defer dirty cases to the 6h rule below
+	# which gives editor sessions a much wider safety margin.
+	if [[ "$commits_ahead" -eq 0 && "$dirty_count" -eq 0 && "$wt_age_secs" -ge "$age_grace" ]]; then
 		local has_open_pr=false
 		if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
 			local open_pr_count
@@ -475,7 +500,7 @@ _evaluate_worktree_removal() {
 			[[ "$open_pr_count" -gt 0 ]] && has_open_pr=true
 		fi
 		if [[ "$has_open_pr" == "false" ]]; then
-			echo "0 commits, no open PR, age $((wt_age_secs / 60))m (crashed worker)"
+			echo "0 commits, clean, no open PR, age $((wt_age_secs / 60))m (crashed worker)"
 			return 0
 		fi
 	# 0 commits, clean worktree, >3h → empty (no PR, no dirty state)
@@ -787,13 +812,79 @@ Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 comm
 }
 
 #######################################
+# GH#23677 / t3700: Defence-in-depth refusal of permanent removal when
+# uncommitted work or reflog-only WIP commits would be lost.
+#
+# Two independent safety guards:
+#   1. dirty_count > 0 → "dirty-content-protect"
+#      The 6h "worker died mid-edit" rule used to discard dirty workers
+#      because we assumed workers are non-interactive; in practice the
+#      same code path catches interactive editor sessions whose paths
+#      are not pgrep-visible. Better to leave the directory on disk for
+#      the user to inspect than destroy uncommitted edits.
+#   2. commits not on any remote → "commits-not-on-remote"
+#      `git rev-list --count HEAD --not --remotes` catches commits not
+#      on any remote ref — including the case where a stray `git reset`
+#      moved the branch tip back to the merge base, making the primary
+#      `rev-list HEAD ^${main_branch}` count zero, while the reflog
+#      still holds the WIP commits. Gated on the repo actually having
+#      remote-tracking refs to avoid false-positive on local-only test
+#      repos and freshly-init'd helper sandboxes.
+#
+# Args:
+#   $1 - wt_path_age:   absolute worktree path
+#   $2 - wt_branch_age: branch name (may be empty for detached HEAD)
+#   $3 - dirty_count:   number of dirty files reported by status --porcelain
+#   $4 - orphan_issue_num: parsed GH issue number (may be empty)
+#   $5 - wt_age_secs:   age in seconds
+#   $6 - repo_name_age: basename of repo for log messages
+#   $7 - audit_context_ref: caller-provided audit context (passed through to log)
+# Returns: 0 if safe to proceed with removal, 1 if removal must be skipped
+#######################################
+_pc_assert_no_uncommitted_work() {
+	local wt_path_age="$1"
+	local wt_branch_age="$2"
+	local dirty_count="$3"
+	local orphan_issue_num="$4"
+	local wt_age_secs="$5"
+	local repo_name_age="$6"
+	local audit_context_ref="$7"
+
+	if [[ "$dirty_count" -gt 0 ]]; then
+		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — ${dirty_count} dirty file(s) present, refusing permanent removal (GH#23677)" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "dirty-content-protect" "skipped" "$audit_context_ref"
+		return 1
+	fi
+
+	local has_remote_refs="no"
+	if [[ -n "$(git -C "$wt_path_age" for-each-ref --count=1 refs/remotes/ 2>/dev/null)" ]]; then
+		has_remote_refs="yes"
+	fi
+	if [[ "$has_remote_refs" != "yes" ]]; then
+		return 0
+	fi
+
+	local commits_not_on_remotes=0
+	commits_not_on_remotes=$(git -C "$wt_path_age" rev-list --count HEAD --not --remotes 2>/dev/null || echo 0)
+	if [[ "${commits_not_on_remotes//[!0-9]/}" -gt 0 ]]; then
+		local audit_ctx_reflog
+		audit_ctx_reflog=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_not_on_remotes" "$dirty_count" "$wt_age_secs" "none" "clear" "clear" "clear" "none")
+		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — ${commits_not_on_remotes} commit(s) not on any remote (possible reflog-only WIP)" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "commits-not-on-remote" "skipped" "$audit_ctx_reflog"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Per-worktree age-based orphan cleanup decision and removal.
 #
-# Thin orchestrator over three private helpers:
-#   1. _worktree_creation_epoch      — creation time from .git mtime
-#   2. _worktree_owner_alive         — pgrep + registry ownership check
-#   3. _evaluate_worktree_removal    — age/commit/PR threshold decision
-#   4. _record_orphan_crash_classification — crash type + dedup clearing
+# Thin orchestrator over four private helpers:
+#   1. _worktree_creation_epoch          — creation time from .git mtime
+#   2. _worktree_owner_alive             — pgrep + registry ownership check
+#   3. _evaluate_worktree_removal        — age/commit/PR threshold decision
+#   4. _pc_assert_no_uncommitted_work    — dirty + reflog-only WIP guard (GH#23677)
+#   5. _record_orphan_crash_classification — crash type + dedup clearing
 #
 # On eligible worktrees, performs the git worktree remove + branch delete
 # + remote ref delete sequence (t1884, GH#18021).
@@ -866,6 +957,13 @@ _cleanup_single_worktree() {
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "local-commits-no-pr" "skipped" "$audit_context"
 		return 1
 	fi
+
+	# GH#23677 / t3700: defence-in-depth — refuse removal when any
+	# uncommitted content or reflog-only WIP commit is present.
+	if ! _pc_assert_no_uncommitted_work "$wt_path_age" "$wt_branch_age" "$dirty_count" "$orphan_issue_num" "$wt_age_secs" "$repo_name_age" "$audit_context"; then
+		return 1
+	fi
+
 	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
 
 	# Step 5a: crash classification for the fast-path "crashed worker" case

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -813,7 +813,7 @@ Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 comm
 
 #######################################
 # GH#23677 / t3700: Defence-in-depth refusal of permanent removal when
-# uncommitted work or reflog-only WIP commits would be lost.
+# uncommitted work or reachable unpushed WIP commits would be lost.
 #
 # Two independent safety guards:
 #   1. dirty_count > 0 → "dirty-content-protect"
@@ -823,13 +823,13 @@ Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 comm
 #      are not pgrep-visible. Better to leave the directory on disk for
 #      the user to inspect than destroy uncommitted edits.
 #   2. commits not on any remote → "commits-not-on-remote"
-#      `git rev-list --count HEAD --not --remotes` catches commits not
-#      on any remote ref — including the case where a stray `git reset`
-#      moved the branch tip back to the merge base, making the primary
-#      `rev-list HEAD ^${main_branch}` count zero, while the reflog
-#      still holds the WIP commits. Gated on the repo actually having
-#      remote-tracking refs to avoid false-positive on local-only test
-#      repos and freshly-init'd helper sandboxes.
+#      `git rev-list --count HEAD --not --remotes` catches commits that
+#      are still reachable from HEAD but absent from all remote refs. It
+#      deliberately does NOT claim to protect commits that exist only in
+#      reflog after a later reset moved HEAD back to the base; those require
+#      separate reflog-aware recovery. Gated on the repo actually having
+#      remote-tracking refs to avoid false-positive on local-only test repos
+#      and freshly-init'd helper sandboxes.
 #
 # Args:
 #   $1 - wt_path_age:   absolute worktree path
@@ -869,7 +869,7 @@ _pc_assert_no_uncommitted_work() {
 	if [[ "${commits_not_on_remotes//[!0-9]/}" -gt 0 ]]; then
 		local audit_ctx_reflog
 		audit_ctx_reflog=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_not_on_remotes" "$dirty_count" "$wt_age_secs" "none" "clear" "clear" "clear" "none")
-		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — ${commits_not_on_remotes} commit(s) not on any remote (possible reflog-only WIP)" >>"$LOGFILE"
+		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — ${commits_not_on_remotes} commit(s) reachable from HEAD but not on any remote" >>"$LOGFILE"
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "commits-not-on-remote" "skipped" "$audit_ctx_reflog"
 		return 1
 	fi
@@ -959,7 +959,7 @@ _cleanup_single_worktree() {
 	fi
 
 	# GH#23677 / t3700: defence-in-depth — refuse removal when any
-	# uncommitted content or reflog-only WIP commit is present.
+	# uncommitted content or reachable unpushed WIP commit is present.
 	if ! _pc_assert_no_uncommitted_work "$wt_path_age" "$wt_branch_age" "$dirty_count" "$orphan_issue_num" "$wt_age_secs" "$repo_name_age" "$audit_context"; then
 		return 1
 	fi

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -76,6 +76,8 @@ test_appends_escalation_contract() {
 		[[ "$output" == *'do bounded discovery instead of stopping'* ]] &&
 		[[ "$output" == *'Exit BLOCKED with reason "missing implementation context" only after bounded discovery'* ]] &&
 		[[ "$output" == *'Worktree edit verification (GH#22816)'* ]] &&
+		[[ "$output" == *'Incremental WIP commits (GH#23677)'* ]] &&
+		[[ "$output" == *'A first WIP commit makes the worktree cleanup-visible as active real work even before a PR exists'* ]] &&
 		[[ "$output" == *'Progressive context loading'* ]] &&
 		[[ "$output" == *'Load only referenced workflow/reference docs'* ]] &&
 		[[ "$output" == *'Stop reading once target files, reference pattern, constraints, and verification are clear.'* ]] &&

--- a/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
@@ -8,16 +8,16 @@
 # past 30m grace) are satisfied.
 #
 # Real-world incident: an interactive OpenCode session with three WIP
-# commits later reset via `git reset --hard origin/main` left the
+# commits later reset back to the default-branch tip left the
 # worktree showing commits_ahead=0 dirty=5 age=35m. The fast-path then
 # matched and called remove_worktree_path_permanently → 3 hours of
-# editor work + 3 reflog-only commits were destroyed with no recovery
+# editor work plus local WIP commit evidence were destroyed with no recovery
 # path (mode=permanent, branch deleted, no Trash backing).
 #
-# Two scenarios covered:
+# Key cleanup scenarios covered:
 #   1. zero commits + dirty + past grace → skip (fast-path now requires clean)
-#   2. zero commits + clean + past grace + commits-not-on-remote > 0
-#      via reflog → skip (defence-in-depth: HEAD..--not --remotes)
+#   2. reachable unpushed commit + past grace → skip
+#      (defence-in-depth: HEAD --not --remotes)
 
 set -uo pipefail
 
@@ -184,28 +184,25 @@ test_dirty_worktree_past_6h_still_skips() {
 	return 0
 }
 
-# Scenario 3: a worktree with reflog-only WIP commits (HEAD reset to
-# origin/main, but the original commits still reachable via reflog) is
-# protected by the "commits not on any remote" check.
-test_reflog_only_wip_commits_protected() {
-	local repo_dir="${TEST_ROOT}/repo-reflog"
-	local wt_path="${TEST_ROOT}/wt-reflog"
-	local branch_name="fix/reflog-only-wip"
+# Scenario 3: a worktree with WIP commits still reachable from HEAD but not
+# present on any remote is protected by the "commits not on any remote" check.
+# This does not claim to recover reflog-only commits after HEAD is reset away
+# from them; cleanup can only inspect reachable state without a separate reflog
+# walk.
+test_reachable_unpushed_commits_protected() {
+	local repo_dir="${TEST_ROOT}/repo-unpushed"
+	local wt_path="${TEST_ROOT}/wt-unpushed"
+	local branch_name="fix/reachable-unpushed-wip"
 	setup_repo_with_worktree_aged "$repo_dir" "$wt_path" "$branch_name" 1 || return 1
 	source_pulse_cleanup_with_stubs || return 1
 
-	# Create a commit then reset HEAD back to base — the commit is now
-	# reflog-only. `rev-list HEAD ^main` returns 0, but
-	# `rev-list HEAD --not --remotes` will report the lost commit if we
-	# move HEAD back to it.
+	# Create a WIP commit and leave HEAD on it. `rev-list HEAD --not --remotes`
+	# reports it as local-only, so cleanup must refuse permanent removal.
 	(
 		cd "$wt_path" || exit 1
 		printf 'wip change\n' >wip.txt
 		git add wip.txt
 		git -c user.email=t@test -c user.name=T commit -q -m "wip: editor edit"
-		# Leave HEAD on the WIP commit so rev-list --not --remotes > 0.
-		# (If we reset, commits_ahead becomes 0 AND the worktree is clean,
-		# making it indistinguishable from a fresh worktree — accepted limit.)
 	)
 
 	local now_epoch
@@ -225,7 +222,7 @@ test_reflog_only_wip_commits_protected() {
 	if ! grep -qE 'local-commits-no-pr|commits-not-on-remote' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null; then
 		grep -q 'worktree-removed' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null && rc=1
 	fi
-	print_result "worktree with unpushed commit is preserved" "$rc" \
+	print_result "worktree with reachable unpushed commit is preserved" "$rc" \
 		"cleanup_rc=$cleanup_rc dir_exists=$([[ -d "$wt_path" ]] && echo y || echo n) log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
 }
@@ -270,7 +267,7 @@ mkdir -p "${HOME}/.aidevops/logs"
 echo "=== test-pulse-cleanup-preserves-dirty.sh ==="
 test_dirty_worktree_past_grace_skips_removal
 test_dirty_worktree_past_6h_still_skips
-test_reflog_only_wip_commits_protected
+test_reachable_unpushed_commits_protected
 test_sources_under_set_u
 
 echo ""

--- a/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#23677 / t3700: pulse orphan cleanup must NOT
+# permanently remove a worktree that has dirty (uncommitted) content,
+# even when the fast-path's other conditions (0 commits, no open PR,
+# past 30m grace) are satisfied.
+#
+# Real-world incident: an interactive OpenCode session with three WIP
+# commits later reset via `git reset --hard origin/main` left the
+# worktree showing commits_ahead=0 dirty=5 age=35m. The fast-path then
+# matched and called remove_worktree_path_permanently → 3 hours of
+# editor work + 3 reflog-only commits were destroyed with no recovery
+# path (mode=permanent, branch deleted, no Trash backing).
+#
+# Two scenarios covered:
+#   1. zero commits + dirty + past grace → skip (fast-path now requires clean)
+#   2. zero commits + clean + past grace + commits-not-on-remote > 0
+#      via reflog → skip (defence-in-depth: HEAD..--not --remotes)
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PULSE_CLEANUP="${SCRIPT_DIR}/../pulse-cleanup.sh"
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s %s\n' "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Create a repo + worktree with the .git file mtime aged to N hours ago so
+# the cleanup logic considers it past the 30m grace period.
+setup_repo_with_worktree_aged() {
+	local repo_dir="$1"
+	local wt_path="$2"
+	local branch_name="$3"
+	local hours_ago="${4:-2}"
+
+	mkdir -p "$repo_dir"
+	(
+		cd "$repo_dir" || exit 1
+		git init -q -b main
+		git config user.email "test@example.invalid"
+		git config user.name "Test Editor"
+		printf 'base\n' >README.md
+		git add README.md
+		git commit -q -m "init"
+		git worktree add -q -b "$branch_name" "$wt_path" main
+	)
+	# touch -t reads local time, so date must also produce local time
+	# (no -u flag). GNU touch -d accepts free-form relative offsets;
+	# BSD touch needs the -t form. Try -d first, fall back to -t.
+	if ! touch -d "${hours_ago} hours ago" "$wt_path/.git" 2>/dev/null; then
+		local old_ts
+		old_ts=$(date -v-"${hours_ago}"H +%Y%m%d%H%M 2>/dev/null \
+			|| date -d "${hours_ago} hours ago" +%Y%m%d%H%M 2>/dev/null \
+			|| printf '202601010000\n')
+		touch -t "$old_ts" "$wt_path/.git"
+	fi
+	return 0
+}
+
+source_pulse_cleanup_with_stubs() {
+	LOGFILE="${TEST_ROOT}/pulse.log"
+	export LOGFILE
+	AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG
+	ORPHAN_WORKTREE_GRACE_SECS=1800
+	export ORPHAN_WORKTREE_GRACE_SECS
+
+	is_worktree_owned_by_others() { return 1; }
+	unregister_worktree() { local wt_path="$1"; : "$wt_path"; return 0; }
+	gh_pr_list() { return 0; }
+	recover_failed_launch_state() { return 0; }
+	gh_issue_comment() { return 0; }
+
+	unset _PULSE_CLEANUP_LOADED 2>/dev/null || true
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../portable-stat.sh
+	source "${SCRIPT_DIR}/../portable-stat.sh"
+	# shellcheck source=../pulse-cleanup.sh
+	source "$PULSE_CLEANUP"
+	return 0
+}
+
+# Scenario 1: zero commits + dirty file + past grace → MUST skip.
+# Reproduces the exact preamble-truncation incident shape:
+# commits=0 dirty>0 age>30m no-PR no-owner → fast-path matched +
+# remove_worktree_path_permanently destroyed dirty edits.
+test_dirty_worktree_past_grace_skips_removal() {
+	local repo_dir="${TEST_ROOT}/repo-dirty"
+	local wt_path="${TEST_ROOT}/wt-dirty"
+	local branch_name="fix/dirty-uncommitted-work"
+	setup_repo_with_worktree_aged "$repo_dir" "$wt_path" "$branch_name" 1 || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	# Introduce uncommitted dirty content — simulating an active editor session.
+	(
+		cd "$wt_path" || exit 1
+		printf 'uncommitted work in progress\n' >wip-edit.txt
+		printf 'more uncommitted edits\n' >>README.md
+	)
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	[[ -f "$wt_path/wip-edit.txt" ]] || rc=1
+	# The fast-path now requires dirty_count==0, so the dirty worktree should
+	# not even enter the removal pipeline at this age. It falls through to
+	# the 6h dirty rule (not yet eligible at 1h), so the audit log must
+	# either skip entirely or show one of the safety reasons.
+	if ! grep -qE 'worktree-skipped|dirty-content-protect' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null; then
+		# Acceptable alternative: no removal event logged at all (worktree was
+		# never deemed eligible by _evaluate_worktree_removal).
+		if grep -q 'worktree-removed' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null; then
+			rc=1
+		fi
+	fi
+	print_result "dirty worktree past 30m grace is NOT permanently removed" "$rc" \
+		"cleanup_rc=$cleanup_rc dir_exists=$([[ -d "$wt_path" ]] && echo y || echo n) log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+# Scenario 2: even past 6h, a dirty worktree must be REFUSED permanent
+# removal by the _cleanup_single_worktree defence-in-depth check. The 6h
+# rule used to discard dirty workers; we now treat dirty as "could be an
+# editor session that pgrep missed" and leave the directory alone.
+test_dirty_worktree_past_6h_still_skips() {
+	local repo_dir="${TEST_ROOT}/repo-dirty-old"
+	local wt_path="${TEST_ROOT}/wt-dirty-old"
+	local branch_name="fix/old-dirty-uncommitted"
+	setup_repo_with_worktree_aged "$repo_dir" "$wt_path" "$branch_name" 7 || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	(
+		cd "$wt_path" || exit 1
+		printf 'long-running uncommitted edits\n' >slow-edit.txt
+	)
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	[[ -f "$wt_path/slow-edit.txt" ]] || rc=1
+	grep -q 'dirty-content-protect' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "dirty worktree past 6h refused by defence-in-depth" "$rc" \
+		"cleanup_rc=$cleanup_rc dir_exists=$([[ -d "$wt_path" ]] && echo y || echo n) log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+# Scenario 3: a worktree with reflog-only WIP commits (HEAD reset to
+# origin/main, but the original commits still reachable via reflog) is
+# protected by the "commits not on any remote" check.
+test_reflog_only_wip_commits_protected() {
+	local repo_dir="${TEST_ROOT}/repo-reflog"
+	local wt_path="${TEST_ROOT}/wt-reflog"
+	local branch_name="fix/reflog-only-wip"
+	setup_repo_with_worktree_aged "$repo_dir" "$wt_path" "$branch_name" 1 || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	# Create a commit then reset HEAD back to base — the commit is now
+	# reflog-only. `rev-list HEAD ^main` returns 0, but
+	# `rev-list HEAD --not --remotes` will report the lost commit if we
+	# move HEAD back to it.
+	(
+		cd "$wt_path" || exit 1
+		printf 'wip change\n' >wip.txt
+		git add wip.txt
+		git -c user.email=t@test -c user.name=T commit -q -m "wip: editor edit"
+		# Leave HEAD on the WIP commit so rev-list --not --remotes > 0.
+		# (If we reset, commits_ahead becomes 0 AND the worktree is clean,
+		# making it indistinguishable from a fresh worktree — accepted limit.)
+	)
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	# Expect either local-commits-no-pr (commits_ahead via primary path) OR
+	# commits-not-on-remote (defence-in-depth path) — both are correct
+	# refusals. The worktree must survive.
+	if ! grep -qE 'local-commits-no-pr|commits-not-on-remote' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null; then
+		grep -q 'worktree-removed' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null && rc=1
+	fi
+	print_result "worktree with unpushed commit is preserved" "$rc" \
+		"cleanup_rc=$cleanup_rc dir_exists=$([[ -d "$wt_path" ]] && echo y || echo n) log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+# Scenario 4: pulse-cleanup must source cleanly under `set -u` — the
+# previous `unset _PULSE_CLEANUP_SCRIPT_DIR` left line ~251 with an
+# unbound variable. This test catches regression of the unset.
+test_sources_under_set_u() {
+	(
+		set -u
+		LOGFILE="${TEST_ROOT}/pulse-u.log"
+		export LOGFILE
+		AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup-u.log"
+		export AIDEVOPS_CLEANUP_LOG
+		unset _PULSE_CLEANUP_LOADED 2>/dev/null || true
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../pulse-cleanup.sh
+		source "$PULSE_CLEANUP" || exit 7
+		# Force-evaluate the previously-broken code path; failure would be an
+		# unbound-variable abort, not a function return.
+		if declare -F _cleanup_merged_prs_for_all_repos >/dev/null 2>&1; then
+			# We don't actually run the function (it needs jq + repos.json);
+			# referencing the variable directly is enough to catch unset.
+			: "${_PULSE_CLEANUP_SCRIPT_DIR:?missing _PULSE_CLEANUP_SCRIPT_DIR}"
+		else
+			exit 6
+		fi
+		exit 0
+	)
+	local sub_rc=$?
+	local rc=0
+	[[ "$sub_rc" -eq 0 ]] || rc=1
+	print_result "pulse-cleanup.sh sources cleanly under set -u" "$rc" "subshell_rc=$sub_rc"
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap teardown EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+echo "=== test-pulse-cleanup-preserves-dirty.sh ==="
+test_dirty_worktree_past_grace_skips_removal
+test_dirty_worktree_past_6h_still_skips
+test_reflog_only_wip_commits_protected
+test_sources_under_set_u
+
+echo ""
+echo "Results: $((TESTS_RUN - TESTS_FAILED))/${TESTS_RUN} passed, ${TESTS_FAILED} failed."
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Fast-path in `_evaluate_worktree_removal()` now requires `dirty_count == 0`; dirty worktrees can no longer be permanently destroyed at the 30m grace boundary
- New `_pc_assert_no_uncommitted_work()` helper refuses removal of any worktree with dirty content (`dirty-content-protect`) or commits reachable from `HEAD` but not present on any remote (`commits-not-on-remote`), gated on the repo actually having remote-tracking refs to avoid local-only false positives
- Fixed `_PULSE_CLEANUP_SCRIPT_DIR: unbound variable` regression that aborted cleanup passes under `set -u`
- Headless worker contract now requires incremental WIP commits so the first meaningful edit becomes cleanup-visible active work before a PR exists

Resolves #23677

## Why

A real incident lost five uncommitted files (319 insertions in two new tests + three modified production files) when an interactive editor session's worktree was permanently destroyed at age 35m by the 30m crashed-worker fast-path:

```text
[2026-05-16T00:02:49Z] [pulse-cleanup.sh] worktree-removed: …/preamble-truncation
  — age-eligible — mode=permanent — branch=fix/preamble-truncation-detection
  … commits=0 dirty=5 pr_state=none age_secs=2098 recovery_path=none
```

Recovery required salvaging orphaned `.git/worktrees/<name>/index` blobs. The same incident also showed WIP commit evidence in reflog, but this PR intentionally narrows the implemented commit guard to commits still reachable from `HEAD`; true reflog-only recovery remains a separate future enhancement.

## Changes

- `.agents/scripts/pulse-cleanup.sh`:
  - `_evaluate_worktree_removal()` fast-path now requires `dirty_count == 0`
  - New `_pc_assert_no_uncommitted_work()` helper refuses dirty content and reachable unpushed commits
  - Removed premature `unset _PULSE_CLEANUP_SCRIPT_DIR`
  - Updated docblocks + inline comments to avoid overstating reflog-only protection
- `.agents/scripts/headless-runtime-lib.sh`:
  - Adds headless contract instructions to commit WIP after first meaningful edit and after each logical change
- `.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh` — regression coverage for dirty cleanup, reachable unpushed commits, and `set -u` sourcing
- `.agents/scripts/tests/test-headless-runtime-helper.sh` — verifies the WIP commit contract is injected

## Verification

```bash
shellcheck -x .agents/scripts/pulse-cleanup.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh .agents/scripts/tests/test-headless-runtime-helper.sh
bash .agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh # 4/4 pass
bash .agents/scripts/tests/test-headless-runtime-helper.sh        # 58/58 pass
.agents/scripts/linters-local.sh                                  # exit 0
```

## Regression test scenarios

1. **dirty worktree past 30m grace is NOT permanently removed** — exact incident shape
2. **dirty worktree past 6h refused by defence-in-depth** — the 6h "worker died mid-edit" rule used to discard dirty workers; now refused with `dirty-content-protect` audit reason
3. **worktree with reachable unpushed commit is preserved** — `commits-not-on-remote` protects commits reachable from `HEAD` but absent from remotes
4. **pulse-cleanup.sh sources cleanly under `set -u`** — guards against regression of the `_PULSE_CLEANUP_SCRIPT_DIR` unset bug
5. **headless contract includes incremental WIP commit guidance** — workers are instructed to commit early and often so cleanup sees active real work

## Related

- GH#23081 — earlier owned-worktree branch-merged cleanup protection
- GH#23075 — worker-worktree protection
- GH#22417 — t3490 worktree cleanup Trash-growth safety
- GH#21699 — worktree-removal audit instrumentation (Phase 1)

## Author note

This PR originated from an external fork (`superdav42/aidevops`) and was maintainer-updated after review to narrow the reflog claim and add harness/session hardening.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2h 43m and 328,926 tokens on this with the user in an interactive session.