### PR TITLE
GH#23857: simplify pulse multiplier fallback

### DIFF
--- a/.agents/scripts/pulse-capacity.sh
+++ b/.agents/scripts/pulse-capacity.sh
@@ -276,9 +276,8 @@ pulse_apply_provider_load_capacity_cap() {
 
 	local account_multiplier="${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-}"
 	if [[ -z "$account_multiplier" ]] && declare -F config_get >/dev/null 2>&1; then
-		account_multiplier=$(config_get "orchestration.provider_account_slot_multiplier" "2") || account_multiplier="2"
+		account_multiplier=$(config_get "orchestration.provider_account_slot_multiplier" "2")
 	fi
-	[[ -n "$account_multiplier" ]] || account_multiplier=2
 	[[ "$account_multiplier" =~ ^[0-9]+$ ]] || account_multiplier=2
 	((account_multiplier < 1)) && account_multiplier=1
 	local account_cap=-1


### PR DESCRIPTION
## Summary

Removed redundant config fallback checks from pulse provider account multiplier loading while keeping numeric validation as the fallback guard.

## Files Changed

.agents/scripts/pulse-capacity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-capacity.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh; bash .agents/scripts/tests/test-dispatch-min-concurrency.sh

Resolves #23857


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 38,961 tokens on this as a headless worker.