### PR TITLE
fix: harden issue dedup API fallback

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-title-dedup.sh
+++ b/.agents/scripts/tests/test-issue-sync-title-dedup.sh
@@ -51,6 +51,26 @@ test_title_window_not_shadowed_by_fingerprint_window() {
 	return 0
 }
 
+test_api_fallback_does_not_append_partial_stdout() {
+	if grep -q '_dedup_gh_api_json' "$WORKFLOW_FILE" \
+		&& grep -q "gh api \"\$@\" >\"\$tmp_file\"" "$WORKFLOW_FILE" \
+		&& ! grep -q "issues_json=\$(gh api" "$WORKFLOW_FILE"; then
+		print_result "dedup API fallback discards partial stdout before fallback" 0
+	else
+		print_result "dedup API fallback discards partial stdout before fallback" 1
+	fi
+	return 0
+}
+
+test_issue_candidate_fetch_uses_get_method() {
+	if grep -q -- '--method GET -f state=open' "$WORKFLOW_FILE"; then
+		print_result "candidate issue fetch stays a GET request" 0
+	else
+		print_result "candidate issue fetch stays a GET request" 1
+	fi
+	return 0
+}
+
 main() {
 	if [[ ! -f "$WORKFLOW_FILE" ]]; then
 		printf 'FATAL: workflow not found: %s\n' "$WORKFLOW_FILE" >&2
@@ -59,6 +79,8 @@ main() {
 	test_title_window_configured
 	test_title_match_sets_duplicate_reason
 	test_title_window_not_shadowed_by_fingerprint_window
+	test_api_fallback_does_not_append_partial_stdout
+	test_issue_candidate_fetch_uses_get_method
 	printf 'Tests run: %s\n' "$TESTS_RUN"
 	printf 'Tests failed: %s\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -336,13 +336,35 @@ jobs:
           # shellcheck source=__aidevops/.agents/scripts/lib/issue-fingerprint.sh
           source __aidevops/.agents/scripts/lib/issue-fingerprint.sh
 
+          # Run gh api through a temp file so fallback JSON never appends to
+          # partial stdout from a non-zero gh exit. Appended fallback produces a
+          # multi-document stream (for example, candidate length "3\n0"), which
+          # made the duplicate scan skip obvious same-title reports.
+          _dedup_gh_api_json() {
+            local fallback="$1"
+            shift
+            local tmp_file=""
+            tmp_file=$(mktemp) || {
+              printf '%s\n' "$fallback"
+              return 0
+            }
+            if gh api "$@" >"$tmp_file"; then
+              printf '%s\n' "$(<"$tmp_file")"
+              rm -f "$tmp_file"
+              return 0
+            fi
+            rm -f "$tmp_file"
+            printf '%s\n' "$fallback"
+            return 0
+          }
+
           WINDOW="${ISSUE_SYNC_DEDUP_WINDOW_SECONDS:-120}"
           TITLE_WINDOW="${ISSUE_SYNC_TITLE_DEDUP_WINDOW_SECONDS:-600}"
           echo "[dedup] Checking issue #${ISSUE_NUMBER} by @${ISSUE_AUTHOR} (fingerprint window: ${WINDOW}s, title window: ${TITLE_WINDOW}s)"
 
           # Fetch the full issue title and body via API (avoids env-var size limits
           # and injection risks from untrusted content in the event payload).
-          issue_json=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '{title:.title,body:(.body//""),createdAt:.created_at}' 2>/dev/null || echo '{}')
+          issue_json=$(_dedup_gh_api_json '{}' "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '{title:.title,body:(.body//""),createdAt:.created_at}' 2>/dev/null)
           ISSUE_TITLE=$(printf '%s' "$issue_json" | jq -r '.title // ""')
           ISSUE_BODY=$(printf '%s' "$issue_json" | jq -r '.body // ""')
           ISSUE_CREATED_AT_RESOLVED=$(printf '%s' "$issue_json" | jq -r '.createdAt // ""')
@@ -373,10 +395,10 @@ jobs:
           # can be backed by GitHub search/indexing and miss an issue opened only
           # seconds earlier, which is exactly the race this server-side guard
           # exists to close (GH#24840 duplicate of GH#24839).
-          issues_json=$(gh api "repos/${REPO}/issues" \
-            -f state=open -f creator="$ISSUE_AUTHOR" -f since="$since_iso" -f per_page=100 \
+          issues_json=$(_dedup_gh_api_json '[]' "repos/${REPO}/issues" \
+            --method GET -f state=open -f creator="$ISSUE_AUTHOR" -f since="$since_iso" -f per_page=100 \
             --jq '[.[] | select(.pull_request | not) | {number,title,body:(.body//""),createdAt:.created_at}]' \
-            2>/dev/null || echo "[]")
+            2>/dev/null)
 
           cand_count=$(printf '%s' "$issues_json" | jq 'length')
           echo "[dedup] Found ${cand_count} open issue(s) by @${ISSUE_AUTHOR}"


### PR DESCRIPTION
## Summary

- Fix server-side issue dedup so failed `gh api` calls cannot append fallback JSON to partial stdout and create multi-document streams like `3\n0`.
- Force the duplicate candidate fetch to use `--method GET` with query parameters.
- Add regression coverage for the API fallback and GET candidate fetch.

## Root cause

Runs for #25486/#25487 showed `cand_count` became `3\n0` after `gh api ... || echo "[]"` appended fallback output to partial successful stdout from a non-zero command. Numeric comparisons then errored, the loop never evaluated prior same-title issues, and the model-created duplicates remained open until manual closure.

## Verification

- `bash .agents/scripts/tests/test-issue-sync-title-dedup.sh`
- `shellcheck .agents/scripts/tests/test-issue-sync-title-dedup.sh`
- `.agents/scripts/linters-local.sh` (passes; existing markdown/complexity findings reported as advisory by the script)
- `actionlint .github/workflows/issue-sync-reusable.yml` (ran when available)

Refs #25485, #25486, #25487.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 17m and 145,324 tokens on this with the user in an interactive session.