### PR TITLE
GH#24786: fix: accept prefetched rulesets for review counts

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -55,20 +55,22 @@ _check_required_pr_checks_passing_fallback() {
 # GitHub stores ruleset approval requirements under pull_request rules, not as
 # CI contexts, so an empty status context list is not enough to allow a merge.
 #
-# Args: $1=repo_slug, $2=default_branch
+# Args: $1=repo_slug, $2=default_branch, $3=optional pre-fetched rulesets JSON
 # Stdout: integer maximum required_approving_review_count (0 when none)
 # Returns: 0=requirement resolved, 1=ruleset API/parse error
 #######################################
 _ruleset_required_review_count_for_default_branch() {
 	local repo_slug="$1"
 	local default_branch="$2"
+	local rulesets_json="${3:-}"
 	local log_target="${LOGFILE:-/dev/stderr}"
 
-	local rulesets_json=""
-	rulesets_json=$(gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
-		echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
-		return 1
-	}
+	if [[ -z "$rulesets_json" ]]; then
+		rulesets_json=$(gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
+			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
+			return 1
+		}
+	fi
 	[[ -n "$rulesets_json" && "$rulesets_json" != "[]" && "$rulesets_json" != null ]] || {
 		printf '0'
 		return 0

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -386,12 +386,24 @@ assert_ruleset_review_gate_returns() {
 assert_ruleset_review_count_output() {
 	local expected_output="$1"
 	local label="$2"
+	local rulesets_json="${3:-}"
 	local actual_output=""
-	actual_output=$(_ruleset_required_review_count_for_default_branch "marcusquinn/aidevops" "main") || actual_output="ERR"
+	actual_output=$(_ruleset_required_review_count_for_default_branch "marcusquinn/aidevops" "main" "$rulesets_json") || actual_output="ERR"
 	if [[ "$actual_output" == "$expected_output" ]]; then
 		print_result "$label" 0
 	else
 		print_result "$label" 1 "Expected output='$expected_output', got output='$actual_output'"
+	fi
+	return 0
+}
+
+assert_gh_call_absent() {
+	local pattern="$1"
+	local label="$2"
+	if grep -Fxq -- "$pattern" "$GH_CALL_LOG" 2>/dev/null; then
+		print_result "$label" 1 "Unexpected gh invocation: $pattern"
+	else
+		print_result "$label" 0
 	fi
 	return 0
 }
@@ -592,6 +604,18 @@ test_ruleset_review_only_missing_blocks_merge() {
 	return 0
 }
 
+test_ruleset_review_count_accepts_prefetched_rulesets_json() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_only_missing"
+	assert_ruleset_review_count_output "1" \
+		"pre-fetched rulesets JSON skips rulesets list fetch" \
+		'[{"id":101,"enforcement":"active"}]'
+	assert_gh_call_absent "api repos/marcusquinn/aidevops/rulesets" \
+		"pre-fetched rulesets JSON avoids redundant rulesets list API call"
+	return 0
+}
+
 test_ruleset_review_only_approved_allows_merge() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -668,6 +692,7 @@ main() {
 	test_expected_required_is_non_terminal
 	test_skipping_required_allows_merge
 	test_ruleset_review_only_missing_blocks_merge
+	test_ruleset_review_count_accepts_prefetched_rulesets_json
 	test_ruleset_review_only_approved_allows_merge
 	test_ruleset_mixed_review_status_preserves_both_gates
 	test_ruleset_review_zero_does_not_require_approval


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-merge-required-checks.sh so _ruleset_required_review_count_for_default_branch accepts optional pre-fetched rulesets JSON as argument 3 and only calls gh api repos/<repo>/rulesets when that argument is empty. Added regression coverage in .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh to prove the pre-fetched path preserves review-count extraction while skipping the redundant rulesets-list API call.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh,.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

Resolves #24786


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2m and 47,757 tokens on this as a headless worker.