### PR TITLE
GH#23976: feat: adopt rtk compact status guidance

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -58,6 +58,9 @@ Use comparison results to classify a command:
   structured fields can answer the question more precisely.
 - **Unsafe for RTK**: exit codes differ, omitted lines could alter diagnosis, or
   exact evidence/security/JSON/diff semantics are required.
+- `git status` expansion is a regression signal: RTK upstream dropped the
+  compact-status `-uall` flag so untracked directories collapse like raw git;
+  rerun raw status and verify RTK version when comparison shows expansion.
 
 ## Always bypass RTK
 
@@ -72,9 +75,11 @@ Use comparison results to classify a command:
 ## Validation notes
 
 Initial validation for GH#23212 found RTK useful for list-style GitHub context
-(`gh issue list`, `gh pr list`) and not useful for tiny `git status`, already
-compact `git log --oneline`, or full issue bodies. Prefer RTK for discovery and
-triage summaries; prefer raw output or structured fields for exact task briefs.
+(`gh issue list`, `gh pr list`) and only situational for tiny `git status`,
+already compact `git log --oneline`, or full issue bodies. After the upstream
+compact-status fix, `git status` should no longer expand fully-untracked
+directories beyond raw output. Prefer RTK for discovery and triage summaries;
+prefer raw output or structured fields for exact task briefs.
 
 For future regressions, capture:
 

--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -123,6 +123,8 @@ if raw_rc != rtk_rc:
     print("- Broaden immediately: exit codes differ, so use the raw command for diagnosis.")
 elif delta <= 0:
     print("- Prefer raw or a narrower structured command: RTK did not reduce this output.")
+    if command == "git status":
+        print("- For `git status`, verify RTK includes the upstream compact-status fix that drops `-uall` before treating expanded output as expected.")
 else:
     print("- RTK is useful for first-pass discovery if all decision facts are present.")
 print("- For exact evidence, JSON assertions, diffs, security scans, or terminal failures, rerun raw/direct commands.")

--- a/.agents/scripts/tests/test-rtk-helper.sh
+++ b/.agents/scripts/tests/test-rtk-helper.sh
@@ -72,6 +72,16 @@ printf 'long raw payload with extra diagnostic detail\n'
 STUB
 chmod +x "${TMPDIR_TEST}/samplecmd"
 
+cat >"${TMPDIR_TEST}/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "status" ]]; then
+  printf 'raw git status\n'
+  exit 0
+fi
+printf 'git %s\n' "$*"
+STUB
+chmod +x "${TMPDIR_TEST}/git"
+
 session_db="${TMPDIR_TEST}/opencode.db"
 python3 - "$session_db" <<'PY'
 import json
@@ -116,6 +126,9 @@ assert_contains "compare emits diagnostic heading" "RTK output comparison" "$com
 assert_contains "compare records same exit code" "Same exit code: yes" "$compare_output"
 assert_contains "compare emits decision guidance" "Decision guidance" "$compare_output"
 assert_not_contains "compare strips advisory" "No hook installed" "$compare_output"
+
+PATH="${TMPDIR_TEST}:$PATH" git_status_compare_output=$("$HELPER" --compare git status)
+assert_contains "git status compare flags upstream compact fix" "drops \`-uall\`" "$git_status_compare_output"
 
 export OPENCODE_DB_PATH="$session_db"
 adoption_output=$("$HELPER" --adoption-report "2026-05-08 00:00:00")


### PR DESCRIPTION
## Summary

Adopted the upstream RTK compact git status review by teaching rtk-helper compare output to flag git status expansion as an upstream compact-status regression, adding test coverage, and updating context-efficient-output guidance.

## Files Changed

.agents/reference/context-efficient-output.md,.agents/scripts/rtk-helper.sh,.agents/scripts/tests/test-rtk-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-rtk-helper.sh; shellcheck .agents/scripts/rtk-helper.sh .agents/scripts/tests/test-rtk-helper.sh; .agents/scripts/linters-local.sh (passed; pre-existing warnings/errors reported but final gate passed)

Resolves #23976


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 7m and 62,863 tokens on this as a headless worker.