### PR TITLE
feat: define report component taxonomy

### DIFF
--- a/.agents/configs/report-component-taxonomy.json.txt
+++ b/.agents/configs/report-component-taxonomy.json.txt
@@ -1,0 +1,385 @@
+{
+  "_comment": "Canonical report component taxonomy and evidence badge model. See .agents/reference/report-component-taxonomy.md.",
+  "version": 1,
+  "evidence_badges": [
+    {
+      "id": "observed",
+      "label": "Observed",
+      "description": "First-party crawl, audit, screenshot, log, analytics, search console, or manual review evidence",
+      "required_fields": [
+        "source_id",
+        "source_title",
+        "source_type",
+        "observed_date",
+        "claim_supported",
+        "confidence",
+        "sensitivity"
+      ]
+    },
+    {
+      "id": "sourced",
+      "label": "Sourced",
+      "description": "Third-party source, vendor documentation, public research, standards, or cited article",
+      "required_fields": [
+        "source_id",
+        "source_title",
+        "source_type",
+        "observed_date",
+        "claim_supported",
+        "confidence",
+        "sensitivity"
+      ]
+    },
+    {
+      "id": "benchmark",
+      "label": "Benchmark",
+      "description": "Competitive comparison, industry baseline, mention comparison, or before/after metric",
+      "required_fields": [
+        "source_id",
+        "source_title",
+        "source_type",
+        "observed_date",
+        "claim_supported",
+        "confidence",
+        "sensitivity"
+      ]
+    },
+    {
+      "id": "inferred",
+      "label": "Inferred",
+      "description": "Modelled conclusion from multiple signals where no single source proves the whole claim",
+      "required_fields": [
+        "source_id",
+        "source_title",
+        "source_type",
+        "observed_date",
+        "claim_supported",
+        "confidence",
+        "sensitivity"
+      ]
+    },
+    {
+      "id": "estimate",
+      "label": "Estimate",
+      "description": "Forecast, projection, sizing, effort, cost, lift, or priority score",
+      "required_fields": [
+        "source_id",
+        "source_title",
+        "source_type",
+        "observed_date",
+        "claim_supported",
+        "confidence",
+        "sensitivity"
+      ]
+    }
+  ],
+  "enums": {
+    "evidence_badge": [
+      "observed",
+      "sourced",
+      "benchmark",
+      "inferred",
+      "estimate"
+    ],
+    "source_type": [
+      "first_party",
+      "third_party",
+      "benchmark",
+      "model",
+      "manual_review",
+      "generated_artifact"
+    ],
+    "confidence": [
+      "high",
+      "medium",
+      "low"
+    ],
+    "sensitivity": [
+      "public",
+      "internal",
+      "confidential",
+      "redacted"
+    ],
+    "priority": [
+      "critical",
+      "high",
+      "medium",
+      "low"
+    ],
+    "checklist_status": [
+      "todo",
+      "doing",
+      "done",
+      "blocked",
+      "not_applicable"
+    ]
+  },
+  "shared_fields": [
+    "id",
+    "component",
+    "title",
+    "body",
+    "evidence",
+    "rendering_notes"
+  ],
+  "components": [
+    {
+      "id": "cover_meta",
+      "label": "Cover/meta",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "subtitle",
+        "prepared_for",
+        "prepared_by",
+        "prepared_date",
+        "version",
+        "confidentiality",
+        "summary"
+      ],
+      "rendering_notes": "First page or report header with safe metadata and summary."
+    },
+    {
+      "id": "sticky_toc",
+      "label": "Sticky TOC",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "items"
+      ],
+      "item_required_fields": [
+        "label",
+        "anchor",
+        "level",
+        "status"
+      ],
+      "rendering_notes": "Pinned navigation in HTML; normal table of contents in Markdown/PDF."
+    },
+    {
+      "id": "chapter_hero_heading",
+      "label": "Chapter hero heading",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "anchor",
+        "kicker",
+        "summary",
+        "priority",
+        "evidence"
+      ],
+      "rendering_notes": "Major section opener with outcome-focused summary."
+    },
+    {
+      "id": "action_line",
+      "label": "Action line",
+      "required_fields": [
+        "id",
+        "component",
+        "action",
+        "owner",
+        "priority",
+        "effort",
+        "impact",
+        "due",
+        "evidence"
+      ],
+      "rendering_notes": "High-contrast single-sentence action strip."
+    },
+    {
+      "id": "evidence_badge",
+      "label": "Evidence badge",
+      "required_fields": [
+        "id",
+        "component",
+        "badge",
+        "label",
+        "evidence"
+      ],
+      "rendering_notes": "Compact badge mapped to the evidence_badge enum."
+    },
+    {
+      "id": "tactic_card",
+      "label": "What/Why/How tactic card",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "what",
+        "why",
+        "how",
+        "priority",
+        "impact",
+        "effort",
+        "evidence"
+      ],
+      "rendering_notes": "Recommendation card with rationale and execution steps."
+    },
+    {
+      "id": "code_example_card",
+      "label": "Code/example card",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "language",
+        "code_or_example",
+        "context",
+        "copy_safe",
+        "evidence"
+      ],
+      "rendering_notes": "Preserve fenced-code readability and production-readiness labels."
+    },
+    {
+      "id": "good_bad_rows",
+      "label": "Good/bad rows",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "rows"
+      ],
+      "item_required_fields": [
+        "good",
+        "bad",
+        "reason",
+        "evidence"
+      ],
+      "rendering_notes": "Contrastive guidance focused on observable differences."
+    },
+    {
+      "id": "stats_strip",
+      "label": "Stats strip",
+      "required_fields": [
+        "id",
+        "component",
+        "metrics"
+      ],
+      "item_required_fields": [
+        "label",
+        "value",
+        "unit",
+        "delta",
+        "period",
+        "evidence"
+      ],
+      "rendering_notes": "Compact KPI cards with period and unit."
+    },
+    {
+      "id": "facts_table",
+      "label": "Facts table",
+      "required_fields": [
+        "id",
+        "component",
+        "columns",
+        "rows",
+        "evidence"
+      ],
+      "rendering_notes": "Dense factual data with stable export columns."
+    },
+    {
+      "id": "details_note",
+      "label": "Details note",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "body",
+        "tone",
+        "evidence"
+      ],
+      "rendering_notes": "Aside/details block for caveats, assumptions, and implementation notes."
+    },
+    {
+      "id": "industry_card",
+      "label": "Industry card",
+      "required_fields": [
+        "id",
+        "component",
+        "industry",
+        "title",
+        "context",
+        "pattern",
+        "implication",
+        "evidence"
+      ],
+      "rendering_notes": "Vertical-specific guidance with applicability boundary."
+    },
+    {
+      "id": "priority_group",
+      "label": "Priority group",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "priority",
+        "items",
+        "rationale",
+        "evidence"
+      ],
+      "rendering_notes": "Grouped actions sorted from critical to low priority."
+    },
+    {
+      "id": "checklist",
+      "label": "Checklist",
+      "required_fields": [
+        "id",
+        "component",
+        "title",
+        "items"
+      ],
+      "item_required_fields": [
+        "label",
+        "status",
+        "owner",
+        "evidence"
+      ],
+      "rendering_notes": "Action checklist using the checklist_status enum."
+    },
+    {
+      "id": "source_card",
+      "label": "Source card",
+      "required_fields": [
+        "id",
+        "component",
+        "source_id",
+        "source_title",
+        "source_type",
+        "observed_date",
+        "summary",
+        "sensitivity"
+      ],
+      "rendering_notes": "Appendix/source-section card backing citations and badges."
+    },
+    {
+      "id": "myth_callout",
+      "label": "Myth callout",
+      "required_fields": [
+        "id",
+        "component",
+        "myth",
+        "reality",
+        "why_it_matters",
+        "evidence"
+      ],
+      "rendering_notes": "Evidence-backed misconception correction."
+    },
+    {
+      "id": "print_rules",
+      "label": "Print rules",
+      "required_fields": [
+        "id",
+        "component",
+        "page_size",
+        "margins",
+        "break_rules",
+        "hide_selectors",
+        "show_urls",
+        "footer"
+      ],
+      "rendering_notes": "Renderer-only PDF/print control; must not carry claims."
+    }
+  ]
+}

--- a/.agents/reference/domain-index.md
+++ b/.agents/reference/domain-index.md
@@ -12,7 +12,7 @@ Read subagents on-demand when trigger words clearly match. Full index: `subagent
 | Legal | legal, compliance, privacy policy, terms, contract, GDPR | `legal.md`, `tools/legal/legal-research.md` |
 | Code quality | lint, review, smells, standards, simplify, audit | `tools/code-review/code-standards.md` |
 | Git/PRs/Releases | git, PR, branch, merge, release, changelog, version | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `workflows/release.md` |
-| Documents/PDF | PDF, document, report, pandoc, forms, extraction | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
+| Documents/PDF | PDF, document, report, reporting, styled report, report components, evidence badges, pandoc, forms, extraction | `reference/report-component-taxonomy.md`, `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | OCR, receipt scan, invoice scan, image text, PaddleOCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Product (shared) | product, onboarding, monetisation, growth, analytics, UX | `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/growth.md`, `product/ui-design.md`, `product/analytics.md` |
 | Browser/Mobile | browser, Playwright, screenshot, mobile, app, extension, Swift, SwiftUI, Xcode, iOS, macOS | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/browser/browser-use.md`, `tools/browser/chromium-debug-use.md`, `tools/browser/skyvern.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-dev-swift.md`, `tools/mobile/swift-xcode-agent-workflow.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |

--- a/.agents/reference/report-component-taxonomy.md
+++ b/.agents/reference/report-component-taxonomy.md
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Report Component Taxonomy
+
+Canonical contract for report agents, report templates, renderers, and SEO/GEO outputs. Keep this reference on-demand; do not duplicate it in always-loaded guidance.
+
+## Evidence Badge Model
+
+Every recommendation, claim, statistic, and tactic card should carry at least one evidence badge when the report makes an externally supportable claim.
+
+| Badge | Use for | Required evidence fields | Rendering notes |
+|-------|---------|--------------------------|-----------------|
+| `observed` | First-party crawl, audit, screenshot, log, analytics, search console, or manual review observations | `source_id`, `source_title`, `source_type`, `observed_date`, `claim_supported`, `confidence`, `sensitivity` | Show as the strongest badge; pair with the inspected URL, artefact, or dataset label when safe. |
+| `sourced` | Third-party source, vendor documentation, public research, standards, or cited article | `source_id`, `source_title`, `source_type`, `observed_date`, `claim_supported`, `confidence`, `sensitivity` | Link to the source card or citation list; avoid inline raw URLs in print-first layouts. |
+| `benchmark` | Competitive comparison, industry baseline, SERP/LLM mention comparison, or before/after metric | `source_id`, `source_title`, `source_type`, `observed_date`, `claim_supported`, `confidence`, `sensitivity` | Render with comparison context: peer set, time window, and metric unit. |
+| `inferred` | Modelled conclusion from multiple signals where no single source proves the whole claim | `source_id`, `source_title`, `source_type`, `observed_date`, `claim_supported`, `confidence`, `sensitivity` | Visually softer than direct evidence; include the inputs that support the inference. |
+| `estimate` | Forecast, projection, sizing, effort, cost, lift, or priority score | `source_id`, `source_title`, `source_type`, `observed_date`, `claim_supported`, `confidence`, `sensitivity` | Label assumptions clearly; show ranges instead of false precision when possible. |
+
+### Shared evidence fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `source_id` | yes | Stable slug or report-local identifier, for example `gsc-2026-05` or `crawl-homepage`. |
+| `source_title` | yes | Human-readable source label safe for the report audience. |
+| `source_type` | yes | Use the config enum: `first_party`, `third_party`, `benchmark`, `model`, `manual_review`, `generated_artifact`. |
+| `observed_date` | yes | ISO date for when the evidence was observed or generated. |
+| `claim_supported` | yes | One sentence stating exactly what the evidence supports. |
+| `confidence` | yes | `high`, `medium`, or `low`; do not imply certainty from weak sources. |
+| `sensitivity` | yes | `public`, `internal`, `confidential`, or `redacted`; redact or aggregate before export when needed. |
+
+## Component Contract
+
+All components share these fields unless explicitly unnecessary: `id`, `component`, `title`, `body`, `evidence`, and `rendering_notes`. Components that create navigation also require `anchor`.
+
+| Component | Required fields | Rendering notes |
+|-----------|-----------------|-----------------|
+| Cover/meta | `id`, `component`, `title`, `subtitle`, `prepared_for`, `prepared_by`, `prepared_date`, `version`, `confidentiality`, `summary` | First page or report header. Keep sensitive client identifiers controlled by `confidentiality` and `sensitivity`. |
+| Sticky TOC | `id`, `component`, `title`, `items[]` with `label`, `anchor`, `level`, `status` | HTML renderers may pin it; Markdown/PDF renderers should degrade to a normal table of contents. |
+| Chapter hero heading | `id`, `component`, `title`, `anchor`, `kicker`, `summary`, `priority`, `evidence` | Start major sections with a short outcome-focused summary and optional priority badge. |
+| Action line | `id`, `component`, `action`, `owner`, `priority`, `effort`, `impact`, `due`, `evidence` | Use one sentence beginning with a verb. Render as a high-contrast strip or callout. |
+| Evidence badge | `id`, `component`, `badge`, `label`, `evidence` | Badge must map to the evidence badge enum. Prefer compact labels with a details link. |
+| What/Why/How tactic card | `id`, `component`, `title`, `what`, `why`, `how`, `priority`, `impact`, `effort`, `evidence` | Keep each section scannable. Use for recommendations that need rationale and execution steps. |
+| Code/example card | `id`, `component`, `title`, `language`, `code_or_example`, `context`, `copy_safe`, `evidence` | Mark whether content is illustrative or production-ready. Preserve fenced-code readability in Markdown. |
+| Good/bad rows | `id`, `component`, `title`, `rows[]` with `good`, `bad`, `reason`, `evidence` | Use for contrastive guidance. Avoid shaming language; focus on observable differences. |
+| Stats strip | `id`, `component`, `metrics[]` with `label`, `value`, `unit`, `delta`, `period`, `evidence` | Render as compact KPI cards. Always include period and unit. |
+| Facts table | `id`, `component`, `columns[]`, `rows[]`, `evidence` | Use for dense factual data. Keep columns stable across exports. |
+| Details note | `id`, `component`, `title`, `body`, `tone`, `evidence` | Render as aside/details block. Use for caveats, assumptions, or implementation notes. |
+| Industry card | `id`, `component`, `industry`, `title`, `context`, `pattern`, `implication`, `evidence` | Use when advice differs by vertical. Include the applicability boundary. |
+| Priority group | `id`, `component`, `title`, `priority`, `items[]`, `rationale`, `evidence` | Group actions by `critical`, `high`, `medium`, or `low`; sort critical first. |
+| Checklist | `id`, `component`, `title`, `items[]` with `label`, `status`, `owner`, `evidence` | Status values: `todo`, `doing`, `done`, `blocked`, `not_applicable`. |
+| Source card | `id`, `component`, `source_id`, `source_title`, `source_type`, `observed_date`, `summary`, `sensitivity` | Source cards back citations and should be collected in an appendix or source section. |
+| Myth callout | `id`, `component`, `myth`, `reality`, `why_it_matters`, `evidence` | Use sparingly to correct common misconceptions with evidence. |
+| Print rules | `id`, `component`, `page_size`, `margins`, `break_rules`, `hide_selectors`, `show_urls`, `footer` | Renderer-only component. Must not carry claims; use to preserve PDF-ready output. |
+
+## Rendering Rules
+
+- Renderers must preserve component order unless a template explicitly defines a safe reordering strategy.
+- Missing required fields should fail validation before export, not produce partial reports.
+- Evidence badges must link to a source card, footnote, appendix entry, or redacted evidence stub.
+- Sensitive fields must be redacted before public export; use `redacted` sensitivity rather than omitting evidence entirely.
+- Markdown renderers should remain readable without CSS; HTML renderers may add sticky navigation, cards, and badges; PDF renderers must respect print rules.
+
+## Verification
+
+```bash
+python3 -m json.tool .agents/configs/report-component-taxonomy.json.txt >/dev/null
+bunx markdownlint-cli2 ".agents/reference/report-component-taxonomy.md" ".agents/reference/domain-index.md"
+```


### PR DESCRIPTION
## Summary

- Added `.agents/reference/report-component-taxonomy.md` with canonical report components, required fields, rendering notes, and evidence badge guidance.
- Added `.agents/configs/report-component-taxonomy.json.txt` with the evidence badge enum, shared evidence fields, and component required-field contract.
- Updated `.agents/reference/domain-index.md` so report/reporting/styled report/report component/evidence badge triggers route to the report taxonomy docs.

Resolves #23996
For #23995

## Testing

- `python3 -m json.tool .agents/configs/report-component-taxonomy.json.txt >/dev/null`
- `npx --yes markdownlint-cli2 ".agents/reference/report-component-taxonomy.md" ".agents/reference/domain-index.md"`

Note: the requested `bunx markdownlint-cli2 ...` command could not run because `bunx` is unavailable in the worker PATH; `npx --yes markdownlint-cli2 ...` passed as an equivalent markdownlint-cli2 fallback.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 78,765 tokens on this as a headless worker.
