### PR TITLE
GH#24001: Add SEO/GEO page-type weighting and report template

### DIFF
--- a/.agents/seo/ai-search-report-template.md
+++ b/.agents/seo/ai-search-report-template.md
@@ -1,0 +1,119 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# AI Search Report Template
+
+Use this report after an AI-search readiness cycle, GEO audit, or SEO audit
+that includes LLM visibility evidence. Keep source IDs attached to every
+material recommendation so findings can be verified or handed to a worker.
+
+## Report Metadata
+
+- Project:
+- Domain or page set:
+- Date range:
+- Auditor:
+- Intent clusters:
+- Engines tested: AIO, Gemini, ChatGPT, AI Mode, Perplexity
+- Evidence ledger location:
+
+## 1. Executive Summary
+
+| Item | Finding | Business impact | Source IDs |
+|------|---------|-----------------|------------|
+| Highest-value opportunity | | | |
+| Highest-risk visibility gap | | | |
+| Fastest hygiene win | | | |
+| Evidence confidence | | | |
+
+Summarise outcomes in business language. Do not claim AI Share of Voice unless
+the per-engine lines in section 3 support the summary.
+
+## 2. Method
+
+- Inputs: priority pages, target intents, competitor/entity set, analytics or
+  conversion proxy, crawl/index checks, third-party profiles, and engine runs.
+- Page-type framework:
+  `seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md`.
+- Scoring framework: `seo/ai-search-scoring.md`.
+- Evidence rule: every material recommendation must cite `source_id` values
+  from section 5.
+- Engine rule: report AIO, Gemini, ChatGPT, AI Mode, and Perplexity separately;
+  only then add an optional aggregate summary.
+
+## 3. Weighted Scorecard
+
+| Page or cluster | Page type | Business value | Page-type applicability | Retrieval eligibility | Evidence strength | Effort | Confidence | Freshness | Third-party breadth | Engine behaviour | Priority |
+|-----------------|-----------|----------------|-------------------------|-----------------------|-------------------|--------|------------|-----------|---------------------|------------------|----------|
+| | | | | | | | | | | | |
+
+### Per-Engine Visibility Lines
+
+| Engine | Query/prompt set | Mentions | Citations | Cited URLs | Missing or wrong facts | Source IDs | Notes |
+|--------|------------------|----------|-----------|------------|------------------------|------------|-------|
+| AIO | | | | | | | |
+| Gemini | | | | | | | |
+| ChatGPT | | | | | | | |
+| AI Mode | | | | | | | |
+| Perplexity | | | | | | | |
+
+## 4. Page-Type Findings
+
+| Page | Page type | Required tactic gaps | Conditional opportunities | Hygiene items | Avoided tactics | Source IDs |
+|------|-----------|----------------------|---------------------------|---------------|-----------------|------------|
+| | PDP/category/homepage/article/local/SaaS feature/pricing/comparison/glossary/use-case/research/report | | | | | |
+
+Use visible FAQ recommendations only where the page type supports them.
+Treat `FAQPage` schema and other structured data as hygiene unless a validation
+error blocks rich-result eligibility or entity clarity.
+
+## 5. Evidence Ledger
+
+| source_id | Type | URL/path | Captured date | Claim supported | Confidence | Freshness risk |
+|-----------|------|----------|---------------|-----------------|------------|----------------|
+| S001 | | | | | | |
+
+Allowed source types: crawl record, page section, analytics snapshot, SERP
+capture, AIO run, Gemini run, ChatGPT run, AI Mode run, Perplexity run,
+third-party profile, review, policy, certificate, research data, log sample.
+
+## 6. Finding-to-Taxonomy Map
+
+| Finding | Taxonomy component | Why it matters | Source IDs |
+|---------|--------------------|----------------|------------|
+| | Grounding eligibility | Can the engine retrieve and trust the page? | |
+| | Fan-out coverage | Does the site answer the sub-queries behind the intent? | |
+| | Criteria alignment (GEO) | Does the page match buyer or evaluator criteria? | |
+| | Snippet survivability (SRO) | Can a concise answer survive extraction? | |
+| | Fact integrity | Are canonical facts consistent and contradiction-free? | |
+| | Autonomous discoverability | Can an agent find and complete the task? | |
+| | Citation monitoring | Do per-engine mentions and citations move after changes? | |
+| | Page-type tactic fit | Are tactics weighted for PDP, category, homepage, article, local, SaaS feature, pricing, comparison, glossary, use-case, or research/report intent? | |
+
+## 7. Roadmap
+
+| Priority | Recommendation | Page(s) | Owner | Effort | Verification | Source IDs |
+|----------|----------------|---------|-------|--------|--------------|------------|
+| P0 | | | | | | |
+| P1 | | | | | | |
+| P2 | | | | | | |
+
+Write recommendations as worker-ready tasks: target files or pages, reference
+pattern, expected change, and verification command or measurement.
+
+## 8. Verification Plan
+
+- Re-run crawl/index checks for changed pages.
+- Re-run per-engine prompt/query sets for AIO, Gemini, ChatGPT, AI Mode, and
+  Perplexity with dates and source IDs.
+- Compare weighted scorecard deltas against baseline.
+- Validate schema only as hygiene; verify visible content and evidence first.
+- Re-check third-party profile parity for facts changed on owned pages.
+
+## 9. Custom-Agent and Routine Handoff
+
+| Handoff | Trigger | Context to include | Verification |
+|---------|---------|--------------------|--------------|
+| Custom agent | Repeated audit pattern requires a reusable specialist workflow. | Prompt, target pages, source IDs, taxonomy component, expected report output. | Dry-run on one page or cluster. |
+| Routine | Monthly or quarterly monitoring is needed. | Engine list, query set, evidence ledger path, scorecard path, cadence. | First scheduled run posts scorecard and evidence ledger. |
+| Worker task | A concrete remediation is ready. | File/page path, before/after pattern, source IDs, acceptance criteria. | Lint, crawl, or per-engine re-test evidence. |

--- a/.agents/seo/ai-search-scoring.md
+++ b/.agents/seo/ai-search-scoring.md
@@ -1,0 +1,127 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# AI Search Scoring
+
+Use this scoring model to prioritise SEO, AEO, and GEO recommendations for
+AI-search visibility. Score per page, per intent cluster, and per engine line;
+do not collapse material findings into a single aggregate AI Share of Voice.
+
+## Weighted Scorecard
+
+| Dimension | Weight | Score 0-5 evidence |
+|-----------|--------|--------------------|
+| Business value | 20% | Revenue, lead quality, retention, or strategic importance of the intent/page. |
+| Page-type applicability | 15% | Fit against `seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md`. |
+| Retrieval eligibility | 15% | Page can be discovered, indexed, crawled, and matched to grounded queries. |
+| Evidence strength | 15% | Claims have source IDs, visible proof, dated facts, and corroboration. |
+| Engine-specific mention/citation behaviour | 10% | Per-engine mention, citation, or exclusion patterns are measured separately. |
+| Third-party breadth | 10% | Review sites, directories, research, partner pages, or authoritative references support the claim. |
+| Freshness | 5% | Facts, reviews, pricing, and methodology are current for the query. |
+| Confidence | 5% | Recommendation is supported by repeatable evidence, not one volatile prompt snapshot. |
+| Effort | 5% | Lower effort receives higher priority when impact and confidence are similar. |
+
+Weighted priority score:
+
+```text
+sum(score_0_to_5 * weight) / 5 = priority percentage
+```
+
+## Scoring Dimensions
+
+### Business value
+
+- Score `5`: revenue-critical page or buying intent with proven conversion
+  value.
+- Score `3`: assists discovery, nurture, or trust but has indirect commercial
+  value.
+- Score `1`: low-value informational page with no clear business outcome.
+
+### Page-type applicability
+
+- Score against the matrix tags: missing `required` tactics reduce priority
+  confidence and raise implementation urgency.
+- Penalise recommendations that apply a tactic marked `avoid` for the page
+  type.
+- Treat schema and `FAQPage` work as `hygiene` unless visible content gaps are
+  already solved.
+
+### Retrieval eligibility
+
+- Confirm indexability, canonical status, internal links, crawler access, and
+  query-language alignment.
+- Separate retrieval problems from answer wording problems; an unindexed page
+  cannot be reliably cited.
+
+### Evidence strength
+
+- Every material recommendation must reference one or more source IDs from an
+  evidence ledger.
+- Strong evidence includes dated primary facts, screenshots, policies,
+  certifications, research methods, review profiles, or third-party pages.
+- Unsupported marketing claims score low even if the copy is well written.
+
+### Effort
+
+- Score `5`: small copy, metadata, parity, or table edits.
+- Score `3`: moderate page restructure or evidence collection.
+- Score `1`: new asset production, engineering dependency, legal review, or
+  third-party profile remediation.
+
+### Confidence
+
+- Score confidence from repeatability: multiple prompts, engines, logs, SERP
+  checks, or source records.
+- Lower confidence when the evidence is a single prompt run or an unstable
+  daily answer snapshot.
+
+### Freshness
+
+- Require dates for pricing, product capabilities, local details, research
+  samples, and comparison claims.
+- Deprioritise stale facts until canonical values are refreshed.
+
+### Third-party breadth
+
+- Measure whether the same facts appear consistently across review platforms,
+  directories, partner pages, profiles, citations, and independent references.
+- Thin third-party coverage weakens GEO recommendations for PDP, SaaS feature,
+  local, comparison, use-case, and research/report pages.
+
+### Engine-specific mention and citation behaviour
+
+Track each engine separately because retrieval, mention, and citation behaviour
+diverge by product surface.
+
+| Engine line | Record |
+|-------------|--------|
+| AIO | Query, date, location/device where relevant, cited URLs, mentioned brands, answer position, source IDs. |
+| Gemini | Prompt, date, grounded/browsing state, citations, uncited mentions, source IDs. |
+| ChatGPT | Prompt, date, browsing/search mode, citations or source links, brand mention context, source IDs. |
+| AI Mode | Query, date, cited URLs, follow-up refinements, brand/entity mentions, source IDs. |
+| Perplexity | Prompt, date, cited URLs, ranked source order, summary framing, source IDs. |
+
+Reporting rule: never report aggregate AI Share of Voice without per-engine
+lines. If a summary is required, show the aggregate only after the engine table
+and state which engines and prompts contributed to it.
+
+## Evidence Ledger Fields
+
+| Field | Use |
+|-------|-----|
+| `source_id` | Stable ID used in recommendations, scorecards, and reports. |
+| Source type | Page section, crawl record, SERP capture, engine run, third-party profile, log, review, policy, research data. |
+| URL or path | Canonical source location when available. |
+| Captured date | Date evidence was observed. |
+| Claim supported | Specific recommendation or score dimension supported. |
+| Confidence | High, medium, or low with reason. |
+| Freshness risk | Expiry date or event that requires re-validation. |
+
+## Priority Bands
+
+| Weighted score | Band | Action |
+|----------------|------|--------|
+| 80-100 | P0 | Implement in the current sprint when evidence is strong and page value is high. |
+| 60-79 | P1 | Plan next; batch with related page-type or evidence fixes. |
+| 40-59 | P2 | Backlog unless needed to unblock P0/P1 work. |
+| 0-39 | Watch | Monitor, collect evidence, or reject if page-type fit is poor. |

--- a/.agents/seo/geo-strategy.md
+++ b/.agents/seo/geo-strategy.md
@@ -20,8 +20,8 @@ tools:
 
 Increase citation likelihood in AI search by matching decision criteria with verifiable page content on pages that already rank. Ranking is prerequisite — unranked pages cannot be consistently cited. Optimize for deterministic retrieval signals, not daily answer volatility.
 
-**Inputs:** core query set, top landing pages, competitor set, proof assets (certifications, policies, prices, case evidence)
-**Outputs:** criteria matrix, page gap map, prioritized implementation plan
+**Inputs:** core query set, top landing pages, page types, competitor set, proof assets (certifications, policies, prices, case evidence)
+**Outputs:** criteria matrix, source-ID evidence ledger, page-type gap map, weighted implementation plan, per-engine report lines
 
 ## Workflow
 
@@ -30,6 +30,7 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 - Select 5-20 intents that influence revenue or lead quality; map each to an existing target page
 - Exclude intents without a realistic ranking path
 - Classify by grounding likelihood to avoid optimizing non-retrieval prompts
+- Classify each target as PDP, category, homepage, article, local, SaaS feature, pricing, comparison, glossary, use-case, or research/report before scoring tactics
 
 ### 2) Extract decision criteria
 
@@ -39,8 +40,9 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 ### 3) Score coverage per page
 
 - Mark each criterion: strong, partial, missing, or not applicable
-- Require evidence references (URL section, data source, policy, certification)
+- Require source IDs for every material recommendation; each source ID must map to a URL section, data source, policy, certification, third-party profile, log, or engine run
 - Flag unsupported marketing claims immediately
+- Score business value, page-type applicability, retrieval eligibility, evidence strength, effort, confidence, freshness, third-party breadth, and engine-specific mention/citation behavior with `ai-search-scoring.md`
 
 ### 4) Build retrieval-ready summaries
 
@@ -51,6 +53,7 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 
 - Re-check retrieval fitness after edits; evaluate coverage before citation counts
 - Monitor citations directionally, not as the only success metric
+- Report AIO, Gemini, ChatGPT, AI Mode, and Perplexity on separate per-engine lines; never aggregate AI Share of Voice without the underlying engine-level evidence
 - Re-run criteria extraction monthly or after major model shifts
 
 ## Anti-Patterns
@@ -59,6 +62,8 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 - Large batches of AI-generated pages with weak evidence
 - Generic "best" claims without supporting proof
 - Treating one model's output snapshot as durable ground truth
+- Recommendations without source IDs or with source IDs that do not support the claimed fix
+- Treating `FAQPage` schema as a primary GEO tactic; visible FAQ content can help where page type and query fan-out justify it, but schema is hygiene
 
 ## Implementation Rules
 
@@ -66,6 +71,7 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 - Use explicit headings for key buyer concerns; align terminology with user query vocabulary
 - Single canonical value for every critical fact across the site
 - Prefer additive edits to existing pages before creating net-new pages
+- Weight tactics with `seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md` before proposing copy, schema, FAQ, comparison, or proof work
 - Keep key pages accessible to major AI/search crawlers
 - One topic per URL; titles, H1s, and headings must include category terms, feature type, year, and pricing where applicable
 - Keep pricing, feature lists, and comparison data in crawlable HTML — not behind JS rendering or gated forms
@@ -80,6 +86,17 @@ AI models query G2, Capterra, and TrustRadius as a validation stage after extrac
 - Respond to reviews — AI models may extract vendor responses as support quality evidence
 - Monitor profiles quarterly; add TrustRadius, PeerSpot, or vertical-specific sites where G2/Capterra coverage is thin
 
+## Report Output
+
+- Use `ai-search-report-template.md` for executive summaries, method,
+  weighted scorecards, page-type findings, evidence ledgers, roadmap,
+  verification, and custom-agent/routine handoff.
+- Use stable `source_id` values in the evidence ledger and repeat those IDs in
+  every roadmap item, scorecard row, and material recommendation.
+- Map each finding to a taxonomy component: grounding eligibility, fan-out
+  coverage, criteria alignment, snippet survivability, fact integrity,
+  autonomous discoverability, citation monitoring, or page-type tactic fit.
+
 ## Related Subagents
 
 - `sro-grounding.md` for snippet selection and grounding optimization
@@ -88,3 +105,5 @@ AI models query G2, Capterra, and TrustRadius as a validation stage after extrac
 - `keyword-research.md` for demand and intent validation
 - `video-seo.md` — video as a GEO content atom; LLM surface retrieval via transcript
 - `transcript-seo.md` — transcript paragraphs as GEO snippet candidates
+- `ai-search-scoring.md` for weighted AI-search prioritisation
+- `ai-search-report-template.md` for report-ready SEO/GEO outputs

--- a/.agents/seo/seo-ai-readiness.md
+++ b/.agents/seo/seo-ai-readiness.md
@@ -17,10 +17,19 @@ Target: $ARGUMENTS
 2. Execute chained phases:
    - Fan-out decomposition
    - GEO criteria alignment
+   - Page-type tactic weighting for PDP, category, homepage, article, local,
+     SaaS feature, pricing, comparison, glossary, use-case, and
+     research/report pages
    - SRO snippet optimization
    - Hallucination defense
    - Agent discoverability validation
-3. Return one prioritized backlog with readiness scorecard deltas
+3. Score material recommendations with `~/.aidevops/agents/seo/ai-search-scoring.md`
+4. Return report-ready output using `~/.aidevops/agents/seo/ai-search-report-template.md`:
+   executive summary, method, weighted scorecard, page-type findings, evidence
+   ledger, roadmap, verification, and custom-agent/routine handoff
+5. Require source IDs for material recommendations and show AIO, Gemini,
+   ChatGPT, AI Mode, and Perplexity as per-engine lines before any aggregate
+   visibility summary
 
 ## Usage
 
@@ -35,6 +44,9 @@ Target: $ARGUMENTS
 ## Related
 
 - `seo/ai-search-readiness.md`
+- `seo/ai-search-scoring.md`
+- `seo/ai-search-report-template.md`
+- `seo/seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md`
 - `commands/seo-fanout.md`
 - `commands/seo-geo.md`
 - `commands/seo-sro.md`

--- a/.agents/seo/seo-audit-skill/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/aeo-geo-patterns.md
@@ -12,12 +12,22 @@ Reference corpus for answer engines, AI Overviews, voice search, and AI citation
 | [`aeo-geo-patterns/01-aeo-patterns.md`](aeo-geo-patterns/01-aeo-patterns.md) | Featured snippets, answer boxes, listicles, FAQs, and voice-search blocks |
 | [`aeo-geo-patterns/02-geo-patterns.md`](aeo-geo-patterns/02-geo-patterns.md) | Citation templates, evidence structures, and product-answer patterns for AI assistants |
 | [`aeo-geo-patterns/03-authority-signals-and-attribution.md`](aeo-geo-patterns/03-authority-signals-and-attribution.md) | Domain trust signals and UTM citation attribution rules |
+| [`aeo-geo-patterns/04-page-type-tactic-matrix.md`](aeo-geo-patterns/04-page-type-tactic-matrix.md) | Page-type weighting for PDP, category, homepage, article, local, SaaS, pricing, comparison, glossary, use-case, and research/report pages |
 
 ## How to Use
 
 - Start with the chapter matching the output format you need.
+- Use the page-type matrix before recommending tactics; it devalues
+  `FAQPage` and other schema work to hygiene unless visible content already
+  satisfies the page intent.
 - Copy templates verbatim, then replace placeholders with topic-specific facts.
 - Keep cited claims, URLs, and freshness details in the chapter files; this index stays slim by design.
+
+## Report-Ready Outputs
+
+- Score material AI-search recommendations with `../ai-search-scoring.md`.
+- Convert audit findings into client or worker handoff format with
+  `../ai-search-report-template.md`.
 
 ## Preservation Notes
 

--- a/.agents/seo/seo-audit-skill/aeo-geo-patterns/03-authority-signals-and-attribution.md
+++ b/.agents/seo/seo-audit-skill/aeo-geo-patterns/03-authority-signals-and-attribution.md
@@ -25,3 +25,30 @@ https://yourdomain.com/product-features/?utm_source=ai&utm_medium=citation&utm_c
 ```
 
 Track citation traffic volume, citation-to-conversion rate, page citation distribution, and UTM coverage.
+
+## Evidence Ledger Source IDs
+
+Material SEO/GEO recommendations must cite source IDs so reports and workers can
+trace each claim back to evidence.
+
+| Source type | Example source ID | Required detail |
+|-------------|-------------------|-----------------|
+| Owned page section | `OWN-001` | URL/path, heading or selector, captured date, claim supported |
+| Third-party profile | `TP-001` | Platform, profile URL, visible fact, captured date |
+| Engine result | `ENG-001` | Engine, prompt/query, date, citations or mentions, observed gap |
+| Research or report | `RES-001` | Method, sample, date range, limitation, reusable statistic |
+| Policy or certification | `POL-001` | Issuer, scope, expiry or review date, claim supported |
+
+Do not promote a finding to the roadmap unless the cited source IDs support the
+recommendation. If evidence is weak, mark confidence low and add evidence
+collection before content changes.
+
+## Engine-Specific Attribution
+
+- Track AIO, Gemini, ChatGPT, AI Mode, and Perplexity separately because they
+  may mention a brand without citing it, cite a third party instead of the owned
+  page, or omit the entity for different reasons.
+- Do not aggregate AI Share of Voice without showing per-engine mention and
+  citation lines first.
+- Attach source IDs to each engine observation so citation movement can be
+  re-tested after page or profile updates.

--- a/.agents/seo/seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md
+++ b/.agents/seo/seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Page-Type Tactic Matrix
+
+Use this matrix to weight AEO/GEO recommendations by page intent before writing
+copy or audit notes. Page types covered: PDP, category, homepage, article,
+local, SaaS feature, pricing, comparison, glossary, use-case, and
+research/report pages.
+
+## Legend
+
+| Tag | Meaning |
+|-----|---------|
+| `required` | Missing tactic materially reduces retrieval, selection, or conversion usefulness for this page type. |
+| `conditional` | Use when the page intent, query fan-out, or available evidence supports it. |
+| `hygiene` | Keep valid and consistent, but do not treat as a primary GEO lever. |
+| `avoid` | Usually harms focus, adds unsupported claims, or creates irrelevant SERP/LLM signals. |
+
+## Tactic Weighting by Page Type
+
+| Tactic | PDP | category | homepage | article | local | SaaS feature | pricing | comparison | glossary | use-case | research/report |
+|--------|-----|----------|----------|---------|-------|--------------|---------|------------|----------|----------|-----------------|
+| Criteria-matching summary in first 200-300 words | required | required | conditional | conditional | required | required | required | required | conditional | required | conditional |
+| Evidence sandwich with source IDs | required | conditional | conditional | required | required | required | required | required | hygiene | required | required |
+| Visible FAQ block with search-language questions | conditional | conditional | hygiene | conditional | conditional | conditional | required | conditional | conditional | conditional | conditional |
+| `FAQPage` schema | hygiene | hygiene | avoid | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene |
+| Page-specific structured data validation | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene | hygiene |
+| Pricing, packaging, availability, or eligibility facts | required | conditional | conditional | avoid | conditional | conditional | required | required | avoid | conditional | avoid |
+| Third-party corroboration breadth | required | conditional | conditional | required | required | required | conditional | required | avoid | required | required |
+| Comparison table against alternatives or criteria | conditional | conditional | avoid | conditional | conditional | conditional | conditional | required | avoid | required | conditional |
+| Freshness marker and dated review cadence | required | required | conditional | required | required | required | required | required | conditional | required | required |
+| Canonical fact parity across owned and third-party pages | required | required | required | conditional | required | required | required | required | hygiene | required | conditional |
+
+## Page-Type Notes
+
+- **PDP**: optimise for product/category retrieval, feature extraction,
+  availability, price, differentiators, and proof. Treat Product schema as
+  hygiene; the visible facts and evidence decide citation usefulness.
+- **category**: summarise category coverage, buyer criteria, product variants,
+  inventory logic, and internal links to PDPs. Avoid generic buying-guide copy
+  without evidence.
+- **homepage**: reinforce entity clarity, category terms, proof, and navigation.
+  Avoid forcing FAQ blocks unless they answer real branded or navigational
+  questions.
+- **article**: lead with the direct answer, cite source IDs for material claims,
+  and use visible FAQ only when People Also Ask or fan-out branches justify it.
+- **local**: prioritise NAP parity, service-area detail, opening hours,
+  licensing, reviews, and locally verifiable proof. LocalBusiness schema remains
+  hygiene, not a substitute for visible evidence.
+- **SaaS feature**: expose use cases, integrations, limits, screenshots or demo
+  proof, and third-party profile parity for the same feature naming.
+- **pricing**: make plan names, units, exclusions, renewal terms, and latest
+  update dates crawlable. Visible FAQ can clarify packaging; `FAQPage` schema is
+  still hygiene.
+- **comparison**: require neutral criteria, dated facts, strengths, trade-offs,
+  and competitor source IDs. Avoid unsupported superiority claims.
+- **glossary**: keep definitions concise, link to deeper pages, and avoid
+  pricing or comparison sections that dilute informational intent.
+- **use-case**: show audience, trigger scenario, workflow, results, proof, and
+  links to feature/PDP pages.
+- **research/report**: require methodology, sample, date, limitations, data
+  source IDs, and citation-ready charts or findings.
+
+## FAQ and Schema Devaluation Rules
+
+- Treat visible FAQs as content, not markup. They are useful when the page type
+  supports question-led objections, packaging clarification, local service
+  details, or fan-out branches.
+- Treat `FAQPage` and other schema as validation hygiene. Schema can clarify
+  entities for crawlers, but it should not outrank missing visible evidence,
+  weak criteria coverage, stale facts, or low business value.
+- Do not add FAQ sections solely to justify `FAQPage` schema. Mark the tactic
+  `avoid` when questions are not natural for the page intent.
+- When schema conflicts with visible copy, fix the visible canonical fact first,
+  then update markup to match.


### PR DESCRIPTION
## Summary

Added a page-type tactic matrix, AI-search scoring model, report template, and linked GEO/readiness guidance requiring source IDs and per-engine visibility reporting.

## Files Changed

.agents/seo/ai-search-report-template.md,.agents/seo/ai-search-scoring.md,.agents/seo/geo-strategy.md,.agents/seo/seo-ai-readiness.md,.agents/seo/seo-audit-skill/aeo-geo-patterns.md,.agents/seo/seo-audit-skill/aeo-geo-patterns/03-authority-signals-and-attribution.md,.agents/seo/seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep acceptance check for required page types/schema/per-engine terms; bunx markdownlint-cli2 on required new docs; bunx markdownlint-cli2 on all changed SEO docs.

Resolves #24001


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6m and 89,506 tokens on this as a headless worker.