### PR TITLE
fix: pass FOSS worker issue context

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1255,6 +1255,14 @@ dispatch_foss_workers() {
 		local foss_path_expanded
 		foss_path_expanded=$(_expand_foss_repo_path "$foss_path")
 
+		env \
+			HEADLESS=1 \
+			FULL_LOOP_HEADLESS=true \
+			AIDEVOPS_SESSION_ORIGIN=worker \
+			AIDEVOPS_HEADLESS=true \
+			WORKER_ISSUE_NUMBER="$foss_issue_num" \
+			WORKER_REPO_SLUG="$foss_slug" \
+			WORKER_WORKTREE_PATH="$foss_path_expanded" \
 		"$HEADLESS_RUNTIME_HELPER" run \
 			--role worker \
 			--session-key "$foss_session_key" \

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -34,7 +34,8 @@ exit 0
 EOS
 	cat >"${TEST_TMP}/headless-runtime-helper.sh" <<'EOS'
 #!/usr/bin/env bash
-printf '%s\n' "$*" >>"${HEADLESS_INVOCATION_LOG}"
+printf 'WORKER_ISSUE_NUMBER=%s WORKER_REPO_SLUG=%s WORKER_WORKTREE_PATH=%s %s\n' \
+	"${WORKER_ISSUE_NUMBER:-<unset>}" "${WORKER_REPO_SLUG:-<unset>}" "${WORKER_WORKTREE_PATH:-<unset>}" "$*" >>"${HEADLESS_INVOCATION_LOG}"
 exit 0
 EOS
 	chmod +x "${TEST_TMP}/scripts/foss-contribution-helper.sh" "${TEST_TMP}/headless-runtime-helper.sh" || fail "failed to chmod fixtures"
@@ -139,6 +140,18 @@ launch_count="$(wc -l <"$HEADLESS_INVOCATION_LOG" | tr -d ' ')"
 
 if ! grep -q -- '--session-key foss-owner/project-42' "$HEADLESS_INVOCATION_LOG"; then
 	fail "expected FOSS session key was not used"
+fi
+
+if ! grep -q -- 'WORKER_ISSUE_NUMBER=42' "$HEADLESS_INVOCATION_LOG"; then
+	fail "FOSS worker launch did not include WORKER_ISSUE_NUMBER"
+fi
+
+if ! grep -q -- 'WORKER_REPO_SLUG=owner/project' "$HEADLESS_INVOCATION_LOG"; then
+	fail "FOSS worker launch did not include WORKER_REPO_SLUG"
+fi
+
+if ! grep -q -- "WORKER_WORKTREE_PATH=${HOME}/Git/project" "$HEADLESS_INVOCATION_LOG"; then
+	fail "FOSS worker launch did not include expanded WORKER_WORKTREE_PATH"
 fi
 
 : >"$GH_ISSUE_LIST_LABEL_LOG"


### PR DESCRIPTION
## Summary
- Export issue, repo, and worktree context before launching FOSS workers.
- Cover the contract in the FOSS dispatch regression test.

Resolves #23679

## Testing
- bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
- shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.4-mini spent 4m and 87,726 tokens on this as a headless worker.