### PR TITLE
fix: classify benign release unlock failures (GH#24376)

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -243,6 +243,28 @@ _hrff_handle_rate_limit_release_circuit() {
 }
 
 #######################################
+# Return success when a GitHub issue unlock failure is benign.
+#
+# GitHub treats unlocking an already-unlocked issue as a failed mutation in some
+# gh/API paths. Release cleanup calls unlock defensively after active-state
+# cleanup, so that already-clean state should not produce pulse warnings.
+#
+# Args:
+#   $1 = gh failure output
+#######################################
+_hrff_unlock_failure_is_benign() {
+	local unlock_output="$1"
+
+	if [[ "$unlock_output" =~ [Aa]lready[[:space:]-]+unlocked ]] || \
+		[[ "$unlock_output" =~ [Nn]ot[[:space:]-]+locked ]] || \
+		[[ "$unlock_output" =~ [Cc]onversation[[:space:]]+is[[:space:]]+not[[:space:]]+locked ]] || \
+		[[ "$unlock_output" =~ [Ii]ssue[[:space:]]+is[[:space:]]+not[[:space:]]+locked ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Unlock the issue once a worker releases its dispatch claim.
 #
 # Worker dispatch locks the issue before launch. Release paths already clear
@@ -257,10 +279,20 @@ _hrff_handle_rate_limit_release_circuit() {
 _unlock_issue_after_dispatch_release() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local unlock_output=""
 
 	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 0
-	gh issue unlock "$issue_number" --repo "$repo_slug" >/dev/null 2>&1 || {
-		print_warning "Failed to unlock released issue #${issue_number} (non-fatal)"
+	if [[ "$issue_number" =~ ^0[0-9]+$ ]]; then
+		print_info "Skipping release unlock for local task ID ${issue_number} in ${repo_slug}: not a GitHub issue number"
+		return 0
+	fi
+
+	unlock_output=$(gh issue unlock "$issue_number" --repo "$repo_slug" 2>&1) || {
+		if _hrff_unlock_failure_is_benign "$unlock_output"; then
+			print_info "Release unlock skipped for GitHub issue #${issue_number} in ${repo_slug}: already unlocked"
+			return 0
+		fi
+		print_warning "Failed to unlock released GitHub issue #${issue_number} in ${repo_slug} (non-fatal): ${unlock_output:-unknown error}"
 	}
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
+++ b/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
@@ -85,6 +85,17 @@ gh() {
 				prev="$arg"
 			done
 			printf 'UNLOCK issue=%s repo=%s\n' "$issue_number" "$repo_slug" >>"$CALL_LOG"
+			case "${GH_UNLOCK_MODE:-success}" in
+			already_unlocked)
+				printf 'GraphQL: Issue is not locked\n' >&2
+				return 1
+				;;
+			hard_fail)
+				printf 'GraphQL: repository access denied\n' >&2
+				return 1
+				;;
+			*) ;;
+			esac
 		fi
 		;;
 	*) ;;
@@ -115,9 +126,41 @@ if grep -q 'CLAIM_RELEASED reason=worker_noop' "$CALL_LOG" &&
 	! grep -q 'runner=local-os-user' "$CALL_LOG" &&
 	grep -q 'UNLOCK issue=12345 repo=owner/repo' "$CALL_LOG"; then
 	printf 'PASS release posts claim, clears assigned GitHub login, and unlocks issue\n'
+else
+	printf 'FAIL release lifecycle missing expected calls\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+
+: >"$CALL_LOG"
+GH_UNLOCK_MODE=already_unlocked _unlock_issue_after_dispatch_release "12345" "owner/repo"
+if grep -q 'INFO Release unlock skipped for GitHub issue #12345 in owner/repo: already unlocked' "$CALL_LOG" &&
+	! grep -q 'WARN Failed to unlock released' "$CALL_LOG"; then
+	printf 'PASS already-unlocked release cleanup is benign\n'
+else
+	printf 'FAIL already-unlocked release cleanup was not benign\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+
+: >"$CALL_LOG"
+GH_UNLOCK_MODE=hard_fail _unlock_issue_after_dispatch_release "12345" "owner/repo"
+if grep -q 'WARN Failed to unlock released GitHub issue #12345 in owner/repo (non-fatal): GraphQL: repository access denied' "$CALL_LOG"; then
+	printf 'PASS hard unlock failures include issue, repo, and cause\n'
+else
+	printf 'FAIL hard unlock failure did not include issue, repo, and cause\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+
+: >"$CALL_LOG"
+GH_UNLOCK_MODE=success _unlock_issue_after_dispatch_release "004" "owner/repo"
+if grep -q 'INFO Skipping release unlock for local task ID 004 in owner/repo: not a GitHub issue number' "$CALL_LOG" &&
+	! grep -q 'UNLOCK issue=004' "$CALL_LOG"; then
+	printf 'PASS leading-zero local task IDs are not formatted as GitHub issues\n'
 	exit 0
 fi
 
-printf 'FAIL release lifecycle missing expected calls\n'
+printf 'FAIL leading-zero local task ID handling was not explicit\n'
 sed 's/^/  /' "$CALL_LOG"
 exit 1


### PR DESCRIPTION
## Summary
- Treat already-unlocked release cleanup as a benign info log instead of warning noise.
- Preserve real unlock warnings with GitHub issue number, repo slug, and captured failure cause.
- Skip leading-zero local task IDs explicitly instead of logging them as GitHub issue numbers.

Resolves #24376

## Verification
- `bash .agents/scripts/tests/test-headless-runtime-release-unlock.sh`
- `shellcheck .agents/scripts/headless-runtime-failure.sh .agents/scripts/tests/test-headless-runtime-release-unlock.sh`
- `.agents/scripts/linters-local.sh` timed out after 120s after advisory markdownlint findings, before completion.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 75,603 tokens on this as a headless worker.