### PR TITLE
GH#23685: fix: use pathlib as_uri in headless canary test

### DIFF
--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -811,7 +811,7 @@ EOF
 		local env_output
 		env_output=$(<"$env_file")
 		local expected_plugin_url
-		expected_plugin_url=$(python3 -c 'import pathlib, sys, urllib.parse; print("file://" + urllib.parse.quote(str(pathlib.Path(sys.argv[1]).absolute())))' "$plugin_path")
+		expected_plugin_url=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).absolute().as_uri())' "$plugin_path")
 		if [[ "$args" == *'What is two plus two?'* && "$args" != *'--pure'* && "$args" != *'--agent build'* ]] &&
 			[[ "$env_output" == *"OPENCODE_BIN=${fake_bin_dir}/opencode"* ]] &&
 			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]] &&


### PR DESCRIPTION
## Summary

Aligned the headless runtime canary test's expected plugin URL calculation with the production helper by using pathlib.Path.as_uri().

## Files Changed

.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #23685


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 1m and 39,991 tokens on this as a headless worker.