### PR TITLE
t3602: Classify profile temp sessions as workers

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -91,24 +91,6 @@ _session_time_archive_db_for() {
 }
 
 #######################################
-# SQL clause that excludes runtime temp sessions from profile-level all-dir stats.
-# Output: SQL AND clause to stdout
-#######################################
-_session_time_temp_dir_exclusion_clause() {
-	cat <<'SQL'
-AND (s.directory IS NULL OR (
-	s.directory NOT IN ('/private/tmp/opencode', '/tmp/opencode')
-	AND s.directory NOT LIKE '/private/tmp/opencode.%' ESCAPE '\'
-	AND s.directory NOT LIKE '/private/tmp/opencode-%' ESCAPE '\'
-	AND s.directory NOT LIKE '/tmp/opencode.%' ESCAPE '\'
-	AND s.directory NOT LIKE '/tmp/opencode-%' ESCAPE '\'
-	AND s.directory NOT LIKE '/var/folders/%/T/opencode%'
-))
-SQL
-	return 0
-}
-
-#######################################
 # Auto-detect all SQLite session DBs that make up the local history.
 # Output: one database path per line, primary first, archive second if present
 #######################################
@@ -213,13 +195,12 @@ _session_time_query_db() {
 	local since_ms="$3"
 
 	# Build directory filter clause.
-	# When abs_repo_path is empty (--all-dirs), dir_clause stays empty
-	# to aggregate sessions across all repos (profile-level stats), while
-	# temp_dir_clause excludes short runtime classifier sessions created in
-	# OpenCode temp workdirs so they do not masquerade as interactive work.
+	# When abs_repo_path is empty (--all-dirs), dir_clause stays empty to
+	# aggregate sessions across all repos (profile-level stats). Runtime temp
+	# sessions are retained and classified as worker sessions later so 24h/7d
+	# worker activity remains visible without masquerading as user work.
 	# Uses parameter expansion to avoid an if/fi block (nesting budget).
 	local dir_clause=""
-	local temp_dir_clause=""
 	local safe_path="${abs_repo_path//\'/\'\'}"
 	local like_path="${safe_path//%/\\%}"
 	like_path="${like_path//_/\\_}"
@@ -229,9 +210,6 @@ _session_time_query_db() {
 	dir_clause="${safe_path:+AND (s.directory = '${safe_path}'
 			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\'
 			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\')}"
-	if [[ -z "$abs_repo_path" ]]; then
-		temp_dir_clause=$(_session_time_temp_dir_exclusion_clause)
-	fi
 
 	# Query per-session human vs machine time using window functions.
 	# LAG() compares each message with the previous one in the same session:
@@ -245,6 +223,7 @@ _session_time_query_db() {
 			SELECT
 				s.id AS session_id,
 				s.title,
+				s.directory,
 				json_extract(m.data, '\$.role') AS role,
 				m.time_created AS created,
 				json_extract(m.data, '\$.time.completed') AS completed,
@@ -257,11 +236,11 @@ _session_time_query_db() {
 			WHERE s.parent_id IS NULL
 			  AND m.time_created > ${since_ms}
 			  ${dir_clause}
-			  ${temp_dir_clause}
 		)
 		SELECT
 			session_id,
 			title,
+			directory,
 			MIN(created) AS first_message_ms,
 			MAX(COALESCE(completed, created)) AS last_message_ms,
 			SUM(CASE
@@ -369,7 +348,23 @@ worker_patterns = [
     re.compile(r'^Gemini feedback\b', re.IGNORECASE),
 ]
 
-def classify_session(title):
+runtime_temp_dir_patterns = [
+    re.compile(r'^/private/tmp/opencode(?:[.-].*)?$'),
+    re.compile(r'^/tmp/opencode(?:[.-].*)?$'),
+    re.compile(r'^/var/folders/.*/T/opencode.*$'),
+]
+
+def is_runtime_temp_directory(directory):
+    if not directory:
+        return False
+    for pat in runtime_temp_dir_patterns:
+        if pat.search(directory):
+            return True
+    return False
+
+def classify_session(title, directory):
+    if is_runtime_temp_directory(directory):
+        return 'worker'
     for pat in worker_patterns:
         if pat.search(title):
             return 'worker'
@@ -390,8 +385,9 @@ def number_or_zero(value):
         return 0
 
 for row in sessions:
-    title = row.get('title', '')
-    stype = classify_session(title)
+    title = row.get('title') or ''
+    directory = row.get('directory') or ''
+    stype = classify_session(title, directory)
     stats[stype]['count'] += 1
     stats[stype]['human_ms'] += number_or_zero(row.get('human_ms'))
     stats[stype]['machine_ms'] += number_or_zero(row.get('machine_ms'))
@@ -507,8 +503,9 @@ _session_time_process() {
 # message (reading + thinking + typing). machine_time = gap between
 # assistant message created and completed (AI generating).
 #
-# Session type classification (by title pattern):
+# Session type classification (by title pattern and runtime temp workdir):
 #   - Worker: "Issue #*", "PR #*", "Supervisor Pulse", "/full-loop", "dispatch:", "Worker:"
+#     or runtime temp directories used by classifier/headless sessions
 #   - Interactive: everything else (root sessions only)
 #   - Subagent: sessions with parent_id (excluded — time attributed to parent)
 #

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -131,33 +131,52 @@ test_session_time_includes_archive_and_dedupes() {
 	insert_session_fixture "$archive_db" "near-month-interactive" "Near month interactive" "$near_month_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "old-worker" "Issue #123: archived worker" "$old_ms" "$TEST_DIR/repo"
 
-	local year_json month_json twenty_eight_json year_sessions month_sessions twenty_eight_sessions worker_sessions observed_days
+	local year_json month_json twenty_eight_json repo_json year_sessions month_sessions twenty_eight_sessions worker_sessions interactive_sessions repo_sessions repo_worker_sessions observed_days
 	year_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period year --format json)
 	month_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period month --format json)
 	twenty_eight_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period 28d --format json)
+	repo_json=$(HOME="${TEST_DIR}/home" session_time "${TEST_DIR}/repo" --period year --format json)
 	year_sessions=$(echo "$year_json" | jq -r '.total_sessions')
 	month_sessions=$(echo "$month_json" | jq -r '.total_sessions')
 	twenty_eight_sessions=$(echo "$twenty_eight_json" | jq -r '.total_sessions')
 	worker_sessions=$(echo "$year_json" | jq -r '.worker_sessions')
+	interactive_sessions=$(echo "$year_json" | jq -r '.interactive_sessions')
+	repo_sessions=$(echo "$repo_json" | jq -r '.total_sessions')
+	repo_worker_sessions=$(echo "$repo_json" | jq -r '.worker_sessions')
 	observed_days=$(echo "$year_json" | jq -r '.observed_days')
 
-	if [[ "$year_sessions" != "4" ]]; then
-		print_result "$test_name" 1 "expected 4 year sessions, got ${year_sessions}; JSON: ${year_json}"
+	if [[ "$year_sessions" != "5" ]]; then
+		print_result "$test_name" 1 "expected 5 year sessions including temp workers and NULL dirs, got ${year_sessions}; JSON: ${year_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$month_sessions" != "3" ]]; then
-		print_result "$test_name" 1 "expected 3 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
+	if [[ "$month_sessions" != "4" ]]; then
+		print_result "$test_name" 1 "expected 4 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$twenty_eight_sessions" != "2" ]]; then
-		print_result "$test_name" 1 "expected 2 sessions in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
+	if [[ "$twenty_eight_sessions" != "3" ]]; then
+		print_result "$test_name" 1 "expected 3 sessions in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$worker_sessions" != "1" ]]; then
-		print_result "$test_name" 1 "expected archived worker classification, got ${worker_sessions}; JSON: ${year_json}"
+	if [[ "$worker_sessions" != "2" ]]; then
+		print_result "$test_name" 1 "expected archived and temp worker classification, got ${worker_sessions}; JSON: ${year_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$interactive_sessions" != "3" ]]; then
+		print_result "$test_name" 1 "expected NULL-directory and archive interactive sessions preserved, got ${interactive_sessions}; JSON: ${year_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$repo_sessions" != "3" ]]; then
+		print_result "$test_name" 1 "expected repo-specific filter to exclude temp and NULL dirs, got ${repo_sessions}; JSON: ${repo_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$repo_worker_sessions" != "1" ]]; then
+		print_result "$test_name" 1 "expected repo-specific worker classification unaffected, got ${repo_worker_sessions}; JSON: ${repo_json}"
 		teardown
 		return 0
 	fi

--- a/TODO.md
+++ b/TODO.md
@@ -980,6 +980,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3598 Headless external GitHub write guard #bug #security ref:GH#24720 pr:#24719 completed:2026-06-12
 
+- [ ] t3602 Fix profile temp sessions as workers #bug #no-auto-dispatch ref:GH#24866
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Keep profile-level `--all-dirs` session queries from dropping runtime temp OpenCode sessions.
- Classify runtime temp workdir sessions as workers during aggregation so they do not count as user-interactive time.
- Extend archive/de-dupe regression coverage for temp workers, NULL-directory sessions, and repo-specific filtering.

## Verification
- `bash .agents/scripts/tests/test-contributor-session-archive.sh`
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh`
- `shellcheck .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/tests/test-contributor-session-archive.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `AIDEVOPS_KNOWLEDGE_DB=/nonexistent .agents/scripts/profile-readme-helper.sh generate`
- `.agents/scripts/linters-local.sh`

Resolves #24866
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.72 with gpt-5.5 spent 15h 51m and 2,147,270 tokens on this with the user in an interactive session.