### PR TITLE
GH#24017: harden report renderer parsing

### DIFF
--- a/.agents/scripts/report-render-helper.py
+++ b/.agents/scripts/report-render-helper.py
@@ -17,6 +17,10 @@ from report_render_badges import BADGE_VERIFIED
 from report_render_json import DETAIL_KEY, SUMMARY_KEY, TITLE_KEY, render_json, validate_json_badges
 from report_render_markdown import render_markdown, validate_markdown_badges
 
+if len(sys.argv) < 2:
+    sys.stderr.write(f"Usage: {sys.argv[0]} <mode> [input]\n")
+    sys.exit(1)
+
 MODE = sys.argv[1]
 INPUT = sys.argv[2] if len(sys.argv) > 2 else ""
 CSS = """
@@ -110,7 +114,7 @@ def main() -> int:
             validate_markdown_badges(text)
         return 0
     stripped = text.lstrip()
-    headings, body = render_json(text) if stripped.startswith("{") else render_markdown(text)
+    headings, body = render_json(text) if stripped.startswith(("{", "[")) else render_markdown(text)
     sys.stdout.write(wrap_document(headings, body))
     return 0
 

--- a/.agents/scripts/report_render_json.py
+++ b/.agents/scripts/report_render_json.py
@@ -39,13 +39,16 @@ def append_json_section(
     body: list[str],
     section: dict[str, Any],
 ) -> None:
+    if not isinstance(section, dict):
+        return
     section_title = section.get(TITLE_KEY, "Section")
     headings.append((2, section_title, slug(section_title)))
     body.append(f'<h2 id="{slug(section_title)}">{inline_markup(section_title)}</h2>')
     if section.get(SUMMARY_KEY):
         body.append(f"<p>{inline_markup(str(section[SUMMARY_KEY]))}</p>")
     for item in section.get("items", []):
-        append_json_item(body, item)
+        if isinstance(item, dict):
+            append_json_item(body, item)
 
 
 def render_json(text: str) -> tuple[list[tuple[int, str, str]], str]:
@@ -56,6 +59,7 @@ def render_json(text: str) -> tuple[list[tuple[int, str, str]], str]:
     title = data.get(TITLE_KEY, "Report") if isinstance(data, dict) else "Report"
     headings.append((1, title, slug(title)))
     body.append(f'<h1 id="{slug(title)}">{inline_markup(title)}</h1>')
-    for section in data.get("sections", []):
+    sections = data.get("sections", []) if isinstance(data, dict) else []
+    for section in sections:
         append_json_section(headings, body, section)
     return headings, "\n".join(body)

--- a/.agents/scripts/report_render_markdown.py
+++ b/.agents/scripts/report_render_markdown.py
@@ -5,11 +5,12 @@
 
 from __future__ import annotations
 
-import html
 import re
 
 from report_render_badges import badge_html
 from report_render_markup import inline_markup, slug
+
+BlockState = dict[str, bool | list[str]]
 
 
 def validate_markdown_badges(text: str) -> None:
@@ -17,18 +18,27 @@ def validate_markdown_badges(text: str) -> None:
         badge_html(match.group(1))
 
 
-def close_blocks(body: list[str], states: dict[str, bool]) -> None:
+def close_blocks(body: list[str], states: BlockState) -> None:
+    flush_paragraph(body, states)
     for key, tag in (("list", "</ul>"), ("table", "</tbody></table>")):
         if states[key]:
             body.append(tag)
             states[key] = False
 
 
+def flush_paragraph(body: list[str], states: BlockState) -> None:
+    paragraph_lines = states["paragraph"]
+    if not isinstance(paragraph_lines, list) or not paragraph_lines:
+        return
+    body.append(f"<p>{inline_markup(' '.join(paragraph_lines))}</p>")
+    states["paragraph"] = []
+
+
 def handle_heading(
     line: str,
     headings: list[tuple[int, str, str]],
     body: list[str],
-    states: dict[str, bool],
+    states: BlockState,
 ) -> bool:
     heading = re.match(r"^(#{1,3})\s+(.+)$", line)
     if not heading:
@@ -42,22 +52,25 @@ def handle_heading(
     return True
 
 
-def handle_table(line: str, body: list[str], states: dict[str, bool]) -> bool:
+def handle_table(line: str, body: list[str], states: BlockState) -> bool:
     if not line.startswith("|") or not line.endswith("|"):
         return False
-    cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
-    raw_cells = [html.unescape(cell) for cell in cells]
+    raw_cells = [cell.strip() for cell in line.strip("|").split("|")]
     if all(re.match(r"^:?-{3,}:?$", cell) for cell in raw_cells):
         return True
+    cells = [inline_markup(cell) for cell in raw_cells]
     if not states["table"]:
         close_blocks(body, states)
-        body.append("<table><tbody>")
+        body.append("<table><thead>")
+        body.append("<tr>{}</tr>".format("".join(f"<th>{cell}</th>" for cell in cells)))
+        body.append("</thead><tbody>")
         states["table"] = True
+        return True
     body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
     return True
 
 
-def handle_list(line: str, body: list[str], states: dict[str, bool]) -> bool:
+def handle_list(line: str, body: list[str], states: BlockState) -> bool:
     if not line.startswith(("- ", "* ")):
         return False
     if not states["list"]:
@@ -68,19 +81,23 @@ def handle_list(line: str, body: list[str], states: dict[str, bool]) -> bool:
     return True
 
 
-def handle_paragraph(line: str, body: list[str], states: dict[str, bool]) -> None:
-    close_blocks(body, states)
+def handle_paragraph(line: str, body: list[str], states: BlockState) -> None:
+    if states["list"] or states["table"]:
+        close_blocks(body, states)
     if line.lower().startswith(("source:", "source card:")):
+        flush_paragraph(body, states)
         body.append(f'<aside class="source-card">{inline_markup(line)}</aside>')
         return
-    body.append(f"<p>{inline_markup(line)}</p>")
+    paragraph_lines = states["paragraph"]
+    if isinstance(paragraph_lines, list):
+        paragraph_lines.append(line)
 
 
 def handle_markdown_line(
     line: str,
     headings: list[tuple[int, str, str]],
     body: list[str],
-    states: dict[str, bool],
+    states: BlockState,
 ) -> None:
     if handle_heading(line, headings, body, states):
         return
@@ -95,7 +112,7 @@ def render_markdown(text: str) -> tuple[list[tuple[int, str, str]], str]:
     validate_markdown_badges(text)
     headings: list[tuple[int, str, str]] = []
     body: list[str] = []
-    states = {"list": False, "table": False}
+    states = {"list": False, "table": False, "paragraph": []}
     for raw_line in text.splitlines():
         line = raw_line.rstrip()
         handle_markdown_line(line, headings, body, states) if line else close_blocks(body, states)

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -96,6 +96,57 @@ test_validate_rejects_unknown_badge() {
 	return 0
 }
 
+test_python_helper_requires_mode() {
+	local _result=0
+	python3 "${SCRIPT_DIR}/../report-render-helper.py" >/dev/null 2>&1 || _result=$?
+	if [[ "$_result" -ne 1 ]]; then
+		print_result "Python helper requires mode argument" 1 "Expected exit 1, got ${_result}"
+		return 0
+	fi
+	print_result "Python helper requires mode argument" 0
+	return 0
+}
+
+test_markdown_table_uses_header_cells() {
+	local _input="${TEST_ROOT}/table.md"
+	local _out="${TEST_ROOT}/table.html"
+	cat >"$_input" <<'MARKDOWN'
+# Table
+
+| Component | Evidence |
+|---|---|
+| AIO | {{evidence:verified}} |
+MARKDOWN
+	"$HELPER_SH" render "$_input" --output "$_out"
+	assert_contains "$_out" "<thead>" "Markdown table renders thead"
+	assert_contains "$_out" "<th>Component</th>" "Markdown table renders header cells"
+	assert_contains "$_out" "<td>AIO</td>" "Markdown table renders body cells"
+	return 0
+}
+
+test_multiline_markdown_paragraph() {
+	local _input="${TEST_ROOT}/paragraph.md"
+	local _out="${TEST_ROOT}/paragraph.html"
+	cat >"$_input" <<'MARKDOWN'
+# Paragraph
+
+First line continues
+onto the next line.
+MARKDOWN
+	"$HELPER_SH" render "$_input" --output "$_out"
+	assert_contains "$_out" "<p>First line continues onto the next line.</p>" "Markdown joins paragraph lines"
+	return 0
+}
+
+test_render_json_array_is_resilient() {
+	local _input="${TEST_ROOT}/array.json"
+	local _out="${TEST_ROOT}/array.html"
+	printf '[{"title":"List item","badge":"verified"}]\n' >"$_input"
+	"$HELPER_SH" render "$_input" --output "$_out"
+	assert_contains "$_out" "<h1 id=\"report\">Report</h1>" "JSON array render falls back to report title"
+	return 0
+}
+
 test_sample_and_css_commands() {
 	local _sample="${TEST_ROOT}/sample.md"
 	local _css="${TEST_ROOT}/print.css"
@@ -112,6 +163,10 @@ main() {
 	test_render_markdown_fixture
 	test_render_json_fixture
 	test_validate_rejects_unknown_badge
+	test_python_helper_requires_mode
+	test_markdown_table_uses_header_cells
+	test_multiline_markdown_paragraph
+	test_render_json_array_is_resilient
 	test_sample_and_css_commands
 	printf '\nReport render helper tests: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Added defensive mode validation, Markdown table headers, multiline paragraph joining, and JSON array resilience for the report renderer.

## Files Changed

.agents/scripts/report-render-helper.py,.agents/scripts/report_render_json.py,.agents/scripts/report_render_markdown.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-render-helper.sh; python3 -m py_compile .agents/scripts/report-render-helper.py .agents/scripts/report_render_markdown.py .agents/scripts/report_render_json.py; shellcheck .agents/scripts/tests/test-report-render-helper.sh .agents/scripts/report-render-helper.sh

Resolves #24017


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 9m and 70,271 tokens on this as a headless worker.