### PR TITLE
feat: add macOS GUI launcher scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,8 @@ data/dspyground/
 
 # Node.js dependencies
 node_modules/
+packages/gui-web/dist/
+packages/gui-desktop/dist/
 package-lock.json
 pnpm-lock.yaml
 yarn.lock

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,10 @@
       "name": "@aidevops/gui-api",
       "version": "0.0.0",
     },
+    "packages/gui-desktop": {
+      "name": "@aidevops/gui-desktop",
+      "version": "0.0.0",
+    },
     "packages/gui-shared": {
       "name": "@aidevops/gui-shared",
       "version": "0.0.0",
@@ -39,6 +43,8 @@
   },
   "packages": {
     "@aidevops/gui-api": ["@aidevops/gui-api@workspace:packages/gui-api"],
+
+    "@aidevops/gui-desktop": ["@aidevops/gui-desktop@workspace:packages/gui-desktop"],
 
     "@aidevops/gui-shared": ["@aidevops/gui-shared@workspace:packages/gui-shared"],
 

--- a/docs/gui/desktop-packaging.md
+++ b/docs/gui/desktop-packaging.md
@@ -1,0 +1,29 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# GUI desktop packaging
+
+The first desktop step is an unsigned macOS `.app` launcher that can be placed in
+`/Applications` and opens the existing local read-only web/API scaffold. This is
+not the final Tauri wrapper; it is the smallest local-first bridge so users can
+open aidevops from the Applications folder while the web/API contract stabilises.
+
+Install locally on macOS:
+
+```bash
+npm run gui:desktop:install:macos
+```
+
+The app starts the read-only Hono API on `127.0.0.1:8787`, starts the Vite web
+dashboard on `127.0.0.1:5173`, and opens the dashboard in the default browser.
+It does not add write, destructive, Cloudron-control, pairing, shell, or exec
+routes.
+
+For test installs without writing to `/Applications`:
+
+```bash
+bash packages/gui-desktop/scripts/install-macos-app.sh --app-dir /tmp/aidevops-app-test
+```
+
+The eventual Tauri package must replace this launcher before signed desktop
+release artifacts or auto-updates are published.

--- a/docs/gui/release-signing-updates.md
+++ b/docs/gui/release-signing-updates.md
@@ -1,0 +1,24 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# GUI release, signing, and updates
+
+The current macOS launcher is unsigned and local-only. It is suitable for manual
+developer installs, not public auto-update distribution.
+
+Update notification contract:
+
+- aidevops may update in the background through existing framework update flows.
+- The GUI API reports both the running app version and the installed deployed
+  agents version from `~/.aidevops/agents/VERSION`.
+- When those versions differ, the dashboard shows a restart-required message.
+- The macOS launcher also posts a local notification before opening the app when
+  the installed version differs from the app's checked-out `VERSION` file.
+
+Before publishing signed desktop artifacts, add:
+
+- Tauri sidecar policy for the local API;
+- Apple signing and notarization evidence;
+- signed update metadata and checksum/provenance files;
+- artifact redaction scans for logs, bundles, and update metadata;
+- rollback instructions for failed desktop updates.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "workspaces": [
     "packages/gui-shared",
     "packages/gui-api",
-    "packages/gui-web"
+    "packages/gui-web",
+    "packages/gui-desktop"
   ],
   "bin": {
     "aidevops": "./bin/aidevops"
@@ -31,6 +32,8 @@
     "gui:test:components": "bun test packages/gui-web/tests",
     "gui:test:security": "bun test packages/gui-shared/tests/security.test.ts packages/gui-api/tests/security.test.ts packages/gui-web/tests/security.test.ts",
     "gui:test:smoke": "bun test packages/gui-api/tests/smoke.test.ts",
+    "gui:desktop:check": "bash packages/gui-desktop/scripts/install-macos-app.sh --check",
+    "gui:desktop:install:macos": "bash packages/gui-desktop/scripts/install-macos-app.sh",
     "postinstall": "node scripts/npm-postinstall.cjs || true"
   },
   "keywords": [

--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -25,10 +25,20 @@ export function readStatus(
   const aidevopsVersion = existsSync(versionPath)
     ? readFileSync(versionPath, "utf8").trim()
     : statusFixture.aidevops_version;
+  const installedVersion = readOptionalText(expandHome("~/.aidevops/agents/VERSION")) ?? aidevopsVersion;
+  const restartRequired = installedVersion !== aidevopsVersion;
 
   const data: GuiStatusData = {
     ...statusFixture,
     aidevops_version: aidevopsVersion || "unknown",
+    update: {
+      running_version: aidevopsVersion || "unknown",
+      installed_version: installedVersion || "unknown",
+      restart_required: restartRequired,
+      message: restartRequired
+        ? "aidevops has updated in the background. Restart the GUI app to use the latest installed version."
+        : "The GUI app is using the latest installed aidevops version.",
+    },
     paths: [
       {
         label: "deployed agents",
@@ -73,4 +83,12 @@ function expandHome(pathRef: string): string {
   }
 
   return join(process.env.HOME ?? "", pathRef.slice(2));
+}
+
+function readOptionalText(pathName: string): string | null {
+  if (!existsSync(pathName)) {
+    return null;
+  }
+
+  return readFileSync(pathName, "utf8").trim();
 }

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -12,6 +12,8 @@ describe("status adapter", () => {
     expect(response.ok).toBe(true);
     expect(response.operation_id).toBe("setup.status.read");
     expect(response.data.runtime).toEqual({ host: "local", api: "hono", read_only: true });
+    expect(response.data.update.restart_required).toBeBoolean();
+    expect(response.data.update.message).toContain("GUI app");
     expect(response.data.secrets[0]).toEqual({ name: "GITHUB_TOKEN", status: "unchecked" });
   });
 });

--- a/packages/gui-desktop/package.json
+++ b/packages/gui-desktop/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@aidevops/gui-desktop",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true
+}

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+APP_NAME="aidevops.app"
+DEFAULT_APP_DIR="/Applications"
+
+usage() {
+  printf 'Usage: %s [--check] [--app-dir DIR]\n' "$0"
+  return 0
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+  return 0
+}
+
+validate_environment() {
+  local root="$1"
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    printf 'gui desktop install currently supports macOS only\n' >&2
+    return 1
+  fi
+  if [[ ! -f "${root}/package.json" ]]; then
+    printf 'repo root missing package.json: %s\n' "$root" >&2
+    return 1
+  fi
+  if ! command -v bun >/dev/null 2>&1; then
+    printf 'bun is required to launch the current GUI scaffold\n' >&2
+    return 1
+  fi
+
+  return 0
+}
+
+write_app_bundle() {
+  local root="$1"
+  local app_dir="$2"
+  local app_path="${app_dir}/${APP_NAME}"
+  local contents_dir="${app_path}/Contents"
+  local macos_dir="${contents_dir}/MacOS"
+  local resources_dir="${contents_dir}/Resources"
+
+  mkdir -p "$macos_dir" "$resources_dir"
+  cat > "${contents_dir}/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>aidevops</string>
+  <key>CFBundleDisplayName</key><string>aidevops</string>
+  <key>CFBundleIdentifier</key><string>sh.aidevops.gui</string>
+  <key>CFBundleVersion</key><string>3.21.7</string>
+  <key>CFBundleShortVersionString</key><string>3.21.7</string>
+  <key>CFBundleExecutable</key><string>aidevops-gui</string>
+  <key>LSMinimumSystemVersion</key><string>13.0</string>
+</dict>
+</plist>
+PLIST
+
+  cat > "${macos_dir}/aidevops-gui" <<LAUNCHER
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${root}"
+API_PORT="\${AIDEVOPS_GUI_API_PORT:-8787}"
+WEB_PORT="\${AIDEVOPS_GUI_WEB_PORT:-5173}"
+LOG_DIR="\${HOME}/Library/Logs/aidevops-gui"
+mkdir -p "\${LOG_DIR}"
+
+cd "\${REPO_ROOT}"
+
+if [[ -f "\${HOME}/.aidevops/agents/VERSION" && -f "\${REPO_ROOT}/VERSION" ]]; then
+  INSTALLED_VERSION="\$(tr -d '\n' < "\${HOME}/.aidevops/agents/VERSION")"
+  RUNNING_VERSION="\$(tr -d '\n' < "\${REPO_ROOT}/VERSION")"
+  if [[ "\${INSTALLED_VERSION}" != "\${RUNNING_VERSION}" ]]; then
+    osascript -e "display notification \"Restart aidevops GUI after update: installed \${INSTALLED_VERSION}, app \${RUNNING_VERSION}.\" with title \"aidevops update ready\"" >/dev/null 2>&1 || true
+  fi
+fi
+
+AIDEVOPS_GUI_API_PORT="\${API_PORT}" bun run packages/gui-api/src/server.ts >"\${LOG_DIR}/api.log" 2>&1 &
+API_PID="\$!"
+bun ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port "\${WEB_PORT}" packages/gui-web >"\${LOG_DIR}/web.log" 2>&1 &
+WEB_PID="\$!"
+
+sleep 2
+open "http://127.0.0.1:\${WEB_PORT}"
+
+wait "\${API_PID}" "\${WEB_PID}"
+LAUNCHER
+  chmod 755 "${macos_dir}/aidevops-gui"
+  printf 'Installed %s\n' "$app_path"
+  return 0
+}
+
+main() {
+  local mode="install"
+  local app_dir="$DEFAULT_APP_DIR"
+  local root=""
+
+  while [[ $# -gt 0 ]]; do
+    local arg="$1"
+    case "$arg" in
+      --check)
+        mode="check"
+        shift
+        ;;
+      --app-dir)
+        if [[ $# -lt 2 ]]; then
+          usage >&2
+          return 1
+        fi
+        local next_arg="$2"
+        app_dir="$next_arg"
+        shift 2
+        ;;
+      --help|-h)
+        usage
+        return 0
+        ;;
+      *)
+        usage >&2
+        return 1
+        ;;
+    esac
+  done
+
+  root="$(repo_root)"
+  validate_environment "$root"
+  if [[ "$mode" == "check" ]]; then
+    printf 'macOS app bundle check passed for %s\n' "$root"
+    return 0
+  fi
+  write_app_bundle "$root" "$app_dir"
+  return 0
+}
+
+main "$@"

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -37,6 +37,12 @@ export interface GuiSecretReference {
 
 export interface GuiStatusData {
   aidevops_version: string;
+  update: {
+    running_version: string;
+    installed_version: string;
+    restart_required: boolean;
+    message: string;
+  };
   runtime: {
     host: "local";
     api: "hono";

--- a/packages/gui-shared/src/fixtures.ts
+++ b/packages/gui-shared/src/fixtures.ts
@@ -2,6 +2,12 @@ import type { GuiStatusData } from "./contracts";
 
 export const statusFixture: GuiStatusData = {
   aidevops_version: "unknown",
+  update: {
+    running_version: "unknown",
+    installed_version: "unknown",
+    restart_required: false,
+    message: "The GUI app is using the latest installed aidevops version.",
+  },
   runtime: {
     host: "local",
     api: "hono",

--- a/packages/gui-shared/tests/schema.test.ts
+++ b/packages/gui-shared/tests/schema.test.ts
@@ -28,5 +28,6 @@ describe("GUI shared schema contracts", () => {
     expect(envelope.operation_id).toBe("setup.status.read");
     expect(envelope.redactions).toContain("secret_values");
     expect(envelope.data.runtime.read_only).toBe(true);
+    expect(envelope.data.update.restart_required).toBe(false);
   });
 });

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -23,6 +23,13 @@ export function App() {
         <p className="eyebrow">Read-only local dashboard scaffold</p>
         <h1>aidevops control plane</h1>
         {warning ? <p role="status">{warning}</p> : null}
+        {status.data.update.restart_required ? (
+          <p role="alert">
+            {status.data.update.message} Running {status.data.update.running_version}; installed {status.data.update.installed_version}.
+          </p>
+        ) : (
+          <p role="status">{status.data.update.message}</p>
+        )}
         <dl>
           <dt>Version</dt>
           <dd>{status.data.aidevops_version}</dd>

--- a/packages/gui-web/src/dashboard.ts
+++ b/packages/gui-web/src/dashboard.ts
@@ -13,7 +13,7 @@ export function renderDashboardHtml(status: GuiResponseEnvelope<GuiStatusData>):
     .map((secret) => `<li>${escapeHtml(secret.name)}: ${escapeHtml(secret.status)}</li>`)
     .join("");
 
-  return `<section aria-label="aidevops status"><h1>aidevops control plane</h1><p>Read-only local dashboard scaffold.</p><dl><dt>Version</dt><dd>${escapeHtml(status.data.aidevops_version)}</dd><dt>API</dt><dd>${escapeHtml(status.data.runtime.api)}</dd></dl><h2>Path health</h2><ul>${paths}</ul><h2>Helper availability</h2><ul>${helpers}</ul><h2>Secret references</h2><ul>${secrets}</ul><p>${escapeHtml(status.data.placeholders[0] ?? "More read-only adapters are planned.")}</p></section>`;
+  return `<section aria-label="aidevops status"><h1>aidevops control plane</h1><p>Read-only local dashboard scaffold.</p><p>${escapeHtml(status.data.update.message)}</p><dl><dt>Version</dt><dd>${escapeHtml(status.data.aidevops_version)}</dd><dt>API</dt><dd>${escapeHtml(status.data.runtime.api)}</dd></dl><h2>Path health</h2><ul>${paths}</ul><h2>Helper availability</h2><ul>${helpers}</ul><h2>Secret references</h2><ul>${secrets}</ul><p>${escapeHtml(status.data.placeholders[0] ?? "More read-only adapters are planned.")}</p></section>`;
 }
 
 function escapeHtml(value: string): string {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -8,6 +8,7 @@ describe("dashboard shell", () => {
 
     expect(html).toContain("aidevops control plane");
     expect(html).toContain("Read-only local dashboard scaffold");
+    expect(html).toContain("GUI app");
     expect(html).toContain("Secret references");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `packages/gui-desktop` with an unsigned macOS `.app` launcher installer for the current read-only GUI scaffold.
- Adds dashboard/API restart-required update metadata when deployed aidevops agents update in the background.
- Documents current unsigned launcher scope plus future Tauri signing, notarization, and auto-update requirements.

For #25304

## Verification

- `git diff --check` — passed, no output
- `npm run typecheck` — passed
- `npm run gui:test:schema` — 3 pass, 0 fail
- `npm run gui:test:adapters` — 2 pass, 0 fail
- `npm run gui:test:api` — 2 pass, 0 fail
- `npm run gui:test:components` — 2 pass, 0 fail
- `npm run gui:test:security` — 4 pass, 0 fail
- `npm run gui:test:smoke` — 1 pass, 0 fail
- `npm run gui:desktop:check` — passed
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — passed, no output
- `bash packages/gui-desktop/scripts/install-macos-app.sh --app-dir /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/aidevops-app-test-final` — installed temp app and executable check passed

## Notes

This does not introduce write/destructive routes, shell/exec API routes, Cloudron control, machine pairing, or a signed public auto-update channel. The macOS launcher is an unsigned local bridge until the future Tauri release lane is implemented.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 23m and 311,973 tokens on this with the user in an interactive session.
