### PR TITLE
Mission m-20260504-1e325d 3.3: classify local worker runtime errors

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -205,6 +205,27 @@ PY
 		printf '%s' "local_error"
 		return 0
 	fi
+	if [[ "$lowered" == *"spawn"*"enoent"* ]] || [[ "$lowered" == *"command not found"* ]] || [[ "$lowered" == *"no such file or directory"* && "$lowered" == *"opencode"* ]]; then
+		_failure_runtime_error_type="runtime_command_missing"
+		_failure_classification_source="local_runtime"
+		_failure_classification_pattern="command_missing|spawn_enoent"
+		printf '%s' "local_error"
+		return 0
+	fi
+	if [[ "$lowered" == *"permission denied"* ]] || [[ "$lowered" == *"eacces"* ]]; then
+		_failure_runtime_error_type="runtime_permission_denied"
+		_failure_classification_source="local_runtime"
+		_failure_classification_pattern="permission_denied|eacces"
+		printf '%s' "local_error"
+		return 0
+	fi
+	if [[ "$lowered" == *"no space left on device"* ]] || [[ "$lowered" == *"enospc"* ]]; then
+		_failure_runtime_error_type="runtime_storage_full"
+		_failure_classification_source="local_runtime"
+		_failure_classification_pattern="no_space_left|enospc"
+		printf '%s' "local_error"
+		return 0
+	fi
 	# Provider/rate-limit/auth/server classification intentionally uses only
 	# trusted chunks above. Generic tool output, file reads, docs, and skill
 	# content can mention provider failures and must not trigger backoff.

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -109,6 +109,21 @@ fatal: not a git repository
 SQLiteError: disk I/O error' \
 	"local_error" "" "" "opencode_sqlite_io" "opencode_runtime"
 
+check_classification \
+	"local_runtime_missing_command" \
+	'Error: spawn opencode ENOENT' \
+	"local_error" "" "" "runtime_command_missing" "local_runtime"
+
+check_classification \
+	"local_runtime_permission_denied" \
+	'bash: /tmp/aidevops-worker/run.sh: Permission denied' \
+	"local_error" "" "" "runtime_permission_denied" "local_runtime"
+
+check_classification \
+	"local_runtime_storage_full" \
+	'OSError: [Errno 28] No space left on device while writing worker log' \
+	"local_error" "" "" "runtime_storage_full" "local_runtime"
+
 mkdir -p "$METRICS_DIR"
 append_runtime_metric "worker" "issue-22379" "openai/gpt-5.5" "openai" \
 	"provider_error" "1" "provider_error" "1" "1234" "22379" "marcusquinn/aidevops" \


### PR DESCRIPTION
## Summary
- Extend headless worker failure classification for local runtime launch errors.
- Add structured `runtime_error_type` values for missing command / `ENOENT`, permission denied / `EACCES`, and storage-full / `ENOSPC` failures.
- Add regression fixtures to keep these local errors out of provider/rate-limit backoff buckets.

## Mission context
For #23231. Follow-up to PR #23229 for mission `m-20260504-1e325d` task 3.3 (strengthen worker launch and watchdog diagnostics for premature exits, local errors, and stall-killed sessions).

## Testing
- `bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh`
- `bash .agents/scripts/tests/test-worker-diagnostic-evidence.sh`
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-failure-classification.sh`

MERGE_SUMMARY: Local worker runtime launch failures now produce structured `runtime_error_type` diagnostics for command-missing, permission-denied, and storage-full cases, with regression coverage and ShellCheck verification.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.56 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5
