### PR TITLE
GH#25116: fix: harden prefetch gh wrapper test

### DIFF
--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -217,7 +217,7 @@ test_search_opt_in_preserves_owner_search() {
 test_prefetch_gh_reads_are_timeout_wrapped() {
 	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$HELPER" \
 		| sed -E 's/_prefetch_gh_read[[:space:]]+gh[[:space:]]+(api|search)//g' \
-		| grep -nE '^[[:space:]]*[^#]*(^|[[:space:]])gh[[:space:]]+(api|search)([[:space:]]|$)'; } >/dev/null 2>&1; then
+		| grep -nE '^[[:space:]]*((if|while|until|then|do|else|elif)[[:space:]]+)?gh[[:space:]]+(api|search)([[:space:]]|$)|^[[:space:]]*(local[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\(gh[[:space:]]+(api|search)([[:space:]]|$))'; } >/dev/null 2>&1; then
 		print_result "prefetch gh reads use timeout wrapper" 1
 	else
 		print_result "prefetch gh reads use timeout wrapper" 0

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -215,9 +215,10 @@ test_search_opt_in_preserves_owner_search() {
 }
 
 test_prefetch_gh_reads_are_timeout_wrapped() {
-	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$HELPER" \
+	if { sed -E '/^[[:space:]]*#/d' "$HELPER" \
+		| awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' \
 		| sed -E 's/_prefetch_gh_read[[:space:]]+gh[[:space:]]+(api|search)//g' \
-		| grep -nE '^[[:space:]]*((if|while|until|then|do|else|elif)[[:space:]]+)?gh[[:space:]]+(api|search)([[:space:]]|$)|^[[:space:]]*(local[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*="?\$\(gh[[:space:]]+(api|search)([[:space:]]|$))'; } >/dev/null 2>&1; then
+		| grep -nE '^[[:space:]]*((if|while|until|then|do|else|elif)[[:space:]]+)*(![[:space:]]+)?gh[[:space:]]+(api|search)([[:space:]]|$)|[;|{(][[:space:]]*(![[:space:]]+)?gh[[:space:]]+(api|search)([[:space:]]|$)|\$\([[:space:]]*gh[[:space:]]+(api|search)([[:space:]]|[)])'; } >/dev/null 2>&1; then
 		print_result "prefetch gh reads use timeout wrapper" 1
 	else
 		print_result "prefetch gh reads use timeout wrapper" 0

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -215,7 +215,9 @@ test_search_opt_in_preserves_owner_search() {
 }
 
 test_prefetch_gh_reads_are_timeout_wrapped() {
-	if grep -nE '^[[:space:]]*(gh api|gh search|[a-zA-Z0-9_]+="?\$\(gh (api|search))' "$HELPER" >/dev/null 2>&1; then
+	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$HELPER" \
+		| sed -E 's/_prefetch_gh_read[[:space:]]+gh[[:space:]]+(api|search)//g' \
+		| grep -nE '^[[:space:]]*[^#]*(^|[[:space:]])gh[[:space:]]+(api|search)([[:space:]]|$)'; } >/dev/null 2>&1; then
 		print_result "prefetch gh reads use timeout wrapper" 1
 	else
 		print_result "prefetch gh reads use timeout wrapper" 0


### PR DESCRIPTION
## Summary

Broadened the pulse batch prefetch raw-gh wrapper assertion to catch local variable command substitutions while preserving line-continuation handling and avoiding logged-string false positives. Verified the required-checks wrapper test already covers the companion path on this branch.

## Files Changed

.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh && .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh && .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

Resolves #25116


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 39,884 tokens on this as a headless worker.