### PR TITLE
GH#25129/GH#25130/GH#25131: fix runtime observability signals

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -868,6 +868,20 @@ _handle_run_result() {
 	# premature-exit or watchdog-stall continuation budgets. Require activity or
 	# session evidence so startup failures still follow normal backoff paths.
 	if [[ "$role" == "worker" && "$session_key" == issue-* ]] && \
+		runtime_signal_terminated_candidate "$output_file" "$exit_code" "$activity_detected"; then
+		if [[ -n "$discovered_session" ]]; then
+			store_session_id "$provider" "$session_key" "$discovered_session" "$selected_model"
+		fi
+		_run_result_label="signal_terminated_continue"
+		_run_failure_reason="signal_terminated_continue"
+		_run_runtime_error_type="sigterm"
+		_run_classification_source="worker_exit_diagnostics"
+		_run_classification_pattern="sigterm_or_terminated_tail"
+		rm -f "$output_file"
+		print_warning "$selected_model worker received SIGTERM after activity — will attempt session continuation"
+		return 78
+	fi
+	if [[ "$role" == "worker" && "$session_key" == issue-* ]] && \
 		service_interruption_continue_candidate \
 			"$failure_reason" "$exit_code" "$activity_detected" "$discovered_session" \
 			"${_failure_provider_error_type:-}"; then
@@ -1080,6 +1094,10 @@ _derive_worker_failure_evidence() {
 		;;
 	watchdog_stall_continue | service_interruption_continue | service_interruption_exhausted | signal_killed_continue)
 		launch_failure_cause="mid_session_interruption"
+		next_action="resume_existing_session"
+		;;
+	signal_terminated_continue)
+		launch_failure_cause="signal_terminated"
 		next_action="resume_existing_session"
 		;;
 	watchdog_stall_killed)

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -285,7 +285,7 @@ except OSError:
 if not lines:
     sys.exit(1)
 tail = "\n".join(lines[-5:]).lower()
-if lines[-1] == "Terminated" or "sigterm" in tail or "received sigterm" in tail:
+if lines[-1].lower() == "terminated" or "sigterm" in tail or "received sigterm" in tail:
     sys.exit(0)
 sys.exit(1)
 PY

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -251,13 +251,45 @@ service_interruption_continue_candidate() {
 
 	if [[ "$activity_detected" == "1" ]]; then
 		case "$exit_code" in
-		137 | 143)
+		137)
 			return 0
 			;;
 		esac
 	fi
 
 	return 1
+}
+
+runtime_signal_terminated_candidate() {
+	local output_file="$1"
+	local exit_code="$2"
+	local activity_detected="$3"
+
+	if [[ "$activity_detected" != "1" ]]; then
+		return 1
+	fi
+	if [[ "$exit_code" -eq 143 ]]; then
+		return 0
+	fi
+	if [[ ! -f "$output_file" ]]; then
+		return 1
+	fi
+	python3 - "$output_file" <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    lines = [line.strip() for line in Path(sys.argv[1]).read_text(errors="ignore").splitlines() if line.strip()]
+except OSError:
+    sys.exit(1)
+if not lines:
+    sys.exit(1)
+tail = "\n".join(lines[-5:]).lower()
+if lines[-1] == "Terminated" or "sigterm" in tail or "received sigterm" in tail:
+    sys.exit(0)
+sys.exit(1)
+PY
+	return $?
 }
 
 extract_session_id_from_output() {

--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -80,6 +80,11 @@ LOGFILE="${HOME}/.aidevops/logs/process-guard.log"
 
 mkdir -p "$(dirname "$LOGFILE")" || true
 
+_process_guard_timestamp() {
+	date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf '%s' 'unknown'
+	return 0
+}
+
 #######################################
 # List aidevops-related processes using pgrep (SC2009: avoids ps|grep)
 # Output: ps fields (pid,ppid,tty,rss,etime,command) for matching processes
@@ -398,8 +403,23 @@ cmd_kill_runaways() {
 
 		if [[ -n "$violation" ]]; then
 			local rss_mb=$((rss / 1024))
+			local process_class killed_at
+			process_class='other'
+			case "$cmd_base" in
+			shel[l]check) process_class='lint' ;;
+			node)
+				if [[ $cmd_full == *playwright* && $cmd_full == *--list* ]]; then
+					process_class='playwright-list'
+				else
+					process_class='node'
+				fi
+				;;
+			opencode | opencode-ai | claude | claude-ai) process_class='ai-runtime' ;;
+			esac
+			killed_at=$(_process_guard_timestamp)
 			echo "Killing PID $pid ($cmd_base) — $violation"
-			echo "[process-guard] Killing PID $pid ($cmd_base) — $violation" >>"$LOGFILE"
+			printf '[process-guard] %s Killing PID %s class=%s cmd=%s rss_mb=%s age_seconds=%s — %s\n' \
+				"$killed_at" "$pid" "$process_class" "$cmd_base" "$rss_mb" "$age_seconds" "$violation" >>"$LOGFILE"
 			kill "$pid" 2>/dev/null || true
 			sleep 1
 			if kill -0 "$pid" 2>/dev/null; then
@@ -412,7 +432,7 @@ cmd_kill_runaways() {
 
 	if [[ "$killed" -gt 0 ]]; then
 		echo "Killed $killed process(es), freed ~${total_freed_mb}MB"
-		echo "[process-guard] Killed $killed process(es), freed ~${total_freed_mb}MB" >>"$LOGFILE"
+		printf '[process-guard] %s Killed %s process(es), freed ~%sMB\n' "$(_process_guard_timestamp)" "$killed" "$total_freed_mb" >>"$LOGFILE"
 	else
 		echo "No runaway processes found"
 	fi

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -244,8 +244,14 @@ list_dispatchable_issue_candidates_json() {
 	issue_json=$(gh_issue_list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>"$issue_dispatch_err") || gh_exit_code=$?
 	if [[ "$gh_exit_code" -ne 0 ]] || [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
 		local _issue_dispatch_err_msg
-		_issue_dispatch_err_msg=$(cat "$issue_dispatch_err" 2>/dev/null || echo "unknown error")
-		echo "[pulse-wrapper] list_dispatchable_issue_candidates: gh_issue_list FAILED for ${repo_slug} (exit ${gh_exit_code}): ${_issue_dispatch_err_msg}" >>"$LOGFILE"
+		_issue_dispatch_err_msg=$(<"$issue_dispatch_err") || _issue_dispatch_err_msg="unknown error"
+		if [[ "$gh_exit_code" -eq 75 || "$_issue_dispatch_err_msg" == *"secondary-rate-limit active=true skip=read"* ]]; then
+			printf '[pulse-wrapper] list_dispatchable_issue_candidates: gh_issue_list cooldown skip for %s (exit %s): %s\n' \
+				"$repo_slug" "$gh_exit_code" "$_issue_dispatch_err_msg" >>"$LOGFILE"
+		else
+			printf '[pulse-wrapper] list_dispatchable_issue_candidates: gh_issue_list FAILED for %s (exit %s): %s\n' \
+				"$repo_slug" "$gh_exit_code" "$_issue_dispatch_err_msg" >>"$LOGFILE"
+		fi
 		issue_json="[]"
 	fi
 	rm -f "$issue_dispatch_err"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -917,11 +917,11 @@ test_service_interruption_candidate_uses_separate_path() {
 	fi
 
 	local terminated_tail_file="${TEST_ROOT}/terminated-tail.out"
-	printf '%s\n' '{"type":"text","sessionID":"ses_tail","text":"editing files"}' 'Terminated' >"$terminated_tail_file"
+	printf '%s\n' '{"type":"text","sessionID":"ses_tail","text":"editing files"}' 'terminated' >"$terminated_tail_file"
 	if runtime_signal_terminated_candidate "$terminated_tail_file" "1" "1"; then
-		print_result "Terminated tail classifies as signal termination" 0
+		print_result "terminated tail classifies as signal termination" 0
 	else
-		print_result "Terminated tail classifies as signal termination" 1
+		print_result "terminated tail classifies as signal termination" 1
 	fi
 
 	return 0

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -891,11 +891,11 @@ test_service_interruption_candidate_uses_separate_path() {
 	status=0
 	_handle_run_result 143 "$local_output_file" "worker" "openai" "issue-23037" "openai/gpt-5.5" || status=$?
 
-	if [[ "$status" -eq 81 && "$_run_result_label" == "service_interruption_continue" && "$_run_failure_reason" == "local_error" && -f "$local_output_file" ]]; then
-		print_result "service interruption preserves specific failure reason and diagnostics" 0
+	if [[ "$status" -eq 78 && "$_run_result_label" == "signal_terminated_continue" && "$_run_runtime_error_type" == "sigterm" && ! -f "$local_output_file" ]]; then
+		print_result "SIGTERM uses signal-specific continuation path" 0
 	else
-		print_result "service interruption preserves specific failure reason and diagnostics" 1 \
-			"status=$status label=${_run_result_label:-<empty>} reason=${_run_failure_reason:-<empty>} output_exists=$([[ -f "$local_output_file" ]] && printf yes || printf no)"
+		print_result "SIGTERM uses signal-specific continuation path" 1 \
+			"status=$status label=${_run_result_label:-<empty>} runtime=${_run_runtime_error_type:-<empty>} output_exists=$([[ -f "$local_output_file" ]] && printf yes || printf no)"
 	fi
 
 	if ! service_interruption_continue_candidate "rate_limit" "1" "1" "" "rate_limit"; then
@@ -908,6 +908,20 @@ test_service_interruption_candidate_uses_separate_path() {
 		print_result "SIGKILL with activity can resume as interruption" 0
 	else
 		print_result "SIGKILL with activity can resume as interruption" 1
+	fi
+
+	if ! service_interruption_continue_candidate "local_error" "143" "1" "" ""; then
+		print_result "SIGTERM does not consume service interruption budget" 0
+	else
+		print_result "SIGTERM does not consume service interruption budget" 1
+	fi
+
+	local terminated_tail_file="${TEST_ROOT}/terminated-tail.out"
+	printf '%s\n' '{"type":"text","sessionID":"ses_tail","text":"editing files"}' 'Terminated' >"$terminated_tail_file"
+	if runtime_signal_terminated_candidate "$terminated_tail_file" "1" "1"; then
+		print_result "Terminated tail classifies as signal termination" 0
+	else
+		print_result "Terminated tail classifies as signal termination" 1
 	fi
 
 	return 0

--- a/.agents/scripts/tests/test-process-guard-playwright-list.sh
+++ b/.agents/scripts/tests/test-process-guard-playwright-list.sh
@@ -121,6 +121,20 @@ test_rejects_substring_grep_option() {
 	return 0
 }
 
+test_kill_log_format_carries_timestamp_and_process_class() {
+	local helper_text
+	helper_text=$(<"$HELPER")
+	if [[ "$helper_text" == *"class=%s cmd=%s rss_mb=%s age_seconds=%s"* && \
+		"$helper_text" == *"_process_guard_timestamp"* && \
+		"$helper_text" == *"process_class='playwright-list'"* ]]; then
+		print_result "kill log format carries timestamp and process class" 0
+		return 0
+	fi
+
+	print_result "kill log format carries timestamp and process class" 1
+	return 0
+}
+
 main() {
 	test_matches_stale_aidevops_playwright_list
 	test_matches_stale_aidevops_playwright_list_with_flexible_spacing
@@ -128,6 +142,7 @@ main() {
 	test_rejects_interactive_playwright_list
 	test_rejects_fresh_aidevops_playwright_list
 	test_rejects_substring_grep_option
+	test_kill_log_format_carries_timestamp_and_process_class
 
 	printf '\n%s/%s tests passed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -15,6 +15,8 @@ TESTS_RUN=0
 TESTS_FAILED=0
 PS_MOCK_OUTPUT=""
 GH_ISSUE_LIST_JSON="[]"
+GH_ISSUE_LIST_EXIT=0
+GH_ISSUE_LIST_ERR=""
 GH_PR_LIST_JSON="[]"
 GH_PR_CHECK_STATUS_JSON="[]"
 TEST_ROOT=""
@@ -53,6 +55,10 @@ setup_test_env() {
 	# this level bypasses _gh_with_timeout entirely and is the canonical test
 	# pattern (see test-large-file-gate-dedup.sh:94-131).
 	gh_issue_list() {
+		if [[ "$GH_ISSUE_LIST_EXIT" -ne 0 ]]; then
+			printf '%s\n' "$GH_ISSUE_LIST_ERR" >&2
+			return "$GH_ISSUE_LIST_EXIT"
+		fi
 		printf '%s\n' "$GH_ISSUE_LIST_JSON"
 		return 0
 	}
@@ -262,6 +268,8 @@ test_counts_review_issue_pr_workers() {
 }
 
 test_list_dispatchable_candidates_default_open_except_needs_labels() {
+	GH_ISSUE_LIST_EXIT=0
+	GH_ISSUE_LIST_ERR=""
 	local repos_json_path="${HOME}/.config/aidevops/repos.json"
 	mkdir -p "$(dirname "$repos_json_path")"
 	printf '{"initialized_repos":[{"slug":"owner/repo","path":"/tmp/repo","pulse":true,"maintainer":"maintainer-bot"}]}\n' >"$repos_json_path"
@@ -293,6 +301,28 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	fi
 
 	print_result "list_dispatchable_issue_candidates is default-open except needs-* and active-status labels" 1 "Unexpected candidate set: ${output}"
+	return 0
+}
+
+test_list_dispatchable_candidates_logs_cooldown_skip_not_failure() {
+	GH_ISSUE_LIST_JSON='[]'
+	GH_ISSUE_LIST_EXIT=75
+	GH_ISSUE_LIST_ERR='[gh-cooldown] secondary-rate-limit active=true skip=read expires_at=2026-06-19T00:00:00Z'
+	: >"$LOGFILE"
+
+	local output log_text
+	output=$(list_dispatchable_issue_candidates "owner/repo" 100)
+	log_text=$(<"$LOGFILE")
+	GH_ISSUE_LIST_EXIT=0
+	GH_ISSUE_LIST_ERR=""
+
+	if [[ -z "$output" && "$log_text" == *"cooldown skip"* && "$log_text" != *"FAILED"* ]]; then
+		print_result "list_dispatchable_issue_candidates treats secondary cooldown as expected skip" 0
+		return 0
+	fi
+
+	print_result "list_dispatchable_issue_candidates treats secondary cooldown as expected skip" 1 \
+		"output=${output:-<empty>} log=${log_text:-<empty>}"
 	return 0
 }
 
@@ -758,6 +788,7 @@ main() {
 	test_has_worker_exact_dir_match_accepts_correct_path
 	test_counts_review_issue_pr_workers
 	test_list_dispatchable_candidates_default_open_except_needs_labels
+	test_list_dispatchable_candidates_logs_cooldown_skip_not_failure
 	test_count_runnable_candidates_counts_default_open_backlog
 	test_count_runnable_candidates_keeps_stdout_numeric_with_debug
 	test_count_queued_without_worker_keeps_stdout_numeric_with_debug


### PR DESCRIPTION
## Summary
- Treat secondary GitHub cooldown candidate reads as expected skips instead of terminal failures.
- Route SIGTERM/final `Terminated` worker exits through a signal-specific continuation path.
- Add timestamped, sanitized process-class attribution to process guard kill logs.

## Verification
- `.agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-process-guard-playwright-list.sh`
- `shellcheck .agents/scripts/pulse-repo-meta.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/process-guard-helper.sh .agents/scripts/tests/test-pulse-wrapper-worker-count.sh .agents/scripts/tests/test-headless-runtime-helper.sh .agents/scripts/tests/test-process-guard-playwright-list.sh`

Resolves #25129
Resolves #25130
Resolves #25131

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 with gpt-5.5 spent 3d and 2,431,141 tokens on this with the user in an interactive session.