### PR TITLE
GH#25417: fix: harden worker diagnostics review followup

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -843,11 +843,11 @@ _handle_run_result() {
 		local natural_kill_reason=natural
 		local unknown_kill_reason=unknown
 		if [[ "$role" == "worker" && "$session_key" == issue-* ]] && \
-			[[ "$exit_code" -eq 137 || "$exit_code" -eq 143 ]] && \
+			[[ "$exit_code" == "137" || "$exit_code" == "143" ]] && \
 			[[ -n "$local_kill_reason" && "$local_kill_reason" != "$natural_kill_reason" && "$local_kill_reason" != "$unknown_kill_reason" ]]; then
 			_run_result_label="local_kill"
 			_run_failure_reason="$local_kill_reason"
-			if [[ "$exit_code" -eq 143 ]]; then
+			if [[ "$exit_code" == "143" ]]; then
 				_run_runtime_error_type="sigterm"
 			else
 				_run_runtime_error_type="sigkill"

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -154,8 +154,8 @@ _wah_metric_details_json() {
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
 			diagnostic_focus: {
 				premature_exit: ($failures | map(select(.result == "premature_exit" or .launch_failure_cause == "model_stopped_before_completion")) | length),
-				local_runtime_error: ($failures | map(select((.result // null) != $local_kill_result and (.launch_failure_cause // null) != $local_kill_result and (.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type != null and .runtime_error_type != "")))) | length),
-				local_kill: ($failures | map(select(.result == $local_kill_result or .launch_failure_cause == $local_kill_result or ((.kill_reason // null) as $kr | ($kr != null and $kr != "unknown" and $kr != "natural")))) | length),
+				local_runtime_error: ($failures | map(select(.result != $local_kill_result and .launch_failure_cause != $local_kill_result and (.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type != null and .runtime_error_type != "")))) | length),
+				local_kill: ($failures | map(select(.result == $local_kill_result or .launch_failure_cause == $local_kill_result or (.kill_reason != null and .kill_reason != "unknown" and .kill_reason != "natural"))) | length),
 				stall_hard_killed: ($failures | map(select(.result == $watchdog_killed_result or .launch_failure_cause == "stall_hard_killed" or .kill_reason == "hard_kill_stall")) | length)
 			},
 			timing_ms: {


### PR DESCRIPTION
## Summary

Adjusted local-kill exit-code checks to use string comparisons and simplified worker activity jq filters while preserving diagnostics.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/worker-activity-helper.sh

Resolves #25417


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 2m and 35,255 tokens on this as a headless worker.