### PR TITLE
fix: avoid stale time on ops comments

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -39,6 +39,13 @@
 #   AIDEVOPS_GH_SHIM_DISABLE=1 gh …          # skip entire shim
 #   AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 gh …  # skip read-rewrite only (t3037)
 #
+# Ops/audit comments
+# ------------------
+# Deterministic ops comments such as the dispatch audit trail are posted by
+# shell automation, not by the worker LLM session. They must still be signed for
+# provenance, but the footer must not inherit stale OpenCode session duration or
+# token metrics from a long-lived Linux runner DB.
+#
 # Runtime-vs-pre-execution split (t2893)
 # --------------------------------------
 # Two enforcement layers cooperate, separated by WHEN they run:
@@ -656,6 +663,24 @@ _shim_api_target_from_path() {
 	return 1
 }
 
+_shim_body_is_ops_audit() {
+	local body="$1"
+	case "$body" in
+	*'<!-- ops:start'* | *'Dispatching worker (deterministic)'* | *'<!-- routine-description'* | *'<!-- dispatch-infrastructure-failure -->'*) return 0 ;;
+	esac
+	return 1
+}
+
+_shim_sig_footer_for_body() {
+	local body="${1:-}"
+	if _shim_body_is_ops_audit "$body"; then
+		"$SIG_HELPER" footer --body "$body" --no-session 2>/dev/null
+	else
+		"$SIG_HELPER" footer --body "$body" 2>/dev/null
+	fi
+	return $?
+}
+
 # -----------------------------------------------------------------------------
 # _shim_api_inject_body_sig
 # Scans _modified_args for -f/-F body=@<file> or body=<inline> arguments
@@ -674,14 +699,15 @@ _shim_api_inject_body_sig() {
 			body=@*)
 				_bfile="${_next#body=@}"
 				if [[ -f "$_bfile" ]] && ! grep -q "<!-- aidevops:sig -->" "$_bfile" 2>/dev/null; then
-					_footer=$("$SIG_HELPER" footer 2>/dev/null) || true
+					_bval=$(<"$_bfile") || _bval=""
+					_footer=$(_shim_sig_footer_for_body "$_bval") || true
 					[[ -n "$_footer" ]] && printf '%s' "$_footer" >>"$_bfile" || true
 				fi
 				;;
 			body=*)
 				_bval="${_next#body=}"
 				if [[ "$_bval" != *"<!-- aidevops:sig -->"* ]]; then
-					_footer=$("$SIG_HELPER" footer --body "$_bval" 2>/dev/null) || {
+					_footer=$(_shim_sig_footer_for_body "$_bval") || {
 						i=$((i + 2))
 						continue
 					}
@@ -704,14 +730,15 @@ _shim_api_inject_body_sig() {
 			body=@*)
 				_bfile="${_kv#body=@}"
 				if [[ -f "$_bfile" ]] && ! grep -q "<!-- aidevops:sig -->" "$_bfile" 2>/dev/null; then
-					_footer=$("$SIG_HELPER" footer 2>/dev/null) || true
+					_bval=$(<"$_bfile") || _bval=""
+					_footer=$(_shim_sig_footer_for_body "$_bval") || true
 					[[ -n "$_footer" ]] && printf '%s' "$_footer" >>"$_bfile" || true
 				fi
 				;;
 			body=*)
 				_bval="${_kv#body=}"
 				if [[ "$_bval" != *"<!-- aidevops:sig -->"* ]]; then
-					_footer=$("$SIG_HELPER" footer --body "$_bval" 2>/dev/null) || {
+					_footer=$(_shim_sig_footer_for_body "$_bval") || {
 						i=$((i + 1))
 						continue
 					}

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -132,6 +132,12 @@ mkdir -p "$TMP/scripts"
 cat >"$TMP/scripts/gh-signature-helper.sh" <<'EOF'
 #!/usr/bin/env bash
 # Stub emits fixed footer so tests are deterministic.
+if [[ -n "${STUB_SIG_LOG:-}" ]]; then
+	: >"$STUB_SIG_LOG"
+	for arg in "$@"; do
+		printf '%s\n' "$arg" >>"$STUB_SIG_LOG"
+	done
+fi
 printf '\n\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub footer\n'
 EOF
 chmod +x "$TMP/scripts/gh-signature-helper.sh"
@@ -148,6 +154,7 @@ cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-fallback.sh" "$TMP/scripts
 # $TMP/scripts (for direct invocation in tests).
 export PATH="$TMP/bin:$PATH"
 export STUB_GH_LOG="$TMP/gh-argv.log"
+export STUB_SIG_LOG="$TMP/sig-argv.log"
 
 SHIM_RUN="$TMP/scripts/gh"
 
@@ -163,6 +170,16 @@ _read_argv() {
 
 _reset_log() {
 	: >"$STUB_GH_LOG"
+	: >"$STUB_SIG_LOG"
+	return 0
+}
+
+_read_sig_argv() {
+	[[ -f "$STUB_SIG_LOG" ]] || {
+		echo "(no sig log)"
+		return 0
+	}
+	cat "$STUB_SIG_LOG"
 	return 0
 }
 
@@ -574,6 +591,20 @@ if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
 	_pass "headless write to maintainer-managed repo proceeds normally"
 else
 	_fail "maintainer repo headless write" "argv: $argv"
+fi
+
+_reset_log
+ops_body='<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+Dispatching worker (deterministic).
+- **Worker PID**: 123
+<!-- ops:end -->'
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" api /repos/managed/repo/issues/789/comments -X POST -f body="$ops_body" 2>/dev/null
+sig_argv=$(_read_sig_argv)
+argv=$(_read_argv)
+if [[ "$argv" == *"<!-- aidevops:sig -->"* ]] && [[ "$sig_argv" == *$'--no-session'* ]]; then
+	_pass "deterministic ops REST comments sign without session metrics"
+else
+	_fail "ops REST no-session signature" "argv: $argv sig argv: $sig_argv"
 fi
 
 repos_json_missing_role="$TMP/repos-missing-role.json"

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -170,16 +170,16 @@ _read_argv() {
 
 _reset_log() {
 	: >"$STUB_GH_LOG"
-	: >"$STUB_SIG_LOG"
+	[[ -n "${STUB_SIG_LOG:-}" ]] && : >"$STUB_SIG_LOG"
 	return 0
 }
 
 _read_sig_argv() {
-	[[ -f "$STUB_SIG_LOG" ]] || {
+	[[ -f "${STUB_SIG_LOG:-}" ]] || {
 		echo "(no sig log)"
 		return 0
 	}
-	cat "$STUB_SIG_LOG"
+	cat "${STUB_SIG_LOG:-}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -485,36 +485,36 @@ rm -rf "$tmp_home_19"
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "Test 20: session-mode footer detection"
-result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS -u AIDEVOPS_SESSION_ORIGIN \
 	OPENCODE=1 AIDEVOPS_HEADLESS_VARIANT_SONNET="high" \
 	"$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_contains "variant config alone remains interactive" "with the user in an interactive session" "$result"
 assert_not_contains "variant config does not imply worker" "as a headless worker" "$result"
 
-result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS -u AIDEVOPS_SESSION_ORIGIN \
 	OPENCODE=true AIDEVOPS_HEADLESS_VARIANT_SONNET="high" \
 	"$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_contains "truthy OPENCODE marks interactive" "with the user in an interactive session" "$result"
 
-result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS -u AIDEVOPS_SESSION_ORIGIN \
 	-u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID OPENCODE=false CLAUDE_CODE=0 \
 	"$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_not_contains "false runtime markers do not imply interactive" "with the user in an interactive session" "$result"
 
-result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS -u AIDEVOPS_SESSION_ORIGIN \
 	-u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID OPENCODE=0 CLAUDE_CODE=true \
 	"$HELPER" generate --cli "Claude Code" --model "m" --tokens 1 --time 60)
 assert_contains "truthy CLAUDE_CODE marks interactive" "with the user in an interactive session" "$result"
 
-result=$(env -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS FULL_LOOP_HEADLESS=true \
+result=$(env -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS -u AIDEVOPS_SESSION_ORIGIN FULL_LOOP_HEADLESS=true \
 	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_contains "FULL_LOOP_HEADLESS marks worker" "as a headless worker" "$result"
 
-result=$(env -u FULL_LOOP_HEADLESS -u OPENCODE_HEADLESS AIDEVOPS_HEADLESS=true \
+result=$(env -u FULL_LOOP_HEADLESS -u OPENCODE_HEADLESS -u AIDEVOPS_SESSION_ORIGIN AIDEVOPS_HEADLESS=true \
 	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_contains "AIDEVOPS_HEADLESS marks worker" "as a headless worker" "$result"
 
-result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS OPENCODE_HEADLESS=true \
+result=$(env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u AIDEVOPS_SESSION_ORIGIN OPENCODE_HEADLESS=true \
 	OPENCODE=1 "$HELPER" generate --cli "OpenCode" --model "m" --tokens 1 --time 60)
 assert_contains "OPENCODE_HEADLESS marks worker" "as a headless worker" "$result"
 


### PR DESCRIPTION
## Summary

Fixes deterministic ops/audit comments so the gh PATH shim signs them with provenance but does not auto-attach OpenCode session duration or token metrics from the local session DB.

## Root cause

Raw REST writes such as the deterministic worker dispatch comment go through `.agents/scripts/gh`, which auto-injects a signature footer. On a Linux runner, the footer helper can find a long-lived/stale OpenCode session in the same repo directory and report its `session.time_created` delta as “spent … on this”, even though the comment is shell audit trail posted before worker work starts.

## Changes

- Detect ops/audit bodies in `.agents/scripts/gh` and call `gh-signature-helper.sh footer --no-session` for those bodies.
- Preserve normal session metrics for regular issue/PR comments.
- Cover the REST issue-comment path used by deterministic dispatch comments.
- Make signature-helper session-mode tests hermetic by unsetting inherited `AIDEVOPS_SESSION_ORIGIN`.

## Verification

- `.agents/scripts/tests/test-gh-shim.sh` — 42 passed, 0 failed.
- `.agents/scripts/tests/test-gh-signature-helper.sh` — 70 passed, 0 failed.
- `shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh .agents/scripts/tests/test-gh-signature-helper.sh` — passed.
- `git diff --check` — passed.
- `.agents/scripts/linters-local.sh` — ALL LOCAL CHECKS PASSED.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.7 with gpt-5.5 spent 22m and 139,659 tokens on this with the user in an interactive session.

Ref #25541
