### PR TITLE
GH#24437: fix: skip closed issue dispatch before claim

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1654,6 +1654,30 @@ _dlw_blocked_by_hard_stop() {
 	return 1
 }
 
+_dlw_issue_still_open_before_claim() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local refreshed_state=""
+
+	# GH#24437: the canonical metadata bundle is fetched before canary/model
+	# preflight and may be stale by the time the dispatcher is about to publish a
+	# persistent DISPATCH_CLAIM. Refresh just the issue state immediately before
+	# cross-runner claim/label/worktree mutation so auto-resolved meta-issues do
+	# not consume worker capacity after they close.
+	refreshed_state=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+		--json state --jq '.state // ""' 2>/dev/null | tr '[:lower:]' '[:upper:]') || refreshed_state=""
+	if [[ -z "$refreshed_state" ]]; then
+		echo "[dispatch_with_dedup] Warning: unable to refresh issue state for #${issue_number} in ${repo_slug} before claim; proceeding with prior dispatch gates" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$refreshed_state" != "OPEN" ]]; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: refreshed issue state before claim is ${refreshed_state} (GH#24437)" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
 #######################################
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
@@ -1709,6 +1733,13 @@ _dispatch_launch_worker() {
 		return 2
 	fi
 	_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
+
+	_ds_t0=$(_ds_now_ns)
+	if ! _dlw_issue_still_open_before_claim "$issue_number" "$repo_slug"; then
+		_ds_record "$issue_number" "$repo_slug" "preclaim_state_refresh" "$_ds_t0"
+		return 2
+	fi
+	_ds_record "$issue_number" "$repo_slug" "preclaim_state_refresh" "$_ds_t0"
 
 	if ! _dlw_claim_lock_after_canary "$issue_number" "$repo_slug" "$self_login"; then
 		return 2

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1678,6 +1678,21 @@ _dlw_issue_still_open_before_claim() {
 	return 0
 }
 
+_dlw_preclaim_state_refresh_or_skip() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local _ds_t0
+
+	_ds_t0=$(_ds_now_ns)
+	if ! _dlw_issue_still_open_before_claim "$issue_number" "$repo_slug"; then
+		_ds_record "$issue_number" "$repo_slug" "preclaim_state_refresh" "$_ds_t0"
+		return 1
+	fi
+	_ds_record "$issue_number" "$repo_slug" "preclaim_state_refresh" "$_ds_t0"
+
+	return 0
+}
+
 #######################################
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
@@ -1718,9 +1733,7 @@ _dispatch_launch_worker() {
 	_ds_t0=$(_ds_now_ns)
 	_dlw_resolve_tier_and_model "$issue_meta_json" "$model_override"
 	_ds_record "$issue_number" "$repo_slug" "resolve_tier_model" "$_ds_t0"
-	local dispatch_tier="$_DLW_DISPATCH_TIER"
-	local dispatch_model_tier="$_DLW_DISPATCH_MODEL_TIER"
-	local selected_model="$_DLW_SELECTED_MODEL"
+	local dispatch_tier="$_DLW_DISPATCH_TIER" dispatch_model_tier="$_DLW_DISPATCH_MODEL_TIER" selected_model="$_DLW_SELECTED_MODEL"
 
 	if _dlw_blocked_by_hard_stop "$issue_number" "$repo_slug" "$issue_meta_json"; then
 		return 2
@@ -1734,12 +1747,7 @@ _dispatch_launch_worker() {
 	fi
 	_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
 
-	_ds_t0=$(_ds_now_ns)
-	if ! _dlw_issue_still_open_before_claim "$issue_number" "$repo_slug"; then
-		_ds_record "$issue_number" "$repo_slug" "preclaim_state_refresh" "$_ds_t0"
-		return 2
-	fi
-	_ds_record "$issue_number" "$repo_slug" "preclaim_state_refresh" "$_ds_t0"
+	_dlw_preclaim_state_refresh_or_skip "$issue_number" "$repo_slug" || return 2
 
 	if ! _dlw_claim_lock_after_canary "$issue_number" "$repo_slug" "$self_login"; then
 		return 2

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -202,6 +202,11 @@ _dlw_resolve_tier_and_model() {
 	return 0
 }
 _dlw_canary_preflight() { return 0; }
+STUB_REFRESH_STATE="OPEN"
+gh_issue_view() {
+	printf '%s\n' "$STUB_REFRESH_STATE"
+	return 0
+}
 CLAIM_LOCK_CALLS_FILE="${TMP}/claim-lock-calls.txt"
 _dedup_layer7_claim_lock() {
 	printf '%s\n' "${1:-}" >>"$CLAIM_LOCK_CALLS_FILE"
@@ -396,7 +401,48 @@ else
 fi
 
 # =============================================================================
-# Test 7: _dispatch_launch_worker skips dispatch when pre-creation fails
+# Test 7: _dispatch_launch_worker refreshes state before claim
+# =============================================================================
+_dlw_canary_preflight() { return 0; }
+STUB_REFRESH_STATE="CLOSED"
+
+: >"$LOGFILE"
+: >"${TMP}/setsid-calls.txt"
+: >"$CLAIM_LOCK_CALLS_FILE"
+
+launch_rc=0
+_dispatch_launch_worker "77778" "owner/repo" "test-dispatch" "Test Issue" \
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-closed" "" \
+	'{"state":"OPEN","body":""}' || launch_rc=$?
+
+if [[ "$launch_rc" -eq 2 ]]; then
+	pass "closed pre-claim refresh returns explicit no-op rc=2"
+else
+	fail "closed pre-claim refresh returns explicit no-op rc=2" "got rc=$launch_rc"
+fi
+
+if [[ ! -s "$CLAIM_LOCK_CALLS_FILE" ]]; then
+	pass "closed pre-claim refresh does not post dispatch claim"
+else
+	fail "closed pre-claim refresh does not post dispatch claim" "claim lock calls: $(cat "$CLAIM_LOCK_CALLS_FILE")"
+fi
+
+if [[ ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "closed pre-claim refresh does not spawn worker"
+else
+	fail "closed pre-claim refresh does not spawn worker" "setsid was called"
+fi
+
+if grep -q "refreshed issue state before claim is CLOSED" "$LOGFILE" 2>/dev/null; then
+	pass "closed pre-claim refresh logs blocked state"
+else
+	fail "closed pre-claim refresh logs blocked state" "LOGFILE: $(cat "$LOGFILE")"
+fi
+
+STUB_REFRESH_STATE="OPEN"
+
+# =============================================================================
+# Test 8: _dispatch_launch_worker skips dispatch when pre-creation fails
 # =============================================================================
 _dlw_canary_preflight() { return 0; }
 
@@ -437,7 +483,7 @@ else
 fi
 
 # =============================================================================
-# Test 8: worktree_precreation_failed_count counter is incremented
+# Test 9: worktree_precreation_failed_count counter is incremented
 # =============================================================================
 local_count=""
 if command -v jq &>/dev/null; then
@@ -457,7 +503,7 @@ else
 fi
 
 # =============================================================================
-# Test 9: --dir argument no longer contains repo_path fallback
+# Test 10: --dir argument no longer contains repo_path fallback
 # =============================================================================
 # Grep the source file for the old pattern (single quotes intentional — literal search)
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary

Added a just-in-time issue state refresh in pulse worker launch before DISPATCH_CLAIM, labels, worktree creation, or worker spawn so stale auto-resolved meta-issues do not consume worker capacity after closure. Added regression coverage that a stale OPEN metadata bundle with refreshed CLOSED state returns rc=2 without claim or spawn, and kept dispatch launch under the function-complexity ratchet.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-precreation-failure-skip.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-precreation-failure-skip.sh; .agents/scripts/tests/test-precreation-failure-skip.sh (26 tests, 0 failed); .agents/scripts/complexity-regression-helper.sh check --base origin/main (no new violations)

Resolves #24437


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 105,105 tokens on this as a headless worker.