### PR TITLE
GH#24576: fix: fall back on blockedBy lookup failure

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -647,8 +647,8 @@ query($owner:String!,$name:String!,$number:Int!) {
 		-F owner="$owner" -F name="$repo_name" -F number="$issue_number" \
 		--jq '.data.repository.issue.blockedBy.nodes[]? | "\(.number):\(.state)"' \
 		2>/dev/null); then
-		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup failed — skipping dispatch (GH#23932)" >>"$LOGFILE"
-		return 0
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup failed — falling back to body markers (GH#24576)" >>"$LOGFILE"
+		return 1
 	fi
 
 	local rel_state="" rel_num="" state="" saw_relationship="false"

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -215,14 +215,27 @@ test_native_relationship_open_blocks_duplicate_text_marker() {
 	return 0
 }
 
-test_native_relationship_lookup_failure_fails_closed() {
+test_native_relationship_lookup_failure_falls_back_to_empty_body() {
 	printf '\n=== native blockedBy lookup failure ===\n'
 	_setup_blocked_by_resolution_test
 	TEST_GH_RELATIONSHIP_MODE="fail"
 
 	local rc=0
 	is_blocked_by_unresolved '' 'owner/repo' '2000' || rc=$?
-	_assert_rc "native blockedBy lookup failure blocks as unknown" 0 "$rc"
+	_assert_rc "native blockedBy lookup failure allows empty body fallback" 1 "$rc"
+	_cleanup_blocked_by_resolution_test
+	return 0
+}
+
+test_native_relationship_lookup_failure_checks_body_markers() {
+	printf '\n=== native blockedBy lookup failure with body marker ===\n'
+	_setup_blocked_by_resolution_test
+	TEST_GH_RELATIONSHIP_MODE="fail"
+	TEST_GH_ISSUE_LIST_MODE="open"
+
+	local rc=0
+	is_blocked_by_unresolved 'blocked-by:t1000' 'owner/repo' '2000' || rc=$?
+	_assert_rc "native blockedBy lookup failure still checks body markers" 0 "$rc"
 	_cleanup_blocked_by_resolution_test
 	return 0
 }
@@ -423,7 +436,8 @@ main() {
 	test_native_relationship_clear_allows_empty_body
 	test_native_relationship_clear_ignores_duplicate_text_marker
 	test_native_relationship_open_blocks_duplicate_text_marker
-	test_native_relationship_lookup_failure_fails_closed
+	test_native_relationship_lookup_failure_falls_back_to_empty_body
+	test_native_relationship_lookup_failure_checks_body_markers
 	test_unknown_task_blocker_fails_closed
 	test_live_task_lookup_failure_fails_closed
 	test_closed_task_blocker_is_clear


### PR DESCRIPTION
## Summary

Changed native blockedBy GraphQL lookup failures to fall through to body-marker fallback instead of treating every candidate as blocked. Added regressions for empty-body fallback and body-marker enforcement after native lookup failure.

## Files Changed

.agents/scripts/pulse-dep-graph.sh,.agents/tests/test-pulse-dep-graph-blocked-by.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-dep-graph-blocked-by.sh; shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh

Resolves #24576


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.38 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 28,189 tokens on this as a headless worker.