### PR TITLE
For #23594: prefer OpenCode for AI research auto

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -14,7 +14,7 @@
 #
 # Environment:
 #   AIDEVOPS_AI_RESEARCH_PROVIDER — auto (default), anthropic, or opencode
-#   AIDEVOPS_AI_RESEARCH_OPENCODE_MODEL — OpenCode model for runtime fallback
+#   AIDEVOPS_AI_RESEARCH_OPENCODE_MODEL — OpenCode model for default runtime path
 #   ANTHROPIC_API_KEY — env, gopass, credentials.sh, or OAuth pool
 #
 # Exit codes: 0=success (response on stdout), 1=error, 2=no usable provider credentials
@@ -276,7 +276,7 @@ call_opencode() {
 	: "$max_tokens"
 
 	if ! command -v opencode &>/dev/null; then
-		log_error "OpenCode CLI not found for AI research runtime fallback"
+		log_error "OpenCode CLI not found for AI research runtime provider"
 		return 2
 	fi
 
@@ -309,7 +309,7 @@ call_opencode() {
 
 	text=$(extract_opencode_text "$raw") || text=""
 	if [[ -z "$text" ]]; then
-		log_error "Empty response from OpenCode AI research fallback"
+		log_error "Empty response from OpenCode AI research provider"
 		return 1
 	fi
 
@@ -333,12 +333,12 @@ call_ai() {
 		return $?
 		;;
 	auto)
-		if resolve_provider_credential anthropic >/dev/null 2>&1; then
-			call_anthropic "$prompt" "$model" "$max_tokens"
-			return $?
-		fi
 		if command -v opencode &>/dev/null; then
 			call_opencode "$prompt" "$model" "$max_tokens"
+			return $?
+		fi
+		if resolve_provider_credential anthropic >/dev/null 2>&1; then
+			call_anthropic "$prompt" "$model" "$max_tokens"
 			return $?
 		fi
 		log_error "No AI research provider available (Anthropic credentials or OpenCode runtime)"
@@ -387,7 +387,7 @@ main() {
 			echo "       printf '%s' \"PROMPT\" | ai-research-helper.sh --stdin [--provider opencode] [--model haiku]"
 			echo ""
 			echo "Lightweight multi-provider API wrapper for AI threshold judgments."
-			echo "Default provider: auto (Anthropic direct API first, then OpenCode runtime)."
+			echo "Default provider: auto (OpenCode runtime first, then Anthropic direct API)."
 			return 0
 			;;
 		*)

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # Regression test for GH#23594:
-# - ai-research-helper.sh falls back to OAuth pool credentials when static
-#   Anthropic key sources miss and OpenCode runtime fallback is available.
+# - ai-research-helper.sh keeps OAuth pool credential resolution available for
+#   explicit Anthropic calls while the default auto provider prefers OpenCode.
 # - pulse-fix-the-fixer-detector.sh treats ai-research-helper rc=2 as an auth
 #   class signal even when stderr prose does not match API error substrings.
 
@@ -126,26 +126,34 @@ test_oauth_pool_fallbacks() {
 	return 0
 }
 
-test_auto_provider_falls_back_to_opencode() {
+test_auto_provider_prefers_opencode() {
 	rm -f "${HOME}/.aidevops/oauth-pool.json"
 	cat >"${TEST_ROOT}/bin/opencode" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' '> Build+ · gpt-5.4-mini'
-printf '%s\n' 'VERDICT: YES - opencode fallback works'
+printf '%s\n' 'VERDICT: YES - opencode primary works'
 exit 0
 STUB
 	chmod +x "${TEST_ROOT}/bin/opencode"
+	cat >"${TEST_ROOT}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'unexpected direct Anthropic call in auto provider\n' >&2
+exit 42
+STUB
+	chmod +x "${TEST_ROOT}/bin/curl"
 
 	local output rc
 	set +e
+	export ANTHROPIC_API_KEY="[redacted-env-token]"
 	output=$("${REPO_ROOT}/.agents/scripts/ai-research-helper.sh" --prompt "ping" --max-tokens 5 2>"${TEST_ROOT}/auto-provider.err")
 	rc=$?
+	unset ANTHROPIC_API_KEY
 	set -e
-	if [[ "$rc" -eq 0 && "$output" == "VERDICT: YES - opencode fallback works" ]]; then
-		record_result "auto provider falls back to OpenCode runtime when Anthropic is absent" 0
+	if [[ "$rc" -eq 0 && "$output" == "VERDICT: YES - opencode primary works" ]]; then
+		record_result "auto provider prefers OpenCode runtime even when Anthropic is configured" 0
 		return 0
 	fi
-	record_result "auto provider falls back to OpenCode runtime when Anthropic is absent" 1 \
+	record_result "auto provider prefers OpenCode runtime even when Anthropic is configured" 1 \
 		"rc=${rc} output=${output} err=$(tr '\n' ' ' <"${TEST_ROOT}/auto-provider.err")"
 	return 0
 }
@@ -203,7 +211,7 @@ main() {
 	setup_sandbox
 	trap teardown_sandbox EXIT
 	test_oauth_pool_fallbacks
-	test_auto_provider_falls_back_to_opencode
+	test_auto_provider_prefers_opencode
 	test_detector_rc2_records_cooldown
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Make `AIDEVOPS_AI_RESEARCH_PROVIDER=auto` prefer OpenCode runtime before Anthropic direct API.
- Keep explicit `--provider anthropic` and Anthropic fallback when OpenCode is unavailable.
- Update regression coverage so auto mode stays OpenCode-first even with Anthropic credentials configured.

For #23594.

## Verification
- `bash .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh`
- `shellcheck .agents/scripts/ai-research-helper.sh .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh`
- `bash -n .agents/scripts/ai-research-helper.sh .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh`
- `git diff --check`
- `.agents/scripts/ai-research-helper.sh --model haiku --max-tokens 30 --prompt 'Output exactly: VERDICT: YES - auto opencode primary works'`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.26 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 3d 3h and 1,957,457 tokens on this with the user in an interactive session.
