### PR TITLE
fix: add timeout to person-stats calls in health dashboard refresh

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -903,7 +903,8 @@ _refresh_person_stats_cache() {
 		local slug_safe="${slug//\//-}"
 		local cache_file="${PERSON_STATS_CACHE_DIR}/person-stats-cache-${slug_safe}.md"
 		local md
-		md=$(bash "$activity_helper" person-stats "$path" --period month --format markdown 2>/dev/null) || md=""
+		# t2687: add 60s timeout to person-stats to prevent hanging on GitHub API calls
+		md=$(timeout 60 bash "$activity_helper" person-stats "$path" --period month --format markdown 2>/dev/null) || md=""
 		if [[ -n "$md" ]]; then
 			echo "$md" >"$cache_file"
 		fi
@@ -920,7 +921,8 @@ _refresh_person_stats_cache() {
 		done <<<"$all_repo_paths"
 		if [[ ${#cross_args[@]} -gt 1 ]]; then
 			local cross_md
-			cross_md=$(bash "$activity_helper" cross-repo-person-stats "${cross_args[@]}" --period month --format markdown 2>/dev/null) || cross_md=""
+			# t2687: add 60s timeout to cross-repo-person-stats to prevent hanging on GitHub API calls
+			cross_md=$(timeout 60 bash "$activity_helper" cross-repo-person-stats "${cross_args[@]}" --period month --format markdown 2>/dev/null) || cross_md=""
 			if [[ -n "$cross_md" ]]; then
 				echo "$cross_md" >"${PERSON_STATS_CACHE_DIR}/person-stats-cache-cross-repo.md"
 			fi


### PR DESCRIPTION
The stats wrapper was hanging indefinitely when calling person-stats and cross-repo-person-stats because these functions make GitHub API calls without a timeout. When the GitHub API is slow or unresponsive, the stats wrapper would hang, preventing the health dashboard from being updated.

This fix adds a 60-second timeout to both person-stats calls to ensure the stats wrapper completes within a reasonable time. If the person-stats call times out, it gracefully falls back to an empty string, allowing the health dashboard update to continue.

Fixes Ultimate-Multisite/ultimate-multisite-plugin-and-theme-manager#181: Supervisor health dashboard stale: 8d2h
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with claude-haiku-4-5 spent 8m and 1,910 tokens on this as a headless worker.
