### PR TITLE
GH#25034: fix: harden raw gh read wrapper test

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -278,7 +278,8 @@ EOF
 }
 
 test_required_checks_gh_reads_are_timeout_wrapped() {
-	if grep -nE '^[[:space:]]*[^#]*\bgh (api|pr checks)\b' "$REQUIRED_CHECKS_SCRIPT" | grep -v '_pmrc_gh_read' >/dev/null 2>&1; then
+	if sed -E 's/_pmrc_gh_read[[:space:]]+gh[[:space:]]+(api|pr checks)//g' "$REQUIRED_CHECKS_SCRIPT" \
+		| grep -nE '^[[:space:]]*[^#]*\bgh (api|pr checks)\b' >/dev/null 2>&1; then
 		print_result "required-check gh reads use timeout wrapper" 1
 	else
 		print_result "required-check gh reads use timeout wrapper" 0


### PR DESCRIPTION
## Summary

Updated the required-checks wrapper enforcement test to strip only valid _pmrc_gh_read gh api / gh pr checks prefixes before scanning for raw gh reads, preserving same-line raw gh calls even when comments mention the wrapper.

## Files Changed

.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh (42 tests, 0 failed)

Resolves #25034


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 28,653 tokens on this as a headless worker.