### PR TITLE
GH#24680: test: expand duplicate PR parser local coverage

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
@@ -299,13 +299,15 @@ test_group_parsing_vars_do_not_pollute_global_scope() {
 	pr_number="sentinel-pr"
 	_score="sentinel-score"
 	_is_draft="sentinel-draft"
+	_issue="sentinel-issue"
+	_created="sentinel-created"
 	_pmp_consolidate_duplicate_pr_groups "owner/repo" "$pr_json"
-	if [[ "$pr_number" == "sentinel-pr" && "$_score" == "sentinel-score" && "$_is_draft" == "sentinel-draft" ]]; then
+	if [[ "$pr_number" == "sentinel-pr" && "$_score" == "sentinel-score" && "$_is_draft" == "sentinel-draft" && "$_issue" == "sentinel-issue" && "$_created" == "sentinel-created" ]]; then
 		pass "group parsing variables stay local"
 	else
-		fail "group parsing variables stay local" "Expected sentinel globals, got pr_number=${pr_number}, _score=${_score}, _is_draft=${_is_draft}"
+		fail "group parsing variables stay local" "Expected sentinel globals, got pr_number=${pr_number}, _score=${_score}, _is_draft=${_is_draft}, _issue=${_issue}, _created=${_created}"
 	fi
-	unset pr_number _score _is_draft
+	unset pr_number _score _is_draft _issue _created
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Expanded the duplicate PR consolidation parser-scope regression to include _issue and _created sentinel globals alongside the existing parser variables.

## Files Changed

.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh; .agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh

Resolves #24680


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 3m and 46,920 tokens on this as a headless worker.