### PR TITLE
GH#25600: fix: handle corrupted vault audit sequence

### DIFF
--- a/.agents/scripts/tests/test-vault-audit-helper.sh
+++ b/.agents/scripts/tests/test-vault-audit-helper.sh
@@ -55,6 +55,28 @@ if ! grep -q "VAULT_AUDIT_SEQUENCE_GAP\|VAULT_AUDIT_CHAIN_BROKEN" "$tmp_root/mis
 	exit 1
 fi
 
+corrupted_sequence_log="$tmp_root/corrupted-sequence.jsonl"
+python3 - "$vault_dir/audit-events.jsonl" "$corrupted_sequence_log" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+records = [json.loads(line) for line in source.read_text(encoding="utf-8").splitlines()]
+records[0]["sequence"] = "not-an-integer"
+target.write_text("\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n", encoding="utf-8")
+PY
+
+if "$VAULT_AUDIT_HELPER" verify --vault-dir "$vault_dir" --log "$corrupted_sequence_log" >/dev/null 2>"$tmp_root/corrupted-sequence.err"; then
+	printf '%s\n' "corrupted sequence unexpectedly verified" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_AUDIT_CORRUPTED" "$tmp_root/corrupted-sequence.err"; then
+	printf '%s\n' "corrupted sequence did not use a stable corruption error code" >&2
+	exit 1
+fi
+
 tampered_log="$tmp_root/tampered.jsonl"
 python3 - "$vault_dir/audit-events.jsonl" "$tampered_log" <<'PY'
 from pathlib import Path

--- a/.agents/scripts/vault-audit-helper.sh
+++ b/.agents/scripts/vault-audit-helper.sh
@@ -336,7 +336,11 @@ def verify_records(records: list[dict[str, Any]], trusted_device_id: str | None,
     expected_sequence = 1
     last_hash = GENESIS_HASH
     for record in records:
-        if int(record.get(FIELD_SEQUENCE, -1)) != expected_sequence:
+        try:
+            sequence = int(record.get(FIELD_SEQUENCE, -1))
+        except (TypeError, ValueError) as exc:
+            raise AuditError(ERR_CORRUPTED, "Vault audit sequence is not a valid integer", 3) from exc
+        if sequence != expected_sequence:
             raise AuditError("VAULT_AUDIT_SEQUENCE_GAP", "Vault audit sequence is missing or reordered", 6)
         if record.get(FIELD_PREV_HASH) != expected_prev:
             raise AuditError("VAULT_AUDIT_CHAIN_BROKEN", "Vault audit hash chain is broken", 6)


### PR DESCRIPTION
## Summary

Handled invalid vault audit sequence values by raising VAULT_AUDIT_CORRUPTED instead of allowing raw int conversion exceptions, and added regression coverage for non-integer sequence records.

## Files Changed

.agents/scripts/tests/test-vault-audit-helper.sh,.agents/scripts/vault-audit-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-vault-audit-helper.sh .agents/scripts/vault-audit-helper.sh (pass); .agents/scripts/tests/test-vault-audit-helper.sh (blocked: local python3 lacks cryptography module before exercising test body)

Resolves #25600


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 48,595 tokens on this as a headless worker.