### PR TITLE
fix: make pulse search prefetch last-resort

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -131,6 +131,20 @@ AIDEVOPS_GH_WRITE_TIMEOUT=45
 # Env var PULSE_EVENTS_TICKLE_ENABLED takes precedence if already set.
 PULSE_EVENTS_TICKLE_ENABLED=1
 
+# ── Pulse batch Search API last-resort mode ───────────────────────────────────
+#
+# Keep `gh search issues/prs` out of the normal pulse path. GitHub Search has a
+# visible quota, but secondary-limit/abuse heuristics can still trip on bursty
+# search fanout even when primary budgets remain. Conditional REST and per-slug
+# REST are acceptable for pulse cache refresh because consumers already tolerate
+# fresh-enough cached issue/PR state and exact views fetch lazily when needed.
+#
+# Set to 0 only for a bounded diagnostic run where owner-wide search semantics
+# are required and secondary cooldown is known clear.
+#
+# Env var PULSE_BATCH_SEARCH_LAST_RESORT takes precedence if already set.
+: "${PULSE_BATCH_SEARCH_LAST_RESORT:=1}"
+
 # ── GitHub Actions runner queue saturation (t3211, GH#21942) ──────────────────
 #
 # Detects when the GitHub Actions runner pool for a repo is saturated — many

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -2,15 +2,16 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # =============================================================================
-# pulse-batch-prefetch-helper.sh — Batch prefetch via org-level gh search
+# pulse-batch-prefetch-helper.sh — Batch prefetch with search as last resort
 # =============================================================================
-# Groups pulse-enabled repos by owner and runs one `gh search issues` +
-# one `gh search prs` per owner, splitting results into per-slug cache
-# files. This is L3 in the layered cache hierarchy:
+# Groups pulse-enabled repos by owner and refreshes per-slug cache files. Search
+# fanout is deliberately a last resort because GitHub secondary-limit heuristics
+# penalize bursty search patterns more aggressively than ordinary cached REST
+# reads. This is L3 in the layered cache hierarchy:
 #
 #   L1: State fingerprint (t2041) — 0 API calls, local hash comparison
 #   L2: Idle skip (t2098)         — 0 API calls, reads L4 cache
-#   L3: Batch prefetch (THIS)     — 2 calls per owner via Search API
+#   L3: Batch prefetch (THIS)     — conditional REST first, Search only by opt-in
 #   L4: Delta prefetch (GH#15286) — 2 calls per repo for changes since last fetch
 #   L5: Per-PR enrichment         — 1 call per repo with open PRs (GraphQL)
 #
@@ -23,8 +24,9 @@
 # Feature flag: PULSE_BATCH_PREFETCH_ENABLED (default: 1)
 # When 0, all subcommands exit 0 immediately (no-op).
 #
-# GH#19963: Reduces GraphQL consumption by using the separate Search API
-# rate-limit bucket (30/min = 1800/hr, currently near 0 usage).
+# GH#19963: Originally reduced GraphQL consumption by using the separate Search
+# API bucket. Secondary-limit incidents showed that raw search bursts can still
+# cascade; the default is now REST/cache-first with Search available by opt-in.
 #
 # Part of aidevops framework: https://aidevops.sh
 # =============================================================================
@@ -99,6 +101,7 @@ PULSE_PREFETCH_FULL_SWEEP_INTERVAL="${PULSE_PREFETCH_FULL_SWEEP_INTERVAL:-14400}
 BATCH_SEARCH_LIMIT="${PULSE_BATCH_SEARCH_LIMIT:-200}"
 LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse-wrapper.log}"
 PULSE_BATCH_CONDITIONAL_REST_ENABLED="${PULSE_BATCH_CONDITIONAL_REST_ENABLED:-1}"
+PULSE_BATCH_SEARCH_LAST_RESORT="${PULSE_BATCH_SEARCH_LAST_RESORT:-1}"
 
 # String constants to avoid repeated-literal ratchet violations
 _KIND_ISSUES="issues"
@@ -457,6 +460,31 @@ _write_per_slug_caches() {
 # Subcommand: refresh — per-owner fetch helpers
 # =============================================================================
 
+_search_should_route_to_rest() {
+	local graphql_remaining="${1:-}"
+	if [[ "${PULSE_BATCH_SEARCH_LAST_RESORT:-1}" == "1" ]]; then
+		return 0
+	fi
+	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
+		return 0
+	fi
+	if declare -F _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
+		_gh_secondary_cooldown_preflight read >/dev/null 2>&1 || return 0
+	fi
+	return 1
+}
+
+_route_owner_search_to_rest() {
+	local kind="$1"
+	local owner="$2"
+	local slugs="${3:-}"
+	local caller="pulse_batch_prefetch_search_${kind}_fallback"
+	_log "search last-resort active — routing ${kind} prefetch for owner=${owner} through per-repo REST"
+	declare -F gh_record_call >/dev/null && gh_record_call search-rest "$caller" || true
+	_prefetch_rest_per_slug "$kind" "$slugs"
+	return 0
+}
+
 # Fetch and cache issues for a single owner.
 # Sets _OWNER_SEARCH_CALLS, _OWNER_CACHE_WRITES, _OWNER_ERRORS (Bash 3.2 namerefs workaround)
 # Arguments: $1=owner  $2=slugs (comma-separated owner/repo list for REST fallback)
@@ -468,6 +496,10 @@ _refresh_owner_issues() {
 	local graphql_remaining="${3:-}"
 	if _conditional_rest_per_slug issues "$slugs"; then
 		_log "conditional REST issues complete for owner=${owner} — skipped search"
+		return 0
+	fi
+	if _search_should_route_to_rest "$graphql_remaining"; then
+		_route_owner_search_to_rest issues "$owner" "$slugs"
 		return 0
 	fi
 	# Proactive REST fallback (t2902): if GraphQL is at/below the fallback
@@ -531,6 +563,10 @@ _refresh_owner_prs() {
 	local graphql_remaining="${3:-}"
 	if _conditional_rest_per_slug prs "$slugs"; then
 		_log "conditional REST prs complete for owner=${owner} — skipped search"
+		return 0
+	fi
+	if _search_should_route_to_rest "$graphql_remaining"; then
+		_route_owner_search_to_rest prs "$owner" "$slugs"
 		return 0
 	fi
 	# Proactive REST fallback (t2902): same pattern as _refresh_owner_issues.
@@ -913,6 +949,7 @@ main() {
 		echo "  PULSE_BATCH_PREFETCH_ENABLED     Enable/disable (default: 1)"
 		echo "  PULSE_BATCH_PREFETCH_CACHE_DIR   Cache directory"
 		echo "  PULSE_BATCH_SEARCH_LIMIT         Max results per search call (default: 200)"
+		echo "  PULSE_BATCH_SEARCH_LAST_RESORT   Route owner search through REST/cache by default (default: 1)"
 		return 0
 		;;
 	*)

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -1651,6 +1651,52 @@ _api_budget_cache_dir_state() {
 	return 0
 }
 
+_api_budget_cooldown_file() {
+	printf '%s' "${PULSE_DIAGNOSE_GH_SECONDARY_COOLDOWN_FILE:-${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE:-${HOME}/.aidevops/cache/gh-secondary-cooldown.json}}"
+	return 0
+}
+
+_api_budget_cooldown_events_file() {
+	printf '%s' "${PULSE_DIAGNOSE_GH_SECONDARY_COOLDOWN_EVENTS_FILE:-${AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE:-${HOME}/.aidevops/cache/gh-cooldown-events.jsonl}}"
+	return 0
+}
+
+_api_budget_cooldown_event_count() {
+	local events_file="$1"
+	local count="0"
+	if [[ -f "$events_file" ]]; then
+		count=$(wc -l <"$events_file" 2>/dev/null | tr -d ' ' || printf '0')
+	fi
+	[[ "$count" =~ ^[0-9]+$ ]] || count="0"
+	printf '%s' "$count"
+	return 0
+}
+
+_api_budget_cooldown_summary_csv() {
+	local cooldown_file=""
+	local events_file=""
+	local event_count="0"
+	local now="0"
+	cooldown_file="$(_api_budget_cooldown_file)"
+	events_file="$(_api_budget_cooldown_events_file)"
+	event_count="$(_api_budget_cooldown_event_count "$events_file")"
+	if [[ ! -f "$cooldown_file" ]]; then
+		printf 'active=no expires_in_s=0 reason=none endpoint_family=none body=none recent_secondary_5m=0 cooldown_events=%s' "$event_count"
+		return 0
+	fi
+	now=$(date +%s 2>/dev/null || printf '0')
+	if command -v jq >/dev/null 2>&1; then
+		jq -r --argjson now "$now" --arg events "$event_count" '
+			(.expires_at // 0) as $expires |
+			($expires - $now) as $remaining |
+			"active=\(if $remaining > 0 then "yes" else "no" end) expires_in_s=\(if $remaining > 0 then $remaining else 0 end) reason=\(.reason // "unknown") endpoint_family=\(.diagnostic.endpoint_family // "unknown") body=\(.diagnostic.body_message_class // .diagnostic.body_classification // "unknown") recent_secondary_5m=\(.diagnostic.recent_secondary_count_5m // 0) cooldown_events=\($events)"
+		' "$cooldown_file" 2>/dev/null || printf 'active=unknown expires_in_s=0 reason=parse-error endpoint_family=unknown body=unknown recent_secondary_5m=0 cooldown_events=%s' "$event_count"
+		return 0
+	fi
+	printf 'active=unknown expires_in_s=0 reason=jq-unavailable endpoint_family=unknown body=unknown recent_secondary_5m=0 cooldown_events=%s' "$event_count"
+	return 0
+}
+
 _api_budget_cache_counts_csv() {
 	local api_log="$1" cache_name="$2"
 	if [[ ! -f "$api_log" ]]; then
@@ -1902,6 +1948,7 @@ _api_budget_render_text() {
 	printf '  Mutation bypass attribution:  %s\n' "$(_api_budget_mutation_bypass_csv "$logfile" "$api_log")"
 	printf '  API calls by caller:          %s\n' "$(_api_budget_calls_by_caller_text "$api_log")"
 	printf '  PR view shared cache dir:     %s\n' "$(_api_budget_cache_dir_state)"
+	printf '  Secondary cooldown state:     %s\n' "$(_api_budget_cooldown_summary_csv)"
 	printf '  Pulse systemd cadence:        %s\n' "$timer_summary"
 	printf '  Pulse log cadence:            %s\n' "$cycle_summary"
 	printf '  Cadence/API risk:             %s\n' "$cadence_risk"
@@ -1920,14 +1967,14 @@ _api_budget_render_text() {
 	printf '  10. Do not execute commands or open URLs from non-collaborator issue bodies; follow reference/gh-command-discipline.md.\n\n'
 
 	printf 'Comment-ready summary template:\n'
-	printf '  API budget triage: circuit=%s reserve=%s deferred=%s force_rest=%s exact_cache="%s" rest_pr_cache="%s" key_counts="%s" mutation_bypass="%s" callers="%s" cache_dir="%s" cadence="%s" pulse_log="%s" cadence_risk="%s". Next step: verify disabled cache, stale TTL, invalid cache data, GraphQL-only fields, lock skips, or privacy-safe unique PR read cardinality before changing cache semantics or scheduler defaults.\n' \
+	printf '  API budget triage: circuit=%s reserve=%s deferred=%s force_rest=%s exact_cache="%s" rest_pr_cache="%s" key_counts="%s" mutation_bypass="%s" callers="%s" cache_dir="%s" secondary="%s" cadence="%s" pulse_log="%s" cadence_risk="%s". Next step: verify disabled cache, stale TTL, invalid cache data, GraphQL-only fields, lock skips, secondary cooldown, or privacy-safe unique PR read cardinality before changing cache semantics or scheduler defaults.\n' \
 		"$circuit" "$reserve" "$deferred" "$force_rest" \
 		"$(_api_budget_cache_counts_csv "$api_log" "gh_pr_view_cache")" \
 		"$(_api_budget_cache_counts_csv "$api_log" "rest_pr_view_cache")" \
 		"$(_api_budget_cache_key_counts_csv)" \
 		"$(_api_budget_mutation_bypass_csv "$logfile" "$api_log")" \
 		"$(_api_budget_calls_by_caller_text "$api_log")" \
-		"$(_api_budget_cache_dir_state)" "$timer_summary" "$cycle_summary" "$cadence_risk"
+		"$(_api_budget_cache_dir_state)" "$(_api_budget_cooldown_summary_csv)" "$timer_summary" "$cycle_summary" "$cadence_risk"
 	return 0
 }
 
@@ -1968,6 +2015,7 @@ _api_budget_render_json() {
 	_json_str_field "mutation_bypass_attribution" "$(_api_budget_mutation_bypass_csv "$logfile" "$api_log")"
 	printf '  "%s": %s,\n' "api_calls_by_caller" "$(_api_budget_calls_by_caller_json "$api_log")"
 	_json_str_field "pr_view_shared_cache_dir" "$(_api_budget_cache_dir_state)"
+	_json_str_field "secondary_cooldown_state" "$(_api_budget_cooldown_summary_csv)"
 	_json_str_field "pulse_systemd_cadence" "$timer_summary"
 	_json_str_field "pulse_log_cadence" "$cycle_summary"
 	_json_str_field "cadence_api_risk" "$cadence_risk"

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -32,6 +32,7 @@ setup_env() {
 	export LOGFILE="$TEST_ROOT/pulse.log"
 	export PULSE_EVENTS_TICKLE_ENABLED=0
 	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=999999999
+	export PULSE_BATCH_SEARCH_LAST_RESORT=1
 	unset AIDEVOPS_GH_FORCE_REST_READS
 	unset AIDEVOPS_GH_REST_FIRST_READS
 	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
@@ -148,17 +149,17 @@ test_changed_repo_refreshes_cache() {
 	return 0
 }
 
-test_legacy_issue_cache_falls_open_to_search() {
+test_legacy_issue_cache_avoids_search_by_default() {
 	setup_env
 	seed_legacy_issue_cache
 	write_gh_stub not_modified
 	"$HELPER" refresh >/dev/null
 	local issue_num
 	issue_num=$(jq -r '.items[0].number' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
-	if grep -q 'search issues' "$TEST_ROOT/gh-calls.log" && [[ "$issue_num" == "5" ]]; then
-		print_result "legacy issue cache without state falls open to search refresh" 0
+	if ! grep -q 'search issues' "$TEST_ROOT/gh-calls.log" && [[ "$issue_num" == "1" ]]; then
+		print_result "legacy issue cache without state avoids search by default" 0
 	else
-		print_result "legacy issue cache without state falls open to search refresh" 1
+		print_result "legacy issue cache without state avoids search by default" 1
 	fi
 	teardown_env
 	return 0
@@ -183,15 +184,31 @@ JSON
 	return 0
 }
 
-test_conditional_failure_falls_open_to_search() {
+test_conditional_failure_routes_to_rest_by_default() {
 	setup_env
 	seed_cache
 	write_gh_stub fail
 	"$HELPER" refresh >/dev/null
-	if grep -q 'search issues' "$TEST_ROOT/gh-calls.log" && grep -q 'search prs' "$TEST_ROOT/gh-calls.log"; then
-		print_result "conditional failure falls open to owner search" 0
+	if ! grep -q 'search issues' "$TEST_ROOT/gh-calls.log" && ! grep -q 'search prs' "$TEST_ROOT/gh-calls.log"; then
+		print_result "conditional failure routes to REST instead of owner search" 0
 	else
-		print_result "conditional failure falls open to owner search" 1
+		print_result "conditional failure routes to REST instead of owner search" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_search_opt_in_preserves_owner_search() {
+	setup_env
+	seed_cache
+	write_gh_stub fail
+	export PULSE_BATCH_SEARCH_LAST_RESORT=0
+	export AIDEVOPS_GH_READ_RAMP_ENABLED=0
+	"$HELPER" refresh >/dev/null
+	if grep -q 'search issues' "$TEST_ROOT/gh-calls.log" && grep -q 'search prs' "$TEST_ROOT/gh-calls.log"; then
+		print_result "search opt-in preserves owner search fallback" 0
+	else
+		print_result "search opt-in preserves owner search fallback" 1
 	fi
 	teardown_env
 	return 0
@@ -208,8 +225,9 @@ test_prefetch_gh_reads_are_timeout_wrapped() {
 
 test_unchanged_repo_uses_304_cache
 test_changed_repo_refreshes_cache
-test_conditional_failure_falls_open_to_search
-test_legacy_issue_cache_falls_open_to_search
+test_conditional_failure_routes_to_rest_by_default
+test_search_opt_in_preserves_owner_search
+test_legacy_issue_cache_avoids_search_by_default
 test_read_cache_filters_closed_issues
 test_prefetch_gh_reads_are_timeout_wrapped
 

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -83,6 +83,8 @@ FIXTURE_METRICS="${TMPDIR_TEST}/headless-runtime-metrics.jsonl"
 FIXTURE_STATS="${TMPDIR_TEST}/pulse-stats.json"
 FIXTURE_GH_API_LOG="${TMPDIR_TEST}/gh-api-calls.log"
 FIXTURE_TIMER="${TMPDIR_TEST}/aidevops-supervisor-pulse.timer"
+FIXTURE_GH_COOLDOWN="${TMPDIR_TEST}/gh-secondary-cooldown.json"
+FIXTURE_GH_COOLDOWN_EVENTS="${TMPDIR_TEST}/gh-cooldown-events.jsonl"
 
 # Create fixture pulse.log with 3+ distinct rule outcomes:
 # 1. PR #20329: escalated by dirty-pr-sweep (notify), then admin-bypass merge
@@ -146,6 +148,15 @@ cat > "$FIXTURE_GH_API_LOG" <<'GHAPILOG'
 1700000012	pulse-wrapper.sh	graphql	gh-pat	graphql	graphql-selected	1200
 1700000013	_rest_pr_view	rest	gh-pat	rest-core	rest-core-selected	4987
 GHAPILOG
+
+cat > "$FIXTURE_GH_COOLDOWN" <<'COOLDOWN'
+{"reason":"github-secondary-rate-limit","expires_at":9999999999,"diagnostic":{"endpoint_family":"rest-search","body_message_class":"secondary-rate-limit","recent_secondary_count_5m":2}}
+COOLDOWN
+
+cat > "$FIXTURE_GH_COOLDOWN_EVENTS" <<'COOLDOWNEVENTS'
+{"timestamp":1700000014,"body_message_class":"secondary-rate-limit"}
+{"timestamp":1700000015,"body_message_class":"abuse-detection"}
+COOLDOWNEVENTS
 
 # Also create a rotated log with older PR #20329 entries
 cat > "${TMPDIR_TEST}/pulse.log.1" <<'ROTATED'
@@ -530,6 +541,8 @@ printf '\nTest 21: api-budget compact sanitized summary\n'
 output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
 	PULSE_DIAGNOSE_STATS_FILE="$FIXTURE_STATS" \
 	PULSE_DIAGNOSE_GH_API_LOG="$FIXTURE_GH_API_LOG" \
+	PULSE_DIAGNOSE_GH_SECONDARY_COOLDOWN_FILE="$FIXTURE_GH_COOLDOWN" \
+	PULSE_DIAGNOSE_GH_SECONDARY_COOLDOWN_EVENTS_FILE="$FIXTURE_GH_COOLDOWN_EVENTS" \
 	PULSE_DIAGNOSE_SYSTEMD_TIMER_FILE="$FIXTURE_TIMER" \
 	"$HELPER" api-budget 2>&1) || true
 
@@ -541,6 +554,8 @@ assert_contains "api-budget shows REST cache decisions" "_rest_pr_view repo#PR c
 assert_contains "api-budget shows cache key cardinality" "Cache key cardinality:" "$output"
 assert_contains "api-budget shows mutation bypass attribution" "Mutation bypass attribution:  bypass_disabled_total=2 expected_mutation_sensitive_lower_bound=1 unexplained_lower_bound=1 attribution=limited_by_log_schema" "$output"
 assert_contains "api-budget shows API calls by caller" "API calls by caller:" "$output"
+assert_contains "api-budget shows secondary cooldown state" "Secondary cooldown state:     active=yes" "$output"
+assert_contains "api-budget shows secondary cooldown class" "body=secondary-rate-limit" "$output"
 assert_contains "api-budget shows systemd cadence" "Pulse systemd cadence:        source=systemd_user_timer present=yes configured_interval=180s on_active=10s" "$output"
 assert_contains "api-budget shows log cadence" "Pulse log cadence:            cycles=4 lock_skips=0 cache_enabled_cycles=1" "$output"
 assert_contains "api-budget shows cadence risk" "Cadence/API risk:             risk=watch reason=fast_timer_detected_without_lock_skip_evidence" "$output"
@@ -554,6 +569,8 @@ printf '\nTest 22: api-budget --json counters\n'
 output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
 	PULSE_DIAGNOSE_STATS_FILE="$FIXTURE_STATS" \
 	PULSE_DIAGNOSE_GH_API_LOG="$FIXTURE_GH_API_LOG" \
+	PULSE_DIAGNOSE_GH_SECONDARY_COOLDOWN_FILE="$FIXTURE_GH_COOLDOWN" \
+	PULSE_DIAGNOSE_GH_SECONDARY_COOLDOWN_EVENTS_FILE="$FIXTURE_GH_COOLDOWN_EVENTS" \
 	PULSE_DIAGNOSE_SYSTEMD_TIMER_FILE="$FIXTURE_TIMER" \
 	"$HELPER" api-budget --json 2>&1) || true
 
@@ -570,6 +587,8 @@ if command -v jq >/dev/null 2>&1; then
 	assert_contains "JSON api-budget cadence" "on_active=10s" "$json_cadence"
 	json_risk=$(echo "$output" | jq -r '.cadence_api_risk' 2>/dev/null || echo "")
 	assert_contains "JSON api-budget cadence risk" "risk=watch" "$json_risk"
+	json_cooldown=$(echo "$output" | jq -r '.secondary_cooldown_state' 2>/dev/null || echo "")
+	assert_contains "JSON api-budget secondary cooldown" "active=yes" "$json_cooldown"
 fi
 
 # =============================================================================


### PR DESCRIPTION
Resolves #24978

## Summary
- make pulse batch prefetch route owner search fallback through per-repo REST/cache by default
- keep `gh search issues/prs` available only via explicit `PULSE_BATCH_SEARCH_LAST_RESORT=0` opt-in plus existing cooldown/ramp guards
- add sanitized secondary cooldown state to `pulse-diagnose-helper.sh api-budget` text and JSON output

## Verification
- `.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh` — 7/7 passed
- `.agents/scripts/tests/test-pulse-diagnose-helper.sh` — 86/86 passed
- `shellcheck .agents/scripts/pulse-batch-prefetch-helper.sh .agents/scripts/pulse-diagnose-helper.sh .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh .agents/scripts/tests/test-pulse-diagnose-helper.sh` — passed
- `.agents/scripts/linters-local.sh` — ALL LOCAL CHECKS PASSED

## Notes
- Search fallback remains available for bounded diagnostics by setting `PULSE_BATCH_SEARCH_LAST_RESORT=0` when secondary cooldown is known clear.
- API-budget output remains sanitized: no repo slugs, local paths, raw log tails, or private issue text.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.87 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 43m and 305,398 tokens on this with the user in an interactive session.