### PR TITLE
m-20260508-0e27c3: harden duplicate PR consolidation safety

### DIFF
--- a/.agents/scripts/pulse-merge-duplicate-consolidation.sh
+++ b/.agents/scripts/pulse-merge-duplicate-consolidation.sh
@@ -10,6 +10,9 @@ _PULSE_MERGE_DUPLICATE_CONSOLIDATION_LOADED=1
 
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
 
+_PMDC_REVIEW_NONE="NONE"
+_PMDC_DRAFT_TRUE="true"
+
 #######################################
 # Return comma-padded label CSV for a PR JSON object.
 #
@@ -111,9 +114,9 @@ _pmp_pr_consolidation_health_score() {
 	local arg_count="$#"
 	local precomputed_pr_number="${3:-}"
 	local precomputed_mergeable="${4:-UNKNOWN}"
-	local precomputed_review="${5:-NONE}"
+	local precomputed_review="${5:-$_PMDC_REVIEW_NONE}"
 	local precomputed_is_draft="${6:-false}"
-	local pr_number="" mergeable="UNKNOWN" review="NONE" is_draft="false" score=0
+	local pr_number="" mergeable="UNKNOWN" review="$_PMDC_REVIEW_NONE" is_draft="false" score=0
 	local parsed_fields=""
 	if [[ "$arg_count" -ge 6 ]]; then
 		pr_number="$precomputed_pr_number"
@@ -130,7 +133,7 @@ _pmp_pr_consolidation_health_score() {
 		if [[ -n "$parsed_fields" ]]; then
 			IFS=$'\t' read -r pr_number mergeable review is_draft <<<"$parsed_fields"
 			[[ -n "$mergeable" ]] || mergeable="UNKNOWN"
-			[[ -n "$review" ]] || review="NONE"
+			[[ -n "$review" ]] || review="$_PMDC_REVIEW_NONE"
 			[[ -n "$is_draft" ]] || is_draft="false"
 		fi
 	fi
@@ -142,8 +145,28 @@ _pmp_pr_consolidation_health_score() {
 	_pmp_normalize_mergeable_for_consolidation_into mergeable "$mergeable" || mergeable="UNKNOWN"
 	[[ "$mergeable" == "MERGEABLE" ]] && score=$((score + 200))
 	[[ "$review" == "APPROVED" ]] && score=$((score + 100))
-	[[ "$is_draft" != "true" ]] && score=$((score + 50))
+	[[ "$is_draft" != "$_PMDC_DRAFT_TRUE" ]] && score=$((score + 50))
 	printf '%s' "$score"
+	return 0
+}
+
+#######################################
+# Check whether the selected duplicate-group candidate is healthy enough to
+# justify closing sibling PRs. Scope verification alone proves issue fit; this
+# guard ensures the kept candidate is also a viable merge candidate.
+#
+# Args: $1 = numeric health score, $2 = isDraft value
+# Returns: 0 healthy candidate, 1 too weak/protected
+#######################################
+_pmp_pr_consolidation_candidate_is_healthy() {
+	local score="$1"
+	local is_draft="$2"
+
+	[[ "$score" =~ ^[0-9]+$ ]] || score=0
+	[[ "$is_draft" != "$_PMDC_DRAFT_TRUE" ]] || return 1
+	# Require either required checks passing, or mergeable+approved+nondraft.
+	# This prevents closing siblings against merely newer unreviewed PRs.
+	[[ "$score" -ge 300 ]] || return 1
 	return 0
 }
 
@@ -185,8 +208,9 @@ _pmp_consolidate_duplicate_pr_group() {
 	local repo_slug="$1"
 	local issue_number="$2"
 	local group_file="$3"
-	local group_count=0 candidate_line="" candidate_pr=""
-	group_count=$(grep -c "^${issue_number}|" "$group_file" 2>/dev/null || true)
+	local group_count=0 candidate_line="" candidate_pr="" candidate_score="" candidate_is_draft=""
+	local group_pattern="^${issue_number}|"
+	group_count=$(grep -c "$group_pattern" "$group_file" 2>/dev/null || true)
 	[[ "$group_count" =~ ^[0-9]+$ ]] || group_count=0
 	[[ "$group_count" -gt 1 ]] || return 0
 
@@ -195,19 +219,25 @@ _pmp_consolidate_duplicate_pr_group() {
 		return 0
 	fi
 
-	candidate_line=$(grep "^${issue_number}|" "$group_file" | sort -t'|' -k3,3nr -k4,4r | head -1) || candidate_line=""
+	candidate_line=$(grep "$group_pattern" "$group_file" | sort -t'|' -k3,3nr -k4,4r | head -1) || candidate_line=""
 	candidate_pr=$(printf '%s' "$candidate_line" | cut -d'|' -f2)
+	candidate_score=$(printf '%s' "$candidate_line" | cut -d'|' -f3)
+	candidate_is_draft=$(printf '%s' "$candidate_line" | cut -d'|' -f5)
 	[[ "$candidate_pr" =~ ^[0-9]+$ ]] || return 0
+	if ! _pmp_pr_consolidation_candidate_is_healthy "$candidate_score" "$candidate_is_draft"; then
+		echo "[pulse-wrapper] Duplicate PR consolidation: candidate PR #${candidate_pr} for issue #${issue_number} is not healthy enough for superseding close — leaving sibling PRs open" >>"$LOGFILE"
+		return 0
+	fi
 	if ! _verify_superseding_pr_for_issue "$issue_number" "$candidate_pr" "$repo_slug"; then
 		echo "[pulse-wrapper] Duplicate PR consolidation: candidate PR #${candidate_pr} for issue #${issue_number} failed verification — leaving sibling PRs open" >>"$LOGFILE"
 		return 0
 	fi
 
-	while IFS='|' read -r _issue pr_number _score _created; do
+	while IFS='|' read -r _issue pr_number _score _created _is_draft; do
 		[[ "$pr_number" =~ ^[0-9]+$ ]] || continue
 		[[ "$pr_number" != "$candidate_pr" ]] || continue
 		_pmp_close_superseded_sibling_pr "$repo_slug" "$issue_number" "$pr_number" "$candidate_pr"
-	done < <(grep "^${issue_number}|" "$group_file")
+	done < <(grep "$group_pattern" "$group_file")
 	return 0
 }
 
@@ -232,7 +262,7 @@ _pmp_consolidate_duplicate_pr_groups() {
 	group_file=$(mktemp 2>/dev/null) || group_file="${TMPDIR:-/tmp}/pulse-duplicate-pr-groups-$$.tmp"
 	: >"$group_file"
 
-	local pr_number="" created_at="" labels_csv="" mergeable="UNKNOWN" review="NONE" is_draft="false" pr_obj="" linked_issue="" score=0
+	local pr_number="" created_at="" labels_csv="" mergeable="UNKNOWN" review="$_PMDC_REVIEW_NONE" is_draft="false" pr_obj="" linked_issue="" score=0
 	while IFS=$'\t' read -r pr_number created_at labels_csv mergeable review is_draft pr_obj; do
 		linked_issue=""
 		score=0
@@ -242,7 +272,7 @@ _pmp_consolidate_duplicate_pr_groups() {
 		linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked_issue=""
 		[[ "$linked_issue" =~ ^[0-9]+$ ]] || continue
 		score=$(_pmp_pr_consolidation_health_score "$repo_slug" "$pr_obj" "$pr_number" "$mergeable" "$review" "$is_draft") || score=0
-		printf '%s|%s|%s|%s\n' "$linked_issue" "$pr_number" "$score" "$created_at" >>"$group_file"
+		printf '%s|%s|%s|%s|%s\n' "$linked_issue" "$pr_number" "$score" "$created_at" "$is_draft" >>"$group_file"
 	done < <(printf '%s' "$pr_json" | jq -r '.[] | [
 		(.number // "" | tostring),
 		(.createdAt // ""),

--- a/.agents/scripts/pulse-merge-duplicate-consolidation.sh
+++ b/.agents/scripts/pulse-merge-duplicate-consolidation.sh
@@ -208,8 +208,8 @@ _pmp_consolidate_duplicate_pr_group() {
 	local repo_slug="$1"
 	local issue_number="$2"
 	local group_file="$3"
-	local group_count=0 candidate_line="" candidate_pr="" candidate_score="" candidate_is_draft=""
-	local group_pattern="^${issue_number}|"
+	local group_count=0 candidate_line="" candidate_pr="" candidate_score="" candidate_is_draft="" _issue="" _created=""
+	local group_pattern="^${issue_number}[|]"
 	group_count=$(grep -c "$group_pattern" "$group_file" 2>/dev/null || true)
 	[[ "$group_count" =~ ^[0-9]+$ ]] || group_count=0
 	[[ "$group_count" -gt 1 ]] || return 0
@@ -220,9 +220,7 @@ _pmp_consolidate_duplicate_pr_group() {
 	fi
 
 	candidate_line=$(grep "$group_pattern" "$group_file" | sort -t'|' -k3,3nr -k4,4r | head -1) || candidate_line=""
-	candidate_pr=$(printf '%s' "$candidate_line" | cut -d'|' -f2)
-	candidate_score=$(printf '%s' "$candidate_line" | cut -d'|' -f3)
-	candidate_is_draft=$(printf '%s' "$candidate_line" | cut -d'|' -f5)
+	IFS='|' read -r _issue candidate_pr candidate_score _created candidate_is_draft <<<"$candidate_line"
 	[[ "$candidate_pr" =~ ^[0-9]+$ ]] || return 0
 	if ! _pmp_pr_consolidation_candidate_is_healthy "$candidate_score" "$candidate_is_draft"; then
 		echo "[pulse-wrapper] Duplicate PR consolidation: candidate PR #${candidate_pr} for issue #${issue_number} is not healthy enough for superseding close — leaving sibling PRs open" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
@@ -54,12 +54,15 @@ teardown_test_env() {
 
 define_functions_under_test() {
 	local fn_src
+	_PMDC_REVIEW_NONE="NONE"
+	_PMDC_DRAFT_TRUE="true"
 	fn_src=$(awk '
 		/^_pmp_pr_label_csv\(\) \{/,/^}$/ { print }
 		/^_pmp_pr_is_worker_owned_for_consolidation\(\) \{/,/^}$/ { print }
 		/^_pmp_normalize_mergeable_for_consolidation_into\(\) \{/,/^}$/ { print }
 		/^_pmp_issue_blocks_pr_consolidation\(\) \{/,/^}$/ { print }
 		/^_pmp_pr_consolidation_health_score\(\) \{/,/^}$/ { print }
+		/^_pmp_pr_consolidation_candidate_is_healthy\(\) \{/,/^}$/ { print }
 		/^_pmp_close_superseded_sibling_pr\(\) \{/,/^}$/ { print }
 		/^_pmp_consolidate_duplicate_pr_group\(\) \{/,/^}$/ { print }
 		/^_pmp_consolidate_duplicate_pr_groups\(\) \{/,/^}$/ { print }
@@ -252,6 +255,38 @@ test_noop_for_untrusted_gated_or_unverified_groups() {
 	return 0
 }
 
+test_noop_when_candidate_is_not_healthy_enough() {
+	reset_case
+	TEST_LINKED_ISSUES=$'601=905\n602=905'
+	local weak_json
+	weak_json='[
+		{"number":601,"mergeable":"UNKNOWN","reviewDecision":"NONE","isDraft":false,"createdAt":"2026-05-08T10:00:00Z","labels":[{"name":"origin:worker"}]},
+		{"number":602,"mergeable":"MERGEABLE","reviewDecision":"NONE","isDraft":false,"createdAt":"2026-05-08T12:00:00Z","labels":[{"name":"origin:worker"}]}
+	]'
+	_pmp_consolidate_duplicate_pr_groups "owner/repo" "$weak_json"
+	assert_log_not_contains "$GH_CALL_LOG" "verify 905 602 owner/repo" "weak candidate is not scope-verified"
+	assert_log_not_contains "$GH_CALL_LOG" "pr close" "weak candidate leaves sibling PRs open"
+	assert_log_contains "$LOGFILE" "not healthy enough" "weak candidate reason is logged"
+	return 0
+}
+
+test_close_is_comment_only_and_keeps_branch() {
+	reset_case
+	TEST_LINKED_ISSUES=$'701=906\n702=906'
+	TEST_PASSING_CHECKS="702"
+	local pr_json
+	pr_json='[
+		{"number":701,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"createdAt":"2026-05-08T10:00:00Z","labels":[{"name":"origin:worker"}]},
+		{"number":702,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"createdAt":"2026-05-08T11:00:00Z","labels":[{"name":"origin:worker"}]}
+	]'
+	_pmp_consolidate_duplicate_pr_groups "owner/repo" "$pr_json"
+	assert_log_contains "$GH_CALL_LOG" "pr close 701" "superseded PR close command is used"
+	assert_log_contains "$GH_CALL_LOG" "--comment" "superseded close carries evidence comment"
+	assert_log_not_contains "$GH_CALL_LOG" "--delete-branch" "superseded close does not delete branches"
+	assert_log_not_contains "$GH_CALL_LOG" "issue close" "superseded duplicate consolidation never closes issues"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -263,6 +298,8 @@ main() {
 	test_health_score_handles_precomputed_legacy_mergeable_values
 	test_health_score_uses_shared_mergeable_normalizer_when_available
 	test_noop_for_untrusted_gated_or_unverified_groups
+	test_noop_when_candidate_is_not_healthy_enough
+	test_close_is_comment_only_and_keeps_branch
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Keep duplicate worker PR consolidation limited to healthy candidates before closing siblings.
- Treat required-check-passing candidates or mergeable+approved+nondraft candidates as eligible, leaving weak/newer candidates open.
- Preserve trust-boundary gates: only worker-owned PRs, no maintainer/security/research issue labels, verify-issue-close-helper scope verification, comment-only PR close, and no branch or issue deletion.

## Testing
- `bash .agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh` → 20/20 PASS
- `bash .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh` → 22/22 PASS
- `shellcheck .agents/scripts/pulse-merge-duplicate-consolidation.sh .agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh` → PASS

Ref m-20260508-0e27c3 feature 2.4.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 135,298 tokens on this as a headless worker.

For #23105