### PR TITLE
fix: refactor FOSS label lookup

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -65,19 +65,18 @@ _expand_foss_repo_path() {
 _foss_issue_list_for_label() {
 	local repo_slug="$1"
 	local label="$2"
-	local search_label
+	local selector_args=()
 
 	if [[ "$label" == *,* ]]; then
-		search_label="${label//\\/\\\\}"
+		local search_label="${label//\\/\\\\}"
 		search_label="${search_label//\"/\\\"}"
-		gh_issue_list --repo "$repo_slug" --state open \
-			--search "label:\"${search_label}\"" --limit 1 \
-			--json number,title --jq '.[] | "\(.number // "")|\(.title // "")"'
-		return $?
+		selector_args=(--search "label:\"${search_label}\"")
+	else
+		selector_args=(--label "$label")
 	fi
 
 	gh_issue_list --repo "$repo_slug" --state open \
-		--label "$label" --limit 1 \
+		"${selector_args[@]}" --limit 1 \
 		--json number,title --jq '.[] | "\(.number // "")|\(.title // "")"'
 	return $?
 }


### PR DESCRIPTION
## Summary
- Refactor `_foss_issue_list_for_label` to build conditional selector arguments with a Bash array.
- Preserve comma-containing label handling through quoted search syntax and retain the explicit return.

## Testing
- `shellcheck .agents/scripts/pulse-ancillary-dispatch.sh`
- `bash .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh`

Resolves #23766

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 3m and 41,079 tokens on this as a headless worker.
