### PR TITLE
t17997: docs: define vault security architecture

### DIFF
--- a/.agents/reference/vault.md
+++ b/.agents/reference/vault.md
@@ -1,0 +1,328 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Aidevops Vault Security Architecture RFC
+
+> **Status:** RFC. This records the canonical threat model and architecture
+> constraints for future Vault implementation work. It does not claim that every
+> control described here exists today.
+
+<!-- AI-CONTEXT-START -->
+
+**TL;DR:** Aidevops Vault is the policy and architecture model for protecting
+agent memory, history, workspace, knowledge, mail, metadata, audits, device
+state, and sync collections. Current tools such as gopass, SOPS, and gocryptfs
+cover specific storage needs; Vault defines how protected data is classified,
+routed, encrypted, synced, audited, and withheld from third-party AI providers.
+
+**Hard limits:** Vault does not protect data from malware/root access while
+unlocked, provider-side AI logs after data is sent to a third-party model,
+unsupported runtime caches, or OS crash dumps/swap/snapshots created before
+encryption. Future local LLM mode reduces provider exposure but does not reduce
+local host compromise risk.
+
+<!-- AI-CONTEXT-END -->
+
+## 1. Goals
+
+Vault exists to give every later encryption, sync, remote unlock, UI, and agent
+behaviour change one decision record.
+
+It must:
+
+- Classify aidevops protected data consistently across local machines, third-
+  party VPS hosts, public/private Git transports, object storage, secure
+  messaging, third-party AI providers, and future local LLM runtimes.
+- Protect sensitive data at rest on machines and untrusted transports.
+- Minimise plaintext lifetime and make unlocked state visible and auditable.
+- Preserve agent usefulness without silently sending restricted data to
+  providers that are not allowed to see it.
+- Support multi-device operation without trusting transport providers.
+- Prefer audited primitives and maintained libraries over custom cryptography.
+
+Vault must not:
+
+- Invent new cryptographic algorithms or unaudited protocols.
+- Treat Git, object storage, SimpleX-style messaging, SSH, Tailscale, public
+  GitHub, private GitHub, or VPS disks as trusted merely because they are
+  authenticated.
+- Ask agents or users to paste passphrases, recovery keys, or raw secrets into
+  AI chat, command arguments, environment variables, logs, issue comments, test
+  fixtures, or shell history.
+
+## 2. Protected Data Classes
+
+| Class | Examples | Default label | Default storage intent |
+|---|---|---|---|
+| Memory | Cross-session lessons, user preferences, task history | `confidential` | Encrypted local store; redacted excerpts only when provider-allowed |
+| Session/history | Chat transcripts, tool outputs, runtime state, compacted checkpoints | `confidential` | Encrypted at rest; short retention; provider routing checks before reuse |
+| Workspace | Draft files, generated reports, temporary data, cloned task context | `internal` or `confidential` | Per-project encrypted workspace for sensitive jobs |
+| Knowledge | Indexed docs, embeddings, search cache, project notes | `internal` | Encrypted when private or client-derived; public docs may be public |
+| Mail/messages | Email, chat, support tickets, outreach drafts, group messages | `client-confidential` when external-party specific | Encrypted mail/message cache; explicit provider routing |
+| Config metadata | Repo registry, runner identity, model preferences, enabled features | `internal` | Local config store; avoid secret values; encrypt when correlated with clients |
+| Audit logs | Security operations, unlock/lock events, sync decisions, routing denials | `confidential` | Append-only hash-chained log; replicated encrypted summaries |
+| Device registry | Device public keys, trust state, revocation, last-seen audit heads | `confidential` | Signed registry; encrypted backup; public keys may sync over untrusted media |
+| Sync collections | Encrypted bundles, vector clocks, collection manifests, tombstones | `confidential` | End-to-end encrypted before Git/object/message transport |
+
+Data derived from a protected class inherits the stricter label unless a human-
+reviewed transformation explicitly declassifies it. Summaries, embeddings,
+filenames, audit metadata, and issue titles can leak sensitive facts and are not
+automatically safe.
+
+## 3. Classification Labels and Routing Semantics
+
+Vault labels are additive. The strictest applicable label controls storage,
+sync, and model routing.
+
+| Label | Meaning | Storage/sync rule | Provider rule |
+|---|---|---|---|
+| `public` | Intended for public disclosure | May be stored and synced in plaintext | May be sent to providers |
+| `internal` | Aidevops operational data not intended for publication | Encrypt at rest when practical; avoid public transports in plaintext | Provider-allowed only when task-relevant |
+| `confidential` | Sensitive user/project data | Encrypt at rest and in transit; redact logs | Send only if `provider-allowed` also applies |
+| `client-confidential` | Data tied to a client, customer, private repo, or third party | Encrypt and isolate by tenant/context | Do not send unless the provider and task are approved for that client/context |
+| `secret` | Credentials, tokens, passphrases, private keys, recovery material | Store only in secret manager or hardware-backed key storage | Never send to AI providers or logs |
+| `local-only` | Must remain on the current device | No sync except encrypted backup explicitly approved for this class | Never send to remote providers |
+| `provider-allowed` | Approved to include in third-party model prompts/tool context | May be sent according to provider policy and task need | Allowed, but still minimise and redact |
+| `local-LLM-only` | Model processing allowed only on a local runtime | Sync only as encrypted data; decrypt on trusted local host | Route only to local model workers |
+
+Routing decisions should evaluate labels before context loading. If a task needs
+restricted data, the agent should prefer local deterministic tools, local LLM
+mode where available, or a decision-ready prompt that asks the user to run a
+local command rather than exposing the data.
+
+## 4. Threat Environments
+
+### 4.1 Third-party VPS cloned disks, snapshots, and backups
+
+Assume the provider or attacker can copy powered-off disks, stale snapshots,
+volume backups, object-store data, and hypervisor-level images. Vault protects
+locked data with encryption at rest and treats provider storage as untrusted.
+
+Required properties:
+
+- Key material required to decrypt protected data is not stored beside the
+  ciphertext on the VPS.
+- Snapshot-safe setup writes ciphertext before sync/backup and avoids leaving
+  plaintext staging files.
+- Recovery material is never placed in VPS environment variables, shell history,
+  user-data scripts, cloud-init logs, or issue comments.
+
+### 4.2 Compromised unattended server
+
+Assume an unattended machine may be remotely compromised while Vault is locked
+or unlocked.
+
+- Locked state should deny plaintext access without local unlock material.
+- Unlocked state is high risk: malware/root can read files, process memory,
+  sockets, model prompts, and mounted filesystems.
+- Remote operation should prefer lock, revoke, rotate, and unlock-request flows.
+  True remote unlock is default-disabled because it risks turning any remote
+  channel compromise into data compromise.
+
+### 4.3 Local machine physical theft or remote compromise
+
+Assume laptops/desktops may be stolen, imaged, or infected.
+
+- Full-disk encryption remains mandatory baseline; Vault protects application-
+  layer stores when the OS account is offline or locked.
+- Passphrases must be memory-hard and entered through local secure prompts.
+- Recovery must be possible without training users to store passphrases in chat,
+  docs, screenshots, or plaintext notes.
+- While unlocked, local malware/root access defeats Vault confidentiality.
+
+### 4.4 Public/private Git transports and object storage
+
+Assume all Git remotes and object stores are untrusted transport, regardless of
+access controls.
+
+- Public Git must never receive plaintext protected data.
+- Private Git may carry encrypted Vault bundles, SOPS-encrypted structured
+  config, public device keys, and signed metadata, but must not be treated as a
+  trust boundary.
+- Commit history is durable; never commit plaintext data expecting later removal
+  to erase exposure.
+
+### 4.5 Third-party AI providers
+
+Assume any prompt, completion, tool result, system context, screenshot, or file
+attachment sent to a third-party provider is decrypted to that provider for the
+duration and handling defined by the provider relationship.
+
+Vault can reduce what is sent; it cannot encrypt data while still asking a
+remote model to reason over plaintext. Provider routing must therefore be
+explicit:
+
+- `secret`, `local-only`, and `local-LLM-only` data are not sent to remote
+  providers.
+- `confidential` and `client-confidential` data require `provider-allowed` plus
+  task necessity.
+- Redaction and summarisation are preferred when they preserve task quality.
+- Provider-side AI logs, abuse-monitoring copies, operator access, retention, and
+  model-training policy are outside Vault's technical control.
+
+### 4.6 Future local LLM mode
+
+Local LLM mode reduces third-party provider exposure by keeping prompts and
+outputs on a trusted local machine. It does not solve:
+
+- Local malware/root access.
+- Plaintext runtime caches, model server logs, swap, crash dumps, screenshots, or
+  terminal scrollback.
+- Model quality failures, prompt injection, or unsafe tool use.
+
+Local LLM mode is a routing target, not a universal declassification mechanism.
+
+## 5. Trust Boundaries
+
+| Boundary | Trusted for | Not trusted for |
+|---|---|---|
+| User with passphrase/recovery material | Authorising unlock, recovery, device trust | Keeping secrets safe after pasting into AI chat or shell history |
+| Local OS account | Running helpers and enforcing file permissions | Protection against root, malware, crash dumps, swap, screenshots |
+| Hardware/OS keychain | Wrapping local keys when available | Cross-device recovery by itself |
+| gopass/SOPS/gocryptfs | Current storage primitives for specific scopes | Global policy, device trust, provider routing, fleet sync |
+| Git/object/message transports | Delivery, versioning, conflict visibility | Confidentiality, integrity without signatures, deletion guarantees |
+| Third-party AI provider | Reasoning over allowed plaintext | Keeping disallowed protected data private from provider systems |
+| Local LLM runtime | Provider-avoiding inference | Host compromise resistance or guaranteed output correctness |
+| Remote VPS runner | Automation while locked/unlocked according to policy | Storing keys beside ciphertext or silently unlocking sensitive data |
+
+## 6. Cryptographic Design Constraints
+
+Vault implementations must use maintained, audited libraries and conservative
+protocols:
+
+- **Passphrase KDF:** Argon2id with interactive parameters calibrated per device;
+  store parameters with the encrypted header. Use a migration path for parameter
+  increases.
+- **Envelope encryption:** Generate random data-encryption keys per collection or
+  object group; wrap them with user/device key-encryption keys.
+- **AEAD:** Prefer XChaCha20-Poly1305 for nonce-misuse resistance and platform
+  portability, or AES-256-GCM through audited libraries where hardware support
+  and nonce discipline are strong.
+- **Device identities:** Each trusted device has a signing key and an encryption
+  key. Registry updates, trust changes, sync manifests, lock/unlock requests,
+  and audit-head claims are signed.
+- **Audit integrity:** Security-relevant events append to a hash chain. Replicated
+  audit summaries include previous hash, event hash, device signature, and
+  monotonic local sequence number.
+- **Randomness:** Use OS CSPRNG only. Never derive nonces from timestamps alone.
+- **No custom crypto:** Do not design new ciphers, KDFs, ad-hoc MACs, or hidden
+  transport encryption. Compose standard primitives using reviewed patterns.
+- **Key rotation:** Support rewrapping collection keys for device revocation and
+  KDF upgrades without rewriting every payload when practical.
+
+## 7. Phased Architecture
+
+### Phase 0: RFC and labels
+
+- Document protected data classes, labels, threat environments, and routing
+  semantics in this RFC.
+- Add workflow docs for first-use setup and fleet operation.
+- Keep always-loaded guidance short; point here instead of expanding
+  `.agents/AGENTS.md`.
+
+### Phase 1: Local encrypted stores
+
+- Inventory memory, session/history, workspace, knowledge, mail/message, config,
+  and audit storage paths.
+- Map each path to a label and retention policy.
+- Use existing primitives where they fit: gopass for secrets, SOPS for encrypted
+  structured config in Git, and gocryptfs for directory-at-rest protection.
+- Add explicit lock/unlock status and safe local prompts. Do not accept
+  passphrases in AI context.
+
+### Phase 2: Device registry and encrypted sync
+
+- Create a signed device registry with trust states: `pending`, `trusted`,
+  `limited`, `revoked`, and `retired`.
+- Sync only encrypted collections and signed manifests over untrusted transports.
+- Include vector clocks or comparable conflict metadata for collection merges.
+- Replicate hash-chained audit summaries so devices can detect missing or forked
+  history.
+
+### Phase 3: Remote lock and unlock-request
+
+- Implement remote lock first: a trusted device can request that another device
+  unmount stores, stop workers that require protected data, and record an audit
+  event.
+- Implement unlock-request second: a remote device can ask for approval, but the
+  passphrase/recovery material stays local to the approving device or hardware
+  authenticator.
+- Keep true remote unlock default-disabled. Enabling it requires an explicit
+  threat-model exception, strong device-bound encryption, short-lived grants,
+  clear audit events, and a local kill switch.
+
+### Phase 4: Provider-aware routing and local LLM mode
+
+- Gate context loading and tool-output reuse on Vault labels.
+- Route `local-LLM-only` data to local model workers when available.
+- For remote providers, send the minimum provider-allowed context needed for the
+  task and record redaction/routing decisions in audit metadata.
+
+## 8. Protects
+
+Vault is intended to protect against:
+
+- Offline disk theft, copied home directories, cloned VPS disks, stale snapshots,
+  and object-store/Git transport disclosure when data is locked and encrypted.
+- Accidental plaintext commits or sync uploads when routing and storage policies
+  are enforced.
+- Cross-device tampering with sync manifests, device trust state, and audit
+  history when signatures and hash chains are verified.
+- Provider overexposure by denying or redacting disallowed context before it is
+  sent to third-party AI systems.
+- Ambiguous future implementation by defining accepted primitives, labels, and
+  trust boundaries up front.
+
+## 9. Does Not Protect
+
+Vault does not protect against:
+
+- Malware, root access, malicious browser extensions, or debugger access on a
+  host while protected data is unlocked.
+- Third-party AI provider logs, retention, operator access, abuse monitoring, or
+  training policy after plaintext has been sent to that provider.
+- Runtime caches not yet integrated with Vault, unsupported tool logs, terminal
+  scrollback, screenshots, crash dumps, swap, hibernation files, or backups made
+  before encryption.
+- Weak passphrases, passphrases pasted into chat, recovery material committed to
+  Git, or secrets passed through command arguments/environment variables.
+- Compromised dependencies or malicious code that runs inside the trusted local
+  process while data is unlocked.
+- Deletion guarantees from Git history, object storage versioning, provider
+  backups, or synced replicas.
+
+## 10. Relationship to Current Credential Tools
+
+Current credential tooling remains valid and should be composed under the Vault
+model:
+
+- `tools/credentials/gopass.md`: individual secrets such as API keys, tokens, and
+  passwords. Values never enter AI context.
+- `tools/credentials/sops.md`: structured secret-bearing files that must be
+  committed to Git in encrypted form.
+- `tools/credentials/gocryptfs.md`: directory-level encryption at rest for
+  sensitive local workspaces and intermediate files.
+- `tools/credentials/encryption-stack.md`: decision guide for choosing the
+  smallest current tool. Vault is the framework-level classification, routing,
+  trust, sync, and audit architecture.
+
+## 11. Operational Rules for Future Work
+
+- Every Vault implementation issue must name the data classes it touches, labels
+  it enforces, trust boundary crossed, and verification command.
+- Security-sensitive Vault work must include a negative test or checklist proving
+  passphrases/secrets are not accepted through chat, arguments, environment
+  variables, logs, issue comments, or fixtures.
+- New always-loaded guidance should be a short pointer to this RFC or the Vault
+  workflows, not a full rule expansion.
+- Any proposal for true remote unlock must start default-disabled and include a
+  safer remote-lock/unlock-request alternative.
+
+## Related
+
+- `workflows/vault-setup.md` -- first-use setup, passphrase, recovery, migration,
+  and safe prompts.
+- `workflows/vault-fleet.md` -- device trust, sync, secure messaging, remote
+  lock/unlock-request, and audit replication.
+- `tools/credentials/encryption-stack.md` -- current gopass/SOPS/gocryptfs
+  decision guide.

--- a/.agents/tools/credentials/encryption-stack.md
+++ b/.agents/tools/credentials/encryption-stack.md
@@ -26,16 +26,23 @@ Use the smallest tool that fits the problem:
 1. Single secret → `aidevops secret set NAME`
 2. Structured file you must commit → `sops-helper.sh encrypt file.enc.yaml`
 3. Sensitive directory at rest → `gocryptfs-helper.sh create vault-name`
+4. Framework-wide protected data policy → `reference/vault.md`
 
 | Tool | Best for | Scope | Git-safe | AI-safe | Docs |
 |------|----------|-------|----------|---------|------|
 | **gopass** | API keys, tokens, passwords | Per secret | No (separate store) | Yes (subprocess injection) | `tools/credentials/gopass.md` |
 | **SOPS** | Structured config files with secrets | Per file | Yes (encrypted in repo) | Yes (stdout only) | `tools/credentials/sops.md` |
 | **gocryptfs** | Sensitive directories at rest | Per directory | No (filesystem overlay) | Yes (mount/unmount) | `tools/credentials/gocryptfs.md` |
+| **Vault RFC** | Protected data classes, routing, trust, sync, audit | Framework-wide | Policy-dependent | Provider-gated | `reference/vault.md` |
 
 **Commands:** `aidevops secret set NAME` / `aidevops secret run CMD` (gopass) · `sops-helper.sh encrypt config.enc.yaml` (SOPS) · `gocryptfs-helper.sh create vault-name` (gocryptfs)
 
 **Storage:** gopass → `~/.local/share/gopass/stores/root/aidevops/` (fallback: `~/.config/aidevops/credentials.sh`, 600 perms) · SOPS → encrypted files in git (age preferred, GPG, AWS/GCP/Azure KMS) · gocryptfs → `~/.aidevops/.agent-workspace/vaults/` (AES-256-GCM)
+
+**Vault model:** `reference/vault.md` defines protected data classes, labels,
+provider routing, trust boundaries, and future encrypted sync. It does not
+replace gopass/SOPS/gocryptfs today; it explains when each primitive is the
+right building block.
 
 <!-- AI-CONTEXT-END -->
 
@@ -92,7 +99,28 @@ sops updatekeys config.enc.yaml
 4. **Key separation** -- each tool uses independent key material.
 5. **Audit trail** -- gopass and SOPS changes are git-versioned.
 
+## Relationship to Aidevops Vault
+
+Vault is the framework-level security model for memory, sessions, workspaces,
+knowledge, mail/messages, config metadata, audit logs, device registry, and sync
+collections. The existing tools remain the current implementation choices for
+specific storage scopes:
+
+- **gopass** stores individual `secret` values. Agents use `aidevops secret` so
+  values stay out of AI context.
+- **SOPS** stores structured secret-bearing files that must be committed to Git
+  in encrypted form.
+- **gocryptfs** protects sensitive directories at rest on local machines.
+- **Vault** defines classification labels, provider routing, fleet trust,
+  encrypted sync, and audit constraints across all protected data classes.
+
+For first-use setup and fleet behaviour, use `workflows/vault-setup.md` and
+`workflows/vault-fleet.md`.
+
 ## Related
 
+- `reference/vault.md` -- Aidevops Vault threat model and architecture RFC
+- `workflows/vault-setup.md` -- Vault first-use setup and migration workflow
+- `workflows/vault-fleet.md` -- Vault device trust and sync workflow
 - `tools/credentials/api-key-setup.md` -- API key setup guide
 - `tools/credentials/multi-tenant.md` -- Multi-tenant credential storage

--- a/.agents/workflows/vault-fleet.md
+++ b/.agents/workflows/vault-fleet.md
@@ -1,0 +1,230 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Vault Fleet Workflow
+
+> **Audience:** agents and maintainers designing multi-device Vault operation,
+> secure messaging, encrypted sync, remote lock/unlock-request, and audit
+> replication. Current status is RFC guidance; implementation must conform to
+> `reference/vault.md`.
+
+<!-- AI-CONTEXT-START -->
+
+**TL;DR:** Treat every transport as untrusted. Sync encrypted collections and
+signed manifests only. Device trust is explicit and revocable. Remote lock is
+safe to prioritise; unlock-request is safer than true remote unlock. True remote
+unlock remains default-disabled unless a future implementation proves a narrow,
+audited, short-lived, device-bound exception.
+
+<!-- AI-CONTEXT-END -->
+
+## 1. Fleet Model
+
+A Vault fleet is a set of user-approved devices that can hold encrypted Vault
+collections and prove their identity with signed metadata.
+
+Device trust states:
+
+| State | Meaning | Allowed operations |
+|---|---|---|
+| `pending` | Device has requested trust but is not approved | Publish public keys and request metadata only |
+| `trusted` | Full member of the user's fleet | Sync allowed collections, sign audits, approve requests |
+| `limited` | Scoped access for a project, tenant, or time window | Sync only assigned collections and labels |
+| `revoked` | Device must no longer receive new keys or data | Read old ciphertext only; cannot update trusted state |
+| `retired` | Gracefully removed device | Historical audit identity only |
+
+Every registry update must be signed by an already trusted device or a recovery
+authority defined during setup.
+
+## 2. Device Onboarding
+
+Safe onboarding pattern:
+
+1. New device creates local signing and encryption key pairs.
+2. New device publishes public keys and a short human-verifiable fingerprint.
+3. Existing trusted device verifies the fingerprint over an authenticated local
+   channel or user-mediated check.
+4. Existing trusted device signs a registry update granting `trusted` or
+   `limited` state.
+5. Existing trusted device rewraps only the collection keys the new device may
+   access.
+6. Both devices append audit events with the registry version and audit-head
+   hashes they observed.
+
+Do not approve devices solely because they can reach the same Git remote,
+message channel, object bucket, SSH host, Tailscale network, or VPS account.
+
+## 3. Sync Collections
+
+Sync collections are encrypted bundles plus signed metadata. They may represent
+memory, session/history, workspace, knowledge, mail/messages, config metadata,
+audit logs, device registry snapshots, or other future Vault stores.
+
+Each collection manifest should include:
+
+- Collection ID and data class.
+- Classification labels.
+- Format version.
+- Encrypted data key references per authorised device.
+- Vector clock or equivalent merge metadata.
+- Previous manifest hash.
+- Payload hashes.
+- Author device ID and signature.
+
+Payloads should be encrypted before transport with envelope encryption and AEAD
+as defined in `reference/vault.md`.
+
+## 4. Transport Rules
+
+Treat all transports as untrusted delivery mechanisms:
+
+- **Public Git:** encrypted bundles only; no protected plaintext, private paths,
+  client names, or secret identifiers.
+- **Private Git:** encrypted bundles, SOPS files, public device keys, and signed
+  manifests are acceptable; do not rely on private repo ACLs for confidentiality.
+- **Object storage:** encrypted payloads and signed manifests only; versioned
+  deletes are not erasure.
+- **Secure messaging:** useful for device requests, audit-head exchange, and
+  encrypted payload relay; still verify signatures and replay protection.
+- **SSH/Tailscale/VPN:** authenticated transport is not a Vault trust boundary;
+  payload encryption and signatures still apply.
+- **Third-party VPS:** may store locked ciphertext and run limited automation;
+  must not store unlock material beside ciphertext.
+
+## 5. Remote Lock
+
+Remote lock is the first remote-control feature to implement because it reduces
+exposure without transferring unlock secrets.
+
+A valid remote-lock request:
+
+- Is signed by a trusted device.
+- Names target device(s), collection(s), reason, and timestamp.
+- Uses replay protection.
+- Causes the target to close mounts/handles, stop workers that require protected
+  data, clear plaintext temp files where practical, and append an audit event.
+- Returns a signed acknowledgement with the target's new lock status and audit
+  head.
+
+Remote lock must be safe to process over untrusted transports because the action
+is protective. Denial-of-service risk remains, so rate limits and user-visible
+audit are still required.
+
+## 6. Unlock-Request
+
+Unlock-request is the safer remote access pattern.
+
+Flow:
+
+1. Remote device sends a signed request naming the collection, task, duration,
+   labels, and reason.
+2. Trusted approving device shows the request locally, including provider-routing
+   implications.
+3. User or local policy approves, narrows, or denies the request.
+4. Approval rewraps only the required collection keys for the requester and a
+   short duration/scope, or instructs the user to unlock locally on the target.
+5. Both sides append audit events.
+
+The passphrase and recovery material never leave the approving device or
+hardware-backed flow. Agents must not ask users to paste the passphrase to make
+an unlock-request succeed.
+
+## 7. True Remote Unlock
+
+True remote unlock means a remote request can cause a locked device to become
+unlocked without a local user at that device entering unlock material. This is
+default-disabled.
+
+Any future exception must include:
+
+- Explicit opt-in with a threat-model warning.
+- Device-bound keys or hardware-backed approval.
+- Short-lived grants scoped to specific collections and labels.
+- Signed request/approval records and hash-chained audit events.
+- Automatic relock and revocation controls.
+- A local kill switch that disables remote unlock immediately.
+- Tests proving passphrases/recovery material are not sent through chat,
+  arguments, environment variables, logs, issue comments, or fixtures.
+
+If these cannot be met, implement remote lock and unlock-request only.
+
+## 8. Audit Replication
+
+Fleet audit logs should be append-only and hash-chained per device, with
+replicated summaries to detect forks and gaps.
+
+Each audit event should include:
+
+- Event type.
+- Device ID.
+- Local sequence number.
+- Timestamp.
+- Previous event hash.
+- Event payload hash.
+- Signature.
+- Optional redacted human-readable summary.
+
+Replicated audit summaries should include audit-head hashes for each device and
+collection. Devices should warn when another trusted device's audit chain forks,
+skips expected sequence numbers, or rolls back.
+
+Audit payloads must not contain passphrases, recovery material, raw secrets, or
+private data beyond the minimum metadata needed to understand security events.
+
+## 9. Conflict and Revocation Handling
+
+### Conflicts
+
+- Use collection-specific merge rules. Memory summaries, mail caches, and config
+  metadata should not share one generic merge strategy.
+- Preserve conflicting encrypted payloads until a trusted device can resolve
+  them.
+- Do not ask a third-party AI provider to inspect conflict payloads unless the
+  labels allow provider routing.
+
+### Device revocation
+
+After revocation:
+
+1. Mark the device `revoked` in a signed registry update.
+2. Stop rewrapping new collection keys for it.
+3. Rotate or rewrap affected collection keys where practical.
+4. Reject new manifests signed by the revoked device after the revocation point.
+5. Preserve historical audit events for attribution.
+
+Revocation cannot erase ciphertext or plaintext already copied to the device.
+
+## 10. Provider-Aware Fleet Operation
+
+Fleet sync does not make data provider-safe. Before a worker on any device sends
+context to a third-party AI provider, it must evaluate Vault labels:
+
+- `secret`, `local-only`, and `local-LLM-only` stay out of provider prompts.
+- `confidential` and `client-confidential` require `provider-allowed` and task
+  necessity.
+- Remote VPS workers should default to locked/no-provider access for protected
+  data unless explicitly unlocked and routed.
+- Future local LLM workers are preferred for `local-LLM-only` data, but still
+  require host trust and local cache hygiene.
+
+## 11. Completion Evidence
+
+Fleet tasks should produce evidence without exposing protected data:
+
+- Signed registry version or public device fingerprint.
+- Sanitised sync status showing encrypted collection counts.
+- Audit-head hashes and event counts.
+- Remote-lock acknowledgement status.
+- Unlock-request approval/denial metadata with labels and scope, not secrets.
+
+Public PRs/issues/comments must redact private repo names, local paths, client
+names, message subjects, and private basenames.
+
+## Related
+
+- `reference/vault.md` -- canonical threat model, labels, primitives, and phased
+  architecture.
+- `workflows/vault-setup.md` -- first-use setup, migration, passphrase, recovery,
+  and safe prompts.
+- `reference/cross-runner-coordination.md` -- model for multi-machine state,
+  auditability, and failure modes.

--- a/.agents/workflows/vault-setup.md
+++ b/.agents/workflows/vault-setup.md
@@ -1,0 +1,196 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Vault Setup Workflow
+
+> **Audience:** agents and maintainers designing first-use Vault setup,
+> migration, recovery, and safe prompts. Current status is RFC guidance; future
+> helper implementations must conform to `reference/vault.md`.
+
+<!-- AI-CONTEXT-START -->
+
+**TL;DR:** Vault setup is local-first. Never ask for or accept Vault
+passphrases, recovery phrases, private keys, or raw secrets in AI chat, CLI
+arguments, environment variables, logs, issue comments, or fixtures. Use local
+interactive prompts, classify data before migration, and keep third-party AI
+provider routing explicit.
+
+<!-- AI-CONTEXT-END -->
+
+## 1. Setup Goals
+
+First-use setup must create a protected local baseline without training unsafe
+habits. A valid setup flow:
+
+1. Explains what Vault protects and what it does not protect.
+2. Collects passphrases only through local hidden prompts or OS/hardware-backed
+   key prompts.
+3. Creates or imports local key material without printing it.
+4. Classifies existing aidevops data before migration.
+5. Records an audit event for setup, migration, and recovery operations without
+   storing secret values.
+6. Leaves a visible lock/unlock status and a safe recovery path.
+
+## 2. Safe Prompt Contract
+
+Agents must use wording like this when setup requires user-held secrets:
+
+> Run the Vault setup helper in your own terminal. Enter the Vault passphrase
+> only into the local hidden prompt. Do not paste passphrases, recovery material,
+> private keys, or secret values into AI chat.
+
+Agents must not request:
+
+- Vault passphrases.
+- Recovery phrases or recovery key shards.
+- Private device keys.
+- Raw API tokens, passwords, or credentials.
+- Screenshots or logs that reveal the above.
+
+Agents may request non-secret evidence:
+
+- Whether setup completed.
+- Key fingerprints or public device IDs.
+- Sanitised error codes/messages that do not contain secret values.
+- Lock/unlock status produced by a helper that redacts sensitive fields.
+
+## 3. First-Use Flow
+
+### Step 1: Explain boundaries
+
+Before creating a Vault, the setup UI/helper should show a concise boundary
+statement:
+
+- Protects locked local stores, encrypted backups, and encrypted sync bundles.
+- Does not protect against malware/root access while unlocked.
+- Does not protect provider-side AI logs after data is sent to a third-party AI
+  provider.
+- Does not retroactively encrypt old OS snapshots, crash dumps, swap, shell
+  history, or unsupported runtime caches.
+- Future local LLM mode reduces third-party provider exposure but does not reduce
+  local host compromise risk.
+
+### Step 2: Inventory local data
+
+Classify existing paths by `reference/vault.md` data classes before migration:
+
+| Data class | Examples to inventory | Default action |
+|---|---|---|
+| Memory | Cross-session memory DB/files | Encrypt or migrate into encrypted store |
+| Session/history | Runtime transcripts, checkpoints | Encrypt current retention set; expire stale low-value data |
+| Workspace | Agent work/tmp/mail dirs | Move sensitive projects into encrypted workspace |
+| Knowledge | Private indexes, embeddings, notes | Encrypt if private/client-derived; leave public indexes public only if verified |
+| Mail/messages | Mailbox and message caches | Encrypt; tenant-isolate when client-specific |
+| Config metadata | Repo registry and runtime preferences | Keep non-secret; encrypt when client-correlated |
+| Audit logs | Security and sync events | Start append-only hash chain |
+| Device registry | Local public keys and trust state | Create signed local registry |
+| Sync collections | Existing synced data bundles | Re-encrypt before future transport sync |
+
+### Step 3: Choose local unlock method
+
+The default unlock method should combine:
+
+- User passphrase processed through Argon2id with stored parameters.
+- OS/hardware-backed key wrapping where available.
+- A recovery method that can survive device loss without copying the primary
+  passphrase into plaintext notes.
+
+Do not store passphrases in environment variables, shell profile files,
+credentials templates, issue bodies, PR bodies, test fixtures, or AI memory.
+
+### Step 4: Create local Vault metadata
+
+Initial metadata should include:
+
+- Vault format version.
+- KDF parameters.
+- Device public signing/encryption keys.
+- Empty or migrated collection manifests.
+- Audit-chain genesis event.
+- Local routing policy defaults.
+
+Private key material must be encrypted or hardware-wrapped before persistence.
+
+### Step 5: Migrate current tools deliberately
+
+Current tools are still the right primitive for many scopes:
+
+- Keep individual API keys, tokens, and passwords in gopass via
+  `aidevops secret`.
+- Keep structured secret config committed to Git under SOPS.
+- Keep sensitive directories at rest under gocryptfs until native Vault storage
+  exists.
+
+Vault setup should record these as protected collections and routing rules; it
+does not need to merge every existing tool into one physical store.
+
+### Step 6: Verify lock/unlock status
+
+After setup, helpers should prove:
+
+- Locked state denies plaintext reads.
+- Unlock state is visible and scoped.
+- Lock closes mounts/handles and removes plaintext temp files where practical.
+- Status output exposes no secret values.
+
+## 4. Recovery Design
+
+Recovery must be safe by default:
+
+- Recovery material is created locally and shown only through a local secure UI
+  or written to a user-chosen offline destination.
+- Agents never see recovery material.
+- Recovery flow rotates or rewraps affected keys after use.
+- Lost-device recovery revokes the missing device before adding a replacement.
+- Recovery audit events include device IDs, timestamps, and operation type, not
+  secret values.
+
+Acceptable recovery approaches include offline recovery codes, hardware-backed
+keys, Shamir-style splits implemented by audited libraries, or trusted-device
+approval. Avoid bespoke recovery cryptography.
+
+## 5. Migration Checklist
+
+For each migrated path:
+
+1. Identify data class and labels.
+2. Decide whether migration is copy-then-verify, move, or leave-in-place with
+   gopass/SOPS/gocryptfs ownership.
+3. Encrypt before syncing or backing up.
+4. Verify plaintext source cleanup where safe and non-destructive.
+5. Record an audit event.
+6. Run a secret scan or equivalent hygiene check before any PR/public output.
+
+## 6. Provider Routing During Setup
+
+Setup may need an agent to explain errors or generate a plan. Before sending
+context to a third-party AI provider:
+
+- Strip passphrases, recovery material, private keys, token values, and raw
+  secret-bearing config.
+- Prefer key fingerprints, public device IDs, and sanitised helper status.
+- Treat migration inventories as `confidential` unless all paths and names are
+  verified public/non-sensitive.
+- Use future local LLM routing for `local-LLM-only` setup diagnostics.
+
+## 7. Completion Evidence
+
+A setup or migration task is complete only with evidence such as:
+
+- Sanitised helper status showing locked/unlocked state.
+- Audit event count or hash-chain head, without secret values.
+- File/path inventory showing expected collections, with private paths redacted
+  in public comments.
+- Verification command output from local helpers.
+
+Do not publish private basenames, client names, local paths, passphrase hints, or
+secret identifiers in public issues, PRs, or comments.
+
+## Related
+
+- `reference/vault.md` -- threat model, data classes, labels, cryptographic
+  constraints, trust boundaries, and phased architecture.
+- `workflows/vault-fleet.md` -- multi-device trust, sync, remote lock,
+  unlock-request, and audit replication.
+- `tools/credentials/encryption-stack.md` -- current credential/encryption tool
+  decision guide.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Since the last README feature refresh, aidevops has added or expanded:
 
 **Comprehensive DevOps framework with tried & tested services integrations, popular and trusted MCP servers, and enterprise-grade infrastructure quality assurance code monitoring and recommendations.**
 
+**Vault security model:** aidevops defines protected data classes, provider
+routing labels, trust boundaries, and phased encrypted sync architecture in
+`.agents/reference/vault.md`. Vault guidance is local-first: third-party AI
+providers can only reason over data that has been decrypted into their prompt or
+tool context, so provider-side logs/retention remain outside Vault's technical
+control. Future local LLM mode reduces provider exposure but not local host
+compromise risk.
+
 ### Report creation, previews, and PDF exports
 
 Use aidevops to turn evidence bundles into decision-ready reports while keeping Markdown or JSON as the canonical source. Report agents can produce AI-search audits, SEO/GEO scorecards, delivery reviews, campaign reports, board packs, incident summaries, recurring client handoffs, and before/after remediation evidence.


### PR DESCRIPTION
## Summary

Added the Vault RFC plus setup/fleet workflows, linked the encryption stack to the Vault model, and added a short README overview with third-party AI provider limitations.

## Files Changed

.agents/reference/vault.md,.agents/tools/credentials/encryption-stack.md,.agents/workflows/vault-fleet.md,.agents/workflows/vault-setup.md,README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/verify-brief.sh todo/tasks/t17997-brief.md || true (brief absent as expected); .agents/scripts/linters-local.sh (passed)

Resolves #25534


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 23m and 113,548 tokens on this as a headless worker.