### PR TITLE
GH#25484: fix: reject gh api tmp symlink fallback

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -81,14 +81,16 @@ fi
 # later append follow attacker-controlled paths.
 case "$_GH_API_HOME" in
 "${TMPDIR:-/tmp}"/* | /tmp/*)
-	if [[ ! -e "$_GH_API_HOME" ]]; then
+	if [[ -L "$_GH_API_HOME" ]]; then
+		AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1
+	elif [[ ! -e "$_GH_API_HOME" ]]; then
 		mkdir -p "$_GH_API_HOME" 2>/dev/null || AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1
 	fi
-	if [[ -e "$_GH_API_HOME" ]]; then
-		if [[ ! -O "$_GH_API_HOME" ]]; then
+	if [[ -e "$_GH_API_HOME" && "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" != "1" ]]; then
+		if [[ ! -O "$_GH_API_HOME" || -L "$_GH_API_HOME" ]]; then
 			AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1
 		else
-			chmod 0700 "$_GH_API_HOME" 2>/dev/null || true
+			chmod 0700 "$_GH_API_HOME" || true
 		fi
 	fi
 	;;

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -219,6 +219,25 @@ fallback_status="$?"
 set -e
 assert_eq "HOME-less temp fallback is private" "0" "$fallback_status"
 
+# --- Test 9: HOME-less temp fallback rejects pre-created symlink ------
+unset _GH_API_INSTRUMENT_LOADED AIDEVOPS_GH_API_LOG AIDEVOPS_GH_API_REPORT
+SYMLINK_TMP="$TMPDIR/symlink-root"
+SYMLINK_TARGET="$TMPDIR/symlink-target"
+mkdir -p "$SYMLINK_TMP" "$SYMLINK_TARGET"
+ln -s "$SYMLINK_TARGET" "$SYMLINK_TMP/aidevops-ghapitest"
+set +e
+PATH="$FAKE_BIN:$PATH" HOME='' TMPDIR="$SYMLINK_TMP" USER="ghapitest" bash -c '
+	set -euo pipefail
+	# shellcheck source=../gh-api-instrument.sh
+	source "$1"
+	gh_record_call rest symlink-fallback-test
+	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]]
+	[[ ! -e "$TMPDIR/aidevops-$USER/.aidevops/logs/gh-api-calls.log" ]]
+' _ "${PARENT_DIR}/gh-api-instrument.sh"
+symlink_status="$?"
+set -e
+assert_eq "HOME-less temp fallback rejects symlink" "0" "$symlink_status"
+
 # Restore per-test overrides for summary diagnostics if future tests append.
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"


### PR DESCRIPTION
## Summary

Reject pre-created symlink HOME-less gh API instrumentation fallback roots before ownership/chmod handling, and cover the regression with a shell test.

## Files Changed

.agents/scripts/gh-api-instrument.sh,.agents/scripts/tests/test-gh-api-instrument.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-api-instrument.sh .agents/scripts/tests/test-gh-api-instrument.sh; .agents/scripts/tests/test-gh-api-instrument.sh

Resolves #25484


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 38,360 tokens on this as a headless worker.