### PR TITLE
GH#23772: fix: normalize health dashboard cache state

### DIFF
--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -116,9 +116,8 @@ _health_issue_operator_label_allows_identity() {
 	local canonical_identity="$2"
 	local canonical_label="operator:${canonical_identity}"
 	local issue_json_input="${issue_json}"
-	[[ -z "$issue_json_input" ]] && issue_json_input='{}'
 	case "$issue_json_input" in
-		[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd]) issue_json_input='{}' ;;
+		""|[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd]) issue_json_input='{}' ;;
 	esac
 
 	printf '%s' "$issue_json_input" | jq -e --arg canonical_label "$canonical_label" '
@@ -166,10 +165,14 @@ _try_cached_health_issue_lookup() {
 	fi
 
 	local raw_issue_json="$issue_json"
-	[[ -z "$issue_json" ]] && issue_json='{}'
-	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null || echo "")
 	case "$raw_issue_json" in
-		[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd]) issue_state="$raw_issue_json" ;;
+		""|[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd])
+			issue_state="$raw_issue_json"
+			issue_json='{}'
+			;;
+		*)
+			issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' || echo "")
+			;;
 	esac
 
 	# gh issue view has returned both GraphQL-style uppercase enums (OPEN/CLOSED)

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -56,6 +56,14 @@ gh() {
 			printf '%s' '{"state":"OPEN","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"}]}'
 			return 0
 			;;
+		cache_open_state:*"issue view 4644 --repo owner/repo --json state,labels"*)
+			printf '%s' 'OPEN'
+			return 0
+			;;
+		cache_closed_state:*"issue view 4645 --repo owner/repo --json state,labels"*)
+			printf '%s' 'CLOSED'
+			return 0
+			;;
 		:*"issue list --repo owner/repo --label source:health-dashboard"*)
 			printf '%s' '[{"number":20408,"title":"[Supervisor:github-user] 1 PR at 10:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"}],"createdAt":"2026-05-01T10:00:00Z"},{"number":18669,"title":"[Contributor:local-user] 0 PRs at 09:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"contributor"},{"name":"local-user"}],"createdAt":"2026-04-01T09:00:00Z"}]'
 			return 0
@@ -216,6 +224,44 @@ if _health_issue_operator_label_allows_identity "" "canonical-operator"; then
 	pass "allows empty cached issue metadata as unknown rather than jq parse failure"
 else
 	fail "allows empty cached issue metadata as unknown rather than jq parse failure" "empty input was rejected"
+fi
+
+if _health_issue_operator_label_allows_identity "OPEN" "canonical-operator"; then
+	pass "allows raw open state metadata as unknown rather than jq parse failure"
+else
+	fail "allows raw open state metadata as unknown rather than jq parse failure" "OPEN input was rejected"
+fi
+
+cache_file="${HOME}/.aidevops/logs/health-issue-cache-open-owner-repo"
+printf '%s\n' '4644' >"$cache_file"
+: >"$GH_CALLS"
+export HEALTH_FIXTURE=cache_open_state
+result=$(_find_health_issue \
+	"owner/repo" "marcusquinn" "supervisor" "[Supervisor:marcusquinn]" \
+	"supervisor" "Supervisor" "$cache_file" \
+	"marcusquinn" "marcusquinn")
+unset HEALTH_FIXTURE
+
+if [[ "$result" == "4644" && -f "$cache_file" ]]; then
+	pass "keeps raw OPEN cached dashboard state without jq parse noise"
+else
+	fail "keeps raw OPEN cached dashboard state without jq parse noise" "result=${result}; cache_exists=$([[ -f "$cache_file" ]] && printf yes || printf no); calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+cache_file="${HOME}/.aidevops/logs/health-issue-cache-closed-owner-repo"
+printf '%s\n' '4645' >"$cache_file"
+: >"$GH_CALLS"
+export HEALTH_FIXTURE=cache_closed_state
+result=$(_find_health_issue \
+	"owner/repo" "marcusquinn" "supervisor" "[Supervisor:marcusquinn]" \
+	"supervisor" "Supervisor" "$cache_file" \
+	"marcusquinn" "marcusquinn")
+unset HEALTH_FIXTURE
+
+if [[ -z "$result" && ! -f "$cache_file" ]]; then
+	pass "drops raw CLOSED cached dashboard state without jq parse noise"
+else
+	fail "drops raw CLOSED cached dashboard state without jq parse noise" "result=${result}; cache_exists=$([[ -f "$cache_file" ]] && printf yes || printf no); calls=$(tr '\n' ';' <"$GH_CALLS")"
 fi
 
 body=$(_build_health_issue_body \


### PR DESCRIPTION
## Summary

Normalized health dashboard issue metadata with single case branches for empty and raw OPEN/CLOSED state payloads, avoided jq parsing for known state strings, and added regression coverage for raw state cache validation.

## Files Changed

.agents/scripts/stats-health-dashboard-issue.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-health-dashboard-issue.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

Resolves #23772


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 3m and 56,996 tokens on this as a headless worker.