### PR TITLE
fix: refresh unknown mergeable before conflict handling

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -835,6 +835,19 @@ _process_single_ready_pr() {
 		return 1
 	fi
 
+	# REST-first PR lists cannot preserve GraphQL-only mergeable state, so a
+	# truly conflicting PR may enter this function as UNKNOWN. Refresh that
+	# value before the CONFLICTING branch; otherwise the later non-MERGEABLE
+	# skip makes conflict remediation unreachable (GH#24634).
+	if [[ "$pr_mergeable" == UNKNOWN || -z "$pr_mergeable" ]]; then
+		local _pre_conflict_mergeable _pre_conflict_exit
+		_pre_conflict_mergeable=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json mergeable --jq '.mergeable // ""')
+		_pre_conflict_exit=$?
+		[[ $_pre_conflict_exit -eq 0 && -n "$_pre_conflict_mergeable" ]] && pr_mergeable="$_pre_conflict_mergeable" || pr_mergeable=UNKNOWN
+		_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
+	fi
+
 	# CONFLICTING handling (t2116): before closing, attempt to salvage the
 	# PR via `gh pr update-branch` which fast-forwards the base branch into
 	# the PR's branch when the conflict is purely due to base advancement

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -840,7 +840,7 @@ _process_single_ready_pr() {
 	# value before the CONFLICTING branch; otherwise the later non-MERGEABLE
 	# skip makes conflict remediation unreachable (GH#24634).
 	if [[ "$pr_mergeable" == UNKNOWN || -z "$pr_mergeable" ]]; then
-		local _pre_conflict_mergeable _pre_conflict_exit
+		local _pre_conflict_mergeable="" _pre_conflict_exit=0
 		_pre_conflict_mergeable=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json mergeable --jq '.mergeable // ""')
 		_pre_conflict_exit=$?

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -12,6 +12,8 @@
 #      `needs-maintainer-review` — verified indirectly via a smoke test that
 #      drives `_process_single_ready_pr` through a mocked `gh` binary and
 #      asserts the close path is NOT taken.
+#   4. GH#24634: UNKNOWN mergeable is refreshed before the CONFLICTING branch
+#      so REST-first list metadata cannot make conflict remediation unreachable.
 #
 # Mock pattern follows test-pulse-merge-rebase-nudge.sh: extract the helper
 # source from the real pulse-merge.sh via awk, eval it into the test shell,
@@ -407,6 +409,39 @@ test_mergeable_refetch_after_update_branch() {
 	return 0
 }
 
+test_unknown_mergeable_refreshed_before_conflict_handler() {
+	local function_src refresh_pos conflict_pos
+	function_src=$(awk '
+		/^_process_single_ready_pr\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^\}$/ { exit }
+	' "$MERGE_SCRIPT")
+
+	refresh_pos=$(printf '%s\n' "$function_src" | awk '/GH#24634/ { print NR; exit }')
+	conflict_pos=$(printf '%s\n' "$function_src" | awk '/if \[\[ "\$pr_mergeable" == "CONFLICTING"/ { print NR; exit }')
+
+	if [[ -z "$refresh_pos" || -z "$conflict_pos" ]]; then
+		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
+			"Expected GH#24634 refresh and CONFLICTING branch in _process_single_ready_pr (refresh=${refresh_pos}, conflict=${conflict_pos})"
+		return 0
+	fi
+
+	if [[ "$refresh_pos" -ge "$conflict_pos" ]]; then
+		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
+			"Refresh must run before CONFLICTING branch (refresh=${refresh_pos}, conflict=${conflict_pos})"
+		return 0
+	fi
+
+	if [[ "$function_src" != *"AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view"* || "$function_src" != *"_pmp_normalize_mergeable_state_into pr_mergeable"* ]]; then
+		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
+			"Refresh must bypass stale PR-view cache and normalize into pr_mergeable"
+		return 0
+	fi
+
+	print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -426,6 +461,7 @@ main() {
 	test_nmr_guard_exists_before_close
 	test_stale_route_runs_before_protected_precheck
 	test_mergeable_refetch_after_update_branch
+	test_unknown_mergeable_refreshed_before_conflict_handler
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Refresh `UNKNOWN` PR mergeability before the `CONFLICTING` branch in `_process_single_ready_pr`
- Preserve existing conflict remediation flow so REST-first list metadata cannot skip update-branch/close routing
- Add a regression check that the GH#24634 refresh happens before conflict handling

Resolves #24634

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-update-branch.sh` — 11/11 passed
- `bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh` — 60/60 passed
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-update-branch.sh` — passed
- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh` — 5/5 passed
- `.agents/scripts/linters-local.sh` — passed; advisory markdown/ratchet/complexity debt unchanged, focused canary rerun passed after one infrastructure timeout warning

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.47 plugin for [OpenCode](https://opencode.ai) v1.17.2 with gpt-5.5 spent 36m and 246,167 tokens on this with the user in an interactive session.
