### PR TITLE
GH#24065: fix: harden report markdown rendering

### DIFF
--- a/.agents/scripts/report_render_markdown.py
+++ b/.agents/scripts/report_render_markdown.py
@@ -193,7 +193,7 @@ def render_mermaid_svg(code_text: str) -> str:
     edges: list[tuple[str, str]] = []
 
     def node_parts(raw_node: str) -> tuple[str, str]:
-        match = re.match(r"^([A-Za-z0-9_]+)(?:\[([^\]]+)\])?$", raw_node.strip())
+        match = re.match(r"^([A-Za-z0-9_-]+)\s*(?:\[([^\]]+)\])?$", raw_node.strip())
         if not match:
             fallback = raw_node.strip()
             return fallback, fallback
@@ -263,10 +263,11 @@ def render_mermaid_svg(code_text: str) -> str:
             )
 
     if not arrows:
-        for index, node_id in enumerate(nodes):
-            if index >= len(nodes) - 1:
+        node_ids = list(nodes.keys())
+        for index, node_id in enumerate(node_ids):
+            if index >= len(node_ids) - 1:
                 break
-            next_id = list(nodes.keys())[index + 1]
+            next_id = node_ids[index + 1]
             x, y, column, row = positions[node_id]
             next_x, next_y, _, _ = positions[next_id]
             if (index + 1) % columns == 0:
@@ -529,11 +530,10 @@ def split_markdown_table_row(line: str) -> list[str]:
     index = 0
     while index < len(row):
         char = row[index]
-        if char == "\\" and index + 1 < len(row) and row[index + 1] == "|":
+        if char == "|" and _has_odd_trailing_backslashes(current):
+            current.pop()
             current.append("|")
-            index += 2
-            continue
-        if char == "|":
+        elif char == "|":
             cells.append("".join(current))
             current = []
         else:
@@ -541,6 +541,15 @@ def split_markdown_table_row(line: str) -> list[str]:
         index += 1
     cells.append("".join(current))
     return cells
+
+
+def _has_odd_trailing_backslashes(chars: list[str]) -> bool:
+    count = 0
+    for char in reversed(chars):
+        if char != "\\":
+            break
+        count += 1
+    return count % 2 == 1
 
 
 def open_list(body: list[str], states: dict[str, object], tag: str, css_class: str = "") -> None:

--- a/.agents/scripts/report_render_markdown.py
+++ b/.agents/scripts/report_render_markdown.py
@@ -189,15 +189,30 @@ def is_executive_summary(title: str) -> bool:
 def render_mermaid_svg(code_text: str) -> str:
     """Render a small self-contained SVG for simple Mermaid flowchart examples."""
 
-    nodes: list[str] = []
+    nodes: dict[str, str] = {}
+    edges: list[tuple[str, str]] = []
+
+    def node_parts(raw_node: str) -> tuple[str, str]:
+        match = re.match(r"^([A-Za-z0-9_]+)(?:\[([^\]]+)\])?$", raw_node.strip())
+        if not match:
+            fallback = raw_node.strip()
+            return fallback, fallback
+        node_id = match.group(1)
+        label = (match.group(2) or node_id).strip()
+        return node_id, label
+
     for line in code_text.splitlines():
         if "-->" not in line:
             continue
         left, right = [part.strip() for part in line.split("-->", 1)]
-        for node in (left, right):
-            label = re.sub(r"^[A-Za-z0-9_]+\[([^\]]+)\]$", r"\1", node).strip()
-            if label and label not in nodes:
-                nodes.append(label)
+        left_id, left_label = node_parts(left)
+        right_id, right_label = node_parts(right)
+        if left_id and left_id not in nodes:
+            nodes[left_id] = left_label
+        if right_id and right_id not in nodes:
+            nodes[right_id] = right_label
+        if left_id and right_id:
+            edges.append((left_id, right_id))
     if len(nodes) < 2:
         return ""
     if len(nodes) > 4:
@@ -215,27 +230,52 @@ def render_mermaid_svg(code_text: str) -> str:
         width = max(720, len(nodes) * 190)
         height = 130
     boxes = []
+    positions: dict[str, tuple[int, int, int, int]] = {}
     arrows = []
-    for index, label in enumerate(nodes):
+    for index, (node_id, label) in enumerate(nodes.items()):
         column = index % columns
         row = index // columns
         x = 24 + column * cell_width
         y = 35 + row * cell_height
+        positions[node_id] = (x, y, column, row)
         safe_label = html.escape(label)
         boxes.append(
             f'<rect x="{x}" y="{y}" width="160" height="58" rx="14" class="diagram-node" />'
             f'<text x="{x + 80}" y="{y + 35}" text-anchor="middle" class="diagram-label">{safe_label}</text>'
         )
-        if index < len(nodes) - 1:
+    for left_id, right_id in edges:
+        if left_id not in positions or right_id not in positions:
+            continue
+        left_x, left_y, left_column, left_row = positions[left_id]
+        right_x, right_y, right_column, right_row = positions[right_id]
+        if left_row == right_row and left_column < right_column:
+            arrows.append(
+                f'<line x1="{left_x + 165}" y1="{left_y + 29}" x2="{right_x - 10}" y2="{right_y + 29}" class="diagram-arrow" />'
+            )
+        elif left_column == right_column and left_row < right_row:
+            arrows.append(
+                f'<line x1="{left_x + 80}" y1="{left_y + 63}" x2="{right_x + 80}" y2="{right_y - 10}" class="diagram-arrow" />'
+            )
+        else:
+            mid_y = left_y + 78
+            arrows.append(
+                f'<path d="M {left_x + 80} {left_y + 63} V {mid_y} H {right_x + 80} V {right_y - 10}" class="diagram-arrow" fill="none" />'
+            )
+
+    if not arrows:
+        for index, node_id in enumerate(nodes):
+            if index >= len(nodes) - 1:
+                break
+            next_id = list(nodes.keys())[index + 1]
+            x, y, column, row = positions[node_id]
+            next_x, next_y, _, _ = positions[next_id]
             if (index + 1) % columns == 0:
-                next_row = row + 1
-                next_y = 35 + next_row * cell_height
                 arrows.append(
-                    f'<path d="M {x + 80} {y + 63} V {next_y - 16} H 104 V {next_y + 28}" class="diagram-arrow" fill="none" />'
+                    f'<path d="M {x + 80} {y + 63} V {next_y - 16} H {next_x + 80} V {next_y - 10}" class="diagram-arrow" fill="none" />'
                 )
             else:
                 arrows.append(
-                    f'<line x1="{x + 165}" y1="{y + 29}" x2="{x + cell_width - 16}" y2="{y + 29}" class="diagram-arrow" />'
+                    f'<line x1="{x + 165}" y1="{y + 29}" x2="{next_x - 10}" y2="{next_y + 29}" class="diagram-arrow" />'
                 )
     return (
         '<figure class="mermaid-rendered" aria-label="Rendered Mermaid diagram">'
@@ -468,7 +508,7 @@ def handle_rule(line: str, body: list[str], states: dict[str, object]) -> bool:
 def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     if not line.startswith("|") or not line.endswith("|"):
         return False
-    cells = [inline_markup(cell.strip()) for cell in line.strip("|").split("|")]
+    cells = [inline_markup(cell.strip()) for cell in split_markdown_table_row(line)]
     raw_cells = [html.unescape(cell) for cell in cells]
     if all(re.match(r"^:?-{3,}:?$", cell) for cell in raw_cells):
         return True
@@ -480,6 +520,27 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
         return True
     body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
     return True
+
+
+def split_markdown_table_row(line: str) -> list[str]:
+    row = line.strip()[1:-1]
+    cells: list[str] = []
+    current: list[str] = []
+    index = 0
+    while index < len(row):
+        char = row[index]
+        if char == "\\" and index + 1 < len(row) and row[index + 1] == "|":
+            current.append("|")
+            index += 2
+            continue
+        if char == "|":
+            cells.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+        index += 1
+    cells.append("".join(current))
+    return cells
 
 
 def open_list(body: list[str], states: dict[str, object], tag: str, css_class: str = "") -> None:

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -222,9 +222,11 @@ test_markdown_table_preserves_escaped_pipes() {
 | Component | Evidence |
 |---|---|
 | AIO \| CLI | Keeps one cell |
+| Literal \\| Separator | Next cell |
 MARKDOWN
 	"$HELPER_SH" render "$_input" --output "$_out"
 	assert_contains "$_out" "<td>AIO | CLI</td>" "Markdown table preserves escaped pipes inside cells"
+	assert_contains "$_out" "<td>Separator</td>" "Markdown table keeps even-backslash pipe as separator"
 	if grep -qF "<td>CLI</td>" "$_out"; then
 		print_result "Markdown table does not split escaped pipe cells" 1 "Escaped pipe created an extra cell"
 	else
@@ -241,7 +243,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(sys.argv[1]).resolve()))
 from report_render_markdown import render_mermaid_svg
 
-html = render_mermaid_svg("A[Repeat] --> B[Repeat]\nB[Repeat] --> C[Done]")
+html = render_mermaid_svg("node-1 [Repeat] --> node-2[Repeat]\nnode-2[Repeat] --> node-3[Done]")
 if html.count('class="diagram-label">Repeat</text>') != 2:
     raise SystemExit(1)
 if "H 104" in html:

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -213,6 +213,48 @@ MARKDOWN
 	return 0
 }
 
+test_markdown_table_preserves_escaped_pipes() {
+	local _input="${TEST_ROOT}/table-escaped-pipe.md"
+	local _out="${TEST_ROOT}/table-escaped-pipe.html"
+	cat >"$_input" <<'MARKDOWN'
+# Escaped Pipe Table
+
+| Component | Evidence |
+|---|---|
+| AIO \| CLI | Keeps one cell |
+MARKDOWN
+	"$HELPER_SH" render "$_input" --output "$_out"
+	assert_contains "$_out" "<td>AIO | CLI</td>" "Markdown table preserves escaped pipes inside cells"
+	if grep -qF "<td>CLI</td>" "$_out"; then
+		print_result "Markdown table does not split escaped pipe cells" 1 "Escaped pipe created an extra cell"
+	else
+		print_result "Markdown table does not split escaped pipe cells" 0
+	fi
+	return 0
+}
+
+test_mermaid_renderer_uses_node_ids() {
+	if python3 - "${SCRIPT_DIR}/.." <<'PYHTML'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1]).resolve()))
+from report_render_markdown import render_mermaid_svg
+
+html = render_mermaid_svg("A[Repeat] --> B[Repeat]\nB[Repeat] --> C[Done]")
+if html.count('class="diagram-label">Repeat</text>') != 2:
+    raise SystemExit(1)
+if "H 104" in html:
+    raise SystemExit(1)
+PYHTML
+	then
+		print_result "Mermaid renderer preserves distinct IDs with duplicate labels" 0
+	else
+		print_result "Mermaid renderer preserves distinct IDs with duplicate labels" 1 "Expected duplicate labels to render as separate nodes"
+	fi
+	return 0
+}
+
 test_multiline_markdown_paragraph() {
 	local _input="${TEST_ROOT}/paragraph.md"
 	local _out="${TEST_ROOT}/paragraph.html"
@@ -296,6 +338,8 @@ main() {
 	test_python_helper_requires_mode
 	test_python_helper_reads_stdin_by_default
 	test_markdown_table_uses_header_cells
+	test_markdown_table_preserves_escaped_pipes
+	test_mermaid_renderer_uses_node_ids
 	test_multiline_markdown_paragraph
 	test_render_json_array_is_resilient
 	test_sample_and_css_commands


### PR DESCRIPTION
## Summary

Handled escaped pipe characters when splitting Markdown table rows and updated Mermaid SVG rendering to track nodes by ID and draw declared edges instead of assuming a linear label sequence. Added regression coverage for escaped table pipes and duplicate Mermaid labels.

## Files Changed

.agents/scripts/report_render_markdown.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_markdown.py && .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh; .agents/scripts/linters-local.sh was attempted and exceeded 120s after reporting pre-existing markdown advisory issues

Resolves #24065


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 58,041 tokens on this as a headless worker.