### PR TITLE
test: annotate git safety guard helper

### DIFF
--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -18,7 +18,7 @@ spec.loader.exec_module(git_safety_guard)
 class TestCanonicalBranchSwitchDash(unittest.TestCase):
     """Protect canonical checkouts from ``git switch -`` bypasses."""
 
-    def _patch_canonical_repo(self, previous_branch):
+    def _patch_canonical_repo(self, previous_branch: str) -> mock.MagicMock:
         """Patch repository helpers and return the authorization mock."""
         patchers = [
             mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo"),


### PR DESCRIPTION
## Summary
- Salvages the useful part of closed, unmerged PR #24509.
- Adds the missing type annotations to `TestCanonicalBranchSwitchDash._patch_canonical_repo`.
- Avoids the original PR CRLF-driven full-file rewrite; this PR is a one-line semantic change.

## Supersession check
- Current `origin/main` still had `def _patch_canonical_repo(self, previous_branch):` in `tests/test-git-safety-guard.py`.
- No existing PR was found for branch `salvage-pr-24509-type-annotations`.

## Testing
- `python3 -m unittest tests/test-git-safety-guard.py`

MERGE_SUMMARY: Salvaged PR #24509 by applying only the useful `_patch_canonical_repo` type annotation without line-ending churn. Verified with `python3 -m unittest tests/test-git-safety-guard.py`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.37 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 33,834 tokens on this as a headless worker.
