### PR TITLE
t18010: feat: add vault security validation suite

### DIFF
--- a/.agents/reference/ci-gate-policy.md
+++ b/.agents/reference/ci-gate-policy.md
@@ -36,6 +36,10 @@ feedback loops when they find defects.
    a broad filter such as `--filter="...[origin/<base>]"` can include the
    workspace root; if root `lint`/`typecheck` scripts call Turbo, exclude root
    with `--filter="!//"` or run root checks in a separate job.
+8. Vault changes require the fast deterministic security suite on develop/main
+   PRs. Broad reboot, fleet, migration-recovery, and manual crypto-review drills
+   are staging/release advisory until stable enough for every PR. See
+   `reference/vault-security-review.md`.
 
 ## Ruleset checklist
 

--- a/.agents/reference/vault-security-review.md
+++ b/.agents/reference/vault-security-review.md
@@ -1,0 +1,73 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Vault Security Review and Release Criteria
+
+Use this checklist before enabling Vault destructive migration, remote unlock, or
+fleet sync by default. The fast deterministic gate is
+`.agents/scripts/tests/test-vault-security-suite.sh`; broad fleet and recovery
+drills remain staging/release advisory until they are stable enough for every PR.
+
+## Required before default-on release
+
+- External crypto/security review covers `vault-crypto-helper.py`,
+  `vault_crypto_core.py`, broker lifecycle, device registry, sync, remote control,
+  audit chain, and migration rollback paths.
+- Destructive migration stays behind explicit operator intent until recovery from
+  interrupted migration and rollback is verified on a disposable copy of each
+  protected data plane.
+- True remote unlock remains default-disabled behind a feature flag. Remote lock
+  and unlock-request are the safe default; true remote unlock requires a written
+  threat-model exception, device-bound encryption, short TTL, audit events, and a
+  local kill switch.
+- Public/private Git, object storage, SimpleX, SSH, Tailscale, and VPS disks are
+  treated as untrusted transports. Only ciphertext, opaque ids, public keys, and
+  signed metadata may cross them.
+- Passphrases, recovery material, root keys, private device keys, and plaintext
+  protected data are never accepted through chat, issue bodies, CLI args,
+  environment variables, logs, or test fixtures.
+
+## Fast required security gate
+
+The fast suite must pass locally and in CI before Vault changes merge:
+
+```bash
+./.agents/scripts/tests/test-vault-security-suite.sh
+```
+
+It aggregates the existing Vault helper tests and pins these failure modes:
+
+- wrong passphrase and non-TTY passphrase input fail closed without echoing the
+  supplied value;
+- broker crash/app restart simulation returns Vault to `locked` and denies reads;
+- locked data-plane access and locked migration fail before plaintext removal;
+- interrupted or tampered migration/audit/sync inputs fail with stable errors;
+- replayed sync records, remote commands, stale commands, and revoked devices are
+  rejected;
+- public Git/message transports expose only ciphertext and opaque paths;
+- deterministic scans reject plaintext secret-like test fixtures.
+
+## Staging or release advisory drills
+
+Run these on disposable test Vaults before release candidates and before changing
+Vault defaults:
+
+1. Reboot simulation: unlock, write entries, terminate broker/session, restart the
+   host or runtime, and verify locked status before any plaintext read.
+2. Interrupted migration: stop the migration after encrypt-before-remove and
+   after remove-before-manifest-finalise; verify rollback restores only from
+   verified Vault entries.
+3. Interrupted sync: stop export/import mid-record and verify replay/rollback
+   protection rejects partial or stale records.
+4. Interrupted audit write: force an audit append failure with
+   `AIDEVOPS_VAULT_AUDIT_REQUIRE=1`; sensitive operations must fail closed.
+5. Public ciphertext scan: scan public transport repos for client names, local
+   paths, entry ids, plaintext payloads, and search indexes.
+
+## Honest security-limit wording
+
+Vault does not protect data from malware/root access while unlocked, provider-side
+AI logs after plaintext is sent to a third-party provider, unsupported runtime
+caches, unmanaged crash reports, terminal scrollback, screenshots, OS crash
+dumps/swap/hibernation, snapshots/backups created before encryption, or durable
+plaintext already committed to Git history.

--- a/.agents/reference/vault.md
+++ b/.agents/reference/vault.md
@@ -473,6 +473,9 @@ model:
 - Security-sensitive Vault work must include a negative test or checklist proving
   passphrases/secrets are not accepted through chat, arguments, environment
   variables, logs, issue comments, or fixtures.
+- Default-on destructive migration, remote unlock, or fleet sync requires the
+  release checklist and external security review in
+  `reference/vault-security-review.md`; keep true remote unlock feature-gated.
 - New always-loaded guidance should be a short pointer to this RFC or the Vault
   workflows, not a full rule expansion.
 - Any proposal for true remote unlock must start default-disabled and include a

--- a/.agents/scripts/tests/test-vault-helper.sh
+++ b/.agents/scripts/tests/test-vault-helper.sh
@@ -177,6 +177,27 @@ assert_eq "unlock verifies restart test and enables migration" "migration-ready"
 
 printf 'protected value' | "$VAULT_HELPER" update sample >/dev/null
 assert_eq "read returns encrypted entry after unlock" "protected value" "$($VAULT_HELPER read sample)"
+broker_pid_file="$AIDEVOPS_VAULT_RUNTIME_DIR/broker.pid"
+if [[ -s "$broker_pid_file" ]]; then
+	broker_pid="$(sed -n '1p' "$broker_pid_file")"
+	kill -9 "$broker_pid" >/dev/null 2>&1 || true
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[[ "$($VAULT_HELPER status 2>/dev/null || true)" == "locked" ]] && break
+		sleep 0.2
+	done
+	assert_eq "broker crash returns Vault to locked state" "locked" "$($VAULT_HELPER status 2>/dev/null || true)"
+	set +e
+	crash_read_output="$($VAULT_HELPER read sample 2>&1 >/dev/null)"
+	crash_read_rc=$?
+	set -e
+	assert_nonzero "broker crash denies plaintext read" "$crash_read_rc"
+	case "$crash_read_output" in
+	*VAULT_LOCKED*) pass "broker crash read reports VAULT_LOCKED" ;;
+	*) fail "broker crash read reports VAULT_LOCKED" ;;
+	esac
+else
+	fail "broker crash drill has broker pid"
+fi
 "$VAULT_HELPER" lock >/dev/null
 assert_eq "status reports locked after lock" "locked" "$($VAULT_HELPER status)"
 

--- a/.agents/scripts/tests/test-vault-security-suite.sh
+++ b/.agents/scripts/tests/test-vault-security-suite.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-vault-security-suite)"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	printf 'FAIL: %s\n' "$name" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+run_child_test() {
+	local name="$1"
+	local path="$2"
+	if bash "$path"; then
+		pass "$name"
+	else
+		fail "$name"
+	fi
+	return 0
+}
+
+test_no_public_plaintext_fixtures() {
+	local public_scan="$TEST_ROOT/public-scan.out"
+	if git -C "$REPO_ROOT" grep -n -E 'BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY|vault passphrase|recovery key' -- \
+		'.agents/scripts/tests/test-vault*.sh' '.agents/reference/vault-security-review.md' >"$public_scan" 2>/dev/null; then
+		printf 'Plaintext secret-like fixture matches:\n' >&2
+		sed -n '1,80p' "$public_scan" >&2 || true
+		fail "Vault security fixtures avoid plaintext secret material"
+	else
+		pass "Vault security fixtures avoid plaintext secret material"
+	fi
+	return 0
+}
+
+run_child_test "vault helper local broker and wrong-passphrase tests" "$SCRIPT_DIR/test-vault-helper.sh"
+run_child_test "vault data migration locked-state tests" "$SCRIPT_DIR/test-vault-data-migration.sh"
+run_child_test "vault sync replay, tamper, revoked-device tests" "$SCRIPT_DIR/test-vault-sync-helper.sh"
+run_child_test "vault remote lock, replay, stale-grant tests" "$SCRIPT_DIR/test-vault-remote-control-helper.sh"
+run_child_test "vault message ciphertext and revoked-device tests" "$SCRIPT_DIR/test-vault-message-helper.sh"
+run_child_test "vault audit tamper and receipt tests" "$SCRIPT_DIR/test-vault-audit-helper.sh"
+test_no_public_plaintext_fixtures
+
+printf '\nVault security suite summary: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -344,6 +344,12 @@ jobs:
         bash .agents/scripts/safety-policy-check.sh
         echo "Secret safety policy checks passed"
 
+    - name: Vault Security Suite
+      run: |
+        echo "Running Vault security validation suite..."
+        bash .agents/scripts/tests/test-vault-security-suite.sh
+        echo "Vault security validation suite passed"
+
     - name: Profile README Boundary Guard
       run: |
         echo "Running profile README boundary regression guard..."


### PR DESCRIPTION
## Summary

Added a required Vault security suite aggregating local broker, migration, sync, remote-control, message, and audit negative tests; extended broker crash coverage; documented Vault security release criteria; and wired the suite into code-quality CI.

## Files Changed

.agents/reference/ci-gate-policy.md,.agents/reference/vault-security-review.md,.agents/reference/vault.md,.agents/scripts/tests/test-vault-helper.sh,.agents/scripts/tests/test-vault-security-suite.sh,.github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ./.agents/scripts/tests/test-vault-security-suite.sh; .agents/scripts/linters-local.sh; shellcheck -S error .agents/scripts/tests/test-vault-security-suite.sh .agents/scripts/tests/test-vault-helper.sh; /bin/bash -n .agents/scripts/tests/test-vault-security-suite.sh; /bin/bash -n .agents/scripts/tests/test-vault-helper.sh

Resolves #25547


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.24.2 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 24m and 145,322 tokens on this as a headless worker.