### PR TITLE
fix: fail closed on dispatch claim errors

### DIFF
--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -303,7 +303,7 @@ _dedup_layer6_assignee_and_stale() {
 # value propagates up two stack frames.
 #
 # Arguments: issue_number, repo_slug, self_login
-# Exit: 0 = blocked, 1 = continue (won claim or fail-open error path)
+# Exit: 0 = blocked, 1 = continue (won claim)
 #######################################
 _dedup_layer7_claim_lock() {
 	local issue_number="$1"
@@ -328,7 +328,11 @@ _dedup_layer7_claim_lock() {
 			echo "[pulse-wrapper] Dedup: pre-check found active claim on #${issue_number} in ${repo_slug} — skipping (${_precheck_output})" >>"$LOGFILE"
 			return 0
 		fi
-		# No active claim found (exit 1) or error (exit 2, fail-open) — proceed to claim
+		if [[ "$_precheck_exit" -eq 2 ]]; then
+			echo "[pulse-wrapper] Dedup: claim pre-check error for #${issue_number} in ${repo_slug} — blocking dispatch for this cycle (fail-closed)" >>"$LOGFILE"
+			return 0
+		fi
+		# No active claim found (exit 1) — proceed to claim.
 		local claim_exit=0 claim_output=""
 		claim_output=$("$dedup_helper" claim "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE") || claim_exit=$?
 		echo "$claim_output" >>"$LOGFILE"
@@ -337,7 +341,8 @@ _dedup_layer7_claim_lock() {
 			return 0
 		fi
 		if [[ "$claim_exit" -eq 2 ]]; then
-			echo "[pulse-wrapper] Dedup: claim error for #${issue_number} in ${repo_slug} — proceeding (fail-open)" >>"$LOGFILE"
+			echo "[pulse-wrapper] Dedup: claim error for #${issue_number} in ${repo_slug} — blocking dispatch for this cycle (fail-closed)" >>"$LOGFILE"
+			return 0
 		fi
 		# Extract claim comment_id for post-dispatch cleanup (GH#15317)
 		_claim_comment_id=$(printf '%s' "$claim_output" | sed -n 's/.*comment_id=\([0-9]*\).*/\1/p')

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -40,6 +40,7 @@ WORKER_LAUNCH="${AGENT_SCRIPT_DIR}/pulse-dispatch-worker-launch.sh"
 HEADLESS_LIB="${AGENT_SCRIPT_DIR}/headless-runtime-lib.sh"
 PULSE_ENGINE="${AGENT_SCRIPT_DIR}/pulse-dispatch-engine.sh"
 WORKER_LIFECYCLE="${AGENT_SCRIPT_DIR}/worker-lifecycle-common.sh"
+DEDUP_LAYERS="${AGENT_SCRIPT_DIR}/pulse-dispatch-dedup-layers.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -660,6 +661,18 @@ test_nohup_launch_passes_repo_slug_contract() {
 	return 0
 }
 
+test_claim_lock_errors_fail_closed() {
+	if grep -q 'claim pre-check error.*fail-closed' "$DEDUP_LAYERS" \
+		&& grep -q 'claim error.*fail-closed' "$DEDUP_LAYERS" \
+		&& ! grep -q 'proceeding (fail-open)' "$DEDUP_LAYERS"; then
+		print_result "invariant: claim API errors block dispatch instead of launching duplicate workers" 0
+		return 0
+	fi
+	print_result "invariant: claim API errors block dispatch instead of launching duplicate workers" 1 \
+		"Expected claim pre-check/claim exit=2 paths in $DEDUP_LAYERS to fail closed and no fail-open launch path"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main runner
 # ---------------------------------------------------------------------------
@@ -667,7 +680,7 @@ test_nohup_launch_passes_repo_slug_contract() {
 main_test() {
 	# Verify the target files exist before running tests
 	local f
-	for f in "$PULSE_CLEANUP" "$WORKER_LAUNCH" "$HEADLESS_LIB" "$PULSE_ENGINE" "$WORKER_LIFECYCLE"; do
+	for f in "$PULSE_CLEANUP" "$WORKER_LAUNCH" "$HEADLESS_LIB" "$PULSE_ENGINE" "$WORKER_LIFECYCLE" "$DEDUP_LAYERS"; do
 		if [[ ! -f "$f" ]]; then
 			printf 'FATAL: target file missing: %s\n' "$f" >&2
 			return 2
@@ -708,6 +721,7 @@ main_test() {
 	test_prelaunch_reason_parser_behavioural
 	test_prelaunch_reason_parser_preserves_explicit_reason
 	test_nohup_launch_passes_repo_slug_contract
+	test_claim_lock_errors_fail_closed
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Root cause: `.agents/scripts/pulse-dispatch-dedup-layers.sh::_dedup_layer7_claim_lock` treated `dispatch-dedup-helper.sh` claim/pre-check API errors as fail-open, so transient comment-fetch failures allowed multiple runners to launch against the same issue/worktree and later record `no_worker_process` fast-fails.
- Changed claim pre-check and claim exit-code `2` paths to fail closed for the current pulse cycle instead of launching a worker without a trustworthy cross-runner claim.
- Added a regression guard to `.agents/scripts/tests/test-no-worker-process-fix.sh` so claim API errors cannot reintroduce the duplicate-worker launch path.

Resolves #23944
Ref awardsapp/awardsapp#5471
Ref awardsapp/awardsapp#5454

## Testing

```bash
bash .agents/scripts/tests/test-no-worker-process-fix.sh
bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh
bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.22 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 12m and 140,605 tokens on this as a headless worker.