### PR TITLE
GH#25495: fix: harden config fallback home

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -66,6 +66,18 @@ fi
 # File paths (use defaults if not already set — allows override for testing)
 # ---------------------------------------------------------------------------
 _CONFIG_HOME="${HOME:-/tmp/aidevops-${USER:-uid-${UID:-shared}}}"
+_validate_config_home() {
+	local config_home="$1"
+	if [[ "$config_home" == /tmp/* && -e "$config_home" ]]; then
+		if [[ -L "$config_home" || ! -O "$config_home" ]]; then
+			echo "[ERROR] Security risk: $config_home is a symlink or not owned by the current user." >&2
+			return 1
+		fi
+	fi
+	return 0
+}
+
+_validate_config_home "$_CONFIG_HOME" || return 1 2>/dev/null || exit 1
 JSONC_DEFAULTS="${JSONC_DEFAULTS:-${_CONFIG_HOME}/.aidevops/agents/configs/aidevops.defaults.jsonc}"
 JSONC_USER="${JSONC_USER:-${_CONFIG_HOME}/.config/aidevops/config.jsonc}"
 JSONC_SCHEMA="${JSONC_SCHEMA:-${_CONFIG_HOME}/.aidevops/agents/configs/aidevops-config.schema.json}"
@@ -1090,6 +1102,7 @@ main() {
 			if [[ -n "$migrate_stderr" ]]; then
 				echo "[WARN] Migration error: ${migrate_stderr}" >&2
 			fi
+			mkdir -p "$(dirname "$MIGRATE_FAILED_FLAG")"
 			touch "$MIGRATE_FAILED_FLAG"
 		else
 			rm -f "$MIGRATE_FAILED_FLAG"


### PR DESCRIPTION
## Summary

Validated the computed fallback config home before deriving config paths, rejecting unsafe /tmp symlink or non-owned directories, and ensured the migration failure flag parent directory exists before touching the flag.

## Files Changed

.agents/scripts/config-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/config-helper.sh; targeted symlink fallback rejection check; .agents/scripts/linters-local.sh progressed through required secret/policy checks but timed out later during broad Bash compatibility audit after advisory markdown/ratchet output

Resolves #25495


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 12m and 54,123 tokens on this as a headless worker.