### PR TITLE
GH#24770: fix: clarify zero-progress recovery reason

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1462,14 +1462,21 @@ pulse_merge_zero_progress_record() {
 	# keeping the streak alive would file false throughput-collapse meta-issues.
 	if [[ "$merged_count" -gt 0 || "$progress_count" -gt 0 ]]; then
 		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
-		local recovery_reason="${merged_count} PR(s) merged after a ${cur_before}-cycle zero-progress streak"
-		if [[ "$merged_count" -le 0 ]]; then
-			recovery_reason="${progress_count} deterministic conflict/close progress action(s) after a ${cur_before}-cycle zero-progress streak"
-		fi
+		local recovery_reason
 		if [[ "$cur_before" -gt 0 ]]; then
+			if [[ "$merged_count" -gt 0 ]]; then
+				recovery_reason="${merged_count} PR(s) merged after a ${cur_before}-cycle zero-progress streak"
+			else
+				recovery_reason="${progress_count} deterministic conflict/close progress action(s) after a ${cur_before}-cycle zero-progress streak"
+			fi
 			_pms_close_zero_progress_meta_issue_if_recovered "$recovery_reason"
 		else
-			_pms_close_zero_progress_meta_issue_if_recovered_due "$recovery_reason while zero-progress gauge was already 0"
+			if [[ "$merged_count" -gt 0 ]]; then
+				recovery_reason="${merged_count} PR(s) merged while zero-progress gauge was already 0"
+			else
+				recovery_reason="${progress_count} deterministic conflict/close progress action(s) while zero-progress gauge was already 0"
+			fi
+			_pms_close_zero_progress_meta_issue_if_recovered_due "$recovery_reason"
 		fi
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -347,6 +347,25 @@ fi
 TESTS_RUN=$((TESTS_RUN + 1))
 PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
 
+# 5b.4: recovery sweeps from an already-zero gauge must not compose a
+# contradictory "after a 0-cycle streak while gauge was already 0" reason.
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE="23039"
+AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=0
+: >"$LOGFILE"
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
+pulse_merge_zero_progress_record 2 0 1 >/dev/null 2>&1
+if grep -q 'deterministic conflict/close progress action(s) while zero-progress gauge was already 0' "$LOGFILE" \
+	&& ! grep -q 'after a 0-cycle zero-progress streak while zero-progress gauge was already 0' "$LOGFILE"; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5b.4: already-zero recovery reason is direct and non-contradictory"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5b.4: already-zero recovery reason is contradictory"
+	echo "  log: $(cat "$LOGFILE")"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+PMS_TEST_OPEN_ZERO_PROGRESS_ISSUE=""
+AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=3600
+
 # 5c: merged=0 + eligible>0 → gauge increments by 1
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
 pulse_merge_zero_progress_record 4 0 >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Adjusted pulse_merge_zero_progress_record so already-zero recovery sweeps construct direct recovery reasons instead of appending contradictory zero-cycle streak text. Added regression coverage for deterministic conflict/close progress when the gauge is already zero.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-stuck.sh (53 tests, 0 failures; includes shellcheck coverage)

Resolves #24770


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 2m and 37,565 tokens on this as a headless worker.