### PR TITLE
GH#23862: fix: optimize worktree cleanup branch matching

### DIFF
--- a/.agents/scripts/tests/test-worktree-cleanup-empty-branch.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-empty-branch.sh
@@ -319,6 +319,37 @@ test_classify_zero_commit_not_merged() {
 }
 test_classify_zero_commit_not_merged
 
+test_branch_list_exact_matching() {
+	local stdout=""
+	stdout=$(
+		set +e
+		: "${RED:=}" "${GREEN:=}" "${YELLOW:=}" "${BLUE:=}" "${BOLD:=}" "${NC:=}"
+		_WTAR_REMOVED="${_WTAR_REMOVED:-removed}"
+		_WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"
+		_WTAR_WH_CALLER="${_WTAR_WH_CALLER:-test}"
+		export RED GREEN YELLOW BLUE BOLD NC
+		export _WTAR_REMOVED _WTAR_SKIPPED _WTAR_WH_CALLER
+
+		# shellcheck source=/dev/null
+		source "$CLEAN_LIB_PATH" >/dev/null 2>&1 || exit 9
+
+		if _clean_branch_list_contains_exact "feature/target" $'feature/target-extra\nfeature/target\nfeature/other' \
+			&& ! _clean_branch_list_contains_exact "feature/target" $'feature/target-extra\nfeature/other'; then
+			printf 'ok\n'
+		else
+			printf 'fail\n'
+		fi
+	)
+	if [[ "$stdout" == "ok" ]]; then
+		print_result "_clean_branch_list_contains_exact matches whole lines only" 0
+	else
+		print_result "_clean_branch_list_contains_exact matches whole lines only" 1 \
+			"(unexpected result='$stdout')"
+	fi
+	return 0
+}
+test_branch_list_exact_matching
+
 # =============================================================================
 # Summary
 # =============================================================================

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -405,7 +405,7 @@ _clean_branch_has_exact_merged_pr() {
 	local merged_count=""
 
 	[[ -z "$wt_branch" ]] && return 1
-	if [[ -n "$merged_prs" ]] && printf '%s\n' "$merged_prs" | grep -Fxq -- "$wt_branch"; then
+	if _clean_branch_list_contains_exact "$wt_branch" "$merged_prs"; then
 		return 0
 	fi
 	if ! command -v gh_pr_list &>/dev/null; then
@@ -416,6 +416,15 @@ _clean_branch_has_exact_merged_pr() {
 		return 0
 	fi
 	return 1
+}
+
+_clean_branch_list_contains_exact() {
+	local wt_branch="$1"
+	local branch_list="${2:-}"
+
+	[[ -n "$wt_branch" && -n "$branch_list" ]] || return 1
+	[[ $'\n'"$branch_list"$'\n' == *$'\n'"$wt_branch"$'\n'* ]] || return 1
+	return 0
 }
 
 _WT_CLEAN_PROTECTED_PATHS="${_WT_CLEAN_PROTECTED_PATHS:-}"
@@ -526,14 +535,13 @@ _clean_classify_worktree() {
 	# branch may still exist if "auto-delete head branches" is off, or may be
 	# gone when auto-delete is on. Trust only exact headRefName metadata here;
 	# issue/PR cross-reference text must not be treated as cleanup proof.
-	# grep -Fxq: exact fixed-string line match (no regex injection risk).
 	elif _clean_branch_has_exact_merged_pr "$wt_branch" "$merged_prs"; then
 		is_merged=true
 		merge_type="squash-merged PR"
 	# Check 3: Closed (abandoned) PR — PR was closed without merging.
 	# The remote branch may still exist (auto-delete only fires on merge).
 	# Work is abandoned; worktree is safe to remove.
-	elif [[ -n "$closed_prs" ]] && printf '%s\n' "$closed_prs" | grep -Fxq -- "$wt_branch"; then
+	elif _clean_branch_list_contains_exact "$wt_branch" "$closed_prs"; then
 		is_merged=true
 		merge_type="closed PR"
 	# Check 4: Remote branch deleted (indicates squash merge or PR closed)


### PR DESCRIPTION
## Summary

Replaced per-worktree printf|grep branch-list checks in worktree cleanup with a shared pure Bash whole-line membership helper, and reused it for both merged and closed PR branch classification.

## Files Changed

.agents/scripts/tests/test-worktree-cleanup-empty-branch.sh,.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh; bash .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh; .agents/scripts/linters-local.sh (completed with pre-existing advisory/complexity warnings and final ALL LOCAL CHECKS PASSED)

Resolves #23862


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.2 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 6m and 53,665 tokens on this as a headless worker.