### PR TITLE
GH#24677: harden OpenAI OAuth timestamp validation

### DIFF
--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -487,13 +487,16 @@ _probe_openai_oauth_fallback_verified() {
 		return 0
 	fi
 
-	local access_token expires_ms now_ms
+	local access_token expires_ms now_s now_ms
 	access_token=$(jq -r '.openai.access // empty' "$auth_file" 2>/dev/null) || access_token=""
 	expires_ms=$(jq -r '.openai.expires // empty' "$auth_file" 2>/dev/null) || expires_ms=""
 	if [[ -n "$access_token" && "$expires_ms" =~ ^[0-9]+$ ]]; then
-		now_ms=$(($(date +%s) * 1000))
-		if [[ "$expires_ms" -gt "$now_ms" ]]; then
-			return 0
+		now_s=$(date +%s 2>/dev/null) || now_s=""
+		if [[ "$now_s" =~ ^[0-9]+$ ]]; then
+			now_ms=$((now_s * 1000))
+			if [[ "$expires_ms" -gt "$now_ms" ]]; then
+				return 0
+			fi
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-model-availability-oauth-probe.sh
+++ b/.agents/scripts/tests/test-model-availability-oauth-probe.sh
@@ -277,6 +277,36 @@ else
 		"(got rc=$rc — expected 0; live OAuth access should remain eligible)"
 fi
 
+# Assertion 4b.4 — date failures fail closed instead of producing arithmetic
+# syntax errors while checking a live OpenAI OAuth access token.
+cat >"$AUTH_FILE" <<JSON
+{
+  "openai": {
+    "type": "oauth",
+    "access": "fake-openai-live-access-token",
+    "expires": ${future_ms}
+  }
+}
+JSON
+DATE_STUB_DIR="${TEST_ROOT}/date-stub"
+mkdir -p "$DATE_STUB_DIR"
+cat >"${DATE_STUB_DIR}/date" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "${DATE_STUB_DIR}/date"
+ORIGINAL_PATH="$PATH"
+PATH="${DATE_STUB_DIR}:${PATH}"
+_probe_check_oauth_fallback openai true "gopass:OPENAI_API_KEY" >/dev/null 2>&1
+rc=$?
+PATH="$ORIGINAL_PATH"
+if [[ "$rc" -eq 3 ]]; then
+	print_result "openai-oauth-live-access: date failure fails closed" 0
+else
+	print_result "openai-oauth-live-access: date failure fails closed" 1 \
+		"(got rc=$rc — expected 3; invalid date output must not mark OAuth healthy)"
+fi
+
 # Assertion 4c — no OAuth in auth.json → fallback returns 3 (no override).
 rm -f "$AUTH_FILE"
 _probe_check_oauth_fallback openai true

--- a/.agents/scripts/tests/test-model-availability-oauth-probe.sh
+++ b/.agents/scripts/tests/test-model-availability-oauth-probe.sh
@@ -295,11 +295,11 @@ cat >"${DATE_STUB_DIR}/date" <<'SH'
 exit 1
 SH
 chmod +x "${DATE_STUB_DIR}/date"
-ORIGINAL_PATH="$PATH"
-PATH="${DATE_STUB_DIR}:${PATH}"
-_probe_check_oauth_fallback openai true "gopass:OPENAI_API_KEY" >/dev/null 2>&1
-rc=$?
-PATH="$ORIGINAL_PATH"
+rc=$(
+	PATH="${DATE_STUB_DIR}:${PATH}"
+	_probe_check_oauth_fallback openai true "gopass:OPENAI_API_KEY" >/dev/null
+	printf '%s\n' "$?"
+)
 if [[ "$rc" -eq 3 ]]; then
 	print_result "openai-oauth-live-access: date failure fails closed" 0
 else


### PR DESCRIPTION
Resolves #24677

## Summary

- Validate the OpenAI OAuth fallback timestamp before millisecond conversion so failed or non-numeric date output fails closed.

- Add regression coverage that stubs date failure and expects OpenAI OAuth fallback to remain unavailable.

## Testing

- shellcheck .agents/scripts/model-availability-probe-lib.sh .agents/scripts/tests/test-model-availability-oauth-probe.sh
- bash .agents/scripts/tests/test-model-availability-oauth-probe.sh
- .agents/scripts/linters-local.sh


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.1 with gpt-5.5 spent 8m and 77,267 tokens on this as a headless worker.
