### PR TITLE
GH#23913: test: cover middle traversal cleanup path

### DIFF
--- a/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
+++ b/.agents/scripts/tests/test-supply-chain-advisory-helper.sh
@@ -58,7 +58,7 @@ cleanup_test_tmpdir() {
 test_cleanup_test_tmpdir_rejects_unsafe_paths() {
 	local test_name="cleanup helper rejects unsafe tmpdir paths"
 	local path
-	for path in '' relative / // /// //// /. /.. /./ /../ //./ //../ /tmp/..; do
+	for path in '' relative / // /// //// /. /.. /./ /../ //./ //../ /tmp/.. /tmp/../unsafe; do
 		if is_safe_test_tmpdir "$path"; then
 			print_result "$test_name" 1 "accepted unsafe path: ${path:-<empty>}"
 			return 0


### PR DESCRIPTION
## Summary

Added the middle-path traversal case /tmp/../unsafe to the unsafe tmpdir rejection regression test so the */../* guard is directly covered.

## Files Changed

.agents/scripts/tests/test-supply-chain-advisory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-supply-chain-advisory-helper.sh && .agents/scripts/tests/test-supply-chain-advisory-helper.sh

Resolves #23913


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 1m and 29,214 tokens on this as a headless worker.