### PR TITLE
GH#24942: fix: make trailing newline helper set-e safe

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -163,11 +163,16 @@ check_file() {
 ensure_trailing_newline() {
 	local file="$1"
 	local last
-	last="$(
-		tail -c 1 "$file"
-		printf x
-	)"
-	[[ -s "$file" ]] && [[ "$last" != $'\n'x ]] && printf '\n' >>"$file"
+	if [[ -s "$file" ]]; then
+		last="$(
+			tail -c 1 "$file"
+			printf x
+		)"
+		if [[ "$last" != $'\n'x ]]; then
+			printf '\n' >>"$file"
+		fi
+	fi
+	return 0
 }
 
 # Source CLI implementation modules from the namespaced module tree.

--- a/tests/test-ensure-trailing-newline.sh
+++ b/tests/test-ensure-trailing-newline.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+load_function() {
+	python3 - "$REPO_DIR/aidevops.sh" <<'PY'
+import sys
+
+path = sys.argv[1]
+collect = False
+depth = 0
+with open(path, "r", encoding="utf-8") as handle:
+    for line in handle:
+        if line.startswith("ensure_trailing_newline()"):
+            collect = True
+        if collect:
+            print(line, end="")
+            depth += line.count("{") - line.count("}")
+            if depth == 0 and line.strip() == "}":
+                break
+PY
+	return 0
+}
+
+eval "$(load_function)"
+
+assert_file_bytes() {
+	local file="$1"
+	local expected="$2"
+	local actual
+	actual="$(python3 - "$file" <<'PY'
+import sys
+with open(sys.argv[1], "rb") as handle:
+    print(repr(handle.read().decode("utf-8")))
+PY
+)"
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'Expected %s, got %s\n' "$expected" "$actual" >&2
+		return 1
+	fi
+	return 0
+}
+
+with_newline="$TMP_DIR/with-newline.txt"
+without_newline="$TMP_DIR/without-newline.txt"
+empty_file="$TMP_DIR/empty.txt"
+
+printf 'already newline\n' >"$with_newline"
+printf 'missing newline' >"$without_newline"
+: >"$empty_file"
+
+ensure_trailing_newline "$with_newline"
+ensure_trailing_newline "$without_newline"
+ensure_trailing_newline "$empty_file"
+
+assert_file_bytes "$with_newline" "'already newline\\n'"
+assert_file_bytes "$without_newline" "'missing newline\\n'"
+assert_file_bytes "$empty_file" "''"
+
+printf 'ensure_trailing_newline handles newline-present, newline-missing, and empty files\n'


### PR DESCRIPTION
## Summary

Reworked ensure_trailing_newline to return success when files already end with newlines and added a focused regression test for newline-present, newline-missing, and empty-file cases.

## Files Changed

aidevops.sh,tests/test-ensure-trailing-newline.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-ensure-trailing-newline.sh; bash -n aidevops.sh tests/test-ensure-trailing-newline.sh; shellcheck aidevops.sh tests/test-ensure-trailing-newline.sh

Resolves #24942


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.91 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 4m and 63,159 tokens on this as a headless worker.