### PR TITLE
GH#24919: fix: harden OAuth refresh response parsing

### DIFF
--- a/.agents/scripts/oauth-pool-lib/_common.py
+++ b/.agents/scripts/oauth-pool-lib/_common.py
@@ -193,8 +193,13 @@ def call_token_endpoint(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            data = json.loads(resp.read().decode("utf-8"))
+            if isinstance(data, dict):
+                return data
+            return {TOKEN_REFRESH_ERROR_KEY: "invalid_response"}
     except urllib.error.HTTPError as exc:
         return {TOKEN_REFRESH_ERROR_KEY: _classify_http_error(exc)}
     except (urllib.error.URLError, OSError):
         return {TOKEN_REFRESH_ERROR_KEY: "network"}
+    except ValueError:
+        return {TOKEN_REFRESH_ERROR_KEY: "invalid_response"}

--- a/.agents/scripts/oauth-pool-lib/pool_ops_rotate.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_rotate.py
@@ -47,9 +47,6 @@ def _try_refresh_token(account: dict, provider: str, now_ms: int, ua_header: str
     if error_label:
         print(f"REFRESH_FAILED:{error_label}", file=sys.stderr)
         return
-    if rdata is None:
-        print("REFRESH_FAILED", file=sys.stderr)
-        return
     new_access = rdata.get("access_token", "")
     if not new_access:
         return

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -58,6 +58,7 @@ _POOL_OPS_SPEC.loader.exec_module(_POOL_OPS_MOD)
 
 from oauth_pool_lib import _common  # noqa: E402
 from oauth_pool_lib import pool_ops_refresh  # noqa: E402
+from oauth_pool_lib import pool_ops_rotate  # noqa: E402
 
 
 def run_pool_ops(command: str, env: dict[str, str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -666,6 +667,34 @@ class RefreshTests(PoolOpsTestCase):
 
         self.assertEqual(_common.token_refresh_error_label(result), "http_401")
         self.assertNotIn("secret-refresh", json.dumps(result))
+
+    def test_successful_refresh_with_invalid_json_is_sanitized(self) -> None:
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b"not-json"
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            result = _common.call_token_endpoint("https://auth.example.invalid/token", "client", "secret-refresh", "ua")
+
+        self.assertEqual(_common.token_refresh_error_label(result), "invalid_response")
+        self.assertNotIn("secret-refresh", json.dumps(result))
+
+    def test_successful_refresh_with_non_dict_json_is_sanitized(self) -> None:
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b'[]'
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            result = _common.call_token_endpoint("https://auth.example.invalid/token", "client", "secret-refresh", "ua")
+
+        self.assertEqual(_common.token_refresh_error_label(result), "invalid_response")
+
+    def test_rotate_reports_invalid_refresh_response(self) -> None:
+        account = {"email": "a@example.com", "access": "old", "refresh": "secret-refresh", "expires": 1}
+        with mock.patch.object(pool_ops_rotate, "TOKEN_URLS", {"anthropic": "https://auth.example.invalid/token"}), \
+            mock.patch.object(pool_ops_rotate, "CLIENT_IDS", {"anthropic": "client"}), \
+            mock.patch.object(pool_ops_rotate, "call_token_endpoint", return_value={_common.TOKEN_REFRESH_ERROR_KEY: "invalid_response"}), \
+            mock.patch("sys.stderr") as stderr:
+            pool_ops_rotate._try_refresh_token(account, "anthropic", int(time.time() * 1000), "ua")
+
+        self.assertEqual(stderr.write.call_args_list[0].args[0], "REFRESH_FAILED:invalid_response")
+        self.assertEqual(account["access"], "old")
 
     def test_refresh_account_reports_sanitized_http_failure(self) -> None:
         account = {"email": "a@example.com", "access": "old", "refresh": "secret-refresh", "expires": 1}


### PR DESCRIPTION
## Summary

Validated OAuth token endpoint success responses before callers consume them; invalid JSON, undecodable payloads, and non-object JSON now return a sanitized invalid_response label. Removed the obsolete rotate None branch and added regression coverage for invalid success payloads and rotate failure reporting.

## Files Changed

.agents/scripts/oauth-pool-lib/_common.py,.agents/scripts/oauth-pool-lib/pool_ops_rotate.py,.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest discover -s .agents/scripts/oauth-pool-lib/tests; python3 -m compileall -q .agents/scripts/oauth-pool-lib; .agents/scripts/linters-local.sh

Resolves #24919


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.81 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 15m and 86,872 tokens on this as a headless worker.