### PR TITLE
GH#25264: fix: await session title test helpers

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -12,22 +12,22 @@ import {
   withAidevopsTitleSuffix,
 } from "../session-title-suffix.mjs";
 
-function withTempAgentsDir(fn) {
+async function withTempAgentsDir(fn) {
   const root = mkdtempSync(join(tmpdir(), "aidevops-title-suffix-"));
   const dir = join(root, "agents");
   mkdirSync(dir);
   try {
-    return fn(dir);
+    return await fn(dir);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 }
 
-function withoutEnvVersion(fn) {
+async function withoutEnvVersion(fn) {
   const saved = process.env.AIDEVOPS_VERSION;
   try {
     delete process.env.AIDEVOPS_VERSION;
-    return fn();
+    return await fn();
   } finally {
     if (saved === undefined) delete process.env.AIDEVOPS_VERSION;
     else process.env.AIDEVOPS_VERSION = saved;
@@ -45,8 +45,8 @@ test("title suffix appends and replaces idempotently", () => {
   );
 });
 
-test("version reader prefers deployed agents VERSION", () => {
-  withoutEnvVersion(() =>
+test("version reader prefers deployed agents VERSION", async () => {
+  await withoutEnvVersion(() =>
     withTempAgentsDir((agentsDir) => {
       writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
       writeFileSync(join(agentsDir, "..", "version"), "2.44.2\n");


### PR DESCRIPTION
## Summary

Refactored the session title suffix test helpers so temporary agent directories and AIDEVOPS_VERSION cleanup await asynchronous callbacks before finally cleanup runs.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs

Resolves #25264


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 34,114 tokens on this as a headless worker.