### PR TITLE
GH#21670: restrict stats routines to maintainers

### DIFF
--- a/.agents/scripts/shared-repo-state-guard.sh
+++ b/.agents/scripts/shared-repo-state-guard.sh
@@ -75,3 +75,65 @@ aidevops_can_manage_repo_issue_state() {
 
 	return 1
 }
+
+#######################################
+# Check whether aidevops may run public repo routines for a repo.
+#
+# Routine jobs (quality sweeps, health dashboards, merge/repair loops) can
+# create comments/issues and consume API budget. Unlike narrow issue-state
+# markers, these jobs require maintainer-equivalent authority; write-only
+# collaborators and external contributors should keep results local.
+#
+# Args:
+#   $1 = repo slug (owner/repo)
+#   $2 = optional authenticated login override
+# Returns: 0 when routines are allowed, 1 otherwise.
+#######################################
+aidevops_can_run_repo_routines() {
+	local slug="${1:-}"
+	local user="${2:-}"
+
+	if [[ "${AIDEVOPS_TEST_MODE:-}" == "1" && \
+		"${AIDEVOPS_REPO_ROUTINE_GUARD_TEST_BYPASS:-}" == "1" ]]; then
+		return 0
+	fi
+
+	if [[ -z "$slug" || "$slug" != */* ]]; then
+		return 1
+	fi
+
+	if [[ -z "$user" ]]; then
+		user=$(aidevops_repo_state_current_user)
+	fi
+	if [[ -z "$user" ]]; then
+		return 1
+	fi
+
+	local repo_owner="${slug%%/*}"
+	if [[ "$user" == "$repo_owner" ]]; then
+		return 0
+	fi
+
+	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+	if [[ -f "$repos_json" ]]; then
+		local registered_maintainer=""
+		registered_maintainer=$(jq -r \
+			--arg slug "$slug" \
+			'.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' \
+			"$repos_json" 2>/dev/null | sed -n '1p')
+		if [[ -n "$registered_maintainer" && "$registered_maintainer" == "$user" ]]; then
+			return 0
+		fi
+	fi
+
+	local permission=""
+	permission=$(gh api "repos/${slug}/collaborators/${user}/permission" \
+		--jq '.permission // ""' 2>/dev/null || printf '')
+	case "$permission" in
+		admin | maintain)
+			return 0
+			;;
+	esac
+
+	return 1
+}

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -57,6 +57,9 @@ fi
 STATS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
 # Phase 1: shared utility functions (slug validation, runner role)
+# shellcheck source=shared-repo-state-guard.sh
+source "${STATS_SCRIPT_DIR}/shared-repo-state-guard.sh"
+
 # shellcheck source=stats-shared.sh
 source "${STATS_SCRIPT_DIR}/stats-shared.sh"
 

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -267,6 +267,29 @@ _update_health_issue_for_repo() {
 }
 
 #######################################
+# Filter repo entries to repos where public routines are authorized.
+# Arguments:
+#   $1 - newline-delimited slug|path entries
+#   $2 - authenticated GitHub user
+# Output: authorized slug|path entries
+#######################################
+_filter_routine_eligible_repo_entries() {
+	local repo_entries="$1"
+	local routine_runner_user="$2"
+	local slug path
+
+	while IFS='|' read -r slug path; do
+		[[ -z "$slug" ]] && continue
+		if ! aidevops_can_run_repo_routines "$slug" "$routine_runner_user"; then
+			echo "[stats] Health dashboard skipped for ${slug}: ${routine_runner_user} is not maintainer-equivalent" >>"$LOGFILE"
+			continue
+		fi
+		printf '%s|%s\n' "$slug" "$path"
+	done <<<"$repo_entries"
+	return 0
+}
+
+#######################################
 # Update health issues for ALL pulse-enabled repos
 #
 # Iterates repos.json and calls _update_health_issue_for_repo for each
@@ -296,6 +319,18 @@ update_health_issues() {
 		return 0
 	fi
 
+	local routine_runner_user
+	routine_runner_user=$(aidevops_repo_state_current_user)
+	if [[ -z "$routine_runner_user" ]]; then
+		echo "[stats] Health dashboard skipped: could not resolve authenticated GitHub user" >>"$LOGFILE"
+		return 0
+	fi
+
+	repo_entries=$(_filter_routine_eligible_repo_entries "$repo_entries" "$routine_runner_user")
+	if [[ -z "$repo_entries" ]]; then
+		return 0
+	fi
+
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	_refresh_person_stats_cache || true
 
@@ -312,7 +347,7 @@ update_health_issues() {
 	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
 	if [[ -x "$activity_helper" ]]; then
 		local all_repo_paths
-		all_repo_paths=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .path' "$repos_json" || echo "")
+		all_repo_paths=$(printf '%s\n' "$repo_entries" | awk -F'|' 'NF >= 2 && $2 != "" { print $2 }')
 		if [[ -n "$all_repo_paths" ]]; then
 			local -a cross_args=()
 			while IFS= read -r rp; do

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -143,12 +143,23 @@ run_daily_quality_sweep() {
 		return 0
 	fi
 
+	local routine_runner_user
+	routine_runner_user=$(aidevops_repo_state_current_user)
+	if [[ -z "$routine_runner_user" ]]; then
+		echo "[stats] Quality sweep skipped: could not resolve authenticated GitHub user" >>"$LOGFILE"
+		return 0
+	fi
+
 	echo "[stats] Starting daily code quality sweep..." >>"$LOGFILE"
 
 	local swept=0
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
 		[[ ! -d "$path" ]] && continue
+		if ! aidevops_can_run_repo_routines "$slug" "$routine_runner_user"; then
+			echo "[stats] Quality sweep skipped for ${slug}: ${routine_runner_user} is not maintainer-equivalent" >>"$LOGFILE"
+			continue
+		fi
 		_quality_sweep_for_repo "$slug" "$path" || true
 		swept=$((swept + 1))
 	done <<<"$repo_entries"

--- a/.agents/scripts/tests/test-repo-state-guard.sh
+++ b/.agents/scripts/tests/test-repo-state-guard.sh
@@ -29,6 +29,10 @@ if [[ "$1" == "api" && "$2" == repos/*/collaborators/*/permission ]]; then
     printf '%s\n' "write"
     exit 0
   fi
+  if [[ "$mode" == "routine-maintain" ]]; then
+    printf '%s\n' "maintain"
+    exit 0
+  fi
   printf '%s\n' '{"message":"Must have push access"}' >&2
   exit 1
 fi
@@ -77,10 +81,22 @@ else
 	check 0 "repo owner may manage state"
 fi
 
+if aidevops_can_run_repo_routines "tester/project"; then
+	check 1 "repo owner may run routines"
+else
+	check 0 "repo owner may run routines"
+fi
+
 if aidevops_can_manage_repo_issue_state "other/project"; then
 	check 0 "external non-maintainer is blocked"
 else
 	check 1 "external non-maintainer is blocked"
+fi
+
+if aidevops_can_run_repo_routines "other/project"; then
+	check 0 "external non-maintainer routine is blocked"
+else
+	check 1 "external non-maintainer routine is blocked"
 fi
 
 printf 'managed\n' >"$mode_file"
@@ -88,6 +104,19 @@ if aidevops_can_manage_repo_issue_state "other/project"; then
 	check 1 "write collaborator may manage state"
 else
 	check 0 "write collaborator may manage state"
+fi
+
+if aidevops_can_run_repo_routines "other/project"; then
+	check 0 "write collaborator routine is blocked"
+else
+	check 1 "write collaborator routine is blocked"
+fi
+
+printf 'routine-maintain\n' >"$mode_file"
+if aidevops_can_run_repo_routines "other/project"; then
+	check 1 "maintain collaborator may run routines"
+else
+	check 0 "maintain collaborator may run routines"
 fi
 
 printf 'external\n' >"$mode_file"

--- a/.agents/scripts/tests/test-stats-routine-maintainer-guard.sh
+++ b/.agents/scripts/tests/test-stats-routine-maintainer-guard.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "${tmp_dir}/bin" "${tmp_dir}/repo-write" "${tmp_dir}/repo-maintain" "${tmp_dir}/logs"
+
+cat >"${tmp_dir}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "user" ]]; then
+	printf '%s\n' 'tester'
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == repos/*/collaborators/tester/permission ]]; then
+	case "$2" in
+		repos/other/write/collaborators/tester/permission)
+			printf '%s\n' 'write'
+			;;
+		repos/other/maintain/collaborators/tester/permission)
+			printf '%s\n' 'maintain'
+			;;
+		*)
+			printf '%s\n' '{"message":"not found"}' >&2
+			exit 1
+			;;
+	esac
+	exit 0
+fi
+
+exit 0
+STUB
+chmod +x "${tmp_dir}/bin/gh"
+
+cat >"${tmp_dir}/repos.json" <<JSON
+{
+  "initialized_repos": [
+    {"slug": "other/write", "path": "${tmp_dir}/repo-write", "pulse": true},
+    {"slug": "other/maintain", "path": "${tmp_dir}/repo-maintain", "pulse": true}
+  ]
+}
+JSON
+
+export PATH="${tmp_dir}/bin:${PATH}"
+export HOME="$tmp_dir"
+export REPOS_JSON="${tmp_dir}/repos.json"
+export LOGFILE="${tmp_dir}/logs/stats.log"
+export QUALITY_SWEEP_INTERVAL=0
+export QUALITY_SWEEP_LAST_RUN="${tmp_dir}/logs/quality-sweep-last-run"
+export PERSON_STATS_LAST_RUN="${tmp_dir}/logs/person-stats-last-run"
+export PERSON_STATS_CACHE_DIR="${tmp_dir}/logs"
+export QUALITY_SWEEP_STATE_DIR="${tmp_dir}/logs/quality-sweep-state"
+
+# stats-functions.sh submodules expect caller SCRIPT_DIR to be the scripts dir,
+# matching stats-wrapper.sh production sourcing.
+SCRIPT_DIR="$AGENTS_SCRIPTS_DIR"
+
+# shellcheck source=../shared-constants.sh
+source "${AGENTS_SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=../worker-lifecycle-common.sh
+source "${AGENTS_SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=../stats-functions.sh
+source "${AGENTS_SCRIPTS_DIR}/stats-functions.sh"
+
+called_file="${tmp_dir}/called"
+_quality_sweep_for_repo() {
+	local repo_slug="$1"
+	local repo_path="$2"
+	printf '%s|%s\n' "$repo_slug" "$repo_path" >>"$called_file"
+	return 0
+}
+
+run_daily_quality_sweep
+
+if [[ ! -f "$called_file" ]]; then
+	printf 'FAIL no eligible repo was swept\n'
+	exit 1
+fi
+
+if grep -q '^other/write|' "$called_file"; then
+	printf 'FAIL write-only collaborator repo was swept\n'
+	exit 1
+fi
+
+if ! grep -q '^other/maintain|' "$called_file"; then
+	printf 'FAIL maintain collaborator repo was not swept\n'
+	exit 1
+fi
+
+printf 'PASS stats routines require maintainer-equivalent access\n'


### PR DESCRIPTION
## Summary

- Adds a shared routine authorization guard that permits public repo routines only for repo owners, configured maintainers, or GitHub admin/maintain collaborators.
- Applies the guard to stats quality sweeps and health dashboard refreshes before comments/issues are created or cross-repo routine summaries are built.
- Extends repo-state guard coverage and adds a stats regression test proving write-only collaborators are skipped while maintainers still run routines.

Resolves #21670

## Verification

- `bash .agents/scripts/tests/test-repo-state-guard.sh`
- `bash .agents/scripts/tests/test-stats-routine-maintainer-guard.sh`
- `.agents/scripts/stats-wrapper.sh --self-check`
- `shellcheck -x .agents/scripts/shared-repo-state-guard.sh .agents/scripts/stats-functions.sh .agents/scripts/stats-quality-sweep.sh .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-repo-state-guard.sh .agents/scripts/tests/test-stats-routine-maintainer-guard.sh`
- `git diff --check origin/main...HEAD`

Note: `.agents/scripts/linters-local.sh` was attempted twice; it passed earlier gates including SonarCloud, Qlty check, string literal ratchet, secretlint, TOON, skill frontmatter, and secret policy, then timed out during broader ratchet processing.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.22 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5
