### PR TITLE
GH#24734: fix: replace stale opencode worker db ledgers

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1041,6 +1041,9 @@ _watchdog_kill() {
 # The ledger table list is intentionally allowlisted by the caller; this helper
 # creates a missing worker-side table from the shared DB schema before copying
 # rows so OpenCode does not replay migrations against pre-created user tables.
+# Existing worker ledger rows are replaced, not merely inserted, because a
+# pre-warmed DB can have stale rows with matching primary keys/counts; leaving
+# those in place can still make OpenCode/Drizzle treat the schema as unmigrated.
 #######################################
 _copy_worker_db_migration_ledger_table() {
 	local worker_db="$1"
@@ -1059,6 +1062,7 @@ _copy_worker_db_migration_ledger_table() {
 	shared_db_sql=$(sql_escape "$shared_db")
 	sqlite3_with_timeout "$worker_db" <<-SQL >/dev/null 2>&1 || true
 		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		DELETE FROM main."${ledger_table}";
 		INSERT OR IGNORE INTO main."${ledger_table}" SELECT * FROM shared."${ledger_table}";
 		DETACH DATABASE shared;
 	SQL

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1061,9 +1061,12 @@ _copy_worker_db_migration_ledger_table() {
 
 	shared_db_sql=$(sql_escape "$shared_db")
 	sqlite3_with_timeout "$worker_db" <<-SQL >/dev/null 2>&1 || true
+		.bail on
 		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		BEGIN IMMEDIATE;
 		DELETE FROM main."${ledger_table}";
 		INSERT OR IGNORE INTO main."${ledger_table}" SELECT * FROM shared."${ledger_table}";
+		COMMIT;
 		DETACH DATABASE shared;
 	SQL
 	return 0

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1235,6 +1235,52 @@ SQL
 	return 0
 }
 
+test_sync_worker_db_migration_metadata_replaces_stale_ledgers() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-stale-ledger"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE migration (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL);
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+INSERT INTO __drizzle_migrations VALUES (1, 'shared-schema-ready', 12345);
+INSERT INTO data_migration VALUES ('shared-data-ready', 67890);
+INSERT INTO migration VALUES ('shared-opencode-ready', 1700000000);
+SQL
+	sqlite3 "$worker_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE migration (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL);
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+INSERT INTO __drizzle_migrations VALUES (1, 'stale-schema-row', 11111);
+INSERT INTO data_migration VALUES ('shared-data-ready', 22222);
+INSERT INTO migration VALUES ('shared-opencode-ready', 33333);
+INSERT INTO project VALUES ('prewarmed-project', 'Prewarmed Project');
+SQL
+
+	_sync_worker_db_migration_metadata "$isolated_dir"
+
+	local schema_hash data_updated_at migration_completed projects
+	schema_hash=$(sqlite3 "$worker_db" "SELECT hash FROM __drizzle_migrations WHERE id = 1;")
+	data_updated_at=$(sqlite3 "$worker_db" "SELECT updated_at FROM data_migration WHERE id = 'shared-data-ready';")
+	migration_completed=$(sqlite3 "$worker_db" "SELECT time_completed FROM migration WHERE id = 'shared-opencode-ready';")
+	projects=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM project WHERE id = 'prewarmed-project';")
+
+	if [[ "$schema_hash" == "shared-schema-ready" && "$data_updated_at" == "67890" && "$migration_completed" == "1700000000" && "$projects" == "1" ]]; then
+		print_result "sync worker DB replaces stale migration ledger rows" 0
+		return 0
+	fi
+
+	print_result "sync worker DB replaces stale migration ledger rows" 1 \
+		"schema_hash=$schema_hash data_updated_at=$data_updated_at migration_completed=$migration_completed projects=$projects"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_archives_unrepairable_project_table() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-unrepairable"
@@ -1997,6 +2043,7 @@ main() {
 	test_seed_worker_db_session_context_copies_only_selected_session
 	test_seed_worker_db_session_context_copies_migration_metadata
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
+	test_sync_worker_db_migration_metadata_replaces_stale_ledgers
 	test_sync_worker_db_migration_metadata_archives_unrepairable_project_table
 	test_sync_worker_db_migration_metadata_repeated_launch_reaches_seed
 	test_large_opencode_prompt_uses_file_attachment


### PR DESCRIPTION
## Summary

Replaced isolated worker migration ledger rows from the shared OpenCode DB instead of leaving stale primary-key collisions in place, and added regression coverage for prewarmed project-table DBs with stale ledger rows.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #24734


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 4m and 81,046 tokens on this as a headless worker.