### PR TITLE
GH#25565: fix: tolerate missing vault device registry

### DIFF
--- a/.agents/scripts/tests/test-vault-device-helper.sh
+++ b/.agents/scripts/tests/test-vault-device-helper.sh
@@ -139,6 +139,14 @@ else
 	fail "revocation queues rotation task"
 fi
 
+rm -f "$AIDEVOPS_VAULT_DEVICE_DIR/registry.json"
+missing_registry_heartbeat="$($VAULT_DEVICE_HELPER heartbeat --active-workers 0 --max-workers 1)"
+if [[ -s "$missing_registry_heartbeat" ]]; then
+	pass "heartbeat tolerates missing registry"
+else
+	fail "heartbeat tolerates missing registry"
+fi
+
 if [[ "$FAIL" -ne 0 ]]; then
 	printf 'FAIL: %s failed, %s passed\n' "$FAIL" "$PASS" >&2
 	exit 1

--- a/.agents/scripts/vault-device-helper.sh
+++ b/.agents/scripts/vault-device-helper.sh
@@ -490,8 +490,10 @@ state_unsynced = os.environ["VAULT_DEVICE_STATE_UNSYNCED"]
 field_unlock_status = os.environ["VAULT_DEVICE_FIELD_UNLOCK_STATUS"]
 with open(local_state_path, encoding="utf-8") as handle:
     state = json.load(handle)
-with open(registry_path, encoding="utf-8") as handle:
-    registry = json.load(handle)
+registry = {}
+if os.path.exists(registry_path):
+    with open(registry_path, encoding="utf-8") as handle:
+        registry = json.load(handle)
 device = next((item for item in registry.get("devices", []) if item.get(field_id) == device_id), {})
 print(json.dumps({
     "schema_version": 1,


### PR DESCRIPTION
## Summary
- tolerate missing vault device registry while publishing heartbeats
- add regression coverage for heartbeat without registry.json

## Verification
- `shellcheck .agents/scripts/vault-device-helper.sh .agents/scripts/tests/test-vault-device-helper.sh`
- `.agents/scripts/tests/test-vault-device-helper.sh`

Follow-up for unresolved review thread on PR #25574. For #25565.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
