### PR TITLE
GH#23791: allow squash-merged worktree cleanup

### DIFF
--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -83,6 +83,9 @@ source_clean_lib_with_stubs() {
 	source "$AUDIT_HELPER_PATH" || return 1
 	# shellcheck source=/dev/null
 	source "$CLEAN_LIB_PATH" || return 1
+	_branch_has_active_interactive_claim() { return 1; }
+	worktree_is_in_grace_period() { return 1; }
+	branch_has_zero_commits_ahead() { return 1; }
 	return 0
 }
 
@@ -116,10 +119,10 @@ test_protected_pass_set_blocks_branch_merged_removal() {
 	return 0
 }
 
-test_merged_pr_without_ancestor_proof_skips() {
+test_squash_merged_pr_without_ancestor_proof_classifies() {
 	local repo_path="${TEST_ROOT}/repo-unproven"
 	local wt_path="${TEST_ROOT}/wt-unproven"
-	local log_file="${TEST_ROOT}/unproven-cleanup.log"
+	local log_file="${TEST_ROOT}/squash-merged-cleanup.log"
 	local branch="feature/gh-99022-unproven"
 	local classification=""
 	local rc=0
@@ -138,17 +141,51 @@ test_merged_pr_without_ancestor_proof_skips() {
 		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "$branch" "" "false" ""
 	) || rc=1
 
+	[[ "$classification" == *"squash-merged PR"* ]] || rc=1
+	[[ "$classification" == *"merge_proof=github-merged-pr-state"* ]] || rc=1
+	[[ "$classification" == *"merge_proof_result=github-merged-pr"* ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "squash-merged PR metadata does not require ancestor proof" "$rc" \
+		"Expected squash-merged classification with GitHub PR-state proof"
+	return 0
+}
+
+test_remote_deleted_without_ancestor_proof_skips() {
+	local repo_path="${TEST_ROOT}/repo-remote-deleted"
+	local wt_path="${TEST_ROOT}/wt-remote-deleted"
+	local log_file="${TEST_ROOT}/remote-deleted-cleanup.log"
+	local branch="feature/gh-99023-remote-deleted"
+	local classification=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'not ancestor remote deleted\n' >"$repo_path/remote-deleted.txt" || rc=1
+	git -C "$repo_path" add remote-deleted.txt || rc=1
+	git -C "$repo_path" commit -q -m "unmerged remote-deleted branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	classification=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		branch_was_pushed() { return 0; }
+		_branch_exists_on_any_remote() { return 1; }
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "" "" "false" ""
+	) || rc=1
+
 	[[ -z "$classification" ]] || rc=1
 	[[ -d "$wt_path" ]] || rc=1
 	assert_file_contains "$log_file" "worktree-skipped.*branch-merged-unproven.*mode=skipped.*merge_proof_result=not-ancestor" || rc=1
-	print_result "merged PR metadata without ancestor proof skips" "$rc" \
+	print_result "remote-deleted metadata without ancestor proof skips" "$rc" \
 		"Expected empty classification, surviving worktree, and unproven audit entry"
 	return 0
 }
 
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
-test_merged_pr_without_ancestor_proof_skips
+test_squash_merged_pr_without_ancestor_proof_classifies
+test_remote_deleted_without_ancestor_proof_skips
 
 printf '\nResults: %d/%d passed, %d failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -433,8 +433,22 @@ _clean_branch_merge_proof_context() {
 	local default_br="$2"
 	local head_sha="${3:-unknown}"
 	local proof_result="${4:-unknown}"
-	printf 'target_branch=%s merge_proof=merge-base-is-ancestor merge_proof_result=%s head=%s branch=%s owner_guard=clear protected_status=clear' \
-		"$default_br" "$proof_result" "$head_sha" "$wt_branch"
+	local proof_method="${5:-merge-base-is-ancestor}"
+	printf 'target_branch=%s merge_proof=%s merge_proof_result=%s head=%s branch=%s owner_guard=clear protected_status=clear' \
+		"$default_br" "$proof_method" "$proof_result" "$head_sha" "$wt_branch"
+	return 0
+}
+
+_clean_branch_requires_ancestor_proof() {
+	local merge_type="$1"
+
+	case "$merge_type" in
+	"squash-merged PR")
+		# GitHub squash merges intentionally create a new target-branch commit,
+		# so the branch tip is not expected to be an ancestor of the default branch.
+		return 1
+		;;
+	esac
 	return 0
 }
 
@@ -514,7 +528,9 @@ _clean_classify_worktree() {
 	fi
 
 	head_sha=$(_clean_branch_head "$wt_branch" 2>/dev/null || printf '%s' "unknown")
-	if _clean_branch_head_is_ancestor "$wt_branch" "$default_br"; then
+	if ! _clean_branch_requires_ancestor_proof "$merge_type"; then
+		proof_result="github-merged-pr"
+	elif _clean_branch_head_is_ancestor "$wt_branch" "$default_br"; then
 		proof_result="ancestor"
 	else
 		proof_result="not-ancestor"
@@ -529,7 +545,11 @@ _clean_classify_worktree() {
 		return 0
 	fi
 
-	audit_context=$(_clean_branch_merge_proof_context "$wt_branch" "$default_br" "$head_sha" "$proof_result")
+	if _clean_branch_requires_ancestor_proof "$merge_type"; then
+		audit_context=$(_clean_branch_merge_proof_context "$wt_branch" "$default_br" "$head_sha" "$proof_result")
+	else
+		audit_context=$(_clean_branch_merge_proof_context "$wt_branch" "$default_br" "$head_sha" "$proof_result" "github-merged-pr-state")
+	fi
 
 	if worktree_has_changes "$wt_path" && [[ "$force_merged" == "true" ]]; then
 		# PR is confirmed merged — dirty state is abandoned WIP, safe to force-remove


### PR DESCRIPTION
## Summary
- Treat GitHub merged-PR metadata as the proof source for squash-merged worktree branches instead of requiring branch-tip ancestry.
- Keep ancestry proof for remote-deleted metadata so stale/deleted branch evidence remains conservative.
- Extend the worktree cleanup regression test to cover both paths.

Resolves #23791

## Verification
- `bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `bash .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh`
- `bash .agents/scripts/tests/test-worktree-removal-audit.sh`
- `shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `.agents/scripts/linters-local.sh` (passed; advisory pre-existing warnings reported)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.63 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 25m and 98,577 tokens on this with the user in an interactive session.