### PR TITLE
GH#23802: fix: allow closed PR worktree cleanup

### DIFF
--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -150,6 +150,37 @@ test_squash_merged_pr_without_ancestor_proof_classifies() {
 	return 0
 }
 
+test_closed_pr_without_ancestor_proof_classifies() {
+	local repo_path="${TEST_ROOT}/repo-closed-pr"
+	local wt_path="${TEST_ROOT}/wt-closed-pr"
+	local log_file="${TEST_ROOT}/closed-pr-cleanup.log"
+	local branch="feature/gh-99024-closed-pr"
+	local classification=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'abandoned closed pr\n' >"$repo_path/closed-pr.txt" || rc=1
+	git -C "$repo_path" add closed-pr.txt || rc=1
+	git -C "$repo_path" commit -q -m "abandoned branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	classification=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "" "" "false" "$branch"
+	) || rc=1
+
+	[[ "$classification" == *"closed PR"* ]] || rc=1
+	[[ "$classification" == *"merge_proof=github-merged-pr-state"* ]] || rc=1
+	[[ "$classification" == *"merge_proof_result=github-merged-pr"* ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "closed PR metadata does not require ancestor proof" "$rc" \
+		"Expected closed PR classification with GitHub PR-state proof"
+	return 0
+}
+
 test_remote_deleted_without_ancestor_proof_skips() {
 	local repo_path="${TEST_ROOT}/repo-remote-deleted"
 	local wt_path="${TEST_ROOT}/wt-remote-deleted"
@@ -185,6 +216,7 @@ test_remote_deleted_without_ancestor_proof_skips() {
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_squash_merged_pr_without_ancestor_proof_classifies
+test_closed_pr_without_ancestor_proof_classifies
 test_remote_deleted_without_ancestor_proof_skips
 
 printf '\nResults: %d/%d passed, %d failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -443,9 +443,10 @@ _clean_branch_requires_ancestor_proof() {
 	local merge_type="$1"
 
 	case "$merge_type" in
-	"squash-merged PR")
+	"squash-merged PR" | "closed PR")
 		# GitHub squash merges intentionally create a new target-branch commit,
-		# so the branch tip is not expected to be an ancestor of the default branch.
+		# and abandoned closed PRs are not expected to reach the default branch.
+		# In both cases, GitHub PR state is the proof source rather than ancestry.
 		return 1
 		;;
 	esac


### PR DESCRIPTION
## Summary

Exempted closed PR cleanup classifications from ancestor proof and added regression coverage for closed PR GitHub-state proof.

## Files Changed

.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh,.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh; bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh (4/4 passed); .agents/scripts/linters-local.sh timed out after reporting pre-existing markdownlint/ratchet warnings outside changed shell files.

Resolves #23802


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.65 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 8m and 47,438 tokens on this as a headless worker.