### PR TITLE
GH#25604: fix: harden pulse cache jq input

### DIFF
--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -662,7 +662,7 @@ _prefetch_single_repo() {
 			"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}") || new_entry=""
 	else
 		local last_full_sweep
-		last_full_sweep=$(echo "$cache_entry" | jq -r '.last_full_sweep // ""' 2>/dev/null) || last_full_sweep=""
+		last_full_sweep=$(printf '%s\n' "$cache_entry" | jq -r '.last_full_sweep // ""') || last_full_sweep=""
 		new_entry=$(_prefetch_build_cache_entry \
 			"$now_iso" "$last_full_sweep" "$fingerprint" \
 			"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}") || new_entry=""


### PR DESCRIPTION
## Summary

Replaced echo-based JSON piping with printf and allowed jq parse errors to surface when preserving last_full_sweep in the pulse prefetch cache path.

## Files Changed

.agents/scripts/pulse-prefetch-fetch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-prefetch-fetch.sh; bash -n .agents/scripts/pulse-prefetch-fetch.sh; git diff --check

Resolves #25604


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 29,885 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background cache prefetching by handling cached metadata more safely.
  * Reduced the chance of missing or incorrect prefetch timing information when cache data is parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->