### PR TITLE
fix: guard supply-chain test cleanup helper

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -38,8 +38,8 @@ make_tmpdir() {
 }
 
 cleanup_test_tmpdir() {
-	local tmpdir="$1"
-	rm -rf "$tmpdir"
+	local tmpdir="${1:-}"
+	[[ -n "$tmpdir" ]] && rm -rf "$tmpdir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- Guard cleanup_test_tmpdir against empty or unset arguments before rm -rf.
- Preserve the explicit return required by the shell helper standards.

## Review context
- Follow-up to Gemini review comment on PR #23752.
- Keeps the existing supply-chain advisory helper regression tests functionally unchanged.

## Testing
- bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh
- shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh

For #23750

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 3m and 74,884 tokens on this as a headless worker.
