### PR TITLE
GH#25385: fix: harden orphan recovery branch guards

### DIFF
--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -280,6 +280,10 @@ _ensure_orphan_recovery_branch_remote() {
 	local issue_number="$3"
 	local repo_slug="$4"
 
+	if [[ -z "$work_dir" || -z "$branch_name" ]] || ! git -C "$work_dir" rev-parse --git-dir >/dev/null 2>&1; then
+		return 1
+	fi
+
 	local remote_ref=""
 	if ! remote_ref=$(git -C "$work_dir" ls-remote origin "refs/heads/$branch_name" 2>/dev/null); then
 		return 1
@@ -295,9 +299,6 @@ _ensure_orphan_recovery_branch_remote() {
 		default_branch=$(_hrw_resolve_default_branch "$work_dir")
 	fi
 	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
-	if [[ -z "$work_dir" ]] || ! git -C "$work_dir" rev-parse --git-dir >/dev/null 2>&1; then
-		return 1
-	fi
 	if [[ -z "$issue_number" || "$branch_name" == "$default_branch" || "$branch_name" != *"$issue_number"* ]]; then
 		return 1
 	fi
@@ -323,12 +324,12 @@ _build_orphan_recovery_pr_body() {
 	local session_key="$1"
 	local branch_name="$2"
 	local closing_line="$3"
-	local published_local_branch="$4"
+	local published_local_branch="${4:-}"
 
 	local pr_summary="Orphan recovery PR — worker pushed this branch but exited before opening a PR."
 	local pr_context="Branch \`${branch_name}\` was pushed by headless worker session \`${session_key}\` which released as \`worker_branch_orphan\`. This PR was auto-created by the orphan-recovery path (GH#20819) so the change can land via the normal review and merge pipeline."
 	local pr_marker="<!-- aidevops:orphan-recovery worker_branch_orphan session=${session_key} -->"
-	if [[ "$published_local_branch" -eq 1 ]]; then
+	if [[ "${published_local_branch:-}" == "1" ]]; then
 		pr_summary="Local branch recovery PR — worker committed locally but exited before pushing or opening a PR."
 		pr_context="Branch \`${branch_name}\` had local commits from headless worker session \`${session_key}\` and was published by the recovery path before this PR was created (GH#25374)."
 		pr_marker="<!-- aidevops:orphan-recovery worker_local_branch_unpushed session=${session_key} -->"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1988,6 +1988,43 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 	return 0
 }
 
+test_ensure_orphan_recovery_rejects_empty_branch() {
+	local work_dir="${TEST_ROOT}/repo-orphan-recovery-empty-branch"
+	_setup_test_git_repo "$work_dir" 1
+
+	local recovery_state=""
+	if recovery_state=$(_ensure_orphan_recovery_branch_remote "$work_dir" "" "99999" "test-owner/test-repo"); then
+		print_result "_ensure_orphan_recovery_branch_remote rejects empty branch" 1 \
+			"Expected failure for empty branch, got '${recovery_state}'"
+		return 0
+	fi
+
+	if [[ -z "$recovery_state" ]]; then
+		print_result "_ensure_orphan_recovery_branch_remote rejects empty branch" 0
+	else
+		print_result "_ensure_orphan_recovery_branch_remote rejects empty branch" 1 \
+			"Expected no state for empty branch, got '${recovery_state}'"
+	fi
+	return 0
+}
+
+test_build_orphan_recovery_pr_body_tolerates_missing_publish_flag() {
+	local pr_body=""
+	if ! pr_body=$(_build_orphan_recovery_pr_body "issue-99999" "feature/auto-test-issue-99999" "Resolves #99999"); then
+		print_result "_build_orphan_recovery_pr_body tolerates missing publish flag" 1 \
+			"Function failed when published_local_branch arg was omitted"
+		return 0
+	fi
+
+	if [[ "$pr_body" == *"worker_branch_orphan"* ]] && [[ "$pr_body" != *"worker_local_branch_unpushed"* ]]; then
+		print_result "_build_orphan_recovery_pr_body tolerates missing publish flag" 0
+	else
+		print_result "_build_orphan_recovery_pr_body tolerates missing publish flag" 1 \
+			"Expected default orphan marker, got '${pr_body}'"
+	fi
+	return 0
+}
+
 # AC#4: on auto-PR success, _cmd_run_finish emits worker_complete with orphan note
 test_cmd_run_finish_orphan_recovery_success_emits_worker_complete() {
 	local work_dir="${TEST_ROOT}/repo-finish-orphan-ok"
@@ -2423,6 +2460,8 @@ main() {
 	test_cmd_run_finish_emits_complete_for_real_output
 	test_cmd_run_finish_emits_complete_when_no_workdir
 	test_attempt_orphan_recovery_pr_calls_gh_create
+	test_ensure_orphan_recovery_rejects_empty_branch
+	test_build_orphan_recovery_pr_body_tolerates_missing_publish_flag
 	test_cmd_run_finish_orphan_recovery_success_emits_worker_complete
 	test_cmd_run_finish_local_unpushed_pushes_and_recovers_pr
 	test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete


### PR DESCRIPTION
## Summary

Validated orphan recovery inputs before git remote checks, treated the optional local-branch flag safely under strict shell mode, and added regression coverage for empty branch rejection plus omitted publish flag handling.

## Files Changed

.agents/scripts/shared-claim-lifecycle.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-claim-lifecycle.sh .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #25385


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 5m and 55,200 tokens on this as a headless worker.