### PR TITLE
GH#25073: fix: validate required checks script path

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -278,6 +278,12 @@ EOF
 }
 
 test_required_checks_gh_reads_are_timeout_wrapped() {
+	if [[ -z "${REQUIRED_CHECKS_SCRIPT:-}" ]]; then
+		printf 'ERROR: REQUIRED_CHECKS_SCRIPT is empty or not set\n' >&2
+		print_result "required-check gh reads use timeout wrapper" 1
+		return 0
+	fi
+
 	if [[ ! -f "$REQUIRED_CHECKS_SCRIPT" ]]; then
 		printf 'ERROR: REQUIRED_CHECKS_SCRIPT file does not exist or is not a regular file: %s\n' "$REQUIRED_CHECKS_SCRIPT" >&2
 		print_result "required-check gh reads use timeout wrapper" 1

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -278,8 +278,8 @@ EOF
 }
 
 test_required_checks_gh_reads_are_timeout_wrapped() {
-	if [[ -z "$REQUIRED_CHECKS_SCRIPT" ]]; then
-		printf 'ERROR: REQUIRED_CHECKS_SCRIPT is empty or not set\n' >&2
+	if [[ ! -f "$REQUIRED_CHECKS_SCRIPT" ]]; then
+		printf 'ERROR: REQUIRED_CHECKS_SCRIPT file does not exist or is not a regular file: %s\n' "$REQUIRED_CHECKS_SCRIPT" >&2
 		print_result "required-check gh reads use timeout wrapper" 1
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Validated REQUIRED_CHECKS_SCRIPT with a regular-file check before scanning it, preventing missing paths from silently passing the timeout-wrapper test.

## Files Changed

.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh (42 tests, 0 failed)

Resolves #25073


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 33,296 tokens on this as a headless worker.