### PR TITLE
fix: edge-trigger zero-progress meta issue filing

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -957,8 +957,8 @@ _pms_file_runner_saturation_issue() {
 
 # ── Zero-progress meta-issue ────────────────────────────────────────────────
 
-# File ONE meta-issue describing the throughput collapse when consecutive
-# zero-progress cycles cross the threshold. Dedup'd by the fixed marker.
+# File ONE meta-issue when consecutive zero-progress cycles cross the threshold.
+# The caller invokes this on the crossing edge; open-issue dedupe is a safety net.
 # Disabled while the GraphQL circuit-breaker is tripped — the breaker
 # already names the root cause and a meta-issue would just be noise.
 _pms_file_zero_progress_meta_issue() {
@@ -1071,7 +1071,7 @@ The pulse merge zero-progress detector recovered automatically: ${reason}.
 
 Evidence:
 - pulse_merge_zero_progress_cycles was reset to 0.
-- The next detector cycle can file a fresh issue if throughput collapses again.
+- A fresh issue is filed only if a new zero-progress streak crosses the threshold.
 
 Closing this stale zero-progress meta-issue so auto-dispatch does not spend worker capacity on an already-recovered incident."
 
@@ -1488,8 +1488,9 @@ pulse_merge_zero_progress_record() {
 
 	echo "[pulse-merge-stuck] pulse_merge_zero_progress_record: zero_progress_cycles=${cur}/${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES}, eligible_unmerged=${eligible_unmerged}" >>"$LOGFILE"
 
-	# At threshold, file the meta-issue (dedup'd by marker).
-	if [[ "$cur" -ge "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" ]]; then
+	# File only on the threshold-crossing edge to prevent post-close issue storms.
+	if [[ "$cur_before" -lt "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" \
+		&& "$cur" -ge "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" ]]; then
 		local stuck_summary
 		stuck_summary=$(pulse_stats_get_gauge "pulse_merge_eligible_stuck_pr_count")
 		stuck_summary="eligible_unmerged_this_cycle=${eligible_unmerged}, eligible_stuck_count=${stuck_summary}, zero_progress_cycles=${cur}"

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -261,6 +261,11 @@ gh() {
 	return 1
 }
 
+gh_create_issue() {
+	printf '%s\n' "gh_create_issue $*" >>"$GH_CALLS"
+	return 0
+}
+
 # Reset gauge for a clean state.
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
 
@@ -321,6 +326,18 @@ else
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
+
+# 5g: issue filing is edge-triggered at the configured threshold. Once the
+# gauge is already above threshold, closing the open issue externally must not
+# produce one fresh meta-issue per pulse cycle.
+: >"$GH_CALLS"
+AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=5
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "4" >/dev/null 2>&1
+pulse_stats_set_gauge "pulse_merge_eligible_stuck_pr_count" "0" >/dev/null 2>&1
+pulse_merge_zero_progress_record 1 0 >/dev/null 2>&1
+pulse_merge_zero_progress_record 1 0 >/dev/null 2>&1
+create_count=$(grep -c 'gh_create_issue --repo marcusquinn/aidevops' "$GH_CALLS")
+assert_eq "5g: zero-progress meta-issue files once on threshold crossing" "1" "$create_count"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Make zero-progress meta-issue filing edge-triggered at the threshold crossing instead of every above-threshold cycle.
- Update recovery copy so it reflects the new fresh-streak behaviour.
- Add regression coverage for the closed-issue/still-above-threshold storm seen in #24472.

For #24472

## Verification

- `.agents/scripts/tests/test-pulse-merge-stuck.sh` — 47 tests, 0 failures
- `shellcheck '.agents/scripts/pulse-merge-stuck.sh' '.agents/scripts/tests/test-pulse-merge-stuck.sh'`
- `git diff --check origin/main...HEAD`
- `.agents/scripts/linters-local.sh` — passed; advisory markdown/ratchet/complexity baseline warnings only
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.14 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1h 4m and 323,111 tokens on this with the user in an interactive session.