### PR TITLE
GH#25019: fix: combine gh shim repo metadata lookup

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -281,8 +281,8 @@ _shim_repo_role() {
 	local slug_owner=""
 	local metadata=""
 	if [[ -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
-		metadata=$(jq -r --arg slug "$repo_slug" '[.initialized_repos[]? | select(.slug == $slug)] | first // {} | [(.role // ""), (.maintainer // "")] | @tsv' "$repos_json" 2>/dev/null || true)
-		IFS=$'\t' read -r explicit_role configured_maintainer <<<"$metadata"
+		metadata=$(jq -r --arg slug "$repo_slug" '[.initialized_repos[]? | select(.slug == $slug)] | first // {} | "\(.role // "")\u001f\(.maintainer // "")"' "$repos_json" 2>/dev/null || true)
+		IFS=$'\037' read -r explicit_role configured_maintainer <<<"$metadata"
 		case "$explicit_role" in
 		maintainer | contributor)
 			printf '%s\n' "$explicit_role"

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -279,15 +279,16 @@ _shim_repo_role() {
 	local configured_maintainer=""
 	local current_user=""
 	local slug_owner=""
+	local metadata=""
 	if [[ -n "$repo_slug" && -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
-		explicit_role=$(jq -r --arg slug "$repo_slug" 'first(.initialized_repos[]? | select(.slug == $slug) | .role) // ""' "$repos_json" 2>/dev/null || true)
+		metadata=$(jq -r --arg slug "$repo_slug" '[.initialized_repos[]? | select(.slug == $slug)] | first // {} | [(.role // ""), (.maintainer // "")] | @tsv' "$repos_json" 2>/dev/null || true)
+		IFS=$'\t' read -r explicit_role configured_maintainer <<<"$metadata"
 		case "$explicit_role" in
 		maintainer | contributor)
 			printf '%s\n' "$explicit_role"
 			return 0
 			;;
 		esac
-		configured_maintainer=$(jq -r --arg slug "$repo_slug" 'first(.initialized_repos[]? | select(.slug == $slug) | .maintainer) // ""' "$repos_json" 2>/dev/null || true)
 	fi
 	# Match pulse/repo metadata semantics: omitted role is derived from the
 	# authenticated user and either configured maintainer or slug owner, then


### PR DESCRIPTION
## Summary

Combined _shim_repo_role role and maintainer metadata extraction into one robust jq query, preserving omitted-role fallback semantics with a non-whitespace delimiter.

## Files Changed

.agents/scripts/gh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh; .agents/scripts/tests/test-gh-shim.sh; .agents/scripts/linters-local.sh reached shell portability after 300s with prior checks successful and advisory markdown/ratchet warnings only

Resolves #25019


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 11m and 82,134 tokens on this as a headless worker.