### PR TITLE
GH#23891: fix: reject traversal cleanup tmpdirs

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -41,6 +41,8 @@ is_safe_test_tmpdir() {
 	local tmpdir="${1:-}"
 	[[ -n "$tmpdir" ]] || return 1
 	[[ "$tmpdir" == /*[!/.]* ]] || return 1
+	[[ "$tmpdir" != */.. ]] || return 1
+	[[ "$tmpdir" != */../* ]] || return 1
 	return 0
 }
 
@@ -56,7 +58,7 @@ cleanup_test_tmpdir() {
 test_cleanup_test_tmpdir_rejects_unsafe_paths() {
 	local test_name="cleanup helper rejects unsafe tmpdir paths"
 	local path
-	for path in '' relative / // /// //// /. /.. /./ /../ //./ //../; do
+	for path in '' relative / // /// //// /. /.. /./ /../ //./ //../ /tmp/..; do
 		if is_safe_test_tmpdir "$path"; then
 			print_result "$test_name" 1 "accepted unsafe path: ${path:-<empty>}"
 			return 0


### PR DESCRIPTION
## Summary

Added traversal-segment rejection to the supply-chain advisory test cleanup guard and covered /tmp/.. in the unsafe-path regression list.

## Files Changed

.agents/scripts/tests/test-supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-supply-chain-advisory-helper.sh; shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh

Resolves #23891


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.13 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 1m and 35,467 tokens on this as a headless worker.