### PR TITLE
GH#24620: Extend pulse-merge systemd timeout

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -404,6 +404,9 @@ _install_pulse_merge_routine_linux() {
 	local pmr_script="$1"
 	local _pmr_log_dir="$2"
 	local pmr_systemd="aidevops-pulse-merge"
+	# Keep systemd above pulse-merge-routine.sh's default 600s watchdog so
+	# the script reaches its own timeout/cleanup path before systemd stops it.
+	local pmr_timeout_sec="660"
 
 	# One-time migration: remove legacy systemd/cron entry for aidevops-pulse-merge-routine.
 	if _systemd_user_available 2>/dev/null; then
@@ -427,7 +430,9 @@ _install_pulse_merge_routine_linux() {
 		"Pulse merge pass enabled (every 60s via pulse-merge-routine.sh)" \
 		"Failed to install pulse merge pass scheduler" \
 		"true" \
-		"true"
+		"true" \
+		"" \
+		"${pmr_timeout_sec}"
 	return 0
 }
 

--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -34,6 +34,11 @@ _systemd_user_available() {
 	return 0
 }
 
+uname() {
+	printf 'Linux\n'
+	return 0
+}
+
 systemctl() {
 	local scope="${1:-}"
 	local action="${2:-}"
@@ -64,6 +69,10 @@ WRAPPER_SCRIPT="$HOME/.aidevops/agents/scripts/pulse-wrapper.sh"
 touch "$WRAPPER_SCRIPT"
 chmod +x "$WRAPPER_SCRIPT"
 
+PMR_SCRIPT="$HOME/.aidevops/agents/scripts/pulse-merge-routine.sh"
+touch "$PMR_SCRIPT"
+chmod +x "$PMR_SCRIPT"
+
 # shellcheck source=.agents/scripts/setup/modules/schedulers.sh
 source "$SCHEDULERS_SCRIPT"
 
@@ -73,6 +82,11 @@ _scheduler_detect_installed() {
 }
 
 _systemd_user_available() {
+	return 0
+}
+
+_resolve_log_dir() {
+	printf '%s' "$HOME/.aidevops/logs"
 	return 0
 }
 
@@ -140,3 +154,20 @@ if ! grep -qE '^Environment=OPENCODE_BIN=' "$SERVICE_FILE"; then
 fi
 
 printf 'PASS %s\n' "GH#18439 Bug 2 OPENCODE_BIN propagated to Linux systemd service"
+
+setup_pulse_merge_routine
+
+PMR_SERVICE_FILE="$HOME/.config/systemd/user/aidevops-pulse-merge.service"
+PMR_TIMER_FILE="$HOME/.config/systemd/user/aidevops-pulse-merge.timer"
+
+if ! grep -q '^TimeoutStartSec=660$' "$PMR_SERVICE_FILE"; then
+	echo "expected pulse-merge TimeoutStartSec=660 in ${PMR_SERVICE_FILE}" >&2
+	exit 1
+fi
+
+if ! grep -q '^OnUnitActiveSec=60$' "$PMR_TIMER_FILE"; then
+	echo "expected pulse-merge OnUnitActiveSec=60 in ${PMR_TIMER_FILE}" >&2
+	exit 1
+fi
+
+printf 'PASS %s\n' "pulse-merge systemd timeout exceeds routine watchdog with 60s cadence"


### PR DESCRIPTION
## Summary

Sets the Linux pulse-merge systemd TimeoutStartSec to 660s so the routine can reach its 600s watchdog plus grace, while preserving the 60s cadence.

## Files Changed

.agents/scripts/setup/modules/schedulers-platform.sh,tests/test-pulse-systemd-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-pulse-systemd-timeout.sh; shellcheck .agents/scripts/setup/modules/schedulers-platform.sh tests/test-pulse-systemd-timeout.sh; .agents/scripts/linters-local.sh

Resolves #24620


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 36m and 167,334 tokens on this with the user in an interactive session.