### PR TITLE
GH#24522: fix: clean up repo sync auth capture

### DIFF
--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -372,19 +372,19 @@ gh_auth_available() {
 # Returns: git exit code
 #######################################
 run_git_capturing_stderr() {
-	local repo_path="$1"
-	shift
-	local stderr_file
-	stderr_file=$(mktemp) || return 1
 	_REPO_SYNC_LAST_GIT_STDERR=""
+	local -a git_args=("$@")
+	local repo_path
+	repo_path="${git_args[0]}"
+	shift
+	local rc
+	local stderr_output
 
-	if GIT_TERMINAL_PROMPT=0 git -C "$repo_path" "$@" 2>"$stderr_file"; then
-		rm -f "$stderr_file"
+	if { stderr_output=$(GIT_TERMINAL_PROMPT=0 git -C "$repo_path" "$@" 2>&1 >&3); } 3>&1; then
 		return 0
 	else
-		local rc=$?
-		_REPO_SYNC_LAST_GIT_STDERR=$(<"$stderr_file")
-		rm -f "$stderr_file"
+		rc=$?
+		_REPO_SYNC_LAST_GIT_STDERR="$stderr_output"
 		return "$rc"
 	fi
 }
@@ -397,22 +397,22 @@ run_git_capturing_stderr() {
 # Returns: git exit code
 #######################################
 run_git_with_gh_credential() {
-	local repo_path="$1"
-	shift
-	local stderr_file
-	stderr_file=$(mktemp) || return 1
 	_REPO_SYNC_LAST_GIT_STDERR=""
+	local -a git_args=("$@")
+	local repo_path
+	repo_path="${git_args[0]}"
+	shift
+	local rc
+	local stderr_output
 
-	if GIT_TERMINAL_PROMPT=0 git -C "$repo_path" \
+	if { stderr_output=$(GIT_TERMINAL_PROMPT=0 git -C "$repo_path" \
 		-c credential.helper= \
 		-c "credential.helper=!gh auth git-credential" \
-		"$@" 2>"$stderr_file"; then
-		rm -f "$stderr_file"
+		"$@" 2>&1 >&3); } 3>&1; then
 		return 0
 	else
-		local rc=$?
-		_REPO_SYNC_LAST_GIT_STDERR=$(<"$stderr_file")
-		rm -f "$stderr_file"
+		rc=$?
+		_REPO_SYNC_LAST_GIT_STDERR="$stderr_output"
 		return "$rc"
 	fi
 }

--- a/.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh
+++ b/.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="${SCRIPT_DIR}/../repo-sync-helper.sh"
 
 failures=0
+declare -a TEMP_DIRS=()
+
+cleanup() {
+	rm -rf "${TEMP_DIRS[@]}"
+	return 0
+}
+trap cleanup EXIT
 
 pass() {
 	local message="$1"
@@ -31,10 +38,12 @@ make_fake_tools() {
 }
 
 run_case() {
-	local case_name="$1"
+	local case_name
+	case_name="$1"
 	shift
 	local tmp_dir
 	tmp_dir=$(mktemp -d)
+	TEMP_DIRS+=("$tmp_dir")
 	mkdir -p "${tmp_dir}/home/.config/aidevops" "${tmp_dir}/parent/repo/.git"
 	make_fake_tools "$tmp_dir"
 	printf '{"git_parent_dirs":["%s"]}\n' "${tmp_dir}/parent" >"${tmp_dir}/home/.config/aidevops/repos.json"


### PR DESCRIPTION
## Summary

Eliminated temporary stderr files from repo-sync git auth capture by capturing stderr in-memory while preserving stdout and exit status; added test temp directory cleanup.

## Files Changed

.agents/scripts/repo-sync-helper.sh,.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/repo-sync-helper.sh .agents/scripts/tests/test-repo-sync-helper-gh-auth.sh; .agents/scripts/tests/test-repo-sync-helper-gh-auth.sh

Resolves #24522


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.28 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 8m and 77,171 tokens on this as a headless worker.