### PR TITLE
GH#25485: prefer npm for OpenCode installs

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -678,22 +678,42 @@ check_python_version() {
 
 # Install a package globally via npm or bun, with sudo when needed on Linux.
 # Usage: npm_global_install "package-name" OR npm_global_install "package@version"
-# Uses bun if available (no sudo needed), falls back to npm.
+# OpenCode uses npm first when available so stale bun installs are not recreated.
+# Other packages keep the historic bun-first policy, then fall back to npm.
 # On Linux with apt-installed npm, automatically prepends sudo.
 # Returns: 0 on success, 1 on failure
+_npm_global_install_via_npm() {
+	local pkg="$1"
+
+	# npm global installs need sudo on Linux when prefix dir isn't writable
+	if [[ "$(uname)" != "Darwin" ]] && [[ ! -w "$(npm config get prefix 2>/dev/null)/lib" ]]; then
+		sudo npm install -g "$pkg"
+	else
+		npm install -g "$pkg"
+	fi
+	return $?
+}
+
 npm_global_install() {
 	local pkg="$1"
+
+	if [[ "$pkg" == opencode-ai || "$pkg" == opencode-ai@* ]]; then
+		if command -v npm >/dev/null 2>&1; then
+			_npm_global_install_via_npm "$pkg"
+			return $?
+		elif command -v bun >/dev/null 2>&1; then
+			bun install -g "$pkg"
+			return $?
+		else
+			return 1
+		fi
+	fi
 
 	if command -v bun >/dev/null 2>&1; then
 		bun install -g "$pkg"
 		return $?
 	elif command -v npm >/dev/null 2>&1; then
-		# npm global installs need sudo on Linux when prefix dir isn't writable
-		if [[ "$(uname)" != "Darwin" ]] && [[ ! -w "$(npm config get prefix 2>/dev/null)/lib" ]]; then
-			sudo npm install -g "$pkg"
-		else
-			npm install -g "$pkg"
-		fi
+		_npm_global_install_via_npm "$pkg"
 		return $?
 	else
 		return 1

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -2146,10 +2146,10 @@ _setup_opencode_force_heal() {
 	print_info "Forcing reinstall of $install_pkg to heal bin collision (t2891)..."
 
 	local installer=""
-	if command -v bun >/dev/null 2>&1; then
-		installer="bun"
-	elif command -v npm >/dev/null 2>&1; then
+	if command -v npm >/dev/null 2>&1; then
 		installer="npm"
+	elif command -v bun >/dev/null 2>&1; then
+		installer="bun"
 	else
 		print_warning "Neither bun nor npm found — cannot heal OpenCode binary"
 		print_info "Install Node.js or Bun first, then re-run 'aidevops update'"
@@ -2157,8 +2157,8 @@ _setup_opencode_force_heal() {
 	fi
 
 	local install_timeout="${AIDEVOPS_OPENCODE_INSTALL_TIMEOUT:-180}"
-	# npm_global_install is the shared generic helper; despite its historic
-	# name, it uses bun when available and falls back to npm.
+	# npm_global_install intentionally uses npm first for opencode-ai when npm is
+	# available, falling back to bun only for bun-only systems.
 	if run_with_spinner "Reinstalling OpenCode via $installer (heal)" _setup_opencode_timeout_cmd "$install_timeout" npm_global_install "$install_pkg"; then
 		print_success "OpenCode reinstalled via $installer"
 	else
@@ -2242,13 +2242,13 @@ setup_opencode_cli() {
 
 	# Missing → first-time install path (preserves prompt for interactive UX).
 	local installer=""
-	if command -v bun >/dev/null 2>&1; then
-		installer="bun"
-	elif command -v npm >/dev/null 2>&1; then
+	if command -v npm >/dev/null 2>&1; then
 		installer="npm"
+	elif command -v bun >/dev/null 2>&1; then
+		installer="bun"
 	else
 		print_warning "Neither bun nor npm found - cannot install OpenCode"
-		print_info "Install Node.js first, then re-run setup"
+		print_info "Install Node.js or Bun first, then re-run setup"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -19,9 +19,14 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TOOL_INSTALL="$REPO_ROOT/.agents/scripts/setup/modules/tool-install.sh"
+SETUP_COMMON="$REPO_ROOT/.agents/scripts/setup/_common.sh"
 
 if [[ ! -f "$TOOL_INSTALL" ]]; then
 	echo "FAIL: cannot find $TOOL_INSTALL" >&2
+	exit 1
+fi
+if [[ ! -f "$SETUP_COMMON" ]]; then
+	echo "FAIL: cannot find $SETUP_COMMON" >&2
 	exit 1
 fi
 
@@ -75,6 +80,20 @@ extract_functions() {
 	return 0
 }
 extract_functions
+
+extract_common_npm_global_install() {
+	awk '
+		/^_npm_global_install_via_npm\(\)/, /^}$/ { print; next }
+		/^npm_global_install\(\)/, /^}$/ { print; next }
+	' "$SETUP_COMMON" >"$SANDBOX/common-extract.sh"
+	if ! grep -q "^_npm_global_install_via_npm()" "$SANDBOX/common-extract.sh" || \
+		! grep -q "^npm_global_install()" "$SANDBOX/common-extract.sh"; then
+		echo "FAIL: extraction did not capture npm_global_install" >&2
+		exit 1
+	fi
+	return 0
+}
+extract_common_npm_global_install
 
 source_extracted() {
 	# shellcheck disable=SC2317
@@ -390,6 +409,41 @@ else
 	assert_eq "hanging auto-heal returns within bound" "elapsed<=12" "elapsed=${elapsed7}"
 fi
 
+# --- Test 7b: first install chooses npm when npm and bun are both present ----
+echo "Test 7b: setup_opencode_cli first install prompt prefers npm over bun"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved" "$SANDBOX/bin/opencode"
+cat >"$SANDBOX/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$SANDBOX/bin/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SANDBOX/bin/npm" "$SANDBOX/bin/bun"
+(
+	source_extracted
+	setup_prompt() {
+		local _var="$1"
+		local _prompt="$2"
+		local _default="$3"
+		printf '%s\n' "$_prompt"
+		printf -v "$_var" '%s' "$_default"
+		return $?
+	}
+	export -f setup_prompt 2>/dev/null || true
+	export PATH="$SANDBOX/bin:/usr/bin:/bin"
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+) >"$SANDBOX/out7b" 2>&1
+rc7b=$(grep '^rc=' "$SANDBOX/out7b" | tail -1)
+npm_prompt7b=$(grep -c "Install OpenCode via npm" "$SANDBOX/out7b" || true)
+bun_prompt7b=$(grep -c "Install OpenCode via bun" "$SANDBOX/out7b" || true)
+assert_eq "first install npm+bun rc" "rc=0" "$rc7b"
+assert_eq "first install prompt uses npm" "1" "$npm_prompt7b"
+assert_eq "first install prompt avoids bun" "0" "$bun_prompt7b"
+
 # --- Test 8: install failure hint matches selected installer -----------------
 echo "Test 8: setup_opencode_cli install failure omits hard-coded sudo npm hint"
 rm -f "$HOME/.aidevops/.opencode-bin-resolved" "$SANDBOX/bin/opencode" "$SANDBOX/bin/bun"
@@ -456,6 +510,52 @@ sudo_hint9=$(grep -c "sudo npm install" "$SANDBOX/out9" || true)
 assert_eq "homebrew remediation rc" "rc=0" "$rc9"
 assert_eq "homebrew remediation uses brew" "1" "$brew_hint9"
 assert_eq "homebrew remediation has no sudo npm hint" "0" "$sudo_hint9"
+
+# --- Test 10: shared installer policy uses npm first for OpenCode -----------
+echo "Test 10: npm_global_install prefers npm for opencode-ai when bun also exists"
+mkdir -p "$SANDBOX/install-policy/bin" "$SANDBOX/install-policy/prefix/lib"
+cat >"$SANDBOX/install-policy/bin/npm" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "config" && "\${2:-}" == "get" && "\${3:-}" == "prefix" ]]; then
+	printf '%s\n' "$SANDBOX/install-policy/prefix"
+	exit 0
+fi
+printf 'npm %s\n' "\$*" >>"$SANDBOX/install-policy/calls"
+exit 0
+EOF
+cat >"$SANDBOX/install-policy/bin/bun" <<EOF
+#!/usr/bin/env bash
+printf 'bun %s\n' "\$*" >>"$SANDBOX/install-policy/calls"
+exit 0
+EOF
+chmod +x "$SANDBOX/install-policy/bin/npm" "$SANDBOX/install-policy/bin/bun"
+(
+	# shellcheck source=/dev/null
+	source "$SANDBOX/common-extract.sh"
+	export PATH="$SANDBOX/install-policy/bin:/usr/bin:/bin"
+	npm_global_install opencode-ai@latest
+) >"$SANDBOX/out10" 2>&1
+assert_eq "opencode-ai with npm+bun uses npm" "npm install -g opencode-ai@latest" "$(cat "$SANDBOX/install-policy/calls")"
+
+echo "Test 10b: npm_global_install keeps bun-first policy for other packages"
+rm -f "$SANDBOX/install-policy/calls"
+(
+	# shellcheck source=/dev/null
+	source "$SANDBOX/common-extract.sh"
+	export PATH="$SANDBOX/install-policy/bin:/usr/bin:/bin"
+	npm_global_install serve-sim@latest
+) >"$SANDBOX/out10b" 2>&1
+assert_eq "generic packages still use bun first" "bun install -g serve-sim@latest" "$(cat "$SANDBOX/install-policy/calls")"
+
+echo "Test 10c: npm_global_install falls back to bun for opencode-ai without npm"
+rm -f "$SANDBOX/install-policy/calls" "$SANDBOX/install-policy/bin/npm"
+(
+	# shellcheck source=/dev/null
+	source "$SANDBOX/common-extract.sh"
+	export PATH="$SANDBOX/install-policy/bin:/usr/bin:/bin"
+	npm_global_install opencode-ai@latest
+) >"$SANDBOX/out10c" 2>&1
+assert_eq "opencode-ai bun-only fallback" "bun install -g opencode-ai@latest" "$(cat "$SANDBOX/install-policy/calls")"
 
 echo ""
 echo "===== Results: $PASS passed, $FAIL failed ====="

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1055,9 +1055,8 @@ _help_management_sections() {
 	echo "  aidevops skills categories   # List all categories"
 	echo ""
 	echo "Installation:"
-	echo "  npm install -g aidevops && aidevops update      # via npm (recommended)"
-	echo "  brew install marcusquinn/tap/aidevops && aidevops update  # via Homebrew"
-	echo "  bash <(curl -fsSL https://aidevops.sh/install)                     # manual"
+	echo "  brew install marcusquinn/tap/aidevops && aidevops update  # macOS/Homebrew"
+	echo "  npm install -g aidevops && aidevops update                # Linux/cross-platform"
 	echo ""
 	echo "Documentation: https://github.com/marcusquinn/aidevops"
 	return 0


### PR DESCRIPTION
## Summary

Prefer npm for opencode-ai setup/heal paths when npm is available, keep bun fallback for bun-only systems, and align aidevops.sh install guidance with Homebrew-on-macOS/npm-cross-platform recommendations.

## Files Changed

.agents/scripts/setup/_common.sh,.agents/scripts/setup/modules/tool-install.sh,.agents/scripts/tests/test-tool-install-opencode.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-tool-install-opencode.sh (38 passed); .agents/scripts/tests/test-tool-version-check-opencode.sh (4 passed); shellcheck on changed shell files; .agents/scripts/linters-local.sh passed blocking gates but timed during later shell portability after advisory-only markdown/ratchet warnings.

Resolves #25485


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.3 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 56m and 193,356 tokens on this with the user in an interactive session.