### PR TITLE
GH#23748: test: harden no-node utility path test

### DIFF
--- a/.agents/scripts/tests/test-agent-source-manifest-index.sh
+++ b/.agents/scripts/tests/test-agent-source-manifest-index.sh
@@ -147,10 +147,15 @@ test_check_validates_capability_cardinality() {
 test_sync_without_node_fails_open() {
 	local path_without_node="$TEST_HOME/no-node-bin"
 	mkdir -p "$path_without_node"
-	ln -s "$(command -v bash)" "$path_without_node/bash"
-	ln -s "$(command -v cat)" "$path_without_node/cat"
-	ln -s "$(command -v dirname)" "$path_without_node/dirname"
-	ln -s "$(command -v mkdir)" "$path_without_node/mkdir"
+
+	local cmd=""
+	local cmd_path=""
+	for cmd in bash cat dirname find grep ln mkdir readlink rm rsync sed; do
+		cmd_path=$(command -v "$cmd")
+		if [[ -n "$cmd_path" ]]; then
+			ln -s "$cmd_path" "$path_without_node/$cmd"
+		fi
+	done
 
 	local output=""
 	local status=0


### PR DESCRIPTION
## Summary

Updated the no-node sync regression test to build its mock PATH from the required helper utilities using guarded command -v lookups, so missing optional utilities do not create empty symlink targets.

## Files Changed

.agents/scripts/tests/test-agent-source-manifest-index.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-agent-source-manifest-index.sh; shellcheck .agents/scripts/tests/test-agent-source-manifest-index.sh

Resolves #23748


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.59 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 1m and 31,305 tokens on this as a headless worker.