### PR TITLE
GH#25605: fix: guard pulse prefetch cache temp file

### DIFF
--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -509,7 +509,10 @@ _prefetch_cache_set() {
 	local tmp_file="" entry_file=""
 	local failure_msg
 	failure_msg='[pulse-wrapper] _prefetch_cache_set: failed to write cache for'
-	tmp_file=$(mktemp "${cache_dir}/.pulse-prefetch-cache.XXXXXX")
+	tmp_file=$(mktemp "${cache_dir}/.pulse-prefetch-cache.XXXXXX") || {
+		printf '%s %s\n' "$failure_msg" "$slug" >>"$LOGFILE"
+		return 0
+	}
 	entry_file=$(mktemp "${cache_dir}/.pulse-prefetch-entry.XXXXXX") || {
 		rm -f "$tmp_file"
 		printf '%s %s\n' "$failure_msg" "$slug" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Added mktemp failure handling for the pulse prefetch cache temp file so cache writes log and return safely when the temp file cannot be created.

## Files Changed

.agents/scripts/pulse-prefetch-infra.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-prefetch-infra.sh; bash -n .agents/scripts/pulse-prefetch-infra.sh

Resolves #25605


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 17,466 tokens on this as a headless worker.