### PR TITLE
GH#23686: preserve model selection failure status

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1592,8 +1592,8 @@ cmd_run() {
 
 	print_info "[lifecycle] pre_model_select session=$session_key role=$role tier=${tier_override:-auto} pid=$$"
 	local selected_model
+	local choose_exit
 	selected_model=$(choose_model "$role" "${model_override:-$initial_model}" "$tier_override") || {
-		local choose_exit
 		choose_exit=$?
 		_cmd_run_finish "$session_key" "fail"
 		return "$choose_exit"


### PR DESCRIPTION
## Summary

Preserve choose_model failure exit status by declaring choose_exit before the command substitution and assigning it immediately in the failure handler.

## Files Changed

.agents/scripts/headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-helper.sh

Resolves #23686


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 1m and 36,678 tokens on this as a headless worker.