### PR TITLE
GH#25350: fix pulse merge target branch comments

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -423,25 +423,26 @@ _check_pr_merge_gates() {
 # Perform all post-merge actions for a successfully merged PR:
 # build and post closing comment, close linked issue, unlock.
 # Best-effort — failures are logged but do not propagate.
-# Args: $1=pr_number, $2=repo_slug, $3=linked_issue, $4=merge_summary, $5=pr_labels
+# Args: $1=pr_number, $2=repo_slug, $3=linked_issue, $4=merge_summary, $5=pr_labels, $6=pr_base_ref_name (optional)
 #######################################
 #######################################
 # Build the closing comment body for a merged PR (with signature footer).
-# Args: $1=pr_number, $2=repo_slug, $3=linked_issue, $4=merge_summary
+# Args: $1=pr_number, $2=repo_slug, $3=linked_issue, $4=merge_summary, $5=pr_base_ref_name (optional)
 # Stdout: closing comment body
 # Returns: 0 always
 #######################################
 _pm_build_closing_comment() {
 	local pr_number="$1" repo_slug="$2" linked_issue="$3" merge_summary="$4"
+	local pr_base_ref_name="${5:-main}"
 	local body
 	if [[ -n "$merge_summary" ]]; then
 		body="${merge_summary}
 
 ---
-Merged via PR #${pr_number} to main.
+Merged via PR #${pr_number} to ${pr_base_ref_name}.
 _Merged by deterministic merge pass (pulse-wrapper.sh)._"
 	else
-		body="Completed via PR #${pr_number}, merged to main.
+		body="Completed via PR #${pr_number}, merged to ${pr_base_ref_name}.
 
 _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY comment nor PR body text was available._"
 	fi
@@ -629,10 +630,11 @@ _handle_post_merge_actions() {
 	local linked_issue="$3"
 	local merge_summary="$4"
 	local pr_labels="${5:-}"
+	local pr_base_ref_name="${6:-main}"
 
 	local closing_comment
 	closing_comment=$(_pm_build_closing_comment "$pr_number" "$repo_slug" \
-		"$linked_issue" "$merge_summary")
+		"$linked_issue" "$merge_summary" "$pr_base_ref_name")
 
 	# Post closing comment on PR; unlock the merged PR (t1934)
 	gh_pr_comment "$pr_number" --repo "$repo_slug" \
@@ -1191,12 +1193,12 @@ ${merge_output}"
 		if [[ ",${_ipr_labels}," == *"${_OW_LABEL_PAT}"* ]]; then
 			echo "[pulse-merge] auto-merged origin:worker (worker-briefed) PR #${pr_number} (author=${pr_author}, linked_issue=#${linked_issue:-unknown})" >>"$LOGFILE"
 		fi
-		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels"
+		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels" "$pr_base_ref_name"
 		return 0
 	elif [[ "$merge_output" == *"Merge already in progress"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: PR #${pr_number} in ${repo_slug} already has a merge in progress; counting as merge progress (GH#24383): ${merge_output}" >>"$LOGFILE"
 		local _ipr_labels="$pr_labels"
-		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels"
+		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels" "$pr_base_ref_name"
 		return $?
 	else
 		local final_merge_output="$merge_output"

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -216,6 +216,32 @@ test_superseded_pr_closes_original_issue() {
 	return 0
 }
 
+test_closing_comment_uses_pr_base_ref() {
+	: >"$GH_CALL_LOG"
+	: >"$SOLVED_LABEL_LOG"
+	export TEST_PR_LABELS="origin:worker"
+
+	_handle_post_merge_actions "753" "marcusquinn/aidevops" "25350" "merged" "origin:worker" "develop"
+
+	assert_log_contains "$GH_CALL_LOG" "Merged via PR #753 to develop" \
+		"closing comment names non-main PR base ref"
+	assert_log_not_contains "$GH_CALL_LOG" "Merged via PR #753 to main" \
+		"closing comment does not hardcode main when base ref is provided"
+	return 0
+}
+
+test_closing_comment_defaults_to_main_for_legacy_callers() {
+	: >"$GH_CALL_LOG"
+	: >"$SOLVED_LABEL_LOG"
+	export TEST_PR_LABELS="origin:worker"
+
+	_handle_post_merge_actions "754" "marcusquinn/aidevops" "25350" "" "origin:worker"
+
+	assert_log_contains "$GH_CALL_LOG" "Completed via PR #754, merged to main" \
+		"legacy post-merge callers default closing comment base ref to main"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -225,6 +251,8 @@ main() {
 	test_provided_empty_pr_labels_skip_refetch
 	test_omitted_pr_labels_fetches_fallback
 	test_superseded_pr_closes_original_issue
+	test_closing_comment_uses_pr_base_ref
+	test_closing_comment_defaults_to_main_for_legacy_callers
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- Thread the PR base ref into pulse post-merge comment generation.
- Report non-main merge targets accurately in PR and issue closing comments.
- Keep legacy callers compatible by defaulting the base ref to main.

Resolves #25350

## Verification

- `.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh`
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh`
- `.agents/scripts/linters-local.sh` (completed; repo-wide pre-existing advisory/blocking debt reported, final script status: ALL LOCAL CHECKS PASSED)


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.11 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 44m and 138,486 tokens on this with the user in an interactive session. Overall, 2h 15m since this issue was created.
