### PR TITLE
GH#23684: harden blocker candidate handling

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -73,14 +73,12 @@ _task_line_from_block() {
 }
 
 _has_unresolved_blocker() {
-	local text="$1" task_id="${2:-}" task_line="${3:-}"
+	local text="$1"
+	local task_id="${2:-}"
+	local task_line="${3:-}"
 	local candidate
-	if [[ -n "$task_line" ]]; then
-		candidate="$task_line"
-	else
-		candidate=$(_task_line_from_block "$text" "$task_id")
-	fi
-	echo "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
+	candidate="${task_line:-$(_task_line_from_block "$text" "$task_id")}"
+	printf '%s\n' "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
 	return 1
 }
 


### PR DESCRIPTION
## Summary

Hardened _has_unresolved_blocker by using parameter-expansion fallback for the precomputed task line and replacing echo with printf for blocker detection. Kept local argument declarations in the repo-approved style because the positional-parameter ratchet rejects split assignments from $1.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/issue-sync-helper-close.sh; .agents/scripts/tests/test-issue-sync-completion-evidence.sh; .agents/scripts/tests/test-issue-sync-close-signature.sh

Resolves #23684


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 1m and 42,512 tokens on this as a headless worker.