### PR TITLE
GH#24204: fix: remove redundant visibility bar placement

### DIFF
--- a/.agents/templates/reports/llm-visibility-report.css
+++ b/.agents/templates/reports/llm-visibility-report.css
@@ -2003,12 +2003,6 @@ a {
     grid-template-columns: minmax(8rem, 0.32fr) minmax(0, 1fr) minmax(3.5rem, auto);
   }
 
-  .visibility-bars p::before,
-  .visibility-bars p::after {
-    grid-column: 2;
-    grid-row: 1;
-  }
-
   .action-line {
     display: grid;
   }


### PR DESCRIPTION
## Summary

Removed the redundant media-query grid-column/grid-row restatement for .visibility-bars pseudo-elements while preserving the responsive .visibility-bars p column template.

## Files Changed

.agents/templates/reports/llm-visibility-report.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check HEAD~1..HEAD; git show --check --oneline --stat HEAD; .agents/scripts/linters-local.sh reached the Secretlint phase and timed out after 240s after earlier gates passed

Resolves #24204


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 10m and 83,149 tokens on this as a headless worker.