### PR TITLE
GH#25497: fix: avoid redundant worktree registry fallback checks

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -37,7 +37,7 @@ _worktree_registry_ensure_dir() {
 	local path="$1"
 	_worktree_registry_dir_is_safe "$path" || return 1
 	if [[ ! -d "$path" ]]; then
-		mkdir -m 0700 "$path" || return 1
+		mkdir -m 0700 "$path" || [[ -d "$path" ]] || return 1
 	fi
 	_worktree_registry_dir_is_safe "$path" || return 1
 	return 0
@@ -54,9 +54,9 @@ if [[ -z "$_WORKTREE_REGISTRY_HOME" ]]; then
 	_WORKTREE_REGISTRY_HOME="${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}"
 	if ! _worktree_registry_ensure_dir "$_WORKTREE_REGISTRY_HOME"; then
 		_WORKTREE_REGISTRY_HOME="${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}-$$"
-	fi
-	if ! _worktree_registry_ensure_dir "$_WORKTREE_REGISTRY_HOME"; then
-		_WORKTREE_REGISTRY_HOME="$(mktemp -d "${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}.XXXXXXXXXX")" || _WORKTREE_REGISTRY_HOME=""
+		if ! _worktree_registry_ensure_dir "$_WORKTREE_REGISTRY_HOME"; then
+			_WORKTREE_REGISTRY_HOME="$(mktemp -d "${_WORKTREE_REGISTRY_TMPDIR}/aidevops-${_WORKTREE_REGISTRY_UID}.XXXXXXXXXX")" || _WORKTREE_REGISTRY_HOME=""
+		fi
 	fi
 	if [[ -z "${_WORKTREE_REGISTRY_HOME:-}" ]] || ! _worktree_registry_dir_is_safe "$_WORKTREE_REGISTRY_HOME"; then
 		printf 'ERROR: unable to create a safe worktree registry home under %s\n' "${_WORKTREE_REGISTRY_TMPDIR:-}" >&2


### PR DESCRIPTION
## Summary

Handled concurrent creation of the worktree registry fallback directory by accepting a directory created after mkdir fails, and nested fallback checks so the primary registry home is not revalidated redundantly after success.

## Files Changed

.agents/scripts/shared-worktree-registry.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh .agents/scripts/tests/test-worktree-registry-unset-home.sh; bash .agents/scripts/tests/test-worktree-registry-unset-home.sh

Resolves #25497


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 38,339 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating the worktree registry directory by handling rare race conditions more gracefully.
  * If the registry directory already exists, the setup now continues instead of failing unnecessarily.
  * Existing fallback behavior for temporary registry location setup remains unchanged when the default path cannot be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->