### PR TITLE
fix: stabilize failure miner affected paths

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -400,8 +400,13 @@ fetch_pr_changed_paths_json() {
 		printf '%s\n' '[]'
 		return 0
 	fi
-	gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" --jq '.[].filename' 2>/dev/null |
-		jq -c -R -s '[splits("\n") | select(length > 0)] | unique' 2>/dev/null || printf '%s\n' '[]'
+
+	local files
+	if ! files=$(gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" --jq '.[].filename' 2>/dev/null); then
+		printf '%s\n' '[]'
+		return 0
+	fi
+	printf '%s\n' "$files" | jq -c -R -s '[splits("\n") | select(length > 0)] | unique' || printf '%s\n' '[]'
 	return 0
 }
 
@@ -551,16 +556,21 @@ process_failed_runs() {
 			is_infra="true"
 		fi
 
+		local run_affected_paths="[]"
 		if [[ "$source_kind" == "pr" ]] && [[ -n "$pr_number" ]] &&
 			{ [[ "$check_name" =~ [Cc]ode[Ff]actor ]] || [[ "$signature" == "failure:codefactor.io" ]]; } &&
 			[[ "$affected_paths_json" == "[]" ]]; then
 			affected_paths_json=$(fetch_pr_changed_paths_json "$repo_slug" "$pr_number")
 		fi
+		if [[ "$source_kind" == "pr" ]] && [[ -n "$pr_number" ]] &&
+			{ [[ "$check_name" =~ [Cc]ode[Ff]actor ]] || [[ "$signature" == "failure:codefactor.io" ]]; }; then
+			run_affected_paths="$affected_paths_json"
+		fi
 
 		emit_event_json "$repo_slug" "$source_kind" "$source_ref" "$source_url" \
 			"$pr_number" "$commit_sha" "$check_name" "$conclusion" \
 			"$run_id" "$html_url" "$details_url" "$completed_at" \
-			"$signature" "$notification_updated_at" "$is_infra" "$affected_paths_json" >>"$event_file"
+			"$signature" "$notification_updated_at" "$is_infra" "$run_affected_paths" >>"$event_file"
 
 		failed_index=$((failed_index + 1))
 	done

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -32,6 +32,20 @@ assert_contains() {
 	return 0
 }
 
+assert_equals() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected: %s\n' "$(printf '%q' "$expected")"
+		printf '  actual:   %s\n' "$(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
 HELPER="$SCRIPT_DIR/gh-failure-miner-helper.sh"
 
@@ -47,7 +61,11 @@ set -- help
 source "$HELPER" >/dev/null
 
 gh() {
-	local _api="$1" _paginate="$2" _endpoint="$3" _jq_flag="$4" _jq_expr="$5"
+	local _api="${1:-}" _paginate="${2:-}" _endpoint="${3:-}" _jq_flag="${4:-}" _jq_expr="${5:-}"
+	if [[ "${GH_MODE:-success}" == "fail" ]]; then
+		printf '%s\n' "simulated gh api failure" >&2
+		return 1
+	fi
 	if [[ "$_api" == "api" && "$_paginate" == "--paginate" && "$_endpoint" == "repos/marcusquinn/aidevops/pulls/25324/files?per_page=100" && "$_jq_flag" == "--jq" && "$_jq_expr" == ".[].filename" ]]; then
 		printf '%s\n' ".agents/scripts/vault-helper.sh" ".agents/scripts/vault-crypto-helper.py" ".agents/scripts/vault-helper.sh"
 		return 0
@@ -99,6 +117,42 @@ JSON
 body=$(build_issue_body "$cluster_json" "46250abc5695" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
 paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
+GH_MODE=fail
+failed_paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
+GH_MODE=success
+
+failed_runs_json=$(cat <<'JSON'
+[
+  {
+    "name": "CodeFactor",
+    "conclusion": "failure",
+    "details_url": "https://www.codefactor.io/repository/github/marcusquinn/aidevops/pull/25324",
+    "html_url": "https://github.com/marcusquinn/aidevops/runs/82536587204",
+    "completed_at": "2026-06-26T07:00:00Z",
+    "app": {"name": "codefactor.io"}
+  },
+  {
+    "name": "ShellCheck",
+    "conclusion": "failure",
+    "details_url": "https://github.com/marcusquinn/aidevops/actions/runs/82536587205/job/1",
+    "html_url": "https://github.com/marcusquinn/aidevops/runs/82536587205",
+    "completed_at": "2026-06-26T07:01:00Z",
+    "app": {"name": "GitHub Actions"}
+  }
+]
+JSON
+)
+checks_json=$(cat <<'JSON'
+{"check_runs":[]}
+JSON
+)
+event_file=$(mktemp)
+process_failed_runs "$failed_runs_json" "marcusquinn/aidevops" "pr" "#25324" "https://github.com/marcusquinn/aidevops/pull/25324" \
+	"25324" "46250abc5695" "2026-06-26T07:02:00Z" "false" "0" "0" "$event_file" "$checks_json" >/dev/null
+mined_events_json=$(jq -s '.' "$event_file")
+codefactor_paths_json=$(printf '%s\n' "$mined_events_json" | jq -c '.[0].affected_paths')
+shellcheck_paths_json=$(printf '%s\n' "$mined_events_json" | jq -c '.[1].affected_paths')
+rm -f "$event_file"
 
 assert_contains "build_issue_body includes Worker Guidance" "## Worker Guidance" "$body"
 assert_contains "build_issue_body directs workers to CodeFactor details" "Open the CodeFactor details URL from Evidence first" "$body"
@@ -110,6 +164,9 @@ assert_contains "render_issue_body_markdown includes Worker Guidance" "## Worker
 assert_contains "render_issue_body_markdown directs workers to provider details" "details URL" "$legacy_body"
 assert_contains "render_issue_body_markdown includes affected file fallback" "affected files: .agents/scripts/vault-crypto-helper.py, .agents/scripts/vault-helper.sh" "$legacy_body"
 assert_contains "fetch_pr_changed_paths_json returns unique sorted paths" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$paths_json"
+assert_equals "fetch_pr_changed_paths_json emits one JSON array on gh failure" '[]' "$failed_paths_json"
+assert_equals "process_failed_runs attaches paths to CodeFactor failure" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$codefactor_paths_json"
+assert_equals "process_failed_runs does not leak CodeFactor paths to later checks" '[]' "$shellcheck_paths_json"
 
 printf '\nTests run: %s\n' "$TESTS_RUN"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Fixed PR changed-path fetching so `gh api` failures emit exactly one `[]` fallback instead of invalid duplicated JSON.
- Scoped cached CodeFactor affected paths to CodeFactor events so later non-CodeFactor failures do not inherit those paths.
- Added regression coverage for the API failure fallback and per-run affected-path scoping.

## Testing
- `shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh`
- `.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh`

Resolves #25564
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 105,808 tokens on this as a headless worker.