### PR TITLE
GH#25149: perf: use defaultdict for daily usage

### DIFF
--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -12,6 +12,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -568,13 +569,10 @@ def _collect_reports(args: argparse.Namespace) -> list[SessionReport]:
 
 
 def _daily_usage(reports: list[SessionReport]) -> list[DailyUsage]:
-    grouped: dict[str, dict[str, Any]] = {}
+    grouped: defaultdict[str, dict[str, Any]] = defaultdict(_new_daily_usage_bucket)
     for report in reports:
         date = (report.finished_at or report.started_at or "unknown")[:10]
-        bucket = grouped.get(date)
-        if bucket is None:
-            grouped[date] = bucket = _new_daily_usage_bucket()
-        _add_daily_usage_report(bucket, report)
+        _add_daily_usage_report(grouped[date], report)
     return [
         _daily_usage_from_bucket(date, data)
         for date, data in sorted(grouped.items(), reverse=True)


### PR DESCRIPTION
## Summary

Replaced manual daily usage bucket lookup with collections.defaultdict in .agents/scripts/report-token-use-helper.py.

## Files Changed

.agents/scripts/report-token-use-helper.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m py_compile .agents/scripts/report-token-use-helper.py; .agents/scripts/report-token-use-helper.py --help; .agents/scripts/linters-local.sh

Resolves #25149


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 5m and 37,733 tokens on this as a headless worker.