### PR TITLE
GH#23988: fix: consolidate partial closeout issue parsing

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -478,8 +478,11 @@ _pm_handle_partial_parent_closeout() {
 	if [[ -z "$issue_json" ]]; then
 		return 0
 	fi
-	issue_body=$(printf '%s' "$issue_json" | jq -r '.body // empty' 2>/dev/null) || issue_body=""
-	issue_labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+	local _RS=$'\x1e'
+	IFS="$_RS" read -r -d '' issue_body issue_labels < <(
+		printf '%s' "$issue_json" | jq -j --arg rs "$_RS" \
+			'(.body // ""), $rs, ([.labels[]?.name] | join(",")), "\u0000"'
+	) || true
 
 	if ! _pm_issue_needs_partial_closeout "$issue_body" "$issue_labels"; then
 		return 0


### PR DESCRIPTION
## Summary

- Consolidates partial parent closeout issue parsing into one jq pass.
- Uses ASCII record separator plus NUL-terminated read to preserve multiline bodies and empty fields.
- Uses optional label traversal so missing labels do not fail parsing.

## Testing

- `shellcheck .agents/scripts/pulse-merge.sh`
- `.agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh`

<!-- MERGE_SUMMARY
Consolidated partial parent closeout issue body and label extraction into one jq pass using an ASCII record separator, NUL-terminated read, and optional label traversal.
Testing: shellcheck .agents/scripts/pulse-merge.sh; .agents/scripts/tests/test-pulse-merge-partial-parent-closeout.sh
MERGE_SUMMARY -->

Resolves #23988

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 51,926 tokens on this as a headless worker.
