### PR TITLE
GH#24320: handle pending PR required checks fallback

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -21,7 +21,12 @@ _check_required_pr_checks_passing_fallback() {
 	local pr_number="$2"
 
 	local checks_json=""
-	checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null) || return 2
+	local checks_exit=0
+	checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null)
+	checks_exit=$?
+	if [[ $checks_exit -ne 0 && -z "$checks_json" ]]; then
+		return 2
+	fi
 	if [[ -z "$checks_json" || "$checks_json" == "null" || "$checks_json" == "[]" ]]; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -156,7 +156,7 @@ if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
 			{"name":"ShellCheck (macos-latest)","state":"PENDING","bucket":"pending"},
 			{"name":"maintainer-gate","state":"SUCCESS","bucket":"pass"}
 		]' "$@"
-		exit 0
+		exit 2
 		;;
 	*)
 		apply_jq '[]' "$@"


### PR DESCRIPTION
## Summary

Made the PR required-check fallback consume gh pr checks JSON even when GitHub CLI exits non-zero for pending required checks, and updated the test mock to exit 2 for pending checks.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh,.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; .agents/scripts/linters-local.sh (passes; existing advisory ratchet/complexity warnings reported)

Resolves #24320


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 7m and 85,040 tokens on this as a headless worker.