### PR TITLE
GH#25160: fix: reuse nmr issue metadata

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -481,6 +481,7 @@ _nmr_application_is_circuit_breaker_trip() {
 # Args:
 #   $1 - issue_num  : GitHub issue number
 #   $2 - slug       : repo slug (owner/repo)
+#   $3 - issue_meta : optional precomputed issue metadata JSON
 #
 # Exit codes:
 #   0 - security-sensitive label present (NMR must be preserved)
@@ -489,13 +490,16 @@ _nmr_application_is_circuit_breaker_trip() {
 _nmr_application_is_security_sensitive() {
 	local issue_num="$1"
 	local slug="$2"
+	local precomputed_meta="${3:-}"
 
 	[[ -n "$issue_num" && -n "$slug" ]] || return 1
 
-	local issue_meta_json
-	local issue_api_path
-	printf -v issue_api_path 'repos/%s/issues/%s' "$slug" "$issue_num"
-	issue_meta_json=$(gh api "$issue_api_path" 2>/dev/null) || issue_meta_json=""
+	local issue_meta_json="$precomputed_meta"
+	if [[ -z "$issue_meta_json" ]]; then
+		local issue_api_path
+		printf -v issue_api_path 'repos/%s/issues/%s' "$slug" "$issue_num"
+		issue_meta_json=$(gh api "$issue_api_path" 2>/dev/null) || issue_meta_json=""
+	fi
 	[[ -n "$issue_meta_json" ]] || return 1
 
 	local has_security_label

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -516,6 +516,18 @@ test_security_sensitive_detects_security_review_label() {
 	return 0
 }
 
+test_security_sensitive_uses_precomputed_issue_meta() {
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"quality-debt"}]}'
+	if _nmr_application_is_security_sensitive 24842 marcusquinn/aidevops \
+		'{"labels":[{"name":"needs-maintainer-review"},{"name":"security"}]}'; then
+		print_result "security_sensitive uses precomputed issue metadata" 0
+		return 0
+	fi
+	print_result "security_sensitive uses precomputed issue metadata" 1 \
+		"Expected exit 0 — supplied issue metadata should avoid fixture/API fallback"
+	return 0
+}
+
 test_security_sensitive_ignores_non_security_labels() {
 	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"source:review-feedback"},{"name":"quality-debt"}]}'
 	if _nmr_application_is_security_sensitive 24843 marcusquinn/aidevops; then
@@ -746,6 +758,7 @@ main() {
 	# _nmr_application_is_security_sensitive (security review boundary)
 	test_security_sensitive_detects_security_label
 	test_security_sensitive_detects_security_review_label
+	test_security_sensitive_uses_precomputed_issue_meta
 	test_security_sensitive_ignores_non_security_labels
 
 	# _nmr_applied_by_maintainer end-to-end (#19756 loop regression)


### PR DESCRIPTION
## Summary

Refactored _nmr_application_is_security_sensitive to accept optional precomputed issue metadata and fall back to gh api only when metadata is absent. Added regression coverage proving supplied metadata is used instead of the fixture/API fallback.

## Files Changed

.agents/scripts/pulse-nmr-approval.sh,.agents/scripts/tests/test-pulse-nmr-automation-signature.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh && .agents/scripts/tests/test-pulse-nmr-automation-signature.sh

Resolves #25160


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 50,124 tokens on this as a headless worker.