### PR TITLE
GH#23983: fix: narrow RTK git status regression guidance

### DIFF
--- a/.agents/scripts/rtk-helper.sh
+++ b/.agents/scripts/rtk-helper.sh
@@ -123,7 +123,7 @@ if raw_rc != rtk_rc:
     print("- Broaden immediately: exit codes differ, so use the raw command for diagnosis.")
 elif delta <= 0:
     print("- Prefer raw or a narrower structured command: RTK did not reduce this output.")
-    if command == "git status":
+    if delta < 0 and command.startswith("git status"):
         print("- For `git status`, verify RTK includes the upstream compact-status fix that drops `-uall` before treating expanded output as expected.")
 else:
     print("- RTK is useful for first-pass discovery if all decision facts are present.")

--- a/.agents/scripts/tests/test-rtk-helper.sh
+++ b/.agents/scripts/tests/test-rtk-helper.sh
@@ -62,6 +62,10 @@ if [[ "${1:-}" == "samplecmd" ]]; then
   printf 'short\n'
   exit 0
 fi
+if [[ "${1:-}" == "git" && "${2:-}" == "status" && "${3:-}" == "--unchanged" ]]; then
+  printf 'payload: git status --unchanged\n'
+  exit 0
+fi
 printf 'payload: %s\n' "$*"
 STUB
 chmod +x "${TMPDIR_TEST}/rtk"
@@ -75,6 +79,10 @@ chmod +x "${TMPDIR_TEST}/samplecmd"
 cat >"${TMPDIR_TEST}/git" <<'STUB'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "status" ]]; then
+  if [[ "${2:-}" == "--unchanged" ]]; then
+    printf 'payload: git status --unchanged\n'
+    exit 0
+  fi
   printf 'raw git status\n'
   exit 0
 fi
@@ -129,6 +137,12 @@ assert_not_contains "compare strips advisory" "No hook installed" "$compare_outp
 
 PATH="${TMPDIR_TEST}:$PATH" git_status_compare_output=$("$HELPER" --compare git status)
 assert_contains "git status compare flags upstream compact fix" "drops \`-uall\`" "$git_status_compare_output"
+
+PATH="${TMPDIR_TEST}:$PATH" git_status_flag_compare_output=$("$HELPER" --compare git status -s)
+assert_contains "git status compare handles flags" "drops \`-uall\`" "$git_status_flag_compare_output"
+
+PATH="${TMPDIR_TEST}:$PATH" git_status_unchanged_compare_output=$("$HELPER" --compare git status --unchanged)
+assert_not_contains "git status compare omits unchanged compact fix noise" "drops \`-uall\`" "$git_status_unchanged_compare_output"
 
 export OPENCODE_DB_PATH="$session_db"
 adoption_output=$("$HELPER" --adoption-report "2026-05-08 00:00:00")


### PR DESCRIPTION
## Summary

Updated RTK compare guidance to warn only when git status output expands, while matching git status commands with flags; added regression coverage for flagged and unchanged output cases.

## Files Changed

.agents/scripts/rtk-helper.sh,.agents/scripts/tests/test-rtk-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-rtk-helper.sh; shellcheck .agents/scripts/rtk-helper.sh .agents/scripts/tests/test-rtk-helper.sh

Resolves #23983


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 38,237 tokens on this as a headless worker.