### PR TITLE
GH#23787: extract timeout mock helper

### DIFF
--- a/.agents/scripts/tests/test-contributor-activity-helper-person.sh
+++ b/.agents/scripts/tests/test-contributor-activity-helper-person.sh
@@ -28,6 +28,17 @@ fail() {
 	return 0
 }
 
+define_timeout_sec_mock() {
+	timeout_sec() {
+		local _seconds="$1"
+		shift
+		[[ -n "$_seconds" ]] || return 124
+		"$@"
+		return $?
+	}
+	return 0
+}
+
 test_person_stats_uses_portable_timeout() {
 	local name="person stats wraps gh api with timeout_sec"
 	local wrapper_pattern="timeout_sec \"\$timeout_budget\" gh api \"\$@\""
@@ -100,13 +111,7 @@ GH
 		PERSON_STATS_INTERVAL=0
 		PERSON_STATS_LAST_RUN="${TMP_DIR}/partial.last"
 		PERSON_STATS_CACHE_DIR="${TMP_DIR}/cache"
-		timeout_sec() {
-			local _seconds="$1"
-			shift
-			[[ -n "$_seconds" ]] || return 124
-			"$@"
-			return $?
-		}
+		define_timeout_sec_mock
 		PATH="${TMP_DIR}/bin:${PATH}"
 		export HOME LOGFILE REPOS_JSON PERSON_STATS_INTERVAL PERSON_STATS_LAST_RUN PERSON_STATS_CACHE_DIR PATH
 		# shellcheck source=../stats-health-dashboard-data.sh
@@ -149,13 +154,7 @@ GH
 		PERSON_STATS_INTERVAL=0
 		PERSON_STATS_LAST_RUN="${TMP_DIR}/fail.last"
 		PERSON_STATS_CACHE_DIR="${TMP_DIR}/cache-fail"
-		timeout_sec() {
-			local _seconds="$1"
-			shift
-			[[ -n "$_seconds" ]] || return 124
-			"$@"
-			return $?
-		}
+		define_timeout_sec_mock
 		PATH="${TMP_DIR}/bin-fail:${PATH}"
 		export HOME LOGFILE REPOS_JSON PERSON_STATS_INTERVAL PERSON_STATS_LAST_RUN PERSON_STATS_CACHE_DIR PATH
 		# shellcheck source=../stats-health-dashboard-data.sh


### PR DESCRIPTION
## Summary

Extracted the duplicated timeout_sec mock in the contributor activity person test into one internal helper and reused it in both dashboard cache test subshells.

## Files Changed

.agents/scripts/tests/test-contributor-activity-helper-person.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-contributor-activity-helper-person.sh; shellcheck .agents/scripts/tests/test-contributor-activity-helper-person.sh

Resolves #23787


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.63 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 2m and 45,155 tokens on this as a headless worker.