### PR TITLE
GH#25420: fix: harden local kill exit-code checks

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -843,11 +843,11 @@ _handle_run_result() {
 		local natural_kill_reason=natural
 		local unknown_kill_reason=unknown
 		if [[ "$role" == "worker" && "$session_key" == issue-* ]] && \
-			[[ "$exit_code" -eq 137 || "$exit_code" -eq 143 ]] && \
+			[[ "$exit_code" == "137" || "$exit_code" == "143" ]] && \
 			[[ -n "$local_kill_reason" && "$local_kill_reason" != "$natural_kill_reason" && "$local_kill_reason" != "$unknown_kill_reason" ]]; then
 			_run_result_label="local_kill"
 			_run_failure_reason="$local_kill_reason"
-			if [[ "$exit_code" -eq 143 ]]; then
+			if [[ "$exit_code" == "143" ]]; then
 				_run_runtime_error_type="sigterm"
 			else
 				_run_runtime_error_type="sigkill"


### PR DESCRIPTION
## Summary

Replaced arithmetic -eq checks in the local-kill exit-code branch with string comparisons so empty or non-numeric exit_code values cannot trigger Bash arithmetic syntax errors at the reviewed lines.

## Files Changed

.agents/scripts/headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh

Resolves #25420


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 3m and 78,223 tokens on this as a headless worker.