### PR TITLE
GH#24878: fix: harden qlty sweep directory change

### DIFF
--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -202,7 +202,7 @@ _sweep_qlty() {
 
 	# Use SARIF output for machine-parseable smell data (structured by rule, file, location)
 	local qlty_sarif
-	qlty_sarif=$(cd "$repo_path" && "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || qlty_sarif=""
+	qlty_sarif=$(cd -- "$repo_path" && "$qlty_bin" smells --all --sarif --no-snippets --quiet) || qlty_sarif=""
 
 	local qlty_smell_count=0
 	local qlty_grade="UNKNOWN"


### PR DESCRIPTION
## Summary

Updated .agents/scripts/stats-quality-sweep.sh so the Qlty sweep changes directory with cd -- to avoid option injection when a repo path begins with a hyphen, and stopped blanket stderr suppression so qlty command errors remain visible for diagnostics.

## Files Changed

.agents/scripts/stats-quality-sweep.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/stats-quality-sweep.sh

Resolves #24878


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 15,625 tokens on this as a headless worker.