### PR TITLE
GH#24595: fix OpenAI quota probe fallback

### DIFF
--- a/.agents/scripts/model-availability-cmd-lib.sh
+++ b/.agents/scripts/model-availability-cmd-lib.sh
@@ -196,6 +196,7 @@ _status_print_providers() {
 		case "$stat" in
 		healthy) status_display="${GREEN}healthy${NC}" ;;
 		unhealthy | unreachable) status_display="${RED}$stat${NC}" ;;
+		quota_exceeded) status_display="${RED}quota-exc${NC}" ;;
 		rate_limited) status_display="${YELLOW}rate-ltd${NC}" ;;
 		key_invalid) status_display="${RED}bad-key${NC}" ;;
 		no_key) status_display="${YELLOW}no-key${NC}" ;;
@@ -588,4 +589,3 @@ cmd_help() {
 	echo ""
 	return 0
 }
-

--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -279,6 +279,22 @@ _probe_build_request() {
 	return 0
 }
 
+# Detect provider quota exhaustion from an HTTP error body before generic auth
+# handling. OpenAI returns HTTP 403 for both auth and billing quota failures, so
+# status-code-only parsing can incorrectly trigger OAuth fallback and record a
+# quota-exhausted provider as healthy.
+_probe_body_has_quota_error() {
+	local body="$1"
+	local body_lc
+
+	body_lc=$(printf '%s\n' "$body" | tr '[:upper:]' '[:lower:]')
+	if [[ "$body_lc" == *"insufficient_quota"* ]] || [[ "$body_lc" == *"quota exceeded"* ]] || [[ "$body_lc" == *"exceeded your current quota"* ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
 # Parse an HTTP response code into status, error_msg, models_count, and exit_code.
 # Outputs four lines: status, error_msg, models_count, exit_code.
 _probe_parse_http_response() {
@@ -303,10 +319,17 @@ _probe_parse_http_response() {
 		[[ "$quiet" != "true" ]] && print_success "$provider: healthy (${models_count} models)"
 		;;
 	401 | 403)
-		status="key_invalid"
-		error_msg="Authentication failed (HTTP $http_code)"
-		exit_code=3
-		[[ "$quiet" != "true" ]] && print_error "$provider: API key invalid (HTTP $http_code)"
+		if _probe_body_has_quota_error "$body"; then
+			status="quota_exceeded"
+			error_msg="Quota exceeded (HTTP $http_code)"
+			exit_code=1
+			[[ "$quiet" != "true" ]] && print_error "$provider: quota exceeded (HTTP $http_code)"
+		else
+			status="key_invalid"
+			error_msg="Authentication failed (HTTP $http_code)"
+			exit_code=3
+			[[ "$quiet" != "true" ]] && print_error "$provider: API key invalid (HTTP $http_code)"
+		fi
 		;;
 	429)
 		status="rate_limited"

--- a/.agents/scripts/tests/test-model-availability-oauth-probe.sh
+++ b/.agents/scripts/tests/test-model-availability-oauth-probe.sh
@@ -247,6 +247,35 @@ else
 	print_result "stale-env-key+no-oauth: _probe_check_oauth_fallback returns 3 (no override)" 1 \
 		"(got rc=$rc — expected 3; no auth.json OAuth should not produce a false healthy)"
 fi
+
+# Assertion 4d — OpenAI quota-specific 403 is unavailable, not auth fallback.
+# GH#24595: OpenAI returns HTTP 403 for insufficient billing quota. The parser
+# must classify that as quota_exceeded with a non-3 exit code so probe_provider
+# cannot convert it to healthy via auth.json OAuth fallback.
+quota_body='{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","code":"insufficient_quota"}}'
+parsed=$(_probe_parse_http_response openai 403 "$quota_body" true)
+status=$(printf '%s\n' "$parsed" | sed -n '1p')
+error_msg=$(printf '%s\n' "$parsed" | sed -n '2p')
+exit_code=$(printf '%s\n' "$parsed" | sed -n '4p')
+if [[ "$status" == "quota_exceeded" && "$error_msg" == "Quota exceeded (HTTP 403)" && "$exit_code" -eq 1 ]]; then
+	print_result "openai-quota-403: parser returns quota_exceeded without OAuth fallback exit" 0
+else
+	print_result "openai-quota-403: parser returns quota_exceeded without OAuth fallback exit" 1 \
+		"(got status='$status', error='$error_msg', exit=$exit_code — expected quota_exceeded / Quota exceeded / exit 1)"
+fi
+
+# Assertion 4e — generic 403 remains key_invalid and preserves existing t3229
+# fallback eligibility for stale non-env keys.
+auth_body='{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}'
+parsed=$(_probe_parse_http_response openai 403 "$auth_body" true)
+status=$(printf '%s\n' "$parsed" | sed -n '1p')
+exit_code=$(printf '%s\n' "$parsed" | sed -n '4p')
+if [[ "$status" == "key_invalid" && "$exit_code" -eq 3 ]]; then
+	print_result "openai-auth-403: parser preserves key_invalid fallback exit" 0
+else
+	print_result "openai-auth-403: parser preserves key_invalid fallback exit" 1 \
+		"(got status='$status', exit=$exit_code — expected key_invalid / exit 3)"
+fi
 # =============================================================================
 # Assertion 5 — ChatGPT OAuth denylist blocks known-unsupported pro models
 # (GH#21990)


### PR DESCRIPTION
## Summary

Classify quota-specific 401/403 response bodies as quota_exceeded so OAuth fallback cannot mark quota-exhausted OpenAI as healthy; add status display and regression coverage preserving generic auth fallback.

## Files Changed

.agents/scripts/model-availability-cmd-lib.sh,.agents/scripts/model-availability-probe-lib.sh,.agents/scripts/tests/test-model-availability-oauth-probe.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-model-availability-oauth-probe.sh; shellcheck .agents/scripts/model-availability-probe-lib.sh .agents/scripts/model-availability-cmd-lib.sh .agents/scripts/tests/test-model-availability-oauth-probe.sh; .agents/scripts/linters-local.sh

Resolves #24595


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1h 3m and 136,246 tokens on this with the user in an interactive session.