### PR TITLE
GH#24495: fix: bound pulse check gh api calls

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -54,6 +54,37 @@
 _SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED=1
 
 #######################################
+# Internal: invoke a read-only `gh api` request with a wall-clock cap.
+#
+# Prefer the shared `_gh_with_timeout` wrapper when this sub-library is loaded
+# through shared-gh-wrappers.sh. Keep a local fallback because some tests and
+# single-purpose pulse helpers source shared-gh-wrappers-checks.sh directly.
+#
+# Args:
+#   $1 - REST API endpoint
+#   $@ - remaining gh api arguments
+# Returns: passthrough command exit code (124 when coreutils timeout fires)
+#######################################
+_gh_checks_api_read() {
+	local endpoint="$1"
+	shift
+
+	if declare -f _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read gh api "$endpoint" "$@"
+		return $?
+	fi
+
+	local secs="${AIDEVOPS_GH_READ_TIMEOUT:-15}"
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" gh api "$endpoint" "$@"
+		return $?
+	fi
+
+	gh api "$endpoint" "$@"
+	return $?
+}
+
+#######################################
 # Aggregate PR check status via REST `/commits/{sha}/check-suites`.
 #
 # REST check-suites is ~15x smaller than GraphQL statusCheckRollup
@@ -80,7 +111,7 @@ gh_pr_check_status_rest() {
 	# read-only special variable, which would silently fail under zsh-sourced
 	# interactive use even though the script declares `#!/usr/bin/env bash`.
 	local _check_state=""
-	_check_state=$(gh api "repos/${slug}/commits/${sha}/check-suites" --jq '
+	_check_state=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-suites" --jq '
 		if (.check_suites | length) == 0 then "none"
 		elif (.check_suites | all(.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral")) then "PASS"
 		elif (.check_suites | any(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")) then "FAIL"
@@ -131,7 +162,7 @@ gh_pr_check_runs_rest() {
 	# fails, we emit empty so callers can fail-closed; /status alone is
 	# insufficient signal for branch-protection gating.
 	local runs=""
-	runs=$(gh api "repos/${slug}/commits/${sha}/check-runs" --paginate \
+	runs=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-runs" --paginate \
 		--jq '[.check_runs[]? | {name, conclusion, status}]' 2>/dev/null) || runs=""
 
 	if [[ -z "$runs" ]]; then
@@ -151,7 +182,7 @@ gh_pr_check_runs_rest() {
 	# ($ok/$fail) avoid repeating "success"/"failure" literals three times
 	# each across the file (string-literal ratchet gate).
 	# shellcheck disable=SC2016  # $ok/$fail are jq variables, not bash expansions
-	statuses=$(gh api "repos/${slug}/commits/${sha}/status" \
+	statuses=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/status" \
 		--jq '[.statuses[]? |
 			"success" as $ok | "failure" as $fail |
 			{

--- a/.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)"
+CHECKS_LIB="${SCRIPTS_DIR}/shared-gh-wrappers-checks.sh"
+
+if [[ ! -f "$CHECKS_LIB" ]]; then
+	printf 'ERROR: shared-gh-wrappers-checks.sh not found at %s\n' "$CHECKS_LIB" >&2
+	exit 1
+fi
+
+# shellcheck source=../shared-gh-wrappers-checks.sh
+source "$CHECKS_LIB"
+
+WRAPPER_LOG="$(mktemp)"
+export WRAPPER_LOG
+
+_gh_with_timeout() {
+	local op_class="$1"
+	shift
+	printf '%s\t%s\n' "$op_class" "$*" >>"$WRAPPER_LOG"
+	case "$*" in
+	*check-suites*)
+		printf 'PASS\n'
+		;;
+	*check-runs*)
+		printf '[{"name":"quality","conclusion":"success","status":"completed"}]\n'
+		;;
+	*status*)
+		printf '[]\n'
+		;;
+	*)
+		return 1
+		;;
+	esac
+	return 0
+}
+
+status="$(gh_pr_check_status_rest "owner/repo" "abc123")"
+runs="$(gh_pr_check_runs_rest "owner/repo" "abc123")"
+
+if [[ "$status" != "PASS" ]]; then
+	printf 'FAIL: expected PASS status, got %s\n' "$status" >&2
+	exit 1
+fi
+
+if ! printf '%s' "$runs" | jq -e '. == [{"name":"quality","conclusion":"success","status":"completed"}]' >/dev/null; then
+	printf 'FAIL: unexpected runs JSON: %s\n' "$runs" >&2
+	exit 1
+fi
+
+if [[ "$(grep -c '^read	gh api repos/owner/repo/commits/abc123/' "$WRAPPER_LOG")" -ne 3 ]]; then
+	printf 'FAIL: expected 3 wrapped gh api calls\n' >&2
+	cat "$WRAPPER_LOG" >&2
+	exit 1
+fi
+
+rm -f "$WRAPPER_LOG"
+printf 'PASS shared-gh-wrappers-checks gh api timeout wrapper\n'


### PR DESCRIPTION
## Summary

Wrapped REST check-suites, check-runs, and status gh api calls in shared-gh-wrappers-checks.sh with the shared read timeout helper, plus a regression test proving the checks helper routes all three API reads through the timeout wrapper.

## Files Changed

.agents/scripts/shared-gh-wrappers-checks.sh,.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-checks.sh .agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh; .agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh; .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; bash .agents/scripts/tests/test-pulse-nmr-approval.sh; .agents/scripts/linters-local.sh timed out after 240s during the pre-existing forbidden exec FD locks gate after earlier checks passed

Resolves #24495


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.19 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 14m and 71,998 tokens on this as a headless worker.