### PR TITLE
GH#23789: reuse partial exit constant

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -37,8 +37,9 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 fi
 
 # Distinct exit code emitted by contributor-activity-helper.sh when stdout
-# contains valid but incomplete data due to rate limits or timeouts.
-readonly STATS_HEALTH_EX_PARTIAL=75
+# contains valid but incomplete data due to rate limits or timeouts. Reuse a
+# shared EX_PARTIAL value when the sourcing context already defines one.
+readonly STATS_HEALTH_EX_PARTIAL="${EX_PARTIAL:-75}"
 
 # Wall-clock guard for each dashboard person-stats helper invocation. The
 # helper already bounds individual GitHub API calls; this keeps the health


### PR DESCRIPTION
## Summary

Updated stats health dashboard partial-exit handling to reuse an existing EX_PARTIAL value from the sourcing context while retaining the script-local fallback.

## Files Changed

.agents/scripts/stats-health-dashboard-data.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-health-dashboard-data.sh; bash -n .agents/scripts/stats-health-dashboard-data.sh

Resolves #23789


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.63 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 5m and 42,259 tokens on this as a headless worker.