### PR TITLE
fix: derive missing gh shim repo role

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -276,6 +276,8 @@ _shim_repo_role() {
 	local repo_slug="$1"
 	local repos_json="${AIDEVOPS_REPOS_JSON:-${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}}"
 	local explicit_role=""
+	local current_user=""
+	local slug_owner=""
 	if [[ -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
 		explicit_role=$(jq -r --arg slug "$repo_slug" 'first(.initialized_repos[]? | select(.slug == $slug) | .role) // ""' "$repos_json" 2>/dev/null || true)
 		case "$explicit_role" in
@@ -284,6 +286,16 @@ _shim_repo_role() {
 			return 0
 			;;
 		esac
+	fi
+	# Match pulse/repo metadata semantics: omitted role is derived from the
+	# authenticated user and slug owner, then fail-closed to contributor.
+	if [[ -n "$repo_slug" && "$repo_slug" == */* && -n "${REAL_GH:-}" ]]; then
+		slug_owner="${repo_slug%%/*}"
+		current_user=$("$REAL_GH" api user --jq '.login' 2>/dev/null || true)
+		if [[ -n "$current_user" && "$slug_owner" == "$current_user" ]]; then
+			printf 'maintainer\n'
+			return 0
+		fi
 	fi
 	printf 'contributor\n'
 	return 0

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -71,6 +71,10 @@ mkdir -p "$TMP/bin"
 cat >"$TMP/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 # Stub gh that logs argv
+if [[ "$1" == "api" && "$2" == "user" ]]; then
+	printf 'managed\n'
+	exit 0
+fi
 : >"$STUB_GH_LOG"
 for arg in "$@"; do
 	printf '%s\n' "$arg" >>"$STUB_GH_LOG"
@@ -570,6 +574,31 @@ if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
 	_pass "headless write to maintainer-managed repo proceeds normally"
 else
 	_fail "maintainer repo headless write" "argv: $argv"
+fi
+
+repos_json_missing_role="$TMP/repos-missing-role.json"
+printf '{"initialized_repos":[{"slug":"managed/repo","maintainer":"managed","pulse":true}]}' >"$repos_json_missing_role"
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json_missing_role" "$SHIM_RUN" api /repos/managed/repo/issues/789/comments -X POST -f body="managed" 2>"$TMP/guard-api-missing-role.err"
+argv=$(_read_argv)
+if [[ "$argv" == *$'api\n/repos/managed/repo/issues/789/comments'* ]]; then
+	_pass "omitted role on owned managed repo is derived as maintainer"
+else
+	_fail "missing role maintainer fallback" "argv: $argv err: $(cat "$TMP/guard-api-missing-role.err" 2>/dev/null || true)"
+fi
+
+repos_json_contributor="$TMP/repos-contributor-role.json"
+printf '{"initialized_repos":[{"slug":"managed/repo","role":"contributor","maintainer":"managed","pulse":true}]}' >"$repos_json_contributor"
+_reset_log
+if AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json_contributor" "$SHIM_RUN" api /repos/managed/repo/issues/789/comments -X POST -f body="managed" 2>"$TMP/guard-api-explicit-contributor.err"; then
+	_fail "explicit contributor role overrides owner fallback" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api-explicit-contributor.err"; then
+		_pass "explicit contributor role remains blocked for owned slug"
+	else
+		_fail "explicit contributor role guard" "argv: $argv err: $(cat "$TMP/guard-api-explicit-contributor.err" 2>/dev/null || true)"
+	fi
 fi
 
 _reset_log


### PR DESCRIPTION
## Summary

- Preserve explicit `role` values in `.agents/scripts/gh:_shim_repo_role()`.
- Derive omitted roles from authenticated `gh api user --jq '.login'` and slug owner, matching pulse/repo metadata semantics.
- Keep fail-closed contributor behavior and add regression coverage for missing-role owned repos plus explicit contributor overrides.

## Verification

- `bash .agents/scripts/tests/test-gh-shim.sh` — 39 passed, 0 failed
- `shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh`
- `.agents/scripts/linters-local.sh` — ALL LOCAL CHECKS PASSED; advisory pre-existing markdown/ratchet/complexity warnings reported

Resolves #24965

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.89 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
