### PR TITLE
GH#23887: preserve triage runtime context

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -352,7 +352,7 @@ _triage_runtime_infra_failure_reason() {
 		return 0
 	fi
 
-	if printf '%s' "$sample" | grep -qE 'WORKER_ISSUE_NUMBER unset|WORKER_WORKTREE_PATH unset|issue worker env contract missing|worker --dir does not match WORKER_WORKTREE_PATH|worker worktree repo mismatch' 2>/dev/null; then
+	if printf '%s' "$sample" | grep -qE 'WORKER_ISSUE_NUMBER unset|WORKER_WORKTREE_PATH unset|worker env contract missing|worker --dir does not match WORKER_WORKTREE_PATH|worker worktree repo mismatch|WORKER_WORKTREE_PATH does not exist|OpenCode version drift|Failed to restore OpenCode|opencode version mismatch|launch cwd is deleted' 2>/dev/null; then
 		printf '%s\n' 'prelaunch-contract-failure'
 		return 0
 	fi
@@ -1032,15 +1032,20 @@ _dispatch_triage_review_worker() {
 	# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep.
 	# Use a distinct role so the implementation-worker issue/worktree contract
 	# does not reject triage sessions before model launch (GH#23854).
-	# shellcheck disable=SC2086
-	"$HEADLESS_RUNTIME_HELPER" run \
-		--role triage \
-		--session-key "triage-review-${issue_num}" \
-		--dir "$repo_path" \
-		$model_flag \
-		--agent triage-review \
-		--title "Sandboxed triage review: Issue #${issue_num}" \
-		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
+	if [[ -n "$issue_num" && -n "$repo_slug" && -n "$repo_path" ]]; then
+		# shellcheck disable=SC2086
+		env HEADLESS=1 WORKER_ISSUE_NUMBER="$issue_num" WORKER_REPO_SLUG="$repo_slug" WORKER_WORKTREE_PATH="$repo_path" \
+			"$HEADLESS_RUNTIME_HELPER" run \
+			--role triage \
+			--session-key "triage-review-${issue_num}" \
+			--dir "$repo_path" \
+			$model_flag \
+			--agent triage-review \
+			--title "Sandboxed triage review: Issue #${issue_num}" \
+			--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
+	else
+		printf '%s\n' '[fatal] triage worker env contract missing; aborting before model launch' >"$review_output_file"
+	fi
 
 	rm -f "$prefetch_file"
 

--- a/.agents/scripts/tests/test-triage-output-shape.sh
+++ b/.agents/scripts/tests/test-triage-output-shape.sh
@@ -196,6 +196,7 @@ _install_headless_stub() {
 # Test stub: concatenate the payload to stdout so the caller's
 # >"\$review_output_file" 2>&1 captures it.
 printf '%s\n' "\$*" >>"${HEADLESS_INVOCATION_LOG}"
+printf 'env HEADLESS=%s WORKER_ISSUE_NUMBER=%s WORKER_REPO_SLUG=%s WORKER_WORKTREE_PATH=%s\n' "\${HEADLESS:-}" "\${WORKER_ISSUE_NUMBER:-}" "\${WORKER_REPO_SLUG:-}" "\${WORKER_WORKTREE_PATH:-}" >>"${HEADLESS_INVOCATION_LOG}"
 cat "${payload_file}"
 exit 0
 STUB_EOF
@@ -373,6 +374,37 @@ $(tail -5 "$GH_CALL_LOG")"
 	else
 		print_result "triage dispatch uses distinct triage role" 1 \
 			"headless invocation log:\n$(cat "$HEADLESS_INVOCATION_LOG")"
+	fi
+	if grep -q 'env HEADLESS=1 WORKER_ISSUE_NUMBER=18400 WORKER_REPO_SLUG=owner/repo WORKER_WORKTREE_PATH=/tmp/repo' "$HEADLESS_INVOCATION_LOG"; then
+		print_result "triage dispatch exports standard worker environment" 0
+	else
+		print_result "triage dispatch exports standard worker environment" 1 \
+			"headless invocation log:\n$(cat "$HEADLESS_INVOCATION_LOG")"
+	fi
+	teardown_test_env
+}
+
+test_prelaunch_classifier_covers_runtime_guard_modes() {
+	setup_test_env
+	load_helpers_under_test
+
+	local ok=0
+	local sample=""
+	local reason=""
+	for sample in \
+		'[fatal] WORKER_WORKTREE_PATH does not exist: /tmp/missing' \
+		'[WARN] OpenCode version drift: installed=1.2.3, pin=1.2.4 -- reinstalling' \
+		'[fatal] opencode version mismatch: expected pinned runtime' \
+		'[fatal] launch cwd is deleted and no valid fallback directory is available'; do
+		reason=$(_triage_runtime_infra_failure_reason "$sample")
+		[[ "$reason" == 'prelaunch-contract-failure' ]] || ok=1
+	done
+
+	if [[ "$ok" -eq 0 ]]; then
+		print_result "prelaunch classifier covers runtime guard failure modes" 0
+	else
+		print_result "prelaunch classifier covers runtime guard failure modes" 1 \
+			"last sample='${sample}' reason='${reason}'"
 	fi
 	teardown_test_env
 }
@@ -586,6 +618,7 @@ main() {
 	test_dispatch_suppresses_oversized_output
 	test_dispatch_suppresses_headerless_json_output
 	test_dispatch_suppresses_raw_sandbox_output
+	test_prelaunch_classifier_covers_runtime_guard_modes
 	test_prelaunch_contract_failure_is_infrastructure
 	test_post_escalation_handles_oversized_reason
 


### PR DESCRIPTION
## Summary

Expanded triage prelaunch infrastructure classification and exported standard worker environment values when launching triage review workers.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/tests/test-triage-output-shape.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-triage-output-shape.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-triage-output-shape.sh

Resolves #23887


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.10 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 3m and 67,256 tokens on this as a headless worker.