### PR TITLE
GH#24640: test: harden pulse timeout uname mock

### DIFF
--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -35,8 +35,15 @@ _systemd_user_available() {
 }
 
 uname() {
-	printf 'Linux\n'
-	return 0
+	local flag="${1:-}"
+
+	if [[ -z "$flag" || "$flag" == "-s" ]]; then
+		printf 'Linux\n'
+		return 0
+	fi
+
+	command uname "$@"
+	return $?
 }
 
 systemctl() {


### PR DESCRIPTION
## Summary

Hardened the pulse systemd timeout test's uname mock so it only forces Linux for OS-name requests and delegates other uname flags to the system command.

## Files Changed

tests/test-pulse-systemd-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck tests/test-pulse-systemd-timeout.sh; bash tests/test-pulse-systemd-timeout.sh

Resolves #24640


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 92,461 tokens on this as a headless worker.