### PR TITLE
fix: allow gh write commands with heredoc/cmd-sub when signature footer is included

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs
@@ -37,15 +37,15 @@ const SAME_BASH_CALL_HINT =
   "also runs at exec-time as a backstop.";
 
 const STANDARD_FIXES =
-	`Standard fixes:\n` +
-	`  1. Append to --body directly:\n` +
-	`       gh issue comment N --body "...$(gh-signature-helper.sh footer)"\n` +
-	`  2. Append to --body-file before posting:\n` +
-	`       gh-signature-helper.sh footer >> "$BODY_FILE"\n` +
-	`       gh issue comment N --body-file "$BODY_FILE"\n` +
-	`  3. Source shared-gh-wrappers.sh and call by name:\n` +
-	`       source ~/.aidevops/agents/scripts/shared-gh-wrappers.sh\n` +
-	`       gh_issue_comment N --body-file "$BODY_FILE"`;
+  `Standard fixes:\n` +
+  `  1. Append to --body directly:\n` +
+  `       gh issue comment N --body "...$(gh-signature-helper.sh footer)"\n` +
+  `  2. Append to --body-file before posting:\n` +
+  `       gh-signature-helper.sh footer >> "$BODY_FILE"\n` +
+  `       gh issue comment N --body-file "$BODY_FILE"\n` +
+  `  3. Source shared-gh-wrappers.sh and call by name:\n` +
+  `       source ~/.aidevops/agents/scripts/shared-gh-wrappers.sh\n` +
+  `       gh_issue_comment N --body-file "$BODY_FILE"`;
 
 /**
  * Build the throw error message for a structured repair failure (t2893).

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs
@@ -37,15 +37,15 @@ const SAME_BASH_CALL_HINT =
   "also runs at exec-time as a backstop.";
 
 const STANDARD_FIXES =
-  `Standard fixes:\n` +
-  `  1. Append to --body directly:\n` +
-  `       gh issue comment N --body "...$(gh-signature-helper.sh footer)"\n` +
-  `  2. Append to --body-file (two-step pattern):\n` +
-  `       gh-signature-helper.sh footer >> "$BODY_FILE"\n` +
-  `       gh issue comment N --body-file "$BODY_FILE"\n` +
-  `  3. Source the wrapper and call by name:\n` +
-  `       source ~/.aidevops/agents/scripts/shared-gh-wrappers.sh\n` +
-  `       gh_issue_comment N --body-file "$BODY_FILE"`;
+	`Standard fixes:\n` +
+	`  1. Append to --body directly:\n` +
+	`       gh issue comment N --body "...$(gh-signature-helper.sh footer)"\n` +
+	`  2. Append to --body-file before posting:\n` +
+	`       gh-signature-helper.sh footer >> "$BODY_FILE"\n` +
+	`       gh issue comment N --body-file "$BODY_FILE"\n` +
+	`  3. Source shared-gh-wrappers.sh and call by name:\n` +
+	`       source ~/.aidevops/agents/scripts/shared-gh-wrappers.sh\n` +
+	`       gh_issue_comment N --body-file "$BODY_FILE"`;
 
 /**
  * Build the throw error message for a structured repair failure (t2893).

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -198,9 +198,9 @@ export function hasTrustedSignatureSignal(cmd) {
  * @returns {boolean}
  */
 function _hasUnparseableBody(cmd) {
-  // If the command already invokes the helper or includes the marker,
-  // it's safe to pass through (signature is being handled).
-  if (cmd.includes("gh-signature-helper") || cmd.includes(SIG_MARKER)) {
+  // If the command already carries a trusted signature signal, it's safe
+  // to pass through (signature is being handled by the caller/shim).
+  if (hasTrustedSignatureSignal(cmd)) {
     return false;
   }
 

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -190,10 +190,20 @@ export function hasTrustedSignatureSignal(cmd) {
  * substitution, or command substitution in the body argument). These forms
  * are too dynamic to rewrite safely and the caller should use the helper
  * explicitly. Returns true if unparseable.
+ *
+ * Exception: if the command already includes gh-signature-helper.sh or the
+ * canonical marker, it's safe to pass through (the signature is already
+ * being handled by the caller).
  * @param {string} cmd
  * @returns {boolean}
  */
 function _hasUnparseableBody(cmd) {
+  // If the command already invokes the helper or includes the marker,
+  // it's safe to pass through (signature is being handled).
+  if (cmd.includes("gh-signature-helper") || cmd.includes(SIG_MARKER)) {
+    return false;
+  }
+
   // Heredoc / process substitution
   if (/--body(?:-file)?\s*=?\s*(?:<<-?\s*['"]?\w+|<\()/.test(cmd)) return true;
   // Command substitution inside --body value

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -613,7 +613,7 @@ describe("checkSignatureFooterGate throw message (t2893)", () => {
     assert.ok(thrown);
     assert.match(thrown.message, /Standard fixes/);
     assert.match(thrown.message, /Append to --body directly/);
-    assert.match(thrown.message, /two-step pattern/);
-    assert.match(thrown.message, /Source the wrapper/);
+    assert.match(thrown.message, /before posting/);
+    assert.match(thrown.message, /Source shared-gh-wrappers/);
   });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -370,6 +370,24 @@ describe("checkSignatureFooterGate", () => {
     assert.equal(output.args.command, cmd);
   });
 
+  test("no-ops on process-substitution body-file when helper appends footer", () => {
+    const { log } = makeLogger();
+    const cmd =
+      'gh issue comment 1 --body-file <(cat body.md && gh-signature-helper.sh footer)';
+    const output = { args: { command: cmd } };
+    checkSignatureFooterGate(cmd, log, "/nonexistent", output);
+    assert.equal(output.args.command, cmd);
+  });
+
+  test("no-ops on command-substitution body containing canonical marker", () => {
+    const { log } = makeLogger();
+    const cmd =
+      `gh issue comment 1 --body "$(printf 'body\\n\\n${SIG_MARKER}\\n---\\nfooter')"`;
+    const output = { args: { command: cmd } };
+    checkSignatureFooterGate(cmd, log, "/nonexistent", output);
+    assert.equal(output.args.command, cmd);
+  });
+
   test("REPAIRS simple --body command in place (t2685)", () => {
     const dir = setupStubHelper();
     const { log } = makeLogger();


### PR DESCRIPTION
## Summary

Fixes issue #1469 in superdav-ai-agent: recurring gh write command blocked at signature gate errors (47x occurrences).

Resolves #1469 (in superdav-ai-agent repository)

## Changes

- Modify `_hasUnparseableBody()` to allow commands that already include `gh-signature-helper.sh` or the canonical marker
- This allows users to use heredoc or command substitution as long as they're also including the signature footer
- Update error message wording for clarity ('before posting' instead of 'two-step pattern')
- Update test to match new error message wording

## Testing

All existing tests pass. The fix allows patterns like:
- `gh issue comment N --body "$(gh-signature-helper.sh footer)"`
- `gh issue comment N --body-file <(cat file && gh-signature-helper.sh footer)`

These patterns were previously blocked even though they correctly include the signature footer.