### PR TITLE
GH#24313: fix merge-stuck legacy status detection

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -118,9 +118,9 @@ readonly _PMS_GAUGE_ZERO_PROGRESS_CYCLES='pulse_merge_zero_progress_cycles'
 readonly _PMS_JQ_NULL_GUARD="null"
 readonly _PMS_RUNNER_SATURATION_MARKER_TEXT="merge-stuck:runner-queue-saturation"
 # jq filter snippet that selects normalized REST check entries with a failing
-# conclusion/status. Extracted so the upcase predicate is defined exactly once
+# conclusion/state. Extracted so the upcase predicate is defined exactly once
 # and reused across classification, fingerprinting, and escalation guidance.
-readonly _PMS_JQ_REST_FAILURE_SELECTOR='def _ueq(f;v): (f // "" | ascii_upcase) == v; select(_ueq(.conclusion; "FAILURE") or _ueq(.conclusion; "TIMED_OUT") or _ueq(.conclusion; "CANCELLED") or _ueq(.status; "FAILURE"))'
+readonly _PMS_JQ_REST_FAILURE_SELECTOR='def _ueq(f;v): (f // "" | ascii_upcase) == v; select(_ueq(.conclusion; "FAILURE") or _ueq(.conclusion; "TIMED_OUT") or _ueq(.conclusion; "CANCELLED") or _ueq(.state; "FAILURE") or _ueq(.status; "FAILURE"))'
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -418,7 +418,7 @@ _escalate_individual_stuck_pr() {
 
 	# Fetch failing check names for the worker-ready guidance via REST check-runs
 	# to avoid GraphQL statusCheckRollup polling in every pulse cycle.
-	local failing_checks head_sha runs_json
+	local failing_checks="" head_sha="" runs_json=""
 	head_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || head_sha=""
 	runs_json=$(_pms_check_runs_for_head "$repo_slug" "$head_sha")

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -427,6 +427,8 @@ gh_pr_view() {
 	201) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-queued"}' ;;
 	202) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-failing"}' ;;
 	203) printf 'sha-failing' ;;
+	204) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-legacy-failing"}' ;;
+	205) printf 'sha-legacy-failing' ;;
 	*) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean"}' ;;
 	esac
 	return 0
@@ -439,6 +441,7 @@ gh_pr_check_runs_rest() {
 	case "$head_sha" in
 	sha-queued) printf '[{"name":"Build","conclusion":null,"status":"queued"}]' ;;
 	sha-failing) printf '[{"name":"Format","conclusion":"failure","status":"completed"},{"name":"Lint","conclusion":"timed_out","status":"completed"}]' ;;
+	sha-legacy-failing) printf '[{"context":"legacy-ci","state":"failure"}]' ;;
 	*) printf '[]' ;;
 	esac
 	return 0
@@ -469,6 +472,14 @@ assert_eq "7b: REST check-run failure classifies as checks failing" \
 got=$(_pms_failure_fingerprint "203" "example/repo")
 assert_eq "7c: failure fingerprint comes from REST check-runs" \
 	"Format,Lint" "$got"
+
+got=$(_classify_stuck_pr "204" "example/repo" "0")
+assert_eq "7d: legacy status context state=failure classifies as checks failing" \
+	"STUCK_CHECKS_FAILING" "$got"
+
+got=$(_pms_failure_fingerprint "205" "example/repo")
+assert_eq "7e: legacy status context fingerprint uses context name" \
+	"legacy-ci" "$got"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix the merge-stuck REST failure selector so legacy status contexts with `state=failure` are treated as failing checks.
- Initialize the flagged multi-var local declaration in `.agents/scripts/pulse-merge-stuck.sh` to satisfy set -u safety.
- Add regression coverage for legacy status classification and fingerprinting.

## Context
Follow-up to PR #24309 review/check findings. The REST check-run migration handled check-run `conclusion` values but could miss legacy commit status contexts that expose `state=failure`.

Resolves #24313

## Files
- `.agents/scripts/pulse-merge-stuck.sh`
- `.agents/scripts/tests/test-pulse-merge-stuck.sh`

## Verification
- `.agents/scripts/tests/test-pulse-merge-stuck.sh` → 42 tests, 0 failures
- `shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh .agents/scripts/shared-gh-wrappers-checks.sh` → pass
- `.agents/scripts/pulse-unbound-var-check.sh --fix-hint` → no violations reported; printed remediation hint only
- pre-commit hooks → pass

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 18h 24m and 2,505,294 tokens on this with the user in an interactive session.
