### PR TITLE
GH#24397: fix pulse blocked-by self-match

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -773,11 +773,23 @@ _blocked_by_check_task_id() {
 	# Empty/error is not proof of resolution because GitHub search can lag
 	# immediately after rapid task creation. Treat that as unknown and block.
 	local blocker_state=""
-	if ! blocker_state=$(gh_issue_list --repo "$repo_slug" --state all \
-		--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null); then
+	local live_matches=""
+	if ! live_matches=$(gh_issue_list --repo "$repo_slug" --state all \
+		--search "t${task_id} in:title" --json number,title,state 2>/dev/null); then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked-by-unresolved-reference t${task_id} (live lookup failed) — skipping dispatch" >>"$LOGFILE"
 		return 0
 	fi
+	blocker_state=$(printf '%s' "$live_matches" | jq -r \
+		--arg current_issue "$issue_number" \
+		--arg task_id "$task_id" '
+		def canonical_title:
+			(.title // "" | ascii_downcase) as $title
+			| ("t" + ($task_id | ascii_downcase)) as $needle
+			| (($title | startswith($needle + ":")) or ($title | startswith($needle + " ")));
+		[.[] | select((.number | tostring) != $current_issue)] as $matches
+		| (($matches | map(select(canonical_title)) | .[0]) // $matches[0] // {})
+		| .state // ""
+		' 2>/dev/null) || blocker_state=""
 	case "$blocker_state" in
 		[Oo][Pp][Ee][Nn])
 			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -79,19 +79,31 @@ gh_issue_list() {
 			return 1
 			;;
 		closed)
-			printf 'CLOSED\n'
+			printf '[{"number":1000,"title":"t1000: blocker","state":"CLOSED"}]\n'
 			return 0
 			;;
 		closed-lower)
-			printf 'closed\n'
+			printf '[{"number":1000,"title":"t1000: blocker","state":"closed"}]\n'
 			return 0
 			;;
 		open)
-			printf 'OPEN\n'
+			printf '[{"number":1000,"title":"t1000: blocker","state":"OPEN"}]\n'
 			return 0
 			;;
 		open-lower)
-			printf 'open\n'
+			printf '[{"number":1000,"title":"t1000: blocker","state":"open"}]\n'
+			return 0
+			;;
+		self-open-only)
+			printf '[{"number":2000,"title":"Review follow-up with copied t1000 context","state":"OPEN"}]\n'
+			return 0
+			;;
+		self-open-then-canonical-closed)
+			printf '[{"number":2000,"title":"Review follow-up with copied t1000 context","state":"OPEN"},{"number":1000,"title":"t1000: canonical blocker","state":"CLOSED"}]\n'
+			return 0
+			;;
+		incidental-open-then-canonical-closed)
+			printf '[{"number":3000,"title":"Review follow-up with copied t1000 context","state":"OPEN"},{"number":1000,"title":"t1000: canonical blocker","state":"CLOSED"}]\n'
 			return 0
 			;;
 		repo-json)
@@ -99,7 +111,7 @@ gh_issue_list() {
 			return 0
 			;;
 		*)
-			printf '\n'
+			printf '[]\n'
 			return 0
 			;;
 	esac
@@ -307,6 +319,42 @@ test_lowercase_open_task_blocker_blocks() {
 	return 0
 }
 
+test_task_lookup_excludes_current_issue_self_match() {
+	printf '\n=== live task lookup excludes current issue self-match ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="self-open-then-canonical-closed"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "current issue self-match is ignored when canonical blocker is closed" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_task_lookup_self_only_fails_closed() {
+	printf '\n=== live task lookup self-only result fails closed ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="self-open-only"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "self-only task lookup remains unknown and blocked" 0 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_task_lookup_prefers_canonical_title() {
+	printf '\n=== live task lookup prefers canonical title ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_ISSUE_LIST_MODE="incidental-open-then-canonical-closed"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "canonical task title wins over incidental open title match" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
 test_issue_number_live_failure_fails_closed() {
 	printf '\n=== fail-closed issue-number blocker resolution ===\n'
 	_setup_blocked_by_resolution_test
@@ -381,6 +429,9 @@ main() {
 	test_closed_task_blocker_is_clear
 	test_lowercase_closed_task_blocker_is_clear
 	test_lowercase_open_task_blocker_blocks
+	test_task_lookup_excludes_current_issue_self_match
+	test_task_lookup_self_only_fails_closed
+	test_task_lookup_prefers_canonical_title
 	test_issue_number_live_failure_fails_closed
 	test_cached_issue_number_absence_requires_live_proof
 	test_lowercase_closed_issue_number_blocker_is_clear


### PR DESCRIPTION
## Summary

Exclude the current dispatch candidate from live tNNN title fallback results, prefer canonical tNNN task titles over incidental review-followup matches, and keep unknown/self-only lookups fail-closed.

## Files Changed

.agents/scripts/pulse-dep-graph.sh,.agents/tests/test-pulse-dep-graph-blocked-by.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-dep-graph-blocked-by.sh (27 passed); shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh; bash .agents/scripts/lint-shell-portability.sh --summary .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh; bash .agents/scripts/tests/test-pulse-wrapper-canary.sh (5 passed); .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED).

Resolves #24397


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.9 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2h 3m and 137,366 tokens on this with the user in an interactive session.