### PR TITLE
GH#24041: fix: preserve dispatch cleanup exit codes

### DIFF
--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -34,23 +34,17 @@ clear_terminal_issue_dispatch_labels() {
 		return 1
 	fi
 
-	local current_labels
-	if ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
+	local current_labels="${4:-}"
+	if [[ -z "$current_labels" ]] && ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
 		echo "[pulse-wrapper] dispatch-label-cleanup: failed to fetch labels for ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 1
 	fi
 
 	local -a edit_args=("issue" "edit" "$issue_number" "--repo" "$repo_slug")
-	local label current_label label_found found=0
+	local label labels_blob found=0
+	labels_blob=$'\n'"$current_labels"$'\n'
 	for label in "${_TERMINAL_DISPATCH_LABELS[@]}"; do
-		label_found=0
-		while IFS= read -r current_label; do
-			if [[ "$current_label" == "$label" ]]; then
-				label_found=1
-				break
-			fi
-		done <<<"$current_labels"
-		if [[ "$label_found" -eq 1 ]]; then
+		if [[ "$labels_blob" == *$'\n'"$label"$'\n'* ]]; then
 			edit_args+=("--remove-label" "$label")
 			found=1
 		fi
@@ -60,15 +54,15 @@ clear_terminal_issue_dispatch_labels() {
 		return 0
 	fi
 
-	gh "${edit_args[@]}" >/dev/null 2>&1
-	local exit_code=$?
+	local exit_code=0
+	gh "${edit_args[@]}" >/dev/null 2>&1 || exit_code=$?
 	if [[ "$exit_code" -eq 0 ]]; then
 		echo "[pulse-wrapper] dispatch-label-cleanup: stripped terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 0
 	fi
 
 	echo "[pulse-wrapper] dispatch-label-cleanup: failed to strip terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
-	return 1
+	return "$exit_code"
 }
 
 _dispatch_label_sweep_due() {
@@ -132,8 +126,8 @@ sweep_closed_auto_dispatch_issues() {
 		[[ -n "$issue_numbers" ]] || continue
 		while IFS= read -r issue_number; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
-			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep"
-			local exit_code=$?
+			local exit_code=0
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" || exit_code=$?
 			if [[ "$exit_code" -eq 0 ]]; then
 				total=$((total + 1))
 			fi

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -60,6 +60,9 @@ install_gh_stub() {
 			printf 'auto-dispatch\nstatus:queued\n'
 			return 0
 		fi
+		if [[ "${GH_STUB_FAIL_EDIT:-0}" == "1" && "$1" == "issue" && "$2" == "edit" ]]; then
+			return 7
+		fi
 		return 0
 	}
 	return 0
@@ -86,6 +89,24 @@ test_clear_terminal_labels_removes_dispatch_labels() {
 	return 0
 }
 
+test_clear_terminal_labels_propagates_edit_failure() {
+	setup_env
+	install_gh_stub
+	export GH_STUB_FAIL_EDIT=1
+	# shellcheck source=../shared-dispatch-label-cleanup.sh
+	source "$HELPER"
+	local exit_code=0
+	clear_terminal_issue_dispatch_labels 42 owner/repo test-context || exit_code=$?
+	unset GH_STUB_FAIL_EDIT
+	if [[ "$exit_code" == "7" ]]; then
+		print_result "terminal label cleanup propagates edit failure" 0
+	else
+		print_result "terminal label cleanup propagates edit failure" 1
+	fi
+	teardown_env
+	return 0
+}
+
 test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
 	setup_env
 	install_gh_stub
@@ -105,6 +126,7 @@ test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
 }
 
 test_clear_terminal_labels_removes_dispatch_labels
+test_clear_terminal_labels_propagates_edit_failure
 test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos
 
 printf 'Tests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

- Follow-up to #24051 / #24041 after post-merge review identified `set -e` exit-code handling in dispatch label cleanup.
- Preserves `gh issue edit` failure codes instead of allowing an unguarded command to terminate before cleanup logging.
- Replaces nested label scans with newline-delimited Bash matching that remains safe for labels containing `:`.
- Adds a regression test proving edit failures propagate.

## Files

- `.agents/scripts/shared-dispatch-label-cleanup.sh`
- `.agents/scripts/tests/test-dispatch-label-cleanup.sh`

## Verification

- `bash .agents/scripts/tests/test-dispatch-label-cleanup.sh` → 3 passed
- `shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh`
- `git diff --check origin/main...HEAD`

Ref #24041
Follow-up to #24051

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 109,266 tokens on this as a headless worker.