### PR TITLE
GH#24797: fix: make gh wrappers safe from zsh

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -187,8 +187,7 @@ _gh_ci_prepare_status_label() {
 }
 
 gh_create_issue() {
-	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
+	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_create_issue 2>/dev/null || true
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
@@ -504,8 +503,7 @@ _gh_create_pr_should_default_draft() {
 }
 
 gh_create_pr() {
-	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
+	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_create_pr 2>/dev/null || true
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
@@ -589,8 +587,7 @@ _gh_recover_pr_if_exists() {
 # <!-- aidevops:sig --> marker, so callers that build their own footer
 # are not double-signed.
 gh_issue_comment() {
-	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
+	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_issue_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
@@ -605,8 +602,7 @@ gh_issue_comment() {
 }
 
 gh_pr_comment() {
-	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
+	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_pr_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -50,6 +50,69 @@ if ! command -v print_warning >/dev/null 2>&1; then
 	print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
 fi
 
+# Standalone-source cleanup compatibility.
+# shared-constants.sh provides the canonical cleanup stack before sourcing this
+# file in normal bash helper execution. OpenCode zsh recovery commands can
+# source shared-gh-wrappers.sh directly, so provide minimal fallbacks and avoid
+# bash-only `trap ... RETURN` under zsh.
+if ! command -v push_cleanup >/dev/null 2>&1; then
+	_CLEANUP_CMDS=""
+	_CLEANUP_SAVE_STACK=""
+	push_cleanup() {
+		local cmd="$1"
+		if [[ -n "$_CLEANUP_CMDS" ]]; then
+			_CLEANUP_CMDS="${_CLEANUP_CMDS}"$'\n'"${cmd}"
+		else
+			_CLEANUP_CMDS="${cmd}"
+		fi
+		return 0
+	}
+fi
+if ! command -v _run_cleanups >/dev/null 2>&1; then
+	_run_cleanups() {
+		if [[ -n "$_CLEANUP_CMDS" ]]; then
+			local reversed=""
+			local line
+			while IFS= read -r line; do
+				[[ -z "$line" ]] && continue
+				if [[ -n "$reversed" ]]; then
+					reversed="${line}"$'\n'"${reversed}"
+				else
+					reversed="$line"
+				fi
+			done <<<"$_CLEANUP_CMDS"
+			while IFS= read -r line; do
+				[[ -z "$line" ]] && continue
+				bash -c "$line" 2>/dev/null || true
+			done <<<"$reversed"
+		fi
+		local sep=$'\x1F'
+		if [[ -n "$_CLEANUP_SAVE_STACK" ]]; then
+			_CLEANUP_CMDS="${_CLEANUP_SAVE_STACK%%"${sep}"*}"
+			_CLEANUP_SAVE_STACK="${_CLEANUP_SAVE_STACK#*"${sep}"}"
+		else
+			_CLEANUP_CMDS=""
+		fi
+		return 0
+	}
+fi
+if ! command -v _save_cleanup_scope >/dev/null 2>&1; then
+	_save_cleanup_scope() {
+		local sep=$'\x1F'
+		_CLEANUP_SAVE_STACK="${_CLEANUP_CMDS}${sep}${_CLEANUP_SAVE_STACK}"
+		_CLEANUP_CMDS=""
+		return 0
+	}
+fi
+
+_gh_wrapper_enter_cleanup_scope() {
+	_save_cleanup_scope
+	if [[ -n "${BASH_VERSION:-}" ]]; then
+		trap '_run_cleanups' RETURN
+	fi
+	return 0
+}
+
 # t3461: optional user-owned GitHub App auth and route decisions. Source this
 # before the REST translators so _rest_api_call can use installation tokens for
 # REST core/search pools while native gh/PAT remains the fallback path.

--- a/.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh
@@ -31,6 +31,7 @@
 #   6. zsh:  standalone source emits no 'command not found' stderr (skip if no zsh)
 #   7. zsh:  print_info + print_warning defined after standalone sourcing (skip if no zsh)
 #   8. zsh:  all major wrapper functions defined after standalone sourcing (skip if no zsh)
+#   9. zsh:  gh_create_pr --help emits no cleanup/trap errors (skip if no zsh)
 
 set -uo pipefail
 
@@ -252,6 +253,20 @@ fi
 	else
 		fail "8: zsh: all major wrapper functions defined after standalone sourcing" \
 			"output: $(printf '%q' "$zsh_wrappers")"
+	fi
+
+	# Test 9: zsh — gh_create_pr --help should exercise the wrapper entry path
+	# without bash-only cleanup helper or RETURN trap errors.
+	zsh_help_output=$(zsh -c "
+source '${WRAPPERS_FILE}'
+gh(){ printf 'gh-called:%s\\n' \"\$*\"; return 0; }
+gh_create_pr --help
+" 2>&1)
+	if [[ "$zsh_help_output" == *"_save_cleanup_scope"* ]] || [[ "$zsh_help_output" == *"undefined signal: RETURN"* ]]; then
+		fail "9: zsh: gh_create_pr --help emits no cleanup/trap errors" \
+			"output: $(printf '%q' "$zsh_help_output")"
+	else
+		pass "9: zsh: gh_create_pr --help emits no cleanup/trap errors"
 	fi
 fi
 


### PR DESCRIPTION
## Summary

Added standalone cleanup fallbacks, routed create/comment wrappers through a zsh-safe cleanup entry helper, and added a zsh gh_create_pr --help regression smoke test.

## Files Changed

.agents/scripts/shared-gh-wrappers-create.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/tests/test-shared-gh-wrappers-standalone.sh; zsh smoke for gh_create_pr --help with a gh stub; all .agents/scripts/tests/test-gh-wrapper-*.sh and test-shared-gh-wrappers-*.sh; .agents/scripts/linters-local.sh.

Resolves #24797


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 7m and 123,302 tokens on this as a headless worker.