### PR TITLE
GH#24336: fix: use optional jq label iterator

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -310,7 +310,7 @@ _dashboard_issue_is_supervisor() {
 	local issue_json="$1"
 	printf '%s\n' "$issue_json" | jq -e '
 		((.title // "") | startswith("[Supervisor:"))
-		or any((.labels // [])[]; (.name // .) == "supervisor")
+		or any(.labels[]?; (.name // .) == "supervisor")
 	' >/dev/null 2>&1
 	return $?
 }


### PR DESCRIPTION
## Summary

Updated the supervisor dashboard issue jq predicate to iterate labels with .labels[]? instead of wrapping labels with an empty-array fallback.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dashboard-freshness-check.sh; .agents/scripts/linters-local.sh (passes; advisory pre-existing complexity warnings reported by the linter)

Resolves #24336


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 35,818 tokens on this as a headless worker.