### PR TITLE
For #23932: enforce native blocked-by relationships

### DIFF
--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -28,6 +28,15 @@ For prompt-economy reasons these rules live here rather than in always-on AGENTS
 
 Format: `- [ ] t001 Description @owner #tag ~4h started:ISO blocked-by:t002`
 
+Dependency rule: when a TODO/issue declares ordered work with `blocked-by:*`
+or `blocks:*`, preserve the text marker for human/reconciliation context and
+sync it into GitHub's native issue relationship field. The native `blockedBy`
+relationship is the primary dispatch gate; body/TODO markers are fallback intent
+and repair signals. If the relationship cannot be created or verified, keep the
+dependent task non-dispatchable (`status:blocked`, no `#auto-dispatch`) until the
+blocker is positively linked or resolved. `issue-sync-relationships.sh` performs
+the normal TODO-to-GitHub relationship backfill.
+
 Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 ## Briefs, Tiers, and Dispatchability

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -70,7 +70,7 @@ _dep_graph_process_issue_json() {
 	local issue_json="$1"
 	local acc_json="$2"
 
-	local num title body
+	local num="" title="" body=""
 	num=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
 	title=$(printf '%s' "$issue_json" | jq -r '.title // ""' 2>/dev/null)
 	body=$(printf '%s' "$issue_json" | jq -r '.body // ""' 2>/dev/null)
@@ -90,12 +90,12 @@ _dep_graph_process_issue_json() {
 	# the bare TODO.md format (`blocked-by:tNNN,tMMM`). BSD/GNU portable
 	# via POSIX `[^[:cntrl:]]` (see t1983 / t2015 for history).
 	# Subtask decimal suffixes (t325.1) are preserved (GH#19165).
-	local blocker_lines blocker_tids blocker_nums
+	local blocker_lines="" blocker_tids="" blocker_nums=""
 	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*' || true)
 	blocker_tids=$(printf '%s' "$blocker_lines" | grep -oE 't[0-9]+(\.[0-9a-z]+)*' | sed 's/^t//' || true)
 	blocker_nums=$(printf '%s' "$blocker_lines" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' || true)
 
-	local tid_arr num_arr
+	local tid_arr="" num_arr=""
 	tid_arr=$(printf '%s' "$blocker_tids" | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || tid_arr='[]'
 	num_arr=$(printf '%s' "$blocker_nums" | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || num_arr='[]'
 	local has_blockers="false"
@@ -303,7 +303,7 @@ build_dependency_graph_cache() {
 		rm -f "$tmp_file"
 	fi
 
-	local build_end build_dur
+	local build_end="" build_dur=""
 	build_end=$(date +%s)
 	build_dur=$((build_end - build_start))
 	echo "[pulse-wrapper] dep-graph-cache: built in ${build_dur}s → ${cache_file}" >>"$LOGFILE"
@@ -406,7 +406,7 @@ _refresh_all_blockers_resolved() {
 	local open_issues_json="$3"
 
 	# Task ID blockers
-	local blocker_tids tid blocker_issue_num is_open
+	local blocker_tids="" tid="" blocker_issue_num="" is_open=""
 	blocker_tids=$(printf '%s' "$entry_json" | jq -r '.task_ids[]' 2>/dev/null) || blocker_tids=""
 	while IFS= read -r tid; do
 		[[ -n "$tid" ]] || continue
@@ -417,7 +417,7 @@ _refresh_all_blockers_resolved() {
 	done <<<"$blocker_tids"
 
 	# Issue number blockers
-	local blocker_nums bnum
+	local blocker_nums="" bnum=""
 	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]' 2>/dev/null) || blocker_nums=""
 	while IFS= read -r bnum; do
 		[[ "$bnum" =~ ^[0-9]+$ ]] || continue
@@ -458,7 +458,7 @@ _refresh_try_unblock_issue() {
 
 	# Cached defer flag — either inside the blocked_by entry or in the
 	# repo-level defer_flags map. Either "true" triggers defer.
-	local entry_defer top_defer has_defer_flag
+	local entry_defer="" top_defer="" has_defer_flag=""
 	entry_defer=$(printf '%s' "$entry_json" | jq -r '.has_defer_marker // false' 2>/dev/null) || entry_defer="false"
 	top_defer=$(printf '%s' "$defer_flags_json" | jq -r --arg n "$issue_num" '.[$n] // false' 2>/dev/null) || top_defer="false"
 	has_defer_flag="false"
@@ -515,7 +515,7 @@ refresh_blocked_status_from_graph() {
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
 
-		local repo_data open_issues_json task_to_issue_json blocked_by_json defer_flags_json
+		local repo_data="" open_issues_json="" task_to_issue_json="" blocked_by_json="" defer_flags_json=""
 		repo_data=$(printf '%s' "$graph_json" | jq -c --arg s "$slug" '.repos[$s]' 2>/dev/null) || continue
 		open_issues_json=$(printf '%s' "$repo_data" | jq -c '.open_issues // []' 2>/dev/null) || open_issues_json='[]'
 		task_to_issue_json=$(printf '%s' "$repo_data" | jq -c '.task_to_issue // {}' 2>/dev/null) || task_to_issue_json='{}'
@@ -526,7 +526,7 @@ refresh_blocked_status_from_graph() {
 		blocked_issue_nums=$(printf '%s' "$blocked_by_json" | jq -r 'keys[]' 2>/dev/null) || blocked_issue_nums=""
 		[[ -n "$blocked_issue_nums" ]] || continue
 
-		local issue_num entry_json
+		local issue_num="" entry_json=""
 		while IFS= read -r issue_num; do
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 			entry_json=$(printf '%s' "$blocked_by_json" | jq -c --arg n "$issue_num" '.[$n]' 2>/dev/null) || continue
@@ -599,6 +599,73 @@ _blocked_by_extract_nums() {
 	blocker_lines=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ][Bb]y[^[:cntrl:]]*' || true)
 	printf '%s' "$blocker_lines" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' || true
 	return 0
+}
+
+#######################################
+# Check GitHub's native blocked-by relationship field for unresolved blockers.
+#
+# GitHub's issue relationship graph is the canonical source once blockers have
+# been synced by issue-sync-relationships.sh. Body/TODO `blocked-by:*` tokens are
+# retained as fallback intent and repair signals, but dispatch must consult the
+# native relationship first so UI-created/backfilled dependencies are enforced
+# even when the issue body does not repeat them.
+#
+# Arguments:
+#   $1 - repo slug
+#   $2 - issue number
+# Exit codes:
+#   0 - native relationship is open/unknown (caller should block dispatch)
+#   1 - native relationships are positively clear
+#######################################
+_blocked_by_check_native_relationships() {
+	local repo_slug="$1"
+	local issue_number="$2"
+
+	[[ -n "$repo_slug" && -n "$issue_number" ]] || return 1
+	[[ "$repo_slug" == */* ]] || return 1
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+
+	local owner="" repo_name=""
+	owner="${repo_slug%%/*}"
+	repo_name="${repo_slug#*/}"
+	[[ -n "$owner" && -n "$repo_name" ]] || return 1
+
+	local rel_states=""
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
+	if ! rel_states=$(gh api graphql \
+		-f query='
+query($owner:String!,$name:String!,$number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      blockedBy(first: 50) {
+        nodes { number state }
+      }
+    }
+  }
+}' \
+		-F owner="$owner" -F name="$repo_name" -F number="$issue_number" \
+		--jq '.data.repository.issue.blockedBy.nodes[]? | "\(.number):\(.state)"' \
+		2>/dev/null); then
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup failed — skipping dispatch (GH#23932)" >>"$LOGFILE"
+		return 0
+	fi
+
+	local rel_state="" rel_num="" state=""
+	while IFS= read -r rel_state; do
+		[[ -n "$rel_state" ]] || continue
+		rel_num="${rel_state%%:*}"
+		state="${rel_state#*:}"
+		if [[ "$state" == OPEN ]]; then
+			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by native relationship #${rel_num} (open) — skipping dispatch (GH#23932)" >>"$LOGFILE"
+			return 0
+		fi
+		if [[ "$state" != CLOSED ]]; then
+			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy #${rel_num} has unknown state '${state}' — skipping dispatch (GH#23932)" >>"$LOGFILE"
+			return 0
+		fi
+	done <<<"$rel_states"
+
+	return 1
 }
 
 #######################################
@@ -786,9 +853,10 @@ _blocked_by_check_issue_num() {
 #######################################
 # Blocked-by enforcement (t1927, enhanced t1935, decomposed GH#18693)
 #
-# Parses the issue body for blocked-by dependencies and checks whether the
-# blocking task/issue is still open. Uses the cached dependency graph (built
-# once per cycle) for zero-API-call resolution. Falls back to live API calls
+# Checks GitHub's native blockedBy relationship field first, then parses the
+# issue body for blocked-by dependencies and checks whether the blocking
+# task/issue is still open. Uses the cached dependency graph (built once per
+# cycle) for zero-API-call body-token resolution. Falls back to live API calls
 # only when the cache is absent or the blocker is not found in it.
 #
 # Decomposed into _blocked_by_extract_tids, _blocked_by_extract_nums,
@@ -810,13 +878,21 @@ is_blocked_by_unresolved() {
 	local repo_slug="$2"
 	local issue_number="$3"
 
-	[[ -n "$issue_body" ]] || return 1
 	[[ -n "$repo_slug" ]] || return 1
+	[[ -n "$issue_number" ]] || return 1
+
+	# Native GitHub dependencies are the primary source of truth. Body/TODO
+	# markers remain as fallback repair intent below.
+	if _blocked_by_check_native_relationships "$repo_slug" "$issue_number"; then
+		return 0
+	fi
+
+	[[ -n "$issue_body" ]] || return 1
 
 	# Extract blocked-by references (tNNN and #NNN) via two single-return
 	# helpers. GH#18830: the previous NUL-delimited two-value return was
 	# fatally broken on bash 3.2 — see `_blocked_by_extract_refs` header.
-	local blocker_task_ids blocker_issue_nums
+	local blocker_task_ids="" blocker_issue_nums=""
 	blocker_task_ids=$(_blocked_by_extract_tids "$issue_body")
 	blocker_issue_nums=$(_blocked_by_extract_nums "$issue_body")
 

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1110,7 +1110,7 @@ _dispatch_dedup_check_layers() {
 	# sub-stage records let us identify which gate dominates the 235s avg.
 	local _dss_t0
 
-	local target_state target_title
+	local target_state="" target_title=""
 	# GH#21717: normalize to uppercase — REST fallback returns lowercase "open"/"closed"
 	# while GraphQL returns enum "OPEN"/"CLOSED". The comparison at line 921 is
 	# case-sensitive, so without normalization every issue appears non-OPEN when
@@ -1149,7 +1149,7 @@ _dispatch_dedup_check_layers() {
 	# registered git worktrees. At that scale, new worktrees risk consuming
 	# tens of GB; stale merged ones should be cleaned before adding more.
 	_dss_t0=$(_ds_now_ns)
-	local _wt_count _wt_max
+	local _wt_count="" _wt_max=""
 	_wt_max="${AIDEVOPS_MAX_WORKTREES:-200}"
 	_wt_count=$(git -C "$repo_path" worktree list 2>/dev/null | wc -l | tr -d ' ')
 	if [[ -n "$_wt_count" ]] && [[ "$_wt_count" -ge "$_wt_max" ]]; then
@@ -1225,8 +1225,9 @@ _dispatch_dedup_check_layers() {
 	# discovery; helpers retained for diagnostic use. Regression guard:
 	# tests/test-pulse-dispatch-core-t3040-gate-removed.sh.
 
-	# t1927: Blocked-by enforcement — skip dispatch if a dependency is unresolved.
-	# Parses issue body for "blocked-by:tNNN" or "Blocked by #NNN".
+	# t1927/GH#23932: Blocked-by enforcement — skip dispatch if a dependency is unresolved.
+	# Checks GitHub's native blockedBy relationship field first, then falls back
+	# to issue-body markers such as "blocked-by:tNNN" or "Blocked by #NNN".
 	# t2996: body now travels in $issue_meta_json (`,body` was added at the
 	# canonical gh call); extract once and reuse for the consolidation,
 	# large-file, and footprint gates below — eliminating 1-2 extra gh calls
@@ -1234,7 +1235,7 @@ _dispatch_dedup_check_layers() {
 	_dss_t0=$(_ds_now_ns)
 	local _dispatch_issue_body
 	_dispatch_issue_body=$(printf '%s' "$issue_meta_json" | jq -r '.body // ""' 2>/dev/null) || _dispatch_issue_body=""
-	if [[ -n "$_dispatch_issue_body" ]] && is_blocked_by_unresolved "$_dispatch_issue_body" "$repo_slug" "$issue_number"; then
+	if is_blocked_by_unresolved "$_dispatch_issue_body" "$repo_slug" "$issue_number"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unresolved blocked-by dependency (t1927)" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.blocked_by" "$_dss_t0"
 		return 1
@@ -1488,7 +1489,7 @@ dispatch_with_dedup() {
 	}
 
 	# t3034: per-stage timing instrumentation — capture ceremony overhead.
-	local _ds_ceremony_t0 _ds_t0
+	local _ds_ceremony_t0="" _ds_t0=""
 	_ds_ceremony_t0=$(_ds_now_ns)
 
 	# Hard stop for supervisor/telemetry issues (t1702 pulse guard).
@@ -2035,7 +2036,7 @@ check_terminal_blockers() {
 	local pattern_output
 	pattern_output=$(_match_terminal_blocker_pattern "$all_bodies") || return 1
 
-	local blocker_reason user_action
+	local blocker_reason="" user_action=""
 	blocker_reason=$(echo "$pattern_output" | sed -n '1p')
 	user_action=$(echo "$pattern_output" | sed -n '2p')
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -302,7 +302,10 @@ _dlw_comment_bloat_requires_clean_room() {
 	local repo_slug="$2"
 	local precomputed_metrics="${3:-}"
 
-	local comments ops zero chars
+	local comments=""
+	local ops=""
+	local zero=""
+	local chars=""
 	if [[ -z "$precomputed_metrics" ]]; then
 		precomputed_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
 	fi
@@ -421,7 +424,10 @@ _dlw_prepare_prompt_for_launch() {
 	local original_prompt="$4"
 	local precomputed_comment_metrics="${5:-}"
 	local comment_metrics=""
-	local comments ops metrics_zero_count chars
+	local comments=""
+	local ops=""
+	local metrics_zero_count=""
+	local chars=""
 	local precomputed_zero_count=""
 
 	comment_metrics="$precomputed_comment_metrics"
@@ -459,7 +465,10 @@ _dlw_hold_repeated_zero_output() {
 	local repo_slug="$2"
 	local precomputed_comment_metrics="${3:-}"
 	local comment_metrics=""
-	local comments ops metrics_zero_count chars
+	local comments=""
+	local ops=""
+	local metrics_zero_count=""
+	local chars=""
 	local precomputed_zero_count=""
 
 	comment_metrics="$precomputed_comment_metrics"
@@ -1619,6 +1628,25 @@ _dlw_canary_preflight() {
 	return 1
 }
 
+_dlw_blocked_by_hard_stop() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_meta_json="$3"
+
+	if [[ "$(type -t is_blocked_by_unresolved 2>/dev/null)" != "function" ]]; then
+		return 1
+	fi
+
+	local issue_body=""
+	issue_body=$(printf '%s' "$issue_meta_json" | jq -r '.body // ""' 2>/dev/null) || issue_body=""
+	if is_blocked_by_unresolved "$issue_body" "$repo_slug" "$issue_number"; then
+		echo "[dispatch_with_dedup] Hard-stop before worker bootstrap for #${issue_number} in ${repo_slug}: unresolved blocked-by dependency (GH#23932)" >>"$LOGFILE"
+		return 0
+	fi
+
+	return 1
+}
+
 #######################################
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
@@ -1662,6 +1690,10 @@ _dispatch_launch_worker() {
 	local dispatch_tier="$_DLW_DISPATCH_TIER"
 	local dispatch_model_tier="$_DLW_DISPATCH_MODEL_TIER"
 	local selected_model="$_DLW_SELECTED_MODEL"
+
+	if _dlw_blocked_by_hard_stop "$issue_number" "$repo_slug" "$issue_meta_json"; then
+		return 2
+	fi
 
 	_ds_t0=$(_ds_now_ns)
 	if ! _dlw_canary_preflight "$issue_number" "$repo_slug" "$worker_log" \

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -108,10 +108,23 @@ if [[ "$resolved_pid" != "4242" ]]; then
 	fail "systemd PID resolver skipped final unterminated property"
 fi
 
+is_blocked_by_unresolved() {
+	local issue_body="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	[[ "$issue_body" == "blocked-body" && "$repo_slug" == "owner/repo" && "$issue_number" == "123" ]] || return 1
+	return 0
+}
+
+if ! LOGFILE="${TEST_TMP}/pulse.log" _dlw_blocked_by_hard_stop "123" "owner/repo" '{"body":"blocked-body"}'; then
+	fail "worker launch hard-stop did not block unresolved blocked-by dependency"
+fi
+
 printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
 printf 'PASS: root node_modules payload is skipped by default\n'
 printf 'PASS: root node_modules .bin tooling is linked by default\n'
 printf 'PASS: precomputed zero-output evidence count skips redundant lookups\n'
 printf 'PASS: pulse worker launch forwards dispatching GitHub login\n'
 printf 'PASS: systemd PID resolver handles final unterminated property\n'
+printf 'PASS: worker launch hard-stops unresolved blocked-by dependencies\n'
 exit 0

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -26,6 +26,7 @@ mode: subagent
 - **Session:** {app}:{session-id}
 - **Created by:** {author} (human | ai-supervisor | ai-interactive)
 - **Parent task:** {parent_id} (if subtask)
+- **Blocked by:** {GitHub issue relationship(s) + optional `blocked-by:tNNN/#NNN` marker; if unresolved, keep `status:blocked` and omit `#auto-dispatch`}
 - **Conversation context:** {1-2 sentence summary of what was discussed that led to this task}
 
 ## What

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -61,6 +61,7 @@ _setup_blocked_by_resolution_test() {
 	LOGFILE="${TEST_TMP}/pulse.log"
 	DEP_GRAPH_CACHE_FILE="${TEST_TMP}/dep-graph.json"
 	DEP_GRAPH_CACHE_TTL_SECS=3600
+	TEST_GH_RELATIONSHIP_MODE="clear"
 	return 0
 }
 
@@ -97,6 +98,29 @@ gh_issue_list() {
 }
 
 gh() {
+	if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+		case "${TEST_GH_RELATIONSHIP_MODE:-clear}" in
+			fail)
+				return 1
+				;;
+			open)
+				printf '1000:OPEN\n'
+				return 0
+				;;
+			closed)
+				printf '1000:CLOSED\n'
+				return 0
+				;;
+			unknown)
+				printf '1000:\n'
+				return 0
+				;;
+			*)
+				printf '\n'
+				return 0
+				;;
+		esac
+	fi
 	if [[ "${TEST_GH_ISSUE_VIEW_MODE:-fail}" == "closed" ]]; then
 		printf 'CLOSED\n'
 		return 0
@@ -106,6 +130,47 @@ gh() {
 		return 0
 	fi
 	return 1
+}
+
+test_native_relationship_open_blocks_empty_body() {
+	printf '\n=== native blockedBy relationship ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_RELATIONSHIP_MODE="open"
+
+	local rc=0
+	is_blocked_by_unresolved '' 'owner/repo' '2000' || rc=$?
+	_assert_rc "native blockedBy open relationship blocks without body marker" 0 "$rc"
+	if grep -q 'native relationship #1000' "$LOGFILE"; then
+		_pass "native relationship block logs distinct reason"
+	else
+		_fail "native relationship block logs distinct reason" "missing native relationship log"
+	fi
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_native_relationship_clear_allows_empty_body() {
+	printf '\n=== native blockedBy clear ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_RELATIONSHIP_MODE="closed"
+
+	local rc=0
+	is_blocked_by_unresolved '' 'owner/repo' '2000' || rc=$?
+	_assert_rc "native blockedBy closed relationship allows dispatch when no body marker" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_native_relationship_lookup_failure_fails_closed() {
+	printf '\n=== native blockedBy lookup failure ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_RELATIONSHIP_MODE="fail"
+
+	local rc=0
+	is_blocked_by_unresolved '' 'owner/repo' '2000' || rc=$?
+	_assert_rc "native blockedBy lookup failure blocks as unknown" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
 }
 
 test_task_id_blocker_parsing() {
@@ -228,6 +293,9 @@ test_cache_rebuild_preserves_previous_repo_data_on_fetch_failure() {
 main() {
 	test_task_id_blocker_parsing
 	test_issue_number_blocker_parsing
+	test_native_relationship_open_blocks_empty_body
+	test_native_relationship_clear_allows_empty_body
+	test_native_relationship_lookup_failure_fails_closed
 	test_unknown_task_blocker_fails_closed
 	test_live_task_lookup_failure_fails_closed
 	test_closed_task_blocker_is_clear

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -86,6 +86,16 @@ The wrapper currently self-assigns in violation of t2157. Until t2406/GH#19991 m
 
 **The brief IS the product.** A vague brief dispatched to Opus wastes more money than a prescriptive brief dispatched to Haiku. Invest the effort in the brief, not the worker.
 
+## Ordered Work / Dependencies
+
+When composing TODOs or issues that must run in sequence, include the textual
+`blocked-by:*` or `blocks:*` marker for auditability and ensure the GitHub native
+issue relationship is or will be synced. Treat GitHub's `blockedBy` relationship
+as the primary dispatch gate; body markers are fallback intent for
+`issue-sync-relationships.sh` and pulse repair. If a blocker cannot be resolved
+to a GitHub issue relationship, mark the dependent issue `status:blocked` and do
+not add `#auto-dispatch` until the relationship exists or the blocker is closed.
+
 ## Seeded Draft PR Decision
 
 When an issue or brief is created after enough discovery to know the likely implementation path, the author MAY open a seeded draft PR that gives the worker verified implementation context. This is opt-in. Issue-only remains the default when confidence is not high.


### PR DESCRIPTION
## Summary
- Make GitHub's native `blockedBy` relationship the primary dispatch gate before body/TODO markers.
- Keep body `blocked-by:*` parsing as fallback repair intent for TODO/issue-sync drift.
- Add a worker-launch hard stop so late relationship changes cannot bootstrap a worker.
- Update brief/task composition guidance to sync ordered work into GitHub relationships and keep unresolved dependents non-dispatchable.

Resolves #23932

## Verification
- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `bash .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-dep-graph.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-worker-launch.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.24 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 7h and 1,323,896 tokens on this with the user in an interactive session.