### PR TITLE
Append AIDevOps version to session titles

### DIFF
--- a/.agents/scripts/session-rename-helper.sh
+++ b/.agents/scripts/session-rename-helper.sh
@@ -40,6 +40,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly DEFAULT_DB_PATH="${HOME}/.local/share/opencode/opencode.db"
 readonly DEFAULT_LIST_LIMIT=10
+readonly AIDEVOPS_TITLE_SUFFIX_ERE='[[:space:]]+· AIDevOps [0-9]+\.[0-9]+\.[0-9]+$'
 
 # =============================================================================
 # Helpers
@@ -78,6 +79,50 @@ _require_sqlite3() {
 _sql_escape() {
 	local raw_value="$1"
 	printf '%s' "$raw_value" | sed "s/'/''/g"
+	return 0
+}
+
+# Read the currently deployed aidevops version.
+# Output: version on stdout, or empty string if unavailable.
+_get_aidevops_version() {
+	if [[ -n "${AIDEVOPS_VERSION:-}" ]]; then
+		printf '%s' "$AIDEVOPS_VERSION"
+		return 0
+	fi
+
+	local version_file="${SCRIPT_DIR}/../VERSION"
+	if [[ -f "$version_file" ]]; then
+		tr -d '[:space:]' <"$version_file"
+		return 0
+	fi
+
+	version_file="${HOME}/.aidevops/agents/VERSION"
+	if [[ -f "$version_file" ]]; then
+		tr -d '[:space:]' <"$version_file"
+		return 0
+	fi
+
+	return 0
+}
+
+# Append the aidevops version to titles, replacing any older suffix.
+# Arguments:
+#   $1 - raw title
+# Output: title with idempotent suffix when a version is known
+_with_aidevops_title_suffix() {
+	local raw_title="$1"
+	local version
+	version="$(_get_aidevops_version)"
+
+	local base_title
+	base_title="$(printf '%s' "$raw_title" | sed -E "s/${AIDEVOPS_TITLE_SUFFIX_ERE}//")"
+
+	if [[ -z "$version" ]]; then
+		printf '%s' "$base_title"
+		return 0
+	fi
+
+	printf '%s · AIDevOps %s' "$base_title" "$version"
 	return 0
 }
 
@@ -154,8 +199,11 @@ cmd_rename() {
 	local now_ms
 	now_ms="$(date +%s)000"
 
+	local display_title
+	display_title="$(_with_aidevops_title_suffix "$new_title")"
+
 	local escaped_title escaped_session_id
-	escaped_title="$(_sql_escape "$new_title")"
+	escaped_title="$(_sql_escape "$display_title")"
 	escaped_session_id="$(_sql_escape "$session_id")"
 
 	local changes
@@ -168,7 +216,7 @@ cmd_rename() {
 		return 1
 	fi
 
-	print_success "Session renamed to: ${new_title}"
+	print_success "Session renamed to: ${display_title}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-session-rename-helper.sh
+++ b/.agents/scripts/tests/test-session-rename-helper.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../session-rename-helper.sh"
+export AIDEVOPS_VERSION="9.8.7"
 
 PASS=0
 FAIL=0
@@ -157,7 +158,7 @@ seed_session "New Session"
 run_sync_on_branch "feature/cool-thing"
 rc=$?
 assert_exit "exit 0 on feature branch" "0" "$rc"
-assert_eq "title renamed to feature branch" "feature/cool-thing" "$(get_title)"
+assert_eq "title renamed to feature branch with suffix" "feature/cool-thing · AIDevOps 9.8.7" "$(get_title)"
 
 # Test 4: do not clobber a meaningful existing title with a feature branch sync
 echo ""
@@ -175,7 +176,7 @@ seed_session ""
 run_sync_on_branch "feature/empty-title"
 rc=$?
 assert_exit "exit 0 on empty title sync" "0" "$rc"
-assert_eq "empty title filled in" "feature/empty-title" "$(get_title)"
+assert_eq "empty title filled in with suffix" "feature/empty-title · AIDevOps 9.8.7" "$(get_title)"
 
 # Test 6: existing 'main' title is overwritten on feature branch sync
 # (recovery path: sessions that already got stuck as 'main' by the old code
@@ -186,7 +187,7 @@ seed_session "main"
 run_sync_on_branch "feature/heal-me"
 rc=$?
 assert_exit "exit 0 heal" "0" "$rc"
-assert_eq "main title healed to feature" "feature/heal-me" "$(get_title)"
+assert_eq "main title healed to feature with suffix" "feature/heal-me · AIDevOps 9.8.7" "$(get_title)"
 
 # Test 7: existing 'master' title is overwritten too
 echo ""
@@ -195,7 +196,7 @@ seed_session "master"
 run_sync_on_branch "feature/heal-master"
 rc=$?
 assert_exit "exit 0 heal master" "0" "$rc"
-assert_eq "master title healed" "feature/heal-master" "$(get_title)"
+assert_eq "master title healed with suffix" "feature/heal-master · AIDevOps 9.8.7" "$(get_title)"
 
 # Test 8: explicit rename still works for main (direct rename command is unguarded)
 # The guards apply only to sync-branch (automatic, driven by cwd branch).
@@ -206,7 +207,25 @@ seed_session "New Session"
 OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "main" >/dev/null 2>&1
 rc=$?
 assert_exit "exit 0 explicit rename" "0" "$rc"
-assert_eq "explicit rename to main allowed" "main" "$(get_title)"
+assert_eq "explicit rename to main allowed with suffix" "main · AIDevOps 9.8.7" "$(get_title)"
+
+# Test 9: explicit rename is idempotent and replaces older suffix versions
+echo ""
+echo "Test 9: explicit rename replaces existing AIDevOps suffix"
+seed_session "New Session"
+OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #123: concise title · AIDevOps 1.2.3" >/dev/null 2>&1
+rc=$?
+assert_exit "exit 0 explicit suffix replacement" "0" "$rc"
+assert_eq "old suffix replaced" "Issue #123: concise title · AIDevOps 9.8.7" "$(get_title)"
+
+# Test 10: issue prefix remains first for OpenCode session search/grouping
+echo ""
+echo "Test 10: issue prefix remains first after suffix append"
+seed_session "New Session"
+OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #456: preserve prefix" >/dev/null 2>&1
+rc=$?
+assert_exit "exit 0 explicit issue title" "0" "$rc"
+assert_eq "issue prefix preserved before suffix" "Issue #456: preserve prefix · AIDevOps 9.8.7" "$(get_title)"
 
 # -----------------------------------------------------------------------------
 # Summary

--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -23,6 +23,9 @@ import { join } from "node:path";
 const { isDefaultBranchTitle, isTitleOverwritable } = await import(
   "../../../.opencode/lib/session-rename-guards.ts"
 );
+const { withAidevopsTitleSuffix } = await import(
+  "../../../.opencode/lib/session-title-suffix.ts"
+);
 const { isTerminalTitleEnabled, sanitizeTerminalTitle, terminalTitleSequence } = await import(
   "../../../.opencode/lib/terminal-title.ts"
 );
@@ -159,6 +162,29 @@ assertEq(
   isTerminalTitleEnabled({ AIDEVOPS_TABBY_ENABLED: "false" }),
 );
 assertEq("terminal title emit defaults to enabled", true, isTerminalTitleEnabled({}));
+
+// --- AIDevOps session title suffix helpers ----------------------------------
+console.log("\nGroup 4: AIDevOps session title suffix helpers");
+assertEq(
+  "suffix is appended",
+  "Issue #123: concise title · AIDevOps 9.8.7",
+  withAidevopsTitleSuffix("Issue #123: concise title", "9.8.7"),
+);
+assertEq(
+  "existing suffix is idempotently replaced",
+  "Issue #123: concise title · AIDevOps 9.8.7",
+  withAidevopsTitleSuffix("Issue #123: concise title · AIDevOps 1.2.3", "9.8.7"),
+);
+assertEq(
+  "issue prefix remains first",
+  "Issue #456: preserve prefix · AIDevOps 9.8.7",
+  withAidevopsTitleSuffix("Issue #456: preserve prefix", "9.8.7"),
+);
+assertEq(
+  "missing version leaves title without stale suffix",
+  "Issue #123: concise title",
+  withAidevopsTitleSuffix("Issue #123: concise title · AIDevOps 1.2.3", ""),
+);
 
 console.log("\n=== Results ===");
 console.log(`PASS: ${pass}`);

--- a/.opencode/lib/session-title-suffix.ts
+++ b/.opencode/lib/session-title-suffix.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/
+
+function readVersionFile(path: string): string {
+  if (!existsSync(path)) return ""
+  return readFileSync(path, "utf8").trim()
+}
+
+export function getAidevopsVersion(): string {
+  if (process.env.AIDEVOPS_VERSION) return process.env.AIDEVOPS_VERSION.trim()
+
+  const here = dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    join(here, "..", "..", "VERSION"),
+    join(here, "..", "..", ".agents", "VERSION"),
+    join(process.env.HOME || "", ".aidevops", "agents", "VERSION"),
+  ]
+
+  for (const candidate of candidates) {
+    const version = readVersionFile(candidate)
+    if (version) return version
+  }
+
+  return ""
+}
+
+export function withAidevopsTitleSuffix(title: string, version = getAidevopsVersion()): string {
+  const baseTitle = title.replace(AIDEVOPS_TITLE_SUFFIX_RE, "")
+  if (!version) return baseTitle
+  return `${baseTitle} · AIDevOps ${version}`
+}

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { tool } from "@opencode-ai/plugin"
 import { isDefaultBranchTitle, isTitleOverwritable } from "../lib/session-rename-guards"
+import { withAidevopsTitleSuffix } from "../lib/session-title-suffix"
 import { emitTerminalTitle } from "../lib/terminal-title"
 
 /**
@@ -26,6 +27,7 @@ function getDbPath(): string {
  */
 function renameSession(sessionID: string, title: string): { success: boolean; message: string } {
   const dbPath = getDbPath()
+  const displayTitle = withAidevopsTitleSuffix(title)
 
   try {
     const db = new Database(dbPath)
@@ -33,14 +35,14 @@ function renameSession(sessionID: string, title: string): { success: boolean; me
       const nowMs = Date.now()
       const result = db.run(
         "UPDATE session SET title = ?, time_updated = ? WHERE id = ?",
-        [title, nowMs, sessionID],
+        [displayTitle, nowMs, sessionID],
       )
 
       if (result.changes === 0) {
         return { success: false, message: `Session ${sessionID} not found in database` }
       }
 
-      return { success: true, message: title }
+      return { success: true, message: displayTitle }
     } finally {
       db.close()
     }
@@ -82,17 +84,18 @@ function syncSessionWithBranch(
         }
       }
 
+      const displayTitle = withAidevopsTitleSuffix(branch)
       const nowMs = Date.now()
       const result = db.run(
         "UPDATE session SET title = ?, time_updated = ? WHERE id = ?",
-        [branch, nowMs, sessionID],
+        [displayTitle, nowMs, sessionID],
       )
 
       if (result.changes === 0) {
         return { outcome: "error", message: `Session ${sessionID} not found in database` }
       }
 
-      return { outcome: "renamed", message: branch }
+      return { outcome: "renamed", message: displayTitle }
     } finally {
       db.close()
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,9 @@
     "target": "ES2022",
     "types": ["bun"]
   },
-  "include": [".opencode/lib/session-rename-guards.ts", ".opencode/lib/terminal-title.ts"]
+  "include": [
+    ".opencode/lib/session-rename-guards.ts",
+    ".opencode/lib/session-title-suffix.ts",
+    ".opencode/lib/terminal-title.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- Append an idempotent ` · AIDevOps <version>` suffix to OpenCode session titles when aidevops renames sessions.
- Share suffix logic with the TypeScript OpenCode tool path and shell helper path.
- Preserve issue/PR prefixes at the start of titles for session search/grouping.

## Verification

- `.agents/scripts/tests/test-session-rename-helper.sh`
- `bun run .agents/scripts/tests/test-session-rename-ts.mjs`
- `shellcheck .agents/scripts/session-rename-helper.sh .agents/scripts/tests/test-session-rename-helper.sh`
- `npm run typecheck`
- `.agents/scripts/linters-local.sh`

## Notes

- The full local linter completed with existing advisory markdown/ratchet/complexity output and ended with `ALL LOCAL CHECKS PASSED`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
