### PR TITLE
fix: respect closed native blockedBy relationships

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -615,7 +615,8 @@ _blocked_by_extract_nums() {
 #   $2 - issue number
 # Exit codes:
 #   0 - native relationship is open/unknown (caller should block dispatch)
-#   1 - native relationships are positively clear
+#   1 - no native relationships were found (caller should check text fallback)
+#   2 - native relationships exist and are positively clear
 #######################################
 _blocked_by_check_native_relationships() {
 	local repo_slug="$1"
@@ -650,20 +651,26 @@ query($owner:String!,$name:String!,$number:Int!) {
 		return 0
 	fi
 
-	local rel_state="" rel_num="" state=""
+	local rel_state="" rel_num="" state="" state_normalized="" saw_relationship="false"
 	while IFS= read -r rel_state; do
 		[[ -n "$rel_state" ]] || continue
+		saw_relationship="true"
 		rel_num="${rel_state%%:*}"
 		state="${rel_state#*:}"
-		if [[ "$state" == OPEN ]]; then
+		state_normalized=$(printf '%s' "$state" | tr '[:lower:]' '[:upper:]')
+		if [[ "$state_normalized" == OPEN ]]; then
 			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by native relationship #${rel_num} (open) — skipping dispatch (GH#23932)" >>"$LOGFILE"
 			return 0
 		fi
-		if [[ "$state" != CLOSED ]]; then
+		if [[ "$state_normalized" != CLOSED ]]; then
 			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy #${rel_num} has unknown state '${state}' — skipping dispatch (GH#23932)" >>"$LOGFILE"
 			return 0
 		fi
 	done <<<"$rel_states"
+
+	if [[ "$saw_relationship" == "true" ]]; then
+		return 2
+	fi
 
 	return 1
 }
@@ -761,17 +768,18 @@ _blocked_by_check_task_id() {
 	# Live API fallback: search all issues with this task ID in the title.
 	# Empty/error is not proof of resolution because GitHub search can lag
 	# immediately after rapid task creation. Treat that as unknown and block.
-	local blocker_state
+	local blocker_state blocker_state_normalized
 	if ! blocker_state=$(gh_issue_list --repo "$repo_slug" --state all \
 		--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null); then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference t${task_id} (live lookup failed) — skipping dispatch" >>"$LOGFILE"
 		return 0
 	fi
-	if [[ "$blocker_state" == "OPEN" ]]; then
+	blocker_state_normalized=$(printf '%s' "$blocker_state" | tr '[:lower:]' '[:upper:]')
+	if [[ "$blocker_state_normalized" == "OPEN" ]]; then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 		return 0
 	fi
-	if [[ "$blocker_state" == "CLOSED" ]]; then
+	if [[ "$blocker_state_normalized" == "CLOSED" ]]; then
 		return 1
 	fi
 	echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference t${task_id} (cache miss / live lookup inconclusive) — skipping dispatch" >>"$LOGFILE"
@@ -795,17 +803,18 @@ _blocked_by_check_issue_num_live() {
 	local repo_slug="$2"
 	local issue_number="$3"
 
-	local blocker_state
+	local blocker_state blocker_state_normalized
 	if ! blocker_state=$(gh issue view "$blocker_num" --repo "$repo_slug" \
 		--json state --jq '.state // ""' 2>/dev/null); then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference #${blocker_num} (live lookup failed) — skipping dispatch" >>"$LOGFILE"
 		return 0
 	fi
-	if [[ "$blocker_state" == "OPEN" ]]; then
+	blocker_state_normalized=$(printf '%s' "$blocker_state" | tr '[:lower:]' '[:upper:]')
+	if [[ "$blocker_state_normalized" == "OPEN" ]]; then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 		return 0
 	fi
-	if [[ "$blocker_state" == "CLOSED" ]]; then
+	if [[ "$blocker_state_normalized" == "CLOSED" ]]; then
 		return 1
 	fi
 	echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference #${blocker_num} (live lookup inconclusive) — skipping dispatch" >>"$LOGFILE"
@@ -881,10 +890,17 @@ is_blocked_by_unresolved() {
 	[[ -n "$repo_slug" ]] || return 1
 	[[ -n "$issue_number" ]] || return 1
 
-	# Native GitHub dependencies are the primary source of truth. Body/TODO
-	# markers remain as fallback repair intent below.
-	if _blocked_by_check_native_relationships "$repo_slug" "$issue_number"; then
+	# Native GitHub dependencies are the primary source of truth once present.
+	# Body/TODO markers remain as fallback repair intent only when no native
+	# relationships exist yet. GH#23952: closed native blockers must not be
+	# re-blocked by stale duplicate text markers.
+	local native_rc=0
+	_blocked_by_check_native_relationships "$repo_slug" "$issue_number" || native_rc=$?
+	if [[ "$native_rc" -eq 0 ]]; then
 		return 0
+	fi
+	if [[ "$native_rc" -eq 2 ]]; then
+		return 1
 	fi
 
 	[[ -n "$issue_body" ]] || return 1

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -768,7 +768,7 @@ _blocked_by_check_task_id() {
 	# Live API fallback: search all issues with this task ID in the title.
 	# Empty/error is not proof of resolution because GitHub search can lag
 	# immediately after rapid task creation. Treat that as unknown and block.
-	local blocker_state blocker_state_normalized
+	local blocker_state="" blocker_state_normalized=""
 	if ! blocker_state=$(gh_issue_list --repo "$repo_slug" --state all \
 		--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null); then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference t${task_id} (live lookup failed) — skipping dispatch" >>"$LOGFILE"
@@ -803,7 +803,7 @@ _blocked_by_check_issue_num_live() {
 	local repo_slug="$2"
 	local issue_number="$3"
 
-	local blocker_state blocker_state_normalized
+	local blocker_state="" blocker_state_normalized=""
 	if ! blocker_state=$(gh issue view "$blocker_num" --repo "$repo_slug" \
 		--json state --jq '.state // ""' 2>/dev/null); then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference #${blocker_num} (live lookup failed) — skipping dispatch" >>"$LOGFILE"

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -82,8 +82,16 @@ gh_issue_list() {
 			printf 'CLOSED\n'
 			return 0
 			;;
+		closed-lower)
+			printf 'closed\n'
+			return 0
+			;;
 		open)
 			printf 'OPEN\n'
+			return 0
+			;;
+		open-lower)
+			printf 'open\n'
 			return 0
 			;;
 		repo-json)
@@ -125,8 +133,16 @@ gh() {
 		printf 'CLOSED\n'
 		return 0
 	fi
+	if [[ "${TEST_GH_ISSUE_VIEW_MODE:-fail}" == "closed-lower" ]]; then
+		printf 'closed\n'
+		return 0
+	fi
 	if [[ "${TEST_GH_ISSUE_VIEW_MODE:-fail}" == "open" ]]; then
 		printf 'OPEN\n'
+		return 0
+	fi
+	if [[ "${TEST_GH_ISSUE_VIEW_MODE:-fail}" == "open-lower" ]]; then
+		printf 'open\n'
 		return 0
 	fi
 	return 1
@@ -157,6 +173,32 @@ test_native_relationship_clear_allows_empty_body() {
 	local rc=0
 	is_blocked_by_unresolved '' 'owner/repo' '2000' || rc=$?
 	_assert_rc "native blockedBy closed relationship allows dispatch when no body marker" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_native_relationship_clear_ignores_duplicate_text_marker() {
+	printf '\n=== native blockedBy clear overrides duplicate text marker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_RELATIONSHIP_MODE="closed"
+	TEST_GH_ISSUE_LIST_MODE="empty"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "native closed blocker clears despite duplicate text marker" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_native_relationship_open_blocks_duplicate_text_marker() {
+	printf '\n=== native blockedBy open blocks duplicate text marker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_RELATIONSHIP_MODE="open"
+	TEST_GH_ISSUE_LIST_MODE="closed"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "native open blocker blocks regardless of text fallback" 0 "$rc"
 	_cleanup_blocked_by_resolution_test
 	return 0
 }
@@ -241,6 +283,30 @@ test_closed_task_blocker_is_clear() {
 	return 0
 }
 
+test_lowercase_closed_task_blocker_is_clear() {
+	printf '\n=== lowercase closed task blocker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="closed-lower"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "lowercase closed task blocker is clear" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_lowercase_open_task_blocker_blocks() {
+	printf '\n=== lowercase open task blocker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="open-lower"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "lowercase open task blocker blocks" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
 test_issue_number_live_failure_fails_closed() {
 	printf '\n=== fail-closed issue-number blocker resolution ===\n'
 	_setup_blocked_by_resolution_test
@@ -262,6 +328,18 @@ test_cached_issue_number_absence_requires_live_proof() {
 	local rc=0
 	is_blocked_by_unresolved 'blocked-by:#1000' 'owner/repo' '2000' || rc=$?
 	_assert_rc "cached issue-number absence blocks when live proof fails" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_lowercase_closed_issue_number_blocker_is_clear() {
+	printf '\n=== lowercase closed issue-number blocker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_VIEW_MODE="closed-lower"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:#1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "lowercase closed issue-number blocker is clear" 1 "$rc"
 	_cleanup_blocked_by_resolution_test
 	return 0
 }
@@ -295,12 +373,17 @@ main() {
 	test_issue_number_blocker_parsing
 	test_native_relationship_open_blocks_empty_body
 	test_native_relationship_clear_allows_empty_body
+	test_native_relationship_clear_ignores_duplicate_text_marker
+	test_native_relationship_open_blocks_duplicate_text_marker
 	test_native_relationship_lookup_failure_fails_closed
 	test_unknown_task_blocker_fails_closed
 	test_live_task_lookup_failure_fails_closed
 	test_closed_task_blocker_is_clear
+	test_lowercase_closed_task_blocker_is_clear
+	test_lowercase_open_task_blocker_blocks
 	test_issue_number_live_failure_fails_closed
 	test_cached_issue_number_absence_requires_live_proof
+	test_lowercase_closed_issue_number_blocker_is_clear
 	test_cache_rebuild_preserves_previous_repo_data_on_fetch_failure
 
 	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Make native GitHub `blockedBy` relationships tri-state: blocked, no-native-fallback, and clear-with-native.
- Stop parsing duplicate legacy text markers once native relationships exist and all blockers are closed.
- Normalize live fallback issue states case-insensitively for task-ID and issue-number blockers.

## Verification

- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh` → 24 passed, 0 failed
- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `.agents/scripts/linters-local.sh` → ALL LOCAL CHECKS PASSED (with pre-existing advisory markdown/ratchet/complexity warnings)

Resolves #23952
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.25 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 18m and 180,711 tokens on this with the user in an interactive session.