### PR TITLE
GH#24180: harden version-manager branch lookup

### DIFF
--- a/.agents/scripts/tests/test-version-manager-headless-guard.sh
+++ b/.agents/scripts/tests/test-version-manager-headless-guard.sh
@@ -99,6 +99,17 @@ else
 fi
 
 reset_guard_env
+original_repo_root="$REPO_ROOT"
+REPO_ROOT="${TMPDIR:-/tmp}/aidevops-version-manager-missing-repo-root-$$"
+branch_name=$(_version_manager_current_branch_name)
+REPO_ROOT="$original_repo_root"
+if [[ "$branch_name" == "unknown" ]]; then
+	print_result 'branch lookup falls back when repo root is not a git worktree' 0
+else
+	print_result 'branch lookup falls back when repo root is not a git worktree' 1 "branch_name=$branch_name"
+fi
+
+reset_guard_env
 export AIDEVOPS_SESSION_KEY='RELEASE-20260525'
 rc=0
 _version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -62,7 +62,7 @@ _version_manager_is_headless_task_worker() {
 
 _version_manager_has_approved_release_context() {
 	local branch_name=""
-	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	branch_name=$(_version_manager_current_branch_name)
 	local session_key="${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-}}"
 	local session_key_lower=""
 	local session_title="${AIDEVOPS_SESSION_TITLE:-${WORKER_SESSION_TITLE:-}}"
@@ -77,6 +77,17 @@ _version_manager_has_approved_release_context() {
 	[[ "$session_key_lower" == release-* || "$session_key_lower" == hotfix-* ]] && return 0
 	[[ "$session_title_lower" == release* || "$session_title_lower" == *" release" || "$session_title_lower" == *" release "* ]] && return 0
 	return 1
+}
+
+_version_manager_current_branch_name() {
+	local branch_name=""
+
+	branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	if [[ -z "$branch_name" ]]; then
+		branch_name="unknown"
+	fi
+	printf '%s\n' "$branch_name"
+	return 0
 }
 
 _version_manager_action_is_read_only() {
@@ -105,12 +116,7 @@ _version_manager_guard_headless_release_scope() {
 	_version_manager_has_approved_release_context && return 0
 
 	local branch_name=""
-	if ! branch_name=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null); then
-		branch_name="unknown"
-	fi
-	if [[ -z "$branch_name" ]]; then
-		branch_name="unknown"
-	fi
+	branch_name=$(_version_manager_current_branch_name)
 
 	print_warning "Skipping version-manager ${action:-help}: release/write operations are blocked in ordinary headless task-worker context."
 	print_info "Task worker: ${WORKER_TASK_NUMBER:-unknown}; issue: ${WORKER_ISSUE_NUMBER:-unknown}; repo: ${REPO_ROOT}; session: ${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-unknown}}; branch: ${branch_name}"


### PR DESCRIPTION
## Summary

Centralized version-manager branch discovery behind a safe helper that falls back to unknown when REPO_ROOT is not a git worktree, and added regression coverage for that fallback.

## Files Changed

.agents/scripts/tests/test-version-manager-headless-guard.sh,.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-version-manager-headless-guard.sh; shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-version-manager-headless-guard.sh; .agents/scripts/linters-local.sh timed out during secretlint after earlier gates passed

Resolves #24180


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 7m and 120,410 tokens on this as a headless worker.