### PR TITLE
GH#25239: docs: clarify SYNC_PAT bypass semantics

### DIFF
--- a/.agents/reference/auto-dispatch.md
+++ b/.agents/reference/auto-dispatch.md
@@ -66,7 +66,7 @@ Full active lifecycle recognised: `status:queued`, `status:in-progress`, `status
 
 ## Issue-Sync TODO Auto-Completion (t2029 → t2166)
 
-`issue-sync.yml` auto-marks TODO entries complete on PR merge but cannot push to `main` without a `SYNC_PAT` — branch protection rejects `github-actions[bot]` pushes (`required_approving_review_count: 1`, no bypass on personal-account plans — `bypass_pull_request_allowances` returns HTTP 500, re-verified 2026-04-13).
+`issue-sync.yml` auto-marks TODO entries complete on PR merge but cannot push to `main` without a `SYNC_PAT` — branch protection rejects `github-actions[bot]` pushes (`required_approving_review_count: 1`). On personal-account classic protection, `bypass_pull_request_allowances` returning HTTP 500 describes the unsupported `github-actions[bot]` bypass-list path; it does not prove a fine-grained admin/maintainer PAT cannot help, because `SYNC_PAT` changes the authenticated push principal.
 
 **To enable auto-sync** (run in a separate terminal, NOT in AI chat):
 

--- a/.agents/reference/sync-pat-platforms.md
+++ b/.agents/reference/sync-pat-platforms.md
@@ -25,6 +25,14 @@ on GitHub Actions). Issues are then authored by the bot, which:
 2. Cannot push to a branch-protected default branch on most platforms,
    leaving TODO.md sync commits silently failing.
 
+Do not equate `bypass_pull_request_allowances` with `SYNC_PAT`. The former is
+the classic branch-protection bypass list for `github-actions[bot]`/apps; the
+latter changes the authenticated push principal to the maintainer/admin PAT
+owner. A missing or empty bypass list does not prove `SYNC_PAT` cannot help.
+Before filing or approving a false-positive advisory issue, prove that a
+correctly scoped admin/maintainer PAT cannot bypass the repo's actual
+protection settings.
+
 ## Security posture (cross-platform)
 
 Three rules apply on every platform:
@@ -127,6 +135,12 @@ If all four conditions resolve to "this repo needs `SYNC_PAT`", an advisory
 file is written at `~/.aidevops/advisories/sync-pat-<SLUG_SAFE>.advisory` and
 the `setup-debt-helper.sh` aggregator picks it up for the toast warning + the
 `/setup-git` walkthrough.
+
+`aidevops security dismiss sync-pat-*` is an operator opt-out/defer path for a
+known setup-debt warning. Treat dismissal as local risk acceptance or scheduling
+debt, not as evidence that `_check_sync_pat_need` is wrong. Do not suppress the
+advisory solely because `bypass_pull_request_allowances` is absent, null, empty,
+or unavailable.
 
 ---
 

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -47,7 +47,7 @@ these keywords.
 
 ## Pre-composition Checks (MANDATORY)
 
-Before composing any framework-bug report, run these 5 checks. They are shared with t2409 (`workflows/brief.md` "Pre-composition checks") — referenced here by pointer, not duplicated.
+Before composing any framework-bug report, run these 6 checks. They are shared with t2409 (`workflows/brief.md` "Pre-composition checks") — referenced here by pointer, not duplicated.
 
 1. **Memory recall**: `memory-helper.sh recall --query "<symptom-keywords>" --limit 5` — surface accumulated lessons before re-diagnosing a known issue. A lesson that says "same error, fixed in t2108" saves 30+ minutes.
 
@@ -66,6 +66,8 @@ Before composing any framework-bug report, run these 5 checks. They are shared w
 4. **Tier disqualifier check**: Framework bugs are usually `tier:standard`. Cross-check the draft brief against `reference/task-taxonomy.md` "Tier Assignment Validation" disqualifiers before assigning `tier:simple`. Default to `tier:standard` when uncertain.
 
 5. **Self-assignment awareness**: If filing via `gh_create_issue` with the `auto-dispatch` label, plan to `gh issue edit N --remove-assignee <user>` immediately after — the wrapper currently self-assigns (t2406/#19991). Alternatively, omit `auto-dispatch` until ready to hand off.
+
+6. **Security/setup advisory suppression proof**: Before filing a false-positive issue for any setup or security advisory, require proof that the fully configured positive path cannot work. For `SYNC_PAT`, do not equate `bypass_pull_request_allowances` with the `SYNC_PAT` principal: the former is the classic `github-actions[bot]`/app bypass list, while the latter authenticates as the maintainer/admin PAT owner. A missing or empty bypass list alone is insufficient; require evidence that a correctly scoped admin/maintainer PAT cannot bypass the repo's actual protection settings.
 
 ## Workflow
 

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -75,6 +75,7 @@ Verify the issue's cited symptoms actually match the codebase's behaviour. A rev
 - **"Z is broken"** → check if Z is invoked at all — the cited path may be dead code, or the function may return early before reaching it.
 - **"A locks/unlocks repeatedly"** → grep for the specific events — the observed "churn" may be a different mechanism entirely (e.g., the user may mean "cycles repeatedly" but frame it as "lock/unlock").
 - **Producer/consumer mismatch** → when one helper writes state and another validates it, test the full chain. A validator-only fixture can pass while the writer still emits data the validator rejects (e.g., `sync-workflows` output later flagged by `check-workflows`).
+- **Security/setup advisory suppression** → identify the actual credential principal and require positive-path evidence before approving suppression. Known hazard: `SYNC_PAT` authenticates as the maintainer/admin PAT owner; `bypass_pull_request_allowances` only describes the classic `github-actions[bot]`/app bypass list. A missing or empty bypass list is not enough to prove the `SYNC_PAT` advisory is a false positive.
 
 If the framing doesn't match reality, the review documents the mismatch before proposing changes. "The cited symptom doesn't reproduce, but here's what's actually happening" is more useful than reviewing a fix for a non-existent problem.
 
@@ -157,6 +158,13 @@ aidevops has several safety gates. Every non-trivial change must be mapped again
 | **Origin labels** (`origin:interactive` / `origin:worker`) | Session provenance | Does this change behaviour based on provenance in a way that could be spoofed? |
 
 If the change touches any gate, the review must call it out explicitly. "Does not touch any gate" is a valid answer — but the question must be asked.
+
+For security or setup-advisory suppression proposals, require reproduction against
+the fully configured positive path before approval. Identify the credential
+principal being tested, the repo protection mechanism, and the bypass semantics
+that apply to that principal. For `SYNC_PAT`, require evidence that a correctly
+scoped admin/maintainer PAT cannot bypass the repo's actual protection settings;
+do not accept missing/empty `bypass_pull_request_allowances` as sufficient proof.
 
 #### 6.3 Symptom vs root cause
 


### PR DESCRIPTION
## Summary

Clarified that SYNC_PAT uses the maintainer/admin PAT owner as the authenticated principal, while bypass_pull_request_allowances only describes the classic github-actions[bot]/app bypass-list path. Added issue-logging and review guidance requiring positive-path evidence before filing or approving setup/security advisory suppression, and documented dismissals as operator opt-out/defer rather than detector-error proof.

## Files Changed

.agents/reference/auto-dispatch.md,.agents/reference/sync-pat-platforms.md,.agents/workflows/log-issue-aidevops.md,.agents/workflows/review-issue-pr.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "bypass_pull_request_allowances|correctly scoped.*PAT|operator opt-out|false-positive.*advisory|SYNC_PAT.*principal" .agents/reference/sync-pat-platforms.md .agents/reference/auto-dispatch.md .agents/scripts/commands/log-issue-aidevops.md .agents/workflows/log-issue-aidevops.md .agents/workflows/review-issue-pr.md; .agents/scripts/linters-local.sh

Resolves #25239


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.103 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 5m and 99,280 tokens on this as a headless worker.