### PR TITLE
GH#23804: tighten supply-chain cleanup guard

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -40,8 +40,7 @@ make_tmpdir() {
 is_safe_test_tmpdir() {
 	local tmpdir="${1:-}"
 	[[ -n "$tmpdir" ]] || return 1
-	[[ "$tmpdir" == /* ]] || return 1
-	[[ "$tmpdir" == *[^/]* ]] || return 1
+	[[ "$tmpdir" == /*[!/]* ]] || return 1
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Tighten `is_safe_test_tmpdir` to require an absolute path containing at least one non-slash character before cleanup can call `rm -rf`.
- Preserve the existing empty-value guard and regression coverage for `/`, `//`, `///`, and `////`.

## Files changed

- `.agents/scripts/tests/test-supply-chain-advisory-helper.sh`

## Runtime Testing

Self-assessed (shell test helper change; no long-running runtime service).

## Verification

- `shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh`
- `bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh` (6 tests, 0 failures)

Resolves #23804

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.66 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 3m and 61,023 tokens on this as a headless worker.