### PR TITLE
GH#24411: feat: add OpenCode hidden session lookup

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -216,9 +216,32 @@ OPENCODE_DB_MAINTENANCE_HOUR=8 \
 - `~/.aidevops/.agent-workspace/work/opencode-maintenance/maintenance.log`
   — append-only history
 
+## Hidden session lookup — child, archive, and project ID drift
+
+**Symptom:** The TUI `/sessions` picker or `opencode session list` does not show a session that should still exist. Closing and reopening opencode does not help.
+
+**First checks:**
+
+```bash
+opencode session list --format json -n 50
+aidevops opencode-db sessions --query "issue-or-title-text" --include-archive
+aidevops opencode-db sessions --directory "/absolute/path/to/repo" --include-archive --limit 50
+```
+
+The aidevops lookup is read-only. It searches the active OpenCode DB and, with `--include-archive`, `opencode-archive.db`. Use `--id ses_...` for an exact session ID and `--json` for scriptable output.
+
+**Interpretation:**
+
+- `active-top-level`: active DB row with no `parent_id`; normal top-level session lists should usually be able to show it.
+- `active-child`: active DB row with `parent_id` set. Child/subagent sessions can be hidden from top-level OpenCode list UX even though they are still present and recoverable from SQLite metadata.
+- `archived`: row is in `opencode-archive.db`. The OpenCode TUI/CLI does not read the archive DB.
+- `possible-project-id-mismatch`: the same directory has multiple `project_id` values, so the current picker may be filtering out older rows.
+
+Do not manually mutate SQLite during diagnosis. Restore/remap operations should use a dedicated safe workflow with the OpenCode TUI closed and a DB backup.
+
 ## Project ID drift — /sessions loses history
 
-**Symptom:** The TUI `/sessions` picker shows only the current session (or a handful of recent ones), not the full history. Closing and reopening opencode does not help.
+**Symptom:** The TUI `/sessions` picker shows only the current session (or a handful of recent ones), not the full history. Closing and reopening opencode does not help. Prefer the read-only `aidevops opencode-db sessions --directory "/absolute/path/to/repo" --include-archive` lookup before writing manual SQL.
 
 **Cause:** Opencode identifies git-tracked projects by a **git commit SHA** stored in `session.project_id`. The `/sessions` picker filters by the *current* session's `project_id`. When opencode regenerates this SHA (binary update, rebase, or certain git reference events), prior sessions orphan onto the old `project_id` and disappear from the picker. They are NOT deleted.
 

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -47,6 +47,7 @@
 #   status               — report scheduler install state (launchd on macOS,
 #                          systemd/cron on Linux).
 #   notice               — emit one toast-safe warning line when due/scheduled.
+#   sessions             — read-only lookup for hidden/child/archived sessions.
 #   help                 — show this help
 #
 # Usage:
@@ -85,11 +86,14 @@ fi
 # -----------------------------------------------------------------------------
 
 readonly OPENCODE_DATA_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/opencode"
-readonly OPENCODE_DB="${OPENCODE_DATA_DIR}/opencode.db"
+readonly OPENCODE_DB="${OPENCODE_DB_PATH:-${OPENCODE_DB:-${OPENCODE_DATA_DIR}/opencode.db}}"
+readonly OPENCODE_ARCHIVE_DB="${OPENCODE_ARCHIVE_DB:-${OPENCODE_DATA_DIR}/opencode-archive.db}"
 readonly OPENCODE_WAL="${OPENCODE_DB}-wal"
 readonly OPENCODE_SHM="${OPENCODE_DB}-shm"
 readonly MAINTENANCE_WINDOW_MODE="maintenance-window"
 readonly SQLITE_QUICK_CHECK="PRAGMA quick_check;"
+readonly SESSION_PARENT_ID_COLUMN="parent_id"
+readonly SESSION_PROJECT_ID_COLUMN="project_id"
 
 readonly STATE_DIR="${HOME}/.aidevops/.agent-workspace/work/opencode-maintenance"
 readonly STATE_FILE="${STATE_DIR}/last-run.json"
@@ -272,6 +276,265 @@ _wal_list_db_holders() {
 	[[ -f "$db" ]] || return 0
 	command -v lsof >/dev/null 2>&1 || return 0
 	lsof "$db" 2>/dev/null | awk 'NR>1 {print $2, $1}' | sort -u || true
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: sessions
+# -----------------------------------------------------------------------------
+
+_sql_quote() {
+	local value="$1"
+	value=${value//\'/\'\'}
+	printf "'%s'" "$value"
+	return 0
+}
+
+_json_escape() {
+	local value="$1"
+	value=${value//\\/\\\\}
+	value=${value//\"/\\\"}
+	value=${value//$'\t'/\\t}
+	value=${value//$'\n'/\\n}
+	value=${value//$'\r'/\\r}
+	printf '%s' "$value"
+	return 0
+}
+
+_sessions_column_exists() {
+	local db="$1"
+	local column="$2"
+	if "$SQLITE3_BIN" -readonly "$db" "SELECT 1 FROM pragma_table_info('session') WHERE name='$column' LIMIT 1;" 2>/dev/null | grep -q '^1$'; then
+		return 0
+	fi
+	return 1
+}
+
+_sessions_select_expr() {
+	local db="$1"
+	local column="$2"
+	local fallback="$3"
+	if _sessions_column_exists "$db" "$column"; then
+		printf 's.%s' "$column"
+	else
+		printf '%s' "$fallback"
+	fi
+	return 0
+}
+
+_sessions_parent_title_expr() {
+	local db="$1"
+	if _sessions_column_exists "$db" "$SESSION_PARENT_ID_COLUMN"; then
+		printf "COALESCE(p.title, '')"
+	else
+		printf "''"
+	fi
+	return 0
+}
+
+_sessions_from_join() {
+	local db="$1"
+	if _sessions_column_exists "$db" "$SESSION_PARENT_ID_COLUMN"; then
+		printf 'session s LEFT JOIN session p ON p.id = s.%s' "$SESSION_PARENT_ID_COLUMN"
+	else
+		printf 'session s'
+	fi
+	return 0
+}
+
+_sessions_status_expr() {
+	local db="$1"
+	local source="$2"
+	if [[ "$source" == "archive" ]]; then
+		printf "'archived'"
+	elif _sessions_column_exists "$db" "$SESSION_PARENT_ID_COLUMN"; then
+		printf "CASE WHEN COALESCE(s.%s, '') <> '' THEN 'active-child' ELSE 'active-top-level' END" "$SESSION_PARENT_ID_COLUMN"
+	else
+		printf "'active-top-level'"
+	fi
+	return 0
+}
+
+_sessions_project_mismatch_expr() {
+	local db="$1"
+	if _sessions_column_exists "$db" "$SESSION_PROJECT_ID_COLUMN"; then
+		printf "CASE WHEN COALESCE(s.directory, '') <> '' AND (SELECT COUNT(DISTINCT COALESCE(s2.%s, '')) FROM session s2 WHERE s2.directory = s.directory) > 1 THEN 'possible-project-id-mismatch' ELSE '' END" "$SESSION_PROJECT_ID_COLUMN"
+	else
+		printf "''"
+	fi
+	return 0
+}
+
+_sessions_query_db() {
+	local db="$1"
+	local source="$2"
+	local query="$3"
+	local exact_id="$4"
+	local directory="$5"
+	local limit="$6"
+
+	[[ -f "$db" ]] || return 0
+
+	local title_expr directory_expr project_expr parent_expr created_expr updated_expr parent_title_expr from_join status_expr mismatch_expr
+	title_expr=$(_sessions_select_expr "$db" "title" "''")
+	directory_expr=$(_sessions_select_expr "$db" "directory" "''")
+	project_expr=$(_sessions_select_expr "$db" "$SESSION_PROJECT_ID_COLUMN" "''")
+	parent_expr=$(_sessions_select_expr "$db" "$SESSION_PARENT_ID_COLUMN" "''")
+	created_expr=$(_sessions_select_expr "$db" "time_created" "''")
+	updated_expr=$(_sessions_select_expr "$db" "time_updated" "$created_expr")
+	parent_title_expr=$(_sessions_parent_title_expr "$db")
+	from_join=$(_sessions_from_join "$db")
+	status_expr=$(_sessions_status_expr "$db" "$source")
+	mismatch_expr=$(_sessions_project_mismatch_expr "$db")
+
+	local where="1=1"
+	if [[ -n "$exact_id" ]]; then
+		where="s.id = $(_sql_quote "$exact_id")"
+	elif [[ -n "$query" ]]; then
+		local like
+		like=$(_sql_quote "%${query}%")
+		where="(s.id LIKE $like OR $title_expr LIKE $like OR $directory_expr LIKE $like OR $project_expr LIKE $like)"
+	fi
+	if [[ -n "$directory" ]]; then
+		local dir_like
+		dir_like=$(_sql_quote "%${directory}%")
+		where="($where) AND $directory_expr LIKE $dir_like"
+	fi
+
+	"$SQLITE3_BIN" -readonly -separator $'\037' "$db" "
+SELECT '$source', $status_expr, s.id, COALESCE($title_expr, ''), COALESCE($directory_expr, ''),
+       COALESCE($project_expr, ''), COALESCE($parent_expr, ''), $parent_title_expr,
+       COALESCE($created_expr, ''), COALESCE($updated_expr, ''), $mismatch_expr
+FROM $from_join
+WHERE $where
+ORDER BY COALESCE($updated_expr, $created_expr, 0) DESC, s.id
+LIMIT $limit;" 2>/dev/null || return 1
+	return 0
+}
+
+_sessions_print_json() {
+	local rows="$1"
+	local first=true
+	printf '[\n'
+	while IFS=$'\037' read -r source status id title directory project_id parent_id parent_title created updated mismatch; do
+		[[ -n "${id:-}" ]] || continue
+		if [[ "$first" == true ]]; then
+			first=false
+		else
+			printf ',\n'
+		fi
+		printf '  {"source":"%s","status":"%s","id":"%s","title":"%s","directory":"%s","project_id":"%s","parent_id":"%s","parent_title":"%s","created":"%s","updated":"%s","diagnostic":"%s"}' \
+			"$(_json_escape "$source")" "$(_json_escape "$status")" "$(_json_escape "$id")" \
+			"$(_json_escape "$title")" "$(_json_escape "$directory")" "$(_json_escape "$project_id")" \
+			"$(_json_escape "$parent_id")" "$(_json_escape "$parent_title")" "$(_json_escape "$created")" \
+			"$(_json_escape "$updated")" "$(_json_escape "$mismatch")"
+	done <<<"$rows"
+	printf '\n]\n'
+	return 0
+}
+
+_sessions_print_table() {
+	local rows="$1"
+	printf '%-8s %-44s %-22s %-30s %-36s %s\n' "SOURCE" "STATUS" "ID" "TITLE" "PARENT" "DIRECTORY"
+	printf '%-8s %-44s %-22s %-30s %-36s %s\n' "--------" "--------------------------------------------" "----------------------" "------------------------------" "------------------------------------" "---------"
+	while IFS=$'\037' read -r source status id title directory project_id parent_id parent_title created updated mismatch; do
+		[[ -n "${id:-}" ]] || continue
+		local parent="-"
+		if [[ -n "$parent_id" ]]; then
+			parent="$parent_id"
+			[[ -n "$parent_title" ]] && parent="${parent_id} (${parent_title})"
+		fi
+		[[ -n "$mismatch" ]] && status="${status}+${mismatch}"
+		printf '%-8.8s %-44s %-22.22s %-30.30s %-36s %s\n' "$source" "$status" "$id" "$title" "$parent" "$directory"
+	done <<<"$rows"
+	printf '\nDiagnostic notes:\n'
+	printf '  active-child: session has parent_id and may be hidden from top-level OpenCode session lists.\n'
+	printf '  archived: row is in opencode-archive.db, which the OpenCode TUI/CLI does not read.\n'
+	printf '  possible-project-id-mismatch: same directory has multiple project_id values.\n'
+	return 0
+}
+
+cmd_sessions() {
+	local query=""
+	local exact_id=""
+	local directory=""
+	local include_archive=false
+	local json=false
+	local limit=20
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--query | -q)
+			query="${2:-}"
+			shift 2
+			;;
+		--id)
+			exact_id="${2:-}"
+			shift 2
+			;;
+		--directory | --dir)
+			directory="${2:-}"
+			shift 2
+			;;
+		--include-archive | --archive)
+			include_archive=true
+			shift
+			;;
+		--json)
+			json=true
+			shift
+			;;
+		--limit)
+			limit="${2:-20}"
+			shift 2
+			;;
+		--help | -h)
+			printf 'Usage: opencode-db-maintenance-helper.sh sessions [--query TEXT|--id ID] [--directory PATH] [--include-archive] [--limit N] [--json]\n'
+			return 0
+			;;
+		*)
+			print_error "Unknown sessions option: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	if ! _sqlite_available; then
+		print_error "${SQLITE3_BIN} CLI not available"
+		return 1
+	fi
+	if ! [[ "$limit" =~ ^[0-9]+$ ]] || [[ "$limit" -lt 1 ]]; then
+		print_error "--limit must be a positive integer"
+		return 1
+	fi
+	if [[ -n "$exact_id" && -n "$query" ]]; then
+		print_error "Use either --id or --query, not both"
+		return 1
+	fi
+	if [[ ! -f "$OPENCODE_DB" && "$include_archive" != true ]]; then
+		print_info "opencode DB not found at $OPENCODE_DB"
+		return 0
+	fi
+
+	local rows=""
+	if [[ -f "$OPENCODE_DB" ]]; then
+		rows+="$(_sessions_query_db "$OPENCODE_DB" "active" "$query" "$exact_id" "$directory" "$limit")"
+	fi
+	if [[ "$include_archive" == true && -f "$OPENCODE_ARCHIVE_DB" ]]; then
+		[[ -n "$rows" ]] && rows+=$'\n'
+		rows+="$(_sessions_query_db "$OPENCODE_ARCHIVE_DB" "archive" "$query" "$exact_id" "$directory" "$limit")"
+	elif [[ "$include_archive" == true && "$json" != true ]]; then
+		print_warning "archive DB not found at $OPENCODE_ARCHIVE_DB; continuing with active DB only"
+	fi
+
+	if [[ "$json" == true ]]; then
+		_sessions_print_json "$rows"
+	elif [[ -z "$rows" ]]; then
+		print_info "No matching OpenCode sessions found"
+	else
+		_sessions_print_table "$rows"
+	fi
 	return 0
 }
 
@@ -1081,6 +1344,7 @@ Subcommands:
   uninstall              macOS: remove LaunchAgent. Idempotent.
   status                 Report scheduler state (launchd/systemd/cron).
   notice                 Emit one toast-safe warning when maintenance is due or disruptive mode is scheduled.
+  sessions               Read-only lookup for active child, archived, and project-id-hidden sessions.
   help                   This help
 
 What maintenance does:
@@ -1104,6 +1368,13 @@ Environment variables (advanced):
   OPENCODE_DB_MAINTENANCE_HOUR Scheduled local hour for install (default 4)
   OPENCODE_DB_MAINTENANCE_MINUTE Scheduled local minute for install (default 0)
   OPENCODE_DB_MAINTENANCE_MODE  Scheduler mode: auto or maintenance-window
+  OPENCODE_DB_PATH              Active DB override for sessions/maintenance
+  OPENCODE_ARCHIVE_DB           Archive DB override for sessions lookup
+
+Session lookup examples:
+  opencode-db-maintenance-helper.sh sessions --query "24396" --include-archive
+  opencode-db-maintenance-helper.sh sessions --id "ses_..." --json
+  opencode-db-maintenance-helper.sh sessions --directory "/path/to/repo" --limit 20
 
 State:
   ~/.aidevops/.agent-workspace/work/opencode-maintenance/last-run.json
@@ -1134,6 +1405,7 @@ main() {
 	uninstall) cmd_uninstall "$@" ;;
 	status) cmd_status "$@" ;;
 	notice) cmd_notice "$@" ;;
+	sessions | find-session | find-sessions) cmd_sessions "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		print_error "Unknown subcommand: $sub"

--- a/.agents/scripts/tests/test-opencode-session-lookup-helper.sh
+++ b/.agents/scripts/tests/test-opencode-session-lookup-helper.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for `opencode-db-maintenance-helper.sh sessions` (GH#24411).
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../opencode-db-maintenance-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	printf 'FAIL: helper not executable at %s\n' "$HELPER"
+	exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+	printf 'SKIP: sqlite3 not available\n'
+	exit 0
+fi
+
+PASS=0
+FAIL=0
+
+_pass() {
+	local message="$1"
+	PASS=$((PASS + 1))
+	printf '  \033[0;32mPASS\033[0m %s\n' "$message"
+	return 0
+}
+
+_fail() {
+	local message="$1"
+	FAIL=$((FAIL + 1))
+	printf '  \033[0;31mFAIL\033[0m %s\n' "$message"
+	return 0
+}
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+ACTIVE_DB="${SANDBOX}/opencode.db"
+ARCHIVE_DB="${SANDBOX}/opencode-archive.db"
+
+_run_helper() {
+	if HOME="${SANDBOX}/home" OPENCODE_DB_PATH="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" sessions "$@"; then
+		return 0
+	fi
+	return 1
+}
+
+_make_db() {
+	local db="$1"
+	sqlite3 "$db" <<'SQL'
+CREATE TABLE session (
+  id text PRIMARY KEY,
+  directory text,
+  title text,
+  project_id text,
+  parent_id text,
+  time_created integer,
+  time_updated integer
+);
+SQL
+	return 0
+}
+
+_make_db "$ACTIVE_DB"
+_make_db "$ARCHIVE_DB"
+
+sqlite3 "$ACTIVE_DB" <<'SQL'
+INSERT INTO session VALUES ('ses_parent', '/repo/demo', 'Issue 24411 parent', 'proj-new', '', 10, 20);
+INSERT INTO session VALUES ('ses_child', '/repo/demo', 'Issue 24411 child', 'proj-new', 'ses_parent', 11, 21);
+INSERT INTO session VALUES ('ses_old_project', '/repo/demo', 'Old project id session', 'proj-old', '', 5, 6);
+SQL
+
+sqlite3 "$ARCHIVE_DB" <<'SQL'
+INSERT INTO session VALUES ('ses_archived', '/repo/demo', 'Archived issue 24411', 'proj-old', '', 1, 2);
+SQL
+
+out=$(_run_helper --query "24411" --include-archive 2>&1)
+if grep -q 'active-top-level' <<<"$out" && grep -q 'active-child' <<<"$out" && grep -q 'archived' <<<"$out"; then
+	_pass "table lookup includes active top-level, active child, and archived sessions"
+else
+	_fail "table lookup missed expected statuses: $out"
+fi
+
+if grep -q 'ses_parent (Issue 24411 pare' <<<"$out"; then
+	_pass "child session output includes parent title"
+else
+	_fail "child session output missing parent title: $out"
+fi
+
+out=$(_run_helper --directory "/repo/demo" 2>&1)
+if grep -q 'possible-project-id-mismatch' <<<"$out"; then
+	_pass "directory lookup reports possible project-id mismatch"
+else
+	_fail "directory lookup missing project-id mismatch guidance: $out"
+fi
+
+rm -f "$ARCHIVE_DB"
+set +e
+out=$(_run_helper --query "24411" --include-archive 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -q 'archive DB not found' <<<"$out" && grep -q 'active-child' <<<"$out"; then
+	_pass "missing archive DB falls back to active lookup"
+else
+	_fail "missing archive DB should not fail active lookup (rc=$rc): $out"
+fi
+
+json=$(_run_helper --id "ses_child" --json 2>&1)
+if python3 -c 'import json,sys; data=json.load(sys.stdin); assert data[0]["status"] == "active-child"; assert data[0]["parent_title"] == "Issue 24411 parent"' <<<"$json"; then
+	_pass "JSON output is valid and includes expected fields"
+else
+	_fail "JSON output invalid or missing expected fields: $json"
+fi
+
+printf '\nOpenCode session lookup tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -839,7 +839,7 @@ _help_commands() {
 	echo "  cleanup <cmd>      Cleanup helpers (remote branch audit/delete)"
 	echo "  model-accounts-pool OAuth account pool (list/check/diagnose/add/rotate/reset-cooldowns)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
-	echo "  opencode-db <cmd>  OpenCode SQLite maintenance (check/report/maintain/window/status/install)"
+	echo "  opencode-db <cmd>  OpenCode SQLite maintenance/session lookup (check/report/sessions/maintain/window/status/install)"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
 	echo "  circuit-breaker    Supervisor circuit breaker (status/reset/check/trip) (alias: cb)"


### PR DESCRIPTION
## Summary

Added a read-only aidevops opencode-db sessions lookup that searches active and optional archive OpenCode SQLite DBs, includes child sessions, reports parent metadata, flags possible project-id mismatch, exposes JSON/table output, and documents the troubleshooting ladder.

## Files Changed

.agents/reference/opencode-maintenance.md,.agents/scripts/opencode-db-maintenance-helper.sh,.agents/scripts/tests/test-opencode-session-lookup-helper.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-opencode-session-lookup-helper.sh; bash .agents/scripts/tests/test-opencode-db-maintenance.sh; shellcheck .agents/scripts/opencode-db-maintenance-helper.sh .agents/scripts/tests/test-opencode-session-lookup-helper.sh .agents/scripts/tests/test-opencode-db-maintenance.sh

Resolves #24411


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.10 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 87,820 tokens on this as a headless worker.