### PR TITLE
GH#25352: docs: adopt serve-sim native addon guidance

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1296,7 +1296,7 @@ _setup_serve_sim_cli_version() {
 }
 
 setup_serve_sim() {
-	# serve-sim currently ships an arm64 Apple Simulator helper.
+	# serve-sim currently ships an arm64 native Apple Simulator addon.
 	if [[ "$(uname -s)" != "Darwin" ]]; then
 		return 0
 	fi
@@ -1336,15 +1336,15 @@ setup_serve_sim() {
 		return 0
 	fi
 
-	if ! command -v bun >/dev/null 2>&1 && ! command -v npm >/dev/null 2>&1; then
-		print_info "serve-sim installs via npm or bun; install Node.js/npm or Bun first"
+	if ! command -v npm >/dev/null 2>&1; then
+		print_info "serve-sim installs via npm; install Node.js/npm first"
 		return 0
 	fi
 
 	print_info "serve-sim streams booted Apple Simulators to a browser for agent/user review"
 	printf '%s\n' "  Features:"
 	printf '%s\n' "    - Browser preview at http://localhost:3200"
-	printf '%s\n' "    - H.264/MJPEG stream with --codec control + WebSocket control channel"
+	printf '%s\n' "    - In-process native capture/HID with H.264/MJPEG stream control"
 	printf '%s\n' "    - Gestures, hardware buttons, typing, rotation, memory warnings"
 	printf '%s\n' "    - Camera feed injection for simulator apps"
 	printf '%s\n' ""
@@ -1363,7 +1363,7 @@ setup_serve_sim() {
 		fi
 	else
 		print_info "Skipped serve-sim installation"
-		print_info "Install later: npm install -g serve-sim (or bun install -g serve-sim)"
+		print_info "Install later: npm install -g serve-sim"
 	fi
 
 	return 0

--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -22,22 +22,22 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Stream a booted iOS, iPad, or Apple Watch Simulator to a browser and drive it from CLI/agent commands.
-- **Install**: `npm install -g serve-sim` or run ad hoc with `npx serve-sim`.
+- **Install**: `npm install -g serve-sim` or run ad hoc with `npx serve-sim`; Bun is not required to run the CLI.
 - **Setup**: `./setup.sh` offers this on supported local Macs after MiniSim.
-- **Requirements**: macOS on Apple Silicon, Xcode command-line tools (`xcrun simctl`), Node.js 20+, and at least one booted Apple Simulator.
+- **Requirements**: macOS on Apple Silicon, Xcode command-line tools (`xcrun simctl`), a maintained Node.js LTS release (Node.js 20+), and at least one booted Apple Simulator.
 - **GitHub**: https://github.com/EvanBacon/serve-sim (Apache-2.0)
 
 ```bash
 serve-sim                         # Preview UI at http://localhost:3200
-serve-sim --detach -q             # Start helper and return JSON with url/streamUrl
+serve-sim --detach -q             # Start background preview and return JSON with url/streamUrl
 serve-sim --codec mjpeg           # Pin stream codec when H.264 is unavailable
 serve-sim --list -q               # List running simulator streams
 serve-sim button home             # Send hardware button
 serve-sim type "hello"            # Type into focused field
-serve-sim --kill                  # Stop helper(s)
+serve-sim --kill                  # Stop stream(s)
 ```
 
-Use `serve-sim` when the user needs a visible, browser-shareable simulator surface. Pair it with `agent-device`, `ios-simulator-mcp`, or `maestro` when the task needs accessibility refs, MCP tool calls, or repeatable E2E flows. The preview defaults to H.264 when available and can switch or auto-downgrade to MJPEG when hardware decoding is unstable during screen recording; use `--codec <auto|h264|mjpeg>` when the host must pin a server-side stream codec.
+Use `serve-sim` when the user needs a visible, browser-shareable simulator surface. Pair it with `agent-device`, `ios-simulator-mcp`, or `maestro` when the task needs accessibility refs, MCP tool calls, or repeatable E2E flows. Current upstream builds serve capture, accessibility, and HID input through an in-process native addon instead of a separate `serve-sim-bin` helper, so malformed browser input should be ignored rather than crash the preview server. The preview defaults to H.264 when available and can switch or auto-downgrade to MJPEG when hardware decoding is unstable during screen recording; use `--codec <auto|mjpeg>` when the host must pin stream compatibility.
 
 <!-- AI-CONTEXT-END -->
 
@@ -47,7 +47,7 @@ Use `serve-sim` when the user needs a visible, browser-shareable simulator surfa
 |------|-----|
 | Show a simulator in a browser or preview pane | `serve-sim --detach -q`, surface the `url` |
 | Let humans and agents share the same local/LAN/tunneled simulator view | `serve-sim` preview UI |
-| Drive low-level gestures, buttons, rotation, typing, memory warnings | `serve-sim gesture/button/type/rotate/memory-warning` |
+| Drive low-level gestures, buttons, keyboard toggles, rotation, typing, memory warnings | `serve-sim gesture/button/type/rotate/memory-warning` |
 | Test camera-dependent flows | `serve-sim camera <bundle-id> --file/--webcam` |
 | Read simulator logs in browser-based agent tooling | `serve-sim` preview UI/log forwarding |
 
@@ -72,14 +72,15 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 | Stream only | `serve-sim --no-preview [device...]` | Foreground stream without React preview UI |
 | List streams | `serve-sim --list -q` | Use `-q` for machine-readable output |
 | Force compatibility stream | `serve-sim --codec mjpeg [device...]`, open the preview with `?codec=mjpeg`, or use Stream → Codec | Use MJPEG if H.264/WebCodecs stutters or fails while recording |
-| Stop helpers | `serve-sim --kill [device]` | Stop all or one device helper |
+| Stop streams | `serve-sim --kill [device]` | Stop all streams or one device stream |
 | Gesture | `serve-sim gesture '<json>' [-d udid]` | Use documented JSON shape; avoid guessing coordinates |
 | Button | `serve-sim button home [-d udid]` | Hardware/home/app-switcher style controls |
 | Type | `serve-sim type "text" [-d udid]` | Also supports `--stdin` and `--file <path>` |
+| Toggle software keyboard | Press `Cmd+K` in the preview | Mirrors Simulator's software keyboard toggle without changing hardware-keyboard state |
 | Rotate | `serve-sim rotate landscape_left [-d udid]` | portrait, portrait_upside_down, landscape_left, landscape_right |
 | Memory warning | `serve-sim memory-warning [-d udid]` | Simulator memory-pressure test |
 | CoreAnimation | `serve-sim ca-debug slow-animations on [-d udid]` | blended, copies, misaligned, offscreen, slow-animations |
-| Camera injection | `serve-sim camera <bundle-id> --file <path>` | Also supports placeholder and webcam sources |
+| Camera injection | `serve-sim camera <bundle-id> --file <path>` | Also supports placeholder/webcam sources, `camera switch`, `camera mirror`, `camera status`, `--list-webcams`, and `--stop-webcam` |
 
 ## Agent Workflow
 
@@ -93,7 +94,7 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 
 ## Expo / Dev Server Embedding
 
-`serve-sim/middleware` can mount the preview under an existing Connect-style server, including Expo Metro. This is useful when a mobile dev server should expose the simulator at a stable path such as `/.sim` while the helper runs in the background. Recent upstream versions can opt in to same-origin helper and WebKit DevTools proxying (`proxyHelpers`) when the host wires HTTP upgrade handling, so remote viewers only need the preview server port; plain `app.use(simMiddleware())` mounts still expose direct helper URLs.
+`serve-sim/middleware` can mount the preview under an existing Connect-style server, including Expo Metro. This is useful when a mobile dev server should expose the simulator at a stable path such as `/.sim`. Recent upstream versions route the preview, same-origin helper endpoints, and WebKit DevTools proxying through the in-process server when the host wires HTTP upgrade handling, so remote viewers only need the preview server port.
 
 ## Upstream Agent Skill
 
@@ -109,10 +110,10 @@ aidevops keeps this native guide so mobile-testing tasks route to `serve-sim` ev
 
 ## Troubleshooting
 
-- **Unsupported host**: The bundled helper is Apple Silicon only. Intel Macs should use other simulator tools.
+- **Unsupported host**: The native simulator addon is Apple Silicon only. Intel Macs should use other simulator tools.
 - **No simulator**: Boot one first with Xcode Simulator, MiniSim, or `xcrun simctl boot <device>`.
-- **Node too old**: Upgrade to Node.js 20+ before running the CLI.
-- **Port collision**: Stop stale helpers with `serve-sim --kill`.
+- **Node too old**: Upgrade to a maintained Node.js LTS release (Node.js 20+) before running the CLI.
+- **Port collision**: Stop stale streams with `serve-sim --kill`.
 - **H.264/WebCodecs instability**: Use `serve-sim --codec mjpeg`, the Stream → Codec picker, or append `?codec=mjpeg` to the preview URL; recent versions auto-downgrade fatal AVCC decoder failures to MJPEG.
 - **Camera injection**: Requires macOS 14+ and a simulator app bundle ID.
 


### PR DESCRIPTION
## Summary

Adopts the upstream serve-sim ab5dd5a guidance by documenting the in-process native simulator addon, updated codec/stream wording, expanded camera/keyboard commands, and aligning setup messaging with npm-only Node.js 20+ installation.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh,.agents/tools/mobile/serve-sim.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck: .agents/scripts/shellcheck-wrapper.sh .agents/scripts/setup/modules/tool-install.sh; Markdown: npx --no-install markdownlint-cli2 .agents/tools/mobile/serve-sim.md; Regression: bash .agents/scripts/tests/test-tool-install-serve-sim.sh

Resolves #25352


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 15m and 94,587 tokens on this as a headless worker.