### PR TITLE
fix: refresh profile metrics from complete local history

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -71,6 +71,48 @@ _session_time_detect_db() {
 }
 
 #######################################
+# Resolve the OpenCode archive DB associated with a primary session DB.
+# Arguments:
+#   $1 - primary db path
+# Output: archive database path to stdout, or empty string if unavailable
+#######################################
+_session_time_archive_db_for() {
+	local db_path="$1"
+	local archive_path="${OPENCODE_ARCHIVE_DB_PATH:-${OPENCODE_ARCHIVE_DB:-}}"
+
+	if [[ -z "$archive_path" && "$db_path" == */opencode.db ]]; then
+		archive_path="${db_path%/opencode.db}/opencode-archive.db"
+	fi
+
+	if [[ -n "$archive_path" && "$archive_path" != "$db_path" && -f "$archive_path" ]]; then
+		printf '%s\n' "$archive_path"
+	fi
+	return 0
+}
+
+#######################################
+# Auto-detect all SQLite session DBs that make up the local history.
+# Output: one database path per line, primary first, archive second if present
+#######################################
+_session_time_detect_db_paths() {
+	local primary_db
+	primary_db=$(_session_time_detect_db)
+	if [[ -z "$primary_db" ]]; then
+		printf '%s' ""
+		return 0
+	fi
+
+	printf '%s\n' "$primary_db"
+
+	local archive_db
+	archive_db=$(_session_time_archive_db_for "$primary_db")
+	if [[ -n "$archive_db" ]]; then
+		printf '%s\n' "$archive_db"
+	fi
+	return 0
+}
+
+#######################################
 # Handle --period all for session_time
 #
 # Calls session_time for each sub-period and combines into a single table.
@@ -195,6 +237,8 @@ _session_time_query_db() {
 		SELECT
 			session_id,
 			title,
+			MIN(created) AS first_message_ms,
+			MAX(COALESCE(completed, created)) AS last_message_ms,
 			SUM(CASE
 				WHEN role = 'user' AND prev_role = 'assistant'
 				     AND prev_completed IS NOT NULL
@@ -219,6 +263,45 @@ _session_time_query_db() {
 	fi
 
 	echo "$query_result"
+	return 0
+}
+
+#######################################
+# Query all detected session databases and de-duplicate copied archive rows.
+# Arguments:
+#   $1 - newline-delimited db paths
+#   $2 - abs repo path (empty string = all directories)
+#   $3 - since_ms (milliseconds threshold)
+# Output: JSON array of session rows to stdout
+#######################################
+_session_time_query_db_paths() {
+	local db_paths="$1"
+	local abs_repo_path="$2"
+	local since_ms="$3"
+	local combined_json=""
+	local db_path
+
+	while IFS= read -r db_path; do
+		[[ -z "$db_path" || ! -f "$db_path" ]] && continue
+
+		local db_json
+		db_json=$(_session_time_query_db "$db_path" "$abs_repo_path" "$since_ms") || db_json="[]"
+		if echo "$db_json" | jq -e . >/dev/null 2>&1; then
+			combined_json="${combined_json}${db_json}"$'\n'
+		fi
+	done <<<"$db_paths"
+
+	if [[ -z "$combined_json" ]]; then
+		echo "[]"
+		return 0
+	fi
+
+	printf '%s' "$combined_json" | jq -s '
+		add
+		| reduce .[] as $row ([];
+			if any(.[]; .session_id == $row.session_id) then . else . + [$row] end
+		)
+	' 2>/dev/null || echo "[]"
 	return 0
 }
 
@@ -272,18 +355,37 @@ stats = {
     'interactive': {'count': 0, 'human_ms': 0, 'machine_ms': 0},
     'worker':      {'count': 0, 'human_ms': 0, 'machine_ms': 0},
 }
+first_seen = []
+last_seen = []
+
+def number_or_zero(value):
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
 for row in sessions:
     title = row.get('title', '')
     stype = classify_session(title)
     stats[stype]['count'] += 1
-    stats[stype]['human_ms'] += row.get('human_ms', 0)
-    stats[stype]['machine_ms'] += row.get('machine_ms', 0)
+    stats[stype]['human_ms'] += number_or_zero(row.get('human_ms'))
+    stats[stype]['machine_ms'] += number_or_zero(row.get('machine_ms'))
+    first_ms = number_or_zero(row.get('first_message_ms'))
+    last_ms = number_or_zero(row.get('last_message_ms'))
+    if first_ms > 0:
+        first_seen.append(first_ms)
+    if last_ms > 0:
+        last_seen.append(last_ms)
 
 def ms_to_h(ms):
     return round(ms / 3600000, 1)
 
 i = stats['interactive']
 w = stats['worker']
+observed_days = 0
+if first_seen and last_seen:
+    observed_days = round(max(0, max(last_seen) - min(first_seen)) / 86400000, 1)
+
 print(json.dumps({
     'interactive_sessions': i['count'],
     'interactive_human_hours': ms_to_h(i['human_ms']),
@@ -294,6 +396,7 @@ print(json.dumps({
     'total_human_hours': ms_to_h(i['human_ms'] + w['human_ms']),
     'total_machine_hours': ms_to_h(i['machine_ms'] + w['machine_ms']),
     'total_sessions': i['count'] + w['count'],
+    'observed_days': observed_days,
 }, indent=2))
 "
 	return 0
@@ -431,20 +534,6 @@ session_time() {
 		repo_path="${repo_path:-.}"
 	fi
 
-	# Auto-detect database path
-	if [[ -z "$db_path" ]]; then
-		db_path=$(_session_time_detect_db)
-	fi
-
-	if [[ -z "$db_path" ]]; then
-		if [[ "$format" == "json" ]]; then
-			echo '{"interactive_sessions":0,"interactive_human_hours":0,"interactive_machine_hours":0,"worker_sessions":0,"worker_machine_hours":0,"total_human_hours":0,"total_machine_hours":0,"total_sessions":0}'
-		else
-			echo "_Session database not found._"
-		fi
-		return 0
-	fi
-
 	if ! command -v sqlite3 &>/dev/null; then
 		if [[ "$format" == "json" ]]; then
 			echo '{"interactive_sessions":0,"interactive_human_hours":0,"interactive_machine_hours":0,"worker_sessions":0,"worker_machine_hours":0,"total_human_hours":0,"total_machine_hours":0,"total_sessions":0}'
@@ -464,11 +553,28 @@ session_time() {
 		return 0
 	fi
 
+	local db_paths=""
+	if [[ -n "$db_path" ]]; then
+		db_paths="$db_path"
+	else
+		db_paths=$(_session_time_detect_db_paths)
+	fi
+
+	if [[ -z "$db_paths" ]]; then
+		if [[ "$format" == "json" ]]; then
+			echo '{"interactive_sessions":0,"interactive_human_hours":0,"interactive_machine_hours":0,"worker_sessions":0,"worker_machine_hours":0,"total_human_hours":0,"total_machine_hours":0,"total_sessions":0}'
+		else
+			echo "_Session database not found._"
+		fi
+		return 0
+	fi
+
 	# Determine --since threshold in milliseconds (single Python call)
 	local seconds
 	case "$period" in
 	day) seconds=86400 ;;
 	week) seconds=604800 ;;
+	28d | 28day | 28days) seconds=2419200 ;;
 	month) seconds=2592000 ;;
 	quarter) seconds=7776000 ;;
 	year) seconds=31536000 ;;
@@ -485,7 +591,7 @@ session_time() {
 	fi
 
 	local query_result
-	query_result=$(_session_time_query_db "$db_path" "$abs_repo_path" "$since_ms")
+	query_result=$(_session_time_query_db_paths "$db_paths" "$abs_repo_path" "$since_ms")
 
 	_session_time_process "$query_result" "$format" "$period"
 	return 0

--- a/.agents/scripts/loc-badge-helper.sh
+++ b/.agents/scripts/loc-badge-helper.sh
@@ -339,11 +339,11 @@ language_color() {
 # Escape characters that would break SVG/XML content.
 xml_escape() {
 	local _s="$1"
-	_s="${_s//&/&amp;}"
-	_s="${_s//</&lt;}"
-	_s="${_s//>/&gt;}"
-	_s="${_s//\"/&quot;}"
-	_s="${_s//\'/&apos;}"
+	_s="${_s//&/\&amp;}"
+	_s="${_s//</\&lt;}"
+	_s="${_s//>/\&gt;}"
+	_s="${_s//\"/\&quot;}"
+	_s="${_s//\'/\&apos;}"
 	printf '%s' "$_s"
 	return 0
 }

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -470,6 +470,14 @@ _generate_work_with_ai_table() {
 		;;
 	esac
 
+	local session_coverage_note=""
+	local session_observed_days
+	session_observed_days=$(echo "$year_json" | jq -r '(.observed_days // 0 | floor)')
+	if [[ "$session_observed_days" =~ ^[0-9]+$ ]] &&
+		[[ "$session_observed_days" -gt 0 && "$session_observed_days" -lt 330 ]]; then
+		session_coverage_note=$'\n\n'"_AI session 365-day totals cover ${session_observed_days} days of local assistant session history (not extrapolated)._"
+	fi
+
 	cat <<EOF
 ## Work with AI
 
@@ -484,7 +492,7 @@ _generate_work_with_ai_table() {
 
 _Screen time from ${screen_source}, snapshotted daily.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
 
-_User AI session hours measured from AI message timestamps (reading, thinking, typing between responses)._
+_User AI session hours measured from AI message timestamps (reading, thinking, typing between responses)._${session_coverage_note}
 EOF
 	return 0
 }
@@ -498,7 +506,9 @@ cmd_generate() {
 	local day_json week_json month_json year_json
 	day_json=$(_get_session_time day)
 	week_json=$(_get_session_time week)
-	month_json=$(_get_session_time month)
+	# The profile table column is explicitly 28 days; keep AI session windows
+	# aligned with the screen-time window instead of contributor "month" (30d).
+	month_json=$(_get_session_time 28d)
 	year_json=$(_get_session_time year)
 
 	local model_json_30d model_json_all

--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -113,11 +113,11 @@ validate_routine_prompt() {
 
 xml_escape() {
 	local value="$1"
-	value="${value//&/&amp;}"
-	value="${value//</&lt;}"
-	value="${value//>/&gt;}"
-	value="${value//\"/&quot;}"
-	value="${value//\'/&apos;}"
+	value="${value//&/\&amp;}"
+	value="${value//</\&lt;}"
+	value="${value//>/\&gt;}"
+	value="${value//\"/\&quot;}"
+	value="${value//\'/\&apos;}"
 	printf '%s' "$value"
 	return 0
 }

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+SOURCE_SESSION_LIB="${SCRIPT_DIR}/../contributor-activity-helper-session.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local result="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$result" -eq 0 ]]; then
+		echo -e "${TEST_GREEN}PASS${RESET} ${test_name}"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo -e "${TEST_RED}FAIL${RESET} ${test_name}"
+		if [[ -n "$message" ]]; then
+			echo "       ${message}"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	mkdir -p "${TEST_DIR}/home/.local/share/opencode"
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	TEST_DIR=""
+	return 0
+}
+
+create_session_db() {
+	local db_path="$1"
+	sqlite3 "$db_path" '
+		CREATE TABLE session (
+			id TEXT PRIMARY KEY,
+			title TEXT,
+			parent_id TEXT,
+			directory TEXT
+		);
+		CREATE TABLE message (
+			session_id TEXT,
+			data TEXT,
+			time_created INTEGER
+		);
+	'
+	return 0
+}
+
+insert_session_fixture() {
+	local db_path="$1"
+	local session_id="$2"
+	local title="$3"
+	local start_ms="$4"
+	local directory="$5"
+	local assistant_completed=$((start_ms + 10000))
+	local user_created=$((assistant_completed + 20000))
+
+	sqlite3 "$db_path" <<SQL
+INSERT INTO session(id, title, parent_id, directory)
+VALUES('${session_id}', '${title}', NULL, '${directory}');
+INSERT INTO message(session_id, data, time_created)
+VALUES('${session_id}', '{"role":"assistant","time":{"completed":${assistant_completed}}}', ${start_ms});
+INSERT INTO message(session_id, data, time_created)
+VALUES('${session_id}', '{"role":"user"}', ${user_created});
+SQL
+	return 0
+}
+
+test_session_time_includes_archive_and_dedupes() {
+	local test_name="session time includes OpenCode archive and dedupes"
+	setup
+
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+
+	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
+	local archive_db="${TEST_DIR}/home/.local/share/opencode/opencode-archive.db"
+	create_session_db "$active_db"
+	create_session_db "$archive_db"
+
+	local now_ms old_ms near_month_ms recent_ms
+	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
+	recent_ms=$((now_ms - 86400000))
+	near_month_ms=$((now_ms - (29 * 86400000)))
+	old_ms=$((now_ms - (100 * 86400000)))
+
+	insert_session_fixture "$active_db" "current-interactive" "Current interactive" "$recent_ms" "$TEST_DIR/repo"
+	insert_session_fixture "$archive_db" "current-interactive" "Current interactive duplicate" "$recent_ms" "$TEST_DIR/repo"
+	insert_session_fixture "$archive_db" "near-month-interactive" "Near month interactive" "$near_month_ms" "$TEST_DIR/repo"
+	insert_session_fixture "$archive_db" "old-worker" "Issue #123: archived worker" "$old_ms" "$TEST_DIR/repo"
+
+	local year_json month_json twenty_eight_json year_sessions month_sessions twenty_eight_sessions worker_sessions observed_days
+	year_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period year --format json)
+	month_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period month --format json)
+	twenty_eight_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period 28d --format json)
+	year_sessions=$(echo "$year_json" | jq -r '.total_sessions')
+	month_sessions=$(echo "$month_json" | jq -r '.total_sessions')
+	twenty_eight_sessions=$(echo "$twenty_eight_json" | jq -r '.total_sessions')
+	worker_sessions=$(echo "$year_json" | jq -r '.worker_sessions')
+	observed_days=$(echo "$year_json" | jq -r '.observed_days')
+
+	if [[ "$year_sessions" != "3" ]]; then
+		print_result "$test_name" 1 "expected 3 year sessions, got ${year_sessions}; JSON: ${year_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$month_sessions" != "2" ]]; then
+		print_result "$test_name" 1 "expected 2 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$twenty_eight_sessions" != "1" ]]; then
+		print_result "$test_name" 1 "expected 1 session in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$worker_sessions" != "1" ]]; then
+		print_result "$test_name" 1 "expected archived worker classification, got ${worker_sessions}; JSON: ${year_json}"
+		teardown
+		return 0
+	fi
+	if ! awk "BEGIN {exit !(${observed_days} >= 99)}"; then
+		print_result "$test_name" 1 "expected observed_days >= 99, got ${observed_days}"
+		teardown
+		return 0
+	fi
+
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+main() {
+	if [[ ! -f "$SOURCE_SESSION_LIB" ]]; then
+		echo "Session library not found: ${SOURCE_SESSION_LIB}" >&2
+		return 1
+	fi
+	if ! command -v sqlite3 >/dev/null 2>&1; then
+		echo "sqlite3 not available; skipping"
+		return 0
+	fi
+
+	test_session_time_includes_archive_and_dedupes
+
+	echo ""
+	echo "Tests run: ${TESTS_RUN}"
+	echo "Passed:    ${TESTS_PASSED}"
+	echo "Failed:    ${TESTS_FAILED}"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-launchd-install-if-changed.sh
+++ b/.agents/scripts/tests/test-launchd-install-if-changed.sh
@@ -274,7 +274,16 @@ _load_schedulers_platform_functions() {
 	_install_scheduler_linux() { return 0; }
 	_uninstall_scheduler()    { return 0; }
 	_resolve_modern_bash()    { printf '%s\n' "/bin/bash"; return 0; }
-	_xml_escape()             { printf '%s' "$1"; return 0; }
+	_xml_escape() {
+		local value="$1"
+		value="${value//&/\&amp;}"
+		value="${value//</\&lt;}"
+		value="${value//>/\&gt;}"
+		value="${value//\"/\&quot;}"
+		value="${value//\'/\&apos;}"
+		printf '%s' "$value"
+		return 0
+	}
 	aidevops_launchd_sanitized_path() { printf '%s\n' "/usr/bin:/bin"; return 0; }
 	_launchd_install_if_changed() { return 0; }
 	_launchd_kickstart_and_recover() { return 1; }
@@ -807,7 +816,7 @@ test_profile_readme_install_does_not_kickstart() {
 	<array>
 		<string>/bin/bash</string>
 		<string>-lc</string>
-		<string>start_epoch=$(date +%s); status=success; '/fake/profile-readme-helper.sh' update; rc=$?; end_epoch=$(date +%s); duration=$(( ${end_epoch:-0} - ${start_epoch:-0} )); if [ "$rc" -ne 0 ]; then status=failure; fi; if [ -x "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" ]; then "\$HOME/.aidevops/agents/scripts/routine-log-helper.sh" update "r908" --status "$status" --duration "$duration" >/dev/null 2>&1 || true; fi; exit "$rc"</string>
+		<string>start_epoch=$(date +%s); status=success; &apos;/fake/profile-readme-helper.sh&apos; update; rc=$?; end_epoch=$(date +%s); duration=$(( ${end_epoch:-0} - ${start_epoch:-0} )); if [ &quot;$rc&quot; -ne 0 ]; then status=failure; fi; if [ -x &quot;$HOME/.aidevops/agents/scripts/routine-log-helper.sh&quot; ]; then &quot;$HOME/.aidevops/agents/scripts/routine-log-helper.sh&quot; update &quot;r908&quot; --status &quot;$status&quot; --duration &quot;$duration&quot; &gt;/dev/null 2&gt;&amp;1 || true; fi; exit &quot;$rc&quot;</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>3600</integer>

--- a/.agents/scripts/tests/test-xml-escape-patsub.sh
+++ b/.agents/scripts/tests/test-xml-escape-patsub.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+SETUP_SH="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local result="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$result" -eq 0 ]]; then
+		echo -e "${TEST_GREEN}PASS${RESET} ${test_name}"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo -e "${TEST_RED}FAIL${RESET} ${test_name}"
+		if [[ -n "$message" ]]; then
+			echo "       ${message}"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	TEST_DIR=""
+	return 0
+}
+
+load_setup_xml_escape() {
+	local function_file="${TEST_DIR}/xml-escape-function.sh"
+	awk '
+		/^_xml_escape\(\) \{/ { capture = 1 }
+		capture { print }
+		capture && /^}/ { exit }
+	' "$SETUP_SH" >"$function_file"
+
+	# shellcheck source=/dev/null
+	source "$function_file"
+	if ! declare -F _xml_escape >/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+}
+
+restore_patsub_replacement() {
+	local previous_state="$1"
+	case "$previous_state" in
+	on) shopt -s patsub_replacement 2>/dev/null || true ;;
+	off) shopt -u patsub_replacement 2>/dev/null || true ;;
+	*) ;;
+	esac
+	return 0
+}
+
+test_xml_escape_survives_patsub_replacement() {
+	local test_name="xml escape survives patsub_replacement"
+	setup
+
+	if ! load_setup_xml_escape; then
+		print_result "$test_name" 1 "could not load _xml_escape from setup.sh"
+		teardown
+		return 0
+	fi
+
+	local previous_state="unsupported"
+	if shopt -q patsub_replacement 2>/dev/null; then
+		previous_state="on"
+	elif shopt -u patsub_replacement 2>/dev/null; then
+		previous_state="off"
+	fi
+	shopt -s patsub_replacement 2>/dev/null || true
+
+	local input expected escaped
+	input="cmd 'x' \"y\" >/tmp/a&b <tag>"
+	expected="cmd &apos;x&apos; &quot;y&quot; &gt;/tmp/a&amp;b &lt;tag&gt;"
+	escaped=$(_xml_escape "$input")
+	restore_patsub_replacement "$previous_state"
+
+	if [[ "$escaped" != "$expected" ]]; then
+		print_result "$test_name" 1 "expected '${expected}', got '${escaped}'"
+		teardown
+		return 0
+	fi
+
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+main() {
+	if [[ ! -f "$SETUP_SH" ]]; then
+		echo "setup.sh not found: ${SETUP_SH}" >&2
+		return 1
+	fi
+
+	test_xml_escape_survives_patsub_replacement
+
+	echo ""
+	echo "Tests run: ${TESTS_RUN}"
+	echo "Passed:    ${TESTS_PASSED}"
+	echo "Failed:    ${TESTS_FAILED}"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -131,11 +131,13 @@ unset _SHARED_CONSTANTS
 # Prevents XML injection if paths contain &, <, >, ", or ' characters.
 _xml_escape() {
 	local str="$1"
-	str="${str//&/&amp;}"
-	str="${str//</&lt;}"
-	str="${str//>/&gt;}"
-	str="${str//\"/&quot;}"
-	str="${str//\'/&apos;}"
+	# Escape replacement ampersands so Bash 5.2+ with patsub_replacement
+	# enabled does not turn "&apos;" into "'apos;" in generated plists.
+	str="${str//&/\&amp;}"
+	str="${str//</\&lt;}"
+	str="${str//>/\&gt;}"
+	str="${str//\"/\&quot;}"
+	str="${str//\'/\&apos;}"
 	printf '%s' "$str"
 	return 0
 }


### PR DESCRIPTION
## Summary
- Fix profile README update and screen-time scheduler plist XML escaping under Bash `patsub_replacement` so launchd commands no longer render as `apos;`, `quot;`, or `>gt;`.
- Aggregate AI session metrics from both active `opencode.db` and `opencode-archive.db`, de-duplicating copied sessions.
- Align the profile table’s 28-day AI session window with the screen-time 28-day window and disclose partial 365-day local session coverage.

## Root Cause
- `_xml_escape` used replacement strings beginning with `&`; with Bash `patsub_replacement` enabled, XML entities became malformed command text in launchd plists.
- Session-time metrics only read the active OpenCode DB, while older sessions had been archived, making 365-day values collapse to the current active DB window.
- The profile’s “28 Days” column used contributor `month` (30d) for AI session metrics.

## Testing
- `bash .agents/scripts/tests/test-xml-escape-patsub.sh`
- `bash .agents/scripts/tests/test-contributor-session-archive.sh`
- `bash .agents/scripts/tests/test-launchd-install-if-changed.sh`
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh`
- `bash .agents/scripts/tests/test-routine-tracking-updates.sh`
- `bash .agents/scripts/tests/test-loc-badge-reusable-install.sh`
- `shellcheck setup.sh .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/routine-helper.sh .agents/scripts/loc-badge-helper.sh .agents/scripts/tests/test-launchd-install-if-changed.sh .agents/scripts/tests/test-xml-escape-patsub.sh .agents/scripts/tests/test-contributor-session-archive.sh`
- `.agents/scripts/linters-local.sh` (passes; advisory pre-existing markdown/ratchet/complexity output only)
- `.agents/scripts/profile-readme-helper.sh generate` confirmed current Work with AI values use archive-backed 365-day session totals and include coverage disclosure.

Resolves #24835

## Runtime Testing
self-assessed: shell helpers and generated Markdown/plist behavior verified via regression tests and local generation.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.65 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 38m and 310,179 tokens on this with the user in an interactive session.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI session coverage metrics to user profiles, displaying the observed time span of local assistant session history when data is available.

* **Bug Fixes**
  * Fixed session time calculations to correctly aggregate data across multiple databases and deduplicate overlapping sessions.
  * Corrected special character encoding in profile content.

* **Tests**
  * Added comprehensive test coverage for multi-database session aggregation and character encoding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->