### PR TITLE
GH#24828: fix: avoid linked issue workflow failures

### DIFF
--- a/.agents/scripts/tests/test-linked-issue-guidance.sh
+++ b/.agents/scripts/tests/test-linked-issue-guidance.sh
@@ -21,6 +21,18 @@ assert_contains() {
 	return 0
 }
 
+assert_not_contains() {
+	local file="$1"
+	local pattern="$2"
+	local label="$3"
+	if grep -Eq "$pattern" "${REPO_ROOT}/${file}"; then
+		printf 'FAIL: %s found unexpected pattern in %s\n' "$label" "$file" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$label"
+	return 0
+}
+
 assert_contains "CONTRIBUTING.md" 'Issue-first PRs' "CONTRIBUTING issue-first section"
 assert_contains "CONTRIBUTING.md" 'Closes #NNN' "CONTRIBUTING closing keyword"
 assert_contains "CONTRIBUTING.md" 'Ref #NNN' "CONTRIBUTING reference keyword"
@@ -29,5 +41,7 @@ assert_contains ".github/PULL_REQUEST_TEMPLATE.md" 'Closes #NNN' "PR template cl
 assert_contains ".github/PULL_REQUEST_TEMPLATE.md" 'Ref #NNN' "PR template reference keyword"
 assert_contains ".agents/scripts/commands/log-issue-aidevops.md" 'For #NNN.*Ref #NNN' "command log issue PR reference guidance"
 assert_contains ".agents/workflows/log-issue-aidevops.md" 'For #NNN.*Ref #NNN' "workflow log issue PR reference guidance"
+assert_contains ".github/workflows/linked-issue-check.yml" "state: 'failure'" "linked issue status gate remains blocking"
+assert_not_contains ".github/workflows/linked-issue-check.yml" 'core\.setFailed' "linked issue policy gate avoids workflow failure"
 
 exit 0

--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -116,7 +116,9 @@ jobs:
               return;
             }
 
-            // No linked issue found — block
+            // No linked issue found — block through the explicit commit status.
+            // Keep the workflow job green so CI-failure mining does not treat
+            // an intentional policy gate as a systemic workflow failure.
             console.log(`No linked issue reference found in PR body`);
             await github.rest.repos.createCommitStatus({
               owner: repo.owner,
@@ -127,7 +129,7 @@ jobs:
               description: 'No linked issue — add Closes/Fixes/Resolves/For #NNN to PR body'
             });
 
-            core.setFailed(
+            core.warning(
               'PR body must reference a linked issue.\n' +
               'Add one of: `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN`, `For #NNN`, or `Ref #NNN`\n' +
               'If no issue exists for this change, please create one first.'


### PR DESCRIPTION
## Summary

Changed linked-issue-check to preserve the explicit linked-issue commit-status failure gate while emitting a warning instead of failing the workflow job, preventing CI-failure mining from classifying intentional policy blocks as systemic workflow failures. Added regression coverage that requires the blocking status and forbids core.setFailed in the workflow.

## Files Changed

.agents/scripts/tests/test-linked-issue-guidance.sh,.github/workflows/linked-issue-check.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-linked-issue-guidance.sh; shellcheck .agents/scripts/tests/test-linked-issue-guidance.sh; git diff --check

Resolves #24828


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.65 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2m and 86,685 tokens on this as a headless worker.