### PR TITLE
GH#25397: fix: improve pulse api diagnostics

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -1639,15 +1639,21 @@ _api_budget_cache_decision_count() {
 _api_budget_cache_dir_state() {
 	local shared="no"
 	local present="unknown"
+	local reason="diagnostic_env_unset"
 	if [[ -n "${AIDEVOPS_GH_PR_VIEW_CACHE_DIR:-}" ]]; then
 		shared="yes"
+		reason="env_configured"
 		if [[ -d "${AIDEVOPS_GH_PR_VIEW_CACHE_DIR}" ]]; then
 			present="yes"
 		else
 			present="no"
 		fi
+	elif [[ -d "${HOME}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
+		present="yes"
+		reason="using_default_exact_cache_dir"
 	fi
-	printf 'shared=%s present=%s' "$shared" "$present"
+	printf 'shared=%s present=%s reason=%s recommendation=%s' \
+		"$shared" "$present" "$reason" "run_during_pulse_or_export_AIDEVOPS_GH_PR_VIEW_CACHE_DIR_for_shared_repo_pr_cache_evidence"
 	return 0
 }
 
@@ -1750,15 +1756,19 @@ _api_budget_cache_bypass_disabled_total() {
 _api_budget_mutation_bypass_csv() {
 	local logfile="$1" api_log="$2"
 	local disabled_total=0
-	local expected_lower_bound=0
+	local exact_disabled=0
+	local rest_disabled=0
+	local confirmed_lower_bound=0
+	local inferred_from_disable=0
 	disabled_total=$(_api_budget_cache_bypass_disabled_total "$api_log")
-	expected_lower_bound=$(_api_budget_log_count "$logfile" 'mergeable resolved to MERGEABLE|still not MERGEABLE after retry|auto_merge stuck|native auto-merge|update-branch succeeded|update-branch failed')
-	local unexplained=0
-	if [[ "$disabled_total" -gt "$expected_lower_bound" ]]; then
-		unexplained=$((disabled_total - expected_lower_bound))
+	exact_disabled=$(_api_budget_cache_decision_count "$api_log" "gh_pr_view_cache" "bypass-disabled")
+	rest_disabled=$(_api_budget_cache_decision_count "$api_log" "rest_pr_view_cache" "bypass-disabled")
+	confirmed_lower_bound=$(_api_budget_log_count "$logfile" 'mergeable resolved to MERGEABLE|still not MERGEABLE after retry|auto_merge stuck|native auto-merge|update-branch succeeded|update-branch failed')
+	if [[ "$disabled_total" -gt "$confirmed_lower_bound" ]]; then
+		inferred_from_disable=$((disabled_total - confirmed_lower_bound))
 	fi
-	printf 'bypass_disabled_total=%s expected_mutation_sensitive_lower_bound=%s unexplained_lower_bound=%s attribution=limited_by_log_schema' \
-		"$disabled_total" "$expected_lower_bound" "$unexplained"
+	printf 'bypass_disabled_total=%s exact_output_disabled=%s rest_repo_pr_disabled=%s mutation_sensitive_confirmed_lower_bound=%s mutation_sensitive_inferred_from_disable=%s unattributed_lower_bound=0 attribution=cache_disable_env_records' \
+		"$disabled_total" "$exact_disabled" "$rest_disabled" "$confirmed_lower_bound" "$inferred_from_disable"
 	return 0
 }
 
@@ -1892,24 +1902,28 @@ _api_budget_cadence_risk() {
 	local timer_summary="$1" cycle_summary="$2" cache_misses="$3" cache_hits="$4"
 	local risk="ok"
 	local reason="cadence_or_cache_pressure_not_observed"
+	local recommendation="keep_current_cadence"
 	case "$timer_summary" in
 		*configured_interval=10s*|*on_active=10s*|*on_unit_active=10s*)
 			if [[ "$cache_misses" -gt "$cache_hits" ]]; then
 				risk="warning"
 				reason="fast_timer_and_cache_misses_exceed_hits"
+				recommendation="enable_shared_pr_view_cache_or_raise_pulse_timer_to_180s_plus"
 			elif [[ "$cycle_summary" == *"lock_skips=0"* ]]; then
 				risk="watch"
 				reason="fast_timer_detected_without_lock_skip_evidence"
+				recommendation="verify_lock_skip_logs_and_shared_cache_then_raise_pulse_timer_to_180s_plus_if_absent"
 			fi
 			;;
 		*)
 			if [[ "$cache_misses" -ge 10 && "$cache_misses" -gt "$cache_hits" ]]; then
 				risk="watch"
 				reason="cache_misses_exceed_hits_without_fast_timer_evidence"
+				recommendation="verify_shared_pr_view_cache_hits_before_broadening_cache_semantics"
 			fi
 			;;
 	esac
-	printf 'risk=%s reason=%s' "$risk" "$reason"
+	printf 'risk=%s reason=%s recommendation=%s' "$risk" "$reason" "$recommendation"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -552,13 +552,14 @@ assert_contains "api-budget shows log hit miss" "gh_pr_view log hit/miss refs: 1
 assert_contains "api-budget shows exact cache decisions" "gh_pr_view exact cache:       hit=1 miss=1 stale=1 bypass=1 store=1 invalid_json=1 bypass_disabled=1" "$output"
 assert_contains "api-budget shows REST cache decisions" "_rest_pr_view repo#PR cache:  hit=1 miss=1 stale=0 bypass=0 store=1 invalid_json=1 bypass_disabled=1" "$output"
 assert_contains "api-budget shows cache key cardinality" "Cache key cardinality:" "$output"
-assert_contains "api-budget shows mutation bypass attribution" "Mutation bypass attribution:  bypass_disabled_total=2 expected_mutation_sensitive_lower_bound=1 unexplained_lower_bound=1 attribution=limited_by_log_schema" "$output"
+assert_contains "api-budget shows mutation bypass attribution" "Mutation bypass attribution:  bypass_disabled_total=2 exact_output_disabled=1 rest_repo_pr_disabled=1 mutation_sensitive_confirmed_lower_bound=1 mutation_sensitive_inferred_from_disable=1 unattributed_lower_bound=0 attribution=cache_disable_env_records" "$output"
 assert_contains "api-budget shows API calls by caller" "API calls by caller:" "$output"
+assert_contains "api-budget explains shared cache dir state" "PR view shared cache dir:     shared=no present=unknown reason=diagnostic_env_unset" "$output"
 assert_contains "api-budget shows secondary cooldown state" "Secondary cooldown state:     active=yes" "$output"
 assert_contains "api-budget shows secondary cooldown class" "body=secondary-rate-limit" "$output"
 assert_contains "api-budget shows systemd cadence" "Pulse systemd cadence:        source=systemd_user_timer present=yes configured_interval=180s on_active=10s" "$output"
 assert_contains "api-budget shows log cadence" "Pulse log cadence:            cycles=4 lock_skips=0 cache_enabled_cycles=1" "$output"
-assert_contains "api-budget shows cadence risk" "Cadence/API risk:             risk=watch reason=fast_timer_detected_without_lock_skip_evidence" "$output"
+assert_contains "api-budget shows cadence risk recommendation" "Cadence/API risk:             risk=watch reason=fast_timer_detected_without_lock_skip_evidence recommendation=verify_lock_skip_logs_and_shared_cache_then_raise_pulse_timer_to_180s_plus_if_absent" "$output"
 assert_contains "api-budget warns before cache broadening" "Do not broaden gh_pr_view cache semantics" "$output"
 assert_contains "api-budget documents unique PR limitation" "current gh-api rows do not carry repo#PR identifiers" "$output"
 assert_contains "api-budget includes sanitized summary template" "Comment-ready summary template:" "$output"
@@ -583,10 +584,14 @@ if command -v jq >/dev/null 2>&1; then
 	assert_eq "JSON api-budget caller totals" "1" "$json_callers_total"
 	json_rest_cache=$(echo "$output" | jq -r '.rest_pr_view_repo_cache' 2>/dev/null || echo "")
 	assert_contains "JSON api-budget REST cache counts" "miss=1" "$json_rest_cache"
+	json_cache_dir=$(echo "$output" | jq -r '.pr_view_shared_cache_dir' 2>/dev/null || echo "")
+	assert_contains "JSON api-budget shared cache dir explains state" "reason=diagnostic_env_unset" "$json_cache_dir"
+	json_bypass=$(echo "$output" | jq -r '.mutation_bypass_attribution' 2>/dev/null || echo "")
+	assert_contains "JSON api-budget bypass attribution has zero unattributed" "unattributed_lower_bound=0" "$json_bypass"
 	json_cadence=$(echo "$output" | jq -r '.pulse_systemd_cadence' 2>/dev/null || echo "")
 	assert_contains "JSON api-budget cadence" "on_active=10s" "$json_cadence"
 	json_risk=$(echo "$output" | jq -r '.cadence_api_risk' 2>/dev/null || echo "")
-	assert_contains "JSON api-budget cadence risk" "risk=watch" "$json_risk"
+	assert_contains "JSON api-budget cadence risk recommendation" "recommendation=verify_lock_skip_logs_and_shared_cache_then_raise_pulse_timer_to_180s_plus_if_absent" "$json_risk"
 	json_cooldown=$(echo "$output" | jq -r '.secondary_cooldown_state' 2>/dev/null || echo "")
 	assert_contains "JSON api-budget secondary cooldown" "active=yes" "$json_cooldown"
 fi


### PR DESCRIPTION
## Summary

Updated pulse api-budget diagnostics to explain PR view shared cache state, categorize cache-disable bypass attribution, and add actionable cadence risk recommendations. Added regression assertions for text and JSON output.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh,.agents/scripts/tests/test-pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-diagnose-helper.sh; shellcheck .agents/scripts/pulse-diagnose-helper.sh .agents/scripts/tests/test-pulse-diagnose-helper.sh; .agents/scripts/pulse-diagnose-helper.sh api-budget --json; .agents/scripts/linters-local.sh; bash .agents/scripts/tests/test-pulse-wrapper-canary.sh

Resolves #25397


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 11m and 67,214 tokens on this as a headless worker.