### PR TITLE
GH#25641: fix: tolerate missing check suites

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -116,7 +116,7 @@ gh_pr_check_status_rest() {
 	local _check_state=""
 	# shellcheck disable=SC2016 # jq program uses $active as a jq variable.
 	_check_state=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-suites" --jq '
-		(.check_suites | map(select(.conclusion != null or .status != "queued"))) as $active |
+		((.check_suites // []) | map(select(.conclusion != null or .status != "queued"))) as $active |
 		if ($active | length) == 0 then "none"
 		elif ($active | all(.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral")) then "PASS"
 		elif ($active | any(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")) then "FAIL"

--- a/.agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh
@@ -64,6 +64,8 @@ assert_status() {
 }
 
 main() {
+	assert_status "missing check_suites defaults to none" "none" '{}'
+	assert_status "null check_suites defaults to none" "none" '{"check_suites":null}'
 	assert_status "null queued app suites ignored when actions passed" "PASS" '{"check_suites":[{"app":{"slug":"github-actions"},"status":"completed","conclusion":"success"},{"app":{"slug":"coderabbitai"},"status":"queued","conclusion":null}]}'
 	assert_status "all null suites mean no active checks" "none" '{"check_suites":[{"app":{"slug":"coderabbitai"},"status":"queued","conclusion":null}]}'
 	assert_status "terminal failure still fails" "FAIL" '{"check_suites":[{"app":{"slug":"github-actions"},"status":"completed","conclusion":"success"},{"app":{"slug":"github-actions"},"status":"completed","conclusion":"failure"},{"app":{"slug":"coderabbitai"},"status":"queued","conclusion":null}]}'


### PR DESCRIPTION
## Summary

Updated gh_pr_check_status_rest to default missing or null check_suites to an empty array before filtering active suites; added regression coverage for missing and null check_suites payloads.

## Files Changed

.agents/scripts/shared-gh-wrappers-checks.sh,.agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-checks.sh .agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh; .agents/scripts/tests/test-shared-gh-wrappers-checks-null-suites.sh

Resolves #25641


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.24.2 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 50,949 tokens on this as a headless worker.