### PR TITLE
GH#25583: avoid large jq argv for cache JSON

### DIFF
--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -503,6 +503,61 @@ _prefetch_single_repo_idle_skip() {
 	return 0
 }
 
+#######################################
+# Build a per-repo prefetch cache entry without passing large JSON via argv.
+#
+# Large PR/issue arrays can exceed Linux MAX_ARG_STRLEN when passed through
+# jq --argjson. Store them in temp files and load with --slurpfile instead.
+#
+# Arguments:
+#   $1 - last_prefetch ISO timestamp
+#   $2 - last_full_sweep ISO timestamp
+#   $3 - state fingerprint
+#   $4 - PR JSON array
+#   $5 - issue JSON array
+# Outputs: JSON cache entry object
+#######################################
+_prefetch_build_cache_entry() {
+	local now_iso="$1"
+	local last_full_sweep="$2"
+	local fingerprint="$3"
+	local prs_json="$4"
+	local issues_json="$5"
+
+	[[ -n "$prs_json" && "$prs_json" != "null" ]] || prs_json="[]"
+	[[ -n "$issues_json" && "$issues_json" != "null" ]] || issues_json="[]"
+
+	local prs_file issues_file
+	prs_file=$(mktemp) || return 1
+	issues_file=$(mktemp) || {
+		rm -f "$prs_file"
+		return 1
+	}
+
+	if ! printf '%s' "$prs_json" >"$prs_file"; then
+		rm -f "$prs_file" "$issues_file"
+		return 1
+	fi
+	if ! printf '%s' "$issues_json" >"$issues_file"; then
+		rm -f "$prs_file" "$issues_file"
+		return 1
+	fi
+
+	local jq_output jq_status
+	jq_status=0
+	jq_output=$(jq -n \
+		--arg now "$now_iso" \
+		--arg lfs "$last_full_sweep" \
+		--arg fp "$fingerprint" \
+		--slurpfile prs "$prs_file" \
+		--slurpfile issues "$issues_file" \
+		'{last_prefetch: $now, last_full_sweep: $lfs, state_fingerprint: $fp, prs: ($prs[0] // []), issues: ($issues[0] // [])}') || jq_status=$?
+	rm -f "$prs_file" "$issues_file"
+	[[ "$jq_status" -eq 0 ]] || return "$jq_status"
+	printf '%s\n' "$jq_output"
+	return 0
+}
+
 _prefetch_single_repo() {
 	local slug="$1"
 	local path="$2"
@@ -603,24 +658,21 @@ _prefetch_single_repo() {
 	local fingerprint="${PREFETCH_CURRENT_FINGERPRINT:-}"
 	local new_entry
 	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" ]]; then
-		new_entry=$(jq -n \
-			--arg now "$now_iso" \
-			--arg fp "$fingerprint" \
-			--argjson prs "${PREFETCH_UPDATED_PRS:-[]}" \
-			--argjson issues "${PREFETCH_UPDATED_ISSUES:-[]}" \
-			'{last_prefetch: $now, last_full_sweep: $now, state_fingerprint: $fp, prs: $prs, issues: $issues}')
+		new_entry=$(_prefetch_build_cache_entry \
+			"$now_iso" "$now_iso" "$fingerprint" \
+			"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}") || new_entry=""
 	else
 		local last_full_sweep
 		last_full_sweep=$(echo "$cache_entry" | jq -r '.last_full_sweep // ""' 2>/dev/null) || last_full_sweep=""
-		new_entry=$(jq -n \
-			--arg now "$now_iso" \
-			--arg lfs "$last_full_sweep" \
-			--arg fp "$fingerprint" \
-			--argjson prs "${PREFETCH_UPDATED_PRS:-[]}" \
-			--argjson issues "${PREFETCH_UPDATED_ISSUES:-[]}" \
-			'{last_prefetch: $now, last_full_sweep: $lfs, state_fingerprint: $fp, prs: $prs, issues: $issues}')
+		new_entry=$(_prefetch_build_cache_entry \
+			"$now_iso" "$last_full_sweep" "$fingerprint" \
+			"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}") || new_entry=""
 	fi
-	_prefetch_cache_set "$slug" "$new_entry"
+	if [[ -n "$new_entry" && "$new_entry" != "null" ]]; then
+		_prefetch_cache_set "$slug" "$new_entry"
+	else
+		echo "[pulse-wrapper] _prefetch_single_repo: failed to build cache entry for ${slug}" >>"$LOGFILE"
+	fi
 
 	return 0
 }

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -527,7 +527,7 @@ _prefetch_build_cache_entry() {
 	[[ -n "$prs_json" && "$prs_json" != "null" ]] || prs_json="[]"
 	[[ -n "$issues_json" && "$issues_json" != "null" ]] || issues_json="[]"
 
-	local prs_file issues_file
+	local prs_file="" issues_file=""
 	prs_file=$(mktemp) || return 1
 	issues_file=$(mktemp) || {
 		rm -f "$prs_file"
@@ -543,8 +543,7 @@ _prefetch_build_cache_entry() {
 		return 1
 	fi
 
-	local jq_output jq_status
-	jq_status=0
+	local jq_output="" jq_status=0
 	jq_output=$(jq -n \
 		--arg now "$now_iso" \
 		--arg lfs "$last_full_sweep" \

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -258,12 +258,34 @@ _compute_repo_state_fingerprint() {
 	[[ -n "$issues_json" && "$issues_json" != "null" ]] || issues_json="[]"
 	[[ -n "$prs_json" && "$prs_json" != "null" ]] || prs_json="[]"
 
-	# Canonicalize both lists. jq --argjson merges the PR list into the
-	# top-level object so the hash covers both.
+	# Canonicalize both lists. The PR/issue arrays can exceed Linux
+	# MAX_ARG_STRLEN, so pass them through temp files instead of jq --argjson.
 	local canon
+	local issues_file prs_file
+	issues_file=$(mktemp) || {
+		echo ""
+		return 0
+	}
+	prs_file=$(mktemp) || {
+		rm -f "$issues_file"
+		echo ""
+		return 0
+	}
+	if ! printf '%s' "$issues_json" >"$issues_file"; then
+		rm -f "$issues_file" "$prs_file"
+		echo ""
+		return 0
+	fi
+	if ! printf '%s' "$prs_json" >"$prs_file"; then
+		rm -f "$issues_file" "$prs_file"
+		echo ""
+		return 0
+	fi
 	canon=$(jq -cSn \
-		--argjson issues "$issues_json" \
-		--argjson prs "$prs_json" '
+		--slurpfile issues "$issues_file" \
+		--slurpfile prs "$prs_file" '
+		($issues[0] // []) as $issues |
+		($prs[0] // []) as $prs |
 		{
 			issues: ($issues | sort_by(.number) | map({
 				n: .number,
@@ -281,6 +303,7 @@ _compute_repo_state_fingerprint() {
 			}))
 		}
 	' 2>/dev/null) || canon=""
+	rm -f "$issues_file" "$prs_file"
 	[[ -n "$canon" ]] || {
 		echo ""
 		return 0
@@ -480,16 +503,29 @@ _prefetch_cache_set() {
 	if [[ -f "$cache_file" ]]; then
 		existing=$(cat "$cache_file" 2>/dev/null) || existing="{}"
 		# Validate JSON; reset if corrupt
-		echo "$existing" | jq empty 2>/dev/null || existing="{}"
+		printf '%s' "$existing" | jq empty 2>/dev/null || existing="{}"
 	fi
 
-	local tmp_file
+	local tmp_file entry_file
+	local failure_msg
+	failure_msg='[pulse-wrapper] _prefetch_cache_set: failed to write cache for'
 	tmp_file=$(mktemp "${cache_dir}/.pulse-prefetch-cache.XXXXXX")
-	echo "$existing" | jq --arg slug "$slug" --argjson entry "$entry" \
-		'.[$slug] = $entry' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+	entry_file=$(mktemp "${cache_dir}/.pulse-prefetch-entry.XXXXXX") || {
 		rm -f "$tmp_file"
-		echo "[pulse-wrapper] _prefetch_cache_set: failed to write cache for ${slug}" >>"$LOGFILE"
+		printf '%s %s\n' "$failure_msg" "$slug" >>"$LOGFILE"
+		return 0
 	}
+	if ! printf '%s' "$entry" >"$entry_file"; then
+		rm -f "$tmp_file" "$entry_file"
+		printf '%s %s\n' "$failure_msg" "$slug" >>"$LOGFILE"
+		return 0
+	fi
+	printf '%s' "$existing" | jq --arg slug "$slug" --slurpfile entry "$entry_file" \
+		'.[$slug] = ($entry[0] // {})' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+		rm -f "$tmp_file" "$entry_file"
+		printf '%s %s\n' "$failure_msg" "$slug" >>"$LOGFILE"
+	}
+	rm -f "$entry_file"
 	return 0
 }
 

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -261,7 +261,7 @@ _compute_repo_state_fingerprint() {
 	# Canonicalize both lists. The PR/issue arrays can exceed Linux
 	# MAX_ARG_STRLEN, so pass them through temp files instead of jq --argjson.
 	local canon
-	local issues_file prs_file
+	local issues_file="" prs_file=""
 	issues_file=$(mktemp) || {
 		echo ""
 		return 0
@@ -506,7 +506,7 @@ _prefetch_cache_set() {
 		printf '%s' "$existing" | jq empty 2>/dev/null || existing="{}"
 	fi
 
-	local tmp_file entry_file
+	local tmp_file="" entry_file=""
 	local failure_msg
 	failure_msg='[pulse-wrapper] _prefetch_cache_set: failed to write cache for'
 	tmp_file=$(mktemp "${cache_dir}/.pulse-prefetch-cache.XXXXXX")

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1002,6 +1002,40 @@ _filter_unscanned_prs() {
 # _print_scan_summary: emit the final scan summary to stdout.
 # Arguments: $1=json_output $2=backfill $3=dry_run $4=all_findings_json
 #            $5=batch_count $6=total_findings $7=total_issues_created
+_print_scan_summary_json() {
+	local details_json="$1"
+	local dry_run="$2"
+	local batch_count="$3"
+	local total_findings="$4"
+	local total_issues_created="$5"
+
+	[[ -n "$details_json" && "$details_json" != "null" ]] || details_json="[]"
+
+	local details_file
+	details_file=$(mktemp) || return 1
+	if ! printf '%s' "$details_json" >"$details_file"; then
+		rm -f "$details_file"
+		return 1
+	fi
+
+	local dry_run_json="false"
+	[[ "$dry_run" == true ]] && dry_run_json="true"
+
+	local jq_output jq_status
+	jq_status=0
+	jq_output=$(jq -n \
+		--argjson scanned "$batch_count" \
+		--argjson findings "$total_findings" \
+		--argjson issues_created "$total_issues_created" \
+		--slurpfile details "$details_file" \
+		--argjson dry_run "$dry_run_json" \
+		'{scanned: $scanned, findings: $findings, issues_created: $issues_created, details: ($details[0] // []), dry_run: $dry_run}') || jq_status=$?
+	rm -f "$details_file"
+	[[ "$jq_status" -eq 0 ]] || return "$jq_status"
+	printf '%s\n' "$jq_output"
+	return 0
+}
+
 _print_scan_summary() {
 	local json_output="$1"
 	local backfill="$2"
@@ -1014,13 +1048,7 @@ _print_scan_summary() {
 	if [[ "$json_output" == "true" ]]; then
 		local details_json="$all_findings_json"
 		[[ "$backfill" == true && "$dry_run" != true ]] && details_json="[]"
-		jq -n \
-			--argjson scanned "$batch_count" \
-			--argjson findings "$total_findings" \
-			--argjson issues_created "$total_issues_created" \
-			--argjson details "$details_json" \
-			--argjson dry_run "$([[ "$dry_run" == true ]] && echo 'true' || echo 'false')" \
-			'{scanned: $scanned, findings: $findings, issues_created: $issues_created, details: $details, dry_run: $dry_run}'
+		_print_scan_summary_json "$details_json" "$dry_run" "$batch_count" "$total_findings" "$total_issues_created" || return 1
 	else
 		echo ""
 		echo -e "${BLUE:-}=== Scan Summary ===${NC:-}"

--- a/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
+++ b/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" || exit 1
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+LARGE_ISSUES_JSON=""
+LARGE_PRS_JSON=""
+LARGE_FINDINGS_JSON=""
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="$TEST_ROOT/home"
+	export LOGFILE="$TEST_ROOT/pulse.log"
+	export PULSE_PREFETCH_CACHE_FILE="$TEST_ROOT/cache/pulse-prefetch.json"
+	export PULSE_QUEUED_SCAN_LIMIT=200
+	mkdir -p "$HOME" "$TEST_ROOT/cache"
+	: >"$LOGFILE"
+	return 0
+}
+
+teardown_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+build_large_json() {
+	LARGE_ISSUES_JSON=$(python3 - <<'PY'
+import json
+payload = "x" * 300
+print(json.dumps([
+    {"number": i, "labels": [{"name": "bug"}], "assignees": [{"login": "dev"}], "updatedAt": "2026-06-26T00:00:00Z", "title": payload}
+    for i in range(600)
+]))
+PY
+)
+	LARGE_PRS_JSON=$(python3 - <<'PY'
+import json
+payload = "y" * 300
+print(json.dumps([
+    {"number": i, "labels": [{"name": "ready"}], "assignees": [{"login": "dev"}], "reviewDecision": "APPROVED", "mergeable": "MERGEABLE", "updatedAt": "2026-06-26T00:00:00Z", "title": payload}
+    for i in range(600)
+]))
+PY
+)
+	LARGE_FINDINGS_JSON=$(python3 - <<'PY'
+import json
+payload = "z" * 300
+print(json.dumps([
+    {"pr": i, "file": "script.sh", "line": i, "severity": "medium", "body": payload}
+    for i in range(600)
+]))
+PY
+)
+	return 0
+}
+
+gh_issue_list() {
+	printf '%s' "$LARGE_ISSUES_JSON"
+	return 0
+}
+
+pulse_pr_list_get() {
+	printf '%s' "$LARGE_PRS_JSON"
+	return 0
+}
+
+test_prefetch_fingerprint_accepts_large_lists() {
+	setup_env
+	# shellcheck source=../pulse-prefetch-infra.sh
+	source "$SCRIPTS_DIR/pulse-prefetch-infra.sh"
+	local hash
+	hash=$(_compute_repo_state_fingerprint "owner/repo")
+	if [[ "$hash" =~ ^[0-9a-f]{16}$ ]]; then
+		print_result "prefetch fingerprint avoids large jq argv" 0
+	else
+		print_result "prefetch fingerprint avoids large jq argv" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_prefetch_cache_entry_accepts_large_lists() {
+	setup_env
+	# shellcheck source=../pulse-prefetch-fetch.sh
+	source "$SCRIPTS_DIR/pulse-prefetch-fetch.sh"
+	local entry pr_count issue_count
+	entry=$(_prefetch_build_cache_entry \
+		"2026-06-26T00:00:00Z" \
+		"2026-06-26T00:00:00Z" \
+		"fingerprint" \
+		"$LARGE_PRS_JSON" \
+		"$LARGE_ISSUES_JSON")
+	pr_count=$(printf '%s' "$entry" | jq '.prs | length')
+	issue_count=$(printf '%s' "$entry" | jq '.issues | length')
+	if [[ "$pr_count" == "600" && "$issue_count" == "600" ]]; then
+		print_result "prefetch cache entry avoids large jq argv" 0
+	else
+		print_result "prefetch cache entry avoids large jq argv" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_prefetch_cache_set_accepts_large_entry() {
+	setup_env
+	# shellcheck source=../pulse-prefetch-infra.sh
+	source "$SCRIPTS_DIR/pulse-prefetch-infra.sh"
+	local entry stored_count
+	entry=$(jq -n \
+		--slurpfile prs <(printf '%s' "$LARGE_PRS_JSON") \
+		--slurpfile issues <(printf '%s' "$LARGE_ISSUES_JSON") \
+		'{last_prefetch:"2026-06-26T00:00:00Z", last_full_sweep:"2026-06-26T00:00:00Z", state_fingerprint:"fp", prs: $prs[0], issues: $issues[0]}')
+	_prefetch_cache_set "owner/repo" "$entry"
+	stored_count=$(jq '.["owner/repo"].prs | length' "$PULSE_PREFETCH_CACHE_FILE")
+	if [[ "$stored_count" == "600" ]]; then
+		print_result "prefetch cache set avoids large jq argv" 0
+	else
+		print_result "prefetch cache set avoids large jq argv" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_quality_feedback_summary_accepts_large_details() {
+	setup_env
+	# shellcheck source=../quality-feedback-helper.sh
+	source "$SCRIPTS_DIR/quality-feedback-helper.sh"
+	local output detail_count
+	output=$(_print_scan_summary true false false "$LARGE_FINDINGS_JSON" 600 600 0)
+	detail_count=$(printf '%s' "$output" | jq '.details | length')
+	if [[ "$detail_count" == "600" ]]; then
+		print_result "quality feedback summary avoids large jq argv" 0
+	else
+		print_result "quality feedback summary avoids large jq argv" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_known_large_argjson_patterns_absent() {
+	local failed=0
+	if grep -nE -- '--argjson (prs|issues) "\$\{PREFETCH_UPDATED_(PRS|ISSUES)' "$SCRIPTS_DIR/pulse-prefetch-fetch.sh" >/dev/null 2>&1; then
+		failed=1
+	fi
+	# shellcheck disable=SC2016 # Literal regex: match shell variable names in source.
+	if grep -nE -- '--argjson (issues|prs) "\$(issues_json|prs_json)"|--argjson entry "\$entry"' "$SCRIPTS_DIR/pulse-prefetch-infra.sh" >/dev/null 2>&1; then
+		failed=1
+	fi
+	# shellcheck disable=SC2016 # Literal regex: match shell variable names in source.
+	if grep -nE -- '--argjson details "\$details_json"' "$SCRIPTS_DIR/quality-feedback-helper.sh" >/dev/null 2>&1; then
+		failed=1
+	fi
+	print_result "known-large jq --argjson variables stay out of argv" "$failed"
+	return 0
+}
+
+main() {
+	build_large_json
+	test_prefetch_fingerprint_accepts_large_lists
+	test_prefetch_cache_entry_accepts_large_lists
+	test_prefetch_cache_set_accepts_large_entry
+	test_quality_feedback_summary_accepts_large_details
+	test_known_large_argjson_patterns_absent
+	printf '\nTests run: %d\n' "$TESTS_RUN"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		printf 'Tests failed: %d\n' "$TESTS_FAILED"
+		return 1
+	fi
+	printf 'All tests passed\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
Resolves #25583

## Summary
- Load large pulse PR/issue cache JSON through temp files and `jq --slurpfile` instead of `--argjson` argv.
- Apply the same stdin/file transport pattern to quality feedback scan summary details.
- Add regression coverage with >128 KB JSON payloads plus a static guard for known-large `--argjson` variables.

## Verification
- `.agents/scripts/tests/test-jq-large-json-argv-regression.sh`
- `shellcheck .agents/scripts/pulse-prefetch-fetch.sh .agents/scripts/pulse-prefetch-infra.sh .agents/scripts/quality-feedback-helper.sh .agents/scripts/tests/test-jq-large-json-argv-regression.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.5 with gpt-5.5 spent 1h 11m and 223,735 tokens on this with the user in an interactive session.