### PR TITLE
GH#24741: test: use portable literal dollar grep

### DIFF
--- a/.agents/scripts/tests/test-reconcile-budget-isolation.sh
+++ b/.agents/scripts/tests/test-reconcile-budget-isolation.sh
@@ -245,7 +245,7 @@ test_budget_state_at_function_entry() {
 	fn_line=$(grep -n '^reconcile_issues_single_pass()' "${RECONCILE_SRC}" | head -1 | cut -d: -f1)
 	# SC2016: single-quoted grep pattern intentionally contains literal $SECONDS.
 	# shellcheck disable=SC2016
-	start_line=$(grep -n 'local .*_t2984_start_ts=\$SECONDS' "${RECONCILE_SRC}" | head -1 | cut -d: -f1)
+	start_line=$(grep -n 'local .*_t2984_start_ts=[$]SECONDS' "${RECONCILE_SRC}" | head -1 | cut -d: -f1)
 	# shellcheck disable=SC2016
 	budget_line=$(grep -n '_t2984_budget="${RECONCILE_TIME_BUDGET_SECS' "${RECONCILE_SRC}" | head -1 | cut -d: -f1)
 


### PR DESCRIPTION
## Summary

Updated the reconcile budget isolation test grep pattern to use [$] for matching literal 0 portably across grep implementations.

## Files Changed

.agents/scripts/tests/test-reconcile-budget-isolation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-reconcile-budget-isolation.sh && .agents/scripts/tests/test-reconcile-budget-isolation.sh

Resolves #24741


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 1m and 58,042 tokens on this as a headless worker.