### PR TITLE
GH#24179: fix: relax report component required fields

### DIFF
--- a/.agents/configs/report-component-taxonomy.json.txt
+++ b/.agents/configs/report-component-taxonomy.json.txt
@@ -307,12 +307,8 @@
         "component",
         "label",
         "value",
-        "unit",
         "note",
-        "delta",
-        "period",
-        "source_id",
-        "status"
+        "source_id"
       ],
       "rendering_notes": "Large per-metric card with figure, note, delta/period, and provenance footer."
     },
@@ -340,8 +336,7 @@
         "label",
         "value",
         "unit",
-        "status",
-        "evidence"
+        "status"
       ],
       "rendering_notes": "Horizontal bar rows for answer-engine citation/mention share or score distribution."
     },
@@ -383,8 +378,7 @@
         "component",
         "rule",
         "body",
-        "owner",
-        "effective_date"
+        "owner"
       ],
       "rendering_notes": "Redaction/public-artifact rule displayed before sensitive evidence references."
     },
@@ -462,8 +456,7 @@
         "acceptance",
         "verification",
         "owner",
-        "due",
-        "rollback"
+        "due"
       ],
       "rendering_notes": "Worker-ready handoff block where each field maps to an implementation step or acceptance check."
     },
@@ -492,8 +485,7 @@
         "token_type",
         "sample",
         "value",
-        "usage",
-        "constraint"
+        "usage"
       ],
       "rendering_notes": "Style-guide/report-design card for colour swatches, type samples, component usage, and constraints."
     },


### PR DESCRIPTION
## Summary

Relaxed overly restrictive report component taxonomy required fields so KPI cards, visibility bars, privacy notes, implementation briefs, and brand specimen cards continue to support simpler valid examples.

## Files Changed

.agents/configs/report-component-taxonomy.json.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m json.tool .agents/configs/report-component-taxonomy.json.txt >/dev/null; bash .agents/scripts/tests/test-report-render-helper.sh; python3 -m pytest tests/test_report_render_blocks.py (blocked: pytest module unavailable in runtime)

Resolves #24179


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 4m and 47,090 tokens on this as a headless worker.