### PR TITLE
docs: deduplicate changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests: guard opencode continuation seeding (#24304)
 - surface stale dashboard refresh failures (#24265)
 - fix: quote runner health jq filters (#24297)
-- Maintenance: update simplification state registry
 - fix: normalize token worker path detection (#24280)
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Removed the duplicate `Maintenance: update simplification state registry` entry from the 3.20.6 changelog Changed section.

Resolves #24362

## Testing

- `markdownlint-cli2 CHANGELOG.md`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 54,963 tokens on this as a headless worker.
