### PR TITLE
fix: harden repo health version-bump recovery

### DIFF
--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -447,6 +447,7 @@ _open_version_bump_pr() {
 
 	if ! command -v gh_create_pr >/dev/null 2>&1; then
 		log_warn "bump failed ($slug): gh_create_pr unavailable"
+		git -C "$repo_path" checkout -q "$default_branch" >/dev/null 2>&1 || true
 		return 1
 	fi
 
@@ -460,6 +461,7 @@ _open_version_bump_pr() {
 		--head "$branch_name" \
 		--base "$default_branch" 2>&1); then
 		log_warn "bump failed ($slug): gh_create_pr failed: $pr_url"
+		git -C "$repo_path" checkout -q "$default_branch" >/dev/null 2>&1 || true
 		return 1
 	fi
 	log_info "bumped: $slug → v${target_version} via PR $pr_url"
@@ -485,7 +487,7 @@ _push_version_bump_pr() {
 	local entry_version="$5"
 	local target_version="$6"
 
-	if ! git -C "$repo_path" push -u origin "$branch_name" >/dev/null 2>&1; then
+	if ! git -C "$repo_path" push -q -f -u origin "$branch_name"; then
 		log_warn "bump failed ($slug): branch push failed"
 		git -C "$repo_path" checkout -q "$default_branch" >/dev/null 2>&1 || true
 		return 1
@@ -547,7 +549,7 @@ _bump_single_repo() {
 			local ahead_count ahead_files branch_name
 			ahead_count=$(git -C "$repo_path" rev-list --count "origin/${default_branch}..HEAD" 2>/dev/null || echo 0)
 			ahead_files=$(git -C "$repo_path" diff --name-only "origin/${default_branch}..HEAD" 2>/dev/null || true)
-			if [[ "$ahead_count" != "0" && "$ahead_files" == *".aidevops.json"* ]]; then
+			if [[ "$ahead_count" != "0" && "$ahead_files" == ".aidevops.json" ]]; then
 				branch_name=$(_version_bump_branch_name "$slug" "$target_version")
 				if git -C "$repo_path" checkout -q -B "$branch_name" HEAD >/dev/null 2>&1 &&
 					_push_version_bump_pr "$slug" "$repo_path" "$branch_name" "$default_branch" "$entry_version" "$target_version"; then

--- a/.agents/scripts/tests/test-repo-aidevops-health.sh
+++ b/.agents/scripts/tests/test-repo-aidevops-health.sh
@@ -212,6 +212,69 @@ assert_contains "non-local bump creates PR against repo" "$PR_ARGS" "--repo test
 assert_contains "non-local bump creates PR from version branch" "$PR_ARGS" "--head chore/aidevops-version-v9.9.9-test-pr-bump-repo"
 
 # ---------------------------------------------------------------------------
+# Test 8 — PR creation failures restore the default branch
+# ---------------------------------------------------------------------------
+git -C "$WORK_REPO" checkout -q chore/aidevops-version-v9.9.9-test-pr-bump-repo
+gh_create_pr() {
+	printf '%s\n' "simulated PR creation failure"
+	return 1
+}
+
+set +e
+_open_version_bump_pr "test/pr-bump-repo" "$WORK_REPO" "chore/aidevops-version-v9.9.9-test-pr-bump-repo" "main" "0.0.1" "9.9.9" >/dev/null 2>&1
+OPEN_PR_RC=$?
+set -e
+if [[ "$OPEN_PR_RC" -ne 0 ]]; then
+	echo "${GREEN}PASS${NC} PR creation failure returns non-zero"
+	PASS=$((PASS + 1))
+else
+	echo "${RED}FAIL${NC} PR creation failure returned 0"
+	FAIL=$((FAIL + 1))
+fi
+CURRENT_BRANCH=$(git -C "$WORK_REPO" rev-parse --abbrev-ref HEAD)
+assert "PR creation failure restores default branch" "$CURRENT_BRANCH" "main"
+
+# ---------------------------------------------------------------------------
+# Test 9 — rerunning a machine branch force-pushes replacement commits
+# ---------------------------------------------------------------------------
+gh_create_pr() {
+	printf '%s\n' "$*" >"$GH_CREATE_PR_ARGS"
+	printf '%s\n' "https://example.invalid/pr/2"
+	return 0
+}
+
+BUMP_OUT=$(_bump_single_repo "test/pr-bump-repo" "$WORK_REPO" "false" "9.9.9" "0")
+assert "non-local bump rerun reports bumped" "$BUMP_OUT" "bumped"
+REMOTE_BRANCH_VERSION=$(git -C "$WORK_REPO" show "origin/chore/aidevops-version-v9.9.9-test-pr-bump-repo:.aidevops.json" | jq -r '.aidevops_version')
+assert "non-local bump rerun replaces remote version branch" "$REMOTE_BRANCH_VERSION" "9.9.9"
+
+# ---------------------------------------------------------------------------
+# Test 10 — recovery reset only runs when .aidevops.json is the sole ahead file
+# ---------------------------------------------------------------------------
+MULTI_REMOTE_DIR=$(mktemp -d)
+MULTI_REPO="$FIXTURE_DIR/multi-ahead-repo"
+git init --bare -q "$MULTI_REMOTE_DIR/origin.git"
+git init -q "$MULTI_REPO"
+git -C "$MULTI_REPO" checkout -q -b main
+git -C "$MULTI_REPO" config user.email t@t
+git -C "$MULTI_REPO" config user.name T
+git -C "$MULTI_REPO" config commit.gpgsign false
+printf '%s\n' '{"aidevops_version":"9.9.9"}' >"$MULTI_REPO/.aidevops.json"
+git -C "$MULTI_REPO" add .aidevops.json
+git -C "$MULTI_REPO" commit -qm init
+git -C "$MULTI_REPO" remote add origin "$MULTI_REMOTE_DIR/origin.git"
+git -C "$MULTI_REPO" push -q -u origin main
+git -C "$MULTI_REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+printf '%s\n' '{"aidevops_version":"10.0.0"}' >"$MULTI_REPO/.aidevops.json"
+printf '%s\n' 'preserve me' >"$MULTI_REPO/extra.txt"
+git -C "$MULTI_REPO" add .aidevops.json extra.txt
+git -C "$MULTI_REPO" commit -qm 'local mixed changes'
+MULTI_OUT=$(_bump_single_repo "test/multi-ahead-repo" "$MULTI_REPO" "false" "9.9.9" "0")
+assert "mixed ahead files skip destructive recovery" "$MULTI_OUT" "skipped"
+MULTI_AHEAD_COUNT=$(git -C "$MULTI_REPO" rev-list --count origin/main..HEAD)
+assert "mixed ahead files remain preserved" "$MULTI_AHEAD_COUNT" "1"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- Restores the default branch if version-bump PR creation is unavailable or fails.
- Force-pushes the dedicated machine-managed version-bump branch so reruns can recover from previously pushed replacement commits.
- Restricts destructive recovery reset to cases where `.aidevops.json` is the sole ahead file.
- Adds regression coverage for PR failure cleanup, force-push reruns, and mixed ahead-file preservation.

## Testing

- `shellcheck .agents/scripts/repo-aidevops-health-helper.sh .agents/scripts/tests/test-repo-aidevops-health.sh`
- `.agents/scripts/tests/test-repo-aidevops-health.sh`

Resolves #25182
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.99 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 54,007 tokens on this as a headless worker.