### PR TITLE
GH#23917: fix: delegate triage env contract validation

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -290,20 +290,29 @@ _ensure_valid_launch_cwd() {
 	return 1
 }
 
-# _run_looks_like_issue_worker: detect issue-scoped worker dispatches from
-# independent caller-owned signals. The env contract is only mandatory for
-# issue workers; pulse/non-issue runs keep the historical path.
-_run_looks_like_issue_worker() {
+# _run_requires_issue_env_contract: detect issue-scoped worker and triage
+# dispatches from independent caller-owned signals. The env contract is only
+# mandatory for issue-scoped runs; pulse/non-issue runs keep the historical path.
+_run_requires_issue_env_contract() {
 	local role_value="$1"
 	local session_key_value="$2"
 	local title_value="$3"
 	local prompt_value="$4"
 
-	[[ "$role_value" == "worker" ]] || return 1
+	case "$role_value" in
+		worker | triage) ;;
+		*) return 1 ;;
+	esac
 	if [[ "$session_key_value" =~ ^issue-[0-9]+$ ]]; then
 		return 0
 	fi
+	if [[ "$session_key_value" =~ ^triage-review-[0-9]+$ ]]; then
+		return 0
+	fi
 	if [[ "$title_value" =~ ^Issue[[:space:]]+#[0-9]+ ]]; then
+		return 0
+	fi
+	if [[ "$title_value" =~ Issue[[:space:]]+#[0-9]+ ]]; then
 		return 0
 	fi
 	if [[ "$prompt_value" =~ [Ii]ssue[[:space:]]*#?[0-9]+ ]]; then
@@ -322,12 +331,16 @@ _validate_issue_worker_env_contract() {
 	local title_value="$4"
 	local prompt_value="$5"
 
-	if ! _run_looks_like_issue_worker "$role_value" "$session_key_value" "$title_value" "$prompt_value"; then
+	if ! _run_requires_issue_env_contract "$role_value" "$session_key_value" "$title_value" "$prompt_value"; then
 		return 0
 	fi
 
 	if [[ -z "${WORKER_ISSUE_NUMBER:-}" ]]; then
 		print_error "[fatal] WORKER_ISSUE_NUMBER unset — issue worker env contract missing; aborting before model launch"
+		return 1
+	fi
+	if [[ -z "${WORKER_REPO_SLUG:-}" ]]; then
+		print_error "[fatal] WORKER_REPO_SLUG unset — issue worker env contract missing; aborting before model launch"
 		return 1
 	fi
 	if [[ -z "${WORKER_WORKTREE_PATH:-}" ]]; then
@@ -348,15 +361,13 @@ _validate_issue_worker_env_contract() {
 		return 1
 	fi
 
-	if [[ -n "${WORKER_REPO_SLUG:-}" ]]; then
-		local remote_url=""
-		local actual_slug=""
-		remote_url=$(git -C "$WORKER_WORKTREE_PATH" remote get-url origin 2>/dev/null) || remote_url=""
-		actual_slug=$(printf '%s' "$remote_url" | sed 's|.*github\.com[:/]||;s|\.git$||') || actual_slug=""
-		if [[ -z "$actual_slug" || "$actual_slug" != "$WORKER_REPO_SLUG" ]]; then
-			print_error "[fatal] worker worktree repo mismatch: expected ${WORKER_REPO_SLUG}, got ${actual_slug:-<unknown>}"
-			return 1
-		fi
+	local remote_url=""
+	local actual_slug=""
+	remote_url=$(git -C "$WORKER_WORKTREE_PATH" remote get-url origin 2>/dev/null) || remote_url=""
+	actual_slug=$(printf '%s' "$remote_url" | sed 's|.*github\.com[:/]||;s|\.git$||') || actual_slug=""
+	if [[ -z "$actual_slug" || "$actual_slug" != "$WORKER_REPO_SLUG" ]]; then
+		print_error "[fatal] worker worktree repo mismatch: expected ${WORKER_REPO_SLUG}, got ${actual_slug:-<unknown>}"
+		return 1
 	fi
 
 	return 0

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -995,9 +995,9 @@ _finalize_triage_state() {
 # Exit code: always 0; runtime failures are captured in the output file.
 #######################################
 _run_triage_review_worker() {
-	local issue_num="$1"
-	local repo_slug="$2"
-	local repo_path="$3"
+	local triage_issue_num="$1"
+	local triage_repo_slug="$2"
+	local triage_repo_path="$3"
 	local model_flag="$4"
 	local prefetch_file="$5"
 	local review_output_file="$6"
@@ -1007,20 +1007,16 @@ _run_triage_review_worker() {
 		return 0
 	fi
 
-	if [[ -n "$issue_num" && -n "$repo_slug" && -n "$repo_path" && -n "$prefetch_file" ]]; then
-		# shellcheck disable=SC2086
-		env HEADLESS=1 WORKER_ISSUE_NUMBER="$issue_num" WORKER_REPO_SLUG="$repo_slug" WORKER_WORKTREE_PATH="$repo_path" \
-			"$HEADLESS_RUNTIME_HELPER" run \
-			--role triage \
-			--session-key "triage-review-${issue_num}" \
-			--dir "$repo_path" \
-			$model_flag \
-			--agent triage-review \
-			--title "Sandboxed triage review: Issue #${issue_num}" \
-			--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
-	else
-		printf '%s\n' '[fatal] triage worker env contract missing; aborting before model launch' >"$review_output_file"
-	fi
+	# shellcheck disable=SC2086
+	env HEADLESS=1 WORKER_ISSUE_NUMBER="$triage_issue_num" WORKER_REPO_SLUG="$triage_repo_slug" WORKER_WORKTREE_PATH="$triage_repo_path" \
+		"$HEADLESS_RUNTIME_HELPER" run \
+		--role triage \
+		--session-key "triage-review-${triage_issue_num}" \
+		--dir "$triage_repo_path" \
+		$model_flag \
+		--agent triage-review \
+		--title "Sandboxed triage review: Issue #${triage_issue_num}" \
+		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1 || true
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Delegated sandboxed triage review env contract failures to headless-runtime-helper by teaching the helper to recognise issue-scoped triage sessions, requiring WORKER_REPO_SLUG alongside issue/worktree env, and removing the duplicate pre-launch env branch from pulse ancillary dispatch while keeping the output-file guard.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/pulse-ancillary-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/headless-runtime-helper.sh .agents/scripts/pulse-ancillary-dispatch.sh; shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/pulse-ancillary-dispatch.sh; .agents/scripts/linters-local.sh (timed out after advisory markdown/ratchet checks and Bash 3.2 success; no blocking edited-file failures before timeout); tests/test-headless-runtime-helper.sh currently fails on pre-existing model expectation drift before reaching the edited path

Resolves #23917


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.19 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 19m and 71,881 tokens on this as a headless worker.