### PR TITLE
GH#24706: fix: preserve OpenAI OAuth probe metrics

### DIFF
--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -535,8 +535,8 @@ _probe_check_oauth_fallback() {
 			_probe_openai_oauth_fallback_verified "$auth_file" "$quiet" || oauth_exit=$?
 			if [[ "$oauth_exit" -ne 0 ]]; then
 				[[ "$quiet" != "true" ]] && print_warning "$provider: env key rejected (HTTP 401/403); OpenAI OAuth API verification failed"
-				return "$oauth_exit"
 			fi
+			return "$oauth_exit"
 		fi
 		[[ "$quiet" != "true" ]] && print_success "$provider: env key rejected (HTTP 401/403) but OAuth found in auth.json — recording healthy (t3229)"
 		_record_health "$provider" "healthy" 0 0 "OAuth available (env key rejected, t3229)" 0

--- a/.agents/scripts/tests/test-model-availability-oauth-probe.sh
+++ b/.agents/scripts/tests/test-model-availability-oauth-probe.sh
@@ -266,6 +266,14 @@ else
 		"(got rc=$rc — expected 0; successful OAuth API verification should record healthy)"
 fi
 
+health_row=$(db_query "SELECT response_ms || ':' || models_count FROM provider_health WHERE provider = 'openai';")
+if [[ "$health_row" == "1:1" ]]; then
+	print_result "rejected-non-env-key+openai-oauth: preserves live probe health metrics" 0
+else
+	print_result "rejected-non-env-key+openai-oauth: preserves live probe health metrics" 1 \
+		"(got '$health_row' — expected response_ms:models_count of 1:1 from the live OAuth probe)"
+fi
+
 # Assertion 4b.1 — Sourced credentials.sh-style variables are not process env.
 # resolve_api_key sources credentials.sh into the helper process, leaving an
 # OPENAI_API_KEY shell variable behind even though key_source is credentials:*.


### PR DESCRIPTION
## Summary

Returned immediately after OpenAI OAuth fallback verification so the live HTTP probe health row is not overwritten by synthetic OAuth availability metrics. Added a regression assertion for response time and model count preservation.

## Files Changed

.agents/scripts/model-availability-probe-lib.sh,.agents/scripts/tests/test-model-availability-oauth-probe.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/model-availability-probe-lib.sh .agents/scripts/tests/test-model-availability-oauth-probe.sh && .agents/scripts/tests/test-model-availability-oauth-probe.sh

Resolves #24706


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.56 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 2m and 88,186 tokens on this as a headless worker.