### PR TITLE
GH#23767: harden no-node utility path test

### DIFF
--- a/.agents/scripts/tests/test-agent-source-manifest-index.sh
+++ b/.agents/scripts/tests/test-agent-source-manifest-index.sh
@@ -150,7 +150,7 @@ test_sync_without_node_fails_open() {
 
 	local cmd=""
 	local cmd_path=""
-	for cmd in bash cat dirname find grep ln mkdir readlink rm rsync sed; do
+	for cmd in bash cat cp dirname find grep jq ln mkdir readlink rm rsync sed; do
 		cmd_path=$(command -v "$cmd")
 		if [[ -n "$cmd_path" ]]; then
 			ln -s "$cmd_path" "$path_without_node/$cmd"


### PR DESCRIPTION
## Summary

Added cp and jq to the restricted PATH utility allowlist used by the no-node agent source manifest regression test.

## Files Changed

.agents/scripts/tests/test-agent-source-manifest-index.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-agent-source-manifest-index.sh; shellcheck .agents/scripts/tests/test-agent-source-manifest-index.sh

Resolves #23767


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.61 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 73,496 tokens on this as a headless worker.