### PR TITLE
fix: remove default value from operator label check to prevent shell parsing issue

### DIFF
--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -116,7 +116,7 @@ _health_issue_operator_label_allows_identity() {
 	local canonical_identity="$2"
 	local canonical_label="operator:${canonical_identity}"
 
-	printf '%s' "${issue_json:-{}}" | jq -e --arg canonical_label "$canonical_label" '
+	printf '%s' "$issue_json" | jq -e --arg canonical_label "$canonical_label" '
 		((.labels // []) | map(.name) | map(select(startswith("operator:")))) as $operator_labels
 		| ($operator_labels | length == 0 or any(. == $canonical_label))
 	' >/dev/null 2>&1


### PR DESCRIPTION
## Summary

The `${issue_json:-{}}` expansion was causing a shell parsing issue where the closing brace in the JSON was being interpreted as the end of the parameter expansion, resulting in malformed JSON being passed to jq. This caused the operator label check to fail, preventing the health dashboard from being updated.

## Root Cause

The issue was in the `_health_issue_operator_label_allows_identity` function in `.agents/scripts/stats-health-dashboard-issue.sh`. The function was using `${issue_json:-{}}` to provide a default value, but this caused the shell to misinterpret the closing brace in the JSON.

## Solution

Remove the default value and assume that `issue_json` is always set, since it's always provided by the caller.

## Testing

The fix has been tested and verified to resolve the issue. The health dashboard for superdav42/aidevops-routines is now being updated correctly.

Fixes #62

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-haiku-4-5 spent 34m and 2,300 tokens on this as a headless worker.
