### PR TITLE
GH#23861: fix 3.15.68 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation: clarify timeout fallback marker guidance (#23839)
 - fix secure PR salvage test temp file (#23835)
 - fix: harden body-file signature repair (#23834)
-- Maintenance: update simplification state registry
 
 ### Fixed
 
+- harden worktree cleanup PR branch matching (#23838)
 - harden body-file signature repair (#23836)
 
 ## [3.15.67] - 2026-05-19


### PR DESCRIPTION
## Summary

Removed the duplicate 3.15.68 changelog entry and added the missing #23838 release note under Fixed.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff HEAD~1 --check; .agents/scripts/linters-local.sh (passed; markdownlint unavailable warning only, historical/advisory debt unchanged)

Resolves #23861


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.3 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 8m and 48,532 tokens on this as a headless worker.