### PR TITLE
fix: parse compact blocked-by dispatch refs

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -571,13 +571,19 @@ refresh_blocked_status_from_graph() {
 # No NUL, no parser traps, trivially portable across bash versions.
 _blocked_by_extract_tids() {
 	local body="$1"
-	# Capture full subtask ID including decimal suffix (e.g. t325.1 → 325.1)
-	printf '%s' "$body" | grep -ioE '[Bb]locked[- ]by[: ]*t[0-9]+(\.[0-9a-z]+)*' | grep -oE 't[0-9]+(\.[0-9a-z]+)*' | sed 's/^t//' || true
+	local blocker_lines
+	# Match the dep-graph whole-line parser so compact blocker lists such as
+	# `blocked-by:t001,t002,t003` are enforced consistently at dispatch time.
+	# Capture full subtask ID including decimal suffix (e.g. t325.1 → 325.1).
+	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*|[Bb]locked[- ]by[^[:cntrl:]]*' || true)
+	printf '%s' "$blocker_lines" | grep -oE 't[0-9]+(\.[0-9a-z]+)*' | sed 's/^t//' || true
 }
 
 _blocked_by_extract_nums() {
 	local body="$1"
-	printf '%s' "$body" | grep -ioE '[Bb]locked[- ]by[: ]*#([0-9]+)' | grep -oE '[0-9]+' || true
+	local blocker_lines
+	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*|[Bb]locked[- ]by[^[:cntrl:]]*' || true)
+	printf '%s' "$blocker_lines" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' || true
 }
 
 #######################################

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression checks for pulse dispatch blocked-by reference parsing.
+#
+# Usage: bash .agents/tests/test-pulse-dep-graph-blocked-by.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+TARGET="${SCRIPT_DIR}/../scripts/pulse-dep-graph.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# shellcheck source=/dev/null
+source "$TARGET"
+
+_pass() {
+	local name="$1"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	printf '  [PASS] %s\n' "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local reason="${2:-}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  [FAIL] %s%s\n' "$name" "${reason:+ — ${reason}}"
+	return 0
+}
+
+_assert_lines_equal() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		_pass "$name"
+		return 0
+	fi
+	_fail "$name" "expected [${expected//$'\n'/,}] got [${actual//$'\n'/,}]"
+	return 0
+}
+
+test_task_id_blocker_parsing() {
+	printf '\n=== blocked-by task IDs ===\n'
+	_assert_lines_equal "compact comma-separated task IDs" $'001\n002\n003' \
+		"$(_blocked_by_extract_tids 'blocked-by:t001,t002,t003')"
+	_assert_lines_equal "spaced comma-separated task IDs" $'001\n002\n003' \
+		"$(_blocked_by_extract_tids 'Blocked by: t001, t002, t003')"
+	_assert_lines_equal "prose task IDs" $'001\n002' \
+		"$(_blocked_by_extract_tids 'Blocked by t001 and t002')"
+	_assert_lines_equal "one task blocker per line" $'001\n002\n003' \
+		"$(_blocked_by_extract_tids $'blocked-by:t001\nblocked-by:t002\nblocked-by:t003')"
+	_assert_lines_equal "decimal subtask suffixes" $'325.1\n325.2a' \
+		"$(_blocked_by_extract_tids 'blocked-by:t325.1,t325.2a')"
+	return 0
+}
+
+test_issue_number_blocker_parsing() {
+	printf '\n=== blocked-by issue numbers ===\n'
+	_assert_lines_equal "compact comma-separated issue numbers" $'123\n456' \
+		"$(_blocked_by_extract_nums 'blocked-by:#123,#456')"
+	_assert_lines_equal "spaced issue numbers" $'123\n456' \
+		"$(_blocked_by_extract_nums 'Blocked by: #123, #456')"
+	_assert_lines_equal "mixed prose issue numbers" $'123\n456' \
+		"$(_blocked_by_extract_nums 'Blocked by #123 and #456')"
+	return 0
+}
+
+main() {
+	test_task_id_blocker_parsing
+	test_issue_number_blocker_parsing
+
+	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Align dispatch-time blocked-by extraction with the dep-graph whole-line parser so compact comma-separated blocker lists enforce every blocker.
- Preserve decimal task suffixes and issue-number blockers for compact, spaced, prose, and one-per-line forms.
- Add regression coverage in `.agents/tests/test-pulse-dep-graph-blocked-by.sh`.

## Verification
- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/tests/test-pulse-merge-conflict.sh`
- `.agents/scripts/linters-local.sh` (passes; advisory pre-existing markdown/ratchet/layout/complexity debt reported)

Resolves #23784

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.61 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 1h 2m and 109,197 tokens on this with the user in an interactive session.
