### PR TITLE
GH#23769: preserve detector logging fail-open

### DIFF
--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -80,17 +80,17 @@ _log() {
 	local level="$1"
 	shift
 	printf '[fix-the-fixer-detector] %s: %s\n' "$level" "$*" >&2
-	return $?
+	return 0
 }
 
 _log_info() {
 	_log "$_LL_INFO" "$@"
-	return $?
+	return 0
 }
 
 _log_warn() {
 	_log "$_LL_WARN" "$@"
-	return $?
+	return 0
 }
 
 _auth_item_logs_suppressed() {


### PR DESCRIPTION
## Summary

- Restores the fix-the-fixer detector logging helpers to return 0 so logging remains non-critical under `set -e`.
- Keeps the script aligned with its documented fail-open design at `.agents/scripts/pulse-fix-the-fixer-detector.sh:36`.

Resolves #23769

## Testing

- `shellcheck .agents/scripts/pulse-fix-the-fixer-detector.sh`
- `.agents/scripts/tests/test-fix-the-fixer-observability.sh && .agents/scripts/tests/test-pulse-fix-the-fixer-detector-auth-cooldown.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 3m and 44,993 tokens on this as a headless worker.
