### PR TITLE
GH#25343: fix: filter positive inline review acknowledgements

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -52,6 +52,7 @@ _build_inline_findings() {
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
 			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
+			"\\bimplementation looks correct and addresses?\\b|" +
 			"\\btests are passing\\b"; "i")) as $resolution_or_ack |
 		select($resolution_or_ack | not) |
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -694,6 +694,59 @@ test_scan_single_pr_positive_body_with_inline_comments_not_summary_only() {
 	return 0
 }
 
+test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					echo '[{"id":10,"user":{"login":"gemini-code-assist[bot]"},"path":".agents/scripts/pulse-merge.sh","line":230,"original_line":230,"position":37,"body":"Thank you for verifying the fix and adding the regression test. The implementation looks correct and addresses the efficiency concern regarding redundant API calls.","html_url":"https://github.com/example/repo/pull/1#discussion_r10","created_at":"2026-06-21T16:07:10Z"}]'
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					echo '[]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '[".agents/scripts/pulse-merge.sh"]'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "positive inline acknowledgement reply is filtered" 0
+	else
+		print_result "positive inline acknowledgement reply is filtered" 1 "expected 0 findings, got ${count}"
+	fi
+
+	_restore_mock_gh
+	return 0
+}
+
 test_scan_single_pr_filters_issue3158_review_body() {
 	# Regression: PR #3060 Gemini review — "The changes are correct and well-justified."
 	# with summary praise (effectively, improves, correct, well-justified) must be filtered

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -269,6 +269,7 @@ main() {
 	echo "Running positive-review filter regression tests (GH#4814)"
 	test_scan_single_pr_filters_issue4814_pr2166_exact_body
 	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
+	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
 
 	echo ""
 	echo "Running merge/CI-status comment filter tests (GH#5668)"


### PR DESCRIPTION
## Summary

Filtered Gemini-style positive inline acknowledgement replies from quality-feedback inline finding extraction and added a regression test covering the PR #25341 acknowledgement text.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh,.agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (55/55 passed); .agents/scripts/linters-local.sh (completed with ALL LOCAL CHECKS PASSED; advisory warnings only)

Resolves #25343


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.11 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 9m and 61,635 tokens on this as a headless worker.