### PR TITLE
fix: fallback session title from first prompt

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -36,6 +36,7 @@ import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
+import { createSessionTitleFallbackHandler } from "./session-title-fallback.mjs";
 import { createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
 
 // Existing modules
@@ -291,6 +292,10 @@ export async function AidevopsPlugin({ directory, client }) {
     agentsDir: AGENTS_DIR,
     client,
   });
+  const sessionTitleFallbackHandler = createSessionTitleFallbackHandler({
+    agentsDir: AGENTS_DIR,
+    client,
+  });
 
   const debugEventError = (label, err) => {
     if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
@@ -330,6 +335,7 @@ export async function AidevopsPlugin({ directory, client }) {
       await Promise.all([
         handleEvent(input),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
+        sessionTitleFallbackHandler(input).catch((err) => debugEventError("title fallback handler", err)),
         greetingHandler(input).catch((err) => debugEventError("greeting handler", err)),
       ]);
     },

--- a/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { readAidevopsVersion, withAidevopsTitleSuffix } from "./session-title-suffix.mjs";
+
+const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
+const DEFAULT_SESSION_TITLE_RE = /^New session - /;
+const URL_RE = /https?:\/\/\S+/g;
+const TITLE_MAX_LENGTH = 72;
+
+export function isDefaultSessionTitle(title) {
+  const baseTitle = String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, "").trim();
+  return DEFAULT_SESSION_TITLE_RE.test(baseTitle) || baseTitle === "New Session";
+}
+
+function firstPromptLine(prompt) {
+  return (
+    String(prompt || "")
+      .replace(URL_RE, " ")
+      .split("\n")
+      .map((value) => value.trim())
+      .find((value) => value.length > 0) || "OpenCode session"
+  );
+}
+
+function cleanedTitleLine(line) {
+  const cleaned = line
+    .replace(/^(i'd like to|i would like to|please|can you|could you)\s+/i, "")
+    .replace(/[.?!:;,]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned || "OpenCode session";
+}
+
+function titleCaseFirstWord(text) {
+  return text.replace(/^([a-z])/, (letter) => letter.toUpperCase());
+}
+
+function trimTitle(text) {
+  return text.length <= TITLE_MAX_LENGTH ? text : `${text.slice(0, TITLE_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+export function deriveFallbackTitleFromPrompt(prompt) {
+  return trimTitle(titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt))));
+}
+
+function getEventType(input) {
+  return input?.event?.type || input?.type || "";
+}
+
+function getProperties(input) {
+  return input?.event?.properties || input?.properties || input || {};
+}
+
+function getInfo(input) {
+  return getProperties(input).info || input?.info || null;
+}
+
+function getSessionId(input, info) {
+  const properties = getProperties(input);
+  if (properties.sessionID) return properties.sessionID;
+  if (input?.sessionID) return input.sessionID;
+  if (info?.sessionID) return info.sessionID;
+  return info?.id || "";
+}
+
+function getPart(input) {
+  return getProperties(input).part || null;
+}
+
+function isUserMessageEvent(input) {
+  const info = getInfo(input);
+  if (!getEventType(input).startsWith("message.updated")) return false;
+  return info?.role === "user";
+}
+
+function isTextPartEvent(input) {
+  const part = getPart(input);
+  if (!getEventType(input).startsWith("message.part.updated")) return false;
+  if (part?.type !== "text") return false;
+  return Boolean(part.text?.trim());
+}
+
+async function updateSessionTitle(client, sessionID, title) {
+  try {
+    await client.session.update({ path: { id: sessionID }, body: { title } });
+  } catch {
+    await client.session.update({ path: { sessionID }, body: { title } });
+  }
+}
+
+function rememberTitle(input, sessionTitles) {
+  const info = getInfo(input);
+  const eventType = getEventType(input);
+  if (!eventType.startsWith("session.")) return;
+  if (!info?.title) return;
+  sessionTitles.set(getSessionId(input, info), info.title);
+}
+
+function rememberUserMessage(input, userMessagesBySession) {
+  const info = getInfo(input);
+  const sessionID = getSessionId(input, info);
+  const messages = userMessagesBySession.get(sessionID) || new Set();
+  if (isUserMessageEvent(input) && info?.id) messages.add(info.id);
+  if (messages.size > 0) userMessagesBySession.set(sessionID, messages);
+}
+
+function shouldApplyFallback(input, sessionTitles, userMessagesBySession, fallbackDone) {
+  const part = getPart(input);
+  const sessionID = part?.sessionID || getSessionId(input, null);
+  const userMessages = userMessagesBySession.get(sessionID);
+  const currentTitle = sessionTitles.get(sessionID) || "";
+  if (!isTextPartEvent(input)) return false;
+  if (!userMessages?.has(part?.messageID)) return false;
+  if (fallbackDone.has(sessionID)) return false;
+  return isDefaultSessionTitle(currentTitle);
+}
+
+export function createSessionTitleFallbackHandler({ agentsDir, client }) {
+  const sessionTitles = new Map();
+  const userMessagesBySession = new Map();
+  const fallbackDone = new Set();
+
+  return async function sessionTitleFallbackHandler(input) {
+    if (typeof client?.session?.update !== "function") return;
+    rememberTitle(input, sessionTitles);
+    rememberUserMessage(input, userMessagesBySession);
+    if (!shouldApplyFallback(input, sessionTitles, userMessagesBySession, fallbackDone)) return;
+
+    const part = getPart(input);
+    const sessionID = part.sessionID || getSessionId(input, null);
+    const version = readAidevopsVersion(agentsDir);
+    const title = withAidevopsTitleSuffix(deriveFallbackTitleFromPrompt(part.text), version);
+    await updateSessionTitle(client, sessionID, title);
+    sessionTitles.set(sessionID, title);
+    fallbackDone.add(sessionID);
+  };
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -11,6 +11,11 @@ import {
   readAidevopsVersion,
   withAidevopsTitleSuffix,
 } from "../session-title-suffix.mjs";
+import {
+  createSessionTitleFallbackHandler,
+  deriveFallbackTitleFromPrompt,
+  isDefaultSessionTitle,
+} from "../session-title-fallback.mjs";
 
 async function withTempAgentsDir(fn) {
   const root = mkdtempSync(join(tmpdir(), "aidevops-title-suffix-"));
@@ -43,6 +48,22 @@ test("title suffix appends and replaces idempotently", () => {
     withAidevopsTitleSuffix("Investigate title path · AIDevOps 3.20.101", "3.20.102"),
     "Investigate title path · AIDevOps 3.20.102",
   );
+});
+
+test("default session title detection ignores AIDevOps suffix", () => {
+  assert.equal(isDefaultSessionTitle("New session - 2026-06-20T21:27:42.505Z"), true);
+  assert.equal(isDefaultSessionTitle("New session - 2026-06-20T21:27:42.505Z · AIDevOps 3.21.2"), true);
+  assert.equal(isDefaultSessionTitle("Study newsjack repository capabilities · AIDevOps 3.21.2"), false);
+});
+
+test("fallback title derives concise title from first meaningful prompt line", () => {
+  assert.equal(
+    deriveFallbackTitleFromPrompt(`https://github.com/elvisun/newsjack
+
+i'd like to add the capabilities this repo offers. there may be overlap`),
+    "Add the capabilities this repo offers. there may be overlap",
+  );
+  assert.equal(deriveFallbackTitleFromPrompt("please review PR #123"), "Review PR #123");
 });
 
 test("version reader prefers deployed agents VERSION", async () => {
@@ -164,4 +185,86 @@ test("session.updated handler falls back to sessionID path shape", async () => {
       });
     }),
   );
+});
+
+test("message part fallback replaces stuck New session title", async () => {
+  await withoutEnvVersion(() =>
+    withTempAgentsDir(async (agentsDir) => {
+      writeFileSync(join(agentsDir, "VERSION"), "3.21.2\n");
+      const calls = [];
+      const client = { session: { update: async (payload) => calls.push(payload) } };
+      const handler = createSessionTitleFallbackHandler({ agentsDir, client });
+
+      await handler({
+        event: {
+          type: "session.updated",
+          properties: {
+            sessionID: "ses_test",
+            info: { id: "ses_test", title: "New session - 2026-06-20T21:27:42.505Z" },
+          },
+        },
+      });
+      await handler({
+        event: {
+          type: "message.updated",
+          properties: {
+            sessionID: "ses_test",
+            info: { id: "msg_user", sessionID: "ses_test", role: "user" },
+          },
+        },
+      });
+      await handler({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "ses_test",
+            part: {
+              sessionID: "ses_test",
+              messageID: "msg_user",
+              type: "text",
+              text: "please study the newsjack repository capabilities",
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(calls.at(-1), {
+        path: { id: "ses_test" },
+        body: { title: "Study the newsjack repository capabilities · AIDevOps 3.21.2" },
+      });
+    }),
+  );
+});
+
+test("message part fallback preserves meaningful session title", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.21.2\n");
+    const calls = [];
+    const client = { session: { update: async (payload) => calls.push(payload) } };
+    const handler = createSessionTitleFallbackHandler({ agentsDir, client });
+
+    await handler({
+      event: {
+        type: "session.updated",
+        properties: { sessionID: "ses_test", info: { id: "ses_test", title: "Existing title · AIDevOps 3.21.2" } },
+      },
+    });
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { sessionID: "ses_test", info: { id: "msg_user", sessionID: "ses_test", role: "user" } },
+      },
+    });
+    await handler({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_test",
+          part: { sessionID: "ses_test", messageID: "msg_user", type: "text", text: "please replace me" },
+        },
+      },
+    });
+
+    assert.deepEqual(calls, []);
+  });
 });


### PR DESCRIPTION
For #25227

## Summary
- add an OpenCode session title fallback handler that derives a concise title from the first user prompt when OpenCode leaves a session at `New session ...`
- keep the existing AIDevOps version suffix handler separate and idempotent
- add regression coverage for default-title detection, prompt-title derivation, fallback replacement, and preserving meaningful titles

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `npx biome check .agents/plugins/opencode-aidevops/index.mjs .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/session-title-fallback.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`
- `npm run typecheck`
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/qlty-session-title-fallback.md` → base 45, head 45, delta 0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.2 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
