### PR TITLE
fix: support exact PR salvage scans

### DIFF
--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -9,7 +9,7 @@
 # that was written, reviewed, and possibly review-addressed but never landed.
 #
 # Usage:
-#   pr-salvage-helper.sh scan [--repo <slug>] [--days <N>] [--json]
+#   pr-salvage-helper.sh scan [--repo <slug>] [--days <N>] [--json] [PR_NUMBER...]
 #   pr-salvage-helper.sh prefetch <slug> <path>
 #   pr-salvage-helper.sh help
 #
@@ -260,28 +260,42 @@ build_salvage_entry() {
 # Arguments:
 #   $1 - repo slug (owner/repo)
 #   $2 - lookback days (default: 7)
+#   $3 - optional space-separated explicit PR numbers
 # Output: JSON array of salvageable PRs
 #######################################
 scan_repo() {
 	local slug="$1"
 	local lookback_days="${2:-$DEFAULT_LOOKBACK_DAYS}"
-
-	# Fetch closed-unmerged PRs using GitHub search API (gh pr list --state closed
-	# returns both merged and unmerged interleaved, so a small --limit misses most
-	# unmerged PRs). The search query filters server-side for is:unmerged.
-	local cutoff_date
-	cutoff_date=$(date -u -v-"${lookback_days}"d +%Y-%m-%d 2>/dev/null) ||
-		cutoff_date=$(date -u -d "${lookback_days} days ago" +%Y-%m-%d 2>/dev/null) ||
-		cutoff_date="1970-01-01"
+	local pr_numbers="${3:-}"
 
 	local unmerged
-	unmerged=$(gh pr list --repo "$slug" --state closed \
-		--search "is:unmerged closed:>=${cutoff_date}" \
-		--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels \
-		--limit 100 2>/dev/null) || unmerged="[]"
+	if [[ -n "$pr_numbers" ]]; then
+		unmerged="[]"
+		local pr_number pr_record
+		for pr_number in $pr_numbers; do
+			pr_record=$(gh pr view "$pr_number" --repo "$slug" \
+				--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels,state \
+				2>/dev/null) || pr_record=""
+			[[ -z "$pr_record" ]] && continue
+			unmerged=$(echo "$unmerged" | jq --argjson pr "$pr_record" '. + [$pr]') || unmerged="[]"
+		done
+	else
+		# Fetch closed-unmerged PRs using GitHub search API (gh pr list --state closed
+		# returns both merged and unmerged interleaved, so a small --limit misses most
+		# unmerged PRs). The search query filters server-side for is:unmerged.
+		local cutoff_date
+		cutoff_date=$(date -u -v-"${lookback_days}"d +%Y-%m-%d 2>/dev/null) ||
+			cutoff_date=$(date -u -d "${lookback_days} days ago" +%Y-%m-%d 2>/dev/null) ||
+			cutoff_date="1970-01-01"
+
+		unmerged=$(gh pr list --repo "$slug" --state closed \
+			--search "is:unmerged closed:>=${cutoff_date}" \
+			--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels \
+			--limit 100 2>/dev/null) || unmerged="[]"
+	fi
 
 	# Safety filter: remove any that slipped through with mergedAt set or 0 additions
-	unmerged=$(echo "$unmerged" | jq '[.[] | select(.mergedAt == null and .additions > 0)]') || unmerged="[]"
+	unmerged=$(echo "$unmerged" | jq '[.[] | select((.mergedAt == null) and (.additions > 0) and ((.state // "CLOSED") == "CLOSED"))]') || unmerged="[]"
 
 	local count
 	count=$(echo "$unmerged" | jq 'length')
@@ -438,6 +452,7 @@ cmd_scan() {
 	local target_repo=""
 	local lookback_days="$DEFAULT_LOOKBACK_DAYS"
 	local json_output="false"
+	local pr_numbers=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -454,6 +469,9 @@ cmd_scan() {
 			shift
 			;;
 		*)
+			if [[ "$1" =~ ^#?[0-9]+$ ]]; then
+				pr_numbers="${pr_numbers}${pr_numbers:+ }${1#\#}"
+			fi
 			shift
 			;;
 		esac
@@ -465,9 +483,13 @@ cmd_scan() {
 
 	if [[ -n "$target_repo" ]]; then
 		local results
-		results=$(scan_repo "$target_repo" "$lookback_days")
+		results=$(scan_repo "$target_repo" "$lookback_days" "$pr_numbers")
 		all_results=$(echo "$results" | jq --arg slug "$target_repo" '[.[] | . + {repo: $slug}]')
 	else
+		if [[ -n "$pr_numbers" ]]; then
+			log_warn "explicit PR numbers require --repo <slug>"
+			return 1
+		fi
 		all_results=$(scan_all_repos "$lookback_days") || return 1
 	fi
 
@@ -512,7 +534,7 @@ Prevents knowledge loss by identifying PRs that were closed without merge
 but still have branches with unmerged commits containing valuable work.
 
 USAGE:
-    pr-salvage-helper.sh scan [--repo <slug>] [--days <N>] [--json]
+    pr-salvage-helper.sh scan [--repo <slug>] [--days <N>] [--json] [PR_NUMBER...]
     pr-salvage-helper.sh prefetch <slug> <path>
     pr-salvage-helper.sh help
 
@@ -525,6 +547,7 @@ SCAN OPTIONS:
     --repo <slug>   Scan a specific repo (default: all pulse-enabled)
     --days <N>      Lookback window in days (default: 7)
     --json          Output raw JSON
+    PR_NUMBER...    Optional explicit closed PR numbers to evaluate with --repo
 
 RISK LEVELS:
     HIGH    Branch deleted + >100 lines, or branch exists + >500 lines
@@ -537,6 +560,9 @@ INTEGRATION:
 
     # Manual scan
     pr-salvage-helper.sh scan --repo marcusquinn/aidevops --days 14
+
+    # Exact PR salvage triage
+    pr-salvage-helper.sh scan --repo marcusquinn/aidevops 23745 23695 23682
 
     # JSON output for scripting
     pr-salvage-helper.sh scan --json | jq '.[] | select(.risk == "high")'

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -110,8 +110,26 @@ test_explicit_pr_numbers_fetch_exact_records() {
 	return 0
 }
 
+test_cmd_scan_accepts_hash_prefixed_pr_numbers() {
+	# shellcheck source=/dev/null
+	source "${TEST_SCRIPT_DIR}/pr-salvage-helper.sh"
+
+	local result
+	result=$(cmd_scan --repo example/repo --json 54 '#55')
+
+	local numbers
+	numbers=$(printf '%s' "$result" | jq -r '[.[].number] | join(",")')
+	if [[ "$numbers" == "54" ]]; then
+		print_result "scan command accepts hash-prefixed explicit PR numbers" 0
+	else
+		print_result "scan command accepts hash-prefixed explicit PR numbers" 1 "expected only PR 54, got '${numbers}'"
+	fi
+	return 0
+}
+
 test_completed_recovery_issue_suppresses_salvage_candidate
 test_explicit_pr_numbers_fetch_exact_records
+test_cmd_scan_accepts_hash_prefixed_pr_numbers
 
 printf '\nResults: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -39,6 +39,14 @@ gh() {
 
 	case "$area" in
 	pr)
+		if [[ " ${*} " == *" view 54 "* ]]; then
+			printf '%s\n' '{"number":54,"title":"Recoverable unsuppressed work","headRefName":"feature/keep-me","closedAt":"2026-05-01T13:00:00Z","mergedAt":null,"additions":70,"deletions":0,"author":{"login":"worker-b"},"labels":[],"state":"CLOSED"}'
+			return 0
+		fi
+		if [[ " ${*} " == *" view 55 "* ]]; then
+			printf '%s\n' '{"number":55,"title":"Already merged work","headRefName":"feature/merged","closedAt":"2026-05-01T14:00:00Z","mergedAt":"2026-05-01T15:00:00Z","additions":90,"deletions":0,"author":{"login":"worker-c"},"labels":[],"state":"MERGED"}'
+			return 0
+		fi
 		if [[ " ${*} " == *" --state closed "* ]]; then
 			printf '%s\n' '[
 				{"number":53,"title":"Add buffalo logo favicon","headRefName":"feature/buffalo-favicon","closedAt":"2026-05-01T12:00:00Z","mergedAt":null,"additions":7,"deletions":0,"author":{"login":"worker-a"},"labels":[]},
@@ -85,7 +93,25 @@ test_completed_recovery_issue_suppresses_salvage_candidate() {
 	return 0
 }
 
+test_explicit_pr_numbers_fetch_exact_records() {
+	# shellcheck source=/dev/null
+	source "${TEST_SCRIPT_DIR}/pr-salvage-helper.sh"
+
+	local result
+	result=$(scan_repo "example/repo" 30 "54 55")
+
+	local numbers
+	numbers=$(printf '%s' "$result" | jq -r '[.[].number] | join(",")')
+	if [[ "$numbers" == "54" ]]; then
+		print_result "explicit PR numbers fetch exact closed-unmerged records" 0
+	else
+		print_result "explicit PR numbers fetch exact closed-unmerged records" 1 "expected only PR 54, got '${numbers}'"
+	fi
+	return 0
+}
+
 test_completed_recovery_issue_suppresses_salvage_candidate
+test_explicit_pr_numbers_fetch_exact_records
 
 printf '\nResults: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
Resolves #23798

## Summary
- Add explicit PR-number support to `pr-salvage-helper.sh scan --repo` for exact closed-PR salvage triage.
- Preserve the existing lookback-based scan path for pulse prefetch and routine scans.
- Add regression coverage that explicit PR inputs use `gh pr view` records and filter merged/non-salvageable PRs.

## Salvage evidence
`pr-salvage-helper.sh scan --repo marcusquinn/aidevops 23745 23695 23682 23521 23478 23439` now evaluates exactly the requested closed PRs. The six target PRs are still reported as closed-unmerged recoverable candidates; local history shows their fixes have already landed or been superseded by later focused PRs, so this PR salvages the reusable helper capability rather than duplicating shipped fixes.

## Verification
- `shellcheck .agents/scripts/pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-completed-recovery.sh`
- `bash .agents/scripts/tests/test-pr-salvage-helper.sh`
- `bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh`
- `.agents/scripts/pr-salvage-helper.sh scan --repo marcusquinn/aidevops 23745 23695 23682 23521 23478 23439 --json | jq -r '[length, (.[].number // empty)] | @tsv'` returned `6 23745 23695 23682 23521 23478 23439`.
