### PR TITLE
GH#23830: harden body-file signature repair

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs
@@ -17,6 +17,7 @@
 export const FAIL_REASON = {
   FILE_NOT_FOUND: "body-file not found (may be created later in this same bash call)",
   FILE_UNREADABLE: "body-file exists but cannot be read",
+  BODY_FILE_OUTSIDE_ALLOWED_ROOT: "body-file resolves outside allowed roots",
   HELPER_MISSING: "gh-signature-helper.sh not found",
   HELPER_FAILED: "gh-signature-helper.sh invocation failed",
   UNPARSEABLE_BODY: "body uses heredoc, process substitution, or command substitution",

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -257,7 +257,7 @@ function _isPathWithin(childPath, parentPath) {
  * known-safe writable areas. This prevents a `--body-file` symlink or traversal
  * path from making the hook append signatures outside the worktree/tmp space.
  * @param {string} filePath
- * @returns {string}
+ * @returns {{ status: "ok", filePath: string } | { status: "fail", reason: string, detail: string }}
  */
 function _resolveAllowedBodyFilePath(filePath) {
   const realFilePath = realpathSync(filePath);
@@ -265,13 +265,13 @@ function _resolveAllowedBodyFilePath(filePath) {
     .filter((root) => existsSync(root))
     .map((root) => realpathSync(root));
   if (allowedRoots.some((root) => _isPathWithin(realFilePath, root))) {
-    return realFilePath;
+    return { status: "ok", filePath: realFilePath };
   }
-  const e = new Error(
-    `resolved body-file path ${realFilePath} is outside allowed repair directories`,
-  );
-  e.code = "EACCES";
-  throw e;
+  return {
+    status: "fail",
+    reason: FAIL_REASON.BODY_FILE_OUTSIDE_ALLOWED_ROOT,
+    detail: `${filePath} -> ${realFilePath}`,
+  };
 }
 
 /**
@@ -291,20 +291,28 @@ function _resolveAllowedBodyFilePath(filePath) {
  */
 function _repairBodyFile(cmd, filePath, helperPath, log) {
   try {
-    const realFilePath = _resolveAllowedBodyFilePath(filePath);
-    const current = readFileSync(realFilePath, "utf-8");
+    const resolved = _resolveAllowedBodyFilePath(filePath);
+    if (resolved.status === "fail") {
+      log("WARN", `Refusing --body-file outside allowed roots: ${resolved.detail}`);
+      return resolved;
+    }
+    const current = readFileSync(resolved.filePath, "utf-8");
     if (current.includes(SIG_MARKER)) return { status: "ok", cmd };
     if (isMachineProtocolCommand(current)) {
       log(
         "INFO",
-        `Body-file ${filePath} contains machine-protocol content; no repair needed`,
+        `Body-file ${resolved.filePath} contains machine-protocol content; no repair needed`,
       );
       return { status: "ok", cmd };
     }
+    if (!existsSync(helperPath)) {
+      log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
+      return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
+    }
     const sigResult = _generateSignature(helperPath, current, log);
     if (sigResult.status === "fail") return sigResult;
-    appendFileSync(realFilePath, sigResult.sig);
-    log("INFO", `Auto-appended signature footer to body-file ${filePath} (t2685)`);
+    appendFileSync(resolved.filePath, sigResult.sig);
+    log("INFO", `Auto-appended signature footer to body-file ${resolved.filePath} (t2685)`);
     return { status: "ok", cmd };
   } catch (e) {
     const reason =
@@ -398,10 +406,6 @@ export function tryRepairSignature(cmd, scriptsDir, log) {
   }
 
   const helperPath = join(scriptsDir, "gh-signature-helper.sh");
-  if (!existsSync(helperPath)) {
-    log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
-    return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
-  }
   if (_hasUnparseableBody(cmd)) {
     log("WARN", "Command has unparseable body (heredoc/command-sub); refusing auto-repair (t2685)");
     return { status: "fail", reason: FAIL_REASON.UNPARSEABLE_BODY };
@@ -414,6 +418,11 @@ export function tryRepairSignature(cmd, scriptsDir, log) {
   if (bodyFileMatch) {
     const filePath = bodyFileMatch[2] || bodyFileMatch[4];
     return _repairBodyFile(cmd, filePath, helperPath, log);
+  }
+
+  if (!existsSync(helperPath)) {
+    log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
+    return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
   }
 
   // --body VALUE form: command-side repair.

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -335,7 +335,7 @@ describe("tryRepairSignature", () => {
   });
 
   test("no-ops on machine-protocol --body-file content", () => {
-    const dir = setupStubHelper();
+    const dir = mkdtempSync(join(tmpdir(), "t2685-machine-file-"));
     const bodyFile = join(dir, "machine-protocol.md");
     writeFileSync(bodyFile, "<!-- MERGE_SUMMARY -->\nsummary\n");
     const before = readFileSync(bodyFile, "utf-8");
@@ -360,8 +360,8 @@ describe("tryRepairSignature", () => {
       const out = tryRepairSignature(cmd, dir, log);
       const after = readFileSync(outsideBodyFile, "utf-8");
       assert.equal(out.status, "fail");
-      assert.equal(out.reason, FAIL_REASON.FILE_UNREADABLE);
-      assert.match(out.detail, /outside allowed repair directories/);
+      assert.equal(out.reason, FAIL_REASON.BODY_FILE_OUTSIDE_ALLOWED_ROOT);
+      assert.match(out.detail, /body\.md/);
       assert.equal(after, "unsigned external content\n", "outside target must not be modified");
     } finally {
       rmSync(outsideDir, { recursive: true, force: true });
@@ -481,10 +481,11 @@ describe("checkSignatureFooterGate", () => {
 // ---------------------------------------------------------------------------
 
 describe("FAIL_REASON enum (t2893)", () => {
-  test("exposes the seven canonical failure reasons", () => {
+  test("exposes the canonical failure reasons", () => {
     const expected = [
       "FILE_NOT_FOUND",
       "FILE_UNREADABLE",
+      "BODY_FILE_OUTSIDE_ALLOWED_ROOT",
       "HELPER_MISSING",
       "HELPER_FAILED",
       "UNPARSEABLE_BODY",


### PR DESCRIPTION
## Summary

Added body-file realpath enforcement with a structured outside-root failure, preserved machine-protocol body-file no-op behavior without requiring the signature helper, and covered symlink traversal regression behavior.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs,.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs,.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; node --check .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs; node --check .agents/plugins/opencode-aidevops/quality-hooks-signature-failures.mjs; node --check .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; .agents/scripts/linters-local.sh. full-loop project validator typecheck was skipped because local node_modules/tsc is unavailable (tsc: not found); no dependency install was performed.

Resolves #23830


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 13m and 109,544 tokens on this as a headless worker.