### PR TITLE
GH#24048: fix: improve rtk manual install hints

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -339,12 +339,14 @@ _setup_rtk_install_supported_version() {
 	fi
 
 	print_warning "rtk upgrade failed (non-critical, optional tool)"
+	_setup_rtk_print_manual_install "$rtk_installer_url" "upgrade"
 	return 1
 }
 
 _setup_rtk_print_manual_install() {
 	local rtk_installer_url="$1"
-	echo "  Manual install: brew upgrade rtk  OR  curl -fsSL $rtk_installer_url | sh"
+	local brew_cmd="${2:-upgrade}"
+	echo "  Manual install: brew $brew_cmd rtk  OR  curl -fsSL $rtk_installer_url | sh"
 	return 0
 }
 
@@ -426,7 +428,7 @@ setup_rtk() {
 			fi
 		else
 			print_info "Skipped rtk installation"
-			_setup_rtk_print_manual_install "$rtk_installer_url"
+			_setup_rtk_print_manual_install "$rtk_installer_url" "install"
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-tool-install-rtk.sh
+++ b/.agents/scripts/tests/test-tool-install-rtk.sh
@@ -95,6 +95,18 @@ chmod +x "$SANDBOX/bin/rtk"
 assert_eq "existing mismatched rtk is upgraded" "rtk 0.41.0" "$(rtk --version)"
 assert_eq "setup reports matching version" "1" "$(grep -c 'rtk now matches the aidevops-tested version' "$SANDBOX/out")"
 
+manual_upgrade_hint=$(
+	source_extracted
+	_setup_rtk_print_manual_install "https://example.invalid/install.sh" "upgrade"
+)
+manual_install_hint=$(
+	source_extracted
+	_setup_rtk_print_manual_install "https://example.invalid/install.sh" "install"
+)
+
+assert_eq "manual upgrade hint uses brew upgrade" "  Manual install: brew upgrade rtk  OR  curl -fsSL https://example.invalid/install.sh | sh" "$manual_upgrade_hint"
+assert_eq "manual install hint uses brew install" "  Manual install: brew install rtk  OR  curl -fsSL https://example.invalid/install.sh | sh" "$manual_install_hint"
+
 if [[ "$FAIL" -gt 0 ]]; then
 	echo "FAIL: $FAIL rtk setup checks failed" >&2
 	exit 1

--- a/.agents/scripts/tests/test-tool-install-rtk.sh
+++ b/.agents/scripts/tests/test-tool-install-rtk.sh
@@ -86,6 +86,11 @@ cat >"$SANDBOX/bin/rtk" <<'EOF'
 [[ "${1:-}" == "--version" ]] && echo "rtk 0.40.0"
 EOF
 chmod +x "$SANDBOX/bin/rtk"
+cat >"$SANDBOX/bin/brew" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$SANDBOX/bin/brew"
 
 (
 	source_extracted


### PR DESCRIPTION
## Summary

Parameterized the rtk manual install helper so upgrade paths show brew upgrade, first-install skip paths show brew install, and failed automatic upgrades print immediate manual remediation.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh,.agents/scripts/tests/test-tool-install-rtk.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/setup/modules/tool-install.sh .agents/scripts/tests/test-tool-install-rtk.sh; .agents/scripts/tests/test-tool-install-rtk.sh

Resolves #24048


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 43,805 tokens on this as a headless worker.