### PR TITLE
GH#24018: docs: register report outputs contract

### DIFF
--- a/.agents/reports.md
+++ b/.agents/reports.md
@@ -11,6 +11,7 @@ subagents:
   - citations
   - exporters
   - routine-handoff
+  - outputs
 ---
 
 <!-- SPDX-License-Identifier: MIT -->

--- a/.agents/reports/outputs.md
+++ b/.agents/reports/outputs.md
@@ -1,3 +1,9 @@
+---
+description: Repo-local _reports artifact layout and privacy contract
+agent: Reports
+mode: subagent
+---
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 


### PR DESCRIPTION
## Summary

Registered reports/outputs.md as a reports subagent and added matching frontmatter so the shared _reports/ contract referenced by reports.md, citations.md, and exporters.md is loadable.

## Files Changed

.agents/reports.md,.agents/reports/outputs.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint .agents/reports.md .agents/reports/outputs.md; python3 .agents/scripts/lib/subagent_validation.py .agents/reports.md .agents/reports/outputs.md; .agents/scripts/secretlint-helper.sh scan .agents/reports.md stylish; .agents/scripts/secretlint-helper.sh scan .agents/reports/outputs.md stylish

Resolves #24018


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 9m and 45,296 tokens on this as a headless worker.