### PR TITLE
GH#25452: fix: scope config fallback home

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -65,12 +65,13 @@ fi
 # ---------------------------------------------------------------------------
 # File paths (use defaults if not already set — allows override for testing)
 # ---------------------------------------------------------------------------
-JSONC_DEFAULTS="${JSONC_DEFAULTS:-${HOME:-/tmp}/.aidevops/agents/configs/aidevops.defaults.jsonc}"
-JSONC_USER="${JSONC_USER:-${HOME:-/tmp}/.config/aidevops/config.jsonc}"
-JSONC_SCHEMA="${JSONC_SCHEMA:-${HOME:-/tmp}/.aidevops/agents/configs/aidevops-config.schema.json}"
-OLD_CONF_USER="${OLD_CONF_USER:-${HOME:-/tmp}/.config/aidevops/feature-toggles.conf}"
-OLD_CONF_DEFAULTS="${OLD_CONF_DEFAULTS:-${HOME:-/tmp}/.aidevops/agents/configs/feature-toggles.conf.defaults}"
-MIGRATE_FAILED_FLAG="${MIGRATE_FAILED_FLAG:-${HOME:-/tmp}/.aidevops/migrate_failed}"
+_CONFIG_HOME="${HOME:-/tmp/aidevops-${USER:-uid-${UID:-shared}}}"
+JSONC_DEFAULTS="${JSONC_DEFAULTS:-${_CONFIG_HOME}/.aidevops/agents/configs/aidevops.defaults.jsonc}"
+JSONC_USER="${JSONC_USER:-${_CONFIG_HOME}/.config/aidevops/config.jsonc}"
+JSONC_SCHEMA="${JSONC_SCHEMA:-${_CONFIG_HOME}/.aidevops/agents/configs/aidevops-config.schema.json}"
+OLD_CONF_USER="${OLD_CONF_USER:-${_CONFIG_HOME}/.config/aidevops/feature-toggles.conf}"
+OLD_CONF_DEFAULTS="${OLD_CONF_DEFAULTS:-${_CONFIG_HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults}"
+MIGRATE_FAILED_FLAG="${MIGRATE_FAILED_FLAG:-${_CONFIG_HOME}/.aidevops/migrate_failed}"
 
 # nice — cache avoids re-parsing on every call
 _JSONC_MERGED_CACHE=""


### PR DESCRIPTION
## Summary

Scoped config-helper's HOME-unset fallback under /tmp/aidevops-<user> instead of shared /tmp while preserving existing JSONC_* override behavior.

## Files Changed

.agents/scripts/config-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/config-helper.sh; shellcheck .agents/scripts/config-helper.sh; env -u HOME USER=testuser bash -c 'source .agents/scripts/config-helper.sh >/dev/null 2>&1; [[ "" == /tmp/aidevops-testuser/.aidevops/agents/configs/aidevops.defaults.jsonc ]] && [[ "" == /tmp/aidevops-testuser/.config/aidevops/config.jsonc ]] && [[ "" == /tmp/aidevops-testuser/.aidevops/migrate_failed ]]'; .agents/scripts/linters-local.sh timed out at Secretlint after remote/ratchet checks passed

Resolves #25452


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 10m and 42,491 tokens on this as a headless worker.