### PR TITLE
GH#25426: fix: propagate scheduler helper load failures

### DIFF
--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -45,14 +45,10 @@ setup() {
 }
 
 load_scheduler_helpers() {
-	if ! restore_scheduler_helper_mocks; then
-		return 1
-	fi
+	restore_scheduler_helper_mocks || return $?
 	# shellcheck source=/dev/null
-	if ! source "$SCHEDULERS_PLATFORM_SH"; then
-		return 1
-	fi
-	return 0
+	source "$SCHEDULERS_PLATFORM_SH"
+	return $?
 }
 
 restore_scheduler_helper_mocks() {


### PR DESCRIPTION
## Summary

Refactored load_scheduler_helpers in .agents/scripts/tests/test-routine-tracking-updates.sh to reuse restore_scheduler_helper_mocks and return the sourced scheduler helper exit status instead of masking failures.

## Files Changed

.agents/scripts/tests/test-routine-tracking-updates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-routine-tracking-updates.sh (8/8 tests passed); shellcheck .agents/scripts/tests/test-routine-tracking-updates.sh

Resolves #25426


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 2m and 31,925 tokens on this as a headless worker.