### PR TITLE
t3598: fix headless external gh write guard

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -175,6 +175,165 @@ _find_real_gh() {
 }
 
 # -----------------------------------------------------------------------------
+# Headless external-repo write guard.
+#
+# Signature/footer and privacy layers protect content shape. Automated pulse and
+# routine workers also need a trust-boundary guard: contributor/read-only repos
+# are observe-only unless a human explicitly instigates the exact target. Keep
+# this in the PATH shim so raw `gh ...` calls from LLM workers and scripts share
+# one fail-closed gate.
+# -----------------------------------------------------------------------------
+_shim_is_headless_automation() {
+	case ":${HEADLESS:-}:${FULL_LOOP_HEADLESS:-}:${AIDEVOPS_HEADLESS:-}:${OPENCODE_HEADLESS:-}:${GITHUB_ACTIONS:-}:${AIDEVOPS_SESSION_ORIGIN:-}:" in
+	*:1:* | *:true:* | *:worker:* | *:pulse:* | *:routine:* | *:headless:*) return 0 ;;
+	esac
+	return 1
+}
+
+_shim_normalize_repo_slug() {
+	local target="$1"
+	target="${target#https://github.com/}"
+	target="${target#http://github.com/}"
+	target="${target#git@github.com:}"
+	target="${target%.git}"
+	if [[ "$target" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		printf '%s\n' "$target"
+		return 0
+	fi
+	return 1
+}
+
+_shim_repo_from_git_remote() {
+	local remote_url=""
+	remote_url=$(git remote get-url origin 2>/dev/null || true)
+	[[ -z "$remote_url" ]] && return 1
+	_shim_normalize_repo_slug "$remote_url"
+	return $?
+}
+
+_shim_repo_from_args() {
+	local args=("$@")
+	local idx=0
+	local arg=""
+	local next=""
+	while [[ $idx -lt ${#args[@]} ]]; do
+		arg="${args[$idx]}"
+		case "$arg" in
+		--repo | -R)
+			next="${args[idx + 1]:-}"
+			_shim_normalize_repo_slug "$next" && return 0
+			idx=$((idx + 2))
+			continue
+			;;
+		--repo=*) _shim_normalize_repo_slug "${arg#--repo=}" && return 0 ;;
+		-R*) _shim_normalize_repo_slug "${arg#-R}" && return 0 ;;
+		esac
+		idx=$((idx + 1))
+	done
+	return 1
+}
+
+_shim_repo_from_api_path_args() {
+	local args=("$@")
+	local idx=0
+	local arg=""
+	local path=""
+	while [[ $idx -lt ${#args[@]} ]]; do
+		arg="${args[$idx]}"
+		case "$arg" in
+		-f | --field | -F | --raw-field | --jq | -H | --header | --input | --template | --cache | --hostname | --preview | -X | --method)
+			idx=$((idx + 2))
+			continue
+			;;
+		api) ;;
+		/repos/* | repos/*) [[ -z "$path" ]] && path="$arg" ;;
+		-*) ;;
+		*) [[ -z "$path" ]] && path="$arg" ;;
+		esac
+		idx=$((idx + 1))
+	done
+	local npath="${path#/}"
+	if [[ "$npath" =~ ^repos/([^/]+/[^/]+)(/|$|\?) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+_shim_target_repo_slug() {
+	local repo_slug=""
+	repo_slug=$(_shim_repo_from_args "$@" 2>/dev/null || true)
+	if [[ -z "$repo_slug" && "${1:-}" == "api" ]]; then
+		repo_slug=$(_shim_repo_from_api_path_args "$@" 2>/dev/null || true)
+	fi
+	if [[ -z "$repo_slug" ]]; then
+		repo_slug=$(_shim_repo_from_git_remote 2>/dev/null || true)
+	fi
+	[[ -n "$repo_slug" ]] || return 1
+	printf '%s\n' "$repo_slug"
+	return 0
+}
+
+_shim_repo_role() {
+	local repo_slug="$1"
+	local repos_json="${AIDEVOPS_REPOS_JSON:-${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}}"
+	local explicit_role=""
+	if [[ -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
+		explicit_role=$(jq -r --arg slug "$repo_slug" 'first(.initialized_repos[]? | select(.slug == $slug) | .role) // ""' "$repos_json" 2>/dev/null || true)
+		case "$explicit_role" in
+		maintainer | contributor)
+			printf '%s\n' "$explicit_role"
+			return 0
+			;;
+		esac
+	fi
+	printf 'contributor\n'
+	return 0
+}
+
+_shim_external_write_has_explicit_instigation() {
+	local repo_slug="$1"
+	local allow="${AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE:-${AIDEVOPS_EXTERNAL_GH_WRITE_ALLOWLIST:-}}"
+	local item=""
+	local allow_items=()
+	[[ -z "$allow" ]] && return 1
+	IFS=',' read -r -a allow_items <<< "$allow"
+	for item in "${allow_items[@]}"; do
+		item="${item#"${item%%[![:space:]]*}"}"
+		item="${item%"${item##*[![:space:]]}"}"
+		if [[ "$item" == "$repo_slug" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+_shim_is_content_write_command() {
+	case "${1:-}:${2:-}" in
+	issue:comment | issue:create | issue:edit | issue:close | issue:reopen | issue:lock | issue:pin | issue:delete | \
+	pr:create | pr:comment | pr:edit | pr:review | pr:merge | pr:close | pr:reopen | pr:ready | pr:lock | \
+	label:create | label:edit | label:delete | release:create | release:delete | release:upload)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+_shim_block_headless_external_write_if_needed() {
+	_shim_is_headless_automation || return 0
+	local repo_slug=""
+	repo_slug=$(_shim_target_repo_slug "$@" 2>/dev/null || true)
+	[[ -z "$repo_slug" ]] && return 0
+	local repo_role="contributor"
+	repo_role=$(_shim_repo_role "$repo_slug" 2>/dev/null || printf 'contributor\n')
+	[[ "$repo_role" == "maintainer" ]] && return 0
+	_shim_external_write_has_explicit_instigation "$repo_slug" && return 0
+	printf '[aidevops][external-write-guard][BLOCK] Headless automation attempted a GitHub write to contributor/read-only repo %s.\n' "$repo_slug" >&2
+	printf '  This repo is observe-only for unattended pulse/routine workers. Re-run interactively or set AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE=%s for this exact target.\n' "$repo_slug" >&2
+	return 1
+}
+
+# -----------------------------------------------------------------------------
 # Fast pass-through for non-intercepted subcommands.
 # Every gh invocation pays this case-match plus one exec.
 # t2876: extended to include issue:edit and pr:edit so privacy-scan layer
@@ -185,7 +344,9 @@ _find_real_gh() {
 # -----------------------------------------------------------------------------
 _SHIM_READ_REWRITE=""
 case "${1:-}:${2:-}" in
-	issue:comment | issue:create | issue:edit | pr:create | pr:comment | pr:edit | pr:review) ;;
+	issue:comment | issue:create | issue:edit | issue:close | issue:reopen | issue:lock | issue:pin | issue:delete | \
+	pr:create | pr:comment | pr:edit | pr:review | pr:merge | pr:close | pr:reopen | pr:ready | pr:lock | \
+	label:create | label:edit | label:delete | release:create | release:delete | release:upload) ;;
 pr:view | issue:view | pr:list | issue:list)
 	# t3037: read subcommands — may be rewritten to REST when GraphQL budget
 	# is low. Falls through to the read-rewrite handler below.
@@ -939,6 +1100,12 @@ _shim_normalize_interactive_tracking_issue_create() {
 
 _shim_normalize_interactive_tracking_issue_create
 
+if _shim_is_content_write_command "${_modified_args[@]}"; then
+	if ! _shim_block_headless_external_write_if_needed "${_modified_args[@]}"; then
+		exit 1
+	fi
+fi
+
 # -----------------------------------------------------------------------------
 # Handle `gh api` subcommand: intercept write calls to content endpoints.
 # Non-targeted api calls pass straight through after this block.
@@ -946,6 +1113,9 @@ _shim_normalize_interactive_tracking_issue_create
 # -----------------------------------------------------------------------------
 if [[ "${1:-}" == "api" ]]; then
 	if _shim_api_is_write_endpoint; then
+		if ! _shim_block_headless_external_write_if_needed "${_modified_args[@]}"; then
+			exit 1
+		fi
 		_shim_api_inject_body_sig
 		if ! _shim_privacy_scan; then
 			exit 1

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -28,6 +28,8 @@ unset FULL_LOOP_HEADLESS
 unset AIDEVOPS_HEADLESS
 unset OPENCODE_HEADLESS
 unset GITHUB_ACTIONS
+unset AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE
+unset AIDEVOPS_EXTERNAL_GH_WRITE_ALLOWLIST
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
@@ -456,7 +458,7 @@ else
 fi
 
 _reset_log
-AIDEVOPS_HEADLESS=1 "$SHIM_RUN" issue create --repo owner/repo --title "t3565: Headless labels" --body "tracking body" 2>/dev/null
+AIDEVOPS_HEADLESS=1 AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE=owner/repo "$SHIM_RUN" issue create --repo owner/repo --title "t3565: Headless labels" --body "tracking body" 2>/dev/null
 argv=$(_read_argv)
 if [[ "$argv" != *"origin:interactive"* ]] && [[ "$argv" != *"status:in-review"* ]]; then
 	_pass "headless issue creation is not normalized as interactive"
@@ -481,6 +483,91 @@ if [[ "$argv" == *$'--label\norigin:interactive'* ]] && [[ "$argv" == *$'--label
 	_pass "last title flag wins during normalization"
 else
 	_fail "multiple title flag handling" "argv: $argv"
+fi
+
+# =============================================================================
+# Test 18: headless external contributor write guard blocks raw comments
+# =============================================================================
+echo ""
+echo "Test 18: headless external write guard blocks raw comments"
+_reset_log
+if AIDEVOPS_HEADLESS=1 "$SHIM_RUN" issue comment 123 --repo external/repo --body "uninstigated" 2>"$TMP/guard-issue.err"; then
+	_fail "headless issue comment guard" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-issue.err"; then
+		_pass "headless issue comment to contributor repo is blocked before gh exec"
+	else
+		_fail "headless issue comment guard" "argv: $argv err: $(cat "$TMP/guard-issue.err" 2>/dev/null || true)"
+	fi
+fi
+
+_reset_log
+if AIDEVOPS_SESSION_ORIGIN=pulse "$SHIM_RUN" pr comment 456 --repo external/repo --body "uninstigated" 2>"$TMP/guard-pr.err"; then
+	_fail "headless pr comment guard" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-pr.err"; then
+		_pass "headless pr comment to contributor repo is blocked before gh exec"
+	else
+		_fail "headless pr comment guard" "argv: $argv err: $(cat "$TMP/guard-pr.err" 2>/dev/null || true)"
+	fi
+fi
+
+# =============================================================================
+# Test 19: headless external write guard blocks REST write endpoints
+# =============================================================================
+echo ""
+echo "Test 19: headless external write guard blocks REST writes"
+_reset_log
+if FULL_LOOP_HEADLESS=1 "$SHIM_RUN" api /repos/external/repo/issues/123/comments -X POST -f body="uninstigated" 2>"$TMP/guard-api.err"; then
+	_fail "headless REST comment guard" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api.err"; then
+		_pass "headless REST issue comment endpoint is blocked before gh exec"
+	else
+		_fail "headless REST comment guard" "argv: $argv err: $(cat "$TMP/guard-api.err" 2>/dev/null || true)"
+	fi
+fi
+
+# =============================================================================
+# Test 20: interactive or explicitly instigated writes still pass through
+# =============================================================================
+echo ""
+echo "Test 20: interactive and explicit external writes pass"
+_reset_log
+"$SHIM_RUN" issue comment 123 --repo external/repo --body "interactive" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "interactive external comment still receives normal signature handling"
+else
+	_fail "interactive external comment pass-through" "argv: $argv"
+fi
+
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE=external/repo "$SHIM_RUN" pr comment 456 --repo external/repo --body "explicit" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "explicit per-repo headless allowance permits normal signature handling"
+else
+	_fail "explicit headless external allowance" "argv: $argv"
+fi
+
+# =============================================================================
+# Test 21: managed maintainer repos are not blocked in headless mode
+# =============================================================================
+echo ""
+echo "Test 21: maintainer repo metadata permits headless writes"
+repos_json="$TMP/repos.json"
+printf '{"initialized_repos":[{"slug":"managed/repo","role":"maintainer"}]}' >"$repos_json"
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" issue comment 789 --repo managed/repo --body "managed" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "headless write to maintainer-managed repo proceeds normally"
+else
+	_fail "maintainer repo headless write" "argv: $argv"
 fi
 
 # =============================================================================

--- a/TODO.md
+++ b/TODO.md
@@ -978,6 +978,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3597 Release preflight ShellCheck SC2123 blocks v3.20.44 #bug ref:GH#24628 pr:#24629 completed:2026-06-10
 
+- [ ] t3598 Headless external GitHub write guard #bug #security ref:GH#24720
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Add a centralized gh PATH-shim guard that blocks headless/pulse/routine GitHub writes to contributor/read-only repos unless the exact target is explicitly instigated.
- Cover raw CLI comment/write commands and REST comment endpoints before signature/privacy handling.
- Add regression tests for blocked issue comments, PR comments, REST comment endpoints, explicit per-repo allowance, and maintainer metadata pass-through.
- Track the hotfix as t3598 in TODO.

Resolves #24720

## Verification
- `.agents/scripts/tests/test-gh-shim.sh` — 29 passed, 0 failed
- `shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh`
- `.agents/scripts/linters-local.sh` partially completed: SonarCloud, Secretlint, TOON, skill frontmatter, secret safety, pulse canary, Bash 3.2 checks passed; markdown and ratchet findings were advisory/pre-existing; command timed out during later portability checks.

## Release note
This is a safety hotfix for unattended automation: external/contributor repos are observe-only by default for headless GitHub writes.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.56 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 1h 9m and 702,805 tokens on this with the user in an interactive session.