### PR TITLE
GH#24118: fix: support chained mermaid arrows

### DIFF
--- a/.agents/scripts/report_render_diagrams.py
+++ b/.agents/scripts/report_render_diagrams.py
@@ -25,15 +25,16 @@ def mermaid_graph(code_text: str) -> tuple[dict[str, str], list[tuple[str, str]]
     for line in code_text.splitlines():
         if "-->" not in line:
             continue
-        left, right = [part.strip() for part in line.split("-->", 1)]
-        left_id, left_label = mermaid_node_parts(left)
-        right_id, right_label = mermaid_node_parts(right)
-        if left_id and left_id not in nodes:
-            nodes[left_id] = left_label
-        if right_id and right_id not in nodes:
-            nodes[right_id] = right_label
-        if left_id and right_id:
-            edges.append((left_id, right_id))
+        parts = [part.strip() for part in line.split("-->")]
+        for index in range(len(parts) - 1):
+            left_id, left_label = mermaid_node_parts(parts[index])
+            right_id, right_label = mermaid_node_parts(parts[index + 1])
+            if left_id and left_id not in nodes:
+                nodes[left_id] = left_label
+            if right_id and right_id not in nodes:
+                nodes[right_id] = right_label
+            if left_id and right_id:
+                edges.append((left_id, right_id))
     return nodes, edges
 
 

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -352,6 +352,28 @@ PYHTML
 	return 0
 }
 
+test_mermaid_renderer_supports_chained_arrows() {
+	if python3 - "${SCRIPT_DIR}/.." <<'PYHTML'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1]).resolve()))
+from report_render_diagrams import mermaid_graph
+
+nodes, edges = mermaid_graph("A[Start] --> B[Middle] --> C[Done]")
+if list(nodes.items()) != [("A", "Start"), ("B", "Middle"), ("C", "Done")]:
+    raise SystemExit(1)
+if edges != [("A", "B"), ("B", "C")]:
+    raise SystemExit(1)
+PYHTML
+	then
+		print_result "Mermaid renderer supports chained arrows" 0
+	else
+		print_result "Mermaid renderer supports chained arrows" 1 "Expected A --> B --> C to create both edges"
+	fi
+	return 0
+}
+
 test_multiline_markdown_paragraph() {
 	local _input="${TEST_ROOT}/paragraph.md"
 	local _out="${TEST_ROOT}/paragraph.html"
@@ -507,6 +529,7 @@ main() {
 	test_markdown_table_uses_header_cells
 	test_markdown_table_preserves_escaped_pipes
 	test_mermaid_renderer_uses_node_ids
+	test_mermaid_renderer_supports_chained_arrows
 	test_multiline_markdown_paragraph
 	test_print_keep_with_heading_groups
 	test_render_json_array_is_resilient


### PR DESCRIPTION
## Summary

Updated the Mermaid graph parser to split every arrow in a flow line and add each adjacent edge, so linear chains such as A --> B --> C render all nodes and arrows. Added a regression test for chained arrows in the report render helper suite.

## Files Changed

.agents/scripts/report_render_diagrams.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_diagrams.py; shellcheck .agents/scripts/tests/test-report-render-helper.sh; .agents/scripts/tests/test-report-render-helper.sh

Resolves #24118


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 44,661 tokens on this as a headless worker.