### PR TITLE
GH#24399: fix: close superseded duplicate PRs after issue solved

### DIFF
--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -194,6 +194,56 @@ EOF
 	return 0
 }
 
+_psh_extract_closing_issue_from_pr_json() {
+	local pr_json="$1"
+	local body title body_issue title_issue
+
+	body=$(printf '%s' "$pr_json" | jq -r '.body // empty' 2>/dev/null) || body=""
+	title=$(printf '%s' "$pr_json" | jq -r '.title // empty' 2>/dev/null) || title=""
+	body_issue=$(printf '%s' "$body" | grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#[0-9]+' | head -1 | grep -oE '[0-9]+') || body_issue=""
+	title_issue=$(printf '%s' "$title" | grep -oE 'GH#[0-9]+' | head -1 | grep -oE '[0-9]+') || title_issue=""
+
+	[[ -n "$body_issue" ]] || return 0
+	if [[ -n "$title_issue" ]]; then
+		printf '%s' "$title_issue"
+		return 0
+	fi
+	printf '%s' "$body_issue"
+	return 0
+}
+
+_psh_find_merged_closer_for_closed_issue() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local current_pr="$3"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$current_pr" =~ ^[0-9]+$ ]] || return 1
+
+	local issue_json issue_state closer_numbers closer_number pr_state merged_at
+	issue_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,closedByPullRequestsReferences 2>/dev/null) || return 1
+	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null) || issue_state=""
+	[[ "$issue_state" == "CLOSED" ]] || return 1
+
+	closer_numbers=$(printf '%s' "$issue_json" | jq -r '.closedByPullRequestsReferences[]?.number // empty' 2>/dev/null) || closer_numbers=""
+	while IFS= read -r closer_number; do
+		[[ "$closer_number" =~ ^[0-9]+$ ]] || continue
+		[[ "$closer_number" != "$current_pr" ]] || continue
+		pr_state=$(gh pr view "$closer_number" --repo "$repo_slug" \
+			--json state,mergedAt --jq '.state // empty' 2>/dev/null) || pr_state=""
+		merged_at=$(gh pr view "$closer_number" --repo "$repo_slug" \
+			--json mergedAt --jq '.mergedAt // empty' 2>/dev/null) || merged_at=""
+		if [[ "$pr_state" == "MERGED" || -n "$merged_at" ]]; then
+			printf '%s' "$closer_number"
+			return 0
+		fi
+	done <<EOF
+$closer_numbers
+EOF
+	return 1
+}
+
 _psh_classify_json() {
 	local pr_json="$1"
 	local repo_path="$2"

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -549,6 +549,27 @@ _dps_consider_close() {
 # -----------------------------------------------------------------------------
 # Classification
 # -----------------------------------------------------------------------------
+
+_dps_closed_by_other_merged_pr_reason() {
+	local pr_json="$1"
+	local repo_slug="$2"
+	local pr_number="$3"
+	local labels="$4"
+
+	_dps_labels_has "$labels" "origin:worker" || _dps_labels_has "$labels" "origin:worker-takeover" || return 1
+	_dps_labels_has "$labels" "do-not-close" && return 1
+	_dps_labels_has "$labels" "hold-for-review" && return 1
+
+	local linked_issue="" superseding_pr=""
+	linked_issue=$(_psh_extract_closing_issue_from_pr_json "$pr_json" 2>/dev/null) || linked_issue=""
+	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 1
+	superseding_pr=$(_psh_find_merged_closer_for_closed_issue "$repo_slug" "$linked_issue" "$pr_number" 2>/dev/null) || superseding_pr=""
+	[[ "$superseding_pr" =~ ^[0-9]+$ ]] || return 1
+
+	printf 'linked-issue-%s-closed-by-pr-%s' "$linked_issue" "$superseding_pr"
+	return 0
+}
+
 #
 # Given a PR JSON object (from `gh pr list`), classify the action:
 #   rebase | close | notify | skip
@@ -604,6 +625,12 @@ _dirty_pr_classify() {
 	_dps_labels_has "$labels" "origin:worker" && has_worker_origin=1
 	_dps_labels_has "$labels" "origin:worker-takeover" && has_worker_origin=1
 
+	local closed_issue_reason
+	if closed_issue_reason=$(_dps_closed_by_other_merged_pr_reason "$pr_json" "$_repo_slug" "$pr_number" "$labels"); then
+		printf '%s|%s' "$_DIRTY_ACTION_CLOSE" "$closed_issue_reason"
+		return 0
+	fi
+
 	local rebase_author_ok=0
 	if [[ -n "$self_login" && "$author" == "$self_login" ]]; then
 		rebase_author_ok=1
@@ -635,24 +662,17 @@ _dirty_pr_classify() {
 		printf '%s|hold-for-review-label' "$_DIRTY_ACTION_NOTIFY"
 		return 0
 	fi
-	# origin:interactive PRs: notify only if the body has no recognised
-	# issue reference (true orphan). PRs with "For #NNN", "Ref #NNN", or any
-	# closing keyword reference a tracked issue and should flow through the
-	# normal age/idle close heuristic like any other PR (t2708).
 	if [[ "$has_interactive" -eq 1 ]]; then
 		if ! _dps_pr_body_has_issue_reference "$body"; then
 			printf '%s|origin-interactive-orphan' "$_DIRTY_ACTION_NOTIFY"
 			return 0
 		fi
-		# Has a reference — use extended close window for interactive PRs (t2711 Q2).
 		if [[ "$age" -le "$DIRTY_PR_CLOSE_MIN_AGE_INTERACTIVE" ]]; then
 			printf '%s|origin-interactive-referenced-within-extended-window' "$_DIRTY_ACTION_NOTIFY"
 			return 0
 		fi
-		# Beyond extended window — fall through to normal age-based close.
 	fi
 
-	# Age-based close.
 	local close_decision
 	close_decision=$(_dps_consider_close "$age" "$now" "$updated_epoch" "$created_epoch")
 	if [[ -n "$close_decision" ]]; then
@@ -858,6 +878,7 @@ _dirty_pr_action_rebase() {
 _dirty_pr_action_close() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local reason="${3:-stale-and-idle}"
 
 	local key="${repo_slug}#${pr_number}"
 
@@ -887,6 +908,9 @@ _dirty_pr_action_close() {
 	local linked_hint=""
 	if [[ -n "$linked" ]]; then
 		linked_hint=$(printf 'The linked issue #%s remains open and available to worker re-dispatch.' "$linked")
+	fi
+	if [[ "$reason" =~ ^linked-issue-([0-9]+)-closed-by-pr-([0-9]+)$ ]]; then
+		linked_hint=$(printf 'The linked issue #%s is already closed by merged PR #%s, so this worker PR is superseded and must not merge later.' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}")
 	fi
 
 	local comment_body
@@ -1039,7 +1063,7 @@ _dirty_pr_sweep_for_repo() {
 				_dirty_pr_action_rebase "$pr_number" "$repo_slug" "$repo_path" "$head_ref" || true
 				;;
 			"$_DIRTY_ACTION_CLOSE")
-				_dirty_pr_action_close "$pr_number" "$repo_slug" || true
+				_dirty_pr_action_close "$pr_number" "$repo_slug" "$reason" || true
 				;;
 		"$_DIRTY_ACTION_NOTIFY")
 			_dirty_pr_action_notify "$pr_number" "$repo_slug" "$reason" || true

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -120,6 +120,12 @@ source "${_PULSE_MERGE_DIR}/shared-phase-filing.sh"
 # shellcheck source=shared-dispatch-label-cleanup.sh
 source "${_PULSE_MERGE_DIR}/shared-dispatch-label-cleanup.sh"
 
+# Source shared supersession helpers (GH#24399). Merge-ready PRs that use a
+# closing keyword against an issue already closed by a different merged PR are
+# duplicate worker outputs and must be closed before any merge attempt.
+# shellcheck source=pr-supersession-helper.sh
+source "${_PULSE_MERGE_DIR}/pr-supersession-helper.sh"
+
 readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
 
 # Source author permission check helpers (GH#21426 — extracted to bring
@@ -691,6 +697,49 @@ _unblock_circuit_breaker_meta_pr() {
 	return 0
 }
 
+_pm_pr_labels_mark_intentional_followup() {
+	local pr_labels_csv="$1"
+	local labels_padded=",${pr_labels_csv},"
+
+	case "$labels_padded" in
+	*,intentional-follow-up,* | *,follow-up,* | *,do-not-close,* | *,hold-for-review,* | *,no-auto-dispatch,* | *,needs-maintainer-review,*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+_pm_close_superseded_duplicate_pr_if_issue_solved() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local pr_labels_csv="$4"
+
+	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 1
+	case ",${pr_labels_csv}," in
+	*,origin:worker,* | *,origin:worker-takeover,*) ;;
+	*) return 1 ;;
+	esac
+	if _pm_pr_labels_mark_intentional_followup "$pr_labels_csv"; then
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} links closed issue #${linked_issue} but has intentional-follow-up/protection label; not closing as duplicate (GH#24399)" >>"$LOGFILE"
+		return 1
+	fi
+
+	local superseding_pr
+	superseding_pr=$(_psh_find_merged_closer_for_closed_issue "$repo_slug" "$linked_issue" "$pr_number" 2>/dev/null) || superseding_pr=""
+	[[ "$superseding_pr" =~ ^[0-9]+$ ]] || return 1
+
+	gh pr close "$pr_number" --repo "$repo_slug" \
+		--comment "Closing as superseded: linked issue #${linked_issue} is already closed by merged PR #${superseding_pr}. This worker PR uses a closing keyword for the same issue, so merging it would duplicate an already-terminal fix.
+
+Intentional follow-ups should use For #${linked_issue} / Ref #${linked_issue} or an explicit follow-up/protection label instead of a closing keyword.
+
+_Closed by deterministic merge pass (GH#24399)._" 2>/dev/null || true
+	unlock_issue_after_worker "$pr_number" "$repo_slug"
+	echo "[pulse-wrapper] Merge pass: closed superseded duplicate PR #${pr_number} in ${repo_slug} — issue #${linked_issue} already closed by merged PR #${superseding_pr} (GH#24399)" >>"$LOGFILE"
+	return 0
+}
+
 #######################################
 # Process a single PR end-to-end: gate checks, merge attempt,
 # conflict detection, and closing comment posting.
@@ -825,6 +874,11 @@ _process_single_ready_pr() {
 	# merge and CI-repair paths. This preserves the security boundary for PRs
 	# that are red but would not be trusted if green.
 	if ! _check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue"; then
+		return 1
+	fi
+
+	if declare -F _pm_close_superseded_duplicate_pr_if_issue_solved >/dev/null 2>&1 \
+		&& _pm_close_superseded_duplicate_pr_if_issue_solved "$pr_number" "$repo_slug" "$linked_issue" "$pr_labels"; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
+++ b/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 MERGE_CONFLICT_FILE="${SCRIPT_DIR_TEST}/../pulse-merge-conflict.sh"
+MERGE_FILE="${SCRIPT_DIR_TEST}/../pulse-merge.sh"
+SUPERSESSION_FILE="${SCRIPT_DIR_TEST}/../pr-supersession-helper.sh"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -80,6 +82,14 @@ define_functions_under_test() {
 		/^_close_conflicting_pr_comment_not_landed\(\) \{/,/^}$/ { print }
 		/^_close_conflicting_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_CONFLICT_FILE")
+	fn_src="${fn_src}
+$(awk '
+		/^_psh_find_merged_closer_for_closed_issue\(\) \{/,/^}$/ { print }
+	' "$SUPERSESSION_FILE")
+$(awk '
+		/^_pm_pr_labels_mark_intentional_followup\(\) \{/,/^}$/ { print }
+		/^_pm_close_superseded_duplicate_pr_if_issue_solved\(\) \{/,/^}$/ { print }
+	' "$MERGE_FILE")"
 	if [[ -z "$fn_src" ]]; then
 		printf 'ERROR: could not extract conflict functions from %s\n' "$MERGE_CONFLICT_FILE" >&2
 		return 1
@@ -95,8 +105,20 @@ install_stubs() {
 			printf '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"},"authorAssociation":"MEMBER"}\n'
 			return 0
 		fi
+		if [[ "$1" == "pr" && "$2" == "view" && "$3" == "6130" && "$*" == *"state"* ]]; then
+			printf 'MERGED\n'
+			return 0
+		fi
+		if [[ "$1" == "pr" && "$2" == "view" && "$3" == "6130" && "$*" == *"mergedAt"* ]]; then
+			printf '2026-06-02T14:53:00Z\n'
+			return 0
+		fi
 		if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--jq"* ]]; then
 			printf 'origin:worker\n'
+			return 0
+		fi
+		if [[ "$1" == "issue" && "$2" == "view" && "$3" == "6125" ]]; then
+			printf '{"state":"CLOSED","closedByPullRequestsReferences":[{"number":6130}]}\n'
 			return 0
 		fi
 		if [[ "$1" == "api" && "$2" == *"/commits" ]]; then
@@ -257,6 +279,26 @@ test_protected_precheck_skips_draft_interactive_without_metadata_fetch() {
 	return 0
 }
 
+test_merge_ready_duplicate_pr_closed_before_merge() {
+	reset_case
+	_pm_close_superseded_duplicate_pr_if_issue_solved "6131" "awardsapp/awardsapp" "6125" "origin:worker"
+	assert_log_contains "$GH_CALL_LOG" "pr close 6131" "merge-ready duplicate closes current PR"
+	assert_log_contains "$GH_CALL_LOG" "issue view 6125" "merge-ready duplicate checks linked issue closer"
+	assert_log_contains "$GH_CALL_LOG" "merged PR #6130" "merge-ready duplicate comment cites merged PR"
+	return 0
+}
+
+test_followup_label_preserves_duplicate_guard() {
+	reset_case
+	if _pm_close_superseded_duplicate_pr_if_issue_solved "6132" "awardsapp/awardsapp" "6125" "origin:worker,follow-up"; then
+		fail "follow-up label is not auto-closed" "Expected guard to skip explicit follow-up"
+	else
+		pass "follow-up label is not auto-closed"
+	fi
+	assert_log_not_contains "$GH_CALL_LOG" "pr close 6132" "follow-up label avoids close write"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -270,6 +312,8 @@ main() {
 	test_parent_research_comment_avoids_closing_keywords
 	test_label_lookup_failure_skips_issue_closure
 	test_protected_precheck_skips_draft_interactive_without_metadata_fetch
+	test_merge_ready_duplicate_pr_closed_before_merge
+	test_followup_label_preserves_duplicate_guard
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Added a merge-ready guard and dirty-PR sweep path that close origin:worker duplicate PRs when their closing-keyword linked issue is already closed by a different merged PR, while preserving For/Ref follow-ups and protection labels. Regression coverage models the awardsapp #6125 / #6130 / #6131 pattern.

## Files Changed

.agents/scripts/pr-supersession-helper.sh,.agents/scripts/pulse-dirty-pr-sweep.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh; .agents/scripts/tests/test-dirty-pr-sweep.sh; .agents/scripts/linters-local.sh (pass; run-tests.sh path from issue was absent; broad test-pulse-merge*.sh stopped on pre-existing test-pulse-merge-admin-safety-check expectation)

Resolves #24399


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 18m and 141,615 tokens on this as a headless worker.