### PR TITLE
GH#24294: fix: guard terminal completion checks

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -704,12 +704,14 @@ _worker_external_terminal_complete() {
 	local work_dir="$2"
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
 	local issue_number=""
+
+	[[ "$session_key" == issue-* ]] || return 1
+	[[ -n "$repo_slug" ]] || return 1
+
 	if [[ "$session_key" =~ ([0-9]+)$ ]]; then
 		issue_number="${BASH_REMATCH[1]}"
 	fi
-
-	[[ "$session_key" == issue-* ]] || return 1
-	[[ -n "$repo_slug" && -n "$issue_number" ]] || return 1
+	[[ -n "$issue_number" ]] || return 1
 	command -v gh >/dev/null 2>&1 || return 1
 
 	local issue_state=""

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -395,6 +395,27 @@ test_external_terminal_complete_uses_trailing_issue_digits() {
 	return 0
 }
 
+test_external_terminal_complete_guards_before_github_calls() {
+	export STUB_GH_LOG="${TEST_ROOT}/case8-gh.log"
+	: >"$STUB_GH_LOG"
+
+	if _worker_external_terminal_complete "session-24153-123" "" >/dev/null 2>&1; then
+		print_result "case 8: external terminal complete guards before GitHub calls" 1 "non-issue session returned complete"
+		unset STUB_GH_LOG
+		return 0
+	fi
+
+	local gh_calls=""
+	gh_calls=$(grep -E '^(issue|pr) ' "$STUB_GH_LOG" || true)
+	unset STUB_GH_LOG
+	if [[ -z "$gh_calls" ]]; then
+		print_result "case 8: external terminal complete guards before GitHub calls" 0
+	else
+		print_result "case 8: external terminal complete guards before GitHub calls" 1 "unexpected gh calls: $gh_calls"
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Run
 # -----------------------------------------------------------------------------
@@ -406,6 +427,7 @@ test_feature_branch_with_pr_returns_pr_exists
 test_failure_recovery_ignores_default_branch_pr_match
 test_feature_branch_without_default_ref_returns_branch_orphan
 test_external_terminal_complete_uses_trailing_issue_digits
+test_external_terminal_complete_guards_before_github_calls
 
 printf '\nRan %d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary

Moved the `_worker_external_terminal_complete` session/repository guard clauses before issue-number regex parsing, then split the issue-number presence check so invalid inputs return before later work.

## Files Changed

.agents/scripts/headless-runtime-worker.sh, .agents/scripts/tests/test-worker-output-classification.sh

## Runtime Testing

- **Risk level:** Low (headless worker helper guard ordering)
- **Verification:** `shellcheck .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-worker-output-classification.sh`; `.agents/scripts/tests/test-worker-output-classification.sh`

Resolves #24294

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 3m and 54,701 tokens on this as a headless worker.