### PR TITLE
GH#24152: fix: block infrastructure advisory dispatch

### DIFF
--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -177,7 +177,7 @@ get_repo_role_by_slug() {
 # The jq filter excludes only deterministic blockers:
 #   - status:blocked (explicit hold)
 #   - needs-* (waiting for maintainer action)
-#   - supervisor/persistent/routine-tracking (non-work telemetry)
+#   - supervisor/persistent/routine-tracking/infrastructure (non-work telemetry/advisories)
 #   - parent-task (decomposition tracker, never directly dispatchable; t2924)
 #   - no-auto-dispatch (explicit dispatch opt-out; t2924)
 #   - status:in-progress, status:in-review, status:claimed, status:done
@@ -234,6 +234,11 @@ list_dispatchable_issue_candidates_json() {
 			select(($labels | index("supervisor")) == null) |
 			select(($labels | index("persistent")) == null) |
 			select(($labels | index("routine-tracking")) == null) |
+			# GH#24152: infrastructure outage advisories are operational alerts, not
+			# implementation tasks. They may carry status:available after generic label
+			# normalization, but dispatching /full-loop workers would chase external
+			# billing/runner incidents with code changes.
+			select(($labels | index("infrastructure")) == null) |
 			# t2924: filter non-dispatchable management labels at candidate-build
 			# time, not dispatch time. Reduces wasted GraphQL+CPU on every pulse cycle
 			# re-evaluating issues the dispatcher would always block.

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -276,7 +276,8 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	  {"number":6,"title":"needs review","updatedAt":"2026-03-31T00:05:00Z","assignees":[],"labels":[{"name":"needs-maintainer-review"}]},
 	  {"number":7,"title":"needs docs","updatedAt":"2026-03-31T00:06:00Z","assignees":[],"labels":[{"name":"needs-docs"}]},
 	  {"number":8,"title":"supervisor telemetry","updatedAt":"2026-03-31T00:07:00Z","assignees":[],"labels":[{"name":"supervisor"}]},
-	  {"number":9,"title":"in progress but runnable","updatedAt":"2026-03-31T00:08:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-progress"}]}
+	  {"number":9,"title":"in progress but runnable","updatedAt":"2026-03-31T00:08:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-progress"}]},
+	  {"number":10,"title":"Infrastructure outage: 2 checks affected","updatedAt":"2026-03-31T00:09:00Z","assignees":[],"labels":[{"name":"infrastructure"},{"name":"source:ci-failure-miner"},{"name":"status:available"}]}
 	]'
 	GH_PR_LIST_JSON='[]'
 
@@ -286,7 +287,7 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	# t2924: status:in-progress is filtered at candidate-build time to avoid
 	# re-evaluating always-blocked candidates every pulse cycle.  Issue #9
 	# carries status:in-progress and must NOT appear in the output.
-	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* ]]; then
+	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* && "$output" != *$'10|Infrastructure outage: 2 checks affected'* ]]; then
 		print_result "list_dispatchable_issue_candidates is default-open except needs-* and active-status labels" 0
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Filtered infrastructure-labeled outage advisories out of pulse dispatch candidate enumeration so status:available normalization cannot send /full-loop workers to non-code billing/runner incidents. Added a regression fixture covering an infrastructure/source:ci-failure-miner/status:available issue.

## Files Changed

.agents/scripts/pulse-repo-meta.sh,.agents/scripts/tests/test-pulse-wrapper-worker-count.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-wrapper-worker-count.sh; shellcheck .agents/scripts/pulse-repo-meta.sh .agents/scripts/tests/test-pulse-wrapper-worker-count.sh

Resolves #24152


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 4m and 124,683 tokens on this as a headless worker.