### PR TITLE
fix: recheck GitHub write identity after auth rotation

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1079,8 +1079,8 @@ Evidence:
 
 Closing this stale zero-progress meta-issue so auto-dispatch does not spend worker capacity on an already-recovered incident."
 
-	gh issue comment "$existing" --repo "$meta_repo" --body "$body" >/dev/null 2>&1 || true
-	gh issue close "$existing" --repo "$meta_repo" --reason completed >/dev/null 2>&1 || true
+	gh_issue_comment "$existing" --repo "$meta_repo" --body "$body" >/dev/null 2>&1 || true
+	gh_issue_close_safe "$existing" --repo "$meta_repo" --reason completed >/dev/null 2>&1 || true
 	echo "[pulse-merge-stuck] _pms_close_zero_progress_meta_issue_if_recovered: closed #${existing} — ${reason}" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -154,12 +154,10 @@ _gh_current_user_allows_repo_write() {
 		return 1
 	fi
 
-	if [[ -n "${_AIDEVOPS_CACHED_GH_LOGIN:-}" ]]; then
-		current_user="$_AIDEVOPS_CACHED_GH_LOGIN"
-	else
-		current_user=$(gh api user --jq '.login' 2>/dev/null) || current_user=""
-		_AIDEVOPS_CACHED_GH_LOGIN="$current_user"
-	fi
+	# #aidevops:trust-boundary — do not cache this lookup. Long-running pulse
+	# sessions can rotate GH_TOKEN/OAuth accounts between writes; a stale owner
+	# login would authorize a later non-collaborator token.
+	current_user=$(gh api user --jq '.login' 2>/dev/null) || current_user=""
 	AIDEVOPS_GH_WRITE_PERMISSION_USER="$current_user"
 	export AIDEVOPS_GH_WRITE_PERMISSION_USER
 	if [[ -z "$current_user" ]]; then

--- a/.agents/scripts/tests/test-gh-current-user-write-guard.sh
+++ b/.agents/scripts/tests/test-gh-current-user-write-guard.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-gh-current-user-write-guard.sh — auth-rotation regression for repo write guard.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_LOGIN="owner"
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS: %s\n' "$name"
+		return 0
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL: %s\n' "$name"
+	return 0
+}
+
+gh() {
+	local command_name="${1:-}"
+	local target="${2:-}"
+	if [[ "$command_name" == "api" && "$target" == "user" ]]; then
+		printf '%s\n' "$CURRENT_LOGIN"
+		return 0
+	fi
+	return 1
+}
+
+_rest_api_call() {
+	local class_name="$1"
+	shift
+	local command_name="${1:-}"
+	local api_subcommand="${2:-}"
+	local flag="${3:-}"
+	local path="${4:-}"
+	[[ "$class_name" == "read" && "$command_name" == "gh" && "$api_subcommand" == "api" && "$flag" == "-i" ]] || return 1
+	if [[ "$path" == */collaborators/owner/permission ]]; then
+		printf 'HTTP/2.0 200 OK\n\n{"permission":"write"}\n'
+		return 0
+	fi
+	if [[ "$path" == */collaborators/outsider/permission ]]; then
+		printf 'HTTP/2.0 200 OK\n\n{"permission":"read"}\n'
+		return 0
+	fi
+	printf 'HTTP/2.0 404 Not Found\n\n{"message":"Not Found"}\n'
+	return 1
+}
+
+# shellcheck source=../shared-gh-collaborator-permission.sh
+source "${PARENT_DIR}/shared-gh-collaborator-permission.sh"
+
+if _gh_current_user_allows_repo_write "example/repo"; then
+	print_result "owner token with write permission is allowed" 0
+else
+	print_result "owner token with write permission is allowed" 1
+fi
+
+CURRENT_LOGIN="outsider"
+if _gh_current_user_allows_repo_write "example/repo"; then
+	print_result "rotated outsider token is not allowed after owner token" 1
+else
+	print_result "rotated outsider token is not allowed after owner token" 0
+fi
+
+printf '%d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary
- re-read the authenticated GitHub login on each repo write permission check instead of using a process-lifetime cache
- route merge-stuck recovery comments/closes through the signed/audited wrappers
- add a regression test proving an owner token followed by a rotated non-collaborator token fails closed

## Root cause
The v3.20.58 guard was correct for a single auth identity, but long-running pulse sessions can rotate GH_TOKEN/OAuth accounts. `_gh_current_user_allows_repo_write` cached the first login for the process, so an earlier owner/maintainer identity could authorize a later non-collaborator token. The raw `gh issue comment` then posted as the rotated non-collaborator, while `gh issue close` failed.

## Verification
- shellcheck .agents/scripts/shared-gh-collaborator-permission.sh .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-gh-current-user-write-guard.sh .agents/scripts/tests/test-pulse-merge-stuck.sh
- bash .agents/scripts/tests/test-gh-current-user-write-guard.sh
- bash .agents/scripts/tests/test-pulse-merge-stuck.sh
- bash .agents/scripts/tests/test-pre-dispatch-validator.sh
- bash .agents/scripts/tests/test-repo-role-guard.sh
- .agents/scripts/complexity-regression-helper.sh check --metric file-size --base origin/main --head HEAD
- .agents/scripts/linters-local.sh

Resolves #24754
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.58 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5