### PR TITLE
GH#24561: suppress resolved review feedback summaries

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -101,8 +101,9 @@ BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 # comments the thread-resolution filter is the canonical signal — every
 # unresolved review thread is by definition a finding worth surfacing.
 ACT_RE="should|consider|fix|change|update|refactor|missing|add"
-# NOOP_RE matches review bodies that are LGTM/no-feedback statements even when
-# they incidentally contain ACT_RE keywords. The canonical false-positive pattern
+# NOOP_RE matches review bodies that are LGTM/no-feedback/already-resolved
+# statements even when they incidentally contain ACT_RE keywords. The canonical
+# false-positive pattern
 # (webapp#2349, Gemini on PR #2308): bot writes a PR description
 # containing "refactors" (matches ACT_RE "refactor"), then concludes with "I have
 # no feedback to provide." — the entire body is a description + LGTM, not an
@@ -118,7 +119,7 @@ ACT_RE="should|consider|fix|change|update|refactor|missing|add"
 # issue creation) over the more frequent false positive (an empty LGTM fires a
 # dispatch cycle). Gemini's deterministic empty-review sentence makes the saving
 # repeatable; losing a genuine finding to an incidental phrase match is rare.
-NOOP_RE="(I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make)|no review comments)"
+NOOP_RE="(I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make)|no review comments|feedback was (already )?(provided|addressed|corrected)|addressed in commit|already (fixed|resolved|addressed)|has been (resolved|addressed|fixed))"
 
 log() { echo "[scanner] $*" >&2; }
 

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -615,6 +615,36 @@ else
 fi
 
 echo ""
+echo "Test: NOOP_RE — already-provided feedback summary is filtered"
+write_graphql_fixture "$FIX_GRAPHQL"
+write_reviews_fixture "$FIX_REVIEWS" \
+	"gemini-code-assist" "This pull request updates the ExampleACL configuration by adding explanatory comments regarding access restrictions. Feedback was provided to correct an inconsistency in one of the new comments, where the text refers to 'proxy-service' instead of 'actual-worker' as defined in the actual ACL rule."
+out=$(fetch_review_summaries_md "stub/repo" "42")
+if [[ -z "$out" ]]; then
+	echo "  PASS: already-provided feedback summary is filtered (empty output)"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: already-provided feedback summary was NOT filtered"
+	echo "    actual (first 200): ${out:0:200}"
+	FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Test: NOOP_RE — already-addressed and resolved feedback summaries are filtered"
+write_graphql_fixture "$FIX_GRAPHQL"
+write_reviews_fixture "$FIX_REVIEWS" \
+	"gemini-code-assist" "The requested updates have been resolved and the feedback was already addressed in commit abc123."
+out=$(fetch_review_summaries_md "stub/repo" "42")
+if [[ -z "$out" ]]; then
+	echo "  PASS: already-addressed feedback summary is filtered (empty output)"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: already-addressed feedback summary was NOT filtered"
+	echo "    actual (first 200): ${out:0:200}"
+	FAIL=$((FAIL + 1))
+fi
+
+echo ""
 echo "Test: NOOP_RE positive control — actionable prose with 'feedback' keyword is preserved"
 # A real review that contains the word "feedback" in actionable prose should
 # NOT be suppressed by NOOP_RE. Only the exact deny-list phrases should match.


### PR DESCRIPTION
## Summary

Extended post-merge review scanner NOOP filtering for already-provided, addressed, corrected, fixed, and resolved feedback summaries so resolved bot reviews do not create auto-dispatch follow-up issues.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh,.agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-post-merge-review-scanner.sh (41 passed, 0 failed); shellcheck .agents/scripts/post-merge-review-scanner.sh .agents/scripts/tests/test-post-merge-review-scanner.sh; .agents/scripts/linters-local.sh reached repository advisory checks and timed during shell portability after no blocking modified-file failures

Resolves #24561


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.35 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 37m and 68,733 tokens on this with the user in an interactive session.