### PR TITLE
GH#25260: docs: align GUI banned endpoint lists

### DIFF
--- a/docs/gui/adr-0002-trust-boundaries.md
+++ b/docs/gui/adr-0002-trust-boundaries.md
@@ -143,7 +143,8 @@ Allowed patterns:
 
 Banned patterns:
 
-- `POST /shell`, `POST /exec`, `POST /terminal`, `POST /run-command`, or any
+- `POST /shell`, `POST /exec`, `POST /terminal`, `POST /run`,
+  `POST /run-command`, or any
   equivalent arbitrary command endpoint.
 - Browser-provided command strings, helper names, shell flags, environment
   variables, working directories, or install commands.

--- a/docs/gui/threat-model.md
+++ b/docs/gui/threat-model.md
@@ -112,7 +112,8 @@ Allowed patterns:
 
 Banned patterns:
 
-- `POST /shell`, `POST /exec`, `POST /terminal`, `POST /run-command`, or any
+- `POST /shell`, `POST /exec`, `POST /terminal`, `POST /run`,
+  `POST /run-command`, or any
   equivalent arbitrary command endpoint.
 - Passing browser-provided helper names, flags, environment variables, paths,
   or command strings directly to a shell.


### PR DESCRIPTION
## Summary

Aligned the banned arbitrary command endpoint lists in docs/gui/threat-model.md and docs/gui/adr-0002-trust-boundaries.md so both include POST /run alongside shell, exec, terminal, and run-command.

## Files Changed

docs/gui/adr-0002-trust-boundaries.md,docs/gui/threat-model.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; .agents/scripts/linters-local.sh (Markdown/Secretlint/TOON and other completed gates passed before timeout during Shell Portability)

Resolves #25260


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 6m and 38,147 tokens on this as a headless worker.