### PR TITLE
fix: treat terminal worker state as complete

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -689,6 +689,57 @@ _recover_worker_output_on_failure() {
 	return 1
 }
 
+#######################################
+# Return success when GitHub already shows the worker target as terminal.
+#
+# A worker can be interrupted after it merged a PR or closed the linked issue.
+# In that case the local process lacks a completion signal, but redispatching is
+# noise. Only confirmed terminal GitHub state returns 0; unknown/API failures
+# return 1 so normal failure handling remains conservative.
+#
+# Args: $1=session_key, $2=work_dir (optional, used to resolve branch)
+#######################################
+_worker_external_terminal_complete() {
+	local session_key="$1"
+	local work_dir="$2"
+	local repo_slug="${DISPATCH_REPO_SLUG:-}"
+	local issue_number=""
+	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
+
+	[[ "$session_key" == issue-* ]] || return 1
+	[[ -n "$repo_slug" && -n "$issue_number" ]] || return 1
+	command -v gh >/dev/null 2>&1 || return 1
+
+	local issue_state=""
+	issue_state=$(gh issue view "$issue_number" --repo "$repo_slug" --json state --jq '.state // empty' 2>/dev/null || true)
+	if [[ "$issue_state" == "CLOSED" ]]; then
+		print_info "[lifecycle] worker_external_terminal issue_closed session=${session_key} issue=${issue_number}"
+		return 0
+	fi
+
+	local branch_name=""
+	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
+		branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	fi
+
+	local merged_count=""
+	if [[ -n "$branch_name" && "$branch_name" != "HEAD" ]]; then
+		merged_count=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state merged --json number --jq 'length' 2>/dev/null || true)
+		if [[ "$merged_count" =~ ^[0-9]+$ && "$merged_count" -gt 0 ]]; then
+			print_info "[lifecycle] worker_external_terminal pr_merged session=${session_key} branch=${branch_name}"
+			return 0
+		fi
+	fi
+
+	merged_count=$(gh pr list --repo "$repo_slug" --search "$issue_number" --state merged --json number --jq 'length' 2>/dev/null || true)
+	if [[ "$merged_count" =~ ^[0-9]+$ && "$merged_count" -gt 0 ]]; then
+		print_info "[lifecycle] worker_external_terminal issue_pr_merged session=${session_key} issue=${issue_number}"
+		return 0
+	fi
+
+	return 1
+}
+
 # =============================================================================
 # Run lifecycle — prepare, finish, retry, detach
 # =============================================================================
@@ -886,7 +937,10 @@ _cmd_run_finish() {
 	# CLAIM_RELEASED comment is redundant operational metadata.
 	if [[ "$ledger_status" == "$_HRW_STATUS_FAIL" ]]; then
 		local _failure_recovered=0
-		if _recover_worker_output_on_failure "$session_key" "$work_dir"; then
+		if _worker_external_terminal_complete "$session_key" "$work_dir"; then
+			_release_dispatch_claim "$session_key" "worker_complete"
+			_failure_recovered=1
+		elif _recover_worker_output_on_failure "$session_key" "$work_dir"; then
 			_failure_recovered=1
 		else
 			_release_dispatch_claim "$session_key" "worker_failed"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1492,6 +1492,67 @@ test_cmd_run_finish_fail_recovers_branch_orphan_output() {
 	return 0
 }
 
+test_cmd_run_finish_fail_closed_issue_releases_complete() {
+	local work_dir="${TEST_ROOT}/repo-fail-issue-closed"
+	local released_reason="" fast_fail_called=0
+	_setup_test_git_repo "$work_dir" 0
+	DISPATCH_REPO_SLUG="test-owner/test-repo"
+	gh() {
+		if [[ "${*}" == *"issue view"* ]]; then printf 'CLOSED'
+		else printf '0'
+		fi
+		return 0
+	}
+	_release_dispatch_claim() { released_reason="$2"; return 0; }
+	_report_failure_to_fast_fail() { fast_fail_called=1; return 0; }
+	_update_dispatch_ledger() { return 0; }
+	_release_session_lock() { return 0; }
+	_increment_orphan_count_stat() { return 0; }
+
+	_cmd_run_finish "issue-99999" "fail" "$work_dir"
+
+	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh 2>/dev/null || true
+	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
+		print_result "_cmd_run_finish fail treats closed linked issue as complete" 0
+	else
+		print_result "_cmd_run_finish fail treats closed linked issue as complete" 1 \
+			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
+	fi
+	return 0
+}
+
+test_cmd_run_finish_fail_merged_pr_releases_complete() {
+	local work_dir="${TEST_ROOT}/repo-fail-pr-merged"
+	local released_reason="" fast_fail_called=0
+	_setup_test_git_repo "$work_dir" 1
+	DISPATCH_REPO_SLUG="test-owner/test-repo"
+	gh() {
+		if [[ "${*}" == *"issue view"* ]]; then printf 'OPEN'
+		elif [[ "${*}" == *"pr list"* && "${*}" == *"--state merged"* ]]; then printf '1'
+		else printf '0'
+		fi
+		return 0
+	}
+	_release_dispatch_claim() { released_reason="$2"; return 0; }
+	_report_failure_to_fast_fail() { fast_fail_called=1; return 0; }
+	_update_dispatch_ledger() { return 0; }
+	_release_session_lock() { return 0; }
+	_increment_orphan_count_stat() { return 0; }
+
+	_cmd_run_finish "issue-99999" "fail" "$work_dir"
+
+	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh 2>/dev/null || true
+	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
+		print_result "_cmd_run_finish fail treats merged PR as complete" 0
+	else
+		print_result "_cmd_run_finish fail treats merged PR as complete" 1 \
+			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
+	fi
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_appends_escalation_contract
@@ -1544,6 +1605,8 @@ main() {
 	test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete
 	test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan
 	test_cmd_run_finish_fail_recovers_branch_orphan_output
+	test_cmd_run_finish_fail_closed_issue_releases_complete
+	test_cmd_run_finish_fail_merged_pr_releases_complete
 	teardown_test_env
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	printf 'Failures: %d\n' "$TESTS_FAILED"


### PR DESCRIPTION
For #23977

## Summary
- Treat confirmed terminal GitHub state as worker completion on failure paths.
- Check closed linked issues, merged PRs by branch, and merged PRs by issue search before releasing `worker_failed`.
- Add regression coverage for closed issue and merged PR recovery paths.

## Verification
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash -n .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh` (completed; existing markdown/ratchet/complexity advisories reported, final local checks passed)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 3d 18h and 2,986,392 tokens on this with the user in an interactive session.