### PR TITLE
GH#24205: fix: gate opencode brew prefix lookup

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -87,9 +87,12 @@ _opencode_upgrade_cmd() {
 		'r_link=$(readlink "$r" 2>/dev/null || printf ""); r_real="$r"; ' \
 		'if [[ -n "$r_link" ]]; then case "$r_link" in /*) r_real="$r_link" ;; *) r_real="$r_dir/$r_link" ;; esac; fi; ' \
 		'r_real_dir=$(cd "$(dirname "$r_real")" 2>/dev/null && pwd -P || printf ""); ' \
-		'brew_formula_real=""; brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
-		'[[ -n "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" 2>/dev/null && pwd -P || printf ""); ' \
-		'if brew list --versions opencode >/dev/null 2>&1 && [[ -n "$brew_formula_real" ]] && { [[ "$r_dir" == "$brew_formula_real"/* ]] || [[ "$r_real_dir" == "$brew_formula_real"/* ]]; }; then ' \
+		'brew_formula_real=""; ' \
+		'if brew list --versions opencode >/dev/null 2>&1; then ' \
+		'brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
+		'[[ -d "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" && pwd -P || printf ""); ' \
+		'fi; ' \
+		'if [[ -n "$brew_formula_real" ]] && { [[ "$r_dir" == "$brew_formula_real"/* ]] || [[ "$r_real_dir" == "$brew_formula_real"/* ]]; }; then ' \
 		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \
 		'fi; fi; ' \
 		'if [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${pkg_version}"'; else npm install -g opencode-ai@'"${pkg_version}"'; fi; ' \

--- a/tests/test-update-fallbacks.sh
+++ b/tests/test-update-fallbacks.sh
@@ -98,13 +98,17 @@ PATH="$FAKE_BIN:/usr/bin:/bin" TOOL_OUTPUT="$(bash "$TOOL_CHECK_SCRIPT" --catego
 
 # shellcheck disable=SC2016
 BREW_BIN_PATTERN='\[\[ -n "\$brew_bin" && -x "\$brew_bin" \]\]'
+# shellcheck disable=SC2016
+BREW_FORMULA_DIR_PATTERN='\[\[ -d "\$brew_formula" \]\]'
 GH_LATEST_PATTERN='"latest": "2.1.0"'
 GH_INSTALLED_PATTERN='"installed": "2.0.0"'
 
 assert_grep 'brew_bin=.*command -v brew' "$TOOL_CHECK_SCRIPT" 'Tool checker resolves brew path before timeout use'
 assert_grep "$BREW_BIN_PATTERN" "$TOOL_CHECK_SCRIPT" 'Tool checker requires brew to be executable before invoking timeout'
 assert_grep 'get_public_release_tag "cli/cli"' "$TOOL_CHECK_SCRIPT" 'Tool checker uses public GitHub API fallback for gh latest version'
+assert_grep 'if brew list --versions opencode' "$TOOL_CHECK_SCRIPT" 'OpenCode upgrade checks Homebrew installation before formula prefix lookup'
 assert_grep 'brew --prefix opencode' "$TOOL_CHECK_SCRIPT" 'OpenCode upgrade verifies the Homebrew formula prefix'
+assert_grep "$BREW_FORMULA_DIR_PATTERN" "$TOOL_CHECK_SCRIPT" 'OpenCode upgrade verifies the formula directory before cd'
 assert_not_grep 'brew_root.*/opt/opencode' "$TOOL_CHECK_SCRIPT" 'OpenCode upgrade avoids brew-root ownership heuristics'
 
 assert_contains "$TOOL_OUTPUT" "$GH_LATEST_PATTERN" 'Tool checker reports gh latest version from public API fallback'


### PR DESCRIPTION
## Summary

Gated OpenCode Homebrew prefix lookup behind brew list --versions opencode and checked the formula directory before resolving it. Added regression assertions in tests/test-update-fallbacks.sh for the Homebrew install check and directory guard.

## Files Changed

.agents/scripts/tool-version-check.sh,tests/test-update-fallbacks.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tool-version-check.sh tests/test-update-fallbacks.sh; bash tests/test-update-fallbacks.sh (11 tests passed). .agents/scripts/linters-local.sh reached Sonar/Qlty/string-literal/FD-lock/ShellCheck parity successes but timed out during Secretlint after 600s without a reported finding.

Resolves #24205


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 22m and 144,428 tokens on this as a headless worker.