### PR TITLE
GH#25563: fix: harden vault storage helper lookup

### DIFF
--- a/.agents/scripts/vault-storage-lib.sh
+++ b/.agents/scripts/vault-storage-lib.sh
@@ -22,7 +22,7 @@ vault_storage_dir() {
 		printf '%s\n' "$configured"
 		return 0
 	fi
-	printf '%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/aidevops/vault"
+	printf '%s\n' "${XDG_CONFIG_HOME:-${HOME:-}/.config}/aidevops/vault"
 	return 0
 }
 
@@ -43,7 +43,7 @@ vault_storage_require_unlocked() {
 		return 0
 	fi
 	helper=$(vault_storage_helper_path)
-	if [[ ! -x "$helper" ]]; then
+	if ! command -v "$helper" >/dev/null 2>&1; then
 		printf '%s\n' "VAULT_LOCKED: Vault helper is unavailable for ${collection}" >&2
 		return 6
 	fi


### PR DESCRIPTION
## Summary

Updated vault storage defaults to tolerate unset HOME under set -u and switched vault helper availability checks to command -v so PATH-resolved helper commands work.

## Files Changed

.agents/scripts/vault-storage-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/vault-storage-lib.sh; custom set -u smoke tests for unset HOME and PATH-based AIDEVOPS_VAULT_HELPER

Resolves #25563


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 29,172 tokens on this as a headless worker.