### PR TITLE
GH#24944: fix: respect pulse capacity cap during floor refill

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -898,17 +898,50 @@ _dispatch_min_worker_floor_refill() {
 	if ((min_worker_floor <= 0)); then
 		return 0
 	fi
+	local capped_max_workers capped_active_workers capped_available_slots
+	capped_max_workers=$(get_max_workers_target)
+	capped_active_workers=$(count_active_workers)
+	[[ "$capped_max_workers" =~ ^[0-9]+$ ]] || capped_max_workers=1
+	[[ "$capped_active_workers" =~ ^[0-9]+$ ]] || capped_active_workers=0
+	local refill_floor_active=0
+	if declare -F pulse_apply_provider_load_capacity_cap >/dev/null 2>&1; then
+		local capacity_cap_line=""
+		capacity_cap_line=$(pulse_apply_provider_load_capacity_cap "$capped_max_workers" "$capped_active_workers" "$min_worker_floor") || capacity_cap_line="${capped_max_workers} 0"
+		read -r capped_max_workers refill_floor_active <<<"$capacity_cap_line"
+		[[ "$capped_max_workers" =~ ^[0-9]+$ ]] || capped_max_workers=1
+		[[ "$refill_floor_active" =~ ^[0-9]+$ ]] || refill_floor_active=0
+	elif ((min_worker_floor > 0 && capped_active_workers < min_worker_floor)); then
+		refill_floor_active=1
+		if ((capped_max_workers < min_worker_floor)); then
+			capped_max_workers="$min_worker_floor"
+		fi
+	fi
+	capped_available_slots=$((capped_max_workers - capped_active_workers))
+	local guardrail_line=""
+	guardrail_line=$(_dispatch_apply_current_state_guardrails "$capped_max_workers" "$capped_active_workers" "$capped_available_slots") || guardrail_line="${capped_max_workers} ${capped_active_workers} ${capped_available_slots}"
+	read -r capped_max_workers capped_active_workers capped_available_slots <<<"$guardrail_line"
+	[[ "$capped_max_workers" =~ ^[0-9]+$ ]] || capped_max_workers=1
+	[[ "$capped_active_workers" =~ ^[0-9]+$ ]] || capped_active_workers=0
+	[[ "$capped_available_slots" =~ ^-?[0-9]+$ ]] || capped_available_slots=0
+	if ((capped_available_slots < 0)); then
+		capped_available_slots=0
+	fi
+	if (( refill_floor_active <= 0 || capped_max_workers <= capped_active_workers || capped_available_slots <= 0 )); then
+		return 0
+	fi
 
 	local refill_attempt=0
 	local max_refill_attempts="$min_worker_floor"
-	local active_workers fill_dispatched
+	local active_workers="$capped_active_workers" active_workers_known=1 fill_dispatched
 	while ((refill_attempt < max_refill_attempts)); do
 		if [[ -f "$STOP_FLAG" ]]; then
 			echo "[pulse-wrapper] Minimum worker floor refill stopped: stop flag present" >>"$LOGFILE"
 			return 0
 		fi
-		active_workers=$(count_active_workers)
-		[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+		if ((active_workers_known <= 0)); then
+			active_workers=$(count_active_workers)
+			[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+		fi
 		if ((active_workers >= min_worker_floor)); then
 			return 0
 		fi
@@ -922,6 +955,7 @@ _dispatch_min_worker_floor_refill() {
 			return 0
 		fi
 		_adaptive_launch_settle_wait "$fill_dispatched" "minimum worker floor refill"
+		active_workers_known=0
 	done
 
 	echo "[pulse-wrapper] Minimum worker floor refill stopped: reached attempt cap ${max_refill_attempts}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -688,6 +688,9 @@ _dispatch_compute_capacity() {
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 	[[ "$available_slots" =~ ^-?[0-9]+$ ]] || available_slots=0
+	if ((available_slots < 0)); then
+		available_slots=0
+	fi
 
 	printf '%s %s %s\n' "$max_workers" "$active_workers" "$available_slots"
 	return 0

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -314,6 +314,37 @@ test_capacity_recent_progress_gets_runway_under_pressure() {
 	return 0
 }
 
+test_capacity_clamps_provider_cap_below_active_to_zero_available() {
+	(
+		reset_capacity_pressure_env
+		TEST_MAX_WORKERS=8
+		TEST_ACTIVE_WORKERS=4
+		AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+		pulse_apply_provider_load_capacity_cap() {
+			printf '1 0\n'
+			return 0
+		}
+		unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
+		local result capacity_file
+		capacity_file=$(mktemp)
+		_dispatch_compute_capacity >"$capacity_file"
+		result=$(<"$capacity_file")
+		rm -f "$capacity_file"
+		if [[ "$result" == "1 4 0" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "0" ]]; then
+			return 0
+		fi
+		printf 'result=%s floor_active=%s\n' "$result" "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}" >"${TEST_ROOT}/capacity-clamp-failure.txt"
+		return 1
+	)
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "capacity: provider cap below active clamps available to zero" 0
+	else
+		print_result "capacity: provider cap below active clamps available to zero" 1 "$(<"${TEST_ROOT}/capacity-clamp-failure.txt")"
+	fi
+	return 0
+}
+
 test_throttle_does_not_force_serial_under_floor() {
 	reset_capacity_pressure_env
 	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
@@ -391,6 +422,7 @@ test_apply_dispatch_refills_until_active_floor_after_partial_launch() {
 	printf '%s\n%s\n' 4 6 >"$TEST_ACTIVE_WORKERS_SEQUENCE_FILE"
 	printf '%s\n' 0 >"$TEST_DISPATCH_CALLS_FILE"
 	printf '%s\n%s\n' 2 2 >"$TEST_DISPATCH_RETURNS_FILE"
+	AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS=1
 	STOP_FLAG="${HOME}/.aidevops/logs/stop"
 	# shellcheck disable=SC2329  # Override sourced function for this regression.
 	dispatch_max() {
@@ -420,7 +452,54 @@ test_apply_dispatch_refills_until_active_floor_after_partial_launch() {
 	else
 		print_result "apply: refills minimum active-worker floor after partial launch" 1 "dispatch_calls=${dispatch_calls}"
 	fi
-	unset TEST_ACTIVE_WORKERS_SEQUENCE_FILE TEST_DISPATCH_CALLS_FILE TEST_DISPATCH_RETURNS_FILE
+	unset TEST_ACTIVE_WORKERS_SEQUENCE_FILE TEST_DISPATCH_CALLS_FILE TEST_DISPATCH_RETURNS_FILE AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS
+	return 0
+}
+
+test_apply_dispatch_skips_refill_when_capacity_cap_disables_floor() {
+	(
+		AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+		TEST_MAX_WORKERS=8
+		TEST_ACTIVE_WORKERS=4
+		TEST_DISPATCH_CALLS_FILE="${TEST_ROOT}/cap-refill-dispatch-calls.txt"
+		printf '%s\n' 0 >"$TEST_DISPATCH_CALLS_FILE"
+		STOP_FLAG="${HOME}/.aidevops/logs/stop"
+		: >"$LOGFILE"
+		pulse_apply_provider_load_capacity_cap() {
+			printf '1 0\n'
+			return 0
+		}
+		# shellcheck disable=SC2329  # Override sourced function for this regression.
+		dispatch_max() {
+			local calls
+			calls=$(<"$TEST_DISPATCH_CALLS_FILE")
+			[[ "$calls" =~ ^[0-9]+$ ]] || calls=0
+			printf '%s\n' "$((calls + 1))" >"$TEST_DISPATCH_CALLS_FILE"
+			printf '0\n'
+			return 0
+		}
+		# shellcheck disable=SC2329  # Override sourced function to keep the test fast.
+		_adaptive_launch_settle_wait() {
+			return 0
+		}
+
+		apply_dispatch_max
+
+		local dispatch_calls
+		dispatch_calls=$(<"$TEST_DISPATCH_CALLS_FILE")
+		if [[ "$dispatch_calls" -eq 1 ]] && ! grep -q 'Minimum worker floor refill:' "$LOGFILE" 2>/dev/null; then
+			return 0
+		fi
+		printf 'dispatch_calls=%s log=%s\n' "$dispatch_calls" "$(<"$LOGFILE")" >"${TEST_ROOT}/cap-refill-failure.txt"
+		return 1
+	)
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "apply: capacity cap disables minimum floor refill" 0
+	else
+		print_result "apply: capacity cap disables minimum floor refill" 1 "$(<"${TEST_ROOT}/cap-refill-failure.txt")"
+	fi
+	unset TEST_DISPATCH_CALLS_FILE
 	return 0
 }
 
@@ -545,10 +624,12 @@ test_capacity_env_multiplier_overrides_config
 test_capacity_defaults_single_account_to_max_cap
 test_capacity_recent_service_interruptions_reduce_slots
 test_capacity_recent_progress_gets_runway_under_pressure
+test_capacity_clamps_provider_cap_below_active_to_zero_available
 test_throttle_does_not_force_serial_under_floor
 test_throttle_forces_serial_above_floor
 test_canary_preflight_marks_floor_without_cpu_bypass
 test_apply_dispatch_refills_until_active_floor_after_partial_launch
+test_apply_dispatch_skips_refill_when_capacity_cap_disables_floor
 test_active_pulse_refill_uses_min_floor_above_raw_max
 test_soft_canary_failure_bypasses_with_recent_worker_evidence
 test_hard_canary_failure_blocks_despite_recent_worker_evidence


### PR DESCRIPTION
## Summary

Clamped dispatch capacity available slots to zero when caps put max at or below active workers, made minimum-floor refill recompute and honor provider/load floor eligibility before re-entering dispatch, and added regression coverage for provider caps below active worker count.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-dispatch-min-concurrency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-min-concurrency.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh

Resolves #24944


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.91 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 7m and 81,350 tokens on this as a headless worker.