### PR TITLE
GH#24675: fix: harden gh merge cache remediation

### DIFF
--- a/.agents/scripts/gh-merge-cache-remediation-lib.sh
+++ b/.agents/scripts/gh-merge-cache-remediation-lib.sh
@@ -9,7 +9,7 @@ _GH_MERGE_CACHE_REMEDIATION_LIB_LOADED=1
 gh_merge_output_is_auth_401() {
 	local merge_output="$1"
 
-	printf '%s' "$merge_output" | grep -qiE '(^|[^0-9])(401)([^0-9]|$)|401 Unauthorized|Requires authentication'
+	printf '%s' "$merge_output" | grep -qiE 'HTTP([^[:alnum:]]+[0-9.]+)?[[:space:]]+401|status code:?[[:space:]]*401|401 Unauthorized|Requires authentication'
 	return $?
 }
 
@@ -31,17 +31,16 @@ gh_merge_cache_file_has_stale_auth_401() {
 	local cache_file="$1"
 
 	[[ -f "$cache_file" ]] || return 1
-	grep -Iq . "$cache_file" 2>/dev/null || return 1
-	grep -qiE '401 Unauthorized|Requires authentication|"message"[[:space:]]*:[[:space:]]*"Requires authentication"' "$cache_file" 2>/dev/null || return 1
-	grep -qiE 'api\.github\.com|graphql|GraphQL|X-Gh-Cache-Ttl|Requires authentication' "$cache_file" 2>/dev/null || return 1
-	return 0
+	grep -qiE '401 Unauthorized|Requires authentication' "$cache_file"
+	return $?
 }
 
 gh_merge_quarantine_stale_auth_cache() {
 	local cache_root="${GH_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/gh}"
 	local quarantine_dir=""
 	local cache_file=""
-	local base_name=""
+	local rel_path=""
+	local dest_file=""
 	local moved=0
 
 	[[ -d "$cache_root" ]] || return 1
@@ -53,13 +52,14 @@ gh_merge_quarantine_stale_auth_cache() {
 		"$cache_root"/aidevops-quarantine-*) continue ;;
 		esac
 		if gh_merge_cache_file_has_stale_auth_401 "$cache_file"; then
-			mkdir -p "$quarantine_dir" || return 1
-			base_name=$(basename "$cache_file")
-			if mv "$cache_file" "${quarantine_dir}/${base_name}.$$" 2>/dev/null; then
+			rel_path="${cache_file#"$cache_root"/}"
+			dest_file="${quarantine_dir}/${rel_path}"
+			mkdir -p "$(dirname "$dest_file")" || return 1
+			if mv "$cache_file" "$dest_file"; then
 				moved=$((moved + 1))
 			fi
 		fi
-	done < <(find "$cache_root" -type f -print 2>/dev/null)
+	done < <(find "$cache_root" -type f -print)
 
 	[[ "$moved" -gt 0 ]] || return 1
 	printf '%s\n' "$moved"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -498,8 +498,18 @@ test_review_gate_failure_blocks_rest_fallback() {
 test_stale_cache_401_retry() {
 	rm -f "${TEST_ROOT}/logs/"*.txt
 	rm -rf "${TEST_ROOT:?}/home"
-	mkdir -p "${TEST_ROOT}/home/.cache/gh"
+	mkdir -p "${TEST_ROOT}/home/.cache/gh/api" "${TEST_ROOT}/home/.cache/gh/graphql"
 	cat >"${TEST_ROOT}/home/.cache/gh/graphql-401.cache" <<'CACHE'
+HTTP/2.0 401 Unauthorized
+X-Gh-Cache-Ttl: 24h0m0s
+{"message":"Requires authentication","documentation_url":"https://docs.github.com/graphql"}
+CACHE
+	cat >"${TEST_ROOT}/home/.cache/gh/api/shared.cache" <<'CACHE'
+HTTP/2.0 401 Unauthorized
+X-Gh-Cache-Ttl: 24h0m0s
+{"message":"Requires authentication","documentation_url":"https://docs.github.com/rest"}
+CACHE
+	cat >"${TEST_ROOT}/home/.cache/gh/graphql/shared.cache" <<'CACHE'
 HTTP/2.0 401 Unauthorized
 X-Gh-Cache-Ttl: 24h0m0s
 {"message":"Requires authentication","documentation_url":"https://docs.github.com/graphql"}
@@ -521,14 +531,42 @@ CACHE
 
 	local stale_quarantined=0
 	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql-401.cache" ]] && \
-		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/*graphql-401.cache*' -type f | grep -q .; then
+		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/graphql-401.cache' -type f | grep -q .; then
 		stale_quarantined=1
 	fi
-	print_result "stale gh cache 401: only matching 401 cache quarantined" "$((1 - stale_quarantined))"
+	print_result "stale gh cache 401: top-level 401 cache quarantined" "$((1 - stale_quarantined))"
+
+	local collision_paths_preserved=0
+	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/api/shared.cache" ]] && \
+		[[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql/shared.cache" ]] && \
+		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/api/shared.cache' -type f | grep -q . && \
+		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/graphql/shared.cache' -type f | grep -q .; then
+		collision_paths_preserved=1
+	fi
+	print_result "stale gh cache 401: quarantine preserves relative paths" "$((1 - collision_paths_preserved))"
 
 	local healthy_preserved=0
 	[[ -f "${TEST_ROOT}/home/.cache/gh/healthy.cache" ]] && healthy_preserved=1
 	print_result "stale gh cache 401: healthy cache preserved" "$((1 - healthy_preserved))"
+
+	return 0
+}
+
+# Test 9: 401 detection only matches authentication-shaped merge errors.
+test_auth_401_detection_avoids_numeric_false_positives() {
+	source "${SCRIPT_DIR}/../gh-merge-cache-remediation-lib.sh"
+
+	local false_positive=0
+	gh_merge_output_is_auth_401 "Merged PR #401" && false_positive=1
+	print_result "auth 401 detection: PR number 401 is not auth" "$false_positive"
+
+	false_positive=0
+	gh_merge_output_is_auth_401 "Merged commit a401b2c" && false_positive=1
+	print_result "auth 401 detection: SHA fragment 401 is not auth" "$false_positive"
+
+	local auth_detected=0
+	gh_merge_output_is_auth_401 "HTTP/2.0 401 Unauthorized" && auth_detected=1
+	print_result "auth 401 detection: HTTP 401 remains auth" "$((1 - auth_detected))"
 
 	return 0
 }
@@ -549,6 +587,7 @@ main() {
 	test_graphql_rate_limit_auto_no_rest_fallback
 	test_review_gate_failure_blocks_rest_fallback
 	test_stale_cache_401_retry
+	test_auth_401_detection_avoids_numeric_false_positives
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Refined gh pr merge 401 detection to auth-shaped errors, reduced stale cache file scanning to one grep, and quarantined cache entries under preserved relative paths to avoid basename collisions.

## Files Changed

.agents/scripts/gh-merge-cache-remediation-lib.sh,.agents/scripts/tests/test-full-loop-merge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-merge-cache-remediation-lib.sh .agents/scripts/tests/test-full-loop-merge.sh; bash .agents/scripts/tests/test-full-loop-merge.sh

Resolves #24675


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 3m and 65,372 tokens on this as a headless worker.