### PR TITLE
fix: expand sibling PR dispatch dedup

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -17,10 +17,11 @@
 # has_open_pr Check 0: healthy open sibling PRs for this issue.
 #
 # Redispatch should not create another worker when an existing sibling PR for
-# the same issue is already approved and mergeable. This catches PRs that are
+# the same issue is already approved or mergeable. This catches PRs that are
 # ready for the merge path but do not use a closing keyword in the body (for
 # example parent/phase work using `For #NNN`), while still allowing dispatch
-# when only draft, unapproved, or conflicting candidates exist.
+# when only draft, changes-requested, conflicting, or explicitly blocked
+# candidates exist.
 #
 # Args: $1 = issue number, $2 = repo slug
 # Returns: exit 0 if a healthy sibling PR matches, exit 1 if none
@@ -32,20 +33,27 @@ _has_open_pr_check_healthy_sibling() {
 	local pr_json match_pr
 	pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number}" --limit 20 \
-		--json number,title,body,isDraft,reviewDecision,mergeStateStatus 2>/dev/null) || pr_json="[]"
+		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable 2>/dev/null) || pr_json="[]"
 
-	local issue_ref_pattern healthy_state_pattern
+	local issue_ref_pattern healthy_state_pattern blocked_state_pattern
 	issue_ref_pattern="([^[:alnum:]_]|^)((close[sd]?|fix(e[sd])?|resolve[sd]?|for|refs?):?[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}|GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
 	healthy_state_pattern="^(CLEAN|HAS_HOOKS|UNSTABLE|BEHIND)$"
+	blocked_state_pattern="^(DIRTY|BLOCKED|CONFLICTING)$"
 
 	match_pr=$(printf '%s' "$pr_json" | jq -r \
 		--arg issue_pattern "$issue_ref_pattern" \
 		--arg healthy_pattern "$healthy_state_pattern" \
+		--arg blocked_pattern "$blocked_state_pattern" \
 		'[
 			.[] | select(
 				(.isDraft // false | not) and
-				((.reviewDecision // "") == "APPROVED") and
-				((.mergeStateStatus // "") | test($healthy_pattern)) and
+				((.reviewDecision // "") != "CHANGES_REQUESTED") and
+				(((.mergeStateStatus // "") | test($blocked_pattern) | not)) and
+				(
+					((.reviewDecision // "") == "APPROVED") or
+					((.mergeStateStatus // "") | test($healthy_pattern)) or
+					((.mergeable // "") == "MERGEABLE")
+				) and
 				(((.title // "") | test($issue_pattern; "i")) or ((.body // "") | test($issue_pattern; "i")))
 			)
 		] | .[0].number // empty' 2>/dev/null) || match_pr=""

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -352,6 +352,49 @@ test_has_open_pr_blocks_approved_mergeable_sibling() {
 	return 0
 }
 
+test_has_open_pr_blocks_approved_sibling_without_merge_state() {
+	# Approved siblings can briefly have UNKNOWN merge state while GitHub computes
+	# mergeability. They should still suppress redispatch unless explicitly
+	# blocked/conflicting, because an approved sibling is already in the merge path.
+	set_gh_fixtures 'marcusquinn/aidevops|open|#23255|[{"number":23295,"title":"Approved sibling","body":"For #23255. Adds the worker redispatch guard.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"UNKNOWN"}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 23255 marcusquinn/aidevops 't3505: approved sibling dedup'); then
+		case "$output" in
+		*'open PR #23295 is approved and mergeable for issue #23255'*)
+			print_result "has-open-pr blocks approved sibling while merge state computes" 0
+			return 0
+			;;
+		esac
+		print_result "has-open-pr blocks approved sibling while merge state computes" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr blocks approved sibling while merge state computes" 1 "Expected approved sibling PR to block redispatch"
+	return 0
+}
+
+test_has_open_pr_blocks_mergeable_sibling_without_approval() {
+	# A clean/mergeable sibling is already healthy enough for normal review/merge
+	# progression. Dispatching another worker would race the in-flight PR.
+	set_gh_fixtures 'marcusquinn/aidevops|open|#23256|[{"number":23296,"title":"Mergeable sibling","body":"For #23256. Adds the worker redispatch guard.","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"CLEAN","mergeable":"MERGEABLE"}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 23256 marcusquinn/aidevops 't3506: mergeable sibling dedup'); then
+		case "$output" in
+		*'open PR #23296 is approved and mergeable for issue #23256'*)
+			print_result "has-open-pr blocks mergeable sibling without approval" 0
+			return 0
+			;;
+		esac
+		print_result "has-open-pr blocks mergeable sibling without approval" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr blocks mergeable sibling without approval" 1 "Expected mergeable sibling PR to block redispatch"
+	return 0
+}
+
 test_has_open_pr_blocks_refs_colon_healthy_sibling() {
 	# Check 0 supports common reference variants used by PR bodies, including
 	# plural `Refs` and colon punctuation after the keyword.
@@ -395,14 +438,15 @@ test_has_open_pr_blocks_behind_healthy_sibling() {
 }
 
 test_has_open_pr_allows_when_no_healthy_sibling() {
-	# Unhealthy siblings (draft, unapproved, or conflicting) must not hold the
-	# issue forever. They are not candidates the merge path can finish safely, so
-	# redispatch remains allowed when no other PR evidence exists.
-	set_gh_fixtures 'marcusquinn/aidevops|open|#23251|[{"number":23289,"title":"Draft sibling","body":"For #23251.","isDraft":true,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN"},{"number":23290,"title":"Needs review","body":"For #23251.","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"CLEAN"},{"number":23291,"title":"Conflicting sibling","body":"For #23251.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"DIRTY"}]'
+	# Blocked siblings (draft, changes-requested, conflicting, or unknown without
+	# approval) must not hold the issue forever. They are not candidates the merge
+	# path can finish safely, so redispatch remains allowed when no other PR
+	# evidence exists.
+	set_gh_fixtures 'marcusquinn/aidevops|open|#23251|[{"number":23289,"title":"Draft sibling","body":"For #23251.","isDraft":true,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN"},{"number":23290,"title":"Needs changes","body":"For #23251.","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","mergeStateStatus":"CLEAN"},{"number":23291,"title":"Conflicting sibling","body":"For #23251.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"DIRTY"},{"number":23297,"title":"Unknown sibling","body":"For #23251.","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"UNKNOWN"}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 23251 marcusquinn/aidevops 't3501: allow unhealthy sibling recovery'; then
 		print_result "has-open-pr allows dispatch when no healthy sibling exists" 1 \
-			"Expected exit 1: draft/unapproved/conflicting siblings must not block redispatch"
+			"Expected exit 1: draft/changes-requested/conflicting/unknown siblings must not block redispatch"
 		return 0
 	fi
 
@@ -458,6 +502,8 @@ main() {
 	test_has_open_pr_ignores_open_body_planning_for_reference
 	test_has_open_pr_requires_open_close_keyword_for_our_issue
 	test_has_open_pr_blocks_approved_mergeable_sibling
+	test_has_open_pr_blocks_approved_sibling_without_merge_state
+	test_has_open_pr_blocks_mergeable_sibling_without_approval
 	test_has_open_pr_blocks_refs_colon_healthy_sibling
 	test_has_open_pr_blocks_behind_healthy_sibling
 	test_has_open_pr_allows_when_no_healthy_sibling


### PR DESCRIPTION
## Summary
- Expands dispatch dedup sibling PR evidence from approved-and-mergeable to approved-or-mergeable/healthy siblings.
- Blocks redispatch for approved siblings while GitHub mergeability is still UNKNOWN unless the PR is explicitly blocked/conflicting.
- Blocks redispatch for clean/mergeable siblings even before approval, while preserving redispatch for draft, changes-requested, conflicting, or unknown-unreviewed siblings.

For #23234

## Mission context
- Continuation of mission m-20260508-0e27c3 task 2.3.
- Prior task #23234 / PR #23230 added the healthy sibling check; this follow-up aligns it with approved OR mergeable sibling semantics from the mission prompt.

## Verification
- bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
- shellcheck .agents/scripts/dispatch-dedup-pr.sh .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
