### PR TITLE
GH#24375: fix: avoid cleanup reversal broken pipes

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1048,13 +1048,20 @@ push_cleanup() {
 # This is the RETURN trap handler — do not call directly.
 _run_cleanups() {
 	if [[ -n "$_CLEANUP_CMDS" ]]; then
-		# Reverse the command list (LIFO) and execute each
+		# Reverse the command list (LIFO) without an external pipeline. Using
+		# echo | tail -r/tac can emit Broken pipe noise under pipefail when the
+		# consumer exits early.
 		local reversed
-		# tail -r is macOS, tac is GNU — try both
-		reversed=$(echo "$_CLEANUP_CMDS" | tail -r 2>/dev/null) ||
-			reversed=$(echo "$_CLEANUP_CMDS" | tac 2>/dev/null) ||
-			reversed="$_CLEANUP_CMDS"
+		reversed=""
 		local line
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			if [[ -n "$reversed" ]]; then
+				reversed="${line}"$'\n'"${reversed}"
+			else
+				reversed="$line"
+			fi
+		done <<<"$_CLEANUP_CMDS"
 		while IFS= read -r line; do
 			[[ -z "$line" ]] && continue
 			bash -c "$line" 2>/dev/null || true

--- a/.agents/scripts/tests/test-shared-constants-cleanup-stack.sh
+++ b/.agents/scripts/tests/test-shared-constants-cleanup-stack.sh
@@ -28,8 +28,10 @@ _test() {
 	return 0
 }
 
-SCRIPT_DIR="${BASH_SOURCE[0]%/*}/.."
-[[ "$SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && SCRIPT_DIR="."
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+SCRIPT_DIR="${SCRIPT_PATH%/*}"
+[[ "$SCRIPT_DIR" == "$SCRIPT_PATH" ]] && SCRIPT_DIR="."
+SCRIPT_DIR="${SCRIPT_DIR}/.."
 SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
 
 TMPDIR_TEST="$(mktemp -d)"
@@ -41,6 +43,7 @@ printf '=== cleanup stack reversal tests ===\n'
 
 order_file="$TMPDIR_TEST/order.txt"
 stderr_file="$TMPDIR_TEST/stderr.txt"
+: >"$order_file"
 
 _CLEANUP_CMDS=""
 push_cleanup "printf '%s\\n' first >> '$order_file'"

--- a/.agents/scripts/tests/test-shared-constants-cleanup-stack.sh
+++ b/.agents/scripts/tests/test-shared-constants-cleanup-stack.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Test: shared-constants.sh cleanup stack reversal
+# Verifies cleanup commands execute in LIFO order without reversal stderr noise.
+# =============================================================================
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TESTS=0
+
+_test() {
+	local desc="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS=$((TESTS + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		printf '  PASS: %s\n' "$desc"
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: %s\n' "$desc"
+		printf '    expected: %s\n' "$expected"
+		printf '    actual:   %s\n' "$actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}/.."
+[[ "$SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+source "$SCRIPT_DIR/shared-constants.sh"
+
+printf '=== cleanup stack reversal tests ===\n'
+
+order_file="$TMPDIR_TEST/order.txt"
+stderr_file="$TMPDIR_TEST/stderr.txt"
+
+_CLEANUP_CMDS=""
+push_cleanup "printf '%s\\n' first >> '$order_file'"
+push_cleanup "printf '%s\\n' second >> '$order_file'"
+push_cleanup "printf '%s\\n' third >> '$order_file'"
+
+_run_cleanups 2>"$stderr_file"
+
+actual_order="$(tr '\n' ' ' <"$order_file")"
+actual_stderr="$(<"$stderr_file")"
+
+_test "Cleanup stack executes in LIFO order" "third second first " "$actual_order"
+_test "Cleanup stack reversal emits no stderr" "" "$actual_stderr"
+_test "Cleanup stack is empty after execution" "" "$_CLEANUP_CMDS"
+
+printf '\nResults: %s passed, %s failed, %s total\n' "$PASS" "$FAIL" "$TESTS"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Replaced cleanup stack reversal pipeline with Bash-only LIFO reversal and added a regression test covering cleanup order and stderr silence.

## Files Changed

.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-shared-constants-cleanup-stack.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-constants.sh .agents/scripts/tests/test-shared-constants-cleanup-stack.sh; .agents/scripts/tests/test-shared-constants-cleanup-stack.sh; .agents/scripts/linters-local.sh

Resolves #24375


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5m and 63,856 tokens on this as a headless worker.