### PR TITLE
GH#25505: fix: make worktree registry mkdir race-free

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -37,8 +37,7 @@ _worktree_registry_ensure_dir() {
 	local path="$1"
 	_worktree_registry_dir_is_safe "$path" || return 1
 	if [[ ! -d "$path" ]]; then
-		mkdir -p "$path" || return 1
-		chmod 0700 "$path" || return 1
+		(umask 0077 && mkdir -p "$path") || return 1
 	fi
 	_worktree_registry_dir_is_safe "$path" || return 1
 	return 0


### PR DESCRIPTION
## Summary

Changed .agents/scripts/shared-worktree-registry.sh to create missing registry directories under umask 0077 with mkdir -p, avoiding the create-then-chmod race flagged in the review follow-up.

## Files Changed

.agents/scripts/shared-worktree-registry.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh; pre-commit hook passed during git commit

Resolves #25505


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 30,736 tokens on this as a headless worker.