### PR TITLE
For #24796: label orphan recovery PRs in review

### DIFF
--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -271,8 +271,9 @@ _resolve_orphan_recovery_base_branch() {
 # _attempt_orphan_recovery_pr — auto-recover a worker_branch_orphan (GH#20819)
 #
 # Called when a worker pushed a branch but exited without opening a PR.
-# Attempts to open a non-draft PR against the repo's configured PR base branch with
-# origin:worker-takeover label so the normal review/merge pipeline applies.
+# Attempts to open a non-draft PR against the repo's configured PR base branch
+# with origin:worker-takeover + status:in-review labels so the normal
+# review/merge pipeline applies immediately.
 #
 # Short-circuits (returns 1) when:
 #   - repo_slug is empty (cannot query or construct PR)
@@ -385,6 +386,7 @@ _attempt_orphan_recovery_pr() {
 		--title "$pr_title"
 		--body "$pr_body"
 		--label "origin:worker-takeover"
+		--label "status:in-review"
 	)
 	gh pr create "${create_args[@]}" >/dev/null 2>&1 # aidevops-allow: raw-gh-wrapper
 	return $?

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1858,7 +1858,7 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
 	printf '{"pr_base_branch":"develop"}\n' >"${work_dir}/.aidevops.json"
 
-	local gh_head="" gh_base="" gh_repo="" gh_label=""
+	local gh_head="" gh_base="" gh_repo="" gh_labels=""
 	local gh_called=0
 	gh() {
 		# Capture pr create args
@@ -1868,7 +1868,13 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 			"--head") gh_head="$arg" ;;
 			"--base") gh_base="$arg" ;;
 			"--repo") gh_repo="$arg" ;;
-			"--label") gh_label="$arg" ;;
+			"--label")
+				if [[ -z "$gh_labels" ]]; then
+					gh_labels="$arg"
+				else
+					gh_labels="${gh_labels},${arg}"
+				fi
+				;;
 			esac
 			_last_flag="$arg"
 		done
@@ -1896,11 +1902,18 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 			"Expected --head=feature/auto-test-issue-99999, got '${gh_head}'"
 	fi
 
-	if [[ "$gh_label" == "origin:worker-takeover" ]]; then
+	if [[ ",${gh_labels}," == *",origin:worker-takeover,"* ]]; then
 		print_result "_attempt_orphan_recovery_pr passes --label origin:worker-takeover" 0
 	else
 		print_result "_attempt_orphan_recovery_pr passes --label origin:worker-takeover" 1 \
-			"Expected --label=origin:worker-takeover, got '${gh_label}'"
+			"Expected --label=origin:worker-takeover, got '${gh_labels}'"
+	fi
+
+	if [[ ",${gh_labels}," == *",status:in-review,"* ]]; then
+		print_result "_attempt_orphan_recovery_pr passes --label status:in-review" 0
+	else
+		print_result "_attempt_orphan_recovery_pr passes --label status:in-review" 1 \
+			"Expected --label=status:in-review, got '${gh_labels}'"
 	fi
 
 	if [[ "$gh_base" == "develop" ]]; then


### PR DESCRIPTION
## Summary

- Adds `status:in-review` when the orphan-recovery path auto-creates a PR for a pushed worker branch.
- Updates the headless runtime regression test to require both `origin:worker-takeover` and `status:in-review` labels on orphan-recovery PRs.

## Root cause and systemic fix

The main issue fix landed in #24811. During the intervention, the recovered PR was found with worker-takeover provenance but without an in-review lifecycle label until it was corrected manually. That made the PR lifecycle less deterministic for pulse/review/merge processing.

This follow-up makes the orphan-recovery creator label recovered PRs as `status:in-review` at creation time so future recovered branches immediately enter the normal review/merge pipeline.

## Files changed

- `.agents/scripts/shared-claim-lifecycle.sh`
- `.agents/scripts/tests/test-headless-runtime-helper.sh`

## Testing

- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/shared-claim-lifecycle.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --metric function-complexity`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --metric bash32-compat`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Runtime-verified with the headless runtime shell harness. The test stubs `gh pr create` and asserts orphan-recovery PR creation now carries both lifecycle labels without touching production workers.

For #24796

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.64 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 41m and 266,821 tokens on this with the user in an interactive session.
