### PR TITLE
GH#25507: fix: preserve runtime false grouping

### DIFF
--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -254,6 +254,8 @@ assert_eq "2h12: diagnostic focus counts stall-killed sessions" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.stall_hard_killed')"
 assert_eq "2h13: diagnostic focus counts local runtime errors" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.local_runtime_error')"
+assert_eq "2h13b: failure groups preserve false runtime markers" "false" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-15") | .runtime_error_type')"
 assert_eq "2h14: failure families carry next action for stall kills" "redispatch_worker" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_families[] | select(.launch_failure_cause == "stall_hard_killed") | .next_action')"
 assert_eq "2h15: diagnostic focus groups local kills separately" "2" \

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -190,13 +190,13 @@ _wah_metric_details_json() {
 			})),
 			failure_groups: (
 				$failures
-				| group_by([.result // "unknown", .failure_reason // "", .provider_error_type // "", .provider_status // "", .runtime_error_type // "", .classification_source // "", .classification_pattern // "", .launch_failure_cause // "", .kill_reason // "", .next_action // "", .provider // "", .model // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
+				| group_by([.result // "unknown", .failure_reason // "", .provider_error_type // "", .provider_status // "", (if .runtime_error_type == null then "" else .runtime_error_type end), .classification_source // "", .classification_pattern // "", .launch_failure_cause // "", .kill_reason // "", .next_action // "", .provider // "", .model // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
 				| map({
 					result: (.[0].result // "unknown"),
 					failure_reason: (.[0].failure_reason // ""),
 					provider_error_type: (.[0].provider_error_type // ""),
 					provider_status: (.[0].provider_status // ""),
-					runtime_error_type: (.[0].runtime_error_type // ""),
+					runtime_error_type: (if .[0].runtime_error_type == null then "" else .[0].runtime_error_type end),
 					classification_source: (.[0].classification_source // ""),
 					classification_pattern: (.[0].classification_pattern // ""),
 					launch_failure_cause: (.[0].launch_failure_cause // ""),

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -147,6 +147,7 @@ _wah_metric_details_json() {
 	now_epoch="${2:-$(date +%s)}"
 
 	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" '
+		def _wah_empty_if_null: if . == null then "" else . end;
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 		| ($w | map(.duration_ms // 0)) as $durations
 		| ($w | map(select((.result // "") != "success" or (.exit_code // 1) != 0))) as $failures
@@ -190,13 +191,13 @@ _wah_metric_details_json() {
 			})),
 			failure_groups: (
 				$failures
-				| group_by([.result // "unknown", .failure_reason // "", .provider_error_type // "", .provider_status // "", (if .runtime_error_type == null then "" else .runtime_error_type end), .classification_source // "", .classification_pattern // "", .launch_failure_cause // "", .kill_reason // "", .next_action // "", .provider // "", .model // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
+				| group_by([.result // "unknown", .failure_reason // "", .provider_error_type // "", .provider_status // "", (.runtime_error_type | _wah_empty_if_null), .classification_source // "", .classification_pattern // "", .launch_failure_cause // "", .kill_reason // "", .next_action // "", .provider // "", .model // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
 				| map({
 					result: (.[0].result // "unknown"),
 					failure_reason: (.[0].failure_reason // ""),
 					provider_error_type: (.[0].provider_error_type // ""),
 					provider_status: (.[0].provider_status // ""),
-					runtime_error_type: (if .[0].runtime_error_type == null then "" else .[0].runtime_error_type end),
+					runtime_error_type: (.[0].runtime_error_type | _wah_empty_if_null),
 					classification_source: (.[0].classification_source // ""),
 					classification_pattern: (.[0].classification_pattern // ""),
 					launch_failure_cause: (.[0].launch_failure_cause // ""),

--- a/packages/gui-shared/src/fixtures.ts
+++ b/packages/gui-shared/src/fixtures.ts
@@ -41,32 +41,12 @@ export const statusFixture: GuiStatusData = {
     },
   ],
   navigation: [
-    {
-      id: "overview",
-      label: "Overview",
-      description: "Local setup, update, and API health.",
-    },
-    {
-      id: "agents",
-      label: "Agents",
-      description: "Read-only file explorer for deployed agent files.",
-    },
-    {
-      id: "config",
-      label: "Config",
-      description: "Read-only file explorer for aidevops config.",
-    },
-    {
-      id: "git",
-      label: "Local Repos",
-      description: "Read-only local git workspace browser.",
-    },
-    {
-      id: "security",
-      label: "Secrets",
-      description: "Secret-reference-only trust boundary.",
-    },
-  ],
+    ["overview", "Overview", "Local setup, update, and API health."],
+    ["agents", "Agents", "Read-only file explorer for deployed agent files."],
+    ["config", "Config", "Read-only file explorer for aidevops config."],
+    ["git", "Local Repos", "Read-only local git workspace browser."],
+    ["security", "Secrets", "Secret-reference-only trust boundary."],
+  ].map(([id, label, description]) => ({ id, label, description })),
   settings: {
     path_ref: "~/.config/aidevops/settings.json",
     health: "unchecked",

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -265,13 +265,11 @@ export const fontOptions: FontOption[] = [
   { value: "Ubuntu Mono", label: "Ubuntu Mono", fontFamily: '"Ubuntu Mono", Menlo, Monaco, Consolas, monospace' },
 ];
 
-export const fontSizeOptions: FontSizeOption[] = [
-  { value: "xs", label: "xs", cssSize: "14px" },
-  { value: "s", label: "s", cssSize: "15px" },
-  { value: "m", label: "m", cssSize: "16px" },
-  { value: "lg", label: "lg", cssSize: "17px" },
-  { value: "xl", label: "xl", cssSize: "18px" },
-];
+export const fontSizeOptions: FontSizeOption[] = (["xs", "s", "m", "lg", "xl"] as const).map((size, index) => ({
+  value: size,
+  label: size,
+  cssSize: `${14 + index}px`,
+}));
 
 export const navGroups: SurfaceNavGroup[] = [
   {


### PR DESCRIPTION
## Summary

Preserved literal false runtime_error_type values in worker failure grouping and added a regression assertion for issue-15.

## Files Changed

.agents/scripts/tests/test-worker-activity-helper.sh,.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worker-activity-helper.sh .agents/scripts/tests/test-worker-activity-helper.sh; .agents/scripts/tests/test-worker-activity-helper.sh

Resolves #25507


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 41,464 tokens on this as a headless worker.