### PR TITLE
GH#23959: fix: streamline ai research auto fallback

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -337,12 +337,8 @@ call_ai() {
 			call_opencode "$prompt" "$model" "$max_tokens"
 			return $?
 		fi
-		if resolve_provider_credential anthropic >/dev/null 2>&1; then
-			call_anthropic "$prompt" "$model" "$max_tokens"
-			return $?
-		fi
-		log_error "No AI research provider available (Anthropic credentials or OpenCode runtime)"
-		return 2
+		call_anthropic "$prompt" "$model" "$max_tokens"
+		return $?
 		;;
 	*)
 		log_error "Unsupported provider: $provider"

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -141,6 +141,7 @@ printf 'unexpected direct Anthropic call in auto provider\n' >&2
 exit 42
 STUB
 	chmod +x "${TEST_ROOT}/bin/curl"
+	trap 'rm -f "${TEST_ROOT}/bin/curl"' RETURN
 
 	local output rc
 	set +e


### PR DESCRIPTION
## Summary

Removed the redundant Anthropic credential pre-check from the auto provider path so call_anthropic performs credential resolution once, and cleaned up the auto-provider curl test stub with a RETURN trap for test isolation.

## Files Changed

.agents/scripts/ai-research-helper.sh,.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/ai-research-helper.sh .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh && REPO_ROOT=<repo> .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh

Resolves #23959


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 7m and 39,393 tokens on this as a headless worker.