### PR TITLE
GH#23721: fix agent source registry test isolation

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -22,7 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-AGENTS_DIR="${HOME}/.aidevops/agents"
+AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
 CUSTOM_DIR="${AGENTS_DIR}/custom"
 CONFIG_FILE="${AGENTS_DIR}/configs/agent-sources.json"
 CAPABILITY_INDEX_FILE="${AGENTS_DIR}/agent-source-capabilities.toon"

--- a/.agents/scripts/tests/test-agent-source-manifest-index.sh
+++ b/.agents/scripts/tests/test-agent-source-manifest-index.sh
@@ -147,10 +147,10 @@ test_check_validates_capability_cardinality() {
 test_sync_without_node_fails_open() {
 	local path_without_node="$TEST_HOME/no-node-bin"
 	mkdir -p "$path_without_node"
-	ln -s /usr/bin/bash "$path_without_node/bash"
-	ln -s /usr/bin/cat "$path_without_node/cat"
-	ln -s /usr/bin/dirname "$path_without_node/dirname"
-	ln -s /usr/bin/mkdir "$path_without_node/mkdir"
+	ln -s "$(command -v bash)" "$path_without_node/bash"
+	ln -s "$(command -v cat)" "$path_without_node/cat"
+	ln -s "$(command -v dirname)" "$path_without_node/dirname"
+	ln -s "$(command -v mkdir)" "$path_without_node/mkdir"
 
 	local output=""
 	local status=0


### PR DESCRIPTION
## Summary

Respected `AIDEVOPS_AGENTS_DIR` in `agent-sources-helper.sh` so isolated tests and callers can override the agents directory.

Updated the no-node registry test to resolve required utility paths with `command -v` instead of hard-coded `/usr/bin` paths.

Resolves #23721

## Testing

- `shellcheck .agents/scripts/agent-sources-helper.sh .agents/scripts/tests/test-agent-source-manifest-index.sh`
- `.agents/scripts/tests/test-agent-source-manifest-index.sh`

## Runtime Testing

self-assessed: shell helper/test-only change verified by targeted shellcheck and regression test.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 52,553 tokens on this as a headless worker.
