### PR TITLE
GH#24311: exclude pending required checks from zero-progress

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1015,40 +1015,6 @@ _ruleset_ref_matches_default_branch() {
 }
 
 #######################################
-# Fallback required-check verification for repositories where the classic branch
-# protection endpoint and repository-rulesets endpoint expose no contexts, but
-# GitHub still reports PR-level required checks (for example org-level rulesets).
-#
-# Args: $1=repo_slug, $2=pr_number
-# Returns: 0=all reported required checks passing or none reported,
-#          1=at least one reported required check is not passing,
-#          2=API/parse error
-#######################################
-_check_required_pr_checks_passing_fallback() {
-	local repo_slug="$1"
-	local pr_number="$2"
-
-	local checks_json=""
-	checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null) || return 2
-	if [[ -z "$checks_json" || "$checks_json" == "null" || "$checks_json" == "[]" ]]; then
-		return 0
-	fi
-
-	local nonpassing_count="" _pc_exit=0
-	nonpassing_count=$(printf '%s' "$checks_json" \
-		| jq '[.[]? | select((.bucket // "") != "pass")] | length' 2>/dev/null)
-	_pc_exit=$?
-	if [[ $_pc_exit -ne 0 || -z "$nonpassing_count" ]]; then
-		return 2
-	fi
-
-	if [[ "$nonpassing_count" -gt 0 ]]; then
-		return 1
-	fi
-	return 0
-}
-
-#######################################
 # Resolve newline-delimited required status check contexts from active
 # repository rulesets matching the default branch. This supplements classic
 # branch protection because rulesets can enforce required checks even when

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1015,6 +1015,40 @@ _ruleset_ref_matches_default_branch() {
 }
 
 #######################################
+# Fallback required-check verification for repositories where the classic branch
+# protection endpoint and repository-rulesets endpoint expose no contexts, but
+# GitHub still reports PR-level required checks (for example org-level rulesets).
+#
+# Args: $1=repo_slug, $2=pr_number
+# Returns: 0=all reported required checks passing or none reported,
+#          1=at least one reported required check is not passing,
+#          2=API/parse error
+#######################################
+_check_required_pr_checks_passing_fallback() {
+	local repo_slug="$1"
+	local pr_number="$2"
+
+	local checks_json=""
+	checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null) || return 2
+	if [[ -z "$checks_json" || "$checks_json" == "null" || "$checks_json" == "[]" ]]; then
+		return 0
+	fi
+
+	local nonpassing_count="" _pc_exit=0
+	nonpassing_count=$(printf '%s' "$checks_json" \
+		| jq '[.[]? | select((.bucket // "") != "pass")] | length' 2>/dev/null)
+	_pc_exit=$?
+	if [[ $_pc_exit -ne 0 || -z "$nonpassing_count" ]]; then
+		return 2
+	fi
+
+	if [[ "$nonpassing_count" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Resolve newline-delimited required status check contexts from active
 # repository rulesets matching the default branch. This supplements classic
 # branch protection because rulesets can enforce required checks even when
@@ -1194,8 +1228,19 @@ _check_required_checks_passing() {
 
 	# No required contexts → nothing required, treat as passing.
 	if [[ -z "$required_contexts" ]]; then
-		echo "[pulse-merge] _check_required_checks_passing: no required contexts for ${repo_slug} — allowing (t2922)" >>"$LOGFILE"
-		return 0
+		local fallback_rc=0
+		_check_required_pr_checks_passing_fallback "$repo_slug" "$pr_number"
+		fallback_rc=$?
+		if [[ $fallback_rc -eq 0 ]]; then
+			echo "[pulse-merge] _check_required_checks_passing: no branch/ruleset contexts and PR required checks are passing or absent for PR #${pr_number} in ${repo_slug} — allowing (t2922)" >>"$LOGFILE"
+			return 0
+		fi
+		if [[ $fallback_rc -eq 1 ]]; then
+			echo "[pulse-merge] _check_required_checks_passing: PR-level required checks are not passing for PR #${pr_number} in ${repo_slug} despite no branch/ruleset contexts — failing closed (t2922)" >>"$LOGFILE"
+			return 1
+		fi
+		echo "[pulse-merge] _check_required_checks_passing: PR-level required checks fallback failed for PR #${pr_number} in ${repo_slug} — failing closed (t2922)" >>"$LOGFILE"
+		return 1
 	fi
 
 	# GH#21799: replace GraphQL statusCheckRollup with REST check-runs (single

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -7,6 +7,40 @@
 _PULSE_MERGE_REQUIRED_CHECKS_LOADED=1
 
 #######################################
+# Fallback required-check verification for repositories where the classic branch
+# protection endpoint and repository-rulesets endpoint expose no contexts, but
+# GitHub still reports PR-level required checks (for example org-level rulesets).
+#
+# Args: $1=repo_slug, $2=pr_number
+# Returns: 0=all reported required checks passing or none reported,
+#          1=at least one reported required check is not passing,
+#          2=API/parse error
+#######################################
+_check_required_pr_checks_passing_fallback() {
+	local repo_slug="$1"
+	local pr_number="$2"
+
+	local checks_json=""
+	checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null) || return 2
+	if [[ -z "$checks_json" || "$checks_json" == "null" || "$checks_json" == "[]" ]]; then
+		return 0
+	fi
+
+	local nonpassing_count="" _pc_exit=0
+	nonpassing_count=$(printf '%s' "$checks_json" \
+		| jq '[.[]? | select((.bucket // "") != "pass")] | length' 2>/dev/null)
+	_pc_exit=$?
+	if [[ $_pc_exit -ne 0 || -z "$nonpassing_count" ]]; then
+		return 2
+	fi
+
+	if [[ "$nonpassing_count" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Return whether any branch-protection-required check on a PR is in a terminal
 # failed state. Pending states are explicitly non-terminal: queued, pending,
 # in_progress, waiting, skipped-by-dependency, expected, absent-from-rollup,

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -71,6 +71,8 @@ print_result() {
 #   queued_only     — required check-run is queued with no conclusion yet
 #   expected_only   — required status context is expected/not reported yet
 #   skipping_only   — required check-run concludes skipped
+#   empty_required_pending_fallback — branch/ruleset APIs expose no contexts,
+#      but `gh pr checks --required` reports a pending required check
 #   error           — branch-protection API exits non-zero
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
@@ -127,7 +129,7 @@ fi
 
 if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	empty_required)
+	empty_required | empty_required_pending_fallback)
 		apply_jq '{"contexts":[]}' "$@"
 		exit 0
 		;;
@@ -145,6 +147,22 @@ fi
 if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"headRefOid"* ]]; then
 	apply_jq '{"headRefOid":"abc123def456789000000000000000000000abcd"}' "$@"
 	exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
+	case "${MOCK_GH_MODE:-all_pass}" in
+	empty_required_pending_fallback)
+		apply_jq '[
+			{"name":"ShellCheck (macos-latest)","state":"PENDING","bucket":"pending"},
+			{"name":"maintainer-gate","state":"SUCCESS","bucket":"pass"}
+		]' "$@"
+		exit 0
+		;;
+	*)
+		apply_jq '[]' "$@"
+		exit 0
+		;;
+	esac
 fi
 
 if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
@@ -252,6 +270,17 @@ define_function_under_test() {
 	# shellcheck disable=SC1090  # dynamic source from extracted helper
 	eval "$ref_match_src"
 
+	local pr_checks_fallback_src
+	pr_checks_fallback_src=$(awk '
+		/^_check_required_pr_checks_passing_fallback\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$pr_checks_fallback_src" ]]; then
+		printf 'ERROR: could not extract _check_required_pr_checks_passing_fallback from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$pr_checks_fallback_src"
+
 	local rulesets_src
 	rulesets_src=$(awk '
 		/^_required_contexts_from_rulesets_for_default_branch\(\) \{/,/^}$/ { print }
@@ -314,6 +343,19 @@ assert_function_returns() {
 	local label="$2"
 	local actual_rc=0
 	_pr_required_checks_pass "19023" "marcusquinn/aidevops" || actual_rc=$?
+	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Expected rc=$expected_rc, got rc=$actual_rc"
+	fi
+	return 0
+}
+
+assert_passing_check_returns() {
+	local expected_rc="$1"
+	local label="$2"
+	local actual_rc=0
+	_check_required_checks_passing "marcusquinn/aidevops" "19023" || actual_rc=$?
 	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
 		print_result "$label" 0
 	else
@@ -423,6 +465,19 @@ test_empty_required_set_allows_merge() {
 	return 0
 }
 
+test_empty_required_pending_fallback_blocks_ready_merge() {
+	# GH#24311: branch/ruleset APIs can expose no contexts while GitHub's
+	# PR-level required-check view still has pending required checks. The strict
+	# passing gate must not count such a PR as merge-ready / zero-progress-eligible.
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="empty_required_pending_fallback"
+	assert_passing_check_returns 1 "empty branch contexts + pending PR required check → strict passing gate blocks"
+	assert_log_contains "PR-level required checks are not passing" \
+		"empty_required_pending_fallback: fallback skip reason logged"
+	return 0
+}
+
 test_pending_required_blocks_merge() {
 	# t3567 semantics: pending required checks are not terminal failures, so the
 	# CI repair/close/requeue gate must not fire while GitHub is still running CI.
@@ -495,6 +550,7 @@ main() {
 	test_required_cancel_blocks_merge
 	test_required_action_required_is_non_terminal
 	test_empty_required_set_allows_merge
+	test_empty_required_pending_fallback_blocks_ready_merge
 	test_pending_required_blocks_merge
 	test_queued_required_is_non_terminal
 	test_expected_required_is_non_terminal

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -273,9 +273,9 @@ define_function_under_test() {
 	local pr_checks_fallback_src
 	pr_checks_fallback_src=$(awk '
 		/^_check_required_pr_checks_passing_fallback\(\) \{/,/^}$/ { print }
-	' "$MERGE_SCRIPT")
+	' "$REQUIRED_CHECKS_SCRIPT")
 	if [[ -z "$pr_checks_fallback_src" ]]; then
-		printf 'ERROR: could not extract _check_required_pr_checks_passing_fallback from %s\n' "$MERGE_SCRIPT" >&2
+		printf 'ERROR: could not extract _check_required_pr_checks_passing_fallback from %s\n' "$REQUIRED_CHECKS_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090  # dynamic source from extracted helper


### PR DESCRIPTION
## Summary

Added a PR-level required-check fallback so strict merge-readiness/zero-progress counting does not treat pending required checks as eligible when branch protection and repo ruleset APIs expose no contexts.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; ran shellcheck on modified scripts; ran .agents/scripts/linters-local.sh; verified pulse_merge_zero_progress_cycles is 0 and PR #24309 merged after checks passed.

Resolves #24311


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 10m and 127,132 tokens on this as a headless worker.