### PR TITLE
For #23932: block stale recovery on unresolved deps

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -263,6 +263,77 @@ _This escalation is the \"no-progress fail-safe\" from t2008 (paired with t1986 
 }
 
 #######################################
+# Re-check declared blocked-by dependencies before stale relaunch.
+#
+# Stale recovery may remove an abandoned assignment, but it must not convert
+# an issue with open/unknown declared blockers back to status:available. The
+# normal dispatch path also checks blocked-by before launch; this earlier gate
+# prevents stale/no_work recovery from re-amplifying blocked issues into the
+# ranked candidate pool.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+# Returns: 0 if declared dependency is open/unknown; 1 otherwise.
+#######################################
+_stale_recovery_has_unresolved_blocked_by() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	if [[ "$(type -t is_blocked_by_unresolved 2>/dev/null)" != "function" ]]; then
+		local dep_graph_lib="${SCRIPT_DIR}/pulse-dep-graph.sh"
+		# shellcheck source=/dev/null
+		[[ -f "$dep_graph_lib" ]] && source "$dep_graph_lib" 2>/dev/null || true
+	fi
+	[[ "$(type -t is_blocked_by_unresolved 2>/dev/null)" == "function" ]] || return 1
+
+	local issue_body=""
+	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body --jq '.body // ""' 2>/dev/null) || issue_body=""
+	[[ -n "$issue_body" ]] || return 1
+
+	if is_blocked_by_unresolved "$issue_body" "$repo_slug" "$issue_number"; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Apply stale recovery as dependency-blocked instead of available.
+# Args mirror _stale_recovery_apply.
+#######################################
+_stale_recovery_apply_blocked_by_hold() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local stale_assignees="$3"
+	local reason="$4"
+	shift 4
+	local -a recov_extra=("$@")
+
+	set_issue_status "$issue_number" "$repo_slug" "blocked" "${recov_extra[@]}" || true
+
+	local _now_ts=""
+	_now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	gh_issue_comment "$issue_number" --repo "$repo_slug" \
+		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- WORKER_SUPERSEDED runners=${stale_assignees} ts=${_now_ts} -->
+<!-- stale-recovery-blocked-by-unresolved -->
+**Stale assignment recovered, but re-dispatch remains blocked** (GH#23932)
+
+Previously assigned to: ${stale_assignees}
+Reason: ${reason}
+Threshold: ${STALE_ASSIGNMENT_THRESHOLD_SECONDS}s
+
+The stale assignment was unassigned, but the issue still declares an open or unknown \`blocked-by\` dependency. Kept the issue at \`status:blocked\` instead of \`status:available\` so stale/no_work recovery cannot relaunch it until every declared blocker is positively clear.
+
+_This is the stale-recovery dependency re-check for GH#23932._
+<!-- ops:end -->" 2>/dev/null || true
+
+	printf 'STALE_BLOCKED_BY_DEPENDENCY: issue #%s in %s — unassigned %s but kept status:blocked due to unresolved blocked-by (%s)\n' \
+		"$issue_number" "$repo_slug" "$stale_assignees" "$reason"
+	return 0
+}
+
+#######################################
 # Apply normal stale recovery: unassign stale users, transition to
 # status:available, post the audit comment with WORKER_SUPERSEDED marker.
 #
@@ -298,6 +369,10 @@ _stale_recovery_apply() {
 	for assignee in "${assignee_arr[@]}"; do
 		[[ -n "$assignee" ]] && _recov_extra+=(--remove-assignee "$assignee")
 	done
+	if _stale_recovery_has_unresolved_blocked_by "$issue_number" "$repo_slug"; then
+		_stale_recovery_apply_blocked_by_hold "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "${_recov_extra[@]}"
+		return 0
+	fi
 	set_issue_status "$issue_number" "$repo_slug" "available" "${_recov_extra[@]}" || true
 
 	local _now_ts

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -287,6 +287,10 @@ _dedup_layer6_assignee_and_stale() {
 			echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} crash_type=${_stale_crash_type} — recording fast-fail (t1927/t2042)" >>"$LOGFILE"
 			fast_fail_record "$issue_number" "$repo_slug" "stale_timeout" "" "$_stale_crash_type" || true
 		fi
+		if [[ "$assigned_output" == *STALE_BLOCKED_BY_DEPENDENCY* ]]; then
+			echo "[pulse-wrapper] Dedup: stale recovery for #${issue_number} in ${repo_slug} found unresolved blocked-by dependency — blocking re-dispatch (GH#23932)" >>"$LOGFILE"
+			return 0
+		fi
 	fi
 	return 1
 }

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -64,6 +64,10 @@ if [[ "$cmd" == "is-assigned" ]]; then
 		printf '%s\n' 'STALE_RECOVERED: issue #2905 in awardsapp/awardsapp - unassigned runner (dispatch claim 900s old, last activity 900s old (threshold=600s, interactive=false))'
 		exit 1
 		;;
+	blocked_by)
+		printf '%s\n' 'STALE_BLOCKED_BY_DEPENDENCY: issue #2905 in awardsapp/awardsapp - unassigned runner but kept status:blocked due to unresolved blocked-by (no_work)'
+		exit 1
+		;;
 	*)
 		printf '%s\n' 'ASSIGNED: issue #2905 in awardsapp/awardsapp is assigned to runner'
 		exit 0
@@ -193,9 +197,32 @@ test_stale_recovery_with_dispatch_claim_records_fast_fail() {
 	return 0
 }
 
+test_stale_recovery_blocked_by_dependency_blocks_redispatch() {
+	export TEST_STALE_MODE="blocked_by"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "awardsapp/awardsapp" "runner" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		fail "blocked-by stale recovery blocks redispatch" "expected rc=0, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$FAST_FAIL_CALLS" -ne 0 ]]; then
+		fail "blocked-by stale recovery skips fast-fail" "fast_fail_record called ${FAST_FAIL_CALLS} time(s): ${LAST_FAST_FAIL}"
+		return 0
+	fi
+	if ! grep -q 'unresolved blocked-by dependency' "$LOGFILE" 2>/dev/null; then
+		fail "blocked-by stale recovery logs redispatch block" "log: $(tr '\n' ' ' <"$LOGFILE")"
+		return 0
+	fi
+	pass "blocked-by stale recovery blocks redispatch"
+	return 0
+}
+
 test_stale_recovery_without_claim_skips_fast_fail
 test_prelaunch_canary_stale_recovery_skips_fast_fail
 test_stale_recovery_with_dispatch_claim_records_fast_fail
+test_stale_recovery_blocked_by_dependency_blocks_redispatch
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh
+++ b/.agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#23932: stale/no_work recovery must not relabel an
+# issue status:available when its declared blocked-by dependencies are still
+# open or unknown.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPT_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+
+TEST_ROOT="$(mktemp -d -t stale-blocked-by.XXXXXX)" || exit 1
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+LOGFILE="${TEST_ROOT}/pulse.log"
+STATUS_LOG="${TEST_ROOT}/status.log"
+COMMENT_LOG="${TEST_ROOT}/comments.log"
+TEST_ISSUE_BODY=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+reset_logs() {
+	: >"$LOGFILE"
+	: >"$STATUS_LOG"
+	: >"$COMMENT_LOG"
+	return 0
+}
+
+gh() {
+	local resource="${1:-}"
+	local action="${2:-}"
+	if [[ "$resource" == "issue" && "$action" == "view" ]]; then
+		printf '%s\n' "$TEST_ISSUE_BODY"
+		return 0
+	fi
+	return 0
+}
+
+gh_issue_comment() {
+	printf '%s\n' "$*" >>"$COMMENT_LOG"
+	return 0
+}
+
+set_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local status="$3"
+	shift 3
+	printf '%s|%s|%s|%s\n' "$issue_number" "$repo_slug" "$status" "$*" >>"$STATUS_LOG"
+	return 0
+}
+
+is_blocked_by_unresolved() {
+	local issue_body="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	: "$repo_slug" "$issue_number"
+	[[ "$issue_body" == *"blocked-by:"* ]] && return 0
+	return 1
+}
+
+# shellcheck source=../dispatch-dedup-stale.sh
+source "${SCRIPT_DIR}/dispatch-dedup-stale.sh"
+
+test_blocked_by_dependency_keeps_issue_blocked() {
+	reset_logs
+	TEST_ISSUE_BODY="blocked-by:t1000"
+	local output=""
+	output=$(_stale_recovery_apply "123" "owner/repo" "runner-a" "no_work")
+
+	if [[ "$output" == *"STALE_BLOCKED_BY_DEPENDENCY"* ]]; then
+		pass "blocked-by stale recovery emits dependency-blocked marker"
+	else
+		fail "blocked-by stale recovery emits dependency-blocked marker" "output=${output}"
+	fi
+	if grep -q '^123|owner/repo|blocked|' "$STATUS_LOG" && ! grep -q '^123|owner/repo|available|' "$STATUS_LOG"; then
+		pass "blocked-by stale recovery keeps issue status:blocked"
+	else
+		fail "blocked-by stale recovery keeps issue status:blocked" "status=$(tr '\n' ' ' <"$STATUS_LOG")"
+	fi
+	if grep -q 'stale-recovery-blocked-by-unresolved' "$COMMENT_LOG"; then
+		pass "blocked-by stale recovery posts dependency hold comment"
+	else
+		fail "blocked-by stale recovery posts dependency hold comment" "comments=$(tr '\n' ' ' <"$COMMENT_LOG")"
+	fi
+	return 0
+}
+
+test_clear_dependency_state_requeues_available() {
+	reset_logs
+	TEST_ISSUE_BODY="No blockers here"
+	local output=""
+	output=$(_stale_recovery_apply "124" "owner/repo" "runner-a" "stale_timeout")
+
+	if [[ "$output" == *"STALE_RECOVERED"* ]]; then
+		pass "clear stale recovery emits normal recovered marker"
+	else
+		fail "clear stale recovery emits normal recovered marker" "output=${output}"
+	fi
+	if grep -q '^124|owner/repo|available|' "$STATUS_LOG"; then
+		pass "clear stale recovery requeues status:available"
+	else
+		fail "clear stale recovery requeues status:available" "status=$(tr '\n' ' ' <"$STATUS_LOG")"
+	fi
+	return 0
+}
+
+test_blocked_by_dependency_keeps_issue_blocked
+test_clear_dependency_state_requeues_available
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- Re-check declared `blocked-by` dependencies during stale assignment recovery before relabeling an issue `status:available`.
- If a dependency remains open or unknown, unassign stale runners but keep the issue `status:blocked` and post a structured `stale-recovery-blocked-by-unresolved` audit comment.
- Teach the dispatch dedup layer to treat `STALE_BLOCKED_BY_DEPENDENCY` as a current-cycle redispatch block instead of continuing to claim/launch.

## Verification
- `bash .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-dispatch-dedup-layers.sh`
- `shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/pulse-dispatch-dedup-layers.sh .agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `bash .agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh`
- `.agents/scripts/linters-local.sh`

For #23932

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.21 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 47m and 168,000 tokens on this with the user in an interactive session.
