### PR TITLE
GH#24710: fix: use numeric opencode threshold result comparison

### DIFF
--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -274,7 +274,7 @@ _freelist_exceeds_threshold() {
 	[[ $((10#$page_count)) -eq 0 ]] && return 1
 	local threshold_met
 	threshold_met=$(awk -v free="$freelist_count" -v pages="$page_count" -v threshold="$VACUUM_FREELIST_THRESHOLD" 'BEGIN { if (pages <= 0) { print 0; exit } print ((free / pages) >= threshold) ? 1 : 0 }' </dev/null)
-	if [[ "$threshold_met" == "1" ]]; then
+	if [[ "$threshold_met" =~ ^[0-9]+$ && $((10#$threshold_met)) -eq 1 ]]; then
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
## Summary

Changed the opencode DB freelist threshold result check from string equality to a guarded numeric comparison, preserving base-10 normalization for any leading-zero result.

## Files Changed

.agents/scripts/opencode-db-maintenance-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/opencode-db-maintenance-helper.sh; bash .agents/scripts/tests/test-opencode-db-maintenance.sh (25 passed, 0 failed)

Resolves #24710


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.56 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 36,071 tokens on this as a headless worker.