### PR TITLE
GH#24789: docs: clarify tab keyboard key names

### DIFF
--- a/.agents/tools/app-stack/static-site-starter.md
+++ b/.agents/tools/app-stack/static-site-starter.md
@@ -47,7 +47,7 @@ Use for plain public sites that need speed, metadata quality, accessibility, and
 ## Interaction rules
 
 - Prefer native links/buttons/details before custom widgets.
-- If tabs are used, implement roving `tabindex`, arrow keys, `Home`/`End`, `aria-selected`, `aria-controls`, and `aria-hidden`.
+- If tabs are used, implement roving `tabindex`, `ArrowLeft`/`ArrowRight` keys, `Home`/`End`, `aria-selected`, `aria-controls`, and `aria-hidden`.
 - Keep JavaScript null-safe and scoped in small modules.
 - Update visual state and accessibility state together.
 - Theme state may persist locally, but the page must remain readable without JavaScript.


### PR DESCRIPTION
## Summary

Updated .agents/tools/app-stack/static-site-starter.md so the tab interaction checklist wraps concrete keyboard key names in backticks, matching the existing markup for tabindex, Home/End, and ARIA attributes.

## Files Changed

.agents/tools/app-stack/static-site-starter.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check -- .agents/tools/app-stack/static-site-starter.md

Resolves #24789


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 53,744 tokens on this as a headless worker.