### PR TITLE
GH#23803: fix: harden timeout mock argument handling

### DIFF
--- a/.agents/scripts/tests/test-contributor-activity-helper-person.sh
+++ b/.agents/scripts/tests/test-contributor-activity-helper-person.sh
@@ -30,9 +30,9 @@ fail() {
 
 define_timeout_sec_mock() {
 	timeout_sec() {
-		local _seconds="$1"
-		shift
+		local _seconds="${1:-}"
 		[[ -n "$_seconds" ]] || return 124
+		shift
 		"$@"
 		return $?
 	}


### PR DESCRIPTION
## Summary

Hardened the contributor activity timeout_sec test mock by safely reading the optional timeout argument before shifting, so missing arguments return 124 under set -u instead of aborting.

## Files Changed

.agents/scripts/tests/test-contributor-activity-helper-person.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-contributor-activity-helper-person.sh; bash .agents/scripts/tests/test-contributor-activity-helper-person.sh

Resolves #23803


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.65 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 32,572 tokens on this as a headless worker.