### PR TITLE
fix: reuse approval lock issue json

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -395,17 +395,19 @@ _approval_verify_conversation_locked() {
 	local target_type="$1"
 	local target_number="$2"
 	local slug="$3"
-	local issue_json=""
+	local issue_json="${4:-}"
 	local label="issue"
 
 	if [[ "$target_type" == "pr" ]]; then
 		label="PR conversation"
 	fi
 
-	issue_json=$(_approval_fetch_issue_json "$target_number" "$slug") || {
-		_print_error "Approval state verification failed: could not read ${label} #$target_number via REST"
-		return 1
-	}
+	if [[ -z "$issue_json" ]]; then
+		issue_json=$(_approval_fetch_issue_json "$target_number" "$slug") || {
+			_print_error "Approval state verification failed: could not read ${label} #$target_number via REST"
+			return 1
+		}
+	fi
 
 	if ! printf '%s' "$issue_json" | jq -e '.locked == true' >/dev/null 2>&1; then
 		_print_error "Approval state verification failed: ${label} #$target_number is not locked"

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -182,6 +182,17 @@ run_case "PR approval locks conversation with gh pr lock" '
 assert_contains "PR approval reports real conversation lock" "$LAST_OUTPUT" "PR #456 approval recorded and conversation locked"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "conversation lock verification reuses provided issue JSON" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	gh() {
+		return 1
+	}
+	_approval_verify_conversation_locked pr 456 marcusquinn/aidevops "{\"locked\":true}"
+' 0
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "PR approval REST fallback locks conversation" '
 	set -uo pipefail
 	# shellcheck disable=SC1090


### PR DESCRIPTION
## Summary
- Refactor `_approval_verify_conversation_locked` to accept optional precomputed issue JSON.
- Preserve REST fallback when no issue JSON is supplied.
- Add regression coverage that provided issue JSON skips the REST fetch path.

## Testing
- `bash .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `shellcheck .agents/scripts/approval-helper.sh .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `.agents/scripts/linters-local.sh`

Resolves #24233

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.2 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 6m and 98,445 tokens on this as a headless worker.