### PR TITLE
GH#23690: harden pulse PR cache cleanup

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1813,7 +1813,7 @@ main() {
 		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-view-cache-${$}"
 		export AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}"
 		_save_cleanup_scope
-		trap '_run_cleanups' RETURN
+		trap '_run_cleanups' EXIT
 		push_cleanup 'release_instance_lock'
 		_pulse_pr_cache_cleanup_scope=1
 		push_cleanup "rm -rf \"${AIDEVOPS_GH_PR_VIEW_CACHE_DIR}\""
@@ -1831,7 +1831,7 @@ main() {
 		export AIDEVOPS_GH_PR_LIST_CACHE_TTL="${AIDEVOPS_PULSE_PR_LIST_CACHE_TTL:-3600}"
 		if [[ "$_pulse_pr_cache_cleanup_scope" -eq 0 ]]; then
 			_save_cleanup_scope
-			trap '_run_cleanups' RETURN
+			trap '_run_cleanups' EXIT
 			push_cleanup 'release_instance_lock'
 			_pulse_pr_cache_cleanup_scope=1
 		fi

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -204,12 +204,15 @@ test_pr_cache_ttls_are_per_cycle() {
 	if ! grep -q 'AIDEVOPS_GH_PR_LIST_CACHE_DIR=.*aidevops-pulse-pr-list-cache' "$WRAPPER_SCRIPT"; then
 		missing="${missing} list-cache-dir"
 	fi
+	if ! grep -q "trap '_run_cleanups' EXIT" "$WRAPPER_SCRIPT"; then
+		missing="${missing} exit-cleanup-trap"
+	fi
 
 	if [[ -z "$missing" ]]; then
-		print_result "pulse configures per-cycle PR list/view cache TTLs" 0
+		print_result "pulse configures per-cycle PR list/view cache TTLs and EXIT cleanup" 0
 		return 0
 	fi
-	print_result "pulse configures per-cycle PR list/view cache TTLs" 1 \
+	print_result "pulse configures per-cycle PR list/view cache TTLs and EXIT cleanup" 1 \
 		"Missing pulse cache wiring:${missing}"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Use EXIT traps for pulse PR metadata cache cleanup so temporary cache directories and the instance lock are cleaned up on set -e aborts.
- Add canary test coverage for EXIT cleanup wiring alongside the PR cache TTL checks.

## Testing

- shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-canary.sh
- .agents/scripts/tests/test-pulse-wrapper-canary.sh

## Runtime Testing

- self-assessed: shell cleanup path covered by static/canary test; no live pulse daemon run required for this narrow trap-signal fix.

Resolves #23690


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 2m and 73,622 tokens on this as a headless worker.
