### PR TITLE
GH#23805: simplify blocked-by parser regex

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -575,15 +575,17 @@ _blocked_by_extract_tids() {
 	# Match the dep-graph whole-line parser so compact blocker lists such as
 	# `blocked-by:t001,t002,t003` are enforced consistently at dispatch time.
 	# Capture full subtask ID including decimal suffix (e.g. t325.1 → 325.1).
-	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*|[Bb]locked[- ]by[^[:cntrl:]]*' || true)
+	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*' || true)
 	printf '%s' "$blocker_lines" | grep -oE 't[0-9]+(\.[0-9a-z]+)*' | sed 's/^t//' || true
+	return 0
 }
 
 _blocked_by_extract_nums() {
 	local body="$1"
 	local blocker_lines
-	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*|[Bb]locked[- ]by[^[:cntrl:]]*' || true)
+	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*' || true)
 	printf '%s' "$blocker_lines" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' || true
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/tests/test-pulse-dep-graph-bash32-nul-crash.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-bash32-nul-crash.sh
@@ -152,13 +152,13 @@ EOF
 # (after optional leading whitespace) with `#` (a comment). The test file
 # is excluded by --exclude so the grep doesn't catch its own documentation.
 nul_in_expansion=$(
-	grep -rn -E '\$\{[^}]*\$'"'"'\\0' "$REPO_ROOT/.agents/scripts/" \
+	grep -rn -E "\$\{[^}]*\$'\\\\0'" "$REPO_ROOT/.agents/scripts/" \
 		--include='*.sh' \
 		--exclude='test-pulse-dep-graph-bash32-nul-crash.sh' 2>/dev/null |
 		grep -vE ':[[:space:]]*#' || true
 )
 if [[ -z "$nul_in_expansion" ]]; then
-	printf 'PASS: no ${...$'"'"'\\0...} patterns in shell code\n'
+	printf "%s\n" "PASS: no \${...\$'\\0...} patterns in shell code"
 	pass_count=$((pass_count + 1))
 else
 	printf 'FAIL: found NUL-in-parameter-expansion pattern (bash 3.2 will crash):\n%s\n' "$nul_in_expansion" >&2


### PR DESCRIPTION
## Summary

Simplified duplicate blocked-by regex alternations to match the dep-graph parser pattern, and narrowed the bash 3.2 NUL regression guard so octal colour escapes are not false positives.

## Files Changed

.agents/scripts/pulse-dep-graph.sh,.agents/scripts/tests/test-pulse-dep-graph-bash32-nul-crash.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dep-graph.sh .agents/scripts/tests/test-pulse-dep-graph-bash32-nul-crash.sh; .agents/scripts/tests/test-pulse-dep-graph-parse.sh; .agents/scripts/tests/test-pulse-dep-graph-bash32-nul-crash.sh; .agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh; .agents/scripts/tests/test-claim-blocked-by-detection.sh; bash .agents/tests/test-pulse-dep-graph-blocked-by.sh

Resolves #23805


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.65 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 3m and 52,595 tokens on this as a headless worker.