### PR TITLE
Fix sync workflow org reusable comments

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -234,8 +234,13 @@ _render_template_with_target() {
 	local _repo_escaped _ref_escaped
 	_repo_escaped=$(_escape_sed_replacement "$_repo")
 	_ref_escaped=$(_escape_sed_replacement "${_ref#@}")
-	# Template ships with `marcusquinn/aidevops@main` by default; rewrite both.
-	sed -E 's|(uses:[[:space:]]*)marcusquinn/aidevops(/\.github/workflows/[^@]+)@[^[:space:]]+|\1'"$_repo_escaped"'\2@'"$_ref_escaped"'|' "$_template"
+	# Template ships with `marcusquinn/aidevops@main` by default; rewrite the
+	# executable `uses:` target and any managed comment/reference path so
+	# sync-generated org-owned callers are byte-comparable by check-workflows.
+	sed -E \
+		-e 's|(uses:[[:space:]]*)marcusquinn/aidevops(/\.github/workflows/[^@[:space:]]+)@[^[:space:]]+|\1'"$_repo_escaped"'\2@'"$_ref_escaped"'|' \
+		-e 's|marcusquinn/aidevops(/\.github/workflows/[^[:space:]]+)|'"$_repo_escaped"'\1|g' \
+		"$_template"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -335,6 +335,10 @@ WF_USES_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-s
 	| grep -E "^[[:space:]]+uses:" | head -n 1 || true)
 WF_RUNNER_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
 	| grep -E "^[[:space:]]+runner:" | head -n 1 || true)
+git -C "$REPO_13" checkout -q "$SYNC_BRANCH_13" 2>/dev/null || true
+CHECK_CLASS_13=$(HOME="$TMPDIR_13" bash "$CHECK_HELPER" --json --repo "owner/repo-org-target" --workflow issue-sync 2>/dev/null \
+	| jq -r 'select(.slug == "owner/repo-org-target") | .classification' \
+	| head -n 1)
 if [[ "$WF_USES_13" == *"ORG/.github/.github/workflows/issue-sync-reusable.yml@1234567890abcdef1234567890abcdef12345678"* ]]; then
 	printf '%sPASS%s GH#24520 apply writes configured org reusable target\n' "$GREEN" "$NC"
 	((_PASS++))
@@ -349,6 +353,14 @@ if [[ "$WF_RUNNER_13" == *"ubuntu-latest-arm64"* ]]; then
 else
 	printf '%sFAIL%s GH#24520 runner injection survives configured org target\n' "$RED" "$NC"
 	printf '       got: %s\n' "$WF_RUNNER_13"
+	((_FAIL++))
+fi
+if [[ "$CHECK_CLASS_13" == "CURRENT/CALLER" ]]; then
+	printf '%sPASS%s GH#25222 sync-generated org caller checks clean\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s GH#25222 sync-generated org caller checks clean\n' "$RED" "$NC"
+	printf '       got: %s\n' "$CHECK_CLASS_13"
 	((_FAIL++))
 fi
 rm -rf "$TMPDIR_13"

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -74,6 +74,7 @@ Verify the issue's cited symptoms actually match the codebase's behaviour. A rev
 - **"Y is too expensive"** → measure the actual cost — is the expense real, or a hypothetical based on misreading the code path?
 - **"Z is broken"** → check if Z is invoked at all — the cited path may be dead code, or the function may return early before reaching it.
 - **"A locks/unlocks repeatedly"** → grep for the specific events — the observed "churn" may be a different mechanism entirely (e.g., the user may mean "cycles repeatedly" but frame it as "lock/unlock").
+- **Producer/consumer mismatch** → when one helper writes state and another validates it, test the full chain. A validator-only fixture can pass while the writer still emits data the validator rejects (e.g., `sync-workflows` output later flagged by `check-workflows`).
 
 If the framing doesn't match reality, the review documents the mismatch before proposing changes. "The cited symptom doesn't reproduce, but here's what's actually happening" is more useful than reviewing a fix for a non-existent problem.
 


### PR DESCRIPTION
## Summary

- Render managed reusable workflow comment/path references in `sync-workflows`, matching `check-workflows` canonical rendering.
- Add a regression proving an org-owned sync-generated caller checks clean afterward.
- Update `/review-issue-pr` guidance to test producer/consumer chains, not validator-only fixtures.

## Testing

- `.agents/scripts/tests/test-sync-workflows-helper.sh` — 31/31 passed
- `.agents/scripts/tests/test-check-workflows-helper.sh` — 15/15 passed
- `shellcheck .agents/scripts/sync-workflows-helper.sh .agents/scripts/tests/test-sync-workflows-helper.sh` — passed
- `.agents/scripts/linters-local.sh` — passed
- First `.agents/scripts/linters-local.sh` attempt timed out at 120s during Secretlint; rerun with 600s completed successfully.

## Runtime Testing

Self-assessed low-risk shell helper/template rendering change with focused fixture coverage; no live service runtime required.

## Key Decisions

- Kept replacement scoped to managed `.github/workflows/` references rather than rewriting every repository string.
- Linked the review-workflow lesson to producer/consumer mismatch because the original validator-only reproduction missed the writer path.

Resolves #25222

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 32m and 328,077 tokens on this with the user in an interactive session.
