### PR TITLE
GH#25500: fix worktree registry mkdir race

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -37,7 +37,8 @@ _worktree_registry_ensure_dir() {
 	local path="$1"
 	_worktree_registry_dir_is_safe "$path" || return 1
 	if [[ ! -d "$path" ]]; then
-		mkdir -m 0700 "$path" || [[ -d "$path" ]] || return 1
+		mkdir -p "$path" || return 1
+		chmod 0700 "$path" || return 1
 	fi
 	_worktree_registry_dir_is_safe "$path" || return 1
 	return 0


### PR DESCRIPTION
## Summary

- Use `mkdir -p` in `_worktree_registry_ensure_dir` so concurrent creators do not emit a noisy `File exists` race.
- Apply `chmod 0700` after creation to preserve the registry directory permission contract without triggering ShellCheck SC2174.

## Testing

- `shellcheck .agents/scripts/shared-worktree-registry.sh`
- `bash -n .agents/scripts/shared-worktree-registry.sh`
- `bash .agents/scripts/tests/test-worktree-registry-unset-home.sh`

MERGE_SUMMARY: Changed `.agents/scripts/shared-worktree-registry.sh` so registry directory creation uses `mkdir -p` for concurrent workers and then enforces `0700` permissions with `chmod`; verified with ShellCheck, Bash syntax validation, and the unset-HOME worktree registry test.

Resolves #25500
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 63,861 tokens on this as a headless worker.