### PR TITLE
fix: refresh opencode main agent discovery

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -204,6 +204,14 @@ _get_extra_tools() {
 	return 0
 }
 
+_yaml_quote_scalar() {
+	local value="$1"
+	value="${value//\\/\\\\}"
+	value="${value//\"/\\\"}"
+	printf '"%s"' "$value"
+	return 0
+}
+
 # GH#18509: Copy source verbatim (with model-name normalisation) when the
 # agent's frontmatter sets bash: false — it is security-sandboxed or has its
 # own tool restrictions and must not be overwritten with a permissive stub.
@@ -238,10 +246,12 @@ _write_permissive_stub() {
 	local src_desc="$2"
 	local rel_path="$3"
 	local extra_tools="$4"
+	local quoted_desc
+	quoted_desc=$(_yaml_quote_scalar "$src_desc")
 	{
 		printf '%s\n' \
 			"---" \
-			"description: ${src_desc}" \
+			"description: ${quoted_desc}" \
 			"mode: subagent" \
 			"temperature: 0.2" \
 			"permission:" \
@@ -279,7 +289,7 @@ generate_subagent_stub() {
 	return 0
 }
 
-export -f generate_subagent_stub _get_subagent_description _get_extra_tools _write_sandboxed_agent _write_permissive_stub 2>/dev/null || true
+export -f generate_subagent_stub _get_subagent_description _get_extra_tools _yaml_quote_scalar _write_sandboxed_agent _write_permissive_stub 2>/dev/null || true
 export AGENTS_DIR
 export OPENCODE_AGENT_DIR
 

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -254,6 +254,17 @@ _get_subagent_extra_tools() {
 	return 0
 }
 
+# Quote a scalar for YAML frontmatter. OpenCode parses agent frontmatter as
+# YAML; an unquoted description containing ':' can make the whole block invalid,
+# which can cause a subagent stub to appear in the primary tab cycle.
+_yaml_quote_scalar() {
+	local value="$1"
+	value="${value//\\/\\\\}"
+	value="${value//\"/\\\"}"
+	printf '"%s"' "$value"
+	return 0
+}
+
 # Write a single subagent markdown stub file.
 # Arguments: $1 - source .md file path
 # Requires: AGENTS_DIR and agent_dir to be set (exported for xargs usage)
@@ -299,10 +310,13 @@ _write_subagent_stub() {
 	local extra_tools
 	extra_tools=$(_get_subagent_extra_tools "$name")
 
+	local quoted_desc
+	quoted_desc=$(_yaml_quote_scalar "$src_desc")
+
 	{
 		printf '%s\n' \
 			"---" \
-			"description: ${src_desc}" \
+			"description: ${quoted_desc}" \
 			"mode: subagent" \
 			"temperature: 0.2" \
 			"permission:" \
@@ -414,6 +428,7 @@ _generate_subagents_opencode() {
 	_clean_generated_subagents "$agent_dir"
 
 	export -f _get_subagent_extra_tools 2>/dev/null || true
+	export -f _yaml_quote_scalar 2>/dev/null || true
 	export -f _write_subagent_stub 2>/dev/null || true
 	export AGENTS_DIR
 	export agent_dir

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -99,7 +99,8 @@ _SKIP_CACHE=false
 RUNTIME_CACHE_HASH_FILE_PREFIX="${AGENTS_DIR}/.runtime-config-source-hash"
 
 # Compute a stable hash of all files the generator reads.
-# Includes: the script itself + all source .md/.toml/.json files under AGENTS_DIR.
+# Includes: the script itself + source .md/.toml/.json files and generator
+# .sh/.py libraries under AGENTS_DIR.
 # Uses file metadata (name/size/mtime) for speed (~10ms for 1600 files)
 # rather than content hashing (~80s per runtime).
 # Portable: uses _stat_translate_fmt from portable-stat.sh.
@@ -110,7 +111,7 @@ compute_runtime_source_hash() {
 	_stat_translate_fmt '%n %s %Y' || { echo "no-cache-${RANDOM}"; return 0; }
 	metadata=$({
 		stat "$_STAT_FLAG" "$_STAT_FMT" "${BASH_SOURCE[0]}" 2>/dev/null || true
-		find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" \) \
+		find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" -o -name "*.sh" -o -name "*.py" \) \
 			-print0 2>/dev/null | xargs -0 stat "$_STAT_FLAG" "$_STAT_FMT" 2>/dev/null || true
 	})
 
@@ -120,6 +121,59 @@ compute_runtime_source_hash() {
 
 	echo "$metadata" | LC_ALL=C sort | shasum -a 256 | cut -d' ' -f1
 	return 0
+}
+
+_opencode_agent_output_matches_source() {
+	python3 - <<'PY'
+import json
+import os
+import sys
+
+agents_dir = os.path.expanduser("~/.aidevops/agents")
+config_path = os.path.expanduser("~/.config/opencode/opencode.json")
+script_dir = os.path.expanduser("~/.aidevops/agents/scripts/lib")
+
+sys.path.insert(0, script_dir)
+
+try:
+    from agent_config import discover_primary_agents
+except Exception:
+    sys.exit(1)
+
+try:
+    _primary_agents, sorted_agents, _filtered = discover_primary_agents(agents_dir)
+except Exception:
+    sys.exit(1)
+
+try:
+    with open(config_path, "r", encoding="utf-8") as handle:
+        config = json.load(handle)
+except Exception:
+    sys.exit(1)
+
+configured = config.get("agent", {})
+if not isinstance(configured, dict):
+    sys.exit(1)
+
+expected = set(sorted_agents.keys())
+actual = {name for name, value in configured.items() if not (isinstance(value, dict) and value.get("disable") is True)}
+
+sys.exit(0 if expected <= actual else 1)
+PY
+	return $?
+}
+
+_runtime_output_matches_source() {
+	local runtime_id="$1"
+	case "$runtime_id" in
+	opencode)
+		_opencode_agent_output_matches_source
+		return $?
+		;;
+	*)
+		return 0
+		;;
+	esac
 }
 
 # =============================================================================
@@ -179,9 +233,11 @@ _generate_for_runtime() {
 					output_ok=true
 					;;
 				esac
-				if [[ "$output_ok" == true ]]; then
+				if [[ "$output_ok" == true ]] && _runtime_output_matches_source "$runtime_id"; then
 					print_info "$display_name config up to date (source unchanged) -- skipping generation"
 					return 0
+				elif [[ "$output_ok" == true ]]; then
+					print_info "$display_name config output is stale relative to source -- regenerating"
 				fi
 			fi
 		fi

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -23,6 +23,7 @@ from discovery_utils import parse_frontmatter
 # If not in this map, derive from filename (e.g., build-agent.md -> Build-Agent)
 DISPLAY_NAMES = {
     "build-plus": "Build+",
+    "pr": "PR",
     "seo": "SEO",
     "social-media": "Social-Media",
 }

--- a/.agents/scripts/verify-agent-discoverability.sh
+++ b/.agents/scripts/verify-agent-discoverability.sh
@@ -106,6 +106,31 @@ check_string_in_file() {
 	return 0
 }
 
+check_frontmatter_description_quoting() {
+	local file="$1"
+	local label="$2"
+	local path="${AGENTS_DIR}/${file}"
+	local description_line=""
+	local description_value=""
+	if [[ ! -f "$path" ]]; then
+		log_fail "${label}: ${file} — NOT FOUND"
+		return 0
+	fi
+	description_line=$(awk '
+		/^---$/ { fm++; next }
+		fm == 1 && /^description:/ { print; exit }
+		fm == 2 { exit }
+	' "$path" 2>/dev/null || true)
+	description_value="${description_line#description:}"
+	description_value="${description_value# }"
+	if [[ "$description_value" != "\""* && "$description_value" != "'"* && "$description_value" == *": "* ]]; then
+		log_fail "${label}: ${file} has unquoted description containing ':'"
+	else
+		log_ok "${label}: ${file} frontmatter description is safely quoted"
+	fi
+	return 0
+}
+
 # ─── Test 1: Extracted reference files exist and are non-empty ───────────────
 echo ""
 echo "=== 1. Extracted Reference Files ==="
@@ -194,6 +219,8 @@ AGENT_FILES=(
 for af in "${AGENT_FILES[@]}"; do
 	check_file_nonempty "$af" 100 "Primary agent file"
 done
+check_string_in_file "subagent-index.toon" "PR,pr.md" "subagent-index: PR display name is uppercase"
+check_frontmatter_description_quoting "services/communications/privacy-comparison.md" "OpenCode subagent YAML safety"
 
 # ─── Test 6: Capabilities section retains key entries ─────────────────────────
 echo ""

--- a/.agents/services/communications/privacy-comparison.md
+++ b/.agents/services/communications/privacy-comparison.md
@@ -1,5 +1,5 @@
 ---
-description: Privacy/security comparison matrix for all 15 chat platform integrations — select by threat model. Max privacy → SimpleX. E2E mainstream → Signal. Corporate compliance → Nextcloud Talk. Censorship resistance → Nostr/Urbit. Related: `tools/security/opsec.md`, `services/communications/`.
+description: "Privacy/security comparison matrix for all 15 chat platform integrations — select by threat model. Max privacy → SimpleX. E2E mainstream → Signal. Corporate compliance → Nextcloud Talk. Censorship resistance → Nostr/Urbit. Related: `tools/security/opsec.md`, `services/communications/`."
 mode: subagent
 tools:
   read: true


### PR DESCRIPTION
## Summary
- Display `pr.md` as uppercase `PR` in generated OpenCode main agents.
- Force stale OpenCode agent config regeneration when source primary agents are missing from `opencode.json`.
- Quote generated subagent descriptions and the `privacy-comparison` description so YAML frontmatter with `:` parses as `mode: subagent`.
- Extend discoverability verification to catch PR display and YAML description regressions.

## Verification
- `bash -n .agents/scripts/generate-runtime-config.sh .agents/scripts/generate-runtime-config-agents.sh .agents/scripts/generate-opencode-agents.sh .agents/scripts/verify-agent-discoverability.sh`
- `shellcheck .agents/scripts/generate-runtime-config.sh .agents/scripts/generate-runtime-config-agents.sh .agents/scripts/generate-opencode-agents.sh .agents/scripts/verify-agent-discoverability.sh`
- `.agents/scripts/verify-agent-discoverability.sh --agents-dir .agents`
- temp HOME OpenCode generation asserts 12 primaries including `PR`, excluding `Pr` and `Privacy-Comparison`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.6 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5

Resolves #25303
