### PR TITLE
GH#25193: test: clean repo health temporary fixture

### DIFF
--- a/.agents/scripts/tests/test-repo-aidevops-health.sh
+++ b/.agents/scripts/tests/test-repo-aidevops-health.sh
@@ -251,8 +251,9 @@ assert "non-local bump rerun replaces remote version branch" "$REMOTE_BRANCH_VER
 # ---------------------------------------------------------------------------
 # Test 10 — recovery reset only runs when .aidevops.json is the sole ahead file
 # ---------------------------------------------------------------------------
-MULTI_REMOTE_DIR=$(mktemp -d)
+MULTI_REMOTE_DIR="$FIXTURE_DIR/multi-remote"
 MULTI_REPO="$FIXTURE_DIR/multi-ahead-repo"
+mkdir -p "$MULTI_REMOTE_DIR"
 git init --bare -q "$MULTI_REMOTE_DIR/origin.git"
 git init -q "$MULTI_REPO"
 git -C "$MULTI_REPO" checkout -q -b main


### PR DESCRIPTION
## Summary

Changed the multi-remote test fixture to live under FIXTURE_DIR so the existing EXIT cleanup removes it, while preserving the bare remote setup used by the mixed-ahead-files recovery test.

## Files Changed

.agents/scripts/tests/test-repo-aidevops-health.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-repo-aidevops-health.sh; .agents/scripts/tests/test-repo-aidevops-health.sh

Resolves #25193


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 30,102 tokens on this as a headless worker.