### PR TITLE
GH#24934: handle large review scanner head file lists

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -319,9 +319,10 @@ _filter_findings_by_head_files() {
 
 	local jq_status
 	printf '%s' "$findings" | jq --slurpfile head_files "$head_files_file" '
+		(reduce $head_files[0][] as $f ({}; .[$f] = true)) as $existing_files |
 		[.[] |
 		if .file == null then .  # review bodies without file refs — keep
-		elif (.file as $f | $head_files[0] | any(. == $f)) then .  # file still exists
+		elif $existing_files[.file] then .  # file still exists
 		else empty  # file was removed/renamed — skip
 		end]
 	'

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -319,7 +319,8 @@ _filter_findings_by_head_files() {
 
 	local jq_status
 	printf '%s' "$findings" | jq --slurpfile head_files "$head_files_file" '
-		(reduce $head_files[0][] as $f ({}; .[$f] = true)) as $existing_files |
+		($head_files[0] | if type == "array" then . else [.tree[].path] end) as $head_file_paths |
+		(reduce $head_file_paths[] as $f ({}; .[$f] = true)) as $existing_files |
 		[.[] |
 		if .file == null then .  # review bodies without file refs — keep
 		elif $existing_files[.file] then .  # file still exists

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -310,14 +310,24 @@ _filter_findings_by_head_files() {
 	head_files=$(gh api "repos/${repo_slug}/git/trees/HEAD?recursive=1" \
 		--jq '[.tree[].path]') || head_files="[]"
 
-	echo "$findings" | jq --argjson head_files "$head_files" '
+	local head_files_file
+	head_files_file=$(mktemp) || return 1
+	printf '%s' "$head_files" >"$head_files_file" || {
+		rm -f "$head_files_file"
+		return 1
+	}
+
+	local jq_status
+	printf '%s' "$findings" | jq --slurpfile head_files "$head_files_file" '
 		[.[] |
 		if .file == null then .  # review bodies without file refs — keep
-		elif (.file as $f | $head_files | any(. == $f)) then .  # file still exists
+		elif (.file as $f | $head_files[0] | any(. == $f)) then .  # file still exists
 		else empty  # file was removed/renamed — skip
 		end]
 	'
-	return 0
+	jq_status=$?
+	rm -f "$head_files_file"
+	return "$jq_status"
 }
 
 # _check_empty_review_guard: return 0 (skip) when the PR has zero inline

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -398,7 +398,7 @@ _finding_still_exists_on_main() {
 	file_content=$(_fetch_file_on_branch "$repo_slug" "$file_path" "$default_branch") || fetch_rc=$?
 	fetch_rc="${fetch_rc:-0}"
 
-	if [[ "$fetch_rc" -eq 1 || -z "$file_content" ]]; then
+	if [[ "$fetch_rc" -eq 1 || ( "$fetch_rc" -eq 0 && -z "$file_content" ) ]]; then
 		echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - file missing on ${default_branch}" >&2
 		echo '{"result":false,"status":"resolved"}'
 		return 1
@@ -916,11 +916,7 @@ _process_pr_scan_loop() {
 
 		local findings
 		findings=$(_scan_single_pr "$repo_slug" "$pr_num" "$min_severity" "$include_positive") || {
-			# In dry-run mode, don't mark PRs as scanned so they can be re-scanned
-			if [[ "$dry_run" != true ]]; then
-				gh pr edit "$pr_num" --repo "$repo_slug" --add-label "review-feedback-scanned" >/dev/null 2>&1 || true
-				newly_scanned+=("$pr_num")
-			fi
+			echo "  Scan failed for PR #${pr_num}; leaving unmarked for retry" >&2
 			batch_count=$((batch_count + 1))
 			continue
 		}

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -41,6 +41,10 @@ _restore_mock_gh() {
 			_mock_gh_issue "$@"
 			return $?
 			;;
+		pr)
+			echo "{}"
+			return 0
+			;;
 		esac
 		echo "unexpected gh call: ${command}" >&2
 		return 1
@@ -77,6 +81,96 @@ test_quality_debt_security_labels_do_not_overprioritize_ordinary_feedback() {
 
 	print_result "quality-debt leaves ordinary review feedback at normal priority" 1 \
 		"labels=${labels}"
+	return 0
+}
+
+test_filter_findings_by_head_files_handles_large_head_file_json() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			python3 - <<'PY'
+import json
+paths = [f"dir_{i:05d}/file_{i:05d}.py" for i in range(6000)]
+paths.append("src/live.py")
+print(json.dumps(paths, separators=(",", ":")))
+PY
+			return 0
+			;;
+		label | issue | pr) return 0 ;;
+		esac
+		printf 'unexpected gh call: %s\n' "$command" >&2
+		return 1
+	}
+
+	local findings
+	findings='[{"pr":1,"file":"src/live.py","body":"keep"},{"pr":1,"file":"src/deleted.py","body":"drop"},{"pr":1,"file":null,"body":"body"}]'
+
+	local filtered
+	filtered=$(_filter_findings_by_head_files "owner/repo" "$findings")
+	local files
+	files=$(printf '%s' "$filtered" | jq -r '[.[].file] | @json')
+
+	if [[ "$files" == '["src/live.py",null]' ]]; then
+		print_result "head-file filtering handles large JSON without jq --argjson" 0
+	else
+		print_result "head-file filtering handles large JSON without jq --argjson" 1 "files=${files}"
+	fi
+
+	_restore_mock_gh
+	return 0
+}
+
+test_failed_scan_does_not_mark_pr_review_feedback_scanned() {
+	reset_mock_state
+
+	local state_file
+	state_file=$(mktemp)
+	printf '{"scanned_prs":[],"last_run":null,"issues_created":0}' >"$state_file"
+	local edit_count_file
+	edit_count_file=$(mktemp)
+
+	(
+		gh() {
+			local command="$1"
+			shift
+			case "$command" in
+			pr)
+				if [[ "${1:-}" == "edit" ]]; then
+					printf 'edit\n' >>"$edit_count_file"
+				fi
+				return 0
+				;;
+			api | label | issue) return 0 ;;
+			esac
+			printf 'unexpected gh call: %s\n' "$command" >&2
+			return 1
+		}
+
+		_scan_single_pr() {
+			return 1
+		}
+
+		_process_pr_scan_loop "owner/repo" "medium" "false" "false" "false" "false" "20" "false" "$state_file" "123" >/dev/null 2>&1
+	)
+
+	local gh_pr_edit_count
+	gh_pr_edit_count=$(wc -l <"$edit_count_file" | tr -d ' ')
+	local scanned_count
+	scanned_count=$(jq '.scanned_prs | length' "$state_file")
+	rm -f "$state_file" "${state_file}.findings_tmp" "$edit_count_file"
+
+	if [[ "$gh_pr_edit_count" -eq 0 && "$scanned_count" -eq 0 ]]; then
+		print_result "failed scan does not add review-feedback-scanned label or state" 0
+	else
+		print_result "failed scan does not add review-feedback-scanned label or state" 1 \
+			"gh_pr_edit_count=${gh_pr_edit_count} scanned_count=${scanned_count}"
+	fi
+
+	_restore_mock_gh
 	return 0
 }
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -206,6 +206,8 @@ main() {
 	echo "Running quality-debt security classification tests (GH#22429)"
 	test_quality_debt_security_labels_for_security_review_feedback
 	test_quality_debt_security_labels_do_not_overprioritize_ordinary_feedback
+	test_filter_findings_by_head_files_handles_large_head_file_json
+	test_failed_scan_does_not_mark_pr_review_feedback_scanned
 
 	echo "Running quality-feedback main-branch verification tests"
 	test_skips_resolved_finding_when_snippet_missing


### PR DESCRIPTION
## Summary
- Replace large HEAD path-list transport from `jq --argjson` to `jq --slurpfile` so merged PR review scanning does not hit per-argument limits.
- Leave PRs unmarked when `_scan_single_pr` fails, so failed scans are retried instead of labelled `review-feedback-scanned`.
- Preserve transient content-fetch failures as unverifiable findings rather than treating them as deleted files.

## Testing
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` → `49/49 passed, 0 failed`
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/quality-feedback-helper.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh` → clean
- `bash .agents/scripts/lint-shell-portability.sh --summary .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/quality-feedback-helper.sh` → `shell-portability: clean`
- `.agents/scripts/linters-local.sh` → reached repo-wide shell-portability after passing Secretlint and other gates, but timed out in the full repo-wide portability scan; targeted portability on modified production scripts is clean.

Resolves #24934
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.84 with gpt-5.5 spent 24m and 204,407 tokens on this with the user in an interactive session.