### PR TITLE
fix: cover review scanner supersession

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -642,17 +642,17 @@ _rf_issue_in_supersession_scope() {
 
 	labels_lc=$(printf '%s' "$labels" | tr '[:upper:]' '[:lower:]')
 	case ",${labels_lc}," in
-	*",source:review-feedback,"* | *",quality-debt,"*)
+	*",source:review-feedback,"* | *",quality-debt,"* | *",review-followup,"* | *",source:review-scanner,"*)
 		return 0
 		;;
 	esac
 
-	if printf '%s' "$issue_body" | grep -qF '<!-- source:review-feedback -->'; then
+	if printf '%s' "$issue_body" | grep -Eq '<!-- (source:review-feedback|source:review-scanner|review-followup:PR)'; then
 		return 0
 	fi
 
 	title_lc=$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]')
-	if printf '%s' "$title_lc" | grep -Eq '(^|[^[:alnum:]-])(quality-debt|review-feedback|review feedback)([^[:alnum:]-]|$)'; then
+	if printf '%s' "$title_lc" | grep -Eq '(^|[^[:alnum:]-])(quality-debt|review-feedback|review feedback|review-followup|review followup)([^[:alnum:]-]|$)'; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -227,6 +227,12 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\
 			extended-extension)
 				printf 'quality debt kotlin coroutine MainActivity.kt\n'
 				;;
+			review-followup-label)
+				printf 'review followup changelog fixed \`CHANGELOG.md:18\`\n'
+				;;
+			source-review-scanner-label)
+				printf 'review scanner changelog fixed \`CHANGELOG.md:18\`\n'
+				;;
 			whole-word)
 				printf 'quality debt rate cache worker.sh\n'
 				;;
@@ -240,7 +246,17 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\
 		esac
 		exit 0
 	fi
-	printf '2026-05-07T00:00:00Z\tquality-debt supersession test\tquality-debt,source:review-feedback\n'
+	case "${mode}" in
+		review-followup-label)
+			printf '2026-05-07T00:00:00Z\tReview followup supersession test\treview-followup,source:review-scanner\n'
+			;;
+		source-review-scanner-label)
+			printf '2026-05-07T00:00:00Z\tReview followup supersession test\tsource:review-scanner\n'
+			;;
+		*)
+			printf '2026-05-07T00:00:00Z\tquality-debt supersession test\tquality-debt,source:review-feedback\n'
+			;;
+	esac
 	exit 0
 fi
 
@@ -256,6 +272,13 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qE 'pulls/99/files';
 				printf 'app/src/MainActivity.kt\n'
 			else
 				printf 'app/src/MainActivity.kt\nfix kotlin coroutine reliability\n'
+			fi
+			;;
+		review-followup-label|source-review-scanner-label)
+			if printf '%s' "\$args" | grep -qF '.[].filename'; then
+				printf 'CHANGELOG.md\n'
+			else
+				printf 'CHANGELOG.md\nmove changelog entries to fixed section\n'
 			fi
 			;;
 		whole-word)
@@ -284,6 +307,9 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/99\$'; t
 	case "${mode}" in
 		extended-extension)
 			printf '2026-05-08T00:00:00Z\tfix kotlin coroutine reliability\tUpdates mobile handling\n'
+			;;
+		review-followup-label|source-review-scanner-label)
+			printf '2026-05-08T00:00:00Z\tdocs: clean up changelog duplicates\tMoves changelog fixes under Fixed. Refs #50 #51\n'
 			;;
 		whole-word)
 			printf '2026-05-08T00:00:00Z\tgenerate cache output\tUpdates cache handling\n'
@@ -468,6 +494,40 @@ test_review_feedback_preserves_version_directory_paths() {
 	return 0
 }
 
+test_review_followup_label_enters_supersession_scope() {
+	setup_test_env
+	create_gh_stub_review_feedback "review-followup-label"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "50" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "review_followup label enters supersession scope" 0
+	else
+		print_result "review_followup label enters supersession scope" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_source_review_scanner_label_enters_supersession_scope() {
+	setup_test_env
+	create_gh_stub_review_feedback "source-review-scanner-label"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "51" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "source_review_scanner label enters supersession scope" 0
+	else
+		print_result "source_review_scanner label enters supersession scope" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -488,6 +548,8 @@ main() {
 	test_review_feedback_extended_extensions
 	test_review_feedback_keyword_scoring_whole_words
 	test_review_feedback_preserves_version_directory_paths
+	test_review_followup_label_enters_supersession_scope
+	test_source_review_scanner_label_enters_supersession_scope
 
 	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -220,42 +220,24 @@ create_gh_stub_review_feedback() {
 set -euo pipefail
 
 args="\$*"
+mode="${mode}"
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
 	if printf '%s' "\$args" | grep -qF '.body // ""'; then
-		case "${mode}" in
-			extended-extension)
-				printf 'quality debt kotlin coroutine MainActivity.kt\n'
-				;;
-			review-followup-label)
-				printf 'review followup changelog fixed \`CHANGELOG.md:18\`\n'
-				;;
-			source-review-scanner-label)
-				printf 'review scanner changelog fixed \`CHANGELOG.md:18\`\n'
-				;;
-			whole-word)
-				printf 'quality debt rate cache worker.sh\n'
-				;;
-			version-directory)
-				printf 'quality debt setup rollout v3.14.93/setup.sh\n'
-				;;
-			*)
-				printf 'unsupported review-feedback mode: %s\n' "${mode}" >&2
-				exit 1
-				;;
+		case "\$mode" in
+			extended-extension) printf 'quality debt kotlin coroutine MainActivity.kt\n' ;;
+			review-followup-label) printf 'review followup changelog fixed \`CHANGELOG.md:18\`\n' ;;
+			source-review-scanner-label) printf 'review scanner changelog fixed \`CHANGELOG.md:18\`\n' ;;
+			whole-word) printf 'quality debt rate cache worker.sh\n' ;;
+			version-directory) printf 'quality debt setup rollout v3.14.93/setup.sh\n' ;;
+			*) printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2; exit 1 ;;
 		esac
 		exit 0
 	fi
-	case "${mode}" in
-		review-followup-label)
-			printf '2026-05-07T00:00:00Z\tReview followup supersession test\treview-followup,source:review-scanner\n'
-			;;
-		source-review-scanner-label)
-			printf '2026-05-07T00:00:00Z\tReview followup supersession test\tsource:review-scanner\n'
-			;;
-		*)
-			printf '2026-05-07T00:00:00Z\tquality-debt supersession test\tquality-debt,source:review-feedback\n'
-			;;
+	case "\$mode" in
+		review-followup-label) printf '2026-05-07T00:00:00Z\tReview followup supersession test\treview-followup,source:review-scanner\n' ;;
+		source-review-scanner-label) printf '2026-05-07T00:00:00Z\tReview followup supersession test\tsource:review-scanner\n' ;;
+		*) printf '2026-05-07T00:00:00Z\tquality-debt supersession test\tquality-debt,source:review-feedback\n' ;;
 	esac
 	exit 0
 fi
@@ -266,45 +248,39 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qF 'search/issues'; 
 fi
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qE 'pulls/99/files'; then
-	case "${mode}" in
+	if printf '%s' "\$args" | grep -qF '.[].filename'; then
+		case "\$mode" in
+			extended-extension) printf 'app/src/MainActivity.kt\n' ;;
+			review-followup-label|source-review-scanner-label) printf 'CHANGELOG.md\n' ;;
+			whole-word) printf 'worker.sh\n' ;;
+			version-directory) printf 'v3.14.93/setup.sh\n' ;;
+			*) printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2; exit 1 ;;
+		esac
+	else
+		case "\$mode" in
 		extended-extension)
-			if printf '%s' "\$args" | grep -qF '.[].filename'; then
-				printf 'app/src/MainActivity.kt\n'
-			else
-				printf 'app/src/MainActivity.kt\nfix kotlin coroutine reliability\n'
-			fi
+			printf 'app/src/MainActivity.kt\nfix kotlin coroutine reliability\n'
 			;;
 		review-followup-label|source-review-scanner-label)
-			if printf '%s' "\$args" | grep -qF '.[].filename'; then
-				printf 'CHANGELOG.md\n'
-			else
-				printf 'CHANGELOG.md\nmove changelog entries to fixed section\n'
-			fi
+			printf 'CHANGELOG.md\nmove changelog entries to fixed section\n'
 			;;
 		whole-word)
-			if printf '%s' "\$args" | grep -qF '.[].filename'; then
-				printf 'worker.sh\n'
-			else
-				printf 'worker.sh\ngenerate cache output\n'
-			fi
+			printf 'worker.sh\ngenerate cache output\n'
 			;;
 		version-directory)
-			if printf '%s' "\$args" | grep -qF '.[].filename'; then
-				printf 'v3.14.93/setup.sh\n'
-			else
-				printf 'v3.14.93/setup.sh\nfix setup rollout quality debt\n'
-			fi
+			printf 'v3.14.93/setup.sh\nfix setup rollout quality debt\n'
 			;;
 		*)
-			printf 'unsupported review-feedback mode: %s\n' "${mode}" >&2
+			printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2
 			exit 1
 			;;
-	esac
+		esac
+	fi
 	exit 0
 fi
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/99\$'; then
-	case "${mode}" in
+	case "\$mode" in
 		extended-extension)
 			printf '2026-05-08T00:00:00Z\tfix kotlin coroutine reliability\tUpdates mobile handling\n'
 			;;
@@ -318,7 +294,7 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/99\$'; t
 			printf '2026-05-08T00:00:00Z\tfix setup rollout quality debt\tUpdates setup handling\n'
 			;;
 		*)
-			printf 'unsupported review-feedback mode: %s\n' "${mode}" >&2
+			printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2
 			exit 1
 			;;
 	esac


### PR DESCRIPTION
## Summary

- Extend the review-feedback supersession detector to include post-merge review-scanner follow-up issues.
- Treat `review-followup`, `source:review-scanner`, and matching body/title markers as in scope for pre-dispatch supersession checks.
- Add regression coverage for stale changelog-style review follow-ups closed by a later merged PR.
- Refactor the review-feedback test stub to stay below the function-complexity gate.

For #23921

## Verification

- `bash .agents/scripts/tests/test-pre-dispatch-validator.sh`
- `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-pre-dispatch-validator.sh`
- `bash -n .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-pre-dispatch-validator.sh`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/complexity-report-23933-4.md`
- `.agents/scripts/linters-local.sh` attempted twice; focused gates passed, but the full run timed out during later broad checks after advisory markdown/ratchet warnings.
