### PR TITLE
fix: harden pulse PR cache cleanup

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1813,8 +1813,10 @@ main() {
 		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-view-cache-${$}"
 		export AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}"
 		_save_cleanup_scope
-		trap '_run_cleanups' EXIT
 		push_cleanup 'release_instance_lock'
+		# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
+		# register release_instance_lock before replacing the direct EXIT trap.
+		trap '_run_cleanups' EXIT
 		_pulse_pr_cache_cleanup_scope=1
 		push_cleanup "rm -rf \"${AIDEVOPS_GH_PR_VIEW_CACHE_DIR}\""
 		if ! rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
@@ -1831,8 +1833,10 @@ main() {
 		export AIDEVOPS_GH_PR_LIST_CACHE_TTL="${AIDEVOPS_PULSE_PR_LIST_CACHE_TTL:-3600}"
 		if [[ "$_pulse_pr_cache_cleanup_scope" -eq 0 ]]; then
 			_save_cleanup_scope
-			trap '_run_cleanups' EXIT
 			push_cleanup 'release_instance_lock'
+			# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
+			# register release_instance_lock before replacing the direct EXIT trap.
+			trap '_run_cleanups' EXIT
 			_pulse_pr_cache_cleanup_scope=1
 		fi
 		push_cleanup "rm -rf \"${AIDEVOPS_GH_PR_LIST_CACHE_DIR}\""

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -207,6 +207,9 @@ test_pr_cache_ttls_are_per_cycle() {
 	if ! grep -q "trap '_run_cleanups' EXIT" "$WRAPPER_SCRIPT"; then
 		missing="${missing} exit-cleanup-trap"
 	fi
+	if ! grep -A5 '_save_cleanup_scope' "$WRAPPER_SCRIPT" | grep -B4 "trap '_run_cleanups' EXIT" | grep -q "push_cleanup 'release_instance_lock'"; then
+		missing="${missing} lock-cleanup-before-exit-trap"
+	fi
 
 	if [[ -z "$missing" ]]; then
 		print_result "pulse configures per-cycle PR list/view cache TTLs and EXIT cleanup" 0


### PR DESCRIPTION
## Summary
- Register `release_instance_lock` before replacing the direct pulse EXIT trap with `_run_cleanups` during PR cache setup.
- Preserve EXIT cleanup rather than RETURN so SIGTERM/set -e exits still release the pulse instance lock.
- Add canary coverage for lock cleanup registration before the EXIT cleanup trap.

## Testing
- `shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-canary.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh`

MERGE_SUMMARY: Hardened pulse PR cache cleanup by ensuring lock release is on the cleanup stack before the direct EXIT trap is replaced, with canary coverage for the ordering.

Resolves #23728

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 5m and 59,637 tokens on this as a headless worker.