### PR TITLE
test: cover scheduler review regressions

### DIFF
--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -1449,4 +1449,6 @@ main() {
 	return 0
 }
 
-main "$@"
+if [[ "${AIDEVOPS_REPO_HEALTH_HELPER_SOURCE_ONLY:-0}" != "1" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-repo-aidevops-health.sh
+++ b/.agents/scripts/tests/test-repo-aidevops-health.sh
@@ -59,6 +59,16 @@ assert_contains() {
 	fi
 }
 
+load_helper_without_main() {
+	local source_copy="$1"
+	AIDEVOPS_REPO_HEALTH_HELPER_SOURCE_ONLY=1
+	# shellcheck source=/dev/null
+	source "$HELPER"
+	unset AIDEVOPS_REPO_HEALTH_HELPER_SOURCE_ONLY
+	: >"$source_copy"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Test 1 — helper is executable
 # ---------------------------------------------------------------------------
@@ -127,7 +137,7 @@ CONFIG_FILE="$FIXTURE_DIR/repos.json" \
 	AIDEVOPS_REPO_HEALTH_DRY_RUN=1 \
 	"$HELPER" check >"$DRY_LOG" 2>&1 || true
 
-LOG_CONTENT="$(cat ~/.aidevops/logs/repo-aidevops-health.log 2>/dev/null | tail -30 || true)"
+LOG_CONTENT="$(tail -30 ~/.aidevops/logs/repo-aidevops-health.log 2>/dev/null || true)"
 
 # NOTE: The helper reads CONFIG_FILE from its own readonly — the env override
 # above is a best-effort. If the helper didn't honour it, the test will still
@@ -155,6 +165,14 @@ else
 	FAIL=$((FAIL + 1))
 fi
 assert_contains "unknown subcommand prints help" "$UNKNOWN_OUT" "Unknown command"
+
+# ---------------------------------------------------------------------------
+# Test 6 — plist generation accepts legacy two-argument invocation
+# ---------------------------------------------------------------------------
+load_helper_without_main "$FIXTURE_DIR/helper-functions.sh"
+PLIST_OUT=$(_generate_plist "/tmp/aidevops-health" "/usr/bin:/bin")
+assert_contains "plist two-argument legacy call keeps environment path" "$PLIST_OUT" "<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>"
+assert_contains "plist generation uses calendar schedule" "$PLIST_OUT" "<key>StartCalendarInterval</key>"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.agents/scripts/tests/test-routine-systemd-calendar.sh
+++ b/.agents/scripts/tests/test-routine-systemd-calendar.sh
@@ -125,6 +125,23 @@ test_pulse_step_minutes_supported() {
 	return 0
 }
 
+test_empty_schedule_fails_cleanly() {
+	local output=""
+	local rc=0
+	set +e
+	output=$("${REPO_SCRIPTS_DIR}/routine-schedule-helper.sh" parse '' 2>&1)
+	rc=$?
+	set -e
+
+	if [[ "$rc" -ne 0 && "$output" != *"unary operator expected"* && "$output" == *"unrecognised schedule expression"* ]]; then
+		print_result "empty schedule expression uses clean parse error" 0
+	else
+		print_result "empty schedule expression uses clean parse error" 1 \
+			"Expected clean non-zero parse error, rc=$rc output: $output"
+	fi
+	return 0
+}
+
 main() {
 	printf 'Running routine systemd calendar tests...\n\n'
 
@@ -133,6 +150,7 @@ main() {
 	test_step_minutes_supported
 	test_daily_expression_supported
 	test_pulse_step_minutes_supported
+	test_empty_schedule_fails_cleanly
 
 	printf '\n%s/%s tests passed.\n' \
 		"$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"


### PR DESCRIPTION
## Summary
- add source-only loading for repo-aidevops-health helper so private plist generation can be regression-tested without running main
- cover legacy two-argument `_generate_plist` env-path handling from PR #24698 review feedback
- cover empty routine schedule parsing so it stays on the clean parse-error path instead of a Bash unary-operator failure

Resolves #24704

## Testing
- `shellcheck .agents/scripts/repo-aidevops-health-helper.sh .agents/scripts/routine-schedule-helper.sh .agents/scripts/tests/test-routine-systemd-calendar.sh .agents/scripts/tests/test-repo-aidevops-health.sh`
- `.agents/scripts/tests/test-routine-systemd-calendar.sh`
- `GIT_CONFIG_GLOBAL=/dev/null .agents/scripts/tests/test-repo-aidevops-health.sh`
- `.agents/scripts/linters-local.sh`

MERGE_SUMMARY: Added regression coverage for the PR #24698 review-bot findings. `_generate_plist` now has a source-only test path verifying legacy two-argument env-path fallback remains safe, and routine schedule parsing verifies empty expressions fail cleanly without unary-operator errors.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.56 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5
