### PR TITLE
GH#24900: harden pulse GitHub reliability

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -680,8 +680,8 @@ Thread preview: ${preview}
    PR, do not mark a draft PR ready, and do not bypass review-bot-gate.
 3. Do not use blanket auto-resolution scripts. For active review threads, respond
    in the same GitHub review thread with
-   '.agents/scripts/pr-review-thread-response-scanner.sh reply'; resolve with
-   '.agents/scripts/pr-review-thread-response-scanner.sh resolve' only after
+   '${SCRIPT_DIR}/pr-review-thread-response-scanner.sh reply'; resolve with
+   '${SCRIPT_DIR}/pr-review-thread-response-scanner.sh resolve' only after
    you have verified the finding is addressed or no longer applies.
 4. For each unresolved bot finding:
    - Verify the premise by reading the cited file and surrounding context.

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -81,6 +81,16 @@ if [[ -f "${SCRIPT_DIR}/pulse-stats-helper.sh" ]]; then
 	source "${SCRIPT_DIR}/pulse-stats-helper.sh" 2>/dev/null || true
 fi
 
+_prefetch_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 # --- Configuration ---
 REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 BATCH_CACHE_DIR="${PULSE_BATCH_PREFETCH_CACHE_DIR:-${HOME}/.aidevops/logs/batch-prefetch}"
@@ -141,7 +151,7 @@ _prefetch_rest_issues_for_slug() {
 	local slug="$1"
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_issues || true
 	local rest_json
-	rest_json=$(gh api "/repos/${slug}/issues?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
+	rest_json=$(_prefetch_gh_read gh api "/repos/${slug}/issues?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
 	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
 		_log "REST issues fallback: empty/null response for ${slug}"
 		return 1
@@ -182,7 +192,7 @@ _prefetch_rest_prs_for_slug() {
 	local slug="$1"
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_prs || true
 	local rest_json
-	rest_json=$(gh api "/repos/${slug}/pulls?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
+	rest_json=$(_prefetch_gh_read gh api "/repos/${slug}/pulls?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
 	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
 		_log "REST PRs fallback: empty/null response for ${slug}"
 		return 1
@@ -377,9 +387,9 @@ _conditional_rest_refresh_slug() {
 	err_file=$(mktemp)
 	local rc=0
 	if [[ -n "$etag" ]]; then
-		gh api -i -H "Accept: application/vnd.github+json" -H "If-None-Match: ${etag}" "$endpoint" >"$response_file" 2>"$err_file" || rc=$?
+		_prefetch_gh_read gh api -i -H "Accept: application/vnd.github+json" -H "If-None-Match: ${etag}" "$endpoint" >"$response_file" 2>"$err_file" || rc=$?
 	else
-		gh api -i -H "Accept: application/vnd.github+json" "$endpoint" >"$response_file" 2>"$err_file" || rc=$?
+		_prefetch_gh_read gh api -i -H "Accept: application/vnd.github+json" "$endpoint" >"$response_file" 2>"$err_file" || rc=$?
 	fi
 	local status=""
 	status=$(_conditional_rest_update_cache_from_response "$kind" "$slug" "$response_file" "$cache_file" 2>/dev/null) || status=""
@@ -475,7 +485,7 @@ _refresh_owner_issues() {
 	local issue_err
 	issue_err=$(mktemp)
 	local issue_json=""
-	issue_json=$(gh search issues --owner "$owner" --state open \
+	issue_json=$(_prefetch_gh_read gh search issues --owner "$owner" --state open \
 		--limit "$BATCH_SEARCH_LIMIT" \
 		--json number,title,state,labels,updatedAt,assignees,repository 2>"$issue_err") || issue_json=""
 	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
@@ -535,7 +545,7 @@ _refresh_owner_prs() {
 	local pr_err
 	pr_err=$(mktemp)
 	local pr_json=""
-	pr_json=$(gh search prs --owner "$owner" --state open \
+	pr_json=$(_prefetch_gh_read gh search prs --owner "$owner" --state open \
 		--limit "$BATCH_SEARCH_LIMIT" \
 		--json number,title,labels,updatedAt,assignees,repository,createdAt,author 2>"$pr_err") || pr_json=""
 	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
@@ -631,7 +641,7 @@ _cmd_refresh() {
 	# fall back to their own rate-limit call (the existing behaviour).
 	local _graphql_remaining=""
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rate_limit || true
-	_graphql_remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || _graphql_remaining=""
+	_graphql_remaining=$(_prefetch_gh_read gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || _graphql_remaining=""
 
 	# L1 tickle counters — reset per refresh cycle (module globals from
 	# pulse-events-tickle.sh; may already be 0 if sourced fresh, but

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -6,6 +6,16 @@
 [[ -n "${_PULSE_MERGE_REQUIRED_CHECKS_LOADED:-}" ]] && return 0
 _PULSE_MERGE_REQUIRED_CHECKS_LOADED=1
 
+_pmrc_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 #######################################
 # Fallback required-check verification for repositories where the classic branch
 # protection endpoint and repository-rulesets endpoint expose no contexts, but
@@ -22,7 +32,7 @@ _check_required_pr_checks_passing_fallback() {
 
 	local checks_json=""
 	local checks_exit=0
-	checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null)
+	checks_json=$(_pmrc_gh_read gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null)
 	checks_exit=$?
 	if [[ $checks_exit -ne 0 && -z "$checks_json" ]]; then
 		return 2
@@ -66,7 +76,7 @@ _ruleset_required_review_count_for_default_branch() {
 	local log_target="${LOGFILE:-/dev/stderr}"
 
 	if [[ -z "$rulesets_json" ]]; then
-		rulesets_json=$(gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
+		rulesets_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
 			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
 			return 1
 		}
@@ -91,7 +101,7 @@ _ruleset_required_review_count_for_default_branch() {
 	local matches_default=0 excluded_default=0 approval_count=""
 	while IFS= read -r id; do
 		[[ -n "$id" ]] || continue
-		detail=$(gh api "repos/${repo_slug}/rulesets/${id}" 2>/dev/null) || {
+		detail=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets/${id}" 2>/dev/null) || {
 			echo "[pulse-merge] _ruleset_required_review_count_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#24577)" >>"$log_target"
 			return 1
 		}
@@ -140,7 +150,7 @@ _check_ruleset_required_reviews_passing() {
 	local pr_author="$3"
 
 	local default_branch="" required_count=""
-	default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch=""
+	default_branch=$(_pmrc_gh_read gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch=""
 	if [[ -z "$default_branch" ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: failed to resolve default branch for ${repo_slug} — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -52,6 +52,11 @@ unset _aidevops_path_prefix
 # SCRIPT_DIR resolution — uses BASH_SOURCE[0]:-$0 for zsh portability (GH#3931).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
+# GH#24900: launchd/cron PATH repair must not bypass the aidevops gh shim.
+# Keep the framework script directory first so standalone merge runs inherit
+# GraphQL instrumentation, REST routing, and signature/write safeguards.
+export PATH="${SCRIPT_DIR}:${PATH}"
+
 # =============================================================================
 # Source pulse libraries
 # =============================================================================
@@ -190,6 +195,41 @@ _pmr_log() {
 	return 0
 }
 
+_pmr_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
+_pmr_graphql_remaining() {
+	local remaining="${AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING:-}"
+	if [[ "$remaining" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$remaining"
+		return 0
+	fi
+	remaining=$(_pmr_gh_read gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="0"
+	[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=0
+	printf '%s\n' "$remaining"
+	return 0
+}
+
+_pmr_graphql_budget_allows_run() {
+	local threshold="${AIDEVOPS_PULSE_MERGE_GRAPHQL_MIN_REMAINING:-500}"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=500
+	local remaining=""
+	remaining=$(_pmr_graphql_remaining)
+	[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=0
+	if [[ "$remaining" -lt "$threshold" ]]; then
+		_pmr_log WARN "GraphQL budget depleted (${remaining} remaining < ${threshold}); deferring merge pass to next cycle (GH#24904)"
+		return 1
+	fi
+	return 0
+}
+
 # =============================================================================
 # File-based lock (mkdir-based for bash 3.2 + macOS portability)
 # =============================================================================
@@ -316,6 +356,10 @@ cmd_run() {
 	if ! _pmr_acquire_lock; then
 		exit 0
 	fi
+	if ! _pmr_graphql_budget_allows_run; then
+		date +%s >"$PULSE_MERGE_ROUTINE_LAST_RUN" 2>/dev/null || true
+		return 0
+	fi
 
 	# Wrap merge_ready_prs_all_repos with a hard timeout ceiling (t3041, GH#21708).
 	# Whatever the underlying hang site (gh API call, flock deadlock, infinite
@@ -378,6 +422,9 @@ cmd_dry_run() {
 	_pmr_log INFO "DRY-RUN mode: merge routine (pid=$$, timeout=${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS}s)"
 	if ! _pmr_acquire_lock; then
 		exit 0
+	fi
+	if ! _pmr_graphql_budget_allows_run; then
+		return 0
 	fi
 
 	# Same timeout protection as cmd_run (t3041, GH#21708).

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -246,6 +246,12 @@ PULSE_START_EPOCH=$(date +%s)
 # resolves correctly whether the script is executed directly (bash) or sourced
 # from zsh. See GH#3931.
 SCRIPT_DIR="$(_pulse_wrapper_resolve_script_dir "${BASH_SOURCE[0]:-$0}")" || return 2>/dev/null || exit
+
+# GH#24900: PATH normalisation above restores system bins for minimal
+# launchd/MCP environments, but it must not let the real gh binary outrank the
+# aidevops gh shim. Re-prioritise the framework scripts directory once it is
+# resolved so every subprocess inherits instrumentation and budget routing.
+export PATH="${SCRIPT_DIR}:${PATH}"
 # Source shared-constants.sh BEFORE config-helper.sh so the bash 4+ re-exec
 # guard (t2087/t2176) fires at BASH_SOURCE depth 1, where the outermost caller
 # is unambiguously pulse-wrapper.sh. If config-helper.sh is sourced first and it

--- a/.agents/scripts/tests/test-issue-sync-title-dedup.sh
+++ b/.agents/scripts/tests/test-issue-sync-title-dedup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/issue-sync-reusable.yml"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_title_window_configured() {
+	if grep -q 'ISSUE_SYNC_TITLE_DEDUP_WINDOW_SECONDS' "$WORKFLOW_FILE"; then
+		print_result "title dedup window configured" 0
+	else
+		print_result "title dedup window configured" 1
+	fi
+	return 0
+}
+
+test_title_match_sets_duplicate_reason() {
+	if grep -q 'same title within' "$WORKFLOW_FILE" && grep -q 'title matches' "$WORKFLOW_FILE"; then
+		print_result "same-title duplicate path present" 0
+	else
+		print_result "same-title duplicate path present" 1
+	fi
+	return 0
+}
+
+test_title_window_not_shadowed_by_fingerprint_window() {
+	if grep -q "time_diff\" -gt \"\$TITLE_WINDOW" "$WORKFLOW_FILE" && grep -q "time_diff\" -le \"\$WINDOW" "$WORKFLOW_FILE"; then
+		print_result "title window is checked independently from fingerprint window" 0
+	else
+		print_result "title window is checked independently from fingerprint window" 1
+	fi
+	return 0
+}
+
+main() {
+	if [[ ! -f "$WORKFLOW_FILE" ]]; then
+		printf 'FATAL: workflow not found: %s\n' "$WORKFLOW_FILE" >&2
+		return 1
+	fi
+	test_title_window_configured
+	test_title_match_sets_duplicate_reason
+	test_title_window_not_shadowed_by_fingerprint_window
+	printf 'Tests run: %s\n' "$TESTS_RUN"
+	printf 'Tests failed: %s\n' "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCANNER="${TEST_SCRIPT_DIR}/../pr-review-thread-response-scanner.sh"
+SCANNER="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)/pr-review-thread-response-scanner.sh"
 TEST_ROOT=""
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -243,6 +243,19 @@ test_dispatch_launches_worker_and_writes_state() {
 	return 0
 }
 
+test_dispatch_prompt_uses_framework_script_path() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if grep -q "${SCANNER} reply" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && grep -q "${SCANNER} resolve" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
+		print_result "dispatch prompt uses framework scanner path" 0
+	else
+		print_result "dispatch prompt uses framework scanner path" 1 "prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_pr_launches_targeted_worker_with_human_opt_in() {
 	setup_test_env
 	export STUB_THREADS_MODE="human"
@@ -464,6 +477,7 @@ main() {
 	test_scan_pr_excludes_human_threads_by_default
 	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state
+	test_dispatch_prompt_uses_framework_script_path
 	test_dispatch_pr_launches_targeted_worker_with_human_opt_in
 	test_dispatch_is_idempotent_for_same_fingerprint
 	test_dispatch_skips_mixed_fingerprint_during_inflight_window

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -197,11 +197,21 @@ test_conditional_failure_falls_open_to_search() {
 	return 0
 }
 
+test_prefetch_gh_reads_are_timeout_wrapped() {
+	if grep -nE '^[[:space:]]*(gh api|gh search|[a-zA-Z0-9_]+="?\$\(gh (api|search))' "$HELPER" >/dev/null 2>&1; then
+		print_result "prefetch gh reads use timeout wrapper" 1
+	else
+		print_result "prefetch gh reads use timeout wrapper" 0
+	fi
+	return 0
+}
+
 test_unchanged_repo_uses_304_cache
 test_changed_repo_refreshes_cache
 test_conditional_failure_falls_open_to_search
 test_legacy_issue_cache_falls_open_to_search
 test_read_cache_filters_closed_issues
+test_prefetch_gh_reads_are_timeout_wrapped
 
 printf 'Tests run: %s\n' "$TESTS_RUN"
 printf 'Tests failed: %s\n' "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -15,6 +15,7 @@
 #   4. Pending/queued/expected required checks are non-terminal for CI repair
 #      routing; skipped required checks still allow the merge.
 #   5. API errors fail-closed (a bubbling gh failure must never auto-merge).
+#   6. Merge-read gh calls are routed through the timeout wrapper.
 #
 # Regression root cause: PR #19023 (GH#18787) had all required checks green
 # but statusCheckRollup contained a FAILURE entry from the post-merge
@@ -276,6 +277,15 @@ EOF
 	return 0
 }
 
+test_required_checks_gh_reads_are_timeout_wrapped() {
+	if grep -nE '^[[:space:]]*(gh api|gh pr checks|[a-zA-Z0-9_]+="?\$\(gh (api|pr checks))' "$REQUIRED_CHECKS_SCRIPT" >/dev/null 2>&1; then
+		print_result "required-check gh reads use timeout wrapper" 1
+	else
+		print_result "required-check gh reads use timeout wrapper" 0
+	fi
+	return 0
+}
+
 teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
@@ -322,6 +332,7 @@ define_function_under_test() {
 	eval_function_from_file _required_contexts_for_default_branch "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _check_required_checks_passing "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _pr_required_checks_pass "$MERGE_SCRIPT" || return 1
+	eval_function_from_file _pmrc_gh_read "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_required_pr_checks_passing_fallback "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _ruleset_required_review_count_for_default_branch "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_ruleset_required_reviews_passing "$REQUIRED_CHECKS_SCRIPT" || return 1
@@ -698,6 +709,7 @@ main() {
 	test_ruleset_review_zero_does_not_require_approval
 	test_ruleset_review_malformed_optional_does_not_fail_parse
 	test_gh_api_error_fails_closed
+	test_required_checks_gh_reads_are_timeout_wrapped
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -40,6 +40,7 @@
 #   8. setup.sh call site uses the new helper (not the generic gate)
 #   9. scheduler uses timeout-protected pulse-merge-routine
 #   10. merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false
+#   11. standalone PATH repair keeps the framework gh shim first
 
 set -uo pipefail
 
@@ -172,6 +173,13 @@ if grep -qE 'source "\$\{SCRIPT_DIR\}/pulse-fast-fail\.sh"' "$ROUTINE_FILE"; the
 else
 	fail "6: pulse-fast-fail.sh sourced (fast_fail_reset)" \
 		"missing 'source ... pulse-fast-fail.sh' line"
+fi
+
+if grep -qF "export PATH=\"\${SCRIPT_DIR}:\${PATH}\"" "$ROUTINE_FILE"; then
+	pass "6b: routine re-prioritises framework scripts in PATH"
+else
+	fail "6b: routine re-prioritises framework scripts in PATH" \
+		"missing SCRIPT_DIR PATH prepend after script-dir resolution"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-pulse-wrapper-stale-script-dir.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-stale-script-dir.sh
@@ -113,8 +113,19 @@ test_stale_script_dir_recovers_to_deployed_scripts() {
 	return 0
 }
 
+test_wrapper_reprioritises_framework_scripts_path() {
+	if grep -qF "export PATH=\"\${SCRIPT_DIR}:\${PATH}\"" "$WRAPPER_SCRIPT"; then
+		print_result "pulse wrapper re-prioritises framework scripts in PATH" 0
+	else
+		print_result "pulse wrapper re-prioritises framework scripts in PATH" 1 \
+			"missing SCRIPT_DIR PATH prepend after script-dir resolution"
+	fi
+	return 0
+}
+
 main() {
 	test_stale_script_dir_recovers_to_deployed_scripts
+	test_wrapper_reprioritises_framework_scripts_path
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -328,6 +328,7 @@ jobs:
           ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
           REPO: ${{ github.repository }}
           ISSUE_SYNC_DEDUP_WINDOW_SECONDS: '120'
+          ISSUE_SYNC_TITLE_DEDUP_WINDOW_SECONDS: '600'
         run: |
           set -euo pipefail
 
@@ -336,7 +337,8 @@ jobs:
           source __aidevops/.agents/scripts/lib/issue-fingerprint.sh
 
           WINDOW="${ISSUE_SYNC_DEDUP_WINDOW_SECONDS:-120}"
-          echo "[dedup] Checking issue #${ISSUE_NUMBER} by @${ISSUE_AUTHOR} (window: ${WINDOW}s)"
+          TITLE_WINDOW="${ISSUE_SYNC_TITLE_DEDUP_WINDOW_SECONDS:-600}"
+          echo "[dedup] Checking issue #${ISSUE_NUMBER} by @${ISSUE_AUTHOR} (fingerprint window: ${WINDOW}s, title window: ${TITLE_WINDOW}s)"
 
           # Fetch the full issue title and body via API (avoids env-var size limits
           # and injection risks from untrusted content in the event payload).
@@ -361,7 +363,9 @@ jobs:
             exit 0
           fi
 
-          since_epoch=$((new_epoch - WINDOW))
+          if ! [[ "$TITLE_WINDOW" =~ ^[0-9]+$ ]]; then TITLE_WINDOW=600; fi
+          if [[ "$TITLE_WINDOW" -lt "$WINDOW" ]]; then TITLE_WINDOW="$WINDOW"; fi
+          since_epoch=$((new_epoch - TITLE_WINDOW))
           since_iso=$(date -u -d "@${since_epoch}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 
           echo "[dedup] Fetching recent open issues by @${ISSUE_AUTHOR}..."
@@ -378,6 +382,7 @@ jobs:
           echo "[dedup] Found ${cand_count} open issue(s) by @${ISSUE_AUTHOR}"
 
           canonical_num=""
+          canonical_reason=""
           if [[ "$cand_count" -eq 0 ]]; then
             echo "[dedup] No recent open issues found — issue is unique"
             exit 0
@@ -397,7 +402,7 @@ jobs:
             # Only close the new issue when the candidate is strictly older and
             # within the dedup window. Positive time_diff = candidate is older.
             time_diff=$((new_epoch - cand_epoch))
-            if [[ "$time_diff" -le 0 ]] || [[ "$time_diff" -gt "$WINDOW" ]]; then
+            if [[ "$time_diff" -le 0 ]] || [[ "$time_diff" -gt "$TITLE_WINDOW" ]]; then
               echo "[dedup] Issue #${cand_num} not a prior duplicate (gap: ${time_diff}s) — skipping"
               continue
             fi
@@ -407,9 +412,22 @@ jobs:
 
             cand_fingerprint=$(_compute_issue_fingerprint "$cand_title" "$cand_body")
 
-            if [[ "$cand_fingerprint" == "$new_fingerprint" ]]; then
+            if [[ "$time_diff" -le "$WINDOW" ]] && [[ "$cand_fingerprint" == "$new_fingerprint" ]]; then
               canonical_num="$cand_num"
+              canonical_reason="identical content"
               echo "[dedup] Match: #${ISSUE_NUMBER} fingerprint matches #${canonical_num} (${time_diff}s apart)"
+              break
+            fi
+
+            # GH#24901/#24904: smaller-model retry loops can file the same
+            # titled report several times with slight body/footer drift that
+            # defeats exact fingerprinting. Exact-title, same-author issues
+            # opened inside TITLE_WINDOW are duplicates unless the title is
+            # intentionally reused much later for a fresh reproduction.
+            if [[ "$cand_title" == "$ISSUE_TITLE" ]] && [[ "$time_diff" -le "$TITLE_WINDOW" ]]; then
+              canonical_num="$cand_num"
+              canonical_reason="same title within ${TITLE_WINDOW}s"
+              echo "[dedup] Match: #${ISSUE_NUMBER} title matches #${canonical_num} (${time_diff}s apart)"
               break
             fi
           done
@@ -419,7 +437,7 @@ jobs:
             exit 0
           fi
 
-          echo "[dedup] Closing #${ISSUE_NUMBER} as duplicate of #${canonical_num}"
+          echo "[dedup] Closing #${ISSUE_NUMBER} as duplicate of #${canonical_num} (${canonical_reason})"
 
           # Ensure duplicate label exists before applying it
           gh label create "duplicate" --color "cfd3d7" \
@@ -427,7 +445,7 @@ jobs:
             --repo "$REPO" --force 2>/dev/null || true
 
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-            --body "This issue appears to be a duplicate of #${canonical_num}, filed within ${WINDOW}s with identical content. Closing automatically — please continue the discussion in #${canonical_num}.
+            --body "This issue appears to be a duplicate of #${canonical_num} (${canonical_reason:-duplicate signal}). Closing automatically — please continue the discussion in #${canonical_num}.
 
           <!-- issue-dedup:auto-closed -->"
 


### PR DESCRIPTION
## Summary

- Keep aidevops script directory first in pulse PATH normalization so the `gh` shim remains active in pulse and merge-routine subprocesses.
- Wrap raw GitHub read calls in batch prefetch and merge required-check paths with timeout-aware helpers.
- Add standalone GraphQL budget gating for the fast merge routine.
- Use runtime-stable review-thread scanner prompt paths and preserve fail-loud scan diagnostics for GraphQL/fetch failures.
- Extend issue dedupe to catch same-author, same-title retry duplicates within a bounded window.

Resolves #24900
Resolves #24901
Resolves #24904
Resolves #24906
Resolves #24908

## Testing

- `bash .agents/scripts/tests/test-pr-review-thread-response-scanner.sh`
- `bash .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh`
- `bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-stale-script-dir.sh`
- `bash .agents/scripts/tests/test-issue-sync-title-dedup.sh`
- `shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/pulse-batch-prefetch-helper.sh .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/pulse-merge-routine.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh .agents/scripts/tests/test-pulse-wrapper-stale-script-dir.sh .agents/scripts/tests/test-issue-sync-title-dedup.sh`
- `.agents/scripts/linters-local.sh`

## Decisions

- Preserved existing fail-closed merge semantics; budget depletion defers standalone merge passes instead of weakening gates.
- Used small local wrapper functions around `_gh_with_timeout read` to preserve existing stdout/stderr handling.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.85 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 8h 19m and 1,282,021 tokens on this with the user in an interactive session.
