### PR TITLE
GH#24565: hold orphan retries with remote children

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -901,6 +901,7 @@ check_worker_branch_orphan_loop() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local branch_name="$3"
+	local todo_file="${4:-}"
 
 	[[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]] || return 1
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
@@ -912,10 +913,15 @@ check_worker_branch_orphan_loop() {
 	[[ "$window_s" =~ ^[0-9]+$ ]] || window_s=7200
 	[[ "$threshold" -gt 0 && "$window_s" -gt 0 ]] || return 1
 
+	if [[ -n "$todo_file" ]] && check_worker_orphan_remote_children "$issue_number" "$repo_slug" "$todo_file"; then
+		return 0
+	fi
+
 	# Fetch all comment pages. The issue-comments endpoint is oldest-first and may
 	# hold orphan markers beyond the first 30/100 results on noisy issues. Keep the
 	# POST endpoint separate because --paginate --slurp returns page arrays for jq.
-	local comments_post_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	local comments_issue_endpoint="repos/${repo_slug}/issues/${issue_number}"
+	local comments_post_endpoint="${comments_issue_endpoint}/comments"
 	local comments_endpoint="${comments_post_endpoint}?per_page=100"
 	local comments_json
 	comments_json=$(gh api --paginate --slurp "$comments_endpoint" 2>/dev/null) || return 1
@@ -977,6 +983,90 @@ check_worker_branch_orphan_loop() {
 
 	printf 'WORKER_BRANCH_ORPHAN_LOOP_BLOCKED (issue=%s repo=%s branch=%s count=%s threshold=%s window_s=%s latest=%s pr=%s)\n' \
 		"$issue_number" "$repo_slug" "$branch_name" "$count" "$threshold" "$window_s" "${latest_iso:-unknown}" "$pr_hint"
+	return 0
+}
+
+#######################################
+# Hold orphan redispatch when remote child issues exist but local TODO lacks them.
+#
+# This is intentionally conservative: it does not import issue bodies or trust
+# remote relationships. It only detects the dangerous retry state from GH#24565
+# and posts one quarantine diagnostic so maintainers can reconcile or import the
+# canonical child set before a retry allocates replacement task IDs.
+#
+# Args: $1 = parent issue number, $2 = repo slug, $3 = TODO.md path (optional)
+# Returns: exit 0 if remote children require a hold, exit 1 otherwise.
+#######################################
+check_worker_orphan_remote_children() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local todo_file="${3:-TODO.md}"
+
+	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 1
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+
+	local comments_post_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	local comments_endpoint="${comments_post_endpoint}?per_page=100"
+	local comments_json=""
+	comments_json=$(gh api --paginate --slurp "$comments_endpoint" 2>/dev/null) || return 1
+	[[ -n "$comments_json" ]] || return 1
+
+	local orphan_count="0"
+	orphan_count=$(printf '%s' "$comments_json" |
+		jq -r '[.[][] | (.body // empty) | select(contains("WORKER_BRANCH_ORPHAN"))] | length' 2>/dev/null) || orphan_count="0"
+	[[ "$orphan_count" =~ ^[0-9]+$ ]] || orphan_count=0
+	[[ "$orphan_count" -gt 0 ]] || return 1
+
+	local children_json=""
+	children_json=$(gh issue list --repo "$repo_slug" --state open \
+		--search "#${issue_number} in:body" \
+		--json number,title,body,labels --limit 50 2>/dev/null) || return 1
+	[[ -n "$children_json" ]] || return 1
+
+	local candidate_rows=""
+	candidate_rows=$(printf '%s' "$children_json" |
+		jq -r --arg parent "${issue_number}" '
+			.[]
+			| select((.number | tostring) != $parent)
+			| select(((.body // empty) + "\n" + (.title // empty))
+				| test("(#|GH#|issue[[:space:]]+#?)" + $parent + "\\b"; "i"))
+			| [.number, (.title // empty)] | @tsv
+		' 2>/dev/null) || candidate_rows=""
+	[[ -n "$candidate_rows" ]] || return 1
+
+	local missing_count=0
+	local candidate_count=0
+	local missing_lines=""
+	local child_number="" child_title=""
+	while IFS=$'\t' read -r child_number child_title; do
+		[[ "$child_number" =~ ^[0-9]+$ ]] || continue
+		candidate_count=$((candidate_count + 1))
+		if [[ ! -f "$todo_file" ]] || ! grep -qE "ref:GH#${child_number}([^0-9]|$)" "$todo_file" 2>/dev/null; then
+			missing_count=$((missing_count + 1))
+			missing_lines="${missing_lines}- #${child_number}: ${child_title}\n"
+		fi
+	done <<<"$candidate_rows"
+
+	[[ "$candidate_count" -gt 0 && "$missing_count" -gt 0 ]] || return 1
+
+	local existing_block="0"
+	existing_block=$(printf '%s' "$comments_json" |
+		jq -r '[.[][] | (.body // empty) | select(contains("worker-orphan-remote-children:blocked"))] | length' 2>/dev/null) || existing_block="0"
+	[[ "$existing_block" =~ ^[0-9]+$ ]] || existing_block=0
+
+	if [[ "$existing_block" -eq 0 ]]; then
+		local diag=""
+		# shellcheck disable=SC2016 # Backticks are literal Markdown in this printf template.
+		diag=$(printf '<!-- ops:start -->\n<!-- worker-orphan-remote-children:blocked issue=%s missing=%s -->\n## Dispatch held: orphaned remote child issues need reconciliation\n\nThis parent has `WORKER_BRANCH_ORPHAN` telemetry and open child-like issues that reference #%s, but local TODO state does not contain `ref:GH#` entries for every candidate. Auto-dispatch is held to avoid allocating replacement task IDs and creating duplicate children.\n\nMissing local refs detected:\n%s\nNext verification:\n- Run `issue-sync pull` or manually reconcile the canonical child set.\n- Validate blocker relationships before trusting recovered issue bodies.\n- Re-run dispatch only after TODO/brief state exists or the duplicates are closed/quarantined.\n<!-- ops:end -->' \
+			"$issue_number" "$missing_count" "$issue_number" "$missing_lines")
+		gh api "$comments_post_endpoint" \
+			--method POST \
+			--field body="$diag" \
+			>/dev/null 2>&1 || true
+	fi
+
+	printf 'WORKER_BRANCH_ORPHAN_REMOTE_CHILDREN_BLOCKED (issue=%s repo=%s candidates=%s missing_local_refs=%s)\n' \
+		"$issue_number" "$repo_slug" "$candidate_count" "$missing_count"
 	return 0
 }
 
@@ -1909,8 +1999,8 @@ Usage:
                                                        t2007: cost circuit breaker (exit 0=tripped, 1=under budget)
   dispatch-dedup-helper.sh sum-issue-token-spend <issue> <slug>
                                                        t2007: aggregate token spend (returns "spent|attempts")
-  dispatch-dedup-helper.sh check-orphan-loop <issue> <slug> <branch>
-                                                       Hold repeated worker_branch_orphan loops for same branch
+  dispatch-dedup-helper.sh check-orphan-loop <issue> <slug> <branch> [todo-file]
+                                                       Hold repeated worker_branch_orphan loops or unreconciled remote children
   dispatch-dedup-helper.sh has-fix-the-fixer-label <issue> <slug>
                                                        t3077: detect the fix-the-fixer label (exit 0=labeled, 1=unlabeled).
                                                        Used by headless-runtime-helper.sh to enable verbose lifecycle,
@@ -2031,9 +2121,9 @@ main() {
 		has_open_pr "$1" "$2" "${3:-}"
 		;;
 	check-orphan-loop)
-		_require_args check-orphan-loop 3 "$#" "<issue-number> <repo-slug> <branch>" || return 1
-		local _ol_issue="$1" _ol_repo="$2" _ol_branch="$3"
-		check_worker_branch_orphan_loop "$_ol_issue" "$_ol_repo" "$_ol_branch"
+		_require_args check-orphan-loop 3 "$#" "<issue-number> <repo-slug> <branch> [todo-file]" || return 1
+		local _ol_issue="$1" _ol_repo="$2" _ol_branch="$3" _ol_todo="${4:-}"
+		check_worker_branch_orphan_loop "$_ol_issue" "$_ol_repo" "$_ol_branch" "$_ol_todo"
 		;;
 	claim)
 		_require_args claim 2 "$#" "<issue-number> <repo-slug> [runner-login]" || return 1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1474,7 +1474,8 @@ Dispatching worker (deterministic).
 # not inherit an old branch's orphan count.
 #
 # Args: $1 = issue number, $2 = repo slug, $3 = worker worktree branch,
-#       $4 = 1 when the branch was reused, 0 for a freshly-created branch
+#       $4 = 1 when the branch was reused, 0 for a freshly-created branch,
+#       $5 = TODO.md path for remote-child reconciliation (optional)
 # Returns: exit 0 if dispatch should be held, exit 1 if safe to continue
 #######################################
 _dlw_check_worker_branch_orphan_loop() {
@@ -1482,6 +1483,7 @@ _dlw_check_worker_branch_orphan_loop() {
 	local repo_slug="$2"
 	local worker_worktree_branch="$3"
 	local worker_worktree_reused="${4:-0}"
+	local todo_file="${5:-TODO.md}"
 
 	[[ "$worker_worktree_reused" == "1" ]] || return 1
 	[[ -n "$worker_worktree_branch" ]] || return 1
@@ -1490,7 +1492,7 @@ _dlw_check_worker_branch_orphan_loop() {
 	[[ -x "$dedup_helper" ]] || return 1
 
 	local orphan_loop_out=""
-	if orphan_loop_out=$("$dedup_helper" check-orphan-loop "$issue_number" "$repo_slug" "$worker_worktree_branch" 2>/dev/null); then
+	if orphan_loop_out=$("$dedup_helper" check-orphan-loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$todo_file" 2>/dev/null); then
 		echo "[dispatch_with_dedup] Dispatch held for #${issue_number} in ${repo_slug}: ${orphan_loop_out}" >>"$LOGFILE"
 		return 0
 	fi
@@ -1790,7 +1792,7 @@ _dispatch_launch_worker() {
 	local worker_worktree_path="$_DLW_WORKTREE_PATH"
 	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
 	local worker_worktree_reused="${_DLW_WORKTREE_REUSED:-0}"
-	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused"; then
+	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused" "${repo_path}/TODO.md"; then
 		return 2
 	fi
 

--- a/.agents/scripts/tests/test-orphan-remote-children-hold.sh
+++ b/.agents/scripts/tests/test-orphan-remote-children-hold.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-orphan-remote-children-hold.sh — GH#24565 regression guard.
+#
+# Verifies that worker_branch_orphan redispatch is held when remote child issues
+# reference a parent but local TODO.md lacks their ref:GH# state. This prevents a
+# retry from allocating replacement task IDs and creating duplicate children.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../dispatch-dedup-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/posts"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	create_gh_stub
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+create_gh_stub() {
+	cat >"${TEST_ROOT}/comments-orphan.json" <<'EOF'
+[
+  [
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=2026-06-08T20:00:00Z\n<!-- ops:end -->"}
+  ]
+]
+EOF
+
+	cat >"${TEST_ROOT}/comments-clean.json" <<'EOF'
+[
+  [
+    {"body":"ordinary maintainer note"}
+  ]
+]
+EOF
+
+	cat >"${TEST_ROOT}/children.json" <<'EOF'
+[
+  {"number":501,"title":"t501: plan audit child","body":"For #100 — recover canonical plan-audit child","labels":[]},
+  {"number":502,"title":"t502: implementation child","body":"Parent issue #100; blocked-by:t501","labels":[]}
+]
+EOF
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "api" ]]; then
+	issue=""
+	for arg in "$@"; do
+		if [[ "$arg" =~ /issues/([0-9]+)/comments ]]; then
+			issue="${BASH_REMATCH[1]}"
+			break
+		fi
+	done
+	[[ -n "$issue" ]] || exit 1
+	if [[ " $* " == *" --method POST "* ]]; then
+		printf '%s\n' "$*" >>"${TEST_ROOT}/posts/${issue}.argv"
+		exit 0
+	fi
+	if [[ "${ORPHAN_REMOTE_CHILDREN_COMMENTS:-orphan}" == "clean" ]]; then
+		cat "${TEST_ROOT}/comments-clean.json"
+	else
+		cat "${TEST_ROOT}/comments-orphan.json"
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	cat "${TEST_ROOT}/children.json"
+	exit 0
+fi
+
+printf 'unsupported gh invocation in orphan-remote-children stub: %s\n' "$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+test_remote_children_without_local_refs_blocks() {
+	local todo_file="${TEST_ROOT}/TODO-empty.md"
+	local output=""
+	: >"$todo_file"
+	rm -f "${TEST_ROOT}/posts/100.argv"
+
+	if output=$(TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/reused "$todo_file" 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_REMOTE_CHILDREN_BLOCKED"* && -f "${TEST_ROOT}/posts/100.argv" ]]; then
+			print_result "remote children missing local refs block redispatch" 0
+			return 0
+		fi
+		print_result "remote children missing local refs block redispatch" 1 "unexpected output or missing post: ${output}"
+		return 0
+	fi
+	print_result "remote children missing local refs block redispatch" 1 "expected dispatch hold"
+	return 0
+}
+
+test_remote_children_with_local_refs_do_not_block() {
+	local todo_file="${TEST_ROOT}/TODO-synced.md"
+	printf '%s\n' '- [ ] t501 plan audit ref:GH#501 logged:2026-06-08' '- [ ] t502 implementation ref:GH#502 logged:2026-06-08' >"$todo_file"
+	rm -f "${TEST_ROOT}/posts/100.argv"
+
+	if TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/reused "$todo_file" >/dev/null 2>&1; then
+		print_result "remote children with local refs stay dispatchable" 1 "unexpected hold"
+		return 0
+	fi
+	if [[ ! -f "${TEST_ROOT}/posts/100.argv" ]]; then
+		print_result "remote children with local refs stay dispatchable" 0
+		return 0
+	fi
+	print_result "remote children with local refs stay dispatchable" 1 "unexpected diagnostic post"
+	return 0
+}
+
+test_no_orphan_telemetry_does_not_block() {
+	local todo_file="${TEST_ROOT}/TODO-no-orphan.md"
+	: >"$todo_file"
+	rm -f "${TEST_ROOT}/posts/100.argv"
+
+	if ORPHAN_REMOTE_CHILDREN_COMMENTS=clean TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/reused "$todo_file" >/dev/null 2>&1; then
+		print_result "remote children without orphan telemetry stay dispatchable" 1 "unexpected hold"
+		return 0
+	fi
+	print_result "remote children without orphan telemetry stay dispatchable" 0
+	return 0
+}
+
+main() {
+	setup_test_env
+	test_remote_children_without_local_refs_blocks
+	test_remote_children_with_local_refs_do_not_block
+	test_no_orphan_telemetry_does_not_block
+	teardown_test_env
+
+	printf '\nTests run: %d\n' "$TESTS_RUN"
+	printf 'Failures: %d\n' "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a conservative orphan redispatch hold that detects open remote child issues referencing the parent while local TODO.md lacks their ref:GH# rows, then posts an idempotent quarantine diagnostic instead of allowing replacement child allocation.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-orphan-remote-children-hold.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-orphan-remote-children-hold.sh; bash .agents/scripts/tests/test-worker-branch-orphan-loop.sh; bash .agents/scripts/tests/test-precreation-failure-skip.sh; shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-orphan-remote-children-hold.sh; .agents/scripts/linters-local.sh

Resolves #24565


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.37 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2h 20m and 167,818 tokens on this with the user in an interactive session.