### PR TITLE
fix: allow orphan recovery diagnostic command

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -997,7 +997,7 @@ check_worker_branch_orphan_loop() {
 	pr_line=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state all \
 		--json number,state,url --jq '.[0] | select(.number != null) | "#\(.number) (\(.state)) \(.url)"' 2>/dev/null || true)
 	[[ -n "$pr_line" ]] && pr_hint="$pr_line"
-	local next_action="Open recovery PR: \`gh pr create --repo ${repo_slug} --head ${branch_name} --base ${pr_base_branch}\`"
+	local next_action="Open recovery PR: \`gh pr create --repo ${repo_slug} --head ${branch_name} --base ${pr_base_branch}\`" # aidevops-allow: raw-gh-wrapper
 	if [[ "$pr_hint" != "none found" ]]; then
 		next_action="Link, review, or merge the existing PR for this branch."
 	fi


### PR DESCRIPTION
## Summary
- Add the GH Wrapper Guard allow marker to the orphan-loop diagnostic recovery command string.
- This is emitted guidance inside a comment, not an executed raw GitHub write.

## Testing
- `bash .agents/scripts/tests/test-worker-branch-orphan-loop.sh`
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-worker-branch-orphan-loop.sh`
- `bash .agents/scripts/gh-wrapper-guard.sh check --base origin/main`

Ref #80

Follow-up to #24799 for original tracked issue marcusquinn/aidevops.sh#80.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 19m and 219,615 tokens on this as a headless worker.
