### PR TITLE
GH#24504: mention review thread authors in replies

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -121,12 +121,79 @@ _prrts_thread_has_marker() {
 	return $?
 }
 
+_prrts_thread_author_login() {
+	local thread_id="$1"
+	local response="" login="" rc=0
+	[[ -n "$thread_id" ]] || return 1
+
+	# shellcheck disable=SC2016
+	response=$(gh api graphql \
+		-F thread="$thread_id" -f query='
+			query($thread: ID!) {
+				node(id: $thread) {
+					... on PullRequestReviewThread {
+						comments(first: 1) { nodes { author { login } } }
+					}
+				}
+			}
+		' 2>/dev/null) || rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		_prrts_log "reply: author lookup failed for thread ${thread_id} (rc=${rc})"
+		return 1
+	fi
+	login=$(printf '%s' "$response" | jq -r '.data.node.comments.nodes[0].author.login // ""' 2>/dev/null) || login=""
+	if [[ -z "$login" || "$login" == "null" ]]; then
+		_prrts_log "reply: author login missing for thread ${thread_id}"
+		return 1
+	fi
+	printf '%s\n' "$login"
+	return 0
+}
+
+_prrts_body_content_starts_with_mention() {
+	local body="$1"
+	local author_login="$2"
+	local mention="@${author_login}"
+	local line="" next_char=""
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ -z "$line" ]]; then
+			continue
+		fi
+		if [[ "$line" == "<!-- "*" -->" ]]; then
+			continue
+		fi
+		if [[ "${line:0:${#mention}}" != "$mention" ]]; then
+			return 1
+		fi
+		next_char="${line:${#mention}:1}"
+		[[ -z "$next_char" || ! "$next_char" =~ [[:alnum:]_-] ]]
+		return $?
+	done <<<"$body"
+	return 1
+}
+
+_prrts_body_with_author_mention() {
+	local body="$1"
+	local author_login="$2"
+	[[ -n "$body" && -n "$author_login" ]] || {
+		printf '%s' "$body"
+		return 0
+	}
+	if _prrts_body_content_starts_with_mention "$body" "$author_login"; then
+		printf '%s' "$body"
+		return 0
+	fi
+	printf '@%s %s' "$author_login" "$body"
+	return 0
+}
+
 cmd_reply() {
 	local repo_slug="$1"
 	local thread_id="$2"
 	local body_file="$3"
 	local marker="${4:-}"
-	local body="" dry_run="${PR_REVIEW_THREAD_RESPONSE_DRY_RUN:-false}"
+	local body="" dry_run="${PR_REVIEW_THREAD_RESPONSE_DRY_RUN:-false}" author_login=""
 
 	[[ -n "$repo_slug" && -n "$thread_id" && -n "$body_file" && -f "$body_file" ]] || {
 		_prrts_usage >&2
@@ -144,6 +211,11 @@ cmd_reply() {
 		return 0
 	fi
 	_prrts_graphql_rate_limit_ok || return 1
+	if author_login="$(_prrts_thread_author_login "$thread_id")"; then
+		body="$(_prrts_body_with_author_mention "$body" "$author_login")"
+	else
+		_prrts_log "reply: posting without author mention for ${repo_slug} thread ${thread_id}"
+	fi
 
 	# shellcheck disable=SC2016
 	gh api graphql \

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -54,6 +54,11 @@ if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
 		fi
 	done
 	if [[ "$*" == *"addPullRequestReviewThreadReply"* ]]; then
+		for arg in "$@"; do
+			if [[ "$arg" == body=* ]]; then
+				printf '%s' "${arg#body=}" >"${GRAPHQL_BODY_CAPTURE:-/dev/null}"
+			fi
+		done
 		printf 'reply\n' >>"${GRAPHQL_MUTATIONS_LOG:-/dev/null}"
 		printf '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"COMMENT1","url":"https://example.invalid/reply"}}}}\n'
 		exit 0
@@ -63,7 +68,15 @@ if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
 		printf '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD1","isResolved":true}}}}\n'
 		exit 0
 	fi
-	if [[ "$*" == *"node(id: $thread)"* || "$*" == *"comments(first: 100)"* ]]; then
+	if [[ "$*" == *"node(id:"* && "$*" == *"comments(first: 1)"* ]]; then
+		if [[ "${STUB_THREAD_AUTHOR_MODE:-ok}" == "missing" ]]; then
+			printf '{"data":{"node":{"comments":{"nodes":[{"author":null}]}}}}\n'
+		else
+			printf '{"data":{"node":{"comments":{"nodes":[{"author":{"login":"%s"}}]}}}}\n' "${STUB_THREAD_AUTHOR_LOGIN:-reviewer}"
+		fi
+		exit 0
+	fi
+	if [[ "$*" == *"node(id:"* || "$*" == *"comments(first: 100)"* ]]; then
 		printf '{"data":{"node":{"comments":{"nodes":[]}}}}\n'
 		exit 0
 	fi
@@ -108,8 +121,10 @@ HEADLESS_STUB
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export HEADLESS_RUNTIME_HELPER="${TEST_ROOT}/headless-runtime-helper.sh"
 	export GRAPHQL_MUTATIONS_LOG="${TEST_ROOT}/graphql-mutations.log"
+	export GRAPHQL_BODY_CAPTURE="${TEST_ROOT}/graphql-body.txt"
 	export PR_REVIEW_THREAD_RESPONSE_COOLDOWN=3600
 	: >"$GRAPHQL_MUTATIONS_LOG"
+	: >"$GRAPHQL_BODY_CAPTURE"
 	return 0
 }
 
@@ -218,6 +233,55 @@ test_reply_and_resolve_use_graphql_mutations() {
 	return 0
 }
 
+test_reply_auto_prepends_thread_author() {
+	setup_test_env
+	local body_file="${TEST_ROOT}/reply.md"
+	local captured=""
+	printf '<!-- aidevops:review-thread-response:THREAD1 -->\nfixed at file.sh:1; verified with test.sh\n' >"$body_file"
+	$SCANNER reply owner/repo THREAD1 "$body_file" 'aidevops:review-thread-response:THREAD1'
+	captured=$(<"$GRAPHQL_BODY_CAPTURE")
+	if [[ "$captured" == @reviewer\ * ]]; then
+		print_result "reply prepends review thread author mention" 0
+	else
+		print_result "reply prepends review thread author mention" 1 "body=${captured}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_reply_does_not_double_prepend_thread_author() {
+	setup_test_env
+	local body_file="${TEST_ROOT}/reply.md"
+	local mention_count=""
+	printf '<!-- aidevops:review-thread-response:THREAD1 -->\n@reviewer fixed at file.sh:1; verified with test.sh\n' >"$body_file"
+	$SCANNER reply owner/repo THREAD1 "$body_file" 'aidevops:review-thread-response:THREAD1'
+	mention_count=$(grep -o '@reviewer' "$GRAPHQL_BODY_CAPTURE" 2>/dev/null | wc -l | tr -d '[:space:]')
+	if [[ "$mention_count" == "1" ]]; then
+		print_result "reply does not double-prepend thread author mention" 0
+	else
+		print_result "reply does not double-prepend thread author mention" 1 "count=${mention_count}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_reply_falls_back_when_thread_author_missing() {
+	setup_test_env
+	export STUB_THREAD_AUTHOR_MODE="missing"
+	local body_file="${TEST_ROOT}/reply.md"
+	local captured=""
+	printf '<!-- aidevops:review-thread-response:THREAD1 -->\nfixed at file.sh:1; verified with test.sh\n' >"$body_file"
+	$SCANNER reply owner/repo THREAD1 "$body_file" 'aidevops:review-thread-response:THREAD1'
+	captured=$(<"$GRAPHQL_BODY_CAPTURE")
+	if [[ "$captured" == '<!-- aidevops:review-thread-response:THREAD1 -->'* ]]; then
+		print_result "reply falls back when thread author is missing" 0
+	else
+		print_result "reply falls back when thread author is missing" 1 "body=${captured}"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_reply_skips_duplicate_marker() {
 	setup_test_env
 	export STUB_THREADS_MODE="marker"
@@ -261,6 +325,9 @@ main() {
 	test_dispatch_launches_worker_and_writes_state
 	test_dispatch_is_idempotent_for_same_fingerprint
 	test_reply_and_resolve_use_graphql_mutations
+	test_reply_auto_prepends_thread_author
+	test_reply_does_not_double_prepend_thread_author
+	test_reply_falls_back_when_thread_author_missing
 	test_reply_skips_duplicate_marker
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Fetches the first review-thread author before posting GraphQL replies and prefixes the body with @login when the caller has not already addressed that author.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh,.agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused scanner tests: ./.agents/scripts/tests/test-pr-review-thread-response-scanner.sh (10 passed, 0 failed). ShellCheck: shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh (no output). Repo local linter started but exceeded 600s after reporting pre-existing/advisory markdown/ratchet/complexity noise.

Resolves #24504


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.23 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 25m and 136,520 tokens on this with the user in an interactive session.