### PR TITLE
fix: keep profile AI stats source-consistent

### DIFF
--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -231,6 +231,30 @@ _compute_costs_from_tokens() {
 	return 0
 }
 
+# --- Count model-usage requests in a JSON array ---
+_model_usage_request_count() {
+	local model_json="$1"
+	echo "$model_json" | jq -r 'if type == "array" then ([.[].requests // 0] | add // 0) else 0 end' 2>/dev/null || printf '0\n'
+	return 0
+}
+
+# --- Detect whether a candidate all-time model set is lower than a reference ---
+_model_usage_undercuts_reference() {
+	local candidate_json="$1"
+	local reference_json="$2"
+	jq -e -n --argjson candidate "${candidate_json:-[]}" --argjson reference "${reference_json:-[]}" '
+		def rows($a): if ($a | type) == "array" then $a else [] end;
+		(rows($candidate) | INDEX(.model)) as $candidate_by_model
+		| any(rows($reference)[];
+			(($candidate_by_model[.model].requests // 0) < (.requests // 0))
+			or (($candidate_by_model[.model].input_tokens // 0) < (.input_tokens // 0))
+			or (($candidate_by_model[.model].output_tokens // 0) < (.output_tokens // 0))
+			or (($candidate_by_model[.model].cache_read_tokens // 0) < (.cache_read_tokens // 0))
+		)
+	' >/dev/null 2>&1
+	return $?
+}
+
 # --- Gather model usage from OpenCode session DB (full history) ---
 # Returns JSON array with cost_total computed, or empty string if unavailable.
 _get_model_usage_from_opencode() {
@@ -380,12 +404,29 @@ _get_model_usage_from_obs_db() {
 _get_model_usage() {
 	local period="${1:-30d}"
 
-	# For "all" period, use OpenCode session DB (has full history back to first use).
-	# The observability DB (llm-requests.db) only has data from when it was created.
+	# For "all" period, compare complete local sources and use the one with the
+	# larger request population. This avoids stale OpenCode message JSON causing
+	# "all time" to be lower than the last-30-days observability totals after
+	# runtime schema changes, while preserving OpenCode as fallback for installs
+	# where observability started later.
 	if [[ "$period" == "all" ]]; then
-		local oc_result
+		local obs_all_result obs_recent_result oc_result obs_requests oc_requests
+		local recent_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+		obs_all_result=$(_get_model_usage_from_obs_db "")
+		obs_recent_result=$(_get_model_usage_from_obs_db "$recent_filter")
 		oc_result=$(_get_model_usage_from_opencode)
-		if [[ -n "$oc_result" ]]; then
+		obs_requests=$(_model_usage_request_count "$obs_all_result")
+		oc_requests=$(_model_usage_request_count "$oc_result")
+
+		if [[ "$obs_requests" -gt 0 ]] && _model_usage_undercuts_reference "$oc_result" "$obs_recent_result"; then
+			echo "$obs_all_result"
+			return 0
+		fi
+		if [[ "$obs_requests" -gt 0 && "$obs_requests" -ge "$oc_requests" ]]; then
+			echo "$obs_all_result"
+			return 0
+		fi
+		if [[ "$oc_requests" -gt 0 ]]; then
 			echo "$oc_result"
 			return 0
 		fi
@@ -470,6 +511,13 @@ _token_totals_enrich() {
 	else
 		echo '{"total_all":0,"cache_hit_pct":0}'
 	fi
+	return 0
+}
+
+# --- Token totals: extract enriched total_all for source comparison ---
+_token_totals_total_all() {
+	local totals_json="$1"
+	echo "$totals_json" | jq -r '.total_all // 0' 2>/dev/null || printf '0\n'
 	return 0
 }
 
@@ -608,21 +656,48 @@ _get_token_totals() {
 	local period="${1:-30d}"
 	local raw_totals=""
 
-	# Source 1: OpenCode session DB (all-time only)
+	# For all-time totals, compare all available complete-history sources and use
+	# the largest token population. This keeps the footer consistent with the
+	# model table when one local source is stale or was introduced later.
 	if [[ "$period" == "all" ]]; then
-		raw_totals=$(_token_totals_from_opencode_db) && {
-			_token_totals_enrich "$raw_totals"
+		local best_totals="" best_total=0 candidate_totals candidate_total
+		if raw_totals=$(_token_totals_from_obs_db "$period"); then
+			candidate_totals=$(_token_totals_enrich "$raw_totals")
+			candidate_total=$(_token_totals_total_all "$candidate_totals")
+			if [[ "$candidate_total" -gt "$best_total" ]]; then
+				best_totals="$candidate_totals"
+				best_total="$candidate_total"
+			fi
+		fi
+		if raw_totals=$(_token_totals_from_opencode_db); then
+			candidate_totals=$(_token_totals_enrich "$raw_totals")
+			candidate_total=$(_token_totals_total_all "$candidate_totals")
+			if [[ "$candidate_total" -gt "$best_total" ]]; then
+				best_totals="$candidate_totals"
+				best_total="$candidate_total"
+			fi
+		fi
+		if raw_totals=$(_token_totals_from_jsonl "$period"); then
+			candidate_totals=$(_token_totals_enrich "$raw_totals")
+			candidate_total=$(_token_totals_total_all "$candidate_totals")
+			if [[ "$candidate_total" -gt "$best_total" ]]; then
+				best_totals="$candidate_totals"
+				best_total="$candidate_total"
+			fi
+		fi
+		if [[ -n "$best_totals" ]]; then
+			echo "$best_totals"
 			return 0
-		}
+		fi
 	fi
 
-	# Source 2: Observability DB
+	# Source 1: Observability DB
 	raw_totals=$(_token_totals_from_obs_db "$period") && {
 		_token_totals_enrich "$raw_totals"
 		return 0
 	}
 
-	# Source 3: Legacy JSONL metrics
+	# Source 2: Legacy JSONL metrics
 	raw_totals=$(_token_totals_from_jsonl "$period") && {
 		_token_totals_enrich "$raw_totals"
 		return 0

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -675,6 +675,75 @@ test_work_with_ai_worker_counts_above_thousand() {
 	return 0
 }
 
+test_all_time_model_usage_prefers_larger_complete_source() {
+	local test_name="all-time model usage prefers larger complete source"
+
+	# Simulate the OpenCode-schema drift case where message JSON all-time data is
+	# stale for one current model even though its older aggregate request count is
+	# larger than observability's complete current population.
+	_get_model_usage_from_obs_db() {
+		local date_filter="${1:-}"
+		if [[ -n "${date_filter}" ]]; then
+			printf '%s\n' '[{"model":"obs-model","requests":20,"input_tokens":200,"output_tokens":20,"cache_read_tokens":2000,"cache_write_tokens":0,"cost_total":2}]'
+			return 0
+		fi
+		printf '%s\n' '[{"model":"obs-model","requests":30,"input_tokens":300,"output_tokens":30,"cache_read_tokens":3000,"cache_write_tokens":0,"cost_total":3}]'
+		return 0
+	}
+
+	_get_model_usage_from_opencode() {
+		printf '%s\n' '[{"model":"obs-model","requests":10,"input_tokens":100,"output_tokens":10,"cache_read_tokens":1000,"cache_write_tokens":0,"cost_total":1},{"model":"old-model","requests":100,"input_tokens":1000,"output_tokens":100,"cache_read_tokens":10000,"cache_write_tokens":0,"cost_total":10}]'
+		return 0
+	}
+
+	local result model
+	result=$(_get_model_usage all)
+	model=$(printf '%s' "${result}" | jq -r '.[0].model')
+
+	if [[ "${model}" != "obs-model" ]]; then
+		print_result "${test_name}" 1 "expected obs-model, got ${model}"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
+test_all_time_token_totals_prefers_largest_population() {
+	local test_name="all-time token totals prefer largest population"
+
+	_token_totals_from_obs_db() {
+		local period="${1:-30d}"
+		[[ "${period}" == "all" ]] || return 1
+		printf '%s\n' '{"total_input":20,"total_output":20,"total_cache_read":20,"total_cache_write":0}'
+		return 0
+	}
+
+	_token_totals_from_opencode_db() {
+		printf '%s\n' '{"total_input":10,"total_output":10,"total_cache_read":10,"total_cache_write":0}'
+		return 0
+	}
+
+	_token_totals_from_jsonl() {
+		local period="${1:-30d}"
+		[[ "${period}" == "all" ]] || return 1
+		printf '%s\n' '{"total_input":5,"total_output":5,"total_cache_read":5,"total_cache_write":0}'
+		return 0
+	}
+
+	local result total_all
+	result=$(_get_token_totals all)
+	total_all=$(printf '%s' "${result}" | jq -r '.total_all')
+
+	if [[ "${total_all}" != "60" ]]; then
+		print_result "${test_name}" 1 "expected total_all=60, got ${total_all}"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 main() {
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
 		echo "Helper script not found or not executable: ${SOURCE_HELPER}" >&2
@@ -694,6 +763,10 @@ main() {
 	test_session_time_vars_default_missing_null_values
 	teardown
 	test_work_with_ai_worker_counts_above_thousand
+	teardown
+	test_all_time_model_usage_prefers_larger_complete_source
+	teardown
+	test_all_time_token_totals_prefers_largest_population
 	teardown
 
 	echo ""


### PR DESCRIPTION
## Summary

- Fix profile README AI model all-time stats source selection when OpenCode message JSON is stale but observability has current complete rows.
- Keep all-time token footers source-consistent by selecting the largest complete token population across observability, OpenCode, and JSONL.
- Add regression coverage for stale OpenCode aggregate selection and all-time token source comparison.

## Root cause

Profile README all-time model usage always preferred OpenCode message JSON. After OpenCode schema/runtime changes, message-level JSON can lag current request rows while still containing more old total requests, causing all-time stats to under-report current 30-day models and show inconsistent costs/tokens.

## Verification

- `.agents/scripts/tests/test-profile-readme-boundary.sh`
- `shellcheck .agents/scripts/profile-readme-data-lib.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `.agents/scripts/profile-readme-helper.sh generate`
- `.agents/scripts/linters-local.sh` (passes; existing advisory markdown/ratchet/complexity/nesting output unchanged by this diff)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.56 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 19m and 279,683 tokens on this with the user in an interactive session.

Fixes #23713
