### PR TITLE
GH#25493: fix: harden worktree registry pid fallback

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -24,6 +24,25 @@ _SHARED_WORKTREE_REGISTRY_LOADED=1
 # Worktree Ownership Registry (t189)
 # =============================================================================
 
+_worktree_registry_dir_is_safe() {
+	local path="$1"
+	[[ -n "$path" ]] || return 1
+	[[ -L "$path" ]] && return 1
+	[[ -e "$path" && ! -O "$path" ]] && return 1
+	[[ -e "$path" && ! -d "$path" ]] && return 1
+	return 0
+}
+
+_worktree_registry_ensure_dir() {
+	local path="$1"
+	_worktree_registry_dir_is_safe "$path" || return 1
+	if [[ ! -d "$path" ]]; then
+		mkdir -m 0700 "$path" || return 1
+	fi
+	_worktree_registry_dir_is_safe "$path" || return 1
+	return 0
+}
+
 _WORKTREE_REGISTRY_HOME="${HOME:-}"
 if [[ -z "$_WORKTREE_REGISTRY_HOME" ]]; then
 	if _WORKTREE_REGISTRY_UID="$(id -u)"; then
@@ -33,12 +52,15 @@ if [[ -z "$_WORKTREE_REGISTRY_HOME" ]]; then
 	fi
 	_WORKTREE_REGISTRY_TMPDIR="${WORKTREE_REGISTRY_TMPDIR:-/tmp}"
 	_WORKTREE_REGISTRY_HOME="${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}"
-	if [[ -L "$_WORKTREE_REGISTRY_HOME" || ( -e "$_WORKTREE_REGISTRY_HOME" && ! -O "$_WORKTREE_REGISTRY_HOME" ) ]]; then
+	if ! _worktree_registry_ensure_dir "$_WORKTREE_REGISTRY_HOME"; then
 		_WORKTREE_REGISTRY_HOME="${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}-$$"
 	fi
-	if [[ ! -d "$_WORKTREE_REGISTRY_HOME" ]] && ! mkdir -m 0700 "$_WORKTREE_REGISTRY_HOME"; then
-		_WORKTREE_REGISTRY_HOME="${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}-$$"
-		[[ -d "$_WORKTREE_REGISTRY_HOME" ]] || mkdir -m 0700 "$_WORKTREE_REGISTRY_HOME" || true
+	if ! _worktree_registry_ensure_dir "$_WORKTREE_REGISTRY_HOME"; then
+		_WORKTREE_REGISTRY_HOME="$(mktemp -d "${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}.XXXXXXXXXX")" || _WORKTREE_REGISTRY_HOME=""
+	fi
+	if [[ -z "${_WORKTREE_REGISTRY_HOME:-}" ]] || ! _worktree_registry_dir_is_safe "$_WORKTREE_REGISTRY_HOME"; then
+		printf 'ERROR: unable to create a safe worktree registry home under %s\n' "${_WORKTREE_REGISTRY_TMPDIR:-}" >&2
+		return 1
 	fi
 fi
 WORKTREE_REGISTRY_DIR="${WORKTREE_REGISTRY_DIR:-${_WORKTREE_REGISTRY_HOME}/.aidevops/.agent-workspace}"

--- a/.agents/scripts/tests/test-worktree-registry-unset-home.sh
+++ b/.agents/scripts/tests/test-worktree-registry-unset-home.sh
@@ -49,6 +49,12 @@ else
 fi
 
 fallback_home="${test_tmpdir}/aidevops-${fallback_uid}"
+if [[ -O "$fallback_home" ]]; then
+	print_result "unset HOME creates user-owned fallback root" 0
+else
+	print_result "unset HOME creates user-owned fallback root" 1 "fallback_home=${fallback_home}"
+fi
+
 if [[ -d "$fallback_home" && ! -L "$fallback_home" ]]; then
 	print_result "unset HOME creates fallback root as directory" 0
 else
@@ -66,6 +72,23 @@ case "$symlink_actual_dir" in
 	;;
 *)
 	print_result "unset HOME avoids symlinked fallback root" 1 "actual=${symlink_actual_dir} expected-prefix=${symlink_expected_dir}"
+	;;
+esac
+
+rm -rf "$fallback_home" "${test_tmpdir}/hijack-target"
+mkdir -p "${test_tmpdir}/hijack-target"
+# shellcheck disable=SC2016 # Inner bash must expand its own PID-specific fallback path.
+pid_symlink_actual_dir="$(env -u HOME -u USER -u LOGNAME REGISTRY_LIB="$REGISTRY_LIB" WORKTREE_REGISTRY_TMPDIR="$test_tmpdir" bash -c 'fallback_uid="$(id -u 2>/dev/null || printf '\''shared'\'')"; primary_home="${WORKTREE_REGISTRY_TMPDIR}/aidevops-${fallback_uid}"; pid_home="${primary_home}-$$"; ln -s "${WORKTREE_REGISTRY_TMPDIR}/hijack-target" "$primary_home"; ln -s "${WORKTREE_REGISTRY_TMPDIR}/hijack-target" "$pid_home"; source "$REGISTRY_LIB"; printf '\''%s'\'' "$WORKTREE_REGISTRY_DIR"')"
+
+case "$pid_symlink_actual_dir" in
+"${test_tmpdir}/hijack-target"*)
+	print_result "unset HOME avoids symlinked pid fallback root" 1 "actual=${pid_symlink_actual_dir}"
+	;;
+"${test_tmpdir}/aidevops-${fallback_uid}."*"/.aidevops/.agent-workspace")
+	print_result "unset HOME avoids symlinked pid fallback root" 0
+	;;
+*)
+	print_result "unset HOME avoids symlinked pid fallback root" 1 "actual=${pid_symlink_actual_dir}"
 	;;
 esac
 


### PR DESCRIPTION
## Summary

Validated worktree registry fallback directories before use, added mktemp fallback when primary and PID-scoped tmp paths are unsafe, and extended unset-HOME regression coverage for PID-suffixed symlink hijacking.

## Files Changed

.agents/scripts/shared-worktree-registry.sh,.agents/scripts/tests/test-worktree-registry-unset-home.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh .agents/scripts/tests/test-worktree-registry-unset-home.sh; bash .agents/scripts/tests/test-worktree-registry-unset-home.sh; bash .agents/scripts/tests/test-worktree-registry-dead-owner.sh; bash .agents/scripts/tests/test-worktree-registry-prune-batch.sh

Resolves #25493


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 50,854 tokens on this as a headless worker.