### PR TITLE
GH#24161: fall back for empty raised paper token

### DIFF
--- a/.agents/scripts/report_render_styles.py
+++ b/.agents/scripts/report_render_styles.py
@@ -638,7 +638,7 @@ def _theme_css(name: str, tokens: dict[str, str]) -> str:
   --report-body-size: {tokens.get('body-md.fontSize', DEFAULT_TOKENS['body-md.fontSize'])};
   --report-body-line: {tokens.get('body-md.lineHeight', DEFAULT_TOKENS['body-md.lineHeight'])};
   --report-paper: {tokens['background']};
-  --report-paper-raised: {tokens.get('paper-raised', tokens['primary-container'])};
+  --report-paper-raised: {tokens.get('paper-raised') or tokens['primary-container']};
   --report-panel: {tokens['surface']};
   --report-surface: {tokens['surface']};
   --report-ink: {tokens['on-surface']};

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -311,9 +311,13 @@ tokens["paper-raised"] = "#F5F6F4"
 css = module._theme_css("signal-agency", tokens)
 assert "--report-paper-raised: #F5F6F4;" in css
 assert "--report-paper-raised: #F3DED5;" not in css
+
+tokens["paper-raised"] = ""
+css = module._theme_css("signal-agency", tokens)
+assert "--report-paper-raised: #F3DED5;" in css
 PY
 	if [[ "$_result" -ne 0 ]]; then
-		print_result "Style CSS uses paper-raised token" 1 "Expected paper-raised to override primary-container for raised surfaces"
+		print_result "Style CSS uses paper-raised token" 1 "Expected paper-raised to override primary-container for raised surfaces and fall back when empty"
 		return 0
 	fi
 	print_result "Style CSS uses paper-raised token" 0


### PR DESCRIPTION
## Summary

Treat empty paper-raised style tokens as absent so raised report paper falls back to primary-container, and cover the empty-token case in report render tests.

## Files Changed

.agents/scripts/report_render_styles.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh; python3 -m py_compile .agents/scripts/report_render_styles.py

Resolves #24161


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 3m and 45,166 tokens on this as a headless worker.