### PR TITLE
GH#23725: fix: reuse resolved claim runner in repo state guard

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -238,7 +238,7 @@ _post_claim() {
 	local reason_fields="${6:-}"
 
 	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
-		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug" "$runner"; then
 			echo "CLAIM_SKIPPED: repo_state_not_managed issue=#${issue_number} repo=${repo_slug}" >&2
 			return 1
 		fi
@@ -1005,15 +1005,15 @@ cmd_claim() {
 		return 2
 	fi
 
+	local runner
+	runner=$(_resolve_runner "$runner_login") || runner="unknown"
+
 	if declare -F aidevops_can_manage_repo_issue_state >/dev/null 2>&1; then
-		if ! aidevops_can_manage_repo_issue_state "$repo_slug"; then
+		if ! aidevops_can_manage_repo_issue_state "$repo_slug" "$runner"; then
 			echo "CLAIM_SKIPPED: repo_state_not_managed issue=#${issue_number} repo=${repo_slug} — not dispatching" >&2
 			return 1
 		fi
 	fi
-
-	local runner
-	runner=$(_resolve_runner "$runner_login") || runner="unknown"
 
 	local nonce
 	nonce=$(_generate_nonce)

--- a/.agents/scripts/shared-repo-state-guard.sh
+++ b/.agents/scripts/shared-repo-state-guard.sh
@@ -19,11 +19,11 @@ _SHARED_REPO_STATE_GUARD_LOADED=1
 #######################################
 aidevops_repo_state_current_user() {
 	local login=""
-	login=$(gh api user --jq '.login' 2>/dev/null || printf '')
+	login=$(gh api user --jq '.login // ""' || printf '')
 	if [[ "$login" == *'"login"'* ]] && command -v jq >/dev/null 2>&1; then
-		login=$(printf '%s' "$login" | jq -r '.login // empty' 2>/dev/null || printf '')
+		login=$(printf '%s' "$login" | jq -r '.login // ""' || printf '')
 	fi
-	if [[ -z "$login" || "$login" == "null" ]]; then
+	if [[ -z "$login" ]]; then
 		printf ''
 		return 0
 	fi
@@ -55,7 +55,7 @@ aidevops_can_manage_repo_issue_state() {
 	if [[ -z "$user" ]]; then
 		user=$(aidevops_repo_state_current_user)
 	fi
-	if [[ -z "$user" || "$user" == "null" ]]; then
+	if [[ -z "$user" ]]; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-repo-state-guard.sh
+++ b/.agents/scripts/tests/test-repo-state-guard.sh
@@ -91,6 +91,19 @@ else
 fi
 
 printf 'external\n' >"$mode_file"
+: >"$call_log"
+if aidevops_can_manage_repo_issue_state "other/project" "tester"; then
+	check 0 "explicit user override still blocks external repo"
+else
+	check 1 "explicit user override still blocks external repo"
+fi
+if grep -q '^api user' "$call_log"; then
+	check 0 "explicit user override skips current-user lookup"
+else
+	check 1 "explicit user override skips current-user lookup"
+fi
+
+: >"$call_log"
 set +e
 claim_output=$("${AGENTS_SCRIPTS_DIR}/dispatch-claim-helper.sh" claim 866 afragen/git-updater tester 2>&1)
 claim_rc=$?
@@ -105,6 +118,12 @@ if grep -q 'repos/afragen/git-updater/issues/866/comments' "$call_log"; then
 	check 0 "unmanaged dispatch claim posts no comment"
 else
 	check 1 "unmanaged dispatch claim posts no comment"
+fi
+
+if grep -q '^api user' "$call_log"; then
+	check 0 "dispatch claim passes resolved runner to state guard"
+else
+	check 1 "dispatch claim passes resolved runner to state guard"
 fi
 
 set +e


### PR DESCRIPTION
## Summary

- Reuse the resolved runner login when checking repo-state guard permissions from claim posting and claim dispatch.

- Simplify current-user null handling with jq fallback filters while preserving empty-string failure behavior.


## Testing
- shellcheck .agents/scripts/shared-repo-state-guard.sh .agents/scripts/dispatch-claim-helper.sh .agents/scripts/tests/test-repo-state-guard.sh

- .agents/scripts/tests/test-repo-state-guard.sh
- .agents/scripts/tests/test-dispatch-claim-helper.sh

Files changed: .agents/scripts/dispatch-claim-helper.sh,.agents/scripts/shared-repo-state-guard.sh,.agents/scripts/tests/test-repo-state-guard.sh,



Resolves #23725



<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 3m and 59,810 tokens on this as a headless worker.





