### PR TITLE
GH#25454: fix: harden github app tmp fallback

### DIFF
--- a/.agents/scripts/github-app-auth-helper.sh
+++ b/.agents/scripts/github-app-auth-helper.sh
@@ -28,8 +28,19 @@ if ! command -v print_error >/dev/null 2>&1; then
 	print_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
 fi
 
-: "${AIDEVOPS_GITHUB_APP_CONFIG:=${HOME:-/tmp}/.config/aidevops/github-app-auth.json}"
-: "${AIDEVOPS_GITHUB_APP_CACHE_DIR:=${HOME:-/tmp}/.aidevops/cache/github-app}"
+_github_app_default_home() {
+	local user_slug="${USER:-}"
+	local tmp_root="${TMPDIR:-/tmp}"
+	if [[ -z "$user_slug" ]]; then
+		user_slug="uid-${UID:-unknown}"
+	fi
+	printf '%s/aidevops-%s\n' "${tmp_root%/}" "$user_slug"
+	return 0
+}
+
+: "${AIDEVOPS_GITHUB_APP_HOME:=${HOME:-$(_github_app_default_home)}}"
+: "${AIDEVOPS_GITHUB_APP_CONFIG:=${AIDEVOPS_GITHUB_APP_HOME}/.config/aidevops/github-app-auth.json}"
+: "${AIDEVOPS_GITHUB_APP_CACHE_DIR:=${AIDEVOPS_GITHUB_APP_HOME}/.aidevops/cache/github-app}"
 : "${AIDEVOPS_GITHUB_APP_RATE_LIMIT_CACHE_TTL:=20}"
 : "${AIDEVOPS_GITHUB_APP_REST_FIRST:=1}"
 
@@ -107,8 +118,37 @@ github_app_enabled() {
 }
 
 _github_app_cache_dir() {
-	mkdir -p "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || true
-	chmod 700 "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || true
+	local old_umask=""
+	if [[ -L "$AIDEVOPS_GITHUB_APP_CACHE_DIR" ]]; then
+		return 1
+	fi
+	old_umask=$(umask)
+	umask 077
+	if [[ -z "${HOME:-}" && "$AIDEVOPS_GITHUB_APP_CACHE_DIR" == "$AIDEVOPS_GITHUB_APP_HOME"/* ]]; then
+		if [[ -L "$AIDEVOPS_GITHUB_APP_HOME" ]]; then
+			umask "$old_umask"
+			return 1
+		fi
+		mkdir -p "$AIDEVOPS_GITHUB_APP_HOME" 2>/dev/null || {
+			umask "$old_umask"
+			return 1
+		}
+		[[ -d "$AIDEVOPS_GITHUB_APP_HOME" && ! -L "$AIDEVOPS_GITHUB_APP_HOME" ]] || {
+			umask "$old_umask"
+			return 1
+		}
+		chmod 700 "$AIDEVOPS_GITHUB_APP_HOME" 2>/dev/null || {
+			umask "$old_umask"
+			return 1
+		}
+	fi
+	mkdir -p "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || {
+		umask "$old_umask"
+		return 1
+	}
+	umask "$old_umask"
+	[[ -d "$AIDEVOPS_GITHUB_APP_CACHE_DIR" && ! -L "$AIDEVOPS_GITHUB_APP_CACHE_DIR" ]] || return 1
+	chmod 700 "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || return 1
 	printf '%s\n' "$AIDEVOPS_GITHUB_APP_CACHE_DIR"
 	return 0
 }

--- a/.agents/scripts/tests/test-github-app-auth-helper.sh
+++ b/.agents/scripts/tests/test-github-app-auth-helper.sh
@@ -76,6 +76,30 @@ source "${SCRIPTS_DIR}/github-app-auth-helper.sh"
 
 printf 'Running GitHub App auth helper tests\n'
 
+# shellcheck disable=SC2016 # Keep the inner script expanded by the env-isolated bash process.
+fallback_output=$(env -i USER="fallback-user" TMPDIR="$TMP/fallback-tmp" PATH="$PATH" bash -c '
+source "$1"
+_github_app_cache_dir >/dev/null
+printf "%s\n%s\n%s\n" "$AIDEVOPS_GITHUB_APP_HOME" "$AIDEVOPS_GITHUB_APP_CONFIG" "$AIDEVOPS_GITHUB_APP_CACHE_DIR"
+' bash "${SCRIPTS_DIR}/github-app-auth-helper.sh")
+fallback_home=$(printf '%s\n' "$fallback_output" | sed -n '1p')
+fallback_config=$(printf '%s\n' "$fallback_output" | sed -n '2p')
+fallback_cache=$(printf '%s\n' "$fallback_output" | sed -n '3p')
+assert_eq "unset HOME uses user-scoped tmp fallback root" "$TMP/fallback-tmp/aidevops-fallback-user" "$fallback_home"
+assert_eq "unset HOME config stays under user-scoped fallback" "$TMP/fallback-tmp/aidevops-fallback-user/.config/aidevops/github-app-auth.json" "$fallback_config"
+assert_eq "unset HOME cache stays under user-scoped fallback" "$TMP/fallback-tmp/aidevops-fallback-user/.aidevops/cache/github-app" "$fallback_cache"
+mkdir -p "$TMP/fallback-tmp"
+ln -s "$TMP" "$TMP/fallback-tmp/aidevops-linked-user"
+# shellcheck disable=SC2016 # Keep the inner script expanded by the env-isolated bash process.
+if env -i USER="linked-user" TMPDIR="$TMP/fallback-tmp" PATH="$PATH" bash -c '
+source "$1"
+_github_app_cache_dir >/dev/null
+' bash "${SCRIPTS_DIR}/github-app-auth-helper.sh"; then
+	fail "unset HOME fallback cache rejects symlinked fallback root"
+else
+	pass "unset HOME fallback cache rejects symlinked fallback root"
+fi
+
 route_auth=$(github_app_route_json issue-list owner/repo | jq -r '.auth_mode')
 assert_eq "no app configured falls back to gh/PAT auth" "gh-pat" "$route_auth"
 


### PR DESCRIPTION
## Summary

Scoped GitHub App auth defaults to a per-user fallback root when HOME is unset and reject symlinked fallback/cache directories before writing token cache files.

## Files Changed

.agents/scripts/github-app-auth-helper.sh,.agents/scripts/tests/test-github-app-auth-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-github-app-auth-helper.sh; shellcheck .agents/scripts/github-app-auth-helper.sh .agents/scripts/tests/test-github-app-auth-helper.sh

Resolves #25454


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 10m and 70,258 tokens on this as a headless worker.