### PR TITLE
Fix Homebrew OpenCode update routing (Resolves #24107)

### DIFF
--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -16,7 +16,7 @@ if [[ ! -f "$TOOL_VERSION_CHECK" ]]; then
 	exit 1
 fi
 
-SANDBOX="$(mktemp -d -t t24107-XXXXXX)"
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/t24107-XXXXXX")"
 trap 'rm -rf "$SANDBOX"' EXIT
 SYSTEM_PATH="$PATH"
 

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#24107: `aidevops update` must not route a
+# Homebrew-managed OpenCode binary through npm and collide with Homebrew's
+# managed symlink.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOL_VERSION_CHECK="$REPO_ROOT/.agents/scripts/tool-version-check.sh"
+
+if [[ ! -f "$TOOL_VERSION_CHECK" ]]; then
+	printf 'FAIL: cannot find %s\n' "$TOOL_VERSION_CHECK" >&2
+	exit 1
+fi
+
+SANDBOX="$(mktemp -d -t t24107-XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+SYSTEM_PATH="$PATH"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local desc="$1"
+	local expected="$2"
+	local actual="$3"
+
+	if [[ "$expected" == "$actual" ]]; then
+		printf '  PASS: %s\n' "$desc"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+
+	printf '  FAIL: %s -- expected %s, got %s\n' "$desc" "$expected" "$actual" >&2
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+extract_function() {
+	awk '
+		/^_opencode_upgrade_cmd\(\)/, /^}$/ { print; next }
+	' "$TOOL_VERSION_CHECK" >"$SANDBOX/extract.sh"
+	if ! grep -q '^_opencode_upgrade_cmd()' "$SANDBOX/extract.sh"; then
+		printf 'FAIL: extraction did not capture _opencode_upgrade_cmd\n' >&2
+		exit 1
+	fi
+	return 0
+}
+
+source_extracted() {
+	# shellcheck source=/dev/null
+	source "$SANDBOX/extract.sh"
+	return 0
+}
+
+write_executable() {
+	local path="$1"
+	local body="$2"
+
+	mkdir -p "$(dirname "$path")"
+	printf '%s\n' "$body" >"$path"
+	chmod +x "$path"
+	return 0
+}
+
+extract_function
+
+printf 'Test 1: Homebrew OpenCode chooses brew instead of npm\n'
+mkdir -p "$SANDBOX/opt/homebrew/bin" "$SANDBOX/opt/homebrew/opt/opencode" "$SANDBOX/homebrew-case"
+write_executable "$SANDBOX/opt/homebrew/bin/opencode" '#!/usr/bin/env bash
+printf "1.15.10\n"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/opt/homebrew/bin/brew" '#!/usr/bin/env bash
+case "${1:-}" in
+--prefix)
+	if [[ "${2:-}" == "opencode" ]]; then
+		printf "%s\n" "'"$SANDBOX"'/opt/homebrew/opt/opencode"
+	else
+		printf "%s\n" "'"$SANDBOX"'/opt/homebrew"
+	fi
+	;;
+list)
+	[[ "${2:-}" == "--versions" && "${3:-}" == "opencode" ]] || exit 1
+	printf "opencode 1.15.10\n"
+	;;
+upgrade | reinstall)
+	printf "%s %s\n" "$1" "${2:-}" >>"'"$SANDBOX"'/homebrew-case/calls"
+	;;
+*) exit 1 ;;
+esac'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/homebrew-case/npm" '#!/usr/bin/env bash
+printf "npm %s\n" "$*" >>"'"$SANDBOX"'/homebrew-case/calls"'
+(
+	source_extracted
+	cmd="$(_opencode_upgrade_cmd 1.15.10)"
+	PATH="$SANDBOX/opt/homebrew/bin:$SANDBOX/homebrew-case:$SYSTEM_PATH" bash -c "$cmd"
+)
+assert_eq "Homebrew OpenCode upgrade command" "upgrade opencode" "$(tr '\n' ';' <"$SANDBOX/homebrew-case/calls" | sed 's/;$//')"
+
+printf 'Test 2: bun OpenCode still chooses bun\n'
+mkdir -p "$SANDBOX/home/.bun/bin" "$SANDBOX/bun-case"
+write_executable "$SANDBOX/home/.bun/bin/opencode" '#!/usr/bin/env bash
+printf "1.15.10\n"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/bun-case/bun" '#!/usr/bin/env bash
+printf "bun %s\n" "$*" >>"'"$SANDBOX"'/bun-case/calls"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/bun-case/npm" '#!/usr/bin/env bash
+printf "npm %s\n" "$*" >>"'"$SANDBOX"'/bun-case/calls"'
+(
+	source_extracted
+	cmd="$(_opencode_upgrade_cmd 1.15.10)"
+	PATH="$SANDBOX/home/.bun/bin:$SANDBOX/bun-case:$SYSTEM_PATH" bash -c "$cmd"
+)
+assert_eq "bun OpenCode upgrade command" "bun install -g opencode-ai@1.15.10" "$(tr '\n' ';' <"$SANDBOX/bun-case/calls" | sed 's/;$//')"
+
+printf 'Test 3: non-Homebrew/non-bun OpenCode falls back to npm\n'
+mkdir -p "$SANDBOX/npm-bin" "$SANDBOX/npm-case"
+write_executable "$SANDBOX/npm-bin/opencode" '#!/usr/bin/env bash
+printf "1.15.10\n"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/npm-case/npm" '#!/usr/bin/env bash
+printf "npm %s\n" "$*" >>"'"$SANDBOX"'/npm-case/calls"'
+(
+	source_extracted
+	cmd="$(_opencode_upgrade_cmd 1.15.10)"
+	PATH="$SANDBOX/npm-bin:$SANDBOX/npm-case:$SYSTEM_PATH" bash -c "$cmd"
+)
+assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$(tr '\n' ';' <"$SANDBOX/npm-case/calls" | sed 's/;$//')"
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -36,7 +36,7 @@ assert_eq() {
 
 	printf '  FAIL: %s -- expected %s, got %s\n' "$desc" "$expected" "$actual" >&2
 	FAIL=$((FAIL + 1))
-	return 1
+	return 0
 }
 
 extract_function() {
@@ -69,9 +69,11 @@ write_executable() {
 extract_function
 
 printf 'Test 1: Homebrew OpenCode chooses brew instead of npm\n'
-mkdir -p "$SANDBOX/opt/homebrew/bin" "$SANDBOX/opt/homebrew/opt/opencode" "$SANDBOX/homebrew-case"
-write_executable "$SANDBOX/opt/homebrew/bin/opencode" '#!/usr/bin/env bash
+mkdir -p "$SANDBOX/opt/homebrew/bin" "$SANDBOX/opt/homebrew/Cellar/opencode/1.15.10/bin" "$SANDBOX/opt/homebrew/opt" "$SANDBOX/homebrew-case"
+write_executable "$SANDBOX/opt/homebrew/Cellar/opencode/1.15.10/bin/opencode" '#!/usr/bin/env bash
 printf "1.15.10\n"'
+ln -s "../Cellar/opencode/1.15.10" "$SANDBOX/opt/homebrew/opt/opencode"
+ln -s "../Cellar/opencode/1.15.10/bin/opencode" "$SANDBOX/opt/homebrew/bin/opencode"
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/opt/homebrew/bin/brew" '#!/usr/bin/env bash
 case "${1:-}" in
@@ -100,6 +102,20 @@ printf "npm %s\n" "$*" >>"'"$SANDBOX"'/homebrew-case/calls"'
 	PATH="$SANDBOX/opt/homebrew/bin:$SANDBOX/homebrew-case:$SYSTEM_PATH" bash -c "$cmd"
 )
 assert_eq "Homebrew OpenCode upgrade command" "upgrade opencode" "$(tr '\n' ';' <"$SANDBOX/homebrew-case/calls" | sed 's/;$//')"
+
+printf 'Test 1b: npm OpenCode inside brew prefix still chooses npm\n'
+mkdir -p "$SANDBOX/opt/homebrew/npm-global/bin" "$SANDBOX/brew-prefix-npm-case"
+write_executable "$SANDBOX/opt/homebrew/npm-global/bin/opencode" '#!/usr/bin/env bash
+printf "1.15.10\n"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/brew-prefix-npm-case/npm" '#!/usr/bin/env bash
+printf "npm %s\n" "$*" >>"'"$SANDBOX"'/brew-prefix-npm-case/calls"'
+(
+	source_extracted
+	cmd="$(_opencode_upgrade_cmd 1.15.10)"
+	PATH="$SANDBOX/opt/homebrew/npm-global/bin:$SANDBOX/opt/homebrew/bin:$SANDBOX/brew-prefix-npm-case:$SYSTEM_PATH" bash -c "$cmd"
+)
+assert_eq "npm OpenCode under brew prefix command" "npm install -g opencode-ai@1.15.10" "$(tr '\n' ';' <"$SANDBOX/brew-prefix-npm-case/calls" | sed 's/;$//')"
 
 printf 'Test 2: bun OpenCode still chooses bun\n'
 mkdir -p "$SANDBOX/home/.bun/bin" "$SANDBOX/bun-case"

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -85,10 +85,14 @@ _opencode_upgrade_cmd() {
 		'if command -v brew >/dev/null 2>&1; then ' \
 		'brew_root=$(brew --prefix 2>/dev/null || printf ""); ' \
 		'r_dir=$(cd "$(dirname "$r")" 2>/dev/null && pwd -P || printf ""); ' \
-		'brew_root_real=""; brew_formula_real=""; ' \
+		'r_link=$(readlink "$r" 2>/dev/null || printf ""); r_real="$r"; ' \
+		'if [[ -n "$r_link" ]]; then case "$r_link" in /*) r_real="$r_link" ;; *) r_real="$r_dir/$r_link" ;; esac; fi; ' \
+		'r_real_dir=$(cd "$(dirname "$r_real")" 2>/dev/null && pwd -P || printf ""); ' \
+		'brew_root_real=""; brew_formula_real=""; brew_formula=""; ' \
 		'[[ -n "$brew_root" ]] && brew_root_real=$(cd "$brew_root" 2>/dev/null && pwd -P || printf ""); ' \
-		'[[ -n "$brew_root_real" ]] && brew_formula_real="$brew_root_real/opt/opencode"; ' \
-		'if brew list --versions opencode >/dev/null 2>&1 && { [[ -n "$brew_root_real" && "$r_dir" == "$brew_root_real"/* ]] || [[ -n "$brew_formula_real" && "$r_dir" == "$brew_formula_real"/* ]]; }; then ' \
+		'[[ -n "$brew_root_real" ]] && brew_formula="$brew_root_real/opt/opencode"; ' \
+		'[[ -n "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" 2>/dev/null && pwd -P || printf ""); ' \
+		'if brew list --versions opencode >/dev/null 2>&1 && [[ -n "$brew_formula_real" ]] && { [[ "$r_dir" == "$brew_formula_real"/* ]] || [[ "$r_real_dir" == "$brew_formula_real"/* ]]; }; then ' \
 		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \
 		'fi; fi; ' \
 		'if [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${pkg_version}"'; else npm install -g opencode-ai@'"${pkg_version}"'; fi; ' \

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -71,11 +71,33 @@ done
 
 # Detect how OpenCode was installed — build the right upgrade command.
 # update_cmd is executed via `bash -c` so it must be a self-contained string.
-# Use `command -v` path directly: bun-installed binaries live under ~/.bun/bin/,
-# so the path itself contains "bun". This avoids `readlink -f` which is a GNU
-# extension not available on macOS by default.
-# shellcheck disable=SC2016  # Single quotes intentional: string is a bash -c payload, must not expand at assignment time
-_oc_upgrade_cmd='if r=$(command -v opencode 2>/dev/null); [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${OPENCODE_PINNED_VERSION}"'; else npm install -g opencode-ai@'"${OPENCODE_PINNED_VERSION}"'; fi'
+# Homebrew ownership must be checked before the npm fallback: Homebrew-managed
+# binaries live under the brew prefix and npm can fail with EEXIST against them.
+# Bun-installed binaries still use the direct path heuristic because they live
+# under ~/.bun/bin/ and macOS lacks GNU `readlink -f` by default.
+# $1 = OpenCode package version to install with bun/npm when not Homebrew-owned.
+_opencode_upgrade_cmd() {
+	local pkg_version="$1"
+
+	# shellcheck disable=SC2016  # Single quotes intentional: bash -c payload
+	printf '%s' \
+		'if r=$(command -v opencode 2>/dev/null); then ' \
+		'if command -v brew >/dev/null 2>&1; then ' \
+		'brew_root=$(brew --prefix 2>/dev/null || printf ""); ' \
+		'brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
+		'r_dir=$(cd "$(dirname "$r")" 2>/dev/null && pwd -P || printf ""); ' \
+		'brew_root_real=""; brew_formula_real=""; ' \
+		'[[ -n "$brew_root" ]] && brew_root_real=$(cd "$brew_root" 2>/dev/null && pwd -P || printf ""); ' \
+		'[[ -n "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" 2>/dev/null && pwd -P || printf ""); ' \
+		'if brew list --versions opencode >/dev/null 2>&1 && { [[ -n "$brew_root_real" && "$r_dir" == "$brew_root_real"/* ]] || [[ -n "$brew_formula_real" && "$r_dir" == "$brew_formula_real"/* ]]; }; then ' \
+		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \
+		'fi; fi; ' \
+		'if [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${pkg_version}"'; else npm install -g opencode-ai@'"${pkg_version}"'; fi; ' \
+		'fi'
+	return 0
+}
+
+_oc_upgrade_cmd=$(_opencode_upgrade_cmd "$OPENCODE_PINNED_VERSION")
 
 # Platform-aware brew package upgrade command.
 # On macOS (or any system with brew), use brew upgrade.

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -84,11 +84,10 @@ _opencode_upgrade_cmd() {
 		'if r=$(command -v opencode 2>/dev/null); then ' \
 		'if command -v brew >/dev/null 2>&1; then ' \
 		'brew_root=$(brew --prefix 2>/dev/null || printf ""); ' \
-		'brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
 		'r_dir=$(cd "$(dirname "$r")" 2>/dev/null && pwd -P || printf ""); ' \
 		'brew_root_real=""; brew_formula_real=""; ' \
 		'[[ -n "$brew_root" ]] && brew_root_real=$(cd "$brew_root" 2>/dev/null && pwd -P || printf ""); ' \
-		'[[ -n "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" 2>/dev/null && pwd -P || printf ""); ' \
+		'[[ -n "$brew_root_real" ]] && brew_formula_real="$brew_root_real/opt/opencode"; ' \
 		'if brew list --versions opencode >/dev/null 2>&1 && { [[ -n "$brew_root_real" && "$r_dir" == "$brew_root_real"/* ]] || [[ -n "$brew_formula_real" && "$r_dir" == "$brew_formula_real"/* ]]; }; then ' \
 		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \
 		'fi; fi; ' \


### PR DESCRIPTION
## Summary
- Add an OpenCode update-command helper that checks Homebrew ownership before bun/npm fallback.
- Route Homebrew-managed `opencode` binaries to `brew upgrade opencode` with `brew reinstall opencode` fallback.
- Add regression coverage for Homebrew, bun, and npm OpenCode update command selection.

## Verification
- `.agents/scripts/tests/test-tool-version-check-opencode.sh`
- `.agents/scripts/tests/test-tool-install-opencode.sh`
- `shellcheck .agents/scripts/tool-version-check.sh .agents/scripts/tests/test-tool-version-check-opencode.sh`
- `.agents/scripts/linters-local.sh` partially ran: core checks passed through Bash 3.2 compatibility; command timed out during Shell Portability after 300s. Advisory existing Qlty/Markdown/ratchet warnings were reported before timeout.

Resolves #24107
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.1 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 22m and 98,691 tokens on this with the user in an interactive session.