### PR TITLE
GH#24156: fix: align report component followups

### DIFF
--- a/.agents/configs/report-component-taxonomy.json.txt
+++ b/.agents/configs/report-component-taxonomy.json.txt
@@ -307,8 +307,12 @@
         "component",
         "label",
         "value",
+        "unit",
         "note",
-        "source_id"
+        "delta",
+        "period",
+        "source_id",
+        "status"
       ],
       "rendering_notes": "Large per-metric card with figure, note, delta/period, and provenance footer."
     },
@@ -330,15 +334,14 @@
       "required_fields": [
         "id",
         "component",
-        "series",
-        "threshold",
-        "evidence"
+        "series"
       ],
       "item_required_fields": [
         "label",
         "value",
         "unit",
-        "status"
+        "status",
+        "evidence"
       ],
       "rendering_notes": "Horizontal bar rows for answer-engine citation/mention share or score distribution."
     },
@@ -380,7 +383,8 @@
         "component",
         "rule",
         "body",
-        "owner"
+        "owner",
+        "effective_date"
       ],
       "rendering_notes": "Redaction/public-artifact rule displayed before sensitive evidence references."
     },
@@ -425,6 +429,7 @@
         "owner",
         "due",
         "source_ids",
+        "status",
         "evidence"
       ],
       "rendering_notes": "One remediation per card with state header and provenance footer."
@@ -457,7 +462,8 @@
         "acceptance",
         "verification",
         "owner",
-        "due"
+        "due",
+        "rollback"
       ],
       "rendering_notes": "Worker-ready handoff block where each field maps to an implementation step or acceptance check."
     },
@@ -486,7 +492,8 @@
         "token_type",
         "sample",
         "value",
-        "usage"
+        "usage",
+        "constraint"
       ],
       "rendering_notes": "Style-guide/report-design card for colour swatches, type samples, component usage, and constraints."
     },

--- a/.agents/templates/reports/llm-visibility-report.css
+++ b/.agents/templates/reports/llm-visibility-report.css
@@ -1977,8 +1977,8 @@ a {
 
   .report-meta-grid,
   .tactic-grid,
-    .stats-strip,
-    .summary-stats,
+  .stats-strip,
+  .summary-stats,
   .sources-layout,
   .severity-key,
   .brand-swatch-grid,
@@ -1992,7 +1992,6 @@ a {
   .privacy-note,
   .toc-list p,
   .ledger-list p,
-  .visibility-bars p,
   .manifest-card dl,
   .dossier-card dl,
   .manifest-card ul,


### PR DESCRIPTION
## Summary

Aligned report component taxonomy required fields with the Markdown reference and kept visibility bars out of the mobile one-column grid override.

## Files Changed

.agents/configs/report-component-taxonomy.json.txt,.agents/templates/reports/llm-visibility-report.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m json.tool .agents/configs/report-component-taxonomy.json.txt >/dev/null; bunx markdownlint-cli2 .agents/reference/report-component-taxonomy.md .agents/reference/domain-index.md

Resolves #24156


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 31m and 56,807 tokens on this as a headless worker.