### PR TITLE
GH#23997: Register reports output plane

### DIFF
--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -145,7 +145,7 @@ The repository root is a public contract, not a scratch space. New top-level fil
 - **Framework internals:** implementation and source-of-truth framework assets such as `.agents/`, `configs/`, `templates/`, `tests/`, `setup-modules/`, and temporary root shell modules pending cleanup.
 - **Runtime and plugin surfaces:** runtime integration packages such as `.claude-plugin/`, `.opencode/`, and editor/runtime config files.
 - **Packaging surfaces:** distribution and package-manager assets such as `bin/`, `scripts/`, `homebrew/`, `package.json`, and lock/dependency files.
-- **Repo-local data planes:** underscore-prefixed local working areas such as `_knowledge/`, `_cases/`, `_campaigns/`, `_inbox/`, `_feedback/`, `_projects/`, and `_performance/`.
+- **Repo-local data planes:** underscore-prefixed local working areas such as `_knowledge/`, `_cases/`, `_campaigns/`, `_inbox/`, `_feedback/`, `_projects/`, `_performance/`, and `_reports/`.
 - **Docs and planning:** documentation and task surfaces such as `.wiki/`, `docs/`, `todo/`, `TODO.md`, and model/reference docs.
 - **Generated or ignored tooling surfaces:** intentionally tracked tool config and generated-input files such as `.github/`, `.qlty/`, lint configs, Repomix configs, and scanner config.
 

--- a/.agents/configs/repo-layout-policy.conf
+++ b/.agents/configs/repo-layout-policy.conf
@@ -42,6 +42,7 @@ SECURITY.md	public-entrypoint	Security reporting and support policy.
 TERMS.md	public-entrypoint	Project terms and usage policy.
 TODO.md	docs-planning	Tracked task and routine ledger.
 VERSION	public-entrypoint	Current framework version marker.
+_config	repo-data-plane	Repo-local runtime config templates and ignored local configuration.
 _campaigns	repo-data-plane	Repo-local campaign data plane for AI-assisted operations.
 _cases	repo-data-plane	Repo-local case data plane for AI-assisted operations.
 _feedback	repo-data-plane	Repo-local feedback data plane placeholder.
@@ -49,6 +50,7 @@ _inbox	repo-data-plane	Repo-local inbox data plane for intake workflows.
 _knowledge	repo-data-plane	Repo-local knowledge ingestion data plane.
 _performance	repo-data-plane	Repo-local performance data plane placeholder.
 _projects	repo-data-plane	Repo-local project data plane placeholder.
+_reports	repo-data-plane	Repo-local report output data plane for generated report artifacts.
 aidevops-init-lib.sh	framework-internal	Root shell module for aidevops CLI initialization pending module cleanup.
 aidevops-repos-lib.sh	framework-internal	Root shell module for repo management pending module cleanup.
 aidevops-skills-plugin-lib.sh	framework-internal	Root shell module for skills/plugin logic pending module cleanup.
@@ -74,3 +76,4 @@ sonar-project.properties	tooling-generated	SonarCloud project configuration.
 templates	framework-internal	Framework templates consumed by task and setup helpers.
 tests	framework-internal	Repository-level tests outside `.agents/scripts/tests/`.
 todo	docs-planning	Task briefs, plans, and planning artifacts.
+tsconfig.json	tooling-generated	TypeScript compiler configuration for repository tooling.

--- a/.agents/reports/outputs.md
+++ b/.agents/reports/outputs.md
@@ -1,0 +1,32 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Report Output Contract
+
+`_reports/` is the repo-local data plane for generated report outputs. It keeps
+report drafts, published artifacts, indexes, local configuration, and templates
+out of the repository root while giving automation a stable path contract.
+
+## Directory Contract
+
+| Path | Purpose | Default git policy |
+|------|---------|--------------------|
+| `_reports/drafts/` | Work-in-progress report runs and review copies. | Gitignored |
+| `_reports/published/` | Final report bundles ready for sharing or archival. | Gitignored |
+| `_reports/index/` | Generated search, catalogue, and lookup indexes. | Gitignored |
+| `_reports/_config/` | Repo-local report configuration and private options. | Gitignored |
+| `_reports/templates/` | Reviewed reusable report templates and examples. | Versioned |
+
+## Artifact Contract
+
+- `report.md` is the canonical source for each report.
+- HTML, PDF, screenshots, archives, and other exports are derived artifacts.
+- Regenerate derived artifacts from `report.md` rather than editing them by hand.
+- Keep generated drafts, published bundles, and indexes out of git unless a
+  maintainer explicitly promotes a small fixture or template for review.
+
+## Privacy Rules
+
+Public reports must not expose private local paths, private repository names, or
+machine-specific filesystem details. Use placeholders when a path, repo name, or
+environment detail would identify private infrastructure.

--- a/.gitignore
+++ b/.gitignore
@@ -266,6 +266,10 @@ _knowledge/index/
 _campaigns/intel/
 _campaigns/active/
 _campaigns/index/
+_reports/drafts/
+_reports/published/
+_reports/index/
+_reports/_config/
 _inbox/*
 !_inbox/README.md
 !_inbox/.gitignore


### PR DESCRIPTION
## Summary

- Registered `_reports` as a repo-local report output data plane.
- Documented report output directories, canonical `report.md`, derived artifacts, and privacy rules.
- Added ignore defaults for generated `_reports` drafts, published bundles, indexes, and local config.

Resolves #23997

## Testing

- `.agents/scripts/repo-layout-audit-helper.sh --check`
- `npx --yes markdownlint-cli2 ".agents/aidevops/architecture.md" ".agents/reports/outputs.md"`

## Runtime Testing

Docs/config-only change; self-assessed with repo layout audit and markdownlint.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 52,271 tokens on this as a headless worker.
