### PR TITLE
GH#24723: fix: classify provider nonzero successes

### DIFF
--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -328,6 +328,8 @@ assert_contains "5i: human output shows failure families" "Failure families" "$O
 echo
 echo "--- Section 6: provider/account diagnostics ---"
 
+printf '{"ts":%d,"role":"worker","session_key":"issue-13","model":"openai/gpt-5.5","provider":"openai","result":"success","exit_code":9}\n' "$T_5MIN_AGO" >>"$METRICS"
+
 JSON=$(env "${RUN_ENV[@]}" "$HELPER" providers --since 24h --json 2>&1)
 RC=$?
 assert_rc "6a: providers --json exits 0" 0 "$RC"
@@ -335,6 +337,8 @@ assert_eq "6b: openai available accounts exclude auth-error/rate-limited" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .available')"
 assert_eq "6c: openai capacity_slots uses redacted multiplier" "4" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
+assert_eq "6c2: nonzero-exit success counts as other provider failure" "4" \
+	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .other_failure')"
 
 OUT=$(env "${RUN_ENV[@]}" "$HELPER" providers --since 24h 2>&1)
 assert_contains "6d: human provider output shows capacity slots" "capacity_slots=4" "$OUT"

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -270,7 +270,7 @@ _wah_provider_usage_json() {
 						count: length,
 						success: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length),
 						rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length),
-						other_failure: (map(select((.result // "") != "success" and (.result // "") != "rate_limit")) | length),
+						other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and (.result // "") != "rate_limit" and (.provider_error_type // "") != "rate_limit" and (.provider_status // "") != "429")) | length),
 						latest_ts: (map(.ts // 0) | max)
 					})
 					| sort_by(.count, .latest_ts) | reverse | .[0:12]
@@ -300,7 +300,7 @@ _wah_provider_usage_json() {
 		jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
 			[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 			| {
-				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, success: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length), other_failure: (map(select((.result // "") != "success" and (.result // "") != "rate_limit")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
+				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, success: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length), other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and (.result // "") != "rate_limit" and (.provider_error_type // "") != "rate_limit" and (.provider_status // "") != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
 				recent_events: ($w | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, provider, model, result, exit_code, issue_number, session_key})),
 				account_pool: []
 			}' <"$input_file" 2>/dev/null || printf '{"provider_model_usage":[],"recent_events":[],"account_pool":[]}'


### PR DESCRIPTION
## Summary

Updated worker activity provider diagnostics so result=success records with non-zero exit codes count as other_failure unless they are rate-limit records; added regression coverage in test-worker-activity-helper.

## Files Changed

.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-worker-activity-helper.sh (63 tests passed); bash -n .agents/scripts/worker-activity-helper.sh .agents/scripts/tests/test-worker-activity-helper.sh; pre-commit shell validation passed during WIP commit

Resolves #24723


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 74,308 tokens on this as a headless worker.