### PR TITLE
GH#24624: guard review-thread dispatch with per-PR lock

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -449,10 +449,12 @@ _prrts_lock_dir() {
 _prrts_write_lock_metadata() {
 	local lock_dir="$1"
 	local now_epoch="$2"
+	local metadata_tmp="${lock_dir}/metadata.$$"
 	{
 		printf 'pid=%s\n' "$$"
 		printf 'created_at=%s\n' "$now_epoch"
-	} >"${lock_dir}/metadata"
+	} >"$metadata_tmp"
+	mv "$metadata_tmp" "${lock_dir}/metadata"
 	return 0
 }
 
@@ -485,22 +487,25 @@ _prrts_acquire_dispatch_lock() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local lock_var="$3"
-	local lock_dir="" now_epoch=""
+	local lock_path="" now_epoch="" stale_rename=""
 	_prrts_ensure_dirs
-	lock_dir="$(_prrts_lock_dir "$repo_slug" "$pr_number")"
+	lock_path="$(_prrts_lock_dir "$repo_slug" "$pr_number")"
 	now_epoch="$(date +%s)"
-	if mkdir "$lock_dir" 2>/dev/null; then
-		_prrts_write_lock_metadata "$lock_dir" "$now_epoch"
-		printf -v "$lock_var" '%s' "$lock_dir"
+	if mkdir "$lock_path" 2>/dev/null; then
+		_prrts_write_lock_metadata "$lock_path" "$now_epoch"
+		printf -v "$lock_var" '%s' "$lock_path"
 		return 0
 	fi
-	if _prrts_lock_is_stale "$lock_dir" "$now_epoch"; then
+	if _prrts_lock_is_stale "$lock_path" "$now_epoch"; then
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} removing stale dispatch lock"
-		_prrts_remove_lock_dir "$lock_dir"
-		if mkdir "$lock_dir" 2>/dev/null; then
-			_prrts_write_lock_metadata "$lock_dir" "$now_epoch"
-			printf -v "$lock_var" '%s' "$lock_dir"
-			return 0
+		stale_rename="${lock_path}.stale.$$"
+		if mv "$lock_path" "$stale_rename"; then
+			_prrts_remove_lock_dir "$stale_rename"
+			if mkdir "$lock_path" 2>/dev/null; then
+				_prrts_write_lock_metadata "$lock_path" "$now_epoch"
+				printf -v "$lock_var" '%s' "$lock_path"
+				return 0
+			fi
 		fi
 	fi
 	_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dispatch lock already held"

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -32,6 +32,8 @@ HEADLESS_RUNTIME_HELPER="${HEADLESS_RUNTIME_HELPER:-${SCRIPT_DIR}/headless-runti
 PR_REVIEW_THREAD_RESPONSE_PR_LIMIT="${PR_REVIEW_THREAD_RESPONSE_PR_LIMIT:-50}"
 PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO="${PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO:-2}"
 PR_REVIEW_THREAD_RESPONSE_COOLDOWN="${PR_REVIEW_THREAD_RESPONSE_COOLDOWN:-3600}"
+PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL="${PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL:-300}"
+PR_REVIEW_THREAD_RESPONSE_LOCK_STALE="${PR_REVIEW_THREAD_RESPONSE_LOCK_STALE:-600}"
 PR_REVIEW_THREAD_RESPONSE_MODEL="${PR_REVIEW_THREAD_RESPONSE_MODEL:-}"
 PR_REVIEW_THREAD_RESPONSE_BOT_RE="${PR_REVIEW_THREAD_RESPONSE_BOT_RE:-coderabbitai|gemini-code-assist|claude-review|gpt-review|augment-code|augmentcode|copilot}"
 PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN="${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN:-false}"
@@ -435,6 +437,76 @@ _prrts_state_file() {
 	return 0
 }
 
+_prrts_lock_dir() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local safe_slug=""
+	safe_slug="$(_prrts_safe_slug "$repo_slug")"
+	printf '%s/%s-%s.lock\n' "$STATE_DIR" "$safe_slug" "$pr_number"
+	return 0
+}
+
+_prrts_write_lock_metadata() {
+	local lock_dir="$1"
+	local now_epoch="$2"
+	{
+		printf 'pid=%s\n' "$$"
+		printf 'created_at=%s\n' "$now_epoch"
+	} >"${lock_dir}/metadata"
+	return 0
+}
+
+_prrts_lock_is_stale() {
+	local lock_dir="$1"
+	local now_epoch="$2"
+	local stale_after="" metadata_file="" created_at="0" key="" value="" age_seconds="0"
+	stale_after="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_LOCK_STALE" "600" "60")"
+	metadata_file="${lock_dir}/metadata"
+	[[ -f "$metadata_file" ]] || return 1
+	while IFS='=' read -r key value; do
+		case "$key" in
+		created_at) created_at="$value" ;;
+		esac
+	done <"$metadata_file"
+	[[ "$created_at" =~ ^[0-9]+$ ]] || return 1
+	age_seconds=$((now_epoch - created_at))
+	[[ "$age_seconds" -ge "$stale_after" ]]
+	return $?
+}
+
+_prrts_remove_lock_dir() {
+	local lock_dir="$1"
+	[[ -n "$lock_dir" && "$lock_dir" == "${STATE_DIR}/"* && -d "$lock_dir" ]] || return 0
+	rm -rf "$lock_dir"
+	return 0
+}
+
+_prrts_acquire_dispatch_lock() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local lock_var="$3"
+	local lock_dir="" now_epoch=""
+	_prrts_ensure_dirs
+	lock_dir="$(_prrts_lock_dir "$repo_slug" "$pr_number")"
+	now_epoch="$(date +%s)"
+	if mkdir "$lock_dir" 2>/dev/null; then
+		_prrts_write_lock_metadata "$lock_dir" "$now_epoch"
+		printf -v "$lock_var" '%s' "$lock_dir"
+		return 0
+	fi
+	if _prrts_lock_is_stale "$lock_dir" "$now_epoch"; then
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} removing stale dispatch lock"
+		_prrts_remove_lock_dir "$lock_dir"
+		if mkdir "$lock_dir" 2>/dev/null; then
+			_prrts_write_lock_metadata "$lock_dir" "$now_epoch"
+			printf -v "$lock_var" '%s' "$lock_dir"
+			return 0
+		fi
+	fi
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dispatch lock already held"
+	return 1
+}
+
 _prrts_session_key() {
 	local repo_slug="$1"
 	local pr_number="$2"
@@ -482,9 +554,10 @@ _prrts_should_dispatch() {
 	local pr_number="$2"
 	local fingerprint="$3"
 	local now_epoch="$4"
-	local state_file="" last_fingerprint="" dispatched_at="0" cooldown="" age_seconds="0"
+	local state_file="" last_fingerprint="" dispatched_at="0" cooldown="" inflight_ttl="" age_seconds="0"
 	state_file="$(_prrts_state_file "$repo_slug" "$pr_number")"
 	cooldown="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_COOLDOWN" "3600" "60")"
+	inflight_ttl="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL" "300" "1")"
 	_prrts_read_state "$state_file" last_fingerprint dispatched_at
 
 	if _prrts_worker_active "$repo_slug" "$pr_number"; then
@@ -492,6 +565,10 @@ _prrts_should_dispatch() {
 		return 1
 	fi
 	age_seconds=$((now_epoch - dispatched_at))
+	if [[ "$dispatched_at" -gt 0 && "$age_seconds" -lt "$inflight_ttl" ]]; then
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dispatch state active ${age_seconds}s ago"
+		return 1
+	fi
 	if [[ "$fingerprint" == "$last_fingerprint" && "$age_seconds" -lt "$cooldown" ]]; then
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — same thread fingerprint dispatched ${age_seconds}s ago"
 		return 1
@@ -601,6 +678,46 @@ _prrts_dispatch_worker() {
 	return 0
 }
 
+_prrts_dispatch_guarded() {
+	local repo_slug="$1"
+	local repo_path="$2"
+	local pr_number="$3"
+	local title="$4"
+	local thread_count="$5"
+	local fingerprint="$6"
+	local preview="$7"
+	local now_epoch="$8"
+	local dry_run="$9"
+	local dispatch_mode="${10}"
+	local head_ref="${11:-}"
+	local author="${12:-}"
+	local lock_dir=""
+	if ! _prrts_acquire_dispatch_lock "$repo_slug" "$pr_number" lock_dir; then
+		return 1
+	fi
+	if ! _prrts_should_dispatch "$repo_slug" "$pr_number" "$fingerprint" "$now_epoch"; then
+		_prrts_remove_lock_dir "$lock_dir"
+		return 1
+	fi
+	if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
+		printf 'DRY-RUN would dispatch %s#%s (%s unresolved thread(s))\n' "$repo_slug" "$pr_number" "$thread_count"
+		if [[ "$dispatch_mode" == "dispatch-pr" ]]; then
+			_prrts_log "dry-run: would dispatch targeted ${repo_slug}#${pr_number} (${thread_count} unresolved thread(s), include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN})"
+		else
+			_prrts_log "dry-run: would dispatch ${repo_slug}#${pr_number} (${thread_count} unresolved thread(s), head=${head_ref}, author=${author})"
+		fi
+		_prrts_remove_lock_dir "$lock_dir"
+		return 0
+	fi
+	if ! _prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$preview"; then
+		_prrts_remove_lock_dir "$lock_dir"
+		return 1
+	fi
+	_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch"
+	_prrts_remove_lock_dir "$lock_dir"
+	return 0
+}
+
 _prrts_dispatch_repo() {
 	local repo_slug="$1"
 	local repo_path="$2"
@@ -623,17 +740,9 @@ _prrts_dispatch_repo() {
 	while IFS=$'\t' read -r pr_number thread_count fingerprint title head_ref author preview; do
 		[[ -n "$pr_number" ]] || continue
 		[[ "$dispatched" -lt "$max_per_repo" ]] || break
-		if ! _prrts_should_dispatch "$repo_slug" "$pr_number" "$fingerprint" "$now_epoch"; then
-			continue
+		if _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$now_epoch" "$dry_run" "dispatch" "$head_ref" "$author"; then
+			dispatched=$((dispatched + 1))
 		fi
-		if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
-			printf 'DRY-RUN would dispatch %s#%s (%s unresolved thread(s))\n' "$repo_slug" "$pr_number" "$thread_count"
-			_prrts_log "dry-run: would dispatch ${repo_slug}#${pr_number} (${thread_count} unresolved thread(s), head=${head_ref}, author=${author})"
-		else
-			_prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$preview" || continue
-			_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch"
-		fi
-		dispatched=$((dispatched + 1))
 	done <<<"$candidates"
 	_prrts_log "dispatch: ${repo_slug} completed, dispatched=${dispatched}, dry_run=${dry_run}"
 	return 0
@@ -666,17 +775,11 @@ _prrts_dispatch_pr() {
 	}
 	now_epoch="$(date +%s)"
 	IFS=$'\t' read -r pr_number thread_count fingerprint title head_ref author preview <<<"$candidate"
-	if ! _prrts_should_dispatch "$repo_slug" "$pr_number" "$fingerprint" "$now_epoch"; then
-		return 0
+	if _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$now_epoch" "$dry_run" "dispatch-pr" "$head_ref" "$author"; then
+		if [[ "$dry_run" != "$PRRTS_BOOL_TRUE" ]]; then
+			_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} completed, dispatched=1, include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN}"
+		fi
 	fi
-	if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
-		printf 'DRY-RUN would dispatch %s#%s (%s unresolved thread(s))\n' "$repo_slug" "$pr_number" "$thread_count"
-		_prrts_log "dry-run: would dispatch targeted ${repo_slug}#${pr_number} (${thread_count} unresolved thread(s), include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN})"
-		return 0
-	fi
-	_prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$preview" || return 0
-	_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch"
-	_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} completed, dispatched=1, include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -269,6 +269,40 @@ test_dispatch_is_idempotent_for_same_fingerprint() {
 	return 0
 }
 
+test_dispatch_skips_mixed_fingerprint_during_inflight_window() {
+	setup_test_env
+	export STUB_THREADS_MODE="human"
+	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true $SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
+	wait_for_headless_log || true
+	: >"$HEADLESS_LOG"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	if [[ ! -s "$HEADLESS_LOG" ]]; then
+		print_result "dispatch skips mixed fingerprint during in-flight window" 0
+	else
+		print_result "dispatch skips mixed fingerprint during in-flight window" 1 "mixed fingerprint dispatch unexpectedly launched"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_pr_skips_when_pr_lock_held() {
+	setup_test_env
+	local lock_dir="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.lock"
+	mkdir -p "$lock_dir"
+	{
+		printf 'pid=%s\n' "$$"
+		printf 'created_at=%s\n' "$(date +%s)"
+	} >"${lock_dir}/metadata"
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
+	if [[ ! -s "$HEADLESS_LOG" ]]; then
+		print_result "dispatch-pr skips when repo PR lock is held" 0
+	else
+		print_result "dispatch-pr skips when repo PR lock is held" 1 "lock-held dispatch unexpectedly launched"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_reply_and_resolve_use_graphql_mutations() {
 	setup_test_env
 	local body_file="${TEST_ROOT}/reply.md"
@@ -378,6 +412,8 @@ main() {
 	test_dispatch_launches_worker_and_writes_state
 	test_dispatch_pr_launches_targeted_worker_with_human_opt_in
 	test_dispatch_is_idempotent_for_same_fingerprint
+	test_dispatch_skips_mixed_fingerprint_during_inflight_window
+	test_dispatch_pr_skips_when_pr_lock_held
 	test_reply_and_resolve_use_graphql_mutations
 	test_reply_auto_prepends_thread_author
 	test_reply_does_not_double_prepend_thread_author

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -303,6 +303,28 @@ test_dispatch_pr_skips_when_pr_lock_held() {
 	return 0
 }
 
+test_dispatch_pr_reclaims_stale_lock() {
+	setup_test_env
+	local lock_dir="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.lock"
+	local old_epoch=""
+	old_epoch="$(($(date +%s) - 120))"
+	mkdir -p "$lock_dir"
+	{
+		printf 'pid=%s\n' "999999"
+		printf 'created_at=%s\n' "$old_epoch"
+	} >"${lock_dir}/metadata"
+	PR_REVIEW_THREAD_RESPONSE_LOCK_STALE=60 $SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	if [[ -s "$HEADLESS_LOG" && -f "$state_file" && ! -d "$lock_dir" ]]; then
+		print_result "dispatch-pr reclaims stale repo PR lock" 0
+	else
+		print_result "dispatch-pr reclaims stale repo PR lock" 1 "headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=${state_file}, lock_dir=${lock_dir}"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_reply_and_resolve_use_graphql_mutations() {
 	setup_test_env
 	local body_file="${TEST_ROOT}/reply.md"
@@ -414,6 +436,7 @@ main() {
 	test_dispatch_is_idempotent_for_same_fingerprint
 	test_dispatch_skips_mixed_fingerprint_during_inflight_window
 	test_dispatch_pr_skips_when_pr_lock_held
+	test_dispatch_pr_reclaims_stale_lock
 	test_reply_and_resolve_use_graphql_mutations
 	test_reply_auto_prepends_thread_author
 	test_reply_does_not_double_prepend_thread_author


### PR DESCRIPTION
## Summary

Adds a repo+PR keyed mkdir lock around review-thread worker eligibility, launch, and state publication, plus a short in-flight state TTL so mixed dispatch/dispatch-pr fingerprints cannot duplicate workers immediately.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh,.agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pr-review-thread-response-scanner.sh: 15 passed, 0 failed; shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh: passed; git diff --check: passed; .agents/scripts/linters-local.sh: ALL LOCAL CHECKS PASSED (with pre-existing advisory reports).

Resolves #24624


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 35m and 233,563 tokens on this with the user in an interactive session.