### PR TITLE
GH#23826: harden worktree cleanup PR branch matching

### DIFF
--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -508,13 +508,13 @@ _clean_classify_worktree() {
 	# gone when auto-delete is on. Trust only exact headRefName metadata here;
 	# issue/PR cross-reference text must not be treated as cleanup proof.
 	# grep -Fxq: exact fixed-string line match (no regex injection risk).
-	elif [[ -n "$merged_prs" ]] && echo "$merged_prs" | grep -Fxq "$wt_branch"; then
+	elif [[ -n "$merged_prs" ]] && printf '%s\n' "$merged_prs" | grep -Fxq -- "$wt_branch"; then
 		is_merged=true
 		merge_type="squash-merged PR"
 	# Check 3: Closed (abandoned) PR — PR was closed without merging.
 	# The remote branch may still exist (auto-delete only fires on merge).
 	# Work is abandoned; worktree is safe to remove.
-	elif [[ -n "$closed_prs" ]] && echo "$closed_prs" | grep -Fxq "$wt_branch"; then
+	elif [[ -n "$closed_prs" ]] && printf '%s\n' "$closed_prs" | grep -Fxq -- "$wt_branch"; then
 		is_merged=true
 		merge_type="closed PR"
 	# Check 4: Remote branch deleted (indicates squash merge or PR closed)


### PR DESCRIPTION
## Summary

Replaced echo-based PR branch matching in worktree cleanup classification with guarded printf pipelines and grep -- separators for merged and closed PR checks.

## Files Changed

.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worktree-clean-lib.sh; bash -n .agents/scripts/worktree-clean-lib.sh; .agents/scripts/linters-local.sh (completed with pre-existing advisory output and final success).

Resolves #23826


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 4m and 44,328 tokens on this as a headless worker.