### PR TITLE
GH#25412: fix: guard skill cleanup arguments

### DIFF
--- a/.agents/scripts/setup/modules/plugins.sh
+++ b/.agents/scripts/setup/modules/plugins.sh
@@ -269,7 +269,7 @@ remove_duplicate_opencode_skill_symlink() {
 	local full_path="$2"
 	local home_dir="${HOME:-}"
 
-	if [[ -z "$home_dir" ]]; then
+	if [[ -z "$name" || -z "$full_path" || -z "$home_dir" ]]; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-setup-skill-symlink-dedup.sh
+++ b/.agents/scripts/tests/test-setup-skill-symlink-dedup.sh
@@ -138,6 +138,21 @@ test_create_skill_symlinks_handles_unset_home() {
 	return 0
 }
 
+test_duplicate_opencode_cleanup_handles_empty_arguments() {
+	local rc=0
+
+	remove_duplicate_opencode_skill_symlink "" "$HOME/.aidevops/agents/tools/video/video-use-skill.md" || rc=$?
+	remove_duplicate_opencode_skill_symlink "video-use" "" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "duplicate OpenCode cleanup tolerates empty arguments" 1 "unexpected rc $rc"
+		return 0
+	fi
+
+	print_result "duplicate OpenCode cleanup tolerates empty arguments" 0
+	return 0
+}
+
 main() {
 	trap cleanup EXIT
 	setup_fixture
@@ -146,6 +161,7 @@ main() {
 
 	test_imported_skills_use_shared_claude_path_for_opencode
 	test_create_skill_symlinks_handles_unset_home
+	test_duplicate_opencode_cleanup_handles_empty_arguments
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Added early return guards for empty skill cleanup inputs and covered the behavior in the skill symlink dedup test.

## Files Changed

.agents/scripts/setup/modules/plugins.sh,.agents/scripts/tests/test-setup-skill-symlink-dedup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/setup/modules/plugins.sh .agents/scripts/tests/test-setup-skill-symlink-dedup.sh; .agents/scripts/tests/test-setup-skill-symlink-dedup.sh

Resolves #25412


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 3m and 40,539 tokens on this as a headless worker.