### PR TITLE
fix: suffix OpenCode session update titles

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -36,7 +36,7 @@ import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
-import { applyTitleAgentSuffix } from "./session-title-suffix.mjs";
+import { applyTitleAgentSuffix, createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
@@ -295,6 +295,10 @@ export async function AidevopsPlugin({ directory, client }) {
     scriptsDir: SCRIPTS_DIR,
     client,
   });
+  const sessionTitleSuffixHandler = createSessionTitleSuffixHandler({
+    agentsDir: AGENTS_DIR,
+    client,
+  });
 
   return {
     // Config: agent index, MCP registration, OAuth pool injection
@@ -327,6 +331,11 @@ export async function AidevopsPlugin({ directory, client }) {
       // Fire both in parallel — neither depends on the other's result.
       await Promise.all([
         handleEvent(input),
+        sessionTitleSuffixHandler(input).catch((err) => {
+          if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+            console.error(`[aidevops] title suffix handler error: ${err.message}`);
+          }
+        }),
         greetingHandler(input).catch((err) => {
           if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
             console.error(`[aidevops] greeting handler error: ${err.message}`);

--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -18,8 +18,6 @@ function readIfExists(filepath) {
 }
 
 export function readAidevopsVersion(agentsDir) {
-  if (process.env.AIDEVOPS_VERSION) return process.env.AIDEVOPS_VERSION.trim();
-
   const candidates = [
     join(agentsDir, "VERSION"),
     join(agentsDir, "..", "VERSION"),
@@ -60,4 +58,50 @@ export function applyTitleAgentSuffix(input, output, agentsDir) {
 
   const version = readAidevopsVersion(agentsDir);
   output.text = withAidevopsTitleSuffix(output.text, version);
+}
+
+function getEventInfo(input) {
+  return input?.event?.properties?.info || input?.properties?.info || input?.info || null;
+}
+
+function getEventSessionId(input, info) {
+  return input?.event?.properties?.sessionID || input?.properties?.sessionID || input?.sessionID || info?.id || "";
+}
+
+export function createSessionTitleSuffixHandler({ agentsDir, client }) {
+  const inFlight = new Set();
+
+  return async function sessionTitleSuffixHandler(input) {
+    const eventType = input?.event?.type || input?.type || "";
+    if (eventType !== "session.updated") return;
+
+    const info = getEventInfo(input);
+    const title = info?.title || "";
+    if (!title) return;
+
+    const version = readAidevopsVersion(agentsDir);
+    const suffixedTitle = withAidevopsTitleSuffix(title, version);
+    if (suffixedTitle === title) return;
+
+    const sessionID = getEventSessionId(input, info);
+    if (!sessionID || inFlight.has(sessionID)) return;
+
+    inFlight.add(sessionID);
+    try {
+      try {
+        await client.session.update({
+          path: { id: sessionID },
+          body: { title: suffixedTitle },
+        });
+      } catch (err) {
+        if (!client?.session?.update) throw err;
+        await client.session.update({
+          path: { sessionID },
+          body: { title: suffixedTitle },
+        });
+      }
+    } finally {
+      inFlight.delete(sessionID);
+    }
+  };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   applyTitleAgentSuffix,
+  createSessionTitleSuffixHandler,
   isTitleAgentCompletion,
   readAidevopsVersion,
   withAidevopsTitleSuffix,
@@ -87,4 +88,95 @@ test("title agent detection accepts known hook shapes", () => {
   assert.equal(isTitleAgentCompletion({ agent: { id: "title" } }), true);
   assert.equal(isTitleAgentCompletion({ agent: { name: "title" } }), true);
   assert.equal(isTitleAgentCompletion({ agent: "build" }), false);
+});
+
+test("session.updated handler appends suffix through OpenCode session update API", async () => {
+  await withoutEnvVersion(() =>
+    withTempAgentsDir(async (agentsDir) => {
+      writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");
+      const calls = [];
+      const client = {
+        session: {
+          update: async (payload) => {
+            calls.push(payload);
+            return { data: {} };
+          },
+        },
+      };
+
+      const handler = createSessionTitleSuffixHandler({ agentsDir, client });
+      await handler({
+        event: {
+          type: "session.updated",
+          properties: {
+            sessionID: "ses_test",
+            info: { id: "ses_test", title: "Work on live title fix" },
+          },
+        },
+      });
+
+      assert.deepEqual(calls, [
+        {
+          path: { id: "ses_test" },
+          body: { title: "Work on live title fix · AIDevOps 3.20.103" },
+        },
+      ]);
+    }),
+  );
+});
+
+test("session.updated handler is idempotent when suffix already exists", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");
+    const calls = [];
+    const client = { session: { update: async (payload) => calls.push(payload) } };
+    const handler = createSessionTitleSuffixHandler({ agentsDir, client });
+
+    await handler({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_test",
+          info: { id: "ses_test", title: "Work · AIDevOps 3.20.103" },
+        },
+      },
+    });
+
+    assert.deepEqual(calls, []);
+  });
+});
+
+test("session.updated handler falls back to sessionID path shape", async () => {
+  await withoutEnvVersion(() =>
+    withTempAgentsDir(async (agentsDir) => {
+      writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");
+      const calls = [];
+      const client = {
+        session: {
+          update: async (payload) => {
+            calls.push(payload);
+            if (calls.length === 1) throw new Error("wrong path shape");
+            return { data: {} };
+          },
+        },
+      };
+      const handler = createSessionTitleSuffixHandler({ agentsDir, client });
+
+      await handler({
+        event: {
+          type: "session.updated",
+          properties: {
+            sessionID: "ses_test",
+            info: { id: "ses_test", title: "Fallback path" },
+          },
+        },
+      });
+
+      assert.equal(calls.length, 2);
+      assert.deepEqual(calls[1], {
+        path: { sessionID: "ses_test" },
+        body: { title: "Fallback path · AIDevOps 3.20.103" },
+      });
+    }),
+  );
 });


### PR DESCRIPTION
## Summary

- patch OpenCode `session.updated` events so built-in title generation gets the AIDevOps version suffix after `Session.setTitle`
- keep the previous text-complete helper/tests but add the event-level path that OpenCode 1.17.8 actually uses for initial titles
- ignore stale `AIDEVOPS_VERSION` process env in the plugin suffix helper and prefer deployed version files

Resolves #25227

## Live failure evidence

- OpenCode 1.17.8 binary shows `experimental.text.complete` receives only `{ sessionID, messageID, partID }`, so PR #25235 could not identify `agent=title` there.
- The same binary shows the initial title generator calls `setTitle({ sessionID, title })` directly.
- User verified a new session did not show the suffix after v3.20.103.

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `npx biome check .agents/plugins/opencode-aidevops/index.mjs .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`
- `npm run typecheck`
- `bun run .agents/scripts/tests/test-session-rename-ts.mjs`
- `.agents/scripts/tests/test-session-rename-helper.sh`
- `.agents/scripts/linters-local.sh` (`ALL LOCAL CHECKS PASSED`; historical/advisory warnings only)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.103 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
