### PR TITLE
t18011: fix: refresh existing macOS GUI app on update

### DIFF
--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -69,6 +69,8 @@ test_setup_stage_contract() {
 	assert_contains "gui-desktop scope maps to native app installer" "$text" "gui-desktop | gui | app | \"\$SETUP_STAGE_GUI_DESKTOP\") printf '%s' \"\$SETUP_STAGE_GUI_DESKTOP\""
 	assert_contains "gui desktop default path is opt-in gated" "$text" "_time_step \"setup_gui_desktop_app_opt_in\" _setup_offer_gui_desktop_app"
 	assert_contains "gui desktop env flag enables install" "$text" "AIDEVOPS_GUI_DESKTOP_INSTALL"
+	assert_contains "gui desktop app dir can be configured" "$text" "AIDEVOPS_GUI_DESKTOP_APP_DIR"
+	assert_contains "existing gui desktop app refreshes during update" "$text" "Refreshing existing macOS"
 	assert_contains "gui desktop scoped stage runs installer" "$text" "_time_step \"\$SETUP_STAGE_GUI_DESKTOP\" setup_gui_desktop_app"
 	assert_contains "unknown stages print actionable help" "$text" "Unknown setup stage/scope"
 	return 0
@@ -105,10 +107,24 @@ test_gui_desktop_package_contract() {
 	return 0
 }
 
+test_gui_desktop_installer_contract() {
+	local installer="${REPO_ROOT}/packages/gui-desktop/scripts/install-macos-app.sh"
+	local text=""
+	text="$(file_text "$installer")" || {
+		print_result "GUI desktop installer is readable" 1 "$installer"
+		return 0
+	}
+
+	assert_contains "installer honours configured app dir env" "$text" 'AIDEVOPS_GUI_DESKTOP_APP_DIR'
+	assert_contains "installer keeps explicit app-dir override" "$text" '--app-dir'
+	return 0
+}
+
 main() {
 	test_setup_stage_contract
 	test_cli_scope_contract
 	test_gui_desktop_package_contract
+	test_gui_desktop_installer_contract
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -9,6 +9,7 @@ DEFAULT_APP_DIR="/Applications"
 
 usage() {
   printf 'Usage: %s [--check] [--app-dir DIR]\n' "$0"
+  printf 'Environment: AIDEVOPS_GUI_DESKTOP_APP_DIR overrides the default app directory.\n'
   return 0
 }
 
@@ -991,7 +992,7 @@ PLIST
 
 main() {
   local mode="install"
-  local app_dir="$DEFAULT_APP_DIR"
+  local app_dir="${AIDEVOPS_GUI_DESKTOP_APP_DIR:-$DEFAULT_APP_DIR}"
   local root=""
 
   while [[ $# -gt 0 ]]; do

--- a/setup.sh
+++ b/setup.sh
@@ -458,8 +458,20 @@ _setup_gui_desktop_install_opted_in() {
 	return 1
 }
 
+_setup_gui_desktop_app_dir() {
+	printf '%s' "${AIDEVOPS_GUI_DESKTOP_APP_DIR:-/Applications}"
+	return 0
+}
+
+_setup_gui_desktop_app_exists() {
+	local app_dir="$1"
+	[[ -d "${app_dir}/${SETUP_GUI_APP_NAME}" ]]
+	return $?
+}
+
 setup_gui_desktop_app() {
 	local installer="${INSTALL_DIR}/packages/gui-desktop/scripts/install-macos-app.sh"
+	local app_dir=""
 	local os=""
 	local rc=0
 
@@ -476,7 +488,8 @@ setup_gui_desktop_app() {
 		return 0
 	fi
 
-	bash "$installer" || rc=$?
+	app_dir="$(_setup_gui_desktop_app_dir)"
+	bash "$installer" --app-dir "$app_dir" || rc=$?
 	if [[ "$rc" -eq 0 ]]; then
 		setup_track_configured "$SETUP_GUI_APP_NAME"
 		return 0
@@ -489,8 +502,16 @@ setup_gui_desktop_app() {
 
 _setup_offer_gui_desktop_app() {
 	local answer=""
+	local app_dir=""
 
 	if _setup_gui_desktop_install_opted_in; then
+		setup_gui_desktop_app
+		return 0
+	fi
+
+	app_dir="$(_setup_gui_desktop_app_dir)"
+	if [[ "$(uname -s)" == "$SETUP_OS_DARWIN" ]] && _setup_gui_desktop_app_exists "$app_dir"; then
+		print_info "Refreshing existing macOS ${SETUP_GUI_APP_NAME} in ${app_dir}"
 		setup_gui_desktop_app
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Added non-interactive setup refresh for an existing macOS aidevops.app, honoured AIDEVOPS_GUI_DESKTOP_APP_DIR in setup/installer paths, and expanded scoped setup tests for the refresh contract.

## Files Changed

.agents/scripts/tests/test-setup-scoped-dispatch.sh,packages/gui-desktop/scripts/install-macos-app.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n setup.sh aidevops.sh packages/gui-desktop/scripts/install-macos-app.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh && .agents/scripts/tests/test-setup-scoped-dispatch.sh; shellcheck setup.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh packages/gui-desktop/scripts/install-macos-app.sh aidevops.sh; AIDEVOPS_GUI_DESKTOP_APP_DIR=<temp> bash setup.sh --stage gui-desktop (Linux macOS-only skip passed); npm run gui:desktop:check (blocked on Linux: installer reports macOS only)

Resolves #25590


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.6 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 57,485 tokens on this as a headless worker.