### PR TITLE
GH#24249: harden Playwright grep matching

### DIFF
--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -162,12 +162,16 @@ _classify_stale_playwright_list() {
 		return 1
 	fi
 
-	if [[ ! "$cmd_full" =~ playwright[[:space:]]+test[[:space:]]+--list ]]; then
+	local playwright_regex
+	playwright_regex='playwright[[:space:]]+test[[:space:]]+--list'
+	if [[ ! "$cmd_full" =~ $playwright_regex ]]; then
 		printf '%s' "SAFE not playwright test --list"
 		return 1
 	fi
 
-	if [[ ! "$cmd_full" =~ --grep([[:space:]]+|=) ]]; then
+	local grep_regex
+	grep_regex='(^|[[:space:]])--grep([[:space:]]+|=)'
+	if [[ ! "$cmd_full" =~ $grep_regex ]]; then
 		printf '%s' "SAFE missing grep selector"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-process-guard-playwright-list.sh
+++ b/.agents/scripts/tests/test-process-guard-playwright-list.sh
@@ -107,12 +107,27 @@ test_rejects_fresh_aidevops_playwright_list() {
 	return 0
 }
 
+test_rejects_substring_grep_option() {
+	local output
+	if output=$(run_matcher 1200 '?' "$HOME/Git/aidevops-feature-auto-123" playwright test --list --no-grep @flaky 2>&1); then
+		print_result "rejects substring grep option" 1 "Unexpected match: $output"
+	else
+		if [[ "$output" == NO_MATCH*"missing grep selector"* ]]; then
+			print_result "rejects substring grep option" 0
+		else
+			print_result "rejects substring grep option" 1 "Unexpected output: $output"
+		fi
+	fi
+	return 0
+}
+
 main() {
 	test_matches_stale_aidevops_playwright_list
 	test_matches_stale_aidevops_playwright_list_with_flexible_spacing
 	test_rejects_unrelated_playwright_list
 	test_rejects_interactive_playwright_list
 	test_rejects_fresh_aidevops_playwright_list
+	test_rejects_substring_grep_option
 
 	printf '\n%s/%s tests passed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Hardened stale Playwright list classification by storing Bash regexes in variables and requiring a real --grep option boundary.

## Files Changed

.agents/scripts/process-guard-helper.sh,.agents/scripts/tests/test-process-guard-playwright-list.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-process-guard-playwright-list.sh; shellcheck .agents/scripts/process-guard-helper.sh .agents/scripts/tests/test-process-guard-playwright-list.sh

Resolves #24249


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 2m and 39,358 tokens on this as a headless worker.