### PR TITLE
GH#23856: fix: simplify framework routing dedup check

### DIFF
--- a/.agents/scripts/framework-routing-helper.sh
+++ b/.agents/scripts/framework-routing-helper.sh
@@ -306,7 +306,7 @@ _lfi_check_dedup() {
 		existing=$(gh issue list --repo "$slug" \
 			--state open --search "$search_terms" \
 			--json number,url --limit 1 -q '.[0].url // ""' || echo "")
-		if [[ -n "$existing" && "$existing" != "[]" && "$existing" != "null" ]]; then
+		if [[ -n "$existing" ]]; then
 			log_info "Duplicate found (search): $existing"
 			_LFI_DEDUP_URL="$existing"
 			return 2

--- a/.agents/scripts/tests/test-framework-routing-helper.sh
+++ b/.agents/scripts/tests/test-framework-routing-helper.sh
@@ -87,7 +87,14 @@ set -euo pipefail
 printf '%s\n' "$*" >>"$TEST_GH_TRACE"
 
 if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
-	printf '%s\n' "${TEST_DUPLICATE_VALUE:-}"
+	case "${TEST_DUPLICATE_VALUE:-}" in
+		"[]"|"null")
+			printf '\n'
+			;;
+		*)
+			printf '%s\n' "${TEST_DUPLICATE_VALUE:-}"
+			;;
+	esac
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

Removed redundant literal []/null checks from framework-routing-helper search dedup because the gh -q jq fallback already emits an empty string; updated the test gh stub to mimic that query behaviour.

## Files Changed

.agents/scripts/framework-routing-helper.sh,.agents/scripts/tests/test-framework-routing-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/framework-routing-helper.sh .agents/scripts/tests/test-framework-routing-helper.sh; bash .agents/scripts/tests/test-framework-routing-helper.sh

Resolves #23856


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 2m and 40,019 tokens on this as a headless worker.