### PR TITLE
GH#23809: harden agent source registry test isolation

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -23,6 +23,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
+if [[ "${AGENTS_DIR}" != /* ]]; then
+	AGENTS_DIR="${PWD}/${AGENTS_DIR}"
+fi
 CUSTOM_DIR="${AGENTS_DIR}/custom"
 CONFIG_FILE="${AGENTS_DIR}/configs/agent-sources.json"
 CAPABILITY_INDEX_FILE="${AGENTS_DIR}/agent-source-capabilities.toon"

--- a/.agents/scripts/tests/test-agent-source-manifest-index.sh
+++ b/.agents/scripts/tests/test-agent-source-manifest-index.sh
@@ -131,6 +131,25 @@ test_subagent_index_includes_capability_registry() {
 	return 0
 }
 
+test_sync_resolves_relative_agents_dir() {
+	local output=""
+	local status=0
+	output=$(cd "$TEST_HOME" && AIDEVOPS_AGENTS_DIR=".aidevops/agents" HOME="$TEST_HOME" "$TEST_HOME/.aidevops/agents/scripts/agent-sources-helper.sh" sync 2>&1)
+	status=$?
+	if [[ "$status" -ne 0 ]]; then
+		print_result "sync resolves relative agents dir" 1 "$output"
+		return 0
+	fi
+
+	local registry="$TEST_HOME/.aidevops/agents/agent-source-capabilities.toon"
+	if grep -q '^<!--TOON:agent_source_capabilities\[1\]' "$registry"; then
+		print_result "sync resolves relative agents dir" 0
+	else
+		print_result "sync resolves relative agents dir" 1 "capability registry missing from $registry"
+	fi
+	return 0
+}
+
 test_check_validates_capability_cardinality() {
 	local output=""
 	local status=0
@@ -176,6 +195,7 @@ main() {
 	setup
 	test_sync_generates_capability_registry
 	test_subagent_index_includes_capability_registry
+	test_sync_resolves_relative_agents_dir
 	test_check_validates_capability_cardinality
 	test_sync_without_node_fails_open
 


### PR DESCRIPTION
## Summary

Resolved relative AIDEVOPS_AGENTS_DIR overrides to absolute paths before derived agent-source paths are computed, and added a regression test for relative override sync behavior.

## Files Changed

.agents/scripts/agent-sources-helper.sh,.agents/scripts/tests/test-agent-source-manifest-index.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/agent-sources-helper.sh .agents/scripts/tests/test-agent-source-manifest-index.sh; .agents/scripts/tests/test-agent-source-manifest-index.sh

Resolves #23809


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.65 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 43,114 tokens on this as a headless worker.