### PR TITLE
fix: suppress REST fallback Broken pipe noise

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -202,6 +202,24 @@ _rest_append_sig() {
 }
 
 #######################################
+# Emit one REST helper output line while tolerating early-closing consumers.
+#
+# Pulse prefetch/list callers may pipe REST fallback output into consumers that
+# intentionally exit after the first match. Bash's printf reports EPIPE as noisy
+# "Broken pipe" stderr output unless stderr is suppressed at the emit site.
+# Return 1 so callers can stop emitting without treating the closed pipe as a
+# legitimate REST fallback failure.
+#
+# Args: $1=line
+# Returns: 0 when emitted, 1 when the output pipe is closed.
+#######################################
+_rest_emit_line() {
+	local _line="$1"
+	printf '%s\n' "$_line" 2>/dev/null || return 1
+	return 0
+}
+
+#######################################
 # _rest_split_csv: portable CSV tokeniser. Emits one token per line to stdout.
 #
 # Works in bash 3.2+, zsh 5+, and BusyBox ash — uses POSIX parameter
@@ -224,10 +242,10 @@ _rest_split_csv() {
 	local _delim="${2:-,}"
 	while [[ -n "$_str" ]]; do
 		if [[ "$_str" == *"$_delim"* ]]; then
-			printf '%s\n' "${_str%%"$_delim"*}"
+			_rest_emit_line "${_str%%"$_delim"*}" || break
 			_str="${_str#*"$_delim"}"
 		else
-			printf '%s\n' "$_str"
+			_rest_emit_line "$_str" || break
 			_str=""
 		fi
 	done

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -62,6 +62,7 @@
 #      rate-limit probe while leaving GraphQL-only PR list fields on GraphQL
 #  33. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate REST PR view reads
 #  34. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate GraphQL-only PR view reads
+#  35. _rest_split_csv suppresses Broken pipe noise when consumers close early
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -1191,6 +1192,34 @@ else
 fi
 
 unset AIDEVOPS_GITHUB_APP_ENABLED AIDEVOPS_GITHUB_APP_ID AIDEVOPS_GITHUB_APP_INSTALLATION_ID AIDEVOPS_GITHUB_APP_REST_FIRST
+
+# =============================================================================
+# Test 35: _rest_split_csv suppresses early-close Broken pipe noise
+# =============================================================================
+long_csv=""
+for i in $(seq 1 5000); do
+	if [[ -z "$long_csv" ]]; then
+		long_csv="token-${i}"
+	else
+		long_csv="${long_csv},token-${i}"
+	fi
+done
+
+early_close_output=""
+early_close_stderr=$({
+	early_close_output=$(_rest_split_csv "$long_csv" | {
+		IFS= read -r first_token || true
+		printf '%s\n' "$first_token"
+	})
+	printf '%s\n' "$early_close_output" >"$TMP/early-close-output.log"
+} 2>&1)
+
+if [[ "$(cat "$TMP/early-close-output.log")" == "token-1" && "$early_close_stderr" != *"Broken pipe"* ]]; then
+	pass "_rest_split_csv suppresses Broken pipe noise when consumers close early"
+else
+	fail "_rest_split_csv suppresses Broken pipe noise when consumers close early" \
+		"stdout=$(cat "$TMP/early-close-output.log") stderr=${early_close_stderr}"
+fi
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary
- Added a SIGPIPE-tolerant REST fallback line emitter for _rest_split_csv so early-closing consumers stop emission without noisy printf Broken pipe stderr.
- Added regression coverage for an early-closing consumer with the observed REST fallback output shape.

## Testing
- bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
- shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
- bash .agents/scripts/tests/test-gh-wrapper-shell-compat.sh

Resolves #24429

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 74,635 tokens on this as a headless worker.
