### PR TITLE
GH#25120: fix: stop scan after GraphQL exhaustion

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -444,6 +444,7 @@ _prrts_scan_repo_to_files() {
 			if [[ "$rc" -eq "$PRRTS_RC_GRAPHQL_EXHAUSTED" ]]; then
 				graphql_exhausted_count=$((graphql_exhausted_count + 1))
 				_prrts_log "scan: ${repo_slug}#${pr_number} skipped — GraphQL budget exhausted"
+				break
 			else
 				_prrts_log "scan: ${repo_slug}#${pr_number} skipped — review-thread fetch failed"
 			fi


### PR DESCRIPTION
## Summary

Stopped the review-thread response scanner loop immediately after GraphQL budget exhaustion so subsequent PRs do not trigger redundant GraphQL checks.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pr-review-thread-response-scanner.sh; .agents/scripts/tests/test-pr-review-thread-response-scanner.sh; bash .agents/tests/test-pr-review-thread-response-scanner.sh

Resolves #25120


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 31,727 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PR scanning to properly halt processing when resource limits are reached, preventing unnecessary continued processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->