### PR TITLE
GH#24757: fix: harden collaborator current user lookup

### DIFF
--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -157,7 +157,7 @@ _gh_current_user_allows_repo_write() {
 	# #aidevops:trust-boundary — do not cache this lookup. Long-running pulse
 	# sessions can rotate GH_TOKEN/OAuth accounts between writes; a stale owner
 	# login would authorize a later non-collaborator token.
-	current_user=$(gh api user --jq '.login' 2>/dev/null) || current_user=""
+	current_user=$(gh api user --jq '.login // ""') || current_user=""
 	AIDEVOPS_GH_WRITE_PERMISSION_USER="$current_user"
 	export AIDEVOPS_GH_WRITE_PERMISSION_USER
 	if [[ -z "$current_user" ]]; then

--- a/.agents/scripts/tests/test-shared-gh-collaborator-permission-current-user.sh
+++ b/.agents/scripts/tests/test-shared-gh-collaborator-permission-current-user.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../shared-gh-collaborator-permission.sh"
+
+TEST_ROOT=""
+GH_LOG=""
+REST_LOG=""
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	GH_LOG="${TEST_ROOT}/gh.log"
+	REST_LOG="${TEST_ROOT}/rest.log"
+	: >"$GH_LOG"
+	: >"$REST_LOG"
+	export GH_LOG
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_LOG:?}"
+
+if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+	jq_expr=""
+	while [[ "$#" -gt 0 ]]; do
+		arg="$1"
+		shift
+		if [[ "$arg" == "--jq" && "$#" -gt 0 ]]; then
+			jq_expr="$1"
+			break
+		fi
+	done
+	case "$jq_expr" in
+	'.login // ""')
+		printf '\n'
+		;;
+	'.login')
+		printf 'null\n'
+		;;
+	*)
+		printf 'unexpected-jq:%s\n' "$jq_expr"
+		;;
+	esac
+	exit 0
+fi
+
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+test_current_user_null_maps_to_lookup_failure() {
+	# shellcheck source=../shared-gh-collaborator-permission.sh
+	source "$HELPER_SCRIPT"
+
+	_rest_api_call() {
+		printf '%s\n' "$*" >>"$REST_LOG"
+		return 2
+	}
+
+	local result=0
+	_gh_current_user_allows_repo_write "owner/repo" || result=$?
+
+	[[ "$result" -eq 1 ]] || fail "expected return 1 for missing current user, got ${result}"
+	[[ "${AIDEVOPS_GH_WRITE_PERMISSION_USER-}" == "" ]] || fail "expected empty current user, got '${AIDEVOPS_GH_WRITE_PERMISSION_USER}'"
+	[[ "${AIDEVOPS_GH_WRITE_PERMISSION_REASON:-}" == "current-user-lookup-failed" ]] || fail "expected current-user-lookup-failed, got '${AIDEVOPS_GH_WRITE_PERMISSION_REASON:-}'"
+	[[ ! -s "$REST_LOG" ]] || fail "collaborator lookup should not run for empty current user: $(<"$REST_LOG")"
+	grep -qF -- "--jq .login // \"\"" "$GH_LOG" || fail "expected gh user lookup to request jq null fallback; log: $(<"$GH_LOG")"
+	return 0
+}
+
+test_current_user_lookup_keeps_stderr_visible() {
+	grep -qF "current_user=\$(gh api user --jq '.login // \"\"') || current_user=\"\"" "$HELPER_SCRIPT" \
+		|| fail "current user lookup should use jq null fallback without redirecting stderr"
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+	test_current_user_null_maps_to_lookup_failure
+	test_current_user_lookup_keeps_stderr_visible
+	printf 'PASS shared gh collaborator current-user tests\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Updated the GitHub write-permission guard to request an empty login via jq when gh api user returns null or omits login, preserving visible stderr for real gh errors. Added a regression test that proves null current-user responses stop before collaborator permission lookup.

## Files Changed

.agents/scripts/shared-gh-collaborator-permission.sh,.agents/scripts/tests/test-shared-gh-collaborator-permission-current-user.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted regression: .agents/scripts/tests/test-shared-gh-collaborator-permission-current-user.sh. ShellCheck: shellcheck .agents/scripts/shared-gh-collaborator-permission.sh .agents/scripts/tests/test-shared-gh-collaborator-permission-current-user.sh. Local linters: .agents/scripts/linters-local.sh exceeded the 240s worker timeout after passing Sonar, Secretlint, TOON, skill frontmatter, and other early gates; markdown advisory debt was pre-existing.

Resolves #24757


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 7m and 72,295 tokens on this as a headless worker.