### PR TITLE
GH#25474: fix: harden feature toggle uid fallback

### DIFF
--- a/.agents/scripts/shared-feature-toggles.sh
+++ b/.agents/scripts/shared-feature-toggles.sh
@@ -77,7 +77,7 @@ fi
 # Legacy paths (kept for backward compatibility and migration)
 # =============================================================================
 
-FEATURE_TOGGLES_HOME="${HOME:-/tmp/aidevops-uid-${UID:-unknown}}"
+FEATURE_TOGGLES_HOME="${HOME:-/tmp/aidevops-uid-${UID:-$(id -u || echo 'unknown')}}"
 FEATURE_TOGGLES_DEFAULTS="${FEATURE_TOGGLES_HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults"
 FEATURE_TOGGLES_USER="${FEATURE_TOGGLES_HOME}/.config/aidevops/feature-toggles.conf"
 


### PR DESCRIPTION
## Summary

Updated .agents/scripts/shared-feature-toggles.sh so HOME fallback resolves UID with id -u before falling back to unknown, avoiding shared /tmp/aidevops-uid-unknown paths in shells without UID.

## Files Changed

.agents/scripts/shared-feature-toggles.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-feature-toggles.sh; env -u HOME -u UID sh -c 'FEATURE_TOGGLES_HOME="${HOME:-/tmp/aidevops-uid-${UID:-$(id -u || echo '\''unknown'\'')}}"; test "" = "/tmp/aidevops-uid-$(id -u)"'; git diff --check HEAD~1..HEAD

Resolves #25474


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 56,437 tokens on this as a headless worker.