### PR TITLE
GH#24673: fix: classify anthropic credit exhaustion

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -157,8 +157,8 @@ if not text:
 def emit(reason, provider_type, status, pattern):
     print('\t'.join([reason, provider_type, status, 'trusted_provider', pattern]))
 
-if any(token in text for token in ('insufficient_quota', 'insufficient quota', 'quota_exceeded', 'quota exceeded', 'exceeded your current quota')):
-    emit('quota_exceeded', 'quota_exceeded', '429', 'trusted_quota|insufficient_quota|quota_exceeded')
+if any(token in text for token in ('insufficient_quota', 'insufficient quota', 'quota_exceeded', 'quota exceeded', 'exceeded your current quota', 'credit_exhausted', 'credit exhausted', 'exhausted your credit')):
+    emit('quota_exceeded', 'quota_exceeded', '429', 'trusted_quota|insufficient_quota|quota_exceeded|credit_exhausted')
 elif any(token in text for token in ('rate limit', 'rate_limit', 'too many requests')) or re.search(r'\b429\b', text):
     emit('rate_limit', 'rate_limit', '429', 'trusted_rate_limit|429|too_many_requests')
 elif re.search(r'\b(500|502|503|504)\b', text) or any(token in text for token in ('server_error', 'internal server error', 'service unavailable', 'bad gateway', 'gateway timeout', 'connection refused', 'connection reset', 'overloaded')):

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -817,6 +817,29 @@ test_failure_classifier_distinguishes_quota_exhaustion() {
 	return 0
 }
 
+test_failure_classifier_distinguishes_anthropic_credit_exhaustion() {
+	local output_file="${TEST_ROOT}/failure-classifier-anthropic-quota.out"
+	local reason_file="${TEST_ROOT}/failure-classifier-anthropic-quota.reason"
+	printf 'Anthropic provider error HTTP 429: {"error":{"type":"credit_exhausted","message":"You have exhausted your credit"}}\n' >"$output_file"
+
+	local reason
+	classify_failure_reason "$output_file" >"$reason_file"
+	reason=$(<"$reason_file")
+
+	if [[ "$reason" == "quota_exceeded" ]] &&
+		[[ "${_failure_provider_error_type:-}" == "quota_exceeded" ]] &&
+		[[ "${_failure_provider_status:-}" == "429" ]] &&
+		[[ "${_failure_classification_source:-}" == "trusted_provider" ]] &&
+		[[ "${_failure_classification_pattern:-}" == *"credit_exhausted"* ]]; then
+		print_result "failure classifier distinguishes Anthropic credit exhaustion" 0
+		return 0
+	fi
+
+	print_result "failure classifier distinguishes Anthropic credit exhaustion" 1 \
+		"reason=$reason type=${_failure_provider_error_type:-} status=${_failure_provider_status:-} source=${_failure_classification_source:-} pattern=${_failure_classification_pattern:-}"
+	return 0
+}
+
 test_service_interruption_candidate_uses_separate_path() {
 	local output_file="${TEST_ROOT}/service-interruption.out"
 	printf '%s\n' '{"type":"text","sessionID":"ses_23037","text":"editing files"}' 'OpenAI 503 service unavailable after tool activity' >"$output_file"
@@ -1885,6 +1908,7 @@ main() {
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
 	test_failure_classifier_distinguishes_quota_exhaustion
+	test_failure_classifier_distinguishes_anthropic_credit_exhaustion
 	test_service_interruption_candidate_uses_separate_path
 	test_service_interruption_exhausted_metric_preserves_context
 	test_canary_pins_vanilla_agent_with_isolated_plugin_config


### PR DESCRIPTION
## Summary

Classified Anthropic credit exhaustion messages as quota_exceeded and added regression coverage for credit_exhausted provider output.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24673


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 2m and 40,749 tokens on this as a headless worker.