### PR TITLE
GH#24271: fix: tighten report table separator detection

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -40,11 +40,7 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return False
     raw_cells = [cell.strip() for cell in split_markdown_table_row(stripped)]
-    separator_cells = [html.unescape(cell) for cell in raw_cells]
-    is_separator_row = all(re.match(r"^:?-+:?$", cell) for cell in separator_cells) and (
-        all(len(cell.strip(":")) >= 3 for cell in separator_cells)
-        or any(cell.startswith(":") or cell.endswith(":") for cell in separator_cells)
-    )
+    is_separator_row = is_markdown_table_separator_row(raw_cells)
     if (
         is_separator_row
         and states.get("table")
@@ -65,6 +61,12 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
     body.append("<tr>{}</tr>".format("".join(f"<td>{cell}</td>" for cell in cells)))
     states["table_body_started"] = True
     return True
+
+
+def is_markdown_table_separator_row(cells: list[str]) -> bool:
+    """Return True only for a real Markdown table header separator row."""
+    separator_cells = [html.unescape(cell) for cell in cells]
+    return all(re.fullmatch(r":?-{3,}:?", cell) for cell in separator_cells)
 
 
 def split_markdown_table_row(line: str) -> list[str]:

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -12,7 +12,7 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _SCRIPTS_DIR = os.path.join(_REPO_ROOT, ".agents", "scripts")
 sys.path.insert(0, _SCRIPTS_DIR)
 
-from report_render_blocks import handle_table, split_markdown_table_row  # noqa: E402
+from report_render_blocks import handle_table, is_markdown_table_separator_row, split_markdown_table_row  # noqa: E402
 
 
 def assert_equal(actual: object, expected: object, description: str) -> None:
@@ -100,12 +100,26 @@ def test_handle_table_keeps_single_dash_first_body_row() -> None:
     )
 
 
+def test_table_separator_requires_three_dashes_per_cell() -> None:
+    assert_equal(
+        is_markdown_table_separator_row([":---", "---:", ":---:"]),
+        True,
+        "standard alignment separator cells are recognised",
+    )
+    assert_equal(
+        is_markdown_table_separator_row([":-", "-:"]),
+        False,
+        "short dash cells with alignment markers are data, not separators",
+    )
+
+
 def main() -> int:
     test_split_markdown_table_row_unescapes_backslash_pairs()
     test_split_markdown_table_row_keeps_escaped_pipes_in_cell()
     test_handle_table_skips_only_header_separator_row()
     test_handle_table_keeps_separator_shaped_first_body_row()
     test_handle_table_keeps_single_dash_first_body_row()
+    test_table_separator_requires_three_dashes_per_cell()
     print("report_render_blocks tests passed")
     return 0
 


### PR DESCRIPTION
## Summary

Tightened report Markdown table separator detection so only separator cells with at least three dashes are consumed; extracted the predicate for direct regression coverage.

## Files Changed

.agents/scripts/report_render_blocks.py,tests/test_report_render_blocks.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 tests/test_report_render_blocks.py; python3 -m py_compile .agents/scripts/report_render_blocks.py tests/test_report_render_blocks.py; .agents/scripts/linters-local.sh reached Secretlint then timed out after 240s

Resolves #24271


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 9m and 46,632 tokens on this as a headless worker.