### PR TITLE
GH#25682: fix: reduce diskcache direct alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@
 # Update versions deliberately via requirements-lock.txt, not automatically.
 
 # Core DSPy packages (dspy-ai was a legacy alias, removed in favour of dspy)
+# KNOWN: dspy resolves diskcache transitively and no patched diskcache release is
+# available yet. Avoid a direct application pin; keep the audited transitive pin
+# in requirements-lock.txt until dspy can resolve a fixed version or replacement.
 dspy==3.1.0b1
 
 # Core dependencies for AI/ML workflows
@@ -21,7 +24,6 @@ requests==2.33.0
 
 # Data processing and storage
 datasets==4.4.1
-diskcache==5.6.3  # KNOWN: no patched release; transitive via dspy, monitor for replacement/update
 joblib==1.5.2
 
 # Optimization and experimentation


### PR DESCRIPTION
## Summary

Removed the direct diskcache pin from requirements.txt after merged no-patch documentation established it is a dspy transitive dependency; kept the audited lock-file pin and documented that the direct requirements file should avoid an application-level diskcache pin until a patched release or replacement exists.

## Files Changed

requirements.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m pip install --dry-run --ignore-installed -r requirements.txt (diskcache selected via dspy>=5.6.0); python3 -m pip_audit -r requirements.txt (reports diskcache 5.6.3 with no fix version); .agents/scripts/linters-local.sh (ALL LOCAL CHECKS PASSED)

Resolves #25682


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.27.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 21m and 142,045 tokens on this as a headless worker.