### PR TITLE
GH#24605: fix: narrow ever-nmr blocker classifier

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1934,7 +1934,7 @@ classify_dispatch_blocker_reason() {
 			printf 'runner_health_circuit_breaker\n'
 			return 0
 			;;
-		*dispatch_block_reason*ever_nmr_without_approval* | *blocked*ever*nmr* | *requires*cryptographic*approval*)
+		*dispatch_block_reason*ever_nmr_without_approval* | *blocked*ever*nmr*lacks*approval* | *requires*cryptographic*approval*)
 			printf 'ever_nmr_without_approval\n'
 			return 0
 			;;
@@ -1950,7 +1950,7 @@ classify_dispatch_blocker_reason() {
 			printf 'missing_worker_context\n'
 			return 0
 			;;
-		*worktree*cap* | *max*worktree* | *disk*space* | *large*file*)
+		*local*capacity*gate* | *worktree*cap* | *max*worktree* | *disk*space* | *large*file*)
 			printf 'local_capacity_gate\n'
 			return 0
 			;;

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -28,6 +28,7 @@ assert_reason 'DISPATCH_COOLDOWN_ACTIVE until=2026-05-02T23:00:00Z reason=no_wor
 assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — requires cryptographic approval (ever-NMR)' 'ever_nmr_without_approval'
 assert_reason 'DISPATCH_BLOCK_REASON reason=ever_nmr_without_approval signal=ever-NMR issue requires approval' 'ever_nmr_without_approval'
 assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — ever-NMR issue lacks approval' 'ever_nmr_without_approval'
+assert_reason 'blocked by local capacity gate (ever-nmr check not run)' 'local_capacity_gate'
 assert_reason 'review-followup exemption: skipping historical ever-NMR check (GH#18648)' 'unclassified_signal'
 assert_reason 'skipping historical ever-NMR check for bot-generated cleanup issue (GH#18648)' 'unclassified_signal'
 assert_reason 'pre-dispatch validator failed: missing worker context; needs-brief label present' 'missing_worker_context'


### PR DESCRIPTION
## Summary

Narrowed the ever-NMR blocker classifier so generic blocked ever-NMR mentions no longer bypass later classifier arms, and added local capacity wording coverage for the false-positive shape.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh && .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh

Resolves #24605


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 94,627 tokens on this as a headless worker.