### PR TITLE
Harden session title version lookup

### DIFF
--- a/.agents/scripts/session-rename-helper.sh
+++ b/.agents/scripts/session-rename-helper.sh
@@ -38,7 +38,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # Constants
 # =============================================================================
 
-readonly DEFAULT_DB_PATH="${HOME}/.local/share/opencode/opencode.db"
+readonly DEFAULT_DB_PATH="${HOME:-}/.local/share/opencode/opencode.db"
 readonly DEFAULT_LIST_LIMIT=10
 readonly AIDEVOPS_TITLE_SUFFIX_ERE='[[:space:]]+· AIDevOps [0-9]+\.[0-9]+\.[0-9]+$'
 
@@ -90,13 +90,24 @@ _get_aidevops_version() {
 		return 0
 	fi
 
-	local version_file="${SCRIPT_DIR}/../VERSION"
+	local version_file="${SCRIPT_DIR}/../../VERSION"
 	if [[ -f "$version_file" ]]; then
 		tr -d '[:space:]' <"$version_file"
 		return 0
 	fi
 
-	version_file="${HOME}/.aidevops/agents/VERSION"
+	version_file="${SCRIPT_DIR}/../VERSION"
+	if [[ -f "$version_file" ]]; then
+		tr -d '[:space:]' <"$version_file"
+		return 0
+	fi
+
+	local home_dir="${HOME:-}"
+	if [[ -z "$home_dir" ]]; then
+		return 0
+	fi
+
+	version_file="${home_dir}/.aidevops/agents/VERSION"
 	if [[ -f "$version_file" ]]; then
 		tr -d '[:space:]' <"$version_file"
 		return 0

--- a/.agents/scripts/tests/test-session-rename-helper.sh
+++ b/.agents/scripts/tests/test-session-rename-helper.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../session-rename-helper.sh"
 export AIDEVOPS_VERSION="9.8.7"
+ROOT_VERSION="$(tr -d '[:space:]' <"${SCRIPT_DIR}/../../../VERSION")"
 
 PASS=0
 FAIL=0
@@ -226,6 +227,15 @@ OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #456: preserve pref
 rc=$?
 assert_exit "exit 0 explicit issue title" "0" "$rc"
 assert_eq "issue prefix preserved before suffix" "Issue #456: preserve prefix · AIDevOps 9.8.7" "$(get_title)"
+
+# Test 11: version fallback reads the repository root VERSION
+echo ""
+echo "Test 11: repo-root VERSION fallback works"
+seed_session "New Session"
+env -u AIDEVOPS_VERSION OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #789: root version" >/dev/null 2>&1
+rc=$?
+assert_exit "exit 0 root version fallback" "0" "$rc"
+assert_eq "root VERSION suffix used" "Issue #789: root version · AIDevOps ${ROOT_VERSION}" "$(get_title)"
 
 # -----------------------------------------------------------------------------
 # Summary

--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -23,7 +23,7 @@ import { join } from "node:path";
 const { isDefaultBranchTitle, isTitleOverwritable } = await import(
   "../../../.opencode/lib/session-rename-guards.ts"
 );
-const { withAidevopsTitleSuffix } = await import(
+const { getAidevopsVersion, withAidevopsTitleSuffix } = await import(
   "../../../.opencode/lib/session-title-suffix.ts"
 );
 const { isTerminalTitleEnabled, sanitizeTerminalTitle, terminalTitleSequence } = await import(
@@ -185,6 +185,9 @@ assertEq(
   "Issue #123: concise title",
   withAidevopsTitleSuffix("Issue #123: concise title · AIDevOps 1.2.3", ""),
 );
+process.env.AIDEVOPS_VERSION = "7.6.5";
+assertEq("env version override is read", "7.6.5", getAidevopsVersion());
+delete process.env.AIDEVOPS_VERSION;
 
 console.log("\n=== Results ===");
 console.log(`PASS: ${pass}`);

--- a/.opencode/lib/session-title-suffix.ts
+++ b/.opencode/lib/session-title-suffix.ts
@@ -5,8 +5,12 @@ import { fileURLToPath } from "node:url"
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/
 
 function readVersionFile(path: string): string {
-  if (!existsSync(path)) return ""
-  return readFileSync(path, "utf8").trim()
+  try {
+    if (!existsSync(path)) return ""
+    return readFileSync(path, "utf8").trim()
+  } catch {
+    return ""
+  }
 }
 
 export function getAidevopsVersion(): string {


### PR DESCRIPTION
## Summary

- Resolve review follow-up from PR #25225.
- Add repo-root `VERSION` fallback to the shell session rename helper and guard `HOME` access.
- Wrap TypeScript version-file reads so permission/path errors fail closed to no suffix instead of crashing.

Resolves #25226

## Verification

- `.agents/scripts/tests/test-session-rename-helper.sh`
- `bun run .agents/scripts/tests/test-session-rename-ts.mjs`
- `shellcheck .agents/scripts/session-rename-helper.sh .agents/scripts/tests/test-session-rename-helper.sh`
- `npm run typecheck`
- `.agents/scripts/linters-local.sh`

## Notes

- The local linter completed with existing advisory markdown/ratchet/complexity output and ended with `ALL LOCAL CHECKS PASSED`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.100 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
