### PR TITLE
feat: add ObscuraVPN agent

### DIFF
--- a/.agents/reference/domain-index.md
+++ b/.agents/reference/domain-index.md
@@ -33,6 +33,7 @@ Read subagents on-demand when trigger words clearly match. Full index: `subagent
 | Local Development | localhost, local dev, Traefik, mkcert, preview proxy | `services/hosting/local-hosting.md` |
 | Hosting/Deployment | deploy, hosting, Fly, Coolify, Vercel, Daytona, cloud | `tools/deployment/hosting-comparison.md`, `tools/deployment/fly-io.md`, `tools/deployment/coolify.md`, `tools/deployment/vercel.md`, `tools/deployment/uncloud.md`, `tools/deployment/daytona.md` |
 | Infrastructure | GPU, containers, OrbStack, remote dispatch, servers | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |
+| Networking/VPN | VPN, mesh, WireGuard, Tailscale, NetBird, Obscura, MPR, multi-party relay, Mullvad, QUIC obfuscation | `services/networking/tailscale.md`, `services/networking/netbird.md`, `services/networking/obscuravpn.md` |
 | Accessibility | accessibility, WCAG, a11y, contrast, screen reader | `tools/accessibility/accessibility-audit.md` |
 | OpenAPI exploration | OpenAPI, API spec, endpoint search, schema discovery | `tools/context/openapi-search.md` |
 | Local models | local model, llama.cpp, GGUF, Hugging Face, offline | `tools/local-models/local-models.md`, `tools/local-models/huggingface.md`, `scripts/local-model-helper.sh` |

--- a/.agents/services/networking/obscuravpn.md
+++ b/.agents/services/networking/obscuravpn.md
@@ -1,0 +1,126 @@
+---
+description: ObscuraVPN - two-party relay VPN with WireGuard-over-QUIC, Mullvad exits, and censorship resistance
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# ObscuraVPN - Two-Party Relay VPN
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Privacy-by-design VPN/MPR: user → Obscura relay → Mullvad exit → internet.
+- **Architecture**: WireGuard packets encrypted to the exit hop, carried over QUIC/datagrams to Obscura relay servers.
+- **Privacy boundary**: Obscura can see connecting IP/account/payment metadata, not decrypted traffic; Mullvad exits see Obscura relay IP, not user identity.
+- **Use for**: ObscuraVPN client work, MPR/two-party relay analysis, WireGuard-over-QUIC troubleshooting, app build guidance, privacy claims review.
+- **Sources**: https://obscura.com/ · https://github.com/Sovereign-Engineering/obscuravpn-client · Privacy Guides MPR article supplied by user.
+- **Related**: `services/networking/netbird.md`, `services/networking/tailscale.md`, `tools/security/opsec.md`, `tools/mobile/app-dev.md`.
+
+<!-- AI-CONTEXT-END -->
+
+## Product Model
+
+Obscura is closer to a commercial Multi-Party Relay than a traditional single-provider VPN. The key design claim is separation of **who the user is** from **what destinations they reach**:
+
+```text
+user device -> Obscura relay -> Mullvad WireGuard exit -> destination
+```
+
+Use precise wording:
+
+- It is **not Tor**: two high-performance hops, not volunteer onion routing.
+- It is **not normal multihop VPN**: the exit hop is operated by an independent provider.
+- It is **not magic anonymity**: privacy depends on non-collusion and traffic-correlation resistance.
+- It is **not full stealth in WireGuard compatibility mode**: generated WireGuard configs keep two-party privacy but lose QUIC-based obfuscation.
+
+## Client Repository
+
+Repository: https://github.com/Sovereign-Engineering/obscuravpn-client.
+
+Observed repository shape:
+
+- Rust core/library in `rustlib/`.
+- Apple clients in `apple/`; macOS uses a sandboxed Network Extension.
+- Android client in `android/`.
+- UI in `obscura-ui/`.
+- Platform support and build notes in `README.md`, `flake.nix`, and `justfile`.
+
+Upstream contribution policy from the repository README: external contributions are currently not accepted; PRs may be closed unread until their paperwork process changes. For upstream work, produce issues/notes/repro cases or a fork patch only when explicitly requested.
+
+## Build and Test Pointers
+
+Prefer Nix/Just paths from the upstream README; do not invent commands.
+
+| Area | Upstream pattern | Notes |
+|------|------------------|-------|
+| Lint | `nix develop --print-build-logs --command just lint` | Run before claiming code quality. |
+| Format check | `nix flake check` | Use for formatting/flake validation. |
+| Format fix | `nix develop --print-build-logs --command just format-fix` | Only when editing upstream code. |
+| macOS/iOS | Xcode project via `nix develop --print-build-logs --command just xcode-open` | Codesigning and Network Extension entitlements may require Sovereign Engineering team access. |
+| Android Nix build | `nix build '.#apks-foss'` | Signing/install steps need local keystore/device context. |
+
+macOS app debugging uses Apple unified logging. Search predicates should target `process CONTAINS[c] "obscura"` or `subsystem CONTAINS[c] "obscura"`.
+
+## Privacy and Security Review Checklist
+
+When reviewing Obscura claims, verify against source or first-party docs before repeating:
+
+1. **Tunnel boundary**: packets are encrypted to Mullvad WireGuard public keys before Obscura relay handling.
+2. **Relay visibility**: Obscura relays cannot decrypt user traffic; Mullvad exits should only see relay source IPs.
+3. **Transport**: QUIC/datagram transport is the censorship-resistance layer; WireGuard configs do not provide that layer.
+4. **Account privacy**: randomized account numbers reduce account identifiers; payment methods still determine metadata exposure.
+5. **Location claims**: separate relay locations from exit locations; do not conflate first-hop and exit-hop lists.
+6. **Threat model**: document residual risks: relay/exit collusion, timing correlation, compromised client, payment/linkability, destination-side tracking.
+
+## Common Tasks
+
+### Compare with VPN, Tor, iCloud Private Relay, and OHTTP
+
+- Traditional VPN: one provider can see user identity plus destination traffic metadata.
+- Tor: stronger multi-hop anonymity, usually slower and more failure-prone for everyday traffic.
+- iCloud Private Relay: commercial two-party relay limited to Apple ecosystems and constrained location choices.
+- OHTTP: similar two-party privacy principle, but fit for transactional app/API traffic rather than whole-device proxying.
+- Obscura: commercial whole-device VPN-style product with independent Mullvad exits and QUIC obfuscation in the app path.
+
+### Troubleshoot client issues
+
+1. Identify platform: macOS/iOS/Android/WireGuard compatibility mode.
+2. Confirm app mode vs generated WireGuard config; this changes obfuscation expectations.
+3. Inspect local logs with platform-native tooling; avoid collecting destination history or account/payment data.
+4. Verify exit hop public key against Mullvad server information when diagnosing authenticity claims.
+5. Reproduce with a non-sensitive destination and redact account IDs before sharing logs.
+
+### Work on upstream code
+
+1. Read upstream `README.md` for the exact platform flow.
+2. Use a fork/worktree; do not open upstream PRs unless contribution policy changes or maintainer explicitly requests it.
+3. Expect codesigning/provisioning blockers for production Apple builds.
+4. Run the closest feasible Nix/Just validation and report any skipped checks with the missing dependency or credential.
+
+## aidevops Integration
+
+- Route ObscuraVPN, MPR, two-party relay, WireGuard-over-QUIC, Mullvad exit, QUIC obfuscation, and VPN privacy review tasks here first.
+- For app implementation, combine with `tools/mobile/app-dev.md`, `tools/mobile/app-dev-swift.md`, or Android guidance after this agent sets protocol/threat-model context.
+- For operational access to private infrastructure, use `services/networking/netbird.md` or `services/networking/tailscale.md`; Obscura is for internet egress privacy/censorship resistance, not private mesh access.
+- For OPSEC/legal/privacy-policy work, combine with `tools/security/opsec.md` and `legal.md`.
+
+## Related Agents
+
+| Resource | Path | Purpose |
+|----------|------|---------|
+| NetBird | `services/networking/netbird.md` | Self-hosted WireGuard mesh VPN and worker access. |
+| Tailscale | `services/networking/tailscale.md` | Managed mesh VPN, Serve/Funnel, secure private access. |
+| OPSEC | `tools/security/opsec.md` | Threat modelling and operational privacy discipline. |
+| Mobile app development | `tools/mobile/app-dev.md` | App planning/build/release workflows. |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -51,7 +51,7 @@ services/hosting/cloudflare-platform-skill/sandbox-patterns/,services/hosting/cl
 services/hosting/cloudflare-platform-skill/,services/hosting/cloudflare-platform-skill subagents,sandbox-patterns|smart-placement-gotchas|smart-placement|smart-placement-patterns|snippets-gotchas|snippets|snippets-patterns|spectrum-gotchas|spectrum|spectrum-patterns|static-assets-gotchas|static-assets|static-assets-patterns|stream-gotchas|stream|stream-patterns|tail-workers|terraform-gotchas|terraform|terraform-patterns|tunnel-gotchas|tunnel|tunnel-patterns|turn|turnstile-gotchas|turnstile|turnstile-patterns|vectorize-gotchas|vectorize|vectorize-patterns|waf-gotchas|waf|waf-patterns|web-analytics-gotchas|web-analytics|web-analytics-patterns|workerd-gotchas|workerd|workerd-patterns|workers-ai|workers-for-platforms-gotchas|workers-for-platforms|workers-for-platforms-patterns|workers-gotchas|workers|workers-patterns|workers-playground-gotchas|workers-playground|workers-playground-patterns|workers-vpc|workflows-gotchas|workflows|workflows-patterns|wrangler-gotchas|wrangler|wrangler-patterns|zaraz
 services/hosting/,services/hosting subagents,cloudron|dns-providers|domain-purchasing|hetzner|hostinger|local-hosting|localhost|spaceship|webhosting
 services/monitoring/,services/monitoring subagents,langwatch|sentry|socket
-services/networking/,services/networking subagents,netbird|tailscale
+services/networking/,services/networking subagents,netbird|obscuravpn|tailscale
 services/outreach/,services/outreach subagents,cold-outreach|infraforge|instantly|leadsforge|manyreach|smartlead|warmforge
 services/payments/,services/payments subagents,procurement|revenuecat|stripe|superwall
 tools/accessibility/,tools/accessibility subagents,accessibility-audit|accessibility


### PR DESCRIPTION
## Summary

- Add `services/networking/obscuravpn.md` as a shared ObscuraVPN subagent.
- Add Networking/VPN routing in `reference/domain-index.md`.
- Register `obscuravpn` in `subagent-index.toon`.

## Verification

- `bunx markdownlint-cli2 ".agents/services/networking/obscuravpn.md" ".agents/reference/domain-index.md"`
- `python3 .agents/scripts/lib/subagent_validation.py --agents-dir .agents`
- `.agents/scripts/linters-local.sh`

## Release note

Feature-level framework capability; recommend a minor release after merge.

For #23850

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.16.0 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 18m and 155,785 tokens on this with the user in an interactive session.
