### PR TITLE
Ref #24808: make Nostr VPN pkg expand guidance idempotent

### DIFF
--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -201,7 +201,7 @@ macOS package verification for FIPS v0.4.0-rc1 and later:
   4. Run structural checks before installing:
        pkgutil --check-signature fips-0.4.0-rc1-macos-$(uname -m).pkg
        pkgutil --payload-files fips-0.4.0-rc1-macos-$(uname -m).pkg
-       pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+       rm -rf /tmp/fips-pkg-expanded && pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
        xar -tf fips-0.4.0-rc1-macos-$(uname -m).pkg
   5. Install only after hash and structural checks pass:
        sudo installer -pkg fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
@@ -219,7 +219,7 @@ Source-build fallback if release packages are unavailable or fail integrity:
   4. Verify the generated package before installing:
        pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
        pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
-       pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
+       rm -rf /tmp/fips-source-pkg-expanded && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
   5. Install only after package integrity checks pass:
        sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 

--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -201,7 +201,7 @@ macOS package verification for FIPS v0.4.0-rc1 and later:
   4. Run structural checks before installing:
        pkgutil --check-signature fips-0.4.0-rc1-macos-$(uname -m).pkg
        pkgutil --payload-files fips-0.4.0-rc1-macos-$(uname -m).pkg
-       rm -rf /tmp/fips-pkg-expanded && pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+       rm -rf /tmp/fips-pkg-expanded-${USER} && pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded-${USER}
        xar -tf fips-0.4.0-rc1-macos-$(uname -m).pkg
   5. Install only after hash and structural checks pass:
        sudo installer -pkg fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
@@ -219,7 +219,7 @@ Source-build fallback if release packages are unavailable or fail integrity:
   4. Verify the generated package before installing:
        pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
        pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
-       rm -rf /tmp/fips-source-pkg-expanded && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
+       rm -rf /tmp/fips-source-pkg-expanded-${USER} && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded-${USER}
   5. Install only after package integrity checks pass:
        sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -67,7 +67,7 @@ For upstream macOS packages:
 shasum -a 256 fips-0.4.0-rc1-macos-$(uname -m).pkg
 pkgutil --check-signature fips-0.4.0-rc1-macos-$(uname -m).pkg
 pkgutil --payload-files fips-0.4.0-rc1-macos-$(uname -m).pkg
-rm -rf /tmp/fips-pkg-expanded && pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+rm -rf /tmp/fips-pkg-expanded-${USER} && pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded-${USER}
 xar -tf fips-0.4.0-rc1-macos-$(uname -m).pkg
 sudo installer -pkg fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 ```
@@ -82,11 +82,11 @@ git checkout v0.4.0-rc1
 
 pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
 pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
-rm -rf /tmp/fips-source-pkg-expanded && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
+rm -rf /tmp/fips-source-pkg-expanded-${USER} && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded-${USER}
 sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 ```
 
-Prerequisites for source builds: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Remove any previous `/tmp/fips-pkg-expanded` directory before expanding because `pkgutil --expand` fails when the destination already exists. Do not install if package integrity checks fail.
+Prerequisites for source builds: Rust toolchain from https://rustup.rs and Xcode command line tools (`xcode-select --install`). Remove any previous user-scoped `/tmp/fips-*-pkg-expanded-${USER}` directory before expanding because `pkgutil --expand` fails when the destination already exists. Do not install if package integrity checks fail.
 
 ## Safe Local Posture
 

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -67,7 +67,7 @@ For upstream macOS packages:
 shasum -a 256 fips-0.4.0-rc1-macos-$(uname -m).pkg
 pkgutil --check-signature fips-0.4.0-rc1-macos-$(uname -m).pkg
 pkgutil --payload-files fips-0.4.0-rc1-macos-$(uname -m).pkg
-pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
+rm -rf /tmp/fips-pkg-expanded && pkgutil --expand fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-pkg-expanded
 xar -tf fips-0.4.0-rc1-macos-$(uname -m).pkg
 sudo installer -pkg fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 ```
@@ -82,7 +82,7 @@ git checkout v0.4.0-rc1
 
 pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
 pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg
-pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
+rm -rf /tmp/fips-source-pkg-expanded && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded
 sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /
 ```
 

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -19,7 +19,7 @@
       "./packaging/macos/build-pkg.sh",
       "pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg",
       "pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg",
-      "rm -rf /tmp/fips-source-pkg-expanded && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded",
+      "rm -rf /tmp/fips-source-pkg-expanded-${USER} && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded-${USER}",
       "sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /"
     ],
     "notes": "Do not install if pkgutil integrity checks fail. Never store private Nostr keys in the cloned source tree."

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -19,7 +19,7 @@
       "./packaging/macos/build-pkg.sh",
       "pkgutil --check-signature deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg",
       "pkgutil --payload-files deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg",
-      "pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded",
+      "rm -rf /tmp/fips-source-pkg-expanded && pkgutil --expand deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg /tmp/fips-source-pkg-expanded",
       "sudo installer -pkg deploy/fips-0.4.0-rc1-macos-$(uname -m).pkg -target /"
     ],
     "notes": "Do not install if pkgutil integrity checks fail. Never store private Nostr keys in the cloned source tree."


### PR DESCRIPTION
## Summary
- Add `rm -rf` cleanup before FIPS macOS `pkgutil --expand` examples so repeated validation commands do not fail on existing destination directories.
- Mirrors the fix in helper output, service docs, and the JSON config template.

## Verification
- `bash .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `shellcheck .agents/scripts/nostr-vpn-helper.sh .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `python3 -m json.tool configs/nostr-vpn-config.json.txt >/dev/null`

Ref #24808

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.62 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 5m and 88,795 tokens on this as a headless worker.