### PR TITLE
GH#24085: fix: guard issue-worker release operations

### DIFF
--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER_SCRIPT="${SCRIPT_DIR}/../headless-runtime-helper.sh"
+VERSION_MANAGER_SCRIPT="${SCRIPT_DIR}/../version-manager.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -618,6 +619,57 @@ This worker run is unattended.'
 	fi
 
 	print_result "does not double-append existing contract" 1 "Existing contract was modified"
+	return 0
+}
+
+test_version_manager_denies_issue_worker_release_writes() {
+	local worktree_dir="${TEST_ROOT}/version-manager-deny"
+	mkdir -p "$worktree_dir"
+	init_git_worktree "$worktree_dir"
+	printf '%s\n' "1.2.3" >"${worktree_dir}/VERSION"
+
+	local output="" status=0 version_after=""
+	output=$(
+		cd "$worktree_dir" || exit 1
+		# shellcheck source=/dev/null
+		source "$VERSION_MANAGER_SCRIPT" >/dev/null 2>&1 || exit 1
+		export AIDEVOPS_HEADLESS=1 WORKER_ISSUE_NUMBER=24085 WORKER_SESSION_KEY="issue-24085"
+		_version_manager_guard_headless_release_scope release patch
+	) 2>&1 || status=$?
+	version_after=$(<"${worktree_dir}/VERSION")
+
+	if [[ "$status" -ne 0 && "$version_after" == "1.2.3" ]]; then
+		print_result "version-manager denies ordinary issue-worker release writes" 0
+		return 0
+	fi
+
+	print_result "version-manager denies ordinary issue-worker release writes" 1 \
+		"status=$status version=${version_after:-<empty>} output=${output:-<empty>}"
+	return 0
+}
+
+test_version_manager_allows_approved_release_context() {
+	local worktree_dir="${TEST_ROOT}/version-manager-allow"
+	mkdir -p "$worktree_dir"
+	init_git_worktree "$worktree_dir"
+	printf '%s\n' "1.2.3" >"${worktree_dir}/VERSION"
+
+	local output="" status=0
+	output=$(
+		cd "$worktree_dir" || exit 1
+		# shellcheck source=/dev/null
+		source "$VERSION_MANAGER_SCRIPT" >/dev/null 2>&1 || exit 1
+		export AIDEVOPS_HEADLESS=1 WORKER_ISSUE_NUMBER=24085 WORKER_SESSION_KEY="issue-24085" AIDEVOPS_RELEASE_CONTEXT_APPROVED=1
+		_version_manager_guard_headless_release_scope release patch
+	) 2>&1 || status=$?
+
+	if [[ "$status" -eq 0 && -z "$output" ]]; then
+		print_result "version-manager allows explicit approved release context" 0
+		return 0
+	fi
+
+	print_result "version-manager allows explicit approved release context" 1 \
+		"status=$status output=${output:-<empty>}"
 	return 0
 }
 
@@ -1607,6 +1659,8 @@ main() {
 	test_cmd_run_preserves_worker_origin_overrides_before_canary
 	test_deleted_launch_cwd_recovers_to_work_dir
 	test_does_not_double_append
+	test_version_manager_denies_issue_worker_release_writes
+	test_version_manager_allows_approved_release_context
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_blocked_completion_records_blocked_label
 	test_missing_context_blocked_requests_brief_recovery

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -31,6 +31,64 @@ else
 	REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 fi
 VERSION_FILE="$REPO_ROOT/VERSION"
+_VERSION_MANAGER_ACTION_RELEASE="release"
+
+_version_manager_is_headless_issue_worker() {
+	local headless_marker="${AIDEVOPS_HEADLESS:-}${FULL_LOOP_HEADLESS:-}${OPENCODE_HEADLESS:-}${HEADLESS:-}"
+	local issue_marker="${WORKER_ISSUE_NUMBER:-}${WORKER_SESSION_KEY:-}${AIDEVOPS_SESSION_KEY:-}"
+
+	[[ -n "$headless_marker" ]] || return 1
+	[[ -n "${WORKER_ISSUE_NUMBER:-}" ]] && return 0
+	[[ "$issue_marker" == *issue-* ]] && return 0
+	return 1
+}
+
+_version_manager_has_approved_release_context() {
+	local branch_name=""
+	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	local session_key="${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-}}"
+	local session_title="${AIDEVOPS_SESSION_TITLE:-${WORKER_SESSION_TITLE:-}}"
+
+	[[ "${AIDEVOPS_RELEASE_CONTEXT_APPROVED:-}" == "1" ]] && return 0
+	[[ "${VERSION_MANAGER_RELEASE_CONTEXT_APPROVED:-}" == "1" ]] && return 0
+	[[ "${AIDEVOPS_TASK_SCOPE:-}" == "$_VERSION_MANAGER_ACTION_RELEASE" ]] && return 0
+	[[ "$branch_name" == release/* || "$branch_name" == hotfix/* ]] && return 0
+	[[ "$session_key" == release-* || "$session_key" == hotfix-* ]] && return 0
+	[[ "$session_title" == Release\ * || "$session_title" == *" release "* ]] && return 0
+	return 1
+}
+
+_version_manager_action_is_read_only() {
+	local action="$1"
+	shift || true
+	case "$action" in
+	"" | "get" | "validate" | "preflight" | "changelog-check" | "changelog-preview" | "list-task-ids")
+		return 0
+		;;
+	"$_VERSION_MANAGER_ACTION_RELEASE")
+		local arg=""
+		for arg in "$@"; do
+			[[ "$arg" == "--dry-run" ]] && return 0
+		done
+		;;
+	esac
+	return 1
+}
+
+_version_manager_guard_headless_release_scope() {
+	local action="$1"
+	shift || true
+
+	_version_manager_is_headless_issue_worker || return 0
+	_version_manager_action_is_read_only "$action" "$@" && return 0
+	_version_manager_has_approved_release_context && return 0
+
+	print_warning "Skipping version-manager ${action:-help}: release/write operations are blocked in ordinary headless issue-worker context."
+	print_info "Issue worker: ${WORKER_ISSUE_NUMBER:-unknown}; branch: $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown')"
+	print_info "Approved release contexts: AIDEVOPS_RELEASE_CONTEXT_APPROVED=1, VERSION_MANAGER_RELEASE_CONTEXT_APPROVED=1, AIDEVOPS_TASK_SCOPE=release, or a release/*/hotfix/* branch/session."
+	print_info "This guard is non-fatal so the original issue workflow can continue without treating release cleanup as required."
+	return 1
+}
 
 # Source sub-libraries
 # shellcheck source=./version-manager-changelog.sh
@@ -479,6 +537,10 @@ main() {
 	local action="${1:-}"
 	local bump_type="${2:-}"
 
+	if ! _version_manager_guard_headless_release_scope "$action" "${@:2}"; then
+		return 0
+	fi
+
 	case "$action" in
 	"get")
 		get_current_version
@@ -491,7 +553,7 @@ main() {
 		version=$(get_current_version)
 		create_git_tag "$version"
 		;;
-	"release")
+	"$_VERSION_MANAGER_ACTION_RELEASE")
 		_main_release "$bump_type" "${@:3}"
 		;;
 	"github-release")


### PR DESCRIPTION
## Summary

Added a version-manager release-scope guard that blocks write/release actions for ordinary headless issue workers while allowing read-only checks and explicit release contexts; added focused helper tests for denied and approved release contexts.

## Files Changed

.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/version-manager.sh get; bash .agents/scripts/version-manager.sh release patch --dry-run; bash -n .agents/scripts/version-manager.sh .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-headless-runtime-helper.sh; git diff --check

Resolves #24085


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 120,780 tokens on this as a headless worker.