### PR TITLE
For #25541: retry OpenCode DB migration replay

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -412,6 +412,29 @@ _recover_deleted_cwd_before_launch() {
 # Runtime invocation — OpenCode and Claude CLI
 # =============================================================================
 
+#######################################
+# Detect OpenCode/Drizzle replaying CREATE TABLE migrations against an already
+# prewarmed worker DB. This happens before the seed prompt reaches the model and
+# is safe to recover by retrying once with a fresh isolated DB.
+# Args: $1 = runtime exit code, $2 = output file path.
+#######################################
+_opencode_project_table_migration_replay_detected() {
+	local exit_code="$1"
+	local output_file="$2"
+	local project_table_backtick="table \`project\` already exists"
+	local output_text=""
+
+	[[ "${exit_code:-}" != "0" ]] || return 1
+	[[ -f "$output_file" ]] || return 1
+	output_text=$(<"$output_file") || output_text=""
+	case "$output_text" in
+	*"$project_table_backtick"* | *"table project already exists"* | *"table 'project' already exists"* | *'table "project" already exists'*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
 # _invoke_opencode: run the opencode command (with or without sandbox) and capture output.
 # Args: output_file exit_code_file cmd_args (null-delimited, read from stdin via process sub)
 # Caller passes the cmd array elements as positional args after the two file args.
@@ -1443,6 +1466,34 @@ _execute_run_attempt() {
 	# and must be checked after the stale-session retry block.
 	local _rl_fast_sentinel="${exit_code_file}.rate_limit_fast"
 	rm -f "$exit_code_file"
+
+	# GH#25541: A prewarmed isolated OpenCode DB can still reach `opencode run`
+	# with user tables present but migration ledgers unusable/mismatched, causing
+	# Drizzle to replay CREATE TABLE and abort with `table project already exists`
+	# before the seed prompt/model activity. The DB is per-worker scratch state, so
+	# retry once with a fresh isolated dir and no dispatcher prewarm dir instead of
+	# releasing the claim as a model/worker failure.
+	if [[ "$runtime" != "claude" ]] && _opencode_project_table_migration_replay_detected "$exit_code" "$output_file"; then
+		print_warning "OpenCode worker DB migration replay detected for ${session_key}; retrying once with fresh isolated DB (GH#25541)"
+		unset AIDEVOPS_WORKER_PREWARM_DIR
+		rm -f "$output_file" 2>/dev/null || true
+		output_file=$(mktemp)
+		exit_code_file=$(mktemp)
+		exit_code=0
+		_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
+		if ! read -r exit_code <"$exit_code_file" 2>/dev/null; then
+			exit_code=1
+		fi
+		_normalized_exit_info=$(_normalize_worker_exit_code_and_kill_reason "$exit_code_file" "$exit_code")
+		IFS=$'\t' read -r exit_code _metric_kill_reason <<<"$_normalized_exit_info"
+		local _project_retry_stall_killed_marker="${exit_code_file}.watchdog_stall_killed"
+		if [[ -f "$_project_retry_stall_killed_marker" ]]; then
+			_run_watchdog_hard_killed=1
+			rm -f "$_project_retry_stall_killed_marker"
+		fi
+		_rl_fast_sentinel="${exit_code_file}.rate_limit_fast"
+		rm -f "$exit_code_file"
+	fi
 
 	# GH#16978 Bug B: Stale session ID causes "Session not found" on OpenCode.
 	# When a persisted session ID is stale (e.g., from a previous OpenCode version

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1602,6 +1602,22 @@ SQL
 	return 0
 }
 
+test_opencode_project_table_migration_replay_detected() {
+	local output_file="${TEST_ROOT}/opencode-project-replay.log"
+	local project_table_error="table \`project\` already exists"
+	printf '%s\n' 'Error: Unexpected error' "$project_table_error" >"$output_file"
+
+	if _opencode_project_table_migration_replay_detected 1 "$output_file" && \
+		! _opencode_project_table_migration_replay_detected 0 "$output_file"; then
+		print_result "detects OpenCode project table migration replay startup failure" 0
+		return 0
+	fi
+
+	print_result "detects OpenCode project table migration replay startup failure" 1 \
+		"Expected non-zero exit with project table replay output to be detected only on failure"
+	return 0
+}
+
 test_large_opencode_prompt_uses_file_attachment() {
 	local prompt="large-seed-prompt-with-worker-contract"
 	local old_threshold="${HEADLESS_PROMPT_FILE_THRESHOLD_BYTES:-}"
@@ -2507,6 +2523,7 @@ main() {
 	test_sync_worker_db_migration_metadata_archives_unrepairable_project_table
 	test_sync_worker_db_migration_metadata_preserves_worker_db_when_shared_query_fails
 	test_sync_worker_db_migration_metadata_repeated_launch_reaches_seed
+	test_opencode_project_table_migration_replay_detected
 	test_large_opencode_prompt_uses_file_attachment
 	test_large_claude_prompt_uses_stdin_file
 	test_registered_prompt_temp_cleanup_removes_dir


### PR DESCRIPTION
## Summary
- Detect OpenCode startup failures where Drizzle replays migrations and exits with `table project already exists` before model activity.
- Retry once with the dispatcher prewarm dir cleared so the worker gets a fresh isolated DB instead of failing GH#25541 as a model/worker error.
- Add a focused regression for the startup-failure detector.

For #25541

## Verification
- `bash -n .agents/scripts/headless-runtime-helper.sh && bash -n .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh` → 93 tests, 0 failures
- `git diff --check`

## Notes
- Broad `.agents/scripts/linters-local.sh` reached advisory-only phases but timed out in later portability checks; targeted changed-file checks and the headless runtime suite passed.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.7 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 15h 22m and 2,099,929 tokens on this with the user in an interactive session.