### PR TITLE
GH#24358: fix: reuse merge PR metadata

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -136,14 +136,18 @@ _merge_output_is_graphql_rate_limit() {
 _merge_linked_issue_numbers() {
 	local pr_number="$1"
 	local repo="$2"
+	local pr_json="${3:-}"
 	local issue_numbers=""
 
-	issue_numbers=$(gh pr view "$pr_number" --repo "$repo" \
-		--json closingIssuesReferences --jq '.closingIssuesReferences[]?.number' 2>/dev/null) || return 1
+	if [[ -z "$pr_json" ]]; then
+		pr_json=$(gh pr view "$pr_number" --repo "$repo" \
+			--json closingIssuesReferences,body 2>/dev/null) || return 1
+	fi
+
+	issue_numbers=$(printf '%s' "$pr_json" | jq -r '.closingIssuesReferences[]?.number // empty') || return 1
 
 	if [[ -z "$issue_numbers" ]]; then
-		issue_numbers=$(gh pr view "$pr_number" --repo "$repo" --json body \
-			--jq '.body // ""' 2>/dev/null |
+		issue_numbers=$(printf '%s' "$pr_json" | jq -r '.body // ""' |
 			grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
 			grep -oE '[0-9]+' || true)
 	fi

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -122,6 +122,14 @@ if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
 fi
 
 if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
+	if [[ "\$*" == *"--json closingIssuesReferences,body"* ]]; then
+		if [[ "$mode" == "fallback-nmr" ]]; then
+			echo '{"closingIssuesReferences":[{"number":24354}],"body":"Resolves #22621"}'
+		else
+			echo '{"closingIssuesReferences":[],"body":"Resolves #22621"}'
+		fi
+		exit 0
+	fi
 	if [[ "\$*" == *"--json closingIssuesReferences"* ]]; then
 		if [[ "$mode" == "fallback-nmr" ]]; then
 			echo '24354'


### PR DESCRIPTION
## Summary

Refactored _merge_linked_issue_numbers to fetch closingIssuesReferences and body in one gh pr view call, with optional precomputed PR JSON support. Updated the merge test gh stub for the combined JSON request.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh,.agents/scripts/tests/test-full-loop-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/full-loop-helper-merge.sh .agents/scripts/tests/test-full-loop-merge.sh; bash .agents/scripts/tests/test-full-loop-merge.sh

Resolves #24358


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 57,113 tokens on this as a headless worker.