### PR TITLE
GH#23717: fail open without node for agent source registry

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -200,6 +200,14 @@ update_last_synced() {
 generate_capability_registry() {
 	ensure_config
 	mkdir -p "$(dirname "${CAPABILITY_INDEX_FILE}")"
+	if ! command -v node >/dev/null 2>&1; then
+		warn "Node not found; skipping agent source capability registry generation."
+		cat >"${CAPABILITY_INDEX_FILE}" <<'EOF_CAPABILITIES'
+<!--TOON:agent_source_capabilities[0]{source,pack,version,domains,triggers,agents,subagents,commands,helpers,secrets,artifacts,sensitivity,upstream_candidate,status}:
+-->
+EOF_CAPABILITIES
+		return 0
+	fi
 	CONFIG_PATH="${CONFIG_FILE}" INDEX_PATH="${CAPABILITY_INDEX_FILE}" node <<'NODE'
 const fs = require('fs');
 const path = require('path');

--- a/.agents/scripts/tests/test-agent-source-manifest-index.sh
+++ b/.agents/scripts/tests/test-agent-source-manifest-index.sh
@@ -94,7 +94,7 @@ teardown() {
 test_sync_generates_capability_registry() {
 	local output=""
 	local status=0
-	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/agent-sources-helper.sh" sync 2>&1)
+	output=$(AIDEVOPS_AGENTS_DIR="$TEST_HOME/.aidevops/agents" HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/agent-sources-helper.sh" sync 2>&1)
 	status=$?
 	if [[ "$status" -ne 0 ]]; then
 		print_result "sync generates capability registry" 1 "$output"
@@ -114,7 +114,7 @@ test_sync_generates_capability_registry() {
 test_subagent_index_includes_capability_registry() {
 	local output=""
 	local status=0
-	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" generate 2>&1)
+	output=$(AIDEVOPS_AGENTS_DIR="$TEST_HOME/.aidevops/agents" HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" generate 2>&1)
 	status=$?
 	if [[ "$status" -ne 0 ]]; then
 		print_result "subagent index includes capability registry" 1 "$output"
@@ -134,7 +134,7 @@ test_subagent_index_includes_capability_registry() {
 test_check_validates_capability_cardinality() {
 	local output=""
 	local status=0
-	output=$(HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" check 2>&1)
+	output=$(AIDEVOPS_AGENTS_DIR="$TEST_HOME/.aidevops/agents" HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh" check 2>&1)
 	status=$?
 	if [[ "$status" -eq 0 && "$output" == *"Declared agent source capability rows: 1"* && "$output" == *"Actual agent source capability rows: 1"* ]]; then
 		print_result "check validates capability cardinality" 0
@@ -144,11 +144,35 @@ test_check_validates_capability_cardinality() {
 	return 0
 }
 
+test_sync_without_node_fails_open() {
+	local path_without_node="$TEST_HOME/no-node-bin"
+	mkdir -p "$path_without_node"
+	ln -s /usr/bin/bash "$path_without_node/bash"
+	ln -s /usr/bin/cat "$path_without_node/cat"
+	ln -s /usr/bin/dirname "$path_without_node/dirname"
+	ln -s /usr/bin/mkdir "$path_without_node/mkdir"
+
+	local output=""
+	local status=0
+	output=$(PATH="$path_without_node" AIDEVOPS_AGENTS_DIR="$TEST_HOME/.aidevops/agents" HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/agent-sources-helper.sh" sync 2>&1)
+	status=$?
+
+	local registry="$TEST_HOME/.aidevops/agents/agent-source-capabilities.toon"
+	if [[ "$status" -eq 0 && "$output" == *"Node not found; skipping agent source capability registry generation."* && "$output" != *"node: command not found"* ]] && \
+		grep -q '^<!--TOON:agent_source_capabilities\[0\]' "$registry"; then
+		print_result "sync without node fails open" 0
+	else
+		print_result "sync without node fails open" 1 "$output"
+	fi
+	return 0
+}
+
 main() {
 	setup
 	test_sync_generates_capability_registry
 	test_subagent_index_includes_capability_registry
 	test_check_validates_capability_cardinality
+	test_sync_without_node_fails_open
 
 	echo ""
 	echo "Tests run: $TESTS_RUN"


### PR DESCRIPTION
## Summary

Added a node availability guard before capability registry generation so missing optional Node runtimes emit one bounded warning and write an empty registry instead of recurring shell errors. Hardened the manifest-index regression test to isolate AIDEVOPS_AGENTS_DIR and cover a PATH without node.

## Files Changed

.agents/scripts/agent-sources-helper.sh,.agents/scripts/tests/test-agent-source-manifest-index.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-agent-source-manifest-index.sh; shellcheck .agents/scripts/agent-sources-helper.sh .agents/scripts/tests/test-agent-source-manifest-index.sh

Resolves #23717


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 58,794 tokens on this as a headless worker.