### PR TITLE
GH#24360: docs: harden review submission lookup

### DIFF
--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -95,7 +95,7 @@ asc versions check-readiness --version-id "$VERSION_ID"
 asc versions submit --version-id "$VERSION_ID"
 
 # If Apple returns unresolved issues, inspect the rejected submission item and linked resource
-SUBMISSION_ID=$(asc review-submissions list --app-id APP_ID | jq -r '.data[0].id')
+SUBMISSION_ID=$(asc review-submissions list --app-id APP_ID | jq -r '.data[0].id // ""')
 asc review-submissions get --submission-id "$SUBMISSION_ID" --output json
 asc review-submissions items list --submission-id "$SUBMISSION_ID" --state REJECTED --output json
 


### PR DESCRIPTION
## Summary

Updated the App Store Connect CLI review submission example to use jq's empty-string fallback when no submission id exists.

## Files Changed

.agents/tools/mobile/app-store-connect.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --no-install markdownlint-cli2 .agents/tools/mobile/app-store-connect.md (0 errors)

Resolves #24360


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 30,152 tokens on this as a headless worker.