### PR TITLE
GH#24389: fix: address legacy model cleanup review

### DIFF
--- a/.agents/scripts/pulse-wrapper-config.sh
+++ b/.agents/scripts/pulse-wrapper-config.sh
@@ -105,15 +105,12 @@ _pulse_file_has_active_legacy_model_var() {
 _pulse_warn_if_legacy_model_var_from_credentials() {
 	local var_name="$1"
 	local var_value="$2"
-	local files=""
 	local config_file=""
 	local matches=""
 
 	[[ -n "$var_value" ]] || return 0
 
-	files="$(_pulse_legacy_model_config_files)"
 	while IFS= read -r config_file; do
-		[[ -n "$config_file" ]] || continue
 		if _pulse_file_has_active_legacy_model_var "$config_file" "$var_name"; then
 			if [[ -n "$matches" ]]; then
 				matches="${matches}, ${config_file}"
@@ -121,7 +118,7 @@ _pulse_warn_if_legacy_model_var_from_credentials() {
 				matches="$config_file"
 			fi
 		fi
-	done <<<"$files"
+	done < <(_pulse_legacy_model_config_files)
 
 	[[ -n "$matches" ]] || return 0
 	printf '[pulse-wrapper] WARN: %s env var is deprecated (v3.7+). Model routing is now automatic via routing table + availability checks. Remove or comment this export in: %s\n' \

--- a/setup.sh
+++ b/setup.sh
@@ -526,7 +526,8 @@ _comment_out_deprecated_model_vars() {
 	# Only process active assignments/exports (not already commented). Some old
 	# credentials used VAR=... followed by export VAR, so clean both shapes.
 	if grep -qE "^[[:space:]]*(export[[:space:]]+)?(${deprecated_vars})=" "$file" 2>/dev/null; then
-		sed -i.bak -E "s/^([[:space:]]*)((export[[:space:]]+)?(${deprecated_vars})=.*)$/\1${deprecation_note}\n\1# \2/" "$file"
+		sed -i.bak -E "s/^([[:space:]]*)((export[[:space:]]+)?(${deprecated_vars})=.*)$/\\1${deprecation_note}\\
+\\1# \\2/" "$file"
 		rm -f "${file}.bak"
 		print_info "Commented out deprecated model env vars in $(basename "$file")"
 	fi


### PR DESCRIPTION
## Summary

Replaced the legacy model config loop here-string with process substitution and made the setup.sh sed replacement use a BSD-compatible literal newline form.

## Files Changed

.agents/scripts/pulse-wrapper-config.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper-config.sh setup.sh; BSD sed smoke test for PULSE_MODEL and AIDEVOPS_HEADLESS_MODELS cleanup; .agents/scripts/linters-local.sh partially passed before timing out during Markdown style after earlier gates.

Resolves #24389


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 37,100 tokens on this as a headless worker.