### PR TITLE
GH#24185: fix: keep optional label lookup non-fatal

### DIFF
--- a/.github/workflows/unknown-bot-alert.yml
+++ b/.github/workflows/unknown-bot-alert.yml
@@ -90,7 +90,10 @@ jobs:
           SOURCE_URL: ${{ github.event.comment.html_url }}
           REPO: ${{ github.repository }}
         run: |
-          existing_labels=$(gh label list --repo "$REPO" --limit 1000 --json name --jq '.[].name')
+          if ! existing_labels=$(gh label list --repo "$REPO" --limit 1000 --json name --jq '.[].name'); then
+            printf 'Warning: unable to list repository labels; creating alert without optional labels.\n' >&2
+            existing_labels=""
+          fi
           label_args=()
           for label in unknown-bot quality-debt; do
             if printf '%s\n' "$existing_labels" | grep -Fxq "$label"; then


### PR DESCRIPTION
## Summary

Handled gh label list failures in .github/workflows/unknown-bot-alert.yml by falling back to an empty label list and warning, so alert issue creation can proceed without optional labels during transient API/rate-limit errors.

## Files Changed

.github/workflows/unknown-bot-alert.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** actionlint .github/workflows/unknown-bot-alert.yml

Resolves #24185


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 27,389 tokens on this as a headless worker.