### PR TITLE
GH#24398: fix: harden dispatch claim assignment guard

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -105,6 +105,12 @@ AIDEVOPS_VERSION_FILE="${AIDEVOPS_VERSION_FILE:-${HOME}/.aidevops/agents/VERSION
 # waste API writes; small windows (<=5s) catch only genuine races.
 DISPATCH_TIEBREAKER_WINDOW="${DISPATCH_TIEBREAKER_WINDOW:-5}"
 
+# GH#24398: direct dispatch-claim-helper.sh callers must not post a
+# DISPATCH_CLAIM on top of another runner's active lifecycle assignment. Unit
+# tests that exercise the low-level claim protocol can opt out explicitly; the
+# dispatch-dedup-helper.sh wrapper always runs the guard before routing here.
+DISPATCH_CLAIM_ASSIGNMENT_GUARD="${DISPATCH_CLAIM_ASSIGNMENT_GUARD:-true}"
+
 # t2422: Source the structured override resolver so _override_resolve is
 # available to _apply_structured_filter below. The resolver is sourceable —
 # its main() is gated by BASH_SOURCE. If the resolver is missing (partial
@@ -971,6 +977,54 @@ _post_deferred() {
 }
 
 #######################################
+# Fail-closed guard before posting a DISPATCH_CLAIM.
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+#   $3 = runner login
+# Returns:
+#   exit 0 = safe to post claim
+#   exit 1 = active assignment/guard block; do not post claim
+#######################################
+_guard_no_active_assignment_before_claim() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local runner="$3"
+
+	if [[ "$DISPATCH_CLAIM_ASSIGNMENT_GUARD" != "true" ]]; then
+		return 0
+	fi
+	if [[ "${AIDEVOPS_TEST_MODE:-}" == "1" && -z "${AIDEVOPS_FORCE_CLAIM_ASSIGNMENT_GUARD:-}" ]]; then
+		return 0
+	fi
+
+	local dedup_helper="${DISPATCH_CLAIM_HELPER_DIR}/dispatch-dedup-helper.sh"
+	if [[ ! -x "$dedup_helper" ]]; then
+		printf 'CLAIM_BLOCKED: assignment_guard_unavailable issue=#%s repo=%s helper=%s\n' \
+			"$issue_number" "$repo_slug" "$dedup_helper"
+		return 1
+	fi
+
+	local guard_output="" guard_rc=0
+	guard_output=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" "$runner" 2>&1) || guard_rc=$?
+	case "$guard_rc" in
+	0)
+		printf 'CLAIM_BLOCKED: active_assignment issue=#%s repo=%s runner=%s signal=%s\n' \
+			"$issue_number" "$repo_slug" "$runner" "$guard_output"
+		return 1
+		;;
+	1)
+		return 0
+		;;
+	*)
+		printf 'CLAIM_BLOCKED: assignment_guard_error issue=#%s repo=%s runner=%s rc=%s signal=%s\n' \
+			"$issue_number" "$repo_slug" "$runner" "$guard_rc" "$guard_output"
+		return 1
+		;;
+	esac
+}
+
+#######################################
 # Attempt to claim an issue for dispatch.
 #
 # Protocol:
@@ -1013,6 +1067,10 @@ cmd_claim() {
 			echo "CLAIM_SKIPPED: repo_state_not_managed issue=#${issue_number} repo=${repo_slug} — not dispatching" >&2
 			return 1
 		fi
+	fi
+
+	if ! _guard_no_active_assignment_before_claim "$issue_number" "$repo_slug" "$runner"; then
+		return 1
 	fi
 
 	local nonce

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -109,7 +109,7 @@ DISPATCH_TIEBREAKER_WINDOW="${DISPATCH_TIEBREAKER_WINDOW:-5}"
 # DISPATCH_CLAIM on top of another runner's active lifecycle assignment. Unit
 # tests that exercise the low-level claim protocol can opt out explicitly; the
 # dispatch-dedup-helper.sh wrapper always runs the guard before routing here.
-DISPATCH_CLAIM_ASSIGNMENT_GUARD="${DISPATCH_CLAIM_ASSIGNMENT_GUARD:-true}"
+DISPATCH_CLAIM_ASSIGNMENT_GUARD="${DISPATCH_CLAIM_ASSIGNMENT_GUARD:-enabled}"
 
 # t2422: Source the structured override resolver so _override_resolve is
 # available to _apply_structured_filter below. The resolver is sourceable —
@@ -991,7 +991,7 @@ _guard_no_active_assignment_before_claim() {
 	local repo_slug="$2"
 	local runner="$3"
 
-	if [[ "$DISPATCH_CLAIM_ASSIGNMENT_GUARD" != "true" ]]; then
+	if [[ "$DISPATCH_CLAIM_ASSIGNMENT_GUARD" != "enabled" ]]; then
 		return 0
 	fi
 	if [[ "${AIDEVOPS_TEST_MODE:-}" == "1" && -z "${AIDEVOPS_FORCE_CLAIM_ASSIGNMENT_GUARD:-}" ]]; then

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2041,7 +2041,23 @@ main() {
 			echo "Error: dispatch-claim-helper.sh not found at ${CLAIM_HELPER}" >&2
 			return 2
 		fi
-		"$CLAIM_HELPER" claim "$1" "$2" "${3:-}"
+		local _claim_issue="$1" _claim_repo="$2" _claim_runner="${3:-}"
+		local _claim_guard_output="" _claim_guard_rc=0
+		_claim_guard_output=$(is_assigned "$_claim_issue" "$_claim_repo" "$_claim_runner" 2>&1) || _claim_guard_rc=$?
+		case "$_claim_guard_rc" in
+		0)
+			printf 'CLAIM_BLOCKED: active_assignment issue=#%s repo=%s runner=%s signal=%s\n' \
+				"$_claim_issue" "$_claim_repo" "$_claim_runner" "$_claim_guard_output"
+			return 1
+			;;
+		1) ;;
+		*)
+			printf 'CLAIM_BLOCKED: assignment_guard_error issue=#%s repo=%s runner=%s rc=%s signal=%s\n' \
+				"$_claim_issue" "$_claim_repo" "$_claim_runner" "$_claim_guard_rc" "$_claim_guard_output"
+			return 1
+			;;
+		esac
+		DISPATCH_CLAIM_ASSIGNMENT_GUARD=false "$CLAIM_HELPER" claim "$_claim_issue" "$_claim_repo" "$_claim_runner"
 		;;
 	check-claim)
 		# GH#17590: Pre-check for active claims (read-only, no comment posted).

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -647,6 +647,69 @@ test_dedup_claim_routing() {
 	else
 		print_result "dedup claim with no args returns exit 1" 1 "got exit $LAST_EXIT"
 	fi
+
+	local tmp_dir="" mock_bin_dir="" output="" exit_code=0
+	tmp_dir="$(mktemp -d)"
+	mock_bin_dir="${tmp_dir}/bin"
+	mkdir -p "$mock_bin_dir"
+	cat >"${mock_bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	printf '%s\n' '{"state":"OPEN","assignees":[{"login":"other-runner"}],"labels":[{"name":"status:queued"},{"name":"auto-dispatch"}],"createdAt":"2026-06-02T00:00:00Z"}'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && ("${2:-}" == /repos/*/issues/* || "${2:-}" == repos/*/issues/*) ]]; then
+	endpoint="${2:-}"
+	shift 2
+	if [[ "$endpoint" == */comments* ]]; then
+		recent_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		printf '[{"created_at":"%s","author":"other-runner","body_start":"Dispatching worker (PID 12345)","body":"Dispatching worker (PID 12345)"}]\n' "$recent_ts"
+		exit 0
+	fi
+	printf '%s\n' '{"state":"OPEN","assignees":[{"login":"other-runner"}],"labels":[{"name":"status:queued"},{"name":"auto-dispatch"}],"created_at":"2026-06-02T00:00:00Z"}'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+	printf 'self-runner\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == repos/*/issues/*/comments* ]]; then
+	if [[ "$*" == *"--method POST"* ]]; then
+		printf 'unexpected claim post\n' >"${MOCK_POST_FILE:?}"
+		printf '999\n'
+		exit 0
+	fi
+	printf '%s\n' '[]'
+	exit 0
+fi
+
+printf 'unsupported gh invocation in claim guard stub: %s\n' "$*" >&2
+exit 1
+EOF
+	chmod +x "${mock_bin_dir}/gh"
+
+	set +e
+	output=$(PATH="${mock_bin_dir}:$PATH" MOCK_POST_FILE="${tmp_dir}/post_body.txt" \
+		DISPATCH_CLAIM_WINDOW=0 "$DEDUP_HELPER" claim 42 owner/repo self-runner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 1 && "$output" == *"CLAIM_BLOCKED: active_assignment"* ]]; then
+		print_result "queued non-self assignee blocks dedup claim before post" 0
+	else
+		print_result "queued non-self assignee blocks dedup claim before post" 1 "exit=${exit_code} output=${output}"
+	fi
+	if [[ ! -f "${tmp_dir}/post_body.txt" ]]; then
+		print_result "blocked dedup claim does not post DISPATCH_CLAIM" 0
+	else
+		print_result "blocked dedup claim does not post DISPATCH_CLAIM" 1 "post file exists"
+	fi
+	rm -rf "$tmp_dir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Added fail-closed assignment guard before DISPATCH_CLAIM posting in dispatch-dedup-helper claim routing and direct dispatch-claim-helper calls; added regression coverage for status:queued plus non-self assignee blocking before any claim post.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-dispatch-claim-helper.sh; shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh; .agents/scripts/linters-local.sh

Resolves #24398


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 24m and 130,989 tokens on this as a headless worker.