### PR TITLE
GH#24121: preserve caller Tabby config override

### DIFF
--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -28,11 +28,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 
-# Tabby config path (platform-aware)
-if [[ "$(uname -s)" == "Darwin" ]]; then
-	TABBY_CONFIG="${HOME}/Library/Application Support/tabby/config.yaml"
-else
-	TABBY_CONFIG="${HOME}/.config/tabby-terminal/config.yaml"
+# Tabby config path (platform-aware, unless caller provided an override)
+if [[ -z "${TABBY_CONFIG:-}" ]]; then
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		TABBY_CONFIG="${HOME}/Library/Application Support/tabby/config.yaml"
+	else
+		TABBY_CONFIG="${HOME}/.config/tabby-terminal/config.yaml"
+	fi
 fi
 
 _info() { echo -e "${BLUE}[INFO]${NC} $1"; }


### PR DESCRIPTION
## Summary

- Preserves caller-provided `TABBY_CONFIG` in `.agents/scripts/tabby-helper.sh`.
- Keeps the existing Darwin/Linux default path selection when `TABBY_CONFIG` is unset.

## Testing

- `shellcheck .agents/scripts/tabby-helper.sh`
- Custom HOME/TABBY_CONFIG status-path regression verified the override path is reported unchanged.

Resolves #24121


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 70,722 tokens on this as a headless worker.
