### PR TITLE
GH#25058: fix: harden dispatch claim fallback creation

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -230,7 +230,7 @@ _claim_post_error_fallback_path() {
 	if [[ -n "${HOME:-}" && -d "$HOME" && -w "$HOME" ]]; then
 		local home_dir="${HOME%/}"
 		local path="${home_dir}/.aidevops-claim-post-error.$$.$RANDOM"
-		if (set -C; umask 077; : >"$path") 2>/dev/null; then
+		if (umask 077 && touch "$path"); then
 			if chmod 600 "$path"; then
 				printf '%s' "$path"
 				return 0

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -603,7 +603,7 @@ test_claim_retries_transient_post_failure() {
 # Test: claim POST stderr fallback avoids predictable /tmp paths when mktemp fails.
 #######################################
 test_claim_post_error_fallback_avoids_tmp() {
-	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts test_home chmod_log chmod_mode chmod_path
+	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts test_home chmod_log chmod_mode chmod_path touch_log touch_mode touch_path suppressed_creation_pattern
 	tmp_dir=$(mktemp -d)
 	mock_path=$(create_mock_gh "$tmp_dir")
 	test_home="${tmp_dir}/home"
@@ -623,11 +623,23 @@ printf '%s\t%s\n' "${1:-}" "${2:-}" >>"${MOCK_CHMOD_LOG:?}"
 command -p chmod "$@"
 EOF
 	chmod +x "${mock_path}/chmod"
+	touch_log="${tmp_dir}/touch.log"
+	cat >"${mock_path}/touch" <<'EOF'
+#!/usr/bin/env bash
+command -p touch "$@"
+touch_mode=""
+if [[ -e "${1:-}" ]]; then
+	touch_mode=$(command -p stat -c '%a' "$1")
+fi
+printf '%s\t%s\n' "$touch_mode" "${1:-}" >>"${MOCK_TOUCH_LOG:?}"
+EOF
+	chmod +x "${mock_path}/touch"
 
 	set +e
 	output=$(PATH="${mock_path}:$PATH" \
 		HOME="${test_home}/" \
 		MOCK_CHMOD_LOG="$chmod_log" \
+		MOCK_TOUCH_LOG="$touch_log" \
 		MOCK_GH_STATE_DIR="$tmp_dir" \
 		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" \
 		MOCK_NEW_CLAIM_CREATED_AT="$claim_created_at" \
@@ -673,6 +685,22 @@ EOF
 		print_result "claim POST fallback pre-creates private stderr file" 0
 	else
 		print_result "claim POST fallback pre-creates private stderr file" 1 "chmod_mode=${chmod_mode:-missing} chmod_path=${chmod_path:-missing} output: $output"
+	fi
+	touch_mode=""
+	touch_path=""
+	if [[ -f "$touch_log" ]]; then
+		IFS=$'\t' read -r touch_mode touch_path <"$touch_log" || true
+	fi
+	if [[ "$touch_mode" == "600" && "$touch_path" == "${test_home}/.aidevops-claim-post-error."* ]]; then
+		print_result "claim POST fallback creates file under restrictive umask" 0
+	else
+		print_result "claim POST fallback creates file under restrictive umask" 1 "touch_mode=${touch_mode:-missing} touch_path=${touch_path:-missing} output: $output"
+	fi
+	suppressed_creation_pattern=": >\"\$path\") 2>/dev/null"
+	if grep -Fq "$suppressed_creation_pattern" "$CLAIM_HELPER"; then
+		print_result "claim POST fallback does not suppress creation stderr" 1 "fallback creation still suppresses stderr"
+	else
+		print_result "claim POST fallback does not suppress creation stderr" 0
 	fi
 	if [[ "$chmod_path" == *"//.aidevops-claim-post-error."* ]]; then
 		print_result "claim POST fallback strips trailing HOME slash" 1 "chmod_path=${chmod_path}"

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -600,6 +600,27 @@ test_claim_retries_transient_post_failure() {
 }
 
 #######################################
+# Build a mock touch executable that records the mode immediately after creation.
+# Args:
+#   $1 = mock bin directory
+# Returns: exit 0
+#######################################
+create_mock_touch_logger() {
+	local mock_bin_dir="$1"
+	cat >"${mock_bin_dir}/touch" <<'EOF'
+#!/usr/bin/env bash
+command -p touch "$@"
+touch_mode=""
+if [[ -e "${1:-}" ]]; then
+	touch_mode=$(command -p stat -c '%a' "$1")
+fi
+printf '%s\t%s\n' "$touch_mode" "${1:-}" >>"${MOCK_TOUCH_LOG:?}"
+EOF
+	chmod +x "${mock_bin_dir}/touch"
+	return 0
+}
+
+#######################################
 # Test: claim POST stderr fallback avoids predictable /tmp paths when mktemp fails.
 #######################################
 test_claim_post_error_fallback_avoids_tmp() {
@@ -624,16 +645,7 @@ command -p chmod "$@"
 EOF
 	chmod +x "${mock_path}/chmod"
 	touch_log="${tmp_dir}/touch.log"
-	cat >"${mock_path}/touch" <<'EOF'
-#!/usr/bin/env bash
-command -p touch "$@"
-touch_mode=""
-if [[ -e "${1:-}" ]]; then
-	touch_mode=$(command -p stat -c '%a' "$1")
-fi
-printf '%s\t%s\n' "$touch_mode" "${1:-}" >>"${MOCK_TOUCH_LOG:?}"
-EOF
-	chmod +x "${mock_path}/touch"
+	create_mock_touch_logger "$mock_path"
 
 	set +e
 	output=$(PATH="${mock_path}:$PATH" \


### PR DESCRIPTION
## Summary

Hardened dispatch claim fallback stderr-file creation by creating the fallback file under umask 077 without suppressing creation stderr, and added regression coverage for restrictive creation mode plus visible creation errors.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh,.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-claim-helper.sh; shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/tests/test-dispatch-claim-helper.sh

Resolves #25058


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 89,731 tokens on this as a headless worker.