### PR TITLE
fix: add maintainer gate permission fallback

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -145,7 +145,8 @@ assert_contains "pr_author_has_maintainer_authority" \
 	"defines shared maintainer-authority helper"
 assert_contains "CONTRIBUTOR\)" \
 	"helper handles ambiguous CONTRIBUTOR webhook association"
-collaborator_case_count=$(grep -cE 'COLLABORATOR\)' "$WORKFLOW_FILE" 2>/dev/null || echo "0")
+collaborator_case_count=$(grep -cE 'COLLABORATOR\)' "$WORKFLOW_FILE" 2>/dev/null || true)
+[[ "$collaborator_case_count" =~ ^[0-9]+$ ]] || collaborator_case_count=0
 if [[ "$collaborator_case_count" -eq 1 ]]; then
 	print_result "helper does not add bare COLLABORATOR string exemption" 0
 else

--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -4,7 +4,7 @@
 #
 # test-maintainer-gate-trusted-origin-exemption.sh — t2451 regression guard.
 #
-# Structural assertions over `.github/workflows/maintainer-gate.yml`:
+# Structural assertions over `.github/workflows/maintainer-gate-reusable.yml`:
 #
 #   A. The file parses as valid YAML.
 #   B. Job 1 Check 2 includes a HAS_TRUSTED_ORIGIN_LABEL computation
@@ -20,6 +20,8 @@
 #      origin:worker PRs with OWNER/MEMBER author and a trusted issue author
 #      with no non-maintainer comments.
 #   F. REPO_OWNER env var is wired through both Job 1 and Job 3 steps.
+#   G. GH#24546 private-org CONTRIBUTOR fallback uses authenticated
+#      collaborator permission metadata and fails closed.
 #
 # Workflow execution cannot be tested locally — this is a static shape
 # check that prevents accidental regressions to the exemption logic
@@ -51,7 +53,7 @@ print_result() {
 # Resolve the workflow file relative to the test (tests live in .agents/scripts/tests/)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/maintainer-gate.yml"
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/maintainer-gate-reusable.yml"
 
 if [[ ! -f "$WORKFLOW_FILE" ]]; then
 	print_result "workflow file exists" 1 "not found: $WORKFLOW_FILE"
@@ -64,9 +66,9 @@ print_result "workflow file exists" 0
 # Check A: YAML parses
 # -------------------------------------------------------------------
 if python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$WORKFLOW_FILE" 2>/dev/null; then
-	print_result "maintainer-gate.yml parses as valid YAML" 0
+	print_result "maintainer-gate-reusable.yml parses as valid YAML" 0
 else
-	print_result "maintainer-gate.yml parses as valid YAML" 1 "python3 yaml.safe_load failed"
+	print_result "maintainer-gate-reusable.yml parses as valid YAML" 1 "python3 yaml.safe_load failed"
 fi
 
 assert_contains() {
@@ -133,6 +135,33 @@ else
 	print_result "REPO_OWNER env in both Job 1 and Job 3" 1 \
 		"expected >=2 occurrences, found $owner_env_count"
 fi
+
+# -------------------------------------------------------------------
+# Check G: GH#24546 private-org CONTRIBUTOR permission fallback
+# -------------------------------------------------------------------
+assert_contains "PR_AUTHOR:[[:space:]]*\\$\\{\\{[[:space:]]*github\.event\.pull_request\.user\.login" \
+	"Job 1 exposes PR_AUTHOR for permission fallback"
+assert_contains "pr_author_has_maintainer_authority" \
+	"defines shared maintainer-authority helper"
+assert_contains "CONTRIBUTOR\)" \
+	"helper handles ambiguous CONTRIBUTOR webhook association"
+collaborator_case_count=$(grep -cE 'COLLABORATOR\)' "$WORKFLOW_FILE" 2>/dev/null || echo "0")
+if [[ "$collaborator_case_count" -eq 1 ]]; then
+	print_result "helper does not add bare COLLABORATOR string exemption" 0
+else
+	print_result "helper does not add bare COLLABORATOR string exemption" 1 \
+		"expected only the existing label-protection COLLABORATOR case, found $collaborator_case_count"
+fi
+assert_contains "collaborators/.*/permission" \
+	"helper uses authenticated collaborator permission endpoint"
+assert_contains "admin\|maintain\|write" \
+	"helper accepts admin/maintain/write permissions"
+assert_contains "permission fallback failed" \
+	"helper logs and fails closed on permission API failure"
+assert_contains "#aidevops:trust-boundary GH#24546" \
+	"trust-boundary marker documents authenticated fallback"
+assert_contains "authorAssociation,author" \
+	"Job 3 fetches PR author login with author association"
 
 # -------------------------------------------------------------------
 # Summary

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -121,6 +121,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           REPO: ${{ github.repository }}
@@ -162,6 +163,49 @@ jobs:
                 exit 1
               }
             return 0
+          }
+
+          pr_author_has_maintainer_authority() {
+            local author_association="$1"
+            local pr_author="$2"
+            local permission=""
+
+            case "$author_association" in
+              OWNER|MEMBER)
+                return 0
+                ;;
+              CONTRIBUTOR)
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+
+            if [[ -z "$pr_author" ]]; then
+              echo "INFO: PR author unavailable for authenticated permission fallback — treating $author_association as non-maintainer"
+              return 1
+            fi
+
+            #aidevops:trust-boundary GH#24546: webhook author_association can
+            # report CONTRIBUTOR for private org members. Use an authenticated,
+            # metadata-only permission lookup as the fallback and fail closed on
+            # API errors or permissions below write.
+            permission=$(gh api "repos/${REPO}/collaborators/${pr_author}/permission" \
+              --jq '.permission' 2>/dev/null) || {
+              echo "INFO: permission fallback failed for PR author $pr_author — treating $author_association as non-maintainer"
+              return 1
+            }
+
+            case "$permission" in
+              admin|maintain|write)
+                echo "INFO: PR author $pr_author has authenticated repo permission '$permission' despite webhook association $author_association — treating as maintainer-authority"
+                return 0
+                ;;
+              *)
+                echo "INFO: PR author $pr_author permission '$permission' is below maintainer-authority threshold"
+                return 1
+                ;;
+            esac
           }
 
           # ---------------------------------------------------------------
@@ -254,17 +298,16 @@ jobs:
           # flow still hit the full linked-issue gate despite being the exact
           # case the rule was supposed to cover.
           #
-          # Security gate: ONLY passes for OWNER or MEMBER author_association.
-          # COLLABORATOR is excluded — write-access contributors must still go
-          # through the normal gate. A contributor could apply origin:interactive
-          # manually (labels are not protected like origin:worker), so we verify
-          # the PR author is actually a maintainer via GitHub's author_association.
-          # The authorship check is unchanged from the pre-t2030 version — the
-          # only change is which PRs reach it.
+          # Security gate: passes for OWNER/MEMBER author_association, or for
+          # an ambiguous CONTRIBUTOR webhook value only when an authenticated
+          # collaborator permission lookup confirms admin/maintain/write access
+          # (GH#24546 private-org membership fallback). Bare COLLABORATOR is
+          # still excluded from the string-only path: write-access contributors
+          # must not bypass the normal gate unless the authenticated fallback
+          # proves maintainer-authority for this PR author.
           # ---------------------------------------------------------------
           if echo "$PR_LABELS" | grep -q 'origin:interactive'; then
-            if [[ "$PR_AUTHOR_ASSOCIATION" == "OWNER" ]] || \
-               [[ "$PR_AUTHOR_ASSOCIATION" == "MEMBER" ]]; then
+            if pr_author_has_maintainer_authority "$PR_AUTHOR_ASSOCIATION" "$PR_AUTHOR"; then
               echo "PASS: PR #$PR_NUMBER has origin:interactive and author is maintainer ($PR_AUTHOR_ASSOCIATION) — implied approval (t2030: applies to linked-issue PRs too)"
               post_maintainer_gate_status_once \
                 success \
@@ -272,7 +315,7 @@ jobs:
                 2>/dev/null || true
               exit 0
             else
-              echo "SKIP: PR #$PR_NUMBER has origin:interactive but author is $PR_AUTHOR_ASSOCIATION (not OWNER/MEMBER) — continuing normal gate checks"
+              echo "SKIP: PR #$PR_NUMBER has origin:interactive but author is $PR_AUTHOR_ASSOCIATION without maintainer-authority — continuing normal gate checks"
             fi
           fi
 
@@ -342,11 +385,11 @@ jobs:
             fi
 
             # Check 2: no assignee
-            # Exempt when BOTH conditions hold (GH#6623, GH#18197, GH#19956, GH#20195):
-            #   1) PR author is OWNER or MEMBER (maintainer-tier only).
-            #      COLLABORATOR is excluded — write-access contributors must have the
-            #      issue explicitly assigned before their PR passes the gate.
-            #      On personal repos there are no MEMBERs, so effectively OWNER-only.
+            # Exempt when BOTH conditions hold (GH#6623, GH#18197, GH#19956, GH#20195, GH#24546):
+            #   1) PR author has maintainer-authority: OWNER/MEMBER, or an
+            #      ambiguous CONTRIBUTOR webhook value backed by authenticated
+            #      admin/maintain/write collaborator permission. Bare
+            #      COLLABORATOR remains excluded from string-only exemption.
             #   2) AND one of:
             #      a) Issue was created by github-actions[bot] — immutable, cannot be spoofed, OR
             #      b) Issue carries a source:* automation label (non-spoofable — only the
@@ -370,8 +413,7 @@ jobs:
             # worker's behaviour.
             if [[ -z "$ASSIGNEES" ]]; then
               PR_AUTHOR_IS_MAINTAINER=false
-              if [[ "$PR_AUTHOR_ASSOCIATION" == "OWNER" ]] || \
-                 [[ "$PR_AUTHOR_ASSOCIATION" == "MEMBER" ]]; then
+              if pr_author_has_maintainer_authority "$PR_AUTHOR_ASSOCIATION" "$PR_AUTHOR"; then
                 PR_AUTHOR_IS_MAINTAINER=true
               fi
 
@@ -600,6 +642,48 @@ jobs:
             return 0
           }
 
+          pr_author_has_maintainer_authority() {
+            local author_association="$1"
+            local pr_author="$2"
+            local permission=""
+
+            case "$author_association" in
+              OWNER|MEMBER)
+                return 0
+                ;;
+              CONTRIBUTOR)
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+
+            if [[ -z "$pr_author" ]]; then
+              echo "INFO: PR author unavailable for authenticated permission fallback — treating $author_association as non-maintainer"
+              return 1
+            fi
+
+            #aidevops:trust-boundary GH#24546: mirror Job 1's private-org
+            # membership fallback using authenticated metadata only. Fail closed
+            # when the permission endpoint is unavailable or below write.
+            permission=$(gh api "repos/${REPO}/collaborators/${pr_author}/permission" \
+              --jq '.permission' 2>/dev/null) || {
+              echo "INFO: permission fallback failed for PR author $pr_author — treating $author_association as non-maintainer"
+              return 1
+            }
+
+            case "$permission" in
+              admin|maintain|write)
+                echo "INFO: PR author $pr_author has authenticated repo permission '$permission' despite webhook association $author_association — treating as maintainer-authority"
+                return 0
+                ;;
+              *)
+                echo "INFO: PR author $pr_author permission '$permission' is below maintainer-authority threshold"
+                return 1
+                ;;
+            esac
+          }
+
           echo "Issue #$ISSUE_NUMBER updated (labels/assignee) — checking for linked PRs"
 
           # Find open PRs that reference this issue via body closing keywords
@@ -652,18 +736,19 @@ jobs:
             # origin:interactive PRs. For those PRs the gate will always pass,
             # so post success directly and skip the rerun entirely.
             #
-            # Security gate: same as Job 1 — only OWNER or MEMBER. COLLABORATOR
-            # is excluded (write-access contributors must still use the normal gate).
+            # Security gate: same as Job 1 — OWNER/MEMBER, plus the
+            # authenticated private-org CONTRIBUTOR fallback from GH#24546.
+            # Bare COLLABORATOR remains excluded from string-only exemption.
             # -----------------------------------------------------------------
             PR_INFO=$(gh pr view "$PR_NUM" --repo "$REPO" \
-              --json labels,authorAssociation \
-              --jq '{labels: [.labels[].name], assoc: .authorAssociation}' \
+              --json labels,authorAssociation,author \
+              --jq '{labels: [.labels[].name], assoc: .authorAssociation, author: .author.login}' \
               2>/dev/null || true)
             PR_LABELS_J3=$(printf '%s' "$PR_INFO" | jq -r '.labels[]' 2>/dev/null || true)
             PR_AUTHOR_ASSOC_J3=$(printf '%s' "$PR_INFO" | jq -r '.assoc' 2>/dev/null || true)
+            PR_AUTHOR_J3=$(printf '%s' "$PR_INFO" | jq -r '.author // empty' 2>/dev/null || true)
             if printf '%s' "$PR_LABELS_J3" | grep -q 'origin:interactive'; then
-              if [[ "$PR_AUTHOR_ASSOC_J3" == "OWNER" ]] || \
-                 [[ "$PR_AUTHOR_ASSOC_J3" == "MEMBER" ]]; then
+              if pr_author_has_maintainer_authority "$PR_AUTHOR_ASSOC_J3" "$PR_AUTHOR_J3"; then
                 echo "SKIP rerun: PR #$PR_NUM has origin:interactive and author is maintainer ($PR_AUTHOR_ASSOC_J3) — posting success, no Job 1 rerun needed"
                 post_maintainer_gate_status_once \
                   success \
@@ -687,8 +772,7 @@ jobs:
             # gate will definitely pass.
             # -----------------------------------------------------------------
             if printf '%s' "$PR_LABELS_J3" | grep -q 'origin:worker'; then
-              if [[ "$PR_AUTHOR_ASSOC_J3" == "OWNER" ]] || \
-                 [[ "$PR_AUTHOR_ASSOC_J3" == "MEMBER" ]]; then
+              if pr_author_has_maintainer_authority "$PR_AUTHOR_ASSOC_J3" "$PR_AUTHOR_J3"; then
                 ISSUE_DATA_J3=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" \
                   --jq '{author: .user.login}' 2>/dev/null || true)
                 ISSUE_AUTHOR_J3=$(printf '%s' "$ISSUE_DATA_J3" | jq -r '.author // empty' 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- add a shared maintainer-authority predicate for maintainer-gate PR author checks
- keep `OWNER`/`MEMBER` as the string fast path and add an authenticated `CONTRIBUTOR` fallback for private org members
- mirror the predicate in the issue-change rerun job so status refresh behavior matches Job 1
- update the trusted-origin regression test to scan the reusable workflow and cover GH#24546

Resolves #24546

## Verification

```bash
.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
shellcheck .agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/maintainer-gate-reusable.yml'))"
actionlint .github/workflows/maintainer-gate-reusable.yml
git diff --check
```

Note: `.agents/scripts/linters-local.sh` was attempted in the interactive session and timed out after 5 minutes during shell portability; before timeout it showed only advisory/pre-existing repository-wide markdown/ratchet warnings and no changed-file failure.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.34 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 31m and 178,819 tokens on this with the user in an interactive session.