### PR TITLE
GH#25455: fix: scope feature toggle fallback home

### DIFF
--- a/.agents/scripts/shared-feature-toggles.sh
+++ b/.agents/scripts/shared-feature-toggles.sh
@@ -77,8 +77,9 @@ fi
 # Legacy paths (kept for backward compatibility and migration)
 # =============================================================================
 
-FEATURE_TOGGLES_DEFAULTS="${HOME:-/tmp}/.aidevops/agents/configs/feature-toggles.conf.defaults"
-FEATURE_TOGGLES_USER="${HOME:-/tmp}/.config/aidevops/feature-toggles.conf"
+FEATURE_TOGGLES_HOME="${HOME:-/tmp/aidevops-uid-${UID:-unknown}}"
+FEATURE_TOGGLES_DEFAULTS="${FEATURE_TOGGLES_HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults"
+FEATURE_TOGGLES_USER="${FEATURE_TOGGLES_HOME}/.config/aidevops/feature-toggles.conf"
 
 # Prefix for dynamic toggle variables exposed by legacy mode (e.g. _FT_auto_update).
 readonly _FT_VAR_PREFIX="_FT_"


### PR DESCRIPTION
## Summary

Scoped the shared feature-toggle legacy HOME fallback to a per-UID directory under /tmp when HOME is unset, avoiding shared /tmp/.config and /tmp/.aidevops paths.

## Files Changed

.agents/scripts/shared-feature-toggles.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-feature-toggles.sh; env -u HOME bash -c 'source .agents/scripts/shared-feature-toggles.sh; [[ "" == /tmp/aidevops-uid-*"/.aidevops/agents/configs/feature-toggles.conf.defaults" ]] && [[ "" == /tmp/aidevops-uid-*"/.config/aidevops/feature-toggles.conf" ]]'; .agents/scripts/linters-local.sh (timed out after passing early gates, during Secretlint)

Resolves #25455


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 6m and 59,712 tokens on this as a headless worker.