### PR TITLE
auto-recover: orphaned worker branch for #25500

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -37,7 +37,8 @@ _worktree_registry_ensure_dir() {
 	local path="$1"
 	_worktree_registry_dir_is_safe "$path" || return 1
 	if [[ ! -d "$path" ]]; then
-		mkdir -m 0700 "$path" || [[ -d "$path" ]] || return 1
+		mkdir -p "$path" || return 1
+		chmod 0700 "$path" || return 1
 	fi
 	_worktree_registry_dir_is_safe "$path" || return 1
 	return 0


### PR DESCRIPTION
Local branch recovery PR — worker committed locally but exited before pushing or opening a PR.

Branch `feature/auto-20260626-021801-gh25500` had local commits from headless worker session `issue-25500` and was published by the recovery path before this PR was created (GH#25374).

Resolves #25500

<!-- aidevops:orphan-recovery worker_local_branch_unpushed session=issue-25500 -->