### PR TITLE
fix: parameterize session time repo filters

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -211,23 +211,6 @@ _session_time_query_db() {
 	local abs_repo_path="$2"
 	local since_ms="$3"
 
-	# Build directory filter clause.
-	# When abs_repo_path is empty (--all-dirs), dir_clause stays empty to
-	# aggregate sessions across all repos (profile-level stats). Runtime temp
-	# sessions are retained and classified as worker sessions later so 24h/7d
-	# worker activity remains visible without masquerading as user work.
-	# Uses parameter expansion to avoid an if/fi block (nesting budget).
-	local dir_clause=""
-	local safe_path="${abs_repo_path//\'/\'\'}"
-	local like_path="${safe_path//%/\\%}"
-	like_path="${like_path//_/\\_}"
-	# Only set dir_clause when a path was provided; empty abs_repo_path
-	# produces empty safe_path, so the :+ expansion yields nothing.
-	# shellcheck disable=SC2016,SC1003 # Single quotes are SQL delimiters, not bash
-	dir_clause="${safe_path:+AND (s.directory = '${safe_path}'
-			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\'
-			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\')}"
-
 	# Query per-session human vs machine time using window functions.
 	# LAG() compares each message with the previous one in the same session:
 	#   human_time = user.created - prev_assistant.completed (reading + thinking + typing)
@@ -235,48 +218,80 @@ _session_time_query_db() {
 	# Caps human gaps at 1 hour to exclude idle/abandoned sessions.
 	# Worker sessions (headless) have ~0% human time; interactive ~70-85%.
 	local query_result
-	query_result=$(sqlite3 -cmd ".timeout 5000" -json "$db_path" "
-		WITH msg_data AS (
-			SELECT
-				s.id AS session_id,
-				s.title,
-				s.directory,
-				json_extract(m.data, '\$.role') AS role,
-				m.time_created AS created,
-				json_extract(m.data, '\$.time.completed') AS completed,
-				LAG(json_extract(m.data, '\$.role'))
-					OVER (PARTITION BY s.id ORDER BY m.time_created) AS prev_role,
-				LAG(json_extract(m.data, '\$.time.completed'))
-					OVER (PARTITION BY s.id ORDER BY m.time_created) AS prev_completed
-			FROM session s
-			JOIN message m ON m.session_id = s.id
-			WHERE s.parent_id IS NULL
-			  AND m.time_created > ${since_ms}
-			  ${dir_clause}
-		)
-		SELECT
-			session_id,
-			title,
-			directory,
-			MIN(created) AS first_message_ms,
-			MAX(COALESCE(completed, created)) AS last_message_ms,
-			SUM(CASE
-				WHEN role = 'user' AND prev_role = 'assistant'
-				     AND prev_completed IS NOT NULL
-				     AND (created - prev_completed) BETWEEN 1 AND 3600000
-				THEN created - prev_completed
-				ELSE 0
-			END) AS human_ms,
-			SUM(CASE
-				WHEN role = 'assistant' AND completed IS NOT NULL
-				     AND (completed - created) > 0
-				THEN completed - created
-				ELSE 0
-			END) AS machine_ms
-		FROM msg_data
-		GROUP BY session_id
-		HAVING human_ms + machine_ms > 5000
-	" 2>/dev/null) || query_result="[]"
+	query_result=$(python3 - "$db_path" "$abs_repo_path" "$since_ms" <<'PY' 2>/dev/null
+import json
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+abs_repo_path = sys.argv[2]
+since_ms = int(float(sys.argv[3] or 0))
+
+where = ["s.parent_id IS NULL", "m.time_created > ?"]
+params = [since_ms]
+if abs_repo_path:
+    like_path = (
+        abs_repo_path
+        .replace('\\', '\\\\')
+        .replace('%', '\\%')
+        .replace('_', '\\_')
+    )
+    where.append("""(s.directory = ?
+        OR s.directory LIKE ? ESCAPE '\\'
+        OR s.directory LIKE ? ESCAPE '\\')""")
+    params.extend([
+        abs_repo_path,
+        f"{like_path}.%",
+        f"{like_path}-%",
+    ])
+
+query = f"""
+    WITH msg_data AS (
+        SELECT
+            s.id AS session_id,
+            s.title,
+            s.directory,
+            json_extract(m.data, '$.role') AS role,
+            m.time_created AS created,
+            json_extract(m.data, '$.time.completed') AS completed,
+            LAG(json_extract(m.data, '$.role'))
+                OVER (PARTITION BY s.id ORDER BY m.time_created) AS prev_role,
+            LAG(json_extract(m.data, '$.time.completed'))
+                OVER (PARTITION BY s.id ORDER BY m.time_created) AS prev_completed
+        FROM session s
+        JOIN message m ON m.session_id = s.id
+        WHERE {' AND '.join(where)}
+    )
+    SELECT
+        session_id,
+        title,
+        directory,
+        MIN(created) AS first_message_ms,
+        MAX(COALESCE(completed, created)) AS last_message_ms,
+        SUM(CASE
+            WHEN role = 'user' AND prev_role = 'assistant'
+                 AND prev_completed IS NOT NULL
+                 AND (created - prev_completed) BETWEEN 1 AND 3600000
+            THEN created - prev_completed
+            ELSE 0
+        END) AS human_ms,
+        SUM(CASE
+            WHEN role = 'assistant' AND completed IS NOT NULL
+                 AND (completed - created) > 0
+            THEN completed - created
+            ELSE 0
+        END) AS machine_ms
+    FROM msg_data
+    GROUP BY session_id
+    HAVING human_ms + machine_ms > 5000
+"""
+
+with sqlite3.connect(db_path, timeout=5) as conn:
+    conn.row_factory = sqlite3.Row
+    rows = [dict(row) for row in conn.execute(query, params)]
+print(json.dumps(rows))
+PY
+	) || query_result="[]"
 
 	# t1427: sqlite3 -json returns "" (not "[]") when no rows match.
 	if [[ "$query_result" != "["* ]]; then

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -78,14 +78,33 @@ insert_session_fixture() {
 	local assistant_completed=$((start_ms + 10000))
 	local user_created=$((assistant_completed + 20000))
 
-	sqlite3 "$db_path" <<SQL
-INSERT INTO session(id, title, parent_id, directory)
-VALUES('${session_id}', '${title}', NULL, '${directory}');
-INSERT INTO message(session_id, data, time_created)
-VALUES('${session_id}', '{"role":"assistant","time":{"completed":${assistant_completed}}}', ${start_ms});
-INSERT INTO message(session_id, data, time_created)
-VALUES('${session_id}', '{"role":"user"}', ${user_created});
-SQL
+	python3 - "$db_path" "$session_id" "$title" "$start_ms" "$directory" "$assistant_completed" "$user_created" <<'PY'
+import json
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+session_id = sys.argv[2]
+title = sys.argv[3]
+start_ms = int(sys.argv[4])
+directory = sys.argv[5]
+assistant_completed = int(sys.argv[6])
+user_created = int(sys.argv[7])
+
+with sqlite3.connect(db_path) as conn:
+    conn.execute(
+        "INSERT INTO session(id, title, parent_id, directory) VALUES(?, ?, NULL, ?)",
+        (session_id, title, directory),
+    )
+    conn.execute(
+        "INSERT INTO message(session_id, data, time_created) VALUES(?, ?, ?)",
+        (session_id, json.dumps({"role": "assistant", "time": {"completed": assistant_completed}}), start_ms),
+    )
+    conn.execute(
+        "INSERT INTO message(session_id, data, time_created) VALUES(?, ?, ?)",
+        (session_id, '{"role":"user"}', user_created),
+    )
+PY
 	return 0
 }
 
@@ -270,6 +289,50 @@ test_session_time_uses_observability_machine_floor() {
 	return 0
 }
 
+test_session_time_repo_filter_treats_path_metacharacters_literally() {
+	local test_name="session time repo filter treats SQL path metacharacters literally"
+	setup
+
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+
+	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
+	create_session_db "$active_db"
+
+	local now_ms recent_ms repo_path sibling_path wildcard_path quote_path
+	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
+	recent_ms=$((now_ms - 60000))
+	repo_path="${TEST_DIR}/repo_100%\\literal"
+	sibling_path="${TEST_DIR}/repo_100%\\literal-feature-auto-20260616-120000-gh123"
+	wildcard_path="${TEST_DIR}/repoX100Y\\literal"
+	quote_path="${TEST_DIR}/repo_100%\\literal' OR 1=1 --"
+
+	insert_session_fixture "$active_db" "exact-special" "Exact special" "$recent_ms" "$repo_path"
+	insert_session_fixture "$active_db" "sibling-special" "Issue #123: sibling special" "$recent_ms" "$sibling_path"
+	insert_session_fixture "$active_db" "wildcard-looking" "Wildcard looking" "$recent_ms" "$wildcard_path"
+	insert_session_fixture "$active_db" "quote-injection-looking" "Quote injection looking" "$recent_ms" "$quote_path"
+
+	local repo_json repo_sessions repo_worker_sessions
+	repo_json=$(HOME="${TEST_DIR}/home" session_time "$repo_path" --period day --format json)
+	repo_sessions=$(echo "$repo_json" | jq -r '.total_sessions')
+	repo_worker_sessions=$(echo "$repo_json" | jq -r '.worker_sessions')
+
+	if [[ "$repo_sessions" != "2" ]]; then
+		print_result "$test_name" 1 "expected literal filter to include exact+sibling only, got ${repo_sessions}; JSON: ${repo_json}"
+		teardown
+		return 0
+	fi
+	if [[ "$repo_worker_sessions" != "1" ]]; then
+		print_result "$test_name" 1 "expected only sibling worker classification, got ${repo_worker_sessions}; JSON: ${repo_json}"
+		teardown
+		return 0
+	fi
+
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
 main() {
 	if [[ ! -f "$SOURCE_SESSION_LIB" ]]; then
 		echo "Session library not found: ${SOURCE_SESSION_LIB}" >&2
@@ -282,6 +345,7 @@ main() {
 
 	test_session_time_includes_archive_and_dedupes
 	test_session_time_uses_observability_machine_floor
+	test_session_time_repo_filter_treats_path_metacharacters_literally
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}"


### PR DESCRIPTION
Resolves #24916

## Summary
- Replace interpolated session-time repository filter SQL with Python sqlite parameter bindings.
- Escape LIKE metacharacters, including literal backslashes, for repository path filters.
- Add a regression proving paths containing SQL metacharacters are treated literally while sibling worker paths still match.

## Testing
- `bash .agents/scripts/tests/test-contributor-session-archive.sh`
- `shellcheck .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/tests/test-contributor-session-archive.sh`

MERGE_SUMMARY: Parameterized session-time repo filters and added SQL metacharacter regression coverage.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.81 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 3m and 95,449 tokens on this as a headless worker.