### PR TITLE
GH#25336: preserve merge failure context for remediation

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1070,6 +1070,7 @@ _process_single_ready_pr() {
 	# PR without admin bypass, then fall back to a direct non-admin merge for repos
 	# whose rulesets allow immediate maintainer merges.
 	local merge_output="" _merge_exit=0 _auto_merge_output="" _auto_merge_exit=0
+	local merge_failure_context=""
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)
 	_merge_exit=$?
 	if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
@@ -1083,6 +1084,10 @@ _process_single_ready_pr() {
 ${merge_output}"
 		fi
 	fi
+	if [[ $_merge_exit -ne 0 ]]; then
+		merge_failure_context="[admin merge]
+${merge_output}"
+	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
 		_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)
@@ -1091,6 +1096,10 @@ ${merge_output}"
 			echo "[pulse-wrapper] Deterministic merge: enabled native auto-merge for PR #${pr_number} in ${repo_slug} after ruleset blocked admin bypass (GH#24438)" >>"$LOGFILE"
 			return 0
 		fi
+		merge_failure_context="${merge_failure_context}
+
+[native auto-merge fallback]
+${_auto_merge_output}"
 		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash 2>&1)
 		_merge_exit=$?
@@ -1104,6 +1113,12 @@ ${merge_output}"
 [retry after stale gh cache remediation]
 ${merge_output}"
 			fi
+		fi
+		if [[ $_merge_exit -ne 0 ]]; then
+			merge_failure_context="${merge_failure_context}
+
+[direct merge fallback]
+${merge_output}"
 		fi
 	fi
 
@@ -1132,8 +1147,10 @@ ${merge_output}"
 		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels"
 		return $?
 	else
-		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${merge_output}" >>"$LOGFILE"
-		_pulse_merge_maybe_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "$merge_output"
+		local final_merge_output="$merge_output"
+		[[ -n "$merge_failure_context" ]] && final_merge_output="$merge_failure_context"
+		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${final_merge_output}" >>"$LOGFILE"
+		_pulse_merge_maybe_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "$final_merge_output"
 		return 3
 	fi
 }

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -20,6 +20,7 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 GH_LOG=""
+REMEDIATION_LOG=""
 _OW_LABEL_PAT=",origin:worker,"
 
 print_result() {
@@ -48,7 +49,9 @@ setup_test_env() {
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
-	export TEST_ROOT GH_LOG
+	REMEDIATION_LOG="${TEST_ROOT}/remediation.log"
+	: >"$REMEDIATION_LOG"
+	export TEST_ROOT GH_LOG REMEDIATION_LOG
 
 cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
@@ -74,6 +77,22 @@ if [[ "$mode" == "stale-cache-401" && "$1" == "pr" && "$2" == "merge" && "$*" ==
 		exit 1
 	fi
 	exit 0
+fi
+
+if [[ "$mode" == "conversation-chain" && "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
+	printf '%s\n' 'GraphQL: Repository rule violations found' >&2
+	printf '%s\n' 'GraphQL: A conversation must be resolved before merging' >&2
+	exit 1
+fi
+
+if [[ "$mode" == "conversation-chain" && "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
+	printf '%s\n' 'GraphQL: Pull request is not eligible for native auto-merge' >&2
+	exit 1
+fi
+
+if [[ "$mode" == "conversation-chain" && "$1" == "pr" && "$2" == "merge" ]]; then
+	printf '%s\n' 'X Pull request owner/repo#77 is not mergeable: the base branch policy prohibits the merge.' >&2
+	exit 1
 fi
 
 if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
@@ -136,8 +155,17 @@ _extract_merge_summary() { printf 'summary'; return 0; }
 _retarget_stacked_children() { return 0; }
 _pulse_merge_admin_safety_check() { return 0; }
 _set_native_auto_merge_or_skip() { return 1; }
+_attempt_existing_auto_merge_behind_update_branch() { return 1; }
 _handle_post_merge_actions() { return 0; }
 gh_pr_view() { printf '{"labels":[]}'; return 0; }
+
+_pulse_merge_maybe_dispatch_review_thread_remediation() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local merge_output="$3"
+	printf 'pr=%s repo=%s\n%s\n' "$pr_number" "$repo_slug" "$merge_output" >>"${REMEDIATION_LOG:?}"
+	return 0
+}
 
 prepare_stale_cache_fixture() {
 	export HOME="${TEST_ROOT}/home"
@@ -275,10 +303,59 @@ test_stale_cache_401_retries_admin_merge_once() {
 	return 0
 }
 
+test_ruleset_fallback_failure_preserves_admin_conversation_context() {
+	GH_STUB_MODE="conversation-chain"
+	setup_test_env
+	define_function_under_test || { teardown_test_env; unset GH_STUB_MODE; return 0; }
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 3 ]]; then
+		print_result "fallback-chain failure preserves admin conversation context" 1 \
+			"Expected 3, got ${result}; log: $(tr '\n' ';' <"$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	if ! grep -qF 'A conversation must be resolved' "$REMEDIATION_LOG"; then
+		print_result "fallback-chain failure preserves admin conversation context" 1 \
+			"remediation did not receive admin blocker: $(tr '\n' ';' <"$REMEDIATION_LOG")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	if ! grep -qF '[native auto-merge fallback]' "$REMEDIATION_LOG" \
+		|| ! grep -qF '[direct merge fallback]' "$REMEDIATION_LOG"; then
+		print_result "fallback-chain failure preserves admin conversation context" 1 \
+			"remediation did not receive accumulated fallback attempts: $(tr '\n' ';' <"$REMEDIATION_LOG")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	if ! grep -qF 'A conversation must be resolved' "$LOGFILE"; then
+		print_result "fallback-chain failure preserves admin conversation context" 1 \
+			"final failure log did not retain admin blocker: $(tr '\n' ';' <"$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+
+	print_result "fallback-chain failure preserves admin conversation context" 0
+	teardown_test_env
+	unset GH_STUB_MODE
+	return 0
+}
+
 main() {
 	test_ruleset_violation_enables_auto_merge_without_admin
 	test_draft_pr_without_origin_labels_skips_merge_write
 	test_stale_cache_401_retries_admin_merge_once
+	test_ruleset_fallback_failure_preserves_admin_conversation_context
 
 	printf '\n=================================\n'
 	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Preserve failed pulse merge attempt outputs across admin, native auto-merge, and direct fallback attempts so review-thread remediation still sees actionable unresolved-conversation blockers.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; git diff --check

Resolves #25336


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.9 with gpt-5.5 spent 1h 3m and 118,688 tokens on this with the user in an interactive session.