### PR TITLE
fix: default issue create status labels

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -223,7 +223,11 @@ gh_create_issue() {
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 	fi
 
-	_gh_ci_prepare_status_label "$@" "${_todo_label_args[@]}"
+	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
+		_gh_ci_prepare_status_label "$@" "${_todo_label_args[@]}"
+	else
+		_gh_ci_prepare_status_label "$@"
+	fi
 
 	# Build command arrays safely; avoid empty-arg injection (GH#22056).
 	local -a _issue_cmd=(gh issue create "$@")

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -377,7 +377,7 @@ if grep -qx '<--draft>' "$GH_ARGV_RECORD_FILE"; then
 else
 	print_result "B8: AIDEVOPS_PR_CREATE_READY leaves interactive PR non-draft" 0
 fi
-unset GH_ARGV_RECORD_FILE
+unset AIDEVOPS_PR_CREATE_READY GH_ARGV_RECORD_FILE
 
 # ---------------------------------------------------------------------------
 # Layer B': gh_create_issue defence-in-depth (mirrors PR tests)


### PR DESCRIPTION
## Summary
- Confirms the valuable `status:available` default-label work from closed PR #23521 is already present on `main` via merged PRs #23518 and #23523.
- Salvages the remaining issue exposed by that verification: `gh_create_issue` expanded an empty local Bash array under `set -u`, aborting the create-path regression test before the new status-label assertions ran.
- Isolates `AIDEVOPS_PR_CREATE_READY` in the PR-create test fixture so the issue-create cases run with a clean environment.

## Testing
- `.agents/scripts/tests/test-origin-label-mutex-create.sh`
- `.agents/scripts/tests/test-label-invariants.sh`
- `shellcheck .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/shared-gh-wrappers-session.sh .agents/scripts/tests/test-origin-label-mutex-create.sh .agents/scripts/tests/test-label-invariants.sh`

Ref #23521

## Notes
- Replacement/salvage PR only; do not merge from this headless run per dispatch instruction.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 6m and 101,057 tokens on this as a headless worker.
