### PR TITLE
GH#24016: fix: upgrade mismatched rtk setup

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -313,6 +313,59 @@ setup_file_discovery_tools() {
 	return 0
 }
 
+_setup_rtk_installed_version() {
+	local rtk_version="unknown"
+	rtk_version=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || printf 'unknown')
+	printf '%s\n' "$rtk_version"
+	return 0
+}
+
+_setup_rtk_install_supported_version() {
+	local rtk_installer_url="$1"
+	local rtk_supported_version="$2"
+	VERIFIED_INSTALL_SHELL="sh"
+
+	if command -v brew >/dev/null 2>&1; then
+		if run_with_spinner "Upgrading rtk via Homebrew" brew upgrade rtk; then
+			print_success "rtk upgraded via Homebrew"
+			return 0
+		fi
+		print_warning "Homebrew upgrade failed, trying pinned installer..."
+	fi
+
+	if verified_install "rtk" "$rtk_installer_url"; then
+		print_success "rtk installed to ~/.local/bin/rtk (v${rtk_supported_version})"
+		return 0
+	fi
+
+	print_warning "rtk upgrade failed (non-critical, optional tool)"
+	return 1
+}
+
+_setup_rtk_print_manual_install() {
+	local rtk_installer_url="$1"
+	echo "  Manual install: brew upgrade rtk  OR  curl -fsSL $rtk_installer_url | sh"
+	return 0
+}
+
+_setup_rtk_offer_supported_upgrade() {
+	local rtk_version="$1"
+	local rtk_supported_version="$2"
+	local rtk_installer_url="$3"
+
+	print_warning "rtk version mismatch: found v${rtk_version}, aidevops supports v${rtk_supported_version}"
+	setup_prompt upgrade_rtk "Upgrade rtk to the aidevops-tested v${rtk_supported_version}? [Y/n]: " "Y"
+	# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
+	if [[ "$upgrade_rtk" =~ ^[Yy]?$ ]]; then
+		_setup_rtk_install_supported_version "$rtk_installer_url" "$rtk_supported_version"
+		return $?
+	fi
+
+	print_info "Skipped rtk upgrade"
+	_setup_rtk_print_manual_install "$rtk_installer_url"
+	return 1
+}
+
 setup_rtk() {
 	# rtk — CLI proxy that reduces LLM token consumption by 60-90% (t1430)
 	# Opinionated default optimization: compresses git/gh/test outputs before they reach LLM context
@@ -326,11 +379,18 @@ setup_rtk() {
 
 	if command -v rtk >/dev/null 2>&1; then
 		local rtk_version
-		rtk_version=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+		rtk_version=$(_setup_rtk_installed_version)
 		print_success "rtk found: v$rtk_version (token optimization proxy)"
-		if [[ "$rtk_version" != "unknown" && "$rtk_version" != "$rtk_supported_version" ]]; then
-			print_info "rtk supported by this aidevops release: v$rtk_supported_version"
-			print_info "Run 'brew upgrade rtk' or re-run setup if you want the pinned aidevops-tested version."
+		if [[ "$rtk_version" != "$rtk_supported_version" ]]; then
+			if _setup_rtk_offer_supported_upgrade "$rtk_version" "$rtk_supported_version" "$rtk_installer_url"; then
+				rtk_version=$(_setup_rtk_installed_version)
+				if [[ "$rtk_version" == "$rtk_supported_version" ]]; then
+					print_success "rtk now matches the aidevops-tested version"
+				else
+					print_warning "rtk still reports v${rtk_version}; aidevops supports v${rtk_supported_version}"
+					_setup_rtk_print_manual_install "$rtk_installer_url"
+				fi
+			fi
 		fi
 		# Fall through to ensure config is applied (telemetry, tee)
 	else
@@ -366,7 +426,7 @@ setup_rtk() {
 			fi
 		else
 			print_info "Skipped rtk installation"
-			echo "  Manual install: brew install rtk  OR  curl -fsSL $rtk_installer_url | sh"
+			_setup_rtk_print_manual_install "$rtk_installer_url"
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-tool-install-rtk.sh
+++ b/.agents/scripts/tests/test-tool-install-rtk.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOL_INSTALL="$REPO_ROOT/.agents/scripts/setup/modules/tool-install.sh"
+
+SANDBOX="$(mktemp -d -t tool-install-rtk-XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+mkdir -p "$SANDBOX/bin" "$SANDBOX/home"
+export HOME="$SANDBOX/home"
+export PATH="$SANDBOX/bin:$PATH"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local desc="$1" expected="$2" actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $desc"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	echo "  FAIL: $desc -- expected '$expected', got '$actual'" >&2
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+extract_functions() {
+	awk '
+		/^_setup_rtk_installed_version\(\)/, /^}$/ { print; next }
+		/^_setup_rtk_install_supported_version\(\)/, /^}$/ { print; next }
+		/^_setup_rtk_print_manual_install\(\)/, /^}$/ { print; next }
+		/^_setup_rtk_offer_supported_upgrade\(\)/, /^}$/ { print; next }
+		/^setup_rtk\(\)/, /^}$/ { print; next }
+	' "$TOOL_INSTALL" >"$SANDBOX/extract.sh"
+	if ! grep -q '^_setup_rtk_offer_supported_upgrade()' "$SANDBOX/extract.sh"; then
+		echo "FAIL: extraction did not capture rtk upgrade helpers" >&2
+		exit 1
+	fi
+	return 0
+}
+
+source_extracted() {
+	# shellcheck disable=SC2317
+	print_info() { echo "INFO: $*"; return 0; }
+	# shellcheck disable=SC2317
+	print_success() { echo "OK: $*"; return 0; }
+	# shellcheck disable=SC2317
+	print_warning() { echo "WARN: $*"; return 0; }
+	# shellcheck disable=SC2317
+	setup_prompt() {
+		local var_name="$1"
+		local prompt_text="$2"
+		local default_value="$3"
+		: "$prompt_text"
+		printf -v "$var_name" '%s' "$default_value"
+		return 0
+	}
+	# shellcheck disable=SC2317
+	run_with_spinner() { shift; "$@"; return $?; }
+	# shellcheck disable=SC2317
+	verified_install() {
+		local tool_name="$1"
+		local installer_url="$2"
+		: "$tool_name" "$installer_url"
+		cat >"$SANDBOX/bin/rtk" <<'INNER_EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "rtk 0.41.0"
+INNER_EOF
+		chmod +x "$SANDBOX/bin/rtk"
+		return 0
+	}
+	# shellcheck disable=SC1090
+	source "$SANDBOX/extract.sh"
+	return 0
+}
+
+extract_functions
+
+cat >"$SANDBOX/bin/rtk" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "rtk 0.40.0"
+EOF
+chmod +x "$SANDBOX/bin/rtk"
+
+(
+	source_extracted
+	setup_rtk
+) >"$SANDBOX/out" 2>&1
+
+assert_eq "existing mismatched rtk is upgraded" "rtk 0.41.0" "$(rtk --version)"
+assert_eq "setup reports matching version" "1" "$(grep -c 'rtk now matches the aidevops-tested version' "$SANDBOX/out")"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	echo "FAIL: $FAIL rtk setup checks failed" >&2
+	exit 1
+fi
+
+echo "PASS: $PASS rtk setup checks passed"
+exit 0


### PR DESCRIPTION
## Summary
- Update setup_rtk to offer/default an upgrade when an installed rtk version differs from the aidevops-tested v0.41.0.
- Fall back to the pinned installer and re-check the reported version after upgrade.
- Add a targeted shell test for upgrading an existing mismatched rtk binary.

## Testing
- .agents/scripts/tests/test-tool-install-rtk.sh
- shellcheck .agents/scripts/setup/modules/tool-install.sh .agents/scripts/tests/test-tool-install-rtk.sh

Resolves #24016

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 71,718 tokens on this as a headless worker.