### PR TITLE
GH#25593: fix: log merge pr list failures

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -496,7 +496,7 @@ _merge_ready_prs_for_repo() {
 	pr_merge_err=$(mktemp)
 	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
 		--json "$(_pulse_merge_ready_pr_json_fields)" \
-		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json="[]"
+		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
 	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg
 		_pr_merge_err_msg=$(cat "$pr_merge_err" 2>/dev/null || echo "unknown error")

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -74,9 +74,23 @@ test_callers_use_shared_field_helper() {
 	return 0
 }
 
+test_merge_ready_pr_list_failure_logs_error() {
+	if ! file_contains "$MERGE_PROCESS" '|| pr_json=""'; then
+		print_result "merge-ready list failure leaves empty output for error guard" 1 "gh_pr_list failure fallback must be empty so the existing -z guard logs the error"
+		return 0
+	fi
+	if file_contains "$MERGE_PROCESS" '|| pr_json="[]"'; then
+		print_result "merge-ready list failure avoids silent empty array fallback" 1 "gh_pr_list failure fallback still masks errors as []"
+		return 0
+	fi
+	print_result "merge-ready list failure reaches error logging guard" 0
+	return 0
+}
+
 main() {
 	test_ready_pr_fields_include_process_metadata
 	test_callers_use_shared_field_helper
+	test_merge_ready_pr_list_failure_logs_error
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Changed _merge_ready_prs_for_repo so gh_pr_list failures leave pr_json empty and reach the existing error-logging guard, then added a regression assertion covering the fallback pattern.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh; shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh

Resolves #25593


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 26,086 tokens on this as a headless worker.