### PR TITLE
fix: honor maintainer metadata in pulse role guard

### DIFF
--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -114,7 +114,7 @@ get_repo_priority_by_slug() {
 #
 # Returns "maintainer" or "contributor". Resolution order:
 #   1. Explicit "role" field in repos.json entry
-#   2. Auto-detect: if slug owner matches the current gh user → maintainer
+#   2. Configured maintainer or slug owner matches current gh user → maintainer
 #   3. Default: contributor (safe default — gates scanners rather than
 #      allowing them on repos we don't own)
 #
@@ -137,6 +137,7 @@ get_repo_role_by_slug() {
 	fi
 
 	# 1. Explicit role field in repos.json
+	local configured_maintainer=""
 	if [[ -f "$REPOS_JSON" ]]; then
 		local explicit_role
 		explicit_role=$(jq -r --arg slug "$repo_slug" \
@@ -146,15 +147,18 @@ get_repo_role_by_slug() {
 			printf '%s\n' "$explicit_role"
 			return 0
 		fi
+		configured_maintainer=$(jq -r --arg slug "$repo_slug" \
+			'.initialized_repos[] | select(.slug == $slug) | .maintainer // ""' \
+			"$REPOS_JSON" 2>/dev/null | head -n 1) || configured_maintainer=""
 	fi
 
-	# 2. Auto-detect from slug owner vs current gh user.
+	# 2. Auto-detect from configured maintainer or slug owner vs current gh user.
 	# Cache the gh user for the process lifetime to avoid repeated API calls.
 	if [[ -z "${_CACHED_GH_USER:-}" ]]; then
 		_CACHED_GH_USER=$(gh api user --jq '.login' 2>/dev/null) || _CACHED_GH_USER=""
 	fi
 	local slug_owner="${repo_slug%%/*}"
-	if [[ -n "$_CACHED_GH_USER" && "$slug_owner" == "$_CACHED_GH_USER" ]]; then
+	if [[ -n "$_CACHED_GH_USER" && ( "$configured_maintainer" == "$_CACHED_GH_USER" || "$slug_owner" == "$_CACHED_GH_USER" ) ]]; then
 		echo "$_PULSE_REPO_ROLE_MAINTAINER"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-repo-role-guard.sh
+++ b/.agents/scripts/tests/test-repo-role-guard.sh
@@ -58,6 +58,16 @@ cat >"$TEST_REPOS_JSON" <<'JSON'
     {
       "slug": "charlie/auto-detect-other",
       "pulse": true
+    },
+    {
+      "slug": "org/maintained-repo",
+      "pulse": true,
+      "maintainer": "alice"
+    },
+    {
+      "slug": "org/not-maintained-repo",
+      "pulse": true,
+      "maintainer": "charlie"
     }
   ],
   "git_parent_dirs": []
@@ -110,6 +120,14 @@ assert_eq "auto-detect: slug owner matches gh user → maintainer" "maintainer" 
 # Test 4: Auto-detect — slug owner differs from gh user → contributor
 role=$(get_repo_role_by_slug "charlie/auto-detect-other")
 assert_eq "auto-detect: slug owner differs → contributor" "contributor" "$role"
+
+# Test 4b: Configured maintainer matches gh user even when slug owner differs.
+role=$(get_repo_role_by_slug "org/maintained-repo")
+assert_eq "auto-detect: configured maintainer matches gh user → maintainer" "maintainer" "$role"
+
+# Test 4c: Configured maintainer differs and slug owner differs → contributor.
+role=$(get_repo_role_by_slug "org/not-maintained-repo")
+assert_eq "auto-detect: configured maintainer differs → contributor" "contributor" "$role"
 
 # Test 5: Empty slug → contributor (safe default)
 role=$(get_repo_role_by_slug "")


### PR DESCRIPTION
Resolves #24999

## Summary
- Honor configured `maintainer` metadata in the pulse repo role guard when no explicit `role` is set.
- Keep explicit `role: contributor` authoritative/fail-closed.
- Add regression coverage for org-owned repos maintained by the current GitHub user.

## Verification
- `bash -n .agents/scripts/pulse-repo-meta.sh .agents/scripts/tests/test-repo-role-guard.sh`
- `bash .agents/scripts/tests/test-repo-role-guard.sh`
- `shellcheck .agents/scripts/pulse-repo-meta.sh .agents/scripts/tests/test-repo-role-guard.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.91 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1h 39m and 902,089 tokens on this with the user in an interactive session.