### PR TITLE
GH#23825: fix: make pulse cleanup PR lookup robust

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -125,7 +125,7 @@ _pc_branch_has_pr() {
 		return 1
 	fi
 
-	pr_number=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state "$pr_state" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null) || return 1
+	pr_number=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state "$pr_state" --limit 1 --json number --jq '.[].number' 2>/dev/null) || return 1
 	if [[ -n "$pr_number" ]]; then
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-cleanup.sh to use the jq iterator form for extracting a matching PR number, avoiding null-index lookup behavior on empty gh_pr_list responses.

## Files Changed

.agents/scripts/pulse-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-cleanup.sh; .agents/scripts/test-pulse-cleanup-config-defaults.sh; .agents/scripts/test-pulse-cleanup-unregister.sh; .agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh; .agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh; .agents/scripts/tests/test-pulse-cleanup-unregister.sh; bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh

Resolves #23825


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 31,748 tokens on this as a headless worker.