### PR TITLE
GH#25394: fix: preserve worker kill-source diagnostics

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -839,6 +839,25 @@ _handle_run_result() {
 			print_warning "$selected_model activity watchdog timeout (no activity) — classifying as rate_limit for rotation"
 		fi
 	else
+		local local_kill_reason="${_metric_kill_reason:-}"
+		local natural_kill_reason=natural
+		local unknown_kill_reason=unknown
+		if [[ "$role" == "worker" && "$session_key" == issue-* ]] && \
+			[[ "$exit_code" -eq 137 || "$exit_code" -eq 143 ]] && \
+			[[ -n "$local_kill_reason" && "$local_kill_reason" != "$natural_kill_reason" && "$local_kill_reason" != "$unknown_kill_reason" ]]; then
+			_run_result_label="local_kill"
+			_run_failure_reason="$local_kill_reason"
+			if [[ "$exit_code" -eq 143 ]]; then
+				_run_runtime_error_type="sigterm"
+			else
+				_run_runtime_error_type="sigkill"
+			fi
+			_run_classification_source="worker_kill_reason_sentinel"
+			_run_classification_pattern="$local_kill_reason"
+			rm -f "$output_file"
+			print_warning "$selected_model worker was terminated by local kill source ${local_kill_reason} — not attempting provider/runtime continuation"
+			return 83
+		fi
 		if [[ "$exit_code" -eq 137 && "$activity_detected" == "1" ]]; then
 			local discovered_session_for_signal_continue
 			discovered_session_for_signal_continue=$(extract_session_id_from_output "$output_file")
@@ -1095,6 +1114,10 @@ _derive_worker_failure_evidence() {
 	watchdog_stall_continue | service_interruption_continue | service_interruption_exhausted | signal_killed_continue)
 		launch_failure_cause="mid_session_interruption"
 		next_action="resume_existing_session"
+		;;
+	local_kill)
+		launch_failure_cause="local_kill"
+		next_action="inspect_local_kill_source"
 		;;
 	signal_terminated_continue)
 		launch_failure_cause="signal_terminated"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1039,12 +1039,14 @@ _watchdog_kill() {
 	# exit_code_file with its own exit code (race condition). The marker
 	# file survives because only the watchdog writes to it.
 	touch "${exit_code_file}.watchdog_killed"
+	printf '%s\n' "no_output_stall" >"${exit_code_file}.kill_reason" 2>/dev/null || true
 	# t2956 / Issue #21231: Hard-kill sentinel for proactive elapsed-time
 	# kills. Helper reads this and returns 79 instead of 78 — no continuation,
 	# slot freed for re-dispatch. The .watchdog_killed sentinel is still
 	# written above so existing exit-code-124 detection paths keep working.
 	if [[ "$kill_kind" == "stall_killed" ]]; then
 		touch "${exit_code_file}.watchdog_stall_killed"
+		printf '%s\n' "hard_kill_stall" >"${exit_code_file}.kill_reason" 2>/dev/null || true
 	fi
 	# Kill child processes first (pipeline members: opencode, tee), then
 	# the subshell itself. pkill -P walks the process tree by PPID.

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -218,6 +218,33 @@ EOF
 	return 0
 }
 
+test_sigterm_with_local_kill_reason_does_not_resume_as_provider_drop() {
+	local output_file="${TEST_ROOT}/sigterm-local-kill.jsonl"
+	cat >"$output_file" <<'EOF'
+{"type":"text","text":"I was working before the local watchdog killed me."}
+[WORKER_EXIT_DIAGNOSTICS] exit_code=143 model=openai/gpt-5.5 role=worker session_key=issue-25394
+EOF
+	_run_result_label=""
+	_run_failure_reason=""
+	_run_runtime_error_type=""
+	_run_classification_source=""
+	_run_classification_pattern=""
+	_metric_kill_reason="no_output_stall"
+
+	local status=0
+	_handle_run_result 143 "$output_file" "worker" "openai" "issue-25394" "openai/gpt-5.5" || status=$?
+	unset _metric_kill_reason 2>/dev/null || true
+
+	if [[ "$status" -eq 83 && "$_run_result_label" == "local_kill" && "$_run_failure_reason" == "no_output_stall" && "$_run_runtime_error_type" == "sigterm" && "$_run_classification_source" == "worker_kill_reason_sentinel" && ! -f "$output_file" ]]; then
+		print_result "SIGTERM with local kill reason is not treated as provider/runtime drop" 0
+		return 0
+	fi
+
+	print_result "SIGTERM with local kill reason is not treated as provider/runtime drop" 1 \
+		"status=$status label=${_run_result_label:-<empty>} reason=${_run_failure_reason:-<empty>} runtime=${_run_runtime_error_type:-<empty>} source=${_run_classification_source:-<empty>} output_exists=$([[ -f "$output_file" ]] && printf yes || printf no)"
+	return 0
+}
+
 test_dispatcher_initial_model_can_rotate_after_rate_limit() {
 	local result status action next_model
 	result=$(
@@ -2403,6 +2430,7 @@ main() {
 	test_startup_no_activity_timeout_returns_watchdog_continue
 	test_startup_no_activity_can_rotate_after_continuation_budget
 	test_sigkill_with_activity_attempts_continuation
+	test_sigterm_with_local_kill_reason_does_not_resume_as_provider_drop
 	test_dispatcher_initial_model_can_rotate_after_rate_limit
 	test_explicit_model_override_remains_pinned_on_rate_limit
 	test_issue_worker_env_contract_rejects_missing_env

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -111,6 +111,8 @@ T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 #   issue-11         — service_interruption_continue heartbeat, not terminal.
 #   issue-12         — service_interruption_exhausted terminal failure after the
 #                      dedicated continuation budget is spent.
+#   issue-14         — local SIGTERM/kill marker; must group separately from
+#                      provider/runtime stream interruptions.
 {
 	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
@@ -124,6 +126,7 @@ T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 	printf '{"role":"worker","session_key":"issue-10","result":"success","exit_code":0}\n'
 	printf '{"ts":%d,"role":"worker","session_key":"issue-11","model":"openai/gpt-5.5","provider":"openai","result":"service_interruption_continue","failure_reason":"provider_error","provider_error_type":"server_error","provider_status":"503","exit_code":81}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-12","model":"openai/gpt-5.5","provider":"openai","result":"service_interruption_exhausted","failure_reason":"local_error","runtime_error_type":"sigterm","launch_failure_cause":"local_runtime_error","next_action":"inspect_failure_excerpt_and_retry_if_transient","exit_code":81}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-14","model":"openai/gpt-5.5","provider":"openai","result":"local_kill","failure_reason":"no_output_stall","runtime_error_type":"sigterm","classification_source":"worker_kill_reason_sentinel","classification_pattern":"no_output_stall","launch_failure_cause":"local_kill","kill_reason":"no_output_stall","next_action":"inspect_local_kill_source","exit_code":83}\n' "$T_2H_AGO"
 } >"$METRICS"
 
 cat >"$OAUTH_POOL" <<EOF
@@ -208,10 +211,10 @@ else
 	echo "  output: $(printf '%q' "${JSON:0:300}")"
 fi
 
-# Assert exact counts. 24h window: events 1-6 + 8 + 11 + 12, excludes 7 (25h ago).
+# Assert exact counts. 24h window: events 1-6 + 8 + 11 + 12 + 14, excludes 7 (25h ago).
 # issue-8 (watchdog_stall_continue with exit_code=124) tests the t3215
 # regression case — must count as wc, not of, despite non-zero exit.
-assert_eq "2c: total = 9" "9" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2c: total = 10" "10" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
 assert_eq "2d: succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
@@ -219,11 +222,11 @@ assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
 assert_eq "2f2: service_interrupted = 1 (heartbeat)" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.service_interrupted')"
 assert_eq "2g: rate_limited = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.rate_limited')"
-assert_eq "2h: other_failure = 2 (heartbeat excluded, exhausted counted)" "2" \
+assert_eq "2h: other_failure = 3 (heartbeat excluded, exhausted/local kill counted)" "3" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
 assert_eq "2h2: rich result_counts includes success bucket" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.success')"
-assert_eq "2h3: timing summary includes samples" "9" \
+assert_eq "2h3: timing summary includes samples" "10" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
 assert_eq "2h4: recent example carries load context" "2.0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
@@ -249,6 +252,10 @@ assert_eq "2h13: diagnostic focus counts local runtime errors" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.local_runtime_error')"
 assert_eq "2h14: failure families carry next action for stall kills" "redispatch_worker" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_families[] | select(.launch_failure_cause == "stall_hard_killed") | .next_action')"
+assert_eq "2h15: diagnostic focus groups local kills separately" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.local_kill')"
+assert_eq "2h16: failure families expose local kill next action" "inspect_local_kill_source" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_families[] | select(.launch_failure_cause == "local_kill") | .next_action')"
 
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \
@@ -337,7 +344,7 @@ assert_eq "6b: openai available accounts exclude auth-error/rate-limited" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .available')"
 assert_eq "6c: openai capacity_slots uses redacted multiplier" "48" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
-assert_eq "6c2: nonzero-exit success counts as other provider failure" "4" \
+assert_eq "6c2: nonzero-exit success counts as other provider failure" "5" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .other_failure')"
 
 JSONC_DEFAULTS="$FIXTURE_DIR/aidevops.defaults.jsonc"

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -47,6 +47,7 @@ WAH_OAUTH_POOL_FILE="${WAH_OAUTH_POOL_FILE:-${HOME}/.aidevops/oauth-pool.json}"
 WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
 WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 WAH_RESULT_WATCHDOG_STALL_KILLED="watchdog_stall_killed"
+WAH_RESULT_LOCAL_KILL="local_kill"
 
 #######################################
 # Convert short window spec to seconds. Caller owns the cutoff math.
@@ -145,7 +146,7 @@ _wah_metric_details_json() {
 	fi
 	now_epoch="${2:-$(date +%s)}"
 
-	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" '
+	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" '
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 		| ($w | map(.duration_ms // 0)) as $durations
 		| ($w | map(select((.result // "") != "success" or (.exit_code // 1) != 0))) as $failures
@@ -153,7 +154,8 @@ _wah_metric_details_json() {
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
 			diagnostic_focus: {
 				premature_exit: ($failures | map(select(.result == "premature_exit" or .launch_failure_cause == "model_stopped_before_completion")) | length),
-				local_runtime_error: ($failures | map(select(.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type != null and .runtime_error_type != ""))) | length),
+				local_runtime_error: ($failures | map(select((.result // null) != $local_kill_result and (.launch_failure_cause // null) != $local_kill_result and (.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type != null and .runtime_error_type != "")))) | length),
+				local_kill: ($failures | map(select(.result == $local_kill_result or .launch_failure_cause == $local_kill_result or ((.kill_reason // null) as $kr | ($kr != null and $kr != "unknown" and $kr != "natural")))) | length),
 				stall_hard_killed: ($failures | map(select(.result == $watchdog_killed_result or .launch_failure_cause == "stall_hard_killed" or .kill_reason == "hard_kill_stall")) | length)
 			},
 			timing_ms: {

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -431,6 +431,7 @@ _kill_worker() {
 	# subshell may overwrite exit_code_file with its own exit code
 	# (race condition). The sentinel is authoritative.
 	touch "${EXIT_CODE_FILE}.watchdog_killed"
+	printf '%s\n' "no_output_stall" >"${EXIT_CODE_FILE}.kill_reason" 2>/dev/null || true
 
 	# t2956 / Issue #21231: Hard-kill sentinel — distinguishes proactive
 	# elapsed-time kills from passive no-output stall kills. The helper
@@ -441,6 +442,7 @@ _kill_worker() {
 	# sentinel, exit 78 still fires (legacy continuation behaviour).
 	if [[ "$kill_kind" == "stall_killed" ]]; then
 		touch "${EXIT_CODE_FILE}.watchdog_stall_killed"
+		printf '%s\n' "hard_kill_stall" >"${EXIT_CODE_FILE}.kill_reason" 2>/dev/null || true
 	fi
 
 	# Kill child processes first (pipeline members: opencode, tee),


### PR DESCRIPTION
## Summary

Preserved explicit watchdog kill_reason sentinels, classified local SIGTERM/SIGKILL kill-reason evidence separately from provider/runtime stream drops, and exposed local-kill grouping in worker activity diagnostics.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh,.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh,.agents/scripts/worker-activity-watchdog.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-worker-exited-kill-reason.sh; .agents/scripts/tests/test-worker-activity-helper.sh; .agents/scripts/linters-local.sh; .agents/scripts/worker-activity-helper.sh summary --no-pr-check

Resolves #25394


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 20m and 143,760 tokens on this as a headless worker.