### PR TITLE
GH#25308: test: cover OpenCode DB env mocks

### DIFF
--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -202,6 +202,11 @@ assertEq(
   "/tmp/custom-opencode.db",
   getDbPath({ OPENCODE_DB: "/tmp/custom-opencode.db", XDG_DATA_HOME: "/tmp/aidevops-opencode" }),
 );
+assertEq(
+  "mock env accepts unrelated variables",
+  "/tmp/mock-opencode.db",
+  getDbPath({ OPENCODE_DB: "/tmp/mock-opencode.db", NODE_ENV: "test" }),
+);
 
 console.log("\n=== Results ===");
 console.log(`PASS: ${pass}`);


### PR DESCRIPTION
## Summary

Added regression coverage proving getDbPath accepts mock env objects with unrelated variables while preserving OPENCODE_DB override behavior.

## Files Changed

.agents/scripts/tests/test-session-rename-ts.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun .agents/scripts/tests/test-session-rename-ts.mjs; npm run typecheck

Resolves #25308


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 3m and 84,643 tokens on this as a headless worker.