### PR TITLE
GH#23859: fix xurl review followup

### DIFF
--- a/.agents/content/social-xurl.md
+++ b/.agents/content/social-xurl.md
@@ -95,7 +95,7 @@ The helper rejects secret-bearing flags and verbose output, maps common read/wri
 | Search posts | `xurl-helper.sh search "QUERY" --limit 10` |
 | Read post | `xurl-helper.sh read POST_ID_OR_URL` |
 | Timeline / mentions | `xurl-helper.sh timeline --limit 20` / `xurl-helper.sh mentions --limit 10` |
-| Bookmarks / likes | `xurl-helper.sh bookmarks --limit 20` / `xurl-helper.sh likes --limit 20` |
+| Bookmarks / likes / DMs | `xurl-helper.sh bookmarks --limit 20` / `xurl-helper.sh likes --limit 20` / `xurl-helper.sh dms --limit 10` |
 | User lookup | `xurl-helper.sh user @handle` |
 | Post / reply / quote | add `--confirm-write` after explicit user approval |
 | Raw read-only API | `xurl-helper.sh run -- /2/users/me` |

--- a/.agents/scripts/xurl-helper.sh
+++ b/.agents/scripts/xurl-helper.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-WRITE_COMMANDS="post reply quote delete like unlike repost unrepost bookmark unbookmark follow unfollow block unblock mute unmute dm media"
+WRITE_COMMANDS="post:reply:quote:delete:like:unlike:repost:unrepost:bookmark:unbookmark:follow:unfollow:block:unblock:mute:unmute:dm:media"
 FORBIDDEN_FLAGS="--verbose -v --bearer-token --consumer-key --consumer-secret --access-token --token-secret --client-id --client-secret"
 APP_NAME=""
 USERNAME=""
@@ -19,7 +19,7 @@ ARGS=()
 show_help() {
 	printf '%s\n' "xurl-helper.sh - guarded xurl wrapper"
 	printf '\n%s\n' "Usage: xurl-helper.sh <command> [options]"
-	printf '\n%s\n' "Read commands: status, whoami, read, search, user, timeline, mentions, bookmarks, likes, followers, following, run"
+	printf '\n%s\n' "Read commands: status, whoami, read, search, user, timeline, mentions, bookmarks, likes, followers, following, dms, run"
 	printf '%s\n' "Write commands: post, reply, quote, delete, like, unlike, repost, unrepost, bookmark, unbookmark, follow, unfollow, block, unblock, mute, unmute, dm, media"
 	printf '\n%s\n' "Options: --app NAME, --username NAME, --limit N, --confirm-write, -- --raw xurl args"
 	printf '%s\n' "Secrets and verbose flags are rejected. Write commands require --confirm-write."
@@ -33,20 +33,6 @@ check_dependencies() {
 		return 1
 	fi
 	return 0
-}
-
-is_word_in_list() {
-	local needle="$1"
-	local haystack="$2"
-	local word
-
-	for word in ${haystack}; do
-		if [[ "${word}" == "${needle}" ]]; then
-			return 0
-		fi
-	done
-
-	return 1
 }
 
 reject_forbidden_args() {
@@ -102,7 +88,7 @@ require_write_confirmation() {
 	local command_name="$1"
 	local confirmed="$2"
 
-	if is_word_in_list "${command_name}" "${WRITE_COMMANDS}" && [[ "${confirmed}" != "true" ]]; then
+	if [[ ":${WRITE_COMMANDS}:" == *":${command_name}:"* ]] && [[ "${confirmed}" != "true" ]]; then
 		print_error "Write action '${command_name}' requires explicit user approval and --confirm-write"
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- Switch xurl write command membership to colon-delimited matching and remove the now-redundant word-list helper.
- Add the supported `dms` read command to xurl helper help text and social-xurl command map.

Resolves #23859

## Testing

- `bash -n .agents/scripts/xurl-helper.sh`
- `shellcheck .agents/scripts/xurl-helper.sh`
- `markdownlint-cli2 .agents/content/social-xurl.md`
- `.agents/scripts/xurl-helper.sh help` plus write-guard smoke check for post without `--confirm-write`

## Runtime Testing

self-assessed: low-risk shell/docs change verified with syntax, lint, markdown, and helper smoke checks.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 2m and 48,832 tokens on this as a headless worker.
