### PR TITLE
GH#23912: fix: short-circuit health activity guard

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -104,27 +104,30 @@ _check_health_issue_activity_guard() {
 	[[ -f "$health_issue_file" ]] && return 0
 
 	local guard_pr_count guard_assigned_count guard_auto_dispatch_count guard_worker_count
-	guard_pr_count=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json number --jq 'length' 2>/dev/null || echo "0")
-	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
-		--assignee "$runner_user" --state open \
-		--json number --jq 'length' 2>/dev/null || echo "0")
-	guard_auto_dispatch_count=$(gh_issue_list --repo "$repo_slug" \
-		--label "auto-dispatch" --state open \
-		--json number --jq 'length' 2>/dev/null || echo "0")
-
 	local _guard_fields=()
 	while IFS= read -r -d '' _gf; do
 		_guard_fields+=("$_gf")
 	done < <(_scan_active_workers "${repo_path:-}")
 	guard_worker_count="${_guard_fields[1]:-0}"
+	[[ "${guard_worker_count:-0}" -gt 0 ]] && return 0
 
-	if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_auto_dispatch_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 ]]; then
-		echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, assigned issues, auto-dispatch work, or workers" \
-			>>"${LOGFILE:-/dev/null}"
-		return 1
-	fi
-	return 0
+	guard_pr_count=$(gh_pr_list --repo "$repo_slug" --state open \
+		--json number --jq 'length' 2>/dev/null || echo "0")
+	[[ "${guard_pr_count:-0}" -gt 0 ]] && return 0
+
+	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
+		--assignee "$runner_user" --state open \
+		--json number --jq 'length' 2>/dev/null || echo "0")
+	[[ "${guard_assigned_count:-0}" -gt 0 ]] && return 0
+
+	guard_auto_dispatch_count=$(gh_issue_list --repo "$repo_slug" \
+		--label "auto-dispatch" --state open \
+		--json number --jq 'length' 2>/dev/null || echo "0")
+	[[ "${guard_auto_dispatch_count:-0}" -gt 0 ]] && return 0
+
+	echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, assigned issues, auto-dispatch work, or workers" \
+		>>"${LOGFILE:-/dev/null}"
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -108,7 +108,7 @@ gh_create_issue() { gh issue create "$@" && return 0; return 1; }
 # shellcheck disable=SC2317
 gh_issue_edit_safe() { gh issue edit "$@" && return 0; return 1; }
 # shellcheck disable=SC2317
-gh_pr_list() { printf '%s' '0'; return 0; }
+gh_pr_list() { printf '%s\n' "pr list $*" >>"$GH_CALLS"; printf '%s' '0'; return 0; }
 
 # shellcheck source=../portable-stat.sh
 source "${SCRIPTS_DIR}/portable-stat.sh"
@@ -121,7 +121,14 @@ source "${SCRIPTS_DIR}/stats-health-dashboard.sh"
 _unpin_health_issue() { printf 'unpin %s\n' "$*" >>"$GH_CALLS"; return 0; }
 
 # shellcheck disable=SC2317
-_scan_active_workers() { printf '%s\0%s\0%s\0' '_No active workers_' '0' ''; return 0; }
+_scan_active_workers() {
+	if [[ "${HEALTH_FIXTURE:-}" == "activity_guard_worker" ]]; then
+		printf '%s\0%s\0%s\0' '- worker 123' '1' 'worker 123'
+		return 0
+	fi
+	printf '%s\0%s\0%s\0' '_No active workers_' '0' ''
+	return 0
+}
 
 identity_lines=$(_dashboard_identity_aliases "github-user")
 canonical=$(printf '%s\n' "$identity_lines" | sed -n '1p')
@@ -338,6 +345,22 @@ if [[ "$unsafe_cache" != *"{"* && "$unsafe_cache" != *"message\":"* && ${#unsafe
 else
 	fail "sanitizes API error payloads before cache filename use" "safe=${unsafe_cache}"
 fi
+
+missing_cache_file="${HOME}/.aidevops/logs/health-issue-missing-owner-repo"
+rm -f "$missing_cache_file"
+: >"$GH_CALLS"
+: >"$LOGFILE"
+export HEALTH_FIXTURE=activity_guard_worker
+if _check_health_issue_activity_guard "owner/repo" "$TMP" "github-user" "$missing_cache_file"; then
+	if [[ ! -s "$GH_CALLS" ]]; then
+		pass "activity guard short-circuits before GitHub calls when local workers are active"
+	else
+		fail "activity guard short-circuits before GitHub calls when local workers are active" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+	fi
+else
+	fail "activity guard proceeds when local workers are active" "log=$(tr '\n' ';' <"$LOGFILE")"
+fi
+unset HEALTH_FIXTURE
 
 missing_cache_file="${HOME}/.aidevops/logs/health-issue-missing-owner-repo"
 rm -f "$missing_cache_file"


### PR DESCRIPTION
## Summary

Optimized the stats health issue activity guard to scan local workers first and return as soon as workers, PRs, assigned issues, or auto-dispatch work are found. Added a regression test proving active local workers avoid GitHub calls.

## Files Changed

.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

Resolves #23912


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 2m and 46,677 tokens on this as a headless worker.