### PR TITLE
GH#23894: docs: clarify ObscuraVPN related agent tiers

### DIFF
--- a/.agents/services/networking/obscuravpn.md
+++ b/.agents/services/networking/obscuravpn.md
@@ -120,9 +120,11 @@ When reviewing Obscura claims, verify against source or first-party docs before 
 
 | Resource | Path | Purpose |
 |----------|------|---------|
-| NetBird | `services/networking/netbird.md` | Self-hosted WireGuard mesh VPN and worker access. |
-| Tailscale | `services/networking/tailscale.md` | Managed mesh VPN, Serve/Funnel, secure private access. |
-| OPSEC | `tools/security/opsec.md` | Threat modelling and operational privacy discipline. |
-| Mobile app development | `tools/mobile/app-dev.md` | App planning/build/release workflows. |
-| Mobile app development (Swift) | `tools/mobile/app-dev-swift.md` | Swift/iOS-specific app development guidance. |
-| Legal | `legal.md` | Legal compliance, privacy policy, and GDPR guidance. |
+| NetBird | `services/networking/netbird.md` | Shared framework agent for self-hosted WireGuard mesh VPN and worker access. |
+| Tailscale | `services/networking/tailscale.md` | Shared framework agent for managed mesh VPN, Serve/Funnel, and secure private access. |
+| OPSEC | `tools/security/opsec.md` | Shared framework agent for threat modelling and operational privacy discipline. |
+| Mobile app development | `tools/mobile/app-dev.md` | Shared framework agent for app planning/build/release workflows. |
+| Mobile app development (Swift) | `tools/mobile/app-dev-swift.md` | Shared framework agent for Swift/iOS-specific app development guidance. |
+| Legal | `legal.md` | Shared framework agent for legal compliance, privacy policy, and GDPR guidance. |
+
+Tier guidance: these related paths are shared framework agents maintained in `.agents/`. Use `custom/` for permanent private variants and `draft/` for R&D or unreviewed patterns; see `tools/build-agent/build-agent.md` for lifecycle rules and `reference/customization.md` for persistence/update behaviour.


### PR DESCRIPTION
## Summary

Clarified that ObscuraVPN related-agent entries point to shared framework agents and added tier guidance for shared, custom, and draft agents with lifecycle references.

## Files Changed

.agents/services/networking/obscuravpn.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted secretlint passed for .agents/services/networking/obscuravpn.md; markdownlint-cli2 passed with 0 errors. Full .agents/scripts/linters-local.sh reached Secretlint and timed out at 120s and 240s before a terminal result.

Resolves #23894


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.10 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 9m and 41,439 tokens on this as a headless worker.