### PR TITLE
GH#24434: fix: add sqlite schema busy timeout

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -79,7 +79,12 @@ SQL
 
 db_query() {
 	local query="$1"
-	sqlite3 -cmd ".timeout 5000" "$STATE_DB" "$query" 2>/dev/null
+	sqlite3_with_timeout "$STATE_DB" "$query" 2>/dev/null
+	return $?
+}
+
+sqlite3_with_timeout() {
+	sqlite3 -cmd ".timeout 5000" "$@"
 	return $?
 }
 
@@ -1114,10 +1119,10 @@ _sync_worker_db_migration_metadata() {
 	has_data_migration=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'data_migration' LIMIT 1;" 2>/dev/null || true)
 
 	if [[ -z "$has_schema_migrations" ]]; then
-		sqlite3 "$shared_db" ".schema __drizzle_migrations" 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || true
+		sqlite3_with_timeout "$shared_db" ".schema __drizzle_migrations" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
 	fi
 	if [[ -z "$has_data_migration" ]]; then
-		sqlite3 "$shared_db" ".schema data_migration" 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || true
+		sqlite3_with_timeout "$shared_db" ".schema data_migration" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
 	fi
 
 	local shared_db_sql


### PR DESCRIPTION
## Summary

Added a reusable sqlite3 busy-timeout wrapper in .agents/scripts/headless-runtime-lib.sh and used it when copying OpenCode migration ledger schemas into worker databases, preventing locked shared DB reads/writes from silently skipping schema repair.

## Files Changed

.agents/scripts/headless-runtime-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24434


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.16.0 with gpt-5.5 spent 5m and 81,224 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal database operation reliability through enhanced timeout handling across shared and worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->