### PR TITLE
fix: no-op repair for signed dynamic gh bodies

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -350,6 +350,11 @@ function _repairBodyArg(cmd, parsed, helperPath, log) {
  * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail?: string }}
  */
 export function tryRepairSignature(cmd, scriptsDir, log) {
+  if (hasTrustedSignatureSignal(cmd)) {
+    log("INFO", "Command already includes trusted signature signal; no repair needed");
+    return { status: "ok", cmd };
+  }
+
   const helperPath = join(scriptsDir, "gh-signature-helper.sh");
   if (!existsSync(helperPath)) {
     log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -313,6 +313,20 @@ describe("tryRepairSignature", () => {
     assert.equal(before, after, "signed file should not be modified");
   });
 
+  test("no-ops on signed command-substitution --body without reparsing", () => {
+    const { log } = makeLogger();
+    const cmd = 'gh issue comment 1 --body "$(make-body && gh-signature-helper.sh footer)"';
+    const out = tryRepairSignature(cmd, "/nonexistent/aidevops-helper-path", log);
+    assert.deepEqual(out, { status: "ok", cmd });
+  });
+
+  test("no-ops on signed process-substitution --body-file without reparsing", () => {
+    const { log } = makeLogger();
+    const cmd = 'gh issue comment 1 --body-file <(make-body && gh-signature-helper.sh footer)';
+    const out = tryRepairSignature(cmd, "/nonexistent/aidevops-helper-path", log);
+    assert.deepEqual(out, { status: "ok", cmd });
+  });
+
   test("refuses to repair heredoc-sourced body (UNPARSEABLE_BODY)", () => {
     const dir = setupStubHelper();
     const { log } = makeLogger();


### PR DESCRIPTION
## Summary

Ref #23681. Addresses the maintainer review feedback by keeping trusted-signature policy centralized and making the direct repair helper no-op when a dynamic gh body already contains a trusted signature signal.

## Changes

- Add an early trusted-signature return in `tryRepairSignature()` before helper lookup or unparseable-body detection.
- Add direct-helper regression tests for signed command-substitution `--body` and process-substitution `--body-file` forms.

## Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs`
- `npm test` in `.agents/plugins/opencode-aidevops`
