### PR TITLE
GH#25106: fix: keep pulse rate-limit config static

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -142,8 +142,10 @@ PULSE_EVENTS_TICKLE_ENABLED=1
 # Set to 0 only for a bounded diagnostic run where owner-wide search semantics
 # are required and secondary cooldown is known clear.
 #
-# Env var PULSE_BATCH_SEARCH_LAST_RESORT takes precedence if already set.
-PULSE_BATCH_SEARCH_LAST_RESORT=${PULSE_BATCH_SEARCH_LAST_RESORT:-1}
+# This file assigns PULSE_BATCH_SEARCH_LAST_RESORT directly. Consumers that
+# need to preserve a pre-existing environment override must save and restore it
+# around sourcing this config.
+PULSE_BATCH_SEARCH_LAST_RESORT=1
 
 # ── GitHub Actions runner queue saturation (t3211, GH#21942) ──────────────────
 #


### PR DESCRIPTION
## Summary

Restored PULSE_BATCH_SEARCH_LAST_RESORT to a plain KEY=VALUE assignment and documented that consumers must save and restore overrides around sourcing the static config.

## Files Changed

.agents/configs/pulse-rate-limit.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh (passed; markdownlint unavailable warning and historical advisory debt only)

Resolves #25106


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 6m and 71,935 tokens on this as a headless worker.