### PR TITLE
fix: ignore review gate for trusted dependabot CI

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -162,6 +162,46 @@ _is_trusted_dependabot_update_pr() {
 }
 
 #######################################
+# Verify all non-review-bot checks are green for trusted Dependabot updates.
+#
+# GitHub's review-bot-gate workflow can remain red on Dependabot PRs because
+# AI review bots often skip dependency-only updates. This helper is the narrow
+# escape hatch: it ignores only review-bot-gate contexts and requires every
+# other check/status in the rollup to be terminal-success/neutral/skipped.
+# Args: $1=pr_number, $2=repo_slug
+# Returns: 0 non-review checks green, 1 otherwise
+#######################################
+_trusted_dependabot_non_review_checks_green() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_json=""
+	local result=""
+	local non_review_count="0" blocker_count="0"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json statusCheckRollup 2>/dev/null) || return 1
+	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
+
+	result=$(printf '%s' "$pr_json" | jq -r '
+		def up(v): (v // "" | ascii_upcase);
+		def check_label: (.name // .context // "");
+		def is_review_gate: ((check_label | test("(^|/ )review-bot-gate$|^review-bot-gate$"; "i")) or ((.workflowName // "") == "Review Bot Gate"));
+		def passish: (up(.conclusion) == "SUCCESS" or up(.conclusion) == "NEUTRAL" or up(.conclusion) == "SKIPPED" or up(.state) == "SUCCESS");
+		def pendingish: (up(.status) == "QUEUED" or up(.status) == "IN_PROGRESS" or up(.state) == "PENDING" or up(.state) == "EXPECTED" or ((up(.conclusion) == "") and (up(.state) != "SUCCESS") and (up(.status) != "COMPLETED")));
+		[([.statusCheckRollup[]? | select(is_review_gate | not)] | length),
+		 ([.statusCheckRollup[]? | select((is_review_gate | not) and (pendingish or (passish | not)))] | length)] | @tsv
+	' 2>/dev/null) || return 1
+	read -r non_review_count blocker_count <<<"$result"
+	[[ "$non_review_count" =~ ^[0-9]+$ && "$blocker_count" =~ ^[0-9]+$ ]] || return 1
+	if [[ "$non_review_count" -gt 0 && "$blocker_count" -eq 0 ]]; then
+		echo "[pulse-wrapper] trusted Dependabot checks: PR #${pr_number} in ${repo_slug} has all non-review-bot checks green" >>"$LOGFILE"
+		return 0
+	fi
+	echo "[pulse-wrapper] trusted Dependabot checks: PR #${pr_number} in ${repo_slug} blocked (non_review=${non_review_count}, blockers=${blocker_count})" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
 # Check and flag external-contributor PRs (t1391)
 #
 # Deterministic idempotency guard for the external-contributor comment.

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -908,7 +908,10 @@ _process_single_ready_pr() {
 		# CI-failure routing path, preserving the contributor security gate.
 		local _rcl_labels
 		_rcl_labels="$pr_labels"
-		if [[ ",${_rcl_labels}," == *"${_OW_LABEL_PAT}"* ]] \
+		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" \
+			&& _trusted_dependabot_non_review_checks_green "$pr_number" "$repo_slug"; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for trusted Dependabot — all non-review-bot checks are green (GH#24477)" >>"$LOGFILE"
+		elif [[ ",${_rcl_labels}," == *"${_OW_LABEL_PAT}"* ]] \
 			&& _check_required_checks_passing "$repo_slug" "$pr_number"; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for origin:worker — branch-protection required contexts all pass (t2922)" >>"$LOGFILE"
 			# Fall through to linked-issue fetch and merge gate checks

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -43,6 +43,7 @@ write_pr_fixture() {
 	local commit_login="$2"
 	local changed_path="$3"
 	local security_conclusion="$4"
+	local framework_conclusion="${5:-SUCCESS}"
 	cat >"${TEST_ROOT}/pr.json" <<EOF
 {
   "author": {"login": "${author_login}"},
@@ -55,10 +56,11 @@ write_pr_fixture() {
   "files": [
     {"path": "${changed_path}"}
   ],
-  "statusCheckRollup": [
-    {"name": "Socket Security: Pull Request Alerts", "conclusion": "${security_conclusion}", "status": "COMPLETED"},
-    {"name": "Framework Validation", "conclusion": "SUCCESS", "status": "COMPLETED"}
-  ]
+	"statusCheckRollup": [
+		{"name": "Socket Security: Pull Request Alerts", "conclusion": "${security_conclusion}", "status": "COMPLETED"},
+		{"name": "Framework Validation", "conclusion": "${framework_conclusion}", "status": "COMPLETED"},
+		{"name": "gate / review-bot-gate", "workflowName": "Review Bot Gate", "conclusion": "FAILURE", "status": "COMPLETED"}
+	]
 }
 EOF
 	return 0
@@ -142,6 +144,7 @@ define_helpers_under_test() {
 		/^_trusted_dependabot_updates_conf\(\) \{/,/^}$/ { print }
 		/^_trusted_dependabot_dependency_allowed\(\) \{/,/^}$/ { print }
 		/^_is_trusted_dependabot_update_pr\(\) \{/,/^}$/ { print }
+		/^_trusted_dependabot_non_review_checks_green\(\) \{/,/^}$/ { print }
 	' "$GATES_SCRIPT")
 	approve_src=$(awk '/^approve_collaborator_pr\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
 	collab_src=$(awk '/^_is_collaborator_author\(\) \{/,/^}$/ { print }' "$AUTHOR_CHECKS_SCRIPT")
@@ -209,6 +212,26 @@ test_trusted_dependabot_can_be_approved() {
 	return 0
 }
 
+test_review_bot_failure_is_ignored_when_other_checks_green() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS" "SUCCESS"
+	if _trusted_dependabot_non_review_checks_green "24473" "owner/repo"; then
+		print_result "review-bot failure ignored when non-review checks green" 0
+		return 0
+	fi
+	print_result "review-bot failure ignored when non-review checks green" 1 "Expected non-review check helper to pass. Log: $(<"$LOGFILE")"
+	return 0
+}
+
+test_non_review_failure_blocks_required_check_bypass() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS" "FAILURE"
+	if _trusted_dependabot_non_review_checks_green "24473" "owner/repo"; then
+		print_result "non-review failure blocks Dependabot required-check bypass" 1 "Unexpected bypass"
+		return 0
+	fi
+	print_result "non-review failure blocks Dependabot required-check bypass" 0
+	return 0
+}
+
 main() {
 	setup_test_env
 	trap teardown_test_env EXIT
@@ -218,6 +241,8 @@ main() {
 	test_security_failure_fails
 	test_non_dependency_file_fails
 	test_trusted_dependabot_can_be_approved
+	test_review_bot_failure_is_ignored_when_other_checks_green
+	test_non_review_failure_blocks_required_check_bypass
 
 	printf '\nTests run: %s\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- add a required-check escape hatch for trusted Dependabot updates when only review-bot-gate is red
- require every non-review-bot check/status in the rollup to be terminal green/neutral/skipped
- add regression coverage for review-bot-only failure vs real non-review CI failure

## Files / patterns
- `.agents/scripts/pulse-merge-gates.sh`: `_trusted_dependabot_non_review_checks_green`
- `.agents/scripts/pulse-merge.sh`: required-check bypass for trusted Dependabot only
- `.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`: review-gate and non-review failure cases

## Verification
- `.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
- `.agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-merge-gates.sh`
- `shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
- `.agents/scripts/linters-local.sh`

Ref #24477
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.17 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1h 31m and 372,364 tokens on this with the user in an interactive session.