### PR TITLE
GH#24721: fix: harden gh shim repo extraction

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -192,9 +192,8 @@ _shim_is_headless_automation() {
 
 _shim_normalize_repo_slug() {
 	local target="$1"
-	target="${target#https://github.com/}"
-	target="${target#http://github.com/}"
-	target="${target#git@github.com:}"
+	target="${target#*github.com/}"
+	target="${target#*github.com:}"
 	target="${target%.git}"
 	if [[ "$target" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
 		printf '%s\n' "$target"
@@ -248,7 +247,6 @@ _shim_repo_from_api_path_args() {
 		api) ;;
 		/repos/* | repos/*) [[ -z "$path" ]] && path="$arg" ;;
 		-*) ;;
-		*) [[ -z "$path" ]] && path="$arg" ;;
 		esac
 		idx=$((idx + 1))
 	done

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -24,10 +24,12 @@ set -euo pipefail
 # routing globally, but tests opt into that per scenario below.
 unset AIDEVOPS_GH_REST_FIRST_READS
 unset AIDEVOPS_GH_FORCE_REST_READS
+unset HEADLESS
 unset FULL_LOOP_HEADLESS
 unset AIDEVOPS_HEADLESS
 unset OPENCODE_HEADLESS
 unset GITHUB_ACTIONS
+unset AIDEVOPS_SESSION_ORIGIN
 unset AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE
 unset AIDEVOPS_EXTERNAL_GH_WRITE_ALLOWLIST
 
@@ -568,6 +570,45 @@ if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
 	_pass "headless write to maintainer-managed repo proceeds normally"
 else
 	_fail "maintainer repo headless write" "argv: $argv"
+fi
+
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" issue comment 789 --repo ssh://git@github.com/managed/repo.git --body "managed" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "headless write guard normalizes ssh github repo URLs"
+else
+	_fail "ssh github repo URL normalization" "argv: $argv"
+fi
+
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" issue comment 789 --repo https://token@github.com/managed/repo.git --body "managed" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "headless write guard normalizes credentialed github repo URLs"
+else
+	_fail "credentialed github repo URL normalization" "argv: $argv"
+fi
+
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" issue comment 789 --repo git://github.com/managed/repo.git --body "managed" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "headless write guard normalizes git protocol github repo URLs"
+else
+	_fail "git protocol github repo URL normalization" "argv: $argv"
+fi
+
+_reset_log
+if FULL_LOOP_HEADLESS=1 "$SHIM_RUN" api --jq . /repos/external/repo/issues/123/comments -X POST -f body="uninstigated" 2>"$TMP/guard-api-positional.err"; then
+	_fail "headless REST guard ignores non-path positionals" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api-positional.err"; then
+		_pass "headless REST guard finds repo path after query positional"
+	else
+		_fail "headless REST guard path extraction after query positional" "argv: $argv err: $(cat "$TMP/guard-api-positional.err" 2>/dev/null || true)"
+	fi
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Hardened the gh PATH shim so repo slug normalization handles ssh/git/credentialed GitHub URLs, and REST API path detection ignores non-path positional arguments before /repos/... paths. Added regression coverage for both review findings and made the gh shim harness unset headless session-origin variables for hermetic local execution.

## Files Changed

.agents/scripts/gh,.agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-shim.sh; shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh

Resolves #24721


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 59,921 tokens on this as a headless worker.