### PR TITLE
GH#25332: fix: use CodeFactor-compatible GUI media queries

### DIFF
--- a/.agents/scripts/tests/test-gui-codefactor-css.sh
+++ b/.agents/scripts/tests/test-gui-codefactor-css.sh
@@ -3,7 +3,8 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # Regression guard for GH#25321: CodeFactor/stylelint no-duplicate-selectors
-# findings in the GUI stylesheet.
+# findings in the GUI stylesheet, and GH#25332: CodeFactor-compatible media
+# query syntax in the GUI stylesheet.
 
 set -u
 
@@ -30,6 +31,13 @@ pending_line = 0
 with open(css_path, encoding="utf-8") as handle:
     for line_number, raw_line in enumerate(handle, start=1):
         line = raw_line.strip()
+        if re.match(r"@media\s*\([^)]*(?:<=|>=)[^)]*\)", line):
+            print(
+                "FAIL: use max-width/min-width media queries for CodeFactor compatibility "
+                f"at line {line_number}: {line}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         if not line or line.startswith("/*"):
             continue
 

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -718,13 +718,13 @@ code {
   color: var(--accent);
 }
 
-@media (width <= 1100px) {
+@media (max-width: 1100px) {
   .file-workspace {
     grid-template-columns: 1fr;
   }
 }
 
-@media (width <= 980px) {
+@media (max-width: 980px) {
   .app-shell {
     grid-template-columns: 1fr;
     height: auto;
@@ -749,7 +749,7 @@ code {
   }
 }
 
-@media (width <= 720px) {
+@media (max-width: 720px) {
   .app-shell {
     padding: 0;
   }


### PR DESCRIPTION
## Summary

Replaced GUI CSS media range queries with max-width syntax and extended the CodeFactor CSS regression guard to reject <=/>= media query syntax.

## Files Changed

.agents/scripts/tests/test-gui-codefactor-css.sh,packages/gui-web/src/styles.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gui-codefactor-css.sh; shellcheck .agents/scripts/tests/test-gui-codefactor-css.sh; npx --yes @biomejs/biome@2.4.12 lint --reporter=github --max-diagnostics=9999 packages/gui-web/src/styles.css; npm run gui:test:components

Resolves #25332


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.9 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 6m and 96,123 tokens on this as a headless worker.