### PR TITLE
GH#24590: fix: ignore routine ops audit comments

### DIFF
--- a/.agents/scripts/routine-comment-responder.sh
+++ b/.agents/scripts/routine-comment-responder.sh
@@ -18,8 +18,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOGFILE="${HOME}/.aidevops/.agent-workspace/cron/routine-comments/responder.log"
-STATE_DIR="${HOME}/.aidevops/.agent-workspace/cron/routine-comments"
+LOGFILE="${ROUTINE_COMMENT_LOGFILE:-${HOME}/.aidevops/.agent-workspace/cron/routine-comments/responder.log}"
+STATE_DIR="${ROUTINE_COMMENT_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/cron/routine-comments}"
 mkdir -p "$STATE_DIR"
 
 # ---------------------------------------------------------------------------
@@ -35,6 +35,39 @@ _log() {
 _get_self_login() {
 	gh api user --jq '.login' 2>/dev/null || echo ""
 	return 0
+}
+
+_responded_file_for_repo() {
+	local repo_slug="$1"
+	printf '%s\n' "${STATE_DIR}/${repo_slug//\//_}_responded.txt"
+	return 0
+}
+
+_mark_comment_skipped() {
+	local responded_file="$1"
+	local comment_id="$2"
+	local reason="$3"
+	if grep -q "^${comment_id}$" "$responded_file" 2>/dev/null; then
+		return 0
+	fi
+	printf '%s\n' "$comment_id" >>"$responded_file"
+	_log "dispatch: comment ${comment_id} marked skipped (${reason})"
+	return 0
+}
+
+_routine_ops_comment_regex() {
+	printf '%s\n' '^(DISPATCH_CLAIM|DISPATCH_RELEASED|CLAIM_RELEASED|<!-- ops:|<!-- routine-description|<!-- aidevops:sig|## (Cascade Tier Escalation|BLOCKED|Closing|Routine|Worker|Dispatch|Audit|MERGE_SUMMARY)|### (Worker|Audit)|\[aidevops\])'
+	return 0
+}
+
+_is_routine_ops_comment() {
+	local body="$1"
+	local ops_regex
+	ops_regex=$(_routine_ops_comment_regex)
+	if printf '%s' "$body" | grep -qE "$ops_regex"; then
+		return 0
+	fi
+	return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -66,8 +99,12 @@ cmd_scan() {
 		return 0
 	fi
 
-	local responded_file="${STATE_DIR}/${repo_slug//\//_}_responded.txt"
+	local responded_file
+	responded_file=$(_responded_file_for_repo "$repo_slug")
 	touch "$responded_file"
+
+	local ops_regex
+	ops_regex=$(_routine_ops_comment_regex)
 
 	local found=0
 	while IFS= read -r issue_number; do
@@ -81,7 +118,7 @@ cmd_scan() {
 		[[ -z "$comments_json" ]] && continue
 
 		# Process each comment — find user comments that haven't been responded to
-		echo "$comments_json" | jq -r 'select(.is_bot == false) | select(.body | test("^DISPATCH_CLAIM|^<!-- ops:|^<!-- routine-description") | not) | "\(.id)|\(.author)|\(.body | split("\n")[0] | .[0:100])"' 2>/dev/null |
+		echo "$comments_json" | jq -r --arg ops_regex "$ops_regex" 'select(.is_bot == false) | select(.body | test($ops_regex) | not) | "\(.id)|\(.author)|\(.body | split("\n")[0] | .[0:100])"' 2>/dev/null |
 			while IFS='|' read -r comment_id author body_preview; do
 				[[ -z "$comment_id" ]] && continue
 
@@ -90,7 +127,7 @@ cmd_scan() {
 				if [[ "$author" == "$self_login" ]]; then
 					# Check if this looks like a genuine user comment (not automation)
 					# Automation comments start with specific markers
-					if echo "$body_preview" | grep -qE '^(DISPATCH_CLAIM|<!-- |## (Closing|BLOCKED|Routine))'; then
+					if _is_routine_ops_comment "$body_preview"; then
 						continue
 					fi
 				fi
@@ -120,7 +157,8 @@ cmd_dispatch() {
 	local issue_number="$3"
 	local comment_id="$4"
 
-	local responded_file="${STATE_DIR}/${repo_slug//\//_}_responded.txt"
+	local responded_file
+	responded_file=$(_responded_file_for_repo "$repo_slug")
 	touch "$responded_file"
 
 	# Double-check the comment still exists and hasn't been responded to
@@ -130,11 +168,26 @@ cmd_dispatch() {
 	fi
 
 	# Get the comment body
-	local comment_body
+	local comment_body lookup_error
+	lookup_error=""
 	comment_body=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments/${comment_id}" \
-		--jq '.body' 2>/dev/null) || comment_body=""
+		--jq '.body' 2>&1) || {
+		lookup_error="$comment_body"
+		comment_body=""
+	}
 	if [[ -z "$comment_body" ]]; then
-		_log "dispatch: comment ${comment_id} not found — skipping"
+		local lookup_summary="empty response"
+		if [[ -n "$lookup_error" ]]; then
+			lookup_summary="${lookup_error%%$'\n'*}"
+		fi
+		_log "dispatch: comment ${comment_id} on #${issue_number} lookup failed — skipping (${lookup_summary})"
+		_mark_comment_skipped "$responded_file" "$comment_id" "lookup failed"
+		return 0
+	fi
+
+	if _is_routine_ops_comment "$comment_body"; then
+		_log "dispatch: comment ${comment_id} on #${issue_number} is routine ops/audit content — skipping"
+		_mark_comment_skipped "$responded_file" "$comment_id" "routine ops/audit content"
 		return 0
 	fi
 

--- a/.agents/scripts/routine-comment-responder.sh
+++ b/.agents/scripts/routine-comment-responder.sh
@@ -43,11 +43,21 @@ _responded_file_for_repo() {
 	return 0
 }
 
+_comment_already_recorded() {
+	local responded_file="$1"
+	local comment_id="$2"
+	local comment_line_regex="^${comment_id}$"
+	if grep -q "$comment_line_regex" "$responded_file" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
 _mark_comment_skipped() {
 	local responded_file="$1"
 	local comment_id="$2"
 	local reason="$3"
-	if grep -q "^${comment_id}$" "$responded_file" 2>/dev/null; then
+	if _comment_already_recorded "$responded_file" "$comment_id"; then
 		return 0
 	fi
 	printf '%s\n' "$comment_id" >>"$responded_file"
@@ -133,7 +143,7 @@ cmd_scan() {
 				fi
 
 				# Skip if already responded to
-				if grep -q "^${comment_id}$" "$responded_file" 2>/dev/null; then
+				if _comment_already_recorded "$responded_file" "$comment_id"; then
 					continue
 				fi
 
@@ -162,7 +172,7 @@ cmd_dispatch() {
 	touch "$responded_file"
 
 	# Double-check the comment still exists and hasn't been responded to
-	if grep -q "^${comment_id}$" "$responded_file" 2>/dev/null; then
+	if _comment_already_recorded "$responded_file" "$comment_id"; then
 		_log "dispatch: comment ${comment_id} on #${issue_number} already responded to — skipping"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-routine-comment-responder-ops-filter.sh
+++ b/.agents/scripts/tests/test-routine-comment-responder-ops-filter.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+	local test_name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected to contain: $needle"
+		echo "    actual: $haystack"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local test_name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected NOT to contain: $needle"
+		echo "    actual: $haystack"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_equals() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected: $expected"
+		echo "    actual: $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+echo "=== routine-comment-responder ops/audit filter regression ==="
+echo ""
+
+TMPDIR_TEST=$(mktemp -d 2>/dev/null || mktemp -d -t routine-comments)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+STUB_DIR="${TMPDIR_TEST}/stub-bin"
+mkdir -p "$STUB_DIR"
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+	printf '%s\n' 'maintainer'
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	printf '%s\n' '42'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/42/comments" ]]; then
+	cat <<'JSON'
+{"id":101,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:00:00Z","body":"<!-- routine-description -->\nRoutine dashboard"}
+{"id":102,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:01:00Z","body":"DISPATCH_CLAIM worker=abc"}
+{"id":103,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:02:00Z","body":"CLAIM_RELEASED reason=worker_failed"}
+{"id":104,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:03:00Z","body":"## Cascade Tier Escalation\nEscalating worker"}
+{"id":105,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:04:00Z","body":"<!-- ops: pulse audit -->"}
+{"id":106,"author":"user","is_bot":false,"created":"2026-01-01T00:05:00Z","body":"Can this routine run hourly?"}
+JSON
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/42/comments/999" ]]; then
+	printf '%s\n' 'gh: Not Found (HTTP 404)' >&2
+	exit 1
+fi
+
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+export PATH="${STUB_DIR}:$PATH"
+export ROUTINE_COMMENT_STATE_DIR="${TMPDIR_TEST}/state"
+export ROUTINE_COMMENT_LOGFILE="${TMPDIR_TEST}/responder.log"
+mkdir -p "$ROUTINE_COMMENT_STATE_DIR"
+
+scan_output=$(bash "${PARENT_DIR}/routine-comment-responder.sh" scan "owner/repo" "$TMPDIR_TEST")
+assert_contains "real user question emitted" "42|106|user|Can this routine run hourly?" "$scan_output"
+assert_not_contains "CLAIM_RELEASED ignored" "103|" "$scan_output"
+assert_not_contains "cascade escalation ignored" "104|" "$scan_output"
+assert_not_contains "ops marker ignored" "105|" "$scan_output"
+
+bash "${PARENT_DIR}/routine-comment-responder.sh" dispatch "owner/repo" "$TMPDIR_TEST" 42 999
+bash "${PARENT_DIR}/routine-comment-responder.sh" dispatch "owner/repo" "$TMPDIR_TEST" 42 999
+
+responded_file="${ROUTINE_COMMENT_STATE_DIR}/owner_repo_responded.txt"
+responded_count=$(grep -c '^999$' "$responded_file" || true)
+assert_equals "missing comment recorded once" "1" "$responded_count"
+
+already_count=$(grep -c 'already responded to' "$ROUTINE_COMMENT_LOGFILE" || true)
+assert_equals "second dispatch skipped from state" "1" "$already_count"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Filtered deterministic routine ops/audit comments in .agents/scripts/routine-comment-responder.sh, including CLAIM_RELEASED, dispatch release, cascade escalation, BLOCKED, worker/audit headings, and signature/ops markers. Missing comment lookup failures now log the first safe error line and mark the comment ID in the responded state file so future pulse cycles skip it. Added .agents/scripts/tests/test-routine-comment-responder-ops-filter.sh covering ops-comment filtering and missing-comment retry prevention.

## Files Changed

.agents/scripts/routine-comment-responder.sh,.agents/scripts/tests/test-routine-comment-responder-ops-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/routine-comment-responder.sh .agents/scripts/tests/test-routine-comment-responder-ops-filter.sh; .agents/scripts/tests/test-routine-comment-responder-ops-filter.sh; .agents/scripts/linters-local.sh

Resolves #24590


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 13m and 107,587 tokens on this as a headless worker.