### PR TITLE
GH#24089: harden version-manager headless worker guard

### DIFF
--- a/.agents/scripts/tests/test-version-manager-headless-guard.sh
+++ b/.agents/scripts/tests/test-version-manager-headless-guard.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for version-manager.sh headless task-worker release guard.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+reset_guard_env() {
+	unset AIDEVOPS_HEADLESS FULL_LOOP_HEADLESS OPENCODE_HEADLESS HEADLESS
+	unset WORKER_TASK_NUMBER WORKER_ISSUE_NUMBER WORKER_SESSION_KEY AIDEVOPS_SESSION_KEY
+	unset AIDEVOPS_RELEASE_CONTEXT_APPROVED VERSION_MANAGER_RELEASE_CONTEXT_APPROVED AIDEVOPS_TASK_SCOPE
+	unset AIDEVOPS_SESSION_TITLE WORKER_SESSION_TITLE
+	return 0
+}
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager.sh"
+set +e
+
+reset_guard_env
+export AIDEVOPS_HEADLESS=false WORKER_ISSUE_NUMBER=24089
+rc=0
+_version_manager_is_headless_task_worker >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result 'headless guard rejects false marker strings' 0
+else
+	print_result 'headless guard rejects false marker strings' 1 'expected non-zero rc for AIDEVOPS_HEADLESS=false'
+fi
+
+reset_guard_env
+export AIDEVOPS_HEADLESS=1 WORKER_TASK_NUMBER=123
+rc=0
+_version_manager_is_headless_task_worker >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'headless guard accepts explicit task workers' 0
+else
+	print_result 'headless guard accepts explicit task workers' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export FULL_LOOP_HEADLESS=true WORKER_SESSION_KEY='TASK-123'
+rc=0
+_version_manager_is_headless_task_worker >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'headless guard matches task session keys case-insensitively' 0
+else
+	print_result 'headless guard matches task session keys case-insensitively' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export OPENCODE_HEADLESS=1 WORKER_SESSION_KEY='ISSUE-24089'
+rc=0
+_version_manager_is_headless_task_worker >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'headless guard preserves issue session key compatibility' 0
+else
+	print_result 'headless guard preserves issue session key compatibility' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export AIDEVOPS_HEADLESS=1 WORKER_TASK_NUMBER=123
+rc=0
+_version_manager_guard_headless_release_scope help >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'help remains allowed for headless task workers' 0
+else
+	print_result 'help remains allowed for headless task workers' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export AIDEVOPS_HEADLESS=1 WORKER_TASK_NUMBER=123 WORKER_SESSION_KEY='task-123'
+output=$(_version_manager_guard_headless_release_scope bump 2>&1)
+rc=$?
+if [[ "$rc" -ne 0 && "$output" == *"Task worker: 123"* && "$output" == *"repo: ${REPO_ROOT}"* && "$output" == *"session: task-123"* ]]; then
+	print_result 'blocked writes include task, repo, session diagnostics' 0
+else
+	print_result 'blocked writes include task, repo, session diagnostics' 1 "rc=$rc output=$output"
+fi
+
+reset_guard_env
+export WORKER_SESSION_TITLE='Final release'
+rc=0
+_version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'release context accepts case-insensitive trailing title match' 0
+else
+	print_result 'release context accepts case-insensitive trailing title match' 1 "rc=$rc"
+fi
+
+printf '\nTests run: %d, failures: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	exit 0
+fi
+exit 1

--- a/.agents/scripts/tests/test-version-manager-headless-guard.sh
+++ b/.agents/scripts/tests/test-version-manager-headless-guard.sh
@@ -99,6 +99,16 @@ else
 fi
 
 reset_guard_env
+export AIDEVOPS_SESSION_KEY='RELEASE-20260525'
+rc=0
+_version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'release context accepts case-insensitive session key match' 0
+else
+	print_result 'release context accepts case-insensitive session key match' 1 "rc=$rc"
+fi
+
+reset_guard_env
 export WORKER_SESSION_TITLE='Final release'
 rc=0
 _version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -64,15 +64,17 @@ _version_manager_has_approved_release_context() {
 	local branch_name=""
 	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 	local session_key="${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-}}"
+	local session_key_lower=""
 	local session_title="${AIDEVOPS_SESSION_TITLE:-${WORKER_SESSION_TITLE:-}}"
 	local session_title_lower=""
+	session_key_lower=$(printf '%s' "$session_key" | tr '[:upper:]' '[:lower:]')
 	session_title_lower=$(printf '%s' "$session_title" | tr '[:upper:]' '[:lower:]')
 
 	[[ "${AIDEVOPS_RELEASE_CONTEXT_APPROVED:-}" == "1" ]] && return 0
 	[[ "${VERSION_MANAGER_RELEASE_CONTEXT_APPROVED:-}" == "1" ]] && return 0
 	[[ "${AIDEVOPS_TASK_SCOPE:-}" == "$_VERSION_MANAGER_ACTION_RELEASE" ]] && return 0
 	[[ "$branch_name" == release/* || "$branch_name" == hotfix/* ]] && return 0
-	[[ "$session_key" == release-* || "$session_key" == hotfix-* ]] && return 0
+	[[ "$session_key_lower" == release-* || "$session_key_lower" == hotfix-* ]] && return 0
 	[[ "$session_title_lower" == release* || "$session_title_lower" == *" release" || "$session_title_lower" == *" release "* ]] && return 0
 	return 1
 }

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -33,13 +33,30 @@ fi
 VERSION_FILE="$REPO_ROOT/VERSION"
 _VERSION_MANAGER_ACTION_RELEASE="release"
 
-_version_manager_is_headless_issue_worker() {
-	local headless_marker="${AIDEVOPS_HEADLESS:-}${FULL_LOOP_HEADLESS:-}${OPENCODE_HEADLESS:-}${HEADLESS:-}"
-	local issue_marker="${WORKER_ISSUE_NUMBER:-}${WORKER_SESSION_KEY:-}${AIDEVOPS_SESSION_KEY:-}"
+_version_manager_marker_is_truthy() {
+	local marker=""
+	local marker_lower=""
 
-	[[ -n "$headless_marker" ]] || return 1
+	for marker in "$@"; do
+		marker_lower=$(printf '%s' "$marker" | tr '[:upper:]' '[:lower:]')
+		case "$marker_lower" in
+		"1" | "true" | "yes" | "on")
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
+
+_version_manager_is_headless_task_worker() {
+	local worker_marker="${WORKER_TASK_NUMBER:-}${WORKER_ISSUE_NUMBER:-}${WORKER_SESSION_KEY:-}${AIDEVOPS_SESSION_KEY:-}"
+	local worker_marker_lower=""
+
+	_version_manager_marker_is_truthy "${AIDEVOPS_HEADLESS:-}" "${FULL_LOOP_HEADLESS:-}" "${OPENCODE_HEADLESS:-}" "${HEADLESS:-}" || return 1
+	[[ -n "${WORKER_TASK_NUMBER:-}" ]] && return 0
 	[[ -n "${WORKER_ISSUE_NUMBER:-}" ]] && return 0
-	[[ "$issue_marker" == *issue-* ]] && return 0
+	worker_marker_lower=$(printf '%s' "$worker_marker" | tr '[:upper:]' '[:lower:]')
+	[[ "$worker_marker_lower" == *task-* || "$worker_marker_lower" == *issue-* ]] && return 0
 	return 1
 }
 
@@ -48,13 +65,15 @@ _version_manager_has_approved_release_context() {
 	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 	local session_key="${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-}}"
 	local session_title="${AIDEVOPS_SESSION_TITLE:-${WORKER_SESSION_TITLE:-}}"
+	local session_title_lower=""
+	session_title_lower=$(printf '%s' "$session_title" | tr '[:upper:]' '[:lower:]')
 
 	[[ "${AIDEVOPS_RELEASE_CONTEXT_APPROVED:-}" == "1" ]] && return 0
 	[[ "${VERSION_MANAGER_RELEASE_CONTEXT_APPROVED:-}" == "1" ]] && return 0
 	[[ "${AIDEVOPS_TASK_SCOPE:-}" == "$_VERSION_MANAGER_ACTION_RELEASE" ]] && return 0
 	[[ "$branch_name" == release/* || "$branch_name" == hotfix/* ]] && return 0
 	[[ "$session_key" == release-* || "$session_key" == hotfix-* ]] && return 0
-	[[ "$session_title" == Release\ * || "$session_title" == *" release "* ]] && return 0
+	[[ "$session_title_lower" == release* || "$session_title_lower" == *" release" || "$session_title_lower" == *" release "* ]] && return 0
 	return 1
 }
 
@@ -62,7 +81,7 @@ _version_manager_action_is_read_only() {
 	local action="$1"
 	shift || true
 	case "$action" in
-	"" | "get" | "validate" | "preflight" | "changelog-check" | "changelog-preview" | "list-task-ids")
+	"" | "help" | "usage" | "get" | "validate" | "preflight" | "changelog-check" | "changelog-preview" | "list-task-ids")
 		return 0
 		;;
 	"$_VERSION_MANAGER_ACTION_RELEASE")
@@ -78,13 +97,15 @@ _version_manager_action_is_read_only() {
 _version_manager_guard_headless_release_scope() {
 	local action="$1"
 	shift || true
+	local branch_name=""
+	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>&1 || printf 'unknown')
 
-	_version_manager_is_headless_issue_worker || return 0
+	_version_manager_is_headless_task_worker || return 0
 	_version_manager_action_is_read_only "$action" "$@" && return 0
 	_version_manager_has_approved_release_context && return 0
 
-	print_warning "Skipping version-manager ${action:-help}: release/write operations are blocked in ordinary headless issue-worker context."
-	print_info "Issue worker: ${WORKER_ISSUE_NUMBER:-unknown}; branch: $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown')"
+	print_warning "Skipping version-manager ${action:-help}: release/write operations are blocked in ordinary headless task-worker context."
+	print_info "Task worker: ${WORKER_TASK_NUMBER:-unknown}; issue: ${WORKER_ISSUE_NUMBER:-unknown}; repo: ${REPO_ROOT}; session: ${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-unknown}}; branch: ${branch_name}"
 	print_info "Approved release contexts: AIDEVOPS_RELEASE_CONTEXT_APPROVED=1, VERSION_MANAGER_RELEASE_CONTEXT_APPROVED=1, AIDEVOPS_TASK_SCOPE=release, or a release/*/hotfix/* branch/session."
 	print_info "This guard is non-fatal so the original issue workflow can continue without treating release cleanup as required."
 	return 1


### PR DESCRIPTION
## Summary
- Harden version-manager headless worker detection to require explicit true values and accept task/session identifiers case-insensitively.
- Allow help/usage as read-only actions for ordinary headless workers.
- Add diagnostics with task, issue, repo, session, and branch context plus focused regression coverage.

Resolves #24089

## Verification
- shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-version-manager-headless-guard.sh
- .agents/scripts/tests/test-version-manager-headless-guard.sh
- bash .agents/scripts/tests/test-version-manager-release-rest-fallback.sh
- .agents/scripts/tests/test-version-manager-release-rollback.sh
- .agents/scripts/tests/test-version-manager-task-id-extraction.sh
- .agents/scripts/linters-local.sh timed out after 120s during broad ratchet phase; targeted shell and version-manager checks passed; markdown advisory output was existing repository debt
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 8m and 90,082 tokens on this as a headless worker.