### PR TITLE
GH#25561: refactor: split vault status adapter

### DIFF
--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -16,8 +16,6 @@ import {
   type GuiSettingsSummary,
   type GuiSetupTargetSummary,
   type GuiStatusData,
-  type GuiVaultSetupState,
-  type GuiVaultStatus,
   type GuiVaultStatusData,
   statusFixture,
 } from "../../gui-shared/src";
@@ -34,6 +32,9 @@ import {
   stringField,
 } from "./status-adapter-utils";
 import { readLocalReposSetupSummary } from "./status-local-repos";
+import { readVaultSummary } from "./status-vault";
+
+export { readVaultSummary } from "./status-vault";
 
 export interface StatusAdapterOptions {
   repoRoot?: string;
@@ -156,95 +157,7 @@ export function readVaultStatus(
   return envelope;
 }
 
-export function readVaultSummary(repoRoot: string): GuiVaultStatusData {
-  const helperPath = join(repoRoot, ".agents", "scripts", "vault-helper.sh");
-  const helperExists = existsSync(helperPath);
-  const rawStatus = helperExists ? readVaultCommand(helperPath, ["status"], isGuiVaultStatus) : null;
-  const rawSetupState = helperExists ? readVaultCommand(helperPath, ["setup-state"], isGuiVaultSetupState) : null;
-  const helperStatus = !helperExists ? "missing" : rawStatus === null && rawSetupState === null ? "error" : "available";
-  const status = rawStatus ?? "unknown";
-  const setupState = rawSetupState ?? (status === "uninitialized" ? "uninitialized" : "unknown");
-  const unlocked = status === "unlocked";
-  const initialized = status === "locked" || status === "unlocked" || status === "corrupted";
-  const setupRequired = status === "uninitialized" || setupState === "uninitialized";
-  const restartTestRequired = setupState === "test-created" || setupState === "restart-required" || setupState === "test-verified";
-  const migrationAllowed = unlocked && setupState === "migration-ready";
-  const collectionState = vaultCollectionState(status);
-
-  return {
-    ...statusFixture.vault,
-    status,
-    setup_state: setupState,
-    initialized,
-    locked: !unlocked,
-    unlocked,
-    available: helperExists && helperStatus !== "error",
-    helper_status: helperStatus,
-    readiness: {
-      ...statusFixture.vault.readiness,
-      migration_allowed: migrationAllowed,
-      setup_required: setupRequired,
-      restart_test_required: restartTestRequired,
-      locked_content_hidden: !unlocked,
-    },
-    collections: statusFixture.vault.collections.map((collection) => ({
-      ...collection,
-      state: collection.state === "planned" ? "planned" : collectionState,
-    })),
-  };
-}
-
 const AI_PROVIDER_IDS: GuiAiProviderId[] = ["anthropic", "openai", "cursor", "google"];
-const GUI_VAULT_STATUSES: readonly GuiVaultStatus[] = ["uninitialized", "locked", "unlocked", "corrupted", "unknown"];
-const GUI_VAULT_SETUP_STATES: readonly GuiVaultSetupState[] = [
-  "uninitialized",
-  "test-created",
-  "restart-required",
-  "test-verified",
-  "migration-ready",
-  "unknown",
-];
-
-function readVaultCommand<T extends string>(
-  helperPath: string,
-  args: string[],
-  isAllowed: (value: string) => value is T,
-): T | null {
-  try {
-    const output = execFileSync("sh", [helperPath, ...args], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 1_000,
-    }).trim();
-    const firstLine = output.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
-    return isAllowed(firstLine) ? firstLine : null;
-  } catch {
-    return null;
-  }
-}
-
-function isGuiVaultStatus(value: string): value is GuiVaultStatus {
-  return (GUI_VAULT_STATUSES as readonly string[]).includes(value);
-}
-
-function isGuiVaultSetupState(value: string): value is GuiVaultSetupState {
-  return (GUI_VAULT_SETUP_STATES as readonly string[]).includes(value);
-}
-
-function vaultCollectionState(status: GuiVaultStatus): GuiVaultStatusData["collections"][number]["state"] {
-  if (status === "unlocked") {
-    return "unlocked";
-  }
-  if (status === "locked" || status === "corrupted") {
-    return "locked";
-  }
-  if (status === "uninitialized") {
-    return "not_configured";
-  }
-
-  return "unknown";
-}
-
 const SETUP_TARGET_DEFINITIONS: Array<Pick<GuiSetupTargetSummary, "label" | "path_ref" | "purpose">> = [
   {
     label: "Deployed agents",

--- a/packages/gui-api/src/status-vault.ts
+++ b/packages/gui-api/src/status-vault.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type GuiVaultSetupState,
+  type GuiVaultStatus,
+  type GuiVaultStatusData,
+  statusFixture,
+} from "../../gui-shared/src";
+
+const GUI_VAULT_STATUSES = ["uninitialized", "locked", "unlocked", "corrupted", "unknown"] as const satisfies readonly GuiVaultStatus[];
+const GUI_VAULT_SETUP_STATES = [
+  "uninitialized",
+  "test-created",
+  "restart-required",
+  "test-verified",
+  "migration-ready",
+  "unknown",
+] as const satisfies readonly GuiVaultSetupState[];
+const INITIALIZED_VAULT_STATUSES = new Set<GuiVaultStatus>(["locked", "unlocked", "corrupted"]);
+const RESTART_TEST_SETUP_STATES = new Set<GuiVaultSetupState>(["test-created", "restart-required", "test-verified"]);
+
+export function readVaultSummary(repoRoot: string): GuiVaultStatusData {
+  const helperPath = join(repoRoot, ".agents", "scripts", "vault-helper.sh");
+  const helperExists = existsSync(helperPath);
+  const rawStatus = helperExists ? readVaultCommand(helperPath, ["status"], isGuiVaultStatus) : null;
+  const rawSetupState = helperExists ? readVaultCommand(helperPath, ["setup-state"], isGuiVaultSetupState) : null;
+  const helperStatus = vaultHelperStatus(helperExists, rawStatus, rawSetupState);
+  const status = rawStatus ?? "unknown";
+  const setupState = rawSetupState ?? fallbackSetupState(status);
+  const unlocked = status === "unlocked";
+  const collectionState = vaultCollectionState(status);
+
+  return {
+    ...statusFixture.vault,
+    status,
+    setup_state: setupState,
+    initialized: INITIALIZED_VAULT_STATUSES.has(status),
+    locked: !unlocked,
+    unlocked,
+    available: helperExists && helperStatus !== "error",
+    helper_status: helperStatus,
+    readiness: {
+      ...statusFixture.vault.readiness,
+      migration_allowed: unlocked && setupState === "migration-ready",
+      setup_required: status === "uninitialized" || setupState === "uninitialized",
+      restart_test_required: RESTART_TEST_SETUP_STATES.has(setupState),
+      locked_content_hidden: !unlocked,
+    },
+    collections: statusFixture.vault.collections.map((collection) => ({
+      ...collection,
+      state: collection.state === "planned" ? "planned" : collectionState,
+    })),
+  };
+}
+
+function readVaultCommand<T extends string>(
+  helperPath: string,
+  args: string[],
+  isAllowed: (value: string) => value is T,
+): T | null {
+  try {
+    const output = execFileSync("sh", [helperPath, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000,
+    }).trim();
+    const firstLine = output.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
+    return isAllowed(firstLine) ? firstLine : null;
+  } catch {
+    return null;
+  }
+}
+
+function isGuiVaultStatus(value: string): value is GuiVaultStatus {
+  return GUI_VAULT_STATUSES.includes(value as GuiVaultStatus);
+}
+
+function isGuiVaultSetupState(value: string): value is GuiVaultSetupState {
+  return GUI_VAULT_SETUP_STATES.includes(value as GuiVaultSetupState);
+}
+
+function vaultHelperStatus(
+  helperExists: boolean,
+  status: GuiVaultStatus | null,
+  setupState: GuiVaultSetupState | null,
+): GuiVaultStatusData["helper_status"] {
+  if (!helperExists) {
+    return "missing";
+  }
+  return status === null && setupState === null ? "error" : "available";
+}
+
+function fallbackSetupState(status: GuiVaultStatus): GuiVaultSetupState {
+  return status === "uninitialized" ? "uninitialized" : "unknown";
+}
+
+function vaultCollectionState(status: GuiVaultStatus): GuiVaultStatusData["collections"][number]["state"] {
+  if (status === "unlocked") {
+    return "unlocked";
+  }
+  if (status === "locked" || status === "corrupted") {
+    return "locked";
+  }
+  if (status === "uninitialized") {
+    return "not_configured";
+  }
+
+  return "unknown";
+}


### PR DESCRIPTION
## Summary

Split Vault status summary logic from `packages/gui-api/src/status-adapter.ts` into `packages/gui-api/src/status-vault.ts` while re-exporting `readVaultSummary` to preserve the existing adapter API. This removes the Qlty boolean/file-complexity smells from the target file without behavior changes.

## Files Changed

- `packages/gui-api/src/status-adapter.ts`
- `packages/gui-api/src/status-vault.ts`

## Complexity Bump Justification

This PR intentionally adds `packages/gui-api/src/status-vault.ts` as an extract-module refactor so `packages/gui-api/src/status-adapter.ts` no longer carries the Vault-specific helper complexity flagged by Qlty. Verification with `~/.qlty/bin/qlty smells packages/gui-api/src/status-adapter.ts --no-snippets --quiet` and the same command for the new Vault module reports no file-local smells.

## Runtime Testing

- `node --check packages/gui-api/src/status-adapter.ts`
- `node --check packages/gui-api/src/status-vault.ts`
- `~/.qlty/bin/qlty smells packages/gui-api/src/status-adapter.ts --no-snippets --quiet`
- `~/.qlty/bin/qlty smells packages/gui-api/src/status-vault.ts --no-snippets --quiet`
- `~/.bun/bin/bun test packages/gui-api/tests/status-adapter.test.ts`
- `.agents/scripts/linters-local.sh` (passes; historical/advisory debt remains outside this change)
- Environment-limited: route/typecheck commands cannot complete in this worker because `hono`/`tsc` are not installed in the local dependency tree.

Resolves #25561

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 as a headless worker.
