### PR TITLE
GH#25292: publish planning files via PR on protected defaults

### DIFF
--- a/.agents/reference/planning-detail.md
+++ b/.agents/reference/planning-detail.md
@@ -151,7 +151,7 @@ If ANY source confirms a merged PR (with verified `mergedAt`), treat the task as
 
 ## Planning File Workflow
 
-**After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main — no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo.
+**After ANY TODO/planning edit** (interactive sessions only, NOT workers): publish immediately with `planning-commit-helper.sh`. Planning-only files (`TODO.md`, `todo/**`) go direct to the default branch only when that branch accepts direct planning pushes; protected default branches get a planning-only PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo. Do not route `.task-counter` through planning PRs — task IDs remain CAS-allocated by `claim-task-id.sh` on the configured `counter_branch`.
 
 **PR required for ALL non-planning changes** (MANDATORY): Every change to scripts, agents, configs, workflows, or any file outside `TODO.md` and `todo/` MUST go through a worktree + PR + CI pipeline — no matter how small. The pre-edit-check script enforces this; never bypass it.
 
@@ -163,7 +163,7 @@ MANDATORY: Use `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for the nex
 2. `planning-commit-helper.sh next-id --title "Task title"` — wrapper function
 3. `claim-task-id.sh --title "Task title" --repo-path "$(pwd)"` — direct script
 
-**Atomic counter** (t1047): IDs allocated from `.task-counter` via CAS loop — fetch from `origin/main`, increment, commit, push. Push failure (another session grabbed the ID) → retry from fetch. Guarantees no collisions. Batch: `--count N` claims N consecutive IDs atomically. GitHub/GitLab issue creation happens after ID is secured (optional, non-blocking). Offline fallback: local `.task-counter` + 100 offset (reconcile when back online). Output: `task_id=tNNN ref=GH#NNN` (offline: `ref=offline reconcile=true`; batch: adds `task_id_last=tNNN task_count=N`). Retries up to 10 attempts with backoff — no manual intervention needed.
+**Atomic counter** (t1047): IDs allocated from `.task-counter` via CAS loop — fetch from the configured `counter_branch`, increment, commit, push. Push failure (another session grabbed the ID) → retry from fetch. Guarantees no collisions. A protected counter branch is a setup error: configure `counter_branch` to a dedicated unprotected branch rather than using a PR, because PR review is not an atomic lock. Batch: `--count N` claims N consecutive IDs atomically. GitHub/GitLab issue creation happens after ID is secured (optional, non-blocking). Offline fallback: local `.task-counter` + 100 offset (reconcile when back online). Output: `task_id=tNNN ref=GH#NNN` (offline: `ref=offline reconcile=true`; batch: adds `task_id_last=tNNN task_count=N`). Retries up to 10 attempts with backoff — no manual intervention needed.
 
 ## Worker TODO.md Restriction
 

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -299,9 +299,14 @@ complete_task() {
 
 	log_info "Committing: $commit_msg"
 	if todo_commit_push "$repo_root" "$commit_msg" "TODO.md todo/"; then
-		log_success "Task completion committed and pushed"
+		if [[ "${TODO_COMMIT_PUSH_RESULT:-}" == "pr" ]]; then
+			log_success "Task completion submitted via planning PR: ${TODO_COMMIT_PUSH_PR_URL:-created}"
+		else
+			log_success "Task completion committed and pushed"
+		fi
 	else
-		log_warning "Committed locally (push failed after retries - will retry later)"
+		log_error "Task completion publication failed; no successful direct push or planning PR was created"
+		return 1
 	fi
 
 	return 0
@@ -556,9 +561,14 @@ commit_planning_files() {
 	# Use serialized commit+push (flock + pull-rebase-retry)
 	log_info "Committing: $commit_msg"
 	if todo_commit_push "$repo_root" "$commit_msg" "TODO.md todo/"; then
-		log_success "Planning files committed and pushed" # nice
+		if [[ "${TODO_COMMIT_PUSH_RESULT:-}" == "pr" ]]; then
+			log_success "Planning files submitted via planning PR: ${TODO_COMMIT_PUSH_PR_URL:-created}"
+		else
+			log_success "Planning files committed and pushed" # nice
+		fi
 	else
-		log_warning "Committed locally (push failed after retries - will retry later)"
+		log_error "Planning file publication failed; no successful direct push or planning PR was created"
+		return 1
 	fi
 
 	return 0

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -328,13 +328,9 @@ EOF
 	return 0
 }
 
-_todo_create_planning_pr() {
+_todo_planning_pr_slug() {
 	local repo_path="$1"
-	local commit_msg="$2"
-	local files="$3"
-	local current_branch="$4"
-	local default_branch="$5"
-	local log_target="$6"
+	local log_target="$2"
 
 	local slug=""
 	if ! command -v gh >/dev/null 2>&1 || ! command -v gh_create_pr >/dev/null 2>&1; then
@@ -345,14 +341,18 @@ _todo_create_planning_pr() {
 		printf '%s\n' "[todo_commit_push] Planning PR fallback unavailable: cannot resolve GitHub repo slug" >>"$log_target"
 		return 1
 	}
+	printf '%s\n' "$slug"
+	return 0
+}
 
-	local changed_files=""
-	changed_files=$(_todo_changed_planning_files "$repo_path" "$files")
-	if [[ -z "$changed_files" ]]; then
-		printf '%s\n' "[todo_commit_push] No planning changes available for PR fallback" >>"$log_target"
-		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
-		return 0
-	fi
+_TODO_PLANNING_PR_BRANCH=""
+_TODO_PLANNING_PR_WORKTREE=""
+
+_todo_create_planning_worktree() {
+	local repo_path="$1"
+	local commit_msg="$2"
+	local default_branch="$3"
+	local log_target="$4"
 
 	if git -C "$repo_path" remote get-url origin >/dev/null 2>&1; then
 		git -C "$repo_path" fetch -q origin "$default_branch" 2>>"$log_target" || {
@@ -380,6 +380,20 @@ _todo_create_planning_pr() {
 		return 1
 	}
 
+	_TODO_PLANNING_PR_BRANCH="$branch_name"
+	_TODO_PLANNING_PR_WORKTREE="$worktree_path"
+	return 0
+}
+
+_todo_commit_planning_worktree() {
+	local repo_path="$1"
+	local worktree_path="$2"
+	local changed_files="$3"
+	local files="$4"
+	local commit_msg="$5"
+	local branch_name="$6"
+	local log_target="$7"
+
 	if ! _todo_copy_planning_changes_to_worktree "$repo_path" "$worktree_path" "$changed_files"; then
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot copy planning changes" >>"$log_target"
 		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
@@ -406,6 +420,16 @@ _todo_create_planning_pr() {
 		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
 		return 1
 	}
+	return 0
+}
+
+_todo_open_planning_pr() {
+	local slug="$1"
+	local default_branch="$2"
+	local branch_name="$3"
+	local current_branch="$4"
+	local commit_msg="$5"
+	local log_target="$6"
 
 	local pr_title pr_body pr_url
 	pr_title="$commit_msg"
@@ -419,6 +443,32 @@ _todo_create_planning_pr() {
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: PR creation failed" >>"$log_target"
 		return 1
 	}
+	printf '%s\n' "$pr_url"
+	return 0
+}
+
+_todo_create_planning_pr() {
+	local repo_path="$1"
+	local commit_msg="$2"
+	local files="$3"
+	local current_branch="$4"
+	local default_branch="$5"
+	local log_target="$6"
+
+	local slug="" changed_files="" branch_name="" worktree_path="" pr_url=""
+	slug=$(_todo_planning_pr_slug "$repo_path" "$log_target") || return 1
+	changed_files=$(_todo_changed_planning_files "$repo_path" "$files")
+	if [[ -z "$changed_files" ]]; then
+		printf '%s\n' "[todo_commit_push] No planning changes available for PR fallback" >>"$log_target"
+		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
+		return 0
+	fi
+
+	_todo_create_planning_worktree "$repo_path" "$commit_msg" "$default_branch" "$log_target" || return 1
+	branch_name="$_TODO_PLANNING_PR_BRANCH"
+	worktree_path="$_TODO_PLANNING_PR_WORKTREE"
+	_todo_commit_planning_worktree "$repo_path" "$worktree_path" "$changed_files" "$files" "$commit_msg" "$branch_name" "$log_target" || return 1
+	pr_url=$(_todo_open_planning_pr "$slug" "$default_branch" "$branch_name" "$current_branch" "$commit_msg" "$log_target") || return 1
 
 	if ! _todo_clean_source_planning_changes "$repo_path" "$changed_files"; then
 		printf '%s\n' "[todo_commit_push] Planning PR created but source planning cleanup failed" >>"$log_target"

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -40,6 +40,11 @@
 #   - TODO_MAX_RETRIES           — 3
 #   - TODO_LOCK_TIMEOUT          — 30 (seconds to wait for lock acquisition)
 #   - TODO_STALE_LOCK_AGE        — 120 (seconds before age-based reclaim)
+#   - AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1
+#                                 — force the protected-default planning PR
+#                                   path (test/operator override).
+#   - AIDEVOPS_PLANNING_PR_REPO_SLUG=owner/repo
+#                                 — override GitHub slug detection for PRs.
 #
 # Usage: source "${SCRIPT_DIR}/shared-todo-commit.sh"
 #        # Sourced from shared-constants.sh — rarely sourced directly.
@@ -90,6 +95,14 @@ if [[ -z "${TODO_LOCK_DIR:-}" ]]; then
 	readonly TODO_MAX_RETRIES=3
 	readonly TODO_LOCK_TIMEOUT=30
 	readonly TODO_STALE_LOCK_AGE=120
+	readonly TODO_COMMIT_RESULT_NOOP="noop"
+	readonly TODO_COMMIT_RESULT_DIRECT="direct"
+	readonly TODO_COMMIT_RESULT_PR="pr"
+fi
+if [[ -z "${TODO_COMMIT_RESULT_NOOP:-}" ]]; then
+	readonly TODO_COMMIT_RESULT_NOOP="noop"
+	readonly TODO_COMMIT_RESULT_DIRECT="direct"
+	readonly TODO_COMMIT_RESULT_PR="pr"
 fi
 
 # good stuff — portable atomic lock using mkdir (works on macOS + Linux).
@@ -140,11 +153,291 @@ _todo_release_lock() {
 	return 0
 }
 
+_todo_current_branch() {
+	local repo_path="$1"
+	local current_branch=""
+	current_branch=$(git -C "$repo_path" branch --show-current 2>/dev/null) || current_branch=""
+	printf '%s\n' "$current_branch"
+	return 0
+}
+
+_todo_default_branch() {
+	local repo_path="$1"
+	local default_branch=""
+	default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || default_branch=""
+	if [[ -z "$default_branch" ]]; then
+		default_branch=$(git -C "$repo_path" remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' | head -1) || default_branch=""
+	fi
+	if [[ -z "$default_branch" ]]; then
+		if git -C "$repo_path" rev-parse --verify --quiet main >/dev/null 2>&1; then
+			default_branch="main"
+		elif git -C "$repo_path" rev-parse --verify --quiet master >/dev/null 2>&1; then
+			default_branch="master"
+		else
+			default_branch=$(_todo_current_branch "$repo_path")
+		fi
+	fi
+	printf '%s\n' "$default_branch"
+	return 0
+}
+
+_todo_origin_slug() {
+	local repo_path="$1"
+	local override_slug="${AIDEVOPS_PLANNING_PR_REPO_SLUG:-}"
+	if [[ -n "$override_slug" ]]; then
+		printf '%s\n' "$override_slug"
+		return 0
+	fi
+
+	local remote_url=""
+	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null) || remote_url=""
+	[[ -n "$remote_url" ]] || return 1
+
+	local slug="$remote_url"
+	case "$remote_url" in
+	git@github.com:*) slug="${remote_url#git@github.com:}" ;;
+	ssh://git@github.com/*) slug="${remote_url#ssh://git@github.com/}" ;;
+	https://github.com/*) slug="${remote_url#https://github.com/}" ;;
+	http://github.com/*) slug="${remote_url#http://github.com/}" ;;
+	*) return 1 ;;
+	esac
+	slug="${slug%.git}"
+	case "$slug" in
+	*/*) printf '%s\n' "$slug" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_todo_branch_requires_planning_pr() {
+	local repo_path="$1"
+	local branch_name="$2"
+	local slug=""
+
+	if [[ "${AIDEVOPS_PLANNING_FORCE_PR_FALLBACK:-0}" == "1" ]]; then
+		return 0
+	fi
+	[[ -n "$branch_name" ]] || return 1
+	command -v gh >/dev/null 2>&1 || return 1
+	slug=$(_todo_origin_slug "$repo_path") || return 1
+	if gh api "repos/${slug}/branches/${branch_name}/protection" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+_todo_slugify_ref_fragment() {
+	local raw_text="$1"
+	local slug=""
+	slug=$(printf '%s' "$raw_text" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-48)
+	[[ -n "$slug" ]] || slug="planning-files"
+	printf '%s\n' "$slug"
+	return 0
+}
+
+_todo_safe_planning_path() {
+	local rel_path="$1"
+	case "$rel_path" in
+	TODO.md | todo/*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+_todo_changed_planning_files() {
+	local repo_path="$1"
+	local files="$2"
+	{
+		# shellcheck disable=SC2086 # files is the legacy space-delimited API.
+		git -C "$repo_path" diff --name-only HEAD -- $files 2>/dev/null || true
+		# shellcheck disable=SC2086 # files is the legacy space-delimited API.
+		git -C "$repo_path" diff --name-only --cached -- $files 2>/dev/null || true
+		# shellcheck disable=SC2086 # files is the legacy space-delimited API.
+		git -C "$repo_path" ls-files --others --exclude-standard -- $files 2>/dev/null || true
+	} | sort -u | grep -E '^(TODO\.md|todo/)' || true
+	return 0
+}
+
+_todo_copy_planning_changes_to_worktree() {
+	local repo_path="$1"
+	local worktree_path="$2"
+	local changed_files="$3"
+
+	local rel_path
+	while IFS= read -r rel_path; do
+		[[ -n "$rel_path" ]] || continue
+		_todo_safe_planning_path "$rel_path" || continue
+		if [[ -e "${repo_path}/${rel_path}" ]]; then
+			mkdir -p "${worktree_path}/$(dirname "$rel_path")" || return 1
+			cp -p "${repo_path}/${rel_path}" "${worktree_path}/${rel_path}" || return 1
+		else
+			rm -f "${worktree_path}/${rel_path}" || return 1
+		fi
+	done <<<"$changed_files"
+	return 0
+}
+
+_todo_clean_source_planning_changes() {
+	local repo_path="$1"
+	local changed_files="$2"
+
+	local rel_path
+	while IFS= read -r rel_path; do
+		[[ -n "$rel_path" ]] || continue
+		_todo_safe_planning_path "$rel_path" || continue
+		if git -C "$repo_path" ls-files --error-unmatch -- "$rel_path" >/dev/null 2>&1; then
+			git -C "$repo_path" reset -q HEAD -- "$rel_path" >/dev/null 2>&1 || true
+			git -C "$repo_path" checkout -q -- "$rel_path" >/dev/null 2>&1 || return 1
+		else
+			rm -f "${repo_path}/${rel_path}" || return 1
+		fi
+	done <<<"$changed_files"
+	return 0
+}
+
+_todo_remove_temp_worktree() {
+	local repo_path="$1"
+	local worktree_path="$2"
+	[[ -n "$worktree_path" ]] || return 0
+	if [[ -e "${worktree_path}/.git" ]]; then
+		git -C "$repo_path" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
+_todo_planning_pr_body() {
+	local source_branch="$1"
+	local default_branch="$2"
+	local commit_msg="$3"
+	cat <<EOF
+## Planning publication
+
+- Publishes TODO.md and todo/ planning-file changes through a PR because ${default_branch} does not accept direct planning pushes.
+- Source branch at helper invocation: ${source_branch}.
+- Commit message: ${commit_msg}.
+
+## Security and architecture guardrails
+
+- This PR does not update .task-counter.
+- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
+- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.
+
+## Merge note
+
+- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
+EOF
+	return 0
+}
+
+_todo_create_planning_pr() {
+	local repo_path="$1"
+	local commit_msg="$2"
+	local files="$3"
+	local current_branch="$4"
+	local default_branch="$5"
+	local log_target="$6"
+
+	local slug=""
+	if ! command -v gh >/dev/null 2>&1 || ! command -v gh_create_pr >/dev/null 2>&1; then
+		printf '%s\n' "[todo_commit_push] Planning PR fallback unavailable: gh/gh_create_pr not available" >>"$log_target"
+		return 1
+	fi
+	slug=$(_todo_origin_slug "$repo_path") || {
+		printf '%s\n' "[todo_commit_push] Planning PR fallback unavailable: cannot resolve GitHub repo slug" >>"$log_target"
+		return 1
+	}
+
+	local changed_files=""
+	changed_files=$(_todo_changed_planning_files "$repo_path" "$files")
+	if [[ -z "$changed_files" ]]; then
+		printf '%s\n' "[todo_commit_push] No planning changes available for PR fallback" >>"$log_target"
+		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
+		return 0
+	fi
+
+	if git -C "$repo_path" remote get-url origin >/dev/null 2>&1; then
+		git -C "$repo_path" fetch -q origin "$default_branch" 2>>"$log_target" || {
+			printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot fetch origin/${default_branch}" >>"$log_target"
+			return 1
+		}
+	fi
+
+	local repo_abs parent_dir repo_name slug_part timestamp branch_name worktree_path
+	repo_abs=$(cd "$repo_path" 2>/dev/null && pwd -P) || return 1
+	parent_dir=$(dirname "$repo_abs") || return 1
+	repo_name=$(basename "$repo_abs") || return 1
+	slug_part=$(_todo_slugify_ref_fragment "$commit_msg")
+	timestamp=$(date -u +%Y%m%d%H%M%S)
+	branch_name="planning/${timestamp}-$$-${slug_part}"
+	worktree_path="${parent_dir}/${repo_name}-planning-${timestamp}-$$-${slug_part}"
+
+	if [[ -e "$worktree_path" ]]; then
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: worktree path already exists" >>"$log_target"
+		return 1
+	fi
+
+	git -C "$repo_path" worktree add -b "$branch_name" "$worktree_path" "origin/${default_branch}" >/dev/null 2>>"$log_target" || {
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot create linked worktree" >>"$log_target"
+		return 1
+	}
+
+	if ! _todo_copy_planning_changes_to_worktree "$repo_path" "$worktree_path" "$changed_files"; then
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot copy planning changes" >>"$log_target"
+		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
+		return 1
+	fi
+
+	# shellcheck disable=SC2086 # files is the legacy space-delimited API.
+	git -C "$worktree_path" add $files 2>>"$log_target" || true
+	if git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
+		printf '%s\n' "[todo_commit_push] No changes staged in planning PR worktree" >>"$log_target"
+		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
+		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
+		return 0
+	fi
+
+	git -C "$worktree_path" commit -m "$commit_msg" --no-verify >/dev/null 2>>"$log_target" || {
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: commit failed" >>"$log_target"
+		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
+		return 1
+	}
+
+	git -C "$worktree_path" push -u origin "$branch_name" >/dev/null 2>>"$log_target" || {
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: branch push failed" >>"$log_target"
+		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
+		return 1
+	}
+
+	local pr_title pr_body pr_url
+	pr_title="$commit_msg"
+	pr_body=$(_todo_planning_pr_body "$current_branch" "$default_branch" "$commit_msg")
+	pr_url=$(AIDEVOPS_PR_CREATE_READY=1 gh_create_pr \
+		--repo "$slug" \
+		--base "$default_branch" \
+		--head "$branch_name" \
+		--title "$pr_title" \
+		--body "$pr_body" 2>>"$log_target") || {
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: PR creation failed" >>"$log_target"
+		return 1
+	}
+
+	if ! _todo_clean_source_planning_changes "$repo_path" "$changed_files"; then
+		printf '%s\n' "[todo_commit_push] Planning PR created but source planning cleanup failed" >>"$log_target"
+		return 1
+	fi
+	_todo_remove_temp_worktree "$repo_path" "$worktree_path"
+	TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_PR"
+	TODO_COMMIT_PUSH_PR_URL="$pr_url"
+	printf '%s\n' "[todo_commit_push] Planning PR created: ${pr_url}" >>"$log_target"
+	return 0
+}
+
 todo_commit_push() {
 	local repo_path="$1"
 	local commit_msg="$2"
 	local files="${3:-TODO.md todo/}"
 	local log_target="${AIDEVOPS_LOG_FILE:-/dev/null}"
+	TODO_COMMIT_PUSH_RESULT=""
+	TODO_COMMIT_PUSH_PR_URL=""
 
 	mkdir -p "$TODO_LOCK_DIR" 2>/dev/null || true
 
@@ -170,44 +463,48 @@ _todo_commit_push_inner() {
 	local files="$3"
 	local log_target="$4"
 	local attempt=0
+	local current_branch=""
+	local default_branch=""
+
+	current_branch=$(_todo_current_branch "$repo_path")
+	default_branch=$(_todo_default_branch "$repo_path")
+	if [[ -n "$current_branch" && -n "$default_branch" && "$current_branch" == "$default_branch" ]]; then
+		if _todo_branch_requires_planning_pr "$repo_path" "$default_branch"; then
+			printf '%s\n' "[todo_commit_push] Default branch ${default_branch} requires PR publication for planning files" >>"$log_target"
+			_todo_create_planning_pr "$repo_path" "$commit_msg" "$files" "$current_branch" "$default_branch" "$log_target"
+			return $?
+		fi
+	fi
+
+	current_branch=$(_todo_current_branch "$repo_path")
+	[[ -n "$current_branch" ]] || current_branch="main"
+
+	# Stage and commit before pull/rebase. Pulling first fails when the caller has
+	# unstaged planning edits; after a local planning commit, rebase can safely
+	# linearise against a moved remote branch before push.
+	local file
+	for file in $files; do
+		git -C "$repo_path" add "$file" 2>/dev/null || true
+	done
+
+	if git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
+		echo "[todo_commit_push] No changes staged" >>"$log_target"
+		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
+		return 0
+	fi
+
+	if ! git -C "$repo_path" commit -m "$commit_msg" --no-verify 2>>"$log_target"; then
+		echo "[todo_commit_push] Commit failed" >>"$log_target"
+		return 1
+	fi
 
 	while [[ $attempt -lt $TODO_MAX_RETRIES ]]; do
 		attempt=$((attempt + 1))
 
-		# Pull latest before staging (rebase to keep linear history)
-		local current_branch
-		current_branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "main")
-		if git -C "$repo_path" remote get-url origin &>/dev/null; then
-			git -C "$repo_path" pull --rebase origin "$current_branch" 2>>"$log_target" || {
-				echo "[todo_commit_push] Pull --rebase failed (attempt $attempt/$TODO_MAX_RETRIES)" >>"$log_target"
-				# If rebase conflicts, abort and retry
-				git -C "$repo_path" rebase --abort 2>/dev/null || true
-				sleep 1
-				continue
-			}
-		fi
-
-		# Stage planning files
-		local file
-		for file in $files; do
-			git -C "$repo_path" add "$file" 2>/dev/null || true
-		done
-
-		# Check if anything was staged
-		if git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
-			echo "[todo_commit_push] No changes staged" >>"$log_target"
-			return 0
-		fi
-
-		# Commit
-		if ! git -C "$repo_path" commit -m "$commit_msg" --no-verify 2>>"$log_target"; then
-			echo "[todo_commit_push] Commit failed (attempt $attempt/$TODO_MAX_RETRIES)" >>"$log_target"
-			continue
-		fi
-
-		# Push
+		# Push first; only pay the rebase cost if the remote moved or rejected.
 		if git -C "$repo_path" push origin "$current_branch" 2>>"$log_target"; then
 			echo "[todo_commit_push] Success on attempt $attempt" >>"$log_target"
+			TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_DIRECT"
 			return 0
 		fi
 
@@ -223,6 +520,7 @@ _todo_commit_push_inner() {
 		# Retry push after rebase
 		if git -C "$repo_path" push origin "$current_branch" 2>>"$log_target"; then
 			echo "[todo_commit_push] Success after rebase on attempt $attempt" >>"$log_target"
+			TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_DIRECT"
 			return 0
 		fi
 

--- a/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
+++ b/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#25292.
+#
+# Protected default branches must publish TODO.md/todo/ planning changes via a
+# planning-only PR. The task counter remains CAS-only: this test asserts the PR
+# body tells weaker models not to turn .task-counter into a PR-backed lock.
+
+set -u
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
+PLANNING_HELPER="${REPO_ROOT}/.agents/scripts/planning-commit-helper.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL %s' "$name"
+	[[ -n "$detail" ]] && printf ' — %s' "$detail"
+	printf '\n'
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+setup_repo() {
+	local tmpdir="$1"
+	local protected_default="$2"
+	local bare_dir="${tmpdir}/remote.git"
+	local work_dir="${tmpdir}/work"
+
+	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || git init --bare "$bare_dir" >/dev/null 2>&1 || return 1
+	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.email "test@test.local" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config user.name "Test" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" config commit.gpgsign false >/dev/null 2>&1 || true
+	printf '# Tasks\n\n' >"${work_dir}/TODO.md"
+	mkdir -p "${work_dir}/todo/tasks" || return 1
+	git -C "$work_dir" add TODO.md >/dev/null 2>&1 || return 1
+	git -C "$work_dir" commit -m "chore: seed planning files" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin main >/dev/null 2>&1 || return 1
+	git -C "$work_dir" fetch origin main >/dev/null 2>&1 || return 1
+	git -C "$work_dir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main >/dev/null 2>&1 || return 1
+
+	if [[ "$protected_default" == "true" ]]; then
+		mkdir -p "${bare_dir}/hooks" || return 1
+		cat >"${bare_dir}/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+while read -r _old _new ref; do
+	if [[ "$ref" == "refs/heads/main" ]]; then
+		printf 'remote: error: GH006: Protected branch update failed for %s.\n' "$ref" >&2
+		printf 'remote: error: Changes must be made through a pull request.\n' >&2
+		exit 1
+	fi
+done
+exit 0
+HOOK
+		chmod +x "${bare_dir}/hooks/pre-receive" || return 1
+	fi
+
+	printf '%s\n' "$work_dir"
+	return 0
+}
+
+write_fake_gh() {
+	local fake_bin="$1"
+	mkdir -p "$fake_bin" || return 1
+	cat >"${fake_bin}/gh" <<'GH'
+#!/usr/bin/env bash
+set -u
+{
+	printf 'gh'
+	for arg in "$@"; do
+		printf '\t%s' "$arg"
+	done
+	printf '\n'
+} >>"${GH_STUB_LOG:?}"
+
+if [[ "${1:-}" == "label" && "${2:-}" == "create" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" ]]; then
+	exit 1
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+	shift 2
+	head_branch=""
+	body_text=""
+	title_text=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--head)
+			head_branch="${2:-}"
+			shift 2
+			;;
+		--head=*)
+			head_branch="${1#--head=}"
+			shift
+			;;
+		--body)
+			body_text="${2:-}"
+			shift 2
+			;;
+		--body=*)
+			body_text="${1#--body=}"
+			shift
+			;;
+		--title)
+			title_text="${2:-}"
+			shift 2
+			;;
+		--title=*)
+			title_text="${1#--title=}"
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+	printf '%s\n' "$head_branch" >"${GH_STUB_HEAD:?}"
+	printf '%s\n' "$title_text" >"${GH_STUB_TITLE:?}"
+	printf '%s\n' "$body_text" >"${GH_STUB_BODY:?}"
+	printf 'https://github.com/example/repo/pull/1\n'
+	exit 0
+fi
+
+exit 0
+GH
+	chmod +x "${fake_bin}/gh" || return 1
+	return 0
+}
+
+append_planning_change() {
+	local work_dir="$1"
+	local task_id="$2"
+	printf -- '- [ ] %s Protected planning fallback #bug #auto-dispatch ~30m ref:GH#25292\n' "$task_id" >>"${work_dir}/TODO.md"
+	printf 'What: protected planning fallback\nHow: update planning helper\n' >"${work_dir}/todo/tasks/${task_id}-brief.md"
+	return 0
+}
+
+test_protected_default_creates_planning_pr() {
+	local name="protected default branch creates planning PR and cleans source"
+	local tmpdir fake_bin work_dir body_file head_file title_file log_file output rc status head_branch remote_todo pr_body
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+	fake_bin="${tmpdir}/bin"
+	log_file="${tmpdir}/gh.log"
+	body_file="${tmpdir}/body.md"
+	head_file="${tmpdir}/head.txt"
+	title_file="${tmpdir}/title.txt"
+	: >"$log_file"
+	write_fake_gh "$fake_bin" || { fail "$name" "fake gh setup failed"; return 0; }
+	work_dir=$(setup_repo "$tmpdir" true) || { fail "$name" "repo setup failed"; return 0; }
+	append_planning_change "$work_dir" "t999" || { fail "$name" "planning change failed"; return 0; }
+
+	rc=0
+	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="$log_file" GH_STUB_BODY="$body_file" GH_STUB_HEAD="$head_file" GH_STUB_TITLE="$title_file" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 AIDEVOPS_PLANNING_PR_REPO_SLUG="example/repo" \
+		"$PLANNING_HELPER" "plan: add t999 protected planning" 2>&1) || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "helper failed rc=$rc output=$output"
+		return 0
+	fi
+	status=$(git -C "$work_dir" status --short 2>/dev/null)
+	if [[ -n "$status" ]]; then
+		fail "$name" "source worktree dirty after PR fallback: $status"
+		return 0
+	fi
+	if ! grep -q $'gh\tpr\tcreate' "$log_file" 2>/dev/null; then
+		fail "$name" "gh pr create was not called"
+		return 0
+	fi
+	head_branch=$(cat "$head_file" 2>/dev/null || true)
+	if [[ "$head_branch" != planning/* ]]; then
+		fail "$name" "unexpected PR head: ${head_branch:-<empty>}"
+		return 0
+	fi
+	remote_todo=$(git -C "$work_dir" show "origin/main:TODO.md" 2>/dev/null || true)
+	if [[ "$remote_todo" == *"t999"* ]]; then
+		fail "$name" "protected default branch was updated directly"
+		return 0
+	fi
+	git -C "$work_dir" fetch origin "$head_branch" >/dev/null 2>&1 || { fail "$name" "PR branch not pushed"; return 0; }
+	remote_todo=$(git -C "$work_dir" show FETCH_HEAD:TODO.md 2>/dev/null || true)
+	if [[ "$remote_todo" != *"t999"* ]]; then
+		fail "$name" "PR branch does not contain TODO change"
+		return 0
+	fi
+	pr_body=$(cat "$body_file" 2>/dev/null || true)
+	if [[ "$pr_body" != *"does not update .task-counter"* ]] || [[ "$pr_body" != *"PR-backed counter update"* ]]; then
+		fail "$name" "PR body missing counter safety guidance"
+		return 0
+	fi
+	if printf '%s\n' "$pr_body" | grep -Eiq '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'; then
+		fail "$name" "planning PR body contains a closing keyword"
+		return 0
+	fi
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_unprotected_default_keeps_direct_push() {
+	local name="unprotected default branch keeps direct planning push"
+	local tmpdir fake_bin work_dir log_file output rc status remote_todo
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+	fake_bin="${tmpdir}/bin"
+	log_file="${tmpdir}/gh.log"
+	: >"$log_file"
+	write_fake_gh "$fake_bin" || { fail "$name" "fake gh setup failed"; return 0; }
+	work_dir=$(setup_repo "$tmpdir" false) || { fail "$name" "repo setup failed"; return 0; }
+	append_planning_change "$work_dir" "t1000" || { fail "$name" "planning change failed"; return 0; }
+	rc=0
+	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" GH_STUB_LOG="$log_file" GH_STUB_BODY="${tmpdir}/body" GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		"$PLANNING_HELPER" "plan: add t1000 direct planning" 2>&1) || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "helper failed rc=$rc output=$output"
+		return 0
+	fi
+	status=$(git -C "$work_dir" status --short 2>/dev/null)
+	if [[ -n "$status" ]]; then
+		fail "$name" "source worktree dirty after direct push: $status"
+		return 0
+	fi
+	git -C "$work_dir" fetch origin main >/dev/null 2>&1 || true
+	remote_todo=$(git -C "$work_dir" show origin/main:TODO.md 2>/dev/null || true)
+	if [[ "$remote_todo" != *"t1000"* ]]; then
+		fail "$name" "direct push did not update origin/main"
+		return 0
+	fi
+	if grep -q $'gh\tpr\tcreate' "$log_file" 2>/dev/null; then
+		fail "$name" "unexpected PR creation on unprotected default"
+		return 0
+	fi
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_pr_unavailable_fails_before_commit() {
+	local name="PR fallback unavailable fails before local commit"
+	local tmpdir work_dir before_head after_head output rc status
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+	work_dir=$(setup_repo "$tmpdir" true) || { fail "$name" "repo setup failed"; return 0; }
+	append_planning_change "$work_dir" "t1001" || { fail "$name" "planning change failed"; return 0; }
+	before_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || { fail "$name" "missing initial HEAD"; return 0; }
+	rc=0
+	output=$(cd "$work_dir" && AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 "$PLANNING_HELPER" "plan: add t1001 unavailable pr" 2>&1) || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		fail "$name" "helper unexpectedly succeeded: $output"
+		return 0
+	fi
+	after_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || { fail "$name" "missing final HEAD"; return 0; }
+	if [[ "$after_head" != "$before_head" ]]; then
+		fail "$name" "local HEAD changed before PR availability was proven"
+		return 0
+	fi
+	status=$(git -C "$work_dir" status --short 2>/dev/null)
+	if [[ "$status" != *"TODO.md"* ]]; then
+		fail "$name" "planning edits were not preserved for retry"
+		return 0
+	fi
+	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+main() {
+	if [[ ! -x "$PLANNING_HELPER" ]]; then
+		fail "planning helper executable" "$PLANNING_HELPER missing or not executable"
+	else
+		pass "planning helper executable"
+	fi
+	test_protected_default_creates_planning_pr
+	test_unprotected_default_keeps_direct_push
+	test_pr_unavailable_fails_before_commit
+	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+	[[ "$FAIL" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -173,7 +173,12 @@ Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.
 ~/.aidevops/agents/scripts/planning-commit-helper.sh "plan: add ${task_id} ${short_title}"
 ```
 
-Brief and TODO.md are planning files — they go directly to main.
+Brief and TODO.md are planning files. Use `planning-commit-helper.sh`; it pushes
+directly only when the default branch accepts planning pushes. If the default
+branch requires PRs, the helper creates a planning-only PR for `TODO.md`/`todo/**`.
+Merge that PR before expecting pulse or issue-sync to see the new task. Do not
+put `.task-counter` in that PR path — task IDs still come from `claim-task-id.sh`
+CAS allocation on the configured `counter_branch`.
 
 ## Offline Handling
 
@@ -196,7 +201,7 @@ AI:   Added and claimed:
 
 ## Batch Mode
 
-When the user provides multiple task titles at once (e.g., a sprint planning list), use batch mode to avoid 11 interactive rounds. Batch mode creates all tasks in a single pass and emits **one commit+push** for all planning files.
+When the user provides multiple task titles at once (e.g., a sprint planning list), use batch mode to avoid 11 interactive rounds. Batch mode creates all tasks in a single pass and emits **one planning publication** for all planning files: direct push when allowed, or one planning-only PR when the default branch is protected.
 
 **When to use batch:** user provides a list of 3+ titles, or says "create these tasks in bulk", or pastes a list.
 
@@ -252,7 +257,7 @@ Tasks without a complete How section will fail tier:simple dispatch.
 
 - Each title still gets its own GitHub issue (separate API call per title).
 - The `.task-counter` branch is updated per allocation — that is unavoidable.
-- The planning files (`TODO.md`, `todo/tasks/*.md`) use a **single** commit+push.
+- The planning files (`TODO.md`, `todo/tasks/*.md`) use a **single** publication: direct commit+push when allowed, or one planning-only PR when branch protection requires PRs.
 - `--labels` applies the same label set to all tasks in the batch.
 - `--no-issue` skips GitHub issue creation (useful for offline / bulk planning).
 

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -203,7 +203,7 @@ After ANY edit to TODO.md, todo/PLANS.md, or todo/tasks/*, commit and push immed
 
 | Condition | Action |
 |-----------|--------|
-| TODO.md-only changes | Commit directly on main — `planning-commit-helper.sh "chore: add {description} to backlog"` |
+| TODO.md-only changes | Use `planning-commit-helper.sh "chore: add {description} to backlog"`; it pushes directly when allowed or opens a planning-only PR on protected default branches. |
 | Mixed changes (TODO + code/agent files) | Create a worktree (`wt switch -c chore/todo-{slug}`), make changes, commit, push, PR, merge |
 | Adding 3+ unrelated items while in a task worktree | Suggest a separate planning-only main commit instead |
 

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -56,7 +56,7 @@ Note: allowlisted paths (`README.md`, `TODO.md`, `todo/**`) short-circuit to exi
 
 Pass `--file <path>` for path-based enforcement (preferred):
 
-- **Allowlisted path** (`README.md`, `TODO.md`, `todo/**`) → stay on `main`
+- **Allowlisted path** (`README.md`, `TODO.md`, `todo/**`) → stay on `main`; planning publication may still become a PR if branch protection requires it
 - **Any other path** → create worktree
 
 Fallback `--task` description keywords (when `--file` not provided):
@@ -68,7 +68,7 @@ Fallback `--task` description keywords (when `--file` not provided):
 
 Keep `~/Git/{repo}/` on `main`. Avoids blocked branch switches, parallel sessions inheriting the wrong branch, and `local changes would be overwritten` errors.
 
-Stay on `main` only for allowlisted paths: `README.md`, `TODO.md`, `todo/**`. Planning-file commits use `planning-commit-helper.sh "plan: add new task"`.
+Stay on `main` only for allowlisted paths: `README.md`, `TODO.md`, `todo/**`. Planning-file commits use `planning-commit-helper.sh "plan: add new task"`; the helper opens a planning-only PR instead of direct-pushing when the default branch is protected.
 
 Continue on current branch only when: task matches branch purpose, finishes this session, no parallel sessions expected.
 


### PR DESCRIPTION
## Summary

Adds protected-default planning publication fallback. Planning edits are copied into a linked planning worktree, pushed to a planning-only PR, and source planning edits are cleaned only after PR creation succeeds. Counter-file allocation stays CAS-only.

## Files Changed

.agents/reference/planning-detail.md,.agents/scripts/planning-commit-helper.sh,.agents/scripts/shared-todo-commit.sh,.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh,.agents/workflows/new-task.md,.agents/workflows/plans.md,.agents/workflows/pre-edit.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** planning fallback regression; protected counter regression; next-id regression; ShellCheck on modified scripts; linters-local; pulse canary

Resolves #25292


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 with gpt-5.5 spent 53m and 413,693 tokens on this with the user in an interactive session.