### PR TITLE
GH#24857: fix profile session metrics

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -96,12 +96,14 @@ _session_time_archive_db_for() {
 #######################################
 _session_time_temp_dir_exclusion_clause() {
 	cat <<'SQL'
-AND s.directory NOT IN ('/private/tmp/opencode', '/tmp/opencode')
-AND s.directory NOT LIKE '/private/tmp/opencode.%' ESCAPE '\'
-AND s.directory NOT LIKE '/private/tmp/opencode-%' ESCAPE '\'
-AND s.directory NOT LIKE '/tmp/opencode.%' ESCAPE '\'
-AND s.directory NOT LIKE '/tmp/opencode-%' ESCAPE '\'
-AND s.directory NOT LIKE '/var/folders/%/T/opencode%'
+AND (s.directory IS NULL OR (
+	s.directory NOT IN ('/private/tmp/opencode', '/tmp/opencode')
+	AND s.directory NOT LIKE '/private/tmp/opencode.%' ESCAPE '\'
+	AND s.directory NOT LIKE '/private/tmp/opencode-%' ESCAPE '\'
+	AND s.directory NOT LIKE '/tmp/opencode.%' ESCAPE '\'
+	AND s.directory NOT LIKE '/tmp/opencode-%' ESCAPE '\'
+	AND s.directory NOT LIKE '/var/folders/%/T/opencode%'
+))
 SQL
 	return 0
 }

--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -91,6 +91,22 @@ _session_time_archive_db_for() {
 }
 
 #######################################
+# SQL clause that excludes runtime temp sessions from profile-level all-dir stats.
+# Output: SQL AND clause to stdout
+#######################################
+_session_time_temp_dir_exclusion_clause() {
+	cat <<'SQL'
+AND s.directory NOT IN ('/private/tmp/opencode', '/tmp/opencode')
+AND s.directory NOT LIKE '/private/tmp/opencode.%' ESCAPE '\'
+AND s.directory NOT LIKE '/private/tmp/opencode-%' ESCAPE '\'
+AND s.directory NOT LIKE '/tmp/opencode.%' ESCAPE '\'
+AND s.directory NOT LIKE '/tmp/opencode-%' ESCAPE '\'
+AND s.directory NOT LIKE '/var/folders/%/T/opencode%'
+SQL
+	return 0
+}
+
+#######################################
 # Auto-detect all SQLite session DBs that make up the local history.
 # Output: one database path per line, primary first, archive second if present
 #######################################
@@ -196,9 +212,12 @@ _session_time_query_db() {
 
 	# Build directory filter clause.
 	# When abs_repo_path is empty (--all-dirs), dir_clause stays empty
-	# to aggregate sessions across all repos (profile-level stats).
+	# to aggregate sessions across all repos (profile-level stats), while
+	# temp_dir_clause excludes short runtime classifier sessions created in
+	# OpenCode temp workdirs so they do not masquerade as interactive work.
 	# Uses parameter expansion to avoid an if/fi block (nesting budget).
 	local dir_clause=""
+	local temp_dir_clause=""
 	local safe_path="${abs_repo_path//\'/\'\'}"
 	local like_path="${safe_path//%/\\%}"
 	like_path="${like_path//_/\\_}"
@@ -208,6 +227,9 @@ _session_time_query_db() {
 	dir_clause="${safe_path:+AND (s.directory = '${safe_path}'
 			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\'
 			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\')}"
+	if [[ -z "$abs_repo_path" ]]; then
+		temp_dir_clause=$(_session_time_temp_dir_exclusion_clause)
+	fi
 
 	# Query per-session human vs machine time using window functions.
 	# LAG() compares each message with the previous one in the same session:
@@ -233,6 +255,7 @@ _session_time_query_db() {
 			WHERE s.parent_id IS NULL
 			  AND m.time_created > ${since_ms}
 			  ${dir_clause}
+			  ${temp_dir_clause}
 		)
 		SELECT
 			session_id,

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -310,7 +310,7 @@ _generate_session_time_vars() {
 	local year_json="$4"
 
 	local day_human day_worker day_total day_interactive day_workers
-	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0)')")
+	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
 	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	day_total=$(_format_hours "$(echo "$day_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	# Keep counts raw here; _generate_work_with_ai_table formats them once.
@@ -320,21 +320,21 @@ _generate_session_time_vars() {
 	day_workers=$(echo "$day_json" | jq -r '(.worker_sessions // 0)')
 
 	local week_human week_worker week_total week_interactive week_workers
-	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0)')")
+	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
 	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	week_total=$(_format_hours "$(echo "$week_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	week_interactive=$(echo "$week_json" | jq -r '(.interactive_sessions // 0)')
 	week_workers=$(echo "$week_json" | jq -r '(.worker_sessions // 0)')
 
 	local month_human month_worker month_total month_interactive month_workers
-	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0)')")
+	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
 	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	month_total=$(_format_hours "$(echo "$month_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	month_interactive=$(echo "$month_json" | jq -r '(.interactive_sessions // 0)')
 	month_workers=$(echo "$month_json" | jq -r '(.worker_sessions // 0)')
 
 	local year_human year_worker year_total year_interactive year_workers
-	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0)')")
+	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
 	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	year_total=$(_format_hours "$(echo "$year_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	year_interactive=$(echo "$year_json" | jq -r '(.interactive_sessions // 0)')
@@ -492,7 +492,7 @@ _generate_work_with_ai_table() {
 
 _Screen time from ${screen_source}, snapshotted daily.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
 
-_User AI session hours measured from AI message timestamps (reading, thinking, typing between responses)._${session_coverage_note}
+_User AI session hours are interactive session time (user attention + AI generation) measured from AI message timestamps._${session_coverage_note}
 EOF
 	return 0
 }

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -87,6 +87,25 @@ SQL
 	return 0
 }
 
+insert_null_directory_session_fixture() {
+	local db_path="$1"
+	local session_id="$2"
+	local title="$3"
+	local start_ms="$4"
+	local assistant_completed=$((start_ms + 10000))
+	local user_created=$((assistant_completed + 20000))
+
+	sqlite3 "$db_path" <<SQL
+INSERT INTO session(id, title, parent_id, directory)
+VALUES('${session_id}', '${title}', NULL, NULL);
+INSERT INTO message(session_id, data, time_created)
+VALUES('${session_id}', '{"role":"assistant","time":{"completed":${assistant_completed}}}', ${start_ms});
+INSERT INTO message(session_id, data, time_created)
+VALUES('${session_id}', '{"role":"user"}', ${user_created});
+SQL
+	return 0
+}
+
 test_session_time_includes_archive_and_dedupes() {
 	local test_name="session time includes OpenCode archive and dedupes"
 	setup
@@ -107,6 +126,7 @@ test_session_time_includes_archive_and_dedupes() {
 
 	insert_session_fixture "$active_db" "current-interactive" "Current interactive" "$recent_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$active_db" "temp-classifier" "NO Issue is a classifier run" "$recent_ms" "/private/tmp/opencode"
+	insert_null_directory_session_fixture "$active_db" "global-interactive" "Global interactive" "$recent_ms"
 	insert_session_fixture "$archive_db" "current-interactive" "Current interactive duplicate" "$recent_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "near-month-interactive" "Near month interactive" "$near_month_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "old-worker" "Issue #123: archived worker" "$old_ms" "$TEST_DIR/repo"
@@ -121,18 +141,18 @@ test_session_time_includes_archive_and_dedupes() {
 	worker_sessions=$(echo "$year_json" | jq -r '.worker_sessions')
 	observed_days=$(echo "$year_json" | jq -r '.observed_days')
 
-	if [[ "$year_sessions" != "3" ]]; then
-		print_result "$test_name" 1 "expected 3 year sessions, got ${year_sessions}; JSON: ${year_json}"
+	if [[ "$year_sessions" != "4" ]]; then
+		print_result "$test_name" 1 "expected 4 year sessions, got ${year_sessions}; JSON: ${year_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$month_sessions" != "2" ]]; then
-		print_result "$test_name" 1 "expected 2 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
+	if [[ "$month_sessions" != "3" ]]; then
+		print_result "$test_name" 1 "expected 3 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$twenty_eight_sessions" != "1" ]]; then
-		print_result "$test_name" 1 "expected 1 session in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
+	if [[ "$twenty_eight_sessions" != "2" ]]; then
+		print_result "$test_name" 1 "expected 2 sessions in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
 		teardown
 		return 0
 	fi

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -106,6 +106,7 @@ test_session_time_includes_archive_and_dedupes() {
 	old_ms=$((now_ms - (100 * 86400000)))
 
 	insert_session_fixture "$active_db" "current-interactive" "Current interactive" "$recent_ms" "$TEST_DIR/repo"
+	insert_session_fixture "$active_db" "temp-classifier" "NO Issue is a classifier run" "$recent_ms" "/private/tmp/opencode"
 	insert_session_fixture "$archive_db" "current-interactive" "Current interactive duplicate" "$recent_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "near-month-interactive" "Near month interactive" "$near_month_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "old-worker" "Issue #123: archived worker" "$old_ms" "$TEST_DIR/repo"

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -595,8 +595,8 @@ test_session_time_vars_default_missing_null_values() {
 	source "${SOURCE_RENDER_LIB}"
 
 	local valid_json null_json empty_json assignments
-	valid_json='{"interactive_human_hours":1.25,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":6,"worker_sessions":7}'
-	null_json='{"interactive_human_hours":null,"worker_human_hours":null,"worker_machine_hours":null,"total_human_hours":null,"total_machine_hours":null,"interactive_sessions":null,"worker_sessions":null}'
+	valid_json='{"interactive_human_hours":1.25,"interactive_machine_hours":0.25,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":6,"worker_sessions":7}'
+	null_json='{"interactive_human_hours":null,"interactive_machine_hours":null,"worker_human_hours":null,"worker_machine_hours":null,"total_human_hours":null,"total_machine_hours":null,"interactive_sessions":null,"worker_sessions":null}'
 	empty_json='{}'
 
 	if ! _generate_session_time_vars "${empty_json}" "${null_json}" "${valid_json}" "${valid_json}" >"${stdout_file}" 2>"${stderr_file}"; then
@@ -627,8 +627,12 @@ test_session_time_vars_default_missing_null_values() {
 		print_result "${test_name}" 1 "missing/null count fields did not default to 0"
 		return 0
 	fi
-	if [[ "${month_human}" != "1.2" || "${month_worker}" != "5.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
+	if [[ "${month_human}" != "1.5" || "${month_worker}" != "5.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
 		print_result "${test_name}" 1 "valid session data rendering changed"
+		return 0
+	fi
+	if [[ "${year_human}" != "1.5" ]]; then
+		print_result "${test_name}" 1 "interactive machine hours were not included in user AI session hours"
 		return 0
 	fi
 
@@ -649,9 +653,9 @@ test_work_with_ai_worker_counts_above_thousand() {
 
 	local screen_json day_json week_json month_json year_json output_file
 	screen_json='{"today_hours":1,"week_hours":2,"month_hours":3,"year_hours":4}'
-	day_json='{"interactive_human_hours":1,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":22,"worker_sessions":55}'
-	week_json='{"interactive_human_hours":10,"worker_human_hours":20,"worker_machine_hours":30,"total_human_hours":40,"total_machine_hours":50,"interactive_sessions":183,"worker_sessions":1080}'
-	month_json='{"interactive_human_hours":100,"worker_human_hours":200,"worker_machine_hours":300,"total_human_hours":400,"total_machine_hours":500,"interactive_sessions":497,"worker_sessions":1518}'
+	day_json='{"interactive_human_hours":1,"interactive_machine_hours":0.5,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":22,"worker_sessions":55}'
+	week_json='{"interactive_human_hours":10,"interactive_machine_hours":1.5,"worker_human_hours":20,"worker_machine_hours":30,"total_human_hours":40,"total_machine_hours":50,"interactive_sessions":183,"worker_sessions":1080}'
+	month_json='{"interactive_human_hours":100,"interactive_machine_hours":23.4,"worker_human_hours":200,"worker_machine_hours":300,"total_human_hours":400,"total_machine_hours":500,"interactive_sessions":497,"worker_sessions":1518}'
 	year_json="${month_json}"
 	output_file="${TEST_DIR}/work-with-ai.md"
 
@@ -668,6 +672,11 @@ test_work_with_ai_worker_counts_above_thousand() {
 
 	if grep -qF '| Worker sessions | 55 | 0 | 0 | 0 |' "${output_file}"; then
 		print_result "${test_name}" 1 "worker session counts regressed to zero after double-formatting"
+		return 0
+	fi
+
+	if ! grep -qF '| User AI session hours | 1.5h | 11.5h | 123.4h | 123.4h |' "${output_file}"; then
+		print_result "${test_name}" 1 "user AI session hours did not include interactive machine time"
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary
- exclude OpenCode runtime temp workdirs from profile-level `--all-dirs` session metrics
- render `User AI session hours` as interactive total time (`interactive_human_hours + interactive_machine_hours`)
- add regression coverage for temp-session exclusion and interactive machine-hour rendering

## Verification
- `bash .agents/scripts/tests/test-contributor-session-archive.sh`
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh`
- `shellcheck .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/tests/test-contributor-session-archive.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `.agents/scripts/profile-readme-helper.sh generate`
- `.agents/scripts/linters-local.sh`

## Generated Work with AI check
- 28d `User AI session hours`: 237.2h
- 28d `AI worker hours`: 234.5h
- 28d `AI concurrency hours`: 471.7h
- 28d `Interactive sessions`: 304
- 28d `Worker sessions`: 814

Resolves #24857

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.67 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 14h 7m and 1,337,007 tokens on this with the user in an interactive session.