### PR TITLE
fix: recover invalid pulse stats file

### DIFF
--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -61,6 +61,15 @@ _pulse_stats_ensure_file() {
 	fi
 	if [[ ! -f "$PULSE_STATS_FILE" ]]; then
 		printf '{"counters":{}}\n' >"$PULSE_STATS_FILE" 2>/dev/null || return 0
+		return 0
+	fi
+
+	# GH#25584: an interrupted writer or external truncation can leave the stats
+	# file present but empty/invalid. Gauge writers previously treated that as a
+	# jq no-op, leaving stale merge-stuck meta-issues unable to observe recovery.
+	# Reinitialize to the minimal schema so the next atomic update can proceed.
+	if ! jq -e 'type == "object"' "$PULSE_STATS_FILE" >/dev/null 2>&1; then
+		printf '{"counters":{}}\n' >"$PULSE_STATS_FILE" 2>/dev/null || return 0
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-stats-helper.sh
+++ b/.agents/scripts/tests/test-pulse-stats-helper.sh
@@ -40,4 +40,11 @@ help_output="${TMP_DIR}/help.txt"
 "$HELPER" help >"$help_output"
 grep -q 'get-gauge <gauge>' "$help_output"
 
+printf '' >"$PULSE_STATS_FILE"
+# shellcheck disable=SC1090
+source "$HELPER"
+pulse_stats_set_gauge pulse_merge_zero_progress_cycles 0
+gauge_value="$("$HELPER" get-gauge pulse_merge_zero_progress_cycles)"
+[[ "$gauge_value" == "0" ]]
+
 printf 'PASS pulse-stats-helper\n'


### PR DESCRIPTION
## Summary
- For #25584
- Reinitialize pulse-stats.json when it exists but is empty or invalid so gauge writers can recover after interrupted/truncated stats writes.
- Add a regression covering an empty stats file followed by pulse_stats_set_gauge.

## Testing
- .agents/scripts/tests/test-pulse-stats-helper.sh
- .agents/scripts/tests/test-pulse-merge-stuck.sh
- shellcheck .agents/scripts/pulse-stats-helper.sh .agents/scripts/tests/test-pulse-stats-helper.sh

MERGE_SUMMARY: Recovered invalid pulse stats files before gauge writes so stale zero-progress meta-issues can observe recovery after the next pulse stats update.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.4 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for stats files that are empty, invalid, or no longer valid JSON objects, so updates can continue reliably.
  * Added coverage for the case where a gauge value is reloaded from an initially blank stats file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->