### PR TITLE
GH#24957: fix: detect scoped raw gh reads

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -278,7 +278,7 @@ EOF
 }
 
 test_required_checks_gh_reads_are_timeout_wrapped() {
-	if grep -nE '^[[:space:]]*(gh api|gh pr checks|[a-zA-Z0-9_]+="?\$\(gh (api|pr checks))' "$REQUIRED_CHECKS_SCRIPT" >/dev/null 2>&1; then
+	if grep -nE '^[[:space:]]*[^#]*\bgh (api|pr checks)\b' "$REQUIRED_CHECKS_SCRIPT" | grep -v '_pmrc_gh_read' >/dev/null 2>&1; then
 		print_result "required-check gh reads use timeout wrapper" 1
 	else
 		print_result "required-check gh reads use timeout wrapper" 0


### PR DESCRIPTION
## Summary

Hardened the required-checks wrapper test so it detects any active raw gh api or gh pr checks calls, including local assignments, while excluding wrapped _pmrc_gh_read calls.

## Files Changed

.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; shellcheck .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

Resolves #24957


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 57,988 tokens on this as a headless worker.