### PR TITLE
fix: avoid default title suffix race

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
+const DEFAULT_SESSION_TITLE_RE = /^New session - /;
 
 function readIfExists(filepath) {
   try {
@@ -36,6 +37,17 @@ export function withAidevopsTitleSuffix(title, version) {
   const baseTitle = String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, "");
   if (!version) return baseTitle;
   return `${baseTitle} · AIDevOps ${version}`;
+}
+
+function isDefaultSessionTitle(title) {
+  const baseTitle = String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, "").trim();
+  return DEFAULT_SESSION_TITLE_RE.test(baseTitle) || baseTitle === "New Session";
+}
+
+function shouldSuffixSessionTitle(update) {
+  if (update.eventType !== "session.updated") return false;
+  if (!update.title) return false;
+  return !isDefaultSessionTitle(update.title);
 }
 
 function getEventInfo(input) {
@@ -77,21 +89,20 @@ export function createSessionTitleSuffixHandler({ agentsDir, client }) {
   return async function sessionTitleSuffixHandler(input) {
     if (typeof client?.session?.update !== "function") return;
 
-    const { eventType, sessionID, title } = getSessionUpdate(input);
-    if (eventType !== "session.updated") return;
-    if (!title) return;
+    const update = getSessionUpdate(input);
+    if (!shouldSuffixSessionTitle(update)) return;
 
     const version = readAidevopsVersion(agentsDir);
-    const suffixedTitle = withAidevopsTitleSuffix(title, version);
-    if (suffixedTitle === title) return;
+    const suffixedTitle = withAidevopsTitleSuffix(update.title, version);
+    if (suffixedTitle === update.title) return;
 
-    if (!sessionID || inFlight.has(sessionID)) return;
+    if (!update.sessionID || inFlight.has(update.sessionID)) return;
 
-    inFlight.add(sessionID);
+    inFlight.add(update.sessionID);
     try {
-      await updateSessionTitle(client, sessionID, suffixedTitle);
+      await updateSessionTitle(client, update.sessionID, suffixedTitle);
     } finally {
-      inFlight.delete(sessionID);
+      inFlight.delete(update.sessionID);
     }
   };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -133,6 +133,36 @@ test("session.updated handler is idempotent when suffix already exists", async (
   });
 });
 
+test("session.updated handler ignores default titles so stale updates do not overwrite fallback titles", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.21.4\n");
+    const calls = [];
+    const client = { session: { update: async (payload) => calls.push(payload) } };
+    const handler = createSessionTitleSuffixHandler({ agentsDir, client });
+
+    await handler({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_test",
+          info: { id: "ses_test", title: "New session - 2026-06-20T22:54:09.982Z" },
+        },
+      },
+    });
+    await handler({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_test",
+          info: { id: "ses_test", title: "New session - 2026-06-20T22:54:09.982Z · AIDevOps 3.21.4" },
+        },
+      },
+    });
+
+    assert.deepEqual(calls, []);
+  });
+});
+
 test("session.updated handler ignores unavailable session update API", async () => {
   await withTempAgentsDir(async (agentsDir) => {
     writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");


### PR DESCRIPTION
For #25227

## Summary
- prevent the suffix handler from appending AIDevOps versions to default `New session ...` placeholder titles
- leave default titles to OpenCode's native title generator or the first-prompt fallback handler
- add a regression test for stale default title updates so they cannot overwrite a fallback title like `Hi · AIDevOps 3.21.4`

## Evidence
- live OpenCode DB for `ses_118c229c1ffeTLYGgxo2l7kXUr` showed fallback first updated the title to `Hi · AIDevOps 3.21.4`
- a later stale `session.updated` event carried `New session - ...`, and the suffix handler overwrote the meaningful fallback title back to `New session - ... · AIDevOps 3.21.4`

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `npx biome check .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/session-title-fallback.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`
- `npm run typecheck`
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/qlty-title-race.md` → base 45, head 45, delta 0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.4 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
