### PR TITLE
GH#24760: fix: preserve worker db on ledger query errors

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1089,16 +1089,32 @@ _worker_db_migration_ledgers_match_shared() {
 	local worker_db="$1"
 	local shared_db="$2"
 	local ledger_table shared_count worker_count expected_ledgers=0
+	local has_table
 
 	[[ -f "$worker_db" && -f "$shared_db" ]] || return 1
 	for ledger_table in __drizzle_migrations data_migration migration; do
-		shared_count=$(sqlite3_with_timeout "$shared_db" "SELECT COUNT(*) FROM main.\"${ledger_table}\";" 2>/dev/null || printf '0')
+		if ! has_table=$(sqlite3_with_timeout "$shared_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;"); then
+			return 0
+		fi
+		[[ -n "$has_table" ]] || continue
+
+		if ! shared_count=$(sqlite3_with_timeout "$shared_db" "SELECT COUNT(*) FROM main.\"${ledger_table}\";"); then
+			return 0
+		fi
 		[[ "$shared_count" =~ ^[0-9]+$ ]] || shared_count=0
 		if [[ "$shared_count" -eq 0 ]]; then
 			continue
 		fi
 		expected_ledgers=1
-		worker_count=$(sqlite3_with_timeout "$worker_db" "SELECT COUNT(*) FROM main.\"${ledger_table}\";" 2>/dev/null || printf '0')
+
+		if ! has_table=$(sqlite3_with_timeout "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;"); then
+			return 0
+		fi
+		[[ -n "$has_table" ]] || return 1
+
+		if ! worker_count=$(sqlite3_with_timeout "$worker_db" "SELECT COUNT(*) FROM main.\"${ledger_table}\";"); then
+			return 0
+		fi
 		[[ "$worker_count" =~ ^[0-9]+$ ]] || worker_count=0
 		if [[ "$worker_count" -lt "$shared_count" ]]; then
 			return 1

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1268,6 +1268,37 @@ SQL
 	return 0
 }
 
+test_sync_worker_db_migration_metadata_preserves_worker_db_when_shared_query_fails() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-shared-query-fails"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	printf '%s\n' 'not a sqlite database' >"$shared_db"
+	sqlite3 "$worker_db" <<'SQL'
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+INSERT INTO project VALUES ('prewarmed-project', 'Prewarmed Project');
+SQL
+
+	_sync_worker_db_migration_metadata "$isolated_dir"
+
+	local backup_count=0 backup_file
+	for backup_file in "${isolated_dir}"/opencode/opencode.db.incomplete-migration-ledgers.*.bak; do
+		[[ -f "$backup_file" ]] || continue
+		backup_count=$((backup_count + 1))
+	done
+	if [[ -f "$worker_db" && "$backup_count" == "0" ]]; then
+		print_result "sync worker DB preserves prewarmed DB when shared query fails" 0
+		return 0
+	fi
+
+	print_result "sync worker DB preserves prewarmed DB when shared query fails" 1 \
+		"Expected worker DB preserved, file_exists=$([[ -f "$worker_db" ]] && printf yes || printf no) backups=${backup_count}"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_repeated_launch_reaches_seed() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-repeat"
@@ -1998,6 +2029,7 @@ main() {
 	test_seed_worker_db_session_context_copies_migration_metadata
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_sync_worker_db_migration_metadata_archives_unrepairable_project_table
+	test_sync_worker_db_migration_metadata_preserves_worker_db_when_shared_query_fails
 	test_sync_worker_db_migration_metadata_repeated_launch_reaches_seed
 	test_large_opencode_prompt_uses_file_attachment
 	test_large_claude_prompt_uses_stdin_file


### PR DESCRIPTION
## Summary

Updated _worker_db_migration_ledgers_match_shared to check migration ledger table existence before counting rows, handle sqlite3_with_timeout failures explicitly as safe no-op matches, and keep genuine missing/short worker ledgers destructive-repair eligible. Added regression coverage proving a shared DB query failure preserves the prewarmed worker DB.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh (74 tests, 0 failures)

Resolves #24760


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 56,154 tokens on this as a headless worker.