### PR TITLE
GH#24158: fix: defer version-manager branch lookup

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -99,12 +99,16 @@ _version_manager_action_is_read_only() {
 _version_manager_guard_headless_release_scope() {
 	local action="$1"
 	shift || true
-	local branch_name=""
-	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'unknown')
 
 	_version_manager_is_headless_task_worker || return 0
 	_version_manager_action_is_read_only "$action" "$@" && return 0
 	_version_manager_has_approved_release_context && return 0
+
+	local branch_name=""
+	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+	if [[ -z "$branch_name" ]]; then
+		branch_name="unknown"
+	fi
 
 	print_warning "Skipping version-manager ${action:-help}: release/write operations are blocked in ordinary headless task-worker context."
 	print_info "Task worker: ${WORKER_TASK_NUMBER:-unknown}; issue: ${WORKER_ISSUE_NUMBER:-unknown}; repo: ${REPO_ROOT}; session: ${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-unknown}}; branch: ${branch_name}"


### PR DESCRIPTION
## Summary

Deferred the version-manager headless release guard branch lookup until after early-return checks and added an empty-branch fallback before logging.

## Files Changed

.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager.sh

Resolves #24158


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 30,438 tokens on this as a headless worker.