### PR TITLE
GH#24390: fix: harden body-file creation detection

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -259,16 +259,14 @@ function _generateSignature(helperPath, bodyValue, log) {
  */
 function _hasPriorSameCommandBodyFileCreation(cmd, filePath) {
   if (!filePath) return false;
-  const ghWrite = cmd.search(
-    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/,
-  );
-  if (ghWrite <= 0) return false;
-  const beforeGh = cmd.slice(0, ghWrite);
+  const bodyFileIdx = cmd.lastIndexOf("--body-file");
+  if (bodyFileIdx <= 0) return false;
+  const beforeGh = cmd.slice(0, bodyFileIdx);
   if (!beforeGh.includes(filePath)) return false;
   const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const quotedPath = `["']?${escaped}["']?`;
   const creationPatterns = [
-    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:printf|cat|tee)\\b[\\s\\S]*(?:>|>>)\\s*${quotedPath}`),
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:echo|printf|cat|tee)\\b[\\s\\S]*(?:>|>>)\\s*${quotedPath}`),
     new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:cp|mv)\\b[\\s\\S]+\\s+${quotedPath}`),
     new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*touch\\s+${quotedPath}`),
   ];

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -334,6 +334,32 @@ printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n
     );
   });
 
+  test("allows same-command body-file creation with echo for exec-time shim repair", () => {
+    const dir = setupStubHelper();
+    const bodyFile = join(dir, "created-later-echo.md");
+    const { log, entries } = makeLogger();
+    const cmd = `echo 'body' > ${bodyFile} && gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log);
+    assert.deepEqual(out, { status: "ok", cmd });
+    assert.ok(
+      entries.some((entry) => /deferring signature injection to PATH shim/.test(entry.msg)),
+      "same-command creation with echo should be explicitly delegated to shim",
+    );
+  });
+
+  test("allows same-command body-file creation after earlier gh command text", () => {
+    const dir = setupStubHelper();
+    const bodyFile = join(dir, "created-after-gh.md");
+    const { log, entries } = makeLogger();
+    const cmd = `gh auth status >/dev/null && echo 'body' > ${bodyFile} && gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log);
+    assert.deepEqual(out, { status: "ok", cmd });
+    assert.ok(
+      entries.some((entry) => /deferring signature injection to PATH shim/.test(entry.msg)),
+      "same-command creation after earlier gh command text should be delegated to shim",
+    );
+  });
+
   test("is idempotent on already-signed --body-file", () => {
     const dir = setupStubHelper();
     const bodyFile = join(dir, "signed.md");


### PR DESCRIPTION
## Summary

Replaced naive first-gh boundary detection with --body-file boundary detection for same-command body-file creation repair; added echo support and regression tests for echo plus earlier gh command text.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs,.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; npm test --prefix .agents/plugins/opencode-aidevops; .agents/scripts/linters-local.sh (timed out during Pulse Wrapper Canary after Secretlint/TOON/skill checks; markdown issues reported were pre-existing advisory findings outside changed files)

Resolves #24390


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 38,708 tokens on this as a headless worker.