### PR TITLE
GH#24756: fix: reset zero-progress on conflict progress

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -371,7 +371,7 @@ merge_ready_prs_all_repos() {
 	# t3193: record the zero-progress signal AFTER all repos have been processed.
 	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
 	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
-		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" || true
+		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
 	fi
 
 	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1436,31 +1436,40 @@ _pms_close_zero_progress_meta_issue_if_recovered_due() {
 # When the counter crosses AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES, files a
 # meta-issue (dedup'd by marker) describing the throughput collapse.
 #
-# Reset by a separate call to pulse_merge_zero_progress_reset on any
-# successful merge.
+# Reset by any deterministic merge-pass progress: a successful merge or a
+# conflicting PR close/remediation action that drained work from the queue.
 #
 # Args:
 #   $1 - count of PRs that were eligible-unmerged this cycle (>0 to count)
 #   $2 - count of PRs successfully merged this cycle
+#   $3 - count of non-merge deterministic progress actions this cycle
 #######################################
 pulse_merge_zero_progress_record() {
 	local eligible_unmerged="${1:-0}"
 	local merged_count="${2:-0}"
+	local progress_count="${3:-0}"
 
 	[[ "$eligible_unmerged" =~ ^[0-9]+$ ]] || eligible_unmerged=0
 	[[ "$merged_count" =~ ^[0-9]+$ ]] || merged_count=0
+	[[ "$progress_count" =~ ^[0-9]+$ ]] || progress_count=0
 
 	local cur_before
 	cur_before=$(pulse_stats_get_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES")
 	[[ "$cur_before" =~ ^[0-9]+$ ]] || cur_before=0
 
-	# Successful merge resets the counter.
-	if [[ "$merged_count" -gt 0 ]]; then
+	# Any deterministic merge-pass progress resets the counter. Conflict close or
+	# remediation progress drains stuck work even when no PR merged in that cycle;
+	# keeping the streak alive would file false throughput-collapse meta-issues.
+	if [[ "$merged_count" -gt 0 || "$progress_count" -gt 0 ]]; then
 		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
+		local recovery_reason="${merged_count} PR(s) merged after a ${cur_before}-cycle zero-progress streak"
+		if [[ "$merged_count" -le 0 ]]; then
+			recovery_reason="${progress_count} deterministic conflict/close progress action(s) after a ${cur_before}-cycle zero-progress streak"
+		fi
 		if [[ "$cur_before" -gt 0 ]]; then
-			_pms_close_zero_progress_meta_issue_if_recovered "${merged_count} PR(s) merged after a ${cur_before}-cycle zero-progress streak"
+			_pms_close_zero_progress_meta_issue_if_recovered "$recovery_reason"
 		else
-			_pms_close_zero_progress_meta_issue_if_recovered_due "${merged_count} PR(s) merged while zero-progress gauge was already 0"
+			_pms_close_zero_progress_meta_issue_if_recovered_due "$recovery_reason while zero-progress gauge was already 0"
 		fi
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -14,6 +14,7 @@
 #      against an isolated PULSE_STATS_FILE; non-numeric set is rejected.
 #   6. pulse_merge_zero_progress_record:
 #        merged>0 → gauge reset to 0
+#        non-merge deterministic progress → gauge reset to 0
 #        merged=0 + eligible=0 → gauge reset to 0 (streak broken)
 #        merged=0 + eligible>0 → gauge incremented by 1
 #   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
@@ -327,6 +328,24 @@ TESTS_RUN=$((TESTS_RUN + 1))
 PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
 PMS_TEST_ALLOW_WRITE="1"
 AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=3600
+
+# 5b.3: conflict close/remediation progress is not merge throughput, but it is
+# deterministic queue-draining progress and must break a zero-progress streak.
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE="23038"
+: >"$GH_CALLS"
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "3" >/dev/null 2>&1
+pulse_merge_zero_progress_record 2 0 1 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+assert_eq "5b.3: conflict progress resets cycles to 0 (was 3)" "0" "$got"
+if grep -q 'gh issue close 23038 --repo marcusquinn/aidevops --reason completed' "$GH_CALLS"; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5b.3: conflict progress auto-closes zero-progress issue"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5b.3: conflict progress auto-closes zero-progress issue"
+	echo "  gh calls: $(cat "$GH_CALLS")"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
 
 # 5c: merged=0 + eligible>0 → gauge increments by 1
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Root cause: pulse logged deterministic conflict/close progress (closed_conflicting=1) while the zero-progress detector only treated merged PRs as progress, so eligible-unmerged PRs kept incrementing the collapse streak. The fix passes closed/conflict progress into pulse_merge_zero_progress_record and resets/closes recovered zero-progress issues when that progress drains the queue.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-stuck.sh; shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh

Resolves #24756


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 10m and 150,004 tokens on this as a headless worker.