### PR TITLE
GH#24645: fix: harden OpenCode DB maintenance parsing

### DIFF
--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -270,11 +270,17 @@ _state_json_field() {
 _freelist_exceeds_threshold() {
 	local freelist_count="$1"
 	local page_count="$2"
+	[[ "$freelist_count" =~ ^[0-9]+$ ]] || return 1
+	[[ "$page_count" =~ ^[0-9]+$ ]] || return 1
+	[[ "$VACUUM_FREELIST_THRESHOLD" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
 	[[ "$page_count" -gt 0 ]] || return 1
-	local pct_num pct_threshold
-	pct_num=$((freelist_count * 100))
-	pct_threshold=$(awk "BEGIN {printf \"%d\", (${VACUUM_FREELIST_THRESHOLD}) * 100}")
-	if [[ $((pct_num / page_count)) -ge "$pct_threshold" ]]; then
+	local threshold_met
+	threshold_met=$(awk \
+		-v free="$freelist_count" \
+		-v pages="$page_count" \
+		-v threshold="$VACUUM_FREELIST_THRESHOLD" \
+		'BEGIN { if (pages <= 0) { print 0; exit } print ((free / pages) >= threshold) ? 1 : 0 }')
+	if [[ "$threshold_met" -eq 1 ]]; then
 		return 0
 	fi
 	return 1
@@ -710,6 +716,10 @@ cmd_report() {
 	page_count=$(_pragma "$OPENCODE_DB" "$PRAGMA_PAGE_COUNT")
 	page_size=$(_pragma "$OPENCODE_DB" "page_size")
 	freelist_count=$(_pragma "$OPENCODE_DB" "$PRAGMA_FREELIST_COUNT")
+	if [[ ! "$page_count" =~ ^[0-9]+$ || ! "$freelist_count" =~ ^[0-9]+$ ]]; then
+		print_error "Unable to read SQLite page counts from $OPENCODE_DB"
+		return 1
+	fi
 
 	local freelist_pct=0
 	if [[ "$page_count" -gt 0 ]]; then

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -273,8 +273,8 @@ _freelist_exceeds_threshold() {
 	[[ "$freelist_count" =~ ^[0-9]+$ && "$page_count" =~ ^[0-9]+$ && "$VACUUM_FREELIST_THRESHOLD" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
 	[[ "$page_count" -gt 0 ]] || return 1
 	local threshold_met
-	threshold_met=$(awk -v free="$freelist_count" -v pages="$page_count" -v threshold="$VACUUM_FREELIST_THRESHOLD" 'BEGIN { if (pages <= 0) { print 0; exit } print ((free / pages) >= threshold) ? 1 : 0 }')
-	if [[ "$threshold_met" -eq 1 ]]; then
+	threshold_met=$(awk -v free="$freelist_count" -v pages="$page_count" -v threshold="$VACUUM_FREELIST_THRESHOLD" 'BEGIN { if (pages <= 0) { print 0; exit } print ((free / pages) >= threshold) ? 1 : 0 }' </dev/null)
+	if [[ "$threshold_met" == "1" ]]; then
 		return 0
 	fi
 	return 1
@@ -710,8 +710,8 @@ cmd_report() {
 	page_count=$(_pragma "$OPENCODE_DB" "$PRAGMA_PAGE_COUNT")
 	page_size=$(_pragma "$OPENCODE_DB" "page_size")
 	freelist_count=$(_pragma "$OPENCODE_DB" "$PRAGMA_FREELIST_COUNT")
-	if [[ ! "$page_count" =~ ^[0-9]+$ || ! "$freelist_count" =~ ^[0-9]+$ ]]; then
-		print_error "Unable to read SQLite page counts from $OPENCODE_DB"; return 1
+	if [[ ! "$page_count" =~ ^[0-9]+$ || ! "$freelist_count" =~ ^[0-9]+$ || ! "$page_size" =~ ^[0-9]+$ ]]; then
+		print_error "Unable to read SQLite page counts or page size from $OPENCODE_DB"; return 1
 	fi
 
 	local freelist_pct=0

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -270,16 +270,10 @@ _state_json_field() {
 _freelist_exceeds_threshold() {
 	local freelist_count="$1"
 	local page_count="$2"
-	[[ "$freelist_count" =~ ^[0-9]+$ ]] || return 1
-	[[ "$page_count" =~ ^[0-9]+$ ]] || return 1
-	[[ "$VACUUM_FREELIST_THRESHOLD" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+	[[ "$freelist_count" =~ ^[0-9]+$ && "$page_count" =~ ^[0-9]+$ && "$VACUUM_FREELIST_THRESHOLD" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
 	[[ "$page_count" -gt 0 ]] || return 1
 	local threshold_met
-	threshold_met=$(awk \
-		-v free="$freelist_count" \
-		-v pages="$page_count" \
-		-v threshold="$VACUUM_FREELIST_THRESHOLD" \
-		'BEGIN { if (pages <= 0) { print 0; exit } print ((free / pages) >= threshold) ? 1 : 0 }')
+	threshold_met=$(awk -v free="$freelist_count" -v pages="$page_count" -v threshold="$VACUUM_FREELIST_THRESHOLD" 'BEGIN { if (pages <= 0) { print 0; exit } print ((free / pages) >= threshold) ? 1 : 0 }')
 	if [[ "$threshold_met" -eq 1 ]]; then
 		return 0
 	fi
@@ -717,8 +711,7 @@ cmd_report() {
 	page_size=$(_pragma "$OPENCODE_DB" "page_size")
 	freelist_count=$(_pragma "$OPENCODE_DB" "$PRAGMA_FREELIST_COUNT")
 	if [[ ! "$page_count" =~ ^[0-9]+$ || ! "$freelist_count" =~ ^[0-9]+$ ]]; then
-		print_error "Unable to read SQLite page counts from $OPENCODE_DB"
-		return 1
+		print_error "Unable to read SQLite page counts from $OPENCODE_DB"; return 1
 	fi
 
 	local freelist_pct=0

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -433,6 +433,22 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Test 15: threshold parsing does not execute awk code from environment
+# -----------------------------------------------------------------------------
+
+injection_marker="$SANDBOX/awk-threshold-injection"
+threshold_payload="0); system(\"touch ${injection_marker}\"); (0"
+set +e
+out=$(VACUUM_FREELIST_THRESHOLD="$threshold_payload" FORCE_VACUUM_SIZE_MB=0 WAL_LARGE_THRESHOLD_MB=999 _run_helper notice 2>&1)
+rc=$?
+set -e
+if [[ ! -e "$injection_marker" ]]; then
+	_pass "freelist threshold environment value is not executable awk code"
+else
+	_fail "freelist threshold environment value executed code (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Harden `_freelist_exceeds_threshold` so `VACUUM_FREELIST_THRESHOLD` is validated and passed to awk with `-v` instead of interpolated code.
- Guard `cmd_report` SQLite page-count/page-size values before numeric comparisons.
- Add a regression test proving threshold environment payloads are not executable awk code.

## Verification
- `bash .agents/scripts/tests/test-opencode-db-maintenance.sh` — 23 passed, 0 failed
- `shellcheck .agents/scripts/opencode-db-maintenance-helper.sh .agents/scripts/tests/test-opencode-db-maintenance.sh`
- `git diff --check origin/main...HEAD`

Resolves #24645
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 20m and 333,894 tokens on this as a headless worker.