### PR TITLE
GH#24115: fix: honor report raised paper token

### DIFF
--- a/.agents/scripts/report_render_styles.py
+++ b/.agents/scripts/report_render_styles.py
@@ -625,7 +625,7 @@ def _theme_css(name: str, tokens: dict[str, str]) -> str:
   --report-body-size: {tokens.get('body-md.fontSize', DEFAULT_TOKENS['body-md.fontSize'])};
   --report-body-line: {tokens.get('body-md.lineHeight', DEFAULT_TOKENS['body-md.lineHeight'])};
   --report-paper: {tokens['background']};
-  --report-paper-raised: {tokens['primary-container']};
+  --report-paper-raised: {tokens.get('paper-raised', tokens['primary-container'])};
   --report-panel: {tokens['surface']};
   --report-surface: {tokens['surface']};
   --report-ink: {tokens['on-surface']};

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -291,6 +291,35 @@ PY
 	return 0
 }
 
+test_style_css_uses_paper_raised_token() {
+	local _result=0
+	python3 - "$SCRIPT_DIR" <<'PY' || _result=$?
+from pathlib import Path
+import importlib.util
+import sys
+
+script_dir = Path(sys.argv[1])
+module_path = script_dir.parent / "report_render_styles.py"
+spec = importlib.util.spec_from_file_location("report_render_styles", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+tokens = dict(module.DEFAULT_TOKENS)
+tokens["primary-container"] = "#F3DED5"
+tokens["paper-raised"] = "#F5F6F4"
+css = module._theme_css("signal-agency", tokens)
+assert "--report-paper-raised: #F5F6F4;" in css
+assert "--report-paper-raised: #F3DED5;" not in css
+PY
+	if [[ "$_result" -ne 0 ]]; then
+		print_result "Style CSS uses paper-raised token" 1 "Expected paper-raised to override primary-container for raised surfaces"
+		return 0
+	fi
+	print_result "Style CSS uses paper-raised token" 0
+	return 0
+}
+
 test_markdown_table_uses_header_cells() {
 	local _input="${TEST_ROOT}/table.md"
 	local _out="${TEST_ROOT}/table.html"
@@ -504,6 +533,7 @@ main() {
 	test_python_helper_requires_mode
 	test_python_helper_reads_stdin_by_default
 	test_style_token_parser_handles_long_headers_and_tabs
+	test_style_css_uses_paper_raised_token
 	test_markdown_table_uses_header_cells
 	test_markdown_table_preserves_escaped_pipes
 	test_mermaid_renderer_uses_node_ids


### PR DESCRIPTION
## Summary

Updated report renderer CSS token mapping so --report-paper-raised uses DESIGN.md paper-raised when provided, with fallback to primary-container for existing designs. Added regression coverage for Signal Agency raised paper surfaces.

## Files Changed

.agents/scripts/report_render_styles.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh; python3 -m py_compile .agents/scripts/report_render_styles.py

Resolves #24115


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 52,693 tokens on this as a headless worker.