### PR TITLE
t3608: docs: apply GUI ADR review feedback

### DIFF
--- a/docs/gui/control-plane.md
+++ b/docs/gui/control-plane.md
@@ -29,7 +29,7 @@ The first usable product remains local-first:
 4. Helper/API contract.
 5. GUI testing and CI/CD strategy.
 6. Local read-only API and dashboard scaffold.
-7. Setup/status, repos/Git, infrastructure, provider bookmarks, routines,
+7. Setup/status, repos/git, infrastructure, provider bookmarks, routines,
    CalDAV/CardDAV, and capability browser surfaces.
 8. Cloudron package.
 9. Multi-machine pairing and scoped task capsules.
@@ -40,14 +40,14 @@ The first usable product remains local-first:
 - ADR 0001 chooses a Vite React web app, Hono local API, and SQLite-first local
   storage for the first scaffold.
 - First code should land in this repository as staged package subtrees, not as a
-  separate repository and not as new root-level ad hoc app files.
+  separate repository and not as new root-level ad-hoc app files.
 - Future phases that introduce new top-level directories must update
   `.agents/configs/repo-layout-policy.conf` before adding those paths.
 
 ## Implementation gates
 
 - Coding may begin in Phase 6 after ADRs for product/stack, threat model, data
-  model, helper/API contract, and testing/CI strategy are complete.
+  model, helper/API contract, and testing/CI/CD strategy are complete.
 - Write actions remain gated on explicit trust-boundary documentation, helper
   contracts, and tests for destructive-operation safeguards.
 - Cloudron packaging, machine pairing, and desktop packaging remain later-phase


### PR DESCRIPTION
## Summary

- Apply Gemini review consistency feedback to the GUI control-plane docs.
- Standardize `git`, `ad-hoc`, and `CI/CD` wording in `docs/gui/control-plane.md`.

## Verification

- `git diff --check origin/main...HEAD`
- `npx --yes markdownlint-cli2@0.22.0 docs/gui/control-plane.md`

For #25230

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5
