### PR TITLE
GH#24287: fix: harden runner health SHA capture

### DIFF
--- a/.agents/scripts/tests/test-runner-health-diagnose.sh
+++ b/.agents/scripts/tests/test-runner-health-diagnose.sh
@@ -141,7 +141,10 @@ _mark_deploy_healthy() {
 	repo_root=$(cd "${AGENT_SCRIPT_DIR}/../.." && pwd) || return 1
 	tr -d '[:space:]' <"${repo_root}/VERSION" >"$RUNNER_HEALTH_DEPLOYED_VERSION_FILE"
 	if [[ -e "${repo_root}/.git" ]]; then
-		git -C "$repo_root" rev-parse HEAD >"$RUNNER_HEALTH_DEPLOYED_SHA_FILE" 2>/dev/null || true
+		local sha
+		if sha=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null) && [[ -n "$sha" ]]; then
+			printf '%s\n' "$sha" >"$RUNNER_HEALTH_DEPLOYED_SHA_FILE"
+		fi
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Captured the repository SHA in a local variable before writing the deployed SHA file so failed git lookups cannot truncate or corrupt the cache marker.

## Files Changed

.agents/scripts/tests/test-runner-health-diagnose.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-runner-health-diagnose.sh; bash .agents/scripts/tests/test-runner-health-diagnose.sh

Resolves #24287


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1m and 34,255 tokens on this as a headless worker.