### PR TITLE
GH#24483: fix: use sqlite timeout helper for ledger sync

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1025,17 +1025,16 @@ _copy_worker_db_migration_ledger_table() {
 	local ledger_table="$3"
 	local has_shared has_worker shared_db_sql
 
-	has_shared=$(sqlite3 "$shared_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
+	has_shared=$(sqlite3_with_timeout "$shared_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
 	[[ -n "$has_shared" ]] || return 0
 
-	has_worker=$(sqlite3 "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
+	has_worker=$(sqlite3_with_timeout "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
 	if [[ -z "$has_worker" ]]; then
 		sqlite3_with_timeout "$shared_db" ".schema ${ledger_table}" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
 	fi
 
 	shared_db_sql=$(sql_escape "$shared_db")
-	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
-		.timeout 5000
+	sqlite3_with_timeout "$worker_db" <<-SQL >/dev/null 2>&1 || true
 		ATTACH DATABASE '${shared_db_sql}' AS shared;
 		INSERT OR IGNORE INTO main."${ledger_table}" SELECT * FROM shared."${ledger_table}";
 		DETACH DATABASE shared;


### PR DESCRIPTION
## Summary

Replaced the raw sqlite3 migration-ledger table existence checks and copy heredoc in .agents/scripts/headless-runtime-lib.sh with sqlite3_with_timeout so worker DB ledger sync uses the shared busy-timeout handling consistently.

## Files Changed

.agents/scripts/headless-runtime-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh (67 passed); tests/test-headless-runtime-helper.sh (fails pre-existing model-selection/session-env expectations unrelated to this SQLite ledger helper change)

Resolves #24483


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.17 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 40,759 tokens on this as a headless worker.