### PR TITLE
fix: trust safe dependabot updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Maintainer-approved dependencies that may use the trusted Dependabot
+# auto-merge allowance when every other trust boundary passes.
+#
+# Exact entries only, one per line:
+#   dependency-name
+#   package-manager:dependency-name
+#
+# The pulse still requires authentic GitHub Dependabot identity, same-repo
+# branch ownership, dependabot-authored commits, dependency-file-only diffs,
+# no terminal security-scan failures, and green required CI before merging.
+
+pip:pyarrow

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -44,6 +44,124 @@ _PULSE_MERGE_GATES_LOADED=1
 # --- Functions ---
 
 #######################################
+# Resolve the trusted Dependabot update allowlist path.
+# Output: config path
+# Returns: 0 always
+#######################################
+_trusted_dependabot_updates_conf() {
+	local default_conf="${_PULSE_MERGE_DIR:+${_PULSE_MERGE_DIR}/../configs/trusted-dependabot-updates.conf}"
+	printf '%s' "${AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF:-$default_conf}"
+	return 0
+}
+
+#######################################
+# Check whether a Dependabot dependency is on the maintainer allowlist.
+#
+# Config entries are exact, one per line: `package` or `manager:package`.
+# Empty/missing config is fail-closed. `*` is accepted only when explicitly
+# configured by the maintainer.
+# Args: $1=package_manager, $2=dependency_name
+# Returns: 0 allowed, 1 not allowed
+#######################################
+_trusted_dependabot_dependency_allowed() {
+	local package_manager="$1"
+	local dependency_name="$2"
+	local conf_path
+	conf_path=$(_trusted_dependabot_updates_conf)
+
+	[[ -n "$dependency_name" && -f "$conf_path" ]] || return 1
+	local entries
+	entries=$(sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$conf_path" 2>/dev/null | sed '/^$/d') || entries=""
+	[[ -n "$entries" ]] || return 1
+	if printf '%s\n' "$entries" | grep -Fxq '*'; then
+		return 0
+	fi
+	if [[ -n "$package_manager" ]] \
+		&& printf '%s\n' "$entries" | grep -Fxq "${package_manager}:${dependency_name}"; then
+		return 0
+	fi
+	printf '%s\n' "$entries" | grep -Fxq "$dependency_name"
+	return $?
+}
+
+#######################################
+# Verify a Dependabot PR is an authentic, maintainer-allowed version update.
+#
+# This is intentionally narrow: it only grants the collaborator/review-bot
+# allowance for GitHub's Dependabot bot, same-repository branches, commits by
+# dependabot[bot], dependency-file-only diffs, allowlisted dependency names,
+# and no terminal security-scan failures. Required CI still gates the merge in
+# the caller; this helper only answers whether the bot-origin trust boundary is
+# strong enough to avoid treating the PR like an untrusted external author.
+#
+# #aidevops:trust-boundary — Dependabot bypass is not author-name trust. It
+# validates API author identity, repository ownership, commit authorship, diff
+# shape, explicit dependency allowlist, and security-scan status before granting
+# any merge/approval allowance.
+# Args: $1=pr_number, $2=repo_slug, $3=pr_author
+# Returns: 0 trusted Dependabot update, 1 not trusted
+#######################################
+_is_trusted_dependabot_update_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="${3:-}"
+
+	[[ "${AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES:-1}" != "0" ]] || return 1
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	case "$pr_author" in
+	dependabot\[bot\] | app/dependabot | "") ;;
+	*) return 1 ;;
+	esac
+
+	local pr_json
+	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json author,body,commits,files,headRepository,headRepositoryOwner,statusCheckRollup \
+		2>/dev/null) || return 1
+	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
+
+	local repo_owner="${repo_slug%%/*}"
+	local api_author head_owner head_repo
+	api_author=$(printf '%s' "$pr_json" | jq -r '.author.login // ""' 2>/dev/null) || return 1
+	head_owner=$(printf '%s' "$pr_json" | jq -r '.headRepositoryOwner.login // .headRepositoryOwner.name // ""' 2>/dev/null) || return 1
+	head_repo=$(printf '%s' "$pr_json" | jq -r '.headRepository.nameWithOwner // ""' 2>/dev/null) || return 1
+	case "$api_author" in
+	dependabot\[bot\] | app/dependabot) ;;
+	*) return 1 ;;
+	esac
+	[[ "$head_owner" == "$repo_owner" && "$head_repo" == "$repo_slug" ]] || return 1
+
+	local bad_commits
+	bad_commits=$(printf '%s' "$pr_json" | jq '[.commits[]? | select([.authors[]?.login] | index("dependabot[bot]") | not)] | length' 2>/dev/null) || return 1
+	[[ "$bad_commits" == "0" ]] || return 1
+
+	local bad_files
+	bad_files=$(printf '%s' "$pr_json" | jq -r '[.files[]?.path | select(test("(^|/)(requirements(-lock)?\\.txt|requirements.*\\.txt|pyproject\\.toml|poetry\\.lock|uv\\.lock|Pipfile\\.lock|package(-lock)?\\.json|pnpm-lock\\.yaml|yarn\\.lock|composer\\.(json|lock)|Gemfile\\.lock|go\\.(mod|sum)|Cargo\\.(toml|lock))$|^\\.github/dependabot\\.yml$"; "i") | not)] | length' 2>/dev/null) || return 1
+	[[ "$bad_files" == "0" ]] || return 1
+
+	local security_failures
+	security_failures=$(printf '%s' "$pr_json" | jq 'def up(v): (v // "" | ascii_upcase); [.statusCheckRollup[]? | select(((.name // .context // "") | test("security|socket|codeql|dependabot"; "i")) and (up(.conclusion) == "FAILURE" or up(.conclusion) == "ERROR" or up(.state) == "FAILURE" or up(.state) == "ERROR"))] | length' 2>/dev/null) || return 1
+	[[ "$security_failures" == "0" ]] || return 1
+
+	local body package_manager dependencies dependency_name allowed_count=0
+	body=$(printf '%s' "$pr_json" | jq -r '.body // ""' 2>/dev/null) || body=""
+	package_manager=$(printf '%s' "$body" | sed -nE 's/^Bumps the ([A-Za-z0-9_.-]+) group.*$/\1/p' | head -1)
+	dependencies=$(printf '%s\n' "$body" | sed -nE 's/^[[:space:]]*-[[:space:]]*dependency-name:[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/p')
+	[[ -n "$dependencies" ]] || return 1
+	while IFS= read -r dependency_name; do
+		[[ -n "$dependency_name" ]] || continue
+		if ! _trusted_dependabot_dependency_allowed "$package_manager" "$dependency_name"; then
+			echo "[pulse-wrapper] trusted Dependabot gate: PR #${pr_number} in ${repo_slug} dependency ${package_manager:+${package_manager}:}${dependency_name} is not allowlisted" >>"$LOGFILE"
+			return 1
+		fi
+		allowed_count=$((allowed_count + 1))
+	done <<<"$dependencies"
+	[[ "$allowed_count" -gt 0 ]] || return 1
+
+	echo "[pulse-wrapper] trusted Dependabot gate: PR #${pr_number} in ${repo_slug} passed bot identity, same-repo, commit, file, allowlist, and security-scan checks" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
 # Check and flag external-contributor PRs (t1391)
 #
 # Deterministic idempotency guard for the external-contributor comment.
@@ -107,7 +225,7 @@ check_external_contributor_pr() {
 		return 2
 	fi
 
-	if [[ "$has_label" == "true" || "$has_comment" == "true" ]]; then
+	if $has_label || $has_comment; then
 		# Already flagged. Re-add label if missing (comment exists but label doesn't).
 		if [[ "$has_label" == "false" ]]; then
 			gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
@@ -492,8 +610,13 @@ approve_collaborator_pr() {
 	# crypto-approval is an additional path through the author gate, not a
 	# removal of the gate. Case B (CONTRIBUTOR + no crypto = refuse) is
 	# pinned by test-pulse-merge-approve-collaborator-guard.sh Case P.
+	local approval_body
+	approval_body="Auto-approved by pulse runner @${current_user:-unknown} — author @${pr_author} confirmed collaborator, pre-merge gates passed."
 	if [[ -n "$pr_author" ]] && [[ "$pr_author" != "unknown" ]] && ! _is_collaborator_author "$pr_author" "$repo_slug"; then
-		if _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
+			approval_body="Auto-approved by pulse runner @${current_user:-unknown} — trusted Dependabot dependency update verified: GitHub bot identity, same-repo branch, dependabot-authored commits, dependency-file-only diff, maintainer allowlist, no security-scan failures, and pre-merge gates passed."
+			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is trusted Dependabot with allowlisted dependency update — proceeding (GH#24473)" >>"$LOGFILE"
+		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
 			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is not a collaborator on $repo_slug, but maintainer crypto-approval found — proceeding (t3063)" >>"$LOGFILE"
 			# fall through to the approval block below
 		else
@@ -506,7 +629,7 @@ approve_collaborator_pr() {
 	# (author confirmed collaborator + pulse runner has write access),
 	# not just the misleading "collaborator PR" claim.
 	local approve_output
-	approve_output=$(gh pr review "$pr_number" --repo "$repo_slug" --approve --body "Auto-approved by pulse runner @${current_user:-unknown} — author @${pr_author} confirmed collaborator, pre-merge gates passed." 2>&1)
+	approve_output=$(gh pr review "$pr_number" --repo "$repo_slug" --approve --body "$approval_body" 2>&1)
 	local approve_exit=$?
 
 	if [[ $approve_exit -eq 0 ]]; then

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -120,7 +120,7 @@ _is_trusted_dependabot_update_pr() {
 	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
 
 	local repo_owner="${repo_slug%%/*}"
-	local api_author head_owner head_repo
+	local api_author="" head_owner="" head_repo=""
 	api_author=$(printf '%s' "$pr_json" | jq -r '.author.login // ""' 2>/dev/null) || return 1
 	head_owner=$(printf '%s' "$pr_json" | jq -r '.headRepositoryOwner.login // .headRepositoryOwner.name // ""' 2>/dev/null) || return 1
 	head_repo=$(printf '%s' "$pr_json" | jq -r '.headRepository.nameWithOwner // ""' 2>/dev/null) || return 1

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -214,7 +214,9 @@ _check_pr_merge_gates() {
 	# (requires root-owned SSH key that workers cannot forge). Symmetric with
 	# t3052 which extended the worker-briefed gate the same way (PR #21767).
 	if ! _is_collaborator_author "$pr_author" "$repo_slug"; then
-		if _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
+			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
+		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator but has maintainer crypto-approval, proceeding (t3063)" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
@@ -312,6 +314,10 @@ _check_pr_merge_gates() {
 	# --admin bypasses branch protection; enforce in code (see review-bot-gate-helper.sh).
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
 	if [[ -f "$rbg_helper" ]]; then
+		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
+			echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
+			return 0
+		fi
 		local rbg_result="" rbg_status=""
 		rbg_result=$(bash "$rbg_helper" check "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
 		rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -222,6 +222,9 @@ define_helpers_under_test() {
 		cat "${TEST_ROOT}/linked-issue.txt" 2>/dev/null || true
 		return 0
 	}
+	# This test focuses on the collaborator/crypto guard. Dependabot-specific
+	# allowances are covered by test-pulse-merge-trusted-dependabot.sh.
+	_is_trusted_dependabot_update_pr() { return 1; }
 
 	# shellcheck disable=SC1090
 	eval "$collab_src"

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for trusted Dependabot dependency-update allowances.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+GATES_SCRIPT="${SCRIPT_DIR}/../pulse-merge-gates.sh"
+AUTHOR_CHECKS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-author-checks.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+write_pr_fixture() {
+	local author_login="$1"
+	local commit_login="$2"
+	local changed_path="$3"
+	local security_conclusion="$4"
+	cat >"${TEST_ROOT}/pr.json" <<EOF
+{
+  "author": {"login": "${author_login}"},
+  "headRepositoryOwner": {"login": "owner"},
+  "headRepository": {"nameWithOwner": "owner/repo"},
+  "body": "Bumps the pip group with 1 update in the / directory: [pyarrow](https://github.com/apache/arrow).\n\n---\nupdated-dependencies:\n- dependency-name: pyarrow\n  dependency-version: 23.0.1\n  dependency-type: direct:production\n  dependency-group: pip\n...",
+  "commits": [
+    {"authors": [{"login": "${commit_login}"}]}
+  ],
+  "files": [
+    {"path": "${changed_path}"}
+  ],
+  "statusCheckRollup": [
+    {"name": "Socket Security: Pull Request Alerts", "conclusion": "${security_conclusion}", "status": "COMPLETED"},
+    {"name": "Framework Validation", "conclusion": "SUCCESS", "status": "COMPLETED"}
+  ]
+}
+EOF
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="${TEST_ROOT}/trusted-dependabot-updates.conf"
+	printf 'pip:pyarrow\n' >"$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	export TEST_ROOT GH_LOG
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	printf 'pulse-runner\n' >"${TEST_ROOT}/collaborators.txt"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	cat "${TEST_ROOT}/pr.json"
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+	printf 'pulse-runner\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "-i" && "$*" == *"/collaborators/"*"/permission" ]]; then
+	_user="${3#*/collaborators/}"
+	_user="${_user%/permission}"
+	if grep -Fxq "$_user" "${TEST_ROOT}/collaborators.txt"; then
+		printf 'HTTP/2.0 200 OK\n'
+	else
+		printf 'HTTP/2.0 404 Not Found\n'
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "$*" == *"/collaborators/"*"/permission"* && "$*" == *"--jq"* ]]; then
+	_user="${2#*/collaborators/}"
+	_user="${_user%/permission}"
+	if grep -Fxq "$_user" "${TEST_ROOT}/collaborators.txt"; then
+		printf 'admin\n'
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
+	printf '0\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "review" ]]; then
+	exit 0
+fi
+
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+define_helpers_under_test() {
+	local dependabot_src=""
+	local approve_src=""
+	local collab_src=""
+	dependabot_src=$(awk '
+		/^_trusted_dependabot_updates_conf\(\) \{/,/^}$/ { print }
+		/^_trusted_dependabot_dependency_allowed\(\) \{/,/^}$/ { print }
+		/^_is_trusted_dependabot_update_pr\(\) \{/,/^}$/ { print }
+	' "$GATES_SCRIPT")
+	approve_src=$(awk '/^approve_collaborator_pr\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
+	collab_src=$(awk '/^_is_collaborator_author\(\) \{/,/^}$/ { print }' "$AUTHOR_CHECKS_SCRIPT")
+	[[ -n "$dependabot_src" && -n "$approve_src" && -n "$collab_src" ]] || return 1
+
+	_has_maintainer_crypto_approval() { return 1; }
+	# shellcheck disable=SC1090
+	eval "$collab_src"
+	# shellcheck disable=SC1090
+	eval "$dependabot_src"
+	# shellcheck disable=SC1090
+	eval "$approve_src"
+	return 0
+}
+
+test_trusted_dependabot_passes() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]"; then
+		print_result "trusted Dependabot update passes narrow gate" 0
+		return 0
+	fi
+	print_result "trusted Dependabot update passes narrow gate" 1 "Expected helper to trust fixture. Log: $(<"$LOGFILE")"
+	return 0
+}
+
+test_spoofed_author_fails() {
+	write_pr_fixture "attacker" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]"; then
+		print_result "spoofed Dependabot author fails" 1 "Unexpected trusted result"
+		return 0
+	fi
+	print_result "spoofed Dependabot author fails" 0
+	return 0
+}
+
+test_security_failure_fails() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "FAILURE"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]"; then
+		print_result "security-scan failure blocks Dependabot trust" 1 "Unexpected trusted result"
+		return 0
+	fi
+	print_result "security-scan failure blocks Dependabot trust" 0
+	return 0
+}
+
+test_non_dependency_file_fails() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" ".github/workflows/pwn.yml" "SUCCESS"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]"; then
+		print_result "non-dependency file blocks Dependabot trust" 1 "Unexpected trusted result"
+		return 0
+	fi
+	print_result "non-dependency file blocks Dependabot trust" 0
+	return 0
+}
+
+test_trusted_dependabot_can_be_approved() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	approve_collaborator_pr "24473" "owner/repo" "dependabot[bot]" >/dev/null || true
+	if grep -qF 'pr review 24473' "$GH_LOG" \
+		&& grep -qF 'trusted Dependabot dependency update verified' "$GH_LOG"; then
+		print_result "trusted Dependabot PR receives accurate auto-approval" 0
+		return 0
+	fi
+	print_result "trusted Dependabot PR receives accurate auto-approval" 1 "Expected approval call. gh log: $(<"$GH_LOG")"
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	define_helpers_under_test
+	test_trusted_dependabot_passes
+	test_spoofed_author_fails
+	test_security_failure_fails
+	test_non_dependency_file_fails
+	test_trusted_dependabot_can_be_approved
+
+	printf '\nTests run: %s\n' "$TESTS_RUN"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		printf 'Tests failed: %s\n' "$TESTS_FAILED"
+		exit 1
+	fi
+	printf 'All tests passed.\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a narrow trusted-Dependabot gate for authentic same-repo GitHub Dependabot version-update PRs
- require dependabot-authored commits, dependency-file-only diffs, maintainer allowlist entries, no terminal security-scan failures, and normal green required CI before merge
- allow trusted Dependabot PRs to bypass collaborator/review-bot treatment and receive an accurate pulse approval body instead of being handled as untrusted external work

## Files / patterns
- `.agents/scripts/pulse-merge-gates.sh`: trust-boundary helper and approval wording
- `.agents/scripts/pulse-merge.sh`: collaborator/review-bot gate allowance
- `.agents/configs/trusted-dependabot-updates.conf`: maintainer allowlist, currently `pip:pyarrow`
- `.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`: spoof/security/file-shape/approval regression coverage

## Verification
- `.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
- `.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh`
- `shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh`
- `.agents/scripts/linters-local.sh`

Ref #24477

## Notes
- Prompted by interactive maintainer review of PR #24473.
- Security boundary is fail-closed; dependency names must be explicitly allowlisted unless a maintainer intentionally configures `*`.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.15 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 58m and 263,993 tokens on this with the user in an interactive session.