### PR TITLE
GH#24884: preserve GitHub cooldown provenance

### DIFF
--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -47,6 +47,98 @@ _gh_secondary_cooldown_request_id() {
 	return 0
 }
 
+_gh_secondary_cooldown_safe_value() {
+	local value="$1"
+	local max_len="${2:-120}"
+	value=${value//$'\r'/ }
+	value=${value//$'\n'/ }
+	value=${value//$'\t'/ }
+	if [[ "$max_len" =~ ^[0-9]+$ && "${#value}" -gt "$max_len" ]]; then
+		value="${value:0:$max_len}"
+	fi
+	printf '%s' "$value"
+	return 0
+}
+
+_gh_secondary_cooldown_safe_family() {
+	local value="$1"
+	local max_len="${2:-80}"
+	value="${value##*/}"
+	value="$(_gh_secondary_cooldown_safe_value "$value" "$max_len")"
+	value=$(printf '%s' "$value" | tr -c 'A-Za-z0-9._:@+=,-' '_' 2>/dev/null || printf 'unknown')
+	[[ -n "$value" ]] || value="unknown"
+	printf '%s' "$value"
+	return 0
+}
+
+_gh_secondary_cooldown_caller_family() {
+	local i=1
+	local src=""
+	local base=""
+	while [[ "$i" -lt "${#BASH_SOURCE[@]}" ]]; do
+		src="${BASH_SOURCE[$i]:-}"
+		base="${src##*/}"
+		case "$base" in
+		shared-gh-secondary-cooldown.sh | shared-gh-wrappers.sh | shared-constants.sh | bash | -bash | zsh | -zsh | "")
+			i=$((i + 1))
+			continue
+			;;
+		esac
+		_gh_secondary_cooldown_safe_family "$base" 80
+		return 0
+	done
+	printf 'unknown'
+	return 0
+}
+
+_gh_secondary_cooldown_endpoint_family() {
+	local endpoint="${AIDEVOPS_GH_COOLDOWN_ENDPOINT_FAMILY:-${AIDEVOPS_GH_API_POOL:-${AIDEVOPS_GH_ROUTE_DECISION:-unknown}}}"
+	case "$endpoint" in
+	graphql | rest | rest-core | rest-search | search-graphql | search-rest | other | unknown) ;;
+	*) endpoint="unknown" ;;
+	esac
+	_gh_secondary_cooldown_safe_family "$endpoint" 80
+	return 0
+}
+
+_gh_secondary_cooldown_body_classification() {
+	local response_text="$1"
+	local status="${2:-}"
+	local remaining="${3:-}"
+	if printf '%s' "$response_text" | grep -Eqi 'abuse detection mechanism'; then
+		printf 'abuse-detection'
+		return 0
+	fi
+	if printf '%s' "$response_text" | grep -Eqi 'secondary rate limit|You have exceeded a secondary rate limit'; then
+		printf 'secondary-rate-limit'
+		return 0
+	fi
+	if printf '%s' "$response_text" | grep -Eqi 'GraphQL: API rate limit already exceeded|API rate limit exceeded'; then
+		printf 'primary-rate-limit'
+		return 0
+	fi
+	if [[ "$remaining" =~ ^[0-9]+$ && "$remaining" -eq 0 ]]; then
+		printf 'primary-rate-limit'
+		return 0
+	fi
+	case "$status" in
+	403)
+		printf 'generic-forbidden'
+		return 0
+		;;
+	429)
+		printf 'rate-limit-message'
+		return 0
+		;;
+	esac
+	if [[ -z "${response_text//[[:space:]]/}" ]]; then
+		printf 'empty-response'
+		return 0
+	fi
+	printf 'other-error'
+	return 0
+}
+
 _gh_secondary_cooldown_json_string() {
 	local value="$1"
 	value=${value//\\/\\\\}
@@ -62,13 +154,35 @@ _gh_secondary_cooldown_write_until() {
 	local reason="$1"
 	local response_text="${2:-}"
 	local expires_at="${3:-}"
+	local decision_branch="${4:-$reason}"
 	local now=""
 	local expires=""
 	local file=""
 	local dir=""
 	local request_id=""
+	local status=""
+	local retry_after=""
+	local ratelimit_limit=""
+	local ratelimit_remaining=""
+	local ratelimit_reset=""
+	local ratelimit_used=""
+	local ratelimit_resource=""
+	local body_classification=""
+	local caller_family=""
+	local endpoint_family=""
 	local reason_json=""
 	local request_id_json=""
+	local decision_branch_json=""
+	local status_json=""
+	local retry_after_json=""
+	local ratelimit_limit_json=""
+	local ratelimit_remaining_json=""
+	local ratelimit_reset_json=""
+	local ratelimit_used_json=""
+	local ratelimit_resource_json=""
+	local body_classification_json=""
+	local caller_family_json=""
+	local endpoint_family_json=""
 
 	now="$(_gh_secondary_cooldown_now)"
 	if [[ "$expires_at" =~ ^[0-9]+$ && "$expires_at" -gt "$now" ]]; then
@@ -79,6 +193,16 @@ _gh_secondary_cooldown_write_until() {
 	file="$(_gh_secondary_cooldown_file)"
 	dir="${file%/*}"
 	request_id="$(_gh_secondary_cooldown_request_id "$response_text")"
+	status="$(_gh_secondary_cooldown_status "$response_text")"
+	retry_after="$(_gh_secondary_cooldown_header_value "$response_text" "retry-after")"
+	ratelimit_limit="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-limit")"
+	ratelimit_remaining="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-remaining")"
+	ratelimit_reset="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")"
+	ratelimit_used="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-used")"
+	ratelimit_resource="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-resource")"
+	body_classification="$(_gh_secondary_cooldown_body_classification "$response_text" "$status" "$ratelimit_remaining")"
+	caller_family="$(_gh_secondary_cooldown_caller_family)"
+	endpoint_family="$(_gh_secondary_cooldown_endpoint_family)"
 	mkdir -p "$dir" 2>/dev/null || return 1
 
 	if command -v jq >/dev/null 2>&1; then
@@ -87,15 +211,37 @@ _gh_secondary_cooldown_write_until() {
 			--arg first_seen "$now" \
 			--arg expires_at "$expires" \
 			--arg request_id "$request_id" \
-			'{reason:$reason, first_seen:($first_seen|tonumber), expires_at:($expires_at|tonumber), last_request_id:$request_id}' >"${file}.tmp" || {
+			--arg decision_branch "$decision_branch" \
+			--arg status "$status" \
+			--arg retry_after "$retry_after" \
+			--arg ratelimit_limit "$ratelimit_limit" \
+			--arg ratelimit_remaining "$ratelimit_remaining" \
+			--arg ratelimit_reset "$ratelimit_reset" \
+			--arg ratelimit_used "$ratelimit_used" \
+			--arg ratelimit_resource "$ratelimit_resource" \
+			--arg body_classification "$body_classification" \
+			--arg caller_family "$caller_family" \
+			--arg endpoint_family "$endpoint_family" \
+			'{reason:$reason, first_seen:($first_seen|tonumber), expires_at:($expires_at|tonumber), last_request_id:$request_id, diagnostic:{decision_branch:$decision_branch, http_status:$status, request_id:$request_id, body_classification:$body_classification, caller_family:$caller_family, endpoint_family:$endpoint_family, headers:{retry_after:$retry_after, x_ratelimit_limit:$ratelimit_limit, x_ratelimit_remaining:$ratelimit_remaining, x_ratelimit_reset:$ratelimit_reset, x_ratelimit_used:$ratelimit_used, x_ratelimit_resource:$ratelimit_resource}}}' >"${file}.tmp" || {
 			printf 'Failed to write to %s\n' "${file}.tmp" >&2
 			return 1
 		}
 	else
 		reason_json="$(_gh_secondary_cooldown_json_string "$reason")"
 		request_id_json="$(_gh_secondary_cooldown_json_string "$request_id")"
-		printf '{"reason":%s,"first_seen":%s,"expires_at":%s,"last_request_id":%s}\n' \
-			"$reason_json" "$now" "$expires" "$request_id_json" >"${file}.tmp" || {
+		decision_branch_json="$(_gh_secondary_cooldown_json_string "$decision_branch")"
+		status_json="$(_gh_secondary_cooldown_json_string "$status")"
+		retry_after_json="$(_gh_secondary_cooldown_json_string "$retry_after")"
+		ratelimit_limit_json="$(_gh_secondary_cooldown_json_string "$ratelimit_limit")"
+		ratelimit_remaining_json="$(_gh_secondary_cooldown_json_string "$ratelimit_remaining")"
+		ratelimit_reset_json="$(_gh_secondary_cooldown_json_string "$ratelimit_reset")"
+		ratelimit_used_json="$(_gh_secondary_cooldown_json_string "$ratelimit_used")"
+		ratelimit_resource_json="$(_gh_secondary_cooldown_json_string "$ratelimit_resource")"
+		body_classification_json="$(_gh_secondary_cooldown_json_string "$body_classification")"
+		caller_family_json="$(_gh_secondary_cooldown_json_string "$caller_family")"
+		endpoint_family_json="$(_gh_secondary_cooldown_json_string "$endpoint_family")"
+		printf '{"reason":%s,"first_seen":%s,"expires_at":%s,"last_request_id":%s,"diagnostic":{"decision_branch":%s,"http_status":%s,"request_id":%s,"body_classification":%s,"caller_family":%s,"endpoint_family":%s,"headers":{"retry_after":%s,"x_ratelimit_limit":%s,"x_ratelimit_remaining":%s,"x_ratelimit_reset":%s,"x_ratelimit_used":%s,"x_ratelimit_resource":%s}}}\n' \
+			"$reason_json" "$now" "$expires" "$request_id_json" "$decision_branch_json" "$status_json" "$request_id_json" "$body_classification_json" "$caller_family_json" "$endpoint_family_json" "$retry_after_json" "$ratelimit_limit_json" "$ratelimit_remaining_json" "$ratelimit_reset_json" "$ratelimit_used_json" "$ratelimit_resource_json" >"${file}.tmp" || {
 			printf 'Failed to write to %s\n' "${file}.tmp" >&2
 			return 1
 		}
@@ -164,18 +310,18 @@ _gh_secondary_cooldown_record_response_if_needed() {
 	case "$status" in
 	403|429)
 		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
-		_gh_secondary_cooldown_write_until "github-api-rate-limit-status-${status}" "$response_text" "$expires_at" || true
+		_gh_secondary_cooldown_write_until "github-api-rate-limit-status-${status}" "$response_text" "$expires_at" "status-${status}" || true
 		return 0
 		;;
 	esac
 	if [[ "$remaining" =~ ^[0-9]+$ && "$remaining" -eq 0 ]]; then
 		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
-		_gh_secondary_cooldown_write_until "github-api-rate-limit-remaining-zero" "$response_text" "$expires_at" || true
+		_gh_secondary_cooldown_write_until "github-api-rate-limit-remaining-zero" "$response_text" "$expires_at" "remaining-zero" || true
 		return 0
 	fi
 	if [[ "$rc" -ne 0 ]]; then
 		_gh_secondary_cooldown_detect "$response_text" || return 0
-		_gh_secondary_cooldown_write "github-secondary-rate-limit" "$response_text" || true
+		_gh_secondary_cooldown_write_until "github-secondary-rate-limit" "$response_text" "" "secondary-text" || true
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -36,6 +36,18 @@ gh() {
 		printf 'HTTP/2 429\r\nRetry-After: 42\r\nX-RateLimit-Remaining: 0\r\nX-GitHub-Request-Id: REQ-429\r\n\r\n{"message":"rate limit exceeded"}\n'
 		return 1
 	fi
+	if [[ "${GH_GENERIC_403_FAIL:-0}" == "1" ]]; then
+		printf 'HTTP/2 403\r\nX-RateLimit-Remaining: 5\r\nX-GitHub-Request-Id: REQ-403\r\n\r\n{"message":"Resource not accessible by integration"}\n'
+		return 1
+	fi
+	if [[ "${GH_ABUSE_403_FAIL:-0}" == "1" ]]; then
+		printf 'HTTP/2 403\r\nRetry-After: 30\r\nX-RateLimit-Remaining: 5\r\nX-GitHub-Request-Id: REQ-ABUSE\r\n\r\n{"message":"You have triggered an abuse detection mechanism."}\n'
+		return 1
+	fi
+	if [[ "${GH_PRIMARY_REMAINING_ZERO_FAIL:-0}" == "1" ]]; then
+		printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 9999999999\r\nX-RateLimit-Resource: graphql\r\nX-GitHub-Request-Id: REQ-PRIMARY\r\n\r\n{"message":"GraphQL: API rate limit already exceeded"}\n'
+		return 1
+	fi
 	printf '{"ok":true}\n'
 	return 0
 }
@@ -48,7 +60,7 @@ reset_case() {
 	: >"$ERR_LOG"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
 	rm -f "$AIDEVOPS_GH_READ_RAMP_STATE_FILE"
-	unset GH_SECONDARY_FAIL GH_HEADER_LIMIT_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE 2>/dev/null || true
+	unset GH_SECONDARY_FAIL GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE 2>/dev/null || true
 	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
 	_GH_SECONDARY_COOLDOWN_LOGGED_RAMP=0
 	_gh_secondary_system_boot_ts() { return 1; }
@@ -67,7 +79,7 @@ test_secondary_response_writes_cooldown() {
 		return 1
 	fi
 	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
-		jq -e '.reason == "github-secondary-rate-limit" and (.expires_at > .first_seen)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		jq -e '.reason == "github-secondary-rate-limit" and (.expires_at > .first_seen) and .diagnostic.decision_branch == "secondary-text" and .diagnostic.body_classification == "secondary-rate-limit"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
 		printf 'PASS secondary response writes cooldown file\n'
 		return 0
 	fi
@@ -87,11 +99,71 @@ test_header_response_writes_retry_after_cooldown() {
 		return 1
 	fi
 	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
-		jq -e '.reason == "github-api-rate-limit-status-429" and .last_request_id == "REQ-429" and ((.expires_at - .first_seen) >= 40) and ((.expires_at - .first_seen) <= 45)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		jq -e '.reason == "github-api-rate-limit-status-429" and .last_request_id == "REQ-429" and .diagnostic.decision_branch == "status-429" and .diagnostic.http_status == "429" and .diagnostic.headers.retry_after == "42" and ((.expires_at - .first_seen) >= 40) and ((.expires_at - .first_seen) <= 45)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
 		printf 'PASS header response writes retry-after cooldown file\n'
 		return 0
 	fi
 	printf 'FAIL header cooldown file missing or malformed\n'
+	return 1
+}
+
+test_generic_403_diagnostic_distinguishes_forbidden() {
+	reset_case
+	export GH_GENERIC_403_FAIL=1
+	set +e
+	_gh_with_timeout read gh api -i repos/owner/repo/issues >"${TMP_HOME}/generic-403.out" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL expected generic 403 wrapped gh rc=1, got %s\n' "$rc"
+		return 1
+	fi
+	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
+		jq -e '.reason == "github-api-rate-limit-status-403" and .last_request_id == "REQ-403" and .diagnostic.decision_branch == "status-403" and .diagnostic.body_classification == "generic-forbidden" and .diagnostic.headers.x_ratelimit_remaining == "5"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS generic 403 diagnostic distinguishes forbidden response\n'
+		return 0
+	fi
+	printf 'FAIL generic 403 diagnostic missing or malformed\n'
+	return 1
+}
+
+test_abuse_403_diagnostic_distinguishes_abuse_text() {
+	reset_case
+	export GH_ABUSE_403_FAIL=1
+	set +e
+	_gh_with_timeout read gh api -i repos/owner/repo/issues >"${TMP_HOME}/abuse-403.out" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL expected abuse 403 wrapped gh rc=1, got %s\n' "$rc"
+		return 1
+	fi
+	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
+		jq -e '.reason == "github-api-rate-limit-status-403" and .last_request_id == "REQ-ABUSE" and .diagnostic.decision_branch == "status-403" and .diagnostic.body_classification == "abuse-detection" and .diagnostic.headers.retry_after == "30"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS abuse 403 diagnostic distinguishes abuse text\n'
+		return 0
+	fi
+	printf 'FAIL abuse 403 diagnostic missing or malformed\n'
+	return 1
+}
+
+test_remaining_zero_diagnostic_classifies_primary_quota() {
+	reset_case
+	export GH_PRIMARY_REMAINING_ZERO_FAIL=1
+	set +e
+	_gh_with_timeout read gh api -i graphql >"${TMP_HOME}/primary-quota.out" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL expected primary quota wrapped gh rc=1, got %s\n' "$rc"
+		return 1
+	fi
+	if [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
+		jq -e '.reason == "github-api-rate-limit-remaining-zero" and .last_request_id == "REQ-PRIMARY" and .diagnostic.decision_branch == "remaining-zero" and .diagnostic.body_classification == "primary-rate-limit" and .diagnostic.headers.x_ratelimit_resource == "graphql"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS remaining-zero diagnostic classifies primary quota\n'
+		return 0
+	fi
+	printf 'FAIL remaining-zero diagnostic missing or malformed\n'
 	return 1
 }
 
@@ -146,7 +218,7 @@ test_no_jq_fallback_escapes_json_strings() {
 		ln -sf "$(command -v "$tool")" "${nojq_bin}/${tool}"
 	done
 	PATH="$nojq_bin" _gh_secondary_cooldown_write 'quote " reason' 'request id: REQ-123' >/dev/null 2>&1
-	if jq -e '.reason == "quote \" reason" and .last_request_id == "REQ-123" and (.expires_at > .first_seen)' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+	if jq -e '.reason == "quote \" reason" and .last_request_id == "REQ-123" and (.expires_at > .first_seen) and .diagnostic.decision_branch == "quote \" reason" and .diagnostic.request_id == "REQ-123"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
 		printf 'PASS no-jq fallback escapes JSON strings\n'
 		return 0
 	fi
@@ -259,6 +331,9 @@ test_read_ramp_does_not_defer_writes() {
 
 test_secondary_response_writes_cooldown
 test_header_response_writes_retry_after_cooldown
+test_generic_403_diagnostic_distinguishes_forbidden
+test_abuse_403_diagnostic_distinguishes_abuse_text
+test_remaining_zero_diagnostic_classifies_primary_quota
 test_active_cooldown_skips_without_gh_call
 test_override_allows_audited_call
 test_default_path_without_home_is_user_scoped


### PR DESCRIPTION
## Summary

Preserve bounded sanitized response provenance in GitHub cooldown state so maintainers can distinguish generic 403, abuse/secondary responses, 429 retry-after handling, and primary quota exhaustion without retaining raw response bodies.

## Files Changed

.agents/scripts/shared-gh-secondary-cooldown.sh,.agents/scripts/tests/test-gh-secondary-cooldown.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-secondary-cooldown.sh; shellcheck .agents/scripts/shared-gh-secondary-cooldown.sh .agents/scripts/tests/test-gh-secondary-cooldown.sh; .agents/scripts/linters-local.sh

Resolves #24884


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.76 with gpt-5.5 spent 32m and 194,228 tokens on this with the user in an interactive session.