### PR TITLE
GH#24943: fix: isolate floor loop dispatch stdout

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1434,7 +1434,7 @@ _dispatch_floor_loop() {
 			break
 		fi
 		local _dispatch_proc_rc=0
-		_dispatch_process_candidate "$candidate_json" "$self_login" "$available_slots" || _dispatch_proc_rc=$?
+		_dispatch_process_candidate "$candidate_json" "$self_login" "$available_slots" >>"$LOGFILE" 2>&1 || _dispatch_proc_rc=$?
 		echo "[pulse-wrapper] Dispatch_max: loop iter=${processed_count} — _dispatch_process_candidate rc=${_dispatch_proc_rc}" >>"$LOGFILE"
 		if [[ "$_dispatch_proc_rc" -eq 0 ]]; then
 			dispatched_count=$((dispatched_count + 1))

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -518,6 +518,35 @@ test_serial_loop_basic() {
 	return 0
 }
 
+test_serial_loop_isolates_candidate_stdout() {
+	# Stub: simulate noisy lower helpers before a successful launch. The serial
+	# loop must log that output instead of corrupting the count-only stdout
+	# consumed by pulse-dispatch-engine.sh.
+	# shellcheck disable=SC2317  # called via name resolution from loop
+	_dispatch_process_candidate() {
+		local candidate_json="$1"
+		printf 'lower-helper stdout before count for %s\n' "$candidate_json"
+		return 0
+	}
+
+	local candidate_file
+	candidate_file=$(mktemp)
+	printf '%s\n' '{"number":600,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}' >"$candidate_file"
+
+	rm -f "$STOP_FLAG"
+	_DISPATCH_THROTTLE_CLEARED=0
+	local result
+	result=$(_dispatch_floor_loop "$candidate_file" 10 10 "test_user")
+	rm -f "$candidate_file"
+
+	if [[ "$result" == "1 1" ]]; then
+		print_result "serial_loop: isolates candidate stdout from count output" 0
+	else
+		print_result "serial_loop: isolates candidate stdout from count output" 1 "got=${result}"
+	fi
+	return 0
+}
+
 test_serial_loop_budget_cap() {
 	# Stub: every candidate succeeds
 	# shellcheck disable=SC2317  # called via name resolution from loop
@@ -569,6 +598,7 @@ test_parallel_loop_stop_flag_aborts
 test_parallel_loop_graphql_budget_aborts
 test_dispatch_with_timeout_noop_outcome
 test_serial_loop_basic
+test_serial_loop_isolates_candidate_stdout
 test_serial_loop_budget_cap
 
 # Final summary


### PR DESCRIPTION
## Summary

Redirected _dispatch_floor_loop candidate processing stdout/stderr to LOGFILE so lower-helper output cannot corrupt the count-only loop_output parsed by pulse-dispatch-engine. Added a regression in test-dispatch-max-parallel.sh that stubs noisy candidate stdout and asserts the serial floor loop still returns 1 1.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-max-parallel.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-dispatch-max-parallel.sh; .agents/scripts/tests/test-dispatch-max-parallel.sh

Resolves #24943


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.91 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 52,598 tokens on this as a headless worker.