### PR TITLE
GH#23724: fix: harden profile AI stats source selection

### DIFF
--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -246,10 +246,11 @@ _model_usage_undercuts_reference() {
 		def rows($a): if ($a | type) == "array" then $a else [] end;
 		(rows($candidate) | INDEX(.model)) as $candidate_by_model
 		| any(rows($reference)[];
-			(($candidate_by_model[.model].requests // 0) < (.requests // 0))
-			or (($candidate_by_model[.model].input_tokens // 0) < (.input_tokens // 0))
-			or (($candidate_by_model[.model].output_tokens // 0) < (.output_tokens // 0))
-			or (($candidate_by_model[.model].cache_read_tokens // 0) < (.cache_read_tokens // 0))
+			.model as $model | ($candidate_by_model[$model] // {}) as $candidate_row
+			| (($candidate_row.requests // 0) < (.requests // 0))
+			or (($candidate_row.input_tokens // 0) < (.input_tokens // 0))
+			or (($candidate_row.output_tokens // 0) < (.output_tokens // 0))
+			or (($candidate_row.cache_read_tokens // 0) < (.cache_read_tokens // 0))
 		)
 	' >/dev/null 2>&1
 	return $?
@@ -660,31 +661,26 @@ _get_token_totals() {
 	# the largest token population. This keeps the footer consistent with the
 	# model table when one local source is stale or was introduced later.
 	if [[ "$period" == "all" ]]; then
-		local best_totals="" best_total=0 candidate_totals candidate_total
-		if raw_totals=$(_token_totals_from_obs_db "$period"); then
+		local best_totals="" best_total=0 candidate_totals candidate_total source
+		for source in obs-db opencode-db jsonl; do
+			case "$source" in
+				obs-db)
+					raw_totals=$(_token_totals_from_obs_db "$period") || continue
+					;;
+				opencode-db)
+					raw_totals=$(_token_totals_from_opencode_db) || continue
+					;;
+				jsonl)
+					raw_totals=$(_token_totals_from_jsonl "$period") || continue
+					;;
+			esac
 			candidate_totals=$(_token_totals_enrich "$raw_totals")
 			candidate_total=$(_token_totals_total_all "$candidate_totals")
 			if [[ "$candidate_total" -gt "$best_total" ]]; then
 				best_totals="$candidate_totals"
 				best_total="$candidate_total"
 			fi
-		fi
-		if raw_totals=$(_token_totals_from_opencode_db); then
-			candidate_totals=$(_token_totals_enrich "$raw_totals")
-			candidate_total=$(_token_totals_total_all "$candidate_totals")
-			if [[ "$candidate_total" -gt "$best_total" ]]; then
-				best_totals="$candidate_totals"
-				best_total="$candidate_total"
-			fi
-		fi
-		if raw_totals=$(_token_totals_from_jsonl "$period"); then
-			candidate_totals=$(_token_totals_enrich "$raw_totals")
-			candidate_total=$(_token_totals_total_all "$candidate_totals")
-			if [[ "$candidate_total" -gt "$best_total" ]]; then
-				best_totals="$candidate_totals"
-				best_total="$candidate_total"
-			fi
-		fi
+		done
 		if [[ -n "$best_totals" ]]; then
 			echo "$best_totals"
 			return 0

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -709,6 +709,25 @@ test_all_time_model_usage_prefers_larger_complete_source() {
 	return 0
 }
 
+test_model_usage_undercut_handles_missing_candidate_model() {
+	local test_name="model usage undercut handles missing candidate model"
+	local candidate_json reference_json
+
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "${SOURCE_DATA_LIB}"
+
+	candidate_json='[{"model":"other-model","requests":5,"input_tokens":50,"output_tokens":5,"cache_read_tokens":500}]'
+	reference_json='[{"model":"missing-model","requests":1,"input_tokens":10,"output_tokens":1,"cache_read_tokens":100}]'
+
+	if ! _model_usage_undercuts_reference "${candidate_json}" "${reference_json}"; then
+		print_result "${test_name}" 1 "missing candidate model did not undercut reference"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 test_all_time_token_totals_prefers_largest_population() {
 	local test_name="all-time token totals prefer largest population"
 
@@ -765,6 +784,8 @@ main() {
 	test_work_with_ai_worker_counts_above_thousand
 	teardown
 	test_all_time_model_usage_prefers_larger_complete_source
+	teardown
+	test_model_usage_undercut_handles_missing_candidate_model
 	teardown
 	test_all_time_token_totals_prefers_largest_population
 	teardown


### PR DESCRIPTION
## Summary

Guarded model usage undercut comparisons with an explicit empty-row fallback for missing candidate models, refactored all-time token total source selection into a single loop, and added regression coverage for missing candidate models.

## Files Changed

.agents/scripts/profile-readme-data-lib.sh,.agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/profile-readme-data-lib.sh .agents/scripts/tests/test-profile-readme-boundary.sh && .agents/scripts/tests/test-profile-readme-boundary.sh

Resolves #23724


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 47,263 tokens on this as a headless worker.