### PR TITLE
GH#24788: docs: clarify renderer secret storage boundary

### DIFF
--- a/.agents/tools/app-stack/encrypted-collaboration.md
+++ b/.agents/tools/app-stack/encrypted-collaboration.md
@@ -17,7 +17,7 @@ Add encryption and collaboration deliberately. Start by identifying which data m
 | Public/static | Static files or public database rows |
 | Workspace shared | Postgres rows with RLS and audit |
 | Local private | Device store, PGlite/SQLite, or OS keychain-backed files |
-| Secret material | aidevops secret storage, OS keychain, or encrypted config; never stored in renderer rows |
+| Secret material | aidevops secret storage, OS keychain, or encrypted config; never stored in renderer-accessible rows |
 | End-to-end encrypted | Client-side encrypted payloads; server stores ciphertext and metadata only |
 
 ## Collaboration choices


### PR DESCRIPTION
## Summary

Clarified the secret-material storage guidance so it says secret material is never stored in renderer-accessible rows.

## Files Changed

.agents/tools/app-stack/encrypted-collaboration.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check origin/main...HEAD -- .agents/tools/app-stack/encrypted-collaboration.md; pre-commit validation passed; pre-push validation passed

Resolves #24788


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5 spent 1m and 56,679 tokens on this as a headless worker.