### PR TITLE
GH#24182: fix: add sqlite schema busy timeout

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1059,7 +1059,7 @@ _seed_worker_db_session_context() {
 	# from the shared DB so the targeted row copy has compatible tables without
 	# importing unrelated session/message data.
 	if [[ ! -f "$worker_db" ]]; then
-		sqlite3 "$shared_db" .schema 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || return 0
+		sqlite3 -cmd ".timeout 5000" "$shared_db" .schema 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || return 0
 	fi
 
 	local shared_db_sql session_id_sql


### PR DESCRIPTION
## Summary

Added a 5000ms sqlite busy timeout when copying the shared OpenCode schema into an isolated worker DB so transient locks do not cause immediate schema-copy failure.

## Files Changed

.agents/scripts/headless-runtime-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh

Resolves #24182


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 30,838 tokens on this as a headless worker.