### PR TITLE
fix: suffix OpenCode title agent output

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -36,6 +36,7 @@ import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
+import { applyTitleAgentSuffix } from "./session-title-suffix.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
@@ -220,7 +221,7 @@ export async function AidevopsPlugin({ directory, client }) {
   const {
     systemTransformHook: ttsrSystemTransformHook,
     messagesTransformHook: ttsrMessagesTransformHook,
-    textCompleteHook,
+    textCompleteHook: ttsrTextCompleteHook,
   } = createTtsrHooks({
     agentsDir: AGENTS_DIR,
     scriptsDir: SCRIPTS_DIR,
@@ -276,6 +277,14 @@ export async function AidevopsPlugin({ directory, client }) {
     } catch (err) {
       qualityLog("WARN", `[image-size-guard] Unexpected error: ${err?.message ?? err}`);
     }
+  };
+
+  // Compose post-completion hooks. OpenCode's built-in hidden `title` agent
+  // generates the initial prompt-digestion session title outside aidevops-owned
+  // rename tools, so append the version suffix at the text completion boundary.
+  const textCompleteHook = async (input, output) => {
+    await ttsrTextCompleteHook(input, output);
+    applyTitleAgentSuffix(input, output, AGENTS_DIR);
   };
 
   // Greeting handler (t2724) — emits session-start framework status as

--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
+
+function readIfExists(filepath) {
+  try {
+    if (existsSync(filepath)) {
+      return readFileSync(filepath, "utf-8").trim();
+    }
+  } catch {
+    // ignore unreadable version files
+  }
+  return "";
+}
+
+export function readAidevopsVersion(agentsDir) {
+  if (process.env.AIDEVOPS_VERSION) return process.env.AIDEVOPS_VERSION.trim();
+
+  const candidates = [
+    join(agentsDir, "VERSION"),
+    join(agentsDir, "..", "VERSION"),
+    join(agentsDir, "..", "version"),
+  ];
+
+  for (const candidate of candidates) {
+    const version = readIfExists(candidate);
+    if (version) return version;
+  }
+
+  return "";
+}
+
+export function withAidevopsTitleSuffix(title, version) {
+  const baseTitle = String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, "");
+  if (!version) return baseTitle;
+  return `${baseTitle} · AIDevOps ${version}`;
+}
+
+function getAgentName(input) {
+  const candidates = [
+    input?.agent,
+    input?.agentID,
+    input?.agent_id,
+    input?.agent?.id,
+    input?.agent?.name,
+  ];
+  return candidates.find((value) => typeof value === "string" && value.trim()) || "";
+}
+
+export function isTitleAgentCompletion(input) {
+  return getAgentName(input) === "title";
+}
+
+export function applyTitleAgentSuffix(input, output, agentsDir) {
+  if (!output?.text || !isTitleAgentCompletion(input)) return;
+
+  const version = readAidevopsVersion(agentsDir);
+  output.text = withAidevopsTitleSuffix(output.text, version);
+}

--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -107,8 +107,12 @@ export function createShellEnvHook(deps) {
     output.env.AIDEVOPS_WORKSPACE_DIR = workspaceDir;
     output.env.AIDEVOPS_SESSION_ORIGIN = shellSessionOrigin(output.env);
 
-    // Set aidevops version if available
-    const version = readIfExists(join(agentsDir, "..", "version"));
+    // Set aidevops version if available. Prefer the deployed framework version
+    // source; ~/.aidevops/version is a legacy/stale compatibility fallback.
+    const version =
+      readIfExists(join(agentsDir, "VERSION")) ||
+      readIfExists(join(agentsDir, "..", "VERSION")) ||
+      readIfExists(join(agentsDir, "..", "version"));
     if (version) {
       output.env.AIDEVOPS_VERSION = version;
     }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  applyTitleAgentSuffix,
+  isTitleAgentCompletion,
+  readAidevopsVersion,
+  withAidevopsTitleSuffix,
+} from "../session-title-suffix.mjs";
+
+function withTempAgentsDir(fn) {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-title-suffix-"));
+  const dir = join(root, "agents");
+  mkdirSync(dir);
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function withoutEnvVersion(fn) {
+  const saved = process.env.AIDEVOPS_VERSION;
+  try {
+    delete process.env.AIDEVOPS_VERSION;
+    return fn();
+  } finally {
+    if (saved === undefined) delete process.env.AIDEVOPS_VERSION;
+    else process.env.AIDEVOPS_VERSION = saved;
+  }
+}
+
+test("title suffix appends and replaces idempotently", () => {
+  assert.equal(
+    withAidevopsTitleSuffix("Investigate title path", "3.20.102"),
+    "Investigate title path · AIDevOps 3.20.102",
+  );
+  assert.equal(
+    withAidevopsTitleSuffix("Investigate title path · AIDevOps 3.20.101", "3.20.102"),
+    "Investigate title path · AIDevOps 3.20.102",
+  );
+});
+
+test("version reader prefers deployed agents VERSION", () => {
+  withoutEnvVersion(() =>
+    withTempAgentsDir((agentsDir) => {
+      writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
+      writeFileSync(join(agentsDir, "..", "version"), "2.44.2\n");
+
+      assert.equal(readAidevopsVersion(agentsDir), "3.20.102");
+    }),
+  );
+});
+
+test("title agent completion gets version suffix", () => {
+  withoutEnvVersion(() =>
+    withTempAgentsDir((agentsDir) => {
+      writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
+      const output = { text: "Check live title capability" };
+
+      applyTitleAgentSuffix({ agent: "title" }, output, agentsDir);
+
+      assert.equal(output.text, "Check live title capability · AIDevOps 3.20.102");
+    }),
+  );
+});
+
+test("non-title completions are untouched", () => {
+  withTempAgentsDir((agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
+    const output = { text: "Normal assistant output" };
+
+    applyTitleAgentSuffix({ agent: "build" }, output, agentsDir);
+
+    assert.equal(output.text, "Normal assistant output");
+  });
+});
+
+test("title agent detection accepts known hook shapes", () => {
+  assert.equal(isTitleAgentCompletion({ agent: "title" }), true);
+  assert.equal(isTitleAgentCompletion({ agentID: "title" }), true);
+  assert.equal(isTitleAgentCompletion({ agent: { id: "title" } }), true);
+  assert.equal(isTitleAgentCompletion({ agent: { name: "title" } }), true);
+  assert.equal(isTitleAgentCompletion({ agent: "build" }), false);
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -8,11 +8,33 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createShellEnvHook } from "../shell-env.mjs";
 
 function makeHook() {
   return createShellEnvHook({
     agentsDir: "/tmp/aidevops-agents",
+    scriptsDir: "/tmp/aidevops-scripts",
+    workspaceDir: "/tmp/aidevops-workspace",
+  });
+}
+
+function withTempAgentsDir(fn) {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-shell-env-"));
+  const dir = join(root, "agents");
+  mkdirSync(dir);
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function makeHookForAgentsDir(agentsDir) {
+  return createShellEnvHook({
+    agentsDir,
     scriptsDir: "/tmp/aidevops-scripts",
     workspaceDir: "/tmp/aidevops-workspace",
   });
@@ -61,4 +83,18 @@ test("headless OpenCode shell stamps worker origin", async () => {
   await hook({ sessionID: "worker-session" }, output);
 
   assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "worker");
+});
+
+test("shell env version prefers deployed agents VERSION over legacy version", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
+    writeFileSync(join(agentsDir, "..", "version"), "2.44.2\n");
+
+    const hook = makeHookForAgentsDir(agentsDir);
+    const output = { env: { PATH: "/usr/bin:/bin" } };
+
+    await hook({ sessionID: "interactive-session" }, output);
+
+    assert.equal(output.env.AIDEVOPS_VERSION, "3.20.102");
+  });
 });


### PR DESCRIPTION
## Summary

- append the AIDevOps version suffix to OpenCode built-in `agent=title` completions via the plugin text-complete hook
- keep existing manual/session-rename suffix behaviour unchanged
- fix the OpenCode shell env version source to prefer `~/.aidevops/agents/VERSION` over stale legacy `~/.aidevops/version`

Resolves #25227

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `bun run .agents/scripts/tests/test-session-rename-ts.mjs`
- `.agents/scripts/tests/test-session-rename-helper.sh`
- `npm run typecheck`
- `npx biome check .agents/plugins/opencode-aidevops/index.mjs .agents/plugins/opencode-aidevops/shell-env.mjs .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `.agents/scripts/linters-local.sh` (`ALL LOCAL CHECKS PASSED`; historical/advisory warnings only)

## Notes

- This targets the OpenCode hidden title-agent path observed during initial prompt digestion, which is separate from aidevops-owned `session-rename` tools/helpers.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.102 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
