### PR TITLE
GH#24528: docs: harden t3593 permission jq examples

### DIFF
--- a/todo/tasks/t3593-brief.md
+++ b/todo/tasks/t3593-brief.md
@@ -103,11 +103,11 @@ Reference wrapper pattern:
 # Prefer a leading /repos/... path so github_app_api_call can extract repo
 # context when selecting an installation token.
 github_app_api_call read rest-core gh api \
-  "/repos/${repo_slug}/collaborators/${author}/permission" --jq '.permission'
+  "/repos/${repo_slug}/collaborators/${author}/permission" --jq '.permission // ""'
 
 # Where shared-gh-wrappers-rest-fallback.sh is already sourced, prefer:
 _rest_api_call read gh api \
-  "/repos/${repo_slug}/collaborators/${author}/permission" --jq '.permission'
+  "/repos/${repo_slug}/collaborators/${author}/permission" --jq '.permission // ""'
 ```
 
 Critical semantic rule: a 404/permission `none` result may mean "not collaborator"; 403, 429, 5xx, timeout, and network failures must be treated as "permission API failed" and must fail closed without claiming the author is non-collaborator.


### PR DESCRIPTION
## Summary

Updated the t3593 collaborator permission wrapper examples to use jq fallback filters so missing/null permissions resolve to an empty string instead of literal null.

## Files Changed

todo/tasks/t3593-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 'todo/tasks/t3593-brief.md'

For #24528


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.28 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 49,210 tokens on this as a headless worker.
