### PR TITLE
GH#24207: fix: use bash issue parsing

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -704,7 +704,9 @@ _worker_external_terminal_complete() {
 	local work_dir="$2"
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
 	local issue_number=""
-	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
+	if [[ "$session_key" =~ ([0-9]+)$ ]]; then
+		issue_number="${BASH_REMATCH[1]}"
+	fi
 
 	[[ "$session_key" == issue-* ]] || return 1
 	[[ -n "$repo_slug" && -n "$issue_number" ]] || return 1


### PR DESCRIPTION
## Summary

Replaced the external printf|grep pipeline in .agents/scripts/headless-runtime-worker.sh with Bash regex matching via BASH_REMATCH for trailing issue digits.

## Files Changed

.agents/scripts/headless-runtime-worker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-worker-output-classification.sh; bash .agents/scripts/tests/test-worker-output-classification.sh

Resolves #24207


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 4m and 66,801 tokens on this as a headless worker.