### PR TITLE
GH#25136: Schedule OpenCode archive outside pulse

### DIFF
--- a/.agents/scripts/opencode-db-archive-async-helper.sh
+++ b/.agents/scripts/opencode-db-archive-async-helper.sh
@@ -3,32 +3,28 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # opencode-db-archive-async-helper.sh — Async background OpenCode DB archive runner (GH#21105).
 #
-# Designed to be invoked via nohup from _preflight_cleanup_and_ledger in
-# pulse-dispatch-engine.sh so the up-to-30s archive budget never blocks the
-# pulse's main dispatch cycle.
+# Designed to be invoked by the dedicated opencode-db-archive scheduler
+# installed by setup_opencode_db_archive, so archive/VACUUM work stays outside
+# the pulse dispatch preflight path.
 #
 # Background (GH#21105):
 #   The synchronous call `opencode-db-archive.sh archive --max-duration-seconds 30`
 #   was consuming its full 30s time budget every preflight cycle, contributing
-#   ~30s to the parent stage's 60-133s total. Archiving is catch-up work — it
-#   does not need to complete within a single pulse cycle. Mirroring the
-#   cleanup-worktrees-async-helper.sh pattern (GH#20554) moves the workload
-#   off the critical path while preserving correctness.
+#   ~30s to the parent stage's 60-133s total. GH#25136 moved the async trigger
+#   out of pulse preflight entirely. Archiving is catch-up work, not dispatch
+#   work; this helper preserves the single-runner lock for the dedicated
+#   scheduler while leaving cadence control to systemd/launchd/cron.
 #
 # Lifecycle:
 #   1. Acquire a mkdir-based single-runner lock (~/.aidevops/logs/opencode-db-archive.lock).
-#   2. Check cadence gate: skip if last successful run < N minutes ago.
-#   3. Invoke opencode-db-archive.sh archive with the configured budget.
-#   4. Update ~/.aidevops/logs/opencode-db-archive.last-run on success.
-#   5. Release lock on EXIT/INT/TERM (trap).
+#   2. Invoke opencode-db-archive.sh archive with the configured budget.
+#   3. Update ~/.aidevops/logs/opencode-db-archive.last-run on success.
+#   4. Release lock on EXIT/INT/TERM (trap).
 #
-# Usage (from pulse-dispatch-engine.sh):
-#   nohup "${SCRIPT_DIR}/opencode-db-archive-async-helper.sh" \
-#     >>"${HOME}/.aidevops/logs/opencode-db-archive.log" 2>&1 &
-#   disown $! 2>/dev/null || true
+# Usage (normally installed by setup.sh):
+#   opencode-db-archive-async-helper.sh
 #
 # Environment:
-#   OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN — min minutes between runs (default 10)
 #   OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC  — seconds per run (default 60; was 30 inline)
 #
 # Observability (for pulse-diagnose-helper.sh):
@@ -50,12 +46,6 @@ readonly LOCK_DIR="${LOG_DIR}/opencode-db-archive.lock"
 readonly PID_FILE="${LOCK_DIR}/pid"
 readonly LAST_RUN_FILE="${LOG_DIR}/opencode-db-archive.last-run"
 readonly ARCHIVE_HELPER="${SCRIPT_DIR}/opencode-db-archive.sh"
-
-# Minimum minutes between successful runs. The async wrapper can be invoked
-# every pulse cycle (~3 min) but only actually runs every CADENCE minutes.
-OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN="${OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN:-10}"
-OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN="${OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN//[!0-9]/}"
-[[ -n "$OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN" ]] || OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN=10
 
 # Per-run time budget. Larger than the inline 30s default — async runs are not
 # on the critical path, so we let each invocation make more progress.
@@ -124,35 +114,6 @@ _lock_acquire() {
 	return 1
 }
 
-# ============================================================
-# CADENCE GATE
-# ============================================================
-
-# Returns 0 (proceed) if enough time has elapsed since the last successful run.
-# Returns 1 (skip) if we are within the cadence window.
-_cadence_ok() {
-	if [[ ! -f "$LAST_RUN_FILE" ]]; then
-		return 0
-	fi
-
-	local last_run now elapsed cadence_secs
-	last_run=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo "0")
-	if ! [[ "$last_run" =~ ^[0-9]+$ ]]; then
-		return 0
-	fi
-
-	now=$(date +%s)
-	elapsed=$((now - last_run))
-	cadence_secs=$((OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN * 60))
-
-	if [[ "$elapsed" -lt "$cadence_secs" ]]; then
-		echo "[opencode-db-archive-async] Cadence gate: last run ${elapsed}s ago (threshold ${cadence_secs}s). Skipping." >>"$LOGFILE"
-		return 1
-	fi
-
-	return 0
-}
-
 _update_last_run() {
 	date +%s >"$LAST_RUN_FILE" 2>/dev/null || true
 	return 0
@@ -175,11 +136,7 @@ main() {
 		return 0
 	fi
 
-	if ! _cadence_ok; then
-		return 0
-	fi
-
-	echo "[opencode-db-archive-async] Starting archive (budget=${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC}s, cadence=${OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN}m)" >>"$LOGFILE"
+	echo "[opencode-db-archive-async] Starting archive (budget=${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC}s)" >>"$LOGFILE"
 
 	local rc=0
 	"$ARCHIVE_HELPER" archive --max-duration-seconds "$OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC" >>"$LOGFILE" 2>&1 || rc=$?

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -93,28 +93,10 @@ _preflight_cleanup_and_ledger() {
 		disown $! 2>/dev/null || true
 	fi
 
-	# GH#17549: Archive old OpenCode sessions to keep the active DB small.
-	# Concurrent workers hit SQLITE_BUSY on a bloated DB (busy_timeout=0).
-	# GH#21105: Moved to an async background job so the per-cycle 30s budget
-	# stops contributing to preflight_cleanup_and_ledger wall time. The async
-	# helper enforces a single-runner lock and a cadence gate
-	# (OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN, default 10 min) so concurrent
-	# pulse invocations do not spawn duplicate archive processes. With archiving
-	# off the critical path, each invocation can use a larger budget
-	# (OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC, default 60s) and still not block
-	# dispatch. Progress and last-run timestamp: ~/.aidevops/logs/opencode-db-archive.*
-	local _archive_async_helper="${SCRIPT_DIR}/opencode-db-archive-async-helper.sh"
-	if [[ -x "$_archive_async_helper" ]]; then
-		nohup "$_archive_async_helper" \
-			>>"${HOME}/.aidevops/logs/opencode-db-archive.log" 2>&1 &
-		disown $! 2>/dev/null || true
-	else
-		# Fallback: synchronous with short timeout (pre-GH#21105 behaviour)
-		local _archive_helper="${SCRIPT_DIR}/opencode-db-archive.sh"
-		if [[ -x "$_archive_helper" ]]; then
-			"$_archive_helper" archive --max-duration-seconds 30 >>"$LOGFILE" 2>&1 || true
-		fi
-	fi
+	# GH#25136: OpenCode DB archive/VACUUM is heavy SQLite maintenance, not
+	# dispatch preflight work. setup_opencode_db_archive installs a dedicated
+	# low-priority scheduler for opencode-db-archive-async-helper.sh so archive
+	# and VACUUM cadence no longer tracks every pulse cycle.
 
 	# t1751: Reap zombie workers whose PRs have been merged by the deterministic merge pass.
 	# Runs before worker counting so count_active_workers sees accurate slot availability.

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -15,6 +15,7 @@
 #   - Draft responses (t1555): private repo + local draft storage
 #   - Profile README: auto-create and scheduled update
 #   - OAuth token refresh: launchd/systemd/cron/schtasks
+#   - OpenCode DB archive (GH#25136): daily archive/VACUUM scheduler
 #   - OpenCode DB maintenance (r913, t2183): weekly checkpoint/vacuum
 #   - Repo sync: daily fast-forward pull
 #   - Repo aidevops health (r914): daily drift keeper
@@ -901,6 +902,105 @@ setup_opencode_db_maintenance() {
 			"false" \
 			"true" \
 			"Sun *-*-* ${ocdbm_hour}:${ocdbm_minute}:00"
+	fi
+	return 0
+}
+
+# Setup opencode DB archive scheduler (GH#25136).
+# Runs independently from pulse preflight so archive/VACUUM work does not track
+# dispatch-loop cadence. The async helper keeps its single-runner lock and
+# last-run observability while this scheduler supplies the daily cadence.
+setup_opencode_db_archive() {
+	local archive_script="$HOME/.aidevops/agents/scripts/opencode-db-archive-async-helper.sh"
+	if ! [[ -x "$archive_script" ]]; then
+		return 0
+	fi
+
+	local archive_log_dir="$HOME/.aidevops/logs"
+	local archive_hour="${OPENCODE_DB_ARCHIVE_HOUR:-5}"
+	local archive_minute="${OPENCODE_DB_ARCHIVE_MINUTE:-0}"
+	local archive_budget_sec="${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC:-60}"
+	local archive_env="OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC=${archive_budget_sec}"
+	mkdir -p "$archive_log_dir"
+
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		local archive_label="sh.aidevops.opencode-db-archive"
+		local archive_plist="$HOME/Library/LaunchAgents/${archive_label}.plist"
+		local _xml_archive_script _xml_archive_home _xml_archive_log _xml_archive_path
+		_xml_archive_script=$(_xml_escape "$archive_script")
+		_xml_archive_home=$(_xml_escape "$HOME")
+		_xml_archive_log=$(_xml_escape "${archive_log_dir}/opencode-db-archive.log")
+		_xml_archive_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")")
+
+		local archive_plist_content
+		archive_plist_content=$(cat <<ARCHIVE_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${archive_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$(_xml_escape "$(_resolve_modern_bash)")</string>
+		<string>${_xml_archive_script}</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>${archive_hour}</integer>
+		<key>Minute</key>
+		<integer>${archive_minute}</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>${_xml_archive_log}</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_archive_log}</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>${_xml_archive_home}</string>
+		<key>PATH</key>
+		<string>${_xml_archive_path}</string>
+		<key>OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC</key>
+		<string>${archive_budget_sec}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+ARCHIVE_PLIST
+		)
+		if _launchd_install_if_changed "$archive_label" "$archive_plist" "$archive_plist_content"; then
+			print_info "OpenCode DB archive enabled (launchd, daily ${archive_hour}:${archive_minute})"
+		else
+			print_warning "Failed to install opencode DB archive LaunchAgent"
+		fi
+	elif _is_windows; then
+		return 0
+	else
+		_install_scheduler_linux \
+			"aidevops-opencode-db-archive" \
+			"aidevops: opencode-db-archive" \
+			"${archive_minute} ${archive_hour} * * *" \
+			"\"${archive_script}\"" \
+			"86400" \
+			"${archive_log_dir}/opencode-db-archive.log" \
+			"${archive_env}" \
+			"OpenCode DB archive enabled (daily ${archive_hour}:${archive_minute})" \
+			"Failed to install opencode DB archive scheduler" \
+			"false" \
+			"true" \
+			"*-*-* ${archive_hour}:${archive_minute}:00" \
+			"3600"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -192,6 +192,93 @@ HELPER
 	return 0
 }
 
+test_opencode_archive_scheduler_is_daily_and_low_priority() {
+	local fake_home="$TEST_DIR/archive-home"
+	mkdir -p "$fake_home/.aidevops/agents/scripts"
+	local archive_script="$fake_home/.aidevops/agents/scripts/opencode-db-archive-async-helper.sh"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$archive_script"
+	chmod +x "$archive_script"
+
+	local captured_service=""
+	local captured_cron=""
+	local captured_command=""
+	local captured_interval=""
+	local captured_log=""
+	local captured_env=""
+	local captured_run_at_load=""
+	local captured_low_priority=""
+	local captured_calendar=""
+	_install_scheduler_linux() {
+		local service_name="$1"
+		local cron_tag="$2"
+		local cron_schedule="$3"
+		local exec_command="$4"
+		local interval_sec="$5"
+		local log_file="$6"
+		local env_vars="$7"
+		local success_message="$8"
+		local failure_message="$9"
+		local run_at_load="${10}"
+		local low_priority="${11}"
+		local on_calendar="${12:-}"
+		: "$cron_tag" "$success_message" "$failure_message"
+		captured_service="$service_name"
+		captured_cron="$cron_schedule"
+		captured_command="$exec_command"
+		captured_interval="$interval_sec"
+		captured_log="$log_file"
+		captured_env="$env_vars"
+		captured_run_at_load="$run_at_load"
+		captured_low_priority="$low_priority"
+		captured_calendar="$on_calendar"
+		return 0
+	}
+	uname() { printf 'Linux\n'; return 0; }
+
+	local orig_home="$HOME"
+	HOME="$fake_home"
+	setup_opencode_db_archive
+	HOME="$orig_home"
+	unset -f uname _install_scheduler_linux
+
+	if [[ "$captured_service" != "aidevops-opencode-db-archive" ]]; then
+		print_result "opencode archive scheduler uses dedicated service" 1 "$captured_service"
+		return 0
+	fi
+	if [[ "$captured_cron" != "0 5 * * *" || "$captured_interval" != "86400" || "$captured_calendar" != "*-*-* 5:0:00" ]]; then
+		print_result "opencode archive scheduler runs daily" 1 "cron=${captured_cron} interval=${captured_interval} calendar=${captured_calendar}"
+		return 0
+	fi
+	if [[ "$captured_command" != "\"${archive_script}\"" || "$captured_log" != "$fake_home/.aidevops/logs/opencode-db-archive.log" ]]; then
+		print_result "opencode archive scheduler invokes async helper" 1 "command=${captured_command} log=${captured_log}"
+		return 0
+	fi
+	if [[ "$captured_env" == *"OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN"* || "$captured_env" != "OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC=60" ]]; then
+		print_result "opencode archive scheduler leaves cadence to scheduler" 1 "$captured_env"
+		return 0
+	fi
+	if [[ "$captured_run_at_load" != "false" || "$captured_low_priority" != "true" ]]; then
+		print_result "opencode archive scheduler is low priority and not run-at-load" 1 "run_at_load=${captured_run_at_load} low_priority=${captured_low_priority}"
+		return 0
+	fi
+
+	print_result "opencode archive scheduler is daily and low priority" 0
+	return 0
+}
+
+test_pulse_preflight_does_not_launch_opencode_archive() {
+	local preflight_lib="$REPO_ROOT/.agents/scripts/pulse-dispatch-preflight-lib.sh"
+	local body
+	body=$(<"$preflight_lib")
+	# shellcheck disable=SC2016 # Match the literal pre-GH#25136 launch snippet.
+	if [[ "$body" == *'nohup "$_archive_async_helper"'* || "$body" == *'archive --max-duration-seconds 30'* ]]; then
+		print_result "pulse preflight does not launch opencode archive" 1 "archive launch still present"
+		return 0
+	fi
+	print_result "pulse preflight does not launch opencode archive" 0
+	return 0
+}
+
 main() {
 	setup
 	load_scheduler_helpers
@@ -199,6 +286,8 @@ main() {
 	test_core_routine_shell_quote_escapes_single_quotes
 	test_linux_core_scheduler_commands_are_logged
 	test_pulse_routine_update_uses_flags_and_duration
+	test_opencode_archive_scheduler_is_daily_and_low_priority
+	test_pulse_preflight_does_not_launch_opencode_archive
 	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/setup.sh
+++ b/setup.sh
@@ -1423,6 +1423,9 @@ _setup_noninteractive_schedulers() {
 	# opencode DB maintenance (r913, t2183). Helper self-noops on missing
 	# DB — safe to install unconditionally in non-interactive mode too.
 	_time_step "setup_opencode_db_maintenance" setup_opencode_db_maintenance
+	# opencode DB archive/VACUUM (GH#25136). Dedicated low-priority scheduler;
+	# not tied to pulse preflight cadence.
+	_time_step "setup_opencode_db_archive" setup_opencode_db_archive
 	# Migrate cron entries to systemd after schedulers are installed (GH#17695 Finding D)
 	_time_step "migrate_cron_to_systemd" migrate_cron_to_systemd
 	_time_step "$SETUP_STAGE_TABBY" setup_tabby
@@ -1477,6 +1480,7 @@ _setup_post_setup_steps() {
 	setup_profile_readme
 	setup_oauth_token_refresh
 	setup_opencode_db_maintenance
+	setup_opencode_db_archive
 	# Migrate cron entries to systemd after schedulers are installed (GH#17695 Finding D)
 	migrate_cron_to_systemd
 	setup_tabby


### PR DESCRIPTION
## Summary

- Move OpenCode DB archive/VACUUM triggering out of pulse dispatch preflight.
- Add a dedicated low-priority daily OpenCode DB archive scheduler via setup.
- Remove the archive async helper's internal cadence gate so cadence is controlled by systemd/launchd/cron, while retaining the single-runner lock and last-run observability.

Resolves #25136

## Verification

- `.agents/scripts/tests/test-routine-tracking-updates.sh` → 6/6 passed
- `bash .agents/scripts/tests/test-opencode-db-archive.sh` → 13 passed, 0 failed
- `shellcheck .agents/scripts/pulse-dispatch-preflight-lib.sh .agents/scripts/opencode-db-archive-async-helper.sh .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/tests/test-routine-tracking-updates.sh setup.sh`
- `git diff --check`

## Notes

- `VACUUM` remains available in the archive flow; this only changes when it is triggered.
- The archive helper no longer supports `OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN`; the scheduler is now the single cadence control plane.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
