### PR TITLE
GH#25687: chore: document diskcache no-patch status

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,6 +23,7 @@ cloudpickle==3.1.2
 colorlog==6.10.1
 datasets==4.4.1
 dill==0.4.0
+# KNOWN: no patched diskcache release; retained because dspy requires diskcache>=5.6.0.
 diskcache==5.6.3
 distro==1.9.0
 dspy==3.1.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ requests==2.33.0
 
 # Data processing and storage
 datasets==4.4.1
-diskcache==5.6.3  # KNOWN: CVE-2025-69872 — no patch available yet, monitor for update
+diskcache==5.6.3  # KNOWN: no patched release; transitive via dspy, monitor for replacement/update
 joblib==1.5.2
 
 # Optimization and experimentation


### PR DESCRIPTION
## Summary

Documented neutral no-patch risk acceptance for diskcache in requirements.txt and requirements-lock.txt after resolver evidence showed dspy requires diskcache>=5.6.0 and PyPI has no newer release.

## Files Changed

requirements-lock.txt,requirements.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m pip install --dry-run -r requirements.txt in isolated venv; pip-audit -r requirements.txt in isolated venv (confirms diskcache CVE remains no-fix); .agents/scripts/tests/test-dependabot-alert-monitor.sh; .agents/scripts/linters-local.sh

Resolves #25687


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 7m and 61,778 tokens on this as a headless worker.