### PR TITLE
GH#23848: add pulse account multiplier config fallback

### DIFF
--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -136,6 +136,12 @@
           "maximum": 100,
           "description": "Maximum share of worker slots quality-debt issues may consume. Env: AIDEVOPS_QUALITY_DEBT_CAP_PCT"
         },
+        "provider_account_slot_multiplier": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "description": "Worker slots allowed per available provider OAuth account. Env: PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER"
+        },
         "pulse_model": {
           "type": "string",
           "default": "",

--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -135,6 +135,10 @@
     // Env override: AIDEVOPS_QUALITY_DEBT_CAP_PCT
     "quality_debt_cap_pct": 30,
 
+    // Worker slots allowed per available provider OAuth account.
+    // Env override: PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER
+    "provider_account_slot_multiplier": 2,
+
     // DEPRECATED (v3.7+, GH#17769): Model routing is now derived from
     // pool + routing table at runtime. These fields are ignored.
     "pulse_model": "",

--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -316,6 +316,7 @@ _config_env_map() {
 	orchestration.repo_aidevops_health) echo "AIDEVOPS_REPO_HEALTH" ;;
 	orchestration.max_workers_cap) echo "AIDEVOPS_MAX_WORKERS_CAP" ;;
 	orchestration.quality_debt_cap_pct) echo "AIDEVOPS_QUALITY_DEBT_CAP_PCT" ;;
+	orchestration.provider_account_slot_multiplier) echo "PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER" ;;
 	*) echo "" ;;
 	esac
 	return 0

--- a/.agents/scripts/pulse-capacity.sh
+++ b/.agents/scripts/pulse-capacity.sh
@@ -274,7 +274,11 @@ pulse_apply_provider_load_capacity_cap() {
 	[[ "$provider_5xx" =~ ^[0-9]+$ ]] || provider_5xx=0
 	[[ "$progress_heartbeats" =~ ^[0-9]+$ ]] || progress_heartbeats=0
 
-	local account_multiplier="${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-2}"
+	local account_multiplier="${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-}"
+	if [[ -z "$account_multiplier" ]] && declare -F config_get >/dev/null 2>&1; then
+		account_multiplier=$(config_get "orchestration.provider_account_slot_multiplier" "2") || account_multiplier="2"
+	fi
+	[[ -n "$account_multiplier" ]] || account_multiplier=2
 	[[ "$account_multiplier" =~ ^[0-9]+$ ]] || account_multiplier=2
 	((account_multiplier < 1)) && account_multiplier=1
 	local account_cap=-1

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -81,6 +81,7 @@ reset_capacity_pressure_env() {
 	unset PULSE_DISPATCH_CAPACITY_RECENT_PROVIDER_5XX || true
 	unset PULSE_DISPATCH_CAPACITY_RECENT_PROGRESS_HEARTBEATS || true
 	unset PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER PULSE_DISPATCH_OAUTH_POOL_FILE || true
+	unset -f config_get 2>/dev/null || true
 	rm -f "${HOME}/.aidevops/oauth-pool.json"
 	return 0
 }
@@ -144,6 +145,69 @@ JSON
 		print_result "capacity: provider accounts and high load cap below floor" 0
 	else
 		print_result "capacity: provider accounts and high load cap below floor" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+	fi
+	return 0
+}
+
+test_capacity_uses_configured_provider_account_multiplier() {
+	reset_capacity_pressure_env
+	TEST_MAX_WORKERS=10
+	TEST_ACTIVE_WORKERS=1
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=0
+	PULSE_MODEL="openai/gpt-5.5"
+	cat >"${HOME}/.aidevops/oauth-pool.json" <<'JSON'
+{"openai":[{"status":"idle"}]}
+JSON
+	config_get() {
+		local dotpath="$1" default="${2:-}"
+		if [[ "$dotpath" == "orchestration.provider_account_slot_multiplier" ]]; then
+			printf '4\n'
+		else
+			printf '%s\n' "$default"
+		fi
+		return 0
+	}
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "4 1 3" ]]; then
+		print_result "capacity: config multiplier caps provider account slots" 0
+	else
+		print_result "capacity: config multiplier caps provider account slots" 1 "result=${result}"
+	fi
+	return 0
+}
+
+test_capacity_env_multiplier_overrides_config() {
+	reset_capacity_pressure_env
+	TEST_MAX_WORKERS=10
+	TEST_ACTIVE_WORKERS=1
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=0
+	PULSE_MODEL="openai/gpt-5.5"
+	PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=3
+	cat >"${HOME}/.aidevops/oauth-pool.json" <<'JSON'
+{"openai":[{"status":"idle"}]}
+JSON
+	config_get() {
+		local dotpath="$1" default="${2:-}"
+		if [[ "$dotpath" == "orchestration.provider_account_slot_multiplier" ]]; then
+			printf '4\n'
+		else
+			printf '%s\n' "$default"
+		fi
+		return 0
+	}
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "3 1 2" ]]; then
+		print_result "capacity: env multiplier overrides config multiplier" 0
+	else
+		print_result "capacity: env multiplier overrides config multiplier" 1 "result=${result}"
 	fi
 	return 0
 }
@@ -367,6 +431,8 @@ EOF
 test_capacity_raises_soft_cap_to_floor
 test_capacity_respects_existing_higher_cap
 test_capacity_caps_by_provider_accounts_and_high_load
+test_capacity_uses_configured_provider_account_multiplier
+test_capacity_env_multiplier_overrides_config
 test_capacity_recent_service_interruptions_reduce_slots
 test_capacity_recent_progress_gets_runway_under_pressure
 test_throttle_does_not_force_serial_under_floor


### PR DESCRIPTION
## Summary

Adds orchestration.provider_account_slot_multiplier as a JSONC config fallback for pulse provider account capacity while preserving PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER as the highest-priority override. Updates defaults, schema, config env mapping, and capacity regression coverage.

## Files Changed

.agents/configs/aidevops-config.schema.json,.agents/configs/aidevops.defaults.jsonc,.agents/scripts/config-helper.sh,.agents/scripts/pulse-capacity.sh,.agents/scripts/tests/test-dispatch-min-concurrency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-min-concurrency.sh; shellcheck .agents/scripts/pulse-capacity.sh .agents/scripts/config-helper.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh; python3 -m json.tool .agents/configs/aidevops-config.schema.json; sourced config-helper checks for config and env override; .agents/scripts/linters-local.sh

Resolves #23848


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.0 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 18m and 175,702 tokens on this with the user in an interactive session.