### PR TITLE
GH#23824: fix merged PR REST fallback

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1141,13 +1141,14 @@ _rest_pr_object_json_jq() {
 _rest_pr_list_json_jq() {
 	local fields="$1"
 	local user_jq="$2"
+	local source_filter="${3:-.}"
 	local projection=""
 	local field=""
 	while IFS= read -r field; do
 		[[ -z "$field" ]] && continue
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
-		state) projection="${projection}${projection:+,}state: .state" ;;
+		state) projection="${projection}${projection:+,}state: (if .merged_at != null then \"MERGED\" else .state end)" ;;
 		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable | if . == true then \"MERGEABLE\" elif . == false then \"CONFLICTING\" else (. // \"UNKNOWN\") end)" ;;
 		reviewDecision) projection="${projection}${projection:+,}reviewDecision: (.reviewDecision // \"\")" ;;
 		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
@@ -1167,7 +1168,7 @@ _rest_pr_list_json_jq() {
 		esac
 	done < <(_rest_split_csv "$fields")
 	[[ -z "$projection" ]] && projection="number: .number"
-	local jq_expr="[.[] | {${projection}}]"
+	local jq_expr="${source_filter} | [.[] | {${projection}}]"
 	[[ -n "$user_jq" ]] && jq_expr="${jq_expr} | ${user_jq}"
 	printf '%s' "$jq_expr"
 	return 0
@@ -1182,6 +1183,8 @@ _rest_pr_list() {
 	local json_fields=""
 	local head_branch=""
 	local base_branch=""
+	local rest_state=""
+	local source_filter="."
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -1211,7 +1214,13 @@ _rest_pr_list() {
 		return 1
 	fi
 
-	local _query="state=${state}&per_page=${limit}"
+	rest_state="$state"
+	if [[ "$state" == "merged" ]]; then
+		rest_state="closed"
+		source_filter='map(select(.merged_at != null))'
+	fi
+
+	local _query="state=${rest_state}&per_page=${limit}"
 	if [[ -n "$head_branch" ]]; then
 		local _head_encoded
 		if [[ "$head_branch" != *:* ]]; then
@@ -1229,7 +1238,13 @@ _rest_pr_list() {
 	local _path="/repos/${repo}/pulls?${_query}"
 	local _gh_cmd=(gh api "$_path")
 	if [[ -n "$json_fields" ]]; then
-		jq_expr="$(_rest_pr_list_json_jq "$json_fields" "$jq_expr")"
+		jq_expr="$(_rest_pr_list_json_jq "$json_fields" "$jq_expr" "$source_filter")"
+	elif [[ "$source_filter" != "." ]]; then
+		if [[ -n "$jq_expr" ]]; then
+			jq_expr="${source_filter} | ${jq_expr}"
+		else
+			jq_expr="$source_filter"
+		fi
 	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -853,6 +853,29 @@ else
 fi
 
 # =============================================================================
+# Test 23c: gh_pr_list REST fallback translates --state merged to closed+merged_at
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PR_LIST_FIXTURE='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337","head":{"ref":"open-branch"},"base":{"ref":"main"}},{"number":22338,"state":"closed","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22338","head":{"ref":"closed-branch"},"base":{"ref":"main"}},{"number":22339,"state":"closed","merged_at":"2026-05-20T00:00:00Z","html_url":"https://github.com/owner/repo/pull/22339","head":{"ref":"merged-branch"},"base":{"ref":"main"}}]'
+
+merged_prs=$(gh_pr_list --repo "owner/repo" --state merged --json number,state,mergedAt,headRefName --jq '.' 2>/dev/null || true)
+merged_count=$(printf '%s\n' "$merged_prs" | jq 'length' 2>/dev/null || printf '0')
+merged_number=$(printf '%s\n' "$merged_prs" | jq -r '.[0].number // empty' 2>/dev/null || true)
+merged_state=$(printf '%s\n' "$merged_prs" | jq -r '.[0].state // empty' 2>/dev/null || true)
+
+if [[ "$merged_count" == "1" && "$merged_number" == "22339" && "$merged_state" == "MERGED" ]] &&
+	grep -qE '^api /repos/owner/repo/pulls\?state=closed&per_page=30' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE 'state=merged' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list REST fallback maps --state merged to closed PRs filtered by merged_at"
+else
+	fail "gh_pr_list REST fallback maps --state merged to closed PRs filtered by merged_at" \
+		"output=${merged_prs} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+unset STUB_PR_LIST_FIXTURE
+
+# =============================================================================
 # Test 23c: gh_issue_list REST fallback preserves gh-shaped JSON output
 # =============================================================================
 : >"$GH_CALLS"

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -184,6 +184,44 @@ test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted() {
 	return 0
 }
 
+test_exact_head_merged_pr_proof_wins_when_global_list_misses() {
+	local repo_path="${TEST_ROOT}/repo-exact-head-pr"
+	local wt_path="${TEST_ROOT}/wt-exact-head-pr"
+	local log_file="${TEST_ROOT}/exact-head-pr-cleanup.log"
+	local branch="feature/gh-99026-exact-head-pr"
+	local classification=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'exact head merged proof\n' >"$repo_path/exact-head-pr.txt" || rc=1
+	git -C "$repo_path" add exact-head-pr.txt || rc=1
+	git -C "$repo_path" commit -q -m "exact head merged branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	classification=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		gh_pr_list() {
+			printf '1\n'
+			return 0
+		}
+		branch_was_pushed() { return 0; }
+		_branch_exists_on_any_remote() { return 1; }
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "" "" "false" ""
+	) || rc=1
+
+	[[ "$classification" == *"squash-merged PR"* ]] || rc=1
+	[[ "$classification" != *"remote deleted"* ]] || rc=1
+	[[ "$classification" == *"merge_proof=github-merged-pr-state"* ]] || rc=1
+	[[ "$classification" == *"merge_proof_result=github-merged-pr"* ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "exact-head merged PR proof wins when global merged list misses branch" "$rc" \
+		"Expected exact-head merged PR lookup to bypass remote-deleted ancestry proof"
+	return 0
+}
+
 test_closed_pr_without_ancestor_proof_classifies() {
 	local repo_path="${TEST_ROOT}/repo-closed-pr"
 	local wt_path="${TEST_ROOT}/wt-closed-pr"
@@ -251,6 +289,7 @@ echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_squash_merged_pr_without_ancestor_proof_classifies
 test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted
+test_exact_head_merged_pr_proof_wins_when_global_list_misses
 test_closed_pr_without_ancestor_proof_classifies
 test_remote_deleted_without_ancestor_proof_skips
 

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -399,6 +399,22 @@ _clean_build_closed_pr_branches() {
 	return 0
 }
 
+_clean_branch_has_exact_merged_pr() {
+	local wt_branch="$1"
+	local merged_count=""
+
+	[[ -z "$wt_branch" ]] && return 1
+	if ! command -v gh_pr_list &>/dev/null; then
+		return 1
+	fi
+	merged_count=$(gh_pr_list --head "$wt_branch" --state all --limit 1 --json number,state,mergedAt,headRefName \
+		--jq '[.[] | select((.mergedAt != null) and (.mergedAt != ""))] | length' 2>/dev/null || true)
+	if [[ "$merged_count" =~ ^[1-9][0-9]*$ ]]; then
+		return 0
+	fi
+	return 1
+}
+
 _WT_CLEAN_PROTECTED_PATHS="${_WT_CLEAN_PROTECTED_PATHS:-}"
 _WT_CLEAN_LAST_MERGE_TYPE="${_WT_CLEAN_LAST_MERGE_TYPE:-}"
 _WT_CLEAN_LAST_AUDIT_CONTEXT="${_WT_CLEAN_LAST_AUDIT_CONTEXT:-}"
@@ -508,7 +524,7 @@ _clean_classify_worktree() {
 	# gone when auto-delete is on. Trust only exact headRefName metadata here;
 	# issue/PR cross-reference text must not be treated as cleanup proof.
 	# grep -Fxq: exact fixed-string line match (no regex injection risk).
-	elif [[ -n "$merged_prs" ]] && printf '%s\n' "$merged_prs" | grep -Fxq -- "$wt_branch"; then
+	elif _clean_branch_has_exact_merged_pr "$wt_branch" || { [[ -n "$merged_prs" ]] && printf '%s\n' "$merged_prs" | grep -Fxq -- "$wt_branch"; }; then
 		is_merged=true
 		merge_type="squash-merged PR"
 	# Check 3: Closed (abandoned) PR — PR was closed without merging.


### PR DESCRIPTION
## Summary
- Translate REST fallback `gh_pr_list --state merged` to GitHub REST `state=closed` and filter on `merged_at`.
- Preserve gh-shaped merged PR output by emitting `state: MERGED` when REST provides `merged_at`.
- Add exact-head merged PR proof in worktree cleanup before remote-deleted fallback classification.

## Verification
- `.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh`
- `bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `.agents/scripts/linters-local.sh` (passed; pre-existing advisory markdown/ratchet/complexity output only)

Resolves #23824
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.68 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 20m and 181,559 tokens on this with the user in an interactive session.