### PR TITLE
GH#23864: fix: preserve PR salvage test temp cleanup

### DIFF
--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -152,7 +152,7 @@ test_cmd_scan_accepts_hash_prefixed_pr_numbers() {
 
 run_tests() {
 	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
+	trap '_run_cleanups' RETURN EXIT
 	GH_CLOSED_LIST_ARGS_FILE=$(mktemp "${TMPDIR:-/tmp}/pr-salvage-gh-args.XXXXXX")
 	push_cleanup "rm -f \"${GH_CLOSED_LIST_ARGS_FILE}\""
 

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -11,16 +11,12 @@ readonly TEST_RESET='\033[0m'
 TEST_SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 readonly TEST_SCRIPT_DIR
 
+# shellcheck source=../shared-constants.sh
+source "${TEST_SCRIPT_DIR}/shared-constants.sh"
+
 TESTS_RUN=0
 TESTS_FAILED=0
-GH_CLOSED_LIST_ARGS_FILE=$(mktemp "${TMPDIR:-/tmp}/pr-salvage-gh-args.XXXXXX")
-
-cleanup_gh_args_file() {
-	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
-	return 0
-}
-
-trap cleanup_gh_args_file EXIT
+GH_CLOSED_LIST_ARGS_FILE=""
 
 print_result() {
 	local test_name="$1"
@@ -154,13 +150,23 @@ test_cmd_scan_accepts_hash_prefixed_pr_numbers() {
 	return 0
 }
 
-test_completed_recovery_issue_suppresses_salvage_candidate
-test_closed_pr_list_requests_state_field
-test_explicit_pr_numbers_fetch_exact_records
-test_cmd_scan_accepts_hash_prefixed_pr_numbers
+run_tests() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	GH_CLOSED_LIST_ARGS_FILE=$(mktemp "${TMPDIR:-/tmp}/pr-salvage-gh-args.XXXXXX")
+	push_cleanup "rm -f \"${GH_CLOSED_LIST_ARGS_FILE}\""
 
-printf '\nResults: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_FAILED" -gt 0 ]]; then
-	exit 1
-fi
-exit 0
+	test_completed_recovery_issue_suppresses_salvage_candidate
+	test_closed_pr_list_requests_state_field
+	test_explicit_pr_numbers_fetch_exact_records
+	test_cmd_scan_accepts_hash_prefixed_pr_numbers
+
+	printf '\nResults: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+run_tests
+exit $?


### PR DESCRIPTION
## Summary

Updated the PR salvage helper test to create its mktemp file inside the test runner cleanup scope, register removal with push_cleanup, and keep truncation-based reuse so restrictive mktemp permissions are preserved.

## Files Changed

.agents/scripts/tests/test-pr-salvage-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pr-salvage-helper.sh; bash .agents/scripts/tests/test-pr-salvage-helper.sh

Resolves #23864


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.2 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 2m and 61,780 tokens on this as a headless worker.