### PR TITLE
GH#23998: feat: add reports agent family

### DIFF
--- a/.agents/reports.md
+++ b/.agents/reports.md
@@ -1,0 +1,47 @@
+---
+name: reports
+description: Report planning, evidence contracts, exporters, and routine handoffs
+mode: subagent
+subagents:
+  - general
+  - seo-geo
+  - development
+  - marketing
+  - business
+  - citations
+  - exporters
+  - routine-handoff
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Reports Agent
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Turn evidence into decision-ready reports with reusable contracts.
+- **Use first**: `reports/general.md` for report shape and routing.
+- **Domain routes**: `reports/seo-geo.md`, `reports/development.md`,
+  `reports/marketing.md`, and `reports/business.md`.
+- **Shared contracts**: `reports/citations.md`, `reports/exporters.md`,
+  `reports/routine-handoff.md`, and `reports/outputs.md`.
+
+<!-- AI-CONTEXT-END -->
+
+## Routing
+
+1. Identify the report goal, audience, decision, cadence, and evidence sources.
+2. Load the matching family doc instead of duplicating domain expertise here.
+3. Apply the shared citation, exporter, and `_reports/` output contracts.
+4. Return Markdown as the canonical report source; derive exports only after the
+   Markdown is reviewed.
+
+## Related
+
+- `tools/document/document-creation.md` -- document creation and conversion.
+- `tools/conversion/pandoc.md` -- Markdown, HTML, DOCX, and PDF conversion.
+- `tools/pdf/overview.md` -- PDF processing tool selection.
+- `tools/design/report-presentation.md` -- styled report presentation guidance.

--- a/.agents/reports/business.md
+++ b/.agents/reports/business.md
@@ -1,0 +1,50 @@
+---
+description: Business, finance, operations, and company runner report routing
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Business Reports
+
+Use this doc for operations reports, finance reviews, subscription audits,
+receipt or invoice summaries, company-runner status, and cross-function business
+reviews. Route business analysis to business agents; this doc keeps reports
+decision-ready, auditable, and safe to share.
+
+## Domain Routing
+
+- Use `business.md` for company orchestration and runner patterns.
+- Use `business/accounts-receipt-ocr.md` for receipt evidence and OCR review.
+- Use `business/accounts-subscription-audit.md` for recurring cost reviews.
+- Use `business/company-runners.md` for runner status and operational handoffs.
+- Use `marketing-sales.md`, `legal.md`, or finance-specific runners when the
+  report spans departments.
+
+## Report Sections
+
+1. Scope: business function, period, entities, systems, and confidentiality.
+2. Executive summary: decision, financial or operational impact, next action.
+3. Method: source systems, exports, OCR steps, reconciliation rules, caveats.
+4. Findings: costs, anomalies, risks, blockers, opportunities, and owners.
+5. Control checks: approvals, evidence completeness, privacy, and audit trail.
+6. Recommendations: stop/start/continue, owner, due date, verification.
+7. Handoff: runner task, recurring routine, approval queue, or client report.
+
+## Evidence Rules
+
+- Never expose secrets, account numbers, private paths, or private repo names.
+- Cite source IDs for each material cost, operational state, or approval claim.
+- Mark OCR-derived values as observed, verified, inferred, or unsupported.
+- Separate financial facts from recommendations and assumptions.
+- Preserve an audit trail: source, capture date, command or export, and reviewer.
+
+## Export Notes
+
+- Keep sensitive drafts in `_reports/drafts/` and publish only sanitized bundles.
+- Use `reports/citations.md` for source IDs and optional `citations.json`.
+- Use `reports/exporters.md` for Markdown-first client or board outputs.
+- Use `tools/design/report-presentation.md` for risk notes, priority groups,
+  financial tables, and print-safe appendices.

--- a/.agents/reports/citations.md
+++ b/.agents/reports/citations.md
@@ -1,0 +1,83 @@
+---
+description: Inline citation and citations.json contract for reports
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Report Citation Contract
+
+Reports are only as useful as their evidence trail. Use stable source IDs in the
+Markdown report and optionally mirror the ledger in `citations.json` for tools,
+exporters, or client portals.
+
+## Inline Citation Rules
+
+- Assign each source a stable ID: `S001`, `S002`, `S003`.
+- Cite material claims inline with source IDs, for example: `[S001]`.
+- Put citations at the sentence or bullet where the claim appears.
+- Use multiple IDs when a claim depends on multiple sources: `[S001, S004]`.
+- Use evidence labels when helpful: `[S002 observed]`, `[S003 verified]`.
+- If a claim is useful but not proven, label it `unsupported` and move it to a
+  risk, assumption, or backlog section.
+- Do not cite private local paths, private repository names, or secrets in public
+  reports; use placeholders and keep raw source mapping private.
+
+## Evidence Ledger Fields
+
+Include a Markdown table in the report appendix when the report has material
+recommendations:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `source_id` | Yes | Stable ID used inline, such as `S001`. |
+| `type` | Yes | Tool output, URL, screenshot, export, file, metric, log, interview. |
+| `title` | Yes | Human-readable source title. |
+| `locator` | Yes | URL, file path placeholder, command, PR, issue, or dashboard name. |
+| `captured_at` | Yes | ISO date or date-time. |
+| `claim_supported` | Yes | What the source proves. |
+| `confidence` | Yes | `observed`, `verified`, `inferred`, `unsupported`, or `benchmark`. |
+| `freshness_risk` | No | Low, medium, high, or a review date. |
+| `notes` | No | Caveats, filters, sample size, or access constraints. |
+
+## Optional citations.json
+
+Create `citations.json` beside `report.md` when an exporter, portal, or routine
+needs machine-readable sources:
+
+```json
+{
+  "version": 1,
+  "report": "report.md",
+  "sources": [
+    {
+      "source_id": "S001",
+      "type": "tool_output",
+      "title": "Crawl summary",
+      "locator": "_reports/drafts/example/crawl-summary.json",
+      "captured_at": "2026-05-23",
+      "claim_supported": "The crawl found 12 missing meta descriptions.",
+      "confidence": "observed",
+      "freshness_risk": "medium",
+      "notes": "Sanitized path for public bundle."
+    }
+  ]
+}
+```
+
+## Validation Checklist
+
+- Every `source_id` used inline appears in the evidence ledger.
+- Every material recommendation cites at least one `observed` or `verified`
+  source, or explicitly names the assumption being tested.
+- Public reports contain no secrets, private basenames, private repo names, or
+  machine-specific local paths.
+- Derived HTML/PDF exports preserve citation labels and source visibility.
+
+## Related
+
+- `tools/design/report-presentation.md` -- evidence badges and source cards.
+- `reports/exporters.md` -- export bundles must preserve citations.
+- `reports/outputs.md` -- `_reports/` output directory contract.

--- a/.agents/reports/development.md
+++ b/.agents/reports/development.md
@@ -1,0 +1,54 @@
+---
+description: Development, delivery, code quality, and incident report routing
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Development Reports
+
+Use this doc for engineering status, release readiness, quality audits, incident
+reviews, CI reports, performance reviews, and delivery retrospectives. Route code
+analysis and remediation to development workflows; this doc keeps reports
+evidence-backed and handoff-ready.
+
+## Domain Routing
+
+- Use `/full-loop` or `workflows/feature-development.md` for implementation
+  follow-up, not for report-only analysis.
+- Use `workflows/pr.md`, `workflows/pr-loop.md`, and
+  `reference/review-bot-gate.md` for PR review and merge-readiness reporting.
+- Use `workflows/preflight.md`, `workflows/postflight.md`, and
+  `reference/ci-gate-policy.md` for quality gate reporting.
+- Use `tools/browser/pagespeed.md`, `workflows/ui-verification.md`, and
+  `tools/git/conflict-resolution.md` when those evidence types apply.
+- Use `reference/worker-diagnostics.md` for worker failure, stall, loop, or CI
+  diagnosis reports.
+
+## Report Sections
+
+1. Scope: repo, branch, issue/PR, release, service, or incident window.
+2. Summary: current state, risk, decision needed, and recommended next action.
+3. Evidence: commits, diffs, checks, logs, screenshots, metrics, or traces.
+4. Findings: defects, regressions, operational risks, and confirmed non-issues.
+5. Remediation plan: worker-ready tasks with target files and verification.
+6. Verification: commands run, terminal check status, and remaining gaps.
+7. Appendix: raw command outputs, CI links from tool output, and source IDs.
+
+## Evidence Rules
+
+- Distinguish terminal failed checks from pending or expected CI.
+- Avoid unverifiable performance claims; include metric, tool, date, and scope.
+- Cite file paths and line numbers for code findings.
+- Cite PR, issue, commit, check, or command output for delivery claims.
+- Convert broad recommendations into follow-up tasks only when worker-ready.
+
+## Export Notes
+
+- Keep Markdown canonical for review and diffability.
+- Use `reports/exporters.md` for HTML/PDF handoff only after the report passes
+  citation and privacy checks.
+- Use `tools/design/report-presentation.md` for risk tables, timelines,
+  evidence badges, screenshots, and print-safe incident appendices.

--- a/.agents/reports/exporters.md
+++ b/.agents/reports/exporters.md
@@ -1,0 +1,73 @@
+---
+description: Markdown-first report export contract for HTML, PDF, and bundles
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Report Exporter Contract
+
+Use Markdown as the canonical report source. HTML, PDF, DOCX, screenshots, and
+archives are derived artifacts that can be regenerated from `report.md` and its
+assets. Do not automatically install dependencies during report export.
+
+## Source and Output Layout
+
+Use the `_reports/` layout from `reports/outputs.md`:
+
+```text
+_reports/drafts/<report-slug>/report.md
+_reports/drafts/<report-slug>/citations.json
+_reports/drafts/<report-slug>/assets/
+_reports/published/<report-slug>/report.md
+_reports/published/<report-slug>/report.html
+_reports/published/<report-slug>/report.pdf
+```
+
+## Export Rules
+
+- Edit `report.md`, not derived HTML or PDF files.
+- Keep `citations.json` optional, but preserve inline citations in every export.
+- Keep generated drafts, indexes, and published bundles out of git unless a
+  maintainer explicitly promotes a small fixture or template.
+- Check dependency availability before export; report missing tools and the
+  manual install command, but do not run installs automatically.
+- Prefer deterministic commands in `run:` routines for collection and export.
+- Run privacy checks before publishing or attaching a bundle.
+
+## Tool Routing
+
+| Need | Route |
+|------|-------|
+| Create or convert documents | `tools/document/document-creation.md` |
+| Markdown to HTML, DOCX, EPUB, or PDF via Pandoc | `tools/conversion/pandoc.md` |
+| PDF manipulation, extraction, signatures, or form work | `tools/pdf/overview.md` |
+| Complex PDF to Markdown or JSON | `tools/conversion/mineru.md` |
+| OCR or scanned PDF handling | `tools/ocr/overview.md` |
+| Report visual system, print CSS, and components | `tools/design/report-presentation.md` |
+
+## Suggested Export Flow
+
+1. Produce `report.md` with inline citations and an evidence ledger.
+2. Validate citations and privacy with `reports/citations.md`.
+3. Check tool availability with the selected helper or `pandoc --version`.
+4. Generate HTML and PDF into `_reports/drafts/<report-slug>/`.
+5. Review screen, print, citations, links, tables, and accessibility.
+6. Copy reviewed artifacts to `_reports/published/<report-slug>/`.
+
+## Presentation Requirements
+
+- Use `tools/design/report-presentation.md` for component naming, report tokens,
+  print CSS, evidence badges, source cards, and accessibility checks.
+- HTML must remain readable without JavaScript.
+- PDF must preserve source labels, table captions, link targets, and grayscale
+  meaning for status badges.
+- Charts need text summaries or data-table fallbacks.
+
+## Related
+
+- `reports/citations.md` -- citation and source ledger contract.
+- `reports/routine-handoff.md` -- deterministic `run:` collection/export.
+- `reports/outputs.md` -- `_reports/` artifact contract.

--- a/.agents/reports/general.md
+++ b/.agents/reports/general.md
@@ -1,0 +1,66 @@
+---
+description: General report orchestration and shared report anatomy
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# General Reports
+
+Use this doc for report briefs, report outlines, cross-domain reports, and
+quality checks before export. Keep domain analysis in the domain agents; this
+agent owns report structure, evidence traceability, and handoff contracts.
+
+## Intake
+
+Collect only what changes the report outcome:
+
+- Audience, decision, deadline, cadence, and confidentiality level.
+- Report type: one-off, baseline, recurring scorecard, audit, board pack,
+  campaign review, incident review, or client handoff.
+- Evidence sources, capture dates, tool outputs, and known gaps.
+- Required exports: Markdown only, HTML, PDF, DOCX, slides, or archive bundle.
+- Follow-up path: worker tasks, custom client agent, scheduled routine, or none.
+
+## Report Anatomy
+
+Use this default shape unless the domain doc provides a better template:
+
+1. Cover metadata: client/project, scope, date range, author, version.
+2. Executive summary: decision, status, top findings, recommended next action.
+3. Method: data sources, collection commands, assumptions, and limitations.
+4. Findings: evidence-backed observations with source IDs and confidence.
+5. Recommendations: owner, priority, expected outcome, verification path.
+6. Evidence ledger: source IDs, dates, URLs or paths, and supported claims.
+7. Appendix: raw tables, screenshots, exports, unresolved questions.
+8. Handoff: worker-ready tasks, routine schedule, or custom-agent prompt.
+
+## Routing Matrix
+
+| Report focus | Load next | Keep here |
+|--------------|-----------|-----------|
+| SEO, GEO, AI-search visibility | `reports/seo-geo.md` | Structure, citations, export |
+| Engineering, code quality, delivery | `reports/development.md` | Structure, citations, export |
+| Campaigns, content, CRO, sales | `reports/marketing.md` | Structure, citations, export |
+| Finance, operations, company runners | `reports/business.md` | Structure, citations, export |
+| Export format or PDF styling | `reports/exporters.md` | Canonical Markdown contract |
+| Recurring collection or custom client agent | `reports/routine-handoff.md` | Handoff completeness |
+
+## Quality Gate
+
+- Every material claim has an inline citation or an explicit `unsupported` note.
+- Recommendations are decision-ready: owner, priority, rationale, verification.
+- Markdown remains canonical; derived exports are not hand-edited.
+- Public output replaces private paths, private repo names, and local machine
+  details with placeholders.
+- Follow-up tasks include file/page paths when known, reference patterns, and
+  verification commands.
+
+## Related
+
+- `reports/citations.md` -- inline citations and optional `citations.json`.
+- `reports/exporters.md` -- Markdown to HTML/PDF/export bundle contract.
+- `reports/routine-handoff.md` -- recurring routines and custom client agents.
+- `reports/outputs.md` -- `_reports/` directory and artifact contract.

--- a/.agents/reports/marketing.md
+++ b/.agents/reports/marketing.md
@@ -1,0 +1,53 @@
+---
+description: Marketing, content, CRO, paid ads, and sales report routing
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Marketing Reports
+
+Use this doc for campaign reviews, content performance reports, funnel reviews,
+CRO reports, paid media reports, newsletter performance, and sales pipeline
+summaries. Route marketing analysis to the marketing, content, SEO, and analytics
+agents; this doc owns report structure and handoff.
+
+## Domain Routing
+
+- Use `marketing-sales.md` for campaign, paid ads, CRO, email, CRM, and sales
+  pipeline analysis.
+- Use `content.md` for content production, distribution, and multi-channel
+  performance interpretation.
+- Use `seo.md` and `reports/seo-geo.md` when organic search, GEO, or AI-search
+  visibility is material.
+- Use `services/analytics/google-analytics.md` when GA4 evidence is required.
+- Use `marketing-sales/meta-ads.md`, `marketing-sales/cro.md`, and
+  `marketing-sales/direct-response-copy.md` for specialist campaign reviews.
+
+## Report Sections
+
+1. Scope: campaign, channel, audience, offer, date range, spend, and goals.
+2. Executive summary: performance, constraint, opportunity, and decision.
+3. Funnel view: impressions, clicks, leads, sales, retention, and attribution.
+4. Creative/content findings: message, hook, offer, channel fit, and evidence.
+5. Experiment log: variants, sample size, winner, confidence, and next test.
+6. Recommendations: budget, creative, landing page, email, sales, or SEO tasks.
+7. Handoff: campaign routine, client report agent, or worker-ready backlog.
+
+## Evidence Rules
+
+- Separate platform-reported metrics from CRM, analytics, and revenue metrics.
+- State attribution limits; do not overclaim causality from correlation.
+- Cite dashboards, exports, screenshots, source tables, or tool outputs.
+- Record currency, time zone, date range, and data freshness.
+- Make recommendations measurable with owner, target metric, and re-test date.
+
+## Export Notes
+
+- Use `reports/citations.md` for dashboard snapshots and source tables.
+- Use `reports/exporters.md` for client-facing Markdown, HTML, PDF, or archive
+  bundles.
+- Use `tools/design/report-presentation.md` for charts, KPI strips, source
+  cards, recommendations, and print-safe campaign appendices.

--- a/.agents/reports/routine-handoff.md
+++ b/.agents/reports/routine-handoff.md
@@ -1,0 +1,99 @@
+---
+description: Recurring report routines and custom client report agent handoff
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Report Routine Handoff
+
+Use this doc when a finished report should become a repeatable routine, custom
+client report agent, or both. Split deterministic collection/export from
+interpretation: `run:` performs repeatable commands, while `agent:Reports`
+interprets evidence and writes the report.
+
+## Handoff Decision
+
+| Need | Use |
+|------|-----|
+| Same command gathers metrics or exports files | `run:` routine step |
+| Same report needs narrative interpretation | `agent:Reports` routine step |
+| Client has stable domain-specific rules | Custom report agent |
+| Findings become implementation work | Worker-ready issue or `/full-loop` task |
+
+## Routine Pattern
+
+Use `run:` for deterministic collection and export. Use `agent:Reports` only
+after inputs exist.
+
+```yaml
+name: monthly-client-report
+schedule: monthly(first-monday@09:00)
+steps:
+  - run: custom/scripts/collect-client-metrics.sh --month previous
+  - run: custom/scripts/export-client-report-assets.sh --month previous
+  - agent: Reports
+    prompt: >
+      Create the monthly client report from _reports/drafts/client/latest/.
+      Use reports/general.md, reports/citations.md, reports/exporters.md, and
+      the client report agent rules. Return report.md plus handoff notes.
+```
+
+## Custom Client Report Agent Prompt Template
+
+Use this template after a successful report when the format, evidence sources,
+and interpretation rules should be reused.
+
+```markdown
+Create a custom client report agent and routine from the finished report.
+
+Finished report:
+- Canonical Markdown: `<path-to-report.md>`
+- Evidence ledger: `<path-to-citations-or-ledger>`
+- Export bundle: `<path-to-reviewed-export-bundle>`
+
+Client context:
+- Client/project: `<safe public name or placeholder>`
+- Audience: `<decision makers>`
+- Cadence: `<weekly/monthly/quarterly/ad hoc>`
+- Confidentiality: `<public/internal/private>`
+- Required exports: `<Markdown/HTML/PDF/DOCX/archive>`
+
+Reuse rules:
+- Preserve sections: `<list sections>`
+- Preserve KPIs or scorecards: `<list metrics>`
+- Preserve citation style: `reports/citations.md`
+- Preserve exporter rules: `reports/exporters.md`
+- Domain docs to route through: `<seo.md/marketing-sales.md/business.md/...>`
+- Do not duplicate domain expertise in the custom agent.
+
+Routine design:
+- `run:` steps for deterministic collection/export: `<commands or scripts>`
+- `agent:Reports` prompt for interpretation: `<prompt>`
+- Verification: `<commands, lint, export preview, citation/privacy checks>`
+- Output location: `_reports/drafts/<client>/<period>/report.md`
+
+Deliverables:
+1. Custom agent draft under the appropriate `custom/` or project path.
+2. Routine YAML or setup command using `run:` before `agent:Reports`.
+3. First dry-run checklist with expected inputs, outputs, and blockers.
+```
+
+## Handoff Checklist
+
+- The finished report has source IDs, evidence ledger, and export notes.
+- Collection commands are deterministic and safe to run unattended.
+- Secrets and client-specific credentials are referenced by secret name only.
+- The routine writes to `_reports/drafts/` before any published bundle.
+- The interpretation prompt names domain docs and shared report contracts.
+- Verification includes Markdown lint, citation check, export preview, and privacy
+  review appropriate to the report.
+
+## Related
+
+- `workflows/routine.md` -- operational routine setup.
+- `reports/general.md` -- report anatomy and quality gate.
+- `reports/citations.md` -- evidence ledger contract.
+- `reports/exporters.md` -- export and dependency rules.

--- a/.agents/reports/seo-geo.md
+++ b/.agents/reports/seo-geo.md
@@ -1,0 +1,53 @@
+---
+description: SEO, GEO, SRO, and AI-search report routing
+agent: Reports
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# SEO and GEO Reports
+
+Use this doc for SEO audits, GEO strategy reports, AI-search scorecards,
+citation monitoring, ranking opportunity reports, and search visibility reviews.
+Route analysis to the SEO family; this report doc only standardises structure,
+evidence, export, and handoff.
+
+## Domain Routing
+
+- Start with `seo.md` for SEO tool and subagent selection.
+- Use `seo/seo-geo.md` for GEO strategy command flow.
+- Use `seo/geo-strategy.md` for criteria coverage and retrieval-first analysis.
+- Use `seo/ai-search-readiness.md` for end-to-end AI-search readiness.
+- Use `seo/ai-search-report-template.md` for GEO and AI-search report sections.
+- Use `seo/ai-search-kpi-template.md` for recurring scorecards.
+- Use `seo/data-export.md`, `seo/google-search-console.md`,
+  `seo/dataforseo.md`, or `seo/serper.md` for data collection details.
+
+## Report Sections
+
+1. Scope: domain, page set, intent clusters, competitor set, date range.
+2. Method: tools, query/prompt sets, crawl inputs, engines tested, limitations.
+3. Weighted scorecard: page type, retrieval eligibility, evidence strength,
+   effort, confidence, freshness, third-party breadth, and priority.
+4. Per-engine lines: AIO, Gemini, ChatGPT, AI Mode, Perplexity, and SERP data.
+5. Findings: criteria gaps, fan-out gaps, citation behaviour, fact integrity,
+   schema hygiene, and autonomous discoverability.
+6. Roadmap: P0/P1/P2 recommendations with verification and source IDs.
+7. Handoff: worker tasks, baseline re-test plan, custom agent, or routine.
+
+## Evidence Rules
+
+- Separate observed search output from inferred opportunity.
+- Cite every visibility, ranking, citation, or traffic claim with source IDs.
+- Keep per-engine evidence separate before summarising across engines.
+- Treat schema validation as hygiene unless it blocks eligibility or clarity.
+- Record capture dates because AI-search and SERP output changes quickly.
+
+## Export Notes
+
+- Use `reports/citations.md` for inline source IDs and evidence ledger format.
+- Use `reports/exporters.md` for Markdown, HTML, and PDF export bundles.
+- Use `tools/design/report-presentation.md` for scorecards, source cards,
+  evidence badges, tables, and print-safe report presentation.

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,8 @@ tmp.*.json
 # Analysis reports and results
 *.sarif
 reports/
+!.agents/reports/
+!.agents/reports/*.md
 .scannerwork/
 .playwright-cli/
 


### PR DESCRIPTION
## Summary

Added the Reports root agent, domain family routing docs, citation/exporter/routine handoff contracts, and a .gitignore exception so .agents/reports docs stay tracked.

## Files Changed

.agents/reports.md,.agents/reports/business.md,.agents/reports/citations.md,.agents/reports/development.md,.agents/reports/exporters.md,.agents/reports/general.md,.agents/reports/marketing.md,.agents/reports/routine-handoff.md,.agents/reports/seo-geo.md,.gitignore

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bunx markdownlint-cli2 '.agents/reports.md' '.agents/reports/*.md'; ~/.aidevops/agents/scripts/subagent-index-helper.sh generate

Resolves #23998


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 9m and 108,138 tokens on this as a headless worker.