### PR TITLE
fix: pin canary to vanilla opencode agent

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1620,14 +1620,16 @@ _run_canary_test() {
 	# $OPENCODE_BIN_DEFAULT directly. Identical to the default in the
 	# happy path; differs only when alternative-path fallback fired.
 	#
-	# GH#23598: AIDEVOPS_HEADLESS=1 prevents greeting/TTSR prompt injection,
-	# while the benign arithmetic probe avoids prompt-injection-shaped canary
-	# tokens. Omit --agent; isolated config already avoids stale defaults.
+	# GH#23598/GH#23950: AIDEVOPS_HEADLESS=1 prevents plugin greeting/TTSR
+	# injection, while the benign arithmetic probe avoids prompt-injection-shaped
+	# canary tokens. Pin OpenCode's vanilla build agent so hosts with a global
+	# default_agent such as Build+ cannot load interactive greeting mandates into
+	# this runtime/model health check.
 	XDG_CONFIG_HOME="$_canary_config_dir" XDG_DATA_HOME="$_canary_data_dir" \
 		AIDEVOPS_HEADLESS=1 \
 		run_without_opencode_session_env "${_canary_timeout_cmd[@]}" \
 		"$_effective_opencode_bin" run "What is two plus two? Answer with the single word: Four" \
-		-m "$canary_model" --dir "${HOME}" \
+		-m "$canary_model" --dir "${HOME}" --agent build \
 		${canary_attach_args[@]+"${canary_attach_args[@]}"} \
 		>"$canary_output" 2>&1 || canary_exit=$?
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -762,7 +762,7 @@ test_service_interruption_candidate_uses_separate_path() {
 	return 0
 }
 
-test_canary_uses_isolated_plugin_config_without_pure() {
+test_canary_pins_vanilla_agent_with_isolated_plugin_config() {
 	local canary_root="${TEST_ROOT}/canary-agent"
 	local fake_bin_dir="${canary_root}/bin"
 	local plugin_dir="${canary_root}/plugin path"
@@ -819,20 +819,20 @@ EOF
 		env_output=$(<"$env_file")
 		local expected_plugin_url
 		expected_plugin_url=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).absolute().as_uri())' "$plugin_path")
-		if [[ "$args" == *'What is two plus two?'* && "$args" != *'--pure'* && "$args" != *'--agent build'* ]] &&
+		if [[ "$args" == *'What is two plus two?'* && "$args" != *'--pure'* && "$args" == *'--agent build'* ]] &&
 			[[ "$env_output" == *"OPENCODE_BIN=${fake_bin_dir}/opencode"* ]] &&
 			[[ "$env_output" == *"OPENCODE_DB=${canary_root}/opencode.db"* ]] &&
 			[[ "$env_output" == *"AIDEVOPS_HEADLESS=1"* ]] &&
 			[[ "$env_output" == *"$expected_plugin_url"* ]]; then
-			print_result "canary uses isolated plugin config without pure" 0
+			print_result "canary pins vanilla agent with isolated plugin config" 0
 			return 0
 		fi
-		print_result "canary uses isolated plugin config without pure" 1 \
-			"Expected benign prompt, no --pure/--agent build, headless env, plugin config, and preserved OpenCode config env; got args: ${args}; env: ${env_output}"
+		print_result "canary pins vanilla agent with isolated plugin config" 1 \
+			"Expected benign prompt, no --pure, --agent build, headless env, plugin config, and preserved OpenCode config env; got args: ${args}; env: ${env_output}"
 		return 0
 	fi
 
-	print_result "canary uses isolated plugin config without pure" 1 \
+	print_result "canary pins vanilla agent with isolated plugin config" 1 \
 		"Canary stub did not run successfully: ${output:-<empty>}"
 	return 0
 }
@@ -1521,7 +1521,7 @@ main() {
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
 	test_service_interruption_candidate_uses_separate_path
-	test_canary_uses_isolated_plugin_config_without_pure
+	test_canary_pins_vanilla_agent_with_isolated_plugin_config
 	test_opencode_session_env_wrapper_strips_session_vars_only
 	test_worker_opencode_exec_paths_strip_session_env
 	test_sandbox_passthrough_scopes_provider_env


### PR DESCRIPTION
## Summary
- Pin the OpenCode canary to the vanilla `build` agent with `--agent build`.
- Keep the isolated plugin config and `AIDEVOPS_HEADLESS=1` OAuth/headless path intact.
- Update the focused headless runtime test to assert the canary now passes `--agent build` and still avoids `--pure`.

## Verification
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `AIDEVOPS_HEADLESS_RUNTIME_DIR="$(mktemp -d)" CANARY_CACHE_TTL_SECONDS=0 CANARY_TIMEOUT_SECONDS=180 .agents/scripts/headless-runtime-helper.sh canary --role worker --tier haiku`

Resolves #23950
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.25 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 9m and 87,962 tokens on this with the user in an interactive session.