### PR TITLE
Fix lottiefiles report HTML nesting (#24124)

### DIFF
--- a/_reports/examples/llm-visibility-toolbox/lottiefiles-light.html
+++ b/_reports/examples/llm-visibility-toolbox/lottiefiles-light.html
@@ -2575,7 +2575,6 @@ Guide me through the tools, resources, accounts, permissions, source material, a
 <section class="anchor-links">
 <p><a href="#sources" data-filetype="link">Sources</a> <a href="#highest-impact-tactics" data-filetype="link">Tactics</a> <a href="#page-type-matrix" data-filetype="link">Matrix</a> <a href="#roadmap-template" data-filetype="link">Roadmap</a> <a href="#appendices" data-filetype="link">Appendices</a></p>
 </section>
-<section class="report-keep-with-heading report-chapter-page">
 </main>
 </div>
 <div class="toc-pdf-actions" aria-label="PDF downloads"><a class="toc-pdf-link" href="lottiefiles-light-a4.pdf" aria-label="Open A4 PDF version" title="Open A4 PDF version">A4</a><a class="toc-pdf-link" href="lottiefiles-light-usletter.pdf" aria-label="Open US Letter PDF version" title="Open US Letter PDF version">US Letter</a><a class="toc-pdf-link" href="lottiefiles-light-slides.pdf" aria-label="Open slides PDF version" title="Open slides PDF version">Slides</a></div>
@@ -2627,7 +2626,6 @@ Guide me through the tools, resources, accounts, permissions, source material, a
 <section class="details-note">
 <h3 class="section-heading" id="weight-before-recommending"><span class="heading-number">1.1</span> Weight before recommending</h3>
 <p>Do not apply all tactics to all pages. Score page-type fit, retrieval eligibility, source proximity, corroboration, freshness, confidence, impact, and effort before roadmap sequencing.</p>
-</section>
 </section>
 <section class="severity-key">
 <section class="info-panel" data-severity="critical">


### PR DESCRIPTION
## Summary
- Removed the stray `report-keep-with-heading report-chapter-page` section opener immediately before the first `</main>` in `_reports/examples/llm-visibility-toolbox/lottiefiles-light.html`.
- Removed the orphan `</section>` after the `details-note` block so the following `severity-key` section nests correctly.

## Testing
- `python3` HTMLParser-based section/main nesting check passed.
- `git diff --check` passed.
- Pre-commit checks passed.

MERGE_SUMMARY: Fixed malformed HTML nesting in `_reports/examples/llm-visibility-toolbox/lottiefiles-light.html` by removing the unmatched section opener and orphan closing section reported in #24124.

Resolves #24124

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 67,018 tokens on this as a headless worker.