### PR TITLE
fix: serve visible GUI from app launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "gui:api:dev": "bun run packages/gui-api/src/server.ts",
-    "gui:web:dev": "bun ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port 5173 packages/gui-web",
+    "gui:web:dev": "bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts --host 127.0.0.1 --port 5173",
     "gui:test:schema": "bun test packages/gui-shared/tests",
     "gui:test:adapters": "bun test packages/gui-api/tests/status-adapter.test.ts",
     "gui:test:api": "bun test packages/gui-api/tests/status-route.test.ts",

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -134,7 +134,7 @@ if ! url_ready "http://127.0.0.1:\${API_PORT}/api/status"; then
   nohup env AIDEVOPS_GUI_API_PORT="\${API_PORT}" bun run packages/gui-api/src/server.ts >"\${LOG_DIR}/api.log" 2>&1 &
 fi
 if ! url_ready "http://127.0.0.1:\${WEB_PORT}/"; then
-  nohup bun ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port "\${WEB_PORT}" packages/gui-web >"\${LOG_DIR}/web.log" 2>&1 &
+  nohup bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts --host 127.0.0.1 --port "\${WEB_PORT}" >"\${LOG_DIR}/web.log" 2>&1 &
 fi
 
 sleep 2

--- a/packages/gui-web/index.html
+++ b/packages/gui-web/index.html
@@ -6,7 +6,15 @@
     <title>aidevops GUI</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main>
+        <section aria-label="aidevops status">
+          <p class="eyebrow">Read-only local dashboard scaffold</p>
+          <h1>aidevops control plane</h1>
+          <p class="lede">Loading the local GUI. If this message stays visible, refresh the page or check ~/Library/Logs/aidevops-gui/web.log.</p>
+        </section>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -5,6 +5,12 @@ import { fetchStatus, mockedStatus } from "./status-client";
 export function App() {
   const [status, setStatus] = useState<GuiResponseEnvelope<GuiStatusData>>(mockedStatus());
   const [warning, setWarning] = useState<string | null>("Using local fixture until the API responds.");
+  const update = status.data.update ?? {
+    running_version: status.data.aidevops_version,
+    installed_version: status.data.aidevops_version,
+    restart_required: false,
+    message: "The GUI app is using local read-only status data.",
+  };
 
   useEffect(() => {
     fetchStatus()
@@ -22,13 +28,17 @@ export function App() {
       <section aria-label="aidevops status">
         <p className="eyebrow">Read-only local dashboard scaffold</p>
         <h1>aidevops control plane</h1>
+        <p className="lede">
+          This is the first local GUI surface: setup/status insight only, with no write,
+          destructive, Cloudron, pairing, shell, or exec controls.
+        </p>
         {warning ? <p role="status">{warning}</p> : null}
-        {status.data.update.restart_required ? (
+        {update.restart_required ? (
           <p role="alert">
-            {status.data.update.message} Running {status.data.update.running_version}; installed {status.data.update.installed_version}.
+            {update.message} Running {update.running_version}; installed {update.installed_version}.
           </p>
         ) : (
-          <p role="status">{status.data.update.message}</p>
+          <p role="status">{update.message}</p>
         )}
         <dl>
           <dt>Version</dt>

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -30,6 +30,12 @@ section {
   text-transform: uppercase;
 }
 
+.lede {
+  color: #374151;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
 code {
   background: #f3f4f6;
   border-radius: 4px;

--- a/packages/gui-web/vite.config.ts
+++ b/packages/gui-web/vite.config.ts
@@ -3,8 +3,12 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  root: "packages/gui-web",
   server: {
     host: "127.0.0.1",
     port: 5173,
+    proxy: {
+      "/api": "http://127.0.0.1:8787",
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Fixes the launcher/web dev server command to use the GUI Vite config instead of serving without the `/api` proxy.
- Adds Vite root/proxy config so `http://127.0.0.1:5173/api/status` reaches the local read-only API instead of returning `index.html`.
- Adds a visible HTML fallback inside `#root` and a more explicit first dashboard message so the page is not blank if React takes a moment or fails.
- Keeps update metadata backward-compatible when older status fixtures are loaded.

For #25304

## Verification

- `git diff --check origin/main...HEAD` — passed, no output
- `npm run typecheck` — passed
- `npm run gui:desktop:check` — passed
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — passed, no output
- `npm run gui:test:components` — 2 pass, 0 fail
- `bash packages/gui-desktop/scripts/install-macos-app.sh --app-dir /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/aidevops-app-test-gui-visible && open .../aidevops.app` then fetched `http://127.0.0.1:5173/` and `http://127.0.0.1:5173/api/status` — page responded and API proxy returned status JSON with update metadata
- Reinstalled fixed app at `/Applications/aidevops.app`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 48m and 454,678 tokens on this with the user in an interactive session.
