### PR TITLE
GH#25140: fix: guard OAuth rotate empty refresh response

### DIFF
--- a/.agents/scripts/oauth-pool-lib/pool_ops_rotate.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_rotate.py
@@ -43,6 +43,9 @@ def _try_refresh_token(account: dict, provider: str, now_ms: int, ua_header: str
     if not (refresh_tok and token_url and client_id):
         return
     rdata = call_token_endpoint(token_url, client_id, refresh_tok, ua_header)
+    if rdata is None:
+        print("REFRESH_FAILED", file=sys.stderr)
+        return
     error_label = token_refresh_error_label(rdata)
     if error_label:
         print(f"REFRESH_FAILED:{error_label}", file=sys.stderr)

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -712,6 +712,17 @@ class RefreshTests(PoolOpsTestCase):
         self.assertEqual(stderr.write.call_args_list[0].args[0], "REFRESH_FAILED:invalid_response")
         self.assertEqual(account["access"], "old")
 
+    def test_rotate_handles_none_refresh_response(self) -> None:
+        account = {"email": "a@example.com", "access": "old", "refresh": "secret-refresh", "expires": 1}
+        with mock.patch.object(pool_ops_rotate, "TOKEN_URLS", {"anthropic": "https://auth.example.invalid/token"}), \
+            mock.patch.object(pool_ops_rotate, "CLIENT_IDS", {"anthropic": "client"}), \
+            mock.patch.object(pool_ops_rotate, "call_token_endpoint", return_value=None), \
+            mock.patch("sys.stderr") as stderr:
+            pool_ops_rotate._try_refresh_token(account, "anthropic", int(time.time() * 1000), "ua")
+
+        self.assertEqual(stderr.write.call_args_list[0].args[0], "REFRESH_FAILED")
+        self.assertEqual(account["access"], "old")
+
     def test_refresh_account_reports_sanitized_http_failure(self) -> None:
         account = {"email": "a@example.com", "access": "old", "refresh": "secret-refresh", "expires": 1}
         ctx = pool_ops_refresh._RefreshContext("https://auth.example.invalid/token", "client", "ua", "all")


### PR DESCRIPTION
## Summary

Restored a defensive None guard before pool_ops_rotate reads refresh response fields and added a regression test for mocked/future None responses.

## Files Changed

.agents/scripts/oauth-pool-lib/pool_ops_rotate.py,.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest discover -s .agents/scripts/oauth-pool-lib/tests

Resolves #25140


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 87,053 tokens on this as a headless worker.