### PR TITLE
fix: delay session title fallback

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
@@ -7,6 +7,7 @@ const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
 const URL_RE = /https?:\/\/\S+/g;
 const TITLE_MAX_LENGTH = 72;
+const FALLBACK_DELAY_MS = 12000;
 
 export function isDefaultSessionTitle(title) {
   const baseTitle = String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, "").trim();
@@ -97,6 +98,22 @@ function rememberTitle(input, sessionTitles) {
   sessionTitles.set(getSessionId(input, info), info.title);
 }
 
+function clearPendingFallback(sessionID, pendingFallbacks) {
+  const pending = pendingFallbacks.get(sessionID);
+  if (!pending) return;
+  clearTimeout(pending);
+  pendingFallbacks.delete(sessionID);
+}
+
+function clearFallbackWhenTitleIsMeaningful(input, sessionTitles, pendingFallbacks, fallbackDone) {
+  const info = getInfo(input);
+  const sessionID = getSessionId(input, info);
+  const currentTitle = sessionTitles.get(sessionID) || "";
+  if (!sessionID || isDefaultSessionTitle(currentTitle)) return;
+  clearPendingFallback(sessionID, pendingFallbacks);
+  fallbackDone.add(sessionID);
+}
+
 function rememberUserMessage(input, userMessagesBySession) {
   const info = getInfo(input);
   const sessionID = getSessionId(input, info);
@@ -116,23 +133,41 @@ function shouldApplyFallback(input, sessionTitles, userMessagesBySession, fallba
   return isDefaultSessionTitle(currentTitle);
 }
 
-export function createSessionTitleFallbackHandler({ agentsDir, client }) {
+async function applyFallbackTitle(deps, sessionID, prompt) {
+  const currentTitle = deps.sessionTitles.get(sessionID) || "";
+  if (!isDefaultSessionTitle(currentTitle)) return;
+  const version = readAidevopsVersion(deps.agentsDir);
+  const title = withAidevopsTitleSuffix(deriveFallbackTitleFromPrompt(prompt), version);
+  await updateSessionTitle(deps.client, sessionID, title);
+  deps.sessionTitles.set(sessionID, title);
+  deps.fallbackDone.add(sessionID);
+}
+
+function scheduleFallback(input, deps) {
+  const part = getPart(input);
+  const sessionID = part.sessionID || getSessionId(input, null);
+  clearPendingFallback(sessionID, deps.pendingFallbacks);
+  const timer = setTimeout(() => {
+    deps.pendingFallbacks.delete(sessionID);
+    applyFallbackTitle(deps, sessionID, part.text).catch(() => {});
+  }, deps.fallbackDelayMs);
+  timer.unref?.();
+  deps.pendingFallbacks.set(sessionID, timer);
+}
+
+export function createSessionTitleFallbackHandler({ agentsDir, client, fallbackDelayMs = FALLBACK_DELAY_MS }) {
   const sessionTitles = new Map();
   const userMessagesBySession = new Map();
   const fallbackDone = new Set();
+  const pendingFallbacks = new Map();
 
   return async function sessionTitleFallbackHandler(input) {
     if (typeof client?.session?.update !== "function") return;
     rememberTitle(input, sessionTitles);
+    clearFallbackWhenTitleIsMeaningful(input, sessionTitles, pendingFallbacks, fallbackDone);
     rememberUserMessage(input, userMessagesBySession);
     if (!shouldApplyFallback(input, sessionTitles, userMessagesBySession, fallbackDone)) return;
 
-    const part = getPart(input);
-    const sessionID = part.sessionID || getSessionId(input, null);
-    const version = readAidevopsVersion(agentsDir);
-    const title = withAidevopsTitleSuffix(deriveFallbackTitleFromPrompt(part.text), version);
-    await updateSessionTitle(client, sessionID, title);
-    sessionTitles.set(sessionID, title);
-    fallbackDone.add(sessionID);
+    scheduleFallback(input, { agentsDir, client, fallbackDelayMs, fallbackDone, pendingFallbacks, sessionTitles });
   };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -39,6 +39,10 @@ async function withoutEnvVersion(fn) {
   }
 }
 
+function waitForTimer(ms = 5) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 test("title suffix appends and replaces idempotently", () => {
   assert.equal(
     withAidevopsTitleSuffix("Investigate title path", "3.20.102"),
@@ -223,7 +227,7 @@ test("message part fallback replaces stuck New session title", async () => {
       writeFileSync(join(agentsDir, "VERSION"), "3.21.2\n");
       const calls = [];
       const client = { session: { update: async (payload) => calls.push(payload) } };
-      const handler = createSessionTitleFallbackHandler({ agentsDir, client });
+      const handler = createSessionTitleFallbackHandler({ agentsDir, client, fallbackDelayMs: 1 });
 
       await handler({
         event: {
@@ -257,6 +261,7 @@ test("message part fallback replaces stuck New session title", async () => {
           },
         },
       });
+      await waitForTimer();
 
       assert.deepEqual(calls.at(-1), {
         path: { id: "ses_test" },
@@ -264,6 +269,46 @@ test("message part fallback replaces stuck New session title", async () => {
       });
     }),
   );
+});
+
+test("message part fallback waits for native title generation before replacing default title", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.21.6\n");
+    const calls = [];
+    const client = { session: { update: async (payload) => calls.push(payload) } };
+    const handler = createSessionTitleFallbackHandler({ agentsDir, client, fallbackDelayMs: 5 });
+
+    await handler({
+      event: {
+        type: "session.updated",
+        properties: { sessionID: "ses_test", info: { id: "ses_test", title: "New session - 2026-06-20T23:27:52.727Z" } },
+      },
+    });
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { sessionID: "ses_test", info: { id: "msg_user", sessionID: "ses_test", role: "user" } },
+      },
+    });
+    await handler({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_test",
+          part: { sessionID: "ses_test", messageID: "msg_user", type: "text", text: "please check pulse and workers" },
+        },
+      },
+    });
+    await handler({
+      event: {
+        type: "session.updated",
+        properties: { sessionID: "ses_test", info: { id: "ses_test", title: "Worker status check" } },
+      },
+    });
+    await waitForTimer(10);
+
+    assert.deepEqual(calls, []);
+  });
 });
 
 test("message part fallback preserves meaningful session title", async () => {


### PR DESCRIPTION
For #25227

## Summary
- delay the first-prompt fallback title update so OpenCode's native AI session title generator can run first
- cancel/skip the fallback when a meaningful session title arrives before the delay expires
- keep the fallback as a rescue path for sessions that remain at `New session ...`

## Evidence
- live session `ses_118a34c68ffevl46j32D2c0yFM` showed fallback setting `Pluse and workers status check please · AIDevOps 3.21.6` at event sequence 4, before OpenCode could generate an AI summary
- this reproduced the user-visible regression where titles became prompt-derived instead of AI-summary-style titles

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs`
- `npx biome check .agents/plugins/opencode-aidevops/session-title-fallback.mjs .agents/plugins/opencode-aidevops/session-title-suffix.mjs .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`
- `npm run typecheck`
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/qlty-title-fallback-delay.md` → base 45, head 45, delta 0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.6 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5
