### PR TITLE
GH#24523: fix: harden review-thread reply parsing

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -141,8 +141,8 @@ _prrts_thread_author_login() {
 		_prrts_log "reply: author lookup failed for thread ${thread_id} (rc=${rc})"
 		return 1
 	fi
-	login=$(printf '%s' "$response" | jq -r '.data.node.comments.nodes[0].author.login // ""' 2>/dev/null) || login=""
-	if [[ -z "$login" || "$login" == "null" ]]; then
+	login=$(printf '%s' "$response" | jq -r '.data.node.comments?.nodes[0]?.author?.login // ""') || login=""
+	if [[ -z "$login" ]]; then
 		_prrts_log "reply: author login missing for thread ${thread_id}"
 		return 1
 	fi
@@ -154,13 +154,13 @@ _prrts_body_content_starts_with_mention() {
 	local body="$1"
 	local author_login="$2"
 	local mention="@${author_login}"
-	local line="" next_char=""
+	local line="" next_char="" html_comment_re='^[[:space:]]*<!--.*-->[[:space:]]*$'
 
 	while IFS= read -r line || [[ -n "$line" ]]; do
-		if [[ -z "$line" ]]; then
+		if [[ "$line" =~ ^[[:space:]]*$ ]]; then
 			continue
 		fi
-		if [[ "$line" == "<!-- "*" -->" ]]; then
+		if [[ "$line" =~ $html_comment_re ]]; then
 			continue
 		fi
 		if [[ "${line:0:${#mention}}" != "$mention" ]]; then

--- a/.agents/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/tests/test-pr-review-thread-response-scanner.sh
@@ -50,7 +50,31 @@ fi
 
 if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
 	printf '%s\n' "$*" >>"${FAKE_GH_CAPTURE:?}"
+	if [[ "$*" == *"addPullRequestReviewThreadReply"* ]]; then
+		while [[ "$#" -gt 0 ]]; do
+			if [[ "${1:-}" == "-F" && "${2:-}" == body=* ]]; then
+				printf '%s' "${2#body=}" >"${FAKE_GH_REPLY_CAPTURE:?}"
+				break
+			fi
+			shift
+		done
+		printf '%s\n' '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"COMMENT_1","url":""}}}}'
+		exit 0
+	fi
+	if [[ "$*" == *"-F thread="* && "$*" == *"comments(first: 1)"* ]]; then
+		printf '%s\n' '{"data":{"node":{"comments":{"nodes":[{"author":{"login":"gemini-code-assist"}}]}}}}'
+		exit 0
+	fi
 	printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_1","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"script.sh","line":12,"url":"","body":"fixture","diffHunk":"@@","updatedAt":"2026-06-01T00:00:00Z"}]}}]}}}}}'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
+	if [[ "$*" == *"--jq"* ]]; then
+		printf '%s\n' '100'
+		exit 0
+	fi
+	printf '%s\n' '{"resources":{"graphql":{"remaining":100},"core":{"remaining":100}}}'
 	exit 0
 fi
 
@@ -86,8 +110,69 @@ test_scan_passes_nonempty_owner_and_name_to_graphql() {
 	return 0
 }
 
+test_reply_recognises_existing_mention_after_whitespace_and_comment() {
+	printf '==> reply recognises author mention after blank/comment lines\n'
+	_setup
+	local fake_bin="${TEST_TMPDIR}/bin"
+	local capture="${TEST_TMPDIR}/gh-args.log"
+	local reply_capture="${TEST_TMPDIR}/reply-body.txt"
+	local body_file="${TEST_TMPDIR}/body.md"
+	local expected=$'   \n\t<!-- generated marker -->  \n@gemini-code-assist already handled'
+	_write_fake_gh "$fake_bin"
+	printf '%s' "$expected" >"$body_file"
+
+	if FAKE_GH_CAPTURE="$capture" FAKE_GH_REPLY_CAPTURE="$reply_capture" PATH="${fake_bin}:$PATH" "$SCANNER" reply "marcusquinn/aidevops" "THREAD_1" "$body_file"; then
+		_pass "reply command succeeds"
+	else
+		_fail "reply command succeeds"
+	fi
+
+	local actual=""
+	actual="$(<"$reply_capture")"
+	if [[ "$actual" == "$expected" ]]; then
+		_pass "existing mention is not duplicated"
+	else
+		_fail "existing mention is not duplicated" "body: ${actual}"
+	fi
+
+	_teardown
+	return 0
+}
+
+test_reply_prepends_author_when_first_content_is_not_mention() {
+	printf '==> reply prepends author when first content is not a mention\n'
+	_setup
+	local fake_bin="${TEST_TMPDIR}/bin"
+	local capture="${TEST_TMPDIR}/gh-args.log"
+	local reply_capture="${TEST_TMPDIR}/reply-body.txt"
+	local body_file="${TEST_TMPDIR}/body.md"
+	local body=$'   \n<!-- generated marker-->\nPlease fix this.'
+	local expected="@gemini-code-assist ${body}"
+	_write_fake_gh "$fake_bin"
+	printf '%s' "$body" >"$body_file"
+
+	if FAKE_GH_CAPTURE="$capture" FAKE_GH_REPLY_CAPTURE="$reply_capture" PATH="${fake_bin}:$PATH" "$SCANNER" reply "marcusquinn/aidevops" "THREAD_1" "$body_file"; then
+		_pass "reply command succeeds without existing mention"
+	else
+		_fail "reply command succeeds without existing mention"
+	fi
+
+	local actual=""
+	actual="$(<"$reply_capture")"
+	if [[ "$actual" == "$expected" ]]; then
+		_pass "author mention is prepended"
+	else
+		_fail "author mention is prepended" "body: ${actual}"
+	fi
+
+	_teardown
+	return 0
+}
+
 main() {
 	test_scan_passes_nonempty_owner_and_name_to_graphql
+	test_reply_recognises_existing_mention_after_whitespace_and_comment
+	test_reply_prepends_author_when_first_content_is_not_mention
 	printf 'Results: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1


### PR DESCRIPTION
## Summary

Hardened review-thread author login parsing with jq optional access, removed redundant null-string checks, and made reply mention detection skip whitespace-only lines plus flexibly formatted HTML comments. Added unit coverage for reply bodies that already mention the thread author after blank/comment lines and for bodies that still need a prepended mention.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh,.agents/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/tests/test-pr-review-thread-response-scanner.sh; bash .agents/tests/test-pr-review-thread-response-scanner.sh; .agents/scripts/linters-local.sh

Resolves #24523


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.28 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 9m and 59,568 tokens on this as a headless worker.