### PR TITLE
GH#24872: refactor: reduce signature hook complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
@@ -87,6 +87,44 @@ function resolveAllowedBodyFilePath(filePath, commandWorkdir = process.cwd()) {
   };
 }
 
+function okResult(cmd) {
+  return { status: "ok", cmd };
+}
+
+function missingHelperResult(helperPath, log) {
+  log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
+  return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
+}
+
+function repairResolvedBodyFile(cmd, resolvedFilePath, helperPath, log, options) {
+  const current = readFileSync(resolvedFilePath, "utf-8");
+  if (current.includes(options.sigMarker)) return okResult(cmd);
+  if (options.isMachineProtocolCommand(current)) {
+    log("INFO", `Body-file ${resolvedFilePath} contains machine-protocol content; no repair needed`);
+    return okResult(cmd);
+  }
+  if (!existsSync(helperPath)) return missingHelperResult(helperPath, log);
+  const sigResult = options.generateSignature(helperPath, current, log);
+  if (sigResult.status === "fail") return sigResult;
+  appendFileSync(resolvedFilePath, sigResult.sig);
+  log("INFO", `Auto-appended signature footer to body-file ${resolvedFilePath} (t2685)`);
+  return okResult(cmd);
+}
+
+function handleBodyFileRepairError(cmd, filePath, error, log) {
+  const reason =
+    error.code === "ENOENT" ? FAIL_REASON.FILE_NOT_FOUND : FAIL_REASON.FILE_UNREADABLE;
+  if (reason === FAIL_REASON.FILE_NOT_FOUND && hasPriorSameCommandBodyFileCreation(cmd, filePath)) {
+    log(
+      "INFO",
+      `Body-file ${filePath} appears to be created before gh in the same bash command; deferring signature injection to PATH shim`,
+    );
+    return okResult(cmd);
+  }
+  log("WARN", `Could not repair --body-file ${filePath}: ${error.message} (${reason})`);
+  return { status: "fail", reason, detail: `${filePath}: ${error.message}` };
+}
+
 /**
  * Repair a `--body-file PATH` form by appending the signature footer to the
  * referenced file if missing.
@@ -104,35 +142,8 @@ export function repairBodyFile(cmd, filePath, helperPath, log, options) {
       log("WARN", `Refusing --body-file outside allowed roots: ${resolved.detail}`);
       return resolved;
     }
-    const current = readFileSync(resolved.filePath, "utf-8");
-    if (current.includes(options.sigMarker)) return { status: "ok", cmd };
-    if (options.isMachineProtocolCommand(current)) {
-      log(
-        "INFO",
-        `Body-file ${resolved.filePath} contains machine-protocol content; no repair needed`,
-      );
-      return { status: "ok", cmd };
-    }
-    if (!existsSync(helperPath)) {
-      log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
-      return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
-    }
-    const sigResult = options.generateSignature(helperPath, current, log);
-    if (sigResult.status === "fail") return sigResult;
-    appendFileSync(resolved.filePath, sigResult.sig);
-    log("INFO", `Auto-appended signature footer to body-file ${resolved.filePath} (t2685)`);
-    return { status: "ok", cmd };
+    return repairResolvedBodyFile(cmd, resolved.filePath, helperPath, log, options);
   } catch (e) {
-    const reason =
-      e.code === "ENOENT" ? FAIL_REASON.FILE_NOT_FOUND : FAIL_REASON.FILE_UNREADABLE;
-    if (reason === FAIL_REASON.FILE_NOT_FOUND && hasPriorSameCommandBodyFileCreation(cmd, filePath)) {
-      log(
-        "INFO",
-        `Body-file ${filePath} appears to be created before gh in the same bash command; deferring signature injection to PATH shim`,
-      );
-      return { status: "ok", cmd };
-    }
-    log("WARN", `Could not repair --body-file ${filePath}: ${e.message} (${reason})`);
-    return { status: "fail", reason, detail: `${filePath}: ${e.message}` };
+    return handleBodyFileRepairError(cmd, filePath, e, log);
   }
 }

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+// Body-file repair helpers for the signature footer gate. Extracted from
+// quality-hooks-signature.mjs to keep the gate orchestrator below the qlty
+// file-complexity and return-statement smell thresholds.
+
+import { existsSync, readFileSync, appendFileSync, realpathSync } from "fs";
+import { execFileSync } from "child_process";
+import { isAbsolute, resolve, sep } from "path";
+import { tmpdir } from "os";
+
+import { FAIL_REASON } from "./quality-hooks-signature-failures.mjs";
+
+function hasPriorSameCommandBodyFileCreation(cmd, filePath) {
+  if (!filePath) return false;
+  const bodyFileIdx = cmd.lastIndexOf("--body-file");
+  if (bodyFileIdx <= 0) return false;
+  const beforeGh = cmd.slice(0, bodyFileIdx);
+  if (!beforeGh.includes(filePath)) return false;
+  const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const quotedPath = `["']?${escaped}["']?`;
+  const creationPatterns = [
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:echo|printf|cat|tee)\\b[\\s\\S]*(?:>|>>)\\s*${quotedPath}`),
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:cp|mv)\\b[\\s\\S]+\\s+${quotedPath}`),
+    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*touch\\s+${quotedPath}`),
+  ];
+  return creationPatterns.some((pattern) => pattern.test(beforeGh));
+}
+
+function isPathWithin(childPath, parentPath) {
+  const parentPrefix = parentPath.endsWith(sep) ? parentPath : `${parentPath}${sep}`;
+  return childPath === parentPath || childPath.startsWith(parentPrefix);
+}
+
+function safeRealpath(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return "";
+  }
+}
+
+function gitValue(args) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf-8",
+      timeout: 1000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function gitCommonDir(path) {
+  const topLevel = gitValue(["-C", path, "rev-parse", "--show-toplevel"]);
+  if (!topLevel) return "";
+  const commonDir = gitValue(["-C", topLevel, "rev-parse", "--git-common-dir"]);
+  if (!commonDir) return "";
+  return safeRealpath(isAbsolute(commonDir) ? commonDir : resolve(topLevel, commonDir));
+}
+
+function sameGitRepository(pathA, pathB) {
+  const commonA = gitCommonDir(pathA);
+  const commonB = gitCommonDir(pathB);
+  return Boolean(commonA && commonB && commonA === commonB);
+}
+
+function resolveAllowedBodyFilePath(filePath, commandWorkdir = process.cwd()) {
+  const realCommandWorkdir = safeRealpath(commandWorkdir) || process.cwd();
+  const candidatePath = isAbsolute(filePath) ? filePath : resolve(realCommandWorkdir, filePath);
+  const realFilePath = realpathSync(candidatePath);
+  const allowedRoots = [realCommandWorkdir, process.cwd(), tmpdir()]
+    .filter((root) => existsSync(root))
+    .map((root) => realpathSync(root));
+  if (allowedRoots.some((root) => isPathWithin(realFilePath, root))) {
+    return { status: "ok", filePath: realFilePath };
+  }
+  if (sameGitRepository(realFilePath, realCommandWorkdir)) {
+    return { status: "ok", filePath: realFilePath };
+  }
+  return {
+    status: "fail",
+    reason: FAIL_REASON.BODY_FILE_OUTSIDE_ALLOWED_ROOT,
+    detail: `${filePath} -> ${realFilePath}`,
+  };
+}
+
+/**
+ * Repair a `--body-file PATH` form by appending the signature footer to the
+ * referenced file if missing.
+ * @param {string} cmd
+ * @param {string} filePath
+ * @param {string} helperPath
+ * @param {Function} log
+ * @param {{ commandWorkdir?: string, sigMarker: string, isMachineProtocolCommand: Function, generateSignature: Function }} options
+ * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail: string }}
+ */
+export function repairBodyFile(cmd, filePath, helperPath, log, options) {
+  try {
+    const resolved = resolveAllowedBodyFilePath(filePath, options.commandWorkdir);
+    if (resolved.status === "fail") {
+      log("WARN", `Refusing --body-file outside allowed roots: ${resolved.detail}`);
+      return resolved;
+    }
+    const current = readFileSync(resolved.filePath, "utf-8");
+    if (current.includes(options.sigMarker)) return { status: "ok", cmd };
+    if (options.isMachineProtocolCommand(current)) {
+      log(
+        "INFO",
+        `Body-file ${resolved.filePath} contains machine-protocol content; no repair needed`,
+      );
+      return { status: "ok", cmd };
+    }
+    if (!existsSync(helperPath)) {
+      log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
+      return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
+    }
+    const sigResult = options.generateSignature(helperPath, current, log);
+    if (sigResult.status === "fail") return sigResult;
+    appendFileSync(resolved.filePath, sigResult.sig);
+    log("INFO", `Auto-appended signature footer to body-file ${resolved.filePath} (t2685)`);
+    return { status: "ok", cmd };
+  } catch (e) {
+    const reason =
+      e.code === "ENOENT" ? FAIL_REASON.FILE_NOT_FOUND : FAIL_REASON.FILE_UNREADABLE;
+    if (reason === FAIL_REASON.FILE_NOT_FOUND && hasPriorSameCommandBodyFileCreation(cmd, filePath)) {
+      log(
+        "INFO",
+        `Body-file ${filePath} appears to be created before gh in the same bash command; deferring signature injection to PATH shim`,
+      );
+      return { status: "ok", cmd };
+    }
+    log("WARN", `Could not repair --body-file ${filePath}: ${e.message} (${reason})`);
+    return { status: "fail", reason, detail: `${filePath}: ${e.message}` };
+  }
+}

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -43,12 +43,12 @@
 // .agents/scripts/gh runs at exec-time (after bash creates the file) and
 // is the correct enforcement layer for the same-bash-call shape.
 
-import { existsSync, readFileSync, appendFileSync, realpathSync } from "fs";
+import { existsSync } from "fs";
 import { execFileSync } from "child_process";
-import { isAbsolute, join, resolve, sep } from "path";
-import { tmpdir } from "os";
+import { join } from "path";
 
 import { FAIL_REASON, formatGateThrowMessage } from "./quality-hooks-signature-failures.mjs";
+import { repairBodyFile } from "./quality-hooks-signature-body-file.mjs";
 
 export const SIG_MARKER = "<!-- aidevops:sig -->";
 
@@ -175,33 +175,15 @@ export function isMachineProtocolCommand(cmd) {
  * @returns {boolean}
  */
 export function hasTrustedSignatureSignal(cmd) {
-  if (cmd.includes("gh-signature-helper.sh") || cmd.includes("gh-signature-helper ")) {
-    return true;
-  }
-  if (cmd.includes(SIG_MARKER)) return true;
-  // Footer variable interpolation — $FOOTER, ${SIGNATURE}, etc.
-  // Requires the cmd to assign the variable upstream; we trust it here
-  // because the downstream wrapper/shim will enforce the marker anyway.
-  if (/\$\{?\w*(?:footer|FOOTER|signature|SIGNATURE)\w*\}?/i.test(cmd)) return true;
-  return false;
-}
-
-/**
- * Check if the command uses unparseable body syntax (heredoc, process
- * substitution, or command substitution in the body argument). These forms
- * are too dynamic to rewrite safely and the caller should use the helper
- * explicitly. Returns true if unparseable.
- * @param {string} cmd
- * @returns {boolean}
- */
-function _hasUnparseableBody(cmd) {
-  // Heredoc / process substitution
-  if (/--body(?:-file)?\s*=?\s*(?:<<-?\s*['"]?\w+|<\()/.test(cmd)) return true;
-  // Command substitution inside --body value
-  const bodyStart = cmd.search(/--body(?:-file)?(?:=|\s)/);
-  if (bodyStart === -1) return false;
-  const afterBody = cmd.slice(bodyStart);
-  return afterBody.includes("$(") || /`[^`]*`/.test(afterBody);
+  // Footer variable interpolation — $FOOTER, ${SIGNATURE}, etc. Requires the
+  // cmd to assign the variable upstream; we trust it here because the
+  // downstream wrapper/shim will enforce the marker anyway.
+  return (
+    cmd.includes("gh-signature-helper.sh") ||
+    cmd.includes("gh-signature-helper ") ||
+    cmd.includes(SIG_MARKER) ||
+    /\$\{?\w*(?:footer|FOOTER|signature|SIGNATURE)\w*\}?/i.test(cmd)
+  );
 }
 
 /**
@@ -248,156 +230,21 @@ function _generateSignature(helperPath, bodyValue, log) {
 }
 
 /**
- * Decide whether a missing --body-file is likely created earlier in the same
- * bash command. The OpenCode hook runs before bash executes, so this lets safe
- * create-then-gh forms reach the PATH shim, which signs the completed file at
- * exec time. Conservative: requires the same token before the gh write and a
- * file-creation operator/pattern before that write.
+ * Check if the command uses unparseable body syntax (heredoc, process
+ * substitution, or command substitution in the body argument). These forms
+ * are too dynamic to rewrite safely and the caller should use the helper
+ * explicitly. Returns true if unparseable.
  * @param {string} cmd
- * @param {string} filePath
  * @returns {boolean}
  */
-function _hasPriorSameCommandBodyFileCreation(cmd, filePath) {
-  if (!filePath) return false;
-  const bodyFileIdx = cmd.lastIndexOf("--body-file");
-  if (bodyFileIdx <= 0) return false;
-  const beforeGh = cmd.slice(0, bodyFileIdx);
-  if (!beforeGh.includes(filePath)) return false;
-  const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const quotedPath = `["']?${escaped}["']?`;
-  const creationPatterns = [
-    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:echo|printf|cat|tee)\\b[\\s\\S]*(?:>|>>)\\s*${quotedPath}`),
-    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*(?:cp|mv)\\b[\\s\\S]+\\s+${quotedPath}`),
-    new RegExp(`(?:^|[;&|]|&&|\\|\\|)\\s*touch\\s+${quotedPath}`),
-  ];
-  return creationPatterns.some((pattern) => pattern.test(beforeGh));
-}
-
-/**
- * Check whether one resolved filesystem path is inside another resolved path.
- * @param {string} childPath
- * @param {string} parentPath
- * @returns {boolean}
- */
-function _isPathWithin(childPath, parentPath) {
-  const parentPrefix = parentPath.endsWith(sep) ? parentPath : `${parentPath}${sep}`;
-  return childPath === parentPath || childPath.startsWith(parentPrefix);
-}
-
-/**
- * Resolve a body-file path through realpath and keep transparent repair inside
- * known-safe writable areas. This prevents a `--body-file` symlink or traversal
- * path from making the hook append signatures outside the worktree/tmp space.
- * @param {string} filePath
- * @returns {{ status: "ok", filePath: string } | { status: "fail", reason: string, detail: string }}
- */
-function _safeRealpath(path) {
-  try {
-    return realpathSync(path);
-  } catch {
-    return "";
-  }
-}
-
-function _gitValue(args) {
-  try {
-    return execFileSync("git", args, {
-      encoding: "utf-8",
-      timeout: 1000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return "";
-  }
-}
-
-function _gitCommonDir(path) {
-  const topLevel = _gitValue(["-C", path, "rev-parse", "--show-toplevel"]);
-  if (!topLevel) return "";
-  const commonDir = _gitValue(["-C", topLevel, "rev-parse", "--git-common-dir"]);
-  if (!commonDir) return "";
-  return _safeRealpath(isAbsolute(commonDir) ? commonDir : resolve(topLevel, commonDir));
-}
-
-function _sameGitRepository(pathA, pathB) {
-  const commonA = _gitCommonDir(pathA);
-  const commonB = _gitCommonDir(pathB);
-  return Boolean(commonA && commonB && commonA === commonB);
-}
-
-function _resolveAllowedBodyFilePath(filePath, commandWorkdir = process.cwd()) {
-  const realCommandWorkdir = _safeRealpath(commandWorkdir) || process.cwd();
-  const candidatePath = isAbsolute(filePath) ? filePath : resolve(realCommandWorkdir, filePath);
-  const realFilePath = realpathSync(candidatePath);
-  const allowedRoots = [realCommandWorkdir, process.cwd(), tmpdir()]
-    .filter((root) => existsSync(root))
-    .map((root) => realpathSync(root));
-  if (allowedRoots.some((root) => _isPathWithin(realFilePath, root))) {
-    return { status: "ok", filePath: realFilePath };
-  }
-  if (_sameGitRepository(realFilePath, realCommandWorkdir)) {
-    return { status: "ok", filePath: realFilePath };
-  }
-  return {
-    status: "fail",
-    reason: FAIL_REASON.BODY_FILE_OUTSIDE_ALLOWED_ROOT,
-    detail: `${filePath} -> ${realFilePath}`,
-  };
-}
-
-/**
- * Repair a `--body-file PATH` form by appending the signature footer to the
- * referenced file if missing.
- *
- * Returns `{ status: "ok", cmd }` on success or
- * `{ status: "fail", reason, detail }` on failure. The reason distinguishes
- * FILE_NOT_FOUND (likely the same-bash-call race — bash hasn't created the
- * file yet at the moment this hook runs), FILE_UNREADABLE (other I/O error),
- * or a forwarded HELPER_FAILED from _generateSignature. (t2893)
- * @param {string} cmd
- * @param {string} filePath
- * @param {string} helperPath
- * @param {Function} log
- * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail: string }}
- */
-function _repairBodyFile(cmd, filePath, helperPath, log, commandWorkdir = process.cwd()) {
-  try {
-    const resolved = _resolveAllowedBodyFilePath(filePath, commandWorkdir);
-    if (resolved.status === "fail") {
-      log("WARN", `Refusing --body-file outside allowed roots: ${resolved.detail}`);
-      return resolved;
-    }
-    const current = readFileSync(resolved.filePath, "utf-8");
-    if (current.includes(SIG_MARKER)) return { status: "ok", cmd };
-    if (isMachineProtocolCommand(current)) {
-      log(
-        "INFO",
-        `Body-file ${resolved.filePath} contains machine-protocol content; no repair needed`,
-      );
-      return { status: "ok", cmd };
-    }
-    if (!existsSync(helperPath)) {
-      log("WARN", `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
-      return { status: "fail", reason: FAIL_REASON.HELPER_MISSING, detail: helperPath };
-    }
-    const sigResult = _generateSignature(helperPath, current, log);
-    if (sigResult.status === "fail") return sigResult;
-    appendFileSync(resolved.filePath, sigResult.sig);
-    log("INFO", `Auto-appended signature footer to body-file ${resolved.filePath} (t2685)`);
-    return { status: "ok", cmd };
-  } catch (e) {
-    const reason =
-      e.code === "ENOENT" ? FAIL_REASON.FILE_NOT_FOUND : FAIL_REASON.FILE_UNREADABLE;
-    if (reason === FAIL_REASON.FILE_NOT_FOUND && _hasPriorSameCommandBodyFileCreation(cmd, filePath)) {
-      log(
-        "INFO",
-        `Body-file ${filePath} appears to be created before gh in the same bash command; deferring signature injection to PATH shim`,
-      );
-      return { status: "ok", cmd };
-    }
-    log("WARN", `Could not repair --body-file ${filePath}: ${e.message} (${reason})`);
-    return { status: "fail", reason, detail: `${filePath}: ${e.message}` };
-  }
+function _hasUnparseableBody(cmd) {
+  const bodyStart = cmd.search(/--body(?:-file)?(?:=|\s)/);
+  const afterBody = bodyStart === -1 ? "" : cmd.slice(bodyStart);
+  return (
+    /--body(?:-file)?\s*=?\s*(?:<<-?\s*['"]?\w+|<\()/.test(cmd) ||
+    afterBody.includes("$(") ||
+    /`[^`]*`/.test(afterBody)
+  );
 }
 
 /**
@@ -495,7 +342,12 @@ export function tryRepairSignature(cmd, scriptsDir, log, options = {}) {
   );
   if (bodyFileMatch) {
     const filePath = bodyFileMatch[2] || bodyFileMatch[4];
-    return _repairBodyFile(cmd, filePath, helperPath, log, options.commandWorkdir);
+    return repairBodyFile(cmd, filePath, helperPath, log, {
+      commandWorkdir: options.commandWorkdir,
+      sigMarker: SIG_MARKER,
+      isMachineProtocolCommand,
+      generateSignature: _generateSignature,
+    });
   }
 
   if (!existsSync(helperPath)) {


### PR DESCRIPTION
## Summary

Split body-file repair and safe path resolution out of .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs into .agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs, and simplified trusted-signature/unparseable-body checks without changing the public exports.\n\n## Complexity Bump Justification\n\nThis refactor intentionally adds .agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs as a private helper module to reduce Qlty smells reported on .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs: file complexity and return-statement count. The original target drops from 554 to 408 lines with body-file repair helpers extracted; no public API changes were made.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs,.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs && node --check .agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs; node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; npm test (from .agents/plugins/opencode-aidevops, passed before rebase); qlty smells .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs --no-snippets --quiet could not run because qlty is not installed in the worker image

Resolves #24872


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.79 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 4m and 164,228 tokens on this as a headless worker.