### PR TITLE
t2199: complete gh wrapper shim setup cleanup

### DIFF
--- a/.agents/scripts/setup/_deployment.sh
+++ b/.agents/scripts/setup/_deployment.sh
@@ -3,6 +3,43 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # Agent deployment functions for setup.sh
 
+# Sync deployed agent bin shims into ~/.aidevops/bin for PATH discoverability.
+_sync_agent_bin_shims() {
+	local target_dir="$1"
+	local user_bin_dir="${HOME}/.aidevops/bin"
+	local shim=""
+	local shim_name=""
+	local existing=""
+	local existing_target=""
+
+	mkdir -p "$user_bin_dir"
+
+	# Remove stale links from previous aidevops agent-bin deployments. This is the
+	# uninstall path for retired shims: keep user files and unrelated symlinks, but
+	# delete links that still point into ~/.aidevops/agents/bin and no longer have a
+	# matching deployed source.
+	for existing in "$user_bin_dir"/*; do
+		[[ -L "$existing" ]] || continue
+		existing_target="$(readlink "$existing" 2>/dev/null || true)"
+		case "$existing_target" in
+			"${target_dir}/bin/"*)
+				if [[ ! -e "$existing_target" ]]; then
+					rm -f "$existing"
+				fi
+				;;
+		esac
+	done
+
+	if [[ -d "${target_dir}/bin" ]]; then
+		for shim in "${target_dir}/bin/"*; do
+			[[ -f "$shim" ]] || continue
+			shim_name="$(basename "$shim")"
+			ln -sf "$shim" "${user_bin_dir}/${shim_name}"
+		done
+	fi
+	return 0
+}
+
 # Deploy aidevops agents to ~/.aidevops/agents/
 #
 # Uses atomic swap: deploy to a temp directory first, then rename over the
@@ -89,16 +126,7 @@ deploy_aidevops_agents() {
 
 	# t2199: Symlink bin shims into ~/.aidevops/bin/ for PATH discoverability.
 	# ~/.aidevops/bin/ is already on PATH (managed by setup.sh shell-env).
-	if [[ -d "${target_dir}/bin" ]]; then
-		mkdir -p "${HOME}/.aidevops/bin"
-		local shim
-		for shim in "${target_dir}/bin/"*; do
-			[[ -f "$shim" ]] || continue
-			local shim_name
-			shim_name="$(basename "$shim")"
-			ln -sf "$shim" "${HOME}/.aidevops/bin/${shim_name}"
-		done
-	fi
+	_sync_agent_bin_shims "$target_dir"
 
 	echo "[deploy] Deployed agents to ${target_dir} ($(find "$target_dir" -type f | wc -l | tr -d ' ') files)"
 	return 0

--- a/.agents/scripts/tests/test-agent-bin-shim-sync.sh
+++ b/.agents/scripts/tests/test-agent-bin-shim-sync.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression test for t2199 / GH#19686: agent bin shims must be PATH
+# discoverable after setup, and retired shims must be removed from
+# ~/.aidevops/bin when no longer deployed.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+DEPLOYMENT_MODULE="${REPO_DIR}/.agents/scripts/setup/_deployment.sh"
+
+PASS=0
+FAIL=0
+
+assert_symlink_target() {
+	local test_name="$1"
+	local link_path="$2"
+	local expected_target="$3"
+	local actual_target=""
+	if [[ -L "$link_path" ]]; then
+		actual_target="$(readlink "$link_path")"
+		if [[ "$actual_target" == "$expected_target" ]]; then
+			echo "  PASS: $test_name"
+			PASS=$((PASS + 1))
+			return 0
+		fi
+	fi
+	echo "  FAIL: $test_name"
+	echo "    expected symlink: $link_path -> $expected_target"
+	echo "    actual: ${actual_target:-missing or not a symlink}"
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+assert_missing() {
+	local test_name="$1"
+	local path="$2"
+	if [[ ! -e "$path" && ! -L "$path" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	echo "  FAIL: $test_name"
+	echo "    expected missing: $path"
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+assert_exists() {
+	local test_name="$1"
+	local path="$2"
+	if [[ -e "$path" || -L "$path" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	echo "  FAIL: $test_name"
+	echo "    expected existing: $path"
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+echo "Test: agent bin shim sync"
+echo "==========================="
+echo ""
+
+tmp_home="$(mktemp -d)"
+tmp_target="${tmp_home}/.aidevops/agents"
+trap 'rm -rf "$tmp_home"' EXIT
+
+mkdir -p "${tmp_target}/bin" "${tmp_home}/.aidevops/bin" "${tmp_home}/elsewhere"
+printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/gh_create_pr"
+printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/gh_create_issue"
+chmod +x "${tmp_target}/bin/gh_create_pr" "${tmp_target}/bin/gh_create_issue"
+
+ln -sf "${tmp_target}/bin/retired_shim" "${tmp_home}/.aidevops/bin/retired_shim"
+ln -sf "${tmp_home}/elsewhere/external" "${tmp_home}/.aidevops/bin/external_link"
+printf 'user file\n' >"${tmp_home}/.aidevops/bin/user_tool"
+
+# shellcheck disable=SC1090
+source "$DEPLOYMENT_MODULE"
+
+HOME="$tmp_home" _sync_agent_bin_shims "$tmp_target"
+
+assert_symlink_target "gh_create_pr shim is linked into user PATH bin" \
+	"${tmp_home}/.aidevops/bin/gh_create_pr" "${tmp_target}/bin/gh_create_pr"
+assert_symlink_target "gh_create_issue shim is linked into user PATH bin" \
+	"${tmp_home}/.aidevops/bin/gh_create_issue" "${tmp_target}/bin/gh_create_issue"
+assert_missing "stale aidevops-owned shim symlink is removed" \
+	"${tmp_home}/.aidevops/bin/retired_shim"
+assert_exists "external symlink is preserved" \
+	"${tmp_home}/.aidevops/bin/external_link"
+assert_exists "user-managed file is preserved" \
+	"${tmp_home}/.aidevops/bin/user_tool"
+
+echo ""
+echo "==========================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- keeps gh_create_pr and gh_create_issue shims discoverable by extracting setup's agent-bin sync into _sync_agent_bin_shims
- removes stale aidevops-owned ~/.aidevops/bin shim symlinks when deployed .agents/bin entries are retired
- preserves user-managed files and unrelated symlinks in ~/.aidevops/bin
- adds regression coverage for shim linking and cleanup

## Testing
- .agents/scripts/tests/test-agent-bin-shim-sync.sh
- shellcheck .agents/scripts/setup/_deployment.sh .agents/scripts/tests/test-agent-bin-shim-sync.sh .agents/bin/gh_create_pr .agents/bin/gh_create_issue
- PATH="$PWD/.agents/bin:$PATH" bash -c 'cd /tmp && type gh_create_pr && type gh_create_issue'
- .agents/scripts/tests/test-shared-gh-wrappers-standalone.sh && .agents/scripts/tests/test-shared-gh-wrappers-source.sh

Resolves #19686

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 158,503 tokens on this as a headless worker.