### PR TITLE
GH#23706: harden label invariant jq labels handling

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-normalize.sh
+++ b/.agents/scripts/pulse-issue-reconcile-normalize.sh
@@ -177,15 +177,15 @@ _fetch_label_invariant_rows() {
 	# managed via an exception label (needs-info, verify-failed, stale,
 	# needs-testing, orphaned). See CodeRabbit review on PR #18546.
 	printf '%s' "$issues_json" | jq -r '
-		.[] | [
+		.[] | (.labels // []) as $labels | [
 			(.number | tostring),
-			([.labels[].name | select(startswith("status:")) | sub("^status:"; "")] | join(" ")),
-			([.labels[].name | select(startswith("tier:"))   | sub("^tier:";   "")] | join(" ")),
-			((.labels | map(.name) | index("origin:interactive")) != null | tostring),
-			((.labels | map(.name) | index("auto-dispatch"))      != null | tostring),
-			(any(.labels[].name; . == ("supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold")) | tostring),
+			([$labels[].name | select(startswith("status:")) | sub("^status:"; "")] | join(" ")),
+			([$labels[].name | select(startswith("tier:"))   | sub("^tier:";   "")] | join(" ")),
+			(($labels | map(.name) | index("origin:interactive")) != null | tostring),
+			(($labels | map(.name) | index("auto-dispatch"))      != null | tostring),
+			(any($labels[]?.name; . == ("supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold")) | tostring),
 			(.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime | tostring),
-			(([.labels[].name | select(startswith("status:"))] | length) | tostring)
+			(([$labels[].name | select(startswith("status:"))] | length) | tostring)
 		] | join("|")
 	' 2>/dev/null
 	return 0

--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -286,6 +286,7 @@ export PULSE_QUEUED_SCAN_LIMIT=100
 #   #8: triage-missing-but-has-tier → not counted
 #   #9: triage-missing shape but routine-tracking non-task → not counted
 #   #10: triage-missing shape but supervisor non-task → not counted
+#   #11/#12: null/missing labels → no jq error and no edits
 OLD_ISO=$(date -u -d '-1 hour' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
 	TZ=UTC date -v-1H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "2026-04-13T00:00:00Z")
 NEW_ISO=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -302,7 +303,9 @@ ISSUES_JSON=$(
 	{"number":7,"labels":[{"name":"origin:interactive"}],"createdAt":"${NEW_ISO}"},
 	{"number":8,"labels":[{"name":"origin:interactive"},{"name":"tier:standard"}],"createdAt":"${OLD_ISO}"},
 	{"number":9,"labels":[{"name":"origin:interactive"},{"name":"routine-tracking"}],"createdAt":"${OLD_ISO}"},
-	{"number":10,"labels":[{"name":"origin:interactive"},{"name":"supervisor"}],"createdAt":"${OLD_ISO}"}
+	{"number":10,"labels":[{"name":"origin:interactive"},{"name":"supervisor"}],"createdAt":"${OLD_ISO}"},
+	{"number":11,"labels":null,"createdAt":"${OLD_ISO}"},
+	{"number":12,"createdAt":"${OLD_ISO}"}
 ]
 JSON
 )
@@ -415,6 +418,15 @@ if [[ "$n6" -eq 0 && "$n7" -eq 0 && "$n8" -eq 0 && "$n9" -eq 0 && "$n10" -eq 0 ]
 	print_result "reconciler does not auto-fix triage-missing issues" 0
 else
 	print_result "reconciler does not auto-fix triage-missing issues" 1 "(edits: #6=$n6 #7=$n7 #8=$n8 #9=$n9 #10=$n10)"
+fi
+
+# Issues #11/#12: null/missing labels must not make jq abort the row stream.
+n11=$(count_edits_for 11)
+n12=$(count_edits_for 12)
+if [[ "$n11" -eq 0 && "$n12" -eq 0 ]]; then
+	print_result "reconciler tolerates null and missing labels" 0
+else
+	print_result "reconciler tolerates null and missing labels" 1 "(edits: #11=$n11 #12=$n12)"
 fi
 
 # Counter file must be written with exact numbers


### PR DESCRIPTION
## Summary

Hardened label invariant row extraction by normalizing missing/null labels to an empty array before jq label checks, and added regression coverage for null and missing labels.

## Files Changed

.agents/scripts/pulse-issue-reconcile-normalize.sh,.agents/scripts/tests/test-label-invariants.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-label-invariants.sh; shellcheck .agents/scripts/pulse-issue-reconcile-normalize.sh .agents/scripts/tests/test-label-invariants.sh

Resolves #23706


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 60,573 tokens on this as a headless worker.