### PR TITLE
GH#25151: fix: harden signature body git dir lookup

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
@@ -57,7 +57,7 @@ function gitCommonDir(path) {
   if (!path) return "";
   let gitDir = dirname(path);
   try {
-    if (existsSync(path) && statSync(path).isDirectory()) {
+    if (statSync(path).isDirectory()) {
       gitDir = path;
     }
   } catch {

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
@@ -55,7 +55,14 @@ function gitValue(args) {
 
 function gitCommonDir(path) {
   if (!path) return "";
-  const gitDir = existsSync(path) && statSync(path).isDirectory() ? path : dirname(path);
+  let gitDir = dirname(path);
+  try {
+    if (existsSync(path) && statSync(path).isDirectory()) {
+      gitDir = path;
+    }
+  } catch {
+    // Fall back to dirname(path) when statSync is blocked by permissions or a TOCTOU race.
+  }
   const topLevel = gitValue(["-C", gitDir, "rev-parse", "--show-toplevel"]);
   if (!topLevel) return "";
   const commonDir = gitValue(["-C", topLevel, "rev-parse", "--git-common-dir"]);


### PR DESCRIPTION
## Summary

Hardened gitCommonDir so body-file fallback git repository checks default to dirname(path), only promote an existing directory after a guarded statSync, and fail open to dirname(path) if permissions or TOCTOU races make statSync throw.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: node --check quality-hooks-signature-body-file.mjs && npm test -- --test-name-pattern signature (from .agents/plugins/opencode-aidevops; 250 passing tests). Root typecheck unavailable in worker environment: npm run typecheck failed because tsc is not installed; bun is also unavailable to install lockfile dependencies.

Resolves #25151


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 76,020 tokens on this as a headless worker.