### PR TITLE
GH#23829: fix: harden body-file signature repair

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -43,9 +43,10 @@
 // .agents/scripts/gh runs at exec-time (after bash creates the file) and
 // is the correct enforcement layer for the same-bash-call shape.
 
-import { existsSync, readFileSync, appendFileSync } from "fs";
+import { existsSync, readFileSync, appendFileSync, realpathSync } from "fs";
 import { execSync } from "child_process";
-import { join } from "path";
+import { join, sep } from "path";
+import { tmpdir } from "os";
 
 import { FAIL_REASON, formatGateThrowMessage } from "./quality-hooks-signature-failures.mjs";
 
@@ -241,6 +242,39 @@ function _generateSignature(helperPath, bodyValue, log) {
 }
 
 /**
+ * Check whether one resolved filesystem path is inside another resolved path.
+ * @param {string} childPath
+ * @param {string} parentPath
+ * @returns {boolean}
+ */
+function _isPathWithin(childPath, parentPath) {
+  const parentPrefix = parentPath.endsWith(sep) ? parentPath : `${parentPath}${sep}`;
+  return childPath === parentPath || childPath.startsWith(parentPrefix);
+}
+
+/**
+ * Resolve a body-file path through realpath and keep transparent repair inside
+ * known-safe writable areas. This prevents a `--body-file` symlink or traversal
+ * path from making the hook append signatures outside the worktree/tmp space.
+ * @param {string} filePath
+ * @returns {string}
+ */
+function _resolveAllowedBodyFilePath(filePath) {
+  const realFilePath = realpathSync(filePath);
+  const allowedRoots = [process.cwd(), tmpdir()]
+    .filter((root) => existsSync(root))
+    .map((root) => realpathSync(root));
+  if (allowedRoots.some((root) => _isPathWithin(realFilePath, root))) {
+    return realFilePath;
+  }
+  const e = new Error(
+    `resolved body-file path ${realFilePath} is outside allowed repair directories`,
+  );
+  e.code = "EACCES";
+  throw e;
+}
+
+/**
  * Repair a `--body-file PATH` form by appending the signature footer to the
  * referenced file if missing.
  *
@@ -257,7 +291,8 @@ function _generateSignature(helperPath, bodyValue, log) {
  */
 function _repairBodyFile(cmd, filePath, helperPath, log) {
   try {
-    const current = readFileSync(filePath, "utf-8");
+    const realFilePath = _resolveAllowedBodyFilePath(filePath);
+    const current = readFileSync(realFilePath, "utf-8");
     if (current.includes(SIG_MARKER)) return { status: "ok", cmd };
     if (isMachineProtocolCommand(current)) {
       log(
@@ -268,7 +303,7 @@ function _repairBodyFile(cmd, filePath, helperPath, log) {
     }
     const sigResult = _generateSignature(helperPath, current, log);
     if (sigResult.status === "fail") return sigResult;
-    appendFileSync(filePath, sigResult.sig);
+    appendFileSync(realFilePath, sigResult.sig);
     log("INFO", `Auto-appended signature footer to body-file ${filePath} (t2685)`);
     return { status: "ok", cmd };
   } catch (e) {

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -15,9 +15,9 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, chmodSync } from "fs";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, symlinkSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, dirname } from "path";
 
 import {
   SIG_MARKER,
@@ -345,6 +345,23 @@ describe("tryRepairSignature", () => {
     const after = readFileSync(bodyFile, "utf-8");
     assert.deepEqual(out, { status: "ok", cmd });
     assert.equal(after, before, "machine-protocol file should not be signed");
+  });
+
+  test("refuses to repair --body-file symlinks outside allowed directories", () => {
+    const dir = setupStubHelper();
+    const outsideDir = mkdtempSync(join(dirname(process.cwd()), "t2685-outside-"));
+    const outsideBodyFile = join(outsideDir, "body.md");
+    const bodyFile = join(dir, "linked-body.md");
+    writeFileSync(outsideBodyFile, "unsigned external content\n");
+    symlinkSync(outsideBodyFile, bodyFile);
+    const { log } = makeLogger();
+    const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log);
+    const after = readFileSync(outsideBodyFile, "utf-8");
+    assert.equal(out.status, "fail");
+    assert.equal(out.reason, FAIL_REASON.FILE_UNREADABLE);
+    assert.match(out.detail, /outside allowed repair directories/);
+    assert.equal(after, "unsigned external content\n", "outside target must not be modified");
   });
 
   test("refuses to repair heredoc-sourced body (UNPARSEABLE_BODY)", () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -15,9 +15,9 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, chmodSync, symlinkSync } from "fs";
-import { tmpdir } from "os";
-import { join, dirname } from "path";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, symlinkSync, rmSync } from "fs";
+import { tmpdir, homedir } from "os";
+import { join } from "path";
 
 import {
   SIG_MARKER,
@@ -349,19 +349,23 @@ describe("tryRepairSignature", () => {
 
   test("refuses to repair --body-file symlinks outside allowed directories", () => {
     const dir = setupStubHelper();
-    const outsideDir = mkdtempSync(join(dirname(process.cwd()), "t2685-outside-"));
+    const outsideDir = mkdtempSync(join(homedir(), ".t2685-outside-"));
     const outsideBodyFile = join(outsideDir, "body.md");
     const bodyFile = join(dir, "linked-body.md");
-    writeFileSync(outsideBodyFile, "unsigned external content\n");
-    symlinkSync(outsideBodyFile, bodyFile);
-    const { log } = makeLogger();
-    const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
-    const out = tryRepairSignature(cmd, dir, log);
-    const after = readFileSync(outsideBodyFile, "utf-8");
-    assert.equal(out.status, "fail");
-    assert.equal(out.reason, FAIL_REASON.FILE_UNREADABLE);
-    assert.match(out.detail, /outside allowed repair directories/);
-    assert.equal(after, "unsigned external content\n", "outside target must not be modified");
+    try {
+      writeFileSync(outsideBodyFile, "unsigned external content\n");
+      symlinkSync(outsideBodyFile, bodyFile);
+      const { log } = makeLogger();
+      const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+      const out = tryRepairSignature(cmd, dir, log);
+      const after = readFileSync(outsideBodyFile, "utf-8");
+      assert.equal(out.status, "fail");
+      assert.equal(out.reason, FAIL_REASON.FILE_UNREADABLE);
+      assert.match(out.detail, /outside allowed repair directories/);
+      assert.equal(after, "unsigned external content\n", "outside target must not be modified");
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 
   test("refuses to repair heredoc-sourced body (UNPARSEABLE_BODY)", () => {


### PR DESCRIPTION
## Summary

Resolved review feedback by checking --body-file contents for machine-protocol markers before appending signatures, resolving body-file real paths, and constraining transparent repair to the worktree or temp directory to avoid symlink/path traversal writes. Added regression coverage for outside-directory symlink refusal.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs,.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; node --check .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs; node --check .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; .agents/scripts/linters-local.sh

Resolves #23829


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 8m and 61,700 tokens on this as a headless worker.