### PR TITLE
GH#23887: reduce triage dispatch complexity

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -982,6 +982,45 @@ _finalize_triage_state() {
 }
 
 #######################################
+# Run the headless triage-review worker with the standard worker context.
+#
+# Arguments:
+#   $1 - issue_num
+#   $2 - repo_slug
+#   $3 - repo_path
+#   $4 - resolved model flag (empty or "--model ...")
+#   $5 - prompt file
+#   $6 - output file
+#
+# Exit code: always 0; runtime failures are captured in the output file.
+#######################################
+_run_triage_review_worker() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local repo_path="$3"
+	local model_flag="$4"
+	local prefetch_file="$5"
+	local review_output_file="$6"
+
+	if [[ -n "$issue_num" && -n "$repo_slug" && -n "$repo_path" ]]; then
+		# shellcheck disable=SC2086
+		env HEADLESS=1 WORKER_ISSUE_NUMBER="$issue_num" WORKER_REPO_SLUG="$repo_slug" WORKER_WORKTREE_PATH="$repo_path" \
+			"$HEADLESS_RUNTIME_HELPER" run \
+			--role triage \
+			--session-key "triage-review-${issue_num}" \
+			--dir "$repo_path" \
+			$model_flag \
+			--agent triage-review \
+			--title "Sandboxed triage review: Issue #${issue_num}" \
+			--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
+	else
+		printf '%s\n' '[fatal] triage worker env contract missing; aborting before model launch' >"$review_output_file"
+	fi
+
+	return 0
+}
+
+#######################################
 # Dispatch a sandboxed triage review worker and post its output
 #
 # Locks the issue, runs the triage-review agent, posts the review
@@ -1032,20 +1071,9 @@ _dispatch_triage_review_worker() {
 	# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep.
 	# Use a distinct role so the implementation-worker issue/worktree contract
 	# does not reject triage sessions before model launch (GH#23854).
-	if [[ -n "$issue_num" && -n "$repo_slug" && -n "$repo_path" ]]; then
-		# shellcheck disable=SC2086
-		env HEADLESS=1 WORKER_ISSUE_NUMBER="$issue_num" WORKER_REPO_SLUG="$repo_slug" WORKER_WORKTREE_PATH="$repo_path" \
-			"$HEADLESS_RUNTIME_HELPER" run \
-			--role triage \
-			--session-key "triage-review-${issue_num}" \
-			--dir "$repo_path" \
-			$model_flag \
-			--agent triage-review \
-			--title "Sandboxed triage review: Issue #${issue_num}" \
-			--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
-	else
-		printf '%s\n' '[fatal] triage worker env contract missing; aborting before model launch' >"$review_output_file"
-	fi
+	_run_triage_review_worker \
+		"$issue_num" "$repo_slug" "$repo_path" \
+		"$model_flag" "$prefetch_file" "$review_output_file"
 
 	rm -f "$prefetch_file"
 


### PR DESCRIPTION
## Summary

- Extract `_run_triage_review_worker` from `_dispatch_triage_review_worker` to clear the post-merge function-complexity regression from PR #23896.
- Preserve the triage runtime-context behavior added for #23887.

## Testing

- `bash .agents/scripts/tests/test-triage-output-shape.sh` (19/19 passed)
- `shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-triage-output-shape.sh` (clean)
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --output-md /tmp/complexity-repair-report.md` (base: 2, head: 1, new: 0)

## Runtime Testing

- self-assessed: shell helper refactor covered by targeted unit and static checks.

For #23887

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.10 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 7m and 93,871 tokens on this as a headless worker.
