### PR TITLE
For #23854: keep triage prelaunch failures retryable

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1920,12 +1920,12 @@ show_help() {
 headless-runtime-helper.sh - Model-aware headless runtime (OpenCode default, Claude CLI opt-in)
 
 Usage:
-  headless-runtime-helper.sh select [--role pulse|worker] [--model provider/model]
-  headless-runtime-helper.sh canary [--role pulse|worker] [--model provider/model] [--tier haiku|sonnet|opus|...]
-  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model | --initial-model provider/model] [--tier haiku|sonnet|opus|...] [--variant NAME] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
+  headless-runtime-helper.sh select [--role pulse|worker|triage] [--model provider/model]
+  headless-runtime-helper.sh canary [--role pulse|worker|triage] [--model provider/model] [--tier haiku|sonnet|opus|...]
+  headless-runtime-helper.sh run --role pulse|worker|triage --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model | --initial-model provider/model] [--tier haiku|sonnet|opus|...] [--variant NAME] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
-  headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING] [--fast-threshold N]
+  headless-runtime-helper.sh metrics [--role pulse|worker|triage] [--hours N] [--model SUBSTRING] [--fast-threshold N]
   headless-runtime-helper.sh help
 
 Runtime selection:

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -334,6 +334,51 @@ sys.stdout.write(text)
 }
 
 #######################################
+# Classify headless-runtime failures that happen before a triage model can
+# produce a review. These are infrastructure/contract failures, not review
+# content failures, so they must not consume the triage retry/cache budget.
+#
+# Arguments:
+#   $1 - raw runtime output sample
+#
+# Outputs the infrastructure failure reason, or nothing when not recognised.
+# Returns 0 always.
+#######################################
+_triage_runtime_infra_failure_reason() {
+	local sample="$1"
+
+	if printf '%s' "$sample" | grep -qE 'Canary test FAILED|Canary failed.*aborting dispatch' 2>/dev/null; then
+		printf '%s\n' 'canary-unavailable'
+		return 0
+	fi
+
+	if printf '%s' "$sample" | grep -qE 'WORKER_ISSUE_NUMBER unset|WORKER_WORKTREE_PATH unset|issue worker env contract missing|worker --dir does not match WORKER_WORKTREE_PATH|worker worktree repo mismatch' 2>/dev/null; then
+		printf '%s\n' 'prelaunch-contract-failure'
+		return 0
+	fi
+
+	return 0
+}
+
+#######################################
+# Return whether a triage failure reason is infrastructure-only. Keep this
+# centralised so label/cache/retry policy cannot drift across call sites.
+#
+# Arguments:
+#   $1 - failure reason tag
+#
+# Returns 0 when infrastructure-only, 1 otherwise.
+#######################################
+_triage_failure_is_infrastructure() {
+	local failure_reason="$1"
+
+	case "$failure_reason" in
+	canary-unavailable | prelaunch-contract-failure) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+#######################################
 # Append a debug record for a suppressed triage review output. Writes
 # the first 1000 chars (redacted) of the output along with metadata
 # to ~/.aidevops/logs/triage-review-debug.log so future failures can
@@ -889,13 +934,13 @@ _finalize_triage_state() {
 	# can identify issues needing manual triage; remove on success.
 	# t2016: Ensure the label exists first (gh label create --force is
 	# idempotent) and only log "Added" when the add command succeeds.
-	# t2089: canary-unavailable is an infrastructure failure, not a triage
-	# failure — do NOT apply triage-failed; leave the issue in its current
-	# state so the next cycle retries transparently.
+	# t2089/GH#23854: infrastructure failures are not triage content failures —
+	# do NOT apply triage-failed; leave the issue in its current state so the
+	# next cycle retries transparently.
 	if [[ "$triage_posted" == "true" ]]; then
 		gh issue edit "$issue_num" --repo "$repo_slug" \
 			--remove-label "triage-failed" >/dev/null 2>&1 || true
-	elif [[ "$failure_reason" != "canary-unavailable" ]]; then
+	elif ! _triage_failure_is_infrastructure "$failure_reason"; then
 		_ensure_triage_failed_label "$repo_slug"
 		if gh issue edit "$issue_num" --repo "$repo_slug" \
 			--add-label "triage-failed" >/dev/null 2>&1; then
@@ -915,14 +960,14 @@ _finalize_triage_state() {
 	# t2016: When the retry cap is hit, post a structured escalation comment
 	# BEFORE writing the cache, so the maintainer has a visible signal
 	# instead of a silently-cached issue that disappears from triage forever.
-	# t2089: canary-unavailable skips BOTH the retry counter AND the cache
-	# write — the issue content hasn't changed; the infrastructure was just
-	# unavailable. Incrementing the counter would cause the next canary
-	# failure to hit the cap and permanently lock the issue out of triage.
+	# t2089/GH#23854: infrastructure failures skip BOTH the retry counter AND the
+	# cache write — the issue content hasn't changed; the runtime/contract was
+	# unavailable. Incrementing the counter would cause the next infra failure
+	# to hit the cap and permanently lock the issue out of triage.
 	if [[ "$triage_posted" == "true" ]]; then
 		_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
-	elif [[ "$failure_reason" == "canary-unavailable" ]]; then
-		echo "[pulse-wrapper] Triage skipped for #${issue_num} — canary unavailable, will retry next cycle without consuming retry budget (t2089)" >>"$LOGFILE"
+	elif _triage_failure_is_infrastructure "$failure_reason"; then
+		echo "[pulse-wrapper] Triage skipped for #${issue_num} — ${failure_reason}, will retry next cycle without consuming retry budget (GH#23854)" >>"$LOGFILE"
 	elif _triage_increment_failure "$issue_num" "$repo_slug" "$content_hash"; then
 		echo "[pulse-wrapper] Triage retry cap reached for #${issue_num} in ${repo_slug} — caching hash to stop lock/unlock loop (GH#17827)" >>"$LOGFILE"
 		local cap_attempts="${TRIAGE_MAX_RETRIES:-1}"
@@ -965,10 +1010,6 @@ _dispatch_triage_review_worker() {
 	local model_flag=""
 	[[ -n "$resolved_model" ]] && model_flag="--model $resolved_model"
 
-	# t2089: Named pattern for canary-failure detection (see usage below).
-	# Centralised here so future canary exit messages only need one update.
-	local canary_failure_pattern='Canary test FAILED|Canary failed.*aborting dispatch'
-
 	# ── Launch sandboxed agent (no Bash, no gh, no network) ──
 	# t2019: We now pass `--agent triage-review` explicitly. Before this
 	# fix the flag was omitted, so:
@@ -988,16 +1029,18 @@ _dispatch_triage_review_worker() {
 	# t1894/t1934: Lock issue and linked PRs during triage
 	lock_issue_for_worker "$issue_num" "$repo_slug"
 
-	# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep
+	# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep.
+	# Use a distinct role so the implementation-worker issue/worktree contract
+	# does not reject triage sessions before model launch (GH#23854).
 	# shellcheck disable=SC2086
 	"$HEADLESS_RUNTIME_HELPER" run \
-		--role worker \
+		--role triage \
 		--session-key "triage-review-${issue_num}" \
 		--dir "$repo_path" \
 		$model_flag \
 		--agent triage-review \
 		--title "Sandboxed triage review: Issue #${issue_num}" \
-		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1
+		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
 
 	rm -f "$prefetch_file"
 
@@ -1021,19 +1064,13 @@ _dispatch_triage_review_worker() {
 		raw_sample=$(head -c 1000 "$review_output_file" 2>/dev/null || true)
 	fi
 
-	# t2089: Detect canary failure BEFORE calling the safety filter.
-	# When the headless runtime aborts due to a failed canary test (exit=142
-	# timeout, credit exhaustion, port conflict, etc.), the output is infra
-	# log lines with no review header. The safety filter correctly classifies
-	# this as raw-sandbox-output, but that causes _finalize_triage_state to
-	# increment the retry counter and — after TRIAGE_MAX_RETRIES — cache the
-	# content hash, permanently locking the issue out of the triage queue.
-	# Infrastructure unavailability is NOT a triage failure: the issue itself
-	# is fine. Detect it early and route to a separate non-counting path.
-	local canary_failed="false"
-	if printf '%s' "$raw_sample" | grep -qE "$canary_failure_pattern" 2>/dev/null; then
-		canary_failed="true"
-		echo "[pulse-wrapper] Triage canary failed for #${issue_num} in ${repo_slug} — infrastructure unavailability, not a review failure (t2089)" >>"$LOGFILE"
+	# t2089/GH#23854: Detect runtime/prelaunch failures BEFORE finalising triage
+	# state. The safety filter must still suppress any output, but infra
+	# failures must not consume retry budget or cache the content hash.
+	local infra_failure_reason=""
+	infra_failure_reason=$(_triage_runtime_infra_failure_reason "$raw_sample")
+	if [[ -n "$infra_failure_reason" ]]; then
+		echo "[pulse-wrapper] Triage runtime failure for #${issue_num} in ${repo_slug}: ${infra_failure_reason} — infrastructure/contract failure, not a review failure (GH#23854)" >>"$LOGFILE"
 	fi
 
 	# Validate output safety and post or suppress the review comment.
@@ -1048,10 +1085,10 @@ _dispatch_triage_review_worker() {
 	local failure_reason=""
 	if [[ "$post_result" == "POSTED" ]]; then
 		triage_posted="true"
-	elif [[ "$canary_failed" == "true" ]]; then
-		# Canary unavailability overrides the safety-filter result.
+	elif [[ -n "$infra_failure_reason" ]]; then
+		# Infrastructure/contract failures override the safety-filter result.
 		# Route to the infra-failure path — skip retry counter and cache.
-		failure_reason="canary-unavailable"
+		failure_reason="$infra_failure_reason"
 	else
 		failure_reason="${post_result#FAILED:}"
 	fi

--- a/.agents/scripts/tests/test-triage-output-shape.sh
+++ b/.agents/scripts/tests/test-triage-output-shape.sh
@@ -34,6 +34,8 @@ TEST_ROOT=""
 ORIGINAL_HOME="${HOME}"
 GH_CALL_LOG=""
 LOGFILE=""
+HEADLESS_INVOCATION_LOG=""
+TRIAGE_CACHE_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -60,6 +62,10 @@ setup_test_env() {
 	: >"$LOGFILE"
 	GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_CALL_LOG"
+	HEADLESS_INVOCATION_LOG="${TEST_ROOT}/headless-invocations.log"
+	: >"$HEADLESS_INVOCATION_LOG"
+	TRIAGE_CACHE_LOG="${TEST_ROOT}/triage-cache.log"
+	: >"$TRIAGE_CACHE_LOG"
 	return 0
 }
 
@@ -99,8 +105,8 @@ export -f gh
 # can be invoked directly without sourcing the full pulse-wrapper boot.
 _triage_content_hash() { printf 'deadbeef\n'; }
 _triage_is_cached() { return 1; }
-_triage_update_cache() { return 0; }
-_triage_increment_failure() { return 1; }
+_triage_update_cache() { printf 'update %s %s %s\n' "$1" "$2" "$3" >>"$TRIAGE_CACHE_LOG"; return 0; }
+_triage_increment_failure() { printf 'increment %s %s %s\n' "$1" "$2" "$3" >>"$TRIAGE_CACHE_LOG"; return 1; }
 _triage_awaiting_contributor_reply() { return 1; }
 lock_issue_for_worker() { return 0; }
 unlock_issue_after_worker() { return 0; }
@@ -189,8 +195,23 @@ _install_headless_stub() {
 #!/usr/bin/env bash
 # Test stub: concatenate the payload to stdout so the caller's
 # >"\$review_output_file" 2>&1 captures it.
+printf '%s\n' "\$*" >>"${HEADLESS_INVOCATION_LOG}"
 cat "${payload_file}"
 exit 0
+STUB_EOF
+	chmod +x "$HEADLESS_RUNTIME_HELPER"
+	return 0
+}
+
+_install_headless_contract_failure_stub() {
+	local stub_dir="${TEST_ROOT}/stubs"
+	mkdir -p "$stub_dir"
+	export HEADLESS_RUNTIME_HELPER="${stub_dir}/headless-runtime-helper.sh"
+	cat >"$HEADLESS_RUNTIME_HELPER" <<STUB_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"${HEADLESS_INVOCATION_LOG}"
+printf '%b\n' '\033[0;31m[ERROR]\033[0m [fatal] WORKER_ISSUE_NUMBER unset — issue worker env contract missing; aborting before model launch'
+exit 1
 STUB_EOF
 	chmod +x "$HEADLESS_RUNTIME_HELPER"
 	return 0
@@ -347,6 +368,12 @@ test_dispatch_accepts_clean_review_in_json() {
 			"gh call log (last lines):
 $(tail -5 "$GH_CALL_LOG")"
 	fi
+	if grep -q -- '--role triage' "$HEADLESS_INVOCATION_LOG"; then
+		print_result "triage dispatch uses distinct triage role" 0
+	else
+		print_result "triage dispatch uses distinct triage role" 1 \
+			"headless invocation log:\n$(cat "$HEADLESS_INVOCATION_LOG")"
+	fi
 	teardown_test_env
 }
 
@@ -479,6 +506,49 @@ $(cat "$debug_log" 2>/dev/null || echo "<missing>")"
 	teardown_test_env
 }
 
+test_prelaunch_contract_failure_is_infrastructure() {
+	setup_test_env
+	load_helpers_under_test
+	_install_headless_contract_failure_stub
+
+	local prompt_file="${TEST_ROOT}/prompt.txt"
+	printf 'test prompt\n' >"$prompt_file"
+
+	_dispatch_triage_review_worker \
+		"23854" "owner/repo" "/tmp/repo" "$prompt_file" "hash-contract" "" \
+		2>/dev/null
+
+	local debug_log="${HOME}/.aidevops/logs/triage-review-debug.log"
+	if [[ -f "$debug_log" ]] && grep -q 'failure_reason: no-review-header' "$debug_log"; then
+		print_result "prelaunch contract output is still suppressed by safety filter" 0
+	else
+		print_result "prelaunch contract output is still suppressed by safety filter" 1 \
+			"debug log content:\n$(cat "$debug_log" 2>/dev/null || echo "<missing>")"
+	fi
+
+	if grep -q 'prelaunch-contract-failure' "$LOGFILE"; then
+		print_result "prelaunch contract failure is classified as infrastructure" 0
+	else
+		print_result "prelaunch contract failure is classified as infrastructure" 1 \
+			"LOGFILE:\n$(cat "$LOGFILE")"
+	fi
+
+	if [[ ! -s "$TRIAGE_CACHE_LOG" ]]; then
+		print_result "prelaunch infrastructure failure does not consume triage cache or retry" 0
+	else
+		print_result "prelaunch infrastructure failure does not consume triage cache or retry" 1 \
+			"cache log:\n$(cat "$TRIAGE_CACHE_LOG")"
+	fi
+
+	if ! grep -q -- '--add-label triage-failed' "$GH_CALL_LOG"; then
+		print_result "prelaunch infrastructure failure does not add triage-failed" 0
+	else
+		print_result "prelaunch infrastructure failure does not add triage-failed" 1 \
+			"gh calls:\n$(cat "$GH_CALL_LOG")"
+	fi
+	teardown_test_env
+}
+
 test_post_escalation_handles_oversized_reason() {
 	setup_test_env
 	load_helpers_under_test
@@ -516,6 +586,7 @@ main() {
 	test_dispatch_suppresses_oversized_output
 	test_dispatch_suppresses_headerless_json_output
 	test_dispatch_suppresses_raw_sandbox_output
+	test_prelaunch_contract_failure_is_infrastructure
 	test_post_escalation_handles_oversized_reason
 
 	echo ""


### PR DESCRIPTION
## Summary

For #23854.

- run sandboxed triage reviews under a distinct `triage` headless role so implementation-worker issue/worktree contract checks cannot abort them before model launch
- centralize triage infrastructure-failure classification and cache/retry policy so canary and prelaunch contract failures stay retryable instead of receiving `triage-failed`/content-hash cache entries
- add regression coverage for the GH#23854 prelaunch failure shape and document `triage` as a supported headless role

## Verification

- `.agents/scripts/tests/test-triage-output-shape.sh`
- `.agents/scripts/tests/test-triage-failure-escalation.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-triage-output-shape.sh`
- `.agents/scripts/linters-local.sh` started twice; targeted gates above passed, broader run timed out after reporting only pre-existing/advisory Markdown/ratchet/layout warnings before shell portability completed.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.4 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 19m and 316,749 tokens on this with the user in an interactive session.