### PR TITLE
GH#24527: fix: improve gh checks timeout portability

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -78,6 +78,9 @@ _gh_checks_api_read() {
 	if command -v timeout >/dev/null 2>&1; then
 		timeout "$secs" gh api "$endpoint" "$@"
 		return $?
+	elif command -v gtimeout >/dev/null 2>&1; then
+		gtimeout "$secs" gh api "$endpoint" "$@"
+		return $?
 	fi
 
 	gh api "$endpoint" "$@"

--- a/.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)"
 CHECKS_LIB="${SCRIPTS_DIR}/shared-gh-wrappers-checks.sh"
 
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+
 if [[ ! -f "$CHECKS_LIB" ]]; then
 	printf 'ERROR: shared-gh-wrappers-checks.sh not found at %s\n' "$CHECKS_LIB" >&2
 	exit 1
@@ -15,9 +18,7 @@ fi
 
 # shellcheck source=../shared-gh-wrappers-checks.sh
 source "$CHECKS_LIB"
-
-WRAPPER_LOG="$(mktemp)"
-export WRAPPER_LOG
+WRAPPER_LOG=""
 
 _gh_with_timeout() {
 	local op_class="$1"
@@ -40,24 +41,37 @@ _gh_with_timeout() {
 	return 0
 }
 
-status="$(gh_pr_check_status_rest "owner/repo" "abc123")"
-runs="$(gh_pr_check_runs_rest "owner/repo" "abc123")"
+main() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	WRAPPER_LOG="$(mktemp)"
+	export WRAPPER_LOG
+	push_cleanup "rm -f '${WRAPPER_LOG}'"
 
-if [[ "$status" != "PASS" ]]; then
-	printf 'FAIL: expected PASS status, got %s\n' "$status" >&2
-	exit 1
-fi
+	local status
+	status="$(gh_pr_check_status_rest "owner/repo" "abc123")"
+	local runs
+	runs="$(gh_pr_check_runs_rest "owner/repo" "abc123")"
 
-if ! printf '%s' "$runs" | jq -e '. == [{"name":"quality","conclusion":"success","status":"completed"}]' >/dev/null; then
-	printf 'FAIL: unexpected runs JSON: %s\n' "$runs" >&2
-	exit 1
-fi
+	if [[ "$status" != "PASS" ]]; then
+		printf 'FAIL: expected PASS status, got %s\n' "$status" >&2
+		return 1
+	fi
 
-if [[ "$(grep -c '^read	gh api repos/owner/repo/commits/abc123/' "$WRAPPER_LOG")" -ne 3 ]]; then
-	printf 'FAIL: expected 3 wrapped gh api calls\n' >&2
-	cat "$WRAPPER_LOG" >&2
-	exit 1
-fi
+	if ! printf '%s' "$runs" | jq -e '. == [{"name":"quality","conclusion":"success","status":"completed"}]' >/dev/null; then
+		printf 'FAIL: unexpected runs JSON: %s\n' "$runs" >&2
+		return 1
+	fi
 
-rm -f "$WRAPPER_LOG"
-printf 'PASS shared-gh-wrappers-checks gh api timeout wrapper\n'
+	if [[ "$(grep -c '^read[[:space:]]gh api repos/owner/repo/commits/abc123/' "$WRAPPER_LOG")" -ne 3 ]]; then
+		printf 'FAIL: expected 3 wrapped gh api calls\n' >&2
+		cat "$WRAPPER_LOG" >&2
+		return 1
+	fi
+
+	rm -f "$WRAPPER_LOG"
+	printf 'PASS shared-gh-wrappers-checks gh api timeout wrapper\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added gtimeout fallback for read-only gh api timeout handling and updated the timeout wrapper test to use shared cleanup helpers plus a POSIX space class in the log assertion.

## Files Changed

.agents/scripts/shared-gh-wrappers-checks.sh,.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-checks.sh .agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh; .agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh

Resolves #24527


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.28 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 80,340 tokens on this as a headless worker.