### PR TITLE
GH#25514: fix: simplify worker activity jq fallback

### DIFF
--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -155,7 +155,7 @@ _wah_metric_details_json() {
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
 			diagnostic_focus: {
 				premature_exit: ($failures | map(select(.result == "premature_exit" or .launch_failure_cause == "model_stopped_before_completion")) | length),
-				local_runtime_error: ($failures | map(select(.result != $local_kill_result and .launch_failure_cause != $local_kill_result and (.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type != null and .runtime_error_type != "")))) | length),
+				local_runtime_error: ($failures | map(select(.result != $local_kill_result and .launch_failure_cause != $local_kill_result and (.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type // "") != ""))) | length),
 				local_kill: ($failures | map(select(.result == $local_kill_result or .launch_failure_cause == $local_kill_result or (.kill_reason != null and .kill_reason != "unknown" and .kill_reason != "natural"))) | length),
 				stall_hard_killed: ($failures | map(select(.result == $watchdog_killed_result or .launch_failure_cause == "stall_hard_killed" or .kill_reason == "hard_kill_stall")) | length)
 			},


### PR DESCRIPTION
## Summary

Simplified the worker activity diagnostic jq runtime_error_type presence check to use the jq fallback operator while preserving the existing local kill exclusions.

## Files Changed

.agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worker-activity-helper.sh

Resolves #25514


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 32,100 tokens on this as a headless worker.