### PR TITLE
GH#23749: fix: harden pulse cleanup ordering test

### DIFF
--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -187,6 +187,27 @@ test_canary_short_circuit_after_lock() {
 	return 0
 }
 
+cleanup_registration_precedes_exit_trap() {
+	awk '
+		/_save_cleanup_scope/ {
+			seen_scope = 1
+			next
+		}
+		seen_scope && /push_cleanup '\''release_instance_lock'\''/ {
+			seen_cleanup = 1
+			next
+		}
+		seen_scope && seen_cleanup && /trap '\''_run_cleanups'\'' EXIT/ {
+			found = 1
+			exit
+		}
+		END {
+			exit found ? 0 : 1
+		}
+	' "$WRAPPER_SCRIPT"
+	return $?
+}
+
 # Test 5: Static check — pulse enables per-cycle PR list and view cache TTLs.
 #
 # GH#23604: default 15-second wrapper cache windows were too short for a full
@@ -207,7 +228,7 @@ test_pr_cache_ttls_are_per_cycle() {
 	if ! grep -q "trap '_run_cleanups' EXIT" "$WRAPPER_SCRIPT"; then
 		missing="${missing} exit-cleanup-trap"
 	fi
-	if ! grep -A5 '_save_cleanup_scope' "$WRAPPER_SCRIPT" | grep -B4 "trap '_run_cleanups' EXIT" | grep -q "push_cleanup 'release_instance_lock'"; then
+	if ! cleanup_registration_precedes_exit_trap; then
 		missing="${missing} lock-cleanup-before-exit-trap"
 	fi
 


### PR DESCRIPTION
## Summary

Replaced the brittle fixed-context grep pipeline in .agents/scripts/tests/test-pulse-wrapper-canary.sh with an awk-based sequence check that accepts comments or unrelated logic between cleanup registration and the EXIT trap while preserving order validation.

## Files Changed

.agents/scripts/tests/test-pulse-wrapper-canary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-wrapper-canary.sh; shellcheck .agents/scripts/tests/test-pulse-wrapper-canary.sh

Resolves #23749


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.59 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 33,029 tokens on this as a headless worker.