### PR TITLE
GH#24962: fix: guard in-cycle pulse merge lock

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1190,20 +1190,36 @@ _pulse_run_deterministic_pipeline() {
 	# LLM failed to execute merge steps or the prefetch showed 0 PRs.
 	#
 	# t2862 (GH#20919): short-circuit if pulse-merge-routine.sh (the fast
-	# 120s standalone runner) already ran within the last 60s. This avoids
+	# 120s standalone runner) is already running or ran recently. This avoids
 	# double-execution while keeping the in-cycle call as defense-in-depth
 	# for environments where the launchd/cron schedule is not installed.
+	# GH#24962: the standalone routine can run up to
+	# PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS (default 600s), so the in-cycle guard
+	# must honour the live PID lock first and use the same timeout window for the
+	# timestamp fallback instead of the old 60s window.
 	local _pulse_merge_routine_last_run="${HOME}/.aidevops/logs/pulse-merge-routine-last-run"
+	local _pulse_merge_routine_lock_dir="${HOME}/.aidevops/.agent-workspace/locks/pulse-merge-routine.lock"
 	local _pmr_skip=0
-	if [[ -f "$_pulse_merge_routine_last_run" ]]; then
+	if [[ -d "$_pulse_merge_routine_lock_dir" && -f "${_pulse_merge_routine_lock_dir}/pid" ]]; then
+		local _pmr_lock_pid=""
+		_pmr_lock_pid=$(cat "${_pulse_merge_routine_lock_dir}/pid" 2>/dev/null || printf '0\n')
+		if [[ "$_pmr_lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$_pmr_lock_pid" 2>/dev/null; then
+			echo "[pulse-wrapper] deterministic_merge_pass: skipping (pulse-merge-routine pid=${_pmr_lock_pid} still running)" >>"$LOGFILE"
+			_pmr_skip=1
+		fi
+	fi
+	if [[ "$_pmr_skip" -eq 0 && -f "$_pulse_merge_routine_last_run" ]]; then
 		local _pmr_last="" _pmr_now="" _pmr_elapsed=""
+		local _pmr_recent_window="${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS:-600}"
+		[[ "$_pmr_recent_window" =~ ^[0-9]+$ ]] || _pmr_recent_window=600
+		[[ "$_pmr_recent_window" -lt 1 ]] && _pmr_recent_window=600
 		_pmr_last=$(cat "$_pulse_merge_routine_last_run" 2>/dev/null || echo "0")
 		_pmr_now=$(date +%s 2>/dev/null || echo "0")
 		[[ "$_pmr_last" =~ ^[0-9]+$ ]] || _pmr_last=0
 		[[ "$_pmr_now" =~ ^[0-9]+$ ]] || _pmr_now=0
 		_pmr_elapsed=$((_pmr_now - _pmr_last))
-		if [[ "$_pmr_elapsed" -lt 60 ]]; then
-			echo "[pulse-wrapper] deterministic_merge_pass: skipping (pulse-merge-routine ran ${_pmr_elapsed}s ago)" >>"$LOGFILE"
+		if [[ "$_pmr_elapsed" -lt "$_pmr_recent_window" ]]; then
+			echo "[pulse-wrapper] deterministic_merge_pass: skipping (pulse-merge-routine ran ${_pmr_elapsed}s ago, window=${_pmr_recent_window}s)" >>"$LOGFILE"
 			_pmr_skip=1
 		fi
 	fi

--- a/.agents/scripts/tests/test-pulse-wrapper-characterization.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-characterization.sh
@@ -664,6 +664,33 @@ test_sourcing_idempotency() {
 }
 
 #######################################
+# Test 9: deterministic merge guard honours the standalone routine lock.
+# GH#24962: the in-cycle merge pass must skip when pulse-merge-routine.sh owns
+# its PID lock, and its timestamp fallback must use the routine timeout window
+# rather than the historical 60s window.
+#######################################
+test_deterministic_merge_guard_uses_routine_lock() {
+	local wrapper_file="${PULSE_SCRIPTS_DIR}/pulse-wrapper.sh"
+
+	if grep -qF '.agent-workspace/locks/pulse-merge-routine.lock' "$wrapper_file" \
+		&& grep -qF "kill -0 \"\$_pmr_lock_pid\"" "$wrapper_file"; then
+		print_result "deterministic merge guard checks live pulse-merge-routine PID lock" 0
+	else
+		print_result "deterministic merge guard checks live pulse-merge-routine PID lock" 1 \
+			"missing lock-dir or kill -0 guard in pulse-wrapper.sh"
+	fi
+
+	if grep -qF 'PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS:-600' "$wrapper_file" \
+		&& grep -qF "window=\${_pmr_recent_window}s" "$wrapper_file"; then
+		print_result "deterministic merge timestamp guard uses routine timeout window" 0
+	else
+		print_result "deterministic merge timestamp guard uses routine timeout window" 1 \
+			"timestamp fallback should align with PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS"
+	fi
+	return 0
+}
+
+#######################################
 # Test 10: _pulse_is_sourced returns success when sourced from bash.
 # Every test above relies on this guard at L13786 preventing main() from
 # running. Verify it works as documented.
@@ -700,6 +727,7 @@ main() {
 	test_extract_milestone_summary
 	test_triage_content_hash
 	test_sourcing_idempotency
+	test_deterministic_merge_guard_uses_routine_lock
 	test_pulse_is_sourced_guard
 
 	teardown_sandbox


### PR DESCRIPTION
## Summary

Added a live PID-lock check before the in-cycle deterministic merge pass and aligned the timestamp fallback window with PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS so pulse-wrapper does not launch a second merge while pulse-merge-routine is still active.

## Files Changed

.agents/scripts/pulse-wrapper.sh,.agents/scripts/tests/test-pulse-wrapper-characterization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh; shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-characterization.sh

Resolves #24962


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 6m and 88,164 tokens on this as a headless worker.