### PR TITLE
GH#23865: fix: harden supply-chain cleanup path guard

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -40,8 +40,7 @@ make_tmpdir() {
 is_safe_test_tmpdir() {
 	local tmpdir="${1:-}"
 	[[ -n "$tmpdir" ]] || return 1
-	[[ "$tmpdir" != "/." && "$tmpdir" != "/.." ]] || return 1
-	[[ "$tmpdir" == /*[!/]* ]] || return 1
+	[[ "$tmpdir" == /*[!/.]* ]] || return 1
 	return 0
 }
 
@@ -57,7 +56,7 @@ cleanup_test_tmpdir() {
 test_cleanup_test_tmpdir_rejects_unsafe_paths() {
 	local test_name="cleanup helper rejects unsafe tmpdir paths"
 	local path
-	for path in '' relative / // /// //// /. /..; do
+	for path in '' relative / // /// //// /. /.. /./ /../ //./ //../; do
 		if is_safe_test_tmpdir "$path"; then
 			print_result "$test_name" 1 "accepted unsafe path: ${path:-<empty>}"
 			return 0


### PR DESCRIPTION
## Summary

Hardened is_safe_test_tmpdir to reject root-equivalent slash/dot-only paths and expanded regression cases for /./, /../, //./, and //../.

## Files Changed

.agents/scripts/tests/test-supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh && bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh

Resolves #23865


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.2 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 1m and 33,485 tokens on this as a headless worker.