### PR TITLE
GH#23831: fix secure PR salvage test temp file

### DIFF
--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -15,6 +15,13 @@ TESTS_RUN=0
 TESTS_FAILED=0
 GH_CLOSED_LIST_ARGS_FILE=$(mktemp "${TMPDIR:-/tmp}/pr-salvage-gh-args.XXXXXX")
 
+cleanup_gh_args_file() {
+	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
+	return 0
+}
+
+trap cleanup_gh_args_file EXIT
+
 print_result() {
 	local test_name="$1"
 	local passed="$2"
@@ -83,7 +90,7 @@ test_closed_pr_list_requests_state_field() {
 	source "${TEST_SCRIPT_DIR}/pr-salvage-helper.sh"
 
 	local gh_closed_list_args
-	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
+	: >"$GH_CLOSED_LIST_ARGS_FILE"
 	scan_repo "example/repo" 30 >/dev/null
 	gh_closed_list_args=$(<"$GH_CLOSED_LIST_ARGS_FILE")
 
@@ -92,7 +99,7 @@ test_closed_pr_list_requests_state_field() {
 	else
 		print_result "closed PR list requests state for safety filter" 1 "gh pr list args did not include state: ${gh_closed_list_args}"
 	fi
-	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
+	: >"$GH_CLOSED_LIST_ARGS_FILE"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -13,7 +13,7 @@ readonly TEST_SCRIPT_DIR
 
 TESTS_RUN=0
 TESTS_FAILED=0
-GH_CLOSED_LIST_ARGS_FILE="${TMPDIR:-/tmp}/pr-salvage-gh-args.$$"
+GH_CLOSED_LIST_ARGS_FILE=$(mktemp "${TMPDIR:-/tmp}/pr-salvage-gh-args.XXXXXX")
 
 print_result() {
 	local test_name="$1"


### PR DESCRIPTION
## Summary

Replaced the predictable /tmp argument-capture filename in the PR salvage helper test with a mktemp-created file.

## Files Changed

.agents/scripts/tests/test-pr-salvage-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pr-salvage-helper.sh; bash .agents/scripts/tests/test-pr-salvage-helper.sh

Resolves #23831


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 34,584 tokens on this as a headless worker.