### PR TITLE
GH#23963: fix: reuse ruleset data in posture checks

### DIFF
--- a/.agents/scripts/security-posture-helper-repo.sh
+++ b/.agents/scripts/security-posture-helper-repo.sh
@@ -81,43 +81,26 @@ _classic_required_checks_count() {
 _rulesets_pr_gating_state() {
 	local slug="$1"
 	local default_branch="$2"
+	local ruleset_details="${3:-}"
 
-	local rulesets_json
-	rulesets_json=$(gh api "repos/${slug}/rulesets" 2>/dev/null) || return 1
-	[[ -z "$rulesets_json" || "$rulesets_json" == "[]" ]] && return 1
-
-	local active_ids
-	active_ids=$(echo "$rulesets_json" | jq -r --arg active "$RULESET_ENFORCEMENT_ACTIVE" '.[] | select(.enforcement == $active) | .id' 2>/dev/null) || return 1
-	[[ -z "$active_ids" ]] && return 1
+	if [[ "$#" -lt 3 ]]; then
+		ruleset_details=$(_default_branch_ruleset_details "$slug" "$default_branch") || return 1
+	fi
+	[[ -z "$ruleset_details" ]] && return 1
 
 	local protected=0
 	local reviews=0
 	local checks=0
 	local bypass=0
-	local id detail include_patterns pattern matches_default
-	while IFS= read -r id; do
-		[[ -z "$id" ]] && continue
-		detail=$(gh api "repos/${slug}/rulesets/${id}" 2>/dev/null) || continue
-		include_patterns=$(echo "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || continue
-
-		matches_default=0
-		while IFS= read -r pattern; do
-			[[ -z "$pattern" ]] && continue
-			case "$pattern" in
-			"refs/heads/${default_branch}" | "$RULESET_DEFAULT_BRANCH_TOKEN" | "$RULESET_ALL_BRANCHES_TOKEN" | "$RULESET_ALL_HEADS_PATTERN")
-				matches_default=1
-				break
-				;;
-			esac
-		done <<<"$include_patterns"
-
-		[[ "$matches_default" -eq 1 ]] || continue
+	local detail
+	while IFS= read -r detail; do
+		[[ -z "$detail" ]] && continue
 		protected=1
 
 		local approval_count status_count bypass_count
-		approval_count=$(echo "$detail" | jq -r '[.rules[]? | select(.type == "pull_request") | (.parameters.required_approving_review_count // 0)] | max // 0' 2>/dev/null) || approval_count="0"
-		status_count=$(echo "$detail" | jq -r '[.rules[]? | select(.type == "required_status_checks") | (.parameters.required_status_checks // []) | length] | add // 0' 2>/dev/null) || status_count="0"
-		bypass_count=$(echo "$detail" | jq -r '(.bypass_actors // []) | length' 2>/dev/null) || bypass_count="0"
+		approval_count=$(jq -r '[.rules[]? | select(.type == "pull_request") | (.parameters.required_approving_review_count // 0)] | max // 0' <<<"$detail" 2>/dev/null) || approval_count="0"
+		status_count=$(jq -r '[.rules[]? | select(.type == "required_status_checks") | (.parameters.required_status_checks // []) | length] | add // 0' <<<"$detail" 2>/dev/null) || status_count="0"
+		bypass_count=$(jq -r '(.bypass_actors // []) | length' <<<"$detail" 2>/dev/null) || bypass_count="0"
 
 		[[ "$approval_count" =~ ^[0-9]+$ ]] || approval_count="0"
 		[[ "$status_count" =~ ^[0-9]+$ ]] || status_count="0"
@@ -126,7 +109,7 @@ _rulesets_pr_gating_state() {
 		[[ "$approval_count" -gt 0 ]] && reviews=1
 		[[ "$status_count" -gt 0 ]] && checks=1
 		[[ "$bypass_count" -gt 0 ]] && bypass=1
-	done <<<"$active_ids"
+	done <<<"$ruleset_details"
 
 	printf '%s\t%s\t%s\t%s\n' "$protected" "$reviews" "$checks" "$bypass"
 	return 0
@@ -231,14 +214,20 @@ check_workflow_security() {
 	return 0
 }
 
-# _report_rulesets_branch_protection <slug> <default-branch> <public-admin-flag>
+# _report_rulesets_branch_protection <slug> <default-branch> <public-admin-flag> [ruleset-details]
 _report_rulesets_branch_protection() {
 	local slug="$1"
 	local default_branch="$2"
 	local public_admin="$3"
+	local ruleset_details="${4:-}"
 
 	local rulesets_state protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass
-	if rulesets_state=$(_rulesets_pr_gating_state "$slug" "$default_branch"); then
+	if [[ "$#" -ge 4 ]]; then
+		rulesets_state=$(_rulesets_pr_gating_state "$slug" "$default_branch" "$ruleset_details") || true
+	else
+		rulesets_state=$(_rulesets_pr_gating_state "$slug" "$default_branch") || true
+	fi
+	if [[ -n "$rulesets_state" ]]; then
 		IFS=$'\t' read -r protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass <<<"$rulesets_state"
 	else
 		protected_by_rulesets=0
@@ -386,6 +375,7 @@ _report_classic_admin_enforcement() {
 # Phase 2: Check branch protection
 check_branch_protection() {
 	local repo_path="$1"
+	local ruleset_details="${2:-}"
 
 	print_header "Phase 2: Branch Protection"
 
@@ -413,7 +403,11 @@ check_branch_protection() {
 
 	protection_json=$(gh api "repos/$slug/branches/$default_branch/protection" 2>/dev/null) || true
 	if [[ -z "$protection_json" || "$protection_json" == *"Not Found"* || "$protection_json" == *"Branch not protected"* ]]; then
-		_report_rulesets_branch_protection "$slug" "$default_branch" "$public_admin"
+		if [[ "$#" -ge 2 ]]; then
+			_report_rulesets_branch_protection "$slug" "$default_branch" "$public_admin" "$ruleset_details"
+		else
+			_report_rulesets_branch_protection "$slug" "$default_branch" "$public_admin"
+		fi
 		return 0
 	fi
 
@@ -478,44 +472,70 @@ _default_branch_for_repo() {
 	return 0
 }
 
+_ruleset_targets_default_branch() {
+	local detail="$1"
+	local default_branch="$2"
+
+	local include_patterns pattern
+	include_patterns=$(jq -r '.conditions.ref_name.include // [] | .[]' <<<"$detail" 2>/dev/null) || return 1
+
+	while IFS= read -r pattern; do
+		[[ -z "$pattern" ]] && continue
+		case "$pattern" in
+		"refs/heads/${default_branch}" | "$RULESET_DEFAULT_BRANCH_TOKEN" | "$RULESET_ALL_BRANCHES_TOKEN" | "$RULESET_ALL_HEADS_PATTERN")
+			return 0
+			;;
+		esac
+	done <<<"$include_patterns"
+
+	return 1
+}
+
+_default_branch_ruleset_details() {
+	local slug="$1"
+	local default_branch="$2"
+	local rulesets_json="${3:-}"
+
+	if [[ -z "$rulesets_json" ]]; then
+		rulesets_json=$(gh api "repos/${slug}/rulesets" 2>/dev/null) || return 1
+	fi
+	[[ -z "$rulesets_json" || "$rulesets_json" == "[]" ]] && return 1
+
+	local active_ids
+	active_ids=$(jq -r --arg active "$RULESET_ENFORCEMENT_ACTIVE" '.[] | select(.enforcement == $active) | .id' <<<"$rulesets_json" 2>/dev/null) || return 1
+	[[ -z "$active_ids" ]] && return 1
+
+	local id detail
+	while IFS= read -r id; do
+		[[ -z "$id" ]] && continue
+		detail=$(gh api "repos/${slug}/rulesets/${id}" 2>/dev/null) || continue
+		_ruleset_targets_default_branch "$detail" "$default_branch" || continue
+		jq -c '.' <<<"$detail" 2>/dev/null || true
+	done <<<"$active_ids"
+	return 0
+}
+
 _classic_required_check_contexts() {
 	local protection_json="$1"
-	echo "$protection_json" | jq -r '(.required_status_checks.contexts // [])[], (.required_status_checks.checks // [])[].context? // empty' 2>/dev/null || true
+	jq -r '(.required_status_checks.contexts // [])[], (.required_status_checks.checks // [])[].context? // empty' <<<"$protection_json" 2>/dev/null || true
 	return 0
 }
 
 _rulesets_required_check_contexts() {
 	local slug="$1"
 	local default_branch="$2"
+	local ruleset_details="${3:-}"
 
-	local rulesets_json
-	rulesets_json=$(gh api "repos/${slug}/rulesets" 2>/dev/null) || return 0
-	[[ -z "$rulesets_json" || "$rulesets_json" == "[]" ]] && return 0
+	if [[ "$#" -lt 3 ]]; then
+		ruleset_details=$(_default_branch_ruleset_details "$slug" "$default_branch") || return 0
+	fi
+	[[ -z "$ruleset_details" ]] && return 0
 
-	local active_ids
-	active_ids=$(echo "$rulesets_json" | jq -r --arg active "$RULESET_ENFORCEMENT_ACTIVE" '.[] | select(.enforcement == $active) | .id' 2>/dev/null) || return 0
-	[[ -z "$active_ids" ]] && return 0
-
-	local id detail include_patterns pattern matches_default
-	while IFS= read -r id; do
-		[[ -z "$id" ]] && continue
-		detail=$(gh api "repos/${slug}/rulesets/${id}" 2>/dev/null) || continue
-		include_patterns=$(echo "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || continue
-
-		matches_default=0
-		while IFS= read -r pattern; do
-			[[ -z "$pattern" ]] && continue
-			case "$pattern" in
-			"refs/heads/${default_branch}" | "$RULESET_DEFAULT_BRANCH_TOKEN" | "$RULESET_ALL_BRANCHES_TOKEN" | "$RULESET_ALL_HEADS_PATTERN")
-				matches_default=1
-				break
-				;;
-			esac
-		done <<<"$include_patterns"
-
-		[[ "$matches_default" -eq 1 ]] || continue
-		echo "$detail" | jq -r '.rules[]? | select(.type == "required_status_checks") | (.parameters.required_status_checks // [])[] | (.context // .name // empty)' 2>/dev/null || true
-	done <<<"$active_ids"
+	local detail
+	while IFS= read -r detail; do
+		[[ -z "$detail" ]] && continue
+		jq -r '.rules[]? | select(.type == "required_status_checks") | (.parameters.required_status_checks // [])[] | (.context // .name // empty)' <<<"$detail" 2>/dev/null || true
+	done <<<"$ruleset_details"
 	return 0
 }
 
@@ -529,6 +549,7 @@ _required_check_present() {
 # Phase 3.5: Check linked-issue-check workflow and required status
 check_linked_issue_gate() {
 	local repo_path="$1"
+	local ruleset_details="${2:-}"
 
 	print_header "Phase 3.5: Linked-Issue PR Check"
 
@@ -560,7 +581,11 @@ check_linked_issue_gate() {
 	protection_json=$(gh api "repos/$slug/branches/$default_branch/protection" 2>/dev/null) || true
 	check_contexts="$(_classic_required_check_contexts "$protection_json")"
 	check_contexts+=$'\n'
-	check_contexts+="$(_rulesets_required_check_contexts "$slug" "$default_branch")"
+	if [[ "$#" -ge 2 ]]; then
+		check_contexts+="$(_rulesets_required_check_contexts "$slug" "$default_branch" "$ruleset_details")"
+	else
+		check_contexts+="$(_rulesets_required_check_contexts "$slug" "$default_branch")"
+	fi
 
 	if _required_check_present "$check_contexts" "linked-issue-check"; then
 		print_pass "linked-issue-check is a required status check"
@@ -891,7 +916,7 @@ ADVISORY_EOF
 # (the modern replacement for classic branch-protection rules, see t2806).
 # Returns 0 if any active ruleset targets the default branch with a
 # meaningful protection rule; 1 otherwise (including API errors).
-# Usage: _branch_is_rulesets_protected <slug> <default_branch>
+# Usage: _branch_is_rulesets_protected <slug> <default_branch> [ruleset-details]
 #
 # Fail-open: empty/errored rulesets API returns 1 (not protected). A
 # false negative here loses the advisory; a false positive just results
@@ -900,48 +925,27 @@ ADVISORY_EOF
 _branch_is_rulesets_protected() {
 	local slug="$1"
 	local default_branch="$2"
+	local ruleset_details="${3:-}"
 
-	local rulesets_json
-	rulesets_json=$(gh api "repos/${slug}/rulesets" 2>/dev/null) || return 1
-	[[ -z "$rulesets_json" || "$rulesets_json" == "[]" ]] && return 1
+	if [[ "$#" -lt 3 ]]; then
+		ruleset_details=$(_default_branch_ruleset_details "$slug" "$default_branch") || return 1
+	fi
+	[[ -z "$ruleset_details" ]] && return 1
 
-	# Extract active ruleset IDs (enforcement == "active")
-	local active_ids
-	active_ids=$(echo "$rulesets_json" | jq -r --arg active "$RULESET_ENFORCEMENT_ACTIVE" '.[] | select(.enforcement == $active) | .id' 2>/dev/null) || return 1
-	[[ -z "$active_ids" ]] && return 1
-
-	local id detail include_patterns rule_types
-	while IFS= read -r id; do
-		[[ -z "$id" ]] && continue
-		detail=$(gh api "repos/${slug}/rulesets/${id}" 2>/dev/null) || continue
-
-		# Include patterns can be specific refs ("refs/heads/main") or
-		# GitHub wildcards ("~DEFAULT_BRANCH", "~ALL").
-		include_patterns=$(echo "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || continue
-
-		local matches_default="no"
-		while IFS= read -r pattern; do
-			[[ -z "$pattern" ]] && continue
-			case "$pattern" in
-			"refs/heads/${default_branch}" | "$RULESET_DEFAULT_BRANCH_TOKEN" | "$RULESET_ALL_BRANCHES_TOKEN" | "$RULESET_ALL_HEADS_PATTERN")
-				matches_default="yes"
-				break
-				;;
-			esac
-		done <<<"$include_patterns"
-
-		[[ "$matches_default" == "yes" ]] || continue
+	local detail rule_types
+	while IFS= read -r detail; do
+		[[ -z "$detail" ]] && continue
 
 		# Protection signals: pull_request review requirement OR
 		# required_status_checks. Either blocks direct bot pushes via
 		# the PR-required or checks-required gate, and is a strong
 		# signal that SYNC_PAT is needed downstream (t2449 author
 		# association chain, t2806).
-		rule_types=$(echo "$detail" | jq -r '.rules[].type' 2>/dev/null) || continue
-		if echo "$rule_types" | grep -qE '^(pull_request|required_status_checks)$'; then
+		rule_types=$(jq -r '.rules[].type' <<<"$detail" 2>/dev/null) || continue
+		if grep -qE '^(pull_request|required_status_checks)$' <<<"$rule_types"; then
 			return 0
 		fi
-	done <<<"$active_ids"
+	done <<<"$ruleset_details"
 
 	return 1
 }
@@ -956,11 +960,12 @@ _branch_is_rulesets_protected() {
 # lines and the equality check against "not_needed" failed. Using a
 # dedicated global eliminates the capture conflict entirely.
 #
-# Usage: _check_sync_pat_need <repo_path> <slug> <advisory_file>
+# Usage: _check_sync_pat_need <repo_path> <slug> <advisory_file> [ruleset-details]
 _check_sync_pat_need() {
 	local repo_path="$1"
 	local slug="$2"
 	local advisory_file="$3"
+	local ruleset_details="${4:-}"
 
 	SYNC_PAT_NEED_RESULT=""
 
@@ -987,7 +992,7 @@ _check_sync_pat_need() {
 
 	if [[ -n "$protection_json" && "$protection_json" != *"Not Found"* && "$protection_json" != *"Branch not protected"* ]]; then
 		protected_kind="classic"
-	elif _branch_is_rulesets_protected "$slug" "$default_branch"; then
+	elif { [[ "$#" -ge 4 ]] && _branch_is_rulesets_protected "$slug" "$default_branch" "$ruleset_details"; } || { [[ "$#" -lt 4 ]] && _branch_is_rulesets_protected "$slug" "$default_branch"; }; then
 		# Step 2b: Rulesets-based protection (t2806). Modern repos
 		# return 404 on the classic endpoint but carry rulesets via
 		# /repos/{slug}/rulesets — the legacy detector silently
@@ -1044,6 +1049,7 @@ _check_sync_pat_need() {
 # per-repo advisories via ~/.aidevops/advisories/sync-pat-<slug>.advisory.
 check_sync_pat() {
 	local repo_path="$1"
+	local ruleset_details="${2:-}"
 
 	print_header "Phase 7: SYNC_PAT Detection (issue-sync)"
 
@@ -1085,7 +1091,11 @@ check_sync_pat() {
 	# Check need via helper. Result is written to SYNC_PAT_NEED_RESULT — NOT
 	# returned via stdout, because `print_pass` / `add_finding` inside the
 	# helper also write to stdout and would pollute a `$()` capture (t2806).
-	_check_sync_pat_need "$repo_path" "$slug" "$advisory_file"
+	if [[ "$#" -ge 2 ]]; then
+		_check_sync_pat_need "$repo_path" "$slug" "$advisory_file" "$ruleset_details"
+	else
+		_check_sync_pat_need "$repo_path" "$slug" "$advisory_file"
+	fi
 
 	if [[ "$SYNC_PAT_NEED_RESULT" == "$SYNC_PAT_NEED_NOT_NEEDED" ]]; then
 		return 0
@@ -1397,14 +1407,22 @@ run_all_checks() {
 
 	print_info "Repository: $repo_path"
 
+	local slug default_branch ruleset_details
+	if command -v gh &>/dev/null && slug=$(resolve_slug "$repo_path"); then
+		default_branch=$(_default_branch_for_repo "$repo_path")
+		ruleset_details=$(_default_branch_ruleset_details "$slug" "$default_branch") || ruleset_details=""
+	else
+		ruleset_details=""
+	fi
+
 	check_workflow_security "$repo_path"
-	check_branch_protection "$repo_path"
+	check_branch_protection "$repo_path" "$ruleset_details"
 	check_review_bot_gate "$repo_path"
-	check_linked_issue_gate "$repo_path"
+	check_linked_issue_gate "$repo_path" "$ruleset_details"
 	check_dependencies "$repo_path"
 	check_collaborators "$repo_path"
 	check_repo_security "$repo_path"
-	check_sync_pat "$repo_path"
+	check_sync_pat "$repo_path" "$ruleset_details"
 	check_cross_account_inherit "$repo_path"
 	print_report
 


### PR DESCRIPTION
## Summary

Reused precomputed default-branch ruleset details across branch protection, linked-issue, and SYNC_PAT posture checks; replaced JSON echo-to-jq paths with here-strings in the touched ruleset helpers.

## Files Changed

.agents/scripts/security-posture-helper-repo.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/security-posture-helper-repo.sh; bash -n .agents/scripts/security-posture-helper-repo.sh; bash .agents/scripts/tests/test-security-posture-public-pr-gating.sh; bash .agents/scripts/tests/test-linked-issue-guidance.sh

Resolves #23963


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.27 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 6m and 85,360 tokens on this as a headless worker.