### PR TITLE
GH#25028: preserve REST Search cooldown headers

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1401,12 +1401,8 @@ _rest_issue_list() {
 
 #######################################
 # _rest_issue_search: GET /search/issues?q=...  (t2995)
-# REST-side equivalent of `gh issue list --search`. Used by the gh_issue_list
-# wrapper when GraphQL is exhausted AND the call carried a --search filter.
-# The plain /repos/{owner}/{repo}/issues endpoint does NOT support full-text
-# search, so the prior REST translator silently dropped --search and returned
-# label-only results — a silent-correctness bug that caused the file-size-debt
-# dedup helper to match wrong issues during exhaustion windows.
+# REST-side equivalent of `gh issue list --search`; preserves full-text search
+# semantics because /repos/{owner}/{repo}/issues does not support --search.
 #
 # Translation:
 #   gh issue list --repo OWNER/REPO --state open \
@@ -1415,15 +1411,7 @@ _rest_issue_list() {
 #   gh api /search/issues?q=QUERY+repo:OWNER/REPO+is:issue+is:open+label:LABEL \
 #     --jq '.items[0].number'
 #
-# Notes:
-#   - Search API has its own quota (30 req/min for authenticated users) —
-#     separate from both core REST and GraphQL pools.
-#   - Multiple --label flags are AND-joined into multiple `+label:"X"` qualifiers.
-#   - --json FIELDS is accepted for parity but ignored (caller uses --jq).
-#   - --jq expressions written for `gh issue list` operate on a flat array
-#     (e.g. `.[0].number`). The /search/issues endpoint wraps results in
-#     `{items:[...]}`. To preserve drop-in semantics, we extract `.items`
-#     before applying the user's jq filter.
+# Notes: Search has its own quota; caller jq expressions are applied to `.items`.
 #
 # Returns the underlying gh api exit code.
 #######################################
@@ -1494,7 +1482,18 @@ _rest_issue_search() {
 		_final_jq=".items"
 	fi
 
-	local _gh_cmd=(gh api "$_path" --jq "$_final_jq")
-	_rest_api_call read "${_gh_cmd[@]}"
+	local _raw_response=""
+	local _body=""
+	local _rc=0
+	local _gh_cmd=(gh api -i "$_path")
+	_raw_response="$(_rest_api_call read "${_gh_cmd[@]}")"
+	_rc=$?
+	if [[ "$_rc" -ne 0 ]]; then
+		return "$_rc"
+	fi
+
+	_body="$(awk 'BEGIN { body = 0 } { line = $0; sub(/\r$/, "", line); if (body) { print; next } if (line == "") { body = 1 } }' <<<"$_raw_response" 2>/dev/null)"
+	[[ -z "$_body" && "$_raw_response" != HTTP/* ]] && _body="$_raw_response"
+	printf '%s\n' "$_body" | jq -r "$_final_jq"
 	return $?
 }

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -285,6 +285,16 @@ gh() {
 		fi
 		return 0
 	fi
+	if [[ "$1" == "api" && ( "$2" =~ ^/search/issues || ( "$2" == "-i" && "${3:-}" =~ ^/search/issues ) ) ]]; then
+		local fixture='{"items":[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure"}]}'
+		fixture="${STUB_SEARCH_FIXTURE:-$fixture}"
+		if [[ "$2" == "-i" ]]; then
+			printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 29\r\nX-RateLimit-Resource: search\r\nX-GitHub-Request-Id: SEARCH-REQ\r\n\r\n%s\n' "$fixture"
+		else
+			printf '%s\n' "$fixture"
+		fi
+		return 0
+	fi
 	if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+$ ]]; then
 		printf '%s\n' "${STUB_REPO_DEFAULT_BRANCH:-main}"
 		return 0
@@ -846,22 +856,28 @@ else
 	fail "gh_issue_list uses primary path when GraphQL budget is healthy" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
-
 # =============================================================================
 # Test 22: gh_issue_list preserves --search by routing low-budget calls to search
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
 export STUB_RATE_LIMIT_REMAINING=0
-
 gh_issue_list --repo "owner/repo" --search "fallback" --state open --json number --jq '.[0].number' >/dev/null 2>&1 || true
-
-if grep -qE '^api /search/issues\?' "$GH_CALLS" 2>/dev/null &&
+if grep -qE '^api (-i )?/search/issues\?' "$GH_CALLS" 2>/dev/null &&
 	! grep -qE '^issue list' "$GH_CALLS" 2>/dev/null; then
 	pass "gh_issue_list proactively routes --search to /search/issues"
 else
 	fail "gh_issue_list proactively routes --search to /search/issues" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+# Test 22a: _rest_issue_search captures headers but preserves caller output
+: >"$GH_CALLS"; : >"$GH_INFO_OUTPUT"; export STUB_RATE_LIMIT_REMAINING=0
+search_output=$(_rest_issue_search --repo "owner/repo" --search "fallback" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+if [[ "$search_output" == "22430" ]] && grep -qE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null && ! printf '%s\n' "$search_output" | grep -qE '^(HTTP/|X-RateLimit|X-GitHub-Request-Id)'; then
+	pass "_rest_issue_search includes headers for diagnostics without leaking them to callers"
+else
+	fail "_rest_issue_search includes headers for diagnostics without leaking them to callers" \
+		"output=${search_output} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Capture REST Search responses with gh api -i so cooldown diagnostics can record selected headers, then strip headers before applying the existing .items jq contract for callers.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; bash .agents/scripts/tests/test-gh-secondary-cooldown.sh; .agents/scripts/linters-local.sh

Resolves #25028


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.92 with gpt-5.5 spent 1h 17m and 171,393 tokens on this with the user in an interactive session.