### PR TITLE
GH#25603: fix: harden vault sync record validation

### DIFF
--- a/.agents/scripts/tests/test-vault-sync-helper.sh
+++ b/.agents/scripts/tests/test-vault-sync-helper.sh
@@ -99,6 +99,42 @@ if ! grep -q "VAULT_SYNC_BAD_SIGNATURE" "$tmp_root/tampered.err"; then
 	exit 1
 fi
 
+python3 - "$record_file" "$tmp_root/impersonated.json" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+data = json.loads(source.read_text(encoding="utf-8"))
+data["record"]["author_device"] = "0" * 64
+target.write_text(json.dumps(data, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if "$SYNC_HELPER" import --vault-dir "$vault_dir" --input "$tmp_root/impersonated.json" >/dev/null 2>"$tmp_root/impersonated.err"; then
+	printf '%s\n' "impersonated author import unexpectedly succeeded" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_SYNC_BAD_SIGNATURE" "$tmp_root/impersonated.err"; then
+	printf '%s\n' "impersonated author failure did not use stable error code" >&2
+	exit 1
+fi
+
+wrong_key_vault_dir="$tmp_root/wrong-key-vault"
+mkdir -p "$wrong_key_vault_dir"
+chmod 700 "$wrong_key_vault_dir"
+"$SYNC_HELPER" init --vault-dir "$wrong_key_vault_dir" >/dev/null
+if "$SYNC_HELPER" import --vault-dir "$wrong_key_vault_dir" --input "$record_file" >/dev/null 2>"$tmp_root/decrypt.err"; then
+	printf '%s\n' "wrong-key import unexpectedly succeeded" >&2
+	exit 1
+fi
+if ! grep -q "VAULT_SYNC_DECRYPT_FAILED" "$tmp_root/decrypt.err"; then
+	printf '%s\n' "wrong-key decrypt failure did not use stable error code" >&2
+	exit 1
+fi
+
 python3 - "$record_file" "$revoked_file" <<'PY'
 from __future__ import annotations
 

--- a/.agents/scripts/vault-sync-helper.sh
+++ b/.agents/scripts/vault-sync-helper.sh
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import hashlib
 import json
 import os
@@ -47,6 +48,7 @@ from pathlib import Path
 from typing import Any
 
 from cryptography.exceptions import InvalidSignature
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
@@ -110,8 +112,13 @@ def private_write_json(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     os.chmod(path.parent, 0o700)
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding=ENCODING)
-    os.chmod(tmp, 0o600)
+    payload = (json.dumps(data, indent=2, sort_keys=True) + "\n").encode(ENCODING)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(tmp, flags, 0o600)
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(payload)
     tmp.replace(path)
 
 
@@ -177,10 +184,17 @@ def sign_record(record: dict[str, Any], private_key_b64: str) -> str:
 
 
 def verify_record(record: dict[str, Any], signature: str) -> None:
-    public_key = Ed25519PublicKey.from_public_bytes(b64d(str(record["author_public_key"])))
+    try:
+        author_public_key = b64d(str(record["author_public_key"]))
+    except (KeyError, binascii.Error, ValueError) as exc:
+        raise SyncError("VAULT_SYNC_BAD_SIGNATURE", "Vault sync record author public key is invalid", 4) from exc
+    author_device = str(record.get(FIELD_AUTHOR_DEVICE, ""))
+    if hashlib.sha256(author_public_key).hexdigest() != author_device:
+        raise SyncError("VAULT_SYNC_BAD_SIGNATURE", "Vault sync record author device does not match public key", 4)
+    public_key = Ed25519PublicKey.from_public_bytes(author_public_key)
     try:
         public_key.verify(b64d(signature), canonical(record))
-    except InvalidSignature as exc:
+    except (InvalidSignature, binascii.Error, ValueError) as exc:
         raise SyncError("VAULT_SYNC_BAD_SIGNATURE", "Vault sync record signature is invalid", 4) from exc
 
 
@@ -264,10 +278,20 @@ def cmd_import(args: argparse.Namespace) -> int:
     if sequence <= int(device_sequences.get(author, 0)):
         raise SyncError("VAULT_SYNC_ROLLBACK", "Vault sync sequence rolls back", 4)
     ciphertext = record.get("ciphertext", {})
-    plaintext = AESGCM(b64d(str(key[FIELD_TRANSPORT_KEY]))).decrypt(
-        b64d(str(ciphertext["nonce"])), b64d(str(ciphertext["payload"])), b"aidevops-vault-sync-record"
-    )
-    payload = json.loads(plaintext.decode(ENCODING))
+    if not isinstance(ciphertext, dict):
+        raise SyncError("VAULT_SYNC_RECORD_INVALID", "Vault sync record ciphertext is invalid", 3)
+    try:
+        plaintext = AESGCM(b64d(str(key[FIELD_TRANSPORT_KEY]))).decrypt(
+            b64d(str(ciphertext["nonce"])), b64d(str(ciphertext["payload"])), b"aidevops-vault-sync-record"
+        )
+    except (KeyError, binascii.Error, InvalidTag, ValueError) as exc:
+        raise SyncError("VAULT_SYNC_DECRYPT_FAILED", "Failed to decrypt sync record payload", 4) from exc
+    try:
+        payload = json.loads(plaintext.decode(ENCODING))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SyncError("VAULT_SYNC_RECORD_INVALID", "Failed to parse sync record payload", 3) from exc
+    if not isinstance(payload, dict):
+        raise SyncError("VAULT_SYNC_RECORD_INVALID", "Vault sync record payload is invalid", 3)
     inbox = load_json(vault_dir / INBOX_FILE) if (vault_dir / INBOX_FILE).exists() else {FIELD_SCHEMA_VERSION: SCHEMA_VERSION, FIELD_RECORDS: {}}
     records = dict(inbox.get(FIELD_RECORDS, {}))
     records[record_id] = {FIELD_COLLECTION: record.get(FIELD_COLLECTION), FIELD_NAMESPACE_HASH: record.get(FIELD_NAMESPACE_HASH), FIELD_ENTRY: payload.get(FIELD_ENTRY)}


### PR DESCRIPTION
## Summary

Bound vault sync author_device to the SHA-256 hash of the raw author public key, wrote sync device JSON temp files with 0600 permissions at creation time, and converted decrypt/payload parse failures into stable SyncError codes with regression coverage.

## Files Changed

.agents/scripts/tests/test-vault-sync-helper.sh,.agents/scripts/vault-sync-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/vault-sync-helper.sh .agents/scripts/tests/test-vault-sync-helper.sh; bash -n .agents/scripts/vault-sync-helper.sh .agents/scripts/tests/test-vault-sync-helper.sh; uv run --with cryptography .agents/scripts/tests/test-vault-sync-helper.sh

Resolves #25603


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 64,776 tokens on this as a headless worker.