### PR TITLE
test: isolate dispatch tests from gh REST fallback env

### DIFF
--- a/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
@@ -50,6 +50,9 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/bin"
 	mkdir -p "${TEST_ROOT}/config/aidevops"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
+	unset AIDEVOPS_GH_FORCE_REST_READS
+	unset AIDEVOPS_GH_REST_FIRST_READS
+	unset _GH_SHOULD_FALLBACK_OVERRIDE
 
 	# Minimal repos.json so the helper can resolve owner/maintainer.
 	cat >"${TEST_ROOT}/config/aidevops/repos.json" <<'EOF'

--- a/.agents/scripts/tests/test-dispatch-dedup-no-auto-dispatch-block.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-no-auto-dispatch-block.sh
@@ -54,6 +54,9 @@ TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 export HOME="${TEST_ROOT}/home"
 mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+unset AIDEVOPS_GH_FORCE_REST_READS
+unset AIDEVOPS_GH_REST_FIRST_READS
+unset _GH_SHOULD_FALLBACK_OVERRIDE
 
 # =============================================================================
 # Stub the gh CLI so we can feed synthetic issue payloads into is_assigned


### PR DESCRIPTION
## Summary
- Clear GitHub REST fallback override variables inside dispatch-dedup shell test sandboxes.
- Prevent developer/session environment from changing mocked gh path behaviour.

## Testing
- shellcheck .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh .agents/scripts/tests/test-dispatch-dedup-no-auto-dispatch-block.sh
- bash .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
- bash .agents/scripts/tests/test-dispatch-dedup-no-auto-dispatch-block.sh

For #23741

## Notes
- Rebased onto origin/main; earlier hold-for-review implementation was already present on main, leaving this test-isolation follow-up.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 8m and 132,650 tokens on this as a headless worker.

<!-- linked-issue-check-refresh: 2026-05-17T15:31Z -->
