### PR TITLE
GH#23860: optimize merged PR cleanup lookup

### DIFF
--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -150,6 +150,42 @@ test_squash_merged_pr_without_ancestor_proof_classifies() {
 	return 0
 }
 
+test_prefetched_merged_pr_metadata_skips_exact_head_lookup() {
+	local repo_path="${TEST_ROOT}/repo-prefetched-squash-pr"
+	local wt_path="${TEST_ROOT}/wt-prefetched-squash-pr"
+	local log_file="${TEST_ROOT}/prefetched-squash-pr-cleanup.log"
+	local branch="feature/gh-99027-prefetched-squash-pr"
+	local gh_called_marker="${TEST_ROOT}/prefetched-gh-called"
+	local classification=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'prefetched squash merge head\n' >"$repo_path/prefetched-squash-pr.txt" || rc=1
+	git -C "$repo_path" add prefetched-squash-pr.txt || rc=1
+	git -C "$repo_path" commit -q -m "prefetched squash-merged branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	classification=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		gh_pr_list() {
+			printf 'called\n' >"$gh_called_marker"
+			printf '0\n'
+			return 0
+		}
+		_clean_classify_worktree "$wt_path" "$branch" "main" "false" "$branch" "" "false" ""
+	) || rc=1
+
+	[[ "$classification" == *"squash-merged PR"* ]] || rc=1
+	[[ ! -e "$gh_called_marker" ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "prefetched merged PR metadata skips exact-head lookup" "$rc" \
+		"Expected prefetched merged PR list to avoid redundant gh_pr_list lookup"
+	return 0
+}
+
 test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted() {
 	local repo_path="${TEST_ROOT}/repo-deleted-squash-pr"
 	local wt_path="${TEST_ROOT}/wt-deleted-squash-pr"
@@ -204,6 +240,9 @@ test_exact_head_merged_pr_proof_wins_when_global_list_misses() {
 		cd "$repo_path" || exit 1
 		source_clean_lib_with_stubs || exit 1
 		gh_pr_list() {
+			local args="$*"
+			[[ "$args" == *"--state merged"* ]] || return 1
+			[[ "$args" == *"--json number"* ]] || return 1
 			printf '1\n'
 			return 0
 		}
@@ -288,6 +327,7 @@ test_remote_deleted_without_ancestor_proof_skips() {
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_squash_merged_pr_without_ancestor_proof_classifies
+test_prefetched_merged_pr_metadata_skips_exact_head_lookup
 test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted
 test_exact_head_merged_pr_proof_wins_when_global_list_misses
 test_closed_pr_without_ancestor_proof_classifies

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -401,14 +401,17 @@ _clean_build_closed_pr_branches() {
 
 _clean_branch_has_exact_merged_pr() {
 	local wt_branch="$1"
+	local merged_prs="${2:-}"
 	local merged_count=""
 
 	[[ -z "$wt_branch" ]] && return 1
+	if [[ -n "$merged_prs" ]] && printf '%s\n' "$merged_prs" | grep -Fxq -- "$wt_branch"; then
+		return 0
+	fi
 	if ! command -v gh_pr_list &>/dev/null; then
 		return 1
 	fi
-	merged_count=$(gh_pr_list --head "$wt_branch" --state all --limit 1 --json number,state,mergedAt,headRefName \
-		--jq '[.[] | select((.mergedAt != null) and (.mergedAt != ""))] | length' 2>/dev/null || true)
+	merged_count=$(gh_pr_list --head "$wt_branch" --state merged --limit 1 --json number --jq 'length' 2>/dev/null || true)
 	if [[ "$merged_count" =~ ^[1-9][0-9]*$ ]]; then
 		return 0
 	fi
@@ -524,7 +527,7 @@ _clean_classify_worktree() {
 	# gone when auto-delete is on. Trust only exact headRefName metadata here;
 	# issue/PR cross-reference text must not be treated as cleanup proof.
 	# grep -Fxq: exact fixed-string line match (no regex injection risk).
-	elif _clean_branch_has_exact_merged_pr "$wt_branch" || { [[ -n "$merged_prs" ]] && printf '%s\n' "$merged_prs" | grep -Fxq -- "$wt_branch"; }; then
+	elif _clean_branch_has_exact_merged_pr "$wt_branch" "$merged_prs"; then
 		is_merged=true
 		merge_type="squash-merged PR"
 	# Check 3: Closed (abandoned) PR — PR was closed without merging.


### PR DESCRIPTION
## Summary

- Optimized `_clean_branch_has_exact_merged_pr` to use prefetched merged PR branch metadata before making an exact-head GitHub lookup.
- Reduced the fallback lookup to `--state merged --json number --jq length`.
- Added regression coverage that prefetched metadata skips redundant `gh_pr_list` I/O and that fallback queries use merged-only payloads.

## Testing

- `shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh`
- `.agents/scripts/linters-local.sh` timed out after advisory markdown/ratchet warnings; changed-file Bash 3.2 compatibility passed before timeout.

Resolves #23860


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 4m and 100,907 tokens on this as a headless worker.
