### PR TITLE
fix: allow maintainer metadata in gh write guard

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -276,6 +276,7 @@ _shim_repo_role() {
 	local repo_slug="$1"
 	local repos_json="${AIDEVOPS_REPOS_JSON:-${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}}"
 	local explicit_role=""
+	local configured_maintainer=""
 	local current_user=""
 	local slug_owner=""
 	if [[ -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
@@ -286,13 +287,15 @@ _shim_repo_role() {
 			return 0
 			;;
 		esac
+		configured_maintainer=$(jq -r --arg slug "$repo_slug" 'first(.initialized_repos[]? | select(.slug == $slug) | .maintainer) // ""' "$repos_json" 2>/dev/null || true)
 	fi
 	# Match pulse/repo metadata semantics: omitted role is derived from the
-	# authenticated user and slug owner, then fail-closed to contributor.
+	# authenticated user and either configured maintainer or slug owner, then
+	# fail-closed to contributor.
 	if [[ -n "$repo_slug" && "$repo_slug" == */* && -n "${REAL_GH:-}" ]]; then
 		slug_owner="${repo_slug%%/*}"
 		current_user=$("$REAL_GH" api user --jq '.login' 2>/dev/null || true)
-		if [[ -n "$current_user" && "$slug_owner" == "$current_user" ]]; then
+		if [[ -n "$current_user" && ( "$configured_maintainer" == "$current_user" || "$slug_owner" == "$current_user" ) ]]; then
 			printf 'maintainer\n'
 			return 0
 		fi

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -72,7 +72,7 @@ cat >"$TMP/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 # Stub gh that logs argv
 if [[ "$1" == "api" && "$2" == "user" ]]; then
-	printf 'managed\n'
+	printf '%s\n' "${STUB_GH_USER:-managed}"
 	exit 0
 fi
 : >"$STUB_GH_LOG"
@@ -585,6 +585,31 @@ if [[ "$argv" == *$'api\n/repos/managed/repo/issues/789/comments'* ]]; then
 	_pass "omitted role on owned managed repo is derived as maintainer"
 else
 	_fail "missing role maintainer fallback" "argv: $argv err: $(cat "$TMP/guard-api-missing-role.err" 2>/dev/null || true)"
+fi
+
+repos_json_org_maintainer="$TMP/repos-org-maintainer.json"
+printf '{"initialized_repos":[{"slug":"org/repo","maintainer":"managed","pulse":true}]}' >"$repos_json_org_maintainer"
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json_org_maintainer" "$SHIM_RUN" api /repos/org/repo/issues/789/comments -X POST -f body="managed" 2>"$TMP/guard-api-org-maintainer.err"
+argv=$(_read_argv)
+if [[ "$argv" == *$'api\n/repos/org/repo/issues/789/comments'* ]]; then
+	_pass "configured maintainer on non-owned repo is derived as maintainer"
+else
+	_fail "configured maintainer fallback" "argv: $argv err: $(cat "$TMP/guard-api-org-maintainer.err" 2>/dev/null || true)"
+fi
+
+repos_json_org_nonmaintainer="$TMP/repos-org-nonmaintainer.json"
+printf '{"initialized_repos":[{"slug":"org/repo","maintainer":"other","pulse":true}]}' >"$repos_json_org_nonmaintainer"
+_reset_log
+if AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json_org_nonmaintainer" "$SHIM_RUN" api /repos/org/repo/issues/789/comments -X POST -f body="managed" 2>"$TMP/guard-api-org-nonmaintainer.err"; then
+	_fail "non-owner non-maintainer remains blocked" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-api-org-nonmaintainer.err"; then
+		_pass "non-owner non-maintainer remains blocked"
+	else
+		_fail "non-owner non-maintainer guard" "argv: $argv err: $(cat "$TMP/guard-api-org-nonmaintainer.err" 2>/dev/null || true)"
+	fi
 fi
 
 repos_json_contributor="$TMP/repos-contributor-role.json"


### PR DESCRIPTION
For #24965

## Summary
- allow headless gh write guard to derive maintainer capability from repos.json maintainer metadata as well as slug owner
- keep non-owner/non-maintainer repos blocked by default
- add gh shim regression coverage for configured maintainer on non-owned repos

## Verification
- bash -n .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh && .agents/scripts/tests/test-gh-shim.sh
- shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh
- .agents/scripts/linters-local.sh
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 51m and 460,203 tokens on this with the user in an interactive session.