### PR TITLE
GH#24665: record canary quota backoff

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -157,8 +157,10 @@ if not text:
 def emit(reason, provider_type, status, pattern):
     print('\t'.join([reason, provider_type, status, 'trusted_provider', pattern]))
 
-if any(token in text for token in ('rate limit', 'rate_limit', 'too many requests', 'quota exceeded')) or re.search(r'\b429\b', text):
-    emit('rate_limit', 'rate_limit', '429', 'trusted_rate_limit|429|too_many_requests|quota_exceeded')
+if any(token in text for token in ('insufficient_quota', 'insufficient quota', 'quota_exceeded', 'quota exceeded', 'exceeded your current quota')):
+    emit('quota_exceeded', 'quota_exceeded', '429', 'trusted_quota|insufficient_quota|quota_exceeded')
+elif any(token in text for token in ('rate limit', 'rate_limit', 'too many requests')) or re.search(r'\b429\b', text):
+    emit('rate_limit', 'rate_limit', '429', 'trusted_rate_limit|429|too_many_requests')
 elif re.search(r'\b(500|502|503|504)\b', text) or any(token in text for token in ('server_error', 'internal server error', 'service unavailable', 'bad gateway', 'gateway timeout', 'connection refused', 'connection reset', 'overloaded')):
     status = '500'
     if '504' in text or 'gateway timeout' in text:
@@ -1520,7 +1522,7 @@ _classify_canary_failure_reason() {
 	local reason
 	reason=$(classify_failure_reason "$output_file")
 	case "$reason" in
-		auth_error | rate_limit | provider_error)
+		auth_error | quota_exceeded | rate_limit | provider_error)
 			printf '%s' "$reason"
 			return 0
 			;;
@@ -1536,6 +1538,23 @@ _classify_canary_failure_reason() {
 			;;
 	esac
 	printf '%s' "local_error"
+	return 0
+}
+
+_record_canary_provider_backoff() {
+	local canary_model="$1"
+	local canary_reason="$2"
+	local canary_output="$3"
+	case "$canary_reason" in
+	auth_error | quota_exceeded | rate_limit | provider_error)
+		local canary_provider
+		canary_provider=$(extract_provider "$canary_model" 2>/dev/null || printf '%s' "")
+		if [[ -n "$canary_provider" ]]; then
+			record_provider_backoff "$canary_provider" "$canary_reason" "$canary_output" "$canary_model" || true
+		fi
+		;;
+	*) ;;
+	esac
 	return 0
 }
 
@@ -1801,6 +1820,7 @@ _run_canary_test() {
 	mkdir -p "${STATE_DIR}" 2>/dev/null || true
 	date +%s >"$fail_cache_file" 2>/dev/null || true
 	printf '%s\n' "$canary_reason" >"$fail_reason_file" 2>/dev/null || true
+	_record_canary_provider_backoff "$canary_model" "$canary_reason" "$canary_output"
 	rm -f "$canary_output"
 	return 1
 }

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -373,10 +373,11 @@ record_provider_backoff() {
 		return 0
 	fi
 
-	# Auth errors back off at provider level (shared credentials).
-	# Rate limits and provider errors back off at model level so that
-	# other models from the same provider remain available as fallbacks.
-	if [[ "$reason" == "auth_error" ]]; then
+	# Auth errors and account quota exhaustion back off at provider level
+	# (shared credentials/account state). Rate limits and provider errors back
+	# off at model level so other models from the same provider remain
+	# available as fallbacks.
+	if [[ "$reason" == "auth_error" || "$reason" == "quota_exceeded" ]]; then
 		backoff_key="$provider"
 	else
 		backoff_key="$model"

--- a/.agents/scripts/tests/test-canary-saturation-classification.sh
+++ b/.agents/scripts/tests/test-canary-saturation-classification.sh
@@ -170,6 +170,10 @@ classify_failure_reason() {
 		printf '%s' "rate_limit"
 		return 0
 	fi
+	if grep -q "QUOTA_EXCEEDED_FAKE" "$output_file" 2>/dev/null; then
+		printf '%s' "quota_exceeded"
+		return 0
+	fi
 	if grep -q "PROVIDER_ERROR_FAKE" "$output_file" 2>/dev/null; then
 		printf '%s' "provider_error"
 		return 0
@@ -197,8 +201,17 @@ extract_classifier() {
 	' "${SCRIPT_DIR}/headless-runtime-lib.sh"
 }
 
+extract_canary_backoff_recorder() {
+	awk '
+		/^_record_canary_provider_backoff\(\)/ { in_fn = 1 }
+		in_fn { print }
+		in_fn && /^}$/ { in_fn = 0 }
+	' "${SCRIPT_DIR}/headless-runtime-lib.sh"
+}
+
 # shellcheck disable=SC2046
 eval "$(extract_classifier)"
+eval "$(extract_canary_backoff_recorder)"
 
 run_classifier() {
 	# run_classifier <fake_pct_csv> <exit_code> <output_file_marker>
@@ -270,6 +283,113 @@ test_classifier_auth_error_ignores_saturation() {
 	return 0
 }
 
+test_classifier_quota_exceeded_ignores_saturation() {
+	local result
+	result=$(run_classifier saturated 124 "QUOTA_EXCEEDED_FAKE")
+	if [[ "$result" == "quota_exceeded" ]]; then
+		print_result "classifier: quota_exceeded pattern ignores saturation" 0
+	else
+		print_result "classifier: quota_exceeded pattern ignores saturation" 1 "got=$result"
+	fi
+	return 0
+}
+
+extract_provider_backoff_recorder() {
+	awk '
+		/^record_provider_backoff\(\)/ { in_fn = 1 }
+		in_fn { print }
+		in_fn && /^}$/ { in_fn = 0 }
+	' "${SCRIPT_DIR}/headless-runtime-provider.sh"
+}
+
+RECORDED_BACKOFF_SQL=""
+OAUTH_POOL_HELPER=/bin/false
+
+parse_retry_after_seconds() {
+	local details_file="$1"
+	local provider="$2"
+	: "$details_file" "$provider"
+	printf '%s' "0"
+	return 0
+}
+
+clamp_rate_limit_retry_seconds() {
+	local reason="$1"
+	local retry_seconds="$2"
+	: "$reason"
+	printf '%s' "$retry_seconds"
+	return 0
+}
+
+get_auth_signature() {
+	local provider="$1"
+	printf '%s' "sig-${provider}"
+	return 0
+}
+
+db_query() {
+	local query="$1"
+	RECORDED_BACKOFF_SQL="$query"
+	return 0
+}
+
+sql_escape() {
+	local value="$1"
+	printf '%s' "${value//\'/\'\'}"
+	return 0
+}
+
+extract_provider() {
+	local model="$1"
+	if [[ "$model" == */* ]]; then
+		printf '%s' "${model%%/*}"
+		return 0
+	fi
+	return 1
+}
+
+# shellcheck disable=SC2046
+eval "$(extract_provider_backoff_recorder)"
+
+test_record_provider_backoff_quota_uses_provider_key() {
+	local details_file="${TEST_ROOT}/quota-details.txt"
+	printf '%s\n' "provider openai insufficient_quota" >"$details_file"
+	RECORDED_BACKOFF_SQL=""
+	record_provider_backoff "openai" "quota_exceeded" "$details_file" "openai/gpt-5.5"
+	if [[ "$RECORDED_BACKOFF_SQL" == *"'openai'"* && "$RECORDED_BACKOFF_SQL" != *"'openai/gpt-5.5'"* ]]; then
+		print_result "backoff: quota_exceeded records provider-level key" 0
+	else
+		print_result "backoff: quota_exceeded records provider-level key" 1 "sql=$RECORDED_BACKOFF_SQL"
+	fi
+	return 0
+}
+
+test_canary_backoff_recorder_skips_local_error() {
+	local details_file="${TEST_ROOT}/local-details.txt"
+	printf '%s\n' "local setup failure" >"$details_file"
+	RECORDED_BACKOFF_SQL=""
+	_record_canary_provider_backoff "openai/gpt-5.5" "local_error" "$details_file"
+	if [[ -z "$RECORDED_BACKOFF_SQL" ]]; then
+		print_result "canary backoff: local_error does not record provider backoff" 0
+	else
+		print_result "canary backoff: local_error does not record provider backoff" 1 "sql=$RECORDED_BACKOFF_SQL"
+	fi
+	return 0
+}
+
+test_canary_backoff_recorder_records_quota() {
+	local details_file="${TEST_ROOT}/canary-quota-details.txt"
+	printf '%s\n' "provider openai insufficient_quota" >"$details_file"
+	RECORDED_BACKOFF_SQL=""
+	_record_canary_provider_backoff "openai/gpt-5.5" "quota_exceeded" "$details_file"
+	if [[ "$RECORDED_BACKOFF_SQL" == *"'openai'"* && "$RECORDED_BACKOFF_SQL" == *"'quota_exceeded'"* ]]; then
+		print_result "canary backoff: quota_exceeded records provider backoff" 0
+	else
+		print_result "canary backoff: quota_exceeded records provider backoff" 1 "sql=$RECORDED_BACKOFF_SQL"
+	fi
+	return 0
+}
+
 test_classifier_runtime_error_unaffected() {
 	local result
 	result=$(run_classifier saturated 127 "")
@@ -308,6 +428,10 @@ test_classifier_timeout_saturated_to_timeout
 test_classifier_timeout_idle_to_timeout
 test_classifier_timeout_no_samples_to_timeout
 test_classifier_auth_error_ignores_saturation
+test_classifier_quota_exceeded_ignores_saturation
+test_record_provider_backoff_quota_uses_provider_key
+test_canary_backoff_recorder_skips_local_error
+test_canary_backoff_recorder_records_quota
 test_classifier_runtime_error_unaffected
 test_classifier_helper_missing_no_dependency
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -795,6 +795,28 @@ test_failure_classifier_records_provenance() {
 	return 0
 }
 
+test_failure_classifier_distinguishes_quota_exhaustion() {
+	local output_file="${TEST_ROOT}/failure-classifier-quota.out"
+	local reason_file="${TEST_ROOT}/failure-classifier-quota.reason"
+	printf 'OpenAI provider error HTTP 429: {"error":{"code":"insufficient_quota","message":"You exceeded your current quota"}}\n' >"$output_file"
+
+	local reason
+	classify_failure_reason "$output_file" >"$reason_file"
+	reason=$(<"$reason_file")
+
+	if [[ "$reason" == "quota_exceeded" ]] &&
+		[[ "${_failure_provider_error_type:-}" == "quota_exceeded" ]] &&
+		[[ "${_failure_provider_status:-}" == "429" ]] &&
+		[[ "${_failure_classification_source:-}" == "trusted_provider" ]]; then
+		print_result "failure classifier distinguishes OpenAI quota exhaustion" 0
+		return 0
+	fi
+
+	print_result "failure classifier distinguishes OpenAI quota exhaustion" 1 \
+		"reason=$reason type=${_failure_provider_error_type:-} status=${_failure_provider_status:-} source=${_failure_classification_source:-} pattern=${_failure_classification_pattern:-}"
+	return 0
+}
+
 test_service_interruption_candidate_uses_separate_path() {
 	local output_file="${TEST_ROOT}/service-interruption.out"
 	printf '%s\n' '{"type":"text","sessionID":"ses_23037","text":"editing files"}' 'OpenAI 503 service unavailable after tool activity' >"$output_file"
@@ -1862,6 +1884,7 @@ main() {
 	test_headless_activity_timeout_default_matches_watchdog
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
+	test_failure_classifier_distinguishes_quota_exhaustion
 	test_service_interruption_candidate_uses_separate_path
 	test_service_interruption_exhausted_metric_preserves_context
 	test_canary_pins_vanilla_agent_with_isolated_plugin_config


### PR DESCRIPTION
## Summary

Records provider/model backoff from canary preflight failures, distinguishes OpenAI quota exhaustion as quota_exceeded, and backs exhausted account quota off at provider scope so model selection can fall through to healthy providers.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/headless-runtime-provider.sh,.agents/scripts/tests/test-canary-saturation-classification.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh (70 passed); bash .agents/scripts/tests/test-canary-saturation-classification.sh (15 passed); bash .agents/scripts/tests/test-model-availability-oauth-probe.sh (16 passed); shellcheck on changed shell files; .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED, with pre-existing advisory debt only).

Resolves #24665


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.52 with gpt-5.5 spent 3h 24m and 145,717 tokens on this with the user in an interactive session.