### PR TITLE
GH#25354: fix: align zero-progress external contributor gate

### DIFF
--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1132,6 +1132,7 @@ _pms_pr_counts_for_zero_progress() {
 	local pr_author="${4:-}"
 
 	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	local labels_tokenized=",${labels_str},"
 
 	if declare -F _check_required_checks_passing >/dev/null 2>&1; then
 		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
@@ -1140,10 +1141,31 @@ _pms_pr_counts_for_zero_progress() {
 		fi
 	fi
 
-	if [[ ",${labels_str}," == *",origin:interactive,"* ]]; then
+	if [[ "$labels_tokenized" == *",origin:interactive,"* ]]; then
 		if ! declare -F _interactive_pr_auto_merge_allowed >/dev/null 2>&1 \
 			|| ! _interactive_pr_auto_merge_allowed "$pr_number" "$repo_slug" "$labels_str" >/dev/null 2>&1; then
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — origin:interactive PR requires manual merge" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
+	# Keep parity with pulse-merge.sh::_check_pr_merge_gates external-contributor
+	# defence-in-depth. These PRs are intentionally skipped unless a linked issue
+	# carries maintainer crypto approval; counting them as eligible can produce a
+	# false zero-progress collapse when the merge pass is correctly preserving the
+	# trust boundary.
+	if [[ "$labels_tokenized" == *",external-contributor,"* ]]; then
+		local external_linked_issue=""
+		if declare -F _extract_linked_issue >/dev/null 2>&1; then
+			external_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || external_linked_issue=""
+		fi
+		if [[ -z "$external_linked_issue" ]]; then
+			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — external-contributor PR has no linked issue" >>"$LOGFILE"
+			return 1
+		fi
+		if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 \
+			|| ! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — external-contributor PR linked issue #${external_linked_issue} lacks crypto approval" >>"$LOGFILE"
 			return 1
 		fi
 	fi
@@ -1163,7 +1185,7 @@ _pms_pr_counts_for_zero_progress() {
 		fi
 	fi
 
-	if [[ ",${labels_str}," == *",origin:worker,"* ]]; then
+	if [[ "$labels_tokenized" == *",origin:worker,"* ]]; then
 		local linked_issue=""
 		if declare -F _extract_linked_issue >/dev/null 2>&1; then
 			linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked_issue=""

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -19,10 +19,11 @@
 #        merged=0 + eligible>0 → gauge incremented by 1
 #   7. _pms_count_eligible_unmerged_for_repo excludes PRs blocked by
 #      read-only merge gates (required checks, interactive PRs held for manual
-#      merge, worker PR with no linked issue, non-collaborator author without
-#      maintainer crypto-approval, and unknown authors that must not bypass the
-#      collaborator check) and keeps processing when GitHub returns a null PR
-#      author for deleted users.
+#      merge, worker PR with no linked issue, external-contributor PR without
+#      maintainer crypto-approval, non-collaborator author without maintainer
+#      crypto-approval, and unknown authors that must not bypass the collaborator
+#      check) and keeps processing when GitHub returns a null PR author for
+#      deleted users.
 #   8. _detect_pattern_outage de-duplicates repeated PR observations.
 #   9. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
@@ -439,7 +440,9 @@ gh() {
 {"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null},
 {"number":110,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":null,"author":{"login":"external"}},
 {"number":111,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"}],"author":{"login":"trusted"}},
-{"number":112,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"},{"name":"allow-auto-merge"}],"author":{"login":"trusted"}}
+{"number":112,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"},{"name":"allow-auto-merge"}],"author":{"login":"trusted"}},
+{"number":113,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"external-contributor"}],"author":{"login":"trusted"}},
+{"number":114,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"external-contributor"}],"author":{"login":"trusted"}}
 ]'
 		return 0
 	fi
@@ -480,6 +483,9 @@ _has_maintainer_crypto_approval() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	[[ -n "$pr_number" && -n "$repo_slug" ]] || return 1
+	if [[ "$pr_number" == "114" ]]; then
+		return 0
+	fi
 	return 1
 }
 
@@ -495,7 +501,7 @@ _interactive_pr_auto_merge_allowed() {
 }
 
 got=$(_pms_count_eligible_unmerged_for_repo "example/repo")
-assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "3" "$got"
+assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "4" "$got"
 
 PMS_TEST_COUNT_AUTHORS_FILE="$TEST_TMPDIR/count-authors.log"
 : >"$PMS_TEST_COUNT_AUTHORS_FILE"


### PR DESCRIPTION
## Summary

Aligned the zero-progress eligible-unmerged denominator with the deterministic external-contributor merge gate so external-contributor PRs without linked maintainer crypto approval are excluded instead of causing false merge-throughput collapse alerts. Added regression coverage for blocked and approved external-contributor PRs.

## Files Changed

.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-stuck.sh (56 tests, 0 failures); shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh; .agents/scripts/linters-local.sh attempted twice but exceeded 120s and 300s while entering Secretlint after earlier gates passed

Resolves #25354


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.21.12 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 11m and 103,832 tokens on this as a headless worker.