### PR TITLE
GH#25055: docs: clarify pulse batch search override preservation

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -142,7 +142,9 @@ PULSE_EVENTS_TICKLE_ENABLED=1
 # Set to 0 only for a bounded diagnostic run where owner-wide search semantics
 # are required and secondary cooldown is known clear.
 #
-# Env var PULSE_BATCH_SEARCH_LAST_RESORT takes precedence if already set.
+# This file assigns PULSE_BATCH_SEARCH_LAST_RESORT directly. Consumers that
+# need to preserve a pre-existing environment override must save and restore it
+# around sourcing this config.
 PULSE_BATCH_SEARCH_LAST_RESORT=1
 
 # ── GitHub Actions runner queue saturation (t3211, GH#21942) ──────────────────


### PR DESCRIPTION
## Summary

Clarified the pulse rate-limit config comment so consumers know PULSE_BATCH_SEARCH_LAST_RESORT is assigned directly and must be saved/restored when preserving an environment override.

## Files Changed

.agents/configs/pulse-rate-limit.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh (required gates through Secretlint passed; broad run later timed out during repository portability audit after advisory markdown/ratchet warnings unrelated to this config-only comment change)

Resolves #25055


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 8m and 56,192 tokens on this as a headless worker.