### PR TITLE
GH#25121: docs: improve documentation contribution phrasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ Use `Resolves #NNN` for leaf fixes that close the issue. Use `For #NNN` or
 ## Documentation-only changes
 
 Documentation-only PRs are welcome when they stay small, scoped, and linked to
-a GitHub issue. Prefer using `/log-issue-aidevops` to file the issue or request:
-it creates a comprehensive report, checks for duplicates, and follows the
+a GitHub issue. Prefer using `/log-issue-aidevops` to file the issue or request,
+as it creates a comprehensive report, checks for duplicates, and follows the
 project contribution guidelines.
 
 For small documentation-only improvements such as README clarifications,


### PR DESCRIPTION
## Summary

Updated CONTRIBUTING.md documentation-only guidance to use a comma plus 'as' for smoother readability, matching the verified review-bot suggestion.

## Files Changed

CONTRIBUTING.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --no-install markdownlint-cli2 CONTRIBUTING.md

Resolves #25121


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 44,397 tokens on this as a headless worker.