### PR TITLE
GH#25089: fix: verify claim fallback umask at runtime

### DIFF
--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -603,7 +603,7 @@ test_claim_retries_transient_post_failure() {
 # Test: claim POST stderr fallback avoids predictable /tmp paths when mktemp fails.
 #######################################
 test_claim_post_error_fallback_avoids_tmp() {
-	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts test_home chmod_log chmod_mode chmod_path suppressed_creation_pattern
+	local tmp_dir mock_path old_created_at claim_created_at output exit_code attempts test_home chmod_log chmod_mode chmod_path pre_chmod_mode suppressed_creation_pattern
 	tmp_dir=$(mktemp -d)
 	mock_path=$(create_mock_gh "$tmp_dir")
 	test_home="${tmp_dir}/home"
@@ -620,6 +620,15 @@ EOF
 	cat >"${mock_path}/chmod" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\t%s\n' "${1:-}" "${2:-}" >>"${MOCK_CHMOD_LOG:?}"
+if [[ -e "${2:-}" ]]; then
+	python3 - "${2:-}" >>"${MOCK_CHMOD_LOG:?}.pre" <<'PY' || true
+import os
+import stat
+import sys
+
+print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])
+PY
+fi
 command -p chmod "$@"
 EOF
 	chmod +x "${mock_path}/chmod"
@@ -673,10 +682,14 @@ EOF
 	else
 		print_result "claim POST fallback pre-creates private stderr file" 1 "chmod_mode=${chmod_mode:-missing} chmod_path=${chmod_path:-missing} output: $output"
 	fi
-	if grep -q "umask 077" "$CLAIM_HELPER"; then
+	pre_chmod_mode=""
+	if [[ -f "${chmod_log}.pre" ]]; then
+		IFS= read -r pre_chmod_mode <"${chmod_log}.pre" || true
+	fi
+	if [[ "$pre_chmod_mode" == "600" ]]; then
 		print_result "claim POST fallback creates file under restrictive umask" 0
 	else
-		print_result "claim POST fallback creates file under restrictive umask" 1 "umask 077 not found in helper"
+		print_result "claim POST fallback creates file under restrictive umask" 1 "pre_chmod_mode=${pre_chmod_mode:-missing} output: $output"
 	fi
 	if grep -q "set -C" "$CLAIM_HELPER"; then
 		print_result "claim POST fallback uses exclusive creation" 0

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -666,8 +666,6 @@ EOF
 		print_result "claim POST fallback avoids predictable tmp path" 0
 	fi
 
-	chmod_mode=""
-	chmod_path=""
 	if [[ -f "$chmod_log" ]]; then
 		IFS=$'\t' read -r chmod_mode chmod_path <"$chmod_log" || true
 	fi
@@ -676,7 +674,6 @@ EOF
 	else
 		print_result "claim POST fallback pre-creates private stderr file" 1 "chmod_mode=${chmod_mode:-missing} chmod_path=${chmod_path:-missing} output: $output"
 	fi
-	pre_chmod_mode=""
 	if [[ -f "${chmod_log}.pre" ]]; then
 		IFS= read -r pre_chmod_mode <"${chmod_log}.pre" || true
 	fi

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -621,13 +621,7 @@ EOF
 #!/usr/bin/env bash
 printf '%s\t%s\n' "${1:-}" "${2:-}" >>"${MOCK_CHMOD_LOG:?}"
 if [[ -e "${2:-}" ]]; then
-	python3 - "${2:-}" >>"${MOCK_CHMOD_LOG:?}.pre" <<'PY' || true
-import os
-import stat
-import sys
-
-print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])
-PY
+	python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "${2:-}" >>"${MOCK_CHMOD_LOG:?}.pre" || true
 fi
 command -p chmod "$@"
 EOF


### PR DESCRIPTION
## Summary

Replaced the brittle static umask grep in .agents/scripts/tests/test-dispatch-claim-helper.sh with runtime capture of the fallback stderr file mode before chmod is applied, then asserted the pre-chmod mode is 600.

## Files Changed

.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-claim-helper.sh; shellcheck .agents/scripts/tests/test-dispatch-claim-helper.sh

Resolves #25089


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 61,522 tokens on this as a headless worker.