### PR TITLE
GH#24975: feat: skip Renovate Dependency Dashboard issues

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2268,6 +2268,10 @@ classify_dispatch_blocker_reason() {
 			printf 'missing_worker_context\n'
 			return 0
 			;;
+		*renovate*dependency*dashboard* | *dependency*dashboard*renovate*bot* | *renovate_dependency_dashboard*)
+			printf 'renovate_dependency_dashboard\n'
+			return 0
+			;;
 		*local*capacity*gate* | *worktree*cap* | *max*worktree* | *disk*space* | *large*file*)
 			printf 'local_capacity_gate\n'
 			return 0

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2268,7 +2268,7 @@ classify_dispatch_blocker_reason() {
 			printf 'missing_worker_context\n'
 			return 0
 			;;
-		*renovate*dependency*dashboard* | *dependency*dashboard*renovate*bot* | *renovate_dependency_dashboard*)
+		*renovate*dependency*dashboard*)
 			printf 'renovate_dependency_dashboard\n'
 			return 0
 			;;

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -28,6 +28,7 @@
 #   - _is_bot_generated_cleanup_issue
 #   - _is_task_committed_to_main
 #   - _dispatch_target_is_pull_request
+#   - _is_renovate_dependency_dashboard_issue
 #   - _dispatch_has_interactive_hold
 #   - _dispatch_dedup_check_layers  (t1999: extracted from dispatch_with_dedup)
 #   - dispatch_with_dedup           (t1999: thin orchestrator, <80 lines)
@@ -977,6 +978,30 @@ _dispatch_target_is_pull_request() {
 }
 
 #######################################
+# Return success when issue metadata identifies a Renovate Dependency Dashboard
+# meta-issue. These are maintenance tracking issues, not implementation work.
+#
+# Args:
+#   $1 - issue_meta_json (pre-fetched JSON with .author and .title)
+# Returns:
+#   0 - renovate[bot] Dependency Dashboard issue
+#   1 - not a Renovate Dependency Dashboard issue
+#######################################
+_is_renovate_dependency_dashboard_issue() {
+	local issue_meta_json="$1"
+	local author_login="" issue_title="" title_lower=""
+
+	[[ -n "$issue_meta_json" ]] || return 1
+	author_login=$(printf '%s' "$issue_meta_json" | jq -r '.author.login // empty' 2>/dev/null | tr '[:upper:]' '[:lower:]') || author_login=""
+	issue_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // empty' 2>/dev/null) || issue_title=""
+	title_lower=$(printf '%s' "$issue_title" | tr '[:upper:]' '[:lower:]')
+
+	[[ "$author_login" == "renovate[bot]" ]] || return 1
+	[[ "$title_lower" == *"dependency dashboard"* ]] || return 1
+	return 0
+}
+
+#######################################
 # t2955: Apply the `dispatch-blocked:committed-to-main` cache label.
 #
 # Called by `_check_commit_subject_dedup_gate` after the first scan
@@ -1557,7 +1582,7 @@ dispatch_with_dedup() {
 	_ds_t0=$(_ds_now_ns)
 	local issue_meta_json
 	issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
-		--json number,title,state,labels,assignees,body 2>/dev/null) || issue_meta_json=""
+		--json number,title,state,labels,assignees,body,author 2>/dev/null) || issue_meta_json=""
 	_ds_record "$issue_number" "$repo_slug" "gh_issue_view" "$_ds_t0"
 	if [[ -z "$issue_meta_json" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to load issue metadata" >>"$LOGFILE"
@@ -1580,7 +1605,13 @@ dispatch_with_dedup() {
 		return 1
 	fi
 
-	# Run all pre-dispatch validation and dedup check layers (9 gates total).
+	if _is_renovate_dependency_dashboard_issue "$issue_meta_json"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: Renovate Dependency Dashboard issues are metadata only" >>"$LOGFILE"
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=renovate_dependency_dashboard signal=renovate_dependency_dashboard issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+		return 3
+	fi
+
+	# Run all pre-dispatch validation and dedup check layers (10 gates total).
 	# Each gate logs its own blocked reason to LOGFILE before returning 1.
 	# _claim_comment_id is set by check_dispatch_dedup inside this call via
 	# bash dynamic scoping — accessible below because it was declared local above.

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -192,7 +192,7 @@ _dispatch_candidate_failure_reason() {
 _dispatch_candidate_benign_block_reason() {
 	local reason="$1"
 	case "$reason" in
-		dedup_active_claim | interactive_review_hold | pr_target_not_dispatchable)
+		dedup_active_claim | interactive_review_hold | pr_target_not_dispatchable | renovate_dependency_dashboard)
 			return 0
 			;;
 	esac

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -23,6 +23,7 @@ assert_reason 'COST_BUDGET_EXCEEDED (spent=123 budget=100)' 'cost_budget_exceede
 assert_reason 'DISPATCH_BLOCK_REASON reason=dedup_active_claim signal=assigned to runner' 'dedup_active_claim'
 assert_reason 'DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive review hold label present' 'interactive_review_hold'
 assert_reason 'Dispatch blocked for #4849 in awardsapp/awardsapp: target is a pull request, not a dispatchable issue (GH#22948)' 'pr_target_not_dispatchable'
+assert_reason 'DISPATCH_BLOCK_REASON reason=renovate_dependency_dashboard signal=renovate_dependency_dashboard issue=#24975 repo=marcusquinn/aidevops' 'renovate_dependency_dashboard'
 assert_reason 'GraphQL budget below circuit-breaker threshold' 'graphql_circuit_breaker'
 assert_reason 'DISPATCH_COOLDOWN_ACTIVE until=2026-05-02T23:00:00Z reason=no_worker_process' 'cooldown_no_worker_process'
 assert_reason 'dispatch_with_dedup: BLOCKED #3638 in awardsapp/awardsapp — requires cryptographic approval (ever-NMR)' 'ever_nmr_without_approval'

--- a/.agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for the Renovate Dependency Dashboard early-skip helper.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_is_renovate_dependency_dashboard_issue\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _is_renovate_dependency_dashboard_issue from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+test_detects_renovate_dependency_dashboard() {
+	local meta='{"number":24975,"title":"Dependency Dashboard","author":{"login":"renovate[bot]"},"labels":[{"name":"enhancement"}]}'
+	if _is_renovate_dependency_dashboard_issue "$meta"; then
+		print_result "detects renovate Dependency Dashboard issue" 0
+		return 0
+	fi
+	print_result "detects renovate Dependency Dashboard issue" 1 \
+		"Expected exit 0 for renovate[bot] Dependency Dashboard metadata issue"
+	return 0
+}
+
+test_ignores_normal_renovate_update_issue() {
+	local meta='{"number":24976,"title":"chore(deps): bump lodash from 4.17.21 to 4.17.22","author":{"login":"renovate[bot]"},"labels":[{"name":"dependencies"}]}'
+	if _is_renovate_dependency_dashboard_issue "$meta"; then
+		print_result "ignores normal renovate dependency update issue" 1 \
+			"Expected exit 1 for a regular renovate update issue"
+		return 0
+	fi
+	print_result "ignores normal renovate dependency update issue" 0
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_detects_renovate_dependency_dashboard
+	test_ignores_normal_renovate_update_issue
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -169,7 +169,7 @@ assert_grep \
 	"$DISPATCH_LIB"
 assert_grep \
 	"10b: interactive review hold is recognized as a benign block" \
-	'dedup_active_claim \| interactive_review_hold \| pr_target_not_dispatchable' \
+	'dedup_active_claim \| interactive_review_hold \| pr_target_not_dispatchable \| renovate_dependency_dashboard' \
 	"$DISPATCH_LIB"
 assert_grep \
 	"10b2: benign blocks are logged distinctly, not as pre-launch failures" \


### PR DESCRIPTION
## Summary

Early-skip Renovate Dependency Dashboard issues before dispatch classification/launch, with helper and classifier coverage.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh,.agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh,.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh && bash .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh && bash .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh && shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh .agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh

Resolves #24975


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.4-mini spent 9m and 303,786 tokens on this as a headless worker.