### PR TITLE
GH#25262: fix: preserve plugin debug error objects

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -294,7 +294,7 @@ export async function AidevopsPlugin({ directory, client }) {
 
   const debugEventError = (label, err) => {
     if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-      console.error(`[aidevops] ${label} error: ${err?.message ?? err}`);
+      console.error(`[aidevops] ${label} error:`, err);
     }
   };
 


### PR DESCRIPTION
## Summary

Changed plugin debug error logging to pass the original error as a separate console.error argument so Node can render stack traces and object details.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/plugins/opencode-aidevops/index.mjs; npm run typecheck attempted but failed because the environment cannot resolve the Bun type definition file

Resolves #25262


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 20,875 tokens on this as a headless worker.