### PR TITLE
GH#24582: test: enforce PR metadata freshness classes

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -488,7 +488,7 @@ _resolve_pr_mergeable_status() {
 		[[ -z "$original_mergeable" ]] && _was_label="empty"
 		# Separate local declaration from assignment to preserve exit code (SC2181).
 		local _retry_output _retry_exit
-		_retry_output=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+		_retry_output=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json mergeable --jq '.mergeable // ""')
 		_retry_exit=$?
 		[[ $_retry_exit -eq 0 && -n "$_retry_output" ]] && pr_mergeable="$_retry_output" || pr_mergeable="UNKNOWN"
@@ -1421,7 +1421,7 @@ _set_native_auto_merge_or_skip() {
 	# Fetch auto_merge metadata + merge state in one call so the stuck-state
 	# check (t3192) does not require an extra round trip.
 	local _pr_state
-	_pr_state=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+	_pr_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json autoMergeRequest,mergeStateStatus,mergeable,reviewDecision 2>/dev/null)
 
 	local _existing_auto=""

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -67,10 +67,8 @@ _GH_REST_PR_VIEW_CACHE_DIR=""
 
 #######################################
 # Return 0 when REST PR view responses may be reused within this shell.
-# The cache is intentionally process-scoped: pulse stages that source the shared
-# wrappers reuse duplicate REST reads during one cycle, while later cycles start
-# with fresh state. Callers can bypass before mutation-sensitive reads with
-# AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1.
+# Process-scoped: later pulse cycles start fresh. Mutation-sensitive callers
+# MUST bypass with AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1.
 # Returns: 0 when enabled, 1 otherwise.
 #######################################
 _rest_pr_view_cache_enabled() {
@@ -368,6 +366,9 @@ _rest_pr_list_can_preserve_args() {
 
 #######################################
 # Return 0 when gh pr view argv is safe to translate to REST proactively.
+# Field classes: stable-within-cycle REST fields may use repo#PR cache; volatile
+# fields like mergeable need caller refetch after mutation; GraphQL-only fields
+# below never use REST projection.
 # Args: gh-style argv
 #######################################
 _rest_pr_view_can_preserve_args() {
@@ -377,7 +378,7 @@ _rest_pr_view_can_preserve_args() {
 	local field
 	while IFS= read -r field; do
 		case "$field" in
-		statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files) return 1 ;;
+		statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files|reviewDecision|autoMergeRequest|mergeStateStatus) return 1 ;;
 		*) ;;
 		esac
 	done < <(_rest_split_csv "$fields")

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -173,6 +173,12 @@ _gh_pr_list_snapshot_put() {
 # Return 0 when gh_pr_view exact-output caching is enabled. This cache is scoped
 # to pulse cycles (or explicit callers) through AIDEVOPS_GH_PR_VIEW_CACHE and is
 # keyed by the full argv, so different field sets never share projected output.
+# It is intentionally separate from the repo#PR REST-object cache in
+# shared-gh-wrappers-rest-fallback.sh: exact-output hits preserve one argv shape,
+# while REST-object reuse projects supported fields from one REST response.
+# Mutation-sensitive merge gates must set AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1
+# before reading mergeable/reviewDecision/check state after update-branch, label,
+# review, or merge-state mutations.
 #######################################
 _gh_pr_view_snapshot_enabled() {
 	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE:-0}" == "1" ]] || return 1

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -62,7 +62,9 @@
 #      rate-limit probe while leaving GraphQL-only PR list fields on GraphQL
 #  33. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate REST PR view reads
 #  34. AIDEVOPS_GH_PR_VIEW_CACHE coalesces duplicate GraphQL-only PR view reads
-#  35. _rest_split_csv suppresses Broken pipe noise when consumers close early
+#  35. PR metadata freshness classes keep GraphQL-only PR view fields off REST
+#  36. AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE bypasses both PR view cache layers
+#  37. _rest_split_csv suppresses Broken pipe noise when consumers close early
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -1154,6 +1156,56 @@ else
 	fail "gh_pr_view exact-output cache coalesces identical GraphQL-only PR reads" \
 		"pr_view_calls=${pr_view_calls} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
+unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIEW_CACHE_TTL
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+unsupported_pr_view_fields=(statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
+unsupported_preserve_ok=1
+for field in "${unsupported_pr_view_fields[@]}"; do
+	if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json "$field"; then
+		unsupported_preserve_ok=0
+	fi
+	gh_pr_view 123 --repo "owner/repo" --json "$field" >/dev/null 2>&1 || true
+done
+
+unsupported_rest_calls=$(grep -cE '^api /repos/owner/repo/pulls/123$' "$GH_CALLS" 2>/dev/null || true)
+unsupported_graphql_calls=$(grep -cE '^pr view 123 --repo owner/repo --json ' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$unsupported_preserve_ok" == "1" && "$unsupported_rest_calls" == "0" && "$unsupported_graphql_calls" == "${#unsupported_pr_view_fields[@]}" ]]; then
+	pass "gh_pr_view freshness classes keep GraphQL-only fields off REST reuse"
+else
+	fail "gh_pr_view freshness classes keep GraphQL-only fields off REST reuse" \
+		"preserve_ok=${unsupported_preserve_ok} rest_calls=${unsupported_rest_calls} graphql_calls=${unsupported_graphql_calls} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+if grep -q 'stable-within-cycle' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null &&
+	grep -q 'fields like mergeable' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null &&
+	grep -q 'GraphQL-only fields' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null; then
+	pass "gh_pr_view freshness classes document stable, volatile, and GraphQL-only fields"
+else
+	fail "gh_pr_view freshness classes document stable, volatile, and GraphQL-only fields" \
+		"missing freshness class comments in shared-gh-wrappers-rest-fallback.sh"
+fi
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export AIDEVOPS_GH_PR_VIEW_CACHE=1
+export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="$TMP/pr-view-disable-cache"
+export AIDEVOPS_GH_PR_VIEW_CACHE_TTL=30
+rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"
+export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"stale title"}'
+pr_view_stale_title=$(gh_pr_view 123 --repo "owner/repo" --json title --jq '.title' 2>/dev/null || true)
+export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"fresh title"}'
+pr_view_fresh_title=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view 123 --repo "owner/repo" --json title --jq '.title' 2>/dev/null || true)
+pr_view_disable_calls=$(grep -cE '^api /repos/owner/repo/pulls/123( |$)' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$pr_view_stale_title" == "stale title" && "$pr_view_fresh_title" == "fresh title" && "$pr_view_disable_calls" == "2" ]]; then
+	pass "AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE bypasses exact-output and REST-object PR view caches"
+else
+	fail "AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE bypasses exact-output and REST-object PR view caches" \
+		"stale=${pr_view_stale_title} fresh=${pr_view_fresh_title} calls=${pr_view_disable_calls} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_PR_VIEW_FIXTURE
 unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIEW_CACHE_TTL
 
 unset AIDEVOPS_GH_REST_FIRST_READS


### PR DESCRIPTION
## Summary

Documented PR metadata freshness classes for REST vs exact gh_pr_view caches, kept GraphQL-only PR fields out of REST projection, and forced mutation-sensitive pulse merge reads to bypass PR view caches.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh (57/57 passed); .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED; advisory markdown/complexity output pre-existing)

Resolves #24582


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.39 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 15m and 206,073 tokens on this as a headless worker.