### PR TITLE
GH#25366: fix synchronization acknowledgement regex

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -51,7 +51,7 @@ _build_inline_findings() {
 			"\\bno further recommendations?\\b|" +
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
-			"\\bnecessary synchronization\\b.*\\b(already )?incorporates?\\b|" +
+			"\\b(already )?incorporates?\\b.*\\bnecessary synchronization\\b|" +
 			"\\brace condition\\b.*\\b(is|was) indeed addressed\\b|" +
 			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
 			"\\bimplementation looks correct and address(es|ed)?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -331,6 +331,19 @@ test_skips_pr25362_race_condition_ack() {
 	return 0
 }
 
+test_skips_incorporates_necessary_synchronization_ack_without_race_phrase() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The current branch already incorporates the necessary synchronization using `serviceQueue` and the `servicesStopped` flag as discussed.","path":"packages/gui-desktop/scripts/install-macos-app.sh","line":848,"html_url":"https://example.invalid/review","created_at":"2026-06-23T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "25362" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip incorporates necessary-synchronization acknowledgement" 0
+	else
+		print_result "skip incorporates necessary-synchronization acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -245,6 +245,7 @@ main() {
 	test_skips_multispace_implementation_verified_inline_ack
 	test_skips_verified_tests_passing_inline_ack
 	test_skips_pr25362_race_condition_ack
+	test_skips_incorporates_necessary_synchronization_ack_without_race_phrase
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary
- Reordered the inline acknowledgement regex so it matches comments where a branch already incorporates the necessary synchronization.
- Added a regression case that omits the separate race-condition fallback phrase, proving the synchronization regex matches independently.

## Testing
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` (58/58 passed)

Resolves #25366
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 6m and 46,145 tokens on this as a headless worker.