### PR TITLE
t17999: feat: add vault setup verification flow

### DIFF
--- a/.agents/scripts/tests/test-vault-helper.sh
+++ b/.agents/scripts/tests/test-vault-helper.sh
@@ -128,10 +128,11 @@ case "$read_locked_output" in
 esac
 
 set +e
-run_with_tty "${generated_pass}\n${generated_pass}\n" "$VAULT_HELPER" init >/dev/null 2>"$TEST_ROOT/init.err"
+run_with_tty "I UNDERSTAND\n${generated_pass}\n${generated_pass}\n" "$VAULT_HELPER" init >/dev/null 2>"$TEST_ROOT/init.err"
 init_rc=$?
 set -e
 assert_eq "init succeeds through tty prompt" "0" "$init_rc"
+assert_eq "init requires restart verification before migration" "restart-required" "$($VAULT_HELPER setup-state)"
 if grep -q "$generated_pass" "$TEST_ROOT/init.err"; then
 	fail "hidden init prompt does not echo passphrase"
 else
@@ -172,6 +173,7 @@ unlock_rc=$?
 set -e
 assert_eq "unlock succeeds through tty prompt" "0" "$unlock_rc"
 assert_eq "status reports unlocked" "unlocked" "$($VAULT_HELPER status)"
+assert_eq "unlock verifies restart test and enables migration" "migration-ready" "$($VAULT_HELPER setup-state)"
 
 printf 'protected value' | "$VAULT_HELPER" update sample >/dev/null
 assert_eq "read returns encrypted entry after unlock" "protected value" "$($VAULT_HELPER read sample)"

--- a/.agents/scripts/tests/test-vault-setup-flow.sh
+++ b/.agents/scripts/tests/test-vault-setup-flow.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_DIR="${SCRIPT_DIR}/.."
+VAULT_HELPER="${HELPER_DIR}/vault-helper.sh"
+TEST_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-vault-setup-test)"
+PASS=0
+FAIL=0
+
+cleanup() {
+	AIDEVOPS_VAULT_DIR="$TEST_ROOT/vault" AIDEVOPS_VAULT_RUNTIME_DIR="$TEST_ROOT/run" "$VAULT_HELPER" lock >/dev/null 2>&1 || true
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	printf 'FAIL: %s\n' "$name" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$name"
+	else
+		printf '  expected: %s\n  actual:   %s\n' "$expected" "$actual" >&2
+		fail "$name"
+	fi
+	return 0
+}
+
+assert_nonzero() {
+	local name="$1"
+	local rc="$2"
+	if [[ "$rc" -ne 0 ]]; then
+		pass "$name"
+	else
+		fail "$name"
+	fi
+	return 0
+}
+
+run_with_tty() {
+	local input="$1"
+	shift
+	python3 - "$input" "$@" <<'PY'
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+inputs = sys.argv[1].encode().decode("unicode_escape").splitlines()
+cmd = sys.argv[2:]
+master, slave = pty.openpty()
+proc = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=slave)
+os.close(slave)
+sent = 0
+stderr_chunks = []
+deadline = time.time() + 20
+while time.time() < deadline:
+    reads = [master]
+    if proc.stdout is not None:
+        reads.append(proc.stdout.fileno())
+    ready, _, _ = select.select(reads, [], [], 0.1)
+    for fd in ready:
+        if fd == master:
+            try:
+                chunk = os.read(master, 4096)
+                stderr_chunks.append(chunk)
+                prompt_count = b"".join(stderr_chunks).count(b": ")
+                while sent < len(inputs) and sent < prompt_count:
+                    os.write(master, (inputs[sent] + "\n").encode())
+                    sent += 1
+            except OSError:
+                pass
+        elif proc.stdout is not None:
+            proc.stdout.read1(4096)
+    if proc.poll() is not None:
+        break
+if proc.poll() is None:
+    proc.terminate()
+    proc.wait(timeout=5)
+sys.stderr.buffer.write(b''.join(stderr_chunks))
+raise SystemExit(proc.returncode)
+PY
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+export AIDEVOPS_VAULT_DIR="$TEST_ROOT/vault"
+export AIDEVOPS_VAULT_RUNTIME_DIR="$TEST_ROOT/run"
+
+strong_pass="vault-${RANDOM}-$(date +%s)-strong"
+
+set +e
+run_with_tty "I UNDERSTAND\nshort\nshort\n" "$VAULT_HELPER" init >/dev/null 2>"$TEST_ROOT/weak.err"
+weak_rc=$?
+set -e
+assert_nonzero "first-use setup rejects passphrases shorter than 12 characters" "$weak_rc"
+
+set +e
+run_with_tty "I UNDERSTAND\n${strong_pass}\n${strong_pass}\n" "$VAULT_HELPER" init >/dev/null 2>"$TEST_ROOT/init.err"
+init_rc=$?
+set -e
+assert_eq "first-use setup succeeds with acknowledgement and strong passphrase" "0" "$init_rc"
+assert_eq "setup creates restart-required state" "restart-required" "$($VAULT_HELPER setup-state)"
+
+set +e
+printf 'real data' | "$VAULT_HELPER" update real-entry >/dev/null 2>"$TEST_ROOT/preverify.err"
+preverify_rc=$?
+set -e
+assert_nonzero "real data migration is unavailable before restart unlock" "$preverify_rc"
+
+set +e
+run_with_tty "${strong_pass}\n" "$VAULT_HELPER" unlock >/dev/null 2>"$TEST_ROOT/unlock.err"
+unlock_rc=$?
+set -e
+assert_eq "fresh unlock verifies harmless test record" "0" "$unlock_rc"
+assert_eq "restart verification reaches migration-ready" "migration-ready" "$($VAULT_HELPER setup-state)"
+
+printf 'real data' | "$VAULT_HELPER" update real-entry >/dev/null
+assert_eq "real data update succeeds after restart verification" "real data" "$($VAULT_HELPER read real-entry)"
+"$VAULT_HELPER" lock >/dev/null
+
+"$VAULT_HELPER" lost-passphrase archive-and-start-fresh >/dev/null
+assert_eq "archive flow resets active setup" "uninitialized" "$($VAULT_HELPER setup-state 2>/dev/null || true)"
+
+archive_count=0
+archive_dir=""
+for candidate in "$AIDEVOPS_VAULT_DIR"/archives/lost-passphrase-*; do
+	if [[ -d "$candidate" ]]; then
+		archive_count=$((archive_count + 1))
+		archive_dir="$candidate"
+	fi
+done
+assert_eq "archive flow preserves one encrypted archive directory" "1" "$archive_count"
+if [[ -f "$archive_dir/vault.json" && -f "$archive_dir/vault-store.json" && -f "$archive_dir/README.txt" ]]; then
+	pass "archive flow keeps encrypted metadata, store, and recovery README"
+else
+	fail "archive flow keeps encrypted metadata, store, and recovery README"
+fi
+if grep -q "$strong_pass" "$archive_dir/README.txt" "$archive_dir/vault.json" "$archive_dir/vault-store.json" 2>/dev/null; then
+	fail "archive files do not contain plaintext passphrase"
+else
+	pass "archive files do not contain plaintext passphrase"
+fi
+
+set +e
+"$VAULT_HELPER" export >/dev/null 2>"$TEST_ROOT/export.err"
+export_rc=$?
+"$VAULT_HELPER" import >/dev/null 2>"$TEST_ROOT/import.err"
+import_rc=$?
+"$VAULT_HELPER" rekey >/dev/null 2>"$TEST_ROOT/rekey.err"
+rekey_rc=$?
+set -e
+assert_nonzero "export placeholder fails safely" "$export_rc"
+assert_nonzero "import placeholder fails safely" "$import_rc"
+assert_nonzero "rekey placeholder fails safely" "$rekey_rc"
+
+printf '\nVault setup flow test summary: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/vault-crypto-helper.py
+++ b/.agents/scripts/vault-crypto-helper.py
@@ -8,14 +8,20 @@ from __future__ import annotations
 import argparse
 import os
 import secrets
+import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
 
-from vault_broker_lib import broker_alive, broker_request, run_broker
+from vault_broker_lib import broker_alive, broker_request, read_store, run_broker, write_store
 from vault_crypto_core import (
     KEY_LEN,
+    SETUP_STATE_MIGRATION_READY,
+    SETUP_STATE_RESTART_REQUIRED,
+    SETUP_STATE_TEST_VERIFIED,
+    SETUP_TEST_ENTRY_NAME,
+    SETUP_TEST_VALUE,
     STATE_CORRUPTED,
     STATE_LOCKED,
     STATE_UNINITIALIZED,
@@ -28,11 +34,14 @@ from vault_crypto_core import (
     ensure_private_dir,
     load_json,
     metadata_path,
+    prompt_acknowledgement,
     prompt_passphrase,
     runtime_dir,
+    setup_state,
     unwrap_root_key,
     validate_metadata,
     write_private_json,
+    write_setup_state,
 )
 
 
@@ -42,10 +51,17 @@ def cmd_init(args: argparse.Namespace) -> int:
     path = metadata_path(vault_dir)
     if path.exists() and not args.force:
         raise VaultError("VAULT_EXISTS", "Vault is already initialized", 2)
-    metadata = build_metadata(secrets.token_bytes(KEY_LEN), prompt_passphrase(confirm=True))
+    print("Create a Vault passphrase with at least 12 characters.", file=sys.stderr)
+    print("Use a trusted password manager with backups. Aidevops cannot recover it.", file=sys.stderr)
+    prompt_acknowledgement()
+    root_key = secrets.token_bytes(KEY_LEN)
+    metadata = build_metadata(root_key, prompt_passphrase(confirm=True, require_strong=True))
     write_private_json(path, metadata)
+    write_store(vault_dir, root_key, {"entries": {SETUP_TEST_ENTRY_NAME: SETUP_TEST_VALUE}})
+    write_setup_state(vault_dir, SETUP_STATE_RESTART_REQUIRED)
     append_audit(vault_dir, "init", True)
-    print("Vault initialized")
+    append_audit(vault_dir, "setup-test-created", True)
+    print("Vault setup test created; restart the process and run vault unlock to verify before migrating real data")
     return 0
 
 
@@ -75,7 +91,24 @@ def cmd_unlock(_args: argparse.Namespace) -> int:
     except VaultError:
         append_audit(vault_dir, "unlock", False, "decrypt-failed")
         raise
+    _verify_setup_test_if_needed(vault_dir, root_key)
     return _start_broker(vault_dir, root_key)
+
+
+def _verify_setup_test_if_needed(vault_dir: Path, root_key: bytes) -> None:
+    meta = load_json(metadata_path(vault_dir))
+    state = setup_state(meta)
+    if state == SETUP_STATE_MIGRATION_READY:
+        return
+    if state != SETUP_STATE_RESTART_REQUIRED:
+        raise VaultError("VAULT_SETUP_INCOMPLETE", "Vault setup restart test has not reached restart-required", 8)
+    store = read_store(vault_dir, root_key)
+    if store.get("entries", {}).get(SETUP_TEST_ENTRY_NAME) != SETUP_TEST_VALUE:
+        append_audit(vault_dir, "setup-test-verify", False, "missing-test-record")
+        raise VaultError("VAULT_SETUP_TEST_FAILED", "Vault setup test record could not be verified", 8)
+    write_setup_state(vault_dir, SETUP_STATE_TEST_VERIFIED)
+    write_setup_state(vault_dir, SETUP_STATE_MIGRATION_READY)
+    append_audit(vault_dir, "setup-test-verify", True)
 
 
 def _start_broker(vault_dir: Path, root_key: bytes) -> int:
@@ -131,10 +164,63 @@ def cmd_change_passphrase(_args: argparse.Namespace) -> int:
     meta = load_json(metadata_path(vault_dir))
     root_key = unwrap_root_key(meta, prompt_passphrase(confirm=False))
     print("Enter new Vault passphrase", file=sys.stderr)
-    write_private_json(metadata_path(vault_dir), build_metadata(root_key, prompt_passphrase(confirm=True)))
+    write_private_json(metadata_path(vault_dir), build_metadata(root_key, prompt_passphrase(confirm=True, require_strong=True)))
     append_audit(vault_dir, "change-passphrase", True)
     print("Vault passphrase changed")
     return 0
+
+
+def cmd_setup_state(_args: argparse.Namespace) -> int:
+    vault_dir = default_vault_dir()
+    path = metadata_path(vault_dir)
+    if not path.exists():
+        print(STATE_UNINITIALIZED)
+        return 2
+    print(setup_state(load_json(path)))
+    return 0
+
+
+def cmd_lost_passphrase(args: argparse.Namespace) -> int:
+    if args.recovery_command == "archive-and-start-fresh":
+        return _archive_and_start_fresh()
+    print("Lost passphrase options:")
+    print("1. Try again locally with the hidden prompt; do not paste passphrases into chat, env vars, or CLI args.")
+    print("2. Archive encrypted Vault files intact and start fresh: vault lost-passphrase archive-and-start-fresh")
+    print("3. Import from another already-unlocked trusted device when the sync/import child ships.")
+    print("4. Restore an encrypted backup or recovery kit when that child ships.")
+    return 0
+
+
+def _archive_and_start_fresh() -> int:
+    vault_dir = default_vault_dir()
+    if not vault_dir.exists():
+        print("Vault is already uninitialized")
+        return 0
+    archive_root = vault_dir / "archives"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    os.chmod(archive_root, 0o700)
+    archive_dir = archive_root / f"lost-passphrase-{int(time.time())}"
+    archive_dir.mkdir(mode=0o700)
+    for name in ("vault.json", "vault-store.json", "audit.log"):
+        source = vault_dir / name
+        if source.exists():
+            shutil.move(str(source), str(archive_dir / name))
+    readme = archive_dir / "README.txt"
+    readme.write_text(
+        "Encrypted aidevops Vault archive. No passphrase or recovery secret is stored here. "
+        "Keep this directory intact; if the passphrase is later recovered, future import tooling can attempt recovery.\n",
+        encoding="utf-8",
+    )
+    os.chmod(readme, 0o600)
+    shutil.rmtree(runtime_dir(vault_dir), ignore_errors=True)
+    append_audit(vault_dir, "lost-passphrase-archive", True, archive_dir.name)
+    print(f"Vault encrypted files archived intact: {archive_dir.name}")
+    print("Run vault init to start fresh with a new passphrase")
+    return 0
+
+
+def cmd_placeholder(args: argparse.Namespace) -> int:
+    raise VaultError("VAULT_COMMAND_NOT_READY", f"Vault {args.command} is reserved for a later sync/import/rekey phase", 9)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -144,6 +230,7 @@ def build_parser() -> argparse.ArgumentParser:
     init_p.add_argument("--force", action="store_true")
     init_p.set_defaults(func=cmd_init)
     sub.add_parser("status").set_defaults(func=cmd_status)
+    sub.add_parser("setup-state").set_defaults(func=cmd_setup_state)
     sub.add_parser("unlock").set_defaults(func=cmd_unlock)
     sub.add_parser("lock").set_defaults(func=cmd_lock)
     read_p = sub.add_parser("read")
@@ -153,6 +240,12 @@ def build_parser() -> argparse.ArgumentParser:
     update_p.add_argument("name")
     update_p.set_defaults(func=cmd_update)
     sub.add_parser("change-passphrase").set_defaults(func=cmd_change_passphrase)
+    lost_p = sub.add_parser("lost-passphrase")
+    lost_sub = lost_p.add_subparsers(dest="recovery_command")
+    lost_sub.add_parser("archive-and-start-fresh")
+    lost_p.set_defaults(func=cmd_lost_passphrase)
+    for reserved in ("export", "import", "rekey"):
+        sub.add_parser(reserved).set_defaults(func=cmd_placeholder)
     broker_p = sub.add_parser("broker")
     broker_p.add_argument("root_key_b64")
     broker_p.set_defaults(func=lambda args: run_broker(default_vault_dir(), args.root_key_b64))

--- a/.agents/scripts/vault-helper.sh
+++ b/.agents/scripts/vault-helper.sh
@@ -12,10 +12,15 @@ usage() {
 Usage: vault-helper.sh <command> [options]
 
 Commands:
-  init [--force]          Create local Vault metadata through hidden TTY prompts
+  init [--force]          Create local Vault metadata and harmless restart test
   unlock                  Unlock into an in-memory local broker through a hidden TTY prompt
   lock                    Stop the local broker and forget in-memory keys
   status                  Print uninitialized, locked, unlocked, or corrupted
+  setup-state             Print the first-use setup state
+  lost-passphrase         Show safe recovery options
+  lost-passphrase archive-and-start-fresh
+                          Archive encrypted Vault files intact and reset setup
+  export|import|rekey     Reserved placeholders; fail safely until sync/rekey ships
   read <name>             Read an entry through the unlocked broker
   update <name>           Read a new entry value from stdin and encrypt it
   change-passphrase       Rewrap the root key through hidden TTY prompts
@@ -42,7 +47,7 @@ main() {
 		usage
 		return 0
 		;;
-	init | unlock | lock | status | read | update | change-passphrase)
+	init | unlock | lock | status | setup-state | read | update | change-passphrase | lost-passphrase | export | import | rekey)
 		shift || true
 		require_crypto_helper || return 1
 		python3 "$CRYPTO_HELPER" "$command" "$@"

--- a/.agents/scripts/vault_broker_lib.py
+++ b/.agents/scripts/vault_broker_lib.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Any
 
 from vault_crypto_core import (
+    SETUP_STATE_MIGRATION_READY,
+    SETUP_TEST_ENTRY_NAME,
     STATE_LOCKED,
     STATE_UNLOCKED,
     VaultError,
@@ -28,6 +30,8 @@ from vault_crypto_core import (
     store_path,
     write_private_json,
     encrypt_json,
+    metadata_path,
+    setup_state,
 )
 
 
@@ -124,6 +128,10 @@ def _read_entry(vault_dir: Path, root_key: bytes, name: str) -> dict[str, Any]:
 def _update_entry(vault_dir: Path, root_key: bytes, name: str, value: str) -> dict[str, Any]:
     if not name:
         return {"ok": False, "code": "VAULT_BAD_NAME", "message": "Vault entry name is required", "exit": 2}
+    if name != SETUP_TEST_ENTRY_NAME:
+        state = setup_state(load_json(metadata_path(vault_dir)))
+        if state != SETUP_STATE_MIGRATION_READY:
+            return {"ok": False, "code": "VAULT_MIGRATION_BLOCKED", "message": "Vault setup restart test is not verified", "exit": 8}
     store = read_store(vault_dir, root_key)
     entries = dict(store.get("entries", {}))
     entries[name] = value

--- a/.agents/scripts/vault_crypto_core.py
+++ b/.agents/scripts/vault_crypto_core.py
@@ -29,6 +29,12 @@ STATE_UNINITIALIZED = "uninitialized"
 STATE_LOCKED = "locked"
 STATE_UNLOCKED = "unlocked"
 STATE_CORRUPTED = "corrupted"
+SETUP_STATE_TEST_CREATED = "test-created"
+SETUP_STATE_RESTART_REQUIRED = "restart-required"
+SETUP_STATE_TEST_VERIFIED = "test-verified"
+SETUP_STATE_MIGRATION_READY = "migration-ready"
+SETUP_TEST_ENTRY_NAME = "__aidevops_setup_test__"
+SETUP_TEST_VALUE = "aidevops vault setup restart verification test"
 
 
 class VaultError(Exception):
@@ -159,17 +165,29 @@ def decrypt_json(key: bytes, envelope: dict[str, Any], aad: bytes) -> dict[str, 
     return data
 
 
-def prompt_passphrase(confirm: bool = False) -> str:
+def prompt_passphrase(confirm: bool = False, require_strong: bool = False) -> str:
     if not sys.stdin.isatty() or not sys.stderr.isatty():
         raise VaultError("VAULT_TTY_REQUIRED", "Vault passphrase entry requires a local TTY", 5)
     first = getpass.getpass("Vault passphrase: ", stream=sys.stderr)
     if not first:
         raise VaultError("VAULT_PASSPHRASE_EMPTY", "Vault passphrase cannot be empty", 5)
+    if require_strong and len(first) < 12:
+        raise VaultError("VAULT_PASSPHRASE_WEAK", "Vault passphrase must be at least 12 characters", 5)
     if confirm:
         second = getpass.getpass("Confirm Vault passphrase: ", stream=sys.stderr)
         if not secrets.compare_digest(first, second):
             raise VaultError("VAULT_PASSPHRASE_MISMATCH", "Vault passphrases did not match", 5)
     return first
+
+
+def prompt_acknowledgement() -> None:
+    if not sys.stdin.isatty() or not sys.stderr.isatty():
+        raise VaultError("VAULT_TTY_REQUIRED", "Vault setup acknowledgement requires a local TTY", 5)
+    print("Vault cannot recover a lost passphrase. Save it in a trusted password manager with backups.", file=sys.stderr)
+    print("Type I UNDERSTAND to continue: ", end="", file=sys.stderr, flush=True)
+    answer = sys.stdin.readline().rstrip("\n")
+    if answer != "I UNDERSTAND":
+        raise VaultError("VAULT_ACK_REQUIRED", "Vault setup requires the no-recovery acknowledgement", 5)
 
 
 def validate_metadata(meta: dict[str, Any]) -> None:
@@ -202,7 +220,27 @@ def build_metadata(root_key: bytes, passphrase: str) -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
         "created_at": int(time.time()),
+        "setup_state": SETUP_STATE_TEST_CREATED,
         "kdf": {"name": KDF_NAME, "salt": b64e(salt), "params": DEFAULT_SCRYPT},
         "wrapped_root_key": wrapped,
         "broker": {"persisted_unlock_tokens": False, "transport": "local-unix-socket"},
     }
+
+
+def setup_state(meta: dict[str, Any]) -> str:
+    state = str(meta.get("setup_state", SETUP_STATE_MIGRATION_READY))
+    allowed = {
+        SETUP_STATE_TEST_CREATED,
+        SETUP_STATE_RESTART_REQUIRED,
+        SETUP_STATE_TEST_VERIFIED,
+        SETUP_STATE_MIGRATION_READY,
+    }
+    if state not in allowed:
+        raise VaultError("VAULT_METADATA_CORRUPTED", "Vault setup state is invalid", 3)
+    return state
+
+
+def write_setup_state(vault_dir: Path, state: str) -> None:
+    meta = load_json(metadata_path(vault_dir))
+    meta["setup_state"] = state
+    write_private_json(metadata_path(vault_dir), meta)

--- a/.agents/workflows/vault-setup.md
+++ b/.agents/workflows/vault-setup.md
@@ -11,11 +11,13 @@
 <!-- AI-CONTEXT-START -->
 
 **TL;DR:** Vault setup is local-first. Use `aidevops vault init`, `aidevops
-vault unlock`, `aidevops vault lock`, and `aidevops vault status` for the first
-local broker gate. Never ask for or accept Vault passphrases, recovery phrases,
-private keys, or raw secrets in AI chat, CLI arguments, environment variables,
-logs, issue comments, or fixtures. Use local interactive prompts, classify data
-before migration, and keep third-party AI provider routing explicit.
+vault unlock`, `aidevops vault lock`, `aidevops vault status`, and `aidevops
+vault setup-state` for the first local broker gate. Real data migration remains
+blocked until a fresh unlock verifies the harmless setup test record. Never ask
+for or accept Vault passphrases, recovery phrases, private keys, or raw secrets
+in AI chat, CLI arguments, environment variables, logs, issue comments, or
+fixtures. Use local interactive prompts, classify data before migration, and
+keep third-party AI provider routing explicit.
 
 <!-- AI-CONTEXT-END -->
 
@@ -65,24 +67,34 @@ hidden prompt:
 
 ```bash
 aidevops vault init
+aidevops vault setup-state
 aidevops vault status
 aidevops vault unlock
+aidevops vault setup-state
 aidevops vault lock
 ```
 
 Expected states:
 
 - Before setup: `aidevops vault status` prints `uninitialized`.
-- After setup and before unlock: status prints `locked`.
-- After a successful local TTY unlock: status prints `unlocked` while the broker
-  process is alive.
+- After setup and before unlock: status prints `locked`; setup-state prints
+  `restart-required`.
+- After a successful local TTY unlock in a fresh process: status prints
+  `unlocked` while the broker process is alive; setup-state prints
+  `migration-ready` after the harmless encrypted test record is read.
 - After `aidevops vault lock`, broker exit, crash, or restart: status prints
   `locked` and protected reads/updates fail closed.
+Real data writes are blocked with `VAULT_MIGRATION_BLOCKED` until setup-state is
+`migration-ready`.
 
 The initial helper writes `vault.json`, encrypted store data, and redacted audit
 events under `~/.config/aidevops/vault/` unless `AIDEVOPS_VAULT_DIR` relocates
 the store. Do not publish that path when it contains private machine or client
 context.
+
+Initial setup requires a 12+ character passphrase, confirmation, and the exact
+local acknowledgement `I UNDERSTAND` that aidevops cannot recover a lost
+passphrase. Store the passphrase in a trusted password manager with backups.
 
 ### Step 1: Explain boundaries
 
@@ -176,6 +188,20 @@ Recovery must be safe by default:
 Acceptable recovery approaches include offline recovery codes, hardware-backed
 keys, Shamir-style splits implemented by audited libraries, or trusted-device
 approval. Avoid bespoke recovery cryptography.
+
+The currently implemented lost-passphrase CLI flow is conservative:
+
+```bash
+aidevops vault lost-passphrase
+aidevops vault lost-passphrase archive-and-start-fresh
+```
+
+The archive-and-start-fresh path moves active encrypted metadata, store, and
+audit files into a private `archives/lost-passphrase-*` directory, writes a
+README without secrets, clears the local broker runtime, and leaves the active
+Vault uninitialized so a new setup can start. It does not decrypt or delete the
+archive; future import tooling can attempt recovery if the passphrase is later
+found.
 
 ## 5. Migration Checklist
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ tool context, so provider-side logs/retention remain outside Vault's technical
 control. Future local LLM mode reduces provider exposure but not local host
 compromise risk.
 
+**Vault passphrase warning:** aidevops cannot recover a lost Vault passphrase.
+Save it in a trusted password manager with backups; never paste it into AI chat,
+CLI arguments, environment variables, logs, issue comments, or test fixtures.
+
 ### Report creation, previews, and PDF exports
 
 Use aidevops to turn evidence bundles into decision-ready reports while keeping Markdown or JSON as the canonical source. Report agents can produce AI-search audits, SEO/GEO scorecards, delivery reviews, campaign reports, board packs, incident summaries, recurring client handoffs, and before/after remediation evidence.


### PR DESCRIPTION
## Summary

Implemented Vault first-use setup state tracking, harmless restart verification before migration, lost-passphrase archive/start-fresh flow, safe placeholders for export/import/rekey, tests, and user guidance.

## Files Changed

.agents/scripts/tests/test-vault-helper.sh,.agents/scripts/tests/test-vault-setup-flow.sh,.agents/scripts/vault-crypto-helper.py,.agents/scripts/vault-helper.sh,.agents/scripts/vault_broker_lib.py,.agents/scripts/vault_crypto_core.py,.agents/workflows/vault-setup.md,README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/tests/test-vault-setup-flow.sh; ./.agents/scripts/tests/test-vault-helper.sh; .agents/scripts/linters-local.sh

Resolves #25536


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 17m and 105,686 tokens on this as a headless worker.