### PR TITLE
GH#24777: fix: optimize scheduler shell quoting

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -514,9 +514,7 @@ _run_profile_readme_init() {
 
 _core_routine_shell_quote() {
 	local value="$1"
-	printf "'"
-	printf '%s' "$value" | sed "s/'/'\\\\''/g"
-	printf "'"
+	printf "'%s'" "${value//\'/\'\\\'\'}"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Replaced the _core_routine_shell_quote sed pipeline in .agents/scripts/setup/modules/schedulers-platform.sh with Bash parameter expansion, matching the existing shell_quote pattern and avoiding an external process.

## Files Changed

.agents/scripts/setup/modules/schedulers-platform.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/setup/modules/schedulers-platform.sh; shellcheck .agents/scripts/setup/modules/schedulers-platform.sh; sourced _core_routine_shell_quote roundtrip checks for empty, plain, spaced, and single-quote values; .agents/scripts/linters-local.sh (timed out after passing SonarCloud, string literal, FD lock, and shellcheckrc parity checks while running Secretlint)

Resolves #24777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 6m and 62,131 tokens on this as a headless worker.