### PR TITLE
GH#23854: fix release assignee cleanup

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -772,6 +772,7 @@ _dsi_build_prompt() {
 #   $8 - worker_log path
 #   $9 - issue_number
 #   $10 - repo_slug
+#   $11 - self_login (dispatching GitHub login)
 # Stdout (on success): worker PID (single line)
 # Returns: 0 launched, 1 failed
 #######################################
@@ -786,12 +787,14 @@ _dsi_launch_worker() {
 	local worker_log="$8"
 	local issue_number="$9"
 	local repo_slug="${10:-}"
+	local self_login="${11:-}"
 
 	local -a cmd=(
 		env
 		HEADLESS=1
 		FULL_LOOP_HEADLESS=true
 		WORKER_ISSUE_NUMBER="$issue_number"
+		WORKER_GITHUB_LOGIN="$self_login"
 		WORKER_WORKTREE_PATH="$worktree_path"
 		WORKER_REPO_SLUG="$repo_slug"
 		GITHUB_REPOSITORY="$repo_slug"
@@ -1062,7 +1065,7 @@ _dsi_dispatch_after_dedup_clear() {
 	# Steps 8-10 + report: launch worker, resolve real PID, register ledger,
 	# print success summary. Extracted to keep cmd_dispatch under the 100-line
 	# function-complexity gate (t3000).
-	if ! _dsi_launch_and_report "$issue_number" "$repo_slug" "$session_key"; then
+	if ! _dsi_launch_and_report "$issue_number" "$repo_slug" "$self_login" "$session_key"; then
 		_dsi_reset_after_prelaunch_failure "$issue_number" "$repo_slug" "$self_login" "worker_launch_failed"
 		return 1
 	fi
@@ -1111,13 +1114,15 @@ _dsi_reset_after_prelaunch_failure() {
 # Args:
 #   $1 issue_number
 #   $2 repo_slug
-#   $3 session_key
+#   $3 self_login
+#   $4 session_key
 # Reads: _DSI_ISSUE_URL, _DSI_LOG_DIR, _DSI_WORKTREE_PATH, _DSI_ISSUE_TITLE,
 #        _DSI_TIER, _DSI_SELECTED_MODEL, _DSI_ARG_AGENT.
 _dsi_launch_and_report() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	local session_key="$3"
+	local self_login="$3"
+	local session_key="$4"
 
 	local prompt worker_log
 	prompt=$(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")
@@ -1126,7 +1131,7 @@ _dsi_launch_and_report() {
 	launch_pid=$(_dsi_launch_worker \
 		"$session_key" "$_DSI_WORKTREE_PATH" "$_DSI_ISSUE_TITLE" \
 		"$prompt" "$_DSI_TIER" "$_DSI_SELECTED_MODEL" \
-		"$_DSI_ARG_AGENT" "$worker_log" "$issue_number" "$repo_slug") || return 1
+		"$_DSI_ARG_AGENT" "$worker_log" "$issue_number" "$repo_slug" "$self_login") || return 1
 
 	local worker_pid
 	worker_pid=$(_dsi_resolve_worker_pid "$worker_log" "$launch_pid")

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -336,7 +336,7 @@ _release_dispatch_claim() {
 			# GitHub issue is not stranded in an active lifecycle state, but skip
 			# the duplicate CLAIM_RELEASED audit comment that caused storms.
 			local _rl_runner_name=""
-			_rl_runner_name=$(whoami)
+			_rl_runner_name=$(_hrff_resolve_release_runner_login)
 			if declare -F clear_active_status_on_release >/dev/null 2>&1; then
 				clear_active_status_on_release "$issue_number" "$repo_slug" "$_rl_runner_name" \
 					|| print_warning "Failed to clear active status on #${issue_number} (non-fatal)"
@@ -356,7 +356,7 @@ _release_dispatch_claim() {
 	fi
 
 	local runner_name=""
-	runner_name=$(whoami)
+	runner_name=$(_hrff_resolve_release_runner_login)
 	local release_ts=""
 	release_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	local machine_readable_part="CLAIM_RELEASED reason=${reason} runner=${runner_name} ts=${release_ts} aidevops_version=${aidevops_version} opencode_version=${opencode_version}"
@@ -391,6 +391,35 @@ ${machine_readable_part}
 			|| print_warning "Failed to clear active status on #${issue_number} (non-fatal)"
 	fi
 	_unlock_issue_after_dispatch_release "$issue_number" "$repo_slug"
+	return 0
+}
+
+#######################################
+# Resolve the GitHub login whose dispatch claim should be released.
+# Prefer the identity captured by the dispatcher because the local OS user can
+# differ from the GitHub assignee in bot/cross-account worker setups (GH#23854).
+# Globals:
+#   WORKER_GITHUB_LOGIN, AIDEVOPS_WORKER_GITHUB_LOGIN
+# Outputs:
+#   GitHub login or OS username fallback.
+#######################################
+_hrff_resolve_release_runner_login() {
+	local runner_login="${WORKER_GITHUB_LOGIN:-${AIDEVOPS_WORKER_GITHUB_LOGIN:-}}"
+	if [[ -n "$runner_login" ]]; then
+		printf '%s\n' "$runner_login"
+		return 0
+	fi
+
+	if command -v gh >/dev/null 2>&1; then
+		runner_login=$(gh api user --jq .login 2>/dev/null || true)
+		if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+			printf '%s\n' "$runner_login"
+			return 0
+		fi
+	fi
+
+	runner_login=$(whoami)
+	printf '%s\n' "$runner_login"
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1316,6 +1316,7 @@ _dlw_nohup_launch() {
 		AIDEVOPS_SESSION_ORIGIN=worker
 		AIDEVOPS_HEADLESS=true
 		WORKER_ISSUE_NUMBER="$issue_number"
+		WORKER_GITHUB_LOGIN="$self_login"
 		AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1
 	)
 	if _dlw_min_worker_floor_active; then

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -589,6 +589,16 @@ test_launch_worker_forwards_repo_contract() {
 	return 0
 }
 
+test_launch_worker_forwards_github_login() {
+	local failed=1
+	if grep -Fq "WORKER_GITHUB_LOGIN=\"\$self_login\"" "$HELPER_PATH" &&
+		grep -Fq "_dsi_launch_and_report \"\$issue_number\" \"\$repo_slug\" \"\$self_login\" \"\$session_key\"" "$HELPER_PATH"; then
+		failed=0
+	fi
+	print_result "worker launch forwards dispatching GitHub login" "$failed"
+	return 0
+}
+
 test_create_worktree_uses_target_repo_path() {
 	local failed=1
 	if grep -Fq "repo_path=\$(_dsi_repo_path_for_slug \"\$repo_slug\")" "$HELPER_PATH" &&
@@ -818,6 +828,7 @@ _run_tests() {
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract
+	test_launch_worker_forwards_github_login
 	test_create_worktree_uses_target_repo_path
 	test_create_worktree_registers_dispatch_owner
 	test_create_worktree_registration_warns_on_failure

--- a/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
+++ b/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
@@ -40,6 +40,11 @@ clear_active_status_on_release() {
 	return 0
 }
 
+whoami() {
+	printf 'local-os-user\n'
+	return 0
+}
+
 gh() {
 	local cmd="${1:-}"
 	shift || true
@@ -47,6 +52,10 @@ gh() {
 	api)
 		local path="${1:-}"
 		shift || true
+		if [[ "$path" == "user" ]]; then
+			printf 'api-login\n'
+			return 0
+		fi
 		local method="GET" body="" prev=""
 		local arg
 		for arg in "$@"; do
@@ -97,12 +106,15 @@ printf 'PASS empty non-worker claim release is a silent no-op\n'
 : >"$CALL_LOG"
 
 export DISPATCH_REPO_SLUG="owner/repo"
+export WORKER_GITHUB_LOGIN="assigned-bot"
 _release_dispatch_claim "issue-12345" "worker_noop" "0" "0"
 
 if grep -q 'CLAIM_RELEASED reason=worker_noop' "$CALL_LOG" &&
-	grep -q 'CLEAR issue=12345 repo=owner/repo' "$CALL_LOG" &&
+	grep -q 'CLEAR issue=12345 repo=owner/repo runner=assigned-bot' "$CALL_LOG" &&
+	grep -q 'runner=assigned-bot' "$CALL_LOG" &&
+	! grep -q 'runner=local-os-user' "$CALL_LOG" &&
 	grep -q 'UNLOCK issue=12345 repo=owner/repo' "$CALL_LOG"; then
-	printf 'PASS release posts claim, clears status, and unlocks issue\n'
+	printf 'PASS release posts claim, clears assigned GitHub login, and unlocks issue\n'
 	exit 0
 fi
 

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -88,6 +88,10 @@ if [[ "$(_dlw_zero_output_evidence_count 123 owner/repo "" 7)" != "7" ]]; then
 	fail "precomputed zero-output evidence count was not returned directly"
 fi
 
+if ! grep -Fq "WORKER_GITHUB_LOGIN=\"\$self_login\"" "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"; then
+	fail "pulse worker launch does not forward dispatching GitHub login"
+fi
+
 mkdir -p "${TEST_TMP}/bin" || fail "failed to create systemctl stub dir"
 cat >"${TEST_TMP}/bin/systemctl" <<'EOF'
 #!/usr/bin/env bash
@@ -108,5 +112,6 @@ printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
 printf 'PASS: root node_modules payload is skipped by default\n'
 printf 'PASS: root node_modules .bin tooling is linked by default\n'
 printf 'PASS: precomputed zero-output evidence count skips redundant lookups\n'
+printf 'PASS: pulse worker launch forwards dispatching GitHub login\n'
 printf 'PASS: systemd PID resolver handles final unterminated property\n'
 exit 0


### PR DESCRIPTION
## Summary
- propagate the dispatching GitHub login into pulse and manual worker launch env as `WORKER_GITHUB_LOGIN`
- release worker claims using the propagated GitHub login, falling back to `gh api user --jq .login` then `whoami`
- add regression coverage for GitHub-login-vs-OS-username mismatch and launch env propagation

Resolves #23854

## Verification
- `bash .agents/scripts/tests/test-headless-runtime-release-unlock.sh`
- `bash .agents/scripts/tests/test-claim-release-label-mutation.sh`
- `bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `shellcheck .agents/scripts/headless-runtime-failure.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-headless-runtime-release-unlock.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `.agents/scripts/linters-local.sh` (passed; advisory pre-existing markdown/ratchet/layout/complexity warnings reported by the script)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.3 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 49m and 150,863 tokens on this with the user in an interactive session.
