### PR TITLE
fix: use configured base for orphan recovery

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -55,6 +55,7 @@ Agent-source repos receive non-destructive template management:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `pr_base_branch` | string | GitHub default branch | Branch workers should target when creating or recovering PRs. Use for repos whose integration branch differs from the GitHub default branch, e.g. `"develop"`. Aliases accepted by orphan recovery: `pr_target_branch`, `base_branch`, `default_branch`. |
 | `interactive_pr_auto_merge` | bool | unset → global config/default | Per-repo preference for `origin:interactive` PR merge throughput. `true` allows pulse to merge maintainer-authored interactive PRs after normal gates pass and the PR is ready/non-draft. `false` keeps this repo manual even if global config is true. PR-specific `allow-auto-merge` still opts in one PR; `hold-for-review` or draft state still blocks. |
 
 Global equivalent: `orchestration.interactive_pr_auto_merge` in `~/.config/aidevops/config.jsonc`. Env override for the current pulse/session: `AIDEVOPS_INTERACTIVE_PR_AUTO_MERGE`.

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -76,6 +76,34 @@ source "${SCRIPT_DIR}/dispatch-dedup-stale.sh"
 source "${SCRIPT_DIR}/dispatch-dedup-pr.sh"
 
 #######################################
+# Resolve configured PR base branch for worker-orphan diagnostics.
+#
+# Args: $1 = repo slug
+# Outputs: branch name
+# Returns: 0 always
+#######################################
+_ddh_resolve_pr_base_branch() {
+	local repo_slug="$1"
+	local base_branch="${WORKER_PR_BASE_BRANCH:-${DISPATCH_REPO_PR_BASE_BRANCH:-${AIDEVOPS_PR_BASE_BRANCH:-}}}"
+	local repos_json="${AIDEVOPS_REPOS_JSON:-${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}}"
+
+	if [[ -z "$base_branch" && -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
+		base_branch=$(jq -r --arg slug "$repo_slug" '
+			.initialized_repos[]?
+			| select(.slug == $slug)
+			| .pr_base_branch // .pr_target_branch // .base_branch // .default_branch // empty
+		' "$repos_json" 2>/dev/null | sed -n '1p') || base_branch=""
+	fi
+
+	if [[ -z "$base_branch" && -n "$repo_slug" ]]; then
+		base_branch=$(gh repo view "$repo_slug" --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+	fi
+
+	printf '%s' "${base_branch:-main}"
+	return 0
+}
+
+#######################################
 # Extract canonical dedup keys from a title string.
 # Looks for patterns: issue #NNN, PR #NNN, tNNN (task IDs), issue-NNN, pr-NNN.
 # Args: $1 = title string
@@ -964,17 +992,23 @@ check_worker_branch_orphan_loop() {
 
 	local pr_hint="none found"
 	local pr_line=""
+	local pr_base_branch=""
+	pr_base_branch=$(_ddh_resolve_pr_base_branch "$repo_slug")
 	pr_line=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state all \
 		--json number,state,url --jq '.[0] | select(.number != null) | "#\(.number) (\(.state)) \(.url)"' 2>/dev/null || true)
 	[[ -n "$pr_line" ]] && pr_hint="$pr_line"
+	local next_action="Open recovery PR: \`gh pr create --repo ${repo_slug} --head ${branch_name} --base ${pr_base_branch}\`"
+	if [[ "$pr_hint" != "none found" ]]; then
+		next_action="Link, review, or merge the existing PR for this branch."
+	fi
 
 	if [[ "$existing_block" -eq 0 ]]; then
 		local diag
 		# shellcheck disable=SC2016 # Backticks are literal Markdown in this printf template.
-		diag=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan-loop:blocked branch=%s issue=%s count=%s window_s=%s -->\n## Dispatch held: repeated worker_branch_orphan\n\nThe dispatch path has seen `%s` `WORKER_BRANCH_ORPHAN` outcomes for issue #%s on branch `%s` within the last %s seconds. Dispatch is held for this same branch to avoid burning more worker attempts while preserving evidence.\n\n- Branch: `%s`\n- Latest orphan marker: `%s`\n- PR for branch: %s\n- Next verification: `gh pr list --repo %s --head %s --state all --json number,state,url`\n\nIf the branch already has the intended PR, link or merge that PR. If the branch is stale or corrupt, remove/reset that worktree/branch so a fresh branch can dispatch.\n<!-- ops:end -->' \
+		diag=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan-loop:blocked branch=%s issue=%s count=%s window_s=%s -->\n## Dispatch held: repeated worker_branch_orphan\n\nThe dispatch path has seen `%s` `WORKER_BRANCH_ORPHAN` outcomes for issue #%s on branch `%s` within the last %s seconds. Dispatch is held for this same branch to avoid burning more worker attempts while preserving evidence.\n\n- Branch: `%s`\n- Latest orphan marker: `%s`\n- PR for branch: %s\n- Next action: %s\n- Next verification: `gh pr list --repo %s --head %s --state all --json number,state,url`\n\nIf no PR exists and the branch has commits, open the recovery PR against `%s`. If no commits exist to PR, remove/reset that worktree/branch so a fresh branch can dispatch.\n<!-- ops:end -->' \
 			"$branch_name" "$issue_number" "$count" "$window_s" \
 			"$count" "$issue_number" "$branch_name" "$window_s" \
-			"$branch_name" "${latest_iso:-unknown}" "$pr_hint" "$repo_slug" "$branch_name")
+			"$branch_name" "${latest_iso:-unknown}" "$pr_hint" "$next_action" "$repo_slug" "$branch_name" "$pr_base_branch")
 		gh api "$comments_post_endpoint" \
 			--method POST \
 			--field body="$diag" \

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -623,11 +623,15 @@ _handle_worker_branch_orphan() {
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
 			local _orphan_key="${repo_slug}#${issue_number}#${branch_name}#worker_branch_orphan"
+			local _orphan_base_branch="main"
+			if declare -F _resolve_orphan_recovery_base_branch >/dev/null 2>&1; then
+				_orphan_base_branch=$(_resolve_orphan_recovery_base_branch "$repo_slug" "$work_dir")
+			fi
 			# shellcheck disable=SC2016 # backticks are literal markdown, not command substitution
-			_ops_comment=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan:key=%s -->\nWORKER_BRANCH_ORPHAN branch=%s session=%s ts=%s\n\nThis worker pushed branch `%s` but no PR could be opened automatically. To recover, open a PR manually:\n\n```\ngh pr create --head %s --base main --repo %s\n```\n<!-- ops:end -->' \
+			_ops_comment=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan:key=%s -->\nWORKER_BRANCH_ORPHAN branch=%s session=%s ts=%s\n\nThis worker pushed branch `%s` but no PR could be opened automatically. To recover, open a PR manually:\n\n```\ngh pr create --head %s --base %s --repo %s\n```\n<!-- ops:end -->' \
 				"$_orphan_key" \
 				"$branch_name" "$session_key" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-				"$branch_name" "$branch_name" "$repo_slug")
+				"$branch_name" "$branch_name" "$_orphan_base_branch" "$repo_slug")
 			gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 				--method POST \
 				--field body="$_ops_comment" \

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -228,10 +228,50 @@ _pr_exists_for_branch_or_issue() {
 }
 
 #######################################
+# _resolve_orphan_recovery_base_branch — PR base for orphan recovery.
+#
+# Prefers the repository's configured PR target branch over GitHub's default
+# branch. This covers managed repos whose integration branch is `develop` while
+# their default branch remains `main` (GH#80).
+#
+# Args:
+#   $1 = repo_slug (owner/repo)
+#   $2 = work_dir   (path to git worktree; optional)
+# Outputs: branch name
+# Returns: 0 always (falls back to main)
+#######################################
+_resolve_orphan_recovery_base_branch() {
+	local repo_slug="$1"
+	local work_dir="${2:-}"
+	local base_branch="${WORKER_PR_BASE_BRANCH:-${DISPATCH_REPO_PR_BASE_BRANCH:-${AIDEVOPS_PR_BASE_BRANCH:-}}}"
+
+	if [[ -z "$base_branch" && -n "$work_dir" && -f "${work_dir}/.aidevops.json" ]] && command -v jq >/dev/null 2>&1; then
+		base_branch=$(jq -r '.pr_base_branch // .pr_target_branch // .base_branch // .default_branch // empty' "${work_dir}/.aidevops.json" 2>/dev/null || true)
+	fi
+
+	local repos_json="${AIDEVOPS_REPOS_JSON:-${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}}"
+	if [[ -z "$base_branch" && -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
+		base_branch=$(jq -r --arg slug "$repo_slug" '
+			.initialized_repos[]?
+			| select(.slug == $slug)
+			| .pr_base_branch // .pr_target_branch // .base_branch // .default_branch // empty
+		' "$repos_json" 2>/dev/null | sed -n '1p') || base_branch=""
+	fi
+
+	if [[ -z "$base_branch" && -n "$repo_slug" ]]; then
+		base_branch=$(gh repo view "$repo_slug" \
+			--json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+	fi
+
+	printf '%s' "${base_branch:-main}"
+	return 0
+}
+
+#######################################
 # _attempt_orphan_recovery_pr — auto-recover a worker_branch_orphan (GH#20819)
 #
 # Called when a worker pushed a branch but exited without opening a PR.
-# Attempts to open a non-draft PR against the repo's default branch with
+# Attempts to open a non-draft PR against the repo's configured PR base branch with
 # origin:worker-takeover label so the normal review/merge pipeline applies.
 #
 # Short-circuits (returns 1) when:
@@ -308,12 +348,8 @@ _attempt_orphan_recovery_pr() {
 		fi
 	fi
 
-	# Detect repo default branch (fallback: main)
-	local default_branch="main"
-	local detected_default=""
-	detected_default=$(gh repo view "$repo_slug" \
-		--json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
-	[[ -n "$detected_default" ]] && default_branch="$detected_default"
+	local base_branch=""
+	base_branch=$(_resolve_orphan_recovery_base_branch "$repo_slug" "$work_dir")
 
 	# Build PR metadata
 	local pr_title="auto-recover: orphaned worker branch"
@@ -345,7 +381,7 @@ _attempt_orphan_recovery_pr() {
 	local create_args=(
 		--repo "$repo_slug"
 		--head "$branch_name"
-		--base "$default_branch"
+		--base "$base_branch"
 		--title "$pr_title"
 		--body "$pr_body"
 		--label "origin:worker-takeover"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1856,6 +1856,7 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 	local work_dir="${TEST_ROOT}/repo-orphan-recovery"
 	_setup_test_git_repo "$work_dir" 1
 	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
+	printf '{"pr_base_branch":"develop"}\n' >"${work_dir}/.aidevops.json"
 
 	local gh_head="" gh_base="" gh_repo="" gh_label=""
 	local gh_called=0
@@ -1900,6 +1901,13 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 	else
 		print_result "_attempt_orphan_recovery_pr passes --label origin:worker-takeover" 1 \
 			"Expected --label=origin:worker-takeover, got '${gh_label}'"
+	fi
+
+	if [[ "$gh_base" == "develop" ]]; then
+		print_result "_attempt_orphan_recovery_pr uses configured PR base" 0
+	else
+		print_result "_attempt_orphan_recovery_pr uses configured PR base" 1 \
+			"Expected --base=develop, got '${gh_base}'"
 	fi
 
 	return 0
@@ -1981,10 +1989,20 @@ test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan() {
 	_setup_test_git_repo "$work_dir" 1
 	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
+	AIDEVOPS_PR_BASE_BRANCH="develop"
 
 	# Stub gh: pr list returns 0, issue view = OPEN, pr create FAILS
+	local posted_body=""
 	gh() {
-		if [[ "${*}" == *"pr list"* ]]; then
+		if [[ "${1:-}" == "api" ]]; then
+			local arg=""
+			for arg in "$@"; do
+				if [[ "$arg" == body=* ]]; then
+					posted_body="${arg#body=}"
+				fi
+			done
+			return 0
+		elif [[ "${*}" == *"pr list"* ]]; then
 			printf '0'
 			return 0
 		elif [[ "${*}" == *"issue view"* ]]; then
@@ -2009,6 +2027,7 @@ test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan() {
 	_cmd_run_finish "issue-99999" "complete" "$work_dir"
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset AIDEVOPS_PR_BASE_BRANCH 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 
 	if [[ "$released_reason" == "worker_branch_orphan" ]]; then
@@ -2016,6 +2035,13 @@ test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan() {
 	else
 		print_result "_cmd_run_finish emits worker_branch_orphan when PR creation fails" 1 \
 			"Expected worker_branch_orphan (PR create failed), got '${released_reason}'"
+	fi
+
+	if [[ "$posted_body" == *"gh pr create --head feature/auto-test-issue-99999 --base develop --repo test-owner/test-repo"* ]]; then
+		print_result "worker_branch_orphan comment uses configured PR base" 0
+	else
+		print_result "worker_branch_orphan comment uses configured PR base" 1 \
+			"Expected orphan recovery comment with --base develop, got '${posted_body}'"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
+++ b/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
@@ -43,8 +43,12 @@ setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/posts"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export AIDEVOPS_REPOS_JSON="${TEST_ROOT}/repos.json"
 	export WORKER_BRANCH_ORPHAN_LOOP_THRESHOLD=2
 	export WORKER_BRANCH_ORPHAN_LOOP_WINDOW_S=7200
+	cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
+{"initialized_repos":[{"slug":"owner/develop-repo","pr_base_branch":"develop"}]}
+EOF
 	create_gh_stub
 	return 0
 }
@@ -83,6 +87,15 @@ EOF
 ]
 EOF
 
+	cat >"${TEST_ROOT}/comments-300.json" <<EOF
+[
+  [
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-300 ts=${now_iso}\n<!-- ops:end -->"},
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-300 ts=${now_iso}\n<!-- ops:end -->"}
+  ]
+]
+EOF
+
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -110,7 +123,15 @@ if [[ "${1:-}" == "api" ]]; then
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	if [[ "$*" == *"owner/develop-repo"* ]]; then
+		exit 0
+	fi
 	printf '#123 (OPEN) https://example.invalid/pr/123\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+	printf 'main\n'
 	exit 0
 fi
 
@@ -162,12 +183,27 @@ test_unrelated_failure_class_does_not_block() {
 	return 0
 }
 
+test_orphan_loop_next_action_uses_configured_base() {
+	local output=""
+	if output=$(TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 300 owner/develop-repo feature/reused 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_LOOP_BLOCKED"* ]] && grep -q -- "gh pr create --repo owner/develop-repo --head feature/reused --base develop" "${TEST_ROOT}/posts/300.argv"; then
+			print_result "orphan-loop diagnostic uses configured PR base" 0
+			return 0
+		fi
+		print_result "orphan-loop diagnostic uses configured PR base" 1 "Output/post missing develop base: ${output}"
+		return 0
+	fi
+	print_result "orphan-loop diagnostic uses configured PR base" 1 "Expected dispatch hold"
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_same_issue_branch_blocks_and_posts_diagnostic
 	test_different_branch_does_not_block
 	test_different_issue_does_not_block
 	test_unrelated_failure_class_does_not_block
+	test_orphan_loop_next_action_uses_configured_base
 	teardown_test_env
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary
- Resolve orphan-recovery PR bases from configured PR target branches before falling back to GitHub default branches.
- Use the same base branch in worker_branch_orphan recovery comments and repeated orphan-loop next actions.
- Document `pr_base_branch` and add develop-based regression coverage.

## Testing
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-worker-branch-orphan-loop.sh`
- `shellcheck .agents/scripts/shared-claim-lifecycle.sh .agents/scripts/headless-runtime-worker.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh .agents/scripts/tests/test-worker-branch-orphan-loop.sh`

Ref #80

Original tracked issue: marcusquinn/aidevops.sh#80

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 11m and 149,796 tokens on this as a headless worker.
