### PR TITLE
GH#25601: fix: harden vault message transport handling

### DIFF
--- a/.agents/scripts/tests/test-vault-message-helper.sh
+++ b/.agents/scripts/tests/test-vault-message-helper.sh
@@ -98,4 +98,28 @@ if ! grep -q "VAULT_MESSAGE_SIMPLEX_UNAVAILABLE" "$tmp_root/simplex.err"; then
 	exit 1
 fi
 
+python3 - "$transport_repo" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+transport_repo = Path(sys.argv[1])
+message_file = next((transport_repo / ".vault" / "messages" / "inbox").glob("*/*/*/*.json"))
+envelope = json.loads(message_file.read_text(encoding="utf-8"))
+envelope["message"].pop("sender_public_key", None)
+message_file.write_text(json.dumps(envelope, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+rm -f "$recipient_dir/message-replay-cache.json" "$recipient_dir/message-inbox.json"
+if "$MESSAGE_HELPER" receive --vault-dir "$recipient_dir" --repo "$transport_repo" >/dev/null 2>"$tmp_root/invalid.err"; then
+	printf '%s\n' "invalid transport message unexpectedly succeeded" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_MESSAGE_INVALID" "$tmp_root/invalid.err"; then
+	printf '%s\n' "invalid transport message failure did not use stable error code" >&2
+	exit 1
+fi
+
 printf '%s\n' "vault message helper tests passed"

--- a/.agents/scripts/vault-message-helper.sh
+++ b/.agents/scripts/vault-message-helper.sh
@@ -306,7 +306,7 @@ def cmd_send(args: argparse.Namespace) -> int:
     message_file = outbox_dir / f"{message_id}.json"
     public_write_json(message_file, envelope)
     if args.transport == "git":
-        subprocess.run([args.git_helper, "stage-message", ARG_REPO, args.repo, "--message", str(message_file)], check=True, stdout=subprocess.PIPE, text=True)
+        subprocess.run(["bash", args.git_helper, "stage-message", ARG_REPO, args.repo, "--message", str(message_file)], check=True, stdout=subprocess.PIPE, text=True)
     else:
         subprocess.run([os.environ["AIDEVOPS_VAULT_SIMPLEX_ADAPTER"], "send", str(message_file)], check=True)
     outbox = load_json(vault_dir / OUTBOX_FILE) if (vault_dir / OUTBOX_FILE).exists() else {FIELD_SCHEMA_VERSION: SCHEMA_VERSION, FIELD_MESSAGES: {}}
@@ -330,6 +330,12 @@ def load_replay(vault_dir: Path) -> dict[str, Any]:
     return load_json(path)
 
 
+def require_message_string_fields(message: dict[str, Any], fields: tuple[str, ...]) -> None:
+    for field in fields:
+        if field not in message or not isinstance(message[field], str):
+            raise MessageError("VAULT_MESSAGE_INVALID", f"Message is missing or has invalid field: {field}", 3)
+
+
 def decrypt_message(key: dict[str, Any], message: dict[str, Any]) -> dict[str, Any]:
     recipient_private = X25519PrivateKey.from_private_bytes(b64d(str(key[FIELD_ENCRYPTION_PRIVATE_KEY])))
     sender_public = X25519PublicKey.from_public_bytes(b64d(str(message["sender_encryption_public_key"])))
@@ -345,7 +351,7 @@ def cmd_receive(args: argparse.Namespace) -> int:
     encrypted_dir = vault_dir / LOCAL_ENCRYPTED_DIR
     encrypted_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(encrypted_dir, 0o700)
-    subprocess.run([args.git_helper, "collect-messages", ARG_REPO, args.repo, "--mailbox-id", str(key[FIELD_MAILBOX_ID]), "--output", str(encrypted_dir)], check=True, stdout=subprocess.PIPE, text=True)
+    subprocess.run(["bash", args.git_helper, "collect-messages", ARG_REPO, args.repo, "--mailbox-id", str(key[FIELD_MAILBOX_ID]), "--output", str(encrypted_dir)], check=True, stdout=subprocess.PIPE, text=True)
     revoked = load_revoked(args.revoked_devices)
     replay = load_replay(vault_dir)
     seen = dict(replay.get(FIELD_MESSAGES, {}))
@@ -360,7 +366,10 @@ def cmd_receive(args: argparse.Namespace) -> int:
         message = envelope.get(FIELD_MESSAGE)
         if not isinstance(message, dict):
             raise MessageError("VAULT_MESSAGE_INVALID", "Vault message envelope is invalid", 3)
-        signature = str(envelope.get("signature", ""))
+        require_message_string_fields(message, (FIELD_MESSAGE_ID, "sender_public_key", "sender_encryption_public_key", "nonce", "ciphertext"))
+        signature = envelope.get("signature")
+        if not isinstance(signature, str):
+            raise MessageError("VAULT_MESSAGE_INVALID", "Message is missing or has invalid field: signature", 3)
         verify_payload(message, signature, str(message["sender_public_key"]))
         message_id = str(message[FIELD_MESSAGE_ID])
         if message_id in seen:
@@ -431,7 +440,7 @@ def cmd_ack(args: argparse.Namespace) -> int:
     ack_dir = vault_dir / LOCAL_ACK_DIR
     ack_file = ack_dir / f"{ack_id}.json"
     public_write_json(ack_file, envelope)
-    subprocess.run([args.git_helper, "stage-ack", ARG_REPO, args.repo, "--ack", str(ack_file)], check=True, stdout=subprocess.PIPE, text=True)
+    subprocess.run(["bash", args.git_helper, "stage-ack", ARG_REPO, args.repo, "--ack", str(ack_file)], check=True, stdout=subprocess.PIPE, text=True)
     print(ack_id)
     return 0
 


### PR DESCRIPTION
## Summary

Validated untrusted vault transport messages before signature verification and invoked the git transport helper through bash for send, receive, and ack operations.

## Files Changed

.agents/scripts/tests/test-vault-message-helper.sh,.agents/scripts/vault-message-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** uv run --with cryptography bash .agents/scripts/tests/test-vault-message-helper.sh; shellcheck .agents/scripts/vault-message-helper.sh .agents/scripts/tests/test-vault-message-helper.sh

Resolves #25601


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 64,291 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for incoming vault messages so malformed envelopes are rejected instead of being processed.
  * Improved handling of helper subprocess execution for message send, receive, and acknowledgment flows to behave more consistently.
  * Added coverage for a corrupted inbox message case, confirming the vault now fails with a stable invalid-message error when required fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->