### PR TITLE
GH#24682: fix: harden jq fallback cache test

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -75,6 +75,7 @@ _rest_pr_view_cache_enabled() {
 	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE:-0}" == "1" ]] || return 1
 	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" == "1" ]] && return 1
 	command -v jq >/dev/null 2>&1 || return 1
+	jq -n 'true' >/dev/null 2>&1 || return 1
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -330,6 +330,17 @@ export -f gh
 _rest_append_sig() { return 0; }
 export -f _rest_append_sig
 
+# Stub jq as a shell function so tests can toggle jq failures without hiding
+# unrelated system utilities from PATH.
+jq() {
+	if [[ "${STUB_JQ_FAIL:-0}" == "1" ]]; then
+		return 1
+	fi
+	command jq "$@"
+	return $?
+}
+export -f jq
+
 printf '%sRunning gh-wrapper REST fallback tests (t2574 / GH#20243)%s\n' \
 	"$TEST_BLUE" "$TEST_NC"
 
@@ -1239,11 +1250,9 @@ fi
 export STUB_RATE_LIMIT_REMAINING=0
 export AIDEVOPS_GH_PR_VIEW_CACHE=1
 export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"uncached title"}'
-saved_path="$PATH"
-# shellcheck disable=SC2123 # Intentionally isolate PATH to verify fallback when jq is unavailable.
-PATH="$TMP/missing-jq-bin"
-pr_view_uncached_json=$(_rest_pr_view 123 --repo "owner/repo" 2>/dev/null || true)
-PATH="$saved_path"
+export STUB_JQ_FAIL=1
+pr_view_uncached_json=$(_rest_pr_view 123 --repo "owner/repo" || true)
+unset STUB_JQ_FAIL
 rest_cache_bypasses=$(grep -c $'rest_pr_view_cache\tother\tunknown\tother\tbypass' "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)
 rest_cache_disabled_bypasses=$(grep -c $'rest_pr_view_cache\tother\tunknown\tother\tbypass-disabled' "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)
 if [[ "$pr_view_uncached_json" == *'"uncached title"'* && "$rest_cache_bypasses" == "1" && "$rest_cache_disabled_bypasses" == "0" ]]; then


### PR DESCRIPTION
## Summary

Replaced the PATH-isolation jq-missing regression with a toggleable jq shell stub and made PR view cache enablement require a usable jq invocation, so the test no longer hides standard utilities while still verifying unavailable cache prerequisites.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

Resolves #24682


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 5m and 46,861 tokens on this as a headless worker.