### PR TITLE
GH#24268: fix: preserve report heading anchor state

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -40,7 +40,11 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return False
     raw_cells = [cell.strip() for cell in split_markdown_table_row(stripped)]
-    is_separator_row = all(re.match(r"^:?-+:?$", html.unescape(cell)) for cell in raw_cells)
+    separator_cells = [html.unescape(cell) for cell in raw_cells]
+    is_separator_row = all(re.match(r"^:?-+:?$", cell) for cell in separator_cells) and (
+        all(len(cell.strip(":")) >= 3 for cell in separator_cells)
+        or any(cell.startswith(":") or cell.endswith(":") for cell in separator_cells)
+    )
     if (
         is_separator_row
         and states.get("table")

--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -40,7 +40,7 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return False
     raw_cells = [cell.strip() for cell in split_markdown_table_row(stripped)]
-    is_separator_row = all(re.match(r"^:?-{3,}:?$", html.unescape(cell)) for cell in raw_cells)
+    is_separator_row = all(re.match(r"^:?-+:?$", html.unescape(cell)) for cell in raw_cells)
     if (
         is_separator_row
         and states.get("table")

--- a/.agents/scripts/report_render_headings.py
+++ b/.agents/scripts/report_render_headings.py
@@ -48,7 +48,12 @@ def unique_heading_anchor(base_anchor: str, states: dict[str, object]) -> str:
         states["anchor_counts"] = anchor_counts
     used_anchors = states.setdefault("used_anchors", set())
     if not isinstance(used_anchors, set):
-        used_anchors = set()
+        try:
+            if isinstance(used_anchors, (str, bytes)):
+                raise TypeError
+            used_anchors = set(used_anchors)
+        except TypeError:
+            used_anchors = set()
         states["used_anchors"] = used_anchors
     count = int(anchor_counts.get(base_anchor, 0))
     anchor = base_anchor if count == 0 else f"{base_anchor}-{count + 1}"

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -440,6 +440,39 @@ MARKDOWN
 	return 0
 }
 
+test_heading_anchor_preserves_iterable_state() {
+	local _result=0
+	python3 - "$SCRIPT_DIR" <<'PY' || _result=$?
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(sys.argv[1]).parent.resolve()))
+from report_render_headings import unique_heading_anchor
+
+list_state = {"used_anchors": ["repeat"]}
+assert unique_heading_anchor("repeat", list_state) == "repeat-2"
+assert list_state["used_anchors"] == {"repeat", "repeat-2"}
+
+tuple_state = {"used_anchors": ("repeat", "repeat-2")}
+assert unique_heading_anchor("repeat", tuple_state) == "repeat-3"
+assert tuple_state["used_anchors"] == {"repeat", "repeat-2", "repeat-3"}
+
+dict_state = {"used_anchors": {"repeat": True, "repeat-2": True}}
+assert unique_heading_anchor("repeat", dict_state) == "repeat-3"
+assert dict_state["used_anchors"] == {"repeat", "repeat-2", "repeat-3"}
+
+invalid_state = {"used_anchors": 42}
+assert unique_heading_anchor("repeat", invalid_state) == "repeat"
+assert invalid_state["used_anchors"] == {"repeat"}
+PY
+	if [[ "$_result" -ne 0 ]]; then
+		print_result "Heading anchors preserve iterable used_anchors state" 1 "Expected list, tuple, and dict state to be preserved while invalid state resets safely"
+		return 0
+	fi
+	print_result "Heading anchors preserve iterable used_anchors state" 0
+	return 0
+}
+
 test_mermaid_renderer_uses_node_ids() {
 	if python3 - "${SCRIPT_DIR}/.." <<'PYHTML'
 import sys
@@ -642,6 +675,7 @@ main() {
 	test_markdown_table_accepts_indented_single_dash_separator
 	test_markdown_table_preserves_escaped_pipes
 	test_markdown_headings_deduplicate_anchor_ids
+	test_heading_anchor_preserves_iterable_state
 	test_mermaid_renderer_uses_node_ids
 	test_mermaid_renderer_supports_chained_arrows
 	test_multiline_markdown_paragraph

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -80,11 +80,30 @@ def test_handle_table_keeps_separator_shaped_first_body_row() -> None:
     )
 
 
+def test_handle_table_keeps_single_dash_first_body_row() -> None:
+    body: list[str] = []
+    states: dict[str, object] = {"table": False, "paragraph": [], "list": False, "list_tag": ""}
+
+    assert handle_table("| Left | Right |", body, states)
+    assert handle_table("| - | - |", body, states)
+
+    assert_equal(
+        body,
+        [
+            "<table><thead>",
+            "<tr><th>Left</th><th>Right</th></tr></thead><tbody>",
+            "<tr><td>-</td><td>-</td></tr>",
+        ],
+        "single-dash placeholder cells are emitted as data rows",
+    )
+
+
 def main() -> int:
     test_split_markdown_table_row_unescapes_backslash_pairs()
     test_split_markdown_table_row_keeps_escaped_pipes_in_cell()
     test_handle_table_skips_only_header_separator_row()
     test_handle_table_keeps_separator_shaped_first_body_row()
+    test_handle_table_keeps_single_dash_first_body_row()
     print("report_render_blocks tests passed")
     return 0
 

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -84,8 +84,10 @@ def test_handle_table_keeps_single_dash_first_body_row() -> None:
     body: list[str] = []
     states: dict[str, object] = {"table": False, "paragraph": [], "list": False, "list_tag": ""}
 
-    assert handle_table("| Left | Right |", body, states)
-    assert handle_table("| - | - |", body, states)
+    if not handle_table("| Left | Right |", body, states):
+        raise AssertionError("table header row should be handled")
+    if not handle_table("| - | - |", body, states):
+        raise AssertionError("single-dash placeholder row should be handled")
 
     assert_equal(
         body,


### PR DESCRIPTION
## Summary

Preserved pre-populated used_anchors iterable state in unique_heading_anchor, added regression coverage for list/tuple/dict and invalid state, and kept the report render helper suite green by accepting single-dash table header separators in the existing table parser path.

## Files Changed

.agents/scripts/report_render_blocks.py,.agents/scripts/report_render_headings.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report_render_headings.py .agents/scripts/report_render_blocks.py; shellcheck .agents/scripts/tests/test-report-render-helper.sh; .agents/scripts/tests/test-report-render-helper.sh; python3 tests/test_report_render_blocks.py

Resolves #24268


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 2m and 60,918 tokens on this as a headless worker.