### PR TITLE
GH#25446: fix: harden scanner tmp user fallback

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -106,7 +106,8 @@ if [[ -z "${SCANNER_CURSOR_DIR:-}" ]]; then
 	if [[ -n "${HOME:-}" ]]; then
 		SCANNER_CURSOR_DIR="${HOME}/.aidevops/logs/post-merge-review-scanner"
 	else
-		SCANNER_CURSOR_DIR="/tmp/.aidevops-${USER:-shared}/logs/post-merge-review-scanner"
+		SCANNER_TMP_USER="${USER:-${LOGNAME:-$(id -un || printf '%s' shared)}}"
+		SCANNER_CURSOR_DIR="/tmp/.aidevops-${SCANNER_TMP_USER}/logs/post-merge-review-scanner"
 	fi
 fi
 BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"


### PR DESCRIPTION
## Summary

Resolved the review follow-up by making the post-merge scanner's /tmp cursor fallback prefer USER, then LOGNAME, then id -un before the final shared fallback, preventing avoidable ownership collisions when USER is unset.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/post-merge-review-scanner.sh; bash -n .agents/scripts/post-merge-review-scanner.sh

Resolves #25446


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 2m and 60,314 tokens on this as a headless worker.