### PR TITLE
fix: align selector step buttons

### DIFF
--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -221,14 +221,14 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConv
       {conversationMode === "people" ? <PeopleChannelList /> : <>
       <button className="new-session-button" disabled title="Creating sessions needs an audited OpenCode write route." type="button">{text.newSession}</button>
       <section className="repo-session-selector" aria-label={text.localRepoSelector}>
-        <button aria-label="Previous local repo" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft /></button>
+        <button aria-label="Previous local repo" className="selector-step-button" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft aria-hidden="true" /></button>
         <label>
           <span>{text.localRepos}</span>
           <select onChange={(event) => setSelectedLocalRepoIndex(Number.parseInt(event.currentTarget.value, 10))} value={Math.min(selectedLocalRepoIndex, Math.max(0, repos.length - 1))}>
             {repos.length === 0 ? <option value={0}>No local repos</option> : repos.map((repo, index) => <option key={repo.path_ref} value={index}>{repo.name}</option>)}
           </select>
         </label>
-        <button aria-label="Next local repo" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight /></button>
+        <button aria-label="Next local repo" className="selector-step-button" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight aria-hidden="true" /></button>
       </section>
       <section className="sidebar-group session-history-list">
         <h2>{text.sessionHistory}</h2>
@@ -386,8 +386,20 @@ function SidebarFooter({ accentHue, fontPreference, fontSizePreference, setAccen
   const [appearanceOpen, setAppearanceOpen] = useState(true);
   const AppearanceChevron = appearanceOpen ? FiChevronDown : FiChevronUp;
   const selectedFontFamily = fontFamilyForPreference(fontPreference);
+  const fontIndex = Math.max(0, fontOptions.findIndex((option) => option.value === fontPreference));
   const fontSizeIndex = Math.max(0, fontSizeOptions.findIndex((option) => option.value === fontSizePreference));
+  const canSelectPreviousFont = fontIndex > 0;
+  const canSelectNextFont = fontIndex < fontOptions.length - 1;
   const [hueInput, setHueInput] = useState(() => String(accentHue));
+  const setFontByIndex = (index: number) => {
+    const nextFont = fontOptions[index]?.value;
+
+    if (nextFont === undefined) {
+      return;
+    }
+
+    setFontPreference(nextFont);
+  };
   const updateAccentHue = (value: number) => {
     if (!Number.isFinite(value)) {
       return;
@@ -486,20 +498,25 @@ function SidebarFooter({ accentHue, fontPreference, fontSizePreference, setAccen
               {fontSizeOptions.map((option) => <span className={option.value === fontSizePreference ? "active" : ""} key={option.value}>{option.label}</span>)}
             </div>
           </div>
-          <label className="font-control">
-            <span>{text.font}</span>
-            <select
-              onChange={(event) => setFontPreference(event.currentTarget.value as FontPreference)}
-              style={{ fontFamily: selectedFontFamily }}
-              value={fontPreference}
-            >
-              {fontOptions.map((option) => (
-                <option key={option.value} style={{ fontFamily: option.fontFamily }} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
+          <div className="font-control">
+            <span id="appearance-font-selector-label">{text.font}</span>
+            <div className="selector-with-stepper font-selector-row">
+              <button aria-label="Previous font" className="selector-step-button" disabled={!canSelectPreviousFont} onClick={() => setFontByIndex(fontIndex - 1)} type="button"><FiChevronLeft aria-hidden="true" /></button>
+              <select
+                aria-labelledby="appearance-font-selector-label"
+                onChange={(event) => setFontPreference(event.currentTarget.value as FontPreference)}
+                style={{ fontFamily: selectedFontFamily }}
+                value={fontPreference}
+              >
+                {fontOptions.map((option) => (
+                  <option key={option.value} style={{ fontFamily: option.fontFamily }} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <button aria-label="Next font" className="selector-step-button" disabled={!canSelectNextFont} onClick={() => setFontByIndex(fontIndex + 1)} type="button"><FiChevronRight aria-hidden="true" /></button>
+            </div>
+          </div>
         </div>
         : null}
       </section>

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -383,16 +383,41 @@ code {
   grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
-.repo-session-selector button {
+.selector-with-stepper {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.repo-session-selector .selector-step-button,
+.selector-step-button {
   align-items: center;
   background: var(--surface-muted);
   border: 1px solid var(--border);
   border-radius: 999px;
   color: var(--text-secondary);
   display: inline-flex;
-  height: 34px;
+  height: 40px;
   justify-content: center;
-  width: 34px;
+}
+
+.selector-step-button {
+  padding: 0;
+  width: 40px;
+}
+
+.selector-step-button:hover:not(:disabled),
+.selector-step-button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  color: var(--accent);
+  outline: none;
+}
+
+.selector-step-button svg {
+  height: 18px;
+  stroke-width: 2.5;
+  width: 18px;
 }
 
 .repo-session-selector label {
@@ -413,6 +438,7 @@ code {
   border: 1px solid var(--border);
   border-radius: 10px;
   color: var(--text-primary);
+  min-height: 40px;
   min-width: 0;
   padding: 8px;
 }
@@ -754,9 +780,14 @@ code {
   border: 1px solid var(--border);
   border-radius: 12px;
   color: var(--text-primary);
+  min-height: 40px;
   min-width: 0;
   padding: 9px 10px;
   width: 100%;
+}
+
+.font-selector-row {
+  align-items: center;
 }
 
 .app-inset {


### PR DESCRIPTION
## Summary
- Adds previous/next icon buttons around the appearance font dropdown.
- Reuses a shared stepper selector button style for font and local-repo dropdown controls.
- Normalizes selector button/dropdown heights so the side buttons vertically align with the dropdown controls.

## Verification
- `bun test packages/gui-web/tests`
- `bun run typecheck`
- `bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build`
- `.agents/scripts/linters-local.sh` partially ran: Secretlint passed; existing advisory Markdown/Qlty findings surfaced; run timed out later during Pulse Wrapper Canary.
Resolves #25670
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.0 with gpt-5.5 spent 14m and 179,755 tokens on this with the user in an interactive session.