### PR TITLE
GH#24738: fix: harden collaborator permission fallback parser

### DIFF
--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -101,7 +101,7 @@ _gh_collaborator_permission_lookup() {
 
 	permission_value=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || permission_value=""
 	if [[ -z "$permission_value" ]]; then
-		permission_value=$(printf '%s' "$api_response" | sed -nE 's/^[[:space:]]*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | tail -1) || permission_value=""
+		permission_value=$(printf '%s' "$api_response" | sed -nE 's/^[[:space:]]*\{?[[:space:]]*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | tail -1) || permission_value=""
 	fi
 	case "$permission_value" in
 	admin | maintain | write | triage | read | none)

--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -101,7 +101,7 @@ _gh_collaborator_permission_lookup() {
 
 	permission_value=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || permission_value=""
 	if [[ -z "$permission_value" ]]; then
-		permission_value=$(printf '%s' "$api_response" | sed -nE 's/.*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | sed -n '1p') || permission_value=""
+		permission_value=$(printf '%s' "$api_response" | sed -nE 's/^[[:space:]]*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | tail -1) || permission_value=""
 	fi
 	case "$permission_value" in
 	admin | maintain | write | triage | read | none)

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -66,7 +66,8 @@
 #  36. AIDEVOPS_GH_PR_VIEW_CACHE enabled with missing prerequisites records
 #      non-disabled REST cache bypass telemetry
 #  37. AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE bypasses both PR view cache layers
-#  38. _rest_split_csv suppresses Broken pipe noise when consumers close early
+#  38. collaborator permission fallback parser ignores nested spoof fields
+#  39. _rest_split_csv suppresses Broken pipe noise when consumers close early
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -197,6 +198,16 @@ gh() {
 		if [[ "$status" == "404" ]]; then
 			printf 'HTTP/2.0 404 Not Found\n\n{"message":"Not Found"}\n'
 			return 1
+		fi
+		if [[ -n "${STUB_COLLAB_RAW_RESPONSE:-}" ]]; then
+			printf '%s\n' "$STUB_COLLAB_RAW_RESPONSE"
+			return 0
+		fi
+		if [[ -n "${STUB_COLLAB_RAW_RESPONSE_FILE:-}" ]]; then
+			while IFS= read -r raw_response_line || [[ -n "$raw_response_line" ]]; do
+				printf '%s\n' "$raw_response_line"
+			done <"$STUB_COLLAB_RAW_RESPONSE_FILE"
+			return 0
 		fi
 		printf 'HTTP/2.0 %s OK\n\n{"permission":"%s"}\n' "$status" "${STUB_COLLAB_PERMISSION:-write}"
 		return 0
@@ -1397,8 +1408,21 @@ else
 fi
 unset STUB_COLLAB_STATUS STUB_COLLAB_FAIL STUB_COLLAB_PERMISSION
 
+STUB_COLLAB_RAW_RESPONSE_FILE="${TMP}/collab-spoof-response.txt"
+printf '%s\n' 'HTTP/2.0 200 OK' '' '  "bio":"crafted \"permission\": \"admin\""' '  "permission":"write"' >"$STUB_COLLAB_RAW_RESPONSE_FILE"
+export STUB_COLLAB_RAW_RESPONSE_FILE
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "testuser" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "write" ]]; then
+	pass "collaborator permission fallback parser ignores nested spoof fields"
+else
+	fail "collaborator permission fallback parser ignores nested spoof fields" \
+		"perm=${collab_perm} reason=${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unset}"
+fi
+unset STUB_COLLAB_RAW_RESPONSE_FILE
+
 # =============================================================================
-# Test 35: _rest_split_csv suppresses early-close Broken pipe noise
+# Test 39: _rest_split_csv suppresses early-close Broken pipe noise
 # =============================================================================
 long_csv=""
 for i in $(seq 1 5000); do


### PR DESCRIPTION
## Summary

Anchored the collaborator permission fallback parser to top-level permission/role_name fields and added regression coverage for spoofed nested permission text.

## Files Changed

.agents/scripts/shared-gh-collaborator-permission.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-collaborator-permission.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh && .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

Resolves #24738


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 82,036 tokens on this as a headless worker.