### PR TITLE
GH#25662: fix: harden B603 test parameters

### DIFF
--- a/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
+++ b/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
@@ -26,8 +26,8 @@ else
 fi
 
 assert_b603_annotated() {
-	local rel_path="$1"
-	local pattern="$2"
+	local rel_path="${1:-}"
+	local pattern="${2:-}"
 	local file="${REPO_ROOT}/${rel_path}"
 	local match=""
 


### PR DESCRIPTION
## Summary

Updated .agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh so assert_b603_annotated uses safe positional parameter expansion under set -u.

## Files Changed

.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh; .agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh

Resolves #25662


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 29,109 tokens on this as a headless worker.