### PR TITLE
fix: guard session title update api

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -64,7 +64,6 @@ async function updateSessionTitle(client, sessionID, title) {
       body: { title },
     });
   } catch (err) {
-    if (!client?.session?.update) throw err;
     await client.session.update({
       path: { sessionID },
       body: { title },
@@ -76,6 +75,8 @@ export function createSessionTitleSuffixHandler({ agentsDir, client }) {
   const inFlight = new Set();
 
   return async function sessionTitleSuffixHandler(input) {
+    if (typeof client?.session?.update !== "function") return;
+
     const { eventType, sessionID, title } = getSessionUpdate(input);
     if (eventType !== "session.updated") return;
     if (!title) return;

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -112,6 +112,25 @@ test("session.updated handler is idempotent when suffix already exists", async (
   });
 });
 
+test("session.updated handler ignores unavailable session update API", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");
+    const handler = createSessionTitleSuffixHandler({ agentsDir, client: { session: {} } });
+
+    await assert.doesNotReject(() =>
+      handler({
+        event: {
+          type: "session.updated",
+          properties: {
+            sessionID: "ses_test",
+            info: { id: "ses_test", title: "Unavailable update" },
+          },
+        },
+      }),
+    );
+  });
+});
+
 test("session.updated handler falls back to sessionID path shape", async () => {
   await withoutEnvVersion(() =>
     withTempAgentsDir(async (agentsDir) => {


### PR DESCRIPTION
## Summary
- Add an early guard so `createSessionTitleSuffixHandler` exits when `client.session.update` is unavailable.
- Keep the upstream `updateSessionTitle` helper refactor and remove its redundant update-API check.
- Add regression coverage for unavailable session update clients.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs` (pass: 6 tests after rebase)
- `npx --no-install secretlint .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs` (pass)
- `.agents/scripts/linters-local.sh` reached Secretlint twice but exceeded bounded 120s/240s timeouts after earlier gates passed

Resolves #25247
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.106 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 10m and 61,437 tokens on this as a headless worker.