### PR TITLE
fix: handle behind native auto-merge PRs

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -684,6 +684,53 @@ _attempt_pr_ci_rebase_retry() {
 }
 
 #######################################
+# Update an already-auto-merge-enabled PR that is otherwise green but behind.
+#
+# GitHub native auto-merge does not merge a PR while mergeStateStatus=BEHIND;
+# it waits for the branch to be updated first. Pulse used to defer forever once
+# autoMergeRequest was present because _set_native_auto_merge_or_skip treated
+# every existing auto-merge request as GitHub-owned unless it was BLOCKED+stuck.
+#
+# Caller must have already passed maintainer/review/security gates and stopped
+# DRY_RUN before invoking because this helper performs a GitHub write.
+#
+# Returns 0 if update-branch succeeded and caller should defer to the next
+# cycle; 1 if no update was needed or update-branch failed.
+# GH#24839 / GH#24840
+#######################################
+_attempt_existing_auto_merge_behind_update_branch() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	local _pr_state=""
+	_pr_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json autoMergeRequest,mergeStateStatus,mergeable 2>/dev/null) || _pr_state=""
+	[[ -n "$_pr_state" ]] || return 1
+
+	local _existing_auto="" _merge_state="" _mergeable=""
+	IFS=$'\t' read -r _existing_auto _merge_state _mergeable <<<"$(printf '%s' "$_pr_state" \
+		| jq -r '[if .autoMergeRequest then "present" else "" end, .mergeStateStatus // "", .mergeable // ""] | @tsv' \
+		|| true)"
+	_pmp_normalize_mergeable_state_into _mergeable "$_mergeable"
+
+	[[ -n "$_existing_auto" ]] || return 1
+	[[ "$_merge_state" == BEHIND ]] || return 1
+	[[ "$_mergeable" == MERGEABLE ]] || return 1
+	_check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1 || return 1
+
+	local _ub_output="" _ub_exit=0
+	_ub_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+	_ub_exit=$?
+	if [[ $_ub_exit -eq 0 ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge is green but BEHIND — update-branch succeeded, deferring to next cycle (GH#24839)" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge is green but BEHIND — update-branch failed, falling through: ${_ub_output}" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
 # Route a PR to the appropriate fix worker based on origin label and kind.
 #
 # Consolidates the shared routing pattern used by the review, conflict, and CI

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -998,6 +998,14 @@ _process_single_ready_pr() {
 		return 0
 	fi
 
+	# GH#24839/GH#24840: existing native auto-merge requests can wedge when
+	# GitHub reports MERGEABLE+BEHIND with all required checks green. Update the
+	# branch before the t3070 native-auto defer path, otherwise pulse keeps
+	# waiting for GitHub to do work that GitHub requires a branch update for.
+	if _attempt_existing_auto_merge_behind_update_branch "$pr_number" "$repo_slug"; then
+		return 1
+	fi
+
 	# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
 	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" 2>/dev/null || true
 	if ! _check_ruleset_required_reviews_passing "$repo_slug" "$pr_number" "$pr_author"; then

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -20,6 +20,8 @@
 #             → returns 1; no `gh pr merge --auto` invocation
 #   Case (E): autoMergeRequest pending past threshold
 #             → returns 0 and keeps deferring because pending checks are non-terminal
+#   Case (F): autoMergeRequest + MERGEABLE + BEHIND + green required checks
+#             → update-branch succeeds and caller defers to the next cycle
 #
 # Also verifies the caller contract: native auto-merge defer returns 4 from
 # _process_single_ready_pr and _merge_ready_prs_for_repo does not count that as
@@ -119,6 +121,11 @@ if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
 	exit 0
 fi
 
+# `gh pr update-branch <N> --repo <slug>`
+if [[ "$1" == "pr" && "$2" == "update-branch" ]]; then
+	exit 0
+fi
+
 # Default: succeed silently for any other call shape.
 exit 0
 GHEOF
@@ -139,17 +146,20 @@ teardown_test_env() {
 # into the test shell. _set_native_auto_merge_or_skip calls
 # _auto_merge_stuck_seconds (t3192), so we extract that too.
 define_helpers_under_test() {
-	local src_stuck src_repo_allow src_set_native
+	local src_stuck src_repo_allow src_green_behind src_set_native
 	src_stuck=$(awk '
 		/^_auto_merge_stuck_seconds\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_repo_allow=$(awk '
 		/^_repo_allows_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
+	src_green_behind=$(awk '
+		/^_attempt_existing_auto_merge_behind_update_branch\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$PROCESS_SCRIPT")
 	src_set_native=$(awk '
 		/^_set_native_auto_merge_or_skip\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_set_native" ]]; then
+	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_green_behind" || -z "$src_set_native" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -158,10 +168,22 @@ define_helpers_under_test() {
 	# shellcheck disable=SC1090
 	eval "$src_repo_allow"
 	# shellcheck disable=SC1090
+	eval "$src_green_behind"
+	# shellcheck disable=SC1090
 	eval "$src_set_native"
 	gh_pr_view() {
 		gh pr view "$@"
 		return $?
+	}
+	_pmp_normalize_mergeable_state_into() {
+		local __target_var="$1"
+		local __value="$2"
+		case "$__value" in
+			MERGEABLE | CONFLICTING | UNKNOWN) ;;
+			*) __value="UNKNOWN" ;;
+		esac
+		printf -v "$__target_var" '%s' "$__value"
+		return 0
 	}
 	_check_required_checks_passing() {
 		local _repo_slug="$1"
@@ -376,6 +398,43 @@ test_case_e_stale_pending_defers() {
 	return 0
 }
 
+# =============================================================================
+# Case (F): existing auto-merge is green but behind → update branch and defer
+# =============================================================================
+test_case_f_green_behind_updates_branch() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"autoMergeRequest":{"enabledAt":"2026-06-15T14:00:00Z"},"mergeStateStatus":"BEHIND","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+
+	local result=0
+	_attempt_existing_auto_merge_behind_update_branch "600" "owner/repo" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (F): green BEHIND auto_merge → update-branch returns 0" 1 \
+			"Expected exit 0, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'gh pr update-branch 600 --repo owner/repo' "$GH_LOG"; then
+		print_result "Case (F): green BEHIND auto_merge → invokes update-branch" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'green but BEHIND.*update-branch succeeded.*GH#24839' "$LOGFILE"; then
+		print_result "Case (F): green BEHIND auto_merge → audit log written" 1 \
+			"pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (F): green BEHIND auto_merge → updates branch and defers" 0
+	teardown_test_env
+	return 0
+}
+
 test_native_auto_defer_not_counted_as_completed_merge() {
 	local process_src merge_src
 	process_src=$(awk '
@@ -413,6 +472,7 @@ main() {
 	test_case_c_already_set_no_op
 	test_case_d_repo_disallows_falls_through
 	test_case_e_stale_pending_defers
+	test_case_f_green_behind_updates_branch
 	test_native_auto_defer_not_counted_as_completed_merge
 
 	printf '\n=================================\n'

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -291,7 +291,9 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 3
     concurrency:
-      group: issue-dedup-${{ github.event.issue.number }}
+      # Serialize same-author issue openings so double-click / retry storms cannot
+      # race both dedup jobs before the older issue is visible to the newer run.
+      group: issue-dedup-${{ github.repository }}-${{ github.event.issue.user.login }}
       cancel-in-progress: false
     permissions:
       issues: write
@@ -359,15 +361,27 @@ jobs:
             exit 0
           fi
 
+          since_epoch=$((new_epoch - WINDOW))
+          since_iso=$(date -u -d "@${since_epoch}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+
           echo "[dedup] Fetching recent open issues by @${ISSUE_AUTHOR}..."
-          issues_json=$(gh issue list --repo "$REPO" \
-            --author "$ISSUE_AUTHOR" --state open \
-            --limit 20 --json number,title,body,createdAt 2>/dev/null || echo "[]")
+          # Use the REST issues endpoint rather than `gh issue list`; the latter
+          # can be backed by GitHub search/indexing and miss an issue opened only
+          # seconds earlier, which is exactly the race this server-side guard
+          # exists to close (GH#24840 duplicate of GH#24839).
+          issues_json=$(gh api "repos/${REPO}/issues" \
+            -f state=open -f creator="$ISSUE_AUTHOR" -f since="$since_iso" -f per_page=100 \
+            --jq '[.[] | select(.pull_request | not) | {number,title,body:(.body//""),createdAt:.created_at}]' \
+            2>/dev/null || echo "[]")
 
           cand_count=$(printf '%s' "$issues_json" | jq 'length')
           echo "[dedup] Found ${cand_count} open issue(s) by @${ISSUE_AUTHOR}"
 
           canonical_num=""
+          if [[ "$cand_count" -eq 0 ]]; then
+            echo "[dedup] No recent open issues found — issue is unique"
+            exit 0
+          fi
           for i in $(seq 0 $((cand_count - 1))); do
             cand_num=$(printf '%s' "$issues_json" | jq -r ".[$i].number")
 


### PR DESCRIPTION
## Summary

- Fixes native auto-merge PRs that are `MERGEABLE` but `mergeStateStatus=BEHIND` by running `gh pr update-branch` after merge gates pass and before pulse defers to GitHub auto-merge.
- Hardens server-side duplicate issue dedup by serializing same-author issue-open jobs and querying recent issues via REST instead of `gh issue list` search/index output.
- Adds regression coverage for green+behind auto-merge update-branch handling.

## Review

- Root cause for #24839/#24840 is valid: existing pulse update-branch paths handled conflicts and failed-CI drift, but an existing native auto-merge request with green required checks and `BEHIND` fell through to `_set_native_auto_merge_or_skip`, which deferred indefinitely.
- #24840 is a byte-identical duplicate of #24839 opened 9 seconds later. The dedup workflow could race because its concurrency key was per issue number and candidate discovery used `gh issue list`, which can miss just-opened issues during GitHub indexing lag.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-native-auto.sh`
- `bash .agents/scripts/tests/test-issue-fingerprint.sh`
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-native-auto.sh`
- `command -v actionlint >/dev/null 2>&1 && actionlint .github/workflows/issue-sync-reusable.yml || true`
- `.agents/scripts/linters-local.sh` (passed; advisory pre-existing markdown/ratchet/complexity findings reported; focused pulse canary rerun below)
- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh`

Resolves #24839
Resolves #24840

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.66 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 22m and 140,292 tokens on this with the user in an interactive session.
