### PR TITLE
GH#25242: docs: emphasize GUI containment goals

### DIFF
--- a/docs/gui/adr-0002-trust-boundaries.md
+++ b/docs/gui/adr-0002-trust-boundaries.md
@@ -104,7 +104,7 @@ local execution credentials or secret values. Local agents initiate connections,
 authenticate the Cloudron identity, fetch scoped intents, and enforce local
 authorization before doing anything.
 
-Cloudron compromise containment goal: an attacker controlling the hosted app may
+**Cloudron compromise containment goal:** an attacker controlling the hosted app may
 see or tamper with coordination data available to that app, but cannot run
 arbitrary commands on local machines, cannot read local secret values, and
 cannot expand capabilities beyond previously granted scopes without local
@@ -123,7 +123,7 @@ as a task capsule that includes:
 - Expiry and replay protection.
 - Audit and result-return requirements.
 
-Paired-machine compromise containment goal: an attacker controlling one paired
+**Paired-machine compromise containment goal:** an attacker controlling one paired
 machine can misuse only that machine's unexpired capsules and local resources;
 the attacker cannot mint new capabilities for other machines, cannot retrieve
 global secrets, and cannot silently mutate unrelated repos or infrastructure.


### PR DESCRIPTION
## Summary

Bolded the Cloudron and paired-machine compromise containment goal prefixes in docs/gui/adr-0002-trust-boundaries.md for readability and consistency with ADR emphasis patterns.

## Files Changed

docs/gui/adr-0002-trust-boundaries.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bunx markdownlint-cli2 docs/gui/adr-0002-trust-boundaries.md (0 errors)

Resolves #25242


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.103 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 7m and 68,807 tokens on this as a headless worker.