### PR TITLE
GH#24702: fix: robustly classify spawn ENOENT errors

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -205,7 +205,7 @@ PY
 		printf '%s' "local_error"
 		return 0
 	fi
-	if [[ "$lowered" == *"spawn"*"enoent"* ]] || [[ "$lowered" == *"command not found"* ]] || [[ "$lowered" == *"no such file or directory"* && "$lowered" == *"opencode"* ]]; then
+	if [[ "$lowered" == *"spawn"* && "$lowered" == *"enoent"* ]] || [[ "$lowered" == *"command not found"* ]] || [[ "$lowered" == *"no such file or directory"* && "$lowered" == *"opencode"* ]]; then
 		_failure_runtime_error_type="runtime_command_missing"
 		_failure_classification_source="local_runtime"
 		_failure_classification_pattern="command_missing|spawn_enoent"

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -115,6 +115,11 @@ check_classification \
 	"local_error" "" "" "runtime_command_missing" "local_runtime"
 
 check_classification \
+	"local_runtime_missing_command_reversed_spawn_order" \
+	'ENOENT: no such file or directory, spawn opencode' \
+	"local_error" "" "" "runtime_command_missing" "local_runtime"
+
+check_classification \
 	"local_runtime_permission_denied" \
 	'bash: /tmp/aidevops-worker/run.sh: Permission denied' \
 	"local_error" "" "" "runtime_permission_denied" "local_runtime"


### PR DESCRIPTION
## Summary

Updated headless runtime local command-missing classification to detect spawn and ENOENT independently, so reversed Node.js error wording still maps to local_error. Added a regression fixture for the reversed ENOENT/spawn order.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-failure-classification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh; shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-failure-classification.sh

Resolves #24702


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.56 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 1m and 66,374 tokens on this as a headless worker.