### PR TITLE
GH#25014: fix: propagate ruleset helper errors

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -318,13 +318,14 @@ _classify_stuck_pr() {
 			if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
 				local ruleset_contexts_404=""
 				if declare -F _required_contexts_from_rulesets_for_default_branch >/dev/null 2>&1; then
-					ruleset_contexts_404=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || {
+					local ruleset_contexts_rc=0
+					ruleset_contexts_404=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || ruleset_contexts_rc=$?
+					if [[ $ruleset_contexts_rc -ne 0 ]]; then
 						printf 'STUCK_BRANCHPROTECT_API_ERROR'
-						return 0
-					}
+						return "$ruleset_contexts_rc"
+					fi
 					if [[ -n "$ruleset_contexts_404" ]]; then
 						echo "[pulse-merge-stuck] _classify_stuck_pr: no classic branch protection on ${repo_slug} (HTTP 404), but active rulesets require contexts; continuing rollup classification (GH#24935)" >>"$LOGFILE"
-						protection_exit=0
 					else
 						printf 'STUCK_BRANCHPROTECT_404'
 						return 0
@@ -333,8 +334,7 @@ _classify_stuck_pr() {
 					printf 'STUCK_BRANCHPROTECT_404'
 					return 0
 				fi
-			fi
-			if [[ $protection_exit -ne 0 ]]; then
+			else
 				# 401 / 403 / 5xx etc — transient or auth break.
 				if grep -qi 'HTTP 401\|authentication required\|bad credentials' <<<"$protection_resp"; then
 					printf 'STUCK_AUTH'

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -563,6 +563,7 @@ gh_pr_view() {
 	206) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-legacy-error"}' ;;
 	207) printf 'sha-legacy-error' ;;
 	208) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean-ruleset"}' ;;
+	209) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean-ruleset-fail"}' ;;
 	*) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean"}' ;;
 	esac
 	return 0
@@ -593,11 +594,19 @@ gh() {
 		printf 'main'
 		return 0
 	fi
+	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/ruleset-fail" ]]; then
+		printf 'main'
+		return 0
+	fi
 	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/repo/branches/main/protection/required_status_checks" ]]; then
 		printf '{}'
 		return 0
 	fi
 	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/ruleset-repo/branches/main/protection/required_status_checks" ]]; then
+		printf '{"message":"Not Found"}' >&2
+		return 1
+	fi
+	if [[ "$command_name" == "api" && "$path_arg" == "repos/example/ruleset-fail/branches/main/protection/required_status_checks" ]]; then
 		printf '{"message":"Not Found"}' >&2
 		return 1
 	fi
@@ -611,6 +620,9 @@ _required_contexts_from_rulesets_for_default_branch() {
 	if [[ "$repo_slug" == "example/ruleset-repo" ]]; then
 		printf 'CI / build\n'
 		return 0
+	fi
+	if [[ "$repo_slug" == "example/ruleset-fail" ]]; then
+		return 7
 	fi
 	return 0
 }
@@ -646,6 +658,13 @@ assert_eq "7g: legacy error status context fingerprint uses context name" \
 got=$(_classify_stuck_pr "208" "example/ruleset-repo" "0")
 assert_eq "7h: rulesets required checks prevent branch-protection 404 classification" \
 	"STUCK_OTHER" "$got"
+
+got=$(_classify_stuck_pr "209" "example/ruleset-fail" "0")
+ruleset_fail_rc=$?
+assert_eq "7i: ruleset helper failure reports branch-protection API error" \
+	"STUCK_BRANCHPROTECT_API_ERROR" "$got"
+assert_eq "7j: ruleset helper failure propagates helper exit code" \
+	"7" "$ruleset_fail_rc"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Refactored pulse-merge-stuck branch-protection 404 handling so ruleset-required contexts continue without mutating protection_exit, and ruleset helper failures emit STUCK_BRANCHPROTECT_API_ERROR while returning the helper exit code. Added regression coverage for helper failure propagation.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh && .agents/scripts/tests/test-pulse-merge-stuck.sh

Resolves #25014


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 47,299 tokens on this as a headless worker.