### PR TITLE
GH#24876: fix: include systemd timer freshness triage

### DIFF
--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -667,6 +667,7 @@ The supervisor health dashboard is the framework's primary single-glance health 
    Linux / systemd user timers:
 
    \`\`\`bash
+   ${linux_systemctl} --user status aidevops-stats-wrapper.timer --no-pager
    ${linux_systemctl} --user status aidevops-stats-wrapper.service --no-pager
    ${linux_systemctl} --user list-timers --all --no-pager 'aidevops*'
    tail -40 ~/.aidevops/logs/stats.log


### PR DESCRIPTION
## Summary

Added the aidevops-stats-wrapper.timer status command to the Linux systemd triage block before the service status check so dashboard freshness alerts identify disabled or misconfigured timers.

## Files Changed

.agents/scripts/dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dashboard-freshness-check.sh

Resolves #24876


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 42,162 tokens on this as a headless worker.