### PR TITLE
fix: bound dashboard person stats refresh

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -40,6 +40,11 @@ fi
 # contains valid but incomplete data due to rate limits or timeouts.
 readonly STATS_HEALTH_EX_PARTIAL=75
 
+# Wall-clock guard for each dashboard person-stats helper invocation. The
+# helper already bounds individual GitHub API calls; this keeps the health
+# dashboard refresh from spending unbounded time across many contributors.
+: "${STATS_HEALTH_PERSON_STATS_TIMEOUT:=60}"
+
 # --- Functions ---
 
 #######################################
@@ -910,7 +915,7 @@ _refresh_person_stats_cache() {
 		local cache_file="${PERSON_STATS_CACHE_DIR}/person-stats-cache-${slug_safe}.md"
 		local md md_rc
 		md_rc=0
-		md=$(bash "$activity_helper" person-stats "$path" --period month --format markdown 2>/dev/null) || md_rc=$?
+		md=$(timeout_sec "$STATS_HEALTH_PERSON_STATS_TIMEOUT" bash "$activity_helper" person-stats "$path" --period month --format markdown 2>/dev/null) || md_rc=$?
 		if [[ -n "$md" && ( "$md_rc" -eq 0 || "$md_rc" -eq "$partial_exit" ) ]]; then
 			echo "$md" >"$cache_file"
 			refreshed_any=true
@@ -931,7 +936,7 @@ _refresh_person_stats_cache() {
 		if [[ ${#cross_args[@]} -gt 1 ]]; then
 			local cross_md cross_rc
 			cross_rc=0
-			cross_md=$(bash "$activity_helper" cross-repo-person-stats "${cross_args[@]}" --period month --format markdown 2>/dev/null) || cross_rc=$?
+			cross_md=$(timeout_sec "$STATS_HEALTH_PERSON_STATS_TIMEOUT" bash "$activity_helper" cross-repo-person-stats "${cross_args[@]}" --period month --format markdown 2>/dev/null) || cross_rc=$?
 			if [[ -n "$cross_md" && ( "$cross_rc" -eq 0 || "$cross_rc" -eq "$partial_exit" ) ]]; then
 				echo "$cross_md" >"${PERSON_STATS_CACHE_DIR}/person-stats-cache-cross-repo.md"
 				refreshed_any=true

--- a/.agents/scripts/tests/test-contributor-activity-helper-person.sh
+++ b/.agents/scripts/tests/test-contributor-activity-helper-person.sh
@@ -49,6 +49,18 @@ test_person_stats_has_no_direct_timeout() {
 	return 0
 }
 
+test_dashboard_wraps_person_stats_with_timeout() {
+	local name="dashboard wraps person-stats helpers with timeout_sec"
+	local person_pattern="timeout_sec \"\$STATS_HEALTH_PERSON_STATS_TIMEOUT\" bash \"\$activity_helper\" person-stats"
+	local cross_pattern="timeout_sec \"\$STATS_HEALTH_PERSON_STATS_TIMEOUT\" bash \"\$activity_helper\" cross-repo-person-stats"
+	if grep -Fq "$person_pattern" "$DASHBOARD_LIB" && grep -Fq "$cross_pattern" "$DASHBOARD_LIB"; then
+		pass "$name"
+	else
+		fail "$name" "missing dashboard wall-clock timeout around person-stats helper calls"
+	fi
+	return 0
+}
+
 test_dashboard_preserves_partial_cache() {
 	local name="dashboard caches partial person-stats output and updates marker"
 	local fake_home="${TMP_DIR}/home-partial"
@@ -88,6 +100,13 @@ GH
 		PERSON_STATS_INTERVAL=0
 		PERSON_STATS_LAST_RUN="${TMP_DIR}/partial.last"
 		PERSON_STATS_CACHE_DIR="${TMP_DIR}/cache"
+		timeout_sec() {
+			local _seconds="$1"
+			shift
+			[[ -n "$_seconds" ]] || return 124
+			"$@"
+			return $?
+		}
 		PATH="${TMP_DIR}/bin:${PATH}"
 		export HOME LOGFILE REPOS_JSON PERSON_STATS_INTERVAL PERSON_STATS_LAST_RUN PERSON_STATS_CACHE_DIR PATH
 		# shellcheck source=../stats-health-dashboard-data.sh
@@ -130,6 +149,13 @@ GH
 		PERSON_STATS_INTERVAL=0
 		PERSON_STATS_LAST_RUN="${TMP_DIR}/fail.last"
 		PERSON_STATS_CACHE_DIR="${TMP_DIR}/cache-fail"
+		timeout_sec() {
+			local _seconds="$1"
+			shift
+			[[ -n "$_seconds" ]] || return 124
+			"$@"
+			return $?
+		}
 		PATH="${TMP_DIR}/bin-fail:${PATH}"
 		export HOME LOGFILE REPOS_JSON PERSON_STATS_INTERVAL PERSON_STATS_LAST_RUN PERSON_STATS_CACHE_DIR PATH
 		# shellcheck source=../stats-health-dashboard-data.sh
@@ -146,6 +172,7 @@ GH
 
 test_person_stats_uses_portable_timeout
 test_person_stats_has_no_direct_timeout
+test_dashboard_wraps_person_stats_with_timeout
 test_dashboard_preserves_partial_cache
 test_dashboard_skips_marker_when_all_refreshes_fail
 


### PR DESCRIPTION
For #23745 (salvage closed-unmerged PR).

## Summary

- Salvages the valuable part of closed PR #23745 without duplicating the already-merged per-API-call timeout work from #23764.
- Adds a dashboard-level 60s wall-clock guard around each person-stats and cross-repo-person-stats helper invocation using portable timeout_sec.
- Keeps partial-result handling from #23764/#23783 intact and adds targeted test coverage for the dashboard wrapper timeout.

## Testing

- bash .agents/scripts/tests/test-contributor-activity-helper-person.sh
- shellcheck .agents/scripts/stats-health-dashboard-data.sh .agents/scripts/tests/test-contributor-activity-helper-person.sh


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 3m and 74,531 tokens on this as a headless worker.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout (default 60 seconds) for dashboard data refresh operations to prevent indefinite processing.

* **Tests**
  * Added test coverage for timeout enforcement in dashboard operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/aidevops/pull/23785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->