### PR TITLE
GH#25368: fix: harden synchronization acknowledgement regex

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -51,7 +51,7 @@ _build_inline_findings() {
 			"\\bno further recommendations?\\b|" +
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
-			"\\b(already )?incorporates?\\b.*\\bnecessary synchronization\\b|" +
+			"(?s)\\b(already )?incorporate[sd]?\\b.*\\bnecessary synchronization\\b|" +
 			"\\brace condition\\b.*\\b(is|was) indeed addressed\\b|" +
 			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
 			"\\bimplementation looks correct and address(es|ed)?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -334,7 +334,7 @@ test_skips_pr25362_race_condition_ack() {
 test_skips_incorporates_necessary_synchronization_ack_without_race_phrase() {
 	local comments result
 	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
-	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The current branch already incorporates the necessary synchronization using `serviceQueue` and the `servicesStopped` flag as discussed.","path":"packages/gui-desktop/scripts/install-macos-app.sh","line":848,"html_url":"https://example.invalid/review","created_at":"2026-06-23T00:00:00Z"}]'
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The current branch already\nincorporated the necessary synchronization using `serviceQueue` and the `servicesStopped` flag as discussed.","path":"packages/gui-desktop/scripts/install-macos-app.sh","line":848,"html_url":"https://example.invalid/review","created_at":"2026-06-23T00:00:00Z"}]'
 	result=$(_build_inline_findings "$comments" "25362" "medium" | jq 'length')
 	if [[ "$result" == "0" ]]; then
 		print_result "skip incorporates necessary-synchronization acknowledgement" 0


### PR DESCRIPTION
## Summary

Hardened the inline review acknowledgement filter so necessary-synchronization acknowledgements match past-tense incorporated wording and wrapped multiline bodies; updated the regression test to cover an escaped newline before incorporated.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh

Resolves #25368


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 4m and 119,079 tokens on this as a headless worker.