### PR TITLE
GH#24120: deduplicate report heading anchors

### DIFF
--- a/.agents/scripts/report_render_headings.py
+++ b/.agents/scripts/report_render_headings.py
@@ -33,12 +33,24 @@ def handle_heading(
     close_blocks(body, states)
     level = len(heading.group(1))
     title = heading.group(2).strip()
-    anchor = slug(title)
+    anchor = unique_heading_anchor(slug(title), states)
     display_title, classes = heading_display(level, title, states)
     class_attr = f' class="{" ".join(classes)}"' if classes else ""
     headings.append((level, title, anchor))
     body.append(f'<h{level}{class_attr} id="{anchor}">{display_title}</h{level}>')
     return True
+
+
+def unique_heading_anchor(base_anchor: str, states: dict[str, object]) -> str:
+    anchor_counts = states.setdefault("anchor_counts", {})
+    if not isinstance(anchor_counts, dict):
+        anchor_counts = {}
+        states["anchor_counts"] = anchor_counts
+    count = int(anchor_counts.get(base_anchor, 0))
+    anchor_counts[base_anchor] = count + 1
+    if count == 0:
+        return base_anchor
+    return f"{base_anchor}-{count + 1}"
 
 
 def heading_display(level: int, title: str, states: dict[str, object]) -> tuple[str, list[str]]:

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -330,6 +330,32 @@ MARKDOWN
 	return 0
 }
 
+test_markdown_headings_deduplicate_anchor_ids() {
+	local _input="${TEST_ROOT}/duplicate-headings.md"
+	local _out="${TEST_ROOT}/duplicate-headings.html"
+	cat >"$_input" <<'MARKDOWN'
+# Overview
+
+## Repeat
+
+First section.
+
+## Repeat
+
+Second section.
+
+### Repeat
+
+Nested section.
+MARKDOWN
+	"$HELPER_SH" render "$_input" --output "$_out"
+	assert_contains "$_out" "<h2 class=\"chapter-heading\" id=\"repeat\">" "Markdown keeps first duplicate heading anchor unsuffixed"
+	assert_contains "$_out" "<h2 class=\"chapter-heading\" id=\"repeat-2\">" "Markdown suffixes second duplicate heading anchor"
+	assert_contains "$_out" "<h3 class=\"section-heading\" id=\"repeat-3\">" "Markdown suffixes duplicate heading anchors across levels"
+	assert_contains "$_out" "<a href=\"#repeat-2\"" "Markdown TOC targets suffixed duplicate heading anchor"
+	return 0
+}
+
 test_mermaid_renderer_uses_node_ids() {
 	if python3 - "${SCRIPT_DIR}/.." <<'PYHTML'
 import sys
@@ -506,6 +532,7 @@ main() {
 	test_style_token_parser_handles_long_headers_and_tabs
 	test_markdown_table_uses_header_cells
 	test_markdown_table_preserves_escaped_pipes
+	test_markdown_headings_deduplicate_anchor_ids
 	test_mermaid_renderer_uses_node_ids
 	test_multiline_markdown_paragraph
 	test_print_keep_with_heading_groups


### PR DESCRIPTION
## Summary

Deduplicated generated markdown heading anchor IDs so repeated headings receive stable numeric suffixes, and added regression coverage for matching TOC links.

## Files Changed

.agents/scripts/report_render_headings.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-render-helper.sh; python3 -m py_compile .agents/scripts/report_render_headings.py; shellcheck .agents/scripts/tests/test-report-render-helper.sh

Resolves #24120


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 52,744 tokens on this as a headless worker.