### PR TITLE
GH#25030: fix: guard merge timing counter reads

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -81,7 +81,11 @@ _pmp_add_elapsed_seconds() {
 	elapsed=$((end_epoch - start_epoch))
 	[[ "$elapsed" =~ ^[0-9]+$ ]] || elapsed=0
 
-	current_value="${!dest_var:-0}"
+	if declare -p "$dest_var" >/dev/null 2>&1; then
+		current_value="${!dest_var}"
+	else
+		current_value=0
+	fi
 	[[ "$current_value" =~ ^[0-9]+$ ]] || current_value=0
 	current_value=$((current_value + elapsed))
 	printf -v "$dest_var" '%s' "$current_value"


### PR DESCRIPTION
## Summary

Replaced the invalid indirect expansion default in .agents/scripts/pulse-merge-process.sh with an existence check before reading the destination timing counter, preserving the zero fallback for unset counters.

## Files Changed

.agents/scripts/pulse-merge-process.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-merge-process.sh; shellcheck .agents/scripts/pulse-merge-process.sh; bash -uc 'source .agents/scripts/pulse-merge-process.sh; unset total_s || true; _pmp_add_elapsed_seconds total_s 0; [[ "" =~ ^[0-9]+$ ]]; existing=5; _pmp_add_elapsed_seconds existing 0; [[ "" =~ ^[0-9]+$ ]]'

Resolves #25030


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 68,161 tokens on this as a headless worker.