### PR TITLE
GH#24802: fix: allow linked worktree gh body files

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -45,7 +45,7 @@
 
 import { existsSync, readFileSync, appendFileSync, realpathSync } from "fs";
 import { execFileSync } from "child_process";
-import { join, sep } from "path";
+import { isAbsolute, join, resolve, sep } from "path";
 import { tmpdir } from "os";
 
 import { FAIL_REASON, formatGateThrowMessage } from "./quality-hooks-signature-failures.mjs";
@@ -291,12 +291,51 @@ function _isPathWithin(childPath, parentPath) {
  * @param {string} filePath
  * @returns {{ status: "ok", filePath: string } | { status: "fail", reason: string, detail: string }}
  */
-function _resolveAllowedBodyFilePath(filePath) {
-  const realFilePath = realpathSync(filePath);
-  const allowedRoots = [process.cwd(), tmpdir()]
+function _safeRealpath(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return "";
+  }
+}
+
+function _gitValue(args) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf-8",
+      timeout: 1000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function _gitCommonDir(path) {
+  const topLevel = _gitValue(["-C", path, "rev-parse", "--show-toplevel"]);
+  if (!topLevel) return "";
+  const commonDir = _gitValue(["-C", topLevel, "rev-parse", "--git-common-dir"]);
+  if (!commonDir) return "";
+  return _safeRealpath(isAbsolute(commonDir) ? commonDir : resolve(topLevel, commonDir));
+}
+
+function _sameGitRepository(pathA, pathB) {
+  const commonA = _gitCommonDir(pathA);
+  const commonB = _gitCommonDir(pathB);
+  return Boolean(commonA && commonB && commonA === commonB);
+}
+
+function _resolveAllowedBodyFilePath(filePath, commandWorkdir = process.cwd()) {
+  const realCommandWorkdir = _safeRealpath(commandWorkdir) || process.cwd();
+  const candidatePath = isAbsolute(filePath) ? filePath : resolve(realCommandWorkdir, filePath);
+  const realFilePath = realpathSync(candidatePath);
+  const allowedRoots = [realCommandWorkdir, process.cwd(), tmpdir()]
     .filter((root) => existsSync(root))
     .map((root) => realpathSync(root));
   if (allowedRoots.some((root) => _isPathWithin(realFilePath, root))) {
+    return { status: "ok", filePath: realFilePath };
+  }
+  if (_sameGitRepository(realFilePath, realCommandWorkdir)) {
     return { status: "ok", filePath: realFilePath };
   }
   return {
@@ -321,9 +360,9 @@ function _resolveAllowedBodyFilePath(filePath) {
  * @param {Function} log
  * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail: string }}
  */
-function _repairBodyFile(cmd, filePath, helperPath, log) {
+function _repairBodyFile(cmd, filePath, helperPath, log, commandWorkdir = process.cwd()) {
   try {
-    const resolved = _resolveAllowedBodyFilePath(filePath);
+    const resolved = _resolveAllowedBodyFilePath(filePath, commandWorkdir);
     if (resolved.status === "fail") {
       log("WARN", `Refusing --body-file outside allowed roots: ${resolved.detail}`);
       return resolved;
@@ -438,7 +477,7 @@ function _repairBodyArg(cmd, parsed, helperPath, log) {
  * @param {Function} log
  * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail?: string }}
  */
-export function tryRepairSignature(cmd, scriptsDir, log) {
+export function tryRepairSignature(cmd, scriptsDir, log, options = {}) {
   if (hasTrustedSignatureSignal(cmd) || isMachineProtocolCommand(cmd)) {
     log("INFO", "Command is exempt or already includes trusted signature signal; no repair needed");
     return { status: "ok", cmd };
@@ -456,7 +495,7 @@ export function tryRepairSignature(cmd, scriptsDir, log) {
   );
   if (bodyFileMatch) {
     const filePath = bodyFileMatch[2] || bodyFileMatch[4];
-    return _repairBodyFile(cmd, filePath, helperPath, log);
+    return _repairBodyFile(cmd, filePath, helperPath, log, options.commandWorkdir);
   }
 
   if (!existsSync(helperPath)) {
@@ -489,7 +528,8 @@ export function checkSignatureFooterGate(cmd, log, scriptsDir, output) {
   // without thinking about the footer. Mutate the command in place so the
   // user/session gets correct output without an error-retry cycle.
   if (scriptsDir && output && output.args) {
-    const result = tryRepairSignature(cmd, scriptsDir, log);
+    const commandWorkdir = output.args.workdir || output.args.cwd || process.cwd();
+    const result = tryRepairSignature(cmd, scriptsDir, log, { commandWorkdir });
     if (result.status === "ok") {
       if (result.cmd !== cmd) {
         output.args.command = result.cmd;

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -15,7 +15,8 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, chmodSync, symlinkSync, rmSync } from "fs";
+import { execFileSync } from "child_process";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, symlinkSync, rmSync, mkdirSync } from "fs";
 import { tmpdir, homedir } from "os";
 import { join } from "path";
 
@@ -298,6 +299,44 @@ describe("tryRepairSignature", () => {
       `sig should be appended to file: ${fileContent}`,
     );
     assert.ok(fileContent.includes("unsigned content"), "original preserved");
+  });
+
+  test("resolves relative --body-file from Bash tool workdir", () => {
+    const dir = setupStubHelper();
+    const workdir = join(dir, "linked-worktree-cwd");
+    mkdirSync(workdir);
+    const bodyFile = join(workdir, "relative-body.md");
+    writeFileSync(bodyFile, "relative unsigned content\n");
+    const { log } = makeLogger();
+    const cmd = "gh pr create --repo o/r --title test --body-file relative-body.md";
+    const out = tryRepairSignature(cmd, dir, log, { commandWorkdir: workdir });
+    assert.equal(out.status, "ok", "relative body-file should resolve from command workdir");
+    assert.ok(readFileSync(bodyFile, "utf-8").includes(SIG_MARKER));
+  });
+
+  test("allows absolute --body-file from a linked worktree for the same repo", () => {
+    const dir = setupStubHelper();
+    const repo = join(dir, "repo");
+    const linked = join(dir, "repo-linked");
+    mkdirSync(repo);
+    execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.invalid"], { cwd: repo });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: repo });
+    execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
+    writeFileSync(join(repo, "README.md"), "fixture\n");
+    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["commit", "--no-gpg-sign", "-m", "init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["worktree", "add", "-b", "linked-fixture", linked], {
+      cwd: repo,
+      stdio: "ignore",
+    });
+    const bodyFile = join(linked, "linked-body.md");
+    writeFileSync(bodyFile, "linked unsigned content\n");
+    const { log } = makeLogger();
+    const cmd = `gh pr create --repo o/r --title test --body-file ${bodyFile}`;
+    const out = tryRepairSignature(cmd, dir, log, { commandWorkdir: repo });
+    assert.equal(out.status, "ok", "same-repo linked worktree body-file should be allowed");
+    assert.ok(readFileSync(bodyFile, "utf-8").includes(SIG_MARKER));
   });
 
   test("uses cheap no-session helper path when repairing body-file", () => {

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -49,6 +49,21 @@ fi
 if ! command -v print_warning >/dev/null 2>&1; then
 	print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
 fi
+if ! command -v _save_cleanup_scope >/dev/null 2>&1; then
+	_save_cleanup_scope() { return 0; }
+fi
+if ! command -v _run_cleanups >/dev/null 2>&1; then
+	_run_cleanups() { return 0; }
+fi
+
+_gh_wrapper_enter_cleanup_scope() {
+	_save_cleanup_scope
+	if [[ -n "${ZSH_VERSION:-}" ]]; then
+		return 0
+	fi
+	trap '_run_cleanups' RETURN
+	return 0
+}
 
 # Standalone-source cleanup compatibility.
 # shared-constants.sh provides the canonical cleanup stack before sourcing this

--- a/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
@@ -290,6 +290,43 @@ else
 fi
 
 # =============================================================================
+# Test 9: OpenCode default shell shape — sourcing wrappers and calling gh_create_pr
+# under zsh must not emit cleanup/trap false-negative errors.
+# =============================================================================
+if ! command -v zsh >/dev/null 2>&1; then
+	skip "9: gh_create_pr sourced under zsh has quiet cleanup setup" "zsh not installed"
+else
+	ZSH_PR_CALLS="${TMP}/zsh_pr_calls.log"
+	: >"$ZSH_PR_CALLS"
+	zsh_pr_out=$(zsh -c "
+gh() {
+    printf '%s\n' \"\$*\" >>'${ZSH_PR_CALLS}'
+    if [[ \"\$1\" == 'pr' && \"\$2\" == 'create' ]]; then
+        printf 'https://github.com/owner/repo/pull/1\n'
+    fi
+    return 0
+}
+source '${WRAPPERS_FILE}'
+_ensure_origin_labels_for_args() { return 0; }
+_gh_validate_edit_args() { return 0; }
+_rest_should_fallback() { return 1; }
+session_origin_label() { printf 'origin:worker'; return 0; }
+detect_session_origin() { printf 'worker'; return 0; }
+_gh_wrapper_auto_sig() { _GH_WRAPPER_SIG_MODIFIED_ARGS=(\"\$@\"); return 0; }
+gh_create_pr --repo owner/repo --title 'zsh smoke' --body 'body'
+" 2>&1) || true
+	if [[ "$zsh_pr_out" == *"https://github.com/owner/repo/pull/1"* && \
+	      "$zsh_pr_out" != *"_save_cleanup_scope"* && \
+	      "$zsh_pr_out" != *"can't set signal handler for SIGRETURN"* && \
+	      "$zsh_pr_out" != *"trap: RETURN"* ]]; then
+		pass "9: gh_create_pr sourced under zsh has quiet cleanup setup"
+	else
+		fail "9: gh_create_pr sourced under zsh has quiet cleanup setup" \
+			"output: $(printf '%q' "$zsh_pr_out")"
+	fi
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n'


### PR DESCRIPTION
## Summary

Resolved OpenCode GitHub write ergonomics for reviewed body files: relative --body-file paths now resolve from the Bash tool workdir, absolute body files in same-repo linked worktrees are allowed, and gh_create_pr sourced from zsh/OpenCode no longer emits cleanup/trap false-negative errors.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs,.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-gh-wrapper-shell-compat.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; bash .agents/scripts/tests/test-gh-wrapper-shell-compat.sh; shellcheck .agents/scripts/shared-gh-wrappers.sh .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-gh-wrapper-shell-compat.sh. Note: full-loop project validator npm run typecheck failed locally before PR creation because TypeScript could not find type definition file 'bun'.

Resolves #24802


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 6m and 140,018 tokens on this as a headless worker.