### PR TITLE
GH#25345: fix: match addressed inline acknowledgements

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -52,7 +52,7 @@ _build_inline_findings() {
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
 			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
-			"\\bimplementation looks correct and addresses?\\b|" +
+			"\\bimplementation looks correct and address(es|ed)?\\b|" +
 			"\\btests are passing\\b"; "i")) as $resolution_or_ack |
 		select($resolution_or_ack | not) |
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -696,6 +696,7 @@ test_scan_single_pr_positive_body_with_inline_comments_not_summary_only() {
 
 test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 	reset_mock_state
+	local acknowledgement_body="Thank you for verifying the fix and adding the regression test. The implementation looks correct and addresses the efficiency concern regarding redundant API calls."
 
 	gh() {
 		local command="$1"
@@ -705,7 +706,7 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 			while [[ $# -gt 0 ]]; do
 				case "$1" in
 				repos/*/pulls/*/comments)
-					echo '[{"id":10,"user":{"login":"gemini-code-assist[bot]"},"path":".agents/scripts/pulse-merge.sh","line":230,"original_line":230,"position":37,"body":"Thank you for verifying the fix and adding the regression test. The implementation looks correct and addresses the efficiency concern regarding redundant API calls.","html_url":"https://github.com/example/repo/pull/1#discussion_r10","created_at":"2026-06-21T16:07:10Z"}]'
+					jq -n --arg body "$acknowledgement_body" '[{"id":10,"user":{"login":"gemini-code-assist[bot]"},"path":".agents/scripts/pulse-merge.sh","line":230,"original_line":230,"position":37,"body":$body,"html_url":"https://github.com/example/repo/pull/1#discussion_r10","created_at":"2026-06-21T16:07:10Z"}]'
 					return 0
 					;;
 				repos/*/pulls/*/reviews)
@@ -741,6 +742,16 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 		print_result "positive inline acknowledgement reply is filtered" 0
 	else
 		print_result "positive inline acknowledgement reply is filtered" 1 "expected 0 findings, got ${count}"
+	fi
+
+	acknowledgement_body="The implementation looks correct and addressed the stale cleanup path."
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "positive inline acknowledgement reply using addressed is filtered" 0
+	else
+		print_result "positive inline acknowledgement reply using addressed is filtered" 1 "expected 0 findings, got ${count}"
 	fi
 
 	_restore_mock_gh


### PR DESCRIPTION
## Summary

Corrected the inline acknowledgement filter regex so it matches address, addresses, and addressed forms, and added regression coverage for the addressed variant.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh

Resolves #25345


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.11 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 2m and 38,514 tokens on this as a headless worker.