### PR TITLE
GH#25031: fix: reject zero pulse merge lock pid

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1202,8 +1202,8 @@ _pulse_run_deterministic_pipeline() {
 	local _pmr_skip=0
 	if [[ -d "$_pulse_merge_routine_lock_dir" && -f "${_pulse_merge_routine_lock_dir}/pid" ]]; then
 		local _pmr_lock_pid=""
-		_pmr_lock_pid=$(cat "${_pulse_merge_routine_lock_dir}/pid" 2>/dev/null || printf '0\n')
-		if [[ "$_pmr_lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$_pmr_lock_pid" 2>/dev/null; then
+		_pmr_lock_pid=$(cat "${_pulse_merge_routine_lock_dir}/pid" 2>/dev/null || true)
+		if [[ "$_pmr_lock_pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$_pmr_lock_pid" 2>/dev/null; then
 			echo "[pulse-wrapper] deterministic_merge_pass: skipping (pulse-merge-routine pid=${_pmr_lock_pid} still running)" >>"$LOGFILE"
 			_pmr_skip=1
 		fi


### PR DESCRIPTION
## Summary

Updated the pulse merge routine lock guard so an unreadable PID file leaves the PID empty and only positive integer PIDs are passed to kill -0, preventing pid 0/process-group false positives.

## Files Changed

.agents/scripts/pulse-wrapper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper.sh; bash -n .agents/scripts/pulse-wrapper.sh

Resolves #25031


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 31,081 tokens on this as a headless worker.