### PR TITLE
fix: consolidate dispatch hold label semantics

### DIFF
--- a/.agents/reference/auto-dispatch.md
+++ b/.agents/reference/auto-dispatch.md
@@ -146,7 +146,8 @@ For routine bug fixes, refactors, and well-specified work in dispatch-path files
 |---|---|
 | `dispatch-path-ok` | (Legacy / redundant since t2920) Author explicitly requested auto-dispatch on a dispatch-path task. New tasks don't need this label. |
 | `parent-task` | Unconditional dispatch block — `dispatch-dedup-helper.sh` `_is_assigned_check_parent_task` short-circuits with `PARENT_TASK_BLOCKED` |
-| `no-auto-dispatch` | Unconditional dispatch block (t2832) — `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` short-circuits with `NO_AUTO_DISPATCH_BLOCKED`. Use only when you specifically want the dispatch-path opt-out described above. |
+| `no-auto-dispatch` | Canonical unconditional issue dispatch block (t2832) — `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` short-circuits with `NO_AUTO_DISPATCH_BLOCKED`. Use when you want to keep an issue in the backlog but prevent pulse workers from picking it up. |
+| `hold-for-review` | Review-hold label. On issues, blocks dispatch with the same intent as `no-auto-dispatch` (`HOLD_FOR_REVIEW_BLOCKED`). On PRs, blocks auto-merge until explicit maintainer review. |
 
 Companion fixes: t2819 (self-hosting pre-dispatch tier override), t2820 (no_work reclassification), t2832 (no-auto-dispatch unconditional block), t2920 (default reversed to auto-dispatch + advisory). Derived from #20765 / GH#20827 / GH#21086 dispatch-history analysis.
 

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -16,7 +16,8 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 |-------|-------------|-----------|
 | `parent-task` | `dispatch-dedup-helper.sh` `_is_assigned_check_parent_task` | Epics/trackers — children implement, not this issue. Cannot be overridden by NMR clearance (t2211). |
 | `meta` | Same as `parent-task` — treated as an alias | Alternative spelling of `parent-task`. |
-| `no-auto-dispatch` | `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` (t2832), `issue-sync-lib.sh`, `interactive-session-helper.sh` lockdown | Manual hold by session or user. Blocks dispatch path (`NO_AUTO_DISPATCH_BLOCKED` signal), enrich path, and decomposer path. Applied by `interactive-session-helper.sh lockdown`. Pre-fix (before t2832) the label was honoured by enrichment/decomposition only — workers got dispatched anyway. |
+| `no-auto-dispatch` | `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` (t2832), `issue-sync-lib.sh`, `interactive-session-helper.sh` lockdown | Canonical manual hold for issues. Blocks dispatch path (`NO_AUTO_DISPATCH_BLOCKED` signal), enrich path, and decomposer path. Applied by `interactive-session-helper.sh lockdown`. Pre-fix (before t2832) the label was honoured by enrichment/decomposition only — workers got dispatched anyway. |
+| `hold-for-review` | `dispatch-dedup-helper.sh` `_is_assigned_check_hold_for_review`, `issue-sync-lib.sh`; PR merge checks below | Manual review hold. On issues, same dispatch-block intent as `no-auto-dispatch` (`HOLD_FOR_REVIEW_BLOCKED` signal). On PRs, blocks auto-merge until a maintainer removes the label. |
 | `needs-maintainer-review` | `pulse-nmr-approval.sh` `auto_approve_maintainer_issues` | Requires maintainer cryptographic approval (`sudo aidevops approve issue <N>`) before dispatch. |
 | `needs-credentials` | `label-sync-helper.sh` SYSTEM_LABELS | Task requires credentials, API keys, or account access — cannot be completed by a headless worker autonomously. Add when the TODO entry has `#no-auto-dispatch` due to credential dependency. |
 | `persistent` | `pulse-issue-reconcile.sh` | Monitoring/tracking issue — must not be dispatched as a code task. |
@@ -41,7 +42,7 @@ Applied to pull requests. The merge pass checks these before merging.
 
 | Label | Enforced by | Rationale |
 |-------|-------------|-----------|
-| `hold-for-review` | `pulse-merge.sh` `_check_interactive_pr_gates` (t2411), `_check_pr_merge_gates` (t2449) | Opt-out of auto-merge — holds PR for explicit maintainer review. |
+| `hold-for-review` | `pulse-merge.sh` `_check_interactive_pr_gates` (t2411), `_check_pr_merge_gates` (t2449) | Opt-out of auto-merge — holds PR for explicit maintainer review. Same label also blocks issue dispatch when applied to issues. |
 | Draft PR status | `pulse-merge.sh` | Draft PRs are never auto-merged. |
 | CHANGES_REQUESTED review | `review-bot-gate-helper.sh` | Unresolved review blocks merge. Exception: `coderabbit-nits-ok` label dismisses CodeRabbit-only CHANGES_REQUESTED (t2179). |
 
@@ -55,6 +56,7 @@ These are not labels — they are runtime state signals checked by `dispatch-ded
 |--------|-----------|---------|
 | `PARENT_TASK_BLOCKED` | 0 (blocked) | `parent-task` / `meta` label — unconditional block |
 | `NO_AUTO_DISPATCH_BLOCKED` | 0 (blocked) | `no-auto-dispatch` label — unconditional block (t2832) |
+| `HOLD_FOR_REVIEW_BLOCKED` | 0 (blocked) | `hold-for-review` label — unconditional issue dispatch block and PR auto-merge hold |
 | `ASSIGNED: issue #N in repo` | 0 (blocked) | Active assignee with blocking claim state |
 | `GUARD_UNCERTAIN` | 0 (blocked, fail-closed) | API or jq failure — dispatch refused to avoid collision |
 | No assignees | 1 (allow dispatch) | Safe to dispatch |

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -665,6 +665,42 @@ _is_assigned_check_parent_task() {
 }
 
 #######################################
+# is_assigned helper: check an unconditional label block.
+#
+# Args:
+#   $1 = issue metadata JSON (from `gh issue view --json ...,labels`)
+#   $2 = issue number for traceable error output
+#   $3 = repo slug for traceable error output
+#   $4 = label name to check
+#   $5 = block signal to emit when label is present
+#   $6 = check name for GUARD_UNCERTAIN output
+# Returns: exit 0 if label found or jq fails (prints signal),
+#          exit 1 if label absent and jq succeeds
+#######################################
+_is_assigned_check_label_block() {
+	local meta_json="$1"
+	local issue_number="${2:-unknown}"
+	local repo_slug="${3:-unknown}"
+	local label_name="$4"
+	local block_signal="$5"
+	local check_name="$6"
+	local _jq_rc=0
+	local label_hit
+	label_hit=$(printf '%s' "$meta_json" |
+		jq -r --arg label_name "$label_name" '(.labels // [])[].name | select(. == $label_name)' 2>/dev/null | head -n 1) || _jq_rc=$?
+	if [[ "$_jq_rc" -ne 0 ]]; then
+		printf 'GUARD_UNCERTAIN (reason=jq-failure call=%s issue=%s repo=%s)\n' \
+			"$check_name" "$issue_number" "$repo_slug"
+		return 0
+	fi
+	if [[ -n "$label_hit" ]]; then
+		printf '%s (label=%s)\n' "$block_signal" "$label_hit"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # is_assigned helper: check the no-auto-dispatch unconditional block (t2832).
 #
 # t2832: no-auto-dispatch label is an unconditional dispatch block. The label
@@ -703,21 +739,8 @@ _is_assigned_check_no_auto_dispatch() {
 	local meta_json="$1"
 	local issue_number="${2:-unknown}"
 	local repo_slug="${3:-unknown}"
-	# t2061: explicit rc capture — fail-closed on jq failure.
-	local _jq_rc=0
-	local nad_hit
-	nad_hit=$(printf '%s' "$meta_json" |
-		jq -r '(.labels // [])[].name | select(. == "no-auto-dispatch")' 2>/dev/null | head -n 1) || _jq_rc=$?
-	if [[ "$_jq_rc" -ne 0 ]]; then
-		printf 'GUARD_UNCERTAIN (reason=jq-failure call=no-auto-dispatch-check issue=%s repo=%s)\n' \
-			"$issue_number" "$repo_slug"
-		return 0
-	fi
-	if [[ -n "$nad_hit" ]]; then
-		printf 'NO_AUTO_DISPATCH_BLOCKED (label=%s)\n' "$nad_hit"
-		return 0
-	fi
-	return 1
+	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
+		"no-auto-dispatch" "NO_AUTO_DISPATCH_BLOCKED" "no-auto-dispatch-check"
 }
 
 #######################################
@@ -744,20 +767,8 @@ _is_assigned_check_hold_for_review() {
 	local meta_json="$1"
 	local issue_number="${2:-unknown}"
 	local repo_slug="${3:-unknown}"
-	local _jq_rc=0
-	local hfr_hit
-	hfr_hit=$(printf '%s' "$meta_json" |
-		jq -r '(.labels // [])[].name | select(. == "hold-for-review")' 2>/dev/null | head -n 1) || _jq_rc=$?
-	if [[ "$_jq_rc" -ne 0 ]]; then
-		printf 'GUARD_UNCERTAIN (reason=jq-failure call=hold-for-review-check issue=%s repo=%s)\n' \
-			"$issue_number" "$repo_slug"
-		return 0
-	fi
-	if [[ -n "$hfr_hit" ]]; then
-		printf 'HOLD_FOR_REVIEW_BLOCKED (label=%s)\n' "$hfr_hit"
-		return 0
-	fi
-	return 1
+	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
+		"hold-for-review" "HOLD_FOR_REVIEW_BLOCKED" "hold-for-review-check"
 }
 
 #######################################

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -108,7 +108,7 @@ DISPATCH_LABELS=(
 SYSTEM_LABELS=(
 	"auto-dispatch|0E8A16|Eligible for automated worker dispatch"
 	"no-auto-dispatch|EDEDED|Opt-out: block all auto-dispatch on this issue"
-	"hold-for-review|D73A4A|Opt-out: block auto-merge — hold PR for maintainer review"
+	"hold-for-review|D73A4A|Opt-out: block issue auto-dispatch or PR auto-merge for maintainer review"
 	"needs-credentials|FBCA04|Opt-out: block auto-dispatch — requires credentials or account access"
 	"ai-approved|0E8A16|Issue approved for AI agent processing"
 	"persistent|FBCA04|Persistent issue — do not close"


### PR DESCRIPTION
## Summary
- Reuse one helper for both issue dispatch hold labels so `no-auto-dispatch` and `hold-for-review` stay behaviorally aligned.
- Document `no-auto-dispatch` as the canonical issue backlog hold.
- Document `hold-for-review` as an issue dispatch hold plus PR auto-merge hold.

For #23704

## Verification
- `.agents/scripts/tests/test-dispatch-dedup-no-auto-dispatch-block.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh`
- `.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh`
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/label-sync-helper.sh .agents/scripts/tests/test-dispatch-dedup-no-auto-dispatch-block.sh .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/complexity-hold-labels.md`
- `.agents/scripts/lint-shell-portability.sh && .agents/scripts/stat-portability-check.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 23h 41m and 730,500 tokens on this with the user in an interactive session.