### PR TITLE
docs: clarify runner unit cleanup checks

### DIFF
--- a/.agents/reference/github-self-hosted-runners.md
+++ b/.agents/reference/github-self-hosted-runners.md
@@ -94,9 +94,9 @@ EnvironmentFile=/etc/github-runner/<REPO>.env
 Restart=always
 RestartSec=5
 TimeoutStopSec=90
-ExecStartPre=-/usr/bin/docker rm -f github-runner-dind-%i
+ExecStartPre=/bin/sh -c '/usr/bin/docker inspect github-runner-dind-%i >/dev/null 2>&1 || exit 0; exec /usr/bin/docker rm -f github-runner-dind-%i'
 ExecStart=/usr/local/sbin/github-runner-dind-start %i
-ExecStop=/usr/bin/docker stop github-runner-dind-%i
+ExecStop=/bin/sh -c '/usr/bin/docker inspect github-runner-dind-%i >/dev/null 2>&1 || exit 0; exec /usr/bin/docker stop github-runner-dind-%i'
 
 [Install]
 WantedBy=multi-user.target
@@ -105,6 +105,12 @@ WantedBy=multi-user.target
 Keep real environment values out of documentation, issue comments, and PRs. The
 environment file should contain only server-local configuration and secrets such
 as repository URL, runner labels, and runner registration credentials.
+
+The `ExecStartPre` and `ExecStop` checks intentionally treat a missing container
+as success. Ephemeral runner containers are started with `docker run --rm`, so a
+completed job can remove the container before systemd runs `ExecStop`. Checking
+with `docker inspect` first prevents false service failures while still letting
+real `docker rm -f` or `docker stop` errors surface when the container exists.
 
 The launch script should end by replacing the shell with a foreground Docker
 client, for example `exec docker run ...` without `-d` or `--detach`, rather


### PR DESCRIPTION
## Summary
- Document precise systemd cleanup checks for ephemeral GitHub runner containers.
- Replace broad ignored cleanup commands with `docker inspect` guards so missing containers are success while real `docker rm -f`/`docker stop` errors can still surface.

## Verification
- `git diff --check`
- Pre-commit quality validation passed during `git commit`
- Server unit was updated and reloaded with `systemctl daemon-reload`
- `sudo systemd-analyze verify /etc/systemd/system/github-runner-dind@.service`
- `systemctl show github-runner-dind@8.service --property=ExecStartPre,ExecStop,NRestarts,ActiveState,SubState --no-pager`
- Recent journal check after services restarted showed no new `No such container` false failures in the latest one-minute window

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
