### PR TITLE
GH#24041: fix: harden dispatch label cleanup

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -28,7 +28,8 @@ function readIfExists(filepath) {
  * @returns {string}
  */
 function getSessionId(input) {
-  return input?.session?.id || input?.sessionID || input?.session_id || input?.id || "";
+  const candidates = [input?.session?.id, input?.sessionID, input?.session_id, input?.id];
+  return candidates.find((value) => value) || "";
 }
 
 /**

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -343,7 +343,7 @@ _PREFETCH_ISSUE_SWEEP_FULL=full
 
 #######################################
 # Attempt delta issue fetch and merge into cached list (GH#15286).
-# Sets PREFETCH_ISSUE_SWEEP_MODE=full on failure (caller falls through).
+# Sets PREFETCH_ISSUE_SWEEP_MODE=$_PREFETCH_ISSUE_SWEEP_FULL on failure (caller falls through).
 # Sets PREFETCH_ISSUE_RESULT on success.
 # Arguments: $1=slug, $2=cache_entry, $3=issue_err_file
 #######################################
@@ -358,7 +358,7 @@ _prefetch_issues_try_delta() {
 	# No usable timestamp — fall back to full
 	if [[ -z "$last_prefetch" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_issues: delta fetch failed for ${slug} (falling back to full): no timestamp or fetch error" >>"$LOGFILE"
-		PREFETCH_ISSUE_SWEEP_MODE=full
+		PREFETCH_ISSUE_SWEEP_MODE="$_PREFETCH_ISSUE_SWEEP_FULL"
 		return 0
 	fi
 
@@ -372,7 +372,7 @@ _prefetch_issues_try_delta() {
 		local _delta_issue_err
 		_delta_issue_err=$(cat "$issue_err" 2>/dev/null || echo "no timestamp or fetch error")
 		echo "[pulse-wrapper] _prefetch_repo_issues: delta fetch failed for ${slug} (falling back to full): ${_delta_issue_err}" >>"$LOGFILE"
-		PREFETCH_ISSUE_SWEEP_MODE=full
+		PREFETCH_ISSUE_SWEEP_MODE="$_PREFETCH_ISSUE_SWEEP_FULL"
 		return 0
 	fi
 
@@ -381,7 +381,7 @@ _prefetch_issues_try_delta() {
 	cached_issues=$(echo "$cache_entry" | jq '.issues // []' 2>/dev/null) || cached_issues="[]"
 	if echo "$cached_issues" | _prefetch_issue_cache_lacks_state; then
 		echo "[pulse-wrapper] _prefetch_repo_issues: cached issue schema lacks state for ${slug} (falling back to full)" >>"$LOGFILE"
-		PREFETCH_ISSUE_SWEEP_MODE=full
+		PREFETCH_ISSUE_SWEEP_MODE="$_PREFETCH_ISSUE_SWEEP_FULL"
 		return 0
 	fi
 	local merged
@@ -549,7 +549,7 @@ _prefetch_single_repo() {
 	cache_entry=$(_prefetch_cache_get "$slug")
 	local sweep_mode="delta"
 	if _prefetch_needs_full_sweep "$cache_entry"; then
-		sweep_mode=full
+		sweep_mode="$_PREFETCH_ISSUE_SWEEP_FULL"
 		echo "[pulse-wrapper] _prefetch_single_repo: full sweep for ${slug}" >>"$LOGFILE"
 	else
 		echo "[pulse-wrapper] _prefetch_single_repo: delta prefetch for ${slug}" >>"$LOGFILE"
@@ -573,7 +573,7 @@ _prefetch_single_repo() {
 	fi
 	if [[ "$cache_hit" == "true" ]] && echo "$cache_entry" | _prefetch_cache_entry_issues_lack_state; then
 		cache_hit="false"
-		sweep_mode=full
+		sweep_mode="$_PREFETCH_ISSUE_SWEEP_FULL"
 		echo "[pulse-wrapper] _prefetch_single_repo: ignoring issue cache hit for ${slug} because cached issue schema lacks state" >>"$LOGFILE"
 	fi
 

--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -34,13 +34,35 @@ clear_terminal_issue_dispatch_labels() {
 		return 1
 	fi
 
+	local current_labels
+	if ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
+		echo "[pulse-wrapper] dispatch-label-cleanup: failed to fetch labels for ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
+		return 1
+	fi
+
 	local -a edit_args=("issue" "edit" "$issue_number" "--repo" "$repo_slug")
-	local label
+	local label current_label label_found found=0
 	for label in "${_TERMINAL_DISPATCH_LABELS[@]}"; do
-		edit_args+=("--remove-label" "$label")
+		label_found=0
+		while IFS= read -r current_label; do
+			if [[ "$current_label" == "$label" ]]; then
+				label_found=1
+				break
+			fi
+		done <<<"$current_labels"
+		if [[ "$label_found" -eq 1 ]]; then
+			edit_args+=("--remove-label" "$label")
+			found=1
+		fi
 	done
 
-	if gh "${edit_args[@]}" >/dev/null 2>&1; then
+	if [[ "$found" -eq 0 ]]; then
+		return 0
+	fi
+
+	gh "${edit_args[@]}" >/dev/null 2>&1
+	local exit_code=$?
+	if [[ "$exit_code" -eq 0 ]]; then
 		echo "[pulse-wrapper] dispatch-label-cleanup: stripped terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 0
 	fi
@@ -110,8 +132,11 @@ sweep_closed_auto_dispatch_issues() {
 		[[ -n "$issue_numbers" ]] || continue
 		while IFS= read -r issue_number; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
-			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" || true
-			total=$((total + 1))
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep"
+			local exit_code=$?
+			if [[ "$exit_code" -eq 0 ]]; then
+				total=$((total + 1))
+			fi
 		done <<<"$issue_numbers"
 	done < <(_dispatch_label_sweep_repos "$repos_json" || true)
 

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -56,6 +56,10 @@ install_gh_stub() {
 			printf '101\n102\n'
 			return 0
 		fi
+		if [[ "$1" == "issue" && "$2" == "view" ]]; then
+			printf 'auto-dispatch\nstatus:queued\n'
+			return 0
+		fi
 		return 0
 	}
 	return 0
@@ -69,13 +73,14 @@ test_clear_terminal_labels_removes_dispatch_labels() {
 	clear_terminal_issue_dispatch_labels 42 owner/repo test-context
 	local log_line
 	log_line=$(tr '\n' ' ' <"${TEST_ROOT}/gh.log")
-	if [[ "$log_line" == *"issue edit 42 --repo owner/repo"* \
+	if [[ "$log_line" == *"issue view 42 --repo owner/repo"* \
+		&& "$log_line" == *"issue edit 42 --repo owner/repo"* \
 		&& "$log_line" == *"--remove-label auto-dispatch"* \
-		&& "$log_line" == *"--remove-label status:available"* \
-		&& "$log_line" == *"--remove-label status:in-review"* ]]; then
-		print_result "terminal label cleanup strips auto-dispatch and active statuses" 0
+		&& "$log_line" == *"--remove-label status:queued"* \
+		&& "$log_line" != *"--remove-label status:in-review"* ]]; then
+		print_result "terminal label cleanup strips only labels currently present" 0
 	else
-		print_result "terminal label cleanup strips auto-dispatch and active statuses" 1
+		print_result "terminal label cleanup strips only labels currently present" 1
 	fi
 	teardown_env
 	return 0


### PR DESCRIPTION
## Summary

Filtered terminal dispatch label removal to labels present on the target issue, counted closed-issue sweep successes only after cleanup succeeds, and reused the issue full-sweep constant consistently.

## Files Changed

.agents/scripts/pulse-prefetch-fetch.sh,.agents/scripts/shared-dispatch-label-cleanup.sh,.agents/scripts/tests/test-dispatch-label-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/pulse-prefetch-fetch.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh; .agents/scripts/tests/test-dispatch-label-cleanup.sh

Resolves #24041


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 62,182 tokens on this as a headless worker.