### PR TITLE
GH#24095: fix: handle escaped backslashes in markdown tables

### DIFF
--- a/.agents/scripts/report_render_markdown.py
+++ b/.agents/scripts/report_render_markdown.py
@@ -527,29 +527,25 @@ def split_markdown_table_row(line: str) -> list[str]:
     row = line.strip()[1:-1]
     cells: list[str] = []
     current: list[str] = []
-    index = 0
-    while index < len(row):
-        char = row[index]
-        if char == "|" and _has_odd_trailing_backslashes(current):
-            current.pop()
-            current.append("|")
-        elif char == "|":
-            cells.append("".join(current))
-            current = []
+    backslash_run = 0
+    for char in row:
+        if char == "\\":
+            backslash_run += 1
+            continue
+        if char == "|":
+            current.append("\\" * (backslash_run // 2))
+            if backslash_run % 2 == 1:
+                current.append("|")
+            else:
+                cells.append("".join(current))
+                current = []
         else:
+            current.append("\\" * backslash_run)
             current.append(char)
-        index += 1
+        backslash_run = 0
+    current.append("\\" * backslash_run)
     cells.append("".join(current))
     return cells
-
-
-def _has_odd_trailing_backslashes(chars: list[str]) -> bool:
-    count = 0
-    for char in reversed(chars):
-        if char != "\\":
-            break
-        count += 1
-    return count % 2 == 1
 
 
 def open_list(body: list[str], states: dict[str, object], tag: str, css_class: str = "") -> None:


### PR DESCRIPTION
## Summary

Updated split_markdown_table_row to track contiguous backslash runs so Markdown table rows split on pipes after escaped backslashes while preserving escaped literal pipes.

## Files Changed

.agents/scripts/report_render_markdown.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PYTHONPATH=.agents/scripts python3 - <<'PY' targeted split_markdown_table_row assertions; python3 -m py_compile .agents/scripts/report_render_markdown.py; .agents/scripts/linters-local.sh

Resolves #24095


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 15m and 78,386 tokens on this as a headless worker.