### PR TITLE
fix: isolate pulse worker logs per user

### DIFF
--- a/.agents/scripts/circuit-breaker-helper.sh
+++ b/.agents/scripts/circuit-breaker-helper.sh
@@ -696,7 +696,7 @@ Investigate the root cause of supervisor circuit-breaker trip Ref #${trip_issue_
 
 - \`~/.aidevops/logs/pulse-wrapper.log\` — pulse-side dispatch trace; grep for the failed task ID and surrounding cycle.
 - \`~/.aidevops/logs/headless-runtime-metrics.jsonl\` — per-worker outcome ledger; filter \`select(.session_key | contains(\"${last_task_id}\"))\` for terminal events.
-- \`/tmp/pulse-<runner>-<repo>-<task>.log\` — per-worker stdout/stderr if still on disk.
+- \`~/.aidevops/.agent-workspace/tmp/pulse/pulse-<repo>-<task>.log\` (or \`$XDG_RUNTIME_DIR/aidevops/pulse/\`) — per-worker stdout/stderr if still on disk.
 - \`~/.aidevops/.agent-workspace/headless-runtime/canary-last-fail*\` — canary failure artifacts when the canary itself is the live blocker.
 - \`~/.aidevops/logs/dispatch-stages.tsv\` — dispatch-stage timing; recent rows show how far each spawn got before failing.
 

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -104,8 +104,11 @@ get_active_worker_sessions() {
 	local one_hour_ago
 	one_hour_ago=$(($(date +%s) - 3600))
 
-	# Check /tmp/pulse-*.log files modified within the last hour
-	for logfile in /tmp/pulse-*.log; do
+	# Check per-user pulse worker logs modified within the last hour.
+	local pulse_tmp_root=""
+	pulse_tmp_root=$(aidevops_pulse_tmp_root 2>/dev/null || true)
+	[[ -n "$pulse_tmp_root" ]] || return 0
+	for logfile in "$pulse_tmp_root"/pulse-*.log; do
 		[[ -f "$logfile" ]] || continue
 		local file_mtime
 		file_mtime=$(_file_mtime_epoch "$logfile")

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -861,8 +861,9 @@ _dispatch_infra_failure_advisory() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	local safe_slug="${repo_slug//\//-}"
-	local log_path_hint="/tmp/pulse-${safe_slug}-${issue_number}.log"
+	local log_path_hint=""
+	log_path_hint=$(aidevops_pulse_worker_log_path "$repo_slug" "$issue_number" 2>/dev/null || true)
+	[[ -n "$log_path_hint" ]] || log_path_hint="<pulse-temp>/pulse-${issue_number}.log"
 
 	cat <<MARKER_EOF
 ## Dispatch infrastructure failure detected
@@ -879,7 +880,7 @@ A \`session_count=0\` release indicates the worker died in setup (sandbox crash,
 
 1. Read the most recent worker logs:
    - \`${log_path_hint}\`
-   - \`/tmp/pulse-${safe_slug}-${issue_number}.log.*\` (rotated copies)
+   - \`${log_path_hint}.*\` (rotated copies)
 2. Identify the failure family — sandbox / auth / OpenCode / prompt / SIGTERM source.
 3. Once the underlying issue is fixed, clear NMR with:
 
@@ -1864,8 +1865,8 @@ reap_zombie_workers() {
 #
 # t2814 (Phase 3, fix #1): Include the tail of the worker log in the claim-
 # released comment for `no_worker_process` failures. Closes the diagnostic
-# gap identified in t2813 root cause analysis: worker logs at
-# /tmp/pulse-${safe_slug}-${issue_number}.log existed but were never read
+# gap identified in t2813 root cause analysis: worker logs in the pulse temp
+# directory existed but were never read
 # during recovery, so every `no_worker_process` event ended with the same
 # opaque "no active worker process" message and no insight into whether the
 # canary failed, the session lock collided, or the runtime crashed before
@@ -2138,19 +2139,21 @@ cleanup_stalled_workers() {
 		issue_num=$(echo "$cmd" | grep -oE 'issue #[0-9]+' | grep -oE '[0-9]+' | head -1)
 		[[ -n "$issue_num" ]] || continue
 
-		local safe_slug log_file log_size
+		local log_file log_size
 		# Check all pulse-enabled repos for matching log
 		local found_log=""
-		for safe_slug in $(jq -r '.initialized_repos[] | select(.pulse == true) | .slug // ""' "$REPOS_JSON" | tr '/:' '--'); do
-			log_file="/tmp/pulse-${safe_slug}-${issue_num}.log"
+		local repo_slug=""
+		while IFS= read -r repo_slug; do
+			[[ -n "$repo_slug" ]] || continue
+			log_file=$(aidevops_pulse_worker_log_path "$repo_slug" "$issue_num" 2>/dev/null || true)
 			if [[ -f "$log_file" ]]; then
 				found_log="$log_file"
 				break
 			fi
-		done
+		done < <(jq -r '.initialized_repos[] | select(.pulse == true) | .slug // ""' "$REPOS_JSON")
 		# Fallback log path
 		if [[ -z "$found_log" ]]; then
-			log_file="/tmp/pulse-${issue_num}.log"
+			log_file=$(aidevops_pulse_worker_log_fallback_path "$issue_num" 2>/dev/null || true)
 			[[ -f "$log_file" ]] && found_log="$log_file"
 		fi
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -2139,7 +2139,7 @@ cleanup_stalled_workers() {
 		issue_num=$(echo "$cmd" | grep -oE 'issue #[0-9]+' | grep -oE '[0-9]+' | head -1)
 		[[ -n "$issue_num" ]] || continue
 
-		local log_file log_size
+		local log_file="" log_size=""
 		# Check all pulse-enabled repos for matching log
 		local found_log=""
 		local repo_slug=""

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -199,12 +199,11 @@ check_worker_launch() {
 		grace_seconds=1
 	fi
 
-	local safe_slug
-	safe_slug=$(echo "$repo_slug" | tr '/:' '--')
-	local -a log_candidates=(
-		"/tmp/pulse-${safe_slug}-${issue_number}.log"
-		"/tmp/pulse-${issue_number}.log"
-	)
+	local -a log_candidates=()
+	local _candidate=""
+	while IFS= read -r _candidate; do
+		[[ -n "$_candidate" ]] && log_candidates+=("$_candidate")
+	done < <(aidevops_pulse_worker_log_candidates "$repo_slug" "$issue_number" 2>/dev/null || true)
 
 	local elapsed=0
 	local poll_seconds=2

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -136,7 +136,7 @@ _dlw_assign_and_label() {
 #######################################
 # Create per-issue worker log files with a shared fallback symlink (GH#14483).
 # The primary log is namespaced by repo_slug + issue_number; the fallback is
-# a plain `/tmp/pulse-{issue}.log` symlink that older validators expect.
+# a plain `pulse-{issue}.log` symlink in the same per-user pulse temp dir.
 #
 # Arguments: repo_slug, issue_number
 # Stdout: absolute path to the primary worker log
@@ -144,10 +144,10 @@ _dlw_assign_and_label() {
 _dlw_setup_worker_log() {
 	local repo_slug="$1"
 	local issue_number="$2"
-	local safe_slug="" worker_log="" worker_log_fallback=""
-	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
-	worker_log="/tmp/pulse-${safe_slug}-${issue_number}.log"
-	worker_log_fallback="/tmp/pulse-${issue_number}.log"
+	local worker_log="" worker_log_fallback=""
+	aidevops_pulse_tmp_cleanup "${AIDEVOPS_PULSE_TMP_MAX_AGE_MINUTES:-2880}" || true
+	worker_log=$(aidevops_pulse_worker_log_path "$repo_slug" "$issue_number") || return 1
+	worker_log_fallback=$(aidevops_pulse_worker_log_fallback_path "$issue_number") || return 1
 	rm -f "$worker_log" "$worker_log_fallback"
 	: >"$worker_log"
 	ln -s "$worker_log" "$worker_log_fallback" 2>/dev/null || true

--- a/.agents/scripts/pulse-issue-reconcile-stale.sh
+++ b/.agents/scripts/pulse-issue-reconcile-stale.sh
@@ -204,9 +204,8 @@ _normalize_stale_should_skip_reset() {
 	fi
 
 	# Check 3: worker log recency — log written in last 10 min means worker may still be active
-	local safe_slug_check
-	safe_slug_check=$(printf '%s' "$slug" | tr '/:' '--')
-	local worker_log="/tmp/pulse-${safe_slug_check}-${stale_num}.log"
+	local worker_log=""
+	worker_log=$(aidevops_pulse_worker_log_path "$slug" "$stale_num" 2>/dev/null || true)
 	if [[ -f "$worker_log" ]]; then
 		local log_mtime
 		log_mtime=$(_file_mtime_epoch "$worker_log")

--- a/.agents/scripts/pulse-temp-helper.sh
+++ b/.agents/scripts/pulse-temp-helper.sh
@@ -21,7 +21,7 @@ aidevops_pulse_tmp_root() {
 		root="${HOME}/.aidevops/.agent-workspace/tmp/pulse"
 	fi
 	mkdir -p "$root" 2>/dev/null || return 1
-	chmod 700 "$root" 2>/dev/null || true
+	chmod 700 "$root" || return 1
 	printf '%s\n' "$root"
 	return 0
 }

--- a/.agents/scripts/pulse-temp-helper.sh
+++ b/.agents/scripts/pulse-temp-helper.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Pulse temporary workspace helpers (t3619).
+# Use a per-user runtime directory for pulse worker scratch/log files. Plain
+# /tmp/pulse-*.log names collide across multiple aidevops users on one server;
+# this helper prefers XDG_RUNTIME_DIR when available and falls back to the
+# aidevops user workspace on macOS, cron, SSH, and headless sessions.
+
+[[ -n "${_PULSE_TEMP_HELPER_LOADED:-}" ]] && return 0
+_PULSE_TEMP_HELPER_LOADED=1
+
+aidevops_pulse_tmp_root() {
+	local root=""
+	if [[ -n "${AIDEVOPS_PULSE_TMP_DIR:-}" ]]; then
+		root="$AIDEVOPS_PULSE_TMP_DIR"
+	elif [[ -n "${XDG_RUNTIME_DIR:-}" && -d "${XDG_RUNTIME_DIR:-}" && -w "${XDG_RUNTIME_DIR:-}" ]]; then
+		root="${XDG_RUNTIME_DIR}/aidevops/pulse"
+	else
+		root="${HOME}/.aidevops/.agent-workspace/tmp/pulse"
+	fi
+	mkdir -p "$root" 2>/dev/null || return 1
+	chmod 700 "$root" 2>/dev/null || true
+	printf '%s\n' "$root"
+	return 0
+}
+
+aidevops_pulse_worker_log_path() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local root="" safe_slug=""
+	root=$(aidevops_pulse_tmp_root) || return 1
+	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
+	printf '%s/pulse-%s-%s.log\n' "$root" "$safe_slug" "$issue_number"
+	return 0
+}
+
+aidevops_pulse_worker_log_fallback_path() {
+	local issue_number="$1"
+	local root=""
+	root=$(aidevops_pulse_tmp_root) || return 1
+	printf '%s/pulse-%s.log\n' "$root" "$issue_number"
+	return 0
+}
+
+aidevops_pulse_worker_log_candidates() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local primary="" fallback=""
+	primary=$(aidevops_pulse_worker_log_path "$repo_slug" "$issue_number") || return 1
+	fallback=$(aidevops_pulse_worker_log_fallback_path "$issue_number") || return 1
+	printf '%s\n%s\n' "$primary" "$fallback"
+	return 0
+}
+
+aidevops_pulse_tmp_cleanup() {
+	local max_age_minutes="${1:-2880}"
+	local root=""
+	[[ "$max_age_minutes" =~ ^[0-9]+$ ]] || max_age_minutes=2880
+	root=$(aidevops_pulse_tmp_root) || return 0
+	# Best-effort cleanup with exact minutes on macOS/Linux. Files currently open
+	# by a worker are normally newer than the age threshold and therefore kept.
+	if command -v python3 >/dev/null 2>&1; then
+		python3 - "$root" "$max_age_minutes" <<'PY' 2>/dev/null || true
+import os
+import sys
+import time
+
+root = sys.argv[1]
+max_age_seconds = int(sys.argv[2]) * 60
+now = time.time()
+for name in os.listdir(root):
+    if not (name.startswith("pulse-") and name.endswith(".log")):
+        continue
+    path = os.path.join(root, name)
+    try:
+        st = os.lstat(path)
+    except OSError:
+        continue
+    if now - st.st_mtime <= max_age_seconds:
+        continue
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+PY
+	fi
+	return 0
+}

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -50,6 +50,13 @@
 [[ -n "${_SHARED_CLAIM_LIFECYCLE_LOADED:-}" ]] && return 0
 _SHARED_CLAIM_LIFECYCLE_LOADED=1
 
+_scl_script_dir="${BASH_SOURCE[0]%/*}"
+if ! declare -F aidevops_pulse_worker_log_candidates >/dev/null 2>&1 && [[ -r "${_scl_script_dir}/shared-constants.sh" ]]; then
+	# shellcheck source=shared-constants.sh
+	source "${_scl_script_dir}/shared-constants.sh"
+fi
+unset _scl_script_dir
+
 #######################################
 # Release the interactive claim for a linked issue after a PR merge.
 #
@@ -357,10 +364,8 @@ _attempt_orphan_recovery_pr() {
 #      to reclassify `worker_failed` events as `no_work` when the log shows the
 #      worker never produced tool calls (Phase 5 / t2820).
 #
-# Locates the worker log by enumerating the same candidate paths
-# `_post_launch_recovery_claim_released` uses:
-#     /tmp/pulse-${safe_slug}-${issue_number}.log
-#     /tmp/pulse-${issue_number}.log
+# Locates the worker log by enumerating the same per-user candidate paths
+# `_post_launch_recovery_claim_released` uses via shared pulse temp helpers.
 #
 # Reads the last 20 lines (capped at 4KB to match Phase 3's bounds — keeps
 # comments readable and limits credential-leak surface). Classifies the tail
@@ -406,12 +411,11 @@ _read_worker_log_tail_classified() {
 
 	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 0
 
-	local safe_slug
-	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
-	local -a log_candidates=(
-		"/tmp/pulse-${safe_slug}-${issue_number}.log"
-		"/tmp/pulse-${issue_number}.log"
-	)
+	local -a log_candidates=()
+	local _candidate=""
+	while IFS= read -r _candidate; do
+		[[ -n "$_candidate" ]] && log_candidates+=("$_candidate")
+	done < <(aidevops_pulse_worker_log_candidates "$repo_slug" "$issue_number" 2>/dev/null || true)
 
 	local log_file=""
 	for log_file in "${log_candidates[@]}"; do

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -979,6 +979,13 @@ suppress_stderr() {
 	return $?
 }
 
+_shared_constants_dir="${BASH_SOURCE[0]%/*}"
+if [[ -r "${_shared_constants_dir}/pulse-temp-helper.sh" ]]; then
+	# shellcheck source=pulse-temp-helper.sh
+	source "${_shared_constants_dir}/pulse-temp-helper.sh"
+fi
+unset _shared_constants_dir
+
 # =============================================================================
 # RETURN Trap Cleanup Stack (t196)
 # =============================================================================

--- a/.agents/scripts/tests/test-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-issue-reconcile.sh
@@ -192,9 +192,7 @@ STUB
 chmod +x "${STUB_DIR}/gh"
 
 # Create a worker log with current timestamp (active guard should fire: < 600s old)
-# slug "owner/testrepo" → tr '/:' '--' → "owner-testrepo"
-SAFE_SLUG="owner-testrepo"
-WORKER_LOG="/tmp/pulse-${SAFE_SLUG}-77.log"
+WORKER_LOG=$(aidevops_pulse_worker_log_path "owner/testrepo" "77")
 touch "$WORKER_LOG"
 
 rm -f "$GH_EDIT_ARGS_FILE"

--- a/.agents/scripts/tests/test-no-work-reclassification.sh
+++ b/.agents/scripts/tests/test-no-work-reclassification.sh
@@ -132,17 +132,16 @@ test_env_override_documented() {
 # shellcheck source=../shared-claim-lifecycle.sh
 source "$SHARED_CLAIM_LIFECYCLE"
 
-# Helper: write a fake log to a fresh /tmp path (the canonical location the
-# reader scans), invoke the reader, capture classification + content.
+# Helper: write a fake log to the per-user pulse temp path the reader scans,
+# invoke the reader, capture classification + content.
 _run_classifier_with_log() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local log_content="$3"
-	local safe_slug
-	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
-	local log_file="/tmp/pulse-${safe_slug}-${issue_number}.log"
+	local log_file=""
+	log_file=$(aidevops_pulse_worker_log_path "$repo_slug" "$issue_number")
 	# Clean any prior fixture
-	rm -f "$log_file" "/tmp/pulse-${issue_number}.log" 2>/dev/null || true
+	rm -f "$log_file" "$(aidevops_pulse_worker_log_fallback_path "$issue_number")" 2>/dev/null || true
 	if [[ -n "$log_content" ]]; then
 		printf '%s\n' "$log_content" >"$log_file"
 	fi
@@ -250,9 +249,8 @@ _log_no_work_skip_escalation() {
 # Fixture with tool-call markers — real_coding → return 1 (no reclass)
 test_reclassify_real_coding_no_op() {
 	: >"$RECLASS_CAPTURE"
-	local safe_slug
-	safe_slug=$(printf '%s' "test/repo-r1" | tr '/:' '--')
-	local log_file="/tmp/pulse-${safe_slug}-91001.log"
+	local log_file=""
+	log_file=$(aidevops_pulse_worker_log_path "test/repo-r1" "91001")
 	printf 'tool_use Edit foo.sh\ngit commit succeeded\n' >"$log_file"
 	# Make the log "young" so the no_tool_calls timing path is irrelevant
 	if _maybe_reclassify_worker_failed_as_no_work 91001 "test/repo-r1" 1 "worker_failed"; then
@@ -274,9 +272,8 @@ test_reclassify_real_coding_no_op() {
 # Fixture with no tool calls + young log → reclass with no_tool_calls_in_log
 test_reclassify_no_tool_calls_fires() {
 	: >"$RECLASS_CAPTURE"
-	local safe_slug
-	safe_slug=$(printf '%s' "test/repo-r2" | tr '/:' '--')
-	local log_file="/tmp/pulse-${safe_slug}-91002.log"
+	local log_file=""
+	log_file=$(aidevops_pulse_worker_log_path "test/repo-r2" "91002")
 	printf 'session init\nwaiting for stream\nconnection refused\n' >"$log_file"
 	# Force a young mtime (now)
 	touch "$log_file"
@@ -299,9 +296,8 @@ test_reclassify_no_tool_calls_fires() {
 # Fixture with canary marker → reclass with canary_post_spawn_failure
 test_reclassify_canary_fires() {
 	: >"$RECLASS_CAPTURE"
-	local safe_slug
-	safe_slug=$(printf '%s' "test/repo-r3" | tr '/:' '--')
-	local log_file="/tmp/pulse-${safe_slug}-91003.log"
+	local log_file=""
+	log_file=$(aidevops_pulse_worker_log_path "test/repo-r3" "91003")
 	printf '[t2814:early_exit] worker PID 12345 exited\ncanary diagnostics\n' >"$log_file"
 	if _maybe_reclassify_worker_failed_as_no_work 91003 "test/repo-r3" 1 "worker_failed"; then
 		if grep -q 'reason=no_work:canary_post_spawn_failure' "$RECLASS_CAPTURE"; then
@@ -321,9 +317,8 @@ test_reclassify_canary_fires() {
 # NO_WORK_RECLASS_ELAPSED_MAX honoured — old log + no_tool_calls → no reclass
 test_reclassify_old_no_tool_calls_skipped() {
 	: >"$RECLASS_CAPTURE"
-	local safe_slug
-	safe_slug=$(printf '%s' "test/repo-r4" | tr '/:' '--')
-	local log_file="/tmp/pulse-${safe_slug}-91004.log"
+	local log_file=""
+	log_file=$(aidevops_pulse_worker_log_path "test/repo-r4" "91004")
 	printf 'session init\nwaiting\n' >"$log_file"
 	# Use a low elapsed-max, then backdate the log to exceed it.
 	local saved_max="$NO_WORK_RECLASS_ELAPSED_MAX"
@@ -351,7 +346,7 @@ test_reclassify_old_no_tool_calls_skipped() {
 test_reclassify_no_log_falls_through() {
 	: >"$RECLASS_CAPTURE"
 	# Ensure no log file exists for this issue
-	rm -f /tmp/pulse-test--repo-r5-91005.log /tmp/pulse-91005.log 2>/dev/null || true
+	rm -f "$(aidevops_pulse_worker_log_path "test/repo-r5" "91005")" "$(aidevops_pulse_worker_log_fallback_path "91005")" 2>/dev/null || true
 	if _maybe_reclassify_worker_failed_as_no_work 91005 "test/repo-r5" 1 "worker_failed"; then
 		print_result "reclass: no log file → fall-through (no regression)" 1 \
 			"Expected return 1 (fall-through) for missing log"
@@ -369,9 +364,8 @@ test_reclassify_no_log_falls_through() {
 # Reasons that should NOT reclassify (rate_limit, etc.)
 test_reclassify_skips_rate_limit() {
 	: >"$RECLASS_CAPTURE"
-	local safe_slug
-	safe_slug=$(printf '%s' "test/repo-r6" | tr '/:' '--')
-	local log_file="/tmp/pulse-${safe_slug}-91006.log"
+	local log_file=""
+	log_file=$(aidevops_pulse_worker_log_path "test/repo-r6" "91006")
 	# Even with a no_tool_calls log, rate_limit should fall through.
 	printf 'session init\nwaiting\n' >"$log_file"
 	touch "$log_file"

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -81,8 +81,7 @@ print_result() {
 # canonical log paths.
 test_claim_released_reads_log() {
 	local shared_lifecycle="${AGENT_SCRIPT_DIR}/shared-claim-lifecycle.sh"
-	# shellcheck disable=SC2016  # literal text in source — no expansion intended
-	if grep -q '/tmp/pulse-\${safe_slug}-\${issue_number}.log' "$shared_lifecycle" \
+	if grep -q 'aidevops_pulse_worker_log_candidates' "$shared_lifecycle" \
 		&& grep -q 'log_candidates=' "$shared_lifecycle" \
 		&& grep -q '_read_worker_log_tail_classified' "$PULSE_CLEANUP"; then
 		print_result "fix #1: _post_launch_recovery_claim_released enumerates worker-log paths" 0

--- a/.agents/scripts/tests/test-pulse-worker-temp-dir.sh
+++ b/.agents/scripts/tests/test-pulse-worker-temp-dir.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+TEST_ROOT=""
+PASS=0
+FAIL=0
+
+setup() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "$HOME"
+	unset AIDEVOPS_PULSE_TMP_DIR
+	unset XDG_RUNTIME_DIR
+	# shellcheck source=../shared-constants.sh
+	source "${SCRIPTS_DIR}/shared-constants.sh"
+	# shellcheck source=../pulse-dispatch-worker-launch.sh
+	source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"
+	return 0
+}
+
+teardown() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT" || true
+	return 0
+}
+
+record() {
+	local name="$1"
+	local rc="$2"
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'ok - %s\n' "$name"
+		PASS=$((PASS + 1))
+	else
+		printf 'not ok - %s\n' "$name"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+test_fallback_home_workspace() {
+	local root=""
+	root=$(aidevops_pulse_tmp_root)
+	[[ "$root" == "${HOME}/.aidevops/.agent-workspace/tmp/pulse" ]] || return 1
+	[[ -d "$root" ]] || return 1
+	return 0
+}
+
+test_xdg_runtime_preferred() {
+	local runtime="${TEST_ROOT}/runtime"
+	local root=""
+	mkdir -p "$runtime"
+	export XDG_RUNTIME_DIR="$runtime"
+	root=$(aidevops_pulse_tmp_root)
+	[[ "$root" == "${runtime}/aidevops/pulse" ]] || return 1
+	return 0
+}
+
+test_override_wins() {
+	local override="${TEST_ROOT}/override-pulse"
+	local root=""
+	export AIDEVOPS_PULSE_TMP_DIR="$override"
+	root=$(aidevops_pulse_tmp_root)
+	[[ "$root" == "$override" ]] || return 1
+	return 0
+}
+
+test_worker_log_setup_uses_per_user_dir() {
+	unset AIDEVOPS_PULSE_TMP_DIR
+	unset XDG_RUNTIME_DIR
+	local worker_log=""
+	local fallback_log=""
+	worker_log=$(_dlw_setup_worker_log "owner/repo" "12345")
+	fallback_log=$(aidevops_pulse_worker_log_fallback_path "12345")
+	[[ "$worker_log" == "${HOME}/.aidevops/.agent-workspace/tmp/pulse/pulse-owner-repo-12345.log" ]] || return 1
+	[[ -f "$worker_log" ]] || return 1
+	[[ -L "$fallback_log" ]] || return 1
+	[[ ! -e "/tmp/pulse-owner-repo-12345.log" ]] || return 1
+	return 0
+}
+
+test_cleanup_removes_only_old_pulse_logs() {
+	local root=""
+	root=$(aidevops_pulse_tmp_root)
+	local old_log="${root}/pulse-old.log"
+	local new_log="${root}/pulse-new.log"
+	local other_file="${root}/not-pulse.log"
+	: >"$old_log"
+	: >"$new_log"
+	: >"$other_file"
+	python3 - "$old_log" <<'PY'
+import os
+import sys
+import time
+old = time.time() - 7200
+os.utime(sys.argv[1], (old, old))
+PY
+	aidevops_pulse_tmp_cleanup 60
+	[[ ! -e "$old_log" ]] || return 1
+	[[ -e "$new_log" ]] || return 1
+	[[ -e "$other_file" ]] || return 1
+	return 0
+}
+
+main() {
+	setup
+	if test_fallback_home_workspace; then record "fallback home pulse tmp" 0; else record "fallback home pulse tmp" 1; fi
+	if test_xdg_runtime_preferred; then record "xdg runtime preferred" 0; else record "xdg runtime preferred" 1; fi
+	if test_override_wins; then record "override wins" 0; else record "override wins" 1; fi
+	if test_worker_log_setup_uses_per_user_dir; then record "worker log setup avoids global tmp" 0; else record "worker log setup avoids global tmp" 1; fi
+	if test_cleanup_removes_only_old_pulse_logs; then record "cleanup removes old pulse logs" 0; else record "cleanup removes old pulse logs" 1; fi
+	teardown
+	printf '\nPassed: %s, Failed: %s\n' "$PASS" "$FAIL"
+	[[ "$FAIL" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Moves pulse worker log files out of shared `/tmp` into a per-user pulse temp directory.
- Adds portable path helpers with `$XDG_RUNTIME_DIR` preference and `~/.aidevops/.agent-workspace/tmp/pulse` fallback for macOS/Linux/headless sessions.
- Updates launch validation, stale assignment guards, cleanup diagnostics, no-work classification, and OpenCode DB active-session scanning to use the shared helper paths.
- Adds regression coverage for path selection, fallback symlink creation, and age-based cleanup.

## Verification
- `bash .agents/scripts/tests/test-pulse-worker-temp-dir.sh`
- `bash .agents/scripts/tests/test-no-worker-process-fix.sh`
- `bash .agents/scripts/tests/test-no-work-reclassification.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh`
- `bash .agents/scripts/tests/test-opencode-db-maintenance.sh`
- `shellcheck .agents/scripts/pulse-temp-helper.sh .agents/scripts/shared-constants.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/shared-claim-lifecycle.sh .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/pulse-issue-reconcile-stale.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/opencode-db-archive.sh .agents/scripts/circuit-breaker-helper.sh .agents/scripts/tests/test-pulse-worker-temp-dir.sh .agents/scripts/tests/test-no-work-reclassification.sh .agents/scripts/tests/test-no-worker-process-fix.sh .agents/scripts/tests/test-issue-reconcile.sh`

## Notes
- This addresses the observed cross-user `/tmp/pulse-*.log` permission collision on a shared server.
- Current local pulse still runs the deployed scripts until this PR is merged and deployed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 11d 20h and 6,353,578 tokens on this with the user in an interactive session.

Ref #24622
