### PR TITLE
GH#25418: fix: guard post-merge scanner cursor HOME fallback

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -102,7 +102,7 @@ SCANNER_DIFFHUNK_LINES="${SCANNER_DIFFHUNK_LINES:-12}"
 SCANNER_REFRESH_LIMIT="${SCANNER_REFRESH_LIMIT:-200}"
 SCANNER_NEEDS_REVIEW="${SCANNER_NEEDS_REVIEW:-false}"
 SCANNER_BUDGET_SECONDS="${SCANNER_BUDGET_SECONDS:-540}"
-SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR:-${HOME}/.aidevops/logs/post-merge-review-scanner}"
+SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR:-${HOME:-}/.aidevops/logs/post-merge-review-scanner}"
 BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 # ACT_RE is retained ONLY for top-level review summary filtering. For inline
 # comments the thread-resolution filter is the canonical signal — every


### PR DESCRIPTION
## Summary

Updated .agents/scripts/post-merge-review-scanner.sh to use ${HOME:-} in the SCANNER_CURSOR_DIR fallback so set -u does not fail when HOME is unset.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/post-merge-review-scanner.sh; env -u HOME bash -n .agents/scripts/post-merge-review-scanner.sh

Resolves #25418


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 1m and 27,682 tokens on this as a headless worker.