### PR TITLE
GH#25029: fix: use script dir for dedup helper

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1380,7 +1380,7 @@ _dispatch_dedup_check_layers() {
 		local _dedup_block_reason="dedup_active_claim"
 		if [[ -n "$_dedup_signal" ]]; then
 			_dedup_block_signal="${_dedup_signal%%$'\n'*}"
-			_dedup_block_reason=$("${BASH_SOURCE[0]%/*}/dispatch-dedup-helper.sh" classify-blocker "$_dedup_block_signal" 2>/dev/null) || _dedup_block_reason="dedup_active_claim"
+			_dedup_block_reason=$("${SCRIPT_DIR}/dispatch-dedup-helper.sh" classify-blocker "$_dedup_block_signal" 2>/dev/null) || _dedup_block_reason="dedup_active_claim"
 		fi
 		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=${_dedup_block_reason} signal=${_dedup_block_signal} issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
 		echo "[dispatch_with_dedup] Dedup guard blocked #${issue_number} in ${repo_slug}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1380,7 +1380,8 @@ _dispatch_dedup_check_layers() {
 		local _dedup_block_reason="dedup_active_claim"
 		if [[ -n "$_dedup_signal" ]]; then
 			_dedup_block_signal="${_dedup_signal%%$'\n'*}"
-			_dedup_block_reason=$("${SCRIPT_DIR}/dispatch-dedup-helper.sh" classify-blocker "$_dedup_block_signal" 2>/dev/null) || _dedup_block_reason="dedup_active_claim"
+			local _dedup_helper_path="${SCRIPT_DIR:-${BASH_SOURCE[0]%/*}}/dispatch-dedup-helper.sh"
+			_dedup_block_reason=$("$_dedup_helper_path" classify-blocker "$_dedup_block_signal") || _dedup_block_reason="dedup_active_claim"
 		fi
 		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=${_dedup_block_reason} signal=${_dedup_block_signal} issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
 		echo "[dispatch_with_dedup] Dedup guard blocked #${issue_number} in ${repo_slug}" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Replaced the BASH_SOURCE-derived dispatch-dedup-helper path in .agents/scripts/pulse-dispatch-core.sh with the existing SCRIPT_DIR path so blocker classification resolves helpers consistently when sourced or invoked without a path prefix.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-core.sh

Resolves #25029


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 67,054 tokens on this as a headless worker.