### PR TITLE
Add type annotations to _patch_canonical_repo method

### DIFF
--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -18,7 +18,7 @@ spec.loader.exec_module(git_safety_guard)
 class TestCanonicalBranchSwitchDash(unittest.TestCase):
     """Protect canonical checkouts from ``git switch -`` bypasses."""
 
-    def _patch_canonical_repo(self, previous_branch):
+    def _patch_canonical_repo(self, previous_branch: str) -> mock.MagicMock:
         """Patch repository helpers and return the authorization mock."""
         patchers = [
             mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo"),


### PR DESCRIPTION
### Problem Background
The public method `_patch_canonical_repo` in the test file lacked type annotations, which could reduce code readability and hinder compatibility with type checking tools like mypy. Adding type annotations improves clarity and maintainability without altering functionality.

### Changes Made
- Added type annotation for the `previous_branch` parameter as `str`.
- Added return type annotation as `mock.MagicMock` to specify the expected mock object.

### Verification
- All existing tests continue to pass, confirming no functional changes.
- The code can be validated with type checkers (e.g., mypy) to ensure annotations are correct and consistent with the codebase style.