### PR TITLE
GH#24066: fix: harden report style token parsing

### DIFF
--- a/.agents/scripts/report_render_styles.py
+++ b/.agents/scripts/report_render_styles.py
@@ -43,6 +43,12 @@ STYLE_SLUGS = (
     "usgraphics",
 )
 
+TOKEN_SECTION_PREFIXES = {
+    "colors": "",
+    "rounded": "rounded.",
+    "typography": "",
+}
+
 DEFAULT_TOKENS = {
     "background": "#f8f6f1",
     "surface": "#ffffff",
@@ -77,7 +83,7 @@ def _base_report_css() -> str:
 def _front_matter(path: Path) -> list[str]:
     lines = path.read_text(encoding="utf-8").splitlines()
     start = -1
-    for index, line in enumerate(lines[:8]):
+    for index, line in enumerate(lines):
         if line.strip() == "---":
             start = index
             break
@@ -167,44 +173,61 @@ def _parse_mapping(line: str, prefix: str = "") -> tuple[str, str] | None:
     return f"{prefix}{key.strip()}", _clean(value)
 
 
-def _parse_typography_line(line: str, nested: str, indent: int) -> tuple[str, str, str | None]:
-    if indent == 2 and line.endswith(":"):
-        return line[:-1], "", None
-    if nested and indent == 4:
-        parsed = _parse_mapping(line, f"{nested}.")
-        if parsed is not None:
-            key, value = parsed
-            return nested, key, value
-    return nested, "", None
+def _indent_width(line: str) -> int:
+    width = 0
+    for char in line:
+        if char == " ":
+            width += 1
+            continue
+        if char == "\t":
+            width += 2
+            continue
+        break
+    return width
+
+
+def _parse_nested_mapping(lines: list[str]) -> dict[str, object]:
+    root: dict[str, object] = {}
+    stack: list[tuple[int, dict[str, object]]] = []
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        stripped = line.strip()
+        parsed = _parse_mapping(stripped)
+        if parsed is None:
+            continue
+        key, value = parsed
+        indent = _indent_width(line)
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1] if stack else root
+        if stripped.endswith(":") and value == "":
+            child: dict[str, object] = {}
+            parent[key] = child
+            stack.append((indent, child))
+            continue
+        parent[key] = value
+    return root
+
+
+def _flatten_token_mapping(value: object, prefix: str = "") -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    flattened: dict[str, str] = {}
+    for key, item in value.items():
+        token_key = f"{prefix}{key}"
+        if isinstance(item, dict):
+            flattened.update(_flatten_token_mapping(item, f"{token_key}."))
+            continue
+        flattened[token_key] = str(item)
+    return flattened
 
 
 def _parse_tokens(lines: list[str]) -> dict[str, str]:
     tokens: dict[str, str] = {}
-    section = ""
-    nested = ""
-    for line in lines:
-        if not line.strip() or line.lstrip().startswith("#"):
-            continue
-        indent = len(line) - len(line.lstrip(" "))
-        stripped = line.strip()
-        if indent == 0 and stripped.endswith(":"):
-            section = stripped[:-1]
-            nested = ""
-            continue
-        if section == "colors" and indent == 2:
-            parsed = _parse_mapping(stripped)
-            if parsed is not None:
-                tokens[parsed[0]] = parsed[1]
-            continue
-        if section == "rounded" and indent == 2:
-            parsed = _parse_mapping(stripped, "rounded.")
-            if parsed is not None:
-                tokens[parsed[0]] = parsed[1]
-            continue
-        if section == "typography":
-            nested, key, value = _parse_typography_line(stripped, nested, indent)
-            if value is not None:
-                tokens[key] = value
+    document = _parse_nested_mapping(lines)
+    for section, prefix in TOKEN_SECTION_PREFIXES.items():
+        tokens.update(_flatten_token_mapping(document.get(section), prefix))
     return tokens
 
 

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -196,6 +196,49 @@ test_python_helper_reads_stdin_by_default() {
 	return 0
 }
 
+test_style_token_parser_handles_long_headers_and_tabs() {
+	local _result=0
+	python3 - "$SCRIPT_DIR" "$TEST_ROOT" <<'PY' || _result=$?
+from pathlib import Path
+import importlib.util
+import sys
+
+script_dir = Path(sys.argv[1])
+test_root = Path(sys.argv[2])
+module_path = script_dir.parent / "report_render_styles.py"
+spec = importlib.util.spec_from_file_location("report_render_styles", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+design = test_root / "DESIGN.md"
+design.write_text(
+    "# header\n" * 10
+    + "---\n"
+    + "colors:\n"
+    + "\tbackground: '#123456'\n"
+    + "rounded:\n"
+    + "\tlg: 20px\n"
+    + "typography:\n"
+    + "\theadline-display:\n"
+    + "\t\tfontSize: 72px\n"
+    + "---\n",
+    encoding="utf-8",
+)
+front_matter = module._front_matter(design)
+tokens = module._parse_tokens(front_matter)
+assert tokens["background"] == "#123456"
+assert tokens["rounded.lg"] == "20px"
+assert tokens["headline-display.fontSize"] == "72px"
+PY
+	if [[ "$_result" -ne 0 ]]; then
+		print_result "Style token parser handles long headers and tabs" 1 "Expected long preamble and tab-indented tokens to parse"
+		return 0
+	fi
+	print_result "Style token parser handles long headers and tabs" 0
+	return 0
+}
+
 test_markdown_table_uses_header_cells() {
 	local _input="${TEST_ROOT}/table.md"
 	local _out="${TEST_ROOT}/table.html"
@@ -295,6 +338,7 @@ main() {
 	test_validate_rejects_unknown_badge
 	test_python_helper_requires_mode
 	test_python_helper_reads_stdin_by_default
+	test_style_token_parser_handles_long_headers_and_tabs
 	test_markdown_table_uses_header_cells
 	test_multiline_markdown_paragraph
 	test_render_json_array_is_resilient


### PR DESCRIPTION
## Summary

Hardened DESIGN.md style token loading by scanning front matter beyond the first 8 lines and replacing fixed indentation parsing with a nested mapping parser that handles tab-indented token blocks. Added a regression covering long headers and tab indentation.

## Files Changed

.agents/scripts/report_render_styles.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_styles.py; shellcheck .agents/scripts/tests/test-report-render-helper.sh; .agents/scripts/tests/test-report-render-helper.sh

Resolves #24066


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 48,054 tokens on this as a headless worker.