### PR TITLE
fix: harden plugin debug error logging

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -294,7 +294,7 @@ export async function AidevopsPlugin({ directory, client }) {
 
   const debugEventError = (label, err) => {
     if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-      console.error(`[aidevops] ${label} error: ${err.message}`);
+      console.error(`[aidevops] ${label} error: ${err?.message ?? err}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Hardened the OpenCode aidevops plugin debug error helper so non-Error thrown values do not crash debug logging.

## Testing
- `node --check .agents/plugins/opencode-aidevops/index.mjs`
- `npm test -- --runInBand` (blocked locally: `bun` is not installed)

Resolves #25252

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.106 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
