### PR TITLE
GH#24638: fix: harden pulse PR gate guard logging

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -55,13 +55,13 @@ _pulse_repo_allows_pr_gate_writes() {
 	local repo_slug="$1"
 	local gate_name="$2"
 
-	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1; then
-		echo "[pulse-wrapper] ${gate_name}: repo write-action guard unavailable for ${repo_slug} — skipping PR gate write (fail closed)" >>"$LOGFILE"
+	if ! command -v repo_allows_pulse_write_actions >/dev/null; then
+		echo "[pulse-wrapper] ${gate_name}: repo write-action guard unavailable for ${repo_slug} — skipping PR gate write (fail closed)" >>"$LOGFILE" || true
 		return 1
 	fi
 
 	if ! repo_allows_pulse_write_actions "$repo_slug"; then
-		echo "[pulse-wrapper] ${gate_name}: skipping PR gate writes in ${repo_slug} — repo role is contributor/read-only" >>"$LOGFILE"
+		echo "[pulse-wrapper] ${gate_name}: skipping PR gate writes in ${repo_slug} — repo role is contributor/read-only" >>"$LOGFILE" || true
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-merge-gates.sh so the PR gate write guard uses command -v for helper detection and treats LOGFILE append failures as non-fatal while still failing closed.

## Files Changed

.agents/scripts/pulse-merge-gates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/tests/test-pulse-merge-gates-role-guard.sh; bash .agents/scripts/tests/test-pulse-merge-gates-role-guard.sh

Resolves #24638


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 1m and 104,234 tokens on this as a headless worker.