### PR TITLE
GH#25567: fix: guard vault status label

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -252,7 +252,7 @@ function DesktopStatusBar({ status }: { status: GuiStatusData }): ReactElement {
   const localRepoCount = status.local_repos.total || status.local_repos.repos.length;
   const remoteRepoCount = status.repos.total || status.repos.repos.length;
   const statusLabel = status.update.restart_required ? "Restart required" : "Ready";
-  const vaultLabel = status.vault.unlocked ? "Vault unlocked" : `Vault ${status.vault.status}`;
+  const vaultLabel = status.vault?.unlocked ? "Vault unlocked" : `Vault ${status.vault?.status ?? "unknown"}`;
 
   return (
     <div className="desktop-status-bar" role="status">


### PR DESCRIPTION
## Summary

Updated the GUI desktop status bar vault label to safely handle missing vault status using optional chaining and an unknown fallback.

## Files Changed

packages/gui-web/src/App.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check passed. Pre-commit quality validation passed. bun run gui:test:components && bun run typecheck could not run because bun is not installed; full-loop project validator npm run typecheck could not run because tsc is not installed in this checkout.

Resolves #25567


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 44,983 tokens on this as a headless worker.