### PR TITLE
fix: detach macOS GUI launcher

### DIFF
--- a/docs/gui/desktop-packaging.md
+++ b/docs/gui/desktop-packaging.md
@@ -15,9 +15,13 @@ npm run gui:desktop:install:macos
 ```
 
 The app starts the read-only Hono API on `127.0.0.1:8787`, starts the Vite web
-dashboard on `127.0.0.1:5173`, and opens the dashboard in the default browser.
-It does not add write, destructive, Cloudron-control, pairing, shell, or exec
-routes.
+dashboard on `127.0.0.1:5173`, opens the dashboard in the default browser, and
+then exits so it does not leave a frozen Dock-only shell app. It reuses existing
+servers when those local ports are already healthy. It does not add write,
+destructive, Cloudron-control, pairing, shell, or exec routes.
+
+The bundle icon is generated from the same terminal-glyph SVG used by the
+`aidevops.sh` website favicon.
 
 For test installs without writing to `/Applications`:
 

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -32,7 +32,43 @@ validate_environment() {
     printf 'bun is required to launch the current GUI scaffold\n' >&2
     return 1
   fi
+  if ! command -v sips >/dev/null 2>&1 || ! command -v iconutil >/dev/null 2>&1; then
+    printf 'macOS sips and iconutil are required to build the app icon\n' >&2
+    return 1
+  fi
 
+  return 0
+}
+
+write_icon_assets() {
+  local resources_dir="$1"
+  local svg_path="${resources_dir}/aidevops.svg"
+  local png_path="${resources_dir}/aidevops-source.png"
+  local iconset_dir="${resources_dir}/aidevops.iconset"
+
+  cat > "$svg_path" <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#0a0a0a"/>
+  <path fill="#B2E969" d="M73.4 150.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l160 160c12.5 12.5 12.5 32.8 0 45.3l-160 160c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L210.7 288 73.4 150.6zM240 400h192c17.7 0 32 14.3 32 32s-14.3 32-32 32H240c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/>
+</svg>
+SVG
+
+  rm -rf "$iconset_dir"
+  mkdir -p "$iconset_dir"
+  sips -s format png "$svg_path" --out "$png_path" >/dev/null
+  sips -z 16 16 "$png_path" --out "${iconset_dir}/icon_16x16.png" >/dev/null
+  sips -z 32 32 "$png_path" --out "${iconset_dir}/icon_16x16@2x.png" >/dev/null
+  sips -z 32 32 "$png_path" --out "${iconset_dir}/icon_32x32.png" >/dev/null
+  sips -z 64 64 "$png_path" --out "${iconset_dir}/icon_32x32@2x.png" >/dev/null
+  sips -z 128 128 "$png_path" --out "${iconset_dir}/icon_128x128.png" >/dev/null
+  sips -z 256 256 "$png_path" --out "${iconset_dir}/icon_128x128@2x.png" >/dev/null
+  sips -z 256 256 "$png_path" --out "${iconset_dir}/icon_256x256.png" >/dev/null
+  sips -z 512 512 "$png_path" --out "${iconset_dir}/icon_256x256@2x.png" >/dev/null
+  sips -z 512 512 "$png_path" --out "${iconset_dir}/icon_512x512.png" >/dev/null
+  sips -z 1024 1024 "$png_path" --out "${iconset_dir}/icon_512x512@2x.png" >/dev/null
+  iconutil -c icns "$iconset_dir" -o "${resources_dir}/aidevops.icns"
+  rm -rf "$iconset_dir"
+  rm -f "$png_path"
   return 0
 }
 
@@ -55,10 +91,12 @@ write_app_bundle() {
   <key>CFBundleVersion</key><string>3.21.7</string>
   <key>CFBundleShortVersionString</key><string>3.21.7</string>
   <key>CFBundleExecutable</key><string>aidevops-gui</string>
+  <key>CFBundleIconFile</key><string>aidevops.icns</string>
   <key>LSMinimumSystemVersion</key><string>13.0</string>
 </dict>
 </plist>
 PLIST
+  write_icon_assets "$resources_dir"
 
   cat > "${macos_dir}/aidevops-gui" <<LAUNCHER
 #!/usr/bin/env bash
@@ -72,23 +110,36 @@ mkdir -p "\${LOG_DIR}"
 
 cd "\${REPO_ROOT}"
 
+notify() {
+  local message="\$1"
+  osascript -e "display notification \"\${message}\" with title \"aidevops\"" >/dev/null 2>&1 || true
+  return 0
+}
+
+url_ready() {
+  local url="\$1"
+  curl --silent --fail --max-time 2 "\${url}" >/dev/null 2>&1
+  return \$?
+}
+
 if [[ -f "\${HOME}/.aidevops/agents/VERSION" && -f "\${REPO_ROOT}/VERSION" ]]; then
   INSTALLED_VERSION="\$(tr -d '\n' < "\${HOME}/.aidevops/agents/VERSION")"
   RUNNING_VERSION="\$(tr -d '\n' < "\${REPO_ROOT}/VERSION")"
   if [[ "\${INSTALLED_VERSION}" != "\${RUNNING_VERSION}" ]]; then
-    osascript -e "display notification \"Restart aidevops GUI after update: installed \${INSTALLED_VERSION}, app \${RUNNING_VERSION}.\" with title \"aidevops update ready\"" >/dev/null 2>&1 || true
+    notify "Restart aidevops GUI after update: installed \${INSTALLED_VERSION}, app \${RUNNING_VERSION}."
   fi
 fi
 
-AIDEVOPS_GUI_API_PORT="\${API_PORT}" bun run packages/gui-api/src/server.ts >"\${LOG_DIR}/api.log" 2>&1 &
-API_PID="\$!"
-bun ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port "\${WEB_PORT}" packages/gui-web >"\${LOG_DIR}/web.log" 2>&1 &
-WEB_PID="\$!"
+if ! url_ready "http://127.0.0.1:\${API_PORT}/api/status"; then
+  nohup env AIDEVOPS_GUI_API_PORT="\${API_PORT}" bun run packages/gui-api/src/server.ts >"\${LOG_DIR}/api.log" 2>&1 &
+fi
+if ! url_ready "http://127.0.0.1:\${WEB_PORT}/"; then
+  nohup bun ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port "\${WEB_PORT}" packages/gui-web >"\${LOG_DIR}/web.log" 2>&1 &
+fi
 
 sleep 2
 open "http://127.0.0.1:\${WEB_PORT}"
-
-wait "\${API_PID}" "\${WEB_PID}"
+exit 0
 LAUNCHER
   chmod 755 "${macos_dir}/aidevops-gui"
   printf 'Installed %s\n' "$app_path"


### PR DESCRIPTION
## Summary

- Fixes the macOS launcher so it starts/reuses the local API and web dashboard, opens the browser, then exits instead of staying as a frozen Dock-only shell app.
- Generates an `.icns` app icon from the same terminal-glyph SVG used by the `aidevops.sh` website favicon.
- Updates desktop packaging docs to describe the detached launcher behavior.

For #25304

## Verification

- `git diff --check origin/main...HEAD` — passed, no output
- `npm run typecheck` — passed
- `npm run gui:desktop:check` — passed
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — passed, no output
- `bash packages/gui-desktop/scripts/install-macos-app.sh --app-dir /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/aidevops-app-test-icon` — installed temp app with `aidevops.icns` and executable launcher
- `open /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/aidevops-app-test-icon/aidevops.app` then `fetch http://127.0.0.1:5173/` — returned HTTP 200
- `pgrep -fl '/aidevops-app-test-icon/aidevops.app/Contents/MacOS/aidevops-gui'` — no launcher process remained

## Local install

- Reinstalled fixed app at `/Applications/aidevops.app`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 38m and 415,565 tokens on this with the user in an interactive session.
