### PR TITLE
GH#24576: preserve native blockedBy fail-closed fallback

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -617,6 +617,8 @@ _blocked_by_extract_nums() {
 #   0 - native relationship is open/unknown (caller should block dispatch)
 #   1 - no native relationships were found (caller should check text fallback)
 #   2 - native relationships exist and are positively clear
+#   3 - native relationship lookup unavailable (caller should check text
+#       fallback, then fail closed if no fallback marker can prove intent)
 #######################################
 _blocked_by_check_native_relationships() {
 	local repo_slug="$1"
@@ -647,8 +649,8 @@ query($owner:String!,$name:String!,$number:Int!) {
 		-F owner="$owner" -F name="$repo_name" -F number="$issue_number" \
 		--jq '.data.repository.issue.blockedBy.nodes[]? | "\(.number):\(.state)"' \
 		2>/dev/null); then
-		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup failed — falling back to body markers (GH#24576)" >>"$LOGFILE"
-		return 1
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable — checking body fallback (GH#24576)" >>"$LOGFILE"
+		return 3
 	fi
 
 	local rel_state="" rel_num="" state="" saw_relationship="false"
@@ -914,14 +916,24 @@ is_blocked_by_unresolved() {
 	# re-blocked by stale duplicate text markers.
 	local native_rc=0
 	_blocked_by_check_native_relationships "$repo_slug" "$issue_number" || native_rc=$?
+	local native_lookup_unavailable="false"
 	if [[ "$native_rc" -eq 0 ]]; then
 		return 0
 	fi
 	if [[ "$native_rc" -eq 2 ]]; then
 		return 1
 	fi
+	if [[ "$native_rc" -eq 3 ]]; then
+		native_lookup_unavailable="true"
+	fi
 
-	[[ -n "$issue_body" ]] || return 1
+	if [[ -z "$issue_body" ]]; then
+		if [[ "$native_lookup_unavailable" == "true" ]]; then
+			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable and issue body is empty — skipping dispatch (GH#24576)" >>"$LOGFILE"
+			return 0
+		fi
+		return 1
+	fi
 
 	# Extract blocked-by references (tNNN and #NNN) via two single-return
 	# helpers. GH#18830: the previous NUL-delimited two-value return was
@@ -932,6 +944,10 @@ is_blocked_by_unresolved() {
 
 	# No blocked-by references → not blocked
 	if [[ -z "$blocker_task_ids" && -z "$blocker_issue_nums" ]]; then
+		if [[ "$native_lookup_unavailable" == "true" ]]; then
+			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable and no body blocked-by markers found — skipping dispatch (GH#24576)" >>"$LOGFILE"
+			return 0
+		fi
 		return 1
 	fi
 

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -215,14 +215,19 @@ test_native_relationship_open_blocks_duplicate_text_marker() {
 	return 0
 }
 
-test_native_relationship_lookup_failure_falls_back_to_empty_body() {
+test_native_relationship_lookup_failure_fails_closed_empty_body() {
 	printf '\n=== native blockedBy lookup failure ===\n'
 	_setup_blocked_by_resolution_test
 	TEST_GH_RELATIONSHIP_MODE="fail"
 
 	local rc=0
 	is_blocked_by_unresolved '' 'owner/repo' '2000' || rc=$?
-	_assert_rc "native blockedBy lookup failure allows empty body fallback" 1 "$rc"
+	_assert_rc "native blockedBy lookup failure with empty body fails closed" 0 "$rc"
+	if grep -q 'native blockedBy lookup unavailable and issue body is empty' "$LOGFILE"; then
+		_pass "native lookup failure empty-body log is distinct"
+	else
+		_fail "native lookup failure empty-body log is distinct" "missing native-unavailable empty-body log"
+	fi
 	_cleanup_blocked_by_resolution_test
 	return 0
 }
@@ -436,7 +441,7 @@ main() {
 	test_native_relationship_clear_allows_empty_body
 	test_native_relationship_clear_ignores_duplicate_text_marker
 	test_native_relationship_open_blocks_duplicate_text_marker
-	test_native_relationship_lookup_failure_falls_back_to_empty_body
+	test_native_relationship_lookup_failure_fails_closed_empty_body
 	test_native_relationship_lookup_failure_checks_body_markers
 	test_unknown_task_blocker_fails_closed
 	test_live_task_lookup_failure_fails_closed


### PR DESCRIPTION
## Summary

- Adds a distinct native `blockedBy` lookup-unavailable state instead of treating GraphQL failure as either confirmed blocked or confirmed clear.
- Allows existing body-marker fallback to run when native lookup is unavailable.
- Fails closed when native lookup is unavailable and no body fallback marker can prove dependency intent, preserving UI-only native blocker safety.

Ref #24576

## Testing

- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh`
- `bash .agents/scripts/tests/test-pulse-dep-graph-parse.sh`
- `bash .agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh`
- `bash .agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

self-assessed: shell dispatch dependency gate with mocked GitHub CLI states; no live pulse dispatch run required for this low-risk shell logic correction.

## Key Decisions

- Do not use the prior one-line `return 1` behavior for lookup failures because that weakens UI-only native blockers.
- Preserve GH#23932/GH#23952 semantics: native open/unknown blocks, native closed bypasses stale body text, and unavailable native state only delegates to body fallback before failing closed if body has no markers.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.39 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 35m and 127,767 tokens on this with the user in an interactive session.
