### PR TITLE
GH#24090: fix: tighten health sentinel abstain assertion

### DIFF
--- a/.agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh
+++ b/.agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh
@@ -153,10 +153,10 @@ else
 	fail "preserves cached issue number when resolver emits sentinel" "cache contains '${cache_value}'"
 fi
 
-if grep -qx "resolve" "$CALLS_FILE"; then
+if [[ "$(<"$CALLS_FILE")" == "resolve" ]]; then
 	pass "abstains immediately after resolver sentinel"
 else
-	fail "abstains immediately after resolver sentinel" "calls: $(tr '\n' ' ' <"$CALLS_FILE")"
+	fail "abstains immediately after resolver sentinel" "expected only 'resolve', but got: $(tr '\n' ' ' <"$CALLS_FILE")"
 fi
 
 if ((TESTS_FAILED > 0)); then


### PR DESCRIPTION
## Summary

- Tighten .agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh so the sentinel-abstain test requires the call log to equal exactly 'resolve'.
- Preserve the cached issue number assertion while making downstream mock calls fail the abstain check.

## Testing

- .agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh
- shellcheck .agents/scripts/tests/test-health-dashboard-sentinel-abstain.sh

Resolves #24090

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 51,237 tokens on this as a headless worker.