### PR TITLE
fix: lock crypto approval conversations after signing

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -349,14 +349,70 @@ _approval_lock_issue() {
 	local target_number="$1"
 	local slug="$2"
 	local rc=0
+	local rest_rc=0
 
 	gh issue lock "$target_number" --repo "$slug" --reason "resolved" >/dev/null 2>&1 || rc=$?
-	if [[ $rc -ne 0 ]] && command -v _rest_should_fallback >/dev/null 2>&1 && _rest_should_fallback; then
-		_print_info "gh-wrapper: GraphQL exhausted, falling back to REST for issue lock" >&2
-		rc=0
-		gh api -X PUT "/repos/${slug}/issues/${target_number}/lock" -f lock_reason=resolved >/dev/null 2>&1 || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		return 0
 	fi
-	return "$rc"
+
+	# `gh issue lock` rejects PR-backed issue numbers with "use gh pr lock",
+	# while GitHub's REST issue lock endpoint works for both issues and PR
+	# conversations. Always try REST after the CLI path fails so signed
+	# approvals do not leave an unlocked prompt-injection window.
+	if command -v _rest_should_fallback >/dev/null 2>&1 && _rest_should_fallback; then
+		_print_info "gh-wrapper: GraphQL exhausted, falling back to REST for issue lock" >&2
+	else
+		_print_info "gh-wrapper: gh issue lock failed, falling back to REST for issue lock" >&2
+	fi
+	gh api -X PUT "/repos/${slug}/issues/${target_number}/lock" -f lock_reason=resolved >/dev/null 2>&1 || rest_rc=$?
+	return "$rest_rc"
+}
+
+_approval_lock_pr() {
+	local target_number="$1"
+	local slug="$2"
+	local rc=0
+	local rest_rc=0
+
+	gh pr lock "$target_number" --repo "$slug" --reason "resolved" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		return 0
+	fi
+
+	# Fall back to the REST issue lock endpoint because PR conversations are
+	# issue-backed in GitHub's API and the endpoint is stable across gh versions.
+	if command -v _rest_should_fallback >/dev/null 2>&1 && _rest_should_fallback; then
+		_print_info "gh-wrapper: GraphQL exhausted, falling back to REST for PR lock" >&2
+	else
+		_print_info "gh-wrapper: gh pr lock failed, falling back to REST for PR lock" >&2
+	fi
+	gh api -X PUT "/repos/${slug}/issues/${target_number}/lock" -f lock_reason=resolved >/dev/null 2>&1 || rest_rc=$?
+	return "$rest_rc"
+}
+
+_approval_verify_conversation_locked() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local issue_json=""
+	local label="issue"
+
+	if [[ "$target_type" == "pr" ]]; then
+		label="PR conversation"
+	fi
+
+	issue_json=$(_approval_fetch_issue_json "$target_number" "$slug") || {
+		_print_error "Approval state verification failed: could not read ${label} #$target_number via REST"
+		return 1
+	}
+
+	if ! printf '%s' "$issue_json" | jq -e '.locked == true' >/dev/null 2>&1; then
+		_print_error "Approval state verification failed: ${label} #$target_number is not locked"
+		return 1
+	fi
+
+	return 0
 }
 
 _approval_fetch_issue_json() {
@@ -473,9 +529,14 @@ _post_issue_approval_updates() {
 		gh_pr_comment "$target_number" --repo "$slug" \
 			--body "This PR has been approved by a maintainer and is now locked for review." \
 			>/dev/null 2>&1 || true
-		# Note: GitHub does not support locking PRs via gh CLI directly (only issues).
-		# The lock_notice in the approval comment serves as the authoritative signal.
-		_print_info "PR #$target_number approval recorded (conversation locked via approval comment)"
+		local lock_err=""
+		lock_err=$(_approval_lock_pr "$target_number" "$slug" 2>&1 >/dev/null) || {
+			_print_error "Approval advisory lock failure: PR #$target_number conversation could not be locked after approval state updates"
+			[[ -n "$lock_err" ]] && _print_error "$lock_err"
+			return 1
+		}
+		_approval_verify_conversation_locked "$target_type" "$target_number" "$slug" || return 1
+		_print_info "PR #$target_number approval recorded and conversation locked"
 	fi
 
 	return 0

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -134,6 +134,79 @@ assert_not_contains "successful fallback does not print false lock error" "$LAST
 assert_not_contains "successful fallback does not print advisory lock failure" "$LAST_OUTPUT" "Approval advisory lock failure"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "PR-backed issue lock falls back to REST without GraphQL fallback" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_rest_should_fallback() { return 1; }
+	gh_issue_edit_safe() { return 0; }
+	gh_issue_view() { printf "bug,auto-dispatch"; return 0; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		local arg3="${3:-}"
+		local arg4="${4:-}"
+		if [[ "$arg1" == "api" && "$arg2" == "user" ]]; then printf "marcusquinn"; return 0; fi
+		if [[ "$arg1" == "issue" && "$arg2" == "lock" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "-X" && "$arg3" == "PUT" && "$arg4" == "/repos/marcusquinn/aidevops/issues/2417/lock" ]]; then return 0; fi
+		if [[ "$arg1" == "api" && "$arg2" == "/repos/marcusquinn/aidevops/issues/2417" ]]; then
+			printf "%s" "{\"labels\":[{\"name\":\"auto-dispatch\"}],\"assignees\":[{\"login\":\"marcusquinn\"}],\"locked\":true}"
+			return 0
+		fi
+		return 1
+	}
+	_approval_apply_issue_lifecycle_updates 2417 marcusquinn/aidevops
+' 0
+assert_contains "PR-backed issue fallback reports locked state" "$LAST_OUTPUT" "Issue #2417 locked"
+assert_not_contains "PR-backed issue fallback avoids advisory failure" "$LAST_OUTPUT" "Approval advisory lock failure"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "PR approval locks conversation with gh pr lock" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_rest_should_fallback() { return 1; }
+	gh_pr_comment() { return 0; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "pr" && "$arg2" == "lock" ]]; then return 0; fi
+		if [[ "$arg1" == "api" && "$arg2" == "/repos/marcusquinn/aidevops/issues/456" ]]; then
+			printf "%s" "{\"locked\":true}"
+			return 0
+		fi
+		return 1
+	}
+	_post_issue_approval_updates pr 456 marcusquinn/aidevops
+' 0
+assert_contains "PR approval reports real conversation lock" "$LAST_OUTPUT" "PR #456 approval recorded and conversation locked"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "PR approval REST fallback locks conversation" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_rest_should_fallback() { return 1; }
+	gh_pr_comment() { return 0; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		local arg3="${3:-}"
+		local arg4="${4:-}"
+		if [[ "$arg1" == "pr" && "$arg2" == "lock" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "-X" && "$arg3" == "PUT" && "$arg4" == "/repos/marcusquinn/aidevops/issues/456/lock" ]]; then return 0; fi
+		if [[ "$arg1" == "api" && "$arg2" == "/repos/marcusquinn/aidevops/issues/456" ]]; then
+			printf "%s" "{\"locked\":true}"
+			return 0
+		fi
+		return 1
+	}
+	_post_issue_approval_updates pr 456 marcusquinn/aidevops
+' 0
+assert_contains "PR approval fallback reports real lock" "$LAST_OUTPUT" "PR #456 approval recorded and conversation locked"
+assert_not_contains "PR approval fallback avoids advisory failure" "$LAST_OUTPUT" "Approval advisory lock failure"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "genuine lock failure is distinguished" '
 	set -uo pipefail
 	# shellcheck disable=SC1090


### PR DESCRIPTION
## Summary
- Always fall back to GitHub's REST issue lock endpoint when `gh issue lock` fails, covering PR-backed issue approvals such as `sudo aidevops approve issue 2417`.
- Lock `aidevops approve pr` conversations with `gh pr lock`, with the same REST fallback and locked-state verification.
- Add regression coverage for PR-backed issue locks and PR approval locks.

## Verification
- `bash .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `bash .agents/scripts/tests/test-approval-helper-verify-state.sh`
- `shellcheck .agents/scripts/approval-helper.sh .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `.agents/scripts/linters-local.sh` — final result: `ALL LOCAL CHECKS PASSED`; advisory pre-existing markdown/ratchet/complexity output observed.

For #2417

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.0 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 23m and 167,483 tokens on this with the user in an interactive session.
