### PR TITLE
GH#24174: fix: preserve opencode migration metadata

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1055,9 +1055,12 @@ _seed_worker_db_session_context() {
 	[[ -f "$shared_db" ]] || return 0
 	mkdir -p "${isolated_dir}/opencode" 2>/dev/null || return 0
 
-	# Fresh isolated auth dirs may not have a migrated DB yet. Copy schema only
-	# from the shared DB so the targeted row copy has compatible tables without
-	# importing unrelated session/message data.
+	# Fresh isolated auth dirs may not have a migrated DB yet. Copy the schema from
+	# the shared DB so the targeted row copy has compatible tables without importing
+	# unrelated session/message data. Immediately copy OpenCode migration metadata
+	# too: a schema-only DB has tables but an empty migration ledger, which makes
+	# OpenCode/Drizzle replay CREATE TABLE migrations and fail before continuation
+	# can start.
 	if [[ ! -f "$worker_db" ]]; then
 		sqlite3 -cmd ".timeout 5000" "$shared_db" .schema 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || return 0
 	fi
@@ -1065,6 +1068,13 @@ _seed_worker_db_session_context() {
 	local shared_db_sql session_id_sql
 	shared_db_sql=$(sql_escape "$shared_db")
 	session_id_sql=$(sql_escape "$session_id")
+	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
+		.timeout 5000
+		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		INSERT OR IGNORE INTO __drizzle_migrations SELECT * FROM shared.__drizzle_migrations;
+		INSERT OR IGNORE INTO data_migration SELECT * FROM shared.data_migration;
+		DETACH DATABASE shared;
+	SQL
 	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
 		.timeout 5000
 		ATTACH DATABASE '${shared_db_sql}' AS shared;

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -982,6 +982,7 @@ test_seed_worker_db_session_context_copies_only_selected_session() {
 	local shared_db="${shared_dir}/opencode.db"
 	local worker_db="${isolated_dir}/opencode/opencode.db"
 	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
 
 	sqlite3 "$shared_db" <<'SQL'
 CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
@@ -1013,6 +1014,45 @@ SQL
 
 	print_result "seed worker DB copies only selected continuation session" 1 \
 		"sessions=$sessions messages=$messages other_sessions=$other_sessions other_messages=$other_messages projects=$projects"
+	return 0
+}
+
+test_seed_worker_db_session_context_copies_migration_metadata() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-metadata"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
+INSERT INTO __drizzle_migrations VALUES (1, 'schema-ready', 12345);
+INSERT INTO data_migration VALUES ('data-ready', 67890);
+INSERT INTO project VALUES ('project-keep', 'Keep Project');
+INSERT INTO session VALUES ('session-keep', 'project-keep', 'Keep');
+INSERT INTO message VALUES ('message-keep', 'session-keep', 'one');
+SQL
+
+	_seed_worker_db_session_context "$isolated_dir" "session-keep"
+
+	local schema_migrations data_migrations sessions messages
+	schema_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM __drizzle_migrations WHERE hash = 'schema-ready';")
+	data_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM data_migration WHERE id = 'data-ready';")
+	sessions=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM session WHERE id = 'session-keep';")
+	messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-keep';")
+
+	if [[ "$schema_migrations" == "1" && "$data_migrations" == "1" && "$sessions" == "1" && "$messages" == "1" ]]; then
+		print_result "seed worker DB copies migration metadata for continuation" 0
+		return 0
+	fi
+
+	print_result "seed worker DB copies migration metadata for continuation" 1 \
+		"schema_migrations=$schema_migrations data_migrations=$data_migrations sessions=$sessions messages=$messages"
 	return 0
 }
 
@@ -1693,6 +1733,7 @@ main() {
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
 	test_seed_worker_db_session_context_copies_only_selected_session
+	test_seed_worker_db_session_context_copies_migration_metadata
 	test_large_opencode_prompt_uses_file_attachment
 	test_large_claude_prompt_uses_stdin_file
 	test_registered_prompt_temp_cleanup_removes_dir


### PR DESCRIPTION
## Summary

Copied OpenCode migration metadata into isolated continuation DBs before seeding the persisted session, preventing schema-only databases from replaying CREATE TABLE migrations on resume.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh (64 tests, 0 failures); shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh; .agents/scripts/linters-local.sh reached timeout during existing ratchet phase after passing SonarCloud, Secretlint, shellcheckrc parity, TOON, skill frontmatter, and reporting advisory markdown debt

Resolves #24174


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 18m and 64,088 tokens on this as a headless worker.