### PR TITLE
GH#25137: test: cover invalid prefetch detector inputs

### DIFF
--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -130,10 +130,16 @@ prefetch_raw_gh_read_matches() {
 }
 
 test_prefetch_raw_gh_read_detector_rejects_missing_file() {
-	if prefetch_raw_gh_read_matches || prefetch_raw_gh_read_matches "$TEST_ROOT/missing.sh"; then
-		print_result "prefetch raw gh detector rejects missing file input" 1
+	local empty_path=""
+	local missing_path="$TEST_ROOT/missing.sh"
+	local directory_path="$TEST_ROOT"
+	if prefetch_raw_gh_read_matches \
+		|| prefetch_raw_gh_read_matches "$empty_path" \
+		|| prefetch_raw_gh_read_matches "$missing_path" \
+		|| prefetch_raw_gh_read_matches "$directory_path"; then
+		print_result "prefetch raw gh detector rejects invalid file input" 1
 	else
-		print_result "prefetch raw gh detector rejects missing file input" 0
+		print_result "prefetch raw gh detector rejects invalid file input" 0
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Extended the prefetch raw gh read detector regression test to cover explicit empty-string paths and directory paths in addition to omitted and missing file inputs.

## Files Changed

.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh; shellcheck .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

Resolves #25137


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 41,902 tokens on this as a headless worker.