### PR TITLE
GH#25159: test: make contributor session archive setup hermetic

### DIFF
--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -39,6 +39,7 @@ setup() {
 	TEST_DIR=$(mktemp -d)
 	mkdir -p "${TEST_DIR}/home/.local/share/opencode"
 	mkdir -p "${TEST_DIR}/home/.aidevops/.agent-workspace/work/opencode-interactive/project-test/opencode"
+	unset AIDEVOPS_WORK_DIR
 	mkdir -p "${TEST_DIR}/home/.aidevops/.agent-workspace/observability"
 	return 0
 }


### PR DESCRIPTION
## Summary

Made contributor session archive test setup explicitly unset AIDEVOPS_WORK_DIR so wrapper DB fixtures cannot be bypassed by an inherited environment override. Confirmed the production wrapper DB glob guard is already present.

## Files Changed

.agents/scripts/tests/test-contributor-session-archive.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/contributor-activity-helper-session.sh .agents/scripts/tests/test-contributor-session-archive.sh; .agents/scripts/tests/test-contributor-session-archive.sh

Resolves #25159


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 50,894 tokens on this as a headless worker.