### PR TITLE
GH#24637: preserve OpenCode OAuth for AI research

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -296,12 +296,12 @@ call_opencode() {
 	wrapped_prompt="You are a non-interactive AI research helper. Do not use tools. Do not ask follow-up questions. Do not greet. Return only the requested answer text, with no preamble or markdown. Task:\n${prompt}"
 
 	if [[ -n "$timeout_cmd" ]]; then
-		raw=$(cd "$run_dir" && $timeout_cmd opencode run --pure --format json -m "$model_id" "$wrapped_prompt" 2>&1) || {
+		raw=$(cd "$run_dir" && AIDEVOPS_HEADLESS=1 $timeout_cmd opencode run --format json -m "$model_id" "$wrapped_prompt" 2>&1) || {
 			log_error "OpenCode AI research call failed"
 			return 1
 		}
 	else
-		raw=$(cd "$run_dir" && opencode run --pure --format json -m "$model_id" "$wrapped_prompt" 2>&1) || {
+		raw=$(cd "$run_dir" && AIDEVOPS_HEADLESS=1 opencode run --format json -m "$model_id" "$wrapped_prompt" 2>&1) || {
 			log_error "OpenCode AI research call failed"
 			return 1
 		}

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -130,6 +130,16 @@ test_auto_provider_prefers_opencode() {
 	rm -f "${HOME}/.aidevops/oauth-pool.json"
 	cat >"${TEST_ROOT}/bin/opencode" <<'STUB'
 #!/usr/bin/env bash
+if [[ "${AIDEVOPS_HEADLESS:-}" != "1" ]]; then
+	printf 'missing AIDEVOPS_HEADLESS=1\n' >&2
+	exit 43
+fi
+for arg in "$@"; do
+	if [[ "$arg" == "--pure" ]]; then
+		printf 'unexpected --pure flag\n' >&2
+		exit 44
+	fi
+done
 printf '%s\n' '> Build+ · gpt-5.4-mini'
 printf '%s\n' 'VERDICT: YES - opencode primary works'
 exit 0
@@ -151,10 +161,10 @@ STUB
 	unset ANTHROPIC_API_KEY
 	set -e
 	if [[ "$rc" -eq 0 && "$output" == "VERDICT: YES - opencode primary works" ]]; then
-		record_result "auto provider prefers OpenCode runtime even when Anthropic is configured" 0
+		record_result "auto provider uses OpenCode headless without pure mode" 0
 		return 0
 	fi
-	record_result "auto provider prefers OpenCode runtime even when Anthropic is configured" 1 \
+	record_result "auto provider uses OpenCode headless without pure mode" 1 \
 		"rc=${rc} output=${output} err=$(tr '\n' ' ' <"${TEST_ROOT}/auto-provider.err")"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Remove `--pure` from `opencode run` in `.agents/scripts/ai-research-helper.sh` so OAuth/plugin auth remains available.
- Set `AIDEVOPS_HEADLESS=1` for both timed and untimed OpenCode AI research calls to keep non-interactive behaviour.
- Extend the OAuth regression test stub to fail if `--pure` is passed or `AIDEVOPS_HEADLESS=1` is missing.

Resolves #24637

## Verification

- `bash .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh` — 6 passed, 0 failed
- `shellcheck .agents/scripts/ai-research-helper.sh .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh` — passed
- `.agents/scripts/linters-local.sh` — non-terminal before completion: first run timed out at 120s during Secretlint; second run passed SonarCloud, Secretlint, TOON, skill frontmatter, and secret policy, reported pre-existing advisory Markdown/Qlty findings, then timed out at 300s during ratchet `missing_return_files`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.17.2 with gpt-5.5 spent 23m and 81,114 tokens on this with the user in an interactive session.
