### PR TITLE
GH#24841: install complexity scheduler with pulse

### DIFF
--- a/.agents/scripts/setup/_runtime_helpers.sh
+++ b/.agents/scripts/setup/_runtime_helpers.sh
@@ -106,6 +106,32 @@ _should_setup_noninteractive_stats_wrapper() {
 	return 1
 }
 
+# Complexity scan is part of the pulse-maintained quality-debt loop. It was
+# split out of pulse dispatch into a standalone scheduler (t2903, GH#21049),
+# so existing pulse-enabled installs need the same first-time non-interactive
+# escape hatch as stats-wrapper and pulse-merge-routine. The generic scheduler
+# gate only regenerates units that are already installed, which strands older
+# Linux/systemd installs without aidevops-complexity-scan.timer (GH#24841).
+_should_setup_noninteractive_complexity_scan() {
+	if _should_setup_noninteractive_scheduler \
+		"Complexity scan" \
+		"sh.aidevops.complexity-scan" \
+		"aidevops: complexity-scan" \
+		"aidevops-complexity-scan"; then
+		return 0
+	fi
+
+	# Pulse-dependency escape hatch: install the standalone complexity scan
+	# whenever the supervisor pulse is (or will be) enabled. This preserves the
+	# non-interactive consent gate while backfilling the new timer for existing
+	# pulse users during update.
+	if _should_setup_noninteractive_supervisor_pulse; then
+		return 0
+	fi
+
+	return 1
+}
+
 # Pulse-merge-routine is a REQUIRED dependency of the supervisor pulse — it
 # is the merge-side of pulse, running merge_ready_prs_all_repos() on a fast
 # 120s cadence so green PRs land within ~3 min of CI completion instead of

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -36,7 +36,7 @@
 #   4. The routine file initialises PULSE_START_EPOCH (grep guard)
 #   5. The routine file sources pulse-dispatch-core.sh (grep guard)
 #   6. The routine file sources pulse-fast-fail.sh (grep guard)
-#   7. setup.sh has the _should_setup_noninteractive_pulse_merge_routine helper
+#   7. runtime helpers define _should_setup_noninteractive_pulse_merge_routine
 #   8. setup.sh call site uses the new helper (not the generic gate)
 #   9. scheduler uses timeout-protected pulse-merge-routine
 #   10. merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false
@@ -49,6 +49,7 @@ REPO_ROOT="$(cd "${SCRIPTS_DIR}/../.." && pwd)" || exit 1
 
 ROUTINE_FILE="${SCRIPTS_DIR}/pulse-merge-routine.sh"
 SETUP_FILE="${REPO_ROOT}/setup.sh"
+RUNTIME_HELPERS_FILE="${REPO_ROOT}/.agents/scripts/setup/_runtime_helpers.sh"
 
 if [[ -t 1 ]]; then
 	TEST_GREEN=$'\033[0;32m'
@@ -174,21 +175,21 @@ else
 fi
 
 # =============================================================================
-# Test 7: setup.sh has the new escape-hatch helper (Bug 1 fix)
+# Test 7: runtime helpers define the escape-hatch helper (Bug 1 fix)
 # =============================================================================
 printf '\n=== setup.sh escape-hatch guard (Bug 1) ===\n'
 
 if [[ ! -f "$SETUP_FILE" ]]; then
-	skip "7: setup.sh has _should_setup_noninteractive_pulse_merge_routine" \
+	skip "7: runtime helpers define _should_setup_noninteractive_pulse_merge_routine" \
 		"setup.sh not found at $SETUP_FILE"
 	skip "8: setup.sh call site uses new helper" \
 		"setup.sh not found at $SETUP_FILE"
 else
-	if grep -qE '^_should_setup_noninteractive_pulse_merge_routine\(\)' "$SETUP_FILE"; then
-		pass "7: setup.sh has _should_setup_noninteractive_pulse_merge_routine"
+	if [[ -f "$RUNTIME_HELPERS_FILE" ]] && grep -qE '^_should_setup_noninteractive_pulse_merge_routine\(\)' "$RUNTIME_HELPERS_FILE"; then
+		pass "7: runtime helpers define _should_setup_noninteractive_pulse_merge_routine"
 	else
-		fail "7: setup.sh has _should_setup_noninteractive_pulse_merge_routine" \
-			"missing function definition"
+		fail "7: runtime helpers define _should_setup_noninteractive_pulse_merge_routine" \
+			"missing function definition in $RUNTIME_HELPERS_FILE"
 	fi
 
 	# =========================================================================

--- a/.agents/scripts/tests/test-setup-noninteractive-complexity-scan.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-complexity-scan.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+RUNTIME_HELPERS_SCRIPT="${REPO_ROOT}/.agents/scripts/setup/_runtime_helpers.sh"
+SETUP_FILE="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+load_setup_functions() {
+	local helper_definitions=""
+	helper_definitions="$(awk '
+		/^_should_setup_noninteractive_supervisor_pulse\(\) \{/ { emit=1 }
+		/^_should_setup_noninteractive_scheduler\(\) \{/ { emit=1 }
+		/^_should_setup_noninteractive_complexity_scan\(\) \{/ { emit=1 }
+		emit { print }
+		emit && /^}/ { emit=0 }
+	' "$RUNTIME_HELPERS_SCRIPT")"
+
+	if [[ -z "$helper_definitions" ]]; then
+		printf 'failed to load helpers from %s\n' "$RUNTIME_HELPERS_SCRIPT" >&2
+		return 1
+	fi
+
+	eval "$helper_definitions"
+	return 0
+}
+
+test_regenerates_existing_complexity_scheduler() {
+	local output=""
+
+	output=$(
+		load_setup_functions
+		_scheduler_detect_installed() {
+			local name="$1"
+			[[ "$name" == "Complexity scan" ]]
+			return $?
+		}
+		config_enabled() { return 1; }
+
+		if _should_setup_noninteractive_complexity_scan; then
+			printf 'result=true\n'
+		else
+			printf 'result=false\n'
+		fi
+	) || true
+
+	if [[ "$output" == *"result=true"* ]]; then
+		print_result "complexity scan regenerates existing scheduler" 0
+		return 0
+	fi
+
+	print_result "complexity scan regenerates existing scheduler" 1 "output=${output}"
+	return 0
+}
+
+test_installs_when_supervisor_pulse_enabled() {
+	local output=""
+
+	output=$(
+		load_setup_functions
+		_scheduler_detect_installed() { return 1; }
+		config_enabled() {
+			local key="$1"
+			[[ "$key" == "orchestration.supervisor_pulse" ]]
+			return $?
+		}
+
+		if _should_setup_noninteractive_complexity_scan; then
+			printf 'result=true\n'
+		else
+			printf 'result=false\n'
+		fi
+	) || true
+
+	if [[ "$output" == *"result=true"* ]]; then
+		print_result "complexity scan installs when supervisor pulse is enabled" 0
+		return 0
+	fi
+
+	print_result "complexity scan installs when supervisor pulse is enabled" 1 "output=${output}"
+	return 0
+}
+
+test_preserves_noninteractive_consent_gate() {
+	local output=""
+
+	output=$(
+		load_setup_functions
+		_scheduler_detect_installed() { return 1; }
+		config_enabled() { return 1; }
+
+		if _should_setup_noninteractive_complexity_scan; then
+			printf 'result=true\n'
+		else
+			printf 'result=false\n'
+		fi
+	) || true
+
+	if [[ "$output" == *"result=false"* ]]; then
+		print_result "complexity scan preserves non-interactive consent gate" 0
+		return 0
+	fi
+
+	print_result "complexity scan preserves non-interactive consent gate" 1 "output=${output}"
+	return 0
+}
+
+test_setup_uses_complexity_helper() {
+	if awk '
+		BEGIN { in_block=0; lines_since_gate=0; found_call=0 }
+		/^[[:space:]]*if _should_setup_noninteractive_complexity_scan[;[:space:]]/ {
+			in_block=1
+			lines_since_gate=0
+			next
+		}
+		in_block {
+			lines_since_gate++
+			if ($0 ~ /_time_step[[:space:]]+"setup_complexity_scan"/ &&
+				$0 ~ /setup_complexity_scan([[:space:]]|$)/) {
+				found_call=1
+				exit
+			}
+			if (lines_since_gate > 3 || /^[[:space:]]*fi[[:space:]]*$/) {
+				in_block=0
+			}
+		}
+		END { exit (found_call) ? 0 : 1 }
+	' "$SETUP_FILE"; then
+		print_result "setup.sh complexity scan call site uses dedicated helper" 0
+		return 0
+	fi
+
+	print_result "setup.sh complexity scan call site uses dedicated helper" 1 \
+		"missing helper-gated setup_complexity_scan call"
+	return 0
+}
+
+main() {
+	test_regenerates_existing_complexity_scheduler
+	test_installs_when_supervisor_pulse_enabled
+	test_preserves_noninteractive_consent_gate
+	test_setup_uses_complexity_helper
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1392,8 +1392,10 @@ _setup_noninteractive_schedulers() {
 	if _should_setup_noninteractive_scheduler "Contribution watch" "sh.aidevops.contribution-watch" "aidevops: contribution-watch" "aidevops-contribution-watch"; then
 		_time_step "setup_contribution_watch" setup_contribution_watch
 	fi
-	# t2903 (#21049): complexity scan — extracted from pulse dispatch preflight
-	if _should_setup_noninteractive_scheduler "Complexity scan" "sh.aidevops.complexity-scan" "aidevops: complexity-scan" "aidevops-complexity-scan"; then
+	# t2903 (#21049): complexity scan — extracted from pulse dispatch preflight.
+	# GH#24841: use a pulse-dependency escape hatch so non-interactive updates
+	# backfill the standalone timer for existing pulse-enabled installs.
+	if _should_setup_noninteractive_complexity_scan; then
 		_time_step "setup_complexity_scan" setup_complexity_scan
 	fi
 	# t2862 (GH#20919): pulse merge routine — fast 120s standalone merge pass.


### PR DESCRIPTION
## Summary
- add a dedicated non-interactive complexity scan scheduler gate
- install/backfill the standalone complexity timer whenever supervisor pulse is enabled or already installed
- add regression coverage for the complexity gate and refresh the pulse-merge helper-location guard

Resolves #24841

## Verification
- `bash .agents/scripts/tests/test-setup-noninteractive-complexity-scan.sh`
- `bash .agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh`
- `bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `shellcheck setup.sh .agents/scripts/setup/_runtime_helpers.sh .agents/scripts/tests/test-setup-noninteractive-complexity-scan.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.70 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
