### PR TITLE
GH#24899: clarify documentation-only contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,11 @@ Use `Resolves #NNN` for leaf fixes that close the issue. Use `For #NNN` or
 
 ## Documentation-only changes
 
+Documentation-only PRs are welcome when they stay small, scoped, and linked to
+a GitHub issue. Prefer using `/log-issue-aidevops` to file the issue or request:
+it creates a comprehensive report, checks for duplicates, and follows the
+project contribution guidelines.
+
 For small documentation-only improvements such as README clarifications,
 spelling fixes, broken-link fixes, or contribution-guide updates:
 


### PR DESCRIPTION
## Summary

- Adds `/log-issue-aidevops` as the preferred way to file documentation-only issues or requests.
- Keeps the existing documentation-only scope guidance limited to `CONTRIBUTING.md`.

## Testing

- `git diff --check`
- `.agents/scripts/linters-local.sh` passed Markdown and Secretlint before later broad shell-portability timeout in an unrelated stage.

## Runtime Testing

Self-assessed: documentation-only change; no runtime behaviour changed.

## Key decisions

- Preserved the upstream documentation-only checklist and added only the missing preferred issue-logging guidance.

Resolves #24899

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.82 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 1h 22m and 88,798 tokens on this with the user in an interactive session.
