### PR TITLE
fix: defer OpenAI model limits to OpenCode

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -12,7 +12,7 @@ import { getCursorProxyPort, registerCursorProvider } from "./cursor-proxy.mjs";
 import { getGoogleProxyPort, registerGoogleProvider } from "./google-proxy.mjs";
 import { getClaudeProxyPort, registerClaudeProvider } from "./claude-proxy.mjs";
 import { checkOpenCodeVersionDrift } from "./version-tracking.mjs";
-import { CLAUDE_MODEL_LIMITS, OPENAI_MODEL_LIMITS } from "./model-limits.mjs";
+import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
 
 /**
  * Shared model definition template for Claude models managed by aidevops.
@@ -27,25 +27,6 @@ function claudeModelDef(overrides) {
     reasoning: true,
     modalities: { input: ["text", "image"], output: ["text"] },
     cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-    ...overrides,
-  };
-}
-
-/**
- * Shared model definition template for OpenAI models whose limits aidevops
- * must override from OpenCode/provider defaults.
- * @param {object} overrides
- * @returns {object}
- */
-function openaiModelDef(overrides) {
-  return {
-    attachment: true,
-    tool_call: true,
-    temperature: true,
-    reasoning: true,
-    modalities: { input: ["text", "image"], output: ["text"] },
-    cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-    family: "openai",
     ...overrides,
   };
 }
@@ -90,13 +71,6 @@ const CLAUDECLI_MODELS = buildClaudeModelMap({
   "claude-opus-4-7":   "Claude Opus 4.7 (via CLI)",
 });
 
-const OPENAI_MODELS = Object.fromEntries(
-  Object.entries(OPENAI_MODEL_LIMITS).map(([id, limit]) => [
-    id,
-    openaiModelDef({ name: `OpenAI ${id}`, limit }),
-  ]),
-);
-
 /**
  * Upsert aidevops-managed models into the anthropic and claudecli providers.
  * Preserves any user options already set on the providers.
@@ -139,27 +113,6 @@ function registerAnthropicModels(config) {
     if (!existing) count++;
   }
 
-  return count;
-}
-
-/**
- * Upsert aidevops-managed OpenAI model limits into the built-in openai provider.
- * This preserves user provider options while correcting context metadata that
- * drives OpenCode's 80% auto-compaction threshold.
- * @param {object} config - OpenCode Config object (mutable)
- * @returns {number} number of model entries upserted
- */
-function registerOpenAIModels(config) {
-  if (!config.provider) config.provider = {};
-  if (!config.provider.openai) config.provider.openai = {};
-  if (!config.provider.openai.models) config.provider.openai.models = {};
-
-  let count = 0;
-  for (const [id, def] of Object.entries(OPENAI_MODELS)) {
-    const existing = config.provider.openai.models[id];
-    config.provider.openai.models[id] = { ...existing, ...def };
-    if (!existing) count++;
-  }
   return count;
 }
 
@@ -306,7 +259,6 @@ function logConfigSummary(counts, versionDrift) {
     [counts.agentTools, "agent tool perms"],
     [counts.poolCleaned, `cleaned ${counts.poolCleaned} stale pool provider${counts.poolCleaned === 1 ? "" : "s"}`],
     [counts.anthropic, "anthropic models"],
-    [counts.openai, "OpenAI models"],
     [counts.cursor, "Cursor models"],
     [counts.google, "Google models"],
     [counts.claude, "Claude CLI models"],
@@ -346,8 +298,6 @@ export function createConfigHook(deps) {
     const agentTools = applyAgentMcpTools(config);
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
-    const openai = registerOpenAIModels(config);
-
     // Discover and register proxy provider models only when a proxy listener is
     // already active. The normal startup path intentionally leaves these ports
     // null until first use, so unconditional imports/discovery here made config
@@ -382,7 +332,7 @@ export function createConfigHook(deps) {
     const claude = registerClaudeCliModels(config);
 
     logConfigSummary(
-      { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude },
+      { agents, mcps, agentTools, poolCleaned, anthropic, cursor, google, claude },
       checkOpenCodeVersionDrift(pluginDir),
     );
   };

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -96,34 +96,6 @@ export const CLAUDE_MODEL_LIMITS = {
   "claude-opus-4-7":   { context: resolveOpus47Context(), output: 64000 },
 };
 
-/**
- * OpenAI GPT-5.x models can report model metadata that is either stale or
- * absent from OpenCode's built-in provider list. Registering the models here
- * keeps aidevops routing-table entries selectable in OpenCode and gives
- * OpenCode a stable compaction boundary. GPT-5.5 models report a 1M API
- * context window, but Codex/OpenCode sessions are effectively bounded at 400K.
- * Current OpenCode auto-compacts at `limit.input - reserved` when `limit.input`
- * exists, and models.dev supplies a stale 272K input limit. Registering
- * input=420K preserves a 400K usable window with OpenCode's default 20K
- * reserved buffer instead of compacting near 252K.
- *
- * Compatibility note (OpenCode 1.14.33): config model parsing dropped
- * limit.input, falling back to `limit.context - maxOutputTokens(model)`. Keep
- * context at 432K so old OpenCode's 32K output cap still yields a 400K
- * compaction boundary. When deployed OpenCode versions reliably preserve
- * config `limit.input`, this patch can be commented out or removed for GPT-5.5;
- * keep the pattern for future model IDs whose provider metadata is stale.
- * GPT-5.4 mini is registered so OpenAI-backed low-cost tasks (including
- * session-title repair prompts) can select the same model aidevops already
- * routes for haiku/local tiers.
- */
-export const OPENAI_MODEL_LIMITS = {
-  "gpt-5.4-mini": { context: 200000, input: 180000, output: 64000 },
-  "gpt-5.5":      { context: 432000, input: 420000, output: 128000 },
-  "gpt-5.5-fast": { context: 432000, input: 420000, output: 128000 },
-  "gpt-5.5-pro":  { context: 432000, input: 420000, output: 128000 },
-};
-
 // One-shot warn at module load when the env override changed something.
 // Module load runs once per process (Node caches), so this won't spam.
 const _override = describeOpus47Override();

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -20,7 +20,6 @@ import {
   OPUS_47_CONTEXT_DEFAULT,
   OPUS_47_CONTEXT_MAX,
   CLAUDE_MODEL_LIMITS,
-  OPENAI_MODEL_LIMITS,
 } from "../model-limits.mjs";
 
 // ---------------------------------------------------------------------------
@@ -204,35 +203,5 @@ describe("CLAUDE_MODEL_LIMITS table", () => {
     // hard-coded limits regardless.
     assert.equal(CLAUDE_MODEL_LIMITS["claude-opus-4-6"].context, 1000000);
     assert.equal(CLAUDE_MODEL_LIMITS["claude-haiku-4-5"].context, 1000000);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// OPENAI_MODEL_LIMITS — GPT-5.5 compaction-boundary regression guard
-// ---------------------------------------------------------------------------
-
-describe("OPENAI_MODEL_LIMITS table", () => {
-  test("registers GPT-5.4 mini for low-cost OpenAI tasks", () => {
-    const limit = OPENAI_MODEL_LIMITS["gpt-5.4-mini"];
-    assert.ok(limit, "missing OpenAI limit entry for gpt-5.4-mini");
-    assert.equal(limit.context, 200000);
-    assert.equal(limit.input, 180000);
-    assert.equal(limit.input - 20000, 160000);
-    assert.equal(limit.output, 64000);
-  });
-
-  test("sets GPT-5.5 family limits to preserve a 400K OpenCode compaction boundary", () => {
-    const expected = ["gpt-5.5", "gpt-5.5-fast", "gpt-5.5-pro"];
-    for (const id of expected) {
-      assert.ok(OPENAI_MODEL_LIMITS[id], `missing OpenAI limit entry for ${id}`);
-      // OpenCode >= upstream/dev preserves config limit.input, so the modern
-      // boundary is input - reserved. OpenCode 1.14.33 dropped config
-      // limit.input, so keep context - 32K output cap at the same boundary.
-      assert.equal(OPENAI_MODEL_LIMITS[id].context, 432000);
-      assert.equal(OPENAI_MODEL_LIMITS[id].input, 420000);
-      assert.equal(OPENAI_MODEL_LIMITS[id].input - 20000, 400000);
-      assert.equal(OPENAI_MODEL_LIMITS[id].context - 32000, 400000);
-      assert.ok(OPENAI_MODEL_LIMITS[id].output > 0);
-    }
   });
 });


### PR DESCRIPTION
Resolves #24372

## Summary

- remove aidevops OpenAI model-limit registrations from the OpenCode config hook
- delete the GPT-5.4/GPT-5.5 limit table entries so OpenCode/provider metadata controls limits and auto-compaction
- keep Claude model limit handling unchanged

## Verification

- node --test .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
- node --check .agents/plugins/opencode-aidevops/config-hook.mjs
- node --check .agents/plugins/opencode-aidevops/model-limits.mjs
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 15m and 169,649 tokens on this with the user in an interactive session.