### PR TITLE
GH#23863: fix pulse cleanup PR lookup fallback

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -125,7 +125,7 @@ _pc_branch_has_pr() {
 		return 1
 	fi
 
-	pr_number=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state "$pr_state" --limit 1 --json number --jq '.[].number' 2>/dev/null) || return 1
+	pr_number=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state "$pr_state" --limit 1 --json number --jq '.[].number // empty') || true
 	if [[ -n "$pr_number" ]]; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -177,6 +177,27 @@ test_no_newline_open_pr_output_blocks_clean_fastpath() {
 	return 0
 }
 
+test_branch_pr_lookup_uses_null_safe_jq_filter() {
+	source_pulse_cleanup_with_stubs || return 1
+	local captured_args_file="${TEST_ROOT}/gh-pr-list-args.txt"
+	gh_pr_list() {
+		printf '%s' "$*" >"$captured_args_file"
+		return 0
+	}
+
+	_pc_branch_has_pr "testowner/testrepo" "feature/missing-number" "open" >/dev/null
+	local lookup_rc=$?
+	local captured_args=""
+	captured_args=$(<"$captured_args_file") || captured_args=""
+
+	local rc=0
+	[[ "$lookup_rc" -eq 1 ]] || rc=1
+	[[ "$captured_args" == *".[].number // empty"* ]] || rc=1
+	print_result "branch PR lookup uses null-safe jq fallback" "$rc" \
+		"lookup_rc=$lookup_rc args=$captured_args"
+	return 0
+}
+
 TEST_ROOT=$(mktemp -d)
 trap teardown EXIT
 export HOME="${TEST_ROOT}/home"
@@ -187,6 +208,7 @@ test_recent_metric_blocks_local_commit_no_pr_removal
 test_local_commit_no_pr_skips_without_recent_metric
 test_no_newline_pr_output_blocks_local_commit_cleanup
 test_no_newline_open_pr_output_blocks_clean_fastpath
+test_branch_pr_lookup_uses_null_safe_jq_filter
 
 echo ""
 echo "Results: $((TESTS_RUN - TESTS_FAILED))/${TESTS_RUN} passed, ${TESTS_FAILED} failed."


### PR DESCRIPTION
## Summary

Updated pulse cleanup branch PR detection to use a null-safe jq fallback, keep optional lookup failures non-fatal, and expose lookup stderr for diagnostics. Added a targeted regression test to assert the null-safe jq filter is used.

## Files Changed

.agents/scripts/pulse-cleanup.sh,.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh; bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh; .agents/scripts/linters-local.sh

Resolves #23863


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 6m and 52,381 tokens on this as a headless worker.