### PR TITLE
GH#24188: fix: preserve table separator data rows

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -23,6 +23,7 @@ def close_blocks(body: list[str], states: dict[str, object]) -> None:
     if states.get("table"):
         body.append("</tbody></table>")
         states["table"] = False
+        states["table_body_started"] = False
 
 
 def flush_paragraph(body: list[str], states: dict[str, object]) -> None:
@@ -37,17 +38,20 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     stripped = line.strip()
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return False
-    cells = [inline_markup(cell.strip()) for cell in split_markdown_table_row(stripped)]
-    raw_cells = [html.unescape(cell) for cell in cells]
-    if all(re.match(r"^:?-+:?$", cell) for cell in raw_cells):
+    raw_cells = [cell.strip() for cell in split_markdown_table_row(stripped)]
+    is_separator_row = all(re.match(r"^:?-{3,}:?$", html.unescape(cell)) for cell in raw_cells)
+    if is_separator_row and states.get("table") and not states.get("table_body_started"):
         return True
+    cells = [inline_markup(cell) for cell in raw_cells]
     if not states["table"]:
         close_blocks(body, states)
         body.append("<table><thead>")
         states["table"] = True
+        states["table_body_started"] = False
         body.append("<tr>{}</tr></thead><tbody>".format("".join(f"<th>{cell}</th>" for cell in cells)))
         return True
     body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
+    states["table_body_started"] = True
     return True
 
 

--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -41,6 +41,7 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     raw_cells = [cell.strip() for cell in split_markdown_table_row(stripped)]
     is_separator_row = all(re.match(r"^:?-{3,}:?$", html.unescape(cell)) for cell in raw_cells)
     if is_separator_row and states.get("table") and not states.get("table_body_started"):
+        states["table_body_started"] = True
         return True
     cells = [inline_markup(cell) for cell in raw_cells]
     if not states["table"]:

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -12,7 +12,7 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _SCRIPTS_DIR = os.path.join(_REPO_ROOT, ".agents", "scripts")
 sys.path.insert(0, _SCRIPTS_DIR)
 
-from report_render_blocks import split_markdown_table_row  # noqa: E402
+from report_render_blocks import handle_table, split_markdown_table_row  # noqa: E402
 
 
 def assert_equal(actual: object, expected: object, description: str) -> None:
@@ -38,9 +38,31 @@ def test_split_markdown_table_row_keeps_escaped_pipes_in_cell() -> None:
     )
 
 
+def test_handle_table_skips_only_header_separator_row() -> None:
+    body: list[str] = []
+    states: dict[str, object] = {"table": False, "paragraph": [], "list": False, "list_tag": ""}
+
+    assert handle_table("| Name | Value |", body, states)
+    assert handle_table("| --- | --- |", body, states)
+    assert handle_table("| - | - |", body, states)
+    assert handle_table("| --- | --- |", body, states)
+
+    assert_equal(
+        body,
+        [
+            "<table><thead>",
+            "<tr><th>Name</th><th>Value</th></tr></thead><tbody>",
+            "<tr><td>-</td><td>-</td></tr>",
+            "<tr><td>---</td><td>---</td></tr>",
+        ],
+        "table separator detection only consumes the header separator position",
+    )
+
+
 def main() -> int:
     test_split_markdown_table_row_unescapes_backslash_pairs()
     test_split_markdown_table_row_keeps_escaped_pipes_in_cell()
+    test_handle_table_skips_only_header_separator_row()
     print("report_render_blocks tests passed")
     return 0
 

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -44,6 +44,7 @@ def test_handle_table_skips_only_header_separator_row() -> None:
 
     assert handle_table("| Name | Value |", body, states)
     assert handle_table("| --- | --- |", body, states)
+    assert handle_table("| --- | --- |", body, states)
     assert handle_table("| - | - |", body, states)
     assert handle_table("| --- | --- |", body, states)
 
@@ -52,6 +53,7 @@ def test_handle_table_skips_only_header_separator_row() -> None:
         [
             "<table><thead>",
             "<tr><th>Name</th><th>Value</th></tr></thead><tbody>",
+            "<tr><td>---</td><td>---</td></tr>",
             "<tr><td>-</td><td>-</td></tr>",
             "<tr><td>---</td><td>---</td></tr>",
         ],


### PR DESCRIPTION
## Summary

Updated report table rendering so separator detection runs on raw cells before inline markup and only consumes the header separator position, preserving dash-only data rows.

## Files Changed

.agents/scripts/report_render_blocks.py,tests/test_report_render_blocks.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 tests/test_report_render_blocks.py && python3 -m py_compile .agents/scripts/report_render_blocks.py tests/test_report_render_blocks.py

Resolves #24188


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 2m and 38,708 tokens on this as a headless worker.