### PR TITLE
GH#25359: fix: stop macOS GUI services on termination

### DIFF
--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -360,6 +360,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     private let defaultAccentHue: CGFloat = 123
     private let mainWindowFrameAutosaveName = "aidevops-main-window"
     private let titlebarHeight: CGFloat = 24
+    private var servicesStopped = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         configureMenu()
@@ -376,6 +377,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         saveMainWindowFrame()
         stopServices()
         return .terminateNow
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        saveMainWindowFrame()
+        stopServices()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -835,6 +841,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     }
 
     private func stopServices() {
+        if servicesStopped {
+            return
+        }
+        servicesStopped = true
         _ = runServiceHelper(arguments: ["stop"])
     }
 

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -360,6 +360,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     private let defaultAccentHue: CGFloat = 123
     private let mainWindowFrameAutosaveName = "aidevops-main-window"
     private let titlebarHeight: CGFloat = 24
+    private let serviceQueue = DispatchQueue(label: "sh.aidevops.gui.services")
     private var servicesStopped = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -824,8 +825,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     }
 
     private func startServicesAndLoadApp() {
-        DispatchQueue.global(qos: .userInitiated).async {
+        serviceQueue.async {
+            if self.servicesStopped {
+                return
+            }
             let result = self.runServiceHelper()
+            if self.servicesStopped {
+                return
+            }
             DispatchQueue.main.async {
                 if result.ok {
                     self.loadAppURL()
@@ -841,11 +848,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     }
 
     private func stopServices() {
-        if servicesStopped {
-            return
+        serviceQueue.sync {
+            if servicesStopped {
+                return
+            }
+            servicesStopped = true
+            _ = runServiceHelper(arguments: ["stop"])
         }
-        servicesStopped = true
-        _ = runServiceHelper(arguments: ["stop"])
     }
 
     private func runServiceHelper(arguments: [String]) -> (ok: Bool, message: String) {


### PR DESCRIPTION
## Summary

Added an applicationWillTerminate teardown path and made stopServices idempotent so the bundled stop helper runs when the native macOS wrapper exits without double-invoking it.

## Files Changed

packages/gui-desktop/scripts/install-macos-app.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck packages/gui-desktop/scripts/install-macos-app.sh; bash -n packages/gui-desktop/scripts/install-macos-app.sh

Resolves #25359


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 2m and 101,165 tokens on this as a headless worker.