### PR TITLE
GH#25378: docs: clarify serve-sim plugin install flow

### DIFF
--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -105,10 +105,10 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 
 ## Upstream Agent Skill
 
-The upstream repository ships an Agent Skill under `skills/serve-sim`. For runtimes that support the Agent Skills standard, install it with:
+The upstream repository ships an Agent Skill under `skills/serve-sim`. For runtimes that support the Agent Skills standard, install it with the host's native skill/plugin installer:
 
 ```bash
-# Claude Code plugin marketplace
+# Claude Code plugin marketplace (current singular `/plugin` command flow)
 /plugin marketplace add EvanBacon/serve-sim
 /plugin install serve-sim
 


### PR DESCRIPTION
## Summary

Clarified that serve-sim's upstream Agent Skill should be installed through each host's native skill/plugin installer and documented that Claude Code currently uses the singular /plugin marketplace flow already shown in the guide.

## Files Changed

.agents/tools/mobile/serve-sim.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh (passes; markdownlint unavailable warning, historical/advisory debt only)

Resolves #25378


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 7m and 36,344 tokens on this as a headless worker.