### PR TITLE
fix: preserve service interruption exhaustion metrics

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1072,7 +1072,7 @@ _derive_worker_failure_evidence() {
 		launch_failure_cause="model_stopped_before_completion"
 		next_action="resume_session_with_completion_contract"
 		;;
-	watchdog_stall_continue | service_interruption_continue | signal_killed_continue)
+	watchdog_stall_continue | service_interruption_continue | service_interruption_exhausted | signal_killed_continue)
 		launch_failure_cause="mid_session_interruption"
 		next_action="resume_existing_session"
 		;;
@@ -1117,6 +1117,43 @@ _derive_worker_failure_evidence() {
 	fi
 
 	printf '%s\t%s' "$launch_failure_cause" "$next_action"
+	return 0
+}
+
+#######################################
+# Append a context-rich metric when service-interruption continuation budget is exhausted.
+#
+# Args:
+#   $1 - role
+#   $2 - session key
+#   $3 - selected model
+#   $4 - work dir
+#   $5 - failure reason
+#   $6 - output excerpt path
+#   $7 - session id
+# Returns: 0 always (observability must fail open)
+#######################################
+_append_service_interruption_exhausted_metric() {
+	local role="$1"
+	local session_key="$2"
+	local selected_model="$3"
+	local work_dir="$4"
+	local failure_reason="$5"
+	local output_file="$6"
+	local session_id="$7"
+	local result_label="service_interruption_exhausted"
+	local provider
+	provider=$(extract_provider "$selected_model")
+	local evidence_fields launch_failure_cause next_action
+	evidence_fields=$(_derive_worker_failure_evidence "$result_label" "81" "1" "" "$failure_reason")
+	launch_failure_cause="${evidence_fields%%$'\t'*}"
+	next_action="${evidence_fields#*$'\t'}"
+	append_runtime_metric "$role" "$session_key" "$selected_model" \
+		"$provider" \
+		"$result_label" "81" "${failure_reason:-provider_error}" "1" "0" \
+		"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$output_file" "$session_id" \
+		"${_run_provider_error_type:-}" "${_run_provider_status:-}" "${_run_runtime_error_type:-}" "${_run_classification_source:-}" "${_run_classification_pattern:-}" \
+		"$launch_failure_cause" "${_metric_kill_reason:-}" "$next_action"
 	return 0
 }
 
@@ -1468,6 +1505,8 @@ _execute_run_attempt() {
 	else
 		handle_exit=$?
 	fi
+	_run_metric_output_file="$_metric_output_file"
+	_run_metric_session_id="$_metric_session_id"
 	print_info "[lifecycle] handle_run_result_returned session=$session_key handle_exit=$handle_exit result_label=${_run_result_label:-unknown}"
 	end_ms=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
 	if [[ "$end_ms" =~ ^[0-9]+$ && "$start_ms" =~ ^[0-9]+$ && "$end_ms" -ge "$start_ms" ]]; then
@@ -1691,6 +1730,8 @@ cmd_run() {
 	local _run_should_retry=0
 	local _run_result_label="failed"
 	local _run_activity_detected="0"
+	local _run_metric_output_file=""
+	local _run_metric_session_id=""
 	while [[ "$attempt" -le "$max_attempts" ]]; do
 		_run_failure_reason=""
 		_run_should_retry=0
@@ -1744,9 +1785,10 @@ cmd_run() {
 
 			local _sic_exhausted_label="service_interruption_exhausted"
 			_run_result_label="$_sic_exhausted_label"
-			append_runtime_metric "$role" "$session_key" "$selected_model" \
-				"$(extract_provider "$selected_model")" \
-				"$_run_result_label" "81" "${_run_failure_reason:-provider_error}" "1" "0"
+			_append_service_interruption_exhausted_metric \
+				"$role" "$session_key" "$selected_model" "$work_dir" \
+				"${_run_failure_reason:-provider_error}" \
+				"${_run_metric_output_file:-}" "${_run_metric_session_id:-}"
 			print_warning "Exhausted ${max_service_interruption_continue_retries} service-interruption continuations — falling through to normal failure handling"
 		fi
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -762,6 +762,39 @@ test_service_interruption_candidate_uses_separate_path() {
 	return 0
 }
 
+test_service_interruption_exhausted_metric_preserves_context() {
+	local captured_file="${TEST_ROOT}/service-interruption-exhausted.args"
+	append_runtime_metric() {
+		printf '%s\n' "$@" >"$captured_file"
+		return 0
+	}
+	local WORKER_ISSUE_NUMBER="24099"
+	local DISPATCH_REPO_SLUG="owner/repo"
+	local _run_provider_error_type=""
+	local _run_provider_status=""
+	local _run_runtime_error_type=""
+	local _run_classification_source="default_local"
+	local _run_classification_pattern="default_local"
+	local _metric_kill_reason="unknown"
+
+	_append_service_interruption_exhausted_metric \
+		"worker" "issue-24099" "openai/gpt-5.5" \
+		"${TEST_ROOT}/worktree" "local_error" \
+		"${TEST_ROOT}/excerpt.log" "ses_context"
+
+	local captured
+	captured=$(<"$captured_file")
+	if [[ "$captured" == *$'service_interruption_exhausted\n81\nlocal_error\n1\n0\n24099\nowner/repo\n'* ]] && \
+		[[ "$captured" == *$'excerpt.log\nses_context\n'* ]] && \
+		[[ "$captured" == *$'mid_session_interruption\nunknown\nresume_existing_session'* ]]; then
+		print_result "service interruption exhausted metric preserves diagnostics context" 0
+	else
+		print_result "service interruption exhausted metric preserves diagnostics context" 1 "$captured"
+	fi
+	unset -f append_runtime_metric 2>/dev/null || true
+	return 0
+}
+
 test_canary_pins_vanilla_agent_with_isolated_plugin_config() {
 	local canary_root="${TEST_ROOT}/canary-agent"
 	local fake_bin_dir="${canary_root}/bin"
@@ -1582,6 +1615,7 @@ main() {
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
 	test_service_interruption_candidate_uses_separate_path
+	test_service_interruption_exhausted_metric_preserves_context
 	test_canary_pins_vanilla_agent_with_isolated_plugin_config
 	test_opencode_session_env_wrapper_strips_session_vars_only
 	test_worker_opencode_exec_paths_strip_session_env


### PR DESCRIPTION
## What

- Preserve diagnostic context when service-interruption continuation retries are exhausted.
- Classify `service_interruption_exhausted` as a mid-session interruption so metrics recommend resuming the existing session.
- Add regression coverage for issue/repo/worktree/excerpt/session/failure-evidence fields in the exhausted metric path.

## Verification

```bash
bash .agents/scripts/tests/test-headless-runtime-helper.sh
# Tests run: 61; Failures: 0

shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh
# no output

git diff --check
# no output
```

## Notes

No linked issue was present in the recovered session context.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 64,029 tokens on this as a headless worker.
