### PR TITLE
GH#24438: fix: queue ruleset-blocked pulse merges

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -980,7 +980,7 @@ _process_single_ready_pr() {
 	# when the PR is otherwise green. First ask GitHub to enqueue/auto-merge the
 	# PR without admin bypass, then fall back to a direct non-admin merge for repos
 	# whose rulesets allow immediate maintainer merges.
-	local merge_output _merge_exit _auto_merge_output _auto_merge_exit
+	local merge_output="" _merge_exit=0 _auto_merge_output="" _auto_merge_exit=0
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)
 	_merge_exit=$?
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -974,16 +974,24 @@ _process_single_ready_pr() {
 	esac
 
 	# Merge. Prefer the historical admin path for owned repos, but fall back to
-	# a protection-respecting merge when repository rulesets reject admin bypass.
-	# GitHub reports ruleset blocks as a generic GraphQL error; retrying the same
-	# --admin call every pulse cycle creates a zero-progress loop even when the PR
-	# is otherwise green. The non-admin retry lets rulesets/merge queue evaluate
-	# the PR normally instead of counting it as a deterministic merge failure.
-	local merge_output _merge_exit
+	# protection-respecting merge paths when repository rulesets reject admin
+	# bypass. GitHub reports ruleset blocks as a generic GraphQL error; retrying
+	# the same --admin call every pulse cycle creates a zero-progress loop even
+	# when the PR is otherwise green. First ask GitHub to enqueue/auto-merge the
+	# PR without admin bypass, then fall back to a direct non-admin merge for repos
+	# whose rulesets allow immediate maintainer merges.
+	local merge_output _merge_exit _auto_merge_output _auto_merge_exit
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)
 	_merge_exit=$?
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
-		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying without --admin (GH#23087): ${merge_output}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
+		_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)
+		_auto_merge_exit=$?
+		if [[ $_auto_merge_exit -eq 0 ]]; then
+			echo "[pulse-wrapper] Deterministic merge: enabled native auto-merge for PR #${pr_number} in ${repo_slug} after ruleset blocked admin bypass (GH#24438)" >>"$LOGFILE"
+			return 0
+		fi
+		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash 2>&1)
 		_merge_exit=$?
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression test for GH#23087: when GitHub rulesets reject the historical
-# `gh pr merge --admin` path, deterministic merge retries a normal squash merge
-# instead of recording another failed zero-progress cycle.
+# Regression test for GH#23087/GH#24438: when GitHub rulesets reject the
+# historical `gh pr merge --admin` path, deterministic merge first asks GitHub
+# to auto-merge/queue the PR without admin bypass instead of recording another
+# failed zero-progress cycle.
 
 set -euo pipefail
 
@@ -57,8 +58,13 @@ if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
 	exit 1
 fi
 
-if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
 	exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+	printf '%s\n' 'X Pull request owner/repo#77 is not mergeable: the base branch policy prohibits the merge.' >&2
+	exit 1
 fi
 
 exit 0
@@ -107,7 +113,7 @@ _set_native_auto_merge_or_skip() { return 1; }
 _handle_post_merge_actions() { return 0; }
 gh_pr_view() { printf '{"labels":[]}'; return 0; }
 
-test_ruleset_violation_retries_without_admin() {
+test_ruleset_violation_enables_auto_merge_without_admin() {
 	setup_test_env
 	define_function_under_test || { teardown_test_env; return 0; }
 
@@ -125,17 +131,22 @@ test_ruleset_violation_retries_without_admin() {
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'gh pr merge 77 --repo owner/repo --squash$' "$GH_LOG"; then
-		print_result "ruleset violation fallback retries without admin" 1 "gh log: $(cat "$GH_LOG")"
+	if ! grep -qE 'gh pr merge 77 --repo owner/repo --auto --squash$' "$GH_LOG"; then
+		print_result "ruleset violation fallback enables native auto-merge" 1 "gh log: $(cat "$GH_LOG")"
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'retrying without --admin.*GH#23087' "$LOGFILE"; then
+	if grep -qE 'gh pr merge 77 --repo owner/repo --squash$' "$GH_LOG"; then
+		print_result "ruleset violation fallback avoids direct policy-prohibited merge" 1 "gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'retrying with native auto-merge without --admin.*GH#24438' "$LOGFILE"; then
 		print_result "ruleset violation fallback writes audit log" 1 "pulse log: $(cat "$LOGFILE")"
 		teardown_test_env
 		return 0
 	fi
-	print_result "ruleset violation fallback retries without admin and succeeds" 0
+	print_result "ruleset violation fallback enables native auto-merge and succeeds" 0
 	teardown_test_env
 	return 0
 }
@@ -169,7 +180,7 @@ test_draft_pr_without_origin_labels_skips_merge_write() {
 }
 
 main() {
-	test_ruleset_violation_retries_without_admin
+	test_ruleset_violation_enables_auto_merge_without_admin
 	test_draft_pr_without_origin_labels_skips_merge_write
 
 	printf '\n=================================\n'


### PR DESCRIPTION
## Summary

Root cause: PR #6311 repeatedly hit repository ruleset rejection on the historical --admin merge path, then retried a direct non-admin squash merge that the base branch policy also prohibited. The merge pass now tries native GitHub auto-merge/queue without admin bypass before falling back to a direct non-admin merge, preventing repeated failed zero-progress cycles for ruleset-protected repos. Updated the ruleset fallback regression test to cover the --auto path.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

Resolves #24438


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.16.0 with gpt-5.5 spent 3m and 131,382 tokens on this as a headless worker.