### PR TITLE
GH#24977: feat: add merge timing summaries

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -53,6 +53,58 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${STOP_FLAG:=${HOME}/.aidevops/logs/pulse-session.stop}"
 : "${PULSE_MERGE_BATCH_LIMIT:=50}"
 
+#######################################
+# Low-overhead timing helpers for per-repo merge summaries.
+#
+# The merge pass already emits one summary line per repo. These helpers keep
+# the timing capture cheap (integer seconds, no extra subprocess fan-out) so
+# the summary can report list / mergeability / ruleset / branch-protection /
+# stuck-detector phases without adding noisy per-PR logs.
+#######################################
+_pmp_now_epoch() {
+	local now_epoch
+	now_epoch=$(date +%s 2>/dev/null || printf '0')
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+	printf '%s' "$now_epoch"
+	return 0
+}
+
+_pmp_add_elapsed_seconds() {
+	local dest_var="$1"
+	local start_epoch="${2:-0}"
+	local current_value="" end_epoch elapsed
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	[[ "$start_epoch" =~ ^[0-9]+$ ]] || start_epoch=0
+
+	end_epoch=$(_pmp_now_epoch)
+	elapsed=$((end_epoch - start_epoch))
+	[[ "$elapsed" =~ ^[0-9]+$ ]] || elapsed=0
+
+	current_value=$(eval "printf '%s' \"\${$dest_var:-0}\"" 2>/dev/null) || current_value=0
+	[[ "$current_value" =~ ^[0-9]+$ ]] || current_value=0
+	current_value=$((current_value + elapsed))
+	printf -v "$dest_var" '%s' "$current_value"
+	return 0
+}
+
+_pmp_log_repo_timing_summary() {
+	local repo_slug="$1"
+	local total_s="${2:-0}"
+	local list_s="${3:-0}"
+	local mergeability_s="${4:-0}"
+	local ruleset_s="${5:-0}"
+	local branch_protection_s="${6:-0}"
+	local stuck_detector_s="${7:-0}"
+	local merged="${8:-0}"
+	local closed="${9:-0}"
+	local failed="${10:-0}"
+	local pr_count="${11:-0}"
+
+	echo "[pulse-wrapper] deterministic_merge_pass timing: repo=${repo_slug} total_s=${total_s} list_s=${list_s} mergeability_s=${mergeability_s} ruleset_s=${ruleset_s} branch_protection_s=${branch_protection_s} stuck_detector_s=${stuck_detector_s} merged=${merged} closed=${closed} failed=${failed} prs=${pr_count}" >>"$LOGFILE"
+	return 0
+}
+
 # PR backlog categories exposed in logs. These are scheduling/observability
 # buckets only; _process_single_ready_pr still enforces every merge safety gate
 # before approving, merging, closing, or dispatching a fix worker.
@@ -314,6 +366,8 @@ merge_ready_prs_all_repos() {
 	local _mr_repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 	local _mr_logfile="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 	PULSE_MERGE_BATCH_LIMIT="${PULSE_MERGE_BATCH_LIMIT:-50}"
+	local _mr_pass_start
+	_mr_pass_start=$(_pmp_now_epoch)
 
 	if [[ -f "$_mr_stop_flag" ]]; then
 		echo "[pulse-wrapper] Deterministic merge pass skipped: stop flag present" >>"$_mr_logfile"
@@ -342,14 +396,20 @@ merge_ready_prs_all_repos() {
 		local repo_merged=0
 		local repo_closed=0
 		local repo_failed=0
+		local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0 _mr_repo_stuck_detector_s=0
+		local _mr_repo_start
+		_mr_repo_start=$(_pmp_now_epoch)
 
-		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed
+		local _mr_repo_pr_count=0
+		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed _mr_repo_pr_count "_mr_repo_"
 
 		total_merged=$((total_merged + repo_merged))
 		total_closed=$((total_closed + repo_closed))
 		total_failed=$((total_failed + repo_failed))
 
 		# t3193: run the stuck-merge detector pass for this repo.
+		local _mr_repo_stuck_start
+		_mr_repo_stuck_start=$(_pmp_now_epoch)
 		if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
 			pulse_merge_stuck_run_pass "$repo_slug" || true
 		fi
@@ -361,6 +421,10 @@ merge_ready_prs_all_repos() {
 			[[ "$_repo_eligible" =~ ^[0-9]+$ ]] || _repo_eligible=0
 			total_eligible_unmerged=$((total_eligible_unmerged + _repo_eligible))
 		fi
+		_pmp_add_elapsed_seconds _mr_repo_stuck_detector_s "$_mr_repo_stuck_start"
+		local _mr_repo_total_s=0
+		_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
+		_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
 
 		if [[ -f "$_mr_stop_flag" ]]; then
 			echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$_mr_logfile"
@@ -381,6 +445,9 @@ merge_ready_prs_all_repos() {
 	# The parent process reads this file after the stage completes.
 	local _health_delta_file="${TMPDIR:-/tmp}/pulse-health-merge-$$.tmp"
 	printf '%s %s\n' "$total_merged" "$total_closed" >"$_health_delta_file" || true
+	local _mr_pass_total_s=0
+	_pmp_add_elapsed_seconds _mr_pass_total_s "$_mr_pass_start"
+	echo "[pulse-wrapper] deterministic_merge_pass timing: total_s=${_mr_pass_total_s} merged=${total_merged} closed_conflicting=${total_closed} failed=${total_failed} eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
 	return 0
 }
 
@@ -409,6 +476,8 @@ _merge_ready_prs_for_repo() {
 	local _merged_var="$2"
 	local _closed_var="$3"
 	local _failed_var="$4"
+	local _pr_count_var="${5:-}"
+	local _timing_prefix="${6:-}"
 
 	local merged=0
 	local closed=0
@@ -418,6 +487,8 @@ _merge_ready_prs_for_repo() {
 	# enriched below from REST check-suites so merge polling preserves GraphQL
 	# budget for dispatch.
 	local pr_json pr_merge_err
+	local _list_start
+	_list_start=$(_pmp_now_epoch)
 	pr_merge_err=$(mktemp)
 	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
 		--json "$(_pulse_merge_ready_pr_json_fields)" \
@@ -429,10 +500,12 @@ _merge_ready_prs_for_repo() {
 		pr_json="[]"
 	fi
 	rm -f "$pr_merge_err"
+	[[ -n "$_timing_prefix" ]] && _pmp_add_elapsed_seconds "${_timing_prefix}list_s" "$_list_start"
 
 	local pr_count
 	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
 	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	[[ -z "$_pr_count_var" ]] || eval "${_pr_count_var}=${pr_count}"
 
 	if [[ "$pr_count" -eq 0 ]]; then
 		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"
@@ -456,7 +529,7 @@ _merge_ready_prs_for_repo() {
 		i=$((i + 1))
 		[[ -n "$pr_obj" ]] || continue
 
-		_process_single_ready_pr "$repo_slug" "$pr_obj"
+		_process_single_ready_pr "$repo_slug" "$pr_obj" "$_timing_prefix"
 		local _pr_rc=$?
 		case "$_pr_rc" in
 		0) merged=$((merged + 1)) ;;

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -818,8 +818,10 @@ _Closed by deterministic merge pass (GH#24399)._" 2>/dev/null || true
 _process_single_ready_pr() {
 	local repo_slug="$1"
 	local pr_obj="$2"
+	local timing_prefix="${3:-}"
 
 	local pr_number="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at="" pr_head_ref_oid="" pr_head_ref_name="" pr_base_ref_name="" pr_labels="" pr_is_draft="false"
+	local _mergeability_start="" _branch_protection_start="" _ruleset_start=""
 	# Consolidate into a single jq pass to reduce process-spawn overhead.
 	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
 	# instead of \t. Bash read collapses consecutive IFS whitespace chars
@@ -834,6 +836,7 @@ _process_single_ready_pr() {
 			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\(.headRefName // "")\u001e\(.baseRefName // "")\u001e\([(.labels // [])[].name] | join(","))\u001e\(.isDraft // false | tostring)"'
 	)
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
+	[[ -n "$timing_prefix" ]] && _mergeability_start=$(_pmp_now_epoch)
 
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
 	if [[ "$pr_is_draft" == "true" ]]; then
@@ -875,6 +878,7 @@ _process_single_ready_pr() {
 			if [[ "$_t2116_issue_labels" == *"needs-maintainer-review"* ]]; then
 				echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — linked issue #${_t2116_linked_issue} has needs-maintainer-review (t2116)" >>"$LOGFILE"
 				_post_rebase_nudge_on_worker_conflicting "$pr_number" "$repo_slug" "" "" 2>/dev/null || true
+				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 				return 1
 			fi
 		fi
@@ -897,35 +901,40 @@ _process_single_ready_pr() {
 			# conflict is semantic and unsalvageable. Fall through to close.
 		fi
 
-		if [[ "$pr_mergeable" == "CONFLICTING" ]]; then
+			if [[ "$pr_mergeable" == "CONFLICTING" ]]; then
 			# Conflict resolution feedback: route worker PRs and stale interactive
 			# PRs to fix workers before the protected-close precheck. Active
 			# interactive PRs remain protected because _route_pr_to_fix_worker only
 			# accepts origin:interactive after _interactive_pr_is_stale passes.
-			if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid"; then
-				return 2
-			fi
+				if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid"; then
+					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+					return 2
+				fi
 
 			# GH#23371: some PRs are already known to be protected from
 			# automated close handling from the PR list metadata (draft,
 			# origin:interactive, no-auto-dispatch, external-contributor).
 			# Skip them before the close-conflict ownership guard so pulse
 			# does not repeatedly hit the noisy metadata-fetch path.
-			if _close_conflicting_pr_skip_protected_precheck "$pr_number" "$repo_slug" "$pr_obj"; then
-				return 1
-			fi
+				if _close_conflicting_pr_skip_protected_precheck "$pr_number" "$repo_slug" "$pr_obj"; then
+					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+					return 1
+				fi
 
-			_close_conflicting_pr "$pr_number" "$repo_slug" "$pr_title"
-			return 2
-		fi
+				_close_conflicting_pr "$pr_number" "$repo_slug" "$pr_title"
+				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+				return 2
+			fi
 		# Otherwise pr_mergeable is now MERGEABLE/UNKNOWN — continue through
 		# the normal merge path below.
 	fi
 
 	# Resolve UNKNOWN mergeable state with one retry; skip if not MERGEABLE
 	if ! _resolve_pr_mergeable_status "$pr_number" "$repo_slug" "$pr_mergeable"; then
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 		return 1
 	fi
+	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 
 	# Fetch linked issue once — used in gate checks, CI repair routing, and
 	# post-merge close. Do this before CI repair routing so red/pending PRs are
@@ -954,6 +963,7 @@ _process_single_ready_pr() {
 	# idle interactive PRs are handed over via origin:worker-takeover and
 	# then routed through the same pipeline — human session must be gone
 	# (no status, no claim stamp, >24h idle) for handover to fire.
+	[[ -n "$timing_prefix" ]] && _branch_protection_start=$(_pmp_now_epoch)
 	if ! _pr_required_checks_pass "$pr_number" "$repo_slug"; then
 		# t2922: For origin:worker PRs, phantom-pending non-required checks
 		# (CodeRabbit, qlty, linked-issue-check, url-allowlist, etc.) can
@@ -979,13 +989,16 @@ _process_single_ready_pr() {
 			# If rebase succeeds, skip fix-worker routing — next pulse cycle
 			# will re-check CI on the rebased HEAD.
 			if _attempt_pr_ci_rebase_retry "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid"; then
+				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 				return 1
 			fi
 			# CI failure: route to fix worker if applicable (t2203: consolidated).
 			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || true
+			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 			return 1
 		fi
 	fi
+	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 
 	# Dry-run must stop before every write side effect. The standalone merge
 	# routine advertises DRY_RUN=1 as no-side-effects, but the historical path
@@ -1008,9 +1021,12 @@ _process_single_ready_pr() {
 
 	# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
 	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" 2>/dev/null || true
+	[[ -n "$timing_prefix" ]] && _ruleset_start=$(_pmp_now_epoch)
 	if ! _check_ruleset_required_reviews_passing "$repo_slug" "$pr_number" "$pr_author"; then
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}ruleset_s" "$_ruleset_start"
 		return 1
 	fi
+	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}ruleset_s" "$_ruleset_start"
 
 	# Extract merge summary: MERGE_SUMMARY comment → PR body → generic fallback
 	local merge_summary

--- a/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
+++ b/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for per-repo deterministic-merge timing summaries.
+# Verifies that a multi-repo merge pass emits one structured timing line per
+# repo plus the overall deterministic_merge_pass summary, without changing the
+# function return code.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+export LOGFILE="${TEST_ROOT}/pulse.log"
+export STOP_FLAG="${TEST_ROOT}/pulse.stop"
+export REPOS_JSON="${TEST_ROOT}/repos.json"
+export PULSE_MERGE_BATCH_LIMIT=1
+
+mkdir -p "${HOME}/.config/aidevops"
+
+cat >"$REPOS_JSON" <<'JSON'
+{"initialized_repos":[
+  {"slug":"owner/alpha","path":"/tmp/alpha","pulse":true,"local_only":false},
+  {"slug":"owner/beta","path":"/tmp/beta","pulse":true,"local_only":false}
+]}
+JSON
+
+: >"$LOGFILE"
+
+gh() {
+  if [[ "$1" == "api" && "${2:-}" == "user" ]]; then
+    printf '%s' '{"login":"tester"}'
+    return 0
+  fi
+  return 0
+}
+
+# shellcheck source=/dev/null
+source "$MERGE_SCRIPT" >/dev/null 2>&1
+
+gh_pr_list() {
+  local repo_slug=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo)
+        repo_slug="$2"
+        shift 2
+        ;;
+      --state|--json|--limit)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  sleep 1
+  case "$repo_slug" in
+    owner/alpha)
+      printf '%s' '[{"number":11,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"alpha","updatedAt":"2026-06-18T00:00:00Z","headRefOid":"a1","headRefName":"alpha","baseRefName":"main","labels":[],"isDraft":false}]'
+      ;;
+    owner/beta)
+      printf '%s' '[{"number":12,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"beta","updatedAt":"2026-06-18T00:00:00Z","headRefOid":"b1","headRefName":"beta","baseRefName":"main","labels":[],"isDraft":false}]'
+      ;;
+    *)
+      printf '[]'
+      ;;
+  esac
+  return 0
+}
+
+gh_pr_check_status_rest_batch() {
+  sleep 1
+  printf '[]'
+  return 0
+}
+
+repo_allows_pulse_write_actions() {
+  export AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE="$1"
+  return 0
+}
+_resolve_pr_mergeable_status() { sleep 1; return 0; }
+_extract_linked_issue() { printf '101'; return 0; }
+_check_pr_merge_gates() { return 0; }
+_pr_required_checks_pass() { sleep 1; return 0; }
+_check_ruleset_required_reviews_passing() { sleep 1; return 0; }
+approve_collaborator_pr() { return 0; }
+_pmp_consolidate_duplicate_pr_groups() { return 0; }
+_attempt_existing_auto_merge_behind_update_branch() { return 1; }
+_set_native_auto_merge_or_skip() { return 0; }
+_handle_post_merge_actions() { return 0; }
+pulse_merge_stuck_run_pass() { sleep 1; return 0; }
+_pms_count_eligible_unmerged_for_repo() { return 0; }
+
+rc=0
+merge_ready_prs_all_repos || rc=$?
+
+if [[ "$rc" -ne 0 ]]; then
+  printf 'FAIL: merge_ready_prs_all_repos returned %s\n' "$rc"
+  exit 1
+fi
+
+if [[ "$(grep -c 'deterministic_merge_pass timing: repo=' "$LOGFILE")" -ne 2 ]]; then
+  printf 'FAIL: expected 2 per-repo timing summaries\n'
+  cat "$LOGFILE"
+  exit 1
+fi
+
+for repo in owner/alpha owner/beta; do
+  if ! grep -qE "deterministic_merge_pass timing: repo=${repo} .*list_s=[0-9]+ .*mergeability_s=[0-9]+ .*ruleset_s=[0-9]+ .*branch_protection_s=[0-9]+ .*stuck_detector_s=[0-9]+" "$LOGFILE"; then
+    printf 'FAIL: missing structured timing summary for %s\n' "$repo"
+    cat "$LOGFILE"
+    exit 1
+  fi
+done
+
+if ! grep -q 'deterministic_merge_pass timing: total_s=' "$LOGFILE"; then
+  printf 'FAIL: missing overall deterministic_merge_pass timing summary\n'
+  cat "$LOGFILE"
+  exit 1
+fi
+
+printf 'PASS: timing summaries emitted for multi-repo merge pass\n'


### PR DESCRIPTION
## Summary

Adds per-repo deterministic_merge_pass timing summaries for list, mergeability, ruleset, branch-protection, and stuck-detector phases, plus a regression test proving multi-repo timing lines are emitted without changing return semantics.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-timing-summary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-timing-summary.sh && bash .agents/scripts/tests/test-pulse-merge-timing-summary.sh

Resolves #24977


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.4-mini spent 16m and 249,574 tokens on this as a headless worker.