### PR TITLE
GH#24844: test: improve nostr vpn privacy guide diagnostics

### DIFF
--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -201,10 +201,12 @@ test_privacy_guide_mentions_limits_and_companions() {
 		"Rotate identities after suspected compromise"
 	)
 	local missing=()
+	local missing_report=""
 	local item
 	for item in "${expected[@]}"; do
 		if [[ "$output" != *"$item"* ]]; then
 			missing+=("$item")
+			missing_report+="[$item] "
 		fi
 	done
 
@@ -213,7 +215,7 @@ test_privacy_guide_mentions_limits_and_companions() {
 		return 0
 	fi
 
-	print_result "privacy guide mentions limits and companions" 1 "missing: ${missing[*]}"
+	print_result "privacy guide mentions limits and companions" 1 "missing (${#missing[@]}): $missing_report"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-nostr-vpn-helper.sh
+++ b/.agents/scripts/tests/test-nostr-vpn-helper.sh
@@ -193,12 +193,27 @@ test_privacy_guide_mentions_limits_and_companions() {
 	local output=""
 	output="$(bash "$HELPER_SCRIPT" privacy-guide 2>&1)"
 
-	if [[ "$output" == *"not as an anonymity network"* && "$output" == *"SimpleX or Signal"* && "$output" == *"self-hosted or trusted private Nostr relays"* && "$output" == *"high-risk research"* && "$output" == *"Rotate identities after suspected compromise"* ]]; then
+	local expected=(
+		"not as an anonymity network"
+		"SimpleX or Signal"
+		"self-hosted or trusted private Nostr relays"
+		"high-risk research"
+		"Rotate identities after suspected compromise"
+	)
+	local missing=()
+	local item
+	for item in "${expected[@]}"; do
+		if [[ "$output" != *"$item"* ]]; then
+			missing+=("$item")
+		fi
+	done
+
+	if [[ "${#missing[@]}" -eq 0 ]]; then
 		print_result "privacy guide mentions limits and companions" 0
 		return 0
 	fi
 
-	print_result "privacy guide mentions limits and companions" 1 "$output"
+	print_result "privacy guide mentions limits and companions" 1 "missing: ${missing[*]}"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Refactored the Nostr VPN privacy-guide test to check expected substrings via an array loop and report missing entries for clearer failures.

## Files Changed

.agents/scripts/tests/test-nostr-vpn-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-nostr-vpn-helper.sh; bash .agents/scripts/tests/test-nostr-vpn-helper.sh

Resolves #24844


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.66 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2m and 33,316 tokens on this as a headless worker.