### PR TITLE
fix: avoid jq in pulse stats ensure

### DIFF
--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -64,12 +64,15 @@ _pulse_stats_ensure_file() {
 		return 0
 	fi
 
-	# GH#25584: an interrupted writer or external truncation can leave the stats
-	# file present but empty/invalid. Gauge writers previously treated that as a
-	# jq no-op, leaving stale merge-stuck meta-issues unable to observe recovery.
-	# Reinitialize to the minimal schema so the next atomic update can proceed.
-	if ! jq -e 'type == "object"' "$PULSE_STATS_FILE" >/dev/null 2>&1; then
-		printf '{"counters":{}}\n' >"$PULSE_STATS_FILE" 2>/dev/null || return 0
+	# GH#25584/GH#25658: an interrupted writer or external truncation can leave
+	# the stats file empty or obviously malformed. Keep the common valid-file path
+	# pure Bash so every counter/gauge write does not spawn jq just to continue.
+	local first_char=""
+	if [[ ! -s "$PULSE_STATS_FILE" ]] || ! IFS= read -r -n 1 first_char <"$PULSE_STATS_FILE" || [[ "$first_char" != "{" ]]; then
+		printf '{"counters":{}}\n' >"$PULSE_STATS_FILE" || {
+			printf 'Error: Failed to write pulse stats file: %s\n' "$PULSE_STATS_FILE" >&2
+			return 1
+		}
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-stats-helper.sh
+++ b/.agents/scripts/tests/test-pulse-stats-helper.sh
@@ -47,4 +47,27 @@ pulse_stats_set_gauge pulse_merge_zero_progress_cycles 0
 gauge_value="$("$HELPER" get-gauge pulse_merge_zero_progress_cycles)"
 [[ "$gauge_value" == "0" ]]
 
+python3 - "$PULSE_STATS_FILE" <<'PY'
+import json
+import sys
+
+json.dump({'counters': {}, 'gauges': {}}, open(sys.argv[1], 'w'))
+PY
+FAKE_BIN="${TMP_DIR}/bin"
+mkdir -p "$FAKE_BIN"
+cat >"${FAKE_BIN}/jq" <<'SH'
+#!/usr/bin/env bash
+exit 42
+SH
+chmod +x "${FAKE_BIN}/jq"
+PATH="${FAKE_BIN}:${PATH}" _pulse_stats_ensure_file
+python3 - "$PULSE_STATS_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as fh:
+    data = json.load(fh)
+assert data == {'counters': {}, 'gauges': {}}
+PY
+
 printf 'PASS pulse-stats-helper\n'


### PR DESCRIPTION
## Summary
- Replaced per-call jq validation in `_pulse_stats_ensure_file` with a pure-Bash empty/first-character fast path.
- Added visible write diagnostics that include the pulse stats file path.
- Added a regression check that a valid stats file does not require jq during ensure.

## Testing
- `shellcheck .agents/scripts/pulse-stats-helper.sh .agents/scripts/tests/test-pulse-stats-helper.sh`
- `.agents/scripts/tests/test-pulse-stats-helper.sh`

Resolves #25658
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 54,181 tokens on this as a headless worker.