### PR TITLE
fix: harden oauth token response parsing

### DIFF
--- a/.agents/scripts/oauth-pool-lib/_common.py
+++ b/.agents/scripts/oauth-pool-lib/_common.py
@@ -201,5 +201,5 @@ def call_token_endpoint(
         return {TOKEN_REFRESH_ERROR_KEY: _classify_http_error(exc)}
     except (urllib.error.URLError, OSError):
         return {TOKEN_REFRESH_ERROR_KEY: "network"}
-    except ValueError:
+    except (ValueError, TypeError):
         return {TOKEN_REFRESH_ERROR_KEY: "invalid_response"}

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -685,6 +685,15 @@ class RefreshTests(PoolOpsTestCase):
 
         self.assertEqual(_common.token_refresh_error_label(result), "invalid_response")
 
+    def test_successful_refresh_with_type_error_is_sanitized(self) -> None:
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = None
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            result = _common.call_token_endpoint("https://auth.example.invalid/token", "client", "secret-refresh", "ua")
+
+        self.assertEqual(_common.token_refresh_error_label(result), "invalid_response")
+        self.assertNotIn("secret-refresh", json.dumps(result))
+
     def test_rotate_reports_invalid_refresh_response(self) -> None:
         account = {"email": "a@example.com", "access": "old", "refresh": "secret-refresh", "expires": 1}
         with mock.patch.object(pool_ops_rotate, "TOKEN_URLS", {"anthropic": "https://auth.example.invalid/token"}), \

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -687,7 +687,9 @@ class RefreshTests(PoolOpsTestCase):
 
     def test_successful_refresh_with_type_error_is_sanitized(self) -> None:
         response = mock.MagicMock()
-        response.__enter__.return_value.read.return_value = None
+        body = mock.MagicMock()
+        body.decode.return_value = None
+        response.__enter__.return_value.read.return_value = body
         with mock.patch("urllib.request.urlopen", return_value=response):
             result = _common.call_token_endpoint("https://auth.example.invalid/token", "client", "secret-refresh", "ua")
 


### PR DESCRIPTION
## Summary
- Treat TypeError while parsing successful OAuth token refresh responses as a sanitized invalid_response result.
- Add regression coverage that exercises the TypeError path without exposing refresh tokens.

## Testing
- python3 .agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

Resolves #25115

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
