### PR TITLE
feat: make GUI shell app-like

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -59,12 +59,25 @@ export function App() {
 
   return (
     <main className="app-shell">
-      <aside className="sidebar" aria-label="Dashboard navigation">
-        <div className="brand-mark" aria-label="aidevops">
-          <span className="terminal-mark" aria-hidden="true">›_</span>
-          <span>aidevops</span>
+      <header className="app-topbar" aria-label="App controls">
+        <div className="window-controls" aria-hidden="true">
+          <span className="traffic red" />
+          <span className="traffic yellow" />
+          <span className="traffic green" />
         </div>
-        <div className="theme-control" aria-label="Theme preference">
+        <div className="topbar-brand" aria-label="aidevops">
+          <span className="terminal-mark small" aria-hidden="true">›_</span>
+          <strong>aidevops</strong>
+        </div>
+        <div className="command-palette" aria-label="Read-only dashboard search placeholder">
+          <span aria-hidden="true">⌘K</span>
+          <input aria-label="Search dashboard" disabled placeholder="Search setup, repos, settings, capabilities" />
+        </div>
+        <div className="topbar-status">
+          <span className="status-dot" aria-hidden="true" />
+          <span>read-only</span>
+        </div>
+        <div className="theme-control compact" aria-label="Theme preference">
           {(["system", "light", "dark"] as const).map((theme) => (
             <button
               aria-pressed={themePreference === theme}
@@ -76,47 +89,83 @@ export function App() {
               {theme}
             </button>
           ))}
-          <small>Theme: {themePreference === "system" ? `system (${systemTheme})` : themePreference}</small>
         </div>
-        <nav>
-          {status.data.navigation.map((item) => (
-            <button
-              aria-current={activeSection === item.id ? "page" : undefined}
-              className={activeSection === item.id ? "nav-item active" : "nav-item"}
-              key={item.id}
-              onClick={() => setActiveSection(item.id)}
-              type="button"
-            >
-              <span>{item.label}</span>
-              <small>{item.description}</small>
-            </button>
-          ))}
-        </nav>
-      </aside>
+      </header>
 
-      <section className="content" aria-label="aidevops dashboard">
-        <header className="hero">
-          <p className="eyebrow">Read-only local dashboard</p>
-          <h1>aidevops control plane</h1>
-          <p className="lede">
-            Local setup, repos, settings, capabilities, and secret-reference health in one read-only surface.
-          </p>
-          {warning ? <p role="status">{warning}</p> : null}
-          {update.restart_required ? (
-            <p className="alert" role="alert">
-              {update.message} Running {update.running_version}; installed {update.installed_version}.
+      <div className="workspace">
+        <aside className="sidebar" aria-label="Dashboard navigation">
+          <div className="brand-mark" aria-label="aidevops">
+            <span className="terminal-mark" aria-hidden="true">›_</span>
+            <span>aidevops</span>
+          </div>
+          <p className="sidebar-kicker">Control library</p>
+          <nav>
+            {status.data.navigation.map((item) => (
+              <button
+                aria-current={activeSection === item.id ? "page" : undefined}
+                className={activeSection === item.id ? "nav-item active" : "nav-item"}
+                key={item.id}
+                onClick={() => setActiveSection(item.id)}
+                type="button"
+              >
+                <span>{item.label}</span>
+                <small>{item.description}</small>
+              </button>
+            ))}
+          </nav>
+        </aside>
+
+        <section className="content" aria-label="aidevops dashboard">
+          <header className="hero">
+            <p className="eyebrow">Read-only local dashboard</p>
+            <h1>aidevops control plane</h1>
+            <p className="lede">
+              Local setup, repos, settings, capabilities, and secret-reference health in one app-like surface.
             </p>
-          ) : (
-            <p className="notice" role="status">{update.message}</p>
-          )}
-        </header>
+            {warning ? <p role="status">{warning}</p> : null}
+            {update.restart_required ? (
+              <p className="alert" role="alert">
+                {update.message} Running {update.running_version}; installed {update.installed_version}.
+              </p>
+            ) : (
+              <p className="notice" role="status">{update.message}</p>
+            )}
+          </header>
 
-        {activeSection === "overview" ? <OverviewSection status={status.data} /> : null}
-        {activeSection === "repos" ? <ReposSection status={status.data} /> : null}
-        {activeSection === "settings" ? <SettingsSection status={status.data} /> : null}
-        {activeSection === "capabilities" ? <CapabilitiesSection status={status.data} /> : null}
-        {activeSection === "security" ? <SecuritySection status={status.data} /> : null}
-      </section>
+          {activeSection === "overview" ? <OverviewSection status={status.data} /> : null}
+          {activeSection === "repos" ? <ReposSection status={status.data} /> : null}
+          {activeSection === "settings" ? <SettingsSection status={status.data} /> : null}
+          {activeSection === "capabilities" ? <CapabilitiesSection status={status.data} /> : null}
+          {activeSection === "security" ? <SecuritySection status={status.data} /> : null}
+        </section>
+
+        <aside className="detail-rail" aria-label="Dashboard details">
+          <section className="rail-card now-card">
+            <p className="eyebrow">Now viewing</p>
+            <h2>{status.data.navigation.find((item) => item.id === activeSection)?.label ?? "Overview"}</h2>
+            <p>{status.data.navigation.find((item) => item.id === activeSection)?.description}</p>
+          </section>
+          <section className="rail-card">
+            <h3>Local mode</h3>
+            <ul>
+              <li><span>API</span><strong>{status.data.runtime.api}</strong></li>
+              <li><span>Version</span><strong>{status.data.aidevops_version}</strong></li>
+              <li><span>Theme</span><strong>{themePreference === "system" ? systemTheme : themePreference}</strong></li>
+            </ul>
+          </section>
+          <section className="rail-card">
+            <h3>Trust boundary</h3>
+            <p>No writes, shell, exec, Cloudron control, pairing, or secret values.</p>
+          </section>
+        </aside>
+      </div>
+
+      <footer className="app-statusbar" aria-label="App status">
+        <span>Local API: {status.data.runtime.api}</span>
+        <span>Repos: {status.data.repos.total}</span>
+        <span>Settings keys: {status.data.settings.key_count}</span>
+        <span>Theme: {themePreference === "system" ? `system/${systemTheme}` : themePreference}</span>
+      </footer>
     </main>
   );
 }

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -307,3 +307,267 @@ code {
   border-radius: 4px;
   padding: 2px 4px;
 }
+
+/* Desktop-app shell: closer to a native/web-app control surface than a document page. */
+.app-shell {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr;
+  grid-template-rows: 52px minmax(0, 1fr) 52px;
+  height: 100vh;
+  margin: 0;
+  max-width: none;
+  min-height: 0;
+  padding: 8px;
+}
+
+.app-topbar,
+.app-statusbar {
+  align-items: center;
+  background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgb(0 0 0 / 18%);
+  display: flex;
+  gap: 14px;
+  min-width: 0;
+  padding: 8px 12px;
+}
+
+.window-controls {
+  display: flex;
+  gap: 8px;
+  padding: 0 4px;
+}
+
+.traffic {
+  border-radius: 50%;
+  display: block;
+  height: 13px;
+  width: 13px;
+}
+
+.traffic.red {
+  background: #ff5f57;
+}
+
+.traffic.yellow {
+  background: #febc2e;
+}
+
+.traffic.green {
+  background: #28c840;
+}
+
+.topbar-brand {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 128px;
+}
+
+.terminal-mark.small {
+  font-size: 0.78rem;
+  height: 32px;
+  width: 38px;
+}
+
+.command-palette {
+  align-items: center;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: flex;
+  flex: 1;
+  gap: 10px;
+  min-width: 240px;
+  padding: 7px 14px;
+}
+
+.command-palette span {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.command-palette input {
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  flex: 1;
+  font: inherit;
+  min-width: 0;
+}
+
+.topbar-status,
+.app-statusbar span {
+  align-items: center;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  font-size: 0.82rem;
+  gap: 8px;
+  padding: 7px 11px;
+  white-space: nowrap;
+}
+
+.status-dot {
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 16px color-mix(in srgb, var(--accent) 70%, transparent);
+  height: 8px;
+  width: 8px;
+}
+
+.theme-control.compact {
+  display: flex;
+  gap: 4px;
+  margin: 0;
+  padding: 4px;
+}
+
+.theme-control.compact .theme-option {
+  padding: 7px 9px;
+}
+
+.workspace {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 300px minmax(520px, 1fr) 300px;
+  min-height: 0;
+}
+
+.workspace > .sidebar,
+.workspace > .content,
+.detail-rail {
+  border-radius: 16px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.workspace > .sidebar {
+  align-self: stretch;
+  padding: 20px;
+  position: static;
+}
+
+.sidebar-kicker {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin: 0 0 14px;
+  text-transform: uppercase;
+}
+
+.workspace > .content {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent) 16%, transparent) 0%, transparent 280px),
+    var(--bg-primary);
+  padding: 28px;
+}
+
+.detail-rail,
+.rail-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.detail-rail {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 12px;
+}
+
+.rail-card {
+  border-radius: 16px;
+  box-shadow: none;
+  padding: 18px;
+}
+
+.rail-card h2,
+.rail-card h3 {
+  margin-top: 0;
+}
+
+.rail-card p {
+  color: var(--text-secondary);
+}
+
+.rail-card ul {
+  display: grid;
+  gap: 10px;
+  list-style: none;
+  padding: 0;
+}
+
+.rail-card li {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.rail-card li span {
+  color: var(--text-muted);
+}
+
+.app-statusbar {
+  justify-content: center;
+}
+
+.nav-item {
+  border-radius: 10px;
+  margin-bottom: 6px;
+}
+
+.hero {
+  margin-bottom: 18px;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 4.5rem);
+  letter-spacing: -0.055em;
+  line-height: 0.95;
+  margin: 10px 0 16px;
+}
+
+.panel,
+.metric-card,
+.object-list li {
+  background: color-mix(in srgb, var(--bg-primary) 82%, var(--bg-tertiary));
+}
+
+@media (max-width: 1180px) {
+  .workspace {
+    grid-template-columns: 260px minmax(0, 1fr);
+  }
+
+  .detail-rail {
+    display: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .app-topbar,
+  .app-statusbar,
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace {
+    display: grid;
+  }
+
+  .command-palette,
+  .topbar-status {
+    display: none;
+  }
+}

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -7,7 +7,11 @@
   --border: rgba(0, 0, 0, 0.12);
   --border-hover: rgba(0, 0, 0, 0.25);
   --code-bg: #f3f4f6;
-  --shadow: 0 20px 50px rgb(15 23 42 / 8%);
+  --shadow: 0 18px 42px rgb(15 23 42 / 7%);
+  --shade-inset: inset 0 1px 0 rgb(255 255 255 / 70%), inset 0 -1px 0 rgb(0 0 0 / 5%);
+  --shade-raised: 0 18px 42px rgb(15 23 42 / 9%), inset 0 1px 0 rgb(255 255 255 / 72%);
+  --surface-elevated: #ffffff;
+  --surface-muted: #f2f3f4;
   --success-bg: rgba(178, 233, 105, 0.18);
   --success-text: #2f5f16;
   --text-muted: rgba(17, 17, 17, 0.55);
@@ -29,6 +33,10 @@
   --border-hover: rgba(255, 255, 255, 0.2);
   --code-bg: #0c0c0c;
   --shadow: 0 24px 80px rgb(0 0 0 / 35%);
+  --shade-inset: inset 0 1px 0 rgb(255 255 255 / 5%), inset 0 -1px 0 rgb(0 0 0 / 45%);
+  --shade-raised: 0 24px 80px rgb(0 0 0 / 36%), inset 0 1px 0 rgb(255 255 255 / 5%);
+  --surface-elevated: #141414;
+  --surface-muted: #1d1d1d;
   --success-bg: rgba(178, 233, 105, 0.12);
   --success-text: #b2e969;
   --text-muted: rgba(255, 255, 255, 0.42);
@@ -60,10 +68,10 @@ body {
 .content,
 .panel,
 .metric-card {
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
+  background: var(--surface-elevated);
+  border: 0;
   border-radius: 16px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shade-raised);
 }
 
 .sidebar {
@@ -87,8 +95,9 @@ body {
 .terminal-mark {
   align-items: center;
   background: #0a0a0a;
-  border: 1px solid var(--border-hover);
+  border: 0;
   border-radius: 10px;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 12%);
   color: #b2e969;
   display: inline-flex;
   font-size: 1rem;
@@ -98,9 +107,10 @@ body {
 }
 
 .theme-control {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  border: 0;
   border-radius: 14px;
+  box-shadow: var(--shade-inset);
   display: grid;
   gap: 8px;
   grid-template-columns: repeat(3, 1fr);
@@ -123,8 +133,9 @@ body {
 
 .theme-option:hover,
 .theme-option.active {
-  background: var(--bg-primary);
-  border-color: var(--border-hover);
+  background: var(--surface-elevated);
+  border-color: transparent;
+  box-shadow: var(--shade-inset);
   color: var(--accent);
 }
 
@@ -150,7 +161,8 @@ body {
 .nav-item:hover,
 .nav-item.active {
   background: color-mix(in srgb, var(--accent) 14%, transparent);
-  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  border-color: transparent;
+  box-shadow: var(--shade-inset);
   color: var(--text-primary);
 }
 
@@ -248,9 +260,10 @@ body {
 
 .object-list li {
   align-items: center;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  border: 0;
   border-radius: 12px;
+  box-shadow: var(--shade-inset);
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
@@ -286,8 +299,9 @@ body {
 }
 
 .tag-list li {
-  background: var(--bg-tertiary);
+  background: var(--surface-muted);
   border-radius: 999px;
+  box-shadow: var(--shade-inset);
   padding: 6px 10px;
 }
 
@@ -324,10 +338,10 @@ code {
 .app-topbar,
 .app-statusbar {
   align-items: center;
-  background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface-elevated) 94%, transparent);
+  border: 0;
   border-radius: 16px;
-  box-shadow: 0 12px 40px rgb(0 0 0 / 18%);
+  box-shadow: var(--shade-raised);
   display: flex;
   gap: 14px;
   min-width: 0;
@@ -374,9 +388,10 @@ code {
 
 .command-palette {
   align-items: center;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  border: 0;
   border-radius: 999px;
+  box-shadow: var(--shade-inset);
   display: flex;
   flex: 1;
   gap: 10px;
@@ -401,9 +416,10 @@ code {
 .topbar-status,
 .app-statusbar span {
   align-items: center;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  background: var(--surface-muted);
+  border: 0;
   border-radius: 999px;
+  box-shadow: var(--shade-inset);
   color: var(--text-secondary);
   display: inline-flex;
   font-size: 0.82rem;
@@ -470,9 +486,9 @@ code {
 
 .detail-rail,
 .rail-card {
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
+  background: var(--surface-elevated);
+  border: 0;
+  box-shadow: var(--shade-raised);
 }
 
 .detail-rail {
@@ -537,7 +553,7 @@ code {
 .panel,
 .metric-card,
 .object-list li {
-  background: color-mix(in srgb, var(--bg-primary) 82%, var(--bg-tertiary));
+  background: color-mix(in srgb, var(--surface-elevated) 76%, var(--surface-muted));
 }
 
 @media (max-width: 1180px) {


### PR DESCRIPTION
## Summary

- Redesigns the GUI surface from a document-like page into an app-like shell.
- Adds top app chrome with traffic-light affordance, app brand, read-only command/search placeholder, status pill, and theme controls.
- Adds a compact left control-library navigation, center work surface, right detail rail, and bottom status bar.
- Keeps the `aidevops.sh` branding from the previous theme PR: terminal mark, monospace type, black/lime palette, and system-aware light/dark tokens.
- Softens the visual treatment by replacing pervasive hairline borders with shade/elevation surfaces and inset highlights.

For #25304

## Verification

- `git diff --check origin/main...HEAD` — passed, no output
- `npm run typecheck` — passed
- `npm run gui:test:schema` — 3 pass, 0 fail
- `npm run gui:test:adapters` — 2 pass, 0 fail
- `npm run gui:test:api` — 2 pass, 0 fail
- `npm run gui:test:components` — 2 pass, 0 fail
- `npm run gui:test:security` — 4 pass, 0 fail
- `npm run gui:test:smoke` — 1 pass, 0 fail
- `npm run gui:desktop:check` — passed
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — passed, no output
- `npm run gui:desktop:install:macos && open /Applications/aidevops.app` then fetched local app assets: page present, topbar present, detail rail present, statusbar CSS present, shade CSS present, 5 navigation items returned

## Safety

- Still read-only.
- No shell, exec, write, destructive, Cloudron, or pairing routes.
- Search is disabled placeholder UI only.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.8 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 1h 30m and 1,128,617 tokens on this with the user in an interactive session.
