### PR TITLE
GH#24787: fix: clarify scheduler shell quoting

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -514,7 +514,8 @@ _run_profile_readme_init() {
 
 _core_routine_shell_quote() {
 	local value="$1"
-	printf "'%s'" "${value//\'/\'\\\'\'}"
+	local sq="'"
+	printf "'%s'" "${value//$sq/$sq\\$sq$sq}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -87,6 +87,17 @@ test_core_routine_logged_command_shape() {
 	return 0
 }
 
+test_core_routine_shell_quote_escapes_single_quotes() {
+	local quoted
+	quoted=$(_core_routine_shell_quote "one'two")
+	if [[ "$quoted" != "'one'\\''two'" ]]; then
+		print_result "core routine shell quote escapes single quotes" 1 "$quoted"
+		return 0
+	fi
+	print_result "core routine shell quote escapes single quotes" 0
+	return 0
+}
+
 test_linux_core_scheduler_commands_are_logged() {
 	local fake_home="$TEST_DIR/scheduler-home"
 	mkdir -p "$fake_home/.aidevops/agents/scripts" "$fake_home/.aidevops/.agent-workspace/logs"
@@ -185,6 +196,7 @@ main() {
 	setup
 	load_scheduler_helpers
 	test_core_routine_logged_command_shape
+	test_core_routine_shell_quote_escapes_single_quotes
 	test_linux_core_scheduler_commands_are_logged
 	test_pulse_routine_update_uses_flags_and_duration
 	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Reworked _core_routine_shell_quote to use an explicit single-quote helper variable and added a regression test for single-quote escaping.

## Files Changed

.agents/scripts/setup/modules/schedulers-platform.sh,.agents/scripts/tests/test-routine-tracking-updates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-routine-tracking-updates.sh; shellcheck .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/tests/test-routine-tracking-updates.sh

Resolves #24787


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 2m and 37,973 tokens on this as a headless worker.