### PR TITLE
fix: harden supply-chain test cleanup guard

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -39,7 +39,7 @@ make_tmpdir() {
 
 cleanup_test_tmpdir() {
 	local tmpdir="${1:-}"
-	[[ -n "$tmpdir" && "$tmpdir" != "/" ]] && rm -rf -- "$tmpdir"
+	[[ -n "$tmpdir" && "$tmpdir" == /* && "$tmpdir" != "/" && "$tmpdir" != "//" ]] && rm -rf -- "$tmpdir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- Harden cleanup_test_tmpdir in `.agents/scripts/tests/test-supply-chain-advisory-helper.sh` so destructive cleanup only runs for non-empty absolute non-root tmpdir paths.
- Reject `/` and `//` before invoking `rm -rf --`.

## Testing
- `shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh`
- `bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh`

MERGE_SUMMARY: Hardened the supply-chain advisory test cleanup guard and verified shellcheck plus the targeted regression suite.

Resolves #23788

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.62 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 34,369 tokens on this as a headless worker.
