### PR TITLE
GH#23751: fix: preserve comma labels in FOSS dispatch

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -52,6 +52,37 @@ _expand_foss_repo_path() {
 }
 
 #######################################
+# List one open FOSS issue matching a configured label.
+#
+# GitHub CLI treats commas in --label values as multiple labels. Use quoted
+# search syntax only for comma-containing label names so a single configured
+# label such as "needs, triage" remains one label at the point of use.
+#
+# Arguments:
+#   $1 - repo_slug (owner/repo)
+#   $2 - label
+#######################################
+_foss_issue_list_for_label() {
+	local repo_slug="$1"
+	local label="$2"
+	local search_label
+
+	if [[ "$label" == *,* ]]; then
+		search_label="${label//\\/\\\\}"
+		search_label="${search_label//\"/\\\"}"
+		gh_issue_list --repo "$repo_slug" --state open \
+			--search "label:\"${search_label}\"" --limit 1 \
+			--json number,title --jq '.[] | "\(.number // "")|\(.title // "")"'
+		return $?
+	fi
+
+	gh_issue_list --repo "$repo_slug" --state open \
+		--label "$label" --limit 1 \
+		--json number,title --jq '.[] | "\(.number // "")|\(.title // "")"'
+	return $?
+}
+
+#######################################
 # Ensure the triage-failed label exists in the target repo.
 #
 # Uses gh label create --force (idempotent — creates if missing,
@@ -1229,9 +1260,7 @@ dispatch_foss_workers() {
 		done < <(jq -r '.[]' <<<"$labels_filter_json" 2>/dev/null || printf '%s\n' 'help wanted' 'good first issue' 'bug')
 		for foss_label in "${foss_label_candidates[@]}"; do
 			[[ -n "$foss_label" ]] || continue
-			foss_issue=$(gh_issue_list --repo "$foss_slug" --state open \
-				--label "$foss_label" --limit 1 \
-				--json number,title --jq '.[] | "\(.number // "")|\(.title // "")"') || foss_issue=""
+			foss_issue=$(_foss_issue_list_for_label "$foss_slug" "$foss_label") || foss_issue=""
 			[[ -n "$foss_issue" ]] && break
 		done
 		if [[ -z "$foss_issue" ]]; then

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -64,11 +64,26 @@ JSON
 
 gh_issue_list() {
 	local label=""
+	local search=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--label)
 			label="$2"
 			test -n "$label" || break
+			[[ "$label" != *,* ]] || fail "comma-containing label used --label instead of --search"
+			shift 2
+			;;
+		--search)
+			search="$2"
+			case "$search" in
+			label:\"*\")
+				label="${search#label:\"}"
+				label="${label%\"}"
+				;;
+			*)
+				fail "unexpected FOSS issue search query: ${search}"
+				;;
+			esac
 			shift 2
 			;;
 		*)


### PR DESCRIPTION
## Summary

Added a FOSS issue-list helper that routes comma-containing configured labels through quoted GitHub search syntax instead of gh --label, and extended the FOSS dispatch regression test to fail if comma labels reach --label.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

Resolves #23751


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 45,099 tokens on this as a headless worker.