### PR TITLE
GH#24122: align IBM typography prompt weights

### DIFF
--- a/.agents/tools/design/library/brands/ibm/09-agent-prompt-guide.md
+++ b/.agents/tools/design/library/brands/ibm/09-agent-prompt-guide.md
@@ -30,7 +30,7 @@
 
 1. Always use 0px border-radius on buttons, inputs, and cards — this is non-negotiable in Carbon
 2. Letter-spacing only at small sizes: 0.16px at 14px, 0.32px at 12px — never on display text
-3. Three weights: 300 (display), 400 (body), 600 (emphasis) — no bold
+3. Two weights: 400 (display/body), 600 (emphasis) — no bold
 4. Blue 60 is the only accent color — do not introduce secondary accent hues
 5. Depth comes from background-color layering (white → #f4f4f4 → #e0e0e0), not shadows
 6. Inputs have bottom-border only, never fully boxed


### PR DESCRIPTION
## Summary

Aligned IBM design prompt weight guidance so display/headline references consistently use weight 400 and emphasis uses 600.

## Files Changed

.agents/tools/design/library/brands/ibm/09-agent-prompt-guide.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/tools/design/library/brands/ibm/09-agent-prompt-guide.md passed; .agents/scripts/linters-local.sh ran and reported pre-existing unrelated markdown/style debt outside the changed file plus advisory historical complexity debt.

Resolves #24122


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6m and 42,285 tokens on this as a headless worker.