### PR TITLE
GH#24206: fix: reuse version-manager branch lookup

### DIFF
--- a/.agents/scripts/tests/test-version-manager-headless-guard.sh
+++ b/.agents/scripts/tests/test-version-manager-headless-guard.sh
@@ -110,6 +110,18 @@ else
 fi
 
 reset_guard_env
+original_repo_root="$REPO_ROOT"
+REPO_ROOT="${TMPDIR:-/tmp}/aidevops-version-manager-missing-repo-root-arg-$$"
+rc=0
+_version_manager_has_approved_release_context 'release/precomputed' >/dev/null 2>&1 || rc=$?
+REPO_ROOT="$original_repo_root"
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'release context accepts precomputed branch name' 0
+else
+	print_result 'release context accepts precomputed branch name' 1 "rc=$rc"
+fi
+
+reset_guard_env
 export AIDEVOPS_SESSION_KEY='RELEASE-20260525'
 rc=0
 _version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -61,12 +61,14 @@ _version_manager_is_headless_task_worker() {
 }
 
 _version_manager_has_approved_release_context() {
-	local branch_name=""
-	branch_name=$(_version_manager_current_branch_name)
+	local branch_name="${1:-}"
 	local session_key="${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-}}"
 	local session_key_lower=""
 	local session_title="${AIDEVOPS_SESSION_TITLE:-${WORKER_SESSION_TITLE:-}}"
 	local session_title_lower=""
+	if [[ -z "$branch_name" ]]; then
+		branch_name=$(_version_manager_current_branch_name)
+	fi
 	session_key_lower=$(printf '%s' "$session_key" | tr '[:upper:]' '[:lower:]')
 	session_title_lower=$(printf '%s' "$session_title" | tr '[:upper:]' '[:lower:]')
 
@@ -113,10 +115,10 @@ _version_manager_guard_headless_release_scope() {
 
 	_version_manager_is_headless_task_worker || return 0
 	_version_manager_action_is_read_only "$action" "$@" && return 0
-	_version_manager_has_approved_release_context && return 0
 
 	local branch_name=""
 	branch_name=$(_version_manager_current_branch_name)
+	_version_manager_has_approved_release_context "$branch_name" && return 0
 
 	print_warning "Skipping version-manager ${action:-help}: release/write operations are blocked in ordinary headless task-worker context."
 	print_info "Task worker: ${WORKER_TASK_NUMBER:-unknown}; issue: ${WORKER_ISSUE_NUMBER:-unknown}; repo: ${REPO_ROOT}; session: ${WORKER_SESSION_KEY:-${AIDEVOPS_SESSION_KEY:-unknown}}; branch: ${branch_name}"


### PR DESCRIPTION
## Summary

Updated version-manager release-context checks to accept a precomputed branch name and pass the guard's single branch lookup through, avoiding duplicate git branch probes while preserving fallback behavior. Added regression coverage for precomputed release branch context.

## Files Changed

.agents/scripts/tests/test-version-manager-headless-guard.sh,.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-version-manager-headless-guard.sh; .agents/scripts/tests/test-version-manager-headless-guard.sh

Resolves #24206


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 6m and 42,486 tokens on this as a headless worker.