### PR TITLE
GH#25444: fix: isolate scanner cursor tmp fallback

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -102,7 +102,13 @@ SCANNER_DIFFHUNK_LINES="${SCANNER_DIFFHUNK_LINES:-12}"
 SCANNER_REFRESH_LIMIT="${SCANNER_REFRESH_LIMIT:-200}"
 SCANNER_NEEDS_REVIEW="${SCANNER_NEEDS_REVIEW:-false}"
 SCANNER_BUDGET_SECONDS="${SCANNER_BUDGET_SECONDS:-540}"
-SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR:-${HOME:-/tmp}/.aidevops/logs/post-merge-review-scanner}"
+if [[ -n "${SCANNER_CURSOR_DIR:-}" ]]; then
+	SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR}"
+elif [[ -n "${HOME:-}" ]]; then
+	SCANNER_CURSOR_DIR="${HOME}/.aidevops/logs/post-merge-review-scanner"
+else
+	SCANNER_CURSOR_DIR="/tmp/.aidevops-${USER:-shared}/logs/post-merge-review-scanner"
+fi
 BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 # ACT_RE is retained ONLY for top-level review summary filtering. For inline
 # comments the thread-resolution filter is the canonical signal — every

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -102,12 +102,12 @@ SCANNER_DIFFHUNK_LINES="${SCANNER_DIFFHUNK_LINES:-12}"
 SCANNER_REFRESH_LIMIT="${SCANNER_REFRESH_LIMIT:-200}"
 SCANNER_NEEDS_REVIEW="${SCANNER_NEEDS_REVIEW:-false}"
 SCANNER_BUDGET_SECONDS="${SCANNER_BUDGET_SECONDS:-540}"
-if [[ -n "${SCANNER_CURSOR_DIR:-}" ]]; then
-	SCANNER_CURSOR_DIR="${SCANNER_CURSOR_DIR}"
-elif [[ -n "${HOME:-}" ]]; then
-	SCANNER_CURSOR_DIR="${HOME}/.aidevops/logs/post-merge-review-scanner"
-else
-	SCANNER_CURSOR_DIR="/tmp/.aidevops-${USER:-shared}/logs/post-merge-review-scanner"
+if [[ -z "${SCANNER_CURSOR_DIR:-}" ]]; then
+	if [[ -n "${HOME:-}" ]]; then
+		SCANNER_CURSOR_DIR="${HOME}/.aidevops/logs/post-merge-review-scanner"
+	else
+		SCANNER_CURSOR_DIR="/tmp/.aidevops-${USER:-shared}/logs/post-merge-review-scanner"
+	fi
 fi
 BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 # ACT_RE is retained ONLY for top-level review summary filtering. For inline

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -222,13 +222,15 @@ source "$SCANNER"
 
 scanner_cursor_without_home="$(
 	HOME=
+	USER=scanner-test-user
 	SCANNER_CURSOR_DIR=
 	# shellcheck source=../post-merge-review-scanner.sh
 	# shellcheck disable=SC1091
 	source "$SCANNER"
 	printf "%s" "$SCANNER_CURSOR_DIR"
 )"
-assert_equals "SCANNER_CURSOR_DIR falls back to /tmp when HOME is empty" "/tmp/.aidevops/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
+assert_equals "SCANNER_CURSOR_DIR uses a user-isolated /tmp fallback when HOME is empty" "/tmp/.aidevops-scanner-test-user/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
+assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is empty" "$scanner_cursor_without_home" "/tmp/.aidevops/logs/post-merge-review-scanner"
 
 # -----------------------------------------------------------------------------
 # Fixture builders

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -220,9 +220,21 @@ fi
 # shellcheck disable=SC1091
 source "$SCANNER"
 
+scanner_cursor_without_home="$(
+	HOME=
+	USER=scanner-test-user
+	SCANNER_CURSOR_DIR=
+	# shellcheck source=../post-merge-review-scanner.sh
+	# shellcheck disable=SC1091
+	source "$SCANNER"
+	printf "%s" "$SCANNER_CURSOR_DIR"
+)"
+assert_equals "SCANNER_CURSOR_DIR uses a user-isolated /tmp fallback when HOME is empty" "/tmp/.aidevops-scanner-test-user/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
+assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is empty" "$scanner_cursor_without_home" "/tmp/.aidevops/logs/post-merge-review-scanner"
 # shellcheck disable=SC2016
-scanner_cursor_without_home="$(env -u HOME SCANNER_CURSOR_DIR= bash -c 'set -euo pipefail; source "$1"; printf "%s" "$SCANNER_CURSOR_DIR"' _ "$SCANNER")"
-assert_equals "SCANNER_CURSOR_DIR falls back to /tmp when HOME is unset" "/tmp/.aidevops/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
+scanner_cursor_with_unset_home="$(env -u HOME USER=scanner-test-user SCANNER_CURSOR_DIR= bash -c 'set -euo pipefail; source "$1"; printf "%s" "$SCANNER_CURSOR_DIR"' _ "$SCANNER")"
+assert_equals "SCANNER_CURSOR_DIR uses a user-isolated /tmp fallback when HOME is unset" "/tmp/.aidevops-scanner-test-user/logs/post-merge-review-scanner" "$scanner_cursor_with_unset_home"
+assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is unset" "$scanner_cursor_with_unset_home" "/tmp/.aidevops/logs/post-merge-review-scanner"
 
 # -----------------------------------------------------------------------------
 # Fixture builders


### PR DESCRIPTION
## Summary

Updated post-merge review scanner cursor defaults so HOME-empty runs use a user-isolated /tmp/.aidevops-vladimir/logs/post-merge-review-scanner path instead of the shared /tmp/.aidevops path; updated the regression test to assert the isolated fallback and deny the shared path.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh,.agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-post-merge-review-scanner.sh; shellcheck .agents/scripts/post-merge-review-scanner.sh .agents/scripts/tests/test-post-merge-review-scanner.sh

Resolves #25444


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 3m and 42,058 tokens on this as a headless worker.