### PR TITLE
GH#25473: fix: harden gh api instrumentation tmp fallback

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -65,7 +65,34 @@ _GH_API_INSTRUMENT_LOADED=1
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
 
 # --- Configuration --------------------------------------------------------
-_GH_API_HOME="${HOME:-${TMPDIR:-/tmp}/aidevops-${USER:-${UID:-shared}}}"
+_GH_API_HOME="${HOME:-}"
+if [[ -z "$_GH_API_HOME" ]]; then
+	_GH_API_UID="${UID:-}"
+	[[ -z "$_GH_API_UID" ]] && _GH_API_UID="$(id -u)"
+	if command -v getent >/dev/null 2>&1; then
+		_GH_API_HOME="$(getent passwd "$_GH_API_UID" | cut -d: -f6 || true)"
+	fi
+	_GH_API_HOME="${_GH_API_HOME:-${TMPDIR:-/tmp}/aidevops-${USER:-${_GH_API_UID:-shared}}}"
+fi
+
+# If HOME cannot be resolved and we must fall back under a shared temporary
+# parent, create/lock down a user-owned root before any nested log path exists.
+# Otherwise a pre-created /tmp/aidevops-* tree can contain symlinks that make the
+# later append follow attacker-controlled paths.
+case "$_GH_API_HOME" in
+"${TMPDIR:-/tmp}"/* | /tmp/*)
+	if [[ ! -e "$_GH_API_HOME" ]]; then
+		mkdir -p "$_GH_API_HOME" 2>/dev/null || AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1
+	fi
+	if [[ -e "$_GH_API_HOME" ]]; then
+		if [[ ! -O "$_GH_API_HOME" ]]; then
+			AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1
+		else
+			chmod 0700 "$_GH_API_HOME" 2>/dev/null || true
+		fi
+	fi
+	;;
+esac
 GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls.log}"
 GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls-by-stage.json}"
 GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -195,6 +195,34 @@ assert_eq "explicit caller: PR search counted separately" "1" "$search_pr_count"
 tickle_count=$(jq -r '.by_caller["events_tickle_events"].rest_calls' "$AIDEVOPS_GH_API_REPORT")
 assert_eq "explicit caller: events tickle REST call counted separately" "1" "$tickle_count"
 
+# --- Test 8: HOME-less temp fallback is owned and private -------------
+unset _GH_API_INSTRUMENT_LOADED AIDEVOPS_GH_API_LOG AIDEVOPS_GH_API_REPORT
+FAKE_BIN="$TMPDIR/fake-bin"
+mkdir -p "$FAKE_BIN"
+cat >"$FAKE_BIN/getent" <<'EOF_GETENT'
+#!/usr/bin/env bash
+exit 2
+EOF_GETENT
+chmod +x "$FAKE_BIN/getent"
+FALLBACK_TMP="$TMPDIR/fallback-root"
+set +e
+PATH="$FAKE_BIN:$PATH" HOME='' TMPDIR="$FALLBACK_TMP" USER="ghapitest" bash -c '
+	set -euo pipefail
+	# shellcheck source=../gh-api-instrument.sh
+	source "$1"
+	gh_record_call rest fallback-test
+	mode=$(stat -f %Lp "$TMPDIR/aidevops-$USER" 2>/dev/null || stat -c %a "$TMPDIR/aidevops-$USER")
+	[[ "$mode" == "700" ]]
+	[[ -f "$TMPDIR/aidevops-$USER/.aidevops/logs/gh-api-calls.log" ]]
+' _ "${PARENT_DIR}/gh-api-instrument.sh"
+fallback_status="$?"
+set -e
+assert_eq "HOME-less temp fallback is private" "0" "$fallback_status"
+
+# Restore per-test overrides for summary diagnostics if future tests append.
+export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
+export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
+
 # --- Summary ----------------------------------------------------------
 echo ""
 echo "===================================================="


### PR DESCRIPTION
## Summary

Hardened gh-api-instrument HOME-less fallback by resolving passwd home when available, locking temporary fallback roots to user-owned 0700 directories, and disabling instrumentation when the temp root is not owned by the current user. Added regression coverage for the HOME-less temp fallback path.

## Files Changed

.agents/scripts/gh-api-instrument.sh,.agents/scripts/tests/test-gh-api-instrument.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-api-instrument.sh (22 passed); shellcheck .agents/scripts/gh-api-instrument.sh .agents/scripts/tests/test-gh-api-instrument.sh (no output); .agents/scripts/linters-local.sh (timed out after 240s during Secretlint after earlier gates passed)

Resolves #25473


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 10m and 53,318 tokens on this as a headless worker.