### PR TITLE
GH#25581: fix: include CodeFactor annotations in failure briefs

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -410,12 +410,31 @@ fetch_pr_changed_paths_json() {
 	return 0
 }
 
+fetch_check_run_annotations_summary_json() {
+	local repo_slug="$1" check_run_id="$2"
+	if [[ -z "$repo_slug" ]] || [[ -z "$check_run_id" ]]; then
+		printf '%s\n' '[]'
+		return 0
+	fi
+
+	local annotations
+	if ! annotations=$(gh api --paginate "repos/${repo_slug}/check-runs/${check_run_id}/annotations?per_page=100" \
+		--jq '.[] | {path: (.path // ""), start_line: (.start_line // null), annotation_level: (.annotation_level // ""), title: (.title // ""), message: ((.message // .raw_details // "") | gsub("[\r\n\t]+"; " ") | .[0:220])}' 2>/dev/null); then
+		printf '%s\n' '[]'
+		return 0
+	fi
+
+	printf '%s\n' "$annotations" | jq -s -c '[.[] | select(((.path // "") | length) > 0 or ((.message // "") | length) > 0)][0:5]' 2>/dev/null || printf '%s\n' '[]'
+	return 0
+}
+
 emit_event_json() {
 	local repo_slug="$1" source_kind="$2" source_ref="$3" source_url="$4"
 	local pr_number="$5" commit_sha="$6" check_name="$7" conclusion="$8"
 	local run_id="$9" html_url="${10}" details_url="${11}" completed_at="${12}"
 	local signature="${13}" notification_updated_at="${14}" is_infra="${15}"
 	local affected_paths_json="${16:-[]}"
+	local annotations_json="${17:-[]}"
 
 	local pr_url=""
 	if [[ -n "$pr_number" ]]; then
@@ -440,6 +459,7 @@ emit_event_json() {
 		--arg notification_updated_at "$notification_updated_at" \
 		--argjson is_infra "$is_infra" \
 		--argjson affected_paths "$affected_paths_json" \
+		--argjson annotations "$annotations_json" \
 		'{
 			repo: $repo,
 			source_kind: $source_kind,
@@ -457,7 +477,8 @@ emit_event_json() {
 			signature: $signature,
 			notification_updated_at: (if $notification_updated_at == "" then null else $notification_updated_at end),
 			is_infra: $is_infra,
-			affected_paths: $affected_paths
+			affected_paths: $affected_paths,
+			annotations: $annotations
 		}'
 	return 0
 }
@@ -557,12 +578,14 @@ process_failed_runs() {
 		fi
 
 		local run_affected_paths="[]"
+		local run_annotations="[]"
 		if [[ "$source_kind" == "pr" ]] && [[ -n "$pr_number" ]] &&
 			{ [[ "$check_name" =~ [Cc]ode[Ff]actor ]] || [[ "$signature" == "failure:codefactor.io" ]]; }; then
 			if [[ "$affected_paths_json" == "[]" ]]; then
 				affected_paths_json=$(fetch_pr_changed_paths_json "$repo_slug" "$pr_number")
 			fi
 			run_affected_paths="$affected_paths_json"
+			run_annotations=$(fetch_check_run_annotations_summary_json "$repo_slug" "$(printf '%s\n' "$run_json" | jq -r '.id // empty')")
 		fi
 		if [[ "$source_kind" == "pr" ]] && [[ -n "$pr_number" ]] &&
 			{ [[ "$check_name" =~ [Cc]ode[Ff]actor ]] || [[ "$signature" == "failure:codefactor.io" ]]; }; then
@@ -572,7 +595,7 @@ process_failed_runs() {
 		emit_event_json "$repo_slug" "$source_kind" "$source_ref" "$source_url" \
 			"$pr_number" "$commit_sha" "$check_name" "$conclusion" \
 			"$run_id" "$html_url" "$details_url" "$completed_at" \
-			"$signature" "$notification_updated_at" "$is_infra" "$run_affected_paths" >>"$event_file"
+			"$signature" "$notification_updated_at" "$is_infra" "$run_affected_paths" "$run_annotations" >>"$event_file"
 
 		failed_index=$((failed_index + 1))
 	done
@@ -733,7 +756,7 @@ render_issue_body_markdown() {
 			 count: length,
 			 repos: (map(.repo) | unique),
 			 sources: (map(.repo + "|" + .source_kind + "|" + .source_ref) | unique),
-				 examples: (.[0:5] | map({repo, source_kind, source_ref, source_url, run_url, details_url, conclusion, affected_paths}))
+				 examples: (.[0:5] | map({repo, source_kind, source_ref, source_url, run_url, details_url, conclusion, affected_paths, annotations}))
 		   })
 		 | sort_by(-.count)
 		 | .[0]) as $top
@@ -774,7 +797,7 @@ build_repo_clusters_json() {
 		count: length,
 		is_infra: (any(.[]; .is_infra == true)),
 		sources: (map(.source_kind + ":" + .source_ref) | unique),
-		examples: (.[0:5] | map({source_kind, source_ref, source_url, run_url, details_url, conclusion, affected_paths}))
+		examples: (.[0:5] | map({source_kind, source_ref, source_url, run_url, details_url, conclusion, affected_paths, annotations}))
 	}] | sort_by(-.count)'
 	return 0
 }
@@ -860,6 +883,14 @@ build_issue_body() {
 					"\n  affected files: " + (($example.affected_paths // []) | .[0:8] | join(", ")) +
 					(if (($example.affected_paths // []) | length) > 8 then ", ..." else "" end)
 				else "" end;
+			def annotations_line($example):
+				if (($example.annotations // []) | length) > 0 then
+					"\n  reported findings: " + (($example.annotations // []) | .[0:3] | map(
+						((.path // "unreported") + (if (.start_line // null) != null then ":" + ((.start_line // 0) | tostring) else "" end) +
+						(if ((.title // "") | length) > 0 then " — " + .title elif ((.message // "") | length) > 0 then " — " + .message else "" end))
+					) | join("; ")) +
+					(if (($example.annotations // []) | length) > 3 then "; ..." else "" end)
+				else "" end;
 			def systemic_fix_guidance($check_name; $signature):
 				if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
 					"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
@@ -887,7 +918,8 @@ build_issue_body() {
 			  (if .source_url != null then " - " + .source_url else "" end) +
 			  (if .run_url != null then " - " + .run_url else "" end) +
 			  (if .details_url != null then " - " + .details_url else "" end) +
-			  affected_paths_line(.)
+			  affected_paths_line(.) +
+			  annotations_line(.)
 			) | join("\n")) + "\n\n" +
 			"## Root Cause Hypothesis\n" +
 			"- Regression or external dependency/toolchain break in the shared check path.\n\n" +

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -70,6 +70,10 @@ gh() {
 		printf '%s\n' ".agents/scripts/vault-helper.sh" ".agents/scripts/vault-crypto-helper.py" ".agents/scripts/vault-helper.sh"
 		return 0
 	fi
+	if [[ "$_api" == "api" && "$_paginate" == "--paginate" && "$_endpoint" == "repos/marcusquinn/aidevops/check-runs/123/annotations?per_page=100" && "$_jq_flag" == "--jq" ]]; then
+		printf '%s\n' '{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}'
+		return 0
+	fi
 	return 1
 }
 
@@ -89,6 +93,7 @@ cluster_json=$(cat <<'JSON'
       "run_url": "https://github.com/marcusquinn/aidevops/runs/82536587204",
       "details_url": "https://www.codefactor.io/repository/github/marcusquinn/aidevops/pull/25324",
       "affected_paths": [".agents/scripts/vault-crypto-helper.py", ".agents/scripts/vault-helper.sh"],
+      "annotations": [{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}],
       "conclusion": "failure"
     }
   ]
@@ -108,6 +113,7 @@ events_json=$(cat <<'JSON'
     "run_url": "https://github.com/marcusquinn/aidevops/runs/82536587204",
     "details_url": "https://www.codefactor.io/repository/github/marcusquinn/aidevops/pull/25324",
     "affected_paths": [".agents/scripts/vault-crypto-helper.py", ".agents/scripts/vault-helper.sh"],
+    "annotations": [{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}],
     "conclusion": "failure"
   }
 ]
@@ -117,14 +123,17 @@ JSON
 body=$(build_issue_body "$cluster_json" "46250abc5695" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
 paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
+annotations_json=$(fetch_check_run_annotations_summary_json "marcusquinn/aidevops" "123")
 GH_MODE=fail
 failed_paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
+failed_annotations_json=$(fetch_check_run_annotations_summary_json "marcusquinn/aidevops" "123")
 GH_MODE=success
 
 failed_runs_json=$(cat <<'JSON'
 [
   {
     "name": "CodeFactor",
+    "id": 123,
     "conclusion": "failure",
     "details_url": "https://www.codefactor.io/repository/github/marcusquinn/aidevops/pull/25324",
     "html_url": "https://github.com/marcusquinn/aidevops/runs/82536587204",
@@ -151,12 +160,14 @@ process_failed_runs "$failed_runs_json" "marcusquinn/aidevops" "pr" "#25324" "ht
 	"25324" "46250abc5695" "2026-06-26T07:02:00Z" "false" "0" "0" "$event_file" "$checks_json" >/dev/null
 mined_events_json=$(jq -s '.' "$event_file")
 codefactor_paths_json=$(printf '%s\n' "$mined_events_json" | jq -c '.[0].affected_paths')
+codefactor_annotations_json=$(printf '%s\n' "$mined_events_json" | jq -c '.[0].annotations')
 shellcheck_paths_json=$(printf '%s\n' "$mined_events_json" | jq -c '.[1].affected_paths')
 rm -f "$event_file"
 
 assert_contains "build_issue_body includes Worker Guidance" "## Worker Guidance" "$body"
 assert_contains "build_issue_body directs workers to CodeFactor details" "Open the CodeFactor details URL from Evidence first" "$body"
 assert_contains "build_issue_body includes affected file fallback" "affected files: .agents/scripts/vault-crypto-helper.py, .agents/scripts/vault-helper.sh" "$body"
+assert_contains "build_issue_body includes CodeFactor annotations" "reported findings: .agents/scripts/vault-crypto-helper.py:119 — Bandit B603" "$body"
 assert_contains "build_issue_body handles unavailable details" "If CodeFactor details are unavailable" "$body"
 assert_contains "build_issue_body preserves failure signature context" "failure:codefactor.io" "$body"
 assert_contains "build_issue_body asks for focused regression guard" "focused regression guard" "$body"
@@ -165,7 +176,10 @@ assert_contains "render_issue_body_markdown directs workers to provider details"
 assert_contains "render_issue_body_markdown includes affected file fallback" "affected files: .agents/scripts/vault-crypto-helper.py, .agents/scripts/vault-helper.sh" "$legacy_body"
 assert_contains "fetch_pr_changed_paths_json returns unique sorted paths" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$paths_json"
 assert_equals "fetch_pr_changed_paths_json emits one JSON array on gh failure" '[]' "$failed_paths_json"
+assert_equals "fetch_check_run_annotations_summary_json returns provider annotations" '[{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}]' "$annotations_json"
+assert_equals "fetch_check_run_annotations_summary_json emits one JSON array on gh failure" '[]' "$failed_annotations_json"
 assert_equals "process_failed_runs attaches paths to CodeFactor failure" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$codefactor_paths_json"
+assert_equals "process_failed_runs attaches annotations to CodeFactor failure" '[{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}]' "$codefactor_annotations_json"
 assert_equals "process_failed_runs does not leak CodeFactor paths to later checks" '[]' "$shellcheck_paths_json"
 
 printf '\nTests run: %s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Added CodeFactor check-run annotation capture to gh-failure-miner events and rendered reported findings in generated systemic issue evidence so workers can see provider file/line/rule context even when external details pages are inaccessible.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; shellcheck -S error .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; pre-commit checks passed during WIP commit

Resolves #25581


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 12m and 113,434 tokens on this as a headless worker.