### PR TITLE
GH#25634: remove duplicate 3.24.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,21 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add vault remote control helper (#25630)
 
-### Changed
-
-- Documentation: prepare 3.24.0 changelog
-- register opencode plugin during setup
-
-### Fixed
-
-- harden worker dispatch recovery (#25632)
-
-## [3.24.0] - 2026-06-27
-
-### Added
-
-- add vault remote control helper (#25630)
-
 ### Fixed
 
 - harden worker dispatch recovery (#25632)


### PR DESCRIPTION
## Summary

- remove the duplicate generated `3.24.0` changelog section left by the release flow
- keep one clean v3.24.0 section with entries for #25630, #25631, and #25632

## Verification

```bash
python3 - <<'PY'
from pathlib import Path
text = Path('CHANGELOG.md').read_text()
count = text.count('## [3.24.0] - 2026-06-27')
print(f'3.24.0 section count: {count}')
raise SystemExit(0 if count == 1 else 1)
PY
git diff --check
```

Resolves #25634
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.24.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1h 7m and 437,016 tokens on this with the user in an interactive session.