### PR TITLE
GH#24045: fix: default report renderer input to stdin

### DIFF
--- a/.agents/scripts/report-render-helper.py
+++ b/.agents/scripts/report-render-helper.py
@@ -22,7 +22,7 @@ if len(sys.argv) < 2:
     sys.exit(1)
 
 MODE = sys.argv[1]
-INPUT = sys.argv[2] if len(sys.argv) > 2 else ""
+INPUT = sys.argv[2] if len(sys.argv) > 2 else "-"
 CSS = """
 :root { color-scheme: light; --ink: #1f2937; --muted: #6b7280; --line: #d1d5db; --panel: #f9fafb; }
 body { margin: 0; font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); }

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -107,6 +107,14 @@ test_python_helper_requires_mode() {
 	return 0
 }
 
+test_python_helper_reads_stdin_by_default() {
+	local _out="${TEST_ROOT}/stdin.html"
+	printf '# Stdin\n\n{{evidence:verified}}\n' | python3 "${SCRIPT_DIR}/../report-render-helper.py" render >"$_out"
+	assert_contains "$_out" "<h1 id=\"stdin\">Stdin</h1>" "Python helper reads stdin when input omitted"
+	assert_contains "$_out" "Evidence: Verified" "Python helper renders stdin badges"
+	return 0
+}
+
 test_markdown_table_uses_header_cells() {
 	local _input="${TEST_ROOT}/table.md"
 	local _out="${TEST_ROOT}/table.html"
@@ -164,6 +172,7 @@ main() {
 	test_render_json_fixture
 	test_validate_rejects_unknown_badge
 	test_python_helper_requires_mode
+	test_python_helper_reads_stdin_by_default
 	test_markdown_table_uses_header_cells
 	test_multiline_markdown_paragraph
 	test_render_json_array_is_resilient


### PR DESCRIPTION
## Summary

Defaulted the Python report renderer's omitted input argument to '-' so the documented optional input path reads from stdin instead of trying to open an empty path; added regression coverage for stdin rendering.

## Files Changed

.agents/scripts/report-render-helper.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh; python3 -m py_compile .agents/scripts/report-render-helper.py

Resolves #24045


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 36,336 tokens on this as a headless worker.