### PR TITLE
GH#23947: widen review feedback supersession window

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -661,21 +661,49 @@ _rf_issue_in_supersession_scope() {
 
 _rf_search_merged_pr_numbers() {
 	local slug="$1"
-	local created_at="$2"
-	local created_date="${created_at%%T*}"
+	local search_after="$2"
+	local search_date="${search_after%%T*}"
 	local limit="${AIDEVOPS_REVIEW_FEEDBACK_SUPERSESSION_LIMIT:-25}"
 
-	if [[ -z "$created_date" || "$created_date" == "$created_at" ]]; then
+	if [[ -z "$search_date" || "$search_date" == "$search_after" ]]; then
 		return 1
 	fi
 
 	gh api -X GET search/issues \
-		-f q="repo:${slug} is:pr is:merged merged:>=${created_date}" \
+		-f q="repo:${slug} is:pr is:merged merged:>=${search_date}" \
 		-f sort=updated \
 		-f order=desc \
 		-f per_page="$limit" \
 		--jq '.items[]?.number' 2>/dev/null || true
 	return 0
+}
+
+_rf_extract_source_pr_number() {
+	local issue_body="$1"
+	local issue_title="$2"
+	local source_pr=""
+
+	source_pr=$(printf '%s\n%s\n' "$issue_body" "$issue_title" | sed -En '/\*\*Source PR\*\*:/ { s/.*\*\*Source PR\*\*:[[:space:]]*#?([0-9]+).*/\1/; p; q; }; /Review followup:[[:space:]]*PR/ { s/.*Review followup:[[:space:]]*PR[[:space:]]*#?([0-9]+).*/\1/; p; q; }')
+	if [[ "$source_pr" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$source_pr"
+		return 0
+	fi
+
+	return 1
+}
+
+_rf_get_source_pr_merged_at() {
+	local slug="$1"
+	local source_pr="$2"
+	local merged_at=""
+
+	merged_at=$(gh api "repos/${slug}/pulls/${source_pr}" --jq '.merged_at // ""' 2>/dev/null) || return 1
+	if [[ -n "$merged_at" && "$merged_at" == *T* ]]; then
+		printf '%s\n' "$merged_at"
+		return 0
+	fi
+
+	return 1
 }
 
 _rf_get_pr_files() {
@@ -797,6 +825,7 @@ _rf_post_ambiguous_comment() {
 	local issue_paths="$3"
 	local keywords="$4"
 	local ambiguous_evidence="$5"
+	local search_context="$6"
 	local marker='<!-- review-feedback-supersession-ambiguous -->'
 
 	if _rf_comment_marker_exists "$issue_number" "$slug" "$marker"; then
@@ -815,7 +844,7 @@ _rf_post_ambiguous_comment() {
 ${marker}
 ## Possible review-feedback supersession
 
-Pre-dispatch found merged PRs after this issue was created that touched cited file paths, but the diff/title/body keyword evidence was not strong enough to skip worker dispatch.
+Pre-dispatch found merged PRs in the ${search_context} that touched cited file paths, but the diff/title/body keyword evidence was not strong enough to skip worker dispatch.
 
 - **Cited files:** ${compact_paths}
 - **Finding keywords:** ${compact_keywords}
@@ -838,6 +867,8 @@ _rf_close_with_supersession() {
 	local merged_at="$4"
 	local overlaps="$5"
 	local matched_keywords="$6"
+	local search_context="$7"
+	local source_pr="$8"
 	local marker='<!-- review-feedback-superseded-by-merged-pr -->'
 	local sig_footer=""
 
@@ -846,14 +877,19 @@ _rf_close_with_supersession() {
 	fi
 
 	local compact_overlaps=""
+	local source_pr_line=""
 	local comment_body=""
 	compact_overlaps=$(_rf_join_lines "$overlaps")
 	[[ -n "$matched_keywords" ]] || matched_keywords="issue reference"
+	if [[ -n "$source_pr" ]]; then
+		source_pr_line="- **Source PR:** #${source_pr}"
+	fi
 
 	comment_body=$(cat <<EOF
 ${marker}
-> Superseded. Pre-dispatch review-feedback validator found merged PR #${pr_number} after this issue was created. The PR touches the cited file path(s) and matches the finding signal, so worker dispatch is skipped.
+> Superseded. Pre-dispatch review-feedback validator found merged PR #${pr_number} in the ${search_context}. The PR touches the cited file path(s) and matches the finding signal, so worker dispatch is skipped.
 
+${source_pr_line}
 - **Merged PR:** #${pr_number}
 - **Merged at:** ${merged_at}
 - **Overlapping files:** ${compact_overlaps}
@@ -915,10 +951,24 @@ _detect_review_feedback_supersession() {
 	local keywords=""
 	keywords=$(_rf_extract_keywords "$issue_body")
 
+	local source_pr=""
+	local source_merged_at=""
+	local search_after="$created_at"
+	local search_context="issue-created window after ${created_at}"
+	if source_pr=$(_rf_extract_source_pr_number "$issue_body" "$issue_title"); then
+		if source_merged_at=$(_rf_get_source_pr_merged_at "$slug" "$source_pr"); then
+			search_after="$source_merged_at"
+			search_context="source PR #${source_pr} merge window after ${source_merged_at}"
+		else
+			_log "WARN" "#${issue_number}: failed to fetch source PR #${source_pr} merged_at — using issue-created supersession window"
+			source_pr=""
+		fi
+	fi
+
 	local candidate_numbers=""
-	candidate_numbers=$(_rf_search_merged_pr_numbers "$slug" "$created_at") || candidate_numbers=""
+	candidate_numbers=$(_rf_search_merged_pr_numbers "$slug" "$search_after") || candidate_numbers=""
 	if [[ -z "$candidate_numbers" ]]; then
-		_log "INFO" "#${issue_number}: no merged PR candidates after ${created_at} — dispatch proceeds"
+		_log "INFO" "#${issue_number}: no merged PR candidates in ${search_context} — dispatch proceeds"
 		return 0
 	fi
 
@@ -937,7 +987,7 @@ _detect_review_feedback_supersession() {
 		}
 		IFS=$'\t' read -r merged_at pr_title pr_body <<<"$pr_meta"
 
-		if [[ -z "$merged_at" || "$merged_at" < "$created_at" || "$merged_at" == "$created_at" ]]; then
+		if [[ -z "$merged_at" || "$merged_at" < "$search_after" || "$merged_at" == "$search_after" ]]; then
 			continue
 		fi
 
@@ -958,7 +1008,7 @@ _detect_review_feedback_supersession() {
 		_rf_score_keywords "$keywords" "$evidence"
 
 		if _rf_pr_references_issue "$issue_number" "$evidence" || [[ "$_RF_KEYWORD_SCORE" -ge 2 ]]; then
-			_rf_close_with_supersession "$issue_number" "$slug" "$pr_number" "$merged_at" "$overlaps" "$_RF_MATCHED_KEYWORDS"
+			_rf_close_with_supersession "$issue_number" "$slug" "$pr_number" "$merged_at" "$overlaps" "$_RF_MATCHED_KEYWORDS" "$search_context" "$source_pr"
 			return 10
 		fi
 
@@ -966,7 +1016,7 @@ _detect_review_feedback_supersession() {
 	done <<<"$candidate_numbers"
 
 	if [[ -n "$ambiguous_evidence" ]]; then
-		_rf_post_ambiguous_comment "$issue_number" "$slug" "$issue_paths" "$keywords" "$ambiguous_evidence"
+		_rf_post_ambiguous_comment "$issue_number" "$slug" "$issue_paths" "$keywords" "$ambiguous_evidence" "$search_context"
 	fi
 
 	return 0

--- a/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
+++ b/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
@@ -75,10 +75,27 @@ done
 if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/issues/* && "$endpoint" != */comments ]]; then
 	case "$arg_string" in
 	*'.body // ""'*)
-		printf '## Files to modify\n- `.agents/scripts/review-hook.sh`\n\n## Finding\nAdd the event payload guard before worker launch.\n'
+		case "$scenario" in
+		source-clear | source-ambiguous | source-fetch-failure)
+			printf '**Source PR**: #50\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n\n## Finding\nAdd the event payload guard before worker launch.\n'
+			;;
+		no-file)
+			printf '**Source PR**: #50\n\n## Finding\nAdd the event payload guard before worker launch.\n'
+			;;
+		*)
+			printf '## Files to modify\n- `.agents/scripts/review-hook.sh`\n\n## Finding\nAdd the event payload guard before worker launch.\n'
+			;;
+		esac
 		;;
 	*'@tsv'*)
-		printf '2026-05-01T10:00:00Z\treview-feedback: event payload guard\tquality-debt,source:review-feedback,tier:thinking\n'
+		case "$scenario" in
+		source-clear | source-ambiguous | source-fetch-failure | no-file)
+			printf '2026-05-02T10:00:00Z\treview-feedback: event payload guard\tquality-debt,source:review-feedback,tier:thinking\n'
+			;;
+		*)
+			printf '2026-05-01T10:00:00Z\treview-feedback: event payload guard\tquality-debt,source:review-feedback,tier:thinking\n'
+			;;
+		esac
 		;;
 	*'join(",")'*)
 		printf 'quality-debt,source:review-feedback,tier:thinking\n'
@@ -99,6 +116,10 @@ if [[ "${1:-}" == "api" && "$endpoint" == "search/issues" ]]; then
 	case "$scenario" in
 	clear) printf '200\n' ;;
 	ambiguous) printf '201\n' ;;
+	source-clear) printf '200\n' ;;
+	source-ambiguous) printf '201\n' ;;
+	source-fetch-failure) printf '200\n' ;;
+	no-file) printf '200\n' ;;
 	none) printf '' ;;
 	before) printf '203\n' ;;
 	*) printf '' ;;
@@ -108,6 +129,13 @@ fi
 
 if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/* && "$endpoint" != */files ]]; then
 	pr_number="${endpoint##*/}"
+	if [[ "$pr_number" == "50" ]]; then
+		if [[ "$scenario" == "source-fetch-failure" ]]; then
+			exit 1
+		fi
+		printf '2026-05-01T09:30:00Z\n'
+		exit 0
+	fi
 	case "$pr_number" in
 	200)
 		printf '2026-05-01T11:00:00Z\tfix event payload guard\tAdds a guard for event payload handling.\n'
@@ -214,6 +242,31 @@ test_ambiguous_same_file_unrelated_change() {
 	return 0
 }
 
+test_source_pr_window_catches_pre_issue_fix() {
+	run_validator_case "source-clear" 10 "source PR window catches pre-issue supersession"
+	assert_log_contains "source PR window closes pre-issue supersession" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
+test_source_pr_window_ambiguous_fails_open() {
+	run_validator_case "source-ambiguous" 0 "source PR window ambiguous same-file change"
+	assert_log_not_contains "source PR ambiguous change does not close" "issue close 100 --repo owner/repo --reason not planned"
+	assert_log_contains "source PR ambiguous change posts decision comment" "issue comment 100 --repo owner/repo --body"
+	return 0
+}
+
+test_source_pr_fetch_failure_falls_back() {
+	run_validator_case "source-fetch-failure" 0 "source PR fetch failure falls back"
+	assert_log_not_contains "source PR fetch failure does not use pre-issue candidate" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
+test_no_file_finding_skips_supersession() {
+	run_validator_case "no-file" 0 "no cited file paths skips supersession"
+	assert_log_not_contains "no-file finding does not close" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
 test_no_matching_pr() {
 	run_validator_case "none" 0 "no matching merged PR"
 	assert_log_not_contains "no matching PR does not close" "issue close 100 --repo owner/repo --reason not planned"
@@ -239,6 +292,10 @@ main() {
 	write_gh_stub
 	test_clear_same_file_fix
 	test_ambiguous_same_file_unrelated_change
+	test_source_pr_window_catches_pre_issue_fix
+	test_source_pr_window_ambiguous_fails_open
+	test_source_pr_fetch_failure_falls_back
+	test_no_file_finding_skips_supersession
 	test_no_matching_pr
 	test_merged_pr_before_issue_creation
 	teardown_test_env


### PR DESCRIPTION
## Summary

Uses source PR provenance to search superseding merged PRs from the source PR merged_at timestamp when available, while falling back to issue-created-at behavior on missing/failing provenance. Keeps the same conservative same-file plus issue-reference/keyword matching and updates closure/ambiguous rationale wording.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh,.agents/scripts/tests/test-review-feedback-supersession-validator.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-review-feedback-supersession-validator.sh; .agents/scripts/tests/test-pre-dispatch-validator.sh; shellcheck .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-review-feedback-supersession-validator.sh

Resolves #23947


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.24 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 3m and 58,168 tokens on this as a headless worker.