### PR TITLE
For #23695: preserve health issue JSON fallbacks

### DIFF
--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -116,7 +116,7 @@ _health_issue_operator_label_allows_identity() {
 	local canonical_identity="$2"
 	local canonical_label="operator:${canonical_identity}"
 
-	printf '%s' "${issue_json:-{}}" | jq -e --arg canonical_label "$canonical_label" '
+	printf '%s' "$issue_json" | jq -e --arg canonical_label "$canonical_label" '
 		((.labels // []) | map(.name) | map(select(startswith("operator:")))) as $operator_labels
 		| ($operator_labels | length == 0 or any(. == $canonical_label))
 	' >/dev/null 2>&1

--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -115,8 +115,13 @@ _health_issue_operator_label_allows_identity() {
 	local issue_json="$1"
 	local canonical_identity="$2"
 	local canonical_label="operator:${canonical_identity}"
+	local issue_json_input="${issue_json}"
+	[[ -z "$issue_json_input" ]] && issue_json_input='{}'
+	case "$issue_json_input" in
+		[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd]) issue_json_input='{}' ;;
+	esac
 
-	printf '%s' "$issue_json" | jq -e --arg canonical_label "$canonical_label" '
+	printf '%s' "$issue_json_input" | jq -e --arg canonical_label "$canonical_label" '
 		((.labels // []) | map(.name) | map(select(startswith("operator:")))) as $operator_labels
 		| ($operator_labels | length == 0 or any(. == $canonical_label))
 	' >/dev/null 2>&1
@@ -160,7 +165,12 @@ _try_cached_health_issue_lookup() {
 		return 0
 	fi
 
-	issue_state=$(printf '%s' "${issue_json:-{}}" | jq -r '.state // empty' 2>/dev/null || echo "")
+	local raw_issue_json="$issue_json"
+	[[ -z "$issue_json" ]] && issue_json='{}'
+	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null || echo "")
+	case "$raw_issue_json" in
+		[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd]) issue_state="$raw_issue_json" ;;
+	esac
 
 	# gh issue view has returned both GraphQL-style uppercase enums (OPEN/CLOSED)
 	# and REST-style lowercase values (open/closed) depending on fallback path.

--- a/.agents/scripts/tests/test-find-health-issue-rate-limit.sh
+++ b/.agents/scripts/tests/test-find-health-issue-rate-limit.sh
@@ -270,6 +270,22 @@ else
 	fail "does not log lowercase open as unexpected state" "log: $(grep 'unexpected state' "$LOGFILE")"
 fi
 
+section "Scenario 2c: cache-hit + gh view returns empty JSON payload → cache preserved"
+reset_stubs
+setup_cache "42"
+stub_gh_for "issue view 42" "" 0
+result=$(_find_health_issue "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" "$ROLE_LABEL" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "42" ]]; then
+	pass "echoes cached number when view returns an empty payload"
+else
+	fail "echoes cached number when view returns an empty payload" "got '$result'"
+fi
+if grep -q "unexpected state ''" "$LOGFILE"; then
+	pass "empty view payload is normalized without jq parse failure"
+else
+	fail "empty view payload is normalized without jq parse failure" "log: $(cat "$LOGFILE")"
+fi
+
 section "Scenario 3: no cache + label list fails (rc=4) → __QUERY_FAILED__ sentinel"
 reset_stubs
 clear_cache

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -212,6 +212,12 @@ else
 	fail "drops cached dashboard with conflicting operator label" "result=${result}; cache_exists=$([[ -f "$cache_file" ]] && printf yes || printf no); calls=$(tr '\n' ';' <"$GH_CALLS")"
 fi
 
+if _health_issue_operator_label_allows_identity "" "canonical-operator"; then
+	pass "allows empty cached issue metadata as unknown rather than jq parse failure"
+else
+	fail "allows empty cached issue metadata as unknown rather than jq parse failure" "empty input was rejected"
+fi
+
 body=$(_build_health_issue_body \
 	"2026-05-08T00:00:00Z" "Supervisor" "github-user" "owner/repo" \
 	"0" "0" "0" "0" "4" "1" "0" "" \


### PR DESCRIPTION
## Summary

- Continues PR #23695 on a maintainer-owned branch so the review feedback can be addressed.
- Preserves the safe JSON fallback for empty health issue metadata without using the `${var:-{}}` expansion that caused the original shell parsing concern.
- Handles raw `OPEN`/`CLOSED` state payloads before operator-label validation so REST fallback cache checks keep working.

## Testing

- `.agents/scripts/tests/test-health-dashboard-identity-aliases.sh`
- `bash .agents/scripts/tests/test-find-health-issue-rate-limit.sh`
- `shellcheck .agents/scripts/stats-health-dashboard-issue.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh .agents/scripts/tests/test-find-health-issue-rate-limit.sh`

## Runtime Testing

Self-assessed: shell helper regression tests and ShellCheck cover this low-risk shell parsing/cache validation fix.

For #23695

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 5m and 125,179 tokens on this as a headless worker.
