### PR TITLE
fix: block external repo claim spam

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -118,6 +118,10 @@ if [[ -r "${DISPATCH_CLAIM_HELPER_DIR}/gh-signature-helper-detect.sh" ]]; then
 	# shellcheck source=gh-signature-helper-detect.sh
 	source "${DISPATCH_CLAIM_HELPER_DIR}/gh-signature-helper-detect.sh"
 fi
+if [[ -r "${DISPATCH_CLAIM_HELPER_DIR}/shared-repo-state-guard.sh" ]]; then
+	# shellcheck source=shared-repo-state-guard.sh
+	source "${DISPATCH_CLAIM_HELPER_DIR}/shared-repo-state-guard.sh"
+fi
 if [[ -r "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-override-resolve.sh" ]]; then
 	# shellcheck disable=SC1091
 	source "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-override-resolve.sh"
@@ -232,6 +236,13 @@ _post_claim() {
 	local nonce="$4"
 	local ts="$5"
 	local reason_fields="${6:-}"
+
+	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+			echo "CLAIM_SKIPPED: repo_state_not_managed issue=#${issue_number} repo=${repo_slug}" >&2
+			return 1
+		fi
+	fi
 
 	# t2401: include framework version so peers can filter claims from older runners.
 	local version
@@ -994,6 +1005,13 @@ cmd_claim() {
 		return 2
 	fi
 
+	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+			echo "CLAIM_SKIPPED: repo_state_not_managed issue=#${issue_number} repo=${repo_slug} — not dispatching" >&2
+			return 1
+		fi
+	fi
+
 	local runner
 	runner=$(_resolve_runner "$runner_login") || runner="unknown"
 
@@ -1140,6 +1158,14 @@ cmd_check() {
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		echo "Error: check requires <issue-number> <repo-slug>" >&2
 		return 2
+	fi
+
+	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+			printf 'CLAIM_SKIPPED: repo_state_not_managed issue=#%s repo=%s — treating as active to block dispatch\n' \
+				"$issue_number" "$repo_slug" >&2
+			return 0
+		fi
 	fi
 
 	local claims

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -38,6 +38,10 @@ if [[ -r "${_HRFF_SCRIPT_DIR}/gh-signature-helper-detect.sh" ]]; then
 	# shellcheck source=gh-signature-helper-detect.sh
 	source "${_HRFF_SCRIPT_DIR}/gh-signature-helper-detect.sh"
 fi
+if [[ -r "${_HRFF_SCRIPT_DIR}/shared-repo-state-guard.sh" ]]; then
+	# shellcheck source=shared-repo-state-guard.sh
+	source "${_HRFF_SCRIPT_DIR}/shared-repo-state-guard.sh"
+fi
 unset _HRFF_SCRIPT_DIR
 : "${AIDEVOPS_UNKNOWN_VERSION:=unknown}"
 
@@ -303,6 +307,12 @@ _release_dispatch_claim() {
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		print_warning "Cannot release claim: missing issue=$issue_number repo=$repo_slug"
 		return 0
+	fi
+	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+			print_info "Skipping CLAIM_RELEASED for #${issue_number} in ${repo_slug}: repo state is not managed by this account"
+			return 0
+		fi
 	fi
 
 	if [[ "$reason" == "rate_limit_transient" ]]; then

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -266,6 +266,26 @@ _unlock_issue_after_dispatch_release() {
 }
 
 #######################################
+# Check whether dispatch release may mutate issue state for a repo.
+#
+# Args:
+#   $1 = issue_number
+#   $2 = repo_slug
+#######################################
+_hrff_release_repo_state_is_managed() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+			print_info "Skipping CLAIM_RELEASED for #${issue_number} in ${repo_slug}: repo state is not managed by this account"
+			return 1
+		fi
+	fi
+	return 0
+}
+
+#######################################
 # Release a dispatch claim by posting a CLAIM_RELEASED comment.
 # The dedup guard recognises this and allows immediate re-dispatch
 # instead of waiting for the 30-min TTL to expire.
@@ -308,12 +328,7 @@ _release_dispatch_claim() {
 		print_warning "Cannot release claim: missing issue=$issue_number repo=$repo_slug"
 		return 0
 	fi
-	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
-		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
-			print_info "Skipping CLAIM_RELEASED for #${issue_number} in ${repo_slug}: repo state is not managed by this account"
-			return 0
-		fi
-	fi
+	_hrff_release_repo_state_is_managed "$issue_number" "$repo_slug" || return 0
 
 	if [[ "$reason" == "rate_limit_transient" ]]; then
 		if ! _hrff_handle_rate_limit_release_circuit "$issue_number" "$repo_slug"; then

--- a/.agents/scripts/shared-repo-state-guard.sh
+++ b/.agents/scripts/shared-repo-state-guard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Shared Repository State Guard
+# =============================================================================
+# Guards aidevops issue-state writes (dispatch claims, claim releases, labels,
+# locks) so public workflow markers are only emitted where the authenticated
+# user has maintainer-equivalent access. External upstream repositories may be
+# valid PR targets, but they must not receive aidevops internal coordination
+# spam.
+
+[[ -n "${_SHARED_REPO_STATE_GUARD_LOADED:-}" ]] && return 0
+_SHARED_REPO_STATE_GUARD_LOADED=1
+
+#######################################
+# Resolve the authenticated GitHub login.
+# Returns: login on stdout, empty on failure.
+#######################################
+aidevops_repo_state_current_user() {
+	local login=""
+	login=$(gh api user --jq '.login' 2>/dev/null || printf '')
+	if [[ "$login" == *'"login"'* ]] && command -v jq >/dev/null 2>&1; then
+		login=$(printf '%s' "$login" | jq -r '.login // empty' 2>/dev/null || printf '')
+	fi
+	if [[ -z "$login" || "$login" == "null" ]]; then
+		printf ''
+		return 0
+	fi
+	printf '%s' "$login"
+	return 0
+}
+
+#######################################
+# Check whether aidevops may mutate issue workflow state for a repo.
+#
+# Args:
+#   $1 = repo slug (owner/repo)
+#   $2 = optional authenticated login override
+# Returns: 0 when state writes are allowed, 1 otherwise.
+#######################################
+aidevops_can_manage_repo_issue_state() {
+	local slug="${1:-}"
+	local user="${2:-}"
+
+	if [[ "${AIDEVOPS_TEST_MODE:-}" == "1" && \
+		"${AIDEVOPS_REPO_STATE_GUARD_TEST_BYPASS:-}" == "1" ]]; then
+		return 0
+	fi
+
+	if [[ -z "$slug" || "$slug" != */* ]]; then
+		return 1
+	fi
+
+	if [[ -z "$user" ]]; then
+		user=$(aidevops_repo_state_current_user)
+	fi
+	if [[ -z "$user" || "$user" == "null" ]]; then
+		return 1
+	fi
+
+	local repo_owner="${slug%%/*}"
+	if [[ "$user" == "$repo_owner" ]]; then
+		return 0
+	fi
+
+	local permission=""
+	permission=$(gh api "repos/${slug}/collaborators/${user}/permission" \
+		--jq '.permission // ""' 2>/dev/null || printf '')
+	case "$permission" in
+		admin | maintain | write)
+			return 0
+			;;
+	esac
+
+	return 1
+}

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 CLAIM_HELPER="${SCRIPT_DIR}/../dispatch-claim-helper.sh"
 DEDUP_HELPER="${SCRIPT_DIR}/../dispatch-dedup-helper.sh"
+export AIDEVOPS_TEST_MODE=1
+export AIDEVOPS_REPO_STATE_GUARD_TEST_BYPASS=1
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'

--- a/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
+++ b/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
@@ -11,6 +11,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_HOME="$(mktemp -d)"
 CALL_LOG="${TMP_HOME}/gh-calls.log"
 : >"$CALL_LOG"
+export AIDEVOPS_TEST_MODE=1
+export AIDEVOPS_REPO_STATE_GUARD_TEST_BYPASS=1
 
 cleanup() {
 	rm -rf "$TMP_HOME"

--- a/.agents/scripts/tests/test-repo-state-guard.sh
+++ b/.agents/scripts/tests/test-repo-state-guard.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+call_log="${tmp_dir}/gh-calls.log"
+mode_file="${tmp_dir}/mode"
+printf 'external\n' >"$mode_file"
+
+mkdir -p "${tmp_dir}/bin"
+cat >"${tmp_dir}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${GH_CALL_LOG}"
+mode=$(cat "${GH_MODE_FILE}")
+if [[ "$1" == "api" && "$2" == "user" ]]; then
+  printf '%s\n' "tester"
+  exit 0
+fi
+if [[ "$1" == "api" && "$2" == repos/*/collaborators/*/permission ]]; then
+  if [[ "$mode" == "managed" ]]; then
+    printf '%s\n' "write"
+    exit 0
+  fi
+  printf '%s\n' '{"message":"Must have push access"}' >&2
+  exit 1
+fi
+if [[ "$1" == "api" && "$2" == repos/*/issues/*/comments ]]; then
+  if [[ "$mode" == "posted" ]]; then
+    printf '%s\n' '[]'
+    exit 0
+  fi
+  printf '%s\n' '{"id":123}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "${tmp_dir}/bin/gh"
+
+export PATH="${tmp_dir}/bin:${PATH}"
+export GH_CALL_LOG="$call_log"
+export GH_MODE_FILE="$mode_file"
+export DISPATCH_CLAIM_WINDOW=0
+export AIDEVOPS_VERSION_FILE="${tmp_dir}/VERSION"
+printf '9.9.9\n' >"$AIDEVOPS_VERSION_FILE"
+
+# shellcheck source=../shared-repo-state-guard.sh
+source "${AGENTS_SCRIPTS_DIR}/shared-repo-state-guard.sh"
+
+pass_count=0
+fail_count=0
+
+check() {
+	local condition="$1"
+	local name="$2"
+	local detail="${3:-}"
+	if [[ "$condition" == "1" ]]; then
+		printf 'PASS %s\n' "$name"
+		pass_count=$((pass_count + 1))
+	else
+		printf 'FAIL %s %s\n' "$name" "$detail"
+		fail_count=$((fail_count + 1))
+	fi
+	return 0
+}
+
+if aidevops_can_manage_repo_issue_state "tester/project"; then
+	check 1 "repo owner may manage state"
+else
+	check 0 "repo owner may manage state"
+fi
+
+if aidevops_can_manage_repo_issue_state "other/project"; then
+	check 0 "external non-maintainer is blocked"
+else
+	check 1 "external non-maintainer is blocked"
+fi
+
+printf 'managed\n' >"$mode_file"
+if aidevops_can_manage_repo_issue_state "other/project"; then
+	check 1 "write collaborator may manage state"
+else
+	check 0 "write collaborator may manage state"
+fi
+
+printf 'external\n' >"$mode_file"
+set +e
+claim_output=$("${AGENTS_SCRIPTS_DIR}/dispatch-claim-helper.sh" claim 866 afragen/git-updater tester 2>&1)
+claim_rc=$?
+set -e
+if [[ "$claim_rc" -eq 1 && "$claim_output" == *"CLAIM_SKIPPED"* ]]; then
+	check 1 "dispatch claim blocks unmanaged repo"
+else
+	check 0 "dispatch claim blocks unmanaged repo" "rc=${claim_rc} output=${claim_output}"
+fi
+
+if grep -q 'repos/afragen/git-updater/issues/866/comments' "$call_log"; then
+	check 0 "unmanaged dispatch claim posts no comment"
+else
+	check 1 "unmanaged dispatch claim posts no comment"
+fi
+
+set +e
+release_skip_output=$(bash -c '
+  source "${0}/shared-constants.sh"
+  source "${0}/worker-lifecycle-common.sh"
+  source "${0}/headless-runtime-failure.sh"
+  WORKER_ISSUE_NUMBER=866 DISPATCH_REPO_SLUG=afragen/git-updater _release_dispatch_claim issue-866 worker_complete 0 0
+' "$AGENTS_SCRIPTS_DIR" 2>&1)
+release_skip_rc=$?
+set -e
+if [[ "$release_skip_rc" -eq 0 && "$release_skip_output" == *"Skipping CLAIM_RELEASED"* ]]; then
+	check 1 "unmanaged release skips comment"
+else
+	check 0 "unmanaged release skips comment" "rc=${release_skip_rc} output=${release_skip_output}"
+fi
+
+printf 'managed\n' >"$mode_file"
+set +e
+release_output=$(bash -c '
+  source "${0}/shared-constants.sh"
+  source "${0}/worker-lifecycle-common.sh"
+  source "${0}/headless-runtime-failure.sh"
+  WORKER_ISSUE_NUMBER=866 DISPATCH_REPO_SLUG=afragen/git-updater _release_dispatch_claim issue-866 worker_complete 0 0
+' "$AGENTS_SCRIPTS_DIR" 2>&1)
+release_rc=$?
+set -e
+if [[ "$release_rc" -eq 0 && "$release_output" == *"Released claim"* ]]; then
+	check 1 "managed release still posts"
+else
+	check 0 "managed release still posts" "rc=${release_rc} output=${release_output}"
+fi
+
+printf '\nResult: %d passed, %d failed\n' "$pass_count" "$fail_count"
+[[ "$fail_count" -eq 0 ]]

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -70,6 +70,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
+if [[ -r "${SCRIPT_DIR}/shared-repo-state-guard.sh" ]]; then
+	# shellcheck source=shared-repo-state-guard.sh
+	source "${SCRIPT_DIR}/shared-repo-state-guard.sh"
+fi
 
 #######################################
 # Configuration (from args, with defaults)
@@ -490,6 +494,11 @@ _release_claim() {
 
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		return 0
+	fi
+	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+			return 0
+		fi
 	fi
 
 	local comment_body


### PR DESCRIPTION
## Summary
- Add a shared repo state guard that allows aidevops claim/label/lock comment writes only for repo owners or write/maintain/admin collaborators.
- Block dispatch claims/checks and worker CLAIM_RELEASED paths for unmanaged external repos.
- Cover the guard with regression tests and keep existing dispatch/release tests running through an explicit test-mode bypass.

## Root cause
The worker dispatch/release lifecycle trusted any repo slug in dispatch context and posted public DISPATCH_CLAIM/CLAIM_RELEASED audit comments without verifying that the authenticated account could manage issue state in that repository. External upstream repos therefore received internal aidevops coordination markers after worker runs.

## Cleanup performed
Deleted 7 erroneous CLAIM_RELEASED comments authored by marcusquinn from afragen/git-updater issue #866. Verification query returned no remaining CLAIM_RELEASED comments by marcusquinn in that repo.

## Verification
- bash .agents/scripts/tests/test-repo-state-guard.sh
- bash .agents/scripts/tests/test-dispatch-claim-helper.sh
- bash .agents/scripts/tests/test-headless-runtime-release-unlock.sh
- shellcheck .agents/scripts/shared-repo-state-guard.sh .agents/scripts/dispatch-claim-helper.sh .agents/scripts/headless-runtime-failure.sh .agents/scripts/worker-activity-watchdog.sh .agents/scripts/tests/test-repo-state-guard.sh .agents/scripts/tests/test-dispatch-claim-helper.sh .agents/scripts/tests/test-headless-runtime-release-unlock.sh
- .agents/scripts/linters-local.sh reached existing advisory markdown/ratchet warnings and timed out during later portability gate; targeted ShellCheck/tests passed.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.56 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 15m and 148,249 tokens on this with the user in an interactive session.


Resolves #23712
