### PR TITLE
GH#24913: perf: avoid eager daily usage bucket creation

### DIFF
--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -571,7 +571,9 @@ def _daily_usage(reports: list[SessionReport]) -> list[DailyUsage]:
     grouped: dict[str, dict[str, Any]] = {}
     for report in reports:
         date = (report.finished_at or report.started_at or "unknown")[:10]
-        _add_daily_usage_report(grouped.setdefault(date, _new_daily_usage_bucket()), report)
+        if date not in grouped:
+            grouped[date] = _new_daily_usage_bucket()
+        _add_daily_usage_report(grouped[date], report)
     return [
         _daily_usage_from_bucket(date, data)
         for date, data in sorted(grouped.items(), reverse=True)


### PR DESCRIPTION
## Summary

Replaced dict.setdefault in _daily_usage with an explicit missing-date guard so daily usage buckets are only allocated when needed.

## Files Changed

.agents/scripts/report-token-use-helper.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report-token-use-helper.py; bash .agents/scripts/tests/test-report-token-use-helper.sh

Resolves #24913


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.81 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 13m and 59,265 tokens on this as a headless worker.