### PR TITLE
GH#25269: docs: clarify runner ExecStop race guard

### DIFF
--- a/.agents/reference/github-self-hosted-runners.md
+++ b/.agents/reference/github-self-hosted-runners.md
@@ -115,10 +115,12 @@ the actual container start via `ExecStart`.
 
 `ExecStop` intentionally treats a missing container as success. Ephemeral runner
 containers are started with `docker run --rm`, so a completed job can remove the
-container before or during `ExecStop`. Run `docker stop` directly instead of
-checking first, then ignore only Docker's missing-container/object errors so
-other stop failures still surface. Escape literal percent signs as `%%` in the
-systemd unit so systemd does not treat shell `printf` formats as unit specifiers.
+container before or during `ExecStop`. Do not preflight with `docker inspect`:
+that reintroduces a time-of-check/time-of-use race between the existence check
+and the stop command. Run `docker stop` directly, then ignore only Docker's
+missing-container/object errors so other stop failures still surface. Escape
+literal percent signs as `%%` in the systemd unit so systemd does not treat shell
+`printf` formats as unit specifiers.
 
 The launch script should end by replacing the shell with a foreground Docker
 client, for example `exec docker run ...` without `-d` or `--detach`, rather


### PR DESCRIPTION
## Summary

Clarified that the runner systemd ExecStop command must not preflight with docker inspect because that reintroduces a TOCTOU race; the documented pattern runs docker stop directly and only ignores Docker missing-container/object errors.

## Files Changed

.agents/reference/github-self-hosted-runners.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; npx markdownlint-cli2 .agents/reference/github-self-hosted-runners.md

Resolves #25269


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 29,329 tokens on this as a headless worker.