### PR TITLE
GH#24402: preserve recently updated OpenCode sessions during archiving

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -137,31 +137,35 @@ FORCE_VACUUM_SIZE_MB=0 VACUUM_FREELIST_THRESHOLD=0.0 \
 
 `opencode-db-archive.sh archive` supports two retention targets:
 
-- **Age-based retention** (`--retention-days N`) archives sessions older than
-  `N` days. This remains the default mode (`14` days) and is best when session
-  volume is predictable.
+- **Age-based retention** (`--retention-days N`) archives sessions whose last
+  update/activity is older than `N` days. This remains the default mode (`14`
+  days) and is best when session volume is predictable. A resumed or updated
+  session stays active even when its original creation time is older than the
+  cutoff.
 - **Count-based retention** (`--keep-sessions N`) keeps the newest `N` active
-  sessions and archives older sessions beyond that budget. Use this when TUI
-  startup cost tracks active session count more closely than calendar age, for
-  example keeping roughly the newest 500 sessions active.
+  sessions by last update/activity, with creation time and session ID as stable
+  tie-breakers, and archives older sessions beyond that budget. Use this when
+  TUI startup cost tracks active session count more closely than calendar age,
+  for example keeping roughly the 500 most recently active sessions in the
+  active database.
 
 Examples:
 
 ```bash
-# Keep roughly the newest 500 active sessions, archive older sessions
+# Keep roughly the 500 most recently active sessions, archive older sessions
 opencode-db-archive.sh archive --keep-sessions 500
 
 # Preview a stricter active-session budget first
 opencode-db-archive.sh archive --keep-sessions 250 --dry-run
 
-# Conservative combined mode: archive only sessions older than 30 days AND
-# outside the newest 500 sessions
+# Conservative combined mode: archive only sessions inactive for 30 days AND
+# outside the 500 most recently updated sessions
 opencode-db-archive.sh archive --retention-days 30 --keep-sessions 500
 ```
 
 When both modes are provided, the archive uses the conservative intersection:
-recent sessions are preserved if they are within either the age window or the
-newest-session budget.
+recently updated sessions are preserved if they are within either the last-update
+age window or the most-recently-updated session budget.
 
 ## Disruptive maintenance window
 

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -396,10 +396,10 @@ _archive_candidate_filter() {
 	local filter="1=1"
 
 	if ((retention_enabled)); then
-		filter="${filter} AND time_created < ${cutoff_ms}"
+		filter="${filter} AND time_updated < ${cutoff_ms}"
 	fi
 	if ((keep_enabled)); then
-		filter="${filter} AND id NOT IN (SELECT id FROM session ORDER BY time_created DESC, id DESC LIMIT ${keep_sessions})"
+		filter="${filter} AND id NOT IN (SELECT id FROM session ORDER BY time_updated DESC, time_created DESC, id DESC LIMIT ${keep_sessions})"
 	fi
 	if [[ -n "$exclude_clause" ]]; then
 		filter="${filter} ${exclude_clause}"
@@ -464,13 +464,13 @@ cmd_archive() {
 	cutoff_ms=$(($(date +%s) * 1000 - retention_days * 86400 * 1000))
 
 	if ((retention_enabled)); then
-		print_info "Retention: ${retention_days} days (cutoff: $(_format_cutoff_time "$cutoff_ms"))"
+		print_info "Retention: ${retention_days} days since last update (cutoff: $(_format_cutoff_time "$cutoff_ms"))"
 	fi
 	if ((keep_enabled)); then
-		print_info "Retention: keep newest ${keep_sessions} active sessions"
+		print_info "Retention: keep newest ${keep_sessions} active sessions by last update"
 	fi
 	if ((retention_enabled && keep_enabled)); then
-		print_info "Combined retention: archiving only sessions that are older than both targets"
+		print_info "Combined retention: archiving only sessions inactive beyond both targets"
 	fi
 	print_info "Active DB: $ACTIVE_DB"
 	print_info "Archive DB: $ARCHIVE_DB"
@@ -573,7 +573,7 @@ cmd_archive() {
 
 		# Collect batch session IDs
 		local session_ids
-		session_ids=$(sqlite3 "$ACTIVE_DB" "SELECT id FROM session WHERE $candidate_filter ORDER BY time_created ASC LIMIT $batch_limit;")
+		session_ids=$(sqlite3 "$ACTIVE_DB" "SELECT id FROM session WHERE $candidate_filter ORDER BY time_updated ASC, time_created ASC, id ASC LIMIT $batch_limit;")
 
 		if [[ -z "$session_ids" ]]; then
 			break
@@ -716,14 +716,14 @@ cmd_stats() {
 	echo "  Todos:          $todo_count"
 	echo "  Session shares: $share_count"
 
-	# Age distribution
+	# Last-update distribution
 	local last_7d last_14d older
-	last_7d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created >= $seven_days_ms;")
-	last_14d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created >= $fourteen_days_ms AND time_created < $seven_days_ms;")
-	older=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created < $fourteen_days_ms;")
+	last_7d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $seven_days_ms;")
+	last_14d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $fourteen_days_ms AND time_updated < $seven_days_ms;")
+	older=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated < $fourteen_days_ms;")
 
 	echo ""
-	echo "  Age distribution:"
+	echo "  Last-update distribution:"
 	echo "    Last 7 days:   $last_7d"
 	echo "    7–14 days:     $last_14d"
 	echo "    Older than 14: $older"
@@ -746,14 +746,14 @@ cmd_stats() {
 		echo "  Todos:          $arch_todo"
 		echo "  Session shares: $arch_share"
 
-		# Age distribution in archive
+		# Last-update distribution in archive
 		local arch_7d arch_14d arch_older
-		arch_7d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created >= $seven_days_ms;" 2>/dev/null || echo "0")
-		arch_14d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created >= $fourteen_days_ms AND time_created < $seven_days_ms;" 2>/dev/null || echo "0")
-		arch_older=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created < $fourteen_days_ms;" 2>/dev/null || echo "0")
+		arch_7d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $seven_days_ms;" 2>/dev/null || echo "0")
+		arch_14d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $fourteen_days_ms AND time_updated < $seven_days_ms;" 2>/dev/null || echo "0")
+		arch_older=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated < $fourteen_days_ms;" 2>/dev/null || echo "0")
 
 		echo ""
-		echo "  Age distribution:"
+		echo "  Last-update distribution:"
 		echo "    Last 7 days:   $arch_7d"
 		echo "    7–14 days:     $arch_14d"
 		echo "    Older than 14: $arch_older"
@@ -778,8 +778,8 @@ COMMANDS:
   help      Show this help message
 
 ARCHIVE OPTIONS:
-  --retention-days N        Sessions older than N days are archived (default: 14)
-  --keep-sessions N         Keep newest N active sessions; archive older sessions beyond the budget
+  --retention-days N        Sessions inactive for N days are archived (default: 14)
+  --keep-sessions N         Keep newest N active sessions by last update; archive older sessions beyond the budget
   --dry-run                 Show what would be archived without doing it
   --max-duration-seconds N  Stop after N seconds even when not done (default: 60)
 
@@ -794,7 +794,7 @@ EXAMPLES:
   # Preview what would be archived (30-day retention)
   opencode-db-archive.sh archive --retention-days 30 --dry-run
 
-  # Keep the newest 500 active sessions, archive older sessions
+  # Keep the 500 most recently updated active sessions, archive older sessions
   opencode-db-archive.sh archive --keep-sessions 500
 
   # Archive with defaults (14 days, 60s time budget)

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -190,13 +190,14 @@ CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secre
 INSERT INTO project VALUES ('proj1', '/tmp/worktree', 'git', 'project', NULL, NULL, 1, 1, NULL, '{}', NULL, NULL);
 SQL
 
-	local session_id created_ms
-	while IFS=',' read -r session_id created_ms; do
+	local session_id created_ms updated_ms
+	while IFS=',' read -r session_id created_ms updated_ms; do
 		[[ -n "$session_id" ]] || continue
+		updated_ms="${updated_ms:-$created_ms}"
 		sqlite3 "$ACTIVE_DB" \
-			"INSERT INTO session VALUES ('${session_id}', 'proj1', NULL, '${session_id}', '/tmp/dir', '${session_id}', '1.0.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, ${created_ms}, ${created_ms}, NULL, NULL, 'workspace1', '/tmp/${session_id}');"
+			"INSERT INTO session VALUES ('${session_id}', 'proj1', NULL, '${session_id}', '/tmp/dir', '${session_id}', '1.0.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, ${created_ms}, ${updated_ms}, NULL, NULL, 'workspace1', '/tmp/${session_id}');"
 		sqlite3 "$ACTIVE_DB" \
-			"INSERT INTO message VALUES ('msg-${session_id}', '${session_id}', ${created_ms}, ${created_ms}, '{}');"
+			"INSERT INTO message VALUES ('msg-${session_id}', '${session_id}', ${created_ms}, ${updated_ms}, '{}');"
 	done <<<"$sessions_csv"
 	return 0
 }
@@ -238,7 +239,7 @@ else
 fi
 
 _reset_dbs
-_make_active_db_with_sessions $'s1,1000\ns2,2000\ns3,3000\ns4,4000\ns5,5000'
+_make_active_db_with_sessions $'s1,1000,5000\ns2,2000,1000\ns3,3000,4000\ns4,4000,2000\ns5,5000,3000'
 
 set +e
 out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --keep-sessions 2 --max-duration-seconds 30 2>&1)
@@ -251,30 +252,59 @@ else
 	_fail "count-based archive failed with rc=$rc — output: $out"
 fi
 
-active_kept=$(sqlite3 "$ACTIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_created);")
-if [[ "$active_kept" == "s4,s5" ]]; then
-	_pass "count-based retention preserves newest sessions"
+active_kept=$(sqlite3 "$ACTIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY id);")
+if [[ "$active_kept" == "s1,s3" ]]; then
+	_pass "count-based retention preserves most recently updated sessions"
 else
 	_fail "count-based retention kept unexpected active sessions: ${active_kept}"
 fi
 
-archived_count_sessions=$(sqlite3 "$ARCHIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_created);")
-if [[ "$archived_count_sessions" == "s1,s2,s3" ]]; then
-	_pass "count-based retention archives sessions outside keep target"
+archived_count_sessions=$(sqlite3 "$ARCHIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_updated, id);")
+if [[ "$archived_count_sessions" == "s2,s4,s5" ]]; then
+	_pass "count-based retention archives sessions outside update-time keep target"
 else
 	_fail "count-based retention archived unexpected sessions: ${archived_count_sessions}"
 fi
 
 _reset_dbs
 now_seconds=$(date +%s)
+old_created_ms=$(((now_seconds - 30 * 86400) * 1000))
+recent_updated_ms=$(((now_seconds - 1 * 86400) * 1000))
+stale_updated_ms=$old_created_ms
+_make_active_db_with_sessions "resumed,${old_created_ms},${recent_updated_ms}
+stale,${old_created_ms},${stale_updated_ms}"
+
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --retention-days 14 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive succeeds with old-created recently updated regression"
+else
+	_fail "old-created recently updated archive failed with rc=$rc — output: $out"
+fi
+
+recent_active=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE id='resumed';")
+stale_archived=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE id='stale';")
+if [[ "$recent_active" == "1" && "$stale_archived" == "1" ]]; then
+	_pass "age retention preserves recently updated sessions despite old creation time"
+else
+	_fail "age retention regression mismatch: resumed_active=${recent_active}, stale_archived=${stale_archived}"
+fi
+
+_reset_dbs
+now_seconds=$(date +%s)
 old1_ms=$(((now_seconds - 10 * 86400) * 1000))
-old2_ms=$(((now_seconds - 9 * 86400) * 1000))
+old2_created_ms=$(((now_seconds - 9 * 86400) * 1000))
+old2_updated_ms=$(((now_seconds - 8 * 86400) * 1000))
 mid_ms=$(((now_seconds - 3 * 86400) * 1000))
-new_ms=$(((now_seconds - 1 * 86400) * 1000))
+new_created_ms=$(((now_seconds - 20 * 86400) * 1000))
+new_updated_ms=$(((now_seconds - 1 * 86400) * 1000))
 _make_active_db_with_sessions "old1,${old1_ms}
-old2,${old2_ms}
+old2,${old2_created_ms},${old2_updated_ms}
 mid,${mid_ms}
-new,${new_ms}"
+new,${new_created_ms},${new_updated_ms}"
 
 set +e
 out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --retention-days 7 --keep-sessions 3 --max-duration-seconds 30 2>&1)
@@ -287,9 +317,9 @@ else
 	_fail "combined archive failed with rc=$rc — output: $out"
 fi
 
-combined_active=$(sqlite3 "$ACTIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_created);")
+combined_active=$(sqlite3 "$ACTIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_updated);")
 if [[ "$combined_active" == "old2,mid,new" ]]; then
-	_pass "combined retention uses conservative intersection"
+	_pass "combined retention uses conservative update-time intersection"
 else
 	_fail "combined retention kept unexpected active sessions: ${combined_active}"
 fi


### PR DESCRIPTION
## Summary

Updated OpenCode archive retention to use time_updated for age/count eligibility, batch ordering, stats/help, and docs; added regression coverage for old-created recently updated sessions.

## Files Changed

.agents/reference/opencode-maintenance.md,.agents/scripts/opencode-db-archive.sh,.agents/scripts/tests/test-opencode-db-archive.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-opencode-db-archive.sh (11 passed); shellcheck .agents/scripts/opencode-db-archive.sh .agents/scripts/tests/test-opencode-db-archive.sh; git diff --check. .agents/scripts/linters-local.sh was attempted but timed out during shell portability after prior gates passed/only advisory warnings.

Resolves #24402


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1h 47m and 119,085 tokens on this with the user in an interactive session.