### PR TITLE
GH#25439: fix: guard scanner cursor home fallback

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -102,7 +102,7 @@ SCANNER_DIFFHUNK_LINES="${SCANNER_DIFFHUNK_LINES:-12}"
 SCANNER_REFRESH_LIMIT="${SCANNER_REFRESH_LIMIT:-200}"
 SCANNER_NEEDS_REVIEW="${SCANNER_NEEDS_REVIEW:-false}"
 SCANNER_BUDGET_SECONDS="${SCANNER_BUDGET_SECONDS:-540}"
-SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR:-${HOME:-}/.aidevops/logs/post-merge-review-scanner}"
+SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR:-${HOME:-/tmp}/.aidevops/logs/post-merge-review-scanner}"
 BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 # ACT_RE is retained ONLY for top-level review summary filtering. For inline
 # comments the thread-resolution filter is the canonical signal — every

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -73,6 +73,20 @@ assert_rc() {
 	return 0
 }
 
+assert_equals() {
+	local test_name="$1" expected="$2" actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected: $expected"
+		echo "    actual:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Test harness setup: stub `gh` via PATH override
 # -----------------------------------------------------------------------------
@@ -205,6 +219,16 @@ fi
 # shellcheck source=../post-merge-review-scanner.sh
 # shellcheck disable=SC1091
 source "$SCANNER"
+
+scanner_cursor_without_home="$(
+	HOME=
+	SCANNER_CURSOR_DIR=
+	# shellcheck source=../post-merge-review-scanner.sh
+	# shellcheck disable=SC1091
+	source "$SCANNER"
+	printf "%s" "$SCANNER_CURSOR_DIR"
+)"
+assert_equals "SCANNER_CURSOR_DIR falls back to /tmp when HOME is empty" "/tmp/.aidevops/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
 
 # -----------------------------------------------------------------------------
 # Fixture builders


### PR DESCRIPTION
## Summary

Updated post-merge-review-scanner so the default SCANNER_CURSOR_DIR uses /tmp when HOME is empty, preventing cursor/log paths from resolving under /. Added a regression assertion in the scanner test suite.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh,.agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-post-merge-review-scanner.sh; shellcheck .agents/scripts/post-merge-review-scanner.sh .agents/scripts/tests/test-post-merge-review-scanner.sh

Resolves #25439


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 4m and 46,849 tokens on this as a headless worker.