### PR TITLE
GH#24591: fix: record core routine run metrics

### DIFF
--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -104,6 +104,8 @@ _routine_execute() {
 
 	local agents_dir="${HOME}/.aidevops/agents"
 	local status="success"
+	local started_epoch
+	started_epoch=$(date +%s)
 
 	if [[ -n "$run_script" ]]; then
 		# Script-only dispatch — zero LLM tokens.
@@ -118,6 +120,12 @@ _routine_execute() {
 		if [[ ! -x "$script_path" ]]; then
 			echo "[pulse-wrapper] routine ${routine_id}: script not found or not executable: ${script_path}" >>"$LOGFILE"
 			_routine_update_state "$routine_id" "failure"
+			if [[ -x "$ROUTINE_LOG_HELPER" ]]; then
+				local ended_epoch
+				ended_epoch=$(date +%s)
+				local duration=$((ended_epoch - started_epoch))
+				"$ROUTINE_LOG_HELPER" update "$routine_id" --status failure --duration "$duration" 2>/dev/null || true
+			fi
 			return 1
 		fi
 		if [[ ${#script_args[@]} -gt 0 ]]; then
@@ -171,7 +179,10 @@ _routine_execute() {
 
 	# Call routine-log-helper.sh if available (t1926)
 	if [[ -x "$ROUTINE_LOG_HELPER" ]]; then
-		"$ROUTINE_LOG_HELPER" update "$routine_id" "$status" 2>/dev/null || true
+		local ended_epoch
+		ended_epoch=$(date +%s)
+		local duration=$((ended_epoch - started_epoch))
+		"$ROUTINE_LOG_HELPER" update "$routine_id" --status "$status" --duration "$duration" 2>/dev/null || true
 	fi
 
 	return 0

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -507,12 +507,27 @@ _run_profile_readme_init() {
 	return 0
 }
 
+_core_routine_logged_command() {
+	local routine_id="$1"
+	local exec_command="$2"
+	local log_helper="\$HOME/.aidevops/agents/scripts/routine-log-helper.sh"
+	# shellcheck disable=SC2016 # command string is expanded by the generated scheduler shell.
+	printf 'start_epoch=$(date +%%s); status=success; %s; rc=$?; end_epoch=$(date +%%s); duration=$((end_epoch - start_epoch)); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "%s" ]; then "%s" update "%s" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"' \
+		"$exec_command" \
+		"$log_helper" \
+		"$log_helper" \
+		"$routine_id"
+	return 0
+}
+
 _install_profile_readme_launchd() {
 	local pr_label="$1"
 	local pr_script="$2"
 	local pr_plist="$HOME/Library/LaunchAgents/${pr_label}.plist"
 	local _xml_pr_script _xml_pr_home
-	_xml_pr_script=$(_xml_escape "$pr_script")
+	local pr_command
+	pr_command=$(_core_routine_logged_command "r908" "\"${pr_script}\" update")
+	_xml_pr_script=$(_xml_escape "$pr_command")
 	_xml_pr_home=$(_xml_escape "$HOME")
 
 	local pr_plist_content
@@ -527,8 +542,8 @@ _install_profile_readme_launchd() {
 	<key>ProgramArguments</key>
 	<array>
 		<string>$(_xml_escape "$(_resolve_modern_bash)")</string>
+		<string>-lc</string>
 		<string>${_xml_pr_script}</string>
-		<string>update</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>3600</integer>
@@ -591,7 +606,7 @@ _install_profile_readme_scheduler() {
 		"$pr_systemd" \
 		"aidevops: profile-readme-update" \
 		"$CRON_HOURLY" \
-		"\"${pr_script}\" update" \
+		"$(_core_routine_logged_command "r908" "\"${pr_script}\" update")" \
 		"3600" \
 		"$pr_log" \
 		"" \

--- a/.agents/scripts/setup/modules/schedulers.sh
+++ b/.agents/scripts/setup/modules/schedulers.sh
@@ -495,7 +495,9 @@ setup_screen_time_snapshot() {
 
 		# XML-escape paths for safe plist embedding
 		local _xml_st_script _xml_st_home
-		_xml_st_script=$(_xml_escape "$st_script")
+		local st_command
+		st_command=$(_core_routine_logged_command "r909" "\"${st_script}\" snapshot")
+		_xml_st_script=$(_xml_escape "$st_command")
 		_xml_st_home=$(_xml_escape "$HOME")
 
 		local st_plist_content
@@ -510,8 +512,8 @@ setup_screen_time_snapshot() {
 	<key>ProgramArguments</key>
 	<array>
 		<string>$(_xml_escape "$(_resolve_modern_bash)")</string>
+		<string>-lc</string>
 		<string>${_xml_st_script}</string>
-		<string>snapshot</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>21600</integer>
@@ -552,7 +554,7 @@ ST_PLIST
 			"$st_systemd" \
 			"aidevops: screen-time-snapshot" \
 			"0 */6 * * *" \
-			"\"${st_script}\" snapshot" \
+			"$(_core_routine_logged_command "r909" "\"${st_script}\" snapshot")" \
 			"21600" \
 			"$st_log" \
 			"" \

--- a/.agents/scripts/tests/test-launchd-install-if-changed.sh
+++ b/.agents/scripts/tests/test-launchd-install-if-changed.sh
@@ -796,7 +796,7 @@ test_profile_readme_install_does_not_kickstart() {
 	local install_count=0
 	local kickstart_count=0
 	local expected_plist_content
-	expected_plist_content=$(cat <<PROFILE_PLIST
+	expected_plist_content=$(cat <<'PROFILE_PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -806,21 +806,21 @@ test_profile_readme_install_does_not_kickstart() {
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>/fake/profile-readme-helper.sh</string>
-		<string>update</string>
+		<string>-lc</string>
+		<string>start_epoch=$(date +%s); status=success; "/fake/profile-readme-helper.sh" update; rc=$?; end_epoch=$(date +%s); duration=$((end_epoch - start_epoch)); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" ]; then "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" update "r908" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>3600</integer>
 	<key>StandardOutPath</key>
-	<string>${fake_home}/.aidevops/.agent-workspace/logs/profile-readme-update.log</string>
+	<string>__FAKE_HOME__/.aidevops/.agent-workspace/logs/profile-readme-update.log</string>
 	<key>StandardErrorPath</key>
-	<string>${fake_home}/.aidevops/.agent-workspace/logs/profile-readme-update.log</string>
+	<string>__FAKE_HOME__/.aidevops/.agent-workspace/logs/profile-readme-update.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
 		<string>/usr/bin:/bin</string>
 		<key>HOME</key>
-		<string>${fake_home}</string>
+		<string>__FAKE_HOME__</string>
 	</dict>
 	<key>RunAtLoad</key>
 	<false/>
@@ -836,6 +836,7 @@ test_profile_readme_install_does_not_kickstart() {
 </plist>
 PROFILE_PLIST
 )
+	expected_plist_content=${expected_plist_content//__FAKE_HOME__/$fake_home}
 	printf '%s\n' "$expected_plist_content" >"$plist_path"
 
 	_launchd_has_agent() { return 0; }

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+SCHEDULERS_PLATFORM_SH="$REPO_ROOT/.agents/scripts/setup/modules/schedulers-platform.sh"
+SCHEDULERS_SH="$REPO_ROOT/.agents/scripts/setup/modules/schedulers.sh"
+PULSE_ROUTINES_SH="$REPO_ROOT/.agents/scripts/pulse-routines.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		[[ -z "$message" ]] || printf '  %s\n' "$message"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+load_scheduler_helpers() {
+	print_info() { return 0; }
+	print_warning() { return 0; }
+	print_error() { return 0; }
+	_resolve_log_dir() { printf '%s\n' "$TEST_DIR/logs"; return 0; }
+	_install_scheduler_linux() { return 0; }
+	_uninstall_scheduler() { return 0; }
+	_resolve_modern_bash() { printf '%s\n' "/bin/bash"; return 0; }
+	_xml_escape() { local value="$1"; printf '%s' "$value"; return 0; }
+	aidevops_launchd_sanitized_path() { printf '%s\n' "/usr/bin:/bin"; return 0; }
+	_launchd_install_if_changed() { return 0; }
+	_launchd_has_agent() { return 1; }
+	# shellcheck source=/dev/null
+	source "$SCHEDULERS_PLATFORM_SH"
+	return 0
+}
+
+test_core_routine_logged_command_shape() {
+	local command_text
+	command_text=$(_core_routine_logged_command "r908" '"/tmp/profile-readme-helper.sh" update')
+	if [[ "$command_text" != *'"/tmp/profile-readme-helper.sh" update'* ]]; then
+		print_result "core routine logged command keeps original command" 1 "$command_text"
+		return 0
+	fi
+	# shellcheck disable=SC2016 # the generated command must defer variable expansion to runtime.
+	if [[ "$command_text" != *'routine-log-helper.sh" update "r908" --status "$status" --duration "$duration"'* ]]; then
+		print_result "core routine logged command records status and duration" 1 "$command_text"
+		return 0
+	fi
+	# shellcheck disable=SC2016 # the generated command must defer variable expansion to runtime.
+	if [[ "$command_text" != *'exit "$rc"'* ]]; then
+		print_result "core routine logged command preserves script exit" 1 "$command_text"
+		return 0
+	fi
+	print_result "core routine logged command records metrics and preserves exit" 0
+	return 0
+}
+
+test_linux_core_scheduler_commands_are_logged() {
+	local fake_home="$TEST_DIR/scheduler-home"
+	mkdir -p "$fake_home/.aidevops/agents/scripts" "$fake_home/.aidevops/.agent-workspace/logs"
+	local profile_script="$fake_home/.aidevops/agents/scripts/profile-readme-helper.sh"
+	local screen_script="$fake_home/.aidevops/agents/scripts/screen-time-helper.sh"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$profile_script"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$screen_script"
+	chmod +x "$profile_script" "$screen_script"
+
+	# shellcheck source=/dev/null
+	source "$SCHEDULERS_SH"
+	uname() { printf 'Linux\n'; return 0; }
+	_SCHEDULER_CAPTURED_COMMAND=""
+	_install_scheduler_linux() {
+		local service_name="$1"
+		local cron_tag="$2"
+		local cron_schedule="$3"
+		local exec_command="$4"
+		local interval_sec="$5"
+		local log_file="$6"
+		local env_vars="$7"
+		local success_message="$8"
+		local failure_message="$9"
+		local run_at_load="${10}"
+		local low_priority="${11}"
+		: "$service_name" "$cron_tag" "$cron_schedule" "$interval_sec" "$log_file" "$env_vars" "$success_message" "$failure_message" "$run_at_load" "$low_priority"
+		_SCHEDULER_CAPTURED_COMMAND="$exec_command"
+		return 0
+	}
+
+	local orig_home="$HOME"
+	HOME="$fake_home"
+	_install_profile_readme_scheduler "sh.aidevops.profile-readme-update" "aidevops-profile-readme-update" "$profile_script" "$fake_home/profile.log"
+	local profile_command="$_SCHEDULER_CAPTURED_COMMAND"
+	setup_screen_time_snapshot
+	local screen_command="$_SCHEDULER_CAPTURED_COMMAND"
+	HOME="$orig_home"
+	unset -f uname _install_scheduler_linux
+
+	# shellcheck disable=SC2016 # the generated command must defer variable expansion to runtime.
+	if [[ "$profile_command" != *'update "r908" --status "$status" --duration "$duration"'* ]]; then
+		print_result "profile scheduler command updates r908 metrics" 1 "$profile_command"
+		return 0
+	fi
+	# shellcheck disable=SC2016 # the generated command must defer variable expansion to runtime.
+	if [[ "$screen_command" != *'update "r909" --status "$status" --duration "$duration"'* ]]; then
+		print_result "screen-time scheduler command updates r909 metrics" 1 "$screen_command"
+		return 0
+	fi
+	print_result "linux core scheduler commands update routine metrics" 0
+	return 0
+}
+
+test_pulse_routine_update_uses_flags_and_duration() {
+	local fake_home="$TEST_DIR/home"
+	local agents_dir="$fake_home/.aidevops/agents"
+	mkdir -p "$agents_dir/scripts" "$TEST_DIR/bin"
+	cat >"$agents_dir/scripts/sample.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+	chmod +x "$agents_dir/scripts/sample.sh"
+	cat >"$TEST_DIR/bin/routine-log-helper.sh" <<'HELPER'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$ROUTINE_LOG_CAPTURE"
+exit 0
+HELPER
+	chmod +x "$TEST_DIR/bin/routine-log-helper.sh"
+
+	HOME="$fake_home"
+	ROUTINE_STATE_FILE="$TEST_DIR/state.json"
+	LOGFILE="$TEST_DIR/pulse.log"
+	ROUTINE_LOG_HELPER="$TEST_DIR/bin/routine-log-helper.sh"
+	ROUTINE_LOG_CAPTURE="$TEST_DIR/routine-log.args"
+	export ROUTINE_LOG_CAPTURE
+	HEADLESS_RUNTIME_HELPER="$TEST_DIR/bin/headless-runtime-helper.sh"
+	PULSE_DIR="$TEST_DIR"
+	# shellcheck source=/dev/null
+	source "$PULSE_ROUTINES_SH"
+
+	_routine_execute "r777" "sample" "scripts/sample.sh" "" "$TEST_DIR"
+
+	local args
+	args=$(<"$ROUTINE_LOG_CAPTURE")
+	if [[ "$args" == update\ r777\ --status\ success\ --duration\ * ]]; then
+		print_result "pulse routine update passes flags and duration" 0
+	else
+		print_result "pulse routine update passes flags and duration" 1 "$args"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	load_scheduler_helpers
+	test_core_routine_logged_command_shape
+	test_linux_core_scheduler_commands_are_logged
+	test_pulse_routine_update_uses_flags_and_duration
+	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Wrapped profile README and screen-time scheduler commands so successful and failed core executions call routine-log-helper with status, duration, and preserved exit codes. Fixed pulse routine logging to use the update flag contract and duration. Added regression coverage for generated scheduler commands and pulse routine helper invocation.

## Files Changed

.agents/scripts/pulse-routines.sh,.agents/scripts/setup/modules/schedulers-platform.sh,.agents/scripts/setup/modules/schedulers.sh,.agents/scripts/tests/test-launchd-install-if-changed.sh,.agents/scripts/tests/test-routine-tracking-updates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-routine-tracking-updates.sh; bash .agents/scripts/tests/test-launchd-install-if-changed.sh (skips on Linux); shellcheck .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/setup/modules/schedulers.sh .agents/scripts/pulse-routines.sh .agents/scripts/tests/test-routine-tracking-updates.sh .agents/scripts/tests/test-launchd-install-if-changed.sh; git diff --check origin/main...HEAD

Resolves #24591


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 6m and 169,352 tokens on this as a headless worker.