### PR TITLE
GH#24043: docs: clarify RTK compact-status wording

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -62,8 +62,8 @@ Use comparison results to classify a command:
   compact-status `-uall` flag, so tracked-file paths remain visible while
   untracked directories stay summarized as they appear in raw
   `git status --short` output. Rerun raw status and verify RTK version when
-  comparison shows expansion, because older RTK versions still use the noisier
-  compact-status path.
+  comparison shows expansion; older RTK versions still use the noisier
+  compact-status behavior.
 
 ## Always bypass RTK
 


### PR DESCRIPTION
## Summary

Updated .agents/reference/context-efficient-output.md to replace the ambiguous compact-status 'path' wording with 'behavior' and use the clearer semicolon structure from the verified review follow-up.

## Files Changed

.agents/reference/context-efficient-output.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/reference/context-efficient-output.md

Resolves #24043


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 33,958 tokens on this as a headless worker.