### PR TITLE
GH#24861: refactor: split signature detection helpers

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+// Signature footer gate detection helpers. Extracted from
+// quality-hooks-signature.mjs so the gate orchestrator keeps only repair and
+// enforcement flow while command-shape detection remains independently tested
+// through the existing public re-exports.
+
+export const SIG_MARKER = "<!-- aidevops:sig -->";
+
+/**
+ * Strip heredoc body lines from a multi-line command string.
+ * Lines inside <<MARKER ... MARKER blocks are removed so that prose inside a
+ * heredoc body cannot trigger false-positive gh-write detection (GH#20735).
+ * @param {string} cmd
+ * @returns {string} cmd with heredoc body lines removed
+ */
+function stripHeredocBodies(cmd) {
+  const lines = cmd.split("\n");
+  const result = [];
+  let terminator = null;
+  for (const line of lines) {
+    if (terminator !== null) {
+      if (line.trim() === terminator) {
+        terminator = null;
+      }
+      continue;
+    }
+    const match = line.match(/<<-?\s*['"]?([\w-]+)['"]?/);
+    if (match) {
+      terminator = match[1];
+    }
+    result.push(line);
+  }
+  return result.join("\n");
+}
+
+/**
+ * Strip balanced single and double quoted strings from a shell line so quoted
+ * prose containing `gh issue create` remains invisible to command detection.
+ * @param {string} line
+ * @returns {string}
+ */
+function stripQuotedStrings(line) {
+  const withoutDouble = line.replace(/"(?:[^"\\]|\\.)*"/g, '""');
+  return withoutDouble.replace(/'[^']*'/g, "''");
+}
+
+function isCommentOrGitCommit(trimmedLine) {
+  return trimmedLine.startsWith("#") || /\bgit\s+commit\b/.test(trimmedLine);
+}
+
+function lineHasGhWriteCommand(line, ghWritePattern) {
+  const trimmed = line.trim();
+  if (isCommentOrGitCommit(trimmed)) return false;
+  return ghWritePattern.test(stripQuotedStrings(trimmed));
+}
+
+/**
+ * Decide whether a given bash command is a gh write that needs sig enforcement.
+ * @param {string} cmd - Raw bash command string (may be multi-line)
+ * @returns {boolean}
+ */
+export function isGhWriteCommand(cmd) {
+  const ghWritePattern =
+    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
+  return stripHeredocBodies(cmd)
+    .split("\n")
+    .some((line) => lineHasGhWriteCommand(line, ghWritePattern));
+}
+
+/**
+ * Machine-protocol comments that are exempt from sig enforcement.
+ * @param {string} cmd
+ * @returns {boolean}
+ */
+export function isMachineProtocolCommand(cmd) {
+  return /DISPATCH_CLAIM|KILL_WORKER|DISPATCH_ACK|<!-- MERGE_SUMMARY -->/.test(cmd);
+}
+
+/**
+ * Good-path signal: direct helper use, canonical marker, or footer variable.
+ * @param {string} cmd
+ * @returns {boolean}
+ */
+export function hasTrustedSignatureSignal(cmd) {
+  return (
+    cmd.includes("gh-signature-helper.sh") ||
+    cmd.includes("gh-signature-helper ") ||
+    cmd.includes(SIG_MARKER) ||
+    /\$\{?\w*(?:footer|FOOTER|signature|SIGNATURE)\w*\}?/i.test(cmd)
+  );
+}

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -62,6 +62,7 @@ function lineHasGhWriteCommand(line, ghWritePattern) {
  * @returns {boolean}
  */
 export function isGhWriteCommand(cmd) {
+  if (typeof cmd !== "string") return false;
   const ghWritePattern =
     /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
   return stripHeredocBodies(cmd)
@@ -75,6 +76,7 @@ export function isGhWriteCommand(cmd) {
  * @returns {boolean}
  */
 export function isMachineProtocolCommand(cmd) {
+  if (typeof cmd !== "string") return false;
   return /DISPATCH_CLAIM|KILL_WORKER|DISPATCH_ACK|<!-- MERGE_SUMMARY -->/.test(cmd);
 }
 
@@ -84,6 +86,7 @@ export function isMachineProtocolCommand(cmd) {
  * @returns {boolean}
  */
 export function hasTrustedSignatureSignal(cmd) {
+  if (typeof cmd !== "string") return false;
   return (
     cmd.includes("gh-signature-helper.sh") ||
     cmd.includes("gh-signature-helper ") ||

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -49,142 +49,19 @@ import { join } from "path";
 
 import { FAIL_REASON, formatGateThrowMessage } from "./quality-hooks-signature-failures.mjs";
 import { repairBodyFile } from "./quality-hooks-signature-body-file.mjs";
-
-export const SIG_MARKER = "<!-- aidevops:sig -->";
+import {
+  SIG_MARKER,
+  hasTrustedSignatureSignal,
+  isGhWriteCommand,
+  isMachineProtocolCommand,
+} from "./quality-hooks-signature-detection.mjs";
 
 // Re-export FAIL_REASON so existing test imports
 // (`import { FAIL_REASON } from "../quality-hooks-signature.mjs"`) keep
 // working. Definition lives in quality-hooks-signature-failures.mjs to
 // keep this file under the qlty per-file complexity threshold (t2893).
 export { FAIL_REASON };
-
-/**
- * Strip heredoc body lines from a multi-line command string.
- * Lines inside <<MARKER ... MARKER blocks are removed so that prose
- * inside a heredoc body cannot trigger false-positive gh-write detection
- * (GH#20735 Failure 1).
- *
- * Handles: <<TAG  <<-TAG  <<'TAG'  <<"TAG"
- * Single-heredoc only; nested / multiple heredocs on one line are rare
- * and handled conservatively (opener line is kept, body stripped).
- * @param {string} cmd
- * @returns {string} cmd with heredoc body lines removed
- */
-function _stripHeredocBodies(cmd) {
-  const lines = cmd.split("\n");
-  const result = [];
-  let terminator = null;
-  for (const line of lines) {
-    if (terminator !== null) {
-      // Inside a heredoc — check for the terminator (possibly indented for <<-)
-      if (line.trim() === terminator) {
-        terminator = null;
-      }
-      // Skip this line regardless (heredoc body or terminator itself)
-      continue;
-    }
-    // Detect a heredoc opener: <<[-] with optional quotes around the tag
-    // Use [\w-]+ (not \w+) because bash allows hyphens in heredoc tags
-    // e.g. <<EOF-TAG, which \w+ would not match.
-    const m = line.match(/<<-?\s*['"]?([\w-]+)['"]?/);
-    if (m) {
-      terminator = m[1];
-    }
-    result.push(line);
-  }
-  return result.join("\n");
-}
-
-/**
- * Strip balanced single and double quoted strings from a shell line.
- * Replaces quoted content with empty quotes so that `gh …` tokens embedded
- * inside quoted arguments of other tools (rg, grep, memory-helper.sh …)
- * are invisible to the command-boundary check (GH#20735 Failures 2 & 3).
- *
- * Double quotes are stripped first (with basic escape handling), then
- * single quotes (no escapes inside single quotes in POSIX shell).
- * @param {string} line
- * @returns {string}
- */
-function _stripQuotedStrings(line) {
-  // Remove double-quoted strings (handles \" inside)
-  const withoutDouble = line.replace(/"(?:[^"\\]|\\.)*"/g, '""');
-  // Remove single-quoted strings (no escapes possible inside)
-  return withoutDouble.replace(/'[^']*'/g, "''");
-}
-
-/**
- * Decide whether a given bash command is a gh write that needs sig enforcement.
- *
- * Three-layer false-positive prevention (GH#20735):
- *   1. Heredoc stripping — removes lines inside <<TAG…TAG so prose in a
- *      heredoc body cannot match (Failure 1).
- *   2. Quoted-string stripping — replaces content inside balanced quotes
- *      with empty quotes, hiding `gh …` tokens inside string arguments of
- *      unrelated tools like `rg "gh issue create"` (Failures 2 & 3).
- *   3. Command-boundary anchor — requires `gh` to be at a shell command
- *      start: beginning of the trimmed line, or immediately after one of
- *      ; & | ( ` $( ! — preventing matches mid-argument after plain whitespace.
- *      Also allows optional prefixes (sudo, time, env VAR=val) between the
- *      boundary and `gh` to avoid false negatives on prefixed invocations.
- *
- * @param {string} cmd - Raw bash command string (may be multi-line)
- * @returns {boolean}
- */
-export function isGhWriteCommand(cmd) {
-  // Layer 3 pattern: gh must start a command segment.
-  // Boundaries: start-of-trimmed-line (^), semicolon, ampersand (covers &&),
-  // pipe (covers ||), open-paren (subshell / command-sub), backtick, literal $(.
-  // Also: ! (bash negation operator — gh still executes, needs sig).
-  // After a boundary, allow optional common command prefixes (sudo, time,
-  // env with optional VAR=val assignments) before gh to avoid false negatives
-  // for patterns like `sudo gh issue create` or `env GH_TOKEN=xxx gh pr create`.
-  const ghWritePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
-
-  // Layer 1: strip heredoc bodies from the full command string first
-  const noHeredoc = _stripHeredocBodies(cmd);
-
-  return noHeredoc.split("\n").some((line) => {
-    const trimmed = line.trim();
-    if (trimmed.startsWith("#")) return false;
-    if (/\bgit\s+commit\b/.test(trimmed)) return false;
-    // Layer 2: strip quoted strings so embedded gh tokens are invisible
-    const unquoted = _stripQuotedStrings(trimmed);
-    // Layer 3: require a command-boundary anchor before gh
-    return ghWritePattern.test(unquoted);
-  });
-}
-
-/**
- * Machine-protocol comments that are exempt from sig enforcement.
- * These are structured markers parsed by the pulse, not human-readable
- * messages; adding a footer would corrupt them.
- * @param {string} cmd
- * @returns {boolean}
- */
-export function isMachineProtocolCommand(cmd) {
-  return /DISPATCH_CLAIM|KILL_WORKER|DISPATCH_ACK|<!-- MERGE_SUMMARY -->/.test(cmd);
-}
-
-/**
- * Good-path signal: the command invokes gh-signature-helper directly OR
- * the body content already contains the canonical HTML marker OR a
- * footer-like variable is interpolated in.
- * @param {string} cmd
- * @returns {boolean}
- */
-export function hasTrustedSignatureSignal(cmd) {
-  // Footer variable interpolation — $FOOTER, ${SIGNATURE}, etc. Requires the
-  // cmd to assign the variable upstream; we trust it here because the
-  // downstream wrapper/shim will enforce the marker anyway.
-  return (
-    cmd.includes("gh-signature-helper.sh") ||
-    cmd.includes("gh-signature-helper ") ||
-    cmd.includes(SIG_MARKER) ||
-    /\$\{?\w*(?:footer|FOOTER|signature|SIGNATURE)\w*\}?/i.test(cmd)
-  );
-}
+export { SIG_MARKER, hasTrustedSignatureSignal, isGhWriteCommand, isMachineProtocolCommand };
 
 /**
  * Generate a signature footer by invoking gh-signature-helper.sh synchronously.

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -77,6 +77,11 @@ describe("isGhWriteCommand", () => {
     assert.equal(isGhWriteCommand('gh pr comment 1 --body "x"'), true);
   });
 
+  test("ignores non-string input", () => {
+    assert.equal(isGhWriteCommand(undefined), false);
+    assert.equal(isGhWriteCommand({ command: 'gh issue comment 1 --body "x"' }), false);
+  });
+
   test("ignores gh issue view (read)", () => {
     assert.equal(isGhWriteCommand("gh issue view 1"), false);
   });
@@ -201,6 +206,11 @@ describe("isMachineProtocolCommand", () => {
       false,
     );
   });
+
+  test("ignores non-string input", () => {
+    assert.equal(isMachineProtocolCommand(undefined), false);
+    assert.equal(isMachineProtocolCommand({ body: "DISPATCH_ACK" }), false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -257,6 +267,11 @@ describe("hasTrustedSignatureSignal", () => {
       hasTrustedSignatureSignal('gh issue comment 1 --body "thanks"'),
       false,
     );
+  });
+
+  test("ignores non-string input", () => {
+    assert.equal(hasTrustedSignatureSignal(undefined), false);
+    assert.equal(hasTrustedSignatureSignal({ body: SIG_MARKER }), false);
   });
 });
 


### PR DESCRIPTION
## Summary

Extracted signature command detection helpers from quality-hooks-signature.mjs into quality-hooks-signature-detection.mjs, keeping public re-exports intact while reducing the orchestrator file complexity and return-statement density.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs,.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs && node --check .agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs && node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs; .agents/scripts/linters-local.sh; npm run typecheck; qlty smells command unavailable directly in worker PATH, but linters-local Qlty summary no longer lists quality-hooks-signature.mjs in top files

Resolves #24861


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.79 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 6m and 79,864 tokens on this as a headless worker.