### PR TITLE
GH#23760: quote planning next-id assignments

### DIFF
--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -127,9 +127,9 @@ _complete_task_parse_args() {
 		esac
 	done
 
-	echo "task_id=${_task_id}"
-	echo "pr_number=${_pr_number}"
-	echo "verified_mode=${_verified_mode}"
+	printf 'task_id=%q\n' "$_task_id"
+	printf 'pr_number=%q\n' "$_pr_number"
+	printf 'verified_mode=%q\n' "$_verified_mode"
 	return 0
 }
 
@@ -345,11 +345,11 @@ _next_task_id_parse_args() {
 		esac
 	done
 
-	echo "title=${_title}"
-	echo "labels=${_labels}"
-	echo "description=${_description}"
-	echo "offline_flag=${_offline_flag}"
-	echo "dry_run_flag=${_dry_run_flag}"
+	printf 'title=%q\n' "$_title"
+	printf 'labels=%q\n' "$_labels"
+	printf 'description=%q\n' "$_description"
+	printf 'offline_flag=%q\n' "$_offline_flag"
+	printf 'dry_run_flag=%q\n' "$_dry_run_flag"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-planning-commit-helper-next-id.sh
+++ b/.agents/scripts/tests/test-planning-commit-helper-next-id.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#23760: planning-commit-helper next-id must preserve
+# multi-word values when parsing --title, --labels, and --description.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
+PLANNING_HELPER="${REPO_ROOT}/.agents/scripts/planning-commit-helper.sh"
+
+if [[ ! -x "$PLANNING_HELPER" ]]; then
+	printf 'planning-commit-helper.sh not executable: %s\n' "$PLANNING_HELPER" >&2
+	exit 1
+fi
+
+output=$("$PLANNING_HELPER" next-id \
+	--title "Run Phase 3 kickoff adjustment for post-t394 roadmap" \
+	--labels "bug,auto-dispatch" \
+	--description "Multi word description value" \
+	--dry-run 2>&1)
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+	printf 'FAIL: expected next-id dry-run to succeed, rc=%s\n%s\n' "$rc" "$output" >&2
+	exit 1
+fi
+
+if [[ "$output" == *"command not found"* ]]; then
+	printf 'FAIL: parser attempted to execute part of a multi-word value\n%s\n' "$output" >&2
+	exit 1
+fi
+
+if [[ "$output" != *"TASK_ID=tDRY_RUN"* ]] || [[ "$output" != *"TASK_REF=DRY_RUN"* ]]; then
+	printf 'FAIL: expected dry-run task fields in output\n%s\n' "$output" >&2
+	exit 1
+fi
+
+printf 'PASS: planning-commit-helper next-id preserves multi-word arguments\n'
+exit 0


### PR DESCRIPTION
## Summary
- safely shell-quote parser assignment output consumed by `eval` in `planning-commit-helper.sh`
- covers `next-id` values for multi-word `--title`, `--labels`, and `--description`
- applies the same quoting to `complete` parser assignments to avoid the same class of failure
- adds a focused dry-run regression test for GH#23760

## Verification
- `bash .agents/scripts/tests/test-planning-commit-helper-next-id.sh`
- `shellcheck .agents/scripts/planning-commit-helper.sh .agents/scripts/tests/test-planning-commit-helper-next-id.sh`
- `.agents/scripts/linters-local.sh`

Resolves #23760

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.59 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 25m and 105,658 tokens on this with the user in an interactive session.