### PR TITLE
GH#23898: fix: address xurl review feedback

### DIFF
--- a/.agents/scripts/xurl-helper.sh
+++ b/.agents/scripts/xurl-helper.sh
@@ -165,7 +165,6 @@ parse_and_execute() {
 
 	parse_options "$@" || return 1
 
-	reject_forbidden_args "${ARGS[@]}" || return 1
 	require_write_confirmation "${command_name}" "${CONFIRM_WRITE}" || return 1
 
 	local xurl_args=()
@@ -191,9 +190,7 @@ parse_and_execute() {
 		;;
 	search | timeline | mentions | bookmarks | likes | followers | following | dms)
 		xurl_args+=("${command_name}")
-		if [[ ${#ARGS[@]} -gt 0 ]]; then
-			xurl_args+=("${ARGS[@]}")
-		fi
+		xurl_args+=("${ARGS[@]}")
 		if [[ -n "${LIMIT}" ]]; then
 			xurl_args+=("-n" "${LIMIT}")
 		fi


### PR DESCRIPTION
## Summary

Removed the redundant pre-execution forbidden-argument check from parse_and_execute because run_xurl validates the final xurl argument list before every execution. Simplified read-command argument construction by appending ARGS unconditionally; empty arrays are a safe no-op. Verified the dms help entry is already present in the current file.

## Files Changed

.agents/scripts/xurl-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/xurl-helper.sh; bash -n .agents/scripts/xurl-helper.sh; .agents/scripts/xurl-helper.sh --help

Resolves #23898


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.13 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 1m and 19,169 tokens on this as a headless worker.