### PR TITLE
GH#24044: fix LLM visibility report CSS followup

### DIFF
--- a/.agents/templates/reports/llm-visibility-report.css
+++ b/.agents/templates/reports/llm-visibility-report.css
@@ -40,6 +40,7 @@
   --report-badge-strong-bg: #eaf2ff;
   --report-badge-strong-ink: #1d4ed8;
   --report-badge-vendor-bg: #f4ecff;
+  --report-badge-vendor-ink: var(--report-violet);
   --report-badge-practitioner-bg: #fff5db;
   --report-badge-practitioner-ink: #92400e;
   --report-badge-hygiene-bg: #f3f4f6;
@@ -77,7 +78,7 @@ body.report-body {
 }
 
 .report-main {
-  grid-column: span 8;
+  grid-column: span 9;
   min-width: 0;
 }
 
@@ -277,7 +278,7 @@ body.report-body {
 
 .badge--vendor {
   background: var(--report-badge-vendor-bg);
-  color: var(--report-violet);
+  color: var(--report-badge-vendor-ink);
   border-color: rgba(109, 40, 217, 0.2);
 }
 


### PR DESCRIPTION
## Summary
- Add the missing vendor badge ink token and route `.badge--vendor` through it.
- Expand `.report-main` to span 9 of 12 grid columns so it pairs with the 3-column sticky TOC.

## Verification
- `git diff --check`
- Targeted CSS assertions for vendor ink token/use and 9+3 grid spans
- `.agents/scripts/linters-local.sh` reached existing advisory markdown findings, then timed out during ratchet counting; no issue-specific failures before timeout.
- `bun test` reports no matching test files in this repo.

Resolves #24044

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 14m and 68,704 tokens on this as a headless worker.
