### PR TITLE
GH#24097: harden Nostr VPN package expansion

### DIFF
--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -168,7 +168,7 @@ macOS source-build fallback while upstream packages are unavailable:
   4. Verify the generated package before installing:
        pkgutil --check-signature deploy/fips-0.3.0-macos-$(uname -m).pkg
        pkgutil --payload-files deploy/fips-0.3.0-macos-$(uname -m).pkg
-       pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+       rm -rf /tmp/fips-pkg-expanded && pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
   5. Install only after package integrity checks pass:
        sudo installer -pkg deploy/fips-0.3.0-macos-$(uname -m).pkg -target /
 

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -69,11 +69,11 @@ git checkout v0.3.0
 
 pkgutil --check-signature deploy/fips-0.3.0-macos-$(uname -m).pkg
 pkgutil --payload-files deploy/fips-0.3.0-macos-$(uname -m).pkg
-pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+rm -rf /tmp/fips-pkg-expanded && pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
 sudo installer -pkg deploy/fips-0.3.0-macos-$(uname -m).pkg -target /
 ```
 
-Prerequisites: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Do not install if package integrity checks fail.
+Prerequisites: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Remove any previous `/tmp/fips-pkg-expanded` directory before expanding because `pkgutil --expand` fails when the destination already exists. Do not install if package integrity checks fail.
 
 ## Secret Handling
 

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -19,7 +19,7 @@
       "./packaging/macos/build-pkg.sh",
       "pkgutil --check-signature deploy/fips-0.3.0-macos-$(uname -m).pkg",
       "pkgutil --payload-files deploy/fips-0.3.0-macos-$(uname -m).pkg",
-      "pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded",
+      "rm -rf /tmp/fips-pkg-expanded && pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded",
       "sudo installer -pkg deploy/fips-0.3.0-macos-$(uname -m).pkg -target /"
     ],
     "notes": "Do not install if pkgutil integrity checks fail. Never store private Nostr keys in the cloned source tree."


### PR DESCRIPTION
## Summary

- Hardened the Nostr VPN macOS source-build helper, service docs, and config template so repeated package expansion attempts remove the old destination first.
- Documented that `pkgutil --expand` fails when the destination directory already exists.

## Testing

- `shellcheck .agents/scripts/nostr-vpn-helper.sh`
- `markdownlint-cli2 .agents/services/networking/nostr-vpn.md`
- `python3 -m json.tool configs/nostr-vpn-config.json.txt`

## Runtime Testing

- Self-assessed: low-risk docs/config/helper guidance update; no runtime service changes.

Resolves #24097


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 53,293 tokens on this as a headless worker.
