### PR TITLE
GH#24644: fix pulse cadence diagnostics

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -1791,8 +1791,13 @@ _api_budget_timer_summary() {
 	local raw_line="" timer_key="" timer_value=""
 	while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
 		[[ "$raw_line" == *=* ]] || continue
+		[[ "$raw_line" =~ ^[[:space:]]*[#\;] ]] && continue
 		timer_key="${raw_line%%=*}"
+		timer_key="${timer_key#"${timer_key%%[![:space:]]*}"}"
+		timer_key="${timer_key%"${timer_key##*[![:space:]]}"}"
 		timer_value="${raw_line#*=}"
+		timer_value="${timer_value#"${timer_value%%[![:space:]]*}"}"
+		timer_value="${timer_value%"${timer_value##*[![:space:]]}"}"
 		timer_value=$(printf '%s' "$timer_value" | tr -c 'A-Za-z0-9:.,_@* -' '_')
 		[[ -n "$timer_value" ]] || timer_value="empty"
 		case "$timer_key" in
@@ -1824,11 +1829,17 @@ _api_budget_cycle_counts_csv() {
 		printf 'cycles=0 lock_skips=0 cache_enabled_cycles=0'
 		return 0
 	fi
-	local cycles=0 lock_skips=0 cache_cycles=0
-	cycles=$(_api_budget_log_count "$logfile" 'REST-first read routing enabled|Deterministic merge pass complete|Per-cycle PR view cache enabled')
-	lock_skips=$(_api_budget_log_count "$logfile" 'LLM session already running|Pulse already running|Lock verification failed|Lost mkdir lock race|skipping.*lock held')
-	cache_cycles=$(_api_budget_log_count "$logfile" 'Per-cycle PR view cache enabled')
-	printf 'cycles=%s lock_skips=%s cache_enabled_cycles=%s' "$cycles" "$lock_skips" "$cache_cycles"
+	awk '
+		{
+			line = tolower($0)
+			if (line ~ /rest-first read routing enabled|deterministic merge pass complete|per-cycle pr view cache enabled/) cycles++
+			if (line ~ /llm session already running|pulse already running|lock verification failed|lost mkdir lock race|skipping.*lock held/) lock_skips++
+			if (line ~ /per-cycle pr view cache enabled/) cache_cycles++
+		}
+		END {
+			printf "cycles=%d lock_skips=%d cache_enabled_cycles=%d", cycles + 0, lock_skips + 0, cache_cycles + 0
+		}
+	' "$logfile"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -112,9 +112,10 @@ cat > "$FIXTURE_TIMER" <<'TIMER'
 Description=aidevops supervisor pulse Timer
 
 [Timer]
-OnActiveSec=10s
+ ; Leading comment with an equals sign should be ignored: ignored=yes
+OnActiveSec = 10s
 OnBootSec=180s
-OnUnitActiveSec=180s
+OnUnitActiveSec = 180s
 Persistent=true
 TIMER
 


### PR DESCRIPTION
## Summary

- Harden systemd timer parsing in pulse API budget diagnostics by ignoring commented key/value lines and trimming whitespace around keys and values before matching.
- Replace three log scans for cadence counts with one awk pass that preserves case-insensitive pattern matching.
- Extend the pulse diagnose regression fixture to cover spaced systemd timer assignments.

Resolves #24644

## Testing

- shellcheck .agents/scripts/pulse-diagnose-helper.sh .agents/scripts/tests/test-pulse-diagnose-helper.sh
- .agents/scripts/tests/test-pulse-diagnose-helper.sh
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 151,413 tokens on this as a headless worker.