### PR TITLE
feat: add read-only dashboard navigation

### DIFF
--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -5,6 +5,9 @@ import {
   createEnvelope,
   statusFixture,
   type GuiResponseEnvelope,
+  type GuiRepoRegistrySummary,
+  type GuiRepoSummary,
+  type GuiSettingsSummary,
   type GuiStatusData,
 } from "../../gui-shared/src";
 
@@ -21,7 +24,10 @@ export function readStatus(
   const repoRoot = options.repoRoot ?? process.cwd();
   const versionPath = join(repoRoot, "VERSION");
   const settingsPathRef = "~/.config/aidevops/settings.json";
+  const reposPathRef = "~/.config/aidevops/repos.json";
   const agentsPathRef = "~/.aidevops/agents";
+  const settingsPath = expandHome(settingsPathRef);
+  const reposPath = expandHome(reposPathRef);
   const aidevopsVersion = existsSync(versionPath)
     ? readFileSync(versionPath, "utf8").trim()
     : statusFixture.aidevops_version;
@@ -48,9 +54,14 @@ export function readStatus(
       {
         label: "settings",
         path_ref: settingsPathRef,
-        health: existsSync(expandHome("~/.config/aidevops/settings.json"))
+        health: existsSync(settingsPath)
           ? "present"
           : "missing",
+      },
+      {
+        label: "repo registry",
+        path_ref: reposPathRef,
+        health: existsSync(reposPath) ? "present" : "missing",
       },
     ],
     helper_availability: [
@@ -59,6 +70,8 @@ export function readStatus(
         status: "unchecked",
       },
     ],
+    settings: readSettingsSummary(settingsPath, settingsPathRef),
+    repos: readRepoRegistrySummary(reposPath, reposPathRef),
   };
 
   const envelope = createEnvelope({
@@ -75,6 +88,109 @@ export function readStatus(
 
   assertNoSecretSentinels(envelope);
   return envelope;
+}
+
+function readSettingsSummary(pathName: string, pathRef: string): GuiSettingsSummary {
+  if (!existsSync(pathName)) {
+    return {
+      ...statusFixture.settings,
+      path_ref: pathRef,
+      health: "missing",
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(pathName, "utf8")) as Record<string, unknown>;
+    const keys = Object.keys(parsed).sort();
+    return {
+      path_ref: pathRef,
+      health: "present",
+      key_count: keys.length,
+      keys,
+      value_policy: "keys_only_no_values",
+    };
+  } catch {
+    return {
+      ...statusFixture.settings,
+      path_ref: pathRef,
+      health: "invalid",
+    };
+  }
+}
+
+function readRepoRegistrySummary(pathName: string, pathRef: string): GuiRepoRegistrySummary {
+  if (!existsSync(pathName)) {
+    return {
+      ...statusFixture.repos,
+      path_ref: pathRef,
+      health: "missing",
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(pathName, "utf8")) as unknown;
+    const repos = extractRepoSummaries(parsed).slice(0, 12);
+    return {
+      path_ref: pathRef,
+      health: "present",
+      total: extractRepoSummaries(parsed).length,
+      repos,
+    };
+  } catch {
+    return {
+      ...statusFixture.repos,
+      path_ref: pathRef,
+      health: "invalid",
+    };
+  }
+}
+
+function extractRepoSummaries(value: unknown): GuiRepoSummary[] {
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => repoSummaryFromUnknown(entry, `repo-${index + 1}`));
+  }
+  if (isRecord(value) && Array.isArray(value.repos)) {
+    return value.repos.map((entry, index) => repoSummaryFromUnknown(entry, `repo-${index + 1}`));
+  }
+  if (isRecord(value)) {
+    return Object.entries(value)
+      .filter(([, entry]) => isRecord(entry))
+      .map(([name, entry]) => repoSummaryFromUnknown(entry, name));
+  }
+
+  return [];
+}
+
+function repoSummaryFromUnknown(value: unknown, fallbackName: string): GuiRepoSummary {
+  if (!isRecord(value)) {
+    return {
+      name: fallbackName,
+      platform: "unknown",
+      slug: fallbackName,
+      local_path_status: "not_provided",
+    };
+  }
+
+  const name = stringField(value, "name") ?? stringField(value, "slug") ?? fallbackName;
+  const slug = stringField(value, "slug") ?? stringField(value, "repo") ?? name;
+  const platform = stringField(value, "platform") ?? stringField(value, "provider") ?? "unknown";
+  const localPath = stringField(value, "path") ?? stringField(value, "local_path");
+
+  return {
+    name,
+    platform,
+    slug,
+    local_path_status: localPath === undefined ? "not_provided" : existsSync(expandHome(localPath)) ? "present" : "missing",
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, key: string): string | undefined {
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
 }
 
 function expandHome(pathRef: string): string {

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -14,6 +14,10 @@ describe("status adapter", () => {
     expect(response.data.runtime).toEqual({ host: "local", api: "hono", read_only: true });
     expect(response.data.update.restart_required).toBeBoolean();
     expect(response.data.update.message).toContain("GUI app");
+    expect(response.data.navigation.map((item) => item.id)).toContain("repos");
+    expect(response.data.settings.value_policy).toBe("keys_only_no_values");
+    expect(response.data.repos.path_ref).toBe("~/.config/aidevops/repos.json");
+    expect(response.data.capabilities.length).toBeGreaterThan(0);
     expect(response.data.secrets[0]).toEqual({ name: "GITHUB_TOKEN", status: "unchecked" });
   });
 });

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -35,6 +35,41 @@ export interface GuiSecretReference {
   status: "configured" | "missing" | "unchecked";
 }
 
+export interface GuiNavigationItem {
+  id: "overview" | "repos" | "settings" | "capabilities" | "security";
+  label: string;
+  description: string;
+}
+
+export interface GuiSettingsSummary {
+  path_ref: string;
+  health: "present" | "missing" | "invalid" | "unchecked";
+  key_count: number;
+  keys: string[];
+  value_policy: "keys_only_no_values";
+}
+
+export interface GuiRepoSummary {
+  name: string;
+  platform: string;
+  slug: string;
+  local_path_status: "present" | "missing" | "not_provided" | "unchecked";
+}
+
+export interface GuiRepoRegistrySummary {
+  path_ref: string;
+  health: "present" | "missing" | "invalid" | "unchecked";
+  total: number;
+  repos: GuiRepoSummary[];
+}
+
+export interface GuiCapabilitySummary {
+  id: string;
+  label: string;
+  status: "available" | "planned" | "placeholder";
+  doc_ref: string;
+}
+
 export interface GuiStatusData {
   aidevops_version: string;
   update: {
@@ -57,6 +92,10 @@ export interface GuiStatusData {
     name: string;
     status: "available" | "missing" | "unchecked";
   }>;
+  navigation: GuiNavigationItem[];
+  settings: GuiSettingsSummary;
+  repos: GuiRepoRegistrySummary;
+  capabilities: GuiCapabilitySummary[];
   secrets: GuiSecretReference[];
   placeholders: string[];
 }

--- a/packages/gui-shared/src/fixtures.ts
+++ b/packages/gui-shared/src/fixtures.ts
@@ -31,6 +31,66 @@ export const statusFixture: GuiStatusData = {
       status: "unchecked",
     },
   ],
+  navigation: [
+    {
+      id: "overview",
+      label: "Overview",
+      description: "Local setup, update, and API health.",
+    },
+    {
+      id: "repos",
+      label: "Repos",
+      description: "Read-only repository registry summary.",
+    },
+    {
+      id: "settings",
+      label: "Settings",
+      description: "Settings file health and keys only.",
+    },
+    {
+      id: "capabilities",
+      label: "Capabilities",
+      description: "Available and planned dashboard surfaces.",
+    },
+    {
+      id: "security",
+      label: "Security",
+      description: "Secret-reference-only trust boundary.",
+    },
+  ],
+  settings: {
+    path_ref: "~/.config/aidevops/settings.json",
+    health: "unchecked",
+    key_count: 0,
+    keys: [],
+    value_policy: "keys_only_no_values",
+  },
+  repos: {
+    path_ref: "~/.config/aidevops/repos.json",
+    health: "unchecked",
+    total: 0,
+    repos: [],
+  },
+  capabilities: [
+    {
+      id: "setup-status",
+      label: "Setup/status",
+      status: "available",
+      doc_ref: "docs/gui/helper-api-contract.md:98",
+    },
+    {
+      id: "repos",
+      label: "Repository registry",
+      status: "placeholder",
+      doc_ref: "docs/gui/helper-api-contract.md:103",
+    },
+    {
+      id: "settings",
+      label: "Effective settings",
+      status: "placeholder",
+      doc_ref: "docs/gui/helper-api-contract.md:101",
+    },
+  ],
   secrets: [
     {
       name: "GITHUB_TOKEN",

--- a/packages/gui-shared/tests/schema.test.ts
+++ b/packages/gui-shared/tests/schema.test.ts
@@ -29,5 +29,8 @@ describe("GUI shared schema contracts", () => {
     expect(envelope.redactions).toContain("secret_values");
     expect(envelope.data.runtime.read_only).toBe(true);
     expect(envelope.data.update.restart_required).toBe(false);
+    expect(envelope.data.navigation.map((item) => item.label)).toContain("Settings");
+    expect(envelope.data.settings.value_policy).toBe("keys_only_no_values");
+    expect(envelope.data.capabilities[0].status).toBe("available");
   });
 });

--- a/packages/gui-web/index.html
+++ b/packages/gui-web/index.html
@@ -7,8 +7,12 @@
   </head>
   <body>
     <div id="root">
-      <main>
-        <section aria-label="aidevops status">
+      <main class="app-shell">
+        <aside class="sidebar" aria-label="Dashboard navigation">
+          <div class="brand-mark">aidevops</div>
+          <button class="nav-item active" type="button"><span>Overview</span><small>Loading local dashboard.</small></button>
+        </aside>
+        <section class="content" aria-label="aidevops status">
           <p class="eyebrow">Read-only local dashboard scaffold</p>
           <h1>aidevops control plane</h1>
           <p class="lede">Loading the local GUI. If this message stays visible, refresh the page or check ~/Library/Logs/aidevops-gui/web.log.</p>

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import type { GuiResponseEnvelope, GuiStatusData } from "../../gui-shared/src";
+import type { GuiNavigationItem, GuiResponseEnvelope, GuiStatusData } from "../../gui-shared/src";
 import { fetchStatus, mockedStatus } from "./status-client";
 
 export function App() {
   const [status, setStatus] = useState<GuiResponseEnvelope<GuiStatusData>>(mockedStatus());
   const [warning, setWarning] = useState<string | null>("Using local fixture until the API responds.");
+  const [activeSection, setActiveSection] = useState<GuiNavigationItem["id"]>("overview");
   const update = status.data.update ?? {
     running_version: status.data.aidevops_version,
     installed_version: status.data.aidevops_version,
@@ -24,54 +25,163 @@ export function App() {
   }, []);
 
   return (
-    <main>
-      <section aria-label="aidevops status">
-        <p className="eyebrow">Read-only local dashboard scaffold</p>
-        <h1>aidevops control plane</h1>
-        <p className="lede">
-          This is the first local GUI surface: setup/status insight only, with no write,
-          destructive, Cloudron, pairing, shell, or exec controls.
-        </p>
-        {warning ? <p role="status">{warning}</p> : null}
-        {update.restart_required ? (
-          <p role="alert">
-            {update.message} Running {update.running_version}; installed {update.installed_version}.
+    <main className="app-shell">
+      <aside className="sidebar" aria-label="Dashboard navigation">
+        <div className="brand-mark">aidevops</div>
+        <nav>
+          {status.data.navigation.map((item) => (
+            <button
+              aria-current={activeSection === item.id ? "page" : undefined}
+              className={activeSection === item.id ? "nav-item active" : "nav-item"}
+              key={item.id}
+              onClick={() => setActiveSection(item.id)}
+              type="button"
+            >
+              <span>{item.label}</span>
+              <small>{item.description}</small>
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      <section className="content" aria-label="aidevops dashboard">
+        <header className="hero">
+          <p className="eyebrow">Read-only local dashboard</p>
+          <h1>aidevops control plane</h1>
+          <p className="lede">
+            Local setup, repos, settings, capabilities, and secret-reference health in one read-only surface.
           </p>
-        ) : (
-          <p role="status">{update.message}</p>
-        )}
-        <dl>
-          <dt>Version</dt>
-          <dd>{status.data.aidevops_version}</dd>
-          <dt>API</dt>
-          <dd>{status.data.runtime.api}</dd>
-        </dl>
-        <h2>Path health</h2>
-        <ul>
-          {status.data.paths.map((path) => (
-            <li key={path.label}>
-              <strong>{path.label}</strong>: {path.health} <code>{path.path_ref}</code>
-            </li>
-          ))}
-        </ul>
-        <h2>Helper availability</h2>
-        <ul>
-          {status.data.helper_availability.map((helper) => (
-            <li key={helper.name}>
-              {helper.name}: {helper.status}
-            </li>
-          ))}
-        </ul>
-        <h2>Secret references</h2>
-        <ul>
-          {status.data.secrets.map((secret) => (
-            <li key={secret.name}>
-              {secret.name}: {secret.status}
-            </li>
-          ))}
-        </ul>
-        <p>{status.data.placeholders[0]}</p>
+          {warning ? <p role="status">{warning}</p> : null}
+          {update.restart_required ? (
+            <p className="alert" role="alert">
+              {update.message} Running {update.running_version}; installed {update.installed_version}.
+            </p>
+          ) : (
+            <p className="notice" role="status">{update.message}</p>
+          )}
+        </header>
+
+        {activeSection === "overview" ? <OverviewSection status={status.data} /> : null}
+        {activeSection === "repos" ? <ReposSection status={status.data} /> : null}
+        {activeSection === "settings" ? <SettingsSection status={status.data} /> : null}
+        {activeSection === "capabilities" ? <CapabilitiesSection status={status.data} /> : null}
+        {activeSection === "security" ? <SecuritySection status={status.data} /> : null}
       </section>
     </main>
+  );
+}
+
+function OverviewSection({ status }: { status: GuiStatusData }) {
+  return (
+    <section className="panel" aria-label="Overview">
+      <div className="card-grid">
+        <MetricCard label="Version" value={status.aidevops_version} detail="Installed framework version" />
+        <MetricCard label="API" value={status.runtime.api} detail="Local read-only API boundary" />
+        <MetricCard label="Repos" value={String(status.repos.total)} detail={status.repos.health} />
+        <MetricCard label="Settings keys" value={String(status.settings.key_count)} detail={status.settings.health} />
+      </div>
+      <h2>Path health</h2>
+      <ul className="object-list">
+        {status.paths.map((path) => (
+          <li key={path.label}>
+            <strong>{path.label}</strong>
+            <span>{path.health}</span>
+            <code>{path.path_ref}</code>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ReposSection({ status }: { status: GuiStatusData }) {
+  return (
+    <section className="panel" aria-label="Repos">
+      <h2>Repos</h2>
+      <p>Read-only registry summary from <code>{status.repos.path_ref}</code>.</p>
+      {status.repos.repos.length === 0 ? (
+        <p className="empty-state">No repo registry entries are available yet.</p>
+      ) : (
+        <ul className="object-list">
+          {status.repos.repos.map((repo) => (
+            <li key={`${repo.platform}:${repo.slug}`}>
+              <strong>{repo.name}</strong>
+              <span>{repo.platform}</span>
+              <small>{repo.slug}</small>
+              <small>local path: {repo.local_path_status}</small>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function SettingsSection({ status }: { status: GuiStatusData }) {
+  return (
+    <section className="panel" aria-label="Settings">
+      <h2>Settings</h2>
+      <p>Values are intentionally not rendered; this view shows keys and file health only.</p>
+      <dl className="inline-details">
+        <dt>Path</dt>
+        <dd><code>{status.settings.path_ref}</code></dd>
+        <dt>Health</dt>
+        <dd>{status.settings.health}</dd>
+        <dt>Policy</dt>
+        <dd>{status.settings.value_policy}</dd>
+      </dl>
+      {status.settings.keys.length === 0 ? (
+        <p className="empty-state">No settings keys are available yet.</p>
+      ) : (
+        <ul className="tag-list">
+          {status.settings.keys.map((key) => <li key={key}>{key}</li>)}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function CapabilitiesSection({ status }: { status: GuiStatusData }) {
+  return (
+    <section className="panel" aria-label="Capabilities">
+      <h2>Capabilities</h2>
+      <ul className="object-list">
+        {status.capabilities.map((capability) => (
+          <li key={capability.id}>
+            <strong>{capability.label}</strong>
+            <span>{capability.status}</span>
+            <code>{capability.doc_ref}</code>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function SecuritySection({ status }: { status: GuiStatusData }) {
+  return (
+    <section className="panel" aria-label="Security">
+      <h2>Security</h2>
+      <p>Secret values, prefixes, suffixes, raw credential files, and arbitrary commands are not exposed.</p>
+      <ul className="object-list">
+        {status.secrets.map((secret) => (
+          <li key={secret.name}>
+            <strong>{secret.name}</strong>
+            <span>{secret.status}</span>
+          </li>
+        ))}
+      </ul>
+      <p>{status.placeholders[0]}</p>
+    </section>
+  );
+}
+
+function MetricCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <article className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{detail}</small>
+    </article>
   );
 }

--- a/packages/gui-web/src/dashboard.ts
+++ b/packages/gui-web/src/dashboard.ts
@@ -12,8 +12,17 @@ export function renderDashboardHtml(status: GuiResponseEnvelope<GuiStatusData>):
   const secrets = status.data.secrets
     .map((secret) => `<li>${escapeHtml(secret.name)}: ${escapeHtml(secret.status)}</li>`)
     .join("");
+  const repos = status.data.repos.repos
+    .map((repo) => `<li>${escapeHtml(repo.name)}: ${escapeHtml(repo.platform)} ${escapeHtml(repo.local_path_status)}</li>`)
+    .join("");
+  const settings = status.data.settings.keys
+    .map((key) => `<li>${escapeHtml(key)}</li>`)
+    .join("");
+  const capabilities = status.data.capabilities
+    .map((capability) => `<li>${escapeHtml(capability.label)}: ${escapeHtml(capability.status)}</li>`)
+    .join("");
 
-  return `<section aria-label="aidevops status"><h1>aidevops control plane</h1><p>Read-only local dashboard scaffold.</p><p>${escapeHtml(status.data.update.message)}</p><dl><dt>Version</dt><dd>${escapeHtml(status.data.aidevops_version)}</dd><dt>API</dt><dd>${escapeHtml(status.data.runtime.api)}</dd></dl><h2>Path health</h2><ul>${paths}</ul><h2>Helper availability</h2><ul>${helpers}</ul><h2>Secret references</h2><ul>${secrets}</ul><p>${escapeHtml(status.data.placeholders[0] ?? "More read-only adapters are planned.")}</p></section>`;
+  return `<section aria-label="aidevops status"><h1>aidevops control plane</h1><p>Read-only local dashboard scaffold.</p><p>${escapeHtml(status.data.update.message)}</p><dl><dt>Version</dt><dd>${escapeHtml(status.data.aidevops_version)}</dd><dt>API</dt><dd>${escapeHtml(status.data.runtime.api)}</dd></dl><h2>Path health</h2><ul>${paths}</ul><h2>Repos</h2><ul>${repos}</ul><h2>Settings</h2><ul>${settings}</ul><h2>Helper availability</h2><ul>${helpers}</ul><h2>Capabilities</h2><ul>${capabilities}</ul><h2>Secret references</h2><ul>${secrets}</ul><p>${escapeHtml(status.data.placeholders[0] ?? "More read-only adapters are planned.")}</p></section>`;
 }
 
 function escapeHtml(value: string): string {

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -8,18 +8,107 @@ body {
   margin: 0;
 }
 
-main {
+.app-shell {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 320px minmax(0, 1fr);
   margin: 0 auto;
-  max-width: 960px;
-  padding: 48px 24px;
+  max-width: 1440px;
+  min-height: 100vh;
+  padding: 32px;
 }
 
-section {
+.sidebar,
+.content,
+.panel,
+.metric-card {
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 16px;
   box-shadow: 0 20px 50px rgb(15 23 42 / 8%);
+}
+
+.sidebar {
+  align-self: start;
+  padding: 24px;
+  position: sticky;
+  top: 32px;
+}
+
+.brand-mark {
+  color: #111827;
+  font-size: 1.4rem;
+  font-weight: 900;
+  margin-bottom: 24px;
+}
+
+.nav-item {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: #374151;
+  cursor: pointer;
+  display: block;
+  margin: 0 0 8px;
+  padding: 14px;
+  text-align: left;
+  width: 100%;
+}
+
+.nav-item:hover,
+.nav-item.active {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #1e40af;
+}
+
+.nav-item span {
+  display: block;
+  font-weight: 800;
+}
+
+.nav-item small {
+  color: #6b7280;
+  display: block;
+  line-height: 1.35;
+  margin-top: 4px;
+}
+
+.content {
   padding: 32px;
+}
+
+.hero {
+  margin-bottom: 24px;
+}
+
+.panel {
+  box-shadow: none;
+  padding: 28px;
+}
+
+.card-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 28px;
+}
+
+.metric-card {
+  box-shadow: none;
+  padding: 20px;
+}
+
+.metric-card span,
+.metric-card small {
+  color: #6b7280;
+  display: block;
+}
+
+.metric-card strong {
+  display: block;
+  font-size: 1.7rem;
+  margin: 8px 0;
 }
 
 .eyebrow {
@@ -34,6 +123,91 @@ section {
   color: #374151;
   font-size: 1.05rem;
   line-height: 1.6;
+}
+
+.notice,
+.alert,
+.empty-state {
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.notice {
+  background: #ecfdf3;
+  color: #05603a;
+}
+
+.alert {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.empty-state {
+  background: #f9fafb;
+  color: #6b7280;
+}
+
+.object-list {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+}
+
+.object-list li {
+  align-items: center;
+  background: #f9fafb;
+  border: 1px solid #eef2f7;
+  border-radius: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 14px;
+}
+
+.object-list li span {
+  background: #eef2ff;
+  border-radius: 999px;
+  color: #3730a3;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 4px 10px;
+}
+
+.inline-details {
+  display: grid;
+  gap: 8px 16px;
+  grid-template-columns: max-content 1fr;
+}
+
+.inline-details dt {
+  color: #6b7280;
+  font-weight: 700;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+}
+
+.tag-list li {
+  background: #f3f4f6;
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+@media (max-width: 880px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    padding: 16px;
+  }
+
+  .sidebar {
+    position: static;
+  }
 }
 
 code {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -9,6 +9,9 @@ describe("dashboard shell", () => {
     expect(html).toContain("aidevops control plane");
     expect(html).toContain("Read-only local dashboard scaffold");
     expect(html).toContain("GUI app");
+    expect(html).toContain("Repos");
+    expect(html).toContain("Settings");
+    expect(html).toContain("Capabilities");
     expect(html).toContain("Secret references");
   });
 });


### PR DESCRIPTION
## Summary

- Adds left sidebar navigation for Overview, Repos, Settings, Capabilities, and Security sections.
- Extends the read-only status contract with settings-key summaries, repo-registry summaries, capability cards, and navigation metadata.
- Reads local settings and repo registry data without returning setting values, secret values, or raw credential material.
- Updates the dashboard layout from a single scaffold panel into a more useful local control-plane v1.

For #25304

## Verification

- `git diff --check origin/main...HEAD` — passed, no output
- `npm run typecheck` — passed
- `npm run gui:test:schema` — 3 pass, 0 fail
- `npm run gui:test:adapters` — 2 pass, 0 fail
- `npm run gui:test:api` — 2 pass, 0 fail
- `npm run gui:test:components` — 2 pass, 0 fail
- `npm run gui:test:security` — 4 pass, 0 fail
- `npm run gui:test:smoke` — 1 pass, 0 fail
- `npm run gui:desktop:check` — passed
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — passed, no output
- `npm run gui:desktop:install:macos && open /Applications/aidevops.app` then `fetch http://127.0.0.1:5173/api/status` — returned navigation labels `Overview`, `Repos`, `Settings`, `Capabilities`, `Security`; settings key count and capability count populated

## Safety

- Still read-only: no write/destructive routes.
- Still no shell/exec route.
- Settings view returns keys only, not values.
- Secrets remain references/status only.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 58m and 673,931 tokens on this with the user in an interactive session.
