### PR TITLE
GH#24247: normalize token worker path detection

### DIFF
--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -359,7 +359,7 @@ def _tokens_for_group(group: list[SessionRow]) -> dict[str, int]:
 
 def _session_kind_for_group(group: list[SessionRow]) -> str:
     for row in group:
-        location = f"{row.directory} {row.path}".replace("\\", "/").lower()
+        location = f"{row.directory}/{row.path}".replace("\\", "/").lower()
         if (
             "/private/tmp/opencode" in location
             or "/tmp/opencode" in location

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -359,8 +359,12 @@ def _tokens_for_group(group: list[SessionRow]) -> dict[str, int]:
 
 def _session_kind_for_group(group: list[SessionRow]) -> str:
     for row in group:
-        location = f"{row.directory} {row.path}"
-        if "/private/tmp/opencode" in location or "/tmp/opencode" in location:
+        location = f"{row.directory} {row.path}".replace("\\", "/").lower()
+        if (
+            "/private/tmp/opencode" in location
+            or "/tmp/opencode" in location
+            or "/temp/opencode" in location
+        ):
             return "headless_worker"
     return "interactive"
 

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -161,6 +161,7 @@ test_report_summarizes_headless_workers() {
 	sqlite3 "${TEST_ROOT}/opencode.db" <<'SQL'
 INSERT INTO session VALUES ('ses_worker', NULL, 'Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 10, 2, 1, 4, 1, 0.05, 1699999900000, 1699999950000, NULL, '/private/tmp/opencode', 'private/tmp/opencode', 'Build+');
 INSERT INTO session VALUES ('ses_windows_worker', NULL, 'Windows Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 6, 2, 0, 3, 1, 0.03, 1699999800000, 1699999850000, NULL, 'C:\Users\Example\AppData\Local\Temp\OpenCode', 'C:\Users\Example\AppData\Local\Temp\OpenCode\session.json', 'Build+');
+INSERT INTO session VALUES ('ses_split_windows_worker', NULL, 'Split Windows Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 3, 1, 0, 1, 1, 0.01, 1699999700000, 1699999750000, NULL, 'C:\Users\Example\AppData\Local\Temp', 'OpenCode\session.json', 'Build+');
 SQL
 	local _json_path="${TEST_ROOT}/data.json"
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
@@ -168,11 +169,12 @@ SQL
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
 		"$HELPER_SH" data --limit 5 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
-	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "23" "Report sums headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "23" "Report sums daily headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "215" "Report sums daily total net tokens"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "28" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "28" "Report sums daily headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "220" "Report sums daily total net tokens"
 	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[2].session_kind" "headless_worker" "Report classifies Windows temp workdir session as headless worker"
+	assert_json_field "$_json_path" "sessions[3].session_kind" "headless_worker" "Report classifies split Windows temp workdir session as headless worker"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -160,6 +160,7 @@ test_report_summarizes_headless_workers() {
 	create_fixture_dbs
 	sqlite3 "${TEST_ROOT}/opencode.db" <<'SQL'
 INSERT INTO session VALUES ('ses_worker', NULL, 'Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 10, 2, 1, 4, 1, 0.05, 1699999900000, 1699999950000, NULL, '/private/tmp/opencode', 'private/tmp/opencode', 'Build+');
+INSERT INTO session VALUES ('ses_windows_worker', NULL, 'Windows Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 6, 2, 0, 3, 1, 0.03, 1699999800000, 1699999850000, NULL, 'C:\Users\Example\AppData\Local\Temp\OpenCode', 'C:\Users\Example\AppData\Local\Temp\OpenCode\session.json', 'Build+');
 SQL
 	local _json_path="${TEST_ROOT}/data.json"
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
@@ -167,10 +168,11 @@ SQL
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
 		"$HELPER_SH" data --limit 5 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
-	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "14" "Report sums headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "14" "Report sums daily headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "206" "Report sums daily total net tokens"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "23" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "23" "Report sums daily headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "215" "Report sums daily total net tokens"
 	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
+	assert_json_field "$_json_path" "sessions[2].session_kind" "headless_worker" "Report classifies Windows temp workdir session as headless worker"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Normalized OpenCode session paths before classifying headless workers and covered Windows Temp\OpenCode paths in the token-use helper tests.

## Files Changed

.agents/scripts/report-token-use-helper.py,.agents/scripts/tests/test-report-token-use-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-token-use-helper.sh; python3 -m py_compile .agents/scripts/report-token-use-helper.py

Resolves #24247


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 2m and 42,988 tokens on this as a headless worker.