### PR TITLE
GH#23747: simplify pulse lifecycle pipe handling

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -157,8 +157,8 @@ _pulse_emit_pid() {
 
 _pulse_restore_pipe_trap() {
 	local _pipe_trap="$1"
-	if [[ -n "$_pipe_trap" ]]; then
-		eval "$_pipe_trap"
+	if [[ "$_pipe_trap" == *"trap -- '' SIGPIPE"* || "$_pipe_trap" == *"trap -- '' PIPE"* ]]; then
+		trap '' PIPE
 	else
 		trap - PIPE
 	fi
@@ -192,7 +192,6 @@ _pulse_restore_pipe_trap() {
 # all pulse processes including subshells AND sidecars on `stop`.
 _pulse_pids() {
 	local _pids="" _pid="" _ppid="" _ppid_cmd="" _cmd="" _pipe_trap=""
-	local _consumer_closed=0
 	_pids=$(_pulse_pids_raw)
 	[[ -z "$_pids" ]] && return 0
 	_pipe_trap=$(trap -p PIPE || true)
@@ -207,7 +206,7 @@ _pulse_pids() {
 			# Layer 3 (sidecar guard): skip if argv contains a sidecar flag.
 			_cmd=$(ps -p "$_pid" -o command= 2>/dev/null)
 			[[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]] && continue
-			_pulse_emit_pid "$_pid" || { _consumer_closed=1; break; }
+			_pulse_emit_pid "$_pid" || break
 			continue
 		fi
 		# Layer 2 (fallback for manually-started instances): skip PIDs whose
@@ -218,10 +217,9 @@ _pulse_pids() {
 		# (manual --merge-only invocations during testing or debugging).
 		_cmd=$(ps -p "$_pid" -o command= 2>/dev/null)
 		[[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]] && continue
-		_pulse_emit_pid "$_pid" || { _consumer_closed=1; break; }
+		_pulse_emit_pid "$_pid" || break
 	done <<< "$_pids"
 	_pulse_restore_pipe_trap "$_pipe_trap"
-	[[ "$_consumer_closed" -eq 0 ]] || return 0
 	return 0
 }
 
@@ -233,7 +231,6 @@ _pulse_pids() {
 # launchd-spawned processes (PPID=1), never as subshells of a main pulse.
 _pulse_pids_sidecar() {
 	local _pids="" _pid="" _ppid="" _ppid_cmd="" _cmd="" _pipe_trap=""
-	local _consumer_closed=0
 	_pids=$(_pulse_pids_raw)
 	[[ -z "$_pids" ]] && return 0
 	_pipe_trap=$(trap -p PIPE || true)
@@ -247,11 +244,10 @@ _pulse_pids_sidecar() {
 		fi
 		_cmd=$(ps -p "$_pid" -o command= 2>/dev/null)
 		if [[ "$_cmd" =~ $_PULSE_SIDECAR_FLAGS_RE ]]; then
-			_pulse_emit_pid "$_pid" || { _consumer_closed=1; break; }
+			_pulse_emit_pid "$_pid" || break
 		fi
 	done <<< "$_pids"
 	_pulse_restore_pipe_trap "$_pipe_trap"
-	[[ "$_consumer_closed" -eq 0 ]] || return 0
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -528,6 +528,40 @@ test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early() {
 	return 0
 }
 
+test_pipe_trap_restore_avoids_eval() {
+	local out=""
+	out=$(
+		(
+			# shellcheck source=../pulse-lifecycle-helper.sh
+			source "$HELPER"
+			_trap_eval_marker=0
+			_pulse_restore_pipe_trap '_trap_eval_marker=1'
+			printf '%s\n' "$_trap_eval_marker"
+		)
+	)
+	_assert_eq "_pulse_restore_pipe_trap does not eval trap text" "0" "$out"
+	return 0
+}
+
+test_pipe_trap_restore_ignored_sigpipe() {
+	local out=""
+	out=$(
+		(
+			# shellcheck source=../pulse-lifecycle-helper.sh
+			source "$HELPER"
+			trap - PIPE
+			_pulse_restore_pipe_trap "trap -- '' SIGPIPE"
+			trap -p PIPE
+		)
+	)
+	if [[ "$out" == *"''"* ]]; then
+		_print_result "_pulse_restore_pipe_trap restores ignored SIGPIPE" 1
+	else
+		_print_result "_pulse_restore_pipe_trap failed to restore ignored SIGPIPE (out=$out)" 0
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # GH#21903: threshold-based PILE-UP detection
 # -----------------------------------------------------------------------------
@@ -868,6 +902,8 @@ main() {
 	test_skip_env_honoured_in_restart
 	test_missing_pulse_script_exit_2
 	test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early
+	test_pipe_trap_restore_avoids_eval
+	test_pipe_trap_restore_ignored_sigpipe
 
 	# GH#21903 threshold-based PILE-UP detection
 	test_status_two_instances_no_warning_default_threshold


### PR DESCRIPTION
## Summary

- Removed eval-based SIGPIPE trap restoration from `.agents/scripts/pulse-lifecycle-helper.sh`.
- Simplified early-closing consumer handling by breaking directly from PID emit loops.
- Added regression tests for non-evaluated trap text and ignored SIGPIPE restoration.

## Testing

- `shellcheck .agents/scripts/pulse-lifecycle-helper.sh .agents/scripts/tests/test-pulse-lifecycle-helper.sh`
- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh`

## Runtime Testing

Self-assessed: shell helper refactor with focused shellcheck and regression test coverage.

Resolves #23747


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 3m and 58,929 tokens on this as a headless worker.
