### PR TITLE
GH#25403: fix: guard pulse cache home lookup

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -1648,7 +1648,7 @@ _api_budget_cache_dir_state() {
 		else
 			present="no"
 		fi
-	elif [[ -d "${HOME:-}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
+	elif [[ -n "${HOME:-}" && -d "${HOME}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
 		present="yes"
 		reason="using_default_exact_cache_dir"
 	fi


### PR DESCRIPTION
## Summary

Guarded the default gh-pr-view cache directory probe so it only expands HOME after confirming HOME is set and non-empty.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-diagnose-helper.sh; bash -n .agents/scripts/pulse-diagnose-helper.sh

Resolves #25403


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 3m and 37,217 tokens on this as a headless worker.