### PR TITLE
GH#23858: docs: resolve ObscuraVPN review followup

### DIFF
--- a/.agents/services/networking/obscuravpn.md
+++ b/.agents/services/networking/obscuravpn.md
@@ -25,8 +25,8 @@ tools:
 - **Architecture**: WireGuard packets encrypted to the exit hop, carried over QUIC/datagrams to Obscura relay servers.
 - **Privacy boundary**: Obscura can see connecting IP/account/payment metadata, not decrypted traffic; Mullvad exits see Obscura relay IP, not user identity.
 - **Use for**: ObscuraVPN client work, MPR/two-party relay analysis, WireGuard-over-QUIC troubleshooting, app build guidance, privacy claims review.
-- **Sources**: https://obscura.com/ · https://github.com/Sovereign-Engineering/obscuravpn-client · Privacy Guides MPR article supplied by user.
-- **Related**: `services/networking/netbird.md`, `services/networking/tailscale.md`, `tools/security/opsec.md`, `tools/mobile/app-dev.md`.
+- **Sources**: https://obscura.com/ · https://github.com/Sovereign-Engineering/obscuravpn-client · Privacy Guides MPR article.
+- **Related**: `services/networking/netbird.md`, `services/networking/tailscale.md`, `tools/security/opsec.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-dev-swift.md`, `legal.md`.
 
 <!-- AI-CONTEXT-END -->
 
@@ -124,3 +124,5 @@ When reviewing Obscura claims, verify against source or first-party docs before 
 | Tailscale | `services/networking/tailscale.md` | Managed mesh VPN, Serve/Funnel, secure private access. |
 | OPSEC | `tools/security/opsec.md` | Threat modelling and operational privacy discipline. |
 | Mobile app development | `tools/mobile/app-dev.md` | App planning/build/release workflows. |
+| Mobile app development (Swift) | `tools/mobile/app-dev-swift.md` | Swift/iOS-specific app development guidance. |
+| Legal | `legal.md` | Legal compliance, privacy policy, and GDPR guidance. |


### PR DESCRIPTION
## Summary

Removed leftover generated-session wording from the ObscuraVPN sources entry and aligned related-agent links with the integration guidance.

## Files Changed

.agents/services/networking/obscuravpn.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2@0.18.1 '.agents/services/networking/obscuravpn.md' (0 errors; latest markdownlint-cli2 requires Node >=20 and failed under local Node 18 before using compatible version).

Resolves #23858


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 2m and 45,496 tokens on this as a headless worker.