### PR TITLE
GH#24126: fix: normalize report table backslash parsing

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -55,29 +55,28 @@ def split_markdown_table_row(line: str) -> list[str]:
     row = line.strip()[1:-1]
     cells: list[str] = []
     current: list[str] = []
-    index = 0
-    while index < len(row):
-        char = row[index]
-        if char == "|" and _has_odd_trailing_backslashes(current):
-            current.pop()
-            current.append("|")
-        elif char == "|":
-            cells.append("".join(current))
-            current = []
+    backslash_run = 0
+    for char in row:
+        if char == "\\":
+            backslash_run += 1
+            continue
+
+        current.append("\\" * (backslash_run // 2))
+        if char == "|":
+            if backslash_run % 2 == 1:
+                current.append("|")
+            else:
+                cells.append("".join(current))
+                current = []
         else:
+            if backslash_run % 2 == 1:
+                current.append("\\")
             current.append(char)
-        index += 1
+        backslash_run = 0
+
+    current.append("\\" * ((backslash_run + 1) // 2))
     cells.append("".join(current))
     return cells
-
-
-def _has_odd_trailing_backslashes(chars: list[str]) -> bool:
-    count = 0
-    for char in reversed(chars):
-        if char != "\\":
-            break
-        count += 1
-    return count % 2 == 1
 
 
 def open_list(body: list[str], states: dict[str, object], tag: str, css_class: str = "") -> None:

--- a/tests/test-report-render-blocks.py
+++ b/tests/test-report-render-blocks.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Regression tests for report Markdown block rendering helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPTS_DIR = os.path.join(_REPO_ROOT, ".agents", "scripts")
+sys.path.insert(0, _SCRIPTS_DIR)
+
+from report_render_blocks import split_markdown_table_row  # noqa: E402
+
+
+def assert_equal(actual: object, expected: object, description: str) -> None:
+    if actual != expected:
+        raise AssertionError(f"{description}: expected {expected!r}, got {actual!r}")
+
+
+def test_split_markdown_table_row_unescapes_backslash_pairs() -> None:
+    row = r"| before \\a | before \\| after | trailing \\ |"
+    assert_equal(
+        split_markdown_table_row(row),
+        [r" before \a ", " before \\", r" after ", r" trailing \ "],
+        "table rows unescape double backslashes before text, delimiters, and row end",
+    )
+
+
+def test_split_markdown_table_row_keeps_escaped_pipes_in_cell() -> None:
+    row = r"| literal \| pipe | delimiter |"
+    assert_equal(
+        split_markdown_table_row(row),
+        [" literal | pipe ", " delimiter "],
+        "odd backslash before pipe keeps the pipe inside the current cell",
+    )
+
+
+def main() -> int:
+    test_split_markdown_table_row_unescapes_backslash_pairs()
+    test_split_markdown_table_row_keeps_escaped_pipes_in_cell()
+    print("report_render_blocks tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Updated the report table row splitter to collapse paired backslashes before all characters, preserve escaped pipes, and handle trailing backslash runs consistently. Added a regression test for paired backslashes before text, delimiters, and row endings.

## Files Changed

.agents/scripts/report_render_blocks.py,tests/test-report-render-blocks.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 tests/test-report-render-blocks.py; python3 -m py_compile .agents/scripts/report_render_blocks.py tests/test-report-render-blocks.py; .agents/scripts/linters-local.sh (targeted Python checks passed; command reported pre-existing markdown/style debt unrelated to changed files)

Resolves #24126


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 54,065 tokens on this as a headless worker.