### PR TITLE
GH#23730: Document FOSS label parsing behavior

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1217,7 +1217,9 @@ dispatch_foss_workers() {
 		# Pre-dispatch eligibility check (budget + rate limit)
 		"${SCRIPT_DIR}/foss-contribution-helper.sh" check "$foss_slug" >/dev/null || continue
 
-		# Scan for a suitable issue
+		# Scan for a suitable issue. labels_filter_json comes from the outer jq
+		# pass so configured labels stay as JSON array elements, including labels
+		# that contain commas, while avoiding a second repos.json parse per repo.
 		local foss_issue foss_issue_num foss_issue_title
 		local foss_label_candidates=()
 		local foss_label


### PR DESCRIPTION
## Summary

Documented that FOSS dispatch uses the outer repos.json jq pass and JSON array labels so configured labels containing commas remain intact while avoiding redundant parsing.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

Resolves #23730


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 54,507 tokens on this as a headless worker.