### PR TITLE
GH#25020: fix: remove eval from merge timing counters

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -81,7 +81,7 @@ _pmp_add_elapsed_seconds() {
 	elapsed=$((end_epoch - start_epoch))
 	[[ "$elapsed" =~ ^[0-9]+$ ]] || elapsed=0
 
-	current_value=$(eval "printf '%s' \"\${$dest_var:-0}\"" 2>/dev/null) || current_value=0
+	current_value="${!dest_var:-0}"
 	[[ "$current_value" =~ ^[0-9]+$ ]] || current_value=0
 	current_value=$((current_value + elapsed))
 	printf -v "$dest_var" '%s' "$current_value"
@@ -505,7 +505,10 @@ _merge_ready_prs_for_repo() {
 	local pr_count
 	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
 	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	[[ -z "$_pr_count_var" ]] || eval "${_pr_count_var}=${pr_count}"
+	if [[ -n "$_pr_count_var" ]]; then
+		[[ "$_pr_count_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+		printf -v "$_pr_count_var" '%s' "$pr_count"
+	fi
 
 	if [[ "$pr_count" -eq 0 ]]; then
 		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"


### PR DESCRIPTION
## Summary

Replaced eval-based dynamic reads with Bash indirect expansion in _pmp_add_elapsed_seconds and replaced eval-based PR count writes with validated printf -v assignment.

## Files Changed

.agents/scripts/pulse-merge-process.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-merge-process.sh && shellcheck .agents/scripts/pulse-merge-process.sh

Resolves #25020


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 68,489 tokens on this as a headless worker.