### PR TITLE
GH#25099: fix: guard dispatch claim chmod precheck

### DIFF
--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -674,7 +674,7 @@ EOF
 	else
 		print_result "claim POST fallback pre-creates private stderr file" 1 "chmod_mode=${chmod_mode:-missing} chmod_path=${chmod_path:-missing} output: $output"
 	fi
-	if [[ -f "${chmod_log}.pre" ]]; then
+	if [[ -n "${chmod_log:-}" && -f "${chmod_log}.pre" ]]; then
 		IFS= read -r pre_chmod_mode <"${chmod_log}.pre" || true
 	fi
 	if [[ "$pre_chmod_mode" == "600" ]]; then


### PR DESCRIPTION
## Summary

Guard the chmod_log .pre file check in .agents/scripts/tests/test-dispatch-claim-helper.sh so set -u cannot expand an unset/empty path before reading the pre-chmod mode.

## Files Changed

.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-claim-helper.sh; shellcheck .agents/scripts/tests/test-dispatch-claim-helper.sh

Resolves #25099


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 51,393 tokens on this as a headless worker.