### PR TITLE
fix: keep version-manager branch fallback non-fatal

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -105,7 +105,9 @@ _version_manager_guard_headless_release_scope() {
 	_version_manager_has_approved_release_context && return 0
 
 	local branch_name=""
-	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+	if ! branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null); then
+		branch_name="unknown"
+	fi
 	if [[ -z "$branch_name" ]]; then
 		branch_name="unknown"
 	fi


### PR DESCRIPTION
## Summary

- Keep the deferred version-manager branch probe non-fatal under `set -e` by handling `git rev-parse` failure in an `if ! ...; then` guard.
- Preserve the `unknown` fallback for failed or empty branch lookup before emitting headless release guard diagnostics.

Ref #24158

## Files changed

- `.agents/scripts/version-manager.sh`

## Testing

- `shellcheck .agents/scripts/version-manager.sh`
- `bash .agents/scripts/tests/test-version-manager-headless-guard.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 82,902 tokens on this as a headless worker.



## Repair evidence (2026-05-27)

- Rebased `feature/auto-20260526-122602-gh24158` onto `origin/main` to clear the dirty merge state.
- Kept the branch fallback guard non-fatal in `.agents/scripts/version-manager.sh`.
- Verification: `shellcheck .agents/scripts/version-manager.sh`; `bash .agents/scripts/tests/test-version-manager-headless-guard.sh` (8 tests, 0 failures).
