### PR TITLE
fix: replace PR 23885 dashboard staleness fixes

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -273,6 +273,11 @@ _rest_should_fallback() {
 			remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
 		fi
 	fi
+	# When the rate_limit query itself fails, remaining is empty. Treat that as
+	# exhausted so supported calls can move to REST instead of skipping fallback.
+	if [[ -z "$remaining" ]]; then
+		return 0
+	fi
 	[[ "$remaining" =~ ^[0-9]+$ ]] || return 1
 	_GH_LAST_GRAPHQL_REMAINING="$remaining"
 	if [[ "$remaining" -le "$_GH_REST_FALLBACK_THRESHOLD" ]]; then

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -113,16 +113,25 @@ _check_health_issue_activity_guard() {
 
 	guard_pr_count=$(gh_pr_list --repo "$repo_slug" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
+	if ! [[ "$guard_pr_count" =~ ^[0-9]+$ ]]; then
+		guard_pr_count="0"
+	fi
 	[[ "${guard_pr_count:-0}" -gt 0 ]] && return 0
 
 	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
 		--assignee "$runner_user" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
+	if ! [[ "$guard_assigned_count" =~ ^[0-9]+$ ]]; then
+		guard_assigned_count="0"
+	fi
 	[[ "${guard_assigned_count:-0}" -gt 0 ]] && return 0
 
 	guard_auto_dispatch_count=$(gh_issue_list --repo "$repo_slug" \
 		--label "auto-dispatch" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
+	if ! [[ "$guard_auto_dispatch_count" =~ ^[0-9]+$ ]]; then
+		guard_auto_dispatch_count="0"
+	fi
 	[[ "${guard_auto_dispatch_count:-0}" -gt 0 ]] && return 0
 
 	echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, assigned issues, auto-dispatch work, or workers" \
@@ -214,7 +223,11 @@ _update_health_issue_for_repo() {
 		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
 	fi
 
-	echo "$health_issue_number" >"$health_issue_file"
+	# Cache only the trailing issue number. The resolver may emit warnings before
+	# the value, and a multi-line cache makes later dashboard updates stale.
+	local cache_issue_number
+	cache_issue_number=$(printf '%s\n' "$health_issue_number" | awk 'match($0, /[0-9]+$/) { value=substr($0, RSTART, RLENGTH) } END { if (value != "") print value }')
+	echo "$cache_issue_number" >"$health_issue_file"
 
 	local now_iso
 	now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -232,7 +245,7 @@ _update_health_issue_for_repo() {
 	# Bare `gh issue edit` always uses GraphQL and silently fails the body
 	# update when the 5000/hr GraphQL budget is exhausted, leaving the
 	# dashboard stale until the budget resets (up to 1h). GH#33.
-	body_edit_stderr=$(gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" \
+	body_edit_stderr=$(_gh_with_timeout write gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" \
 		--body "$body" 2>&1 >/dev/null) || {
 		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" \
 			>>"$LOGFILE"
@@ -295,6 +308,8 @@ update_health_issues() {
 	# This avoids N×N git log walks (one cross-repo scan per repo dashboard)
 	# and redundant DB queries for session time.
 	# Person stats read from cache (refreshed hourly by _refresh_person_stats_cache).
+	# Skip the optional cross-repo summaries above 30 repos; the contributor
+	# activity helper can time out at that scale and stall the dashboard refresh.
 	local cross_repo_md=""
 	local cross_repo_session_time_md=""
 	local cross_repo_person_stats_md=""
@@ -307,9 +322,9 @@ update_health_issues() {
 			while IFS= read -r rp; do
 				[[ -n "$rp" ]] && cross_args+=("$rp")
 			done <<<"$all_repo_paths"
-			if [[ ${#cross_args[@]} -gt 1 ]]; then
-				cross_repo_md=$(bash "$activity_helper" cross-repo-summary "${cross_args[@]}" --period month --format markdown || echo "_Cross-repo data unavailable._")
-				cross_repo_session_time_md=$(bash "$activity_helper" cross-repo-session-time "${cross_args[@]}" --period all --format markdown || echo "_Cross-repo session data unavailable._")
+			if [[ ${#cross_args[@]} -gt 1 && ${#cross_args[@]} -le 30 ]]; then
+				cross_repo_md=$(timeout 120 bash "$activity_helper" cross-repo-summary "${cross_args[@]}" --period month --format markdown || echo "_Cross-repo data unavailable._")
+				cross_repo_session_time_md=$(timeout 120 bash "$activity_helper" cross-repo-session-time "${cross_args[@]}" --period all --format markdown || echo "_Cross-repo session data unavailable._")
 			fi
 		fi
 	fi


### PR DESCRIPTION
## Summary

Maintainer-owned replacement for #23885. The contributor PR is from an untrusted fork and is blocked only by `Maintainer Review & Assignee Gate` with `needs-maintainer-review`; all code-quality checks on #23885 passed.

This branch carries the consolidated supervisor health dashboard staleness fixes without pushing to the contributor branch:

- validate numeric activity-guard counts before integer comparisons
- keep `auto-dispatch` issues in the health-issue creation guard
- cache only the trailing health issue number when resolver output is noisy
- wrap the dashboard body edit in `_gh_with_timeout write`
- skip optional cross-repo summary generation above 30 repos and bound the helper calls with `timeout 120`
- route REST-supported GitHub wrapper calls to fallback when `gh api rate_limit` itself returns no GraphQL remaining value

Refs #23885.
Refs #23880.
Refs #23884.

## Verification

- `shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh`
- `bash -n .agents/scripts/stats-health-dashboard.sh .agents/scripts/shared-gh-wrappers-rest-fallback.sh`
- `.agents/scripts/secretlint-helper.sh scan .agents/scripts/stats-health-dashboard.sh stylish`
- `.agents/scripts/secretlint-helper.sh scan .agents/scripts/shared-gh-wrappers-rest-fallback.sh stylish`
- `.agents/scripts/linters-local.sh` partially completed through Sonar/Qlty/string-literal/FD-lock/shellcheckrc gates, then timed out during repo-wide Secretlint at 240s; changed-file Secretlint scans passed.

## Notes

Original PR #23885 failing checks diagnosed with `gh pr checks 23885 --repo marcusquinn/aidevops`: only `Maintainer Review & Assignee Gate` / `maintainer-gate` failed, both reporting `PR has needs-maintainer-review — requires cryptographic approval`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 7m and 59,398 tokens on this as a headless worker.
