### PR TITLE
GH#24178: docs: align design md dimension units

### DIFF
--- a/.agents/tools/design/design-md.md
+++ b/.agents/tools/design/design-md.md
@@ -100,7 +100,7 @@ components:
 | Type | Format | Example |
 |------|--------|---------|
 | Color | CSS color parsed to sRGB | `"#1A1C1E"`, `oklch(62% 0.18 24)` |
-| Dimension | number + unit (`px`, `em`, `rem`) | `48px`, `-0.02em` |
+| Dimension | number + CSS length or percentage unit (`px`, `em`, `rem`, `%`) | `48px`, `-0.02em`, `100%` |
 | Token Reference | `{path.to.token}` | `{colors.primary}` |
 | Typography | object (see below) | *inline object* |
 


### PR DESCRIPTION
## Summary

Updated .agents/tools/design/design-md.md so the Dimension token table explicitly includes percentage units and shows 100%, matching the component width example.

## Files Changed

.agents/tools/design/design-md.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Pre-commit hook passed during WIP commit; npx markdownlint-cli2 .agents/tools/design/design-md.md passed. Full .agents/scripts/linters-local.sh was run and only failed on pre-existing unrelated markdown/style and historical complexity debt outside this docs-only change.

Resolves #24178


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 43,579 tokens on this as a headless worker.