### PR TITLE
GH#23958: Fix OpenCode continuation session seeding

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -476,6 +476,10 @@ _invoke_opencode() {
 		# fires while _invoke_opencode is still waiting for the worker.
 		_WORKER_ISOLATED_DB_PATH="${isolated_data_dir}/opencode/opencode.db"
 		print_info "[lifecycle] db_isolated dir=$isolated_data_dir pid=$$"
+		if [[ -n "${_invoke_persisted_session:-}" ]]; then
+			_seed_worker_db_session_context "$isolated_data_dir" "$_invoke_persisted_session"
+			print_info "[lifecycle] db_seeded session=$_invoke_persisted_session pid=$$"
+		fi
 
 		# t2249: Pre-dispatch OAuth pool check. If the account copied into the
 		# isolated auth.json is in cooldown per shared pool metadata (recorded
@@ -1289,6 +1293,9 @@ _execute_run_attempt() {
 	# dispatch rotation against their own pool entries. Same rationale as
 	# _invoke_session_key above: keep _invoke_opencode's arg list stable.
 	_invoke_provider="$provider"
+	# GH#23958: expose the persisted OpenCode session to _invoke_opencode so
+	# isolated worker DBs can be seeded before --session <id> --continue runs.
+	_invoke_persisted_session="$persisted_session"
 
 	# t3077: expose session_key to the verbose lifecycle emitter via the
 	# convention WORKER_SESSION_KEY (read by _emit_verbose_checkpoint).

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1037,6 +1037,46 @@ _merge_worker_db() {
 	return 0
 }
 
+#######################################
+# Seed a continuation session into a worker's isolated OpenCode DB.
+# Called before `opencode run --session <id> --continue` so retries launched
+# with a fresh XDG_DATA_HOME can resolve the persisted conversation locally.
+# Copies only the selected session and its messages (plus its project row for
+# schema/FK compatibility). Non-fatal: failures fall back to normal runtime
+# stale-session handling.
+#######################################
+_seed_worker_db_session_context() {
+	local isolated_dir="$1"
+	local session_id="$2"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	local shared_db="${HOME}/.local/share/opencode/opencode.db"
+
+	[[ -n "$isolated_dir" && -n "$session_id" ]] || return 0
+	[[ -f "$shared_db" ]] || return 0
+	mkdir -p "${isolated_dir}/opencode" 2>/dev/null || return 0
+
+	# Fresh isolated auth dirs may not have a migrated DB yet. Copy schema only
+	# from the shared DB so the targeted row copy has compatible tables without
+	# importing unrelated session/message data.
+	if [[ ! -f "$worker_db" ]]; then
+		sqlite3 "$shared_db" .schema 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || return 0
+	fi
+
+	local shared_db_sql session_id_sql
+	shared_db_sql=$(sql_escape "$shared_db")
+	session_id_sql=$(sql_escape "$session_id")
+	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
+		.timeout 5000
+		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		INSERT OR IGNORE INTO project SELECT * FROM shared.project
+			WHERE id IN (SELECT project_id FROM shared.session WHERE id = '${session_id_sql}');
+		INSERT OR IGNORE INTO session SELECT * FROM shared.session WHERE id = '${session_id_sql}';
+		INSERT OR IGNORE INTO message SELECT * FROM shared.message WHERE session_id = '${session_id_sql}';
+		DETACH DATABASE shared;
+	SQL
+	return 0
+}
+
 # --- Section 10: Dispatch Ledger / Session Locks ---
 
 # _register_dispatch_ledger: register this dispatch in the in-flight ledger (GH#6696).

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -976,6 +976,46 @@ EOF
 	return 0
 }
 
+test_seed_worker_db_session_context_copies_only_selected_session() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-data"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
+INSERT INTO project VALUES ('project-keep', 'Keep Project');
+INSERT INTO project VALUES ('project-other', 'Other Project');
+INSERT INTO session VALUES ('session-keep', 'project-keep', 'Keep');
+INSERT INTO session VALUES ('session-other', 'project-other', 'Other');
+INSERT INTO message VALUES ('message-keep-1', 'session-keep', 'one');
+INSERT INTO message VALUES ('message-keep-2', 'session-keep', 'two');
+INSERT INTO message VALUES ('message-other', 'session-other', 'other');
+SQL
+	sqlite3 "$shared_db" .schema | sqlite3 "$worker_db"
+
+	_seed_worker_db_session_context "$isolated_dir" "session-keep"
+
+	local sessions messages other_sessions other_messages projects
+	sessions=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM session WHERE id = 'session-keep';")
+	messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-keep';")
+	other_sessions=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM session WHERE id = 'session-other';")
+	other_messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-other';")
+	projects=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM project WHERE id = 'project-keep';")
+
+	if [[ "$sessions" == "1" && "$messages" == "2" && "$other_sessions" == "0" && "$other_messages" == "0" && "$projects" == "1" ]]; then
+		print_result "seed worker DB copies only selected continuation session" 0
+		return 0
+	fi
+
+	print_result "seed worker DB copies only selected continuation session" 1 \
+		"sessions=$sessions messages=$messages other_sessions=$other_sessions other_messages=$other_messages projects=$projects"
+	return 0
+}
+
 test_large_opencode_prompt_uses_file_attachment() {
 	local prompt="large-seed-prompt-with-worker-contract"
 	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
@@ -1621,6 +1661,7 @@ main() {
 	test_worker_opencode_exec_paths_strip_session_env
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
+	test_seed_worker_db_session_context_copies_only_selected_session
 	test_large_opencode_prompt_uses_file_attachment
 	test_large_claude_prompt_uses_stdin_file
 	test_registered_prompt_temp_cleanup_removes_dir


### PR DESCRIPTION
## Summary

Seed persisted OpenCode continuation session rows into each isolated worker DB before --session --continue runs, preserving DB isolation while making retries resumable.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n modified shell files; bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck modified files; .agents/scripts/linters-local.sh

Resolves #23958


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.2 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 19m and 110,344 tokens on this with the user in an interactive session.