### PR TITLE
GH#25281: fix shell env hook deps fallback

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -86,8 +86,8 @@ function shellSessionOrigin(env) {
  * @returns {Function} Shell env hook function
  */
 export function createShellEnvHook(deps) {
-  const { agentsDir, scriptsDir, workspaceDir } = deps;
-  const precomputedVersion = typeof deps.version === "string" ? deps.version.trim() : "";
+  const { agentsDir = "", scriptsDir = "", workspaceDir = "", version } = deps || {};
+  const precomputedVersion = typeof version === "string" ? version.trim() : "";
 
   /**
    * Inject aidevops environment variables into shell sessions.

--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -110,11 +110,12 @@ export function createShellEnvHook(deps) {
 
     // Set aidevops version if available. Prefer the deployed framework version
     // source; ~/.aidevops/version is a legacy/stale compatibility fallback.
-    const version =
-      precomputedVersion ||
-      readIfExists(join(agentsDir, "VERSION")) ||
-      readIfExists(join(agentsDir, "..", "VERSION")) ||
-      readIfExists(join(agentsDir, "..", "version"));
+    const version = precomputedVersion ||
+      (agentsDir
+        ? readIfExists(join(agentsDir, "VERSION")) ||
+          readIfExists(join(agentsDir, "..", "VERSION")) ||
+          readIfExists(join(agentsDir, "..", "version"))
+        : "");
     if (version) {
       output.env.AIDEVOPS_VERSION = version;
     }

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -131,3 +131,24 @@ test("shell env hook tolerates missing dependency object", async () => {
     assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "interactive");
   });
 });
+
+test("shell env hook without agentsDir does not read VERSION from process cwd", async () => {
+  await withCleanHeadlessProcessEnv(async () => {
+    const root = mkdtempSync(join(tmpdir(), "aidevops-shell-env-cwd-"));
+    const previousCwd = process.cwd();
+    try {
+      writeFileSync(join(root, "VERSION"), "9.9.9-cwd\n");
+      process.chdir(root);
+
+      const hook = createShellEnvHook();
+      const output = { env: { PATH: "/usr/bin:/bin" } };
+
+      await hook({ sessionID: "interactive-session" }, output);
+
+      assert.equal(output.env.AIDEVOPS_VERSION, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -120,3 +120,14 @@ test("shell env version uses precomputed dependency before filesystem fallbacks"
     assert.equal(output.env.AIDEVOPS_VERSION, "3.21.0");
   });
 });
+
+test("shell env hook tolerates missing dependency object", async () => {
+  await withCleanHeadlessProcessEnv(async () => {
+    const hook = createShellEnvHook();
+    const output = { env: { PATH: "/usr/bin:/bin" } };
+
+    await hook({ sessionID: "interactive-session" }, output);
+
+    assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "interactive");
+  });
+});


### PR DESCRIPTION
## Summary
- Destructure the optional shell env `version` dependency through a safe fallback object.
- Default missing path dependencies to empty strings so `createShellEnvHook()` can be created and run without throwing.
- Add regression coverage for the missing dependency object path.

## Testing
- `npm test` from `.agents/plugins/opencode-aidevops`

Resolves #25281

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.1 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 89,262 tokens on this as a headless worker. Overall, 8m since this issue was created.
