### PR TITLE
GH#25071: fix: preserve pulse batch search override

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -142,10 +142,8 @@ PULSE_EVENTS_TICKLE_ENABLED=1
 # Set to 0 only for a bounded diagnostic run where owner-wide search semantics
 # are required and secondary cooldown is known clear.
 #
-# This file assigns PULSE_BATCH_SEARCH_LAST_RESORT directly. Consumers that
-# need to preserve a pre-existing environment override must save and restore it
-# around sourcing this config.
-PULSE_BATCH_SEARCH_LAST_RESORT=1
+# Env var PULSE_BATCH_SEARCH_LAST_RESORT takes precedence if already set.
+PULSE_BATCH_SEARCH_LAST_RESORT=${PULSE_BATCH_SEARCH_LAST_RESORT:-1}
 
 # ── GitHub Actions runner queue saturation (t3211, GH#21942) ──────────────────
 #


### PR DESCRIPTION
## Summary

Preserved pre-existing PULSE_BATCH_SEARCH_LAST_RESORT overrides when sourcing .agents/configs/pulse-rate-limit.conf by using bash default parameter expansion instead of unconditional assignment.

## Files Changed

.agents/configs/pulse-rate-limit.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck -s bash .agents/configs/pulse-rate-limit.conf; bash -c 'PULSE_BATCH_SEARCH_LAST_RESORT=0; source .agents/configs/pulse-rate-limit.conf; test "" = 0'; bash -c 'unset PULSE_BATCH_SEARCH_LAST_RESORT; source .agents/configs/pulse-rate-limit.conf; test "" = 1'

Resolves #25071


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 55,829 tokens on this as a headless worker.