### PR TITLE
GH#23890: fix PR salvage test cleanup

### DIFF
--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -152,7 +152,7 @@ test_cmd_scan_accepts_hash_prefixed_pr_numbers() {
 
 run_tests() {
 	_save_cleanup_scope
-	trap '_run_cleanups' RETURN EXIT
+	trap '_run_cleanups' RETURN
 	GH_CLOSED_LIST_ARGS_FILE=$(mktemp "${TMPDIR:-/tmp}/pr-salvage-gh-args.XXXXXX")
 	push_cleanup "rm -f \"${GH_CLOSED_LIST_ARGS_FILE}\""
 
@@ -162,6 +162,7 @@ run_tests() {
 	test_cmd_scan_accepts_hash_prefixed_pr_numbers
 
 	printf '\nResults: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	rm -f "$GH_CLOSED_LIST_ARGS_FILE"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1
 	fi


### PR DESCRIPTION
## Summary

Updated the PR salvage helper test to use the shared RETURN cleanup trap without an EXIT trap and added explicit normal-path temp-file cleanup.

## Files Changed

.agents/scripts/tests/test-pr-salvage-helper.sh

## Runtime Testing

- **Risk level:** Low (test-only cleanup change)
- **Verification:** shellcheck .agents/scripts/tests/test-pr-salvage-helper.sh; bash .agents/scripts/tests/test-pr-salvage-helper.sh

Resolves #23890


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.13 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 3m and 58,607 tokens on this as a headless worker.
