### PR TITLE
GH#25047: Ramp pulse dispatch capacity

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -619,6 +619,134 @@ _dispatch_inter_launch_delay() {
 	return 0
 }
 
+_dispatch_ramp_now() {
+	if [[ "${AIDEVOPS_PULSE_DISPATCH_RAMP_NOW:-}" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$AIDEVOPS_PULSE_DISPATCH_RAMP_NOW"
+		return 0
+	fi
+	date +%s
+	return 0
+}
+
+_dispatch_ramp_system_boot_ts() {
+	local boot_ts=""
+	if declare -F _gh_secondary_system_boot_ts >/dev/null 2>&1; then
+		boot_ts="$(_gh_secondary_system_boot_ts 2>/dev/null || true)"
+		if [[ "$boot_ts" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$boot_ts"
+			return 0
+		fi
+	fi
+	if [[ -r /proc/stat ]]; then
+		boot_ts=$(sed -nE 's/^btime[[:space:]]+([0-9]+).*/\1/p' /proc/stat 2>/dev/null | sed -n '1p')
+		if [[ "$boot_ts" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$boot_ts"
+			return 0
+		fi
+	fi
+	if command -v sysctl >/dev/null 2>&1; then
+		boot_ts=$(sysctl -n kern.boottime 2>/dev/null | sed -nE 's/.*sec = ([0-9]+).*/\1/p' | sed -n '1p')
+		if [[ "$boot_ts" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$boot_ts"
+			return 0
+		fi
+	fi
+	return 1
+}
+
+_dispatch_ramp_cooldown_expires_at() {
+	local expires=""
+	local file="${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE:-${HOME}/.aidevops/cache/gh-secondary-cooldown.json}"
+	if declare -F _gh_secondary_cooldown_expires_at >/dev/null 2>&1; then
+		expires="$(_gh_secondary_cooldown_expires_at 2>/dev/null || true)"
+		if [[ "$expires" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$expires"
+			return 0
+		fi
+	fi
+	[[ -f "$file" ]] || return 1
+	if command -v jq >/dev/null 2>&1; then
+		expires=$(jq -r '.expires_at // 0' "$file" 2>/dev/null || true)
+	else
+		expires=$(sed -nE 's/.*"expires_at"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$file" | sed -n '1p')
+	fi
+	if [[ "$expires" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$expires"
+		return 0
+	fi
+	return 1
+}
+
+_dispatch_ramp_phase_start() {
+	local now=""
+	local boot_ts=""
+	local expires=""
+	local boot_secs="${AIDEVOPS_PULSE_DISPATCH_RAMP_BOOT_SECS:-${AIDEVOPS_GH_READ_RAMP_BOOT_SECS:-180}}"
+	local recovery_secs="${AIDEVOPS_PULSE_DISPATCH_RAMP_RECOVERY_SECS:-${AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS:-300}}"
+	if [[ "${AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+		printf '%s %s\n' "${AIDEVOPS_PULSE_DISPATCH_RAMP_PHASE:-manual}" "$AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH"
+		return 0
+	fi
+	now="$(_dispatch_ramp_now)"
+	if [[ "$boot_secs" =~ ^[0-9]+$ && "$boot_secs" -gt 0 ]]; then
+		boot_ts="$(_dispatch_ramp_system_boot_ts 2>/dev/null || true)"
+		if [[ "$boot_ts" =~ ^[0-9]+$ && "$now" -ge "$boot_ts" && $((now - boot_ts)) -lt "$boot_secs" ]]; then
+			printf 'boot %s\n' "$boot_ts"
+			return 0
+		fi
+	fi
+	if [[ "$recovery_secs" =~ ^[0-9]+$ && "$recovery_secs" -gt 0 ]]; then
+		expires="$(_dispatch_ramp_cooldown_expires_at 2>/dev/null || true)"
+		if [[ "$expires" =~ ^[0-9]+$ && "$now" -ge "$expires" && $((now - expires)) -lt "$recovery_secs" ]]; then
+			printf 'cooldown-recovery %s\n' "$expires"
+			return 0
+		fi
+	fi
+	return 1
+}
+
+_dispatch_apply_startup_capacity_ramp() {
+	local max_workers="$1"
+	local active_workers="$2"
+	local slot_secs="${AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS:-120}"
+	local now=""
+	local phase_line=""
+	local phase=""
+	local start_ts=""
+	local elapsed=0
+	local ramp_cap=1
+	[[ "${AIDEVOPS_PULSE_DISPATCH_RAMP_ENABLED:-1}" == "1" ]] || {
+		printf '%s\n' "$max_workers"
+		return 0
+	}
+	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
+	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+	[[ "$slot_secs" =~ ^[0-9]+$ && "$slot_secs" -gt 0 ]] || slot_secs=120
+	phase_line="$(_dispatch_ramp_phase_start 2>/dev/null || true)"
+	[[ -n "$phase_line" ]] || {
+		printf '%s\n' "$max_workers"
+		return 0
+	}
+	read -r phase start_ts <<<"$phase_line"
+	[[ "$start_ts" =~ ^[0-9]+$ ]] || {
+		printf '%s\n' "$max_workers"
+		return 0
+	}
+	now="$(_dispatch_ramp_now)"
+	if [[ "$now" =~ ^[0-9]+$ && "$now" -ge "$start_ts" ]]; then
+		elapsed=$((now - start_ts))
+	fi
+	ramp_cap=$((1 + (elapsed / slot_secs)))
+	((ramp_cap < 1)) && ramp_cap=1
+	if ((ramp_cap < max_workers)); then
+		echo "[pulse-wrapper] Dispatch_ramp active: phase=${phase} cap=${ramp_cap} max_workers=${max_workers} active=${active_workers} step_seconds=${slot_secs}" >>"$LOGFILE"
+		printf '%s\n' "$ramp_cap"
+		return 0
+	fi
+	printf '%s\n' "$max_workers"
+	return 0
+}
+
 #######################################
 # Compute the dispatch capacity for this round.
 #
@@ -680,6 +808,8 @@ _dispatch_compute_capacity() {
 			max_workers="$min_worker_floor"
 		fi
 	fi
+	max_workers="$(_dispatch_apply_startup_capacity_ramp "$max_workers" "$active_workers")"
+	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	available_slots=$((max_workers - active_workers))
 
 	local guardrail_line=""

--- a/.agents/scripts/tests/test-pulse-dispatch-staggering.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-staggering.sh
@@ -45,6 +45,7 @@ reset_stagger_env() {
 	export PULSE_DISPATCH_PROVIDER_BACKOFF_ACTIVE=0
 	export PULSE_DISPATCH_STAGGER_JITTER_MAX_SECONDS=0
 	export PULSE_DISPATCH_STAGGER_MAX_SECONDS=20
+	unset AIDEVOPS_PULSE_DISPATCH_RAMP_ENABLED AIDEVOPS_PULSE_DISPATCH_RAMP_NOW AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH AIDEVOPS_PULSE_DISPATCH_RAMP_PHASE AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS
 	return 0
 }
 
@@ -131,12 +132,76 @@ test_first_launch_never_delayed() {
 	return 0
 }
 
+test_dispatch_ramp_limits_initial_capacity() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH=1000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=1000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS=120
+	local capped
+	capped=$(_dispatch_apply_startup_capacity_ramp 8 0)
+	if [[ "$capped" == "1" ]]; then
+		print_result "dispatch ramp: initial startup capacity is one worker" 0
+	else
+		print_result "dispatch ramp: initial startup capacity is one worker" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
+test_dispatch_ramp_adds_one_slot_per_pulse_interval() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH=1000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=1240
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS=120
+	local capped
+	capped=$(_dispatch_apply_startup_capacity_ramp 8 0)
+	if [[ "$capped" == "3" ]]; then
+		print_result "dispatch ramp: adds one slot per two-minute pulse" 0
+	else
+		print_result "dispatch ramp: adds one slot per two-minute pulse" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
+test_dispatch_ramp_never_exceeds_max_capacity() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH=1000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=4000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS=120
+	local capped
+	capped=$(_dispatch_apply_startup_capacity_ramp 6 0)
+	if [[ "$capped" == "6" ]]; then
+		print_result "dispatch ramp: stops at max concurrency" 0
+	else
+		print_result "dispatch ramp: stops at max concurrency" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
+test_dispatch_ramp_can_be_disabled() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_ENABLED=0
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH=1000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=1000
+	local capped
+	capped=$(_dispatch_apply_startup_capacity_ramp 8 0)
+	if [[ "$capped" == "8" ]]; then
+		print_result "dispatch ramp: feature flag disables capacity cap" 0
+	else
+		print_result "dispatch ramp: feature flag disables capacity cap" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
 test_low_load_no_delay
 test_high_load_delay
 test_provider_backoff_delay
 test_recent_failure_cluster_delay
 test_graphql_low_budget_delay
 test_first_launch_never_delayed
+test_dispatch_ramp_limits_initial_capacity
+test_dispatch_ramp_adds_one_slot_per_pulse_interval
+test_dispatch_ramp_never_exceeds_max_capacity
+test_dispatch_ramp_can_be_disabled
 
 echo ""
 echo "===================="

--- a/todo/tasks/t3602-brief.md
+++ b/todo/tasks/t3602-brief.md
@@ -1,0 +1,63 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t3602: Reduce GitHub API pressure during pulse startup and recovery
+
+## Origin
+
+- **Created:** 2026-06-18
+- **Session:** Interactive aidevops feedback triage from user `robstiles` monitoring report.
+- **Issue:** GH#25047
+- **Parent task:** none
+- **Blocked by:** none
+
+## What
+
+Reduce GitHub secondary-rate-limit loops that surface at REST Search by lowering aggregate pulse GitHub API pressure during startup and cooldown recovery.
+
+Implement a dispatch ramp that starts with one worker slot and adds one slot per two-minute pulse until the normal minimum worker concurrency is reached, then continues one slot per pulse until max concurrency is reached. Keep broader follow-up work worker-ready for header diagnostics, shared read-pressure governance, and Search avoidance.
+
+## Why
+
+User evidence shows every captured secondary-limit event surfaced through REST Search (`_rest_issue_search` / `rest-search`), but one strong pre-event snapshot had only 2 Search calls in 5 minutes alongside 191 total GitHub API calls: 132 REST core, 36 GraphQL, 2 REST Search, and 21 other. That suggests Search is often the visible tripwire, not necessarily the sole cause.
+
+Pulse startup/recovery can create a feedback loop: pulse restarts or exits cooldown, performs many GitHub state checks, then a Search call happens during that pressure and observes/trips the secondary limit.
+
+## Files to Modify
+
+- `EDIT: .agents/scripts/pulse-dispatch-lib.sh` — cap dispatch capacity during boot/cooldown recovery so worker launch pressure ramps gradually instead of jumping to min/max concurrency.
+- `EDIT: .agents/scripts/tests/test-pulse-dispatch-staggering.sh` — cover one-slot initial cap, one-slot-per-120s ramp, max-cap ceiling, and feature-flag bypass.
+- `FOLLOW-UP: .agents/scripts/shared-gh-secondary-cooldown.sh` — ensure retained cooldown events include response headers needed to classify Search quota vs REST core vs GraphQL vs secondary/abuse throttling.
+- `FOLLOW-UP: .agents/scripts/shared-gh-wrappers-status.sh` and batch prefetch callers — avoid REST Search when repo scope is known and prefer cached/per-repo REST reads during pressure windows.
+
+## Acceptance Criteria
+
+- [ ] Startup/recovery dispatch capacity is capped to 1 worker at ramp start.
+- [ ] Capacity increases by one slot per `AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS` seconds, default `120`.
+- [ ] The ramp cap applies after provider/load/min-floor policy so min concurrency does not create an immediate burst.
+- [ ] The cap never exceeds normal max concurrency.
+- [ ] The ramp is feature-flagged with `AIDEVOPS_PULSE_DISPATCH_RAMP_ENABLED=0`.
+- [ ] Tests cover ramp behaviour and normal-mode no-op behaviour.
+- [ ] Follow-up issue context captures header telemetry, shared read-pressure governor, startup/recovery dampening, and Search avoidance.
+
+## Verification
+
+Run:
+
+```bash
+.agents/scripts/tests/test-pulse-dispatch-staggering.sh
+shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-dispatch-staggering.sh
+.agents/scripts/linters-local.sh
+```
+
+## Follow-up Scope
+
+If this ramp lands first, keep these worker-ready follow-ups:
+
+1. Capture missing headers for every GitHub cooldown event: status, `x-ratelimit-resource`, `x-ratelimit-remaining`, `x-ratelimit-reset`, `x-ratelimit-used`, `retry-after`, `x-github-request-id`, endpoint family, and pulse phase.
+2. Add a shared GitHub read-pressure governor that pauses or sharply reduces noncritical REST core, REST Search, and GraphQL reads after any secondary-limit event.
+3. Jitter or defer batch prefetch/cache warmups during boot and cooldown recovery; prefer stale cache over immediate fanout.
+4. Route known-repo issue/PR checks away from REST Search where exact repo scope is already available.


### PR DESCRIPTION
## Summary

- Add a pulse dispatch startup/recovery capacity ramp so worker slots start at 1 and increase by one every 120s by default.
- Apply the ramp after provider/load/min-floor capacity policy so min concurrency cannot create an immediate GitHub API burst.
- Add a worker-ready brief for the broader GitHub API pressure work from the user report.

Resolves #25047

## Verification

- `.agents/scripts/tests/test-pulse-dispatch-staggering.sh`
- `shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-dispatch-staggering.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
