### PR TITLE
GH#25186: fix: simplify process guard shellcheck classification

### DIFF
--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -406,7 +406,7 @@ cmd_kill_runaways() {
 			local process_class killed_at
 			process_class='other'
 			case "$cmd_base" in
-			shel[l]check) process_class='lint' ;;
+			shellcheck) process_class='lint' ;;
 			node)
 				if [[ $cmd_full == *playwright* && $cmd_full == *--list* ]]; then
 					process_class='playwright-list'


### PR DESCRIPTION
## Summary

Updated .agents/scripts/process-guard-helper.sh to classify shellcheck with a direct case pattern instead of a bracketed glob pattern.

## Files Changed

.agents/scripts/process-guard-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/process-guard-helper.sh; bash .agents/scripts/tests/test-process-guard-playwright-list.sh

Resolves #25186


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.99 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 28,190 tokens on this as a headless worker.