### PR TITLE
GH#25033: fix: harden dispatch claim stderr fallback

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -228,8 +228,15 @@ _resolve_version() {
 #######################################
 _claim_post_error_fallback_path() {
 	if [[ -n "${HOME:-}" && -d "$HOME" && -w "$HOME" ]]; then
-		printf '%s' "${HOME}/.aidevops-claim-post-error.$$.$RANDOM"
-		return 0
+		local home_dir="${HOME%/}"
+		local path="${home_dir}/.aidevops-claim-post-error.$$.$RANDOM"
+		if touch "$path" 2>/dev/null; then
+			if chmod 600 "$path"; then
+				printf '%s' "$path"
+				return 0
+			fi
+			rm -f "$path" 2>/dev/null || true
+		fi
 	fi
 
 	printf '%s\n' "Error: mktemp failed and HOME is unavailable for secure claim POST stderr capture" >&2

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -230,7 +230,7 @@ _claim_post_error_fallback_path() {
 	if [[ -n "${HOME:-}" && -d "$HOME" && -w "$HOME" ]]; then
 		local home_dir="${HOME%/}"
 		local path="${home_dir}/.aidevops-claim-post-error.$$.$RANDOM"
-		if touch "$path" 2>/dev/null; then
+		if (set -C; umask 077; : >"$path") 2>/dev/null; then
 			if chmod 600 "$path"; then
 				printf '%s' "$path"
 				return 0

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -620,7 +620,7 @@ EOF
 	cat >"${mock_path}/chmod" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\t%s\n' "${1:-}" "${2:-}" >>"${MOCK_CHMOD_LOG:?}"
-/bin/chmod "$@"
+command -p chmod "$@"
 EOF
 	chmod +x "${mock_path}/chmod"
 

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -603,7 +603,7 @@ test_claim_retries_transient_post_failure() {
 # Test: claim POST stderr fallback avoids predictable /tmp paths when mktemp fails.
 #######################################
 test_claim_post_error_fallback_avoids_tmp() {
-	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts test_home
+	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts test_home chmod_log chmod_mode chmod_path
 	tmp_dir=$(mktemp -d)
 	mock_path=$(create_mock_gh "$tmp_dir")
 	test_home="${tmp_dir}/home"
@@ -616,10 +616,18 @@ test_claim_post_error_fallback_avoids_tmp() {
 exit 1
 EOF
 	chmod +x "${mock_path}/mktemp"
+	chmod_log="${tmp_dir}/chmod.log"
+	cat >"${mock_path}/chmod" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\t%s\n' "${1:-}" "${2:-}" >>"${MOCK_CHMOD_LOG:?}"
+/bin/chmod "$@"
+EOF
+	chmod +x "${mock_path}/chmod"
 
 	set +e
 	output=$(PATH="${mock_path}:$PATH" \
-		HOME="$test_home" \
+		HOME="${test_home}/" \
+		MOCK_CHMOD_LOG="$chmod_log" \
 		MOCK_GH_STATE_DIR="$tmp_dir" \
 		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" \
 		MOCK_NEW_CLAIM_CREATED_AT="$claim_created_at" \
@@ -654,6 +662,22 @@ EOF
 		print_result "claim POST fallback avoids predictable tmp path" 1 "predictable /tmp fallback remains"
 	else
 		print_result "claim POST fallback avoids predictable tmp path" 0
+	fi
+
+	chmod_mode=""
+	chmod_path=""
+	if [[ -f "$chmod_log" ]]; then
+		IFS=$'\t' read -r chmod_mode chmod_path <"$chmod_log" || true
+	fi
+	if [[ "$chmod_mode" == "600" && "$chmod_path" == "${test_home}/.aidevops-claim-post-error."* ]]; then
+		print_result "claim POST fallback pre-creates private stderr file" 0
+	else
+		print_result "claim POST fallback pre-creates private stderr file" 1 "chmod_mode=${chmod_mode:-missing} chmod_path=${chmod_path:-missing} output: $output"
+	fi
+	if [[ "$chmod_path" == *"//.aidevops-claim-post-error."* ]]; then
+		print_result "claim POST fallback strips trailing HOME slash" 1 "chmod_path=${chmod_path}"
+	else
+		print_result "claim POST fallback strips trailing HOME slash" 0
 	fi
 
 	rm -rf "$tmp_dir"


### PR DESCRIPTION
## Summary

Pre-create the HOME fallback stderr capture file with chmod 600 and strip trailing HOME slashes; added regression assertions in dispatch claim helper tests.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh; .agents/scripts/tests/test-dispatch-claim-helper.sh (54 tests, 0 failed)

Resolves #25033


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 61,880 tokens on this as a headless worker.