### PR TITLE
t18007: feat: add vault audit helper

### DIFF
--- a/.agents/reference/vault.md
+++ b/.agents/reference/vault.md
@@ -332,6 +332,19 @@ in repo-visible names or files. Imports fail closed on bad signatures, replay,
 rollback, expiry, or revoked author devices, then stage encrypted payloads for a
 local trusted-device rewrap/reindex pass.
 
+`.agents/scripts/vault-audit-helper.sh` is the dedicated Vault audit layer, kept
+separate from the general `.agents/scripts/audit-log-helper.sh` because Vault
+events have a stricter trust boundary: full event payloads are encrypted for
+trusted audit readers, each record is signed with a device audit key that is
+separate from data/sync/control keys, and public anchors contain only checkpoint
+hashes plus sequence metadata. It supports append, verify, peer receipt, public
+anchor, replicate, and report commands. Verification fails closed on missing
+sequences, broken previous-hash links, edited encrypted payload hashes, invalid
+record signatures, or peer receipts that do not match the observed head. Vault
+CLI operations emit attempt/result events through this helper; set
+`AIDEVOPS_VAULT_AUDIT_REQUIRE=1` when sensitive deployments must fail closed if
+the audit event cannot be written.
+
 Revocation marks the device `revoked`, removes grants, writes a peer-visible
 registry update, and appends a local rotation task instructing follow-up workers
 to rewrap collection keys and notify peers. A stolen-device response should:

--- a/.agents/scripts/tests/test-vault-audit-helper.sh
+++ b/.agents/scripts/tests/test-vault-audit-helper.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+VAULT_AUDIT_HELPER="$REPO_ROOT/.agents/scripts/vault-audit-helper.sh"
+VAULT_HELPER="$REPO_ROOT/.agents/scripts/vault-helper.sh"
+
+tmp_root="$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-vault-audit-test)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+vault_dir="$tmp_root/vault-audit"
+peer_dir="$tmp_root/peer-audit"
+replica_dir="$tmp_root/replica"
+mkdir -p "$vault_dir" "$peer_dir" "$replica_dir"
+
+"$VAULT_AUDIT_HELPER" init --vault-dir "$vault_dir" >/dev/null
+first_head="$("$VAULT_AUDIT_HELPER" append --vault-dir "$vault_dir" --actor worker --action vault.lock --target-collection audit --result attempt --session-id test-session --reason "lock requested")"
+second_head="$("$VAULT_AUDIT_HELPER" append --vault-dir "$vault_dir" --actor worker --action vault.lock --target-collection audit --result success --session-id test-session --reason "lock completed")"
+
+if [[ ! "$first_head" =~ ^[0-9a-f]{64}$ || ! "$second_head" =~ ^[0-9a-f]{64}$ ]]; then
+	printf '%s\n' "audit heads are not stable hex hashes" >&2
+	exit 1
+fi
+
+verify_output="$("$VAULT_AUDIT_HELPER" verify --vault-dir "$vault_dir")"
+case "$verify_output" in
+	*"sequence=2"*"head=$second_head"*) ;;
+	*)
+		printf '%s\n' "verify output did not report expected head" >&2
+		exit 1
+		;;
+esac
+
+missing_log="$tmp_root/missing.jsonl"
+python3 - "$vault_dir/audit-events.jsonl" "$missing_log" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+lines = source.read_text(encoding="utf-8").splitlines()
+target.write_text(lines[1] + "\n", encoding="utf-8")
+PY
+
+if "$VAULT_AUDIT_HELPER" verify --vault-dir "$vault_dir" --log "$missing_log" >/dev/null 2>"$tmp_root/missing.err"; then
+	printf '%s\n' "missing sequence unexpectedly verified" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_AUDIT_SEQUENCE_GAP\|VAULT_AUDIT_CHAIN_BROKEN" "$tmp_root/missing.err"; then
+	printf '%s\n' "missing sequence did not use a stable error code" >&2
+	exit 1
+fi
+
+tampered_log="$tmp_root/tampered.jsonl"
+python3 - "$vault_dir/audit-events.jsonl" "$tampered_log" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+records = [json.loads(line) for line in source.read_text(encoding="utf-8").splitlines()]
+records[0]["encrypted_event"]["payload"] = records[0]["encrypted_event"]["payload"][::-1]
+target.write_text("\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n", encoding="utf-8")
+PY
+
+if "$VAULT_AUDIT_HELPER" verify --vault-dir "$vault_dir" --log "$tampered_log" >/dev/null 2>"$tmp_root/tampered.err"; then
+	printf '%s\n' "tampered event unexpectedly verified" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_AUDIT_EVENT_TAMPERED" "$tmp_root/tampered.err"; then
+	printf '%s\n' "tampered event did not use a stable error code" >&2
+	exit 1
+fi
+
+"$VAULT_AUDIT_HELPER" init --vault-dir "$peer_dir" >/dev/null
+receipt_file="$tmp_root/receipt.json"
+"$VAULT_AUDIT_HELPER" receipt --vault-dir "$peer_dir" --head "$second_head" --sequence 2 --observer-device peer-one --output "$receipt_file" >/dev/null
+"$VAULT_AUDIT_HELPER" verify --vault-dir "$vault_dir" --receipt "$receipt_file" >/dev/null
+
+bad_receipt="$tmp_root/bad-receipt.json"
+python3 - "$receipt_file" "$bad_receipt" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+data["receipt"]["observed_head"] = "0" * 64
+Path(sys.argv[2]).write_text(json.dumps(data, sort_keys=True) + "\n", encoding="utf-8")
+PY
+if "$VAULT_AUDIT_HELPER" verify --vault-dir "$vault_dir" --receipt "$bad_receipt" >/dev/null 2>"$tmp_root/bad-receipt.err"; then
+	printf '%s\n' "mismatched receipt unexpectedly verified" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_AUDIT_RECEIPT_MISMATCH" "$tmp_root/bad-receipt.err"; then
+	printf '%s\n' "mismatched receipt did not use a stable error code" >&2
+	exit 1
+fi
+
+anchor_file="$tmp_root/public-anchor.json"
+"$VAULT_AUDIT_HELPER" anchor --vault-dir "$vault_dir" --head "$second_head" --sequence 2 --output "$anchor_file" >/dev/null
+if grep -E "actor|action|target_collection|reason|encrypted_event|payload|session" "$anchor_file" >/dev/null; then
+	printf '%s\n' "public anchor leaked event metadata" >&2
+	exit 1
+fi
+if ! grep -q "$second_head" "$anchor_file"; then
+	printf '%s\n' "public anchor does not include the checkpoint head" >&2
+	exit 1
+fi
+
+"$VAULT_AUDIT_HELPER" replicate --vault-dir "$vault_dir" --output-dir "$replica_dir" >/dev/null
+if [[ ! -s "$replica_dir/audit-events.jsonl" ]]; then
+	printf '%s\n' "replication did not copy encrypted audit records" >&2
+	exit 1
+fi
+
+export AIDEVOPS_VAULT_AUDIT_DIR="$tmp_root/wrapped-audit"
+"$VAULT_HELPER" audit init >/dev/null
+"$VAULT_HELPER" audit append --actor worker --action vault.status --target-collection vault --result success --reason "wrapper command" >/dev/null
+"$VAULT_HELPER" audit verify >/dev/null
+
+printf '%s\n' "vault audit helper tests passed"

--- a/.agents/scripts/vault-audit-helper.sh
+++ b/.agents/scripts/vault-audit-helper.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+usage() {
+	cat <<'EOF'
+Usage: vault-audit-helper.sh <command> [options]
+
+Commands:
+  init [--force] [--vault-dir DIR]
+      Create a local device audit key separate from Vault data/sync/control keys.
+  append --actor ID --action NAME --target-collection NAME --result RESULT [options]
+      Append an encrypted, signed, hash-chained Vault audit event.
+  verify [--log FILE] [--receipt FILE ...]
+      Verify hash-chain continuity, signatures, sequence ordering, and receipts.
+  receipt --head HASH --sequence N --observer-device ID [--output FILE]
+      Sign a peer receipt proving another trusted device observed a checkpoint.
+  anchor --head HASH --sequence N [--output FILE]
+      Emit a public-safe signed checkpoint containing hashes and sequence only.
+  replicate --output-dir DIR
+      Copy encrypted audit records plus public anchors/receipts to a peer/private repo staging dir.
+  report [--json]
+      Summarise local audit health without decrypting or printing event contents.
+
+Full event payloads are encrypted for trusted audit readers. Public anchors expose
+only schema, device id, sequence, head hash, timestamp, and signature. Passphrases,
+secret values, decrypted content, and full prompt/session text are never accepted
+or printed by this helper.
+EOF
+	return 0
+}
+
+command="${1:-help}"
+case "$command" in
+help | --help | -h)
+	usage
+	exit 0
+	;;
+init | append | verify | receipt | anchor | replicate | report)
+	shift || true
+	python3 - "$command" "$@" <<'PY'
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
+
+
+SCHEMA_VERSION = 1
+GENESIS_HASH = "0" * 64
+ENCODING = "utf-8"
+KEY_FILE = "audit-device.json"
+LOG_FILE = "audit-events.jsonl"
+RECEIPTS_DIR = "receipts"
+ANCHORS_DIR = "anchors"
+NONCE_LEN = 12
+CMD_APPEND = "append"
+CMD_ANCHOR = "anchor"
+CMD_RECEIPT = "receipt"
+FIELD_AUDIT_PRIVATE_KEY = "audit_signing_private_key"
+FIELD_AUDIT_PUBLIC_KEY = "audit_signing_public_key"
+FIELD_ANCHOR = "anchor"
+FIELD_DEVICE_ID = "device_id"
+FIELD_HEAD = "head"
+FIELD_PREV_HASH = "prev_hash"
+FIELD_RECEIPT = "receipt"
+FIELD_RECORD_HASH = "record_hash"
+FIELD_SCHEMA_VERSION = "schema_version"
+FIELD_SEQUENCE = "sequence"
+FIELD_SIGNATURE = "signature"
+FIELD_TIMESTAMP = "timestamp"
+JSON_GLOB = "*.json"
+ERR_CORRUPTED = "VAULT_AUDIT_CORRUPTED"
+SAFE_RESULTS = {"attempt", "success", "failure", "denied", "warning"}
+SENSITIVE_REJECTIONS = ("passphrase", "password", "secret", "token", "private_key", "recovery", "decrypted", "prompt")
+
+
+class AuditError(Exception):
+    def __init__(self, code: str, message: str, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
+
+
+def b64e(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def b64d(data: str) -> bytes:
+    return base64.urlsafe_b64decode((data + ("=" * (-len(data) % 4))).encode("ascii"))
+
+
+def canonical(data: dict[str, Any]) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode(ENCODING)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def now() -> int:
+    return int(time.time())
+
+
+def vault_dir_from(value: str | None) -> Path:
+    if value:
+        return Path(value).expanduser()
+    configured = os.environ.get("AIDEVOPS_VAULT_AUDIT_DIR") or os.environ.get("AIDEVOPS_VAULT_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".config" / "aidevops" / "vault" / "audit"
+
+
+def private_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding=ENCODING)
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
+def write_public_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding=ENCODING)
+    tmp.replace(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding=ENCODING))
+    except FileNotFoundError as exc:
+        raise AuditError("VAULT_AUDIT_MISSING", f"Missing file: {path.name}", 2) from exc
+    except json.JSONDecodeError as exc:
+        raise AuditError(ERR_CORRUPTED, f"Invalid JSON: {path.name}", 3) from exc
+    if not isinstance(data, dict):
+        raise AuditError(ERR_CORRUPTED, f"Invalid JSON shape: {path.name}", 3)
+    return data
+
+
+def key_path(vault_dir: Path) -> Path:
+    return vault_dir / KEY_FILE
+
+
+def log_path(vault_dir: Path) -> Path:
+    return vault_dir / LOG_FILE
+
+
+def load_key(vault_dir: Path) -> dict[str, Any]:
+    key = load_json(key_path(vault_dir))
+    if key.get(FIELD_SCHEMA_VERSION) != SCHEMA_VERSION:
+        raise AuditError("VAULT_AUDIT_KEY_CORRUPTED", "Unsupported audit key schema", 3)
+    return key
+
+
+def ensure_key(vault_dir: Path) -> dict[str, Any]:
+    if key_path(vault_dir).exists():
+        return load_key(vault_dir)
+    cmd_init(argparse.Namespace(vault_dir=str(vault_dir), force=False, quiet=True))
+    return load_key(vault_dir)
+
+
+def read_records(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line_no, line in enumerate(path.read_text(encoding=ENCODING).splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise AuditError(ERR_CORRUPTED, f"Invalid JSONL at line {line_no}", 3) from exc
+        if not isinstance(item, dict):
+            raise AuditError(ERR_CORRUPTED, f"Invalid record shape at line {line_no}", 3)
+        records.append(item)
+    return records
+
+
+def sign_payload(payload: dict[str, Any], private_key_b64: str) -> str:
+    private_key = Ed25519PrivateKey.from_private_bytes(b64d(private_key_b64))
+    return b64e(private_key.sign(canonical(payload)))
+
+
+def verify_signature(payload: dict[str, Any], signature: str, public_key_b64: str, code: str = "VAULT_AUDIT_BAD_SIGNATURE") -> None:
+    public_key = Ed25519PublicKey.from_public_bytes(b64d(public_key_b64))
+    try:
+        public_key.verify(b64d(signature), canonical(payload))
+    except InvalidSignature as exc:
+        raise AuditError(code, "Vault audit signature is invalid", 4) from exc
+
+
+def reject_sensitive(label: str, value: str) -> None:
+    lowered = value.lower()
+    if any(marker in lowered for marker in SENSITIVE_REJECTIONS):
+        raise AuditError("VAULT_AUDIT_SENSITIVE_FIELD", f"Refusing to log sensitive {label}", 5)
+
+
+def validate_safe_name(label: str, value: str) -> str:
+    if not value or len(value) > 160:
+        raise AuditError("VAULT_AUDIT_INVALID_FIELD", f"Invalid {label}", 2)
+    reject_sensitive(label, value)
+    return value
+
+
+def last_state(records: list[dict[str, Any]]) -> tuple[int, str]:
+    if not records:
+        return 0, GENESIS_HASH
+    last = records[-1]
+    return int(last[FIELD_SEQUENCE]), str(last[FIELD_RECORD_HASH])
+
+
+def record_hash(public_record: dict[str, Any]) -> str:
+    return sha256_bytes(canonical(public_record))
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    path = key_path(vault_dir)
+    if path.exists() and not args.force:
+        if not getattr(args, "quiet", False):
+            print("Vault audit device key already exists")
+        return 0
+    signing_key = Ed25519PrivateKey.generate()
+    public_key = signing_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    device_id = "audit-" + hashlib.sha256(public_key).hexdigest()[:32]
+    payload = {
+        FIELD_SCHEMA_VERSION: SCHEMA_VERSION,
+        "created_at": now(),
+        FIELD_DEVICE_ID: device_id,
+        FIELD_AUDIT_PRIVATE_KEY: b64e(signing_key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())),
+        FIELD_AUDIT_PUBLIC_KEY: b64e(public_key),
+        "audit_payload_key": b64e(secrets.token_bytes(32)),
+    }
+    private_write_json(path, payload)
+    log_path(vault_dir).parent.mkdir(parents=True, exist_ok=True)
+    log_path(vault_dir).touch(mode=0o600, exist_ok=True)
+    os.chmod(log_path(vault_dir), 0o600)
+    if not getattr(args, "quiet", False):
+        print(device_id)
+    return 0
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    key = ensure_key(vault_dir)
+    action = validate_safe_name("action", args.action)
+    actor = validate_safe_name("actor", args.actor)
+    target_collection = validate_safe_name("target collection", args.target_collection)
+    result = validate_safe_name("result", args.result)
+    if result not in SAFE_RESULTS:
+        raise AuditError("VAULT_AUDIT_INVALID_RESULT", "Invalid audit result", 2)
+    session_id = validate_safe_name("session id", args.session_id) if args.session_id else "none"
+    reason = args.reason or ""
+    if len(reason) > 240:
+        raise AuditError("VAULT_AUDIT_INVALID_FIELD", "Audit reason is too long", 2)
+    reject_sensitive("reason", reason)
+    records = read_records(log_path(vault_dir))
+    sequence, prev_hash = last_state(records)
+    sequence += 1
+    event_id = secrets.token_hex(16)
+    event_payload = {
+        FIELD_SCHEMA_VERSION: SCHEMA_VERSION,
+        "event_id": event_id,
+        FIELD_DEVICE_ID: str(key[FIELD_DEVICE_ID]),
+        FIELD_SEQUENCE: sequence,
+        FIELD_PREV_HASH: prev_hash,
+        FIELD_TIMESTAMP: now(),
+        "actor": actor,
+        "action": action,
+        "target_collection": target_collection,
+        "result": result,
+        "session_id": session_id,
+        "reason": reason,
+    }
+    nonce = secrets.token_bytes(NONCE_LEN)
+    ciphertext = AESGCM(b64d(str(key["audit_payload_key"]))).encrypt(nonce, canonical(event_payload), b"aidevops-vault-audit-event")
+    encrypted_event = {"aead": "AES-256-GCM", "nonce": b64e(nonce), "payload": b64e(ciphertext)}
+    event_hash = sha256_bytes(canonical(encrypted_event))
+    public_record = {
+        FIELD_SCHEMA_VERSION: SCHEMA_VERSION,
+        "event_id": event_id,
+        FIELD_DEVICE_ID: str(key[FIELD_DEVICE_ID]),
+        FIELD_SEQUENCE: sequence,
+        FIELD_PREV_HASH: prev_hash,
+        FIELD_TIMESTAMP: event_payload[FIELD_TIMESTAMP],
+        "event_hash": event_hash,
+        "encrypted_event": encrypted_event,
+        "audit_public_key": str(key[FIELD_AUDIT_PUBLIC_KEY]),
+    }
+    public_record[FIELD_RECORD_HASH] = record_hash(public_record)
+    signature_payload = {k: public_record[k] for k in sorted(public_record) if k != FIELD_SIGNATURE}
+    public_record[FIELD_SIGNATURE] = sign_payload(signature_payload, str(key[FIELD_AUDIT_PRIVATE_KEY]))
+    log_path(vault_dir).parent.mkdir(parents=True, exist_ok=True)
+    with log_path(vault_dir).open("a", encoding=ENCODING) as handle:
+        handle.write(json.dumps(public_record, sort_keys=True, separators=(",", ":")) + "\n")
+    os.chmod(log_path(vault_dir), 0o600)
+    print(public_record[FIELD_RECORD_HASH])
+    return 0
+
+
+def verify_records(records: list[dict[str, Any]]) -> tuple[int, str]:
+    expected_prev = GENESIS_HASH
+    expected_sequence = 1
+    last_hash = GENESIS_HASH
+    for record in records:
+        if int(record.get(FIELD_SEQUENCE, -1)) != expected_sequence:
+            raise AuditError("VAULT_AUDIT_SEQUENCE_GAP", "Vault audit sequence is missing or reordered", 6)
+        if record.get(FIELD_PREV_HASH) != expected_prev:
+            raise AuditError("VAULT_AUDIT_CHAIN_BROKEN", "Vault audit hash chain is broken", 6)
+        encrypted_event = record.get("encrypted_event")
+        if not isinstance(encrypted_event, dict):
+            raise AuditError(ERR_CORRUPTED, "Encrypted event is missing", 3)
+        if record.get("event_hash") != sha256_bytes(canonical(encrypted_event)):
+            raise AuditError("VAULT_AUDIT_EVENT_TAMPERED", "Vault audit encrypted payload hash changed", 6)
+        stored_hash = str(record.get(FIELD_RECORD_HASH, ""))
+        public_without_hash = {k: record[k] for k in record if k not in {FIELD_SIGNATURE, FIELD_RECORD_HASH}}
+        if record_hash(public_without_hash) != stored_hash:
+            raise AuditError("VAULT_AUDIT_RECORD_TAMPERED", "Vault audit record hash changed", 6)
+        signature_payload = {k: record[k] for k in sorted(record) if k != FIELD_SIGNATURE}
+        verify_signature(signature_payload, str(record.get(FIELD_SIGNATURE, "")), str(record.get("audit_public_key", "")))
+        expected_prev = stored_hash
+        last_hash = stored_hash
+        expected_sequence += 1
+    return expected_sequence - 1, last_hash
+
+
+def verify_receipt(path: Path, expected_head: str | None) -> None:
+    receipt = load_json(path)
+    body = receipt.get(FIELD_RECEIPT)
+    if not isinstance(body, dict):
+        raise AuditError("VAULT_AUDIT_RECEIPT_CORRUPTED", "Receipt body is missing", 3)
+    if expected_head and body.get("observed_head") != expected_head:
+        raise AuditError("VAULT_AUDIT_RECEIPT_MISMATCH", "Receipt does not match audit head", 6)
+    verify_signature(body, str(receipt.get(FIELD_SIGNATURE, "")), str(body.get("observer_public_key", "")), "VAULT_AUDIT_BAD_RECEIPT_SIGNATURE")
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    records = read_records(Path(args.log) if args.log else log_path(vault_dir))
+    sequence, head = verify_records(records)
+    for receipt_file in args.receipt or []:
+        verify_receipt(Path(receipt_file), head)
+    print(f"ok sequence={sequence} head={head}")
+    return 0
+
+
+def cmd_receipt(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    key = ensure_key(vault_dir)
+    observer_device = validate_safe_name("observer device", args.observer_device)
+    body = {
+        FIELD_SCHEMA_VERSION: SCHEMA_VERSION,
+        "receipt_id": secrets.token_hex(16),
+        "observer_device": observer_device,
+        "observer_audit_device": str(key[FIELD_DEVICE_ID]),
+        "observer_public_key": str(key[FIELD_AUDIT_PUBLIC_KEY]),
+        "observed_head": validate_safe_name(FIELD_HEAD, args.head),
+        "observed_sequence": int(args.sequence),
+        "observed_at": now(),
+    }
+    envelope = {FIELD_RECEIPT: body, FIELD_SIGNATURE: sign_payload(body, str(key[FIELD_AUDIT_PRIVATE_KEY]))}
+    output = Path(args.output) if args.output else vault_dir / RECEIPTS_DIR / f"{body['receipt_id']}.json"
+    write_public_json(output, envelope)
+    print(str(output))
+    return 0
+
+
+def cmd_anchor(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    key = ensure_key(vault_dir)
+    anchor = {
+        FIELD_SCHEMA_VERSION: SCHEMA_VERSION,
+        "anchor_id": secrets.token_hex(16),
+        FIELD_DEVICE_ID: str(key[FIELD_DEVICE_ID]),
+        FIELD_SEQUENCE: int(args.sequence),
+        FIELD_HEAD: validate_safe_name(FIELD_HEAD, args.head),
+        "created_at": now(),
+        "public_safe": True,
+    }
+    envelope = {FIELD_ANCHOR: anchor, FIELD_SIGNATURE: sign_payload(anchor, str(key[FIELD_AUDIT_PRIVATE_KEY]))}
+    output = Path(args.output) if args.output else vault_dir / ANCHORS_DIR / f"{anchor['anchor_id']}.json"
+    write_public_json(output, envelope)
+    print(str(output))
+    return 0
+
+
+def cmd_replicate(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    if log_path(vault_dir).exists():
+        shutil.copy2(log_path(vault_dir), output_dir / LOG_FILE)
+        copied += 1
+    for child_dir_name in (RECEIPTS_DIR, ANCHORS_DIR):
+        source_dir = vault_dir / child_dir_name
+        if source_dir.exists():
+            target_dir = output_dir / child_dir_name
+            target_dir.mkdir(parents=True, exist_ok=True)
+            for source in source_dir.glob(JSON_GLOB):
+                shutil.copy2(source, target_dir / source.name)
+                copied += 1
+    print(f"copied={copied}")
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    vault_dir = vault_dir_from(args.vault_dir)
+    records = read_records(log_path(vault_dir))
+    sequence, head = verify_records(records)
+    receipt_count = len(list((vault_dir / RECEIPTS_DIR).glob(JSON_GLOB))) if (vault_dir / RECEIPTS_DIR).exists() else 0
+    anchor_count = len(list((vault_dir / ANCHORS_DIR).glob(JSON_GLOB))) if (vault_dir / ANCHORS_DIR).exists() else 0
+    data = {"status": "ok", FIELD_SEQUENCE: sequence, FIELD_HEAD: head, "receipts": receipt_count, "anchors": anchor_count}
+    if args.json:
+        print(json.dumps(data, sort_keys=True))
+    else:
+        print(f"status=ok sequence={sequence} head={head} receipts={receipt_count} anchors={anchor_count}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vault-audit-helper.sh")
+    sub = parser.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--vault-dir")
+    init = sub.add_parser("init", parents=[common])
+    init.add_argument("--force", action="store_true")
+    append = sub.add_parser(CMD_APPEND, parents=[common])
+    append.add_argument("--actor", required=True)
+    append.add_argument("--action", required=True)
+    append.add_argument("--target-collection", required=True)
+    append.add_argument("--result", required=True)
+    append.add_argument("--session-id")
+    append.add_argument("--reason")
+    verify = sub.add_parser("verify", parents=[common])
+    verify.add_argument("--log")
+    verify.add_argument("--receipt", action="append")
+    receipt = sub.add_parser(CMD_RECEIPT, parents=[common])
+    receipt.add_argument("--head", required=True)
+    receipt.add_argument("--sequence", required=True, type=int)
+    receipt.add_argument("--observer-device", required=True)
+    receipt.add_argument("--output")
+    anchor = sub.add_parser(CMD_ANCHOR, parents=[common])
+    anchor.add_argument("--head", required=True)
+    anchor.add_argument("--sequence", required=True, type=int)
+    anchor.add_argument("--output")
+    replicate = sub.add_parser("replicate", parents=[common])
+    replicate.add_argument("--output-dir", required=True)
+    report = sub.add_parser("report", parents=[common])
+    report.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return {
+            "init": cmd_init,
+            CMD_APPEND: cmd_append,
+            "verify": cmd_verify,
+            CMD_RECEIPT: cmd_receipt,
+            CMD_ANCHOR: cmd_anchor,
+            "replicate": cmd_replicate,
+            "report": cmd_report,
+        }[args.command](args)
+    except AuditError as exc:
+        print(f"{exc.code}: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+raise SystemExit(main(sys.argv[1:]))
+PY
+	exit $?
+	;;
+*)
+	printf '%s\n' "[ERROR] Unknown Vault audit command: $command" >&2
+	usage >&2
+	exit 2
+	;;
+esac

--- a/.agents/scripts/vault-helper.sh
+++ b/.agents/scripts/vault-helper.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 CRYPTO_HELPER="${SCRIPT_DIR}/vault-crypto-helper.py"
+VAULT_AUDIT_HELPER="${SCRIPT_DIR}/vault-audit-helper.sh"
 
 usage() {
 	cat <<'EOF'
@@ -24,12 +25,73 @@ Commands:
   read <name>             Read an entry through the unlocked broker
   update <name>           Read a new entry value from stdin and encrypt it
   change-passphrase       Rewrap the root key through hidden TTY prompts
+  audit <subcommand>       Manage tamper-evident encrypted Vault audit events
   help                    Show this help
 
 Passphrases are never accepted in CLI arguments, environment variables, or
 non-TTY stdin. Set AIDEVOPS_VAULT_DIR only to relocate Vault files.
 EOF
 	return 0
+}
+
+audit_vault_event() {
+	local action="$1"
+	local result="$2"
+	local reason="$3"
+	local safe_action="$action"
+	case "$safe_action" in
+		change-passphrase) safe_action="change-credential" ;;
+		lost-passphrase) safe_action="recovery-guidance" ;;
+	esac
+	if [[ ! -x "$VAULT_AUDIT_HELPER" ]]; then
+		printf '%s\n' "[WARN] Vault audit helper is unavailable" >&2
+		[[ "${AIDEVOPS_VAULT_AUDIT_REQUIRE:-0}" == "1" ]] && return 1
+		return 0
+	fi
+	if "$VAULT_AUDIT_HELPER" append \
+		--actor "${USER:-local}" \
+		--action "vault.$safe_action" \
+		--target-collection "vault" \
+		--result "$result" \
+		--session-id "${AIDEVOPS_SESSION_ID:-none}" \
+		--reason "$reason" >/dev/null; then
+		return 0
+	fi
+	printf '%s\n' "[WARN] Vault audit event could not be written" >&2
+	[[ "${AIDEVOPS_VAULT_AUDIT_REQUIRE:-0}" == "1" ]] && return 1
+	return 0
+}
+
+run_with_audit() {
+	local command_name="$1"
+	shift || true
+	audit_vault_event "$command_name" "attempt" "vault command attempted" || return 1
+	set +e
+	python3 "$CRYPTO_HELPER" "$command_name" "$@"
+	local rc=$?
+	set -e
+	if [[ "$rc" -eq 0 ]]; then
+		audit_vault_event "$command_name" "success" "vault command completed" || return 1
+	else
+		audit_vault_event "$command_name" "failure" "vault command failed" || true
+	fi
+	return "$rc"
+}
+
+run_sync_with_audit() {
+	local command_name="$1"
+	shift || true
+	audit_vault_event "$command_name" "attempt" "vault sync command attempted" || return 1
+	set +e
+	"$SCRIPT_DIR/vault-sync-helper.sh" "$command_name" "$@"
+	local rc=$?
+	set -e
+	if [[ "$rc" -eq 0 ]]; then
+		audit_vault_event "$command_name" "success" "vault sync command completed" || return 1
+	else
+		audit_vault_event "$command_name" "failure" "vault sync command failed" || true
+	fi
+	return "$rc"
 }
 
 require_crypto_helper() {
@@ -50,12 +112,17 @@ main() {
 	init | unlock | lock | status | setup-state | read | update | change-passphrase | lost-passphrase)
 		shift || true
 		require_crypto_helper || return 1
-		python3 "$CRYPTO_HELPER" "$command" "$@"
+		run_with_audit "$command" "$@"
 		return $?
 		;;
 	export | import | rekey)
 		shift || true
-		"$SCRIPT_DIR/vault-sync-helper.sh" "$command" "$@"
+		run_sync_with_audit "$command" "$@"
+		return $?
+		;;
+	audit)
+		shift || true
+		"$VAULT_AUDIT_HELPER" "$@"
 		return $?
 		;;
 	*)


### PR DESCRIPTION
## Summary

Implemented a dedicated Vault audit helper with encrypted signed hash-chained events, peer receipts, public-safe anchors, replication/report commands, Vault CLI audit emission, and Vault RFC guidance.

## Files Changed

.agents/reference/vault.md,.agents/scripts/tests/test-vault-audit-helper.sh,.agents/scripts/vault-audit-helper.sh,.agents/scripts/vault-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/tests/test-vault-audit-helper.sh; .agents/scripts/linters-local.sh

Resolves #25544


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 31m and 121,825 tokens on this as a headless worker.