### PR TITLE
GH#25087: fix: broaden jq stderr matcher

### DIFF
--- a/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
@@ -120,7 +120,7 @@ _gh_collaborator_permission_lookup() {
 stderr_contains_jq_error() {
 	local stderr_output="$1"
 	case "$stderr_output" in
-	*"parse error:"* | *"jq: error"*)
+	*"parse error:"* | *"jq:"*error*)
 		return 0
 		;;
 	*)
@@ -310,6 +310,10 @@ test_comment_jq_error_matcher_handles_jq_versions() {
 	fi
 	if ! stderr_contains_jq_error 'jq: error (at <stdin>:1): Invalid numeric literal at line 1, column 5'; then
 		print_result "comment jq error matcher handles jq versions" 1 "did not match jq 1.7 error output"
+		return 0
+	fi
+	if ! stderr_contains_jq_error 'jq: 1 compile error'; then
+		print_result "comment jq error matcher handles jq versions" 1 "did not match jq compile error output"
 		return 0
 	fi
 	if stderr_contains_jq_error 'bash: unrelated system error'; then


### PR DESCRIPTION
## Summary

Broadened the test helper jq stderr matcher to accept jq compile error formats such as 'jq: 1 compile error' while still excluding unrelated stderr, and added regression coverage for that format.

## Files Changed

.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh && .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh

Resolves #25087


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 32,396 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error detection to recognize additional jq error message patterns, improving test robustness and coverage across different error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->