### PR TITLE
fix: guard automated GitHub writes by repo permission

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -38,6 +38,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+if [[ -f "${SCRIPT_DIR}/pulse-repo-meta.sh" ]]; then
+	# shellcheck source=./pulse-repo-meta.sh
+	source "${SCRIPT_DIR}/pulse-repo-meta.sh"
+fi
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -147,6 +152,14 @@ _close_zero_progress_meta_if_recovered() {
 	}
 	if [[ "$zero_progress_cycles" != "0" ]]; then
 		_log "INFO" "#${issue_number}: zero-progress meta premise still active (pulse_merge_zero_progress_cycles=${zero_progress_cycles}) — dispatch proceeds"
+		return 0
+	fi
+	# #aidevops:trust-boundary — recovered-meta handling writes comments and
+	# closes issues. Public issue comments can succeed for non-collaborators, so
+	# never write unless the runner is admin/maintain/write on this repo.
+	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+		|| ! repo_allows_pulse_write_actions "$slug"; then
+		_log "WARN" "#${issue_number}: recovered zero-progress meta issue left untouched — runner lacks repo write permission"
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1053,17 +1053,13 @@ _pms_close_zero_progress_meta_issue_if_recovered() {
 	local reason="$1"
 	local meta_repo="marcusquinn/aidevops"
 	local marker_text="merge-stuck:zero-progress"
-
 	[[ -n "$reason" ]] || reason="merge progress recovered"
-	# #aidevops:trust-boundary — recovery comments/closes are repo-state writes.
-	# Public issue comments can succeed for non-collaborators, so require the
-	# authenticated runner to be admin/maintain/write before posting.
+	# #aidevops:trust-boundary — public issue comments can succeed for non-collaborators.
 	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
 		|| ! repo_allows_pulse_write_actions "$meta_repo"; then
 		echo "[pulse-merge-stuck] _pms_close_zero_progress_meta_issue_if_recovered: skipping recovery write in ${meta_repo} — runner lacks repo write permission" >>"$LOGFILE"
 		return 0
 	fi
-
 	local existing
 	existing=$(gh issue list --repo "$meta_repo" --state open --search "$marker_text" \
 		--limit 1 --json number --jq '.[0].number' 2>/dev/null) || existing=""
@@ -1088,10 +1084,6 @@ Closing this stale zero-progress meta-issue so auto-dispatch does not spend work
 	echo "[pulse-merge-stuck] _pms_close_zero_progress_meta_issue_if_recovered: closed #${existing} — ${reason}" >>"$LOGFILE"
 	return 0
 }
-
-# ── Module entry point — called once per pulse cycle, per repo ─────────────
-
-#######################################
 # Count PRs in $repo_slug that are eligible-but-unmerged this cycle —
 # APPROVED + MERGEABLE + !draft + !hold-for-review, then narrowed to PRs
 # that are not known to be blocked by the read-only merge gates (NOT age-gated).
@@ -1107,7 +1099,6 @@ Closing this stale zero-progress meta-issue so auto-dispatch does not spend work
 #
 # Args: $1 = repo_slug
 # Stdout: integer count
-#######################################
 #######################################
 # Decide whether a basic eligible PR should contribute to the zero-progress
 # denominator. This is intentionally read-only and narrower than the full

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1055,6 +1055,14 @@ _pms_close_zero_progress_meta_issue_if_recovered() {
 	local marker_text="merge-stuck:zero-progress"
 
 	[[ -n "$reason" ]] || reason="merge progress recovered"
+	# #aidevops:trust-boundary — recovery comments/closes are repo-state writes.
+	# Public issue comments can succeed for non-collaborators, so require the
+	# authenticated runner to be admin/maintain/write before posting.
+	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+		|| ! repo_allows_pulse_write_actions "$meta_repo"; then
+		echo "[pulse-merge-stuck] _pms_close_zero_progress_meta_issue_if_recovered: skipping recovery write in ${meta_repo} — runner lacks repo write permission" >>"$LOGFILE"
+		return 0
+	fi
 
 	local existing
 	existing=$(gh issue list --repo "$meta_repo" --state open --search "$marker_text" \

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -166,19 +166,25 @@ get_repo_role_by_slug() {
 
 #######################################
 # Return success only for repos where pulse may write to GitHub PR/issue state.
-# Contributor repos stay read-only/noise-free: session and memory mining remain
+# Contributor/read-only repos stay noise-free: session and memory mining remain
 # allowed, but merge/stuck/dirty sweeps must not post, label, close, or rebase.
+# The live GitHub collaborator permission check is authoritative because public
+# issue comments can otherwise succeed for users with no repo relationship.
 # Arguments:
 #   $1 - repo slug (owner/repo)
-# Returns: 0 when role=maintainer, 1 otherwise
+# Returns: 0 when current runner has admin/maintain/write, 1 otherwise
 #######################################
 repo_allows_pulse_write_actions() {
 	local repo_slug="$1"
-	local repo_role="$_PULSE_REPO_ROLE_CONTRIBUTOR"
 
-	repo_role=$(get_repo_role_by_slug "$repo_slug" 2>/dev/null) || repo_role="$_PULSE_REPO_ROLE_CONTRIBUTOR"
-	[[ "$repo_role" == "$_PULSE_REPO_ROLE_MAINTAINER" ]] && return 0
-	return 1
+	# #aidevops:trust-boundary — never rely on repos.json role or successful
+	# public comments as authority. Require the authenticated runner to be an
+	# admin, maintainer, or write collaborator on the target repo.
+	if ! declare -F _gh_current_user_allows_repo_write >/dev/null 2>&1; then
+		return 1
+	fi
+	_gh_current_user_allows_repo_write "$repo_slug"
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -8,6 +8,8 @@
 [[ -n "${_SHARED_GH_COLLABORATOR_PERMISSION_LOADED:-}" ]] && return 0
 _SHARED_GH_COLLABORATOR_PERMISSION_LOADED=1
 
+_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE="unknown"
+
 #######################################
 # Look up a repository collaborator permission through App-aware REST routing.
 #
@@ -37,8 +39,8 @@ _gh_collaborator_permission_lookup() {
 	local in_body=0
 	local permission_value=""
 
-	AIDEVOPS_GH_COLLAB_PERMISSION_HTTP="unknown"
-	AIDEVOPS_GH_COLLAB_PERMISSION_REASON="unknown"
+	AIDEVOPS_GH_COLLAB_PERMISSION_HTTP="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
+	AIDEVOPS_GH_COLLAB_PERMISSION_REASON="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
 	export AIDEVOPS_GH_COLLAB_PERMISSION_HTTP AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 
 	if [[ -z "$repo_slug" || -z "$user" ]]; then
@@ -98,6 +100,9 @@ _gh_collaborator_permission_lookup() {
 	fi
 
 	permission_value=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || permission_value=""
+	if [[ -z "$permission_value" ]]; then
+		permission_value=$(printf '%s' "$api_response" | sed -nE 's/.*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | sed -n '1p') || permission_value=""
+	fi
 	case "$permission_value" in
 	admin | maintain | write | triage | read | none)
 		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="ok"
@@ -113,6 +118,75 @@ _gh_collaborator_permission_lookup() {
 		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="malformed-response"
 		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 		return 2
+		;;
+	esac
+}
+
+#######################################
+# Verify the authenticated GitHub user may write repo state.
+#
+# Public issue comments can succeed for non-collaborators, so callers must not
+# infer authorization from a successful write. This guard checks the current
+# auth identity against the collaborator permission API before any automated
+# comment, close, label, approval, merge, or dispatch claim.
+#
+# Globals written:
+#   AIDEVOPS_GH_WRITE_PERMISSION_USER
+#   AIDEVOPS_GH_WRITE_PERMISSION_LEVEL
+#   AIDEVOPS_GH_WRITE_PERMISSION_REASON
+#
+# Args: $1=repo_slug owner/repo
+# Returns: 0=admin/maintain/write, 1=read/triage/none/unknown/failure.
+#######################################
+_gh_current_user_allows_repo_write() {
+	local repo_slug="$1"
+	local current_user=""
+	local current_permission=""
+
+	AIDEVOPS_GH_WRITE_PERMISSION_USER=""
+	AIDEVOPS_GH_WRITE_PERMISSION_LEVEL="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
+	AIDEVOPS_GH_WRITE_PERMISSION_REASON="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
+	export AIDEVOPS_GH_WRITE_PERMISSION_USER AIDEVOPS_GH_WRITE_PERMISSION_LEVEL AIDEVOPS_GH_WRITE_PERMISSION_REASON
+
+	if [[ -z "$repo_slug" ]]; then
+		AIDEVOPS_GH_WRITE_PERMISSION_REASON="missing-repo"
+		export AIDEVOPS_GH_WRITE_PERMISSION_REASON
+		return 1
+	fi
+
+	if [[ -n "${_AIDEVOPS_CACHED_GH_LOGIN:-}" ]]; then
+		current_user="$_AIDEVOPS_CACHED_GH_LOGIN"
+	else
+		current_user=$(gh api user --jq '.login' 2>/dev/null) || current_user=""
+		_AIDEVOPS_CACHED_GH_LOGIN="$current_user"
+	fi
+	AIDEVOPS_GH_WRITE_PERMISSION_USER="$current_user"
+	export AIDEVOPS_GH_WRITE_PERMISSION_USER
+	if [[ -z "$current_user" ]]; then
+		AIDEVOPS_GH_WRITE_PERMISSION_REASON="current-user-lookup-failed"
+		export AIDEVOPS_GH_WRITE_PERMISSION_REASON
+		return 1
+	fi
+
+	if ! _gh_collaborator_permission_lookup "$repo_slug" "$current_user" current_permission; then
+		AIDEVOPS_GH_WRITE_PERMISSION_LEVEL="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
+		AIDEVOPS_GH_WRITE_PERMISSION_REASON="permission-lookup-failed:${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE}"
+		export AIDEVOPS_GH_WRITE_PERMISSION_LEVEL AIDEVOPS_GH_WRITE_PERMISSION_REASON
+		return 1
+	fi
+
+	AIDEVOPS_GH_WRITE_PERMISSION_LEVEL="$current_permission"
+	export AIDEVOPS_GH_WRITE_PERMISSION_LEVEL
+	case "$current_permission" in
+	admin | maintain | write)
+		AIDEVOPS_GH_WRITE_PERMISSION_REASON="allowed"
+		export AIDEVOPS_GH_WRITE_PERMISSION_REASON
+		return 0
+		;;
+	*)
+		AIDEVOPS_GH_WRITE_PERMISSION_REASON="insufficient-permission:${current_permission:-none}"
+		export AIDEVOPS_GH_WRITE_PERMISSION_REASON
+		return 1
 		;;
 	esac
 }

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -51,11 +51,13 @@ setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${TEST_ROOT}/gh-secondary-cooldown.json"
 	return 0
 }
 
 teardown_test_env() {
 	unset PULSE_STATS_FILE
+	unset AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
@@ -144,6 +146,7 @@ GHEOF
 }
 
 create_gh_stub_zero_progress_body() {
+	local permission_value="${1:-write}"
 	local body_file="${TEST_ROOT}/issue_body.txt"
 	printf '<!-- merge-stuck:zero-progress -->\n## What\nZero-progress meta issue.\n' >"$body_file"
 
@@ -153,6 +156,16 @@ set -euo pipefail
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
 	python3 -c "import sys; sys.stdout.write(open('${body_file}').read())" 2>/dev/null
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && [[ "\${2:-}" == "user" ]]; then
+	printf 'runner\n'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\$*" | grep -qE '/repos/.*/collaborators/runner/permission'; then
+	printf 'HTTP/2.0 200 OK\n\n{"permission":"${permission_value}"}\n'
 	exit 0
 fi
 
@@ -455,7 +468,7 @@ test_bypass_env_var() {
 
 test_zero_progress_meta_recovered_blocks_dispatch() {
 	setup_test_env
-	create_gh_stub_zero_progress_body
+	create_gh_stub_zero_progress_body "write"
 	write_zero_progress_stats "0"
 
 	local rc=0
@@ -471,9 +484,27 @@ test_zero_progress_meta_recovered_blocks_dispatch() {
 	return 0
 }
 
+test_zero_progress_meta_recovered_readonly_allows_dispatch_without_write() {
+	setup_test_env
+	create_gh_stub_zero_progress_body "read"
+	write_zero_progress_stats "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "54" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "zero_progress meta recovered read-only exits 0 without write" 0
+	else
+		print_result "zero_progress meta recovered read-only exits 0 without write" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 test_zero_progress_meta_active_allows_dispatch() {
 	setup_test_env
-	create_gh_stub_zero_progress_body
+	create_gh_stub_zero_progress_body "write"
 	write_zero_progress_stats "5"
 
 	local rc=0
@@ -592,6 +623,7 @@ main() {
 	test_validator_error
 	test_bypass_env_var
 	test_zero_progress_meta_recovered_blocks_dispatch
+	test_zero_progress_meta_recovered_readonly_allows_dispatch_without_write
 	test_zero_progress_meta_active_allows_dispatch
 	test_review_feedback_extended_extensions
 	test_review_feedback_keyword_scoring_whole_words

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -266,6 +266,13 @@ gh_create_issue() {
 	return 0
 }
 
+PMS_TEST_ALLOW_WRITE="1"
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	[[ "$repo_slug" == "marcusquinn/aidevops" && "${PMS_TEST_ALLOW_WRITE:-1}" == "1" ]]
+	return $?
+}
+
 # Reset gauge for a clean state.
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
 
@@ -299,6 +306,26 @@ else
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
+AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=3600
+
+# 5b.2: recovery writes are skipped when the authenticated runner is not a
+# repo admin/maintainer/write collaborator.
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE="23037"
+PMS_TEST_ALLOW_WRITE="0"
+AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=0
+: >"$GH_CALLS"
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
+pulse_merge_zero_progress_record 0 0 >/dev/null 2>&1
+if grep -q 'gh issue close 23037' "$GH_CALLS"; then
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5b.2: read-only runner must not close recovered zero-progress issue"
+	echo "  gh calls: $(cat "$GH_CALLS")"
+else
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5b.2: read-only runner skips recovered zero-progress issue write"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
+PMS_TEST_ALLOW_WRITE="1"
 AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=3600
 
 # 5c: merged=0 + eligible>0 → gauge increments by 1

--- a/.agents/scripts/tests/test-repo-role-guard.sh
+++ b/.agents/scripts/tests/test-repo-role-guard.sh
@@ -79,6 +79,18 @@ source "${PARENT_DIR}/pulse-repo-meta.sh"
 # Override the cached gh user for deterministic testing
 _CACHED_GH_USER="alice"
 
+_gh_current_user_allows_repo_write() {
+	local repo_slug="$1"
+	case "$repo_slug" in
+	alice/owned-repo | alice/auto-detect-repo | alice/unknown-repo)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 # --- Tests ---
 
 echo "=== get_repo_role_by_slug ==="
@@ -111,21 +123,21 @@ assert_eq "unknown slug, owner matches gh user → maintainer" "maintainer" "$ro
 role=$(get_repo_role_by_slug "stranger/unknown-repo")
 assert_eq "unknown slug, different owner → contributor" "contributor" "$role"
 
-# Test 8: Write-capable pulse actions are allowed only on maintainer repos.
+# Test 8: Write-capable pulse actions require live admin/maintain/write permission.
 if repo_allows_pulse_write_actions "alice/owned-repo"; then
 	write_allowed="yes"
 else
 	write_allowed="no"
 fi
-assert_eq "write actions allowed for maintainer repo" "yes" "$write_allowed"
+assert_eq "write actions allowed for write-authorized repo" "yes" "$write_allowed"
 
-# Test 9: Contributor repos stay read-only/noise-free for write-capable sweeps.
+# Test 9: Repos without live write permission stay read-only/noise-free.
 if repo_allows_pulse_write_actions "bob/external-repo"; then
 	write_allowed="yes"
 else
 	write_allowed="no"
 fi
-assert_eq "write actions blocked for contributor repo" "no" "$write_allowed"
+assert_eq "write actions blocked without repo write permission" "no" "$write_allowed"
 
 # Test 10: Deterministic merge pass uses the write-action role guard.
 if grep -q "repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-merge-process.sh"; then


### PR DESCRIPTION
## Summary
- add a live authenticated-user permission guard for automated repo-state writes
- require admin/maintain/write before pulse recovery comments/closes recovered merge-stuck meta-issues
- cover the read-only runner case in pre-dispatch and pulse merge-stuck tests

## Root cause
A recovered zero-progress meta path used public issue comments/close attempts without first proving the runner was a repo admin, maintainer, or write collaborator. Public issue comments can succeed for authorAssociation=NONE, so successful write was not a valid authorization signal.

## Verification
- shellcheck changed shell files
- bash .agents/scripts/tests/test-pre-dispatch-validator.sh
- bash .agents/scripts/tests/test-pulse-merge-stuck.sh
- bash .agents/scripts/tests/test-repo-role-guard.sh
- .agents/scripts/linters-local.sh (targeted gates pass; repo has pre-existing complexity/file-size blocking debt unrelated to this change)

For #24729
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.57 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5
