### PR TITLE
fix: close stale zero-progress meta issues (For #24441)

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -108,6 +108,7 @@ fi
 : "${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:=5}"
 : "${AIDEVOPS_MERGE_PATTERN_MIN_PRS:=3}"
 : "${AIDEVOPS_MERGE_STUCK_ENABLED:=1}"
+: "${AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS:=3600}"
 
 # ── Constants (literal-dedup) ────────────────────────────────────────────────
 # Counter and gauge names that would otherwise repeat 3+ times in the body
@@ -115,6 +116,7 @@ fi
 readonly _PMS_COUNTER_ESCALATIONS_FILED="pulse_merge_stuck_escalations_filed"
 readonly _PMS_COUNTER_QUEUE_SATURATION_EVENTS="pulse_actions_queue_saturation_events"
 readonly _PMS_GAUGE_ZERO_PROGRESS_CYCLES='pulse_merge_zero_progress_cycles'
+readonly _PMS_GAUGE_ZERO_PROGRESS_RECOVERY_CHECK_TS='pulse_merge_zero_progress_recovery_check_ts'
 readonly _PMS_JQ_NULL_GUARD="null"
 readonly _PMS_RUNNER_SATURATION_MARKER_TEXT="merge-stuck:runner-queue-saturation"
 # jq filter snippet that selects normalized REST check entries with a failing
@@ -1403,6 +1405,31 @@ pulse_merge_stuck_run_pass() {
 }
 
 #######################################
+# Close stale zero-progress meta-issues after recovery is already gauged 0.
+#
+# Covers pulse-stats.json loss/rotation: the next healthy cycle has cur_before=0,
+# so the normal transition close path would miss an already-open meta-issue.
+# Args: $1 - human-readable recovery reason
+#######################################
+_pms_close_zero_progress_meta_issue_if_recovered_due() {
+	local reason="$1"
+	local now_epoch
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+	local interval="${AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS:-3600}"
+	[[ "$interval" =~ ^[0-9]+$ ]] || interval=3600
+	local last_check
+	last_check=$(pulse_stats_get_gauge "$_PMS_GAUGE_ZERO_PROGRESS_RECOVERY_CHECK_TS")
+	[[ "$last_check" =~ ^[0-9]+$ ]] || last_check=0
+	if [[ "$interval" -gt 0 && "$last_check" -gt 0 && $((now_epoch - last_check)) -lt "$interval" ]]; then
+		return 0
+	fi
+	pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_RECOVERY_CHECK_TS" "$now_epoch"
+	_pms_close_zero_progress_meta_issue_if_recovered "$reason"
+	return 0
+}
+
+#######################################
 # Increment the zero-progress counter for the current pulse cycle.
 # Called by pulse-merge.sh::merge_ready_prs_all_repos at the END of the
 # merge pass — see the wiring there.
@@ -1433,6 +1460,8 @@ pulse_merge_zero_progress_record() {
 		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
 		if [[ "$cur_before" -gt 0 ]]; then
 			_pms_close_zero_progress_meta_issue_if_recovered "${merged_count} PR(s) merged after a ${cur_before}-cycle zero-progress streak"
+		else
+			_pms_close_zero_progress_meta_issue_if_recovered_due "${merged_count} PR(s) merged while zero-progress gauge was already 0"
 		fi
 		return 0
 	fi
@@ -1444,6 +1473,8 @@ pulse_merge_zero_progress_record() {
 		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
 		if [[ "$cur_before" -gt 0 ]]; then
 			_pms_close_zero_progress_meta_issue_if_recovered "eligible-unmerged dropped to 0 after a ${cur_before}-cycle zero-progress streak"
+		else
+			_pms_close_zero_progress_meta_issue_if_recovered_due "eligible-unmerged is 0 while zero-progress gauge was already 0"
 		fi
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -276,6 +276,26 @@ pulse_merge_zero_progress_record 0 0 >/dev/null 2>&1
 got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
 assert_eq "5b: merged=0 + eligible=0 resets cycles to 0 (was 2)" "0" "$got"
 
+# 5b.1: a healthy idle cycle also sweeps stale open zero-progress issues when
+# pulse-stats.json has already lost the non-zero gauge (for example after log
+# rotation/truncation). The sweep is throttled in production, so disable the
+# interval here for deterministic coverage.
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE="23036"
+AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=0
+: >"$GH_CALLS"
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
+pulse_merge_zero_progress_record 0 0 >/dev/null 2>&1
+if grep -q 'gh issue close 23036 --repo marcusquinn/aidevops --reason completed' "$GH_CALLS"; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5b.1: stale zero-progress meta-issue is swept after recovered idle cycle"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5b.1: stale zero-progress meta-issue sweep is missing"
+	echo "  gh calls: $(cat "$GH_CALLS")"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
+AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=3600
+
 # 5c: merged=0 + eligible>0 → gauge increments by 1
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
 pulse_merge_zero_progress_record 4 0 >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- Added a throttled recovered-cycle sweep for stale zero-progress meta issues when `pulse-stats.json` has already lost the prior non-zero gauge.
- Added regression coverage for the recovered idle-cycle stale close path.

## Testing
- `.agents/scripts/tests/test-pulse-merge-stuck.sh`
- `shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh`

For #24441

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 7m and 147,622 tokens on this as a headless worker.
