### PR TITLE
GH#24190: fix: validate report style slugs

### DIFF
--- a/.agents/scripts/report_render_styles.py
+++ b/.agents/scripts/report_render_styles.py
@@ -44,6 +44,8 @@ STYLE_SLUGS = (
     "signal-agency",
 )
 
+STYLE_SLUG_SET = frozenset(STYLE_SLUGS)
+
 TOKEN_SECTION_PREFIXES = {
     "colors": "",
     "rounded": "rounded.",
@@ -256,6 +258,9 @@ def _parse_tokens(lines: list[str]) -> dict[str, str]:
 
 
 def _tokens_for(name: str) -> dict[str, str]:
+    if name not in STYLE_SLUG_SET:
+        raise ValueError(f"Invalid style name: {name}")
+
     path = _brand_root() / name / "DESIGN.md"
     tokens = dict(DEFAULT_TOKENS)
     if path.exists():
@@ -675,7 +680,7 @@ h3 {{ font-size: clamp(1.15rem, 1.5vw, 1.35rem); line-height: 1.24; }}
 def style_names() -> tuple[str, ...]:
     """Return supported DESIGN.md-backed report style identifiers."""
 
-    return tuple(sorted(STYLE_SLUGS))
+    return tuple(sorted(STYLE_SLUG_SET))
 
 
 def style_css(name: str) -> str:

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -324,6 +324,35 @@ PY
 	return 0
 }
 
+test_style_css_rejects_unknown_slug() {
+	local _result=0
+	python3 - "$SCRIPT_DIR" <<'PY' || _result=$?
+from pathlib import Path
+import importlib.util
+import sys
+
+script_dir = Path(sys.argv[1])
+module_path = script_dir.parent / "report_render_styles.py"
+spec = importlib.util.spec_from_file_location("report_render_styles", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+try:
+    module.style_css("../outside")
+except ValueError as exc:
+    assert "Invalid style name" in str(exc)
+else:
+    raise AssertionError("invalid style slug was accepted")
+PY
+	if [[ "$_result" -ne 0 ]]; then
+		print_result "Style CSS rejects unknown slug" 1 "Expected invalid style names to raise before resolving DESIGN.md paths"
+		return 0
+	fi
+	print_result "Style CSS rejects unknown slug" 0
+	return 0
+}
+
 test_markdown_table_uses_header_cells() {
 	local _input="${TEST_ROOT}/table.md"
 	local _out="${TEST_ROOT}/table.html"
@@ -603,6 +632,7 @@ main() {
 	test_python_helper_reads_stdin_by_default
 	test_style_token_parser_handles_long_headers_and_tabs
 	test_style_css_uses_paper_raised_token
+	test_style_css_rejects_unknown_slug
 	test_markdown_table_uses_header_cells
 	test_markdown_table_accepts_indented_single_dash_separator
 	test_markdown_table_preserves_escaped_pipes


### PR DESCRIPTION
## Summary

Validated report renderer style slugs before resolving DESIGN.md paths and added regression coverage for invalid style names.

## Files Changed

.agents/scripts/report_render_styles.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_styles.py; .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh

Resolves #24190


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 86,427 tokens on this as a headless worker.