### PR TITLE
Add experimental Nostr VPN integration

### DIFF
--- a/.agents/reference/domain-index.md
+++ b/.agents/reference/domain-index.md
@@ -32,6 +32,7 @@ Read subagents on-demand when trigger words clearly match. Full index: `subagent
 | Vector Search | vector, embeddings, RAG, semantic search, zvec | `tools/database/vector-search.md`, `tools/database/vector-search/zvec.md` |
 | Local Development | localhost, local dev, Traefik, mkcert, preview proxy | `services/hosting/local-hosting.md` |
 | Hosting/Deployment | deploy, hosting, Fly, Coolify, Vercel, Daytona, cloud | `tools/deployment/hosting-comparison.md`, `tools/deployment/fly-io.md`, `tools/deployment/coolify.md`, `tools/deployment/vercel.md`, `tools/deployment/uncloud.md`, `tools/deployment/daytona.md` |
+| Networking/VPN | VPN, mesh, NetBird, Tailscale, Nostr VPN, FIPS, remote compute network | `services/networking/netbird.md`, `services/networking/tailscale.md`, `services/networking/nostr-vpn.md` |
 | Infrastructure | GPU, containers, OrbStack, remote dispatch, servers | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |
 | Accessibility | accessibility, WCAG, a11y, contrast, screen reader | `tools/accessibility/accessibility-audit.md` |
 | OpenAPI exploration | OpenAPI, API spec, endpoint search, schema discovery | `tools/context/openapi-search.md` |

--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# nostr-vpn-helper.sh — Read-only diagnostics and guidance for Nostr VPN/FIPS.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+set -euo pipefail
+
+CONFIG_TEMPLATE="${SCRIPT_DIR}/../../configs/nostr-vpn-config.json.txt"
+
+print_usage() {
+	cat <<'USAGE'
+Usage: nostr-vpn-helper.sh <command>
+
+Commands:
+  check            Check local FIPS/Nostr VPN tooling availability
+  status           Show FIPS status when fipsctl is installed
+  identity         Show public identity information when available
+  peers            Show peer information when available
+  firewall-status  Show fips0 firewall/service status hints
+  diagnostics      Run non-destructive local diagnostics
+  secrets-help     Show aidevops secret setup guidance
+  opencode-guide   Show secure OpenCode remote compute guidance
+  help             Show this help
+USAGE
+	return 0
+}
+
+has_command() {
+	local command_name="$1"
+	if command -v "$command_name" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	return 1
+}
+
+run_fipsctl() {
+	local subcommand="$1"
+	shift || true
+
+	if ! has_command fipsctl; then
+		printf 'fipsctl not found. Install FIPS first and verify upstream checksums.\n' >&2
+		return 1
+	fi
+
+	fipsctl "$subcommand" "$@"
+	return 0
+}
+
+check_tools() {
+	local missing=0
+	local tool
+
+	for tool in fips fipsctl; do
+		if has_command "$tool"; then
+			printf 'OK: %s found at %s\n' "$tool" "$(command -v "$tool")"
+		else
+			printf 'MISSING: %s\n' "$tool"
+			missing=1
+		fi
+	done
+
+	for tool in fipstop fips-gateway jq systemctl launchctl; do
+		if has_command "$tool"; then
+			printf 'OPTIONAL: %s found at %s\n' "$tool" "$(command -v "$tool")"
+		fi
+	done
+
+	if [[ -r "$CONFIG_TEMPLATE" ]]; then
+		printf 'OK: config template exists: %s\n' "$CONFIG_TEMPLATE"
+	else
+		printf 'WARN: config template missing: %s\n' "$CONFIG_TEMPLATE"
+	fi
+
+	return "$missing"
+}
+
+show_status() {
+	if run_fipsctl status; then
+		return 0
+	fi
+
+	printf 'No FIPS status available. Try upstream command: fipsctl status\n'
+	return 1
+}
+
+show_identity() {
+	if run_fipsctl identity; then
+		return 0
+	fi
+
+	printf 'Identity command unavailable or changed upstream. Inspect: fipsctl --help\n'
+	return 1
+}
+
+show_peers() {
+	if run_fipsctl peers; then
+		return 0
+	fi
+
+	printf 'Peer command unavailable or changed upstream. Inspect: fipsctl --help\n'
+	return 1
+}
+
+show_firewall_status() {
+	if has_command systemctl; then
+		systemctl status fips-firewall --no-pager || true
+	fi
+
+	if has_command launchctl; then
+		launchctl print system 2>/dev/null | grep -F 'fips' || true
+	fi
+
+	printf '\nSecurity baseline: enable upstream fips0 firewall rules before exposing SSH, OpenCode, dashboards, LAN gateway, or exit-node paths.\n'
+	return 0
+}
+
+run_diagnostics() {
+	printf 'Nostr VPN/FIPS diagnostics (read-only)\n'
+	printf '=====================================\n'
+	check_tools || true
+	printf '\nStatus:\n'
+	show_status || true
+	printf '\nPeers:\n'
+	show_peers || true
+	printf '\nFirewall:\n'
+	show_firewall_status || true
+	printf '\nSecret hygiene:\n'
+	show_secrets_help
+	return 0
+}
+
+show_secrets_help() {
+	cat <<'SECRETS'
+WARNING: Never paste secret values into AI chat.
+
+Use aidevops secret storage for sensitive values:
+  aidevops secret set FIPS_NSEC
+  aidevops secret set OPENCODE_SERVER_TOKEN
+
+Guidance:
+  - Prefer one fresh Nostr/FIPS identity per device.
+  - Use FIPS_NSEC only for import/recovery; never commit nsec values or key files.
+  - Pass secrets via environment or aidevops secret execution context, not CLI arguments.
+  - Keep key files owner-only (0600) and outside repositories.
+SECRETS
+	return 0
+}
+
+show_opencode_guide() {
+	cat <<'GUIDE'
+Secure OpenCode remote compute over Nostr VPN/FIPS:
+  1. Start FIPS and verify the client can reach the compute node over .fips/IPv6.
+  2. Bind OpenCode server to loopback or the FIPS interface only, never a public interface.
+  3. Store auth with: aidevops secret set OPENCODE_SERVER_TOKEN
+  4. Allow only the client npub in FIPS peer ACLs and fips0 firewall rules.
+  5. Test SSH first, then test an authenticated OpenCode request over the mesh.
+  6. Disable LAN gateway and exit-node modes unless the trust boundary is reviewed.
+GUIDE
+	return 0
+}
+
+main() {
+	local command_name="${1:-help}"
+	shift || true
+
+	case "$command_name" in
+	check)
+		check_tools "$@"
+		return $?
+		;;
+	status)
+		show_status "$@"
+		return $?
+		;;
+	identity)
+		show_identity "$@"
+		return $?
+		;;
+	peers)
+		show_peers "$@"
+		return $?
+		;;
+	firewall-status)
+		show_firewall_status "$@"
+		return $?
+		;;
+	diagnostics)
+		run_diagnostics "$@"
+		return $?
+		;;
+	secrets-help)
+		show_secrets_help "$@"
+		return $?
+		;;
+	opencode-guide)
+		show_opencode_guide "$@"
+		return $?
+		;;
+	help | --help | -h)
+		print_usage
+		return 0
+		;;
+	*)
+		printf 'Unknown command: %s\n\n' "$command_name" >&2
+		print_usage >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -47,7 +47,7 @@ run_fipsctl() {
 	fi
 
 	fipsctl "$subcommand" "$@"
-	return 0
+	return $?
 }
 
 check_tools() {
@@ -107,7 +107,7 @@ show_peers() {
 
 show_firewall_status() {
 	if has_command systemctl; then
-		systemctl status fips-firewall --no-pager || true
+		systemctl status fips-firewall --no-pager 2>/dev/null || true
 	fi
 
 	if has_command launchctl; then

--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -79,29 +79,29 @@ check_tools() {
 }
 
 show_status() {
-	if run_fipsctl status; then
+	if run_fipsctl show status; then
 		return 0
 	fi
 
-	printf 'No FIPS status available. Try upstream command: fipsctl status\n'
+	printf 'No FIPS status available. Try upstream command: fipsctl show status\n'
 	return 1
 }
 
 show_identity() {
-	if run_fipsctl identity; then
+	if run_fipsctl show identity-cache; then
 		return 0
 	fi
 
-	printf 'Identity command unavailable or changed upstream. Inspect: fipsctl --help\n'
+	printf 'Identity cache command unavailable or changed upstream. Inspect: fipsctl show --help\n'
 	return 1
 }
 
 show_peers() {
-	if run_fipsctl peers; then
+	if run_fipsctl show peers; then
 		return 0
 	fi
 
-	printf 'Peer command unavailable or changed upstream. Inspect: fipsctl --help\n'
+	printf 'Peer command unavailable or changed upstream. Inspect: fipsctl show --help\n'
 	return 1
 }
 

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-nostr-vpn-helper.sh - Nostr VPN/FIPS helper smoke coverage
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_SCRIPT="${SCRIPT_DIR}/../nostr-vpn-helper.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+
+	printf 'FAIL %s\n' "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '  %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT="$(mktemp -d)"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+write_stub_command() {
+	local name="$1"
+	local body="$2"
+	local path="${TEST_ROOT}/${name}"
+
+	cat >"$path" <<EOF_STUB
+#!/usr/bin/env bash
+set -euo pipefail
+${body}
+EOF_STUB
+	chmod +x "$path"
+	return 0
+}
+
+run_helper_with_path() {
+	PATH="${TEST_ROOT}:$PATH" bash "$HELPER_SCRIPT" "$@"
+	return $?
+}
+
+test_check_reports_available_required_tools() {
+	local output=""
+	write_stub_command fips 'printf "fips stub\\n"'
+	# shellcheck disable=SC2016 # Intentionally expands inside the generated stub.
+	write_stub_command fipsctl 'printf "fipsctl %s\\n" "${1:-}"'
+
+	output="$(run_helper_with_path check 2>&1)"
+	if [[ "$output" == *"OK: fips found"* && "$output" == *"OK: fipsctl found"* ]]; then
+		print_result "check reports available required tools" 0
+		return 0
+	fi
+
+	print_result "check reports available required tools" 1 "$output"
+	return 0
+}
+
+test_status_delegates_to_fipsctl() {
+	local output=""
+	# shellcheck disable=SC2016 # Intentionally expands inside the generated stub.
+	write_stub_command fipsctl 'printf "stub-status:%s\\n" "${1:-}"'
+
+	output="$(run_helper_with_path status 2>&1)"
+	if [[ "$output" == "stub-status:status" ]]; then
+		print_result "status delegates to fipsctl status" 0
+		return 0
+	fi
+
+	print_result "status delegates to fipsctl status" 1 "$output"
+	return 0
+}
+
+test_peers_delegates_to_fipsctl() {
+	local output=""
+	# shellcheck disable=SC2016 # Intentionally expands inside the generated stub.
+	write_stub_command fipsctl 'printf "stub-peers:%s\\n" "${1:-}"'
+
+	output="$(run_helper_with_path peers 2>&1)"
+	if [[ "$output" == "stub-peers:peers" ]]; then
+		print_result "peers delegates to fipsctl peers" 0
+		return 0
+	fi
+
+	print_result "peers delegates to fipsctl peers" 1 "$output"
+	return 0
+}
+
+test_secret_guidance_mentions_aidevops_secret() {
+	local output=""
+	output="$(bash "$HELPER_SCRIPT" secrets-help 2>&1)"
+
+	if [[ "$output" == *"aidevops secret set FIPS_NSEC"* && "$output" == *"aidevops secret set OPENCODE_SERVER_TOKEN"* ]]; then
+		print_result "secret guidance uses aidevops secret" 0
+		return 0
+	fi
+
+	print_result "secret guidance uses aidevops secret" 1 "$output"
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	test_check_reports_available_required_tools
+	test_status_delegates_to_fipsctl
+	test_peers_delegates_to_fipsctl
+	test_secret_guidance_mentions_aidevops_secret
+
+	printf '\nTests run: %d\n' "$TESTS_RUN"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		printf 'Tests failed: %d\n' "$TESTS_FAILED"
+		return 1
+	fi
+
+	printf 'All tests passed\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -81,30 +81,30 @@ test_check_reports_available_required_tools() {
 test_status_delegates_to_fipsctl() {
 	local output=""
 	# shellcheck disable=SC2016 # Intentionally expands inside the generated stub.
-	write_stub_command fipsctl 'printf "stub-status:%s\\n" "${1:-}"'
+	write_stub_command fipsctl 'printf "stub-status:%s:%s\\n" "${1:-}" "${2:-}"'
 
 	output="$(run_helper_with_path status 2>&1)"
-	if [[ "$output" == "stub-status:status" ]]; then
-		print_result "status delegates to fipsctl status" 0
+	if [[ "$output" == "stub-status:show:status" ]]; then
+		print_result "status delegates to fipsctl show status" 0
 		return 0
 	fi
 
-	print_result "status delegates to fipsctl status" 1 "$output"
+	print_result "status delegates to fipsctl show status" 1 "$output"
 	return 0
 }
 
 test_peers_delegates_to_fipsctl() {
 	local output=""
 	# shellcheck disable=SC2016 # Intentionally expands inside the generated stub.
-	write_stub_command fipsctl 'printf "stub-peers:%s\\n" "${1:-}"'
+	write_stub_command fipsctl 'printf "stub-peers:%s:%s\\n" "${1:-}" "${2:-}"'
 
 	output="$(run_helper_with_path peers 2>&1)"
-	if [[ "$output" == "stub-peers:peers" ]]; then
-		print_result "peers delegates to fipsctl peers" 0
+	if [[ "$output" == "stub-peers:show:peers" ]]; then
+		print_result "peers delegates to fipsctl show peers" 0
 		return 0
 	fi
 
-	print_result "peers delegates to fipsctl peers" 1 "$output"
+	print_result "peers delegates to fipsctl show peers" 1 "$output"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -93,6 +93,21 @@ test_status_delegates_to_fipsctl() {
 	return 0
 }
 
+test_status_propagates_fipsctl_failure() {
+	local output=""
+	local exit_code=0
+	write_stub_command fipsctl 'printf "stub-status-failed\n" >&2; exit 42'
+
+	output="$(run_helper_with_path status 2>&1)" || exit_code=$?
+	if [[ "$exit_code" -eq 1 && "$output" == *"stub-status-failed"* && "$output" == *"No FIPS status available"* ]]; then
+		print_result "status propagates fipsctl failure" 0
+		return 0
+	fi
+
+	print_result "status propagates fipsctl failure" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 test_peers_delegates_to_fipsctl() {
 	local output=""
 	# shellcheck disable=SC2016 # Intentionally expands inside the generated stub.
@@ -121,14 +136,30 @@ test_secret_guidance_mentions_aidevops_secret() {
 	return 0
 }
 
+test_firewall_status_suppresses_systemctl_stderr() {
+	local output=""
+	write_stub_command systemctl 'printf "systemctl transient failure\n" >&2; exit 1'
+
+	output="$(run_helper_with_path firewall-status 2>&1)"
+	if [[ "$output" == *"Security baseline"* && "$output" != *"systemctl transient failure"* ]]; then
+		print_result "firewall status suppresses systemctl stderr" 0
+		return 0
+	fi
+
+	print_result "firewall status suppresses systemctl stderr" 1 "$output"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
 
 	test_check_reports_available_required_tools
 	test_status_delegates_to_fipsctl
+	test_status_propagates_fipsctl_failure
 	test_peers_delegates_to_fipsctl
 	test_secret_guidance_mentions_aidevops_secret
+	test_firewall_status_suppresses_systemctl_stderr
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -1,0 +1,115 @@
+---
+description: Nostr VPN/FIPS - experimental accountless mesh VPN using Nostr identities
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Nostr VPN / FIPS - Experimental Mesh Networking
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Experimental decentralized mesh VPN for advanced users who want accountless, Nostr-key-based device networking.
+- **Use when**: Connect laptop, workstation, homelab, VPS, and remote compute devices without SaaS coordination.
+- **CLI**: `fips`, `fipsctl`, `fipstop`, `fips-gateway`; aidevops wrapper: `.agents/scripts/nostr-vpn-helper.sh`.
+- **Docs/source**: https://nostrvpn.org/ · https://github.com/jmcorgan/fips · https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/nostr-vpn
+- **Status**: Experimental; upstream says protocol/API are not stable and security audit is pending.
+- **Secrets**: Use `aidevops secret set FIPS_NSEC` only for import/recovery; never paste Nostr private keys into chat or commit key files.
+
+**Key concepts**: Nostr keypair identity · npub node address · FIPS mesh · IPv6 `fd00::/8` TUN · `.fips` DNS · Nostr-mediated discovery · peer ACL · optional `fips0` firewall · LAN gateway · WireGuard exit sidecar.
+
+<!-- AI-CONTEXT-END -->
+
+## Decision Guidance
+
+Use **Nostr VPN/FIPS** when self-sovereign identity and no central control plane matter more than mature administration. Use **NetBird** for teams, SSO, API-managed ACLs, policy UX, and production support. Use **Tailscale** for fastest onboarding where SaaS control-plane dependency is acceptable.
+
+Do not present FIPS as the default aidevops networking layer until upstream protocol stability and security audit status improve.
+
+## aidevops Use Cases
+
+- Secure SSH and OpenCode server access between personal devices across networks.
+- Reach workstation/GPU/storage resources from laptop without exposing public ports.
+- Build a self-hosted mesh spanning homelab, VPS, mobile, and travel devices.
+- Run aidevops helpers on one node while using compute or services on another.
+- Test resilient routing over UDP, TCP, Ethernet, Tor, or Bluetooth transports.
+
+## Setup Pattern
+
+1. Install FIPS from an upstream release or package; verify checksums first.
+2. Generate a persistent identity on each device, or import one from `aidevops secret set FIPS_NSEC` during recovery only.
+3. Record device **npubs**, labels, and intended roles in local config; never store private keys in git.
+4. Configure peer ACLs before joining wider meshes.
+5. Enable the optional `fips0` firewall baseline before exposing services.
+6. Test `.fips` resolution, IPv6 reachability, SSH, and OpenCode server access.
+
+## Secret Handling
+
+WARNING: Never paste secret values into AI chat.
+
+Use aidevops secret storage for private Nostr key recovery material and OpenCode access tokens:
+
+```bash
+aidevops secret set FIPS_NSEC
+aidevops secret set OPENCODE_SERVER_TOKEN
+```
+
+Prefer fresh per-device identities over shared private keys. If a key is imported from `FIPS_NSEC`, write it only to the upstream-supported key file with owner-only permissions, then remove the environment value from shell history/session. Pass secrets as environment variables or secret-helper execution context, not command arguments.
+
+## OpenCode Remote Compute Pattern
+
+1. On the compute node, bind OpenCode or other local services to loopback or the FIPS interface only.
+2. Open only the required port on `fips0`; keep public interfaces default-deny.
+3. From the client node, connect using the peer `.fips` name or mapped IPv6 address.
+4. Store service auth tokens with `aidevops secret set OPENCODE_SERVER_TOKEN`.
+5. Verify with `nostr-vpn-helper.sh diagnostics` and an authenticated application-level request.
+
+## Helper Commands
+
+```bash
+.agents/scripts/nostr-vpn-helper.sh check
+.agents/scripts/nostr-vpn-helper.sh status
+.agents/scripts/nostr-vpn-helper.sh identity
+.agents/scripts/nostr-vpn-helper.sh peers
+.agents/scripts/nostr-vpn-helper.sh firewall-status
+.agents/scripts/nostr-vpn-helper.sh diagnostics
+.agents/scripts/nostr-vpn-helper.sh secrets-help
+.agents/scripts/nostr-vpn-helper.sh opencode-guide
+```
+
+The helper is intentionally read-only except for printing operator instructions; destructive or privileged changes should be confirmed and implemented in a later, tested phase.
+
+## Security Checklist
+
+- Confirm upstream release checksums before installing.
+- Treat npubs as addresses, not proof that a device is trustworthy.
+- Keep peer ACLs tight; default deny unknown peers.
+- Enable `fips0` firewall rules before exposing SSH, OpenCode, dashboards, or LAN gateways.
+- Avoid LAN gateway and exit-node mode until the trust boundary is explicit.
+- Assume public Nostr relays can reveal metadata even when messages are encrypted.
+- Rotate the device identity after suspected compromise; remove stale peers from ACLs and known-hosts.
+
+## Verification
+
+Run:
+
+```bash
+.agents/scripts/nostr-vpn-helper.sh diagnostics
+fipsctl status
+fipsctl peers
+ssh <user>@<peer-alias>.fips
+```
+
+If `fipsctl` output format changes, inspect upstream docs before updating aidevops parsing; do not guess around private key or ACL semantics.

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -108,8 +108,8 @@ Run:
 
 ```bash
 .agents/scripts/nostr-vpn-helper.sh diagnostics
-fipsctl status
-fipsctl peers
+fipsctl show status
+fipsctl show peers
 ssh <user>@<peer-alias>.fips
 ```
 

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -49,11 +49,12 @@ Do not present FIPS as the default aidevops networking layer until upstream prot
 ## Setup Pattern
 
 1. Install FIPS from an upstream release or package; verify checksums first.
-2. Generate a persistent identity on each device, or import one from `aidevops secret set FIPS_NSEC` during recovery only.
-3. Record device **npubs**, labels, and intended roles in local config; never store private keys in git.
-4. Configure peer ACLs before joining wider meshes.
-5. Enable the optional `fips0` firewall baseline before exposing services.
-6. Test `.fips` resolution, IPv6 reachability, SSH, and OpenCode server access.
+2. On macOS, also verify package integrity with `pkgutil --check-signature`, `pkgutil --payload-files`, or `pkgutil --expand`; do not install packages that fail these checks even when the release checksum matches.
+3. Generate a persistent identity on each device, or import one from `aidevops secret set FIPS_NSEC` during recovery only.
+4. Record device **npubs**, labels, and intended roles in local config; never store private keys in git.
+5. Configure peer ACLs before joining wider meshes.
+6. Enable the optional `fips0` firewall baseline before exposing services.
+7. Test `.fips` resolution, IPv6 reachability, SSH, and OpenCode server access.
 
 ## Secret Handling
 

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -1,0 +1,69 @@
+{
+  "status": "experimental",
+  "provider": "nostr-vpn-fips",
+  "upstream": {
+    "website": "https://nostrvpn.org/",
+    "repository": "https://github.com/jmcorgan/fips",
+    "release_channel": "pinned-release",
+    "minimum_reviewed_version": "v0.3.0",
+    "verify_checksums": true
+  },
+  "identity": {
+    "mode": "per-device",
+    "private_key_storage": "aidevops secret set FIPS_NSEC for import/recovery only; otherwise use the upstream key file with owner-only permissions",
+    "public_address_format": "npub",
+    "never_commit": [
+      "Nostr private keys",
+      "nsec values",
+      "FIPS key files",
+      "OpenCode server tokens"
+    ]
+  },
+  "devices": {
+    "laptop": {
+      "role": "client",
+      "npub": "npub1examplelaptop...",
+      "alias": "laptop.fips",
+      "allowed_services": ["ssh"]
+    },
+    "workstation": {
+      "role": "compute",
+      "npub": "npub1exampleworkstation...",
+      "alias": "workstation.fips",
+      "allowed_services": ["ssh", "opencode"]
+    },
+    "vps": {
+      "role": "rendezvous-or-gateway-candidate",
+      "npub": "npub1examplevps...",
+      "alias": "vps.fips",
+      "allowed_services": ["ssh"]
+    }
+  },
+  "opencode_remote_compute": {
+    "enabled": false,
+    "bind": "loopback-or-fips-interface-only",
+    "token_secret": "OPENCODE_SERVER_TOKEN",
+    "allowed_peers": ["npub1examplelaptop..."],
+    "notes": "Store the token with aidevops secret set OPENCODE_SERVER_TOKEN; do not expose OpenCode ports on public interfaces."
+  },
+  "security_defaults": {
+    "peer_acl": "allowlist",
+    "mesh_firewall": "enable-before-service-exposure",
+    "lan_gateway": "disabled-until-reviewed",
+    "exit_node": "disabled-until-reviewed",
+    "public_relay_metadata_warning": true
+  },
+  "tools": {
+    "required": ["fips", "fipsctl"],
+    "optional": ["fipstop", "fips-gateway", "jq", "systemctl", "launchctl"]
+  },
+  "setup_steps": [
+    "1. Verify and install a pinned upstream FIPS release.",
+    "2. Generate one persistent identity per device.",
+    "3. Store recovery nsec with: aidevops secret set FIPS_NSEC (only if needed).",
+    "4. Record npubs and aliases in a private local config, not in git.",
+    "5. Configure peer allowlists before joining untrusted meshes.",
+    "6. Enable the fips0 firewall baseline before exposing SSH/OpenCode.",
+    "7. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics"
+  ]
+}

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -59,11 +59,12 @@
   },
   "setup_steps": [
     "1. Verify and install a pinned upstream FIPS release.",
-    "2. Generate one persistent identity per device.",
-    "3. Store recovery nsec with: aidevops secret set FIPS_NSEC (only if needed).",
-    "4. Record npubs and aliases in a private local config, not in git.",
-    "5. Configure peer allowlists before joining untrusted meshes.",
-    "6. Enable the fips0 firewall baseline before exposing SSH/OpenCode.",
-    "7. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics"
+    "2. On macOS, reject packages that fail pkgutil --check-signature, --payload-files, or --expand even if the release checksum matches.",
+    "3. Generate one persistent identity per device.",
+    "4. Store recovery nsec with: aidevops secret set FIPS_NSEC (only if needed).",
+    "5. Record npubs and aliases in a private local config, not in git.",
+    "6. Configure peer allowlists before joining untrusted meshes.",
+    "7. Enable the fips0 firewall baseline before exposing SSH/OpenCode.",
+    "8. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics"
   ]
 }


### PR DESCRIPTION
## Summary

- Add experimental Nostr VPN/FIPS networking service agent for aidevops users.
- Add read-only `nostr-vpn-helper.sh` diagnostics/guidance wrapper plus tests.
- Add config template with `aidevops secret` guidance for FIPS recovery keys and OpenCode remote compute tokens.
- Add Networking/VPN entry to domain routing.

For #23846.

## Safety and secrets

- No secrets committed; placeholders only.
- Private Nostr recovery material is documented as `aidevops secret set FIPS_NSEC` only.
- OpenCode remote auth is documented as `aidevops secret set OPENCODE_SERVER_TOKEN`.
- Helper is read-only except for local output/guidance.

## Upstream validation notes

- Upstream package issue logged: https://github.com/jmcorgan/fips/issues/102
- macOS `v0.3.0` package matched release checksum but failed `pkgutil`/`xar` integrity checks, so this PR keeps FIPS as experimental and warns not to install failed packages.
- Linux x86_64 tarball checksum passed.
- Docker/OrbStack smoke tests validated real `fipsctl v0.3.0` command shape: `fipsctl show status`, `fipsctl show peers`, and `fipsctl show identity-cache`.
- `fips`/`fips-gateway --help` required `libdbus-1-3` in Debian trixie.

## Verification

- `shellcheck .agents/scripts/nostr-vpn-helper.sh .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `.agents/scripts/tests/test-nostr-vpn-helper.sh`
- `python3 -m json.tool configs/nostr-vpn-config.json.txt`
- `bunx markdownlint-cli2 ".agents/services/networking/nostr-vpn.md" ".agents/reference/domain-index.md"`
- `.agents/scripts/secretlint-helper.sh scan` on all Nostr VPN files
- `git diff --check`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.16.0 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 48m and 345,845 tokens on this with the user in an interactive session.