### PR TITLE
GH#24116: fix: include profile css for basic reports

### DIFF
--- a/.agents/scripts/report-render-helper.py
+++ b/.agents/scripts/report-render-helper.py
@@ -131,15 +131,13 @@ THEMES = ("auto", "light", "dark")
 
 
 def load_css(template: str, pdf_profile: str) -> str:
-    if template == "basic":
-        return BASIC_CSS
-    css = ""
+    css = BASIC_CSS if template == "basic" else ""
     if template == "editorial-evidence":
         path = Path(__file__).resolve().parents[1] / "templates" / "reports" / "llm-visibility-report.css"
         css = path.read_text(encoding="utf-8")
     elif template in style_names():
         css = style_css(template)
-    else:
+    elif template != "basic":
         names = ", ".join(BUILTIN_TEMPLATES)
         raise ValueError(f"unknown report template: {template}. Available: {names}")
     if pdf_profile not in PROFILE_CSS:


### PR DESCRIPTION
## Summary

Updated .agents/scripts/report-render-helper.py so the basic report template flows through profile and pagination CSS assembly instead of returning before PDF print styles are appended.

## Files Changed

.agents/scripts/report-render-helper.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report-render-helper.py && python3 - <<'PY' ... verified basic print-css includes A4 profile and pagination CSS

Resolves #24116


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 36,848 tokens on this as a headless worker.