### PR TITLE
GH#24553: fix: preserve README count qualifier

### DIFF
--- a/.agents/scripts/readme-helper.sh
+++ b/.agents/scripts/readme-helper.sh
@@ -234,7 +234,7 @@ update_readme_counts() {
 
 	# Update patterns
 	# ~N main agents or ~N domain agents
-	sed_inplace -E "s/~?[0-9][0-9,]* (main|domain|primary) agents/$main_agents \1 agents/g" "$readme_file"
+	sed_inplace -E "s/(~?)[0-9][0-9,]* (main|domain|primary) agents/\1$main_agents \2 agents/g" "$readme_file"
 
 	# N+ helper scripts
 	sed_inplace -E "s/[0-9][0-9,]*\+ helper scripts/${approx_scripts}+ helper scripts/g" "$readme_file"


### PR DESCRIPTION
## Summary

Preserved the optional tilde qualifier when updating README main/domain/primary agent counts by capturing the qualifier separately from the agent type.

## Files Changed

.agents/scripts/readme-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/readme-helper.sh; sed regex smoke test for '~15 primary agents' and '15 domain agents'; .agents/scripts/linters-local.sh attempted but exceeded 120s after advisory markdown output and ratchet checks

Resolves #24553


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.34 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 5m and 75,878 tokens on this as a headless worker.