### PR TITLE
GH#24813: docs: document job-level CI log fallback

### DIFF
--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -41,6 +41,24 @@ For prompt-economy reasons these rules live here rather than in always-on AGENTS
 - Workers/scripts that source `shared-gh-wrappers.sh` should call `gh_issue_comment`, `gh_create_issue`, `gh_pr_comment`, or `gh_create_pr` by name — these already auto-inject via `_gh_wrapper_auto_sig`.
 - If the plugin hook blocks your command with a parse-failure, the fix is ALWAYS to add the helper call explicitly — never to work around with `AIDEVOPS_GH_SHIM_DISABLE=1`, which only defeats layer (a) and leaves the audit trail inconsistent.
 
+## Job logs for in-progress workflow runs
+
+When diagnosing CI, distinguish the workflow run state from individual job
+state. `gh run view <run-id> --job <job-id> --log-failed` can refuse logs while
+the workflow run is still `in_progress`, even when that specific job has already
+finished with `conclusion=failure`.
+
+Use `gh run view <run-id> --json status,conclusion,jobs` to confirm the target
+job has `status=completed` and `conclusion=failure`. Then fetch the job log via
+REST instead of waiting for the whole workflow:
+
+```bash
+gh api "repos/<owner/repo>/actions/jobs/<job-id>/logs" > failed-job.log
+```
+
+Keep pending/running jobs out of failure feedback until they are terminal; this
+fallback is for terminal failed jobs whose parent workflow has not completed.
+
 ## Thread-clean reading rules (8a-8d)
 
 ### Signature footer skip when reading (8a, token waste prevention)

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -118,6 +118,37 @@ staging/release boundaries. If advisory E2E finds a real defect, file a focused
 follow-up task with the failing check/artifact evidence instead of closing the
 current PR or redispatching duplicate workers. Full policy: `ci-gate-policy.md`.
 
+### Failed job inside a still-running workflow
+
+GitHub can expose a terminal failed job before its parent workflow run finishes.
+In that state, `gh run view <run-id> --repo <owner/repo> --job <job-id>
+--log-failed` may return only:
+
+```text
+run <run-id> is still in progress; logs will be available when it is complete
+```
+
+Do not wait or rerun blindly when job-level state is already terminal. First
+verify the run/job split:
+
+```bash
+gh run view <run-id> --repo <owner/repo> --json status,conclusion,jobs
+```
+
+If the workflow `status` is still `in_progress` but the relevant job has
+`status=completed` and `conclusion=failure`, fetch that job's logs directly via
+the REST job-log endpoint and diagnose from the output:
+
+```bash
+gh api "repos/<owner/repo>/actions/jobs/<job-id>/logs" > failed-job.log
+```
+
+Only treat still-running CI as pending when the job itself is not terminal, or
+when the job log endpoint is unavailable after the status/conclusion check. The
+failure-mining helper already follows this fallback pattern in
+`.agents/scripts/gh-failure-miner-helper.sh` after `gh run view --log-failed`
+returns no useful failed log output.
+
 ## Architecture Decisions
 
 ### SQLite DB Isolation (v3.6.130)


### PR DESCRIPTION
## Summary

Documented the terminal-failed-job/still-running-workflow diagnosis branch in worker diagnostics and gh command discipline, including the REST job-log endpoint and pending-job guard.

## Files Changed

.agents/reference/gh-command-discipline.md,.agents/reference/worker-diagnostics.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 '.agents/reference/worker-diagnostics.md' '.agents/reference/gh-command-discipline.md'

Resolves #24813


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.62 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2m and 86,679 tokens on this as a headless worker.