### PR TITLE
fix: fail closed unresolved blocked-by refs

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -648,7 +648,8 @@ _blocked_by_load_cache() {
 #
 # Exit codes:
 #   0 - blocker is open (caller should return "blocked")
-#   1 - blocker is resolved or not found (caller should continue)
+#   1 - blocker is resolved (caller should continue)
+#   2 - blocker reference could not be resolved (caller should fail closed)
 #######################################
 _blocked_by_check_task_id() {
 	local task_id="$1"
@@ -668,23 +669,60 @@ _blocked_by_check_task_id() {
 			is_open=$(printf '%s' "$cache_state" |
 				jq --argjson n "$blocker_issue_num" '.open_issues | index($n) != null' 2>/dev/null) || is_open="false"
 			if [[ "$is_open" == "true" ]]; then
-				echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id}=#${blocker_issue_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
+				printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id}=#${blocker_issue_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
 				return 0
 			fi
-			return 1
+			printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id}=#${blocker_issue_num} has inconclusive cache state — skipping dispatch (blocked-by-unresolved-reference)" >>"$LOGFILE"
+			return 2
 		fi
 		# Task not in map → fall through to live API (may be a new issue)
 	fi
 
-	# Live API fallback: search for an open issue with this task ID in the title
+	# Live API fallback: search for an issue with this task ID in the title.
+	# Empty/error is unknown, not clear: newly created issues can be missing from
+	# the fresh cache while GitHub search/indexing has not caught up yet (GH#23911).
 	local blocker_state
-	blocker_state=$(gh_issue_list --repo "$repo_slug" --state open \
+	blocker_state=$(gh_issue_list --repo "$repo_slug" --state all \
 		--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null) || blocker_state=""
 	if [[ "$blocker_state" == "OPEN" ]]; then
-		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
+		printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 		return 0
 	fi
-	return 1
+	if [[ "$blocker_state" == "CLOSED" ]]; then
+		return 1
+	fi
+	printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} has unresolved blocked-by reference t${task_id} (cache miss / live lookup inconclusive) — skipping dispatch (blocked-by-unresolved-reference)" >>"$LOGFILE"
+	return 2
+}
+
+#######################################
+# Invoke _blocked_by_check_task_id and normalize its tri-state result.
+#
+# Arguments: same as _blocked_by_check_task_id
+# Output:    "blocked", "clear", or "unknown" on stdout
+#######################################
+_blocked_by_task_id_state() {
+	local task_id="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	local cache_state="$4"
+
+	local rc
+	if _blocked_by_check_task_id "$task_id" "$repo_slug" "$issue_number" "$cache_state"; then
+		rc=0
+	else
+		rc=$?
+	fi
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'blocked\n'
+		return 0
+	fi
+	if [[ "$rc" -eq 2 ]]; then
+		printf 'unknown\n'
+		return 0
+	fi
+	printf 'clear\n'
+	return 0
 }
 
 #######################################
@@ -698,7 +736,8 @@ _blocked_by_check_task_id() {
 #
 # Exit codes:
 #   0 - blocker is open
-#   1 - blocker is resolved or not found
+#   1 - blocker is resolved
+#   2 - blocker reference could not be resolved
 #######################################
 _blocked_by_check_issue_num() {
 	local blocker_num="$1"
@@ -714,10 +753,11 @@ _blocked_by_check_issue_num() {
 		is_open=$(printf '%s' "$cache_state" |
 			jq --argjson n "$blocker_num" '.open_issues | index($n) != null' 2>/dev/null) || is_open="false"
 		if [[ "$is_open" == "true" ]]; then
-			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
+			printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
 			return 0
 		fi
-		return 1
+		# The cache contains only open issues, so absence is not positive proof
+		# of resolution. Fall through to live view before clearing dispatch.
 	fi
 
 	# Live API fallback
@@ -725,10 +765,44 @@ _blocked_by_check_issue_num() {
 	blocker_state=$(gh issue view "$blocker_num" --repo "$repo_slug" \
 		--json state --jq '.state // ""' 2>/dev/null) || blocker_state=""
 	if [[ "$blocker_state" == "OPEN" ]]; then
-		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
+		printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 		return 0
 	fi
-	return 1
+	if [[ "$blocker_state" == "CLOSED" ]]; then
+		return 1
+	fi
+	printf '%s\n' "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} has unresolved blocked-by reference #${blocker_num} (cache miss / live lookup inconclusive) — skipping dispatch (blocked-by-unresolved-reference)" >>"$LOGFILE"
+	return 2
+}
+
+#######################################
+# Invoke _blocked_by_check_issue_num and normalize its tri-state result.
+#
+# Arguments: same as _blocked_by_check_issue_num
+# Output:    "blocked", "clear", or "unknown" on stdout
+#######################################
+_blocked_by_issue_num_state() {
+	local blocker_num="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	local cache_state="$4"
+
+	local rc
+	if _blocked_by_check_issue_num "$blocker_num" "$repo_slug" "$issue_number" "$cache_state"; then
+		rc=0
+	else
+		rc=$?
+	fi
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'blocked\n'
+		return 0
+	fi
+	if [[ "$rc" -eq 2 ]]; then
+		printf 'unknown\n'
+		return 0
+	fi
+	printf 'clear\n'
+	return 0
 }
 
 #######################################
@@ -750,7 +824,7 @@ _blocked_by_check_issue_num() {
 #   $2 - repo slug (owner/repo)
 #   $3 - issue number (for logging)
 # Returns:
-#   exit 0 = blocker is unresolved (do NOT dispatch)
+#   exit 0 = blocker is unresolved/open or unknown (do NOT dispatch)
 #   exit 1 = no blocker or blocker is resolved (safe to dispatch)
 #######################################
 is_blocked_by_unresolved() {
@@ -779,10 +853,11 @@ is_blocked_by_unresolved() {
 
 	# Check task ID blockers
 	if [[ -n "$blocker_task_ids" ]]; then
-		local task_id
+		local task_id task_state
 		while IFS= read -r task_id; do
 			[[ -n "$task_id" ]] || continue
-			if _blocked_by_check_task_id "$task_id" "$repo_slug" "$issue_number" "$cache_state"; then
+			task_state=$(_blocked_by_task_id_state "$task_id" "$repo_slug" "$issue_number" "$cache_state")
+			if [[ "$task_state" == "blocked" || "$task_state" == "unknown" ]]; then
 				return 0
 			fi
 		done <<<"$blocker_task_ids"
@@ -790,10 +865,11 @@ is_blocked_by_unresolved() {
 
 	# Check GitHub issue number blockers
 	if [[ -n "$blocker_issue_nums" ]]; then
-		local blocker_num
+		local blocker_num issue_state
 		while IFS= read -r blocker_num; do
 			[[ -n "$blocker_num" ]] || continue
-			if _blocked_by_check_issue_num "$blocker_num" "$repo_slug" "$issue_number" "$cache_state"; then
+			issue_state=$(_blocked_by_issue_num_state "$blocker_num" "$repo_slug" "$issue_number" "$cache_state")
+			if [[ "$issue_state" == "blocked" || "$issue_state" == "unknown" ]]; then
 				return 0
 			fi
 		done <<<"$blocker_issue_nums"

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -853,7 +853,7 @@ is_blocked_by_unresolved() {
 
 	# Check task ID blockers
 	if [[ -n "$blocker_task_ids" ]]; then
-		local task_id task_state
+		local task_id="" task_state=""
 		while IFS= read -r task_id; do
 			[[ -n "$task_id" ]] || continue
 			task_state=$(_blocked_by_task_id_state "$task_id" "$repo_slug" "$issue_number" "$cache_state")
@@ -865,7 +865,7 @@ is_blocked_by_unresolved() {
 
 	# Check GitHub issue number blockers
 	if [[ -n "$blocker_issue_nums" ]]; then
-		local blocker_num issue_state
+		local blocker_num="" issue_state=""
 		while IFS= read -r blocker_num; do
 			[[ -n "$blocker_num" ]] || continue
 			issue_state=$(_blocked_by_issue_num_state "$blocker_num" "$repo_slug" "$issue_number" "$cache_state")

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -12,6 +12,9 @@ TARGET="${SCRIPT_DIR}/../scripts/pulse-dep-graph.sh"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+TEST_REPO="example/repo"
+TEST_GH_ISSUE_LIST_STATE=""
+TEST_GH_VIEW_STATE=""
 
 # shellcheck source=/dev/null
 source "$TARGET"
@@ -43,6 +46,54 @@ _assert_lines_equal() {
 	return 0
 }
 
+_assert_blocked_result() {
+	local name="$1"
+	local expected_rc="$2"
+	local body="$3"
+	local actual_rc=1
+
+	if is_blocked_by_unresolved "$body" "$TEST_REPO" "200"; then
+		actual_rc=0
+	else
+		actual_rc=1
+	fi
+	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
+		_pass "$name"
+		return 0
+	fi
+	_fail "$name" "expected rc ${expected_rc} got ${actual_rc}"
+	return 0
+}
+
+_write_test_cache() {
+	local cache_json="$1"
+	DEP_GRAPH_CACHE_FILE="${TEST_TMPDIR}/dep-graph-cache.json"
+	printf '%s\n' "$cache_json" >"$DEP_GRAPH_CACHE_FILE"
+	return 0
+}
+
+gh_issue_list() {
+	local ignored_args=("$@")
+	if [[ -z "$TEST_GH_ISSUE_LIST_STATE" ]]; then
+		return 1
+	fi
+	printf '%s\n' "$TEST_GH_ISSUE_LIST_STATE"
+	return 0
+}
+
+gh() {
+	local command_name="${1:-}"
+	local subcommand_name="${2:-}"
+	if [[ "$command_name" == "issue" && "$subcommand_name" == "view" ]]; then
+		if [[ -z "$TEST_GH_VIEW_STATE" ]]; then
+			return 1
+		fi
+		printf '%s\n' "$TEST_GH_VIEW_STATE"
+		return 0
+	fi
+	return 1
+}
+
 test_task_id_blocker_parsing() {
 	printf '\n=== blocked-by task IDs ===\n'
 	_assert_lines_equal "compact comma-separated task IDs" $'001\n002\n003' \
@@ -69,11 +120,54 @@ test_issue_number_blocker_parsing() {
 	return 0
 }
 
+test_unresolved_task_blocker_fails_closed() {
+	printf '\n=== unresolved blocked-by task IDs ===\n'
+	_write_test_cache '{"repos":{"example/repo":{"open_issues":[42],"task_to_issue":{"42":42}}}}'
+	TEST_GH_ISSUE_LIST_STATE=""
+	_assert_blocked_result "missing task ID in fresh cache and live miss blocks dispatch" 0 \
+		'blocked-by:t1000'
+	if grep -q 'blocked-by-unresolved-reference' "$LOGFILE"; then
+		_pass "unresolved task ID logs distinct reason"
+	else
+		_fail "unresolved task ID logs distinct reason" "missing blocked-by-unresolved-reference log"
+	fi
+	TEST_GH_ISSUE_LIST_STATE="CLOSED"
+	_assert_blocked_result "live closed task ID clears dispatch" 1 \
+		'blocked-by:t1000'
+	TEST_GH_ISSUE_LIST_STATE="OPEN"
+	_assert_blocked_result "live open task ID blocks dispatch" 0 \
+		'blocked-by:t1000'
+	return 0
+}
+
+test_unresolved_issue_blocker_fails_closed() {
+	printf '\n=== unresolved blocked-by issue numbers ===\n'
+	_write_test_cache '{"repos":{"example/repo":{"open_issues":[42],"task_to_issue":{"42":42}}}}'
+	TEST_GH_VIEW_STATE=""
+	_assert_blocked_result "issue reference live miss blocks dispatch" 0 \
+		'blocked-by:#1000'
+	TEST_GH_VIEW_STATE="CLOSED"
+	_assert_blocked_result "live closed issue reference clears dispatch" 1 \
+		'blocked-by:#1000'
+	TEST_GH_VIEW_STATE="OPEN"
+	_assert_blocked_result "live open issue reference blocks dispatch" 0 \
+		'blocked-by:#1000'
+	return 0
+}
+
 main() {
+	TEST_TMPDIR=$(mktemp -d)
+	LOGFILE="${TEST_TMPDIR}/pulse.log"
+	DEP_GRAPH_CACHE_TTL_SECS=300
+	export LOGFILE DEP_GRAPH_CACHE_FILE DEP_GRAPH_CACHE_TTL_SECS
+
 	test_task_id_blocker_parsing
 	test_issue_number_blocker_parsing
+	test_unresolved_task_blocker_fails_closed
+	test_unresolved_issue_blocker_fails_closed
 
 	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
+	rm -rf "$TEST_TMPDIR"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then
 		return 1
 	fi


### PR DESCRIPTION
## Summary
- make blocked-by task refs tri-state: blocked, clear, or unknown
- treat cache misses / inconclusive live lookups for parseable `blocked-by:tNNN` and `blocked-by:#NNN` refs as dispatch-blocking unknowns
- add regression coverage for fresh-cache misses, live lookup misses, open blockers, and closed blockers

## Files / patterns
- `.agents/scripts/pulse-dep-graph.sh`: `_blocked_by_check_task_id`, `_blocked_by_check_issue_num`, and `is_blocked_by_unresolved`
- `.agents/tests/test-pulse-dep-graph-blocked-by.sh`: focused blocked-by parser/resolution regression tests

## Verification
- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh` → 15 passed, 0 failed
- `git diff --check`
- `.agents/scripts/linters-local.sh` was attempted twice; required checks reached success through secret safety/pulse canary, then timed out during later broad portability gates. It reported advisory pre-existing markdown/layout/ratchet warnings before timeout.

Resolves #23911
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.20 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 21m and 74,968 tokens on this with the user in an interactive session.