### PR TITLE
GH#24512: dispatch targeted review-thread remediation

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -5,16 +5,19 @@
 #
 # Usage:
 #   pr-review-thread-response-scanner.sh scan <repo_slug> [repo_path]
+#   pr-review-thread-response-scanner.sh scan-pr <repo_slug> <pr_number>
 #   pr-review-thread-response-scanner.sh dispatch <repo_slug> <repo_path>
+#   pr-review-thread-response-scanner.sh dispatch-pr <repo_slug> <repo_path> <pr_number>
 #   pr-review-thread-response-scanner.sh dry-run <repo_slug> [repo_path]
 #   pr-review-thread-response-scanner.sh reply <repo_slug> <thread_id> <body_file> [marker]
 #   pr-review-thread-response-scanner.sh resolve <repo_slug> <thread_id>
 #
 # This helper is intentionally conservative: it never resolves review threads
-# itself. It only detects unresolved bot review threads on open
-# non-draft PRs and dispatches a bounded worker prompt to verify and respond via
-# the existing PR-review loop model. The worker must read/verify the thread
-# before editing code or resolving/commenting.
+# itself. It only detects unresolved bot review threads on open non-draft PRs by
+# default and dispatches a bounded worker prompt to verify and respond via the
+# existing PR-review loop model. The targeted merge-blocker path can opt in to
+# human-authored threads with PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true. The
+# worker must read/verify the thread before editing code or resolving/commenting.
 
 set -euo pipefail
 
@@ -31,6 +34,7 @@ PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO="${PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO
 PR_REVIEW_THREAD_RESPONSE_COOLDOWN="${PR_REVIEW_THREAD_RESPONSE_COOLDOWN:-3600}"
 PR_REVIEW_THREAD_RESPONSE_MODEL="${PR_REVIEW_THREAD_RESPONSE_MODEL:-}"
 PR_REVIEW_THREAD_RESPONSE_BOT_RE="${PR_REVIEW_THREAD_RESPONSE_BOT_RE:-coderabbitai|gemini-code-assist|claude-review|gpt-review|augment-code|augmentcode|copilot}"
+PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN="${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN:-false}"
 PRRTS_BOOL_TRUE="true"
 PRRTS_BOOL_FALSE="false"
 
@@ -49,7 +53,7 @@ _prrts_log() {
 }
 
 _prrts_usage() {
-	printf 'Usage: %s {scan|dispatch|dry-run|reply|resolve} <repo_slug> ...\n' "$(basename "$0")"
+	printf 'Usage: %s {scan|scan-pr|dispatch|dispatch-pr|dry-run|reply|resolve} <repo_slug> ...\n' "$(basename "$0")"
 	return 0
 }
 
@@ -320,11 +324,12 @@ _prrts_review_thread_summary() {
 	if [[ "$rc" -ne 0 ]]; then
 		return "$rc"
 	fi
-	summary=$(printf '%s' "$json" | jq -r --arg bots "$PR_REVIEW_THREAD_RESPONSE_BOT_RE" '
+	summary=$(printf '%s' "$json" | jq -r --arg bots "$PR_REVIEW_THREAD_RESPONSE_BOT_RE" \
+		--arg include_human "$PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN" '
 		[.data.repository.pullRequest.reviewThreads.nodes[]?
 			| select((.isResolved // false) == false)
 			| {thread_id: (.id // ""), is_outdated: (.isOutdated // false), comment: (.comments.nodes[0]? // {})}
-			| select((.comment.author.login // "") | test($bots; "i"))
+			| select(($include_human == "true") or ((.comment.author.login // "") | test($bots; "i")))
 		] as $threads
 		| [
 			($threads | length),
@@ -336,6 +341,38 @@ _prrts_review_thread_summary() {
 		return 2
 	}
 	printf '%s\n' "$summary"
+	return 0
+}
+
+cmd_scan_pr() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local title head_ref author summary rc
+	local thread_count fingerprint preview
+	title="PR #${pr_number}"
+	head_ref=""
+	author=""
+	summary=""
+	rc=0
+	thread_count=""
+	fingerprint=""
+	preview=""
+
+	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || {
+		_prrts_usage >&2
+		return 2
+	}
+	summary="$(_prrts_review_thread_summary "$repo_slug" "$pr_number")" || rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		_prrts_log "scan-pr: ${repo_slug}#${pr_number} skipped — review-thread fetch failed"
+		return 0
+	fi
+	IFS=$'\t' read -r thread_count fingerprint preview <<<"$summary"
+	[[ "$thread_count" =~ ^[0-9]+$ ]] || thread_count=0
+	if [[ "$thread_count" -gt 0 ]]; then
+		printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+			"$pr_number" "$thread_count" "$fingerprint" "$title" "$head_ref" "$author" "$preview"
+	fi
 	return 0
 }
 
@@ -602,6 +639,47 @@ _prrts_dispatch_repo() {
 	return 0
 }
 
+_prrts_dispatch_pr() {
+	local repo_slug="$1"
+	local repo_path="$2"
+	local pr_number="$3"
+	local dry_run="$4"
+	local candidate now_epoch thread_count fingerprint title head_ref author preview
+	candidate=""
+	now_epoch=""
+	thread_count=""
+	fingerprint=""
+	title=""
+	head_ref=""
+	author=""
+	preview=""
+
+	if [[ -z "$repo_path" || ! -d "${repo_path/#\~/$HOME}" || ! "$pr_number" =~ ^[0-9]+$ ]]; then
+		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} skipped — repo path missing/invalid or PR number invalid (${repo_path})"
+		return 0
+	fi
+	repo_path="${repo_path/#\~/$HOME}"
+	candidate="$(cmd_scan_pr "$repo_slug" "$pr_number")"
+	[[ -n "$candidate" ]] || {
+		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} has no unresolved review threads matching current filters"
+		return 0
+	}
+	now_epoch="$(date +%s)"
+	IFS=$'\t' read -r pr_number thread_count fingerprint title head_ref author preview <<<"$candidate"
+	if ! _prrts_should_dispatch "$repo_slug" "$pr_number" "$fingerprint" "$now_epoch"; then
+		return 0
+	fi
+	if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
+		printf 'DRY-RUN would dispatch %s#%s (%s unresolved thread(s))\n' "$repo_slug" "$pr_number" "$thread_count"
+		_prrts_log "dry-run: would dispatch targeted ${repo_slug}#${pr_number} (${thread_count} unresolved thread(s), include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN})"
+		return 0
+	fi
+	_prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$preview" || return 0
+	_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch"
+	_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} completed, dispatched=1, include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN}"
+	return 0
+}
+
 main() {
 	local command="${1:-}"
 	local repo_slug="${2:-}"
@@ -614,12 +692,22 @@ main() {
 		fi
 		cmd_scan "$repo_slug" "$repo_path"
 		;;
+	scan-pr)
+		cmd_scan_pr "$repo_slug" "${3:-}"
+		;;
 	dispatch)
 		if [[ -z "$repo_slug" || -z "$repo_path" ]]; then
 			_prrts_usage >&2
 			return 2
 		fi
 		_prrts_dispatch_repo "$repo_slug" "$repo_path" "$PRRTS_BOOL_FALSE"
+		;;
+	dispatch-pr)
+		if [[ -z "$repo_slug" || -z "$repo_path" || -z "${4:-}" ]]; then
+			_prrts_usage >&2
+			return 2
+		fi
+		_prrts_dispatch_pr "$repo_slug" "$repo_path" "${4:-}" "$PRRTS_BOOL_FALSE"
 		;;
 	dry-run)
 		if [[ -z "$repo_slug" ]]; then

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -94,6 +94,39 @@ _pm_issue_api() {
 	return 0
 }
 
+_pulse_merge_repo_path_for_slug() {
+	local repo_slug="$1"
+	local repos_json="${AIDEVOPS_REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+	local repo_path=""
+	[[ -n "$repo_slug" && -f "$repos_json" ]] || return 1
+	repo_path=$(jq -r --arg slug "$repo_slug" '
+		.initialized_repos[]? | select(.slug == $slug) | .path // empty
+	' "$repos_json" 2>/dev/null | sed -n '1p') || repo_path=""
+	[[ -n "$repo_path" ]] || return 1
+	printf '%s\n' "${repo_path/#\~/$HOME}"
+	return 0
+}
+
+_pulse_merge_maybe_dispatch_review_thread_remediation() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local merge_output="$3"
+	local repo_path="" scanner="${_PULSE_MERGE_DIR}/pr-review-thread-response-scanner.sh"
+
+	[[ "$merge_output" == *"A conversation must be resolved"* ]] || return 0
+	if [[ ! -x "$scanner" ]]; then
+		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: scanner missing or not executable (${scanner})" >>"$LOGFILE"
+		return 0
+	fi
+	if ! repo_path="$(_pulse_merge_repo_path_for_slug "$repo_slug")"; then
+		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: repo path not found in configured repos" >>"$LOGFILE"
+		return 0
+	fi
+	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true "$scanner" dispatch-pr "$repo_slug" "$repo_path" "$pr_number" >>"$LOGFILE" 2>&1 || true
+	echo "[pulse-merge] review-thread remediation queued for PR #${pr_number} in ${repo_slug} after unresolved conversation merge blocker" >>"$LOGFILE"
+	return 0
+}
+
 # Standard PR JSON fields consumed by _process_single_ready_pr. Keep every
 # caller that builds a PR object on this helper so draft/label/staleness
 # metadata cannot drift between list-based and webhook-triggered merge paths.
@@ -1037,6 +1070,7 @@ _process_single_ready_pr() {
 		return $?
 	else
 		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${merge_output}" >>"$LOGFILE"
+		_pulse_merge_maybe_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "$merge_output"
 		return 3
 	fi
 }

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -27,15 +27,7 @@ print_result() {
 	return 0
 }
 
-setup_test_env() {
-	unset STUB_PR_LIST STUB_THREADS_MODE
-	TEST_ROOT="$(mktemp -d -t prrts.XXXXXX)"
-	export HOME="${TEST_ROOT}/home"
-	export LOGFILE="${TEST_ROOT}/scanner.log"
-	export AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="${TEST_ROOT}/state"
-	export HEADLESS_LOG="${TEST_ROOT}/headless.log"
-	export HEADLESS_PROMPT_CAPTURE="${TEST_ROOT}/prompt.md"
-	mkdir -p "${HOME}" "${TEST_ROOT}/bin" "${TEST_ROOT}/repo" "${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}"
+write_fake_gh_stub() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GH_STUB'
 #!/usr/bin/env bash
 if [[ "$1" == "api" && "${2:-}" == "rate_limit" ]]; then
@@ -84,6 +76,9 @@ if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
 	none)
 		printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n'
 		;;
+	human)
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_HUMAN","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"maintainer"},"path":"script.sh","line":12,"url":"https://example.invalid/human","updatedAt":"2026-06-03T00:00:00Z"}]}},{"id":"THREAD_BOT","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"bot.sh","line":3,"url":"https://example.invalid/bot","updatedAt":"2026-06-03T00:00:00Z"}]}}]}}}}}'
+		;;
 	outdated)
 		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_OLD","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"old.sh","line":7,"url":"https://example.invalid/outdated","updatedAt":"2026-06-03T00:00:00Z"}]}}]}}}}}'
 		;;
@@ -97,6 +92,19 @@ printf '[]\n'
 exit 0
 GH_STUB
 	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+setup_test_env() {
+	unset STUB_PR_LIST STUB_THREADS_MODE
+	TEST_ROOT="$(mktemp -d -t prrts.XXXXXX)"
+	export HOME="${TEST_ROOT}/home"
+	export LOGFILE="${TEST_ROOT}/scanner.log"
+	export AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="${TEST_ROOT}/state"
+	export HEADLESS_LOG="${TEST_ROOT}/headless.log"
+	export HEADLESS_PROMPT_CAPTURE="${TEST_ROOT}/prompt.md"
+	mkdir -p "${HOME}" "${TEST_ROOT}/bin" "${TEST_ROOT}/repo" "${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}"
+	write_fake_gh_stub
 	cat >"${TEST_ROOT}/headless-runtime-helper.sh" <<'HEADLESS_STUB'
 #!/usr/bin/env bash
 prompt_file=""
@@ -189,6 +197,34 @@ test_scan_includes_outdated_unresolved_threads() {
 	return 0
 }
 
+test_scan_pr_excludes_human_threads_by_default() {
+	setup_test_env
+	export STUB_THREADS_MODE="human"
+	local output=""
+	output="$($SCANNER scan-pr owner/repo 1)"
+	if [[ "$output" == *"THREAD_BOT"* && "$output" != *"THREAD_HUMAN"* ]]; then
+		print_result "scan-pr keeps human review threads excluded by default" 0
+	else
+		print_result "scan-pr keeps human review threads excluded by default" 1 "output=${output}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_scan_pr_can_include_human_threads_with_opt_in() {
+	setup_test_env
+	export STUB_THREADS_MODE="human"
+	local output=""
+	output="$(PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true $SCANNER scan-pr owner/repo 1)"
+	if [[ "$output" == *"THREAD_HUMAN"* && "$output" == *"THREAD_BOT"* && "$output" == *$'1\t2\t'* ]]; then
+		print_result "scan-pr includes human review threads only with opt-in" 0
+	else
+		print_result "scan-pr includes human review threads only with opt-in" 1 "output=${output}"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_launches_worker_and_writes_state() {
 	setup_test_env
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
@@ -198,6 +234,21 @@ test_dispatch_launches_worker_and_writes_state() {
 		print_result "dispatch launches bounded worker and writes state" 0
 	else
 		print_result "dispatch launches bounded worker and writes state" 1 "headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=${state_file}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_pr_launches_targeted_worker_with_human_opt_in() {
+	setup_test_env
+	export STUB_THREADS_MODE="human"
+	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true $SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	if [[ -s "$HEADLESS_LOG" && -f "$state_file" ]] && grep -q 'Target: PR #1 in owner/repo' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
+		print_result "dispatch-pr launches bounded targeted worker with human opt-in" 0
+	else
+		print_result "dispatch-pr launches bounded targeted worker with human opt-in" 1 "headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=${state_file}"
 	fi
 	teardown_test_env
 	return 0
@@ -322,7 +373,10 @@ main() {
 	test_scan_finds_unresolved_bot_thread
 	test_scan_skips_draft_prs
 	test_scan_includes_outdated_unresolved_threads
+	test_scan_pr_excludes_human_threads_by_default
+	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state
+	test_dispatch_pr_launches_targeted_worker_with_human_opt_in
 	test_dispatch_is_idempotent_for_same_fingerprint
 	test_reply_and_resolve_use_graphql_mutations
 	test_reply_auto_prepends_thread_author

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '     %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT="$(mktemp -d -t pulse-review-remediation.XXXXXX)"
+	mkdir -p "${TEST_ROOT}/scripts" "${TEST_ROOT}/repo" "${TEST_ROOT}/config"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export SCANNER_LOG="${TEST_ROOT}/scanner.log"
+	export AIDEVOPS_REPOS_JSON="${TEST_ROOT}/config/repos.json"
+	printf '{"initialized_repos":[{"slug":"owner/repo","path":"%s"}]}\n' "${TEST_ROOT}/repo" >"$AIDEVOPS_REPOS_JSON"
+	cat >"${TEST_ROOT}/scripts/pr-review-thread-response-scanner.sh" <<'SCANNER'
+#!/usr/bin/env bash
+printf 'include_human=%s args=%s\n' "${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN:-false}" "$*" >>"${SCANNER_LOG:?}"
+exit 0
+SCANNER
+	chmod +x "${TEST_ROOT}/scripts/pr-review-thread-response-scanner.sh"
+	: >"$LOGFILE"
+	: >"$SCANNER_LOG"
+	_PULSE_MERGE_DIR="${TEST_ROOT}/scripts"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	TEST_ROOT=""
+	return 0
+}
+
+define_helpers_under_test() {
+	local src_repo_path="" src_dispatch=""
+	src_repo_path=$(awk '
+		/^_pulse_merge_repo_path_for_slug\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$MERGE_SCRIPT")
+	src_dispatch=$(awk '
+		/^_pulse_merge_maybe_dispatch_review_thread_remediation\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$src_repo_path" || -z "$src_dispatch" ]]; then
+		printf 'ERROR: could not extract helpers from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$src_repo_path"
+	# shellcheck disable=SC1090
+	eval "$src_dispatch"
+	return 0
+}
+
+test_unresolved_conversation_dispatches_targeted_human_thread_remediation() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	_pulse_merge_maybe_dispatch_review_thread_remediation 77 owner/repo 'GraphQL: A conversation must be resolved before merging'
+
+	if grep -q 'include_human=true args=dispatch-pr owner/repo' "$SCANNER_LOG" \
+		&& grep -q ' 77$' "$SCANNER_LOG" \
+		&& grep -q 'review-thread remediation queued for PR #77 in owner/repo' "$LOGFILE"; then
+		print_result "unresolved conversation queues targeted human-thread remediation" 0
+	else
+		print_result "unresolved conversation queues targeted human-thread remediation" 1 \
+			"scanner=$(tr '\n' ';' <"$SCANNER_LOG"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_other_merge_failures_do_not_dispatch_review_thread_remediation() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	_pulse_merge_maybe_dispatch_review_thread_remediation 77 owner/repo 'GraphQL: required status check is expected'
+
+	if [[ ! -s "$SCANNER_LOG" ]]; then
+		print_result "non-conversation merge failures do not dispatch remediation" 0
+	else
+		print_result "non-conversation merge failures do not dispatch remediation" 1 "scanner=$(tr '\n' ';' <"$SCANNER_LOG")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+main() {
+	test_unresolved_conversation_dispatches_targeted_human_thread_remediation
+	test_other_merge_failures_do_not_dispatch_review_thread_remediation
+	printf '\nTests run: %d\n' "$TESTS_RUN"
+	printf 'Tests failed: %d\n' "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add scan-pr/dispatch-pr modes to target one PR for unresolved review-thread remediation
- keep bot-only scanning as the default, with PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true only for merge-blocker remediation
- have pulse queue targeted remediation when GitHub reports `A conversation must be resolved` during merge

Resolves #24512

## Verification
- bash .agents/scripts/tests/test-pr-review-thread-response-scanner.sh
- bash .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
- bash .agents/tests/test-pr-review-thread-response-scanner.sh
- shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
- .agents/scripts/linters-local.sh
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.30 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1h 18m and 226,237 tokens on this with the user in an interactive session.