### PR TITLE
GH#25402: fix: guard skill symlinks when HOME is unset

### DIFF
--- a/.agents/scripts/setup/modules/plugins.sh
+++ b/.agents/scripts/setup/modules/plugins.sh
@@ -267,8 +267,13 @@ generate_agent_skills() {
 remove_duplicate_opencode_skill_symlink() {
 	local name="$1"
 	local full_path="$2"
-	local opencode_target="$HOME/.config/opencode/skills/$name/SKILL.md"
+	local home_dir="${HOME:-}"
+	local opencode_target="$home_dir/.config/opencode/skills/$name/SKILL.md"
 	local existing_target=""
+
+	if [[ -z "$home_dir" ]]; then
+		return 0
+	fi
 
 	if [[ ! -L "$opencode_target" ]]; then
 		return 0
@@ -289,8 +294,14 @@ remove_duplicate_opencode_skill_symlink() {
 create_skill_symlinks() {
 	print_info "Creating symlinks for imported skills..."
 
-	local skill_sources="$HOME/.aidevops/agents/configs/skill-sources.json"
-	local agents_dir="$HOME/.aidevops/agents"
+	local home_dir="${HOME:-}"
+	local skill_sources="$home_dir/.aidevops/agents/configs/skill-sources.json"
+	local agents_dir="$home_dir/.aidevops/agents"
+
+	if [[ -z "$home_dir" ]]; then
+		print_warning "HOME is not set - cannot create skill symlinks"
+		return 0
+	fi
 
 	# Skip if no skill-sources.json or jq not available
 	if [[ ! -f "$skill_sources" ]]; then
@@ -316,9 +327,9 @@ create_skill_symlinks() {
 	# imported aidevops skills use that shared location instead of duplicating the
 	# same name under ~/.config/opencode/skills.
 	local skill_dirs=(
-		"$HOME/.codex/skills"
-		"$HOME/.claude/skills"
-		"$HOME/.config/amp/tools"
+		"$home_dir/.codex/skills"
+		"$home_dir/.claude/skills"
+		"$home_dir/.config/amp/tools"
 	)
 
 	# Create skill directories if they don't exist

--- a/.agents/scripts/tests/test-setup-skill-symlink-dedup.sh
+++ b/.agents/scripts/tests/test-setup-skill-symlink-dedup.sh
@@ -10,7 +10,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_TMP_DIR=""
-OLD_HOME="${HOME}"
+OLD_HOME="${HOME:-}"
+OLD_HOME_WAS_SET=0
+if [[ -n "${HOME+x}" ]]; then
+	OLD_HOME_WAS_SET=1
+fi
 
 print_info() {
 	return 0
@@ -44,7 +48,12 @@ print_result() {
 }
 
 cleanup() {
-	HOME="$OLD_HOME"
+	if [[ "$OLD_HOME_WAS_SET" -eq 1 ]]; then
+		HOME="$OLD_HOME"
+		export HOME
+	else
+		unset HOME
+	fi
 	if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
 		rm -rf "$TEST_TMP_DIR"
 	fi
@@ -111,6 +120,24 @@ test_imported_skills_use_shared_claude_path_for_opencode() {
 	return 0
 }
 
+test_create_skill_symlinks_handles_unset_home() {
+	local fixture_home="$HOME"
+	local rc=0
+
+	unset HOME
+	create_skill_symlinks >/dev/null || rc=$?
+	HOME="$fixture_home"
+	export HOME
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "create_skill_symlinks tolerates unset HOME" 1 "unexpected rc $rc"
+		return 0
+	fi
+
+	print_result "create_skill_symlinks tolerates unset HOME" 0
+	return 0
+}
+
 main() {
 	trap cleanup EXIT
 	setup_fixture
@@ -118,6 +145,7 @@ main() {
 	source "$REPO_ROOT/.agents/scripts/setup/modules/plugins.sh"
 
 	test_imported_skills_use_shared_claude_path_for_opencode
+	test_create_skill_symlinks_handles_unset_home
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Guarded skill symlink cleanup and creation paths with safe HOME handling, preserved unset HOME during test cleanup, and added regression coverage for create_skill_symlinks with HOME unset.

## Files Changed

.agents/scripts/setup/modules/plugins.sh,.agents/scripts/tests/test-setup-skill-symlink-dedup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/setup/modules/plugins.sh .agents/scripts/tests/test-setup-skill-symlink-dedup.sh && .agents/scripts/tests/test-setup-skill-symlink-dedup.sh && env -u HOME .agents/scripts/tests/test-setup-skill-symlink-dedup.sh. Also attempted .agents/scripts/linters-local.sh; it reached SonarCloud/string-literal checks successfully but timed out during Secretlint at 240s.

Resolves #25402


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 8m and 78,154 tokens on this as a headless worker.