### PR TITLE
t3603: Include wrapper OpenCode DBs in profile metrics

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -91,24 +91,39 @@ _session_time_archive_db_for() {
 }
 
 #######################################
+# Detect aidevops OpenCode wrapper-scoped SQLite session DBs.
+# Output: zero or more database paths, one per line
+#######################################
+_session_time_detect_wrapper_db_paths() {
+	local work_dir="${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}"
+	local candidate
+
+	for candidate in "${work_dir}"/opencode-interactive/*/opencode/opencode.db; do
+		[[ -f "$candidate" ]] || continue
+		printf '%s\n' "$candidate"
+	done
+	return 0
+}
+
+#######################################
 # Auto-detect all SQLite session DBs that make up the local history.
-# Output: one database path per line, primary first, archive second if present
+# Output: one database path per line, primary first, archive second if present,
+# followed by aidevops wrapper-scoped OpenCode DBs.
 #######################################
 _session_time_detect_db_paths() {
 	local primary_db
 	primary_db=$(_session_time_detect_db)
-	if [[ -z "$primary_db" ]]; then
-		printf '%s' ""
-		return 0
+	if [[ -n "$primary_db" ]]; then
+		printf '%s\n' "$primary_db"
+
+		local archive_db
+		archive_db=$(_session_time_archive_db_for "$primary_db")
+		if [[ -n "$archive_db" ]]; then
+			printf '%s\n' "$archive_db"
+		fi
 	fi
 
-	printf '%s\n' "$primary_db"
-
-	local archive_db
-	archive_db=$(_session_time_archive_db_for "$primary_db")
-	if [[ -n "$archive_db" ]]; then
-		printf '%s\n' "$archive_db"
-	fi
+	_session_time_detect_wrapper_db_paths
 	return 0
 }
 

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -38,6 +38,7 @@ print_result() {
 setup() {
 	TEST_DIR=$(mktemp -d)
 	mkdir -p "${TEST_DIR}/home/.local/share/opencode"
+	mkdir -p "${TEST_DIR}/home/.aidevops/.agent-workspace/work/opencode-interactive/project-test/opencode"
 	return 0
 }
 
@@ -115,8 +116,10 @@ test_session_time_includes_archive_and_dedupes() {
 
 	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
 	local archive_db="${TEST_DIR}/home/.local/share/opencode/opencode-archive.db"
+	local wrapper_db="${TEST_DIR}/home/.aidevops/.agent-workspace/work/opencode-interactive/project-test/opencode/opencode.db"
 	create_session_db "$active_db"
 	create_session_db "$archive_db"
+	create_session_db "$wrapper_db"
 
 	local now_ms old_ms near_month_ms recent_ms
 	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
@@ -130,6 +133,7 @@ test_session_time_includes_archive_and_dedupes() {
 	insert_session_fixture "$archive_db" "current-interactive" "Current interactive duplicate" "$recent_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "near-month-interactive" "Near month interactive" "$near_month_ms" "$TEST_DIR/repo"
 	insert_session_fixture "$archive_db" "old-worker" "Issue #123: archived worker" "$old_ms" "$TEST_DIR/repo"
+	insert_session_fixture "$wrapper_db" "wrapper-interactive" "Wrapper interactive" "$recent_ms" "$TEST_DIR/repo"
 
 	local year_json month_json twenty_eight_json repo_json year_sessions month_sessions twenty_eight_sessions worker_sessions interactive_sessions repo_sessions repo_worker_sessions observed_days
 	year_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period year --format json)
@@ -145,18 +149,18 @@ test_session_time_includes_archive_and_dedupes() {
 	repo_worker_sessions=$(echo "$repo_json" | jq -r '.worker_sessions')
 	observed_days=$(echo "$year_json" | jq -r '.observed_days')
 
-	if [[ "$year_sessions" != "5" ]]; then
-		print_result "$test_name" 1 "expected 5 year sessions including temp workers and NULL dirs, got ${year_sessions}; JSON: ${year_json}"
+	if [[ "$year_sessions" != "6" ]]; then
+		print_result "$test_name" 1 "expected 6 year sessions including wrapper DBs, temp workers, and NULL dirs, got ${year_sessions}; JSON: ${year_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$month_sessions" != "4" ]]; then
-		print_result "$test_name" 1 "expected 4 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
+	if [[ "$month_sessions" != "5" ]]; then
+		print_result "$test_name" 1 "expected 5 month sessions in 30-day window, got ${month_sessions}; JSON: ${month_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$twenty_eight_sessions" != "3" ]]; then
-		print_result "$test_name" 1 "expected 3 sessions in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
+	if [[ "$twenty_eight_sessions" != "4" ]]; then
+		print_result "$test_name" 1 "expected 4 sessions in 28-day window, got ${twenty_eight_sessions}; JSON: ${twenty_eight_json}"
 		teardown
 		return 0
 	fi
@@ -165,13 +169,13 @@ test_session_time_includes_archive_and_dedupes() {
 		teardown
 		return 0
 	fi
-	if [[ "$interactive_sessions" != "3" ]]; then
-		print_result "$test_name" 1 "expected NULL-directory and archive interactive sessions preserved, got ${interactive_sessions}; JSON: ${year_json}"
+	if [[ "$interactive_sessions" != "4" ]]; then
+		print_result "$test_name" 1 "expected wrapper, NULL-directory, and archive interactive sessions preserved, got ${interactive_sessions}; JSON: ${year_json}"
 		teardown
 		return 0
 	fi
-	if [[ "$repo_sessions" != "3" ]]; then
-		print_result "$test_name" 1 "expected repo-specific filter to exclude temp and NULL dirs, got ${repo_sessions}; JSON: ${repo_json}"
+	if [[ "$repo_sessions" != "4" ]]; then
+		print_result "$test_name" 1 "expected repo-specific filter to include wrapper repo sessions and exclude temp and NULL dirs, got ${repo_sessions}; JSON: ${repo_json}"
 		teardown
 		return 0
 	fi

--- a/TODO.md
+++ b/TODO.md
@@ -984,6 +984,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3602 Fix profile temp sessions as workers #bug #no-auto-dispatch ref:GH#24866 pr:#24867 completed:2026-06-15
 
+- [ ] t3603 Fix profile AI hours missing wrapper DBs #bug #no-auto-dispatch ref:GH#24870
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Detect aidevops OpenCode wrapper-scoped SQLite databases under the local work workspace in addition to the primary OpenCode DB and archive.
- Feed those DBs through the existing query/de-dupe/classification path so profile `--all-dirs` metrics include active wrapper sessions.
- Extend the session archive regression to cover wrapper DB inclusion, NULL directories, temp worker classification, archive de-dupe, and repo-specific filtering.

## Root cause
The profile helper only queried the primary OpenCode DB plus its archive. Current interactive aidevops OpenCode sessions run with wrapper-scoped `XDG_DATA_HOME`, so active session messages were absent from the queried DB set. That made 24h profile hours render as `0.0h` even while active work existed.

## Verification
- `bash .agents/scripts/tests/test-contributor-session-archive.sh`
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh`
- `shellcheck .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/tests/test-contributor-session-archive.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `.agents/scripts/contributor-activity-helper.sh session-time --all-dirs --period day --format json` -> 24h `interactive_human_hours=6.1`, `interactive_machine_hours=18.8`, `total_sessions=27`
- `AIDEVOPS_KNOWLEDGE_DB=/nonexistent .agents/scripts/profile-readme-helper.sh generate` -> 24h `User AI session hours | 24.9h`
- `.agents/scripts/linters-local.sh`

Resolves #24870
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.74 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 16h 37m and 2,618,305 tokens on this with the user in an interactive session.