### PR TITLE
GH#24184: fix: preserve mobile visibility bar grid

### DIFF
--- a/.agents/templates/reports/llm-visibility-report.css
+++ b/.agents/templates/reports/llm-visibility-report.css
@@ -1999,6 +1999,16 @@ a {
     grid-template-columns: 1fr;
   }
 
+  .visibility-bars p {
+    grid-template-columns: minmax(8rem, 0.32fr) minmax(0, 1fr) minmax(3.5rem, auto);
+  }
+
+  .visibility-bars p::before,
+  .visibility-bars p::after {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .action-line {
     display: grid;
   }


### PR DESCRIPTION
## Summary

Updated the mobile report CSS so visibility bars keep an explicit three-column grid at <=640px, with their bar pseudo-elements pinned to column 2/row 1 instead of being collapsed into one-column mobile overrides.

## Files Changed

.agents/templates/reports/llm-visibility-report.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff HEAD~1..HEAD --check; python3 media-query invariant check for .visibility-bars mobile grid; .agents/scripts/linters-local.sh (timed out during existing ratchet phase after passing SonarCloud, Secretlint, TOON, skill frontmatter, secret safety policy, and pulse canary; markdown issues were advisory/pre-existing)

Resolves #24184


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 9m and 75,351 tokens on this as a headless worker.