### PR TITLE
GH#24568: feat: adopt ClaudeBar v0.4.66 setup upgrade

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1275,8 +1275,45 @@ setup_minisim() {
 	return 0
 }
 
+setup_claudebar_needs_upgrade() {
+	local installed_version="$1"
+	local target_version="$2"
+	local installed_major="" installed_minor="" installed_patch=""
+	local target_major="" target_minor="" target_patch=""
+
+	installed_version="${installed_version#v}"
+	target_version="${target_version#v}"
+
+	if [[ ! "$installed_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+		return 0
+	fi
+	installed_major="${BASH_REMATCH[1]}"
+	installed_minor="${BASH_REMATCH[2]}"
+	installed_patch="${BASH_REMATCH[3]}"
+
+	if [[ ! "$target_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+		return 0
+	fi
+	target_major="${BASH_REMATCH[1]}"
+	target_minor="${BASH_REMATCH[2]}"
+	target_patch="${BASH_REMATCH[3]}"
+
+	if ((10#$installed_major > 10#$target_major)); then
+		return 1
+	fi
+	if ((10#$installed_major == 10#$target_major && 10#$installed_minor > 10#$target_minor)); then
+		return 1
+	fi
+	if ((10#$installed_major == 10#$target_major && 10#$installed_minor == 10#$target_minor && 10#$installed_patch >= 10#$target_patch)); then
+		return 1
+	fi
+
+	return 0
+}
+
 setup_claudebar() {
 	local claudebar_release_url="https://github.com/tddworks/ClaudeBar/releases/latest"
+	local claudebar_target_version="0.4.66"
 	# Only available on macOS (native Swift menu bar app)
 	if [[ "$(uname)" != "Darwin" ]]; then
 		return 0
@@ -1286,7 +1323,19 @@ setup_claudebar() {
 
 	# Check if ClaudeBar is already installed
 	if [[ -d "/Applications/ClaudeBar.app" ]]; then
+		local claudebar_info_plist="/Applications/ClaudeBar.app/Contents/Info.plist"
+		local installed_version=""
+
+		if [[ -f "$claudebar_info_plist" ]]; then
+			installed_version="$(defaults read "$claudebar_info_plist" CFBundleShortVersionString 2>/dev/null || true)"
+		fi
+
 		print_success "ClaudeBar already installed"
+		if ! setup_claudebar_needs_upgrade "$installed_version" "$claudebar_target_version"; then
+			print_info "ClaudeBar ${installed_version} already includes the v${claudebar_target_version} setup upgrade"
+			return 0
+		fi
+
 		print_info "ClaudeBar v0.4.66 adds live background menu-bar refresh and suppresses its own quota probe events"
 		if command -v brew >/dev/null 2>&1; then
 			local upgrade_claudebar

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1287,6 +1287,23 @@ setup_claudebar() {
 	# Check if ClaudeBar is already installed
 	if [[ -d "/Applications/ClaudeBar.app" ]]; then
 		print_success "ClaudeBar already installed"
+		print_info "ClaudeBar v0.4.66 adds live background menu-bar refresh and suppresses its own quota probe events"
+		if command -v brew >/dev/null 2>&1; then
+			local upgrade_claudebar
+			setup_prompt upgrade_claudebar "Upgrade ClaudeBar via Homebrew cask? [y/N]: " "N"
+			if [[ "$upgrade_claudebar" =~ ^[Yy]$ ]]; then
+				if run_with_spinner "Upgrading ClaudeBar" brew upgrade --cask claudebar; then
+					print_success "ClaudeBar upgraded"
+				else
+					print_warning "Failed to upgrade ClaudeBar via Homebrew"
+					print_info "Manual ClaudeBar download: $claudebar_release_url"
+				fi
+			else
+				print_info "Upgrade later: brew upgrade --cask claudebar"
+			fi
+		else
+			print_info "Update manually: $claudebar_release_url"
+		fi
 		return 0
 	fi
 
@@ -1299,7 +1316,7 @@ setup_claudebar() {
 
 	print_info "ClaudeBar monitors AI coding assistant usage quotas in your menu bar"
 	echo "  Supports: Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, Amp"
-	echo "  Features: live menu-bar refresh, real-time quota tracking, provider process detection, status notifications, multiple themes"
+	echo "  Features: live menu-bar refresh, quota probe suppression, real-time quota tracking, provider process detection, status notifications, multiple themes"
 	echo "  Requires: macOS 15+, CLI tools for providers you want to monitor"
 	echo ""
 

--- a/.agents/scripts/tests/test-tool-install-claudebar.sh
+++ b/.agents/scripts/tests/test-tool-install-claudebar.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOL_INSTALL="$REPO_ROOT/.agents/scripts/setup/modules/tool-install.sh"
+
+SANDBOX="$(mktemp -d -t tool-install-claudebar-XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_rc() {
+	local desc="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		printf '  PASS: %s\n' "$desc"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	printf '  FAIL: %s -- expected rc %s, got %s\n' "$desc" "$expected" "$actual" >&2
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+extract_functions() {
+	awk '
+		/^setup_claudebar_needs_upgrade\(\)/, /^}$/ { print; next }
+	' "$TOOL_INSTALL" >"$SANDBOX/extract.sh"
+	if ! grep -q '^setup_claudebar_needs_upgrade()' "$SANDBOX/extract.sh"; then
+		printf 'FAIL: extraction did not capture setup_claudebar_needs_upgrade\n' >&2
+		exit 1
+	fi
+	return 0
+}
+
+needs_upgrade_rc() {
+	local installed_version="$1"
+	local target_version="$2"
+	local rc=0
+	# shellcheck disable=SC1090
+	source "$SANDBOX/extract.sh"
+	setup_claudebar_needs_upgrade "$installed_version" "$target_version" || rc=$?
+	printf '%s\n' "$rc"
+	return 0
+}
+
+extract_functions
+
+assert_rc "older ClaudeBar prompts for upgrade" "0" "$(needs_upgrade_rc "0.4.65" "0.4.66")"
+assert_rc "matching ClaudeBar suppresses upgrade prompt" "1" "$(needs_upgrade_rc "0.4.66" "0.4.66")"
+assert_rc "newer ClaudeBar suppresses upgrade prompt" "1" "$(needs_upgrade_rc "v0.4.67" "0.4.66")"
+assert_rc "unknown ClaudeBar version keeps conservative prompt" "0" "$(needs_upgrade_rc "" "0.4.66")"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	printf 'FAIL: %s ClaudeBar setup checks failed\n' "$FAIL" >&2
+	exit 1
+fi
+
+printf 'PASS: %s ClaudeBar setup checks passed\n' "$PASS"
+exit 0


### PR DESCRIPTION
## Summary

Reviewed tddworks/ClaudeBar v0.4.66 and adopted the relevant setup change by prompting installed macOS users to upgrade the Homebrew cask, while updating setup messaging for live background menu-bar refresh and quota probe suppression.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/linters-local.sh (completed with ALL LOCAL CHECKS PASSED; pre-existing/advisory debt reported)

Resolves #24568


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.36 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 8m and 66,766 tokens on this as a headless worker.