### PR TITLE
GH#24554: fix: escape reusable workflow github path regexes

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -235,7 +235,7 @@ _render_template_with_target() {
 	_repo_escaped=$(_escape_sed_replacement "$_repo")
 	_ref_escaped=$(_escape_sed_replacement "${_ref#@}")
 	# Template ships with `marcusquinn/aidevops@main` by default; rewrite both.
-	sed -E 's|(uses:[[:space:]]*)marcusquinn/aidevops(/.github/workflows/[^@]+)@[^[:space:]]+|\1'"$_repo_escaped"'\2@'"$_ref_escaped"'|' "$_template"
+	sed -E 's|(uses:[[:space:]]*)marcusquinn/aidevops(/\.github/workflows/[^@]+)@[^[:space:]]+|\1'"$_repo_escaped"'\2@'"$_ref_escaped"'|' "$_template"
 	return 0
 }
 
@@ -320,7 +320,7 @@ _inject_runner_in_content() {
 	else
 		# No with: block — inject one after the uses: line.
 		printf '%s\n' "$_content" | \
-			sed -E "s|^(    uses:[[:space:]]*[^[:space:]]+/.github/workflows/.+)$|\\1\n    with:\n      runner: ${_runner_escaped}|"
+			sed -E "s|^(    uses:[[:space:]]*[^[:space:]]+/\.github/workflows/.+)$|\\1\n    with:\n      runner: ${_runner_escaped}|"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Escaped literal .github path components in sync-workflows-helper reusable workflow sed expressions so they match the intended path exactly.

## Files Changed

.agents/scripts/sync-workflows-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/sync-workflows-helper.sh && .agents/scripts/tests/test-sync-workflows-helper.sh

Resolves #24554


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.35 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 21,200 tokens on this as a headless worker.