### PR TITLE
GH#25321: fix: resolve CodeFactor GUI CSS duplicates

### DIFF
--- a/.agents/scripts/tests/test-gui-codefactor-css.sh
+++ b/.agents/scripts/tests/test-gui-codefactor-css.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#25321: CodeFactor/stylelint no-duplicate-selectors
+# findings in the GUI stylesheet.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+CSS_FILE="${REPO_ROOT}/packages/gui-web/src/styles.css"
+
+if [[ ! -f "$CSS_FILE" ]]; then
+	printf 'FAIL: missing GUI stylesheet: %s\n' "$CSS_FILE" >&2
+	exit 1
+fi
+
+python3 - "$CSS_FILE" <<'PY'
+import re
+import sys
+from collections import defaultdict
+
+css_path = sys.argv[1]
+selector_lines: dict[str, list[int]] = defaultdict(list)
+brace_depth = 0
+pending_selector: list[str] = []
+pending_line = 0
+
+with open(css_path, encoding="utf-8") as handle:
+    for line_number, raw_line in enumerate(handle, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("/*"):
+            continue
+
+        if brace_depth == 0 and line.startswith("@"):
+            brace_depth += line.count("{") - line.count("}")
+            continue
+
+        if brace_depth == 0:
+            if "{" in line:
+                selector = " ".join(pending_selector + [line.split("{", 1)[0].strip()])
+                selector = re.sub(r"\s+", " ", selector).strip()
+                if selector:
+                    selector_lines[selector].append(pending_line or line_number)
+                pending_selector = []
+                pending_line = 0
+            else:
+                pending_selector.append(line)
+                pending_line = pending_line or line_number
+
+        brace_depth += line.count("{") - line.count("}")
+        if brace_depth < 0:
+            brace_depth = 0
+
+duplicates = {selector: lines for selector, lines in selector_lines.items() if len(lines) > 1}
+if duplicates:
+    print("FAIL: duplicate top-level CSS selectors found", file=sys.stderr)
+    for selector, lines in sorted(duplicates.items()):
+        joined = ", ".join(str(line) for line in lines)
+        print(f"  {selector}: lines {joined}", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: no duplicate top-level GUI CSS selectors")
+PY

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -56,12 +56,14 @@ body {
 
 .app-shell {
   display: grid;
-  gap: 24px;
-  grid-template-columns: 320px minmax(0, 1fr);
-  margin: 0 auto;
-  max-width: 1440px;
-  min-height: 100vh;
-  padding: 32px;
+  gap: 8px;
+  grid-template-columns: 1fr;
+  grid-template-rows: 52px minmax(0, 1fr) 52px;
+  height: 100vh;
+  margin: 0;
+  max-width: none;
+  min-height: 0;
+  padding: 8px;
 }
 
 .sidebar,
@@ -148,11 +150,11 @@ body {
 .nav-item {
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 12px;
+  border-radius: 10px;
   color: var(--text-secondary);
   cursor: pointer;
   display: block;
-  margin: 0 0 8px;
+  margin: 0 0 6px;
   padding: 14px;
   text-align: left;
   width: 100%;
@@ -183,7 +185,7 @@ body {
 }
 
 .hero {
-  margin-bottom: 24px;
+  margin-bottom: 18px;
 }
 
 .panel {
@@ -320,19 +322,6 @@ code {
   background: var(--code-bg);
   border-radius: 4px;
   padding: 2px 4px;
-}
-
-/* Desktop-app shell: closer to a native/web-app control surface than a document page. */
-.app-shell {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: 1fr;
-  grid-template-rows: 52px minmax(0, 1fr) 52px;
-  height: 100vh;
-  margin: 0;
-  max-width: none;
-  min-height: 0;
-  padding: 8px;
 }
 
 .app-topbar,
@@ -588,15 +577,6 @@ code {
 
 .app-statusbar {
   justify-content: center;
-}
-
-.nav-item {
-  border-radius: 10px;
-  margin-bottom: 6px;
-}
-
-.hero {
-  margin-bottom: 18px;
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary

Consolidated duplicate top-level GUI CSS selectors reported by CodeFactor and added a regression guard for the GUI stylesheet.

## Files Changed

.agents/scripts/tests/test-gui-codefactor-css.sh,packages/gui-web/src/styles.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gui-codefactor-css.sh; shellcheck .agents/scripts/tests/test-gui-codefactor-css.sh; git diff --check origin/main..HEAD; bun test packages/gui-web/tests not run because bun is unavailable in this worker

Resolves #25321


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.8 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 9m and 221,186 tokens on this as a headless worker.