### PR TITLE
GH#23977: Confirm terminal worker completion state

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -692,7 +692,7 @@ _recover_worker_output_on_failure() {
 #######################################
 # Return success when GitHub already shows the worker target as terminal.
 #
-# A worker can be interrupted after it merged a PR or closed the linked issue.
+# A worker can be interrupted after it merged a PR and the linked issue closed.
 # In that case the local process lacks a completion signal, but redispatching is
 # noise. Only confirmed terminal GitHub state returns 0; unknown/API failures
 # return 1 so normal failure handling remains conservative.
@@ -704,7 +704,7 @@ _worker_external_terminal_complete() {
 	local work_dir="$2"
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
 	local issue_number=""
-	issue_number=$(printf '%s' "$session_key" | sed -nE 's/^[^0-9]*([0-9]+).*/\1/p' | tail -1 || true)
+	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 
 	[[ "$session_key" == issue-* ]] || return 1
 	[[ -n "$repo_slug" && -n "$issue_number" ]] || return 1
@@ -712,24 +712,30 @@ _worker_external_terminal_complete() {
 
 	local issue_state=""
 	issue_state=$(gh issue view "$issue_number" --repo "$repo_slug" --json state --jq '.state // empty' 2>/dev/null || true)
-	if [[ "$issue_state" == "CLOSED" ]]; then
-		print_info "[lifecycle] worker_external_terminal issue_closed session=${session_key} issue=${issue_number}"
-		return 0
-	fi
+	[[ "$issue_state" == "CLOSED" ]] || return 1
 
 	local branch_name=""
 	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
 		branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 	fi
+	[[ -n "$branch_name" && "$branch_name" != "HEAD" ]] || return 1
 
-	local merged_count=""
-	if [[ -n "$branch_name" && "$branch_name" != "HEAD" ]]; then
-		merged_count=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state merged --json number --jq 'length' 2>/dev/null || true)
-		if [[ "$merged_count" =~ ^[0-9]+$ && "$merged_count" -gt 0 ]]; then
-			print_info "[lifecycle] worker_external_terminal pr_merged session=${session_key} branch=${branch_name}"
+	local branch_pr_numbers=""
+	branch_pr_numbers=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state merged --json number --jq '.[].number' 2>/dev/null || true)
+	[[ -n "$branch_pr_numbers" ]] || return 1
+
+	local issue_pr_numbers=""
+	issue_pr_numbers=$(gh pr list --repo "$repo_slug" --state merged --search "$issue_number" --json number --jq '.[].number' 2>/dev/null || true)
+	[[ -n "$issue_pr_numbers" ]] || return 1
+
+	local branch_pr_number=""
+	while IFS= read -r branch_pr_number; do
+		[[ -n "$branch_pr_number" ]] || continue
+		if printf '%s\n' "$issue_pr_numbers" | grep -qx "$branch_pr_number"; then
+			print_info "[lifecycle] worker_external_terminal complete session=${session_key} issue=${issue_number} branch=${branch_name} pr=${branch_pr_number}"
 			return 0
 		fi
-	fi
+	done <<<"$branch_pr_numbers"
 
 	return 1
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1525,14 +1525,14 @@ test_cmd_run_finish_fail_recovers_branch_orphan_output() {
 	return 0
 }
 
-test_cmd_run_finish_fail_closed_issue_releases_complete() {
+test_cmd_run_finish_fail_closed_issue_without_merged_pr_fails() {
 	local work_dir="${TEST_ROOT}/repo-fail-issue-closed"
 	local released_reason="" fast_fail_called=0
 	_setup_test_git_repo "$work_dir" 0
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 	gh() {
 		if [[ "${*}" == *"issue view"* ]]; then printf 'CLOSED'
-		else printf '0'
+		elif [[ "${*}" == *"pr list"* ]]; then printf ''
 		fi
 		return 0
 	}
@@ -1546,16 +1546,16 @@ test_cmd_run_finish_fail_closed_issue_releases_complete() {
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
-	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
-		print_result "_cmd_run_finish fail treats closed linked issue as complete" 0
+	if [[ "$released_reason" == "worker_failed" && "$fast_fail_called" -eq 1 ]]; then
+		print_result "_cmd_run_finish fail requires merged PR beyond closed issue" 0
 	else
-		print_result "_cmd_run_finish fail treats closed linked issue as complete" 1 \
-			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
+		print_result "_cmd_run_finish fail requires merged PR beyond closed issue" 1 \
+			"Expected worker_failed and fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
 	fi
 	return 0
 }
 
-test_cmd_run_finish_fail_merged_pr_releases_complete() {
+test_cmd_run_finish_fail_existing_pr_recovery_remains_complete() {
 	local work_dir="${TEST_ROOT}/repo-fail-pr-merged"
 	local released_reason="" fast_fail_called=0
 	_setup_test_git_repo "$work_dir" 1
@@ -1578,9 +1578,40 @@ test_cmd_run_finish_fail_merged_pr_releases_complete() {
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
-		print_result "_cmd_run_finish fail treats merged PR as complete" 0
+		print_result "_cmd_run_finish fail still recovers existing PR for open issue" 0
 	else
-		print_result "_cmd_run_finish fail treats merged PR as complete" 1 \
+		print_result "_cmd_run_finish fail still recovers existing PR for open issue" 1 \
+			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
+	fi
+	return 0
+}
+
+test_cmd_run_finish_fail_confirmed_terminal_state_releases_complete() {
+	local work_dir="${TEST_ROOT}/repo-fail-terminal-complete"
+	local released_reason="" fast_fail_called=0
+	_setup_test_git_repo "$work_dir" 1
+	DISPATCH_REPO_SLUG="test-owner/test-repo"
+	gh() {
+		if [[ "${*}" == *"issue view"* ]]; then printf 'CLOSED'
+		elif [[ "${*}" == *"pr list"* && "${*}" == *"--head"* && "${*}" == *"--state merged"* ]]; then printf '123'
+		elif [[ "${*}" == *"pr list"* && "${*}" == *"--search"* && "${*}" == *"--state merged"* ]]; then printf '123'
+		fi
+		return 0
+	}
+	_release_dispatch_claim() { released_reason="$2"; return 0; }
+	_report_failure_to_fast_fail() { fast_fail_called=1; return 0; }
+	_update_dispatch_ledger() { return 0; }
+	_release_session_lock() { return 0; }
+	_increment_orphan_count_stat() { return 0; }
+
+	_cmd_run_finish "issue-99999" "fail" "$work_dir"
+
+	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh 2>/dev/null || true
+	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
+		print_result "_cmd_run_finish fail treats confirmed terminal GitHub state as complete" 0
+	else
+		print_result "_cmd_run_finish fail treats confirmed terminal GitHub state as complete" 1 \
 			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
 	fi
 	return 0
@@ -1639,8 +1670,9 @@ main() {
 	test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete
 	test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan
 	test_cmd_run_finish_fail_recovers_branch_orphan_output
-	test_cmd_run_finish_fail_closed_issue_releases_complete
-	test_cmd_run_finish_fail_merged_pr_releases_complete
+	test_cmd_run_finish_fail_closed_issue_without_merged_pr_fails
+	test_cmd_run_finish_fail_existing_pr_recovery_remains_complete
+	test_cmd_run_finish_fail_confirmed_terminal_state_releases_complete
 	teardown_test_env
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	printf 'Failures: %d\n' "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Require closed linked issue, merged current-branch PR, and issue-discoverable merged PR before treating interrupted headless workers as externally complete.

## Files Changed

.agents/scripts/headless-runtime-worker.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash -n .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-headless-runtime-helper.sh; git diff --check; .agents/scripts/linters-local.sh

Resolves #23977


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.2 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 19m and 86,276 tokens on this with the user in an interactive session.