### PR TITLE
GH#24854: add systemd dashboard freshness remediation

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -639,6 +639,7 @@ _write_stale_alert_body() {
 	# remediation guidance. The heredoc expansion produces the literal
 	# token for the reader verbatim.
 	local macos_launchctl="launchctl"
+	local linux_systemctl="systemctl"
 
 	# Tempfile + cat >>file instead of $(cat <<EOF) — the subshell form
 	# trips the bash32-compat regression gate (heredoc-in-subshell class).
@@ -653,12 +654,23 @@ The supervisor health dashboard is the framework's primary single-glance health 
 
 ## Triage
 
-1. Inspect the stats scheduler status (macOS):
+1. Inspect the stats scheduler status.
+
+   macOS / launchd:
 
    \`\`\`bash
    ${macos_launchctl} list | grep -i aidevops-stats-wrapper
    tail -40 ~/.aidevops/logs/stats.log
    ls -la ~/Library/LaunchAgents/com.aidevops.aidevops-stats-wrapper.plist
+   \`\`\`
+
+   Linux / systemd user timers:
+
+   \`\`\`bash
+   ${linux_systemctl} --user status aidevops-stats-wrapper.service --no-pager
+   ${linux_systemctl} --user list-timers --all --no-pager 'aidevops*'
+   tail -40 ~/.aidevops/logs/stats.log
+   ls -la ~/.config/systemd/user/aidevops-stats-wrapper.*
    \`\`\`
 
 2. Run the refresh manually and capture the error:
@@ -675,7 +687,8 @@ The supervisor health dashboard is the framework's primary single-glance health 
 
 ## Remediation
 
-- **Missing plist:** re-run \`setup.sh --non-interactive\` (or \`aidevops update\`) with PULSE_ENABLED=true so \`setup_stats_wrapper\` reinstalls \`com.aidevops.aidevops-stats-wrapper.plist\`.
+- **macOS missing plist:** re-run \`setup.sh --non-interactive\` (or \`aidevops update\`) with PULSE_ENABLED=true so \`setup_stats_wrapper\` reinstalls \`com.aidevops.aidevops-stats-wrapper.plist\`.
+- **Linux missing or inactive systemd timer:** re-run \`setup.sh --non-interactive\` (or \`aidevops update\`) with PULSE_ENABLED=true so the Linux scheduler setup reinstalls and enables \`aidevops-stats-wrapper.timer\` and \`aidevops-stats-wrapper.service\` under \`~/.config/systemd/user\`.
 - **\`set -euo pipefail\` fail:** the post-t2418 wrapper emits \`HEALTH-DASHBOARD-FAIL exit=<N>\` on error. Grep \`stats.log\` on that prefix.
 - **Body size / API error:** inspect \`stats.log\` — look at \`gh\` HTTP errors and \`_update_health_issue_for_repo\` failures.
 

--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -192,7 +192,9 @@ run_scan_with_stubs() {
 	local extra_env="${3:-}"
 	local alert_kind="${4:-stale}"
 	local gh_calls="${TMP}/gh-calls.log"
+	local alert_body_capture="${TMP}/alert-body.md"
 	: >"$gh_calls"
+	: >"$alert_body_capture"
 
 	# Reset last-scan marker so cadence gate doesn't suppress unless the
 	# test explicitly sets DASHBOARD_FRESHNESS_SCAN_INTERVAL high.
@@ -207,6 +209,7 @@ run_scan_with_stubs() {
 		BODY_FIXTURE="$body_file" \
 		ALERT_EXISTS="$alert_exists" \
 		ALERT_KIND="$alert_kind" \
+		ALERT_BODY_CAPTURE="$alert_body_capture" \
 		EXTRA_ENV="$extra_env" \
 		SCANNER_PATH="$SCANNER" \
 		bash -c '
@@ -264,6 +267,18 @@ run_scan_with_stubs() {
 								return 0
 								;;
 							create)
+								local prev=""
+								local body_path=""
+								for arg in "$@"; do
+									if [[ "$prev" == "--body-file" ]]; then
+										body_path="$arg"
+										break
+									fi
+									prev="$arg"
+								done
+								if [[ -n "$body_path" && -f "$body_path" ]]; then
+									cp "$body_path" "$ALERT_BODY_CAPTURE"
+								fi
 								printf "https://example.invalid/test/repo/issues/99\n"
 								return 0
 								;;
@@ -304,6 +319,20 @@ if grep -q 'review-followup' "$calls_file" \
 	pass "alert labelled review-followup + priority:high"
 else
 	fail "alert labelling" "calls:\n$(cat "$calls_file")"
+fi
+
+alert_body="${TMP}/alert-body.md"
+home_marker='~'
+if grep -q 'macOS / launchd:' "$alert_body" \
+	&& grep -q 'launchctl list | grep -i aidevops-stats-wrapper' "$alert_body" \
+	&& grep -q 'Linux / systemd user timers:' "$alert_body" \
+	&& grep -q 'systemctl --user status aidevops-stats-wrapper.service --no-pager' "$alert_body" \
+	&& grep -q "systemctl --user list-timers --all --no-pager 'aidevops\*'" "$alert_body" \
+	&& grep -q "${home_marker}/.config/systemd/user/aidevops-stats-wrapper\.\*" "$alert_body" \
+	&& grep -q 'Linux missing or inactive systemd timer' "$alert_body"; then
+	pass "alert body includes macOS launchd and Linux systemd remediation"
+else
+	fail "alert body scheduler remediation" "body:\n$(cat "$alert_body")"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updated the stale dashboard alert body to include separate macOS launchd and Linux systemd scheduler triage/remediation, while preserving existing macOS guidance.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh,.agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dashboard-freshness-check.sh (19 passed); shellcheck .agents/scripts/dashboard-freshness-check.sh .agents/scripts/tests/test-dashboard-freshness-check.sh (clean); .agents/scripts/linters-local.sh reached existing advisory gates but timed out during function complexity after no new Bash 3.2 or portability regressions.

Resolves #24854


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.69 with gpt-5.5 spent 1h 50m and 131,090 tokens on this with the user in an interactive session.