### PR TITLE
fix: preserve separator-shaped table data rows

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -24,6 +24,7 @@ def close_blocks(body: list[str], states: dict[str, object]) -> None:
         body.append("</tbody></table>")
         states["table"] = False
         states["table_body_started"] = False
+        states["table_header_separator_consumed"] = False
 
 
 def flush_paragraph(body: list[str], states: dict[str, object]) -> None:
@@ -40,8 +41,13 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
         return False
     raw_cells = [cell.strip() for cell in split_markdown_table_row(stripped)]
     is_separator_row = all(re.match(r"^:?-{3,}:?$", html.unescape(cell)) for cell in raw_cells)
-    if is_separator_row and states.get("table") and not states.get("table_body_started"):
-        states["table_body_started"] = True
+    if (
+        is_separator_row
+        and states.get("table")
+        and not states.get("table_body_started")
+        and not states.get("table_header_separator_consumed")
+    ):
+        states["table_header_separator_consumed"] = True
         return True
     cells = [inline_markup(cell) for cell in raw_cells]
     if not states["table"]:
@@ -49,6 +55,7 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
         body.append("<table><thead>")
         states["table"] = True
         states["table_body_started"] = False
+        states["table_header_separator_consumed"] = False
         body.append("<tr>{}</tr></thead><tbody>".format("".join(f"<th>{cell}</th>" for cell in cells)))
         return True
     body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -61,10 +61,30 @@ def test_handle_table_skips_only_header_separator_row() -> None:
     )
 
 
+def test_handle_table_keeps_separator_shaped_first_body_row() -> None:
+    body: list[str] = []
+    states: dict[str, object] = {"table": False, "paragraph": [], "list": False, "list_tag": ""}
+
+    assert handle_table("| Left | Right |", body, states)
+    assert handle_table("| --- | --- |", body, states)
+    assert handle_table("| --- | --- |", body, states)
+
+    assert_equal(
+        body,
+        [
+            "<table><thead>",
+            "<tr><th>Left</th><th>Right</th></tr></thead><tbody>",
+            "<tr><td>---</td><td>---</td></tr>",
+        ],
+        "the first body row is emitted even when it looks like a Markdown separator",
+    )
+
+
 def main() -> int:
     test_split_markdown_table_row_unescapes_backslash_pairs()
     test_split_markdown_table_row_keeps_escaped_pipes_in_cell()
     test_handle_table_skips_only_header_separator_row()
+    test_handle_table_keeps_separator_shaped_first_body_row()
     print("report_render_blocks tests passed")
     return 0
 


### PR DESCRIPTION
Resolves #24236

## Summary
- Separate header separator consumption from table body tracking in `.agents/scripts/report_render_blocks.py`.
- Add a regression test that preserves a separator-shaped first table body row.

## Testing
- `python3 tests/test_report_render_blocks.py`
- `python3 -m py_compile .agents/scripts/report_render_blocks.py tests/test_report_render_blocks.py`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.3 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 6m and 72,054 tokens on this as a headless worker.
