### PR TITLE
GH#24000: add editorial evidence report template

### DIFF
--- a/.agents/templates/reports/README.md
+++ b/.agents/templates/reports/README.md
@@ -1,0 +1,62 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Report Templates
+
+Premium report templates for evidence-led outputs. `llm-visibility-report.css` implements the Editorial Evidence Report profile from `.agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md`.
+
+## Minimal semantic structure
+
+```html
+<body class="report-body">
+  <div class="report-shell">
+    <main id="report" class="report-main">
+      <header class="report-cover" aria-labelledby="report-title">
+        <p class="report-kicker">LLM Visibility Report</p>
+        <h1 id="report-title" class="report-title">Evidence-led visibility audit</h1>
+        <p class="report-subtitle">Prepared summary of findings, risks, and recommended actions.</p>
+        <dl class="report-meta-grid" aria-label="Report metadata">
+          <div class="meta-item"><dt class="meta-label">Prepared for</dt><dd class="meta-value">Client name</dd></div>
+          <div class="meta-item"><dt class="meta-label">Prepared by</dt><dd class="meta-value">Team name</dd></div>
+          <div class="meta-item"><dt class="meta-label">Date</dt><dd class="meta-value">2026-05-23</dd></div>
+          <div class="meta-item"><dt class="meta-label">Version</dt><dd class="meta-value">v1</dd></div>
+        </dl>
+      </header>
+
+      <section id="findings" class="chapter-hero" aria-labelledby="findings-title">
+        <p class="eyebrow">Chapter 1</p>
+        <h2 id="findings-title" class="chapter-title">Findings that change priorities</h2>
+        <p class="chapter-summary">Short outcome-focused summary with evidence badges.</p>
+        <div class="badge-row" aria-label="Evidence strength">
+          <span class="badge badge--strong">Strong</span>
+          <span class="badge badge--hygiene">Hygiene</span>
+        </div>
+      </section>
+
+      <article class="tactic-card" aria-labelledby="tactic-title">
+        <h3 id="tactic-title">Add source-backed answer blocks</h3>
+        <div class="tactic-grid">
+          <section><h4>What</h4><p>Describe the recommended change.</p></section>
+          <section><h4>Why</h4><p>Connect the change to the observed evidence.</p></section>
+          <section><h4>How</h4><p>List implementation steps and owners.</p></section>
+        </div>
+      </article>
+    </main>
+
+    <nav class="sticky-toc" aria-label="Report contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#findings" aria-current="true">Findings</a></li>
+      </ol>
+    </nav>
+  </div>
+</body>
+```
+
+## Accessibility notes
+
+- Use semantic landmarks: one `main`, a labelled `nav`, section headings in order, and tables only for tabular facts.
+- Do not rely on colour alone; badges and status dots need readable text labels or adjacent status copy.
+- Keep sticky navigation optional. The CSS disables sticky behaviour on small screens and print.
+- Ensure all source cards and evidence badges have meaningful labels, observed dates, sensitivity states, and citation targets.
+- Preserve visible focus states and readable link text; print CSS exposes link URLs for non-navigation links.

--- a/.agents/templates/reports/llm-visibility-report.css
+++ b/.agents/templates/reports/llm-visibility-report.css
@@ -1,0 +1,669 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: 2025-2026 Marcus Quinn */
+
+:root {
+  color-scheme: light;
+  --report-font-heading: "Newsreader", Georgia, "Times New Roman", "Noto Serif", serif;
+  --report-font-body: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  --report-font-code: "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --report-paper: #f8f6f1;
+  --report-paper-raised: #fffdf8;
+  --report-surface: #ffffff;
+  --report-ink: #111827;
+  --report-ink-muted: #4b5563;
+  --report-ink-soft: #6b7280;
+  --report-rule: #d8d2c4;
+  --report-rule-strong: #b8ae9c;
+  --report-blue: #2563eb;
+  --report-amber: #b7791f;
+  --report-green: #147a4a;
+  --report-red: #b42318;
+  --report-violet: #6d28d9;
+  --report-good-bg: #eaf7ef;
+  --report-bad-bg: #fdecec;
+  --report-code-bg: #111827;
+  --report-code-ink: #e5e7eb;
+  --report-code-accent: #93c5fd;
+  --report-radius-sm: 0.25rem;
+  --report-radius-md: 0.5rem;
+  --report-radius-lg: 0.875rem;
+  --report-radius-xl: 1.375rem;
+  --report-space-1: 0.25rem;
+  --report-space-2: 0.5rem;
+  --report-space-3: 1rem;
+  --report-space-4: 1.5rem;
+  --report-space-5: 2rem;
+  --report-space-6: 3rem;
+  --report-space-7: 4rem;
+  --report-page-max: 78rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--report-paper);
+  color: var(--report-ink);
+  font-family: var(--report-font-body);
+  line-height: 1.65;
+}
+
+body.report-body {
+  margin: 0;
+  background: var(--report-paper);
+  color: var(--report-ink);
+  font-family: var(--report-font-body);
+  font-size: 1rem;
+}
+
+.report-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 20rem);
+  gap: var(--report-space-5);
+  max-width: var(--report-page-max);
+  margin: 0 auto;
+  padding: var(--report-space-6) var(--report-space-5);
+}
+
+.report-main {
+  min-width: 0;
+}
+
+.report-cover,
+.chapter-hero,
+.tactic-card,
+.example-card,
+.good-bad,
+.stats-strip,
+.facts-table-wrap,
+.details-note,
+.industry-card,
+.priority-group,
+.checklist-card,
+.source-card,
+.myth-callout {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+.report-cover {
+  margin-block-end: var(--report-space-7);
+  padding: clamp(2rem, 7vw, 4rem);
+  background: var(--report-paper-raised);
+  border: 1px solid var(--report-rule);
+  border-radius: var(--report-radius-xl);
+}
+
+.report-kicker,
+.eyebrow,
+.meta-label,
+.badge,
+.priority-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.report-kicker,
+.eyebrow {
+  color: var(--report-blue);
+  margin: 0 0 var(--report-space-2);
+}
+
+.report-title,
+.chapter-title {
+  margin: 0;
+  color: var(--report-ink);
+  font-family: var(--report-font-heading);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.report-title {
+  max-width: 12ch;
+  font-size: clamp(3rem, 8vw, 4rem);
+  line-height: 1.05;
+}
+
+.report-subtitle,
+.chapter-summary {
+  max-width: 62ch;
+  color: var(--report-ink-muted);
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+}
+
+.report-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--report-space-3);
+  margin-block-start: var(--report-space-5);
+  padding-block-start: var(--report-space-4);
+  border-block-start: 1px solid var(--report-rule);
+}
+
+.meta-item {
+  min-width: 0;
+}
+
+.meta-label {
+  display: block;
+  color: var(--report-ink-soft);
+}
+
+.meta-value {
+  display: block;
+  color: var(--report-ink);
+  font-weight: 650;
+}
+
+.sticky-toc {
+  position: sticky;
+  top: var(--report-space-4);
+  align-self: start;
+  max-height: calc(100vh - var(--report-space-5));
+  overflow: auto;
+  padding: var(--report-space-3);
+  background: rgba(255, 253, 248, 0.94);
+  border: 1px solid var(--report-rule);
+  border-radius: var(--report-radius-lg);
+  box-shadow: 0 12px 32px rgba(17, 24, 39, 0.1);
+}
+
+.sticky-toc h2 {
+  margin: 0 0 var(--report-space-2);
+  color: var(--report-ink);
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sticky-toc ol {
+  display: grid;
+  gap: var(--report-space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.sticky-toc a {
+  display: block;
+  padding: var(--report-space-1) var(--report-space-2);
+  border-left: 3px solid transparent;
+  color: var(--report-ink-muted);
+  text-decoration: none;
+}
+
+.sticky-toc a[aria-current="true"],
+.sticky-toc a:hover,
+.sticky-toc a:focus-visible {
+  border-left-color: var(--report-blue);
+  color: var(--report-ink);
+  outline: none;
+}
+
+.chapter-hero {
+  margin-block: var(--report-space-6) var(--report-space-4);
+  padding: var(--report-space-5);
+  background: var(--report-paper-raised);
+  border: 1px solid var(--report-rule);
+  border-radius: var(--report-radius-xl);
+}
+
+.chapter-title {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  line-height: 1.12;
+}
+
+.action-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--report-space-2) var(--report-space-3);
+  align-items: baseline;
+  margin-block: var(--report-space-4);
+  padding: var(--report-space-3) var(--report-space-4);
+  background: var(--report-ink);
+  color: #ffffff;
+  border-radius: var(--report-radius-md);
+}
+
+.action-line strong {
+  font-weight: 750;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--report-space-2);
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  gap: var(--report-space-1);
+  align-items: center;
+  width: fit-content;
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.badge--rct {
+  background: var(--report-good-bg);
+  color: var(--report-green);
+  border-color: rgba(20, 122, 74, 0.2);
+}
+
+.badge--strong {
+  background: #eaf2ff;
+  color: #1d4ed8;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
+.badge--vendor {
+  background: #f4ecff;
+  color: var(--report-violet);
+  border-color: rgba(109, 40, 217, 0.2);
+}
+
+.badge--practitioner {
+  background: #fff5db;
+  color: #92400e;
+  border-color: rgba(183, 121, 31, 0.24);
+}
+
+.badge--hygiene {
+  background: #f3f4f6;
+  color: #374151;
+  border-color: rgba(55, 65, 81, 0.18);
+}
+
+.tactic-card,
+.industry-card,
+.priority-group,
+.checklist-card,
+.source-card,
+.details-note,
+.myth-callout {
+  margin-block: var(--report-space-4);
+  padding: var(--report-space-4);
+  background: var(--report-surface);
+  border: 1px solid var(--report-rule);
+  border-radius: var(--report-radius-lg);
+  box-shadow: 0 1px 2px rgba(17, 24, 39, 0.06);
+}
+
+.tactic-card h3,
+.industry-card h3,
+.priority-group h3,
+.checklist-card h3,
+.source-card h3,
+.details-note h3,
+.myth-callout h3 {
+  margin-block: 0 var(--report-space-2);
+  color: var(--report-ink);
+  font-size: 1.25rem;
+  line-height: 1.3;
+}
+
+.tactic-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--report-space-3);
+  margin-block-start: var(--report-space-3);
+}
+
+.tactic-grid > section {
+  padding-inline-start: var(--report-space-3);
+  border-left: 1px solid var(--report-rule);
+}
+
+.example-card {
+  margin-block: var(--report-space-4);
+  overflow: hidden;
+  background: var(--report-code-bg);
+  color: var(--report-code-ink);
+  border-radius: var(--report-radius-md);
+}
+
+.example-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--report-space-3);
+  padding: var(--report-space-2) var(--report-space-3);
+  background: rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--report-code-accent);
+  font-family: var(--report-font-code);
+  font-size: 0.8125rem;
+}
+
+.example-card pre {
+  margin: 0;
+  padding: var(--report-space-3);
+  overflow-x: auto;
+  font-family: var(--report-font-code);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+}
+
+.good-bad {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--report-space-3);
+  margin-block: var(--report-space-4);
+}
+
+.good-row,
+.bad-row {
+  padding: var(--report-space-3);
+  border-radius: var(--report-radius-md);
+  border: 1px solid transparent;
+}
+
+.good-row {
+  background: var(--report-good-bg);
+  border-color: rgba(20, 122, 74, 0.2);
+}
+
+.bad-row {
+  background: var(--report-bad-bg);
+  border-color: rgba(180, 35, 24, 0.2);
+}
+
+.good-row h4,
+.bad-row h4 {
+  margin: 0 0 var(--report-space-1);
+}
+
+.good-row h4 {
+  color: var(--report-green);
+}
+
+.bad-row h4 {
+  color: var(--report-red);
+}
+
+.stats-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--report-space-3);
+  margin-block: var(--report-space-4);
+}
+
+.stat-card {
+  padding: var(--report-space-3);
+  background: var(--report-paper-raised);
+  border: 1px solid var(--report-rule);
+  border-radius: var(--report-radius-lg);
+}
+
+.stat-value {
+  display: block;
+  color: var(--report-ink);
+  font-family: var(--report-font-heading);
+  font-size: 2.25rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.stat-label,
+.stat-period,
+.source-meta {
+  color: var(--report-ink-soft);
+  font-size: 0.875rem;
+}
+
+.facts-table-wrap {
+  margin-block: var(--report-space-4);
+  overflow-x: auto;
+  border: 1px solid var(--report-rule);
+  border-radius: var(--report-radius-md);
+  background: var(--report-surface);
+}
+
+.facts-table {
+  width: 100%;
+  min-width: 42rem;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.facts-table th,
+.facts-table td {
+  padding: 0.75rem 0.875rem;
+  border-bottom: 1px solid var(--report-rule);
+  text-align: left;
+  vertical-align: top;
+}
+
+.facts-table th {
+  background: var(--report-paper-raised);
+  color: var(--report-ink);
+  font-weight: 700;
+}
+
+.details-note {
+  background: #fbf7ec;
+  border-left: 4px solid var(--report-amber);
+}
+
+.myth-callout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--report-space-3);
+  background: #f7f2ff;
+  border-color: rgba(109, 40, 217, 0.22);
+}
+
+.priority-group[data-priority="critical"] {
+  border-top: 4px solid var(--report-red);
+}
+
+.priority-group[data-priority="high"] {
+  border-top: 4px solid var(--report-amber);
+}
+
+.priority-group[data-priority="medium"] {
+  border-top: 4px solid var(--report-blue);
+}
+
+.priority-group[data-priority="low"] {
+  border-top: 4px solid var(--report-green);
+}
+
+.checklist {
+  display: grid;
+  gap: var(--report-space-2);
+  padding: 0;
+  list-style: none;
+}
+
+.checklist li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--report-space-2);
+  align-items: baseline;
+  padding-block: var(--report-space-2);
+  border-bottom: 1px solid var(--report-rule);
+}
+
+.status-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 9999px;
+  background: var(--report-ink-soft);
+}
+
+.status-dot[data-status="done"] {
+  background: var(--report-green);
+}
+
+.status-dot[data-status="blocked"] {
+  background: var(--report-red);
+}
+
+.source-card {
+  background: var(--report-paper-raised);
+}
+
+a {
+  color: var(--report-blue);
+  text-underline-offset: 0.18em;
+}
+
+:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 3px;
+}
+
+@media (max-width: 980px) {
+  .report-shell {
+    grid-template-columns: 1fr;
+    padding: var(--report-space-4) var(--report-space-3);
+  }
+
+  .sticky-toc {
+    position: static;
+    max-height: none;
+    order: -1;
+  }
+
+  .report-meta-grid,
+  .tactic-grid,
+  .stats-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .report-cover,
+  .chapter-hero,
+  .tactic-card,
+  .industry-card,
+  .priority-group,
+  .checklist-card,
+  .source-card,
+  .details-note,
+  .myth-callout {
+    padding: var(--report-space-3);
+    border-radius: var(--report-radius-md);
+  }
+
+  .report-meta-grid,
+  .tactic-grid,
+  .stats-strip,
+  .good-bad,
+  .myth-callout {
+    grid-template-columns: 1fr;
+  }
+
+  .action-line {
+    display: grid;
+  }
+}
+
+@media print {
+  :root {
+    color-scheme: light;
+    --report-paper: #ffffff;
+    --report-paper-raised: #ffffff;
+    --report-surface: #ffffff;
+    --report-ink: #111111;
+    --report-ink-muted: #333333;
+    --report-ink-soft: #555555;
+    --report-rule: #bdb7ab;
+    --report-rule-strong: #8f8778;
+  }
+
+  @page {
+    size: A4;
+    margin: 16mm 14mm 18mm;
+  }
+
+  html,
+  body.report-body {
+    background: #ffffff !important;
+    color: var(--report-ink) !important;
+    font-size: 10.5pt;
+  }
+
+  .report-shell {
+    display: block;
+    max-width: none;
+    padding: 0;
+  }
+
+  .sticky-toc {
+    position: static;
+    max-height: none;
+    overflow: visible;
+    box-shadow: none;
+    break-after: page;
+  }
+
+  .report-cover {
+    min-height: 82vh;
+    border: 0;
+    border-radius: 0;
+    break-after: page;
+  }
+
+  .chapter-hero {
+    break-before: page;
+  }
+
+  .report-cover,
+  .chapter-hero,
+  .tactic-card,
+  .example-card,
+  .good-bad,
+  .stats-strip,
+  .facts-table-wrap,
+  .details-note,
+  .industry-card,
+  .priority-group,
+  .checklist-card,
+  .source-card,
+  .myth-callout {
+    box-shadow: none !important;
+  }
+
+  .facts-table-wrap {
+    overflow: visible;
+  }
+
+  .facts-table {
+    min-width: 0;
+    font-size: 8.5pt;
+  }
+
+  .example-card {
+    background: #ffffff;
+    color: var(--report-ink);
+    border: 1px solid var(--report-rule-strong);
+  }
+
+  .example-card header,
+  .example-card pre {
+    background: #ffffff;
+    color: var(--report-ink);
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    color: var(--report-ink-soft);
+    font-size: 0.85em;
+    overflow-wrap: anywhere;
+  }
+
+  .badge a[href]::after,
+  .sticky-toc a[href]::after {
+    content: "";
+  }
+}

--- a/.agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md
+++ b/.agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md
@@ -1,0 +1,334 @@
+---
+version: alpha
+name: Editorial Evidence Report
+description: Premium print-safe report profile for evidence-led LLM visibility, SEO/GEO, audit, and advisory reports with editorial typography and reusable report primitives
+colors:
+  primary: "#111827"
+  secondary: "#4B5563"
+  tertiary: "#2563EB"
+  neutral: "#F8F6F1"
+  surface: "#FFFFFF"
+  on-surface: "#1F2937"
+  error: "#B42318"
+  paper: "#F8F6F1"
+  paper-raised: "#FFFDF8"
+  ink: "#111827"
+  ink-muted: "#4B5563"
+  ink-soft: "#6B7280"
+  rule: "#D8D2C4"
+  rule-strong: "#B8AE9C"
+  accent-blue: "#2563EB"
+  accent-amber: "#B7791F"
+  accent-green: "#147A4A"
+  accent-red: "#B42318"
+  accent-violet: "#6D28D9"
+  good: "#147A4A"
+  good-surface: "#EAF7EF"
+  bad: "#B42318"
+  bad-surface: "#FDECEC"
+  code-surface: "#111827"
+  code-text: "#E5E7EB"
+  code-accent: "#93C5FD"
+typography:
+  headline-display:
+    fontFamily: "'Newsreader', Georgia, 'Times New Roman', 'Noto Serif', serif"
+    fontSize: 64px
+    fontWeight: 600
+    lineHeight: 1.05
+    letterSpacing: -0.035em
+  headline-lg:
+    fontFamily: "'Newsreader', Georgia, 'Times New Roman', 'Noto Serif', serif"
+    fontSize: 44px
+    fontWeight: 600
+    lineHeight: 1.12
+    letterSpacing: -0.025em
+  headline-md:
+    fontFamily: "'Newsreader', Georgia, 'Times New Roman', 'Noto Serif', serif"
+    fontSize: 30px
+    fontWeight: 600
+    lineHeight: 1.18
+    letterSpacing: -0.015em
+  body-lg:
+    fontFamily: "'IBM Plex Sans', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif"
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.7
+  body-md:
+    fontFamily: "'IBM Plex Sans', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.65
+  body-sm:
+    fontFamily: "'IBM Plex Sans', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.55
+  label-md:
+    fontFamily: "'IBM Plex Sans', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif"
+    fontSize: 12px
+    fontWeight: 700
+    lineHeight: 1.35
+    letterSpacing: 0.08em
+  code-md:
+    fontFamily: "'IBM Plex Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.55
+rounded:
+  none: 0px
+  sm: 4px
+  md: 8px
+  lg: 14px
+  xl: 22px
+  full: 9999px
+spacing:
+  unit: 8px
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 32px
+  xl: 64px
+  gutter: 28px
+  margin: 56px
+components:
+  cover-meta:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    typography: "{typography.headline-display}"
+    border: "1px solid {colors.rule}"
+    padding: 64px
+  sticky-toc:
+    backgroundColor: "rgba(255, 253, 248, 0.94)"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.lg}"
+    border: "1px solid {colors.rule}"
+    padding: 16px
+  chapter-hero:
+    backgroundColor: "{colors.paper-raised}"
+    textColor: "{colors.ink}"
+    typography: "{typography.headline-lg}"
+    border: "1px solid {colors.rule}"
+    padding: 32px
+  action-line:
+    backgroundColor: "#111827"
+    textColor: "#FFFFFF"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 16px 20px
+  evidence-badge:
+    backgroundColor: "#EAF2FF"
+    textColor: "#1D4ED8"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.full}"
+    padding: 4px 10px
+  tactic-card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.lg}"
+    border: "1px solid {colors.rule}"
+    padding: 24px
+  code-example:
+    backgroundColor: "{colors.code-surface}"
+    textColor: "{colors.code-text}"
+    typography: "{typography.code-md}"
+    rounded: "{rounded.md}"
+    padding: 18px
+  facts-table:
+    backgroundColor: "{colors.paper-raised}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    border: "1px solid {colors.rule}"
+    padding: 0
+---
+
+<!--
+DESIGN.md — AI-readable design system document
+Format: google-labs-code/design.md v0.1.0 (format version: alpha)
+Spec: https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
+Validate: npx @google/design.md lint DESIGN.md
+-->
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Design System: Editorial Evidence Report
+
+## 1. Overview
+
+Editorial Evidence Report is a premium report profile for evidence-led advisory work: LLM visibility reports, technical SEO/GEO audits, market research briefs, and implementation roadmaps. It combines a print-first editorial voice with dense, structured evidence components.
+
+The style should feel like a serious analyst report: warm paper, crisp ink, visible rules, restrained accents, readable long-form typography, and scannable evidence primitives. The default mode is light because reports are commonly exported to PDF, printed, reviewed in board packs, and shared as attachments. Dark mode may be added later as a token override, not as the canonical baseline.
+
+**Key characteristics:**
+- **Mood:** editorial, analytical, premium, calm, evidence-first
+- **Background:** near-white warm paper `#F8F6F1` with raised white report surfaces
+- **Typography:** Newsreader headlines, IBM Plex Sans body, IBM Plex Mono code/data
+- **Rules:** visible but soft separators using warm grey ink and paper tones
+- **Density:** high information density with deliberate spacing and strong section hierarchy
+- **Print posture:** page-break-aware cards, visible URLs/citations, sticky UI disabled for print
+
+## 2. Colors
+
+### Core palette
+
+| Role | Value | Usage |
+|------|-------|-------|
+| Paper | `#F8F6F1` | Body background, print canvas |
+| Paper raised | `#FFFDF8` | Cover, cards, chapter panels |
+| Surface | `#FFFFFF` | Tables, cards, inset notes |
+| Ink | `#111827` | Primary text and report titles |
+| Ink muted | `#4B5563` | Summaries, metadata, secondary copy |
+| Ink soft | `#6B7280` | Captions, table notes, disabled states |
+| Rule | `#D8D2C4` | Borders, dividers, table rules |
+| Rule strong | `#B8AE9C` | Active navigation, cover rules, print separators |
+
+### Multi-accent palette
+
+| Accent | Value | Usage |
+|--------|-------|-------|
+| Blue | `#2563EB` | Links, primary evidence, information |
+| Amber | `#B7791F` | Warnings, estimates, effort |
+| Green | `#147A4A` | Good states, wins, validated actions |
+| Red | `#B42318` | Bad states, risks, errors |
+| Violet | `#6D28D9` | Model/LLM-specific notes, strategy |
+
+### Semantic and code palette
+
+| Role | Value | Usage |
+|------|-------|-------|
+| Good | `#147A4A` on `#EAF7EF` | Good rows, positive deltas, pass states |
+| Bad | `#B42318` on `#FDECEC` | Bad rows, risk deltas, fail states |
+| Code surface | `#111827` | Code/example cards |
+| Code text | `#E5E7EB` | Code body text |
+| Code accent | `#93C5FD` | Highlighted tokens, inline labels |
+
+### Evidence badge colours
+
+| Badge | Surface | Text | Use |
+|-------|---------|------|-----|
+| RCT | `#EAF7EF` | `#147A4A` | Randomised/controlled or highest-confidence research evidence |
+| Strong | `#EAF2FF` | `#1D4ED8` | Direct observed or strong third-party evidence |
+| Vendor | `#F4ECFF` | `#6D28D9` | Platform documentation, vendor claims, API docs |
+| Practitioner | `#FFF5DB` | `#92400E` | Experienced implementation guidance and field observations |
+| Hygiene | `#F3F4F6` | `#374151` | Standard best-practice, baseline checks, compliance hygiene |
+
+### Future dark-mode token notes
+
+Reports may expose a light/dark toggle later. Keep component names stable and override only token values: paper becomes near-black, paper-raised becomes charcoal, ink becomes warm white, rules become translucent white, and semantic badge surfaces become low-saturation dark tints. Print export must continue to force the light token set.
+
+## 3. Typography
+
+**Font families:**
+- **Headings:** `"Newsreader", Georgia, "Times New Roman", "Noto Serif", serif`
+- **Body/UI:** `"IBM Plex Sans", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif`
+- **Code/data:** `"IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace`
+
+| Role | Font | Size | Weight | Line-height | Usage |
+|------|------|------|--------|-------------|-------|
+| Display | Newsreader | 64px | 600 | 1.05 | Cover titles and opening statements |
+| H1 | Newsreader | 44px | 600 | 1.12 | Chapter hero headings |
+| H2 | Newsreader | 30px | 600 | 1.18 | Major report sections |
+| H3 | IBM Plex Sans | 20px | 700 | 1.3 | Component titles |
+| Body large | IBM Plex Sans | 18px | 400 | 1.7 | Executive summaries |
+| Body | IBM Plex Sans | 16px | 400 | 1.65 | Main copy |
+| Small | IBM Plex Sans | 14px | 400 | 1.55 | Captions and sidebars |
+| Label | IBM Plex Sans | 12px | 700 | 1.35 | Badges and metadata, uppercase |
+| Code | IBM Plex Mono | 13px | 400 | 1.55 | Code/example cards and data snippets |
+
+## 4. Layout
+
+### Spacing scale
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--space-1` | 4px | Badge internals, tight icon gaps |
+| `--space-2` | 8px | Inline clusters, table cell micro-gaps |
+| `--space-3` | 16px | Card internal rhythm |
+| `--space-4` | 24px | Standard component padding |
+| `--space-5` | 32px | Section groups, chapter panels |
+| `--space-6` | 48px | Report page gutters |
+| `--space-7` | 64px | Cover and chapter vertical spacing |
+| `--space-8` | 96px | Major report breaks |
+
+### Grid and page structure
+
+- Use a 12-column report grid with 28px gutters on desktop.
+- Main article content spans 8 columns; sticky TOC/metadata spans 3 columns.
+- Components may become full-width for facts tables, source lists, and stats strips.
+- Mobile collapses to one column; sticky TOC becomes a normal section.
+- Print uses a single flow with page-break rules and no sticky positioning.
+
+## 5. Elevation & Depth
+
+| Level | Name | Shadow | Usage |
+|-------|------|--------|-------|
+| 0 | Flat | `none` | Most print-safe report elements |
+| 1 | Paper lift | `0 1px 2px rgba(17, 24, 39, 0.06)` | Cards and tables on screen |
+| 2 | Navigation lift | `0 12px 32px rgba(17, 24, 39, 0.10)` | Sticky TOC only, screen mode |
+
+Depth must never be the only separator; retain borders/rules for print fidelity.
+
+## 6. Shapes
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| None | `0px` | Tables, print rules |
+| Small | `4px` | Inline code, small labels |
+| Medium | `8px` | Badges, notes, action lines |
+| Large | `14px` | Tactic cards, source cards |
+| Extra large | `22px` | Cover and chapter panels |
+| Full | `9999px` | Evidence and priority pills |
+
+## 7. Components
+
+Style every canonical report taxonomy component:
+
+- **Cover/meta:** warm paper panel with large Newsreader title, meta grid, confidentiality label, and report summary.
+- **Sticky TOC:** right or left rail on desktop with active rule, compact labels, and accessible anchor links; normal block in print/mobile.
+- **Chapter hero:** raised editorial panel with kicker, title, summary, priority, and evidence badges.
+- **Action line:** high-contrast strip beginning with a verb; includes owner, impact, effort, and due metadata.
+- **Evidence badges:** compact uppercase pills for RCT, Strong, Vendor, Practitioner, and Hygiene evidence levels.
+- **Tactic card:** What/Why/How grid with priority, impact, effort, and evidence.
+- **Example/code card:** dark code surface with IBM Plex Mono and copy-safe status.
+- **Good/bad rows:** two-column contrast rows using semantic green/red surfaces and neutral reasoning text.
+- **Stats strip:** KPI cards with value, unit, delta, period, and source note.
+- **Facts table:** dense ruled table with sticky-compatible headers on screen and repeated headers in print when the renderer supports them.
+- **Details note:** bordered aside for caveats, assumptions, implementation notes, and sensitivity warnings.
+- **Industry card:** vertical-specific context, pattern, implication, and applicability boundary.
+- **Priority group:** grouped action list sorted critical, high, medium, low.
+- **Checklist:** status-aware task list with owner and evidence reference.
+- **Source card:** citation/source appendix card with source id, title, type, observed date, summary, and sensitivity.
+- **Myth callout:** myth vs reality correction with restrained accent and supporting evidence.
+- **Print CSS:** remove sticky behaviour, avoid breaking cards/tables badly, expose URLs/citations, and force light tokens.
+
+## 8. Do's and Don'ts
+
+**Do:**
+- Lead every recommendation with the evidence strength and intended action.
+- Preserve readable Markdown semantics before adding CSS embellishment.
+- Use rules, typography, and spacing instead of heavy gradients or decorative effects.
+- Keep charts, tables, and source cards printable in grayscale.
+- Make badges descriptive in text, not colour-only.
+
+**Don't:**
+- Rely on sticky navigation or hover states for critical report meaning.
+- Use dark mode for print output.
+- Put raw private paths, secret values, or sensitive source identifiers in public report examples.
+- Overuse accent colours; reserve them for evidence type, status, and priority.
+
+## 9. Responsive Behaviour
+
+- `>=1200px`: report grid with sticky TOC and 8-column content well.
+- `768-1199px`: two-column grid when space allows; TOC remains visible but not overly tall.
+- `<768px`: single column, TOC unpinned, cards stack, tables scroll horizontally on screen.
+- `print`: single flow, fixed margins, sticky disabled, links and citations exposed.
+
+## 10. Agent Prompt Guide
+
+When applying this style, generate semantic report HTML first: landmarks, headings, lists, tables, and labelled sections. Then apply the CSS classes from `.agents/templates/reports/llm-visibility-report.css`. Include evidence badges and source cards for externally supportable claims. Prefer concise analyst copy with source-aware wording over marketing language.
+
+<!--
+Style archetype by AI DevOps (https://aidevops.sh)
+DESIGN.md spec: https://github.com/google-labs-code/design.md
+-->

--- a/.agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md
+++ b/.agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md
@@ -139,7 +139,7 @@ components:
     textColor: "{colors.ink}"
     typography: "{typography.body-sm}"
     border: "1px solid {colors.rule}"
-    padding: 0
+    padding: 0px
 ---
 
 <!--


### PR DESCRIPTION
## Summary

Added the Editorial Evidence Report DESIGN.md profile, the print-safe LLM visibility report CSS template, and report template README with semantic HTML/accessibility guidance.

## Files Changed

.agents/templates/reports/README.md,.agents/templates/reports/llm-visibility-report.css,.agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx @google/design.md lint .agents/tools/design/library/styles/editorial-evidence-report/DESIGN.md (0 errors, warnings only for extended tokens); grep -E '@media print|position: sticky|Newsreader|IBM Plex Sans|IBM Plex Mono' .agents/templates/reports/llm-visibility-report.css

Resolves #24000


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 75,678 tokens on this as a headless worker.