### PR TITLE
GH#25075: fix: narrow jq stderr matcher

### DIFF
--- a/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
@@ -120,7 +120,7 @@ _gh_collaborator_permission_lookup() {
 stderr_contains_jq_error() {
 	local stderr_output="$1"
 	case "$stderr_output" in
-	*error*)
+	*"parse error:"* | *"jq: error"*)
 		return 0
 		;;
 	*)
@@ -310,6 +310,10 @@ test_comment_jq_error_matcher_handles_jq_versions() {
 	fi
 	if ! stderr_contains_jq_error 'jq: error (at <stdin>:1): Invalid numeric literal at line 1, column 5'; then
 		print_result "comment jq error matcher handles jq versions" 1 "did not match jq 1.7 error output"
+		return 0
+	fi
+	if stderr_contains_jq_error 'bash: unrelated system error'; then
+		print_result "comment jq error matcher handles jq versions" 1 "matched unrelated stderr error output"
 		return 0
 	fi
 	print_result "comment jq error matcher handles jq versions" 0


### PR DESCRIPTION
## Summary

Narrowed stderr_contains_jq_error to jq-specific parse/error signatures and added a regression assertion that unrelated stderr containing error is not treated as jq output.

## Files Changed

.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh; bash .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh

Resolves #25075


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 32,342 tokens on this as a headless worker.