### PR TITLE
GH#25515: fix: guard post-merge scanner interval

### DIFF
--- a/.agents/scripts/pulse-simplification-review.sh
+++ b/.agents/scripts/pulse-simplification-review.sh
@@ -196,6 +196,8 @@ _run_post_merge_review_scanner() {
 	[[ "$stage_budget" =~ ^[0-9]+$ ]] || stage_budget=600
 	local stage_reserve="${AIDEVOPS_POST_MERGE_SCANNER_STAGE_RESERVE_SECONDS:-30}"
 	[[ "$stage_reserve" =~ ^[0-9]+$ ]] || stage_reserve=30
+	local post_merge_scanner_interval="${POST_MERGE_SCANNER_INTERVAL:-86400}"
+	[[ "$post_merge_scanner_interval" =~ ^[0-9]+$ ]] || post_merge_scanner_interval=86400
 	local scanner_cursor_dir="${AIDEVOPS_POST_MERGE_SCANNER_CURSOR_DIR:-${HOME:-}/.aidevops/logs/post-merge-review-scanner}"
 	local repo_cursor_file="${scanner_cursor_dir}/repo.cursor"
 
@@ -205,7 +207,7 @@ _run_post_merge_review_scanner() {
 		last_run=$(cat "$POST_MERGE_SCANNER_LAST_RUN" 2>/dev/null || echo "0")
 		[[ "$last_run" =~ ^[0-9]+$ ]] || last_run=0
 		local elapsed=$((now_epoch - last_run))
-		if [[ "$elapsed" -lt "$POST_MERGE_SCANNER_INTERVAL" ]]; then
+		if [[ "$elapsed" -lt "$post_merge_scanner_interval" ]]; then
 			return 0
 		fi
 	fi
@@ -278,7 +280,7 @@ _run_post_merge_review_scanner() {
 
 	rm -f "$repo_cursor_file" 2>/dev/null || true
 	printf '%s\n' "$now_epoch" >"$POST_MERGE_SCANNER_LAST_RUN"
-	echo "[pulse-wrapper] Post-merge scanner: completed ${total_repos} repo(s), next run in ~$(( ${POST_MERGE_SCANNER_INTERVAL:-86400} / 3600 ))h" >>"${LOGFILE:-/dev/null}"
+	echo "[pulse-wrapper] Post-merge scanner: completed ${total_repos} repo(s), next run in ~$(( post_merge_scanner_interval / 3600 ))h" >>"${LOGFILE:-/dev/null}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-post-merge-review-cursor.sh
+++ b/.agents/scripts/tests/test-pulse-post-merge-review-cursor.sh
@@ -60,6 +60,23 @@ test_home_unset_does_not_abort() {
 	return 0
 }
 
+test_interval_unset_does_not_abort() {
+	local stub_scripts_dir="${TEST_ROOT}/interval-unset-scripts"
+	mkdir -p "$stub_scripts_dir"
+	SCRIPT_DIR="$stub_scripts_dir"
+	LOGFILE="${TEST_ROOT}/interval-unset.log"
+	POST_MERGE_SCANNER_LAST_RUN="${TEST_ROOT}/interval-unset.last"
+	printf '%s\n' "$(date +%s)" >"$POST_MERGE_SCANNER_LAST_RUN"
+	REPOS_JSON="${TEST_ROOT}/interval-unset-repos.json"
+	printf '{}\n' >"$REPOS_JSON"
+	unset POST_MERGE_SCANNER_INTERVAL
+
+	_run_post_merge_review_scanner
+	printf 'PASS POST_MERGE_SCANNER_INTERVAL unset does not abort post-merge scanner gate\n'
+	PASS=$((PASS + 1))
+	return 0
+}
+
 test_stale_repo_cursor_resets_to_enabled_repos() {
 	local stub_scripts_dir="${TEST_ROOT}/scripts"
 	local cursor_dir="${TEST_ROOT}/cursor"
@@ -93,6 +110,7 @@ STUB
 }
 
 test_home_unset_does_not_abort
+test_interval_unset_does_not_abort
 test_stale_repo_cursor_resets_to_enabled_repos
 
 printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Guarded the post-merge scanner interval inside _run_post_merge_review_scanner with a validated 86400-second fallback and reused that safe value for the time gate/log output. Added a regression test that unsets POST_MERGE_SCANNER_INTERVAL while the last-run gate exists.

## Files Changed

.agents/scripts/pulse-simplification-review.sh,.agents/scripts/tests/test-pulse-post-merge-review-cursor.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-post-merge-review-cursor.sh; shellcheck .agents/scripts/pulse-simplification-review.sh .agents/scripts/tests/test-pulse-post-merge-review-cursor.sh

Resolves #25515


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 41,240 tokens on this as a headless worker.