### PR TITLE
GH#24361: test: simplify action prompt section extraction

### DIFF
--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -113,21 +113,15 @@ import sys
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 sections = []
-start = 0
-while True:
-    start_idx = text.find("<section", start)
-    if start_idx == -1:
-        break
-    end_tag_idx = text.find(">", start_idx)
-    if end_tag_idx == -1:
-        break
-    end_idx = text.find("</section>", end_tag_idx)
-    if end_idx == -1:
-        break
-    tag_header = text[start_idx:end_tag_idx]
+for part in text.split("</section>")[:-1]:
+    if "<section" not in part:
+        continue
+    section_tail = part.rsplit("<section", 1)[1]
+    if ">" not in section_tail:
+        continue
+    tag_header, section = section_tail.split(">", 1)
     if 'class="action-line"' in tag_header or 'class="action-panel"' in tag_header:
-        sections.append(text[end_tag_idx + 1:end_idx])
-    start = end_idx + len("</section>")
+        sections.append(section)
 
 raise SystemExit(0 if any('class="accordion action-prompt"' in section for section in sections) else 1)
 PYHTML


### PR DESCRIPTION
## Summary

Simplified the inline Python section extraction in .agents/scripts/tests/test-report-render-helper.sh while preserving the action-line/action-panel filter from the existing assertion.

## Files Changed

.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-report-render-helper.sh: passed. .agents/scripts/tests/test-report-render-helper.sh: targeted action-prompt assertion passed during full script run; full script currently reports an unrelated pre-existing failure for the single-dash table separator assertion.

Resolves #24361


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 68,054 tokens on this as a headless worker.