### PR TITLE
GH#24679: fix: preserve pulse gate diagnostics

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -55,13 +55,15 @@ _pulse_repo_allows_pr_gate_writes() {
 	local repo_slug="$1"
 	local gate_name="$2"
 
-	if ! command -v repo_allows_pulse_write_actions >/dev/null; then
-		echo "[pulse-wrapper] ${gate_name}: repo write-action guard unavailable for ${repo_slug} — skipping PR gate write (fail closed)" >>"$LOGFILE" || true
+	if ! command -v repo_allows_pulse_write_actions >/dev/null 2>&1; then
+		local msg="[pulse-wrapper] ${gate_name}: repo write-action guard unavailable for ${repo_slug} — skipping PR gate write (fail closed)"
+		echo "$msg" >>"$LOGFILE" || echo "Failed to write to $LOGFILE: $msg" >&2
 		return 1
 	fi
 
 	if ! repo_allows_pulse_write_actions "$repo_slug"; then
-		echo "[pulse-wrapper] ${gate_name}: skipping PR gate writes in ${repo_slug} — repo role is contributor/read-only" >>"$LOGFILE" || true
+		local msg="[pulse-wrapper] ${gate_name}: skipping PR gate writes in ${repo_slug} — repo role is contributor/read-only"
+		echo "$msg" >>"$LOGFILE" || echo "Failed to write to $LOGFILE: $msg" >&2
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary

Preserved pulse PR gate skip diagnostics by redirecting command lookup stderr, replacing silent log-write fallbacks with stderr fallbacks that include the log path, and keeping the guard fail-closed behavior.

## Files Changed

.agents/scripts/pulse-merge-gates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-gates.sh; git diff --check

Resolves #24679


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 2m and 59,907 tokens on this as a headless worker.