### PR TITLE
GH#24373: fix: stop stale headless model pulse warning

### DIFF
--- a/.agents/scripts/pulse-wrapper-config.sh
+++ b/.agents/scripts/pulse-wrapper-config.sh
@@ -70,18 +70,74 @@ MAX_WORKERS_CAP="${MAX_WORKERS_CAP:-$(config_get "orchestration.max_workers_cap"
 DAILY_PR_CAP="${DAILY_PR_CAP:-1000}"                                                                    # Max PRs created per repo per day (GH#3821)
 PRODUCT_RESERVATION_PCT="${PRODUCT_RESERVATION_PCT:-60}"                                                # % of worker slots reserved for product repos (t1423)
 QUALITY_DEBT_CAP_PCT="${QUALITY_DEBT_CAP_PCT:-$(config_get "orchestration.quality_debt_cap_pct" "30")}" # % cap for quality-debt dispatch share
+_pulse_legacy_model_config_files() {
+	local primary_file="${HOME}/.config/aidevops/credentials.sh"
+	local tenant_dir="${HOME}/.config/aidevops/tenants"
+	local tenant_file=""
+
+	if [[ -f "$primary_file" ]]; then
+		printf '%s\n' "$primary_file"
+	fi
+
+	if [[ -d "$tenant_dir" ]]; then
+		while IFS= read -r -d '' tenant_file; do
+			printf '%s\n' "$tenant_file"
+		done < <(find "$tenant_dir" -name "credentials.sh" -print0 2>/dev/null)
+	fi
+
+	return 0
+}
+
+_pulse_file_has_active_legacy_model_var() {
+	local file="$1"
+	local var_name="$2"
+
+	case "$var_name" in
+		PULSE_MODEL | AIDEVOPS_HEADLESS_MODELS) ;;
+		*) return 1 ;;
+	esac
+
+	[[ -f "$file" ]] || return 1
+	grep -qE "^[[:space:]]*(export[[:space:]]+)?${var_name}=" "$file" 2>/dev/null
+	return $?
+}
+
+_pulse_warn_if_legacy_model_var_from_credentials() {
+	local var_name="$1"
+	local var_value="$2"
+	local files=""
+	local config_file=""
+	local matches=""
+
+	[[ -n "$var_value" ]] || return 0
+
+	files="$(_pulse_legacy_model_config_files)"
+	while IFS= read -r config_file; do
+		[[ -n "$config_file" ]] || continue
+		if _pulse_file_has_active_legacy_model_var "$config_file" "$var_name"; then
+			if [[ -n "$matches" ]]; then
+				matches="${matches}, ${config_file}"
+			else
+				matches="$config_file"
+			fi
+		fi
+	done <<<"$files"
+
+	[[ -n "$matches" ]] || return 0
+	printf '[pulse-wrapper] WARN: %s env var is deprecated (v3.7+). Model routing is now automatic via routing table + availability checks. Remove or comment this export in: %s\n' \
+		"$var_name" "$matches" >&2
+	return 0
+}
+
 # GH#17769: PULSE_MODEL and AIDEVOPS_HEADLESS_MODELS are deprecated.
 # Model routing is now derived from the routing table at runtime and resolved
 # through model-availability-helper.sh so pulse follows the same provider
-# fallback logic as workers.
-# Backward compat: if legacy env vars are still set, log deprecation warnings.
+# fallback logic as workers. Warn only when a currently sourced user credentials
+# file still contains the active legacy setting; inherited stale process env
+# alone is not actionable and caused noisy merge-routine logs (GH#24373).
 MODEL_AVAILABILITY_HELPER="${MODEL_AVAILABILITY_HELPER:-${SCRIPT_DIR}/model-availability-helper.sh}"
-if [[ -n "${PULSE_MODEL:-}" ]]; then
-	echo "[pulse-wrapper] WARN: PULSE_MODEL env var is deprecated (v3.7+). Model routing is now automatic via routing table + availability checks. Remove this export from credentials.sh." >&2
-fi
-if [[ -n "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
-	echo "[pulse-wrapper] WARN: AIDEVOPS_HEADLESS_MODELS env var is deprecated (v3.7+). Model routing is now automatic via routing table + availability checks. Remove this export from credentials.sh." >&2
-fi
+_pulse_warn_if_legacy_model_var_from_credentials "PULSE_MODEL" "${PULSE_MODEL:-}"
+_pulse_warn_if_legacy_model_var_from_credentials "AIDEVOPS_HEADLESS_MODELS" "${AIDEVOPS_HEADLESS_MODELS:-}"
 if [[ -z "${PULSE_MODEL:-}" ]] && [[ -x "$MODEL_AVAILABILITY_HELPER" ]]; then
 	PULSE_MODEL=$("$MODEL_AVAILABILITY_HELPER" resolve sonnet --quiet 2>/dev/null || true)
 fi

--- a/.agents/scripts/tests/test-pulse-wrapper-legacy-model-warning.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-legacy-model-warning.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+PULSE_SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
+readonly TEST_SCRIPT_DIR
+readonly PULSE_SCRIPTS_DIR
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+run_config_source() {
+	local test_home="$1"
+	local stderr_file="$2"
+	local headless_models="${3:-}"
+	local pulse_model="${4:-}"
+
+	(
+		set -euo pipefail
+		export HOME="$test_home"
+		export SCRIPT_DIR="$PULSE_SCRIPTS_DIR"
+		export MODEL_AVAILABILITY_HELPER="${test_home}/missing-model-availability-helper.sh"
+		if [[ -n "$headless_models" ]]; then
+			export AIDEVOPS_HEADLESS_MODELS="$headless_models"
+		else
+			unset AIDEVOPS_HEADLESS_MODELS || true
+		fi
+		if [[ -n "$pulse_model" ]]; then
+			export PULSE_MODEL="$pulse_model"
+		else
+			unset PULSE_MODEL || true
+		fi
+
+		config_get() {
+			local key="$1"
+			local default_value="$2"
+			: "$key"
+			printf '%s\n' "$default_value"
+			return 0
+		}
+
+		_validate_int() {
+			local var_name="$1"
+			local value="$2"
+			local default_value="$3"
+			local min_value="${4:-}"
+			: "$var_name" "$min_value"
+			if [[ -n "$value" ]]; then
+				printf '%s\n' "$value"
+			else
+				printf '%s\n' "$default_value"
+			fi
+			return 0
+		}
+
+		# shellcheck source=/dev/null
+		source "${PULSE_SCRIPTS_DIR}/pulse-wrapper-config.sh" >/dev/null
+	) 2>"$stderr_file"
+	return $?
+}
+
+test_inherited_headless_models_without_credentials_export_is_quiet() {
+	local test_home
+	test_home="$(mktemp -d)"
+	local stderr_file="${test_home}/stderr.log"
+	mkdir -p "${test_home}/.config/aidevops"
+	printf '# export AIDEVOPS_HEADLESS_MODELS=old\n' >"${test_home}/.config/aidevops/credentials.sh"
+
+	run_config_source "$test_home" "$stderr_file" "openai/example" ""
+
+	if [[ -s "$stderr_file" ]]; then
+		print_result "inherited AIDEVOPS_HEADLESS_MODELS without active credentials export is quiet" 1 "stderr present"
+	else
+		print_result "inherited AIDEVOPS_HEADLESS_MODELS without active credentials export is quiet" 0
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+test_active_headless_models_credentials_export_warns_with_file() {
+	local test_home
+	test_home="$(mktemp -d)"
+	local stderr_file="${test_home}/stderr.log"
+	mkdir -p "${test_home}/.config/aidevops"
+	printf 'export AIDEVOPS_HEADLESS_MODELS=old\n' >"${test_home}/.config/aidevops/credentials.sh"
+
+	run_config_source "$test_home" "$stderr_file" "openai/example" ""
+
+	if grep -q "AIDEVOPS_HEADLESS_MODELS" "$stderr_file" && grep -q "${test_home}/.config/aidevops/credentials.sh" "$stderr_file"; then
+		print_result "active AIDEVOPS_HEADLESS_MODELS credentials export warns with file" 0
+	else
+		print_result "active AIDEVOPS_HEADLESS_MODELS credentials export warns with file" 1 "expected variable and file in warning"
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+test_active_pulse_model_assignment_warns_with_file() {
+	local test_home
+	test_home="$(mktemp -d)"
+	local stderr_file="${test_home}/stderr.log"
+	mkdir -p "${test_home}/.config/aidevops"
+	printf 'PULSE_MODEL=old\n' >"${test_home}/.config/aidevops/credentials.sh"
+
+	run_config_source "$test_home" "$stderr_file" "" "openai/example"
+
+	if grep -q "PULSE_MODEL" "$stderr_file" && grep -q "${test_home}/.config/aidevops/credentials.sh" "$stderr_file"; then
+		print_result "active PULSE_MODEL assignment warns with file" 0
+	else
+		print_result "active PULSE_MODEL assignment warns with file" 1 "expected variable and file in warning"
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+main() {
+	test_inherited_headless_models_without_credentials_export_is_quiet
+	test_active_headless_models_credentials_export_warns_with_file
+	test_active_pulse_model_assignment_warns_with_file
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -523,9 +523,10 @@ _comment_out_deprecated_model_vars() {
 	local deprecated_vars="AIDEVOPS_HEADLESS_MODELS|PULSE_MODEL"
 	local deprecation_note="# DEPRECATED by aidevops v3.7+ — model routing is now automatic (GH#17769)"
 	[[ -f "$file" ]] || return 0
-	# Only process lines that are active exports (not already commented)
-	if grep -qE "^[[:space:]]*export[[:space:]]+(${deprecated_vars})=" "$file" 2>/dev/null; then
-		sed -i.bak -E "s/^([[:space:]]*)(export[[:space:]]+(${deprecated_vars})=.*)$/\1${deprecation_note}\n\1# \2/" "$file"
+	# Only process active assignments/exports (not already commented). Some old
+	# credentials used VAR=... followed by export VAR, so clean both shapes.
+	if grep -qE "^[[:space:]]*(export[[:space:]]+)?(${deprecated_vars})=" "$file" 2>/dev/null; then
+		sed -i.bak -E "s/^([[:space:]]*)((export[[:space:]]+)?(${deprecated_vars})=.*)$/\1${deprecation_note}\n\1# \2/" "$file"
 		rm -f "${file}.bak"
 		print_info "Commented out deprecated model env vars in $(basename "$file")"
 	fi


### PR DESCRIPTION
## Summary

Pulse wrapper config now only emits deprecated PULSE_MODEL/AIDEVOPS_HEADLESS_MODELS warnings when the active legacy setting still exists in user credentials, reports the exact credentials file to clean, and setup cleanup now comments direct legacy assignments as well as export lines. Added focused regression coverage for stale inherited env noise.

## Files Changed

.agents/scripts/pulse-wrapper-config.sh,.agents/scripts/tests/test-pulse-wrapper-legacy-model-warning.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-wrapper-legacy-model-warning.sh; shellcheck .agents/scripts/pulse-wrapper-config.sh .agents/scripts/tests/test-pulse-wrapper-legacy-model-warning.sh setup.sh; isolated HOME pulse-merge-routine --dry-run simulation with cleaned credentials and inherited AIDEVOPS_HEADLESS_MODELS reported legacy_warning=absent/status=0. Also ran bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh; it still fails pre-existing stale source-content guard 7 because the helper lives in .agents/scripts/setup/_runtime_helpers.sh, while the test greps setup.sh.

Resolves #24373


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 117,627 tokens on this as a headless worker.