### PR TITLE
fix: harden README badge rendering

### DIFF
--- a/.agents/aidevops/badges.md
+++ b/.agents/aidevops/badges.md
@@ -3,10 +3,12 @@
 
 # Badges — README badge template + LOC reusable workflow
 
-aidevops ships a consistent badge block for every managed repo: shields.io
-badges for stats GitHub already exposes, plus a self-hosted SVG for lines
-of code (the only badge that needs custom infrastructure because shields.io's
-tokei endpoint is too unreliable to depend on).
+aidevops ships a consistent badge block for every managed repo: a native
+GitHub Actions badge when a concrete workflow file is known, static shields.io
+badges for values that do not require GitHub API access, and self-hosted SVGs
+for lines of code. The template deliberately avoids `img.shields.io/github/...`
+endpoints because those can render upstream service text such as "Unable to
+select next GitHub token from pool" in public READMEs.
 
 Use `aidevops badges render|check|sync|install` to manage README badge blocks
 and LOC badge workflows for repos listed in `repos.json`.
@@ -27,10 +29,10 @@ Three artifacts deployed by `setup.sh`:
    - `.github/badges/loc-languages.svg` — GitHub-style horizontal stacked
      bar of the top-N languages with a percentage legend
 2. **`.agents/scripts/readme-badges-helper.sh`** — renders the badges
-   markdown for a slug, injects/checks an idempotent block in a README
+   markdown for a slug, injects/checks an idempotent block in a README, and
+   only emits an Actions badge after resolving an actual workflow file
 3. **`.agents/templates/readme/badges.md.tmpl`** — the canonical badges
-   block, with conditional sections for licence, releases, and FOSS-only
-   community badges
+   block, with conditional sections for native Actions, licence, and LOC badges
 
 Plus the GitHub Actions wiring:
 
@@ -64,6 +66,14 @@ generates and commits the SVGs into `.github/badges/`. The README block
 references those SVGs via raw.githubusercontent.com, so they update
 automatically on every push.
 
+Do not add GitHub-backed Shields badges such as repository size, stars,
+watchers, language count, release date, or issue counts to the canonical block.
+Those badges depend on Shields' GitHub token pool and can intermittently render
+the provider error string instead of the intended value. Prefer GitHub-native
+badges for Actions, self-hosted generated SVGs for repository metrics, static
+Shields badges for local/static facts, and direct Markdown links for GitHub
+pages that do not need a badge.
+
 ## How the marker block works
 
 The injected block is bounded by HTML comment markers that are invisible
@@ -72,8 +82,9 @@ in rendered Markdown:
 ```markdown
 <!-- aidevops:badges:start -->
 <!-- managed by aidevops badges; edit the template, not this block -->
+[![GitHub Actions](...)](...)
+[![License](...)](...)
 [![Lines of code](...)](...)
-[![Last commit](...)](...)
 ...
 <!-- aidevops:badges:end -->
 ```
@@ -102,9 +113,11 @@ Available variables (computed from `repos.json` + live `gh` probes):
 | `OWNER` | derived | first segment of slug |
 | `REPO` | derived | second segment of slug |
 | `DEFAULT_BRANCH` | `gh api repos/{slug}` | falls back to `main` |
+| `HAS_ACTIONS_WORKFLOW` | local workflow-file detection | enables the native Actions badge |
+| `ACTIONS_WORKFLOW_FILE` | local workflow-file detection or `--workflow-file` | exact `.github/workflows/*.yml` basename |
 | `HAS_LOC_BADGE` | `--no-loc-badge` flag | default `1`; empty if disabled |
 | `HAS_RELEASES` | `gh api releases?per_page=1` | empty for `local_only` repos |
-| `IS_FOSS` | `repos.json[].foss` | enables Stars/Forks/Open lines |
+| `IS_FOSS` | `repos.json[].foss` | retained for compatibility; unused by the resilient template |
 | `HAS_LICENSE` | (Phase 2: filesystem probe) | currently always `1` |
 
 To add or remove a badge, edit the template — never edit the rendered

--- a/.agents/scripts/auto-version-bump.sh
+++ b/.agents/scripts/auto-version-bump.sh
@@ -63,9 +63,9 @@ update_version_badge() {
 	local readme_file="$REPO_ROOT/README.md"
 
 	if [[ -f "$readme_file" ]]; then
-		# Skip if using dynamic GitHub release badge
+		# Dynamic GitHub-backed Shields badges can render upstream API errors in README.
 		if grep -q "img.shields.io/github/v/release" "$readme_file"; then
-			print_success "README.md uses dynamic GitHub release badge (no update needed)"
+			print_warning "README.md uses dynamic GitHub release badge; prefer static Version-$new_version badge to avoid Shields GitHub token-pool outages"
 			return 0
 		fi
 
@@ -81,7 +81,7 @@ update_version_badge() {
 				print_warning "README.md version badge exists but update failed (pattern mismatch)"
 			fi
 		else
-			print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
+			print_warning "README.md has no version badge (consider adding static Version-$new_version badge)"
 		fi
 	fi
 	return 0

--- a/.agents/scripts/readme-badges-helper.sh
+++ b/.agents/scripts/readme-badges-helper.sh
@@ -32,6 +32,8 @@
 #   {{OWNER}}           — owner
 #   {{REPO}}            — repo
 #   {{DEFAULT_BRANCH}}  — default branch (default: main)
+#   {{HAS_ACTIONS_WORKFLOW}} — "1" when a concrete Actions workflow file is known
+#   {{ACTIONS_WORKFLOW_FILE}} — workflow file used for the native GitHub badge
 #   {{HAS_LOC_BADGE}}   — "1" if the loc-badge workflow is wired up
 #                         (presence of .github/badges/loc-total.svg or
 #                          loc-badge.yml in the repo); "" otherwise
@@ -48,6 +50,7 @@
 # Options:
 #   --branch BRANCH        Override default branch detection
 #   --template PATH        Override template location
+#   --workflow-file FILE   Override GitHub Actions workflow badge file
 #   --no-loc-badge         Force HAS_LOC_BADGE empty (skip LOC line)
 #   --has-releases 0|1     Force the "has releases" flag (skip gh probe)
 #   -h, --help             Show usage
@@ -140,6 +143,7 @@ SLUG=""
 README_PATH=""
 BRANCH_OVERRIDE=""
 TEMPLATE_OVERRIDE=""
+WORKFLOW_FILE_OVERRIDE=""
 NO_LOC_BADGE=0
 HAS_RELEASES_OVERRIDE=""
 
@@ -193,6 +197,13 @@ parse_args() {
 				TEMPLATE_OVERRIDE="$_val"
 				shift 2
 				;;
+			--workflow-file)
+				[[ $# -ge 2 ]] || die "--workflow-file requires an argument" 2
+				local _val="$2"
+				validate_workflow_file "$_val"
+				WORKFLOW_FILE_OVERRIDE="$_val"
+				shift 2
+				;;
 			--no-loc-badge)
 				NO_LOC_BADGE=1
 				shift
@@ -222,6 +233,14 @@ validate_slug() {
 	local _slug="$1"
 	if [[ ! "$_slug" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
 		die "invalid slug (expected owner/repo, got: $_slug)" 2
+	fi
+	return 0
+}
+
+validate_workflow_file() {
+	local _workflow_file="$1"
+	if [[ ! "$_workflow_file" =~ ^[A-Za-z0-9._-]+\.ya?ml$ ]]; then
+		die "invalid workflow file (expected basename ending .yml/.yaml, got: $_workflow_file)" 2
 	fi
 	return 0
 }
@@ -272,11 +291,98 @@ detect_default_branch() {
 	return 0
 }
 
+expand_repo_path() {
+	local _path="$1"
+	if [[ "${_path:0:1}" == "~" && "${_path:1:1}" == "/" ]]; then
+		printf '%s/%s' "$HOME" "${_path#~/}"
+	else
+		printf '%s' "$_path"
+	fi
+	return 0
+}
+
+detect_workflow_in_path() {
+	local _repo_path="$1"
+	[[ -n "$_repo_path" ]] || return 1
+
+	_repo_path=$(expand_repo_path "$_repo_path")
+	local _workflow_dir="$_repo_path/.github/workflows"
+	[[ -d "$_workflow_dir" ]] || return 1
+
+	local _candidate
+	local _preferred=(
+		"code-quality.yml"
+		"code-quality.yaml"
+		"ci.yml"
+		"ci.yaml"
+		"test.yml"
+		"test.yaml"
+		"tests.yml"
+		"tests.yaml"
+		"build.yml"
+		"build.yaml"
+	)
+	for _candidate in "${_preferred[@]}"; do
+		if [[ -f "$_workflow_dir/$_candidate" ]]; then
+			printf '%s' "$_candidate"
+			return 0
+		fi
+	done
+
+	local _found=""
+	local _count=0
+	for _candidate in "$_workflow_dir"/*.yml "$_workflow_dir"/*.yaml; do
+		[[ -f "$_candidate" ]] || continue
+		_count=$((_count + 1))
+		_found="${_candidate##*/}"
+	done
+
+	if [[ "$_count" -eq 1 && -n "$_found" ]]; then
+		printf '%s' "$_found"
+		return 0
+	fi
+
+	return 1
+}
+
+# Detect a concrete workflow file before rendering an Actions badge. This avoids
+# broken image badges caused by hardcoded workflow names such as "CI" when a
+# repo uses a different workflow file.
+detect_actions_workflow_file() {
+	local _slug="$1"
+	if [[ -n "$WORKFLOW_FILE_OVERRIDE" ]]; then
+		printf '%s' "$WORKFLOW_FILE_OVERRIDE"
+		return 0
+	fi
+
+	local _workflow_file=""
+	local _repo_path=""
+	if [[ -n "$README_PATH" ]]; then
+		_repo_path=$(cd "$(dirname "$README_PATH")" 2>/dev/null && pwd || dirname "$README_PATH")
+		if _workflow_file=$(detect_workflow_in_path "$_repo_path"); then
+			printf '%s' "$_workflow_file"
+			return 0
+		fi
+	fi
+
+	_repo_path=$(repos_json_lookup "$_slug" "path" "")
+	if [[ -n "$_repo_path" ]]; then
+		if _workflow_file=$(detect_workflow_in_path "$_repo_path"); then
+			printf '%s' "$_workflow_file"
+			return 0
+		fi
+	fi
+
+	printf ''
+	return 0
+}
+
 # ───────────────────────────── template render ────────────────────────────
 
 # Substitute {{KEY}} with the value of the corresponding env var (KEY must
-# match a name like SLUG / OWNER / REPO / DEFAULT_BRANCH / HAS_LOC_BADGE /
-# HAS_RELEASES / IS_FOSS). Conditional lines:
+# match a name like SLUG / OWNER / REPO / DEFAULT_BRANCH /
+# HAS_ACTIONS_WORKFLOW / ACTIONS_WORKFLOW_FILE / HAS_LOC_BADGE / HAS_RELEASES /
+# IS_FOSS). Conditional lines:
 #   "{{?KEY}}rest"   — included only if KEY is non-empty (prefix stripped)
 #   "{{!KEY}}rest"   — included only if KEY is empty (prefix stripped)
 render_template() {
@@ -289,6 +395,8 @@ render_template() {
 		-v owner="${OWNER_VAL}" \
 		-v repo="${REPO_VAL}" \
 		-v branch="${DEFAULT_BRANCH_VAL}" \
+		-v has_actions_workflow="${HAS_ACTIONS_WORKFLOW_VAL}" \
+		-v actions_workflow_file="${ACTIONS_WORKFLOW_FILE_VAL}" \
 		-v has_loc_badge="${HAS_LOC_BADGE_VAL}" \
 		-v has_releases="${HAS_RELEASES_VAL}" \
 		-v is_foss="${IS_FOSS_VAL}" \
@@ -299,6 +407,8 @@ render_template() {
 			if (k == "OWNER") return owner
 			if (k == "REPO") return repo
 			if (k == "DEFAULT_BRANCH") return branch
+			if (k == "HAS_ACTIONS_WORKFLOW") return has_actions_workflow
+			if (k == "ACTIONS_WORKFLOW_FILE") return actions_workflow_file
 			if (k == "HAS_LOC_BADGE") return has_loc_badge
 			if (k == "HAS_RELEASES") return has_releases
 			if (k == "IS_FOSS") return is_foss
@@ -361,6 +471,12 @@ prepare_render_vars() {
 	OWNER_VAL="${SLUG%%/*}"
 	REPO_VAL="${SLUG##*/}"
 	DEFAULT_BRANCH_VAL=$(detect_default_branch "$SLUG")
+	ACTIONS_WORKFLOW_FILE_VAL=$(detect_actions_workflow_file "$SLUG")
+	if [[ -n "$ACTIONS_WORKFLOW_FILE_VAL" ]]; then
+		HAS_ACTIONS_WORKFLOW_VAL="1"
+	else
+		HAS_ACTIONS_WORKFLOW_VAL=""
+	fi
 
 	# Repo metadata from repos.json (fail-soft to "")
 	local _local_only

--- a/.agents/scripts/tests/test-readme-badges-resilience.sh
+++ b/.agents/scripts/tests/test-readme-badges-resilience.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-readme-badges-resilience.sh — regression tests for resilient README badges.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+HELPER="$REPO_ROOT/.agents/scripts/readme-badges-helper.sh"
+TEMPLATE="$REPO_ROOT/.agents/templates/readme/badges.md.tmpl"
+README="$REPO_ROOT/README.md"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+_pass() {
+	local _name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$_name"
+	return 0
+}
+
+_fail() {
+	local _name="$1"
+	local _message="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n       %s\n' "$_name" "$_message"
+	return 0
+}
+
+_assert_contains_text() {
+	local _name="$1"
+	local _needle="$2"
+	local _haystack="$3"
+	if [[ "$_haystack" == *"$_needle"* ]]; then
+		_pass "$_name"
+		return 0
+	fi
+	_fail "$_name" "missing literal: $_needle"
+	return 0
+}
+
+_assert_not_contains_text() {
+	local _name="$1"
+	local _needle="$2"
+	local _haystack="$3"
+	if [[ "$_haystack" == *"$_needle"* ]]; then
+		_fail "$_name" "unexpected literal present: $_needle"
+		return 0
+	fi
+	_pass "$_name"
+	return 0
+}
+
+_assert_file_not_contains() {
+	local _name="$1"
+	local _needle="$2"
+	local _file="$3"
+	if grep -Fq -- "$_needle" "$_file"; then
+		_fail "$_name" "unexpected literal present in $_file: $_needle"
+		return 0
+	fi
+	_pass "$_name"
+	return 0
+}
+
+_write_repos_json() {
+	local _json_path="$1"
+	local _repo_path="$2"
+	local _slug="$3"
+	printf '{"initialized_repos":[{"slug":"%s","path":"%s","foss":true}]}\n' \
+		"$_slug" "$_repo_path" >"$_json_path"
+	return 0
+}
+
+_render_for_fixture() {
+	local _repo_path="$1"
+	local _slug="$2"
+	local _repos_json="$3"
+	_write_repos_json "$_repos_json" "$_repo_path" "$_slug"
+	REPOS_JSON="$_repos_json" bash "$HELPER" render "$_slug" --branch main --template "$TEMPLATE"
+	return 0
+}
+
+_test_native_actions_badge_uses_workflow_file() {
+	local _tmp
+	_tmp=$(mktemp -d)
+	local _repo="$_tmp/repo"
+	local _slug="example/repo"
+	mkdir -p "$_repo/.github/workflows"
+	printf '# Example\n' >"$_repo/README.md"
+	printf 'name: Code Quality Analysis\non: [push]\n' >"$_repo/.github/workflows/code-quality.yml"
+
+	local _out
+	_out=$(_render_for_fixture "$_repo" "$_slug" "$_tmp/repos.json")
+	_assert_contains_text \
+		"Actions badge uses file-scoped native endpoint" \
+		"https://github.com/example/repo/actions/workflows/code-quality.yml/badge.svg?branch=main" \
+		"$_out"
+	_assert_not_contains_text \
+		"Actions badge does not use workflow-name endpoint" \
+		"/workflows/CI/badge.svg" \
+		"$_out"
+	_assert_not_contains_text \
+		"Rendered canonical block avoids Shields GitHub API endpoints" \
+		"img.shields.io/github/" \
+		"$_out"
+	rm -rf "$_tmp"
+	return 0
+}
+
+_test_actions_badge_skips_unknown_workflow() {
+	local _tmp
+	_tmp=$(mktemp -d)
+	local _repo="$_tmp/repo"
+	local _slug="example/no-workflow"
+	mkdir -p "$_repo"
+	printf '# Example\n' >"$_repo/README.md"
+
+	local _out
+	_out=$(_render_for_fixture "$_repo" "$_slug" "$_tmp/repos.json")
+	_assert_not_contains_text \
+		"Unknown workflow omits Actions badge instead of rendering a broken image" \
+		"[![GitHub Actions]" \
+		"$_out"
+	rm -rf "$_tmp"
+	return 0
+}
+
+_test_source_badge_blocks_avoid_github_shields() {
+	_assert_file_not_contains \
+		"Canonical badge template avoids Shields GitHub API endpoints" \
+		"img.shields.io/github/" \
+		"$TEMPLATE"
+	_assert_file_not_contains \
+		"Top-level README avoids Shields GitHub API endpoints" \
+		"img.shields.io/github/" \
+		"$README"
+	return 0
+}
+
+main() {
+	if [[ ! -f "$HELPER" || ! -f "$TEMPLATE" || ! -f "$README" ]]; then
+		_fail "required files exist" "missing helper/template/README"
+		printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+		return 1
+	fi
+
+	_test_native_actions_badge_uses_workflow_file
+	_test_actions_badge_skips_unknown_workflow
+	_test_source_badge_blocks_avoid_github_shields
+
+	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/validate-version-consistency.sh
+++ b/.agents/scripts/validate-version-consistency.sh
@@ -93,14 +93,15 @@ _check_readme_badge() {
 	local repo_root="$2"
 	if [[ -f "$repo_root/README.md" ]]; then
 		if grep -q "img.shields.io/github/v/release" "$repo_root/README.md"; then
-			print_success "README.md uses dynamic GitHub release badge (recommended)"
+			print_warning "README.md uses dynamic GitHub release badge; prefer static Version-$expected_version badge to avoid Shields GitHub token-pool outages"
+			_vc_warnings=$((_vc_warnings + 1))
 		elif grep -q "Version-$expected_version-blue" "$repo_root/README.md"; then
 			print_success "README.md badge: $expected_version"
 		else
 			local current_badge
 			current_badge=$(grep -o "Version-[0-9]\+\.[0-9]\+\.[0-9]\+-blue" "$repo_root/README.md" || echo "not found")
 			if [[ "$current_badge" == "not found" ]]; then
-				print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
+				print_warning "README.md has no version badge (consider adding static Version-$expected_version badge)"
 				_vc_warnings=$((_vc_warnings + 1))
 			else
 				print_error "README.md badge shows '$current_badge', expected 'Version-$expected_version-blue'"

--- a/.agents/scripts/version-manager-files.sh
+++ b/.agents/scripts/version-manager-files.sh
@@ -95,8 +95,8 @@ _update_readme_version_badge() {
 	fi
 
 	if grep -q "$dynamic_badge_pattern" "$REPO_ROOT/README.md"; then
-		# Dynamic badge - no update needed, GitHub handles it automatically
-		print_success "README.md uses dynamic GitHub release badge (no update needed)" >&2
+		# Dynamic GitHub-backed Shields badges can render upstream API errors in README.
+		print_warning "README.md uses dynamic GitHub release badge; prefer static Version-$new_version badge to avoid Shields GitHub token-pool outages" >&2
 	elif grep -q "$hardcoded_badge_pattern" "$REPO_ROOT/README.md"; then
 		# Hardcoded badge - update it
 		sed_inplace "s/$hardcoded_badge_pattern/Version-$new_version-blue/" "$REPO_ROOT/README.md"
@@ -108,7 +108,7 @@ _update_readme_version_badge() {
 		fi
 	else
 		# No version badge found - that's okay, just warn
-		print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)" >&2
+		print_warning "README.md has no version badge (consider adding static Version-$new_version badge)" >&2
 	fi
 	return 0
 }

--- a/.agents/templates/readme/badges.md.tmpl
+++ b/.agents/templates/readme/badges.md.tmpl
@@ -1,32 +1,12 @@
 <!-- Build & Quality Status -->
-[![GitHub Actions](https://github.com/{{SLUG}}/workflows/CI/badge.svg)](https://github.com/{{SLUG}}/actions)
+{{?HAS_ACTIONS_WORKFLOW}}[![GitHub Actions](https://github.com/{{SLUG}}/actions/workflows/{{ACTIONS_WORKFLOW_FILE}}/badge.svg?branch={{DEFAULT_BRANCH}})](https://github.com/{{SLUG}}/actions/workflows/{{ACTIONS_WORKFLOW_FILE}})
 
 <!-- License & Legal -->
-{{?HAS_LICENSE}}[![License](https://img.shields.io/github/license/{{SLUG}})](https://github.com/{{SLUG}}/blob/{{DEFAULT_BRANCH}}/LICENSE)
+{{?HAS_LICENSE}}[![License](https://img.shields.io/badge/license-see%20file-yellow.svg)](https://github.com/{{SLUG}}/blob/{{DEFAULT_BRANCH}}/LICENSE)
 
-<!-- GitHub Repository Stats -->
+<!-- Repository Metrics -->
 {{?HAS_LOC_BADGE}}[![Lines of code](https://raw.githubusercontent.com/{{SLUG}}/{{DEFAULT_BRANCH}}/.github/badges/loc-total.svg)](https://github.com/{{SLUG}})
-[![Top language](https://img.shields.io/github/languages/top/{{SLUG}})](https://github.com/{{SLUG}})
-[![Languages](https://img.shields.io/github/languages/count/{{SLUG}})](https://github.com/{{SLUG}})
-[![Code size](https://img.shields.io/github/languages/code-size/{{SLUG}}?color=blue)](https://github.com/{{SLUG}})
-[![Repo size](https://img.shields.io/github/repo-size/{{SLUG}}?color=blue)](https://github.com/{{SLUG}})
-
-<!-- Activity & Contributors -->
-[![Last commit](https://img.shields.io/github/last-commit/{{SLUG}})](https://github.com/{{SLUG}}/commits/{{DEFAULT_BRANCH}})
-[![Commits this month](https://img.shields.io/github/commit-activity/m/{{SLUG}})](https://github.com/{{SLUG}}/graphs/commit-activity)
-[![Contributors](https://img.shields.io/github/contributors/{{SLUG}})](https://github.com/{{SLUG}}/graphs/contributors)
-[![Closed PRs](https://img.shields.io/github/issues-pr-closed/{{SLUG}})](https://github.com/{{SLUG}}/pulls?q=is%3Apr+is%3Aclosed)
-[![Closed issues](https://img.shields.io/github/issues-closed/{{SLUG}})](https://github.com/{{SLUG}}/issues?q=is%3Aissue+is%3Aclosed)
-
-<!-- Releases -->
-{{?HAS_RELEASES}}[![Latest release](https://img.shields.io/github/v/release/{{SLUG}})](https://github.com/{{SLUG}}/releases)
-{{?HAS_RELEASES}}[![Release date](https://img.shields.io/github/release-date/{{SLUG}})](https://github.com/{{SLUG}}/releases)
-{{?HAS_RELEASES}}[![Commits since release](https://img.shields.io/github/commits-since/{{SLUG}}/latest)](https://github.com/{{SLUG}}/commits/{{DEFAULT_BRANCH}})
-
-<!-- Community (FOSS only) -->
-{{?IS_FOSS}}[![Stars](https://img.shields.io/github/stars/{{SLUG}}?style=social)](https://github.com/{{SLUG}}/stargazers)
-{{?IS_FOSS}}[![Forks](https://img.shields.io/github/forks/{{SLUG}}?style=social)](https://github.com/{{SLUG}}/network)
-{{?IS_FOSS}}[![Open issues](https://img.shields.io/github/issues/{{SLUG}})](https://github.com/{{SLUG}}/issues)
-{{?IS_FOSS}}[![Open PRs](https://img.shields.io/github/issues-pr/{{SLUG}})](https://github.com/{{SLUG}}/pulls)
-
 {{?HAS_LOC_BADGE}}[![Languages by lines of code](https://raw.githubusercontent.com/{{SLUG}}/{{DEFAULT_BRANCH}}/.github/badges/loc-languages.svg)](https://github.com/{{SLUG}})
+
+<!-- Project Links -->
+[![GitHub repository](https://img.shields.io/badge/github-repository-181717.svg?logo=github)](https://github.com/{{SLUG}})

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The result: an AI operations platform that manages projects across every busines
 ---
 
 <!-- Build & Quality Status -->
-[![GitHub Actions](https://github.com/marcusquinn/aidevops/workflows/Code%20Quality%20Analysis/badge.svg)](https://github.com/marcusquinn/aidevops/actions)
+[![GitHub Actions](https://github.com/marcusquinn/aidevops/actions/workflows/code-quality.yml/badge.svg?branch=main)](https://github.com/marcusquinn/aidevops/actions/workflows/code-quality.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)
 [![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)
 [![Maintainability](https://qlty.sh/gh/marcusquinn/projects/aidevops/maintainability.svg)](https://qlty.sh/gh/marcusquinn/projects/aidevops)
@@ -57,28 +57,11 @@ The result: an AI operations platform that manages projects across every busines
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Copyright](https://img.shields.io/badge/Copyright-Marcus%20Quinn%202025--2026-blue.svg)](https://github.com/marcusquinn)
 
-<!-- GitHub Stats -->
-[![GitHub stars](https://img.shields.io/github/stars/marcusquinn/aidevops.svg?style=social)](https://github.com/marcusquinn/aidevops/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/marcusquinn/aidevops.svg?style=social)](https://github.com/marcusquinn/aidevops/network)
-[![GitHub watchers](https://img.shields.io/github/watchers/marcusquinn/aidevops.svg?style=social)](https://github.com/marcusquinn/aidevops/watchers)
-
 <!-- Release & Version Info -->
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops/releases)
+[![Version](https://img.shields.io/badge/Version-3.20.64-blue.svg)](https://github.com/marcusquinn/aidevops/releases)
 [![npm version](https://img.shields.io/npm/v/aidevops)](https://www.npmjs.com/package/aidevops)
 [![Homebrew](https://img.shields.io/badge/homebrew-marcusquinn%2Ftap-orange)](https://github.com/marcusquinn/homebrew-tap)
-[![GitHub Release Date](https://img.shields.io/github/release-date/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops/releases)
-[![GitHub commits since latest release](https://img.shields.io/github/commits-since/marcusquinn/aidevops/latest)](https://github.com/marcusquinn/aidevops/commits/main)
-
-<!-- Repository Stats (dynamic badges only - no hardcoded versions/counts) -->
-[![GitHub repo size](https://img.shields.io/github/repo-size/marcusquinn/aidevops?style=flat&color=blue)](https://github.com/marcusquinn/aidevops)
-[![GitHub language count](https://img.shields.io/github/languages/count/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops)
-[![GitHub top language](https://img.shields.io/github/languages/top/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops)
-
-<!-- Community & Issues -->
-[![GitHub issues](https://img.shields.io/github/issues/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops/issues)
-[![GitHub closed issues](https://img.shields.io/github/issues-closed/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops/issues?q=is%3Aissue+is%3Aclosed)
-[![GitHub pull requests](https://img.shields.io/github/issues-pr/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops/pulls)
-[![GitHub contributors](https://img.shields.io/github/contributors/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops/graphs/contributors)
+[![GitHub repository](https://img.shields.io/badge/github-repository-181717.svg?logo=github)](https://github.com/marcusquinn/aidevops)
 
 <!-- Framework Specific -->
 [![Services Supported](https://img.shields.io/badge/Services%20Supported-30+-brightgreen.svg)](#comprehensive-service-coverage)


### PR DESCRIPTION
## Summary

- Replace the top README Actions badge with the file-scoped native GitHub Actions workflow badge.
- Remove GitHub API-backed Shields badges from the README and canonical badge template so Shields token-pool failures cannot render as badge text.
- Teach `readme-badges-helper.sh` to emit an Actions badge only when a concrete workflow file is detected or explicitly provided.
- Update badge/version guidance away from dynamic GitHub release Shields badges.
- Add regression coverage for resilient README badge rendering.

Resolves #24832

## Root cause

The README and canonical badge template relied on two fragile patterns:

1. Workflow-name badge URLs that can degrade to broken-image alt text when the image endpoint/proxy fails.
2. `img.shields.io/github/...` badges that require Shields' GitHub token pool; when that upstream pool fails, the SVG can render service text such as "Unable to select next GitHub token from pool".

## Verification

- `bash .agents/scripts/tests/test-readme-badges-resilience.sh`
- `shellcheck .agents/scripts/readme-badges-helper.sh .agents/scripts/version-manager-files.sh .agents/scripts/auto-version-bump.sh .agents/scripts/validate-version-consistency.sh .agents/scripts/tests/test-readme-badges-resilience.sh`
- `bash .agents/scripts/readme-badges-helper.sh render marcusquinn/aidevops --branch main --template .agents/templates/readme/badges.md.tmpl --workflow-file code-quality.yml | rg -n "actions/workflows/code-quality.yml|img\\.shields\\.io/github/|workflows/CI/badge\\.svg|Unable to select next GitHub token"`
- `bash .agents/scripts/linters-local.sh`
- `bash .agents/scripts/validate-version-consistency.sh 3.20.64`
- `curl -fsSIL "https://github.com/marcusquinn/aidevops/actions/workflows/code-quality.yml/badge.svg?branch=main"`
- `rg -n "img\\.shields\\.io/github/|workflows/Code%20Quality%20Analysis/badge\\.svg|workflows/CI/badge\\.svg|Unable to select next GitHub token" README.md .agents/templates/readme/badges.md.tmpl`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.64 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 29m and 275,918 tokens on this with the user in an interactive session.