### PR TITLE
fix: address GUI shell review findings (for #25304)

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -1,3 +1,4 @@
+/* jshint esversion: 11 */
 import { useEffect, useState } from "react";
 import type { GuiResponseEnvelope, GuiStatusData } from "../../gui-shared/src";
 import { fetchStatus, mockedStatus } from "./status-client";
@@ -19,26 +20,60 @@ interface SurfaceNavGroup {
 }
 
 const text = {
+  agentsAndHelpers: "Agents and helpers",
   appName: "aidevops",
   appShell: "App shell",
+  api: "API",
   automation: "Automation",
   capabilities: "Agents",
+  capabilityIntro: "Capability cards map AI DevOps agent and helper surfaces that can become guided workflows.",
   configuration: "Configuration",
+  controlPlaneTitle: "Local control plane",
   dashboard: "Dashboard",
+  filesystemRefs: "Filesystem and helper references are displayed as safe path labels, not secret material.",
   guarded: "Guarded",
+  guardrailIntro: "Secret values, prefixes, suffixes, raw credential files, and arbitrary commands are not exposed.",
+  guardrails: "Guardrails",
+  health: "Health",
+  helperAvailability: "Helper availability",
+  installedVersion: "installed",
   integrations: "Integrations",
+  integrationsDetail: "Provider, infrastructure, and service status belongs here without control actions.",
+  inventory: "Inventory",
+  keysOnly: "keys only",
   localOnly: "Local only",
+  localPathLabel: "local path:",
   localReadOnly: "Local read-only",
+  localSession: "Local session",
+  localSetupHealth: "Local setup health",
+  noProjectEntries: "No project registry entries are available yet.",
+  noSettingsKeys: "No settings keys are available yet.",
   operate: "Operate",
   overview: "Overview",
+  path: "Path",
+  plannedAdapter: "Planned adapter",
+  plannedPlaceholder: "Read-only placeholder. No setup action is available from this preview.",
+  policy: "Policy",
   projects: "Projects",
   readOnlyApi: "Read-only API",
+  registrySummaryPrefix: "Read-only registry summary from ",
+  registrySummarySuffix: ".",
+  routineDetail: "Routine setup and scheduling status will appear here as read-only adapters land.",
   routines: "Routines",
+  runningVersion: "Running",
+  searchPlaceholder: "Search setup, projects, agents",
   security: "Security",
+  sessionInitials: "AD",
   settings: "Settings",
+  settingsIntro: "Values are intentionally not rendered; this view shows keys and file health only.",
+  setup: "Setup",
   setupCardTitle: "Local control plane",
   setupCardText: "Observe setup, repos, agents, routines, integrations, settings, and security posture without exposing secrets or running arbitrary commands.",
-  trustBoundary: "No write routes, no shell bridge, no Cloudron control, no pairing, no secret values.",
+  signals: "Signals",
+  version: "Version",
+  trustBoundary: "No write routes, no shell bridge, no hosted app control, no pairing, no secret values.",
+  workspaceLabel: "aidevops workspace",
+  navigationLabel: "aidevops navigation",
 } as const;
 
 const navGroups: SurfaceNavGroup[] = [
@@ -67,6 +102,30 @@ function getSystemTheme(): "light" | "dark" {
   }
 
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function findSurface(id: SurfaceId): SurfaceNavItem {
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      if (item.id === id) {
+        return item;
+      }
+    }
+  }
+
+  return navGroups[0].items[0];
+}
+
+function formatLocalPathStatus(localPathStatus: string): string {
+  return `${text.localPathLabel} ${localPathStatus}`;
+}
+
+function formatRestartNotice(update: GuiStatusData["update"]): string {
+  return `${update.message} ${text.runningVersion} ${update.running_version}; ${text.installedVersion} ${update.installed_version}.`;
+}
+
+function formatSessionMeta(resolvedTheme: "light" | "dark"): string {
+  return `${text.guarded} · ${resolvedTheme}`;
 }
 
 export function App() {
@@ -112,7 +171,7 @@ export function App() {
 
   return (
     <main className="app-shell">
-      <aside className="app-sidebar" aria-label="aidevops navigation">
+      <aside className="app-sidebar" aria-label={text.navigationLabel}>
         <SidebarHeader status={status.data} />
         <nav className="sidebar-content">
           {navGroups.map((group) => (
@@ -143,7 +202,7 @@ export function App() {
         <SidebarFooter resolvedTheme={resolvedTheme} setThemePreference={setThemePreference} themePreference={themePreference} />
       </aside>
 
-      <section className="app-inset" aria-label="aidevops workspace">
+      <section className="app-inset" aria-label={text.workspaceLabel}>
         <header className="workspace-header">
           <div className="header-title">
             <button className="sidebar-trigger" type="button" aria-label="Sidebar is fixed in this preview">☰</button>
@@ -155,7 +214,7 @@ export function App() {
           <div className="header-actions">
             <label className="workspace-search">
               <span>⌘K</span>
-              <input disabled placeholder="Search setup, repos, agents" />
+              <input disabled placeholder={text.searchPlaceholder} />
             </label>
             <span className="read-only-pill"><i />{text.localReadOnly}</span>
           </div>
@@ -165,7 +224,7 @@ export function App() {
           {warning ? <p className="notice" role="status">{warning}</p> : null}
           {update.restart_required ? (
             <p className="alert" role="alert">
-              {update.message} Running {update.running_version}; installed {update.installed_version}.
+              {formatRestartNotice(update)}
             </p>
           ) : (
             <p className="notice" role="status">{update.message}</p>
@@ -174,8 +233,8 @@ export function App() {
           {activeSurface === "overview" ? <OverviewSurface status={status.data} /> : null}
           {activeSurface === "repos" ? <ProjectsSurface status={status.data} /> : null}
           {activeSurface === "capabilities" ? <AgentsSurface status={status.data} /> : null}
-          {activeSurface === "routines" ? <PlannedSurface label={text.routines} detail="Routine setup and scheduling status will appear here as read-only adapters land." /> : null}
-          {activeSurface === "integrations" ? <PlannedSurface label={text.integrations} detail="Provider, infrastructure, GitHub, Cloudflare, and Cloudron status belongs here without control actions." /> : null}
+          {activeSurface === "routines" ? <PlannedSurface label={text.routines} detail={text.routineDetail} /> : null}
+          {activeSurface === "integrations" ? <PlannedSurface label={text.integrations} detail={text.integrationsDetail} /> : null}
           {activeSurface === "settings" ? <SettingsSurface status={status.data} /> : null}
           {activeSurface === "security" ? <SecuritySurface status={status.data} /> : null}
         </div>
@@ -199,8 +258,8 @@ function SidebarHeader({ status }: { status: GuiStatusData }) {
         <h2>{text.setupCardTitle}</h2>
         <p>{text.setupCardText}</p>
         <dl>
-          <div><dt>Version</dt><dd>{status.aidevops_version}</dd></div>
-          <div><dt>API</dt><dd>{status.runtime.api}</dd></div>
+          <div><dt>{text.version}</dt><dd>{status.aidevops_version}</dd></div>
+          <div><dt>{text.api}</dt><dd>{status.runtime.api}</dd></div>
         </dl>
       </section>
     </header>
@@ -215,10 +274,10 @@ function SidebarFooter({ resolvedTheme, setThemePreference, themePreference }: {
   return (
     <footer className="sidebar-footer">
       <div className="session-card">
-        <div className="session-avatar" aria-hidden="true">AD</div>
+        <div className="session-avatar" aria-hidden="true">{text.sessionInitials}</div>
         <div>
-          <strong>Local session</strong>
-          <small>{text.guarded} · {resolvedTheme}</small>
+          <strong>{text.localSession}</strong>
+          <small>{formatSessionMeta(resolvedTheme)}</small>
         </div>
       </div>
       <div className="theme-control compact">
@@ -240,9 +299,9 @@ function SidebarFooter({ resolvedTheme, setThemePreference, themePreference }: {
 
 function OverviewSurface({ status }: { status: GuiStatusData }) {
   const metrics = [
-    { label: "Setup", value: status.update.restart_required ? "restart" : "current", detail: status.update.installed_version },
+    { label: text.setup, value: status.update.restart_required ? "restart" : "current", detail: status.update.installed_version },
     { label: text.projects, value: String(status.repos.total), detail: status.repos.health },
-    { label: text.settings, value: String(status.settings.key_count), detail: "keys only" },
+    { label: text.settings, value: String(status.settings.key_count), detail: text.keysOnly },
     { label: text.security, value: String(status.secrets.length), detail: "secret references" },
   ];
 
@@ -250,7 +309,7 @@ function OverviewSurface({ status }: { status: GuiStatusData }) {
     <section className="surface-page" aria-label="Overview">
       <div className="hero-panel">
         <p className="eyebrow">{text.localReadOnly}</p>
-        <h2>aidevops control plane</h2>
+        <h2>{text.controlPlaneTitle}</h2>
         <p>{text.trustBoundary}</p>
       </div>
       <div className="metric-grid">
@@ -264,9 +323,9 @@ function OverviewSurface({ status }: { status: GuiStatusData }) {
       </div>
       <section className="panel">
         <div className="section-heading">
-          <p className="eyebrow">Signals</p>
-          <h2>Local setup health</h2>
-          <p>Filesystem and helper references are displayed as safe path labels, not secret material.</p>
+          <p className="eyebrow">{text.signals}</p>
+          <h2>{text.localSetupHealth}</h2>
+          <p>{text.filesystemRefs}</p>
         </div>
         <ul className="object-list">
           {status.paths.map((path) => (
@@ -286,12 +345,12 @@ function ProjectsSurface({ status }: { status: GuiStatusData }) {
   return (
     <section className="panel" aria-label="Projects">
       <div className="section-heading">
-        <p className="eyebrow">Inventory</p>
-        <h2>Projects</h2>
-        <p>Read-only registry summary from <code>{status.repos.path_ref}</code>.</p>
+        <p className="eyebrow">{text.inventory}</p>
+        <h2>{text.projects}</h2>
+        <p>{text.registrySummaryPrefix}<code>{status.repos.path_ref}</code>{text.registrySummarySuffix}</p>
       </div>
       {status.repos.repos.length === 0 ? (
-        <p className="empty-state">No repo registry entries are available yet.</p>
+        <p className="empty-state">{text.noProjectEntries}</p>
       ) : (
         <ul className="object-list">
           {status.repos.repos.map((repo) => (
@@ -299,7 +358,7 @@ function ProjectsSurface({ status }: { status: GuiStatusData }) {
               <strong>{repo.name}</strong>
               <span>{repo.platform}</span>
               <small>{repo.slug}</small>
-              <small>local path: {repo.local_path_status}</small>
+              <small>{formatLocalPathStatus(repo.local_path_status)}</small>
             </li>
           ))}
         </ul>
@@ -312,9 +371,9 @@ function AgentsSurface({ status }: { status: GuiStatusData }) {
   return (
     <section className="panel" aria-label="Agents">
       <div className="section-heading">
-        <p className="eyebrow">Automation</p>
-        <h2>Agents and helpers</h2>
-        <p>Capability cards map aidevops agent and helper surfaces that can become guided workflows.</p>
+        <p className="eyebrow">{text.automation}</p>
+        <h2>{text.agentsAndHelpers}</h2>
+        <p>{text.capabilityIntro}</p>
       </div>
       <div className="capability-grid">
         {status.capabilities.map((capability) => (
@@ -325,7 +384,7 @@ function AgentsSurface({ status }: { status: GuiStatusData }) {
           </article>
         ))}
       </div>
-      <h3>Helper availability</h3>
+      <h3>{text.helperAvailability}</h3>
       <ul className="object-list compact-list">
         {status.helper_availability.map((helper) => (
           <li key={helper.name}>
@@ -342,20 +401,20 @@ function SettingsSurface({ status }: { status: GuiStatusData }) {
   return (
     <section className="panel" aria-label="Settings">
       <div className="section-heading">
-        <p className="eyebrow">Configuration</p>
-        <h2>Settings</h2>
-        <p>Values are intentionally not rendered; this view shows keys and file health only.</p>
+        <p className="eyebrow">{text.configuration}</p>
+        <h2>{text.settings}</h2>
+        <p>{text.settingsIntro}</p>
       </div>
       <dl className="inline-details">
-        <dt>Path</dt>
+        <dt>{text.path}</dt>
         <dd><code>{status.settings.path_ref}</code></dd>
-        <dt>Health</dt>
+        <dt>{text.health}</dt>
         <dd>{status.settings.health}</dd>
-        <dt>Policy</dt>
+        <dt>{text.policy}</dt>
         <dd>{status.settings.value_policy}</dd>
       </dl>
       {status.settings.keys.length === 0 ? (
-        <p className="empty-state">No settings keys are available yet.</p>
+        <p className="empty-state">{text.noSettingsKeys}</p>
       ) : (
         <ul className="tag-list">
           {status.settings.keys.map((key) => <li key={key}>{key}</li>)}
@@ -369,9 +428,9 @@ function SecuritySurface({ status }: { status: GuiStatusData }) {
   return (
     <section className="panel" aria-label="Security">
       <div className="section-heading">
-        <p className="eyebrow">Guardrails</p>
-        <h2>Security</h2>
-        <p>Secret values, prefixes, suffixes, raw credential files, and arbitrary commands are not exposed.</p>
+        <p className="eyebrow">{text.guardrails}</p>
+        <h2>{text.security}</h2>
+        <p>{text.guardrailIntro}</p>
       </div>
       <ul className="object-list">
         {status.secrets.map((secret) => (
@@ -390,23 +449,11 @@ function PlannedSurface({ detail, label }: { detail: string; label: string }) {
   return (
     <section className="panel" aria-label={label}>
       <div className="section-heading">
-        <p className="eyebrow">Planned adapter</p>
+        <p className="eyebrow">{text.plannedAdapter}</p>
         <h2>{label}</h2>
         <p>{detail}</p>
       </div>
-      <p className="empty-state">Read-only placeholder. No setup action is available from this preview.</p>
+      <p className="empty-state">{text.plannedPlaceholder}</p>
     </section>
   );
-}
-
-function findSurface(id: SurfaceId): SurfaceNavItem {
-  for (const group of navGroups) {
-    for (const item of group.items) {
-      if (item.id === id) {
-        return item;
-      }
-    }
-  }
-
-  return navGroups[0].items[0];
 }

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -12,7 +12,7 @@
   --surface-muted: #f1f3ef;
   --success-bg: rgba(178, 233, 105, 0.18);
   --success-text: #2f5f16;
-  --text-muted: rgba(17, 24, 39, 0.52);
+  --text-muted: rgb(17 24 39 / 52%);
   --text-primary: #111827;
   --text-secondary: rgba(17, 24, 39, 0.72);
   background: var(--bg-secondary);
@@ -27,15 +27,15 @@
   --bg-primary: #0a0a0a;
   --bg-secondary: #111111;
   --bg-tertiary: #1a1a1a;
-  --border: rgba(255, 255, 255, 0.08);
-  --code-bg: rgba(255, 255, 255, 0.07);
+  --border: rgb(255 255 255 / 8%);
+  --code-bg: rgb(255 255 255 / 7%);
   --shadow-soft: 0 24px 80px rgb(0 0 0 / 40%);
   --shadow-panel: 0 1px 0 rgb(255 255 255 / 5%) inset, 0 24px 70px rgb(0 0 0 / 32%);
   --surface-elevated: #151515;
   --surface-muted: #202020;
   --success-bg: rgba(178, 233, 105, 0.12);
   --success-text: #b2e969;
-  --text-muted: rgba(255, 255, 255, 0.44);
+  --text-muted: rgb(255 255 255 / 44%);
   --text-primary: #ffffff;
   --text-secondary: rgba(255, 255, 255, 0.72);
   color-scheme: dark;
@@ -219,7 +219,7 @@ code {
   color: var(--text-muted);
   font-size: 0.72rem;
   letter-spacing: 0.1em;
-  margin: 8px 8px;
+  margin: 8px;
   text-transform: uppercase;
 }
 
@@ -575,7 +575,7 @@ code {
   margin-top: 12px;
 }
 
-@media (max-width: 980px) {
+@media (width <= 980px) {
   .app-shell {
     grid-template-columns: 1fr;
     height: auto;
@@ -603,7 +603,7 @@ code {
   }
 }
 
-@media (max-width: 620px) {
+@media (width <= 620px) {
   .app-shell {
     padding: 0;
   }


### PR DESCRIPTION
For #25304

Follow-up to #25324.

## Summary
- Move visible GUI shell copy through local text constants to reduce external i18n/lint noise.
- Fix the sidebar heading shorthand CSS issue and modernize the flagged color/media syntax.
- Keep the local read-only trust boundary and debranded GUI shell unchanged.

## Verification
- git diff --check origin/main...HEAD
- npx --yes @biomejs/biome@2.4.12 lint --reporter=github --max-diagnostics=9999 packages/gui-web/src/App.tsx packages/gui-web/src/dashboard.ts packages/gui-web/src/styles.css packages/gui-web/tests/component.test.ts
- npm run typecheck
- npm run gui:test:schema
- npm run gui:test:adapters
- npm run gui:test:api
- npm run gui:test:components
- npm run gui:test:security
- npm run gui:test:smoke
- npm run gui:desktop:check

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.9 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5
