### PR TITLE
t18012: add app chat session navigation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1018,6 +1018,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18010 vault: add security validation suite, crash drills, destructive-migration gates, and release criteria #architecture #auto-dispatch #ci #feat #security #security-review #testing blocked-by:t17999,t18001,t18004,t18006,t18007,t18009 tier:thinking ~6h ref:GH#25547 logged:2026-06-26 -> [todo/tasks/t18010-brief.md]
 
+- [ ] t18012 Add aidevops app chat session navigation ref:GH#25636
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -2,7 +2,11 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { hostname, networkInterfaces, userInfo } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import {
+  type GuiLocalRepoSetupSummary,
+  type GuiOpenCodeSessionRegistrySummary,
+  type GuiOpenCodeSessionSummary,
   assertNoSecretSentinels,
   createEnvelope,
   VAULT_STATUS_ROUTE_MANIFEST,
@@ -51,11 +55,13 @@ export function readStatus(
   const settingsPathRef = "~/.config/aidevops/settings.json";
   const reposPathRef = "~/.config/aidevops/repos.json";
   const oauthPoolPathRef = "~/.aidevops/oauth-pool.json";
+  const opencodeDbPathRef = "~/.local/share/opencode/opencode.db";
   const agentsPathRef = "~/.aidevops/agents";
   const vaultPathRef = statusFixture.vault.path_ref;
   const settingsPath = expandHome(settingsPathRef);
   const reposPath = expandHome(reposPathRef);
   const oauthPoolPath = expandHome(oauthPoolPathRef);
+  const opencodeDbPath = expandHome(opencodeDbPathRef);
   const aidevopsVersion = existsSync(versionPath)
     ? readFileSync(versionPath, "utf8").trim()
     : statusFixture.aidevops_version;
@@ -63,12 +69,15 @@ export function readStatus(
   const restartRequired = installedVersion !== aidevopsVersion;
   const setupTargets = readSetupTargets(aidevopsVersion || "unknown", installedVersion || "unknown");
   const aiApps = readAiApps(aidevopsVersion || "unknown", installedVersion || "unknown");
+  const localRepos = readLocalReposSetupSummary(reposPath);
+  const opencodeSessions = readOpenCodeSessions(opencodeDbPath, opencodeDbPathRef, localRepos.repos);
   const vault = readVaultSummary(repoRoot);
   const sourcePathRefs = [
     agentsPathRef,
     settingsPathRef,
     reposPathRef,
     oauthPoolPathRef,
+    opencodeDbPathRef,
     vaultPathRef,
     "VERSION",
     ...setupTargets.map((target) => target.path_ref),
@@ -114,7 +123,8 @@ export function readStatus(
     ],
     settings: readSettingsSummary(settingsPath, settingsPathRef),
     repos: readRepoRegistrySummary(reposPath, reposPathRef),
-    local_repos: readLocalReposSetupSummary(reposPath),
+    local_repos: localRepos,
+    opencode_sessions: opencodeSessions,
     oauth_pool: readOAuthPoolSummary(oauthPoolPath, oauthPoolPathRef),
     setup_targets: setupTargets,
     ai_apps: aiApps,
@@ -417,6 +427,83 @@ function resolveBinary(binary: string): string | null {
   } catch {
     return null;
   }
+}
+
+interface OpenCodeSessionRow {
+  id: string;
+  directory: string;
+  title: string;
+  time_updated: number;
+  model: string | null;
+  agent: string | null;
+}
+
+function readOpenCodeSessions(dbPath: string, dbPathRef: string, repos: GuiLocalRepoSetupSummary[]): GuiOpenCodeSessionRegistrySummary {
+  if (!existsSync(dbPath)) {
+    return {
+      path_ref: dbPathRef,
+      health: "missing",
+      value_policy: "metadata_only_no_message_payloads",
+      sessions: [],
+    };
+  }
+
+  try {
+    const database = new Database(dbPath, { readonly: true });
+    try {
+      const rows = database.query(`
+        SELECT id, directory, title, time_updated, model, agent
+        FROM session
+        WHERE time_archived IS NULL
+        ORDER BY time_updated DESC
+        LIMIT 200
+      `).all() as OpenCodeSessionRow[];
+      const sessions = rows
+        .map((row) => opencodeSessionFromRow(row, repos))
+        .filter((session): session is GuiOpenCodeSessionSummary => session !== null);
+
+      return {
+        path_ref: dbPathRef,
+        health: "present",
+        value_policy: "metadata_only_no_message_payloads",
+        sessions,
+      };
+    } finally {
+      database.close();
+    }
+  } catch {
+    return {
+      path_ref: dbPathRef,
+      health: "invalid",
+      value_policy: "metadata_only_no_message_payloads",
+      sessions: [],
+    };
+  }
+}
+
+function opencodeSessionFromRow(row: OpenCodeSessionRow, repos: GuiLocalRepoSetupSummary[]): GuiOpenCodeSessionSummary | null {
+  const repo = repos.find((candidate) => row.directory === expandHome(candidate.path_ref) || row.directory.startsWith(`${expandHome(candidate.path_ref)}/`));
+
+  if (!repo) {
+    return null;
+  }
+
+  return {
+    id_ref: row.id,
+    repo_path_ref: repo.path_ref,
+    title: row.title.trim().length > 0 ? row.title : "Untitled session",
+    updated_at: formatUnixMillis(row.time_updated),
+    model: row.model ?? "unknown",
+    agent: row.agent ?? "unknown",
+  };
+}
+
+function formatUnixMillis(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return "unknown";
+  }
+
+  return new Date(value).toISOString();
 }
 
 function readBinaryVersion(binaryPath: string, args: string[]): string {

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -48,7 +48,7 @@ describe("status adapter", () => {
     expect(response.ok).toBe(true);
     expect(response.operation_id).toBe("vault.status.read");
     expect(response.data.value_policy).toBe("metadata_only_no_secret_material");
-    expect(response.data.collections.map((collection) => collection.surface_ids).flat()).toContain("agents");
+    expect(response.data.collections.flatMap((collection) => collection.surface_ids)).toContain("agents");
     expect(response.redactions).toContain("recovery_material");
   });
 

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -23,6 +23,10 @@ describe("status adapter", () => {
     expect(response.data.settings.value_policy).toBe("keys_only_no_values");
     expect(response.data.repos.path_ref).toBe("~/.config/aidevops/repos.json");
     expect(response.data.local_repos.excluded_worktrees).toBeGreaterThanOrEqual(0);
+    expect(response.data.opencode_sessions.path_ref).toBe("~/.local/share/opencode/opencode.db");
+    expect(response.data.opencode_sessions.value_policy).toBe("metadata_only_no_message_payloads");
+    expect(JSON.stringify(response.data.opencode_sessions)).not.toContain("content");
+    expect(JSON.stringify(response.data.opencode_sessions)).not.toContain("parts");
     expect(response.data.oauth_pool.value_policy).toBe("metadata_only_no_tokens");
     expect(response.data.oauth_pool.providers.map((provider) => provider.provider)).toEqual(["anthropic", "openai", "cursor", "google"]);
     expect(JSON.stringify(response.data.oauth_pool)).not.toContain("\"access\"");

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -131,6 +131,22 @@ export interface GuiLocalReposSetupSummary {
   repos: GuiLocalRepoSetupSummary[];
 }
 
+export interface GuiOpenCodeSessionSummary {
+  id_ref: string;
+  repo_path_ref: string;
+  title: string;
+  updated_at: string;
+  model: string;
+  agent: string;
+}
+
+export interface GuiOpenCodeSessionRegistrySummary {
+  path_ref: string;
+  health: "present" | "missing" | "invalid" | "unchecked";
+  value_policy: "metadata_only_no_message_payloads";
+  sessions: GuiOpenCodeSessionSummary[];
+}
+
 export type GuiAiProviderId = "anthropic" | "openai" | "cursor" | "google";
 
 export interface GuiOAuthPoolAccountSummary {
@@ -298,6 +314,7 @@ export interface GuiStatusData {
   settings: GuiSettingsSummary;
   repos: GuiRepoRegistrySummary;
   local_repos: GuiLocalReposSetupSummary;
+  opencode_sessions: GuiOpenCodeSessionRegistrySummary;
   oauth_pool: GuiOAuthPoolSummary;
   setup_targets: GuiSetupTargetSummary[];
   ai_apps: GuiAiAppSummary[];

--- a/packages/gui-shared/src/fixtures.ts
+++ b/packages/gui-shared/src/fixtures.ts
@@ -68,6 +68,12 @@ export const statusFixture: GuiStatusData = {
     excluded_worktrees: 0,
     repos: [],
   },
+  opencode_sessions: {
+    path_ref: "~/.local/share/opencode/opencode.db",
+    health: "unchecked",
+    value_policy: "metadata_only_no_message_payloads",
+    sessions: [],
+  },
   oauth_pool: {
     path_ref: "~/.aidevops/oauth-pool.json",
     health: "unchecked",

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -2,7 +2,7 @@ import type { GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
 import { type ReactElement, useEffect, useState } from "react";
 import { MachineRail, Sidebar } from "./AppNavigation";
 import { Workspace } from "./AppWorkspace";
-import type { FontPreference, FontSizePreference, SurfaceId, ThemePreference } from "./app-model";
+import type { ConversationMode, FontPreference, FontSizePreference, ShellMode, SurfaceId, ThemePreference } from "./app-model";
 import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, fileRootBySurface, findSurface, findSurfaceSectionLabel, fontFamilyForPreference, fontSizeForPreference, getSystemTheme, isFontPreference, isFontSizePreference } from "./app-model";
 import { fetchStatus, mockedStatus } from "./status-client";
 
@@ -73,6 +73,9 @@ export function App(): ReactElement {
   const [machineRailVisible, setMachineRailVisible] = useState(storedAppearancePreferences.machineRailVisible);
   const [showNavCounts, setShowNavCounts] = useState(storedAppearancePreferences.showNavCounts);
   const [showBorders, setShowBorders] = useState(storedAppearancePreferences.showBorders);
+  const [shellMode, setShellMode] = useState<ShellMode>("devices");
+  const [conversationMode, setConversationMode] = useState<ConversationMode>("ai");
+  const [selectedLocalRepoIndex, setSelectedLocalRepoIndex] = useState(0);
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">("light");
   const resolvedTheme = themePreference === "system" ? systemTheme : themePreference;
   const activeSurface: SurfaceId = navigation.entries[navigation.index] ?? "overview";
@@ -166,6 +169,10 @@ export function App(): ReactElement {
     persistAppearancePreference(appearanceStorageKeys.machineRail, String(machineRailVisible));
   }, [machineRailVisible]);
 
+  useEffect(() => {
+    setSelectedLocalRepoIndex((current) => Math.min(current, Math.max(0, status.data.local_repos.repos.length - 1)));
+  }, [status.data.local_repos.repos.length]);
+
   return (
     <main className={machineRailVisible ? "app-shell" : "app-shell machine-rail-collapsed"}>
       <div className="desktop-titlebar-tagline" aria-hidden="true">Your data protected. Your systems managed. Your creations published.</div>
@@ -173,25 +180,41 @@ export function App(): ReactElement {
       <Sidebar
         activeSurface={activeSurface}
         accentHue={accentHue}
-        canGoBack={canGoBack}
-        canGoForward={canGoForward}
+        conversationMode={conversationMode}
         fontSizePreference={fontSizePreference}
         fontPreference={fontPreference}
-        goBack={goBack}
-        goForward={goForward}
+        selectedLocalRepoIndex={selectedLocalRepoIndex}
         setAccentHue={setAccentHue}
         setActiveSurface={setActiveSurface}
+        setConversationMode={setConversationMode}
         setFontSizePreference={setFontSizePreference}
         setFontPreference={setFontPreference}
+        setSelectedLocalRepoIndex={setSelectedLocalRepoIndex}
+        setShellMode={setShellMode}
         setShowBorders={setShowBorders}
         setShowNavCounts={setShowNavCounts}
         setThemePreference={setThemePreference}
+        shellMode={shellMode}
         showBorders={showBorders}
         showNavCounts={showNavCounts}
         status={status.data}
         themePreference={themePreference}
       />
-      <Workspace activeItem={activeItem} activeSectionLabel={activeSectionLabel} activeSurface={activeSurface} fileRoot={fileRoot} setActiveSurface={setActiveSurface} status={status.data} />
+      <Workspace
+        activeItem={activeItem}
+        activeSectionLabel={activeSectionLabel}
+        activeSurface={activeSurface}
+        canGoBack={canGoBack}
+        canGoForward={canGoForward}
+        conversationMode={conversationMode}
+        fileRoot={fileRoot}
+        goBack={goBack}
+        goForward={goForward}
+        selectedLocalRepoIndex={selectedLocalRepoIndex}
+        setActiveSurface={setActiveSurface}
+        shellMode={shellMode}
+        status={status.data}
+      />
       <DesktopStatusBar status={status.data} />
     </main>
   );

--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -220,7 +220,7 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConv
       <SidebarModeTabs mode={conversationMode} setMode={setConversationMode} />
       {conversationMode === "people" ? <PeopleChannelList /> : <>
       <button className="new-session-button" disabled title="Creating sessions needs an audited OpenCode write route." type="button">{text.newSession}</button>
-      <div className="repo-session-selector" aria-label={text.localRepoSelector}>
+      <section className="repo-session-selector" aria-label={text.localRepoSelector}>
         <button aria-label="Previous local repo" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft /></button>
         <label>
           <span>{text.localRepos}</span>
@@ -229,7 +229,7 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConv
           </select>
         </label>
         <button aria-label="Next local repo" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight /></button>
-      </div>
+      </section>
       <section className="sidebar-group session-history-list">
         <h2>{text.sessionHistory}</h2>
         {selectedRepo ? <ul>
@@ -245,7 +245,7 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConv
 
 function PeopleChannelList() {
   return (
-    <div aria-label="People channels">
+    <section aria-label="People channels">
       <div className="notice compact-notice">{text.simplexReady}</div>
       <section className="sidebar-group session-history-list">
         <h2>{text.teams}</h2>
@@ -259,7 +259,7 @@ function PeopleChannelList() {
           {["Marcus", "AI DevOps"].map((person) => <li key={person}><button className="surface-link" type="button"><span className="surface-icon" aria-hidden="true"><FiMessageSquare /></span><span className="surface-copy"><strong>{person}</strong><small>encrypted DM placeholder</small></span></button></li>)}
         </ul>
       </section>
-    </div>
+    </section>
   );
 }
 

--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -1,6 +1,6 @@
 /* jshint esversion: 11 */
 import type { GuiMachineSummary, GuiStatusData } from "@aidevops/gui-shared";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type { IconType } from "react-icons";
 import {
   FiBookmark,
@@ -18,6 +18,7 @@ import {
   FiGitBranch,
   FiGlobe,
   FiGrid,
+  FiHash,
   FiHardDrive,
   FiLink,
   FiLink2,
@@ -34,7 +35,7 @@ import {
   FiTerminal,
   FiUsers,
 } from "react-icons/fi";
-import type { FontPreference, FontSizePreference, SidebarMode, SurfaceIconName, SurfaceId, SurfaceNavGroup, SurfaceNavItem, ThemePreference } from "./app-model";
+import type { ConversationMode, FontPreference, FontSizePreference, ShellMode, SidebarMode, SurfaceIconName, SurfaceId, SurfaceNavGroup, SurfaceNavItem, ThemePreference } from "./app-model";
 import { DEFAULT_ACCENT_HUE, dashboardNavItem, fontFamilyForPreference, fontOptions, fontSizeOptions, navGroups, sidebarModeForSurface, surfaceRecordCounts, text } from "./app-model";
 import { VaultPadlock, vaultCollectionForSurface } from "./VaultBadges";
 
@@ -106,22 +107,24 @@ export function MachineRail({ machine }: { machine?: GuiMachineSummary }) {
   );
 }
 
-export function Sidebar({ activeSurface, accentHue, canGoBack, canGoForward, fontPreference, fontSizePreference, goBack, goForward, setAccentHue, setActiveSurface, setFontPreference, setFontSizePreference, setShowBorders, setShowNavCounts, setThemePreference, showBorders, showNavCounts, status, themePreference }: {
+export function Sidebar({ activeSurface, accentHue, conversationMode, fontPreference, fontSizePreference, selectedLocalRepoIndex, setAccentHue, setActiveSurface, setConversationMode, setFontPreference, setFontSizePreference, setSelectedLocalRepoIndex, setShellMode, setShowBorders, setShowNavCounts, setThemePreference, shellMode, showBorders, showNavCounts, status, themePreference }: {
   activeSurface: SurfaceId;
   accentHue: number;
-  canGoBack: boolean;
-  canGoForward: boolean;
+  conversationMode: ConversationMode;
   fontPreference: FontPreference;
   fontSizePreference: FontSizePreference;
-  goBack: () => void;
-  goForward: () => void;
+  selectedLocalRepoIndex: number;
   setAccentHue: (hue: number) => void;
   setActiveSurface: (surface: SurfaceId) => void;
+  setConversationMode: (mode: ConversationMode) => void;
   setFontPreference: (font: FontPreference) => void;
   setFontSizePreference: (size: FontSizePreference) => void;
+  setSelectedLocalRepoIndex: (index: number) => void;
+  setShellMode: (mode: ShellMode) => void;
   setShowBorders: (show: boolean) => void;
   setShowNavCounts: (show: boolean) => void;
   setThemePreference: (theme: ThemePreference) => void;
+  shellMode: ShellMode;
   showBorders: boolean;
   showNavCounts: boolean;
   status: GuiStatusData;
@@ -137,13 +140,21 @@ export function Sidebar({ activeSurface, accentHue, canGoBack, canGoForward, fon
 
   return (
     <aside className="app-sidebar" aria-label={text.navigationLabel}>
-      <SidebarHeader canGoBack={canGoBack} canGoForward={canGoForward} goBack={goBack} goForward={goForward} />
+      <SidebarHeader setShellMode={setShellMode} shellMode={shellMode} />
       <nav className="sidebar-content">
-        <SidebarModeTabs mode={sidebarMode} setMode={setSidebarMode} />
-        <ul className="sidebar-top-link">
-          <SidebarItem activeSurface={activeSurface} item={dashboardNavItem} setActiveSurface={setActiveSurface} showCount={false} status={status} />
-        </ul>
-        {visibleGroups.map((group) => <SidebarGroup activeSurface={activeSurface} group={group} key={group.label} recordCounts={recordCounts} setActiveSurface={setActiveSurface} showNavCounts={showNavCounts} status={status} />)}
+        {shellMode === "devices" ? <>
+          <SidebarModeTabs mode={sidebarMode} setMode={(mode) => setSidebarMode(mode as SidebarMode)} />
+          <ul className="sidebar-top-link">
+            <SidebarItem activeSurface={activeSurface} item={dashboardNavItem} setActiveSurface={setActiveSurface} showCount={false} status={status} />
+          </ul>
+          {visibleGroups.map((group) => <SidebarGroup activeSurface={activeSurface} group={group} key={group.label} recordCounts={recordCounts} setActiveSurface={setActiveSurface} showNavCounts={showNavCounts} status={status} />)}
+        </> : <ConversationSidebar
+          conversationMode={conversationMode}
+          selectedLocalRepoIndex={selectedLocalRepoIndex}
+          setConversationMode={setConversationMode}
+          setSelectedLocalRepoIndex={setSelectedLocalRepoIndex}
+          status={status}
+        />}
       </nav>
       <SidebarFooter
         accentHue={accentHue}
@@ -163,14 +174,102 @@ export function Sidebar({ activeSurface, accentHue, canGoBack, canGoForward, fon
   );
 }
 
-function SidebarModeTabs({ mode, setMode }: {
-  mode: SidebarMode;
-  setMode: (mode: SidebarMode) => void;
+function IconSwitch<TValue extends string>({ ariaLabel, options, value }: {
+  ariaLabel: string;
+  options: Array<{ icon: ReactNode; label: string; onSelect: () => void; value: TValue }>;
+  value: TValue;
 }) {
-  const modes: Array<{ label: string; value: SidebarMode }> = [
-    { label: text.devops, value: "devops" },
-    { label: text.comms, value: "comms" },
-  ];
+  return (
+    <div className="icon-switch" role="tablist" aria-label={ariaLabel}>
+      {options.map((option) => (
+        <button
+          aria-label={option.label}
+          aria-selected={value === option.value}
+          className={value === option.value ? "active" : ""}
+          key={option.value}
+          onClick={option.onSelect}
+          role="tab"
+          title={option.label}
+          type="button"
+        >
+          {option.icon}
+          <span>{option.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConversationMode, setSelectedLocalRepoIndex, status }: {
+  conversationMode: ConversationMode;
+  selectedLocalRepoIndex: number;
+  setConversationMode: (mode: ConversationMode) => void;
+  setSelectedLocalRepoIndex: (index: number) => void;
+  status: GuiStatusData;
+}) {
+  const repos = status.local_repos.repos;
+  const selectedRepo = repos[selectedLocalRepoIndex] ?? repos[0];
+  const sessions = selectedRepo === undefined
+    ? []
+    : status.opencode_sessions.sessions.filter((session) => session.repo_path_ref === selectedRepo.path_ref);
+  const canSelectPreviousRepo = selectedLocalRepoIndex > 0;
+  const canSelectNextRepo = selectedLocalRepoIndex < repos.length - 1;
+
+  return (
+    <section className="conversation-panel" aria-label={text.opencodeSessions}>
+      <SidebarModeTabs mode={conversationMode} setMode={setConversationMode} />
+      {conversationMode === "people" ? <PeopleChannelList /> : <>
+      <button className="new-session-button" disabled title="Creating sessions needs an audited OpenCode write route." type="button">{text.newSession}</button>
+      <div className="repo-session-selector" aria-label={text.localRepoSelector}>
+        <button aria-label="Previous local repo" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft /></button>
+        <label>
+          <span>{text.localRepos}</span>
+          <select onChange={(event) => setSelectedLocalRepoIndex(Number.parseInt(event.currentTarget.value, 10))} value={Math.min(selectedLocalRepoIndex, Math.max(0, repos.length - 1))}>
+            {repos.length === 0 ? <option value={0}>No local repos</option> : repos.map((repo, index) => <option key={repo.path_ref} value={index}>{repo.name}</option>)}
+          </select>
+        </label>
+        <button aria-label="Next local repo" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight /></button>
+      </div>
+      <section className="sidebar-group session-history-list">
+        <h2>{text.sessionHistory}</h2>
+        {selectedRepo ? <ul>
+          {sessions.length === 0
+            ? <li><button className="surface-link active" type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{selectedRepo.name}</strong><small>No OpenCode sessions found for this repo yet.</small></span><em>{text.planned}</em></button></li>
+            : sessions.map((session, index) => <li key={session.id_ref}><button className={index === 0 ? "surface-link active" : "surface-link"} type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{session.title}</strong><small>{session.updated_at}</small></span></button></li>)}
+        </ul> : <p className="empty-sidebar-state">No local repos discovered.</p>}
+      </section>
+      </>}
+    </section>
+  );
+}
+
+function PeopleChannelList() {
+  return (
+    <div aria-label="People channels">
+      <div className="notice compact-notice">{text.simplexReady}</div>
+      <section className="sidebar-group session-history-list">
+        <h2>{text.teams}</h2>
+        <ul>
+          {["aidevops", "clients", "ops"].map((team) => <li key={team}><button className="surface-link" type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{team}</strong><small>SimpleX team channel placeholder</small></span></button></li>)}
+        </ul>
+      </section>
+      <section className="sidebar-group session-history-list">
+        <h2>{text.directMessages}</h2>
+        <ul>
+          {["Marcus", "AI DevOps"].map((person) => <li key={person}><button className="surface-link" type="button"><span className="surface-icon" aria-hidden="true"><FiMessageSquare /></span><span className="surface-copy"><strong>{person}</strong><small>encrypted DM placeholder</small></span></button></li>)}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function SidebarModeTabs<TMode extends SidebarMode | ConversationMode>({ mode, setMode }: {
+  mode: TMode;
+  setMode: (mode: TMode) => void;
+}) {
+  const modes = (mode === "ai" || mode === "people"
+    ? [{ label: text.ai, value: "ai" }, { label: text.people, value: "people" }]
+    : [{ label: text.devops, value: "devops" }, { label: text.comms, value: "comms" }]) as Array<{ label: string; value: TMode }>;
 
   return (
     <div className="sidebar-mode-tabs" role="tablist" aria-label="Sidebar sections">
@@ -246,11 +345,9 @@ function SidebarItem({ activeSurface, item, recordCount, setActiveSurface, showC
   );
 }
 
-function SidebarHeader({ canGoBack, canGoForward, goBack, goForward }: {
-  canGoBack: boolean;
-  canGoForward: boolean;
-  goBack: () => void;
-  goForward: () => void;
+function SidebarHeader({ setShellMode, shellMode }: {
+  setShellMode: (mode: ShellMode) => void;
+  shellMode: ShellMode;
 }) {
   return (
     <header className="sidebar-header">
@@ -259,10 +356,14 @@ function SidebarHeader({ canGoBack, canGoForward, goBack, goForward }: {
           <span className="terminal-mark" aria-hidden="true">›_</span>
           <strong>{text.aidevops}</strong>
         </div>
-        <div className="sidebar-history-controls">
-          <button aria-label="Previous surface" disabled={!canGoBack} onClick={goBack} type="button"><FiChevronLeft /></button>
-          <button aria-label="Next surface" disabled={!canGoForward} onClick={goForward} type="button"><FiChevronRight /></button>
-        </div>
+        <IconSwitch
+          ariaLabel="Navigation scope"
+          options={[
+            { icon: <FiMonitor aria-hidden="true" />, label: text.devices, onSelect: () => setShellMode("devices"), value: "devices" },
+            { icon: <FiHash aria-hidden="true" />, label: text.opencodeSessions, onSelect: () => setShellMode("sessions"), value: "sessions" },
+          ]}
+          value={shellMode}
+        />
       </div>
     </header>
   );

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -158,11 +158,11 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, statu
         </header>
         <div className="chat-message-list">
           {conversationMode === "ai" ? <>
-            <ChatBubble role="assistant" title={selectedSession?.title ?? "AI session bridge"} body={selectedSession ? `Most recent OpenCode session metadata: ${selectedSession.model} via ${selectedSession.agent}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the turbostarter/ai chat bridge lands.` : "OpenCode session creation and continuation need an audited write route. This panel is ready for the turbostarter/ai chat surface once that adapter is connected."} />
-            <ChatBubble role="user" title={selectedRepo?.name ?? "Local repo"} body={selectedRepo ? `Selected repo: ${selectedRepo.path_ref}. Session metadata is grouped per local repo and sorted newest first from ${status.opencode_sessions.path_ref}.` : "No local repos were discovered yet."} />
+            <ChatBubble speaker="assistant" title={selectedSession?.title ?? "AI session bridge"} body={selectedSession ? `Most recent OpenCode session metadata: ${selectedSession.model} via ${selectedSession.agent}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the turbostarter/ai chat bridge lands.` : "OpenCode session creation and continuation need an audited write route. This panel is ready for the turbostarter/ai chat surface once that adapter is connected."} />
+            <ChatBubble speaker="user" title={selectedRepo?.name ?? "Local repo"} body={selectedRepo ? `Selected repo: ${selectedRepo.path_ref}. Session metadata is grouped per local repo and sorted newest first from ${status.opencode_sessions.path_ref}.` : "No local repos were discovered yet."} />
           </> : <>
-            <ChatBubble role="assistant" title="SimpleX transport" body={text.simplexReady} />
-            <ChatBubble role="user" title="People channel" body="Teams and direct messages share the same Slack-like channel layout while protected message payloads remain behind Vault policy." />
+            <ChatBubble speaker="assistant" title="SimpleX transport" body={text.simplexReady} />
+            <ChatBubble speaker="user" title="People channel" body="Teams and direct messages share the same Slack-like channel layout while protected message payloads remain behind Vault policy." />
           </>}
         </div>
         <form className="chat-composer" aria-label="Chat composer">
@@ -174,9 +174,9 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, statu
   );
 }
 
-function ChatBubble({ body, role, title }: { body: string; role: "assistant" | "user"; title: string }) {
+function ChatBubble({ body, speaker, title }: { body: string; speaker: "assistant" | "user"; title: string }) {
   return (
-    <article className={`chat-bubble ${role}`}>
+    <article className={`chat-bubble ${speaker}`}>
       <strong>{title}</strong>
       <p>{body}</p>
     </article>

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -1,9 +1,9 @@
 /* jshint esversion: 11 */
 import { type ReactElement, type ReactNode, useEffect, useMemo, useState } from "react";
-import { FiBell, FiCommand, FiCpu, FiGlobe, FiLogOut, FiMessageSquare, FiSearch, FiSettings, FiShield, FiUser } from "react-icons/fi";
+import { FiBell, FiChevronLeft, FiChevronRight, FiCommand, FiCpu, FiGlobe, FiHash, FiLogOut, FiMessageSquare, FiSearch, FiSettings, FiShield, FiUser } from "react-icons/fi";
 import type { GuiFileRootId, GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
-import type { SurfaceId, SurfaceNavItem } from "./app-model";
+import type { ConversationMode, ShellMode, SurfaceId, SurfaceNavItem } from "./app-model";
 import { inventorySurfaceConfigs, orderedNavItems, text } from "./app-model";
 import { FileExplorerSurface } from "./FileExplorerSurface";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
@@ -15,28 +15,41 @@ const communityLinks = {
   x: "https://x.com/marcuswquinn",
 } as const;
 
-export function Workspace({ activeItem, activeSectionLabel, activeSurface, fileRoot, setActiveSurface, status }: {
+export function Workspace({ activeItem, activeSectionLabel, activeSurface, canGoBack, canGoForward, conversationMode, fileRoot, goBack, goForward, selectedLocalRepoIndex, setActiveSurface, shellMode, status }: {
   activeItem: SurfaceNavItem;
   activeSectionLabel: string;
   activeSurface: SurfaceId;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  conversationMode: ConversationMode;
   fileRoot: GuiFileRootId | undefined;
+  goBack: () => void;
+  goForward: () => void;
+  selectedLocalRepoIndex: number;
   setActiveSurface: (surface: SurfaceId) => void;
+  shellMode: ShellMode;
   status: GuiStatusData;
 }) {
   return (
     <section className="app-inset" aria-label={text.workspaceLabel}>
-      <WorkspaceHeader activeItem={activeItem} activeSectionLabel={activeSectionLabel} activeSurface={activeSurface} setActiveSurface={setActiveSurface} status={status} />
+      <WorkspaceHeader activeItem={activeItem} activeSectionLabel={activeSectionLabel} activeSurface={activeSurface} canGoBack={canGoBack} canGoForward={canGoForward} goBack={goBack} goForward={goForward} setActiveSurface={setActiveSurface} status={status} />
       <div className="workspace-scroll">
-        <SurfaceContent activeItem={activeItem} activeSurface={activeSurface} fileRoot={fileRoot} status={status} />
+        {shellMode === "sessions"
+          ? <ConversationWorkspace conversationMode={conversationMode} selectedLocalRepoIndex={selectedLocalRepoIndex} status={status} />
+          : <SurfaceContent activeItem={activeItem} activeSurface={activeSurface} fileRoot={fileRoot} status={status} />}
       </div>
     </section>
   );
 }
 
-function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, setActiveSurface, status }: {
+function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoBack, canGoForward, goBack, goForward, setActiveSurface, status }: {
   activeItem: SurfaceNavItem;
   activeSectionLabel: string;
   activeSurface: SurfaceId;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  goBack: () => void;
+  goForward: () => void;
   setActiveSurface: (surface: SurfaceId) => void;
   status: GuiStatusData;
 }): ReactElement {
@@ -80,6 +93,10 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, setAct
         </div>
       </div>
       <div className="header-actions">
+        <div className="sidebar-history-controls workspace-history-controls">
+          <button aria-label="Previous surface" disabled={!canGoBack} onClick={goBack} type="button"><FiChevronLeft /></button>
+          <button aria-label="Next surface" disabled={!canGoForward} onClick={goForward} type="button"><FiChevronRight /></button>
+        </div>
         <button className="workspace-search command-trigger" onClick={() => setCommandOpen(true)} type="button">
           <FiSearch aria-hidden="true" />
           <span>⌘K</span>
@@ -115,6 +132,54 @@ function NotificationsMenu({ openSurface }: { openSurface: (surface: SurfaceId) 
       <p>Local readiness updates, release activity, and account alerts will collect here.</p>
       <button onClick={() => openSurface("notifications")} role="menuitem" type="button">Open notifications</button>
     </div>
+  );
+}
+
+function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, status }: {
+  conversationMode: ConversationMode;
+  selectedLocalRepoIndex: number;
+  status: GuiStatusData;
+}) {
+  const selectedRepo = status.local_repos.repos[selectedLocalRepoIndex] ?? status.local_repos.repos[0];
+  const selectedSession = selectedRepo === undefined
+    ? undefined
+    : status.opencode_sessions.sessions.find((session) => session.repo_path_ref === selectedRepo.path_ref);
+  const title = conversationMode === "ai" ? selectedRepo?.name ?? text.opencodeSessions : text.teams;
+
+  return (
+    <section className="chat-surface" aria-label={conversationMode === "ai" ? text.opencodeSessions : "People chat"}>
+      <div className="chat-thread-panel">
+        <header className="chat-thread-header">
+          <div>
+            <p className="eyebrow">{conversationMode === "ai" ? text.opencodeSessions : "SimpleX channels"}</p>
+            <h2><FiHash aria-hidden="true" /> {title}</h2>
+          </div>
+          <span className="count-pill">{text.readOnly}</span>
+        </header>
+        <div className="chat-message-list">
+          {conversationMode === "ai" ? <>
+            <ChatBubble role="assistant" title={selectedSession?.title ?? "AI session bridge"} body={selectedSession ? `Most recent OpenCode session metadata: ${selectedSession.model} via ${selectedSession.agent}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the turbostarter/ai chat bridge lands.` : "OpenCode session creation and continuation need an audited write route. This panel is ready for the turbostarter/ai chat surface once that adapter is connected."} />
+            <ChatBubble role="user" title={selectedRepo?.name ?? "Local repo"} body={selectedRepo ? `Selected repo: ${selectedRepo.path_ref}. Session metadata is grouped per local repo and sorted newest first from ${status.opencode_sessions.path_ref}.` : "No local repos were discovered yet."} />
+          </> : <>
+            <ChatBubble role="assistant" title="SimpleX transport" body={text.simplexReady} />
+            <ChatBubble role="user" title="People channel" body="Teams and direct messages share the same Slack-like channel layout while protected message payloads remain behind Vault policy." />
+          </>}
+        </div>
+        <form className="chat-composer" aria-label="Chat composer">
+          <textarea disabled placeholder={text.chatInputPlaceholder} />
+          <button disabled type="button">Send</button>
+        </form>
+      </div>
+    </section>
+  );
+}
+
+function ChatBubble({ body, role, title }: { body: string; role: "assistant" | "user"; title: string }) {
+  return (
+    <article className={`chat-bubble ${role}`}>
+      <strong>{title}</strong>
+      <p>{body}</p>
+    </article>
   );
 }
 

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -2,6 +2,8 @@ import type { GuiFileRootId, GuiStatusData } from "@aidevops/gui-shared";
 
 export type ThemePreference = "system" | "light" | "dark";
 export type SidebarMode = "devops" | "comms";
+export type ShellMode = "devices" | "sessions";
+export type ConversationMode = "ai" | "people";
 export type FontPreference =
   | "IBM Plex Mono"
   | "IBM Plex Sans"
@@ -208,6 +210,16 @@ export const text = {
   plannedHomes: "Planned homes",
   plannedNotice: "This surface is a local UI placeholder. Persistence and actions need explicit trust-boundary work.",
   comms: "Comms",
+  ai: "AI",
+  people: "People",
+  newSession: "New Session",
+  sessionHistory: "Session history",
+  opencodeSessions: "OpenCode sessions",
+  simplexReady: "SimpleX transport placeholder: encrypted channel adapters will mount here behind Vault and trust-boundary checks.",
+  teams: "Teams",
+  directMessages: "Direct Messages",
+  chatInputPlaceholder: "Write a message when audited session write routes are enabled.",
+  localRepoSelector: "Local repo selector",
   performance: "Performance",
   projectWorkIntro: "Document folders for inboxes, campaigns, cases, configuration, feedback, knowledge, maintenance, performance, and reports are planned.",
   projectWork: "Documents",

--- a/packages/gui-web/src/status-client.ts
+++ b/packages/gui-web/src/status-client.ts
@@ -82,6 +82,7 @@ function normalizeStatusEnvelope(envelope: GuiResponseEnvelope<Partial<GuiStatus
       settings: { ...statusFixture.settings, ...data.settings },
       repos: { ...statusFixture.repos, ...data.repos, repos: data.repos?.repos ?? statusFixture.repos.repos },
       local_repos: { ...statusFixture.local_repos, ...data.local_repos, repos: data.local_repos?.repos ?? statusFixture.local_repos.repos },
+      opencode_sessions: { ...statusFixture.opencode_sessions, ...data.opencode_sessions, sessions: data.opencode_sessions?.sessions ?? statusFixture.opencode_sessions.sessions },
       oauth_pool: { ...statusFixture.oauth_pool, ...data.oauth_pool, providers: data.oauth_pool?.providers ?? statusFixture.oauth_pool.providers },
       setup_targets: data.setup_targets ?? statusFixture.setup_targets,
       ai_apps: data.ai_apps ?? statusFixture.ai_apps,

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -206,6 +206,7 @@ code {
 .brand-lockup,
 .sidebar-titlebar,
 .sidebar-history-controls,
+.icon-switch,
 .sidebar-mode-tabs,
 .theme-control-heading,
 .appearance-panel-tab,
@@ -279,6 +280,40 @@ code {
   width: 26px;
 }
 
+.icon-switch {
+  background: color-mix(in srgb, var(--surface-muted) 72%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  gap: 2px;
+  padding: 2px;
+}
+
+.icon-switch button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  gap: 4px;
+  height: 28px;
+  justify-content: center;
+  min-width: 32px;
+  padding: 0 8px;
+}
+
+.icon-switch button span {
+  display: none;
+}
+
+.icon-switch button.active,
+.icon-switch button:hover,
+.icon-switch button:focus-visible {
+  background: var(--surface-elevated);
+  color: var(--accent);
+  outline: none;
+}
+
 .sidebar-history-controls button:hover:not(:disabled),
 .sidebar-history-controls button:focus-visible {
   background: var(--surface-elevated);
@@ -324,6 +359,71 @@ code {
   background: var(--surface-elevated);
   color: var(--accent);
   outline: none;
+}
+
+.conversation-panel {
+  display: grid;
+  gap: 12px;
+  padding: 0 6px;
+}
+
+.new-session-button {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+  border-radius: 12px;
+  color: var(--accent);
+  font-weight: 900;
+  padding: 10px 12px;
+}
+
+.repo-session-selector {
+  align-items: end;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.repo-session-selector button {
+  align-items: center;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  height: 34px;
+  justify-content: center;
+  width: 34px;
+}
+
+.repo-session-selector label {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.repo-session-selector label span {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.repo-session-selector select {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text-primary);
+  min-width: 0;
+  padding: 8px;
+}
+
+.session-history-list .surface-link {
+  min-height: 46px;
+}
+
+.empty-sidebar-state {
+  color: var(--text-muted);
+  margin: 8px;
 }
 
 .sidebar-group {
@@ -752,6 +852,10 @@ code {
   white-space: nowrap;
 }
 
+.workspace-history-controls {
+  flex: 0 0 auto;
+}
+
 .workspace-search span,
 .workspace-search input {
   color: var(--text-muted);
@@ -1013,6 +1117,93 @@ code {
 .surface-page {
   display: grid;
   gap: 16px;
+}
+
+.chat-surface {
+  display: grid;
+  min-height: 100%;
+}
+
+.chat-thread-panel {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  display: grid;
+  grid-template-rows: auto minmax(320px, 1fr) auto;
+  min-height: 620px;
+  overflow: hidden;
+}
+
+.chat-thread-header {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  padding: 18px;
+}
+
+.chat-thread-header h2 {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin: 0;
+}
+
+.chat-message-list {
+  align-content: start;
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+}
+
+.chat-bubble {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  display: grid;
+  gap: 6px;
+  max-width: min(680px, 90%);
+  padding: 14px;
+}
+
+.chat-bubble.assistant {
+  background: var(--surface-muted);
+}
+
+.chat-bubble.user {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  justify-self: end;
+}
+
+.chat-bubble p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.chat-composer {
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 14px;
+}
+
+.chat-composer textarea {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  color: var(--text-primary);
+  min-height: 54px;
+  padding: 12px;
+  resize: vertical;
+}
+
+.chat-composer button {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+  border-radius: 14px;
+  color: var(--accent);
+  font-weight: 900;
+  padding: 0 18px;
 }
 
 .hero-panel,


### PR DESCRIPTION
## Summary
- Move previous/next navigation controls into the top workspace header before search.
- Add screen/# shell mode switch in the sidebar header.
- Add AI/People conversation mode scaffolding with local repo OpenCode session metadata and SimpleX-ready People channel placeholders.

## Files
- `packages/gui-web/src/App.tsx` wires shell/conversation/local repo state.
- `packages/gui-web/src/AppNavigation.tsx` renders screen/# and AI/People sidebar controls.
- `packages/gui-web/src/AppWorkspace.tsx` renders top prev/next controls and chat-style session content.
- `packages/gui-api/src/status-adapter.ts` reads OpenCode session metadata read-only from the local database.
- `packages/gui-shared/src/contracts.ts` adds metadata-only session contracts.

## Verification
```bash
bun run typecheck
bun run gui:test:components
bun run gui:test:security
bun run gui:test:api
bun run gui:test:adapters
bun run gui:test:schema
.agents/scripts/linters-local.sh
bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build
```

Resolves #25636

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.24.2 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
