### PR TITLE
GH#24267: fix: add infrastructure dispatch blocker

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -601,6 +601,7 @@ _has_active_claim() {
 # Outputs: one of the following signals on stdout when blocking:
 #   PARENT_TASK_BLOCKED (label=<name>)      — unconditional parent-task / meta block
 #   NO_AUTO_DISPATCH_BLOCKED (label=...)    — unconditional no-auto-dispatch block (t2832)
+#   INFRASTRUCTURE_BLOCKED (label=...)      — infrastructure / billing / runner advisory block
 #   COST_BUDGET_EXCEEDED (...)              — token spend circuit breaker
 #   GUARD_UNCERTAIN (reason=...)            — internal error, cannot determine safety
 #   <assignee info>                         — active claim by another runner
@@ -741,6 +742,30 @@ _is_assigned_check_no_auto_dispatch() {
 	local repo_slug="${3:-unknown}"
 	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
 		"no-auto-dispatch" "NO_AUTO_DISPATCH_BLOCKED" "no-auto-dispatch-check"
+}
+
+#######################################
+# is_assigned helper: check the infrastructure unconditional block.
+#
+# Infrastructure issues often describe billing, runner, hosting, or platform
+# advisories that must remain visible for human operations rather than consume
+# worker dispatch capacity. Candidate enumeration filters this label, but the
+# dispatch path also checks it to close the race where a label is added after
+# candidate build and before worker launch.
+#
+# Args:
+#   $1 = issue metadata JSON (from `gh issue view --json ...,labels`)
+#   $2 = (optional) issue number — included in GUARD_UNCERTAIN output
+#   $3 = (optional) repo slug — included in GUARD_UNCERTAIN output
+# Returns: exit 0 if infrastructure label found or jq fails (prints signal),
+#          exit 1 if label absent and jq succeeds
+#######################################
+_is_assigned_check_infrastructure() {
+	local meta_json="$1"
+	local issue_number="${2:-unknown}"
+	local repo_slug="${3:-unknown}"
+	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
+		"infrastructure" "INFRASTRUCTURE_BLOCKED" "infrastructure-check"
 }
 
 #######################################
@@ -1174,6 +1199,12 @@ is_assigned() {
 		return 0
 	fi
 
+	# Infrastructure/billing/runner advisories are dispatch-time hard blocks too;
+	# candidate filtering alone is insufficient when labels change mid-cycle.
+	if _is_assigned_check_infrastructure "$issue_meta_json" "$issue_number" "$repo_slug"; then
+		return 0
+	fi
+
 	# Maintainer-requested review hold. This is intentionally separate from
 	# needs-maintainer-review, whose trust-boundary semantics are reserved for
 	# non-maintainer content and circuit-breaker review.
@@ -1346,7 +1377,7 @@ is_assigned() {
 #
 # Unlike is_assigned() which short-circuits on the first match, this function
 # runs every unconditional structural check (parent-task, no-auto-dispatch,
-# hold-for-review)
+# infrastructure, hold-for-review)
 # and emits ALL matching signals as newline-separated tokens on stdout.
 #
 # Intentionally excludes cost-budget, hydration window, and assignee checks —
@@ -1413,14 +1444,21 @@ enumerate_blockers() {
 		_found=true
 	fi
 
-	# Check 3: hold-for-review unconditional maintainer hold.
+	# Check 3: infrastructure advisory/operator block.
+	_blocker_out=$(_is_assigned_check_infrastructure "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
+	if [[ -n "$_blocker_out" ]]; then
+		printf '%s\n' "$_blocker_out"
+		_found=true
+	fi
+
+	# Check 4: hold-for-review unconditional maintainer hold.
 	_blocker_out=$(_is_assigned_check_hold_for_review "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 4: t3197 dispatch cooldown after no_worker_process launch failure.
+	# Check 5: t3197 dispatch cooldown after no_worker_process launch failure.
 	_blocker_out=$(_is_assigned_check_dispatch_cooldown "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
@@ -1826,7 +1864,7 @@ classify_dispatch_blocker_reason() {
 			printf 'local_capacity_gate\n'
 			return 0
 			;;
-		*no-auto-dispatch* | *external*author*gate* | *nmr*gate* | *approval*required*)
+		*no-auto-dispatch* | *infrastructure* | *external*author*gate* | *nmr*gate* | *approval*required*)
 			printf 'policy_gate\n'
 			return 0
 			;;

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
@@ -114,6 +114,11 @@ if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
 	exit 0
 fi
 
+if [[ "\${1:-}" == "api" && "\${2:-}" == "rate_limit" ]]; then
+	printf '%s\n' '5000'
+	exit 0
+fi
+
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -q '/comments'; then
 	printf '%s\n' '[{"created_at":"${recent_ts}","author":"runner1","body_start":"Dispatching worker (PID 12345)"}]'
 	exit 0

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
@@ -6,6 +6,7 @@
 # Verifies that enumerate_blockers() in dispatch-dedup-helper.sh:
 #   - Reports ALL structural label blockers, not just the first
 #   - Emits newline-separated tokens for each matched signal
+#   - Blocks infrastructure labels even when they appear at dispatch time
 #   - Returns exit 0 when at least one blocker is found, exit 1 when none
 #   - Is backward-compatible with the is-assigned API (that contract unchanged)
 #
@@ -220,11 +221,33 @@ test_hold_for_review_only() {
 }
 
 # -------------------------------------------------------------------
-# Test: parent-task, no-auto-dispatch, hold-for-review → all signals emitted
+# Test: only infrastructure → exit 0, INFRASTRUCTURE_BLOCKED emitted
+# -------------------------------------------------------------------
+test_infrastructure_only() {
+	create_gh_stub "infrastructure,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "infrastructure only → exit 0 (blocked)" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -q 'INFRASTRUCTURE_BLOCKED'; then
+		print_result "infrastructure only → emits INFRASTRUCTURE_BLOCKED" 0
+	else
+		print_result "infrastructure only → emits INFRASTRUCTURE_BLOCKED" 1 "Signal not in output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: parent-task, no-auto-dispatch, infrastructure, hold-for-review → all signals emitted
 # This is the core multi-blocker regression guard (t2894).
 # -------------------------------------------------------------------
 test_multi_blocker_both_signals_emitted() {
-	create_gh_stub "parent-task,no-auto-dispatch,hold-for-review,tier:standard"
+	create_gh_stub "parent-task,no-auto-dispatch,infrastructure,hold-for-review,tier:standard"
 
 	local output exit_code=0
 	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
@@ -235,32 +258,35 @@ test_multi_blocker_both_signals_emitted() {
 		return 0
 	fi
 
-	local parent_found=false nad_found=false hfr_found=false
+	local parent_found=false nad_found=false infra_found=false hfr_found=false
 	if printf '%s\n' "$output" | grep -q 'PARENT_TASK_BLOCKED'; then
 		parent_found=true
 	fi
 	if printf '%s\n' "$output" | grep -q 'NO_AUTO_DISPATCH_BLOCKED'; then
 		nad_found=true
 	fi
+	if printf '%s\n' "$output" | grep -q 'INFRASTRUCTURE_BLOCKED'; then
+		infra_found=true
+	fi
 	if printf '%s\n' "$output" | grep -q 'HOLD_FOR_REVIEW_BLOCKED'; then
 		hfr_found=true
 	fi
 
-	if [[ "$parent_found" == "true" && "$nad_found" == "true" && "$hfr_found" == "true" ]]; then
-		print_result "multi-blocker: parent/no-auto/hold signals emitted" 0
+	if [[ "$parent_found" == "true" && "$nad_found" == "true" && "$infra_found" == "true" && "$hfr_found" == "true" ]]; then
+		print_result "multi-blocker: parent/no-auto/infrastructure/hold signals emitted" 0
 	else
-		print_result "multi-blocker: parent/no-auto/hold signals emitted" 1 \
-			"Missing signals — parent_found=${parent_found} nad_found=${nad_found} hfr_found=${hfr_found}; output: '${output}'"
+		print_result "multi-blocker: parent/no-auto/infrastructure/hold signals emitted" 1 \
+			"Missing signals — parent_found=${parent_found} nad_found=${nad_found} infra_found=${infra_found} hfr_found=${hfr_found}; output: '${output}'"
 	fi
 
-	# Count lines — must be exactly 3
+	# Count lines — must be exactly 4
 	local line_count
 	line_count=$(printf '%s\n' "$output" | grep -c '.' 2>/dev/null || true)
-	if [[ "$line_count" -eq 3 ]]; then
-		print_result "multi-blocker: exactly 3 lines emitted (one per signal)" 0
+	if [[ "$line_count" -eq 4 ]]; then
+		print_result "multi-blocker: exactly 4 lines emitted (one per signal)" 0
 	else
-		print_result "multi-blocker: exactly 3 lines emitted (one per signal)" 1 \
-			"Expected 3 lines, got ${line_count}; output: '${output}'"
+		print_result "multi-blocker: exactly 4 lines emitted (one per signal)" 1 \
+			"Expected 4 lines, got ${line_count}; output: '${output}'"
 	fi
 	return 0
 }
@@ -351,6 +377,7 @@ main() {
 	test_parent_task_only
 	test_no_auto_dispatch_only
 	test_hold_for_review_only
+	test_infrastructure_only
 	test_multi_blocker_both_signals_emitted
 	test_api_failure_emits_guard_uncertain
 	test_meta_label_caught


### PR DESCRIPTION
## Summary

Added infrastructure as a dispatch-time structural blocker in dispatch-dedup-helper.sh, including enumerate-blockers coverage and policy-gate classification. Extended the enumerate-blockers regression test to cover infrastructure labels and stabilized its gh rate_limit stub for wrapper fallback checks.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh; shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh

Resolves #24267


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 3m and 85,977 tokens on this as a headless worker.