### PR TITLE
fix: health dashboard staleness — activity guard and REST fallback

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -273,6 +273,11 @@ _rest_should_fallback() {
 			remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
 		fi
 	fi
+	# If remaining is empty, the API is likely exhausted (gh api rate_limit itself failed with 403).
+	# Treat empty remaining as exhausted and trigger REST fallback.
+	if [[ -z "$remaining" ]]; then
+		return 0
+	fi
 	[[ "$remaining" =~ ^[0-9]+$ ]] || return 1
 	_GH_LAST_GRAPHQL_REMAINING="$remaining"
 	if [[ "$remaining" -le "$_GH_REST_FALLBACK_THRESHOLD" ]]; then

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -103,11 +103,14 @@ _check_health_issue_activity_guard() {
 
 	[[ -f "$health_issue_file" ]] && return 0
 
-	local guard_pr_count guard_assigned_count guard_worker_count
+	local guard_pr_count guard_assigned_count guard_worker_count guard_autodispatch_count
 	guard_pr_count=$(gh_pr_list --repo "$repo_slug" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
 	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
 		--assignee "$runner_user" --state open \
+		--json number --jq 'length' 2>/dev/null || echo "0")
+	guard_autodispatch_count=$(gh_issue_list --repo "$repo_slug" \
+		--label "auto-dispatch" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
 
 	local _guard_fields=()
@@ -116,8 +119,8 @@ _check_health_issue_activity_guard() {
 	done < <(_scan_active_workers "${repo_path:-}")
 	guard_worker_count="${_guard_fields[1]:-0}"
 
-	if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 ]]; then
-		echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, issues, or workers" \
+	if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 && "${guard_autodispatch_count:-0}" -eq 0 ]]; then
+		echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, issues, workers, or auto-dispatch work" \
 			>>"${LOGFILE:-/dev/null}"
 		return 1
 	fi


### PR DESCRIPTION
Resolves #68

## What

Fix two independent bugs causing supervisor health dashboard staleness:

1. **Activity guard expansion**: The activity guard in `stats-health-dashboard.sh` now checks for `auto-dispatch` issues, so the dashboard updates when queued work exists even without active workers.

2. **REST fallback trigger fix**: The REST fallback trigger in `shared-gh-wrappers-rest-fallback.sh` now activates when `gh api rate_limit` itself fails with HTTP 403 (empty `remaining`), treating it as API exhaustion.

## How

### Fix 1: Activity guard expansion
- Modified `_check_health_issue_activity_guard` in `stats-health-dashboard.sh`
- Added check for `auto-dispatch` labeled issues using `gh_issue_list --label "auto-dispatch"`
- Updated guard condition to include `guard_autodispatch_count` in the activity check

### Fix 2: REST fallback trigger
- Modified `_rest_should_fallback` in `shared-gh-wrappers-rest-fallback.sh`
- Added check for empty `remaining` value before the numeric validation
- When `remaining` is empty, return 0 (trigger fallback) instead of 1 (skip fallback)

## Verification

- ✅ Activity guard now includes auto-dispatch label check
- ✅ REST fallback triggers on empty remaining value
- ✅ Pre-commit checks passed (ShellCheck, ratchets, return statements)
- ✅ Both fixes follow existing code patterns and conventions

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.3 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-haiku-4-5 spent 2m and 5,952 tokens on this as a headless worker.