### PR TITLE
GH#24658: fix: refresh pulse mergeability before conflict handling

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -111,6 +111,42 @@ _pmp_normalize_mergeable_state_into() {
 }
 
 #######################################
+# Refresh empty/UNKNOWN PR mergeable state into a caller variable.
+#
+# REST-first PR list reads cannot preserve GraphQL-only mergeable data. Before
+# write decisions, refresh only ambiguous per-PR states through gh_pr_view with
+# the PR-view cache disabled so existing CONFLICTING handling can run.
+#
+# Args:
+#   $1 - destination variable name
+#   $2 - PR number
+#   $3 - repo slug
+#   $4 - current mergeable state
+#######################################
+_pmp_refresh_unknown_mergeable_state_into() {
+	local dest_var="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local current_mergeable="$4"
+	local refreshed_mergeable=""
+	local refresh_exit=0
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	_pmp_normalize_mergeable_state_into refreshed_mergeable "$current_mergeable"
+
+	if [[ "$refreshed_mergeable" == "UNKNOWN" || -z "$refreshed_mergeable" ]]; then
+		refreshed_mergeable=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json mergeable --jq '.mergeable // ""')
+		refresh_exit=$?
+		[[ $refresh_exit -eq 0 && -n "$refreshed_mergeable" ]] || refreshed_mergeable="UNKNOWN"
+		_pmp_normalize_mergeable_state_into refreshed_mergeable "$refreshed_mergeable"
+	fi
+
+	printf -v "$dest_var" '%s' "$refreshed_mergeable"
+	return 0
+}
+
+#######################################
 # Classify one PR object into a scheduling/observability backlog bucket.
 # This is intentionally advisory: it never decides merge eligibility. The
 # existing per-PR gate stack remains authoritative.

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -846,12 +846,7 @@ _process_single_ready_pr() {
 	# value before the CONFLICTING branch; otherwise the later non-MERGEABLE
 	# skip makes conflict remediation unreachable (GH#24634).
 	if [[ "$pr_mergeable" == UNKNOWN || -z "$pr_mergeable" ]]; then
-		local _pre_conflict_mergeable="" _pre_conflict_exit=0
-		_pre_conflict_mergeable=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
-			--json mergeable --jq '.mergeable // ""')
-		_pre_conflict_exit=$?
-		[[ $_pre_conflict_exit -eq 0 && -n "$_pre_conflict_mergeable" ]] && pr_mergeable="$_pre_conflict_mergeable" || pr_mergeable=UNKNOWN
-		_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
+		_pmp_refresh_unknown_mergeable_state_into pr_mergeable "$pr_number" "$repo_slug" "$pr_mergeable"
 	fi
 
 	# CONFLICTING handling (t2116): before closing, attempt to salvage the

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -112,10 +112,11 @@ define_helper_under_test() {
 	helper_src=$(awk '
 		/^_pmp_normalize_mergeable_state\(\) \{/,/^}$/ { print }
 		/^_pmp_normalize_mergeable_state_into\(\) \{/,/^}$/ { print }
+		/^_pmp_refresh_unknown_mergeable_state_into\(\) \{/,/^}$/ { print }
 		/^_attempt_pr_update_branch\(\) \{/,/^}$/ { print }
 		/^_resolve_pr_mergeable_status\(\) \{/,/^}$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$helper_src" || "$helper_src" != *"_pmp_normalize_mergeable_state"* || "$helper_src" != *"_pmp_normalize_mergeable_state_into"* || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]]; then
+	if [[ -z "$helper_src" || "$helper_src" != *"_pmp_normalize_mergeable_state"* || "$helper_src" != *"_pmp_normalize_mergeable_state_into"* || "$helper_src" != *"_pmp_refresh_unknown_mergeable_state_into"* || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]]; then
 		printf 'ERROR: could not extract pulse-merge-process helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -294,6 +295,29 @@ test_resolve_mergeable_retries_empty_and_logs_empty() {
 	return 0
 }
 
+test_refresh_unknown_mergeable_surfaces_conflicting() {
+	install_gh_stub
+	: >"$LAST_GH_ARGS_FILE"
+	local pr_mergeable="UNKNOWN"
+	local rc=0
+	GH_VIEW_MERGEABLE=CONFLICTING _pmp_refresh_unknown_mergeable_state_into pr_mergeable "24658" "marcusquinn/aidevops" "$pr_mergeable" || rc=$?
+
+	if [[ $rc -ne 0 || "$pr_mergeable" != "CONFLICTING" ]]; then
+		print_result "UNKNOWN refresh surfaces CONFLICTING before conflict handler" 1 \
+			"Expected pr_mergeable=CONFLICTING and rc=0, got pr_mergeable=${pr_mergeable}, rc=${rc}"
+		return 0
+	fi
+
+	if ! grep -qE '^pr view 24658 --repo marcusquinn/aidevops --json mergeable --jq' "$LAST_GH_ARGS_FILE"; then
+		print_result "UNKNOWN refresh surfaces CONFLICTING before conflict handler" 1 \
+			"Expected gh pr view refresh in args. Got: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	print_result "UNKNOWN refresh surfaces CONFLICTING before conflict handler" 0
+	return 0
+}
+
 # ---------------------------------------------------------------
 # Static analysis of the t2116 block in _process_single_ready_pr.
 # The full control-flow of _process_single_ready_pr depends on many
@@ -432,9 +456,21 @@ test_unknown_mergeable_refreshed_before_conflict_handler() {
 		return 0
 	fi
 
-	if [[ "$function_src" != *"AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view"* || "$function_src" != *"_pmp_normalize_mergeable_state_into pr_mergeable"* ]]; then
+	if [[ "$function_src" != *"_pmp_refresh_unknown_mergeable_state_into pr_mergeable"* ]]; then
 		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
-			"Refresh must bypass stale PR-view cache and normalize into pr_mergeable"
+			"Refresh must use helper to bypass stale PR-view cache and normalize into pr_mergeable"
+		return 0
+	fi
+
+	local helper_src
+	helper_src=$(awk '
+		/^_pmp_refresh_unknown_mergeable_state_into\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^\}$/ { exit }
+	' "$PROCESS_SCRIPT")
+	if [[ "$helper_src" != *"AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view"* || "$helper_src" != *"_pmp_normalize_mergeable_state_into refreshed_mergeable"* || "$helper_src" != *"printf -v \"\$dest_var\""* ]]; then
+		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
+			"Helper must bypass cache, normalize refreshed state, and write caller variable"
 		return 0
 	fi
 
@@ -458,6 +494,7 @@ main() {
 	test_resolve_mergeable_accepts_boolean_true
 	test_resolve_mergeable_retries_boolean_true
 	test_resolve_mergeable_retries_empty_and_logs_empty
+	test_refresh_unknown_mergeable_surfaces_conflicting
 	test_nmr_guard_exists_before_close
 	test_stale_route_runs_before_protected_precheck
 	test_mergeable_refetch_after_update_branch


### PR DESCRIPTION
## Summary

Added a Bash 3.2-safe pulse merge helper that refreshes empty/UNKNOWN mergeable states with cache-disabled gh_pr_view, wired _process_single_ready_pr to use it before CONFLICTING recovery, and added regression coverage for UNKNOWN -> CONFLICTING refresh.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-update-branch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-update-branch.sh; bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-update-branch.sh

Resolves #24658


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.55 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 4m and 68,678 tokens on this as a headless worker.