### PR TITLE
GH#25660: fix: report vault heartbeat test failure cleanly

### DIFF
--- a/.agents/scripts/tests/test-vault-device-helper.sh
+++ b/.agents/scripts/tests/test-vault-device-helper.sh
@@ -140,8 +140,8 @@ else
 fi
 
 rm -f "$AIDEVOPS_VAULT_DEVICE_DIR/registry.json"
-missing_registry_heartbeat="$($VAULT_DEVICE_HELPER heartbeat --active-workers 0 --max-workers 1)"
-if [[ -s "$missing_registry_heartbeat" ]]; then
+if missing_registry_heartbeat="$($VAULT_DEVICE_HELPER heartbeat --active-workers 0 --max-workers 1)" \
+	&& [[ -s "$missing_registry_heartbeat" ]]; then
 	pass "heartbeat tolerates missing registry"
 else
 	fail "heartbeat tolerates missing registry"


### PR DESCRIPTION
## Summary

Wrapped the missing-registry heartbeat command substitution in the conditional so set -e reports the assertion through fail instead of aborting the test runner.

## Files Changed

.agents/scripts/tests/test-vault-device-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-vault-device-helper.sh; .agents/scripts/tests/test-vault-device-helper.sh

Resolves #25660


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 30,529 tokens on this as a headless worker.