### PR TITLE
fix: guard scheduler helper source failures

### DIFF
--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -47,8 +47,8 @@ setup() {
 load_scheduler_helpers() {
 	restore_scheduler_helper_mocks || return $?
 	# shellcheck source=/dev/null
-	source "$SCHEDULERS_PLATFORM_SH"
-	return $?
+	source "$SCHEDULERS_PLATFORM_SH" || return $?
+	return 0
 }
 
 restore_scheduler_helper_mocks() {


### PR DESCRIPTION
## Summary
- Guard `source "$SCHEDULERS_PLATFORM_SH"` in `load_scheduler_helpers` with `|| return $?` so `set -e` does not exit the test process before the function can propagate the failure.
- Keep an explicit `return 0` success path to satisfy shell helper function return discipline.

## Testing
- `shellcheck .agents/scripts/tests/test-routine-tracking-updates.sh`
- `.agents/scripts/tests/test-routine-tracking-updates.sh`

Resolves #25435

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 3m and 34,872 tokens on this as a headless worker.
