### PR TITLE
GH#24324: allow release title delimiters

### DIFF
--- a/.agents/scripts/tests/test-version-manager-headless-guard.sh
+++ b/.agents/scripts/tests/test-version-manager-headless-guard.sh
@@ -152,6 +152,46 @@ else
 fi
 
 reset_guard_env
+export WORKER_SESSION_TITLE='release-3.20.6'
+rc=0
+_version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'release context accepts hyphenated title prefix match' 0
+else
+	print_result 'release context accepts hyphenated title prefix match' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export WORKER_SESSION_TITLE='release/3.20.6'
+rc=0
+_version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'release context accepts slash title prefix match' 0
+else
+	print_result 'release context accepts slash title prefix match' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export WORKER_SESSION_TITLE='release: 3.20.6'
+rc=0
+_version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result 'release context accepts colon title prefix match' 0
+else
+	print_result 'release context accepts colon title prefix match' 1 "rc=$rc"
+fi
+
+reset_guard_env
+export WORKER_SESSION_TITLE='releasecandidate cleanup'
+rc=0
+_version_manager_has_approved_release_context >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result 'release context denies alphanumeric title prefix match' 0
+else
+	print_result 'release context denies alphanumeric title prefix match' 1 "rc=$rc"
+fi
+
+reset_guard_env
 export AIDEVOPS_HEADLESS=1 WORKER_ISSUE_NUMBER=24089 WORKER_SESSION_KEY='issue-24089' AIDEVOPS_SESSION_TITLE='ordinary issue mentioning release cleanup'
 rc=0
 _version_manager_guard_headless_release_scope bump >/dev/null 2>&1 || rc=$?

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -77,7 +77,7 @@ _version_manager_has_approved_release_context() {
 	[[ "${AIDEVOPS_TASK_SCOPE:-}" == "$_VERSION_MANAGER_ACTION_RELEASE" ]] && return 0
 	[[ "$branch_name" == release/* || "$branch_name" == hotfix/* ]] && return 0
 	[[ "$session_key_lower" == release-* || "$session_key_lower" == hotfix-* ]] && return 0
-	[[ "$session_title_lower" == release || "$session_title_lower" == release\ * ]] && return 0
+	[[ "$session_title_lower" == release || "$session_title_lower" == release[![:alnum:]]* ]] && return 0
 	return 1
 }
 


### PR DESCRIPTION
## Summary

Allow approved release session titles to use non-alphanumeric delimiters such as hyphen, slash, and colon while still rejecting broad substring and alphanumeric prefix matches.

## Files Changed

.agents/scripts/tests/test-version-manager-headless-guard.sh,.agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-version-manager-headless-guard.sh; .agents/scripts/tests/test-version-manager-headless-guard.sh

Resolves #24324


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 3m and 41,370 tokens on this as a headless worker.