### PR TITLE
GH#24071: fix: simplify dispatch cleanup label matching

### DIFF
--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -39,12 +39,12 @@ clear_terminal_issue_dispatch_labels() {
 		echo "[pulse-wrapper] dispatch-label-cleanup: failed to fetch labels for ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 1
 	fi
-	current_labels="${current_labels//$'\n'/:}"
 
 	local -a edit_args=("issue" "edit" "$issue_number" "--repo" "$repo_slug")
-	local label found=0
+	local label labels_blob found=0
+	labels_blob=$'\n'"$current_labels"$'\n'
 	for label in "${_TERMINAL_DISPATCH_LABELS[@]}"; do
-		if [[ ":${current_labels}:" == *":${label}:"* ]]; then
+		if [[ "$labels_blob" == *$'\n'"$label"$'\n'* ]]; then
 			edit_args+=("--remove-label" "$label")
 			found=1
 		fi
@@ -117,21 +117,21 @@ sweep_closed_auto_dispatch_issues() {
 	[[ "$limit" =~ ^[0-9]+$ ]] || limit=50
 	[[ "$limit" -gt 0 ]] || limit=50
 
-	local total=0 repo_slug issue_number current_labels issue_rows exit_code
+	local total=0 repo_slug issue_number issue_numbers
 	while IFS= read -r repo_slug; do
 		[[ -n "$repo_slug" ]] || continue
-		issue_rows=$(gh issue list --repo "$repo_slug" --state closed \
+		issue_numbers=$(gh issue list --repo "$repo_slug" --state closed \
 			--label "auto-dispatch" --limit "$limit" \
-			--json number,labels --jq '.[] | [.number, ([.labels[].name] | join(":"))] | @tsv' 2>/dev/null) || issue_rows=""
-		[[ -n "$issue_rows" ]] || continue
-		while IFS=$'\t' read -r issue_number current_labels; do
+			--json number --jq '.[].number' 2>/dev/null) || issue_numbers=""
+		[[ -n "$issue_numbers" ]] || continue
+		while IFS= read -r issue_number; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
-			exit_code=0
-			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" "$current_labels" || exit_code=$?
+			local exit_code=0
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" || exit_code=$?
 			if [[ "$exit_code" -eq 0 ]]; then
 				total=$((total + 1))
 			fi
-		done <<<"$issue_rows"
+		done <<<"$issue_numbers"
 	done < <(_dispatch_label_sweep_repos "$repos_json" || true)
 
 	_dispatch_label_sweep_mark_run

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -53,7 +53,7 @@ install_gh_stub() {
 	gh() {
 		printf '%s\n' "$*" >>"${TEST_ROOT}/gh.log"
 		if [[ "$1" == "issue" && "$2" == "list" ]]; then
-			printf '101\tauto-dispatch:status:queued\n102\tauto-dispatch\n'
+			printf '101\n102\n'
 			return 0
 		fi
 		if [[ "$1" == "issue" && "$2" == "view" ]]; then
@@ -95,11 +95,10 @@ test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
 	# shellcheck source=../shared-dispatch-label-cleanup.sh
 	source "$HELPER"
 	sweep_closed_auto_dispatch_issues
-	local edit_count list_count view_count
+	local edit_count list_count
 	edit_count=$(grep -c 'issue edit' "${TEST_ROOT}/gh.log" || true)
 	list_count=$(grep -c 'issue list' "${TEST_ROOT}/gh.log" || true)
-	view_count=$(grep -c 'issue view' "${TEST_ROOT}/gh.log" || true)
-	if [[ "$edit_count" == "2" && "$list_count" == "1" && "$view_count" == "0" ]]; then
+	if [[ "$edit_count" == "2" && "$list_count" == "1" ]]; then
 		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 0
 	else
 		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 1


### PR DESCRIPTION
## Summary

Follow-up to #24073 and supersedes #24080: preserve the exit-code propagation fix while simplifying label matching back to newline-delimited exact matches and restoring the closed-sweep per-issue label fetch path. Rebasing on current `main` avoids the stale-head Qlty smell regression seen on #24080.

## Files Changed

- `.agents/scripts/shared-dispatch-label-cleanup.sh`
- `.agents/scripts/tests/test-dispatch-label-cleanup.sh`

## Runtime Testing

- `bash .agents/scripts/tests/test-dispatch-label-cleanup.sh`
- `shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh`
- `git diff --check origin/main...HEAD`

Resolves #24071

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 14m and 127,869 tokens on this as a headless worker.
