### PR TITLE
GH#23828: fix: reject root-equivalent cleanup paths

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -40,6 +40,7 @@ make_tmpdir() {
 is_safe_test_tmpdir() {
 	local tmpdir="${1:-}"
 	[[ -n "$tmpdir" ]] || return 1
+	[[ "$tmpdir" != "/." && "$tmpdir" != "/.." ]] || return 1
 	[[ "$tmpdir" == /*[!/]* ]] || return 1
 	return 0
 }
@@ -56,7 +57,7 @@ cleanup_test_tmpdir() {
 test_cleanup_test_tmpdir_rejects_unsafe_paths() {
 	local test_name="cleanup helper rejects unsafe tmpdir paths"
 	local path
-	for path in '' relative / // /// ////; do
+	for path in '' relative / // /// //// /. /..; do
 		if is_safe_test_tmpdir "$path"; then
 			print_result "$test_name" 1 "accepted unsafe path: ${path:-<empty>}"
 			return 0


### PR DESCRIPTION
## Summary

Added /. and /.. cleanup safety regression coverage and tightened the test cleanup predicate so root-equivalent paths are rejected.

## Files Changed

.agents/scripts/tests/test-supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh; shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh

Resolves #23828


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 35,438 tokens on this as a headless worker.