### PR TITLE
GH#24092: fix: restore bulk dispatch label cleanup sweep

### DIFF
--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -117,21 +117,21 @@ sweep_closed_auto_dispatch_issues() {
 	[[ "$limit" =~ ^[0-9]+$ ]] || limit=50
 	[[ "$limit" -gt 0 ]] || limit=50
 
-	local total=0 repo_slug issue_number issue_numbers
+	local total=0 repo_slug issue_number issue_rows labels_csv
 	while IFS= read -r repo_slug; do
 		[[ -n "$repo_slug" ]] || continue
-		issue_numbers=$(gh issue list --repo "$repo_slug" --state closed \
+		issue_rows=$(gh issue list --repo "$repo_slug" --state closed \
 			--label "auto-dispatch" --limit "$limit" \
-			--json number --jq '.[].number' 2>/dev/null) || issue_numbers=""
-		[[ -n "$issue_numbers" ]] || continue
-		while IFS= read -r issue_number; do
+			--json number,labels --jq '.[] | [.number, ([.labels[].name] | join("|"))] | @tsv' 2>/dev/null) || issue_rows=""
+		[[ -n "$issue_rows" ]] || continue
+		while IFS=$'\t' read -r issue_number labels_csv; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
 			local exit_code=0
-			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" || exit_code=$?
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" "${labels_csv//|/$'\n'}" || exit_code=$?
 			if [[ "$exit_code" -eq 0 ]]; then
 				total=$((total + 1))
 			fi
-		done <<<"$issue_numbers"
+		done <<<"$issue_rows"
 	done < <(_dispatch_label_sweep_repos "$repos_json" || true)
 
 	_dispatch_label_sweep_mark_run

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -51,16 +51,18 @@ teardown_env() {
 
 install_gh_stub() {
 	gh() {
+		local command_name="$1"
+		local subcommand_name="$2"
 		printf '%s\n' "$*" >>"${TEST_ROOT}/gh.log"
-		if [[ "$1" == "issue" && "$2" == "list" ]]; then
-			printf '101\n102\n'
+		if [[ "$command_name" == "issue" && "$subcommand_name" == "list" ]]; then
+			printf '101\tauto-dispatch|status:queued\n102\tauto-dispatch\n'
 			return 0
 		fi
-		if [[ "$1" == "issue" && "$2" == "view" ]]; then
+		if [[ "$command_name" == "issue" && "$subcommand_name" == "view" ]]; then
 			printf 'auto-dispatch\nstatus:queued\n'
 			return 0
 		fi
-		if [[ "$1" == "issue" && "$2" == "edit" && "${GH_STUB_FAIL_EDIT:-0}" == "1" ]]; then
+		if [[ "$command_name" == "issue" && "$subcommand_name" == "edit" && "${GH_STUB_FAIL_EDIT:-0}" == "1" ]]; then
 			return 7
 		fi
 		return 0
@@ -95,10 +97,11 @@ test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
 	# shellcheck source=../shared-dispatch-label-cleanup.sh
 	source "$HELPER"
 	sweep_closed_auto_dispatch_issues
-	local edit_count list_count
+	local edit_count list_count view_count
 	edit_count=$(grep -c 'issue edit' "${TEST_ROOT}/gh.log" || true)
 	list_count=$(grep -c 'issue list' "${TEST_ROOT}/gh.log" || true)
-	if [[ "$edit_count" == "2" && "$list_count" == "1" ]]; then
+	view_count=$(grep -c 'issue view' "${TEST_ROOT}/gh.log" || true)
+	if [[ "$edit_count" == "2" && "$list_count" == "1" && "$view_count" == "0" ]]; then
 		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 0
 	else
 		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 1


### PR DESCRIPTION
## Summary

Restored bulk closed-issue label fetching so the sweep passes current labels into cleanup without per-issue view calls; updated the test stub and assertion to verify one list call and zero view calls.

## Files Changed

.agents/scripts/shared-dispatch-label-cleanup.sh,.agents/scripts/tests/test-dispatch-label-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh && .agents/scripts/tests/test-dispatch-label-cleanup.sh

Resolves #24092


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.32 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 15m and 41,960 tokens on this as a headless worker.