### PR TITLE
Ref #23846: align Nostr VPN privacy helper

### DIFF
--- a/.agents/scripts/nostr-vpn-helper.sh
+++ b/.agents/scripts/nostr-vpn-helper.sh
@@ -180,12 +180,13 @@ show_privacy_guide() {
 FIPS/Nostr VPN privacy guidance:
   - Treat FIPS as a private self-sovereign mesh, not as an anonymity network.
   - Use fresh per-device Nostr/FIPS identities; never reuse a public/social npub.
-  - Separate identities by purpose: personal devices, experiments, client/work, and travel.
+  - Separate identities by purpose: personal devices, experiments, client/work, travel, and high-risk research.
   - Prefer self-hosted or trusted private Nostr relays; public relays may observe discovery metadata.
   - Keep peer ACLs explicit and default-deny; do not expose services while ACL state is default-open.
   - Disable LAN gateway, exit-node, and broad service exposure unless the trust boundary is documented.
   - Bind SSH, OpenCode, MCP servers, and dashboards to loopback or the FIPS interface only.
   - Keep the daemon disabled when no trusted peer is ready; enable only for an intentional test window.
+  - Rotate identities after suspected compromise and remove stale peers from ACLs, known-hosts, and local host maps.
   - Do not paste nsec/private keys into chat; store recovery material only with aidevops secret storage.
 
 Companion privacy tooling:

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -193,7 +193,7 @@ test_privacy_guide_mentions_limits_and_companions() {
 	local output=""
 	output="$(bash "$HELPER_SCRIPT" privacy-guide 2>&1)"
 
-	if [[ "$output" == *"not as an anonymity network"* && "$output" == *"SimpleX or Signal"* && "$output" == *"self-hosted or trusted private Nostr relays"* ]]; then
+	if [[ "$output" == *"not as an anonymity network"* && "$output" == *"SimpleX or Signal"* && "$output" == *"self-hosted or trusted private Nostr relays"* && "$output" == *"high-risk research"* && "$output" == *"Rotate identities after suspected compromise"* ]]; then
 		print_result "privacy guide mentions limits and companions" 0
 		return 0
 	fi


### PR DESCRIPTION
Follow-up to merged PR #24821 review threads.

## Summary
- Align `nostr-vpn-helper.sh privacy-guide` with existing Nostr VPN docs/config for high-risk research identity separation.
- Add compromise rotation and stale-peer removal guidance to helper output.
- Extend focused smoke coverage for the helper privacy guide.

## Verification
- `bash .agents/scripts/tests/test-nostr-vpn-helper.sh`
- `shellcheck .agents/scripts/nostr-vpn-helper.sh .agents/scripts/tests/test-nostr-vpn-helper.sh`

## Provenance
- Source: unresolved Gemini Code Assist review threads on PR #24821.
- Ref #23846.

