### PR TITLE
GH#24274: fix runner health test worktree SHA capture

### DIFF
--- a/.agents/scripts/tests/test-runner-health-diagnose.sh
+++ b/.agents/scripts/tests/test-runner-health-diagnose.sh
@@ -140,7 +140,7 @@ _mark_deploy_healthy() {
 	local repo_root
 	repo_root=$(cd "${AGENT_SCRIPT_DIR}/../.." && pwd) || return 1
 	tr -d '[:space:]' <"${repo_root}/VERSION" >"$RUNNER_HEALTH_DEPLOYED_VERSION_FILE"
-	if [[ -d "${repo_root}/.git" ]]; then
+	if [[ -e "${repo_root}/.git" ]]; then
 		git -C "$repo_root" rev-parse HEAD >"$RUNNER_HEALTH_DEPLOYED_SHA_FILE" 2>/dev/null || true
 	fi
 	return 0


### PR DESCRIPTION
## Summary

Updated the runner health diagnose test helper to treat .git files and directories as valid Git checkouts when recording the deployed SHA.

## Files Changed

.agents/scripts/tests/test-runner-health-diagnose.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-runner-health-diagnose.sh; shellcheck .agents/scripts/tests/test-runner-health-diagnose.sh

Resolves #24274


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 4m and 64,883 tokens on this as a headless worker.