### PR TITLE
GH#25329: fix: add CodeFactor miner guidance

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -673,6 +673,18 @@ render_issue_body_markdown() {
 	local events_json="$1"
 	local systemic_threshold="$2"
 	printf '%s\n' "$events_json" | jq -r '
+		def systemic_fix_guidance($check_name; $signature):
+			if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
+				"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
+				"- Reproduce the provider finding locally with the nearest repo linter/style/static-analysis command, fix the source issue rather than suppressing CodeFactor, and add a focused regression guard for the reported rule/file.\n" +
+				"\n## Worker Guidance\n" +
+				"1. Open the CodeFactor details URL from Evidence first; do not infer the reported file/rule from the GitHub run alone.\n" +
+				"2. Inspect the affected source file and the closest existing lint/test guard for that file type. If no focused guard exists, add one under `.agents/scripts/tests/` or the target package tests.\n" +
+				"3. Run the focused guard plus the nearest local linter before opening a PR.\n"
+			else
+				"- Patch the failing workflow/check once at the source (workflow file, shared action, or toolchain pin), then rerun failed checks on affected PRs.\n" +
+				"- Add a regression guard to detect this signature early in future pulses.\n"
+			end;
 		def key: (.check_name + "|" + .signature);
 		(sort_by(key)
 		 | group_by(key)
@@ -707,8 +719,7 @@ render_issue_body_markdown() {
 			"## Root Cause Hypothesis\n" +
 			"- Workflow/config regression or shared dependency/integration break in `" + $top.check_name + "`.\n\n" +
 			"## Proposed Systemic Fix\n" +
-			"- Patch the failing workflow/check once at the source (workflow file, shared action, or toolchain pin), then rerun failed checks on affected PRs.\n" +
-			"- Add a regression guard to detect this signature early in future pulses.\n"
+			systemic_fix_guidance($top.check_name; $top.signature)
 		  end
 	' --argjson min_count "$systemic_threshold"
 	return 0
@@ -804,6 +815,18 @@ build_issue_body() {
 		' --arg pattern_id "$pattern_id" --argjson threshold "$threshold"
 	else
 		printf '%s\n' "$cluster_json" | jq -r '
+			def systemic_fix_guidance($check_name; $signature):
+				if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
+					"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
+					"- Reproduce the provider finding locally with the nearest repo linter/style/static-analysis command, fix the source issue rather than suppressing CodeFactor, and add a focused regression guard for the reported rule/file.\n" +
+					"\n## Worker Guidance\n" +
+					"1. Open the CodeFactor details URL from Evidence first; do not infer the reported file/rule from the GitHub run alone.\n" +
+					"2. Inspect the affected source file and the closest existing lint/test guard for that file type. If no focused guard exists, add one under `.agents/scripts/tests/` or the target package tests.\n" +
+					"3. Run the focused guard plus the nearest local linter before opening a PR.\n"
+				else
+					"- Fix the workflow/check at the source, then rerun failed checks on affected PRs.\n" +
+					"- Add a regression guard for this signature in pulse routine outputs.\n"
+				end;
 			"## Summary\n" +
 			"- Pattern: `" + .check_name + "`\n" +
 			"- Error signature: `" + .signature + "`\n" +
@@ -822,8 +845,7 @@ build_issue_body() {
 			"## Root Cause Hypothesis\n" +
 			"- Regression or external dependency/toolchain break in the shared check path.\n\n" +
 			"## Proposed Systemic Fix\n" +
-			"- Fix the workflow/check at the source, then rerun failed checks on affected PRs.\n" +
-			"- Add a regression guard for this signature in pulse routine outputs.\n\n" +
+			systemic_fix_guidance(.check_name; .signature) + "\n" +
 			"Signal tag: `gh-failure-miner:" + $pattern_id + "`\n"
 		' --arg pattern_id "$pattern_id" --argjson threshold "$threshold"
 	fi

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#25329: gh-failure-miner CodeFactor clusters must
+# render worker-ready guidance instead of generic workflow/toolchain advice.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected to find: %s\n' "$(printf '%q' "$needle")"
+		printf '  in output:        %s\n' "$(printf '%q' "${haystack:0:300}")"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+HELPER="$SCRIPT_DIR/gh-failure-miner-helper.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf '%sFATAL%s: %s not found\n' "$TEST_RED" "$TEST_NC" "$HELPER" >&2
+	exit 1
+fi
+
+# Source with a harmless command so helper functions remain available without
+# making live GitHub API calls.
+set -- help
+# shellcheck source=/dev/null
+source "$HELPER" >/dev/null
+
+cluster_json=$(cat <<'JSON'
+{
+  "repo": "marcusquinn/aidevops",
+  "check_name": "CodeFactor",
+  "signature": "failure:codefactor.io",
+  "count": 3,
+  "is_infra": false,
+  "sources": ["pr:#25324", "pr:#25319", "pr:#25305"],
+  "examples": [
+    {
+      "source_kind": "pr",
+      "source_ref": "#25324",
+      "source_url": "https://github.com/marcusquinn/aidevops/pull/25324",
+      "run_url": "https://github.com/marcusquinn/aidevops/runs/82536587204",
+      "details_url": "https://www.codefactor.io/repository/github/marcusquinn/aidevops/pull/25324",
+      "conclusion": "failure"
+    }
+  ]
+}
+JSON
+)
+
+events_json=$(printf '[%s]\n' "$cluster_json")
+
+body=$(build_issue_body "$cluster_json" "46250abc5695" "2" "false")
+legacy_body=$(render_issue_body_markdown "$events_json" "2")
+
+assert_contains "build_issue_body includes Worker Guidance" "## Worker Guidance" "$body"
+assert_contains "build_issue_body directs workers to CodeFactor details" "Open the CodeFactor details URL from Evidence first" "$body"
+assert_contains "build_issue_body preserves failure signature context" "failure:codefactor.io" "$body"
+assert_contains "build_issue_body asks for focused regression guard" "focused regression guard" "$body"
+assert_contains "render_issue_body_markdown includes Worker Guidance" "## Worker Guidance" "$legacy_body"
+assert_contains "render_issue_body_markdown directs workers to provider details" "details URL" "$legacy_body"
+
+printf '\nTests run: %s\n' "$TESTS_RUN"
+if [[ "$TESTS_FAILED" -ne 0 ]]; then
+	printf 'Tests failed: %s\n' "$TESTS_FAILED" >&2
+	exit 1
+fi
+
+printf '%sAll tests passed%s\n' "$TEST_GREEN" "$TEST_NC"
+exit 0


### PR DESCRIPTION
## Summary

Adds CodeFactor-specific Worker Guidance to gh-failure-miner issue bodies for failure:codefactor.io clusters and covers both current and legacy issue-body renderers with a focused regression test.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; .agents/scripts/tests/test-ci-failure-pattern-detection.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

Resolves #25329


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.9 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 6m and 92,876 tokens on this as a headless worker.