### PR TITLE
GH#24322: use jq any for supervisor labels

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -310,7 +310,7 @@ _dashboard_issue_is_supervisor() {
 	local issue_json="$1"
 	printf '%s\n' "$issue_json" | jq -e '
 		((.title // "") | startswith("[Supervisor:"))
-		or (((.labels // []) | map(.name // .) | index("supervisor")) != null)
+		or any((.labels // [])[]; (.name // .) == "supervisor")
 	' >/dev/null 2>&1
 	return $?
 }


### PR DESCRIPTION
## Summary

Updated dashboard freshness supervisor detection to use jq any() when checking labels, addressing the review follow-up from PR #24310.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dashboard-freshness-check.sh; .agents/scripts/tests/test-dashboard-freshness-check.sh; shellcheck .agents/scripts/tests/test-dashboard-freshness-check.sh

Resolves #24322


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2m and 35,769 tokens on this as a headless worker.