### PR TITLE
t3610: add GUI resource graph ADR

### DIFF
--- a/docs/gui/adr-0003-resource-graph.md
+++ b/docs/gui/adr-0003-resource-graph.md
@@ -1,0 +1,292 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# ADR 0003: GUI data model and infrastructure resource graph
+
+## Status
+
+Accepted for planning. Implementation remains gated by migrations, schemas, and
+schema tests described below.
+
+## Context
+
+The aidevops GUI/control plane must help users understand and operate across
+identities, provider accounts, resources, projects, machines, routines,
+bookmarks, capabilities, integrations, task capsules, and audit events. The
+initial product is local-first, uses SQLite for local storage, and keeps existing
+aidevops helpers, git platforms, and provider systems as sources of truth where
+they already own state.
+
+The core design risk is overfitting the first database to one provider, one
+hosting style, or one secret backend. The app needs to model domains, DNS, git,
+hosting, email, messaging, social media, VPNs, proxies, servers, containers,
+orchestrators, operating-system/device fleets, server apps, git runners,
+provider bookmarks, affiliate metadata, CalDAV/CardDAV integrations, routines,
+and machine delegation without centralizing credentials.
+
+## Decision
+
+Use a typed resource graph with generic core entities and validated metadata
+extensions.
+
+The accepted core entities are:
+
+- `Identity`
+- `Provider`
+- `Account`
+- `Resource`
+- `Machine`
+- `Project`
+- `Routine`
+- `Bookmark`
+- `Capability`
+- `Integration`
+- `TaskCapsule`
+- `AuditEvent`
+
+The GUI will separate provider, account, resource, project, routine, and machine
+records. Provider-specific details will be stored in schema-validated metadata
+objects keyed by entity type, resource/provider type, provider slug, and schema
+version. Secrets will be represented only by secret references and non-sensitive
+health states.
+
+Relationships between entities will be stored as typed graph edges or link
+tables rather than one provider-specific table per resource family. The graph is
+the primary model for cross-domain views such as “which routines touch this
+domain,” “which machine can run this git runner,” or “which CalDAV collection is
+safe for this agent to read.”
+
+## Resource graph scope
+
+The graph must support these resource families from the first schema plan:
+
+- Domains, registrars, DNS zones, DNS records, and DNS providers.
+- GitHub, GitLab, Gitea, Forgejo, repositories, organizations, apps, and git
+  runners.
+- Hosting, VPS providers, servers, serverless apps, object storage, databases,
+  CDNs, backups, and monitoring resources.
+- Email domains, mailboxes, aliases, SMTP/IMAP services, and mailing lists.
+- Messaging accounts, messaging groups, social profiles, social pages, and social
+  apps.
+- VPN networks, VPN nodes, proxies, tunnels, and overlay networks as transport
+  resources rather than authorization grants.
+- Physical servers, VMs, laptops, desktops, mobile devices, and tablets.
+- Container hosts, containers, compose stacks, images, volumes, and container
+  networks.
+- Orchestrators such as Cloudron, Coolify, Ubicloud, Kubernetes, Nomad, and
+  similar app platforms.
+- Operating systems and device fleets including macOS, Windows, Ubuntu, Arch,
+  Omarchy, iOS, Android, GrapheneOS, package managers, and update channels.
+- Server apps such as Nextcloud, Collabora, pastebin apps, Docuseal, Postiz,
+  EspoCRM, Odoo, Vaultwarden, Fider, Gitea, Forgejo, and other self-hosted apps.
+- Calendar/contact resources for CalDAV/CardDAV services, collections, local
+  sync clients, service-account boundaries, and allowed routine/agent access.
+- Local aidevops/OpenCode installs, helper sets, session logs, runtime status,
+  and machines with available compute.
+- AI/agent resources such as agent runtimes, model providers, model accounts,
+  knowledge repositories, and task queues.
+
+## Relationship examples
+
+The graph supports these relationship patterns:
+
+- An `Identity` owns an `Account` at a `Provider`.
+- An `Account` administers a `Resource`.
+- A `domain` resource delegates to one or more `dns_zone` resources.
+- A `dns_zone` contains `dns_record` resources that point to hosting, email, or
+  verification resources.
+- A `Project` references a `git_repo` resource and can use domains, apps,
+  routines, and machines.
+- A `git_runner` resource is backed by a `Machine` and scoped to one or more
+  projects or repos.
+- A `server` runs containers, app resources, proxies, VPN nodes, and backup
+  routines.
+- A `cloudron_instance` owns app resources, domains, backups, update channels,
+  and provider/account links.
+- A `nextcloud_app` exposes `calendar_service` and `contacts_service` resources.
+- A `caldav` or `carddav` `Integration` links an account, app resource, secret
+  refs, collections, local sync clients, and routines with read/write scopes.
+- A `Routine` reads or writes resources and uses secret references through
+  helper adapters.
+- A `Machine` can run routines, OpenCode sessions, git runners, and scoped task
+  capsules.
+- A `TaskCapsule` delegates limited actions from one machine to another with
+  expiry, replay protection, and audit requirements.
+- A `Bookmark` recommends a `Provider` and may include future affiliate metadata
+  as content metadata.
+- An `AuditEvent` records a non-secret action on any graph target.
+
+These relationships make provider-specific dashboards possible without making
+provider-specific data the core model.
+
+## Provider-specific metadata
+
+Core columns should represent identity, ownership, health, trust scope, and
+graph relationships. Provider-specific values belong in validated metadata.
+
+Metadata schema keys should follow this pattern:
+
+```text
+<entity>.<resource_or_provider_type>.<provider_slug>.<version>
+```
+
+Examples:
+
+- `resource.dns_zone.cloudflare.v1`
+- `resource.git_repo.github.v1`
+- `resource.server_app.cloudron.v1`
+- `integration.caldav.nextcloud.v1`
+- `bookmark.provider_catalog.generic.v1`
+
+Metadata may include provider IDs, non-secret endpoint references, product tiers,
+regions, feature flags, plan names, sync direction, collection references,
+backup policy, and adapter hints. It must not include API tokens, passwords,
+private keys, recovery codes, raw credential files, cookie values, or logs that
+may contain secrets.
+
+Unknown metadata extension versions should be preserved for read-only display
+and export, but write paths must validate or migrate them before mutation.
+
+## Provider bookmarks and affiliate metadata
+
+Provider bookmarks are first-class content records, not operational accounts.
+The graph will support providers that are recommended, experimental, avoided,
+user-owned, or unknown before any account is connected.
+
+Bookmark metadata may include setup guide references, pros/cons, tags, price
+bands, open-source/privacy/freedom scores, region notes, helper references,
+verification references, and future affiliate references. Affiliate data is
+content metadata and disclosure context; it is not a secret, not a provider API
+credential, and not authorization for operations.
+
+## CalDAV/CardDAV and local app integrations
+
+Calendar and contact support is modeled through `Integration` plus resource
+records for services, collections, address books, and local sync clients.
+
+The model must represent:
+
+- Nextcloud Calendar/Contacts and other CalDAV/CardDAV providers.
+- Service-account boundaries and account ownership.
+- Credential references and health state only.
+- Local macOS/iOS/Android/desktop sync clients.
+- Which routines and agents may read or write each calendar or address book.
+- Sync status, last check, failure class, and setup guide references.
+
+This keeps the calendar/contact model compatible with local apps and hosted
+providers without special-casing one calendar service in the core schema.
+
+## Routine and machine delegation support
+
+Routine records link scheduler/source definitions to resources, projects,
+machines, secret refs, run history, and audit events. The source of truth remains
+existing routine definitions and scheduler helpers until a later ADR changes it.
+
+Machine delegation is modeled through `Machine`, `TaskCapsule`, `Capability`,
+and `AuditEvent` records. A task capsule must include issuer and target machine
+identity, repo/project/resource scope, allowed action classes, risk ceiling,
+expiry, replay protection, human-approval requirements where needed, and result
+evidence. A capsule does not grant arbitrary shell access and must be enforced by
+the target machine.
+
+## Secret handling decision
+
+The GUI data model stores secret references, not secret values. Any entity may
+link to `secret_refs` that identify the backend, secret name/ID, purpose, health
+state, last check time, and rotation/check helper reference. The GUI may show
+configured/missing/invalid/unknown states and setup guidance. It must not load,
+persist, render, export, diff, or audit raw secret values.
+
+## Migration and schema-test requirements
+
+Before implementation introduces write flows for this model, it must add:
+
+- SQLite migrations for persisted core entities and relationship/link tables.
+- Deterministic migration ordering and fixture upgrade tests.
+- Schema validation for core entities, resource types, metadata extensions, and
+  secret references.
+- Fixtures for domains/DNS, git repos/runners, hosting/server/container,
+  Cloudron/server apps, provider bookmarks, CalDAV/CardDAV, routines, local
+  apps, machines, task capsules, and audit events.
+- Tests proving API responses and audit records do not include secret values.
+- Tests preserving unknown metadata extensions as read-only data until migrated.
+- Tests rejecting metadata payloads with wrong provider, wrong version, missing
+  required fields, or secret-shaped values.
+
+The first read-only dashboard may use transient projections, but persistent
+mutations require migrations and schema tests first.
+
+## Alternatives considered
+
+### One table per provider
+
+Provider-specific tables would make the first provider integration simple, but
+they would duplicate ownership, secret handling, health, audit, and relationship
+logic. This would not scale across DNS, git, Cloudron, CalDAV/CardDAV, local
+apps, and machine delegation.
+
+### Free-form JSON inventory only
+
+An unstructured JSON inventory would be flexible, but it would make schema
+tests, migrations, redaction, relationship queries, and API contracts weak. The
+accepted model allows provider metadata extensions while keeping core entities
+and relationships typed.
+
+### Treat provider accounts as resources
+
+Flattening accounts into resources would blur identity, billing, MFA, recovery,
+and blast-radius boundaries. The model keeps provider, account, and resource
+separate so the GUI can explain who owns an account, what it can administer, and
+which resources depend on it.
+
+### Treat machines as generic resources only
+
+Machines are resources, but they also enforce local authority and accept future
+task capsules. Keeping a separate `Machine` entity avoids mixing compute posture,
+identity keys, scopes, heartbeats, and delegation state into ordinary resources.
+
+## Consequences
+
+Positive consequences:
+
+- The model covers the initial infrastructure families without committing to one
+  provider or secret backend.
+- Provider bookmarks and future affiliate metadata fit as content records.
+- CalDAV/CardDAV, routines, local apps, and machine delegation share the same
+  graph primitives as domains, git, hosting, and server apps.
+- Secret redaction can be tested at the schema/API boundary.
+- Future package code can generate OpenAPI/JSON Schema contracts from typed
+  schemas.
+
+Costs and trade-offs:
+
+- Implementation needs relationship/link tables and metadata schemas before
+  meaningful write flows.
+- Provider adapters must map external IDs into generic graph entities.
+- Query design is more complex than a small provider-specific dashboard.
+- Migration discipline is required from the first persistent schema.
+
+## Repo layout policy impact
+
+This ADR only adds documentation under `docs/gui/`, which is already an allowed
+planning surface. Future code packages for schemas, migrations, tests, and API
+contracts must follow ADR 0001 and update repo-layout policy before adding new
+top-level package paths.
+
+## Verification
+
+Run:
+
+```bash
+git diff --check
+npx --yes markdownlint-cli2@0.22.0 docs/gui/data-model.md docs/gui/adr-0003-resource-graph.md
+```
+
+## Related
+
+- `docs/gui/control-plane.md`
+- `docs/gui/data-model.md`
+- `docs/gui/adr-0001-product-scope-stack-repo-layout.md`
+- `docs/gui/adr-0002-trust-boundaries.md`
+- Issue #25232
+- Parent issue #25229

--- a/docs/gui/data-model.md
+++ b/docs/gui/data-model.md
@@ -1,0 +1,465 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# GUI data model
+
+This document expands the data sketch in `docs/gui/control-plane.md` into the
+first implementation contract for the aidevops GUI/control plane. It is a
+planning artifact for future `packages/gui-core` schemas, SQLite migrations, API
+contracts, and fixtures.
+
+The model is intentionally generic. Providers, accounts, resources, projects,
+routines, machines, bookmarks, capabilities, integrations, task capsules, and
+audit events are separate entities so the GUI can describe mixed infrastructure
+without becoming provider-specific or secret-bearing.
+
+## Design goals
+
+- Model local-first aidevops status, infrastructure inventory, provider
+  bookmarks, routines, calendar/contact integrations, and machine delegation.
+- Keep git platforms, aidevops helpers, scheduler definitions, and provider
+  APIs as sources of truth where they already own state.
+- Store secret references and health signals only, never secret values, partial
+  values, raw credential files, copied clipboard contents, or secret-bearing
+  logs.
+- Prefer stable IDs, typed categories, and validated metadata extensions over
+  provider-specific tables.
+- Make provider-specific details queryable and testable without coupling the
+  core graph to one vendor.
+- Make future migrations and schema tests mandatory before write flows.
+
+## Core entities
+
+### Identity
+
+An `Identity` represents the human, business, team, automation role, service, or
+recovery owner behind accounts and machines.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `name`: display name.
+- `identity_type`: `person`, `business`, `team`, `automation`, `service`, or
+  `recovery`.
+- `trust_level`: local trust label such as `owner`, `admin`, `operator`,
+  `limited`, or `unknown`.
+- `recovery_notes_ref`: reference to non-secret recovery notes.
+- `status`: `active`, `suspended`, `retired`, or `unknown`.
+- `created_at`, `updated_at`.
+
+Identity records do not store private keys, passphrases, recovery codes, or raw
+identity documents.
+
+### Provider
+
+A `Provider` describes an external or local provider family. It is not an
+account and it is not a resource instance.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `name`: provider name.
+- `provider_type`: typed category such as `dns`, `registrar`, `git`, `hosting`,
+  `email`, `messaging`, `social`, `vpn`, `proxy`, `cloud`, `orchestrator`,
+  `server_app`, `calendar`, `contacts`, `ai_model`, `local_app`, or `other`.
+- `homepage_ref`: URL/reference string from trusted setup data.
+- `recommendation_status`: `recommended`, `experimental`, `avoided`,
+  `user_owned`, or `unknown`.
+- `notes_ref`: setup notes or documentation reference.
+- `metadata_json`: provider bookmark and adapter metadata validated by schema.
+- `created_at`, `updated_at`.
+
+Provider entries can exist before any account is connected so the GUI can render
+provider bookmarks and setup guidance.
+
+### Account
+
+An `Account` links an identity to a provider account, tenant, org, workspace,
+email inbox, social profile, or local app profile.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `identity_id`: owning `Identity`.
+- `provider_id`: provider for the account.
+- `account_type`: `personal`, `business`, `admin`, `billing`, `automation`,
+  `service`, `recovery`, `workspace`, or `unknown`.
+- `display_name_ref`: non-secret display reference.
+- `username_ref`: username/email/profile reference; redact where needed.
+- `secret_refs`: names or IDs in aidevops secrets, gopass, Vaultwarden, OS
+  keychain, or provider-native secret storage.
+- `mfa_status`: `configured`, `missing`, `unknown`, or `not_applicable`.
+- `recovery_status`: `configured`, `missing`, `unknown`, or `not_applicable`.
+- `blast_radius`: local risk note or enum.
+- `status`: `active`, `needs_attention`, `disabled`, `retired`, or `unknown`.
+- `metadata_json`: validated account-specific extensions.
+- `created_at`, `updated_at`.
+
+`secret_refs` must identify where a secret lives, not reveal the secret.
+
+### Resource
+
+A `Resource` is any infrastructure object, app, service, namespace, endpoint,
+or managed asset that can be related to accounts, projects, routines, and
+machines.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `resource_type`: category from the resource taxonomy below.
+- `provider_id`: optional provider link.
+- `account_id`: optional account link.
+- `owner_identity_id`: owning identity where it differs from the account.
+- `name`: local display name.
+- `environment`: `local`, `dev`, `staging`, `prod`, `personal`, `client`,
+  `shared`, or `unknown`.
+- `purpose`: concise non-secret purpose.
+- `status`: `healthy`, `degraded`, `missing`, `disabled`, `retired`, or
+  `unknown`.
+- `health_status`: last known health summary.
+- `update_status`: update/posture summary.
+- `backup_status`: backup summary.
+- `trust_scope`: permitted operation scope.
+- `allowed_operations`: read/write/destructive capability labels.
+- `secret_refs`: linked secret references only.
+- `metadata_json`: schema-validated resource extension.
+- `notes_ref`, `setup_guide_ref`, `verification_ref`.
+- `created_at`, `updated_at`, `last_seen_at`.
+
+The core resource row stays small. Provider-specific fields live in
+`metadata_json` and must have a schema keyed by `resource_type` and provider.
+
+### Machine
+
+A `Machine` represents local or paired compute that can run aidevops, OpenCode,
+helpers, runners, routines, or delegated task capsules.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `resource_id`: backing `Resource` when the machine is also a server, laptop,
+  VM, container host, or runner.
+- `machine_identity_pubkey`: public identity key only.
+- `display_name`.
+- `os_family`: `macos`, `windows`, `ubuntu`, `arch`, `omarchy`, `ios`,
+  `android`, `grapheneos`, `linux_other`, or `unknown`.
+- `capabilities`: capability labels such as `opencode`, `aidevops`,
+  `git_runner`, `cloudron_admin`, `docker`, `podman`, `calendar_sync`, or
+  `contacts_sync`.
+- `scopes`: repo, project, routine, resource, and action scopes granted to the
+  machine.
+- `heartbeat_status`, `last_seen_at`, `safe_disable_state`.
+- `metadata_json`: hardware, runtime, scheduler, or local app metadata.
+- `created_at`, `updated_at`.
+
+Machines own local enforcement. A hosted control plane records grants and audit
+evidence but does not inherit unlimited machine authority.
+
+### Project
+
+A `Project` maps GUI inventory to git and aidevops project state.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `git_remote`: remote URL/reference.
+- `repo_slug`: provider repo slug where available.
+- `repos_json_ref`: source row or path reference from `repos.json`.
+- `owner_identity_id`.
+- `provider_id`, `account_id`.
+- `status`: `active`, `paused`, `archived`, `missing`, or `unknown`.
+- `linked_resources`, `linked_routines`, `linked_capabilities`.
+- `metadata_json`: issue/PR source, default branch, managed-repo flags, or
+  worker-policy metadata.
+- `created_at`, `updated_at`, `last_indexed_at`.
+
+Git hosts remain source of truth for issues, PRs, branches, and collaboration.
+The GUI stores references and projections, not a second issue tracker.
+
+### Routine
+
+A `Routine` describes scheduled or manually triggered aidevops operations.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `source_ref`: TODO/routine definition, command doc, helper config, or
+  scheduler reference.
+- `schedule`: cron/launchd/systemd/Cloudron schedule reference where applicable.
+- `runner_type`: `script`, `agent`, `helper`, `local_app`, or `external`.
+- `enabled_state`: `enabled`, `disabled`, `paused`, or `unknown`.
+- `next_run_at`, `last_run_at`, `last_duration_ms`.
+- `last_result`: `success`, `failed`, `skipped`, `cancelled`, or `unknown`.
+- `failure_reason_ref`: non-secret evidence pointer.
+- `linked_resources`, `linked_projects`, `linked_services`.
+- `linked_secret_refs`.
+- `metadata_json`: retry policy, output retention, or LLM-backed agent metadata.
+- `created_at`, `updated_at`.
+
+Routine definitions and scheduler helpers remain canonical until a later ADR
+changes that contract.
+
+### Bookmark
+
+A `Bookmark` stores provider recommendation and catalog content.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `provider_id`.
+- `category`: provider category or use-case category.
+- `recommendation`: `recommended`, `experimental`, `avoided`, `owned`, or
+  `unknown`.
+- `affiliate_ref`: optional reference to affiliate metadata, not an operational
+  credential.
+- `price_band`, `privacy_score`, `open_source_score`, `freedom_score`.
+- `rationale`: concise editorial rationale.
+- `pros`, `cons`, `tags`.
+- `setup_guide_ref`, `helper_ref`, `verification_ref`.
+- `metadata_json`: validated content metadata such as region or supported
+  products.
+- `created_at`, `updated_at`.
+
+Affiliate metadata must be treated as content metadata. It may include campaign
+IDs or disclosure references later, but it must not be mixed with secret refs or
+provider API credentials.
+
+### Capability
+
+A `Capability` is a discoverable aidevops ability surfaced by agents, services,
+tools, workflows, helpers, or skills.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `name`, `summary`.
+- `capability_type`: `agent`, `tool`, `service`, `workflow`, `helper`, `skill`,
+  `integration`, or `other`.
+- `doc_ref`, `agent_ref`, `service_ref`, `helper_ref`.
+- `setup_requirements`.
+- `verification_refs`.
+- `required_secret_refs`: names only.
+- `linked_providers`, `linked_resources`, `linked_routines`.
+- `metadata_json`.
+- `created_at`, `updated_at`, `last_indexed_at`.
+
+The GUI should store concise summaries and references, not duplicate long agent
+instructions.
+
+### Integration
+
+An `Integration` links an account/resource pair to a concrete external protocol,
+local app, or helper-managed connection.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `integration_type`: `github`, `gitlab`, `gitea`, `forgejo`, `cloudron`,
+  `coolify`, `caldav`, `carddav`, `imap`, `smtp`, `xmpp`, `xmtp`, `nostr`,
+  `nextcloud`, `local_calendar`, `local_contacts`, `local_app`, `vpn`,
+  `proxy`, or `other`.
+- `account_id`, `resource_id`.
+- `secret_refs`: credential references only.
+- `health_status`, `last_checked_at`.
+- `read_scope`, `write_scope`.
+- `metadata_json`: protocol endpoint references, collection IDs, sync direction,
+  or adapter details.
+- `created_at`, `updated_at`.
+
+CalDAV/CardDAV support should model calendars, address books, sync health,
+service-account boundaries, and which routines or agents may read or write each
+collection.
+
+### TaskCapsule
+
+A `TaskCapsule` represents future scoped delegation between machines.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `issuer_machine_id`, `target_machine_id`.
+- `repo_scope`, `project_scope`, `resource_scope`.
+- `allowed_actions`: helper/action IDs and risk ceiling.
+- `human_approval_requirement`.
+- `expires_at`, `not_before_at`, `revoked_at`.
+- `nonce_ref` or replay-protection reference.
+- `audit_ref`, `result_ref`.
+- `status`: `issued`, `accepted`, `running`, `completed`, `failed`, `expired`,
+  or `revoked`.
+- `metadata_json`: signed envelope metadata.
+- `created_at`, `updated_at`.
+
+Capsules are not bearer tokens for arbitrary shell access. They must be scoped,
+expiring, replay-protected, and enforced locally by the target machine.
+
+### AuditEvent
+
+An `AuditEvent` records non-secret evidence about reads, writes, confirmations,
+delegation, and helper/API outcomes.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `actor_ref`: user, identity, machine, session, or task capsule reference.
+- `machine_id`.
+- `origin_ip_ref`: redacted or local-only network reference where useful.
+- `action`: operation identifier.
+- `target_ref`: target entity reference.
+- `risk_class`: `read`, `write`, `destructive`, or `delegated`.
+- `confirmation_ref`: confirmation evidence pointer for high-risk actions.
+- `result`: `success`, `failed`, `blocked`, `cancelled`, or `unknown`.
+- `redacted_metadata`: structured non-secret evidence.
+- `created_at`.
+
+Audit events must not contain credential values, private repo names intended for
+public export, raw command output with secrets, or private key material.
+
+## Resource taxonomy
+
+`Resource.resource_type` should be broad enough to cover the initial families in
+`docs/gui/control-plane.md` while keeping room for provider-specific metadata.
+
+| Family | Resource types | Relationship examples |
+|--------|----------------|-----------------------|
+| Domains and DNS | `domain`, `registrar_account`, `dns_zone`, `dns_record`, `dns_provider_zone` | A `domain` is registered through a registrar `Account`, delegates to one or more `dns_zone` resources, and links to hosting/email resources. |
+| Git platforms | `git_host`, `git_org`, `git_repo`, `git_runner`, `git_app`, `git_token_scope` | A `Project` references a `git_repo`; a `git_runner` is also a `Machine` or linked to one; account metadata stores role and 2FA state. |
+| Hosting and cloud | `hosting_account`, `vps`, `server`, `serverless_app`, `object_bucket`, `database`, `cdn_property` | A `server` belongs to a hosting account, runs containers/apps, and links to backup and monitoring resources. |
+| Email | `email_domain`, `mailbox`, `smtp_service`, `imap_service`, `mailing_list`, `email_alias` | An email account links an identity to mail resources and may provide recovery channels for other accounts. |
+| Messaging and social | `messaging_account`, `messaging_group`, `social_profile`, `social_page`, `social_app` | A social profile belongs to an identity/account and can link to routines for posting or monitoring. |
+| VPNs and proxies | `vpn_network`, `vpn_node`, `proxy_service`, `tunnel`, `overlay_network` | VPN or proxy resources model transport and reachability, not authorization. Allowed operations remain on accounts/machines. |
+| Servers and devices | `physical_server`, `vm`, `laptop`, `desktop`, `mobile_device`, `tablet`, `iot_device` | Device resources can back `Machine` records and expose OS, posture, backup, and compute capability metadata. |
+| Containers | `container_host`, `container`, `compose_stack`, `image`, `volume`, `network` | A container host runs containers and volumes; app resources link to their deployment container. |
+| Orchestrators | `cloudron_instance`, `coolify_instance`, `ubicloud_project`, `kubernetes_cluster`, `nomad_cluster`, `orchestrator_app` | Orchestrator instances own app resources, deployment targets, backups, domains, and secrets by reference. |
+| Operating systems and fleets | `os_install`, `device_fleet`, `mdm_profile`, `package_manager`, `update_channel` | Machines link to OS resources for update health, capabilities, and support policy. |
+| Server apps | `nextcloud_app`, `collabora_app`, `pastebin_app`, `docuseal_app`, `postiz_app`, `espocrm_app`, `odoo_app`, `vaultwarden_app`, `fider_app`, `gitea_app`, `forgejo_app`, `server_app_other` | App resources link to domains, databases, object stores, secret refs, projects, routines, and backups. |
+| Calendar and contacts | `calendar_service`, `calendar_collection`, `contacts_service`, `address_book`, `sync_client` | CalDAV/CardDAV integrations link accounts, collections, local apps, routines, and secret refs. |
+| Local aidevops and OpenCode | `aidevops_install`, `opencode_runtime`, `session_log`, `helper_set`, `config_file` | A local machine owns runtime resources, helper capability records, routine state, and session references. |
+| AI and agent systems | `agent_runtime`, `model_provider`, `model_account`, `knowledge_repo`, `task_queue` | Capabilities link to providers/accounts while model/API secrets stay as references. |
+
+Relationships should be stored through typed link tables rather than embedded
+arrays once implementation begins. A link should include source entity, target
+entity, relation type, evidence/source reference, and timestamps.
+
+## Relationship patterns
+
+Use typed relationships to avoid hard-coding provider assumptions:
+
+- `Identity owns Account`.
+- `Account belongs_to Provider`.
+- `Account administers Resource`.
+- `Resource depends_on Resource`.
+- `Resource exposes Integration`.
+- `Resource backs Machine`.
+- `Machine can_run Routine`.
+- `Machine accepts TaskCapsule`.
+- `Project uses Resource`.
+- `Project references git_repo Resource`.
+- `Routine reads/writes Resource`.
+- `Routine uses secret_ref`.
+- `Capability documents Integration`.
+- `Bookmark recommends Provider`.
+- `AuditEvent records action_on target`.
+
+Example: a Cloudron-hosted Nextcloud calendar setup can be represented as one
+`Provider` for Cloudron, one `Account` for the Cloudron admin, a
+`cloudron_instance` resource, a `nextcloud_app` resource, `calendar_service` and
+`contacts_service` resources, `caldav` and `carddav` integrations, local
+`sync_client` resources on devices, and routines that read/write selected
+collections through scoped secret references.
+
+Example: a git runner can be represented as a `git_runner` resource linked to a
+`Machine`, a `Project`, a git provider `Account`, allowed repo scopes, and audit
+events for dispatch, execution, and result upload.
+
+## Provider-specific metadata extensions
+
+Provider-specific fields belong in validated metadata objects, not in new core
+columns for each provider. The implementation should define schemas by a stable
+extension key:
+
+```text
+metadata_schema_key = <entity>.<resource_or_provider_type>.<provider_slug>.<version>
+```
+
+Examples:
+
+- `resource.dns_zone.cloudflare.v1` for Cloudflare zone IDs and plan metadata.
+- `resource.git_repo.github.v1` for repo node IDs, visibility, and default
+  branch projections.
+- `integration.caldav.nextcloud.v1` for collection references, sync direction,
+  and safe read/write scope.
+- `resource.server_app.cloudron.v1` for app ID, domain ref, backup policy, and
+  update channel.
+- `bookmark.provider_catalog.generic.v1` for price band, region, affiliate
+  disclosure reference, and recommendation rationale.
+
+Extension rules:
+
+- Metadata must be JSON-serializable and schema-validated at write time.
+- Metadata may store provider IDs, non-secret endpoint references, product tiers,
+  regions, feature flags, and timestamps.
+- Metadata must not store API tokens, passwords, private keys, recovery codes,
+  cookie values, SSH private keys, or secret-bearing logs.
+- Metadata fields that may reveal sensitive local paths, private repo names, or
+  client identifiers need local-only export controls before sync or public issue
+  generation.
+- Unknown extension versions should be preserved for read-only display but not
+  mutated until migrated or validated.
+
+## Secret reference contract
+
+Every entity that needs credentials uses a `secret_refs` array or equivalent
+link table. A secret reference should contain:
+
+- Secret name or external secret ID.
+- Backend type such as `aidevops`, `gopass`, `vaultwarden`, `os_keychain`,
+  `provider_native`, or `unknown`.
+- Purpose label such as `api_token`, `oauth_client`, `ssh_key`, `password`,
+  `caldav_password`, or `webhook_secret`.
+- Health state and last checked timestamp.
+- Rotation/check helper reference where available.
+
+The GUI may show configured/missing/invalid/unknown states and next-step setup
+guidance. It must not retrieve, persist, render, export, or diff raw secret
+values.
+
+## Migration expectations
+
+Future implementation should treat the schema as an explicit product contract:
+
+- Add SQLite migrations for every persisted table, index, and link table.
+- Use stable migration IDs and deterministic ordering.
+- Include forward migrations before introducing routes that write the new data.
+- Preserve unknown provider metadata when migrating known core fields.
+- Include fixture migrations for representative local-only, Cloudron, git,
+  provider-bookmark, CalDAV/CardDAV, routine, and machine-delegation examples.
+- Provide rollback or recovery guidance for destructive schema changes, even if
+  SQLite rollback migrations are not automated initially.
+- Require exported backups before migrations that delete or rewrite user-owned
+  annotations.
+
+The first read-only dashboard may index transient projections, but any write
+flow must have migration coverage before release.
+
+## Schema-test expectations
+
+Future `packages/gui-core` tests should prove:
+
+- Required entities validate with minimal fixtures.
+- Each resource family listed above has at least one valid fixture.
+- Provider-specific metadata accepts valid fixtures and rejects wrong provider or
+  wrong version payloads.
+- Secret refs validate without exposing secret values.
+- API response fixtures redact secret-bearing fields.
+- Relationship fixtures can express domains/DNS, git runners, Cloudron apps,
+  CalDAV/CardDAV, routines, local apps, and task capsules.
+- Unknown metadata extension versions are preserved read-only.
+- Migration tests upgrade fixtures from the previous schema version.
+- Audit event tests reject raw secret values in metadata and logs.
+
+## Related documents
+
+- `docs/gui/control-plane.md`
+- `docs/gui/adr-0001-product-scope-stack-repo-layout.md`
+- `docs/gui/adr-0002-trust-boundaries.md`
+- `docs/gui/adr-0003-resource-graph.md`


### PR DESCRIPTION
## Summary

- Added `docs/gui/data-model.md` with the GUI control-plane entity model, resource taxonomy, relationship patterns, provider metadata extension rules, secret-reference contract, and migration/schema-test expectations.
- Added `docs/gui/adr-0003-resource-graph.md` accepting the typed resource graph decision for identities, accounts, providers, resources, projects, routines, machines, bookmarks, capabilities, integrations, task capsules, and audit events.

## Testing

- `git diff --check`
- `npx --yes markdownlint-cli2@0.22.0 docs/gui/data-model.md docs/gui/adr-0003-resource-graph.md`

Resolves #25232

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.5 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
