### PR TITLE
GH#24432: fix: repair opencode worker db migration seeding

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -476,6 +476,7 @@ _invoke_opencode() {
 		# fires while _invoke_opencode is still waiting for the worker.
 		_WORKER_ISOLATED_DB_PATH="${isolated_data_dir}/opencode/opencode.db"
 		print_info "[lifecycle] db_isolated dir=$isolated_data_dir pid=$$"
+		_sync_worker_db_migration_metadata "$isolated_data_dir"
 		if [[ -n "${_invoke_persisted_session:-}" ]]; then
 			_seed_worker_db_session_context "$isolated_data_dir" "$_invoke_persisted_session"
 			print_info "[lifecycle] db_seeded session=$_invoke_persisted_session pid=$$"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1088,6 +1088,50 @@ _seed_worker_db_session_context() {
 	return 0
 }
 
+#######################################
+# Synchronise OpenCode migration metadata into a pre-existing worker DB.
+#
+# Pre-warmed isolated DB directories can contain user tables before the worker
+# starts. If the migration ledger is empty/missing, OpenCode/Drizzle replays
+# CREATE TABLE migrations and aborts with errors such as "table project already
+# exists" before the seed prompt reaches the model. Copy only migration ledger
+# tables from the shared DB; session/message data remains isolated.
+#######################################
+_sync_worker_db_migration_metadata() {
+	local isolated_dir="$1"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	local shared_db="${HOME}/.local/share/opencode/opencode.db"
+
+	[[ -n "$isolated_dir" ]] || return 0
+	[[ -f "$worker_db" ]] || return 0
+	[[ -f "$shared_db" ]] || return 0
+
+	local has_project has_schema_migrations has_data_migration
+	has_project=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'project' LIMIT 1;" 2>/dev/null || true)
+	[[ -n "$has_project" ]] || return 0
+
+	has_schema_migrations=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations' LIMIT 1;" 2>/dev/null || true)
+	has_data_migration=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'data_migration' LIMIT 1;" 2>/dev/null || true)
+
+	if [[ -z "$has_schema_migrations" ]]; then
+		sqlite3 "$shared_db" ".schema __drizzle_migrations" 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || true
+	fi
+	if [[ -z "$has_data_migration" ]]; then
+		sqlite3 "$shared_db" ".schema data_migration" 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || true
+	fi
+
+	local shared_db_sql
+	shared_db_sql=$(sql_escape "$shared_db")
+	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
+		.timeout 5000
+		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		INSERT OR IGNORE INTO __drizzle_migrations SELECT * FROM shared.__drizzle_migrations;
+		INSERT OR IGNORE INTO data_migration SELECT * FROM shared.data_migration;
+		DETACH DATABASE shared;
+	SQL
+	return 0
+}
+
 # --- Section 10: Dispatch Ledger / Session Locks ---
 
 # _register_dispatch_ledger: register this dispatch in the in-flight ledger (GH#6696).

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1090,6 +1090,43 @@ SQL
 	return 0
 }
 
+test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-prewarm"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+INSERT INTO __drizzle_migrations VALUES (1, 'schema-ready', 12345);
+INSERT INTO data_migration VALUES ('data-ready', 67890);
+SQL
+	sqlite3 "$worker_db" <<'SQL'
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+INSERT INTO project VALUES ('prewarmed-project', 'Prewarmed Project');
+SQL
+
+	_sync_worker_db_migration_metadata "$isolated_dir"
+
+	local schema_migrations data_migrations projects
+	schema_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM __drizzle_migrations WHERE hash = 'schema-ready';")
+	data_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM data_migration WHERE id = 'data-ready';")
+	projects=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM project WHERE id = 'prewarmed-project';")
+
+	if [[ "$schema_migrations" == "1" && "$data_migrations" == "1" && "$projects" == "1" ]]; then
+		print_result "sync worker DB migration metadata repairs prewarmed project table" 0
+		return 0
+	fi
+
+	print_result "sync worker DB migration metadata repairs prewarmed project table" 1 \
+		"schema_migrations=$schema_migrations data_migrations=$data_migrations projects=$projects"
+	return 0
+}
+
 test_large_opencode_prompt_uses_file_attachment() {
 	local prompt="large-seed-prompt-with-worker-contract"
 	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
@@ -1770,6 +1807,7 @@ main() {
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
 	test_seed_worker_db_session_context_copies_only_selected_session
 	test_seed_worker_db_session_context_copies_migration_metadata
+	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_large_opencode_prompt_uses_file_attachment
 	test_large_claude_prompt_uses_stdin_file
 	test_registered_prompt_temp_cleanup_removes_dir


### PR DESCRIPTION
## Summary

Synced OpenCode migration metadata into prewarmed isolated worker DBs before launch so a pre-existing project table does not trigger Drizzle CREATE TABLE replay failures; added regression coverage for a prewarmed worker DB containing project without migration ledgers.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24432


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.16.0 with gpt-5.5 spent 5m and 87,552 tokens on this as a headless worker.