### PR TITLE
GH#23692: fix FOSS disclosure opt-out

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1206,6 +1206,7 @@ dispatch_foss_workers() {
 	local foss_count=0
 	local foss_max="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"
 	local foss_session_keys_seen=$'\n'
+	local foss_slug foss_path disclosure labels_filter_json
 
 	[[ "$available" =~ ^[0-9]+$ ]] || available=0
 
@@ -1279,7 +1280,7 @@ dispatch_foss_workers() {
 		| [
 			.slug,
 			.path,
-			((.foss_config.disclosure // true) | tostring),
+			((.foss_config.disclosure != false) | tostring),
 			((.foss_config.labels_filter // ["help wanted","good first issue","bug"]) | @json)
 		]
 		| @tsv' \


### PR DESCRIPTION
## Summary

Respect explicit false FOSS disclosure settings and localize read-loop variables in pulse ancillary dispatch.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-ancillary-dispatch.sh; jq disclosure default behavior check

Resolves #23692


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 1m and 38,586 tokens on this as a headless worker.