### PR TITLE
fix: streamline label invariant jq checks

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-normalize.sh
+++ b/.agents/scripts/pulse-issue-reconcile-normalize.sh
@@ -181,9 +181,9 @@ _fetch_label_invariant_rows() {
 			(.number | tostring),
 			([$labels[].name | select(startswith("status:")) | sub("^status:"; "")] | join(" ")),
 			([$labels[].name | select(startswith("tier:"))   | sub("^tier:";   "")] | join(" ")),
-			(($labels | map(.name) | index("origin:interactive")) != null | tostring),
-			(($labels | map(.name) | index("auto-dispatch"))      != null | tostring),
-			(any($labels[]?.name; . == ("supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold")) | tostring),
+			(any($labels[].name; . == "origin:interactive") | tostring),
+			(any($labels[].name; . == "auto-dispatch")      | tostring),
+			(any($labels[].name; . == ("supervisor", "contributor", "persistent", "quality-review", "needs-maintainer-review", "routine-tracking", "on hold")) | tostring),
 			(.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime | tostring),
 			(([$labels[].name | select(startswith("status:"))] | length) | tostring)
 		] | join("|")


### PR DESCRIPTION
## Summary
- Replace label invariant jq `map(.name) | index(...)` lookups with `any/2`.
- Remove the redundant optional iterator from the grouped non-task label check now that labels are normalized with `(.labels // [])`.

## Testing
- `shellcheck .agents/scripts/pulse-issue-reconcile-normalize.sh`
- `bash .agents/scripts/tests/test-label-invariants.sh`

Resolves #23726

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 70,231 tokens on this as a headless worker.
