### PR TITLE
GH#24068: fix: align run metric kill reason variable

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1153,7 +1153,7 @@ _append_service_interruption_exhausted_metric() {
 		"$result_label" "81" "${failure_reason:-provider_error}" "1" "0" \
 		"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$output_file" "$session_id" \
 		"${_run_provider_error_type:-}" "${_run_provider_status:-}" "${_run_runtime_error_type:-}" "${_run_classification_source:-}" "${_run_classification_pattern:-}" \
-		"$launch_failure_cause" "${_metric_kill_reason:-}" "$next_action"
+		"$launch_failure_cause" "${_run_metric_kill_reason:-}" "$next_action"
 	return 0
 }
 
@@ -1269,7 +1269,7 @@ _execute_run_attempt() {
 	local output_file exit_code_file exit_code
 	local start_ms end_ms duration_ms
 	local resource_stop_file resource_result_file resource_sampler_pid
-	local _metric_kill_reason=""
+	local _run_metric_kill_reason=""
 	start_ms=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
 	output_file=$(mktemp)
 	exit_code_file=$(mktemp)
@@ -1368,7 +1368,7 @@ _execute_run_attempt() {
 	# file is authoritative — if it exists, this was a watchdog kill.
 	local _normalized_exit_info=""
 	_normalized_exit_info=$(_normalize_worker_exit_code_and_kill_reason "$exit_code_file" "$exit_code")
-	IFS=$'\t' read -r exit_code _metric_kill_reason <<<"$_normalized_exit_info"
+	IFS=$'\t' read -r exit_code _run_metric_kill_reason <<<"$_normalized_exit_info"
 	# t2956 / Issue #21231: Hard-kill sentinel — set when the watchdog
 	# escalated from passive (78 / continue) to proactive (79 / killed)
 	# because the worker had been stalling for ≥ WORKER_STALL_HARD_KILL_SECONDS
@@ -1411,7 +1411,7 @@ _execute_run_attempt() {
 			_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
 			exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
 			_normalized_exit_info=$(_normalize_worker_exit_code_and_kill_reason "$exit_code_file" "$exit_code")
-			IFS=$'\t' read -r exit_code _metric_kill_reason <<<"$_normalized_exit_info"
+			IFS=$'\t' read -r exit_code _run_metric_kill_reason <<<"$_normalized_exit_info"
 			# t2956: Hard-kill sentinel must also be re-checked on the retry path.
 			local _retry_stall_killed_marker="${exit_code_file}.watchdog_stall_killed"
 			if [[ -f "$_retry_stall_killed_marker" ]]; then
@@ -1459,7 +1459,7 @@ _execute_run_attempt() {
 		append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "$_run_result_label" "0" "$_run_failure_reason" "0" "$_rl_duration_ms" \
 			"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_rl_metric_output_file" "$_rl_metric_session_id" \
 			"${_run_provider_error_type:-}" "${_run_provider_status:-}" "${_run_runtime_error_type:-}" "${_run_classification_source:-}" "${_run_classification_pattern:-}" \
-			"provider_rate_limited" "${_metric_kill_reason}" "rotate_provider_or_wait_for_reset"
+			"provider_rate_limited" "${_run_metric_kill_reason}" "rotate_provider_or_wait_for_reset"
 		return 80
 	fi
 
@@ -1483,7 +1483,7 @@ _execute_run_attempt() {
 		printf '\n[WORKER_EXIT_DIAGNOSTICS] exit_code=%s model=%s role=%s session_key=%s\n' \
 			"$exit_code" "$selected_model" "$role" "$session_key"
 		printf '[WORKER_EXIT_DIAGNOSTICS] structured exit_code=%s kill_reason=%s session_key=%s\n' \
-			"$exit_code" "${_metric_kill_reason:-unknown}" "$session_key"
+			"$exit_code" "${_run_metric_kill_reason:-unknown}" "$session_key"
 		if [[ "$exit_code" -eq 124 ]]; then
 			printf '[WORKER_EXIT_DIAGNOSTICS] cause=watchdog_kill (no LLM activity within timeout)\n'
 		elif [[ "$exit_code" -eq 137 ]]; then
@@ -1527,14 +1527,14 @@ _execute_run_attempt() {
 	local _evidence_fields
 	_evidence_fields=$(_derive_worker_failure_evidence \
 		"${_run_result_label:-failed}" "$exit_code" "${_run_activity_detected:-0}" \
-		"${_metric_kill_reason:-}" "${_run_failure_reason:-}")
+		"${_run_metric_kill_reason:-}" "${_run_failure_reason:-}")
 	_launch_failure_cause="${_evidence_fields%%$'\t'*}"
 	_next_action="${_evidence_fields#*$'\t'}"
-	print_info "[lifecycle] worker_failure_evidence session=$session_key result=${_run_result_label:-failed} exit_code=$exit_code kill_reason=${_metric_kill_reason:-unknown} launch_failure_cause=${_launch_failure_cause:-none} next_action=${_next_action:-none}"
+	print_info "[lifecycle] worker_failure_evidence session=$session_key result=${_run_result_label:-failed} exit_code=$exit_code kill_reason=${_run_metric_kill_reason:-unknown} launch_failure_cause=${_launch_failure_cause:-none} next_action=${_next_action:-none}"
 	append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "${_run_result_label:-failed}" "$handle_exit" "${_run_failure_reason:-}" "${_run_activity_detected:-0}" "$duration_ms" \
 		"${WORKER_ISSUE_NUMBER:-}" "${DISPATCH_REPO_SLUG:-}" "$work_dir" "$_metric_output_file" "$_metric_session_id" \
 		"${_run_provider_error_type:-}" "${_run_provider_status:-}" "${_run_runtime_error_type:-}" "${_run_classification_source:-}" "${_run_classification_pattern:-}" \
-		"$_launch_failure_cause" "${_metric_kill_reason:-}" "$_next_action"
+		"$_launch_failure_cause" "${_run_metric_kill_reason:-}" "$_next_action"
 	return "$handle_exit"
 }
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -775,7 +775,7 @@ test_service_interruption_exhausted_metric_preserves_context() {
 	local _run_runtime_error_type=""
 	local _run_classification_source="default_local"
 	local _run_classification_pattern="default_local"
-	local _metric_kill_reason="unknown"
+	local _run_metric_kill_reason="unknown"
 
 	_append_service_interruption_exhausted_metric \
 		"worker" "issue-24099" "openai/gpt-5.5" \


### PR DESCRIPTION
## Summary

Renamed the run-attempt kill reason metric variable consistently in headless-runtime-helper and its service-interruption exhaustion test so review feedback from PR #24059 is reflected in both implementation and test scaffolding.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24068


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 62,579 tokens on this as a headless worker.