### PR TITLE
GH#25261: docs: apply GUI ADR review feedback

### DIFF
--- a/docs/gui/adr-0001-product-scope-stack-repo-layout.md
+++ b/docs/gui/adr-0001-product-scope-stack-repo-layout.md
@@ -96,7 +96,7 @@ A separate repository would isolate GUI dependencies, but it would split product
 memory, helper contracts, tests, and issue context before the architecture is
 stable. The first implementation should live with the aidevops helpers it wraps.
 
-### Ad hoc root-level app files
+### Ad-hoc root-level app files
 
 Adding root-level `web/`, `api/`, or similar paths without a package policy would
 violate the repository root contract. Staged package subtrees with an explicit
@@ -123,7 +123,7 @@ Expected future package boundaries:
 ## Consequences
 
 - Phase 6 may begin coding the read-only local API and dashboard scaffold after
-  the security, data model, helper/API contract, and testing/CI ADRs are in
+  the security, data model, helper/API contract, and testing/CI/CD ADRs are in
   place.
 - First implementation work should call existing aidevops helpers rather than
   reimplementing helper logic inside the GUI.


### PR DESCRIPTION
## Summary

Updated the GUI scope/stack ADR to hyphenate the ad-hoc heading consistently and refer to testing/CI/CD ADRs.

## Files Changed

docs/gui/adr-0001-product-scope-stack-repo-layout.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; npx markdownlint-cli2 docs/gui/adr-0001-product-scope-stack-repo-layout.md; .agents/scripts/linters-local.sh progressed through Markdown with 0 style issues before timing out later in unrelated portability checks

Resolves #25261


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 8m and 17,090 tokens on this as a headless worker.