### PR TITLE
GH#25070: fix: reuse worker merge permission checks

### DIFF
--- a/.agents/scripts/pulse-merge-author-checks.sh
+++ b/.agents/scripts/pulse-merge-author-checks.sh
@@ -56,17 +56,20 @@ fi
 _PULSE_AUTHOR_PERMISSION_UNKNOWN="unknown"
 _PULSE_AUTHOR_PERMISSION_LOOKUP_STATE="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
 _PULSE_AUTHOR_PERMISSION_HTTP="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+_PULSE_AUTHOR_PERMISSION_VALUE="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
 
 #######################################
 # Record collaborator-permission lookup state for merge callers.
-# Args: $1=state, $2=http-status
+# Args: $1=state, $2=http-status, $3=permission-value(optional)
 # Returns: 0 always.
 #######################################
 _pulse_author_permission_state_set() {
 	local state="$1"
 	local http_status="$2"
+	local permission_value="${3:-$_PULSE_AUTHOR_PERMISSION_UNKNOWN}"
 	_PULSE_AUTHOR_PERMISSION_LOOKUP_STATE="$state"
 	_PULSE_AUTHOR_PERMISSION_HTTP="$http_status"
+	_PULSE_AUTHOR_PERMISSION_VALUE="$permission_value"
 	return 0
 }
 
@@ -91,7 +94,7 @@ _pulse_author_permission_lookup() {
 			_pulse_author_permission_state_set "failed" "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-$_PULSE_AUTHOR_PERMISSION_UNKNOWN}"
 			return 2
 		fi
-		_pulse_author_permission_state_set "ok" "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-$_PULSE_AUTHOR_PERMISSION_UNKNOWN}"
+		_pulse_author_permission_state_set "ok" "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-$_PULSE_AUTHOR_PERMISSION_UNKNOWN}" "$pulse_perm_value"
 		if [[ -n "$out_var" ]]; then
 			printf -v "$out_var" '%s' "$pulse_perm_value"
 		else
@@ -105,7 +108,7 @@ _pulse_author_permission_lookup() {
 		_pulse_author_permission_state_set "failed" "$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
 		return 2
 	}
-	_pulse_author_permission_state_set "ok" "$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+	_pulse_author_permission_state_set "ok" "$_PULSE_AUTHOR_PERMISSION_UNKNOWN" "$pulse_perm_value"
 	if [[ -n "$out_var" ]]; then
 		printf -v "$out_var" '%s' "$pulse_perm_value"
 	else

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1055,7 +1055,9 @@ _issue_has_verified_crypto_approval() {
 # When OFF, all origin:worker PRs fall back to manual merge only.
 #
 # Args: $1=pr_number, $2=repo_slug, $3=labels_str (comma-separated),
-#       $4=is_draft, $5=linked_issue
+#       $4=is_draft, $5=linked_issue,
+#       $6=precomputed_issue_author_permission(optional),
+#       $7=precomputed_permission_login(optional)
 # Returns: 0=all gates pass (eligible for auto-merge), 1=blocked
 #######################################
 _attempt_worker_briefed_auto_merge() {
@@ -1064,6 +1066,8 @@ _attempt_worker_briefed_auto_merge() {
 	local labels_str="$3"
 	local is_draft="$4"
 	local linked_issue="$5"
+	local precomputed_issue_author_permission="${6:-}"
+	local precomputed_permission_login="${7:-}"
 
 	# Feature flag — when OFF, all origin:worker PRs fall back to manual merge
 	if [[ "${AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE:-1}" == "0" ]]; then
@@ -1099,6 +1103,12 @@ _attempt_worker_briefed_auto_merge() {
 	local issue_author_assoc=""
 	local issue_author_login=""
 	read -r issue_author_assoc issue_author_login <<< "$_issue_meta"
+	local issue_author_permission=""
+	if [[ -n "$precomputed_issue_author_permission" ]]; then
+		if [[ -z "$precomputed_permission_login" || "$precomputed_permission_login" == "$issue_author_login" ]]; then
+			issue_author_permission="$precomputed_issue_author_permission"
+		fi
+	fi
 
 	# Fetch auto-approval signal once for the NMR crypto-vs-auto check (t2449).
 	# Cryptographic approval is verified separately via approval-helper.sh; do not
@@ -1121,7 +1131,7 @@ _attempt_worker_briefed_auto_merge() {
 	# an approval on the issue" is at least as strong as the OWNER/MEMBER
 	# author check — the maintainer personally vouched with their private key.
 	if [[ "$issue_author_assoc" != "OWNER" && "$issue_author_assoc" != "MEMBER" ]]; then
-		if _issue_author_has_maintainer_authority "$repo_slug" "$issue_author_login"; then
+		if _issue_author_has_maintainer_authority "$repo_slug" "$issue_author_login" "$issue_author_permission"; then
 			echo "[pulse-merge] worker-briefed auto-merge: PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} author ${issue_author_login} passes via authenticated maintainer permission fallback (GH#24958)" >>"$LOGFILE"
 		elif _is_trusted_issue_author "$issue_author_login"; then
 			echo "[pulse-merge] worker-briefed auto-merge: PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} author ${issue_author_login} passes via trusted-issue-author allowlist (t3062)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1104,10 +1104,8 @@ _attempt_worker_briefed_auto_merge() {
 	local issue_author_login=""
 	read -r issue_author_assoc issue_author_login <<< "$_issue_meta"
 	local issue_author_permission=""
-	if [[ -n "$precomputed_issue_author_permission" ]]; then
-		if [[ -z "$precomputed_permission_login" || "$precomputed_permission_login" == "$issue_author_login" ]]; then
-			issue_author_permission="$precomputed_issue_author_permission"
-		fi
+	if [[ -n "$precomputed_issue_author_permission" && -n "$precomputed_permission_login" && "$precomputed_permission_login" == "$issue_author_login" ]]; then
+		issue_author_permission="$precomputed_issue_author_permission"
 	fi
 
 	# Fetch auto-approval signal once for the NMR crypto-vs-auto check (t2449).

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -258,6 +258,7 @@ _check_pr_merge_gates() {
 	local _author_collab_rc=0
 	_is_collaborator_author "$pr_author" "$repo_slug"
 	_author_collab_rc=$?
+	local _author_collab_permission="${_PULSE_AUTHOR_PERMISSION_VALUE:-}"
 	if [[ "$_author_collab_rc" -eq 2 ]]; then
 		check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — permission check failed for author ${pr_author} (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
@@ -355,7 +356,7 @@ _check_pr_merge_gates() {
 	# Uses comma-delimited matching: ",origin:worker," does NOT match
 	# ",origin:worker-takeover," (substring-safe).
 	if [[ ",${_oi_labels_str}," == *"${_OW_LABEL_PAT}"* ]]; then
-		if ! _attempt_worker_briefed_auto_merge "$pr_number" "$repo_slug" "$_oi_labels_str" "$_oi_is_draft" "$linked_issue"; then
+		if ! _attempt_worker_briefed_auto_merge "$pr_number" "$repo_slug" "$_oi_labels_str" "$_oi_is_draft" "$linked_issue" "$_author_collab_permission" "$pr_author"; then
 			return 1
 		fi
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
+++ b/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
@@ -23,7 +23,9 @@
 #   Case (p): COLLABORATOR author + authenticated write permission → passes (GH#24958)
 #   Case (q): COLLABORATOR author + authenticated read permission → blocked (GH#24958)
 #   Case (r): precomputed write permission skips collaborator permission API (GH#25057)
-#   Case (s): issue-author=NONE + spoofed crypto marker → blocked (GH#21936)
+#   Case (s): worker gate reuses matching precomputed permission (GH#25070)
+#   Case (t): worker gate ignores mismatched precomputed permission (GH#25070)
+#   Case (u): issue-author=NONE + spoofed crypto marker → blocked (GH#21936)
 #
 # No real repository is touched. The gh binary is replaced with a mock stub
 # that serves canned responses from TEST_ROOT fixture files.
@@ -749,10 +751,65 @@ test_case_r_precomputed_permission_skips_api() {
 }
 
 # =============================================================================
-# Case (s): issue-author=NONE + spoofed approval marker but failed verification
+# Case (s): worker gate reuses matching precomputed permission (GH#25070)
+# =============================================================================
+test_case_s_worker_gate_uses_matching_precomputed_permission() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"author_association":"COLLABORATOR","user":{"login":"maintainer-peer"}}' >"${TEST_ROOT}/issue.json"
+	printf '[]' >"${TEST_ROOT}/comments.json"
+	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
+
+	local result=0
+	_attempt_worker_briefed_auto_merge "118" "owner/repo" "origin:worker" "false" "60" "write" "maintainer-peer" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (s): worker gate reuses matching precomputed permission (GH#25070)" 1 \
+			"Expected exit 0, got ${result}"
+	elif grep -q "/collaborators/maintainer-peer/permission" "$GH_LOG" 2>/dev/null; then
+		print_result "Case (s): worker gate reuses matching precomputed permission (GH#25070)" 1 \
+			"Expected worker gate to skip duplicate collaborator permission API call"
+	else
+		print_result "Case (s): worker gate reuses matching precomputed permission (GH#25070)" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (t): worker gate ignores mismatched precomputed permission login (GH#25070)
+# =============================================================================
+test_case_t_worker_gate_ignores_mismatched_precomputed_permission() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"author_association":"COLLABORATOR","user":{"login":"issue-author"}}' >"${TEST_ROOT}/issue.json"
+	printf '[]' >"${TEST_ROOT}/comments.json"
+	printf 'read' >"${TEST_ROOT}/permission.txt"
+	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
+
+	local result=0
+	_attempt_worker_briefed_auto_merge "119" "owner/repo" "origin:worker" "false" "61" "write" "different-pr-author" && result=0 || result=$?
+
+	if [[ "$result" -eq 0 ]]; then
+		print_result "Case (t): worker gate ignores mismatched precomputed permission (GH#25070)" 1 \
+			"Expected non-zero exit, got 0 (mismatched cached permission should not trust issue author)"
+	elif grep -q "/collaborators/issue-author/permission" "$GH_LOG" 2>/dev/null; then
+		print_result "Case (t): worker gate ignores mismatched precomputed permission (GH#25070)" 0
+	else
+		print_result "Case (t): worker gate ignores mismatched precomputed permission (GH#25070)" 1 \
+			"Expected fallback collaborator permission API call for issue-author"
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (u): issue-author=NONE + spoofed approval marker but failed verification
 # → blocked. Comment marker presence alone is not a trust signal (GH#21936).
 # =============================================================================
-test_case_s_spoofed_crypto_marker_blocked() {
+test_case_u_spoofed_crypto_marker_blocked() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
@@ -765,13 +822,13 @@ test_case_s_spoofed_crypto_marker_blocked() {
 	_attempt_worker_briefed_auto_merge "117" "owner/repo" "origin:worker" "false" "59" && result=0 || result=$?
 
 	if [[ "$result" -eq 0 ]]; then
-		print_result "Case (s): spoofed crypto marker without verification → blocked" 1 \
+		print_result "Case (u): spoofed crypto marker without verification → blocked" 1 \
 			"Expected non-zero exit, got 0 (unverified marker should block)"
 	else
 		if grep -q "no cryptographic approval signature found (t2449/t3052)" "$LOGFILE" 2>/dev/null; then
-			print_result "Case (s): spoofed crypto marker without verification → blocked" 0
+			print_result "Case (u): spoofed crypto marker without verification → blocked" 0
 		else
-			print_result "Case (s): spoofed crypto marker without verification → blocked" 1 \
+			print_result "Case (u): spoofed crypto marker without verification → blocked" 1 \
 				"Exit was non-zero but expected block log message not found"
 		fi
 	fi
@@ -806,7 +863,9 @@ main() {
 	test_case_p_collaborator_permission_passes
 	test_case_q_collaborator_read_permission_blocked
 	test_case_r_precomputed_permission_skips_api
-	test_case_s_spoofed_crypto_marker_blocked
+	test_case_s_worker_gate_uses_matching_precomputed_permission
+	test_case_t_worker_gate_ignores_mismatched_precomputed_permission
+	test_case_u_spoofed_crypto_marker_blocked
 
 	echo ""
 	printf 'Results: %d/%d passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Reused the PR author collaborator permission lookup for worker-briefed auto-merge when the linked issue author matches, while ignoring mismatched cached permissions to preserve the trust boundary. Added tests covering cached-permission reuse and mismatch fallback.

## Files Changed

.agents/scripts/pulse-merge-author-checks.sh,.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-worker-briefed.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-worker-briefed.sh; shellcheck .agents/scripts/pulse-merge-author-checks.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-worker-briefed.sh

Resolves #25070


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 91,314 tokens on this as a headless worker.