### PR TITLE
GH#23827: clarify timeout fallback marker guidance

### DIFF
--- a/todo/tasks/t3591-brief.md
+++ b/todo/tasks/t3591-brief.md
@@ -59,7 +59,7 @@ Leaf task: implementation PR should use a closing keyword for GH#23761.
 2. Centralize portable wall-clock protection near those GitHub API calls, using `timeout_sec` or an existing shared wrapper pattern rather than direct `timeout`.
 3. Use separate or configurable budgets for single-person and cross-repo aggregate stats so cross-repo work does not lose useful partial output under a single hard-coded 60s budget.
 4. Adjust `.agents/scripts/stats-health-dashboard-data.sh` so timeout/failure of optional person-stats does not mark a misleading successful refresh when both optional stats paths fail.
-5. Preserve or surface partial-output/timeout markers in dashboard data where possible. Use jq fallback `//` and avoid redundant `"null"` string checks instead of silently converting failures to empty stats.
+5. Preserve or surface partial-output/timeout markers in dashboard data where possible. Use the jq fallback operator `//` to provide explicit markers (for example, `// "timeout"`) and avoid redundant `"null"` string checks, rather than silently converting failures to empty stats.
 6. Add regression coverage for bare macOS/no-coreutils behavior by isolating `PATH` or faking command availability, plus slow/stuck helper behavior for both per-person and cross-repo paths.
 
 ### Verification


### PR DESCRIPTION
## Summary

Clarified the t3591 brief so jq fallback guidance explicitly surfaces timeout markers instead of converting failures to empty stats.

## Files Changed

todo/tasks/t3591-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff HEAD~1 --check; pre-commit hook completed with no shell files modified

Resolves #23827


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 34,842 tokens on this as a headless worker.