### PR TITLE
GH#25451: test: fix scanner fallback assertion order

### DIFF
--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -230,11 +230,11 @@ scanner_cursor_without_home="$(
 	printf "%s" "$SCANNER_CURSOR_DIR"
 )"
 assert_equals "SCANNER_CURSOR_DIR uses a user-isolated /tmp fallback when HOME is empty" "/tmp/.aidevops-scanner-test-user/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
-assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is empty" "$scanner_cursor_without_home" "/tmp/.aidevops/logs/post-merge-review-scanner"
+assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is empty" "/tmp/.aidevops/logs/post-merge-review-scanner" "$scanner_cursor_without_home"
 # shellcheck disable=SC2016
 scanner_cursor_with_unset_home="$(env -u HOME USER=scanner-test-user SCANNER_CURSOR_DIR= bash -c 'set -euo pipefail; source "$1"; printf "%s" "$SCANNER_CURSOR_DIR"' _ "$SCANNER")"
 assert_equals "SCANNER_CURSOR_DIR uses a user-isolated /tmp fallback when HOME is unset" "/tmp/.aidevops-scanner-test-user/logs/post-merge-review-scanner" "$scanner_cursor_with_unset_home"
-assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is unset" "$scanner_cursor_with_unset_home" "/tmp/.aidevops/logs/post-merge-review-scanner"
+assert_not_contains "SCANNER_CURSOR_DIR does not use shared /tmp fallback when HOME is unset" "/tmp/.aidevops/logs/post-merge-review-scanner" "$scanner_cursor_with_unset_home"
 
 # -----------------------------------------------------------------------------
 # Fixture builders


### PR DESCRIPTION
## Summary

- Corrected two `assert_not_contains` calls in `.agents/scripts/tests/test-post-merge-review-scanner.sh`.
- The shared `/tmp/.aidevops/logs/post-merge-review-scanner` path is now the needle and the computed scanner cursor directory is the haystack.

## Testing

- `bash .agents/scripts/tests/test-post-merge-review-scanner.sh` (47 passed, 0 failed)
- Pre-commit ShellCheck ratchet passed during commit

Resolves #25451

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 3m and 46,863 tokens on this as a headless worker.