### PR TITLE
fix: trust maintainer simplification sweeps

### DIFF
--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -57,6 +57,14 @@ source "${SCRIPT_DIR}/stats-quality-sweep-tools.sh"
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/stats-quality-sweep-issues.sh"
 
+if ! declare -F _gh_current_user_allows_repo_write >/dev/null 2>&1; then
+	if [[ -f "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+		# shellcheck source=./shared-gh-collaborator-permission.sh
+		# shellcheck disable=SC1091  # shared helper resolved at runtime via $SCRIPT_DIR
+		source "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh"
+	fi
+fi
+
 # --- Orchestrator functions ---
 
 #######################################
@@ -632,9 +640,9 @@ _create_simplification_issues() {
 	local sarif_json="$2"
 	# t2066: retuned caps for throughput. The old values (5/3/200) were set for
 	# a world where simplification issues were a trickle. With the current
-	# ~109-smell baseline we need flow, not trickle — and the
-	# needs-maintainer-review gate already ensures human approval rate-limits
-	# actual dispatch. See GH#18774.
+	# ~109-smell baseline we need flow, not trickle. The review gate is only for
+	# external/non-collaborator automation identities; maintainer-owned sweeps are
+	# already approved by their trusted issue provenance.
 	local max_issues_per_sweep=5
 	local min_smells_threshold=3
 	local total_open_cap=30
@@ -678,6 +686,20 @@ _create_simplification_issues() {
 		"${HOME}/.config/aidevops/repos.json" 2>/dev/null) || maintainer=""
 	if [[ -z "$maintainer" ]]; then
 		maintainer="${repo_slug%%/*}"
+	fi
+
+	local simplification_labels=("function-complexity-debt" "source:quality-sweep" "tier:thinking")
+	# #aidevops:trust-boundary — NMR is an external-origin approval gate. When
+	# the authenticated sweep identity has repo write authority, the issue author
+	# is already trusted and should not be parked behind maintainer review. If the
+	# permission helper is unavailable or the lookup fails, fail closed and keep
+	# needs-maintainer-review.
+	if declare -F _gh_current_user_allows_repo_write >/dev/null 2>&1 \
+		&& _gh_current_user_allows_repo_write "$repo_slug"; then
+		echo "[stats] Function-complexity-debt issues: trusted current user ${AIDEVOPS_GH_WRITE_PERMISSION_USER:-unknown} (${AIDEVOPS_GH_WRITE_PERMISSION_LEVEL:-unknown}) — skipping needs-maintainer-review" >>"$LOGFILE"
+	else
+		simplification_labels+=("needs-maintainer-review")
+		echo "[stats] Function-complexity-debt issues: current user not verified as repo writer (${AIDEVOPS_GH_WRITE_PERMISSION_REASON:-helper-unavailable}) — keeping needs-maintainer-review" >>"$LOGFILE"
 	fi
 
 	# Total-open cap: stop creating when backlog is already large
@@ -726,9 +748,15 @@ _create_simplification_issues() {
 		qlty_sig=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$issue_body" 2>/dev/null || true)
 		issue_body="${issue_body}${qlty_sig}"
 
+		local label_args=()
+		local label_name
+		for label_name in "${simplification_labels[@]}"; do
+			label_args+=(--label "$label_name")
+		done
+
 		if gh_create_issue --repo "$repo_slug" \
 			--title "$issue_title" \
-			--label "function-complexity-debt" --label "needs-maintainer-review" --label "source:quality-sweep" --label "tier:thinking" \
+			"${label_args[@]}" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1; then
 			issues_created=$((issues_created + 1))
@@ -737,7 +765,7 @@ _create_simplification_issues() {
 
 	if [[ "$issues_created" -gt 0 ]]; then
 		qlty_section="${qlty_section}
-_Created ${issues_created} function-complexity-debt issue(s) for high-smell files (needs maintainer review, tier:thinking)._
+_Created ${issues_created} function-complexity-debt issue(s) for high-smell files (tier:thinking)._
 "
 	fi
 

--- a/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-stats-quality-sweep-simplification-nmr.sh — regression guard for the
+# quality-sweep simplification NMR trust boundary.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TMP=$(mktemp -d -t t-sweep-nmr.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+CREATE_CALLS="${TMP}/create-calls.log"
+LOGFILE="${TMP}/pulse.log"
+export LOGFILE
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local message="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  FAIL %s\n' "$name"
+	[[ -n "$message" ]] && printf '       %s\n' "$message"
+	return 0
+}
+
+print_info() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+print_success() { return 0; }
+log_verbose() { return 0; }
+export -f print_info print_warning print_error print_success log_verbose
+
+gh_create_issue() {
+	printf '%s\n' "$*" >>"$CREATE_CALLS"
+	printf 'https://github.com/test/repo/issues/123\n'
+	return 0
+}
+export -f gh_create_issue
+
+gh() {
+	case "$*" in
+	*"label create"*)
+		return 0
+		;;
+	*"api graphql"*)
+		printf '0\n'
+		return 0
+		;;
+	*"issue list"*)
+		printf '0\n'
+		return 0
+		;;
+	esac
+	return 0
+}
+export -f gh
+
+mkdir -p "${TMP}/.config/aidevops"
+cat >"${TMP}/.config/aidevops/repos.json" <<'JSON'
+{"initialized_repos":[{"slug":"test/repo","maintainer":"maintainer"}]}
+JSON
+ORIGINAL_HOME="$HOME"
+export HOME="$TMP"
+
+# shellcheck source=../stats-quality-sweep.sh
+SCRIPT_DIR="$SCRIPTS_DIR" source "${SCRIPTS_DIR}/stats-quality-sweep.sh" 2>/dev/null || {
+	printf 'FATAL could not source stats-quality-sweep.sh\n'
+	export HOME="$ORIGINAL_HOME"
+	exit 1
+}
+
+make_sarif() {
+	cat <<'JSON'
+{"runs":[{"results":[
+{"ruleId":"complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/foo.py"}}}]},
+{"ruleId":"complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/foo.py"}}}]},
+{"ruleId":"complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/foo.py"}}}]}
+]}]}
+JSON
+	return 0
+}
+
+printf '\n[a] trusted repo writer skips NMR\n'
+true >"$CREATE_CALLS"
+qlty_section=""
+_gh_current_user_allows_repo_write() {
+	AIDEVOPS_GH_WRITE_PERMISSION_USER="maintainer"
+	AIDEVOPS_GH_WRITE_PERMISSION_LEVEL="admin"
+	AIDEVOPS_GH_WRITE_PERMISSION_REASON="allowed"
+	export AIDEVOPS_GH_WRITE_PERMISSION_USER AIDEVOPS_GH_WRITE_PERMISSION_LEVEL AIDEVOPS_GH_WRITE_PERMISSION_REASON
+	return 0
+}
+_create_simplification_issues "test/repo" "$(make_sarif)"
+if grep -q -- '--label needs-maintainer-review' "$CREATE_CALLS" 2>/dev/null; then
+	fail "trusted-writer-no-nmr-label" "unexpected NMR label: $(cat "$CREATE_CALLS")"
+else
+	pass "trusted-writer-no-nmr-label"
+fi
+
+printf '\n[b] unverified identity keeps NMR\n'
+true >"$CREATE_CALLS"
+qlty_section=""
+_gh_current_user_allows_repo_write() {
+	AIDEVOPS_GH_WRITE_PERMISSION_REASON="permission-lookup-failed:api-failure"
+	export AIDEVOPS_GH_WRITE_PERMISSION_REASON
+	return 1
+}
+_create_simplification_issues "test/repo" "$(make_sarif)"
+if grep -q -- '--label needs-maintainer-review' "$CREATE_CALLS" 2>/dev/null; then
+	pass "unverified-keeps-nmr-label"
+else
+	fail "unverified-keeps-nmr-label" "missing NMR label: $(cat "$CREATE_CALLS")"
+fi
+
+export HOME="$ORIGINAL_HOME"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf 'All %d tests passed.\n' "$TESTS_RUN"
+	exit 0
+fi
+printf '%d of %d tests FAILED.\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1


### PR DESCRIPTION
## Summary
- Stop adding `needs-maintainer-review` to quality-sweep simplification issues when the authenticated sweep user has repo write authority.
- Fail closed and keep NMR if the collaborator permission helper is unavailable or lookup fails.
- Add regression coverage for trusted and unverified sweep identities.

## Root cause
`stats-quality-sweep.sh` always labelled function-complexity simplification issues with `needs-maintainer-review`. That treated maintainer/admin-created automation output like external-origin issue content, even though NMR is intended for external/non-collaborator provenance.

Resolves #24886

## Verification
- `shellcheck .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh`
- `.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh`
- `bash .agents/scripts/tests/test-stats-quality-sweep-issues.sh`
- `.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 21m and 135,805 tokens on this with the user in an interactive session.