### PR TITLE
fix: pass repo slug to fallback worker launch

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1237,16 +1237,17 @@ _dlw_spawn_lifecycle_observer() {
 #
 # Arguments:
 #   $1  - issue_number
-#   $2  - dispatch_title
-#   $3  - issue_title
-#   $4  - session_key
-#   $5  - worker_log (path from _dlw_setup_worker_log)
-#   $6  - prompt
-#   $7  - repo_path
-#   $8  - dispatch_model_tier (haiku|sonnet|opus)
-#   $9  - selected_model (may be empty for auto-select)
-#   $10 - worker_worktree_path (may be empty)
-#   $11 - worker_worktree_branch (may be empty)
+#   $2  - repo_slug (owner/repo)
+#   $3  - dispatch_title
+#   $4  - issue_title
+#   $5  - session_key
+#   $6  - worker_log (path from _dlw_setup_worker_log)
+#   $7  - prompt
+#   $8  - repo_path
+#   $9  - dispatch_model_tier (haiku|sonnet|opus)
+#   $10 - selected_model (may be empty for auto-select)
+#   $11 - worker_worktree_path (may be empty)
+#   $12 - worker_worktree_branch (may be empty)
 # Stdout: worker PID
 #######################################
 _dlw_build_worker_title() {
@@ -1284,16 +1285,17 @@ _dlw_build_worker_title() {
 #######################################
 _dlw_nohup_launch() {
 	local issue_number="$1"
-	local dispatch_title="$2"
-	local issue_title="$3"
-	local session_key="$4"
-	local worker_log="$5"
-	local prompt="$6"
-	local repo_path="$7"
-	local dispatch_model_tier="$8"
-	local selected_model="$9"
-	local worker_worktree_path="${10}"
-	local worker_worktree_branch="${11}"
+	local repo_slug="$2"
+	local dispatch_title="$3"
+	local issue_title="$4"
+	local session_key="$5"
+	local worker_log="$6"
+	local prompt="$7"
+	local repo_path="$8"
+	local dispatch_model_tier="$9"
+	local selected_model="${10}"
+	local worker_worktree_path="${11}"
+	local worker_worktree_branch="${12}"
 
 	# Use issue title as session title for searchable history, but keep the
 	# issue marker at the beginning so Tabby tabs and OpenCode session search
@@ -1316,6 +1318,7 @@ _dlw_nohup_launch() {
 		AIDEVOPS_SESSION_ORIGIN=worker
 		AIDEVOPS_HEADLESS=true
 		WORKER_ISSUE_NUMBER="$issue_number"
+		WORKER_REPO_SLUG="$repo_slug"
 		WORKER_GITHUB_LOGIN="$self_login"
 		AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1
 	)
@@ -1717,7 +1720,7 @@ _dispatch_launch_worker() {
 	local worker_pid
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
-	worker_pid=$(_dlw_nohup_launch "$issue_number" "$dispatch_title" "$issue_title" \
+	worker_pid=$(_dlw_nohup_launch "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$session_key" "$worker_log" "$launch_prompt" "$repo_path" \
 		"$dispatch_model_tier" "$selected_model" \
 		"$worker_worktree_path" "$worker_worktree_branch")

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -58,6 +58,7 @@ teardown_test_env() {
 init_git_worktree() {
 	local worktree_dir="$1"
 	git -C "$worktree_dir" init -q
+	git -C "$worktree_dir" remote add origin "https://github.com/owner/repo.git"
 	git -C "$worktree_dir" -c user.name="aidevops-test" -c user.email="aidevops-test@example.invalid" \
 		commit --allow-empty -q -m "initial"
 	git -C "$worktree_dir" update-ref refs/remotes/origin/main HEAD
@@ -242,6 +243,7 @@ test_issue_worker_env_contract_rejects_missing_env() {
 
 test_issue_worker_env_contract_rejects_missing_worktree() {
 	export WORKER_ISSUE_NUMBER="22438"
+	export WORKER_REPO_SLUG="owner/repo"
 	unset WORKER_WORKTREE_PATH 2>/dev/null || true
 	local output=""
 	local status=0
@@ -251,32 +253,34 @@ test_issue_worker_env_contract_rejects_missing_worktree() {
 
 	if [[ "$status" -ne 0 && "$output" == *"WORKER_WORKTREE_PATH unset"* ]]; then
 		print_result "issue worker env contract rejects missing WORKER_WORKTREE_PATH" 0
-		unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+		unset WORKER_ISSUE_NUMBER WORKER_REPO_SLUG 2>/dev/null || true
 		return 0
 	fi
 
 	print_result "issue worker env contract rejects missing WORKER_WORKTREE_PATH" 1 \
 		"status=$status output=${output:-<empty>}"
-	unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+	unset WORKER_ISSUE_NUMBER WORKER_REPO_SLUG 2>/dev/null || true
 	return 0
 }
 
 test_issue_worker_env_contract_accepts_valid_precreated_worktree() {
 	local worktree_dir="${TEST_ROOT}/precreated-worktree"
 	mkdir -p "$worktree_dir"
+	init_git_worktree "$worktree_dir"
 	export WORKER_ISSUE_NUMBER="22438"
+	export WORKER_REPO_SLUG="owner/repo"
 	export WORKER_WORKTREE_PATH="$worktree_dir"
 
 	if _validate_issue_worker_env_contract \
 		"worker" "issue-22438" "$worktree_dir" "Issue #22438: env contract" \
 		"/full-loop Implement issue #22438"; then
 		print_result "issue worker env contract accepts valid precreated worktree" 0
-		unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
+		unset WORKER_ISSUE_NUMBER WORKER_REPO_SLUG WORKER_WORKTREE_PATH 2>/dev/null || true
 		return 0
 	fi
 
 	print_result "issue worker env contract accepts valid precreated worktree" 1
-	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH 2>/dev/null || true
+	unset WORKER_ISSUE_NUMBER WORKER_REPO_SLUG WORKER_WORKTREE_PATH 2>/dev/null || true
 	return 0
 }
 
@@ -541,6 +545,7 @@ test_cmd_run_preserves_worker_origin_overrides_before_canary() {
 	mkdir -p "$worktree_dir"
 	init_git_worktree "$worktree_dir"
 	export WORKER_ISSUE_NUMBER=23558
+	export WORKER_REPO_SLUG="owner/repo"
 	export WORKER_WORKTREE_PATH="$worktree_dir"
 	export AIDEVOPS_SESSION_ORIGIN=interactive
 	export AIDEVOPS_HEADLESS=already-set
@@ -563,7 +568,7 @@ test_cmd_run_preserves_worker_origin_overrides_before_canary() {
 		--title "Issue #23558: origin overrides" \
 		--prompt "/full-loop Implement issue #23558" 2>&1) || status=$?
 
-	unset WORKER_ISSUE_NUMBER WORKER_WORKTREE_PATH AIDEVOPS_SESSION_ORIGIN AIDEVOPS_HEADLESS 2>/dev/null || true
+	unset WORKER_ISSUE_NUMBER WORKER_REPO_SLUG WORKER_WORKTREE_PATH AIDEVOPS_SESSION_ORIGIN AIDEVOPS_HEADLESS 2>/dev/null || true
 	unset -f choose_model _enforce_opencode_version_pin _run_canary_test 2>/dev/null || true
 	if [[ "$status" -eq 1 && "$output" == *"canary_saw_origin_overrides"* && "$output" == *"Canary failed"* ]]; then
 		print_result "cmd_run preserves worker origin env overrides before canary" 0

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -648,6 +648,18 @@ test_prelaunch_reason_parser_preserves_explicit_reason() {
 	return 0
 }
 
+test_nohup_launch_passes_repo_slug_contract() {
+	# shellcheck disable=SC2016  # literal source snippets — no expansion intended
+	if grep -q 'WORKER_REPO_SLUG="$repo_slug"' "$WORKER_LAUNCH" \
+		&& grep -q '_dlw_nohup_launch "$issue_number" "$repo_slug"' "$WORKER_LAUNCH"; then
+		print_result "invariant: fallback nohup launch passes WORKER_REPO_SLUG to headless runtime" 0
+		return 0
+	fi
+	print_result "invariant: fallback nohup launch passes WORKER_REPO_SLUG to headless runtime" 1 \
+		"Expected _dlw_nohup_launch to receive repo_slug and export WORKER_REPO_SLUG for headless-runtime-helper.sh"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main runner
 # ---------------------------------------------------------------------------
@@ -695,6 +707,7 @@ main_test() {
 	test_worker_worktree_live_owner_skips_fast_fail_state
 	test_prelaunch_reason_parser_behavioural
 	test_prelaunch_reason_parser_preserves_explicit_reason
+	test_nohup_launch_passes_repo_slug_contract
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Pass `repo_slug` into `.agents/scripts/pulse-dispatch-worker-launch.sh::_dlw_nohup_launch` explicitly.
- Export `WORKER_REPO_SLUG` alongside `WORKER_ISSUE_NUMBER` for the setsid/nohup fallback launch path.
- Update regression coverage so headless issue-worker contract tests exercise the full issue/worktree/repo env contract.

## Root cause
The systemd launch fallback used by `.agents/scripts/pulse-dispatch-worker-launch.sh::_dlw_nohup_launch` built the headless worker environment without `WORKER_REPO_SLUG`. `.agents/scripts/headless-runtime-helper.sh` validates that issue workers have `WORKER_ISSUE_NUMBER`, `WORKER_REPO_SLUG`, and `WORKER_WORKTREE_PATH` before model launch, so fallback-launched workers aborted before producing worker output. That caused the original t2769 no_work/no_worker_process loop seen on #23921.

## Verification
- `bash .agents/scripts/tests/test-no-worker-process-fix.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-no-worker-process-fix.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/linters-local.sh` — passed; existing advisory warnings reported for markdown style, ratchets, layout, complexity, and nesting.

Resolves #23931
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.20 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 30m and 114,051 tokens on this with the user in an interactive session.