### PR TITLE
GH#24939: fix: filter review-thread acknowledgement findings

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -38,8 +38,20 @@ _build_inline_findings() {
 		 else "human"
 		 end) as $reviewer |
 
-		# Extract severity from body
+		# Extract body for acknowledgement filtering and severity detection.
 		(.body) as $body |
+		# Skip thread-resolution replies and positive acknowledgements that appear
+		# as inline review comments. These are closure evidence from a review-thread
+		# response worker, not new quality debt (GH#24939).
+		($body | test(
+			"aidevops:review-thread-response|" +
+			"\\baddressed in [0-9a-f]{7,40}\\b|" +
+			"\\bno further concerns?\\b|" +
+			"\\bno further feedback\\b|" +
+			"\\bno further recommendations?\\b"; "i")) as $resolution_or_ack |
+		select($resolution_or_ack | not) |
+
+		# Extract severity from body
 		(if ($body | test("security-critical\\.svg|🔴.*critical|CRITICAL"; "i")) then "critical"
 		 elif ($body | test("critical\\.svg|severity:.*critical"; "i")) then "critical"
 		 elif ($body | test("high-priority\\.svg|severity:.*high|HIGH"; "i")) then "high"

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -258,6 +258,30 @@ test_skips_no_suggestions_for_improvement_review() {
 	return 0
 }
 
+test_skips_review_thread_response_inline_comment() {
+	local comments result
+	comments='[{"user":{"login":"marcusquinn"},"body":"<!-- aidevops:review-thread-response:PRRT_1 -->\nAddressed in 055c869cb by building a jq lookup map. Verified with bash -n and shellcheck.","path":".agents/scripts/quality-feedback-findings-lib.sh","line":329,"html_url":"https://example.invalid/review","created_at":"2026-06-16T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "24936" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip review-thread response inline comment" 0
+	else
+		print_result "skip review-thread response inline comment" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_no_further_concerns_inline_ack() {
+	local comments result
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The lookup map implementation is the correct approach, and I have no further concerns regarding this implementation.","path":".agents/scripts/quality-feedback-findings-lib.sh","line":329,"html_url":"https://example.invalid/review","created_at":"2026-06-16T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "24936" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip no-further-concerns inline acknowledgement" 0
+	else
+		print_result "skip no-further-concerns inline acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -239,6 +239,8 @@ main() {
 	test_skips_gemini_style_positive_summary_review
 	test_skips_no_suggestions_at_this_time_review
 	test_skips_no_suggestions_for_improvement_review
+	test_skips_review_thread_response_inline_comment
+	test_skips_no_further_concerns_inline_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Filtered quality-feedback inline findings that are review-thread response markers or no-further-concerns acknowledgements, and added regressions for the PR #24936 false-positive pattern.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh,.agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh && bash .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #24939


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.85 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 3m and 58,936 tokens on this as a headless worker.