### PR TITLE
For #23932: fail closed on unknown blocked-by deps

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -262,9 +262,8 @@ build_dependency_graph_cache() {
 	fi
 
 	# Build the graph JSON incrementally
-	local graph_json old_graph_json
+	local graph_json="" old_graph_json=""
 	graph_json=$(printf '{"built_at":"%s","repos":{}}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
-	old_graph_json=""
 	if [[ -f "$cache_file" ]]; then
 		old_graph_json=$(<"$cache_file") || old_graph_json=""
 	fi

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -148,8 +148,11 @@ _dep_graph_process_issue_json() {
 _dep_graph_build_repo_data() {
 	local slug="$1"
 	local issues_json
-	issues_json=$(gh_issue_list --repo "$slug" --state open --limit 200 \
-		--json number,title,body,labels 2>/dev/null) || issues_json='[]'
+	if ! issues_json=$(gh_issue_list --repo "$slug" --state open --limit 200 \
+		--json number,title,body,labels 2>/dev/null); then
+		echo "[pulse-wrapper] dep-graph-cache: failed to list open issues for ${slug}; preserving previous repo cache when available" >>"$LOGFILE"
+		return 1
+	fi
 
 	# Single jq pass: extract all fields, apply regex, build accumulator.
 	# Equivalent to calling _dep_graph_process_issue_json once per issue
@@ -198,7 +201,8 @@ _dep_graph_build_repo_data() {
 			"blocked_by": .blocked_by_map,
 			"defer_flags": .defer_flags_map
 		}
-	' 2>/dev/null || printf '{"open_issues":[],"task_to_issue":{},"blocked_by":{},"defer_flags":{}}\n'
+	' 2>/dev/null || return 1
+	return 0
 }
 
 #######################################
@@ -258,8 +262,12 @@ build_dependency_graph_cache() {
 	fi
 
 	# Build the graph JSON incrementally
-	local graph_json
+	local graph_json old_graph_json
 	graph_json=$(printf '{"built_at":"%s","repos":{}}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+	old_graph_json=""
+	if [[ -f "$cache_file" ]]; then
+		old_graph_json=$(<"$cache_file") || old_graph_json=""
+	fi
 
 	while IFS= read -r repo_entry; do
 		[[ -n "$repo_entry" ]] || continue
@@ -271,8 +279,14 @@ build_dependency_graph_cache() {
 		# (t2031 refactor — keeps build_dependency_graph_cache under the
 		# 100-line complexity gate).
 		local repo_data
-		repo_data=$(_dep_graph_build_repo_data "$slug")
-		[[ -n "$repo_data" ]] || continue
+		if ! repo_data=$(_dep_graph_build_repo_data "$slug") || [[ -z "$repo_data" ]]; then
+			repo_data=$(printf '%s' "$old_graph_json" | jq -c --arg s "$slug" '.repos[$s] // empty' 2>/dev/null) || repo_data=""
+			if [[ -z "$repo_data" ]]; then
+				echo "[pulse-wrapper] dep-graph-cache: no previous repo cache for ${slug}; omitting failed repo from this cache build" >>"$LOGFILE"
+				continue
+			fi
+			echo "[pulse-wrapper] dep-graph-cache: preserved previous repo cache for ${slug} after fetch/build failure" >>"$LOGFILE"
+		fi
 
 		# Merge repo data into graph
 		graph_json=$(printf '%s' "$graph_json" |
@@ -593,11 +607,11 @@ _blocked_by_extract_nums() {
 #
 # Reads DEP_GRAPH_CACHE_FILE (if present and within 2× TTL) and extracts
 # the per-repo open_issues and task_to_issue maps. Emits a single compact
-# JSON object on stdout with the three fields the resolver needs:
+# JSON object on stdout with the fields the resolver needs:
 #   {"use_cache": bool, "open_issues": [...], "task_to_issue": {...}}
 #
-# Fails open — on any error emits use_cache:false so the caller falls
-# through to live API resolution.
+# Cache errors emit use_cache:false so the caller falls through to live API
+# resolution; unresolved live lookups fail closed at the blocker check.
 #
 # Arguments: $1 - repo slug
 # Output:    one JSON object on stdout
@@ -620,22 +634,24 @@ _blocked_by_load_cache() {
 	fi
 
 	local graph_json
-	graph_json=$(cat "$cache_file" 2>/dev/null) || graph_json=""
+	graph_json=$(<"$cache_file") || graph_json=""
 	if [[ -z "$graph_json" ]]; then
 		printf '{"use_cache":false,"open_issues":[],"task_to_issue":{}}'
 		return 0
 	fi
 
-	printf '%s' "$graph_json" | jq -c --arg s "$repo_slug" '{
-		use_cache: true,
-		open_issues: (.repos[$s].open_issues // []),
-		task_to_issue: (.repos[$s].task_to_issue // {})
-	}' 2>/dev/null || printf '{"use_cache":false,"open_issues":[],"task_to_issue":{}}'
+	printf '%s' "$graph_json" | jq -c --arg s "$repo_slug" '
+		if .repos[$s] == null then
+			{"use_cache":false,"open_issues":[],"task_to_issue":{}}
+		else
+			{"use_cache":true,"open_issues":(.repos[$s].open_issues // []),"task_to_issue":(.repos[$s].task_to_issue // {})}
+		end
+	' 2>/dev/null || printf '{"use_cache":false,"open_issues":[],"task_to_issue":{}}'
 	return 0
 }
 
 #######################################
-# Resolve a single task-ID blocker to open/closed (GH#18693 refactor helper).
+# Resolve a single task-ID blocker to blocked/clear/unknown (GH#18693 refactor helper).
 #
 # Uses the cached dep graph first; falls back to a live `gh issue list`
 # search when the task is not found in the cache.
@@ -647,8 +663,8 @@ _blocked_by_load_cache() {
 #   $4 - cache_state JSON (from _blocked_by_load_cache)
 #
 # Exit codes:
-#   0 - blocker is open (caller should return "blocked")
-#   1 - blocker is resolved or not found (caller should continue)
+#   0 - blocker is open or unknown (caller should return "blocked")
+#   1 - blocker is positively resolved (caller should continue)
 #######################################
 _blocked_by_check_task_id() {
 	local task_id="$1"
@@ -673,18 +689,61 @@ _blocked_by_check_task_id() {
 			fi
 			return 1
 		fi
-		# Task not in map → fall through to live API (may be a new issue)
+		# Task not in map → fall through to live API (may be a new issue).
 	fi
 
-	# Live API fallback: search for an open issue with this task ID in the title
+	# Live API fallback: search all issues with this task ID in the title.
+	# Empty/error is not proof of resolution because GitHub search can lag
+	# immediately after rapid task creation. Treat that as unknown and block.
 	local blocker_state
-	blocker_state=$(gh_issue_list --repo "$repo_slug" --state open \
-		--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null) || blocker_state=""
+	if ! blocker_state=$(gh_issue_list --repo "$repo_slug" --state all \
+		--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null); then
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference t${task_id} (live lookup failed) — skipping dispatch" >>"$LOGFILE"
+		return 0
+	fi
 	if [[ "$blocker_state" == "OPEN" ]]; then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 		return 0
 	fi
-	return 1
+	if [[ "$blocker_state" == "CLOSED" ]]; then
+		return 1
+	fi
+	echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference t${task_id} (cache miss / live lookup inconclusive) — skipping dispatch" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Resolve a single GitHub issue-number blocker through live API.
+#
+# Arguments:
+#   $1 - blocker_num
+#   $2 - repo slug
+#   $3 - issue_number (for logging)
+#
+# Exit codes:
+#   0 - blocker is open or unknown
+#   1 - blocker is positively resolved
+#######################################
+_blocked_by_check_issue_num_live() {
+	local blocker_num="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+
+	local blocker_state
+	if ! blocker_state=$(gh issue view "$blocker_num" --repo "$repo_slug" \
+		--json state --jq '.state // ""' 2>/dev/null); then
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference #${blocker_num} (live lookup failed) — skipping dispatch" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$blocker_state" == "OPEN" ]]; then
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$blocker_state" == "CLOSED" ]]; then
+		return 1
+	fi
+	echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference #${blocker_num} (live lookup inconclusive) — skipping dispatch" >>"$LOGFILE"
+	return 0
 }
 
 #######################################
@@ -697,8 +756,8 @@ _blocked_by_check_task_id() {
 #   $4 - cache_state JSON (from _blocked_by_load_cache)
 #
 # Exit codes:
-#   0 - blocker is open
-#   1 - blocker is resolved or not found
+#   0 - blocker is open or unknown
+#   1 - blocker is positively resolved
 #######################################
 _blocked_by_check_issue_num() {
 	local blocker_num="$1"
@@ -717,18 +776,12 @@ _blocked_by_check_issue_num() {
 			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
 			return 0
 		fi
-		return 1
+		# Cache absence is not positive proof for direct issue-number blockers:
+		# the issue may have been created after the cache snapshot. Verify live.
 	fi
 
-	# Live API fallback
-	local blocker_state
-	blocker_state=$(gh issue view "$blocker_num" --repo "$repo_slug" \
-		--json state --jq '.state // ""' 2>/dev/null) || blocker_state=""
-	if [[ "$blocker_state" == "OPEN" ]]; then
-		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
-		return 0
-	fi
-	return 1
+	_blocked_by_check_issue_num_live "$blocker_num" "$repo_slug" "$issue_number"
+	return $?
 }
 
 #######################################

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -12,6 +12,7 @@ TARGET="${SCRIPT_DIR}/../scripts/pulse-dep-graph.sh"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+TEST_TMP=""
 
 # shellcheck source=/dev/null
 source "$TARGET"
@@ -43,6 +44,70 @@ _assert_lines_equal() {
 	return 0
 }
 
+_assert_rc() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" -eq "$expected" ]]; then
+		_pass "$name"
+		return 0
+	fi
+	_fail "$name" "expected rc ${expected} got ${actual}"
+	return 0
+}
+
+_setup_blocked_by_resolution_test() {
+	TEST_TMP=$(mktemp -d)
+	LOGFILE="${TEST_TMP}/pulse.log"
+	DEP_GRAPH_CACHE_FILE="${TEST_TMP}/dep-graph.json"
+	DEP_GRAPH_CACHE_TTL_SECS=3600
+	return 0
+}
+
+_cleanup_blocked_by_resolution_test() {
+	if [[ -n "$TEST_TMP" && -d "$TEST_TMP" ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+	TEST_TMP=""
+	return 0
+}
+
+gh_issue_list() {
+	case "${TEST_GH_ISSUE_LIST_MODE:-empty}" in
+		fail)
+			return 1
+			;;
+		closed)
+			printf 'CLOSED\n'
+			return 0
+			;;
+		open)
+			printf 'OPEN\n'
+			return 0
+			;;
+		repo-json)
+			printf '[{"number":1000,"title":"t1000: blocker","body":"","labels":[]}]\n'
+			return 0
+			;;
+		*)
+			printf '\n'
+			return 0
+			;;
+	esac
+}
+
+gh() {
+	if [[ "${TEST_GH_ISSUE_VIEW_MODE:-fail}" == "closed" ]]; then
+		printf 'CLOSED\n'
+		return 0
+	fi
+	if [[ "${TEST_GH_ISSUE_VIEW_MODE:-fail}" == "open" ]]; then
+		printf 'OPEN\n'
+		return 0
+	fi
+	return 1
+}
+
 test_task_id_blocker_parsing() {
 	printf '\n=== blocked-by task IDs ===\n'
 	_assert_lines_equal "compact comma-separated task IDs" $'001\n002\n003' \
@@ -69,9 +134,106 @@ test_issue_number_blocker_parsing() {
 	return 0
 }
 
+test_unknown_task_blocker_fails_closed() {
+	printf '\n=== fail-closed task blocker resolution ===\n'
+	_setup_blocked_by_resolution_test
+	printf '{"built_at":"now","repos":{"owner/repo":{"open_issues":[1],"task_to_issue":{},"blocked_by":{},"defer_flags":{}}}}\n' >"$DEP_GRAPH_CACHE_FILE"
+	TEST_GH_ISSUE_LIST_MODE="empty"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "cache miss plus empty live lookup blocks as unknown" 0 "$rc"
+	if grep -q 'blocked-by-unresolved-reference t1000' "$LOGFILE"; then
+		_pass "unknown task blocker logs distinct reason"
+	else
+		_fail "unknown task blocker logs distinct reason" "missing blocked-by-unresolved-reference log"
+	fi
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_live_task_lookup_failure_fails_closed() {
+	printf '\n=== live lookup failure ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="fail"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "task live lookup failure blocks as unknown" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_closed_task_blocker_is_clear() {
+	printf '\n=== positively closed task blocker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="closed"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "closed task blocker is clear" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_issue_number_live_failure_fails_closed() {
+	printf '\n=== fail-closed issue-number blocker resolution ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_VIEW_MODE="fail"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:#1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "issue-number live lookup failure blocks as unknown" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_cached_issue_number_absence_requires_live_proof() {
+	printf '\n=== cached issue-number absence live verification ===\n'
+	_setup_blocked_by_resolution_test
+	printf '{"built_at":"now","repos":{"owner/repo":{"open_issues":[1],"task_to_issue":{},"blocked_by":{},"defer_flags":{}}}}\n' >"$DEP_GRAPH_CACHE_FILE"
+	TEST_GH_ISSUE_VIEW_MODE="fail"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:#1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "cached issue-number absence blocks when live proof fails" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_cache_rebuild_preserves_previous_repo_data_on_fetch_failure() {
+	printf '\n=== cache rebuild fetch failure preservation ===\n'
+	_setup_blocked_by_resolution_test
+	DEP_GRAPH_CACHE_TTL_SECS=0
+	local old_home="$HOME"
+	HOME="${TEST_TMP}/home"
+	mkdir -p "${HOME}/.config/aidevops"
+	printf '{"initialized_repos":[{"slug":"owner/repo","pulse":true}]}\n' >"${HOME}/.config/aidevops/repos.json"
+	printf '{"built_at":"old","repos":{"owner/repo":{"open_issues":[1000],"task_to_issue":{"1000":1000},"blocked_by":{},"defer_flags":{}}}}\n' >"$DEP_GRAPH_CACHE_FILE"
+	TEST_GH_ISSUE_LIST_MODE="fail"
+
+	build_dependency_graph_cache
+	local preserved
+	preserved=$(jq -r '.repos["owner/repo"].task_to_issue["1000"] // empty' "$DEP_GRAPH_CACHE_FILE" 2>/dev/null)
+	if [[ "$preserved" == "1000" ]]; then
+		_pass "failed rebuild preserves previous repo dependency data"
+	else
+		_fail "failed rebuild preserves previous repo dependency data" "preserved=${preserved}"
+	fi
+	HOME="$old_home"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
 main() {
 	test_task_id_blocker_parsing
 	test_issue_number_blocker_parsing
+	test_unknown_task_blocker_fails_closed
+	test_live_task_lookup_failure_fails_closed
+	test_closed_task_blocker_is_clear
+	test_issue_number_live_failure_fails_closed
+	test_cached_issue_number_absence_requires_live_proof
+	test_cache_rebuild_preserves_previous_repo_data_on_fetch_failure
 
 	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Treat parseable blocked-by task IDs as blocked when cache lookup misses and live lookup is empty or fails.
- Verify direct issue-number blockers live when cache absence is not positive proof of closure.
- Preserve prior per-repo dependency cache data when a rebuild cannot fetch or parse repo issue data.

## Verification
- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `.agents/scripts/linters-local.sh`

For #23932

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.20 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 32m and 133,387 tokens on this with the user in an interactive session.
