### PR TITLE
GH#24303: fix: tighten issue-worker release guard

### DIFF
--- a/.agents/scripts/tests/test-version-manager-headless-guard.sh
+++ b/.agents/scripts/tests/test-version-manager-headless-guard.sh
@@ -69,6 +69,16 @@ else
 fi
 
 reset_guard_env
+export AIDEVOPS_HEADLESS=false FULL_LOOP_HEADLESS=0 OPENCODE_HEADLESS=True WORKER_ISSUE_NUMBER=24089
+rc=0
+_version_manager_is_headless_task_worker >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'headless guard accepts mixed-case truthy markers' 0
+else
+	print_result 'headless guard accepts mixed-case truthy markers' 1 "rc=$rc"
+fi
+
+reset_guard_env
 export OPENCODE_HEADLESS=1 WORKER_SESSION_KEY='ISSUE-24089'
 rc=0
 _version_manager_is_headless_task_worker >/dev/null 2>&1 || rc=$?
@@ -132,13 +142,23 @@ else
 fi
 
 reset_guard_env
-export WORKER_SESSION_TITLE='Final release'
+export WORKER_SESSION_TITLE='Release cleanup'
 rc=0
 _version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
 if [[ "$rc" -eq 0 ]]; then
-	print_result 'release context accepts case-insensitive trailing title match' 0
+	print_result 'release context accepts case-insensitive title prefix match' 0
 else
-	print_result 'release context accepts case-insensitive trailing title match' 1 "rc=$rc"
+	print_result 'release context accepts case-insensitive title prefix match' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export AIDEVOPS_HEADLESS=1 WORKER_ISSUE_NUMBER=24089 WORKER_SESSION_KEY='issue-24089' AIDEVOPS_SESSION_TITLE='ordinary issue mentioning release cleanup'
+rc=0
+_version_manager_guard_headless_release_scope bump >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result 'release context denies broad title substring match' 0
+else
+	print_result 'release context denies broad title substring match' 1 "rc=$rc"
 fi
 
 printf '\nTests run: %d, failures: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -77,7 +77,7 @@ _version_manager_has_approved_release_context() {
 	[[ "${AIDEVOPS_TASK_SCOPE:-}" == "$_VERSION_MANAGER_ACTION_RELEASE" ]] && return 0
 	[[ "$branch_name" == release/* || "$branch_name" == hotfix/* ]] && return 0
 	[[ "$session_key_lower" == release-* || "$session_key_lower" == hotfix-* ]] && return 0
-	[[ "$session_title_lower" == release* || "$session_title_lower" == *" release" || "$session_title_lower" == *" release "* ]] && return 0
+	[[ "$session_title_lower" == release || "$session_title_lower" == release\ * ]] && return 0
 	return 1
 }
 


### PR DESCRIPTION
## Summary

Recovered the still-valid release guard fix from closed PR #24087 by narrowing approved release-title matching in .agents/scripts/version-manager.sh to explicit release prefixes only, while preserving explicit approvals, release/hotfix branches, and release/hotfix session keys. Added regression coverage for mixed-case truthy headless markers and broad title substring denial in .agents/scripts/tests/test-version-manager-headless-guard.sh.

## Files Changed

.agents/scripts/tests/test-version-manager-headless-guard.sh,.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-version-manager-headless-guard.sh; shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-version-manager-headless-guard.sh

Resolves #24303


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2m and 59,342 tokens on this as a headless worker.