### PR TITLE
t3591: Bound person-stats GitHub calls with portable timeouts

### DIFF
--- a/.agents/scripts/contributor-activity-helper-person.sh
+++ b/.agents/scripts/contributor-activity-helper-person.sh
@@ -37,6 +37,63 @@ fi
 
 # --- Functions ---
 
+: "${PERSON_STATS_GH_API_TIMEOUT:=20}"
+: "${PERSON_STATS_CROSS_REPO_GH_API_TIMEOUT:=45}"
+
+#######################################
+# Return the active GitHub API timeout budget.
+#
+# Output: timeout seconds
+#######################################
+_person_stats_gh_api_timeout() {
+	if [[ "${PERSON_STATS_MODE:-single}" == "cross-repo" ]]; then
+		printf '%s' "$PERSON_STATS_CROSS_REPO_GH_API_TIMEOUT"
+	else
+		printf '%s' "$PERSON_STATS_GH_API_TIMEOUT"
+	fi
+	return 0
+}
+
+#######################################
+# Run gh api with a portable wall-clock timeout.
+#
+# Arguments:
+#   $@ - gh api arguments
+#######################################
+_person_stats_gh_api() {
+	local timeout_budget
+	timeout_budget=$(_person_stats_gh_api_timeout)
+	timeout_sec "$timeout_budget" gh api "$@"
+	return $?
+}
+
+#######################################
+# Query a GitHub Search API total_count with timeout classification.
+#
+# Arguments:
+#   $1 - human-readable metric label
+#   $2 - GitHub API endpoint/query
+# Output: total_count or 0 on recoverable failure
+#######################################
+_person_stats_query_count() {
+	local label="$1"
+	local query="$2"
+	local value="0"
+	local rc=0
+	value=$(_person_stats_gh_api "$query" --jq '.total_count' 2>/dev/null) || rc=$?
+	if [[ "$rc" -eq 124 ]]; then
+		echo "GitHub Search API ${label} query timed out after $(_person_stats_gh_api_timeout)s" >&2
+		printf '%s' "0"
+		return 124
+	fi
+	if [[ "$rc" -ne 0 || ! "$value" =~ ^[0-9]+$ ]]; then
+		printf '%s' "0"
+		return 1
+	fi
+	printf '%s' "$value"
+	return 0
+}
+
 #######################################
 # Extract repo slug from git remote URL
 #
@@ -149,7 +206,14 @@ _person_stats_query_github() {
 	for login in $logins_csv; do
 		# Check search API rate limit before each batch of 4 queries per user
 		local remaining
-		remaining=$(gh api rate_limit --jq '.resources.search.remaining' 2>/dev/null) || remaining=30
+		local remaining_rc=0
+		remaining=$(_person_stats_gh_api rate_limit --jq '.resources.search.remaining' 2>/dev/null) || remaining_rc=$?
+		if [[ "$remaining_rc" -eq 124 ]]; then
+			echo "GitHub rate-limit probe timed out after $(_person_stats_gh_api_timeout)s, returning partial results" >&2
+			_ps_partial=true
+			break
+		fi
+		[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=30
 		if [[ "$remaining" -lt 5 ]]; then
 			# t1429: bail out with partial results instead of sleeping.
 			# The old code slept until reset, creating an infinite blocking
@@ -161,19 +225,27 @@ _person_stats_query_github() {
 
 		# Issues created by this user in this repo since the date
 		local issues_created
-		issues_created=$(gh api "search/issues?q=author:${login}+repo:${slug}+type:issue+created:>${since_date}&per_page=1" --jq '.total_count' 2>/dev/null) || issues_created=0
+		local issues_created_rc=0
+		issues_created=$(_person_stats_query_count "issues-created" "search/issues?q=author:${login}+repo:${slug}+type:issue+created:>${since_date}&per_page=1") || issues_created_rc=$?
+		[[ "$issues_created_rc" -eq 124 ]] && _ps_partial=true
 
 		# PRs created
 		local prs_created
-		prs_created=$(gh api "search/issues?q=author:${login}+repo:${slug}+type:pr+created:>${since_date}&per_page=1" --jq '.total_count' 2>/dev/null) || prs_created=0
+		local prs_created_rc=0
+		prs_created=$(_person_stats_query_count "prs-created" "search/issues?q=author:${login}+repo:${slug}+type:pr+created:>${since_date}&per_page=1") || prs_created_rc=$?
+		[[ "$prs_created_rc" -eq 124 ]] && _ps_partial=true
 
 		# PRs merged
 		local prs_merged
-		prs_merged=$(gh api "search/issues?q=author:${login}+repo:${slug}+type:pr+is:merged+merged:>${since_date}&per_page=1" --jq '.total_count' 2>/dev/null) || prs_merged=0
+		local prs_merged_rc=0
+		prs_merged=$(_person_stats_query_count "prs-merged" "search/issues?q=author:${login}+repo:${slug}+type:pr+is:merged+merged:>${since_date}&per_page=1") || prs_merged_rc=$?
+		[[ "$prs_merged_rc" -eq 124 ]] && _ps_partial=true
 
 		# Issues/PRs commented on (commenter: qualifier counts unique issues, not comments)
 		local commented_on
-		commented_on=$(gh api "search/issues?q=commenter:${login}+repo:${slug}+updated:>${since_date}&per_page=1" --jq '.total_count' 2>/dev/null) || commented_on=0
+		local commented_on_rc=0
+		commented_on=$(_person_stats_query_count "commented-on" "search/issues?q=commenter:${login}+repo:${slug}+updated:>${since_date}&per_page=1") || commented_on_rc=$?
+		[[ "$commented_on_rc" -eq 124 ]] && _ps_partial=true
 
 		if [[ "$first" == "true" ]]; then
 			first=false
@@ -240,7 +312,7 @@ else:
     if is_partial:
         print()
         print('<!-- partial-results -->')
-        print('_Partial results — GitHub Search API rate limit exhausted._')
+        print('_Partial results — GitHub Search API rate limit exhausted or a query timed out._')
 " "$format" "$period" "$is_partial"
 
 	return 0
@@ -318,10 +390,12 @@ person_stats() {
 	# Rate limit: 30 requests/min for search API. With 4 queries per user,
 	# we can handle ~7 users per minute. If budget is exhausted, bail out
 	# with partial results instead of blocking (t1429).
-	local results_json partial_flag
-	results_json=$(_person_stats_query_github "$logins_csv" "$slug" "$since_date" 2>/tmp/_ps_stderr) || true
-	partial_flag=$(grep '^PARTIAL=' /tmp/_ps_stderr 2>/dev/null | sed 's/PARTIAL=//' || echo "false")
-	cat /tmp/_ps_stderr >&2 2>/dev/null || true
+	local results_json partial_flag ps_stderr
+	ps_stderr=$(mktemp)
+	results_json=$(_person_stats_query_github "$logins_csv" "$slug" "$since_date" 2>"$ps_stderr") || true
+	partial_flag=$(grep '^PARTIAL=' "$ps_stderr" 2>/dev/null | sed 's/PARTIAL=//' || echo "false")
+	cat "$ps_stderr" >&2 2>/dev/null || true
+	rm -f "$ps_stderr"
 
 	_person_stats_format_output "$results_json" "$format" "$period" "$partial_flag"
 
@@ -364,7 +438,7 @@ _cross_repo_person_stats_collect_json() {
 		if [[ -n "$logins_override" ]]; then
 			extra_args+=(--logins "$logins_override")
 		fi
-		repo_json=$(person_stats "$rp" --period "$period" --format json ${extra_args[@]+"${extra_args[@]}"}) || repo_rc=$?
+		repo_json=$(PERSON_STATS_MODE=cross-repo person_stats "$rp" --period "$period" --format json ${extra_args[@]+"${extra_args[@]}"}) || repo_rc=$?
 		if [[ "$repo_rc" -eq "$EX_PARTIAL" ]]; then
 			any_partial=true
 		elif [[ "$repo_rc" -ne 0 ]]; then
@@ -453,7 +527,7 @@ else:
     if is_partial:
         print()
         print('<!-- partial-results -->')
-        print('_Partial results — GitHub Search API rate limit exhausted._')
+        print('_Partial results — GitHub Search API rate limit exhausted or a query timed out._')
 " "$format" "$period" "$repo_count" "$is_partial"
 
 	return 0
@@ -504,13 +578,15 @@ cross_repo_person_stats() {
 	fi
 
 	# Collect JSON from each repo, capture repo_count and partial flag from stderr
-	local raw_json repo_count_line repo_count partial_line partial_flag
-	raw_json=$(_cross_repo_person_stats_collect_json "$period" "$logins_override" "${repo_paths[@]}" 2>/tmp/_crps_stderr) || true
-	repo_count_line=$(grep '^REPO_COUNT=' /tmp/_crps_stderr 2>/dev/null || echo "REPO_COUNT=0")
+	local raw_json repo_count_line repo_count partial_line partial_flag crps_stderr
+	crps_stderr=$(mktemp)
+	raw_json=$(_cross_repo_person_stats_collect_json "$period" "$logins_override" "${repo_paths[@]}" 2>"$crps_stderr") || true
+	repo_count_line=$(grep '^REPO_COUNT=' "$crps_stderr" 2>/dev/null || echo "REPO_COUNT=0")
 	repo_count="${repo_count_line#REPO_COUNT=}"
-	partial_line=$(grep '^PARTIAL=' /tmp/_crps_stderr 2>/dev/null || echo "PARTIAL=false")
+	partial_line=$(grep '^PARTIAL=' "$crps_stderr" 2>/dev/null || echo "PARTIAL=false")
 	partial_flag="${partial_line#PARTIAL=}"
-	cat /tmp/_crps_stderr >&2 2>/dev/null || true
+	cat "$crps_stderr" >&2 2>/dev/null || true
+	rm -f "$crps_stderr"
 
 	# Merge all repo arrays into one, then aggregate per login
 	local all_json

--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -880,6 +880,8 @@ _refresh_person_stats_cache() {
 
 	local repo_count=0
 	local search_api_cost_per_contributor=4
+	local partial_exit=75
+	local refreshed_any=false
 	while IFS='|' read -r _slug _path; do
 		[[ -z "$_slug" ]] && continue
 		repo_count=$((repo_count + 1))
@@ -902,10 +904,14 @@ _refresh_person_stats_cache() {
 
 		local slug_safe="${slug//\//-}"
 		local cache_file="${PERSON_STATS_CACHE_DIR}/person-stats-cache-${slug_safe}.md"
-		local md
-		md=$(bash "$activity_helper" person-stats "$path" --period month --format markdown 2>/dev/null) || md=""
-		if [[ -n "$md" ]]; then
+		local md md_rc
+		md_rc=0
+		md=$(bash "$activity_helper" person-stats "$path" --period month --format markdown 2>/dev/null) || md_rc=$?
+		if [[ -n "$md" && ( "$md_rc" -eq 0 || "$md_rc" -eq "$partial_exit" ) ]]; then
 			echo "$md" >"$cache_file"
+			refreshed_any=true
+		elif [[ "$md_rc" -ne 0 ]]; then
+			echo "[stats] Person stats cache refresh failed for ${slug}: helper exited ${md_rc}" >>"$LOGFILE"
 		fi
 	done <<<"$repo_entries"
 
@@ -919,15 +925,23 @@ _refresh_person_stats_cache() {
 			[[ -n "$rp" ]] && cross_args+=("$rp")
 		done <<<"$all_repo_paths"
 		if [[ ${#cross_args[@]} -gt 1 ]]; then
-			local cross_md
-			cross_md=$(bash "$activity_helper" cross-repo-person-stats "${cross_args[@]}" --period month --format markdown 2>/dev/null) || cross_md=""
-			if [[ -n "$cross_md" ]]; then
+			local cross_md cross_rc
+			cross_rc=0
+			cross_md=$(bash "$activity_helper" cross-repo-person-stats "${cross_args[@]}" --period month --format markdown 2>/dev/null) || cross_rc=$?
+			if [[ -n "$cross_md" && ( "$cross_rc" -eq 0 || "$cross_rc" -eq "$partial_exit" ) ]]; then
 				echo "$cross_md" >"${PERSON_STATS_CACHE_DIR}/person-stats-cache-cross-repo.md"
+				refreshed_any=true
+			elif [[ "$cross_rc" -ne 0 ]]; then
+				echo "[stats] Cross-repo person stats cache refresh failed: helper exited ${cross_rc}" >>"$LOGFILE"
 			fi
 		fi
 	fi
 
-	date +%s >"$PERSON_STATS_LAST_RUN"
-	echo "[stats] Person stats cache refreshed" >>"$LOGFILE"
+	if [[ "$refreshed_any" == "true" ]]; then
+		date +%s >"$PERSON_STATS_LAST_RUN"
+		echo "[stats] Person stats cache refreshed" >>"$LOGFILE"
+	else
+		echo "[stats] Person stats cache refresh produced no successful outputs; last-run marker not updated" >>"$LOGFILE"
+	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-contributor-activity-helper-person.sh
+++ b/.agents/scripts/tests/test-contributor-activity-helper-person.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PERSON_LIB="${SCRIPT_DIR}/../contributor-activity-helper-person.sh"
+DASHBOARD_LIB="${SCRIPT_DIR}/../stats-health-dashboard-data.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf '[PASS] %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	printf '[FAIL] %s\n       %s\n' "$name" "$detail"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+test_person_stats_uses_portable_timeout() {
+	local name="person stats wraps gh api with timeout_sec"
+	local wrapper_pattern="timeout_sec \"\$timeout_budget\" gh api \"\$@\""
+	if grep -Fq "$wrapper_pattern" "$PERSON_LIB" && grep -q 'PERSON_STATS_CROSS_REPO_GH_API_TIMEOUT' "$PERSON_LIB"; then
+		pass "$name"
+	else
+		fail "$name" "missing portable gh api wrapper or cross-repo budget"
+	fi
+	return 0
+}
+
+test_person_stats_has_no_direct_timeout() {
+	local name="person stats does not call direct timeout"
+	if grep -Eq '(^|[[:space:]])timeout[[:space:]]+[0-9]' "$PERSON_LIB"; then
+		fail "$name" "found direct timeout invocation"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+test_dashboard_preserves_partial_cache() {
+	local name="dashboard caches partial person-stats output and updates marker"
+	local fake_home="${TMP_DIR}/home-partial"
+	mkdir -p "${fake_home}/.aidevops/agents/scripts" "${TMP_DIR}/cache" "${TMP_DIR}/bin"
+	cat >"${fake_home}/.aidevops/agents/scripts/contributor-activity-helper.sh" <<'FAKE'
+#!/usr/bin/env bash
+case "$1" in
+person-stats)
+	printf '%s\n' '| Contributor | Issues | PRs | Merged | Commented | % of Total |'
+	exit 75
+	;;
+cross-repo-person-stats)
+	printf '%s\n' '_Across 2 managed repos:_'
+	exit 75
+	;;
+esac
+exit 1
+FAKE
+	chmod +x "${fake_home}/.aidevops/agents/scripts/contributor-activity-helper.sh"
+	cat >"${TMP_DIR}/repos.json" <<JSON
+{"initialized_repos":[{"pulse":true,"local_only":false,"slug":"owner/repo1","path":"${TMP_DIR}/repo1"},{"pulse":true,"local_only":false,"slug":"owner/repo2","path":"${TMP_DIR}/repo2"}]}
+JSON
+	mkdir -p "${TMP_DIR}/repo1" "${TMP_DIR}/repo2"
+	cat >"${TMP_DIR}/bin/gh" <<'GH'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+	printf '%s\n' '1000'
+	exit 0
+fi
+exit 1
+GH
+	chmod +x "${TMP_DIR}/bin/gh"
+	(
+		HOME="$fake_home"
+		LOGFILE="${TMP_DIR}/partial.log"
+		REPOS_JSON="${TMP_DIR}/repos.json"
+		PERSON_STATS_INTERVAL=0
+		PERSON_STATS_LAST_RUN="${TMP_DIR}/partial.last"
+		PERSON_STATS_CACHE_DIR="${TMP_DIR}/cache"
+		PATH="${TMP_DIR}/bin:${PATH}"
+		export HOME LOGFILE REPOS_JSON PERSON_STATS_INTERVAL PERSON_STATS_LAST_RUN PERSON_STATS_CACHE_DIR PATH
+		# shellcheck source=../stats-health-dashboard-data.sh
+		source "$DASHBOARD_LIB"
+		_refresh_person_stats_cache
+	)
+	if [[ -s "${TMP_DIR}/partial.last" && -s "${TMP_DIR}/cache/person-stats-cache-owner-repo1.md" && -s "${TMP_DIR}/cache/person-stats-cache-cross-repo.md" ]]; then
+		pass "$name"
+	else
+		fail "$name" "partial outputs were not cached or last-run marker missing"
+	fi
+	return 0
+}
+
+test_dashboard_skips_marker_when_all_refreshes_fail() {
+	local name="dashboard does not mark success when all person-stats calls fail"
+	local fake_home="${TMP_DIR}/home-fail"
+	mkdir -p "${fake_home}/.aidevops/agents/scripts" "${TMP_DIR}/cache-fail" "${TMP_DIR}/bin-fail"
+	cat >"${fake_home}/.aidevops/agents/scripts/contributor-activity-helper.sh" <<'FAKE'
+#!/usr/bin/env bash
+exit 124
+FAKE
+	chmod +x "${fake_home}/.aidevops/agents/scripts/contributor-activity-helper.sh"
+	cat >"${TMP_DIR}/repos-fail.json" <<JSON
+{"initialized_repos":[{"pulse":true,"local_only":false,"slug":"owner/repo1","path":"${TMP_DIR}/repo1"},{"pulse":true,"local_only":false,"slug":"owner/repo2","path":"${TMP_DIR}/repo2"}]}
+JSON
+	cat >"${TMP_DIR}/bin-fail/gh" <<'GH'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+	printf '%s\n' '1000'
+	exit 0
+fi
+exit 1
+GH
+	chmod +x "${TMP_DIR}/bin-fail/gh"
+	(
+		HOME="$fake_home"
+		LOGFILE="${TMP_DIR}/fail.log"
+		REPOS_JSON="${TMP_DIR}/repos-fail.json"
+		PERSON_STATS_INTERVAL=0
+		PERSON_STATS_LAST_RUN="${TMP_DIR}/fail.last"
+		PERSON_STATS_CACHE_DIR="${TMP_DIR}/cache-fail"
+		PATH="${TMP_DIR}/bin-fail:${PATH}"
+		export HOME LOGFILE REPOS_JSON PERSON_STATS_INTERVAL PERSON_STATS_LAST_RUN PERSON_STATS_CACHE_DIR PATH
+		# shellcheck source=../stats-health-dashboard-data.sh
+		source "$DASHBOARD_LIB"
+		_refresh_person_stats_cache
+	)
+	if [[ ! -e "${TMP_DIR}/fail.last" ]] && grep -q 'last-run marker not updated' "${TMP_DIR}/fail.log"; then
+		pass "$name"
+	else
+		fail "$name" "failure refresh wrote a success marker or omitted log evidence"
+	fi
+	return 0
+}
+
+test_person_stats_uses_portable_timeout
+test_person_stats_has_no_direct_timeout
+test_dashboard_preserves_partial_cache
+test_dashboard_skips_marker_when_all_refreshes_fail
+
+if [[ "$FAIL" -ne 0 ]]; then
+	printf 'FAIL contributor-activity-helper-person (%s failed, %s passed)\n' "$FAIL" "$PASS"
+	exit 1
+fi
+
+printf 'PASS contributor-activity-helper-person (%s checks)\n' "$PASS"


### PR DESCRIPTION
Resolves #23761

## Summary

- wraps person-stats `gh api` calls with the shared portable `timeout_sec` helper
- preserves partial-output semantics for rate-limit exhaustion and timed-out queries
- updates dashboard cache refreshes so successful/partial output is cached, while all-failed runs do not advance the last-run marker
- adds focused regression coverage for portable timeout wiring, partial cache preservation, and all-failed cache metadata

## Verification

- `.agents/scripts/tests/test-contributor-activity-helper-person.sh`
- `bash .agents/scripts/tests/test-contributor-activity-helper-person.sh`
- `shellcheck .agents/scripts/contributor-activity-helper-person.sh .agents/scripts/stats-health-dashboard-data.sh .agents/scripts/tests/test-contributor-activity-helper-person.sh`
- `.agents/scripts/linters-local.sh` (passed; existing advisory markdown/ratchet output reported, final result: ALL LOCAL CHECKS PASSED)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 7m and 132,526 tokens on this as a headless worker.