### PR TITLE
GH#25088: fix: isolate required checks test path expansion

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -278,19 +278,21 @@ EOF
 }
 
 test_required_checks_gh_reads_are_timeout_wrapped() {
-	if [[ -z "${REQUIRED_CHECKS_SCRIPT:-}" ]]; then
+	local required_checks_script="${REQUIRED_CHECKS_SCRIPT:-}"
+
+	if [[ -z "$required_checks_script" ]]; then
 		printf 'ERROR: REQUIRED_CHECKS_SCRIPT is empty or not set\n' >&2
 		print_result "required-check gh reads use timeout wrapper" 1
 		return 0
 	fi
 
-	if [[ ! -f "$REQUIRED_CHECKS_SCRIPT" ]]; then
-		printf 'ERROR: REQUIRED_CHECKS_SCRIPT file does not exist or is not a regular file: %s\n' "$REQUIRED_CHECKS_SCRIPT" >&2
+	if [[ ! -f "$required_checks_script" ]]; then
+		printf 'ERROR: REQUIRED_CHECKS_SCRIPT file does not exist or is not a regular file: %s\n' "$required_checks_script" >&2
 		print_result "required-check gh reads use timeout wrapper" 1
 		return 0
 	fi
 
-	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$REQUIRED_CHECKS_SCRIPT" \
+	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$required_checks_script" \
 		| sed -E 's/_pmrc_gh_read[[:space:]]+gh[[:space:]]+(api|pr[[:space:]]+checks)//g' \
 		| grep -nE '^[[:space:]]*[^#]*(^|[[:space:]])gh[[:space:]]+(api|pr[[:space:]]+checks)([[:space:]]|$)'; } >/dev/null 2>&1; then
 		print_result "required-check gh reads use timeout wrapper" 1


### PR DESCRIPTION
## Summary

Isolated the unset-safe REQUIRED_CHECKS_SCRIPT expansion into a local variable before subsequent path validation and scanning, keeping the required-checks wrapper test robust under set -u.

## Files Changed

.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh && shellcheck .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

Resolves #25088


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 64,944 tokens on this as a headless worker.