### PR TITLE
t18001: feat: migrate data planes behind vault

### DIFF
--- a/.agents/reference/vault.md
+++ b/.agents/reference/vault.md
@@ -4,9 +4,9 @@
 # Aidevops Vault Security Architecture RFC
 
 > **Status:** RFC plus initial local CLI/broker implementation. The first shipped
-> helper covers local metadata, passphrase wrapping, an in-memory broker, and
-> locked-state gates; fleet sync, GUI routing, and protected data migrations are
-> still future phases.
+> helper covers local metadata, passphrase wrapping, an in-memory broker,
+> locked-state gates, managed history gates, and the first verified data-plane
+> migration helper; fleet sync and GUI routing are still future phases.
 
 <!-- AI-CONTEXT-START -->
 
@@ -335,6 +335,31 @@ VPS devices are expected to run locked unless a task explicitly requires unlocke
 protected data and the device has a fresh heartbeat plus matching grants. Never
 place recovery material in cloud-init, environment variables, issue comments,
 logs, or shell history.
+
+### Phase 2.5: Data-plane migration and locked-state gates
+
+`.agents/scripts/vault-storage-lib.sh` is the shared fail-closed gate for helpers
+that read or write protected local data. Memory recall/store, semantic memory
+embeddings, and knowledge add/list/search call it before opening plaintext stores.
+When Vault metadata exists, or `AIDEVOPS_VAULT_REQUIRE=1` is set for tests or
+managed deployments, a locked or unavailable broker returns `VAULT_LOCKED` and
+must not create fresh plaintext databases or generated semantic indexes.
+
+`.agents/scripts/vault-migration-helper.sh` migrates current aidevops data-plane
+files into Vault entries with a TSV manifest containing collection, source path,
+SHA-256 hash, encrypted entry reference, and verification state. It streams each
+source file to `vault update <entry>`, reads the entry back with `vault read`,
+compares hashes, and only then removes the plaintext original with best-effort
+scrubbing. Rollback restores files from verified Vault entries instead of keeping
+a plaintext rollback copy.
+
+Initial collection keys are `memory`, `embeddings`, `knowledge`, `workspace`,
+`mail-messages`, `config-metadata`, and `audit`. Public/private Git, object
+storage, and sync transports may carry only encrypted entries and non-secret
+manifests. The helper cannot erase historical plaintext from SSD remapping,
+APFS/journal metadata, filesystem snapshots, backups, swap, crash dumps, terminal
+scrollback, or committed Git history; full-disk encryption/FileVault remains a
+baseline requirement for historical remnants.
 
 ### Phase 3: Remote lock and unlock-request
 

--- a/.agents/scripts/knowledge-helper.sh
+++ b/.agents/scripts/knowledge-helper.sh
@@ -41,6 +41,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=vault-storage-lib.sh
+[[ -f "${SCRIPT_DIR}/vault-storage-lib.sh" ]] && source "${SCRIPT_DIR}/vault-storage-lib.sh"
 
 # Guard color fallbacks when shared-constants.sh is absent
 [[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
@@ -73,6 +75,7 @@ KNOWLEDGE_ROOT="_knowledge"
 KNOWLEDGE_CONFIG_SUBDIR="_config"
 KNOWLEDGE_CONFIG_FILE="knowledge.json"
 KNOWLEDGE_DIRS=(inbox staging sources index collections)
+VAULT_COLLECTION_KNOWLEDGE="knowledge"
 
 SCRIPT_TEMPLATES_DIR="${SCRIPT_DIR%/scripts}/templates"
 GITIGNORE_TEMPLATE="${SCRIPT_TEMPLATES_DIR}/knowledge-gitignore.txt"
@@ -1104,12 +1107,12 @@ main() {
 	case "$subcommand" in
 	provision)   cmd_provision "$@" ;;
 	init)        cmd_init "$@" ;;
-	add)         cmd_add "$@" ;;
-	list)        cmd_list "$@" ;;
+	add)         vault_storage_require_unlocked "$VAULT_COLLECTION_KNOWLEDGE" && cmd_add "$@" ;;
+	list)        vault_storage_require_unlocked "$VAULT_COLLECTION_KNOWLEDGE" && cmd_list "$@" ;;
 	sensitivity) cmd_sensitivity "$@" ;;
 	enrich)      cmd_enrich "$@" ;;
 	status)      cmd_status "$@" ;;
-	search)      cmd_search "$@" ;;
+	search)      vault_storage_require_unlocked "$VAULT_COLLECTION_KNOWLEDGE" && cmd_search "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		print_error "Unknown subcommand: $subcommand"

--- a/.agents/scripts/memory-embeddings-helper.sh
+++ b/.agents/scripts/memory-embeddings-helper.sh
@@ -31,6 +31,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=vault-storage-lib.sh
+source "${SCRIPT_DIR}/vault-storage-lib.sh"
 
 set -euo pipefail
 
@@ -40,6 +42,7 @@ readonly LOCAL_MODEL_NAME="all-MiniLM-L6-v2"
 readonly LOCAL_EMBEDDING_DIM=384
 readonly OPENAI_MODEL_NAME="text-embedding-3-small"
 readonly OPENAI_EMBEDDING_DIM=1536
+readonly VAULT_COLLECTION_MEMORY_EMBEDDINGS="memory-embeddings"
 
 # Namespace support: resolved in main() before command dispatch
 EMBEDDINGS_NAMESPACE=""
@@ -197,14 +200,14 @@ main() {
 	fi
 
 	case "$command" in
-	setup) cmd_setup "$@" ;;
-	index) cmd_index ;;
-	search) cmd_search "$@" ;;
-	add) cmd_add "${1:-}" ;;
-	auto-index) cmd_auto_index "${1:-}" ;;
-	find-similar) cmd_find_similar "$@" ;;
-	status) cmd_status ;;
-	rebuild) cmd_rebuild ;;
+	setup) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_setup "$@" ;;
+	index) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_index ;;
+	search) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_search "$@" ;;
+	add) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_add "${1:-}" ;;
+	auto-index) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_auto_index "${1:-}" ;;
+	find-similar) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_find_similar "$@" ;;
+	status) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_status ;;
+	rebuild) vault_storage_require_unlocked "$VAULT_COLLECTION_MEMORY_EMBEDDINGS" && cmd_rebuild ;;
 	provider) cmd_provider "${1:-}" ;;
 	help | --help | -h) cmd_help ;;
 	*)

--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -46,6 +46,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=vault-storage-lib.sh
+source "${SCRIPT_DIR}/vault-storage-lib.sh"
 
 set -euo pipefail
 
@@ -416,8 +418,8 @@ main() {
 	fi
 
 	case "$command" in
-	store) cmd_store "$@" ;;
-	recall) cmd_recall "$@" ;;
+	store) vault_storage_require_unlocked "memory" && cmd_store "$@" ;;
+	recall) vault_storage_require_unlocked "memory" && cmd_recall "$@" ;;
 	feedback) cmd_feedback "$@" ;;
 	log) cmd_log "$@" ;;
 	history) cmd_history "$@" ;;

--- a/.agents/scripts/tests/test-vault-data-migration.sh
+++ b/.agents/scripts/tests/test-vault-data-migration.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_DIR="${SCRIPT_DIR}/.."
+MIGRATION_HELPER="${HELPER_DIR}/vault-migration-helper.sh"
+MEMORY_HELPER="${HELPER_DIR}/memory-helper.sh"
+EMBEDDINGS_HELPER="${HELPER_DIR}/memory-embeddings-helper.sh"
+TEST_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-vault-migration-test)"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	printf 'FAIL: %s\n' "$name" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$name"
+	else
+		printf '  expected: %s\n  actual:   %s\n' "$expected" "$actual" >&2
+		fail "$name"
+	fi
+	return 0
+}
+
+assert_nonzero() {
+	local name="$1"
+	local rc="$2"
+	if [[ "$rc" -ne 0 ]]; then
+		pass "$name"
+	else
+		fail "$name"
+	fi
+	return 0
+}
+
+write_mock_vault_helper() {
+	local path="$1"
+	mkdir -p "$(dirname "$path")"
+	cat >"$path" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+store_dir="${MOCK_VAULT_STORE_DIR:?}"
+state_file="${MOCK_VAULT_STATE_FILE:?}"
+command="${1:-status}"
+shift || true
+case "$command" in
+status)
+	cat "$state_file"
+	;;
+update)
+	name="${1:?}"
+	mkdir -p "$store_dir"
+	cat >"${store_dir}/${name//\//_}"
+	;;
+read)
+	name="${1:?}"
+	cat "${store_dir}/${name//\//_}"
+	;;
+*) exit 2 ;;
+esac
+MOCK
+	chmod +x "$path"
+	return 0
+}
+
+export AIDEVOPS_VAULT_REQUIRE=1
+export AIDEVOPS_MEMORY_DIR="$TEST_ROOT/memory"
+export AIDEVOPS_VAULT_MIGRATION_ROOT="$TEST_ROOT/workspace"
+export AIDEVOPS_VAULT_MIGRATION_MANIFEST_DIR="$TEST_ROOT/manifest"
+export MOCK_VAULT_STORE_DIR="$TEST_ROOT/mock-store"
+export MOCK_VAULT_STATE_FILE="$TEST_ROOT/mock-state"
+export AIDEVOPS_VAULT_HELPER="$TEST_ROOT/bin/mock-vault-helper.sh"
+write_mock_vault_helper "$AIDEVOPS_VAULT_HELPER"
+
+printf '%s\n' locked >"$MOCK_VAULT_STATE_FILE"
+
+set +e
+locked_output="$($MEMORY_HELPER recall --query test 2>&1 >/dev/null)"
+locked_rc=$?
+set -e
+assert_nonzero "locked memory recall fails closed" "$locked_rc"
+case "$locked_output" in
+*VAULT_LOCKED*) pass "locked memory recall reports VAULT_LOCKED" ;;
+*) fail "locked memory recall reports VAULT_LOCKED" ;;
+esac
+
+set +e
+embeddings_output="$($EMBEDDINGS_HELPER status 2>&1 >/dev/null)"
+embeddings_rc=$?
+set -e
+assert_nonzero "locked embeddings status fails closed" "$embeddings_rc"
+case "$embeddings_output" in
+*VAULT_LOCKED*) pass "locked embeddings status reports VAULT_LOCKED" ;;
+*) fail "locked embeddings status reports VAULT_LOCKED" ;;
+esac
+
+mkdir -p "$AIDEVOPS_VAULT_MIGRATION_ROOT/memory" "$AIDEVOPS_VAULT_MIGRATION_ROOT/knowledge/sources/a"
+printf '%s' 'memory plaintext' >"$AIDEVOPS_VAULT_MIGRATION_ROOT/memory/memory.db"
+printf '%s' 'knowledge plaintext' >"$AIDEVOPS_VAULT_MIGRATION_ROOT/knowledge/sources/a/source.md"
+
+plan_path="$($MIGRATION_HELPER plan)"
+if grep -q 'memory.db' "$plan_path" && grep -q 'source.md' "$plan_path"; then
+	pass "plan records memory and knowledge files"
+else
+	fail "plan records memory and knowledge files"
+fi
+
+set +e
+$MIGRATION_HELPER migrate >/dev/null 2>"$TEST_ROOT/locked-migrate.err"
+migrate_locked_rc=$?
+set -e
+assert_nonzero "locked migration fails before plaintext removal" "$migrate_locked_rc"
+if [[ -f "$AIDEVOPS_VAULT_MIGRATION_ROOT/memory/memory.db" ]]; then
+	pass "locked migration preserves plaintext source"
+else
+	fail "locked migration preserves plaintext source"
+fi
+
+printf '%s\n' unlocked >"$MOCK_VAULT_STATE_FILE"
+$MIGRATION_HELPER migrate
+$MIGRATION_HELPER verify
+if [[ ! -f "$AIDEVOPS_VAULT_MIGRATION_ROOT/memory/memory.db" ]]; then
+	pass "verified migration removes plaintext memory db"
+else
+	fail "verified migration removes plaintext memory db"
+fi
+if grep -q 'verified-scrubbed' "$plan_path"; then
+	pass "manifest records verified scrub state"
+else
+	fail "manifest records verified scrub state"
+fi
+
+$MIGRATION_HELPER rollback
+assert_eq "rollback restores memory content" "memory plaintext" "$(cat "$AIDEVOPS_VAULT_MIGRATION_ROOT/memory/memory.db")"
+
+if [[ "$FAIL" -ne 0 ]]; then
+	printf 'FAILED: %s failures, %s passes\n' "$FAIL" "$PASS" >&2
+	exit 1
+fi
+printf 'OK: %s assertions passed\n' "$PASS"

--- a/.agents/scripts/vault-migration-helper.sh
+++ b/.agents/scripts/vault-migration-helper.sh
@@ -46,7 +46,11 @@ collection_for_path() {
 
 hash_file() {
 	local path="$1"
-	sha256sum "$path" | cut -d' ' -f1
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$path" | cut -d' ' -f1
+		return 0
+	fi
+	shasum -a 256 "$path" | cut -d' ' -f1
 	return 0
 }
 

--- a/.agents/scripts/vault-migration-helper.sh
+++ b/.agents/scripts/vault-migration-helper.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Migrate aidevops data-plane files into encrypted Vault entries with verified rollback.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=vault-storage-lib.sh
+source "${SCRIPT_DIR}/vault-storage-lib.sh"
+
+MIGRATION_ROOT="${AIDEVOPS_VAULT_MIGRATION_ROOT:-$HOME/.aidevops/.agent-workspace}"
+MANIFEST_DIR="${AIDEVOPS_VAULT_MIGRATION_MANIFEST_DIR:-$(vault_storage_dir)/migration-manifests}"
+MANIFEST_FILE="${AIDEVOPS_VAULT_MIGRATION_MANIFEST:-${MANIFEST_DIR}/aidevops-data-migration.tsv}"
+MANIFEST_HEADER_COLLECTION="collection"
+
+usage() {
+	cat <<'EOF'
+Usage: vault-migration-helper.sh <plan|migrate|verify|rollback|status>
+
+Migrates memory, embeddings, knowledge, workspace, mail/messages, config
+metadata, and audit files into encrypted Vault entries. Plaintext originals are
+removed only after read-back hash verification. Rollback restores from Vault;
+passphrases are never accepted via args, env, chat, logs, or fixtures.
+
+Limits: best-effort file removal cannot erase historical SSD/APFS/journal,
+filesystem snapshot, backup, swap, crash-dump, or committed Git remnants. Keep
+full-disk encryption/FileVault enabled for historical plaintext exposure.
+EOF
+	return 0
+}
+
+collection_for_path() {
+	local path="$1"
+	case "$path" in
+	*/memory.db | */memory.db-* ) printf '%s\n' "memory" ;;
+	*/embeddings.db | */embeddings.db-* | */.embeddings-* ) printf '%s\n' "embeddings" ;;
+	*/knowledge/* | */_knowledge/* ) printf '%s\n' "knowledge" ;;
+	*/mail/* | */messages/* ) printf '%s\n' "mail-messages" ;;
+	*/audit.log | */audit/* ) printf '%s\n' "audit" ;;
+	*/config/* | */repos.json | */credentials.json ) printf '%s\n' "config-metadata" ;;
+	*) printf '%s\n' "workspace" ;;
+	esac
+	return 0
+}
+
+hash_file() {
+	local path="$1"
+	sha256sum "$path" | cut -d' ' -f1
+	return 0
+}
+
+entry_name() {
+	local collection="$1"
+	local digest="$2"
+	printf 'migration:%s:%s\n' "$collection" "$digest"
+	return 0
+}
+
+write_manifest_header() {
+	mkdir -p "$MANIFEST_DIR"
+	chmod 700 "$MANIFEST_DIR"
+	printf '%s\tsha256\tentry\tstate\tpath\n' "$MANIFEST_HEADER_COLLECTION" >"$MANIFEST_FILE"
+	chmod 600 "$MANIFEST_FILE"
+	return 0
+}
+
+iter_sources() {
+	local root="$MIGRATION_ROOT"
+	[[ -d "$root" ]] || return 0
+	find "$root" -type f \( \
+		-name 'memory.db' -o -name 'memory.db-*' -o -name 'embeddings.db' -o -name 'embeddings.db-*' -o \
+		-path '*/knowledge/*' -o -path '*/_knowledge/*' -o -path '*/mail/*' -o -path '*/messages/*' -o \
+		-path '*/config/*' -o -path '*/audit/*' -o -name 'audit.log' \
+	\) -print | sort
+	return 0
+}
+
+cmd_plan() {
+	local path collection digest entry
+	write_manifest_header
+	while IFS= read -r path; do
+		[[ -f "$path" ]] || continue
+		collection=$(collection_for_path "$path")
+		digest=$(hash_file "$path")
+		entry=$(entry_name "$collection" "$digest")
+		printf '%s\t%s\t%s\tplanned\t%s\n' "$collection" "$digest" "$entry" "$path" >>"$MANIFEST_FILE"
+	done < <(iter_sources)
+	printf '%s\n' "$MANIFEST_FILE"
+	return 0
+}
+
+verify_entry() {
+	local entry="$1"
+	local expected="$2"
+	local tmp_file
+	tmp_file=$(mktemp)
+	if ! "$(vault_storage_helper_path)" read "$entry" >"$tmp_file"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	local actual
+	actual=$(hash_file "$tmp_file")
+	rm -f "$tmp_file"
+	[[ "$actual" == "$expected" ]]
+	return $?
+}
+
+scrub_plaintext_file() {
+	local path="$1"
+	chmod u+w "$path" 2>/dev/null || true
+	if command -v shred >/dev/null 2>&1; then
+		shred -u "$path" 2>/dev/null || rm -f "$path"
+	else
+		rm -f "$path"
+	fi
+	return 0
+}
+
+cmd_migrate() {
+	vault_storage_require_unlocked "vault migration" || return $?
+	[[ -f "$MANIFEST_FILE" ]] || cmd_plan >/dev/null
+	local tmp_manifest="${MANIFEST_FILE}.tmp"
+	local read_manifest="${MANIFEST_FILE}.read"
+	local collection digest entry state path
+	cp "$MANIFEST_FILE" "$read_manifest"
+	printf '%s\tsha256\tentry\tstate\tpath\n' "$MANIFEST_HEADER_COLLECTION" >"$tmp_manifest"
+	while IFS=$'\t' read -r collection digest entry state path; do
+		[[ "$collection" == "$MANIFEST_HEADER_COLLECTION" ]] && continue
+		[[ -f "$path" ]] || { printf '%s\t%s\t%s\tmissing\t%s\n' "$collection" "$digest" "$entry" "$path" >>"$tmp_manifest"; continue; }
+		"$(vault_storage_helper_path)" update "$entry" <"$path" >/dev/null
+		if verify_entry "$entry" "$digest"; then
+			scrub_plaintext_file "$path"
+			printf '%s\t%s\t%s\tverified-scrubbed\t%s\n' "$collection" "$digest" "$entry" "$path" >>"$tmp_manifest"
+		else
+			printf '%s\t%s\t%s\tverify-failed\t%s\n' "$collection" "$digest" "$entry" "$path" >>"$tmp_manifest"
+			mv "$tmp_manifest" "$MANIFEST_FILE"
+			return 1
+		fi
+	done <"$read_manifest"
+	rm -f "$read_manifest"
+	mv "$tmp_manifest" "$MANIFEST_FILE"
+	return 0
+}
+
+cmd_verify() {
+	vault_storage_require_unlocked "vault migration verify" || return $?
+	local collection digest entry state path failures=0
+	while IFS=$'\t' read -r collection digest entry state path; do
+		[[ "$collection" == "$MANIFEST_HEADER_COLLECTION" ]] && continue
+		if ! verify_entry "$entry" "$digest"; then
+			printf '%s\n' "verify failed: ${entry}" >&2
+			failures=$((failures + 1))
+		fi
+	done <"$MANIFEST_FILE"
+	[[ "$failures" -eq 0 ]]
+	return $?
+}
+
+cmd_rollback() {
+	vault_storage_require_unlocked "vault migration rollback" || return $?
+	local collection digest entry state path
+	while IFS=$'\t' read -r collection digest entry state path; do
+		[[ "$collection" == "$MANIFEST_HEADER_COLLECTION" ]] && continue
+		mkdir -p "$(dirname "$path")"
+		"$(vault_storage_helper_path)" read "$entry" >"$path"
+		chmod 600 "$path"
+	done <"$MANIFEST_FILE"
+	return 0
+}
+
+cmd_status() {
+	if [[ -f "$MANIFEST_FILE" ]]; then
+		printf '%s\n' "$MANIFEST_FILE"
+	else
+		printf '%s\n' "no migration manifest"
+	fi
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	case "$command" in
+	help | --help | -h) usage ;;
+	plan) cmd_plan ;;
+	migrate) cmd_migrate ;;
+	verify) cmd_verify ;;
+	rollback) cmd_rollback ;;
+	status) cmd_status ;;
+	*) usage >&2; return 2 ;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/vault-storage-lib.sh
+++ b/.agents/scripts/vault-storage-lib.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared locked-state gates for helpers that read/write Vault-protected data.
+
+[[ -n "${_AIDEVOPS_VAULT_STORAGE_LIB_LOADED:-}" ]] && return 0
+_AIDEVOPS_VAULT_STORAGE_LIB_LOADED=1
+
+vault_storage_helper_path() {
+	local helper="${AIDEVOPS_VAULT_HELPER:-}"
+	if [[ -n "$helper" ]]; then
+		printf '%s\n' "$helper"
+		return 0
+	fi
+	printf '%s\n' "${SCRIPT_DIR}/vault-helper.sh"
+	return 0
+}
+
+vault_storage_dir() {
+	local configured="${AIDEVOPS_VAULT_DIR:-}"
+	if [[ -n "$configured" ]]; then
+		printf '%s\n' "$configured"
+		return 0
+	fi
+	printf '%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/aidevops/vault"
+	return 0
+}
+
+vault_storage_active() {
+	local vault_dir
+	vault_dir=$(vault_storage_dir)
+	if [[ "${AIDEVOPS_VAULT_REQUIRE:-0}" == "1" ]]; then
+		return 0
+	fi
+	[[ -f "${vault_dir}/vault.json" ]]
+	return $?
+}
+
+vault_storage_require_unlocked() {
+	local collection="$1"
+	local helper status_output status_rc
+	if ! vault_storage_active; then
+		return 0
+	fi
+	helper=$(vault_storage_helper_path)
+	if [[ ! -x "$helper" ]]; then
+		printf '%s\n' "VAULT_LOCKED: Vault helper is unavailable for ${collection}" >&2
+		return 6
+	fi
+	status_output=$("$helper" status 2>/dev/null) && status_rc=0 || status_rc=$?
+	if [[ "$status_rc" -ne 0 || "$status_output" != "unlocked" ]]; then
+		printf '%s\n' "VAULT_LOCKED: ${collection} requires an unlocked aidevops Vault" >&2
+		return 6
+	fi
+	return 0
+}


### PR DESCRIPTION
## Summary

Added shared Vault locked-state gates for memory, semantic embeddings, and knowledge helpers; added vault-migration-helper.sh with manifest, encrypt-readback verification, best-effort plaintext cleanup, and rollback from Vault entries; documented migration limits in .agents/reference/vault.md; added test-vault-data-migration.sh for locked denial, verified migration, scrub state, and rollback.

## Files Changed

.agents/reference/vault.md,.agents/scripts/knowledge-helper.sh,.agents/scripts/memory-embeddings-helper.sh,.agents/scripts/memory-helper.sh,.agents/scripts/tests/test-vault-data-migration.sh,.agents/scripts/vault-migration-helper.sh,.agents/scripts/vault-storage-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/tests/test-vault-data-migration.sh; .agents/scripts/linters-local.sh

Resolves #25538


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 18m and 123,568 tokens on this as a headless worker.