### PR TITLE
Ref #23846: add Nostr VPN privacy guidance

### DIFF
--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -24,6 +24,7 @@ Commands:
   secrets-help     Show aidevops secret setup guidance
   macos-source     Show macOS package verification and source fallback guidance
   safe-posture     Show safe install, disable, and re-enable guidance
+  privacy-guide    Show privacy/anonymity best-practice guidance
   opencode-guide   Show secure OpenCode remote compute guidance
   help             Show this help
 USAGE
@@ -174,6 +175,33 @@ GUIDE
 	return 0
 }
 
+show_privacy_guide() {
+	cat <<'GUIDE'
+FIPS/Nostr VPN privacy guidance:
+  - Treat FIPS as a private self-sovereign mesh, not as an anonymity network.
+  - Use fresh per-device Nostr/FIPS identities; never reuse a public/social npub.
+  - Separate identities by purpose: personal devices, experiments, client/work, and travel.
+  - Prefer self-hosted or trusted private Nostr relays; public relays may observe discovery metadata.
+  - Keep peer ACLs explicit and default-deny; do not expose services while ACL state is default-open.
+  - Disable LAN gateway, exit-node, and broad service exposure unless the trust boundary is documented.
+  - Bind SSH, OpenCode, MCP servers, and dashboards to loopback or the FIPS interface only.
+  - Keep the daemon disabled when no trusted peer is ready; enable only for an intentional test window.
+  - Do not paste nsec/private keys into chat; store recovery material only with aidevops secret storage.
+
+Companion privacy tooling:
+  - Network privacy: use a reputable no-logs VPN or Tor where the threat model requires IP hiding.
+  - Relay privacy: self-host relays where possible; otherwise assume relay IP/timing metadata exists.
+  - Communications: use SimpleX or Signal for human messages when metadata minimisation matters more than mesh networking.
+  - Browser isolation: use separate browser profiles, CamoFox, or hardened Firefox/Arkenfox for web identity separation.
+  - Device hygiene: FileVault/LUKS/BitLocker, strong passphrases, YubiKey-backed SSH/FIDO2, and EXIF stripping.
+
+Hard limit:
+  - Full privacy and anonymity cannot be guaranteed by FIPS alone. IP addresses, relay timing,
+    traffic correlation, device fingerprints, writing style, and compromised endpoints can still identify users.
+GUIDE
+	return 0
+}
+
 show_secrets_help() {
 	cat <<'SECRETS'
 WARNING: Never paste secret values into AI chat.
@@ -287,6 +315,10 @@ main() {
 		;;
 	safe-posture)
 		show_safe_posture_guide "$@"
+		return $?
+		;;
+	privacy-guide)
+		show_privacy_guide "$@"
 		return $?
 		;;
 	opencode-guide)

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -189,6 +189,19 @@ test_opencode_guide_mentions_aidevops_services() {
 	return 0
 }
 
+test_privacy_guide_mentions_limits_and_companions() {
+	local output=""
+	output="$(bash "$HELPER_SCRIPT" privacy-guide 2>&1)"
+
+	if [[ "$output" == *"not as an anonymity network"* && "$output" == *"SimpleX or Signal"* && "$output" == *"self-hosted or trusted private Nostr relays"* ]]; then
+		print_result "privacy guide mentions limits and companions" 0
+		return 0
+	fi
+
+	print_result "privacy guide mentions limits and companions" 1 "$output"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -202,6 +215,7 @@ main() {
 	test_macos_source_mentions_rc1_package_validation
 	test_safe_posture_mentions_disable_and_default_open
 	test_opencode_guide_mentions_aidevops_services
+	test_privacy_guide_mentions_limits_and_companions
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/services/networking/nostr-vpn.md
+++ b/.agents/services/networking/nostr-vpn.md
@@ -38,6 +38,8 @@ Use **Nostr VPN/FIPS** when self-sovereign identity and no central control plane
 
 Do not present FIPS as the default aidevops networking layer until upstream protocol stability and security audit status improve.
 
+Do not present FIPS as “full anonymity” or “no spying possible”. It reduces dependence on a SaaS control plane, but relays, transport endpoints, timing, IPs, and compromised devices can still leak metadata.
+
 ## aidevops Use Cases
 
 - Secure SSH and OpenCode server access between personal devices across networks.
@@ -46,6 +48,29 @@ Do not present FIPS as the default aidevops networking layer until upstream prot
 - Run aidevops helpers on one node while using compute or services on another.
 - Test resilient routing over UDP, TCP, Ethernet, Tor, or Bluetooth transports.
 - Keep private admin paths for Git remotes, MCP services, dashboards, staging apps, backup/storage nodes, and CI/debug workers bound to loopback or FIPS-only addresses.
+
+## Privacy and Anonymity Best Practices
+
+Use FIPS as a private device mesh, not as a standalone anonymity network:
+
+1. Generate fresh per-device FIPS/Nostr identities; never reuse a public/social Nostr npub.
+2. Separate identities by purpose: personal devices, experiments, client/work, travel, and high-risk research.
+3. Prefer self-hosted or trusted private Nostr relays for discovery. If public relays are used, assume they can observe npubs, IPs, timestamps, and discovery metadata even when payload contents are encrypted.
+4. Keep peer ACLs explicit and default-deny. Treat default-open ACL state as unsafe for exposing SSH, OpenCode, MCP, dashboards, or gateways.
+5. Disable LAN gateway, exit-node, and broad listener modes unless the trust boundary is documented and reviewed.
+6. Bind services to loopback or the FIPS interface only; do not publish public listeners as a shortcut.
+7. Keep FIPS disabled when no trusted peer is ready; enable only for an intentional test window.
+8. Rotate identities after suspected compromise and remove stale peers from ACLs, known-hosts, and local host maps.
+
+For stronger privacy, combine FIPS with other aidevops guidance and tools:
+
+- `tools/security/opsec.md` — threat modelling, DNS privacy, device hygiene, identity compartmentalisation, anti-fingerprinting browsers, and incident response.
+- `services/communications/privacy-comparison.md` — choose SimpleX or Signal for private human messaging; do not use FIPS as a chat privacy substitute.
+- Tor or a reputable no-logs VPN — hide source IP from relays/transports where the threat model requires it.
+- Self-hosted Nostr relay — reduce third-party relay metadata exposure.
+- FileVault/LUKS/BitLocker, YubiKey-backed SSH/FIDO2, EXIF stripping, separate browser profiles, CamoFox, or hardened Firefox/Arkenfox — reduce endpoint and identity-correlation risk.
+
+Hard limit: full privacy and anonymity cannot be guaranteed by a VPN overlay alone. IP addresses, timing correlation, device fingerprints, writing style, payment trails, relay logs, and compromised endpoints can identify users.
 
 ## Setup Pattern
 
@@ -148,6 +173,7 @@ Other aidevops-adjacent candidates after SSH is proven: private Git remotes, MCP
 .agents/scripts/nostr-vpn-helper.sh secrets-help
 .agents/scripts/nostr-vpn-helper.sh macos-source
 .agents/scripts/nostr-vpn-helper.sh safe-posture
+.agents/scripts/nostr-vpn-helper.sh privacy-guide
 .agents/scripts/nostr-vpn-helper.sh opencode-guide
 ```
 
@@ -163,6 +189,8 @@ The helper is intentionally read-only except for printing operator instructions;
 - Enable `fips0` firewall rules before exposing SSH, OpenCode, dashboards, or LAN gateways.
 - Avoid LAN gateway and exit-node mode until the trust boundary is explicit.
 - Assume public Nostr relays can reveal metadata even when messages are encrypted.
+- Use fresh per-purpose identities and private/self-hosted relays where practical.
+- Use Tor, a no-logs VPN, or privacy-preserving transport only when IP hiding is part of the threat model; validate that the chosen FIPS transport actually uses it.
 - Rotate the device identity after suspected compromise; remove stale peers from ACLs and known-hosts.
 
 ## Verification

--- a/configs/nostr-vpn-config.json.txt
+++ b/configs/nostr-vpn-config.json.txt
@@ -26,6 +26,7 @@
   },
   "identity": {
     "mode": "per-device",
+    "privacy_mode": "fresh identity per device and purpose; do not reuse public/social Nostr npubs",
     "private_key_storage": "aidevops secret set FIPS_NSEC for import/recovery only; otherwise use the upstream key file with owner-only permissions",
     "public_address_format": "npub",
     "never_commit": [
@@ -78,6 +79,14 @@
     "exit_node": "disabled-until-reviewed",
     "public_relay_metadata_warning": true
   },
+  "privacy_defaults": {
+    "positioning": "private self-sovereign device mesh, not a standalone anonymity network",
+    "relay_policy": "prefer self-hosted or trusted private relays; assume public relays can observe npubs, IPs, timing, and discovery metadata",
+    "identity_compartmentalization": ["personal", "experiment", "client-work", "travel", "high-risk-research"],
+    "service_binding": "loopback-or-fips-interface-only",
+    "companion_tools": ["tools/security/opsec.md", "services/communications/privacy-comparison.md", "Tor or reputable no-logs VPN", "self-hosted Nostr relay", "FileVault/LUKS/BitLocker", "YubiKey", "EXIF stripping", "separate browser profiles", "CamoFox or hardened Firefox/Arkenfox"],
+    "hard_limit": "full privacy/anonymity cannot be guaranteed by FIPS alone; IPs, timing, fingerprints, writing style, relay logs, and compromised endpoints can identify users"
+  },
   "tools": {
     "required": ["fips", "fipsctl"],
     "optional": ["fipstop", "fips-gateway", "jq", "systemctl", "launchctl", "git", "cargo", "pkgbuild", "xcode-select"]
@@ -92,6 +101,6 @@
     "7. If no trusted peer is ready, stop and disable the macOS LaunchDaemon after validating install state.",
     "8. Configure peer allowlists before joining untrusted meshes.",
     "9. Enable the fips0 firewall baseline before exposing SSH/OpenCode.",
-    "10. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics and safe-posture"
+    "10. Run: .agents/scripts/nostr-vpn-helper.sh diagnostics, safe-posture, and privacy-guide"
   ]
 }


### PR DESCRIPTION
## Summary

- Add explicit Nostr VPN/FIPS privacy and anonymity guidance.
- Add `privacy-guide` helper output covering identity compartmentalisation, relay metadata, default-deny ACLs, and hard anonymity limits.
- Extend the config template with privacy defaults and companion aidevops tools/services.

## Verification

- `shellcheck .agents/scripts/nostr-vpn-helper.sh .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `.agents/scripts/tests/test-nostr-vpn-helper.sh`
- `python3 -m json.tool configs/nostr-vpn-config.json.txt`
- `bunx markdownlint-cli2 ".agents/services/networking/nostr-vpn.md" ".agents/reference/domain-index.md"`
- `.agents/scripts/lint-shell-portability.sh .agents/scripts/nostr-vpn-helper.sh .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `secretlint-helper.sh scan` on all modified Nostr VPN files

Ref #23846
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.62 with gpt-5.5 spent 1h 52m and 612,389 tokens on this with the user in an interactive session.