### PR TITLE
GH#24815: fix: stabilize gh body-file wrappers

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -348,6 +348,23 @@ _gh_wrapper_auto_assignee() {
 #   set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 # Non-fatal: if signature generation fails, original args are preserved.
 _GH_WRAPPER_SIG_MODIFIED_ARGS=()
+_gh_wrapper_abs_body_file_path() {
+	local body_file_path="$1"
+	[[ -z "$body_file_path" ]] && return 1
+	case "$body_file_path" in
+	/*)
+		printf '%s\n' "$body_file_path"
+		return 0
+		;;
+	esac
+	local body_file_dir body_file_base
+	body_file_dir=$(dirname "$body_file_path") || return 1
+	body_file_base=$(basename "$body_file_path") || return 1
+	body_file_dir=$(cd "$body_file_dir" 2>/dev/null && pwd) || return 1
+	printf '%s/%s\n' "$body_file_dir" "$body_file_base"
+	return 0
+}
+
 _gh_wrapper_auto_sig() {
 	_GH_WRAPPER_SIG_MODIFIED_ARGS=("$@")
 	local sig_helper
@@ -402,7 +419,14 @@ _gh_wrapper_auto_sig() {
 	# signed temp copy and point argv at it so callers using --body-file get the
 	# same footer behaviour as --body without surprising filesystem side effects.
 	if [[ $body_file_idx -ge 0 && -n "$body_file_val" && -f "$body_file_val" ]]; then
-		if grep -q '<!-- aidevops:sig -->' "$body_file_val" 2>/dev/null; then
+		local abs_body_file_val
+		abs_body_file_val=$(_gh_wrapper_abs_body_file_path "$body_file_val") || abs_body_file_val="$body_file_val"
+		if grep -q '<!-- aidevops:sig -->' "$abs_body_file_val" 2>/dev/null; then
+			if [[ "$bf_is_eq" -eq 1 ]]; then
+				_GH_WRAPPER_SIG_MODIFIED_ARGS[body_file_idx]="--body-file=${abs_body_file_val}"
+			else
+				_GH_WRAPPER_SIG_MODIFIED_ARGS[body_file_idx + 1]="$abs_body_file_val"
+			fi
 			return 0
 		fi
 		local sig_footer
@@ -415,7 +439,7 @@ _gh_wrapper_auto_sig() {
 		# until the wrapper delegates to gh, then the wrapper-level trap removes it.
 		push_cleanup "rm -f \"$signed_body_file\""
 		{
-			cat "$body_file_val"
+			cat "$abs_body_file_val"
 			printf '%s' "$sig_footer"
 		} >"$signed_body_file" || return 0
 		if [[ "$bf_is_eq" -eq 1 ]]; then

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -398,6 +398,16 @@ _gh_validate_edit_args() {
 			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
 			return 1
 		fi
+		if [[ ! -f "$body_file_val" ]]; then
+			_GH_EDIT_REJECTION_REASON="body-file '${body_file_val}' does not exist"
+			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+			return 1
+		fi
+		if [[ ! -r "$body_file_val" ]]; then
+			_GH_EDIT_REJECTION_REASON="body-file '${body_file_val}' is not readable"
+			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+			return 1
+		fi
 		if [[ -f "$body_file_val" ]]; then
 			local file_size
 			file_size=$(wc -c <"$body_file_val" 2>/dev/null || echo "0")

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
@@ -88,7 +88,6 @@ fi
 source "$SHARED_GH" >/dev/null 2>&1 || true
 
 _ensure_origin_labels_for_args() { return 0; }
-_gh_validate_edit_args() { return 0; }
 _gh_should_fallback_to_rest() { return 1; }
 _rest_should_fallback() { return 1; }
 _gh_auto_link_sub_issue() { return 0; }
@@ -137,9 +136,50 @@ assert_existing_signature_not_duplicated() {
 	return 0
 }
 
+assert_signed_relative_body_file_normalized() {
+	local rel_dir="relative-bodies"
+	local body_name="already-signed-relative.md"
+	local body_file="${TEST_ROOT}/${rel_dir}/${body_name}"
+	mkdir -p "${TEST_ROOT}/${rel_dir}"
+	printf '## Summary\n\nBody\n\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) existing\n' >"$body_file"
+	reset_capture
+	(
+		cd "$TEST_ROOT" || exit 1
+		gh_create_pr --repo o/r --title "Fix relative body-file" --body-file "${rel_dir}/${body_name}" >/dev/null 2>&1
+	)
+	local abs_count rel_count
+	abs_count=$(grep -c "<${body_file}>" "$GH_ARGV_RECORD_FILE" 2>/dev/null || true)
+	rel_count=$(grep -c "<${rel_dir}/${body_name}>" "$GH_ARGV_RECORD_FILE" 2>/dev/null || true)
+	if [[ "$abs_count" == "1" && "$rel_count" == "0" ]]; then
+		print_result "signed relative --body-file is normalized before gh" 0
+	else
+		print_result "signed relative --body-file is normalized before gh" 1 "abs_count=${abs_count}, rel_count=${rel_count}"
+	fi
+	return 0
+}
+
+assert_missing_body_file_rejected_before_gh() {
+	reset_capture
+	if gh_create_pr --repo o/r --title "Reject missing body-file" --body-file "missing-body.md" >/dev/null 2>"${TEST_ROOT}/missing.err"; then
+		print_result "missing --body-file is rejected before gh" 1 "wrapper returned success"
+		return 0
+	fi
+	local gh_calls rejection_count
+	gh_calls=$(wc -l <"$GH_ARGV_RECORD_FILE" | tr -d '[:space:]')
+	rejection_count=$(grep -c "body-file 'missing-body.md' does not exist" "${TEST_ROOT}/missing.err" 2>/dev/null || true)
+	if [[ "$gh_calls" == "0" && "$rejection_count" == "1" ]]; then
+		print_result "missing --body-file is rejected before gh" 0
+	else
+		print_result "missing --body-file is rejected before gh" 1 "gh_calls=${gh_calls}, rejection_count=${rejection_count}"
+	fi
+	return 0
+}
+
 assert_body_file_signed "gh_create_pr --body-file signs temp body" "pr-create"
 assert_body_file_signed "gh_pr_comment --body-file signs temp body" "pr-comment"
 assert_existing_signature_not_duplicated
+assert_signed_relative_body_file_normalized
+assert_missing_body_file_rejected_before_gh
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

Normalized readable relative --body-file paths before gh delegation, rejected missing/unreadable body files before gh create calls, and added regressions for path normalization, pre-gh rejection, signature preservation, and quiet shell cleanup compatibility.

## Files Changed

.agents/scripts/shared-gh-wrappers-session.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh; .agents/scripts/tests/test-gh-wrapper-shell-compat.sh; .agents/scripts/tests/test-gh-wrapper-zsh-compat.sh; shellcheck .agents/scripts/shared-gh-wrappers.sh .agents/scripts/shared-gh-wrappers-session.sh .agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh

Resolves #24815


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.62 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 4m and 79,471 tokens on this as a headless worker.