### PR TITLE
GH#25217: docs: avoid runner ExecStop race

### DIFF
--- a/.agents/reference/github-self-hosted-runners.md
+++ b/.agents/reference/github-self-hosted-runners.md
@@ -98,7 +98,7 @@ RestartSec=5
 TimeoutStopSec=90
 ExecStartPre=/bin/sh -c 'if /usr/bin/docker inspect github-runner-dind-%i >/dev/null 2>&1; then echo "Refusing to start: container github-runner-dind-%i already exists" >&2; exit 1; fi'
 ExecStart=/usr/local/sbin/github-runner-dind-start %i
-ExecStop=/bin/sh -c '/usr/bin/docker inspect github-runner-dind-%i >/dev/null 2>&1 || exit 0; exec /usr/bin/docker stop github-runner-dind-%i'
+ExecStop=/bin/sh -c 'out=$(/usr/bin/docker stop github-runner-dind-%i 2>&1); rc=$?; [ $rc -eq 0 ] || { printf "%s\n" "$out" | grep -qE "No such container|No such object" || { printf "%s\n" "$out" >&2; exit $rc; }; }'
 
 [Install]
 WantedBy=multi-user.target
@@ -115,8 +115,9 @@ the actual container start via `ExecStart`.
 
 `ExecStop` intentionally treats a missing container as success. Ephemeral runner
 containers are started with `docker run --rm`, so a completed job can remove the
-container before systemd runs `ExecStop`. Real `docker stop` errors still surface
-when the container exists.
+container before or during `ExecStop`. Run `docker stop` directly instead of
+checking first, then ignore only Docker's missing-container/object errors so
+other stop failures still surface.
 
 The launch script should end by replacing the shell with a foreground Docker
 client, for example `exec docker run ...` without `-d` or `--detach`, rather


### PR DESCRIPTION
## Summary

Updated the GitHub runner systemd example so ExecStop calls docker stop directly and ignores only Docker missing-container/object errors, preventing an inspect/stop TOCTOU race while preserving real error reporting.

## Files Changed

.agents/reference/github-self-hosted-runners.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/reference/github-self-hosted-runners.md

Resolves #25217


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 55,502 tokens on this as a headless worker.