### PR TITLE
fix: correct profile AI hour semantics

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -235,7 +235,7 @@ _session_time_query_db() {
 	# Caps human gaps at 1 hour to exclude idle/abandoned sessions.
 	# Worker sessions (headless) have ~0% human time; interactive ~70-85%.
 	local query_result
-	query_result=$(sqlite3 -json "$db_path" "
+	query_result=$(sqlite3 -cmd ".timeout 5000" -json "$db_path" "
 		WITH msg_data AS (
 			SELECT
 				s.id AS session_id,
@@ -276,7 +276,7 @@ _session_time_query_db() {
 		FROM msg_data
 		GROUP BY session_id
 		HAVING human_ms + machine_ms > 5000
-	") || query_result="[]"
+	" 2>/dev/null) || query_result="[]"
 
 	# t1427: sqlite3 -json returns "" (not "[]") when no rows match.
 	if [[ "$query_result" != "["* ]]; then
@@ -323,6 +323,146 @@ _session_time_query_db_paths() {
 			if any(.[]; .session_id == $row.session_id) then . else . + [$row] end
 		)
 	' 2>/dev/null || echo "[]"
+	return 0
+}
+
+#######################################
+# Resolve the shared OpenCode observability database, if available.
+# Output: database path to stdout, or empty string if unavailable
+#######################################
+_session_time_obs_db_path() {
+	local obs_db="${AIDEVOPS_OBS_DB_FILE:-${OBS_DB_FILE:-${HOME}/.aidevops/.agent-workspace/observability/llm-requests.db}}"
+
+	if [[ -f "$obs_db" ]]; then
+		printf '%s\n' "$obs_db"
+	fi
+	return 0
+}
+
+#######################################
+# Query OpenCode plugin observability for total AI generation duration.
+# Arguments:
+#   $1 - abs repo path (empty string = all directories)
+#   $2 - since_ms (milliseconds threshold)
+# Output: JSON object with observability_machine_ms and observability_sessions
+#######################################
+_session_time_query_observability() {
+	local abs_repo_path="$1"
+	local since_ms="$2"
+	local obs_db
+	obs_db=$(_session_time_obs_db_path)
+
+	if [[ -z "$obs_db" ]] || ! sqlite3 -cmd ".timeout 5000" "$obs_db" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='llm_requests' LIMIT 1;" >/dev/null 2>&1; then
+		printf '%s\n' '{"observability_machine_ms":0,"observability_sessions":0}'
+		return 0
+	fi
+
+	local project_clause=""
+	local safe_path="${abs_repo_path//\'/\'\'}"
+	local like_path="${safe_path//%/\\%}"
+	like_path="${like_path//_/\\_}"
+	# shellcheck disable=SC2016,SC1003 # Single quotes are SQL delimiters, not bash
+	project_clause="${safe_path:+AND (project_path = '${safe_path}'
+			       OR project_path LIKE '${like_path}/%' ESCAPE '\\'
+			       OR project_path LIKE '${like_path}.%' ESCAPE '\\'
+			       OR project_path LIKE '${like_path}-%' ESCAPE '\\')}"
+
+	local result machine_ms sessions
+	result=$(sqlite3 -cmd ".timeout 5000" -separator '|' "$obs_db" "
+		SELECT
+			COALESCE(SUM(CASE WHEN duration_ms > 0 THEN duration_ms ELSE 0 END), 0),
+			COUNT(DISTINCT session_id)
+		FROM llm_requests
+		WHERE timestamp IS NOT NULL
+		  AND julianday(timestamp) >= (${since_ms} / 86400000.0 + 2440587.5)
+		  ${project_clause};
+	" 2>/dev/null) || result="0|0"
+
+	IFS='|' read -r machine_ms sessions <<<"$result"
+	machine_ms="${machine_ms:-0}"
+	sessions="${sessions:-0}"
+	printf '{"observability_machine_ms":%s,"observability_sessions":%s}\n' "$machine_ms" "$sessions"
+	return 0
+}
+
+#######################################
+# Merge observability AI-generation totals into session stats.
+#
+# Session DB timestamps are the best source for attended interactive time and
+# title/directory classification. The plugin observability DB is the durable
+# source for LLM generation duration across isolated headless workers. To avoid
+# double-counting interactive generation already present in session DBs, use
+# observability as a floor for total machine time: worker machine duration is
+# at least (observability total - interactive machine duration).
+#
+# Arguments:
+#   $1 - aggregated session stats JSON
+#   $2 - observability stats JSON
+# Output: merged stats JSON object to stdout
+#######################################
+_session_time_merge_observability_stats() {
+	local stats_json="$1"
+	local obs_json="$2"
+
+	python3 -c "
+import sys
+import json
+
+stats = json.loads(sys.argv[1] or '{}')
+obs = json.loads(sys.argv[2] or '{}')
+
+def number(value):
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+def ms_field(name, hours_name):
+    if name in stats:
+        return int(number(stats.get(name)))
+    return int(round(number(stats.get(hours_name)) * 3600000))
+
+def ms_to_h(ms):
+    return round(ms / 3600000, 1)
+
+interactive_human_ms = ms_field('interactive_human_ms', 'interactive_human_hours')
+interactive_machine_ms = ms_field('interactive_machine_ms', 'interactive_machine_hours')
+worker_human_ms = ms_field('worker_human_ms', 'worker_human_hours')
+worker_machine_ms = ms_field('worker_machine_ms', 'worker_machine_hours')
+obs_machine_ms = int(number(obs.get('observability_machine_ms')))
+obs_sessions = int(number(obs.get('observability_sessions')))
+
+observed_worker_machine_ms = max(0, obs_machine_ms - interactive_machine_ms)
+worker_machine_ms = max(worker_machine_ms, observed_worker_machine_ms)
+
+interactive_sessions = int(number(stats.get('interactive_sessions')))
+worker_sessions = int(number(stats.get('worker_sessions')))
+if worker_machine_ms > 0 and worker_sessions == 0:
+    worker_sessions = max(1, obs_sessions - interactive_sessions)
+
+total_human_ms = interactive_human_ms + worker_human_ms
+total_machine_ms = interactive_machine_ms + worker_machine_ms
+
+stats.update({
+    'interactive_human_ms': interactive_human_ms,
+    'interactive_machine_ms': interactive_machine_ms,
+    'worker_human_ms': worker_human_ms,
+    'worker_machine_ms': worker_machine_ms,
+    'interactive_sessions': interactive_sessions,
+    'worker_sessions': worker_sessions,
+    'interactive_human_hours': ms_to_h(interactive_human_ms),
+    'interactive_machine_hours': ms_to_h(interactive_machine_ms),
+    'worker_human_hours': ms_to_h(worker_human_ms),
+    'worker_machine_hours': ms_to_h(worker_machine_ms),
+    'total_human_hours': ms_to_h(total_human_ms),
+    'total_machine_hours': ms_to_h(total_machine_ms),
+    'total_sessions': interactive_sessions + worker_sessions,
+    'observability_machine_hours': ms_to_h(obs_machine_ms),
+    'observability_sessions': obs_sessions,
+})
+
+print(json.dumps(stats, indent=2))
+" "$stats_json" "$obs_json"
 	return 0
 }
 
@@ -426,9 +566,13 @@ if first_seen and last_seen:
 
 print(json.dumps({
     'interactive_sessions': i['count'],
+    'interactive_human_ms': i['human_ms'],
+    'interactive_machine_ms': i['machine_ms'],
     'interactive_human_hours': ms_to_h(i['human_ms']),
     'interactive_machine_hours': ms_to_h(i['machine_ms']),
     'worker_sessions': w['count'],
+    'worker_human_ms': w['human_ms'],
+    'worker_machine_ms': w['machine_ms'],
     'worker_human_hours': ms_to_h(w['human_ms']),
     'worker_machine_hours': ms_to_h(w['machine_ms']),
     'total_human_hours': ms_to_h(i['human_ms'] + w['human_ms']),
@@ -496,15 +640,21 @@ else:
 #   $1 - JSON array of session rows
 #   $2 - format: "markdown" or "json"
 #   $3 - period name (for empty-state messages)
+#   $4 - abs repo path (empty string = all directories)
+#   $5 - since_ms (milliseconds threshold)
 # Output: formatted table or JSON to stdout
 #######################################
 _session_time_process() {
 	local query_result="$1"
 	local format="$2"
 	local period="$3"
+	local abs_repo_path="${4:-}"
+	local since_ms="${5:-0}"
 
-	local stats_json
+	local stats_json obs_json
 	stats_json=$(echo "$query_result" | _session_time_classify_and_aggregate)
+	obs_json=$(_session_time_query_observability "$abs_repo_path" "$since_ms")
+	stats_json=$(_session_time_merge_observability_stats "$stats_json" "$obs_json")
 	_session_time_format_stats "$stats_json" "$format" "$period"
 	return 0
 }
@@ -599,15 +749,6 @@ session_time() {
 		db_paths=$(_session_time_detect_db_paths)
 	fi
 
-	if [[ -z "$db_paths" ]]; then
-		if [[ "$format" == "json" ]]; then
-			echo '{"interactive_sessions":0,"interactive_human_hours":0,"interactive_machine_hours":0,"worker_sessions":0,"worker_machine_hours":0,"total_human_hours":0,"total_machine_hours":0,"total_sessions":0}'
-		else
-			echo "_Session database not found._"
-		fi
-		return 0
-	fi
-
 	# Determine --since threshold in milliseconds (single Python call)
 	local seconds
 	case "$period" in
@@ -630,9 +771,13 @@ session_time() {
 	fi
 
 	local query_result
-	query_result=$(_session_time_query_db_paths "$db_paths" "$abs_repo_path" "$since_ms")
+	if [[ -n "$db_paths" ]]; then
+		query_result=$(_session_time_query_db_paths "$db_paths" "$abs_repo_path" "$since_ms")
+	else
+		query_result="[]"
+	fi
 
-	_session_time_process "$query_result" "$format" "$period"
+	_session_time_process "$query_result" "$format" "$period" "$abs_repo_path" "$since_ms"
 	return 0
 }
 

--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -357,26 +357,48 @@ _session_time_query_observability() {
 		return 0
 	fi
 
-	local project_clause=""
-	local safe_path="${abs_repo_path//\'/\'\'}"
-	local like_path="${safe_path//%/\\%}"
-	like_path="${like_path//_/\\_}"
-	# shellcheck disable=SC2016,SC1003 # Single quotes are SQL delimiters, not bash
-	project_clause="${safe_path:+AND (project_path = '${safe_path}'
-			       OR project_path LIKE '${like_path}/%' ESCAPE '\\'
-			       OR project_path LIKE '${like_path}.%' ESCAPE '\\'
-			       OR project_path LIKE '${like_path}-%' ESCAPE '\\')}"
-
 	local result machine_ms sessions
-	result=$(sqlite3 -cmd ".timeout 5000" -separator '|' "$obs_db" "
-		SELECT
-			COALESCE(SUM(CASE WHEN duration_ms > 0 THEN duration_ms ELSE 0 END), 0),
-			COUNT(DISTINCT session_id)
-		FROM llm_requests
-		WHERE timestamp IS NOT NULL
-		  AND julianday(timestamp) >= (${since_ms} / 86400000.0 + 2440587.5)
-		  ${project_clause};
-	" 2>/dev/null) || result="0|0"
+	result=$(python3 - "$obs_db" "$abs_repo_path" "$since_ms" <<'PY' 2>/dev/null
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+abs_repo_path = sys.argv[2]
+since_ms = int(float(sys.argv[3] or 0))
+
+where = ["timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', ? / 1000.0, 'unixepoch')"]
+params = [since_ms]
+if abs_repo_path:
+    like_path = (
+        abs_repo_path
+        .replace('\\', '\\\\')
+        .replace('%', '\\%')
+        .replace('_', '\\_')
+    )
+    where.append("""(project_path = ?
+        OR project_path LIKE ? ESCAPE '\\'
+        OR project_path LIKE ? ESCAPE '\\'
+        OR project_path LIKE ? ESCAPE '\\')""")
+    params.extend([
+        abs_repo_path,
+        f"{like_path}/%",
+        f"{like_path}.%",
+        f"{like_path}-%",
+    ])
+
+query = f"""
+    SELECT
+        COALESCE(SUM(CASE WHEN duration_ms > 0 THEN duration_ms ELSE 0 END), 0),
+        COUNT(DISTINCT session_id)
+    FROM llm_requests
+    WHERE {' AND '.join(where)};
+"""
+
+with sqlite3.connect(db_path, timeout=5) as conn:
+    machine_ms, sessions = conn.execute(query, params).fetchone()
+print(f"{machine_ms or 0}|{sessions or 0}")
+PY
+	) || result="0|0"
 
 	IFS='|' read -r machine_ms sessions <<<"$result"
 	machine_ms="${machine_ms:-0}"

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -310,7 +310,7 @@ _generate_session_time_vars() {
 	local year_json="$4"
 
 	local day_human day_worker day_total day_interactive day_workers
-	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
+	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0)')")
 	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	day_total=$(_format_hours "$(echo "$day_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	# Keep counts raw here; _generate_work_with_ai_table formats them once.
@@ -320,21 +320,21 @@ _generate_session_time_vars() {
 	day_workers=$(echo "$day_json" | jq -r '(.worker_sessions // 0)')
 
 	local week_human week_worker week_total week_interactive week_workers
-	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
+	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0)')")
 	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	week_total=$(_format_hours "$(echo "$week_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	week_interactive=$(echo "$week_json" | jq -r '(.interactive_sessions // 0)')
 	week_workers=$(echo "$week_json" | jq -r '(.worker_sessions // 0)')
 
 	local month_human month_worker month_total month_interactive month_workers
-	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
+	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0)')")
 	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	month_total=$(_format_hours "$(echo "$month_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	month_interactive=$(echo "$month_json" | jq -r '(.interactive_sessions // 0)')
 	month_workers=$(echo "$month_json" | jq -r '(.worker_sessions // 0)')
 
 	local year_human year_worker year_total year_interactive year_workers
-	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0) + (.interactive_machine_hours // 0)')")
+	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0)')")
 	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
 	year_total=$(_format_hours "$(echo "$year_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	year_interactive=$(echo "$year_json" | jq -r '(.interactive_sessions // 0)')
@@ -492,7 +492,7 @@ _generate_work_with_ai_table() {
 
 _Screen time from ${screen_source}, snapshotted daily.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
 
-_User AI session hours are interactive session time (user attention + AI generation) measured from AI message timestamps._${session_coverage_note}
+_User AI session hours are attended interactive time measured from gaps between AI responses and the next user message; AI concurrency hours include attended time, AI generation, and background workers._${session_coverage_note}
 EOF
 	return 0
 }

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -39,6 +39,7 @@ setup() {
 	TEST_DIR=$(mktemp -d)
 	mkdir -p "${TEST_DIR}/home/.local/share/opencode"
 	mkdir -p "${TEST_DIR}/home/.aidevops/.agent-workspace/work/opencode-interactive/project-test/opencode"
+	mkdir -p "${TEST_DIR}/home/.aidevops/.agent-workspace/observability"
 	return 0
 }
 
@@ -103,6 +104,32 @@ INSERT INTO message(session_id, data, time_created)
 VALUES('${session_id}', '{"role":"assistant","time":{"completed":${assistant_completed}}}', ${start_ms});
 INSERT INTO message(session_id, data, time_created)
 VALUES('${session_id}', '{"role":"user"}', ${user_created});
+SQL
+	return 0
+}
+
+create_observability_db() {
+	local db_path="$1"
+	sqlite3 "$db_path" '
+		CREATE TABLE llm_requests (
+			timestamp TEXT,
+			session_id TEXT,
+			duration_ms INTEGER,
+			project_path TEXT
+		);
+	'
+	return 0
+}
+
+insert_observability_fixture() {
+	local db_path="$1"
+	local session_id="$2"
+	local duration_ms="$3"
+	local project_path="$4"
+
+	sqlite3 "$db_path" <<SQL
+INSERT INTO llm_requests(timestamp, session_id, duration_ms, project_path)
+VALUES(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), '${session_id}', ${duration_ms}, '${project_path}');
 SQL
 	return 0
 }
@@ -195,6 +222,54 @@ test_session_time_includes_archive_and_dedupes() {
 	return 0
 }
 
+test_session_time_uses_observability_machine_floor() {
+	local test_name="session time uses observability as worker machine floor"
+	setup
+
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+
+	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
+	local obs_db="${TEST_DIR}/home/.aidevops/.agent-workspace/observability/llm-requests.db"
+	create_session_db "$active_db"
+	create_observability_db "$obs_db"
+
+	local now_ms recent_ms
+	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
+	recent_ms=$((now_ms - 60000))
+
+	insert_session_fixture "$active_db" "current-interactive" "Current interactive" "$recent_ms" "$TEST_DIR/repo"
+	insert_observability_fixture "$obs_db" "current-interactive" 10000 "$TEST_DIR/repo"
+	insert_observability_fixture "$obs_db" "worker-only" 7200000 "$TEST_DIR/repo-feature-auto-20260616-120000-gh123"
+
+	local all_json repo_json worker_machine total_machine repo_worker_machine
+	all_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period day --format json)
+	repo_json=$(HOME="${TEST_DIR}/home" session_time "${TEST_DIR}/repo" --period day --format json)
+	worker_machine=$(echo "$all_json" | jq -r '.worker_machine_hours')
+	total_machine=$(echo "$all_json" | jq -r '.total_machine_hours')
+	repo_worker_machine=$(echo "$repo_json" | jq -r '.worker_machine_hours')
+
+	if [[ "$worker_machine" != "2" && "$worker_machine" != "2.0" ]]; then
+		print_result "$test_name" 1 "expected 2.0 worker machine hours from observability, got ${worker_machine}; JSON: ${all_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$total_machine" != "2" && "$total_machine" != "2.0" ]]; then
+		print_result "$test_name" 1 "expected total machine hours to include observability floor, got ${total_machine}; JSON: ${all_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$repo_worker_machine" != "2" && "$repo_worker_machine" != "2.0" ]]; then
+		print_result "$test_name" 1 "expected repo filter to include sibling feature-auto worker path, got ${repo_worker_machine}; JSON: ${repo_json}"
+		teardown
+		return 0
+	fi
+
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
 main() {
 	if [[ ! -f "$SOURCE_SESSION_LIB" ]]; then
 		echo "Session library not found: ${SOURCE_SESSION_LIB}" >&2
@@ -206,6 +281,7 @@ main() {
 	fi
 
 	test_session_time_includes_archive_and_dedupes
+	test_session_time_uses_observability_machine_floor
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}"

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -595,7 +595,7 @@ test_session_time_vars_default_missing_null_values() {
 	source "${SOURCE_RENDER_LIB}"
 
 	local valid_json null_json empty_json assignments
-	valid_json='{"interactive_human_hours":1.25,"interactive_machine_hours":0.25,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":6,"worker_sessions":7}'
+	valid_json='{"interactive_human_hours":1.2,"interactive_machine_hours":0.3,"worker_human_hours":2,"worker_machine_hours":3,"total_human_hours":4,"total_machine_hours":5,"interactive_sessions":6,"worker_sessions":7}'
 	null_json='{"interactive_human_hours":null,"interactive_machine_hours":null,"worker_human_hours":null,"worker_machine_hours":null,"total_human_hours":null,"total_machine_hours":null,"interactive_sessions":null,"worker_sessions":null}'
 	empty_json='{}'
 
@@ -627,12 +627,12 @@ test_session_time_vars_default_missing_null_values() {
 		print_result "${test_name}" 1 "missing/null count fields did not default to 0"
 		return 0
 	fi
-	if [[ "${month_human}" != "1.5" || "${month_worker}" != "5.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
+	if [[ "${month_human}" != "1.2" || "${month_worker}" != "5.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
 		print_result "${test_name}" 1 "valid session data rendering changed"
 		return 0
 	fi
-	if [[ "${year_human}" != "1.5" ]]; then
-		print_result "${test_name}" 1 "interactive machine hours were not included in user AI session hours"
+	if [[ "${year_human}" != "1.2" ]]; then
+		print_result "${test_name}" 1 "user AI session hours were not limited to attended interactive time"
 		return 0
 	fi
 
@@ -675,8 +675,13 @@ test_work_with_ai_worker_counts_above_thousand() {
 		return 0
 	fi
 
-	if ! grep -qF '| User AI session hours | 1.5h | 11.5h | 123.4h | 123.4h |' "${output_file}"; then
-		print_result "${test_name}" 1 "user AI session hours did not include interactive machine time"
+	if ! grep -qF '| User AI session hours | 1.0h | 10.0h | 100.0h | 100.0h |' "${output_file}"; then
+		print_result "${test_name}" 1 "user AI session hours were not limited to attended interactive time"
+		return 0
+	fi
+
+	if grep -qF '| User AI session hours | 1.5h | 11.5h | 123.4h | 123.4h |' "${output_file}"; then
+		print_result "${test_name}" 1 "user AI session hours still include AI generation time"
 		return 0
 	fi
 


### PR DESCRIPTION
Resolves #24889

## Summary
- Render `User AI session hours` as attended interactive time only so it stays bounded by screen time.
- Use OpenCode observability `llm_requests.duration_ms` as the machine-time floor so isolated/background worker activity is reflected in `AI worker hours`.
- Add regression coverage for the renderer semantics and observability worker floor.

## Files and patterns
- `.agents/scripts/profile-readme-render-lib.sh`: Work with AI row rendering and explanatory copy.
- `.agents/scripts/contributor-activity-helper-session.sh`: session DB classification plus observability machine-time floor without double-counting interactive generation.
- `.agents/scripts/tests/test-profile-readme-boundary.sh`: renderer regression for attended user hours.
- `.agents/scripts/tests/test-contributor-session-archive.sh`: observability-backed worker-hour regression.

## Verification
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh`
- `bash .agents/scripts/tests/test-contributor-session-archive.sh`
- `shellcheck .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/tests/test-contributor-session-archive.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `AIDEVOPS_KNOWLEDGE_DB=/nonexistent bash .agents/scripts/profile-readme-helper.sh generate`
- `bash .agents/scripts/linters-local.sh` (passed; pre-existing/advisory warnings only)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.77 with gpt-5.5 spent 21h 22m and 3,809,847 tokens on this with the user in an interactive session.
