### PR TITLE
fix: trust maintainer collaborator NMR comments

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -80,6 +80,10 @@ source "${BASH_SOURCE[0]%/*}/pulse-stats-helper.sh"
 # t3034: per-stage dispatch ceremony timing instrumentation
 # shellcheck source=dispatch-stage-instrument.sh
 source "${BASH_SOURCE[0]%/*}/dispatch-stage-instrument.sh"
+if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+	# shellcheck source=shared-gh-collaborator-permission.sh
+	source "${BASH_SOURCE[0]%/*}/shared-gh-collaborator-permission.sh"
+fi
 
 #######################################
 # Resolve the worker tier from issue labels. When multiple tier:* labels
@@ -542,7 +546,9 @@ _task_id_in_changed_files() {
 #   3. If NMR is not currently present, skip historical ever-NMR for
 #      trusted maintainer threads: issue author is OWNER/MEMBER and every
 #      issue comment is OWNER/MEMBER or a known framework-generated GitHub
-#      Actions hold/remediation notice. This preserves prompt-injection
+#      Actions hold/remediation notice. COLLABORATOR authors/comments are
+#      trusted only after an authenticated collaborator-permission lookup
+#      confirms write/admin/maintain. This preserves prompt-injection
 #      protection while avoiding permanent crypto approval for internal
 #      retry/hold labels that a maintainer has already removed.
 #   4. Call issue_has_required_approval with the determined state.
@@ -569,11 +575,17 @@ _issue_thread_is_trusted_maintainer_only() {
 	local issue_api_path="repos/${repo_slug}/issues/"
 	issue_api_path="${issue_api_path}${issue_number}"
 	local issue_comments_path="${issue_api_path}/comments"
+	local issue_json
 	local issue_author_association
-	issue_author_association=$(gh api "$issue_api_path" \
-		--jq '.author_association // "NONE"' 2>/dev/null) || issue_author_association=""
+	local issue_author_login
+	issue_json=$(gh api "$issue_api_path" 2>/dev/null) || return 1
+	issue_author_association=$(printf '%s' "$issue_json" | jq -r '.author_association // "NONE"' 2>/dev/null) || issue_author_association=""
+	issue_author_login=$(printf '%s' "$issue_json" | jq -r '.user.login // .author.login // ""' 2>/dev/null) || issue_author_login=""
 	case "$issue_author_association" in
 		OWNER | MEMBER)
+			;;
+		COLLABORATOR)
+			_issue_actor_has_repo_write_permission "$repo_slug" "$issue_author_login" || return 1
 			;;
 		*)
 			return 1
@@ -591,7 +603,7 @@ _issue_thread_is_trusted_maintainer_only() {
 		elif type == $array_type then .
 		else [] end)
 		| [ .[] | select(
-			((.author_association // "NONE") as $a | ($a != "OWNER" and $a != "MEMBER"))
+			((.author_association // "NONE") as $a | ($a != "OWNER" and $a != "MEMBER" and $a != "COLLABORATOR"))
 			and (((.user.login // .author.login // "") as $login
 				| ((($login == "github-actions[bot]") or ($login == "github-actions"))
 					and ((.body // "") | test("^<!-- (nmr-hold-guidance|ever-nmr-remediation) -->")))) | not)
@@ -599,10 +611,42 @@ _issue_thread_is_trusted_maintainer_only() {
 		| length
 	' 2>/dev/null) || return 1
 	[[ "$untrusted_comment_count" =~ ^[0-9]+$ ]] || return 1
+	[[ "$untrusted_comment_count" -eq 0 ]] || return 1
 
-	if [[ "$untrusted_comment_count" -eq 0 ]]; then
-		return 0
-	fi
+	local collaborator_comment_logins
+	collaborator_comment_logins=$(printf '%s' "$comments_json" | jq -r --arg array_type "array" '
+		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
+		elif type == $array_type then .
+		else [] end)
+		| [ .[] | select((.author_association // "NONE") == "COLLABORATOR") | (.user.login // .author.login // "") ]
+		| unique | .[]
+	' 2>/dev/null) || return 1
+	local comment_login
+	while IFS= read -r comment_login; do
+		[[ -n "$comment_login" ]] || continue
+		_issue_actor_has_repo_write_permission "$repo_slug" "$comment_login" || return 1
+	done <<<"$collaborator_comment_logins"
+
+	return 0
+
+	return 1
+}
+
+_issue_actor_has_repo_write_permission() {
+	local repo_slug="$1"
+	local login="$2"
+	local permission=""
+
+	[[ -n "$repo_slug" && -n "$login" ]] || return 1
+	# #aidevops:trust-boundary — never trust bare COLLABORATOR association for
+	# ever-NMR bypass. GitHub can use COLLABORATOR for ambiguous private-org
+	# events; require an authenticated per-repo permission lookup.
+	_gh_collaborator_permission_lookup "$repo_slug" "$login" permission || return 1
+	case "$permission" in
+		admin | maintain | write)
+			return 0
+			;;
+	esac
 
 	return 1
 }

--- a/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
@@ -17,8 +17,10 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 ISSUE_ASSOC="OWNER"
+ISSUE_LOGIN="maintainer"
 COMMENTS_JSON="[]"
 APPROVAL_KNOWN_STATUS=""
+COLLAB_PERMISSION="write"
 
 print_result() {
 	local test_name="$1"
@@ -43,6 +45,7 @@ define_helpers_under_test() {
 	local helper_src
 	helper_src=$(awk '
 		/^_issue_thread_is_trusted_maintainer_only\(\) \{/,/^}$/ { print }
+		/^_issue_actor_has_repo_write_permission\(\) \{/,/^}$/ { print }
 		/^_check_nmr_approval_gate\(\) \{/,/^}$/ { print }
 	' "$CORE_SCRIPT")
 	if [[ -z "$helper_src" ]]; then
@@ -63,8 +66,10 @@ setup_case() {
 	: >"$LOGFILE"
 	ISSUE_ASSOC="$issue_association"
 	COMMENTS_JSON="$comments_json"
+	ISSUE_LOGIN="maintainer"
 	APPROVAL_KNOWN_STATUS=""
-	export LOGFILE ISSUE_ASSOC COMMENTS_JSON APPROVAL_KNOWN_STATUS
+	COLLAB_PERMISSION="write"
+	export LOGFILE ISSUE_ASSOC ISSUE_LOGIN COMMENTS_JSON APPROVAL_KNOWN_STATUS COLLAB_PERMISSION
 	return 0
 }
 
@@ -90,10 +95,26 @@ gh() {
 			return 0
 			;;
 		*)
-			printf '%s\n' "$ISSUE_ASSOC"
+			printf '{"author_association":"%s","user":{"login":"%s"}}\n' "$ISSUE_ASSOC" "$ISSUE_LOGIN"
 			return 0
 			;;
 	esac
+}
+
+_gh_collaborator_permission_lookup() {
+	local repo_slug="$1"
+	local login="$2"
+	local out_var="${3:-}"
+	[[ -n "$repo_slug" && -n "$login" ]] || return 2
+	if [[ "$COLLAB_PERMISSION" == "fail" ]]; then
+		return 2
+	fi
+	if [[ -n "$out_var" ]]; then
+		printf -v "$out_var" '%s' "$COLLAB_PERMISSION"
+	else
+		printf '%s\n' "$COLLAB_PERMISSION"
+	fi
+	return 0
 }
 
 _is_bot_generated_cleanup_issue() {
@@ -216,6 +237,8 @@ test_active_nmr_label_preserves_gate() {
 
 test_collaborator_author_does_not_bypass_historical_nmr() {
 	setup_case "COLLABORATOR" '[{"author_association":"OWNER"}]'
+	ISSUE_LOGIN="collaborator"
+	COLLAB_PERMISSION="read"
 	if _check_nmr_approval_gate 105 "owner/repo" '{"labels":[{"name":"auto-dispatch"}]}'; then
 		if [[ "$APPROVAL_KNOWN_STATUS" == "unknown" ]]; then
 			print_result "COLLABORATOR author does not bypass historical NMR" 0
@@ -226,6 +249,23 @@ test_collaborator_author_does_not_bypass_historical_nmr() {
 		return 0
 	fi
 	print_result "COLLABORATOR author does not bypass historical NMR" 1 "gate unexpectedly allowed dispatch"
+	cleanup_case
+	return 0
+}
+
+test_write_collaborator_comments_bypass_historical_nmr() {
+	setup_case "OWNER" '[{"author_association":"COLLABORATOR","user":{"login":"coadmin"},"body":"<!-- ops:start — workers: skip this comment -->"}]'
+	COLLAB_PERMISSION="write"
+	if _check_nmr_approval_gate 108 "owner/repo" '{"labels":[{"name":"auto-dispatch"}]}'; then
+		print_result "write collaborator comment bypasses historical NMR" 1 "gate blocked; known_status=${APPROVAL_KNOWN_STATUS}"
+		cleanup_case
+		return 0
+	fi
+	if [[ "$APPROVAL_KNOWN_STATUS" == "false" ]]; then
+		print_result "write collaborator comment bypasses historical NMR" 0
+	else
+		print_result "write collaborator comment bypasses historical NMR" 1 "expected known_status=false, got ${APPROVAL_KNOWN_STATUS}"
+	fi
 	cleanup_case
 	return 0
 }
@@ -243,6 +283,7 @@ main() {
 	test_unmarked_actions_comment_preserves_ever_nmr_gate
 	test_active_nmr_label_preserves_gate
 	test_collaborator_author_does_not_bypass_historical_nmr
+	test_write_collaborator_comments_bypass_historical_nmr
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Extend the ever-NMR trusted-thread exemption to maintainer-equivalent `COLLABORATOR` issue authors/comments only after authenticated repo permission lookup confirms `write`, `maintain`, or `admin`.
- Keep fail-closed behavior for read/triage/failed permission checks.
- Add regression coverage for write-collaborator comments and read-collaborator authors.

## Root cause
PR #24891 allowed known framework Actions comments, but existing simplification threads also had maintainer-equivalent collaborator audit comments. Those comments still counted as untrusted because the gate did not resolve collaborator permission.

Resolves #24892

## Verification
- `.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh`
- `shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh`
- live trust check for issue #24873 returned `trusted` with shared constants/helper sourced.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.78 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
