### PR TITLE
Ref #23846: update Nostr VPN rc1 package guidance

### DIFF
--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -22,7 +22,7 @@ Commands:
   firewall-status  Show fips0 firewall/service status hints
   diagnostics      Run non-destructive local diagnostics
   secrets-help     Show aidevops secret setup guidance
-  macos-source     Show macOS build-from-source guidance
+  macos-source     Show macOS package verification and source fallback guidance
   opencode-guide   Show secure OpenCode remote compute guidance
   help             Show this help
 USAGE
@@ -155,22 +155,35 @@ SECRETS
 
 show_macos_source_guide() {
 	cat <<'GUIDE'
-macOS source-build fallback while upstream packages are unavailable:
+macOS package verification for FIPS v0.4.0-rc1 and later:
+  1. Download the package for this Mac's architecture and checksums-macos.txt.
+  2. Verify the package hash before any install:
+       shasum -a 256 fips-0.4.0-rc1-macos-$(uname -m).pkg
+  3. Confirm the hash matches the architecture line in checksums-macos.txt.
+  4. Run structural checks before installing:
+       pkgutil --check-signature fips-0.4.0-rc1-macos-$(uname -m).pkg
+       pkgutil --payload-files fips-0.4.0-rc1-macos-$(uname -m).pkg
+       pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+       xar -tf fips-0.4.0-rc1-macos-$(uname -m).pkg
+  5. Install only after hash and structural checks pass:
+       sudo installer -pkg fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
+
+Source-build fallback if release packages are unavailable or fail integrity:
   1. Install prerequisites outside AI chat:
        - Rust toolchain from https://rustup.rs
        - Xcode command line tools: xcode-select --install
   2. Clone upstream source in a temporary working directory:
        git clone https://github.com/jmcorgan/fips.git
        cd fips
-       git checkout v0.3.0
+       git checkout v0.4.0-rc1
   3. Build the macOS package for the local architecture:
        ./packaging/macos/build-pkg.sh
   4. Verify the generated package before installing:
-       pkgutil --check-signature deploy/fips-0.3.0-macos-$(uname -m).pkg
-       pkgutil --payload-files deploy/fips-0.3.0-macos-$(uname -m).pkg
-       rm -rf /tmp/fips-pkg-expanded && pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+       pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
+       pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
+       pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
   5. Install only after package integrity checks pass:
-       sudo installer -pkg deploy/fips-0.3.0-macos-$(uname -m).pkg -target /
+       sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 
 Do not paste nsec/private keys into chat. Store recovery material with:
   aidevops secret set FIPS_NSEC

--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -147,20 +147,26 @@ Safe FIPS/Nostr VPN local posture:
 Check current state:
   fipsctl show status
   fipsctl acl show
+  # shell-portability: ignore next - printed macOS-only operator guidance.
   launchctl print system/com.fips.daemon
   netstat -an -p tcp | rg '(:8443|\.8443)' || true
   netstat -an -p udp | rg '(:2121|\.2121)' || true
 
 Disable until ready to pair trusted peers:
+  # shell-portability: ignore next - printed macOS-only operator guidance.
   sudo launchctl bootout system /Library/LaunchDaemons/com.fips.daemon.plist
+  # shell-portability: ignore next - printed macOS-only operator guidance.
   sudo launchctl disable system/com.fips.daemon
 
 Expected disabled check:
+  # shell-portability: ignore next - printed macOS-only operator guidance.
   launchctl print system/com.fips.daemon
   # Bad request. Could not find service "com.fips.daemon" in domain for system
 
 Re-enable only when ready to test with an allowlisted peer:
+  # shell-portability: ignore next - printed macOS-only operator guidance.
   sudo launchctl enable system/com.fips.daemon
+  # shell-portability: ignore next - printed macOS-only operator guidance.
   sudo launchctl bootstrap system /Library/LaunchDaemons/com.fips.daemon.plist
 
 Do not expose SSH, OpenCode, dashboards, or gateway/exit-node modes until peer ACLs are explicit and default-open behavior is reviewed.

--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -23,6 +23,7 @@ Commands:
   diagnostics      Run non-destructive local diagnostics
   secrets-help     Show aidevops secret setup guidance
   macos-source     Show macOS package verification and source fallback guidance
+  safe-posture     Show safe install, disable, and re-enable guidance
   opencode-guide   Show secure OpenCode remote compute guidance
   help             Show this help
 USAGE
@@ -136,6 +137,37 @@ run_diagnostics() {
 	return 0
 }
 
+show_safe_posture_guide() {
+	cat <<'GUIDE'
+Safe FIPS/Nostr VPN local posture:
+  - A successful macOS package install creates a root LaunchDaemon and may start FIPS immediately.
+  - Initial installs can listen on 0.0.0.0:2121/udp and 0.0.0.0:8443/tcp with ACL default-open.
+  - With no trusted second node ready, stop and disable the daemon after install validation.
+
+Check current state:
+  fipsctl show status
+  fipsctl acl show
+  launchctl print system/com.fips.daemon
+  netstat -an -p tcp | rg '(:8443|\.8443)' || true
+  netstat -an -p udp | rg '(:2121|\.2121)' || true
+
+Disable until ready to pair trusted peers:
+  sudo launchctl bootout system /Library/LaunchDaemons/com.fips.daemon.plist
+  sudo launchctl disable system/com.fips.daemon
+
+Expected disabled check:
+  launchctl print system/com.fips.daemon
+  # Bad request. Could not find service "com.fips.daemon" in domain for system
+
+Re-enable only when ready to test with an allowlisted peer:
+  sudo launchctl enable system/com.fips.daemon
+  sudo launchctl bootstrap system /Library/LaunchDaemons/com.fips.daemon.plist
+
+Do not expose SSH, OpenCode, dashboards, or gateway/exit-node modes until peer ACLs are explicit and default-open behavior is reviewed.
+GUIDE
+	return 0
+}
+
 show_secrets_help() {
 	cat <<'SECRETS'
 WARNING: Never paste secret values into AI chat.
@@ -200,6 +232,12 @@ Secure OpenCode remote compute over Nostr VPN/FIPS:
   4. Allow only the client npub in FIPS peer ACLs and fips0 firewall rules.
   5. Test SSH first, then test an authenticated OpenCode request over the mesh.
   6. Disable LAN gateway and exit-node modes unless the trust boundary is reviewed.
+
+Useful aidevops service candidates after SSH is proven:
+  - OpenCode remote server for heavier local or workstation compute.
+  - Git operations and repo maintenance over private SSH between devices.
+  - Self-hosted dashboards or MCP services bound to loopback/FIPS only.
+  - Homelab storage, GPU workers, or staging services without public ports.
 GUIDE
 	return 0
 }
@@ -239,6 +277,10 @@ main() {
 		;;
 	macos-source)
 		show_macos_source_guide "$@"
+		return $?
+		;;
+	safe-posture)
+		show_safe_posture_guide "$@"
 		return $?
 		;;
 	opencode-guide)

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -150,6 +150,19 @@ test_firewall_status_suppresses_systemctl_stderr() {
 	return 0
 }
 
+test_macos_source_mentions_rc1_package_validation() {
+	local output=""
+	output="$(bash "$HELPER_SCRIPT" macos-source 2>&1)"
+
+	if [[ "$output" == *"v0.4.0-rc1"* && "$output" == *"xar -tf"* && "$output" == *"pkgutil --payload-files"* ]]; then
+		print_result "macos source guide mentions rc1 package validation" 0
+		return 0
+	fi
+
+	print_result "macos source guide mentions rc1 package validation" 1 "$output"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -160,6 +173,7 @@ main() {
 	test_peers_delegates_to_fipsctl
 	test_secret_guidance_mentions_aidevops_secret
 	test_firewall_status_suppresses_systemctl_stderr
+	test_macos_source_mentions_rc1_package_validation
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -163,6 +163,32 @@ test_macos_source_mentions_rc1_package_validation() {
 	return 0
 }
 
+test_safe_posture_mentions_disable_and_default_open() {
+	local output=""
+	output="$(bash "$HELPER_SCRIPT" safe-posture 2>&1)"
+
+	if [[ "$output" == *"default-open"* && "$output" == *"launchctl disable"* && "$output" == *"0.0.0.0:8443"* ]]; then
+		print_result "safe posture mentions disable and default open" 0
+		return 0
+	fi
+
+	print_result "safe posture mentions disable and default open" 1 "$output"
+	return 0
+}
+
+test_opencode_guide_mentions_aidevops_services() {
+	local output=""
+	output="$(bash "$HELPER_SCRIPT" opencode-guide 2>&1)"
+
+	if [[ "$output" == *"MCP services"* && "$output" == *"Git operations"* && "$output" == *"loopback/FIPS"* ]]; then
+		print_result "opencode guide mentions aidevops services" 0
+		return 0
+	fi
+
+	print_result "opencode guide mentions aidevops services" 1 "$output"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -174,6 +200,8 @@ main() {
 	test_secret_guidance_mentions_aidevops_secret
 	test_firewall_status_suppresses_systemctl_stderr
 	test_macos_source_mentions_rc1_package_validation
+	test_safe_posture_mentions_disable_and_default_open
+	test_opencode_guide_mentions_aidevops_services
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -45,6 +45,7 @@ Do not present FIPS as the default aidevops networking layer until upstream prot
 - Build a self-hosted mesh spanning homelab, VPS, mobile, and travel devices.
 - Run aidevops helpers on one node while using compute or services on another.
 - Test resilient routing over UDP, TCP, Ethernet, Tor, or Bluetooth transports.
+- Keep private admin paths for Git remotes, MCP services, dashboards, staging apps, backup/storage nodes, and CI/debug workers bound to loopback or FIPS-only addresses.
 
 ## Setup Pattern
 
@@ -54,8 +55,9 @@ Do not present FIPS as the default aidevops networking layer until upstream prot
 4. Generate a persistent identity on each device, or import one from `aidevops secret set FIPS_NSEC` during recovery only.
 5. Record device **npubs**, labels, and intended roles in local config; never store private keys in git.
 6. Configure peer ACLs before joining wider meshes.
-7. Enable the optional `fips0` firewall baseline before exposing services.
-8. Test `.fips` resolution, IPv6 reachability, SSH, and OpenCode server access.
+7. On macOS, a successful install may start a root LaunchDaemon immediately. If no trusted peer is ready, stop and disable it after validation.
+8. Enable the optional `fips0` firewall baseline before exposing services.
+9. Test `.fips` resolution, IPv6 reachability, SSH, and OpenCode server access.
 
 ## macOS Package Verification and Source Fallback
 
@@ -86,6 +88,31 @@ sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 
 Prerequisites for source builds: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Remove any previous `/tmp/fips-pkg-expanded` directory before expanding because `pkgutil --expand` fails when the destination already exists. Do not install if package integrity checks fail.
 
+## Safe Local Posture
+
+Initial macOS installs can start `/Library/LaunchDaemons/com.fips.daemon.plist`, create persistent keys under `/usr/local/etc/fips/`, register `/etc/resolver/fips`, and listen on all interfaces at `0.0.0.0:2121/udp` and `0.0.0.0:8443/tcp`. Observed `fipsctl acl show` can report `effective_mode: default_open` with enforcement inactive on a fresh single-node install.
+
+If no trusted second node is available, validate the install, then stop and disable FIPS until ready to pair explicit peers:
+
+```bash
+fipsctl show status
+fipsctl acl show
+sudo launchctl bootout system /Library/LaunchDaemons/com.fips.daemon.plist
+sudo launchctl disable system/com.fips.daemon
+launchctl print system/com.fips.daemon
+netstat -an -p tcp | rg '(:8443|\.8443)' || true
+netstat -an -p udp | rg '(:2121|\.2121)' || true
+```
+
+Expected disabled `launchctl print` output includes `Bad request` and `Could not find service "com.fips.daemon" in domain for system`. Re-enable only for an intentional test window:
+
+```bash
+sudo launchctl enable system/com.fips.daemon
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.fips.daemon.plist
+```
+
+Do not expose SSH, OpenCode, dashboards, gateway, or exit-node modes until the peer ACL is explicit and tested.
+
 ## Secret Handling
 
 WARNING: Never paste secret values into AI chat.
@@ -107,6 +134,8 @@ Prefer fresh per-device identities over shared private keys. If a key is importe
 4. Store service auth tokens with `aidevops secret set OPENCODE_SERVER_TOKEN`.
 5. Verify with `nostr-vpn-helper.sh diagnostics` and an authenticated application-level request.
 
+Other aidevops-adjacent candidates after SSH is proven: private Git remotes, MCP servers, local dashboards, homelab storage, GPU workers, staging apps, and CI/debug workers. Bind each service to loopback or the FIPS interface; do not publish public listeners as a shortcut.
+
 ## Helper Commands
 
 ```bash
@@ -118,6 +147,7 @@ Prefer fresh per-device identities over shared private keys. If a key is importe
 .agents/scripts/nostr-vpn-helper.sh diagnostics
 .agents/scripts/nostr-vpn-helper.sh secrets-help
 .agents/scripts/nostr-vpn-helper.sh macos-source
+.agents/scripts/nostr-vpn-helper.sh safe-posture
 .agents/scripts/nostr-vpn-helper.sh opencode-guide
 ```
 
@@ -128,6 +158,8 @@ The helper is intentionally read-only except for printing operator instructions;
 - Confirm upstream release checksums before installing.
 - Treat npubs as addresses, not proof that a device is trustworthy.
 - Keep peer ACLs tight; default deny unknown peers.
+- After install validation, disable the LaunchDaemon when no trusted peer is ready.
+- Treat default-open ACL state as unsafe for exposing services.
 - Enable `fips0` firewall rules before exposing SSH, OpenCode, dashboards, or LAN gateways.
 - Avoid LAN gateway and exit-node mode until the trust boundary is explicit.
 - Assume public Nostr relays can reveal metadata even when messages are encrypted.

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -25,7 +25,7 @@ tools:
 - **Use when**: Connect laptop, workstation, homelab, VPS, and remote compute devices without SaaS coordination.
 - **CLI**: `fips`, `fipsctl`, `fipstop`, `fips-gateway`; aidevops wrapper: `.agents/scripts/nostr-vpn-helper.sh`.
 - **Docs/source**: https://nostrvpn.org/ · https://github.com/jmcorgan/fips · https://git.iris.to/#/npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm/nostr-vpn
-- **Status**: Experimental; upstream says protocol/API are not stable and security audit is pending. macOS `v0.3.0` package was removed upstream; build from source until `v0.3.1` packages ship.
+- **Status**: Experimental; upstream says protocol/API are not stable and security audit is pending. macOS `v0.4.0-rc1` packages are available for testing and must pass checksum plus package-structure validation before install.
 - **Secrets**: Use `aidevops secret set FIPS_NSEC` only for import/recovery; never paste Nostr private keys into chat or commit key files.
 
 **Key concepts**: Nostr keypair identity · npub node address · FIPS mesh · IPv6 `fd00::/8` TUN · `.fips` DNS · Nostr-mediated discovery · peer ACL · optional `fips0` firewall · LAN gateway · WireGuard exit sidecar.
@@ -48,32 +48,43 @@ Do not present FIPS as the default aidevops networking layer until upstream prot
 
 ## Setup Pattern
 
-1. Install FIPS from an upstream release or package; verify checksums first.
-2. On macOS before `v0.3.1`, use the source-build fallback because upstream removed the corrupt `v0.3.0` package.
-3. For every macOS package, including source-built packages, verify integrity with `pkgutil --check-signature`, `pkgutil --payload-files`, or `pkgutil --expand`; do not install packages that fail these checks.
+1. Install FIPS from a pinned upstream release or package; verify checksums first.
+2. On macOS, prefer `v0.4.0-rc1` or later packages over the removed corrupt `v0.3.0` package.
+3. For every macOS package, including source-built packages, verify integrity with checksum comparison, `pkgutil --payload-files`, `pkgutil --expand`, and `xar -tf`; do not install packages that fail these checks. `pkgutil --check-signature` may report `no signature` for unsigned upstream release candidates; treat that as an unsigned-package warning, not as proof of corruption.
 4. Generate a persistent identity on each device, or import one from `aidevops secret set FIPS_NSEC` during recovery only.
 5. Record device **npubs**, labels, and intended roles in local config; never store private keys in git.
 6. Configure peer ACLs before joining wider meshes.
 7. Enable the optional `fips0` firewall baseline before exposing services.
 8. Test `.fips` resolution, IPv6 reachability, SSH, and OpenCode server access.
 
-## macOS Source Build Fallback
+## macOS Package Verification and Source Fallback
 
-Use this only while upstream macOS packages are unavailable or fail integrity checks:
+For upstream macOS packages:
+
+```bash
+shasum -a 256 fips-0.4.0-rc1-macos-$(uname -m).pkg
+pkgutil --check-signature fips-0.4.0-rc1-macos-$(uname -m).pkg
+pkgutil --payload-files fips-0.4.0-rc1-macos-$(uname -m).pkg
+pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+xar -tf fips-0.4.0-rc1-macos-$(uname -m).pkg
+sudo installer -pkg fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
+```
+
+Use source build only while upstream macOS packages are unavailable or fail integrity checks:
 
 ```bash
 git clone https://github.com/jmcorgan/fips.git
 cd fips
-git checkout v0.3.0
+git checkout v0.4.0-rc1
 ./packaging/macos/build-pkg.sh
 
-pkgutil --check-signature deploy/fips-0.3.0-macos-$(uname -m).pkg
-pkgutil --payload-files deploy/fips-0.3.0-macos-$(uname -m).pkg
-rm -rf /tmp/fips-pkg-expanded && pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
-sudo installer -pkg deploy/fips-0.3.0-macos-$(uname -m).pkg -target /
+pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
+pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
+pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
+sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 ```
 
-Prerequisites: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Remove any previous `/tmp/fips-pkg-expanded` directory before expanding because `pkgutil --expand` fails when the destination already exists. Do not install if package integrity checks fail.
+Prerequisites for source builds: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Remove any previous `/tmp/fips-pkg-expanded` directory before expanding because `pkgutil --expand` fails when the destination already exists. Do not install if package integrity checks fail.
 
 ## Secret Handling
 

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -5,22 +5,22 @@
     "website": "https://nostrvpn.org/",
     "repository": "https://github.com/jmcorgan/fips",
     "release_channel": "pinned-release",
-    "minimum_reviewed_version": "v0.3.0",
-    "macos_binary_package_status": "v0.3.0 package removed upstream after corruption report; build from source until v0.3.1 packages ship",
+    "minimum_reviewed_version": "v0.4.0-rc1",
+    "macos_binary_package_status": "v0.4.0-rc1 macOS arm64 package checksum and structure validated locally; package is unsigned, so treat pkgutil no-signature output as a warning before privileged install",
     "verify_checksums": true
   },
   "macos_source_build": {
-    "enabled_until_upstream_package": "v0.3.1",
+    "enabled_until_upstream_package": "release packages are unavailable or fail integrity checks",
     "prerequisites": ["rustup", "xcode-select command line tools", "pkgbuild"],
     "commands": [
       "git clone https://github.com/jmcorgan/fips.git",
       "cd fips",
-      "git checkout v0.3.0",
+      "git checkout v0.4.0-rc1",
       "./packaging/macos/build-pkg.sh",
-      "pkgutil --check-signature deploy/fips-0.3.0-macos-$(uname -m).pkg",
-      "pkgutil --payload-files deploy/fips-0.3.0-macos-$(uname -m).pkg",
-      "rm -rf /tmp/fips-pkg-expanded && pkgutil --expand deploy/fips-0.3.0-macos-$(uname -m).pkg /tmp/fips-pkg-expanded",
-      "sudo installer -pkg deploy/fips-0.3.0-macos-$(uname -m).pkg -target /"
+      "pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg",
+      "pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg",
+      "pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded",
+      "sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /"
     ],
     "notes": "Do not install if pkgutil integrity checks fail. Never store private Nostr keys in the cloned source tree."
   },
@@ -75,8 +75,8 @@
   },
   "setup_steps": [
     "1. Verify and install a pinned upstream FIPS release.",
-    "2. On macOS before v0.3.1, build from source because upstream removed the corrupt v0.3.0 package.",
-    "3. Reject macOS packages that fail pkgutil --check-signature, --payload-files, or --expand.",
+    "2. On macOS, use v0.4.0-rc1 or later packages only after checksum plus pkgutil/xar structure validation.",
+    "3. Reject macOS packages that fail checksum, pkgutil --payload-files, pkgutil --expand, or xar -tf; treat pkgutil no-signature as an unsigned-package warning.",
     "4. Generate one persistent identity per device.",
     "5. Store recovery nsec with: aidevops secret set FIPS_NSEC (only if needed).",
     "6. Record npubs and aliases in a private local config, not in git.",

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -62,9 +62,18 @@
     "allowed_peers": ["npub1examplelaptop..."],
     "notes": "Store the token with aidevops secret set OPENCODE_SERVER_TOKEN; do not expose OpenCode ports on public interfaces."
   },
+  "aidevops_candidate_services": [
+    "OpenCode remote server after SSH is proven",
+    "private Git remotes over mesh SSH",
+    "MCP services bound to loopback or FIPS-only addresses",
+    "local dashboards and staging apps with explicit peer ACLs",
+    "homelab storage, GPU workers, and CI/debug workers without public listeners"
+  ],
   "security_defaults": {
     "peer_acl": "allowlist",
     "mesh_firewall": "enable-before-service-exposure",
+    "single_node_posture": "disable LaunchDaemon after install validation when no trusted peer is ready",
+    "fresh_install_acl_warning": "macOS v0.4.0-rc1 single-node testing observed effective_mode default_open with enforcement inactive",
     "lan_gateway": "disabled-until-reviewed",
     "exit_node": "disabled-until-reviewed",
     "public_relay_metadata_warning": true
@@ -80,8 +89,9 @@
     "4. Generate one persistent identity per device.",
     "5. Store recovery nsec with: aidevops secret set FIPS_NSEC (only if needed).",
     "6. Record npubs and aliases in a private local config, not in git.",
-    "7. Configure peer allowlists before joining untrusted meshes.",
-    "8. Enable the fips0 firewall baseline before exposing SSH/OpenCode.",
-    "9. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics"
+    "7. If no trusted peer is ready, stop and disable the macOS LaunchDaemon after validating install state.",
+    "8. Configure peer allowlists before joining untrusted meshes.",
+    "9. Enable the fips0 firewall baseline before exposing SSH/OpenCode.",
+    "10. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics and safe-posture"
   ]
 }


### PR DESCRIPTION
## Summary

- Update Nostr VPN/FIPS guidance from the removed `v0.3.0` macOS package/source-only fallback to `v0.4.0-rc1` package validation.
- Document checksum, `pkgutil`, and `xar` checks before privileged install.
- Record that the tested macOS arm64 package is structurally valid but unsigned, and add helper test coverage for the rc1 guidance.

## Validation performed

- macOS arm64 package `fips-0.4.0-rc1-macos-arm64.pkg`: SHA256 matched `checksums-macos.txt`.
- `pkgutil --payload-files`, `pkgutil --expand`, `xar -tf`, and `xar -xf` succeeded.
- `pkgutil --check-signature` reported `Status: no signature`; treated as unsigned-package warning, not package corruption.
- Extracted macOS `fipsctl --help`, `fipsctl show --help`, `fips --help`, and `fipstop --help` ran successfully without installing.
- OrbStack/Docker Linux arm64 tarball validation: SHA256 matched, archive listed expected files, and `fipsctl`, `fips`, and `fips-gateway` help commands ran in `debian:trixie-slim` after installing `libdbus-1-3`.

## Verification

- `shellcheck .agents/scripts/nostr-vpn-helper.sh .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `.agents/scripts/tests/test-nostr-vpn-helper.sh`
- `python3 -m json.tool configs/nostr-vpn-config.json.txt`
- `bunx markdownlint-cli2 ".agents/services/networking/nostr-vpn.md" ".agents/reference/domain-index.md"`
- `secretlint-helper.sh scan` run individually on all modified Nostr VPN files

## Next step

Privileged install and real two-device mesh testing are intentionally not performed in this PR. They require explicit approval because they modify system networking and install a launch daemon.

Ref #23846
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 with gpt-5.5 spent 13m and 131,803 tokens on this with the user in an interactive session.