### PR TITLE
GH#24186: fix: tighten OpenCode Homebrew ownership

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -71,8 +71,8 @@ done
 
 # Detect how OpenCode was installed — build the right upgrade command.
 # update_cmd is executed via `bash -c` so it must be a self-contained string.
-# Homebrew ownership must be checked before the npm fallback: Homebrew-managed
-# binaries live under the brew prefix and npm can fail with EEXIST against them.
+# Homebrew ownership must be checked before the npm fallback against the exact
+# opencode formula prefix; npm-managed binaries can also live under brew's root.
 # Bun-installed binaries still use the direct path heuristic because they live
 # under ~/.bun/bin/ and macOS lacks GNU `readlink -f` by default.
 # $1 = OpenCode package version to install with bun/npm when not Homebrew-owned.
@@ -83,14 +83,11 @@ _opencode_upgrade_cmd() {
 	printf '%s' \
 		'if r=$(command -v opencode 2>/dev/null); then ' \
 		'if command -v brew >/dev/null 2>&1; then ' \
-		'brew_root=$(brew --prefix 2>/dev/null || printf ""); ' \
 		'r_dir=$(cd "$(dirname "$r")" 2>/dev/null && pwd -P || printf ""); ' \
 		'r_link=$(readlink "$r" 2>/dev/null || printf ""); r_real="$r"; ' \
 		'if [[ -n "$r_link" ]]; then case "$r_link" in /*) r_real="$r_link" ;; *) r_real="$r_dir/$r_link" ;; esac; fi; ' \
 		'r_real_dir=$(cd "$(dirname "$r_real")" 2>/dev/null && pwd -P || printf ""); ' \
-		'brew_root_real=""; brew_formula_real=""; brew_formula=""; ' \
-		'[[ -n "$brew_root" ]] && brew_root_real=$(cd "$brew_root" 2>/dev/null && pwd -P || printf ""); ' \
-		'[[ -n "$brew_root_real" ]] && brew_formula="$brew_root_real/opt/opencode"; ' \
+		'brew_formula_real=""; brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
 		'[[ -n "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" 2>/dev/null && pwd -P || printf ""); ' \
 		'if brew list --versions opencode >/dev/null 2>&1 && [[ -n "$brew_formula_real" ]] && { [[ "$r_dir" == "$brew_formula_real"/* ]] || [[ "$r_real_dir" == "$brew_formula_real"/* ]]; }; then ' \
 		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \

--- a/tests/test-update-fallbacks.sh
+++ b/tests/test-update-fallbacks.sh
@@ -5,7 +5,6 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CLI_SCRIPT="$REPO_DIR/aidevops.sh"
 TOOL_CHECK_SCRIPT="$REPO_DIR/.agents/scripts/tool-version-check.sh"
 
 PASS_COUNT=0
@@ -102,14 +101,11 @@ BREW_BIN_PATTERN='\[\[ -n "\$brew_bin" && -x "\$brew_bin" \]\]'
 GH_LATEST_PATTERN='"latest": "2.1.0"'
 GH_INSTALLED_PATTERN='"installed": "2.0.0"'
 
-assert_grep 'brew_bin=.*command -v brew' "$CLI_SCRIPT" 'CLI resolves brew path before timeout use'
-assert_grep "$BREW_BIN_PATTERN" "$CLI_SCRIPT" 'CLI requires brew to be executable before invoking timeout'
-assert_grep 'get_public_release_tag "cli/cli"' "$CLI_SCRIPT" 'CLI uses public GitHub API fallback for gh latest version'
-assert_not_grep 'gh api repos/cli/cli/releases/latest' "$CLI_SCRIPT" 'CLI no longer depends on gh auth for gh latest version checks'
-
 assert_grep 'brew_bin=.*command -v brew' "$TOOL_CHECK_SCRIPT" 'Tool checker resolves brew path before timeout use'
 assert_grep "$BREW_BIN_PATTERN" "$TOOL_CHECK_SCRIPT" 'Tool checker requires brew to be executable before invoking timeout'
 assert_grep 'get_public_release_tag "cli/cli"' "$TOOL_CHECK_SCRIPT" 'Tool checker uses public GitHub API fallback for gh latest version'
+assert_grep 'brew --prefix opencode' "$TOOL_CHECK_SCRIPT" 'OpenCode upgrade verifies the Homebrew formula prefix'
+assert_not_grep 'brew_root.*/opt/opencode' "$TOOL_CHECK_SCRIPT" 'OpenCode upgrade avoids brew-root ownership heuristics'
 
 assert_contains "$TOOL_OUTPUT" "$GH_LATEST_PATTERN" 'Tool checker reports gh latest version from public API fallback'
 assert_contains "$TOOL_OUTPUT" "$GH_INSTALLED_PATTERN" 'Tool checker keeps the installed gh version when brew is unavailable'


### PR DESCRIPTION
## Summary

Updated OpenCode upgrade routing to resolve the exact Homebrew opencode formula prefix instead of deriving ownership from the generic brew root, so npm-managed binaries under Homebrew's root fall back to npm. Added focused update-fallback coverage for the formula-prefix guard and removed stale CLI assertions from that test after aidevops.sh no longer owns those checks.

## Files Changed

.agents/scripts/tool-version-check.sh,tests/test-update-fallbacks.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-update-fallbacks.sh && shellcheck .agents/scripts/tool-version-check.sh tests/test-update-fallbacks.sh

Resolves #24186


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 47,875 tokens on this as a headless worker.