### PR TITLE
GH#23915: docs: resolve ObscuraVPN review followup

### DIFF
--- a/.agents/services/networking/obscuravpn.md
+++ b/.agents/services/networking/obscuravpn.md
@@ -120,11 +120,11 @@ When reviewing Obscura claims, verify against source or first-party docs before 
 
 | Resource | Path | Purpose |
 |----------|------|---------|
-| NetBird | `services/networking/netbird.md` | Shared framework agent for self-hosted WireGuard mesh VPN and worker access. |
-| Tailscale | `services/networking/tailscale.md` | Shared framework agent for managed mesh VPN, Serve/Funnel, and secure private access. |
-| OPSEC | `tools/security/opsec.md` | Shared framework agent for threat modelling and operational privacy discipline. |
-| Mobile app development | `tools/mobile/app-dev.md` | Shared framework agent for app planning/build/release workflows. |
-| Mobile app development (Swift) | `tools/mobile/app-dev-swift.md` | Shared framework agent for Swift/iOS-specific app development guidance. |
-| Legal | `legal.md` | Shared framework agent for legal compliance, privacy policy, and GDPR guidance. |
+| NetBird | `services/networking/netbird.md` | Self-hosted WireGuard mesh VPN and worker access. |
+| Tailscale | `services/networking/tailscale.md` | Managed mesh VPN, Serve/Funnel, and secure private access. |
+| OPSEC | `tools/security/opsec.md` | Threat modelling and operational privacy discipline. |
+| Mobile app development | `tools/mobile/app-dev.md` | App planning/build/release workflows. |
+| Mobile app development (Swift) | `tools/mobile/app-dev-swift.md` | Swift/iOS-specific app development guidance. |
+| Legal | `legal.md` | Legal compliance, privacy policy, and GDPR guidance. |
 
-Tier guidance: these related paths are shared framework agents maintained in `.agents/`. Use `custom/` for permanent private variants and `draft/` for R&D or unreviewed patterns; see `tools/build-agent/build-agent.md` for lifecycle rules and `reference/customization.md` for persistence/update behaviour.
+Tier guidance: the agents listed above are shared framework agents maintained in `.agents/`. Use `custom/` for permanent private variants and `draft/` for R&D or unreviewed patterns; see `tools/build-agent/build-agent.md` for lifecycle rules and `reference/customization.md` for persistence/update behaviour.


### PR DESCRIPTION
## Summary

Removed redundant shared-agent wording from the ObscuraVPN related-agent table and clarified tier guidance to describe the listed agents rather than their paths.

## Files Changed

.agents/services/networking/obscuravpn.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2@0.17.2 .agents/services/networking/obscuravpn.md (0 errors); .agents/scripts/linters-local.sh started and passed early checks, but timed out during ratchet counting after reporting markdownlint was unavailable locally.

Resolves #23915


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 4m and 37,191 tokens on this as a headless worker.