### PR TITLE
GH#24666: docs: update asc-cli install command

### DIFF
--- a/.agents/tools/mobile/app-dev-publishing.md
+++ b/.agents/tools/mobile/app-dev-publishing.md
@@ -31,7 +31,7 @@ tools:
 ## CLI Automation — asc
 
 ```bash
-brew install tddworks/tap/asccli
+brew install asccli
 asc auth login --key-id KEY --issuer-id ISSUER --private-key-path ~/.asc/AuthKey.p8
 asc apps list
 ```

--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -21,7 +21,7 @@ tools:
 
 ## Quick Reference
 
-- **Install**: `brew install tddworks/tap/asccli` (NOT `brew install asc` — different package)
+- **Install**: `brew install asccli` (NOT `brew install asc` — different package)
 - **Auth**: `asc auth login --key-id KEY --issuer-id ISSUER --private-key-path ~/.asc/AuthKey.p8`
 - **API key**: Create at https://appstoreconnect.apple.com/access/integrations/api
 - **Project pin**: `asc init --app-id <id>` (saves `.asc/project.json`, auto-used by all commands)
@@ -35,7 +35,7 @@ tools:
 **Dependency check**: Before any `asc` command:
 
 ```bash
-command -v asc >/dev/null || { brew install tddworks/tap/asccli || exit 1; }
+command -v asc >/dev/null || { brew install asccli || exit 1; }
 command -v jq >/dev/null || { brew install jq || exit 1; }
 ```
 


### PR DESCRIPTION
## Summary

Updated App Store Connect automation docs to use the upstream official Homebrew install command, and aligned the mobile publishing doc example.

## Files Changed

.agents/tools/mobile/app-dev-publishing.md,.agents/tools/mobile/app-store-connect.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - .agents/scripts/linters-local.sh\n- grep check: no remaining brew install tddworks/tap/asccli references under .agents markdown

Resolves #24666


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.52 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 7m and 77,319 tokens on this as a headless worker.