### PR TITLE
GH#24758: fix: harden gh api short option parsing

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -240,7 +240,7 @@ _shim_repo_from_api_path_args() {
 	while [[ $idx -lt ${#args[@]} ]]; do
 		arg="${args[$idx]}"
 		case "$arg" in
-		-f | --field | -F | --raw-field | --jq | -H | --header | --input | --template | --cache | --hostname | --preview | -X | --method)
+		-f | --field | -F | --raw-field | --jq | -q | -H | --header | --input | --template | -t | --cache | --hostname | --preview | -p | -X | --method)
 			idx=$((idx + 2))
 			continue
 			;;
@@ -595,7 +595,7 @@ _shim_api_is_write_endpoint() {
 			continue
 			;;
 		--method=*) method="${a#--method=}" ;;
-		-f | --field | -F | --raw-field | --jq | -H | --header | --input | --template | --cache | --hostname | --preview)
+		-f | --field | -F | --raw-field | --jq | -q | -H | --header | --input | --template | -t | --cache | --hostname | --preview | -p)
 			i=$((i + 2))
 			continue
 			;;
@@ -622,7 +622,7 @@ _shim_api_target_from_path() {
 	while [[ $i -lt ${#_modified_args[@]} ]]; do
 		a="${_modified_args[$i]}"
 		case "$a" in
-		-f | --field | -F | --raw-field | --jq | -H | --header | --input | --template | --cache | --hostname | --preview | -X | --method)
+		-f | --field | -F | --raw-field | --jq | -q | -H | --header | --input | --template | -t | --cache | --hostname | --preview | -p | -X | --method)
 			i=$((i + 2))
 			continue
 			;;

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -623,6 +623,20 @@ else
 	fi
 fi
 
+for short_opt in -q -p -t; do
+	_reset_log
+	if FULL_LOOP_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" api "$short_opt" /repos/managed/repo/issues/1/comments /repos/external/repo/issues/123/comments -X POST -f body="uninstigated" 2>"$TMP/guard-api-$short_opt-injection.err"; then
+		_fail "headless REST guard skips $short_opt argument" "write unexpectedly passed"
+	else
+		argv=$(_read_argv)
+		if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api-$short_opt-injection.err"; then
+			_pass "headless REST guard skips $short_opt argument before repo extraction"
+		else
+			_fail "headless REST guard skips $short_opt argument" "argv: $argv err: $(cat "$TMP/guard-api-$short_opt-injection.err" || true)"
+		fi
+	fi
+done
+
 # =============================================================================
 # Summary
 # =============================================================================


### PR DESCRIPTION
## Summary

Skipped short gh api options that take values (-q, -p, -t) in all repo/path extraction paths so option payloads cannot be mistaken for REST targets; added regression coverage for managed-repo injection before external write targets.

## Files Changed

.agents/scripts/gh,.agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-shim.sh; shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh

Resolves #24758


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 59,352 tokens on this as a headless worker.