### PR TITLE
For #25229: unblock child dispatch from parent footprints

### DIFF
--- a/.agents/scripts/dispatch-dedup-footprint.sh
+++ b/.agents/scripts/dispatch-dedup-footprint.sh
@@ -98,7 +98,9 @@ _footprint_extract_paths() {
 # "In-flight" = issue has an active status label (status:in-progress,
 # status:in-review, status:claimed) which indicates a worker is currently
 # processing it. Issues with status:queued are not yet dispatched and
-# don't count.
+# don't count. Parent-task issues are coordination containers, not worker
+# implementation claims, so their broad planning footprints do not block
+# worker-ready child dispatch.
 #
 # Returns a newline-separated list of "file|issue_number" pairs.
 # Uses a TTL-based cache to avoid repeated API calls within a pulse cycle.
@@ -140,15 +142,15 @@ _footprint_get_inflight() {
 
 	# Launch all 3 queries in parallel
 	(gh issue list --repo "$repo_slug" --label "status:in-progress" --state open \
-		--json number,body --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/in-progress.json" &
+		--json number,body,labels --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/in-progress.json" &
 	local _fp_pid1=$!
 
 	(gh issue list --repo "$repo_slug" --label "status:in-review" --state open \
-		--json number,body --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/in-review.json" &
+		--json number,body,labels --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/in-review.json" &
 	local _fp_pid2=$!
 
 	(gh issue list --repo "$repo_slug" --label "status:claimed" --state open \
-		--json number,body --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/claimed.json" &
+		--json number,body,labels --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/claimed.json" &
 	local _fp_pid3=$!
 
 	# Wait for all to complete
@@ -176,9 +178,14 @@ _footprint_get_inflight() {
 	local cache_data=""
 	local i=0
 	while [[ "$i" -lt "$issue_count" ]]; do
-		local num body paths
+		local num body is_parent_task paths
 		num=$(printf '%s' "$all_inflight" | jq -r ".[$i].number // empty" 2>/dev/null)
 		body=$(printf '%s' "$all_inflight" | jq -r ".[$i].body // empty" 2>/dev/null)
+		is_parent_task=$(printf '%s' "$all_inflight" | jq -r ".[$i] | any((.labels // [])[]?; .name == \"parent-task\")" 2>/dev/null) || is_parent_task="false"
+		if [[ "$is_parent_task" == "true" ]]; then
+			i=$((i + 1))
+			continue
+		fi
 
 		if [[ -n "$num" && -n "$body" ]]; then
 			paths=$(_footprint_extract_paths "$body")

--- a/.agents/scripts/tests/test-dispatch-footprint-overlap.sh
+++ b/.agents/scripts/tests/test-dispatch-footprint-overlap.sh
@@ -197,6 +197,47 @@ else
 fi
 
 # =============================================================================
+# Test 9 — _footprint_get_inflight excludes parent-task coordination footprints
+# =============================================================================
+TEST_BIN="${TEST_ROOT}/bin"
+mkdir -p "$TEST_BIN"
+cat >"${TEST_BIN}/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+label=""
+while [[ "$#" -gt 0 ]]; do
+	case "${1:-}" in
+		--label)
+			shift
+			label="${1:-}"
+			;;
+	esac
+	shift || true
+done
+
+if [[ "$label" == "status:in-review" ]]; then
+	printf '%s\n' '[{"number":400,"body":"## Files to Modify\n- `EDIT: docs/gui/control-plane.md`","labels":[{"name":"status:in-review"},{"name":"parent-task"}]},{"number":401,"body":"## Files to Modify\n- `EDIT: .agents/scripts/pulse-wrapper.sh`","labels":[{"name":"status:in-review"}]}]'
+else
+	printf '[]\n'
+fi
+MOCK_GH
+chmod +x "${TEST_BIN}/gh"
+
+OLD_PATH="$PATH"
+PATH="${TEST_BIN}:$PATH"
+_FOOTPRINT_CACHE_REPO=""
+_FOOTPRINT_CACHE_DATA=""
+_FOOTPRINT_CACHE_EPOCH=0
+
+result=$(_footprint_get_inflight "test/repo" "999")
+PATH="$OLD_PATH"
+if printf '%s' "$result" | grep -q "pulse-wrapper.sh|401" &&
+	! printf '%s' "$result" | grep -q "docs/gui/control-plane.md|400"; then
+	print_result "get_inflight: excludes parent-task coordination footprints" 0
+else
+	print_result "get_inflight: excludes parent-task coordination footprints" 1 "(got: ${result})"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo ""


### PR DESCRIPTION
## Summary

- Exclude `parent-task` coordination issues from the footprint in-flight set.
- Request issue labels in footprint lookups so parent-task blockers can be identified.
- Add regression coverage for parent-task footprints while preserving real same-file worker throttling.

## Evidence

- Recent Pulse log: #25232 was eligible, then deferred by `FOOTPRINT_OVERLAP (issue=#25229 files=docs/gui/control-plane.md)`.
- Patched live check: `_footprint_check_overlap 25232 marcusquinn/aidevops` returned `rc=1`, meaning no overlap after excluding parent-task coordination footprints.

## Verification

- `bash .agents/scripts/tests/test-dispatch-footprint-overlap.sh`
- `bash .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh`
- `bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh`
- `bash .agents/scripts/tests/test-dispatch-min-concurrency.sh`
- `shellcheck -S warning .agents/scripts/dispatch-dedup-footprint.sh .agents/scripts/tests/test-dispatch-footprint-overlap.sh`
- `.agents/scripts/lint-shell-portability.sh --summary`
- `git diff --check origin/main...HEAD`

For #25229
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.4 with gpt-5.5 spent 5h 38m and 3,315,859 tokens on this with the user in an interactive session.