### PR TITLE
GH#23765: name person stats partial exit

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -36,6 +36,10 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+# Distinct exit code emitted by contributor-activity-helper.sh when stdout
+# contains valid but incomplete data due to rate limits or timeouts.
+readonly STATS_HEALTH_EX_PARTIAL=75
+
 # --- Functions ---
 
 #######################################
@@ -880,7 +884,7 @@ _refresh_person_stats_cache() {
 
 	local repo_count=0
 	local search_api_cost_per_contributor=4
-	local partial_exit=75
+	local partial_exit="$STATS_HEALTH_EX_PARTIAL"
 	local refreshed_any=false
 	while IFS='|' read -r _slug _path; do
 		[[ -z "$_slug" ]] && continue


### PR DESCRIPTION
## Summary

- Define a named `STATS_HEALTH_EX_PARTIAL` constant for person-stats partial-result handling.
- Reuse that constant where the stats dashboard accepts valid-but-incomplete contributor activity output.

## Testing

- `shellcheck .agents/scripts/stats-health-dashboard-data.sh`

## Runtime Testing

- self-assessed: low-risk shell constant refactor; ShellCheck and pre-commit shell validation passed.

Resolves #23765

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 3m and 86,873 tokens on this as a headless worker.
