### PR TITLE
GH#23968: fix: support partial parent closeout followups

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -423,7 +423,7 @@ _pm_issue_needs_partial_closeout() {
 		return 0
 	fi
 
-	checklist_count=$(printf '%s' "$issue_body" | grep -cE '^[[:space:]]*-[[:space:]]*\[[ xX]\]' || true)
+	checklist_count=$(printf '%s' "$issue_body" | grep -cE '^[[:space:]]*[-*+][[:space:]]*\[[ xX]\]' || true)
 	[[ "$checklist_count" =~ ^[0-9]+$ ]] || checklist_count=0
 	if [[ "$checklist_count" -ge 2 ]]; then
 		return 0
@@ -443,7 +443,7 @@ _pm_unmet_acceptance_criteria() {
 	local issue_body="$1"
 	local criteria
 
-	criteria=$(printf '%s' "$issue_body" | sed -nE 's/^[[:space:]]*-[[:space:]]*\[[[:space:]]\][[:space:]]*/- /p' | head -20) || criteria=""
+	criteria=$(printf '%s' "$issue_body" | sed -nE 's/^[[:space:]]*[-*+][[:space:]]*\[[[:space:]]\][[:space:]]*/- /p' | head -20) || criteria=""
 	if [[ -z "$criteria" ]]; then
 		criteria="- Review the parent issue acceptance criteria and file worker-ready child issues for remaining scope."
 	fi
@@ -459,21 +459,27 @@ _pm_unmet_acceptance_criteria() {
 # closeout trail naming delivered work and follow-ups so broad parents are not
 # left ambiguous after a leaf PR merge (GH#23937).
 #
-# Args: $1=pr_number, $2=repo_slug, $3=merge_summary
+# Args: $1=pr_number, $2=repo_slug, $3=merge_summary, $4=linked_issue (optional)
 # Returns: 0 always (best-effort post-merge hygiene)
 #######################################
 _pm_handle_partial_parent_closeout() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local merge_summary="$3"
-	local parent_issue="" issue_api="" issue_body="" issue_labels="" dedup_count="" followups="" delivered_body=""
+	local linked_issue="${4:-}"
+	local parent_issue="" issue_api="" issue_json="" issue_body="" issue_labels="" dedup_count="" followups="" delivered_body=""
 
 	parent_issue=$(_pm_extract_partial_parent_reference "$pr_number" "$repo_slug") || parent_issue=""
 	[[ -n "$parent_issue" ]] || return 0
+	[[ "$parent_issue" != "$linked_issue" ]] || return 0
 
 	issue_api=$(_pm_issue_api "$repo_slug" "$parent_issue")
-	issue_body=$(gh api "$issue_api" --jq '.body // empty' 2>/dev/null) || issue_body=""
-	issue_labels=$(gh api "$issue_api" --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+	issue_json=$(gh api "$issue_api" 2>/dev/null) || issue_json=""
+	if [[ -z "$issue_json" ]]; then
+		return 0
+	fi
+	issue_body=$(printf '%s' "$issue_json" | jq -r '.body // empty' 2>/dev/null) || issue_body=""
+	issue_labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
 
 	if ! _pm_issue_needs_partial_closeout "$issue_body" "$issue_labels"; then
 		return 0
@@ -486,7 +492,7 @@ _pm_handle_partial_parent_closeout() {
 		return 0
 	fi
 
-	followups=$(_pm_unmet_acceptance_criteria "$issue_body") || followups="- Review remaining parent acceptance criteria."
+	followups=$(_pm_unmet_acceptance_criteria "$issue_body")
 	delivered_body="${merge_summary:-PR #${pr_number} merged as a leaf delivery.}"
 
 	local partial_comment
@@ -624,9 +630,8 @@ _handle_post_merge_actions() {
 		fi
 	fi
 
-	if [[ -z "$linked_issue" ]]; then
-		_pm_handle_partial_parent_closeout "$pr_number" "$repo_slug" "$merge_summary"
-	fi
+	# Post partial parent closeout if a For/Ref reference exists (GH#23937).
+	_pm_handle_partial_parent_closeout "$pr_number" "$repo_slug" "$merge_summary" "$linked_issue"
 
 	# Auto-release interactive claim if one exists for this issue (t2413).
 	# Handles the "when a PR they opened merges" release trigger from AGENTS.md

--- a/.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh
+++ b/.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh
@@ -65,13 +65,9 @@ if [[ "$1" == "api" && "$2" == *"/issues/23932/comments"* ]]; then
 	exit 0
 fi
 
-if [[ "$1" == "api" && "$2" == *"/issues/23932"* && "$*" == *".body"* ]]; then
-	printf '%s\n' "${TEST_ISSUE_BODY:-}"
-	exit 0
-fi
-
-if [[ "$1" == "api" && "$2" == *"/issues/23932"* && "$*" == *"labels"* ]]; then
-	printf '%s\n' "${TEST_ISSUE_LABELS:-}"
+if [[ "$1" == "api" && "$2" == *"/issues/23932"* ]]; then
+	jq -n --arg body "${TEST_ISSUE_BODY:-}" --arg labels "${TEST_ISSUE_LABELS:-}" \
+		'{body:$body,labels:($labels | split(",") | map(select(length > 0) | {name:.}))}'
 	exit 0
 fi
 
@@ -139,6 +135,19 @@ assert_no_comment() {
 	return 0
 }
 
+assert_api_issue_fetch_count() {
+	local expected="$1"
+	local label="$2"
+	local actual
+	actual=$(grep -c 'repos/marcusquinn/aidevops/issues/23932$' "$GH_CALL_LOG" 2>/dev/null || true)
+	if [[ "$actual" == "$expected" ]]; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Expected ${expected} issue fetches, saw ${actual}"
+	fi
+	return 0
+}
+
 test_for_reference_posts_partial_closeout() {
 	: >"$GH_COMMENT_LOG"
 	: >"$LOGFILE"
@@ -166,6 +175,48 @@ Umbrella lifecycle parent.
 		"For/Ref broad parent: lists remaining acceptance criteria"
 	assert_comment_contains "Do not close this parent" \
 		"For/Ref broad parent: records no-close rule"
+	assert_api_issue_fetch_count "1" \
+		"For/Ref broad parent: fetches issue body and labels once"
+	return 0
+}
+
+test_alternate_checklist_bullets_detect_parent_and_followups() {
+	: >"$GH_COMMENT_LOG"
+	: >"$GH_CALL_LOG"
+	export TEST_PR_BODY="For #23932"
+	export TEST_ISSUE_LABELS="bug,tier:simple"
+	export TEST_ISSUE_BODY="Small parent checklist.
+
+* [ ] Remaining: star bullet.
++ [ ] Remaining: plus bullet."
+	export TEST_EXISTING_COMMENTS="[]"
+
+	_pm_handle_partial_parent_closeout "23936" "marcusquinn/aidevops" "Leaf fix."
+
+	assert_comment_contains "Remaining: star bullet" \
+		"alternate checklist bullets: extracts star task"
+	assert_comment_contains "Remaining: plus bullet" \
+		"alternate checklist bullets: extracts plus task"
+	return 0
+}
+
+test_primary_linked_issue_skips_partial_closeout() {
+	: >"$GH_COMMENT_LOG"
+	: >"$GH_CALL_LOG"
+	export TEST_PR_BODY="Resolves #23932
+
+For #23932"
+	export TEST_ISSUE_LABELS="parent-task"
+	export TEST_ISSUE_BODY="## Acceptance Criteria
+
+- [ ] One
+- [ ] Two"
+	export TEST_EXISTING_COMMENTS="[]"
+
+	_pm_handle_partial_parent_closeout "23936" "marcusquinn/aidevops" "Leaf fix." "23932"
+	assert_no_comment "primary linked issue: partial parent closeout skipped"
+	assert_api_issue_fetch_count "0" \
+		"primary linked issue: skips issue fetch before duplicate path"
 	return 0
 }
 
@@ -206,6 +257,8 @@ main() {
 	fi
 
 	test_for_reference_posts_partial_closeout
+	test_alternate_checklist_bullets_detect_parent_and_followups
+	test_primary_linked_issue_skips_partial_closeout
 	test_leaf_reference_without_broad_signal_skips_comment
 	test_existing_marker_skips_duplicate_comment
 


### PR DESCRIPTION
## Summary

Updated partial parent closeout handling to support Markdown -, *, and + checklist bullets; fetch parent issue body and labels in one REST call; and run partial parent closeout for PRs with a distinct primary linked issue while skipping the primary issue itself.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh

Resolves #23968


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 2m and 62,801 tokens on this as a headless worker.