### PR TITLE
fix: harden release runner login lookup

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -411,7 +411,7 @@ _hrff_resolve_release_runner_login() {
 	fi
 
 	if command -v gh >/dev/null 2>&1; then
-		runner_login=$(gh api user --jq .login 2>/dev/null || true)
+		runner_login=$(gh api user --jq '.login // ""' || true)
 		if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
 			printf '%s\n' "$runner_login"
 			return 0


### PR DESCRIPTION
## Summary
- Resolve issue #23888 by updating `.agents/scripts/headless-runtime-failure.sh` runner login discovery.
- Use `gh api user --jq '.login // ""'` so missing/null login values become empty output.
- Remove stderr suppression so GitHub CLI or jq failures remain diagnosable while the existing fallback still handles invalid/empty output.

## Testing
- `shellcheck .agents/scripts/headless-runtime-failure.sh`
- Pre-commit hook during WIP commit

Resolves #23888

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.10 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 2m and 37,720 tokens on this as a headless worker.
