### PR TITLE
fix: reduce fix-the-fixer auth cooldown log spam

### DIFF
--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -93,6 +93,20 @@ _log_warn() {
 	return 0
 }
 
+_auth_item_logs_suppressed() {
+	[[ "${AIDEVOPS_FIX_THE_FIXER_DETECTOR_SUPPRESS_AUTH_ITEM_LOGS:-0}" == "1" ]] || return 1
+	return 0
+}
+
+_log_auth_skip() {
+	local message="$1"
+	if _auth_item_logs_suppressed; then
+		return 0
+	fi
+	_log_warn "$message"
+	return 0
+}
+
 _auth_cooldown_seconds() {
 	local configured="${AIDEVOPS_FIX_THE_FIXER_DETECTOR_AUTH_COOLDOWN_SECONDS:-$AUTH_COOLDOWN_SECONDS_DEFAULT}"
 	[[ "$configured" =~ ^[0-9]+$ && "$configured" -gt 0 ]] || configured="$AUTH_COOLDOWN_SECONDS_DEFAULT"
@@ -259,7 +273,7 @@ _classify_via_llm() {
 
 	if _auth_cooldown_active; then
 		RATIONALE="auth_error: ${AUTH_ERROR_REASON}; cooldown active"
-		_log_warn "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
+		_log_auth_skip "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
 		printf 'SKIP_AUTH\n'
 		return 0
 	fi
@@ -299,7 +313,7 @@ _classify_via_llm() {
 				fi
 				_record_auth_cooldown "$cooldown_reason"
 				RATIONALE="auth_error: ${AUTH_ERROR_REASON}"
-				_log_warn "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
+				_log_auth_skip "fix-the-fixer detector skipped: ${AUTH_ERROR_REASON}"
 				printf 'SKIP_AUTH\n'
 				return 0
 			fi
@@ -480,7 +494,7 @@ cmd_check() {
 	verdict=$(_classify_via_llm "$title" "$body")
 	if [[ "$verdict" == "SKIP_AUTH" ]]; then
 		[[ -n "$RATIONALE" ]] || RATIONALE="auth_error: ${AUTH_ERROR_REASON}"
-		_log_warn "${slug}#${issue_num} classification skipped — ${RATIONALE}"
+		_log_auth_skip "${slug}#${issue_num} classification skipped — ${RATIONALE}"
 		return 3
 	fi
 	if [[ "$verdict" == "SKIP" ]]; then
@@ -551,6 +565,7 @@ cmd_run() {
 	local classified=0
 	local skipped_llm=0
 	local skipped_auth=0
+	export AIDEVOPS_FIX_THE_FIXER_DETECTOR_SUPPRESS_AUTH_ITEM_LOGS=1
 	local slug
 	for slug in "${target_repos[@]}"; do
 		[[ "$processed" -ge "$limit" ]] && break

--- a/.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
+++ b/.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
@@ -48,7 +48,7 @@ setup_sandbox() {
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
-	printf '[{"number":1,"labels":[{"name":"auto-dispatch"}]}]\n'
+	printf '[{"number":1,"labels":[{"name":"auto-dispatch"}]},{"number":2,"labels":[{"name":"auto-dispatch"}]}]\n'
 	exit 0
 fi
 if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
@@ -86,7 +86,7 @@ teardown_sandbox() {
 run_detector() {
 	local output_file="$1"
 	"${PWD}/.agents/scripts/pulse-fix-the-fixer-detector.sh" run \
-		--repo example/repo --limit 1 >"$output_file" 2>&1
+		--repo example/repo --limit 2 >"$output_file" 2>&1
 	return 0
 }
 
@@ -149,7 +149,23 @@ main() {
 		print_result "auth cooldown state file recorded" 1 "cooldown file missing"
 	fi
 
-	if grep -q 'skipped:auth-error=1' "$second_log" && grep -q 'AI research credentials invalid' "$second_log"; then
+	local first_warn_count
+	first_warn_count=$(grep -c 'fix-the-fixer-detector] WARN:' "$first_log" || true)
+	if [[ "$first_warn_count" == "1" ]] && ! grep -q 'classification skipped' "$first_log"; then
+		print_result "auth failures emit one cycle-level warning" 0
+	else
+		print_result "auth failures emit one cycle-level warning" 1 "warns=${first_warn_count}; first log: $(tr '\n' ' ' <"$first_log")"
+	fi
+
+	local second_warn_count
+	second_warn_count=$(grep -c 'fix-the-fixer-detector] WARN:' "$second_log" || true)
+	if [[ "$second_warn_count" == "1" ]] && ! grep -q 'classification skipped' "$second_log"; then
+		print_result "cooldown skips emit one cycle-level warning" 0
+	else
+		print_result "cooldown skips emit one cycle-level warning" 1 "warns=${second_warn_count}; second log: $(tr '\n' ' ' <"$second_log")"
+	fi
+
+	if grep -q 'skipped:auth-error=2' "$second_log" && grep -q 'AI research credentials invalid' "$second_log"; then
 		print_result "subsequent run reports concise auth skip" 0
 	else
 		print_result "subsequent run reports concise auth skip" 1 "second log: $(tr '\n' ' ' <"$second_log")"


### PR DESCRIPTION
## Summary
- Suppresses per-issue auth skip warnings during fix-the-fixer detector run cycles.
- Preserves fail-open auth cooldown behavior and skipped auth counters.
- Adds regression coverage that repeated auth failures emit one cycle-level warning while still counting skipped issues.

## Testing
- bash .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh
- bash .agents/scripts/tests/test-fix-the-fixer-observability.sh
- shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh .agents/scripts/tests/test-fix-the-fixer-observability.sh

Resolves #23715

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 3m and 63,696 tokens on this as a headless worker.
