### PR TITLE
GH#25266: fix: reuse shell env version dependency

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -82,11 +82,12 @@ function shellSessionOrigin(env) {
 
 /**
  * Create the shell environment hook.
- * @param {object} deps - { agentsDir, scriptsDir, workspaceDir }
+ * @param {object} deps - { agentsDir, scriptsDir, workspaceDir, version? }
  * @returns {Function} Shell env hook function
  */
 export function createShellEnvHook(deps) {
   const { agentsDir, scriptsDir, workspaceDir } = deps;
+  const precomputedVersion = typeof deps.version === "string" ? deps.version.trim() : "";
 
   /**
    * Inject aidevops environment variables into shell sessions.
@@ -110,6 +111,7 @@ export function createShellEnvHook(deps) {
     // Set aidevops version if available. Prefer the deployed framework version
     // source; ~/.aidevops/version is a legacy/stale compatibility fallback.
     const version =
+      precomputedVersion ||
       readIfExists(join(agentsDir, "VERSION")) ||
       readIfExists(join(agentsDir, "..", "VERSION")) ||
       readIfExists(join(agentsDir, "..", "version"));

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -40,6 +40,15 @@ function makeHookForAgentsDir(agentsDir) {
   });
 }
 
+function makeHookForAgentsDirAndVersion(agentsDir, version) {
+  return createShellEnvHook({
+    agentsDir,
+    scriptsDir: "/tmp/aidevops-scripts",
+    workspaceDir: "/tmp/aidevops-workspace",
+    version,
+  });
+}
+
 async function withCleanHeadlessProcessEnv(fn) {
   const keys = ["FULL_LOOP_HEADLESS", "AIDEVOPS_HEADLESS", "OPENCODE_HEADLESS", "GITHUB_ACTIONS"];
   const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
@@ -96,5 +105,18 @@ test("shell env version prefers deployed agents VERSION over legacy version", as
     await hook({ sessionID: "interactive-session" }, output);
 
     assert.equal(output.env.AIDEVOPS_VERSION, "3.20.102");
+  });
+});
+
+test("shell env version uses precomputed dependency before filesystem fallbacks", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
+
+    const hook = makeHookForAgentsDirAndVersion(agentsDir, "3.21.0\n");
+    const output = { env: { PATH: "/usr/bin:/bin" } };
+
+    await hook({ sessionID: "interactive-session" }, output);
+
+    assert.equal(output.env.AIDEVOPS_VERSION, "3.21.0");
   });
 });


### PR DESCRIPTION
## Summary

Updated the OpenCode shell env hook to accept an optional precomputed aidevops version dependency before falling back to VERSION file reads, and added regression coverage confirming the dependency takes precedence.

## Files Changed

.agents/plugins/opencode-aidevops/shell-env.mjs,.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/plugins/opencode-aidevops/shell-env.mjs && node --check .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs; node --test .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs; node --test .agents/plugins/opencode-aidevops/tests/*.mjs (259 tests passed); .agents/scripts/linters-local.sh reached the 240s worker-safe timeout during later portability checks after earlier checks completed

Resolves #25266


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 6m and 52,165 tokens on this as a headless worker.