### PR TITLE
GH#24521: fix: accept triage collaborator permissions

### DIFF
--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -21,7 +21,7 @@ _SHARED_GH_COLLABORATOR_PERMISSION_LOADED=1
 #   AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 #
 # Args: $1=repo_slug owner/repo, $2=user login, $3=optional output variable
-# Output: permission value (admin|maintain|write|read|none) on lookup success.
+# Output: permission value (admin|maintain|write|triage|read|none) on lookup success.
 # Returns: 0=lookup succeeded (404 maps to none), 2=lookup/API/parse failure.
 #######################################
 _gh_collaborator_permission_lookup() {
@@ -99,7 +99,7 @@ _gh_collaborator_permission_lookup() {
 
 	permission_value=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || permission_value=""
 	case "$permission_value" in
-	admin | maintain | write | read | none)
+	admin | maintain | write | triage | read | none)
 		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="ok"
 		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 		if [[ -n "$out_var" ]]; then

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1233,6 +1233,17 @@ else
 		"perm=${collab_perm} GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
 fi
 
+export STUB_COLLAB_PERMISSION=triage
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "testuser" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "triage" && "${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-}" == "ok" ]]; then
+	pass "collaborator permission lookup accepts triage role"
+else
+	fail "collaborator permission lookup accepts triage role" \
+		"perm=${collab_perm} reason=${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unset}"
+fi
+export STUB_COLLAB_PERMISSION=write
+
 export STUB_COLLAB_STATUS=404
 collab_perm=""
 _gh_collaborator_permission_lookup "owner/repo" "outsider" collab_perm 2>/dev/null || true


### PR DESCRIPTION
## Summary

Allowed the GitHub triage role in shared collaborator permission parsing and added regression coverage for triage responses.

## Files Changed

.agents/scripts/shared-gh-collaborator-permission.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-collaborator-permission.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

Resolves #24521


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.28 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 63,965 tokens on this as a headless worker.