### PR TITLE
GH#24631: fix pulse PR gates on contributor repos

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -44,6 +44,31 @@ _PULSE_MERGE_GATES_LOADED=1
 # --- Functions ---
 
 #######################################
+# Confirm PR gate helpers may write GitHub issue/PR state for this repo.
+# #aidevops:trust-boundary — contributor/read-only repos are external
+# observation targets. Pulse must never comment, label, close, approve, or
+# impose aidevops maintainer-gate policy on repos it does not manage.
+# Args: $1=repo_slug, $2=gate_name
+# Returns: 0=write actions allowed, 1=blocked/fail-closed.
+#######################################
+_pulse_repo_allows_pr_gate_writes() {
+	local repo_slug="$1"
+	local gate_name="$2"
+
+	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1; then
+		echo "[pulse-wrapper] ${gate_name}: repo write-action guard unavailable for ${repo_slug} — skipping PR gate write (fail closed)" >>"$LOGFILE"
+		return 1
+	fi
+
+	if ! repo_allows_pulse_write_actions "$repo_slug"; then
+		echo "[pulse-wrapper] ${gate_name}: skipping PR gate writes in ${repo_slug} — repo role is contributor/read-only" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+#######################################
 # Resolve the trusted Dependabot update allowlist path.
 # Output: config path
 # Returns: 0 always
@@ -222,10 +247,11 @@ _trusted_dependabot_non_review_checks_green() {
 # Exit codes:
 #   0 - already flagged (label or comment exists) — no action needed
 #   1 - not yet flagged AND API calls succeeded — caller should post
-#   2 - API error (fail closed) — caller must skip, next pulse retries
+#   2 - API/role-guard error (fail closed) — caller must skip
 #
 # Side effects when exit=1 (caller invokes with --post):
-#   Posts the external-contributor comment and adds the label.
+#   Posts the external-contributor comment and adds the label, but only for
+#   repos where repo_allows_pulse_write_actions confirms maintainer ownership.
 #######################################
 check_external_contributor_pr() {
 	local pr_number="$1"
@@ -236,6 +262,9 @@ check_external_contributor_pr() {
 	# Validate arguments
 	if [[ -z "$pr_number" || -z "$repo_slug" || -z "$pr_author" ]]; then
 		echo "[pulse-wrapper] check_external_contributor_pr: missing arguments" >>"$LOGFILE"
+		return 2
+	fi
+	if ! _pulse_repo_allows_pr_gate_writes "$repo_slug" "check_external_contributor_pr"; then
 		return 2
 	fi
 
@@ -533,7 +562,7 @@ _pulse_merge_admin_safety_check() {
 #
 # Exit codes:
 #   0 - comment already exists or was just posted
-#   2 - API error checking for existing comment (fail closed, skip)
+#   2 - API/role-guard error checking for existing comment (fail closed, skip)
 #######################################
 check_permission_failure_pr() {
 	local pr_number="$1"
@@ -543,6 +572,9 @@ check_permission_failure_pr() {
 
 	if [[ -z "$pr_number" || -z "$repo_slug" || -z "$pr_author" ]]; then
 		echo "[pulse-wrapper] check_permission_failure_pr: missing arguments" >>"$LOGFILE"
+		return 2
+	fi
+	if ! _pulse_repo_allows_pr_gate_writes "$repo_slug" "check_permission_failure_pr"; then
 		return 2
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-gates-role-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-gates-role-guard.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pulse-merge-gates-role-guard.sh — external repo write guard tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+GH_CALLS=0
+COMMENT_CALLS=0
+
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	return 0
+}
+
+teardown_sandbox() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+assert_eq() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_log_contains() {
+	local description="$1"
+	local pattern="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qF "$pattern" "$LOGFILE"; then
+		printf 'PASS %s\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s (missing pattern=%s)\n' "$description" "$pattern"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+gh() {
+	GH_CALLS=$((GH_CALLS + 1))
+	printf 'gh must not be called for contributor/read-only repo gate tests\n' >&2
+	return 99
+}
+
+gh_pr_comment() {
+	COMMENT_CALLS=$((COMMENT_CALLS + 1))
+	printf 'gh_pr_comment must not be called for contributor/read-only repo gate tests\n' >&2
+	return 99
+}
+
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	[[ "$repo_slug" == "alice/owned-repo" ]]
+	return $?
+}
+
+_extract_linked_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	: "$pr_number" "$repo_slug"
+	return 1
+}
+
+setup_sandbox
+trap teardown_sandbox EXIT
+
+# shellcheck source=../pulse-merge-gates.sh
+source "${PARENT_DIR}/pulse-merge-gates.sh"
+
+rc=0
+check_external_contributor_pr "123" "bob/external-repo" "repo-owner" "--post" || rc=$?
+assert_eq "external contributor gate fails closed for contributor repo" "2" "$rc"
+assert_eq "external contributor gate does not call gh" "0" "$GH_CALLS"
+assert_eq "external contributor gate does not comment" "0" "$COMMENT_CALLS"
+assert_log_contains \
+	"external contributor gate logs contributor/read-only skip" \
+	"check_external_contributor_pr: skipping PR gate writes in bob/external-repo — repo role is contributor/read-only"
+
+rc=0
+check_permission_failure_pr "123" "bob/external-repo" "repo-owner" "404" || rc=$?
+assert_eq "permission failure gate fails closed for contributor repo" "2" "$rc"
+assert_eq "permission failure gate does not call gh" "0" "$GH_CALLS"
+assert_eq "permission failure gate does not comment" "0" "$COMMENT_CALLS"
+assert_log_contains \
+	"permission failure gate logs contributor/read-only skip" \
+	"check_permission_failure_pr: skipping PR gate writes in bob/external-repo — repo role is contributor/read-only"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -205,9 +205,11 @@ Output a brief summary of total actions taken across all cycles (past tense).
 
 ## PRs — Merge, Fix, or Flag
 
-### Pre-merge checks (MANDATORY for every PR)
+### Pre-merge checks (MANDATORY for every PR in write-authorized managed repos)
 
-1. **External contributor gate.** `check_external_contributor_pr` / `check_permission_failure_pr` from `pulse-wrapper.sh`. NEVER auto-merge external PRs.
+For repos where `repo_allows_pulse_write_actions SLUG` fails (role=`contributor`/read-only), observe only: never comment, label, approve, close, merge, dispatch, or apply aidevops maintainer-gate policy.
+
+1. **External contributor gate.** On write-authorized managed repos only, use `check_external_contributor_pr` / `check_permission_failure_pr` from `pulse-wrapper.sh`. NEVER auto-merge external PRs.
 
 2. **Maintainer review gate.** If ANY linked issue has `needs-maintainer-review`, do NOT merge.
 


### PR DESCRIPTION
## Summary

- adds a trust-boundary guard before pulse PR gate helpers can write GitHub state
- blocks external-contributor and permission-failure comments/labels on contributor/read-only repos
- documents contributor repos as observe-only in the pulse workflow
- adds regression coverage proving no `gh` calls or comments occur for contributor repos

Resolves #24631

## Verification

- `shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/tests/test-pulse-merge-gates-role-guard.sh`
- `bash .agents/scripts/tests/test-pulse-merge-gates-role-guard.sh`
- `bash .agents/scripts/tests/test-repo-role-guard.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh`
- `.agents/scripts/linters-local.sh` started and passed targeted early gates; it timed out during shell portability at 300s, so targeted guard verification above is the release gate evidence for this fix.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.45 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1h 14m and 706,343 tokens on this with the user in an interactive session.