### PR TITLE
GH#25568: fix: annotate CodeFactor subprocess safety

### DIFF
--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -312,7 +312,10 @@ def resolve_managed_history_db(db_path: Path) -> Path:
         return db_path
     if "AIDEVOPS_VAULT_MANAGED_SESSION_HISTORY" not in __import__("os").environ:
         return db_path
-    result = subprocess.run(
+    # The command is a repo-controlled helper path plus literal arguments; no
+    # user input reaches the argv vector. Keep the explicit annotation so
+    # external Bandit/CodeFactor B603 checks do not block safe Vault gating.
+    result = subprocess.run(  # nosec B603
         [str(VAULT_HISTORY_HELPER), "require-read", "opencode"],
         check=False,
         text=True,

--- a/.agents/scripts/session_tail_query.py
+++ b/.agents/scripts/session_tail_query.py
@@ -52,7 +52,10 @@ def resolve_managed_db_path(db_path):
         return db_path
     if not VAULT_HISTORY_HELPER.exists():
         return db_path
-    result = subprocess.run(
+    # The command is a repo-controlled helper path plus literal arguments; no
+    # user input reaches the argv vector. Keep the explicit annotation so
+    # external Bandit/CodeFactor B603 checks do not block safe Vault gating.
+    result = subprocess.run(  # nosec B603
         [str(VAULT_HISTORY_HELPER), "require-read", "opencode"],
         check=False,
         text=True,

--- a/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
+++ b/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#25568: CodeFactor reports Bandit B603 findings via
+# check-run annotations. The referenced subprocess calls are repo-controlled
+# helper invocations, so each call site must carry an explicit nosec marker and
+# local safety rationale instead of relying on provider-only context.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" || exit 1
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN=""
+	TEST_RED=""
+	TEST_NC=""
+fi
+
+assert_b603_annotated() {
+	local rel_path="$1"
+	local pattern="$2"
+	local file="${REPO_ROOT}/${rel_path}"
+	local match=""
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	match=$(grep -nF -- "$pattern" "$file" 2>/dev/null | head -n 1 || true)
+	if [[ -n "$match" && "$match" == *"# nosec B603"* ]]; then
+		printf '%sPASS%s: %s annotates %s\n' "$TEST_GREEN" "$TEST_NC" "$rel_path" "$pattern"
+		return 0
+	fi
+
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%sFAIL%s: %s must annotate %s with # nosec B603\n' "$TEST_RED" "$TEST_NC" "$rel_path" "$pattern" >&2
+	return 0
+}
+
+assert_b603_annotated ".agents/scripts/session-miner/extract.py" "subprocess.run(  # nosec B603"
+assert_b603_annotated ".agents/scripts/session_tail_query.py" "subprocess.run(  # nosec B603"
+assert_b603_annotated ".agents/scripts/vault-crypto-helper.py" "subprocess.Popen(  # nosec B603"
+
+printf '\nTests run: %s\n' "$TESTS_RUN"
+if [[ "$TESTS_FAILED" -ne 0 ]]; then
+	printf 'Tests failed: %s\n' "$TESTS_FAILED" >&2
+	exit 1
+fi
+
+printf '%sAll tests passed%s\n' "$TEST_GREEN" "$TEST_NC"
+exit 0

--- a/.agents/scripts/vault-crypto-helper.py
+++ b/.agents/scripts/vault-crypto-helper.py
@@ -113,7 +113,10 @@ def _verify_setup_test_if_needed(vault_dir: Path, root_key: bytes) -> None:
 
 def _start_broker(vault_dir: Path, root_key: bytes) -> int:
     ensure_private_dir(runtime_dir(vault_dir))
-    subprocess.Popen(
+    # The broker process is this repo-controlled helper invoked via the current
+    # Python interpreter with generated key material; no user input reaches the
+    # executable path. Keep the annotation for external Bandit/CodeFactor B603.
+    subprocess.Popen(  # nosec B603
         [sys.executable, str(Path(__file__).resolve()), "broker", b64e(root_key)],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary

Annotated the three CodeFactor/Bandit B603 subprocess call sites from the failing check-run annotations with explicit trusted-helper safety rationale and nosec markers; added a focused regression guard for those annotations.

## Files Changed

.agents/scripts/session-miner/extract.py,.agents/scripts/session_tail_query.py,.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh,.agents/scripts/vault-crypto-helper.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh && .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; python3 -m py_compile .agents/scripts/session-miner/extract.py .agents/scripts/session_tail_query.py .agents/scripts/vault-crypto-helper.py; shellcheck .agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; bash .agents/scripts/lint-shell-portability.sh --summary .agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh; .agents/scripts/linters-local.sh reached Shell Portability after passing earlier gates but timed out twice there at 240s/600s

Resolves #25568


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 23m and 196,085 tokens on this as a headless worker.