### PR TITLE
fix: center local repo selector label

### DIFF
--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -221,14 +221,14 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConv
       {conversationMode === "people" ? <PeopleChannelList /> : <>
       <button className="new-session-button" disabled title="Creating sessions needs an audited OpenCode write route." type="button">{text.newSession}</button>
       <section className="repo-session-selector" aria-label={text.localRepoSelector}>
-        <button aria-label="Previous local repo" className="selector-step-button" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft aria-hidden="true" /></button>
-        <label>
-          <span>{text.localRepos}</span>
-          <select onChange={(event) => setSelectedLocalRepoIndex(Number.parseInt(event.currentTarget.value, 10))} value={Math.min(selectedLocalRepoIndex, Math.max(0, repos.length - 1))}>
+        <span className="repo-selector-heading" id="local-repo-selector-label">{text.localRepos}</span>
+        <div className="selector-with-stepper repo-selector-row">
+          <button aria-label="Previous local repo" className="selector-step-button" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft aria-hidden="true" /></button>
+          <select aria-labelledby="local-repo-selector-label" onChange={(event) => setSelectedLocalRepoIndex(Number.parseInt(event.currentTarget.value, 10))} value={Math.min(selectedLocalRepoIndex, Math.max(0, repos.length - 1))}>
             {repos.length === 0 ? <option value={0}>No local repos</option> : repos.map((repo, index) => <option key={repo.path_ref} value={index}>{repo.name}</option>)}
           </select>
-        </label>
-        <button aria-label="Next local repo" className="selector-step-button" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight aria-hidden="true" /></button>
+          <button aria-label="Next local repo" className="selector-step-button" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight aria-hidden="true" /></button>
+        </div>
       </section>
       <section className="sidebar-group session-history-list">
         <h2>{text.sessionHistory}</h2>

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -377,10 +377,8 @@ code {
 }
 
 .repo-session-selector {
-  align-items: end;
   display: grid;
-  gap: 8px;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 7px;
 }
 
 .selector-with-stepper {
@@ -420,17 +418,16 @@ code {
   width: 18px;
 }
 
-.repo-session-selector label {
-  display: grid;
-  gap: 5px;
-  min-width: 0;
-}
-
-.repo-session-selector label span {
+.repo-selector-heading {
   color: var(--text-muted);
   font-size: 0.72rem;
   font-weight: 900;
+  text-align: center;
   text-transform: uppercase;
+}
+
+.repo-selector-row {
+  align-items: center;
 }
 
 .repo-session-selector select {


### PR DESCRIPTION
## Summary
- Moves the Local Repos heading out of the dropdown/button alignment row.
- Centers the Local Repos heading above the selector row.
- Keeps the previous/next buttons and dropdown in the shared middle-aligned stepper row.

## Verification
- `bun test packages/gui-web/tests`
- `bun run typecheck`
- `bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build`
- `.agents/scripts/linters-local.sh` partially ran: SonarCloud, Qlty threshold, string literal, FD lock, ShellCheck RC parity passed/within thresholds; timed out during Secretlint on the broad local suite.

Resolves #25680
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.25.1 with gpt-5.5 spent 1h 37m and 527,384 tokens on this with the user in an interactive session.