### PR TITLE
GH#24208: fix: precompute sorted report style slugs

### DIFF
--- a/.agents/scripts/report_render_styles.py
+++ b/.agents/scripts/report_render_styles.py
@@ -45,6 +45,7 @@ STYLE_SLUGS = (
 )
 
 STYLE_SLUG_SET = frozenset(STYLE_SLUGS)
+SORTED_STYLE_SLUGS = tuple(sorted(STYLE_SLUG_SET))
 
 TOKEN_SECTION_PREFIXES = {
     "colors": "",
@@ -680,7 +681,7 @@ h3 {{ font-size: clamp(1.15rem, 1.5vw, 1.35rem); line-height: 1.24; }}
 def style_names() -> tuple[str, ...]:
     """Return supported DESIGN.md-backed report style identifiers."""
 
-    return tuple(sorted(STYLE_SLUG_SET))
+    return SORTED_STYLE_SLUGS
 
 
 def style_css(name: str) -> str:


### PR DESCRIPTION
## Summary

Precomputed the sorted report style slug tuple at module import time and returned it from style_names().

## Files Changed

.agents/scripts/report_render_styles.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_styles.py; import smoke test confirmed style_names() returns SORTED_STYLE_SLUGS and tuple(sorted(STYLE_SLUG_SET)); .agents/scripts/tests/test-report-render-helper.sh currently has 159 run, 1 pre-existing table separator failure unrelated to this style-name change.

Resolves #24208


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 5m and 102,110 tokens on this as a headless worker.