### PR TITLE
fix: apply Tabby left tab width default

### DIFF
--- a/.agents/scripts/setup/modules/post-setup.sh
+++ b/.agents/scripts/setup/modules/post-setup.sh
@@ -223,6 +223,7 @@ setup_tabby() {
 	# Ensure default local profile uses /bin/zsh (macOS).
 	# After macOS updates, Tabby can fall back to bash when this is unset.
 	bash "$tabby_helper" fix-shell || true
+	bash "$tabby_helper" fix-appearance || true
 
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
 		# Non-interactive: sync silently, warn on failure

--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -14,6 +14,7 @@
 #   tabby-helper.sh status        # Show current profile status
 #   tabby-helper.sh zshrc         # Deprecated no-op (TABBY_AUTORUN is unused)
 #   tabby-helper.sh fix-shell     # Ensure default local profile uses /bin/zsh (macOS)
+#   tabby-helper.sh fix-appearance # Apply aidevops Tabby UI defaults when unchanged
 #   tabby-helper.sh help          # Show usage
 #
 # Requires: python3 (ships with macOS), repos.json
@@ -29,10 +30,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 
 # Tabby config path (platform-aware)
-if [[ "$(uname -s)" == "Darwin" ]]; then
-	TABBY_CONFIG="${HOME}/Library/Application Support/tabby/config.yaml"
-else
-	TABBY_CONFIG="${HOME}/.config/tabby-terminal/config.yaml"
+if [[ -z "${TABBY_CONFIG:-}" ]]; then
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		TABBY_CONFIG="${HOME}/Library/Application Support/tabby/config.yaml"
+	else
+		TABBY_CONFIG="${HOME}/.config/tabby-terminal/config.yaml"
+	fi
 fi
 
 _info() { echo -e "${BLUE}[INFO]${NC} $1"; }
@@ -324,6 +327,154 @@ cmd_fix_shell() {
 	return 0
 }
 
+_fix_appearance_check_prereqs() {
+	if [[ ! -f "$TABBY_CONFIG" ]]; then
+		return 1
+	fi
+
+	if ! command -v python3 >/dev/null 2>&1; then
+		_warn "python3 is required to update Tabby appearance defaults"
+		return 1
+	fi
+
+	return 0
+}
+
+_fix_appearance_patch_config() {
+	# Adds the aidevops left-tab width CSS only when Tabby's appearance.css is
+	# absent or still the upstream placeholder. Existing user CSS is preserved.
+	local config_path="$1"
+
+	python3 - "$config_path" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+lines = text.splitlines(keepends=True)
+newline = "\n" if text.endswith("\n") else ""
+
+desired_block = [
+    "  css: |\n",
+    "    /* Widen left-side tab sidebar by 50% (default is 200px). */\n",
+    "    .content.tabs-on-left {\n",
+    "      --side-tab-width: calc(300px * var(--spaciness));\n",
+    "    }\n",
+]
+desired_marker = "--side-tab-width: calc(300px * var(--spaciness))"
+placeholder = "/* * { color: blue !important; } */"
+
+
+def top_level(line: str) -> bool:
+    return bool(line.strip()) and not line.startswith((" ", "\t")) and ":" in line
+
+
+appearance_start = None
+for index, line in enumerate(lines):
+    if line.startswith("appearance:"):
+        appearance_start = index
+        break
+
+if appearance_start is None:
+    print("WARN")
+    sys.exit(0)
+
+appearance_end = len(lines)
+for index in range(appearance_start + 1, len(lines)):
+    if top_level(lines[index]):
+        appearance_end = index
+        break
+
+css_start = None
+for index in range(appearance_start + 1, appearance_end):
+    stripped = lines[index].lstrip(" ")
+    indent = len(lines[index]) - len(stripped)
+    if indent == 2 and stripped.startswith("css:"):
+        css_start = index
+        break
+
+if css_start is None:
+    insert_at = appearance_end
+    for index in range(appearance_start + 1, appearance_end):
+        stripped = lines[index].lstrip(" ")
+        indent = len(lines[index]) - len(stripped)
+        if indent == 2 and stripped.startswith("tabsLocation:"):
+            insert_at = index
+            break
+    new_lines = lines[:insert_at] + desired_block + lines[insert_at:]
+    path.write_text("".join(new_lines) + ("" if new_lines and new_lines[-1].endswith("\n") else newline))
+    print("FIXED")
+    sys.exit(0)
+
+css_end = css_start + 1
+for index in range(css_start + 1, appearance_end):
+    stripped = lines[index].lstrip(" ")
+    indent = len(lines[index]) - len(stripped)
+    if stripped.strip() and indent <= 2:
+        break
+    css_end = index + 1
+
+css_text = "".join(lines[css_start:css_end])
+css_value = lines[css_start].split(":", 1)[1].strip()
+inline_value = css_value.strip('"\'')
+
+if desired_marker in css_text:
+    print("OK")
+elif inline_value in ("", "|", "|-", ">", ">-"):
+    body = "".join(lines[css_start + 1:css_end])
+    if body.strip() == placeholder:
+        path.write_text("".join(lines[:css_start] + desired_block + lines[css_end:]))
+        print("FIXED")
+    else:
+        print("SKIP:custom-css")
+elif inline_value == placeholder:
+    path.write_text("".join(lines[:css_start] + desired_block + lines[css_end:]))
+    print("FIXED")
+else:
+    print("SKIP:custom-css")
+PY
+
+	return 0
+}
+
+_fix_appearance_report_result() {
+	local result="$1"
+
+	case "$result" in
+	OK)
+		_success "Tabby left tab width default already applied"
+		;;
+	FIXED)
+		_success "Applied Tabby left tab width default (restart Tabby to apply)"
+		;;
+	SKIP:custom-css)
+		_info "Tabby custom CSS exists — not overriding"
+		;;
+	WARN)
+		_warn "Could not find appearance section in Tabby config"
+		;;
+	*)
+		_warn "Unexpected result from fix-appearance: $result"
+		;;
+	esac
+
+	return 0
+}
+
+cmd_fix_appearance() {
+	if ! _fix_appearance_check_prereqs; then
+		return 0
+	fi
+
+	local result
+	result=$(_fix_appearance_patch_config "$TABBY_CONFIG")
+	_fix_appearance_report_result "$result"
+
+	return 0
+}
+
 cmd_help() {
 	echo "tabby-helper.sh — Generate Tabby profiles from repos.json"
 	echo ""
@@ -332,6 +483,7 @@ cmd_help() {
 	echo "  tabby-helper.sh status     Show profile status (which repos have profiles)"
 	echo "  tabby-helper.sh zshrc      Deprecated no-op (TABBY_AUTORUN is unused)"
 	echo "  tabby-helper.sh fix-shell  Ensure default local profile uses /bin/zsh (macOS)"
+	echo "  tabby-helper.sh fix-appearance  Apply aidevops Tabby UI defaults when unchanged"
 	echo "  tabby-helper.sh help       Show this help"
 	echo ""
 	echo "Profiles are created with:"
@@ -353,6 +505,7 @@ main() {
 	status) cmd_status ;;
 	zshrc) cmd_zshrc ;;
 	fix-shell) cmd_fix_shell ;;
+	fix-appearance) cmd_fix_appearance ;;
 	help | --help | -h) cmd_help ;;
 	*)
 		_error "Unknown command: $cmd"

--- a/.agents/scripts/tests/test-tabby-helper-appearance.sh
+++ b/.agents/scripts/tests/test-tabby-helper-appearance.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-tabby-helper-appearance.sh — Tabby UI default migration regressions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+HELPER="${REPO_ROOT}/.agents/scripts/tabby-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_NC='\033[0m'
+
+pass_count=0
+fail_count=0
+
+_pass() {
+	local msg="$1"
+	printf '%b  PASS:%b %s\n' "${TEST_GREEN}" "${TEST_NC}" "${msg}"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+_fail() {
+	local msg="$1"
+	printf '%b  FAIL:%b %s\n' "${TEST_RED}" "${TEST_NC}" "${msg}" >&2
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+_contains() {
+	local path="$1"
+	local needle="$2"
+	python3 - "$path" "$needle" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+sys.exit(0 if sys.argv[2] in text else 1)
+PY
+	return $?
+}
+
+_run_fix_appearance() {
+	local config_path="$1"
+	TABBY_CONFIG="$config_path" bash "$HELPER" fix-appearance >/dev/null
+	return 0
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+config_missing_css="${tmp_dir}/missing-css.yaml"
+cat >"$config_missing_css" <<'YAML'
+version: 8
+appearance:
+  tabsInFullscreen: true
+  colorSchemeMode: auto
+  spaciness: 0.9
+  tabsLocation: left
+  flexTabs: true
+hacks: {}
+YAML
+
+_run_fix_appearance "$config_missing_css"
+if _contains "$config_missing_css" "--side-tab-width: calc(300px * var(--spaciness))"; then
+	_pass "missing appearance.css receives left-tab width default"
+else
+	_fail "missing appearance.css was not patched"
+fi
+
+_run_fix_appearance "$config_missing_css"
+if [[ "$(python3 - "$config_missing_css" <<'PY'
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).read_text().count("--side-tab-width"))
+PY
+)" == "1" ]]; then
+	_pass "left-tab width migration is idempotent"
+else
+	_fail "left-tab width migration duplicated CSS"
+fi
+
+config_placeholder="${tmp_dir}/placeholder-css.yaml"
+cat >"$config_placeholder" <<'YAML'
+version: 8
+appearance:
+  css: '/* * { color: blue !important; } */'
+  tabsLocation: left
+YAML
+
+_run_fix_appearance "$config_placeholder"
+if _contains "$config_placeholder" "--side-tab-width: calc(300px * var(--spaciness))"; then
+	_pass "Tabby placeholder CSS is replaced"
+else
+	_fail "Tabby placeholder CSS was not replaced"
+fi
+
+config_custom="${tmp_dir}/custom-css.yaml"
+cat >"$config_custom" <<'YAML'
+version: 8
+appearance:
+  css: |
+    .terminal { font-size: 18px; }
+  tabsLocation: left
+YAML
+
+before_custom="$(python3 - "$config_custom" <<'PY'
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).read_text())
+PY
+)"
+_run_fix_appearance "$config_custom"
+after_custom="$(python3 - "$config_custom" <<'PY'
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).read_text())
+PY
+)"
+if [[ "$before_custom" == "$after_custom" ]]; then
+	_pass "custom Tabby CSS is preserved"
+else
+	_fail "custom Tabby CSS was modified"
+fi
+
+if ((fail_count > 0)); then
+	printf '%bFAIL:%b %d test(s) failed\n' "${TEST_RED}" "${TEST_NC}" "$fail_count" >&2
+	exit 1
+fi
+
+printf '%bOK:%b %d test(s) passed\n' "${TEST_GREEN}" "${TEST_NC}" "$pass_count"


### PR DESCRIPTION
## Summary
- add `tabby-helper.sh fix-appearance` to apply the aidevops left-tab width CSS default
- run the appearance default during Tabby setup/update after the existing shell default repair
- preserve user custom CSS and keep the migration idempotent

Resolves #24062

## Verification
- `bash .agents/scripts/tests/test-tabby-helper-appearance.sh`
- `bash .agents/scripts/tests/test-tabby-profile-sync.sh`
- `python3 -m unittest tests/test-tabby-profile-sync.py`
- `shellcheck .agents/scripts/tabby-helper.sh .agents/scripts/setup/modules/post-setup.sh .agents/scripts/tests/test-tabby-helper-appearance.sh`
- `git diff --check`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 26m and 226,592 tokens on this with the user in an interactive session.