### PR TITLE
GH#23945: docs: adopt upstream watch updates

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -16,6 +16,7 @@ over token savings.
    - `rtk-helper.sh gh issue list --repo owner/repo --limit N`
    - In interactive discovery, use these RTK forms instead of raw `gh pr list`
      or `gh issue list` unless the command needs structured/exact output.
+   - RTK v0.40.0 also adds upstream Gradle wrapper support, `rtk init --agent hermes`, `rtk init --dry-run`, and `transparent_prefixes` for wrapper command passthrough; prefer those upstream features over custom aidevops shims when integrating supported runtimes or build tools.
 2. **Assess sufficiency**: proceed only if the filtered output contains every
    fact needed for the next decision.
 3. **Broaden immediately** when output is incomplete, ambiguous, expanded rather

--- a/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
+++ b/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
@@ -50,9 +50,11 @@ export YELLOW="" BLUE="" GREEN="" NC=""
 
 GH_CREATE_CALLS="${TMP}/gh_create_calls.log"
 GH_EDIT_CALLS="${TMP}/gh_edit_calls.log"
+GH_ISSUE_LIST_CALLS="${TMP}/gh_issue_list_calls.log"
 GH_WARNINGS="${TMP}/warnings.log"
 : >"$GH_CREATE_CALLS"
 : >"$GH_EDIT_CALLS"
+: >"$GH_ISSUE_LIST_CALLS"
 : >"$GH_WARNINGS"
 
 _log_warn() { printf '%s\n' "$*" >>"$GH_WARNINGS"; return 0; }
@@ -71,6 +73,7 @@ gh() {
 		return 0
 	fi
 	if [[ "$1" == "issue" && "${2:-}" == "list" ]]; then
+		printf '%s\n' "$*" >>"$GH_ISSUE_LIST_CALLS"
 		return 0
 	fi
 	return 0
@@ -150,6 +153,14 @@ else
 	ok=0
 fi
 check "$ok" "unauthorized batch writes local report without public issue" "create_count=${create_count} reports=${before_reports}->${after_reports}"
+
+# Test 5: issue discovery uses gh's supported --limit flag, not unsupported --paginate.
+if grep -q -- '--paginate' "$GH_ISSUE_LIST_CALLS"; then
+	ok=0
+else
+	ok=1
+fi
+check "$ok" "upstream-watch issue list avoids unsupported gh --paginate flag" "calls=$(wc -l <"$GH_ISSUE_LIST_CALLS" | tr -d '[:space:]')"
 
 if [[ "$FAIL" -gt 0 ]]; then
 	printf '%s test(s) failed, %s passed\n' "$FAIL" "$PASS" >&2

--- a/.agents/scripts/upstream-watch-helper-issues.sh
+++ b/.agents/scripts/upstream-watch-helper-issues.sh
@@ -207,7 +207,7 @@ _file_upstream_batch_update_issue() {
 	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
 		--label "$UPSTREAM_WATCH_LABEL" \
 		--search 'in:title "upstream: batch"' \
-		--paginate \
+		--limit 1000 \
 		--json number --jq '.[0].number // empty') || existing_number=""
 
 	local sig_footer=""
@@ -384,12 +384,12 @@ _file_upstream_update_issue() {
 
 	# --- Dedup: check for existing open issue ---
 	# Quote the search term to handle slugs/names with special characters or spaces.
-	# Use --paginate to ensure all results are retrieved (avoids missed dedup on busy repos).
+	# Use a high limit because `gh issue list` does not support `--paginate`.
 	local existing_number=""
 	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
 		--label "$UPSTREAM_WATCH_LABEL" \
 		--search "in:title \"upstream: ${slug_or_name}\"" \
-		--paginate \
+		--limit 1000 \
 		--json number --jq '.[0].number // empty') || existing_number=""
 
 	# Extract relevance, affects, and upstream URL from config entry
@@ -488,12 +488,12 @@ _close_upstream_update_issue() {
 
 	# Find matching open issue.
 	# Quote the search term to handle slugs/names with special characters or spaces.
-	# Use --paginate to ensure all results are retrieved.
+	# Use a high limit because `gh issue list` does not support `--paginate`.
 	local issue_number=""
 	issue_number=$(gh issue list --repo "$aidevops_slug" --state open \
 		--label "$UPSTREAM_WATCH_LABEL" \
 		--search "in:title \"upstream: ${slug_or_name}\"" \
-		--paginate \
+		--limit 1000 \
 		--json number --jq '.[0].number // empty') || issue_number=""
 
 	if [[ -z "$issue_number" ]]; then

--- a/.agents/tools/deployment/cloudron-app-packaging-skill.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill.md
@@ -26,6 +26,7 @@ Cloudron apps are Docker images plus `CloudronManifest.json`. The platform provi
 - **Upstream**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-app-packaging`) | [docs.cloudron.io/packaging](https://docs.cloudron.io/packaging/)
 - **Reference files**: `cloudron-app-packaging-skill/manifest-ref.md`, `cloudron-app-packaging-skill/addons-ref.md`
 - **Also see**: `cloudron-app-packaging.md` (native aidevops guide: helpers, local dev, Dockerfile/start.sh patterns, pre-packaging checks)
+- **Last upstream review**: `fcea39616e6e` ("Update the skill for cloudron sync"); no local import changes required beyond keeping the native guide and skill pointers aligned.
 
 ```bash
 npm install -g cloudron

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -91,7 +91,9 @@ Score both axes before writing code. Initial packaging is ~25% of effort; SSO, u
 
 **Multi-stage builds**: Only when build toolchain is exotic. Build in upstream image, `COPY --from` artifacts into final `cloudron/base` stage. **Alpine/musl warning**: musl-compiled binaries won't run on `cloudron/base` (Ubuntu/glibc) — always use glibc builder stage.
 
-**Base image contents (Cloudron 9.1.3)**: Ubuntu 24.04.1 LTS, Node.js 24.x (default; 22 LTS at `/usr/local/node-22.14.0`), Python 3.12.3, PHP 8.3.6 (redis/imagick/ldap/gd/mbstring), Nginx 1.24.0, Apache 2.4.58, Supervisor 4.2.5, gosu 1.17, gcc 13.3.0, ImageMagick 6.9.12, ffmpeg 6.1.1, psql 16.6, mysql 8.0.41, redis-cli 7.4.2, mongosh 2.4.0. **Not included** (install if needed): Ruby, Go, Java, Rust, pandoc, wkhtmltopdf.
+**Base image contents (Cloudron 9.1.3)**: Ubuntu 24.04.1 LTS, Node.js 24.x (default; 22 LTS at `/usr/local/node-22.14.0`), Python 3.12.3, PHP 8.3.6 (redis/imagick/ldap/gd/mbstring), Nginx 1.24.0, Apache 2.4.58, Supervisor 4.2.5, gosu 1.17, gcc 13.3.0, ImageMagick 6.9.12, ffmpeg 6.1.1, psql 16.6, mysql 8.0.41, redis-cli 7.4.2, mongosh 2.4.0. Reviewed `cloudron/base:5.0.0` tag digest remains `sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c`. **Not included** (install if needed): Ruby, Go, Java, Rust, pandoc, wkhtmltopdf.
+
+**Community assessment intake (reviewed at `047e4b07ce36`)**: import packaging lessons from the added assessment corpus rather than copying whole assessments. Good follow-up candidates include Huginn (medium structural, moderate maintenance, viable), while AppFlowy Cloud and ejabberd remain poor fits because of multi-service/auth/storage or network-port constraints. Prosody is the stronger XMPP path when raw TCP/TLS/DNS requirements are acceptable.
 
 ## CloudronManifest.json
 

--- a/.agents/tools/design/design-md.md
+++ b/.agents/tools/design/design-md.md
@@ -37,6 +37,8 @@ model: sonnet
 
 **Agent relationships:**
 
+Upstream `@google/design.md` v0.1.0 was reviewed as the initial open-source release of the CLI/linter. The current aidevops schema guidance already covers the release's agent-safe JSON output, `designmd` Windows alias, lint/diff/export/spec commands, and alpha-format token model; continue watching for v1 or schema-breaking releases before changing templates.
+
 | Agent | Role | Relationship |
 |-------|------|--------------|
 | `tools/design/brand-identity.md` | Strategic brand profile (8 dimensions) | **Upstream** — feeds DESIGN.md generation |

--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -27,9 +27,9 @@ tools:
 - **Project pin**: `asc init --app-id <id>` (saves `.asc/project.json`, auto-used by all commands)
 - **Verify**: `asc auth check` | **Multi-account**: `asc auth use <name>`
 - **Context resolution**: explicit `--app-id` > `.asc/project.json` > prompt user to `asc init` (CI must use `--app-id` or pre-run `asc init`)
-- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands)
+- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands; v0.18.0 adds `versions update` release metadata flags)
 - **Website**: https://asccli.app | **Web apps**: [Command Center](https://asccli.app/command-center), [Console](https://asccli.app/console), [Screenshot Studio](https://asccli.app/editor)
-- **Skills**: [Official](https://github.com/tddworks/asc-cli-skills) (27 command-group skills, checked at `63a6b994c315`) | [Community](https://github.com/rudrankriyam/app-store-connect-cli-skills) (22 workflow skills, checked at `c45a9fa1f63d`)
+- **Skills**: [Official](https://github.com/tddworks/asc-cli-skills) (27 command-group skills, checked at `6465c10feb89`) | [Community](https://github.com/rudrankriyam/app-store-connect-cli-skills) (22 workflow skills, checked at `8e67f1969e1b`)
 - **Requirements**: macOS 13+, App Store Connect API key, `jq` (workflow scripts use `jq -r`)
 
 **Dependency check**: Before any `asc` command:
@@ -75,6 +75,8 @@ command -v jq >/dev/null || { brew install jq || exit 1; }
 # 1. Archive and upload (or upload pre-built IPA)
 asc builds archive --scheme MyApp --upload --app-id APP_ID --version 1.2.0 --build-number 55
 # OR: asc builds upload --app-id APP_ID --file MyApp.ipa --version 1.2.0 --build-number 55
+# If export compliance is missing, answer it before external TestFlight review
+asc builds set-encryption-compliance --build-id BUILD_ID --uses-non-exempt-encryption false
 
 # 2. TestFlight distribution
 GROUP_ID=$(asc testflight groups list --app-id APP_ID | jq -r '.data[0].id')
@@ -84,6 +86,7 @@ asc builds add-beta-group --build-id "$BUILD_ID" --beta-group-id "$GROUP_ID"
 # 3. Link build to version, update What's New, submit
 VERSION_ID=$(asc versions list --app-id APP_ID | jq -r '.data[0].id')
 asc versions set-build --version-id "$VERSION_ID" --build-id "$BUILD_ID"
+asc versions update --version-id "$VERSION_ID" --copyright "© 2026 Example" --release-type AFTER_APPROVAL
 LOC_ID=$(asc version-localizations list --version-id "$VERSION_ID" | jq -r '.data[0].id')
 asc version-localizations update --localization-id "$LOC_ID" --whats-new "Bug fixes and improvements"
 asc versions check-readiness --version-id "$VERSION_ID"
@@ -113,11 +116,11 @@ Run `asc web-server` to start the local API bridge (ports 8420 HTTP, 8421 HTTPS)
 
 ## Agent Skills
 
-Install on-demand (not pre-loaded): **Official** `asc skills install --all` (per-command reference) | **Community** `npx skills add rudrankriyam/app-store-connect-cli-skills` (workflow orchestration: releases, ASO, localization, RevenueCat, crash triage). These upstream skill packs are tracked for review but intentionally remain on-demand until aidevops has a multi-skill import strategy for repositories containing dozens of `SKILL.md` files.
+Install on-demand (not pre-loaded): **Official** `asc skills install --all` (per-command reference) | **Community** `npx skills add rudrankriyam/app-store-connect-cli-skills` (workflow orchestration: releases, ASO, localization, RevenueCat, crash triage). These upstream skill packs are tracked for review but intentionally remain on-demand until aidevops has a multi-skill import strategy for repositories containing dozens of `SKILL.md` files. Latest reviewed official skill change adds build export-compliance handling; latest community refresh updates stale workflow skills.
 
 ## Blitz MCP Server (Optional)
 
-[Blitz](https://github.com/blitzdotdev/blitz-mac) — native macOS app with 30+ MCP tools for iOS dev. Overlaps with XcodeBuildMCP/ios-simulator-mcp but adds ASC submission. MCP config: `{ "mcpServers": { "blitz": { "command": "npx", "args": ["-y", "@blitzdev/blitz-mcp"] } } }`
+[Blitz](https://github.com/blitzdotdev/blitz-mac) — native macOS app with 30+ MCP tools for iOS dev. Overlaps with XcodeBuildMCP/ios-simulator-mcp but adds ASC submission. v1.0.35 auto-imports existing App Store Connect apps into the dashboard and simplifies screenshots. MCP config: `{ "mcpServers": { "blitz": { "command": "npx", "args": ["-y", "@blitzdev/blitz-mcp"] } } }`
 
 ## Mobile Stack Integration
 


### PR DESCRIPTION
## Summary

Reviewed the upstream-watch batch, adopted relevant RTK, App Store Connect, DESIGN.md, Cloudron, and Blitz guidance updates, acknowledged all watched sources, and fixed upstream-watch ack issue lookup to avoid unsupported gh issue list --paginate usage.

## Files Changed

.agents/reference/context-efficient-output.md,.agents/scripts/tests/test-upstream-watch-issue-gate.sh,.agents/scripts/upstream-watch-helper-issues.sh,.agents/tools/deployment/cloudron-app-packaging-skill.md,.agents/tools/deployment/cloudron-app-packaging.md,.agents/tools/design/design-md.md,.agents/tools/mobile/app-store-connect.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-upstream-watch-issue-gate.sh; shellcheck .agents/scripts/upstream-watch-helper-issues.sh .agents/scripts/tests/test-upstream-watch-issue-gate.sh; .agents/scripts/linters-local.sh

Resolves #23945


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.22 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 16m and 113,232 tokens on this as a headless worker.