### PR TITLE
GH#25061: fix: filter resolved review acknowledgements

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -48,7 +48,11 @@ _build_inline_findings() {
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"\\bno further concerns?\\b|" +
 			"\\bno further feedback\\b|" +
-			"\\bno further recommendations?\\b"; "i")) as $resolution_or_ack |
+			"\\bno further recommendations?\\b|" +
+			"\\bno further action is needed\\b|" +
+			"\\bthread is resolved\\b|" +
+			"\\bimplementation (has been )?(confirmed|verified)\\b|" +
+			"\\btests are passing\\b"; "i")) as $resolution_or_ack |
 		select($resolution_or_ack | not) |
 
 		# Extract severity from body

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -282,6 +282,30 @@ test_skips_no_further_concerns_inline_ack() {
 	return 0
 }
 
+test_skips_resolved_thread_inline_ack() {
+	local comments result
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the verification. Since the implementation has been confirmed as correct and the thread is resolved, no further action is needed.","path":".agents/scripts/pulse-dispatch-engine.sh","line":868,"html_url":"https://example.invalid/review","created_at":"2026-06-18T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "25009" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip resolved-thread inline acknowledgement" 0
+	else
+		print_result "skip resolved-thread inline acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_verified_tests_passing_inline_ack() {
+	local comments result
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. Since the implementation has been verified and the tests are passing, this thread is resolved.","path":".agents/scripts/pulse-dispatch-engine.sh","line":1406,"html_url":"https://example.invalid/review","created_at":"2026-06-18T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "25009" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip verified-tests-passing inline acknowledgement" 0
+	else
+		print_result "skip verified-tests-passing inline acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -241,6 +241,8 @@ main() {
 	test_skips_no_suggestions_for_improvement_review
 	test_skips_review_thread_response_inline_comment
 	test_skips_no_further_concerns_inline_ack
+	test_skips_resolved_thread_inline_ack
+	test_skips_verified_tests_passing_inline_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Filtered Gemini resolved-thread acknowledgement comments from quality-feedback inline findings and added regression coverage for the PR #25009 false-positive phrases.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh,.agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #25061


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 85,781 tokens on this as a headless worker.