### PR TITLE
fix: preserve NMR for security-sensitive issues

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -23,6 +23,7 @@
 #   - issue_was_ever_nmr
 #   - issue_has_required_approval
 #   - _nmr_applied_by_maintainer
+#   - _nmr_application_is_security_sensitive
 #   - notify_ever_nmr_without_approval
 #   - _find_qualifying_pr_for_stale_recovery
 #   - _notify_stale_recovery_resolved_by_pr
@@ -464,6 +465,54 @@ _nmr_application_is_circuit_breaker_trip() {
 }
 
 #######################################
+# Check whether an NMR issue is security-sensitive.
+#
+# Security-labelled work must not be auto-cleared by the generic
+# creation-default path. The NMR label is the human review gate for findings
+# involving credentials, auth, approval/merge gates, supply chain, and similar
+# security boundaries. A scanner provenance marker proves automation created
+# the issue; it does not prove the recommended remediation is safe to dispatch.
+#
+# <!-- aidevops:trust-boundary -->
+# Treat the public `security` and `security-review` labels as authoritative
+# current-state holds. Once present, NMR requires cryptographic approval instead
+# of maintainer auto-approval.
+#
+# Args:
+#   $1 - issue_num  : GitHub issue number
+#   $2 - slug       : repo slug (owner/repo)
+#
+# Exit codes:
+#   0 - security-sensitive label present (NMR must be preserved)
+#   1 - no security-sensitive label found
+#######################################
+_nmr_application_is_security_sensitive() {
+	local issue_num="$1"
+	local slug="$2"
+
+	[[ -n "$issue_num" && -n "$slug" ]] || return 1
+
+	local issue_meta_json
+	local issue_api_path
+	printf -v issue_api_path 'repos/%s/issues/%s' "$slug" "$issue_num"
+	issue_meta_json=$(gh api "$issue_api_path" 2>/dev/null) || issue_meta_json=""
+	[[ -n "$issue_meta_json" ]] || return 1
+
+	local has_security_label
+	has_security_label=$(printf '%s' "$issue_meta_json" \
+		| jq --arg security_label 'security' --arg security_review_label 'security-review' \
+			'[(.labels // [])[].name] | map(select(. == $security_label or . == $security_review_label)) | length' \
+			2>/dev/null) || has_security_label=0
+	[[ "$has_security_label" =~ ^[0-9]+$ ]] || has_security_label=0
+
+	if [[ "$has_security_label" -gt 0 ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Convert a dotted version string into a sortable zero-padded key.
 #
 # Args:
@@ -607,13 +656,15 @@ _nmr_breaker_release_retry_reason() {
 #   1. Human maintainer clicks the label (manual hold)
 #   2. Pulse scanner applies default NMR at creation (auto-clear OK)
 #   3. Circuit breaker trips (t2007 cost / t2008 stale) — MUST preserve
+#   4. Security-sensitive automation applies NMR — MUST preserve
 #
-# Cases 1 and 3 are both "preserve NMR" (return 0); case 2 is
-# "auto-clear OK" (return 1). The split is driven by the two companion
-# helpers `_nmr_application_has_automation_signature` (creation
-# defaults) and `_nmr_application_is_circuit_breaker_trip` (breaker
-# trips). See t2386 brief for the #19756 infinite-loop incident that
-# motivated the split.
+# Cases 1, 3, and 4 are "preserve NMR" (return 0); case 2 is
+# "auto-clear OK" (return 1). The split is driven by companion helpers:
+# `_nmr_application_has_automation_signature` (creation defaults),
+# `_nmr_application_is_circuit_breaker_trip` (breaker trips), and
+# `_nmr_application_is_security_sensitive` (security review boundary).
+# See t2386 brief for the #19756 infinite-loop incident that motivated
+# the automation split.
 #
 # Arguments:
 #   $1 - issue_num  : GitHub issue number
@@ -671,6 +722,11 @@ _nmr_applied_by_maintainer() {
 			_notify_stale_recovery_resolved_by_pr "$issue_num" "$slug" "$nmr_at" || true
 			return 0
 		fi
+	fi
+
+	if _nmr_application_is_security_sensitive "$issue_num" "$slug"; then
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — security-sensitive label present — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}'" >>"$LOGFILE"
+		return 0
 	fi
 
 	if [[ "$nmr_actor" != "$maintainer" ]]; then

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -148,12 +148,15 @@ set_timeline() {
 # Extract helpers from the source file. Same awk-extract-and-eval
 # pattern used by the force-dispatch and bot-cleanup test suites.
 define_helpers_under_test() {
-	local sig_src breaker_src sort_src current_src retry_src maint_src
+	local sig_src breaker_src security_src sort_src current_src retry_src maint_src
 	sig_src=$(awk '
 		/^_nmr_application_has_automation_signature\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
 	breaker_src=$(awk '
 		/^_nmr_application_is_circuit_breaker_trip\(\) \{/,/^}$/ { print }
+	' "$NMR_SCRIPT")
+	security_src=$(awk '
+		/^_nmr_application_is_security_sensitive\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
 	sort_src=$(awk '
 		/^_nmr_version_sort_key\(\) \{/,/^}$/ { print }
@@ -167,7 +170,7 @@ define_helpers_under_test() {
 	maint_src=$(awk '
 		/^_nmr_applied_by_maintainer\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
-	if [[ -z "$sig_src" || -z "$breaker_src" || -z "$sort_src" || -z "$current_src" || -z "$retry_src" || -z "$maint_src" ]]; then
+	if [[ -z "$sig_src" || -z "$breaker_src" || -z "$security_src" || -z "$sort_src" || -z "$current_src" || -z "$retry_src" || -z "$maint_src" ]]; then
 		printf 'ERROR: could not extract one of the NMR helpers from %s\n' "$NMR_SCRIPT" >&2
 		return 1
 	fi
@@ -175,6 +178,8 @@ define_helpers_under_test() {
 	eval "$sig_src"
 	# shellcheck disable=SC1090
 	eval "$breaker_src"
+	# shellcheck disable=SC1090
+	eval "$security_src"
 	# shellcheck disable=SC1090
 	eval "$sort_src"
 	# shellcheck disable=SC1090
@@ -487,6 +492,41 @@ test_breaker_trip_empty_args_returns_nonzero() {
 	return 0
 }
 
+# --- _nmr_application_is_security_sensitive (security review boundary) ---
+
+test_security_sensitive_detects_security_label() {
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"security"},{"name":"source:review-feedback"}]}'
+	if _nmr_application_is_security_sensitive 24841 marcusquinn/aidevops; then
+		print_result "security_sensitive detects security label" 0
+		return 0
+	fi
+	print_result "security_sensitive detects security label" 1 \
+		"Expected exit 0 — security label must preserve NMR"
+	return 0
+}
+
+test_security_sensitive_detects_security_review_label() {
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"security-review"}]}'
+	if _nmr_application_is_security_sensitive 24842 marcusquinn/aidevops; then
+		print_result "security_sensitive detects security-review label" 0
+		return 0
+	fi
+	print_result "security_sensitive detects security-review label" 1 \
+		"Expected exit 0 — security-review label must preserve NMR"
+	return 0
+}
+
+test_security_sensitive_ignores_non_security_labels() {
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"source:review-feedback"},{"name":"quality-debt"}]}'
+	if _nmr_application_is_security_sensitive 24843 marcusquinn/aidevops; then
+		print_result "security_sensitive ignores non-security labels" 1 \
+			"Expected exit 1 — normal review-feedback issues can still use creation-default auto-approval"
+		return 0
+	fi
+	print_result "security_sensitive ignores non-security labels" 0
+	return 0
+}
+
 # --- _nmr_applied_by_maintainer end-to-end (#19756 loop regression) ---
 
 test_19756_loop_prevention_breaker_trip_preserves_nmr() {
@@ -524,6 +564,22 @@ test_scanner_default_still_auto_approves() {
 	return 0
 }
 
+test_security_review_feedback_preserves_nmr() {
+	# Security-labelled review-feedback issues are still automation-created, but
+	# the security label makes NMR a real approval boundary. Without this guard,
+	# source:review-feedback would be treated as a creation default and cleared.
+	set_timeline '[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"marcusquinn"},"created_at":"2026-06-15T18:00:00Z"}]'
+	set_comments '[]'
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"source:review-feedback"},{"name":"security"}],"created_at":"2026-06-15T17:59:57Z"}'
+	if _nmr_applied_by_maintainer 24841 marcusquinn/aidevops marcusquinn; then
+		print_result "security review-feedback issue preserves NMR" 0
+		return 0
+	fi
+	print_result "security review-feedback issue preserves NMR" 1 \
+		"Expected exit 0 — security findings require cryptographic approval, not auto-clear"
+	return 0
+}
+
 test_manual_hold_still_preserves_nmr() {
 	# No signature of any kind — genuine manual hold. Must preserve NMR.
 	set_timeline '[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"marcusquinn"},"created_at":"2026-04-19T05:00:00Z"}]'
@@ -538,18 +594,21 @@ test_manual_hold_still_preserves_nmr() {
 	return 0
 }
 
-test_non_maintainer_actor_auto_approves() {
-	# Someone other than the maintainer applied NMR → not a manual hold
-	# by the maintainer, so auto-approve is OK (return 1).
+test_non_maintainer_label_actor_is_not_manual_maintainer_hold() {
+	# This helper only classifies the latest NMR label event, not issue-author
+	# trust. A non-maintainer label actor is not a manual hold by the configured
+	# maintainer, so the helper returns 1. `auto_approve_maintainer_issues` still
+	# separately requires the issue AUTHOR to be the maintainer (or a crypto
+	# approval) before it can clear NMR.
 	set_timeline '[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"external-contributor"},"created_at":"2026-04-19T05:00:00Z"}]'
 	set_comments '[]'
 	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"}]}'
 	if _nmr_applied_by_maintainer 99 marcusquinn/aidevops marcusquinn; then
-		print_result "non-maintainer actor → auto-approve OK" 1 \
+		print_result "non-maintainer label actor is not manual maintainer hold" 1 \
 			"Expected exit 1 — non-maintainer actor is not a manual hold"
 		return 0
 	fi
-	print_result "non-maintainer actor → auto-approve OK" 0
+	print_result "non-maintainer label actor is not manual maintainer hold" 0
 	return 0
 }
 
@@ -684,11 +743,17 @@ main() {
 	test_breaker_trip_ignores_marker_outside_window
 	test_breaker_trip_empty_args_returns_nonzero
 
+	# _nmr_application_is_security_sensitive (security review boundary)
+	test_security_sensitive_detects_security_label
+	test_security_sensitive_detects_security_review_label
+	test_security_sensitive_ignores_non_security_labels
+
 	# _nmr_applied_by_maintainer end-to-end (#19756 loop regression)
 	test_19756_loop_prevention_breaker_trip_preserves_nmr
 	test_scanner_default_still_auto_approves
+	test_security_review_feedback_preserves_nmr
 	test_manual_hold_still_preserves_nmr
-	test_non_maintainer_actor_auto_approves
+	test_non_maintainer_label_actor_is_not_manual_maintainer_hold
 	test_peer_runner_breaker_trip_preserves_nmr
 	test_paginated_timeline_latest_nmr_event_preserves_breaker_trip
 	test_release_upgrade_allows_rate_limit_breaker_retry

--- a/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
@@ -36,6 +36,8 @@ setup_test_env() {
 	export REPOS_JSON="${TEST_ROOT}/repos.json"
 	export POSTED_COMMENT="${TEST_ROOT}/posted-comment.txt"
 	export ISSUE_ASSOC="OWNER"
+	export ISSUE_API_AUTHOR="maintainer"
+	export ISSUE_LIST_AUTHOR="maintainer"
 	export ACTOR_PERMISSION="write"
 	: >"$LOGFILE"
 	: >"$POSTED_COMMENT"
@@ -70,7 +72,7 @@ if [[ "${1:-}" == "api" ]]; then
 		exit 0
 	fi
 	if [[ "$path" == */issues/24479 ]]; then
-		printf '{"user":{"login":"maintainer"},"author_association":"%s","labels":[]}\n' "${ISSUE_ASSOC:-NONE}"
+		printf '{"user":{"login":"%s"},"author_association":"%s","labels":[]}\n' "${ISSUE_API_AUTHOR:-maintainer}" "${ISSUE_ASSOC:-NONE}"
 		exit 0
 	fi
 	if [[ "$path" == */timeline ]]; then
@@ -103,7 +105,7 @@ teardown_test_env() {
 }
 
 gh_issue_list() {
-	printf '[{"number":24479,"author":{"login":"maintainer"}}]\n'
+	printf '[{"number":24479,"author":{"login":"%s"}}]\n' "${ISSUE_LIST_AUTHOR:-maintainer}"
 	return 0
 }
 export -f gh_issue_list
@@ -144,6 +146,21 @@ test_blocks_none_author_association() {
 	return 0
 }
 
+test_blocks_external_author_even_with_nmr_automation() {
+	setup_test_env
+	export ISSUE_LIST_AUTHOR="external-contributor"
+	export ISSUE_API_AUTHOR="external-contributor"
+	export ISSUE_ASSOC="NONE"
+	run_auto_approve
+	if [[ ! -s "$POSTED_COMMENT" ]]; then
+		print_result "auto-approval blocks non-maintainer issue author with NMR" 0
+	else
+		print_result "auto-approval blocks non-maintainer issue author with NMR" 1 "unexpected approval comment"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_blocks_actor_without_write_permission() {
 	setup_test_env
 	export ISSUE_ASSOC="OWNER"
@@ -174,6 +191,7 @@ test_allows_owner_author_with_write_permission() {
 
 main() {
 	test_blocks_none_author_association
+	test_blocks_external_author_even_with_nmr_automation
 	test_blocks_actor_without_write_permission
 	test_allows_owner_author_with_write_permission
 	printf '\nTests run: %d\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

- Preserve `needs-maintainer-review` for security-sensitive issues carrying `security` or `security-review` labels.
- Keep NMR auto-clear limited to maintainer-authored automation defaults, with explicit regression coverage that non-maintainer issue authors remain blocked.
- Clarify label-actor tests so they cannot be mistaken for issue-author trust exceptions.

Resolves #24869

## Verification

- `bash .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh`
- `bash .agents/scripts/tests/test-pulse-nmr-automation-signature.sh`
- `shellcheck .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh`
- `bash .agents/scripts/lint-shell-portability.sh .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh`

## Notes

Security-labelled NMR remains a cryptographic approval boundary. Non-maintainer-authored NMR issues cannot be auto-cleared for unattended dispatch.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.73 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 2h 38m and 525,544 tokens on this with the user in an interactive session.