### PR TITLE
GH#25380: docs: use plural Claude Code plugins command

### DIFF
--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -108,9 +108,9 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 The upstream repository ships an Agent Skill under `skills/serve-sim`. For runtimes that support the Agent Skills standard, install it with the host's native skill/plugin installer:
 
 ```bash
-# Claude Code plugin marketplace (current singular `/plugin` command flow)
-/plugin marketplace add EvanBacon/serve-sim
-/plugin install serve-sim
+# Claude Code plugin marketplace (current plural `/plugins` command flow)
+/plugins marketplace add EvanBacon/serve-sim
+/plugins install serve-sim
 
 # Other Agent Skills hosts
 npx skills add EvanBacon/serve-sim


### PR DESCRIPTION
## Summary

Updated .agents/tools/mobile/serve-sim.md to document Claude Code's current plural /plugins marketplace and install commands.

## Files Changed

.agents/tools/mobile/serve-sim.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx --yes markdownlint-cli2@0.22.0 .agents/tools/mobile/serve-sim.md (0 errors)

Resolves #25380


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 2m and 101,420 tokens on this as a headless worker.