### PR TITLE
GH#24656: handle stale gh pr merge 401 cache

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -40,6 +40,12 @@ fi
 # shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
 source "${SCRIPT_DIR}/shared-phase-filing.sh"
 
+# Targeted remediation for stale GitHub CLI HTTP cache entries that can make
+# `gh pr merge` return a cached 401 even after live gh auth succeeds (GH#24656).
+# shellcheck source=./gh-merge-cache-remediation-lib.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/gh-merge-cache-remediation-lib.sh"
+
 # --- Repo Resolution ---
 
 # _merge_resolve_repo — resolve repo slug from argument or auto-detect from git remote.
@@ -315,6 +321,20 @@ _merge_execute() {
 		_merge_rc=0
 	else
 		_merge_rc=$?
+	fi
+	if [[ $_merge_rc -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$_merge_out" "full-loop PR #${pr_number} in ${repo}" ""; then
+		local _merge_retry_out="" _merge_original_out="$_merge_out"
+		print_info "gh pr merge returned 401 while live gh auth succeeds; quarantined stale gh cache entries and retrying once..."
+		if _merge_retry_out=$(gh pr merge "$pr_number" --repo "$repo" "$merge_method" ${merge_flags[@]+"${merge_flags[@]}"} 2>&1); then
+			_merge_out="$_merge_retry_out"
+			_merge_rc=0
+		else
+			_merge_rc=$?
+			_merge_out="${_merge_original_out}
+
+[retry after stale gh cache remediation]
+${_merge_retry_out}"
+		fi
 	fi
 
 	if [[ $_merge_rc -ne 0 ]]; then

--- a/.agents/scripts/gh-merge-cache-remediation-lib.sh
+++ b/.agents/scripts/gh-merge-cache-remediation-lib.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# gh-merge-cache-remediation-lib.sh — targeted remediation for stale gh HTTP 401 cache entries.
+
+[[ -n "${_GH_MERGE_CACHE_REMEDIATION_LIB_LOADED:-}" ]] && return 0
+_GH_MERGE_CACHE_REMEDIATION_LIB_LOADED=1
+
+gh_merge_output_is_auth_401() {
+	local merge_output="$1"
+
+	printf '%s' "$merge_output" | grep -qiE '(^|[^0-9])(401)([^0-9]|$)|401 Unauthorized|Requires authentication'
+	return $?
+}
+
+gh_merge_live_auth_probe_ok() {
+	gh api user >/dev/null 2>&1
+	return $?
+}
+
+gh_merge_cache_quarantine_dir() {
+	local cache_root="${GH_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/gh}"
+	local stamp=""
+
+	stamp=$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || date '+%Y%m%dT%H%M%S')
+	printf '%s/aidevops-quarantine-%s' "$cache_root" "$stamp"
+	return 0
+}
+
+gh_merge_cache_file_has_stale_auth_401() {
+	local cache_file="$1"
+
+	[[ -f "$cache_file" ]] || return 1
+	grep -Iq . "$cache_file" 2>/dev/null || return 1
+	grep -qiE '401 Unauthorized|Requires authentication|"message"[[:space:]]*:[[:space:]]*"Requires authentication"' "$cache_file" 2>/dev/null || return 1
+	grep -qiE 'api\.github\.com|graphql|GraphQL|X-Gh-Cache-Ttl|Requires authentication' "$cache_file" 2>/dev/null || return 1
+	return 0
+}
+
+gh_merge_quarantine_stale_auth_cache() {
+	local cache_root="${GH_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/gh}"
+	local quarantine_dir=""
+	local cache_file=""
+	local base_name=""
+	local moved=0
+
+	[[ -d "$cache_root" ]] || return 1
+	quarantine_dir=$(gh_merge_cache_quarantine_dir)
+
+	while IFS= read -r cache_file; do
+		[[ -n "$cache_file" ]] || continue
+		case "$cache_file" in
+		"$cache_root"/aidevops-quarantine-*) continue ;;
+		esac
+		if gh_merge_cache_file_has_stale_auth_401 "$cache_file"; then
+			mkdir -p "$quarantine_dir" || return 1
+			base_name=$(basename "$cache_file")
+			if mv "$cache_file" "${quarantine_dir}/${base_name}.$$" 2>/dev/null; then
+				moved=$((moved + 1))
+			fi
+		fi
+	done < <(find "$cache_root" -type f -print 2>/dev/null)
+
+	[[ "$moved" -gt 0 ]] || return 1
+	printf '%s\n' "$moved"
+	return 0
+}
+
+gh_merge_remediate_stale_auth_cache() {
+	local merge_output="$1"
+	local context="${2:-gh pr merge}"
+	local log_file="${3:-}"
+	local moved=""
+
+	gh_merge_output_is_auth_401 "$merge_output" || return 1
+	if ! gh_merge_live_auth_probe_ok; then
+		[[ -n "$log_file" ]] && printf '[gh-merge-cache] %s: live gh api user probe failed; treating 401 as current auth failure\n' "$context" >>"$log_file"
+		return 1
+	fi
+
+	if ! moved=$(gh_merge_quarantine_stale_auth_cache); then
+		[[ -n "$log_file" ]] && printf '[gh-merge-cache] %s: live auth succeeded, but no stale gh HTTP 401 cache entries were quarantined\n' "$context" >>"$log_file"
+		return 1
+	fi
+
+	if [[ -n "$log_file" ]]; then
+		printf '[gh-merge-cache] %s: live auth succeeded; quarantined %s stale gh HTTP 401 cache file(s); retrying gh pr merge once\n' "$context" "$moved" >>"$log_file"
+	fi
+	return 0
+}

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -159,6 +159,12 @@ source "${_PULSE_MERGE_DIR}/shared-dispatch-label-cleanup.sh"
 # shellcheck source=pr-supersession-helper.sh
 source "${_PULSE_MERGE_DIR}/pr-supersession-helper.sh"
 
+# Targeted remediation for stale GitHub CLI HTTP cache entries that can make
+# `gh pr merge` return a cached 401 even after live gh auth succeeds (GH#24656).
+# shellcheck source=gh-merge-cache-remediation-lib.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via _PULSE_MERGE_DIR
+source "${_PULSE_MERGE_DIR}/gh-merge-cache-remediation-lib.sh"
+
 readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
 
 # Source author permission check helpers (GH#21426 — extracted to bring
@@ -1033,6 +1039,17 @@ _process_single_ready_pr() {
 	local merge_output="" _merge_exit=0 _auto_merge_output="" _auto_merge_exit=0
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)
 	_merge_exit=$?
+	if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
+		local _merge_original_output="$merge_output"
+		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)
+		_merge_exit=$?
+		if [[ $_merge_exit -ne 0 ]]; then
+			merge_output="${_merge_original_output}
+
+[retry after stale gh cache remediation]
+${merge_output}"
+		fi
+	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
 		_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)
@@ -1044,6 +1061,17 @@ _process_single_ready_pr() {
 		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash 2>&1)
 		_merge_exit=$?
+		if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse direct merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
+			local _direct_merge_original_output="$merge_output"
+			merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash 2>&1)
+			_merge_exit=$?
+			if [[ $_merge_exit -ne 0 ]]; then
+				merge_output="${_direct_merge_original_output}
+
+[retry after stale gh cache remediation]
+${merge_output}"
+			fi
+		fi
 	fi
 
 	# Rate-limit: 1 second between merges to avoid GitHub API abuse

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -82,6 +82,7 @@ teardown_test_env() {
 #   $4 = "graphql-rate-limit" — gh pr merge fails with GraphQL quota, REST succeeds
 #   $5 = "graphql-rate-limit-rest-fail" — gh pr merge fails with GraphQL quota, REST fails
 #   $6 = "fallback-nmr" — branch protection fails, but linked issue still needs maintainer review
+#   $7 = "stale-cache-401" — first gh pr merge returns cached 401, live auth succeeds, retry succeeds
 create_gh_stub() {
 	local mode="$1"
 
@@ -92,7 +93,24 @@ _gh_cmd="\$1"
 _gh_sub="\$2"
 echo "gh \$*" >> "${TEST_ROOT}/logs/gh-calls.txt"
 
+_merge_count_file="${TEST_ROOT}/logs/merge-count.txt"
+
 if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
+	if [[ "$mode" == "stale-cache-401" ]]; then
+		_merge_count=0
+		if [[ -f "\$_merge_count_file" ]]; then
+			_merge_count=\$(cat "\$_merge_count_file")
+		fi
+		_merge_count=\$((_merge_count + 1))
+		printf '%s\n' "\$_merge_count" >"\$_merge_count_file"
+		if [[ "\$_merge_count" -eq 1 ]]; then
+			echo 'non-200 OK status code: 401 Unauthorized body: "{ \"message\": \"Requires authentication\" }"' >&2
+			exit 1
+		fi
+		echo "Merged PR after cache remediation"
+		exit 0
+	fi
+
 	# Check if --admin flag is present
 	_gh_has_admin=0
 	for _gh_arg in "\$@"; do
@@ -157,6 +175,10 @@ fi
 
 if [[ "\$_gh_cmd" == "api" ]]; then
 	echo "gh api \$*" >> "${TEST_ROOT}/logs/gh-api-calls.txt"
+	if [[ "\$*" == "user" ]]; then
+		echo '{"login":"tester"}'
+		exit 0
+	fi
 	if [[ "\$*" == *"repos/testorg/testrepo/pulls/42/merge"* ]]; then
 		if [[ "$mode" == "graphql-rate-limit-rest-fail" ]]; then
 			echo "REST merge failed" >&2
@@ -220,6 +242,7 @@ RUNNER_EOF
 	# Run in a subprocess with our stubs on PATH
 	local rc=0
 	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
+		HOME="${TEST_ROOT}/home" \
 		AIDEVOPS_MODEL="test-model" \
 		bash "$tmp_runner" 2>&1 || rc=$?
 	rm -f "$tmp_runner"
@@ -251,6 +274,7 @@ RUNNER_EOF
 
 	local rc=0
 	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
+		HOME="${TEST_ROOT}/home" \
 		AIDEVOPS_MODEL="test-model" \
 		bash "$tmp_runner" 2>&1 || rc=$?
 	rm -f "$tmp_runner"
@@ -470,6 +494,45 @@ test_review_gate_failure_blocks_rest_fallback() {
 	return 0
 }
 
+# Test 8: cached gh HTTP 401 is quarantined and gh pr merge is retried once.
+test_stale_cache_401_retry() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	rm -rf "${TEST_ROOT:?}/home"
+	mkdir -p "${TEST_ROOT}/home/.cache/gh"
+	cat >"${TEST_ROOT}/home/.cache/gh/graphql-401.cache" <<'CACHE'
+HTTP/2.0 401 Unauthorized
+X-Gh-Cache-Ttl: 24h0m0s
+{"message":"Requires authentication","documentation_url":"https://docs.github.com/graphql"}
+CACHE
+	cat >"${TEST_ROOT}/home/.cache/gh/healthy.cache" <<'CACHE'
+HTTP/2.0 200 OK
+{"data":{"viewer":{"login":"tester"}}}
+CACHE
+
+	create_gh_stub "stale-cache-401"
+
+	local exit_code=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "0" "0" >/dev/null 2>&1 || exit_code=$?
+	print_result "stale gh cache 401: retry succeeds" "$exit_code"
+
+	local merge_count="0"
+	[[ -f "${TEST_ROOT}/logs/merge-count.txt" ]] && merge_count=$(cat "${TEST_ROOT}/logs/merge-count.txt")
+	print_result "stale gh cache 401: gh pr merge called exactly twice" "$((merge_count == 2 ? 0 : 1))" "merge_count=${merge_count}"
+
+	local stale_quarantined=0
+	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql-401.cache" ]] && \
+		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/*graphql-401.cache*' -type f | grep -q .; then
+		stale_quarantined=1
+	fi
+	print_result "stale gh cache 401: only matching 401 cache quarantined" "$((1 - stale_quarantined))"
+
+	local healthy_preserved=0
+	[[ -f "${TEST_ROOT}/home/.cache/gh/healthy.cache" ]] && healthy_preserved=1
+	print_result "stale gh cache 401: healthy cache preserved" "$((1 - healthy_preserved))"
+
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -485,6 +548,7 @@ main() {
 	test_graphql_rate_limit_cmd_merge_phase_autofile
 	test_graphql_rate_limit_auto_no_rest_fallback
 	test_review_gate_failure_blocks_rest_fallback
+	test_stale_cache_401_retry
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -43,15 +43,38 @@ setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export GH_STUB_MODE="${GH_STUB_MODE:-ruleset}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
 
-	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+mode="${GH_STUB_MODE:-ruleset}"
+
+if [[ "$1" == "api" && "${2:-}" == "user" ]]; then
+	printf '%s\n' '{"login":"tester"}'
+	exit 0
+fi
+
+if [[ "$mode" == "stale-cache-401" && "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
+	count_file="${TEST_ROOT}/merge-count.txt"
+	count=0
+	if [[ -f "$count_file" ]]; then
+		count=$(cat "$count_file")
+	fi
+	count=$((count + 1))
+	printf '%s\n' "$count" >"$count_file"
+	if [[ "$count" -eq 1 ]]; then
+		printf '%s\n' 'non-200 OK status code: 401 Unauthorized body: "{ \"message\": \"Requires authentication\" }"' >&2
+		exit 1
+	fi
+	exit 0
+fi
 
 if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
 	printf '%s\n' 'GraphQL: Repository rule violations found' >&2
@@ -90,6 +113,8 @@ define_function_under_test() {
 		return 1
 	fi
 	# shellcheck disable=SC1090
+	source "${SCRIPT_DIR}/../gh-merge-cache-remediation-lib.sh"
+	# shellcheck disable=SC1090
 	eval "$src_process"
 	return 0
 }
@@ -113,6 +138,21 @@ _pulse_merge_admin_safety_check() { return 0; }
 _set_native_auto_merge_or_skip() { return 1; }
 _handle_post_merge_actions() { return 0; }
 gh_pr_view() { printf '{"labels":[]}'; return 0; }
+
+prepare_stale_cache_fixture() {
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.cache/gh"
+	cat >"${HOME}/.cache/gh/graphql-401.cache" <<'CACHE'
+HTTP/2.0 401 Unauthorized
+X-Gh-Cache-Ttl: 24h0m0s
+{"message":"Requires authentication","documentation_url":"https://docs.github.com/graphql"}
+CACHE
+	cat >"${HOME}/.cache/gh/healthy.cache" <<'CACHE'
+HTTP/2.0 200 OK
+{"data":{"viewer":{"login":"tester"}}}
+CACHE
+	return 0
+}
 
 test_ruleset_violation_enables_auto_merge_without_admin() {
 	setup_test_env
@@ -153,6 +193,7 @@ test_ruleset_violation_enables_auto_merge_without_admin() {
 }
 
 test_draft_pr_without_origin_labels_skips_merge_write() {
+	unset GH_STUB_MODE
 	setup_test_env
 	define_function_under_test || { teardown_test_env; return 0; }
 
@@ -180,9 +221,64 @@ test_draft_pr_without_origin_labels_skips_merge_write() {
 	return 0
 }
 
+test_stale_cache_401_retries_admin_merge_once() {
+	GH_STUB_MODE="stale-cache-401"
+	setup_test_env
+	prepare_stale_cache_fixture
+	define_function_under_test || { teardown_test_env; unset GH_STUB_MODE; return 0; }
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "stale cache 401 retries admin merge" 1 "Expected 0, got ${result}; log: $(cat "$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	local merge_count="0"
+	[[ -f "${TEST_ROOT}/merge-count.txt" ]] && merge_count=$(cat "${TEST_ROOT}/merge-count.txt")
+	if [[ "$merge_count" != "2" ]]; then
+		print_result "stale cache 401 retries admin merge exactly once" 1 "merge_count=${merge_count}; gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	if [[ -f "${HOME}/.cache/gh/graphql-401.cache" ]] || \
+		! find "${HOME}/.cache/gh" -path '*/aidevops-quarantine-*/*graphql-401.cache*' -type f | grep -q .; then
+		print_result "stale cache 401 quarantines only matching cache file" 1 "cache remediation did not quarantine stale 401 file"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	if [[ ! -f "${HOME}/.cache/gh/healthy.cache" ]]; then
+		print_result "stale cache 401 preserves healthy cache file" 1 "healthy cache file was moved"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	if ! grep -qE 'quarantined 1 stale gh HTTP 401 cache file' "$LOGFILE"; then
+		print_result "stale cache 401 writes remediation audit log" 1 "pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	print_result "stale cache 401 retries admin merge once and succeeds" 0
+	teardown_test_env
+	unset GH_STUB_MODE
+	return 0
+}
+
 main() {
 	test_ruleset_violation_enables_auto_merge_without_admin
 	test_draft_pr_without_origin_labels_skips_merge_write
+	test_stale_cache_401_retries_admin_merge_once
 
 	printf '\n=================================\n'
 	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Adds a targeted gh CLI HTTP-cache remediation path for gh pr merge 401 responses: live auth probe, quarantine matching stale 401 cache files, and retry once in pulse and full-loop merge paths.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh,.agents/scripts/gh-merge-cache-remediation-lib.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-full-loop-merge.sh,.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-full-loop-merge.sh; bash .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; shellcheck changed scripts; .agents/scripts/linters-local.sh

Resolves #24656


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.49 with gpt-5.5 spent 44m and 390,050 tokens on this with the user in an interactive session.