### PR TITLE
GH#24547: enforce GitHub rate-limit cooldown headers

### DIFF
--- a/.agents/scripts/pulse-events-tickle.sh
+++ b/.agents/scripts/pulse-events-tickle.sh
@@ -45,6 +45,12 @@
 [[ -n "${_PULSE_EVENTS_TICKLE_LOADED:-}" ]] && return 0
 _PULSE_EVENTS_TICKLE_LOADED=1
 
+_PULSE_EVENTS_TICKLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _PULSE_EVENTS_TICKLE_DIR=""
+if [[ -n "$_PULSE_EVENTS_TICKLE_DIR" && -f "$_PULSE_EVENTS_TICKLE_DIR/shared-gh-secondary-cooldown.sh" ]]; then
+	# shellcheck source=shared-gh-secondary-cooldown.sh
+	source "$_PULSE_EVENTS_TICKLE_DIR/shared-gh-secondary-cooldown.sh"
+fi
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -132,6 +138,60 @@ _events_tickle_parse_etag() {
 	return 0
 }
 
+_events_tickle_record_rate_limit_response() {
+	local rc="$1"
+	local response="$2"
+	if declare -F _gh_secondary_cooldown_record_response_if_needed >/dev/null 2>&1; then
+		_gh_secondary_cooldown_record_response_if_needed "$rc" "$response"
+	fi
+	return 0
+}
+
+_events_tickle_rate_limited_response() {
+	local response="$1"
+	local http_status="$2"
+	local remaining=""
+	case "$http_status" in
+	403|429) return 0 ;;
+	esac
+	if declare -F _gh_secondary_cooldown_header_value >/dev/null 2>&1; then
+		remaining="$(_gh_secondary_cooldown_header_value "$response" "x-ratelimit-remaining")"
+		[[ "$remaining" =~ ^[0-9]+$ && "$remaining" -eq 0 ]] && return 0
+	fi
+	return 1
+}
+
+_events_tickle_retry_org_endpoint() {
+	local owner="$1"
+	local cache_file="$2"
+	local org_response=""
+	local org_exit=0
+	local org_status=""
+	local new_etag=""
+
+	declare -F gh_record_call >/dev/null 2>&1 && gh_record_call rest events_tickle_org_retry || true
+	org_response=$(gh api -i "/orgs/${owner}/events?per_page=1" 2>&1) || org_exit=$?
+	org_status=$(_events_tickle_parse_status "$org_response")
+	_events_tickle_record_rate_limit_response "$org_exit" "$org_response"
+	if _events_tickle_rate_limited_response "$org_response" "$org_status"; then
+		_events_tickle_log "cooldown recorded for owner=${owner} (org retry status=${org_status:-none} exit=${org_exit}); skipping search fanout"
+		_PULSE_EVENTS_TICKLE_FRESH=$((_PULSE_EVENTS_TICKLE_FRESH + 1))
+		return 0
+	fi
+	if [[ "$org_status" == "200" ]]; then
+		new_etag=$(_events_tickle_parse_etag "$org_response")
+		if [[ -n "$new_etag" ]]; then
+			_events_tickle_write_cache "$cache_file" "$new_etag" "orgs"
+		fi
+		_events_tickle_log "stale for owner=${owner} (org endpoint, 200 on retry)"
+		_PULSE_EVENTS_TICKLE_STALE=$((_PULSE_EVENTS_TICKLE_STALE + 1))
+		return 1
+	fi
+	_events_tickle_log "unknown for owner=${owner} (404 on both user/org endpoints)"
+	_PULSE_EVENTS_TICKLE_STALE=$((_PULSE_EVENTS_TICKLE_STALE + 1))
+	return 2
+}
+
 # ---------------------------------------------------------------------------
 # Public function: events_tickle
 # ---------------------------------------------------------------------------
@@ -146,10 +206,11 @@ _events_tickle_parse_etag() {
 #   3. 304 → return 0 (fresh): batch search can be skipped.
 #   4. 200 → update cache with new ETag, return 1 (stale): search must run.
 #   5. 404 → retry with the other endpoint type (user ↔ org), update cache.
-#   6. Error / rate-limit → return 2 (unknown): fail-open, treat as stale.
+#   6. Rate-limit headers/status → record shared cooldown and skip fanout.
+#   7. Other errors → return 2 (unknown): fail-open, treat as stale.
 #
 # Returns:
-#   0 — fresh (304 Not Modified)
+#   0 — fresh (304 Not Modified) or rate-limited cooldown skip
 #   1 — stale (200 OK, events present or ETag changed)
 #   2 — unknown (error, rate-limit, network failure, or feature disabled)
 events_tickle() {
@@ -158,6 +219,13 @@ events_tickle() {
 	# Feature flag gate — disabled means we cannot skip batch search.
 	if [[ "${PULSE_EVENTS_TICKLE_ENABLED:-1}" != "1" ]]; then
 		return 2
+	fi
+	if declare -F _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
+		if ! _gh_secondary_cooldown_preflight read >/dev/null 2>&1; then
+			_events_tickle_log "cooldown active for owner=${owner}; skipping search fanout"
+			_PULSE_EVENTS_TICKLE_FRESH=$((_PULSE_EVENTS_TICKLE_FRESH + 1))
+			return 0
+		fi
 	fi
 
 	# Ensure the ETag cache directory exists.
@@ -189,9 +257,15 @@ events_tickle() {
 	else
 		response=$(gh api -i "$api_path" 2>&1) || exit_code=$?
 	fi
+	_events_tickle_record_rate_limit_response "$exit_code" "$response"
 
 	local http_status
 	http_status=$(_events_tickle_parse_status "$response")
+	if _events_tickle_rate_limited_response "$response" "$http_status"; then
+		_events_tickle_log "cooldown recorded for owner=${owner} (status=${http_status:-none} exit=${exit_code}); skipping search fanout"
+		_PULSE_EVENTS_TICKLE_FRESH=$((_PULSE_EVENTS_TICKLE_FRESH + 1))
+		return 0
+	fi
 
 	case "$http_status" in
 
@@ -215,28 +289,10 @@ events_tickle() {
 		;;
 
 	404)
-		# Endpoint mismatch — owner type (user vs org) may be wrong.
-		# Retry with the other type; update cache if the retry succeeds.
 		if [[ "$owner_type" == "users" ]]; then
-			local org_response="" org_exit=0
-			declare -F gh_record_call >/dev/null 2>&1 && gh_record_call rest events_tickle_org_retry || true
-			org_response=$(gh api -i "/orgs/${owner}/events?per_page=1" 2>&1) || org_exit=$?
-			local org_status
-			org_status=$(_events_tickle_parse_status "$org_response")
-
-			if [[ "$org_status" == "200" ]]; then
-				owner_type="orgs"
-				local new_etag
-				new_etag=$(_events_tickle_parse_etag "$org_response")
-				if [[ -n "$new_etag" ]]; then
-					_events_tickle_write_cache "$cache_file" "$new_etag" "$owner_type"
-				fi
-				_events_tickle_log "stale for owner=${owner} (org endpoint, 200 on retry)"
-				_PULSE_EVENTS_TICKLE_STALE=$((_PULSE_EVENTS_TICKLE_STALE + 1))
-				return 1
-			fi
+			_events_tickle_retry_org_endpoint "$owner" "$cache_file"
+			return $?
 		fi
-		# 404 on both endpoints — fail-open.
 		_events_tickle_log "unknown for owner=${owner} (404 on both user/org endpoints)"
 		_PULSE_EVENTS_TICKLE_STALE=$((_PULSE_EVENTS_TICKLE_STALE + 1))
 		return 2

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -412,10 +412,10 @@ _merge_ready_prs_for_repo() {
 	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
 	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
 
-	# Process each PR — extract its JSON object and delegate to inner helper
 	local i=0
 	while [[ "$i" -lt "$pr_count" ]]; do
 		[[ -f "$STOP_FLAG" ]] && break
+		declare -F _gh_secondary_cooldown_preflight >/dev/null 2>&1 && ! _gh_secondary_cooldown_preflight write >/dev/null 2>&1 && { echo "[pulse-wrapper] Merge pass: GitHub cooldown active for ${repo_slug}; pausing remaining PR processing" >>"$LOGFILE"; break; }
 		local pr_obj
 		pr_obj=$(printf '%s' "$pr_json" | jq -c ".[$i]" 2>/dev/null)
 		i=$((i + 1))

--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -51,9 +51,10 @@ _gh_secondary_cooldown_json_string() {
 	return 0
 }
 
-_gh_secondary_cooldown_write() {
+_gh_secondary_cooldown_write_until() {
 	local reason="$1"
 	local response_text="${2:-}"
+	local expires_at="${3:-}"
 	local now=""
 	local expires=""
 	local file=""
@@ -63,7 +64,11 @@ _gh_secondary_cooldown_write() {
 	local request_id_json=""
 
 	now="$(_gh_secondary_cooldown_now)"
-	expires=$((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS))
+	if [[ "$expires_at" =~ ^[0-9]+$ && "$expires_at" -gt "$now" ]]; then
+		expires="$expires_at"
+	else
+		expires=$((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS))
+	fi
 	file="$(_gh_secondary_cooldown_file)"
 	dir="${file%/*}"
 	request_id="$(_gh_secondary_cooldown_request_id "$response_text")"
@@ -90,6 +95,78 @@ _gh_secondary_cooldown_write() {
 	fi
 	mv "${file}.tmp" "$file" || return 1
 	printf '[gh-cooldown] secondary-rate-limit active=true expires_at=%s reason=%s\n' "$expires" "$reason" >&2
+	return 0
+}
+
+_gh_secondary_cooldown_write() {
+	local reason="$1"
+	local response_text="${2:-}"
+	_gh_secondary_cooldown_write_until "$reason" "$response_text" ""
+	return $?
+}
+
+_gh_secondary_cooldown_header_value() {
+	local response_text="$1"
+	local header_name="$2"
+	printf '%s\n' "$response_text" | awk -v name="$header_name" '
+		BEGIN { target = tolower(name) ":" }
+		{ line = $0; sub(/\r$/, "", line); lower = tolower(line); if (index(lower, target) == 1) { sub(/^[^:]*:[[:space:]]*/, "", line); print line; exit } }
+	' 2>/dev/null
+	return 0
+}
+
+_gh_secondary_cooldown_status() {
+	local response_text="$1"
+	printf '%s\n' "$response_text" | awk '/^HTTP\// { print $2; exit }' | tr -d '\r' 2>/dev/null || printf ''
+	return 0
+}
+
+_gh_secondary_cooldown_header_expires_at() {
+	local response_text="$1"
+	local now=""
+	local retry_after=""
+	local reset_at=""
+
+	now="$(_gh_secondary_cooldown_now)"
+	retry_after="$(_gh_secondary_cooldown_header_value "$response_text" "retry-after")"
+	if [[ "$retry_after" =~ ^[0-9]+$ && "$retry_after" -gt 0 ]]; then
+		printf '%s' $((now + retry_after))
+		return 0
+	fi
+	reset_at="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")"
+	if [[ "$reset_at" =~ ^[0-9]+$ && "$reset_at" -gt "$now" ]]; then
+		printf '%s' "$reset_at"
+		return 0
+	fi
+	printf '%s' $((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS))
+	return 0
+}
+
+_gh_secondary_cooldown_record_response_if_needed() {
+	local rc="$1"
+	local response_text="${2:-}"
+	local status=""
+	local remaining=""
+	local expires_at=""
+
+	status="$(_gh_secondary_cooldown_status "$response_text")"
+	remaining="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-remaining")"
+	case "$status" in
+	403|429)
+		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
+		_gh_secondary_cooldown_write_until "github-api-rate-limit-status-${status}" "$response_text" "$expires_at" || true
+		return 0
+		;;
+	esac
+	if [[ "$remaining" =~ ^[0-9]+$ && "$remaining" -eq 0 ]]; then
+		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
+		_gh_secondary_cooldown_write_until "github-api-rate-limit-remaining-zero" "$response_text" "$expires_at" || true
+		return 0
+	fi
+	if [[ "$rc" -ne 0 ]]; then
+		_gh_secondary_cooldown_detect "$response_text" || return 0
+		_gh_secondary_cooldown_write "github-secondary-rate-limit" "$response_text" || true
+	fi
 	return 0
 }
 
@@ -144,8 +221,6 @@ _gh_secondary_cooldown_preflight() {
 _gh_secondary_cooldown_record_if_needed() {
 	local rc="$1"
 	local response_text="${2:-}"
-	[[ "$rc" -ne 0 ]] || return 0
-	_gh_secondary_cooldown_detect "$response_text" || return 0
-	_gh_secondary_cooldown_write "github-secondary-rate-limit" "$response_text" || true
+	_gh_secondary_cooldown_record_response_if_needed "$rc" "$response_text"
 	return 0
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -152,45 +152,61 @@ _gh_with_timeout() {
 	esac
 	local cmd="${1:-}"
 	local err_file=""
+	local out_file=""
+	local response_text=""
 	local rc=0
 	if [[ -n "$cmd" ]] && declare -f "$cmd" >/dev/null; then
 		err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || {
 			"$@"
 			return $?
 		}
-		"$@" 2>"$err_file"
+		out_file=$(mktemp -t aidevops-gh-response.XXXXXX) || {
+			"$@" 2>"$err_file"
+			rc=$?
+			cat "$err_file" >&2 2>/dev/null || true
+			rm -f "$err_file"
+			return $rc
+		}
+		"$@" >"$out_file" 2>"$err_file"
 		rc=$?
+		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true
 		if command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1; then
-			_gh_secondary_cooldown_record_if_needed "$rc" "$(cat "$err_file" 2>/dev/null || true)"
+			response_text="$(cat "$out_file" 2>/dev/null || true)
+$(cat "$err_file" 2>/dev/null || true)"
+			_gh_secondary_cooldown_record_if_needed "$rc" "$response_text"
 		fi
-		rm -f "$err_file"
+		rm -f "$err_file" "$out_file"
 		return $rc
 	fi
 	err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || err_file=""
+	out_file=$(mktemp -t aidevops-gh-response.XXXXXX) || out_file=""
 	if command -v timeout >/dev/null 2>&1; then
-		if [[ -n "$err_file" ]]; then
-			timeout "$secs" "$@" 2>"$err_file"
+		if [[ -n "$err_file" && -n "$out_file" ]]; then
+			timeout "$secs" "$@" >"$out_file" 2>"$err_file"
 			rc=$?
 		else
 			timeout "$secs" "$@"
 			rc=$?
 		fi
 	else
-		if [[ -n "$err_file" ]]; then
-			"$@" 2>"$err_file"
+		if [[ -n "$err_file" && -n "$out_file" ]]; then
+			"$@" >"$out_file" 2>"$err_file"
 			rc=$?
 		else
 			"$@"
 			rc=$?
 		fi
 	fi
-	if [[ -n "$err_file" ]]; then
+	if [[ -n "$err_file" && -n "$out_file" ]]; then
+		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true
 		if command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1; then
-			_gh_secondary_cooldown_record_if_needed "$rc" "$(cat "$err_file" 2>/dev/null || true)"
+			response_text="$(cat "$out_file" 2>/dev/null || true)
+$(cat "$err_file" 2>/dev/null || true)"
+			_gh_secondary_cooldown_record_if_needed "$rc" "$response_text"
 		fi
-		rm -f "$err_file"
+		rm -f "$err_file" "$out_file"
 	fi
 	return $rc
 }

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -31,6 +31,10 @@ gh() {
 		printf '{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}\n' >&2
 		return 1
 	fi
+	if [[ "${GH_HEADER_LIMIT_FAIL:-0}" == "1" ]]; then
+		printf 'HTTP/2 429\r\nRetry-After: 42\r\nX-RateLimit-Remaining: 0\r\nX-GitHub-Request-Id: REQ-429\r\n\r\n{"message":"rate limit exceeded"}\n'
+		return 1
+	fi
 	printf '{"ok":true}\n'
 	return 0
 }
@@ -42,7 +46,7 @@ reset_case() {
 	: >"$CALL_LOG"
 	: >"$ERR_LOG"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
-	unset GH_SECONDARY_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE 2>/dev/null || true
+	unset GH_SECONDARY_FAIL GH_HEADER_LIMIT_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE 2>/dev/null || true
 	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
 	return 0
 }
@@ -64,6 +68,26 @@ test_secondary_response_writes_cooldown() {
 		return 0
 	fi
 	printf 'FAIL cooldown file missing or malformed\n'
+	return 1
+}
+
+test_header_response_writes_retry_after_cooldown() {
+	reset_case
+	export GH_HEADER_LIMIT_FAIL=1
+	set +e
+	_gh_with_timeout read gh api -i repos/owner/repo/issues >"${TMP_HOME}/headers.out" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL expected header-limited wrapped gh rc=1, got %s\n' "$rc"
+		return 1
+	fi
+	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
+		jq -e '.reason == "github-api-rate-limit-status-429" and .last_request_id == "REQ-429" and ((.expires_at - .first_seen) >= 40) and ((.expires_at - .first_seen) <= 45)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS header response writes retry-after cooldown file\n'
+		return 0
+	fi
+	printf 'FAIL header cooldown file missing or malformed\n'
 	return 1
 }
 
@@ -127,6 +151,7 @@ test_no_jq_fallback_escapes_json_strings() {
 }
 
 test_secondary_response_writes_cooldown
+test_header_response_writes_retry_after_cooldown
 test_active_cooldown_skips_without_gh_call
 test_override_allows_audited_call
 test_default_path_without_home_is_user_scoped

--- a/.agents/scripts/tests/test-pulse-events-tickle.sh
+++ b/.agents/scripts/tests/test-pulse-events-tickle.sh
@@ -12,7 +12,7 @@
 #   3. 200 response (ETag changed) → returns 1 (stale), cache updated
 #   4. 200 sends correct If-None-Match header when ETag is stored
 #   5. 404 on users/ → retries as orgs/, returns 1 (stale), type cached
-#   6. Rate-limit error → returns 2 (unknown), fail-open
+#   6. Rate-limit error → records cooldown and skips search fanout
 #   7. Feature disabled (PULSE_EVENTS_TICKLE_ENABLED=0) → returns 2 (unknown)
 #   8. Batch prefetch integration: fresh owner skips search calls
 #   9. Batch prefetch integration: stale owner runs search calls
@@ -111,6 +111,8 @@ setup_sandbox() {
 	export HOME="${TEST_ROOT}/home"
 	mkdir -p "${HOME}/.aidevops/logs"
 	mkdir -p "${HOME}/.aidevops/cache/pulse-events-etag"
+	mkdir -p "${HOME}/.aidevops/cache"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${HOME}/.aidevops/cache/gh-secondary-cooldown.json"
 	LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
 	export LOGFILE
 
@@ -336,14 +338,14 @@ STUB_EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 6: Rate-limit error → returns 2 (unknown), fail-open
+# Test 6: Rate-limit error → records cooldown and skips search fanout
 # ---------------------------------------------------------------------------
 test_rate_limit_returns_unknown() {
 	setup_sandbox
 
 	local stub="${TEST_ROOT}/gh-ratelimit"
 	write_gh_stub "$stub" \
-		"printf 'HTTP/2 403\r\nX-RateLimit-Remaining: 0\r\n\r\n{\"message\":\"rate limit exceeded\"}\n'; exit 1"
+		"printf 'HTTP/2 403\r\nRetry-After: 60\r\nX-RateLimit-Remaining: 0\r\nX-GitHub-Request-Id: TEST-RATE-LIMIT\r\n\r\n{\"message\":\"rate limit exceeded\"}\n'; exit 1"
 	local bin_dir="${TEST_ROOT}/bin"
 	cp "$stub" "${bin_dir}/gh"
 
@@ -352,8 +354,12 @@ test_rate_limit_returns_unknown() {
 	local rc=0
 	events_tickle "ratewatcher" || rc=$?
 
-	assert_equals "test_rate_limit: returns exit 2 (unknown)" "2" "$rc"
-	assert_equals "test_rate_limit: TICKLE_STALE incremented (fail-open)" "1" "$_PULSE_EVENTS_TICKLE_STALE"
+	assert_equals "test_rate_limit: returns exit 0 (cooldown skip)" "0" "$rc"
+	assert_equals "test_rate_limit: TICKLE_FRESH incremented (skip fanout)" "1" "$_PULSE_EVENTS_TICKLE_FRESH"
+	assert_file_exists "test_rate_limit: cooldown file created" \
+		"${HOME}/.aidevops/cache/gh-secondary-cooldown.json"
+	assert_file_contains "test_rate_limit: cooldown reason recorded" \
+		"${HOME}/.aidevops/cache/gh-secondary-cooldown.json" "github-api-rate-limit-status-403"
 
 	teardown_sandbox
 	return 0


### PR DESCRIPTION
## Summary

Implemented header-aware GitHub cooldown recording for retry-after, x-ratelimit-remaining, x-ratelimit-reset, 403, and 429; routed pulse event tickle rate-limit responses into cooldown skips; paused pulse merge PR iteration when cooldown is active.

## Files Changed

.agents/scripts/pulse-events-tickle.sh,.agents/scripts/pulse-merge-process.sh,.agents/scripts/shared-gh-secondary-cooldown.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-gh-secondary-cooldown.sh,.agents/scripts/tests/test-pulse-events-tickle.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-secondary-cooldown.sh; bash .agents/scripts/tests/test-pulse-events-tickle.sh; shellcheck changed scripts; .agents/scripts/linters-local.sh

Resolves #24547


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.33 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 26m and 159,879 tokens on this with the user in an interactive session.