### PR TITLE
GH#24529: fix: normalize headless session repo slugs

### DIFF
--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -141,6 +141,7 @@ _provider_session_repo_slug() {
 	repo_slug="${repo_slug#https://github.com/}"
 	repo_slug="${repo_slug#git@github.com:}"
 	repo_slug="${repo_slug%.git}"
+	repo_slug=$(printf '%s' "$repo_slug" | tr '[:upper:]' '[:lower:]')
 	case "$repo_slug" in
 	*/*) printf '%s' "$repo_slug" ;;
 	*) printf '%s' "" ;;

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -275,7 +275,7 @@ _issue_attempt_summary_json() {
 		def is_issue:
 			((.session_key // "") == $sk) or (((.issue_number // "") | tostring) == $issue);
 		def is_repo:
-			($repo == "") or ((.repo_slug // "") == $repo);
+			($repo == "") or (((.repo_slug // "") | ascii_downcase) == ($repo | ascii_downcase));
 		def is_rate_limit:
 			(.result // "") == "rate_limit"
 			or (.result // "") == "rate_limit_fast"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -664,9 +664,10 @@ EOF
 test_provider_sessions_scope_issue_keys_by_repo_slug() {
 	local provider="openai"
 	local model="openai/gpt-5.5"
+	local old_repo_slug="${WORKER_REPO_SLUG:-}"
 	export WORKER_REPO_SLUG="owner/one"
 	store_session_id "$provider" "issue-47" "ses_one" "$model"
-	export WORKER_REPO_SLUG="owner/two"
+	export WORKER_REPO_SLUG="Owner/Two"
 	store_session_id "$provider" "issue-47" "ses_two" "$model"
 
 	local first_session="" second_session="" unscoped_count=""
@@ -675,7 +676,11 @@ test_provider_sessions_scope_issue_keys_by_repo_slug() {
 	export WORKER_REPO_SLUG="owner/two"
 	second_session=$(get_session_id "$provider" "issue-47")
 	unscoped_count=$(db_query "SELECT count(*) FROM provider_sessions WHERE provider = 'openai' AND session_key = 'issue-47';")
-	unset WORKER_REPO_SLUG
+	if [[ -n "$old_repo_slug" ]]; then
+		export WORKER_REPO_SLUG="$old_repo_slug"
+	else
+		unset WORKER_REPO_SLUG
+	fi
 
 	if [[ "$first_session" == "ses_one" && "$second_session" == "ses_two" && "$unscoped_count" == "0" ]]; then
 		print_result "provider_sessions scope issue keys by repo slug" 0
@@ -690,12 +695,17 @@ test_provider_sessions_scope_issue_keys_by_repo_slug() {
 test_provider_sessions_keep_pulse_unscoped() {
 	local provider="openai"
 	local model="openai/gpt-5.5"
+	local old_repo_slug="${WORKER_REPO_SLUG:-}"
 	export WORKER_REPO_SLUG="owner/one"
 	store_session_id "$provider" "pulse" "ses_pulse" "$model"
 	local pulse_session="" pulse_count=""
 	pulse_session=$(get_session_id "$provider" "pulse")
 	pulse_count=$(db_query "SELECT count(*) FROM provider_sessions WHERE provider = 'openai' AND session_key = 'pulse';")
-	unset WORKER_REPO_SLUG
+	if [[ -n "$old_repo_slug" ]]; then
+		export WORKER_REPO_SLUG="$old_repo_slug"
+	else
+		unset WORKER_REPO_SLUG
+	fi
 
 	if [[ "$pulse_session" == "ses_pulse" && "$pulse_count" == "1" ]]; then
 		print_result "provider_sessions keep pulse sessions unscoped" 0

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -350,7 +350,7 @@ recent_rate_limit_2=$(( now_epoch - 120 ))
 recent_success=$(( now_epoch - 60 ))
 cat > "$FIXTURE_METRICS" <<METRICS
 {"ts":${recent_rate_limit_1},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"marcusquinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit","failure_reason":"rate_limit","exit_code":143}
-{"ts":${recent_rate_limit_2},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"marcusquinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit_fast","failure_reason":"rate_limit_fast","provider_error_type":"rate_limit","provider_status":429,"exit_code":143}
+{"ts":${recent_rate_limit_2},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"MarcusQuinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit_fast","failure_reason":"rate_limit_fast","provider_error_type":"rate_limit","provider_status":429,"exit_code":143}
 {"ts":${recent_success},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"marcusquinn/aidevops","provider":"openai","model":"openai/gpt-5.5","result":"success","failure_reason":"","exit_code":0}
 {"ts":${recent_success},"role":"worker","session_key":"issue-21860","issue_number":21860,"repo_slug":"example/other","provider":"openai","model":"openai/gpt-5.5","result":"rate_limit","failure_reason":"rate_limit","exit_code":143}
 METRICS


### PR DESCRIPTION
## Summary

Normalized provider session repository slugs before scoping issue session keys, made pulse diagnose repo filtering case-insensitive, and restored WORKER_REPO_SLUG after provider session tests.

## Files Changed

.agents/scripts/headless-runtime-model.sh,.agents/scripts/pulse-diagnose-helper.sh,.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/scripts/tests/test-pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-model.sh .agents/scripts/pulse-diagnose-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh .agents/scripts/tests/test-pulse-diagnose-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh; .agents/scripts/tests/test-pulse-diagnose-helper.sh

Resolves #24529


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.28 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 94,948 tokens on this as a headless worker.