### PR TITLE
GH#24663: Warn on shell-only headless allowlist

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -76,7 +76,7 @@ _status_ai_configs() {
 _status_headless_runtime_config() {
 	print_header "Headless Runtime Configuration"
 	local allowlist_set=false
-	local credentials_file="${AIDEVOPS_CREDENTIALS_FILE:-$HOME/.config/aidevops/credentials.sh}"
+	local credentials_file="${AIDEVOPS_CREDENTIALS_FILE:-${CONFIG_DIR:-$HOME/.config/aidevops}/credentials.sh}"
 	local credentials_has_allowlist=false
 
 	if [[ -n "${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}" ]]; then

--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -73,6 +73,31 @@ _status_ai_configs() {
 	return 0
 }
 
+_status_headless_runtime_config() {
+	print_header "Headless Runtime Configuration"
+	local allowlist_set=false
+	local credentials_file="${AIDEVOPS_CREDENTIALS_FILE:-$HOME/.config/aidevops/credentials.sh}"
+	local credentials_has_allowlist=false
+
+	if [[ -n "${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}" ]]; then
+		allowlist_set=true
+	fi
+	if [[ -f "$credentials_file" ]] && grep -Eq '^[[:space:]]*(export[[:space:]]+)?AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=' "$credentials_file" 2>/dev/null; then
+		credentials_has_allowlist=true
+	fi
+
+	if [[ "$credentials_has_allowlist" == "true" ]]; then
+		print_success "Headless provider allowlist is configured in credentials.sh"
+	elif [[ "$allowlist_set" == "true" ]]; then
+		print_warning "Headless provider allowlist is only set in this shell; pulse/systemd/cron may not see shell rc files"
+		print_info "Add the export to ~/.config/aidevops/credentials.sh for daemon-visible headless routing"
+	else
+		print_info "No headless provider allowlist configured"
+	fi
+	echo ""
+	return 0
+}
+
 # Status command
 cmd_status() {
 	print_header "AI DevOps Framework Status"
@@ -120,6 +145,7 @@ cmd_status() {
 	_status_ai_tools
 	_status_dev_envs
 	_status_ai_configs
+	_status_headless_runtime_config
 	print_header "SSH Configuration"
 	check_file "$HOME/.ssh/id_ed25519" && print_success "Ed25519 SSH key" || print_warning "Ed25519 SSH key - not found"
 	echo ""

--- a/.agents/scripts/tests/test-status-headless-runtime-config.sh
+++ b/.agents/scripts/tests/test-status-headless-runtime-config.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for aidevops status headless runtime configuration warnings.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+STATUS_LIB="${SCRIPT_DIR}/../aidevops-cli/aidevops-status-lib.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+print_header() {
+	local text="$1"
+	printf 'HEADER: %s\n' "$text"
+	return 0
+}
+
+print_success() {
+	local text="$1"
+	printf 'SUCCESS: %s\n' "$text"
+	return 0
+}
+
+print_warning() {
+	local text="$1"
+	printf 'WARNING: %s\n' "$text"
+	return 0
+}
+
+print_info() {
+	local text="$1"
+	printf 'INFO: %s\n' "$text"
+	return 0
+}
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+		printf '%bPASS%b %s\n' "$GREEN" "$NC" "$name"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%bFAIL%b %s — %s\n' "$RED" "$NC" "$name" "$detail"
+	fi
+	return 0
+}
+
+run_status_check() {
+	local credentials_file="$1"
+	AIDEVOPS_CREDENTIALS_FILE="$credentials_file" _status_headless_runtime_config
+	return 0
+}
+
+# shellcheck source=../aidevops-cli/aidevops-status-lib.sh
+source "$STATUS_LIB"
+
+TMP_DIR=$(mktemp -d -t aidevops-status-env.XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+missing_credentials="${TMP_DIR}/missing-credentials.sh"
+configured_credentials="${TMP_DIR}/credentials.sh"
+printf '%s\n' 'export AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="anthropic"' >"$configured_credentials"
+
+AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="anthropic" output=$(run_status_check "$missing_credentials" 2>&1)
+if printf '%s' "$output" | grep -q 'only set in this shell' && printf '%s' "$output" | grep -q 'credentials.sh'; then
+	print_result "warns when allowlist is shell-only" 0
+else
+	print_result "warns when allowlist is shell-only" 1 "$output"
+fi
+
+AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="anthropic" output=$(run_status_check "$configured_credentials" 2>&1)
+if printf '%s' "$output" | grep -q 'configured in credentials.sh' && ! printf '%s' "$output" | grep -q 'only set in this shell'; then
+	print_result "accepts daemon-visible allowlist with shell env" 0
+else
+	print_result "accepts daemon-visible allowlist with shell env" 1 "$output"
+fi
+
+unset AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST
+output=$(run_status_check "$configured_credentials" 2>&1)
+if printf '%s' "$output" | grep -q 'configured in credentials.sh'; then
+	print_result "accepts daemon-visible allowlist without shell env" 0
+else
+	print_result "accepts daemon-visible allowlist without shell env" 1 "$output"
+fi
+
+output=$(run_status_check "$missing_credentials" 2>&1)
+if printf '%s' "$output" | grep -q 'No headless provider allowlist configured'; then
+	print_result "reports no allowlist when neither source is set" 0
+else
+	print_result "reports no allowlist when neither source is set" 1 "$output"
+fi
+
+printf '\nTests: %d run, %d passed, %d failed\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-status-headless-runtime-config.sh
+++ b/.agents/scripts/tests/test-status-headless-runtime-config.sh
@@ -64,12 +64,15 @@ run_status_check() {
 # shellcheck source=../aidevops-cli/aidevops-status-lib.sh
 source "$STATUS_LIB"
 
-TMP_DIR=$(mktemp -d -t aidevops-status-env.XXXXXX)
-trap 'rm -rf "$TMP_DIR"' EXIT
+TMP_DIR=$(mktemp -d -t aidevops-status-env.XXXXXX) || exit 1
+trap '[[ -n "${TMP_DIR:-}" ]] && rm -rf "$TMP_DIR"' EXIT
 
 missing_credentials="${TMP_DIR}/missing-credentials.sh"
 configured_credentials="${TMP_DIR}/credentials.sh"
+config_dir="${TMP_DIR}/config"
+mkdir -p "$config_dir"
 printf '%s\n' 'export AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="anthropic"' >"$configured_credentials"
+printf '%s\n' 'export AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="openai"' >"${config_dir}/credentials.sh"
 
 AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="anthropic" output=$(run_status_check "$missing_credentials" 2>&1)
 if printf '%s' "$output" | grep -q 'only set in this shell' && printf '%s' "$output" | grep -q 'credentials.sh'; then
@@ -91,6 +94,14 @@ if printf '%s' "$output" | grep -q 'configured in credentials.sh'; then
 	print_result "accepts daemon-visible allowlist without shell env" 0
 else
 	print_result "accepts daemon-visible allowlist without shell env" 1 "$output"
+fi
+
+unset AIDEVOPS_CREDENTIALS_FILE
+CONFIG_DIR="$config_dir" output=$(_status_headless_runtime_config 2>&1)
+if printf '%s' "$output" | grep -q 'configured in credentials.sh'; then
+	print_result "uses CONFIG_DIR credentials fallback" 0
+else
+	print_result "uses CONFIG_DIR credentials fallback" 1 "$output"
 fi
 
 output=$(run_status_check "$missing_credentials" 2>&1)

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -94,6 +94,7 @@ Auto-update overwrites `~/.aidevops/agents/configs/*.json` and `~/.aidevops/agen
 
 - Put persistent model-order overrides in `~/.aidevops/agents/custom/configs/model-routing-table.json`
 - Put the provider pin in `~/.config/aidevops/credentials.sh`
+- Do not rely on `.bashrc`, `.zshrc`, or `.profile` for pulse/worker provider pins; scheduled daemons intentionally do not source interactive shell startup files.
 
 Example custom override for OpenAI-capable headless routing:
 

--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -92,14 +92,14 @@ bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh get sonar-token  # S
 
 ## How It Works
 
-`credentials.sh` contains shell exports (`export SONAR_TOKEN="xxx"`). Shell startup sources it automatically:
+`credentials.sh` contains shell exports (`export SONAR_TOKEN="xxx"`). Shell startup sources it automatically for interactive terminals:
 
 ```bash
 # Added to ~/.zshrc (and ~/.bashrc/~/.bash_profile if present) by setup:
 [[ -f ~/.config/aidevops/credentials.sh ]] && source ~/.config/aidevops/credentials.sh
 ```
 
-All processes (terminals, scripts, MCPs) inherit these env vars.
+Interactive terminals inherit these env vars after their shell startup file runs. aidevops daemons and scheduled jobs do not source `.bashrc`, `.zshrc`, or `.profile`; they read `~/.config/aidevops/credentials.sh` directly when needed. Put persistent headless routing pins such as `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST` in `credentials.sh`, not only in a shell rc file.
 
 ## Permissions
 
@@ -116,7 +116,7 @@ chmod 700 ~/.config/aidevops && chmod 600 ~/.config/aidevops/credentials.sh
 
 **Key not found**: Check storage (`setup-local-api-keys.sh get service-name`), check env (`echo $SERVICE_NAME`), re-add if missing.
 
-**Changes not taking effect**: `source ~/.zshrc` (or `~/.bashrc`), or restart terminal.
+**Interactive changes not taking effect**: `source ~/.zshrc` (or `~/.bashrc`), or restart terminal. For pulse/systemd/cron behaviour, update `~/.config/aidevops/credentials.sh`; shell rc exports alone are not daemon-visible.
 
 **Shell integration missing**: Re-run `setup-local-api-keys.sh setup` to add sourcing lines.
 


### PR DESCRIPTION
## Summary

- add `aidevops status` diagnostics for shell-only `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`
- document that pulse/systemd/cron do not source interactive shell rc files
- add focused regression coverage for daemon-visible provider pins

## Verification

- `bash .agents/scripts/tests/test-status-headless-runtime-config.sh`
- `shellcheck .agents/scripts/aidevops-cli/aidevops-status-lib.sh .agents/scripts/tests/test-status-headless-runtime-config.sh`
- `bash .agents/scripts/tests/test-gh-status-helper.sh`
- `.agents/scripts/linters-local.sh` (passed; pre-existing advisory ratchet/complexity warnings only)

Resolves #24663
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.50 with gpt-5.5 spent 1h 29m and 293,830 tokens on this with the user in an interactive session.