### PR TITLE
GH#24231: harden Playwright list matching

### DIFF
--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -162,12 +162,12 @@ _classify_stale_playwright_list() {
 		return 1
 	fi
 
-	if [[ "$cmd_full" != *"playwright test --list"* ]]; then
+	if [[ ! "$cmd_full" =~ playwright[[:space:]]+test[[:space:]]+--list ]]; then
 		printf '%s' "SAFE not playwright test --list"
 		return 1
 	fi
 
-	if [[ "$cmd_full" != *" --grep "* ]]; then
+	if [[ ! "$cmd_full" =~ --grep([[:space:]]+|=) ]]; then
 		printf '%s' "SAFE missing grep selector"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-process-guard-playwright-list.sh
+++ b/.agents/scripts/tests/test-process-guard-playwright-list.sh
@@ -51,6 +51,20 @@ test_matches_stale_aidevops_playwright_list() {
 	return 0
 }
 
+test_matches_stale_aidevops_playwright_list_with_flexible_spacing() {
+	local output
+	if output=$(run_matcher 1200 '?' "$HOME/Git/aidevops-feature-auto-123" pnpm --filter web exec 'playwright   test   --list' --grep=@flaky --reporter=list 2>&1); then
+		if [[ "$output" == MATCH* ]]; then
+			print_result "matches stale aidevops Playwright list with flexible spacing" 0
+		else
+			print_result "matches stale aidevops Playwright list with flexible spacing" 1 "Unexpected output: $output"
+		fi
+	else
+		print_result "matches stale aidevops Playwright list with flexible spacing" 1 "Matcher rejected: $output"
+	fi
+	return 0
+}
+
 test_rejects_unrelated_playwright_list() {
 	local output
 	if output=$(run_matcher 1200 '?' "$HOME/projects/app" pnpm --filter web exec playwright test --list --grep @flaky --reporter=list 2>&1); then
@@ -95,6 +109,7 @@ test_rejects_fresh_aidevops_playwright_list() {
 
 main() {
 	test_matches_stale_aidevops_playwright_list
+	test_matches_stale_aidevops_playwright_list_with_flexible_spacing
 	test_rejects_unrelated_playwright_list
 	test_rejects_interactive_playwright_list
 	test_rejects_fresh_aidevops_playwright_list


### PR DESCRIPTION
## Summary

Replaced fragile substring checks with Bash regex checks for Playwright list commands and grep selectors; added regression coverage for flexible spacing and --grep= syntax.

## Files Changed

.agents/scripts/process-guard-helper.sh,.agents/scripts/tests/test-process-guard-playwright-list.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-process-guard-playwright-list.sh; shellcheck .agents/scripts/process-guard-helper.sh .agents/scripts/tests/test-process-guard-playwright-list.sh; .agents/scripts/linters-local.sh partial pass until Secretlint timed out at 240s after earlier gates passed

Resolves #24231


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.3 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 6m and 59,031 tokens on this as a headless worker.