### PR TITLE
GH#23801: Exempt machine protocols from signature repair

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -350,8 +350,8 @@ function _repairBodyArg(cmd, parsed, helperPath, log) {
  * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail?: string }}
  */
 export function tryRepairSignature(cmd, scriptsDir, log) {
-  if (hasTrustedSignatureSignal(cmd)) {
-    log("INFO", "Command already includes trusted signature signal; no repair needed");
+  if (hasTrustedSignatureSignal(cmd) || isMachineProtocolCommand(cmd)) {
+    log("INFO", "Command is exempt or already includes trusted signature signal; no repair needed");
     return { status: "ok", cmd };
   }
 

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -259,6 +259,13 @@ function _repairBodyFile(cmd, filePath, helperPath, log) {
   try {
     const current = readFileSync(filePath, "utf-8");
     if (current.includes(SIG_MARKER)) return { status: "ok", cmd };
+    if (isMachineProtocolCommand(current)) {
+      log(
+        "INFO",
+        `Body-file ${filePath} contains machine-protocol content; no repair needed`,
+      );
+      return { status: "ok", cmd };
+    }
     const sigResult = _generateSignature(helperPath, current, log);
     if (sigResult.status === "fail") return sigResult;
     appendFileSync(filePath, sigResult.sig);

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -334,6 +334,19 @@ describe("tryRepairSignature", () => {
     assert.deepEqual(out, { status: "ok", cmd });
   });
 
+  test("no-ops on machine-protocol --body-file content", () => {
+    const dir = setupStubHelper();
+    const bodyFile = join(dir, "machine-protocol.md");
+    writeFileSync(bodyFile, "<!-- MERGE_SUMMARY -->\nsummary\n");
+    const before = readFileSync(bodyFile, "utf-8");
+    const { log } = makeLogger();
+    const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log);
+    const after = readFileSync(bodyFile, "utf-8");
+    assert.deepEqual(out, { status: "ok", cmd });
+    assert.equal(after, before, "machine-protocol file should not be signed");
+  });
+
   test("refuses to repair heredoc-sourced body (UNPARSEABLE_BODY)", () => {
     const dir = setupStubHelper();
     const { log } = makeLogger();

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -327,6 +327,13 @@ describe("tryRepairSignature", () => {
     assert.deepEqual(out, { status: "ok", cmd });
   });
 
+  test("no-ops on machine-protocol commands without requiring helper", () => {
+    const { log } = makeLogger();
+    const cmd = 'gh issue comment 1 --body "<!-- MERGE_SUMMARY -->\\nsummary"';
+    const out = tryRepairSignature(cmd, "/nonexistent/aidevops-helper-path", log);
+    assert.deepEqual(out, { status: "ok", cmd });
+  });
+
   test("refuses to repair heredoc-sourced body (UNPARSEABLE_BODY)", () => {
     const dir = setupStubHelper();
     const { log } = makeLogger();


### PR DESCRIPTION
## Summary

Updated tryRepairSignature to no-op for machine-protocol GitHub comments before attempting helper-based repair, and added direct coverage for MERGE_SUMMARY commands.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs,.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs (57 passing); .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED, historical advisory debt reported)

Resolves #23801


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 7m and 85,136 tokens on this as a headless worker.