### PR TITLE
GH#24544: fix: suppress repeated FOSS dispatches

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -82,6 +82,78 @@ _foss_issue_list_for_label() {
 }
 
 #######################################
+# Resolve the authenticated GitHub login for FOSS PR ownership checks.
+#
+# stdout: login, or empty when unavailable.
+# Returns: 0 always (missing auth must fail open for FOSS dispatch).
+#######################################
+_foss_current_gh_login() {
+	if [[ -n "${FOSS_CURRENT_GH_LOGIN:-}" ]]; then
+		printf '%s\n' "$FOSS_CURRENT_GH_LOGIN"
+		return 0
+	fi
+	gh api user --jq '.login // ""' 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Check whether this account already has an open PR for a FOSS issue.
+#
+# Args:
+#   $1 - repo_slug (owner/repo)
+#   $2 - issue number
+# Returns: 0 when an open PR exists, 1 otherwise.
+#######################################
+_foss_open_pr_exists_for_issue() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local login
+	login=$(_foss_current_gh_login)
+	[[ -n "$login" ]] || return 1
+
+	local count
+	count=$(gh_pr_list --repo "$repo_slug" --state open --author "$login" \
+		--search "$issue_number" --json number --jq 'length' 2>/dev/null || printf '%s' '0')
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	[[ "$count" -gt 0 ]] && return 0
+	return 1
+}
+
+#######################################
+# Check recent FOSS worker metrics for terminal evidence or local-error backoff.
+#
+# Args:
+#   $1 - FOSS session key (foss-owner/repo-issue)
+#   $2 - mode: local_error|terminal
+# Returns: 0 when recent evidence exists, 1 otherwise.
+#######################################
+_foss_recent_runtime_evidence() {
+	local session_key="$1"
+	local mode="$2"
+	local metrics_file="${FOSS_RUNTIME_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+	local backoff_seconds="${FOSS_LOCAL_ERROR_BACKOFF_SECONDS:-3600}"
+	local terminal_seconds="${FOSS_TERMINAL_EVIDENCE_SECONDS:-604800}"
+	local window_seconds="$backoff_seconds"
+	[[ "$mode" == "terminal" ]] && window_seconds="$terminal_seconds"
+	[[ -n "$session_key" && -f "$metrics_file" ]] || return 1
+	[[ "$window_seconds" =~ ^[0-9]+$ ]] || window_seconds=3600
+
+	local matches
+	matches=$(jq -rs --arg key "$session_key" --arg mode "$mode" --argjson window "$window_seconds" '
+		def result_match:
+			if $mode == "local_error" then (.result == "local_error")
+			else (.result == "success" or .result == "blocked")
+			end;
+		[.[] | select((.session_key // "") == $key)
+			| select(((.ts // 0) | tonumber) >= (now - $window))
+			| select(result_match)] | length
+	' "$metrics_file" 2>/dev/null || printf '%s' '0')
+	[[ "$matches" =~ ^[0-9]+$ ]] || matches=0
+	[[ "$matches" -gt 0 ]] && return 0
+	return 1
+}
+
+#######################################
 # Ensure the triage-failed label exists in the target repo.
 #
 # Uses gh label create --force (idempotent — creates if missing,
@@ -1348,6 +1420,18 @@ dispatch_foss_workers() {
 		local foss_session_key="foss-${foss_slug}-${foss_issue_num}"
 		if [[ "${foss_session_keys_seen}" == *$'\n'"${foss_session_key}"$'\n'* ]]; then
 			echo "[pulse-wrapper] FOSS dispatch skipped duplicate session key ${foss_session_key} in this cycle" >>"$LOGFILE"
+			continue
+		fi
+		if _foss_open_pr_exists_for_issue "$foss_slug" "$foss_issue_num"; then
+			echo "[pulse-wrapper] FOSS dispatch skipped ${foss_session_key}: authenticated account already has an open PR for issue #${foss_issue_num}" >>"$LOGFILE"
+			continue
+		fi
+		if _foss_recent_runtime_evidence "$foss_session_key" "terminal"; then
+			echo "[pulse-wrapper] FOSS dispatch skipped ${foss_session_key}: recent success/blocked runtime evidence already exists" >>"$LOGFILE"
+			continue
+		fi
+		if _foss_recent_runtime_evidence "$foss_session_key" "local_error"; then
+			echo "[pulse-wrapper] FOSS dispatch skipped ${foss_session_key}: recent local runtime failure is in backoff" >>"$LOGFILE"
 			continue
 		fi
 		foss_session_keys_seen="${foss_session_keys_seen}${foss_session_key}"$'\n'

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -124,7 +124,7 @@ _foss_open_pr_exists_for_issue() {
 #
 # Args:
 #   $1 - FOSS session key (foss-owner/repo-issue)
-#   $2 - mode: local_error|terminal
+#   $2 - mode: local|terminal
 # Returns: 0 when recent evidence exists, 1 otherwise.
 #######################################
 _foss_recent_runtime_evidence() {
@@ -139,10 +139,13 @@ _foss_recent_runtime_evidence() {
 	[[ "$window_seconds" =~ ^[0-9]+$ ]] || window_seconds=3600
 
 	local matches
-	matches=$(jq -rs --arg key "$session_key" --arg mode "$mode" --argjson window "$window_seconds" '
+	matches=$(jq -rs --arg key "$session_key" --arg mode "$mode" --arg result_field "result" \
+		--arg local_result "local_error" --arg success_result "success" --arg blocked_result "blocked" \
+		--argjson window "$window_seconds" '
 		def result_match:
-			if $mode == "local_error" then (.result == "local_error")
-			else (.result == "success" or .result == "blocked")
+			(.[$result_field] // "") as $runtime_result
+			| if $mode == "local" then ($runtime_result == $local_result)
+			else ($runtime_result == $success_result or $runtime_result == $blocked_result)
 			end;
 		[.[] | select((.session_key // "") == $key)
 			| select(((.ts // 0) | tonumber) >= (now - $window))
@@ -1430,7 +1433,7 @@ dispatch_foss_workers() {
 			echo "[pulse-wrapper] FOSS dispatch skipped ${foss_session_key}: recent success/blocked runtime evidence already exists" >>"$LOGFILE"
 			continue
 		fi
-		if _foss_recent_runtime_evidence "$foss_session_key" "local_error"; then
+		if _foss_recent_runtime_evidence "$foss_session_key" "local"; then
 			echo "[pulse-wrapper] FOSS dispatch skipped ${foss_session_key}: recent local runtime failure is in backoff" >>"$LOGFILE"
 			continue
 		fi

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -109,6 +109,29 @@ gh_issue_list() {
 	return 0
 }
 
+gh_pr_list() {
+	local author=""
+	local search=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--author)
+			author="$2"
+			shift 2
+			;;
+		--search)
+			search="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+	printf '%s|%s\n' "$author" "$search" >>"${TEST_TMP}/pr-list.log"
+	printf '%s\n' "${GH_OPEN_PR_COUNT:-0}"
+	return 0
+}
+
 sleep() {
 	return 0
 }
@@ -121,8 +144,12 @@ HEADLESS_INVOCATION_LOG="${TEST_TMP}/headless.log"
 GH_ISSUE_LIST_LABEL_LOG="${TEST_TMP}/issue-labels.log"
 HOME="${TEST_TMP}/home"
 LOGFILE="${TEST_TMP}/pulse.log"
+FOSS_CURRENT_GH_LOGIN="test-bot"
+FOSS_RUNTIME_METRICS_FILE="${TEST_TMP}/headless-runtime-metrics.jsonl"
 export HEADLESS_INVOCATION_LOG
 export GH_ISSUE_LIST_LABEL_LOG
+export FOSS_CURRENT_GH_LOGIN
+export FOSS_RUNTIME_METRICS_FILE
 
 # shellcheck source=../pulse-ancillary-dispatch.sh
 source "${SCRIPTS_DIR}/pulse-ancillary-dispatch.sh"
@@ -142,6 +169,26 @@ available_after_empty="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "
 if ! grep -q 'FOSS dispatch skipped no issue selection for owner/project' "$LOGFILE"; then
 	fail "empty selection did not log an auditable no-work reason"
 fi
+
+GH_ISSUE_LIST_OUTPUT='42|Fix duplicate dispatch'
+GH_OPEN_PR_COUNT=1
+available_after_open_pr="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json")" || fail "open PR guard dispatch failed"
+[[ "$available_after_open_pr" == "2" ]] || fail "open PR guard changed available worker count"
+[[ ! -f "$HEADLESS_INVOCATION_LOG" ]] || fail "open PR guard launched a worker"
+if ! grep -q 'authenticated account already has an open PR for issue #42' "$LOGFILE"; then
+	fail "open PR guard did not log an auditable skip reason"
+fi
+GH_OPEN_PR_COUNT=0
+
+metric_ts="$(date +%s)"
+printf '{"ts":%s,"role":"worker","session_key":"foss-owner/project-42","result":"local_error"}\n' "$metric_ts" >"$FOSS_RUNTIME_METRICS_FILE"
+available_after_local_error="$(FOSS_MAX_DISPATCH_PER_CYCLE=2 dispatch_foss_workers 2 "$repos_json")" || fail "local error backoff dispatch failed"
+[[ "$available_after_local_error" == "2" ]] || fail "local error backoff changed available worker count"
+[[ ! -f "$HEADLESS_INVOCATION_LOG" ]] || fail "local error backoff launched a worker"
+if ! grep -q 'recent local runtime failure is in backoff' "$LOGFILE"; then
+	fail "local error backoff did not log an auditable skip reason"
+fi
+rm -f "$FOSS_RUNTIME_METRICS_FILE"
 
 GH_ISSUE_LIST_OUTPUT='42|Fix duplicate dispatch'
 available_output="${TEST_TMP}/available.out"
@@ -201,6 +248,8 @@ fi
 
 printf 'PASS: FOSS null issue selections are skipped\n'
 printf 'PASS: FOSS empty issue selections are logged as no work\n'
+printf 'PASS: FOSS open PR selections are skipped\n'
+printf 'PASS: FOSS recent local runtime failures are backed off\n'
 printf 'PASS: FOSS duplicate session keys are deduplicated per cycle\n'
 printf 'PASS: FOSS dispatch falls back across configured labels\n'
 printf 'PASS: FOSS repo paths expand leading tilde before worker launch\n'


### PR DESCRIPTION
## Summary

Added FOSS pre-dispatch guards that skip issues when the authenticated account already has an open PR, when recent success/blocked runtime evidence exists, or when a recent local_error metric puts the FOSS session key in backoff. Added regression coverage for open-PR skips and local runtime failure backoff in the FOSS dispatch test.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; shellcheck .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh; bash -n .agents/scripts/pulse-ancillary-dispatch.sh .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh. .agents/scripts/linters-local.sh passed blocking checks through Bash 3.2 and then timed out during later shell portability; prior output showed only advisory/pre-existing markdown/ratchet warnings.

Resolves #24544


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.33 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 12m and 97,053 tokens on this as a headless worker.