### PR TITLE
Add token-use split by session type

### DIFF
--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 from pathlib import Path
 from typing import Any
 
-from report_token_use_render import as_dict, write_html, write_json, write_markdown
+from report_token_use_render import as_dict, session_kind_summary, write_html, write_json, write_markdown
 
 
 DEFAULT_OPENCODE_DB = Path.home() / ".local/share/opencode/opencode.db"
@@ -53,6 +53,7 @@ class SessionReport:
     session_id: str
     session_name: str
     runtime: str
+    session_kind: str
     models_used: list[str]
     tokens_input: int
     tokens_output: int
@@ -348,6 +349,14 @@ def _tokens_for_group(group: list[SessionRow]) -> dict[str, int]:
     return tokens
 
 
+def _session_kind_for_group(group: list[SessionRow]) -> str:
+    for row in group:
+        location = f"{row.directory} {row.path}"
+        if "/private/tmp/opencode" in location or "/tmp/opencode" in location:
+            return "headless_worker"
+    return "interactive"
+
+
 def _models_for_group(
     conn: sqlite3.Connection,
     group: list[SessionRow],
@@ -375,6 +384,7 @@ def _opencode_report_from_group(
         session_id=root_id,
         session_name=_safe_title(root.title),
         runtime="opencode",
+        session_kind=_session_kind_for_group(group),
         models_used=_models_for_group(conn, group, session_ids, obs),
         tokens_input=tokens["input"],
         tokens_output=tokens["output"],
@@ -490,6 +500,7 @@ def _claude_report_from_group(session_id: str, data: dict[str, Any]) -> SessionR
         session_id=session_id,
         session_name=session_id,
         runtime="claude",
+        session_kind="interactive",
         models_used=sorted(data["models"]) or ["unknown"],
         tokens_input=data["input"],
         tokens_output=data["output"],
@@ -572,7 +583,11 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
 
 def cmd_data(args: argparse.Namespace) -> int:
     reports = _collect_reports(args)
-    payload = {"daily_usage": [as_dict(row) for row in _collect_daily_usage(args)], "sessions": [as_dict(row) for row in reports]}
+    payload = {
+        "daily_usage": [as_dict(row) for row in _collect_daily_usage(args)],
+        "usage_by_session_kind": session_kind_summary(reports),
+        "sessions": [as_dict(row) for row in reports],
+    }
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -81,6 +81,14 @@ class DailyUsage:
     raw_tokens_total: int
     net_tokens_total: int
     cost_usd: float
+    interactive_session_count: int = 0
+    interactive_raw_tokens_total: int = 0
+    interactive_net_tokens_total: int = 0
+    interactive_cost_usd: float = 0.0
+    headless_worker_session_count: int = 0
+    headless_worker_raw_tokens_total: int = 0
+    headless_worker_net_tokens_total: int = 0
+    headless_worker_cost_usd: float = 0.0
 
 
 def _make_session_report(**values: Any) -> SessionReport:
@@ -535,11 +543,35 @@ def _daily_usage(reports: list[SessionReport]) -> list[DailyUsage]:
     grouped: dict[str, dict[str, Any]] = {}
     for report in reports:
         date = (report.finished_at or report.started_at or "unknown")[:10]
-        data = grouped.setdefault(date, {"sessions": 0, "raw": 0, "net": 0, "cost": 0.0})
+        data = grouped.setdefault(
+            date,
+            {
+                "sessions": 0,
+                "raw": 0,
+                "net": 0,
+                "cost": 0.0,
+                "interactive_sessions": 0,
+                "interactive_raw": 0,
+                "interactive_net": 0,
+                "interactive_cost": 0.0,
+                "headless_worker_sessions": 0,
+                "headless_worker_raw": 0,
+                "headless_worker_net": 0,
+                "headless_worker_cost": 0.0,
+            },
+        )
         data["sessions"] += 1
         data["raw"] += report.raw_tokens_total
         data["net"] += report.net_tokens_total
         data["cost"] += report.cost_usd
+        if report.session_kind == "headless_worker":
+            prefix = "headless_worker"
+        else:
+            prefix = "interactive"
+        data[f"{prefix}_sessions"] += 1
+        data[f"{prefix}_raw"] += report.raw_tokens_total
+        data[f"{prefix}_net"] += report.net_tokens_total
+        data[f"{prefix}_cost"] += report.cost_usd
     return [
         DailyUsage(
             date=date,
@@ -547,6 +579,14 @@ def _daily_usage(reports: list[SessionReport]) -> list[DailyUsage]:
             raw_tokens_total=data["raw"],
             net_tokens_total=data["net"],
             cost_usd=round(data["cost"], 6),
+            interactive_session_count=data["interactive_sessions"],
+            interactive_raw_tokens_total=data["interactive_raw"],
+            interactive_net_tokens_total=data["interactive_net"],
+            interactive_cost_usd=round(data["interactive_cost"], 6),
+            headless_worker_session_count=data["headless_worker_sessions"],
+            headless_worker_raw_tokens_total=data["headless_worker_raw"],
+            headless_worker_net_tokens_total=data["headless_worker_net"],
+            headless_worker_cost_usd=round(data["headless_worker_cost"], 6),
         )
         for date, data in sorted(grouped.items(), reverse=True)
     ]

--- a/.agents/scripts/report_token_use_render.py
+++ b/.agents/scripts/report_token_use_render.py
@@ -24,6 +24,7 @@ def as_dict(report: Any) -> dict[str, Any]:
         "session_id": report.session_id,
         "session_name": report.session_name,
         "runtime": report.runtime,
+        "session_kind": report.session_kind,
         "models_used": report.models_used,
         "tokens_input": report.tokens_input,
         "tokens_output": report.tokens_output,
@@ -50,6 +51,39 @@ def _format_int(value: int) -> str:
     return f"{value:,}"
 
 
+def _session_kind_label(value: str) -> str:
+    labels = {"interactive": "Interactive", "headless_worker": "Headless worker"}
+    return labels.get(value, value.replace("_", " ").title() or "Unknown")
+
+
+def session_kind_summary(reports: list[Any]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for row in reports:
+        kind = row.session_kind
+        data = grouped.setdefault(
+            kind,
+            {
+                "session_kind": kind,
+                "label": _session_kind_label(kind),
+                "session_count": 0,
+                "raw_tokens_total": 0,
+                "net_tokens_total": 0,
+                "cost_usd": 0.0,
+            },
+        )
+        data["session_count"] += 1
+        data["raw_tokens_total"] += row.raw_tokens_total
+        data["net_tokens_total"] += row.net_tokens_total
+        data["cost_usd"] += row.cost_usd
+    rows = sorted(
+        grouped.values(),
+        key=lambda item: (item["session_kind"] != "interactive", item["session_kind"]),
+    )
+    for row in rows:
+        row["cost_usd"] = round(row["cost_usd"], 6)
+    return rows
+
+
 def write_markdown(reports: list[Any], daily_usage: list[Any], output_dir: Path, generated_at: str) -> Path:
     report_path = output_dir / "report.md"
     net_total = sum(row.net_tokens_total for row in reports)
@@ -62,6 +96,7 @@ def write_markdown(reports: list[Any], daily_usage: list[Any], output_dir: Path,
         f"Net tokens (excludes cache reads): {_format_int(net_total)}",
         f"Raw tokens (includes cache reads): {_format_int(raw_total)}",
     ]
+    lines.extend(_session_kind_markdown(session_kind_summary(reports)))
     if daily_usage:
         lines.extend(_daily_markdown(daily_usage))
     lines.extend(
@@ -69,8 +104,8 @@ def write_markdown(reports: list[Any], daily_usage: list[Any], output_dir: Path,
             "",
             "## Sessions",
             "",
-            "| Session name | Runtime | Models | Tokens in | Tokens out | Cached-read | Raw tokens | Net tokens | Cost | Compactions | MCPs configured | MCPs observed | Started | Finished |",
-            "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|",
+            "| Session name | Runtime | Type | Models | Tokens in | Tokens out | Cached-read | Raw tokens | Net tokens | Cost | Compactions | MCPs configured | MCPs observed | Started | Finished |",
+            "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|",
         ]
     )
     for row in reports:
@@ -82,12 +117,28 @@ def write_markdown(reports: list[Any], daily_usage: list[Any], output_dir: Path,
             "",
             "- Net tokens are input + output + reasoning + cache-write tokens, excluding cache reads so the main total tracks paid/metered work more closely.",
             "- Raw tokens include cache reads for context volume analysis. Provider-specific cached-read billing discounts are best represented by the Cost column when available.",
+            "- Session type is inferred from runtime metadata. OpenCode sessions under the runtime temporary work directory are reported as headless worker sessions; other local sessions are reported as interactive.",
             "- OpenCode rows recursively include child sessions via `session.parent_id` so compacted sessions are counted with their root session.",
             "- MCPs configured lists configured OpenCode MCP server names at report time. MCPs observed are inferred from session tool-call names when available and are the better proxy for actual use.",
         ]
     )
     report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return report_path
+
+
+def _session_kind_markdown(summary: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "",
+        "## Session type summary",
+        "",
+        "| Type | Sessions | Raw tokens | Net tokens | Cost |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in summary:
+        lines.append(
+            f"| {row['label']} | {row['session_count']} | {_format_int(row['raw_tokens_total'])} | {_format_int(row['net_tokens_total'])} | ${row['cost_usd']:.6f} |"
+        )
+    return lines
 
 
 def _daily_markdown(daily_usage: list[Any]) -> list[str]:
@@ -109,6 +160,7 @@ def _markdown_row(row: Any) -> str:
     cells = [
         row.session_name.replace("|", "\\|"),
         row.runtime,
+        _session_kind_label(row.session_kind),
         ", ".join(row.models_used).replace("|", "\\|"),
         _format_int(row.tokens_input),
         _format_int(row.tokens_output),
@@ -129,6 +181,7 @@ def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
     report_path = output_dir / "report.html"
     body = "\n".join(_html_row(row) for row in reports)
     daily_body = "\n".join(_daily_html_row(row) for row in daily_usage)
+    kind_body = "\n".join(_session_kind_html_row(row) for row in session_kind_summary(reports))
     net_total = _format_int(sum(row.net_tokens_total for row in reports))
     raw_total = _format_int(sum(row.raw_tokens_total for row in reports))
     html_doc = f"""<!doctype html>
@@ -140,7 +193,7 @@ def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
   <style>
     body {{ color: #172033; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; }}
     table {{ border-collapse: collapse; margin-bottom: 2rem; table-layout: fixed; width: 100%; }}
-    table.daily {{ max-width: 64rem; }}
+    table.daily, table.summary {{ max-width: 64rem; }}
     th, td {{ border-bottom: 1px solid #d8dee9; padding: .55rem; text-align: left; vertical-align: top; }}
     th.num, td.num {{ text-align: right; }}
     th {{ background: #f5f7fb; position: sticky; top: 0; }}
@@ -150,6 +203,14 @@ def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
 <body>
   <h1>Token Use Report</h1>
   <p class=\"meta\">Generated: {html.escape(generated_at)} · Sessions: {len(reports)} · Net tokens: {net_total} · Raw tokens: {raw_total}</p>
+  <h2>Session type summary</h2>
+  <table class="summary">
+    <colgroup><col style="width: 12rem"><col style="width: 7rem"><col style="width: 12rem"><col style="width: 12rem"><col style="width: 9rem"></colgroup>
+    <thead><tr><th>Type</th><th class="num">Sessions</th><th class="num">Raw tokens</th><th class="num">Net tokens</th><th class="num">Cost</th></tr></thead>
+    <tbody>
+{kind_body}
+    </tbody>
+  </table>
   <h2>Daily usage</h2>
   <table class="daily">
     <colgroup><col style="width: 9rem"><col style="width: 7rem"><col style="width: 12rem"><col style="width: 12rem"><col style="width: 9rem"></colgroup>
@@ -160,7 +221,7 @@ def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
   </table>
   <h2>Sessions</h2>
   <table>
-    <thead><tr><th>Session name</th><th>Runtime</th><th>Models</th><th class="num">Tokens in</th><th class="num">Tokens out</th><th class="num">Cached-read</th><th class="num">Raw tokens</th><th class="num">Net tokens</th><th class="num">Cost</th><th class="num">Compactions</th><th>MCPs configured</th><th>MCPs observed</th><th>Started</th><th>Finished</th></tr></thead>
+    <thead><tr><th>Session name</th><th>Runtime</th><th>Type</th><th>Models</th><th class="num">Tokens in</th><th class="num">Tokens out</th><th class="num">Cached-read</th><th class="num">Raw tokens</th><th class="num">Net tokens</th><th class="num">Cost</th><th class="num">Compactions</th><th>MCPs configured</th><th>MCPs observed</th><th>Started</th><th>Finished</th></tr></thead>
     <tbody>
 {body}
     </tbody>
@@ -177,6 +238,7 @@ def _html_row(row: Any) -> str:
         "<tr>"
         f"<td>{html.escape(row.session_name)}</td>"
         f"<td>{html.escape(row.runtime)}</td>"
+        f"<td>{html.escape(_session_kind_label(row.session_kind))}</td>"
         f"<td>{html.escape(', '.join(row.models_used))}</td>"
         f"<td class=\"num\">{_format_int(row.tokens_input)}</td>"
         f"<td class=\"num\">{_format_int(row.tokens_output)}</td>"
@@ -189,6 +251,18 @@ def _html_row(row: Any) -> str:
         f"<td>{html.escape(', '.join(row.mcps_observed) or 'none observed')}</td>"
         f"<td>{html.escape(row.started_at)}</td>"
         f"<td>{html.escape(row.finished_at)}</td>"
+        "</tr>"
+    )
+
+
+def _session_kind_html_row(row: dict[str, Any]) -> str:
+    return (
+        "<tr>"
+        f"<td>{html.escape(row['label'])}</td>"
+        f"<td class=\"num\">{row['session_count']}</td>"
+        f"<td class=\"num\">{_format_int(row['raw_tokens_total'])}</td>"
+        f"<td class=\"num\">{_format_int(row['net_tokens_total'])}</td>"
+        f"<td class=\"num\">${row['cost_usd']:.6f}</td>"
         "</tr>"
     )
 
@@ -212,6 +286,7 @@ def write_json(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
         "session_count": len(reports),
         "raw_tokens_total": sum(row.raw_tokens_total for row in reports),
         "net_tokens_total": sum(row.net_tokens_total for row in reports),
+        "usage_by_session_kind": session_kind_summary(reports),
         "daily_usage": [as_dict(row) for row in daily_usage],
         "sessions": [as_dict(row) for row in reports],
     }

--- a/.agents/scripts/report_token_use_render.py
+++ b/.agents/scripts/report_token_use_render.py
@@ -19,6 +19,14 @@ def as_dict(report: Any) -> dict[str, Any]:
             "raw_tokens_total": report.raw_tokens_total,
             "net_tokens_total": report.net_tokens_total,
             "cost_usd": report.cost_usd,
+            "interactive_session_count": report.interactive_session_count,
+            "interactive_raw_tokens_total": report.interactive_raw_tokens_total,
+            "interactive_net_tokens_total": report.interactive_net_tokens_total,
+            "interactive_cost_usd": report.interactive_cost_usd,
+            "headless_worker_session_count": report.headless_worker_session_count,
+            "headless_worker_raw_tokens_total": report.headless_worker_raw_tokens_total,
+            "headless_worker_net_tokens_total": report.headless_worker_net_tokens_total,
+            "headless_worker_cost_usd": report.headless_worker_cost_usd,
         }
     return {
         "session_id": report.session_id,
@@ -146,12 +154,12 @@ def _daily_markdown(daily_usage: list[Any]) -> list[str]:
         "",
         "## Daily usage",
         "",
-        "| Date | Sessions | Raw tokens | Net tokens | Cost |",
-        "|---|---:|---:|---:|---:|",
+        "| Date | Interactive sessions | Interactive net | Headless sessions | Headless net | Total sessions | Total net | Total raw | Cost |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in daily_usage:
         lines.append(
-            f"| {row.date} | {row.session_count} | {_format_int(row.raw_tokens_total)} | {_format_int(row.net_tokens_total)} | ${row.cost_usd:.6f} |"
+            f"| {row.date} | {row.interactive_session_count} | {_format_int(row.interactive_net_tokens_total)} | {row.headless_worker_session_count} | {_format_int(row.headless_worker_net_tokens_total)} | {row.session_count} | {_format_int(row.net_tokens_total)} | {_format_int(row.raw_tokens_total)} | ${row.cost_usd:.6f} |"
         )
     return lines
 
@@ -193,7 +201,8 @@ def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
   <style>
     body {{ color: #172033; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; }}
     table {{ border-collapse: collapse; margin-bottom: 2rem; table-layout: fixed; width: 100%; }}
-    table.daily, table.summary {{ max-width: 64rem; }}
+    table.summary {{ max-width: 64rem; }}
+    table.daily {{ min-width: 82rem; }}
     th, td {{ border-bottom: 1px solid #d8dee9; padding: .55rem; text-align: left; vertical-align: top; }}
     th.num, td.num {{ text-align: right; }}
     th {{ background: #f5f7fb; position: sticky; top: 0; }}
@@ -213,8 +222,8 @@ def write_html(reports: list[Any], daily_usage: list[Any], output_dir: Path, gen
   </table>
   <h2>Daily usage</h2>
   <table class="daily">
-    <colgroup><col style="width: 9rem"><col style="width: 7rem"><col style="width: 12rem"><col style="width: 12rem"><col style="width: 9rem"></colgroup>
-    <thead><tr><th>Date</th><th class="num">Sessions</th><th class="num">Raw tokens</th><th class="num">Net tokens</th><th class="num">Cost</th></tr></thead>
+    <colgroup><col style="width: 9rem"><col style="width: 8rem"><col style="width: 11rem"><col style="width: 8rem"><col style="width: 11rem"><col style="width: 8rem"><col style="width: 11rem"><col style="width: 11rem"><col style="width: 9rem"></colgroup>
+    <thead><tr><th>Date</th><th class="num">Interactive sessions</th><th class="num">Interactive net</th><th class="num">Headless sessions</th><th class="num">Headless net</th><th class="num">Total sessions</th><th class="num">Total net</th><th class="num">Total raw</th><th class="num">Cost</th></tr></thead>
     <tbody>
 {daily_body}
     </tbody>
@@ -271,9 +280,13 @@ def _daily_html_row(row: Any) -> str:
     return (
         "<tr>"
         f"<td>{html.escape(row.date)}</td>"
+        f"<td class=\"num\">{row.interactive_session_count}</td>"
+        f"<td class=\"num\">{_format_int(row.interactive_net_tokens_total)}</td>"
+        f"<td class=\"num\">{row.headless_worker_session_count}</td>"
+        f"<td class=\"num\">{_format_int(row.headless_worker_net_tokens_total)}</td>"
         f"<td class=\"num\">{row.session_count}</td>"
-        f"<td class=\"num\">{_format_int(row.raw_tokens_total)}</td>"
         f"<td class=\"num\">{_format_int(row.net_tokens_total)}</td>"
+        f"<td class=\"num\">{_format_int(row.raw_tokens_total)}</td>"
         f"<td class=\"num\">${row.cost_usd:.6f}</td>"
         "</tr>"
     )

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -47,6 +47,7 @@ teardown_test_env() {
 create_fixture_dbs() {
 	local _opencode_db="${TEST_ROOT}/opencode.db"
 	local _obs_db="${TEST_ROOT}/llm-requests.db"
+	rm -f "$_opencode_db" "$_obs_db"
 	sqlite3 "$_opencode_db" <<'SQL'
 CREATE TABLE session (
   id text PRIMARY KEY,
@@ -144,10 +145,28 @@ PY
 	assert_json_field "$_json_path" "sessions[0].tokens_cache_read" "35" "Report sums cached-read tokens"
 	assert_json_field "$_json_path" "sessions[0].raw_tokens_total" "227" "Report computes raw total"
 	assert_json_field "$_json_path" "sessions[0].net_tokens_total" "192" "Report computes net total excluding cache reads"
+	assert_json_field "$_json_path" "sessions[0].session_kind" "interactive" "Report classifies repo session as interactive"
+	assert_json_field "$_json_path" "usage_by_session_kind[0].session_kind" "interactive" "Report summarizes interactive usage"
 	assert_json_field "$_json_path" "sessions[0].compaction_count" "1" "Report counts child compaction"
 	assert_json_field "$_json_path" "sessions[0].mcps_observed[0]" "context7" "Report infers observed MCP"
 	assert_json_field "$_json_path" "daily_usage[0].date" "2023-11-14" "Report includes daily usage date"
 	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "192" "Report sums daily net tokens"
+	return 0
+}
+
+test_report_summarizes_headless_workers() {
+	create_fixture_dbs
+	sqlite3 "${TEST_ROOT}/opencode.db" <<'SQL'
+INSERT INTO session VALUES ('ses_worker', NULL, 'Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 10, 2, 1, 4, 1, 0.05, 1699999900000, 1699999950000, NULL, '/private/tmp/opencode', 'private/tmp/opencode', 'Build+');
+SQL
+	local _json_path="${TEST_ROOT}/data.json"
+	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
+		"$HELPER_SH" data --limit 5 --daily-days 0 --json >"$_json_path"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "14" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
 	return 0
 }
 
@@ -170,6 +189,7 @@ report = module._make_session_report(
     session_id="session-default",
     session_name="Default Source IDs",
     runtime="opencode",
+    session_kind="interactive",
     models_used=["gpt-5.5"],
     tokens_input=1,
     tokens_output=2,
@@ -204,6 +224,7 @@ main() {
 	setup_test_env
 	trap teardown_test_env EXIT
 	test_report_aggregates_compacted_sessions
+	test_report_summarizes_headless_workers
 	test_session_report_defaults_source_ids
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -151,6 +151,8 @@ PY
 	assert_json_field "$_json_path" "sessions[0].mcps_observed[0]" "context7" "Report infers observed MCP"
 	assert_json_field "$_json_path" "daily_usage[0].date" "2023-11-14" "Report includes daily usage date"
 	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "192" "Report sums daily net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].interactive_net_tokens_total" "192" "Report sums daily interactive net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "0" "Report defaults daily headless net tokens"
 	return 0
 }
 
@@ -163,9 +165,11 @@ SQL
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
-		"$HELPER_SH" data --limit 5 --daily-days 0 --json >"$_json_path"
+		"$HELPER_SH" data --limit 5 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "14" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "14" "Report sums daily headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "206" "Report sums daily total net tokens"
 	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
 	return 0
 }


### PR DESCRIPTION
## Summary
- Add `session_kind` to token-use session rows.
- Classify OpenCode sessions under the runtime temp work directory as `headless_worker`; classify other local sessions as `interactive`.
- Add `usage_by_session_kind` to `data` and report JSON payloads.
- Render a Session type summary table in Markdown and HTML reports, plus a Type column in the session table.

For #24221

## Verification
- `python3 -m py_compile .agents/scripts/report-token-use-helper.py .agents/scripts/report_token_use_render.py`
- `.agents/scripts/tests/test-report-token-use-helper.sh` (16 tests passed)
- `bash -n .agents/scripts/report-token-use-helper.sh .agents/scripts/tests/test-report-token-use-helper.sh`
- `shellcheck .agents/scripts/report-token-use-helper.sh .agents/scripts/tests/test-report-token-use-helper.sh`
- `.agents/scripts/report-token-use-helper.sh report --limit 25 --daily-days 14 --json` plus HTML/JSON assertions for the session type summary

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.3 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 4h and 2,414,359 tokens on this with the user in an interactive session.