### PR TITLE
GH#24359: fix: clarify headless source repo paths

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -657,7 +657,7 @@ Setup shortcuts -- the dispatcher has already done these for you:
 Key framework file paths (use these directly, do NOT search for them):
 - Normal project repos: full-loop workflow is deployed at ~/.aidevops/agents/scripts/commands/full-loop.md
 - Normal project repos: aidevops framework scripts live under ~/.aidevops/agents/scripts/ (not project-local .agents/scripts/)
-- Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and .agents/scripts/
+- Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and under .agents/scripts/
 
 Implementation approach:
 1. Read the issue body FIRST (gh issue view $WORKER_ISSUE_NUMBER). Look for a "Worker Guidance" or "How" section -- it contains the files to modify, reference patterns, and verification commands. Follow these directly when present.

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -107,13 +107,16 @@ test_non_full_loop_prompt_unchanged() {
 }
 
 test_headless_contract_uses_deployed_framework_paths() {
-	local prompt='/full-loop Implement issue #24354'
+	local AIDEVOPS_HEADLESS_APPEND_CONTRACT
+	AIDEVOPS_HEADLESS_APPEND_CONTRACT=1
+	local prompt
+	prompt='/full-loop Implement issue #24354'
 	local output
 	output=$(append_worker_headless_contract "$prompt")
 
 	if [[ "$output" == *'Normal project repos: full-loop workflow is deployed at ~/.aidevops/agents/scripts/commands/full-loop.md'* ]] &&
 		[[ "$output" == *'Normal project repos: aidevops framework scripts live under ~/.aidevops/agents/scripts/ (not project-local .agents/scripts/)'* ]] &&
-		[[ "$output" == *'Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and .agents/scripts/'* ]] &&
+		[[ "$output" == *'Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and under .agents/scripts/'* ]] &&
 		[[ "$output" != *'- Full-loop workflow: .agents/scripts/commands/full-loop.md'* ]] &&
 		[[ "$output" != *'- All agent scripts live under .agents/scripts/ (not scripts/ at root)'* ]]; then
 		print_result "headless contract uses deployed framework paths for project repos" 0


### PR DESCRIPTION
## Summary

Clarified the headless contract source-repo path sentence to say files are edited under .agents/scripts, and isolated the regression test from AIDEVOPS_HEADLESS_APPEND_CONTRACT while separating local declarations from assignments.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24359


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1m and 35,476 tokens on this as a headless worker.