### PR TITLE
GH#25000: fix: reuse precomputed refill worker counts

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -843,7 +843,7 @@ apply_dispatch_max() {
 	[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
 
 	_adaptive_launch_settle_wait "$fill_dispatched" "dispatch_max"
-	_dispatch_min_worker_floor_refill
+	_dispatch_min_worker_floor_refill "" ""
 
 	# t2749: Phase 2 — re-enumerate when consolidation created a child during
 	# Phase 1. The sentinel is written by _dispatch_issue_consolidation in
@@ -865,7 +865,7 @@ apply_dispatch_max() {
 			fill_dispatched_p2=$(dispatch_max) || fill_dispatched_p2=0
 			[[ "$fill_dispatched_p2" =~ ^[0-9]+$ ]] || fill_dispatched_p2=0
 			_adaptive_launch_settle_wait "$fill_dispatched_p2" "dispatch_max phase 2"
-			_dispatch_min_worker_floor_refill
+			_dispatch_min_worker_floor_refill "$_p2_max"
 		else
 			echo "[pulse-wrapper] Dispatch_max Phase 2: consolidation child created but slots full (active=${_p2_active}, max=${_p2_max}) — skipping (t2749)" >>"$LOGFILE"
 		fi
@@ -885,6 +885,10 @@ apply_dispatch_max() {
 # and per-candidate blockers; a zero-dispatch round ends the refill.
 #
 # Returns 0 always; best-effort refill should not abort the pulse cycle.
+#
+# Args:
+#   $1 - optional capped max-worker target
+#   $2 - optional capped active-worker count
 #######################################
 _dispatch_min_worker_floor_refill() {
 	local min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-}"
@@ -898,9 +902,9 @@ _dispatch_min_worker_floor_refill() {
 	if ((min_worker_floor <= 0)); then
 		return 0
 	fi
-	local capped_max_workers capped_active_workers capped_available_slots
-	capped_max_workers=$(get_max_workers_target)
-	capped_active_workers=$(count_active_workers)
+	local capped_max_workers="${1:-}" capped_active_workers="${2:-}" capped_available_slots
+	[[ -n "$capped_max_workers" ]] || capped_max_workers=$(get_max_workers_target)
+	[[ -n "$capped_active_workers" ]] || capped_active_workers=$(count_active_workers)
 	[[ "$capped_max_workers" =~ ^[0-9]+$ ]] || capped_max_workers=1
 	[[ "$capped_active_workers" =~ ^[0-9]+$ ]] || capped_active_workers=0
 	local refill_floor_active=0
@@ -1181,7 +1185,7 @@ maybe_refill_underfilled_pool_during_active_pulse() {
 	echo "[pulse-wrapper] Active pulse refill: underfilled ${active_workers}/${refill_target} (raw_max=${max_workers}) with runnable=${runnable_count}, queued_without_worker=${queued_without_worker}, idle=${idle_seconds}s, stall=${progress_stall_seconds}s" >>"$LOGFILE"
 	run_underfill_worker_recycler "$max_workers" "$active_workers" "$runnable_count" "$queued_without_worker"
 	dispatch_max >/dev/null || true
-	_dispatch_min_worker_floor_refill
+	_dispatch_min_worker_floor_refill "$max_workers"
 
 	echo "$now_epoch"
 	return 0
@@ -1399,7 +1403,7 @@ _run_early_exit_recycle_loop() {
 		fi
 
 		dispatch_max >/dev/null || true
-		_dispatch_min_worker_floor_refill
+		_dispatch_min_worker_floor_refill "$post_max"
 		post_active=$(count_active_workers)
 		post_runnable=$(normalize_count_output "$(count_runnable_candidates)")
 		post_queued=$(normalize_count_output "$(count_queued_without_worker)")

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -865,7 +865,7 @@ apply_dispatch_max() {
 			fill_dispatched_p2=$(dispatch_max) || fill_dispatched_p2=0
 			[[ "$fill_dispatched_p2" =~ ^[0-9]+$ ]] || fill_dispatched_p2=0
 			_adaptive_launch_settle_wait "$fill_dispatched_p2" "dispatch_max phase 2"
-			_dispatch_min_worker_floor_refill "$_p2_max"
+			_dispatch_min_worker_floor_refill "$_p2_max" "$((_p2_active + fill_dispatched_p2))"
 		else
 			echo "[pulse-wrapper] Dispatch_max Phase 2: consolidation child created but slots full (active=${_p2_active}, max=${_p2_max}) — skipping (t2749)" >>"$LOGFILE"
 		fi
@@ -1402,8 +1402,10 @@ _run_early_exit_recycle_loop() {
 			break
 		fi
 
-		dispatch_max >/dev/null || true
-		_dispatch_min_worker_floor_refill "$post_max"
+		local early_dispatched
+		early_dispatched=$(dispatch_max) || early_dispatched=0
+		[[ "$early_dispatched" =~ ^[0-9]+$ ]] || early_dispatched=0
+		_dispatch_min_worker_floor_refill "$post_max" "$((post_active + early_dispatched))"
 		post_active=$(count_active_workers)
 		post_runnable=$(normalize_count_output "$(count_runnable_candidates)")
 		post_queued=$(normalize_count_output "$(count_queued_without_worker)")

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -503,6 +503,49 @@ test_apply_dispatch_skips_refill_when_capacity_cap_disables_floor() {
 	return 0
 }
 
+test_min_worker_floor_refill_uses_precomputed_counts() {
+	(
+		AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+		AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS=1
+		STOP_FLAG="${HOME}/.aidevops/logs/stop"
+		TEST_GET_MAX_CALLED_FILE="${TEST_ROOT}/precomputed-get-max-called.txt"
+		TEST_COUNT_ACTIVE_CALLED_FILE="${TEST_ROOT}/precomputed-count-active-called.txt"
+		get_max_workers_target() {
+			printf 'called\n' >"$TEST_GET_MAX_CALLED_FILE"
+			printf '1\n'
+			return 0
+		}
+		count_active_workers() {
+			printf 'called\n' >"$TEST_COUNT_ACTIVE_CALLED_FILE"
+			printf '0\n'
+			return 0
+		}
+		dispatch_max() {
+			printf 'dispatch_max should not be called with active worker count at floor\n' >"${TEST_ROOT}/precomputed-dispatch-called.txt"
+			return 1
+		}
+
+		_dispatch_min_worker_floor_refill 8 6
+
+		if [[ ! -f "$TEST_GET_MAX_CALLED_FILE" && ! -f "$TEST_COUNT_ACTIVE_CALLED_FILE" && ! -f "${TEST_ROOT}/precomputed-dispatch-called.txt" ]]; then
+			return 0
+		fi
+		printf 'get_max_called=%s count_active_called=%s dispatch_called=%s\n' \
+			"$([[ -f "$TEST_GET_MAX_CALLED_FILE" ]] && printf yes || printf no)" \
+			"$([[ -f "$TEST_COUNT_ACTIVE_CALLED_FILE" ]] && printf yes || printf no)" \
+			"$([[ -f "${TEST_ROOT}/precomputed-dispatch-called.txt" ]] && printf yes || printf no)" >"${TEST_ROOT}/precomputed-refill-failure.txt"
+		return 1
+	)
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "refill: precomputed counts skip worker count reads" 0
+	else
+		print_result "refill: precomputed counts skip worker count reads" 1 "$(<"${TEST_ROOT}/precomputed-refill-failure.txt")"
+	fi
+	unset TEST_GET_MAX_CALLED_FILE TEST_COUNT_ACTIVE_CALLED_FILE AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS
+	return 0
+}
+
 test_active_pulse_refill_uses_min_floor_above_raw_max() {
 	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
 	TEST_MAX_WORKERS=1
@@ -630,6 +673,7 @@ test_throttle_forces_serial_above_floor
 test_canary_preflight_marks_floor_without_cpu_bypass
 test_apply_dispatch_refills_until_active_floor_after_partial_launch
 test_apply_dispatch_skips_refill_when_capacity_cap_disables_floor
+test_min_worker_floor_refill_uses_precomputed_counts
 test_active_pulse_refill_uses_min_floor_above_raw_max
 test_soft_canary_failure_bypasses_with_recent_worker_evidence
 test_hard_canary_failure_blocks_despite_recent_worker_evidence


### PR DESCRIPTION
## Summary

Updated _dispatch_min_worker_floor_refill to accept optional precomputed max/active worker counts, passed known max-worker values from callers where safe, and added a regression test proving supplied counts skip redundant worker-count reads.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-dispatch-min-concurrency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-min-concurrency.sh; shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/tests/test-dispatch-min-concurrency.sh; pre-commit hook during WIP commit

Resolves #25000


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 106,788 tokens on this as a headless worker.