### PR TITLE
GH#24071: fix: preserve dispatch label cleanup exit codes

### DIFF
--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -29,28 +29,22 @@ clear_terminal_issue_dispatch_labels() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local context="${3:-terminal}"
+	local current_labels="${4:-}"
 
 	if [[ ! "$issue_number" =~ ^[0-9]+$ || -z "$repo_slug" ]]; then
 		return 1
 	fi
 
-	local current_labels
-	if ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
+	if [[ -z "$current_labels" ]] && ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
 		echo "[pulse-wrapper] dispatch-label-cleanup: failed to fetch labels for ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 1
 	fi
+	current_labels="${current_labels//$'\n'/:}"
 
 	local -a edit_args=("issue" "edit" "$issue_number" "--repo" "$repo_slug")
-	local label current_label label_found found=0
+	local label found=0
 	for label in "${_TERMINAL_DISPATCH_LABELS[@]}"; do
-		label_found=0
-		while IFS= read -r current_label; do
-			if [[ "$current_label" == "$label" ]]; then
-				label_found=1
-				break
-			fi
-		done <<<"$current_labels"
-		if [[ "$label_found" -eq 1 ]]; then
+		if [[ ":${current_labels}:" == *":${label}:"* ]]; then
 			edit_args+=("--remove-label" "$label")
 			found=1
 		fi
@@ -60,15 +54,15 @@ clear_terminal_issue_dispatch_labels() {
 		return 0
 	fi
 
-	gh "${edit_args[@]}" >/dev/null 2>&1
-	local exit_code=$?
+	local exit_code=0
+	gh "${edit_args[@]}" >/dev/null 2>&1 || exit_code=$?
 	if [[ "$exit_code" -eq 0 ]]; then
 		echo "[pulse-wrapper] dispatch-label-cleanup: stripped terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 0
 	fi
 
 	echo "[pulse-wrapper] dispatch-label-cleanup: failed to strip terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
-	return 1
+	return "$exit_code"
 }
 
 _dispatch_label_sweep_due() {
@@ -123,21 +117,21 @@ sweep_closed_auto_dispatch_issues() {
 	[[ "$limit" =~ ^[0-9]+$ ]] || limit=50
 	[[ "$limit" -gt 0 ]] || limit=50
 
-	local total=0 repo_slug issue_number issue_numbers
+	local total=0 repo_slug issue_number current_labels issue_rows exit_code
 	while IFS= read -r repo_slug; do
 		[[ -n "$repo_slug" ]] || continue
-		issue_numbers=$(gh issue list --repo "$repo_slug" --state closed \
+		issue_rows=$(gh issue list --repo "$repo_slug" --state closed \
 			--label "auto-dispatch" --limit "$limit" \
-			--json number --jq '.[].number' 2>/dev/null) || issue_numbers=""
-		[[ -n "$issue_numbers" ]] || continue
-		while IFS= read -r issue_number; do
+			--json number,labels --jq '.[] | [.number, ([.labels[].name] | join(":"))] | @tsv' 2>/dev/null) || issue_rows=""
+		[[ -n "$issue_rows" ]] || continue
+		while IFS=$'\t' read -r issue_number current_labels; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
-			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep"
-			local exit_code=$?
+			exit_code=0
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" "$current_labels" || exit_code=$?
 			if [[ "$exit_code" -eq 0 ]]; then
 				total=$((total + 1))
 			fi
-		done <<<"$issue_numbers"
+		done <<<"$issue_rows"
 	done < <(_dispatch_label_sweep_repos "$repos_json" || true)
 
 	_dispatch_label_sweep_mark_run

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -53,12 +53,15 @@ install_gh_stub() {
 	gh() {
 		printf '%s\n' "$*" >>"${TEST_ROOT}/gh.log"
 		if [[ "$1" == "issue" && "$2" == "list" ]]; then
-			printf '101\n102\n'
+			printf '101\tauto-dispatch:status:queued\n102\tauto-dispatch\n'
 			return 0
 		fi
 		if [[ "$1" == "issue" && "$2" == "view" ]]; then
 			printf 'auto-dispatch\nstatus:queued\n'
 			return 0
+		fi
+		if [[ "$1" == "issue" && "$2" == "edit" && "${GH_STUB_FAIL_EDIT:-0}" == "1" ]]; then
+			return 7
 		fi
 		return 0
 	}
@@ -92,10 +95,11 @@ test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
 	# shellcheck source=../shared-dispatch-label-cleanup.sh
 	source "$HELPER"
 	sweep_closed_auto_dispatch_issues
-	local edit_count list_count
+	local edit_count list_count view_count
 	edit_count=$(grep -c 'issue edit' "${TEST_ROOT}/gh.log" || true)
 	list_count=$(grep -c 'issue list' "${TEST_ROOT}/gh.log" || true)
-	if [[ "$edit_count" == "2" && "$list_count" == "1" ]]; then
+	view_count=$(grep -c 'issue view' "${TEST_ROOT}/gh.log" || true)
+	if [[ "$edit_count" == "2" && "$list_count" == "1" && "$view_count" == "0" ]]; then
 		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 0
 	else
 		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 1
@@ -104,8 +108,27 @@ test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
 	return 0
 }
 
+test_clear_terminal_labels_propagates_edit_failures() {
+	setup_env
+	install_gh_stub
+	export GH_STUB_FAIL_EDIT=1
+	# shellcheck source=../shared-dispatch-label-cleanup.sh
+	source "$HELPER"
+	local exit_code=0
+	clear_terminal_issue_dispatch_labels 42 owner/repo test-context || exit_code=$?
+	unset GH_STUB_FAIL_EDIT
+	if [[ "$exit_code" == "7" ]]; then
+		print_result "terminal label cleanup propagates edit failures" 0
+	else
+		print_result "terminal label cleanup propagates edit failures" 1
+	fi
+	teardown_env
+	return 0
+}
+
 test_clear_terminal_labels_removes_dispatch_labels
 test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos
+test_clear_terminal_labels_propagates_edit_failures
 
 printf 'Tests run: %s\n' "$TESTS_RUN"
 printf 'Tests failed: %s\n' "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Preserved dispatch label cleanup exit codes, avoided redundant per-item label reads during closed-issue sweeps, and added regression coverage for edit failures.

## Files Changed

.agents/scripts/shared-dispatch-label-cleanup.sh,.agents/scripts/tests/test-dispatch-label-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-label-cleanup.sh; shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh; git diff --check origin/main...HEAD

Resolves #24071


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 60,727 tokens on this as a headless worker.