### PR TITLE
GH#24502: route collaborator permission checks through app auth

### DIFF
--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -146,8 +146,10 @@ _isc_can_manage_issue_state() {
 	fi
 
 	local permission=""
-	permission=$(gh api "repos/${slug}/collaborators/${user}/permission" \
-		--jq '.permission // ""' 2>/dev/null) || permission=""
+	# #aidevops:trust-boundary — managed-repo claim/state writes require a
+	# confirmed collaborator permission; lookup failures fail closed without
+	# being treated as confirmed non-collaborators.
+	_gh_collaborator_permission_lookup "$slug" "$user" permission || return 1
 	case "$permission" in
 		admin | maintain | write)
 			return 0

--- a/.agents/scripts/pulse-merge-author-checks.sh
+++ b/.agents/scripts/pulse-merge-author-checks.sh
@@ -36,24 +36,97 @@ _PULSE_MERGE_AUTHOR_CHECKS_LOADED=1
 : "${REPOS_JSON:=${HOME}/.config/aidevops/repos.json}"
 _INTERACTIVE_PR_BOOL_FALSE=false
 
+if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+	_PULSE_MERGE_AUTHOR_CHECKS_DIR="${BASH_SOURCE[0]%/*}"
+	if [[ -f "${_PULSE_MERGE_AUTHOR_CHECKS_DIR}/github-app-auth-helper.sh" ]]; then
+		# shellcheck source=./github-app-auth-helper.sh
+		source "${_PULSE_MERGE_AUTHOR_CHECKS_DIR}/github-app-auth-helper.sh"
+	fi
+	if [[ -f "${_PULSE_MERGE_AUTHOR_CHECKS_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+		# shellcheck source=./shared-gh-wrappers-rest-fallback.sh
+		source "${_PULSE_MERGE_AUTHOR_CHECKS_DIR}/shared-gh-wrappers-rest-fallback.sh"
+	fi
+	if [[ -f "${_PULSE_MERGE_AUTHOR_CHECKS_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+		# shellcheck source=./shared-gh-collaborator-permission.sh
+		source "${_PULSE_MERGE_AUTHOR_CHECKS_DIR}/shared-gh-collaborator-permission.sh"
+	fi
+	unset _PULSE_MERGE_AUTHOR_CHECKS_DIR
+fi
+
+_PULSE_AUTHOR_PERMISSION_UNKNOWN="unknown"
+_PULSE_AUTHOR_PERMISSION_LOOKUP_STATE="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+_PULSE_AUTHOR_PERMISSION_HTTP="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+
+#######################################
+# Record collaborator-permission lookup state for merge callers.
+# Args: $1=state, $2=http-status
+# Returns: 0 always.
+#######################################
+_pulse_author_permission_state_set() {
+	local state="$1"
+	local http_status="$2"
+	_PULSE_AUTHOR_PERMISSION_LOOKUP_STATE="$state"
+	_PULSE_AUTHOR_PERMISSION_HTTP="$http_status"
+	return 0
+}
+
+#######################################
+# Look up a PR author's repository permission via App-aware REST when available.
+# #aidevops:trust-boundary — collaborator/maintainer trust checks must not
+# collapse API lookup failures into confirmed non-collaborator results.
+# Args: $1=author login, $2=repo slug, $3=optional output variable
+# Output: permission level on lookup success.
+# Returns: 0=lookup success, 2=lookup failure.
+#######################################
+_pulse_author_permission_lookup() {
+	local author="$1"
+	local repo_slug="$2"
+	local out_var="${3:-}"
+	local pulse_perm_value=""
+	_pulse_author_permission_state_set "$_PULSE_AUTHOR_PERMISSION_UNKNOWN" "$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+	if declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+		_gh_collaborator_permission_lookup "$repo_slug" "$author" pulse_perm_value
+		local rc=$?
+		if [[ "$rc" -ne 0 ]]; then
+			_pulse_author_permission_state_set "failed" "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-$_PULSE_AUTHOR_PERMISSION_UNKNOWN}"
+			return 2
+		fi
+		_pulse_author_permission_state_set "ok" "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-$_PULSE_AUTHOR_PERMISSION_UNKNOWN}"
+		if [[ -n "$out_var" ]]; then
+			printf -v "$out_var" '%s' "$pulse_perm_value"
+		else
+			printf '%s\n' "$pulse_perm_value"
+		fi
+		return 0
+	fi
+
+	pulse_perm_value=$(gh api "/repos/${repo_slug}/collaborators/${author}/permission" \
+		--jq '.permission // ""' 2>/dev/null) || {
+		_pulse_author_permission_state_set "failed" "$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+		return 2
+	}
+	_pulse_author_permission_state_set "ok" "$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+	if [[ -n "$out_var" ]]; then
+		printf -v "$out_var" '%s' "$pulse_perm_value"
+	else
+		printf '%s\n' "$pulse_perm_value"
+	fi
+	return 0
+}
+
 #######################################
 # Check if a PR author is a collaborator (admin/maintain/write).
 # Args: $1=author login, $2=repo slug
-# Returns: 0=collaborator, 1=not collaborator or error
+# Returns: 0=collaborator, 1=not collaborator, 2=permission lookup failure
 #######################################
 _is_collaborator_author() {
 	local author="$1"
 	local repo_slug="$2"
-	local perm_url="repos/${repo_slug}/collaborators/${author}/permission"
-	local perm_response
-	perm_response=$(gh api -i "$perm_url" 2>/dev/null | head -1)
-	if [[ "$perm_response" == *"200"* ]]; then
-		local perm
-		perm=$(gh api "$perm_url" --jq '.permission' 2>/dev/null)
-		case "$perm" in
-		admin | maintain | write) return 0 ;;
-		esac
-	fi
+	local perm=""
+	_pulse_author_permission_lookup "$author" "$repo_slug" perm || return 2
+	case "$perm" in
+	admin | maintain | write) return 0 ;;
+	esac
 	return 1
 }
 
@@ -63,21 +136,16 @@ _is_collaborator_author() {
 # collaborators (outside contributors). Used by the origin:interactive
 # auto-merge gate (t2411).
 # Args: $1=author login, $2=repo slug
-# Returns: 0=owner or member, 1=collaborator/not collaborator or error
+# Returns: 0=owner or member, 1=collaborator/not collaborator, 2=lookup failure
 #######################################
 _is_owner_or_member_author() {
 	local author="$1"
 	local repo_slug="$2"
-	local perm_url="repos/${repo_slug}/collaborators/${author}/permission"
-	local perm_response
-	perm_response=$(gh api -i "$perm_url" 2>/dev/null | head -1)
-	if [[ "$perm_response" == *"200"* ]]; then
-		local perm
-		perm=$(gh api "$perm_url" --jq '.permission' 2>/dev/null)
-		case "$perm" in
-		admin | maintain) return 0 ;;
-		esac
-	fi
+	local perm=""
+	_pulse_author_permission_lookup "$author" "$repo_slug" perm || return 2
+	case "$perm" in
+	admin | maintain) return 0 ;;
+	esac
 	return 1
 }
 

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -570,6 +570,30 @@ check_permission_failure_pr() {
 }
 
 #######################################
+# Confirm the current runner has approval-counting write access.
+# #aidevops:trust-boundary — approval must never be posted by an unconfirmed
+# collaborator; permission lookup failure is a distinct fail-closed skip.
+# Args: $1=current_user, $2=repo_slug
+# Returns: 0=confirmed write+, 1=skip approval.
+#######################################
+_approve_collaborator_runner_has_write() {
+	local current_user="$1"
+	local repo_slug="$2"
+	local runner_collab_rc=0
+	_is_collaborator_author "$current_user" "$repo_slug"
+	runner_collab_rc=$?
+	if [[ "$runner_collab_rc" -eq 2 ]]; then
+		echo "[pulse-wrapper] approve_collaborator_pr: permission check failed for current user ($current_user) on $repo_slug (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}) — skipping approval" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$runner_collab_rc" -ne 0 ]]; then
+		echo "[pulse-wrapper] approve_collaborator_pr: current user ($current_user) lacks write access to $repo_slug — skipping approval" >>"$LOGFILE"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Auto-approve a collaborator's PR before merging (GH#10522, t1691)
 #
 # Branch protection requires required_approving_review_count=1.
@@ -616,11 +640,7 @@ approve_collaborator_pr() {
 			return 0
 		fi
 
-		# Guard: only collaborators (write/maintain/admin) may approve.
-		# Non-collaborator approvals are accepted by GitHub on public repos
-		# but don't count toward branch protection — they just create noise.
-		if ! _is_collaborator_author "$current_user" "$repo_slug"; then
-			echo "[pulse-wrapper] approve_collaborator_pr: current user ($current_user) lacks write access to $repo_slug — skipping approval" >>"$LOGFILE"
+		if ! _approve_collaborator_runner_has_write "$current_user" "$repo_slug"; then
 			return 0
 		fi
 
@@ -654,7 +674,18 @@ approve_collaborator_pr() {
 	# pinned by test-pulse-merge-approve-collaborator-guard.sh Case P.
 	local approval_body
 	approval_body="Auto-approved by pulse runner @${current_user:-unknown} — author @${pr_author} confirmed collaborator, pre-merge gates passed."
-	if [[ -n "$pr_author" ]] && [[ "$pr_author" != "unknown" ]] && ! _is_collaborator_author "$pr_author" "$repo_slug"; then
+	local _author_collab_rc=0
+	if [[ -n "$pr_author" ]] && [[ "$pr_author" != "unknown" ]]; then
+		_is_collaborator_author "$pr_author" "$repo_slug"
+		_author_collab_rc=$?
+	else
+		_author_collab_rc=0
+	fi
+	if [[ "$_author_collab_rc" -eq 2 ]]; then
+		echo "[pulse-wrapper] approve_collaborator_pr: permission check failed for PR #$pr_number author (@$pr_author) on $repo_slug (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}) — refusing to auto-approve" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$_author_collab_rc" -ne 0 ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
 			approval_body="Auto-approved by pulse runner @${current_user:-unknown} — trusted Dependabot dependency update verified: GitHub bot identity, same-repo branch, dependabot-authored commits, dependency-file-only diff, maintainer allowlist, no security-scan failures, and pre-merge gates passed."
 			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is trusted Dependabot with allowlisted dependency update — proceeding (GH#24473)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -213,7 +213,15 @@ _check_pr_merge_gates() {
 	# or its linked issue is a stronger trust signal than author-association
 	# (requires root-owned SSH key that workers cannot forge). Symmetric with
 	# t3052 which extended the worker-briefed gate the same way (PR #21767).
-	if ! _is_collaborator_author "$pr_author" "$repo_slug"; then
+	local _author_collab_rc=0
+	_is_collaborator_author "$pr_author" "$repo_slug"
+	_author_collab_rc=$?
+	if [[ "$_author_collab_rc" -eq 2 ]]; then
+		check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — permission check failed for author ${pr_author} (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$_author_collab_rc" -ne 0 ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -37,6 +37,23 @@
 [[ -n "${_PULSE_NMR_APPROVAL_LOADED:-}" ]] && return 0
 _PULSE_NMR_APPROVAL_LOADED=1
 
+if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+	_PULSE_NMR_APPROVAL_DIR="${BASH_SOURCE[0]%/*}"
+	if [[ -f "${_PULSE_NMR_APPROVAL_DIR}/github-app-auth-helper.sh" ]]; then
+		# shellcheck source=./github-app-auth-helper.sh
+		source "${_PULSE_NMR_APPROVAL_DIR}/github-app-auth-helper.sh"
+	fi
+	if [[ -f "${_PULSE_NMR_APPROVAL_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+		# shellcheck source=./shared-gh-wrappers-rest-fallback.sh
+		source "${_PULSE_NMR_APPROVAL_DIR}/shared-gh-wrappers-rest-fallback.sh"
+	fi
+	if [[ -f "${_PULSE_NMR_APPROVAL_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+		# shellcheck source=./shared-gh-collaborator-permission.sh
+		source "${_PULSE_NMR_APPROVAL_DIR}/shared-gh-collaborator-permission.sh"
+	fi
+	unset _PULSE_NMR_APPROVAL_DIR
+fi
+
 #######################################
 # Cached ever-NMR provenance helpers (GH#17458)
 #
@@ -808,8 +825,9 @@ _nmr_current_actor_can_post_maintainer_approval() {
 	[[ -n "$actor" ]] || return 1
 
 	local actor_permission
-	actor_permission=$(gh api "repos/${slug}/collaborators/${actor}/permission" \
-		--jq '.permission // "none"' 2>/dev/null) || actor_permission="none"
+	# #aidevops:trust-boundary — maintainer approval posting requires confirmed
+	# write+ access; transient permission lookup failures fail closed.
+	_gh_collaborator_permission_lookup "$slug" "$actor" actor_permission || return 1
 	case "$actor_permission" in
 	admin | maintain | write) return 0 ;;
 	*) return 1 ;;

--- a/.agents/scripts/pulse-simplification-review.sh
+++ b/.agents/scripts/pulse-simplification-review.sh
@@ -91,8 +91,12 @@ run_daily_codebase_review() {
 		return 0
 	fi
 	local perm_level
-	perm_level=$(gh api "repos/${aidevops_slug}/collaborators/${current_user}/permission" \
-		--jq '.permission' 2>/dev/null) || perm_level=""
+	# #aidevops:trust-boundary — review-trigger comments require confirmed
+	# collaborator write access; API lookup failures skip with explicit wording.
+	if ! _gh_collaborator_permission_lookup "$aidevops_slug" "$current_user" perm_level; then
+		echo "[pulse-wrapper] CodeRabbit review: skipped — permission check failed for user '$current_user' on $aidevops_slug (HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
+		return 0
+	fi
 	case "$perm_level" in
 	admin | maintain | write) ;; # allowed
 	*)

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -483,8 +483,12 @@ _complexity_scan_permission_gate() {
 	current_user=$(gh api user --jq '.login' 2>/dev/null) || current_user=""
 	if [[ -n "$current_user" ]]; then
 		local perm_level
-		perm_level=$(gh api "repos/${aidevops_slug}/collaborators/${current_user}/permission" \
-			--jq '.permission' 2>/dev/null) || perm_level=""
+		# #aidevops:trust-boundary — simplification issue creation requires
+		# confirmed admin access; permission lookup failures skip explicitly.
+		if ! _gh_collaborator_permission_lookup "$aidevops_slug" "$current_user" perm_level; then
+			echo "[pulse-wrapper] Complexity scan: skipped — permission check failed for user '$current_user' on $aidevops_slug (HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
+			return 1
+		fi
 		case "$perm_level" in
 		admin) ;; # allowed — repo owner/admin only
 		*)

--- a/.agents/scripts/pulse-triage-cache.sh
+++ b/.agents/scripts/pulse-triage-cache.sh
@@ -162,8 +162,9 @@ _triage_awaiting_contributor_reply() {
 
 	# Check if the last commenter is a repo collaborator (maintainer/member)
 	local perm_level=""
-	perm_level=$(gh api "repos/${repo_slug}/collaborators/${last_human_author}/permission" \
-		--jq '.permission // ""' 2>/dev/null) || perm_level=""
+	# #aidevops:trust-boundary — contributor-reply triage skipping requires a
+	# confirmed collaborator; permission lookup failures keep triage eligible.
+	_gh_collaborator_permission_lookup "$repo_slug" "$last_human_author" perm_level || return 1
 
 	case "$perm_level" in
 	admin | maintain | write)

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -131,8 +131,16 @@ _check_write_permission() {
 		return 0
 	fi
 
-	permission=$(gh api "repos/${repo_slug}/collaborators/${user}/permission" \
-		--jq '.permission' 2>/dev/null || echo "none")
+	# #aidevops:trust-boundary — quality-feedback issue creation requires
+	# confirmed write+ access; transient lookup failures are not cached as a
+	# confirmed non-collaborator result.
+	if ! _gh_collaborator_permission_lookup "$repo_slug" "$user" permission; then
+		_QF_PERMISSION_CHECKED=""
+		_QF_PERMISSION_REPO=""
+		_QF_HAS_WRITE="false"
+		echo "false"
+		return 0
+	fi
 
 	_QF_PERMISSION_CHECKED="true"
 	_QF_PERMISSION_REPO="$repo_slug"

--- a/.agents/scripts/quality-feedback-issues-lib.sh
+++ b/.agents/scripts/quality-feedback-issues-lib.sh
@@ -19,6 +19,23 @@
 [[ -n "${_QF_ISSUES_LIB_LOADED:-}" ]] && return 0
 readonly _QF_ISSUES_LIB_LOADED=1
 
+if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+	_QF_ISSUES_LIB_DIR="${BASH_SOURCE[0]%/*}"
+	if [[ -f "${_QF_ISSUES_LIB_DIR}/github-app-auth-helper.sh" ]]; then
+		# shellcheck source=./github-app-auth-helper.sh
+		source "${_QF_ISSUES_LIB_DIR}/github-app-auth-helper.sh"
+	fi
+	if [[ -f "${_QF_ISSUES_LIB_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+		# shellcheck source=./shared-gh-wrappers-rest-fallback.sh
+		source "${_QF_ISSUES_LIB_DIR}/shared-gh-wrappers-rest-fallback.sh"
+	fi
+	if [[ -f "${_QF_ISSUES_LIB_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+		# shellcheck source=./shared-gh-collaborator-permission.sh
+		source "${_QF_ISSUES_LIB_DIR}/shared-gh-collaborator-permission.sh"
+	fi
+	unset _QF_ISSUES_LIB_DIR
+fi
+
 #######################################
 # Tag scanned PRs where all review feedback has been actioned (t1413)
 #
@@ -631,9 +648,13 @@ _is_maintainer_equivalent_author() {
 	fi
 
 	# Stage 2: collaborator permission probe. Accepts admin or maintain.
+	# #aidevops:trust-boundary — maintainer-equivalent classification requires
+	# confirmed admin/maintain; lookup failures fail closed separately from none.
 	local collab_permission=""
-	collab_permission=$(gh api "repos/${repo_slug}/collaborators/${pr_author}/permission" \
-		--jq '.permission // empty' 2>/dev/null || echo "")
+	_gh_collaborator_permission_lookup "$repo_slug" "$pr_author" collab_permission || {
+		echo "[quality-feedback] permission check failed for author ${pr_author} on ${repo_slug} (HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown}) — not treating as maintainer-equivalent" >&2
+		return 1
+	}
 	if [[ "$collab_permission" == "admin" || "$collab_permission" == "maintain" ]]; then
 		echo "[quality-feedback] author ${pr_author} has ${collab_permission} permission on ${repo_slug} — treating as maintainer-equivalent (t2686)" >&2
 		return 0

--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Shared GitHub collaborator permission lookup helper
+# =============================================================================
+
+[[ -n "${_SHARED_GH_COLLABORATOR_PERMISSION_LOADED:-}" ]] && return 0
+_SHARED_GH_COLLABORATOR_PERMISSION_LOADED=1
+
+#######################################
+# Look up a repository collaborator permission through App-aware REST routing.
+#
+# Auth selection stays in _rest_api_call/github_app_api_call: GitHub App
+# installation auth is preferred when configured, with normal gh/PAT fallback.
+# Callers can inspect the status globals after a non-zero return to distinguish
+# transient lookup failures from confirmed non-collaborators.
+#
+# Globals written:
+#   AIDEVOPS_GH_COLLAB_PERMISSION_HTTP
+#   AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+#
+# Args: $1=repo_slug owner/repo, $2=user login, $3=optional output variable
+# Output: permission value (admin|maintain|write|read|none) on lookup success.
+# Returns: 0=lookup succeeded (404 maps to none), 2=lookup/API/parse failure.
+#######################################
+_gh_collaborator_permission_lookup() {
+	local repo_slug="$1"
+	local user="$2"
+	local out_var="${3:-}"
+	local perm_url="/repos/${repo_slug}/collaborators/${user}/permission"
+	local api_response=""
+	local rc=0
+	local http_status=""
+	local line=""
+	local body=""
+	local in_body=0
+	local permission_value=""
+
+	AIDEVOPS_GH_COLLAB_PERMISSION_HTTP="unknown"
+	AIDEVOPS_GH_COLLAB_PERMISSION_REASON="unknown"
+	export AIDEVOPS_GH_COLLAB_PERMISSION_HTTP AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+
+	if [[ -z "$repo_slug" || -z "$user" ]]; then
+		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="missing-argument"
+		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+		return 2
+	fi
+
+	api_response=$(_rest_api_call read gh api -i "$perm_url" 2>&1)
+	rc=$?
+	while IFS= read -r line; do
+		line="${line%$'\r'}"
+		case "$line" in
+		HTTP/*)
+			http_status="${line#* }"
+			http_status="${http_status%% *}"
+			;;
+		"")
+			in_body=1
+			;;
+		\{* | \[* )
+			in_body=1
+			body="${body}${line}"$'\n'
+			;;
+		*)
+			if [[ "$in_body" -eq 1 ]]; then
+				body="${body}${line}"$'\n'
+			fi
+			;;
+		esac
+	done <<<"$api_response"
+
+	[[ -n "$http_status" ]] && AIDEVOPS_GH_COLLAB_PERMISSION_HTTP="$http_status"
+	export AIDEVOPS_GH_COLLAB_PERMISSION_HTTP
+
+	if [[ "$http_status" == "404" ]]; then
+		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="not-collaborator"
+		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+		if [[ -n "$out_var" ]]; then
+			printf -v "$out_var" '%s' "none"
+		else
+			printf '%s\n' "none"
+		fi
+		return 0
+	fi
+
+	if [[ "$rc" -ne 0 ]]; then
+		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="api-failure"
+		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+		return 2
+	fi
+
+	if [[ "$http_status" != "200" ]]; then
+		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="unexpected-http"
+		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+		return 2
+	fi
+
+	permission_value=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || permission_value=""
+	case "$permission_value" in
+	admin | maintain | write | read | none)
+		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="ok"
+		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+		if [[ -n "$out_var" ]]; then
+			printf -v "$out_var" '%s' "$permission_value"
+		else
+			printf '%s\n' "$permission_value"
+		fi
+		return 0
+		;;
+	*)
+		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="malformed-response"
+		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+		return 2
+		;;
+	esac
+}

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -90,6 +90,10 @@ if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wr
 	# shellcheck source=shared-gh-wrappers-rest-fallback.sh
 	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh"
 fi
+if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-collaborator-permission.sh" ]]; then
+	# shellcheck source=shared-gh-collaborator-permission.sh
+	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-collaborator-permission.sh"
+fi
 # gh API instrumentation (t2902): records every routed gh call partitioned
 # by endpoint family (graphql/rest/search-*) so heavy GraphQL consumers can
 # be identified. The recorder is fail-open — if the helper is missing, the

--- a/.agents/scripts/shared-repo-state-guard.sh
+++ b/.agents/scripts/shared-repo-state-guard.sh
@@ -13,6 +13,23 @@
 [[ -n "${_SHARED_REPO_STATE_GUARD_LOADED:-}" ]] && return 0
 _SHARED_REPO_STATE_GUARD_LOADED=1
 
+if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+	_SHARED_REPO_STATE_GUARD_DIR="${BASH_SOURCE[0]%/*}"
+	if [[ -f "${_SHARED_REPO_STATE_GUARD_DIR}/github-app-auth-helper.sh" ]]; then
+		# shellcheck source=./github-app-auth-helper.sh
+		source "${_SHARED_REPO_STATE_GUARD_DIR}/github-app-auth-helper.sh"
+	fi
+	if [[ -f "${_SHARED_REPO_STATE_GUARD_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+		# shellcheck source=./shared-gh-wrappers-rest-fallback.sh
+		source "${_SHARED_REPO_STATE_GUARD_DIR}/shared-gh-wrappers-rest-fallback.sh"
+	fi
+	if [[ -f "${_SHARED_REPO_STATE_GUARD_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+		# shellcheck source=./shared-gh-collaborator-permission.sh
+		source "${_SHARED_REPO_STATE_GUARD_DIR}/shared-gh-collaborator-permission.sh"
+	fi
+	unset _SHARED_REPO_STATE_GUARD_DIR
+fi
+
 #######################################
 # Resolve the authenticated GitHub login.
 # Returns: login on stdout, empty on failure.
@@ -65,8 +82,14 @@ aidevops_can_manage_repo_issue_state() {
 	fi
 
 	local permission=""
-	permission=$(gh api "repos/${slug}/collaborators/${user}/permission" \
-		--jq '.permission // ""' 2>/dev/null || printf '')
+	# #aidevops:trust-boundary — issue-state writes require confirmed write+ access;
+	# API lookup failures fail closed but remain distinct from confirmed non-access.
+	if declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+		_gh_collaborator_permission_lookup "$slug" "$user" permission || return 1
+	else
+		permission=$(gh api "/repos/${slug}/collaborators/${user}/permission" \
+			--jq '.permission // ""' 2>/dev/null || printf '')
+	fi
 	case "$permission" in
 		admin | maintain | write)
 			return 0

--- a/.agents/scripts/stats-shared.sh
+++ b/.agents/scripts/stats-shared.sh
@@ -55,6 +55,26 @@ _sanitize_runner_identity_for_cache() {
 	return 0
 }
 
+#######################################
+# Read an expired runner-role cache entry for transient API failure fallback.
+# Args: $1=disk_cache_file $2=repo_slug
+# Output: stale role, when present.
+# Returns: 0 always.
+#######################################
+_get_stale_runner_role() {
+	local disk_cache_file="$1"
+	local repo_slug="$2"
+	local stale_role="" stale_ts=""
+	if [[ -f "$disk_cache_file" ]]; then
+		IFS='|' read -r stale_role stale_ts <"$disk_cache_file" 2>/dev/null || stale_role=""
+		if [[ -n "$stale_role" ]]; then
+			echo "[stats] _get_runner_role: API failed for ${repo_slug}, using stale cache: ${stale_role}" >>"${LOGFILE:-/dev/null}"
+		fi
+	fi
+	printf '%s\n' "$stale_role"
+	return 0
+}
+
 # check_session_count: now provided by worker-lifecycle-common.sh (sourced by caller).
 # Previously duplicated here (17 lines) — see t1431. Consolidated to eliminate
 # divergence risk and ensure single source of truth.
@@ -139,9 +159,11 @@ _get_runner_role() {
 	# On failure, use expired disk cache if available rather than defaulting
 	# to "contributor" — this prevents role flip-flop on transient errors.
 	local role=""
-	local api_path="repos/${repo_slug}/collaborators/${runner_user}/permission"
-	local response
-	response=$(gh api "$api_path" --jq '.permission // empty' 2>/dev/null) || response=""
+	local response=""
+	local lookup_failed=0
+	# #aidevops:trust-boundary — runner role classification uses confirmed
+	# collaborator permission; transient lookup failures prefer stale cache.
+	_gh_collaborator_permission_lookup "$repo_slug" "$runner_user" response || lookup_failed=1
 
 	case "$response" in
 	admin | maintain | write)
@@ -151,16 +173,7 @@ _get_runner_role() {
 		role="contributor"
 		;;
 	"")
-		# API failure — use expired disk cache if available (stale > wrong)
-		if [[ -f "$disk_cache_file" ]]; then
-			local stale_role _stale_ts
-			IFS='|' read -r stale_role _stale_ts <"$disk_cache_file" 2>/dev/null || stale_role=""
-			if [[ -n "$stale_role" ]]; then
-				echo "[stats] _get_runner_role: API failed for ${repo_slug}, using stale cache: ${stale_role}" >>"${LOGFILE:-/dev/null}"
-				role="$stale_role"
-			fi
-		fi
-		# No cache at all — default to contributor (fail closed)
+		role=$(_get_stale_runner_role "$disk_cache_file" "$repo_slug")
 		[[ -z "$role" ]] && role="contributor"
 		;;
 	*)
@@ -168,6 +181,11 @@ _get_runner_role() {
 		role="contributor"
 		;;
 	esac
+
+	if [[ "$lookup_failed" -eq 1 ]]; then
+		echo "$role"
+		return 0
+	fi
 
 	# Persist to both caches
 	export "$cache_key=$role"

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -182,6 +182,19 @@ gh() {
 		printf '"testuser"\n'
 		return 0
 	fi
+	if [[ "$1" == "api" && "$2" == "-i" && "${3:-}" =~ ^/repos/[^/]+/[^/]+/collaborators/[^/]+/permission$ ]]; then
+		local status="${STUB_COLLAB_STATUS:-200}"
+		if [[ "${STUB_COLLAB_FAIL:-0}" == "1" ]]; then
+			printf 'HTTP/2.0 %s Forbidden\n\n{"message":"Forbidden"}\n' "$status"
+			return 1
+		fi
+		if [[ "$status" == "404" ]]; then
+			printf 'HTTP/2.0 404 Not Found\n\n{"message":"Not Found"}\n'
+			return 1
+		fi
+		printf 'HTTP/2.0 %s OK\n\n{"permission":"%s"}\n' "$status" "${STUB_COLLAB_PERMISSION:-write}"
+		return 0
+	fi
 
 	# gh api /repos/.../issues/N (state fetch for label/assignee deltas)
 	if [[ "$1" == "api" && "$2" =~ ^/repos/.+/issues/[0-9]+$ ]]; then
@@ -1191,7 +1204,55 @@ else
 		"GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
 fi
 
+: >"$GH_CALLS"
+: >"$GH_APP_TOKEN_CALLS"
+export STUB_COLLAB_PERMISSION=write
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "testuser" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "write" ]] &&
+	grep -qE '^api -i /repos/owner/repo/collaborators/testuser/permission' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'cached-app-token' "$GH_APP_TOKEN_CALLS" 2>/dev/null; then
+	pass "collaborator permission lookup uses GitHub App REST route when available"
+else
+	fail "collaborator permission lookup uses GitHub App REST route when available" \
+		"perm=${collab_perm} GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
+fi
+
 unset AIDEVOPS_GITHUB_APP_ENABLED AIDEVOPS_GITHUB_APP_ID AIDEVOPS_GITHUB_APP_INSTALLATION_ID AIDEVOPS_GITHUB_APP_REST_FIRST
+
+: >"$GH_CALLS"
+: >"$GH_APP_TOKEN_CALLS"
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "testuser" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "write" ]] &&
+	grep -qE '^api -i /repos/owner/repo/collaborators/testuser/permission' "$GH_CALLS" 2>/dev/null &&
+	! grep -q 'cached-app-token' "$GH_APP_TOKEN_CALLS" 2>/dev/null; then
+	pass "collaborator permission lookup falls back to normal gh auth when App auth is unavailable"
+else
+	fail "collaborator permission lookup falls back to normal gh auth when App auth is unavailable" \
+		"perm=${collab_perm} GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
+fi
+
+export STUB_COLLAB_STATUS=404
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "outsider" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "none" && "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-}" == "404" ]]; then
+	pass "collaborator permission lookup maps 404 to confirmed none"
+else
+	fail "collaborator permission lookup maps 404 to confirmed none" \
+		"perm=${collab_perm} http=${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unset} reason=${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unset}"
+fi
+
+export STUB_COLLAB_STATUS=403
+export STUB_COLLAB_FAIL=1
+if ! _gh_collaborator_permission_lookup "owner/repo" "testuser" >/dev/null 2>&1 &&
+	[[ "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-}" == "403" && "${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-}" == "api-failure" ]]; then
+	pass "collaborator permission lookup keeps API failure distinct from none"
+else
+	fail "collaborator permission lookup keeps API failure distinct from none" \
+		"http=${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unset} reason=${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unset}"
+fi
+unset STUB_COLLAB_STATUS STUB_COLLAB_FAIL STUB_COLLAB_PERMISSION
 
 # =============================================================================
 # Test 35: _rest_split_csv suppresses early-close Broken pipe noise

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -89,7 +89,15 @@ auth)
 			printf 'testuser\n'
 			exit 0
 		fi
-		if [[ "$2" == repos/*/collaborators/*/permission ]]; then
+		if [[ "$2" == "-i" && "${3:-}" == */collaborators/*/permission ]]; then
+			if [[ "${STUB_PERMISSION_FAIL:-0}" == "1" ]]; then
+				printf 'HTTP/2.0 403 Forbidden\n\n{"message":"Forbidden"}\n'
+				exit 1
+			fi
+			printf 'HTTP/2.0 200 OK\n\n{"permission":"%s"}\n' "${STUB_PERMISSION:-admin}"
+			exit 0
+		fi
+		if [[ "$2" == repos/*/collaborators/*/permission || "$2" == /repos/*/collaborators/*/permission ]]; then
 			if [[ "${STUB_PERMISSION_FAIL:-0}" == "1" ]]; then
 				exit 1
 			fi

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -120,16 +120,16 @@ if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
 	exit 0
 fi
 
-# `gh api -i repos/SLUG/collaborators/USER/permission` — return 200/404 line
-# Used by _is_collaborator_author for the membership probe (head -1).
+	# `gh api -i /repos/SLUG/collaborators/USER/permission` — return status+body.
+	# Used by the App-aware collaborator permission lookup helper.
 if [[ "${1:-}" == "api" && "${2:-}" == "-i" && "$*" == *"/collaborators/"*"/permission" ]]; then
 	# Extract the username segment between /collaborators/ and /permission.
 	_user="${3#*/collaborators/}"
 	_user="${_user%/permission}"
 	if grep -Fxq "$_user" "${TEST_ROOT}/collaborators.txt"; then
-		printf 'HTTP/2.0 200 OK\n'
+		printf 'HTTP/2.0 200 OK\n\n{"permission":"admin"}\n'
 	else
-		printf 'HTTP/2.0 404 Not Found\n'
+		printf 'HTTP/2.0 404 Not Found\n\n{"message":"Not Found"}\n'
 	fi
 	exit 0
 fi
@@ -188,15 +188,14 @@ teardown_test_env() {
 # keeping the unit boundary at approve_collaborator_pr.
 define_helpers_under_test() {
 	local approve_src
-	local collab_src
+	local runner_src
 	local crypto_src
 	approve_src=$(awk '
 		/^approve_collaborator_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
-	# _is_collaborator_author was extracted to pulse-merge-author-checks.sh (GH#21426)
-	collab_src=$(awk '
-		/^_is_collaborator_author\(\) \{/,/^}$/ { print }
-	' "$AUTHOR_CHECKS_SCRIPT")
+	runner_src=$(awk '
+		/^_approve_collaborator_runner_has_write\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
 	# _has_maintainer_crypto_approval was added in t3063
 	crypto_src=$(awk '
 		/^_has_maintainer_crypto_approval\(\) \{/,/^}$/ { print }
@@ -206,8 +205,8 @@ define_helpers_under_test() {
 		printf 'ERROR: could not extract approve_collaborator_pr from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
-	if [[ -z "$collab_src" ]]; then
-		printf 'ERROR: could not extract _is_collaborator_author from %s\n' "$AUTHOR_CHECKS_SCRIPT" >&2
+	if [[ -z "$runner_src" ]]; then
+		printf 'ERROR: could not extract _approve_collaborator_runner_has_write from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
 	if [[ -z "$crypto_src" ]]; then
@@ -226,8 +225,10 @@ define_helpers_under_test() {
 	# allowances are covered by test-pulse-merge-trusted-dependabot.sh.
 	_is_trusted_dependabot_update_pr() { return 1; }
 
+	# shellcheck source=../pulse-merge-author-checks.sh
+	source "$AUTHOR_CHECKS_SCRIPT"
 	# shellcheck disable=SC1090
-	eval "$collab_src"
+	eval "$runner_src"
 	# shellcheck disable=SC1090
 	eval "$crypto_src"
 	# shellcheck disable=SC1090

--- a/.agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh
+++ b/.agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh
@@ -74,7 +74,8 @@ _all_args=("$@")
 
 # HEAD call for permission check (-i flag)
 if [[ "$*" == *"-i"* && "$*" == *"permission"* ]]; then
-	printf 'HTTP/2 200\n'
+	printf 'HTTP/2 200\n\n'
+	cat "${TEST_ROOT}/perm.json"
 	exit 0
 fi
 

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -98,9 +98,9 @@ if [[ "${1:-}" == "api" && "${2:-}" == "-i" && "$*" == *"/collaborators/"*"/perm
 	_user="${3#*/collaborators/}"
 	_user="${_user%/permission}"
 	if grep -Fxq "$_user" "${TEST_ROOT}/collaborators.txt"; then
-		printf 'HTTP/2.0 200 OK\n'
+		printf 'HTTP/2.0 200 OK\n\n{"permission":"admin"}\n'
 	else
-		printf 'HTTP/2.0 404 Not Found\n'
+		printf 'HTTP/2.0 404 Not Found\n\n{"message":"Not Found"}\n'
 	fi
 	exit 0
 fi
@@ -139,7 +139,7 @@ teardown_test_env() {
 define_helpers_under_test() {
 	local dependabot_src=""
 	local approve_src=""
-	local collab_src=""
+	local runner_src=""
 	dependabot_src=$(awk '
 		/^_trusted_dependabot_updates_conf\(\) \{/,/^}$/ { print }
 		/^_trusted_dependabot_dependency_allowed\(\) \{/,/^}$/ { print }
@@ -147,12 +147,14 @@ define_helpers_under_test() {
 		/^_trusted_dependabot_non_review_checks_green\(\) \{/,/^}$/ { print }
 	' "$GATES_SCRIPT")
 	approve_src=$(awk '/^approve_collaborator_pr\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
-	collab_src=$(awk '/^_is_collaborator_author\(\) \{/,/^}$/ { print }' "$AUTHOR_CHECKS_SCRIPT")
-	[[ -n "$dependabot_src" && -n "$approve_src" && -n "$collab_src" ]] || return 1
+	runner_src=$(awk '/^_approve_collaborator_runner_has_write\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
+	[[ -n "$dependabot_src" && -n "$approve_src" && -n "$runner_src" ]] || return 1
 
 	_has_maintainer_crypto_approval() { return 1; }
+	# shellcheck source=../pulse-merge-author-checks.sh
+	source "$AUTHOR_CHECKS_SCRIPT"
 	# shellcheck disable=SC1090
-	eval "$collab_src"
+	eval "$runner_src"
 	# shellcheck disable=SC1090
 	eval "$dependabot_src"
 	# shellcheck disable=SC1090

--- a/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
@@ -45,6 +45,13 @@ setup_test_env() {
 set -euo pipefail
 if [[ "${1:-}" == "api" ]]; then
 	path="${2:-}"
+	if [[ "$path" == "-i" ]]; then
+		path="${3:-}"
+		if [[ "$path" == */collaborators/runner/permission ]]; then
+			printf 'HTTP/2.0 200 OK\n\n{"permission":"%s"}\n' "${ACTOR_PERMISSION:-none}"
+			exit 0
+		fi
+	fi
 	jq_filter=""
 	shift 2 2>/dev/null || true
 	while [[ $# -gt 0 ]]; do

--- a/.agents/scripts/tests/test-quality-feedback-trust-bar.sh
+++ b/.agents/scripts/tests/test-quality-feedback-trust-bar.sh
@@ -72,6 +72,18 @@ setup_test_env() {
 set -euo pipefail
 if [[ "${1:-}" == "api" ]]; then
 	path="${2:-}"
+	if [[ "$path" == "-i" ]]; then
+		path="${3:-}"
+		if [[ "$path" == */collaborators/*/permission ]]; then
+			if [[ "$(cat "$PERMISSION_FIXTURE")" == "FAIL" ]]; then
+				printf 'HTTP/2.0 403 Forbidden\n\n{"message":"Forbidden"}\n'
+				exit 1
+			fi
+			printf 'HTTP/2.0 200 OK\n\n'
+			cat "$PERMISSION_FIXTURE"
+			exit 0
+		fi
+	fi
 	jq_filter=""
 	shift 2 2>/dev/null || true
 	while [[ $# -gt 0 ]]; do
@@ -125,6 +137,12 @@ define_helpers_under_test() {
 		printf 'ERROR: could not extract _is_maintainer_equivalent_author from %s\n' "$QF_SCRIPT" >&2
 		return 1
 	fi
+	# shellcheck source=../github-app-auth-helper.sh
+	source "${SCRIPT_DIR}/../github-app-auth-helper.sh"
+	# shellcheck source=../shared-gh-wrappers-rest-fallback.sh
+	source "${SCRIPT_DIR}/../shared-gh-wrappers-rest-fallback.sh"
+	# shellcheck source=../shared-gh-collaborator-permission.sh
+	source "${SCRIPT_DIR}/../shared-gh-collaborator-permission.sh"
 	# shellcheck disable=SC1090
 	eval "$trust_src"
 	return 0

--- a/.agents/scripts/tests/test-repo-state-guard.sh
+++ b/.agents/scripts/tests/test-repo-state-guard.sh
@@ -24,7 +24,15 @@ if [[ "$1" == "api" && "$2" == "user" ]]; then
   printf '%s\n' "tester"
   exit 0
 fi
-if [[ "$1" == "api" && "$2" == repos/*/collaborators/*/permission ]]; then
+if [[ "$1" == "api" && "$2" == "-i" && "${3:-}" == */collaborators/*/permission ]]; then
+  if [[ "$mode" == "managed" ]]; then
+    printf 'HTTP/2.0 200 OK\n\n{"permission":"write"}\n'
+    exit 0
+  fi
+  printf 'HTTP/2.0 403 Forbidden\n\n{"message":"Must have push access"}\n' >&2
+  exit 1
+fi
+if [[ "$1" == "api" && ( "$2" == repos/*/collaborators/*/permission || "$2" == /repos/*/collaborators/*/permission ) ]]; then
   if [[ "$mode" == "managed" ]]; then
     printf '%s\n' "write"
     exit 0

--- a/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
+++ b/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
@@ -68,7 +68,11 @@ gh() {
 		printf 'test-login\n'
 		return 0
 	fi
-	if [[ "$1" == "api" && "${2:-}" == repos/*/collaborators/*/permission ]]; then
+	if [[ "$1" == "api" && "${2:-}" == "-i" && "${3:-}" == */collaborators/*/permission ]]; then
+		printf 'HTTP/2.0 200 OK\n\n{"permission":"%s"}\n' "${GH_PERMISSION:-read}"
+		return 0
+	fi
+	if [[ "$1" == "api" && ( "${2:-}" == repos/*/collaborators/*/permission || "${2:-}" == /repos/*/collaborators/*/permission ) ]]; then
 		printf '%s\n' "${GH_PERMISSION:-read}"
 		return 0
 	fi

--- a/.agents/scripts/upstream-watch-helper-issues.sh
+++ b/.agents/scripts/upstream-watch-helper-issues.sh
@@ -122,7 +122,7 @@ _write_upstream_watch_local_report() {
 
 	mkdir -p "$report_dir"
 	local report_file
-	report_file=$(mktemp "${report_dir}/${stamp}.XXXXXX.md")
+	report_file=$(mktemp "${report_dir}/${stamp}.md.XXXXXX")
 	{
 		printf '# %s\n\n' "$title"
 		printf '%s\n' "$body"

--- a/.agents/scripts/upstream-watch-helper-issues.sh
+++ b/.agents/scripts/upstream-watch-helper-issues.sh
@@ -31,6 +31,21 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+	if [[ -f "${SCRIPT_DIR}/github-app-auth-helper.sh" ]]; then
+		# shellcheck source=./github-app-auth-helper.sh
+		source "${SCRIPT_DIR}/github-app-auth-helper.sh"
+	fi
+	if [[ -f "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+		# shellcheck source=./shared-gh-wrappers-rest-fallback.sh
+		source "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh"
+	fi
+	if [[ -f "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+		# shellcheck source=./shared-gh-collaborator-permission.sh
+		source "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh"
+	fi
+fi
+
 # =============================================================================
 # GitHub issue filing (t2810)
 # =============================================================================
@@ -72,8 +87,12 @@ _upstream_watch_issue_creation_authorized() {
 	fi
 
 	local permission=""
-	permission=$(gh api "repos/${aidevops_slug}/collaborators/${login}/permission" \
-		--jq '.permission // ""' 2>/dev/null) || permission=""
+	# #aidevops:trust-boundary — public upstream-watch issue creation requires
+	# confirmed write+ access; API lookup failures skip without claiming none.
+	if ! _gh_collaborator_permission_lookup "$aidevops_slug" "$login" permission; then
+		_log_warn "Skipping public upstream-watch issue creation in ${aidevops_slug}: permission check failed for gh user ${login} (HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown})"
+		return 1
+	fi
 
 	case "$permission" in
 		admin | maintain | write)

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -257,19 +257,24 @@ _verify_maintainer_identity() {
 		return 1
 	fi
 
+	local repo_owner="${slug%%/*}"
+	if [[ "$current_user" == "$repo_owner" ]]; then
+		return 0
+	fi
+
 	# Check repo collaboration level — OWNER and MEMBER can push hotfixes
-	user_association=$(gh api "repos/${slug}/collaborators/${current_user}/permission" --jq '.role_name' 2>/dev/null || echo "")
+	# #aidevops:trust-boundary — hotfix releases require confirmed write+ access;
+	# permission lookup failures abort as failures, not as confirmed no-access.
+	if ! _gh_collaborator_permission_lookup "$slug" "$current_user" user_association; then
+		print_error "hotfix release requires maintainer identity (permission check failed for ${current_user}, HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown})"
+		return 1
+	fi
 
 	case "$user_association" in
 	admin | maintain | write)
 		return 0
 		;;
 	*)
-		# Fallback: check if the user is the repo owner (slug prefix matches)
-		local repo_owner="${slug%%/*}"
-		if [[ "$current_user" == "$repo_owner" ]]; then
-			return 0
-		fi
 		print_error "hotfix release requires maintainer identity (current: ${current_user}, role: ${user_association:-unknown})"
 		return 1
 		;;


### PR DESCRIPTION
## Summary

Routed collaborator permission probes through the shared GitHub App-aware REST helper, preserved API-failure vs non-collaborator semantics in pulse merge and trust gates, and added regression coverage for App success, fallback, 404, and API failures.

## Files Changed

.agents/scripts/interactive-session-helper.sh,.agents/scripts/pulse-merge-author-checks.sh,.agents/scripts/pulse-merge-gates.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/pulse-nmr-approval.sh,.agents/scripts/pulse-simplification-review.sh,.agents/scripts/pulse-simplification-scan.sh,.agents/scripts/pulse-triage-cache.sh,.agents/scripts/quality-feedback-helper.sh,.agents/scripts/quality-feedback-issues-lib.sh,.agents/scripts/shared-gh-collaborator-permission.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/shared-repo-state-guard.sh,.agents/scripts/stats-shared.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh,.agents/scripts/tests/test-interactive-session-claim.sh,.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh,.agents/scripts/tests/test-pulse-merge-origin-interactive-auto-merge.sh,.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh,.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh,.agents/scripts/tests/test-quality-feedback-trust-bar.sh,.agents/scripts/tests/test-repo-state-guard.sh,.agents/scripts/tests/test-upstream-watch-issue-gate.sh,.agents/scripts/upstream-watch-helper-issues.sh,.agents/scripts/version-manager-release.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted permission regression suite passed; shellcheck on modified scripts passed; .agents/scripts/linters-local.sh passed (markdown and ratchet warnings advisory only).

Resolves #24502


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.27 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1h 31m and 363,768 tokens on this with the user in an interactive session.