### PR TITLE
feat: integrate opencode-aidevops plugin into setup and docs

### DIFF
--- a/.agents/scripts/setup/_opencode.sh
+++ b/.agents/scripts/setup/_opencode.sh
@@ -17,9 +17,52 @@ update_mcp_paths_in_opencode() {
 	return 0
 }
 
-# Add OpenCode plugin
+# Deploy the opencode-aidevops plugin from repo to runtime location.
+# Usage: add_opencode_plugin [--force]
 add_opencode_plugin() {
-	# TODO: Extract from setup.sh lines 4959-4997
-	:
+	local force="${1:-}"
+	local repo_plugin_dir="${AIDEVOPS_REPO:-${HOME}/Git/aidevops}/.agents/plugins/opencode-aidevops"
+	local runtime_plugin_dir="${HOME}/.aidevops/agents/plugins/opencode-aidevops"
+
+	if [[ ! -d "${repo_plugin_dir}" ]]; then
+		echo "WARN: Plugin source not found at ${repo_plugin_dir}" >&2
+		return 1
+	fi
+
+	# Skip if already deployed and not forcing
+	if [[ -d "${runtime_plugin_dir}/node_modules" && "${force}" != "--force" ]]; then
+		echo "OK: opencode-aidevops plugin already deployed"
+		return 0
+	fi
+
+	echo "Deploying opencode-aidevops plugin..."
+
+	# Sync plugin files (exclude tests, .git, etc.)
+	mkdir -p "${runtime_plugin_dir}"
+	rsync -a --delete \
+		--exclude='node_modules/' \
+		--exclude='tests/' \
+		--exclude='.git/' \
+		--exclude='*.log' \
+		"${repo_plugin_dir}/" "${runtime_plugin_dir}/"
+
+	# Install production dependencies
+	if command -v npm &>/dev/null; then
+		(cd "${runtime_plugin_dir}" && npm install --omit=dev --silent 2>/dev/null) || true
+	elif command -v bun &>/dev/null; then
+		(cd "${runtime_plugin_dir}" && bun install --production --silent 2>/dev/null) || true
+	fi
+
+	# Ensure the plugin is referenced in opencode.json
+	local opencode_config="${HOME}/.config/opencode/opencode.json"
+	if [[ -f "${opencode_config}" ]]; then
+		local plugin_ref="file://${runtime_plugin_dir}/index.mjs"
+		if ! rg -q "${plugin_ref}" "${opencode_config}" 2>/dev/null; then
+			echo "NOTE: Add this to opencode.json plugin array:" >&2
+			echo "  \"${plugin_ref}\"" >&2
+		fi
+	fi
+
+	echo "OK: opencode-aidevops plugin deployed to ${runtime_plugin_dir}"
 	return 0
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,25 @@ See `.agents/aidevops/` (architecture, setup) and `.agents/tools/` (agent/MCP au
 | `.agents/aidevops/architecture.md` | Framework structure |
 | `.agents/aidevops/setup.md` | AI guide to setup.sh |
 
+## OpenCode Plugin
+
+The `opencode-aidevops` plugin (`.agents/plugins/opencode-aidevops/`) extends OpenCode with aidevops capabilities: agent loading, quality hooks, OAuth pool, observability, and context preservation.
+
+**Deploy**: `.agents/scripts/setup/_opencode.sh` → `add_opencode_plugin()`
+
+**Runtime location**: `~/.aidevops/agents/plugins/opencode-aidevops/`
+
+**Config reference** in `~/.config/opencode/opencode.json`:
+```json
+"plugin": ["file:///Users/robi/.aidevops/agents/plugins/opencode-aidevops/index.mjs"]
+```
+
+**Modules**: config-hook, quality-hooks, shell-env, compaction, intent-tracing, greeting, session-title, oauth-pool, provider-auth, cursor-proxy, google-proxy, observability, ttsr-rules.
+
+**Tests**: `cd .agents/plugins/opencode-aidevops && npm test`
+
+**Update cycle**: Plugin version tracks OpenCode SDK (`opencode-ai` peer dep). Run `add_opencode_plugin --force` to redeploy after aidevops updates.
+
 ## Agent Design Principles
 
 From `tools/build-agent/build-agent.md`:


### PR DESCRIPTION
## Summary

The `opencode-aidevops` plugin already exists at `.agents/plugins/opencode-aidevops/` but is undocumented and not deployed by `setup.sh`. This PR integrates it properly.

## Changes

- **`setup/_opencode.sh`**: Implement `add_opencode_plugin()` — deploys plugin from repo to `~/.aidevops/agents/plugins/`, installs deps, verifies config reference
- **`AGENTS.md`**: Document plugin architecture, modules, update cycle, and test commands

## What the plugin does

Extends OpenCode with aidevops capabilities: agent loading, quality hooks, OAuth pool, observability, context preservation, greeting injection, session title handling, cursor/google proxy, and TTSR rules.

## Testing

```bash
# Deploy plugin
source .agents/scripts/setup/_opencode.sh
add_opencode_plugin --force

# Run tests
cd .agents/plugins/opencode-aidevops && npm test
```

## Notes

- Plugin tracks OpenCode SDK version via `peerDependencies`
- Survives OpenCode updates (stored in `~/.aidevops/`, not OpenCode install dir)
- Redeploy with `add_opencode_plugin --force` after aidevops updates
