### PR TITLE
GH#25097: fix: retain OpenCode sessions for 30 days

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -122,6 +122,7 @@ All thresholds overrideable via environment variables:
 | `AUTO_MIN_SECONDS_BETWEEN` | `518400` | Throttle for `auto` mode (6 days) |
 | `WAL_LARGE_THRESHOLD_MB` | `500` | Report checkpoint/busy details above this WAL size |
 | `MAINTENANCE_WINDOW_KEEP_SESSIONS` | `500` | Count target used by `maintenance-window` archive |
+| `MAINTENANCE_WINDOW_RETENTION_DAYS` | `30` | Age target used by `maintenance-window` archive |
 | `OPENCODE_DB_MAINTENANCE_HOUR` | `4` | Scheduled local hour for the weekly routine |
 | `OPENCODE_DB_MAINTENANCE_MINUTE` | `0` | Scheduled local minute for the weekly routine |
 | `OPENCODE_DB_MAINTENANCE_MODE` | `auto` | `auto` or disruptive `maintenance-window` scheduler mode |
@@ -138,7 +139,7 @@ FORCE_VACUUM_SIZE_MB=0 VACUUM_FREELIST_THRESHOLD=0.0 \
 `opencode-db-archive.sh archive` supports two retention targets:
 
 - **Age-based retention** (`--retention-days N`) archives sessions whose last
-  update/activity is older than `N` days. This remains the default mode (`14`
+  update/activity is older than `N` days. This remains the default mode (`30`
   days) and is best when session volume is predictable. A resumed or updated
   session stays active even when its original creation time is older than the
   cutoff.
@@ -177,7 +178,8 @@ It does this in order:
 
 1. Stops aidevops-managed pulse/headless workers with `pulse-lifecycle-helper.sh
    stop`.
-2. Archives old sessions with `opencode-db-archive.sh archive --keep-sessions
+2. Archives old sessions with `opencode-db-archive.sh archive --retention-days
+   ${MAINTENANCE_WINDOW_RETENTION_DAYS} --keep-sessions
    ${MAINTENANCE_WINDOW_KEEP_SESSIONS}`.
 3. Runs normal maintenance, including final post-VACUUM WAL checkpoint.
 4. Runs `PRAGMA quick_check`.

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -31,7 +31,7 @@ _oda_dir="${BASH_SOURCE[0]%/*}"
 readonly SCRIPT_NAME="opencode-db-archive"
 readonly DEFAULT_DB="$HOME/.local/share/opencode/opencode.db"
 readonly DEFAULT_ARCHIVE_DB="$HOME/.local/share/opencode/opencode-archive.db"
-readonly DEFAULT_RETENTION_DAYS=14
+readonly DEFAULT_RETENTION_DAYS=30
 readonly DEFAULT_BATCH_SIZE=500
 readonly DEFAULT_MAX_DURATION=60
 
@@ -700,7 +700,7 @@ cmd_stats() {
 	local now_s
 	now_s=$(date +%s)
 	local seven_days_ms=$(((now_s - 7 * 86400) * 1000))
-	local fourteen_days_ms=$(((now_s - 14 * 86400) * 1000))
+	local thirty_days_ms=$(((now_s - 30 * 86400) * 1000))
 
 	echo ""
 	echo "=== Active DB: $ACTIVE_DB ==="
@@ -720,16 +720,16 @@ cmd_stats() {
 	echo "  Session shares: $share_count"
 
 	# Last-update distribution
-	local last_7d last_14d older
+	local last_7d last_30d older
 	last_7d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $seven_days_ms;")
-	last_14d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $fourteen_days_ms AND time_updated < $seven_days_ms;")
-	older=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated < $fourteen_days_ms;")
+	last_30d=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $thirty_days_ms AND time_updated < $seven_days_ms;")
+	older=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated < $thirty_days_ms;")
 
 	echo ""
 	echo "  Last-update distribution:"
 	echo "    Last 7 days:   $last_7d"
-	echo "    7–14 days:     $last_14d"
-	echo "    Older than 14: $older"
+	echo "    7–30 days:     $last_30d"
+	echo "    Older than 30: $older"
 
 	if [[ -f "$ARCHIVE_DB" ]]; then
 		echo ""
@@ -750,16 +750,16 @@ cmd_stats() {
 		echo "  Session shares: $arch_share"
 
 		# Last-update distribution in archive
-		local arch_7d arch_14d arch_older
+		local arch_7d arch_30d arch_older
 		arch_7d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $seven_days_ms;" 2>/dev/null || echo "0")
-		arch_14d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $fourteen_days_ms AND time_updated < $seven_days_ms;" 2>/dev/null || echo "0")
-		arch_older=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated < $fourteen_days_ms;" 2>/dev/null || echo "0")
+		arch_30d=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated >= $thirty_days_ms AND time_updated < $seven_days_ms;" 2>/dev/null || echo "0")
+		arch_older=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE time_updated < $thirty_days_ms;" 2>/dev/null || echo "0")
 
 		echo ""
 		echo "  Last-update distribution:"
 		echo "    Last 7 days:   $arch_7d"
-		echo "    7–14 days:     $arch_14d"
-		echo "    Older than 14: $arch_older"
+		echo "    7–30 days:     $arch_30d"
+		echo "    Older than 30: $arch_older"
 	else
 		echo ""
 		echo "=== Archive DB: (not yet created) ==="
@@ -781,7 +781,7 @@ COMMANDS:
   help      Show this help message
 
 ARCHIVE OPTIONS:
-  --retention-days N        Sessions inactive for N days are archived (default: 14)
+  --retention-days N        Sessions inactive for N days are archived (default: 30)
   --keep-sessions N         Keep newest N active sessions by last update; archive older sessions beyond the budget
   --dry-run                 Show what would be archived without doing it
   --max-duration-seconds N  Stop after N seconds even when not done (default: 60)
@@ -800,7 +800,7 @@ EXAMPLES:
   # Keep the 500 most recently updated active sessions, archive older sessions
   opencode-db-archive.sh archive --keep-sessions 500
 
-  # Archive with defaults (14 days, 60s time budget)
+  # Archive with defaults (30 days, 60s time budget)
   opencode-db-archive.sh archive
 
   # Archive as pulse pre-flight (short time budget)

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -110,8 +110,8 @@ readonly LOG_FILE="${STATE_DIR}/maintenance.log"
 [[ "$FORCE_VACUUM_SIZE_MB" =~ ^[0-9]+$ ]] && FORCE_VACUUM_SIZE_MB=$((10#$FORCE_VACUUM_SIZE_MB)) || FORCE_VACUUM_SIZE_MB=500
 [[ "$AUTO_MIN_SECONDS_BETWEEN" =~ ^[0-9]+$ ]] && AUTO_MIN_SECONDS_BETWEEN=$((10#$AUTO_MIN_SECONDS_BETWEEN)) || AUTO_MIN_SECONDS_BETWEEN=518400
 [[ "$WAL_LARGE_THRESHOLD_MB" =~ ^[0-9]+$ ]] && WAL_LARGE_THRESHOLD_MB=$((10#$WAL_LARGE_THRESHOLD_MB)) || WAL_LARGE_THRESHOLD_MB=500
-# MAINTENANCE_WINDOW_KEEP_SESSIONS: count target for disruptive maintenance-window archive
-: "${MAINTENANCE_WINDOW_KEEP_SESSIONS:=500}"
+: "${MAINTENANCE_WINDOW_KEEP_SESSIONS:=500}"  # maintenance-window count target
+: "${MAINTENANCE_WINDOW_RETENTION_DAYS:=30}" # maintenance-window age target
 # Scheduler knobs: safe default is weekly Sun 04:00 running non-disruptive auto.
 : "${OPENCODE_DB_MAINTENANCE_HOUR:=4}"
 : "${OPENCODE_DB_MAINTENANCE_MINUTE:=0}"
@@ -1000,6 +1000,7 @@ cmd_maintenance_window() {
 
 	local force_opencode=false
 	local keep_sessions="$MAINTENANCE_WINDOW_KEEP_SESSIONS"
+	local retention_days="$MAINTENANCE_WINDOW_RETENTION_DAYS"
 	local skip_archive=false
 	local arg
 
@@ -1007,16 +1008,16 @@ cmd_maintenance_window() {
 		local arg="$1"
 		case "$arg" in
 		--force-opencode)
-			force_opencode=true
-			shift
+			force_opencode=true; shift
 			;;
 		--keep-sessions)
-			keep_sessions="${2:-}"
-			shift 2
+			keep_sessions="${2:-}"; shift 2
+			;;
+		--retention-days)
+			retention_days="${2:-}"; shift 2
 			;;
 		--skip-archive)
-			skip_archive=true
-			shift
+			skip_archive=true; shift
 			;;
 		*)
 			print_error "Unknown maintenance-window option: $arg"
@@ -1025,10 +1026,8 @@ cmd_maintenance_window() {
 		esac
 	done
 
-	if [[ ! "$keep_sessions" =~ ^[0-9]+$ ]]; then
-		print_error "--keep-sessions must be a non-negative integer: ${keep_sessions}"
-		return 1
-	fi
+	[[ "$keep_sessions" =~ ^[0-9]+$ ]] || { print_error "--keep-sessions must be a non-negative integer: ${keep_sessions}"; return 1; }
+	[[ "$retention_days" =~ ^[0-9]+$ ]] || { print_error "--retention-days must be a non-negative integer: ${retention_days}"; return 1; }
 	if ! _opencode_installed; then
 		print_info "opencode not installed — nothing to maintain"
 		return 0
@@ -1058,8 +1057,8 @@ cmd_maintenance_window() {
 
 	local rc=0
 	if [[ "$skip_archive" != true ]] && [[ -x "$OPENCODE_DB_ARCHIVE_HELPER" ]]; then
-		print_info "Archiving old OpenCode sessions (keep newest ${keep_sessions})..."
-		"$OPENCODE_DB_ARCHIVE_HELPER" archive --keep-sessions "$keep_sessions" --max-duration-seconds 300 || rc=$?
+		print_info "Archiving old OpenCode sessions (inactive ${retention_days}+ days and outside newest ${keep_sessions})..."
+		"$OPENCODE_DB_ARCHIVE_HELPER" archive --retention-days "$retention_days" --keep-sessions "$keep_sessions" --max-duration-seconds 300 || rc=$?
 		if [[ "$rc" -ne 0 ]]; then
 			print_warning "archive step failed (rc=${rc}); continuing to maintenance"
 		fi
@@ -1447,6 +1446,7 @@ Environment variables (advanced):
   AUTO_MIN_SECONDS_BETWEEN     Throttle for auto mode (default 518400 = 6 days)
   WAL_LARGE_THRESHOLD_MB       Warn/report large WAL above this size (default 500)
   MAINTENANCE_WINDOW_KEEP_SESSIONS  Archive keep target for maintenance-window (default 500)
+  MAINTENANCE_WINDOW_RETENTION_DAYS Preserve active /sessions history during maintenance-window (default 30)
   OPENCODE_DB_MAINTENANCE_HOUR Scheduled local hour for install (default 4)
   OPENCODE_DB_MAINTENANCE_MINUTE Scheduled local minute for install (default 0)
   OPENCODE_DB_MAINTENANCE_MODE  Scheduler mode: auto or maintenance-window

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -266,7 +266,7 @@ _get_model_usage_from_opencode() {
 
 	local raw_json
 	# GH#17549: Query both active and archive DBs for all-time stats.
-	# The archive DB contains sessions >14 days old, moved by opencode-db-archive.sh.
+	# The archive DB contains sessions >30 days old, moved by opencode-db-archive.sh.
 	local attach_clause=""
 	local union_clause=""
 	if [[ -f "$OPENCODE_ARCHIVE_DB_FILE" ]]; then

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -295,6 +295,32 @@ fi
 
 _reset_dbs
 now_seconds=$(date +%s)
+old_default_ms=$(((now_seconds - 31 * 86400) * 1000))
+recent_default_ms=$(((now_seconds - 29 * 86400) * 1000))
+_make_active_db_with_sessions "default_old,${old_default_ms}
+default_recent,${recent_default_ms}"
+
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive succeeds with default 30-day retention"
+else
+	_fail "default 30-day archive failed with rc=$rc — output: $out"
+fi
+
+default_recent_active=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE id='default_recent';")
+default_old_archived=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE id='default_old';")
+if [[ "$default_recent_active" == "1" && "$default_old_archived" == "1" ]]; then
+	_pass "default retention preserves 30-day /sessions history"
+else
+	_fail "default retention mismatch: recent_active=${default_recent_active}, old_archived=${default_old_archived}"
+fi
+
+_reset_dbs
+now_seconds=$(date +%s)
 old1_ms=$(((now_seconds - 10 * 86400) * 1000))
 old2_created_ms=$(((now_seconds - 9 * 86400) * 1000))
 old2_updated_ms=$(((now_seconds - 8 * 86400) * 1000))

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -424,7 +424,7 @@ out=$(PATH="$mock_bin:$PATH" MOCK_PULSE_LOG="$mock_pulse_log" MOCK_ARCHIVE_LOG="
 	_run_helper maintenance-window --force-opencode --keep-sessions 123 2>&1)
 rc=$?
 set -e
-if [[ "$rc" -eq 0 ]] && grep -q '^stop$' "$mock_pulse_log" && grep -q '^start$' "$mock_pulse_log" && grep -q -- '--keep-sessions 123' "$mock_archive_log"; then
+if [[ "$rc" -eq 0 ]] && grep -q '^stop$' "$mock_pulse_log" && grep -q '^start$' "$mock_pulse_log" && grep -q -- '--retention-days 30' "$mock_archive_log" && grep -q -- '--keep-sessions 123' "$mock_archive_log"; then
 	_pass "maintenance-window stops pulse, archives, maintains, and restarts pulse"
 else
 	_fail "maintenance-window mocked lifecycle failed (rc=$rc) — output: $out"


### PR DESCRIPTION
## Summary

Retain OpenCode /sessions history for 30 days before archiving, including maintenance-window archive behavior, and update docs/tests to match.

## Files Changed

.agents/reference/opencode-maintenance.md,.agents/scripts/opencode-db-archive.sh,.agents/scripts/opencode-db-maintenance-helper.sh,.agents/scripts/profile-readme-data-lib.sh,.agents/scripts/tests/test-opencode-db-archive.sh,.agents/scripts/tests/test-opencode-db-maintenance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on modified shell files; bash .agents/scripts/tests/test-opencode-db-archive.sh; .agents/scripts/tests/test-opencode-db-maintenance.sh; .agents/scripts/linters-local.sh

Resolves #25097


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.95 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1h 13m and 294,130 tokens on this with the user in an interactive session.