### PR TITLE
GH#24950: Fix counter reconciliation race handling

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -897,7 +897,11 @@ _main_resolve_allocation() {
 		# merge activity.  Reconcile before claiming so we do not allocate IDs below
 		# the default branch's observed counter and then rely on manual fallback.
 		if [[ "$CAS_RECONCILE_RETRY_ON_FAILURE" == "1" && "${DEFAULT_BRANCH:-main}" != "$COUNTER_BRANCH" ]]; then
-			_cas_reconcile_counter_branch "$REPO_PATH" "${DEFAULT_BRANCH:-main}" >/dev/null || return 1
+			local _pre_reconcile_rc=0
+			_cas_reconcile_counter_branch "$REPO_PATH" "${DEFAULT_BRANCH:-main}" >/dev/null || _pre_reconcile_rc=$?
+			if [[ $_pre_reconcile_rc -ne 0 && $_pre_reconcile_rc -ne 2 ]]; then
+				return 1
+			fi
 		fi
 
 		if first_id_out=$(_allocate_online_with_collision_check "$REPO_PATH" "$ALLOC_COUNT"); then

--- a/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
+++ b/.agents/scripts/tests/test-claim-task-id-counter-desync.sh
@@ -108,6 +108,31 @@ HOOK
 	return 0
 }
 
+race_first_counter_reconciliation_push() {
+	local work_dir="$1"
+	local bare_dir
+	bare_dir=$(git -C "$work_dir" remote get-url origin 2>/dev/null) || return 1
+	mkdir -p "${bare_dir}/hooks" || return 1
+	cat >"${bare_dir}/hooks/update" <<'HOOK'
+#!/usr/bin/env bash
+set -u
+
+ref_name="$1"
+old_sha="$2"
+state_file="$(dirname "$0")/first-reconcile-raced"
+if [[ "$ref_name" == "refs/heads/develop" && ! -f "$state_file" ]]; then
+	printf 'seen\n' >"$state_file"
+	winning_sha=$(git rev-parse refs/heads/main 2>/dev/null) || exit 1
+	git update-ref "$ref_name" "$winning_sha" "$old_sha" >/dev/null 2>&1 || exit 1
+	printf 'remote: simulated compare-and-swap race for %s.\n' "$ref_name" >&2
+	exit 1
+fi
+exit 0
+HOOK
+	chmod +x "${bare_dir}/hooks/update" || return 1
+	return 0
+}
+
 test_counter_branch_desync_reconciles_before_claim() {
 	local name="counter branch desync is reconciled before allocation"
 	local tmpdir work_dir output rc task_id final_counter claim_commits unique_claims
@@ -201,6 +226,51 @@ test_reconciliation_protected_branch_rejection_is_unrecoverable() {
 	return 0
 }
 
+test_pre_reconciliation_race_continues_to_allocation() {
+	local name="pre-reconciliation race continues to allocation"
+	local tmpdir work_dir output rc task_id final_counter
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+
+	work_dir=$(setup_desynced_remote "$tmpdir") || { fail "$name" "repo setup failed"; rm -rf "$tmpdir"; return 0; }
+	race_first_counter_reconciliation_push "$work_dir" || { fail "$name" "hook setup failed"; rm -rf "$tmpdir"; return 0; }
+
+	rc=0
+	output=$(CAS_MAX_RETRIES=3 CAS_WALL_TIMEOUT_S=20 CAS_SSH_FALLBACK_ENABLED=0 "$CLAIM_SCRIPT" \
+		--title "pre reconciliation race test" \
+		--no-issue \
+		--repo-path "$work_dir" \
+		--counter-branch develop 2>&1) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "claim failed: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'reconcile_raced'; then
+		fail "$name" "missing reconcile_raced status: $output"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+	task_id=$(printf '%s\n' "$output" | awk -F= '/^task_id=/{print $2; exit}')
+	if [[ "$task_id" != "t1100" ]]; then
+		fail "$name" "expected t1100 after raced reconciliation, got ${task_id:-<empty>}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	git -C "$work_dir" fetch origin develop >/dev/null 2>&1 || true
+	final_counter=$(git -C "$work_dir" show origin/develop:.task-counter 2>/dev/null | tr -d '[:space:]')
+	if [[ "$final_counter" != "1101" ]]; then
+		fail "$name" "expected develop counter 1101, got ${final_counter:-<empty>}"
+		rm -rf "$tmpdir"
+		return 0
+	fi
+
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
 test_reconciliation_adds_missing_counter_file() {
 	local name="reconciliation adds missing counter file"
 	local tmpdir work_dir output rc task_id final_counter
@@ -248,6 +318,7 @@ main() {
 	fi
 	test_counter_branch_desync_reconciles_before_claim
 	test_reconciliation_protected_branch_rejection_is_unrecoverable
+	test_pre_reconciliation_race_continues_to_allocation
 	test_reconciliation_adds_missing_counter_file
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ "$FAIL" -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary

- Handle retryable pre-claim counter reconciliation races (`rc=2`) as safe to continue allocation.
- Add regression coverage that simulates another allocator winning the reconciliation push before allocation retries.

Resolves #24950

## Verification

- `shellcheck` on the modified allocator script and counter desync test script
- Counter desync test script → 5 passed, 0 failed
- `.agents/scripts/linters-local.sh` attempted twice; non-secret gates passed, then command timed out during Secretlint at 120s and 300s.

## Notes

- Task creation through `claim-task-id.sh` is itself blocked by protected `origin/main`; this PR uses the wrapper-created fallback issue #24950 and interactive claim stamp.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.85 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
