### PR TITLE
fix: harden opencode archive scheduler environment

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -911,12 +911,18 @@ setup_opencode_db_maintenance() {
 # dispatch-loop cadence. The async helper keeps its single-runner lock and
 # last-run observability while this scheduler supplies the daily cadence.
 setup_opencode_db_archive() {
-	local archive_script="$HOME/.aidevops/agents/scripts/opencode-db-archive-async-helper.sh"
+	local archive_home="${HOME:-}"
+	if [[ -z "$archive_home" ]]; then
+		print_warning "Skipping opencode DB archive scheduler: HOME is unset"
+		return 0
+	fi
+
+	local archive_script="$archive_home/.aidevops/agents/scripts/opencode-db-archive-async-helper.sh"
 	if ! [[ -x "$archive_script" ]]; then
 		return 0
 	fi
 
-	local archive_log_dir="$HOME/.aidevops/logs"
+	local archive_log_dir="$archive_home/.aidevops/logs"
 	local archive_hour="${OPENCODE_DB_ARCHIVE_HOUR:-5}"
 	local archive_minute="${OPENCODE_DB_ARCHIVE_MINUTE:-0}"
 	local archive_budget_sec="${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC:-60}"
@@ -925,12 +931,12 @@ setup_opencode_db_archive() {
 
 	if [[ "$(uname -s)" == "Darwin" ]]; then
 		local archive_label="sh.aidevops.opencode-db-archive"
-		local archive_plist="$HOME/Library/LaunchAgents/${archive_label}.plist"
+		local archive_plist="$archive_home/Library/LaunchAgents/${archive_label}.plist"
 		local _xml_archive_script _xml_archive_home _xml_archive_log _xml_archive_path
 		_xml_archive_script=$(_xml_escape "$archive_script")
-		_xml_archive_home=$(_xml_escape "$HOME")
+		_xml_archive_home=$(_xml_escape "$archive_home")
 		_xml_archive_log=$(_xml_escape "${archive_log_dir}/opencode-db-archive.log")
-		_xml_archive_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")")
+		_xml_archive_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin${PATH:+:${PATH}}")")
 
 		local archive_plist_content
 		archive_plist_content=$(cat <<ARCHIVE_PLIST

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -266,6 +266,73 @@ test_opencode_archive_scheduler_is_daily_and_low_priority() {
 	return 0
 }
 
+test_opencode_archive_scheduler_tolerates_unset_home() {
+	local captured_warning=""
+	print_warning() { captured_warning="$1"; return 0; }
+
+	local had_home="false"
+	local orig_home=""
+	if [[ -n "${HOME+x}" ]]; then
+		had_home="true"
+		orig_home="$HOME"
+	fi
+	unset HOME
+	setup_opencode_db_archive
+	if [[ "$had_home" == "true" ]]; then
+		HOME="$orig_home"
+	else
+		unset HOME
+	fi
+	print_warning() { return 0; }
+
+	if [[ "$captured_warning" != "Skipping opencode DB archive scheduler: HOME is unset" ]]; then
+		print_result "opencode archive scheduler tolerates unset HOME" 1 "$captured_warning"
+		return 0
+	fi
+	print_result "opencode archive scheduler tolerates unset HOME" 0
+	return 0
+}
+
+test_opencode_archive_launchd_uses_safe_path_expansion() {
+	local fake_home="$TEST_DIR/archive-launchd-home"
+	mkdir -p "$fake_home/.aidevops/agents/scripts"
+	local archive_script="$fake_home/.aidevops/agents/scripts/opencode-db-archive-async-helper.sh"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$archive_script"
+	chmod +x "$archive_script"
+
+	local captured_plist=""
+	_launchd_install_if_changed() {
+		local label="$1"
+		local plist="$2"
+		local content="$3"
+		: "$label" "$plist"
+		captured_plist="$content"
+		return 0
+	}
+	aidevops_launchd_sanitized_path() { local value="${1:-}"; printf '%s\n' "$value"; return 0; }
+	mkdir() { /bin/mkdir "$@"; return $?; }
+	uname() { printf 'Darwin\n'; return 0; }
+
+	local orig_home="${HOME:-}"
+	local orig_path="${PATH:-}"
+	HOME="$fake_home"
+	PATH="/bin:/usr/bin"
+	setup_opencode_db_archive
+	HOME="$orig_home"
+	PATH="$orig_path"
+	unset -f uname mkdir aidevops_launchd_sanitized_path _launchd_install_if_changed
+
+	local body
+	body=$(<"$SCHEDULERS_PLATFORM_SH")
+	# shellcheck disable=SC2016 # Match the literal safe expansion used in generated launchd PATH construction.
+	if [[ "$captured_plist" != *"/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:/bin:/usr/bin"* ]] || [[ "$body" != *'${PATH:+:${PATH}}'* ]]; then
+		print_result "opencode archive launchd uses safe PATH expansion" 1 "$captured_plist"
+		return 0
+	fi
+	print_result "opencode archive launchd uses safe PATH expansion" 0
+	return 0
+}
+
 test_pulse_preflight_does_not_launch_opencode_archive() {
 	local preflight_lib="$REPO_ROOT/.agents/scripts/pulse-dispatch-preflight-lib.sh"
 	local body
@@ -287,6 +354,8 @@ main() {
 	test_linux_core_scheduler_commands_are_logged
 	test_pulse_routine_update_uses_flags_and_duration
 	test_opencode_archive_scheduler_is_daily_and_low_priority
+	test_opencode_archive_scheduler_tolerates_unset_home
+	test_opencode_archive_launchd_uses_safe_path_expansion
 	test_pulse_preflight_does_not_launch_opencode_archive
 	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -309,7 +309,7 @@ test_opencode_archive_launchd_uses_safe_path_expansion() {
 		captured_plist="$content"
 		return 0
 	}
-	aidevops_launchd_sanitized_path() { local value="${1:-}"; printf '%s\n' "$value"; return 0; }
+	aidevops_launchd_sanitized_path() { local value="${1:-}"; printf '%s\n' "$value"; return $?; }
 	mkdir() { /bin/mkdir "$@"; return $?; }
 	uname() { printf 'Darwin\n'; return 0; }
 
@@ -320,7 +320,9 @@ test_opencode_archive_launchd_uses_safe_path_expansion() {
 	setup_opencode_db_archive
 	HOME="$orig_home"
 	PATH="$orig_path"
-	unset -f uname mkdir aidevops_launchd_sanitized_path _launchd_install_if_changed
+	unset -f uname mkdir
+	_launchd_install_if_changed() { return 0; }
+	aidevops_launchd_sanitized_path() { printf '%s\n' "/usr/bin:/bin"; return $?; }
 
 	local body
 	body=$(<"$SCHEDULERS_PLATFORM_SH")


### PR DESCRIPTION
## Summary
- Hardened the OpenCode DB archive scheduler against nounset failures when HOME is unset.
- Built the launchd PATH with safe `${PATH:+...}` expansion.
- Added regression coverage for unset HOME and safe PATH construction.

Resolves #25157

## Testing
- `bash .agents/scripts/tests/test-routine-tracking-updates.sh`
- `shellcheck .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/tests/test-routine-tracking-updates.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 4m and 71,641 tokens on this as a headless worker.