### PR TITLE
fix: reconcile TODO task sync drift

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -157,20 +157,35 @@ _reopen_comment() {
 # Mark a TODO entry as done: [ ] -> [x] with completed: date.
 # Also handles [-] (cancelled/declined) entries — leaves marker as [-].
 _mark_todo_done() {
-	local task_id="$1" todo_file="$2"
+	local task_id="$1" todo_file="$2" proof_log="${3:-}"
 	local task_id_ere
 	task_id_ere=$(_escape_ere "$task_id")
 	local today
 	today=$(date -u +%Y-%m-%d)
+	[[ -n "$proof_log" && "$proof_log" != " "* ]] && proof_log=" $proof_log"
 
 	# Only flip [ ] -> [x]; skip if already [x] or [-]
 	# Use [[:space:]] not \s for macOS sed compatibility (bash 3.2)
 	if grep -qE "^[[:space:]]*- \[ \] ${task_id_ere} " "$todo_file" 2>/dev/null; then
 		# Flip checkbox and append completed: date
-		sed -i.bak -E "s/^([[:space:]]*- )\[ \] (${task_id_ere} .*)/\1[x] \2 completed:${today}/" "$todo_file"
+		sed -i.bak -E "s/^([[:space:]]*- )\[ \] (${task_id_ere} .*)/\1[x] \2${proof_log} completed:${today}/" "$todo_file"
 		rm -f "${todo_file}.bak"
+		_dedupe_todo_task_lines "$task_id" "$todo_file" || true
 		log_verbose "Marked $task_id as [x] in TODO.md"
 	fi
+	return 0
+}
+
+_closed_issue_worker_complete_date() {
+	local repo="$1" issue_number="$2"
+	local completed_at
+
+	completed_at=$(gh api "repos/${repo}/issues/${issue_number}/comments" \
+		--jq '[.[] | select(.body | contains("CLAIM_RELEASED reason=worker_complete")) | .created_at][0] // ""' 2>/dev/null || true)
+	if [[ -z "$completed_at" ]]; then
+		return 1
+	fi
+	printf '%s\n' "${completed_at%%T*}"
 	return 0
 }
 
@@ -383,6 +398,19 @@ cmd_reopen() {
 				add_pr_ref_to_todo "$tid" "$pr_num" "$todo_file" 2>/dev/null || true
 				_mark_todo_done "$tid" "$todo_file"
 				log_verbose "#$ref_num ($tid) has merged PR #$pr_num — marked TODO [x]"
+			fi
+			has_pr=$((has_pr + 1))
+			continue
+		fi
+
+		local worker_completed_date
+		worker_completed_date=$(_closed_issue_worker_complete_date "$repo" "$ref_num" || true)
+		if [[ -n "$worker_completed_date" ]]; then
+			if [[ "$DRY_RUN" == "true" ]]; then
+				print_info "[DRY-RUN] Would mark $tid [x] (worker_complete evidence on #$ref_num)"
+			else
+				_mark_todo_done "$tid" "$todo_file" "verified:${worker_completed_date}"
+				log_verbose "#$ref_num ($tid) has worker_complete evidence — marked TODO [x]"
 			fi
 			has_pr=$((has_pr + 1))
 			continue

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -432,6 +432,7 @@ _seed_orphan_todo_line() {
 	local task_id_ere
 	task_id_ere=$(_escape_ere "$task_id")
 	if strip_code_fences <"$todo_file" | grep -qE "^\s*- \[.\] ${task_id_ere} "; then
+		_dedupe_todo_task_lines "$task_id" "$todo_file" || true
 		{ log_verbose "ORPHAN already seeded: $task_id (ref:GH#$num) — skipping" || true; }
 		return 1
 	fi
@@ -457,5 +458,58 @@ _seed_orphan_todo_line() {
 	# Append after the last non-empty line (chronological tail)
 	printf '\n%s\n' "$todo_line" >> "$todo_file"
 	print_success "Seeded orphan TODO: $todo_line"
+	return 0
+}
+
+# Remove duplicate TODO.md task lines, preserving the richest canonical entry.
+# Preference order: completed lines, linked brief lines, detailed metadata, then
+# the first occurrence. This repairs historical simplified orphan duplicates
+# without discarding useful task metadata from the canonical upper section.
+_dedupe_todo_task_lines() {
+	local task_id="$1"
+	local todo_file="$2"
+	local task_id_ere duplicate_count tmp_file
+
+	task_id_ere=$(_escape_ere "$task_id")
+	duplicate_count=$(strip_code_fences <"$todo_file" | grep -Ec "^[[:space:]]*- \[.\] ${task_id_ere} " || true)
+	if [[ "$duplicate_count" -le 1 ]]; then
+		return 1
+	fi
+
+	tmp_file=$(mktemp "${todo_file}.dedupe.XXXXXX") || return 2
+	if ! awk -v task_pattern="$task_id_ere" '
+		BEGIN { pattern = "^[[:space:]]*- \\[.\\] " task_pattern " " }
+		$0 ~ pattern {
+			is_task[NR] = 1
+			score = 0
+			if ($0 ~ /^[[:space:]]*- \\[x\\] /) { score += 1000 }
+			if ($0 ~ / -> \[/) { score += 100 }
+			if ($0 ~ / blocked-by:/) { score += 25 }
+			if ($0 ~ / tier:/) { score += 25 }
+			if ($0 ~ / logged:/) { score += 25 }
+			if ($0 ~ / pr:#[0-9]+| verified:[0-9]{4}-[0-9]{2}-[0-9]{2}| completed:[0-9]{4}-[0-9]{2}-[0-9]{2}/) { score += 10 }
+			if (best_line == 0 || score > best_score) {
+				best_line = NR
+				best_score = score
+			}
+		}
+		{ lines[NR] = $0 }
+		END {
+			for (i = 1; i <= NR; i += 1) {
+				if (is_task[i] && i != best_line) { continue }
+				print lines[i]
+			}
+		}
+	' "$todo_file" >"$tmp_file"; then
+		rm -f "$tmp_file"
+		return 2
+	fi
+
+	if ! mv "$tmp_file" "$todo_file"; then
+		rm -f "$tmp_file"
+		return 2
+	fi
+
+	print_warning "Removed duplicate TODO.md entries for $task_id"
 	return 0
 }

--- a/.agents/tests/test-task-sync-dedupe.sh
+++ b/.agents/tests/test-task-sync-dedupe.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_DIR}/../.." && pwd)"
+SCRIPT_DIR="${REPO_ROOT}/.agents/scripts"
+
+source "${REPO_ROOT}/.agents/scripts/issue-sync-lib.sh"
+source "${REPO_ROOT}/.agents/scripts/issue-sync-helper-close.sh"
+
+log_verbose() {
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf '[FAIL] %s\n' "$message" >&2
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf '[PASS] %s\n' "$message"
+	return 0
+}
+
+test_dedupe_preserves_canonical_brief_line() {
+	local tmpdir todo_file count line
+	tmpdir=$(mktemp -d)
+	todo_file="${tmpdir}/TODO.md"
+	cat >"$todo_file" <<'EOF'
+- [ ] t18002 vault: add GUI Vault sidebar #architecture blocked-by:t17999 tier:thinking ref:GH#25539 logged:2026-06-26 -> [todo/tasks/t18002-brief.md]
+
+- [ ] t18002 vault: add GUI Vault sidebar #architecture #enhancement ref:GH#25539
+EOF
+	_dedupe_todo_task_lines "t18002" "$todo_file" >/dev/null
+	count=$(grep -Ec '^[[:space:]]*- \[.\] t18002 ' "$todo_file" || true)
+	[[ "$count" == "1" ]] || fail "expected one t18002 line after dedupe, got $count"
+	line=$(grep -E '^[[:space:]]*- \[.\] t18002 ' "$todo_file")
+	[[ "$line" == *'-> [todo/tasks/t18002-brief.md]'* ]] || fail "expected canonical brief link to survive"
+	rm -rf "$tmpdir"
+	pass "dedupe preserves canonical brief line"
+	return 0
+}
+
+test_mark_done_dedupes_and_adds_verified_proof() {
+	local tmpdir todo_file count line
+	tmpdir=$(mktemp -d)
+	todo_file="${tmpdir}/TODO.md"
+	cat >"$todo_file" <<'EOF'
+- [ ] t18002 vault: add GUI Vault sidebar #architecture blocked-by:t17999 tier:thinking ref:GH#25539 logged:2026-06-26 -> [todo/tasks/t18002-brief.md]
+
+- [ ] t18002 vault: add GUI Vault sidebar #architecture #enhancement ref:GH#25539
+EOF
+	_mark_todo_done "t18002" "$todo_file" "verified:2026-06-26"
+	count=$(grep -Ec '^[[:space:]]*- \[.\] t18002 ' "$todo_file" || true)
+	[[ "$count" == "1" ]] || fail "expected one t18002 line after mark done, got $count"
+	line=$(grep -E '^[[:space:]]*- \[x\] t18002 ' "$todo_file")
+	[[ "$line" == *'verified:2026-06-26'* ]] || fail "expected verified proof on completed line"
+	[[ "$line" == *'completed:'* ]] || fail "expected completed metadata on completed line"
+	[[ "$line" == *'-> [todo/tasks/t18002-brief.md]'* ]] || fail "expected canonical metadata after mark done"
+	rm -rf "$tmpdir"
+	pass "mark done dedupes and adds verified proof"
+	return 0
+}
+
+main() {
+	test_dedupe_preserves_canonical_brief_line
+	test_mark_done_dedupes_and_adds_verified_proof
+	return 0
+}
+
+main "$@"

--- a/TODO.md
+++ b/TODO.md
@@ -1000,7 +1000,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18001 vault: migrate aidevops memory, workspace, knowledge, and config data with scrub-safe rollback #architecture #auto-dispatch #database #documents #feat #memory #security blocked-by:t17999,t18000 tier:thinking ~8h ref:GH#25538 logged:2026-06-26 -> [todo/tasks/t18001-brief.md] pr:#25560 completed:2026-06-26
 
-- [ ] t18002 vault: add GUI Vault sidebar, setup navigation, padlock indicators, and locked-state gates #architecture #auto-dispatch #design #feat #product #security blocked-by:t17999 tier:thinking ~5h ref:GH#25539 logged:2026-06-26 -> [todo/tasks/t18002-brief.md]
+- [x] t18002 vault: add GUI Vault sidebar, setup navigation, padlock indicators, and locked-state gates #architecture #auto-dispatch #design #feat #product #security blocked-by:t17999 tier:thinking ~5h ref:GH#25539 logged:2026-06-26 -> [todo/tasks/t18002-brief.md] verified:2026-06-26 completed:2026-06-26
 
 - [x] t18003 vault: implement device identity, trust, revocation, and fleet unlock status model #architecture #auto-dispatch #feat #orchestration #security blocked-by:t17998 tier:thinking ~6h ref:GH#25540 logged:2026-06-26 -> [todo/tasks/t18003-brief.md] pr:#25557 completed:2026-06-26
 
@@ -4305,26 +4305,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [x] t3609 GUI ADR: security threat model and trust boundaries #architecture #auto-dispatch #dashboard #security ref:GH#25231 pr:#25237 completed:2026-06-20
 
 - [ ] t17995 GUI testing and CI/CD strategy #architecture #auto-dispatch #ci #dashboard #testing blocked-by:t3608,t3609 ref:GH#25234
-
-- [ ] t17996 Vault: encrypted aidevops data, fleet sync, remote control, messaging, and audit #architecture #parent #plan #security ref:GH#25533
-
-
-
-
-
-
-- [ ] t18007 vault: build tamper-evident access logs with peer replication and public-safe anchors #architecture #audit #auto-dispatch #enhancement #monitoring #security #security-review ref:GH#25544
-
-- [ ] t18006 vault: add remote lock, unlock-request, and sudo plus passphrase remote unlock policy #architecture #auth #auto-dispatch #enhancement #opsec #security ref:GH#25543
-
-- [ ] t18005 vault: implement secure device messaging over Git transport with SimpleX adapter option #architecture #auto-dispatch #communications #enhancement #git #security ref:GH#25542
-
-- [ ] t18004 vault: add encrypted sync, export, import, rekey, and public-Git-safe replication #architecture #auto-dispatch #communications #database #enhancement #git #security ref:GH#25541
-
-
-- [ ] t18002 vault: add GUI Vault sidebar, setup navigation, padlock indicators, and locked-state gates #architecture #auto-dispatch #design #enhancement #product #security ref:GH#25539
-
-- [ ] t18010 vault: add security validation suite, crash drills, destructive-migration gates, and release criteria #architecture #auto-dispatch #ci #enhancement #security #security-review #testing ref:GH#25547
-
-- [ ] t18009 vault: create Vault agent guidance, user workflows, command docs, and dispatch gates #agents #architecture #auto-dispatch #brief #documentation #enhancement #security ref:GH#25546
 


### PR DESCRIPTION
## Summary
- Fix TODO sync drift for the Vault task block.
- Add regression coverage for task-line dedupe and closed worker-complete reconciliation.

## Verification
- Focused regression test passed.
- Whitespace diff check passed.
- Shell lint for changed helper and regression test passed.
- Affected Vault task search confirmed one line per task.
- Broad local linter passed early gates and exceeded the worker timeout during the shell portability stage.

Resolves #25587

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.5 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
