### PR TITLE
GH#24550: fix: harden GitHub cooldown response parsing

### DIFF
--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -110,14 +110,17 @@ _gh_secondary_cooldown_header_value() {
 	local header_name="$2"
 	printf '%s\n' "$response_text" | awk -v name="$header_name" '
 		BEGIN { target = tolower(name) ":" }
-		{ line = $0; sub(/\r$/, "", line); lower = tolower(line); if (index(lower, target) == 1) { sub(/^[^:]*:[[:space:]]*/, "", line); print line; exit } }
+		{ line = $0; sub(/\r$/, "", line); if (line == "") { exit } lower = tolower(line); if (index(lower, target) == 1) { sub(/^[^:]*:[[:space:]]*/, "", line); print line; exit } }
 	' 2>/dev/null
 	return 0
 }
 
 _gh_secondary_cooldown_status() {
 	local response_text="$1"
-	printf '%s\n' "$response_text" | awk '/^HTTP\// { print $2; exit }' | tr -d '\r' 2>/dev/null || printf ''
+	printf '%s\n' "$response_text" | awk '
+		{ line = $0; sub(/\r$/, "", line); if (line == "") { exit } }
+		line ~ /^HTTP\// { split(line, parts, /[[:space:]]+/); print parts[2]; exit }
+	' 2>/dev/null || printf ''
 	return 0
 }
 

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -180,7 +180,13 @@ $(cat "$err_file" 2>/dev/null || true)"
 		return $rc
 	fi
 	err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || err_file=""
-	out_file=$(mktemp -t aidevops-gh-response.XXXXXX) || out_file=""
+	out_file=""
+	if [[ -n "$err_file" ]]; then
+		out_file=$(mktemp -t aidevops-gh-response.XXXXXX) || {
+			rm -f "$err_file"
+			err_file=""
+		}
+	fi
 	if command -v timeout >/dev/null 2>&1; then
 		if [[ -n "$err_file" && -n "$out_file" ]]; then
 			timeout "$secs" "$@" >"$out_file" 2>"$err_file"

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -150,9 +150,53 @@ test_no_jq_fallback_escapes_json_strings() {
 	return 1
 }
 
+test_header_parsers_ignore_response_body() {
+	local response_text=$'HTTP/2 200\r\nX-RateLimit-Remaining: 5\r\n\r\nX-RateLimit-Remaining: 0\nHTTP/2 429'
+	local remaining=""
+	local status=""
+
+	remaining="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-remaining")"
+	status="$(_gh_secondary_cooldown_status "$response_text")"
+	if [[ "$remaining" == "5" && "$status" == "200" ]]; then
+		printf 'PASS header parsers ignore response body lookalikes\n'
+		return 0
+	fi
+	printf 'FAIL header parsers read body lookalikes: status=%s remaining=%s\n' "$status" "$remaining"
+	return 1
+}
+
+test_timeout_temp_cleanup_when_out_mktemp_fails() {
+	reset_case
+	local leaked_file="${TMP_HOME}/leaked.err"
+	_GH_TEST_MKTEMP_CALLS=0
+	mktemp() {
+		local template="${1:-}"
+		: "$template"
+		_GH_TEST_MKTEMP_CALLS=$((_GH_TEST_MKTEMP_CALLS + 1))
+		if [[ "$_GH_TEST_MKTEMP_CALLS" -eq 1 ]]; then
+			: >"$leaked_file"
+			printf '%s\n' "$leaked_file"
+			return 0
+		fi
+		return 1
+	}
+	_gh_with_timeout read gh issue list --repo owner/repo >"${TMP_HOME}/mktemp-fail.out" 2>"$ERR_LOG"
+	local rc=$?
+	unset -f mktemp
+	unset _GH_TEST_MKTEMP_CALLS
+	if [[ "$rc" -eq 0 && ! -e "$leaked_file" ]] && grep -q 'GH issue list --repo owner/repo' "$CALL_LOG"; then
+		printf 'PASS timeout wrapper cleans partial temp file on mktemp failure\n'
+		return 0
+	fi
+	printf 'FAIL timeout wrapper leaked partial temp file or skipped command\n'
+	return 1
+}
+
 test_secondary_response_writes_cooldown
 test_header_response_writes_retry_after_cooldown
 test_active_cooldown_skips_without_gh_call
 test_override_allows_audited_call
 test_default_path_without_home_is_user_scoped
 test_no_jq_fallback_escapes_json_strings
+test_header_parsers_ignore_response_body
+test_timeout_temp_cleanup_when_out_mktemp_fails


### PR DESCRIPTION
## Summary

Restricted GitHub cooldown header/status parsing to HTTP headers before the blank separator, cleaned partially-created temp files when response temp allocation fails, and added regression coverage for body lookalikes plus mktemp cleanup.

## Files Changed

.agents/scripts/shared-gh-secondary-cooldown.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-gh-secondary-cooldown.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-secondary-cooldown.sh .agents/scripts/shared-gh-wrappers.sh .agents/scripts/tests/test-gh-secondary-cooldown.sh; bash .agents/scripts/tests/test-gh-secondary-cooldown.sh; .agents/scripts/linters-local.sh

Resolves #24550


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.34 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 8m and 56,725 tokens on this as a headless worker.