### PR TITLE
GH#24598: fix: harden routine metric scheduler commands

### DIFF
--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -123,7 +123,7 @@ _routine_execute() {
 			if [[ -x "$ROUTINE_LOG_HELPER" ]]; then
 				local ended_epoch
 				ended_epoch=$(date +%s)
-				local duration=$((ended_epoch - started_epoch))
+				local duration=$(( ${ended_epoch:-0} - ${started_epoch:-0} ))
 				"$ROUTINE_LOG_HELPER" update "$routine_id" --status failure --duration "$duration" 2>/dev/null || true
 			fi
 			return 1
@@ -181,7 +181,7 @@ _routine_execute() {
 	if [[ -x "$ROUTINE_LOG_HELPER" ]]; then
 		local ended_epoch
 		ended_epoch=$(date +%s)
-		local duration=$((ended_epoch - started_epoch))
+		local duration=$(( ${ended_epoch:-0} - ${started_epoch:-0} ))
 		"$ROUTINE_LOG_HELPER" update "$routine_id" --status "$status" --duration "$duration" 2>/dev/null || true
 	fi
 

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -507,12 +507,20 @@ _run_profile_readme_init() {
 	return 0
 }
 
+_core_routine_shell_quote() {
+	local value="$1"
+	printf "'"
+	printf '%s' "$value" | sed "s/'/'\\\\''/g"
+	printf "'"
+	return 0
+}
+
 _core_routine_logged_command() {
 	local routine_id="$1"
 	local exec_command="$2"
 	local log_helper="\$HOME/.aidevops/agents/scripts/routine-log-helper.sh"
 	# shellcheck disable=SC2016 # command string is expanded by the generated scheduler shell.
-	printf 'start_epoch=$(date +%%s); status=success; %s; rc=$?; end_epoch=$(date +%%s); duration=$((end_epoch - start_epoch)); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "%s" ]; then "%s" update "%s" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"' \
+	printf 'start_epoch=$(date +%%s); status=success; %s; rc=$?; end_epoch=$(date +%%s); duration=$(( ${end_epoch:-0} - ${start_epoch:-0} )); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "%s" ]; then "%s" update "%s" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"' \
 		"$exec_command" \
 		"$log_helper" \
 		"$log_helper" \
@@ -526,7 +534,7 @@ _install_profile_readme_launchd() {
 	local pr_plist="$HOME/Library/LaunchAgents/${pr_label}.plist"
 	local _xml_pr_script _xml_pr_home
 	local pr_command
-	pr_command=$(_core_routine_logged_command "r908" "\"${pr_script}\" update")
+	pr_command=$(_core_routine_logged_command "r908" "$(_core_routine_shell_quote "$pr_script") update")
 	_xml_pr_script=$(_xml_escape "$pr_command")
 	_xml_pr_home=$(_xml_escape "$HOME")
 

--- a/.agents/scripts/setup/modules/schedulers.sh
+++ b/.agents/scripts/setup/modules/schedulers.sh
@@ -496,7 +496,7 @@ setup_screen_time_snapshot() {
 		# XML-escape paths for safe plist embedding
 		local _xml_st_script _xml_st_home
 		local st_command
-		st_command=$(_core_routine_logged_command "r909" "\"${st_script}\" snapshot")
+		st_command=$(_core_routine_logged_command "r909" "$(_core_routine_shell_quote "$st_script") snapshot")
 		_xml_st_script=$(_xml_escape "$st_command")
 		_xml_st_home=$(_xml_escape "$HOME")
 

--- a/.agents/scripts/tests/test-launchd-install-if-changed.sh
+++ b/.agents/scripts/tests/test-launchd-install-if-changed.sh
@@ -807,7 +807,7 @@ test_profile_readme_install_does_not_kickstart() {
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>start_epoch=$(date +%s); status=success; "/fake/profile-readme-helper.sh" update; rc=$?; end_epoch=$(date +%s); duration=$((end_epoch - start_epoch)); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" ]; then "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" update "r908" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"</string>
+		<string>start_epoch=$(date +%s); status=success; '/fake/profile-readme-helper.sh' update; rc=$?; end_epoch=$(date +%s); duration=$(( ${end_epoch:-0} - ${start_epoch:-0} )); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" ]; then "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" update "r908" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>3600</integer>

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -63,9 +63,14 @@ load_scheduler_helpers() {
 
 test_core_routine_logged_command_shape() {
 	local command_text
-	command_text=$(_core_routine_logged_command "r908" '"/tmp/profile-readme-helper.sh" update')
-	if [[ "$command_text" != *'"/tmp/profile-readme-helper.sh" update'* ]]; then
+	command_text=$(_core_routine_logged_command "r908" "'$TEST_DIR/profile-readme-helper.sh' update")
+	if [[ "$command_text" != *"'$TEST_DIR/profile-readme-helper.sh' update"* ]]; then
 		print_result "core routine logged command keeps original command" 1 "$command_text"
+		return 0
+	fi
+	# shellcheck disable=SC2016 # the generated command must defer variable expansion to runtime.
+	if [[ "$command_text" != *'duration=$(( ${end_epoch:-0} - ${start_epoch:-0} ))'* ]]; then
+		print_result "core routine logged command uses robust duration arithmetic" 1 "$command_text"
 		return 0
 	fi
 	# shellcheck disable=SC2016 # the generated command must defer variable expansion to runtime.
@@ -164,8 +169,10 @@ HELPER
 
 	_routine_execute "r777" "sample" "scripts/sample.sh" "" "$TEST_DIR"
 
-	local args
-	args=$(<"$ROUTINE_LOG_CAPTURE")
+	local args=""
+	if [[ -f "$ROUTINE_LOG_CAPTURE" ]]; then
+		args=$(<"$ROUTINE_LOG_CAPTURE")
+	fi
 	if [[ "$args" == update\ r777\ --status\ success\ --duration\ * ]]; then
 		print_result "pulse routine update passes flags and duration" 0
 	else


### PR DESCRIPTION
## Summary

Hardened generated routine metric command wrappers by using shell single-quoted scheduler script paths, robust duration arithmetic defaults, and graceful test capture handling.

## Files Changed

.agents/scripts/pulse-routines.sh,.agents/scripts/setup/modules/schedulers-platform.sh,.agents/scripts/setup/modules/schedulers.sh,.agents/scripts/tests/test-launchd-install-if-changed.sh,.agents/scripts/tests/test-routine-tracking-updates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-routines.sh .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/setup/modules/schedulers.sh .agents/scripts/tests/test-routine-tracking-updates.sh .agents/scripts/tests/test-launchd-install-if-changed.sh; bash .agents/scripts/tests/test-routine-tracking-updates.sh; bash .agents/scripts/tests/test-launchd-install-if-changed.sh (skips on Linux); .agents/scripts/linters-local.sh

Resolves #24598


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 7m and 119,852 tokens on this as a headless worker.