### PR TITLE
GH#25489: classify in-progress message intent

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -45,6 +45,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
 - Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
+- During in-progress work, classify new user messages before acting: immediate correction/steerage changes the active plan; supplemental context is retained/applied when relevant; follow-up work becomes a todo after the current work reaches a safe pause or completion point.
 - Drive to verified completion. Run relevant tests/lint/build before claiming done; if not verified, say so.
 - Never present intent as completed work. Every claim needs proof: path, command result, PR/issue number, or metric.
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.


### PR DESCRIPTION
## Summary

Added a concise always-loaded AGENTS.md rule for classifying new user messages during in-progress work as immediate steerage, supplemental context, or follow-up work.

## Files Changed

.agents/AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint .agents/AGENTS.md; secretlint .agents/AGENTS.md; .agents/scripts/verify-agent-discoverability.sh --agents-dir .agents; .agents/scripts/linters-local.sh reached Markdown/secret/TOON/frontmatter/policy gates successfully before timing out later in broad shell portability checks unrelated to this Markdown-only change.

Resolves #25489


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.2 with gpt-5.5 spent 28m and 108,461 tokens on this with the user in an interactive session.