### PR TITLE
GH#24487: fix: use gh issue view for preclaim refresh

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1664,8 +1664,8 @@ _dlw_issue_still_open_before_claim() {
 	# persistent DISPATCH_CLAIM. Refresh just the issue state immediately before
 	# cross-runner claim/label/worktree mutation so auto-resolved meta-issues do
 	# not consume worker capacity after they close.
-	refreshed_state=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
-		--json state --jq '.state // ""' 2>/dev/null | tr '[:lower:]' '[:upper:]') || refreshed_state=""
+	refreshed_state=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state --jq '.state // ""' | tr '[:lower:]' '[:upper:]') || refreshed_state=""
 	if [[ -z "$refreshed_state" ]]; then
 		echo "[dispatch_with_dedup] Warning: unable to refresh issue state for #${issue_number} in ${repo_slug} before claim; proceeding with prior dispatch gates" >>"$LOGFILE"
 		return 0

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -203,8 +203,13 @@ _dlw_resolve_tier_and_model() {
 }
 _dlw_canary_preflight() { return 0; }
 STUB_REFRESH_STATE="OPEN"
-gh_issue_view() {
-	printf '%s\n' "$STUB_REFRESH_STATE"
+
+gh() {
+	if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+		printf '%s\n' "$STUB_REFRESH_STATE"
+		return 0
+	fi
+
 	return 0
 }
 CLAIM_LOCK_CALLS_FILE="${TMP}/claim-lock-calls.txt"


### PR DESCRIPTION
## Summary

Replaced the typoed gh_issue_view helper call with the real GitHub CLI gh issue view invocation and updated the regression test to stub gh issue view directly.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-precreation-failure-skip.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-precreation-failure-skip.sh; .agents/scripts/tests/test-precreation-failure-skip.sh

Resolves #24487


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.17 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 74,126 tokens on this as a headless worker.