### PR TITLE
GH#25472: fix: clean home fallback test env

### DIFF
--- a/.agents/scripts/tests/test-shared-todo-commit-home-fallback.sh
+++ b/.agents/scripts/tests/test-shared-todo-commit-home-fallback.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="${BASH_SOURCE[0]%/*}/.."
 SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
 
 # shellcheck disable=SC2016 # Inner shell expands $1 and $TODO_LOCK_DIR after sourcing.
-actual=$(env -u HOME USER=tester UID=12345 bash -c 'source "$1"; printf "%s\n" "$TODO_LOCK_DIR"' _ "${SCRIPT_DIR}/shared-todo-commit.sh")
+actual=$(env -u HOME USER=tester bash -c 'source "$1"; printf "%s\n" "$TODO_LOCK_DIR"' _ "${SCRIPT_DIR}/shared-todo-commit.sh")
 expected="/tmp/aidevops-tester/.aidevops/locks"
 
 if [[ "$actual" != "$expected" ]]; then


### PR DESCRIPTION
## Summary

Removed the redundant UID assignment from the HOME fallback test env invocation so Bash no longer emits a readonly UID warning while preserving the USER-based expected path.

## Files Changed

.agents/scripts/tests/test-shared-todo-commit-home-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shared-todo-commit-home-fallback.sh; shellcheck .agents/scripts/tests/test-shared-todo-commit-home-fallback.sh

Resolves #25472


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 43,423 tokens on this as a headless worker.