### PR TITLE
t17998: feat: add local vault broker

### DIFF
--- a/.agents/reference/vault.md
+++ b/.agents/reference/vault.md
@@ -3,17 +3,20 @@
 
 # Aidevops Vault Security Architecture RFC
 
-> **Status:** RFC. This records the canonical threat model and architecture
-> constraints for future Vault implementation work. It does not claim that every
-> control described here exists today.
+> **Status:** RFC plus initial local CLI/broker implementation. The first shipped
+> helper covers local metadata, passphrase wrapping, an in-memory broker, and
+> locked-state gates; fleet sync, GUI routing, and protected data migrations are
+> still future phases.
 
 <!-- AI-CONTEXT-START -->
 
 **TL;DR:** Aidevops Vault is the policy and architecture model for protecting
 agent memory, history, workspace, knowledge, mail, metadata, audits, device
-state, and sync collections. Current tools such as gopass, SOPS, and gocryptfs
-cover specific storage needs; Vault defines how protected data is classified,
-routed, encrypted, synced, audited, and withheld from third-party AI providers.
+state, and sync collections. `aidevops vault` now provides the first local
+encrypted metadata and in-memory broker gate; current tools such as gopass,
+SOPS, and gocryptfs still cover specific storage needs while Vault defines how
+protected data is classified, routed, encrypted, synced, audited, and withheld
+from third-party AI providers.
 
 **Hard limits:** Vault does not protect data from malware/root access while
 unlocked, provider-side AI logs after data is sent to a third-party model,
@@ -211,6 +214,30 @@ protocols:
   KDF upgrades without rewriting every payload when practical.
 
 ## 7. Phased Architecture
+
+### Initial implementation: local CLI/broker gate
+
+The local broker phase is implemented by `.agents/scripts/vault-helper.sh` and
+`.agents/scripts/vault-crypto-helper.py`, exposed as `aidevops vault`:
+
+- `init` creates `vault.json` metadata under `~/.config/aidevops/vault/` (or
+  `AIDEVOPS_VAULT_DIR`) with schema version, KDF parameters, salt, wrapped root
+  key, and no plaintext passphrase or root-key material.
+- `unlock` reads the passphrase only from a hidden local TTY prompt, unwraps the
+  root key, and starts a Unix-domain socket broker that keeps the root key in
+  process memory only.
+- `lock` stops the broker; process exit, crash, restart, or missing runtime
+  socket returns the system to locked state because no unlock token is persisted.
+- `status` returns `uninitialized`, `locked`, `unlocked`, or `corrupted`.
+- `read` and `update` fail closed with `VAULT_LOCKED` unless the broker is
+  currently unlocked. `update` reads protected payload data from stdin, but
+  passphrases are never accepted from stdin, arguments, environment variables,
+  issue bodies, chat, logs, or fixtures.
+
+Crypto trade-off: the initial helper uses Python `cryptography` with scrypt and
+AES-256-GCM because those audited primitives are available in the supported
+runtime today. The metadata records `kdf.name` and parameters so a later
+Argon2id migration can rewrap the root key without changing callers.
 
 ### Phase 0: RFC and labels
 

--- a/.agents/scripts/tests/test-vault-helper.sh
+++ b/.agents/scripts/tests/test-vault-helper.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_DIR="${SCRIPT_DIR}/.."
+VAULT_HELPER="${HELPER_DIR}/vault-helper.sh"
+TEST_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-vault-test)"
+PASS=0
+FAIL=0
+
+cleanup() {
+	AIDEVOPS_VAULT_DIR="$TEST_ROOT/vault" "$VAULT_HELPER" lock >/dev/null 2>&1 || true
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	printf 'FAIL: %s\n' "$name" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$name"
+	else
+		printf '  expected: %s\n  actual:   %s\n' "$expected" "$actual" >&2
+		fail "$name"
+	fi
+	return 0
+}
+
+assert_nonzero() {
+	local name="$1"
+	local rc="$2"
+	if [[ "$rc" -ne 0 ]]; then
+		pass "$name"
+	else
+		fail "$name"
+	fi
+	return 0
+}
+
+run_with_tty() {
+	local input="$1"
+	shift
+	python3 - "$input" "$@" <<'PY'
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+inputs = sys.argv[1].encode().decode("unicode_escape").splitlines()
+cmd = sys.argv[2:]
+master, slave = pty.openpty()
+proc = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=slave)
+os.close(slave)
+sent = 0
+stderr_chunks = []
+deadline = time.time() + 20
+while time.time() < deadline:
+    reads = [master]
+    if proc.stdout is not None:
+        reads.append(proc.stdout.fileno())
+    ready, _, _ = select.select(reads, [], [], 0.1)
+    for fd in ready:
+        if fd == master:
+            try:
+                chunk = os.read(master, 4096)
+                stderr_chunks.append(chunk)
+                prompt_count = b"".join(stderr_chunks).count(b": ")
+                while sent < len(inputs) and sent < prompt_count:
+                    os.write(master, (inputs[sent] + "\n").encode())
+                    sent += 1
+            except OSError:
+                pass
+        elif proc.stdout is not None:
+            proc.stdout.read1(4096)
+    if proc.poll() is not None:
+        break
+if proc.poll() is None:
+    proc.terminate()
+    proc.wait(timeout=5)
+sys.stderr.buffer.write(b''.join(stderr_chunks))
+raise SystemExit(proc.returncode)
+PY
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+export AIDEVOPS_VAULT_DIR="$TEST_ROOT/vault"
+export AIDEVOPS_VAULT_RUNTIME_DIR="$TEST_ROOT/run"
+
+generated_pass="pw-${RANDOM}-$(date +%s)-vault"
+wrong_pass="wrong-${RANDOM}-vault"
+
+status_output="$($VAULT_HELPER status 2>/dev/null || true)"
+assert_eq "missing metadata reports uninitialized" "uninitialized" "$status_output"
+
+set +e
+read_locked_output="$($VAULT_HELPER read sample 2>&1 >/dev/null)"
+read_locked_rc=$?
+set -e
+assert_nonzero "locked read fails closed" "$read_locked_rc"
+case "$read_locked_output" in
+*VAULT_LOCKED*) pass "locked read has deterministic error" ;;
+*) fail "locked read has deterministic error" ;;
+esac
+
+set +e
+run_with_tty "${generated_pass}\n${generated_pass}\n" "$VAULT_HELPER" init >/dev/null 2>"$TEST_ROOT/init.err"
+init_rc=$?
+set -e
+assert_eq "init succeeds through tty prompt" "0" "$init_rc"
+if grep -q "$generated_pass" "$TEST_ROOT/init.err"; then
+	fail "hidden init prompt does not echo passphrase"
+else
+	pass "hidden init prompt does not echo passphrase"
+fi
+
+if python3 -m json.tool "$AIDEVOPS_VAULT_DIR/vault.json" >/dev/null; then
+	pass "metadata parses as json"
+else
+	fail "metadata parses as json"
+fi
+if grep -q "$generated_pass" "$AIDEVOPS_VAULT_DIR/vault.json"; then
+	fail "metadata omits plaintext passphrase"
+else
+	pass "metadata omits plaintext passphrase"
+fi
+
+set +e
+run_with_tty "${wrong_pass}\n" "$VAULT_HELPER" unlock >/dev/null 2>"$TEST_ROOT/wrong.err"
+wrong_rc=$?
+set -e
+assert_nonzero "wrong passphrase fails" "$wrong_rc"
+if grep -q "$wrong_pass" "$TEST_ROOT/wrong.err"; then
+	fail "wrong passphrase is not printed"
+else
+	pass "wrong passphrase is not printed"
+fi
+
+set +e
+printf '%s\n' "$generated_pass" | "$VAULT_HELPER" unlock >/dev/null 2>"$TEST_ROOT/stdin.err"
+stdin_rc=$?
+set -e
+assert_nonzero "unlock refuses non-tty stdin" "$stdin_rc"
+
+set +e
+run_with_tty "${generated_pass}\n" "$VAULT_HELPER" unlock >/dev/null 2>"$TEST_ROOT/unlock.err"
+unlock_rc=$?
+set -e
+assert_eq "unlock succeeds through tty prompt" "0" "$unlock_rc"
+assert_eq "status reports unlocked" "unlocked" "$($VAULT_HELPER status)"
+
+printf 'protected value' | "$VAULT_HELPER" update sample >/dev/null
+assert_eq "read returns encrypted entry after unlock" "protected value" "$($VAULT_HELPER read sample)"
+"$VAULT_HELPER" lock >/dev/null
+assert_eq "status reports locked after lock" "locked" "$($VAULT_HELPER status)"
+
+cp "$AIDEVOPS_VAULT_DIR/vault.json" "$AIDEVOPS_VAULT_DIR/vault.json.good"
+printf '{not-json' >"$AIDEVOPS_VAULT_DIR/vault.json"
+set +e
+corrupt_status="$($VAULT_HELPER status 2>/dev/null)"
+corrupt_rc=$?
+set -e
+assert_eq "damaged metadata reports corrupted" "corrupted" "$corrupt_status"
+assert_nonzero "damaged metadata exits nonzero" "$corrupt_rc"
+mv "$AIDEVOPS_VAULT_DIR/vault.json.good" "$AIDEVOPS_VAULT_DIR/vault.json"
+
+printf '\nVault helper test summary: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/vault-crypto-helper.py
+++ b/.agents/scripts/vault-crypto-helper.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Local aidevops Vault crypto and broker helper.
+
+This module intentionally keeps passphrase collection in a local TTY prompt and
+keeps unlocked root keys only in a per-session Unix-domain socket broker process.
+The metadata format is versioned so a future Argon2id implementation can migrate
+from the current audited `cryptography` scrypt KDF without changing callers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import errno
+import getpass
+import hashlib
+import json
+import os
+import secrets
+import signal
+import socket
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+SCHEMA_VERSION = 1
+KDF_NAME = "scrypt"
+AEAD_NAME = "AES-256-GCM"
+KEY_LEN = 32
+NONCE_LEN = 12
+DEFAULT_SCRYPT = {"n": 2**15, "r": 8, "p": 1, "length": KEY_LEN}
+STATE_UNINITIALIZED = "uninitialized"
+STATE_LOCKED = "locked"
+STATE_UNLOCKED = "unlocked"
+STATE_CORRUPTED = "corrupted"
+
+
+class VaultError(Exception):
+    """Expected Vault failure with a stable error code."""
+
+    def __init__(self, code: str, message: str, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
+
+
+def b64e(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def b64d(data: str) -> bytes:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode((data + pad).encode("ascii"))
+
+
+def default_vault_dir() -> Path:
+    configured = os.environ.get("AIDEVOPS_VAULT_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return Path(config_home) / "aidevops" / "vault"
+    return Path.home() / ".config" / "aidevops" / "vault"
+
+
+def runtime_dir(vault_dir: Path) -> Path:
+    configured = os.environ.get("AIDEVOPS_VAULT_RUNTIME_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime:
+        digest = hashlib.sha256(str(vault_dir).encode("utf-8")).hexdigest()[:16]
+        return Path(runtime) / "aidevops-vault" / digest
+    return vault_dir / ".runtime"
+
+
+def metadata_path(vault_dir: Path) -> Path:
+    return vault_dir / "vault.json"
+
+
+def store_path(vault_dir: Path) -> Path:
+    return vault_dir / "vault-store.json"
+
+
+def audit_path(vault_dir: Path) -> Path:
+    return vault_dir / "audit.log"
+
+
+def socket_path(vault_dir: Path) -> Path:
+    return runtime_dir(vault_dir) / "broker.sock"
+
+
+def pid_path(vault_dir: Path) -> Path:
+    return runtime_dir(vault_dir) / "broker.pid"
+
+
+def ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def write_private_json(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError as exc:
+        raise VaultError("VAULT_UNINITIALIZED", "Vault metadata is missing", 2) from exc
+    except json.JSONDecodeError as exc:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata is corrupted", 3) from exc
+    if not isinstance(data, dict):
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata has invalid shape", 3)
+    return data
+
+
+def append_audit(vault_dir: Path, event: str, ok: bool, detail: str = "") -> None:
+    ensure_private_dir(vault_dir)
+    record = {
+        "ts": int(time.time()),
+        "event": event,
+        "ok": ok,
+        "detail": detail[:120],
+    }
+    path = audit_path(vault_dir)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    os.chmod(path, 0o600)
+
+
+def derive_kek(passphrase: str, salt: bytes, params: dict[str, Any]) -> bytes:
+    kdf = Scrypt(
+        salt=salt,
+        length=int(params.get("length", KEY_LEN)),
+        n=int(params.get("n", DEFAULT_SCRYPT["n"])),
+        r=int(params.get("r", DEFAULT_SCRYPT["r"])),
+        p=int(params.get("p", DEFAULT_SCRYPT["p"])),
+    )
+    return kdf.derive(passphrase.encode("utf-8"))
+
+
+def encrypt_json(key: bytes, payload: dict[str, Any], aad: bytes) -> dict[str, str]:
+    nonce = secrets.token_bytes(NONCE_LEN)
+    plaintext = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
+    return {"aead": AEAD_NAME, "nonce": b64e(nonce), "ciphertext": b64e(ciphertext)}
+
+
+def decrypt_json(key: bytes, envelope: dict[str, Any], aad: bytes) -> dict[str, Any]:
+    if envelope.get("aead") != AEAD_NAME:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported AEAD in Vault envelope", 3)
+    try:
+        nonce = b64d(str(envelope["nonce"]))
+        ciphertext = b64d(str(envelope["ciphertext"]))
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, aad)
+        data = json.loads(plaintext.decode("utf-8"))
+    except (KeyError, ValueError, InvalidTag) as exc:
+        raise VaultError("VAULT_DECRYPT_FAILED", "Vault decrypt failed", 4) from exc
+    if not isinstance(data, dict):
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault payload has invalid shape", 3)
+    return data
+
+
+def prompt_passphrase(confirm: bool = False) -> str:
+    if not sys.stdin.isatty() or not sys.stderr.isatty():
+        raise VaultError("VAULT_TTY_REQUIRED", "Vault passphrase entry requires a local TTY", 5)
+    first = getpass.getpass("Vault passphrase: ", stream=sys.stderr)
+    if not first:
+        raise VaultError("VAULT_PASSPHRASE_EMPTY", "Vault passphrase cannot be empty", 5)
+    if confirm:
+        second = getpass.getpass("Confirm Vault passphrase: ", stream=sys.stderr)
+        if not secrets.compare_digest(first, second):
+            raise VaultError("VAULT_PASSPHRASE_MISMATCH", "Vault passphrases did not match", 5)
+    return first
+
+
+def validate_metadata(meta: dict[str, Any]) -> None:
+    if meta.get("schema_version") != SCHEMA_VERSION:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported Vault metadata schema", 3)
+    if meta.get("kdf", {}).get("name") != KDF_NAME:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported Vault KDF", 3)
+    if "salt" not in meta.get("kdf", {}) or "wrapped_root_key" not in meta:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata is incomplete", 3)
+
+
+def unwrap_root_key(meta: dict[str, Any], passphrase: str) -> bytes:
+    validate_metadata(meta)
+    kdf_meta = meta["kdf"]
+    kek = derive_kek(passphrase, b64d(str(kdf_meta["salt"])), dict(kdf_meta.get("params", {})))
+    try:
+        payload = decrypt_json(kek, dict(meta["wrapped_root_key"]), b"aidevops-vault-root-key")
+        root = b64d(str(payload["root_key"]))
+    except (KeyError, VaultError) as exc:
+        raise VaultError("VAULT_WRONG_PASSPHRASE", "Vault unlock failed", 4) from exc
+    if len(root) != KEY_LEN:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault root key has invalid length", 3)
+    return root
+
+
+def build_metadata(root_key: bytes, passphrase: str) -> dict[str, Any]:
+    salt = secrets.token_bytes(16)
+    kek = derive_kek(passphrase, salt, DEFAULT_SCRYPT)
+    wrapped = encrypt_json(kek, {"root_key": b64e(root_key)}, b"aidevops-vault-root-key")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": int(time.time()),
+        "kdf": {"name": KDF_NAME, "salt": b64e(salt), "params": DEFAULT_SCRYPT},
+        "wrapped_root_key": wrapped,
+        "broker": {"persisted_unlock_tokens": False, "transport": "local-unix-socket"},
+    }
+
+
+def broker_request(vault_dir: Path, request: dict[str, Any]) -> dict[str, Any]:
+    sock_path = socket_path(vault_dir)
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(5)
+            client.connect(str(sock_path))
+            client.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            chunks = []
+            while True:
+                chunk = client.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+    except OSError as exc:
+        if exc.errno in (errno.ENOENT, errno.ECONNREFUSED):
+            raise VaultError("VAULT_LOCKED", "Vault is locked", 6) from exc
+        raise VaultError("VAULT_BROKER_ERROR", "Vault broker request failed", 6) from exc
+    raw = b"".join(chunks).decode("utf-8")
+    try:
+        response = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise VaultError("VAULT_BROKER_ERROR", "Vault broker returned invalid response", 6) from exc
+    if not isinstance(response, dict):
+        raise VaultError("VAULT_BROKER_ERROR", "Vault broker returned invalid shape", 6)
+    if not response.get("ok"):
+        raise VaultError(str(response.get("code", "VAULT_BROKER_ERROR")), str(response.get("message", "Vault broker error")), int(response.get("exit", 6)))
+    return response
+
+
+def broker_alive(vault_dir: Path) -> bool:
+    try:
+        broker_request(vault_dir, {"op": "status"})
+        return True
+    except VaultError:
+        return False
+
+
+def read_store(vault_dir: Path, root_key: bytes) -> dict[str, Any]:
+    path = store_path(vault_dir)
+    if not path.exists():
+        return {"entries": {}}
+    envelope = load_json(path)
+    payload = decrypt_json(root_key, envelope, b"aidevops-vault-store")
+    if not isinstance(payload.get("entries", {}), dict):
+        raise VaultError("VAULT_STORE_CORRUPTED", "Vault store has invalid shape", 3)
+    return payload
+
+
+def write_store(vault_dir: Path, root_key: bytes, payload: dict[str, Any]) -> None:
+    write_private_json(store_path(vault_dir), encrypt_json(root_key, payload, b"aidevops-vault-store"))
+
+
+def handle_broker_client(vault_dir: Path, root_key: bytes, conn: socket.socket) -> bool:
+    with conn:
+        raw = conn.recv(1048576)
+        try:
+            request = json.loads(raw.decode("utf-8"))
+            op = request.get("op")
+            if op == "status":
+                response = {"ok": True, "state": STATE_UNLOCKED}
+            elif op == "lock":
+                response = {"ok": True, "state": STATE_LOCKED}
+                conn.sendall(json.dumps(response).encode("utf-8"))
+                return False
+            elif op == "read":
+                name = str(request.get("name", ""))
+                store = read_store(vault_dir, root_key)
+                entries = store.get("entries", {})
+                if name not in entries:
+                    response = {"ok": False, "code": "VAULT_ENTRY_MISSING", "message": "Vault entry is missing", "exit": 7}
+                else:
+                    response = {"ok": True, "value": entries[name]}
+            elif op == "update":
+                name = str(request.get("name", ""))
+                value = str(request.get("value", ""))
+                if not name:
+                    response = {"ok": False, "code": "VAULT_BAD_NAME", "message": "Vault entry name is required", "exit": 2}
+                else:
+                    store = read_store(vault_dir, root_key)
+                    entries = dict(store.get("entries", {}))
+                    entries[name] = value
+                    write_store(vault_dir, root_key, {"entries": entries})
+                    response = {"ok": True, "updated": name}
+            else:
+                response = {"ok": False, "code": "VAULT_BAD_REQUEST", "message": "Unknown Vault broker operation", "exit": 2}
+        except Exception as exc:  # noqa: BLE001 - broker must fail closed.
+            response = {"ok": False, "code": "VAULT_BROKER_ERROR", "message": exc.__class__.__name__, "exit": 6}
+        conn.sendall(json.dumps(response).encode("utf-8"))
+    return True
+
+
+def run_broker(vault_dir: Path, root_key_b64: str) -> int:
+    root_key = b64d(root_key_b64)
+    run_dir = runtime_dir(vault_dir)
+    ensure_private_dir(run_dir)
+    sock_path = socket_path(vault_dir)
+    pid_file = pid_path(vault_dir)
+    if sock_path.exists():
+        sock_path.unlink()
+    stop = False
+
+    def _signal_handler(_signum: int, _frame: Any) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(sock_path))
+        os.chmod(sock_path, stat.S_IRUSR | stat.S_IWUSR)
+        server.listen(8)
+        server.settimeout(1)
+        pid_file.write_text(str(os.getpid()), encoding="utf-8")
+        os.chmod(pid_file, 0o600)
+        while not stop:
+            try:
+                conn, _addr = server.accept()
+            except socket.timeout:
+                continue
+            if not handle_broker_client(vault_dir, root_key, conn):
+                break
+    try:
+        sock_path.unlink()
+    except FileNotFoundError:
+        pass
+    try:
+        pid_file.unlink()
+    except FileNotFoundError:
+        pass
+    return 0
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    vault_dir = default_vault_dir()
+    ensure_private_dir(vault_dir)
+    path = metadata_path(vault_dir)
+    if path.exists() and not args.force:
+        raise VaultError("VAULT_EXISTS", "Vault is already initialized", 2)
+    passphrase = prompt_passphrase(confirm=True)
+    metadata = build_metadata(secrets.token_bytes(KEY_LEN), passphrase)
+    write_private_json(path, metadata)
+    append_audit(vault_dir, "init", True)
+    print("Vault initialized")
+    return 0
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    vault_dir = default_vault_dir()
+    path = metadata_path(vault_dir)
+    if not path.exists():
+        print(STATE_UNINITIALIZED)
+        return 2
+    try:
+        validate_metadata(load_json(path))
+    except VaultError:
+        print(STATE_CORRUPTED)
+        return 3
+    print(STATE_UNLOCKED if broker_alive(vault_dir) else STATE_LOCKED)
+    return 0
+
+
+def cmd_unlock(_args: argparse.Namespace) -> int:
+    vault_dir = default_vault_dir()
+    if broker_alive(vault_dir):
+        print("Vault already unlocked")
+        return 0
+    meta = load_json(metadata_path(vault_dir))
+    passphrase = prompt_passphrase(confirm=False)
+    try:
+        root_key = unwrap_root_key(meta, passphrase)
+    except VaultError:
+        append_audit(vault_dir, "unlock", False, "decrypt-failed")
+        raise
+    run_dir = runtime_dir(vault_dir)
+    ensure_private_dir(run_dir)
+    subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), "broker", b64e(root_key)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if broker_alive(vault_dir):
+            append_audit(vault_dir, "unlock", True)
+            print("Vault unlocked")
+            return 0
+        time.sleep(0.05)
+    append_audit(vault_dir, "unlock", False, "broker-start-timeout")
+    raise VaultError("VAULT_BROKER_ERROR", "Vault broker did not start", 6)
+
+
+def cmd_lock(_args: argparse.Namespace) -> int:
+    vault_dir = default_vault_dir()
+    try:
+        broker_request(vault_dir, {"op": "lock"})
+    except VaultError as exc:
+        if exc.code == "VAULT_LOCKED":
+            print("Vault locked")
+            return 0
+        raise
+    append_audit(vault_dir, "lock", True)
+    print("Vault locked")
+    return 0
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    response = broker_request(default_vault_dir(), {"op": "read", "name": args.name})
+    print(str(response.get("value", "")))
+    return 0
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    if sys.stdin.isatty():
+        raise VaultError("VAULT_STDIN_REQUIRED", "Vault update reads the value from stdin", 2)
+    value = sys.stdin.read()
+    broker_request(default_vault_dir(), {"op": "update", "name": args.name, "value": value})
+    print("Vault entry updated")
+    return 0
+
+
+def cmd_change_passphrase(_args: argparse.Namespace) -> int:
+    vault_dir = default_vault_dir()
+    meta = load_json(metadata_path(vault_dir))
+    old_passphrase = prompt_passphrase(confirm=False)
+    root_key = unwrap_root_key(meta, old_passphrase)
+    print("Enter new Vault passphrase", file=sys.stderr)
+    new_passphrase = prompt_passphrase(confirm=True)
+    write_private_json(metadata_path(vault_dir), build_metadata(root_key, new_passphrase))
+    append_audit(vault_dir, "change-passphrase", True)
+    print("Vault passphrase changed")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vault-crypto-helper.py")
+    sub = parser.add_subparsers(dest="command", required=True)
+    init_p = sub.add_parser("init")
+    init_p.add_argument("--force", action="store_true")
+    init_p.set_defaults(func=cmd_init)
+    sub.add_parser("status").set_defaults(func=cmd_status)
+    sub.add_parser("unlock").set_defaults(func=cmd_unlock)
+    sub.add_parser("lock").set_defaults(func=cmd_lock)
+    read_p = sub.add_parser("read")
+    read_p.add_argument("name")
+    read_p.set_defaults(func=cmd_read)
+    update_p = sub.add_parser("update")
+    update_p.add_argument("name")
+    update_p.set_defaults(func=cmd_update)
+    sub.add_parser("change-passphrase").set_defaults(func=cmd_change_passphrase)
+    broker_p = sub.add_parser("broker")
+    broker_p.add_argument("root_key_b64")
+    broker_p.set_defaults(func=lambda args: run_broker(default_vault_dir(), args.root_key_b64))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except VaultError as exc:
+        print(f"{exc.code}: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/vault-crypto-helper.py
+++ b/.agents/scripts/vault-crypto-helper.py
@@ -1,361 +1,39 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Local aidevops Vault crypto and broker helper.
-
-This module intentionally keeps passphrase collection in a local TTY prompt and
-keeps unlocked root keys only in a per-session Unix-domain socket broker process.
-The metadata format is versioned so a future Argon2id implementation can migrate
-from the current audited `cryptography` scrypt KDF without changing callers.
-"""
+"""CLI entrypoint for local aidevops Vault crypto and broker operations."""
 
 from __future__ import annotations
 
 import argparse
-import base64
-import errno
-import getpass
-import hashlib
-import json
 import os
 import secrets
-import signal
-import socket
-import stat
 import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any
 
-from cryptography.exceptions import InvalidTag
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
-
-SCHEMA_VERSION = 1
-KDF_NAME = "scrypt"
-AEAD_NAME = "AES-256-GCM"
-KEY_LEN = 32
-NONCE_LEN = 12
-DEFAULT_SCRYPT = {"n": 2**15, "r": 8, "p": 1, "length": KEY_LEN}
-STATE_UNINITIALIZED = "uninitialized"
-STATE_LOCKED = "locked"
-STATE_UNLOCKED = "unlocked"
-STATE_CORRUPTED = "corrupted"
-
-
-class VaultError(Exception):
-    """Expected Vault failure with a stable error code."""
-
-    def __init__(self, code: str, message: str, exit_code: int = 1) -> None:
-        super().__init__(message)
-        self.code = code
-        self.exit_code = exit_code
-
-
-def b64e(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
-
-
-def b64d(data: str) -> bytes:
-    pad = "=" * (-len(data) % 4)
-    return base64.urlsafe_b64decode((data + pad).encode("ascii"))
-
-
-def default_vault_dir() -> Path:
-    configured = os.environ.get("AIDEVOPS_VAULT_DIR")
-    if configured:
-        return Path(configured).expanduser()
-    config_home = os.environ.get("XDG_CONFIG_HOME")
-    if config_home:
-        return Path(config_home) / "aidevops" / "vault"
-    return Path.home() / ".config" / "aidevops" / "vault"
-
-
-def runtime_dir(vault_dir: Path) -> Path:
-    configured = os.environ.get("AIDEVOPS_VAULT_RUNTIME_DIR")
-    if configured:
-        return Path(configured).expanduser()
-    runtime = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime:
-        digest = hashlib.sha256(str(vault_dir).encode("utf-8")).hexdigest()[:16]
-        return Path(runtime) / "aidevops-vault" / digest
-    return vault_dir / ".runtime"
-
-
-def metadata_path(vault_dir: Path) -> Path:
-    return vault_dir / "vault.json"
-
-
-def store_path(vault_dir: Path) -> Path:
-    return vault_dir / "vault-store.json"
-
-
-def audit_path(vault_dir: Path) -> Path:
-    return vault_dir / "audit.log"
-
-
-def socket_path(vault_dir: Path) -> Path:
-    return runtime_dir(vault_dir) / "broker.sock"
-
-
-def pid_path(vault_dir: Path) -> Path:
-    return runtime_dir(vault_dir) / "broker.pid"
-
-
-def ensure_private_dir(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-    os.chmod(path, 0o700)
-
-
-def write_private_json(path: Path, data: dict[str, Any]) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as handle:
-        json.dump(data, handle, indent=2, sort_keys=True)
-        handle.write("\n")
-    os.chmod(tmp, 0o600)
-    tmp.replace(path)
-
-
-def load_json(path: Path) -> dict[str, Any]:
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            data = json.load(handle)
-    except FileNotFoundError as exc:
-        raise VaultError("VAULT_UNINITIALIZED", "Vault metadata is missing", 2) from exc
-    except json.JSONDecodeError as exc:
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata is corrupted", 3) from exc
-    if not isinstance(data, dict):
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata has invalid shape", 3)
-    return data
-
-
-def append_audit(vault_dir: Path, event: str, ok: bool, detail: str = "") -> None:
-    ensure_private_dir(vault_dir)
-    record = {
-        "ts": int(time.time()),
-        "event": event,
-        "ok": ok,
-        "detail": detail[:120],
-    }
-    path = audit_path(vault_dir)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True) + "\n")
-    os.chmod(path, 0o600)
-
-
-def derive_kek(passphrase: str, salt: bytes, params: dict[str, Any]) -> bytes:
-    kdf = Scrypt(
-        salt=salt,
-        length=int(params.get("length", KEY_LEN)),
-        n=int(params.get("n", DEFAULT_SCRYPT["n"])),
-        r=int(params.get("r", DEFAULT_SCRYPT["r"])),
-        p=int(params.get("p", DEFAULT_SCRYPT["p"])),
-    )
-    return kdf.derive(passphrase.encode("utf-8"))
-
-
-def encrypt_json(key: bytes, payload: dict[str, Any], aad: bytes) -> dict[str, str]:
-    nonce = secrets.token_bytes(NONCE_LEN)
-    plaintext = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
-    return {"aead": AEAD_NAME, "nonce": b64e(nonce), "ciphertext": b64e(ciphertext)}
-
-
-def decrypt_json(key: bytes, envelope: dict[str, Any], aad: bytes) -> dict[str, Any]:
-    if envelope.get("aead") != AEAD_NAME:
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported AEAD in Vault envelope", 3)
-    try:
-        nonce = b64d(str(envelope["nonce"]))
-        ciphertext = b64d(str(envelope["ciphertext"]))
-        plaintext = AESGCM(key).decrypt(nonce, ciphertext, aad)
-        data = json.loads(plaintext.decode("utf-8"))
-    except (KeyError, ValueError, InvalidTag) as exc:
-        raise VaultError("VAULT_DECRYPT_FAILED", "Vault decrypt failed", 4) from exc
-    if not isinstance(data, dict):
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault payload has invalid shape", 3)
-    return data
-
-
-def prompt_passphrase(confirm: bool = False) -> str:
-    if not sys.stdin.isatty() or not sys.stderr.isatty():
-        raise VaultError("VAULT_TTY_REQUIRED", "Vault passphrase entry requires a local TTY", 5)
-    first = getpass.getpass("Vault passphrase: ", stream=sys.stderr)
-    if not first:
-        raise VaultError("VAULT_PASSPHRASE_EMPTY", "Vault passphrase cannot be empty", 5)
-    if confirm:
-        second = getpass.getpass("Confirm Vault passphrase: ", stream=sys.stderr)
-        if not secrets.compare_digest(first, second):
-            raise VaultError("VAULT_PASSPHRASE_MISMATCH", "Vault passphrases did not match", 5)
-    return first
-
-
-def validate_metadata(meta: dict[str, Any]) -> None:
-    if meta.get("schema_version") != SCHEMA_VERSION:
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported Vault metadata schema", 3)
-    if meta.get("kdf", {}).get("name") != KDF_NAME:
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported Vault KDF", 3)
-    if "salt" not in meta.get("kdf", {}) or "wrapped_root_key" not in meta:
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata is incomplete", 3)
-
-
-def unwrap_root_key(meta: dict[str, Any], passphrase: str) -> bytes:
-    validate_metadata(meta)
-    kdf_meta = meta["kdf"]
-    kek = derive_kek(passphrase, b64d(str(kdf_meta["salt"])), dict(kdf_meta.get("params", {})))
-    try:
-        payload = decrypt_json(kek, dict(meta["wrapped_root_key"]), b"aidevops-vault-root-key")
-        root = b64d(str(payload["root_key"]))
-    except (KeyError, VaultError) as exc:
-        raise VaultError("VAULT_WRONG_PASSPHRASE", "Vault unlock failed", 4) from exc
-    if len(root) != KEY_LEN:
-        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault root key has invalid length", 3)
-    return root
-
-
-def build_metadata(root_key: bytes, passphrase: str) -> dict[str, Any]:
-    salt = secrets.token_bytes(16)
-    kek = derive_kek(passphrase, salt, DEFAULT_SCRYPT)
-    wrapped = encrypt_json(kek, {"root_key": b64e(root_key)}, b"aidevops-vault-root-key")
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "created_at": int(time.time()),
-        "kdf": {"name": KDF_NAME, "salt": b64e(salt), "params": DEFAULT_SCRYPT},
-        "wrapped_root_key": wrapped,
-        "broker": {"persisted_unlock_tokens": False, "transport": "local-unix-socket"},
-    }
-
-
-def broker_request(vault_dir: Path, request: dict[str, Any]) -> dict[str, Any]:
-    sock_path = socket_path(vault_dir)
-    try:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-            client.settimeout(5)
-            client.connect(str(sock_path))
-            client.sendall(json.dumps(request).encode("utf-8") + b"\n")
-            chunks = []
-            while True:
-                chunk = client.recv(65536)
-                if not chunk:
-                    break
-                chunks.append(chunk)
-    except OSError as exc:
-        if exc.errno in (errno.ENOENT, errno.ECONNREFUSED):
-            raise VaultError("VAULT_LOCKED", "Vault is locked", 6) from exc
-        raise VaultError("VAULT_BROKER_ERROR", "Vault broker request failed", 6) from exc
-    raw = b"".join(chunks).decode("utf-8")
-    try:
-        response = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise VaultError("VAULT_BROKER_ERROR", "Vault broker returned invalid response", 6) from exc
-    if not isinstance(response, dict):
-        raise VaultError("VAULT_BROKER_ERROR", "Vault broker returned invalid shape", 6)
-    if not response.get("ok"):
-        raise VaultError(str(response.get("code", "VAULT_BROKER_ERROR")), str(response.get("message", "Vault broker error")), int(response.get("exit", 6)))
-    return response
-
-
-def broker_alive(vault_dir: Path) -> bool:
-    try:
-        broker_request(vault_dir, {"op": "status"})
-        return True
-    except VaultError:
-        return False
-
-
-def read_store(vault_dir: Path, root_key: bytes) -> dict[str, Any]:
-    path = store_path(vault_dir)
-    if not path.exists():
-        return {"entries": {}}
-    envelope = load_json(path)
-    payload = decrypt_json(root_key, envelope, b"aidevops-vault-store")
-    if not isinstance(payload.get("entries", {}), dict):
-        raise VaultError("VAULT_STORE_CORRUPTED", "Vault store has invalid shape", 3)
-    return payload
-
-
-def write_store(vault_dir: Path, root_key: bytes, payload: dict[str, Any]) -> None:
-    write_private_json(store_path(vault_dir), encrypt_json(root_key, payload, b"aidevops-vault-store"))
-
-
-def handle_broker_client(vault_dir: Path, root_key: bytes, conn: socket.socket) -> bool:
-    with conn:
-        raw = conn.recv(1048576)
-        try:
-            request = json.loads(raw.decode("utf-8"))
-            op = request.get("op")
-            if op == "status":
-                response = {"ok": True, "state": STATE_UNLOCKED}
-            elif op == "lock":
-                response = {"ok": True, "state": STATE_LOCKED}
-                conn.sendall(json.dumps(response).encode("utf-8"))
-                return False
-            elif op == "read":
-                name = str(request.get("name", ""))
-                store = read_store(vault_dir, root_key)
-                entries = store.get("entries", {})
-                if name not in entries:
-                    response = {"ok": False, "code": "VAULT_ENTRY_MISSING", "message": "Vault entry is missing", "exit": 7}
-                else:
-                    response = {"ok": True, "value": entries[name]}
-            elif op == "update":
-                name = str(request.get("name", ""))
-                value = str(request.get("value", ""))
-                if not name:
-                    response = {"ok": False, "code": "VAULT_BAD_NAME", "message": "Vault entry name is required", "exit": 2}
-                else:
-                    store = read_store(vault_dir, root_key)
-                    entries = dict(store.get("entries", {}))
-                    entries[name] = value
-                    write_store(vault_dir, root_key, {"entries": entries})
-                    response = {"ok": True, "updated": name}
-            else:
-                response = {"ok": False, "code": "VAULT_BAD_REQUEST", "message": "Unknown Vault broker operation", "exit": 2}
-        except Exception as exc:  # noqa: BLE001 - broker must fail closed.
-            response = {"ok": False, "code": "VAULT_BROKER_ERROR", "message": exc.__class__.__name__, "exit": 6}
-        conn.sendall(json.dumps(response).encode("utf-8"))
-    return True
-
-
-def run_broker(vault_dir: Path, root_key_b64: str) -> int:
-    root_key = b64d(root_key_b64)
-    run_dir = runtime_dir(vault_dir)
-    ensure_private_dir(run_dir)
-    sock_path = socket_path(vault_dir)
-    pid_file = pid_path(vault_dir)
-    if sock_path.exists():
-        sock_path.unlink()
-    stop = False
-
-    def _signal_handler(_signum: int, _frame: Any) -> None:
-        nonlocal stop
-        stop = True
-
-    signal.signal(signal.SIGTERM, _signal_handler)
-    signal.signal(signal.SIGINT, _signal_handler)
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
-        server.bind(str(sock_path))
-        os.chmod(sock_path, stat.S_IRUSR | stat.S_IWUSR)
-        server.listen(8)
-        server.settimeout(1)
-        pid_file.write_text(str(os.getpid()), encoding="utf-8")
-        os.chmod(pid_file, 0o600)
-        while not stop:
-            try:
-                conn, _addr = server.accept()
-            except socket.timeout:
-                continue
-            if not handle_broker_client(vault_dir, root_key, conn):
-                break
-    try:
-        sock_path.unlink()
-    except FileNotFoundError:
-        pass
-    try:
-        pid_file.unlink()
-    except FileNotFoundError:
-        pass
-    return 0
+from vault_broker_lib import broker_alive, broker_request, run_broker
+from vault_crypto_core import (
+    KEY_LEN,
+    STATE_CORRUPTED,
+    STATE_LOCKED,
+    STATE_UNINITIALIZED,
+    STATE_UNLOCKED,
+    VaultError,
+    append_audit,
+    b64e,
+    build_metadata,
+    default_vault_dir,
+    ensure_private_dir,
+    load_json,
+    metadata_path,
+    prompt_passphrase,
+    runtime_dir,
+    unwrap_root_key,
+    validate_metadata,
+    write_private_json,
+)
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -364,8 +42,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     path = metadata_path(vault_dir)
     if path.exists() and not args.force:
         raise VaultError("VAULT_EXISTS", "Vault is already initialized", 2)
-    passphrase = prompt_passphrase(confirm=True)
-    metadata = build_metadata(secrets.token_bytes(KEY_LEN), passphrase)
+    metadata = build_metadata(secrets.token_bytes(KEY_LEN), prompt_passphrase(confirm=True))
     write_private_json(path, metadata)
     append_audit(vault_dir, "init", True)
     print("Vault initialized")
@@ -393,14 +70,16 @@ def cmd_unlock(_args: argparse.Namespace) -> int:
         print("Vault already unlocked")
         return 0
     meta = load_json(metadata_path(vault_dir))
-    passphrase = prompt_passphrase(confirm=False)
     try:
-        root_key = unwrap_root_key(meta, passphrase)
+        root_key = unwrap_root_key(meta, prompt_passphrase(confirm=False))
     except VaultError:
         append_audit(vault_dir, "unlock", False, "decrypt-failed")
         raise
-    run_dir = runtime_dir(vault_dir)
-    ensure_private_dir(run_dir)
+    return _start_broker(vault_dir, root_key)
+
+
+def _start_broker(vault_dir: Path, root_key: bytes) -> int:
+    ensure_private_dir(runtime_dir(vault_dir))
     subprocess.Popen(
         [sys.executable, str(Path(__file__).resolve()), "broker", b64e(root_key)],
         stdin=subprocess.DEVNULL,
@@ -442,8 +121,7 @@ def cmd_read(args: argparse.Namespace) -> int:
 def cmd_update(args: argparse.Namespace) -> int:
     if sys.stdin.isatty():
         raise VaultError("VAULT_STDIN_REQUIRED", "Vault update reads the value from stdin", 2)
-    value = sys.stdin.read()
-    broker_request(default_vault_dir(), {"op": "update", "name": args.name, "value": value})
+    broker_request(default_vault_dir(), {"op": "update", "name": args.name, "value": sys.stdin.read()})
     print("Vault entry updated")
     return 0
 
@@ -451,11 +129,9 @@ def cmd_update(args: argparse.Namespace) -> int:
 def cmd_change_passphrase(_args: argparse.Namespace) -> int:
     vault_dir = default_vault_dir()
     meta = load_json(metadata_path(vault_dir))
-    old_passphrase = prompt_passphrase(confirm=False)
-    root_key = unwrap_root_key(meta, old_passphrase)
+    root_key = unwrap_root_key(meta, prompt_passphrase(confirm=False))
     print("Enter new Vault passphrase", file=sys.stderr)
-    new_passphrase = prompt_passphrase(confirm=True)
-    write_private_json(metadata_path(vault_dir), build_metadata(root_key, new_passphrase))
+    write_private_json(metadata_path(vault_dir), build_metadata(root_key, prompt_passphrase(confirm=True)))
     append_audit(vault_dir, "change-passphrase", True)
     print("Vault passphrase changed")
     return 0
@@ -484,8 +160,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
+    args = build_parser().parse_args(argv)
     try:
         return int(args.func(args))
     except VaultError as exc:

--- a/.agents/scripts/vault-helper.sh
+++ b/.agents/scripts/vault-helper.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CRYPTO_HELPER="${SCRIPT_DIR}/vault-crypto-helper.py"
+
+usage() {
+	cat <<'EOF'
+Usage: vault-helper.sh <command> [options]
+
+Commands:
+  init [--force]          Create local Vault metadata through hidden TTY prompts
+  unlock                  Unlock into an in-memory local broker through a hidden TTY prompt
+  lock                    Stop the local broker and forget in-memory keys
+  status                  Print uninitialized, locked, unlocked, or corrupted
+  read <name>             Read an entry through the unlocked broker
+  update <name>           Read a new entry value from stdin and encrypt it
+  change-passphrase       Rewrap the root key through hidden TTY prompts
+  help                    Show this help
+
+Passphrases are never accepted in CLI arguments, environment variables, or
+non-TTY stdin. Set AIDEVOPS_VAULT_DIR only to relocate Vault files.
+EOF
+	return 0
+}
+
+require_crypto_helper() {
+	if [[ ! -x "$CRYPTO_HELPER" ]]; then
+		printf '%s\n' "[ERROR] Missing executable crypto helper: $CRYPTO_HELPER" >&2
+		return 1
+	fi
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	case "$command" in
+	help | --help | -h)
+		usage
+		return 0
+		;;
+	init | unlock | lock | status | read | update | change-passphrase)
+		shift || true
+		require_crypto_helper || return 1
+		python3 "$CRYPTO_HELPER" "$command" "$@"
+		return $?
+		;;
+	*)
+		printf '%s\n' "[ERROR] Unknown Vault command: $command" >&2
+		usage >&2
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/vault_broker_lib.py
+++ b/.agents/scripts/vault_broker_lib.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""In-memory Unix-socket broker for the local aidevops Vault."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import signal
+import socket
+import stat
+from pathlib import Path
+from typing import Any
+
+from vault_crypto_core import (
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+    VaultError,
+    b64d,
+    decrypt_json,
+    ensure_private_dir,
+    load_json,
+    pid_path,
+    runtime_dir,
+    socket_path,
+    store_path,
+    write_private_json,
+    encrypt_json,
+)
+
+
+def broker_request(vault_dir: Path, request: dict[str, Any]) -> dict[str, Any]:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(5)
+            client.connect(str(socket_path(vault_dir)))
+            client.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            chunks = _read_response(client)
+    except OSError as exc:
+        if exc.errno in (errno.ENOENT, errno.ECONNREFUSED):
+            raise VaultError("VAULT_LOCKED", "Vault is locked", 6) from exc
+        raise VaultError("VAULT_BROKER_ERROR", "Vault broker request failed", 6) from exc
+    return _parse_response(chunks)
+
+
+def _read_response(client: socket.socket) -> bytes:
+    chunks = []
+    while True:
+        chunk = client.recv(65536)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _parse_response(raw: bytes) -> dict[str, Any]:
+    try:
+        response = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise VaultError("VAULT_BROKER_ERROR", "Vault broker returned invalid response", 6) from exc
+    if not isinstance(response, dict):
+        raise VaultError("VAULT_BROKER_ERROR", "Vault broker returned invalid shape", 6)
+    if not response.get("ok"):
+        raise VaultError(str(response.get("code", "VAULT_BROKER_ERROR")), str(response.get("message", "Vault broker error")), int(response.get("exit", 6)))
+    return response
+
+
+def broker_alive(vault_dir: Path) -> bool:
+    try:
+        broker_request(vault_dir, {"op": "status"})
+        return True
+    except VaultError:
+        return False
+
+
+def read_store(vault_dir: Path, root_key: bytes) -> dict[str, Any]:
+    path = store_path(vault_dir)
+    if not path.exists():
+        return {"entries": {}}
+    payload = decrypt_json(root_key, load_json(path), b"aidevops-vault-store")
+    if not isinstance(payload.get("entries", {}), dict):
+        raise VaultError("VAULT_STORE_CORRUPTED", "Vault store has invalid shape", 3)
+    return payload
+
+
+def write_store(vault_dir: Path, root_key: bytes, payload: dict[str, Any]) -> None:
+    write_private_json(store_path(vault_dir), encrypt_json(root_key, payload, b"aidevops-vault-store"))
+
+
+def handle_broker_client(vault_dir: Path, root_key: bytes, conn: socket.socket) -> bool:
+    with conn:
+        try:
+            request = json.loads(conn.recv(1048576).decode("utf-8"))
+            response, keep_running = _dispatch_request(vault_dir, root_key, request)
+        except Exception as exc:  # noqa: BLE001 - broker must fail closed.
+            response = {"ok": False, "code": "VAULT_BROKER_ERROR", "message": exc.__class__.__name__, "exit": 6}
+            keep_running = True
+        conn.sendall(json.dumps(response).encode("utf-8"))
+    return keep_running
+
+
+def _dispatch_request(vault_dir: Path, root_key: bytes, request: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    op = request.get("op")
+    if op == "status":
+        return {"ok": True, "state": STATE_UNLOCKED}, True
+    if op == "lock":
+        return {"ok": True, "state": STATE_LOCKED}, False
+    if op == "read":
+        return _read_entry(vault_dir, root_key, str(request.get("name", ""))), True
+    if op == "update":
+        return _update_entry(vault_dir, root_key, str(request.get("name", "")), str(request.get("value", ""))), True
+    return {"ok": False, "code": "VAULT_BAD_REQUEST", "message": "Unknown Vault broker operation", "exit": 2}, True
+
+
+def _read_entry(vault_dir: Path, root_key: bytes, name: str) -> dict[str, Any]:
+    entries = read_store(vault_dir, root_key).get("entries", {})
+    if name not in entries:
+        return {"ok": False, "code": "VAULT_ENTRY_MISSING", "message": "Vault entry is missing", "exit": 7}
+    return {"ok": True, "value": entries[name]}
+
+
+def _update_entry(vault_dir: Path, root_key: bytes, name: str, value: str) -> dict[str, Any]:
+    if not name:
+        return {"ok": False, "code": "VAULT_BAD_NAME", "message": "Vault entry name is required", "exit": 2}
+    store = read_store(vault_dir, root_key)
+    entries = dict(store.get("entries", {}))
+    entries[name] = value
+    write_store(vault_dir, root_key, {"entries": entries})
+    return {"ok": True, "updated": name}
+
+
+def run_broker(vault_dir: Path, root_key_b64: str) -> int:
+    root_key = b64d(root_key_b64)
+    run_dir = runtime_dir(vault_dir)
+    ensure_private_dir(run_dir)
+    sock_file = socket_path(vault_dir)
+    if sock_file.exists():
+        sock_file.unlink()
+    return _serve(vault_dir, root_key, sock_file)
+
+
+def _serve(vault_dir: Path, root_key: bytes, sock_file: Path) -> int:
+    stop = False
+
+    def _signal_handler(_signum: int, _frame: Any) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(sock_file))
+        os.chmod(sock_file, stat.S_IRUSR | stat.S_IWUSR)
+        server.listen(8)
+        server.settimeout(1)
+        _write_pid(vault_dir)
+        while not stop:
+            stop = _accept_once(vault_dir, root_key, server)
+    _cleanup_runtime(vault_dir, sock_file)
+    return 0
+
+
+def _accept_once(vault_dir: Path, root_key: bytes, server: socket.socket) -> bool:
+    try:
+        conn, _addr = server.accept()
+    except socket.timeout:
+        return False
+    return not handle_broker_client(vault_dir, root_key, conn)
+
+
+def _write_pid(vault_dir: Path) -> None:
+    pid_file = pid_path(vault_dir)
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
+    os.chmod(pid_file, 0o600)
+
+
+def _cleanup_runtime(vault_dir: Path, sock_file: Path) -> None:
+    for path in (sock_file, pid_path(vault_dir)):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass

--- a/.agents/scripts/vault_crypto_core.py
+++ b/.agents/scripts/vault_crypto_core.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Core primitives for the local aidevops Vault helper."""
+
+from __future__ import annotations
+
+import base64
+import getpass
+import json
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+SCHEMA_VERSION = 1
+KDF_NAME = "scrypt"
+AEAD_NAME = "AES-256-GCM"
+KEY_LEN = 32
+NONCE_LEN = 12
+DEFAULT_SCRYPT = {"n": 2**15, "r": 8, "p": 1, "length": KEY_LEN}
+STATE_UNINITIALIZED = "uninitialized"
+STATE_LOCKED = "locked"
+STATE_UNLOCKED = "unlocked"
+STATE_CORRUPTED = "corrupted"
+
+
+class VaultError(Exception):
+    """Expected Vault failure with a stable error code."""
+
+    def __init__(self, code: str, message: str, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
+
+
+def b64e(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def b64d(data: str) -> bytes:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode((data + pad).encode("ascii"))
+
+
+def default_vault_dir() -> Path:
+    configured = os.environ.get("AIDEVOPS_VAULT_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return Path(config_home) / "aidevops" / "vault"
+    return Path.home() / ".config" / "aidevops" / "vault"
+
+
+def runtime_dir(vault_dir: Path) -> Path:
+    configured = os.environ.get("AIDEVOPS_VAULT_RUNTIME_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime:
+        import hashlib
+
+        digest = hashlib.sha256(str(vault_dir).encode("utf-8")).hexdigest()[:16]
+        return Path(runtime) / "aidevops-vault" / digest
+    return vault_dir / ".runtime"
+
+
+def metadata_path(vault_dir: Path) -> Path:
+    return vault_dir / "vault.json"
+
+
+def store_path(vault_dir: Path) -> Path:
+    return vault_dir / "vault-store.json"
+
+
+def audit_path(vault_dir: Path) -> Path:
+    return vault_dir / "audit.log"
+
+
+def socket_path(vault_dir: Path) -> Path:
+    return runtime_dir(vault_dir) / "broker.sock"
+
+
+def pid_path(vault_dir: Path) -> Path:
+    return runtime_dir(vault_dir) / "broker.pid"
+
+
+def ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def write_private_json(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError as exc:
+        raise VaultError("VAULT_UNINITIALIZED", "Vault metadata is missing", 2) from exc
+    except json.JSONDecodeError as exc:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata is corrupted", 3) from exc
+    if not isinstance(data, dict):
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata has invalid shape", 3)
+    return data
+
+
+def append_audit(vault_dir: Path, event: str, ok: bool, detail: str = "") -> None:
+    ensure_private_dir(vault_dir)
+    record = {"ts": int(time.time()), "event": event, "ok": ok, "detail": detail[:120]}
+    path = audit_path(vault_dir)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    os.chmod(path, 0o600)
+
+
+def derive_kek(passphrase: str, salt: bytes, params: dict[str, Any]) -> bytes:
+    kdf = Scrypt(
+        salt=salt,
+        length=int(params.get("length", KEY_LEN)),
+        n=int(params.get("n", DEFAULT_SCRYPT["n"])),
+        r=int(params.get("r", DEFAULT_SCRYPT["r"])),
+        p=int(params.get("p", DEFAULT_SCRYPT["p"])),
+    )
+    return kdf.derive(passphrase.encode("utf-8"))
+
+
+def encrypt_json(key: bytes, payload: dict[str, Any], aad: bytes) -> dict[str, str]:
+    nonce = secrets.token_bytes(NONCE_LEN)
+    plaintext = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
+    return {"aead": AEAD_NAME, "nonce": b64e(nonce), "ciphertext": b64e(ciphertext)}
+
+
+def decrypt_json(key: bytes, envelope: dict[str, Any], aad: bytes) -> dict[str, Any]:
+    if envelope.get("aead") != AEAD_NAME:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported AEAD in Vault envelope", 3)
+    try:
+        plaintext = AESGCM(key).decrypt(b64d(str(envelope["nonce"])), b64d(str(envelope["ciphertext"])), aad)
+        data = json.loads(plaintext.decode("utf-8"))
+    except (KeyError, ValueError, InvalidTag) as exc:
+        raise VaultError("VAULT_DECRYPT_FAILED", "Vault decrypt failed", 4) from exc
+    if not isinstance(data, dict):
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault payload has invalid shape", 3)
+    return data
+
+
+def prompt_passphrase(confirm: bool = False) -> str:
+    if not sys.stdin.isatty() or not sys.stderr.isatty():
+        raise VaultError("VAULT_TTY_REQUIRED", "Vault passphrase entry requires a local TTY", 5)
+    first = getpass.getpass("Vault passphrase: ", stream=sys.stderr)
+    if not first:
+        raise VaultError("VAULT_PASSPHRASE_EMPTY", "Vault passphrase cannot be empty", 5)
+    if confirm:
+        second = getpass.getpass("Confirm Vault passphrase: ", stream=sys.stderr)
+        if not secrets.compare_digest(first, second):
+            raise VaultError("VAULT_PASSPHRASE_MISMATCH", "Vault passphrases did not match", 5)
+    return first
+
+
+def validate_metadata(meta: dict[str, Any]) -> None:
+    if meta.get("schema_version") != SCHEMA_VERSION:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported Vault metadata schema", 3)
+    if meta.get("kdf", {}).get("name") != KDF_NAME:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Unsupported Vault KDF", 3)
+    if "salt" not in meta.get("kdf", {}) or "wrapped_root_key" not in meta:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault metadata is incomplete", 3)
+
+
+def unwrap_root_key(meta: dict[str, Any], passphrase: str) -> bytes:
+    validate_metadata(meta)
+    kdf_meta = meta["kdf"]
+    kek = derive_kek(passphrase, b64d(str(kdf_meta["salt"])), dict(kdf_meta.get("params", {})))
+    try:
+        payload = decrypt_json(kek, dict(meta["wrapped_root_key"]), b"aidevops-vault-root-key")
+        root = b64d(str(payload["root_key"]))
+    except (KeyError, VaultError) as exc:
+        raise VaultError("VAULT_WRONG_PASSPHRASE", "Vault unlock failed", 4) from exc
+    if len(root) != KEY_LEN:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault root key has invalid length", 3)
+    return root
+
+
+def build_metadata(root_key: bytes, passphrase: str) -> dict[str, Any]:
+    salt = secrets.token_bytes(16)
+    kek = derive_kek(passphrase, salt, DEFAULT_SCRYPT)
+    wrapped = encrypt_json(kek, {"root_key": b64e(root_key)}, b"aidevops-vault-root-key")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": int(time.time()),
+        "kdf": {"name": KDF_NAME, "salt": b64e(salt), "params": DEFAULT_SCRYPT},
+        "wrapped_root_key": wrapped,
+        "broker": {"persisted_unlock_tokens": False, "transport": "local-unix-socket"},
+    }

--- a/.agents/workflows/vault-setup.md
+++ b/.agents/workflows/vault-setup.md
@@ -3,17 +3,19 @@
 
 # Vault Setup Workflow
 
-> **Audience:** agents and maintainers designing first-use Vault setup,
-> migration, recovery, and safe prompts. Current status is RFC guidance; future
-> helper implementations must conform to `reference/vault.md`.
+> **Audience:** agents and maintainers using or extending first-use Vault setup,
+> migration, recovery, and safe prompts. The first local CLI/broker helper is
+> implemented; future storage, fleet, and GUI phases must conform to
+> `reference/vault.md`.
 
 <!-- AI-CONTEXT-START -->
 
-**TL;DR:** Vault setup is local-first. Never ask for or accept Vault
-passphrases, recovery phrases, private keys, or raw secrets in AI chat, CLI
-arguments, environment variables, logs, issue comments, or fixtures. Use local
-interactive prompts, classify data before migration, and keep third-party AI
-provider routing explicit.
+**TL;DR:** Vault setup is local-first. Use `aidevops vault init`, `aidevops
+vault unlock`, `aidevops vault lock`, and `aidevops vault status` for the first
+local broker gate. Never ask for or accept Vault passphrases, recovery phrases,
+private keys, or raw secrets in AI chat, CLI arguments, environment variables,
+logs, issue comments, or fixtures. Use local interactive prompts, classify data
+before migration, and keep third-party AI provider routing explicit.
 
 <!-- AI-CONTEXT-END -->
 
@@ -55,6 +57,32 @@ Agents may request non-secret evidence:
 - Lock/unlock status produced by a helper that redacts sensitive fields.
 
 ## 3. First-Use Flow
+
+### Current CLI quick start
+
+Run these commands only in a local terminal where the user can type into the
+hidden prompt:
+
+```bash
+aidevops vault init
+aidevops vault status
+aidevops vault unlock
+aidevops vault lock
+```
+
+Expected states:
+
+- Before setup: `aidevops vault status` prints `uninitialized`.
+- After setup and before unlock: status prints `locked`.
+- After a successful local TTY unlock: status prints `unlocked` while the broker
+  process is alive.
+- After `aidevops vault lock`, broker exit, crash, or restart: status prints
+  `locked` and protected reads/updates fail closed.
+
+The initial helper writes `vault.json`, encrypted store data, and redacted audit
+events under `~/.config/aidevops/vault/` unless `AIDEVOPS_VAULT_DIR` relocates
+the store. Do not publish that path when it contains private machine or client
+context.
 
 ### Step 1: Explain boundaries
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -861,6 +861,7 @@ _help_commands() {
 	echo "  review-gate <cmd>  Configure review_gate merge policies (rate-limit/completion)"
 	echo "  github-app-auth    GitHub App auth setup/status and API route decisions"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
+	echo "  vault <cmd>        Local encrypted Vault broker (init/unlock/lock/status/read/update)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
 	echo "  knowledge <cmd>    Knowledge plane management (init/status/provision)"
 	echo "  campaign <cmd>     Campaign plane: init/provision/ls (P1) + asset (P4) + new/list/status/archive (P2) + draft (P5) + launch/promote (P6)"
@@ -936,6 +937,14 @@ _help_detailed_sections() {
 	echo "  aidevops secret init         # Initialize gopass encrypted store"
 	echo "  aidevops secret import       # Import from credentials.sh to gopass"
 	echo "  aidevops secret status       # Show backend status"
+	echo ""
+	echo "Vault:"
+	echo "  aidevops vault init          # Create local encrypted Vault metadata"
+	echo "  aidevops vault status        # Show uninitialized/locked/unlocked/corrupted"
+	echo "  aidevops vault unlock        # Unlock into an in-memory local broker"
+	echo "  aidevops vault lock          # Stop broker and forget in-memory keys"
+	echo "  aidevops vault read NAME     # Read protected data through broker"
+	echo "  aidevops vault update NAME   # Encrypt stdin value through broker"
 	echo ""
 	echo "GitHub App Auth:"
 	echo "  aidevops github-app-auth status --json       # Show active auth mode and budgets"
@@ -1631,6 +1640,7 @@ main() {
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;
+	vault) _dispatch_helper "vault-helper.sh" "vault-helper.sh" "$@" ;;
 	approve) _dispatch_helper "approval-helper.sh" "approval-helper.sh" "$@" ;;
 	circuit-breaker | circuit_breaker | cb)
 		# Supervisor circuit breaker control (t1331). Bare invocation defaults to status.


### PR DESCRIPTION
## Summary

Implemented aidevops vault CLI dispatch, local encrypted Vault metadata, hidden-TTY unlock, in-memory Unix-socket broker, locked read/update gate, redacted audit events, and Vault setup/reference documentation.

## Files Changed

.agents/reference/vault.md,.agents/scripts/tests/test-vault-helper.sh,.agents/scripts/vault-crypto-helper.py,.agents/scripts/vault-helper.sh,.agents/workflows/vault-setup.md,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/tests/test-vault-helper.sh (16 passed); .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED)

Resolves #25535


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 18m and 107,141 tokens on this as a headless worker.