### PR TITLE
GH#24744: fix: harden gh api path parsing

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -602,7 +602,6 @@ _shim_api_is_write_endpoint() {
 		api) ;;
 		/repos/* | repos/*) [[ -z "$path" ]] && path="$a" ;;
 		-*) ;;
-		*) [[ -z "$path" ]] && path="$a" ;;
 		esac
 		i=$((i + 1))
 	done
@@ -630,7 +629,6 @@ _shim_api_target_from_path() {
 		api) ;;
 		/repos/* | repos/*) [[ -z "$path" ]] && path="$a" ;;
 		-*) ;;
-		*) [[ -z "$path" ]] && path="$a" ;;
 		esac
 		i=$((i + 1))
 	done

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -607,7 +607,19 @@ else
 	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api-positional.err"; then
 		_pass "headless REST guard finds repo path after query positional"
 	else
-		_fail "headless REST guard path extraction after query positional" "argv: $argv err: $(cat "$TMP/guard-api-positional.err" 2>/dev/null || true)"
+		_fail "headless REST guard path extraction after query positional" "argv: $argv err: $(cat "$TMP/guard-api-positional.err" || true)"
+	fi
+fi
+
+_reset_log
+if FULL_LOOP_HEADLESS=1 "$SHIM_RUN" api -q . /repos/external/repo/issues/123/comments -X POST -f body="uninstigated" 2>"$TMP/guard-api-positional-short.err"; then
+	_fail "headless REST guard ignores non-path positionals with short flag" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api-positional-short.err"; then
+		_pass "headless REST guard finds repo path after short query positional"
+	else
+		_fail "headless REST guard path extraction after short query positional" "argv: $argv err: $(cat "$TMP/guard-api-positional-short.err" || true)"
 	fi
 fi
 


### PR DESCRIPTION
## Summary

Removed fallback positional API path capture from gh shim write detection and target extraction, then added a short -q regression test for the headless REST external write guard.

## Files Changed

.agents/scripts/gh,.agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh; .agents/scripts/tests/test-gh-shim.sh

Resolves #24744


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 43,403 tokens on this as a headless worker.