### PR TITLE
GH#24899: docs: clarify documentation-only contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,19 @@ or `Ref #NNN`.
 Use `Resolves #NNN` for leaf fixes that close the issue. Use `For #NNN` or
 `Ref #NNN` for parent, research, or non-closing work.
 
+## Documentation-only changes
+
+For small documentation-only improvements such as README clarifications,
+spelling fixes, broken-link fixes, or contribution-guide updates:
+
+1. Reference a GitHub issue before opening a pull request.
+2. Keep the change limited to documentation files.
+3. Do not change code, dependencies, workflows, defaults, configuration
+   structure, or agent framework behaviour.
+4. Run the relevant local checks before committing.
+5. Use a conventional commit such as `docs: clarify contribution guide`.
+6. Link the issue in the pull request body with `Ref #NNN` or `Resolves #NNN`.
+
 ## Development Setup
 
 ```bash


### PR DESCRIPTION
## Summary

Added a Documentation-only changes section to CONTRIBUTING.md covering issue-first workflow, docs-only scope, excluded code/config/framework changes, local checks, conventional commits, and PR issue links.

## Files Changed

CONTRIBUTING.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint CONTRIBUTING.md; npx --no-install secretlint CONTRIBUTING.md; .agents/scripts/linters-local.sh attempted but timed out during Secretlint after earlier gates passed

Resolves #24899


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.82 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 3m and 26,926 tokens on this as a headless worker.