### PR TITLE
GH#25060: fix: harden required-check wrapper scan

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -278,8 +278,15 @@ EOF
 }
 
 test_required_checks_gh_reads_are_timeout_wrapped() {
-	if sed -E 's/_pmrc_gh_read[[:space:]]+gh[[:space:]]+(api|pr checks)//g' "$REQUIRED_CHECKS_SCRIPT" \
-		| grep -nE '^[[:space:]]*[^#]*\bgh (api|pr checks)\b' >/dev/null 2>&1; then
+	if [[ -z "$REQUIRED_CHECKS_SCRIPT" ]]; then
+		printf 'ERROR: REQUIRED_CHECKS_SCRIPT is empty or not set\n' >&2
+		print_result "required-check gh reads use timeout wrapper" 1
+		return 0
+	fi
+
+	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$REQUIRED_CHECKS_SCRIPT" \
+		| sed -E 's/_pmrc_gh_read[[:space:]]+gh[[:space:]]+(api|pr[[:space:]]+checks)//g' \
+		| grep -nE '^[[:space:]]*[^#]*(^|[[:space:]])gh[[:space:]]+(api|pr[[:space:]]+checks)([[:space:]]|$)'; } >/dev/null 2>&1; then
 		print_result "required-check gh reads use timeout wrapper" 1
 	else
 		print_result "required-check gh reads use timeout wrapper" 0


### PR DESCRIPTION
## Summary

Hardened the required-check raw gh read scan in .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh with an empty-script guard, line-continuation preprocessing, whitespace-tolerant wrapper stripping, and whole-pipeline stderr suppression.

## Files Changed

.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; shellcheck .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

Resolves #25060


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 48,092 tokens on this as a headless worker.