### PR TITLE
GH#25275: docs: adopt serve-sim codec fallback guidance

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1344,7 +1344,7 @@ setup_serve_sim() {
 	print_info "serve-sim streams booted Apple Simulators to a browser for agent/user review"
 	printf '%s\n' "  Features:"
 	printf '%s\n' "    - Browser preview at http://localhost:3200"
-	printf '%s\n' "    - MJPEG stream + WebSocket control channel"
+	printf '%s\n' "    - H.264/MJPEG stream with codec fallback + WebSocket control channel"
 	printf '%s\n' "    - Gestures, hardware buttons, typing, rotation, memory warnings"
 	printf '%s\n' "    - Camera feed injection for simulator apps"
 	printf '%s\n' ""

--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -112,7 +112,7 @@ aidevops keeps this native guide so mobile-testing tasks route to `serve-sim` ev
 - **No simulator**: Boot one first with Xcode Simulator, MiniSim, or `xcrun simctl boot <device>`.
 - **Node too old**: Upgrade to Node.js 18+ before running the CLI.
 - **Port collision**: Stop stale helpers with `serve-sim --kill`.
-- **H.264/WebCodecs instability**: Use the Stream → Codec picker or `--codec mjpeg`; recent versions auto-downgrade fatal AVCC decoder failures to MJPEG.
+- **H.264/WebCodecs instability**: Use the Stream → Codec picker or append `?codec=mjpeg` to the preview URL; recent versions auto-downgrade fatal AVCC decoder failures to MJPEG.
 - **Camera injection**: Requires macOS 14+ and a simulator app bundle ID.
 
 ## Related

--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -36,7 +36,7 @@ serve-sim type "hello"            # Type into focused field
 serve-sim --kill                  # Stop helper(s)
 ```
 
-Use `serve-sim` when the user needs a visible, browser-shareable simulator surface. Pair it with `agent-device`, `ios-simulator-mcp`, or `maestro` when the task needs accessibility refs, MCP tool calls, or repeatable E2E flows.
+Use `serve-sim` when the user needs a visible, browser-shareable simulator surface. Pair it with `agent-device`, `ios-simulator-mcp`, or `maestro` when the task needs accessibility refs, MCP tool calls, or repeatable E2E flows. The preview defaults to H.264 when available and can switch or auto-downgrade to MJPEG when hardware decoding is unstable during screen recording.
 
 <!-- AI-CONTEXT-END -->
 
@@ -70,6 +70,7 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 | Start daemon | `serve-sim --detach -q [device...]` | JSON output is safest for agents |
 | Stream only | `serve-sim --no-preview [device...]` | Foreground stream without React preview UI |
 | List streams | `serve-sim --list -q` | Use `-q` for machine-readable output |
+| Force compatibility stream | Open the preview with `?codec=mjpeg` or use Stream → Codec | Use MJPEG if H.264/WebCodecs stutters or fails while recording |
 | Stop helpers | `serve-sim --kill [device]` | Stop all or one device helper |
 | Gesture | `serve-sim gesture '<json>' [-d udid]` | Use documented JSON shape; avoid guessing coordinates |
 | Button | `serve-sim button home [-d udid]` | Hardware/home/app-switcher style controls |
@@ -86,7 +87,8 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 3. Parse only JSON/quiet output; do not scrape human-readable output.
 4. Surface the returned `url` to the user. If the current runtime exposes a preview/open-url tool, pass the URL there too.
 5. Use `agent-device snapshot` or `ios-simulator-mcp` for accessibility-aware targeting; use `serve-sim` for the shared visual stream and simulator-specific commands.
-6. Clean up with `serve-sim --kill` unless the user asks to keep the simulator stream running.
+6. If the browser preview stutters, drops frames, or reports an H.264 decoder failure while screen recording, switch the Stream → Codec control to MJPEG or append `?codec=mjpeg` to the preview URL.
+7. Clean up with `serve-sim --kill` unless the user asks to keep the simulator stream running.
 
 ## Expo / Dev Server Embedding
 
@@ -110,6 +112,7 @@ aidevops keeps this native guide so mobile-testing tasks route to `serve-sim` ev
 - **No simulator**: Boot one first with Xcode Simulator, MiniSim, or `xcrun simctl boot <device>`.
 - **Node too old**: Upgrade to Node.js 18+ before running the CLI.
 - **Port collision**: Stop stale helpers with `serve-sim --kill`.
+- **H.264/WebCodecs instability**: Use the Stream → Codec picker or `--codec mjpeg`; recent versions auto-downgrade fatal AVCC decoder failures to MJPEG.
 - **Camera injection**: Requires macOS 14+ and a simulator app bundle ID.
 
 ## Related


### PR DESCRIPTION
## Summary

Documented serve-sim H.264/MJPEG codec fallback behavior from upstream 9c38ca1 and updated setup messaging to describe codec fallback.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh,.agents/tools/mobile/serve-sim.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-tool-install-serve-sim.sh

Resolves #25275


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.0 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 73,648 tokens on this as a headless worker.