### PR TITLE
GH#25628: register opencode plugin during setup

### DIFF
--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -42,6 +42,30 @@ assert_contains() {
 	return 0
 }
 
+assert_occurrence_count() {
+	local test_name="$1"
+	local haystack="$2"
+	local needle="$3"
+	local expected_count="$4"
+	python3 - "$test_name" "$haystack" "$needle" "$expected_count" <<'PY'
+import sys
+
+test_name, haystack, needle, expected_count = sys.argv[1:]
+actual_count = haystack.count(needle)
+if actual_count == int(expected_count):
+    sys.exit(0)
+print(f"{test_name}: expected {expected_count} occurrence(s), got {actual_count}")
+sys.exit(1)
+PY
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "$test_name" 0
+		return 0
+	fi
+	print_result "$test_name" 1 "occurrence count assertion failed"
+	return 0
+}
+
 file_text() {
 	local path="$1"
 	python3 - "$path" <<'PY'
@@ -72,6 +96,9 @@ test_setup_stage_contract() {
 	assert_contains "gui desktop app dir can be configured" "$text" "AIDEVOPS_GUI_DESKTOP_APP_DIR"
 	assert_contains "existing gui desktop app refreshes during update" "$text" "Refreshing existing macOS"
 	assert_contains "gui desktop scoped stage runs installer" "$text" "_time_step \"\$SETUP_STAGE_GUI_DESKTOP\" setup_gui_desktop_app"
+	assert_contains "agents scoped stage registers opencode plugin" "$text" "_time_step \"setup_opencode_plugins\" setup_opencode_plugins"
+	assert_occurrence_count "scoped and noninteractive setup register opencode plugin" "$text" \
+		"_time_step \"setup_opencode_plugins\" setup_opencode_plugins" 2
 	assert_contains "unknown stages print actionable help" "$text" "Unknown setup stage/scope"
 	return 0
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1205,6 +1205,7 @@ _setup_run_scoped_stage() {
 		;;
 	"$SETUP_STAGE_AGENTS")
 		_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
+		_time_step "setup_opencode_plugins" setup_opencode_plugins
 		_time_step "_deploy_hotfix_config" _deploy_hotfix_config
 		;;
 	"$SETUP_STAGE_HOOKS")
@@ -1264,6 +1265,7 @@ _setup_run_non_interactive() {
 	_time_step "$SETUP_STAGE_OPENCODE" setup_opencode_cli
 	_time_step "validate_opencode_config" validate_opencode_config
 	_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
+	_time_step "setup_opencode_plugins" setup_opencode_plugins
 	_time_step "_setup_install_pulse_plist_early" _setup_install_pulse_plist_early
 	_time_step "_deploy_hotfix_config" _deploy_hotfix_config
 	_time_step "setup_opencode_desktop_launcher" setup_opencode_desktop_launcher


### PR DESCRIPTION
## Summary

- register the existing `opencode-aidevops` plugin during non-interactive setup after agent deployment
- register the plugin during `--stage agents` after the deployed plugin files are refreshed
- add a setup contract test so both paths keep invoking `setup_opencode_plugins()`

## Context

This reimplements the valid intent from external PR #25349 on the active setup path. The external PR targeted the unused `.agents/scripts/setup/_opencode.sh:add_opencode_plugin()` extraction stub; this PR uses the existing active registration helper in `.agents/scripts/setup/modules/mcp-setup.sh`.

## Verification

```bash
.agents/scripts/tests/test-setup-scoped-dispatch.sh
shellcheck setup.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh
.agents/scripts/linters-local.sh
```

Notes: `linters-local.sh` passed targeted early gates and advisory checks but the local tool run hit the 10-minute shell portability timeout; targeted test and ShellCheck passed after rebase.

Resolves #25628
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.23.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 48m and 221,584 tokens on this with the user in an interactive session.