### PR TITLE
GH#24567: fail closed pulse write guard fallback

### DIFF
--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -63,6 +63,10 @@ fi
 source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
 init_log_file 2>/dev/null || true
 
+# shellcheck source=pulse-repo-meta.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/pulse-repo-meta.sh" 2>/dev/null || true
+
 # t2976 / GH#21699: canonical-guard + audit logger for ephemeral worktree
 # cleanup. Defence-in-depth: even though _dps_rebase_in_ephemeral creates its
 # worktree under /tmp via mktemp (never a canonical path), an
@@ -1109,8 +1113,8 @@ dirty_pr_sweep_all_repos() {
 
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" ]] || continue
-		if declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
-			&& ! repo_allows_pulse_write_actions "$repo_slug"; then
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
 			_dps_log "skipping ${repo_slug}: repo role is contributor/read-only"
 			continue
 		fi

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -297,8 +297,8 @@ merge_ready_prs_all_repos() {
 
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" ]] || continue
-		if declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
-			&& ! repo_allows_pulse_write_actions "$repo_slug"; then
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
 			echo "[pulse-wrapper] Deterministic merge pass skipped ${repo_slug}: repo role is contributor/read-only" >>"$_mr_logfile"
 			continue
 		fi

--- a/.agents/scripts/tests/test-repo-role-guard.sh
+++ b/.agents/scripts/tests/test-repo-role-guard.sh
@@ -143,6 +143,25 @@ else
 fi
 assert_eq "dirty PR sweep checks contributor write-action guard" "yes" "$guard_present"
 
+# Test 12: Dirty PR sweep standalone path loads the repo metadata guard.
+if grep -q "source \"\${SCRIPT_DIR}/pulse-repo-meta.sh\"" "${PARENT_DIR}/pulse-dirty-pr-sweep.sh"; then
+	guard_present="yes"
+else
+	guard_present="no"
+fi
+assert_eq "dirty PR sweep loads repo-role guard for standalone execution" "yes" "$guard_present"
+
+# Test 13: Write sweeps fail closed when the guard helper is unavailable.
+if grep -q '! declare -F repo_allows_pulse_write_actions' "${PARENT_DIR}/pulse-merge-process.sh" \
+	&& grep -q "|| ! repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-merge-process.sh" \
+	&& grep -q '! declare -F repo_allows_pulse_write_actions' "${PARENT_DIR}/pulse-dirty-pr-sweep.sh" \
+	&& grep -q "|| ! repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-dirty-pr-sweep.sh"; then
+	guard_present="yes"
+else
+	guard_present="no"
+fi
+assert_eq "write sweeps fail closed when repo-role guard is unavailable" "yes" "$guard_present"
+
 echo ""
 echo "Results: ${_TESTS_PASSED}/${_TESTS_RUN} passed, ${_TESTS_FAILED} failed"
 


### PR DESCRIPTION
## Summary

- Followed up PR #24569 review by making pulse write sweeps fail closed when `repo_allows_pulse_write_actions` is unavailable.
- Source `pulse-repo-meta.sh` in `pulse-dirty-pr-sweep.sh` for standalone execution.
- Added regression checks covering standalone guard loading and fail-closed guard predicates.

## Verification

- `bash .agents/scripts/tests/test-repo-role-guard.sh`
- `shellcheck .agents/scripts/pulse-repo-meta.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-dirty-pr-sweep.sh .agents/scripts/tests/test-repo-role-guard.sh`
- `.agents/scripts/complexity-regression-helper.sh check --metric file-size --base origin/main --head HEAD`

## Notes

New task allocation was attempted for this post-merge follow-up but blocked by protected counter branch safeguards, so this PR continues against the reopened original issue.

Resolves #24567

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.36 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 17m and 215,924 tokens on this as a headless worker.