### PR TITLE
GH#25408: fix: guard pulse cache home lookup

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -1648,7 +1648,7 @@ _api_budget_cache_dir_state() {
 		else
 			present="no"
 		fi
-	elif [[ -n "${HOME:-}" && -d "${HOME}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
+	elif [[ -n "${HOME:-}" && -d "${HOME:-}/.aidevops/cache/gh-pr-view-snapshots" ]]; then
 		present="yes"
 		reason="using_default_exact_cache_dir"
 	fi


### PR DESCRIPTION
## Summary

Guard the default gh-pr-view snapshot cache lookup with safe HOME parameter expansion after the non-empty HOME check, preventing set -u failures if the condition is refactored or evaluated under unset HOME.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-diagnose-helper.sh

Resolves #25408


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 4m and 39,270 tokens on this as a headless worker.