### PR TITLE
GH#24778: fix: harden ruleset jq diagnostics

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -62,10 +62,11 @@ _check_required_pr_checks_passing_fallback() {
 _ruleset_required_review_count_for_default_branch() {
 	local repo_slug="$1"
 	local default_branch="$2"
+	local log_target="${LOGFILE:-/dev/stderr}"
 
 	local rulesets_json=""
 	rulesets_json=$(gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
-		echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$LOGFILE"
+		echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
 		return 1
 	}
 	[[ -n "$rulesets_json" && "$rulesets_json" != "[]" && "$rulesets_json" != null ]] || {
@@ -74,8 +75,8 @@ _ruleset_required_review_count_for_default_branch() {
 	}
 
 	local active_ids=""
-	active_ids=$(printf '%s' "$rulesets_json" | jq -r '.[]? | select(.enforcement == "active") | .id // empty' 2>>"$LOGFILE") || {
-		echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$LOGFILE"
+	active_ids=$(printf '%s' "$rulesets_json" | jq -r '.[]? | select(.enforcement == "active") | .id // empty' 2>>"$log_target") || {
+		echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
 		return 1
 	}
 	[[ -n "$active_ids" ]] || {
@@ -89,11 +90,11 @@ _ruleset_required_review_count_for_default_branch() {
 	while IFS= read -r id; do
 		[[ -n "$id" ]] || continue
 		detail=$(gh api "repos/${repo_slug}/rulesets/${id}" 2>/dev/null) || {
-			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$LOGFILE"
+			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
 			return 1
 		}
-		include_patterns=$(printf '%s' "$detail" | jq -r '.conditions?.ref_name?.include? // [] | .[]?' 2>>"$LOGFILE") || return 1
-		exclude_patterns=$(printf '%s' "$detail" | jq -r '.conditions?.ref_name?.exclude? // [] | .[]?' 2>>"$LOGFILE") || return 1
+		include_patterns=$(printf '%s' "$detail" | jq -r '.conditions?.ref_name?.include? // [] | .[]' 2>>"$log_target") || return 1
+		exclude_patterns=$(printf '%s' "$detail" | jq -r '.conditions?.ref_name?.exclude? // [] | .[]' 2>>"$log_target") || return 1
 
 		matches_default=0
 		while IFS= read -r pattern; do
@@ -113,8 +114,8 @@ _ruleset_required_review_count_for_default_branch() {
 		done <<<"$exclude_patterns"
 		[[ "$excluded_default" -eq 0 ]] || continue
 
-		approval_count=$(printf '%s' "$detail" | jq -r '[.rules[]? | select(.type == "pull_request") | (.parameters?.required_approving_review_count? // 0)] | max // 0' 2>>"$LOGFILE") || {
-			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: pull-request rule parse failed for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#24577)" >>"$LOGFILE"
+		approval_count=$(printf '%s' "$detail" | jq -r '[.rules[]? | select(.type == "pull_request") | (.parameters?.required_approving_review_count? // 0)] | max // 0' 2>>"$log_target") || {
+			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: pull-request rule parse failed for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
 			return 1
 		}
 		[[ "$approval_count" =~ ^[0-9]+$ ]] || approval_count=0

--- a/.agents/tests/test-pulse-merge-required-checks.sh
+++ b/.agents/tests/test-pulse-merge-required-checks.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression checks for pulse merge required-check ruleset parsing.
+#
+# Usage: bash .agents/tests/test-pulse-merge-required-checks.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+TARGET="${SCRIPT_DIR}/../scripts/pulse-merge-required-checks.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+_pass() {
+	local name="$1"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	printf '  [PASS] %s\n' "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local reason="${2:-}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  [FAIL] %s%s\n' "$name" "${reason:+ — ${reason}}"
+	return 0
+}
+
+_assert_contains_literal() {
+	local name="$1"
+	local needle="$2"
+	if grep -Fq -- "$needle" "$TARGET"; then
+		_pass "$name"
+		return 0
+	fi
+	_fail "$name" "missing literal: ${needle}"
+	return 0
+}
+
+_assert_not_contains_literal() {
+	local name="$1"
+	local needle="$2"
+	if grep -Fq -- "$needle" "$TARGET"; then
+		_fail "$name" "unexpected literal: ${needle}"
+		return 0
+	fi
+	_pass "$name"
+	return 0
+}
+
+test_ruleset_jq_diagnostics_have_safe_log_fallback() {
+	printf '\n=== ruleset jq diagnostics ===\n'
+	_assert_contains_literal "ruleset parser defines safe log target" \
+		"local log_target=\"\${LOGFILE:-/dev/stderr}\""
+	_assert_contains_literal "active rulesets jq stderr uses fallback" \
+		"jq -r '.[]? | select(.enforcement == \"active\") | .id // empty' 2>>\"\$log_target\""
+	_assert_contains_literal "approval count jq stderr uses fallback" \
+		"jq -r '[.rules[]? | select(.type == \"pull_request\") | (.parameters?.required_approving_review_count? // 0)] | max // 0' 2>>\"\$log_target\""
+	_assert_not_contains_literal "ruleset jq does not redirect to possibly unset LOGFILE" \
+		"jq -r '[.rules[]? | select(.type == \"pull_request\") | (.parameters?.required_approving_review_count? // 0)] | max // 0' 2>>\"\$LOGFILE\""
+	return 0
+}
+
+test_ruleset_ref_patterns_fail_closed_on_malformed_schema() {
+	printf '\n=== ruleset ref pattern fail-closed parsing ===\n'
+	_assert_contains_literal "include patterns use strict array iteration" \
+		"jq -r '.conditions?.ref_name?.include? // [] | .[]' 2>>\"\$log_target\""
+	_assert_contains_literal "exclude patterns use strict array iteration" \
+		"jq -r '.conditions?.ref_name?.exclude? // [] | .[]' 2>>\"\$log_target\""
+	_assert_not_contains_literal "include patterns do not suppress malformed non-arrays" \
+		"jq -r '.conditions?.ref_name?.include? // [] | .[]?'"
+	_assert_not_contains_literal "exclude patterns do not suppress malformed non-arrays" \
+		"jq -r '.conditions?.ref_name?.exclude? // [] | .[]?'"
+	return 0
+}
+
+main() {
+	test_ruleset_jq_diagnostics_have_safe_log_fallback
+	test_ruleset_ref_patterns_fail_closed_on_malformed_schema
+
+	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Hardened ruleset parsing diagnostics by using a safe LOGFILE fallback and restored strict array iteration for ref patterns so malformed ruleset schemas fail closed. Added a regression test covering the jq redirection and strict include/exclude parsing.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh,.agents/tests/test-pulse-merge-required-checks.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-merge-required-checks.sh && shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/tests/test-pulse-merge-required-checks.sh

Resolves #24778


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 3m and 51,652 tokens on this as a headless worker.