### PR TITLE
GH#23914: fix(issue-sync): deduplicate comment stripping

### DIFF
--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -51,29 +51,7 @@ fi
 # (GH#17804 issue-sync helper) from being parsed as real tasks.
 # Usage: strip_code_fences < file  OR  grep ... | strip_code_fences
 strip_code_fences() {
-	awk '
-		/^[[:space:]]*```/ { in_fence = !in_fence; next }
-		in_fence { next }
-		{
-			line = $0
-			out = ""
-			while (length(line) > 0) {
-				if (in_comment) {
-					pos = index(line, "-->")
-					if (pos == 0) { line = ""; break }
-					line = substr(line, pos + 3)
-					in_comment = 0
-				} else {
-					pos = index(line, "<!--")
-					if (pos == 0) { out = out line; line = ""; break }
-					out = out substr(line, 1, pos - 1)
-					line = substr(line, pos + 4)
-					in_comment = 1
-				}
-			}
-			print out
-		}
-	'
+	awk '/^[[:space:]]*```/ { in_fence = !in_fence; next } !in_fence { print }' | strip_html_comments
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Refactored strip_code_fences to remove markdown fences first and delegate HTML comment removal to strip_html_comments, preserving the existing behavior while avoiding duplicated comment-stripping logic.

## Files Changed

.agents/scripts/issue-sync-lib-parse.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/issue-sync-lib-parse.sh; .agents/scripts/test-issue-sync-lib.sh

Resolves #23914


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.19 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 1m and 35,058 tokens on this as a headless worker.