### PR TITLE
GH#25032: fix: use REST search rate-limit reset

### DIFF
--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -796,18 +796,20 @@ _gh_secondary_cooldown_header_expires_at() {
 	return 0
 }
 
-_gh_secondary_cooldown_rest_core_reset_at() {
+_gh_secondary_cooldown_rest_reset_at() {
 	local endpoint_arg="${1:-}"
 	local endpoint_family=""
+	local resource_key="core"
 	local reset_at=""
 	local now=""
 	endpoint_family="$(_gh_secondary_cooldown_endpoint_family "$endpoint_arg")"
 	case "$endpoint_family" in
-	rest-core | rest-search) ;;
+	rest-core) resource_key="core" ;;
+	rest-search) resource_key="search" ;;
 	*) return 1 ;;
 	esac
 	command -v gh >/dev/null 2>&1 || return 1
-	reset_at=$(gh api rate_limit --jq '.resources.core | select(.remaining == 0) | .reset' 2>/dev/null || true)
+	reset_at=$(gh api rate_limit --jq ".resources.${resource_key} | select(.remaining == 0) | .reset" 2>/dev/null || true)
 	now="$(_gh_secondary_cooldown_now)"
 	if [[ "$reset_at" =~ ^[0-9]+$ && "$reset_at" -gt "$now" ]]; then
 		printf '%s' "$reset_at"
@@ -843,7 +845,7 @@ _gh_secondary_cooldown_record_response_if_needed() {
 		fi
 		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
 		if [[ -z "$retry_after" ]] && ! [[ "$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")" =~ ^[0-9]+$ ]]; then
-			expires_at="$(_gh_secondary_cooldown_rest_core_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
+			expires_at="$(_gh_secondary_cooldown_rest_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
 		fi
 		_gh_secondary_cooldown_write_until "github-api-rate-limit-status-${status}" "$response_text" "$expires_at" "status-${status}" "$_GH_SECONDARY_COOLDOWN_ACTION_CREATED" "$method_arg" "$endpoint_arg" "$query_shape_arg" "$operation_arg" "$wrapper_arg" "$pulse_stage_arg" || true
 		return 0
@@ -851,7 +853,7 @@ _gh_secondary_cooldown_record_response_if_needed() {
 	429)
 		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
 		if [[ -z "$retry_after" ]] && ! [[ "$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")" =~ ^[0-9]+$ ]]; then
-			expires_at="$(_gh_secondary_cooldown_rest_core_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
+			expires_at="$(_gh_secondary_cooldown_rest_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
 		fi
 		_gh_secondary_cooldown_write_until "github-api-rate-limit-status-${status}" "$response_text" "$expires_at" "status-${status}" "$_GH_SECONDARY_COOLDOWN_ACTION_CREATED" "$method_arg" "$endpoint_arg" "$query_shape_arg" "$operation_arg" "$wrapper_arg" "$pulse_stage_arg" || true
 		return 0
@@ -860,7 +862,7 @@ _gh_secondary_cooldown_record_response_if_needed() {
 	if [[ "$remaining" =~ ^[0-9]+$ && "$remaining" -eq 0 ]]; then
 		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
 		if [[ -z "$retry_after" ]] && ! [[ "$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")" =~ ^[0-9]+$ ]]; then
-			expires_at="$(_gh_secondary_cooldown_rest_core_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
+			expires_at="$(_gh_secondary_cooldown_rest_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
 		fi
 		_gh_secondary_cooldown_write_until "github-api-rate-limit-remaining-zero" "$response_text" "$expires_at" "remaining-zero" "$_GH_SECONDARY_COOLDOWN_ACTION_CREATED" "$method_arg" "$endpoint_arg" "$query_shape_arg" "$operation_arg" "$wrapper_arg" "$pulse_stage_arg" || true
 		return 0

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -28,8 +28,17 @@ export AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS=600
 export AIDEVOPS_GH_READ_RAMP_STATE_FILE="${TMP_HOME}/.aidevops/cache/gh-read-ramp-state.tsv"
 
 gh() {
-	printf 'GH %s\n' "$*" >>"$CALL_LOG"
-	case "$*" in
+	local gh_args="$*"
+	printf 'GH %s\n' "$gh_args" >>"$CALL_LOG"
+	case "$gh_args" in
+	"api rate_limit --jq "*.resources.search*)
+		if [[ -n "${GH_SEARCH_RATE_LIMIT_RESET:-}" ]]; then
+			printf '%s\n' "$GH_SEARCH_RATE_LIMIT_RESET"
+		else
+			printf '\n'
+		fi
+		return 0
+		;;
 	"api rate_limit --jq "*)
 		if [[ -n "${GH_CORE_RATE_LIMIT_RESET:-}" ]]; then
 			printf '%s\n' "$GH_CORE_RATE_LIMIT_RESET"
@@ -76,7 +85,7 @@ reset_case() {
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE"
 	rm -f "$AIDEVOPS_GH_READ_RAMP_STATE_FILE"
-	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
+	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_SEARCH_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
 	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
 	_GH_SECONDARY_COOLDOWN_LOGGED_RAMP=0
 	_gh_secondary_system_boot_ts() { return 1; }
@@ -171,6 +180,29 @@ test_rest_core_403_uses_rate_limit_reset_and_skips_next_call() {
 		return 0
 	fi
 	printf 'FAIL REST core cooldown did not suppress next REST call\n'
+	return 1
+}
+
+test_rest_search_403_uses_search_rate_limit_reset() {
+	reset_case
+	local now=""
+	now="$(_gh_secondary_cooldown_now)"
+	export GH_REST_CORE_403_FAIL=1
+	export GH_CORE_RATE_LIMIT_RESET=$((now + 1800))
+	export GH_SEARCH_RATE_LIMIT_RESET=$((now + 900))
+	set +e
+	_gh_with_timeout read gh api -i "/search/issues?q=repo:owner/repo+state:open" >"${TMP_HOME}/rest-search-403.out" 2>"$ERR_LOG"
+	local rc=$?
+	set -e
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL expected REST search 403 wrapped gh rc=1, got %s\n' "$rc"
+		return 1
+	fi
+	if jq -e --argjson reset "$GH_SEARCH_RATE_LIMIT_RESET" '.reason == "github-api-rate-limit-status-403" and .last_request_id == "REQ-CORE" and .expires_at == $reset and .diagnostic.endpoint_family == "rest-search"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS REST search 403 uses search reset timestamp\n'
+		return 0
+	fi
+	printf 'FAIL REST search 403 cooldown did not use search reset timestamp\n'
 	return 1
 }
 
@@ -408,6 +440,7 @@ test_secondary_response_writes_cooldown
 test_header_response_writes_retry_after_cooldown
 test_generic_403_diagnostic_distinguishes_forbidden
 test_rest_core_403_uses_rate_limit_reset_and_skips_next_call
+test_rest_search_403_uses_search_rate_limit_reset
 test_abuse_403_diagnostic_distinguishes_abuse_text
 test_remaining_zero_diagnostic_classifies_primary_quota
 test_active_cooldown_skips_without_gh_call


### PR DESCRIPTION
## Summary

Renamed the REST reset helper and selected GitHub rate-limit resources by endpoint family so REST search cooldowns use resources.search while REST core keeps resources.core. Added a regression test covering REST search 403 fallback reset handling.

## Files Changed

.agents/scripts/shared-gh-secondary-cooldown.sh,.agents/scripts/tests/test-gh-secondary-cooldown.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-secondary-cooldown.sh .agents/scripts/tests/test-gh-secondary-cooldown.sh; bash .agents/scripts/tests/test-gh-secondary-cooldown.sh

Resolves #25032


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 52,914 tokens on this as a headless worker.