### PR TITLE
GH#24974: feat: classify blockedBy native lookup gaps

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2252,6 +2252,10 @@ classify_dispatch_blocker_reason() {
 			printf 'ever_nmr_without_approval\n'
 			return 0
 			;;
+		*blocked_by_native_lookup_unavailable* | *native*blocked*by*lookup*unavailable*)
+			printf 'blocked_by_native_lookup_unavailable\n'
+			return 0
+			;;
 		*canary*failed*)
 			printf 'canary_failed\n'
 			return 0

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -925,7 +925,7 @@ is_blocked_by_unresolved() {
 
 	if [[ -z "$issue_body" ]]; then
 		if [[ "$native_rc" -eq 3 ]]; then
-			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable and issue body is empty — skipping dispatch (GH#24576)" >>"$LOGFILE"
+			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} DISPATCH_BLOCK_REASON reason=blocked_by_native_lookup_unavailable signal=native blockedBy lookup unavailable and issue body is empty — skipping dispatch (GH#24576)" >>"$LOGFILE"
 			return 0
 		fi
 		return 1
@@ -941,7 +941,7 @@ is_blocked_by_unresolved() {
 	# No blocked-by references → not blocked
 	if [[ -z "$blocker_task_ids" && -z "$blocker_issue_nums" ]]; then
 		if [[ "$native_rc" -eq 3 ]]; then
-			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable and no body blocked-by markers found — skipping dispatch (GH#24576)" >>"$LOGFILE"
+			echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} DISPATCH_BLOCK_REASON reason=blocked_by_native_lookup_unavailable signal=native blockedBy lookup unavailable and no body blocked-by markers found — skipping dispatch (GH#24576)" >>"$LOGFILE"
 			return 0
 		fi
 		return 1

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -106,7 +106,7 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
+		cost_budget_exceeded | cooldown_no_worker_process | graphql_circuit_breaker | runner_health_circuit_breaker | ever_nmr_without_approval | blocked_by_native_lookup_unavailable | canary_failed | launch_error | missing_worker_context | local_capacity_gate | policy_gate | no_recent_log_evidence | provider_rate_limit_pressure | repeated_failure_pressure | healthy_pr_backlog | no_dispatchable_evidence | unclassified_signal)
 			;;
 		*)
 			reason="unclassified_signal"
@@ -1173,9 +1173,25 @@ _dispatch_record_nonzero_dispatch_result() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local dispatch_rc="$3"
+	local recent_lines=""
 
 	echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — dispatch_with_dedup returned rc=${dispatch_rc}" >>"$LOGFILE"
 	if [[ "$dispatch_rc" -eq 2 ]]; then
+		if [[ -n "${LOGFILE:-}" && -f "$LOGFILE" ]]; then
+			recent_lines=$(awk -v issue="#${issue_number}" -v repo="$repo_slug" '
+				index($0, issue) && index($0, repo) { lines[++n] = $0 }
+				END {
+					start = n - 20
+					if (start < 1) { start = 1 }
+					for (i = start; i <= n; i++) { print lines[i] }
+				}
+			' "$LOGFILE" 2>/dev/null) || recent_lines=""
+		fi
+		if [[ "$recent_lines" == *"blocked_by_native_lookup_unavailable"* ]]; then
+			echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) pre-launch failure reason=blocked_by_native_lookup_unavailable" >>"$LOGFILE"
+			_dispatch_stats_increment_candidate_failed "blocked_by_native_lookup_unavailable"
+			return 0
+		fi
 		_dispatch_stats_increment "dispatch_candidate_noop"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -31,6 +31,7 @@ assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — eve
 assert_reason 'blocked by local capacity gate (ever-nmr check not run)' 'local_capacity_gate'
 assert_reason 'review-followup exemption: skipping historical ever-NMR check (GH#18648)' 'unclassified_signal'
 assert_reason 'skipping historical ever-NMR check for bot-generated cleanup issue (GH#18648)' 'unclassified_signal'
+assert_reason 'DISPATCH_BLOCK_REASON reason=blocked_by_native_lookup_unavailable signal=native blockedBy lookup unavailable and no body blocked-by markers found' 'blocked_by_native_lookup_unavailable'
 assert_reason 'pre-dispatch validator failed: missing worker context; needs-brief label present' 'missing_worker_context'
 assert_reason 'dedup.worktree_cap blocked by max worktree count' 'local_capacity_gate'
 assert_reason 'external_author_gate blocked no-auto-dispatch policy' 'policy_gate'

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -120,6 +120,26 @@ if ! LOGFILE="${TEST_TMP}/pulse.log" _dlw_blocked_by_hard_stop "123" "owner/repo
 	fail "worker launch hard-stop did not block unresolved blocked-by dependency"
 fi
 
+unset -f is_blocked_by_unresolved
+# shellcheck source=../pulse-dep-graph.sh
+source "${SCRIPTS_DIR}/pulse-dep-graph.sh"
+
+cat >"${TEST_TMP}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "${TEST_TMP}/bin/gh"
+
+if ! LOGFILE="${TEST_TMP}/pulse-native.log" PATH="${TEST_TMP}/bin:${PATH}" is_blocked_by_unresolved 'This issue has no dependencies.' 'owner/repo' '123'; then
+	fail "native blockedBy lookup failure without body markers must still block dispatch"
+fi
+
+if grep -q 'blocked_by_native_lookup_unavailable' "${TEST_TMP}/pulse-native.log" && ! grep -q 'unclassified_signal' "${TEST_TMP}/pulse-native.log"; then
+	:
+else
+	fail "native blockedBy lookup failure should emit blocked_by_native_lookup_unavailable"
+fi
+
 printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
 printf 'PASS: root node_modules payload is skipped by default\n'
 printf 'PASS: root node_modules .bin tooling is linked by default\n'
@@ -127,4 +147,5 @@ printf 'PASS: precomputed zero-output evidence count skips redundant lookups\n'
 printf 'PASS: pulse worker launch forwards dispatching GitHub login\n'
 printf 'PASS: systemd PID resolver handles final unterminated property\n'
 printf 'PASS: worker launch hard-stops unresolved blocked-by dependencies\n'
+printf 'PASS: native blockedBy lookup failure remains fail-closed with classified reason\n'
 exit 0


### PR DESCRIPTION
## Summary

Classified native blockedBy lookup gaps as blocked_by_native_lookup_unavailable, updated dispatch telemetry, and added regressions.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dep-graph.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh,.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dep-graph.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh; bash .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh; bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh

Resolves #24974


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.4-mini spent 6m and 91,494 tokens on this as a headless worker.