### PR TITLE
docs: expand app-stack architecture guidance

### DIFF
--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -35,6 +35,10 @@ mode: subagent
 | Place schemas and migrations | `app-stack/migration-layout.md` |
 | Standardise platform/kernel objects | `app-stack/platform-kernel.md` |
 | Model change history, merges, and relationships | `app-stack/data-history-relationships.md` |
+| Design background jobs, scheduled tasks, and operations | `app-stack/operations-jobs-scheduling.md` |
+| Define API and service contracts | `app-stack/api-service-contracts.md` |
+| Model identity and security lifecycle | `app-stack/identity-security-lifecycle.md` |
+| Plan privacy, sync, scale, and test data | `app-stack/data-protection-sync-scale.md` |
 | Choose standard app objects | `app-stack/standard-objects.md` |
 | Design RBAC/capabilities | `app-stack/rbac-permissions.md` |
 | Design workflows and automations | `app-stack/workflow-architecture.md` |
@@ -50,9 +54,9 @@ Prefer boring, shared primitives that compound across apps:
 2. Put reusable domain logic, database schema, UI, config, and API clients in packages.
 3. Use Postgres + Drizzle as the canonical data model; add RLS from the first multi-user boundary.
 4. Keep schema and migration ownership in `packages/db` for monorepos; generated SQL and metadata snapshots are versioned artifacts.
-5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, import/export, and notifications.
+5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, jobs, import/export, API contracts, privacy, and notifications.
 6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
-7. Start from standard object packs: issues, labels/tags, users, teams, roles, content/pages, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
+7. Start from standard object packs: issues, labels/tags, users, teams, roles, content/pages, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, jobs/processes, quotes, invoices, payments, prices, and referrals.
 8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
 
 ## Builder interpretation rules
@@ -66,7 +70,7 @@ When asked to build a new app or data architecture:
 5. Preserve external sync handles for WebDAV, CalDAV, CardDAV, payment, accounting, and forge integrations.
 6. Verify one complete path: object → permission → workflow → audit → import/export or sync.
 
-Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `data-history-relationships.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
+Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `operations-jobs-scheduling.md` → `api-service-contracts.md` → `identity-security-lifecycle.md` → `data-protection-sync-scale.md` → `data-history-relationships.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
 
 ## Related docs
 

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -49,7 +49,7 @@ Prefer boring, shared primitives that compound across apps:
 4. Keep schema and migration ownership in `packages/db` for monorepos; generated SQL and metadata snapshots are versioned artifacts.
 5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, import/export, and notifications.
 6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
-7. Start from standard object packs: issues, labels/tags, users, teams, roles, chats/channels, CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
+7. Start from standard object packs: issues, labels/tags, users, teams, roles, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
 8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
 
 ## Related docs

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -33,6 +33,7 @@ mode: subagent
 | Model workspace tenancy/collaboration | `app-stack/workspace-model.md` |
 | Design app database foundation | `app-stack/database-foundation.md` |
 | Place schemas and migrations | `app-stack/migration-layout.md` |
+| Standardise platform/kernel objects | `app-stack/platform-kernel.md` |
 | Choose standard app objects | `app-stack/standard-objects.md` |
 | Design RBAC/capabilities | `app-stack/rbac-permissions.md` |
 | Design workflows and automations | `app-stack/workflow-architecture.md` |
@@ -64,7 +65,7 @@ When asked to build a new app or data architecture:
 5. Preserve external sync handles for WebDAV, CalDAV, CardDAV, payment, accounting, and forge integrations.
 6. Verify one complete path: object → permission → workflow → audit → import/export or sync.
 
-Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
+Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
 
 ## Related docs
 

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -49,7 +49,7 @@ Prefer boring, shared primitives that compound across apps:
 4. Keep schema and migration ownership in `packages/db` for monorepos; generated SQL and metadata snapshots are versioned artifacts.
 5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, import/export, and notifications.
 6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
-7. Start from standard object packs: issues, labels/tags, users, teams, roles, accounts, contacts, quotes, invoices, payments, prices, and referrals.
+7. Start from standard object packs: issues, labels/tags, users, teams, roles, chats/channels, CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
 8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
 
 ## Related docs

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -50,7 +50,7 @@ Prefer boring, shared primitives that compound across apps:
 4. Keep schema and migration ownership in `packages/db` for monorepos; generated SQL and metadata snapshots are versioned artifacts.
 5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, import/export, and notifications.
 6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
-7. Start from standard object packs: issues, labels/tags, users, teams, roles, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
+7. Start from standard object packs: issues, labels/tags, users, teams, roles, content/pages, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
 8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
 
 ## Builder interpretation rules

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -35,6 +35,7 @@ mode: subagent
 | Place schemas and migrations | `app-stack/migration-layout.md` |
 | Choose standard app objects | `app-stack/standard-objects.md` |
 | Design RBAC/capabilities | `app-stack/rbac-permissions.md` |
+| Design workflows and automations | `app-stack/workflow-architecture.md` |
 | Build metadata-driven entities/layouts/workflows | `app-stack/metadata-architecture.md` |
 | Add encrypted/local-first collaboration | `app-stack/encrypted-collaboration.md` |
 | Shape app/control-room UX shell | `app-stack/ux-shell-patterns.md` |
@@ -51,6 +52,19 @@ Prefer boring, shared primitives that compound across apps:
 6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
 7. Start from standard object packs: issues, labels/tags, users, teams, roles, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, quotes, invoices, payments, prices, and referrals.
 8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
+
+## Builder interpretation rules
+
+When asked to build a new app or data architecture:
+
+1. Start with `Workspace`, `packages/db`, RLS, users, teams, roles, labels, audit, files, and integrations.
+2. Pick canonical object roots from `app-stack/standard-objects.md` before inventing domain tables.
+3. Use types, labels, views, and metadata before separate tables; split tables only for distinct validation, lifecycle, permissions, integrations, or indexes.
+4. Add workflows as definitions plus runtime events/runs; do not hide state machines in UI-only code.
+5. Preserve external sync handles for WebDAV, CalDAV, CardDAV, payment, accounting, and forge integrations.
+6. Verify one complete path: object → permission → workflow → audit → import/export or sync.
+
+Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
 
 ## Related docs
 

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -32,6 +32,9 @@ mode: subagent
 | Choose/shape desktop shell | `app-stack/electron-desktop.md` |
 | Model workspace tenancy/collaboration | `app-stack/workspace-model.md` |
 | Design app database foundation | `app-stack/database-foundation.md` |
+| Place schemas and migrations | `app-stack/migration-layout.md` |
+| Choose standard app objects | `app-stack/standard-objects.md` |
+| Design RBAC/capabilities | `app-stack/rbac-permissions.md` |
 | Build metadata-driven entities/layouts/workflows | `app-stack/metadata-architecture.md` |
 | Add encrypted/local-first collaboration | `app-stack/encrypted-collaboration.md` |
 | Shape app/control-room UX shell | `app-stack/ux-shell-patterns.md` |
@@ -43,9 +46,11 @@ Prefer boring, shared primitives that compound across apps:
 1. Start web-first with TypeScript and React/Next for app UX.
 2. Put reusable domain logic, database schema, UI, config, and API clients in packages.
 3. Use Postgres + Drizzle as the canonical data model; add RLS from the first multi-user boundary.
-4. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, audit, import/export, and notifications.
-5. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
-6. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
+4. Keep schema and migration ownership in `packages/db` for monorepos; generated SQL and metadata snapshots are versioned artifacts.
+5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, import/export, and notifications.
+6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
+7. Start from standard object packs: issues, labels/tags, users, teams, roles, accounts, contacts, quotes, invoices, payments, prices, and referrals.
+8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
 
 ## Related docs
 

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -34,6 +34,7 @@ mode: subagent
 | Design app database foundation | `app-stack/database-foundation.md` |
 | Place schemas and migrations | `app-stack/migration-layout.md` |
 | Standardise platform/kernel objects | `app-stack/platform-kernel.md` |
+| Model change history, merges, and relationships | `app-stack/data-history-relationships.md` |
 | Choose standard app objects | `app-stack/standard-objects.md` |
 | Design RBAC/capabilities | `app-stack/rbac-permissions.md` |
 | Design workflows and automations | `app-stack/workflow-architecture.md` |
@@ -65,7 +66,7 @@ When asked to build a new app or data architecture:
 5. Preserve external sync handles for WebDAV, CalDAV, CardDAV, payment, accounting, and forge integrations.
 6. Verify one complete path: object → permission → workflow → audit → import/export or sync.
 
-Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
+Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `data-history-relationships.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
 
 ## Related docs
 

--- a/.agents/tools/app-stack.md
+++ b/.agents/tools/app-stack.md
@@ -28,6 +28,7 @@ mode: subagent
 |------|------|
 | Pick site/app platform | `app-stack/decision-matrix.md` |
 | Build a no-build website starter | `app-stack/static-site-starter.md` |
+| Define required public pages, schema, docs/API/MCP/CLI surfaces | `app-stack/public-site-surfaces.md` |
 | Design TypeScript monorepo app structure | `app-stack/monorepo-app-stack.md` |
 | Choose/shape desktop shell | `app-stack/electron-desktop.md` |
 | Model workspace tenancy/collaboration | `app-stack/workspace-model.md` |
@@ -57,7 +58,8 @@ Prefer boring, shared primitives that compound across apps:
 5. Treat metadata as product infrastructure: entity definitions, fields, layouts, views, ACL, workflows, labels, audit, jobs, import/export, API contracts, privacy, and notifications.
 6. Use `Workspace` as the data container, permission boundary, AI context boundary, and collaboration scope.
 7. Start from standard object packs: issues, labels/tags, users, teams, roles, content/pages, conversations/channels, calendar/CRM activities, files/folders, accounts, contacts, jobs/processes, quotes, invoices, payments, prices, and referrals.
-8. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
+8. Keep public surfaces explicit: `/about`, `/contact`, `/privacy`, `/terms`, docs, API, MCP, CLI, sitemap, schema, and support routes.
+9. Keep web/CMS/site routing explicit: WordPress for editors; no-build static for plain sites; static generator only after repeated-layout/content scale proves it.
 
 ## Builder interpretation rules
 
@@ -70,7 +72,7 @@ When asked to build a new app or data architecture:
 5. Preserve external sync handles for WebDAV, CalDAV, CardDAV, payment, accounting, and forge integrations.
 6. Verify one complete path: object → permission → workflow → audit → import/export or sync.
 
-Read order for full app/data design: `monorepo-app-stack.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `operations-jobs-scheduling.md` → `api-service-contracts.md` → `identity-security-lifecycle.md` → `data-protection-sync-scale.md` → `data-history-relationships.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
+Read order for full app/data design: `monorepo-app-stack.md` → `public-site-surfaces.md` → `workspace-model.md` → `database-foundation.md` → `platform-kernel.md` → `operations-jobs-scheduling.md` → `api-service-contracts.md` → `identity-security-lifecycle.md` → `data-protection-sync-scale.md` → `data-history-relationships.md` → `standard-objects.md` → `rbac-permissions.md` → `workflow-architecture.md` → `metadata-architecture.md` → `migration-layout.md`.
 
 ## Related docs
 

--- a/.agents/tools/app-stack/api-service-contracts.md
+++ b/.agents/tools/app-stack/api-service-contracts.md
@@ -64,6 +64,15 @@ Rules:
 - Outbound webhooks use `outbox_events`, retry/backoff, delivery logs, and operator replay controls.
 - Webhook payloads use public contract DTOs, not internal table shape.
 
+## Public developer surfaces
+
+- `/api` explains API status, base URLs, auth, versioning, rate limits, SDKs, schemas, and support.
+- API reference should be generated from OpenAPI/RPC metadata when possible; prose docs cover concepts and examples.
+- `/mcp` documents MCP server URL, tool catalog, auth/scopes, safety rules, and agent examples when an MCP server exists.
+- `/cli` documents CLI install, auth, command groups, examples, updates, and support when a CLI exists.
+- MCP and CLI integrations use the same service contracts, permissions, audit, rate limits, and idempotency rules as the API.
+- Keep `/api`, `/mcp`, and `/cli` stable even if they redirect to docs sections.
+
 ## Package defaults
 
 - `packages/api` owns route adapters, transport-specific middleware, API DTOs, and OpenAPI/RPC metadata.
@@ -76,4 +85,5 @@ Rules:
 - Trace one list route through filter validation, RLS/RBAC, cursor pagination, field expansion, and response DTO.
 - Trace one mutation through idempotency key, validation, service call, audit event, outbox/job enqueue, and response.
 - Trace one webhook from signature validation to persisted event, dedupe, job processing, retry, and delivery log.
+- Confirm `/api`, `/mcp`, and `/cli` pages match implemented endpoints, tools, auth, scopes, and examples.
 - Confirm errors are stable, documented, retry-aware, and do not leak internals or secrets.

--- a/.agents/tools/app-stack/api-service-contracts.md
+++ b/.agents/tools/app-stack/api-service-contracts.md
@@ -1,0 +1,79 @@
+---
+description: API, service, validation, error, pagination, idempotency, and webhook contract standards for app backends
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# API and Service Contracts
+
+APIs are product contracts. Standardise request/response shapes, validation, errors, pagination, filtering, idempotency, and service boundaries before adding many endpoints.
+
+## Contract objects
+
+| Object | Purpose |
+|--------|---------|
+| `api_clients` | Registered internal/external clients, owner, scopes, rate limits, enabled state |
+| `api_keys` | Hashed key records, prefix, scopes, expiry, last used, rotation state |
+| `service_accounts` | Non-human actor used by integrations, automations, jobs, and imports |
+| `idempotency_keys` | Request key, actor/client, operation, request hash, result reference, expiry |
+| `api_request_logs` | Minimal request audit: actor, route, status, duration, target, correlation ID |
+| `error_events` | Normalised operational/application errors with severity, fingerprint, and owner |
+
+Rules:
+
+- Shared validation schemas live in domain/API packages and run at API and service boundaries.
+- Prefer typed service functions for app code; HTTP/RPC routes adapt transport to service contracts.
+- Do not expose database rows directly. Use DTOs with explicit field privacy and expansion rules.
+- Mutating endpoints need idempotency for external clients, retries, imports, webhooks, and payment-like operations.
+- Request logs must minimise payload data and redact secrets, tokens, private URLs, and sensitive fields.
+
+## Route and DTO conventions
+
+| Concern | Standard |
+|---------|----------|
+| Identity | Stable ID in URLs; slugs/paths are routing helpers, not identity |
+| Pagination | Cursor pagination by default for large/mutable collections; offset only for small/admin lists |
+| Filtering | Typed filter schema; no raw SQL/filter expressions from clients |
+| Sorting | Allowlist sort fields and deterministic tie-breaker by stable ID |
+| Field selection | Explicit includes/expands; apply RBAC/RLS and field privacy after expansion |
+| Errors | Stable error code, message, details, correlation ID, retryability, documentation key |
+| Versioning | Version breaking contracts; keep service/domain internals separately evolvable |
+
+Rules:
+
+- List APIs return `items`, `pageInfo`, applied filters/sort, and permission-aware counts only when counts are cheap/safe.
+- Write APIs return the canonical saved object, revision/version, and audit/provenance reference when useful.
+- Validation errors identify field paths and machine-readable reason codes.
+- Use correlation IDs through API, jobs, workflows, outbox events, logs, and audit events.
+
+## Webhook and integration contracts
+
+| Object | Purpose |
+|--------|---------|
+| `webhooks` | Endpoint/subscription definition, events, target, signing, enabled state |
+| `webhook_events` | Inbound/outbound event metadata, status, attempts, dedupe key, next attempt |
+| `webhook_deliveries` | Delivery attempts with status, response summary, latency, retry time |
+| `event_subscriptions` | Internal event subscribers and filters for jobs, search, sync, and automation |
+
+Rules:
+
+- Use signed webhook payloads, timestamp tolerance, replay protection, and event IDs.
+- Persist incoming events before processing and dedupe by provider/event/scope.
+- Outbound webhooks use `outbox_events`, retry/backoff, delivery logs, and operator replay controls.
+- Webhook payloads use public contract DTOs, not internal table shape.
+
+## Package defaults
+
+- `packages/api` owns route adapters, transport-specific middleware, API DTOs, and OpenAPI/RPC metadata.
+- `packages/domain` owns service contracts, business validation, permissions orchestration, and error taxonomy.
+- `packages/sdk` owns typed clients and generated/handwritten API helpers for web/mobile/desktop/extension surfaces.
+- `packages/db` stays behind repositories/services; UI and SDK code do not import DB schema directly.
+
+## Verification
+
+- Trace one list route through filter validation, RLS/RBAC, cursor pagination, field expansion, and response DTO.
+- Trace one mutation through idempotency key, validation, service call, audit event, outbox/job enqueue, and response.
+- Trace one webhook from signature validation to persisted event, dedupe, job processing, retry, and delivery log.
+- Confirm errors are stable, documented, retry-aware, and do not leak internals or secrets.

--- a/.agents/tools/app-stack/data-history-relationships.md
+++ b/.agents/tools/app-stack/data-history-relationships.md
@@ -1,0 +1,86 @@
+---
+description: Change history, diffs, duplicate-record merges, and relationship cardinality for app data models
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Data History and Relationships
+
+Most business apps eventually need record history, user-readable diffs, duplicate merges, and configurable relationships. Model these as shared platform primitives instead of per-object one-offs.
+
+## Change history and diffs
+
+| Object | Purpose |
+|--------|---------|
+| `record_revisions` | User-restorable revision for one entity: entity ref, version, actor, source, reason, timestamp |
+| `record_revision_fields` | Field-level before/after values, diff metadata, redaction/sensitivity markers |
+| `record_snapshots` | Optional full snapshot for rich documents, JSON-heavy records, or restore checkpoints |
+| `change_events` | Low-level change stream for sync, search indexing, automation, cache invalidation |
+| `audit_events` | Immutable security/business ledger with actor, action, entity, summary, and reason |
+
+Rules:
+
+- Use `audit_events` for accountability; use `record_revisions` when users need compare, restore, or revision browsing.
+- Store structured field diffs for normal entity fields. Store patch/snapshot formats for rich text, block content, JSON, or binary-derived metadata.
+- Keep full before/after values behind privacy controls; redact or hash sensitive fields when a diff is enough for accountability.
+- Link revisions to workflow runs, imports, merge jobs, sync runs, and external events so the source of a change is explainable.
+- Content objects can keep specialised `content_revisions`, but the same actor/source/reason/diff rules apply.
+
+## Duplicate-record merge model
+
+| Object | Purpose |
+|--------|---------|
+| `dedupe_candidates` | Potential duplicate group with confidence, evidence, status, and reviewer |
+| `merge_jobs` | Merge execution request: survivor entity, source entities, state, actor, approval, timestamps |
+| `merge_plans` | Draft/final plan containing selected survivor, field choices, relationship choices, and validation result |
+| `merge_field_choices` | Per-field decision: keep survivor value, take source value, combine, clear, or set manual value |
+| `merge_relationship_choices` | Per-relationship decision: move, copy, ignore, dedupe, preserve as related, or flag conflict |
+| `merge_events` | Append-only merge lifecycle events and audit/provenance references |
+| `entity_aliases` | Redirect/tombstone rows so old IDs, external IDs, URLs, and imports resolve to the survivor |
+
+Rules:
+
+- Merges are planned, validated, then executed; do not perform irreversible row rewrites directly from a duplicate suggestion.
+- The merge plan must choose values field-by-field and relationships relationship-by-relationship.
+- Validate unique constraints, required fields, RLS/RBAC, workflow state, legal hold, retention policy, and external sync constraints before execution.
+- Preserve provenance from every merged source. Link source records, source field values, evidence, reviewer, and merge reason.
+- Prefer tombstone/alias rows over hard delete so imports, URLs, audit logs, and external IDs can resolve historical references.
+- Relationship merges need a conflict policy: move links to the survivor, copy links, dedupe equivalent links, preserve source as related, or require manual review.
+- Human approval is the default for customer, financial, identity, legal, or high-impact merges; automation can suggest and prefill plans.
+
+## Relationship definitions and cardinality
+
+| Object | Purpose |
+|--------|---------|
+| `relationship_definitions` | Source entity, target entity, cardinality, direction, inverse label, requiredness, lifecycle |
+| `relationship_type_definitions` | Governed relationship names such as parent, owner, member, blocks, duplicates, supplier |
+| `entity_relationships` | Generic runtime link rows for configurable or cross-object relationships |
+| `relationship_attributes` | Optional metadata on a relationship: role, dates, status, weight, source, confidence |
+| `relationship_events` | Append-only create/update/delete/merge events for relationship history |
+
+Cardinality rules:
+
+- `one_to_one`: use a unique foreign key or a link table with unique source and target constraints.
+- `one_to_many`: use a foreign key on the many/child side; expose the inverse collection as a view/query.
+- `many_to_one`: same physical shape as one-to-many, documented from the child/source perspective.
+- `many_to_many`: use a join/link table with a unique source/target pair and relationship metadata columns when needed.
+- Polymorphic relationships use `entity_type` + `entity_id` only when configurability matters more than database-enforced foreign keys.
+- Use typed join tables for high-volume, referentially critical, permission-critical, or heavily indexed relationships.
+
+Definition rules:
+
+- Define source/target entity, cardinality, inverse name, labels, sort order, ownership, delete/cascade behaviour, and permission inheritance explicitly.
+- Do not let a relationship imply permission inheritance unless the product models and tests inheritance.
+- Distinguish relationship type from label/tag: relationship types connect records; labels classify records.
+- Store external relationship IDs and sync handles at the integration edge, not as primary keys.
+- For symmetric relationships, define canonical ordering and inverse labels so duplicate links cannot be created in reverse order.
+
+## Verification
+
+- Trace one edit through `record_revisions`, field diff, audit event, workflow/import/source reference, and restore/compare UI.
+- Trace one duplicate merge from candidate evidence to reviewed merge plan, field choices, relationship choices, alias/tombstone, audit, and external sync repair.
+- Prove one `one_to_one`, `one_to_many`, `many_to_one`, and `many_to_many` relationship with database constraints and UI labels.
+- Confirm relationship reads/writes obey RBAC/RLS and do not inherit permissions unless explicitly configured.
+- Confirm merge and revision history follow retention, redaction, legal hold, and export policies.

--- a/.agents/tools/app-stack/data-protection-sync-scale.md
+++ b/.agents/tools/app-stack/data-protection-sync-scale.md
@@ -1,0 +1,92 @@
+---
+description: Data classification, privacy, offline sync, conflict handling, read models, performance, and test/demo data standards
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Data Protection, Sync, and Scale
+
+New apps need privacy, sync, performance, and test data rules before growth makes them expensive to retrofit.
+
+## Data classification and privacy
+
+| Object | Purpose |
+|--------|---------|
+| `data_classifications` | Public/internal/confidential/restricted labels and handling rules |
+| `field_sensitivity_rules` | Entity/field sensitivity, masking, export, AI exposure, retention policy |
+| `consent_records` | User/customer consent purpose, source, status, expiry, withdrawal |
+| `privacy_requests` | Access/export/delete/redact orchestration request and fulfilment state |
+| `redaction_events` | Irreversible or reversible redaction with actor, reason, target, evidence |
+| `data_exports` | Privacy/user/admin export metadata linking to export jobs/files, scope, expiry, sensitivity |
+
+Rules:
+
+- Classify fields at schema/metadata level, then enforce in API DTOs, exports, logs, AI prompts, search, analytics, and support tools.
+- Redact or hash sensitive values in diffs, logs, job payloads, search history, and error reports.
+- Export and delete requests need permission checks, retention/legal-hold checks, audit events, and expiry.
+- `privacy_requests` orchestrate `export_jobs`, `deletion_requests`, `redaction_events`, and `data_exports`; they do not replace those execution records.
+- AI exposure is explicit allow/deny metadata, not an afterthought.
+
+## Offline sync and conflict handling
+
+| Object | Purpose |
+|--------|---------|
+| `sync_clients` | Device/app/client installation, actor, workspace, version, last seen |
+| `sync_cursors` | Per-client/provider/entity checkpoint for incremental sync |
+| `change_events` | Ordered changes used for replication, cache invalidation, and search updates |
+| `offline_mutations` | Client-originated writes queued for server validation/replay |
+| `conflict_records` | Conflicting changes, detected policy, chosen resolution, reviewer |
+| `tombstones` | Deleted/merged records retained for sync, imports, aliases, and audit references |
+| `replication_batches` | Sync batch request/result, counts, duration, errors |
+
+Rules:
+
+- Choose conflict policy per entity/field: server wins, client wins, last writer wins, merge, or manual review.
+- Use stable IDs and revision/version checks for offline writes; never trust stale client state for privileged fields.
+- Tombstones outlive cache rows long enough for all sync clients and external providers to observe deletes/merges.
+- Local-first caches reuse canonical schema where practical, but server validation remains authoritative.
+
+## Read models and performance
+
+| Object | Purpose |
+|--------|---------|
+| `read_models` | Derived tables/views for dashboard, list, report, or API read paths |
+| `materialized_views` | Refreshable aggregate/query projections with freshness metadata |
+| `counter_caches` | Denormalised counts/sums with source event and repair strategy |
+| `analytics_events` | Product/business events separated from audit/security events |
+| `partition_policies` | Partition/archive strategy by entity, time, workspace, or retention class |
+| `query_budgets` | Expected latency/row-count/index assumptions for critical paths |
+
+Rules:
+
+- Source tables remain authoritative; read models must declare source events, rebuild path, freshness, and repair command.
+- Add indexes from query plans and access patterns, not speculative field lists.
+- Counters and aggregates need reconciliation jobs and visible freshness metadata.
+- Analytics events must respect consent, privacy, retention, and workspace boundaries.
+
+## Test, seed, and demo data
+
+| Object | Purpose |
+|--------|---------|
+| `seed_scenarios` | Named dataset scenario: minimal, demo, load, integration, regression |
+| `fixture_sets` | Deterministic records for unit/integration tests |
+| `demo_workspaces` | Public-safe sample workspaces with synthetic accounts/users/content |
+| `data_masks` | Rules for transforming production-like data into safe test/demo data |
+| `migration_smoke_tests` | Post-migration assertions for schema, seed, permissions, and critical queries |
+
+Rules:
+
+- Demo and test data must be synthetic or masked; never depend on private customer/source rows.
+- Seed scripts are idempotent, environment-aware, and safe to rerun locally.
+- Every standard object pack should have at least one fixture path through create/read/update/delete, permissions, audit, and export.
+- Load/performance fixtures should include realistic relationship depth, search volume, job queues, and archival/retention edges.
+
+## Verification
+
+- Trace one sensitive field through schema metadata, API response, export, log, search, AI prompt, and redaction path.
+- Trace one offline edit through client mutation, server validation, conflict policy, change event, and sync cursor advance.
+- Trace one dashboard/read model from source write to projection update, freshness display, rebuild, and permission check.
+- Prove one critical query budget with query plan/index evidence, partition/archive path, and counter reconciliation job.
+- Trace one seed scenario from clean database to deterministic test assertions without private data.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -31,8 +31,8 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 
 - `workspaces`, memberships, teams/user groups, roles, role assignments, invitations, settings.
 - `users` / auth identity mapping.
-- `audit_events`, `activity_events`, comments, notifications.
-- `files`, folders, attachments, labels/tags, imports, exports.
+- `audit_events`, `activity_events`, entity-scoped conversation messages, notifications.
+- `files`, folders, file links, labels/tags, imports, exports.
 - `integrations`, external IDs, sync cursors.
 - Platform kernel objects for search/history, saved views, reports, forms, dashboards, jobs, webhooks, feature flags, localisation, and retention; see `app-stack/platform-kernel.md`.
 
@@ -40,10 +40,10 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 
 - `issues` with forge-compatible fields: title, body, state, type, priority, assignee, labels, milestones, parent/related issues, external provider IDs.
 - Content: content types, entries, pages/routes, revisions, blocks, taxonomies, terms, menus, redirects, SEO metadata.
-- Conversations: conversation groups, channel/direct/group/entity conversation types, messages, threads, reactions, mentions, read receipts, attachments.
+- Conversations: conversation groups, channel/direct/group/entity conversation types, messages, threads, reactions, mentions, read receipts, message attachments.
 - Calendar/CRM activities: calendar collections, activity types such as calls/meetings/tasks, participants, alarms/reminders, recurrence, calendar/timeline links.
 - Workflows: definitions, states, transitions, guards, actions, runs/events, timers, decisions, approvals.
-- Tasks, milestones, comments, activity streams.
+- Tasks, milestones, entity-scoped conversation messages, activity streams.
 - Issue relationships: blocks, duplicates, relates-to, split-from, supersedes.
 
 ### Business relationship pack

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -38,6 +38,7 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 ### Collaboration and work pack
 
 - `issues` with forge-compatible fields: title, body, state, type, priority, assignee, labels, milestones, parent/related issues, external provider IDs.
+- Content: content types, entries, pages/routes, revisions, blocks, taxonomies, terms, menus, redirects, SEO metadata.
 - Conversations: conversation groups, channel/direct/group/entity conversation types, messages, threads, reactions, mentions, read receipts, attachments.
 - Calendar/CRM activities: calendar collections, activity types such as calls/meetings/tasks, participants, alarms/reminders, recurrence, calendar/timeline links.
 - Workflows: definitions, states, transitions, guards, actions, runs/events, timers, decisions, approvals.
@@ -60,6 +61,7 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - CRM: leads, opportunities, campaigns, cases, referrers, referrals.
 - Commercial: products/items, services, prices, price lists, discount/voucher codes, quotes/estimates, orders.
 - Accounting: invoices, pro-forma invoices, credit notes, bills, payments, refund payments, payment allocations, `ledger_accounts` / `chart_accounts`, ledger entries, tax codes.
+- Content/editorial: content entries, publishing workflows, navigation, taxonomies, forms, search indexes.
 - Inventory: items, stock movements, locations.
 - Projects: projects, tasks, milestones, time entries.
 - Collaboration: threads, decisions, approvals.
@@ -98,5 +100,5 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - Draw the object graph before writing migrations.
 - Identify every table's workspace boundary and RLS policy.
 - Confirm `accounts` and `contacts` cover imported synonyms before adding new party/person tables.
-- Confirm issues, conversations/channels/chats, workflows/approvals, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
+- Confirm issues, content/pages, conversations/channels/chats, workflows/approvals, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
 - Run Drizzle generate/migrate checks and inspect generated SQL.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -34,6 +34,7 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - `audit_events`, `activity_events`, comments, notifications.
 - `files`, folders, attachments, labels/tags, imports, exports.
 - `integrations`, external IDs, sync cursors.
+- Platform kernel objects for search/history, saved views, reports, forms, dashboards, jobs, webhooks, feature flags, localisation, and retention; see `app-stack/platform-kernel.md`.
 
 ### Collaboration and work pack
 

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -32,13 +32,15 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - `workspaces`, memberships, teams/user groups, roles, role assignments, invitations, settings.
 - `users` / auth identity mapping.
 - `audit_events`, `activity_events`, comments, notifications.
-- `files`, attachments, labels/tags, imports, exports.
+- `files`, folders, attachments, labels/tags, imports, exports.
 - `integrations`, external IDs, sync cursors.
 
 ### Collaboration and work pack
 
 - `issues` with forge-compatible fields: title, body, state, type, priority, assignee, labels, milestones, parent/related issues, external provider IDs.
-- Tasks, milestones, comments, activity streams, mentions, attachments, decisions, approvals.
+- Channels, channel groups, chats, messages, threads, reactions, mentions, read receipts, attachments.
+- Activities: calls, meetings, tasks, reminders, participants, calendar/timeline links.
+- Tasks, milestones, comments, activity streams, decisions, approvals.
 - Issue relationships: blocks, duplicates, relates-to, split-from, supersedes.
 
 ### Business relationship pack
@@ -65,7 +67,8 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 ## Universal labels/tags
 
 - Make labels/tags available to all user-facing object types through a shared assignment model.
-- Use governed `labels` plus `label_assignments` for workflow, reporting, permissions, and sync.
+- Use governed `label_groups`, `labels`, and `label_assignments` for grouping, workflow, reporting, permissions, and sync.
+- Use grouped keys such as `status:normal`, `priority:high`, and `type:support`; make groups exclusive per entity when only one value is valid.
 - Use free-form array tags only for local, low-risk filtering or imported metadata.
 - Prefer typed join tables for high-volume or referentially critical objects.
 
@@ -93,5 +96,5 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - Draw the object graph before writing migrations.
 - Identify every table's workspace boundary and RLS policy.
 - Confirm `accounts` and `contacts` cover imported synonyms before adding new party/person tables.
-- Confirm issues, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
+- Confirm issues, channels/chats, CRM activities, files/folders, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
 - Run Drizzle generate/migrate checks and inspect generated SQL.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -29,12 +29,13 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 
 ### Always-on kernel
 
-- `workspaces`, memberships, teams/user groups, roles, role assignments, invitations, settings.
+- `workspaces`, memberships, teams/user groups, roles, role assignments, workspace invitations, settings.
 - `users` / auth identity mapping.
 - `audit_events`, `activity_events`, `record_revisions`, entity-scoped conversation messages, notifications.
 - `files`, folders, file links, labels/tags, imports, exports.
 - `integrations`, external IDs, sync cursors.
 - `relationship_definitions`, `entity_relationships`, `dedupe_candidates`, `merge_jobs`, and aliases/tombstones.
+- API clients/keys, idempotency keys, service accounts, security events, data classifications, sync clients, conflicts, read models, and seed scenarios.
 - Platform kernel objects for search/history, saved views, reports, forms, dashboards, jobs, webhooks, feature flags, localisation, and retention; see `app-stack/platform-kernel.md`.
 
 ### Collaboration and work pack

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -8,7 +8,7 @@ mode: subagent
 
 # Database Foundation
 
-Default to Postgres + Drizzle for durable application data. Add RLS when records are scoped by workspace, organisation, account, or user.
+Default to Postgres + Drizzle for durable application data. `workspace_id` is the default tenancy and RLS root; organisation, account, and user scopes are ownership/domain filters unless explicitly promoted to tenancy roots.
 
 ## Naming doctrine
 
@@ -40,7 +40,8 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - `issues` with forge-compatible fields: title, body, state, type, priority, assignee, labels, milestones, parent/related issues, external provider IDs.
 - Conversations: conversation groups, channel/direct/group/entity conversation types, messages, threads, reactions, mentions, read receipts, attachments.
 - Calendar/CRM activities: calendar collections, activity types such as calls/meetings/tasks, participants, alarms/reminders, recurrence, calendar/timeline links.
-- Tasks, milestones, comments, activity streams, decisions, approvals.
+- Workflows: definitions, states, transitions, guards, actions, runs/events, timers, decisions, approvals.
+- Tasks, milestones, comments, activity streams.
 - Issue relationships: blocks, duplicates, relates-to, split-from, supersedes.
 
 ### Business relationship pack
@@ -52,13 +53,13 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 ### Metadata pack
 
 - Entity definitions, field definitions, layouts, views, filters.
-- Labels, ACL/RBAC policies, capability definitions, workflow definitions, automations, validation rules.
+- Labels, ACL/RBAC policies, capability definitions, workflow/state/transition definitions, automations, validation rules.
 
 ### Optional packs
 
 - CRM: leads, opportunities, campaigns, cases, referrers, referrals.
 - Commercial: products/items, services, prices, price lists, discount/voucher codes, quotes/estimates, orders.
-- Accounting: invoices, pro-forma invoices, credit notes, bills, payments, refund payments, payment allocations, ledger entries, tax codes.
+- Accounting: invoices, pro-forma invoices, credit notes, bills, payments, refund payments, payment allocations, `ledger_accounts` / `chart_accounts`, ledger entries, tax codes.
 - Inventory: items, stock movements, locations.
 - Projects: projects, tasks, milestones, time entries.
 - Collaboration: threads, decisions, approvals.
@@ -88,6 +89,7 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 
 - Scope tables by `workspace_id` where possible.
 - Use membership/role tables for policy checks.
+- Treat RBAC scope `all` as all records in the current workspace; platform-global access is a separate system capability.
 - Add external IDs per integration, not as primary keys.
 - Audit writes with actor, workspace, entity type, entity ID, action, and diff summary.
 
@@ -96,5 +98,5 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - Draw the object graph before writing migrations.
 - Identify every table's workspace boundary and RLS policy.
 - Confirm `accounts` and `contacts` cover imported synonyms before adding new party/person tables.
-- Confirm issues, conversations/channels/chats, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
+- Confirm issues, conversations/channels/chats, workflows/approvals, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
 - Run Drizzle generate/migrate checks and inspect generated SQL.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -100,5 +100,5 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - Draw the object graph before writing migrations.
 - Identify every table's workspace boundary and RLS policy.
 - Confirm `accounts` and `contacts` cover imported synonyms before adding new party/person tables.
-- Confirm issues, content/pages, conversations/channels/chats, workflows/approvals, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
+- Confirm issues, content/pages, slugs/routes, parent-child hierarchy, conversations/channels/chats, workflows/approvals, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
 - Run Drizzle generate/migrate checks and inspect generated SQL.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -29,11 +29,17 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 
 ### Always-on kernel
 
-- `workspaces`, memberships, roles, invitations, settings.
+- `workspaces`, memberships, teams/user groups, roles, role assignments, invitations, settings.
 - `users` / auth identity mapping.
 - `audit_events`, `activity_events`, comments, notifications.
-- `files`, attachments, imports, exports.
+- `files`, attachments, labels/tags, imports, exports.
 - `integrations`, external IDs, sync cursors.
+
+### Collaboration and work pack
+
+- `issues` with forge-compatible fields: title, body, state, type, priority, assignee, labels, milestones, parent/related issues, external provider IDs.
+- Tasks, milestones, comments, activity streams, mentions, attachments, decisions, approvals.
+- Issue relationships: blocks, duplicates, relates-to, split-from, supersedes.
 
 ### Business relationship pack
 
@@ -44,16 +50,36 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 ### Metadata pack
 
 - Entity definitions, field definitions, layouts, views, filters.
-- ACL policies, workflow definitions, automations, validation rules.
+- Labels, ACL/RBAC policies, capability definitions, workflow definitions, automations, validation rules.
 
 ### Optional packs
 
-- CRM: leads, opportunities, campaigns, cases.
-- Accounting: invoices, bills, payments, ledger entries, tax codes.
+- CRM: leads, opportunities, campaigns, cases, referrers, referrals.
+- Commercial: products/items, services, prices, price lists, discount/voucher codes, quotes/estimates, orders.
+- Accounting: invoices, pro-forma invoices, credit notes, bills, payments, refund payments, payment allocations, ledger entries, tax codes.
 - Inventory: items, stock movements, locations.
 - Projects: projects, tasks, milestones, time entries.
 - Collaboration: threads, decisions, approvals.
 - AI: prompts, runs, tool calls, memory references, evaluations.
+
+## Universal labels/tags
+
+- Make labels/tags available to all user-facing object types through a shared assignment model.
+- Use governed `labels` plus `label_assignments` for workflow, reporting, permissions, and sync.
+- Use free-form array tags only for local, low-risk filtering or imported metadata.
+- Prefer typed join tables for high-volume or referentially critical objects.
+
+## Access model defaults
+
+- Keep teams/user groups distinct from roles: teams group people; roles grant capabilities.
+- Use RBAC permission rules across users, teams, roles, objects, panels, fields, workflows, and scopes.
+- Model common scopes as `own`, `team`, `workspace`, and `all`, with workspace RLS as the database backstop.
+
+## Migration home
+
+- In TypeScript monorepos, `packages/db` owns schemas, relations, seeds, migration helpers, and `migrations/`.
+- Use `packages/db/src/schema/index.ts` as the Drizzle schema entrypoint and `packages/db/migrations/` for generated SQL and metadata snapshots.
+- See `app-stack/migration-layout.md` for the full layout.
 
 ## RLS defaults
 
@@ -67,4 +93,5 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - Draw the object graph before writing migrations.
 - Identify every table's workspace boundary and RLS policy.
 - Confirm `accounts` and `contacts` cover imported synonyms before adding new party/person tables.
+- Confirm issues, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
 - Run Drizzle generate/migrate checks and inspect generated SQL.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -38,8 +38,8 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 ### Collaboration and work pack
 
 - `issues` with forge-compatible fields: title, body, state, type, priority, assignee, labels, milestones, parent/related issues, external provider IDs.
-- Channels, channel groups, chats, messages, threads, reactions, mentions, read receipts, attachments.
-- Activities: calls, meetings, tasks, reminders, participants, calendar/timeline links.
+- Conversations: conversation groups, channel/direct/group/entity conversation types, messages, threads, reactions, mentions, read receipts, attachments.
+- Calendar/CRM activities: calendar collections, activity types such as calls/meetings/tasks, participants, alarms/reminders, recurrence, calendar/timeline links.
 - Tasks, milestones, comments, activity streams, decisions, approvals.
 - Issue relationships: blocks, duplicates, relates-to, split-from, supersedes.
 
@@ -96,5 +96,5 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 - Draw the object graph before writing migrations.
 - Identify every table's workspace boundary and RLS policy.
 - Confirm `accounts` and `contacts` cover imported synonyms before adding new party/person tables.
-- Confirm issues, channels/chats, CRM activities, files/folders, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
+- Confirm issues, conversations/channels/chats, calendar/CRM activities, WebDAV-style files/folders, CardDAV-style contacts/address books, labels/tags, users, teams, roles, prices, quotes, invoices, payments, credits, and refunds are either implemented or intentionally out of scope.
 - Run Drizzle generate/migrate checks and inspect generated SQL.

--- a/.agents/tools/app-stack/database-foundation.md
+++ b/.agents/tools/app-stack/database-foundation.md
@@ -31,9 +31,10 @@ Keep synonyms at the import/integration edge instead of making them canonical ta
 
 - `workspaces`, memberships, teams/user groups, roles, role assignments, invitations, settings.
 - `users` / auth identity mapping.
-- `audit_events`, `activity_events`, entity-scoped conversation messages, notifications.
+- `audit_events`, `activity_events`, `record_revisions`, entity-scoped conversation messages, notifications.
 - `files`, folders, file links, labels/tags, imports, exports.
 - `integrations`, external IDs, sync cursors.
+- `relationship_definitions`, `entity_relationships`, `dedupe_candidates`, `merge_jobs`, and aliases/tombstones.
 - Platform kernel objects for search/history, saved views, reports, forms, dashboards, jobs, webhooks, feature flags, localisation, and retention; see `app-stack/platform-kernel.md`.
 
 ### Collaboration and work pack

--- a/.agents/tools/app-stack/identity-security-lifecycle.md
+++ b/.agents/tools/app-stack/identity-security-lifecycle.md
@@ -1,0 +1,71 @@
+---
+description: Identity, authentication, sessions, service accounts, API keys, impersonation, and security event standards
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Identity and Security Lifecycle
+
+Keep identity separate from workspace membership, roles, contacts, and accounts. Standardise human users, service actors, sessions, keys, workspace invitations, recovery, impersonation, and security audit from the start.
+
+## Identity objects
+
+| Object | Purpose |
+|--------|---------|
+| `users` | Global human identity/profile used for login and ownership |
+| `auth_accounts` | Provider-specific login account: password, OAuth/OIDC, SAML, LDAP, magic link |
+| `sessions` | Active session/device/browser, expiry, IP/user-agent summary, revocation state |
+| `auth_tokens` | Refresh/recovery/verification tokens stored hashed with purpose and expiry |
+| `passkeys` | WebAuthn/passkey credentials, device label, counter, last used |
+| `mfa_factors` | MFA methods, verified state, recovery codes, last challenge |
+| `password_change_requests` | Recovery/change request metadata without raw token values |
+
+Rules:
+
+- Users are identity records; workspace memberships/roles grant access; contacts represent people in the business domain.
+- Store token hashes and secret references, never raw tokens, recovery codes, or provider secrets.
+- Auth logs and action history should capture enough evidence for security review while minimising raw IP/session data.
+- Sensitive auth state changes require audit events and user/admin notification where appropriate.
+
+## Access actors
+
+| Object | Purpose |
+|--------|---------|
+| `workspace_memberships` | User-to-workspace membership, state, invited/accepted timestamps |
+| `workspace_invitations` | Invite target, role/team defaults, expiry, acceptance state, inviter |
+| `service_accounts` | Non-human actor for integrations, automations, imports, and jobs |
+| `api_keys` | Hashed key credentials attached to user/client/service account with scopes |
+| `oauth_connections` | User/workspace external OAuth connection metadata and secret references |
+| `impersonation_sessions` | Admin/support access session with reason, approver, target user, expiry |
+
+Rules:
+
+- Service accounts need owner, purpose, scopes, rotation policy, last used, and disable path.
+- API keys are scoped, expiring, rotatable, prefix-identifiable, and never shown after creation.
+- Impersonation requires explicit reason, least privilege, visible audit trail, and optional user notification.
+- Workspace invitations are not accounts; acceptance creates or links identity, then creates membership.
+
+## Security events and policy
+
+| Object | Purpose |
+|--------|---------|
+| `security_events` | Login, logout, MFA, key creation, privilege change, suspicious access, lockout |
+| `auth_log_events` | Authentication attempt/result with actor/provider/client/IP summary |
+| `policy_rules` | Password/session/MFA/API-key policy by system/workspace/plan |
+| `risk_assessments` | Optional risk score and reason for auth/session/API events |
+
+Rules:
+
+- Security events are append-only, access-controlled, retention-aware, and excluded from casual exports.
+- Privilege changes link to actor, affected user/team/role, reason, approval, and before/after summary.
+- Use consistent lifecycle states: pending, active, suspended, disabled, expired, revoked.
+- Field-level privacy and AI exposure rules apply to identity/security data by default.
+
+## Verification
+
+- Trace invite acceptance through identity/account linking, workspace membership, role assignment, audit, and notification.
+- Trace API-key creation, one authenticated request, rotation, revocation, and audit/security event.
+- Trace session creation, MFA challenge, logout/revocation, and stale session cleanup.
+- Trace support impersonation from approval/reason to scoped session, audit event, and user-visible evidence.

--- a/.agents/tools/app-stack/metadata-architecture.md
+++ b/.agents/tools/app-stack/metadata-architecture.md
@@ -20,7 +20,8 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 | `layout_definitions` | Detail/edit/create/list layouts and panels |
 | `panel_definitions` | Relationship/admin/dashboard panels and visibility rules |
 | `view_definitions` | Saved filters, columns, sorting, grouping |
-| `label_definitions` | Governed labels available across entity types |
+| `label_group_definitions` | Label namespaces/categories such as status, priority, type |
+| `label_definitions` | Governed labels available across entity types, e.g. `status:normal` |
 | `capability_definitions` | Named product actions beyond CRUD |
 | `permission_rules` | Role/user/team/workspace/entity/field/panel/action permissions |
 | `workflow_definitions` | States, transitions, guards, actions, timers |
@@ -36,7 +37,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 - Keep validation close to field definitions and enforce again at API/database boundaries.
 - Model layouts separately from fields so the same entity can have role/context-specific views.
 - Model panels separately from layouts so related lists, admin panels, and dashboards can have independent permissions.
-- Make labels/tags a first-class metadata concern for every user-facing entity.
+- Make labels/tags a first-class metadata concern for every user-facing entity; model label groups, exclusivity, display order, colour, and scope.
 - Keep roles, teams, capabilities, and permission rules separate so teams do not become roles.
 - Make workflows explicit: state, transition, actor, guard, side effects.
 - Preserve import provenance: source, source row ID/hash, mapping version, confidence, reviewer.
@@ -50,7 +51,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 ## Verification
 
 - Demonstrate one entity from definition to list view, detail layout, edit validation, ACL, workflow transition, audit event, and export.
-- Demonstrate one label assignment and one issue relationship if the app exposes work tracking.
+- Demonstrate one grouped label assignment such as `status:normal` and one issue relationship if the app exposes work tracking.
 - Confirm field-level privacy and AI exposure rules.
 - Confirm role/team permission behaviour for object, panel, field, and workflow actions.
 - Confirm imports can be replayed or explained with provenance.

--- a/.agents/tools/app-stack/metadata-architecture.md
+++ b/.agents/tools/app-stack/metadata-architecture.md
@@ -16,7 +16,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 |--------|---------|
 | `entity_definitions` | Entity key, label, table/source, ownership, lifecycle |
 | `field_definitions` | Field key, type, validation, display, indexing, privacy |
-| `relationship_definitions` | One-to-many, many-to-many, polymorphic references |
+| `relationship_definitions` | One-to-one, one-to-many, many-to-one, many-to-many, and polymorphic references |
 | `layout_definitions` | Detail/edit/create/list layouts and panels |
 | `panel_definitions` | Relationship/admin/dashboard panels and visibility rules |
 | `view_definitions` | Template/default list, detail, and search views; runtime saved views live in `saved_views` |
@@ -43,6 +43,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 - Keep validation close to field definitions and enforce again at API/database boundaries.
 - Model layouts separately from fields so the same entity can have role/context-specific views.
 - Model panels separately from layouts so related lists, admin panels, and dashboards can have independent permissions.
+- Model relationships with explicit source, target, cardinality, inverse label, requiredness, delete behaviour, and permission inheritance policy.
 - Make labels/tags a first-class metadata concern for every user-facing entity; model label groups, exclusivity, display order, colour, and scope.
 - Use content type definitions for configurable editorial/domain content; use migrations for core content tables and route ownership.
 - Keep roles, teams, capabilities, and permission rules separate so teams do not become roles.
@@ -60,6 +61,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 - Demonstrate one entity from definition to list view, detail layout, edit validation, ACL, workflow transition, audit event, and export.
 - Demonstrate one workflow definition through state, transition, guard, action, approval or timer, runtime event, and audit log.
 - Demonstrate one grouped label assignment such as `status:normal` and one issue relationship if the app exposes work tracking.
+- Demonstrate each configured relationship cardinality and prove uniqueness/foreign-key/link-table constraints.
 - Confirm field-level privacy and AI exposure rules.
 - Confirm role/team permission behaviour for object, panel, field, and workflow actions.
 - Confirm imports can be replayed or explained with provenance.

--- a/.agents/tools/app-stack/metadata-architecture.md
+++ b/.agents/tools/app-stack/metadata-architecture.md
@@ -20,6 +20,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 | `layout_definitions` | Detail/edit/create/list layouts and panels |
 | `panel_definitions` | Relationship/admin/dashboard panels and visibility rules |
 | `view_definitions` | Saved filters, columns, sorting, grouping |
+| `content_type_definitions` | Optional editor-configurable content schemas akin post types |
 | `label_group_definitions` | Optional templates/catalog rows for label namespaces such as status, priority, type |
 | `label_definitions` | Optional templates/catalog rows for governed labels, e.g. `status:normal` |
 | `capability_definitions` | Optional catalog rows for named product actions beyond CRUD |
@@ -43,6 +44,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 - Model layouts separately from fields so the same entity can have role/context-specific views.
 - Model panels separately from layouts so related lists, admin panels, and dashboards can have independent permissions.
 - Make labels/tags a first-class metadata concern for every user-facing entity; model label groups, exclusivity, display order, colour, and scope.
+- Use content type definitions for configurable editorial/domain content; use migrations for core content tables and route ownership.
 - Keep roles, teams, capabilities, and permission rules separate so teams do not become roles.
 - Make workflows explicit: state, transition, actor, guard, side effects, runtime event, audit record.
 - Preserve import provenance: source, source row ID/hash, mapping version, confidence, reviewer.

--- a/.agents/tools/app-stack/metadata-architecture.md
+++ b/.agents/tools/app-stack/metadata-architecture.md
@@ -19,7 +19,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 | `relationship_definitions` | One-to-many, many-to-many, polymorphic references |
 | `layout_definitions` | Detail/edit/create/list layouts and panels |
 | `panel_definitions` | Relationship/admin/dashboard panels and visibility rules |
-| `view_definitions` | Saved filters, columns, sorting, grouping |
+| `view_definitions` | Template/default list, detail, and search views; runtime saved views live in `saved_views` |
 | `content_type_definitions` | Optional editor-configurable content schemas akin post types |
 | `label_group_definitions` | Optional templates/catalog rows for label namespaces such as status, priority, type |
 | `label_definitions` | Optional templates/catalog rows for governed labels, e.g. `status:normal` |

--- a/.agents/tools/app-stack/metadata-architecture.md
+++ b/.agents/tools/app-stack/metadata-architecture.md
@@ -20,11 +20,15 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 | `layout_definitions` | Detail/edit/create/list layouts and panels |
 | `panel_definitions` | Relationship/admin/dashboard panels and visibility rules |
 | `view_definitions` | Saved filters, columns, sorting, grouping |
-| `label_group_definitions` | Label namespaces/categories such as status, priority, type |
-| `label_definitions` | Governed labels available across entity types, e.g. `status:normal` |
-| `capability_definitions` | Named product actions beyond CRUD |
+| `label_group_definitions` | Optional templates/catalog rows for label namespaces such as status, priority, type |
+| `label_definitions` | Optional templates/catalog rows for governed labels, e.g. `status:normal` |
+| `capability_definitions` | Optional catalog rows for named product actions beyond CRUD |
 | `permission_rules` | Role/user/team/workspace/entity/field/panel/action permissions |
-| `workflow_definitions` | States, transitions, guards, actions, timers |
+| `workflow_definitions` | Workflow key, entity scope, version, lifecycle, trigger model |
+| `workflow_state_definitions` | Initial, normal, terminal, cancelled, error, or approval states |
+| `workflow_transition_definitions` | From/to states, actor, capability, guard, side effects |
+| `workflow_guard_definitions` | Deterministic predicates used by transitions and actions |
+| `workflow_action_definitions` | Field updates, tasks, approvals, notifications, webhooks, jobs |
 | `automation_rules` | Trigger/action rules and integration hooks |
 | `import_mappings` | CSV/API/source-to-canonical field maps |
 | `audit_events` | Immutable change/event ledger |
@@ -32,6 +36,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 ## Design rules
 
 - Metadata augments typed code; it does not replace migrations for core tables.
+- Runtime metadata DDL is opt-in for configurable/custom entities only; core standard objects still use reviewed migrations.
 - Keep entity keys stable and human-readable.
 - Put labels/descriptions/help text in metadata so AI agents can explain fields.
 - Keep validation close to field definitions and enforce again at API/database boundaries.
@@ -39,7 +44,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 - Model panels separately from layouts so related lists, admin panels, and dashboards can have independent permissions.
 - Make labels/tags a first-class metadata concern for every user-facing entity; model label groups, exclusivity, display order, colour, and scope.
 - Keep roles, teams, capabilities, and permission rules separate so teams do not become roles.
-- Make workflows explicit: state, transition, actor, guard, side effects.
+- Make workflows explicit: state, transition, actor, guard, side effects, runtime event, audit record.
 - Preserve import provenance: source, source row ID/hash, mapping version, confidence, reviewer.
 
 ## When not to use metadata
@@ -51,6 +56,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 ## Verification
 
 - Demonstrate one entity from definition to list view, detail layout, edit validation, ACL, workflow transition, audit event, and export.
+- Demonstrate one workflow definition through state, transition, guard, action, approval or timer, runtime event, and audit log.
 - Demonstrate one grouped label assignment such as `status:normal` and one issue relationship if the app exposes work tracking.
 - Confirm field-level privacy and AI exposure rules.
 - Confirm role/team permission behaviour for object, panel, field, and workflow actions.

--- a/.agents/tools/app-stack/metadata-architecture.md
+++ b/.agents/tools/app-stack/metadata-architecture.md
@@ -18,8 +18,11 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 | `field_definitions` | Field key, type, validation, display, indexing, privacy |
 | `relationship_definitions` | One-to-many, many-to-many, polymorphic references |
 | `layout_definitions` | Detail/edit/create/list layouts and panels |
+| `panel_definitions` | Relationship/admin/dashboard panels and visibility rules |
 | `view_definitions` | Saved filters, columns, sorting, grouping |
-| `acl_rules` | Role/user/workspace/entity/field/action permissions |
+| `label_definitions` | Governed labels available across entity types |
+| `capability_definitions` | Named product actions beyond CRUD |
+| `permission_rules` | Role/user/team/workspace/entity/field/panel/action permissions |
 | `workflow_definitions` | States, transitions, guards, actions, timers |
 | `automation_rules` | Trigger/action rules and integration hooks |
 | `import_mappings` | CSV/API/source-to-canonical field maps |
@@ -32,6 +35,9 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 - Put labels/descriptions/help text in metadata so AI agents can explain fields.
 - Keep validation close to field definitions and enforce again at API/database boundaries.
 - Model layouts separately from fields so the same entity can have role/context-specific views.
+- Model panels separately from layouts so related lists, admin panels, and dashboards can have independent permissions.
+- Make labels/tags a first-class metadata concern for every user-facing entity.
+- Keep roles, teams, capabilities, and permission rules separate so teams do not become roles.
 - Make workflows explicit: state, transition, actor, guard, side effects.
 - Preserve import provenance: source, source row ID/hash, mapping version, confidence, reviewer.
 
@@ -44,5 +50,7 @@ Use metadata when the app needs configurable entities, layouts, permissions, imp
 ## Verification
 
 - Demonstrate one entity from definition to list view, detail layout, edit validation, ACL, workflow transition, audit event, and export.
+- Demonstrate one label assignment and one issue relationship if the app exposes work tracking.
 - Confirm field-level privacy and AI exposure rules.
+- Confirm role/team permission behaviour for object, panel, field, and workflow actions.
 - Confirm imports can be replayed or explained with provenance.

--- a/.agents/tools/app-stack/migration-layout.md
+++ b/.agents/tools/app-stack/migration-layout.md
@@ -1,0 +1,66 @@
+---
+description: Standard database schema and migration layout for TypeScript monorepo apps using Drizzle
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Migration Layout
+
+Put database ownership in one package. Apps consume the database package; apps do not own migrations unless they have a separate database.
+
+## Standard home
+
+```text
+packages/db/
+  drizzle.config.ts
+  migrations/
+    0000_initial.sql
+    0001_feature_name.sql
+    meta/
+      0000_snapshot.json
+      _journal.json
+  src/
+    schema/
+      index.ts        # re-exports all schema modules
+      auth.ts
+      workspace.ts
+      billing.ts
+      ...
+    scripts/
+      migrate.ts     # optional programmatic migrator
+      seed.ts
+      status.ts
+```
+
+Use this Drizzle shape by default:
+
+```typescript
+export default defineConfig({
+  out: './migrations',
+  schema: './src/schema/index.ts',
+  dialect: 'postgresql',
+  casing: 'snake_case',
+  strict: true,
+  verbose: true,
+});
+```
+
+## Rules
+
+- `packages/db/src/schema/index.ts` is the single schema entrypoint for generation.
+- `packages/db/migrations/` and `packages/db/migrations/meta/` are committed; never gitignore generated SQL or snapshots.
+- One feature or operational concern per migration; separate schema, RLS, seed, and large data backfill steps when reviewability improves.
+- Review generated SQL before applying; hand-write safe renames, data backfills, RLS policies, trigger changes, and zero-downtime indexes.
+- Prefer additive migrations: add nullable/defaulted columns, backfill, deploy code, then enforce `NOT NULL` or constraints.
+- Runtime metadata can create controlled DDL for configurable entities, but durable core objects still need reviewed migrations and an append-only DDL/audit log.
+- Use external provider IDs as integration fields, not primary keys.
+
+## Verification
+
+- Run Drizzle generate and confirm no unplanned schema drift.
+- Migrate both an empty database and a copy/fixture of an existing database.
+- Inspect the generated SQL and migration journal.
+- Verify RLS policies and permission checks for every new workspace-scoped table.
+- Confirm changed tables are exported from `src/schema/index.ts` and covered by typecheck/tests.

--- a/.agents/tools/app-stack/migration-layout.md
+++ b/.agents/tools/app-stack/migration-layout.md
@@ -54,7 +54,7 @@ export default defineConfig({
 - One feature or operational concern per migration; separate schema, RLS, seed, and large data backfill steps when reviewability improves.
 - Review generated SQL before applying; hand-write safe renames, data backfills, RLS policies, trigger changes, and zero-downtime indexes.
 - Prefer additive migrations: add nullable/defaulted columns, backfill, deploy code, then enforce `NOT NULL` or constraints.
-- Runtime metadata can create controlled DDL for configurable entities, but durable core objects still need reviewed migrations and an append-only DDL/audit log.
+- Runtime metadata can create controlled DDL only for configurable/custom entities. Durable core standard objects still need reviewed migrations and an append-only DDL/audit log.
 - Use external provider IDs as integration fields, not primary keys.
 
 ## Verification

--- a/.agents/tools/app-stack/monorepo-app-stack.md
+++ b/.agents/tools/app-stack/monorepo-app-stack.md
@@ -16,6 +16,7 @@ Use when the product has durable app state, shared domain logic, multiple surfac
 apps/
   web/          # React/Next web app
   api/          # API/server runtime when not colocated with web
+  worker/       # background jobs/schedules when not hosting-native
   desktop/      # Electron shell when needed
   mobile/       # Expo app when needed
   extension/    # WXT extension when needed
@@ -24,6 +25,8 @@ packages/
     migrations/ # generated SQL and Drizzle metadata snapshots
     src/schema/ # table definitions and relations, re-exported by index.ts
   domain/       # entities, services, workflow rules, validation
+  api/          # route adapters, DTOs, errors, API metadata
+  jobs/         # job handlers, schedules, queues when shared across runtimes
   ui/           # shared components/tokens
   config/       # eslint/tsconfig/tailwind/build config
   sdk/          # typed client/API helpers
@@ -38,7 +41,7 @@ Add surfaces only when a user workflow requires them; keep package boundaries re
 - Data: Postgres + Drizzle + migrations; RLS for workspace/user boundaries.
 - Validation: shared schemas in domain/API packages.
 - UI: component library package with design tokens and accessibility rules.
-- Background jobs: explicit worker package or hosting-native queue/cron.
+- Background jobs: explicit `apps/worker` / `packages/jobs` or hosting-native queue/cron; see `operations-jobs-scheduling.md`.
 - Local-first desktop/extension cache: PGlite only when Postgres schema reuse is worth the startup/performance trade-off.
 
 ## Package rules
@@ -47,6 +50,8 @@ Add surfaces only when a user workflow requires them; keep package boundaries re
 - `packages/db/drizzle.config.ts` points `out` to `./migrations` and `schema` to `./src/schema/index.ts`.
 - `packages/db/migrations/` and `packages/db/migrations/meta/` are versioned source artifacts.
 - `packages/domain` owns business rules and metadata interpretation; avoid framework imports.
+- `packages/api` owns route adapters, transport-specific middleware, DTOs, errors, and API metadata.
+- `packages/jobs` owns background handlers, schedule definitions, queue names, and retry policies when workers are not fully hosting-native.
 - `packages/ui` owns presentational components and interaction primitives.
 - Apps compose packages; apps do not become dumping grounds for reusable logic.
 - Keep server-only code out of renderer/mobile/extension bundles.

--- a/.agents/tools/app-stack/monorepo-app-stack.md
+++ b/.agents/tools/app-stack/monorepo-app-stack.md
@@ -21,6 +21,8 @@ apps/
   extension/    # WXT extension when needed
 packages/
   db/           # Drizzle schema, migrations, repositories
+    migrations/ # generated SQL and Drizzle metadata snapshots
+    src/schema/ # table definitions and relations, re-exported by index.ts
   domain/       # entities, services, workflow rules, validation
   ui/           # shared components/tokens
   config/       # eslint/tsconfig/tailwind/build config
@@ -42,6 +44,8 @@ Add surfaces only when a user workflow requires them; keep package boundaries re
 ## Package rules
 
 - `packages/db` owns table definitions, relations, migration helpers, and seed data.
+- `packages/db/drizzle.config.ts` points `out` to `./migrations` and `schema` to `./src/schema/index.ts`.
+- `packages/db/migrations/` and `packages/db/migrations/meta/` are versioned source artifacts.
 - `packages/domain` owns business rules and metadata interpretation; avoid framework imports.
 - `packages/ui` owns presentational components and interaction primitives.
 - Apps compose packages; apps do not become dumping grounds for reusable logic.
@@ -52,5 +56,6 @@ Add surfaces only when a user workflow requires them; keep package boundaries re
 - Show the planned directory tree before implementation.
 - Confirm which surfaces are in-scope now.
 - Confirm database ownership and migration command.
+- Confirm migration files live under `packages/db/migrations/` unless the app intentionally has multiple databases.
 - Run typecheck, lint, tests, and surface-specific build for changed packages.
 - For UI changes, use `workflows/ui-verification.md` for browser evidence.

--- a/.agents/tools/app-stack/operations-jobs-scheduling.md
+++ b/.agents/tools/app-stack/operations-jobs-scheduling.md
@@ -1,0 +1,96 @@
+---
+description: Background jobs, scheduled tasks, long-running processes, operations, and worker architecture for business apps
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Operations, Jobs, and Scheduling
+
+Background work is product infrastructure, not an implementation detail. Model jobs, schedules, long-running processes, retries, logs, and admin controls from the first non-trivial app.
+
+## Runtime objects
+
+| Object | Purpose |
+|--------|---------|
+| `job_definitions` | Registered job types, handler key, queue, timeout, retry policy, owner, enabled state |
+| `scheduled_jobs` | Recurring schedule: cron/interval, timezone, calendar, enabled state, next run |
+| `jobs` | Enqueued job instance: type, status, queue, priority, payload, run time, target entity |
+| `job_runs` | Execution attempt/run: worker, started/finished, duration, result, error summary |
+| `job_attempts` | Retry history with attempt number, backoff, error class, next attempt |
+| `job_locks` | Concurrency/advisory locks, lease owner, expiry, lock key, stale lock policy |
+| `worker_heartbeats` | Worker identity, queues served, last seen, version, capacity, drain state |
+| `operation_logs` | Admin/maintenance action, actor, scope, command, result, evidence |
+
+Rules:
+
+- `jobs` are runtime execution records; `scheduled_jobs` are recurring definitions; workflows are business state machines.
+- Every side-effecting job needs an idempotency key, target entity, retry policy, timeout, and audit/provenance reference.
+- Separate queue, priority, and worker capacity so long-running work cannot starve interactive jobs.
+- Use leases/locks for singleton jobs and entity-scoped jobs; expired locks need safe recovery rules.
+- Job payloads store references and minimal parameters, not secrets or large source data.
+
+## Long-running processes and mass actions
+
+| Object | Purpose |
+|--------|---------|
+| `process_definitions` | Named long-running business/admin process with inputs, permissions, and handler |
+| `process_runs` | Process instance: status, actor, target scope, progress, result, cancellation state |
+| `process_steps` | Ordered steps/checkpoints with status, progress, retry/cancel policy |
+| `job_batches` | Batch of jobs for import/export, bulk update, report generation, or sync |
+| `mass_actions` | User-requested bulk action: entity type, filter/scope snapshot, action, counts, notify flag |
+| `mass_action_items` | Per-record status/result/error for a bulk action when traceability matters |
+
+Rules:
+
+- Use `process_runs` when users need progress, pause/resume/cancel, approvals, or step visibility.
+- Use `job_batches` when a process fans out into many jobs that must be counted, retried, or rolled up.
+- Mass actions must snapshot the selected filter/scope, check permissions at execution time, and record per-record failures when partial success is possible.
+- Long-running jobs emit progress/activity events and optional notifications when finished.
+
+## Trigger sources
+
+| Trigger | Standard handling |
+|---------|-------------------|
+| Schedule | `scheduled_jobs` creates `jobs` using timezone/calendar-aware next-run calculation |
+| Domain event | `change_events` / `outbox_events` enqueue work after transaction commit |
+| Workflow timer | `workflow_timers` creates jobs or resumes workflow runs |
+| User/admin action | `mass_actions` or `process_runs` records actor, scope, and notify preference |
+| Integration/webhook | Webhook event validates, dedupes, then enqueues idempotent work |
+| Maintenance | Operation logs capture actor, evidence, dry-run/result, and rollback note |
+
+Rules:
+
+- Schedule in UTC internally, preserve source timezone, and use working calendars when business-time SLAs matter.
+- Use separate maintenance queues for cleanup, retention, search indexing, cache refresh, reconciliation, and repair work.
+- Treat missed schedules explicitly: skip, catch up once, catch up all, or require operator approval.
+
+## Working calendars and SLAs
+
+| Object | Purpose |
+|--------|---------|
+| `working_calendars` | Timezone, weekdays, default working windows, owner/team/workspace scope |
+| `working_calendar_exceptions` | Holidays, shutdowns, extra working days, user/team overrides |
+| `sla_policies` | Response/resolution clocks, pause rules, escalation targets |
+| `sla_events` | Clock start/pause/resume/breach/resolve events tied to records and workflows |
+
+Rules:
+
+- Keep calendar math in shared domain code and test DST, timezone, holiday, and overnight ranges.
+- SLA timers should produce workflow timers/jobs and audit/activity events, not hidden UI-only state.
+
+## Worker package defaults
+
+- Monorepos use an explicit `apps/worker` or `packages/jobs` when background execution is not hosting-native.
+- Worker code imports domain services and database clients; UI/app code enqueues jobs through typed service functions.
+- Provide local commands for `worker:dev`, `worker:run-once`, `worker:drain`, and `worker:retry-failed` when the app owns its worker runtime.
+- Expose an admin screen for queues, schedules, failures, retries, disabled jobs, worker heartbeats, and operation logs.
+
+## Verification
+
+- Trace one scheduled job from definition to next-run calculation, job row, lock, attempt, run log, notification, and audit event.
+- Trace one bulk action through filter snapshot, permission check, batch jobs, per-record failures, partial-success result, and retry.
+- Prove duplicate delivery/retry is idempotent for one external side effect.
+- Prove one missed schedule policy and one expired-lock recovery path.
+- Confirm job payloads, logs, and errors do not expose secrets or private source data.

--- a/.agents/tools/app-stack/platform-kernel.md
+++ b/.agents/tools/app-stack/platform-kernel.md
@@ -1,0 +1,206 @@
+---
+description: Platform kernel object model for notifications, audit, search, imports, integrations, forms, dashboards, settings, localisation, jobs, and retention
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Platform Kernel Objects
+
+Use these cross-cutting objects before each app invents its own notification, search, import, settings, or reporting tables. Scope durable rows by `workspace_id` unless the row is explicitly global system configuration.
+
+## Notifications, inbox, and subscriptions
+
+| Object | Purpose |
+|--------|---------|
+| `notifications` | User-visible notification row: recipient, type, message, related entity, read state, delivery state |
+| `notification_preferences` | User/team/workspace preferences by channel, event type, quiet hours, digest policy |
+| `notification_subscriptions` | Follow/watch records, conversations, issues, reports, saved searches, or entities |
+| `notification_deliveries` | Email/push/in-app/webhook delivery attempt, provider ID, status, error, retry time |
+| `inbox_items` | Unified action inbox for approvals, mentions, assignments, failed jobs, alerts |
+
+Rules:
+
+- Notifications are derived from events; do not use them as the source of truth for workflow state.
+- Keep delivery attempts separate from notification intent so retries and provider errors are auditable.
+- User search/inbox counts must respect RLS and notification preferences.
+
+## Audit, activity, and provenance
+
+| Object | Purpose |
+|--------|---------|
+| `audit_events` | Immutable security/business change ledger: actor, action, entity, before/after summary, reason |
+| `activity_events` | Human-readable timeline/feed events for records and workspaces |
+| `change_events` | Low-level data change stream for sync, search indexing, automation, cache invalidation |
+| `provenance_records` | Source, import, AI/tool, external system, confidence, reviewer, and evidence metadata |
+| `app_log_events` | Operational logs/errors tied to request/job/user/workspace context |
+
+Rules:
+
+- Security and compliance audit events are append-only and access-controlled.
+- Activity feeds can be denormalised/read-optimised, but must link back to authoritative records.
+- Capture actor, workspace, entity type, entity ID, request/job ID, IP/session where applicable, and timestamp.
+
+## Imports, exports, and data quality
+
+| Object | Purpose |
+|--------|---------|
+| `import_jobs` | Import run: source file/provider, target entity, mapping, status, counts, created by |
+| `import_mappings` | Source-to-canonical field maps, transform rules, defaults, validation options |
+| `import_rows` | Staged source rows with raw payload hash, parsed values, status, matched entity |
+| `import_errors` | Row/cell validation, permission, duplicate, integrity, or transform errors |
+| `dedupe_candidates` | Potential duplicates with confidence, evidence, decision, reviewer |
+| `export_jobs` | Export run: query/scope, format, status, file link, notification preference |
+| `export_files` | Links to generated files plus expiry, sensitivity, and access policy |
+
+Rules:
+
+- Imports stage before mutating production rows when validation/dedupe/review is needed.
+- Preserve raw row hashes and mapping versions so imports can be replayed or explained.
+- Exports need permission checks, audit events, expiry, and sensitivity labels.
+
+## Integrations, sync, and webhooks
+
+| Object | Purpose |
+|--------|---------|
+| `integrations` | Provider/app connection configuration and enabled state |
+| `integration_accounts` | Connected external account/tenant/user metadata without secret values |
+| `external_ids` | Entity-to-provider IDs, URLs, ETags, sync tokens, deleted/tombstone state |
+| `sync_cursors` | Incremental sync checkpoint by provider, scope, collection, and direction |
+| `sync_runs` | Sync execution, status, counts, duration, errors, initiated by |
+| `webhooks` | Outbound/inbound webhook definitions, event filters, signing configuration |
+| `webhook_events` | Received or outgoing event payload metadata, dedupe key, processing state |
+| `outbox_events` | Reliable side-effect queue for webhooks, email, external API calls, AI/tool calls |
+
+Rules:
+
+- Store secret references, not secret values.
+- Use idempotency keys and dedupe keys for every external event.
+- External IDs are integration fields, never primary keys.
+
+## Search, search history, and discovery
+
+| Object | Purpose |
+|--------|---------|
+| `search_indexes` | Search scope/config: entities, fields, language, ranking, vector/full-text mode |
+| `search_documents` | Denormalised searchable record: entity ref, title, summary, body, language, freshness |
+| `search_terms` | Optional normalised term/topic catalog for suggestions and analytics |
+| `search_queries` | User/workspace search history: query, filters, result count, latency, source UI |
+| `search_result_events` | Impressions, clicks, opens, no-results, refinements, conversion signals |
+| `saved_searches` | Named user/team/workspace searches with filters, sort, columns, alerts |
+| `search_suggestions` | Curated/generated suggestions, synonyms, boosts, blocked terms |
+
+Rules:
+
+- Search indexes are derived data; source records remain authoritative.
+- Search history can contain sensitive terms. Apply retention, privacy controls, redaction, and per-user visibility.
+- Store filters separately from raw query text so saved searches and analytics can be explained.
+- Vector embeddings reference search documents or files; keep model/version and sensitivity metadata.
+
+## Views, reports, dashboards, and analytics
+
+| Object | Purpose |
+|--------|---------|
+| `saved_views` | Entity list/table views: filters, columns, sort, grouping, visibility, owner |
+| `filter_presets` | Reusable filter definitions for primary, boolean, text, and access-aware filters |
+| `report_definitions` | Report metadata: source, measures, dimensions, filters, permissions |
+| `report_runs` | Generated report run, parameters, status, result file/cache, created by |
+| `dashboard_definitions` | Dashboard layout, widgets, visibility, default scope |
+| `dashboard_widgets` | Widget config, data source, refresh interval, position, permissions |
+
+Rules:
+
+- Saved views and reports must apply RBAC/RLS at execution time, not only at creation time.
+- Store definition/version separately from generated results.
+- Exported reports use export/audit/sensitivity rules.
+
+## Forms, submissions, and surveys
+
+| Object | Purpose |
+|--------|---------|
+| `form_definitions` | Form key, version, target entity/action, lifecycle, access policy |
+| `form_fields` | Field definitions, validation, conditional visibility, mapping to target fields |
+| `form_submissions` | Submitted instance, submitter, status, source, spam/risk score, reviewed by |
+| `form_submission_values` | Normalised field values or encrypted payload references |
+| `survey_definitions` | Survey/questionnaire metadata, scoring, branching, anonymity policy |
+| `survey_responses` | Response set, respondent, completion state, score, source |
+
+Rules:
+
+- Version forms before changing fields that affect stored submissions.
+- Keep submitted raw payload or hash when legal/privacy policy permits; map to canonical objects through imports/workflows.
+- Treat public forms as untrusted input: validation, rate limits, spam checks, and prompt-injection scanning where AI reads submissions.
+
+## Settings, preferences, flags, and entitlements
+
+| Object | Purpose |
+|--------|---------|
+| `workspace_settings` | Workspace-level configuration, defaults, feature choices |
+| `user_preferences` | User locale/timezone/theme/dashboard/import/export/notification preferences |
+| `system_settings` | Global platform configuration and operational defaults |
+| `feature_flags` | Feature gate key, rollout state, targeting, owner, expiry |
+| `entitlements` | Plan/license/capability limits by workspace/account/user |
+| `usage_counters` | Metered usage by feature, period, source event, billing/export status |
+
+Rules:
+
+- Prefer typed columns for core settings; use JSON only for low-risk/extensible preferences.
+- Feature flags need owner, reason, expiry/review date, and audit events.
+- Entitlements gate capabilities; they do not replace RBAC.
+
+## Localisation and translations
+
+| Object | Purpose |
+|--------|---------|
+| `locales` | Supported locale/language, default, enabled state |
+| `translation_keys` | Stable keys for UI/content/system messages |
+| `translations` | Locale-specific value, source, status, reviewer, updated at |
+| `localized_routes` | Locale-aware route/path mapping when route tables need separate localisation |
+| `localized_content` | Content field translations when not stored as separate content entries |
+
+Rules:
+
+- Use stable translation keys; do not key translations by English source text when values change often.
+- Route, slug, and content localisation must preserve canonical links and redirects.
+- Track translation status: draft, machine, reviewed, approved, stale.
+
+## Jobs, scheduling, and operations
+
+| Object | Purpose |
+|--------|---------|
+| `jobs` | Background job instance: type, status, queue, attempts, scheduled time, payload |
+| `scheduled_jobs` | Recurring schedule definitions, cron/interval, owner, enabled state |
+| `job_runs` | Execution history, started/finished time, worker, result, error |
+| `job_locks` | Concurrency/advisory locks and leases |
+| `operation_logs` | Admin/maintenance operations, actor, scope, outcome, evidence |
+
+Rules:
+
+- Jobs are runtime execution records; workflows are business state machines. Link them but do not collapse them.
+- Use idempotency keys and retry/backoff metadata for side effects.
+- Long-running jobs should emit progress/activity events.
+
+## Retention, archive, and compliance
+
+| Object | Purpose |
+|--------|---------|
+| `retention_policies` | Entity/file/log retention rules, legal basis, purge/archive behaviour |
+| `archive_records` | Archive operation record and storage reference when rows/files move cold |
+| `legal_holds` | Prevent purge/archive for entities/files under hold |
+| `deletion_requests` | User/customer deletion/export requests and fulfilment state |
+| `redaction_events` | Field/file/message redactions with actor, reason, irreversible marker |
+
+Rules:
+
+- Soft delete uses `deleted_at` / `deleted_by`; archive and legal hold are separate concepts.
+- Purge jobs require explicit policy, audit event, and recovery/backup awareness.
+- AI/search indexes, exports, and derived files must follow source retention policies.
+
+## Verification
+
+- Trace one search query through saved filters, result permissions, search history retention, click/open event, and index refresh.
+- Trace one import through mapping, staged rows, validation errors, dedupe review, production write, provenance, and audit.
+- Trace one notification through source event, preference, delivery attempt, read state, and inbox item.
+- Trace one integration through external ID, sync cursor, webhook event, outbox retry, and tombstone/delete handling.
+- Trace one saved view/report/dashboard through RBAC/RLS execution and export audit.

--- a/.agents/tools/app-stack/platform-kernel.md
+++ b/.agents/tools/app-stack/platform-kernel.md
@@ -179,6 +179,8 @@ Rules:
 | `scheduled_jobs` | Recurring schedule definitions, cron/interval, owner, enabled state |
 | `job_runs` | Execution history, started/finished time, worker, result, error |
 | `job_locks` | Concurrency/advisory locks and leases |
+| `process_runs` | Long-running business/admin process with progress, steps, cancellation, result |
+| `mass_actions` | User-requested bulk action with entity scope, filter snapshot, status, counts |
 | `operation_logs` | Admin/maintenance operations, actor, scope, outcome, evidence |
 
 Rules:
@@ -186,6 +188,7 @@ Rules:
 - Jobs are runtime execution records; workflows are business state machines. Link them but do not collapse them.
 - Use idempotency keys and retry/backoff metadata for side effects.
 - Long-running jobs should emit progress/activity events.
+- Use `process_runs` or `mass_actions` when users need progress, cancellation, partial-success detail, notification, or audit beyond a single job row. Full pattern: `app-stack/operations-jobs-scheduling.md`.
 
 ## Retention, archive, and compliance
 

--- a/.agents/tools/app-stack/platform-kernel.md
+++ b/.agents/tools/app-stack/platform-kernel.md
@@ -33,6 +33,7 @@ Rules:
 | `audit_events` | Immutable security/business change ledger: actor, action, entity, before/after summary, reason |
 | `activity_events` | Human-readable timeline/feed events for records and workspaces |
 | `change_events` | Low-level data change stream for sync, search indexing, automation, cache invalidation |
+| `record_revisions` | User-visible revision history and restore/compare checkpoints for business records |
 | `provenance_records` | Source, import, AI/tool, external system, confidence, reviewer, and evidence metadata |
 | `app_log_events` | Operational logs/errors tied to request/job/user/workspace context |
 
@@ -42,6 +43,7 @@ Rules:
 - Activity feeds can be denormalised/read-optimised, but must link back to authoritative records.
 - Capture actor, workspace, entity type, entity ID, request/job ID, IP/session where applicable, and timestamp.
 - Minimise log data: avoid raw session IDs, hash or truncate IPs where appropriate, apply retention/redaction, and prevent operational logs from becoming public support artifacts.
+- Use `record_revisions` for compare/restore UX; keep audit events append-only and access-controlled. Full pattern: `app-stack/data-history-relationships.md`.
 
 ## Imports, exports, and data quality
 
@@ -52,6 +54,7 @@ Rules:
 | `import_rows` | Staged source rows with raw payload hash, parsed values, status, matched entity |
 | `import_errors` | Row/cell validation, permission, duplicate, integrity, or transform errors |
 | `dedupe_candidates` | Potential duplicates with confidence, evidence, decision, reviewer |
+| `merge_jobs` | Reviewed duplicate-record merge plan/execution with field and relationship choices |
 | `export_jobs` | Export run: query/scope, format, status, file link, notification preference |
 | `export_files` | Links to generated files plus expiry, sensitivity, and access policy |
 
@@ -59,6 +62,7 @@ Rules:
 
 - Imports stage before mutating production rows when validation/dedupe/review is needed.
 - Preserve raw row hashes and mapping versions so imports can be replayed or explained.
+- Duplicate merges need a reviewed merge plan, per-field choices, per-relationship choices, aliases/tombstones, and audit/provenance links; see `app-stack/data-history-relationships.md`.
 - Exports need permission checks, audit events, expiry, and sensitivity labels.
 
 ## Integrations, sync, and webhooks

--- a/.agents/tools/app-stack/platform-kernel.md
+++ b/.agents/tools/app-stack/platform-kernel.md
@@ -41,6 +41,7 @@ Rules:
 - Security and compliance audit events are append-only and access-controlled.
 - Activity feeds can be denormalised/read-optimised, but must link back to authoritative records.
 - Capture actor, workspace, entity type, entity ID, request/job ID, IP/session where applicable, and timestamp.
+- Minimise log data: avoid raw session IDs, hash or truncate IPs where appropriate, apply retention/redaction, and prevent operational logs from becoming public support artifacts.
 
 ## Imports, exports, and data quality
 
@@ -78,6 +79,7 @@ Rules:
 - Store secret references, not secret values.
 - Use idempotency keys and dedupe keys for every external event.
 - External IDs are integration fields, never primary keys.
+- Strip credentials and transient query tokens from URLs, classify sensitive source paths, prefer opaque provider IDs for joins, and avoid raw private/local paths in exportable or public-facing rows.
 
 ## Search, search history, and discovery
 

--- a/.agents/tools/app-stack/public-site-surfaces.md
+++ b/.agents/tools/app-stack/public-site-surfaces.md
@@ -1,0 +1,93 @@
+---
+description: Required public pages, structured data, docs/API/MCP/CLI surfaces, and discoverability standards for websites and apps
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Public Site Surfaces and Schema
+
+Every public website and app needs trustworthy public surfaces before launch. Treat legal, contact, docs, developer, agent, and structured-data pages as product infrastructure.
+
+## Required public pages
+
+| Route | Purpose |
+|-------|---------|
+| `/about` | Who operates the site/app, mission, audience, provenance, ownership/publisher details |
+| `/contact` | Support/sales/general contact channels, postal/company details when relevant, response expectations |
+| `/privacy` | Privacy policy, data collection, cookies/analytics, retention, processors, user rights |
+| `/terms` | Terms of service/use, acceptable use, liability, jurisdiction, billing/subscription terms when relevant |
+
+Rules:
+
+- Required pages must be linked from the footer and sitemap, not hidden in app chrome.
+- Use stable canonical URLs; redirects preserve old legal/support URLs.
+- Keep legal pages editable and versionable; record effective date, last updated date, and policy owner.
+- Apps that require login still need public versions of these pages outside the authenticated shell.
+- Small no-build/static sites can ship placeholder pages, but placeholders must be obvious and replaced before launch.
+
+## Structured data and schema
+
+| Surface | Structured data default |
+|---------|-------------------------|
+| Site/app home | `WebSite`, `Organization` or `Person`, app/product/service entity as relevant |
+| About page | `AboutPage`, publisher/person/organization details |
+| Contact page | `ContactPage`, contact points, area served, support channels |
+| Privacy page | Valid `WebPage`/`CreativeWork` policy metadata with publisher, dates, canonical URL; do not invent unsupported types |
+| Terms page | Valid `WebPage`/`CreativeWork` terms metadata with publisher, dates, canonical URL; do not invent unsupported types |
+| Docs/API/MCP/CLI pages | `WebPage`, `TechArticle`, `SoftwareApplication`, `HowTo`, or another validator-supported schema.org type |
+| Content/entity pages | Domain-specific schema for products, articles, events, FAQs, reviews, courses, jobs, places, datasets, or software |
+
+Rules:
+
+- Prefer JSON-LD in the page head or near the relevant content; keep it consistent with visible page content.
+- Use stable `@id` values tied to canonical URLs and avoid duplicate/conflicting entities.
+- Model breadcrumbs with `BreadcrumbList` when pages are nested.
+- Include publisher, logo/image, canonical URL, language, dates, and contact points where relevant.
+- Validate structured data before launch and after template changes.
+- Do not add schema for facts that are not visible, accurate, or supportable.
+
+## Documentation surface
+
+| Surface | Use |
+|---------|-----|
+| `/docs` | Default human documentation entry for small/medium apps and static sites |
+| `docs.` subdomain | Larger docs with versioning, search, generated references, or separate deploy cadence |
+| `/docs/api` | API overview when API reference is part of docs |
+| `/docs/cli` | CLI documentation when CLI docs are part of docs |
+| `/docs/mcp` | MCP/server documentation when agent docs are part of docs |
+
+Rules:
+
+- Every app should have a human-readable docs entry point, even if it starts as a short overview.
+- Choose `/docs` until docs need independent hosting, versioning, search, or contributor workflow.
+- Docs need getting started, concepts, auth/setup, examples, troubleshooting, changelog, and support links.
+- Documentation should link to terms, privacy, contact, API, MCP, CLI, status/support, and release notes when those exist.
+
+## API, MCP, and CLI surfaces
+
+| Route | Purpose |
+|-------|---------|
+| `/api` | Human API overview: status, auth model, base URLs, versioning, rate limits, SDKs, OpenAPI/reference links |
+| `api.` subdomain | Machine/API endpoint host when separated from the web app |
+| `/mcp` | Human MCP overview: server URL, auth/scopes, tool catalog, schemas, safety model, examples |
+| `/cli` | Human CLI overview: install, authentication, command groups, examples, update/uninstall, support |
+
+Rules:
+
+- `/api`, `/mcp`, and `/cli` can redirect to docs sections for small products, but the routes should remain stable and discoverable.
+- If an API, MCP server, or CLI is not yet public, the route should honestly say so or redirect to the roadmap/support page; never imply a non-existent integration works.
+- Generate API reference from OpenAPI/RPC metadata when possible; hand-written pages explain concepts, auth, examples, and support.
+- MCP and CLI integrations use the same service contracts, auth, permissions, audit, rate limits, and idempotency rules as the API.
+- Agent-facing pages should include safe example prompts/commands, data-access scopes, destructive-operation warnings, and support/contact routes.
+- Publish machine-readable discovery only when maintained: OpenAPI document, SDK package metadata, MCP server/tool schema, CLI release metadata, and optional `llms.txt` / agent docs index.
+- Never publish secrets, internal endpoints, private repository names, local paths, or non-public support contacts.
+
+## Verification
+
+- Visit `/about`, `/contact`, `/privacy`, `/terms`, `/docs`, `/api`, `/mcp`, and `/cli` or their documented redirects/status pages.
+- Confirm footer, sitemap, robots policy, canonical URLs, and redirects expose required pages.
+- Validate JSON-LD/schema for home, required pages, docs/API/developer pages, and one domain object page.
+- Confirm API/MCP/CLI pages match implemented auth, scopes, endpoints, tools, and support policy.
+- Confirm no placeholder legal/contact/API data remains before launch.

--- a/.agents/tools/app-stack/rbac-permissions.md
+++ b/.agents/tools/app-stack/rbac-permissions.md
@@ -1,0 +1,65 @@
+---
+description: RBAC, capabilities, teams, field permissions, panel permissions, workflow guards, and RLS boundaries
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# RBAC and Permissions
+
+Standardise permissions from the first multi-user boundary. Roles describe what a principal can do; teams/user groups describe who a principal is grouped with.
+
+## Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| `users` | Authenticated people or service identities |
+| `teams` / `user_groups` | User collections, departments, queues, or collaboration groups |
+| `team_memberships` | User membership in teams, with optional position/title |
+| `roles` | Named permission bundles, not user groups |
+| `role_assignments` | Role assigned to a user or team within a workspace |
+| `capabilities` | Named actions such as `invoice.issue`, `issue.triage`, `file.export` |
+| `permission_rules` | Grants/denies by role, user, team, entity, action, and scope |
+| `field_permission_rules` | Field-level read/update/mask/hidden rules |
+| `panel_permission_rules` | Layout/panel visibility and action rules |
+| `workflow_transition_rules` | Who can move records between states |
+
+## Permission dimensions
+
+- Action: `create`, `read`, `update`, `delete`, `export`, `import`, `assign`, `comment`, `attach`, `approve`, `transition`, `manage`.
+- Scope: `none`, `own`, `team`, `workspace`, `all`, or a named custom predicate.
+- Target: entity/object type, panel, field, workflow, transition, integration, or report.
+- Principal: user, team/user group, role, service account.
+- Context: workspace, record owner, assigned user/team, lifecycle state, sensitivity class.
+
+## Evaluation rules
+
+- Default deny for every non-public action.
+- Workspace membership is the first gate; RLS enforces coarse workspace and row boundaries.
+- System roles such as owner/admin/member/viewer are ceilings or bootstrap roles; custom roles hold product-specific permissions.
+- Assign roles to users and teams; merge grants across assignments.
+- Prefer additive grants. If explicit denies are supported, document precedence and test deny-overrides-grant cases.
+- Apply field/panel/workflow rules after object-level permission so list/detail/edit screens cannot leak hidden fields or invalid actions.
+- Cache permission matrices only with invalidation on role, team, membership, and field-rule changes.
+- Audit permission changes, role assignments, workflow transitions, exports, and privileged reads.
+
+## Object, panel, field, and workflow permissions
+
+- Object permissions cover CRUD plus product actions such as export, import, assign, duplicate, archive, approve, issue, refund, and reconcile.
+- Panel permissions control detail-page panels, relationship panels, admin panels, and dashboard widgets.
+- Field permissions support hidden/read-only/editable/masked states and sensitivity-aware AI exposure.
+- Workflow permissions bind transitions to roles/capabilities and guards: from state, to state, actor, record scope, validation, side effects.
+
+## RLS defaults
+
+- Every workspace-scoped table has `workspace_id` and RLS using current workspace/user context.
+- Ownership and team scopes are backed by `created_by`, `owner_id`, `assigned_user_id`, `assigned_team_id`, or explicit membership join tables.
+- Database RLS protects rows; application permission checks protect capabilities, fields, panels, workflow transitions, and UI affordances.
+
+## Verification
+
+- Build a permission matrix for one entity covering user, team, role, object action, field, panel, and workflow transition.
+- Prove default deny, owner/admin access, own/team/workspace scopes, and field masking with tests.
+- Verify RLS blocks cross-workspace reads/writes even when application code omits filters.
+- Verify role/team changes invalidate caches and produce audit events.

--- a/.agents/tools/app-stack/rbac-permissions.md
+++ b/.agents/tools/app-stack/rbac-permissions.md
@@ -24,11 +24,12 @@ Standardise permissions from the first multi-user boundary. Roles describe what 
 | `field_permission_rules` | Field-level read/update/mask/hidden rules |
 | `panel_permission_rules` | Layout/panel visibility and action rules |
 | `workflow_transition_rules` | Who can move records between states |
+| `workflow_approval_rules` | Who can approve, reject, delegate, override, or cancel workflow steps |
 
 ## Permission dimensions
 
-- Action: `create`, `read`, `update`, `delete`, `export`, `import`, `assign`, `comment`, `attach`, `approve`, `transition`, `manage`.
-- Scope: `none`, `own`, `team`, `workspace`, `all`, or a named custom predicate.
+- Action: `create`, `read`, `update`, `delete`, `export`, `import`, `assign`, `comment`, `attach`, `approve`, `reject`, `delegate`, `override`, `transition`, `manage`.
+- Scope: `none`, `own`, `team`, `workspace`, `all`, or a named custom predicate. `all` means all records in the current workspace; platform-global access requires a separate system capability.
 - Target: entity/object type, panel, field, workflow, transition, integration, or report.
 - Principal: user, team/user group, role, service account.
 - Context: workspace, record owner, assigned user/team, lifecycle state, sensitivity class.
@@ -37,9 +38,9 @@ Standardise permissions from the first multi-user boundary. Roles describe what 
 
 - Default deny for every non-public action.
 - Workspace membership is the first gate; RLS enforces coarse workspace and row boundaries.
-- System roles such as owner/admin/member/viewer are ceilings or bootstrap roles; custom roles hold product-specific permissions.
+- System roles such as owner/admin/member/viewer bootstrap workspace access; custom roles hold product-specific capabilities. If a product needs immutable ceilings, model them separately and test them explicitly.
 - Assign roles to users and teams; merge grants across assignments.
-- Prefer additive grants. If explicit denies are supported, document precedence and test deny-overrides-grant cases.
+- Prefer additive grants. Avoid explicit denies by default; if denies are enabled, deny-overrides-grant precedence and tests are required.
 - Apply field/panel/workflow rules after object-level permission so list/detail/edit screens cannot leak hidden fields or invalid actions.
 - Cache permission matrices only with invalidation on role, team, membership, and field-rule changes.
 - Audit permission changes, role assignments, workflow transitions, exports, and privileged reads.
@@ -49,7 +50,7 @@ Standardise permissions from the first multi-user boundary. Roles describe what 
 - Object permissions cover CRUD plus product actions such as export, import, assign, duplicate, archive, approve, issue, refund, and reconcile.
 - Panel permissions control detail-page panels, relationship panels, admin panels, and dashboard widgets.
 - Field permissions support hidden/read-only/editable/masked states and sensitivity-aware AI exposure.
-- Workflow permissions bind transitions to roles/capabilities and guards: from state, to state, actor, record scope, validation, side effects.
+- Workflow permissions bind transitions to roles/capabilities and guards: from state, to state, actor, record scope, validation, approval step, side effects.
 
 ## RLS defaults
 

--- a/.agents/tools/app-stack/rbac-permissions.md
+++ b/.agents/tools/app-stack/rbac-permissions.md
@@ -14,13 +14,14 @@ Standardise permissions from the first multi-user boundary. Roles describe what 
 
 | Concept | Purpose |
 |---------|---------|
-| `users` | Authenticated people or service identities |
+| `users` | Authenticated human identity records |
+| `service_accounts` | Non-human actors for integrations, automations, imports, jobs, and API clients |
 | `teams` / `user_groups` | User collections, departments, queues, or collaboration groups |
 | `team_memberships` | User membership in teams, with optional position/title |
 | `roles` | Named permission bundles, not user groups |
 | `role_assignments` | Role assigned to a user or team within a workspace |
 | `capabilities` | Named actions such as `invoice.issue`, `issue.triage`, `file.export` |
-| `permission_rules` | Grants/denies by role, user, team, entity, action, and scope |
+| `permission_rules` | Grants/denies by role, user, service account, team, entity, action, and scope |
 | `field_permission_rules` | Field-level read/update/mask/hidden rules |
 | `panel_permission_rules` | Layout/panel visibility and action rules |
 | `workflow_transition_rules` | Who can move records between states |
@@ -39,7 +40,7 @@ Standardise permissions from the first multi-user boundary. Roles describe what 
 - Default deny for every non-public action.
 - Workspace membership is the first gate; RLS enforces coarse workspace and row boundaries.
 - System roles such as owner/admin/member/viewer bootstrap workspace access; custom roles hold product-specific capabilities. If a product needs immutable ceilings, model them separately and test them explicitly.
-- Assign roles to users and teams; merge grants across assignments.
+- Assign roles to users, service accounts, and teams; merge grants across assignments.
 - Prefer additive grants. Avoid explicit denies by default; if denies are enabled, deny-overrides-grant precedence and tests are required.
 - Apply field/panel/workflow rules after object-level permission so list/detail/edit screens cannot leak hidden fields or invalid actions.
 - Cache permission matrices only with invalidation on role, team, membership, and field-rule changes.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -19,6 +19,7 @@ workspace
   labels / label_groups / label_assignments
   users / teams / roles / permissions
   notifications / audit_events / integrations / search_queries / saved_views
+  record_revisions / entity_relationships / merge_jobs
   accounts / contacts / address_books
   issues / issue_relationships
   content_types / content_entries / content_revisions / routes
@@ -33,7 +34,7 @@ Use separate tables only when the subtype needs distinct validation, lifecycle, 
 
 The hierarchy abbreviates always-on platform/kernel objects; see `app-stack/platform-kernel.md` for the full notification, audit, import/export, integration, search, report, form, settings, job, and retention model.
 
-For cross-object relationships, default to generic link tables with `entity_type` and `entity_id`. Use typed join tables only for high-volume, referentially critical, permission-critical, or heavily indexed relationships.
+For cross-object relationships, default to generic link tables with `entity_type` and `entity_id`. Use typed join tables only for high-volume, referentially critical, permission-critical, or heavily indexed relationships. Model cardinality, inverse labels, merge handling, and history using `app-stack/data-history-relationships.md`.
 
 ## Slugs, routes, and hierarchy
 

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -85,7 +85,7 @@ WordPress concept mapping:
 | Page URL/permalink | `routes` or `content_routes` |
 | Revisions | `content_revisions` |
 | Blocks/patterns | `content_blocks` |
-| Categories/tags/custom taxonomies | `taxonomies`, `terms`, `term_assignments`, labels |
+| Categories/tags/custom taxonomies | `taxonomies`, `terms`, `term_assignments` |
 | Media library item | `files` with `file_links` |
 | Menus | `menus`, `menu_items` |
 | SEO fields | `seo_metadata` linked to content/routes |
@@ -99,8 +99,8 @@ Core model:
 | `content_revisions` | Immutable revisions with editor, diff/source snapshot, reason, publish metadata |
 | `content_blocks` | Structured page sections or rich-content blocks ordered within an entry/revision |
 | `routes` / `content_routes` | URL path, canonical target, redirects, locale, route status |
-| `taxonomies` | Category/tag vocabularies, hierarchical or flat |
-| `terms` | Taxonomy values; can mirror labels when simple grouping is enough |
+| `taxonomies` | Content classification vocabularies such as category, tag, topic, audience; hierarchical or flat |
+| `terms` | Values inside a taxonomy, e.g. News, AI, Developers |
 | `term_assignments` | Entry-to-term assignments with sort/context metadata |
 | `menus` / `menu_items` | Navigation structures independent of content storage |
 | `seo_metadata` | Title, description, robots, canonical URL, social cards, structured-data hints |
@@ -112,6 +112,7 @@ Rules:
 - Use workflows for draft/review/approved/published/archived lifecycles; labels can mirror editorial status but are not the source of truth.
 - Use files/file links for media assets; do not create a separate media-blob system for content.
 - Use metadata field definitions when content types are editor-configurable; use migrations for core product content tables.
+- Use taxonomies/terms for content classification. Use labels for cross-object operational grouping such as `status:normal` or `priority:high`. Only use labels as content tags in deliberately simple flat-tag products with no taxonomy hierarchy, term metadata, or editorial taxonomy UI.
 
 Choose WordPress instead when routine editors need posts/pages/media library/revisions/forms/SEO plugins/themes/plugin ecosystem more than product-specific app integration.
 

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -10,6 +10,24 @@ mode: subagent
 
 Use boring canonical names so apps, imports, AI agents, and integrations share one vocabulary.
 
+## Standard hierarchy
+
+Avoid competing roots. Prefer a small set of canonical containers, then model product-specific names as types, labels, or views:
+
+```text
+workspace
+  labels / label_groups / label_assignments
+  users / teams / roles / permissions
+  accounts / contacts / address_books
+  issues / issue_relationships
+  conversation_groups / conversations / messages / message_threads / message_reactions
+  calendar_collections / activities / activity_participants / activity_alarms
+  folders / files / file_versions / file_links
+  quotes / invoices / payments / credits / ledger_entries
+```
+
+Use separate tables only when the subtype needs distinct validation, lifecycle, permissions, integrations, or high-volume indexes. Otherwise use a typed row plus metadata.
+
 ## Universal labels and tags
 
 Every durable object type should be label/tag capable unless there is a deliberate product reason not to expose it.
@@ -48,64 +66,70 @@ Support issue relationships:
 
 Use `issues` for user-visible work, defects, support requests, and change requests. Use `tasks` for schedule/checklist execution when the product needs a lighter sub-work item.
 
-## Chat and communication
+## Conversations, chat, and communication
 
-Use one durable communication model that can attach to issues, accounts, contacts, projects, documents, or standalone workspaces.
+Use one durable conversation model that can attach to issues, accounts, contacts, projects, documents, or standalone workspaces. Channels and chats are conversation types, not competing roots.
 
 | Object | Purpose |
 |--------|---------|
-| `channel_groups` | Group channels by workspace area, team, customer, project, or product |
-| `channels` | Named spaces: public, private, team, project, support, announcement |
-| `channel_memberships` | User/team membership, role, notification preference, last-read pointer |
-| `chats` | Direct, group, or entity-scoped conversations that are not named channels |
-| `chat_participants` | Users, contacts, service accounts, or external participants in a chat |
+| `conversation_groups` | Group conversations by workspace area, team, customer, project, or product |
+| `conversations` | Channel, direct chat, group chat, support thread, announcement, or entity-scoped discussion |
+| `conversation_memberships` | User/team/contact membership, role, notification preference, last-read pointer |
 | `messages` | Durable message body, author, timestamps, edit/delete state, source metadata |
-| `threads` | Replies anchored to a message or entity record |
-| `reactions` | Emoji/action reactions on messages, comments, or activity events |
+| `message_threads` | Thread root/reply metadata when `messages.thread_root_id` is insufficient |
+| `message_reactions` | Emoji/action reactions on messages, comments, or activity events |
 | `mentions` | User/team/entity mentions for notification and search |
-| `read_receipts` | Per-user read state for channels, chats, threads, and messages |
+| `read_receipts` | Per-user read state for conversations, threads, and messages |
 | `message_attachments` | Links from messages to files, documents, or external assets |
 
 Rules:
 
+- `conversation_type` covers channel, direct, group, entity, support, and announcement.
+- Comments can be implemented as messages in an entity-scoped conversation; do not maintain a separate comment system unless deliberately lighter-weight.
 - Keep message bodies append/audit friendly: edits create version/audit events or preserve edited-at metadata.
 - Treat typing indicators and transient presence as ephemeral runtime state, not durable business records.
-- Use labels on channels, chats, and threads for grouping such as `status:normal`, `topic:sales`, or `visibility:internal`.
+- Use labels on conversations and threads for grouping such as `status:normal`, `topic:sales`, or `visibility:internal`.
 
 ## CRM activities and reminders
 
-Use `activities` as the shared activity/event surface, with typed objects when fields diverge.
+Use `activities` as the shared timeline/calendar surface. Calls, meetings, tasks, and reminders are activity/calendar types by default, not separate root tables.
 
 | Object | Purpose |
 |--------|---------|
-| `activities` | Shared timeline/calendar base: subject, type, status, parent entity, owner, team |
-| `calls` | Direction, phone/contact links, outcome, recording/transcript links |
-| `meetings` | Start/end, location/link, participants, acceptance status, agenda/outcome |
-| `tasks` | Due date, priority, status, assignee/team, checklist/subtask links |
-| `reminders` | Trigger time, channel, target entity, snooze/dismiss/completed state |
+| `calendar_collections` | Calendar/task-list grouping, including CalDAV calendar collections |
+| `activities` | Shared base: subject, activity type, calendar component, status, parent entity, owner, team |
 | `activity_participants` | Users, contacts, accounts, or external attendees |
 | `activity_links` | Polymorphic links to accounts, contacts, opportunities, cases, issues, documents |
+| `activity_alarms` | Reminder/notification rows: trigger time, delivery channel, snooze/dismiss/completed state; maps to iCalendar alarms |
+| Optional detail tables | `call_details`, `meeting_details`, or `task_details` only when subtype fields justify them |
 
 Default activity statuses:
 
 - planned/scheduled, in-progress, completed/held, cancelled/not-held, deferred.
 
+Default activity/calendar types:
+
+- `call`, `meeting`, `task`, `deadline`, `note`, `journal`, `time_block`.
+
 Rules:
 
-- Calls, meetings, and tasks can be first-class tables or typed `activities`; choose typed tables when they need different validation, UI, or integrations.
-- Reminders are separate rows so one record can notify multiple people through multiple channels.
+- CalDAV-style mapping: meetings/calls/time blocks map to event components; tasks map to todo components; notes/log entries map to journal components; reminders map to alarms.
+- Choose typed detail tables only when the subtype needs different validation, UI, integrations, or indexes: e.g. call recording/transcript fields or meeting room/video-link fields.
+- Activity alarms are one-to-many rows so one activity can notify multiple people through multiple channels; product UI can label them reminders.
 - Use labels for grouping/reporting, but use typed fields for workflow-critical state and dates.
 
 ## Document management
 
-Use a file model that separates binary storage from document metadata and object links.
+Use a file model that separates binary storage from document metadata and object links. WebDAV terms map cleanly: folders are collections, files/file versions are resources, metadata are properties.
 
 | Object | Purpose |
 |--------|---------|
-| `folders` | Workspace-scoped hierarchy for navigation and grouping |
+| `folders` | Workspace-scoped hierarchy/navigation; maps to WebDAV collections |
 | `files` | Logical file/document record: title, mime type, size, checksum, owner, status |
-| `file_versions` | Immutable versions with storage key, checksum, size, created by/at |
+| `file_versions` | Immutable resources with storage key, checksum, size, ETag, created by/at |
 | `file_links` | Attach files/folders to any entity type and entity ID |
+| `file_properties` | WebDAV/dead properties, custom metadata, retention and sensitivity data |
+| `file_locks` | Optional WebDAV-compatible lock tokens, owners, depth, and expiry |
 | `file_permissions` | Optional object-specific grants when folder/workspace permissions are insufficient |
 | `file_comments` | Document comments/annotations when comments are not global |
 | `file_previews` | Derived thumbnails, OCR text, transcripts, embeddings, renditions |
@@ -115,6 +139,23 @@ Rules:
 - Folders organise records; they are not the only permission boundary unless the product explicitly defines folder inheritance.
 - Attachments are links to `files`, not independent binary blobs on each business table.
 - Preserve version, checksum, storage provider/key, source/import provenance, retention class, and sensitivity labels.
+
+## DAV sync compatibility
+
+When an app may mirror with WebDAV, CalDAV, or CardDAV, preserve standard sync handles instead of treating sync as a one-off import.
+
+| Standard | Local model |
+|----------|-------------|
+| WebDAV collections/resources/properties/locks | `folders`, `files`, `file_versions`, `file_properties`, `file_locks` |
+| CalDAV calendars/events/todos/journals/alarms | `calendar_collections`, `activities`, `activity_participants`, `activity_alarms` |
+| CardDAV address books/vCards/groups | `address_books`, `contacts`, account/contact relationships, contact groups or labels |
+
+Rules:
+
+- Store external UID, source URL/path, ETag, sync token/change tag, component type, last synced time, deletion/tombstone state, and raw payload hash where applicable.
+- Keep `contacts` canonical for people; map CardDAV vCards into contacts/contact methods, and map organisation fields to `accounts` when they represent companies.
+- Use address books as sync/grouping containers, not replacements for workspace/account/contact boundaries.
+- Preserve recurrence, attendee, organizer, timezone, alarm, and free/busy fields for calendar objects even if the product UI starts simpler.
 
 ## Access and identity
 
@@ -158,7 +199,7 @@ Accounting rules:
 - Confirm labels/tags are available for each user-facing object type.
 - Confirm grouped label keys such as `status:normal` have a label group/category and exclusivity policy.
 - Trace one issue through label assignment, comments, state transition, audit event, and external-provider sync.
-- Trace one channel/chat message through thread replies, reactions, mentions, read receipts, attachments, audit, and retention rules.
-- Trace one CRM activity through participants, reminders, parent entity links, labels, and calendar/timeline output.
-- Trace one file through folder placement, versioning, attachment to an entity, preview/OCR, permissions, and audit.
+- Trace one conversation message through thread replies, reactions, mentions, read receipts, attachments, audit, and retention rules.
+- Trace one CRM/calendar activity through participants, alarms/reminders, recurrence, parent entity links, labels, and calendar/timeline output.
+- Trace one file through folder placement, versioning, WebDAV-style metadata, attachment to an entity, preview/OCR, permissions, and audit.
 - Trace one quote-to-invoice-to-payment/refund path before calling billing/accounting ready.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -1,0 +1,83 @@
+---
+description: Standard app object packs for issues, labels, commercial documents, accounting, users, teams, and referrals
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Standard Objects
+
+Use boring canonical names so apps, imports, AI agents, and integrations share one vocabulary.
+
+## Universal labels and tags
+
+Every durable object type should be label/tag capable unless there is a deliberate product reason not to expose it.
+
+Prefer a governed label model for important records:
+
+- `labels`: workspace, key, name, color, description, category, visibility, archived state.
+- `label_assignments`: workspace, label, entity type, entity ID, assigned by, assigned at.
+- Optional typed join tables for high-volume or referentially critical objects.
+
+Use free-form tags only for low-risk local filtering or imported metadata. Do not rely on array-only tags for permissions, workflow state, billing, or audit-critical classification.
+
+## Issues
+
+Model `issues` after common forge trackers so GitHub, GitLab, Gitea, support tickets, and internal work items map cleanly.
+
+Core fields:
+
+- `workspace_id`, `title`, `body`, `state`, `state_reason`, `issue_type`, `priority`, `severity`.
+- `author_id`, `assignee_id`, `team_id`, `milestone_id`, `parent_issue_id`, `due_at`, `closed_at`.
+- External mapping: `source_provider`, `source_project`, `source_issue_id`, `source_issue_number`, `source_url`.
+- Labels via `label_assignments`; comments, activity, files, and audit via shared collaboration objects.
+
+Support issue relationships:
+
+- `blocks`, `blocked_by`, `duplicates`, `duplicated_by`, `relates_to`, `split_from`, `supersedes`.
+
+Use `issues` for user-visible work, defects, support requests, and change requests. Use `tasks` for schedule/checklist execution when the product needs a lighter sub-work item.
+
+## Access and identity
+
+- `users`: global/auth identity records.
+- `workspaces`: data and permission boundary.
+- `teams` / `user_groups`: collections of users; distinct from roles.
+- `roles`: permission bundles; assigned to users and/or teams within a workspace.
+- `invitations`, sessions, auth accounts, API keys, and audit events belong in the always-on kernel.
+
+## Commercial and accounting pack
+
+Add commercial objects deliberately, but keep names conventional:
+
+| Need | Canonical objects |
+|------|-------------------|
+| Parties | `accounts`, `contacts`, addresses, contact methods |
+| Products/services | `items` or `products`, `services`, units, tax categories |
+| Pricing | `prices`, `price_lists`, price list items, currencies |
+| Discounts | `discount_codes` / `voucher_codes`, pricing rules, redemptions |
+| Sales pipeline | leads, opportunities, campaigns, referrers, referrals |
+| Quotes | `quotes` / estimates, quote lines, expiry, acceptance state |
+| Orders | orders, order lines, fulfilment/status events |
+| Invoices | invoices, invoice lines, pro-forma invoices, tax totals |
+| Credits | credit notes, account credits, credit allocations |
+| Payments | payments, payment allocations, refunds, refund payments |
+| Subscriptions | subscriptions, plans, billing periods, renewal events |
+| Accounting | ledger entries, journals, tax codes, accounts, reconciliation |
+
+Accounting rules:
+
+- Store money as exact numeric values with explicit currency and tax treatment.
+- Keep document numbers stable, sequential where legally required, and workspace/account scoped.
+- Treat issued invoices as immutable; correct them with credit notes, adjustments, or reversal documents.
+- Pro-forma invoices are non-posting documents until converted/issued; do not mix them with posted ledger entries.
+- Payments are separate from invoices; allocate payments/refunds to documents through allocation rows.
+- Preserve provider IDs, payment processor event IDs, and import provenance for reconciliation.
+
+## Verification
+
+- Map incoming synonyms to canonical objects before adding new tables.
+- Confirm labels/tags are available for each user-facing object type.
+- Trace one issue through label assignment, comments, state transition, audit event, and external-provider sync.
+- Trace one quote-to-invoice-to-payment/refund path before calling billing/accounting ready.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -20,6 +20,7 @@ workspace
   users / teams / roles / permissions
   accounts / contacts / address_books
   issues / issue_relationships
+  content_types / content_entries / content_revisions / routes
   workflow_definitions / workflow_runs / workflow_transition_events / approval_requests
   conversation_groups / conversations / messages / message_threads / message_reactions
   calendar_collections / activities / activity_participants / activity_alarms
@@ -70,6 +71,49 @@ Support issue relationships:
 - `blocks`, `blocked_by`, `duplicates`, `duplicated_by`, `relates_to`, `split_from`, `supersedes`.
 
 Use `issues` for user-visible work, defects, support requests, and change requests. Use `activities` with `activity_type = task` for calendar/todo items. Add a separate task/checklist table only when task-specific lifecycle, nesting, or execution queues justify it.
+
+## Content, posts, and pages
+
+Use WordPress for full editorial/CMS sites where editors need the WordPress ecosystem. In product apps or custom portals, use an app-native content model that mirrors the useful post/post-type/page concepts without adopting WordPress table names.
+
+WordPress concept mapping:
+
+| WordPress concept | App-stack object |
+|-------------------|------------------|
+| Post type | `content_types` |
+| Post/page/custom post record | `content_entries` |
+| Page URL/permalink | `routes` or `content_routes` |
+| Revisions | `content_revisions` |
+| Blocks/patterns | `content_blocks` |
+| Categories/tags/custom taxonomies | `taxonomies`, `terms`, `term_assignments`, labels |
+| Media library item | `files` with `file_links` |
+| Menus | `menus`, `menu_items` |
+| SEO fields | `seo_metadata` linked to content/routes |
+
+Core model:
+
+| Object | Purpose |
+|--------|---------|
+| `content_types` | Editorial/domain content type: page, post, article, help doc, landing page, product page |
+| `content_entries` | Typed content record with title, slug, status, owner, locale, dates, summary/body |
+| `content_revisions` | Immutable revisions with editor, diff/source snapshot, reason, publish metadata |
+| `content_blocks` | Structured page sections or rich-content blocks ordered within an entry/revision |
+| `routes` / `content_routes` | URL path, canonical target, redirects, locale, route status |
+| `taxonomies` | Category/tag vocabularies, hierarchical or flat |
+| `terms` | Taxonomy values; can mirror labels when simple grouping is enough |
+| `term_assignments` | Entry-to-term assignments with sort/context metadata |
+| `menus` / `menu_items` | Navigation structures independent of content storage |
+| `seo_metadata` | Title, description, robots, canonical URL, social cards, structured-data hints |
+
+Rules:
+
+- Pages and posts are content entries with different `content_type` values by default; use separate tables only for distinct lifecycle, validation, or performance needs.
+- Use `routes` for URL ownership so slugs, redirects, previews, and localized routes do not become hidden fields on unrelated tables.
+- Use workflows for draft/review/approved/published/archived lifecycles; labels can mirror editorial status but are not the source of truth.
+- Use files/file links for media assets; do not create a separate media-blob system for content.
+- Use metadata field definitions when content types are editor-configurable; use migrations for core product content tables.
+
+Choose WordPress instead when routine editors need posts/pages/media library/revisions/forms/SEO plugins/themes/plugin ecosystem more than product-specific app integration.
 
 ## Workflows and automations
 
@@ -240,6 +284,7 @@ Accounting rules:
 - Confirm labels/tags are available for each user-facing object type.
 - Confirm grouped label keys such as `status:normal` have a label group/category and exclusivity policy.
 - Trace one issue through label assignment, comments, state transition, audit event, and external-provider sync.
+- Trace one content entry through type definition, route, revision, block/media link, taxonomy/label assignment, workflow, SEO metadata, and publish/preview output.
 - Trace one workflow through definition, state, transition, guard, action, approval, timer, runtime event, and audit record.
 - Trace one conversation message through thread replies, reactions, mentions, read receipts, attachments, audit, and retention rules.
 - Trace one CRM/calendar activity through participants, alarms/reminders, recurrence, parent entity links, labels, and calendar/timeline output.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -292,8 +292,8 @@ Rules:
 - `users`: global/auth identity records.
 - `workspaces`: data and permission boundary.
 - `teams` / `user_groups`: collections of users; distinct from roles.
-- `roles`: permission bundles; assigned to users and/or teams within a workspace.
-- `invitations`, sessions, auth accounts, API keys, and audit events belong in the always-on kernel.
+- `roles`: permission bundles; assigned to users, service accounts, and/or teams within a workspace.
+- `workspace_invitations`, sessions, auth accounts, API keys, and audit events belong in the always-on kernel.
 
 ## Commercial and accounting pack
 

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -31,6 +31,8 @@ workspace
 
 Use separate tables only when the subtype needs distinct validation, lifecycle, permissions, integrations, or high-volume indexes. Otherwise use a typed row plus metadata.
 
+The hierarchy abbreviates always-on platform/kernel objects; see `app-stack/platform-kernel.md` for the full notification, audit, import/export, integration, search, report, form, settings, job, and retention model.
+
 For cross-object relationships, default to generic link tables with `entity_type` and `entity_id`. Use typed join tables only for high-volume, referentially critical, permission-critical, or heavily indexed relationships.
 
 ## Slugs, routes, and hierarchy
@@ -92,7 +94,9 @@ Core fields:
 - `workspace_id`, `title`, `body`, `state`, `state_reason`, `issue_type`, `priority`, `severity`.
 - `author_id`, `assignee_id`, `team_id`, `milestone_id`, `parent_issue_id`, `due_at`, `closed_at`.
 - External mapping: `source_provider`, `source_project`, `source_issue_id`, `source_issue_number`, `source_url`.
-- Labels via `label_assignments`; comments, activity, files, and audit via shared collaboration objects.
+- Labels via `label_assignments`; entity-scoped messages, activity, files, and audit via shared collaboration objects.
+
+Treat external URLs and paths as sensitive integration metadata: strip credentials and transient query tokens, prefer opaque provider IDs for matching, and avoid exposing private/local paths in public exports or support artifacts.
 
 Support issue relationships:
 
@@ -179,7 +183,7 @@ Rules:
 - Version workflow definitions; existing runtime runs keep the definition version they started with unless migrated deliberately.
 - Treat transition events as append-only audit records; never infer history only from the current state.
 - Keep guards deterministic and side-effect free; actions perform side effects after guards pass.
-- Model approvals as workflow steps, not as free-floating comments.
+- Model approvals as workflow steps, not as free-floating messages.
 - Automation rules can start workflows, enqueue actions, or create issues/tasks, but should not bypass RBAC or RLS.
 - Use outbox/job rows for webhooks, email, AI actions, document generation, ledger posting, and external integration calls.
 
@@ -187,7 +191,7 @@ Relationship to other objects:
 
 - Issues track work; workflows control state and process.
 - Activities log or schedule CRM/calendar events; workflows can create activities or wait for them.
-- Conversations/comments discuss records; workflows can require/emit comments but should not use comments as state.
+- Conversations and entity-scoped messages discuss records; workflows can require or emit messages, but messages are not state.
 - Labels group and filter; typed workflow state remains the source of truth.
 
 ## Conversations, chat, and communication
@@ -277,6 +281,7 @@ When an app may mirror with WebDAV, CalDAV, or CardDAV, preserve standard sync h
 Rules:
 
 - Store external UID, source URL/path, ETag, sync token/change tag, component type, last synced time, deletion/tombstone state, and raw payload hash where applicable.
+- Strip credentials and transient query tokens from URLs, classify sensitive source paths, prefer opaque provider IDs for joins, and avoid raw private/local paths in exportable or public-facing rows.
 - Keep `contacts` canonical for people; map CardDAV vCards into contacts/contact methods, and map organisation fields to `accounts` when they represent companies.
 - Use address books as sync/grouping containers, not replacements for workspace/account/contact boundaries.
 - Preserve recurrence, attendee, organizer, timezone, alarm, and free/busy fields for calendar objects even if the product UI starts simpler.
@@ -322,7 +327,7 @@ Accounting rules:
 - Map incoming synonyms to canonical objects before adding new tables.
 - Confirm labels/tags are available for each user-facing object type.
 - Confirm grouped label keys such as `status:normal` have a label group/category and exclusivity policy.
-- Trace one issue through label assignment, comments, state transition, audit event, and external-provider sync.
+- Trace one issue through label assignment, entity-scoped message, state transition, audit event, and external-provider sync.
 - Trace one content entry through type definition, route, revision, block/media link, taxonomy/label assignment, workflow, SEO metadata, and publish/preview output.
 - Trace one workflow through definition, state, transition, guard, action, approval, timer, runtime event, and audit record.
 - Trace one conversation message through thread replies, reactions, mentions, read receipts, attachments, audit, and retention rules.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -127,8 +127,8 @@ Core model:
 | `content_revisions` | Immutable revisions with editor, diff/source snapshot, reason, publish metadata |
 | `content_blocks` | Structured page sections or rich-content blocks ordered within an entry/revision |
 | `routes` / `content_routes` | Full URL path/permalink, local slug/segment when useful, parent route, canonical target, redirects, locale, route status |
-| `taxonomies` | Content classification vocabularies such as category, tag, topic, audience; hierarchical or flat |
-| `terms` | Values inside a taxonomy, e.g. News, AI, Developers; hierarchical terms use `parent_id` |
+| `taxonomies` | Content classification vocabularies such as category, tag, topic, audience; includes hierarchy and navigation policy |
+| `terms` | Values inside a taxonomy, e.g. News, AI, Developers; include slug, description, SEO metadata, and optional `parent_id` |
 | `term_assignments` | Entry-to-term assignments with sort/context metadata |
 | `menus` / `menu_items` | Navigation structures independent of content storage |
 | `seo_metadata` | Title, description, robots, canonical URL, social cards, structured-data hints |
@@ -142,6 +142,14 @@ Rules:
 - Use files/file links for media assets; do not create a separate media-blob system for content.
 - Use metadata field definitions when content types are editor-configurable; use migrations for core product content tables.
 - Use taxonomies/terms for content classification. Use labels for cross-object operational grouping such as `status:normal` or `priority:high`. Only use labels as content tags in deliberately simple flat-tag products with no taxonomy hierarchy, term metadata, or editorial taxonomy UI.
+
+Category/tag taxonomy rules:
+
+- Category-style taxonomies are hierarchical, navigational, and high-level. Use them for primary site/app information architecture, menus, archive pages, breadcrumbs, and broad editorial grouping.
+- Tag-style taxonomies are flat keyword/topic facets. Use them for long-tail discovery, search/filtering, related-content matching, and SEO topic coverage.
+- Model taxonomy behaviour explicitly with fields such as `is_hierarchical`, `is_navigational`, `has_public_archive`, `allows_multiple`, and `term_description_required`.
+- Term descriptions should be editorial content, not keyword stuffing. For public archive pages, a 150-300 character description is a useful default target.
+- If term descriptions render on public pages, support safe internal links to relevant canonical content or related terms, with validation/sanitisation and no raw HTML bypass.
 
 Choose WordPress instead when routine editors need posts/pages/media library/revisions/forms/SEO plugins/themes/plugin ecosystem more than product-specific app integration.
 

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -1,5 +1,5 @@
 ---
-description: Standard app object packs for issues, labels, commercial documents, accounting, users, teams, and referrals
+description: Standard app object packs for issues, labels, chat, CRM activities, document management, accounting, users, teams, and referrals
 mode: subagent
 ---
 
@@ -16,11 +16,20 @@ Every durable object type should be label/tag capable unless there is a delibera
 
 Prefer a governed label model for important records:
 
-- `labels`: workspace, key, name, color, description, category, visibility, archived state.
+- `label_groups`: workspace, key, name, description, exclusive-per-entity flag, sort order, archived state.
+- `labels`: workspace, group, key, value, name, color, description, visibility, archived state.
 - `label_assignments`: workspace, label, entity type, entity ID, assigned by, assigned at.
 - Optional typed join tables for high-volume or referentially critical objects.
 
 Use free-form tags only for low-risk local filtering or imported metadata. Do not rely on array-only tags for permissions, workflow state, billing, or audit-critical classification.
+
+Use grouped label keys for classification and UI grouping:
+
+- `status:normal`, `status:blocked`, `status:archived`.
+- `priority:high`, `priority:low`.
+- `type:bug`, `type:feature`, `type:support`.
+
+If a value drives workflow or compliance, keep a typed status/state field as the source of truth and mirror it to labels only for filtering/grouping.
 
 ## Issues
 
@@ -38,6 +47,74 @@ Support issue relationships:
 - `blocks`, `blocked_by`, `duplicates`, `duplicated_by`, `relates_to`, `split_from`, `supersedes`.
 
 Use `issues` for user-visible work, defects, support requests, and change requests. Use `tasks` for schedule/checklist execution when the product needs a lighter sub-work item.
+
+## Chat and communication
+
+Use one durable communication model that can attach to issues, accounts, contacts, projects, documents, or standalone workspaces.
+
+| Object | Purpose |
+|--------|---------|
+| `channel_groups` | Group channels by workspace area, team, customer, project, or product |
+| `channels` | Named spaces: public, private, team, project, support, announcement |
+| `channel_memberships` | User/team membership, role, notification preference, last-read pointer |
+| `chats` | Direct, group, or entity-scoped conversations that are not named channels |
+| `chat_participants` | Users, contacts, service accounts, or external participants in a chat |
+| `messages` | Durable message body, author, timestamps, edit/delete state, source metadata |
+| `threads` | Replies anchored to a message or entity record |
+| `reactions` | Emoji/action reactions on messages, comments, or activity events |
+| `mentions` | User/team/entity mentions for notification and search |
+| `read_receipts` | Per-user read state for channels, chats, threads, and messages |
+| `message_attachments` | Links from messages to files, documents, or external assets |
+
+Rules:
+
+- Keep message bodies append/audit friendly: edits create version/audit events or preserve edited-at metadata.
+- Treat typing indicators and transient presence as ephemeral runtime state, not durable business records.
+- Use labels on channels, chats, and threads for grouping such as `status:normal`, `topic:sales`, or `visibility:internal`.
+
+## CRM activities and reminders
+
+Use `activities` as the shared activity/event surface, with typed objects when fields diverge.
+
+| Object | Purpose |
+|--------|---------|
+| `activities` | Shared timeline/calendar base: subject, type, status, parent entity, owner, team |
+| `calls` | Direction, phone/contact links, outcome, recording/transcript links |
+| `meetings` | Start/end, location/link, participants, acceptance status, agenda/outcome |
+| `tasks` | Due date, priority, status, assignee/team, checklist/subtask links |
+| `reminders` | Trigger time, channel, target entity, snooze/dismiss/completed state |
+| `activity_participants` | Users, contacts, accounts, or external attendees |
+| `activity_links` | Polymorphic links to accounts, contacts, opportunities, cases, issues, documents |
+
+Default activity statuses:
+
+- planned/scheduled, in-progress, completed/held, cancelled/not-held, deferred.
+
+Rules:
+
+- Calls, meetings, and tasks can be first-class tables or typed `activities`; choose typed tables when they need different validation, UI, or integrations.
+- Reminders are separate rows so one record can notify multiple people through multiple channels.
+- Use labels for grouping/reporting, but use typed fields for workflow-critical state and dates.
+
+## Document management
+
+Use a file model that separates binary storage from document metadata and object links.
+
+| Object | Purpose |
+|--------|---------|
+| `folders` | Workspace-scoped hierarchy for navigation and grouping |
+| `files` | Logical file/document record: title, mime type, size, checksum, owner, status |
+| `file_versions` | Immutable versions with storage key, checksum, size, created by/at |
+| `file_links` | Attach files/folders to any entity type and entity ID |
+| `file_permissions` | Optional object-specific grants when folder/workspace permissions are insufficient |
+| `file_comments` | Document comments/annotations when comments are not global |
+| `file_previews` | Derived thumbnails, OCR text, transcripts, embeddings, renditions |
+
+Rules:
+
+- Folders organise records; they are not the only permission boundary unless the product explicitly defines folder inheritance.
+- Attachments are links to `files`, not independent binary blobs on each business table.
+- Preserve version, checksum, storage provider/key, source/import provenance, retention class, and sensitivity labels.
 
 ## Access and identity
 
@@ -79,5 +156,9 @@ Accounting rules:
 
 - Map incoming synonyms to canonical objects before adding new tables.
 - Confirm labels/tags are available for each user-facing object type.
+- Confirm grouped label keys such as `status:normal` have a label group/category and exclusivity policy.
 - Trace one issue through label assignment, comments, state transition, audit event, and external-provider sync.
+- Trace one channel/chat message through thread replies, reactions, mentions, read receipts, attachments, audit, and retention rules.
+- Trace one CRM activity through participants, reminders, parent entity links, labels, and calendar/timeline output.
+- Trace one file through folder placement, versioning, attachment to an entity, preview/OCR, permissions, and audit.
 - Trace one quote-to-invoice-to-payment/refund path before calling billing/accounting ready.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -20,13 +20,16 @@ workspace
   users / teams / roles / permissions
   accounts / contacts / address_books
   issues / issue_relationships
+  workflow_definitions / workflow_runs / workflow_transition_events / approval_requests
   conversation_groups / conversations / messages / message_threads / message_reactions
   calendar_collections / activities / activity_participants / activity_alarms
   folders / files / file_versions / file_links
-  quotes / invoices / payments / credits / ledger_entries
+  quotes / invoices / payments / credits / ledger_accounts / ledger_entries
 ```
 
 Use separate tables only when the subtype needs distinct validation, lifecycle, permissions, integrations, or high-volume indexes. Otherwise use a typed row plus metadata.
+
+For cross-object relationships, default to generic link tables with `entity_type` and `entity_id`. Use typed join tables only for high-volume, referentially critical, permission-critical, or heavily indexed relationships.
 
 ## Universal labels and tags
 
@@ -38,6 +41,8 @@ Prefer a governed label model for important records:
 - `labels`: workspace, group, key, value, name, color, description, visibility, archived state.
 - `label_assignments`: workspace, label, entity type, entity ID, assigned by, assigned at.
 - Optional typed join tables for high-volume or referentially critical objects.
+
+`label_group_definitions` and `label_definitions` are reusable metadata templates/catalog rows. `label_groups` and `labels` are workspace/runtime rows. If a product has no template layer, use only the runtime rows.
 
 Use free-form tags only for low-risk local filtering or imported metadata. Do not rely on array-only tags for permissions, workflow state, billing, or audit-critical classification.
 
@@ -64,7 +69,43 @@ Support issue relationships:
 
 - `blocks`, `blocked_by`, `duplicates`, `duplicated_by`, `relates_to`, `split_from`, `supersedes`.
 
-Use `issues` for user-visible work, defects, support requests, and change requests. Use `tasks` for schedule/checklist execution when the product needs a lighter sub-work item.
+Use `issues` for user-visible work, defects, support requests, and change requests. Use `activities` with `activity_type = task` for calendar/todo items. Add a separate task/checklist table only when task-specific lifecycle, nesting, or execution queues justify it.
+
+## Workflows and automations
+
+Use workflows for repeatable state machines and business processes. Do not hide workflow state in labels, UI-only conditionals, or ad-hoc background jobs.
+
+Core model:
+
+| Object | Purpose |
+|--------|---------|
+| `workflow_definitions` | Workflow key, version, entity scope, trigger model, active/draft/archived state |
+| `workflow_state_definitions` | Initial, normal, terminal, cancelled, error, or approval states |
+| `workflow_transition_definitions` | From/to state, label, capability, guard, validation, sort order |
+| `workflow_action_definitions` | Side effects: field update, task, approval, notification, webhook, job, document, ledger post |
+| `workflow_guard_definitions` | Conditions and predicates evaluated before a transition or action |
+| `workflow_runs` | Runtime instance for an entity/process with current state and correlation ID |
+| `workflow_transition_events` | Append-only transition history with actor, old/new state, reason, guard result |
+| `approval_requests` | Human approval step, approver user/team/role, due date, delegated/rejected/approved state |
+| `automation_rules` | Event/schedule triggers that start workflows or execute safe actions |
+| `workflow_timers` | SLA, delay, escalation, reminder, and timeout scheduling |
+
+Rules:
+
+- For workflow-managed records, `workflow_runs.current_state` is authoritative. A business-record status field may denormalise current state for fast queries. For simple fixed lifecycles without a workflow engine, a typed status field can be authoritative.
+- Version workflow definitions; existing runtime runs keep the definition version they started with unless migrated deliberately.
+- Treat transition events as append-only audit records; never infer history only from the current state.
+- Keep guards deterministic and side-effect free; actions perform side effects after guards pass.
+- Model approvals as workflow steps, not as free-floating comments.
+- Automation rules can start workflows, enqueue actions, or create issues/tasks, but should not bypass RBAC or RLS.
+- Use outbox/job rows for webhooks, email, AI actions, document generation, ledger posting, and external integration calls.
+
+Relationship to other objects:
+
+- Issues track work; workflows control state and process.
+- Activities log or schedule CRM/calendar events; workflows can create activities or wait for them.
+- Conversations/comments discuss records; workflows can require/emit comments but should not use comments as state.
+- Labels group and filter; typed workflow state remains the source of truth.
 
 ## Conversations, chat, and communication
 
@@ -85,7 +126,7 @@ Use one durable conversation model that can attach to issues, accounts, contacts
 Rules:
 
 - `conversation_type` covers channel, direct, group, entity, support, and announcement.
-- Comments can be implemented as messages in an entity-scoped conversation; do not maintain a separate comment system unless deliberately lighter-weight.
+- Comments default to messages in an entity-scoped conversation. Use a separate lightweight comments table only when the product deliberately does not need conversation membership, threads, read receipts, or chat features.
 - Keep message bodies append/audit friendly: edits create version/audit events or preserve edited-at metadata.
 - Treat typing indicators and transient presence as ephemeral runtime state, not durable business records.
 - Use labels on conversations and threads for grouping such as `status:normal`, `topic:sales`, or `visibility:internal`.
@@ -137,7 +178,7 @@ Use a file model that separates binary storage from document metadata and object
 Rules:
 
 - Folders organise records; they are not the only permission boundary unless the product explicitly defines folder inheritance.
-- Attachments are links to `files`, not independent binary blobs on each business table.
+- Attachments are links to `files`, not independent binary blobs on each business table. Default to `file_links`; use `message_attachments` only for message-specific ordering, captions, or inline display metadata.
 - Preserve version, checksum, storage provider/key, source/import provenance, retention class, and sensitivity labels.
 
 ## DAV sync compatibility
@@ -182,7 +223,7 @@ Add commercial objects deliberately, but keep names conventional:
 | Credits | credit notes, account credits, credit allocations |
 | Payments | payments, payment allocations, refunds, refund payments |
 | Subscriptions | subscriptions, plans, billing periods, renewal events |
-| Accounting | ledger entries, journals, tax codes, accounts, reconciliation |
+| Accounting | `ledger_accounts` / `chart_accounts`, ledger entries, journals, tax codes, reconciliation |
 
 Accounting rules:
 
@@ -199,6 +240,7 @@ Accounting rules:
 - Confirm labels/tags are available for each user-facing object type.
 - Confirm grouped label keys such as `status:normal` have a label group/category and exclusivity policy.
 - Trace one issue through label assignment, comments, state transition, audit event, and external-provider sync.
+- Trace one workflow through definition, state, transition, guard, action, approval, timer, runtime event, and audit record.
 - Trace one conversation message through thread replies, reactions, mentions, read receipts, attachments, audit, and retention rules.
 - Trace one CRM/calendar activity through participants, alarms/reminders, recurrence, parent entity links, labels, and calendar/timeline output.
 - Trace one file through folder placement, versioning, WebDAV-style metadata, attachment to an entity, preview/OCR, permissions, and audit.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -32,6 +32,33 @@ Use separate tables only when the subtype needs distinct validation, lifecycle, 
 
 For cross-object relationships, default to generic link tables with `entity_type` and `entity_id`. Use typed join tables only for high-volume, referentially critical, permission-critical, or heavily indexed relationships.
 
+## Slugs, routes, and hierarchy
+
+Use stable IDs for identity. Use slugs and routes for human-readable addressing.
+
+| Concept | Standard meaning |
+|---------|------------------|
+| `slug` | URL-safe local segment or human-readable key, e.g. `about-us`; not a primary key and not necessarily a full path |
+| `path` | Full route/permalink path, e.g. `/company/about-us` |
+| `routes` / `content_routes` | URL ownership, canonical target, redirects, previews, locale, and publication state |
+| `parent_id` | Single-parent hierarchy for pages, folders, terms, menu items, issues, teams, or accounts when needed |
+| `sort_order` | Sibling ordering within the same parent/container |
+
+Slug rules:
+
+- Do not use slugs as primary keys. Store stable IDs and treat slugs as mutable display/routing fields.
+- Scope slug uniqueness by workspace plus parent/container plus locale/type, e.g. `(workspace_id, parent_id, slug, locale)`.
+- Preserve old slugs as redirect rows when public URLs change.
+- Use `slug` for a segment; use `path` on `routes` for the full permalink.
+
+Hierarchy rules:
+
+- Default to an adjacency list: nullable `parent_id`, `sort_order`, and a cycle-prevention check in application/service code.
+- Add `depth`, `path`, or materialized-path/cache columns only for fast breadcrumbs, URL generation, tree queries, or sync.
+- Add closure tables such as `term_ancestors` or `folder_ancestors` only for deep trees, inherited permissions, or high-volume ancestor queries.
+- Parent-child hierarchy is not permission inheritance unless the product explicitly defines inheritance and tests it.
+- Use assignment/link tables instead of `parent_id` for many-to-many grouping.
+
 ## Universal labels and tags
 
 Every durable object type should be label/tag capable unless there is a deliberate product reason not to expose it.
@@ -82,7 +109,8 @@ WordPress concept mapping:
 |-------------------|------------------|
 | Post type | `content_types` |
 | Post/page/custom post record | `content_entries` |
-| Page URL/permalink | `routes` or `content_routes` |
+| Slug/post name | `slug` field scoped to parent/container/locale/type |
+| Page URL/permalink | `routes` or `content_routes` with full `path` |
 | Revisions | `content_revisions` |
 | Blocks/patterns | `content_blocks` |
 | Categories/tags/custom taxonomies | `taxonomies`, `terms`, `term_assignments` |
@@ -98,9 +126,9 @@ Core model:
 | `content_entries` | Typed content record with title, slug, status, owner, locale, dates, summary/body |
 | `content_revisions` | Immutable revisions with editor, diff/source snapshot, reason, publish metadata |
 | `content_blocks` | Structured page sections or rich-content blocks ordered within an entry/revision |
-| `routes` / `content_routes` | URL path, canonical target, redirects, locale, route status |
+| `routes` / `content_routes` | Full URL path/permalink, local slug/segment when useful, parent route, canonical target, redirects, locale, route status |
 | `taxonomies` | Content classification vocabularies such as category, tag, topic, audience; hierarchical or flat |
-| `terms` | Values inside a taxonomy, e.g. News, AI, Developers |
+| `terms` | Values inside a taxonomy, e.g. News, AI, Developers; hierarchical terms use `parent_id` |
 | `term_assignments` | Entry-to-term assignments with sort/context metadata |
 | `menus` / `menu_items` | Navigation structures independent of content storage |
 | `seo_metadata` | Title, description, robots, canonical URL, social cards, structured-data hints |
@@ -108,7 +136,8 @@ Core model:
 Rules:
 
 - Pages and posts are content entries with different `content_type` values by default; use separate tables only for distinct lifecycle, validation, or performance needs.
-- Use `routes` for URL ownership so slugs, redirects, previews, and localized routes do not become hidden fields on unrelated tables.
+- Use `routes` for URL ownership so full paths, redirects, previews, and localized routes do not become hidden fields on unrelated tables.
+- Use `slug` for the local content or route segment; use route `path` for the full permalink.
 - Use workflows for draft/review/approved/published/archived lifecycles; labels can mirror editorial status but are not the source of truth.
 - Use files/file links for media assets; do not create a separate media-blob system for content.
 - Use metadata field definitions when content types are editor-configurable; use migrations for core product content tables.

--- a/.agents/tools/app-stack/standard-objects.md
+++ b/.agents/tools/app-stack/standard-objects.md
@@ -18,6 +18,7 @@ Avoid competing roots. Prefer a small set of canonical containers, then model pr
 workspace
   labels / label_groups / label_assignments
   users / teams / roles / permissions
+  notifications / audit_events / integrations / search_queries / saved_views
   accounts / contacts / address_books
   issues / issue_relationships
   content_types / content_entries / content_revisions / routes

--- a/.agents/tools/app-stack/static-site-starter.md
+++ b/.agents/tools/app-stack/static-site-starter.md
@@ -30,9 +30,19 @@ Use for plain public sites that need speed, metadata quality, accessibility, and
 | File | Purpose |
 |------|---------|
 | `index.html` | Semantic structure, metadata, JSON-LD, nav, hero, sections, CTA, footer |
+| `about.html` | Required public about/publisher page |
+| `contact.html` | Required contact/support/sales page |
+| `privacy.html` | Required privacy policy placeholder page |
+| `terms.html` | Required terms of service/use placeholder page |
+| `docs.html` | Human docs entry point or redirect target |
+| `api.html` | API overview or redirect target for generated API docs |
+| `mcp.html` | MCP/agent integration overview or redirect target |
+| `cli.html` | CLI overview or redirect target |
 | `styles.css` | Reset, tokens, layout, responsive components, themes, focus states |
 | `script.js` | Progressive enhancement only: theme, tabs, copy feedback, anchors |
 | `site.webmanifest` | App name, colours, icons |
+| `robots.txt` | Crawl policy and sitemap pointer |
+| `sitemap.xml` | Required routes and canonical URLs |
 | `README.md` | Customization, validation, deployment notes |
 
 ## Metadata checklist
@@ -42,7 +52,15 @@ Use for plain public sites that need speed, metadata quality, accessibility, and
 - Theme colour and app names.
 - Favicons and manifest links.
 - JSON-LD graph for `WebSite`, `Organization`, and page/app-specific entity.
+- JSON-LD/schema for required pages and relevant public objects; see `public-site-surfaces.md`.
 - Obvious placeholders for all URLs, images, social accounts, analytics, and product copy.
+
+## Required routes
+
+- `/about`, `/contact`, `/privacy`, and `/terms` are launch blockers for every downstream site.
+- `/docs`, `/api`, `/mcp`, and `/cli` should exist as pages, honest status pages, or stable redirects to docs sections.
+- Footer and sitemap link to every required page.
+- Placeholder legal/contact/developer copy must be visibly marked and replaced before launch.
 
 ## Interaction rules
 
@@ -57,5 +75,6 @@ Use for plain public sites that need speed, metadata quality, accessibility, and
 - Open locally at desktop and mobile widths.
 - Keyboard-test all links, buttons, tabs, copy controls, and theme toggle.
 - Check metadata placeholders before launch.
+- Verify required public pages, developer pages, sitemap links, and structured data.
 - Run accessibility and Lighthouse checks.
-- Confirm no site-specific brand, analytics key, private URL, command, or product copy leaked from a reference site.
+- Confirm no site-specific brand, analytics key, secret, internal endpoint, private URL, private repository name, local path, command, non-public support contact, or product copy leaked from a reference site.

--- a/.agents/tools/app-stack/workflow-architecture.md
+++ b/.agents/tools/app-stack/workflow-architecture.md
@@ -1,0 +1,73 @@
+---
+description: Workflow, automation, approval, state machine, and runtime event architecture for business apps
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Workflow Architecture
+
+Model workflows as explicit, versioned state machines with runtime events. Workflow state must be queryable, auditable, permissioned, and testable.
+
+## Canonical objects
+
+| Object | Purpose |
+|--------|---------|
+| `workflow_definitions` | Workflow key, version, entity scope, trigger model, owner, lifecycle |
+| `workflow_state_definitions` | State keys, labels, categories, initial/terminal flags, display order |
+| `workflow_transition_definitions` | From/to states, label, actor type, capability, guard, action list |
+| `workflow_guard_definitions` | Deterministic predicates: field values, role/team, amount limits, dates, related records |
+| `workflow_action_definitions` | Field update, task/issue creation, approval request, notification, webhook, job, document, ledger post |
+| `workflow_runs` | Runtime instance for a record/process with current state, definition version, correlation ID |
+| `workflow_transition_events` | Append-only event log: actor, old/new state, guard result, reason, metadata |
+| `approval_requests` | Human approval/rejection/delegation step assigned to user, team, role, or capability |
+| `automation_rules` | Event/schedule/integration triggers that start workflows or enqueue safe actions |
+| `workflow_timers` | Delays, SLA timers, escalation, reminders, timeouts, retry windows |
+| `workflow_outbox` | Reliable side-effect queue for email, webhooks, AI calls, documents, ledger posts |
+
+## Definition vs runtime
+
+- Definition tables describe allowed states, transitions, guards, actions, and approvals.
+- Runtime tables record the current workflow run, transition history, pending approvals, timers, and outbox jobs.
+- `workflow_runs.current_state` is authoritative for workflow-managed records. A business-record status field may denormalise current state for fast queries, but transition history still lives in `workflow_transition_events`.
+- Labels such as `status:normal` can mirror workflow state for grouping; they are not the source of truth for a state machine.
+
+## Triggers
+
+| Trigger | Use |
+|---------|-----|
+| Record event | create/update/delete, field changed, label assigned, file attached |
+| User action | explicit transition, approve, reject, submit, publish, close |
+| Timer | due date, SLA, scheduled recurrence, timeout, retry |
+| Integration | webhook, payment event, email, calendar sync, import completion |
+| AI/tool event | reviewed output, extraction complete, confidence threshold crossed |
+
+## Guards and actions
+
+- Guards are side-effect free checks. Examples: role/capability, amount threshold, required fields, related approval, no open blockers, valid transition.
+- Actions run only after guards pass. Examples: update state, create task/issue/activity, request approval, send notification, enqueue webhook, generate document, post ledger entry.
+- Actions that touch external systems use `workflow_outbox` and idempotency keys.
+
+## Approvals
+
+- Approval definitions belong to the workflow, not only to comments or tasks.
+- Approval requests record approver user/team/role/capability, due date, delegation, decision, reason, and audit metadata.
+- Multi-step approvals need order, quorum/all-of/any-of policy, escalation, and override rules.
+- Approval permissions are capabilities such as `invoice.approve`, `workflow.override`, or `quote.reject`.
+
+## Relationship to other standard objects
+
+- Issues track human-visible work; workflows can create, update, block, or close issues.
+- Activities schedule/log calls, meetings, tasks, deadlines, and reminders; workflows can wait for or create activities.
+- Conversations/comments discuss records; workflow actions can emit comments/messages, but comments are not workflow state.
+- Labels group/filter records; typed state and transition events remain authoritative.
+- Files/documents can be workflow inputs/outputs; document generation and signing use outbox jobs and audit events.
+
+## Verification
+
+- Draw the state diagram before writing migrations.
+- Demonstrate one workflow from draft definition to active version, start trigger, transition, guard, approval, action, timer, outbox job, and audit event.
+- Prove invalid transitions fail, stale versions remain reproducible, and repeated external events are idempotent.
+- Test RBAC/RLS for transition, approval, override, export, and privileged read actions.
+- Confirm workflow events are append-only and enough to explain current state.

--- a/.agents/tools/app-stack/workflow-architecture.md
+++ b/.agents/tools/app-stack/workflow-architecture.md
@@ -24,12 +24,12 @@ Model workflows as explicit, versioned state machines with runtime events. Workf
 | `approval_requests` | Human approval/rejection/delegation step assigned to user, team, role, or capability |
 | `automation_rules` | Event/schedule/integration triggers that start workflows or enqueue safe actions |
 | `workflow_timers` | Delays, SLA timers, escalation, reminders, timeouts, retry windows |
-| `workflow_outbox` | Reliable side-effect queue for email, webhooks, AI calls, documents, ledger posts |
+| `outbox_events` | Reliable side-effect queue for workflow-triggered email, webhooks, AI calls, documents, ledger posts |
 
 ## Definition vs runtime
 
 - Definition tables describe allowed states, transitions, guards, actions, and approvals.
-- Runtime tables record the current workflow run, transition history, pending approvals, timers, and outbox jobs.
+- Runtime tables record the current workflow run, transition history, pending approvals, timers, and outbox events.
 - `workflow_runs.current_state` is authoritative for workflow-managed records. A business-record status field may denormalise current state for fast queries, but transition history still lives in `workflow_transition_events`.
 - Labels such as `status:normal` can mirror workflow state for grouping; they are not the source of truth for a state machine.
 
@@ -47,11 +47,11 @@ Model workflows as explicit, versioned state machines with runtime events. Workf
 
 - Guards are side-effect free checks. Examples: role/capability, amount threshold, required fields, related approval, no open blockers, valid transition.
 - Actions run only after guards pass. Examples: update state, create task/issue/activity, request approval, send notification, enqueue webhook, generate document, post ledger entry.
-- Actions that touch external systems use `workflow_outbox` and idempotency keys.
+- Actions that touch external systems use `outbox_events` and idempotency keys.
 
 ## Approvals
 
-- Approval definitions belong to the workflow, not only to comments or tasks.
+- Approval definitions belong to the workflow, not only to messages or tasks.
 - Approval requests record approver user/team/role/capability, due date, delegation, decision, reason, and audit metadata.
 - Multi-step approvals need order, quorum/all-of/any-of policy, escalation, and override rules.
 - Approval permissions are capabilities such as `invoice.approve`, `workflow.override`, or `quote.reject`.
@@ -60,14 +60,14 @@ Model workflows as explicit, versioned state machines with runtime events. Workf
 
 - Issues track human-visible work; workflows can create, update, block, or close issues.
 - Activities schedule/log calls, meetings, tasks, deadlines, and reminders; workflows can wait for or create activities.
-- Conversations/comments discuss records; workflow actions can emit comments/messages, but comments are not workflow state.
+- Conversations and entity-scoped messages discuss records; workflow actions can emit messages, but messages are not workflow state.
 - Labels group/filter records; typed state and transition events remain authoritative.
-- Files/documents can be workflow inputs/outputs; document generation and signing use outbox jobs and audit events.
+- Files/documents can be workflow inputs/outputs; document generation and signing use outbox events and audit events.
 
 ## Verification
 
 - Draw the state diagram before writing migrations.
-- Demonstrate one workflow from draft definition to active version, start trigger, transition, guard, approval, action, timer, outbox job, and audit event.
+- Demonstrate one workflow from draft definition to active version, start trigger, transition, guard, approval, action, timer, outbox event, and audit event.
 - Prove invalid transitions fail, stale versions remain reproducible, and repeated external events are idempotent.
 - Test RBAC/RLS for transition, approval, override, export, and privileged read actions.
 - Confirm workflow events are append-only and enough to explain current state.

--- a/.agents/tools/app-stack/workspace-model.md
+++ b/.agents/tools/app-stack/workspace-model.md
@@ -18,7 +18,7 @@ A workspace is a named boundary that groups:
 - Members, teams/user groups, roles, role assignments, invitations, and access policies.
 - AI memory/context, tool permissions, and audit trails.
 - Integrations, secrets references, and environment settings.
-- Collaboration state such as issues, comments, activity, notifications, labels, and tasks.
+- Collaboration state such as issues, channels, chats, comments, activity, notifications, labels, files, folders, and tasks.
 
 ## Kernel tables
 
@@ -34,8 +34,11 @@ Start with these concepts before app-specific objects:
 - `workspace_settings`
 - `labels` / `label_assignments`
 - `issues` / issue relationships
+- `channel_groups` / `channels` / `chats`
+- `messages` / `threads` / `reactions`
+- `activities` / calls / meetings / tasks / reminders
 - `audit_events`
-- `files` / `attachments`
+- `files` / `folders` / `attachments`
 - `comments` / `activity_events`
 - `notifications`
 

--- a/.agents/tools/app-stack/workspace-model.md
+++ b/.agents/tools/app-stack/workspace-model.md
@@ -15,10 +15,10 @@ Use `Workspace` as the default container abstraction for app data, permissions, 
 A workspace is a named boundary that groups:
 
 - Data records and files.
-- Members, roles, invitations, and access policies.
+- Members, teams/user groups, roles, role assignments, invitations, and access policies.
 - AI memory/context, tool permissions, and audit trails.
 - Integrations, secrets references, and environment settings.
-- Collaboration state such as comments, activity, notifications, and tasks.
+- Collaboration state such as issues, comments, activity, notifications, labels, and tasks.
 
 ## Kernel tables
 
@@ -26,9 +26,14 @@ Start with these concepts before app-specific objects:
 
 - `workspaces`
 - `workspace_memberships`
-- `workspace_roles`
+- `teams` / `user_groups`
+- `team_memberships`
+- `roles`
+- `role_assignments`
 - `workspace_invitations`
 - `workspace_settings`
+- `labels` / `label_assignments`
+- `issues` / issue relationships
 - `audit_events`
 - `files` / `attachments`
 - `comments` / `activity_events`
@@ -38,6 +43,7 @@ Start with these concepts before app-specific objects:
 
 - Every durable business record belongs to exactly one workspace unless the product explicitly needs cross-workspace sharing.
 - RLS policies include workspace membership and role checks.
+- Teams group users; roles grant capabilities. Do not collapse teams/user groups into roles.
 - AI agents receive only the workspace context needed for the task.
 - Secrets are referenced by name/handle, not copied into workspace rows.
 - Cross-workspace reporting uses read models or controlled exports, not hidden permission bypasses.

--- a/.agents/tools/app-stack/workspace-model.md
+++ b/.agents/tools/app-stack/workspace-model.md
@@ -18,7 +18,7 @@ A workspace is a named boundary that groups:
 - Members, teams/user groups, roles, role assignments, invitations, and access policies.
 - AI memory/context, tool permissions, and audit trails.
 - Integrations, secrets references, and environment settings.
-- Collaboration state such as issues, channels, chats, comments, activity, notifications, labels, files, folders, and tasks.
+- Collaboration state such as issues, conversations/channels/chats, comments, calendar activities, notifications, labels, files, folders, and tasks.
 
 ## Kernel tables
 
@@ -34,9 +34,9 @@ Start with these concepts before app-specific objects:
 - `workspace_settings`
 - `labels` / `label_assignments`
 - `issues` / issue relationships
-- `channel_groups` / `channels` / `chats`
-- `messages` / `threads` / `reactions`
-- `activities` / calls / meetings / tasks / reminders
+- `conversation_groups` / `conversations`
+- `messages` / `message_threads` / `message_reactions`
+- `calendar_collections` / `activities` / `activity_alarms`
 - `audit_events`
 - `files` / `folders` / `attachments`
 - `comments` / `activity_events`

--- a/.agents/tools/app-stack/workspace-model.md
+++ b/.agents/tools/app-stack/workspace-model.md
@@ -18,7 +18,7 @@ A workspace is a named boundary that groups:
 - Members, teams/user groups, roles, role assignments, invitations, and access policies.
 - AI memory/context, tool permissions, and audit trails.
 - Integrations, secrets references, and environment settings.
-- Collaboration state such as issues, conversations/channels/chats, comments, calendar activities, notifications, labels, files, folders, and tasks.
+- Collaboration state such as issues, conversations/channels/chats, entity-scoped messages, calendar activities, notifications, labels, files, folders, and tasks.
 
 ## Kernel tables
 
@@ -38,8 +38,8 @@ Start with these concepts before app-specific objects:
 - `messages` / `message_threads` / `message_reactions`
 - `calendar_collections` / `activities` / `activity_alarms`
 - `audit_events`
-- `files` / `folders` / `attachments`
-- `comments` / `activity_events`
+- `files` / `folders` / `file_links`
+- `activity_events`
 - `notifications`
 
 ## Boundary rules

--- a/.agents/tools/app-stack/workspace-model.md
+++ b/.agents/tools/app-stack/workspace-model.md
@@ -44,7 +44,7 @@ Start with these concepts before app-specific objects:
 
 ## Boundary rules
 
-- Every durable business record belongs to exactly one workspace unless the product explicitly needs cross-workspace sharing.
+- Every durable business record belongs to exactly one workspace unless the product explicitly needs cross-workspace sharing. Workspace is the default tenancy and RLS root.
 - RLS policies include workspace membership and role checks.
 - Teams group users; roles grant capabilities. Do not collapse teams/user groups into roles.
 - AI agents receive only the workspace context needed for the task.


### PR DESCRIPTION
## Summary

- Expand app-stack guidance with database foundations, workspace/RLS, metadata, RBAC, workflows, standard objects, and migration layout.
- Add platform-kernel guidance for notifications, audit, imports/exports, integrations, search, reports, forms, settings, jobs, retention, and operations.
- Add data-history, relationship, public-surface, API/service, identity/security, sync/privacy/scale, and background-job guidance for new app development.
- Update the static-site starter guidance with required public/legal/docs/developer surfaces, sitemap/robots, and structured-data expectations.

## Verification

- `git diff --check origin/main...HEAD`
- `.agents/scripts/markdoc-validate.sh validate .agents/tools/app-stack.md .agents/tools/app-stack/api-service-contracts.md .agents/tools/app-stack/data-history-relationships.md .agents/tools/app-stack/data-protection-sync-scale.md .agents/tools/app-stack/database-foundation.md .agents/tools/app-stack/identity-security-lifecycle.md .agents/tools/app-stack/metadata-architecture.md .agents/tools/app-stack/migration-layout.md .agents/tools/app-stack/monorepo-app-stack.md .agents/tools/app-stack/operations-jobs-scheduling.md .agents/tools/app-stack/platform-kernel.md .agents/tools/app-stack/public-site-surfaces.md .agents/tools/app-stack/rbac-permissions.md .agents/tools/app-stack/standard-objects.md .agents/tools/app-stack/static-site-starter.md .agents/tools/app-stack/workflow-architecture.md .agents/tools/app-stack/workspace-model.md`
- public-safety grep for private/reference names and local paths
- `.agents/scripts/linters-local.sh`

## Notes

- Docs-only change.
- Guidance is generic/public-safe and avoids project-specific implementation details.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.63 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
