### PR TITLE
GH#25078: fix: reuse dispatch ramp timestamps

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -629,7 +629,11 @@ _dispatch_ramp_now() {
 }
 
 _dispatch_ramp_system_boot_ts() {
-	local boot_ts=""
+	local boot_ts="${1:-}"
+	if [[ "$boot_ts" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$boot_ts"
+		return 0
+	fi
 	if declare -F _gh_secondary_system_boot_ts >/dev/null 2>&1; then
 		boot_ts="$(_gh_secondary_system_boot_ts 2>/dev/null || true)"
 		if [[ "$boot_ts" =~ ^[0-9]+$ ]]; then
@@ -655,8 +659,12 @@ _dispatch_ramp_system_boot_ts() {
 }
 
 _dispatch_ramp_cooldown_expires_at() {
-	local expires=""
+	local expires="${1:-}"
 	local file="${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE:-${HOME}/.aidevops/cache/gh-secondary-cooldown.json}"
+	if [[ "$expires" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$expires"
+		return 0
+	fi
 	if declare -F _gh_secondary_cooldown_expires_at >/dev/null 2>&1; then
 		expires="$(_gh_secondary_cooldown_expires_at 2>/dev/null || true)"
 		if [[ "$expires" =~ ^[0-9]+$ ]]; then
@@ -679,8 +687,8 @@ _dispatch_ramp_cooldown_expires_at() {
 
 _dispatch_ramp_phase_start() {
 	local now=""
-	local boot_ts=""
-	local expires=""
+	local boot_ts="${1:-}"
+	local expires="${2:-}"
 	local boot_secs="${AIDEVOPS_PULSE_DISPATCH_RAMP_BOOT_SECS:-${AIDEVOPS_GH_READ_RAMP_BOOT_SECS:-180}}"
 	local recovery_secs="${AIDEVOPS_PULSE_DISPATCH_RAMP_RECOVERY_SECS:-${AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS:-300}}"
 	if [[ "${AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH:-}" =~ ^[0-9]+$ ]]; then
@@ -689,14 +697,18 @@ _dispatch_ramp_phase_start() {
 	fi
 	now="$(_dispatch_ramp_now)"
 	if [[ "$boot_secs" =~ ^[0-9]+$ && "$boot_secs" -gt 0 ]]; then
-		boot_ts="$(_dispatch_ramp_system_boot_ts 2>/dev/null || true)"
+		if [[ ! "$boot_ts" =~ ^[0-9]+$ ]]; then
+			boot_ts="$(_dispatch_ramp_system_boot_ts "" 2>/dev/null || true)"
+		fi
 		if [[ "$boot_ts" =~ ^[0-9]+$ && "$now" -ge "$boot_ts" && $((now - boot_ts)) -lt "$boot_secs" ]]; then
 			printf 'boot %s\n' "$boot_ts"
 			return 0
 		fi
 	fi
 	if [[ "$recovery_secs" =~ ^[0-9]+$ && "$recovery_secs" -gt 0 ]]; then
-		expires="$(_dispatch_ramp_cooldown_expires_at 2>/dev/null || true)"
+		if [[ ! "$expires" =~ ^[0-9]+$ ]]; then
+			expires="$(_dispatch_ramp_cooldown_expires_at "" 2>/dev/null || true)"
+		fi
 		if [[ "$expires" =~ ^[0-9]+$ && "$now" -ge "$expires" && $((now - expires)) -lt "$recovery_secs" ]]; then
 			printf 'cooldown-recovery %s\n' "$expires"
 			return 0
@@ -709,6 +721,8 @@ _dispatch_apply_startup_capacity_ramp() {
 	local max_workers="$1"
 	local active_workers="$2"
 	local slot_secs="${AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS:-120}"
+	local boot_ts="${3:-}"
+	local expires="${4:-}"
 	local now=""
 	local phase_line=""
 	local phase=""
@@ -722,7 +736,7 @@ _dispatch_apply_startup_capacity_ramp() {
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 	[[ "$slot_secs" =~ ^[0-9]+$ && "$slot_secs" -gt 0 ]] || slot_secs=120
-	phase_line="$(_dispatch_ramp_phase_start 2>/dev/null || true)"
+	phase_line="$(_dispatch_ramp_phase_start "$boot_ts" "$expires" 2>/dev/null || true)"
 	[[ -n "$phase_line" ]] || {
 		printf '%s\n' "$max_workers"
 		return 0
@@ -739,7 +753,7 @@ _dispatch_apply_startup_capacity_ramp() {
 	ramp_cap=$((1 + (elapsed / slot_secs)))
 	((ramp_cap < 1)) && ramp_cap=1
 	if ((ramp_cap < max_workers)); then
-		echo "[pulse-wrapper] Dispatch_ramp active: phase=${phase} cap=${ramp_cap} max_workers=${max_workers} active=${active_workers} step_seconds=${slot_secs}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Dispatch_ramp active: phase=${phase} cap=${ramp_cap} max_workers=${max_workers} active=${active_workers} step_seconds=${slot_secs}" >>"${LOGFILE:-/dev/null}"
 		printf '%s\n' "$ramp_cap"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-dispatch-staggering.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-staggering.sh
@@ -45,7 +45,7 @@ reset_stagger_env() {
 	export PULSE_DISPATCH_PROVIDER_BACKOFF_ACTIVE=0
 	export PULSE_DISPATCH_STAGGER_JITTER_MAX_SECONDS=0
 	export PULSE_DISPATCH_STAGGER_MAX_SECONDS=20
-	unset AIDEVOPS_PULSE_DISPATCH_RAMP_ENABLED AIDEVOPS_PULSE_DISPATCH_RAMP_NOW AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH AIDEVOPS_PULSE_DISPATCH_RAMP_PHASE AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS
+	unset AIDEVOPS_PULSE_DISPATCH_RAMP_ENABLED AIDEVOPS_PULSE_DISPATCH_RAMP_NOW AIDEVOPS_PULSE_DISPATCH_RAMP_START_EPOCH AIDEVOPS_PULSE_DISPATCH_RAMP_PHASE AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS AIDEVOPS_PULSE_DISPATCH_RAMP_BOOT_SECS AIDEVOPS_PULSE_DISPATCH_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS
 	return 0
 }
 
@@ -192,6 +192,52 @@ test_dispatch_ramp_can_be_disabled() {
 	return 0
 }
 
+test_dispatch_ramp_uses_precomputed_boot_timestamp() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=1100
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS=120
+	local capped
+	capped=$(_dispatch_apply_startup_capacity_ramp 8 0 1000)
+	if [[ "$capped" == "1" ]]; then
+		print_result "dispatch ramp: accepts precomputed boot timestamp" 0
+	else
+		print_result "dispatch ramp: accepts precomputed boot timestamp" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
+test_dispatch_ramp_uses_precomputed_cooldown_expiry() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_BOOT_SECS=0
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=1120
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS=120
+	local capped
+	capped=$(_dispatch_apply_startup_capacity_ramp 8 0 "" 1000)
+	if [[ "$capped" == "2" ]]; then
+		print_result "dispatch ramp: accepts precomputed cooldown expiry" 0
+	else
+		print_result "dispatch ramp: accepts precomputed cooldown expiry" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
+test_dispatch_ramp_handles_unset_logfile() {
+	reset_stagger_env
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_NOW=1000
+	export AIDEVOPS_PULSE_DISPATCH_RAMP_SLOT_SECS=120
+	local old_logfile="${LOGFILE:-}"
+	local capped
+	unset LOGFILE
+	capped=$(_dispatch_apply_startup_capacity_ramp 8 0 1000)
+	export LOGFILE="$old_logfile"
+	if [[ "$capped" == "1" ]]; then
+		print_result "dispatch ramp: unset LOGFILE falls back to dev null" 0
+	else
+		print_result "dispatch ramp: unset LOGFILE falls back to dev null" 1 "cap=${capped}"
+	fi
+	return 0
+}
+
 test_low_load_no_delay
 test_high_load_delay
 test_provider_backoff_delay
@@ -202,6 +248,9 @@ test_dispatch_ramp_limits_initial_capacity
 test_dispatch_ramp_adds_one_slot_per_pulse_interval
 test_dispatch_ramp_never_exceeds_max_capacity
 test_dispatch_ramp_can_be_disabled
+test_dispatch_ramp_uses_precomputed_boot_timestamp
+test_dispatch_ramp_uses_precomputed_cooldown_expiry
+test_dispatch_ramp_handles_unset_logfile
 
 echo ""
 echo "===================="


### PR DESCRIPTION
## Summary

Refactored dispatch ramp helpers to accept precomputed boot and cooldown timestamps, passed them through startup capacity ramp calculation, and made ramp logging safe when LOGFILE is unset. Added regression coverage for precomputed inputs and LOGFILE fallback.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/tests/test-pulse-dispatch-staggering.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-dispatch-staggering.sh; .agents/scripts/tests/test-pulse-dispatch-staggering.sh

Resolves #25078


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 97,479 tokens on this as a headless worker.