### PR TITLE
GH#24937: fix: classify dedup guard blocks before infra policy

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2276,7 +2276,11 @@ classify_dispatch_blocker_reason() {
 			printf 'local_capacity_gate\n'
 			return 0
 			;;
-		*no-auto-dispatch* | *infrastructure* | *external*author*gate* | *nmr*gate* | *approval*required*)
+		*dedup*guard*blocked*)
+			printf 'dedup_active_claim\n'
+			return 0
+			;;
+		*no-auto-dispatch* | *infrastructure_blocked* | *label=infrastructure* | *external*author*gate* | *nmr*gate* | *approval*required*)
 			printf 'policy_gate\n'
 			return 0
 			;;

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1375,6 +1375,7 @@ _dispatch_dedup_check_layers() {
 	ISSUE_META_JSON="$issue_meta_json" \
 		check_dispatch_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" "$self_login" || _dedup_rc=$?
 	if [[ "$_dedup_rc" -eq 0 || "$_dedup_rc" -eq 3 ]]; then
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=dedup_active_claim signal=dedup_guard_blocked issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
 		echo "[dispatch_with_dedup] Dedup guard blocked #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.7_layers" "$_dss_t0"
 		if [[ "$_dedup_rc" -eq 3 ]]; then

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -35,6 +35,8 @@ assert_reason 'skipping historical ever-NMR check for bot-generated cleanup issu
 assert_reason 'DISPATCH_BLOCK_REASON reason=blocked_by_native_lookup_unavailable signal=native blockedBy lookup unavailable and no body blocked-by markers found' 'blocked_by_native_lookup_unavailable'
 assert_reason 'pre-dispatch validator failed: missing worker context; needs-brief label present' 'missing_worker_context'
 assert_reason 'dedup.worktree_cap blocked by max worktree count' 'local_capacity_gate'
+assert_reason 'dedup guard blocked #303 in some-org/infrastructure' 'dedup_active_claim'
+assert_reason 'INFRASTRUCTURE_BLOCKED (label=infrastructure)' 'policy_gate'
 assert_reason 'external_author_gate blocked no-auto-dispatch policy' 'policy_gate'
 assert_reason '' 'no_recent_log_evidence'
 assert_reason 'new blocker shape not yet classified' 'unclassified_signal'

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -163,6 +163,15 @@ test_pr_guard_emits_structured_block_reason() {
 	return 0
 }
 
+test_dedup_guard_emits_structured_block_reason() {
+	if grep -q 'DISPATCH_BLOCK_REASON reason=dedup_active_claim signal=dedup_guard_blocked' "$CORE_SCRIPT"; then
+		print_result "dedup guard emits structured active-claim block reason" 0
+		return 0
+	fi
+	print_result "dedup guard emits structured active-claim block reason" 1 "expected dedup guard structured reason in dispatch core"
+	return 0
+}
+
 main() {
 	if ! define_helpers_under_test; then
 		return 1
@@ -176,6 +185,7 @@ main() {
 	test_interactive_hold_allows_worker_issue
 	test_interactive_hold_emits_structured_block_reason
 	test_pr_guard_emits_structured_block_reason
+	test_dedup_guard_emits_structured_block_reason
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Narrowed infrastructure policy classification to structured infrastructure signals, classified dedup guard log text as dedup_active_claim, and emitted a structured DISPATCH_BLOCK_REASON for dedup guard blocks.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh,.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh; .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh; shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh

Resolves #24937


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.91 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 76,065 tokens on this as a headless worker.