### PR TITLE
GH#25105: fix: clarify worker cached permission login

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1057,7 +1057,7 @@ _issue_has_verified_crypto_approval() {
 # Args: $1=pr_number, $2=repo_slug, $3=labels_str (comma-separated),
 #       $4=is_draft, $5=linked_issue,
 #       $6=precomputed_pr_author_permission(optional),
-#       $7=precomputed_permission_login(optional)
+#       $7=precomputed_pr_author_login(optional)
 # Returns: 0=all gates pass (eligible for auto-merge), 1=blocked
 #######################################
 _attempt_worker_briefed_auto_merge() {
@@ -1067,7 +1067,7 @@ _attempt_worker_briefed_auto_merge() {
 	local is_draft="$4"
 	local linked_issue="$5"
 	local precomputed_pr_author_permission="${6:-}"
-	local precomputed_permission_login="${7:-}"
+	local precomputed_pr_author_login="${7:-}"
 
 	# Feature flag — when OFF, all origin:worker PRs fall back to manual merge
 	if [[ "${AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE:-1}" == "0" ]]; then
@@ -1105,7 +1105,7 @@ _attempt_worker_briefed_auto_merge() {
 	read -r issue_author_assoc issue_author_login <<< "$_issue_meta"
 	local issue_author_permission=""
 	#aidevops:trust-boundary — reuse PR-author permission only for the same non-empty issue-author login.
-	if [[ -n "$precomputed_pr_author_permission" && -n "$precomputed_permission_login" && "$precomputed_permission_login" == "$issue_author_login" ]]; then
+	if [[ -n "$precomputed_pr_author_permission" && -n "$precomputed_pr_author_login" && "$precomputed_pr_author_login" == "$issue_author_login" ]]; then
 		issue_author_permission="$precomputed_pr_author_permission"
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
+++ b/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
@@ -806,9 +806,9 @@ test_case_t_worker_gate_ignores_mismatched_precomputed_permission() {
 }
 
 # =============================================================================
-# Case (u): worker gate ignores precomputed permission with empty login (GH#25090)
+# Case (u): worker gate ignores precomputed PR-author permission with empty login (GH#25105)
 # =============================================================================
-test_case_u_worker_gate_ignores_empty_precomputed_permission_login() {
+test_case_u_worker_gate_ignores_empty_precomputed_pr_author_login() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
@@ -821,12 +821,12 @@ test_case_u_worker_gate_ignores_empty_precomputed_permission_login() {
 	_attempt_worker_briefed_auto_merge "120" "owner/repo" "origin:worker" "false" "62" "write" "" && result=0 || result=$?
 
 	if [[ "$result" -eq 0 ]]; then
-		print_result "Case (u): worker gate ignores empty precomputed permission login (GH#25090)" 1 \
+		print_result "Case (u): worker gate ignores empty precomputed PR-author login (GH#25105)" 1 \
 			"Expected non-zero exit, got 0 (empty cached-permission login should not trust issue author)"
 	elif grep -q "/collaborators/issue-author/permission" "$GH_LOG" 2>/dev/null; then
-		print_result "Case (u): worker gate ignores empty precomputed permission login (GH#25090)" 0
+		print_result "Case (u): worker gate ignores empty precomputed PR-author login (GH#25105)" 0
 	else
-		print_result "Case (u): worker gate ignores empty precomputed permission login (GH#25090)" 1 \
+		print_result "Case (u): worker gate ignores empty precomputed PR-author login (GH#25105)" 1 \
 			"Expected fallback collaborator permission API call for issue-author"
 	fi
 	teardown_test_env
@@ -893,7 +893,7 @@ main() {
 	test_case_r_precomputed_permission_skips_api
 	test_case_s_worker_gate_uses_matching_precomputed_permission
 	test_case_t_worker_gate_ignores_mismatched_precomputed_permission
-	test_case_u_worker_gate_ignores_empty_precomputed_permission_login
+	test_case_u_worker_gate_ignores_empty_precomputed_pr_author_login
 	test_case_v_spoofed_crypto_marker_blocked
 
 	echo ""


### PR DESCRIPTION
## Summary

Clarified the worker-briefed auto-merge cached permission parameter as the PR author login, preserving the non-empty same-login trust boundary, and updated the regression test naming/output to cover GH#25105.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/tests/test-pulse-merge-worker-briefed.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-worker-briefed.sh; shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-worker-briefed.sh

Resolves #25105


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 64,764 tokens on this as a headless worker.