### PR TITLE
GH#24246: fix: simplify REST PR projection expressions

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1107,12 +1107,12 @@ _rest_pr_object_json_jq() {
 		[[ -z "$field" ]] && continue
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
-		state) projection="${projection}${projection:+,}state: (if ((.merged_at // null) != null or (.merged // false) == true) then \"MERGED\" else ((.state // \"\") | ascii_upcase) end)" ;;
-		merged) projection="${projection}${projection:+,}merged: ((.merged // false) == true or (.merged_at // null) != null)" ;;
+		state) projection="${projection}${projection:+,}state: (if (.merged_at != null or .merged == true) then \"MERGED\" else (.state // \"\" | ascii_upcase) end)" ;;
+		merged) projection="${projection}${projection:+,}merged: (.merged == true or .merged_at != null)" ;;
 		mergedAt) projection="${projection}${projection:+,}mergedAt: .merged_at" ;;
 		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
 		mergeCommit) projection="${projection}${projection:+,}mergeCommit: (if (.merge_commit_sha // \"\") != \"\" then {oid: .merge_commit_sha} else null end)" ;;
-		mergedBy) projection="${projection}${projection:+,}mergedBy: (.merged_by // null)" ;;
+		mergedBy) projection="${projection}${projection:+,}mergedBy: .merged_by" ;;
 		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable | if . == true then \"MERGEABLE\" elif . == false then \"CONFLICTING\" else (. // \"UNKNOWN\") end)" ;;
 		reviewDecision) projection="${projection}${projection:+,}reviewDecision: (.reviewDecision // \"\")" ;;
 		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;


### PR DESCRIPTION
## Summary

Simplified redundant jq defaults and parentheses in REST PR merged-field projections while preserving merged field mapping behavior.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh (48/48 passed)

Resolves #24246


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 2m and 59,393 tokens on this as a headless worker.