### PR TITLE
GH#24875: fix: guard wrapper db glob

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -98,6 +98,8 @@ _session_time_detect_wrapper_db_paths() {
 	local work_dir="${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}"
 	local candidate
 
+	[[ -d "${work_dir}/opencode-interactive" ]] || return 0
+
 	for candidate in "${work_dir}"/opencode-interactive/*/opencode/opencode.db; do
 		[[ -f "$candidate" ]] || continue
 		printf '%s\n' "$candidate"


### PR DESCRIPTION
## Summary

Added a defensive opencode-interactive directory check before iterating wrapper-scoped OpenCode session DBs in .agents/scripts/contributor-activity-helper-session.sh.

## Files Changed

.agents/scripts/contributor-activity-helper-session.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/contributor-activity-helper-session.sh && shellcheck .agents/scripts/contributor-activity-helper-session.sh

Resolves #24875


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 27,430 tokens on this as a headless worker.