### PR TITLE
GH#25364: filter resolved race-condition acknowledgement

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -51,6 +51,8 @@ _build_inline_findings() {
 			"\\bno further recommendations?\\b|" +
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
+			"\\bnecessary synchronization\\b.*\\b(already )?incorporates?\\b|" +
+			"\\brace condition\\b.*\\b(is|was) indeed addressed\\b|" +
 			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
 			"\\bimplementation looks correct and address(es|ed)?\\b|" +
 			"\\btests are passing\\b"; "i")) as $resolution_or_ack |

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -318,6 +318,19 @@ test_skips_verified_tests_passing_inline_ack() {
 	return 0
 }
 
+test_skips_pr25362_race_condition_ack() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update and for verifying the implementation. Since the current branch already incorporates the necessary synchronization using `serviceQueue` and the `servicesStopped` flag as discussed, the race condition is indeed addressed. I appreciate the thorough verification.","path":"packages/gui-desktop/scripts/install-macos-app.sh","line":848,"html_url":"https://example.invalid/review","created_at":"2026-06-23T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "25362" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip PR #25362 race-condition acknowledgement" 0
+	else
+		print_result "skip PR #25362 race-condition acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -244,6 +244,7 @@ main() {
 	test_skips_resolved_thread_inline_ack
 	test_skips_multispace_implementation_verified_inline_ack
 	test_skips_verified_tests_passing_inline_ack
+	test_skips_pr25362_race_condition_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

- Treat Gemini's PR #25362 race-condition acknowledgement as resolved/non-actionable review feedback.
- Add regression coverage for the exact acknowledgement shape so `quality-feedback-helper.sh scan-merged` does not file this resolved comment again.

Resolves #25364

## Verification

- `bash .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh`
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 7m and 199,784 tokens on this as a headless worker.