### PR TITLE
GH#25453: fix: scope gh api tmp fallback

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -65,8 +65,9 @@ _GH_API_INSTRUMENT_LOADED=1
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
 
 # --- Configuration --------------------------------------------------------
-GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${HOME:-/tmp}/.aidevops/logs/gh-api-calls.log}"
-GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${HOME:-/tmp}/.aidevops/logs/gh-api-calls-by-stage.json}"
+_GH_API_HOME="${HOME:-${TMPDIR:-/tmp}/aidevops-${USER:-${UID:-shared}}}"
+GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls.log}"
+GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls-by-stage.json}"
 GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 
 # --- gh_record_call <path> [caller] [auth] [pool] [decision] [budget] ------


### PR DESCRIPTION
## Summary

Scoped gh-api-instrument.sh unset-HOME defaults to a user-specific temporary directory instead of shared /tmp, preserving explicit AIDEVOPS_GH_API_LOG and AIDEVOPS_GH_API_REPORT overrides.

## Files Changed

.agents/scripts/gh-api-instrument.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/gh-api-instrument.sh; shellcheck .agents/scripts/gh-api-instrument.sh; env -u HOME TMPDIR=<temp>/ USER=aidevops-test bash .agents/scripts/gh-api-instrument.sh record/report verified the log/report are written under the user-scoped temp fallback; .agents/scripts/linters-local.sh reached Secretlint but timed out after 120s and 240s

Resolves #25453


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 8m and 33,150 tokens on this as a headless worker.