### PR TITLE
GH#25122: docs: clarify issue requirement for documentation PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ project contribution guidelines.
 For small documentation-only improvements such as README clarifications,
 spelling fixes, broken-link fixes, or contribution-guide updates:
 
-1. Reference a GitHub issue before opening a pull request.
+1. Ensure there is an associated GitHub issue (create one if it does not exist)
+   before opening a pull request.
 2. Keep the change limited to documentation files.
 3. Do not change code, dependencies, workflows, defaults, configuration
    structure, or agent framework behaviour.


### PR DESCRIPTION
## Summary

Clarified that documentation-only contributors should ensure an associated GitHub issue exists and create one when needed before opening a PR.

## Files Changed

CONTRIBUTING.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --no-install markdownlint-cli2 CONTRIBUTING.md

Resolves #25122


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 56s and 23,235 tokens on this as a headless worker.