### PR TITLE
GH#24814: docs: document recursive Turbo affected filters

### DIFF
--- a/.agents/reference/ci-gate-policy.md
+++ b/.agents/reference/ci-gate-policy.md
@@ -32,6 +32,10 @@ feedback loops when they find defects.
 6. If an E2E failure is required by branch protection, fix or explicitly
    quarantine the failing path before merge; do not bypass production/release
    gates silently.
+7. In JS/TS monorepos, make affected-package checks non-recursive. For Turbo,
+   a broad filter such as `--filter="...[origin/<base>]"` can include the
+   workspace root; if root `lint`/`typecheck` scripts call Turbo, exclude root
+   with `--filter="!//"` or run root checks in a separate job.
 
 ## Ruleset checklist
 
@@ -73,3 +77,5 @@ work; only defects in the PR's own code block the PR.
   follow-up tasks.
 - Treating delayed, pending, cancelled, or infrastructure-timed-out checks as
   proof of a source-code defect.
+- Broad affected Turbo lint/typecheck filters that include a recursive root
+  script, making CI look hung or quiet instead of testing changed packages.

--- a/.agents/tools/monorepo/turborepo.md
+++ b/.agents/tools/monorepo/turborepo.md
@@ -53,6 +53,19 @@ pnpm --filter "./packages/*" build     # by directory
 pnpm --filter "!web" build             # exclude
 ```
 
+**Affected CI filters:** broad affected selectors can include the workspace root.
+If the root `package.json` task calls Turbo again, split root checks from package
+affected checks or exclude the root selector:
+
+```bash
+pnpm exec turbo run lint --continue --filter="...[origin/<base>]" --filter="!//"
+pnpm exec turbo run typecheck --continue --filter="...[origin/<base>]" --filter="!//"
+```
+
+Use this when root scripts look like `"lint": "turbo lint"` or
+`"typecheck": "turbo typecheck"`; otherwise CI can recursively schedule the root
+task, appear hung, or hit no-output watchdogs.
+
 ## Package Exports & Dependencies
 
 ```json
@@ -117,6 +130,7 @@ pnpm --filter @workspace/db db:studio    # open studio UI
 | Cache not invalidating | Check `outputs` in turbo.json; add env vars to `globalEnv` |
 | Wrong workspace protocol | Use `"workspace:*"` not `"*"` |
 | TypeScript path issues | Use `moduleResolution: "bundler"`; match `exports` in package.json |
+| Affected lint/typecheck appears hung | Check whether the root task invokes Turbo; add `--filter="!//"` or run root checks separately |
 
 ## Related
 


### PR DESCRIPTION
## Summary

Added Turborepo and CI gate guidance warning that broad affected filters can include the workspace root, and that recursive root lint/typecheck scripts should use --filter="!//" or separate root checks.

## Files Changed

.agents/reference/ci-gate-policy.md,.agents/tools/monorepo/turborepo.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/markdownlint-diff-helper.sh --base 62cf2a9cffa786a067b80bac3aad2afbec38fcae --head HEAD (no new violations reported); .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED)

Resolves #24814


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.62 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 5m and 66,197 tokens on this as a headless worker.