### PR TITLE
GH#24958: trust maintainer collaborators in worker merge gates

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -966,6 +966,39 @@ _is_trusted_issue_author() {
 }
 
 #######################################
+# Check whether an issue author has maintainer-equivalent repository access.
+#
+# GitHub can expose maintainer-operated issues/PRs as COLLABORATOR rather than
+# OWNER/MEMBER. For worker-briefed auto-merge, verify that ambiguous metadata
+# through the authenticated collaborator permission endpoint instead of forcing
+# per-issue cryptographic approvals for every maintainer-run aidevops worker.
+#
+# Args: $1=repo_slug, $2=github_login
+# Returns: 0=trusted maintainer-equivalent access, 1=not trusted or API error
+#######################################
+_issue_author_has_maintainer_authority() {
+	local repo_slug="$1"
+	local login="$2"
+	local permission=""
+
+	[[ -n "$repo_slug" && -n "$login" ]] || return 1
+
+	#aidevops:trust-boundary GH#24958: ambiguous GitHub issue
+	# author_association values are not sufficient to auto-merge worker PRs.
+	# Confirm maintainer-equivalent access with authenticated metadata and fail
+	# closed on API errors or permissions below write.
+	permission=$(gh api "repos/${repo_slug}/collaborators/${login}/permission" \
+		--jq '.permission // ""' 2>/dev/null) || return 1
+
+	case "$permission" in
+		admin | maintain | write)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+#######################################
 # Verify that a linked issue has a maintainer cryptographic approval (t3052).
 #
 # Marker-string presence is not a trust signal: any user able to comment could
@@ -1075,13 +1108,16 @@ _attempt_worker_briefed_auto_merge() {
 		_has_crypto="true"
 	fi
 
-	# Gate: linked issue authored by OWNER/MEMBER, OR login is in the
+	# Gate: linked issue authored by OWNER/MEMBER, OR login has authenticated
+	# maintainer-equivalent repo permission (GH#24958), OR login is in the
 	# trusted-issue-author allowlist (t3062), OR cryptographically approved
 	# by maintainer (t3052). The trust chain "maintainer SSH-signed
 	# an approval on the issue" is at least as strong as the OWNER/MEMBER
 	# author check — the maintainer personally vouched with their private key.
 	if [[ "$issue_author_assoc" != "OWNER" && "$issue_author_assoc" != "MEMBER" ]]; then
-		if _is_trusted_issue_author "$issue_author_login"; then
+		if _issue_author_has_maintainer_authority "$repo_slug" "$issue_author_login"; then
+			echo "[pulse-merge] worker-briefed auto-merge: PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} author ${issue_author_login} passes via authenticated maintainer permission fallback (GH#24958)" >>"$LOGFILE"
+		elif _is_trusted_issue_author "$issue_author_login"; then
 			echo "[pulse-merge] worker-briefed auto-merge: PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} author ${issue_author_login} passes via trusted-issue-author allowlist (t3062)" >>"$LOGFILE"
 		elif [[ "$_has_crypto" != "true" ]]; then
 			echo "[pulse-merge] worker-briefed auto-merge: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} author_association=${issue_author_assoc} (not OWNER/MEMBER) and no cryptographic approval signature found (t2449/t3052)" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -20,7 +20,7 @@
 #      origin:worker PRs with OWNER/MEMBER author and a trusted issue author
 #      with no non-maintainer comments.
 #   F. REPO_OWNER env var is wired through both Job 1 and Job 3 steps.
-#   G. GH#24546 private-org CONTRIBUTOR fallback uses authenticated
+#   G. GH#24546/GH#24958 private-org CONTRIBUTOR/COLLABORATOR fallback uses authenticated
 #      collaborator permission metadata and fails closed.
 #
 # Workflow execution cannot be tested locally — this is a static shape
@@ -137,22 +137,14 @@ else
 fi
 
 # -------------------------------------------------------------------
-# Check G: GH#24546 private-org CONTRIBUTOR permission fallback
+# Check G: GH#24546/GH#24958 private-org CONTRIBUTOR/COLLABORATOR permission fallback
 # -------------------------------------------------------------------
 assert_contains "PR_AUTHOR:[[:space:]]*\\$\\{\\{[[:space:]]*github\.event\.pull_request\.user\.login" \
 	"Job 1 exposes PR_AUTHOR for permission fallback"
 assert_contains "pr_author_has_maintainer_authority" \
 	"defines shared maintainer-authority helper"
-assert_contains "CONTRIBUTOR\)" \
-	"helper handles ambiguous CONTRIBUTOR webhook association"
-collaborator_case_count=$(grep -cE 'COLLABORATOR\)' "$WORKFLOW_FILE" 2>/dev/null || true)
-[[ "$collaborator_case_count" =~ ^[0-9]+$ ]] || collaborator_case_count=0
-if [[ "$collaborator_case_count" -eq 1 ]]; then
-	print_result "helper does not add bare COLLABORATOR string exemption" 0
-else
-	print_result "helper does not add bare COLLABORATOR string exemption" 1 \
-		"expected only the existing label-protection COLLABORATOR case, found $collaborator_case_count"
-fi
+assert_contains "CONTRIBUTOR\|COLLABORATOR" \
+	"helper routes ambiguous CONTRIBUTOR/COLLABORATOR webhook association through permission fallback"
 assert_contains "collaborators/.*/permission" \
 	"helper uses authenticated collaborator permission endpoint"
 assert_contains "admin\|maintain\|write" \
@@ -161,6 +153,8 @@ assert_contains "permission fallback failed" \
 	"helper logs and fails closed on permission API failure"
 assert_contains "#aidevops:trust-boundary GH#24546" \
 	"trust-boundary marker documents authenticated fallback"
+assert_contains "GH#24546/GH#24958" \
+	"trust-boundary marker covers maintainer-operated collaborator fallback"
 assert_contains "authorAssociation,author" \
 	"Job 3 fetches PR author login with author association"
 

--- a/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
+++ b/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
@@ -20,6 +20,9 @@
 #   Case (m): origin:worker + OWNER author + no crypto → still passes (t3052)
 #   Case (n): COLLABORATOR author + login in trusted-issue-author allowlist → passes (t3062)
 #   Case (o): COLLABORATOR author + login NOT in allowlist + no crypto → blocked (t3062)
+#   Case (p): COLLABORATOR author + authenticated write permission → passes (GH#24958)
+#   Case (q): COLLABORATOR author + authenticated read permission → blocked (GH#24958)
+#   Case (r): issue-author=NONE + spoofed crypto marker → blocked (GH#21936)
 #
 # No real repository is touched. The gh binary is replaced with a mock stub
 # that serves canned responses from TEST_ROOT fixture files.
@@ -76,6 +79,8 @@ setup_test_env() {
 	printf '{"author_association":"OWNER"}' >"${TEST_ROOT}/issue.json"
 	# Default comments fixture: empty array (no NMR markers)
 	printf '[]' >"${TEST_ROOT}/comments.json"
+	# Default collaborator permission fixture: read (not maintainer-equivalent)
+	printf 'read' >"${TEST_ROOT}/permission.txt"
 
 	# Mock gh: logs every call and returns canned data from TEST_ROOT fixtures.
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
@@ -117,6 +122,25 @@ if [[ "$*" == *"/comments"* ]]; then
 	exit 0
 fi
 
+# Collaborator permission API (maintainer-authority fallback)
+if [[ "$*" == *"/collaborators/"*"/permission"* ]]; then
+	_jq_filter=""
+	_permission="$(cat "${TEST_ROOT}/permission.txt" 2>/dev/null || printf 'read')"
+	_json="{\"permission\":\"${_permission}\"}"
+	for _i in "${!_all_args[@]}"; do
+		if [[ "${_all_args[$_i]}" == "--jq" ]]; then
+			_jq_filter="${_all_args[$((_i + 1))]:-}"
+			break
+		fi
+	done
+	if [[ -n "$_jq_filter" ]]; then
+		printf '%s' "$_json" | jq -r "$_jq_filter"
+	else
+		printf '%s\n' "$_json"
+	fi
+	exit 0
+fi
+
 exit 0
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
@@ -147,7 +171,7 @@ teardown_test_env() {
 # _is_trusted_issue_author and _attempt_worker_briefed_auto_merge live in
 # pulse-merge-process.sh (post-split, t3062 adds the trusted-author helper).
 define_helpers_under_test() {
-	local src_worker_briefed src_issue_api src_trusted_author src_crypto_approval
+	local src_worker_briefed src_issue_api src_trusted_author src_issue_authority src_crypto_approval
 	src_issue_api=$(awk '
 		/^_pm_issue_api\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
@@ -158,6 +182,9 @@ define_helpers_under_test() {
 	fi
 	src_trusted_author=$(awk '
 		/^_is_trusted_issue_author\(\) \{/,/^\}$/ { print }
+	' "$extract_from")
+	src_issue_authority=$(awk '
+		/^_issue_author_has_maintainer_authority\(\) \{/,/^\}$/ { print }
 	' "$extract_from")
 	src_crypto_approval=$(awk '
 		/^_issue_has_verified_crypto_approval\(\) \{/,/^\}$/ { print }
@@ -173,6 +200,8 @@ define_helpers_under_test() {
 	eval "$src_issue_api"
 	# shellcheck disable=SC1090
 	eval "$src_trusted_author"
+	# shellcheck disable=SC1090
+	eval "$src_issue_authority"
 	# shellcheck disable=SC1090
 	eval "$src_crypto_approval"
 	# shellcheck disable=SC1090
@@ -633,10 +662,73 @@ test_case_o_trusted_author_not_in_allowlist_blocked() {
 }
 
 # =============================================================================
-# Case (p): issue-author=NONE + spoofed approval marker but failed verification
+# Case (p): COLLABORATOR author + authenticated write permission → passes
+# Maintainer-operated aidevops workers may surface as COLLABORATOR in webhook
+# metadata; authenticated collaborator permission is the trust source.
+# =============================================================================
+test_case_p_collaborator_permission_passes() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"author_association":"COLLABORATOR","user":{"login":"maintainer-peer"}}' >"${TEST_ROOT}/issue.json"
+	printf '[]' >"${TEST_ROOT}/comments.json"
+	printf 'write' >"${TEST_ROOT}/permission.txt"
+	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
+
+	local result=0
+	_attempt_worker_briefed_auto_merge "115" "owner/repo" "origin:worker" "false" "57" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (p): COLLABORATOR + authenticated write permission → passes (GH#24958)" 1 \
+			"Expected exit 0, got ${result}"
+	else
+		if grep -q "authenticated maintainer permission fallback (GH#24958)" "$LOGFILE" 2>/dev/null; then
+			print_result "Case (p): COLLABORATOR + authenticated write permission → passes (GH#24958)" 0
+		else
+			print_result "Case (p): COLLABORATOR + authenticated write permission → passes (GH#24958)" 1 \
+				"Exit was 0 but expected GH#24958 permission fallback log message not found"
+		fi
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (q): COLLABORATOR author + authenticated read permission → blocked
+# The fallback must fail closed when the login lacks write-level repo access.
+# =============================================================================
+test_case_q_collaborator_read_permission_blocked() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"author_association":"COLLABORATOR","user":{"login":"read-only-peer"}}' >"${TEST_ROOT}/issue.json"
+	printf '[]' >"${TEST_ROOT}/comments.json"
+	printf 'read' >"${TEST_ROOT}/permission.txt"
+	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
+
+	local result=0
+	_attempt_worker_briefed_auto_merge "116" "owner/repo" "origin:worker" "false" "58" && result=0 || result=$?
+
+	if [[ "$result" -eq 0 ]]; then
+		print_result "Case (q): COLLABORATOR + authenticated read permission → blocked (GH#24958)" 1 \
+			"Expected non-zero exit, got 0 (read-only collaborator should block)"
+	else
+		if grep -q "no cryptographic approval signature found (t2449/t3052)" "$LOGFILE" 2>/dev/null; then
+			print_result "Case (q): COLLABORATOR + authenticated read permission → blocked (GH#24958)" 0
+		else
+			print_result "Case (q): COLLABORATOR + authenticated read permission → blocked (GH#24958)" 1 \
+				"Exit was non-zero but expected block log message not found"
+		fi
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (r): issue-author=NONE + spoofed approval marker but failed verification
 # → blocked. Comment marker presence alone is not a trust signal (GH#21936).
 # =============================================================================
-test_case_p_spoofed_crypto_marker_blocked() {
+test_case_r_spoofed_crypto_marker_blocked() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
@@ -646,16 +738,16 @@ test_case_p_spoofed_crypto_marker_blocked() {
 	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
 
 	local result=0
-	_attempt_worker_briefed_auto_merge "115" "owner/repo" "origin:worker" "false" "57" && result=0 || result=$?
+	_attempt_worker_briefed_auto_merge "117" "owner/repo" "origin:worker" "false" "59" && result=0 || result=$?
 
 	if [[ "$result" -eq 0 ]]; then
-		print_result "Case (p): spoofed crypto marker without verification → blocked" 1 \
+		print_result "Case (r): spoofed crypto marker without verification → blocked" 1 \
 			"Expected non-zero exit, got 0 (unverified marker should block)"
 	else
 		if grep -q "no cryptographic approval signature found (t2449/t3052)" "$LOGFILE" 2>/dev/null; then
-			print_result "Case (p): spoofed crypto marker without verification → blocked" 0
+			print_result "Case (r): spoofed crypto marker without verification → blocked" 0
 		else
-			print_result "Case (p): spoofed crypto marker without verification → blocked" 1 \
+			print_result "Case (r): spoofed crypto marker without verification → blocked" 1 \
 				"Exit was non-zero but expected block log message not found"
 		fi
 	fi
@@ -687,7 +779,9 @@ main() {
 	test_case_m_owner_no_crypto_still_passes
 	test_case_n_trusted_author_allowlist_passes
 	test_case_o_trusted_author_not_in_allowlist_blocked
-	test_case_p_spoofed_crypto_marker_blocked
+	test_case_p_collaborator_permission_passes
+	test_case_q_collaborator_read_permission_blocked
+	test_case_r_spoofed_crypto_marker_blocked
 
 	echo ""
 	printf 'Results: %d/%d passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -174,7 +174,7 @@ jobs:
               OWNER|MEMBER)
                 return 0
                 ;;
-              CONTRIBUTOR)
+              CONTRIBUTOR|COLLABORATOR)
                 ;;
               *)
                 return 1
@@ -186,8 +186,9 @@ jobs:
               return 1
             fi
 
-            #aidevops:trust-boundary GH#24546: webhook author_association can
-            # report CONTRIBUTOR for private org members. Use an authenticated,
+            #aidevops:trust-boundary GH#24546/GH#24958: webhook
+            # author_association can report CONTRIBUTOR/COLLABORATOR for
+            # maintainer-equivalent humans using aidevops. Use an authenticated,
             # metadata-only permission lookup as the fallback and fail closed on
             # API errors or permissions below write.
             permission=$(gh api "repos/${REPO}/collaborators/${pr_author}/permission" \
@@ -651,7 +652,7 @@ jobs:
               OWNER|MEMBER)
                 return 0
                 ;;
-              CONTRIBUTOR)
+              CONTRIBUTOR|COLLABORATOR)
                 ;;
               *)
                 return 1
@@ -663,9 +664,10 @@ jobs:
               return 1
             fi
 
-            #aidevops:trust-boundary GH#24546: mirror Job 1's private-org
-            # membership fallback using authenticated metadata only. Fail closed
-            # when the permission endpoint is unavailable or below write.
+            #aidevops:trust-boundary GH#24546/GH#24958: mirror Job 1's
+            # private-org / maintainer-operated collaborator fallback using
+            # authenticated metadata only. Fail closed when the permission
+            # endpoint is unavailable or below write.
             permission=$(gh api "repos/${REPO}/collaborators/${pr_author}/permission" \
               --jq '.permission' 2>/dev/null) || {
               echo "INFO: permission fallback failed for PR author $pr_author — treating $author_association as non-maintainer"
@@ -737,8 +739,10 @@ jobs:
             # so post success directly and skip the rerun entirely.
             #
             # Security gate: same as Job 1 — OWNER/MEMBER, plus the
-            # authenticated private-org CONTRIBUTOR fallback from GH#24546.
-            # Bare COLLABORATOR remains excluded from string-only exemption.
+            # authenticated private-org CONTRIBUTOR/COLLABORATOR fallback from
+            # GH#24546/GH#24958. Bare COLLABORATOR remains excluded from
+            # string-only exemption because the fallback verifies repo
+            # permission before returning success.
             # -----------------------------------------------------------------
             PR_INFO=$(gh pr view "$PR_NUM" --repo "$REPO" \
               --json labels,authorAssociation,author \


### PR DESCRIPTION
## Summary

- Let maintainer-gate treat ambiguous `COLLABORATOR` PR author metadata like `CONTRIBUTOR`: verify repo permission through the authenticated collaborator endpoint before granting maintainer authority.
- Let worker-briefed auto-merge trust linked issue authors that have authenticated admin/maintain/write repository permission, so maintainer-operated aidevops workers do not require per-issue crypto approvals solely because GitHub reports `author_association=COLLABORATOR`.
- Add regression coverage for the GH#24958 / PR #24969 failure mode and read-permission fail-closed behavior.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-worker-briefed.sh`
- `bash .agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh`
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-worker-briefed.sh .agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh` (passes; reports existing advisory markdown/ratchet/complexity debt)

Refs #24958. Test-case: PR #24969 should stop being blocked by the collaborator/assignee/worker-briefed gate after this lands and workflows sync.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 with gpt-5.5 spent 2h 11m and 220,778 tokens on this with the user in an interactive session.