### PR TITLE
GH#25133: fix: narrow oauth response parsing errors

### DIFF
--- a/.agents/scripts/oauth-pool-lib/_common.py
+++ b/.agents/scripts/oauth-pool-lib/_common.py
@@ -193,13 +193,16 @@ def call_token_endpoint(
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-            if isinstance(data, dict):
-                return data
-            return {TOKEN_REFRESH_ERROR_KEY: "invalid_response"}
+            raw_data = resp.read()
     except urllib.error.HTTPError as exc:
         return {TOKEN_REFRESH_ERROR_KEY: _classify_http_error(exc)}
     except (urllib.error.URLError, OSError):
         return {TOKEN_REFRESH_ERROR_KEY: "network"}
+
+    try:
+        data = json.loads(raw_data.decode("utf-8"))
+        if isinstance(data, dict):
+            return data
     except (ValueError, TypeError):
-        return {TOKEN_REFRESH_ERROR_KEY: "invalid_response"}
+        pass
+    return {TOKEN_REFRESH_ERROR_KEY: "invalid_response"}

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -696,6 +696,11 @@ class RefreshTests(PoolOpsTestCase):
         self.assertEqual(_common.token_refresh_error_label(result), "invalid_response")
         self.assertNotIn("secret-refresh", json.dumps(result))
 
+    def test_urlopen_type_error_is_not_reclassified_as_invalid_response(self) -> None:
+        with mock.patch("urllib.request.urlopen", side_effect=TypeError("bad timeout")):
+            with self.assertRaises(TypeError):
+                _common.call_token_endpoint("https://auth.example.invalid/token", "client", "secret-refresh", "ua")
+
     def test_rotate_reports_invalid_refresh_response(self) -> None:
         account = {"email": "a@example.com", "access": "old", "refresh": "secret-refresh", "expires": 1}
         with mock.patch.object(pool_ops_rotate, "TOKEN_URLS", {"anthropic": "https://auth.example.invalid/token"}), \


### PR DESCRIPTION
## Summary

Separated OAuth token endpoint network execution from response decoding so TypeError/ValueError are only converted to invalid_response during decode/JSON parsing. Added a regression test that urlopen TypeError propagates instead of being reclassified.

## Files Changed

.agents/scripts/oauth-pool-lib/_common.py,.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest discover -s .agents/scripts/oauth-pool-lib/tests; python3 -m py_compile .agents/scripts/oauth-pool-lib/_common.py .agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

Resolves #25133


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 37,584 tokens on this as a headless worker.