### PR TITLE
GH#24480: fix: reuse dependabot status rollup

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -168,18 +168,20 @@ _is_trusted_dependabot_update_pr() {
 # AI review bots often skip dependency-only updates. This helper is the narrow
 # escape hatch: it ignores only review-bot-gate contexts and requires every
 # other check/status in the rollup to be terminal-success/neutral/skipped.
-# Args: $1=pr_number, $2=repo_slug
+# Args: $1=pr_number, $2=repo_slug, $3=optional precomputed PR JSON
 # Returns: 0 non-review checks green, 1 otherwise
 #######################################
 _trusted_dependabot_non_review_checks_green() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local pr_json=""
+	local pr_json="${3:-}"
 	local result=""
 	local non_review_count="0" blocker_count="0"
 
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
-	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json statusCheckRollup 2>/dev/null) || return 1
+	if [[ -z "$pr_json" ]]; then
+		pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json statusCheckRollup 2>/dev/null) || return 1
+	fi
 	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
 
 	result=$(printf '%s' "$pr_json" | jq -r '

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -98,7 +98,7 @@ _pm_issue_api() {
 # caller that builds a PR object on this helper so draft/label/staleness
 # metadata cannot drift between list-based and webhook-triggered merge paths.
 _pulse_merge_ready_pr_json_fields() {
-	printf '%s' 'number,mergeable,reviewDecision,author,title,isDraft,labels,updatedAt,headRefOid,createdAt'
+	printf '%s' 'number,mergeable,reviewDecision,author,title,isDraft,labels,updatedAt,headRefOid,createdAt,statusCheckRollup'
 	return 0
 }
 
@@ -909,7 +909,7 @@ _process_single_ready_pr() {
 		local _rcl_labels
 		_rcl_labels="$pr_labels"
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" \
-			&& _trusted_dependabot_non_review_checks_green "$pr_number" "$repo_slug"; then
+			&& _trusted_dependabot_non_review_checks_green "$pr_number" "$repo_slug" "$pr_obj"; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for trusted Dependabot — all non-review-bot checks are green (GH#24477)" >>"$LOGFILE"
 		elif [[ ",${_rcl_labels}," == *"${_OW_LABEL_PAT}"* ]] \
 			&& _check_required_checks_passing "$repo_slug" "$pr_number"; then

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -222,6 +222,21 @@ test_review_bot_failure_is_ignored_when_other_checks_green() {
 	return 0
 }
 
+test_precomputed_status_rollup_skips_pr_view() {
+	local pr_json=""
+
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS" "SUCCESS"
+	pr_json=$(<"${TEST_ROOT}/pr.json")
+	: >"$GH_LOG"
+	if _trusted_dependabot_non_review_checks_green "24473" "owner/repo" "$pr_json" \
+		&& ! grep -qF 'gh pr view 24473' "$GH_LOG"; then
+		print_result "precomputed status rollup skips PR view" 0
+		return 0
+	fi
+	print_result "precomputed status rollup skips PR view" 1 "Expected no gh pr view call. gh log: $(<"$GH_LOG")"
+	return 0
+}
+
 test_non_review_failure_blocks_required_check_bypass() {
 	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS" "FAILURE"
 	if _trusted_dependabot_non_review_checks_green "24473" "owner/repo"; then
@@ -242,6 +257,7 @@ main() {
 	test_non_dependency_file_fails
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green
+	test_precomputed_status_rollup_skips_pr_view
 	test_non_review_failure_blocks_required_check_bypass
 
 	printf '\nTests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Updated the trusted Dependabot non-review check helper to accept optional precomputed PR JSON, included statusCheckRollup in ready PR JSON fields, and passed the existing PR object through the merge bypass path to avoid a redundant gh pr view.

## Files Changed

.agents/scripts/pulse-merge-gates.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh && .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #24480


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.17 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 117,818 tokens on this as a headless worker.