### PR TITLE
GH#24264: surface stale dashboard refresh failures

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -335,14 +335,23 @@ update_health_issues() {
 	fi
 
 	local updated=0
+	local failed=0
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
-		_update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" || true
+		if ! _update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md"; then
+			echo "[stats] Health issue update failed for ${slug}" >>"$LOGFILE"
+			failed=$((failed + 1))
+			continue
+		fi
 		updated=$((updated + 1))
 	done <<<"$repo_entries"
 
 	if [[ "$updated" -gt 0 ]]; then
 		echo "[stats] Health issues: updated $updated repo(s)" >>"$LOGFILE"
+	fi
+	if [[ "$failed" -gt 0 ]]; then
+		echo "[stats] Health issues: failed $failed repo(s)" >>"$LOGFILE"
+		return 1
 	fi
 	return 0
 }

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -157,7 +157,7 @@ _check_health_issue_activity_guard() {
 #   $3 - cross-repo activity markdown (pre-computed by update_health_issues)
 #   $4 - cross-repo session time markdown (pre-computed by update_health_issues)
 #   $5 - cross-repo person stats markdown (pre-computed by update_health_issues)
-# Returns: 0 always (best-effort, never breaks the pulse)
+# Returns: 0 when refreshed/skipped, 1 when an existing dashboard update fails
 #######################################
 _update_health_issue_for_repo() {
 	local repo_slug="$1"
@@ -244,7 +244,7 @@ _update_health_issue_for_repo() {
 		--body "$body" 2>&1 >/dev/null) || {
 		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" \
 			>>"$LOGFILE"
-		return 0
+		return 1
 	}
 
 	# Re-extract headline counts from the rendered body to build the title.

--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -262,8 +262,11 @@ main() {
 		return 1
 	}
 
-	run_daily_quality_sweep || true
-	update_health_issues || true
+	run_daily_quality_sweep || {
+		local sweep_ec=$?
+		echo "[stats-wrapper] QUALITY-SWEEP-FAIL exit=${sweep_ec} at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
+	}
+	update_health_issues
 
 	echo "[stats-wrapper] Finished at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
 	return 0

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -103,7 +103,7 @@ test_detect_session_origin_returns_worker_when_headless() {
 # testing must not have AIDEVOPS_HEADLESS set on their behalf.
 test_export_is_inside_main_not_top_level() {
 	local count line_num
-	count=$(safe_grep_count -E '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT")
+	count=$(grep -cE '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT" || true)
 	if [[ "$count" -ne 1 ]]; then
 		print_result "export is inside main(), not top-level" 1 \
 			"Expected exactly 1 export line, found $count"
@@ -148,11 +148,37 @@ test_export_before_self_check() {
 	return 0
 }
 
+# Test 5: dashboard refresh failures must not be swallowed by the wrapper.
+# The EXIT trap only emits HEALTH-DASHBOARD-FAIL when main() returns non-zero;
+# keeping `update_health_issues || true` here would recreate the silent-stale
+# dashboard failure mode from GH#24264.
+test_dashboard_update_failure_not_swallowed() {
+	local production_snippet
+	production_snippet=$(awk '
+		/^[[:space:]]*run_daily_quality_sweep \|\| \{/ { in_production=1 }
+		in_production { print }
+		in_production && /^[[:space:]]*echo "\[stats-wrapper\] Finished/ { exit }
+	' "$WRAPPER_SCRIPT")
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*update_health_issues[[:space:]]*\|\|[[:space:]]*true'; then
+		print_result "dashboard update failures propagate to stats-wrapper trap" 1 \
+			"stats-wrapper.sh still swallows update_health_issues failures with '|| true'"
+		return 0
+	fi
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*update_health_issues[[:space:]]*$'; then
+		print_result "dashboard update failures propagate to stats-wrapper trap" 0
+		return 0
+	fi
+	print_result "dashboard update failures propagate to stats-wrapper trap" 1 \
+		"Expected a direct update_health_issues call in stats-wrapper.sh"
+	return 0
+}
+
 main_test() {
 	test_export_line_present_at_top_of_main
 	test_detect_session_origin_returns_worker_when_headless
 	test_export_is_inside_main_not_top_level
 	test_export_before_self_check
+	test_dashboard_update_failure_not_swallowed
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 WRAPPER_SCRIPT="${SCRIPT_DIR}/../stats-wrapper.sh"
 SHARED_CONSTANTS="${SCRIPT_DIR}/../shared-constants.sh"
+HEALTH_DASHBOARD_SCRIPT="${SCRIPT_DIR}/../stats-health-dashboard.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -173,12 +174,32 @@ test_dashboard_update_failure_not_swallowed() {
 	return 0
 }
 
+# Test 6: the dashboard updater itself must return non-zero when the body edit
+# fails, otherwise the wrapper's direct update_health_issues call still exits 0
+# and the HEALTH-DASHBOARD-FAIL trap never fires.
+test_dashboard_body_edit_failure_returns_nonzero() {
+	local failure_snippet
+	failure_snippet=$(awk '
+		/failed to update body for/ { in_failure=1 }
+		in_failure { print }
+		in_failure && /^[[:space:]]*}/ { exit }
+	' "$HEALTH_DASHBOARD_SCRIPT")
+	if printf '%s' "$failure_snippet" | grep -qE '^[[:space:]]*return 1[[:space:]]*$'; then
+		print_result "dashboard body edit failures return non-zero" 0
+		return 0
+	fi
+	print_result "dashboard body edit failures return non-zero" 1 \
+		"Expected _update_health_issue_for_repo body-edit failure block to return 1"
+	return 0
+}
+
 main_test() {
 	test_export_line_present_at_top_of_main
 	test_detect_session_origin_returns_worker_when_headless
 	test_export_is_inside_main_not_top_level
 	test_export_before_self_check
 	test_dashboard_update_failure_not_swallowed
+	test_dashboard_body_edit_failure_returns_nonzero
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -29,6 +29,9 @@ WRAPPER_SCRIPT="${SCRIPT_DIR}/../stats-wrapper.sh"
 SHARED_CONSTANTS="${SCRIPT_DIR}/../shared-constants.sh"
 HEALTH_DASHBOARD_SCRIPT="${SCRIPT_DIR}/../stats-health-dashboard.sh"
 
+# shellcheck source=../shared-constants.sh
+source "$SHARED_CONSTANTS"
+
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
 readonly TEST_RESET='\033[0m'
@@ -104,7 +107,7 @@ test_detect_session_origin_returns_worker_when_headless() {
 # testing must not have AIDEVOPS_HEADLESS set on their behalf.
 test_export_is_inside_main_not_top_level() {
 	local count line_num
-	count=$(grep -cE '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT" || true)
+	count=$(safe_grep_count -E '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT")
 	if [[ "$count" -ne 1 ]]; then
 		print_result "export is inside main(), not top-level" 1 \
 			"Expected exactly 1 export line, found $count"


### PR DESCRIPTION
## Summary

- Propagate health dashboard body-edit failures from `_update_health_issue_for_repo` through `update_health_issues`.
- Let `stats-wrapper.sh` surface dashboard refresh failures via the existing `HEALTH-DASHBOARD-FAIL` exit trap instead of swallowing them with `|| true`.
- Keep quality sweep best-effort but log `QUALITY-SWEEP-FAIL` separately.

## Testing

- `.agents/scripts/tests/test-stats-wrapper-headless-export.sh`
- `bash .agents/scripts/stats-wrapper.sh --self-check`
- `bash .agents/scripts/stats-wrapper.sh --dry-run`
- `shellcheck .agents/scripts/stats-wrapper.sh .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh`

## Runtime Testing

self-assessed: low-risk shell scheduler/error-propagation change with local regression, self-check, dry-run, and ShellCheck verification.

Resolves #24264

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 8m and 107,339 tokens on this as a headless worker.
