### PR TITLE
GH#25141: perf: optimize daily usage bucket lookup

### DIFF
--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -571,9 +571,10 @@ def _daily_usage(reports: list[SessionReport]) -> list[DailyUsage]:
     grouped: dict[str, dict[str, Any]] = {}
     for report in reports:
         date = (report.finished_at or report.started_at or "unknown")[:10]
-        if date not in grouped:
-            grouped[date] = _new_daily_usage_bucket()
-        _add_daily_usage_report(grouped[date], report)
+        bucket = grouped.get(date)
+        if bucket is None:
+            grouped[date] = bucket = _new_daily_usage_bucket()
+        _add_daily_usage_report(bucket, report)
     return [
         _daily_usage_from_bucket(date, data)
         for date, data in sorted(grouped.items(), reverse=True)


### PR DESCRIPTION
## Summary

Updated .agents/scripts/report-token-use-helper.py daily usage grouping to reuse a bucket local from dict.get(), avoiding a second grouped lookup in the hot loop.

## Files Changed

.agents/scripts/report-token-use-helper.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report-token-use-helper.py; bash .agents/scripts/tests/test-report-token-use-helper.sh

Resolves #25141


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 58,787 tokens on this as a headless worker.