### PR TITLE
GH#24636: fix OpenAI OAuth fallback verification

### DIFF
--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -472,6 +472,34 @@ _probe_allows_oauth_fallback_after_rejected_key() {
 	return 0
 }
 
+_probe_openai_oauth_fallback_verified() {
+	local auth_file="$1"
+
+	[[ -f "$auth_file" ]] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+
+	# OpenAI ChatGPT OAuth is usable by the runtime when auth.json contains a
+	# refresh token, or a still-live access token. Do not treat openai.type ==
+	# "oauth" alone as provider health after a rejected static key (GH#24636).
+	local has_refresh
+	has_refresh=$(jq -r '.openai.refresh // empty' "$auth_file" 2>/dev/null) || has_refresh=""
+	if [[ -n "$has_refresh" ]]; then
+		return 0
+	fi
+
+	local access_token expires_ms now_ms
+	access_token=$(jq -r '.openai.access // empty' "$auth_file" 2>/dev/null) || access_token=""
+	expires_ms=$(jq -r '.openai.expires // empty' "$auth_file" 2>/dev/null) || expires_ms=""
+	if [[ -n "$access_token" && "$expires_ms" =~ ^[0-9]+$ ]]; then
+		now_ms=$(($(date +%s) * 1000))
+		if [[ "$expires_ms" -gt "$now_ms" ]]; then
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
 # _probe_check_oauth_fallback: called when an HTTP probe rejected the resolved
 # key with exit code 3 (HTTP 401/403). Checks whether auth.json has an OAuth
 # entry for the provider and whether the runtime path can actually prefer that
@@ -498,6 +526,10 @@ _probe_check_oauth_fallback() {
 	local auth_type
 	auth_type=$(jq -r --arg p "$provider" '.[$p].type // empty' "$auth_file" 2>/dev/null) || auth_type=""
 	if [[ "$auth_type" == "oauth" ]]; then
+		if [[ "$provider" == openai ]] && ! _probe_openai_oauth_fallback_verified "$auth_file"; then
+			[[ "$quiet" != "true" ]] && print_warning "$provider: env key rejected (HTTP 401/403); OpenAI OAuth in auth.json is not refreshable or currently valid"
+			return 3
+		fi
 		[[ "$quiet" != "true" ]] && print_success "$provider: env key rejected (HTTP 401/403) but OAuth found in auth.json — recording healthy (t3229)"
 		_record_health "$provider" "healthy" 0 0 "OAuth available (env key rejected, t3229)" 0
 		return 0

--- a/.agents/scripts/tests/test-model-availability-oauth-probe.sh
+++ b/.agents/scripts/tests/test-model-availability-oauth-probe.sh
@@ -237,6 +237,46 @@ else
 fi
 unset OPENAI_API_KEY
 
+# Assertion 4b.2 — OpenAI OAuth fallback must not mark healthy from type alone.
+# GH#24636: after a rejected static key, openai.type == "oauth" in auth.json is
+# insufficient unless the runtime has a refresh token or currently-live access.
+cat >"$AUTH_FILE" <<JSON
+{
+  "openai": {
+    "type": "oauth"
+  }
+}
+JSON
+_probe_check_oauth_fallback openai true "gopass:OPENAI_API_KEY"
+rc=$?
+if [[ "$rc" -eq 3 ]]; then
+	print_result "openai-oauth-type-only: fallback fails closed (GH#24636)" 0
+else
+	print_result "openai-oauth-type-only: fallback fails closed (GH#24636)" 1 \
+		"(got rc=$rc — expected 3; type-only auth.json must not record healthy)"
+fi
+
+# Assertion 4b.3 — A currently-live OpenAI OAuth access token is usable even
+# without refresh, preserving runtime-compatible OAuth fallback when verified.
+future_ms=$(($(date +%s) * 1000 + 3600000))
+cat >"$AUTH_FILE" <<JSON
+{
+  "openai": {
+    "type": "oauth",
+    "access": "fake-openai-live-access-token",
+    "expires": ${future_ms}
+  }
+}
+JSON
+_probe_check_oauth_fallback openai true "gopass:OPENAI_API_KEY"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result "openai-oauth-live-access: verified fallback remains healthy" 0
+else
+	print_result "openai-oauth-live-access: verified fallback remains healthy" 1 \
+		"(got rc=$rc — expected 0; live OAuth access should remain eligible)"
+fi
+
 # Assertion 4c — no OAuth in auth.json → fallback returns 3 (no override).
 rm -f "$AUTH_FILE"
 _probe_check_oauth_fallback openai true


### PR DESCRIPTION
## Summary
- require OpenAI OAuth fallback to have a refresh token or still-live access token before recording provider health after a rejected static key
- keep env-key rejection fail-closed behavior for OpenAI built-in provider paths
- add GH#24636 regression coverage for type-only auth.json entries and live-access OAuth fallback

## Verification
- `bash .agents/scripts/tests/test-model-availability-oauth-probe.sh` — 16 tests, 0 failed
- `shellcheck .agents/scripts/model-availability-probe-lib.sh .agents/scripts/tests/test-model-availability-oauth-probe.sh`
- `.agents/scripts/linters-local.sh` — ALL LOCAL CHECKS PASSED

Resolves #24636
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.46 plugin for [OpenCode](https://opencode.ai) v1.17.2 with gpt-5.5 spent 26m and 174,115 tokens on this with the user in an interactive session.