### PR TITLE
GH#25456: fix: scope todo lock tmp fallback

### DIFF
--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -35,7 +35,8 @@
 #                                        TODO_MAX_RETRIES.
 #
 # Tunable constants (readonly):
-#   - TODO_LOCK_DIR              — ${HOME}/.aidevops/locks
+#   - TODO_LOCK_DIR              — ${HOME}/.aidevops/locks, or a user-scoped
+#                                  /tmp fallback when HOME is unset
 #   - TODO_LOCK_PATH             — ${TODO_LOCK_DIR}/todo-md.lock
 #   - TODO_MAX_RETRIES           — 3
 #   - TODO_LOCK_TIMEOUT          — 30 (seconds to wait for lock acquisition)
@@ -90,7 +91,7 @@ _SHARED_TODO_COMMIT_LOADED=1
 # Guard against re-declaration when shared-constants.sh is sourced more than once
 # in a process (the readonly statement would otherwise abort the second source).
 if [[ -z "${TODO_LOCK_DIR:-}" ]]; then
-	readonly TODO_LOCK_DIR="${HOME:-/tmp}/.aidevops/locks"
+	readonly TODO_LOCK_DIR="${HOME:-/tmp/aidevops-${USER:-uid-${UID:-shared}}}/.aidevops/locks"
 	readonly TODO_LOCK_PATH="${TODO_LOCK_DIR}/todo-md.lock"
 	readonly TODO_MAX_RETRIES=3
 	readonly TODO_LOCK_TIMEOUT=30

--- a/.agents/scripts/tests/test-shared-todo-commit-home-fallback.sh
+++ b/.agents/scripts/tests/test-shared-todo-commit-home-fallback.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Test: shared-todo-commit.sh HOME fallback
+# Verifies the TODO lock directory avoids shared /tmp/.aidevops when HOME is
+# unset, preventing cross-user permission conflicts and symlink-prone shared
+# state.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}/.."
+[[ "$SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+
+# shellcheck disable=SC2016 # Inner shell expands $1 and $TODO_LOCK_DIR after sourcing.
+actual=$(env -u HOME USER=tester UID=12345 bash -c 'source "$1"; printf "%s\n" "$TODO_LOCK_DIR"' _ "${SCRIPT_DIR}/shared-todo-commit.sh")
+expected="/tmp/aidevops-tester/.aidevops/locks"
+
+if [[ "$actual" != "$expected" ]]; then
+	printf 'FAIL: TODO_LOCK_DIR unset HOME fallback\n'
+	printf '  expected: %s\n' "$expected"
+	printf '  actual:   %s\n' "$actual"
+	exit 1
+fi
+
+if [[ "$actual" == /tmp/.aidevops/* ]]; then
+	printf 'FAIL: TODO_LOCK_DIR used shared /tmp fallback: %s\n' "$actual"
+	exit 1
+fi
+
+printf 'PASS: TODO_LOCK_DIR unset HOME fallback is user-scoped\n'
+exit 0


### PR DESCRIPTION
## Summary

Scoped shared-todo-commit.sh unset-HOME TODO lock fallback under /tmp/aidevops-marcusquinn and added a regression test that sources the helper with HOME unset.

## Files Changed

.agents/scripts/shared-todo-commit.sh,.agents/scripts/tests/test-shared-todo-commit-home-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shared-todo-commit-home-fallback.sh; shellcheck .agents/scripts/shared-todo-commit.sh .agents/scripts/tests/test-shared-todo-commit-home-fallback.sh; .agents/scripts/linters-local.sh timed out twice during Secretlint after earlier gates passed

Resolves #25456


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 10m and 87,516 tokens on this as a headless worker.