### PR TITLE
fix: reduce session title suffix complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -36,7 +36,7 @@ import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
-import { applyTitleAgentSuffix, createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
+import { createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
@@ -221,7 +221,7 @@ export async function AidevopsPlugin({ directory, client }) {
   const {
     systemTransformHook: ttsrSystemTransformHook,
     messagesTransformHook: ttsrMessagesTransformHook,
-    textCompleteHook: ttsrTextCompleteHook,
+    textCompleteHook,
   } = createTtsrHooks({
     agentsDir: AGENTS_DIR,
     scriptsDir: SCRIPTS_DIR,
@@ -279,14 +279,6 @@ export async function AidevopsPlugin({ directory, client }) {
     }
   };
 
-  // Compose post-completion hooks. OpenCode's built-in hidden `title` agent
-  // generates the initial prompt-digestion session title outside aidevops-owned
-  // rename tools, so append the version suffix at the text completion boundary.
-  const textCompleteHook = async (input, output) => {
-    await ttsrTextCompleteHook(input, output);
-    applyTitleAgentSuffix(input, output, AGENTS_DIR);
-  };
-
   // Greeting handler (t2724) — emits session-start framework status as
   // TUI toasts via client.tui.showToast(). Fires once per plugin init on
   // the first session.created event. See greeting.mjs for classification
@@ -299,6 +291,12 @@ export async function AidevopsPlugin({ directory, client }) {
     agentsDir: AGENTS_DIR,
     client,
   });
+
+  const debugEventError = (label, err) => {
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error(`[aidevops] ${label} error: ${err.message}`);
+    }
+  };
 
   return {
     // Config: agent index, MCP registration, OAuth pool injection
@@ -331,16 +329,8 @@ export async function AidevopsPlugin({ directory, client }) {
       // Fire both in parallel — neither depends on the other's result.
       await Promise.all([
         handleEvent(input),
-        sessionTitleSuffixHandler(input).catch((err) => {
-          if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-            console.error(`[aidevops] title suffix handler error: ${err.message}`);
-          }
-        }),
-        greetingHandler(input).catch((err) => {
-          if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-            console.error(`[aidevops] greeting handler error: ${err.message}`);
-          }
-        }),
+        sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
+        greetingHandler(input).catch((err) => debugEventError("greeting handler", err)),
       ]);
     },
 

--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -38,28 +38,6 @@ export function withAidevopsTitleSuffix(title, version) {
   return `${baseTitle} · AIDevOps ${version}`;
 }
 
-function getAgentName(input) {
-  const candidates = [
-    input?.agent,
-    input?.agentID,
-    input?.agent_id,
-    input?.agent?.id,
-    input?.agent?.name,
-  ];
-  return candidates.find((value) => typeof value === "string" && value.trim()) || "";
-}
-
-export function isTitleAgentCompletion(input) {
-  return getAgentName(input) === "title";
-}
-
-export function applyTitleAgentSuffix(input, output, agentsDir) {
-  if (!output?.text || !isTitleAgentCompletion(input)) return;
-
-  const version = readAidevopsVersion(agentsDir);
-  output.text = withAidevopsTitleSuffix(output.text, version);
-}
-
 function getEventInfo(input) {
   return input?.event?.properties?.info || input?.properties?.info || input?.info || null;
 }
@@ -68,38 +46,49 @@ function getEventSessionId(input, info) {
   return input?.event?.properties?.sessionID || input?.properties?.sessionID || input?.sessionID || info?.id || "";
 }
 
+function getSessionUpdate(input) {
+  const eventType = input?.event?.type || input?.type || "";
+  const info = getEventInfo(input);
+  return {
+    eventType,
+    info,
+    sessionID: getEventSessionId(input, info),
+    title: info?.title || "",
+  };
+}
+
+async function updateSessionTitle(client, sessionID, title) {
+  try {
+    await client.session.update({
+      path: { id: sessionID },
+      body: { title },
+    });
+  } catch (err) {
+    if (!client?.session?.update) throw err;
+    await client.session.update({
+      path: { sessionID },
+      body: { title },
+    });
+  }
+}
+
 export function createSessionTitleSuffixHandler({ agentsDir, client }) {
   const inFlight = new Set();
 
   return async function sessionTitleSuffixHandler(input) {
-    const eventType = input?.event?.type || input?.type || "";
+    const { eventType, sessionID, title } = getSessionUpdate(input);
     if (eventType !== "session.updated") return;
-
-    const info = getEventInfo(input);
-    const title = info?.title || "";
     if (!title) return;
 
     const version = readAidevopsVersion(agentsDir);
     const suffixedTitle = withAidevopsTitleSuffix(title, version);
     if (suffixedTitle === title) return;
 
-    const sessionID = getEventSessionId(input, info);
     if (!sessionID || inFlight.has(sessionID)) return;
 
     inFlight.add(sessionID);
     try {
-      try {
-        await client.session.update({
-          path: { id: sessionID },
-          body: { title: suffixedTitle },
-        });
-      } catch (err) {
-        if (!client?.session?.update) throw err;
-        await client.session.update({
-          path: { sessionID },
-          body: { title: suffixedTitle },
-        });
-      }
+      await updateSessionTitle(client, sessionID, suffixedTitle);
     } finally {
       inFlight.delete(sessionID);
     }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -7,9 +7,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  applyTitleAgentSuffix,
   createSessionTitleSuffixHandler,
-  isTitleAgentCompletion,
   readAidevopsVersion,
   withAidevopsTitleSuffix,
 } from "../session-title-suffix.mjs";
@@ -56,38 +54,6 @@ test("version reader prefers deployed agents VERSION", () => {
       assert.equal(readAidevopsVersion(agentsDir), "3.20.102");
     }),
   );
-});
-
-test("title agent completion gets version suffix", () => {
-  withoutEnvVersion(() =>
-    withTempAgentsDir((agentsDir) => {
-      writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
-      const output = { text: "Check live title capability" };
-
-      applyTitleAgentSuffix({ agent: "title" }, output, agentsDir);
-
-      assert.equal(output.text, "Check live title capability · AIDevOps 3.20.102");
-    }),
-  );
-});
-
-test("non-title completions are untouched", () => {
-  withTempAgentsDir((agentsDir) => {
-    writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
-    const output = { text: "Normal assistant output" };
-
-    applyTitleAgentSuffix({ agent: "build" }, output, agentsDir);
-
-    assert.equal(output.text, "Normal assistant output");
-  });
-});
-
-test("title agent detection accepts known hook shapes", () => {
-  assert.equal(isTitleAgentCompletion({ agent: "title" }), true);
-  assert.equal(isTitleAgentCompletion({ agentID: "title" }), true);
-  assert.equal(isTitleAgentCompletion({ agent: { id: "title" } }), true);
-  assert.equal(isTitleAgentCompletion({ agent: { name: "title" } }), true);
-  assert.equal(isTitleAgentCompletion({ agent: "build" }), false);
 });
 
 test("session.updated handler appends suffix through OpenCode session update API", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #25245 for #25227.
- Remove the obsolete `experimental.text.complete` title-agent suffix path because OpenCode initial titles are applied through `session.updated` / `Session.setTitle`.
- Split the session title suffix updater into smaller helpers to clear the Qlty smell regression while preserving the working `session.updated` path.

## Files and patterns
- `.agents/plugins/opencode-aidevops/session-title-suffix.mjs`: keeps the idempotent suffix application and `session.updated` handler.
- `.agents/plugins/opencode-aidevops/index.mjs`: wires only the event-based handler.
- `.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`: removes obsolete title-agent completion coverage and keeps event-path regressions.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `npx biome check .agents/plugins/opencode-aidevops/index.mjs .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`
- `npm run typecheck`
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/qlty-25227-followup.md` -> no regression, smell count 46 -> 45

## Notes
- Full `.agents/scripts/linters-local.sh` was attempted with a longer timeout; focused checks above passed, while the broad gate exceeded the session timeout during repository-wide ratchets after reporting only unrelated Markdown advisory findings.

For #25227

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.105 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
