### PR TITLE
GH#24604: fix: simplify native blocked-by fallback

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -916,19 +916,15 @@ is_blocked_by_unresolved() {
 	# re-blocked by stale duplicate text markers.
 	local native_rc=0
 	_blocked_by_check_native_relationships "$repo_slug" "$issue_number" || native_rc=$?
-	local native_lookup_unavailable="false"
 	if [[ "$native_rc" -eq 0 ]]; then
 		return 0
 	fi
 	if [[ "$native_rc" -eq 2 ]]; then
 		return 1
 	fi
-	if [[ "$native_rc" -eq 3 ]]; then
-		native_lookup_unavailable="true"
-	fi
 
 	if [[ -z "$issue_body" ]]; then
-		if [[ "$native_lookup_unavailable" == "true" ]]; then
+		if [[ "$native_rc" -eq 3 ]]; then
 			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable and issue body is empty — skipping dispatch (GH#24576)" >>"$LOGFILE"
 			return 0
 		fi
@@ -944,7 +940,7 @@ is_blocked_by_unresolved() {
 
 	# No blocked-by references → not blocked
 	if [[ -z "$blocker_task_ids" && -z "$blocker_issue_nums" ]]; then
-		if [[ "$native_lookup_unavailable" == "true" ]]; then
+		if [[ "$native_rc" -eq 3 ]]; then
 			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable and no body blocked-by markers found — skipping dispatch (GH#24576)" >>"$LOGFILE"
 			return 0
 		fi


### PR DESCRIPTION
## Summary

Removed the redundant native_lookup_unavailable string flag in is_blocked_by_unresolved and now checks native_rc directly for the native blockedBy lookup unavailable fallback paths.

## Files Changed

.agents/scripts/pulse-dep-graph.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dep-graph.sh

Resolves #24604


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 33,718 tokens on this as a headless worker.