### PR TITLE
GH#25400: fix: guard pulse cache home lookup

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -1648,7 +1648,7 @@ _api_budget_cache_dir_state() {
 		else
 			present="no"
 		fi
-	elif [[ -d "${HOME}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
+	elif [[ -d "${HOME:-}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
 		present="yes"
 		reason="using_default_exact_cache_dir"
 	fi


### PR DESCRIPTION
## Summary

Guarded the default pulse PR-view cache directory check with safe HOME parameter expansion so set -u environments do not fail when HOME is unset.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-diagnose-helper.sh

Resolves #25400


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 1m and 29,717 tokens on this as a headless worker.