### PR TITLE
GH#24812: fix: require dependency evidence for error mappings

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -51,6 +51,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Before declaring completion, scan conversation for unfulfilled commitments, unnotified external parties, and displaced requests.
 - Memory recall is mandatory before non-trivial edits, debugging, PR review, git side effects, or design decisions: CLI `memory-helper.sh recall --query "<task keywords>" --limit 5`; OpenCode tool `aidevops_memory` with `{action:"recall", query:"<task keywords>", limit:"5"}`. Store only concrete reusable lessons: `{action:"store", content:"<lesson with evidence>", confidence:"medium"}`. Empty `aidevops_memory` calls are invalid; never use them as placeholders.
 - Before non-trivial code changes, run one duplicate/collision check: `prework-discovery-helper.sh --keywords "<task>" --files "<targets>" [--repo owner/repo]`.
+- Before changing third-party API/error-code mappings, verify the installed dependency version and local exported symbols first; brief authors include this checklist via `templates/brief-template.md`.
 
 ### Automation safety invariants
 

--- a/.agents/scripts/tests/test-brief-template-third-party-deps.sh
+++ b/.agents/scripts/tests/test-brief-template-third-party-deps.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-brief-template-third-party-deps.sh — regression coverage for GH#24812
+
+set -u
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+TEMPLATE_PATH="${SCRIPT_DIR}/../../templates/brief-template.md"
+
+if [[ ! -f "$TEMPLATE_PATH" ]]; then
+	printf 'FAIL brief template missing at %s\n' "$TEMPLATE_PATH" >&2
+	exit 1
+fi
+
+template_contents="$(<"$TEMPLATE_PATH")"
+failures=0
+
+if [[ "$template_contents" == *"THIRD-PARTY API/ERROR MAPPING COMPATIBILITY (GH#24812)"* ]]; then
+	printf 'PASS third-party compatibility heading present\n'
+else
+	printf 'FAIL third-party compatibility heading missing\n' >&2
+	failures=$((failures + 1))
+fi
+
+if [[ "$template_contents" == *"installed dependency version plus local"* ]]; then
+	printf 'PASS installed dependency version evidence required\n'
+else
+	printf 'FAIL installed dependency version evidence not required\n' >&2
+	failures=$((failures + 1))
+fi
+
+if [[ "$template_contents" == *"exported symbols/source"* ]]; then
+	printf 'PASS local exported symbols evidence required\n'
+else
+	printf 'FAIL local exported symbols evidence not required\n' >&2
+	failures=$((failures + 1))
+fi
+
+if [[ "$template_contents" == *"package manifest, lockfile, and installed package"* ]]; then
+	printf 'PASS manifest lockfile installed package checklist present\n'
+else
+	printf 'FAIL manifest lockfile installed package checklist missing\n' >&2
+	failures=$((failures + 1))
+fi
+
+if [[ $failures -eq 0 ]]; then
+	exit 0
+fi
+
+exit 1

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -218,6 +218,14 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
       signatures may have been updated since. A wrong signature in a brief causes the
       worker to write broken code and burn tokens debugging.
 
+      THIRD-PARTY API/ERROR MAPPING COMPATIBILITY (GH#24812):
+      If the task changes mappings, translations, or tests for third-party API or error
+      codes, require the worker to verify the installed dependency version plus local
+      exported symbols/source from the package manifest, lockfile, and installed package
+      before implementing upstream-reported values. If the local version does not expose
+      the upstream value, add a compatibility regression test or an explicit upgrade task
+      instead of adding unavailable mappings.
+
       ALWAYS-LOADED PROMPT BUDGET RULE (Phase 8 of #22616):
       If this task edits AGENTS.md, .agents/AGENTS.md, prompts/build.txt, or another
       always-loaded instruction surface, require progressive disclosure by default:


### PR DESCRIPTION
## Summary

Added worker-facing dependency evidence guidance for third-party API/error-code mapping tasks, including a brief-template checklist and AGENTS pointer.

## Files Changed

.agents/AGENTS.md,.agents/scripts/tests/test-brief-template-third-party-deps.sh,.agents/templates/brief-template.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-brief-template-third-party-deps.sh; .agents/scripts/tests/test-brief-template-third-party-deps.sh; AGENTS.md size check (.agents/AGENTS.md: 17774 bytes <= 24000)

Resolves #24812


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.62 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 4m and 90,788 tokens on this as a headless worker.