### PR TITLE
GH#24253: fix: harden runner health review followups

### DIFF
--- a/.agents/scripts/pulse-runner-health-helper.sh
+++ b/.agents/scripts/pulse-runner-health-helper.sh
@@ -188,11 +188,8 @@ _rh_get_field() {
 #######################################
 _rh_read_token_file() {
 	local token_file="$1"
-	[[ -r "$token_file" ]] || {
-		printf '\n'
-		return 0
-	}
-	tr -d '[:space:]' <"$token_file" 2>/dev/null || true
+	[[ -r "$token_file" ]] || return 0
+	tr -d '[:space:]' <"$token_file" || true
 	return 0
 }
 
@@ -251,12 +248,15 @@ _rh_auto_resume() {
 	_rh_init_state || return 1
 	local now
 	now=$(_rh_now)
+	# shellcheck disable=SC2016 # $reason and $now are jq variables supplied by --arg.
 	_rh_state_apply \
-		".circuit_breaker.state = \"closed\" \
-		| .circuit_breaker.tripped_at = null \
-		| .circuit_breaker.reason = \"${reason}\" \
-		| .consecutive_zero_attempts = 0 \
-		| .window_started_at = \"${now}\"" || return 1
+		'.circuit_breaker.state = "closed"
+		| .circuit_breaker.tripped_at = null
+		| .circuit_breaker.reason = $reason
+		| .consecutive_zero_attempts = 0
+		| .window_started_at = $now' \
+		--arg reason "$reason" \
+		--arg now "$now" || return 1
 	rm -f "$RUNNER_HEALTH_ADVISORY_FILE" "$RUNNER_HEALTH_ADVISORY_STAMP" 2>/dev/null || true
 	return 0
 }
@@ -264,13 +264,15 @@ _rh_auto_resume() {
 #######################################
 # Atomic write: render JSON via jq pipeline, write to tmp, mv into place.
 # Args: $1 = jq filter (operates on existing state)
+#       remaining args = optional jq arguments (for example --arg name value)
 #######################################
 _rh_state_apply() {
 	local jq_filter="$1"
+	shift
 	_rh_init_state || return 1
 	local tmp
 	tmp="${RUNNER_HEALTH_STATE_FILE}.tmp.$$"
-	if jq "$jq_filter" <"$RUNNER_HEALTH_STATE_FILE" >"$tmp" 2>/dev/null; then
+	if jq "$@" "$jq_filter" <"$RUNNER_HEALTH_STATE_FILE" >"$tmp" 2>/dev/null; then
 		mv "$tmp" "$RUNNER_HEALTH_STATE_FILE"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-runner-health-diagnose.sh
+++ b/.agents/scripts/tests/test-runner-health-diagnose.sh
@@ -140,7 +140,9 @@ _mark_deploy_healthy() {
 	local repo_root
 	repo_root=$(cd "${AGENT_SCRIPT_DIR}/../.." && pwd) || return 1
 	tr -d '[:space:]' <"${repo_root}/VERSION" >"$RUNNER_HEALTH_DEPLOYED_VERSION_FILE"
-	git -C "$repo_root" rev-parse HEAD >"$RUNNER_HEALTH_DEPLOYED_SHA_FILE"
+	if [[ -d "${repo_root}/.git" ]]; then
+		git -C "$repo_root" rev-parse HEAD >"$RUNNER_HEALTH_DEPLOYED_SHA_FILE" 2>/dev/null || true
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Hardened runner-health auto-resume jq updates with safe --arg binding, simplified token-file reads, and guarded the diagnose test deploy SHA stamp when .git is absent.

## Files Changed

.agents/scripts/pulse-runner-health-helper.sh,.agents/scripts/tests/test-runner-health-diagnose.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-runner-health-helper.sh .agents/scripts/tests/test-runner-health-diagnose.sh; bash .agents/scripts/tests/test-runner-health-diagnose.sh

Resolves #24253


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 3m and 48,833 tokens on this as a headless worker.