### PR TITLE
GH#24383: fix: count merge-in-progress as pulse progress

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -292,6 +292,7 @@ merge_ready_prs_all_repos() {
 	local total_merged=0
 	local total_closed=0
 	local total_failed=0
+	local total_merge_progress=0
 
 	# t3193: track eligible-but-unmerged across all repos for the zero-progress
 	# circuit breaker. Eligible = APPROVED + MERGEABLE + !draft + !hold-for-review.
@@ -303,12 +304,14 @@ merge_ready_prs_all_repos() {
 		local repo_merged=0
 		local repo_closed=0
 		local repo_failed=0
+		local repo_merge_progress=0
 
-		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed
+		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed repo_merge_progress
 
 		total_merged=$((total_merged + repo_merged))
 		total_closed=$((total_closed + repo_closed))
 		total_failed=$((total_failed + repo_failed))
+		total_merge_progress=$((total_merge_progress + repo_merge_progress))
 
 		# t3193: run the stuck-merge detector pass for this repo. Resolves
 		# at runtime via bash lazy lookup — defined in pulse-merge-stuck.sh
@@ -336,10 +339,10 @@ merge_ready_prs_all_repos() {
 	# t3193: record the zero-progress signal AFTER all repos have been processed.
 	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
 	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
-		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" || true
+		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$((total_merged + total_merge_progress))" || true
 	fi
 
-	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
+	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, merge_progress=${total_merge_progress}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
 	# Write health counter deltas to a temp file (GH#18571, GH#15107).
 	# run_stage_with_timeout backgrounds this function in a subshell, so
 	# direct updates to _PULSE_HEALTH_* variables are lost on return.
@@ -374,10 +377,12 @@ _merge_ready_prs_for_repo() {
 	local _merged_var="$2"
 	local _closed_var="$3"
 	local _failed_var="$4"
+	local _progress_var="${5:-}"
 
 	local merged=0
 	local closed=0
 	local failed=0
+	local progress=0
 
 	# Fetch open PRs without GraphQL statusCheckRollup. Backlog scheduling is
 	# enriched below from REST check-suites so merge polling preserves GraphQL
@@ -401,6 +406,7 @@ _merge_ready_prs_for_repo() {
 
 	if [[ "$pr_count" -eq 0 ]]; then
 		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"
+		[[ -n "$_progress_var" ]] && eval "${_progress_var}=0"
 		return 0
 	fi
 
@@ -427,10 +433,12 @@ _merge_ready_prs_for_repo() {
 		0) merged=$((merged + 1)) ;;
 		2) closed=$((closed + 1)) ;;
 		3) failed=$((failed + 1)) ;;
+		4) progress=$((progress + 1)) ;;
 		esac
 	done
 
 	eval "${_merged_var}=${merged}; ${_closed_var}=${closed}; ${_failed_var}=${failed}"
+	[[ -n "$_progress_var" ]] && eval "${_progress_var}=${progress}"
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -292,7 +292,6 @@ merge_ready_prs_all_repos() {
 	local total_merged=0
 	local total_closed=0
 	local total_failed=0
-	local total_merge_progress=0
 
 	# t3193: track eligible-but-unmerged across all repos for the zero-progress
 	# circuit breaker. Eligible = APPROVED + MERGEABLE + !draft + !hold-for-review.
@@ -304,14 +303,12 @@ merge_ready_prs_all_repos() {
 		local repo_merged=0
 		local repo_closed=0
 		local repo_failed=0
-		local repo_merge_progress=0
 
-		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed repo_merge_progress
+		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed
 
 		total_merged=$((total_merged + repo_merged))
 		total_closed=$((total_closed + repo_closed))
 		total_failed=$((total_failed + repo_failed))
-		total_merge_progress=$((total_merge_progress + repo_merge_progress))
 
 		# t3193: run the stuck-merge detector pass for this repo. Resolves
 		# at runtime via bash lazy lookup — defined in pulse-merge-stuck.sh
@@ -339,10 +336,10 @@ merge_ready_prs_all_repos() {
 	# t3193: record the zero-progress signal AFTER all repos have been processed.
 	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
 	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
-		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$((total_merged + total_merge_progress))" || true
+		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" || true
 	fi
 
-	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, merge_progress=${total_merge_progress}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
+	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
 	# Write health counter deltas to a temp file (GH#18571, GH#15107).
 	# run_stage_with_timeout backgrounds this function in a subshell, so
 	# direct updates to _PULSE_HEALTH_* variables are lost on return.
@@ -377,12 +374,10 @@ _merge_ready_prs_for_repo() {
 	local _merged_var="$2"
 	local _closed_var="$3"
 	local _failed_var="$4"
-	local _progress_var="${5:-}"
 
 	local merged=0
 	local closed=0
 	local failed=0
-	local progress=0
 
 	# Fetch open PRs without GraphQL statusCheckRollup. Backlog scheduling is
 	# enriched below from REST check-suites so merge polling preserves GraphQL
@@ -406,7 +401,6 @@ _merge_ready_prs_for_repo() {
 
 	if [[ "$pr_count" -eq 0 ]]; then
 		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"
-		[[ -n "$_progress_var" ]] && eval "${_progress_var}=0"
 		return 0
 	fi
 
@@ -433,12 +427,10 @@ _merge_ready_prs_for_repo() {
 		0) merged=$((merged + 1)) ;;
 		2) closed=$((closed + 1)) ;;
 		3) failed=$((failed + 1)) ;;
-		4) progress=$((progress + 1)) ;;
 		esac
 	done
 
 	eval "${_merged_var}=${merged}; ${_closed_var}=${closed}; ${_failed_var}=${failed}"
-	[[ -n "$_progress_var" ]] && eval "${_progress_var}=${progress}"
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -957,7 +957,7 @@ _process_single_ready_pr() {
 		return 0
 	elif [[ "$merge_output" == *"Merge already in progress"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: PR #${pr_number} in ${repo_slug} already has a merge in progress; counting as merge progress (GH#24383): ${merge_output}" >>"$LOGFILE"
-		return 4
+		return 0
 	else
 		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${merge_output}" >>"$LOGFILE"
 		return 3
@@ -984,7 +984,6 @@ _process_single_ready_pr() {
 #   1 = skipped (gate failure, non-mergeable, or PR not found)
 #   2 = closed conflicting
 #   3 = merge failed
-#   4 = merge already in progress on GitHub
 #######################################
 process_pr() {
 	local repo_slug="$1"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -955,6 +955,9 @@ _process_single_ready_pr() {
 		fi
 		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels"
 		return 0
+	elif [[ "$merge_output" == *"Merge already in progress"* ]]; then
+		echo "[pulse-wrapper] Deterministic merge: PR #${pr_number} in ${repo_slug} already has a merge in progress; counting as merge progress (GH#24383): ${merge_output}" >>"$LOGFILE"
+		return 4
 	else
 		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${merge_output}" >>"$LOGFILE"
 		return 3
@@ -981,6 +984,7 @@ _process_single_ready_pr() {
 #   1 = skipped (gate failure, non-mergeable, or PR not found)
 #   2 = closed conflicting
 #   3 = merge failed
+#   4 = merge already in progress on GitHub
 #######################################
 process_pr() {
 	local repo_slug="$1"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -957,7 +957,11 @@ _process_single_ready_pr() {
 		return 0
 	elif [[ "$merge_output" == *"Merge already in progress"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: PR #${pr_number} in ${repo_slug} already has a merge in progress; counting as merge progress (GH#24383): ${merge_output}" >>"$LOGFILE"
-		return 0
+		local _ipr_labels
+		_ipr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _ipr_labels=""
+		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels"
+		return $?
 	else
 		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${merge_output}" >>"$LOGFILE"
 		return 3

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -418,8 +418,9 @@ echo ""
 # progress, not a deterministic merge failure; otherwise the zero-progress
 # detector can file false collapse issues while GitHub is completing the merge.
 TESTS_RUN=$((TESTS_RUN + 1))
-if grep -q 'Merge already in progress' "$MERGE_SCRIPT" \
-	&& grep -q 'return 0' "$MERGE_SCRIPT"; then
+if grep -q "Merge already in progress" "$MERGE_SCRIPT" \
+	&& grep -Fq "_handle_post_merge_actions \"\$pr_number\" \"\$repo_slug\" \"\$linked_issue\" \"\$merge_summary\" \"\$_ipr_labels\"" "$MERGE_SCRIPT" \
+	&& grep -Fq "return \$?" "$MERGE_SCRIPT"; then
 	echo "${TEST_GREEN}PASS${TEST_NC}: 6d: merge-in-progress is counted as zero-progress-breaking progress"
 else
 	TESTS_FAILED=$((TESTS_FAILED + 1))

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -91,10 +91,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODULE="$SCRIPT_DIR/pulse-merge-stuck.sh"
 STATS_HELPER="$SCRIPT_DIR/pulse-stats-helper.sh"
 MERGE_SCRIPT="$SCRIPT_DIR/pulse-merge.sh"
-MERGE_PROCESS_SCRIPT="$SCRIPT_DIR/pulse-merge-process.sh"
 CONF_FILE="$SCRIPT_DIR/../configs/pulse-merge-stuck.conf"
 
-for required in "$MODULE" "$STATS_HELPER" "$MERGE_SCRIPT" "$MERGE_PROCESS_SCRIPT"; do
+for required in "$MODULE" "$STATS_HELPER" "$MERGE_SCRIPT"; do
 	if [[ ! -f "$required" ]]; then
 		echo "${TEST_RED}FATAL${TEST_NC}: $required not found"
 		exit 1
@@ -420,9 +419,7 @@ echo ""
 # detector can file false collapse issues while GitHub is completing the merge.
 TESTS_RUN=$((TESTS_RUN + 1))
 if grep -q 'Merge already in progress' "$MERGE_SCRIPT" \
-	&& grep -q 'return 4' "$MERGE_SCRIPT" \
-	&& grep -q 'merge_progress' "$MERGE_PROCESS_SCRIPT" \
-	&& grep -q 'total_merged + total_merge_progress' "$MERGE_PROCESS_SCRIPT"; then
+	&& grep -q 'return 0' "$MERGE_SCRIPT"; then
 	echo "${TEST_GREEN}PASS${TEST_NC}: 6d: merge-in-progress is counted as zero-progress-breaking progress"
 else
 	TESTS_FAILED=$((TESTS_FAILED + 1))

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -90,9 +90,11 @@ assert_gt() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODULE="$SCRIPT_DIR/pulse-merge-stuck.sh"
 STATS_HELPER="$SCRIPT_DIR/pulse-stats-helper.sh"
+MERGE_SCRIPT="$SCRIPT_DIR/pulse-merge.sh"
+MERGE_PROCESS_SCRIPT="$SCRIPT_DIR/pulse-merge-process.sh"
 CONF_FILE="$SCRIPT_DIR/../configs/pulse-merge-stuck.conf"
 
-for required in "$MODULE" "$STATS_HELPER"; do
+for required in "$MODULE" "$STATS_HELPER" "$MERGE_SCRIPT" "$MERGE_PROCESS_SCRIPT"; do
 	if [[ ! -f "$required" ]]; then
 		echo "${TEST_RED}FATAL${TEST_NC}: $required not found"
 		exit 1
@@ -410,6 +412,22 @@ got=$(_pms_count_eligible_unmerged_for_repo "example/repo")
 count_authors=$(<"$PMS_TEST_COUNT_AUTHORS_FILE")
 assert_eq "6b: null author does not abort zero-progress candidate parsing" "1" "$got"
 assert_eq "6c: null author falls back to unknown" "109:unknown" "$count_authors"
+echo ""
+
+# GH#24383: GitHub can return "Merge already in progress" for a PR that a
+# previous pulse cycle has already submitted for server-side merge. That is
+# progress, not a deterministic merge failure; otherwise the zero-progress
+# detector can file false collapse issues while GitHub is completing the merge.
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'Merge already in progress' "$MERGE_SCRIPT" \
+	&& grep -q 'return 4' "$MERGE_SCRIPT" \
+	&& grep -q 'merge_progress' "$MERGE_PROCESS_SCRIPT" \
+	&& grep -q 'total_merged + total_merge_progress' "$MERGE_PROCESS_SCRIPT"; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 6d: merge-in-progress is counted as zero-progress-breaking progress"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 6d: merge-in-progress progress accounting is missing"
+fi
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Treat GitHub 'Merge already in progress' responses as zero-progress-breaking merge progress instead of deterministic merge failures. Kept the implementation within the shell file-size ratchet and added coverage in the pulse merge stuck tests.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-stuck.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-stuck.sh

Resolves #24383


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5m and 151,523 tokens on this as a headless worker.