### PR TITLE
GH#24041: fix: include dispatch cleanup exit code

### DIFF
--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -61,7 +61,7 @@ clear_terminal_issue_dispatch_labels() {
 		return 0
 	fi
 
-	echo "[pulse-wrapper] dispatch-label-cleanup: failed to strip terminal dispatch labels from ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
+	echo "[pulse-wrapper] dispatch-label-cleanup: failed to strip terminal dispatch labels from ${repo_slug}#${issue_number} (${context}) [exit: ${exit_code}]" >>"$LOGFILE"
 	return "$exit_code"
 }
 

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -119,7 +119,9 @@ test_clear_terminal_labels_propagates_edit_failures() {
 	local exit_code=0
 	clear_terminal_issue_dispatch_labels 42 owner/repo test-context || exit_code=$?
 	unset GH_STUB_FAIL_EDIT
-	if [[ "$exit_code" == "7" ]]; then
+	local log_line=""
+	log_line=$(tr '\n' ' ' <"$LOGFILE")
+	if [[ "$exit_code" == "7" && "$log_line" == *"[exit: 7]"* ]]; then
 		print_result "terminal label cleanup propagates edit failures" 0
 	else
 		print_result "terminal label cleanup propagates edit failures" 1


### PR DESCRIPTION
## Summary
- Log the concrete GitHub edit exit code when terminal dispatch-label cleanup fails.
- Add a regression assertion that the failure log includes the propagated exit code.

## Context
For #24041.
Supersedes #24054 with a clean branch based on current `origin/main`.

## Files
- `.agents/scripts/shared-dispatch-label-cleanup.sh`: include `[exit: N]` in the failure log line.
- `.agents/scripts/tests/test-dispatch-label-cleanup.sh`: verify failed cleanup logs include `[exit: 7]`.

## Verification
- `bash .agents/scripts/tests/test-dispatch-label-cleanup.sh`
- `shellcheck .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh`
- `bash -n .agents/scripts/shared-dispatch-label-cleanup.sh .agents/scripts/tests/test-dispatch-label-cleanup.sh && git diff --check HEAD~1..HEAD`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6d 22h and 5,428,198 tokens on this with the user in an interactive session.