### PR TITLE
GH#23770: harden supply-chain cleanup test helper

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -39,7 +39,7 @@ make_tmpdir() {
 
 cleanup_test_tmpdir() {
 	local tmpdir="${1:-}"
-	[[ -n "$tmpdir" ]] && rm -rf "$tmpdir"
+	[[ -n "$tmpdir" && "$tmpdir" != "/" ]] && rm -rf -- "$tmpdir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Harden `cleanup_test_tmpdir` in the supply-chain advisory helper tests.
- Skip root path deletion and use `rm -rf --` for option-boundary safety.

## Testing

- `shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh`
- `bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh` (5 tests passed)

## Runtime Testing

- self-assessed: test-only shell helper hardening; targeted shell test suite passed.

Resolves #23770


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 52,584 tokens on this as a headless worker.
