### PR TITLE
GH#24496: fix: scope headless sessions by repo

### DIFF
--- a/.agents/scripts/headless-runtime-helper-cmds.sh
+++ b/.agents/scripts/headless-runtime-helper-cmds.sh
@@ -132,7 +132,7 @@ cmd_session() {
 			print_error "Usage: session clear <provider> <session_key>"
 			return 1
 		}
-		db_query "DELETE FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$session_key")';" >/dev/null
+		clear_session_id "$provider" "$session_key"
 		return 0
 		;;
 	*)

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -136,17 +136,45 @@ ON CONFLICT(role) DO UPDATE SET
 	return 0
 }
 
+_provider_session_repo_slug() {
+	local repo_slug="${WORKER_REPO_SLUG:-${DISPATCH_REPO_SLUG:-${GITHUB_REPOSITORY:-}}}"
+	repo_slug="${repo_slug#https://github.com/}"
+	repo_slug="${repo_slug#git@github.com:}"
+	repo_slug="${repo_slug%.git}"
+	case "$repo_slug" in
+	*/*) printf '%s' "$repo_slug" ;;
+	*) printf '%s' "" ;;
+	esac
+	return 0
+}
+
+scoped_provider_session_key() {
+	local session_key="$1"
+	local repo_slug=""
+	repo_slug=$(_provider_session_repo_slug)
+	if [[ "$session_key" == issue-* && -n "$repo_slug" ]]; then
+		printf '%s#%s' "$repo_slug" "$session_key"
+		return 0
+	fi
+	printf '%s' "$session_key"
+	return 0
+}
+
 get_session_id() {
 	local provider="$1"
 	local session_key="$2"
-	db_query "SELECT session_id FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$session_key")';"
+	local scoped_key=""
+	scoped_key=$(scoped_provider_session_key "$session_key")
+	db_query "SELECT session_id FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$scoped_key")';"
 	return 0
 }
 
 clear_session_id() {
 	local provider="$1"
 	local session_key="$2"
-	db_query "DELETE FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$session_key")';" >/dev/null
+	local scoped_key=""
+	scoped_key=$(scoped_provider_session_key "$session_key")
+	db_query "DELETE FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key IN ('$(sql_escape "$scoped_key")', '$(sql_escape "$session_key")');" >/dev/null
 	return 0
 }
 
@@ -155,11 +183,16 @@ store_session_id() {
 	local session_key="$2"
 	local session_id="$3"
 	local model="$4"
+	local scoped_key=""
+	scoped_key=$(scoped_provider_session_key "$session_key")
+	if [[ "$scoped_key" != "$session_key" ]]; then
+		db_query "DELETE FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$session_key")';" >/dev/null
+	fi
 	db_query "
 INSERT INTO provider_sessions (provider, session_key, session_id, model, updated_at)
 VALUES (
     '$(sql_escape "$provider")',
-    '$(sql_escape "$session_key")',
+    '$(sql_escape "$scoped_key")',
     '$(sql_escape "$session_id")',
     '$(sql_escape "$model")',
     strftime('%Y-%m-%dT%H:%M:%SZ', 'now')

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -257,11 +257,12 @@ _diagnose_cooldown_for_rate_limit_count() {
 }
 
 # Summarise headless runtime attempts for an issue and project retry/backoff state.
-# Args: $1=issue_number $2=metrics_file
+# Args: $1=issue_number $2=metrics_file $3=repo_slug (optional)
 # Outputs compact JSON object.
 _issue_attempt_summary_json() {
 	local issue_number="$1"
 	local metrics_file="$2"
+	local repo_slug="${3:-}"
 	local session_key="issue-${issue_number}"
 
 	if [[ ! -f "$metrics_file" ]] || ! command -v jq >/dev/null 2>&1; then
@@ -270,15 +271,17 @@ _issue_attempt_summary_json() {
 	fi
 
 	local summary=""
-	summary=$(jq -rs --arg sk "$session_key" --arg issue "$issue_number" '
+	summary=$(jq -rs --arg sk "$session_key" --arg issue "$issue_number" --arg repo "$repo_slug" '
 		def is_issue:
 			((.session_key // "") == $sk) or (((.issue_number // "") | tostring) == $issue);
+		def is_repo:
+			($repo == "") or ((.repo_slug // "") == $repo);
 		def is_rate_limit:
 			(.result // "") == "rate_limit"
 			or (.result // "") == "rate_limit_fast"
 			or (.provider_error_type // "") == "rate_limit"
 			or ((.provider_status // "") | tostring) == "429";
-		[.[] | select(is_issue)] as $attempts
+		[.[] | select(is_issue and is_repo)] as $attempts
 		| ($attempts | map(select(is_rate_limit))) as $rl
 		| {
 			attempt_count: ($attempts | length),
@@ -286,7 +289,7 @@ _issue_attempt_summary_json() {
 			last_attempt_ts: (($attempts | map(.ts // 0) | max) // 0),
 			last_rate_limit_ts: (($rl | map(.ts // 0) | max) // 0),
 			results: ($attempts | group_by(.result // "unknown") | map({result: (.[0].result // "unknown"), count: length}) | sort_by(.result)),
-			recent_attempts: ($attempts | sort_by(.ts // 0) | reverse | .[0:5] | map({ts: (.ts // 0), result: (.result // "unknown"), failure_reason: (.failure_reason // ""), provider: (.provider // ""), model: (.model // ""), exit_code: (.exit_code // null)}))
+			recent_attempts: ($attempts | sort_by(.ts // 0) | reverse | .[0:5] | map({ts: (.ts // 0), result: (.result // "unknown"), failure_reason: (.failure_reason // ""), provider: (.provider // ""), model: (.model // ""), exit_code: (.exit_code // null), repo_slug: (.repo_slug // "")}))
 		}
 	' "$metrics_file" 2>/dev/null) || summary=""
 
@@ -1571,7 +1574,7 @@ cmd_issue() {
 	issue_json=$(_fetch_issue_metadata "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG")
 	comments_json=$(_fetch_issue_comments "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG")
 	pr_numbers=$(_fetch_issue_linked_prs "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG")
-	attempt_summary_json=$(_issue_attempt_summary_json "$_CMD_ISSUE_NUMBER" "$metrics_file")
+	attempt_summary_json=$(_issue_attempt_summary_json "$_CMD_ISSUE_NUMBER" "$metrics_file" "$_CMD_ISSUE_REPO_SLUG")
 	issue_log_lines=$(_collect_issue_log_lines "$_CMD_ISSUE_NUMBER" "$logfile" "$logdir")
 
 	if [[ "$_CMD_ISSUE_JSON_OUTPUT" -eq 1 ]]; then

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -660,6 +660,53 @@ EOF
 	print_result "extract_session_id_from_output returns latest session id" 1 "Expected ses_latest, got ${session_id:-<empty>}"
 	return 0
 }
+
+test_provider_sessions_scope_issue_keys_by_repo_slug() {
+	local provider="openai"
+	local model="openai/gpt-5.5"
+	export WORKER_REPO_SLUG="owner/one"
+	store_session_id "$provider" "issue-47" "ses_one" "$model"
+	export WORKER_REPO_SLUG="owner/two"
+	store_session_id "$provider" "issue-47" "ses_two" "$model"
+
+	local first_session="" second_session="" unscoped_count=""
+	export WORKER_REPO_SLUG="owner/one"
+	first_session=$(get_session_id "$provider" "issue-47")
+	export WORKER_REPO_SLUG="owner/two"
+	second_session=$(get_session_id "$provider" "issue-47")
+	unscoped_count=$(db_query "SELECT count(*) FROM provider_sessions WHERE provider = 'openai' AND session_key = 'issue-47';")
+	unset WORKER_REPO_SLUG
+
+	if [[ "$first_session" == "ses_one" && "$second_session" == "ses_two" && "$unscoped_count" == "0" ]]; then
+		print_result "provider_sessions scope issue keys by repo slug" 0
+		return 0
+	fi
+
+	print_result "provider_sessions scope issue keys by repo slug" 1 \
+		"first=${first_session:-<empty>} second=${second_session:-<empty>} unscoped_count=${unscoped_count:-<empty>}"
+	return 0
+}
+
+test_provider_sessions_keep_pulse_unscoped() {
+	local provider="openai"
+	local model="openai/gpt-5.5"
+	export WORKER_REPO_SLUG="owner/one"
+	store_session_id "$provider" "pulse" "ses_pulse" "$model"
+	local pulse_session="" pulse_count=""
+	pulse_session=$(get_session_id "$provider" "pulse")
+	pulse_count=$(db_query "SELECT count(*) FROM provider_sessions WHERE provider = 'openai' AND session_key = 'pulse';")
+	unset WORKER_REPO_SLUG
+
+	if [[ "$pulse_session" == "ses_pulse" && "$pulse_count" == "1" ]]; then
+		print_result "provider_sessions keep pulse sessions unscoped" 0
+		return 0
+	fi
+
+	print_result "provider_sessions keep pulse sessions unscoped" 1 \
+		"pulse=${pulse_session:-<empty>} count=${pulse_count:-<empty>}"
+	return 0
+}
+
 test_blocked_completion_records_blocked_label() {
 	local output_file="${TEST_ROOT}/blocked-output.jsonl"
 	printf '%s\n' '{"type":"text","sessionID":"ses_blocked","text":"BLOCKED: missing dependency credentials"}' >"$output_file"
@@ -1798,6 +1845,8 @@ main() {
 	test_deleted_launch_cwd_recovers_to_work_dir
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
+	test_provider_sessions_scope_issue_keys_by_repo_slug
+	test_provider_sessions_keep_pulse_unscoped
 	test_blocked_completion_records_blocked_label
 	test_missing_context_blocked_requests_brief_recovery
 	test_headless_activity_timeout_default_matches_watchdog

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -349,9 +349,10 @@ recent_rate_limit_1=$(( now_epoch - 360 ))
 recent_rate_limit_2=$(( now_epoch - 120 ))
 recent_success=$(( now_epoch - 60 ))
 cat > "$FIXTURE_METRICS" <<METRICS
-{"ts":${recent_rate_limit_1},"role":"worker","session_key":"issue-21860","issue_number":21860,"provider":"openai","model":"openai/gpt-5.5","result":"rate_limit","failure_reason":"rate_limit","exit_code":143}
-{"ts":${recent_rate_limit_2},"role":"worker","session_key":"issue-21860","issue_number":21860,"provider":"openai","model":"openai/gpt-5.5","result":"rate_limit_fast","failure_reason":"rate_limit_fast","provider_error_type":"rate_limit","provider_status":429,"exit_code":143}
-{"ts":${recent_success},"role":"worker","session_key":"issue-21860","issue_number":21860,"provider":"openai","model":"openai/gpt-5.5","result":"success","failure_reason":"","exit_code":0}
+{"ts":${recent_rate_limit_1},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"marcusquinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit","failure_reason":"rate_limit","exit_code":143}
+{"ts":${recent_rate_limit_2},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"marcusquinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit_fast","failure_reason":"rate_limit_fast","provider_error_type":"rate_limit","provider_status":429,"exit_code":143}
+{"ts":${recent_success},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"marcusquinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"success","failure_reason":"","exit_code":0}
+{"ts":${recent_success},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"example/other","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit","failure_reason":"rate_limit","exit_code":143}
 METRICS
 
 # --- Test 13: issue subcommand — basic output ---


### PR DESCRIPTION
## Summary

Scoped persisted headless provider session keys by repository for issue workers, kept pulse sessions unscoped, cleaned stale unscoped issue rows, and filtered issue diagnostics metrics by repo slug.

## Files Changed

.agents/scripts/headless-runtime-helper-cmds.sh,.agents/scripts/headless-runtime-model.sh,.agents/scripts/pulse-diagnose-helper.sh,.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/scripts/tests/test-pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; .agents/scripts/tests/test-pulse-diagnose-helper.sh; shellcheck .agents/scripts/headless-runtime-model.sh .agents/scripts/headless-runtime-helper-cmds.sh .agents/scripts/pulse-diagnose-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh .agents/scripts/tests/test-pulse-diagnose-helper.sh; .agents/scripts/linters-local.sh timed out at Secretlint after prior gates passed

Resolves #24496


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.19 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 17m and 133,393 tokens on this as a headless worker.