### PR TITLE
GH#24935: fix: check rulesets before stuck branchprotect 404

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -312,19 +312,37 @@ _classify_stuck_pr() {
 			2>&1)
 		protection_exit=$?
 		if [[ $protection_exit -ne 0 ]]; then
-			# 404 = no protection (intentional or accidental — the
-			# rollup-pass path will still gate based on actual checks).
+			# 404 = no classic protection. Org/repo rulesets can still enforce
+			# required checks, so mirror pulse-merge-process.sh before treating the
+			# branch as unprotected (GH#24935 / GH#23019).
 			if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
-				printf 'STUCK_BRANCHPROTECT_404'
+				local ruleset_contexts_404=""
+				if declare -F _required_contexts_from_rulesets_for_default_branch >/dev/null 2>&1; then
+					ruleset_contexts_404=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || {
+						printf 'STUCK_BRANCHPROTECT_API_ERROR'
+						return 0
+					}
+					if [[ -n "$ruleset_contexts_404" ]]; then
+						echo "[pulse-merge-stuck] _classify_stuck_pr: no classic branch protection on ${repo_slug} (HTTP 404), but active rulesets require contexts; continuing rollup classification (GH#24935)" >>"$LOGFILE"
+						protection_exit=0
+					else
+						printf 'STUCK_BRANCHPROTECT_404'
+						return 0
+					fi
+				else
+					printf 'STUCK_BRANCHPROTECT_404'
+					return 0
+				fi
+			fi
+			if [[ $protection_exit -ne 0 ]]; then
+				# 401 / 403 / 5xx etc — transient or auth break.
+				if grep -qi 'HTTP 401\|authentication required\|bad credentials' <<<"$protection_resp"; then
+					printf 'STUCK_AUTH'
+					return 0
+				fi
+				printf 'STUCK_BRANCHPROTECT_API_ERROR'
 				return 0
 			fi
-			# 401 / 403 / 5xx etc — transient or auth break.
-			if grep -qi 'HTTP 401\|authentication required\|bad credentials' <<<"$protection_resp"; then
-				printf 'STUCK_AUTH'
-				return 0
-			fi
-			printf 'STUCK_BRANCHPROTECT_API_ERROR'
-			return 0
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -562,6 +562,7 @@ gh_pr_view() {
 	205) printf 'sha-legacy-failing' ;;
 	206) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-legacy-error"}' ;;
 	207) printf 'sha-legacy-error' ;;
+	208) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean-ruleset"}' ;;
 	*) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean"}' ;;
 	esac
 	return 0
@@ -588,11 +589,30 @@ gh() {
 		printf 'main'
 		return 0
 	fi
+	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/ruleset-repo" ]]; then
+		printf 'main'
+		return 0
+	fi
 	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/repo/branches/main/protection/required_status_checks" ]]; then
 		printf '{}'
 		return 0
 	fi
+	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/ruleset-repo/branches/main/protection/required_status_checks" ]]; then
+		printf '{"message":"Not Found"}' >&2
+		return 1
+	fi
 	return 1
+}
+
+_required_contexts_from_rulesets_for_default_branch() {
+	local repo_slug="$1"
+	local default_branch="$2"
+	[[ "$default_branch" == "main" ]] || return 1
+	if [[ "$repo_slug" == "example/ruleset-repo" ]]; then
+		printf 'CI / build\n'
+		return 0
+	fi
+	return 0
 }
 
 got=$(_classify_stuck_pr "201" "example/repo" "1")
@@ -622,6 +642,10 @@ assert_eq "7f: legacy status context state=error classifies as checks failing" \
 got=$(_pms_failure_fingerprint "207" "example/repo")
 assert_eq "7g: legacy error status context fingerprint uses context name" \
 	"legacy-error" "$got"
+
+got=$(_classify_stuck_pr "208" "example/ruleset-repo" "0")
+assert_eq "7h: rulesets required checks prevent branch-protection 404 classification" \
+	"STUCK_OTHER" "$got"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updated pulse-merge-stuck.sh so HTTP 404 from classic branch protection checks org/repo ruleset required contexts before classifying STUCK_BRANCHPROTECT_404; added a regression case covering rulesets-only required checks.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-stuck.sh (54 tests, 0 failures); shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh; .agents/scripts/linters-local.sh (timed out during Secretlint after passing SonarCloud, string literals, FD locks, shellcheckrc parity)

Resolves #24935


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.91 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 10m and 69,071 tokens on this as a headless worker.