### PR TITLE
GH#24094: fix: bound report style front matter parsing

### DIFF
--- a/.agents/scripts/report_render_styles.py
+++ b/.agents/scripts/report_render_styles.py
@@ -83,7 +83,7 @@ def _base_report_css() -> str:
 def _front_matter(path: Path) -> list[str]:
     lines = path.read_text(encoding="utf-8").splitlines()
     start = -1
-    for index, line in enumerate(lines):
+    for index, line in enumerate(lines[:100]):
         if line.strip() == "---":
             start = index
             break
@@ -180,7 +180,7 @@ def _indent_width(line: str) -> int:
             width += 1
             continue
         if char == "\t":
-            width += 2
+            width += 4
             continue
         break
     return width


### PR DESCRIPTION
## Summary

Bounded report style front matter delimiter scanning to the first 100 lines and aligned tab indentation width with standard four-space YAML indentation.

## Files Changed

.agents/scripts/report_render_styles.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_styles.py; .agents/scripts/linters-local.sh (timed out during Secretlint after earlier gates passed)

Resolves #24094


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.32 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 22m and 64,334 tokens on this as a headless worker.