### PR TITLE
GH#24119: keep report action prompts inside sections

### DIFF
--- a/.agents/scripts/report_render_enhance.py
+++ b/.agents/scripts/report_render_enhance.py
@@ -62,7 +62,7 @@ def inject_action_prompts(body_html: str, classes: tuple[str, ...], code_rendere
         if not action_text:
             return match.group(0)
         prompt = action_prompt_details(action_prompt_from_text(action_text), code_renderer)
-        return f"{match.group(1)}{section_body}{match.group(4)}{prompt}"
+        return f"{match.group(1)}{section_body}{prompt}{match.group(4)}"
 
     return action_section_pattern(classes).sub(replace, body_html)
 

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -107,7 +107,20 @@ test_render_markdown_fixture() {
 	assert_contains "$_out" "class=\"code-copy\"" "Markdown render includes copy buttons for code"
 	assert_contains "$_out" "code-copy.is-copied" "Markdown render includes copy feedback state"
 	assert_contains "$_out" "class=\"accordion action-prompt\"" "Markdown render includes action prompt accordions"
-	assert_contains "$_out" "</section><details class=\"accordion action-prompt\" open" "Markdown render places open action prompts after action panels"
+	if python3 - "$_out" <<'PYHTML'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+match = re.search(r'<section class="(?:action-line|action-panel)"[^>]*>(.*?)</section>', text, re.S)
+raise SystemExit(0 if match and 'class="accordion action-prompt"' in match.group(1) else 1)
+PYHTML
+	then
+		print_result "Markdown render places action prompts inside action sections" 0
+	else
+		print_result "Markdown render places action prompts inside action sections" 1 "Expected action prompt markup before closing action section"
+	fi
 	assert_contains "$_out" "<details class=\"accordion\" open" "Markdown render opens accordions for PDF output"
 	assert_contains "$_out" "class=\"toc-pdf-link\"" "Markdown render includes TOC PDF link"
 	assert_contains "$_out" ">A4</a>" "Markdown render labels portrait PDF as A4"


### PR DESCRIPTION
## Summary

Moves report action prompt injection before the matched section closing tag so prompts render within action sections, and updates the renderer regression test to assert that placement.

## Files Changed

.agents/scripts/report_render_enhance.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh

Resolves #24119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 68,102 tokens on this as a headless worker.