### PR TITLE
Improve report-token-use totals and daily summary

### DIFF
--- a/.agents/reports/token-use.md
+++ b/.agents/reports/token-use.md
@@ -25,6 +25,7 @@ only after the helper has written the local evidence bundle.
 ```bash
 ~/.aidevops/agents/scripts/report-token-use-helper.sh report --limit 25
 ~/.aidevops/agents/scripts/report-token-use-helper.sh report --session ses_abc123 --open
+~/.aidevops/agents/scripts/report-token-use-helper.sh report --daily-days 90
 ~/.aidevops/agents/scripts/report-token-use-helper.sh data --json --since 7d
 ```
 
@@ -35,6 +36,8 @@ only after the helper has written the local evidence bundle.
   is the browser review copy.
 - The command prints the `file://` link for `report.html` and opens it only when
   `--open` is supplied.
+- Daily usage covers the last 90 days by default; use `--daily-days N` to change
+  the window or `--daily-days 0` to disable it.
 
 ## Data Sources
 
@@ -48,12 +51,15 @@ only after the helper has written the local evidence bundle.
 
 - Session name and root session ID.
 - Runtime and model(s) used.
-- Tokens in, tokens out, reasoning, cached-read, cached-write, and net total.
+- Tokens in, tokens out, reasoning, cached-read, cached-write, net total, raw total, and cost.
 - Compaction count and child session count.
-- Active/configured MCP servers and observed MCP tools.
+- Configured MCP servers and observed MCP tools.
 - Date-time started and date-time finished.
 
-Net token total is input + output + reasoning + cache-read + cache-write tokens.
+Net token total is input + output + reasoning + cache-write tokens. Cache reads
+are excluded from net totals and retained in raw totals for context-volume review.
+Provider-specific cached-read discounts are best represented by the cost field
+when available from the runtime database.
 
 ## Privacy
 

--- a/.agents/scripts/commands/report-token-use.md
+++ b/.agents/scripts/commands/report-token-use.md
@@ -25,6 +25,7 @@ Arguments: `$ARGUMENTS`
 /report-token-use --session ses_abc123
 /report-token-use --since 7d
 /report-token-use --runtime opencode
+/report-token-use --daily-days 90
 /report-token-use --json
 /report-token-use --open
 ```
@@ -36,13 +37,15 @@ Reports are written under `~/.aidevops/_reports/token-use/<UTC-run-id>/`:
 - `report.md` — canonical Markdown review copy.
 - `report.json` — machine-readable session rows.
 - `report.html` — local browser review file.
+- Each report includes a daily usage summary for the last 90 days by default.
 
 ## Data contract
 
 Each session row includes session name, runtime, model(s), tokens in, tokens out,
-cached-read tokens, net token total, compaction count, active/configured MCPs,
+cached-read tokens, raw token total, net token total, compaction count, configured MCPs,
 observed MCPs, started time, and finished time.
 
-Net token total is input + output + reasoning + cache-read + cache-write tokens.
+Net token total is input + output + reasoning + cache-write tokens. Cache reads
+are excluded from net totals and retained in raw totals for context-volume review.
 OpenCode reports recursively include child sessions via `session.parent_id` so
 compacted sessions are counted with their root session.

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,7 @@ class SessionReport:
     tokens_reasoning: int
     tokens_cache_read: int
     tokens_cache_write: int
+    raw_tokens_total: int
     net_tokens_total: int
     child_session_count: int
     compaction_count: int
@@ -69,6 +71,15 @@ class SessionReport:
     request_count: int
     tool_call_count: int
     source_session_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DailyUsage:
+    date: str
+    session_count: int
+    raw_tokens_total: int
+    net_tokens_total: int
+    cost_usd: float
 
 
 def _make_session_report(**values: Any) -> SessionReport:
@@ -335,7 +346,8 @@ def _tokens_for_group(group: list[SessionRow]) -> dict[str, int]:
         "cache_read": sum(row.tokens_cache_read for row in group),
         "cache_write": sum(row.tokens_cache_write for row in group),
     }
-    tokens["total"] = sum(tokens.values())
+    tokens["raw_total"] = sum(tokens.values())
+    tokens["net_total"] = tokens["input"] + tokens["output"] + tokens["reasoning"] + tokens["cache_write"]
     return tokens
 
 
@@ -372,7 +384,8 @@ def _opencode_report_from_group(
         tokens_reasoning=tokens["reasoning"],
         tokens_cache_read=tokens["cache_read"],
         tokens_cache_write=tokens["cache_write"],
-        net_tokens_total=tokens["total"],
+        raw_tokens_total=tokens["raw_total"],
+        net_tokens_total=tokens["net_total"],
         child_session_count=max(len(group) - 1, 0),
         compaction_count=sum(1 for row in group if row.parent_id or row.time_compacting),
         mcps_active=configured_mcps,
@@ -474,7 +487,8 @@ def _add_claude_row(grouped: dict[str, dict[str, Any]], session_id: str, row: di
 
 
 def _claude_report_from_group(session_id: str, data: dict[str, Any]) -> SessionReport:
-    net_tokens_total = data["input"] + data["output"] + data["cache_read"] + data["cache_write"]
+    raw_tokens_total = data["input"] + data["output"] + data["cache_read"] + data["cache_write"]
+    net_tokens_total = data["input"] + data["output"] + data["cache_write"]
     return _make_session_report(
         session_id=session_id,
         session_name=session_id,
@@ -485,6 +499,7 @@ def _claude_report_from_group(session_id: str, data: dict[str, Any]) -> SessionR
         tokens_reasoning=0,
         tokens_cache_read=data["cache_read"],
         tokens_cache_write=data["cache_write"],
+        raw_tokens_total=raw_tokens_total,
         net_tokens_total=net_tokens_total,
         child_session_count=0,
         compaction_count=0,
@@ -508,6 +523,39 @@ def _collect_reports(args: argparse.Namespace) -> list[SessionReport]:
     return reports if reports else _claude_reports(args)
 
 
+def _daily_usage(reports: list[SessionReport]) -> list[DailyUsage]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for report in reports:
+        date = (report.finished_at or report.started_at or "unknown")[:10]
+        data = grouped.setdefault(date, {"sessions": 0, "raw": 0, "net": 0, "cost": 0.0})
+        data["sessions"] += 1
+        data["raw"] += report.raw_tokens_total
+        data["net"] += report.net_tokens_total
+        data["cost"] += report.cost_usd
+    return [
+        DailyUsage(
+            date=date,
+            session_count=data["sessions"],
+            raw_tokens_total=data["raw"],
+            net_tokens_total=data["net"],
+            cost_usd=round(data["cost"], 6),
+        )
+        for date, data in sorted(grouped.items(), reverse=True)
+    ]
+
+
+def _collect_daily_usage(args: argparse.Namespace) -> list[DailyUsage]:
+    if args.daily_days < 1:
+        return []
+    daily_args = SimpleNamespace(
+        limit=100000,
+        session=args.session,
+        since=f"{args.daily_days}d",
+        runtime=args.runtime,
+    )
+    return _daily_usage(_collect_reports(daily_args))
+
+
 def _open_path(path: Path) -> None:
     if sys.platform == "darwin":
         subprocess.run(["open", str(path)], check=False)
@@ -522,24 +570,26 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--session", help="include one session/root session")
     parser.add_argument("--since", help="restrict to sessions updated within duration, e.g. 24h, 7d, 2w")
     parser.add_argument("--runtime", choices=["auto", "opencode", "claude"], default="auto")
+    parser.add_argument("--daily-days", type=int, default=90, help="days to include in the daily usage summary; 0 disables")
 
 
 def cmd_data(args: argparse.Namespace) -> int:
     reports = _collect_reports(args)
-    payload = {"sessions": [as_dict(row) for row in reports]}
+    payload = {"daily_usage": [as_dict(row) for row in _collect_daily_usage(args)], "sessions": [as_dict(row) for row in reports]}
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 
 def cmd_report(args: argparse.Namespace) -> int:
     reports = _collect_reports(args)
+    daily_usage = _collect_daily_usage(args)
     generated_at = datetime.now(UTC).astimezone().isoformat(timespec="seconds")
     output_root = Path(os.environ.get("AIDEVOPS_REPORT_TOKEN_USE_ROOT", DEFAULT_REPORT_ROOT))
     output_dir = output_root / _iso_now_id()
     output_dir.mkdir(parents=True, exist_ok=True)
-    md_path = write_markdown(reports, output_dir, generated_at)
-    json_path = write_json(reports, output_dir, generated_at)
-    html_path = write_html(reports, output_dir, generated_at)
+    md_path = write_markdown(reports, daily_usage, output_dir, generated_at)
+    json_path = write_json(reports, daily_usage, output_dir, generated_at)
+    html_path = write_html(reports, daily_usage, output_dir, generated_at)
     if args.open:
         _open_path(html_path)
     if args.json:

--- a/.agents/scripts/report_token_use_render.py
+++ b/.agents/scripts/report_token_use_render.py
@@ -12,6 +12,14 @@ from typing import Any
 
 
 def as_dict(report: Any) -> dict[str, Any]:
+    if hasattr(report, "date"):
+        return {
+            "date": report.date,
+            "session_count": report.session_count,
+            "raw_tokens_total": report.raw_tokens_total,
+            "net_tokens_total": report.net_tokens_total,
+            "cost_usd": report.cost_usd,
+        }
     return {
         "session_id": report.session_id,
         "session_name": report.session_name,
@@ -22,10 +30,12 @@ def as_dict(report: Any) -> dict[str, Any]:
         "tokens_reasoning": report.tokens_reasoning,
         "tokens_cache_read": report.tokens_cache_read,
         "tokens_cache_write": report.tokens_cache_write,
+        "raw_tokens_total": report.raw_tokens_total,
         "net_tokens_total": report.net_tokens_total,
         "child_session_count": report.child_session_count,
         "compaction_count": report.compaction_count,
         "mcps_active": report.mcps_active,
+        "mcps_configured": report.mcps_active,
         "mcps_observed": report.mcps_observed,
         "started_at": report.started_at,
         "finished_at": report.finished_at,
@@ -40,19 +50,29 @@ def _format_int(value: int) -> str:
     return f"{value:,}"
 
 
-def write_markdown(reports: list[Any], output_dir: Path, generated_at: str) -> Path:
+def write_markdown(reports: list[Any], daily_usage: list[Any], output_dir: Path, generated_at: str) -> Path:
     report_path = output_dir / "report.md"
-    total = sum(row.net_tokens_total for row in reports)
+    net_total = sum(row.net_tokens_total for row in reports)
+    raw_total = sum(row.raw_tokens_total for row in reports)
     lines = [
         "# Token Use Report",
         "",
         f"Generated: {generated_at}",
         f"Sessions: {len(reports)}",
-        f"Net tokens: {_format_int(total)}",
-        "",
-        "| Session name | Runtime | Models | Tokens in | Tokens out | Cached-read | Net total | Compactions | MCPs active | MCPs observed | Started | Finished |",
-        "|---|---|---|---:|---:|---:|---:|---:|---|---|---|---|",
+        f"Net tokens (excludes cache reads): {_format_int(net_total)}",
+        f"Raw tokens (includes cache reads): {_format_int(raw_total)}",
     ]
+    if daily_usage:
+        lines.extend(_daily_markdown(daily_usage))
+    lines.extend(
+        [
+            "",
+            "## Sessions",
+            "",
+            "| Session name | Runtime | Models | Tokens in | Tokens out | Cached-read | Net tokens | Raw tokens | Cost | Compactions | MCPs configured | MCPs observed | Started | Finished |",
+            "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|",
+        ]
+    )
     for row in reports:
         lines.append(_markdown_row(row))
     lines.extend(
@@ -60,13 +80,29 @@ def write_markdown(reports: list[Any], output_dir: Path, generated_at: str) -> P
             "",
             "## Notes",
             "",
-            "- Net total is input + output + reasoning + cache-read + cache-write tokens.",
+            "- Net tokens are input + output + reasoning + cache-write tokens, excluding cache reads so the main total tracks paid/metered work more closely.",
+            "- Raw tokens include cache reads for context volume analysis. Provider-specific cached-read billing discounts are best represented by the Cost column when available.",
             "- OpenCode rows recursively include child sessions via `session.parent_id` so compacted sessions are counted with their root session.",
-            "- MCPs active are configured OpenCode MCP server names at report time; MCPs observed are inferred from session tool-call names when available.",
+            "- MCPs configured lists configured OpenCode MCP server names at report time. MCPs observed are inferred from session tool-call names when available and are the better proxy for actual use.",
         ]
     )
     report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return report_path
+
+
+def _daily_markdown(daily_usage: list[Any]) -> list[str]:
+    lines = [
+        "",
+        "## Daily usage",
+        "",
+        "| Date | Sessions | Net tokens | Raw tokens | Cost |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in daily_usage:
+        lines.append(
+            f"| {row.date} | {row.session_count} | {_format_int(row.net_tokens_total)} | {_format_int(row.raw_tokens_total)} | ${row.cost_usd:.6f} |"
+        )
+    return lines
 
 
 def _markdown_row(row: Any) -> str:
@@ -78,6 +114,8 @@ def _markdown_row(row: Any) -> str:
         _format_int(row.tokens_output),
         _format_int(row.tokens_cache_read),
         _format_int(row.net_tokens_total),
+        _format_int(row.raw_tokens_total),
+        f"${row.cost_usd:.6f}",
         str(row.compaction_count),
         ", ".join(row.mcps_active) or "none configured",
         ", ".join(row.mcps_observed) or "none observed",
@@ -87,10 +125,12 @@ def _markdown_row(row: Any) -> str:
     return "| " + " | ".join(cells) + " |"
 
 
-def write_html(reports: list[Any], output_dir: Path, generated_at: str) -> Path:
+def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, generated_at: str) -> Path:
     report_path = output_dir / "report.html"
     body = "\n".join(_html_row(row) for row in reports)
-    total = _format_int(sum(row.net_tokens_total for row in reports))
+    daily_body = "\n".join(_daily_html_row(row) for row in daily_usage)
+    net_total = _format_int(sum(row.net_tokens_total for row in reports))
+    raw_total = _format_int(sum(row.raw_tokens_total for row in reports))
     html_doc = f"""<!doctype html>
 <html lang=\"en\">
 <head>
@@ -99,18 +139,26 @@ def write_html(reports: list[Any], output_dir: Path, generated_at: str) -> Path:
   <title>Token Use Report</title>
   <style>
     body {{ color: #172033; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; }}
-    table {{ border-collapse: collapse; width: 100%; }}
+    table {{ border-collapse: collapse; margin-bottom: 2rem; width: 100%; }}
     th, td {{ border-bottom: 1px solid #d8dee9; padding: .55rem; text-align: left; vertical-align: top; }}
-    td:nth-child(4), td:nth-child(5), td:nth-child(6), td:nth-child(7), td:nth-child(8) {{ text-align: right; }}
+    td.num {{ text-align: right; }}
     th {{ background: #f5f7fb; position: sticky; top: 0; }}
     .meta {{ color: #5f6b7a; }}
   </style>
 </head>
 <body>
   <h1>Token Use Report</h1>
-  <p class=\"meta\">Generated: {html.escape(generated_at)} · Sessions: {len(reports)} · Net tokens: {total}</p>
+  <p class=\"meta\">Generated: {html.escape(generated_at)} · Sessions: {len(reports)} · Net tokens: {net_total} · Raw tokens: {raw_total}</p>
+  <h2>Daily usage</h2>
   <table>
-    <thead><tr><th>Session name</th><th>Runtime</th><th>Models</th><th>Tokens in</th><th>Tokens out</th><th>Cached-read</th><th>Net total</th><th>Compactions</th><th>MCPs active</th><th>MCPs observed</th><th>Started</th><th>Finished</th></tr></thead>
+    <thead><tr><th>Date</th><th>Sessions</th><th>Net tokens</th><th>Raw tokens</th><th>Cost</th></tr></thead>
+    <tbody>
+{daily_body}
+    </tbody>
+  </table>
+  <h2>Sessions</h2>
+  <table>
+    <thead><tr><th>Session name</th><th>Runtime</th><th>Models</th><th>Tokens in</th><th>Tokens out</th><th>Cached-read</th><th>Net tokens</th><th>Raw tokens</th><th>Cost</th><th>Compactions</th><th>MCPs configured</th><th>MCPs observed</th><th>Started</th><th>Finished</th></tr></thead>
     <tbody>
 {body}
     </tbody>
@@ -128,11 +176,13 @@ def _html_row(row: Any) -> str:
         f"<td>{html.escape(row.session_name)}</td>"
         f"<td>{html.escape(row.runtime)}</td>"
         f"<td>{html.escape(', '.join(row.models_used))}</td>"
-        f"<td>{_format_int(row.tokens_input)}</td>"
-        f"<td>{_format_int(row.tokens_output)}</td>"
-        f"<td>{_format_int(row.tokens_cache_read)}</td>"
-        f"<td>{_format_int(row.net_tokens_total)}</td>"
-        f"<td>{row.compaction_count}</td>"
+        f"<td class=\"num\">{_format_int(row.tokens_input)}</td>"
+        f"<td class=\"num\">{_format_int(row.tokens_output)}</td>"
+        f"<td class=\"num\">{_format_int(row.tokens_cache_read)}</td>"
+        f"<td class=\"num\">{_format_int(row.net_tokens_total)}</td>"
+        f"<td class=\"num\">{_format_int(row.raw_tokens_total)}</td>"
+        f"<td class=\"num\">${row.cost_usd:.6f}</td>"
+        f"<td class=\"num\">{row.compaction_count}</td>"
         f"<td>{html.escape(', '.join(row.mcps_active) or 'none configured')}</td>"
         f"<td>{html.escape(', '.join(row.mcps_observed) or 'none observed')}</td>"
         f"<td>{html.escape(row.started_at)}</td>"
@@ -141,12 +191,26 @@ def _html_row(row: Any) -> str:
     )
 
 
-def write_json(reports: list[Any], output_dir: Path, generated_at: str) -> Path:
+def _daily_html_row(row: Any) -> str:
+    return (
+        "<tr>"
+        f"<td>{html.escape(row.date)}</td>"
+        f"<td class=\"num\">{row.session_count}</td>"
+        f"<td class=\"num\">{_format_int(row.net_tokens_total)}</td>"
+        f"<td class=\"num\">{_format_int(row.raw_tokens_total)}</td>"
+        f"<td class=\"num\">${row.cost_usd:.6f}</td>"
+        "</tr>"
+    )
+
+
+def write_json(reports: list[Any], daily_usage: list[Any], output_dir: Path, generated_at: str) -> Path:
     report_path = output_dir / "report.json"
     payload = {
         "generated_at": generated_at,
         "session_count": len(reports),
+        "raw_tokens_total": sum(row.raw_tokens_total for row in reports),
         "net_tokens_total": sum(row.net_tokens_total for row in reports),
+        "daily_usage": [as_dict(row) for row in daily_usage],
         "sessions": [as_dict(row) for row in reports],
     }
     report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -130,7 +130,7 @@ test_report_aggregates_compacted_sessions() {
 		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_ROOT="${TEST_ROOT}/reports" \
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
-		"$HELPER_SH" report --limit 5 --json)
+		"$HELPER_SH" report --limit 5 --daily-days 2000 --json)
 	local _json_path
 	_json_path=$(python3 - <<PY
 import json
@@ -142,9 +142,12 @@ PY
 	assert_json_field "$_json_path" "sessions[0].tokens_input" "150" "Report sums input tokens"
 	assert_json_field "$_json_path" "sessions[0].tokens_output" "30" "Report sums output tokens"
 	assert_json_field "$_json_path" "sessions[0].tokens_cache_read" "35" "Report sums cached-read tokens"
-	assert_json_field "$_json_path" "sessions[0].net_tokens_total" "227" "Report computes net total"
+	assert_json_field "$_json_path" "sessions[0].raw_tokens_total" "227" "Report computes raw total"
+	assert_json_field "$_json_path" "sessions[0].net_tokens_total" "192" "Report computes net total excluding cache reads"
 	assert_json_field "$_json_path" "sessions[0].compaction_count" "1" "Report counts child compaction"
 	assert_json_field "$_json_path" "sessions[0].mcps_observed[0]" "context7" "Report infers observed MCP"
+	assert_json_field "$_json_path" "daily_usage[0].date" "2023-11-14" "Report includes daily usage date"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "192" "Report sums daily net tokens"
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- Change token-use report net totals to exclude cache-read tokens, while preserving raw totals that include cache reads.
- Rename report-facing MCP wording from active to configured and keep observed MCPs as the actual-use signal.
- Add a daily usage summary for the last 90 days by default, with `--daily-days N` / `--daily-days 0` controls.

For #24221

## Verification
- `python3 -m py_compile .agents/scripts/report-token-use-helper.py .agents/scripts/report_token_use_render.py`
- `.agents/scripts/tests/test-report-token-use-helper.sh` (10 tests passed)
- `bash -n .agents/scripts/report-token-use-helper.sh .agents/scripts/tests/test-report-token-use-helper.sh`
- `shellcheck .agents/scripts/report-token-use-helper.sh .agents/scripts/tests/test-report-token-use-helper.sh`
- `.agents/scripts/report-token-use-helper.sh report --limit 2 --daily-days 90 --json`
- `.agents/scripts/report-token-use-helper.sh data --limit 2 --daily-days 90 --json`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.2 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 3h 4m and 1,845,531 tokens on this with the user in an interactive session.