### PR TITLE
GH#24785: fix: harden worker ledger schema copy

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1049,14 +1049,14 @@ _copy_worker_db_migration_ledger_table() {
 	local worker_db="$1"
 	local shared_db="$2"
 	local ledger_table="$3"
-	local has_shared has_worker shared_db_sql
+	local has_shared has_worker schema shared_db_sql
 
 	has_shared=$(sqlite3_with_timeout "$shared_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
 	[[ -n "$has_shared" ]] || return 0
 
 	has_worker=$(sqlite3_with_timeout "$worker_db" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '${ledger_table}' LIMIT 1;" 2>/dev/null || true)
 	if [[ -z "$has_worker" ]]; then
-		if ! sqlite3_with_timeout "$shared_db" ".schema ${ledger_table}" 2>/dev/null | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1; then
+		if ! schema=$(sqlite3_with_timeout "$shared_db" ".schema ${ledger_table}" 2>/dev/null) || [[ -z "$schema" ]] || ! printf '%s\n' "$schema" | sqlite3_with_timeout "$worker_db" >/dev/null 2>&1; then
 			print_warning "OpenCode worker DB could not create ${ledger_table} migration ledger from shared DB"
 			return 1
 		fi

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1338,6 +1338,61 @@ SQL
 	return 0
 }
 
+test_copy_worker_db_migration_ledger_stops_when_schema_query_fails() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-schema-query-failure"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	local sqlite_wrapper
+	local create_attempts=0
+	local rc=0
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+INSERT INTO __drizzle_migrations VALUES (1, 'shared-schema-ready', 12345);
+SQL
+	sqlite3 "$worker_db" <<'SQL'
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+SQL
+
+	sqlite_wrapper=$(declare -f sqlite3_with_timeout | sed '1s/sqlite3_with_timeout/sqlite3_with_timeout_original_for_test/')
+	eval "$sqlite_wrapper"
+	sqlite3_with_timeout() {
+		local db_path="${1:-}"
+		local sql_arg="${2:-}"
+		local line
+
+		if [[ "$db_path" == "$shared_db" && "$sql_arg" == ".schema __drizzle_migrations" ]]; then
+			return 1
+		fi
+		if [[ "$db_path" == "$worker_db" && "$#" -eq 1 ]]; then
+			create_attempts=$((create_attempts + 1))
+			while IFS= read -r line; do
+				:
+			done
+			return 0
+		fi
+
+		sqlite3_with_timeout_original_for_test "$@"
+		return $?
+	}
+
+	_copy_worker_db_migration_ledger_table "$worker_db" "$shared_db" "__drizzle_migrations" >/dev/null 2>&1 || rc=$?
+
+	eval "$(declare -f sqlite3_with_timeout_original_for_test | sed '1s/sqlite3_with_timeout_original_for_test/sqlite3_with_timeout/')"
+	unset -f sqlite3_with_timeout_original_for_test
+
+	if [[ "$rc" == "1" && "$create_attempts" == "0" ]]; then
+		print_result "copy worker DB migration ledger stops when schema query fails" 0
+		return 0
+	fi
+
+	print_result "copy worker DB migration ledger stops when schema query fails" 1 "rc=$rc create_attempts=$create_attempts"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_archives_unrepairable_project_table() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-unrepairable"
@@ -2133,6 +2188,7 @@ main() {
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_sync_worker_db_migration_metadata_replaces_stale_ledgers
 	test_copy_worker_db_migration_ledger_preserves_rows_when_attach_fails
+	test_copy_worker_db_migration_ledger_stops_when_schema_query_fails
 	test_sync_worker_db_migration_metadata_archives_unrepairable_project_table
 	test_sync_worker_db_migration_metadata_preserves_worker_db_when_shared_query_fails
 	test_sync_worker_db_migration_metadata_repeated_launch_reaches_seed


### PR DESCRIPTION
## Summary

Captured the shared migration ledger schema before replaying it into the worker DB so schema query failures cannot be hidden by the downstream sqlite process. Added a regression test that fails if a schema query failure still attempts worker-side schema creation.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh (77 tests, 0 failures); shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh (pass); .agents/scripts/linters-local.sh attempted twice but exceeded bounded timeouts after non-blocking checks

Resolves #24785


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 26m and 75,092 tokens on this as a headless worker.