### PR TITLE
GH#25072: fix: harden review acknowledgement regex

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -51,7 +51,7 @@ _build_inline_findings() {
 			"\\bno further recommendations?\\b|" +
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
-			"\\bimplementation (has been )?(confirmed|verified)\\b|" +
+			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
 			"\\btests are passing\\b"; "i")) as $resolution_or_ack |
 		select($resolution_or_ack | not) |
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -294,6 +294,18 @@ test_skips_resolved_thread_inline_ack() {
 	return 0
 }
 
+test_skips_multispace_implementation_verified_inline_ack() {
+	local comments result
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The implementation\nhas   been verified and the tests are passing.","path":".agents/scripts/pulse-dispatch-engine.sh","line":1406,"html_url":"https://example.invalid/review","created_at":"2026-06-18T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "25009" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip multispace implementation-verified inline acknowledgement" 0
+	else
+		print_result "skip multispace implementation-verified inline acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_skips_verified_tests_passing_inline_ack() {
 	local comments result
 	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. Since the implementation has been verified and the tests are passing, this thread is resolved.","path":".agents/scripts/pulse-dispatch-engine.sh","line":1406,"html_url":"https://example.invalid/review","created_at":"2026-06-18T00:00:00Z"}]'

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -242,6 +242,7 @@ main() {
 	test_skips_review_thread_response_inline_comment
 	test_skips_no_further_concerns_inline_ack
 	test_skips_resolved_thread_inline_ack
+	test_skips_multispace_implementation_verified_inline_ack
 	test_skips_verified_tests_passing_inline_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review


### PR DESCRIPTION
## Summary

Updated the inline acknowledgement filter to use POSIX whitespace classes for implementation-confirmed/verified phrases and added a regression covering newline/multiple-space wording.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh,.agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #25072


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 84,332 tokens on this as a headless worker.