### PR TITLE
GH#24482: fix: sanitize zero-progress threshold

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1485,12 +1485,14 @@ pulse_merge_zero_progress_record() {
 	[[ "$cur" =~ ^[0-9]+$ ]] || cur=0
 	cur=$((cur + 1))
 	pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "$cur"
+	local threshold="${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:-}"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=5
 
-	echo "[pulse-merge-stuck] pulse_merge_zero_progress_record: zero_progress_cycles=${cur}/${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES}, eligible_unmerged=${eligible_unmerged}" >>"$LOGFILE"
+	echo "[pulse-merge-stuck] pulse_merge_zero_progress_record: zero_progress_cycles=${cur}/${threshold}, eligible_unmerged=${eligible_unmerged}" >>"$LOGFILE"
 
 	# File only on the threshold-crossing edge to prevent post-close issue storms.
-	if [[ "$cur_before" -lt "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" \
-		&& "$cur" -ge "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" ]]; then
+	if [[ "$cur_before" -lt "$threshold" \
+		&& "$cur" -ge "$threshold" ]]; then
 		local stuck_summary
 		stuck_summary=$(pulse_stats_get_gauge "pulse_merge_eligible_stuck_pr_count")
 		stuck_summary="eligible_unmerged_this_cycle=${eligible_unmerged}, eligible_stuck_count=${stuck_summary}, zero_progress_cycles=${cur}"

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1479,7 +1479,6 @@ pulse_merge_zero_progress_record() {
 		return 0
 	fi
 
-	# Increment the gauge by 1.
 	local cur
 	cur=$(pulse_stats_get_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES")
 	[[ "$cur" =~ ^[0-9]+$ ]] || cur=0
@@ -1487,7 +1486,6 @@ pulse_merge_zero_progress_record() {
 	pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "$cur"
 	local threshold="${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:-}"
 	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=5
-
 	echo "[pulse-merge-stuck] pulse_merge_zero_progress_record: zero_progress_cycles=${cur}/${threshold}, eligible_unmerged=${eligible_unmerged}" >>"$LOGFILE"
 
 	# File only on the threshold-crossing edge to prevent post-close issue storms.

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -338,6 +338,19 @@ pulse_merge_zero_progress_record 1 0 >/dev/null 2>&1
 pulse_merge_zero_progress_record 1 0 >/dev/null 2>&1
 create_count=$(grep -c 'gh_create_issue --repo marcusquinn/aidevops' "$GH_CALLS")
 assert_eq "5g: zero-progress meta-issue files once on threshold crossing" "1" "$create_count"
+
+# 5h: an invalid threshold environment value falls back to the safe default
+# instead of making Bash integer comparisons abort the pulse.
+: >"$GH_CALLS"
+AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES="not-a-number"
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "4" >/dev/null 2>&1
+pulse_stats_set_gauge "pulse_merge_eligible_stuck_pr_count" "0" >/dev/null 2>&1
+pulse_merge_zero_progress_record 1 0 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+create_count=$(grep -c 'gh_create_issue --repo marcusquinn/aidevops' "$GH_CALLS")
+assert_eq "5h: invalid zero-progress threshold still increments gauge" "5" "$got"
+assert_eq "5h: invalid zero-progress threshold falls back to default for filing" "1" "$create_count"
+AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=5
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sanitized the zero-progress cycle threshold before integer comparisons and added regression coverage for invalid threshold values while keeping pulse-merge-stuck.sh within the file-size ratchet.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh; .agents/scripts/tests/test-pulse-merge-stuck.sh

Resolves #24482


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.17 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 48,147 tokens on this as a headless worker.