### PR TITLE
GH#25566: fix: run vault helper through sh

### DIFF
--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -202,7 +202,7 @@ function readVaultCommand<T extends string>(
   isAllowed: (value: string) => value is T,
 ): T | null {
   try {
-    const output = execFileSync(helperPath, args, {
+    const output = execFileSync("sh", [helperPath, ...args], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 1_000,

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { readStatus, readVaultStatus, STATUS_ADAPTER_COMMAND } from "../src/status-adapter";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readStatus, readVaultStatus, readVaultSummary, STATUS_ADAPTER_COMMAND } from "../src/status-adapter";
 
 describe("status adapter", () => {
   test("uses an exact helper command pattern", () => {
@@ -43,5 +46,30 @@ describe("status adapter", () => {
     expect(response.data.value_policy).toBe("metadata_only_no_secret_material");
     expect(response.data.collections.map((collection) => collection.surface_ids).flat()).toContain("agents");
     expect(response.redactions).toContain("recovery_material");
+  });
+
+  test("reads Vault helper output through sh without requiring an executable bit", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "aidevops-gui-vault-helper-"));
+    const scriptsDir = join(repoRoot, ".agents", "scripts");
+    const helperPath = join(scriptsDir, "vault-helper.sh");
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(
+      helperPath,
+      [
+        "case \"$1\" in",
+        "  status) printf '%s\\n' unlocked ;;",
+        "  setup-state) printf '%s\\n' migration-ready ;;",
+        "  *) exit 2 ;;",
+        "esac",
+      ].join("\n"),
+    );
+    chmodSync(helperPath, 0o600);
+
+    const vault = readVaultSummary(repoRoot);
+
+    expect(vault.helper_status).toBe("available");
+    expect(vault.status).toBe("unlocked");
+    expect(vault.setup_state).toBe("migration-ready");
+    expect(vault.readiness.migration_allowed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Changed the GUI status adapter to invoke the Vault helper via sh so helper reads do not depend on executable-bit preservation, and added a regression test covering a non-executable helper script.

## Files Changed

packages/gui-api/src/status-adapter.ts,packages/gui-api/tests/status-adapter.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Attempted bun test tests/status-adapter.test.ts from packages/gui-api, but bun is not installed. The full-loop validator attempted npm run typecheck and failed because tsc is not installed in this worker environment. Ran git diff --check origin/main..HEAD for the touched files; pre-commit checks passed on commit/amend.

Resolves #25566


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 85,077 tokens on this as a headless worker.