### PR TITLE
GH#24003: add report renderer workflow

### DIFF
--- a/.agents/scripts/commands/report-render.md
+++ b/.agents/scripts/commands/report-render.md
@@ -1,0 +1,34 @@
+---
+description: Render report-ready Markdown or JSON to HTML for browser PDF export
+agent: Document
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Render a report-ready Markdown or JSON file:
+
+Input: $ARGUMENTS
+
+## Process
+
+1. Confirm the input is a Markdown or JSON report file.
+2. Run `~/.aidevops/agents/scripts/report-render-helper.sh validate <input.md|input.json>`.
+3. Render HTML with `~/.aidevops/agents/scripts/report-render-helper.sh render <input.md|input.json> --output report.html`.
+4. Open the HTML in a browser, review the sticky table of contents, source cards, and evidence badges.
+5. Use the browser print dialog to export or print the PDF-ready output.
+
+## Usage
+
+```bash
+/report-render report.md
+/report-render report.json
+```
+
+## Notes
+
+- Markdown remains canonical; HTML is generated output.
+- Evidence badges are limited to `verified`, `partial`, `inferred`, and `missing`.
+- JSON reports use `evidence_badge` fields for the same badge values.
+- `print-css` exposes the embedded print stylesheet for custom handoff workflows.

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -19,6 +19,8 @@
 #   - Secretlint for exposed secrets
 #   - Pattern validation (return statements, positional parameters)
 #   - Markdown formatting
+#   - Report renderer fixtures and command docs are covered by
+#     tests/test-report-render-helper.sh
 #   - Skill frontmatter validation (name field matches skill-sources.json)
 #   - Ratchet quality checks (anti-pattern regression prevention)
 #   - Function complexity, nesting depth, file size

--- a/.agents/scripts/report-render-helper.py
+++ b/.agents/scripts/report-render-helper.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Render report-ready Markdown/JSON to portable HTML."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import sys
+from typing import Any
+
+MODE = sys.argv[1]
+INPUT = sys.argv[2] if len(sys.argv) > 2 else ""
+BADGE_VERIFIED = "verified"
+BADGE_PARTIAL = "partial"
+BADGE_INFERRED = "inferred"
+BADGE_MISSING = "missing"
+BADGE_KEY = "evidence_badge"
+TITLE_KEY = "title"
+DETAIL_KEY = "detail"
+SUMMARY_KEY = "summary"
+ALLOWED_BADGES = (BADGE_VERIFIED, BADGE_PARTIAL, BADGE_INFERRED, BADGE_MISSING)
+BADGE_LABELS = {
+    BADGE_VERIFIED: "Evidence: Verified",
+    BADGE_PARTIAL: "Evidence: Partial",
+    BADGE_INFERRED: "Evidence: Inferred",
+    BADGE_MISSING: "Evidence: Missing",
+}
+
+CSS = """
+:root { color-scheme: light; --ink: #1f2937; --muted: #6b7280; --line: #d1d5db; --panel: #f9fafb; }
+body { margin: 0; font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); }
+.report-shell { display: grid; grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr); gap: 2rem; max-width: 1180px; margin: 0 auto; padding: 2rem; }
+.sticky-toc { position: sticky; top: 1rem; align-self: start; max-height: calc(100vh - 2rem); overflow: auto; border: 1px solid var(--line); border-radius: 12px; padding: 1rem; background: var(--panel); }
+.sticky-toc a { display: block; color: inherit; text-decoration: none; margin: .35rem 0; }
+.report-content { min-width: 0; }
+.badge { display: inline-block; border-radius: 999px; padding: .15rem .55rem; font-size: .78rem; font-weight: 700; border: 1px solid var(--line); }
+.badge-verified { background: #dcfce7; color: #166534; }
+.badge-partial { background: #fef9c3; color: #854d0e; }
+.badge-inferred { background: #dbeafe; color: #1e40af; }
+.badge-missing { background: #fee2e2; color: #991b1b; }
+.source-card { border: 1px solid var(--line); border-left: 4px solid #111827; border-radius: 10px; padding: .85rem 1rem; margin: .75rem 0; background: #fff; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid var(--line); padding: .5rem; text-align: left; }
+@media print { .report-shell { display: block; padding: 0; } .sticky-toc { position: static; page-break-after: always; } a { color: inherit; } }
+""".strip()
+
+
+def read_input(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def slug(text: str) -> str:
+    value = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return value or "section"
+
+
+def badge_html(value: Any) -> str:
+    key = str(value).strip().lower()
+    if key not in ALLOWED_BADGES:
+        raise ValueError(f"unknown evidence badge value: {value}")
+    return f'<span class="badge badge-{key}">{BADGE_LABELS[key]}</span>'
+
+
+def validate_json_badges(node: Any) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in (BADGE_KEY, "evidenceBadge"):
+                badge_html(value)
+            validate_json_badges(value)
+    elif isinstance(node, list):
+        for item in node:
+            validate_json_badges(item)
+
+
+def validate_markdown_badges(text: str) -> None:
+    for match in re.finditer(r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}", text, re.I):
+        badge_html(match.group(1))
+
+
+def inline_markup(text: str) -> str:
+    escaped = html.escape(text)
+    escaped = re.sub(
+        r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}",
+        lambda match: badge_html(html.unescape(match.group(1))),
+        escaped,
+        flags=re.I,
+    )
+    escaped = re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
+    return re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
+
+
+def close_blocks(body: list[str], states: dict[str, bool]) -> None:
+    if states["list"]:
+        body.append("</ul>")
+        states["list"] = False
+    if states["table"]:
+        body.append("</tbody></table>")
+        states["table"] = False
+
+
+def handle_markdown_line(
+    line: str,
+    headings: list[tuple[int, str, str]],
+    body: list[str],
+    states: dict[str, bool],
+) -> None:
+    heading = re.match(r"^(#{1,3})\s+(.+)$", line)
+    if heading:
+        close_blocks(body, states)
+        level = len(heading.group(1))
+        title = heading.group(2).strip()
+        anchor = slug(title)
+        headings.append((level, title, anchor))
+        body.append(f'<h{level} id="{anchor}">{inline_markup(title)}</h{level}>')
+        return
+    if line.startswith("|") and line.endswith("|"):
+        cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
+        raw_cells = [html.unescape(cell) for cell in cells]
+        if all(re.match(r"^:?-{3,}:?$", cell) for cell in raw_cells):
+            return
+        if not states["table"]:
+            close_blocks(body, states)
+            body.append("<table><tbody>")
+            states["table"] = True
+        body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
+        return
+    if line.startswith(("- ", "* ")):
+        if not states["list"]:
+            close_blocks(body, states)
+            body.append("<ul>")
+            states["list"] = True
+        body.append(f"<li>{inline_markup(line[2:].strip())}</li>")
+        return
+    close_blocks(body, states)
+    if line.lower().startswith(("source:", "source card:")):
+        body.append(f'<aside class="source-card">{inline_markup(line)}</aside>')
+    else:
+        body.append(f"<p>{inline_markup(line)}</p>")
+
+
+def render_markdown(text: str) -> tuple[list[tuple[int, str, str]], str]:
+    validate_markdown_badges(text)
+    headings: list[tuple[int, str, str]] = []
+    body: list[str] = []
+    states = {"list": False, "table": False}
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if line:
+            handle_markdown_line(line, headings, body, states)
+        else:
+            close_blocks(body, states)
+    close_blocks(body, states)
+    return headings, "\n".join(body)
+
+
+def render_json(text: str) -> tuple[list[tuple[int, str, str]], str]:
+    data = json.loads(text)
+    validate_json_badges(data)
+    headings: list[tuple[int, str, str]] = []
+    body: list[str] = []
+    title = data.get(TITLE_KEY, "Report") if isinstance(data, dict) else "Report"
+    headings.append((1, title, slug(title)))
+    body.append(f'<h1 id="{slug(title)}">{inline_markup(title)}</h1>')
+    for section in data.get("sections", []):
+        section_title = section.get(TITLE_KEY, "Section")
+        headings.append((2, section_title, slug(section_title)))
+        body.append(f'<h2 id="{slug(section_title)}">{inline_markup(section_title)}</h2>')
+        if section.get(SUMMARY_KEY):
+            body.append(f"<p>{inline_markup(str(section[SUMMARY_KEY]))}</p>")
+        for item in section.get("items", []):
+            badge = f" {badge_html(item[BADGE_KEY])}" if item.get(BADGE_KEY) else ""
+            item_title = inline_markup(str(item.get(TITLE_KEY, "Item")))
+            detail = inline_markup(str(item.get(DETAIL_KEY, "")))
+            body.append(f'<div class="source-card"><strong>{item_title}</strong>{badge}<p>{detail}</p></div>')
+    return headings, "\n".join(body)
+
+
+def wrap_document(headings: list[tuple[int, str, str]], body: str) -> str:
+    toc_items = []
+    for level, title, anchor in headings:
+        indent = f' style="margin-left:{max(level - 1, 0)}rem"'
+        toc_items.append(f'<a href="#{anchor}"{indent}>{html.escape(title)}</a>')
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Report</title>
+<style>{CSS}</style>
+</head>
+<body>
+<div class="report-shell">
+<nav class="sticky-toc" aria-label="Report table of contents">
+<strong>Contents</strong>
+{chr(10).join(toc_items)}
+</nav>
+<main class="report-content">
+{body}
+</main>
+</div>
+</body>
+</html>
+"""
+
+
+def sample_json() -> str:
+    return json.dumps(
+        {
+            TITLE_KEY: "AI Visibility Report",
+            "sections": [
+                {
+                    TITLE_KEY: "Executive summary",
+                    SUMMARY_KEY: "Visibility improved across answer engines.",
+                    "items": [
+                        {TITLE_KEY: "AIO", DETAIL_KEY: "Cited with source card.", BADGE_KEY: BADGE_VERIFIED},
+                        {TITLE_KEY: "Gemini", DETAIL_KEY: "Partial coverage found.", BADGE_KEY: BADGE_PARTIAL},
+                        {TITLE_KEY: "ChatGPT", DETAIL_KEY: "Inference from comparable prompts.", BADGE_KEY: BADGE_INFERRED},
+                        {TITLE_KEY: "Perplexity", DETAIL_KEY: "No citation found.", BADGE_KEY: BADGE_MISSING},
+                    ],
+                }
+            ],
+        },
+        indent=2,
+    )
+
+
+def main() -> int:
+    if MODE == "print-css":
+        print(CSS)
+        return 0
+    if MODE == "sample-json":
+        print(sample_json())
+        return 0
+    text = read_input(INPUT)
+    if MODE == "validate":
+        stripped = text.lstrip()
+        if stripped.startswith(("{", "[")):
+            validate_json_badges(json.loads(text))
+        else:
+            validate_markdown_badges(text)
+        return 0
+    stripped = text.lstrip()
+    headings, body = render_json(text) if stripped.startswith("{") else render_markdown(text)
+    sys.stdout.write(wrap_document(headings, body))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        sys.stderr.write(f"{exc}\n")
+        sys.exit(1)

--- a/.agents/scripts/report-render-helper.py
+++ b/.agents/scripts/report-render-helper.py
@@ -7,28 +7,18 @@ from __future__ import annotations
 
 import html
 import json
-import re
 import sys
-from typing import Any
+
+from report_render_badges import BADGE_INFERRED
+from report_render_badges import BADGE_KEY
+from report_render_badges import BADGE_MISSING
+from report_render_badges import BADGE_PARTIAL
+from report_render_badges import BADGE_VERIFIED
+from report_render_json import DETAIL_KEY, SUMMARY_KEY, TITLE_KEY, render_json, validate_json_badges
+from report_render_markdown import render_markdown, validate_markdown_badges
 
 MODE = sys.argv[1]
 INPUT = sys.argv[2] if len(sys.argv) > 2 else ""
-BADGE_VERIFIED = "verified"
-BADGE_PARTIAL = "partial"
-BADGE_INFERRED = "inferred"
-BADGE_MISSING = "missing"
-BADGE_KEY = "evidence_badge"
-TITLE_KEY = "title"
-DETAIL_KEY = "detail"
-SUMMARY_KEY = "summary"
-ALLOWED_BADGES = (BADGE_VERIFIED, BADGE_PARTIAL, BADGE_INFERRED, BADGE_MISSING)
-BADGE_LABELS = {
-    BADGE_VERIFIED: "Evidence: Verified",
-    BADGE_PARTIAL: "Evidence: Partial",
-    BADGE_INFERRED: "Evidence: Inferred",
-    BADGE_MISSING: "Evidence: Missing",
-}
-
 CSS = """
 :root { color-scheme: light; --ink: #1f2937; --muted: #6b7280; --line: #d1d5db; --panel: #f9fafb; }
 body { margin: 0; font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); }
@@ -53,132 +43,6 @@ def read_input(path: str) -> str:
         return sys.stdin.read()
     with open(path, encoding="utf-8") as handle:
         return handle.read()
-
-
-def slug(text: str) -> str:
-    value = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
-    return value or "section"
-
-
-def badge_html(value: Any) -> str:
-    key = str(value).strip().lower()
-    if key not in ALLOWED_BADGES:
-        raise ValueError(f"unknown evidence badge value: {value}")
-    return f'<span class="badge badge-{key}">{BADGE_LABELS[key]}</span>'
-
-
-def validate_json_badges(node: Any) -> None:
-    if isinstance(node, dict):
-        for key, value in node.items():
-            if key in (BADGE_KEY, "evidenceBadge"):
-                badge_html(value)
-            validate_json_badges(value)
-    elif isinstance(node, list):
-        for item in node:
-            validate_json_badges(item)
-
-
-def validate_markdown_badges(text: str) -> None:
-    for match in re.finditer(r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}", text, re.I):
-        badge_html(match.group(1))
-
-
-def inline_markup(text: str) -> str:
-    escaped = html.escape(text)
-    escaped = re.sub(
-        r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}",
-        lambda match: badge_html(html.unescape(match.group(1))),
-        escaped,
-        flags=re.I,
-    )
-    escaped = re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
-    return re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
-
-
-def close_blocks(body: list[str], states: dict[str, bool]) -> None:
-    if states["list"]:
-        body.append("</ul>")
-        states["list"] = False
-    if states["table"]:
-        body.append("</tbody></table>")
-        states["table"] = False
-
-
-def handle_markdown_line(
-    line: str,
-    headings: list[tuple[int, str, str]],
-    body: list[str],
-    states: dict[str, bool],
-) -> None:
-    heading = re.match(r"^(#{1,3})\s+(.+)$", line)
-    if heading:
-        close_blocks(body, states)
-        level = len(heading.group(1))
-        title = heading.group(2).strip()
-        anchor = slug(title)
-        headings.append((level, title, anchor))
-        body.append(f'<h{level} id="{anchor}">{inline_markup(title)}</h{level}>')
-        return
-    if line.startswith("|") and line.endswith("|"):
-        cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
-        raw_cells = [html.unescape(cell) for cell in cells]
-        if all(re.match(r"^:?-{3,}:?$", cell) for cell in raw_cells):
-            return
-        if not states["table"]:
-            close_blocks(body, states)
-            body.append("<table><tbody>")
-            states["table"] = True
-        body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
-        return
-    if line.startswith(("- ", "* ")):
-        if not states["list"]:
-            close_blocks(body, states)
-            body.append("<ul>")
-            states["list"] = True
-        body.append(f"<li>{inline_markup(line[2:].strip())}</li>")
-        return
-    close_blocks(body, states)
-    if line.lower().startswith(("source:", "source card:")):
-        body.append(f'<aside class="source-card">{inline_markup(line)}</aside>')
-    else:
-        body.append(f"<p>{inline_markup(line)}</p>")
-
-
-def render_markdown(text: str) -> tuple[list[tuple[int, str, str]], str]:
-    validate_markdown_badges(text)
-    headings: list[tuple[int, str, str]] = []
-    body: list[str] = []
-    states = {"list": False, "table": False}
-    for raw_line in text.splitlines():
-        line = raw_line.rstrip()
-        if line:
-            handle_markdown_line(line, headings, body, states)
-        else:
-            close_blocks(body, states)
-    close_blocks(body, states)
-    return headings, "\n".join(body)
-
-
-def render_json(text: str) -> tuple[list[tuple[int, str, str]], str]:
-    data = json.loads(text)
-    validate_json_badges(data)
-    headings: list[tuple[int, str, str]] = []
-    body: list[str] = []
-    title = data.get(TITLE_KEY, "Report") if isinstance(data, dict) else "Report"
-    headings.append((1, title, slug(title)))
-    body.append(f'<h1 id="{slug(title)}">{inline_markup(title)}</h1>')
-    for section in data.get("sections", []):
-        section_title = section.get(TITLE_KEY, "Section")
-        headings.append((2, section_title, slug(section_title)))
-        body.append(f'<h2 id="{slug(section_title)}">{inline_markup(section_title)}</h2>')
-        if section.get(SUMMARY_KEY):
-            body.append(f"<p>{inline_markup(str(section[SUMMARY_KEY]))}</p>")
-        for item in section.get("items", []):
-            badge = f" {badge_html(item[BADGE_KEY])}" if item.get(BADGE_KEY) else ""
-            item_title = inline_markup(str(item.get(TITLE_KEY, "Item")))
-            detail = inline_markup(str(item.get(DETAIL_KEY, "")))
-            body.append(f'<div class="source-card"><strong>{item_title}</strong>{badge}<p>{detail}</p></div>')
-    return headings, "\n".join(body)
 
 
 def wrap_document(headings: list[tuple[int, str, str]], body: str) -> str:

--- a/.agents/scripts/report-render-helper.sh
+++ b/.agents/scripts/report-render-helper.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# report-render-helper.sh — render report-ready Markdown/JSON to portable HTML.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]:-$0}")"
+
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+_die() {
+	local _message="${1:-usage error}"
+	printf '%b[%s] ERROR: %s%b\n' "$RED" "$SCRIPT_NAME" "$_message" "$NC" >&2
+	exit 2
+	# shellcheck disable=SC2317
+	return 1
+}
+
+_python_render() {
+	local _mode="${1:-render}"
+	local _input="${2:-}"
+	python3 - "$_mode" "$_input" <<'PYEOF'
+import html
+import json
+import os
+import re
+import sys
+
+MODE = sys.argv[1]
+INPUT = sys.argv[2] if len(sys.argv) > 2 else ""
+BADGE_VERIFIED = "verified"
+BADGE_PARTIAL = "partial"
+BADGE_INFERRED = "inferred"
+BADGE_MISSING = "missing"
+BADGE_KEY = "evidence_badge"
+TITLE_KEY = "title"
+DETAIL_KEY = "detail"
+SUMMARY_KEY = "summary"
+ALLOWED_BADGES = (BADGE_VERIFIED, BADGE_PARTIAL, BADGE_INFERRED, BADGE_MISSING)
+BADGE_LABELS = {
+    BADGE_VERIFIED: "Evidence: Verified",
+    BADGE_PARTIAL: "Evidence: Partial",
+    BADGE_INFERRED: "Evidence: Inferred",
+    BADGE_MISSING: "Evidence: Missing",
+}
+
+CSS = """
+:root { color-scheme: light; --ink: #1f2937; --muted: #6b7280; --line: #d1d5db; --panel: #f9fafb; }
+body { margin: 0; font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); }
+.report-shell { display: grid; grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr); gap: 2rem; max-width: 1180px; margin: 0 auto; padding: 2rem; }
+.sticky-toc { position: sticky; top: 1rem; align-self: start; max-height: calc(100vh - 2rem); overflow: auto; border: 1px solid var(--line); border-radius: 12px; padding: 1rem; background: var(--panel); }
+.sticky-toc a { display: block; color: inherit; text-decoration: none; margin: .35rem 0; }
+.report-content { min-width: 0; }
+.badge { display: inline-block; border-radius: 999px; padding: .15rem .55rem; font-size: .78rem; font-weight: 700; border: 1px solid var(--line); }
+.badge-verified { background: #dcfce7; color: #166534; }
+.badge-partial { background: #fef9c3; color: #854d0e; }
+.badge-inferred { background: #dbeafe; color: #1e40af; }
+.badge-missing { background: #fee2e2; color: #991b1b; }
+.source-card { border: 1px solid var(--line); border-left: 4px solid #111827; border-radius: 10px; padding: .85rem 1rem; margin: .75rem 0; background: #fff; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid var(--line); padding: .5rem; text-align: left; }
+@media print { .report-shell { display: block; padding: 0; } .sticky-toc { position: static; page-break-after: always; } a { color: inherit; } }
+""".strip()
+
+
+def read_input(path):
+    if path == "-":
+        return sys.stdin.read()
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def slug(text):
+    value = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return value or "section"
+
+
+def badge_html(value):
+    key = str(value).strip().lower()
+    if key not in ALLOWED_BADGES:
+        raise ValueError("unknown evidence badge value: {}".format(value))
+    return '<span class="badge badge-{0}">{1}</span>'.format(key, BADGE_LABELS[key])
+
+
+def validate_json_badges(node):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in (BADGE_KEY, "evidenceBadge"):
+                badge_html(value)
+            validate_json_badges(value)
+    elif isinstance(node, list):
+        for item in node:
+            validate_json_badges(item)
+
+
+def validate_markdown_badges(text):
+    for match in re.finditer(r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}", text, re.I):
+        badge_html(match.group(1))
+
+
+def inline_markup(text):
+    escaped = html.escape(text)
+    escaped = re.sub(
+        r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}",
+        lambda match: badge_html(html.unescape(match.group(1))),
+        escaped,
+        flags=re.I,
+    )
+    escaped = re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
+    escaped = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
+    return escaped
+
+
+def render_markdown(text):
+    validate_markdown_badges(text)
+    headings = []
+    body = []
+    in_list = False
+    in_table = False
+
+    def close_blocks():
+        nonlocal in_list, in_table
+        if in_list:
+            body.append("</ul>")
+            in_list = False
+        if in_table:
+            body.append("</tbody></table>")
+            in_table = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            close_blocks()
+            continue
+        heading = re.match(r"^(#{1,3})\s+(.+)$", line)
+        if heading:
+            close_blocks()
+            level = len(heading.group(1))
+            title = heading.group(2).strip()
+            anchor = slug(title)
+            headings.append((level, title, anchor))
+            body.append('<h{0} id="{1}">{2}</h{0}>'.format(level, anchor, inline_markup(title)))
+            continue
+        if line.startswith("|") and line.endswith("|"):
+            cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
+            if all(re.match(r"^:?-{3,}:?$", cell) for cell in [html.unescape(c) for c in cells]):
+                continue
+            if not in_table:
+                close_blocks()
+                body.append("<table><tbody>")
+                in_table = True
+            body.append("<tr>{}</tr>".format("".join("<td>{}</td>".format(cell) for cell in cells)))
+            continue
+        if line.startswith(("- ", "* ")):
+            if not in_list:
+                close_blocks()
+                body.append("<ul>")
+                in_list = True
+            body.append("<li>{}</li>".format(inline_markup(line[2:].strip())))
+            continue
+        close_blocks()
+        if line.lower().startswith("source:") or line.lower().startswith("source card:"):
+            body.append('<aside class="source-card">{}</aside>'.format(inline_markup(line)))
+        else:
+            body.append("<p>{}</p>".format(inline_markup(line)))
+    close_blocks()
+    return headings, "\n".join(body)
+
+
+def render_json(text):
+    data = json.loads(text)
+    validate_json_badges(data)
+    headings = []
+    body = []
+    title = data.get(TITLE_KEY, "Report") if isinstance(data, dict) else "Report"
+    headings.append((1, title, slug(title)))
+    body.append('<h1 id="{}">{}</h1>'.format(slug(title), inline_markup(title)))
+    for section in data.get("sections", []):
+        section_title = section.get(TITLE_KEY, "Section")
+        headings.append((2, section_title, slug(section_title)))
+        body.append('<h2 id="{}">{}</h2>'.format(slug(section_title), inline_markup(section_title)))
+        if section.get(SUMMARY_KEY):
+            body.append("<p>{}</p>".format(inline_markup(str(section[SUMMARY_KEY]))))
+        for item in section.get("items", []):
+            badge = ""
+            if item.get(BADGE_KEY):
+                badge = " " + badge_html(item[BADGE_KEY])
+            body.append('<div class="source-card"><strong>{}</strong>{}<p>{}</p></div>'.format(
+                inline_markup(str(item.get(TITLE_KEY, "Item"))),
+                badge,
+                inline_markup(str(item.get(DETAIL_KEY, ""))),
+            ))
+    return headings, "\n".join(body)
+
+
+def wrap_document(headings, body):
+    toc_items = []
+    for level, title, anchor in headings:
+        indent = " style=\"margin-left:{}rem\"".format(max(level - 1, 0))
+        toc_items.append('<a href="#{0}"{1}>{2}</a>'.format(anchor, indent, html.escape(title)))
+    return """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Report</title>
+<style>{css}</style>
+</head>
+<body>
+<div class="report-shell">
+<nav class="sticky-toc" aria-label="Report table of contents">
+<strong>Contents</strong>
+{toc}
+</nav>
+<main class="report-content">
+{body}
+</main>
+</div>
+</body>
+</html>
+""".format(css=CSS, toc="\n".join(toc_items), body=body)
+
+
+def main():
+    if MODE == "print-css":
+        print(CSS)
+        return 0
+    if MODE == "sample-json":
+        print(json.dumps({
+            TITLE_KEY: "AI Visibility Report",
+            "sections": [{
+                TITLE_KEY: "Executive summary",
+                SUMMARY_KEY: "Visibility improved across answer engines.",
+                "items": [
+                    {TITLE_KEY: "AIO", DETAIL_KEY: "Cited with source card.", BADGE_KEY: BADGE_VERIFIED},
+                    {TITLE_KEY: "Gemini", DETAIL_KEY: "Partial coverage found.", BADGE_KEY: BADGE_PARTIAL},
+                    {TITLE_KEY: "ChatGPT", DETAIL_KEY: "Inference from comparable prompts.", BADGE_KEY: BADGE_INFERRED},
+                    {TITLE_KEY: "Perplexity", DETAIL_KEY: "No citation found.", BADGE_KEY: BADGE_MISSING},
+                ],
+            }],
+        }, indent=2))
+        return 0
+    text = read_input(INPUT)
+    if MODE == "validate":
+        stripped = text.lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            validate_json_badges(json.loads(text))
+        else:
+            validate_markdown_badges(text)
+        return 0
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        headings, body = render_json(text)
+    else:
+        headings, body = render_markdown(text)
+    sys.stdout.write(wrap_document(headings, body))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        sys.stderr.write("{}\n".format(exc))
+        sys.exit(1)
+PYEOF
+	return 0
+}
+
+_print_usage() {
+	cat <<'USAGE'
+Usage:
+  report-render-helper.sh render <input.md|input.json|-> [--output output.html]
+  report-render-helper.sh validate <input.md|input.json|->
+  report-render-helper.sh sample [markdown|json]
+  report-render-helper.sh print-css
+
+Evidence badges: {{evidence:verified}}, {{evidence:partial}}, {{evidence:inferred}}, {{evidence:missing}}
+USAGE
+	return 0
+}
+
+cmd_render() {
+	local _input=""
+	local _output=""
+	while [[ $# -gt 0 ]]; do
+		local _arg="${1:-}"
+		shift
+		case "$_arg" in
+		--output)
+			_output="${1:-}"
+			[[ -z "$_output" ]] && _die "--output requires a path"
+			shift
+			;;
+		-*)
+			[[ "$_arg" == "-" && -z "$_input" ]] && _input="$_arg" && continue
+			_die "unknown option: ${_arg}"
+			;;
+		*)
+			[[ -n "$_input" ]] && _die "render accepts one input"
+			_input="$_arg"
+			;;
+		esac
+	done
+	[[ -z "$_input" ]] && _die "render requires an input path"
+	if [[ "$_input" != "-" && ! -f "$_input" ]]; then
+		_die "input file not found: ${_input}"
+	fi
+	if [[ -n "$_output" ]]; then
+		_python_render render "$_input" >"$_output"
+	else
+		_python_render render "$_input"
+	fi
+	return 0
+}
+
+cmd_validate() {
+	local _input="${1:-}"
+	[[ -z "$_input" ]] && _die "validate requires an input path"
+	[[ "$_input" != "-" && ! -f "$_input" ]] && _die "input file not found: ${_input}"
+	_python_render validate "$_input"
+	return 0
+}
+
+cmd_sample() {
+	local _format="${1:-markdown}"
+	case "$_format" in
+	markdown | md)
+		cat <<'SAMPLE_MD'
+# AI Visibility Report
+
+## Executive summary
+
+Visibility improved across answer engines. {{evidence:verified}}
+
+## Scorecard
+
+| Component | Score | Evidence |
+|---|---:|---|
+| AIO | 82 | {{evidence:verified}} |
+| Gemini | 74 | {{evidence:partial}} |
+| ChatGPT | 68 | {{evidence:inferred}} |
+| Perplexity | 0 | {{evidence:missing}} |
+
+## Sources
+
+Source: SERP capture, crawl export, analytics comparison, and remediation notes.
+SAMPLE_MD
+		;;
+	json)
+		_python_render sample-json "-"
+		;;
+	*)
+		_die "unknown sample format: ${_format}"
+		;;
+	esac
+	return 0
+}
+
+cmd_print_css() {
+	_python_render print-css "-"
+	return 0
+}
+
+main() {
+	local _command="${1:-help}"
+	[[ $# -gt 0 ]] && shift
+	case "$_command" in
+	render)
+		cmd_render "$@"
+		;;
+	validate)
+		cmd_validate "$@"
+		;;
+	sample)
+		cmd_sample "$@"
+		;;
+	print-css)
+		cmd_print_css
+		;;
+	help | --help | -h)
+		_print_usage
+		;;
+	*)
+		_die "unknown command: ${_command}"
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/report-render-helper.sh
+++ b/.agents/scripts/report-render-helper.sh
@@ -6,7 +6,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]:-$0}")"
+PY_HELPER="${SCRIPT_DIR}/report-render-helper.py"
 
 [[ -z "${RED+x}" ]] && RED='\033[0;31m'
 [[ -z "${NC+x}" ]] && NC='\033[0m'
@@ -19,254 +21,10 @@ _die() {
 	return 1
 }
 
-_python_render() {
+_run_python() {
 	local _mode="${1:-render}"
 	local _input="${2:-}"
-	python3 - "$_mode" "$_input" <<'PYEOF'
-import html
-import json
-import os
-import re
-import sys
-
-MODE = sys.argv[1]
-INPUT = sys.argv[2] if len(sys.argv) > 2 else ""
-BADGE_VERIFIED = "verified"
-BADGE_PARTIAL = "partial"
-BADGE_INFERRED = "inferred"
-BADGE_MISSING = "missing"
-BADGE_KEY = "evidence_badge"
-TITLE_KEY = "title"
-DETAIL_KEY = "detail"
-SUMMARY_KEY = "summary"
-ALLOWED_BADGES = (BADGE_VERIFIED, BADGE_PARTIAL, BADGE_INFERRED, BADGE_MISSING)
-BADGE_LABELS = {
-    BADGE_VERIFIED: "Evidence: Verified",
-    BADGE_PARTIAL: "Evidence: Partial",
-    BADGE_INFERRED: "Evidence: Inferred",
-    BADGE_MISSING: "Evidence: Missing",
-}
-
-CSS = """
-:root { color-scheme: light; --ink: #1f2937; --muted: #6b7280; --line: #d1d5db; --panel: #f9fafb; }
-body { margin: 0; font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); }
-.report-shell { display: grid; grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr); gap: 2rem; max-width: 1180px; margin: 0 auto; padding: 2rem; }
-.sticky-toc { position: sticky; top: 1rem; align-self: start; max-height: calc(100vh - 2rem); overflow: auto; border: 1px solid var(--line); border-radius: 12px; padding: 1rem; background: var(--panel); }
-.sticky-toc a { display: block; color: inherit; text-decoration: none; margin: .35rem 0; }
-.report-content { min-width: 0; }
-.badge { display: inline-block; border-radius: 999px; padding: .15rem .55rem; font-size: .78rem; font-weight: 700; border: 1px solid var(--line); }
-.badge-verified { background: #dcfce7; color: #166534; }
-.badge-partial { background: #fef9c3; color: #854d0e; }
-.badge-inferred { background: #dbeafe; color: #1e40af; }
-.badge-missing { background: #fee2e2; color: #991b1b; }
-.source-card { border: 1px solid var(--line); border-left: 4px solid #111827; border-radius: 10px; padding: .85rem 1rem; margin: .75rem 0; background: #fff; }
-table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
-th, td { border: 1px solid var(--line); padding: .5rem; text-align: left; }
-@media print { .report-shell { display: block; padding: 0; } .sticky-toc { position: static; page-break-after: always; } a { color: inherit; } }
-""".strip()
-
-
-def read_input(path):
-    if path == "-":
-        return sys.stdin.read()
-    with open(path, "r", encoding="utf-8") as handle:
-        return handle.read()
-
-
-def slug(text):
-    value = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
-    return value or "section"
-
-
-def badge_html(value):
-    key = str(value).strip().lower()
-    if key not in ALLOWED_BADGES:
-        raise ValueError("unknown evidence badge value: {}".format(value))
-    return '<span class="badge badge-{0}">{1}</span>'.format(key, BADGE_LABELS[key])
-
-
-def validate_json_badges(node):
-    if isinstance(node, dict):
-        for key, value in node.items():
-            if key in (BADGE_KEY, "evidenceBadge"):
-                badge_html(value)
-            validate_json_badges(value)
-    elif isinstance(node, list):
-        for item in node:
-            validate_json_badges(item)
-
-
-def validate_markdown_badges(text):
-    for match in re.finditer(r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}", text, re.I):
-        badge_html(match.group(1))
-
-
-def inline_markup(text):
-    escaped = html.escape(text)
-    escaped = re.sub(
-        r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}",
-        lambda match: badge_html(html.unescape(match.group(1))),
-        escaped,
-        flags=re.I,
-    )
-    escaped = re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
-    escaped = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
-    return escaped
-
-
-def render_markdown(text):
-    validate_markdown_badges(text)
-    headings = []
-    body = []
-    in_list = False
-    in_table = False
-
-    def close_blocks():
-        nonlocal in_list, in_table
-        if in_list:
-            body.append("</ul>")
-            in_list = False
-        if in_table:
-            body.append("</tbody></table>")
-            in_table = False
-
-    for raw_line in text.splitlines():
-        line = raw_line.rstrip()
-        if not line:
-            close_blocks()
-            continue
-        heading = re.match(r"^(#{1,3})\s+(.+)$", line)
-        if heading:
-            close_blocks()
-            level = len(heading.group(1))
-            title = heading.group(2).strip()
-            anchor = slug(title)
-            headings.append((level, title, anchor))
-            body.append('<h{0} id="{1}">{2}</h{0}>'.format(level, anchor, inline_markup(title)))
-            continue
-        if line.startswith("|") and line.endswith("|"):
-            cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
-            if all(re.match(r"^:?-{3,}:?$", cell) for cell in [html.unescape(c) for c in cells]):
-                continue
-            if not in_table:
-                close_blocks()
-                body.append("<table><tbody>")
-                in_table = True
-            body.append("<tr>{}</tr>".format("".join("<td>{}</td>".format(cell) for cell in cells)))
-            continue
-        if line.startswith(("- ", "* ")):
-            if not in_list:
-                close_blocks()
-                body.append("<ul>")
-                in_list = True
-            body.append("<li>{}</li>".format(inline_markup(line[2:].strip())))
-            continue
-        close_blocks()
-        if line.lower().startswith("source:") or line.lower().startswith("source card:"):
-            body.append('<aside class="source-card">{}</aside>'.format(inline_markup(line)))
-        else:
-            body.append("<p>{}</p>".format(inline_markup(line)))
-    close_blocks()
-    return headings, "\n".join(body)
-
-
-def render_json(text):
-    data = json.loads(text)
-    validate_json_badges(data)
-    headings = []
-    body = []
-    title = data.get(TITLE_KEY, "Report") if isinstance(data, dict) else "Report"
-    headings.append((1, title, slug(title)))
-    body.append('<h1 id="{}">{}</h1>'.format(slug(title), inline_markup(title)))
-    for section in data.get("sections", []):
-        section_title = section.get(TITLE_KEY, "Section")
-        headings.append((2, section_title, slug(section_title)))
-        body.append('<h2 id="{}">{}</h2>'.format(slug(section_title), inline_markup(section_title)))
-        if section.get(SUMMARY_KEY):
-            body.append("<p>{}</p>".format(inline_markup(str(section[SUMMARY_KEY]))))
-        for item in section.get("items", []):
-            badge = ""
-            if item.get(BADGE_KEY):
-                badge = " " + badge_html(item[BADGE_KEY])
-            body.append('<div class="source-card"><strong>{}</strong>{}<p>{}</p></div>'.format(
-                inline_markup(str(item.get(TITLE_KEY, "Item"))),
-                badge,
-                inline_markup(str(item.get(DETAIL_KEY, ""))),
-            ))
-    return headings, "\n".join(body)
-
-
-def wrap_document(headings, body):
-    toc_items = []
-    for level, title, anchor in headings:
-        indent = " style=\"margin-left:{}rem\"".format(max(level - 1, 0))
-        toc_items.append('<a href="#{0}"{1}>{2}</a>'.format(anchor, indent, html.escape(title)))
-    return """<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Report</title>
-<style>{css}</style>
-</head>
-<body>
-<div class="report-shell">
-<nav class="sticky-toc" aria-label="Report table of contents">
-<strong>Contents</strong>
-{toc}
-</nav>
-<main class="report-content">
-{body}
-</main>
-</div>
-</body>
-</html>
-""".format(css=CSS, toc="\n".join(toc_items), body=body)
-
-
-def main():
-    if MODE == "print-css":
-        print(CSS)
-        return 0
-    if MODE == "sample-json":
-        print(json.dumps({
-            TITLE_KEY: "AI Visibility Report",
-            "sections": [{
-                TITLE_KEY: "Executive summary",
-                SUMMARY_KEY: "Visibility improved across answer engines.",
-                "items": [
-                    {TITLE_KEY: "AIO", DETAIL_KEY: "Cited with source card.", BADGE_KEY: BADGE_VERIFIED},
-                    {TITLE_KEY: "Gemini", DETAIL_KEY: "Partial coverage found.", BADGE_KEY: BADGE_PARTIAL},
-                    {TITLE_KEY: "ChatGPT", DETAIL_KEY: "Inference from comparable prompts.", BADGE_KEY: BADGE_INFERRED},
-                    {TITLE_KEY: "Perplexity", DETAIL_KEY: "No citation found.", BADGE_KEY: BADGE_MISSING},
-                ],
-            }],
-        }, indent=2))
-        return 0
-    text = read_input(INPUT)
-    if MODE == "validate":
-        stripped = text.lstrip()
-        if stripped.startswith("{") or stripped.startswith("["):
-            validate_json_badges(json.loads(text))
-        else:
-            validate_markdown_badges(text)
-        return 0
-    stripped = text.lstrip()
-    if stripped.startswith("{"):
-        headings, body = render_json(text)
-    else:
-        headings, body = render_markdown(text)
-    sys.stdout.write(wrap_document(headings, body))
-    return 0
-
-
-if __name__ == "__main__":
-    try:
-        sys.exit(main())
-    except Exception as exc:
-        sys.stderr.write("{}\n".format(exc))
-        sys.exit(1)
-PYEOF
+	python3 "$PY_HELPER" "$_mode" "$_input"
 	return 0
 }
 
@@ -295,8 +53,11 @@ cmd_render() {
 			[[ -z "$_output" ]] && _die "--output requires a path"
 			shift
 			;;
+		-)
+			[[ -n "$_input" ]] && _die "render accepts one input"
+			_input="$_arg"
+			;;
 		-*)
-			[[ "$_arg" == "-" && -z "$_input" ]] && _input="$_arg" && continue
 			_die "unknown option: ${_arg}"
 			;;
 		*)
@@ -310,9 +71,9 @@ cmd_render() {
 		_die "input file not found: ${_input}"
 	fi
 	if [[ -n "$_output" ]]; then
-		_python_render render "$_input" >"$_output"
+		_run_python render "$_input" >"$_output"
 	else
-		_python_render render "$_input"
+		_run_python render "$_input"
 	fi
 	return 0
 }
@@ -321,7 +82,7 @@ cmd_validate() {
 	local _input="${1:-}"
 	[[ -z "$_input" ]] && _die "validate requires an input path"
 	[[ "$_input" != "-" && ! -f "$_input" ]] && _die "input file not found: ${_input}"
-	_python_render validate "$_input"
+	_run_python validate "$_input"
 	return 0
 }
 
@@ -351,7 +112,7 @@ Source: SERP capture, crawl export, analytics comparison, and remediation notes.
 SAMPLE_MD
 		;;
 	json)
-		_python_render sample-json "-"
+		_run_python sample-json "-"
 		;;
 	*)
 		_die "unknown sample format: ${_format}"
@@ -361,7 +122,7 @@ SAMPLE_MD
 }
 
 cmd_print_css() {
-	_python_render print-css "-"
+	_run_python print-css "-"
 	return 0
 }
 

--- a/.agents/scripts/report_render_badges.py
+++ b/.agents/scripts/report_render_badges.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Evidence badge helpers for report rendering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+BADGE_VERIFIED = "verified"
+BADGE_PARTIAL = "partial"
+BADGE_INFERRED = "inferred"
+BADGE_MISSING = "missing"
+BADGE_KEY = "evidence_badge"
+
+ALLOWED_BADGES = (BADGE_VERIFIED, BADGE_PARTIAL, BADGE_INFERRED, BADGE_MISSING)
+BADGE_LABELS = {
+    BADGE_VERIFIED: "Evidence: Verified",
+    BADGE_PARTIAL: "Evidence: Partial",
+    BADGE_INFERRED: "Evidence: Inferred",
+    BADGE_MISSING: "Evidence: Missing",
+}
+
+
+def badge_html(value: Any) -> str:
+    key = str(value).strip().lower()
+    if key not in ALLOWED_BADGES:
+        raise ValueError(f"unknown evidence badge value: {value}")
+    return f'<span class="badge badge-{key}">{BADGE_LABELS[key]}</span>'

--- a/.agents/scripts/report_render_json.py
+++ b/.agents/scripts/report_render_json.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""JSON rendering helpers for report-render-helper.py."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from report_render_badges import BADGE_KEY, badge_html
+from report_render_markup import inline_markup, slug
+
+TITLE_KEY = "title"
+DETAIL_KEY = "detail"
+SUMMARY_KEY = "summary"
+
+
+def validate_json_badges(node: Any) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            badge_html(value) if key in (BADGE_KEY, "evidenceBadge") else None
+            validate_json_badges(value)
+        return
+    if isinstance(node, list):
+        for item in node:
+            validate_json_badges(item)
+
+
+def append_json_item(body: list[str], item: dict[str, Any]) -> None:
+    badge = f" {badge_html(item[BADGE_KEY])}" if item.get(BADGE_KEY) else ""
+    item_title = inline_markup(str(item.get(TITLE_KEY, "Item")))
+    detail = inline_markup(str(item.get(DETAIL_KEY, "")))
+    body.append(f'<div class="source-card"><strong>{item_title}</strong>{badge}<p>{detail}</p></div>')
+
+
+def append_json_section(
+    headings: list[tuple[int, str, str]],
+    body: list[str],
+    section: dict[str, Any],
+) -> None:
+    section_title = section.get(TITLE_KEY, "Section")
+    headings.append((2, section_title, slug(section_title)))
+    body.append(f'<h2 id="{slug(section_title)}">{inline_markup(section_title)}</h2>')
+    if section.get(SUMMARY_KEY):
+        body.append(f"<p>{inline_markup(str(section[SUMMARY_KEY]))}</p>")
+    for item in section.get("items", []):
+        append_json_item(body, item)
+
+
+def render_json(text: str) -> tuple[list[tuple[int, str, str]], str]:
+    data = json.loads(text)
+    validate_json_badges(data)
+    headings: list[tuple[int, str, str]] = []
+    body: list[str] = []
+    title = data.get(TITLE_KEY, "Report") if isinstance(data, dict) else "Report"
+    headings.append((1, title, slug(title)))
+    body.append(f'<h1 id="{slug(title)}">{inline_markup(title)}</h1>')
+    for section in data.get("sections", []):
+        append_json_section(headings, body, section)
+    return headings, "\n".join(body)

--- a/.agents/scripts/report_render_markdown.py
+++ b/.agents/scripts/report_render_markdown.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Markdown rendering helpers for report-render-helper.py."""
+
+from __future__ import annotations
+
+import html
+import re
+
+from report_render_badges import badge_html
+from report_render_markup import inline_markup, slug
+
+
+def validate_markdown_badges(text: str) -> None:
+    for match in re.finditer(r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}", text, re.I):
+        badge_html(match.group(1))
+
+
+def close_blocks(body: list[str], states: dict[str, bool]) -> None:
+    for key, tag in (("list", "</ul>"), ("table", "</tbody></table>")):
+        if states[key]:
+            body.append(tag)
+            states[key] = False
+
+
+def handle_heading(
+    line: str,
+    headings: list[tuple[int, str, str]],
+    body: list[str],
+    states: dict[str, bool],
+) -> bool:
+    heading = re.match(r"^(#{1,3})\s+(.+)$", line)
+    if not heading:
+        return False
+    close_blocks(body, states)
+    level = len(heading.group(1))
+    title = heading.group(2).strip()
+    anchor = slug(title)
+    headings.append((level, title, anchor))
+    body.append(f'<h{level} id="{anchor}">{inline_markup(title)}</h{level}>')
+    return True
+
+
+def handle_table(line: str, body: list[str], states: dict[str, bool]) -> bool:
+    if not line.startswith("|") or not line.endswith("|"):
+        return False
+    cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
+    raw_cells = [html.unescape(cell) for cell in cells]
+    if all(re.match(r"^:?-{3,}:?$", cell) for cell in raw_cells):
+        return True
+    if not states["table"]:
+        close_blocks(body, states)
+        body.append("<table><tbody>")
+        states["table"] = True
+    body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
+    return True
+
+
+def handle_list(line: str, body: list[str], states: dict[str, bool]) -> bool:
+    if not line.startswith(("- ", "* ")):
+        return False
+    if not states["list"]:
+        close_blocks(body, states)
+        body.append("<ul>")
+        states["list"] = True
+    body.append(f"<li>{inline_markup(line[2:].strip())}</li>")
+    return True
+
+
+def handle_paragraph(line: str, body: list[str], states: dict[str, bool]) -> None:
+    close_blocks(body, states)
+    if line.lower().startswith(("source:", "source card:")):
+        body.append(f'<aside class="source-card">{inline_markup(line)}</aside>')
+        return
+    body.append(f"<p>{inline_markup(line)}</p>")
+
+
+def handle_markdown_line(
+    line: str,
+    headings: list[tuple[int, str, str]],
+    body: list[str],
+    states: dict[str, bool],
+) -> None:
+    if handle_heading(line, headings, body, states):
+        return
+    if handle_table(line, body, states):
+        return
+    if handle_list(line, body, states):
+        return
+    handle_paragraph(line, body, states)
+
+
+def render_markdown(text: str) -> tuple[list[tuple[int, str, str]], str]:
+    validate_markdown_badges(text)
+    headings: list[tuple[int, str, str]] = []
+    body: list[str] = []
+    states = {"list": False, "table": False}
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        handle_markdown_line(line, headings, body, states) if line else close_blocks(body, states)
+    close_blocks(body, states)
+    return headings, "\n".join(body)

--- a/.agents/scripts/report_render_markup.py
+++ b/.agents/scripts/report_render_markup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Shared inline markup helpers for report rendering."""
+
+from __future__ import annotations
+
+import html
+import re
+
+from report_render_badges import badge_html
+
+
+def slug(text: str) -> str:
+    value = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return value or "section"
+
+
+def inline_markup(text: str) -> str:
+    escaped = html.escape(text)
+    escaped = re.sub(
+        r"\{\{\s*evidence\s*:\s*([^}]+?)\s*\}\}",
+        lambda match: badge_html(html.unescape(match.group(1))),
+        escaped,
+        flags=re.I,
+    )
+    escaped = re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
+    return re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)

--- a/.agents/scripts/tests/fixtures/llm-visibility-report-sample.json
+++ b/.agents/scripts/tests/fixtures/llm-visibility-report-sample.json
@@ -1,0 +1,42 @@
+{
+  "title": "LLM Visibility Report",
+  "sections": [
+    {
+      "title": "Executive Summary",
+      "summary": "The site appears in AI Overviews and answer-engine citations for priority service prompts.",
+      "items": [
+        {
+          "title": "AIO",
+          "detail": "Cited with a source card from the readiness run.",
+          "evidence_badge": "verified"
+        },
+        {
+          "title": "Gemini",
+          "detail": "Partial citation coverage across the sampled prompts.",
+          "evidence_badge": "partial"
+        },
+        {
+          "title": "ChatGPT",
+          "detail": "Opportunity inferred from comparable prompts and source IDs.",
+          "evidence_badge": "inferred"
+        },
+        {
+          "title": "Perplexity",
+          "detail": "No citation surfaced for the target prompt group.",
+          "evidence_badge": "missing"
+        }
+      ]
+    },
+    {
+      "title": "Roadmap",
+      "summary": "Add source cards, rerun readiness, then export the rendered HTML to PDF.",
+      "items": [
+        {
+          "title": "Source cards",
+          "detail": "Attach prompt, engine, URL, and capture references to each material claim.",
+          "evidence_badge": "verified"
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/llm-visibility-report-sample.md
+++ b/.agents/scripts/tests/fixtures/llm-visibility-report-sample.md
@@ -1,0 +1,46 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# LLM Visibility Report
+
+## Executive Summary
+
+The site appears in AI Overviews and answer-engine citations for priority service prompts. {{evidence:verified}}
+
+## Method
+
+- Run SEO AI readiness across AIO, Gemini, ChatGPT, AI Mode, and Perplexity.
+- Capture prompts, source IDs, screenshots, crawl exports, and remediation notes.
+
+## Weighted Scorecard
+
+| Component | Score | Badge |
+|---|---:|---|
+| AIO | 82 | {{evidence:verified}} |
+| Gemini | 74 | {{evidence:partial}} |
+| ChatGPT | 68 | {{evidence:inferred}} |
+| AI Mode | 51 | {{evidence:partial}} |
+| Perplexity | 0 | {{evidence:missing}} |
+
+## Page-Type Findings
+
+- Product detail pages include source-backed claims. {{evidence:verified}}
+- Comparison pages need stronger evidence cards. {{evidence:partial}}
+- Research pages have inferred opportunity clusters. {{evidence:inferred}}
+
+## Evidence Ledger
+
+Source: AIO capture and crawl export for priority prompts.
+Source card: Gemini citation export and manual verification worksheet.
+Source: ChatGPT prompt transcript with source IDs.
+Source card: Perplexity query set showing missing citation coverage.
+
+## Roadmap
+
+- Add cited source cards to weak pages.
+- Rerun `/seo-ai-readiness example.com` after remediation.
+
+## Verification
+
+- Render this Markdown fixture to HTML.
+- Print or export the HTML to PDF from the browser print dialog.

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SH="${SCRIPT_DIR}/../report-render-helper.sh"
+FIXTURE_DIR="${SCRIPT_DIR}/fixtures"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local _test_name="$1"
+	local _passed="$2"
+	local _message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$_passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$_test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$_test_name"
+	if [[ -n "$_message" ]]; then
+		printf '       %s\n' "$_message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local _file="$1"
+	local _needle="$2"
+	local _label="$3"
+	if grep -qF "$_needle" "$_file"; then
+		print_result "$_label" 0
+		return 0
+	fi
+	print_result "$_label" 1 "Missing '${_needle}' in ${_file}"
+	return 0
+}
+
+test_render_markdown_fixture() {
+	local _out="${TEST_ROOT}/sample-md.html"
+	"$HELPER_SH" render "${FIXTURE_DIR}/llm-visibility-report-sample.md" --output "$_out"
+	assert_contains "$_out" "sticky-toc" "Markdown render includes sticky TOC"
+	assert_contains "$_out" "@media print" "Markdown render includes print CSS"
+	assert_contains "$_out" "Evidence: Verified" "Markdown render includes verified badge"
+	assert_contains "$_out" "Evidence: Partial" "Markdown render includes partial badge"
+	assert_contains "$_out" "Evidence: Inferred" "Markdown render includes inferred badge"
+	assert_contains "$_out" "Evidence: Missing" "Markdown render includes missing badge"
+	assert_contains "$_out" "source-card" "Markdown render includes source cards"
+	return 0
+}
+
+test_render_json_fixture() {
+	local _out="${TEST_ROOT}/sample-json.html"
+	"$HELPER_SH" render "${FIXTURE_DIR}/llm-visibility-report-sample.json" --output "$_out"
+	assert_contains "$_out" "sticky-toc" "JSON render includes sticky TOC"
+	assert_contains "$_out" "@media print" "JSON render includes print CSS"
+	assert_contains "$_out" "Evidence: Verified" "JSON render includes verified badge"
+	assert_contains "$_out" "Evidence: Partial" "JSON render includes partial badge"
+	assert_contains "$_out" "Evidence: Inferred" "JSON render includes inferred badge"
+	assert_contains "$_out" "Evidence: Missing" "JSON render includes missing badge"
+	assert_contains "$_out" "source-card" "JSON render includes source cards"
+	return 0
+}
+
+test_validate_rejects_unknown_badge() {
+	local _bad="${TEST_ROOT}/bad.md"
+	printf '# Bad\n\n{{evidence:unknown}}\n' >"$_bad"
+	local _result=0
+	"$HELPER_SH" validate "$_bad" >/dev/null 2>&1 || _result=$?
+	if [[ "$_result" -ne 1 ]]; then
+		print_result "Validate rejects unknown badge" 1 "Expected exit 1, got ${_result}"
+		return 0
+	fi
+	print_result "Validate rejects unknown badge" 0
+	return 0
+}
+
+test_sample_and_css_commands() {
+	local _sample="${TEST_ROOT}/sample.md"
+	local _css="${TEST_ROOT}/print.css"
+	"$HELPER_SH" sample markdown >"$_sample"
+	"$HELPER_SH" print-css >"$_css"
+	assert_contains "$_sample" "{{evidence:verified}}" "Sample command emits Markdown report"
+	assert_contains "$_css" "@media print" "print-css emits print stylesheet"
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	test_render_markdown_fixture
+	test_render_json_fixture
+	test_validate_rejects_unknown_badge
+	test_sample_and_css_commands
+	printf '\nReport render helper tests: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/tools/document/document-creation.md
+++ b/.agents/tools/document/document-creation.md
@@ -27,6 +27,7 @@ tools:
 - **Commands**: `convert`, `create`, `template`, `install`, `formats`, `status`
 - **OCR**: Auto-detects scanned PDFs; supports Tesseract, EasyOCR, GLM-OCR, Vision LLM
 - **Formats**: ODT, DOCX, PDF, MD, HTML, EPUB, PPTX, ODP, XLSX, ODS, RTF, CSV, TSV
+- **Report rendering**: `scripts/report-render-helper.sh render report.md --output report.html` keeps Markdown canonical and creates browser/PDF-ready HTML with sticky TOC, print CSS, source cards, and evidence badges
 
 ```bash
 document-creation-helper.sh status                                    # check tools
@@ -38,6 +39,7 @@ document-creation-helper.sh create template.odt --data fields.json --output lett
 document-creation-helper.sh formats                                   # list supported conversions
 document-creation-helper.sh template list
 document-creation-helper.sh template draft --type letter --format odt
+report-render-helper.sh render report.md --output report.html         # report-ready HTML/PDF handoff
 ```
 
 <!-- AI-CONTEXT-END -->
@@ -62,6 +64,9 @@ document-creation-helper.sh template draft --type letter --format odt
     +-- Generate draft template
         +-- Collect: format, fields, header/footer, logo
         +-- Generate with odfpy/python-docx → user refines in editor
+    |
+    +-- Render report-ready Markdown/JSON for PDF handoff
+        +-- Validate evidence badges → render HTML → browser print/export PDF
 ```
 
 ## Architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add report renderer helper, fixtures, command docs, and end-to-end AI search report workflow (#24003)
+
 ## [3.17.29] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.17.24] - 2026-05-21
 
 ### Changed
@@ -132,7 +131,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.17.18] - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The result: an AI operations platform that manages projects across every busines
 - `/design-artifact` - Route artifact-first UI, deck, email, poster, and mobile mockup work
 - `/open-design` - Manage the optional Open Design companion studio
 - `/auto-browse` - Learn, optimize, and graduate repeatable browser operations and web data-mining workflows
+- `/report-render` - Render report-ready Markdown or JSON to HTML with sticky TOC, print CSS, evidence badges, and source cards for PDF export
 
 ### Agent Structure
 
@@ -131,6 +132,17 @@ The result: an AI operations platform that manages projects across every busines
 ## **Enterprise-Grade Quality & Security**
 
 **Comprehensive DevOps framework with tried & tested services integrations, popular and trusted MCP servers, and enterprise-grade infrastructure quality assurance code monitoring and recommendations.**
+
+### Report-ready AI search workflow
+
+Use aidevops to turn AI search readiness work into a client-ready report without making HTML the source of truth:
+
+1. Run `/seo-ai-readiness example.com` for the domain or priority URLs.
+2. Request report-ready output with executive summary, method, scorecard, page-type findings, evidence ledger, roadmap, verification, and source IDs.
+3. Save the Markdown or JSON report, then render it with `/report-render report.md` or `report-render-helper.sh render report.md --output report.html`.
+4. Review the generated HTML for sticky table of contents, source cards, print CSS, and `verified`, `partial`, `inferred`, or `missing` evidence badges.
+5. Export or print the HTML to PDF from the browser print dialog.
+6. After remediation, rerun `/seo-ai-readiness` and render the updated report for before/after comparison.
 
 ## **Security Notice**
 


### PR DESCRIPTION
## Summary

- Add report-render helper with render, validate, sample, and print-css subcommands
- Render Markdown/JSON report inputs to portable HTML with sticky TOC, print CSS, evidence badges, and source cards
- Add fixtures, regression tests, /report-render command docs, README workflow, and document-creation routing notes

## Verification

- `shellcheck .agents/scripts/report-render-helper.sh .agents/scripts/tests/test-report-render-helper.sh`
- `bash -n .agents/scripts/report-render-helper.sh`
- `bash .agents/scripts/tests/test-report-render-helper.sh` — 17 run, 0 failed
- `python3 -m py_compile .agents/scripts/report-render-helper.py`
- `rg "<local-path>/Downloads" README.md CHANGELOG.md .agents/tools/document/document-creation.md .agents/scripts/commands/report-render.md` — no matches
- `.agents/scripts/linters-local.sh` — passed; advisory pre-existing Qlty/ratchet/complexity warnings reported by the gate

Resolves #24003

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6m and 68,500 tokens on this as a headless worker.