### PR TITLE
GH#24306: scan orphaned health dashboards

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -231,13 +231,16 @@ _cadence_gate_ok() {
 # Dashboard enumeration
 # =============================================================================
 
-# Emit "slug issue_number" lines for every known dashboard via the
-# ~/.aidevops/logs/health-issue-* cache files written by
-# stats-health-dashboard.sh. Historical cache names included the role segment
-# (`health-issue-<runner>-supervisor-<slug-dashed>`); current canonical
-# identity caches omit it (`health-issue-<canonical>-<slug-dashed>`). Resolve
-# both by matching the longest repos.json slug suffix instead of parsing a fixed
-# segment position.
+# Emit "slug issue_number" lines for every known dashboard. Prefer local
+# ~/.aidevops/logs/health-issue-* cache files written by stats-health-dashboard.sh,
+# then fall back to open `source:health-dashboard` issues in configured repos.
+# The fallback covers orphaned historical dashboards after cache migration,
+# identity changes, or fresh hosts where the stale dashboard's cache is absent.
+# Historical cache names included the role segment
+# (`health-issue-<runner>-supervisor-<slug-dashed>`); current canonical identity
+# caches omit it (`health-issue-<canonical>-<slug-dashed>`). Resolve both by
+# matching the longest repos.json slug suffix instead of parsing a fixed segment
+# position.
 _enumerate_dashboards() {
 	local cache issue slug_raw slug key seen="|" slug_candidates
 	slug_candidates="$(_repo_slug_candidates)"
@@ -256,6 +259,43 @@ _enumerate_dashboards() {
 		printf '%s %s\n' "$slug" "$issue"
 	done
 	shopt -u nullglob
+	if command -v gh >/dev/null 2>&1 && gh auth status &>/dev/null 2>&1; then
+		while IFS= read -r slug; do
+			[[ -n "$slug" ]] || continue
+			while IFS= read -r issue; do
+				[[ "$issue" =~ ^[0-9]+$ ]] || continue
+				key="${slug} ${issue}"
+				case "$seen" in
+					*"|${key}|"*) continue ;;
+				esac
+				seen="${seen}${key}|"
+				printf '%s %s\n' "$slug" "$issue"
+			done < <(_github_health_dashboard_issue_numbers "$slug")
+		done < <(_repo_slugs_for_dashboard_scan)
+	fi
+	return 0
+}
+
+# Emit configured remote pulse repo slugs that may host health dashboards.
+_repo_slugs_for_dashboard_scan() {
+	[[ -f "$REPOS_JSON" ]] || return 0
+	if ! command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+	jq -r '
+		.initialized_repos[]
+		| select(.pulse == true and (.local_only // false) == false and .slug != null and .slug != "")
+		| .slug
+	' "$REPOS_JSON" 2>/dev/null
+	return 0
+}
+
+# Emit open health-dashboard issue numbers for a repo via REST-backed gh api.
+_github_health_dashboard_issue_numbers() {
+	local slug="$1"
+	[[ -n "$slug" ]] || return 0
+	gh api --paginate "repos/${slug}/issues?state=open&labels=source%3Ahealth-dashboard&per_page=100" \
+		--jq '.[] | select(.pull_request == null) | .number' 2>>"$LOGFILE" || true
 	return 0
 }
 

--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -233,9 +233,10 @@ _cadence_gate_ok() {
 
 # Emit "slug issue_number" lines for every known dashboard. Prefer local
 # ~/.aidevops/logs/health-issue-* cache files written by stats-health-dashboard.sh,
-# then fall back to open `source:health-dashboard` issues in configured repos.
-# The fallback covers orphaned historical dashboards after cache migration,
-# identity changes, or fresh hosts where the stale dashboard's cache is absent.
+# and include open `source:health-dashboard` issues in configured repos. The
+# GitHub enumeration is intentional even when some caches exist: it covers
+# orphaned historical dashboards after cache migration, identity changes, or
+# fresh hosts where only the stale dashboard's cache is absent.
 # Historical cache names included the role segment
 # (`health-issue-<runner>-supervisor-<slug-dashed>`); current canonical identity
 # caches omit it (`health-issue-<canonical>-<slug-dashed>`). Resolve both by
@@ -283,10 +284,10 @@ _repo_slugs_for_dashboard_scan() {
 		return 0
 	fi
 	jq -r '
-		.initialized_repos[]
+		.initialized_repos[]?
 		| select(.pulse == true and (.local_only // false) == false and .slug != null and .slug != "")
 		| .slug
-	' "$REPOS_JSON" 2>/dev/null
+	' "$REPOS_JSON" || true
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -27,7 +27,9 @@
 #      closes the recovered missing-marker alert and files a stale alert.
 #  11. open issue list failures are logged instead of silently treated as an
 #      empty dedup result.
-#  12. source regression: recovered stale and missing-marker alert paths share
+#  12. scan without a local health-issue cache falls back to open
+#      source:health-dashboard issues for configured repos.
+#  13. source regression: recovered stale and missing-marker alert paths share
 #      the parameterized close helper and accept a pre-fetched open issue list.
 #
 # The scanner is expected to use `command -v gh` + `gh auth status` guards
@@ -223,6 +225,10 @@ run_scan_with_stubs() {
 						return 0
 						;;
 					api)
+						if [[ "$gh_args" == *"repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard&per_page=100"* ]]; then
+							printf "%s\n" 424242
+							return 0
+						fi
 						if [[ "$gh_args" == *"repos/test/repo/issues?state=open&per_page=100"* ]]; then
 							if [[ "${GH_ISSUE_LIST_FAIL:-0}" == "1" ]]; then
 								printf "simulated gh api issue list failure\n" >&2
@@ -465,7 +471,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 12: source shape for shared recovered-alert helper and cached issue list
+# Test 12: missing local cache falls back to source:health-dashboard issues
+# ---------------------------------------------------------------------------
+echo "Testing: source health-dashboard fallback without local cache"
+rm -f "$HEALTH_CACHE"
+run_scan_with_stubs "$STALE_BODY" 0 "" >/dev/null
+calls_file="${TMP}/gh-calls.log"
+created_count=$(grep -c '^issue create ' "$calls_file" 2>/dev/null || true)
+[[ "$created_count" =~ ^[0-9]+$ ]] || created_count=0
+
+if (( created_count == 1 )) \
+	&& grep -q '^api --paginate repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard&per_page=100 ' "$calls_file"; then
+	pass "missing cache → source:health-dashboard fallback scans dashboard"
+else
+	fail "source health-dashboard fallback" \
+		"created=$created_count; calls:\n$(cat "$calls_file")"
+fi
+printf '%s\n' 424242 >"$HEALTH_CACHE"
+
+# ---------------------------------------------------------------------------
+# Test 13: source shape for shared recovered-alert helper and cached issue list
 # ---------------------------------------------------------------------------
 echo "Testing: recovered-alert source shape"
 if grep -q '^_close_recovered_alerts_for_kind()' "$SCANNER" \
@@ -480,7 +505,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 13: missing-marker body → alerts with MISSING title
+# Test 14: missing-marker body → alerts with MISSING title
 # ---------------------------------------------------------------------------
 echo "Testing: missing-marker body files alert"
 run_scan_with_stubs "$MISSING_BODY" 0 "" >/dev/null


### PR DESCRIPTION
## Summary

Added a REST fallback so dashboard-freshness-check scans open source:health-dashboard issues from configured pulse repos when local health-issue cache files are missing, preserving existing cache-based enumeration and deduping duplicate entries. Root cause: the stale #24173 dashboard belonged to operator vod, but this runner had no matching local health-issue cache, so the freshness scanner logged 'No dashboards to scan' while stats-wrapper continued refreshing only the current operator dashboard.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh,.agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dashboard-freshness-check.sh; shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh; DASHBOARD_FRESHNESS_DRY_RUN=1 .agents/scripts/dashboard-freshness-check.sh scan --force --dry-run logged #24173 as stale and found four dashboards

Resolves #24306


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 3m and 106,267 tokens on this as a headless worker.