### PR TITLE
GH#23746: propagate detector log statuses

### DIFF
--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -80,17 +80,17 @@ _log() {
 	local level="$1"
 	shift
 	printf '[fix-the-fixer-detector] %s: %s\n' "$level" "$*" >&2
-	return 0
+	return $?
 }
 
 _log_info() {
 	_log "$_LL_INFO" "$@"
-	return 0
+	return $?
 }
 
 _log_warn() {
 	_log "$_LL_WARN" "$@"
-	return 0
+	return $?
 }
 
 _auth_item_logs_suppressed() {


### PR DESCRIPTION
## Summary

Updated pulse-fix-the-fixer detector logging wrappers to return the underlying printf/_log exit status instead of masking failures.

## Files Changed

.agents/scripts/pulse-fix-the-fixer-detector.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh; .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh

Resolves #23746


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 1m and 41,069 tokens on this as a headless worker.