### PR TITLE
GH#24356: fix: block maintainer gate bypasses

### DIFF
--- a/.agents/scripts/commands/dispatch-issue.md
+++ b/.agents/scripts/commands/dispatch-issue.md
@@ -32,6 +32,9 @@ helper deliberately does not.
      `slug` from `~/.config/aidevops/repos.json`.
 2. Pre-flight (always, even with `--dry-run`):
    - Issue must exist + be `OPEN`.
+   - Reject `needs-maintainer-review` issues; use
+     `sudo aidevops approve issue <issue_number> <owner/repo>` or record an
+     equivalent maintainer decision before any manual worker dispatch.
    - Reject `parent-task` issues with a clear "use a phase child" message.
 3. Dedup pre-check via `dispatch-dedup-helper.sh is-assigned`.
    - Exit 0 (active claim) → real dispatch blocks, exit 0 with explanation.

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -178,6 +178,27 @@ _dsi_guard_no_interactive_hold() {
 }
 
 #######################################
+# Block manual worker dispatch until maintainer-review trust gates are cleared.
+# Args: $1 - labels CSV, $2 - issue number, $3 - owner/repo slug
+# Returns: 0 when safe, 1 when maintainer review is still required
+#######################################
+_dsi_guard_no_maintainer_review_required() {
+	local labels_csv="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local labels_with_commas=",${labels_csv},"
+
+	#aidevops:trust-boundary -- manual dispatch must not bypass signed/maintainer issue approval.
+	if [[ "$labels_with_commas" == *",needs-maintainer-review,"* ]]; then
+		_dsi_err "Issue #${issue_number} in ${repo_slug} still requires maintainer review; refusing manual worker dispatch"
+		_dsi_info "  Required action: run 'sudo aidevops approve issue ${issue_number} ${repo_slug}' or record an equivalent maintainer decision before dispatch."
+		return 1
+	fi
+
+	return 0
+}
+
+#######################################
 # Check parent-task gate. parent-task is always a hard block (never single-dispatch).
 # Args: $1 - labels CSV (from _dsi_load_issue_meta)
 # Returns: 0 not parent-task, 1 IS parent-task (block)
@@ -982,6 +1003,7 @@ cmd_dispatch() {
 		return 1
 	fi
 	_dsi_guard_no_interactive_hold "$_DSI_ISSUE_LABELS" || return 1
+	_dsi_guard_no_maintainer_review_required "$_DSI_ISSUE_LABELS" "$issue_number" "$repo_slug" || return 1
 	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
 
 	# Step 3: dedup check (informational under --dry-run, blocking otherwise).

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -186,7 +186,8 @@ _dsi_guard_no_maintainer_review_required() {
 	local labels_csv="$1"
 	local issue_number="$2"
 	local repo_slug="$3"
-	local labels_with_commas=",${labels_csv},"
+	local labels_with_commas=""
+	labels_with_commas=$(printf ',%s,' "$labels_csv")
 
 	#aidevops:trust-boundary -- manual dispatch must not bypass signed/maintainer issue approval.
 	if [[ "$labels_with_commas" == *",needs-maintainer-review,"* ]]; then

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -133,6 +133,73 @@ _merge_output_is_graphql_rate_limit() {
 	return $?
 }
 
+_merge_linked_issue_numbers() {
+	local pr_number="$1"
+	local repo="$2"
+	local issue_numbers=""
+
+	issue_numbers=$(gh pr view "$pr_number" --repo "$repo" \
+		--json closingIssuesReferences --jq '.closingIssuesReferences[]?.number' 2>/dev/null) || return 1
+
+	if [[ -z "$issue_numbers" ]]; then
+		issue_numbers=$(gh pr view "$pr_number" --repo "$repo" --json body \
+			--jq '.body // ""' 2>/dev/null |
+			grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
+			grep -oE '[0-9]+' || true)
+	fi
+
+	printf '%s\n' "$issue_numbers" | grep -E '^[0-9]+$' | sort -u || true
+	return 0
+}
+
+_merge_issue_requires_maintainer_review() {
+	local issue_number="$1"
+	local repo="$2"
+	local labels_csv=""
+
+	labels_csv=$(gh issue view "$issue_number" --repo "$repo" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 2
+	if [[ ",${labels_csv}," == *",needs-maintainer-review,"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_merge_guard_admin_merge_maintainer_review() {
+	local pr_number="$1"
+	local repo="$2"
+	local issue_numbers=""
+	local issue_number=""
+	local blocked_issues=""
+	local verify_rc=0
+
+	issue_numbers=$(_merge_linked_issue_numbers "$pr_number" "$repo") || {
+		print_error "Admin merge blocked: unable to verify linked issues for PR #${pr_number}; refusing to override branch protection"
+		return 1
+	}
+
+	while IFS= read -r issue_number; do
+		[[ -n "$issue_number" ]] || continue
+		verify_rc=0
+		_merge_issue_requires_maintainer_review "$issue_number" "$repo" || verify_rc=$?
+		if [[ "$verify_rc" -eq 0 ]]; then
+			blocked_issues+=" #${issue_number}"
+		elif [[ "$verify_rc" -ne 1 ]]; then
+			print_error "Admin merge blocked: unable to verify maintainer-review labels on issue #${issue_number}"
+			return 1
+		fi
+	done <<<"$issue_numbers"
+
+	#aidevops:trust-boundary -- admin merge must not bypass signed/maintainer issue approval.
+	if [[ -n "$blocked_issues" ]]; then
+		print_error "Admin merge blocked: linked issue(s)${blocked_issues} still require maintainer review"
+		print_info "Required action: run 'sudo aidevops approve issue <issue_number> ${repo}' or record an equivalent maintainer decision before merging."
+		return 1
+	fi
+
+	return 0
+}
+
 _merge_fetch_head_sha_rest() {
 	local pr_number="$1"
 	local repo="$2"
@@ -220,6 +287,9 @@ _merge_execute() {
 	local merge_flags=()
 	[[ "$has_admin" -eq 1 ]] && merge_flags+=("--admin")
 	[[ "$has_auto" -eq 1 ]] && merge_flags+=("--auto")
+	if [[ "$has_admin" -eq 1 ]]; then
+		_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" || return 1
+	fi
 
 	local merge_desc="$merge_method"
 	[[ ${#merge_flags[@]} -gt 0 ]] && merge_desc+=" ${merge_flags[*]}"
@@ -254,6 +324,7 @@ _merge_execute() {
 		# Only fall back to --admin when caller passed neither --admin nor --auto.
 		elif [[ $has_admin -eq 0 && $has_auto -eq 0 ]] &&
 			printf '%s' "$_merge_out" | grep -qE 'base branch policy prohibits|Required status checks? (is|are) expected|At least [0-9]+ approving review'; then
+			_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" || return 1
 			print_info "Branch protection blocked plain merge; retrying with --admin (workers share the maintainer's gh auth per GH#18538)..."
 			if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin 2>&1; then
 				print_success "PR #${pr_number} merged with --admin fallback"

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -33,6 +33,7 @@ SET_ORIGIN_LABEL_LOG=""
 REGISTER_WORKTREE_LOG=""
 MOCK_WORKTREE_HELPER_LOG=""
 MOCK_GH_ISSUE_STATE="OPEN"
+MOCK_GH_LABELS_JSON="[]"
 MOCK_GH_FAIL="0"
 MOCK_GH_TARGET_IS_PR="0"
 MOCK_PS_LINES=""
@@ -161,8 +162,8 @@ gh() {
 	fi
 
 	if [[ "$gh_subcommand" == "issue" && "$gh_resource" == "view" ]]; then
-		printf '{"number":%s,"title":"Mock issue","state":"%s","labels":[],"assignees":[],"url":"https://example.invalid/issues/%s"}\n' \
-			"$3" "$MOCK_GH_ISSUE_STATE" "$3"
+		printf '{"number":%s,"title":"Mock issue","state":"%s","labels":%s,"assignees":[],"url":"https://example.invalid/issues/%s"}\n' \
+			"$3" "$MOCK_GH_ISSUE_STATE" "$MOCK_GH_LABELS_JSON" "$3"
 		return 0
 	fi
 
@@ -570,6 +571,37 @@ test_interactive_hold_guard_allows_auto_dispatch_handoff() {
 	return 0
 }
 
+test_maintainer_review_guard_blocks_manual_dispatch() {
+	local rc=0
+	local out=""
+	out=$(_dsi_guard_no_maintainer_review_required "bug,needs-maintainer-review" 24354 owner/repo 2>&1) || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 && "$out" == *"requires maintainer review"* && "$out" == *"sudo aidevops approve issue 24354 owner/repo"* ]] && check=0
+	print_result "maintainer-review guard blocks manual dispatch" "$check" "rc=$rc output=$out"
+	return 0
+}
+
+test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup() {
+	MOCK_GH_FAIL="0"
+	MOCK_GH_TARGET_IS_PR="0"
+	MOCK_GH_ISSUE_STATE="OPEN"
+	MOCK_GH_LABELS_JSON='[{"name":"needs-maintainer-review"}]'
+
+	local original_dedup_helper="$_DSI_DEDUP_HELPER"
+	_DSI_DEDUP_HELPER="/path/that/must/not/be/called"
+	local out="" rc=0
+	out=$(cmd_dispatch 123 owner/repo --dry-run 2>&1) || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 && "$out" == *"requires maintainer review"* && "$out" != *"must/not/be/called"* ]] && check=0
+	print_result "dispatch command blocks needs-maintainer-review before dedup" "$check" "rc=$rc output=$out"
+
+	_DSI_DEDUP_HELPER="$original_dedup_helper"
+	MOCK_GH_LABELS_JSON="[]"
+	return 0
+}
+
 test_launch_worker_forwards_agent() {
 	local failed=1
 	if grep -Fq "cmd+=(--agent \"\$agent_name\")" "$HELPER_PATH"; then
@@ -825,6 +857,8 @@ _run_tests() {
 	test_interactive_hold_guard_blocks_review_label
 	test_interactive_hold_guard_blocks_origin_interactive_without_handoff
 	test_interactive_hold_guard_allows_auto_dispatch_handoff
+	test_maintainer_review_guard_blocks_manual_dispatch
+	test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -81,6 +81,7 @@ teardown_test_env() {
 #   $3 = "other-error" — merge fails with non-branch-protection error
 #   $4 = "graphql-rate-limit" — gh pr merge fails with GraphQL quota, REST succeeds
 #   $5 = "graphql-rate-limit-rest-fail" — gh pr merge fails with GraphQL quota, REST fails
+#   $6 = "fallback-nmr" — branch protection fails, but linked issue still needs maintainer review
 create_gh_stub() {
 	local mode="$1"
 
@@ -100,7 +101,7 @@ if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
 		fi
 	done
 
-	if [[ "$mode" == "fallback" ]]; then
+	if [[ "$mode" == "fallback" || "$mode" == "fallback-nmr" ]]; then
 		if [[ "\$_gh_has_admin" -eq 1 ]]; then
 			echo "Merged PR"
 			exit 0
@@ -121,11 +122,28 @@ if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
 fi
 
 if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
+	if [[ "\$*" == *"--json closingIssuesReferences"* ]]; then
+		if [[ "$mode" == "fallback-nmr" ]]; then
+			echo '24354'
+		else
+			echo ''
+		fi
+		exit 0
+	fi
 	if [[ "\$*" == *"--json body"* ]]; then
 		echo 'Resolves #22621'
 		exit 0
 	fi
 	echo '{}'
+	exit 0
+fi
+
+if [[ "\$_gh_cmd" == "issue" && "\$_gh_sub" == "view" ]]; then
+	if [[ "$mode" == "fallback-nmr" ]]; then
+		echo 'needs-maintainer-review'
+	else
+		echo ''
+	fi
 	exit 0
 fi
 
@@ -266,6 +284,34 @@ test_admin_fallback_signals() {
 		fi
 	fi
 	print_result "admin fallback: admin-merge label applied" "$((1 - label_applied))"
+
+	return 0
+}
+
+# Test 2b: Admin fallback refuses to bypass a linked issue still needing maintainer review.
+test_admin_fallback_blocks_needs_maintainer_review_issue() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "fallback-nmr"
+
+	local exit_code=0
+	local out=""
+	out=$(run_merge_execute "42" "testorg/testrepo" "--squash" "0" "0" 2>&1) || exit_code=$?
+	print_result "admin fallback: needs-maintainer-review blocks merge" "$((exit_code == 0 ? 1 : 0))" "output=$out"
+
+	local admin_called=0
+	if [[ -f "${TEST_ROOT}/logs/gh-calls.txt" ]] && grep -q -- '--admin' "${TEST_ROOT}/logs/gh-calls.txt"; then
+		admin_called=1
+	fi
+	print_result "admin fallback: blocked before --admin retry" "$admin_called"
+
+	local signaled=0
+	if [[ -f "${TEST_ROOT}/logs/pr-comments.txt" ]] ||
+		[[ -f "${TEST_ROOT}/logs/audit-log-calls.txt" ]] ||
+		[[ -f "${TEST_ROOT}/logs/pr-edits.txt" ]]; then
+		signaled=1
+	fi
+	print_result "admin fallback: no success signaling when maintainer gate blocks" "$signaled"
 
 	return 0
 }
@@ -424,6 +470,7 @@ main() {
 	echo ""
 
 	test_admin_fallback_signals
+	test_admin_fallback_blocks_needs_maintainer_review_issue
 	test_explicit_admin_no_signaling
 	test_other_error_no_fallback
 	test_graphql_rate_limit_rest_fallback


### PR DESCRIPTION
## Summary

Blocked manual single-issue dispatch when a target still has needs-maintainer-review, and blocked full-loop --admin merge fallback/explicit admin merge when linked issues still require maintainer review.

## Files Changed

.agents/scripts/commands/dispatch-issue.md,.agents/scripts/dispatch-single-issue-helper.sh,.agents/scripts/full-loop-helper-merge.sh,.agents/scripts/tests/test-dispatch-single-issue-helper.sh,.agents/scripts/tests/test-full-loop-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/full-loop-helper-merge.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh .agents/scripts/tests/test-full-loop-merge.sh; bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh; bash .agents/scripts/tests/test-full-loop-merge.sh; .agents/scripts/linters-local.sh

Resolves #24356


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.6 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1h 27m and 268,695 tokens on this with the user in an interactive session.