### PR TITLE
GH#24967: fix: align dispatch repos config source

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -392,7 +392,7 @@ _dsi_dispatch_base_branch() {
 			"${repo_path}/.aidevops.json" 2>/dev/null | sed -n '1p') || base_branch=""
 	fi
 
-	local repos_json="${AIDEVOPS_REPOS_JSON:-${REPOS_JSON:-${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}}}"
+	local repos_json="${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
 	if [[ -z "$base_branch" && -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
 		base_branch=$(jq -r --arg slug "$repo_slug" '
 			.initialized_repos[]?


### PR DESCRIPTION
## Summary

Updated .agents/scripts/dispatch-single-issue-helper.sh so _dsi_dispatch_base_branch reads repos.json through AIDEVOPS_REPOS_FILE, matching _dsi_repo_path_for_slug and removing the inconsistent AIDEVOPS_REPOS_JSON/REPOS_JSON lookup.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-single-issue-helper.sh

Resolves #24967


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 31,543 tokens on this as a headless worker.