### PR TITLE
GH#23937: require partial parent closeout

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -114,6 +114,8 @@ source "${_PULSE_MERGE_DIR}/shared-claim-lifecycle.sh"
 # when a phase child PR merges for a parent-task issue.
 source "${_PULSE_MERGE_DIR}/shared-phase-filing.sh"
 
+readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
+
 # Source author permission check helpers (GH#21426 — extracted to bring
 # pulse-merge.sh below the 2000-line file-size-debt threshold).
 # shellcheck source=./pulse-merge-author-checks.sh
@@ -384,6 +386,132 @@ _pm_resolve_superseded_original_issue() {
 	return 0
 }
 
+#######################################
+# Extract a non-closing parent/umbrella reference from a PR body.
+#
+# Args: $1=pr_number, $2=repo_slug
+# Stdout: issue number from the first `For #NNN` / `Ref #NNN` reference
+# Returns: 0 always
+#######################################
+_pm_extract_partial_parent_reference() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_body parent_issue
+
+	pr_body=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json body --jq '.body // empty' 2>/dev/null) || pr_body=""
+	parent_issue=$(printf '%s' "$pr_body" | grep -ioE '(^|[[:space:]])(for|ref)[[:space:]]+#[0-9]+' | head -1 | grep -oE '[0-9]+') || parent_issue=""
+	printf '%s' "$parent_issue"
+	return 0
+}
+
+#######################################
+# Decide whether an issue is broad enough to require partial closeout hygiene.
+#
+# Args: $1=issue body, $2=comma-separated label names
+# Returns: 0=broad parent/umbrella issue, 1=normal leaf issue
+#######################################
+_pm_issue_needs_partial_closeout() {
+	local issue_body="$1"
+	local issue_labels="$2"
+	local checklist_count
+
+	if [[ ",${issue_labels}," == *"${_PM_PARENT_TASK_LABEL_NEEDLE}"* ]]; then
+		return 0
+	fi
+
+	if printf '%s' "$issue_body" | grep -qiE '\b(parent|umbrella|roadmap|lifecycle|incident|acceptance criteria)\b'; then
+		return 0
+	fi
+
+	checklist_count=$(printf '%s' "$issue_body" | grep -cE '^[[:space:]]*-[[:space:]]*\[[ xX]\]' || true)
+	[[ "$checklist_count" =~ ^[0-9]+$ ]] || checklist_count=0
+	if [[ "$checklist_count" -ge 2 ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
+# Extract unchecked acceptance criteria as a Markdown bullet list.
+#
+# Args: $1=issue body
+# Stdout: bullet list (or a conservative fallback)
+# Returns: 0 always
+#######################################
+_pm_unmet_acceptance_criteria() {
+	local issue_body="$1"
+	local criteria
+
+	criteria=$(printf '%s' "$issue_body" | sed -nE 's/^[[:space:]]*-[[:space:]]*\[[[:space:]]\][[:space:]]*/- /p' | head -20) || criteria=""
+	if [[ -z "$criteria" ]]; then
+		criteria="- Review the parent issue acceptance criteria and file worker-ready child issues for remaining scope."
+	fi
+	printf '%s' "$criteria"
+	return 0
+}
+
+#######################################
+# Post partial parent/umbrella closeout when a For/Ref PR merges.
+#
+# Non-closing references intentionally do not flow through the normal linked
+# issue close path. This helper keeps the parent open but leaves an explicit
+# closeout trail naming delivered work and follow-ups so broad parents are not
+# left ambiguous after a leaf PR merge (GH#23937).
+#
+# Args: $1=pr_number, $2=repo_slug, $3=merge_summary
+# Returns: 0 always (best-effort post-merge hygiene)
+#######################################
+_pm_handle_partial_parent_closeout() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local merge_summary="$3"
+	local parent_issue issue_api issue_body issue_labels dedup_count followups delivered_body
+
+	parent_issue=$(_pm_extract_partial_parent_reference "$pr_number" "$repo_slug") || parent_issue=""
+	[[ -n "$parent_issue" ]] || return 0
+
+	issue_api=$(_pm_issue_api "$repo_slug" "$parent_issue")
+	issue_body=$(gh api "$issue_api" --jq '.body // empty' 2>/dev/null) || issue_body=""
+	issue_labels=$(gh api "$issue_api" --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+
+	if ! _pm_issue_needs_partial_closeout "$issue_body" "$issue_labels"; then
+		return 0
+	fi
+
+	dedup_count=$(gh api "${issue_api}/comments" 2>/dev/null | jq --arg marker "PARTIAL_PARENT_CLOSEOUT:PR#${pr_number}" '[.[] | select(.body | contains($marker))] | length' 2>/dev/null) || dedup_count=0
+	[[ "$dedup_count" =~ ^[0-9]+$ ]] || dedup_count=0
+	if [[ "$dedup_count" -gt 0 ]]; then
+		echo "[pulse-wrapper] Deterministic merge: skipped duplicate partial parent closeout on #${parent_issue} for PR #${pr_number} (GH#23937)" >>"$LOGFILE"
+		return 0
+	fi
+
+	followups=$(_pm_unmet_acceptance_criteria "$issue_body") || followups="- Review remaining parent acceptance criteria."
+	delivered_body="${merge_summary:-PR #${pr_number} merged as a leaf delivery.}"
+
+	local partial_comment
+	partial_comment="<!-- PARTIAL_PARENT_CLOSEOUT:PR#${pr_number} -->
+## Partial Parent Closeout
+
+PR #${pr_number} merged against this broad parent using a non-closing \`For #${parent_issue}\` / \`Ref #${parent_issue}\` reference, so the parent remains open.
+
+### Delivered
+
+${delivered_body}
+
+### Follow-ups still requiring closure or child issues
+
+${followups}
+
+### Closeout rule
+
+Do not close this parent until the remaining acceptance criteria are covered by merged release evidence or an explicit maintainer/operator closeout decision is posted."
+
+	gh_issue_comment "$parent_issue" --repo "$repo_slug" --body "$partial_comment" 2>/dev/null || true
+	echo "[pulse-wrapper] Deterministic merge: posted partial parent closeout on issue #${parent_issue} for PR #${pr_number} (GH#23937)" >>"$LOGFILE"
+	return 0
+}
+
 _handle_post_merge_actions() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -422,7 +550,7 @@ _handle_post_merge_actions() {
 		local _linked_labels
 		_linked_labels=$(gh api "${_pm_li_api}" \
 			--jq '[.labels[].name] | join(",")' 2>/dev/null) || _linked_labels=""
-		if [[ ",${_linked_labels}," == *",parent-task,"* ]]; then
+		if [[ ",${_linked_labels}," == *"${_PM_PARENT_TASK_LABEL_NEEDLE}"* ]]; then
 			_parent_task_guard=1
 			echo "[pulse-wrapper] Deterministic merge: skipping close of parent-task issue #${linked_issue} (PR #${pr_number} is a phase child; parent stays open until all phases merge) — t2099/GH#19032" >>"$LOGFILE"
 		fi
@@ -467,7 +595,7 @@ _handle_post_merge_actions() {
 			_sup_api=$(_pm_issue_api "$repo_slug" "$_superseded_original_issue")
 			_sup_labels=$(gh api "${_sup_api}" \
 				--jq '[.labels[].name] | join(",")' 2>/dev/null) || _sup_labels=""
-			if [[ ",${_sup_labels}," == *",parent-task,"* ]]; then
+			if [[ ",${_sup_labels}," == *"${_PM_PARENT_TASK_LABEL_NEEDLE}"* ]]; then
 				_sup_parent_guard=1
 				echo "[pulse-wrapper] Deterministic merge: skipping close of parent-task original issue #${_superseded_original_issue} via superseded PR #${linked_issue} (merged PR #${pr_number}) — GH#22964" >>"$LOGFILE"
 			fi
@@ -494,6 +622,10 @@ _handle_post_merge_actions() {
 				unlock_issue_after_worker "$_superseded_original_issue" "$repo_slug"
 			fi
 		fi
+	fi
+
+	if [[ -z "$linked_issue" ]]; then
+		_pm_handle_partial_parent_closeout "$pr_number" "$repo_slug" "$merge_summary"
 	fi
 
 	# Auto-release interactive claim if one exists for this issue (t2413).

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -396,7 +396,7 @@ _pm_resolve_superseded_original_issue() {
 _pm_extract_partial_parent_reference() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local pr_body parent_issue
+	local pr_body="" parent_issue=""
 
 	pr_body=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json body --jq '.body // empty' 2>/dev/null) || pr_body=""
 	parent_issue=$(printf '%s' "$pr_body" | grep -ioE '(^|[[:space:]])(for|ref)[[:space:]]+#[0-9]+' | head -1 | grep -oE '[0-9]+') || parent_issue=""
@@ -466,7 +466,7 @@ _pm_handle_partial_parent_closeout() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local merge_summary="$3"
-	local parent_issue issue_api issue_body issue_labels dedup_count followups delivered_body
+	local parent_issue="" issue_api="" issue_body="" issue_labels="" dedup_count="" followups="" delivered_body=""
 
 	parent_issue=$(_pm_extract_partial_parent_reference "$pr_number" "$repo_slug") || parent_issue=""
 	[[ -n "$parent_issue" ]] || return 0

--- a/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
@@ -32,6 +32,7 @@ readonly TEST_RESET=$'\033[0m'
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
+readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
 
 print_result() {
 	local test_name="$1"
@@ -78,6 +79,11 @@ if [[ "$1" == "api" && "$*" == *"/issues/"* && "$*" == *"labels"* && "$*" != *"/
 	exit 0
 fi
 
+# gh api repos/OWNER/REPO/pulls/NNN  (superseded-PR lookup)
+if [[ "$1" == "api" && "$*" == *"/pulls/"* ]]; then
+	exit 1
+fi
+
 # gh api repos/OWNER/REPO/issues/NNN/comments  (dedup check)
 if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
 	printf '[]\n'
@@ -97,7 +103,9 @@ EOF
 	unlock_issue_after_worker() { return 0; }
 	fast_fail_reset() { return 0; }
 	_release_interactive_claim_on_merge() { return 0; }
-	export -f unlock_issue_after_worker fast_fail_reset _release_interactive_claim_on_merge 2>/dev/null || true
+	set_solved_label() { return 0; }
+	auto_file_next_phase() { return 0; }
+	export -f unlock_issue_after_worker fast_fail_reset _release_interactive_claim_on_merge set_solved_label auto_file_next_phase 2>/dev/null || true
 
 	# Shim shared-gh-wrappers.sh wrappers → gh binary stub. The function was
 	# refactored post-GH#21595 to use gh_pr_comment / gh_issue_comment instead
@@ -137,7 +145,10 @@ define_function_under_test() {
 	local fn_src
 	fn_src=$(awk '
 		/^_pm_issue_api\(\) \{/,/^}$/ { print }
+		/^_pm_build_closing_comment\(\) \{/,/^}$/ { print }
+		/^_pm_resolve_superseded_original_issue\(\) \{/,/^}$/ { print }
 		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
+		/^_unblock_circuit_breaker_meta_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	if [[ -z "$fn_src" ]]; then
 		printf 'ERROR: could not extract _handle_post_merge_actions from %s\n' "$MERGE_SCRIPT" >&2

--- a/.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh
+++ b/.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for GH#23937: when a merged PR references a broad parent with
+# `For #NNN` / `Ref #NNN`, deterministic post-merge automation must keep the
+# parent open but post an explicit partial closeout trail with remaining
+# follow-ups.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%sFAIL%s %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	export GH_COMMENT_LOG="${TEST_ROOT}/gh-comments.log"
+	export TEST_PR_BODY=""
+	export TEST_ISSUE_BODY=""
+	export TEST_ISSUE_LABELS=""
+	export TEST_EXISTING_COMMENTS="[]"
+	: >"$LOGFILE"
+	: >"$GH_CALL_LOG"
+	: >"$GH_COMMENT_LOG"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh for test-pulse-merge-partial-parent-closeout.sh
+printf '%s\n' "$*" >>"${GH_CALL_LOG}"
+
+if [[ "$1" == "api" && "$2" == *"/issues/23932/comments"* ]]; then
+	printf '%s\n' "${TEST_EXISTING_COMMENTS:-[]}"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == *"/issues/23932"* && "$*" == *".body"* ]]; then
+	printf '%s\n' "${TEST_ISSUE_BODY:-}"
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == *"/issues/23932"* && "$*" == *"labels"* ]]; then
+	printf '%s\n' "${TEST_ISSUE_LABELS:-}"
+	exit 0
+fi
+
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+gh_pr_view() {
+	local pr_number="$1"
+	shift
+	printf '%s\n' "${TEST_PR_BODY:-}"
+	return 0
+}
+
+gh_issue_comment() {
+	printf '%s\n' "$*" >>"$GH_COMMENT_LOG"
+	return 0
+}
+
+define_functions_under_test() {
+	local fn_src
+	fn_src=$(awk '
+		/^_pm_issue_api\(\) \{/,/^}$/ { print }
+		/^_pm_extract_partial_parent_reference\(\) \{/,/^}$/ { print }
+		/^_pm_issue_needs_partial_closeout\(\) \{/,/^}$/ { print }
+		/^_pm_unmet_acceptance_criteria\(\) \{/,/^}$/ { print }
+		/^_pm_handle_partial_parent_closeout\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$fn_src" ]]; then
+		printf 'ERROR: could not extract partial closeout helpers from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helpers
+	eval "$fn_src"
+	return 0
+}
+
+assert_comment_contains() {
+	local pattern="$1"
+	local label="$2"
+	if grep -q -- "$pattern" "$GH_COMMENT_LOG" 2>/dev/null; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Expected comment pattern: $pattern"
+	fi
+	return 0
+}
+
+assert_no_comment() {
+	local label="$1"
+	if [[ ! -s "$GH_COMMENT_LOG" ]]; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Unexpected comment: $(tr '\n' ' ' <"$GH_COMMENT_LOG")"
+	fi
+	return 0
+}
+
+test_for_reference_posts_partial_closeout() {
+	: >"$GH_COMMENT_LOG"
+	: >"$LOGFILE"
+	export TEST_PR_BODY="For #23932
+
+Delivered leaf work only."
+	export TEST_ISSUE_LABELS="enhancement,tier:standard"
+	export TEST_ISSUE_BODY="## Summary
+
+Umbrella lifecycle parent.
+
+## Acceptance Criteria
+
+- [ ] Delivered leaf: dependency graph fail-closed unknown blocked-by resolution.
+- [ ] Remaining: stale/no_work re-checks.
+- [ ] Remaining: candidate ranking suppression.
+- [ ] Remaining: worker bootstrap hard-stop."
+	export TEST_EXISTING_COMMENTS="[]"
+
+	_pm_handle_partial_parent_closeout "23936" "marcusquinn/aidevops" "Merged dependency graph leaf."
+
+	assert_comment_contains "PARTIAL_PARENT_CLOSEOUT:PR#23936" \
+		"For/Ref broad parent: posts dedup marker"
+	assert_comment_contains "Remaining: stale/no_work re-checks" \
+		"For/Ref broad parent: lists remaining acceptance criteria"
+	assert_comment_contains "Do not close this parent" \
+		"For/Ref broad parent: records no-close rule"
+	return 0
+}
+
+test_leaf_reference_without_broad_signal_skips_comment() {
+	: >"$GH_COMMENT_LOG"
+	export TEST_PR_BODY="Ref #23932"
+	export TEST_ISSUE_LABELS="bug,tier:simple"
+	export TEST_ISSUE_BODY="Small leaf bug report without checklist."
+	export TEST_EXISTING_COMMENTS="[]"
+
+	_pm_handle_partial_parent_closeout "23936" "marcusquinn/aidevops" "Leaf fix."
+	assert_no_comment "leaf issue: partial parent closeout skipped"
+	return 0
+}
+
+test_existing_marker_skips_duplicate_comment() {
+	: >"$GH_COMMENT_LOG"
+	export TEST_PR_BODY="For #23932"
+	export TEST_ISSUE_LABELS="parent-task"
+	export TEST_ISSUE_BODY="## Acceptance Criteria
+
+- [ ] One
+- [ ] Two"
+	export TEST_EXISTING_COMMENTS='[{"body":"<!-- PARTIAL_PARENT_CLOSEOUT:PR#23936 -->"}]'
+
+	_pm_handle_partial_parent_closeout "23936" "marcusquinn/aidevops" "Leaf fix."
+	assert_no_comment "duplicate marker: comment skipped"
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	if ! define_functions_under_test; then
+		printf 'FATAL: function extraction failed\n' >&2
+		return 1
+	fi
+
+	test_for_reference_posts_partial_closeout
+	test_leaf_reference_without_broad_signal_skips_comment
+	test_existing_marker_skips_duplicate_comment
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Added deterministic post-merge partial parent closeout for merged `For #NNN` / `Ref #NNN` PRs.
- Posts a deduplicated parent progress comment with delivered work, remaining follow-ups, and a no-close rule.
- Added regression coverage for the broad parent/leaf PR pattern.

Resolves #23937

## Testing

- `.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh`
- `.agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh`
- `.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh`
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh .agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.22 plugin for [OpenCode](https://opencode.ai) v1.15.6
