### PR TITLE
GH#24774: fix: harden worker migration ledger replacement

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1056,11 +1056,14 @@ _copy_worker_db_migration_ledger_table() {
 
 	has_worker=$(sqlite3_with_timeout "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
 	if [[ -z "$has_worker" ]]; then
-		sqlite3_with_timeout "$shared_db" ".schema ${ledger_table}" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1 || true
+		if ! sqlite3_with_timeout "$shared_db" ".schema ${ledger_table}" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1; then
+			print_warning "OpenCode worker DB could not create ${ledger_table} migration ledger from shared DB"
+			return 1
+		fi
 	fi
 
 	shared_db_sql=$(sql_escape "$shared_db")
-	sqlite3_with_timeout "$worker_db" <<-SQL >/dev/null 2>&1 || true
+	if ! sqlite3_with_timeout "$worker_db" <<-SQL >/dev/null 2>&1; then
 		.bail on
 		ATTACH DATABASE '${shared_db_sql}' AS shared;
 		BEGIN IMMEDIATE;
@@ -1069,6 +1072,9 @@ _copy_worker_db_migration_ledger_table() {
 		COMMIT;
 		DETACH DATABASE shared;
 	SQL
+		print_warning "OpenCode worker DB could not replace ${ledger_table} migration ledger from shared DB"
+		return 1
+	fi
 	return 0
 }
 
@@ -1083,7 +1089,7 @@ _sync_worker_db_migration_ledgers() {
 
 	[[ -f "$worker_db" && -f "$shared_db" ]] || return 0
 	for ledger_table in __drizzle_migrations data_migration migration; do
-		_copy_worker_db_migration_ledger_table "$worker_db" "$shared_db" "$ledger_table"
+		_copy_worker_db_migration_ledger_table "$worker_db" "$shared_db" "$ledger_table" || true
 	done
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1281,6 +1281,63 @@ SQL
 	return 0
 }
 
+test_copy_worker_db_migration_ledger_preserves_rows_when_attach_fails() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-attach-failure"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	local sqlite_wrapper
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+INSERT INTO __drizzle_migrations VALUES (1, 'shared-schema-ready', 12345);
+SQL
+	sqlite3 "$worker_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+INSERT INTO __drizzle_migrations VALUES (1, 'stale-schema-row', 11111);
+SQL
+
+	sqlite_wrapper=$(declare -f sqlite3_with_timeout | sed '1s/sqlite3_with_timeout/sqlite3_with_timeout_original_for_test/')
+	eval "$sqlite_wrapper"
+	sqlite3_with_timeout() {
+		local db_path="${1:-}"
+		local line
+		local sql_input
+
+		if [[ "$db_path" == "$worker_db" && "$#" -eq 1 ]]; then
+			sql_input=""
+			while IFS= read -r line; do
+				sql_input+="${line}"$'\n'
+			done
+			if [[ "$sql_input" == *"ATTACH DATABASE"* ]]; then
+				return 1
+			fi
+			printf '%s\n' "$sql_input" | sqlite3_with_timeout_original_for_test "$db_path"
+			return $?
+		fi
+
+		sqlite3_with_timeout_original_for_test "$@"
+		return $?
+	}
+
+	_copy_worker_db_migration_ledger_table "$worker_db" "$shared_db" "__drizzle_migrations" >/dev/null 2>&1 || true
+
+	eval "$(declare -f sqlite3_with_timeout_original_for_test | sed '1s/sqlite3_with_timeout_original_for_test/sqlite3_with_timeout/')"
+	unset -f sqlite3_with_timeout_original_for_test
+
+	local schema_hash
+	schema_hash=$(sqlite3 "$worker_db" "SELECT hash FROM __drizzle_migrations WHERE id = 1;")
+	if [[ "$schema_hash" == "stale-schema-row" ]]; then
+		print_result "copy worker DB migration ledger preserves rows when attach fails" 0
+		return 0
+	fi
+
+	print_result "copy worker DB migration ledger preserves rows when attach fails" 1 "schema_hash=$schema_hash"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_archives_unrepairable_project_table() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-unrepairable"
@@ -2075,6 +2132,7 @@ main() {
 	test_seed_worker_db_session_context_copies_migration_metadata
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_sync_worker_db_migration_metadata_replaces_stale_ledgers
+	test_copy_worker_db_migration_ledger_preserves_rows_when_attach_fails
 	test_sync_worker_db_migration_metadata_archives_unrepairable_project_table
 	test_sync_worker_db_migration_metadata_preserves_worker_db_when_shared_query_fails
 	test_sync_worker_db_migration_metadata_repeated_launch_reaches_seed


### PR DESCRIPTION
## Summary

Hardened OpenCode worker migration ledger copying so schema/copy failures return non-zero with warnings instead of blanket suppression, while keeping sync best-effort across allowlisted ledgers. Added regression coverage that simulates an ATTACH-stage failure and verifies stale worker ledger rows are preserved.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh (76 tests, 0 failures); .agents/scripts/linters-local.sh reached existing repository-wide markdown/complexity debt before timeout, with no changed-file ShellCheck or Bash 3.2 regressions

Resolves #24774


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 21m and 65,585 tokens on this as a headless worker.