### PR TITLE
GH#24681: test: support kernel-name in pulse uname mock

### DIFF
--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -37,7 +37,7 @@ _systemd_user_available() {
 uname() {
 	local flag="${1:-}"
 
-	if [[ -z "$flag" || "$flag" == "-s" ]]; then
+	if [[ -z "$flag" || "$flag" == "-s" || "$flag" == "--kernel-name" ]]; then
 		printf 'Linux\n'
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Extended the pulse systemd timeout test's uname mock to return Linux for --kernel-name as well as -s/empty probes, keeping fallback exit-code propagation for other flags.

## Files Changed

tests/test-pulse-systemd-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck tests/test-pulse-systemd-timeout.sh; bash tests/test-pulse-systemd-timeout.sh

Resolves #24681


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 2m and 39,476 tokens on this as a headless worker.