### PR TITLE
GH#25592: fix: ignore inactive queued check suites

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -114,10 +114,12 @@ gh_pr_check_status_rest() {
 	# read-only special variable, which would silently fail under zsh-sourced
 	# interactive use even though the script declares `#!/usr/bin/env bash`.
 	local _check_state=""
+	# shellcheck disable=SC2016 # jq program uses $active as a jq variable.
 	_check_state=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-suites" --jq '
-		if (.check_suites | length) == 0 then "none"
-		elif (.check_suites | all(.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral")) then "PASS"
-		elif (.check_suites | any(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")) then "FAIL"
+		(.check_suites | map(select(.conclusion != null or .status != "queued"))) as $active |
+		if ($active | length) == 0 then "none"
+		elif ($active | all(.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral")) then "PASS"
+		elif ($active | any(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")) then "FAIL"
 		else "PENDING"
 		end' 2>/dev/null) || _check_state=""
 

--- a/.agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)"
+CHECKS_LIB="${SCRIPTS_DIR}/shared-gh-wrappers-checks.sh"
+
+# shellcheck source=../shared-gh-wrappers-checks.sh
+source "$CHECKS_LIB"
+
+CHECK_SUITES_FIXTURE='{}'
+
+_gh_checks_api_read() {
+	local endpoint="$1"
+	shift
+	local jq_filter=""
+
+	if [[ "$endpoint" != "repos/owner/repo/commits/abc123/check-suites" ]]; then
+		printf 'FAIL: unexpected endpoint: %s\n' "$endpoint" >&2
+		return 1
+	fi
+
+	while [[ "$#" -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--jq)
+			shift
+			local filter_arg="$1"
+			jq_filter="$filter_arg"
+			;;
+		esac
+		if [[ "$#" -gt 0 ]]; then
+			shift
+		fi
+	done
+
+	if [[ -z "$jq_filter" ]]; then
+		printf 'FAIL: missing jq filter\n' >&2
+		return 1
+	fi
+
+	printf '%s\n' "$CHECK_SUITES_FIXTURE" | jq -r "$jq_filter"
+	return $?
+}
+
+assert_status() {
+	local name="$1"
+	local expected="$2"
+	local fixture="$3"
+
+	CHECK_SUITES_FIXTURE="$fixture"
+	local actual
+	actual="$(gh_pr_check_status_rest "owner/repo" "abc123")"
+
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'FAIL: %s expected %s, got %s\n' "$name" "$expected" "$actual" >&2
+		return 1
+	fi
+
+	return 0
+}
+
+main() {
+	assert_status "null queued app suites ignored when actions passed" "PASS" '{"check_suites":[{"app":{"slug":"github-actions"},"status":"completed","conclusion":"success"},{"app":{"slug":"coderabbitai"},"status":"queued","conclusion":null}]}'
+	assert_status "all null suites mean no active checks" "none" '{"check_suites":[{"app":{"slug":"coderabbitai"},"status":"queued","conclusion":null}]}'
+	assert_status "terminal failure still fails" "FAIL" '{"check_suites":[{"app":{"slug":"github-actions"},"status":"completed","conclusion":"success"},{"app":{"slug":"github-actions"},"status":"completed","conclusion":"failure"},{"app":{"slug":"coderabbitai"},"status":"queued","conclusion":null}]}'
+	assert_status "in-progress null suite remains pending" "PENDING" '{"check_suites":[{"app":{"slug":"github-actions"},"status":"completed","conclusion":"success"},{"app":{"slug":"github-actions"},"status":"in_progress","conclusion":null}]}'
+
+	printf 'PASS shared-gh-wrappers-checks null-conclusion suites ignored\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Updated gh_pr_check_status_rest to ignore queued check-suites with null conclusions while preserving PENDING for in-progress null-conclusion suites. Added regression coverage for inactive app suites, all-inactive suites, failures, and real in-progress suites.

## Files Changed

.agents/scripts/shared-gh-wrappers-checks.sh,.agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh; .agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh; shellcheck .agents/scripts/shared-gh-wrappers-checks.sh .agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh

Resolves #25592


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 44,549 tokens on this as a headless worker.