### PR TITLE
GH#24315: detect legacy status error states

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -120,7 +120,7 @@ readonly _PMS_RUNNER_SATURATION_MARKER_TEXT="merge-stuck:runner-queue-saturation
 # jq filter snippet that selects normalized REST check entries with a failing
 # conclusion/state. Extracted so the upcase predicate is defined exactly once
 # and reused across classification, fingerprinting, and escalation guidance.
-readonly _PMS_JQ_REST_FAILURE_SELECTOR='def _ueq(f;v): (f // "" | ascii_upcase) == v; select(_ueq(.conclusion; "FAILURE") or _ueq(.conclusion; "TIMED_OUT") or _ueq(.conclusion; "CANCELLED") or _ueq(.state; "FAILURE") or _ueq(.status; "FAILURE"))'
+readonly _PMS_JQ_REST_FAILURE_SELECTOR='def _ueq(f;v): (f // "" | ascii_upcase) == v; select(_ueq(.conclusion; "FAILURE") or _ueq(.conclusion; "TIMED_OUT") or _ueq(.conclusion; "CANCELLED") or _ueq(.state; "FAILURE") or _ueq(.state; "ERROR") or _ueq(.status; "FAILURE"))'
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -429,6 +429,8 @@ gh_pr_view() {
 	203) printf 'sha-failing' ;;
 	204) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-legacy-failing"}' ;;
 	205) printf 'sha-legacy-failing' ;;
+	206) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-legacy-error"}' ;;
+	207) printf 'sha-legacy-error' ;;
 	*) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean"}' ;;
 	esac
 	return 0
@@ -442,6 +444,7 @@ gh_pr_check_runs_rest() {
 	sha-queued) printf '[{"name":"Build","conclusion":null,"status":"queued"}]' ;;
 	sha-failing) printf '[{"name":"Format","conclusion":"failure","status":"completed"},{"name":"Lint","conclusion":"timed_out","status":"completed"}]' ;;
 	sha-legacy-failing) printf '[{"context":"legacy-ci","state":"failure"}]' ;;
+	sha-legacy-error) printf '[{"context":"legacy-error","state":"error"}]' ;;
 	*) printf '[]' ;;
 	esac
 	return 0
@@ -480,6 +483,14 @@ assert_eq "7d: legacy status context state=failure classifies as checks failing"
 got=$(_pms_failure_fingerprint "205" "example/repo")
 assert_eq "7e: legacy status context fingerprint uses context name" \
 	"legacy-ci" "$got"
+
+got=$(_classify_stuck_pr "206" "example/repo" "0")
+assert_eq "7f: legacy status context state=error classifies as checks failing" \
+	"STUCK_CHECKS_FAILING" "$got"
+
+got=$(_pms_failure_fingerprint "207" "example/repo")
+assert_eq "7g: legacy error status context fingerprint uses context name" \
+	"legacy-error" "$got"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treat legacy commit status contexts with `state=error` as failing checks in the merge-stuck REST selector.
- Add regression coverage for classification and fingerprinting of legacy `state=error` statuses.

## Context
Follow-up to review feedback on PR #24314. Legacy commit statuses can expose terminal failure via `state=error`, so the selector should classify both `state=failure` and `state=error` as failing.

Resolves #24315

## Files
- `.agents/scripts/pulse-merge-stuck.sh`
- `.agents/scripts/tests/test-pulse-merge-stuck.sh`

## Verification
- `.agents/scripts/tests/test-pulse-merge-stuck.sh` → 44 tests, 0 failures
- `shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh .agents/scripts/shared-gh-wrappers-checks.sh` → pass
- `.agents/scripts/pulse-unbound-var-check.sh --fix-hint` → no violations reported; printed remediation hint only
- pre-commit hooks → pass

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 18h 43m and 2,609,559 tokens on this with the user in an interactive session.
