### PR TITLE
GH#24842: run Qlty sweep from repo path

### DIFF
--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -202,7 +202,7 @@ _sweep_qlty() {
 
 	# Use SARIF output for machine-parseable smell data (structured by rule, file, location)
 	local qlty_sarif
-	qlty_sarif=$("$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || qlty_sarif=""
+	qlty_sarif=$(cd "$repo_path" && "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || qlty_sarif=""
 
 	local qlty_smell_count=0
 	local qlty_grade="UNKNOWN"

--- a/.agents/scripts/tests/test-quality-sweep-serialization.sh
+++ b/.agents/scripts/tests/test-quality-sweep-serialization.sh
@@ -22,8 +22,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
 
 # Isolate from real state files
 TMP_HOME=$(mktemp -d)

--- a/.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#24842: `_sweep_qlty` must execute Qlty from the
+# target repository path, not from the stats wrapper's current directory.
+#
+# Run:
+#   bash .agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
+#
+# shellcheck disable=SC1090,SC1091
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
+
+TMP_HOME=$(mktemp -d)
+TMP_REPO=$(mktemp -d)
+FAKE_BIN=$(mktemp -d)
+QLTY_PWD_FILE="${TMP_HOME}/qlty-pwd.txt"
+export HOME="$TMP_HOME"
+export LOGFILE="${TMP_HOME}/test.log"
+export QUALITY_SWEEP_STATE_DIR="${TMP_HOME}/state"
+export QLTY_PWD_FILE
+PATH="${FAKE_BIN}:${PATH}"
+export PATH
+
+cleanup() {
+	rm -rf "$TMP_HOME" "$TMP_REPO" "$FAKE_BIN"
+	return 0
+}
+trap cleanup EXIT
+
+mkdir -p "${HOME}/.qlty/bin" "${TMP_REPO}/.qlty" "$QUALITY_SWEEP_STATE_DIR"
+printf '%s\n' '[plugins]' >"${TMP_REPO}/.qlty/qlty.toml"
+
+cat >"${HOME}/.qlty/bin/qlty" <<'QLTY'
+#!/usr/bin/env bash
+set -euo pipefail
+pwd >"${QLTY_PWD_FILE:?}"
+printf '%s\n' '{"runs":[{"results":[{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"scripts/example.sh"}}}]}]}]}'
+QLTY
+chmod +x "${HOME}/.qlty/bin/qlty"
+
+cat >"${FAKE_BIN}/curl" <<'CURL'
+#!/usr/bin/env bash
+exit 22
+CURL
+chmod +x "${FAKE_BIN}/curl"
+
+# Source dependencies. stats-functions.sh expects shared-constants and
+# worker-lifecycle-common to be sourced first.
+source "${SCRIPTS_DIR}/shared-constants.sh"
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+source "${SCRIPTS_DIR}/stats-functions.sh"
+
+_create_simplification_issues() {
+	return 0
+}
+
+result=$(_sweep_qlty "owner/repo" "$TMP_REPO")
+qlty_section="${result%%|*}"
+qlty_remainder="${result#*|}"
+qlty_smell_count="${qlty_remainder%%|*}"
+
+if [[ ! -f "$QLTY_PWD_FILE" ]]; then
+	printf '%s\n' "FAIL qlty was not executed"
+	exit 1
+fi
+
+actual_pwd=$(<"$QLTY_PWD_FILE")
+if [[ "$actual_pwd" != "$TMP_REPO" ]]; then
+	printf '%s\n' "FAIL qlty ran from wrong cwd: expected ${TMP_REPO}, got ${actual_pwd}"
+	exit 1
+fi
+
+if [[ "$qlty_smell_count" != "1" ]]; then
+	printf '%s\n' "FAIL qlty smell count: expected 1, got ${qlty_smell_count}"
+	exit 1
+fi
+
+if [[ "$qlty_section" != *"scripts/example.sh"* ]]; then
+	printf '%s\n' "FAIL qlty section omitted SARIF file path"
+	exit 1
+fi
+
+printf '%s\n' "PASS _sweep_qlty runs from repo_path"


### PR DESCRIPTION
## Summary

- Run `_sweep_qlty()` from the target `repo_path` so Qlty sees the repository-local Git checkout and `.qlty` config.
- Add a regression test that stubs Qlty and asserts its working directory is the target repo.
- Rename the serialization test's local script-dir variable to avoid clobbering the sourced stats module's `SCRIPT_DIR`.

## Runtime Testing

Self-assessed: shell helper bugfix with hermetic shell tests.

## Testing

- `bash .agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh`
- `bash .agents/scripts/tests/test-quality-sweep-serialization.sh`
- `shellcheck .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh .agents/scripts/tests/test-quality-sweep-serialization.sh`

Resolves #24842

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.68 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1h 34m and 198,278 tokens on this with the user in an interactive session.
