### PR TITLE
GH#24286: fix: guard empty table separator cells

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -65,6 +65,8 @@ def handle_table(line: str, body: list[str], states: dict[str, object]) -> bool:
 
 def is_markdown_table_separator_row(cells: list[str]) -> bool:
     """Return True only for a real Markdown table header separator row."""
+    if not cells:
+        return False
     separator_cells = [html.unescape(cell) for cell in cells]
     return all(re.fullmatch(r":?-{3,}:?", cell) for cell in separator_cells)
 

--- a/tests/test_report_render_blocks.py
+++ b/tests/test_report_render_blocks.py
@@ -111,6 +111,11 @@ def test_table_separator_requires_three_dashes_per_cell() -> None:
         False,
         "short dash cells with alignment markers are data, not separators",
     )
+    assert_equal(
+        is_markdown_table_separator_row([]),
+        False,
+        "an empty list of cells is not a separator row",
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Added an explicit empty-cell guard to Markdown table separator detection and covered it with a regression test.

## Files Changed

.agents/scripts/report_render_blocks.py,tests/test_report_render_blocks.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 tests/test_report_render_blocks.py

Resolves #24286


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1m and 31,114 tokens on this as a headless worker.