### PR TITLE
GH#24597: fix: harden routine comment filtering

### DIFF
--- a/.agents/scripts/routine-comment-responder.sh
+++ b/.agents/scripts/routine-comment-responder.sh
@@ -74,7 +74,7 @@ _is_routine_ops_comment() {
 	local body="$1"
 	local ops_regex
 	ops_regex=$(_routine_ops_comment_regex)
-	if printf '%s' "$body" | grep -qE "$ops_regex"; then
+	if [[ "$body" =~ $ops_regex ]]; then
 		return 0
 	fi
 	return 1
@@ -128,7 +128,7 @@ cmd_scan() {
 		[[ -z "$comments_json" ]] && continue
 
 		# Process each comment — find user comments that haven't been responded to
-		echo "$comments_json" | jq -r --arg ops_regex "$ops_regex" 'select(.is_bot == false) | select(.body | test($ops_regex) | not) | "\(.id)|\(.author)|\(.body | split("\n")[0] | .[0:100])"' 2>/dev/null |
+		echo "$comments_json" | jq -r --arg ops_regex "$ops_regex" 'select(.is_bot == false) | .body |= (. // "") | select(.body | test($ops_regex) | not) | "\(.id)|\(.author)|\(.body | split("\n")[0] | .[0:100])"' |
 			while IFS='|' read -r comment_id author body_preview; do
 				[[ -z "$comment_id" ]] && continue
 

--- a/.agents/scripts/tests/test-routine-comment-responder-ops-filter.sh
+++ b/.agents/scripts/tests/test-routine-comment-responder-ops-filter.sh
@@ -88,6 +88,8 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/42/comments" ]];
 {"id":103,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:02:00Z","body":"CLAIM_RELEASED reason=worker_failed"}
 {"id":104,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:03:00Z","body":"## Cascade Tier Escalation\nEscalating worker"}
 {"id":105,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:04:00Z","body":"<!-- ops: pulse audit -->"}
+{"id":107,"author":"maintainer","is_bot":false,"created":"2026-01-01T00:04:30Z","body":"Can this be clarified?\nBLOCKED by missing context"}
+{"id":108,"author":"user","is_bot":false,"created":"2026-01-01T00:04:45Z"}
 {"id":106,"author":"user","is_bot":false,"created":"2026-01-01T00:05:00Z","body":"Can this routine run hourly?"}
 JSON
 	exit 0
@@ -110,9 +112,17 @@ mkdir -p "$ROUTINE_COMMENT_STATE_DIR"
 
 scan_output=$(bash "${PARENT_DIR}/routine-comment-responder.sh" scan "owner/repo" "$TMPDIR_TEST")
 assert_contains "real user question emitted" "42|106|user|Can this routine run hourly?" "$scan_output"
+assert_contains "missing body normalized" "42|108|user|" "$scan_output"
+assert_contains "multiline non-ops owner comment emitted" "42|107|maintainer|Can this be clarified?" "$scan_output"
 assert_not_contains "CLAIM_RELEASED ignored" "103|" "$scan_output"
 assert_not_contains "cascade escalation ignored" "104|" "$scan_output"
 assert_not_contains "ops marker ignored" "105|" "$scan_output"
+
+if ROUTINE_COMMENT_LOGFILE="$ROUTINE_COMMENT_LOGFILE" ROUTINE_COMMENT_STATE_DIR="$ROUTINE_COMMENT_STATE_DIR" bash -c 'source "$1"; _is_routine_ops_comment $'"'"'Can this be clarified?\nBLOCKED by missing context'"'"'' bash "${PARENT_DIR}/routine-comment-responder.sh"; then
+	assert_equals "multiline helper does not match later marker" "non-ops" "ops"
+else
+	assert_equals "multiline helper does not match later marker" "non-ops" "non-ops"
+fi
 
 bash "${PARENT_DIR}/routine-comment-responder.sh" dispatch "owner/repo" "$TMPDIR_TEST" 42 999
 bash "${PARENT_DIR}/routine-comment-responder.sh" dispatch "owner/repo" "$TMPDIR_TEST" 42 999


### PR DESCRIPTION
## Summary

Hardened routine-comment-responder filtering by normalizing missing comment bodies before jq regex/split processing and using Bash regex matching to avoid line-by-line grep false positives. Added regression coverage for missing bodies and multiline comments with later ops markers.

## Files Changed

.agents/scripts/routine-comment-responder.sh,.agents/scripts/tests/test-routine-comment-responder-ops-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-routine-comment-responder-ops-filter.sh; shellcheck .agents/scripts/routine-comment-responder.sh .agents/scripts/tests/test-routine-comment-responder-ops-filter.sh

Resolves #24597


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 44,219 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal comment detection and filtering logic for routine operations workflows.

* **Tests**
  * Enhanced regression test coverage to verify comment normalization and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->