### PR TITLE
GH#25337: route review feedback before mergeability skip

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -195,6 +195,62 @@ source "${_PULSE_MERGE_DIR}/pulse-merge-required-checks.sh"
 # (including _handle_post_merge_actions below) continue to work unchanged.
 
 #######################################
+# Handle terminal CHANGES_REQUESTED review state for a PR.
+#
+# Security invariant: this helper never marks a PR mergeable and never bypasses
+# collaborator, maintainer, review-bot, or branch-protection gates. A blocking
+# review either remains a skip/repair-route, or the existing maintainer-labeled
+# CodeRabbit-only dismissal path clears stale bot nits before normal gates run.
+#
+# Returns 0 if the caller may keep evaluating merge gates.
+# Returns 1 if the PR must be skipped for review feedback handling.
+# Args: $1=pr_number, $2=repo_slug, $3=pr_review, $4=linked_issue, $5=pr_labels (optional), $6=dismissed_dest_var (optional)
+#######################################
+_handle_changes_requested_review_gate() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_review="$3"
+	local linked_issue="$4"
+	local pr_labels="${5:-}"
+	local dismissed_dest_var="${6:-}"
+	local _cr_pr_labels=""
+
+	if [[ -n "$dismissed_dest_var" && "$dismissed_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+		printf -v "$dismissed_dest_var" '%s' "0"
+	fi
+
+	[[ "$pr_review" == "CHANGES_REQUESTED" ]] || return 0
+
+	# Fetch labels once — reused by both the nits-ok check and the
+	# worker-routing block below.
+	_cr_pr_labels="$pr_labels"
+	if [[ -z "$_cr_pr_labels" ]]; then
+		_cr_pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
+	fi
+
+	# t2179: coderabbit-nits-ok path.
+	if [[ ",${_cr_pr_labels}," == *",coderabbit-nits-ok,"* ]]; then
+		if _pulse_merge_dismiss_coderabbit_nits "$pr_number" "$repo_slug"; then
+			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — auto-dismissed CodeRabbit-only CHANGES_REQUESTED reviews (coderabbit-nits-ok label) (t2179)" >>"$LOGFILE"
+			if [[ -n "$dismissed_dest_var" && "$dismissed_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+				printf -v "$dismissed_dest_var" '%s' "1"
+			fi
+			return 0
+		fi
+
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — coderabbit-nits-ok label present but human reviewer also blocking (t2179)" >>"$LOGFILE"
+		return 1
+	fi
+
+	# No coderabbit-nits-ok label — route worker-authored PRs for fix
+	# dispatch and skip the merge (t2203: consolidated in helper).
+	_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "review" "$_cr_pr_labels" || true
+	echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
 # Run all merge-eligibility gate checks for a single PR.
 # Returns 0 if all gates pass (PR may proceed to merge).
 # Returns 1 if any gate fails (PR should be skipped).
@@ -223,31 +279,8 @@ _check_pr_merge_gates() {
 	# label and EVERY CHANGES_REQUESTED reviewer is coderabbitai[bot],
 	# auto-dismiss those reviews and fall through to the next gate. If any
 	# human reviewer is also blocking, the label is ignored.
-	if [[ "$pr_review" == "CHANGES_REQUESTED" ]]; then
-		# Fetch labels once — reused by both the nits-ok check and the
-		# worker-routing block below.
-		local _cr_pr_labels="$pr_labels"
-		if [[ -z "$_cr_pr_labels" ]]; then
-			_cr_pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-				--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
-		fi
-
-		# t2179: coderabbit-nits-ok path.
-		if [[ ",${_cr_pr_labels}," == *",coderabbit-nits-ok,"* ]]; then
-			if _pulse_merge_dismiss_coderabbit_nits "$pr_number" "$repo_slug"; then
-				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — auto-dismissed CodeRabbit-only CHANGES_REQUESTED reviews (coderabbit-nits-ok label) (t2179)" >>"$LOGFILE"
-				# Fall through to the next gate — do NOT return 1.
-			else
-				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — coderabbit-nits-ok label present but human reviewer also blocking (t2179)" >>"$LOGFILE"
-				return 1
-			fi
-		else
-			# No coderabbit-nits-ok label — route worker-authored PRs for fix
-			# dispatch and skip the merge (t2203: consolidated in helper).
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "review" "$_cr_pr_labels" || true
-			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
-			return 1
-		fi
+	if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$linked_issue" "$pr_labels"; then
+		return 1
 	fi
 
 	# Skip external contributor PRs (non-collaborator).
@@ -928,6 +961,25 @@ _process_single_ready_pr() {
 			fi
 		# Otherwise pr_mergeable is now MERGEABLE/UNKNOWN — continue through
 		# the normal merge path below.
+	fi
+
+	# Review feedback routing is terminal for worker PRs and must not wait for
+	# GitHub's mergeable cache to resolve. Keep this narrow: conflict handling
+	# above retains precedence, and the helper only routes/skips CHANGES_REQUESTED
+	# via the same origin-label and stale-handover checks used by the later gate.
+	if [[ "$pr_review" == "CHANGES_REQUESTED" ]]; then
+		local _early_review_linked_issue=""
+		local _early_review_dismissed="0"
+		_early_review_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || _early_review_linked_issue=""
+		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$_early_review_linked_issue" "$pr_labels" _early_review_dismissed; then
+			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+			return 1
+		fi
+		# Avoid re-processing stale CHANGES_REQUESTED metadata in the later merge
+		# gate after the CodeRabbit-only dismissal path has already succeeded.
+		if [[ "$_early_review_dismissed" == "1" ]]; then
+			pr_review="NONE"
+		fi
 	fi
 
 	# Resolve UNKNOWN mergeable state with one retry; skip if not MERGEABLE

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -224,7 +224,7 @@ _handle_changes_requested_review_gate() {
 	# Fetch labels once — reused by both the nits-ok check and the
 	# worker-routing block below.
 	_cr_pr_labels="$pr_labels"
-	if [[ -z "$_cr_pr_labels" ]]; then
+	if [[ $# -lt 5 && -z "$_cr_pr_labels" ]]; then
 		_cr_pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -284,6 +284,27 @@ test_coderabbit_nits_ok_dismissed_once_before_late_gate() {
 	return 0
 }
 
+test_changes_requested_explicit_empty_labels_skip_refetch() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for explicit empty labels" 1 "could not extract review gate"; teardown_test_env; return 0; }
+
+	: >"$GH_LOG"
+	_handle_changes_requested_review_gate "556" "owner/repo" "CHANGES_REQUESTED" "42" "" || true
+
+	local label_fetch_count=0
+	label_fetch_count=$(grep -c -- '--json labels' "$GH_LOG" || true)
+	[[ "$label_fetch_count" =~ ^[0-9]+$ ]] || label_fetch_count=0
+	if [[ "$label_fetch_count" -ne 0 ]]; then
+		print_result "explicit empty PR labels do not refetch labels" 1 "label_fetch_count=${label_fetch_count}"
+	elif [[ "$ROUTE_CALLS" -ne 1 || "$ROUTE_ARGS" != "556|owner/repo|42|review" ]]; then
+		print_result "explicit empty PR labels do not refetch labels" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
+	else
+		print_result "explicit empty PR labels do not refetch labels" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_ci_feedback_dedupes_by_pr_head_sha() {
 	setup_test_env
 	define_feedback_helpers || { print_result "defines feedback helpers" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
@@ -412,6 +433,7 @@ main() {
 	test_red_pr_passes_gates_before_repair_route
 	test_changes_requested_unknown_routes_before_mergeable_skip
 	test_coderabbit_nits_ok_dismissed_once_before_late_gate
+	test_changes_requested_explicit_empty_labels_skip_refetch
 	test_ci_feedback_dedupes_by_pr_head_sha
 	test_ci_feedback_skips_pending_only_checks
 	test_ci_feedback_skips_mixed_pending_pass_checks

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -156,29 +156,42 @@ extract_function() {
 }
 
 define_process_helper() {
-	local fn_src=""
+	local fn_src="" review_gate_src=""
+	review_gate_src=$(extract_function _handle_changes_requested_review_gate "$MERGE_SCRIPT")
 	fn_src=$(extract_function _process_single_ready_pr "$MERGE_SCRIPT")
-	[[ -n "$fn_src" ]] || return 1
+	[[ -n "$review_gate_src" && -n "$fn_src" ]] || return 1
 
 	_OW_LABEL_PAT=",origin:worker,"
 	PULSE_MERGE_CLOSE_CONFLICTING=false
 	DRY_RUN=0
 	GATE_CALLS=0
+	GATE_REVIEW_ARG=""
+	RESOLVE_CALLS=0
 	ROUTE_CALLS=0
 	ROUTE_ARGS=""
+	ROUTE_LABELS=""
+	DISMISS_CALLS=0
+	PR_REQUIRED_CHECKS_RC=1
+	REFRESHED_MERGEABLE="UNKNOWN"
 
-	_resolve_pr_mergeable_status() { local pr_number="$1" repo_slug="$2" mergeable="$3"; [[ -n "$pr_number$repo_slug$mergeable" ]]; return 0; }
+	_resolve_pr_mergeable_status() { local pr_number="$1" repo_slug="$2" mergeable="$3"; [[ -n "$pr_number$repo_slug$mergeable" ]]; RESOLVE_CALLS=$((RESOLVE_CALLS + 1)); return 0; }
+	_pmp_refresh_unknown_mergeable_state_into() { local dest_var="$1" pr_number="$2" repo_slug="$3" mergeable="$4"; [[ -n "$pr_number$repo_slug$mergeable" ]]; printf -v "$dest_var" '%s' "$REFRESHED_MERGEABLE"; return 0; }
 	_extract_linked_issue() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; printf '42\n'; return 0; }
-	_check_pr_merge_gates() { local pr_number="$1" repo_slug="$2" pr_author="$3" pr_review="$4" linked_issue="$5"; [[ -n "$pr_number$repo_slug$pr_author$pr_review$linked_issue" ]]; GATE_CALLS=$((GATE_CALLS + 1)); return 0; }
-	_pr_required_checks_pass() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; return 1; }
+	_check_pr_merge_gates() { local pr_number="$1" repo_slug="$2" pr_author="$3" pr_review="$4" linked_issue="$5"; [[ -n "$pr_number$repo_slug$pr_author$pr_review$linked_issue" ]]; GATE_CALLS=$((GATE_CALLS + 1)); GATE_REVIEW_ARG="$pr_review"; return 0; }
+	_pr_required_checks_pass() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; if [[ "$PR_REQUIRED_CHECKS_RC" -eq 0 ]]; then return 0; fi; return 1; }
 	_check_required_checks_passing() { local repo_slug="$1" pr_number="$2"; [[ -n "$repo_slug$pr_number" ]]; return 1; }
+	_is_trusted_dependabot_update_pr() { local pr_number="$1" repo_slug="$2" pr_author="$3"; [[ -n "$pr_number$repo_slug$pr_author" ]]; return 1; }
+	_trusted_dependabot_non_review_checks_green() { local pr_number="$1" repo_slug="$2" pr_obj="$3"; [[ -n "$pr_number$repo_slug$pr_obj" ]]; return 1; }
 	_attempt_pr_ci_rebase_retry() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; return 1; }
-	_route_pr_to_fix_worker() { local pr_number="$1" repo_slug="$2" linked_issue="$3" mode="$4"; ROUTE_CALLS=$((ROUTE_CALLS + 1)); ROUTE_ARGS="${pr_number}|${repo_slug}|${linked_issue}|${mode}"; return 0; }
+	_route_pr_to_fix_worker() { local pr_number="$1" repo_slug="$2" linked_issue="$3" mode="$4" pr_labels="${5:-}"; ROUTE_CALLS=$((ROUTE_CALLS + 1)); ROUTE_ARGS="${pr_number}|${repo_slug}|${linked_issue}|${mode}"; ROUTE_LABELS="$pr_labels"; return 0; }
+	_pulse_merge_dismiss_coderabbit_nits() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; DISMISS_CALLS=$((DISMISS_CALLS + 1)); if [[ "${DISMISS_NITS_RC:-0}" -eq 0 ]]; then return 0; fi; return 1; }
 	_attempt_pr_update_branch() { return 1; }
 	_close_conflicting_pr() { return 0; }
 	_pmp_normalize_mergeable_state_into() { return 0; }
 	printf -v PR_OBJECT '%s' '{"number":100,"mergeable":"MERGEABLE","reviewDecision":"","author":{"login":"worker-bot"},"title":"t1: fix"}'
 
+	# shellcheck disable=SC1090
+	eval "$review_gate_src"
 	# shellcheck disable=SC1090
 	eval "$fn_src"
 	return 0
@@ -220,6 +233,52 @@ test_red_pr_passes_gates_before_repair_route() {
 		print_result "red PR routes one CI repair after gates pass" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
 	else
 		print_result "red PR passes gates then routes exactly one CI repair" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_changes_requested_unknown_routes_before_mergeable_skip() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for review routing" 1 "could not extract _process_single_ready_pr or review gate"; teardown_test_env; return 0; }
+
+	local pr_object rc=0
+	printf -v pr_object '%s' '{"number":554,"mergeable":"UNKNOWN","reviewDecision":"CHANGES_REQUESTED","author":{"login":"worker-bot"},"title":"GH#500: fix","updatedAt":"2026-06-21T00:00:00Z","headRefOid":"sha554","headRefName":"fix/review","baseRefName":"main","labels":[{"name":"origin:worker"},{"name":"status:in-review"}],"isDraft":false}'
+	_process_single_ready_pr "owner/repo" "$pr_object" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "CHANGES_REQUESTED+UNKNOWN routes before mergeability skip" 1 "Expected skip return 1, got ${rc}"
+	elif [[ "$ROUTE_CALLS" -ne 1 || "$ROUTE_ARGS" != "554|owner/repo|42|review" ]]; then
+		print_result "CHANGES_REQUESTED+UNKNOWN routes before mergeability skip" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
+	elif [[ "$RESOLVE_CALLS" -ne 0 || "$GATE_CALLS" -ne 0 ]]; then
+		print_result "CHANGES_REQUESTED+UNKNOWN routes before mergeability skip" 1 "resolve_calls=${RESOLVE_CALLS}, gate_calls=${GATE_CALLS}"
+	else
+		print_result "CHANGES_REQUESTED+UNKNOWN routes before mergeability skip" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_coderabbit_nits_ok_dismissed_once_before_late_gate() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for coderabbit review routing" 1 "could not extract _process_single_ready_pr or review gate"; teardown_test_env; return 0; }
+
+	local pr_object rc=0
+	DRY_RUN=1
+	PR_REQUIRED_CHECKS_RC=0
+	printf -v pr_object '%s' '{"number":555,"mergeable":"UNKNOWN","reviewDecision":"CHANGES_REQUESTED","author":{"login":"worker-bot"},"title":"GH#501: fix","updatedAt":"2026-06-21T00:00:00Z","headRefOid":"sha555","headRefName":"fix/nits","baseRefName":"main","labels":[{"name":"origin:worker"},{"name":"status:in-review"},{"name":"coderabbit-nits-ok"}],"isDraft":false}'
+	_process_single_ready_pr "owner/repo" "$pr_object" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "Expected dry-run success return 0, got ${rc}"
+	elif [[ "$DISMISS_CALLS" -ne 1 ]]; then
+		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "dismiss_calls=${DISMISS_CALLS}"
+	elif [[ "$GATE_CALLS" -ne 1 || "$GATE_REVIEW_ARG" != "NONE" ]]; then
+		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "gate_calls=${GATE_CALLS}, gate_review=${GATE_REVIEW_ARG}"
+	elif [[ "$ROUTE_CALLS" -ne 0 ]]; then
+		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "route_calls=${ROUTE_CALLS}"
+	else
+		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 0
 	fi
 	teardown_test_env
 	return 0
@@ -351,6 +410,8 @@ test_ci_feedback_emits_advisory_failure_when_required_clean() {
 
 main() {
 	test_red_pr_passes_gates_before_repair_route
+	test_changes_requested_unknown_routes_before_mergeable_skip
+	test_coderabbit_nits_ok_dismissed_once_before_late_gate
 	test_ci_feedback_dedupes_by_pr_head_sha
 	test_ci_feedback_skips_pending_only_checks
 	test_ci_feedback_skips_mixed_pending_pass_checks

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -108,7 +108,7 @@ case "$_subcmd" in
 		exit 0
 	fi
 	if [[ "$*" == *"--json name,bucket,conclusion,link"* ]]; then
-		printf '%s\n' '- **Lint**: failure — [check URL](https://example.invalid/check)'
+		printf '%s\n' '[{"name":"Lint","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
 		exit 0
 	fi
 	exit 0
@@ -201,6 +201,9 @@ define_helpers_under_test() {
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
 		_close_and_label_feedback_pr
+		_ci_check_url_has_infra_timeout_log
+		_ci_actionable_failed_checks_markdown
+		_ci_terminal_failed_check_results
 		_build_ci_feedback_section
 		_dispatch_ci_fix_worker
 		_dispatch_pr_fix_worker


### PR DESCRIPTION
## Summary

Extracted CHANGES_REQUESTED handling into a narrow helper and run that review-feedback route before the non-MERGEABLE hard skip, while preserving conflict precedence, origin-label routing checks, and CodeRabbit-only dismissal semantics.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh,.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh && bash .agents/scripts/tests/test-pulse-merge-update-branch.sh && bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh && bash .agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh; shellcheck touched files; secretlint touched files; git diff --check; .agents/scripts/linters-local.sh timed out twice at broad Secretlint after earlier gates passed

Resolves #25337


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.10 with gpt-5.5 spent 1h 24m and 326,581 tokens on this with the user in an interactive session.