### PR TITLE
GH#23773: categorize changelog fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- fix: suppress pulse PID broken pipe noise (#23719)
 - Maintenance: update simplification state registry
 
 ### Fixed
 
+- suppress pulse PID broken pipe noise (#23719)
 - reuse resolved claim runner in repo state guard (#23735)
 - harden pulse PR cache cleanup (#23733)
 - document FOSS label parsing behavior (#23731)


### PR DESCRIPTION
## Summary

Moved the v3.15.58 pulse PID broken-pipe bug-fix changelog entry from Changed to Fixed and removed the fix: prefix for Keep a Changelog consistency.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check passed; markdownlint-cli2 CHANGELOG.md reports 80 pre-existing changelog lint errors outside the edited lines

Resolves #23773


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 1m and 38,852 tokens on this as a headless worker.