### PR TITLE
GH#24015: docs: finish RTK status clarification

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -60,9 +60,10 @@ Use comparison results to classify a command:
   exact evidence/security/JSON/diff semantics are required.
 - `git status` expansion is a regression signal: RTK v0.41.0 dropped the
   compact-status `-uall` flag, so tracked-file paths remain visible while
-  untracked directories stay summarized at the same directory level raw
-  `git status --short` would show; rerun raw status and verify RTK version when
-  comparison shows expansion.
+  untracked directories stay summarized as they appear in raw
+  `git status --short` output. Rerun raw status and verify RTK version when
+  comparison shows expansion, because older RTK versions still use the noisier
+  compact-status path.
 
 ## Always bypass RTK
 


### PR DESCRIPTION
## Summary
- Clarify RTK `git status` guidance so untracked directory summarization is described as raw `git status --short` behavior.
- Add fallback guidance to verify RTK version when older compact-status behavior expands output.

## Testing
- `.agents/scripts/linters-local.sh` (passed; historical advisory debt only)

Follow-up for #24015 after #24032 merged before this second review-feedback clarification landed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 9m and 73,760 tokens on this as a headless worker.
