### PR TITLE
GH#24947: fix: normalize linked PR status on worker release

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -548,7 +548,7 @@ _rebase_and_push() {
 	# Reset to origin/main's value to prevent silent regression on merge.
 	if [[ -f .task-counter ]]; then
 		local branch_counter="" base_counter=""
-		branch_counter=$(cat .task-counter 2>/dev/null | tr -d '[:space:]') || true
+		branch_counter=$(tr -d '[:space:]' <.task-counter 2>/dev/null) || true
 		base_counter=$(git show origin/main:.task-counter 2>/dev/null | tr -d '[:space:]') || true
 		if [[ -n "$branch_counter" && -n "$base_counter" ]] \
 			&& [[ "$branch_counter" =~ ^[0-9]+$ ]] \
@@ -973,6 +973,7 @@ _post_merge_summary() {
 # Arguments: issue_number, repo
 _label_issue_in_review() {
 	local issue_number="$1" repo="$2"
+	local review_status="in-review"
 
 	local issue_state=""
 	issue_state=$(gh issue view "$issue_number" --repo "$repo" --json state -q '.state' 2>/dev/null || echo "")
@@ -981,11 +982,25 @@ _label_issue_in_review() {
 		local current_user=""
 		current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
 		if [[ -n "$current_user" && "$current_user" != "null" ]]; then
-			set_issue_status "$issue_number" "$repo" "in-review" \
+			set_issue_status "$issue_number" "$repo" "$review_status" \
 				--add-assignee "$current_user" >/dev/null 2>&1 || true
 		else
-			set_issue_status "$issue_number" "$repo" "in-review" >/dev/null 2>&1 || true
+			set_issue_status "$issue_number" "$repo" "$review_status" >/dev/null 2>&1 || true
 		fi
 	fi
+	return 0
+}
+
+# Label the newly opened PR as in-review, removing stale status:available that
+# can be inherited from issue-style label operations on PR issues.
+# Arguments: pr_number, repo
+_label_pr_in_review() {
+	local pr_number="$1" repo="$2"
+	local review_status="in-review"
+
+	if [[ -z "$pr_number" || -z "$repo" ]]; then
+		return 0
+	fi
+	set_issue_status "$pr_number" "$repo" "$review_status" >/dev/null 2>&1 || true
 	return 0
 }

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -177,6 +177,7 @@ Worker aborted PR creation: issue #${issue_number} was already closed by the tim
 
 	_post_merge_summary "$pr_number" "$repo" "$issue_number" "$summary_what" "$files_changed" "$summary_testing" "$summary_decisions"
 	_label_issue_in_review "$issue_number" "$repo"
+	_label_pr_in_review "$pr_number" "$repo"
 
 	# Output PR number for caller to pass to `merge`
 	printf '%s\n' "$pr_number"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1205,6 +1205,8 @@ clear_active_status_on_release() {
 	# `Ref` or `For` — those are planning references that MUST NOT block
 	# assignee cleanup (see t2046).
 	local has_linked_pr=false
+	local has_open_linked_pr=0
+	local linked_open_pr_numbers=""
 	local linked_prs_json=""
 	linked_prs_json=$(gh pr list --repo "$repo_slug" --state all \
 		--search "#${issue_num} in:body" \
@@ -1216,6 +1218,12 @@ clear_active_status_on_release() {
 		'[.[] | select((.state == "OPEN" or .state == "MERGED") and ((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i")))] | length > 0' \
 		>/dev/null 2>&1; then
 		has_linked_pr=true
+	fi
+	linked_open_pr_numbers=$(printf '%s' "$linked_prs_json" | jq -r --arg num "$issue_num" \
+		'.[] | select(.state == "OPEN" and ((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i"))) | .number' \
+		2>/dev/null || true)
+	if [[ -n "$linked_open_pr_numbers" ]]; then
+		has_open_linked_pr=1
 	fi
 
 	local -a _flags=()
@@ -1229,9 +1237,19 @@ clear_active_status_on_release() {
 		if [[ -n "$worker_login" ]]; then
 			_flags+=(--remove-assignee "$worker_login")
 		fi
+	elif [[ "$has_open_linked_pr" -eq 1 && ",${labels_json}," != *",status:done,"* ]]; then
+		_flags+=(--remove-label "status:available")
+		_flags+=(--add-label "status:in-review")
 	fi
 
 	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null || return 1
+	if [[ "$has_open_linked_pr" -eq 1 ]]; then
+		local linked_pr_number=""
+		while IFS= read -r linked_pr_number; do
+			[[ -z "$linked_pr_number" ]] && continue
+			set_issue_status "$linked_pr_number" "$repo_slug" "in-review" >/dev/null 2>&1 || true
+		done <<<"$linked_open_pr_numbers"
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh
+++ b/.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh
@@ -10,6 +10,7 @@
 #   1. Does NOT emit --remove-assignee (worker's assignee is preserved)
 #   2. Does NOT emit --remove-label status:in-review (label is preserved)
 #   3. STILL emits --remove-label for status:queued, status:claimed, status:in-progress
+#   4. Removes stale status:available and ensures status:in-review on the issue and PR
 #
 # Motivation: maintainer-gate.yml Job 1 Check 2 blocks PRs with no assignee.
 # Without this behaviour the worker's CLAIM_RELEASED cleanup strands every
@@ -126,6 +127,9 @@ clear_active_status_on_release 20156 owner/repo alice
 assert_grep "remove-label status:queued" "removes queued when PR open"
 assert_grep "remove-label status:claimed" "removes claimed when PR open"
 assert_grep "remove-label status:in-progress" "removes in-progress when PR open"
+assert_grep "remove-label status:available" "removes available when PR open"
+assert_grep "add-label status:in-review" "ensures issue in-review when PR open"
+assert_grep "issue edit 20188 --repo owner/repo" "normalizes linked PR status when PR open"
 assert_not_grep "remove-label status:in-review" "preserves in-review when PR open (Resolves)"
 assert_not_grep "remove-assignee" "preserves assignee when PR open (Resolves)"
 


### PR DESCRIPTION
## Summary

Normalize issue and linked PR status labels when worker_complete release sees an open closing-keyword PR; full-loop PR creation also labels the PR in-review.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh,.agents/scripts/full-loop-helper.sh,.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on modified shell files; test-clear-active-status-on-release-preserves-pr.sh; test-clear-active-status-on-release-preserves-merged-pr.sh; test-clear-active-status-on-release-no-pr.sh

Resolves #24947


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.85 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 5m and 84,460 tokens on this as a headless worker.