### PR TITLE
docs: clarify runner docker foreground mode

### DIFF
--- a/.agents/reference/github-self-hosted-runners.md
+++ b/.agents/reference/github-self-hosted-runners.md
@@ -106,10 +106,11 @@ Keep real environment values out of documentation, issue comments, and PRs. The
 environment file should contain only server-local configuration and secrets such
 as repository URL, runner labels, and runner registration credentials.
 
-The launch script should end by replacing the shell with Docker, for example
-`exec docker run ...`, rather than starting Docker as a child or background
-process. This lets systemd deliver stop signals to the Docker client directly and
-reduces the risk of orphaned runner containers or later container-name conflicts.
+The launch script should end by replacing the shell with a foreground Docker
+client, for example `exec docker run ...` without `-d` or `--detach`, rather
+than starting Docker as a child or background process. This lets systemd deliver
+stop signals to the Docker client directly and reduces the risk of orphaned
+runner containers, restart loops, or later container-name conflicts.
 
 ## Health checks
 


### PR DESCRIPTION
## Summary
- Clarifies that the systemd-managed runner launch script must use a foreground Docker client with `exec docker run ...`.
- Explicitly documents avoiding `-d` / `--detach` to prevent systemd `Restart=always` loops while preserving direct stop-signal handling.

## Testing
- `npx --no-install markdownlint-cli2 .agents/reference/github-self-hosted-runners.md`

Resolves #25198
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 30,896 tokens on this as a headless worker.