### PR TITLE
GH#24976: feat: measure PR list shapes

### DIFF
--- a/.agents/scripts/pulse-capacity-alloc.sh
+++ b/.agents/scripts/pulse-capacity-alloc.sh
@@ -424,7 +424,7 @@ _count_dispatchable_product_repos() {
 			local pr_json daily_pr_count pr_alloc_err
 			# GH#4412: use --state all to count merged/closed PRs too
 			pr_alloc_err=$(mktemp)
-			pr_json=$(gh_pr_list --repo "$slug" --state all --json createdAt --limit 200 2>"$pr_alloc_err") || pr_json="[]"
+			pr_json=$(pulse_pr_list_get --repo "$slug" --state all --json createdAt --limit 200 2>"$pr_alloc_err") || pr_json="[]"
 			if [[ -z "$pr_json" ]]; then
 				local _pr_alloc_err_msg
 				_pr_alloc_err_msg=$(cat "$pr_alloc_err" 2>/dev/null || echo "unknown error")

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -240,7 +240,7 @@ _compute_repo_state_fingerprint() {
 	issues_json=$(gh_issue_list --repo "$slug" --state open \
 		--json number,labels,assignees,updatedAt \
 		--limit "$limit" 2>/dev/null) && issues_ok=true
-	prs_json=$(gh_pr_list --repo "$slug" --state open \
+	prs_json=$(pulse_pr_list_get --repo "$slug" --state open \
 		--json number,labels,assignees,reviewDecision,mergeable,updatedAt \
 		--limit "$limit" 2>/dev/null) && prs_ok=true
 

--- a/.agents/scripts/pulse-quality-debt.sh
+++ b/.agents/scripts/pulse-quality-debt.sh
@@ -88,7 +88,7 @@ close_stale_quality_debt_prs() {
 	cutoff_epoch=$(date -v-24H +%s 2>/dev/null || date -d '24 hours ago' +%s 2>/dev/null || echo 0)
 
 	local pr_json
-	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
+	pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open \
 		--json number,title,labels,mergeable,updatedAt \
 		--jq '[.[] | select(.mergeable == "CONFLICTING") | select(.labels[]?.name == "quality-debt" or (.title | test("quality.debt|fix:.*batch|fix:.*harden"; "i")))]' \
 		2>/dev/null) || pr_json="[]"

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -111,6 +111,19 @@ _gh_pr_list_snapshot_key() {
 }
 
 #######################################
+# Record one lightweight telemetry event for the exact gh_pr_list argv shape.
+# The shape key is the same full-argv hash used by the exact-output caches, so
+# repeated counts identify only semantics-preserving candidates for migration.
+# Args: gh-style argv
+#######################################
+_gh_pr_list_shape_record() {
+	local _key
+	_key="$(_gh_pr_list_snapshot_key "$@")" || return 0
+	_gh_read_cache_record gh_pr_list_shape "shape:${_key}"
+	return 0
+}
+
+#######################################
 # Record a lightweight cache decision in the same instrumentation stream as API
 # calls. These records use path=other so cache hit/miss/stale decisions are
 # visible without inflating REST/GraphQL call counts.
@@ -444,6 +457,7 @@ gh_issue_view() {
 gh_pr_list() {
 	local _has_search=1
 	_rest_args_have_search "$@" || _has_search=0
+	_gh_pr_list_shape_record "$@"
 	local _cached_output=""
 	if _cached_output=$(_gh_pr_list_snapshot_get "$@" 2>/dev/null); then
 		printf '%s' "$_cached_output"

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -68,6 +68,7 @@
 #  37. AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE bypasses both PR view cache layers
 #  38. collaborator permission fallback parser ignores nested spoof fields
 #  39. _rest_split_csv suppresses Broken pipe noise when consumers close early
+#  40. gh_pr_list records exact argv shape telemetry for repeated-call analysis
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -878,6 +879,27 @@ if grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null &&
 else
 	fail "gh_pr_list proactively routes to REST when GraphQL budget is low" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+# =============================================================================
+# Test 23a: gh_pr_list records exact argv shape telemetry
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+: >"$AIDEVOPS_GH_API_LOG"
+export STUB_RATE_LIMIT_REMAINING=5000
+
+gh_pr_list --repo "owner/repo" --state open --json number --limit 10 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --state open --json number --limit 10 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --state open --json number,title --limit 10 >/dev/null 2>&1 || true
+
+shape_total=$(grep -c $'\tgh_pr_list_shape\t' "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)
+shape_unique=$(grep $'\tgh_pr_list_shape\t' "$AIDEVOPS_GH_API_LOG" 2>/dev/null | cut -f6 | sort -u | wc -l | tr -d '[:space:]' || true)
+if [[ "$shape_total" == "3" && "$shape_unique" == "2" ]]; then
+	pass "gh_pr_list records exact argv shape telemetry for repeated-call analysis"
+else
+	fail "gh_pr_list records exact argv shape telemetry for repeated-call analysis" \
+		"shape_total=${shape_total} shape_unique=${shape_unique} log=$(cat "$AIDEVOPS_GH_API_LOG")"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-pulse-pr-list-cache.sh
+++ b/.agents/scripts/tests/test-pulse-pr-list-cache.sh
@@ -32,6 +32,7 @@ trap 'rm -rf "$TMP_DIR" 2>/dev/null || true' EXIT
 
 GH_CALLS="${TMP_DIR}/gh-calls.log"
 : >"$GH_CALLS"
+unset PULSE_PR_LIST_PROVIDER_CACHE_DISABLE
 
 gh_pr_list() {
 	printf '%s\n' "$*" >>"$GH_CALLS"
@@ -62,6 +63,19 @@ if [[ "$third_output" == '[{"number":1,"reviewDecision":"APPROVED","headRefOid":
 else
 	fail "provider cache keys different field sets separately" \
 		"third=${third_output} different_shape_calls=${different_shape_calls} calls=$(<"$GH_CALLS")"
+fi
+
+: >"$GH_CALLS"
+pulse_pr_list_get --repo owner/repo --state open --head branch-a --json number --limit 10 >/dev/null
+pulse_pr_list_get --repo owner/repo --state open --head branch-a --json number --limit 10 >/dev/null
+pulse_pr_list_get --repo owner/repo --state open --head branch-b --json number --limit 10 >/dev/null
+head_a_calls=$(grep -c -- '--head branch-a' "$GH_CALLS" 2>/dev/null || true)
+head_b_calls=$(grep -c -- '--head branch-b' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$head_a_calls" == "1" && "$head_b_calls" == "1" ]]; then
+	pass "provider cache keys different filter arguments separately"
+else
+	fail "provider cache keys different filter arguments separately" \
+		"head_a_calls=${head_a_calls} head_b_calls=${head_b_calls} calls=$(<"$GH_CALLS")"
 fi
 
 : >"$GH_CALLS"


### PR DESCRIPTION
## Summary

Added exact gh_pr_list argv-shape telemetry, migrated repeated safe pulse PR-list reads to pulse_pr_list_get, and expanded cache regression coverage for field/filter separation.

## Files Changed

.agents/scripts/pulse-capacity-alloc.sh,.agents/scripts/pulse-prefetch-infra.sh,.agents/scripts/pulse-quality-debt.sh,.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh,.agents/scripts/tests/test-pulse-pr-list-cache.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-status.sh .agents/scripts/pulse-pr-list-cache.sh .agents/scripts/pulse-prefetch-infra.sh .agents/scripts/pulse-quality-debt.sh .agents/scripts/pulse-capacity-alloc.sh .agents/scripts/tests/test-pulse-pr-list-cache.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh && .agents/scripts/tests/test-pulse-pr-list-cache.sh && .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

Resolves #24976


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 5m and 81,702 tokens on this as a headless worker.