### PR TITLE
GH#24747: test: address scheduler review followups

### DIFF
--- a/.agents/scripts/tests/test-repo-aidevops-health.sh
+++ b/.agents/scripts/tests/test-repo-aidevops-health.sh
@@ -60,12 +60,9 @@ assert_contains() {
 }
 
 load_helper_without_main() {
-	local source_copy="$1"
-	AIDEVOPS_REPO_HEALTH_HELPER_SOURCE_ONLY=1
+	local AIDEVOPS_REPO_HEALTH_HELPER_SOURCE_ONLY=1
 	# shellcheck source=/dev/null
 	source "$HELPER"
-	unset AIDEVOPS_REPO_HEALTH_HELPER_SOURCE_ONLY
-	: >"$source_copy"
 	return 0
 }
 
@@ -104,7 +101,7 @@ mkdir -p "$FIXTURE_DIR/stale-repo"
 cd "$FIXTURE_DIR/stale-repo"
 git init -q
 echo '{"aidevops_version":"0.0.1"}' >.aidevops.json
-git add .aidevops.json && git -c user.email=t@t -c user.name=T commit -qm init >/dev/null 2>&1 || true
+git add .aidevops.json && git -c user.email=t@t -c user.name=T -c commit.gpgsign=false commit -qm init >/dev/null 2>&1 || true
 
 mkdir -p "$FIXTURE_DIR/unregistered-repo"
 cd "$FIXTURE_DIR/unregistered-repo"
@@ -169,9 +166,9 @@ assert_contains "unknown subcommand prints help" "$UNKNOWN_OUT" "Unknown command
 # ---------------------------------------------------------------------------
 # Test 6 — plist generation accepts legacy two-argument invocation
 # ---------------------------------------------------------------------------
-load_helper_without_main "$FIXTURE_DIR/helper-functions.sh"
+load_helper_without_main
 PLIST_OUT=$(_generate_plist "/tmp/aidevops-health" "/usr/bin:/bin")
-assert_contains "plist two-argument legacy call keeps environment path" "$PLIST_OUT" "<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>"
+assert_contains "plist two-argument legacy call keeps environment path" "$PLIST_OUT" "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>"
 assert_contains "plist generation uses calendar schedule" "$PLIST_OUT" "<key>StartCalendarInterval</key>"
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-routine-systemd-calendar.sh
+++ b/.agents/scripts/tests/test-routine-systemd-calendar.sh
@@ -126,12 +126,9 @@ test_pulse_step_minutes_supported() {
 }
 
 test_empty_schedule_fails_cleanly() {
-	local output=""
+	local output
 	local rc=0
-	set +e
-	output=$("${REPO_SCRIPTS_DIR}/routine-schedule-helper.sh" parse '' 2>&1)
-	rc=$?
-	set -e
+	output=$("${REPO_SCRIPTS_DIR}/routine-schedule-helper.sh" parse '' 2>&1) || rc=$?
 
 	if [[ "$rc" -ne 0 && "$output" != *"unary operator expected"* && "$output" == *"unrecognised schedule expression"* ]]; then
 		print_result "empty schedule expression uses clean parse error" 0


### PR DESCRIPTION
## Summary

Simplified review-followup test helpers, removed unsafe fixture truncation, captured schedule parse failures without set toggling, and made the health test fixture portable under signed-commit and Homebrew path environments.

## Files Changed

.agents/scripts/tests/test-repo-aidevops-health.sh,.agents/scripts/tests/test-routine-systemd-calendar.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-repo-aidevops-health.sh .agents/scripts/tests/test-routine-systemd-calendar.sh; .agents/scripts/tests/test-repo-aidevops-health.sh; .agents/scripts/tests/test-routine-systemd-calendar.sh

Resolves #24747


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 2m and 86,591 tokens on this as a headless worker.