### PR TITLE
GH#24442: fix: simplify native auto merge defer handling

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -965,13 +965,6 @@ _process_single_ready_pr() {
 		0)
 			return 4
 			;;
-		2)
-			# t3508: auto-merge has been stuck on required pending checks past
-			# threshold. Route bounded CI repair feedback rather than silently
-			# deferring forever or attempting an admin bypass through pending CI.
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || true
-			return 1
-			;;
 	esac
 
 	# Merge. Prefer the historical admin path for owned repos, but fall back to

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -141,13 +141,13 @@ teardown_test_env() {
 define_helpers_under_test() {
 	local src_stuck src_repo_allow src_set_native
 	src_stuck=$(awk '
-		/^_auto_merge_stuck_seconds\(\) \{/,/^\}$/ { print }
+		/^_auto_merge_stuck_seconds\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_repo_allow=$(awk '
-		/^_repo_allows_auto_merge\(\) \{/,/^\}$/ { print }
+		/^_repo_allows_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_set_native=$(awk '
-		/^_set_native_auto_merge_or_skip\(\) \{/,/^\}$/ { print }
+		/^_set_native_auto_merge_or_skip\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_set_native" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
@@ -379,10 +379,10 @@ test_case_e_stale_pending_defers() {
 test_native_auto_defer_not_counted_as_completed_merge() {
 	local process_src merge_src
 	process_src=$(awk '
-		/^_merge_ready_prs_for_repo\(\) \{/,/^\}$/ { print }
+		/^_merge_ready_prs_for_repo\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	merge_src=$(awk '
-		/^_process_single_ready_pr\(\) \{/,/^\}$/ { print }
+		/^_process_single_ready_pr\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
 
 	if [[ -z "$process_src" || -z "$merge_src" ]]; then


### PR DESCRIPTION
## Summary

Follow-up to PR #24444: removes the now-unreachable native auto-merge rc=2 handler and makes the helper-extraction regexes in the native auto-merge regression test resilient to trailing whitespace.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-native-auto.sh

## Runtime Testing

- bash .agents/scripts/tests/test-pulse-merge-native-auto.sh
- shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-native-auto.sh
- bash .agents/scripts/tests/test-pulse-merge-stuck.sh
- .agents/scripts/linters-local.sh (final `ALL LOCAL CHECKS PASSED`; existing advisory ratchet/markdown/complexity/nesting/file-size warnings reported by the repo-wide gate)

For #24442

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5
