### PR TITLE
GH#24769: fix provider multiplier config fallback

### DIFF
--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -340,6 +340,24 @@ assert_eq "6c: openai capacity_slots uses redacted multiplier" "48" \
 assert_eq "6c2: nonzero-exit success counts as other provider failure" "4" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .other_failure')"
 
+JSONC_DEFAULTS="$FIXTURE_DIR/aidevops.defaults.jsonc"
+JSONC_USER="$FIXTURE_DIR/config.jsonc"
+printf '{"orchestration":{"provider_account_slot_multiplier":11}}\n' >"$JSONC_DEFAULTS"
+printf '{"orchestration":{"provider_account_slot_multiplier":7}}\n' >"$JSONC_USER"
+
+JSON=$(env \
+	"WAH_METRICS_FILE=$METRICS" \
+	"WAH_PULSE_STATS_FILE=$STATS" \
+	"WAH_PR_CACHE_FILE=$PR_CACHE" \
+	"WAH_OAUTH_POOL_FILE=$OAUTH_POOL" \
+	"JSONC_DEFAULTS=$JSONC_DEFAULTS" \
+	"JSONC_USER=$JSONC_USER" \
+	"$HELPER" providers --since 24h --json 2>&1)
+RC=$?
+assert_rc "6c3: providers reads config multiplier when env unset" 0 "$RC"
+assert_eq "6c4: config multiplier overrides defaults" "14" \
+	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
+
 OUT=$(env "${RUN_ENV[@]}" "$HELPER" providers --since 24h 2>&1)
 assert_contains "6d: human provider output shows capacity slots" "capacity_slots=48" "$OUT"
 

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -244,7 +244,12 @@ _wah_provider_usage_json() {
 	now_epoch=$(date +%s)
 	input_file="/dev/null"
 	[[ -f "$metrics" ]] && input_file="$metrics"
-	account_multiplier="${WAH_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-24}}"
+	account_multiplier="${WAH_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-${PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER:-}}"
+	if [[ -z "$account_multiplier" ]]; then
+		# shellcheck source=config-helper.sh
+		source "${SCRIPT_DIR}/config-helper.sh"
+		account_multiplier=$(config_get "orchestration.provider_account_slot_multiplier" "24")
+	fi
 	[[ "$account_multiplier" =~ ^[0-9]+$ ]] || account_multiplier=24
 	((account_multiplier < 1)) && account_multiplier=1
 


### PR DESCRIPTION
## Summary

Updated worker-activity provider diagnostics to read orchestration.provider_account_slot_multiplier from config-helper when WAH/PULSE env overrides are unset, preserving env override precedence and numeric fallback.

## Files Changed

.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worker-activity-helper.sh; shellcheck .agents/scripts/worker-activity-helper.sh .agents/scripts/tests/test-worker-activity-helper.sh

Resolves #24769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 2m and 53,802 tokens on this as a headless worker.