### PR TITLE
GH#24162: clarify report css template flow

### DIFF
--- a/.agents/scripts/report-render-helper.py
+++ b/.agents/scripts/report-render-helper.py
@@ -131,13 +131,14 @@ THEMES = ("auto", "light", "dark")
 
 
 def load_css(template: str, pdf_profile: str) -> str:
-    css = BASIC_CSS if template == "basic" else ""
-    if template == "editorial-evidence":
+    if template == "basic":
+        css = BASIC_CSS
+    elif template == "editorial-evidence":
         path = Path(__file__).resolve().parents[1] / "templates" / "reports" / "llm-visibility-report.css"
         css = path.read_text(encoding="utf-8")
     elif template in style_names():
         css = style_css(template)
-    elif template != "basic":
+    else:
         names = ", ".join(BUILTIN_TEMPLATES)
         raise ValueError(f"unknown report template: {template}. Available: {names}")
     if template == "basic":


### PR DESCRIPTION
## Summary

Refactored load_css to use a unified if/elif/else template selection flow while preserving the basic template early return.

## Files Changed

.agents/scripts/report-render-helper.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report-render-helper.py; python3 .agents/scripts/report-render-helper.py print-css for basic, editorial-evidence, and invalid template paths

Resolves #24162


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 43,882 tokens on this as a headless worker.