### PR TITLE
GH#25471: fix: harden github app cache dir expansion

### DIFF
--- a/.agents/scripts/github-app-auth-helper.sh
+++ b/.agents/scripts/github-app-auth-helper.sh
@@ -118,38 +118,40 @@ github_app_enabled() {
 }
 
 _github_app_cache_dir() {
+	local cache_dir="${AIDEVOPS_GITHUB_APP_CACHE_DIR:-}"
+	local app_home="${AIDEVOPS_GITHUB_APP_HOME:-}"
 	local old_umask=""
-	if [[ -L "$AIDEVOPS_GITHUB_APP_CACHE_DIR" ]]; then
+	if [[ -L "$cache_dir" ]]; then
 		return 1
 	fi
 	old_umask=$(umask)
 	umask 077
-	if [[ -z "${HOME:-}" && "$AIDEVOPS_GITHUB_APP_CACHE_DIR" == "$AIDEVOPS_GITHUB_APP_HOME"/* ]]; then
-		if [[ -L "$AIDEVOPS_GITHUB_APP_HOME" ]]; then
+	if [[ -z "${HOME:-}" && -n "$app_home" && "$cache_dir" == "$app_home"/* ]]; then
+		if [[ -L "$app_home" ]]; then
 			umask "$old_umask"
 			return 1
 		fi
-		mkdir -p "$AIDEVOPS_GITHUB_APP_HOME" 2>/dev/null || {
+		mkdir -p "$app_home" 2>/dev/null || {
 			umask "$old_umask"
 			return 1
 		}
-		[[ -d "$AIDEVOPS_GITHUB_APP_HOME" && ! -L "$AIDEVOPS_GITHUB_APP_HOME" ]] || {
+		[[ -d "$app_home" && ! -L "$app_home" ]] || {
 			umask "$old_umask"
 			return 1
 		}
-		chmod 700 "$AIDEVOPS_GITHUB_APP_HOME" 2>/dev/null || {
+		chmod 700 "$app_home" 2>/dev/null || {
 			umask "$old_umask"
 			return 1
 		}
 	fi
-	mkdir -p "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || {
+	mkdir -p "$cache_dir" 2>/dev/null || {
 		umask "$old_umask"
 		return 1
 	}
 	umask "$old_umask"
-	[[ -d "$AIDEVOPS_GITHUB_APP_CACHE_DIR" && ! -L "$AIDEVOPS_GITHUB_APP_CACHE_DIR" ]] || return 1
-	chmod 700 "$AIDEVOPS_GITHUB_APP_CACHE_DIR" 2>/dev/null || return 1
-	printf '%s\n' "$AIDEVOPS_GITHUB_APP_CACHE_DIR"
+	[[ -d "$cache_dir" && ! -L "$cache_dir" ]] || return 1
+	chmod 700 "$cache_dir" 2>/dev/null || return 1
+	printf '%s\n' "$cache_dir"
 	return 0
 }
 

--- a/.agents/scripts/github-app-auth-helper.sh
+++ b/.agents/scripts/github-app-auth-helper.sh
@@ -121,6 +121,9 @@ _github_app_cache_dir() {
 	local cache_dir="${AIDEVOPS_GITHUB_APP_CACHE_DIR:-}"
 	local app_home="${AIDEVOPS_GITHUB_APP_HOME:-}"
 	local old_umask=""
+	if [[ -z "$cache_dir" ]]; then
+		return 1
+	fi
 	if [[ -L "$cache_dir" ]]; then
 		return 1
 	fi

--- a/.agents/scripts/tests/test-github-app-auth-helper.sh
+++ b/.agents/scripts/tests/test-github-app-auth-helper.sh
@@ -100,6 +100,18 @@ else
 	pass "unset HOME fallback cache rejects symlinked fallback root"
 fi
 
+# shellcheck disable=SC2016 # Keep variable unsets inside the env-isolated bash process.
+if env -i USER="unset-var-user" TMPDIR="$TMP/fallback-tmp" PATH="$PATH" bash -c '
+set -euo pipefail
+source "$1"
+unset AIDEVOPS_GITHUB_APP_CACHE_DIR AIDEVOPS_GITHUB_APP_HOME HOME
+_github_app_cache_dir >/dev/null
+' bash "${SCRIPTS_DIR}/github-app-auth-helper.sh"; then
+	fail "cache dir helper fails closed when cache/home variables are unset"
+else
+	pass "cache dir helper fails closed when cache/home variables are unset"
+fi
+
 route_auth=$(github_app_route_json issue-list owner/repo | jq -r '.auth_mode')
 assert_eq "no app configured falls back to gh/PAT auth" "gh-pat" "$route_auth"
 

--- a/.agents/scripts/tests/test-github-app-auth-helper.sh
+++ b/.agents/scripts/tests/test-github-app-auth-helper.sh
@@ -101,15 +101,22 @@ else
 fi
 
 # shellcheck disable=SC2016 # Keep variable unsets inside the env-isolated bash process.
-if env -i USER="unset-var-user" TMPDIR="$TMP/fallback-tmp" PATH="$PATH" bash -c '
+if env -i USER="unset-var-user" TMPDIR="$TMP/fallback-tmp" PATH="$PATH" MKDIR_LOG="$TMP/empty-cache-mkdir.log" bash -c '
 set -euo pipefail
 source "$1"
 unset AIDEVOPS_GITHUB_APP_CACHE_DIR AIDEVOPS_GITHUB_APP_HOME HOME
-_github_app_cache_dir >/dev/null
+mkdir() {
+	printf "mkdir called\n" >"$MKDIR_LOG"
+	return 1
+}
+if _github_app_cache_dir >/dev/null; then
+	exit 1
+fi
+[[ ! -e "$MKDIR_LOG" ]]
 ' bash "${SCRIPTS_DIR}/github-app-auth-helper.sh"; then
-	fail "cache dir helper fails closed when cache/home variables are unset"
-else
 	pass "cache dir helper fails closed when cache/home variables are unset"
+else
+	fail "cache dir helper fails closed when cache/home variables are unset"
 fi
 
 route_auth=$(github_app_route_json issue-list owner/repo | jq -r '.auth_mode')


### PR DESCRIPTION
## Summary
- Hardened `_github_app_cache_dir` to snapshot cache/home values with `${VAR:-}` before file tests and path operations.
- Added regression coverage for `set -u` behavior when cache/home variables are unset after sourcing.

## Files changed
- `.agents/scripts/github-app-auth-helper.sh`
- `.agents/scripts/tests/test-github-app-auth-helper.sh`

## Testing
- `bash -n .agents/scripts/github-app-auth-helper.sh .agents/scripts/tests/test-github-app-auth-helper.sh`
- `shellcheck .agents/scripts/github-app-auth-helper.sh .agents/scripts/tests/test-github-app-auth-helper.sh`
- `.agents/scripts/tests/test-github-app-auth-helper.sh`

Resolves #25471


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.10 with gpt-5.5 spent 5m and 55,701 tokens on this as a headless worker.
