### PR TITLE
GH#17804: fix issue-sync HTML comment stripping

### DIFF
--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -43,11 +43,66 @@ fi
 # Parse — TODO.md Utilities
 # =============================================================================
 
-# Strip lines inside markdown code-fenced blocks (``` ... ```) from stdin.
-# Prevents task-like lines in format examples from being parsed as real tasks.
+# Strip content that should not be parsed as live tasks. Removes:
+#   1. Markdown code-fenced blocks (``` ... ```) — whole lines inside fences.
+#   2. HTML comment regions (<!-- ... -->) — character spans, possibly spanning
+#      multiple lines, leaving any text outside the comment intact.
+# Prevents task-like lines in format examples and documentation comments
+# (GH#17804 issue-sync helper) from being parsed as real tasks.
 # Usage: strip_code_fences < file  OR  grep ... | strip_code_fences
 strip_code_fences() {
-	awk '/^[[:space:]]*```/{in_fence=!in_fence; next} !in_fence{print}'
+	awk '
+		/^[[:space:]]*```/ { in_fence = !in_fence; next }
+		in_fence { next }
+		{
+			line = $0
+			out = ""
+			while (length(line) > 0) {
+				if (in_comment) {
+					pos = index(line, "-->")
+					if (pos == 0) { line = ""; break }
+					line = substr(line, pos + 3)
+					in_comment = 0
+				} else {
+					pos = index(line, "<!--")
+					if (pos == 0) { out = out line; line = ""; break }
+					out = out substr(line, 1, pos - 1)
+					line = substr(line, pos + 4)
+					in_comment = 1
+				}
+			}
+			print out
+		}
+	'
+	return 0
+}
+
+# Strip only HTML comment regions (<!-- ... -->) from stdin, including
+# multi-line comments. Leaves code fences and everything else untouched.
+# Useful for callers that need comment stripping without fence removal.
+# Usage: strip_html_comments < file  OR  grep ... | strip_html_comments
+strip_html_comments() {
+	awk '
+		{
+			line = $0
+			out = ""
+			while (length(line) > 0) {
+				if (in_comment) {
+					pos = index(line, "-->")
+					if (pos == 0) { line = ""; break }
+					line = substr(line, pos + 3)
+					in_comment = 0
+				} else {
+					pos = index(line, "<!--")
+					if (pos == 0) { out = out line; line = ""; break }
+					out = out substr(line, 1, pos - 1)
+					line = substr(line, pos + 4)
+					in_comment = 1
+				}
+			}
+			print out
+		}
+	'
 	return 0
 }
 

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -23,6 +23,9 @@
 #   9.  strip_code_fences: passes through non-fenced content
 #   10. _escape_ere: escapes regex metacharacters in sub-task IDs like t001.1
 #   11. t1983 explicit regression: pre-fix awk pattern WOULD fail, post-fix works
+#   12. strip_code_fences: strips HTML comment regions (GH#17804 regression)
+#   13. strip_code_fences: strips multi-line HTML comments and example tasks
+#   14. strip_html_comments: standalone helper strips comments only
 #
 # Exit 0 = all tests pass, 1 = at least one failure.
 
@@ -295,6 +298,75 @@ if grep -q 't9011.*ref:GH#1983' "$TMP/todo11.md"; then
 else
 	fail "t1983 regression: awk pattern failed — bug has regressed"
 	cat "$TMP/todo11.md" | sed 's/^/     /'
+fi
+
+# -----------------------------------------------------------------------------
+# Test 12: strip_code_fences strips HTML-commented task examples (GH#17804)
+# Regression: issue-sync-helper-push.sh extracted commented `- [ ] tNNN` lines
+# from the todo-template format-example block and created spurious GitHub issues.
+# -----------------------------------------------------------------------------
+cat >"$TMP/todo12.md" <<'EOF'
+## Ready
+
+<!-- GH#17804: Format examples wrapped in HTML comment
+- [ ] t9001 Example task description @owner ~30m
+- [ ] t9002 Another example task
+-->
+
+- [ ] t9100 Real task that must survive ~15m
+EOF
+
+output12=$(strip_code_fences <"$TMP/todo12.md")
+if printf '%s\n' "$output12" | grep -qE '^- \[ \] t9100 ' &&
+	! printf '%s\n' "$output12" | grep -qE '^- \[ \] t900[12] '; then
+	pass "strip_code_fences: HTML-commented example tasks stripped (GH#17804)"
+else
+	fail "strip_code_fences: HTML-commented tasks leaked through"
+	printf '%s\n' "$output12" | sed 's/^/     /'
+fi
+
+# -----------------------------------------------------------------------------
+# Test 13: strip_code_fences handles multi-line comments and inline spans
+# -----------------------------------------------------------------------------
+cat >"$TMP/todo13.md" <<'EOF'
+before <!-- inline comment --> middle <!-- second --> after
+<!-- multi-line
+- [ ] t9201 commented task
+end of comment -->
+keeper line
+EOF
+
+output13=$(strip_code_fences <"$TMP/todo13.md")
+if printf '%s\n' "$output13" | grep -q 'before  middle  after' &&
+	printf '%s\n' "$output13" | grep -q 'keeper line' &&
+	! printf '%s\n' "$output13" | grep -q 't9201'; then
+	pass "strip_code_fences: multi-line + inline HTML comments handled"
+else
+	fail "strip_code_fences: comment span handling incorrect"
+	printf '%s\n' "$output13" | sed 's/^/     /'
+fi
+
+# -----------------------------------------------------------------------------
+# Test 14: strip_html_comments standalone helper
+# -----------------------------------------------------------------------------
+cat >"$TMP/todo14.md" <<'EOF'
+keep <!-- drop --> keep
+```
+fenced content stays
+```
+<!-- whole-line comment -->
+final
+EOF
+
+output14=$(strip_html_comments <"$TMP/todo14.md")
+if printf '%s\n' "$output14" | grep -q 'keep  keep' &&
+	printf '%s\n' "$output14" | grep -q 'fenced content stays' &&
+	printf '%s\n' "$output14" | grep -q 'final' &&
+	! printf '%s\n' "$output14" | grep -q 'whole-line comment'; then
+	pass "strip_html_comments: removes comments, leaves fences intact"
+else
+	fail "strip_html_comments: unexpected output"
+	printf '%s\n' "$output14" | sed 's/^/     /'
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`strip_code_fences` in `issue-sync-lib-parse.sh` only removed lines inside markdown code fences. The `todo-template.md` format-example block wraps example tasks in `<!-- ... -->` (`templates/todo-template.md:14-21`) precisely so they are not extracted as live tasks, but the helper ignored the wrapper. After `aidevops update` ran the planning-template upgrade across 68 repos, every repo whose upgrade commit reached `origin/main` had its `issue-sync.yml` workflow fire and create three spurious GitHub issues from placeholder task IDs.

Observed in the wild: `Ultimate-Multisite/superdav-ai-agent#1573`, `#1574`, `#1575` — closed as `not planned`.

## Fix

1. Extend `strip_code_fences` to also strip HTML comment regions (multi-line and inline same-line spans). All existing call sites in `issue-sync-helper-*.sh`, `issue-sync-relationships.sh`, `issue-sync-lib-ref.sh`, and `claim-task-id-issue.sh` get the fix for free — the function's documented contract was always "make safe to parse", just understated.
2. Add `strip_html_comments` as a standalone helper for callers that need comment removal without fence removal.
3. Three regression tests in `test-issue-sync-lib.sh`:
   - GH#17804 scenario: commented placeholder task lines stripped, real task survives.
   - Multi-line + inline `<!-- … -->` spans handled.
   - Standalone `strip_html_comments` leaves fences intact.

## Verification

- `bash .agents/scripts/test-issue-sync-lib.sh` → **15/15 pass** (was 12/12).
- `bash .agents/scripts/linters-local.sh` → `ALL LOCAL CHECKS PASSED`. Pre-existing SC2002 warnings on lines not touched by this PR.
- Roundtrip: `strip_code_fences < .agents/templates/todo-template.md | rg 'placeholder task pattern'` → no live placeholder task lines extracted.
- Pre-commit/pre-push hooks passed.

## Impact

After this lands and gets deployed via `aidevops update`, the 47 outstanding `chore: upgrade planning templates` merges (held back to prevent further spurious-issue noise) can be safely pushed.

Resolves #17804

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.12 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 7h 18m and 184,158 tokens on this with the user in an interactive session.
