### PR TITLE
GH#23716: fix: suppress pulse PID broken pipe noise

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -140,6 +140,22 @@ _pulse_pids_raw() {
 	return 0
 }
 
+# _pulse_emit_pid: print one PID while tolerating early-closing consumers.
+#
+# Watchdog/status callers may pipe PID lists into consumers that intentionally
+# exit after the first match. Bash's printf reports EPIPE as noisy "Broken pipe"
+# stderr output unless stderr is suppressed at the emit site. Return 1 to tell
+# the caller to stop emitting without treating the closed pipe as discovery
+# failure.
+_pulse_emit_pid() {
+	local _pid="$1" _rc=0
+	trap '' PIPE
+	printf '%s\n' "$_pid" 2>/dev/null || _rc=$?
+	trap - PIPE
+	[[ "$_rc" -eq 0 ]] || return 1
+	return 0
+}
+
 # _pulse_pids: print only top-level MAIN pulse PIDs (one per line). Subshells
 # of a running pulse cycle inherit the parent's argv so naive pgrep over-counts.
 # This function filters to PIDs whose PARENT command is NOT itself
@@ -179,7 +195,7 @@ _pulse_pids() {
 			# Layer 3 (sidecar guard): skip if argv contains a sidecar flag.
 			_cmd=$(ps -p "$_pid" -o command= 2>/dev/null)
 			[[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]] && continue
-			printf '%s\n' "$_pid"
+			_pulse_emit_pid "$_pid" || return 0
 			continue
 		fi
 		# Layer 2 (fallback for manually-started instances): skip PIDs whose
@@ -190,7 +206,7 @@ _pulse_pids() {
 		# (manual --merge-only invocations during testing or debugging).
 		_cmd=$(ps -p "$_pid" -o command= 2>/dev/null)
 		[[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]] && continue
-		printf '%s\n' "$_pid"
+		_pulse_emit_pid "$_pid" || return 0
 	done <<< "$_pids"
 	return 0
 }
@@ -213,7 +229,9 @@ _pulse_pids_sidecar() {
 			[[ "$_ppid_cmd" =~ pulse-wrapper\.sh ]] && continue
 		fi
 		_cmd=$(ps -p "$_pid" -o command= 2>/dev/null)
-		[[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]] && printf '%s\n' "$_pid"
+		if [[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]]; then
+			_pulse_emit_pid "$_pid" || return 0
+		fi
 	done <<< "$_pids"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -497,7 +497,7 @@ test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early() {
 			}
 
 			ps() {
-				local _arg1="${1:-}" _arg2="${2:-}" _arg3="${3:-}" _arg4="${4:-}"
+				local _arg1="${1:-}" _arg2="${2:-}" _arg3="${3:-}" _arg4="${4:-}" _fallback_rc=0
 				case "$_arg1 $_arg3 $_arg4" in
 				"-p -o ppid=")
 					printf '1\n'
@@ -508,7 +508,6 @@ test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early() {
 					return 0
 					;;
 				*)
-					local _fallback_rc=0
 					command ps "$@"
 					_fallback_rc=$?
 					return "$_fallback_rc"

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -480,6 +480,59 @@ test_missing_pulse_script_exit_2() {
 	return 0
 }
 
+test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early() {
+	local rc=0 err=""
+	err=$(
+		(
+			# shellcheck source=../pulse-lifecycle-helper.sh
+			source "$HELPER"
+
+			_pulse_pids_raw() {
+				local _i=1
+				while [[ "$_i" -le 100000 ]]; do
+					printf '%s\n' "$_i"
+					_i=$((_i + 1))
+				done
+				return 0
+			}
+
+			ps() {
+				local _arg1="${1:-}" _arg2="${2:-}" _arg3="${3:-}" _arg4="${4:-}"
+				case "$_arg1 $_arg3 $_arg4" in
+				"-p -o ppid=")
+					printf '1\n'
+					return 0
+					;;
+				"-p -o command=")
+					printf 'bash %s/scripts/pulse-wrapper.sh pid=%s\n' "${TEST_ROOT:-/tmp}" "$_arg2"
+					return 0
+					;;
+				*)
+					local _fallback_rc=0
+					command ps "$@"
+					_fallback_rc=$?
+					return "$_fallback_rc"
+					;;
+				esac
+			}
+
+			_pulse_pids | {
+				local _first=""
+				read -r _first || true
+				return 0
+			} >/dev/null
+		) 2>&1
+	) || rc=$?
+
+	_assert_eq "_pulse_pids exits 0 when consumer closes early" "0" "$rc"
+	if [[ "$err" != *"Broken pipe"* ]]; then
+		_print_result "_pulse_pids suppresses Broken pipe noise on early close" 1
+	else
+		_print_result "_pulse_pids emitted Broken pipe noise (stderr=$err)" 0
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # GH#21903: threshold-based PILE-UP detection
 # -----------------------------------------------------------------------------
@@ -819,6 +872,7 @@ main() {
 	test_skip_env_honoured_in_restart_if_running
 	test_skip_env_honoured_in_restart
 	test_missing_pulse_script_exit_2
+	test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early
 
 	# GH#21903 threshold-based PILE-UP detection
 	test_status_two_instances_no_warning_default_threshold

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -498,21 +498,17 @@ test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early() {
 
 			ps() {
 				local _arg1="${1:-}" _arg2="${2:-}" _arg3="${3:-}" _arg4="${4:-}" _fallback_rc=0
-				case "$_arg1 $_arg3 $_arg4" in
-				"-p -o ppid=")
+				if [[ "$_arg1" == "-p" && "$_arg3" == "-o" && "$_arg4" == "ppid=" ]]; then
 					printf '1\n'
 					return 0
-					;;
-				"-p -o command=")
+				fi
+				if [[ "$_arg1" == "-p" && "$_arg3" == "-o" && "$_arg4" == "command=" ]]; then
 					printf 'bash %s/scripts/pulse-wrapper.sh pid=%s\n' "${TEST_ROOT:-/tmp}" "$_arg2"
 					return 0
-					;;
-				*)
-					command ps "$@"
-					_fallback_rc=$?
-					return "$_fallback_rc"
-					;;
-				esac
+				fi
+				command ps "$@"
+				_fallback_rc=$?
+				return "$_fallback_rc"
 			}
 
 			_pulse_pids | {


### PR DESCRIPTION
## Summary

Added a safe PID emit path for pulse lifecycle PID lists so early-closing consumers stop emission without Broken pipe stderr noise; added regression coverage for _pulse_pids piped into an early-exiting consumer.

## Files Changed

.agents/scripts/pulse-lifecycle-helper.sh,.agents/scripts/tests/test-pulse-lifecycle-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh; shellcheck .agents/scripts/pulse-lifecycle-helper.sh .agents/scripts/tests/test-pulse-lifecycle-helper.sh

Resolves #23716


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 4m and 65,395 tokens on this as a headless worker.