### PR TITLE
GH#25360: fix: preserve editable hue input

### DIFF
--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -64,6 +64,22 @@ const surfaceIcons: Record<SurfaceIconName, IconType> = {
   users: FiUsers,
 };
 
+export function hueFromInputValue(value: string): number | null {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.length === 0) {
+    return null;
+  }
+
+  const hue = Number(trimmedValue);
+
+  if (!Number.isInteger(hue)) {
+    return null;
+  }
+
+  return Math.min(359, Math.max(0, hue));
+}
+
 export function SurfaceGlyph({ icon }: { icon: SurfaceIconName }) {
   const Icon = surfaceIcons[icon];
 
@@ -271,10 +287,14 @@ function SidebarFooter({ accentHue, fontPreference, fontSizePreference, setAccen
   };
   const updateHueInput = (value: string) => {
     setHueInput(value);
-    if (value.trim().length === 0) {
+
+    const nextHue = hueFromInputValue(value);
+
+    if (nextHue === null) {
       return;
     }
-    updateAccentHue(Number.parseInt(value, 10));
+
+    updateAccentHue(nextHue);
   };
 
   useEffect(() => {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { appearanceStorageKeys, readStoredAppearancePreferences } from "../src/App";
+import { hueFromInputValue } from "../src/AppNavigation";
 import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
@@ -124,6 +125,14 @@ describe("dashboard shell", () => {
     expect(preferences.showBorders).toBe(true);
     expect(preferences.showNavCounts).toBe(true);
     expect(preferences.themePreference).toBe("system");
+  });
+
+  test("allows clearing the editable hue input without resetting to the default", () => {
+    expect(hueFromInputValue("")).toBeNull();
+    expect(hueFromInputValue("   ")).toBeNull();
+    expect(hueFromInputValue("210")).toBe(210);
+    expect(hueFromInputValue("999")).toBe(359);
+    expect(hueFromInputValue("1e")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Added a hue input normalization helper, kept empty/invalid numeric input from updating accentHue, and covered the clear-input case in GUI web component tests.

## Files Changed

packages/gui-web/src/AppNavigation.tsx,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Attempted: bun test packages/gui-web/tests/component.test.ts (failed: bun: command not found). Attempted: npm exec --no -- tsc --noEmit (failed: local TypeScript compiler unavailable).

Resolves #25360


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 2m and 39,338 tokens on this as a headless worker.