### PR TITLE
GH#23689: simplify non-task label detection

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-normalize.sh
+++ b/.agents/scripts/pulse-issue-reconcile-normalize.sh
@@ -183,7 +183,7 @@ _fetch_label_invariant_rows() {
 			([.labels[].name | select(startswith("tier:"))   | sub("^tier:";   "")] | join(" ")),
 			((.labels | map(.name) | index("origin:interactive")) != null | tostring),
 			((.labels | map(.name) | index("auto-dispatch"))      != null | tostring),
-			((.labels | map(.name) | any(.[]; . as $label | ["supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold"] | index($label))) | tostring),
+			(any(.labels[].name; . == ("supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold")) | tostring),
 			(.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime | tostring),
 			(([.labels[].name | select(startswith("status:"))] | length) | tostring)
 		] | join("|")


### PR DESCRIPTION
## Summary

- Simplifies non-task label detection in `pulse-issue-reconcile-normalize.sh` to use jq `any(generator; condition)` directly.

## Testing

- `shellcheck .agents/scripts/pulse-issue-reconcile-normalize.sh`
- Targeted jq sample returned expected `true`/`false` non-task rows.

## Runtime Testing

self-assessed: low-risk shell jq expression cleanup verified with static ShellCheck and a focused jq sample.

Resolves #23689


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 1m and 39,027 tokens on this as a headless worker.
