### PR TITLE
GH#24374: fix: harden gh signature repair

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -44,7 +44,7 @@
 // is the correct enforcement layer for the same-bash-call shape.
 
 import { existsSync, readFileSync, appendFileSync, realpathSync } from "fs";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { join, sep } from "path";
 import { tmpdir } from "os";
 
@@ -216,11 +216,17 @@ function _hasUnparseableBody(cmd) {
  */
 function _generateSignature(helperPath, bodyValue, log) {
   try {
-    const sig = execSync(`"${helperPath}" footer --body ${JSON.stringify(bodyValue)}`, {
+    const sig = execFileSync(helperPath, ["footer", "--no-session", "--body", bodyValue], {
       encoding: "utf-8",
-      timeout: 5000,
+      timeout: 1500,
       stdio: ["pipe", "pipe", "pipe"],
-      shell: "/bin/bash",
+      env: {
+        ...process.env,
+        AIDEVOPS_SIG_CLI: process.env.AIDEVOPS_SIG_CLI || "OpenCode",
+        AIDEVOPS_SIG_MODEL:
+          process.env.AIDEVOPS_SIG_MODEL || process.env.OPENCODE_MODEL || "openai/gpt-5.5",
+        AIDEVOPS_SIG_TOKENS: process.env.AIDEVOPS_SIG_TOKENS || "0",
+      },
     });
     if (!sig || !sig.includes(SIG_MARKER)) {
       log("WARN", "gh-signature-helper output missing marker; refusing to inject");
@@ -239,6 +245,34 @@ function _generateSignature(helperPath, bodyValue, log) {
       detail: e.message,
     };
   }
+}
+
+/**
+ * Decide whether a missing --body-file is likely created earlier in the same
+ * bash command. The OpenCode hook runs before bash executes, so this lets safe
+ * create-then-gh forms reach the PATH shim, which signs the completed file at
+ * exec time. Conservative: requires the same token before the gh write and a
+ * file-creation operator/pattern before that write.
+ * @param {string} cmd
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function _hasPriorSameCommandBodyFileCreation(cmd, filePath) {
+  if (!filePath) return false;
+  const ghWrite = cmd.search(
+    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/,
+  );
+  if (ghWrite <= 0) return false;
+  const beforeGh = cmd.slice(0, ghWrite);
+  if (!beforeGh.includes(filePath)) return false;
+  const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const quotedPath = `["']?${escaped}["']?`;
+  const creationPatterns = [
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:printf|cat|tee)\\b[\\s\\S]*(?:>|>>)\\s*${quotedPath}`),
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:cp|mv)\\b[\\s\\S]+\\s+${quotedPath}`),
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*touch\\s+${quotedPath}`),
+  ];
+  return creationPatterns.some((pattern) => pattern.test(beforeGh));
 }
 
 /**
@@ -317,6 +351,13 @@ function _repairBodyFile(cmd, filePath, helperPath, log) {
   } catch (e) {
     const reason =
       e.code === "ENOENT" ? FAIL_REASON.FILE_NOT_FOUND : FAIL_REASON.FILE_UNREADABLE;
+    if (reason === FAIL_REASON.FILE_NOT_FOUND && _hasPriorSameCommandBodyFileCreation(cmd, filePath)) {
+      log(
+        "INFO",
+        `Body-file ${filePath} appears to be created before gh in the same bash command; deferring signature injection to PATH shim`,
+      );
+      return { status: "ok", cmd };
+    }
     log("WARN", `Could not repair --body-file ${filePath}: ${e.message} (${reason})`);
     return { status: "fail", reason, detail: `${filePath}: ${e.message}` };
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -300,6 +300,40 @@ describe("tryRepairSignature", () => {
     assert.ok(fileContent.includes("unsigned content"), "original preserved");
   });
 
+  test("uses cheap no-session helper path when repairing body-file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "t24374-fast-helper-"));
+    const helper = join(dir, "gh-signature-helper.sh");
+    const argvLog = join(dir, "helper-argv.log");
+    const bodyFile = join(dir, "body.md");
+    writeFileSync(bodyFile, "unsigned content\n");
+    writeFileSync(
+      helper,
+      `#!/usr/bin/env bash
+printf '%s\n' "$*" >"${argvLog}"
+printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n'
+`,
+    );
+    chmodSync(helper, 0o755);
+    const { log } = makeLogger();
+    const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log);
+    assert.equal(out.status, "ok");
+    assert.match(readFileSync(argvLog, "utf-8"), /footer --no-session --body/);
+  });
+
+  test("allows same-command body-file creation for exec-time shim repair", () => {
+    const dir = setupStubHelper();
+    const bodyFile = join(dir, "created-later.md");
+    const { log, entries } = makeLogger();
+    const cmd = `printf 'body\\n' > ${bodyFile} && gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log);
+    assert.deepEqual(out, { status: "ok", cmd });
+    assert.ok(
+      entries.some((entry) => /deferring signature injection to PATH shim/.test(entry.msg)),
+      "same-command creation should be explicitly delegated to shim",
+    );
+  });
+
   test("is idempotent on already-signed --body-file", () => {
     const dir = setupStubHelper();
     const bodyFile = join(dir, "signed.md");


### PR DESCRIPTION
## Summary

Hardened OpenCode gh signature gate repair by using a low-cost no-session helper invocation, reducing helper timeout exposure, and deferring safe same-command body-file creation to the exec-time PATH shim for signing.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs,.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-signature-helper.sh .agents/scripts/gh; node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS -u GITHUB_ACTIONS -u AIDEVOPS_SESSION_ORIGIN bash .agents/scripts/tests/test-gh-signature-helper.sh && bash .agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh && bash .agents/scripts/tests/test-gh-shim.sh

Resolves #24374


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 4m and 109,603 tokens on this as a headless worker.