### PR TITLE
feat: polish GUI command centre

### DIFF
--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -1,5 +1,5 @@
 /* jshint esversion: 11 */
-import { type ReactElement, type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactElement, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { FiBell, FiChevronLeft, FiChevronRight, FiCommand, FiCpu, FiGlobe, FiHash, FiLogOut, FiMessageSquare, FiSearch, FiSettings, FiShield, FiUser } from "react-icons/fi";
 import type { GuiFileRootId, GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
@@ -54,6 +54,7 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
   status: GuiStatusData;
 }): ReactElement {
   const [assistantOpen, setAssistantOpen] = useState(false);
+  const [commandInitialQuery, setCommandInitialQuery] = useState("");
   const [commandOpen, setCommandOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
@@ -64,6 +65,14 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
     const openCommandPalette = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault();
+        setCommandInitialQuery("");
+        setCommandOpen(true);
+        return;
+      }
+
+      if (event.key === "/" && !isEditableShortcutTarget(event.target)) {
+        event.preventDefault();
+        setCommandInitialQuery("/");
         setCommandOpen(true);
       }
     };
@@ -92,16 +101,18 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
           <h1>{activeItem.label}</h1>
         </div>
       </div>
-      <div className="header-actions">
+      <div className="header-center-controls">
         <div className="sidebar-history-controls workspace-history-controls">
           <button aria-label="Previous surface" disabled={!canGoBack} onClick={goBack} type="button"><FiChevronLeft /></button>
           <button aria-label="Next surface" disabled={!canGoForward} onClick={goForward} type="button"><FiChevronRight /></button>
         </div>
-        <button className="workspace-search command-trigger" onClick={() => setCommandOpen(true)} type="button">
+        <button className="workspace-search command-trigger" onClick={() => { setCommandInitialQuery(""); setCommandOpen(true); }} type="button">
           <FiSearch aria-hidden="true" />
           <span>⌘K</span>
           <strong>{text.searchPlaceholder}</strong>
         </button>
+      </div>
+      <div className="header-actions">
         <div className="header-action-menu">
           <button aria-expanded={notificationsOpen} aria-label="Open notifications" className="header-icon-button" onClick={() => { setNotificationsOpen((current) => !current); setProfileOpen(false); }} type="button">
             <FiBell aria-hidden="true" />
@@ -120,9 +131,17 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
         </div>
       </div>
       {assistantOpen ? <AssistantPanel activeSurface={activeSurface} userName={userName} /> : null}
-      {commandOpen ? <CommandPalette close={() => setCommandOpen(false)} openSurface={openSurface} /> : null}
+      {commandOpen ? <CommandPalette close={() => setCommandOpen(false)} initialQuery={commandInitialQuery} openSurface={openSurface} status={status} /> : null}
     </header>
   );
+}
+
+function isEditableShortcutTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return target.isContentEditable || ["INPUT", "SELECT", "TEXTAREA"].includes(target.tagName);
 }
 
 function NotificationsMenu({ openSurface }: { openSurface: (surface: SurfaceId) => void }): ReactElement {
@@ -216,14 +235,79 @@ function AssistantPanel({ activeSurface, userName }: { activeSurface: SurfaceId;
   );
 }
 
-function CommandPalette({ close, openSurface }: { close: () => void; openSurface: (surface: SurfaceId) => void }): ReactElement {
-  const [query, setQuery] = useState("");
+interface CommandPaletteItem {
+  description: string;
+  icon: SurfaceNavItem["icon"];
+  id: string;
+  label: string;
+  searchText: string;
+  surface: SurfaceId;
+  tag: string;
+}
+
+const slashCommandItems: CommandPaletteItem[] = [
+  { id: "slash-add-device", label: "/add-device", description: "Start device pairing setup", icon: "device", searchText: "/add-device add device pair machine", surface: "devices", tag: "Command" },
+  { id: "slash-add-local-repo", label: "/add-local-repo", description: "Add a local repository path", icon: "folder", searchText: "/add-local-repo add local repo git", surface: "git", tag: "Command" },
+  { id: "slash-add-remote-repo", label: "/add-remote-repo", description: "Register a remote repository", icon: "git", searchText: "/add-remote-repo add remote repo", surface: "projects", tag: "Command" },
+  { id: "slash-add-secret", label: "/add-secret", description: "Add a protected secret reference", icon: "shield", searchText: "/add-secret add secret vault", surface: "security", tag: "Command" },
+  { id: "slash-add-ai-provider", label: "/add-ai-provider", description: "Connect an AI provider account", icon: "users", searchText: "/add-ai-provider add ai provider oauth", surface: "aiProviders", tag: "Command" },
+];
+
+const plannedChannelItems: CommandPaletteItem[] = [
+  { id: "channel-devops", label: "#devops", description: "Chat channel for aidevops operations", icon: "message", searchText: "#devops devops channel chat", surface: "messagingAccounts", tag: "Channel" },
+  { id: "channel-comms", label: "#comms", description: "Chat channel for communications", icon: "message", searchText: "#comms comms channel chat", surface: "messagingAccounts", tag: "Channel" },
+];
+
+function CommandPalette({ close, initialQuery, openSurface, status }: { close: () => void; initialQuery: string; openSurface: (surface: SurfaceId) => void; status: GuiStatusData }): ReactElement {
+  const [query, setQuery] = useState(initialQuery);
+  const inputRef = useRef<HTMLInputElement>(null);
   const matches = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
-    return orderedNavItems
-      .filter((item) => normalizedQuery.length === 0 || `${item.label} ${item.description}`.toLowerCase().includes(normalizedQuery))
+    const surfaceItems: CommandPaletteItem[] = orderedNavItems.map((item) => ({
+      description: item.description,
+      icon: item.icon,
+      id: `surface-${item.id}`,
+      label: item.label,
+      searchText: `${item.label} ${item.description}`,
+      surface: item.id,
+      tag: "Surface",
+    }));
+    const sessionItems: CommandPaletteItem[] = status.opencode_sessions.sessions.map((session) => ({
+      description: `AI session in ${session.repo_path_ref}`,
+      icon: "terminal",
+      id: `session-${session.id_ref}`,
+      label: `#${session.title}`,
+      searchText: `#${session.title} ${session.title} ${session.repo_path_ref} ${session.agent} ${session.model}`,
+      surface: "git",
+      tag: "AI session",
+    }));
+    const directMessageItems: CommandPaletteItem[] = [{
+      description: "Direct message thread placeholder",
+      icon: "users",
+      id: "dm-local-user",
+      label: `@${status.machine.username || "local-user"}`,
+      searchText: `@${status.machine.username || "local-user"} direct message dm person local user`,
+      surface: "messagingAccounts",
+      tag: "Direct message",
+    }];
+    const items = [...surfaceItems, ...sessionItems, ...plannedChannelItems, ...directMessageItems, ...slashCommandItems];
+    const prefix = normalizedQuery.charAt(0);
+    const scopedItems = prefix === "/"
+      ? slashCommandItems
+      : prefix === "@"
+        ? directMessageItems
+        : prefix === "#"
+          ? [...sessionItems, ...plannedChannelItems]
+          : items;
+
+    return scopedItems
+      .filter((item) => normalizedQuery.length === 0 || item.searchText.toLowerCase().includes(normalizedQuery))
       .slice(0, 8);
-  }, [query]);
+  }, [query, status.machine.username, status.opencode_sessions.sessions]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     const closeOnEscape = (event: KeyboardEvent) => {
@@ -242,14 +326,14 @@ function CommandPalette({ close, openSurface }: { close: () => void; openSurface
       <section aria-label="Command palette" className="command-palette">
         <label className="command-input-row">
           <FiSearch aria-hidden="true" />
-          <input onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Search commands and surfaces" value={query} />
+          <input ref={inputRef} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Search commands, #sessions, #channels, @people, or /actions" value={query} />
         </label>
         <ul>
           {matches.map((item) => (
             <li key={item.id}>
-              <button onClick={() => openSurface(item.id)} type="button">
+              <button onClick={() => openSurface(item.surface)} type="button">
                 <span className="surface-icon" aria-hidden="true"><SurfaceGlyph icon={item.icon} /></span>
-                <span><strong>{item.label}</strong><small>{item.description}</small></span>
+                <span><strong>{item.label}</strong><small>{item.tag} · {item.description}</small></span>
               </button>
             </li>
           ))}

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -211,6 +211,7 @@ code {
 .theme-control-heading,
 .appearance-panel-tab,
 .header-title,
+.header-center-controls,
 .header-actions,
 .workspace-search,
 .version-pill,
@@ -801,9 +802,9 @@ code {
   background: color-mix(in srgb, var(--surface-elevated) 94%, transparent);
   border-bottom: 1px solid var(--border);
   display: flex;
-  gap: 16px;
-  min-height: 58px;
-  padding: 10px 14px;
+  gap: 12px;
+  min-height: 54px;
+  padding: 8px 14px;
   position: sticky;
   top: 0;
   z-index: 2;
@@ -811,7 +812,7 @@ code {
 
 .header-title {
   flex: 0 0 auto;
-  gap: 10px;
+  gap: 8px;
   min-width: 0;
 }
 
@@ -819,12 +820,14 @@ code {
   color: var(--text-muted);
   font-size: 0.76rem;
   font-weight: 900;
+  line-height: 1.15;
   margin: 0;
   text-transform: uppercase;
 }
 
 .header-title h1 {
   font-size: 1rem;
+  line-height: 1.15;
   margin: 0;
 }
 
@@ -840,15 +843,25 @@ code {
   align-items: center;
   color: var(--accent);
   display: inline-flex;
-  height: 34px;
+  height: 32px;
   justify-content: center;
-  width: 34px;
+  width: 32px;
 }
 
 .workspace-surface-icon svg {
-  height: 24px;
+  height: 23px;
   stroke-width: 2.2;
-  width: 24px;
+  width: 23px;
+}
+
+.header-center-controls {
+  gap: 10px;
+  left: 50%;
+  max-width: min(560px, 48vw);
+  min-width: 0;
+  position: absolute;
+  transform: translateX(-50%);
+  width: min(560px, 48vw);
 }
 
 .header-actions {
@@ -871,7 +884,7 @@ code {
 
 .command-trigger {
   justify-content: flex-start;
-  max-width: 340px;
+  max-width: none;
 }
 
 .command-trigger strong {
@@ -1055,12 +1068,11 @@ code {
 }
 
 .command-palette-backdrop {
-  align-items: flex-start;
+  align-items: center;
   background: rgb(0 0 0 / 28%);
   display: flex;
   inset: 0;
   justify-content: center;
-  padding-top: 12vh;
   position: fixed;
   z-index: 20;
 }
@@ -1083,6 +1095,7 @@ code {
   max-width: min(680px, calc(100vw - 32px));
   padding: 14px;
   position: relative;
+  transform: translateY(-2vh);
   width: 100%;
 }
 
@@ -2102,10 +2115,18 @@ code {
   }
 
   .workspace-header,
+  .header-center-controls,
   .header-actions,
   .split-heading {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .header-center-controls {
+    max-width: none;
+    position: static;
+    transform: none;
+    width: 100%;
   }
 
   .workspace-search {


### PR DESCRIPTION
## Summary
- Tighten the workspace header title/icon spacing.
- Center the previous/next controls and command search trigger in the top bar.
- Center the command centre modal on the viewport and focus its input when opened.
- Add scoped command centre prefixes for `#` AI sessions/channels, `@` direct-message people, and `/` slash commands including `/add-device`, `/add-local-repo`, `/add-remote-repo`, `/add-secret`, and `/add-ai-provider`.

## Verification
- `bun test packages/gui-web/tests`
- `bunx tsc --noEmit`
- `bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build`
- `git diff --check`

Resolves #25678
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1h 39m and 360,531 tokens on this with the user in an interactive session.