### PR TITLE
GH#24128: suppress version-manager branch probe stderr

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -100,7 +100,7 @@ _version_manager_guard_headless_release_scope() {
 	local action="$1"
 	shift || true
 	local branch_name=""
-	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>&1 || printf 'unknown')
+	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown')
 
 	_version_manager_is_headless_task_worker || return 0
 	_version_manager_action_is_read_only "$action" "$@" && return 0


### PR DESCRIPTION
## Summary

Updated version-manager headless release guard to suppress stderr from the branch-name git probe and use the clean unknown fallback on failure.

## Files Changed

.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager.sh

Resolves #24128


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 34,078 tokens on this as a headless worker.