### PR TITLE
GH#25406: fix: guard skill path construction

### DIFF
--- a/.agents/scripts/setup/modules/plugins.sh
+++ b/.agents/scripts/setup/modules/plugins.sh
@@ -268,12 +268,13 @@ remove_duplicate_opencode_skill_symlink() {
 	local name="$1"
 	local full_path="$2"
 	local home_dir="${HOME:-}"
-	local opencode_target="$home_dir/.config/opencode/skills/$name/SKILL.md"
-	local existing_target=""
 
 	if [[ -z "$home_dir" ]]; then
 		return 0
 	fi
+
+	local opencode_target="$home_dir/.config/opencode/skills/$name/SKILL.md"
+	local existing_target=""
 
 	if [[ ! -L "$opencode_target" ]]; then
 		return 0
@@ -295,13 +296,14 @@ create_skill_symlinks() {
 	print_info "Creating symlinks for imported skills..."
 
 	local home_dir="${HOME:-}"
-	local skill_sources="$home_dir/.aidevops/agents/configs/skill-sources.json"
-	local agents_dir="$home_dir/.aidevops/agents"
 
 	if [[ -z "$home_dir" ]]; then
 		print_warning "HOME is not set - cannot create skill symlinks"
 		return 0
 	fi
+
+	local skill_sources="$home_dir/.aidevops/agents/configs/skill-sources.json"
+	local agents_dir="$home_dir/.aidevops/agents"
 
 	# Skip if no skill-sources.json or jq not available
 	if [[ ! -f "$skill_sources" ]]; then


### PR DESCRIPTION
## Summary

Moved HOME-empty guard clauses before constructing dependent skill symlink paths in .agents/scripts/setup/modules/plugins.sh.

## Files Changed

.agents/scripts/setup/modules/plugins.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/setup/modules/plugins.sh; .agents/scripts/tests/test-setup-skill-symlink-dedup.sh

Resolves #25406


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 2m and 44,240 tokens on this as a headless worker.