### PR TITLE
fix: unblock trusted ever-NMR simplification issues

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -540,8 +540,9 @@ _task_id_in_changed_files() {
 #      cleanup issues whose NMR label was applied by the fast-fail
 #      escalation path and has since been removed.
 #   3. If NMR is not currently present, skip historical ever-NMR for
-#      maintainer-only threads: issue author is OWNER/MEMBER and every
-#      issue comment is also OWNER/MEMBER. This preserves prompt-injection
+#      trusted maintainer threads: issue author is OWNER/MEMBER and every
+#      issue comment is OWNER/MEMBER or a known framework-generated GitHub
+#      Actions hold/remediation notice. This preserves prompt-injection
 #      protection while avoiding permanent crypto approval for internal
 #      retry/hold labels that a maintainer has already removed.
 #   4. Call issue_has_required_approval with the determined state.
@@ -589,7 +590,12 @@ _issue_thread_is_trusted_maintainer_only() {
 		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
 		elif type == $array_type then .
 		else [] end)
-		| [ .[] | select((.author_association // "NONE") as $a | ($a != "OWNER" and $a != "MEMBER")) ]
+		| [ .[] | select(
+			((.author_association // "NONE") as $a | ($a != "OWNER" and $a != "MEMBER"))
+			and (((.user.login // .author.login // "") as $login
+				| ((($login == "github-actions[bot]") or ($login == "github-actions"))
+					and ((.body // "") | test("^<!-- (nmr-hold-guidance|ever-nmr-remediation) -->")))) | not)
+		) ]
 		| length
 	' 2>/dev/null) || return 1
 	[[ "$untrusted_comment_count" =~ ^[0-9]+$ ]] || return 1
@@ -625,7 +631,7 @@ _check_nmr_approval_gate() {
 	# MEMBER, allow dispatch without requiring a cryptographic approval marker.
 	if [[ "$known_ever_nmr" != "true" ]] && _issue_thread_is_trusted_maintainer_only "$issue_number" "$repo_slug"; then
 		known_ever_nmr=false
-		echo "[pulse-wrapper] dispatch_with_dedup: trusted maintainer-only thread exemption for #${issue_number} in ${repo_slug} — skipping historical ever-NMR check" >>"$LOGFILE"
+		echo "[pulse-wrapper] dispatch_with_dedup: trusted maintainer thread exemption for #${issue_number} in ${repo_slug} — skipping historical ever-NMR check" >>"$LOGFILE"
 	fi
 
 	if ! issue_has_required_approval "$issue_number" "$repo_slug" "$known_ever_nmr"; then

--- a/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
@@ -166,6 +166,38 @@ test_external_comment_preserves_ever_nmr_gate() {
 	return 0
 }
 
+test_framework_actions_guidance_comment_bypasses_historical_nmr() {
+	setup_case "OWNER" '[{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]"},"body":"<!-- nmr-hold-guidance -->\nGenerated hold guidance."}]'
+	if _check_nmr_approval_gate 106 "owner/repo" '{"labels":[{"name":"auto-dispatch"}]}'; then
+		print_result "framework Actions hold guidance bypasses historical NMR" 1 "gate blocked; known_status=${APPROVAL_KNOWN_STATUS}"
+		cleanup_case
+		return 0
+	fi
+	if [[ "$APPROVAL_KNOWN_STATUS" == "false" ]]; then
+		print_result "framework Actions hold guidance bypasses historical NMR" 0
+	else
+		print_result "framework Actions hold guidance bypasses historical NMR" 1 "expected known_status=false, got ${APPROVAL_KNOWN_STATUS}"
+	fi
+	cleanup_case
+	return 0
+}
+
+test_unmarked_actions_comment_preserves_ever_nmr_gate() {
+	setup_case "OWNER" '[{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]"},"body":"unmarked comment"}]'
+	if _check_nmr_approval_gate 107 "owner/repo" '{"labels":[{"name":"auto-dispatch"}]}'; then
+		if [[ "$APPROVAL_KNOWN_STATUS" == "unknown" ]]; then
+			print_result "unmarked Actions comment preserves ever-NMR gate" 0
+		else
+			print_result "unmarked Actions comment preserves ever-NMR gate" 1 "expected known_status=unknown, got ${APPROVAL_KNOWN_STATUS}"
+		fi
+		cleanup_case
+		return 0
+	fi
+	print_result "unmarked Actions comment preserves ever-NMR gate" 1 "gate unexpectedly allowed dispatch"
+	cleanup_case
+	return 0
+}
+
 test_active_nmr_label_preserves_gate() {
 	setup_case "OWNER" '[{"author_association":"OWNER"}]'
 	if _check_nmr_approval_gate 104 "owner/repo" '{"labels":[{"name":"needs-maintainer-review"}]}'; then
@@ -207,6 +239,8 @@ main() {
 	test_owner_author_owner_member_comments_bypasses_historical_nmr
 	test_member_author_no_comments_bypasses_historical_nmr
 	test_external_comment_preserves_ever_nmr_gate
+	test_framework_actions_guidance_comment_bypasses_historical_nmr
+	test_unmarked_actions_comment_preserves_ever_nmr_gate
 	test_active_nmr_label_preserves_gate
 	test_collaborator_author_does_not_bypass_historical_nmr
 


### PR DESCRIPTION
## Summary
- Let trusted maintainer-authored former-NMR threads bypass historical ever-NMR when the only non-maintainer comment is a known framework-generated GitHub Actions hold/remediation notice.
- Preserve the gate for unmarked Actions comments and external contributor comments.
- Extend the NMR trusted-thread regression test for both paths.

## Root cause
PR #24885 fixed future simplification issue creation, but existing issues were still blocked because the ever-NMR trusted-thread check treated the framework's own `<!-- nmr-hold-guidance -->` GitHub Actions comment as untrusted external content.

Resolves #24890

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.77 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
