### PR TITLE
fix: use isolated OpenCode DB for session renames

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -23,6 +23,7 @@ import { join } from "node:path";
 const { isDefaultBranchTitle, isTitleOverwritable } = await import(
   "../../../.opencode/lib/session-rename-guards.ts"
 );
+const { getDbPath } = await import("../../../.opencode/lib/opencode-db-path.ts");
 const { getAidevopsVersion, withAidevopsTitleSuffix } = await import(
   "../../../.opencode/lib/session-title-suffix.ts"
 );
@@ -188,6 +189,19 @@ assertEq(
 process.env.AIDEVOPS_VERSION = "7.6.5";
 assertEq("env version override is read", "7.6.5", getAidevopsVersion());
 delete process.env.AIDEVOPS_VERSION;
+
+// --- OpenCode DB path helpers ------------------------------------------------
+console.log("\nGroup 5: OpenCode DB path helpers");
+assertEq(
+  "XDG_DATA_HOME selects isolated OpenCode DB",
+  "/tmp/aidevops-opencode/opencode/opencode.db",
+  getDbPath({ XDG_DATA_HOME: "/tmp/aidevops-opencode" }),
+);
+assertEq(
+  "OPENCODE_DB overrides XDG_DATA_HOME",
+  "/tmp/custom-opencode.db",
+  getDbPath({ OPENCODE_DB: "/tmp/custom-opencode.db", XDG_DATA_HOME: "/tmp/aidevops-opencode" }),
+);
 
 console.log("\n=== Results ===");
 console.log(`PASS: ${pass}`);

--- a/.opencode/lib/opencode-db-path.ts
+++ b/.opencode/lib/opencode-db-path.ts
@@ -1,0 +1,15 @@
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+/**
+ * Resolve the OpenCode SQLite database path.
+ * OpenCode stores sessions in ${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db.
+ * The OPENCODE_DB env var overrides the data-dir derived path.
+ */
+export function getDbPath(env = process.env): string {
+  if (env.OPENCODE_DB) {
+    return env.OPENCODE_DB
+  }
+  const dataHome = env.XDG_DATA_HOME || join(homedir(), ".local", "share")
+  return join(dataHome, "opencode", "opencode.db")
+}

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -1,22 +1,9 @@
 import { Database } from "bun:sqlite"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import { tool } from "@opencode-ai/plugin"
+import { getDbPath } from "../lib/opencode-db-path"
 import { isDefaultBranchTitle, isTitleOverwritable } from "../lib/session-rename-guards"
 import { withAidevopsTitleSuffix } from "../lib/session-title-suffix"
 import { emitTerminalTitle } from "../lib/terminal-title"
-
-/**
- * Resolve the OpenCode SQLite database path.
- * OpenCode stores sessions in ~/.local/share/opencode/opencode.db (Drizzle ORM).
- * The OPENCODE_DB env var overrides the default path.
- */
-function getDbPath(): string {
-  if (process.env.OPENCODE_DB) {
-    return process.env.OPENCODE_DB
-  }
-  return join(homedir(), ".local", "share", "opencode", "opencode.db")
-}
 
 /**
  * Rename a session by updating the title directly in the SQLite database.


### PR DESCRIPTION
## Summary
- Fixes the descriptive OpenCode session rename regression observed after adding the AIDevOps version suffix.
- Extracts OpenCode DB path resolution into `.opencode/lib/opencode-db-path.ts`.
- Makes `session-rename` respect `${XDG_DATA_HOME}/opencode/opencode.db` when `OPENCODE_DB` is not set, matching `aidevops opencode` isolated per-project DB launches.

## Root cause
`aidevops opencode` launches OpenCode with `XDG_DATA_HOME` pointed at an isolated per-project data dir. The `session-rename` tool still defaulted to `~/.local/share/opencode/opencode.db`, so the model-generated descriptive title was written to the shared/stale DB instead of the live session DB.

## Files and patterns
- `.opencode/tool/session-rename.ts`: imports the shared DB path resolver before writing the session title.
- `.opencode/lib/opencode-db-path.ts`: pure resolver for `OPENCODE_DB` override, then `XDG_DATA_HOME`, then legacy `~/.local/share` fallback.
- `.agents/scripts/tests/test-session-rename-ts.mjs`: regression coverage for isolated DB resolution and override precedence.

## Verification
- `bun run .agents/scripts/tests/test-session-rename-ts.mjs`
- `npm run typecheck`
- `npx biome check .opencode/tool/session-rename.ts .opencode/lib/opencode-db-path.ts .agents/scripts/tests/test-session-rename-ts.mjs`
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/qlty-session-rename-isolated-db.md` → no regression

For #25227.

Follow-up to #25249.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
