### PR TITLE
GH#23691: tighten supply-chain self-reference path matching

### DIFF
--- a/.agents/scripts/supply-chain-advisory-helper.sh
+++ b/.agents/scripts/supply-chain-advisory-helper.sh
@@ -27,7 +27,7 @@ is_known_safe_ioc_self_reference() {
 	local hit_path="${hit_line%%:*}"
 
 	case "$hit_path" in
-	*.agents/reference/npm-supply-chain-response.md | *.agents/scripts/supply-chain-advisory-helper.sh)
+	.agents/reference/npm-supply-chain-response.md | */.agents/reference/npm-supply-chain-response.md | .agents/scripts/supply-chain-advisory-helper.sh | */.agents/scripts/supply-chain-advisory-helper.sh)
 		return 0
 		;;
 	*)

--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -140,11 +140,36 @@ test_non_self_ioc_scan_fails() {
 	return 0
 }
 
+test_similar_agents_suffix_ioc_scan_fails() {
+	local tmpdir
+	tmpdir=$(make_tmpdir) || {
+		print_result "similarly named agents directory still fails" 1 "mktemp failed"
+		return 0
+	}
+
+	mkdir -p "${tmpdir}/not.agents/reference" || return 1
+	printf '%s\n' 'Suspicious artifact: router_''init.js' >"${tmpdir}/not.agents/reference/npm-supply-chain-response.md"
+
+	local output
+	local status=0
+	output=$(HOME="$tmpdir" bash "$HELPER_SCRIPT" scan "$tmpdir" 2>&1) || status=$?
+	if [[ "$status" -eq 1 ]] \
+		&& [[ "$output" == *"not.agents/reference/npm-supply-chain-response.md"* ]] \
+		&& [[ "$output" == *"Potential supply-chain compromise indicators found"* ]]; then
+		print_result "similarly named agents directory still fails" 0
+	else
+		print_result "similarly named agents directory still fails" 1 "status=${status} output=${output}"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
 main() {
 	test_self_reference_only_scan_succeeds
 	test_relative_self_reference_only_scan_succeeds
 	test_single_file_self_reference_only_scan_succeeds
 	test_non_self_ioc_scan_fails
+	test_similar_agents_suffix_ioc_scan_fails
 
 	printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -147,7 +147,11 @@ test_similar_agents_suffix_ioc_scan_fails() {
 		return 0
 	}
 
-	mkdir -p "${tmpdir}/not.agents/reference" || return 1
+	if ! mkdir -p "${tmpdir}/not.agents/reference"; then
+		print_result "similarly named agents directory still fails" 1 "mkdir failed"
+		rm -rf "$tmpdir"
+		return 0
+	fi
 	printf '%s\n' 'Suspicious artifact: router_''init.js' >"${tmpdir}/not.agents/reference/npm-supply-chain-response.md"
 
 	local output


### PR DESCRIPTION
## Summary

Tightened supply-chain advisory self-reference matching to only allow exact .agents paths and added regression coverage for similarly named directories.

## Files Changed

.agents/scripts/supply-chain-advisory-helper.sh,.agents/scripts/tests/test-supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/supply-chain-advisory-helper.sh .agents/scripts/tests/test-supply-chain-advisory-helper.sh; bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh

Resolves #23691


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 1m and 42,296 tokens on this as a headless worker.