### PR TITLE
GH#24354: fix: clarify headless framework paths

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -654,9 +654,10 @@ Setup shortcuts -- the dispatcher has already done these for you:
   is already set by the dispatcher with the issue marker first (for example,
   `Issue #123: succinct description`).
 
-Key file paths (use these directly, do NOT search for them):
-- Full-loop workflow: .agents/scripts/commands/full-loop.md
-- All agent scripts live under .agents/scripts/ (not scripts/ at root)
+Key framework file paths (use these directly, do NOT search for them):
+- Normal project repos: full-loop workflow is deployed at ~/.aidevops/agents/scripts/commands/full-loop.md
+- Normal project repos: aidevops framework scripts live under ~/.aidevops/agents/scripts/ (not project-local .agents/scripts/)
+- Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and .agents/scripts/
 
 Implementation approach:
 1. Read the issue body FIRST (gh issue view $WORKER_ISSUE_NUMBER). Look for a "Worker Guidance" or "How" section -- it contains the files to modify, reference patterns, and verification commands. Follow these directly when present.

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -106,6 +106,25 @@ test_non_full_loop_prompt_unchanged() {
 	return 0
 }
 
+test_headless_contract_uses_deployed_framework_paths() {
+	local prompt='/full-loop Implement issue #24354'
+	local output
+	output=$(append_worker_headless_contract "$prompt")
+
+	if [[ "$output" == *'Normal project repos: full-loop workflow is deployed at ~/.aidevops/agents/scripts/commands/full-loop.md'* ]] &&
+		[[ "$output" == *'Normal project repos: aidevops framework scripts live under ~/.aidevops/agents/scripts/ (not project-local .agents/scripts/)'* ]] &&
+		[[ "$output" == *'Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and .agents/scripts/'* ]] &&
+		[[ "$output" != *'- Full-loop workflow: .agents/scripts/commands/full-loop.md'* ]] &&
+		[[ "$output" != *'- All agent scripts live under .agents/scripts/ (not scripts/ at root)'* ]]; then
+		print_result "headless contract uses deployed framework paths for project repos" 0
+		return 0
+	fi
+
+	print_result "headless contract uses deployed framework paths for project repos" 1 \
+		"Output still contains ambiguous source-repo framework path guidance"
+	return 0
+}
+
 test_parse_initial_model_does_not_set_explicit_override() {
 	local role="worker" session_key="issue-22862" work_dir="$TEST_ROOT" title="Issue #22862" prompt="/full-loop test" prompt_file=""
 	local model_override="" initial_model="" tier_override="" variant_override="" agent_name="" headless_runtime="" detach=0
@@ -1713,6 +1732,7 @@ main() {
 	setup_test_env
 	test_appends_escalation_contract
 	test_non_full_loop_prompt_unchanged
+	test_headless_contract_uses_deployed_framework_paths
 	test_parse_initial_model_does_not_set_explicit_override
 	test_startup_no_activity_timeout_returns_watchdog_continue
 	test_sigkill_with_activity_attempts_continuation


### PR DESCRIPTION
## Summary

Updated the headless continuation contract to distinguish normal project repositories from the aidevops source repository, pointing project workers at the deployed ~/.aidevops framework command/script paths while keeping source-repo edit paths scoped explicitly. Added a regression test that rejects the previous unconditional .agents/scripts guidance.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24354


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.6 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 47,329 tokens on this as a headless worker.