### PR TITLE
GH#24340: test: harden action prompt section assertion

### DIFF
--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -109,12 +109,27 @@ test_render_markdown_fixture() {
 	assert_contains "$_out" "class=\"accordion action-prompt\"" "Markdown render includes action prompt accordions"
 	if python3 - "$_out" <<'PYHTML'
 from pathlib import Path
-import re
 import sys
 
-text = Path(sys.argv[1]).read_text()
-match = re.search(r'<section class="(?:action-line|action-panel)"[^>]*>(.*?)</section>', text, re.S)
-raise SystemExit(0 if match and 'class="accordion action-prompt"' in match.group(1) else 1)
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+sections = []
+start = 0
+while True:
+    start_idx = text.find("<section", start)
+    if start_idx == -1:
+        break
+    end_tag_idx = text.find(">", start_idx)
+    if end_tag_idx == -1:
+        break
+    end_idx = text.find("</section>", end_tag_idx)
+    if end_idx == -1:
+        break
+    tag_header = text[start_idx:end_tag_idx]
+    if 'class="action-line"' in tag_header or 'class="action-panel"' in tag_header:
+        sections.append(text[end_tag_idx + 1:end_idx])
+    start = end_idx + len("</section>")
+
+raise SystemExit(0 if any('class="accordion action-prompt"' in section for section in sections) else 1)
 PYHTML
 	then
 		print_result "Markdown render places action prompts inside action sections" 0


### PR DESCRIPTION
## Summary

Replaced the action prompt section assertion with fixed-string section scanning so it checks every action section and avoids regex tag extraction.

## Files Changed

- `.agents/scripts/tests/test-report-render-helper.sh`

## Runtime Testing

- `shellcheck .agents/scripts/tests/test-report-render-helper.sh`
- `bash .agents/scripts/tests/test-report-render-helper.sh` (modified action prompt assertion passes; existing `Markdown table treats single-dash separator as separator` failure remains outside this change)

Resolves #24340

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.6 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 53,068 tokens on this as a headless worker.