### PR TITLE
GH#24541: fix: install tokei via cargo for LOC badges

### DIFF
--- a/.github/workflows/loc-badge-reusable.yml
+++ b/.github/workflows/loc-badge-reusable.yml
@@ -113,8 +113,15 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          # tokei lands in Ubuntu repos; jq is preinstalled on ubuntu-latest but kept explicit.
-          sudo apt-get install -y --no-install-recommends tokei jq
+          # jq is available from Ubuntu apt; tokei is not packaged for Ubuntu/Debian.
+          sudo apt-get install -y --no-install-recommends jq
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            # shellcheck source=/dev/null
+            source "$HOME/.cargo/env"
+          fi
+          cargo install --locked tokei
+          export PATH="$HOME/.cargo/bin:$PATH"
           tokei --version
           jq --version
 


### PR DESCRIPTION
## Summary

Updated .github/workflows/loc-badge-reusable.yml so Ubuntu installs jq from apt and installs tokei with cargo, falling back to rustup minimal setup when cargo is unavailable.

## Files Changed

.github/workflows/loc-badge-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** actionlint .github/workflows/loc-badge-reusable.yml

Resolves #24541


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.32 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 29,091 tokens on this as a headless worker.