### PR TITLE
GH#23723: fix auth skip warning wrapper

### DIFF
--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -99,12 +99,11 @@ _auth_item_logs_suppressed() {
 }
 
 _log_auth_skip() {
-	local message="$1"
 	if _auth_item_logs_suppressed; then
 		return 0
 	fi
-	_log_warn "$message"
-	return 0
+	_log_warn "$@"
+	return $?
 }
 
 _auth_cooldown_seconds() {


### PR DESCRIPTION
## Summary

- Updated `_log_auth_skip` to forward all arguments to `_log_warn`.
- Propagated the underlying warning logger exit status when auth item logs are not suppressed.

## Testing

- `bash -n .agents/scripts/pulse-fix-the-fixer-detector.sh`
- `shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh`
- `shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`

## Runtime Testing

- `.agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`

- Self-assessed: low-risk shell wrapper bugfix; syntax and ShellCheck verification completed.

Resolves #23723


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 45,220 tokens on this as a headless worker.

