### PR TITLE
fix: block recovered merge-stuck dispatch

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -111,6 +111,61 @@ _register_validators() {
 }
 
 # ---------------------------------------------------------------------------
+# Merge-stuck zero-progress meta-issue validator (GH#24729)
+# ---------------------------------------------------------------------------
+_zero_progress_gauge_from_stats() {
+	local stats_file="${PULSE_STATS_FILE:-${HOME}/.aidevops/logs/pulse-stats.json}"
+
+	if [[ ! -f "$stats_file" ]]; then
+		return 1
+	fi
+
+	local gauge_value
+	gauge_value=$(jq -r '(.gauges.pulse_merge_zero_progress_cycles.value // empty) | tostring' \
+		"$stats_file" 2>/dev/null) || return 1
+	if [[ -z "$gauge_value" ]]; then
+		return 1
+	fi
+
+	printf '%s\n' "$gauge_value"
+	return 0
+}
+
+_close_zero_progress_meta_if_recovered() {
+	local issue_number="$1"
+	local slug="$2"
+	local issue_body="$3"
+
+	if [[ "$issue_body" != *"merge-stuck:zero-progress"* ]]; then
+		return 0
+	fi
+
+	local zero_progress_cycles
+	zero_progress_cycles=$(_zero_progress_gauge_from_stats) || {
+		_log "WARN" "#${issue_number}: zero-progress meta validator could not read pulse_merge_zero_progress_cycles — dispatch proceeds"
+		return 0
+	}
+	if [[ "$zero_progress_cycles" != "0" ]]; then
+		_log "INFO" "#${issue_number}: zero-progress meta premise still active (pulse_merge_zero_progress_cycles=${zero_progress_cycles}) — dispatch proceeds"
+		return 0
+	fi
+
+	local comment_body
+	comment_body="## Recovery detected
+
+The pulse merge zero-progress detector recovered before worker dispatch: \`pulse_merge_zero_progress_cycles\` is 0.
+
+Closing this stale zero-progress meta-issue in the pre-dispatch validator so auto-dispatch does not spend worker capacity on an already-recovered incident. A fresh issue will be filed if a new zero-progress streak crosses the threshold."
+
+	gh issue comment "$issue_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1 ||
+		_log "WARN" "#${issue_number}: failed to comment on recovered zero-progress meta-issue"
+	gh issue close "$issue_number" --repo "$slug" --reason completed >/dev/null 2>&1 ||
+		_log "WARN" "#${issue_number}: failed to close recovered zero-progress meta-issue"
+	_log "INFO" "#${issue_number}: zero-progress meta premise recovered — issue closed, dispatch blocked"
+	return 10
+}
+
+# ---------------------------------------------------------------------------
 # Ratchet-down validator
 #
 # Clones the target repo into a scratch directory and runs:
@@ -1110,6 +1165,15 @@ cmd_validate() {
 	fi
 	if [[ "$review_feedback_rc" -ne 0 ]]; then
 		_log "WARN" "#${issue_number}: review-feedback supersession detector returned rc=${review_feedback_rc} — dispatch proceeds"
+	fi
+
+	local zero_progress_rc=0
+	_close_zero_progress_meta_if_recovered "$issue_number" "$slug" "$issue_body" || zero_progress_rc=$?
+	if [[ "$zero_progress_rc" -eq 10 ]]; then
+		return 10
+	fi
+	if [[ "$zero_progress_rc" -ne 0 ]]; then
+		_log "WARN" "#${issue_number}: zero-progress meta validator returned rc=${zero_progress_rc} — dispatch proceeds"
 	fi
 
 	# Extract generator marker (supports both simple and attributed forms):

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -1116,6 +1116,40 @@ EOF
 	return 0
 }
 
+_run_pre_generator_validators() {
+	local issue_number="$1"
+	local slug="$2"
+	local issue_body="$3"
+	local issue_api_path="$4"
+
+	# Run self-hosting detector BEFORE generator-marker validators (t2819).
+	# Always returns 0; label mutation is advisory, not a dispatch block.
+	_detect_self_hosting_task "$issue_number" "$slug" "$issue_body"
+
+	# Run review-feedback/quality-debt supersession detector before launching a
+	# worker. Exit 10 only on clear same-file + finding-signal matches; ambiguous
+	# matches are commented and fail open so dispatch can proceed.
+	local review_feedback_rc=0
+	_detect_review_feedback_supersession "$issue_number" "$slug" "$issue_body" "$issue_api_path" || review_feedback_rc=$?
+	if [[ "$review_feedback_rc" -eq 10 ]]; then
+		return 10
+	fi
+	if [[ "$review_feedback_rc" -ne 0 ]]; then
+		_log "WARN" "#${issue_number}: review-feedback supersession detector returned rc=${review_feedback_rc} — dispatch proceeds"
+	fi
+
+	local zero_progress_rc=0
+	_close_zero_progress_meta_if_recovered "$issue_number" "$slug" "$issue_body" || zero_progress_rc=$?
+	if [[ "$zero_progress_rc" -eq 10 ]]; then
+		return 10
+	fi
+	if [[ "$zero_progress_rc" -ne 0 ]]; then
+		_log "WARN" "#${issue_number}: zero-progress meta validator returned rc=${zero_progress_rc} — dispatch proceeds"
+	fi
+
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # validate — main subcommand
 #
@@ -1151,29 +1185,13 @@ cmd_validate() {
 		return 20
 	}
 
-	# Run self-hosting detector BEFORE generator-marker validators (t2819).
-	# Always returns 0; label mutation is advisory, not a dispatch block.
-	_detect_self_hosting_task "$issue_number" "$slug" "$issue_body"
-
-	# Run review-feedback/quality-debt supersession detector before launching a
-	# worker. Exit 10 only on clear same-file + finding-signal matches; ambiguous
-	# matches are commented and fail open so dispatch can proceed.
-	local review_feedback_rc=0
-	_detect_review_feedback_supersession "$issue_number" "$slug" "$issue_body" "$issue_api_path" || review_feedback_rc=$?
-	if [[ "$review_feedback_rc" -eq 10 ]]; then
+	local pre_generator_rc=0
+	_run_pre_generator_validators "$issue_number" "$slug" "$issue_body" "$issue_api_path" || pre_generator_rc=$?
+	if [[ "$pre_generator_rc" -eq 10 ]]; then
 		return 10
 	fi
-	if [[ "$review_feedback_rc" -ne 0 ]]; then
-		_log "WARN" "#${issue_number}: review-feedback supersession detector returned rc=${review_feedback_rc} — dispatch proceeds"
-	fi
-
-	local zero_progress_rc=0
-	_close_zero_progress_meta_if_recovered "$issue_number" "$slug" "$issue_body" || zero_progress_rc=$?
-	if [[ "$zero_progress_rc" -eq 10 ]]; then
-		return 10
-	fi
-	if [[ "$zero_progress_rc" -ne 0 ]]; then
-		_log "WARN" "#${issue_number}: zero-progress meta validator returned rc=${zero_progress_rc} — dispatch proceeds"
+	if [[ "$pre_generator_rc" -ne 0 ]]; then
+		_log "WARN" "#${issue_number}: pre-generator validator returned rc=${pre_generator_rc} — dispatch proceeds"
 	fi
 
 	# Extract generator marker (supports both simple and attributed forms):

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -9,6 +9,8 @@
 #   test_unregistered_generator     — issue without marker returns exit 0
 #   test_validator_error            — scan fails unexpectedly → exit 20
 #   test_bypass_env_var             — AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 → exit 0
+#   test_zero_progress_meta_recovered_blocks_dispatch — recovered meta issue → exit 10
+#   test_zero_progress_meta_active_allows_dispatch    — active meta issue → exit 0
 
 set -euo pipefail
 
@@ -53,6 +55,7 @@ setup_test_env() {
 }
 
 teardown_test_env() {
+	unset PULSE_STATS_FILE
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
@@ -137,6 +140,37 @@ printf 'unsupported gh invocation: %s\n' "\$*" >&2
 exit 1
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+create_gh_stub_zero_progress_body() {
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- merge-stuck:zero-progress -->\n## What\nZero-progress meta issue.\n' >"$body_file"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	python3 -c "import sys; sys.stdout.write(open('${body_file}').read())" 2>/dev/null
+	exit 0
+fi
+
+if [[ "\${1:-}" == "issue" ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+write_zero_progress_stats() {
+	local gauge_value="$1"
+	export PULSE_STATS_FILE="${TEST_ROOT}/pulse-stats.json"
+	printf '{"gauges":{"pulse_merge_zero_progress_cycles":{"value":%s}}}\n' "$gauge_value" >"$PULSE_STATS_FILE"
 	return 0
 }
 
@@ -419,6 +453,42 @@ test_bypass_env_var() {
 	return 0
 }
 
+test_zero_progress_meta_recovered_blocks_dispatch() {
+	setup_test_env
+	create_gh_stub_zero_progress_body
+	write_zero_progress_stats "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "52" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "zero_progress meta recovered exits 10" 0
+	else
+		print_result "zero_progress meta recovered exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_zero_progress_meta_active_allows_dispatch() {
+	setup_test_env
+	create_gh_stub_zero_progress_body
+	write_zero_progress_stats "5"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "53" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "zero_progress meta active exits 0" 0
+	else
+		print_result "zero_progress meta active exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 test_review_feedback_extended_extensions() {
 	setup_test_env
 	create_gh_stub_review_feedback "extended-extension"
@@ -521,6 +591,8 @@ main() {
 	test_unregistered_generator
 	test_validator_error
 	test_bypass_env_var
+	test_zero_progress_meta_recovered_blocks_dispatch
+	test_zero_progress_meta_active_allows_dispatch
 	test_review_feedback_extended_extensions
 	test_review_feedback_keyword_scoring_whole_words
 	test_review_feedback_preserves_version_directory_paths


### PR DESCRIPTION
## Summary
- Add a zero-progress meta-issue pre-dispatch validator path for `<!-- merge-stuck:zero-progress -->` issues.
- Close and block dispatch when `pulse_merge_zero_progress_cycles` has already recovered to `0`.
- Add regression coverage for recovered and still-active zero-progress gauge states.

## Testing
- `.agents/scripts/tests/test-pre-dispatch-validator.sh`
- `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-pre-dispatch-validator.sh`
- `.agents/scripts/linters-local.sh`

MERGE_SUMMARY: Added a pre-dispatch guard that closes recovered merge-stuck zero-progress meta issues before worker launch, preventing stale recovered incidents from consuming worker capacity. Verified with pre-dispatch validator tests, ShellCheck, and local linters.

For #24729

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5
