### PR TITLE
fix: harden issue sync dedupe

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -181,7 +181,7 @@ _closed_issue_worker_complete_date() {
 	local completed_at
 
 	completed_at=$(gh api "repos/${repo}/issues/${issue_number}/comments" \
-		--jq '[.[] | select(.body | contains("CLAIM_RELEASED reason=worker_complete")) | .created_at][0] // ""' 2>/dev/null || true)
+		--jq '[.[] | select((.body // "") | contains("CLAIM_RELEASED reason=worker_complete")) | .created_at][0] // ""' || true)
 	if [[ -z "$completed_at" ]]; then
 		return 1
 	fi

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -479,6 +479,8 @@ _dedupe_todo_task_lines() {
 	tmp_file=$(mktemp "${todo_file}.dedupe.XXXXXX") || return 2
 	if ! awk -v task_pattern="$task_id_ere" '
 		BEGIN { pattern = "^[[:space:]]*- \\[.\\] " task_pattern " " }
+		/^[[:space:]]*```/ { in_fence = !in_fence; lines[NR] = $0; next }
+		in_fence { lines[NR] = $0; next }
 		$0 ~ pattern {
 			is_task[NR] = 1
 			score = 0
@@ -487,7 +489,9 @@ _dedupe_todo_task_lines() {
 			if ($0 ~ / blocked-by:/) { score += 25 }
 			if ($0 ~ / tier:/) { score += 25 }
 			if ($0 ~ / logged:/) { score += 25 }
-			if ($0 ~ / pr:#[0-9]+| verified:[0-9]{4}-[0-9]{2}-[0-9]{2}| completed:[0-9]{4}-[0-9]{2}-[0-9]{2}/) { score += 10 }
+			if ($0 ~ / pr:#[0-9]+/) { score += 10 }
+			if ($0 ~ / verified:[0-9]{4}-[0-9]{2}-[0-9]{2}/) { score += 10 }
+			if ($0 ~ / completed:[0-9]{4}-[0-9]{2}-[0-9]{2}/) { score += 10 }
 			if (best_line == 0 || score > best_score) {
 				best_line = NR
 				best_score = score

--- a/.agents/tests/test-task-sync-dedupe.sh
+++ b/.agents/tests/test-task-sync-dedupe.sh
@@ -67,9 +67,51 @@ EOF
 	return 0
 }
 
+test_dedupe_ignores_markdown_fences() {
+	local tmpdir todo_file count fenced_count canonical_count
+	tmpdir=$(mktemp -d)
+	todo_file="${tmpdir}/TODO.md"
+	cat >"$todo_file" <<'EOF'
+```markdown
+- [ ] t18002 vault: example task inside docs ref:GH#25539
+```
+
+- [ ] t18002 vault: add GUI Vault sidebar #architecture ref:GH#25539
+EOF
+	_dedupe_todo_task_lines "t18002" "$todo_file" >/dev/null || true
+	count=$(grep -Ec '^[[:space:]]*- \[.\] t18002 ' "$todo_file" || true)
+	fenced_count=$(grep -Ec 'example task inside docs' "$todo_file" || true)
+	canonical_count=$(grep -Ec 'add GUI Vault sidebar' "$todo_file" || true)
+	[[ "$count" == "2" ]] || fail "expected fenced and canonical t18002 lines to remain, got $count"
+	[[ "$fenced_count" == "1" ]] || fail "expected fenced example line to remain"
+	[[ "$canonical_count" == "1" ]] || fail "expected canonical task line to remain"
+	rm -rf "$tmpdir"
+	pass "dedupe ignores markdown fences"
+	return 0
+}
+
+test_dedupe_scores_metadata_individually() {
+	local tmpdir todo_file line
+	tmpdir=$(mktemp -d)
+	todo_file="${tmpdir}/TODO.md"
+	cat >"$todo_file" <<'EOF'
+- [ ] t18002 vault: add GUI Vault sidebar #architecture ref:GH#25539 pr:#1
+- [ ] t18002 vault: add GUI Vault sidebar #architecture ref:GH#25539 verified:2026-06-26 completed:2026-06-27
+EOF
+	_dedupe_todo_task_lines "t18002" "$todo_file" >/dev/null
+	line=$(grep -E '^[[:space:]]*- \[.\] t18002 ' "$todo_file")
+	[[ "$line" == *'verified:2026-06-26'* ]] || fail "expected verified metadata to win cumulative score"
+	[[ "$line" == *'completed:2026-06-27'* ]] || fail "expected completed metadata to win cumulative score"
+	rm -rf "$tmpdir"
+	pass "dedupe scores metadata individually"
+	return 0
+}
+
 main() {
 	test_dedupe_preserves_canonical_brief_line
 	test_mark_done_dedupes_and_adds_verified_proof
+	test_dedupe_ignores_markdown_fences
+	test_dedupe_scores_metadata_individually
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- Ignore fenced markdown task examples during TODO task dedupe.
- Score pr, verified, and completed metadata independently so the richest canonical TODO entry wins.
- Make worker-complete comment parsing tolerate null bodies while leaving gh errors visible.

## Testing
- `bash .agents/tests/test-task-sync-dedupe.sh`
- `shellcheck --severity=warning .agents/scripts/issue-sync-lib-ref.sh .agents/scripts/issue-sync-helper-close.sh .agents/tests/test-task-sync-dedupe.sh`

Resolves #25656
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 6m and 55,113 tokens on this as a headless worker.