### PR TITLE
GH#25370: fix: localize synchronization regex dotall

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -51,7 +51,7 @@ _build_inline_findings() {
 			"\\bno further recommendations?\\b|" +
 			"\\bno further action is needed\\b|" +
 			"\\bthread is resolved\\b|" +
-			"(?s)\\b(already )?incorporate[sd]?\\b.*\\bnecessary synchronization\\b|" +
+			"(?s:\\b(already )?incorporate[sd]?\\b.*\\bnecessary synchronization\\b)|" +
 			"\\brace condition\\b.*\\b(is|was) indeed addressed\\b|" +
 			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
 			"\\bimplementation looks correct and address(es|ed)?\\b|" +


### PR DESCRIPTION
## Summary

Localized the jq dotall modifier for the synchronization acknowledgement branch in .agents/scripts/quality-feedback-findings-lib.sh so it cannot leak into later alternations.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #25370


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 4m and 98,174 tokens on this as a headless worker.