### PR TITLE
GH#25286: fix: guard shell env version lookup

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -23,6 +23,16 @@ function readIfExists(filepath) {
 }
 
 /**
+ * Return true when the agents directory is usable for deterministic framework
+ * file lookups.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function hasAgentsDir(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/**
  * Extract the current OpenCode session ID from hook input variants.
  * @param {object} input
  * @returns {string}
@@ -111,7 +121,7 @@ export function createShellEnvHook(deps) {
     // Set aidevops version if available. Prefer the deployed framework version
     // source; ~/.aidevops/version is a legacy/stale compatibility fallback.
     const version = precomputedVersion ||
-      (agentsDir
+      (hasAgentsDir(agentsDir)
         ? readIfExists(join(agentsDir, "VERSION")) ||
           readIfExists(join(agentsDir, "..", "VERSION")) ||
           readIfExists(join(agentsDir, "..", "version"))

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -152,3 +152,24 @@ test("shell env hook without agentsDir does not read VERSION from process cwd", 
     }
   });
 });
+
+test("shell env hook with blank agentsDir does not read VERSION from process cwd", async () => {
+  await withCleanHeadlessProcessEnv(async () => {
+    const root = mkdtempSync(join(tmpdir(), "aidevops-shell-env-blank-cwd-"));
+    const previousCwd = process.cwd();
+    try {
+      writeFileSync(join(root, "VERSION"), "9.9.9-cwd\n");
+      process.chdir(root);
+
+      const hook = makeHookForAgentsDir("   ");
+      const output = { env: { PATH: "/usr/bin:/bin" } };
+
+      await hook({ sessionID: "interactive-session" }, output);
+
+      assert.equal(output.env.AIDEVOPS_VERSION, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Guard shell env VERSION fallback behind a non-blank agentsDir check and add regression coverage for blank agentsDir values so cwd VERSION files are not read.

## Files Changed

.agents/plugins/opencode-aidevops/shell-env.mjs,.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs

Resolves #25286


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.1 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 1m and 46,631 tokens on this as a headless worker.