### PR TITLE
GH#23768: fix: harden pulse cleanup canary patterns

### DIFF
--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -189,15 +189,15 @@ test_canary_short_circuit_after_lock() {
 
 cleanup_registration_precedes_exit_trap() {
 	awk '
-		/_save_cleanup_scope/ {
+		/^[[:space:]]*_save_cleanup_scope/ {
 			seen_scope = 1
 			next
 		}
-		seen_scope && /push_cleanup '\''release_instance_lock'\''/ {
+		seen_scope && /^[[:space:]]*push_cleanup[[:space:]]+'\''release_instance_lock'\''/ {
 			seen_cleanup = 1
 			next
 		}
-		seen_scope && seen_cleanup && /trap '\''_run_cleanups'\'' EXIT/ {
+		seen_scope && seen_cleanup && /^[[:space:]]*trap[[:space:]]+'\''_run_cleanups'\''[[:space:]]+EXIT/ {
 			found = 1
 			exit
 		}


### PR DESCRIPTION
## Summary

Anchored the pulse cleanup-order awk assertions and switched whitespace matching to POSIX character classes so the static canary does not match comments or unrelated text.

## Files Changed

.agents/scripts/tests/test-pulse-wrapper-canary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-wrapper-canary.sh; .agents/scripts/tests/test-pulse-wrapper-canary.sh

Resolves #23768


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.61 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 31,067 tokens on this as a headless worker.