### PR TITLE
GH#24458: sync OpenCode migration ledger tables

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1013,6 +1013,53 @@ _watchdog_kill() {
 # --- Section 9: DB Merge ---
 
 #######################################
+# Copy one OpenCode migration ledger table from shared DB to worker DB.
+# Args: $1 = worker DB path, $2 = shared DB path, $3 = ledger table name.
+# The ledger table list is intentionally allowlisted by the caller; this helper
+# creates a missing worker-side table from the shared DB schema before copying
+# rows so OpenCode does not replay migrations against pre-created user tables.
+#######################################
+_copy_worker_db_migration_ledger_table() {
+	local worker_db="$1"
+	local shared_db="$2"
+	local ledger_table="$3"
+	local has_shared has_worker shared_db_sql
+
+	has_shared=$(sqlite3 "$shared_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
+	[[ -n "$has_shared" ]] || return 0
+
+	has_worker=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
+	if [[ -z "$has_worker" ]]; then
+		sqlite3_with_timeout "$shared_db" ".schema ${ledger_table}" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
+	fi
+
+	shared_db_sql=$(sql_escape "$shared_db")
+	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
+		.timeout 5000
+		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		INSERT OR IGNORE INTO main."${ledger_table}" SELECT * FROM shared."${ledger_table}";
+		DETACH DATABASE shared;
+	SQL
+	return 0
+}
+
+#######################################
+# Synchronise all known OpenCode migration ledger tables into worker DB.
+# Args: $1 = worker DB path, $2 = shared DB path.
+#######################################
+_sync_worker_db_migration_ledgers() {
+	local worker_db="$1"
+	local shared_db="$2"
+	local ledger_table
+
+	[[ -f "$worker_db" && -f "$shared_db" ]] || return 0
+	for ledger_table in __drizzle_migrations data_migration migration; do
+		_copy_worker_db_migration_ledger_table "$worker_db" "$shared_db" "$ledger_table"
+	done
+	return 0
+}
+
+#######################################
 # Merge worker's isolated SQLite DB back to the shared DB.
 # Called after worker exits -- no contention risk.
 # Uses ATTACH DATABASE to copy session and message rows.
@@ -1071,16 +1118,11 @@ _seed_worker_db_session_context() {
 		sqlite3 -cmd ".timeout 5000" "$shared_db" .schema 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || return 0
 	fi
 
+	_sync_worker_db_migration_ledgers "$worker_db" "$shared_db"
+
 	local shared_db_sql session_id_sql
 	shared_db_sql=$(sql_escape "$shared_db")
 	session_id_sql=$(sql_escape "$session_id")
-	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
-		.timeout 5000
-		ATTACH DATABASE '${shared_db_sql}' AS shared;
-		INSERT OR IGNORE INTO __drizzle_migrations SELECT * FROM shared.__drizzle_migrations;
-		INSERT OR IGNORE INTO data_migration SELECT * FROM shared.data_migration;
-		DETACH DATABASE shared;
-	SQL
 	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
 		.timeout 5000
 		ATTACH DATABASE '${shared_db_sql}' AS shared;
@@ -1111,29 +1153,11 @@ _sync_worker_db_migration_metadata() {
 	[[ -f "$worker_db" ]] || return 0
 	[[ -f "$shared_db" ]] || return 0
 
-	local has_project has_schema_migrations has_data_migration
+	local has_project
 	has_project=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'project' LIMIT 1;" 2>/dev/null || true)
 	[[ -n "$has_project" ]] || return 0
 
-	has_schema_migrations=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations' LIMIT 1;" 2>/dev/null || true)
-	has_data_migration=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'data_migration' LIMIT 1;" 2>/dev/null || true)
-
-	if [[ -z "$has_schema_migrations" ]]; then
-		sqlite3_with_timeout "$shared_db" ".schema __drizzle_migrations" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
-	fi
-	if [[ -z "$has_data_migration" ]]; then
-		sqlite3_with_timeout "$shared_db" ".schema data_migration" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
-	fi
-
-	local shared_db_sql
-	shared_db_sql=$(sql_escape "$shared_db")
-	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
-		.timeout 5000
-		ATTACH DATABASE '${shared_db_sql}' AS shared;
-		INSERT OR IGNORE INTO __drizzle_migrations SELECT * FROM shared.__drizzle_migrations;
-		INSERT OR IGNORE INTO data_migration SELECT * FROM shared.data_migration;
-		DETACH DATABASE shared;
-	SQL
+	_sync_worker_db_migration_ledgers "$worker_db" "$shared_db"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1062,11 +1062,13 @@ test_seed_worker_db_session_context_copies_migration_metadata() {
 	sqlite3 "$shared_db" <<'SQL'
 CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
 CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE migration (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL);
 CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
 CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL);
 CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
 INSERT INTO __drizzle_migrations VALUES (1, 'schema-ready', 12345);
 INSERT INTO data_migration VALUES ('data-ready', 67890);
+INSERT INTO migration VALUES ('opencode-v16-ready', 1700000000);
 INSERT INTO project VALUES ('project-keep', 'Keep Project');
 INSERT INTO session VALUES ('session-keep', 'project-keep', 'Keep');
 INSERT INTO message VALUES ('message-keep', 'session-keep', 'one');
@@ -1074,19 +1076,20 @@ SQL
 
 	_seed_worker_db_session_context "$isolated_dir" "session-keep"
 
-	local schema_migrations data_migrations sessions messages
+	local schema_migrations data_migrations migration_rows sessions messages
 	schema_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM __drizzle_migrations WHERE hash = 'schema-ready';")
 	data_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM data_migration WHERE id = 'data-ready';")
+	migration_rows=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM migration WHERE id = 'opencode-v16-ready';")
 	sessions=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM session WHERE id = 'session-keep';")
 	messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-keep';")
 
-	if [[ "$schema_migrations" == "1" && "$data_migrations" == "1" && "$sessions" == "1" && "$messages" == "1" ]]; then
+	if [[ "$schema_migrations" == "1" && "$data_migrations" == "1" && "$migration_rows" == "1" && "$sessions" == "1" && "$messages" == "1" ]]; then
 		print_result "seed worker DB copies migration metadata for continuation" 0
 		return 0
 	fi
 
 	print_result "seed worker DB copies migration metadata for continuation" 1 \
-		"schema_migrations=$schema_migrations data_migrations=$data_migrations sessions=$sessions messages=$messages"
+		"schema_migrations=$schema_migrations data_migrations=$data_migrations migration_rows=$migration_rows sessions=$sessions messages=$messages"
 	return 0
 }
 
@@ -1101,9 +1104,11 @@ test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table() {
 	sqlite3 "$shared_db" <<'SQL'
 CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
 CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE migration (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL);
 CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
 INSERT INTO __drizzle_migrations VALUES (1, 'schema-ready', 12345);
 INSERT INTO data_migration VALUES ('data-ready', 67890);
+INSERT INTO migration VALUES ('opencode-v16-ready', 1700000000);
 SQL
 	sqlite3 "$worker_db" <<'SQL'
 CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
@@ -1112,18 +1117,19 @@ SQL
 
 	_sync_worker_db_migration_metadata "$isolated_dir"
 
-	local schema_migrations data_migrations projects
+	local schema_migrations data_migrations migration_rows projects
 	schema_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM __drizzle_migrations WHERE hash = 'schema-ready';")
 	data_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM data_migration WHERE id = 'data-ready';")
+	migration_rows=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM migration WHERE id = 'opencode-v16-ready';")
 	projects=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM project WHERE id = 'prewarmed-project';")
 
-	if [[ "$schema_migrations" == "1" && "$data_migrations" == "1" && "$projects" == "1" ]]; then
+	if [[ "$schema_migrations" == "1" && "$data_migrations" == "1" && "$migration_rows" == "1" && "$projects" == "1" ]]; then
 		print_result "sync worker DB migration metadata repairs prewarmed project table" 0
 		return 0
 	fi
 
 	print_result "sync worker DB migration metadata repairs prewarmed project table" 1 \
-		"schema_migrations=$schema_migrations data_migrations=$data_migrations projects=$projects"
+		"schema_migrations=$schema_migrations data_migrations=$data_migrations migration_rows=$migration_rows projects=$projects"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Added a shared table-driven migration ledger sync for OpenCode worker DB seeding/prewarm repair and covered the v1.16 migration table in regression tests.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh (67 pass, 0 fail); shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh; .agents/scripts/linters-local.sh timed out twice at Secretlint after earlier gates passed

Resolves #24458


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 31m and 91,575 tokens on this with the user in an interactive session.