### PR TITLE
GH#24275: fix: simplify memory monitor test calls

### DIFF
--- a/.agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh
+++ b/.agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh
@@ -154,15 +154,9 @@ main() {
 	fi
 
 	setup_fake_ps
-	if ! test_ok_service_exit_zero; then
-		:
-	fi
-	if ! test_warning_service_exit_zero_and_logs; then
-		:
-	fi
-	if ! test_critical_service_exit_nonzero_and_logs; then
-		:
-	fi
+	test_ok_service_exit_zero || true
+	test_warning_service_exit_zero_and_logs || true
+	test_critical_service_exit_nonzero_and_logs || true
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Replaced verbose set -e guard blocks in .agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh with concise || true calls while preserving assertion aggregation.

## Files Changed

.agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh; bash .agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh

Resolves #24275


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1m and 52,908 tokens on this as a headless worker.