### PR TITLE
GH#25481: fix: verify serve-sim SwiftPM support

### DIFF
--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1295,6 +1295,22 @@ _setup_serve_sim_cli_version() {
 	return 0
 }
 
+_setup_serve_sim_swiftpm_ok() {
+	if ! command -v xcrun >/dev/null 2>&1; then
+		return 1
+	fi
+
+	if ! xcrun simctl list devices >/dev/null 2>&1; then
+		return 1
+	fi
+
+	if ! xcrun swift build --version >/dev/null 2>&1; then
+		return 1
+	fi
+
+	return 0
+}
+
 setup_serve_sim() {
 	# serve-sim currently ships an arm64 native Apple Simulator addon.
 	if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -1316,7 +1332,7 @@ setup_serve_sim() {
 		return 0
 	fi
 
-	if ! command -v xcrun >/dev/null 2>&1 || ! xcrun simctl list devices >/dev/null 2>&1; then
+	if ! _setup_serve_sim_swiftpm_ok; then
 		print_info "serve-sim requires Xcode command-line tools, SwiftPM swiftbuild support, and simulator support"
 		print_info "Install Xcode/Command Line Tools, then re-run setup"
 		return 0


### PR DESCRIPTION
## Summary

Added a serve-sim preflight helper that verifies xcrun, simulator access, and SwiftPM via xcrun swift build --version before attempting the native addon install.

## Files Changed

.agents/scripts/setup/modules/tool-install.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/setup/modules/tool-install.sh; shellcheck .agents/scripts/setup/modules/tool-install.sh; pre-commit hook ShellCheck/ratchet checks passed during WIP commit

Resolves #25481


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 32,757 tokens on this as a headless worker.