### PR TITLE
feat: add OpenCode Desktop app isolation

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -218,6 +218,32 @@ OPENCODE_DB_MAINTENANCE_HOUR=8 \
 - `~/.aidevops/.agent-workspace/work/opencode-maintenance/maintenance.log`
   — append-only history
 
+## OpenCode Desktop isolation on macOS
+
+OpenCode Desktop (`OpenCode.app`) also honors `XDG_DATA_HOME` for the session
+database. To keep Desktop off the shared CLI hot spot, aidevops installs a
+macOS app wrapper when Desktop is present:
+
+```bash
+aidevops opencode-desktop install-shortcut
+open ~/Applications/OpenCode\ AIDevOps.app
+```
+
+The generated `~/Applications/OpenCode AIDevOps.app` calls the deployed
+`opencode-launcher-helper.sh`, which exports an isolated Desktop data directory
+under `~/.aidevops/.agent-workspace/work/opencode-desktop/` before execing
+`/Applications/OpenCode.app/Contents/MacOS/OpenCode`. This keeps Desktop session
+rows out of `~/.local/share/opencode/opencode.db` while preserving the normal
+Electron app support directory for window state and preferences.
+
+CLI entry points:
+
+```bash
+aidevops opencode-desktop                 # launch Desktop with isolated DB
+aidevops opencode-desktop --dir ~/Git/repo # per-project Desktop shard
+aidevops opencode-desktop status          # show wrapper/source status
+```
+
 ## Hidden session lookup — child, archive, and project ID drift
 
 **Symptom:** The TUI `/sessions` picker or `opencode session list` does not show a session that should still exist. Closing and reopening opencode does not help.

--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -24,9 +24,14 @@ print_info() { printf '%b[INFO]%b %s\n' "${YELLOW}" "${NC}" "$*"; return 0; }
 print_success() { printf '%b[OK]%b %s\n' "${GREEN}" "${NC}" "$*"; return 0; }
 print_error() { printf '%b[ERROR]%b %s\n' "${RED}" "${NC}" "$*" >&2; return 0; }
 
+OPT_DESKTOP_SOURCE_BINARY="--source-binary"
+
 usage() {
     cat <<'EOF'
 Usage: aidevops opencode [options] [--] [opencode args...]
+       aidevops opencode-desktop [launch options]
+       aidevops opencode-desktop install-shortcut [options]
+       aidevops opencode-desktop status [options]
 
 Launch OpenCode with an isolated per-project SQLite DB by default.
 
@@ -41,6 +46,38 @@ Examples:
   aidevops opencode
   aidevops opencode --dir ~/Git/aidevops
   aidevops opencode -- --version
+  aidevops opencode-desktop
+  aidevops opencode-desktop install-shortcut
+EOF
+    return 0
+}
+
+desktop_usage() {
+    cat <<EOF
+Usage: aidevops opencode-desktop [launch options]
+       aidevops opencode-desktop install-shortcut [options]
+       aidevops opencode-desktop status [options]
+
+Launch OpenCode Desktop with an aidevops-managed XDG_DATA_HOME so the Desktop
+app does not write to the shared ~/.local/share/opencode/opencode.db hot spot.
+
+Launch options:
+  --dir PATH             Working directory for Desktop (default: cwd; app bundle: HOME)
+  --session-id ID        Explicit isolated DB name (default: desktop-default or per-project)
+  --data-dir PATH        Explicit XDG_DATA_HOME for Desktop
+  ${OPT_DESKTOP_SOURCE_BINARY} PATH   OpenCode.app executable path
+  --dry-run              Print the command without launching
+
+Shortcut options:
+  --name NAME            App display name (default: OpenCode AIDevOps)
+  --app-dir PATH         Parent directory for the generated .app (default: ~/Applications)
+  ${OPT_DESKTOP_SOURCE_BINARY} PATH   OpenCode.app executable path
+  --dry-run              Print the target path without writing
+
+Environment overrides:
+  AIDEVOPS_OPENCODE_DESKTOP_APP_DIR       Parent directory for generated .app
+  AIDEVOPS_OPENCODE_DESKTOP_BINARY        OpenCode Desktop executable path
+  AIDEVOPS_OPENCODE_DESKTOP_DATA_DIR      Explicit Desktop XDG_DATA_HOME
 EOF
     return 0
 }
@@ -100,7 +137,392 @@ build_project_session_id() {
     return 0
 }
 
+build_desktop_data_dir() {
+    local session_id="$1"
+    local launch_dir="${2:-}"
+    local safe_id=""
+
+    if [[ -z "${session_id}" ]]; then
+        if [[ -n "${launch_dir}" ]]; then
+            session_id="desktop-$(build_project_session_id "${launch_dir}")"
+        else
+            session_id="desktop-default"
+        fi
+    fi
+    safe_id=$(sql_escape_label "${session_id}")
+    printf '%s/opencode-desktop/%s' "${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}" "${safe_id}"
+    return 0
+}
+
+xml_escape() {
+    local value="$1"
+    value=${value//&/\&amp;}
+    value=${value//</\&lt;}
+    value=${value//>/\&gt;}
+    value=${value//\"/\&quot;}
+    value=${value//\'/\&apos;}
+    printf '%s' "${value}"
+    return 0
+}
+
+write_file_if_changed() {
+    local path="$1"
+    local content="$2"
+    local tmp_path="${path}.tmp.$$"
+
+    if [[ -f "${path}" ]]; then
+        printf '%s' "${content}" >"${tmp_path}" || return 1
+        if cmp -s "${tmp_path}" "${path}"; then
+            rm -f "${tmp_path}" || true
+            return 0
+        fi
+        mv "${tmp_path}" "${path}" || return 1
+        return 0
+    fi
+    printf '%s' "${content}" >"${path}" || return 1
+    return 0
+}
+
+is_macos() {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+detect_desktop_binary() {
+    local explicit_binary="${1:-}"
+
+    if [[ -n "${explicit_binary}" ]]; then
+        [[ -x "${explicit_binary}" ]] || return 1
+        printf '%s' "${explicit_binary}"
+        return 0
+    fi
+    if [[ -n "${AIDEVOPS_OPENCODE_DESKTOP_BINARY:-}" ]]; then
+        [[ -x "${AIDEVOPS_OPENCODE_DESKTOP_BINARY}" ]] || return 1
+        printf '%s' "${AIDEVOPS_OPENCODE_DESKTOP_BINARY}"
+        return 0
+    fi
+    if [[ -x "/Applications/OpenCode.app/Contents/MacOS/OpenCode" ]]; then
+        printf '%s' "/Applications/OpenCode.app/Contents/MacOS/OpenCode"
+        return 0
+    fi
+    if [[ -x "${HOME}/Applications/OpenCode.app/Contents/MacOS/OpenCode" ]]; then
+        printf '%s' "${HOME}/Applications/OpenCode.app/Contents/MacOS/OpenCode"
+        return 0
+    fi
+    return 1
+}
+
+desktop_app_path() {
+    local app_name="$1"
+    local app_dir="$2"
+    local safe_name=""
+
+    safe_name=${app_name//\//-}
+    safe_name=${safe_name:-OpenCode AIDevOps}
+    printf '%s/%s.app' "${app_dir}" "${safe_name}"
+    return 0
+}
+
+desktop_wrapper_content() {
+    cat <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+helper="${AIDEVOPS_OPENCODE_LAUNCHER_HELPER:-${HOME}/.aidevops/agents/scripts/opencode-launcher-helper.sh}"
+if [[ ! -x "${helper}" ]]; then
+    osascript -e 'display alert "OpenCode AIDevOps launcher is not installed" message "Run aidevops update, then open this app again."' >/dev/null 2>&1 || true
+    exit 1
+fi
+
+exec "${helper}" desktop launch --from-app "$@"
+EOF
+    return 0
+}
+
+desktop_plist_content() {
+    local app_name="$1"
+    local bundle_id="$2"
+    local executable_name="$3"
+
+    cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>$(xml_escape "${app_name}")</string>
+  <key>CFBundleDisplayName</key>
+  <string>$(xml_escape "${app_name}")</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(xml_escape "${bundle_id}")</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleExecutable</key>
+  <string>$(xml_escape "${executable_name}")</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.13</string>
+</dict>
+</plist>
+EOF
+    return 0
+}
+
+cmd_desktop_install_shortcut() {
+    local app_name="OpenCode AIDevOps"
+    local app_dir="${AIDEVOPS_OPENCODE_DESKTOP_APP_DIR:-${HOME}/Applications}"
+    local source_binary=""
+    local dry_run=0
+
+    while (($# > 0)); do
+        case "$1" in
+        --name)
+            [[ $# -ge 2 ]] || { print_error "--name requires a value"; return 1; }
+            app_name="$2"
+            shift 2
+            ;;
+        --app-dir)
+            [[ $# -ge 2 ]] || { print_error "--app-dir requires a path"; return 1; }
+            app_dir="$2"
+            shift 2
+            ;;
+        "${OPT_DESKTOP_SOURCE_BINARY}")
+            [[ $# -ge 2 ]] || { print_error "${OPT_DESKTOP_SOURCE_BINARY} requires a path"; return 1; }
+            source_binary="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --help | -h)
+            desktop_usage
+            return 0
+            ;;
+        *)
+            print_error "Unknown install-shortcut option: $1"
+            return 1
+            ;;
+        esac
+    done
+
+    if ! is_macos; then
+        print_info "OpenCode Desktop app shortcut install is currently macOS-only"
+        return 0
+    fi
+    if ! detect_desktop_binary "${source_binary}" >/dev/null 2>&1; then
+        print_info "OpenCode Desktop app not found; skipping shortcut install"
+        return 3
+    fi
+
+    local app_path=""
+    local contents_dir=""
+    local macos_dir=""
+    local plist_path=""
+    local executable_name="opencode-aidevops"
+    local executable_path=""
+    local bundle_id="sh.aidevops.opencode.desktop"
+
+    app_path=$(desktop_app_path "${app_name}" "${app_dir}")
+    contents_dir="${app_path}/Contents"
+    macos_dir="${contents_dir}/MacOS"
+    plist_path="${contents_dir}/Info.plist"
+    executable_path="${macos_dir}/${executable_name}"
+
+    if ((dry_run == 1)); then
+        printf '%s\n' "${app_path}"
+        return 0
+    fi
+
+    mkdir -p "${macos_dir}" || return 1
+    write_file_if_changed "${plist_path}" "$(desktop_plist_content "${app_name}" "${bundle_id}" "${executable_name}")" || return 1
+    write_file_if_changed "${executable_path}" "$(desktop_wrapper_content)" || return 1
+    chmod 755 "${executable_path}" || return 1
+    print_success "Installed ${app_name}.app at ${app_path}"
+    return 0
+}
+
+cmd_desktop_status() {
+    local app_name="OpenCode AIDevOps"
+    local app_dir="${AIDEVOPS_OPENCODE_DESKTOP_APP_DIR:-${HOME}/Applications}"
+    local source_binary=""
+    local app_path=""
+
+    while (($# > 0)); do
+        case "$1" in
+        --name)
+            [[ $# -ge 2 ]] || { print_error "--name requires a value"; return 1; }
+            app_name="$2"
+            shift 2
+            ;;
+        --app-dir)
+            [[ $# -ge 2 ]] || { print_error "--app-dir requires a path"; return 1; }
+            app_dir="$2"
+            shift 2
+            ;;
+        "${OPT_DESKTOP_SOURCE_BINARY}")
+            [[ $# -ge 2 ]] || { print_error "${OPT_DESKTOP_SOURCE_BINARY} requires a path"; return 1; }
+            source_binary="$2"
+            shift 2
+            ;;
+        --help | -h)
+            desktop_usage
+            return 0
+            ;;
+        *)
+            print_error "Unknown status option: $1"
+            return 1
+            ;;
+        esac
+    done
+
+    app_path=$(desktop_app_path "${app_name}" "${app_dir}")
+    if [[ -d "${app_path}" ]]; then
+        print_success "Desktop shortcut installed: ${app_path}"
+    else
+        print_info "Desktop shortcut not installed: ${app_path}"
+    fi
+    if detect_desktop_binary "${source_binary}" >/dev/null 2>&1; then
+        print_success "OpenCode Desktop source app found"
+    else
+        print_info "OpenCode Desktop source app not found"
+    fi
+    return 0
+}
+
+cmd_desktop_launch() {
+    local dry_run=0
+    local launch_dir="$PWD"
+    local launch_dir_set=0
+    local from_app=0
+    local session_id=""
+    local data_dir="${AIDEVOPS_OPENCODE_DESKTOP_DATA_DIR:-}"
+    local source_binary=""
+    local -a desktop_args=()
+
+    while (($# > 0)); do
+        case "$1" in
+        --dir)
+            [[ $# -ge 2 ]] || { print_error "--dir requires a path"; return 1; }
+            launch_dir="$2"
+            launch_dir_set=1
+            shift 2
+            ;;
+        --session-id)
+            [[ $# -ge 2 ]] || { print_error "--session-id requires a value"; return 1; }
+            session_id="$2"
+            shift 2
+            ;;
+        --data-dir)
+            [[ $# -ge 2 ]] || { print_error "--data-dir requires a path"; return 1; }
+            data_dir="$2"
+            shift 2
+            ;;
+        "${OPT_DESKTOP_SOURCE_BINARY}")
+            [[ $# -ge 2 ]] || { print_error "${OPT_DESKTOP_SOURCE_BINARY} requires a path"; return 1; }
+            source_binary="$2"
+            shift 2
+            ;;
+        --from-app)
+            from_app=1
+            shift
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --help | -h)
+            desktop_usage
+            return 0
+            ;;
+        --)
+            shift
+            desktop_args+=("$@")
+            break
+            ;;
+        *)
+            desktop_args+=("$1")
+            shift
+            ;;
+        esac
+    done
+
+    if ! is_macos; then
+        print_error "OpenCode Desktop launch is currently macOS-only"
+        return 1
+    fi
+
+    local desktop_binary=""
+    if ! desktop_binary=$(detect_desktop_binary "${source_binary}"); then
+        print_error "OpenCode Desktop app not found. Install OpenCode.app or pass --source-binary PATH."
+        return 1
+    fi
+
+    if ((from_app == 1 && launch_dir_set == 0)); then
+        launch_dir="${HOME}"
+    fi
+    [[ -d "${launch_dir}" ]] || { print_error "Directory not found: ${launch_dir}"; return 1; }
+
+    if [[ -z "${data_dir}" ]]; then
+        if ((launch_dir_set == 1)); then
+            data_dir=$(build_desktop_data_dir "${session_id}" "${launch_dir}")
+        else
+            data_dir=$(build_desktop_data_dir "${session_id}" "")
+        fi
+    fi
+    mkdir -p "${data_dir}/opencode" || return 1
+    copy_auth_json "${data_dir}" || true
+    prewarm_opencode_data_dir "${data_dir}"
+
+    if ((dry_run == 1)); then
+        printf 'cd %q && XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1 %q' "${launch_dir}" "${data_dir}" "${desktop_binary}"
+        printf ' %q' "${desktop_args[@]}"
+        printf '\n'
+        return 0
+    fi
+
+    cd "${launch_dir}" || return 1
+    export XDG_DATA_HOME="${data_dir}"
+    export AIDEVOPS_OPENCODE_ISOLATED_DB=1
+    exec "${desktop_binary}" "${desktop_args[@]}"
+    return 1
+}
+
+cmd_desktop() {
+    local subcommand="${1:-launch}"
+    case "${subcommand}" in
+    launch)
+        shift || true
+        cmd_desktop_launch "$@"
+        ;;
+    install-shortcut | install-app | install)
+        shift || true
+        cmd_desktop_install_shortcut "$@"
+        ;;
+    status)
+        shift || true
+        cmd_desktop_status "$@"
+        ;;
+    help | --help | -h)
+        desktop_usage
+        ;;
+    *)
+        cmd_desktop_launch "$@"
+        ;;
+    esac
+    return $?
+}
+
 main() {
+    if [[ "${1:-}" == "desktop" ]]; then
+        shift || true
+        cmd_desktop "$@"
+        return $?
+    fi
+
     local use_shared_db=0
     local dry_run=0
     local launch_dir="$PWD"

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -2273,6 +2273,33 @@ setup_opencode_cli() {
 	return 0
 }
 
+setup_opencode_desktop_launcher() {
+	if [[ "$(uname -s)" != "Darwin" ]]; then
+		return 0
+	fi
+
+	local launcher_script="${HOME}/.aidevops/agents/scripts/opencode-launcher-helper.sh"
+	if ! [[ -x "$launcher_script" ]]; then
+		return 0
+	fi
+
+	local install_rc=0
+	bash "$launcher_script" desktop install-shortcut >/dev/null 2>&1 || install_rc=$?
+	case "$install_rc" in
+	0)
+		print_success "OpenCode AIDevOps Desktop app installed in ~/Applications"
+		;;
+	3)
+		# OpenCode Desktop is optional; do not warn on systems that only use the CLI.
+		return 0
+		;;
+	*)
+		print_warning "Failed to install OpenCode AIDevOps Desktop app wrapper"
+		;;
+	esac
+	return 0
+}
+
 setup_codex_cli() {
 	print_info "Setting up OpenAI Codex CLI..."
 

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -57,6 +57,13 @@ fake_log="${tmp_root}/fake-opencode.log"
 mkdir -p "${work_dir}" "${launch_dir}" "${home_dir}/.local/share/opencode"
 make_fake_opencode "${fake_bin}"
 printf '{"anthropic":{}}\n' >"${home_dir}/.local/share/opencode/auth.json"
+desktop_source="${tmp_root}/OpenCode.app/Contents/MacOS/OpenCode"
+mkdir -p "$(dirname "${desktop_source}")"
+cat >"${desktop_source}" <<'SH'
+#!/usr/bin/env bash
+printf 'desktop source launched\n'
+SH
+chmod +x "${desktop_source}"
 
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" FAKE_OPENCODE_LOG="${fake_log}" \
     "${HELPER}" --dir "${launch_dir}" -- --version 2>&1)
@@ -102,6 +109,31 @@ if [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB="* ]] \
     _pass "shared-db mode leaves OpenCode data dir untouched"
 else
     _fail "shared-db launcher output unexpected: ${output}"
+fi
+
+desktop_app_dir="${tmp_root}/Applications"
+output=$(HOME="${home_dir}" "${HELPER}" desktop install-shortcut --app-dir "${desktop_app_dir}" --source-binary "${desktop_source}" 2>&1)
+desktop_app="${desktop_app_dir}/OpenCode AIDevOps.app"
+desktop_wrapper="${desktop_app}/Contents/MacOS/opencode-aidevops"
+desktop_plist="${desktop_app}/Contents/Info.plist"
+if [[ -x "${desktop_wrapper}" ]] \
+    && [[ -f "${desktop_plist}" ]] \
+    && grep -q "sh.aidevops.opencode.desktop" "${desktop_plist}" \
+    && grep -q "desktop launch --from-app" "${desktop_wrapper}" \
+    && [[ "${output}" == *"Installed OpenCode AIDevOps.app"* ]]; then
+    _pass "desktop install-shortcut creates macOS app wrapper"
+else
+    _fail "desktop app wrapper install unexpected: ${output}"
+fi
+
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" desktop launch --source-binary "${desktop_source}" --dir "${launch_dir}" --dry-run 2>&1)
+if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-desktop/desktop-project-repo-"* ]] \
+    && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
+    && [[ "${output}" == *"${desktop_source}"* ]]; then
+    _pass "desktop launch dry-run uses isolated per-project data dir"
+else
+    _fail "desktop launch dry-run output unexpected: ${output}"
 fi
 
 if ((fail_count > 0)); then

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -847,6 +847,7 @@ _help_commands() {
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-db <cmd>  OpenCode SQLite maintenance/session lookup (check/report/sessions/maintain/window/status/install)"
 	echo "  opencode [args]    Launch OpenCode with aidevops per-session DB isolation"
+	echo "  opencode-desktop   Launch/install OpenCode Desktop with aidevops DB isolation"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
 	echo "  circuit-breaker    Supervisor circuit breaker (status/reset/check/trip) (alias: cb)"
@@ -1626,6 +1627,7 @@ main() {
 	github-app-auth | github-app | gh-auth) _dispatch_helper "github-app-auth-helper.sh" "github-app-auth-helper.sh" "$@" ;;
 	opencode-db | oc-db) _dispatch_helper "opencode-db-maintenance-helper.sh" "opencode-db-maintenance-helper.sh" "$@" ;;
 	opencode | oc) _dispatch_helper "opencode-launcher-helper.sh" "opencode-launcher-helper.sh" "$@" ;;
+	opencode-desktop | oc-desktop) _dispatch_helper "opencode-launcher-helper.sh" "opencode-launcher-helper.sh" desktop "$@" ;;
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;

--- a/setup.sh
+++ b/setup.sh
@@ -1246,6 +1246,31 @@ _setup_run_non_interactive() {
 	return 0
 }
 
+# Interactive runtime/tool setup prompts. Extracted so the parent interactive
+# setup function stays below the function-complexity gate while preserving the
+# prompt order around runtime-specific installers and config updates.
+_setup_run_interactive_runtime_tools() {
+	confirm_step "Deploy aidevops agents to runtime agent directories" && deploy_agents_to_runtimes
+	confirm_step "Setup Python environment (DSPy, crawl4ai)" && setup_python_env
+	confirm_step "Setup Node.js environment" && setup_nodejs_env
+	confirm_step "Install MCP packages globally (fast startup)" && install_mcp_packages
+	confirm_step "Setup LocalWP MCP server" && setup_localwp_mcp
+	confirm_step "Setup Beads task management" && setup_beads
+	confirm_step "Setup SEO integrations (curl subagents)" && setup_seo_mcps
+	confirm_step "Setup Google Analytics MCP" && setup_google_analytics_mcp
+	confirm_step "Setup QuickFile MCP (UK accounting)" && setup_quickfile_mcp
+	confirm_step "Setup browser automation tools" && setup_browser_tools
+	confirm_step "Setup AI orchestration frameworks info" && setup_ai_orchestration
+	confirm_step "Setup Ollama (local LLM for knowledge plane pii/sensitive/privileged tiers)" && setup_ollama_for_knowledge
+	confirm_step "Setup Google Workspace CLI (Gmail, Calendar, Drive)" && setup_google_workspace_cli
+	confirm_step "Setup OpenCode CLI (AI coding tool)" && setup_opencode_cli
+	confirm_step "Install OpenCode AIDevOps Desktop app wrapper" && setup_opencode_desktop_launcher
+	confirm_step "Setup OpenCode plugins" && setup_opencode_plugins
+	confirm_step "Setup Codex CLI (OpenAI AI coding tool)" && setup_codex_cli
+	confirm_step "Setup Droid CLI (Factory.AI coding tool)" && setup_droid_cli
+	return 0
+}
+
 # Interactive path: all optional steps gated behind confirm_step prompts.
 _setup_run_interactive() {
 	# Required steps (always run)
@@ -1315,24 +1340,7 @@ _setup_run_interactive() {
 	confirm_step "Check for skill updates from upstream" && check_skill_updates
 	confirm_step "Security scan imported skills" && scan_imported_skills
 	confirm_step "Inject agents reference into AI configs" && inject_agents_reference
-	confirm_step "Deploy aidevops agents to runtime agent directories" && deploy_agents_to_runtimes
-	confirm_step "Setup Python environment (DSPy, crawl4ai)" && setup_python_env
-	confirm_step "Setup Node.js environment" && setup_nodejs_env
-	confirm_step "Install MCP packages globally (fast startup)" && install_mcp_packages
-	confirm_step "Setup LocalWP MCP server" && setup_localwp_mcp
-	confirm_step "Setup Beads task management" && setup_beads
-	confirm_step "Setup SEO integrations (curl subagents)" && setup_seo_mcps
-	confirm_step "Setup Google Analytics MCP" && setup_google_analytics_mcp
-	confirm_step "Setup QuickFile MCP (UK accounting)" && setup_quickfile_mcp
-	confirm_step "Setup browser automation tools" && setup_browser_tools
-	confirm_step "Setup AI orchestration frameworks info" && setup_ai_orchestration
-	confirm_step "Setup Ollama (local LLM for knowledge plane pii/sensitive/privileged tiers)" && setup_ollama_for_knowledge
-	confirm_step "Setup Google Workspace CLI (Gmail, Calendar, Drive)" && setup_google_workspace_cli
-	confirm_step "Setup OpenCode CLI (AI coding tool)" && setup_opencode_cli
-	confirm_step "Install OpenCode AIDevOps Desktop app wrapper" && setup_opencode_desktop_launcher
-	confirm_step "Setup OpenCode plugins" && setup_opencode_plugins
-	confirm_step "Setup Codex CLI (OpenAI AI coding tool)" && setup_codex_cli
-	confirm_step "Setup Droid CLI (Factory.AI coding tool)" && setup_droid_cli
+	_setup_run_interactive_runtime_tools
 	# Run AFTER CLI installs so config dirs may exist for agent config
 	confirm_step "Update OpenCode configuration" && update_opencode_config
 	# Run AFTER OpenCode config so Claude Code gets equivalent setup

--- a/setup.sh
+++ b/setup.sh
@@ -1110,6 +1110,7 @@ _setup_run_scoped_stage() {
 	case "$stage" in
 	"$SETUP_STAGE_OPENCODE")
 		_time_step "$SETUP_STAGE_OPENCODE" setup_opencode_cli
+		_time_step "setup_opencode_desktop_launcher" setup_opencode_desktop_launcher
 		;;
 	"$SETUP_STAGE_AGENTS")
 		_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
@@ -1171,6 +1172,7 @@ _setup_run_non_interactive() {
 	_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
 	_time_step "_setup_install_pulse_plist_early" _setup_install_pulse_plist_early
 	_time_step "_deploy_hotfix_config" _deploy_hotfix_config
+	_time_step "setup_opencode_desktop_launcher" setup_opencode_desktop_launcher
 	_time_step "sync_agent_sources" sync_agent_sources
 	_time_step "install_aidevops_cli" install_aidevops_cli
 	_time_step "setup_shellcheck_wrapper" setup_shellcheck_wrapper
@@ -1327,6 +1329,7 @@ _setup_run_interactive() {
 	confirm_step "Setup Ollama (local LLM for knowledge plane pii/sensitive/privileged tiers)" && setup_ollama_for_knowledge
 	confirm_step "Setup Google Workspace CLI (Gmail, Calendar, Drive)" && setup_google_workspace_cli
 	confirm_step "Setup OpenCode CLI (AI coding tool)" && setup_opencode_cli
+	confirm_step "Install OpenCode AIDevOps Desktop app wrapper" && setup_opencode_desktop_launcher
 	confirm_step "Setup OpenCode plugins" && setup_opencode_plugins
 	confirm_step "Setup Codex CLI (OpenAI AI coding tool)" && setup_codex_cli
 	confirm_step "Setup Droid CLI (Factory.AI coding tool)" && setup_droid_cli


### PR DESCRIPTION
## Summary
- add `aidevops opencode-desktop` for macOS OpenCode Desktop launches with isolated `XDG_DATA_HOME`
- install/refresh `~/Applications/OpenCode AIDevOps.app` during setup/update when OpenCode Desktop is present
- document Desktop isolation and add launcher regression coverage

Resolves #25317

## Verification
- `bash -n` on modified shell files
- `shellcheck` on modified shell files
- `.agents/scripts/tests/test-opencode-launcher-helper.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.7 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 1h 5m and 496,565 tokens on this with the user in an interactive session.
