### PR TITLE
GH#24918: fix: harden simplification NMR test

### DIFF
--- a/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
@@ -12,7 +12,7 @@ SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
 
 TESTS_RUN=0
 TESTS_FAILED=0
-TMP=$(mktemp -d -t t-sweep-nmr.XXXXXX)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/t-sweep-nmr.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
 CREATE_CALLS="${TMP}/create-calls.log"
@@ -76,7 +76,7 @@ ORIGINAL_HOME="$HOME"
 export HOME="$TMP"
 
 # shellcheck source=../stats-quality-sweep.sh
-SCRIPT_DIR="$SCRIPTS_DIR" source "${SCRIPTS_DIR}/stats-quality-sweep.sh" 2>/dev/null || {
+SCRIPT_DIR="$SCRIPTS_DIR" source "${SCRIPTS_DIR}/stats-quality-sweep.sh" || {
 	printf 'FATAL could not source stats-quality-sweep.sh\n'
 	export HOME="$ORIGINAL_HOME"
 	exit 1
@@ -113,6 +113,7 @@ fi
 printf '\n[b] unverified identity keeps NMR\n'
 true >"$CREATE_CALLS"
 qlty_section=""
+unset AIDEVOPS_GH_WRITE_PERMISSION_USER AIDEVOPS_GH_WRITE_PERMISSION_LEVEL
 _gh_current_user_allows_repo_write() {
 	AIDEVOPS_GH_WRITE_PERMISSION_REASON="permission-lookup-failed:api-failure"
 	export AIDEVOPS_GH_WRITE_PERMISSION_REASON


### PR DESCRIPTION
## Summary

Hardened the simplification NMR regression test by using a portable mktemp template, preserving source-time stderr, and clearing cached write-permission identity before the unverified-identity case.

## Files Changed

.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh; .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh

Resolves #24918


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.81 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1m and 62,098 tokens on this as a headless worker.