### PR TITLE
GH#24877: test: assert systemd timer alert remediation

### DIFF
--- a/.agents/scripts/tests/test-dashboard-freshness-check.sh
+++ b/.agents/scripts/tests/test-dashboard-freshness-check.sh
@@ -326,6 +326,7 @@ home_marker='~'
 if grep -q 'macOS / launchd:' "$alert_body" \
 	&& grep -q 'launchctl list | grep -i aidevops-stats-wrapper' "$alert_body" \
 	&& grep -q 'Linux / systemd user timers:' "$alert_body" \
+	&& grep -q 'systemctl --user status aidevops-stats-wrapper.timer --no-pager' "$alert_body" \
 	&& grep -q 'systemctl --user status aidevops-stats-wrapper.service --no-pager' "$alert_body" \
 	&& grep -q "systemctl --user list-timers --all --no-pager 'aidevops\*'" "$alert_body" \
 	&& grep -q "${home_marker}/.config/systemd/user/aidevops-stats-wrapper\.\*" "$alert_body" \


### PR DESCRIPTION
## Summary

Added coverage in .agents/scripts/tests/test-dashboard-freshness-check.sh to assert the stale dashboard alert body includes the systemd user timer status command alongside the service status command.

## Files Changed

.agents/scripts/tests/test-dashboard-freshness-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dashboard-freshness-check.sh; shellcheck .agents/scripts/tests/test-dashboard-freshness-check.sh

Resolves #24877


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 28,320 tokens on this as a headless worker.