### PR TITLE
GH#24276: fix: normalize token worker path detection

### DIFF
--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -357,9 +357,13 @@ def _tokens_for_group(group: list[SessionRow]) -> dict[str, int]:
     return tokens
 
 
+def _normalized_session_location(row: SessionRow) -> str:
+    return f"/{row.directory}/{row.path}".replace("\\", "/").lower()
+
+
 def _session_kind_for_group(group: list[SessionRow]) -> str:
     for row in group:
-        location = f"{row.directory}/{row.path}".replace("\\", "/").lower()
+        location = _normalized_session_location(row)
         if (
             "/private/tmp/opencode" in location
             or "/tmp/opencode" in location

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -358,7 +358,8 @@ def _tokens_for_group(group: list[SessionRow]) -> dict[str, int]:
 
 
 def _normalized_session_location(row: SessionRow) -> str:
-    return f"/{row.directory}/{row.path}".replace("\\", "/").lower()
+    location = f"/{row.directory}/{row.path}".replace("\\", "/").lower()
+    return re.sub(r"/+", "/", location)
 
 
 def _session_kind_for_group(group: list[SessionRow]) -> str:

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -162,6 +162,8 @@ test_report_summarizes_headless_workers() {
 INSERT INTO session VALUES ('ses_worker', NULL, 'Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 10, 2, 1, 4, 1, 0.05, 1699999900000, 1699999950000, NULL, '/private/tmp/opencode', 'private/tmp/opencode', 'Build+');
 INSERT INTO session VALUES ('ses_windows_worker', NULL, 'Windows Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 6, 2, 0, 3, 1, 0.03, 1699999800000, 1699999850000, NULL, 'C:\Users\Example\AppData\Local\Temp\OpenCode', 'C:\Users\Example\AppData\Local\Temp\OpenCode\session.json', 'Build+');
 INSERT INTO session VALUES ('ses_split_windows_worker', NULL, 'Split Windows Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 3, 1, 0, 1, 1, 0.01, 1699999700000, 1699999750000, NULL, 'C:\Users\Example\AppData\Local\Temp', 'OpenCode\session.json', 'Build+');
+INSERT INTO session VALUES ('ses_relative_worker', NULL, 'Relative Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 4, 1, 0, 1, 1, 0.02, 1699999600000, 1699999650000, NULL, '', 'tmp/opencode/session.json', 'Build+');
+INSERT INTO session VALUES ('ses_split_unix_worker', NULL, 'Split Unix Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 5, 1, 0, 1, 1, 0.02, 1699999500000, 1699999550000, NULL, '/tmp', 'opencode/session.json', 'Build+');
 SQL
 	local _json_path="${TEST_ROOT}/data.json"
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
@@ -169,12 +171,14 @@ SQL
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
 		"$HELPER_SH" data --limit 5 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
-	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "28" "Report sums headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "28" "Report sums daily headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "220" "Report sums daily total net tokens"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "40" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "40" "Report sums daily headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "232" "Report sums daily total net tokens"
 	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[2].session_kind" "headless_worker" "Report classifies Windows temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[3].session_kind" "headless_worker" "Report classifies split Windows temp workdir session as headless worker"
+	assert_json_field "$_json_path" "sessions[4].session_kind" "headless_worker" "Report classifies relative temp path session as headless worker"
+	assert_json_field "$_json_path" "sessions[5].session_kind" "headless_worker" "Report classifies split Unix temp path session as headless worker"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -169,11 +169,11 @@ SQL
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
-		"$HELPER_SH" data --limit 5 --daily-days 2000 --json >"$_json_path"
+		"$HELPER_SH" data --limit 10 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
-	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "40" "Report sums headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "40" "Report sums daily headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "232" "Report sums daily total net tokens"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "41" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "41" "Report sums daily headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "233" "Report sums daily total net tokens"
 	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[2].session_kind" "headless_worker" "Report classifies Windows temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[3].session_kind" "headless_worker" "Report classifies split Windows temp workdir session as headless worker"

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -164,6 +164,7 @@ INSERT INTO session VALUES ('ses_windows_worker', NULL, 'Windows Worker Session'
 INSERT INTO session VALUES ('ses_split_windows_worker', NULL, 'Split Windows Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 3, 1, 0, 1, 1, 0.01, 1699999700000, 1699999750000, NULL, 'C:\Users\Example\AppData\Local\Temp', 'OpenCode\session.json', 'Build+');
 INSERT INTO session VALUES ('ses_relative_worker', NULL, 'Relative Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 4, 1, 0, 1, 1, 0.02, 1699999600000, 1699999650000, NULL, '', 'tmp/opencode/session.json', 'Build+');
 INSERT INTO session VALUES ('ses_split_unix_worker', NULL, 'Split Unix Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 5, 1, 0, 1, 1, 0.02, 1699999500000, 1699999550000, NULL, '/tmp', 'opencode/session.json', 'Build+');
+INSERT INTO session VALUES ('ses_double_slash_worker', NULL, 'Double Slash Unix Worker Session', '{"id":"gpt-5.5","providerID":"openai"}', 2, 1, 0, 1, 1, 0.01, 1699999400000, 1699999450000, NULL, '/tmp/', '/opencode/session.json', 'Build+');
 SQL
 	local _json_path="${TEST_ROOT}/data.json"
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
@@ -171,14 +172,15 @@ SQL
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
 		"$HELPER_SH" data --limit 10 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
-	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "41" "Report sums headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "41" "Report sums daily headless worker net tokens"
-	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "233" "Report sums daily total net tokens"
+	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "45" "Report sums headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "45" "Report sums daily headless worker net tokens"
+	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "237" "Report sums daily total net tokens"
 	assert_json_field "$_json_path" "sessions[1].session_kind" "headless_worker" "Report classifies temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[2].session_kind" "headless_worker" "Report classifies Windows temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[3].session_kind" "headless_worker" "Report classifies split Windows temp workdir session as headless worker"
 	assert_json_field "$_json_path" "sessions[4].session_kind" "headless_worker" "Report classifies relative temp path session as headless worker"
 	assert_json_field "$_json_path" "sessions[5].session_kind" "headless_worker" "Report classifies split Unix temp path session as headless worker"
+	assert_json_field "$_json_path" "sessions[6].session_kind" "headless_worker" "Report classifies double-slash Unix temp path session as headless worker"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Normalized token-use session location matching so relative tmp/opencode paths and directory/path boundary splits are classified as headless workers; added regression coverage for relative and split Unix temp paths.

## Files Changed

.agents/scripts/report-token-use-helper.py,.agents/scripts/tests/test-report-token-use-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-report-token-use-helper.sh; python3 -m py_compile .agents/scripts/report-token-use-helper.py

Resolves #24276


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2m and 43,550 tokens on this as a headless worker.