### PR TITLE
GH#24176: fix: exclude manual interactive PRs from zero-progress signal

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1026,9 +1026,9 @@ Closing this stale zero-progress meta-issue so auto-dispatch does not spend work
 # age gate — zero-progress detection wants the wider population (any cycle
 # with eligible-unmerged > 0 + zero merges is a candidate, regardless of age).
 # It must still exclude PRs that the merge pass already proved are not mergeable
-# in this cycle (for example failing required checks or origin:worker PRs with
-# no linked issue), otherwise a legitimate skip becomes a false zero-progress
-# structural-block signal.
+# in this cycle (for example failing required checks, origin:interactive PRs
+# held for manual merge, or origin:worker PRs with no linked issue), otherwise a
+# legitimate skip becomes a false zero-progress structural-block signal.
 #
 # Args: $1 = repo_slug
 # Stdout: integer count
@@ -1052,6 +1052,14 @@ _pms_pr_counts_for_zero_progress() {
 	if declare -F _check_required_checks_passing >/dev/null 2>&1; then
 		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — required checks are not provably passing" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
+	if [[ ",${labels_str}," == *",origin:interactive,"* ]]; then
+		if ! declare -F _interactive_pr_auto_merge_allowed >/dev/null 2>&1 \
+			|| ! _interactive_pr_auto_merge_allowed "$pr_number" "$repo_slug" "$labels_str" >/dev/null 2>&1; then
+			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — origin:interactive PR requires manual merge" >>"$LOGFILE"
 			return 1
 		fi
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -17,10 +17,11 @@
 #        merged=0 + eligible=0 → gauge reset to 0 (streak broken)
 #        merged=0 + eligible>0 → gauge incremented by 1
 #   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
-#      read-only merge gates (required checks, worker PR with no linked issue,
-#      non-collaborator author without maintainer crypto-approval, and unknown
-#      authors that must not bypass the collaborator check) and keeps processing
-#      when GitHub returns a null PR author for deleted users.
+#      read-only merge gates (required checks, interactive PRs held for manual
+#      merge, worker PR with no linked issue, non-collaborator author without
+#      maintainer crypto-approval, and unknown authors that must not bypass the
+#      collaborator check) and keeps processing when GitHub returns a null PR
+#      author for deleted users.
 #   8. _detect_pattern_outage de-duplicates repeated PR observations.
 #   9. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
@@ -320,7 +321,9 @@ gh() {
 {"number":107,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"external"}},
 {"number":108,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
 {"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null},
-{"number":110,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":null,"author":{"login":"external"}}
+{"number":110,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":null,"author":{"login":"external"}},
+{"number":111,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"}],"author":{"login":"trusted"}},
+{"number":112,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"},{"name":"allow-auto-merge"}],"author":{"login":"trusted"}}
 ]'
 		return 0
 	fi
@@ -364,8 +367,19 @@ _has_maintainer_crypto_approval() {
 	return 1
 }
 
+_interactive_pr_auto_merge_allowed() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local labels_str="$3"
+	[[ -n "$pr_number" && -n "$repo_slug" ]] || return 1
+	if [[ ",${labels_str}," == *",allow-auto-merge,"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
 got=$(_pms_count_eligible_unmerged_for_repo "example/repo")
-assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "2" "$got"
+assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "3" "$got"
 
 PMS_TEST_COUNT_AUTHORS_FILE="$TEST_TMPDIR/count-authors.log"
 : >"$PMS_TEST_COUNT_AUTHORS_FILE"


### PR DESCRIPTION
## Summary

Aligned the zero-progress denominator with the deterministic origin:interactive manual-merge gate so approved/mergeable interactive PRs held for human merge no longer create false throughput-collapse meta-issues. Added regression coverage for manual vs allow-auto-merge interactive PRs.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-stuck.sh

Resolves #24176


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 5m and 70,098 tokens on this as a headless worker.