### PR TITLE
GH#23821: fix pulse cleanup PR detection

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -18,6 +18,7 @@
 #   - _cleanup_merged_prs_for_all_repos     (Pass 1: merged-PR worktree removal)
 #   - _worktree_owner_alive                 (pgrep + registry ownership check)
 #   - _worktree_creation_epoch              (stat .git file mtime, with silent-skip logging)
+#   - _pc_branch_has_pr                     (newline-safe PR existence probe)
 #   - _evaluate_worktree_removal            (age/commit/PR threshold decision)
 #   - _record_orphan_crash_classification   (crash type + dedup clearing for orphaned workers)
 #   - _cleanup_single_worktree              (per-worktree orchestrator)
@@ -94,6 +95,38 @@ _pc_issue_from_branch() {
 	local branch_name="$1"
 	if [[ "$branch_name" =~ gh[-]?([0-9]+) ]]; then
 		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Check whether a branch has at least one matching PR.
+#
+# `gh_pr_list` intentionally emits cached/output text with `printf '%s'`, so
+# single-row output can be non-empty without a trailing newline. Counting via
+# `wc -l` treats that output as zero lines and can misclassify branches with
+# PRs as no-PR orphan cleanup candidates (GH#23821). Ask for a single PR number
+# and test the captured string instead.
+#
+# Args:
+#   $1 - repo slug (owner/repo)
+#   $2 - branch name
+#   $3 - PR state (open|closed|merged|all)
+# Returns: 0 when a matching PR is found, 1 otherwise or on lookup failure
+#######################################
+_pc_branch_has_pr() {
+	local repo_slug="$1"
+	local branch_name="$2"
+	local pr_state="$3"
+	local pr_number=""
+
+	if [[ -z "$repo_slug" || -z "$branch_name" || -z "$pr_state" ]]; then
+		return 1
+	fi
+
+	pr_number=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state "$pr_state" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null) || return 1
+	if [[ -n "$pr_number" ]]; then
 		return 0
 	fi
 	return 1
@@ -495,9 +528,9 @@ _evaluate_worktree_removal() {
 	if [[ "$commits_ahead" -eq 0 && "$dirty_count" -eq 0 && "$wt_age_secs" -ge "$age_grace" ]]; then
 		local has_open_pr=false
 		if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
-			local open_pr_count
-			open_pr_count=$(gh_pr_list --repo "$repo_slug_age" --head "$wt_branch_age" --state open --limit 1 2>/dev/null | wc -l | tr -d ' ') || open_pr_count=0
-			[[ "$open_pr_count" -gt 0 ]] && has_open_pr=true
+			if _pc_branch_has_pr "$repo_slug_age" "$wt_branch_age" "open"; then
+				has_open_pr=true
+			fi
 		fi
 		if [[ "$has_open_pr" == "false" ]]; then
 			echo "0 commits, clean, no open PR, age $((wt_age_secs / 60))m (crashed worker)"
@@ -515,9 +548,9 @@ _evaluate_worktree_removal() {
 	elif [[ "$commits_ahead" -gt 0 && "$wt_age_secs" -ge "$age_24h" ]]; then
 		local has_pr=false
 		if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
-			local pr_count
-			pr_count=$(gh_pr_list --repo "$repo_slug_age" --head "$wt_branch_age" --state all --limit 1 2>/dev/null | wc -l | tr -d ' ') || pr_count=0
-			[[ "$pr_count" -gt 0 ]] && has_pr=true
+			if _pc_branch_has_pr "$repo_slug_age" "$wt_branch_age" "all"; then
+				has_pr=true
+			fi
 		fi
 		if [[ "$has_pr" == "false" ]]; then
 			echo "${commits_ahead} commits, no PR, age $((wt_age_secs / 3600))h"

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -145,6 +145,38 @@ test_local_commit_no_pr_skips_without_recent_metric() {
 	return 0
 }
 
+test_no_newline_pr_output_blocks_local_commit_cleanup() {
+	source_pulse_cleanup_with_stubs || return 1
+	gh_pr_list() { printf '42'; return 0; }
+
+	local reason=""
+	reason=$(_evaluate_worktree_removal 1 0 $((25 * 3600)) "feature/has-pr" "testowner/testrepo" 2>/dev/null)
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -z "$reason" ]] || rc=1
+	print_result "no-newline PR output blocks local-commit no-PR cleanup" "$rc" \
+		"cleanup_rc=$cleanup_rc reason=$reason"
+	return 0
+}
+
+test_no_newline_open_pr_output_blocks_clean_fastpath() {
+	source_pulse_cleanup_with_stubs || return 1
+	gh_pr_list() { printf '42'; return 0; }
+
+	local reason=""
+	reason=$(_evaluate_worktree_removal 0 0 3600 "feature/open-pr" "testowner/testrepo" 2>/dev/null)
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -z "$reason" ]] || rc=1
+	print_result "no-newline open PR output blocks clean fast-path cleanup" "$rc" \
+		"cleanup_rc=$cleanup_rc reason=$reason"
+	return 0
+}
+
 TEST_ROOT=$(mktemp -d)
 trap teardown EXIT
 export HOME="${TEST_ROOT}/home"
@@ -153,6 +185,8 @@ mkdir -p "${HOME}/.aidevops/logs"
 echo "=== test-pulse-cleanup-worker-owned-no-pr.sh ==="
 test_recent_metric_blocks_local_commit_no_pr_removal
 test_local_commit_no_pr_skips_without_recent_metric
+test_no_newline_pr_output_blocks_local_commit_cleanup
+test_no_newline_open_pr_output_blocks_clean_fastpath
 
 echo ""
 echo "Results: $((TESTS_RUN - TESTS_FAILED))/${TESTS_RUN} passed, ${TESTS_FAILED} failed."


### PR DESCRIPTION
## Summary

- Replaced newline-count based gh_pr_list checks in pulse-cleanup with a newline-safe PR-number probe.\n- Covered both open-PR fast-path protection and any-state local-commit protection for no-newline output.

## Files Changed

.agents/scripts/pulse-cleanup.sh,.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh\n- bash .agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh\n- shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh\n- git diff --check\n- .agents/scripts/linters-local.sh (timed out during shell portability after passing SonarCloud, Secretlint, ShellCheck RC parity, TOON, skill frontmatter, pulse canary, and Bash 3.2 gate; markdown/ratchet/layout findings were advisory pre-existing repo-wide debt)

Resolves #23821


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.65 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 33m and 131,655 tokens on this with the user in an interactive session.