### PR TITLE
feat: add design init and guideline exports

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -15,6 +15,7 @@ Config file: `~/.config/aidevops/repos.json`. Structure: `{"initialized_repos": 
 | `maintainer` | string | GitHub username. Auto-detected from `gh api user`; falls back to slug owner |
 | `role` | string | `"maintainer"` or `"contributor"`. Controls which pulse scanners run |
 | `init_scope` | string | `"minimal"`, `"standard"` (default), or `"public"`. Controls `aidevops init` scaffolding |
+| `has_interface` | bool | Explicit GUI/interface flag. `true` forces DESIGN.md scaffolding/backfill; `false` suppresses heuristic interface detection. |
 | `agent_source` | bool | `true` = repo is a managed private agent source pack; `aidevops init` seeds core-style agent structure and `aidevops update` refreshes framework-owned organization templates |
 
 ### `role` detail
@@ -31,6 +32,10 @@ Auto-detected from slug owner vs `gh api user` when omitted.
 - `public`: adds LICENCE, CHANGELOG.md, CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md
 
 Auto-inferred when absent: `local_only`/no-remote → `minimal`; others → `standard`. Stored in `.aidevops.json` per project. Preserved on re-registration.
+
+### `has_interface` detail
+
+`aidevops init` records this field in `.aidevops.json` and mirrors it into `repos.json` during registration. When absent, design helpers infer it from UI markers such as Next/Vite/Nuxt/Astro/Svelte config, React/Vue/Svelte entry files, view templates, frontend/client/web directories, or UI dependencies. Minimal-scope repos with `has_interface: true` still receive a root `DESIGN.md`; standard/public scopes continue to seed it by default.
 
 ### `agent_source` detail
 

--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -610,13 +610,14 @@ _init_scaffold_commands_symlinks() {
 	return 0
 }
 
-# Scaffold optional files gated by init_scope (t2265).
+# Scaffold optional files gated by init_scope (t2265) and interface detection.
 # Extracted from cmd_init to reduce nesting depth and function length.
-# Usage: _init_scaffold_scope_gated_files <project_root> <init_scope> <repo_name>
+# Usage: _init_scaffold_scope_gated_files <project_root> <init_scope> <repo_name> [has_interface]
 _init_scaffold_scope_gated_files() {
 	local project_root="$1"
 	local init_scope="$2"
 	local repo_name="$3"
+	local has_interface="${4:-false}"
 
 	# Collaborator pointer files — require standard scope
 	if _scope_includes "$init_scope" "standard"; then
@@ -641,19 +642,11 @@ _init_scaffold_scope_gated_files() {
 		print_info "Collaborator pointer files skipped (init_scope: $init_scope)"
 	fi
 
-	# DESIGN.md — requires standard scope
-	if _scope_includes "$init_scope" "standard"; then
-		if [[ ! -f "$project_root/DESIGN.md" ]]; then
-			local design_template="$AGENTS_DIR/templates/DESIGN.md.template"
-			if [[ -f "$design_template" ]]; then
-				sed "s/{Project Name}/$repo_name/g" "$design_template" >"$project_root/DESIGN.md"
-				print_success "Created DESIGN.md (design system skeleton — populate with tools/design/design-md.md)"
-			fi
-		else
-			print_info "DESIGN.md already exists, skipping"
-		fi
+	# DESIGN.md — standard scope, plus minimal-scope repos when a GUI/interface is detected.
+	if _scope_includes "$init_scope" "standard" || [[ "$has_interface" == "true" ]]; then
+		_init_scaffold_design_md "$project_root" "$repo_name"
 	else
-		print_info "DESIGN.md skipped (init_scope: $init_scope)"
+		print_info "DESIGN.md skipped (init_scope: $init_scope, interface: $has_interface)"
 	fi
 
 	# Courtesy files (README, LICENCE, CHANGELOG, etc.) — scope handled internally
@@ -796,6 +789,9 @@ cmd_init() {
 	init_scope=$(_infer_init_scope "$project_root")
 	print_info "Init scope: $init_scope (controls which scaffolding files are created)"
 
+	local has_interface=false
+	_init_repo_has_interface "$project_root" && has_interface=true
+
 	local is_agent_source=false
 	if is_agent_source_repo "$project_root"; then
 		is_agent_source=true
@@ -813,6 +809,7 @@ cmd_init() {
   "version": "$aidevops_version",
   "initialized": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "init_scope": "$init_scope",
+  "has_interface": $has_interface,
   "agent_source": $is_agent_source,
   "features": {
     "planning": $enable_planning,
@@ -1296,7 +1293,7 @@ GITATTRSEOF
 	# Scaffold optional files gated by init_scope (collaborator pointers,
 	# DESIGN.md, courtesy files, MODELS.md). Extracted to reduce cmd_init
 	# nesting depth and function length (t2265).
-	_init_scaffold_scope_gated_files "$project_root" "$init_scope" "$repo_name"
+	_init_scaffold_scope_gated_files "$project_root" "$init_scope" "$repo_name" "$has_interface"
 
 	_init_configure_coderabbit_abort_on_close "$project_root" "$enable_code_quality"
 

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -410,6 +410,15 @@ _init_scaffold_design_md() {
 	return 0
 }
 
+_repo_registration_maintainer() {
+	local maintainer=""
+	if command -v gh &>/dev/null; then
+		maintainer=$(gh api user --jq '.login' 2>/dev/null) || maintainer=""
+	fi
+	printf '%s\n' "$maintainer"
+	return 0
+}
+
 # Register a repo in repos.json
 # Usage: register_repo <path> <version> <features>
 register_repo() {
@@ -455,27 +464,20 @@ register_repo() {
 		fi
 	fi
 
-	# Auto-detect maintainer from gh API (current authenticated user)
-	# Only runs once per registration — preserved on subsequent updates
 	local maintainer=""
-	if command -v gh &>/dev/null; then
-		maintainer=$(gh api user --jq '.login' 2>/dev/null) || maintainer=""
-	fi
+	maintainer=$(_repo_registration_maintainer)
 
 	local DEFAULT_PULSE="false"
 	local DEFAULT_PRIORITY=""
 	eval "$(_compute_repo_registration_defaults "$repo_path" "$slug" "$is_local_only" "$maintainer")"
 
-	# Infer default init_scope; pass is_local_only (already computed) to skip redundant I/O
 	local default_init_scope
 	default_init_scope=$(_infer_init_scope "$repo_path" "$is_local_only")
 
 	local has_interface
 	has_interface=$(_repo_config_has_interface_value "$repo_path")
 
-	# Check if repo already registered
 	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" &>/dev/null; then
-		# Update existing entry, preserving pulse/priority/local_only/maintainer/init_scope if already set
 		local temp_file="${REPOS_FILE}.tmp"
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 			--arg slug "$slug" --argjson local_only "$is_local_only" --arg maintainer "$maintainer" \
@@ -493,7 +495,6 @@ register_repo() {
 			)' \
 			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
 	else
-		# Add new entry with slug, defaults, maintainer, and init_scope
 		local temp_file="${REPOS_FILE}.tmp"
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 			--arg slug "$slug" --arg maintainer "$maintainer" \

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -358,6 +358,58 @@ resolve_canonical_repo_path() {
 	return 0
 }
 
+_repo_config_has_interface_value() {
+	local repo_path="$1"
+	local has_interface=""
+	if command -v jq &>/dev/null && [[ -f "$repo_path/.aidevops.json" ]]; then
+		has_interface=$(jq -r 'if has("has_interface") then .has_interface elif has("interface") then .interface else empty end' "$repo_path/.aidevops.json" 2>/dev/null || echo "")
+		case "$has_interface" in
+		true | false)
+			printf '%s\n' "$has_interface"
+			return 0
+			;;
+		esac
+	fi
+	printf '\n'
+	return 0
+}
+
+_init_design_helper_path() {
+	local helper="$AGENTS_DIR/scripts/design-guidelines-helper.sh"
+	[[ -x "$helper" ]] || helper="$INSTALL_DIR/.agents/scripts/design-guidelines-helper.sh"
+	[[ -x "$helper" ]] || return 1
+	printf '%s\n' "$helper"
+	return 0
+}
+
+_init_repo_has_interface() {
+	local project_root="$1"
+	local helper
+	helper=$(_init_design_helper_path) || return 1
+	"$helper" detect "$project_root" >/dev/null 2>&1
+	return $?
+}
+
+_init_scaffold_design_md() {
+	local project_root="$1"
+	local repo_name="$2"
+	local helper
+	if [[ -f "$project_root/DESIGN.md" ]]; then
+		print_info "DESIGN.md already exists, skipping"
+		return 0
+	fi
+	helper=$(_init_design_helper_path) || {
+		print_warning "DESIGN.md helper not found; run aidevops update and retry"
+		return 0
+	}
+	if "$helper" scaffold "$project_root" --force >/dev/null; then
+		print_success "Created DESIGN.md for $repo_name (design system skeleton — populate with tools/design/design-md.md)"
+	else
+		print_warning "DESIGN.md scaffolding failed"
+	fi
+	return 0
+}
+
 # Register a repo in repos.json
 # Usage: register_repo <path> <version> <features>
 register_repo() {
@@ -418,6 +470,9 @@ register_repo() {
 	local default_init_scope
 	default_init_scope=$(_infer_init_scope "$repo_path" "$is_local_only")
 
+	local has_interface
+	has_interface=$(_repo_config_has_interface_value "$repo_path")
+
 	# Check if repo already registered
 	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" &>/dev/null; then
 		# Update existing entry, preserving pulse/priority/local_only/maintainer/init_scope if already set
@@ -425,7 +480,7 @@ register_repo() {
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 			--arg slug "$slug" --argjson local_only "$is_local_only" --arg maintainer "$maintainer" \
 			--argjson pulse_default "$DEFAULT_PULSE" --arg priority_default "$DEFAULT_PRIORITY" \
-			--arg init_scope_default "$default_init_scope" \
+			--arg init_scope_default "$default_init_scope" --arg has_interface "$has_interface" \
 			'(.initialized_repos[] | select(.path == $path)) |= (
 				. + {path: $path, version: $version, features: ($features | split(",")), updated: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}
 				| if $slug != "" then .slug = $slug else . end
@@ -434,6 +489,7 @@ register_repo() {
 				| if (.priority == null or .priority == "") and $priority_default != "" then .priority = $priority_default else . end
 				| if (.maintainer == null or .maintainer == "") and $maintainer != "" then .maintainer = $maintainer else . end
 				| if (.init_scope == null or .init_scope == "") then .init_scope = $init_scope_default else . end
+				| if $has_interface == "true" then .has_interface = true elif $has_interface == "false" then .has_interface = false else . end
 			)' \
 			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
 	else
@@ -442,7 +498,7 @@ register_repo() {
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 			--arg slug "$slug" --arg maintainer "$maintainer" \
 			--argjson local_only "$is_local_only" --argjson pulse_default "$DEFAULT_PULSE" \
-			--arg priority_default "$DEFAULT_PRIORITY" --arg init_scope "$default_init_scope" \
+			--arg priority_default "$DEFAULT_PRIORITY" --arg init_scope "$default_init_scope" --arg has_interface "$has_interface" \
 			'.initialized_repos += [(
 				{
 					path: $path,
@@ -456,6 +512,7 @@ register_repo() {
 				| if $slug != "" then . + {slug: $slug} else . end
 				| if $local_only then . + {local_only: true, pulse: false} else . end
 				| if $priority_default != "" then . + {priority: $priority_default} else . end
+				| if $has_interface == "true" then . + {has_interface: true} elif $has_interface == "false" then . + {has_interface: false} else . end
 			)]' \
 			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
 	fi

--- a/.agents/scripts/commands/design-artifact.md
+++ b/.agents/scripts/commands/design-artifact.md
@@ -14,10 +14,12 @@ Request: $ARGUMENTS
 ## Decision Tree
 
 1. If the project lacks `DESIGN.md`, create/lint it first via `tools/design/design-md.md`.
-2. If the task is implementation in an existing codebase, use aidevops UI agents directly.
-3. If the task is artifact-first preview/export (deck, poster, carousel, mobile mock, email, one-off HTML), consider `/open-design route "$ARGUMENTS"`.
-4. If Open Design is used, keep generated files in its `.od/` workspace until selected outputs are reviewed.
-5. Run verification: `workflows/ui-verification.md`, `email-design-test-helper.sh`, or media/deck export checks.
+2. For brand guideline handoff, run `aidevops design guidelines . --pdf` and review `_reports/brand-guidelines/`.
+3. For cross-repo rollout, run `aidevops design survey --json` then `aidevops design issues --apply` to file worker-ready GUI repo tasks.
+4. If the task is implementation in an existing codebase, use aidevops UI agents directly.
+5. If the task is artifact-first preview/export (deck, poster, carousel, mobile mock, email, one-off HTML), consider `/open-design route "$ARGUMENTS"`.
+6. If Open Design is used, keep generated files in its `.od/` workspace until selected outputs are reviewed.
+7. Run verification: `workflows/ui-verification.md`, `email-design-test-helper.sh`, or media/deck export checks.
 
 ## Recommended Outputs
 

--- a/.agents/scripts/commands/report-render.md
+++ b/.agents/scripts/commands/report-render.md
@@ -36,6 +36,12 @@ Direct helper options:
   --output report.html
 ```
 
+Brand guideline handoff from a project `DESIGN.md`:
+
+```bash
+aidevops design guidelines . --pdf
+```
+
 ## Templates and profiles
 
 Templates:

--- a/.agents/scripts/design-guidelines-helper.sh
+++ b/.agents/scripts/design-guidelines-helper.sh
@@ -1,0 +1,787 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# design-guidelines-helper.sh — DESIGN.md detection, scaffolding, and brand guideline exports.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]:-$0}")"
+AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-$HOME/.aidevops/agents}"
+REPOS_FILE="${AIDEVOPS_REPOS_FILE:-$HOME/.config/aidevops/repos.json}"
+
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${BLUE+x}" ]] && BLUE='\033[0;34m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+_dg_info() {
+	local message="$1"
+	printf '%b[INFO]%b %s\n' "$BLUE" "$NC" "$message" >&2
+	return 0
+}
+
+_dg_success() {
+	local message="$1"
+	printf '%b[OK]%b %s\n' "$GREEN" "$NC" "$message" >&2
+	return 0
+}
+
+_dg_warn() {
+	local message="$1"
+	printf '%b[WARN]%b %s\n' "$YELLOW" "$NC" "$message" >&2
+	return 0
+}
+
+_dg_die() {
+	local message="${1:-usage error}"
+	printf '%b[%s] ERROR: %s%b\n' "$RED" "$SCRIPT_NAME" "$message" "$NC" >&2
+	exit 2
+	# shellcheck disable=SC2317
+	return 1
+}
+
+usage() {
+	cat <<'USAGE'
+Usage:
+  design-guidelines-helper.sh detect [repo-path]
+  design-guidelines-helper.sh scaffold [repo-path] [--force] [--dry-run]
+  design-guidelines-helper.sh guidelines [repo-path|DESIGN.md] [--output-dir DIR] [--template NAME] [--theme auto|light|dark] [--pdf|--no-pdf] [--pdf-profile all|a4|letter|slides]
+  design-guidelines-helper.sh survey [--json]
+  design-guidelines-helper.sh issues [--apply]
+
+Commands:
+  detect       Exit 0 and print "interface" when repo markers indicate a GUI/interface.
+  scaffold     Create a root DESIGN.md skeleton when missing and the repo has an interface.
+  guidelines   Generate brand-guidelines.md, brand-guidelines.html, and optional PDFs from DESIGN.md.
+  survey       List initialized owned repos with detected interfaces and DESIGN.md/guidelines status.
+  issues       File worker-ready auto-dispatch issues for survey repos missing DESIGN.md/guides.
+
+Examples:
+  aidevops design detect .
+  aidevops design scaffold .
+  aidevops design guidelines . --pdf
+  aidevops design survey --json
+  aidevops design issues --apply
+USAGE
+	return 0
+}
+
+_dg_abs_path() {
+	local input_path="$1"
+	local base_name=""
+	local dir_name=""
+	if [[ -d "$input_path" ]]; then
+		(cd "$input_path" 2>/dev/null && pwd -P) || return 1
+		return 0
+	fi
+	dir_name="$(dirname "$input_path")"
+	base_name="$(basename "$input_path")"
+	(cd "$dir_name" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$base_name") || return 1
+	return 0
+}
+
+_dg_glob_exists() {
+	local pattern="$1"
+	compgen -G "$pattern" >/dev/null
+	return $?
+}
+
+_dg_repo_config_interface_value() {
+	local repo_path="$1"
+	local explicit=""
+	if command -v jq >/dev/null 2>&1 && [[ -f "$repo_path/.aidevops.json" ]]; then
+		explicit=$(jq -r 'if has("has_interface") then .has_interface elif has("interface") then .interface else empty end' "$repo_path/.aidevops.json" 2>/dev/null || printf '')
+		case "$explicit" in
+		true | false)
+			printf '%s\n' "$explicit"
+			return 0
+			;;
+		esac
+	fi
+	return 1
+}
+
+_dg_repos_json_interface_value() {
+	local repo_path="$1"
+	local explicit=""
+	[[ -f "$REPOS_FILE" ]] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+
+	local canonical_path
+	canonical_path=$(_dg_abs_path "$repo_path" 2>/dev/null || printf '%s' "$repo_path")
+	explicit=$(jq -r --arg path "$canonical_path" --arg raw_path "$repo_path" '
+		.initialized_repos // []
+		| map(select(.path == $path or .path == $raw_path))
+		| if length == 0 then empty else (.[0].has_interface // .[0].interface // empty) end
+	' "$REPOS_FILE" 2>/dev/null || printf '')
+	case "$explicit" in
+	true | false)
+		printf '%s\n' "$explicit"
+		return 0
+		;;
+	esac
+	return 1
+}
+
+repo_has_interface() {
+	local repo_path="${1:-.}"
+	[[ -d "$repo_path" ]] || return 1
+
+	local explicit=""
+	explicit=$(_dg_repo_config_interface_value "$repo_path" 2>/dev/null || printf '')
+	case "$explicit" in
+	true) return 0 ;;
+	false) return 1 ;;
+	esac
+	explicit=$(_dg_repos_json_interface_value "$repo_path" 2>/dev/null || printf '')
+	case "$explicit" in
+	true) return 0 ;;
+	false) return 1 ;;
+	esac
+
+	local marker
+	for marker in \
+		"next.config.js" "next.config.mjs" "next.config.ts" \
+		"vite.config.js" "vite.config.mjs" "vite.config.ts" \
+		"nuxt.config.js" "nuxt.config.ts" "astro.config.mjs" "astro.config.ts" \
+		"svelte.config.js" "svelte.config.ts" "angular.json" "tailwind.config.js" "tailwind.config.ts" \
+		"index.html" "src/App.jsx" "src/App.tsx" "src/App.vue" "src/main.jsx" "src/main.tsx" \
+		"src/routes" "src/pages" "src/components" "app/page.jsx" "app/page.tsx" "pages/_app.jsx" "pages/_app.tsx" \
+		"resources/views" "app/views" "public/index.html" "frontend" "client" "web" "ui"; do
+		[[ -e "$repo_path/$marker" ]] && return 0
+	done
+
+	local pattern
+	for pattern in \
+		"$repo_path/templates/*.html" \
+		"$repo_path/templates/*.twig" \
+		"$repo_path/templates/*.liquid" \
+		"$repo_path/views/*.html" \
+		"$repo_path/views/*.erb" \
+		"$repo_path/views/*.php"; do
+		_dg_glob_exists "$pattern" && return 0
+	done
+
+	if git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		local ui_file=""
+		while IFS= read -r ui_file; do
+			[[ -n "$ui_file" ]] && return 0
+		done < <(git -C "$repo_path" ls-files '*.tsx' '*.jsx' '*.vue' '*.svelte' 2>/dev/null)
+	fi
+
+	local package_json="$repo_path/package.json"
+	if [[ -f "$package_json" ]]; then
+		if command -v jq >/dev/null 2>&1; then
+			local dep_count="0"
+			dep_count=$(jq '[((.dependencies // {}) + (.devDependencies // {}) + (.peerDependencies // {})) | keys[] | select(test("^(next|react|react-dom|vue|svelte|astro|@angular/core|@remix-run/react|@vitejs/plugin-react|@vitejs/plugin-vue|tailwindcss|@mui/material|@chakra-ui/react|@mantine/core|framer-motion)$"))] | length' "$package_json" 2>/dev/null || printf '0')
+			case "$dep_count" in
+			'' | *[!0-9]*) dep_count=0 ;;
+			esac
+			[[ "$dep_count" -gt 0 ]] && return 0
+		elif grep -Eq '"(next|react|react-dom|vue|svelte|astro|@angular/core|@remix-run/react|tailwindcss)"[[:space:]]*:' "$package_json" 2>/dev/null; then
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+_dg_repo_name() {
+	local repo_path="$1"
+	local remote_url=""
+	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null || printf '')
+	if [[ -n "$remote_url" ]]; then
+		basename "$remote_url" .git
+		return 0
+	fi
+	basename "$repo_path"
+	return 0
+}
+
+_dg_template_path() {
+	local candidate="$AGENTS_DIR/templates/DESIGN.md.template"
+	if [[ -f "$candidate" ]]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+	candidate="$SCRIPT_DIR/../templates/DESIGN.md.template"
+	if [[ -f "$candidate" ]]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+	return 1
+}
+
+_dg_write_design_template() {
+	local template_path="$1"
+	local output_path="$2"
+	local repo_name="$3"
+	python3 - "$template_path" "$output_path" "$repo_name" <<'PY'
+from pathlib import Path
+import sys
+
+template = Path(sys.argv[1])
+output = Path(sys.argv[2])
+repo_name = sys.argv[3]
+
+text = template.read_text(encoding="utf-8")
+text = text.replace("{Project Name}", repo_name)
+text = text.replace("{one-line description of the design system}", f"{repo_name} interface design system")
+output.write_text(text, encoding="utf-8")
+PY
+	return 0
+}
+
+cmd_detect() {
+	local repo_path="${1:-.}"
+	if repo_has_interface "$repo_path"; then
+		printf 'interface\n'
+		return 0
+	fi
+	printf 'non-interface\n'
+	return 1
+}
+
+cmd_scaffold() {
+	local repo_path="."
+	local force=false
+	local dry_run=false
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--force)
+			force=true
+			shift
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		-h | --help)
+			usage
+			return 0
+			;;
+		-*)
+			_dg_die "unknown scaffold option: $arg"
+			;;
+		*)
+			repo_path="$arg"
+			shift
+			;;
+		esac
+	done
+
+	[[ -d "$repo_path" ]] || _dg_die "repo path not found: $repo_path"
+	local design_path="$repo_path/DESIGN.md"
+	if [[ -f "$design_path" ]]; then
+		_dg_info "DESIGN.md already exists: $design_path"
+		printf '%s\n' "$design_path"
+		return 0
+	fi
+
+	if [[ "$force" != "true" ]] && ! repo_has_interface "$repo_path"; then
+		_dg_info "No interface markers detected; use --force to scaffold DESIGN.md anyway"
+		return 0
+	fi
+
+	local template_path
+	template_path=$(_dg_template_path) || _dg_die "DESIGN.md template not found"
+	local repo_name
+	repo_name=$(_dg_repo_name "$repo_path")
+	if [[ "$dry_run" == "true" ]]; then
+		printf 'would-create %s from %s\n' "$design_path" "$template_path"
+		return 0
+	fi
+	_dg_write_design_template "$template_path" "$design_path" "$repo_name"
+	_dg_success "Created $design_path"
+	printf '%s\n' "$design_path"
+	return 0
+}
+
+_dg_design_path_from_arg() {
+	local input_path="$1"
+	if [[ -d "$input_path" ]]; then
+		printf '%s/DESIGN.md\n' "$input_path"
+		return 0
+	fi
+	printf '%s\n' "$input_path"
+	return 0
+}
+
+_dg_generate_markdown() {
+	local design_path="$1"
+	local output_path="$2"
+	python3 "$SCRIPT_DIR/design_guidelines_render.py" "$design_path" "$output_path"
+	return 0
+}
+
+_dg_report_helper() {
+	local candidate="$AGENTS_DIR/scripts/report-render-helper.sh"
+	if [[ -x "$candidate" ]]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+	candidate="$SCRIPT_DIR/report-render-helper.sh"
+	if [[ -x "$candidate" ]]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+	return 1
+}
+
+_dg_browser_bin() {
+	local candidate=""
+	for candidate in \
+		"${AIDEVOPS_CHROME_BIN:-}" \
+		"$(command -v chromium 2>/dev/null || printf '')" \
+		"$(command -v chromium-browser 2>/dev/null || printf '')" \
+		"$(command -v google-chrome 2>/dev/null || printf '')" \
+		"$(command -v google-chrome-stable 2>/dev/null || printf '')" \
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+		"/Applications/Chromium.app/Contents/MacOS/Chromium" \
+		"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"; do
+		[[ -n "$candidate" && -x "$candidate" ]] && { printf '%s\n' "$candidate"; return 0; }
+	done
+	return 1
+}
+
+_dg_render_pdf() {
+	local html_path="$1"
+	local pdf_path="$2"
+	local browser_bin="$3"
+	local abs_html
+	abs_html=$(_dg_abs_path "$html_path") || return 1
+	"$browser_bin" --headless --disable-gpu --no-pdf-header-footer --print-to-pdf="$pdf_path" "file://${abs_html}" >/dev/null 2>&1
+	return $?
+}
+
+_dg_profile_pdf_name() {
+	local output_dir="$1"
+	local profile="$2"
+	case "$profile" in
+	a4)
+		printf '%s/brand-guidelines-a4.pdf\n' "$output_dir"
+		;;
+	letter)
+		printf '%s/brand-guidelines-usletter.pdf\n' "$output_dir"
+		;;
+	slides-16-9-*)
+		printf '%s/brand-guidelines-slides.pdf\n' "$output_dir"
+		;;
+	*)
+		printf '%s/brand-guidelines-%s.pdf\n' "$output_dir" "$profile"
+		;;
+	esac
+	return 0
+}
+
+_dg_expand_profiles() {
+	local requested="$1"
+	case "$requested" in
+	all)
+		printf '%s\n' "a4" "letter" "slides-16-9-2"
+		;;
+	slides)
+		printf '%s\n' "slides-16-9-2"
+		;;
+	a4 | letter | slides-16-9-1 | slides-16-9-2 | slides-16-9-3)
+		printf '%s\n' "$requested"
+		;;
+	*)
+		_dg_die "unknown PDF profile: $requested"
+		;;
+	esac
+	return 0
+}
+
+_dg_render_one_guidelines_pdf() {
+	local profile="$1"
+	local output_dir="$2"
+	local html_path="$3"
+	local markdown_path="$4"
+	local report_helper="$5"
+	local template="$6"
+	local theme="$7"
+	local browser_bin="$8"
+	local profile_html="$html_path"
+	local remove_profile_html=false
+	if [[ "$profile" != "a4" ]]; then
+		profile_html="$output_dir/.brand-guidelines-${profile}.html"
+		"$report_helper" render "$markdown_path" --template "$template" --theme "$theme" --pdf-profile "$profile" --output "$profile_html"
+		remove_profile_html=true
+	fi
+	local pdf_path
+	pdf_path=$(_dg_profile_pdf_name "$output_dir" "$profile")
+	if _dg_render_pdf "$profile_html" "$pdf_path" "$browser_bin"; then
+		_dg_success "Generated $pdf_path"
+	else
+		_dg_warn "PDF export failed for profile $profile"
+	fi
+	[[ "$remove_profile_html" == "true" ]] && rm -f "$profile_html"
+	return 0
+}
+
+_dg_render_guidelines_pdfs() {
+	local render_pdf="$1"
+	local requested_profile="$2"
+	local output_dir="$3"
+	local html_path="$4"
+	local markdown_path="$5"
+	local report_helper="$6"
+	local template="$7"
+	local theme="$8"
+	[[ "$render_pdf" == "true" ]] || return 0
+	local browser_bin=""
+	browser_bin=$(_dg_browser_bin 2>/dev/null || printf '')
+	if [[ -z "$browser_bin" ]]; then
+		_dg_warn "No Chrome/Chromium binary found; skipped PDF export"
+		return 0
+	fi
+	local profile
+	while IFS= read -r profile; do
+		[[ -z "$profile" ]] && continue
+		_dg_render_one_guidelines_pdf "$profile" "$output_dir" "$html_path" "$markdown_path" "$report_helper" "$template" "$theme" "$browser_bin"
+	done < <(_dg_expand_profiles "$requested_profile")
+	return 0
+}
+
+cmd_guidelines() {
+	local input_path="."
+	local output_dir=""
+	local template="signal-agency"
+	local theme="auto"
+	local render_pdf=true
+	local requested_profile="all"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--output-dir)
+			output_dir="${2:-}"
+			[[ -n "$output_dir" ]] || _dg_die "--output-dir requires a value"
+			shift 2
+			;;
+		--template)
+			template="${2:-}"
+			[[ -n "$template" ]] || _dg_die "--template requires a value"
+			shift 2
+			;;
+		--theme)
+			theme="${2:-}"
+			[[ -n "$theme" ]] || _dg_die "--theme requires a value"
+			shift 2
+			;;
+		--pdf)
+			render_pdf=true
+			shift
+			;;
+		--no-pdf)
+			render_pdf=false
+			shift
+			;;
+		--pdf-profile | --profile)
+			requested_profile="${2:-}"
+			[[ -n "$requested_profile" ]] || _dg_die "$arg requires a value"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			return 0
+			;;
+		-*)
+			_dg_die "unknown guidelines option: $arg"
+			;;
+		*)
+			input_path="$arg"
+			shift
+			;;
+		esac
+	done
+
+	local design_path
+	design_path=$(_dg_design_path_from_arg "$input_path")
+	[[ -f "$design_path" ]] || _dg_die "DESIGN.md not found: $design_path"
+	if [[ -z "$output_dir" ]]; then
+		if [[ -d "$input_path" ]]; then
+			output_dir="$input_path/_reports/brand-guidelines"
+		else
+			output_dir="$(dirname "$design_path")/_reports/brand-guidelines"
+		fi
+	fi
+	mkdir -p "$output_dir"
+
+	local markdown_path="$output_dir/brand-guidelines.md"
+	local html_path="$output_dir/brand-guidelines.html"
+	local report_helper
+	report_helper=$(_dg_report_helper) || _dg_die "report-render-helper.sh not found"
+
+	_dg_generate_markdown "$design_path" "$markdown_path"
+	"$report_helper" render "$markdown_path" --template "$template" --theme "$theme" --pdf-profile a4 --output "$html_path"
+	_dg_success "Generated $markdown_path"
+	_dg_success "Generated $html_path"
+
+	_dg_render_guidelines_pdfs "$render_pdf" "$requested_profile" "$output_dir" "$html_path" "$markdown_path" "$report_helper" "$template" "$theme"
+
+	printf '%s\n' "$html_path"
+	return 0
+}
+
+_dg_current_login() {
+	if command -v gh >/dev/null 2>&1; then
+		gh api user --jq '.login' 2>/dev/null || printf ''
+		return 0
+	fi
+	printf ''
+	return 0
+}
+
+_dg_repo_is_owned() {
+	local slug="$1"
+	local maintainer="$2"
+	local role="$3"
+	local login="$4"
+	local owner=""
+	[[ "$slug" == */* ]] && owner="${slug%%/*}"
+	[[ -n "$login" && "$owner" == "$login" ]] && return 0
+	[[ -n "$login" && "$maintainer" == "$login" ]] && return 0
+	[[ "$role" == "maintainer" ]] && return 0
+	return 1
+}
+
+cmd_survey() {
+	local json=false
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--json)
+			json=true
+			shift
+			;;
+		-h | --help)
+			usage
+			return 0
+			;;
+		*)
+			_dg_die "unknown survey option: $arg"
+			;;
+		esac
+	done
+
+	[[ -f "$REPOS_FILE" ]] || _dg_die "repos.json not found: $REPOS_FILE"
+	command -v jq >/dev/null 2>&1 || _dg_die "jq required for survey"
+
+	local login
+	login=$(_dg_current_login)
+	local tmp_json
+	tmp_json=$(mktemp)
+	printf '[\n' >"$tmp_json"
+	local first=true
+
+	while IFS=$'\t' read -r repo_path slug maintainer role local_only; do
+		[[ -n "$repo_path" && -d "$repo_path" ]] || continue
+		[[ -f "$repo_path/.aidevops.json" ]] || continue
+		[[ "$local_only" == "true" ]] && continue
+		_dg_repo_is_owned "$slug" "$maintainer" "$role" "$login" || continue
+		repo_has_interface "$repo_path" || continue
+
+		local has_design=false
+		local has_html=false
+		local has_pdf=false
+		[[ -f "$repo_path/DESIGN.md" ]] && has_design=true
+		[[ -f "$repo_path/_reports/brand-guidelines/brand-guidelines.html" ]] && has_html=true
+		[[ -f "$repo_path/_reports/brand-guidelines/brand-guidelines-a4.pdf" ]] && has_pdf=true
+
+		if [[ "$json" == "true" ]]; then
+			[[ "$first" == "true" ]] || printf ',\n' >>"$tmp_json"
+			first=false
+			jq -n --arg path "$repo_path" --arg slug "$slug" --argjson has_design "$has_design" --argjson has_html "$has_html" --argjson has_pdf "$has_pdf" \
+				'{path:$path, slug:$slug, has_design:$has_design, has_brand_guidelines_html:$has_html, has_brand_guidelines_pdf:$has_pdf}' >>"$tmp_json"
+		else
+			printf '%s\tDESIGN.md=%s\tHTML=%s\tPDF=%s\n' "${slug:-$repo_path}" "$has_design" "$has_html" "$has_pdf"
+		fi
+	done < <(jq -r '.initialized_repos // [] | .[] | [.path // "", .slug // "", .maintainer // "", .role // "", (.local_only // false | tostring)] | @tsv' "$REPOS_FILE")
+
+	if [[ "$json" == "true" ]]; then
+		printf '\n]\n' >>"$tmp_json"
+		cat "$tmp_json"
+	fi
+	rm -f "$tmp_json"
+	return 0
+}
+
+_dg_issue_body() {
+	local body_file="$1"
+	cat >"$body_file" <<'EOF'
+## What
+
+Create or populate the project-root `DESIGN.md` and generate brand guideline handoff artifacts from it.
+
+## Why
+
+This repo has a GUI/interface. Coding agents need a canonical design source before changing UI, and reviewers need generated HTML/PDF brand guideline files for visual QA and handoff.
+
+## How (Approach)
+
+### Files to Modify
+
+- `DESIGN.md` — create if missing, otherwise replace placeholders with observed project tokens and rules.
+- `_reports/brand-guidelines/brand-guidelines.md` — generated Markdown handoff from `DESIGN.md`.
+- `_reports/brand-guidelines/brand-guidelines.html` — generated browser review file.
+- `_reports/brand-guidelines/brand-guidelines-a4.pdf` — generated A4 PDF.
+- `_reports/brand-guidelines/brand-guidelines-usletter.pdf` — generated US Letter PDF.
+- `_reports/brand-guidelines/brand-guidelines-slides.pdf` — generated 16:9 slides PDF.
+
+### Implementation Steps
+
+1. Inspect existing UI sources for colours, typography, spacing, radius, component states, screenshots, and current brand copy.
+2. If `DESIGN.md` is absent, run `aidevops design scaffold . --force`; then replace skeleton placeholders with real observed tokens.
+3. Populate the canonical sections from `~/.aidevops/agents/tools/design/design-md.md`: overview, colours, typography, layout, elevation/depth, shapes, components, do/don'ts, responsive behaviour, and agent prompt guide.
+4. Run `aidevops design guidelines . --pdf` to regenerate the brand guideline Markdown, HTML, and PDFs.
+5. Review the generated HTML/PDF for placeholder values, broken contrast, bad pagination, and private identifiers before committing.
+
+### Verification
+
+```bash
+npx @google/design.md lint DESIGN.md
+aidevops design guidelines . --pdf
+test -f _reports/brand-guidelines/brand-guidelines.html
+test -f _reports/brand-guidelines/brand-guidelines-a4.pdf
+test -f _reports/brand-guidelines/brand-guidelines-usletter.pdf
+test -f _reports/brand-guidelines/brand-guidelines-slides.pdf
+```
+
+If `npx @google/design.md` is unavailable in this repo, record that as verification partial and include the exact install-free blocker in the PR body; still run the aidevops guideline generation command.
+
+## Acceptance Criteria
+
+- [ ] `DESIGN.md` exists at repo root and contains real project tokens, not skeleton placeholders.
+- [ ] Brand guideline Markdown, HTML, A4 PDF, US Letter PDF, and slides PDF are generated under `_reports/brand-guidelines/`.
+- [ ] Generated artifacts contain no secrets, private local paths, raw transcripts, or unrelated repo names.
+- [ ] The PR body includes the lint/generation commands and their results.
+EOF
+	return 0
+}
+
+_dg_ensure_gh_create_issue() {
+	if declare -F gh_create_issue >/dev/null 2>&1; then
+		return 0
+	fi
+	local wrappers="$SCRIPT_DIR/shared-gh-wrappers.sh"
+	[[ -f "$wrappers" ]] || return 1
+	# shellcheck source=/dev/null
+	source "$wrappers"
+	declare -F gh_create_issue >/dev/null 2>&1
+	return $?
+}
+
+_dg_existing_design_issue() {
+	local slug="$1"
+	local title="$2"
+	gh issue list --repo "$slug" --state open --search "${title} in:title" --json number,title --jq '.[0].number // empty' 2>/dev/null || true
+	return 0
+}
+
+cmd_issues() {
+	local apply=false
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--apply)
+			apply=true
+			shift
+			;;
+		--dry-run)
+			apply=false
+			shift
+			;;
+		-h | --help)
+			usage
+			return 0
+			;;
+		*)
+			_dg_die "unknown issues option: $arg"
+			;;
+		esac
+	done
+
+	[[ -f "$REPOS_FILE" ]] || _dg_die "repos.json not found: $REPOS_FILE"
+	command -v jq >/dev/null 2>&1 || _dg_die "jq required for issues"
+	command -v gh >/dev/null 2>&1 || _dg_die "gh required for issues"
+	if [[ "$apply" == "true" ]]; then
+		_dg_ensure_gh_create_issue || _dg_die "gh_create_issue wrapper unavailable"
+	fi
+
+	local survey_file
+	survey_file=$(mktemp)
+	cmd_survey --json >"$survey_file"
+	local title="Populate DESIGN.md and brand guideline exports"
+	local created=0 skipped=0 dry=0
+
+	while IFS=$'\t' read -r slug has_design has_html has_pdf; do
+		[[ -n "$slug" ]] || continue
+		if [[ "$has_design" == "true" && "$has_html" == "true" && "$has_pdf" == "true" ]]; then
+			continue
+		fi
+		local existing=""
+		existing=$(_dg_existing_design_issue "$slug" "$title")
+		if [[ -n "$existing" ]]; then
+			printf 'skip existing %s #%s\n' "$slug" "$existing"
+			skipped=$((skipped + 1))
+			continue
+		fi
+		if [[ "$apply" != "true" ]]; then
+			printf 'would-create %s %s\n' "$slug" "$title"
+			dry=$((dry + 1))
+			continue
+		fi
+
+		local body_file
+		body_file=$(mktemp)
+		_dg_issue_body "$body_file"
+		if gh_create_issue --repo "$slug" --title "$title" --body-file "$body_file" --label "auto-dispatch,tier:standard,enhancement"; then
+			created=$((created + 1))
+		else
+			_dg_warn "Issue creation failed for $slug"
+		fi
+		rm -f "$body_file"
+	done < <(jq -r '.[] | [.slug, (.has_design|tostring), (.has_brand_guidelines_html|tostring), (.has_brand_guidelines_pdf|tostring)] | @tsv' "$survey_file")
+	rm -f "$survey_file"
+
+	printf 'created=%s skipped=%s dry_run=%s\n' "$created" "$skipped" "$dry"
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	[[ $# -gt 0 ]] && shift
+	case "$command" in
+	detect)
+		cmd_detect "$@"
+		;;
+	scaffold | init)
+		cmd_scaffold "$@"
+		;;
+	guidelines | guide | render)
+		cmd_guidelines "$@"
+		;;
+	survey | status)
+		cmd_survey "$@"
+		;;
+	issues | file-issues)
+		cmd_issues "$@"
+		;;
+	help | --help | -h)
+		usage
+		;;
+	*)
+		_dg_die "unknown command: $command"
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/design-guidelines-helper.sh
+++ b/.agents/scripts/design-guidelines-helper.sh
@@ -19,6 +19,9 @@ REPOS_FILE="${AIDEVOPS_REPOS_FILE:-$HOME/.config/aidevops/repos.json}"
 [[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
 [[ -z "${NC+x}" ]] && NC='\033[0m'
 
+DG_TRUE=true
+DG_FALSE=false
+
 _dg_info() {
 	local message="$1"
 	printf '%b[INFO]%b %s\n' "$BLUE" "$NC" "$message" >&2
@@ -249,17 +252,17 @@ cmd_detect() {
 
 cmd_scaffold() {
 	local repo_path="."
-	local force=false
-	local dry_run=false
+	local force="$DG_FALSE"
+	local dry_run="$DG_FALSE"
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
 		--force)
-			force=true
+			force="$DG_TRUE"
 			shift
 			;;
 		--dry-run)
-			dry_run=true
+			dry_run="$DG_TRUE"
 			shift
 			;;
 		-h | --help)
@@ -284,7 +287,7 @@ cmd_scaffold() {
 		return 0
 	fi
 
-	if [[ "$force" != "true" ]] && ! repo_has_interface "$repo_path"; then
+	if [[ "$force" != "$DG_TRUE" ]] && ! repo_has_interface "$repo_path"; then
 		_dg_info "No interface markers detected; use --force to scaffold DESIGN.md anyway"
 		return 0
 	fi
@@ -293,7 +296,7 @@ cmd_scaffold() {
 	template_path=$(_dg_template_path) || _dg_die "DESIGN.md template not found"
 	local repo_name
 	repo_name=$(_dg_repo_name "$repo_path")
-	if [[ "$dry_run" == "true" ]]; then
+	if [[ "$dry_run" == "$DG_TRUE" ]]; then
 		printf 'would-create %s from %s\n' "$design_path" "$template_path"
 		return 0
 	fi
@@ -409,11 +412,11 @@ _dg_render_one_guidelines_pdf() {
 	local theme="$7"
 	local browser_bin="$8"
 	local profile_html="$html_path"
-	local remove_profile_html=false
+	local remove_profile_html="$DG_FALSE"
 	if [[ "$profile" != "a4" ]]; then
 		profile_html="$output_dir/.brand-guidelines-${profile}.html"
 		"$report_helper" render "$markdown_path" --template "$template" --theme "$theme" --pdf-profile "$profile" --output "$profile_html"
-		remove_profile_html=true
+		remove_profile_html="$DG_TRUE"
 	fi
 	local pdf_path
 	pdf_path=$(_dg_profile_pdf_name "$output_dir" "$profile")
@@ -422,7 +425,7 @@ _dg_render_one_guidelines_pdf() {
 	else
 		_dg_warn "PDF export failed for profile $profile"
 	fi
-	[[ "$remove_profile_html" == "true" ]] && rm -f "$profile_html"
+	[[ "$remove_profile_html" == "$DG_TRUE" ]] && rm -f "$profile_html"
 	return 0
 }
 
@@ -435,7 +438,7 @@ _dg_render_guidelines_pdfs() {
 	local report_helper="$6"
 	local template="$7"
 	local theme="$8"
-	[[ "$render_pdf" == "true" ]] || return 0
+	[[ "$render_pdf" == "$DG_TRUE" ]] || return 0
 	local browser_bin=""
 	browser_bin=$(_dg_browser_bin 2>/dev/null || printf '')
 	if [[ -z "$browser_bin" ]]; then
@@ -455,7 +458,7 @@ cmd_guidelines() {
 	local output_dir=""
 	local template="signal-agency"
 	local theme="auto"
-	local render_pdf=true
+	local render_pdf="$DG_TRUE"
 	local requested_profile="all"
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
@@ -476,11 +479,11 @@ cmd_guidelines() {
 			shift 2
 			;;
 		--pdf)
-			render_pdf=true
+			render_pdf="$DG_TRUE"
 			shift
 			;;
 		--no-pdf)
-			render_pdf=false
+			render_pdf="$DG_FALSE"
 			shift
 			;;
 		--pdf-profile | --profile)
@@ -553,12 +556,12 @@ _dg_repo_is_owned() {
 }
 
 cmd_survey() {
-	local json=false
+	local json="$DG_FALSE"
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
 		--json)
-			json=true
+			json="$DG_TRUE"
 			shift
 			;;
 		-h | --help)
@@ -579,25 +582,25 @@ cmd_survey() {
 	local tmp_json
 	tmp_json=$(mktemp)
 	printf '[\n' >"$tmp_json"
-	local first=true
+	local first="$DG_TRUE"
 
 	while IFS=$'\t' read -r repo_path slug maintainer role local_only; do
 		[[ -n "$repo_path" && -d "$repo_path" ]] || continue
 		[[ -f "$repo_path/.aidevops.json" ]] || continue
-		[[ "$local_only" == "true" ]] && continue
+		[[ "$local_only" == "$DG_TRUE" ]] && continue
 		_dg_repo_is_owned "$slug" "$maintainer" "$role" "$login" || continue
 		repo_has_interface "$repo_path" || continue
 
-		local has_design=false
-		local has_html=false
-		local has_pdf=false
-		[[ -f "$repo_path/DESIGN.md" ]] && has_design=true
-		[[ -f "$repo_path/_reports/brand-guidelines/brand-guidelines.html" ]] && has_html=true
-		[[ -f "$repo_path/_reports/brand-guidelines/brand-guidelines-a4.pdf" ]] && has_pdf=true
+		local has_design="$DG_FALSE"
+		local has_html="$DG_FALSE"
+		local has_pdf="$DG_FALSE"
+		[[ -f "$repo_path/DESIGN.md" ]] && has_design="$DG_TRUE"
+		[[ -f "$repo_path/_reports/brand-guidelines/brand-guidelines.html" ]] && has_html="$DG_TRUE"
+		[[ -f "$repo_path/_reports/brand-guidelines/brand-guidelines-a4.pdf" ]] && has_pdf="$DG_TRUE"
 
-		if [[ "$json" == "true" ]]; then
-			[[ "$first" == "true" ]] || printf ',\n' >>"$tmp_json"
-			first=false
+		if [[ "$json" == "$DG_TRUE" ]]; then
+			[[ "$first" == "$DG_TRUE" ]] || printf ',\n' >>"$tmp_json"
+			first="$DG_FALSE"
 			jq -n --arg path "$repo_path" --arg slug "$slug" --argjson has_design "$has_design" --argjson has_html "$has_html" --argjson has_pdf "$has_pdf" \
 				'{path:$path, slug:$slug, has_design:$has_design, has_brand_guidelines_html:$has_html, has_brand_guidelines_pdf:$has_pdf}' >>"$tmp_json"
 		else
@@ -605,7 +608,7 @@ cmd_survey() {
 		fi
 	done < <(jq -r '.initialized_repos // [] | .[] | [.path // "", .slug // "", .maintainer // "", .role // "", (.local_only // false | tostring)] | @tsv' "$REPOS_FILE")
 
-	if [[ "$json" == "true" ]]; then
+	if [[ "$json" == "$DG_TRUE" ]]; then
 		printf '\n]\n' >>"$tmp_json"
 		cat "$tmp_json"
 	fi
@@ -686,16 +689,16 @@ _dg_existing_design_issue() {
 }
 
 cmd_issues() {
-	local apply=false
+	local apply="$DG_FALSE"
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
 		--apply)
-			apply=true
+			apply="$DG_TRUE"
 			shift
 			;;
 		--dry-run)
-			apply=false
+			apply="$DG_FALSE"
 			shift
 			;;
 		-h | --help)
@@ -711,7 +714,7 @@ cmd_issues() {
 	[[ -f "$REPOS_FILE" ]] || _dg_die "repos.json not found: $REPOS_FILE"
 	command -v jq >/dev/null 2>&1 || _dg_die "jq required for issues"
 	command -v gh >/dev/null 2>&1 || _dg_die "gh required for issues"
-	if [[ "$apply" == "true" ]]; then
+	if [[ "$apply" == "$DG_TRUE" ]]; then
 		_dg_ensure_gh_create_issue || _dg_die "gh_create_issue wrapper unavailable"
 	fi
 
@@ -723,7 +726,7 @@ cmd_issues() {
 
 	while IFS=$'\t' read -r slug has_design has_html has_pdf; do
 		[[ -n "$slug" ]] || continue
-		if [[ "$has_design" == "true" && "$has_html" == "true" && "$has_pdf" == "true" ]]; then
+		if [[ "$has_design" == "$DG_TRUE" && "$has_html" == "$DG_TRUE" && "$has_pdf" == "$DG_TRUE" ]]; then
 			continue
 		fi
 		local existing=""
@@ -733,7 +736,7 @@ cmd_issues() {
 			skipped=$((skipped + 1))
 			continue
 		fi
-		if [[ "$apply" != "true" ]]; then
+		if [[ "$apply" != "$DG_TRUE" ]]; then
 			printf 'would-create %s %s\n' "$slug" "$title"
 			dry=$((dry + 1))
 			continue

--- a/.agents/scripts/design_guidelines_render.py
+++ b/.agents/scripts/design_guidelines_render.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Generate brand guideline Markdown from a DESIGN.md file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+
+def _split_design(text: str) -> tuple[str, str]:
+    if not text.startswith("---"):
+        return "", text
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return "", text
+    return parts[1], parts[2]
+
+
+def _scalar(front: str, name: str, default: str = "") -> str:
+    match = re.search(rf"(?m)^{re.escape(name)}:\s*(.+?)\s*$", front)
+    if not match:
+        return default
+    return match.group(1).strip().strip("\"'")
+
+
+def _section_lines(front: str, name: str) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    capture = False
+    for line in front.splitlines():
+        if re.match(rf"^{re.escape(name)}:\s*$", line):
+            capture = True
+            continue
+        if capture and re.match(r"^[A-Za-z0-9_-]+:\s*", line):
+            break
+        if not capture:
+            continue
+        match = re.match(r"^\s{2}([A-Za-z0-9_.-]+):\s*(.+?)\s*$", line)
+        if match and not match.group(2).lstrip().startswith("#"):
+            out.append((match.group(1), match.group(2).strip().strip("\"'")))
+    return out
+
+
+def _prose_section(body: str, title: str) -> str:
+    pattern = re.compile(rf"(?ms)^##\s+\d*\.?\s*{re.escape(title)}\s*\n(.*?)(?=^##\s+|\Z)")
+    match = pattern.search(body)
+    if not match:
+        return ""
+    content = re.sub(r"<!--.*?-->", "", match.group(1), flags=re.S).strip()
+    return content[:1200]
+
+
+def _append_cover(lines: list[str], description: str, design_path: Path) -> None:
+    lines.extend(
+        [
+            "::: report-cover",
+            f"**{description}**",
+            "",
+            "Generated from the project-root `DESIGN.md` so implementation agents, designers, and reviewers share one canonical visual source of truth.",
+            ":::",
+            "",
+            "::: manifest-card",
+            "",
+            "### Production manifest",
+            "",
+            f"- **Design source:** `{design_path.name}`",
+            "- **Canonical use:** UI implementation, screenshots, report styling, and brand handoff",
+            "- **Verification:** lint `DESIGN.md`, regenerate this guide, then review HTML/PDF exports",
+            "- **Change rule:** update `DESIGN.md` first; regenerate generated outputs rather than editing them by hand",
+            ":::",
+            "",
+        ]
+    )
+
+
+def _append_colours(lines: list[str], colors: list[tuple[str, str]]) -> None:
+    lines.extend(["## Colour roles", ""])
+    if not colors:
+        lines.extend(["No colour tokens were found in the YAML front matter.", ""])
+        return
+    lines.append("::: brand-swatch-grid")
+    for key, value in colors:
+        accent = key.replace("on-", "").replace("_", "-")
+        lines.extend([f"::: swatch-card accent={accent}", "", f"### {key}", "", f"`{value}`", ":::"])
+    lines.extend([":::", ""])
+
+
+def _append_token_table(lines: list[str], spacing: list[tuple[str, str]], rounded: list[tuple[str, str]]) -> None:
+    spacing_values = ", ".join(f"`{key}` {value}" for key, value in spacing) or "Populate `spacing:` tokens"
+    rounded_values = ", ".join(f"`{key}` {value}" for key, value in rounded) or "Populate `rounded:` tokens"
+    lines.extend(
+        [
+            "## Typography and layout tokens",
+            "",
+            "::: facts-table-wrap",
+            "",
+            "| Token group | Values | Usage |",
+            "|---|---|---|",
+            f"| Spacing | {spacing_values} | Layout rhythm, gutters, section spacing |",
+            f"| Rounded | {rounded_values} | Shape language for buttons, cards, forms |",
+            ":::",
+            "",
+        ]
+    )
+
+
+def render_markdown(design_path: Path) -> str:
+    text = design_path.read_text(encoding="utf-8")
+    front, body = _split_design(text)
+    name = _scalar(front, "name", design_path.parent.name)
+    description = _scalar(front, "description", f"Brand guidelines generated from {design_path.name}.")
+    colors = _section_lines(front, "colors")
+    spacing = _section_lines(front, "spacing")
+    rounded = _section_lines(front, "rounded")
+    overview = _prose_section(body, "Overview")
+    dos = _prose_section(body, "Do's and Don'ts") or _prose_section(body, "Dos and Don'ts")
+    agent = _prose_section(body, "Agent Prompt Guide")
+
+    lines = [f"# {name} Brand Guidelines", ""]
+    _append_cover(lines, description, design_path)
+    lines.extend(["## Brand overview", "", overview or "Populate the Overview section in `DESIGN.md` with the product mood, density, atmosphere, and key characteristics.", ""])
+    _append_colours(lines, colors)
+    _append_token_table(lines, spacing, rounded)
+    lines.extend(
+        [
+            "## Component and state guidance",
+            "",
+            "Use the `components:` YAML tokens in `DESIGN.md` for exact button, input, card, badge, and navigation styling. Add missing component states before implementation when hover, focus, disabled, error, loading, or selected states are not explicit.",
+            "",
+            "## Do's and don'ts",
+            "",
+            dos or "Populate the Do's and Don'ts section in `DESIGN.md` with concrete visual rules, anti-patterns, accessibility constraints, and content tone guidance.",
+            "",
+            "## Agent handoff",
+            "",
+            agent or "Implementation agents must read `DESIGN.md` before UI changes, preserve token names where practical, and regenerate this guide after brand-significant edits.",
+            "",
+            "## Verification checklist",
+            "",
+            "- [ ] `npx @google/design.md lint DESIGN.md` exits with zero errors; warnings reviewed",
+            "- [ ] `aidevops design guidelines . --pdf` regenerates Markdown, HTML, and PDFs",
+            "- [ ] Browser review confirms colour contrast, typography hierarchy, component states, and print/PDF layout",
+            "- [ ] Generated files contain no private URLs, credentials, raw transcripts, or unapproved client identifiers",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: design_guidelines_render.py DESIGN.md OUTPUT.md", file=sys.stderr)
+        return 2
+    design_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2])
+    output_path.write_text(render_markdown(design_path), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/tests/test-design-guidelines-helper.sh
+++ b/.agents/scripts/tests/test-design-guidelines-helper.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-design-guidelines-helper.sh — DESIGN.md helper regression tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/.agents/scripts/design-guidelines-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+cleanup() {
+	if [[ -n "${TEST_ROOT:-}" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+trap cleanup EXIT
+
+assert_file() {
+	local file_path="$1"
+	local test_name="$2"
+	[[ -f "$file_path" ]] && { print_result "$test_name" 0; return 0; }
+	print_result "$test_name" 1 "missing: $file_path"
+	return 0
+}
+
+test_detect_interface_markers() {
+	TEST_ROOT=$(mktemp -d)
+	local ui_repo="$TEST_ROOT/ui"
+	local cli_repo="$TEST_ROOT/cli"
+	mkdir -p "$ui_repo/src" "$cli_repo"
+	git -C "$ui_repo" init --quiet 2>/dev/null
+	git -C "$cli_repo" init --quiet 2>/dev/null
+	touch "$ui_repo/src/App.tsx"
+
+	if "$HELPER" detect "$ui_repo" >/dev/null; then
+		print_result "detect finds React UI marker" 0
+	else
+		print_result "detect finds React UI marker" 1
+	fi
+
+	if "$HELPER" detect "$cli_repo" >/dev/null 2>&1; then
+		print_result "detect ignores CLI-only repo" 1 "unexpected interface result"
+	else
+		print_result "detect ignores CLI-only repo" 0
+	fi
+
+	rm -rf "$TEST_ROOT"
+	TEST_ROOT=""
+	return 0
+}
+
+test_scaffold_and_guidelines() {
+	TEST_ROOT=$(mktemp -d)
+	local repo_dir="$TEST_ROOT/product"
+	mkdir -p "$repo_dir/src"
+	git -C "$repo_dir" init --quiet 2>/dev/null
+	git -C "$repo_dir" remote add origin "https://github.com/example/product.git"
+	touch "$repo_dir/src/App.tsx"
+
+	"$HELPER" scaffold "$repo_dir" >/dev/null
+	assert_file "$repo_dir/DESIGN.md" "scaffold creates DESIGN.md"
+
+	local output_dir="$repo_dir/_reports/brand-guidelines"
+	"$HELPER" guidelines "$repo_dir" --output-dir "$output_dir" --template basic --no-pdf >/dev/null
+	assert_file "$output_dir/brand-guidelines.md" "guidelines creates Markdown handoff"
+	assert_file "$output_dir/brand-guidelines.html" "guidelines creates HTML handoff"
+
+	rm -rf "$TEST_ROOT"
+	TEST_ROOT=""
+	return 0
+}
+
+echo "test-design-guidelines-helper.sh — DESIGN.md helper tests"
+echo "========================================================"
+
+if [[ ! -x "$HELPER" ]]; then
+	printf 'ERROR: helper not executable: %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+test_detect_interface_markers
+test_scaffold_and_guidelines
+
+echo ""
+echo "========================================================"
+echo "Results: $TESTS_RUN tests, $TESTS_FAILED failures"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/tests/test-init-scope.sh
+++ b/.agents/scripts/tests/test-init-scope.sh
@@ -206,6 +206,46 @@ test_infer_init_scope() {
 	return 0
 }
 
+# ---- Test interface detection for DESIGN.md scaffolding ----
+
+test_interface_detection() {
+	echo ""
+	echo "=== Testing interface detection ==="
+
+	TEST_ROOT=$(mktemp -d)
+
+	local helper_path_func detect_func
+	helper_path_func=$(sed -n '/_init_design_helper_path() {/,/^}/p' "$AIDEVOPS_REPOS_LIB")
+	detect_func=$(sed -n '/_init_repo_has_interface() {/,/^}/p' "$AIDEVOPS_REPOS_LIB")
+	AGENTS_DIR="$REPO_ROOT/.agents"
+	INSTALL_DIR="$REPO_ROOT"
+	eval "$helper_path_func"
+	eval "$detect_func"
+
+	local ui_dir="$TEST_ROOT/ui-repo"
+	mkdir -p "$ui_dir/src"
+	git -C "$ui_dir" init --quiet 2>/dev/null
+	touch "$ui_dir/src/App.tsx"
+	_init_repo_has_interface "$ui_dir"
+	print_result "React entry file detects interface" "$?"
+
+	local explicit_false_dir="$TEST_ROOT/explicit-false"
+	mkdir -p "$explicit_false_dir/src"
+	git -C "$explicit_false_dir" init --quiet 2>/dev/null
+	touch "$explicit_false_dir/src/App.tsx"
+	printf '%s\n' '{"has_interface": false}' >"$explicit_false_dir/.aidevops.json"
+	assert_negative "has_interface:false suppresses heuristic markers" _init_repo_has_interface "$explicit_false_dir"
+
+	local cli_dir="$TEST_ROOT/cli-repo"
+	mkdir -p "$cli_dir"
+	git -C "$cli_dir" init --quiet 2>/dev/null
+	assert_negative "CLI-only repo does not detect interface" _init_repo_has_interface "$cli_dir"
+
+	rm -rf "$TEST_ROOT"
+	TEST_ROOT=""
+	return 0
+}
+
 # ---- Test scaffold_repo_courtesy_files with scope ----
 
 # Shared setup for scaffold scope tests — extracts needed functions from aidevops.sh
@@ -313,6 +353,7 @@ test_aidevops_json_roundtrip() {
   "version": "3.8.72",
   "initialized": "2026-04-19T00:00:00Z",
   "init_scope": "minimal",
+  "has_interface": true,
   "features": {
     "planning": true
   }
@@ -328,6 +369,10 @@ EOF
 	local has_scope
 	has_scope=$(jq 'has("init_scope")' "$test_dir/.aidevops.json")
 	assert_equals "true" "$has_scope" ".aidevops.json has init_scope field"
+
+	local has_interface
+	has_interface=$(jq -r '.has_interface' "$test_dir/.aidevops.json")
+	assert_equals "true" "$has_interface" ".aidevops.json has has_interface field"
 
 	rm -rf "$TEST_ROOT"
 	TEST_ROOT=""
@@ -430,6 +475,7 @@ echo "============================================================="
 
 test_scope_includes
 test_infer_init_scope
+test_interface_detection
 test_scaffold_minimal_scope
 test_scaffold_standard_scope
 test_scaffold_public_scope

--- a/.agents/tools/design/design-md.md
+++ b/.agents/tools/design/design-md.md
@@ -32,6 +32,8 @@ model: sonnet
 - **Template**: `templates/DESIGN.md.template`
 - **Library**: `tools/design/library/` (86 brand examples, style templates, and report presentation presets)
 - **Preview**: `tools/design/library/_template/preview.html.template`
+- **Brand guide export**: `scripts/design-guidelines-helper.sh guidelines . --pdf`
+- **Repo rollout**: `scripts/design-guidelines-helper.sh survey --json` then `scripts/design-guidelines-helper.sh issues --apply`
 - **Palette tools**: `tools/design/colour-palette.md`, `scripts/colormind-helper.sh`
 - **Preview capture**: `scripts/design-preview-helper.sh`
 
@@ -60,8 +62,9 @@ Upstream `@google/design.md` v0.2.0 and follow-up commit `18508f2` were reviewed
 3. **Create** — from scratch (interview), links/local style guides (`tools/design/design-md-from-links.md`), report presentation (`tools/design/report-presentation.md`), or library example.
 4. **Validate** — run `npx @google/design.md lint DESIGN.md`. Zero errors, warnings reviewed.
 5. **Preview** — generate `preview.html` to visually verify the design system.
-6. **Iterate** — spin palettes, adjust tokens, regenerate preview until satisfied.
-7. **Build** — hand DESIGN.md to coding agents for consistent, on-brand UI output.
+6. **Brand guide** — run `aidevops design guidelines . --pdf` to create `_reports/brand-guidelines/` Markdown, HTML, and PDF handoff files.
+7. **Iterate** — spin palettes, adjust tokens, regenerate preview/guide until satisfied.
+8. **Build** — hand DESIGN.md to coding agents for consistent, on-brand UI output.
 
 <!-- AI-CONTEXT-END -->
 
@@ -216,6 +219,8 @@ Choose method based on what exists:
 | Styled report, HTML export, or PDF-ready output | Report presentation | `tools/design/report-presentation.md` |
 | Known brand/style | Library copy | `tools/design/library/brands/` or `library/styles/` |
 | `brand-identity.toon` exists | Brand identity | Map dimensions to sections (see below) |
+
+`aidevops init` now records `has_interface` and creates root `DESIGN.md` for standard-scope repos plus minimal-scope repos where interface markers are detected. Use `aidevops design scaffold . --force` for unusual GUI repos without detectable markers.
 
 **Method 1 (Interview):** Brand identity interview (`tools/design/brand-identity.md`) → select UI style from `ui-ux-catalogue.toon` → generate palette (`colour-palette.md`) → copy closest library example → synthesise into template → lint + preview + iterate.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ aidevops auto-update      # Manage automatic update polling (every 10 min)
 aidevops init             # Initialize aidevops in any project
 aidevops features         # List available features
 aidevops repos            # List/add/remove registered projects
+aidevops design           # DESIGN.md detection + brand guideline HTML/PDF exports
 aidevops detect           # Scan for unregistered aidevops projects
 aidevops upgrade-planning # Upgrade TODO.md/PLANS.md to latest templates
 aidevops update-tools     # Check and update installed tools
@@ -244,6 +245,9 @@ aidevops uninstall        # Remove aidevops
 aidevops now treats design as a self-contained stack with optional peripherals:
 
 - **Google `DESIGN.md` standard**: AI-readable design systems with YAML tokens, linting, previews, and brand/style libraries (`.agents/tools/design/design-md.md`).
+- **Init-aware design files**: `aidevops init` records `has_interface` and seeds root `DESIGN.md` for standard repos plus minimal-scope repos with detected GUI/interface markers.
+- **Brand guideline exports**: `aidevops design guidelines . --pdf` generates `_reports/brand-guidelines/brand-guidelines.md`, HTML, and A4/US Letter/slides PDFs from `DESIGN.md`.
+- **Repo rollout**: `aidevops design survey --json` audits owned initialized GUI repos; `aidevops design issues --apply` files worker-ready auto-dispatch issues for missing `DESIGN.md`/brand-guideline artifacts.
 - **Design agents and skills**: brand identity, palettes, UI inspiration, product UI rules, shadcn/Tailwind/UI skills, Nothing-style design, email rendering, Remotion/video, and browser-based UI verification.
 - **Artifact routing commands**: `/design-artifact` decides whether to use aidevops-native implementation or a companion artifact studio; `/open-design` manages optional Open Design workflows.
 - **Verification gates**: Playwright screenshots, accessibility/contrast checks, email rendering, deck export/fidelity checks, and media smoke tests before generated artifacts are accepted.
@@ -585,7 +589,7 @@ See `.agents/tools/terminal/terminal-title.md` for customization options.
 
 **Collaborator compatibility:** Projects initialized with `aidevops init` include pointer files (`.cursorrules`, `.windsurfrules`, etc.) that reference `AGENTS.md`, helping collaborators using other editors find project context. aidevops does not install into or configure those tools.
 
-**Repo courtesy files:** `aidevops init` scaffolds standard repo files if they don't exist: `README.md`, `LICENCE` (MIT), `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`. Author name and email are auto-detected from git config. Existing files are never overwritten.
+**Repo courtesy files:** `aidevops init` scaffolds standard repo files if they don't exist: `DESIGN.md` for GUI/interface repos, `README.md`, `LICENCE` (MIT), `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`. Author name and email are auto-detected from git config. Existing files are never overwritten.
 
 ## **Core Capabilities**
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -836,6 +836,7 @@ _help_commands() {
 	echo "  repo-sync <cmd>    Daily git pull for repos in parent dirs (enable/disable/status/dirs)"
 	echo "  update-tools       Check for outdated tools (--update to auto-update)"
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
+	echo "  design <cmd>       DESIGN.md detection, scaffolding, and brand guideline exports"
 	echo "  cleanup <cmd>      Cleanup helpers (remote branch audit/delete)"
 	echo "  model-accounts-pool OAuth account pool (list/check/diagnose/add/rotate/reset-cooldowns)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
@@ -950,6 +951,13 @@ _help_detailed_sections() {
 	echo "  aidevops knowledge add <file|url>      # Ingest file or URL into sources/"
 	echo "  aidevops knowledge list [--state s] [--kind k]  # List all known sources"
 	echo "  aidevops knowledge search <query>      # Search sources (grep fallback)"
+	echo ""
+	echo "Design Systems:"
+	echo "  aidevops design detect [path]          # Detect whether a repo has a GUI/interface"
+	echo "  aidevops design scaffold [path]        # Create DESIGN.md skeleton when missing"
+	echo "  aidevops design guidelines [path] --pdf # Generate brand guideline HTML/PDF exports"
+	echo "  aidevops design survey [--json]        # Audit owned initialized GUI repos"
+	echo "  aidevops design issues --apply         # File auto-dispatch issues for missing design artifacts"
 	echo ""
 	echo "Campaign Plane:"
 	echo "  aidevops campaign init [<path>]          # Provision _campaigns/ directory contract (P1)"
@@ -1500,6 +1508,7 @@ main() {
 	update-tools | tools) cmd_update_tools "$@" ;;
 	upgrade-planning | up) cmd_upgrade_planning "$@" ;;
 	repos | projects) cmd_repos "$@" ;;
+	design) _dispatch_helper "design-guidelines-helper.sh" "design-guidelines-helper.sh" "$@" ;;
 	skill) cmd_skill "$@" ;;
 	skills) cmd_skills "$@" ;;
 	sources | agent-sources) _dispatch_helper "agent-sources-helper.sh" "agent-sources-helper.sh" "$@" ;;


### PR DESCRIPTION
For #24834

## Summary

- Add `aidevops design` CLI dispatch for interface detection, DESIGN.md scaffolding, brand-guideline export, repo survey, and issue rollout.
- Record `has_interface` in `.aidevops.json` / `repos.json` and scaffold root `DESIGN.md` for standard repos plus minimal GUI repos.
- Generate brand guideline Markdown/HTML/PDF handoff files from `DESIGN.md` and document the workflow.

## Rollout issues filed

- https://github.com/marcusquinn/aidevops/issues/24834
- https://github.com/marcusquinn/turbostarter-plus/issues/174
- One private managed GUI repo issue filed; redacted from this public PR body.
- https://github.com/essentials-com/essentials.com/issues/103
- https://github.com/marcusquinn/static-site-starter/issues/12

## Verification

- `bash -n .agents/scripts/aidevops-cli/aidevops-init-lib.sh .agents/scripts/aidevops-cli/aidevops-repos-lib.sh .agents/scripts/design-guidelines-helper.sh`
- `shellcheck .agents/scripts/design-guidelines-helper.sh .agents/scripts/aidevops-cli/aidevops-init-lib.sh .agents/scripts/aidevops-cli/aidevops-repos-lib.sh .agents/scripts/tests/test-init-scope.sh .agents/scripts/tests/test-design-guidelines-helper.sh`
- `python3 -m py_compile .agents/scripts/design_guidelines_render.py`
- `.agents/scripts/tests/test-design-guidelines-helper.sh && .agents/scripts/tests/test-init-scope.sh`
- `git diff --check origin/main...HEAD`
- `.agents/scripts/linters-local.sh` — passed; warnings were pre-existing/advisory, with no new repeated string literals after the fix.

## Notes

- No release/version bump is included.
- The generated repo rollout issues are worker-ready and use auto-dispatch labels.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.66 with gpt-5.5 spent 1h 20m and 786,210 tokens on this with the user in an interactive session.
