### PR TITLE
GH#25057: fix: reuse maintainer permission checks

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -977,22 +977,24 @@ _is_trusted_issue_author() {
 # through the authenticated collaborator permission endpoint instead of forcing
 # per-issue cryptographic approvals for every maintainer-run aidevops worker.
 #
-# Args: $1=repo_slug, $2=github_login
+# Args: $1=repo_slug, $2=github_login, $3=precomputed_permission(optional)
 # Returns: 0=trusted maintainer-equivalent access, 1=not trusted or API error
 #######################################
 _issue_author_has_maintainer_authority() {
 	local repo_slug="$1"
 	local login="$2"
-	local permission=""
+	local permission="${3:-}"
 
 	[[ -n "$repo_slug" && -n "$login" ]] || return 1
 
-	#aidevops:trust-boundary GH#24958: ambiguous GitHub issue
-	# author_association values are not sufficient to auto-merge worker PRs.
-	# Confirm maintainer-equivalent access with authenticated metadata and fail
-	# closed on API errors or permissions below write.
-	permission=$(gh api "repos/${repo_slug}/collaborators/${login}/permission" \
-		--jq '.permission // ""' 2>/dev/null) || return 1
+	if [[ -z "$permission" ]]; then
+		#aidevops:trust-boundary GH#24958: ambiguous GitHub issue
+		# author_association values are not sufficient to auto-merge worker PRs.
+		# Confirm maintainer-equivalent access with authenticated metadata and fail
+		# closed on API errors or permissions below write.
+		permission=$(gh api "repos/${repo_slug}/collaborators/${login}/permission" \
+			--jq '.permission // ""' 2>/dev/null) || return 1
+	fi
 
 	case "$permission" in
 		admin | maintain | write)

--- a/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
+++ b/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
@@ -22,7 +22,8 @@
 #   Case (o): COLLABORATOR author + login NOT in allowlist + no crypto → blocked (t3062)
 #   Case (p): COLLABORATOR author + authenticated write permission → passes (GH#24958)
 #   Case (q): COLLABORATOR author + authenticated read permission → blocked (GH#24958)
-#   Case (r): issue-author=NONE + spoofed crypto marker → blocked (GH#21936)
+#   Case (r): precomputed write permission skips collaborator permission API (GH#25057)
+#   Case (s): issue-author=NONE + spoofed crypto marker → blocked (GH#21936)
 #
 # No real repository is touched. The gh binary is replaced with a mock stub
 # that serves canned responses from TEST_ROOT fixture files.
@@ -725,10 +726,33 @@ test_case_q_collaborator_read_permission_blocked() {
 }
 
 # =============================================================================
-# Case (r): issue-author=NONE + spoofed approval marker but failed verification
+# Case (r): precomputed permission skips collaborator permission API (GH#25057)
+# =============================================================================
+test_case_r_precomputed_permission_skips_api() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	local result=0
+	_issue_author_has_maintainer_authority "owner/repo" "maintainer" "write" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (r): precomputed write permission skips collaborator permission API (GH#25057)" 1 \
+			"Expected exit 0, got ${result}"
+	elif grep -q "/collaborators/maintainer/permission" "$GH_LOG" 2>/dev/null; then
+		print_result "Case (r): precomputed write permission skips collaborator permission API (GH#25057)" 1 \
+			"Expected no collaborator permission API call when permission argument is supplied"
+	else
+		print_result "Case (r): precomputed write permission skips collaborator permission API (GH#25057)" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (s): issue-author=NONE + spoofed approval marker but failed verification
 # → blocked. Comment marker presence alone is not a trust signal (GH#21936).
 # =============================================================================
-test_case_r_spoofed_crypto_marker_blocked() {
+test_case_s_spoofed_crypto_marker_blocked() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
@@ -741,13 +765,13 @@ test_case_r_spoofed_crypto_marker_blocked() {
 	_attempt_worker_briefed_auto_merge "117" "owner/repo" "origin:worker" "false" "59" && result=0 || result=$?
 
 	if [[ "$result" -eq 0 ]]; then
-		print_result "Case (r): spoofed crypto marker without verification → blocked" 1 \
+		print_result "Case (s): spoofed crypto marker without verification → blocked" 1 \
 			"Expected non-zero exit, got 0 (unverified marker should block)"
 	else
 		if grep -q "no cryptographic approval signature found (t2449/t3052)" "$LOGFILE" 2>/dev/null; then
-			print_result "Case (r): spoofed crypto marker without verification → blocked" 0
+			print_result "Case (s): spoofed crypto marker without verification → blocked" 0
 		else
-			print_result "Case (r): spoofed crypto marker without verification → blocked" 1 \
+			print_result "Case (s): spoofed crypto marker without verification → blocked" 1 \
 				"Exit was non-zero but expected block log message not found"
 		fi
 	fi
@@ -781,7 +805,8 @@ main() {
 	test_case_o_trusted_author_not_in_allowlist_blocked
 	test_case_p_collaborator_permission_passes
 	test_case_q_collaborator_read_permission_blocked
-	test_case_r_spoofed_crypto_marker_blocked
+	test_case_r_precomputed_permission_skips_api
+	test_case_s_spoofed_crypto_marker_blocked
 
 	echo ""
 	printf 'Results: %d/%d passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"


### PR DESCRIPTION
## Summary

- Adds an optional precomputed permission argument to `_issue_author_has_maintainer_authority`.
- Skips the collaborator permission API call when worker-briefed auto-merge already has the permission value.
- Adds a regression case proving the precomputed write permission path avoids redundant network I/O.

Resolves #25057

## Verification

- `.agents/scripts/tests/test-pulse-merge-worker-briefed.sh` — 19/19 passed.
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-worker-briefed.sh` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/scripts/linters-local.sh` — partial pass through SonarCloud, Qlty, string-literal ratchet, forbidden FD locks, and shellcheckrc parity; timed out twice while entering Secretlint (120s and 300s), with no reported failures before timeout.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 21m and 131,834 tokens on this as a headless worker.