### PR TITLE
For #23761: bound dashboard person-stats rate probes

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -46,7 +46,25 @@ readonly STATS_HEALTH_EX_PARTIAL="${EX_PARTIAL:-75}"
 # dashboard refresh from spending unbounded time across many contributors.
 : "${STATS_HEALTH_PERSON_STATS_TIMEOUT:=60}"
 
+# Wall-clock guard for dashboard Search API budget probes. These probes run
+# before optional person-stats helper calls, so they must not become a separate
+# unbounded blocking point when GitHub is slow.
+: "${STATS_HEALTH_PERSON_STATS_RATE_LIMIT_TIMEOUT:=10}"
+
 # --- Functions ---
+
+#######################################
+# Read remaining GitHub Search API budget with portable timeout protection.
+#
+# Output: remaining search requests, or 0 on timeout/failure
+#######################################
+_stats_health_person_stats_search_remaining() {
+	local remaining="0"
+	remaining=$(timeout_sec "$STATS_HEALTH_PERSON_STATS_RATE_LIMIT_TIMEOUT" gh api rate_limit --jq '.resources.search.remaining' 2>/dev/null) || remaining="0"
+	remaining="${remaining//[^0-9]/}"
+	printf '%s\n' "${remaining:-0}"
+	return 0
+}
 
 #######################################
 # Scan active headless worker processes for a repo.
@@ -883,7 +901,7 @@ _refresh_person_stats_cache() {
 	mkdir -p "$PERSON_STATS_CACHE_DIR"
 
 	local search_remaining
-	search_remaining=$(gh api rate_limit --jq '.resources.search.remaining' 2>/dev/null) || search_remaining=0
+	search_remaining=$(_stats_health_person_stats_search_remaining)
 
 	local repo_entries
 	repo_entries=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
@@ -906,7 +924,7 @@ _refresh_person_stats_cache() {
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
 
-		search_remaining=$(gh api rate_limit --jq '.resources.search.remaining' 2>/dev/null) || search_remaining=0
+		search_remaining=$(_stats_health_person_stats_search_remaining)
 		if [[ "$search_remaining" -lt "$search_api_cost_per_contributor" ]]; then
 			echo "[stats] Person stats cache refresh stopped mid-run: Search API budget exhausted (${search_remaining} remaining)" >>"$LOGFILE"
 			break
@@ -926,7 +944,7 @@ _refresh_person_stats_cache() {
 	done <<<"$repo_entries"
 
 	# Cross-repo person-stats
-	search_remaining=$(gh api rate_limit --jq '.resources.search.remaining' 2>/dev/null) || search_remaining=0
+	search_remaining=$(_stats_health_person_stats_search_remaining)
 	local all_repo_paths
 	all_repo_paths=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .path' "$repos_json" 2>/dev/null || echo "")
 	if [[ -n "$all_repo_paths" && "$search_remaining" -ge "$search_api_cost_per_contributor" ]]; then

--- a/.agents/scripts/tests/test-contributor-activity-helper-person.sh
+++ b/.agents/scripts/tests/test-contributor-activity-helper-person.sh
@@ -72,6 +72,18 @@ test_dashboard_wraps_person_stats_with_timeout() {
 	return 0
 }
 
+test_dashboard_wraps_person_stats_rate_limit_probes() {
+	local name="dashboard wraps person-stats rate-limit probes with timeout_sec"
+	local helper_pattern="timeout_sec \"\$STATS_HEALTH_PERSON_STATS_RATE_LIMIT_TIMEOUT\" gh api rate_limit"
+	local caller_pattern="search_remaining=\$(_stats_health_person_stats_search_remaining)"
+	if grep -Fq "$helper_pattern" "$DASHBOARD_LIB" && grep -Fq "$caller_pattern" "$DASHBOARD_LIB"; then
+		pass "$name"
+	else
+		fail "$name" "person-stats Search API budget probes can still call gh api without a wall-clock guard"
+	fi
+	return 0
+}
+
 test_dashboard_preserves_partial_cache() {
 	local name="dashboard caches partial person-stats output and updates marker"
 	local fake_home="${TMP_DIR}/home-partial"
@@ -172,6 +184,7 @@ GH
 test_person_stats_uses_portable_timeout
 test_person_stats_has_no_direct_timeout
 test_dashboard_wraps_person_stats_with_timeout
+test_dashboard_wraps_person_stats_rate_limit_probes
 test_dashboard_preserves_partial_cache
 test_dashboard_skips_marker_when_all_refreshes_fail
 


### PR DESCRIPTION
## Summary

- Salvages the non-duplicative part of orphan branch `feature/gh23761-person-stats-timeouts` after PR #23764 and PR #23785 superseded PR #23745.
- Wraps dashboard person-stats Search API rate-limit probes with shared `timeout_sec` so those optional preflight `gh api rate_limit` calls cannot hang independently of the helper-level timeouts.
- Keeps the already-merged helper timeout implementation intact and adds focused regression coverage in the existing person-stats test.

For #23761.

## Testing

- `.agents/scripts/tests/test-contributor-activity-helper-person.sh`
- `.agents/scripts/linters-local.sh` (completed with existing advisory markdown/complexity/layout warnings and final `ALL LOCAL CHECKS PASSED`)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 10m and 111,866 tokens on this as a headless worker.