### PR TITLE
fix: log merge PR list failures (#25593)

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -496,7 +496,7 @@ _merge_ready_prs_for_repo() {
 	pr_merge_err=$(mktemp)
 	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
 		--json "$(_pulse_merge_ready_pr_json_fields)" \
-		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json="[]"
+		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
 	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg
 		_pr_merge_err_msg=$(cat "$pr_merge_err" 2>/dev/null || echo "unknown error")

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -74,9 +74,20 @@ test_callers_use_shared_field_helper() {
 	return 0
 }
 
+test_merge_ready_list_failure_preserves_error_guard() {
+	local failure_fallback='|| pr_json=""'
+	if ! file_contains "$MERGE_PROCESS" "$failure_fallback"; then
+		print_result "merge-ready list failure preserves error guard" 1 "gh_pr_list failure should leave pr_json empty so the -z guard logs the error"
+		return 0
+	fi
+	print_result "merge-ready list failure preserves error guard" 0
+	return 0
+}
+
 main() {
 	test_ready_pr_fields_include_process_metadata
 	test_callers_use_shared_field_helper
+	test_merge_ready_list_failure_preserves_error_guard
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Leave `pr_json` empty when the merge-ready `gh_pr_list` call fails so the existing `-z` guard logs the error before falling back to `[]`.
- Add a regression check that preserves the failure fallback contract.

## Verification
- `bash .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh`
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh`
- `.agents/scripts/linters-local.sh`

Resolves #25593

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.9 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
