### PR TITLE
fix: retry dispatch claim comment posts

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -268,14 +268,36 @@ _post_claim() {
 ${machine_readable_part}
 <!-- ops:end -->"
 
-	local comment_id
-	comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--method POST \
-		--field body="$body" \
-		--jq '.id' 2>/dev/null) || {
-		echo "Error: failed to post claim comment on #${issue_number} in ${repo_slug}" >&2
+	local attempts="${DISPATCH_CLAIM_POST_ATTEMPTS:-3}"
+	local retry_delay="${DISPATCH_CLAIM_POST_RETRY_DELAY:-2}"
+	if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+		attempts=3
+	fi
+	if ! [[ "$retry_delay" =~ ^[0-9]+$ ]]; then
+		retry_delay=2
+	fi
+
+	local comment_id="" attempt=1 post_err_file="" post_error_summary=""
+	post_err_file=$(mktemp 2>/dev/null || printf '%s' "/tmp/aidevops-claim-post-error.$$" )
+	while [[ "$attempt" -le "$attempts" ]]; do
+		comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+			--method POST \
+			--field body="$body" \
+			--jq '.id' 2>"$post_err_file") && break
+
+		post_error_summary=$(tr '\n' ' ' <"$post_err_file" | cut -c1-240 2>/dev/null || printf '%s' "unknown")
+		if [[ "$attempt" -lt "$attempts" ]]; then
+			echo "Warning: claim comment POST failed on #${issue_number} in ${repo_slug} (attempt ${attempt}/${attempts}): ${post_error_summary:-unknown}; retrying" >&2
+			sleep "$retry_delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+	rm -f "$post_err_file" 2>/dev/null || true
+
+	if [[ -z "$comment_id" ]]; then
+		echo "Error: failed to post claim comment on #${issue_number} in ${repo_slug} after ${attempts} attempt(s): ${post_error_summary:-unknown}" >&2
 		return 1
-	}
+	fi
 
 	if [[ -z "$comment_id" || "$comment_id" == "null" ]]; then
 		echo "Error: claim comment posted but no ID returned" >&2
@@ -1278,6 +1300,8 @@ Environment:
   DISPATCH_CLAIM_WINDOW    Consensus window in seconds (default: 8)
   DISPATCH_CLAIM_MAX_AGE   Max age of claim comments in seconds (default: 1800 = 30 min)
   DISPATCH_CLAIM_ORPHAN_GRACE  Claim-only pre-launch grace in seconds (default: 120)
+  DISPATCH_CLAIM_POST_ATTEMPTS  Claim comment POST attempts (default: 3)
+  DISPATCH_CLAIM_POST_RETRY_DELAY  Seconds between claim POST attempts (default: 2)
 
 Protocol:
   1. Runner posts plain-text claim comment with unique nonce

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -79,6 +79,7 @@ set -euo pipefail
 local_state_dir="${MOCK_GH_STATE_DIR:?}"
 post_body_file="${local_state_dir}/post_body.txt"
 delete_log_file="${local_state_dir}/delete_ids.log"
+post_attempts_file="${local_state_dir}/post_attempts.txt"
 
 if [[ "${1:-}" != "api" ]]; then
 	exit 1
@@ -118,6 +119,16 @@ if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
 	done
 
 	if [[ "$method" == "POST" ]]; then
+		post_attempts=0
+		if [[ -f "$post_attempts_file" ]]; then
+			post_attempts=$(<"$post_attempts_file")
+		fi
+		post_attempts=$((post_attempts + 1))
+		printf '%s' "$post_attempts" >"$post_attempts_file"
+		if [[ "${MOCK_POST_FAILS:-0}" =~ ^[0-9]+$ && "$post_attempts" -le "${MOCK_POST_FAILS:-0}" ]]; then
+			printf 'mock transient claim post failure %s\n' "$post_attempts" >&2
+			exit 1
+		fi
 		printf '%s' "$body" >"$post_body_file"
 		printf '999\n'
 		exit 0
@@ -536,6 +547,52 @@ test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment() {
 		print_result "claim comments are ops-wrapped" 0
 	else
 		print_result "claim comments are ops-wrapped" 1 "body: ${post_body:-none}"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+#######################################
+# Test: transient claim comment POST failures are retried before failing.
+#######################################
+test_claim_retries_transient_post_failure() {
+	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts
+	tmp_dir=$(mktemp -d)
+	mock_path=$(create_mock_gh "$tmp_dir")
+	old_created_at="$(iso_seconds_ago 600)"
+	claim_created_at="$(iso_seconds_ago 1)"
+
+	set +e
+	output=$(PATH="${mock_path}:$PATH" \
+		MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" \
+		MOCK_NEW_CLAIM_CREATED_AT="$claim_created_at" \
+		MOCK_OLD_CLAIM_RUNNER="other-runner" \
+		MOCK_POST_FAILS=1 \
+		DISPATCH_CLAIM_WINDOW=0 \
+		DISPATCH_CLAIM_MAX_AGE=300 \
+		DISPATCH_CLAIM_POST_ATTEMPTS=2 \
+		DISPATCH_CLAIM_POST_RETRY_DELAY=0 \
+		OPENCODE_VERSION=1.14.33 \
+		"$CLAIM_HELPER" claim 42 owner/repo mockrunner 2>&1)
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "claim retries transient POST failure" 0
+	else
+		print_result "claim retries transient POST failure" 1 "got exit $exit_code output: $output"
+	fi
+
+	attempts=0
+	if [[ -f "${tmp_dir}/post_attempts.txt" ]]; then
+		attempts=$(<"${tmp_dir}/post_attempts.txt")
+	fi
+	if [[ "$attempts" -eq 2 ]]; then
+		print_result "claim POST retry count recorded" 0
+	else
+		print_result "claim POST retry count recorded" 1 "attempts=${attempts} output: $output"
 	fi
 
 	rm -rf "$tmp_dir"
@@ -1368,6 +1425,7 @@ main() {
 	test_claim_reads_lowercase_paginated_claim_marker
 	test_claim_ignore_filter_preserves_self_claim
 	test_claim_structured_override_preserves_self_claim
+	test_claim_retries_transient_post_failure
 	test_claim_marks_stale_worker_takeover
 	test_claim_marks_paginated_stale_worker_takeover
 	test_claim_marks_stale_worker_takeover_for_ops_wrapped_dispatch_comment


### PR DESCRIPTION
Resolves #24972

## Summary

- Retry transient dispatch claim comment POST failures before the pulse dedup layer fails closed.
- Preserve the existing duplicate-worker safety invariant: persistent claim API errors still block dispatch for the cycle.
- Add regression coverage for a one-shot transient POST failure.

## Root cause

Pulse was finding quality-debt issues (for example #24967/#24968), but worker launch stopped at the cross-runner claim gate after transient GitHub comment POST failures. Because claim errors intentionally fail closed in `pulse-dispatch-dedup-layers.sh`, those issues stayed `status:available` with no worker PR. The systemic gap was that `dispatch-claim-helper.sh` treated a single failed POST as terminal, so transient API/comment failures could strand the quality-debt queue for the cycle.

## Testing

- `shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh`
- `.agents/scripts/tests/test-dispatch-claim-helper.sh`
- `.agents/scripts/tests/test-no-worker-process-fix.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Self-assessed. This is a shell helper reliability fix covered by offline unit tests and ShellCheck; no external runtime service beyond GitHub API semantics is required.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.86 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 14m and 149,924 tokens on this with the user in an interactive session.

