### PR TITLE
GH#23893: fix: optimize cleanup PR branch matching

### DIFF
--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -262,7 +262,7 @@ should_skip_cleanup() {
 	# GH#5694 Safety check B: Open PR
 	# Skip worktrees whose branch has an open PR — active work in progress.
 	# This applies even with --force-merged: an open PR means the work is not done.
-	if [[ -n "$open_pr_list" ]] && echo "$open_pr_list" | grep -Fxq "$wt_branch"; then
+	if _clean_branch_list_contains_exact "$wt_branch" "$open_pr_list"; then
 		echo -e "  ${RED}$wt_branch${NC} (has open PR - skipping)"
 		echo "    $wt_path"
 		printf '\n'


### PR DESCRIPTION
## Summary

Reused the newline-delimited exact branch matching helper for worktree cleanup open-PR detection, removing the per-worktree printf/grep-style external process path while preserving whole-line branch matching.

## Files Changed

.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh; .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh

Resolves #23893


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.11 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 1m and 38,934 tokens on this as a headless worker.