### PR TITLE
GH#24497: fix: preserve review thread repo slug parsing

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -63,10 +63,10 @@ _prrts_parse_repo_slug() {
 	local repo_slug="$1"
 	local owner_var="$2"
 	local name_var="$3"
-	local owner="${repo_slug%%/*}"
-	local name="${repo_slug##*/}"
-	printf -v "$owner_var" '%s' "$owner"
-	printf -v "$name_var" '%s' "$name"
+	local parsed_owner="${repo_slug%%/*}"
+	local parsed_name="${repo_slug##*/}"
+	printf -v "$owner_var" '%s' "$parsed_owner"
+	printf -v "$name_var" '%s' "$parsed_name"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -47,6 +47,12 @@ if [[ "$1" == "pr" && "${2:-}" == "list" ]]; then
 	exit 0
 fi
 if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
+	for arg in "$@"; do
+		if [[ "$arg" == "owner=" || "$arg" == "name=" ]]; then
+			printf 'empty repo GraphQL field: %s\n' "$arg" >&2
+			exit 1
+		fi
+	done
 	if [[ "$*" == *"addPullRequestReviewThreadReply"* ]]; then
 		printf 'reply\n' >>"${GRAPHQL_MUTATIONS_LOG:-/dev/null}"
 		printf '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"COMMENT1","url":"https://example.invalid/reply"}}}}\n'


### PR DESCRIPTION
## Summary

Renamed the parser's local owner/name temporaries so printf -v writes to the caller-provided owner and name variables, then added a scanner regression guard that fails if GraphQL receives empty owner/name fields.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh,.agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pr-review-thread-response-scanner.sh; shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

Resolves #24497


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.21 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 54,690 tokens on this as a headless worker.