### PR TITLE
GH#24308: ignore stale contributor dashboards

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -291,13 +291,28 @@ _repo_slugs_for_dashboard_scan() {
 	return 0
 }
 
-# Emit open health-dashboard issue numbers for a repo via REST-backed gh api.
+# Emit open supervisor health-dashboard issue numbers for a repo via
+# REST-backed gh api. Contributor dashboards are intentionally excluded: they
+# can be stale when that contributor is offline and are not the operator's
+# primary single-glance health surface.
 _github_health_dashboard_issue_numbers() {
 	local slug="$1"
 	[[ -n "$slug" ]] || return 0
-	gh api --paginate "repos/${slug}/issues?state=open&labels=source%3Ahealth-dashboard&per_page=100" \
+	gh api --paginate "repos/${slug}/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100" \
 		--jq '.[] | select(.pull_request == null) | .number' 2>>"$LOGFILE" || true
 	return 0
+}
+
+# Return success when a dashboard issue belongs to a supervisor runner. This is
+# a defense-in-depth guard for local cache entries, which do not encode the
+# role in the current canonical filename format.
+_dashboard_issue_is_supervisor() {
+	local issue_json="$1"
+	printf '%s\n' "$issue_json" | jq -e '
+		((.title // "") | startswith("[Supervisor:"))
+		or (((.labels // []) | map(.name // .) | index("supervisor")) != null)
+	' >/dev/null 2>&1
+	return $?
 }
 
 # Emit known repos as "dashed<TAB>slug" lines sorted by longest dashed slug
@@ -758,9 +773,13 @@ scan_one_dashboard() {
 		return 0
 	fi
 
-	issue_json=$(gh api "repos/${slug}/issues/${dash_issue}" --jq '{state,body}' 2>>"$LOGFILE" || echo "")
+	issue_json=$(gh api "repos/${slug}/issues/${dash_issue}" --jq '{state,body,title,labels}' 2>>"$LOGFILE" || echo "")
 	if [[ -z "$issue_json" ]]; then
 		_log_warn "Empty issue payload from gh at ${slug}#${dash_issue}"
+		return 0
+	fi
+	if ! _dashboard_issue_is_supervisor "$issue_json"; then
+		_log_info "Dashboard ${slug}#${dash_issue} is not a supervisor dashboard — skipping stale scan"
 		return 0
 	fi
 	issue_state=$(printf '%s\n' "$issue_json" | jq -r '.state // ""' 2>/dev/null || true)

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -225,7 +225,7 @@ run_scan_with_stubs() {
 						return 0
 						;;
 					api)
-						if [[ "$gh_args" == *"repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard&per_page=100"* ]]; then
+						if [[ "$gh_args" == *"repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100"* ]]; then
 							printf "%s\n" 424242
 							return 0
 						fi
@@ -249,8 +249,10 @@ run_scan_with_stubs() {
 						# $2 = repos/test/repo/issues/424242
 						jq -n \
 							--arg state "${DASHBOARD_STATE:-OPEN}" \
+							--arg title "${DASHBOARD_TITLE:-[Supervisor:testrunner] ok}" \
+							--arg role "${DASHBOARD_ROLE_LABEL:-supervisor}" \
 							--rawfile body "$BODY_FIXTURE" \
-							"{state: \$state, body: \$body}"
+							"{state: \$state, title: \$title, labels: [{name: \$role}], body: \$body}"
 						return 0
 						;;
 					issue)
@@ -481,13 +483,32 @@ created_count=$(grep -c '^issue create ' "$calls_file" 2>/dev/null || true)
 [[ "$created_count" =~ ^[0-9]+$ ]] || created_count=0
 
 if (( created_count == 1 )) \
-	&& grep -q '^api --paginate repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard&per_page=100 ' "$calls_file"; then
+	&& grep -q '^api --paginate repos/test/repo/issues?state=open&labels=source%3Ahealth-dashboard,supervisor&per_page=100 ' "$calls_file"; then
 	pass "missing cache → source:health-dashboard fallback scans dashboard"
 else
 	fail "source health-dashboard fallback" \
 		"created=$created_count; calls:\n$(cat "$calls_file")"
 fi
 printf '%s\n' 424242 >"$HEALTH_CACHE"
+
+# ---------------------------------------------------------------------------
+# Test 12b: contributor health dashboards are ignored
+# ---------------------------------------------------------------------------
+echo "Testing: contributor dashboard is ignored"
+run_scan_with_stubs "$STALE_BODY" 0 "export DASHBOARD_TITLE='[Contributor:testrunner] stale'; export DASHBOARD_ROLE_LABEL=contributor" >/dev/null
+calls_file="${TMP}/gh-calls.log"
+created_count=$(grep -c '^issue create ' "$calls_file" 2>/dev/null || true)
+[[ "$created_count" =~ ^[0-9]+$ ]] || created_count=0
+
+if (( created_count == 0 )) \
+	&& grep -q 'Dashboard test/repo#424242 is not a supervisor dashboard — skipping stale scan' \
+		"${HOME_ISO}/.aidevops/logs/dashboard-freshness.log" \
+	&& grep -q 'startswith("\[Supervisor:")' "$SCANNER"; then
+	pass "contributor dashboard → no stale alert filed"
+else
+	fail "contributor dashboard skip" \
+		"created=$created_count; calls:\n$(cat "$calls_file"); log:\n$(cat "${HOME_ISO}/.aidevops/logs/dashboard-freshness.log")"
+fi
 
 # ---------------------------------------------------------------------------
 # Test 13: source shape for shared recovered-alert helper and cached issue list


### PR DESCRIPTION
## Summary

Dashboard freshness now treats only supervisor health dashboards as freshness-watch targets. GitHub fallback enumeration requires source:health-dashboard plus supervisor labels, and cached/local dashboard entries are verified by title/label before stale alerts are filed, preventing contributor dashboards like #24173 from being reported as supervisor scheduler failures.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh,.agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dashboard-freshness-check.sh; shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh; .agents/scripts/linters-local.sh

Resolves #24308


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 10m and 118,675 tokens on this as a headless worker.