### PR TITLE
GH#24117: Relax report markdown table parsing

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -34,11 +34,12 @@ def flush_paragraph(body: list[str], states: dict[str, object]) -> None:
 
 
 def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
-    if not line.startswith("|") or not line.endswith("|"):
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
         return False
-    cells = [inline_markup(cell.strip()) for cell in split_markdown_table_row(line)]
+    cells = [inline_markup(cell.strip()) for cell in split_markdown_table_row(stripped)]
     raw_cells = [html.unescape(cell) for cell in cells]
-    if all(re.match(r"^:?-{3,}:?$", cell) for cell in raw_cells):
+    if all(re.match(r"^:?-+:?$", cell) for cell in raw_cells):
         return True
     if not states["table"]:
         close_blocks(body, states)

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -337,6 +337,23 @@ MARKDOWN
 	return 0
 }
 
+test_markdown_table_accepts_indented_single_dash_separator() {
+	local _input="${TEST_ROOT}/table-indented-single-dash.md"
+	local _out="${TEST_ROOT}/table-indented-single-dash.html"
+	cat >"$_input" <<'MARKDOWN'
+# Table
+
+  | Component | Evidence |
+  | - | :-: |
+  | AIO | {{evidence:verified}} |
+MARKDOWN
+	"$HELPER_SH" render "$_input" --template editorial-evidence --output "$_out"
+	assert_contains "$_out" "<th>Component</th>" "Markdown table accepts indented table headers"
+	assert_contains "$_out" "<td>AIO</td>" "Markdown table accepts indented table body"
+	assert_not_contains "$_out" "<td>-</td>" "Markdown table treats single-dash separator as separator"
+	return 0
+}
+
 test_markdown_table_preserves_escaped_pipes() {
 	local _input="${TEST_ROOT}/table-escaped-pipe.md"
 	local _out="${TEST_ROOT}/table-escaped-pipe.html"
@@ -583,6 +600,7 @@ main() {
 	test_style_token_parser_handles_long_headers_and_tabs
 	test_style_css_uses_paper_raised_token
 	test_markdown_table_uses_header_cells
+	test_markdown_table_accepts_indented_single_dash_separator
 	test_markdown_table_preserves_escaped_pipes
 	test_markdown_headings_deduplicate_anchor_ids
 	test_mermaid_renderer_uses_node_ids


### PR DESCRIPTION
## Summary

Relaxed report Markdown table parsing to accept indented pipe tables and GFM single-dash separator cells; added a regression test for indented single-dash tables.

## Files Changed

.agents/scripts/report_render_blocks.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: .agents/scripts/tests/test-report-render-helper.sh (152 tests); python3 -m py_compile .agents/scripts/report_render_blocks.py; shellcheck .agents/scripts/tests/test-report-render-helper.sh. Also ran .agents/scripts/linters-local.sh twice; it passed through Secretlint/Bash 3.2 compatibility but exceeded the worker timeout at later Shell Portability.

Resolves #24117


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 19m and 108,882 tokens on this as a headless worker.