### PR TITLE
GH#25150: test: initialize prefetch detector invalid-input env

### DIFF
--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="$SCRIPT_DIR/../pulse-batch-prefetch-helper.sh"
 
+# shellcheck source=../shared-constants.sh
+source "$SCRIPT_DIR/../shared-constants.sh"
+
 TEST_ROOT=""
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -130,9 +133,13 @@ prefetch_raw_gh_read_matches() {
 }
 
 test_prefetch_raw_gh_read_detector_rejects_missing_file() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	setup_env
+	push_cleanup "rm -rf '${TEST_ROOT}'"
 	local empty_path=""
-	local missing_path="$TEST_ROOT/missing.sh"
-	local directory_path="$TEST_ROOT"
+	local missing_path="${TEST_ROOT:-}/missing.sh"
+	local directory_path="${TEST_ROOT:-}"
 	if prefetch_raw_gh_read_matches \
 		|| prefetch_raw_gh_read_matches "$empty_path" \
 		|| prefetch_raw_gh_read_matches "$missing_path" \
@@ -141,6 +148,7 @@ test_prefetch_raw_gh_read_detector_rejects_missing_file() {
 	else
 		print_result "prefetch raw gh detector rejects invalid file input" 0
 	fi
+	teardown_env
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Initialized the invalid-input detector test with a temporary TEST_ROOT, robust cleanup scope, and safe TEST_ROOT expansion so directory and missing-path cases exercise real paths.

## Files Changed

.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh; .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

Resolves #25150


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 65,317 tokens on this as a headless worker.