### PR TITLE
GH#23800: fix: harden PR salvage scan collection

### DIFF
--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -270,15 +270,18 @@ scan_repo() {
 
 	local unmerged
 	if [[ -n "$pr_numbers" ]]; then
-		unmerged="[]"
+		local pr_records=()
 		local pr_number pr_record
 		for pr_number in $pr_numbers; do
 			pr_record=$(gh pr view "$pr_number" --repo "$slug" \
 				--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels,state \
-				2>/dev/null) || pr_record=""
-			[[ -z "$pr_record" ]] && continue
-			unmerged=$(echo "$unmerged" | jq --argjson pr "$pr_record" '. + [$pr]') || unmerged="[]"
+				2>/dev/null) || continue
+			[[ -n "$pr_record" ]] && pr_records+=("$pr_record")
 		done
+		unmerged="[]"
+		if [[ "${#pr_records[@]}" -gt 0 ]]; then
+			unmerged=$(printf '%s\n' "${pr_records[@]}" | jq -s '.') || unmerged="[]"
+		fi
 	else
 		# Fetch closed-unmerged PRs using GitHub search API (gh pr list --state closed
 		# returns both merged and unmerged interleaved, so a small --limit misses most
@@ -290,7 +293,7 @@ scan_repo() {
 
 		unmerged=$(gh pr list --repo "$slug" --state closed \
 			--search "is:unmerged closed:>=${cutoff_date}" \
-			--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels \
+			--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels,state \
 			--limit 100 2>/dev/null) || unmerged="[]"
 	fi
 

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -13,6 +13,7 @@ readonly TEST_SCRIPT_DIR
 
 TESTS_RUN=0
 TESTS_FAILED=0
+GH_CLOSED_LIST_ARGS_FILE="${TMPDIR:-/tmp}/pr-salvage-gh-args.$$"
 
 print_result() {
 	local test_name="$1"
@@ -48,9 +49,10 @@ gh() {
 			return 0
 		fi
 		if [[ " ${*} " == *" --state closed "* ]]; then
+			printf ' %s ' "$*" >"$GH_CLOSED_LIST_ARGS_FILE"
 			printf '%s\n' '[
-				{"number":53,"title":"Add buffalo logo favicon","headRefName":"feature/buffalo-favicon","closedAt":"2026-05-01T12:00:00Z","mergedAt":null,"additions":7,"deletions":0,"author":{"login":"worker-a"},"labels":[]},
-				{"number":54,"title":"Recoverable unsuppressed work","headRefName":"feature/keep-me","closedAt":"2026-05-01T13:00:00Z","mergedAt":null,"additions":70,"deletions":0,"author":{"login":"worker-b"},"labels":[]}
+				{"number":53,"title":"Add buffalo logo favicon","headRefName":"feature/buffalo-favicon","closedAt":"2026-05-01T12:00:00Z","mergedAt":null,"additions":7,"deletions":0,"author":{"login":"worker-a"},"labels":[],"state":"CLOSED"},
+				{"number":54,"title":"Recoverable unsuppressed work","headRefName":"feature/keep-me","closedAt":"2026-05-01T13:00:00Z","mergedAt":null,"additions":70,"deletions":0,"author":{"login":"worker-b"},"labels":[],"state":"CLOSED"}
 			]'
 			return 0
 		fi
@@ -74,6 +76,24 @@ gh() {
 	esac
 
 	return 1
+}
+
+test_closed_pr_list_requests_state_field() {
+	# shellcheck source=/dev/null
+	source "${TEST_SCRIPT_DIR}/pr-salvage-helper.sh"
+
+	local gh_closed_list_args
+	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
+	scan_repo "example/repo" 30 >/dev/null
+	gh_closed_list_args=$(<"$GH_CLOSED_LIST_ARGS_FILE")
+
+	if [[ "$gh_closed_list_args" == *"--json number,title,headRefName,closedAt,mergedAt,additions,deletions,author,labels,state"* ]]; then
+		print_result "closed PR list requests state for safety filter" 0
+	else
+		print_result "closed PR list requests state for safety filter" 1 "gh pr list args did not include state: ${gh_closed_list_args}"
+	fi
+	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
+	return 0
 }
 
 test_completed_recovery_issue_suppresses_salvage_candidate() {
@@ -128,6 +148,7 @@ test_cmd_scan_accepts_hash_prefixed_pr_numbers() {
 }
 
 test_completed_recovery_issue_suppresses_salvage_candidate
+test_closed_pr_list_requests_state_field
 test_explicit_pr_numbers_fetch_exact_records
 test_cmd_scan_accepts_hash_prefixed_pr_numbers
 


### PR DESCRIPTION
## Summary

Collect explicit PR records in memory and combine them with one jq pass so a single append failure cannot discard already fetched records; request state in closed PR list output for the existing safety filter.

## Files Changed

.agents/scripts/pr-salvage-helper.sh,.agents/scripts/tests/test-pr-salvage-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pr-salvage-helper.sh; bash .agents/scripts/tests/test-pr-salvage-completed-recovery.sh; shellcheck .agents/scripts/pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-helper.sh

Resolves #23800


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 3m and 75,774 tokens on this as a headless worker.