### PR TITLE
fix: prioritize PR state in cleanup classifier

### DIFF
--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -150,6 +150,40 @@ test_squash_merged_pr_without_ancestor_proof_classifies() {
 	return 0
 }
 
+test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted() {
+	local repo_path="${TEST_ROOT}/repo-deleted-squash-pr"
+	local wt_path="${TEST_ROOT}/wt-deleted-squash-pr"
+	local log_file="${TEST_ROOT}/deleted-squash-pr-cleanup.log"
+	local branch="feature/gh-99025-deleted-squash-pr"
+	local classification=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'deleted squash merge head\n' >"$repo_path/deleted-squash-pr.txt" || rc=1
+	git -C "$repo_path" add deleted-squash-pr.txt || rc=1
+	git -C "$repo_path" commit -q -m "deleted squash-merged branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	classification=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		branch_was_pushed() { return 0; }
+		_branch_exists_on_any_remote() { return 1; }
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "$branch" "" "false" ""
+	) || rc=1
+
+	[[ "$classification" == *"squash-merged PR"* ]] || rc=1
+	[[ "$classification" != *"remote deleted"* ]] || rc=1
+	[[ "$classification" == *"merge_proof=github-merged-pr-state"* ]] || rc=1
+	[[ "$classification" == *"merge_proof_result=github-merged-pr"* ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "deleted squash-merged PR metadata wins over remote-deleted classification" "$rc" \
+		"Expected exact merged PR branch metadata to bypass remote-deleted ancestry proof"
+	return 0
+}
+
 test_closed_pr_without_ancestor_proof_classifies() {
 	local repo_path="${TEST_ROOT}/repo-closed-pr"
 	local wt_path="${TEST_ROOT}/wt-closed-pr"
@@ -216,6 +250,7 @@ test_remote_deleted_without_ancestor_proof_skips() {
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_squash_merged_pr_without_ancestor_proof_classifies
+test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted
 test_closed_pr_without_ancestor_proof_classifies
 test_remote_deleted_without_ancestor_proof_skips
 

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -501,27 +501,29 @@ _clean_classify_worktree() {
 		&& ! branch_has_zero_commits_ahead "$wt_branch" "$default_br"; then
 		is_merged=true
 		merge_type="merged"
-	# Check 2: Remote branch deleted (indicates squash merge or PR closed)
+	# Check 2: Squash-merge detection via GitHub PR state
+	# GitHub squash merges create a new commit — the original branch is NOT
+	# an ancestor of the target, so git branch --merged misses it. The remote
+	# branch may still exist if "auto-delete head branches" is off, or may be
+	# gone when auto-delete is on. Trust only exact headRefName metadata here;
+	# issue/PR cross-reference text must not be treated as cleanup proof.
+	# grep -Fxq: exact fixed-string line match (no regex injection risk).
+	elif [[ -n "$merged_prs" ]] && echo "$merged_prs" | grep -Fxq "$wt_branch"; then
+		is_merged=true
+		merge_type="squash-merged PR"
+	# Check 3: Closed (abandoned) PR — PR was closed without merging.
+	# The remote branch may still exist (auto-delete only fires on merge).
+	# Work is abandoned; worktree is safe to remove.
+	elif [[ -n "$closed_prs" ]] && echo "$closed_prs" | grep -Fxq "$wt_branch"; then
+		is_merged=true
+		merge_type="closed PR"
+	# Check 4: Remote branch deleted (indicates squash merge or PR closed)
 	# ONLY check this if the branch was previously pushed - unpushed branches should NOT be flagged
 	# Check all remotes, not just origin (consistent with branch_was_pushed)
 	# Skip if fetch failed — stale refs could cause false-positive deletion
 	elif [[ "$remote_unknown" == "false" ]] && branch_was_pushed "$wt_branch" && ! _branch_exists_on_any_remote "$wt_branch"; then
 		is_merged=true
 		merge_type="remote deleted"
-	# Check 3: Squash-merge detection via GitHub PR state
-	# GitHub squash merges create a new commit — the original branch is NOT
-	# an ancestor of the target, so git branch --merged misses it. The remote
-	# branch may still exist if "auto-delete head branches" is off.
-	# grep -Fxq: exact fixed-string line match (no regex injection risk).
-	elif [[ -n "$merged_prs" ]] && echo "$merged_prs" | grep -Fxq "$wt_branch"; then
-		is_merged=true
-		merge_type="squash-merged PR"
-	# Check 4: Closed (abandoned) PR — PR was closed without merging.
-	# The remote branch may still exist (auto-delete only fires on merge).
-	# Work is abandoned; worktree is safe to remove.
-	elif [[ -n "$closed_prs" ]] && echo "$closed_prs" | grep -Fxq "$wt_branch"; then
-		is_merged=true
-		merge_type="closed PR"
 	fi
 
 	if [[ "$is_merged" == "false" ]]; then


### PR DESCRIPTION
## Summary
- Reorder worktree cleanup classification so exact GitHub PR branch metadata wins before generic remote-deleted evidence.
- Preserve ancestor-proof requirements for deleted remote branches without matching PR metadata.
- Add regression coverage for deleted squash-merged PR branches that are not ancestors of the default branch.

## Verification
- `bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `bash -n .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `.agents/scripts/linters-local.sh` started; focused gates passed through Secretlint, then broader advisory checks timed out in Shell Portability after reporting pre-existing markdown/ratchet/layout warnings.

Resolves #23820
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.65 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 32m and 77,432 tokens on this with the user in an interactive session.