### PR TITLE
GH#24424: docs: adopt ClaudeBar live refresh

### DIFF
--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -32,7 +32,7 @@
     {
       "slug": "tddworks/ClaudeBar",
       "description": "macOS menu bar app monitoring AI coding assistant usage quotas (Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, Amp)",
-      "relevance": "Visual quota monitoring complementing our headless model-accounts-pool rotation. New provider support, provider process detection (including Antigravity language_server), and multi-account features (GH#86) directly relevant. Installed via brew cask in setup.sh.",
+      "relevance": "Visual quota monitoring complementing our headless model-accounts-pool rotation. New provider support, provider process detection (including Antigravity language_server), multi-account features (GH#86), and live menu-bar background refresh are directly relevant. Installed via brew cask in setup.sh.",
       "default_branch": "main",
       "added_at": "2026-03-21"
     },

--- a/.agents/reference/platform-support.md
+++ b/.agents/reference/platform-support.md
@@ -118,7 +118,7 @@ Used when systemd is unavailable (containers, older distros, WSL2 without system
 | Contacts.app | Full | khard (via carddav) | Different backend |
 | OrbStack VMs | macOS only | N/A | Use native Docker on Linux |
 | MiniSim | macOS only | N/A | iOS/Android emulator launcher |
-| ClaudeBar | macOS only | N/A | Menu bar quota monitor for Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, and Amp |
+| ClaudeBar | macOS only | N/A | Menu bar quota monitor with live background refresh for Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, and Amp |
 
 ## Installing Clipboard Tools on Linux
 

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1299,7 +1299,7 @@ setup_claudebar() {
 
 	print_info "ClaudeBar monitors AI coding assistant usage quotas in your menu bar"
 	echo "  Supports: Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, Amp"
-	echo "  Features: real-time quota tracking, provider process detection, status notifications, multiple themes"
+	echo "  Features: live menu-bar refresh, real-time quota tracking, provider process detection, status notifications, multiple themes"
 	echo "  Requires: macOS 15+, CLI tools for providers you want to monitor"
 	echo ""
 


### PR DESCRIPTION
## Summary

Updated ClaudeBar setup/platform/upstream-watch metadata to reflect upstream live menu-bar background refresh while retaining Homebrew cask latest installation.

## Files Changed

.agents/configs/upstream-watch.json,.agents/reference/platform-support.md,.agents/scripts/setup/modules/tool-install.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** jq empty .agents/configs/upstream-watch.json; shellcheck .agents/scripts/setup/modules/tool-install.sh; .agents/scripts/linters-local.sh

Resolves #24424


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5m and 93,821 tokens on this as a headless worker.