### PR TITLE
fix: clear stale auto-dispatch labels on close

### DIFF
--- a/.agents/scripts/pulse-batch-conditional-cache.py
+++ b/.agents/scripts/pulse-batch-conditional-cache.py
@@ -47,6 +47,7 @@ def _normalize_items(kind: str, body: str) -> list[dict[str, Any]]:
                 {
                     "number": item.get("number"),
                     "title": item.get("title"),
+                    "state": item.get("state") or "open",
                     "labels": item.get("labels") or [],
                     "updatedAt": item.get("updated_at") or item.get("updatedAt"),
                     "assignees": item.get("assignees") or [],
@@ -83,6 +84,15 @@ def main(argv: list[str]) -> int:
             return 1
         with open(cache_file, encoding="utf-8") as handle:
             payload = json.load(handle)
+        if kind == "issues":
+            items = payload.get("items") or []
+            if any("state" not in item for item in items):
+                return 1
+            payload["items"] = [
+                item
+                for item in items
+                if str(item.get("state") or "open").lower() == "open"
+            ]
         payload.update(
             {
                 "timestamp": now,

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -96,6 +96,7 @@ _KIND_PRS="prs"
 _JSON_NULL="null"
 _JSON_EMPTY_OBJ="{}"
 _JSON_EMPTY_ARR="[]"
+_STATE_OPEN="open"
 
 # --- Feature flag gate ---
 _check_enabled() {
@@ -149,11 +150,12 @@ _prefetch_rest_issues_for_slug() {
 	cache_file=$(_cache_file_path "$_KIND_ISSUES" "$slug")
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	echo "$rest_json" | jq --arg ts "$ts" '{
+	echo "$rest_json" | jq --arg ts "$ts" --arg state_open "$_STATE_OPEN" '{
 		timestamp: $ts,
 		items: [.[] | {
 			number: .number,
 			title: .title,
+			state: (.state // $state_open),
 			labels: (.labels // []),
 			updatedAt: .updated_at,
 			assignees: (.assignees // [])
@@ -283,13 +285,14 @@ _normalize_search_to_prefetch_schema() {
 	local kind="$1"
 
 	if [[ "$kind" == "$_KIND_ISSUES" ]]; then
-		jq '
+		jq --arg state_open "$_STATE_OPEN" '
 			group_by(.repository.nameWithOwner) |
 			map({
 				key: (.[0].repository.nameWithOwner),
 				value: [.[] | {
 					number: .number,
 					title: .title,
+					state: (.state // $state_open),
 					labels: .labels,
 					updatedAt: .updatedAt,
 					assignees: .assignees
@@ -474,7 +477,7 @@ _refresh_owner_issues() {
 	local issue_json=""
 	issue_json=$(gh search issues --owner "$owner" --state open \
 		--limit "$BATCH_SEARCH_LIMIT" \
-		--json number,title,labels,updatedAt,assignees,repository 2>"$issue_err") || issue_json=""
+		--json number,title,state,labels,updatedAt,assignees,repository 2>"$issue_err") || issue_json=""
 	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
 
 	if [[ -z "$issue_json" || "$issue_json" == "$_JSON_NULL" ]]; then
@@ -779,6 +782,13 @@ _cmd_read_cache() {
 
 	local cache_file
 	cache_file=$(_cmd_cache_path --kind "$kind" --slug "$slug") || return 1
+
+	if [[ "$kind" == "$_KIND_ISSUES" ]]; then
+		jq -c --arg state_open "$_STATE_OPEN" '[.items[]? | select(has("state") and ((.state | ascii_downcase) == $state_open))]' "$cache_file" 2>/dev/null || {
+			return 1
+		}
+		return 0
+	fi
 
 	jq -c '.items // []' "$cache_file" 2>/dev/null || {
 		return 1

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -71,6 +71,10 @@ if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/gh-signa
 	# shellcheck source=gh-signature-helper-detect.sh
 	source "$_PULSE_CLEANUP_SCRIPT_DIR/gh-signature-helper-detect.sh"
 fi
+if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/shared-dispatch-label-cleanup.sh" ]]; then
+	# shellcheck source=shared-dispatch-label-cleanup.sh
+	source "$_PULSE_CLEANUP_SCRIPT_DIR/shared-dispatch-label-cleanup.sh"
+fi
 # GH#23677 / t3700: Do NOT `unset _PULSE_CLEANUP_SCRIPT_DIR`. The previous
 # version unset this immediately after sourcing the four sibling helpers,
 # but _cleanup_merged_prs_for_all_repos() (line ~251) reads it later to

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -49,6 +49,9 @@ _preflight_cleanup_and_ledger() {
 	run_stage_with_timeout "cleanup_orphans" "$PRE_RUN_STAGE_TIMEOUT" cleanup_orphans || true
 	run_stage_with_timeout "cleanup_stale_opencode" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stale_opencode || true
 	run_stage_with_timeout "cleanup_stalled_workers" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stalled_workers || true
+	if declare -F sweep_closed_auto_dispatch_issues >/dev/null 2>&1; then
+		run_stage_with_timeout "sweep_closed_auto_dispatch_issues" "$PRE_RUN_STAGE_TIMEOUT" sweep_closed_auto_dispatch_issues || true
+	fi
 	# GH#20554: Worktree cleanup is moved to an async background job so a slow
 	# cleanup (20+ worktrees × 2-5s gh API calls each) never hits a hard timeout
 	# and blocks the pulse cycle. The helper enforces a single-runner lock and

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -114,6 +114,12 @@ source "${_PULSE_MERGE_DIR}/shared-claim-lifecycle.sh"
 # when a phase child PR merges for a parent-task issue.
 source "${_PULSE_MERGE_DIR}/shared-phase-filing.sh"
 
+# Source terminal dispatch-label cleanup (GH#24012). Close paths strip
+# auto-dispatch and active status labels before closing resolved issues so
+# stale closed issues cannot poison dispatch caches/candidate scans.
+# shellcheck source=shared-dispatch-label-cleanup.sh
+source "${_PULSE_MERGE_DIR}/shared-dispatch-label-cleanup.sh"
+
 readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
 
 # Source author permission check helpers (GH#21426 — extracted to bring
@@ -587,6 +593,7 @@ _handle_post_merge_actions() {
 			*,origin:worker,* | *,origin:worker-takeover,*) _solved_actor="worker" ;;
 			esac
 			set_solved_label "$linked_issue" "$repo_slug" "$_solved_actor" || true
+			clear_terminal_issue_dispatch_labels "$linked_issue" "$repo_slug" "post-merge-pr-${pr_number}" || true
 			gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
 			# Reset fast-fail counter now that the issue is resolved (GH#2076)
 			fast_fail_reset "$linked_issue" "$repo_slug" || true
@@ -626,6 +633,7 @@ _handle_post_merge_actions() {
 				*,origin:worker,* | *,origin:worker-takeover,*) _sup_solved_actor="worker" ;;
 				esac
 				set_solved_label "$_superseded_original_issue" "$repo_slug" "$_sup_solved_actor" || true
+				clear_terminal_issue_dispatch_labels "$_superseded_original_issue" "$repo_slug" "post-merge-superseded-pr-${pr_number}" || true
 				gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null || true
 				fast_fail_reset "$_superseded_original_issue" "$repo_slug" || true
 				unlock_issue_after_worker "$_superseded_original_issue" "$repo_slug"

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -45,9 +45,11 @@ fi
 # PR Prefetch Helpers (GH#5627, GH#15286, GH#15060)
 # =============================================================================
 
+_PREFETCH_PR_SWEEP_FULL=full
+
 #######################################
 # Attempt delta PR fetch and merge into cached list (GH#15286).
-# Sets PREFETCH_PR_SWEEP_MODE="full" on failure (caller falls through).
+# Sets PREFETCH_PR_SWEEP_MODE=full on failure (caller falls through).
 # Sets PREFETCH_PR_RESULT on success.
 # Arguments: $1=slug, $2=cache_entry, $3=pr_err_file
 #######################################
@@ -62,7 +64,7 @@ _prefetch_prs_try_delta() {
 	# No usable timestamp — fall back to full
 	if [[ -z "$last_prefetch" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_prs: delta fetch failed for ${slug} (falling back to full): no timestamp or fetch error" >>"$LOGFILE"
-		PREFETCH_PR_SWEEP_MODE="full"
+		PREFETCH_PR_SWEEP_MODE="$_PREFETCH_PR_SWEEP_FULL"
 		return 0
 	fi
 
@@ -77,7 +79,7 @@ _prefetch_prs_try_delta() {
 		local _delta_err_msg
 		_delta_err_msg=$(cat "$pr_err" 2>/dev/null || echo "no timestamp or fetch error")
 		echo "[pulse-wrapper] _prefetch_repo_prs: delta fetch failed for ${slug} (falling back to full): ${_delta_err_msg}" >>"$LOGFILE"
-		PREFETCH_PR_SWEEP_MODE="full"
+		PREFETCH_PR_SWEEP_MODE="$_PREFETCH_PR_SWEEP_FULL"
 		return 0
 	fi
 
@@ -93,7 +95,7 @@ _prefetch_prs_try_delta() {
 
 	if [[ -z "$merged" || "$merged" == "null" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_prs: delta merge failed for ${slug} (falling back to full)" >>"$LOGFILE"
-		PREFETCH_PR_SWEEP_MODE="full"
+		PREFETCH_PR_SWEEP_MODE="$_PREFETCH_PR_SWEEP_FULL"
 		return 0
 	fi
 
@@ -227,7 +229,7 @@ _prefetch_repo_prs() {
 
 		# Full fetch: either requested directly or delta fell back.
 		# headRefOid required for REST check-suites lookup (GH#21799).
-		if [[ "$sweep_mode" == "full" ]]; then
+		if [[ "$sweep_mode" == "$_PREFETCH_PR_SWEEP_FULL" ]]; then
 			pr_json=$(gh_pr_list --repo "$slug" --state open \
 				--json number,title,reviewDecision,updatedAt,headRefName,headRefOid,createdAt,author \
 				--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || pr_json=""
@@ -322,9 +324,26 @@ _prefetch_repo_daily_cap() {
 # Issue Delta Fetch Helper (GH#15286)
 # =============================================================================
 
+_prefetch_open_issues_only() {
+	jq -c '[.[]? | select(((.state // "open") | ascii_downcase) == "open")]' 2>/dev/null || printf '[]'
+	return 0
+}
+
+_prefetch_issue_cache_lacks_state() {
+	jq -e 'any(.[]?; has("state") | not)' >/dev/null 2>&1
+	return $?
+}
+
+_prefetch_cache_entry_issues_lack_state() {
+	jq -e 'any((.issues // [])[]?; has("state") | not)' >/dev/null 2>&1
+	return $?
+}
+
+_PREFETCH_ISSUE_SWEEP_FULL=full
+
 #######################################
 # Attempt delta issue fetch and merge into cached list (GH#15286).
-# Sets PREFETCH_ISSUE_SWEEP_MODE="full" on failure (caller falls through).
+# Sets PREFETCH_ISSUE_SWEEP_MODE=full on failure (caller falls through).
 # Sets PREFETCH_ISSUE_RESULT on success.
 # Arguments: $1=slug, $2=cache_entry, $3=issue_err_file
 #######################################
@@ -339,13 +358,13 @@ _prefetch_issues_try_delta() {
 	# No usable timestamp — fall back to full
 	if [[ -z "$last_prefetch" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_issues: delta fetch failed for ${slug} (falling back to full): no timestamp or fetch error" >>"$LOGFILE"
-		PREFETCH_ISSUE_SWEEP_MODE="full"
+		PREFETCH_ISSUE_SWEEP_MODE=full
 		return 0
 	fi
 
 	local delta_json=""
 	delta_json=$(gh_issue_list --repo "$slug" --state open \
-		--json number,title,labels,updatedAt,assignees,body \
+		--json number,title,state,labels,updatedAt,assignees,body \
 		--search "updated:>=${last_prefetch}" \
 		--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || delta_json=""
 
@@ -353,13 +372,18 @@ _prefetch_issues_try_delta() {
 		local _delta_issue_err
 		_delta_issue_err=$(cat "$issue_err" 2>/dev/null || echo "no timestamp or fetch error")
 		echo "[pulse-wrapper] _prefetch_repo_issues: delta fetch failed for ${slug} (falling back to full): ${_delta_issue_err}" >>"$LOGFILE"
-		PREFETCH_ISSUE_SWEEP_MODE="full"
+		PREFETCH_ISSUE_SWEEP_MODE=full
 		return 0
 	fi
 
 	# Merge delta into cached full list
 	local cached_issues
 	cached_issues=$(echo "$cache_entry" | jq '.issues // []' 2>/dev/null) || cached_issues="[]"
+	if echo "$cached_issues" | _prefetch_issue_cache_lacks_state; then
+		echo "[pulse-wrapper] _prefetch_repo_issues: cached issue schema lacks state for ${slug} (falling back to full)" >>"$LOGFILE"
+		PREFETCH_ISSUE_SWEEP_MODE=full
+		return 0
+	fi
 	local merged
 	merged=$(echo "$cached_issues" | jq --argjson delta "$delta_json" '
 		($delta | map(.number) | map(tostring) | map({(.) : true}) | add // {}) as $delta_nums |
@@ -369,14 +393,14 @@ _prefetch_issues_try_delta() {
 
 	if [[ -z "$merged" || "$merged" == "null" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_issues: delta merge failed for ${slug} (falling back to full)" >>"$LOGFILE"
-		PREFETCH_ISSUE_SWEEP_MODE="full"
+		PREFETCH_ISSUE_SWEEP_MODE="$_PREFETCH_ISSUE_SWEEP_FULL"
 		return 0
 	fi
 
 	local delta_count
 	delta_count=$(echo "$delta_json" | jq 'length' 2>/dev/null) || delta_count=0
 	echo "[pulse-wrapper] _prefetch_repo_issues: delta for ${slug}: ${delta_count} changed issues merged into cache" >>"$LOGFILE"
-	PREFETCH_ISSUE_RESULT="$merged"
+	PREFETCH_ISSUE_RESULT=$(echo "$merged" | _prefetch_open_issues_only)
 	return 0
 }
 
@@ -415,6 +439,7 @@ _prefetch_single_repo_idle_skip() {
 	_cached_issues=$(echo "$cache_entry" | jq -c '.issues // []' 2>/dev/null) || _cached_issues="[]"
 	_cached_pr_count=$(echo "$_cached_prs" | jq 'length' 2>/dev/null) || _cached_pr_count=0
 	[[ "$_cached_pr_count" =~ ^[0-9]+$ ]] || _cached_pr_count=0
+	_cached_issues=$(echo "$_cached_issues" | _prefetch_open_issues_only)
 	_cached_issue_count=$(echo "$_cached_issues" | jq 'length' 2>/dev/null) || _cached_issue_count=0
 	[[ "$_cached_issue_count" =~ ^[0-9]+$ ]] || _cached_issue_count=0
 
@@ -524,7 +549,7 @@ _prefetch_single_repo() {
 	cache_entry=$(_prefetch_cache_get "$slug")
 	local sweep_mode="delta"
 	if _prefetch_needs_full_sweep "$cache_entry"; then
-		sweep_mode="full"
+		sweep_mode=full
 		echo "[pulse-wrapper] _prefetch_single_repo: full sweep for ${slug}" >>"$LOGFILE"
 	else
 		echo "[pulse-wrapper] _prefetch_single_repo: delta prefetch for ${slug}" >>"$LOGFILE"
@@ -545,6 +570,11 @@ _prefetch_single_repo() {
 	if _prefetch_detect_cache_hit "$slug" "$cache_entry"; then
 		cache_hit="true"
 		echo "[pulse-wrapper] _prefetch_single_repo: STATE CACHE HIT for ${slug} (fingerprint=${PREFETCH_CURRENT_FINGERPRINT})" >>"$LOGFILE"
+	fi
+	if [[ "$cache_hit" == "true" ]] && echo "$cache_entry" | _prefetch_cache_entry_issues_lack_state; then
+		cache_hit="false"
+		sweep_mode=full
+		echo "[pulse-wrapper] _prefetch_single_repo: ignoring issue cache hit for ${slug} because cached issue schema lacks state" >>"$LOGFILE"
 	fi
 
 	{
@@ -572,7 +602,7 @@ _prefetch_single_repo() {
 	fi
 	local fingerprint="${PREFETCH_CURRENT_FINGERPRINT:-}"
 	local new_entry
-	if [[ "$sweep_mode" == "full" ]]; then
+	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" ]]; then
 		new_entry=$(jq -n \
 			--arg now "$now_iso" \
 			--arg fp "$fingerprint" \

--- a/.agents/scripts/pulse-prefetch.sh
+++ b/.agents/scripts/pulse-prefetch.sh
@@ -161,7 +161,7 @@ _prefetch_repo_issues() {
 		# Full fetch: either requested directly or delta fell back
 		if [[ "$sweep_mode" == "full" ]]; then
 		issue_json=$(gh_issue_list --repo "$slug" --state open \
-			--json number,title,labels,updatedAt,assignees,body \
+			--json number,title,state,labels,updatedAt,assignees,body \
 			--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || issue_json=""
 
 			if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
@@ -177,6 +177,7 @@ _prefetch_repo_issues() {
 		fi
 	fi
 	rm -f "$issue_err"
+	issue_json=$(echo "$issue_json" | _prefetch_open_issues_only)
 
 	# Export updated issue list for cache update by caller (Bash 3.2: no namerefs)
 	PREFETCH_UPDATED_ISSUES="$issue_json"

--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shared-dispatch-label-cleanup.sh — terminal issue dispatch-label hygiene.
+
+[[ -n "${_SHARED_DISPATCH_LABEL_CLEANUP_LOADED:-}" ]] && return 0
+_SHARED_DISPATCH_LABEL_CLEANUP_LOADED=1
+
+: "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
+: "${REPOS_JSON:=${HOME}/.config/aidevops/repos.json}"
+: "${PULSE_STALE_DISPATCH_LABEL_SWEEP_INTERVAL:=86400}"
+: "${PULSE_STALE_DISPATCH_LABEL_SWEEP_LIMIT_PER_REPO:=50}"
+
+_TERMINAL_DISPATCH_LABELS=(
+	"auto-dispatch"
+	"status:available"
+	"status:queued"
+	"status:claimed"
+	"status:in-progress"
+	"status:in-review"
+)
+
+_dispatch_label_cleanup_stamp_file() {
+	printf '%s\n' "${HOME}/.aidevops/logs/pulse-stale-dispatch-label-sweep.last"
+	return 0
+}
+
+clear_terminal_issue_dispatch_labels() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local context="${3:-terminal}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ || -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	local -a edit_args=("issue" "edit" "$issue_number" "--repo" "$repo_slug")
+	local label
+	for label in "${_TERMINAL_DISPATCH_LABELS[@]}"; do
+		edit_args+=("--remove-label" "$label")
+	done
+
+	if gh "${edit_args[@]}" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] dispatch-label-cleanup: stripped terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[pulse-wrapper] dispatch-label-cleanup: failed to strip terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
+	return 1
+}
+
+_dispatch_label_sweep_due() {
+	if [[ "${PULSE_STALE_DISPATCH_LABEL_SWEEP_FORCE:-0}" == "1" ]]; then
+		return 0
+	fi
+
+	local stamp_file
+	stamp_file=$(_dispatch_label_cleanup_stamp_file)
+	[[ -f "$stamp_file" ]] || return 0
+
+	local now_epoch stamp_epoch age
+	now_epoch=$(date +%s 2>/dev/null || echo "0")
+	stamp_epoch=$(cat "$stamp_file" 2>/dev/null || echo "0")
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+	[[ "$stamp_epoch" =~ ^[0-9]+$ ]] || stamp_epoch=0
+	age=$((now_epoch - stamp_epoch))
+
+	if [[ "$age" -ge "$PULSE_STALE_DISPATCH_LABEL_SWEEP_INTERVAL" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_dispatch_label_sweep_mark_run() {
+	local stamp_file
+	stamp_file=$(_dispatch_label_cleanup_stamp_file)
+	mkdir -p "$(dirname "$stamp_file")" 2>/dev/null || true
+	date +%s >"$stamp_file" 2>/dev/null || true
+	return 0
+}
+
+_dispatch_label_sweep_repos() {
+	local repos_json="${1:-$REPOS_JSON}"
+	[[ -f "$repos_json" ]] || return 1
+	jq -r '
+		.initialized_repos[]? |
+		select((.pulse // false) == true) |
+		select((.local_only // false) == false) |
+		.slug // empty
+	' "$repos_json" 2>/dev/null
+	return 0
+}
+
+sweep_closed_auto_dispatch_issues() {
+	if ! _dispatch_label_sweep_due; then
+		return 0
+	fi
+
+	local repos_json="${1:-$REPOS_JSON}"
+	local limit="${PULSE_STALE_DISPATCH_LABEL_SWEEP_LIMIT_PER_REPO:-50}"
+	[[ "$limit" =~ ^[0-9]+$ ]] || limit=50
+	[[ "$limit" -gt 0 ]] || limit=50
+
+	local total=0 repo_slug issue_number issue_numbers
+	while IFS= read -r repo_slug; do
+		[[ -n "$repo_slug" ]] || continue
+		issue_numbers=$(gh issue list --repo "$repo_slug" --state closed \
+			--label "auto-dispatch" --limit "$limit" \
+			--json number --jq '.[].number' 2>/dev/null) || issue_numbers=""
+		[[ -n "$issue_numbers" ]] || continue
+		while IFS= read -r issue_number; do
+			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" || true
+			total=$((total + 1))
+		done <<<"$issue_numbers"
+	done < <(_dispatch_label_sweep_repos "$repos_json" || true)
+
+	_dispatch_label_sweep_mark_run
+	echo "[pulse-wrapper] dispatch-label-cleanup: closed issue sweep stripped labels from ${total} issue(s)" >>"$LOGFILE"
+	return 0
+}

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR_TEST}/../shared-dispatch-label-cleanup.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="$HOME"
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export REPOS_JSON="${TEST_ROOT}/repos.json"
+	export PULSE_STALE_DISPATCH_LABEL_SWEEP_FORCE=1
+	export PULSE_STALE_DISPATCH_LABEL_SWEEP_LIMIT_PER_REPO=5
+	mkdir -p "$HOME/.aidevops/logs"
+	: >"$LOGFILE"
+	: >"${TEST_ROOT}/gh.log"
+	cat >"$REPOS_JSON" <<'JSON'
+{"initialized_repos":[{"slug":"owner/repo","pulse":true,"local_only":false},{"slug":"owner/local","pulse":true,"local_only":true},{"slug":"owner/off","pulse":false,"local_only":false}]}
+JSON
+	return 0
+}
+
+teardown_env() {
+	export HOME="$ORIGINAL_HOME"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+install_gh_stub() {
+	gh() {
+		printf '%s\n' "$*" >>"${TEST_ROOT}/gh.log"
+		if [[ "$1" == "issue" && "$2" == "list" ]]; then
+			printf '101\n102\n'
+			return 0
+		fi
+		return 0
+	}
+	return 0
+}
+
+test_clear_terminal_labels_removes_dispatch_labels() {
+	setup_env
+	install_gh_stub
+	# shellcheck source=../shared-dispatch-label-cleanup.sh
+	source "$HELPER"
+	clear_terminal_issue_dispatch_labels 42 owner/repo test-context
+	local log_line
+	log_line=$(tr '\n' ' ' <"${TEST_ROOT}/gh.log")
+	if [[ "$log_line" == *"issue edit 42 --repo owner/repo"* \
+		&& "$log_line" == *"--remove-label auto-dispatch"* \
+		&& "$log_line" == *"--remove-label status:available"* \
+		&& "$log_line" == *"--remove-label status:in-review"* ]]; then
+		print_result "terminal label cleanup strips auto-dispatch and active statuses" 0
+	else
+		print_result "terminal label cleanup strips auto-dispatch and active statuses" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
+	setup_env
+	install_gh_stub
+	# shellcheck source=../shared-dispatch-label-cleanup.sh
+	source "$HELPER"
+	sweep_closed_auto_dispatch_issues
+	local edit_count list_count
+	edit_count=$(grep -c 'issue edit' "${TEST_ROOT}/gh.log" || true)
+	list_count=$(grep -c 'issue list' "${TEST_ROOT}/gh.log" || true)
+	if [[ "$edit_count" == "2" && "$list_count" == "1" ]]; then
+		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 0
+	else
+		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_clear_terminal_labels_removes_dispatch_labels
+test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos
+
+printf 'Tests run: %s\n' "$TESTS_RUN"
+printf 'Tests failed: %s\n' "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -31,6 +31,7 @@ setup_env() {
 	export PULSE_BATCH_PREFETCH_CACHE_DIR="$TEST_ROOT/cache"
 	export LOGFILE="$TEST_ROOT/pulse.log"
 	export PULSE_EVENTS_TICKLE_ENABLED=0
+	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=999999999
 	unset AIDEVOPS_GH_FORCE_REST_READS
 	unset AIDEVOPS_GH_REST_FIRST_READS
 	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
@@ -51,8 +52,8 @@ write_gh_stub() {
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$TEST_ROOT/gh-calls.log"
 if [[ "\$1" == "api" && "\$2" == "rate_limit" ]]; then
-  printf '{"resources":{"graphql":{"remaining":5000}}}'
-  exit 0
+	printf '{"resources":{"graphql":{"remaining":5000}}}'
+	exit 0
 fi
 if [[ "\$1" == "api" ]]; then
   if [[ "\$*" == *'/users/owner --jq .type'* ]]; then
@@ -72,15 +73,19 @@ if [[ "\$1" == "api" ]]; then
       printf 'HTTP/2 200\\r\\netag: "etag-pr-v2"\\r\\n\\r\\n[{"number":7,"title":"PR","updated_at":"2026-05-02T00:00:00Z","user":{"login":"dev"},"head":{"sha":"abc","ref":"branch"}}]'
       exit 0
     fi
-    printf 'HTTP/2 200\\r\\netag: "etag-issue-v2"\\r\\n\\r\\n[{"number":3,"title":"Issue","updated_at":"2026-05-02T00:00:00Z","labels":[],"assignees":[]},{"number":4,"title":"PR-shaped issue","pull_request":{},"updated_at":"2026-05-02T00:00:00Z"}]'
+		printf 'HTTP/2 200\\r\\netag: "etag-issue-v2"\\r\\n\\r\\n[{"number":3,"title":"Issue","state":"open","updated_at":"2026-05-02T00:00:00Z","labels":[],"assignees":[]},{"number":4,"title":"PR-shaped issue","pull_request":{},"updated_at":"2026-05-02T00:00:00Z"}]'
     exit 0
   fi
   printf 'HTTP/2 500\\r\\n\\r\\n{}'
   exit 1
 fi
 if [[ "\$1" == "search" ]]; then
-  printf '[]'
-  exit 0
+	if [[ "\$*" == *'search issues'* ]]; then
+		printf '[{"number":5,"title":"Search issue","state":"open","updatedAt":"2026-05-03T00:00:00Z","labels":[],"assignees":[],"repository":{"nameWithOwner":"owner/repo"}}]'
+		exit 0
+	fi
+	printf '[]'
+	exit 0
 fi
 exit 1
 SH
@@ -91,7 +96,17 @@ SH
 
 seed_cache() {
 	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" <<'JSON'
-{"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Cached issue","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
+{"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Cached issue","state":"open","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
+JSON
+	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json" <<'JSON'
+{"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":2,"title":"Cached PR","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
+JSON
+	return 0
+}
+
+seed_legacy_issue_cache() {
+	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" <<'JSON'
+{"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Legacy cached issue","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
 JSON
 	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json" <<'JSON'
 {"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":2,"title":"Cached PR","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
@@ -122,10 +137,47 @@ test_changed_repo_refreshes_cache() {
 	local issue_count pr_author
 	issue_count=$(jq '.items | length' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
 	pr_author=$(jq -r '.items[0].author.login' "$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json")
-	if grep -q 'conditional_refreshes=2' <<<"$output" && [[ "$issue_count" == "1" && "$pr_author" == "dev" ]]; then
+	local issue_state
+	issue_state=$(jq -r '.items[0].state' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
+	if grep -q 'conditional_refreshes=2' <<<"$output" && [[ "$issue_count" == "1" && "$pr_author" == "dev" && "$issue_state" == "open" ]]; then
 		print_result "changed repo refreshes normalized issue and PR caches" 0
 	else
 		print_result "changed repo refreshes normalized issue and PR caches" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_legacy_issue_cache_falls_open_to_search() {
+	setup_env
+	seed_legacy_issue_cache
+	write_gh_stub not_modified
+	"$HELPER" refresh >/dev/null
+	local issue_num
+	issue_num=$(jq -r '.items[0].number' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
+	if grep -q 'search issues' "$TEST_ROOT/gh-calls.log" && [[ "$issue_num" == "5" ]]; then
+		print_result "legacy issue cache without state falls open to search refresh" 0
+	else
+		print_result "legacy issue cache without state falls open to search refresh" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_read_cache_filters_closed_issues() {
+	setup_env
+	mkdir -p "$PULSE_BATCH_PREFETCH_CACHE_DIR"
+	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" <<'JSON'
+{"timestamp":"2026-05-01T00:00:00Z","items":[{"number":10,"title":"Open","state":"open"},{"number":11,"title":"Closed","state":"closed"}]}
+JSON
+	local output count first
+	output=$("$HELPER" read-cache --kind issues --slug owner/repo)
+	count=$(printf '%s' "$output" | jq 'length')
+	first=$(printf '%s' "$output" | jq -r '.[0].number')
+	if [[ "$count" == "1" && "$first" == "10" ]]; then
+		print_result "read-cache filters closed issue rows" 0
+	else
+		print_result "read-cache filters closed issue rows" 1
 	fi
 	teardown_env
 	return 0
@@ -148,6 +200,8 @@ test_conditional_failure_falls_open_to_search() {
 test_unchanged_repo_uses_304_cache
 test_changed_repo_refreshes_cache
 test_conditional_failure_falls_open_to_search
+test_legacy_issue_cache_falls_open_to_search
+test_read_cache_filters_closed_issues
 
 printf 'Tests run: %s\n' "$TESTS_RUN"
 printf 'Tests failed: %s\n' "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -79,6 +79,7 @@ define_function_under_test() {
 		printf 'ERROR: could not extract _handle_post_merge_actions from %s\n' "$MERGE_FILE" >&2
 		return 1
 	fi
+	_PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
 	eval "$fn_src"
 	return 0
 }
@@ -127,11 +128,19 @@ install_helper_stubs() {
 		printf '%s %s %s\n' "$issue" "$repo" "$actor" >>"$SOLVED_LABEL_LOG"
 		return 0
 	}
+	clear_terminal_issue_dispatch_labels() {
+		local issue="$1"
+		local repo="$2"
+		local context="$3"
+		printf 'cleanup %s %s %s\n' "$issue" "$repo" "$context" >>"$GH_CALL_LOG"
+		return 0
+	}
 	unlock_issue_after_worker() { return 0; }
 	fast_fail_reset() { return 0; }
 	_release_interactive_claim_on_merge() { return 0; }
 	auto_file_next_phase() { return 0; }
 	_unblock_circuit_breaker_meta_pr() { return 0; }
+	_pm_handle_partial_parent_closeout() { return 0; }
 	return 0
 }
 
@@ -170,6 +179,8 @@ test_provided_empty_pr_labels_skip_refetch() {
 		"provided empty pr_labels skips fallback fetch"
 	assert_log_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops interactive" \
 		"provided empty pr_labels keeps interactive solved attribution"
+	assert_log_contains "$GH_CALL_LOG" "cleanup 22219 marcusquinn/aidevops post-merge-pr-22585" \
+		"post-merge close strips terminal dispatch labels"
 	return 0
 }
 
@@ -200,6 +211,8 @@ test_superseded_pr_closes_original_issue() {
 		"superseded chain closes original issue"
 	assert_log_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops worker" \
 		"superseded chain marks original issue solved by worker"
+	assert_log_contains "$GH_CALL_LOG" "cleanup 22219 marcusquinn/aidevops post-merge-superseded-pr-44444" \
+		"superseded close strips terminal dispatch labels"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Resolves #24012.

- Add shared terminal dispatch-label cleanup for resolved/closed issues.
- Strip `auto-dispatch` and active `status:*` labels before pulse merge close paths close linked or superseded issues.
- Run a bounded preflight sweep for already-closed issues still carrying `auto-dispatch`.
- Add defensive issue `state` propagation/filtering to batch, conditional, and L4 prefetch caches so closed issue rows are not surfaced as open candidates.

## Verification

- `.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh`
- `.agents/scripts/tests/test-dispatch-label-cleanup.sh`
- `.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh`
- `.agents/scripts/tests/test-pulse-wrapper-delta-prefetch.sh`
- `shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/pulse-merge.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/pulse-dispatch-preflight-lib.sh .agents/scripts/pulse-batch-prefetch-helper.sh .agents/scripts/pulse-prefetch-fetch.sh .agents/scripts/pulse-prefetch.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh`
- `python3 -m py_compile .agents/scripts/pulse-batch-conditional-cache.py`
- `.agents/scripts/linters-local.sh`

## Notes

- `test-enrich-batch-prefetch.sh` still has two unrelated pre-existing characterization failures around `cmd_enrich` call detection; it was not part of this change.
- `linters-local.sh` ended with `ALL LOCAL CHECKS PASSED`; its pulse canary subcheck reported an infrastructure timeout warning once, then the overall gate completed successfully.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3h 32m and 343,753 tokens on this with the user in an interactive session.