### PR TITLE
feat: add GUI managed apps controls

### DIFF
--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -1,7 +1,36 @@
+import { spawn } from "node:child_process";
 import { Hono } from "hono";
-import { BANNED_ROUTE_PATTERNS, FILE_EXPLORER_ROUTE_MANIFEST, STATUS_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
+import { APP_ACTION_ROUTE_MANIFEST, APP_ACTION_STATUS_ROUTE_MANIFEST, BANNED_ROUTE_PATTERNS, createEnvelope, FILE_EXPLORER_ROUTE_MANIFEST, type GuiAppActionId, type GuiAppActionJobSummary, STATUS_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
 import { readFileExplorer } from "./file-adapter";
 import { readStatus, readVaultStatus } from "./status-adapter";
+
+const appActionCommands: Record<string, Partial<Record<GuiAppActionId, string[]>>> = {
+  aidevops: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update"], reinstall: ["./setup.sh", "--non-interactive"] },
+  agents: { install: ["aidevops", "setup", "--scope", "agents"], update: ["aidevops", "setup", "--scope", "agents"], reinstall: ["aidevops", "setup", "--scope", "agents"] },
+  "gui-desktop": { install: ["aidevops", "setup", "--scope", "gui-desktop"], update: ["aidevops", "setup", "--scope", "gui-desktop"], reinstall: ["aidevops", "setup", "--scope", "gui-desktop"] },
+  hooks: { install: ["aidevops", "setup", "--scope", "hooks"], update: ["aidevops", "setup", "--scope", "hooks"], reinstall: ["aidevops", "setup", "--scope", "hooks"] },
+  opencode: { install: ["aidevops", "setup", "--scope", "opencode"], update: ["aidevops", "setup", "--scope", "opencode"], reinstall: ["aidevops", "setup", "--scope", "opencode"] },
+  pulse: { install: ["aidevops", "setup", "--scope", "pulse"], update: ["aidevops", "setup", "--scope", "pulse"], reinstall: ["aidevops", "setup", "--scope", "pulse"] },
+  tabby: { install: ["aidevops", "setup", "--scope", "tabby"], update: ["aidevops", "setup", "--scope", "tabby"], reinstall: ["aidevops", "setup", "--scope", "tabby"] },
+  bun: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  cursor: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  fd: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  gh: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  glab: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  homebrew: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  node: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  ollama: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  orbstack: { install: ["./setup.sh", "--non-interactive"] },
+  qlty: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  ripgrep: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  "ripgrep-all": { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  rtk: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  shellcheck: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  shfmt: { install: ["./setup.sh", "--non-interactive"], update: ["aidevops", "update-tools", "--update"] },
+  zed: { install: ["./setup.sh", "--non-interactive"] },
+};
+
+const appActionJobs = new Map<string, GuiAppActionJobSummary>();
 
 export function createGuiApiApp() {
   const app = new Hono();
@@ -12,6 +41,48 @@ export function createGuiApiApp() {
 
   app.get(VAULT_STATUS_ROUTE_MANIFEST.route, (context) => {
     return context.json(readVaultStatus());
+  });
+
+  app.post(APP_ACTION_ROUTE_MANIFEST.route, (context) => {
+    const appId = context.req.param("appId");
+    const action = context.req.param("action") as GuiAppActionId;
+    const command = appActionCommands[appId]?.[action];
+
+    if (command === undefined) {
+      return context.json(createEnvelope({
+        operation_id: APP_ACTION_ROUTE_MANIFEST.operation_id,
+        source: { surface: "apps", authority: "allowlisted local command runner", path_refs: [] },
+        data: rejectedJob(appId, action, "No allowlisted command for this app action."),
+        errors: ["action_not_allowlisted"],
+      }), 400);
+    }
+
+    const job = startAppActionJob(appId, action, command);
+    return context.json(createEnvelope({
+      operation_id: APP_ACTION_ROUTE_MANIFEST.operation_id,
+      source: { surface: "apps", authority: "allowlisted local command runner", path_refs: ["setup.sh", "aidevops.sh"] },
+      data: job,
+      warnings: ["Command runs locally in the background. Output is retained in memory for this GUI API process only."],
+    }), 202);
+  });
+
+  app.get(APP_ACTION_STATUS_ROUTE_MANIFEST.route, (context) => {
+    const jobId = context.req.param("jobId");
+    const job = appActionJobs.get(jobId);
+    if (job === undefined) {
+      return context.json(createEnvelope({
+        operation_id: APP_ACTION_STATUS_ROUTE_MANIFEST.operation_id,
+        source: { surface: "apps", authority: "background job store", path_refs: [] },
+        data: rejectedJob("unknown", "install", "Unknown job."),
+        errors: ["unknown_job"],
+      }), 404);
+    }
+
+    return context.json(createEnvelope({
+      operation_id: APP_ACTION_STATUS_ROUTE_MANIFEST.operation_id,
+      source: { surface: "apps", authority: "background job store", path_refs: [] },
+      data: job,
+    }));
   });
 
   app.get(FILE_EXPLORER_ROUTE_MANIFEST.route, (context) => {
@@ -48,6 +119,59 @@ export function createGuiApiApp() {
   });
 
   return app;
+}
+
+function startAppActionJob(appId: string, action: GuiAppActionId, command: string[]): GuiAppActionJobSummary {
+  const now = new Date().toISOString();
+  const job: GuiAppActionJobSummary = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    app_id: appId,
+    action,
+    status: "running",
+    command_preview: command.join(" "),
+    started_at: now,
+    finished_at: null,
+    exit_code: null,
+    output: [`$ ${command.join(" ")}`],
+  };
+  appActionJobs.set(job.id, job);
+
+  const child = spawn(command[0], command.slice(1), {
+    cwd: process.cwd(),
+    env: { ...process.env, AIDEVOPS_NON_INTERACTIVE: "true" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (chunk) => appendJobOutput(job, chunk.toString()));
+  child.stderr.on("data", (chunk) => appendJobOutput(job, chunk.toString()));
+  child.on("error", (error) => {
+    appendJobOutput(job, error.message);
+    job.status = "failed";
+    job.finished_at = new Date().toISOString();
+    job.exit_code = 127;
+  });
+  child.on("close", (code) => {
+    job.status = code === 0 ? "completed" : "failed";
+    job.finished_at = new Date().toISOString();
+    job.exit_code = code;
+  });
+
+  return job;
+}
+
+function appendJobOutput(job: GuiAppActionJobSummary, output: string): void {
+  job.output.push(...output.split(/\r?\n/).filter((line) => line.length > 0).map(redactOutputLine));
+  if (job.output.length > 400) {
+    job.output.splice(1, job.output.length - 400);
+  }
+}
+
+function redactOutputLine(line: string): string {
+  return line.replace(/(token|secret|password|authorization)=\S+/gi, "$1=[redacted]");
+}
+
+function rejectedJob(appId: string, action: GuiAppActionId, message: string): GuiAppActionJobSummary {
+  const now = new Date().toISOString();
+  return { id: "rejected", app_id: appId, action, status: "rejected", command_preview: "not run", started_at: now, finished_at: now, exit_code: null, output: [message] };
 }
 
 export const app = createGuiApiApp();

--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -1,19 +1,19 @@
+import { Database } from "bun:sqlite";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { hostname, networkInterfaces, userInfo } from "node:os";
 import { join } from "node:path";
-import { Database } from "bun:sqlite";
 import {
-  type GuiLocalRepoSetupSummary,
-  type GuiOpenCodeSessionRegistrySummary,
-  type GuiOpenCodeSessionSummary,
   assertNoSecretSentinels,
   createEnvelope,
-  VAULT_STATUS_ROUTE_MANIFEST,
   type GuiAiAppSummary,
   type GuiAiProviderId,
+  type GuiLocalRepoSetupSummary,
+  type GuiManagedAppSummary,
   type GuiOAuthPoolSummary,
   type GuiOAuthProviderSummary,
+  type GuiOpenCodeSessionRegistrySummary,
+  type GuiOpenCodeSessionSummary,
   type GuiRepoRegistrySummary,
   type GuiRepoSummary,
   type GuiResponseEnvelope,
@@ -22,6 +22,7 @@ import {
   type GuiStatusData,
   type GuiVaultStatusData,
   statusFixture,
+  VAULT_STATUS_ROUTE_MANIFEST,
 } from "../../gui-shared/src";
 import {
   collapseHome,
@@ -69,6 +70,7 @@ export function readStatus(
   const restartRequired = installedVersion !== aidevopsVersion;
   const setupTargets = readSetupTargets(aidevopsVersion || "unknown", installedVersion || "unknown");
   const aiApps = readAiApps(aidevopsVersion || "unknown", installedVersion || "unknown");
+  const managedApps = readManagedApps(aidevopsVersion || "unknown", installedVersion || "unknown");
   const localRepos = readLocalReposSetupSummary(reposPath);
   const opencodeSessions = readOpenCodeSessions(opencodeDbPath, opencodeDbPathRef, localRepos.repos);
   const vault = readVaultSummary(repoRoot);
@@ -82,6 +84,7 @@ export function readStatus(
     "VERSION",
     ...setupTargets.map((target) => target.path_ref),
     ...aiApps.flatMap((app) => [app.app_path_ref, app.binary_path_ref, app.config_path_ref, app.aidevops_target_path_ref]),
+    ...managedApps.map((app) => app.install_path_ref),
   ].filter(isSourcePathRef);
 
   const data: GuiStatusData = {
@@ -128,6 +131,7 @@ export function readStatus(
     oauth_pool: readOAuthPoolSummary(oauthPoolPath, oauthPoolPathRef),
     setup_targets: setupTargets,
     ai_apps: aiApps,
+    managed_apps: managedApps,
     vault,
   };
 
@@ -215,6 +219,22 @@ interface AiAppDefinition {
   version_args: string[];
 }
 
+interface ManagedAppDefinition {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  binary: string | null;
+  version_args: string[];
+  install_path_refs: string[];
+  origin_website_url: string;
+  origin_repo_url: string;
+  aidevops_install: boolean;
+  aidevops_update: boolean;
+  latest_version_source: "aidevops" | "binary" | "unknown";
+  action_commands: Partial<Record<"install" | "update" | "reinstall" | "remove", string>>;
+}
+
 const AI_APP_DEFINITIONS: AiAppDefinition[] = [
   {
     name: "OpenCode",
@@ -249,6 +269,36 @@ const AI_APP_DEFINITIONS: AiAppDefinition[] = [
     version_args: [],
   },
 ];
+
+const MANAGED_APP_DEFINITIONS: ManagedAppDefinition[] = [
+  managedApp("aidevops", "aidevops", "Framework CLI, agents, workflows, scripts, and local GUI assets.", "core", "aidevops", ["--version"], ["~/.aidevops/agents", "/opt/homebrew/bin/aidevops", "/usr/local/bin/aidevops"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "./setup.sh --non-interactive", update: "aidevops update", reinstall: "./setup.sh --non-interactive" }),
+  managedApp("agents", "Deployed agents", "Canonical aidevops agents, commands, workflows, scripts, and reference files.", "core", null, [], ["~/.aidevops/agents/VERSION"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope agents", update: "aidevops setup --scope agents", reinstall: "aidevops setup --scope agents" }),
+  managedApp("gui-desktop", "aidevops.app", "Native macOS desktop launcher for the local GUI.", "desktop", null, [], ["~/Applications/aidevops.app", "/Applications/aidevops.app"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope gui-desktop", update: "aidevops setup --scope gui-desktop", reinstall: "aidevops setup --scope gui-desktop" }),
+  managedApp("opencode", "OpenCode", "AI terminal runtime configured by aidevops for local sessions.", "ai runtime", "opencode", ["--version"], ["~/Applications/OpenCode AIDevOps.app", "/Applications/OpenCode.app", "~/.config/opencode/opencode.json"], "https://opencode.ai", "", true, true, "binary", { install: "aidevops setup --scope opencode", update: "aidevops setup --scope opencode", reinstall: "aidevops setup --scope opencode" }),
+  managedApp("hooks", "Safety hooks", "Git, prompt, privacy, complexity, task-id, and canonical-install guards.", "safety", null, [], ["~/.aidevops/hooks", "~/.config/aidevops"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope hooks", update: "aidevops setup --scope hooks", reinstall: "aidevops setup --scope hooks" }),
+  managedApp("pulse", "Pulse scheduler", "Launchd/cron supervisor for autonomous aidevops maintenance and dispatch routines.", "automation", null, [], ["~/Library/LaunchAgents/sh.aidevops.pulse.plist", "~/.aidevops/.agent-workspace/pulse"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope pulse", update: "aidevops setup --scope pulse", reinstall: "aidevops setup --scope pulse" }),
+  managedApp("tabby", "Tabby terminal profiles", "Terminal profile sync for aidevops-managed shells.", "terminal", "tabby", ["--version"], ["~/Library/Application Support/tabby", "/Applications/Tabby.app"], "https://github.com/Eugeny/tabby/releases/latest", "https://github.com/Eugeny/tabby/releases/latest", true, true, "binary", { install: "aidevops setup --scope tabby", update: "aidevops setup --scope tabby", reinstall: "aidevops setup --scope tabby" }),
+  managedApp("gh", "GitHub CLI", "GitHub issues, PRs, checks, releases, and API automation.", "git", "gh", ["--version"], ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("glab", "GitLab CLI", "GitLab repository, issue, merge request, and CI automation.", "git", "glab", ["--version"], ["/opt/homebrew/bin/glab", "/usr/local/bin/glab", "/usr/bin/glab"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("fd", "fd", "Fast file discovery for agents and developer workflows.", "search", "fd", ["--version"], ["/opt/homebrew/bin/fd", "/usr/local/bin/fd", "/usr/bin/fd"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("ripgrep", "ripgrep", "Fast code and text search used by agents and local diagnostics.", "search", "rg", ["--version"], ["/opt/homebrew/bin/rg", "/usr/local/bin/rg", "/usr/bin/rg"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("ripgrep-all", "ripgrep-all", "Document/archive-aware search companion for ripgrep.", "search", "rga", ["--version"], ["/opt/homebrew/bin/rga", "/usr/local/bin/rga", "/usr/bin/rga"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("shellcheck", "ShellCheck", "Shell script static analysis gate.", "quality", "shellcheck", ["--version"], ["/opt/homebrew/bin/shellcheck", "/usr/local/bin/shellcheck", "/usr/bin/shellcheck"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("shfmt", "shfmt", "Shell formatter used by local quality workflows.", "quality", "shfmt", ["--version"], ["/opt/homebrew/bin/shfmt", "/usr/local/bin/shfmt", "/usr/bin/shfmt"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("bun", "Bun", "JavaScript runtime used for the GUI and toolchain helpers.", "runtime", "bun", ["--version"], ["~/.bun/bin/bun", "/opt/homebrew/bin/bun", "/usr/local/bin/bun"], "https://bun.sh/install", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("node", "Node.js", "JavaScript runtime required by npm-hosted helpers and frontend tooling.", "runtime", "node", ["--version"], ["/opt/homebrew/bin/node", "/usr/local/bin/node", "/usr/bin/node"], "https://nodejs.org/", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("homebrew", "Homebrew", "macOS package manager used by setup/update when available.", "package manager", "brew", ["--version"], ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"], "https://brew.sh", "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("qlty", "Qlty CLI", "Optional code quality aggregator installed by setup when selected.", "quality", "qlty", ["--version"], ["/opt/homebrew/bin/qlty", "/usr/local/bin/qlty", "~/.qlty/bin/qlty"], "https://qlty.sh", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("rtk", "rtk", "Token-optimized GitHub/API helper used by interactive discovery.", "developer tooling", "rtk", ["--version"], ["~/.local/bin/rtk", "/opt/homebrew/bin/rtk", "/usr/local/bin/rtk"], "https://github.com/rtk-ai/rtk#installation", "https://github.com/rtk-ai/rtk", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("cursor", "Cursor CLI", "Cursor command-line integration and config targets.", "ai runtime", "cursor", ["--version"], ["~/.cursor/bin/cursor", "/Applications/Cursor.app"], "https://cursor.com/install", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+  managedApp("zed", "Zed", "Optional editor installed by setup when selected.", "editor", "zed", ["--version"], ["/Applications/Zed.app", "/opt/homebrew/bin/zed", "/usr/local/bin/zed"], "https://zed.dev/download", "", false, false, "binary", { install: "./setup.sh --non-interactive" }),
+  managedApp("orbstack", "OrbStack", "Optional local container/VM runtime for macOS development.", "runtime", "orb", ["version"], ["/Applications/OrbStack.app", "/opt/homebrew/bin/orb"], "https://orbstack.dev/", "", false, false, "binary", { install: "./setup.sh --non-interactive" }),
+  managedApp("ollama", "Ollama", "Optional local model runtime for local AI workflows.", "ai runtime", "ollama", ["--version"], ["/Applications/Ollama.app", "/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"], "https://ollama.com", "", false, false, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
+];
+
+function managedApp(id: string, name: string, description: string, category: string, binary: string | null, versionArgs: string[], installPathRefs: string[], originWebsiteUrl: string, originRepoUrl: string, aidevopsInstall: boolean, aidevopsUpdate: boolean, latestVersionSource: ManagedAppDefinition["latest_version_source"], actionCommands: ManagedAppDefinition["action_commands"]): ManagedAppDefinition {
+  return { id, name, description, category, binary, version_args: versionArgs, install_path_refs: installPathRefs, origin_website_url: originWebsiteUrl, origin_repo_url: originRepoUrl, aidevops_install: aidevopsInstall, aidevops_update: aidevopsUpdate, latest_version_source: latestVersionSource, action_commands: actionCommands };
+}
 
 function readMachineSummary(): GuiStatusData["machine"] {
   const username = userInfo().username || "local";
@@ -390,6 +440,55 @@ function readAiApps(latestVersion: string, installedVersion: string): GuiAiAppSu
   return AI_APP_DEFINITIONS.map((definition) => aiAppSummary(definition, latestVersion, installedVersion));
 }
 
+function readManagedApps(latestVersion: string, installedVersion: string): GuiManagedAppSummary[] {
+  return MANAGED_APP_DEFINITIONS.map((definition) => managedAppSummary(definition, latestVersion, installedVersion));
+}
+
+function managedAppSummary(definition: ManagedAppDefinition, latestVersion: string, installedVersion: string): GuiManagedAppSummary {
+  const binaryPath = definition.binary === null ? null : resolveBinary(definition.binary);
+  const installPathRef = firstExistingPathRef(definition.install_path_refs) ?? definition.install_path_refs[0] ?? "not found";
+  const installedVersionText = readManagedAppVersion(definition, binaryPath, installedVersion);
+  const latestVersionText = definition.latest_version_source === "aidevops"
+    ? latestVersion
+    : definition.latest_version_source === "binary"
+      ? installedVersionText
+      : "unknown";
+
+  return {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    category: definition.category,
+    origin_website_url: definition.origin_website_url,
+    origin_repo_url: definition.origin_repo_url,
+    aidevops_install: definition.aidevops_install,
+    aidevops_update: definition.aidevops_update,
+    installed_version: installedVersionText,
+    latest_version: latestVersionText,
+    install_path_ref: binaryPath === null ? installPathRef : collapseHome(binaryPath),
+    status: binaryPath !== null || definition.install_path_refs.some((pathRef) => existsSync(expandHome(pathRef))) ? "found" : "missing",
+    actions: (["install", "update", "reinstall", "remove"] as const).map((action) => ({
+      id: action,
+      label: action[0].toUpperCase() + action.slice(1),
+      enabled: definition.action_commands[action] !== undefined,
+      command_preview: definition.action_commands[action] ?? "No allowlisted command yet",
+      confirmation: action === "remove" ? "required" : action === "reinstall" ? "recommended" : "none",
+    })),
+  };
+}
+
+function readManagedAppVersion(definition: ManagedAppDefinition, binaryPath: string | null, installedVersion: string): string {
+  if (definition.latest_version_source === "aidevops") {
+    return firstExistingPathRef(definition.install_path_refs) === null ? "not installed" : installedVersion;
+  }
+
+  if (binaryPath === null) {
+    return "not installed";
+  }
+
+  return readBinaryVersion(binaryPath, definition.version_args);
+}
+
 function aiAppSummary(definition: AiAppDefinition, latestVersion: string, installedVersion: string): GuiAiAppSummary {
   const binaryPath = resolveBinary(definition.binary);
   const appPathRef = firstExistingPathRef(definition.app_path_refs) ?? definition.app_path_refs[0] ?? "not applicable";
@@ -421,7 +520,7 @@ function resolveBinary(binary: string): string | null {
     const output = execFileSync("/usr/bin/which", [binary], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
-      timeout: 1_000,
+      timeout: 200,
     }).trim();
     return output.split("\n").find((line) => line.length > 0) ?? null;
   } catch {
@@ -515,7 +614,7 @@ function readBinaryVersion(binaryPath: string, args: string[]): string {
     const output = execFileSync(binaryPath, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
-      timeout: 1_500,
+      timeout: 500,
     }).trim();
     return output.split("\n").find((line) => line.length > 0) ?? "unknown";
   } catch {

--- a/packages/gui-api/tests/status-route.test.ts
+++ b/packages/gui-api/tests/status-route.test.ts
@@ -10,6 +10,16 @@ describe("status API route", () => {
     expect(body.ok).toBe(true);
     expect(body.operation_id).toBe("setup.status.read");
     expect(body.redactions).toContain("secret_values");
+    expect(body.data.managed_apps.map((app: { id: string }) => app.id)).toContain("aidevops");
+  });
+
+  test("app actions reject commands outside the allowlist", async () => {
+    const response = await app.request("/api/apps/not-real/actions/install", { method: "POST" });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.operation_id).toBe("apps.action.run");
+    expect(body.errors).toContain("action_not_allowlisted");
   });
 
   test("unknown routes fail closed", async () => {

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -1,6 +1,6 @@
 export type GuiRouteClassification = "read" | "write" | "destructive";
 
-export type GuiOperationId = "setup.status.read" | "capabilities.read" | "filesystem.read" | "vault.status.read";
+export type GuiOperationId = "setup.status.read" | "capabilities.read" | "filesystem.read" | "vault.status.read" | "apps.action.run" | "apps.action.status";
 
 export type GuiFileRootId = "agents" | "config" | "localSetup" | "git";
 
@@ -23,7 +23,7 @@ export interface GuiResponseEnvelope<TData> {
 
 export interface GuiRouteManifest {
   route: string;
-  method: "GET";
+  method: "GET" | "POST";
   operation_id: GuiOperationId;
   classification: GuiRouteClassification;
   source_surface: string;
@@ -66,6 +66,44 @@ export interface GuiFileExplorerData {
   entries: GuiFileEntry[];
   selected_preview: GuiFilePreview | null;
   entry_limit: number;
+}
+
+export type GuiAppActionId = "install" | "update" | "reinstall" | "remove";
+
+export interface GuiManagedAppActionSummary {
+  id: GuiAppActionId;
+  label: string;
+  enabled: boolean;
+  command_preview: string;
+  confirmation: "none" | "recommended" | "required";
+}
+
+export interface GuiManagedAppSummary {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  origin_website_url: string;
+  origin_repo_url: string;
+  aidevops_install: boolean;
+  aidevops_update: boolean;
+  installed_version: string;
+  latest_version: string;
+  install_path_ref: string;
+  status: "found" | "missing" | "unchecked";
+  actions: GuiManagedAppActionSummary[];
+}
+
+export interface GuiAppActionJobSummary {
+  id: string;
+  app_id: string;
+  action: GuiAppActionId;
+  status: "running" | "completed" | "failed" | "rejected";
+  command_preview: string;
+  started_at: string;
+  finished_at: string | null;
+  exit_code: number | null;
+  output: string[];
 }
 
 export interface GuiSecretReference {
@@ -318,6 +356,7 @@ export interface GuiStatusData {
   oauth_pool: GuiOAuthPoolSummary;
   setup_targets: GuiSetupTargetSummary[];
   ai_apps: GuiAiAppSummary[];
+  managed_apps: GuiManagedAppSummary[];
   vault: GuiVaultStatusData;
   capabilities: GuiCapabilitySummary[];
   secrets: GuiSecretReference[];
@@ -355,6 +394,28 @@ export const VAULT_STATUS_ROUTE_MANIFEST: GuiRouteManifest = {
   adapter: "statusAdapter.readVaultStatus",
   command_pattern: ["aidevops", "vault", "status"],
   redactions: ["secret_values", "credential_paths", "private_key_material", "vault_passphrases", "recovery_material"],
+};
+
+export const APP_ACTION_ROUTE_MANIFEST: GuiRouteManifest = {
+  route: "/api/apps/:appId/actions/:action",
+  method: "POST",
+  operation_id: "apps.action.run",
+  classification: "write",
+  source_surface: "apps",
+  adapter: "appActions.startAppAction",
+  command_pattern: ["allowlisted", "aidevops", "setup/update", "background-job"],
+  redactions: ["secret_values", "credential_paths", "private_key_material"],
+};
+
+export const APP_ACTION_STATUS_ROUTE_MANIFEST: GuiRouteManifest = {
+  route: "/api/apps/jobs/:jobId",
+  method: "GET",
+  operation_id: "apps.action.status",
+  classification: "read",
+  source_surface: "apps",
+  adapter: "appActions.readAppActionJob",
+  command_pattern: ["background-job", "metadata-and-output-only"],
+  redactions: ["secret_values", "credential_paths", "private_key_material"],
 };
 
 export const GUI_FILE_ROOTS: readonly GuiFileRootDefinition[] = [

--- a/packages/gui-shared/src/fixtures.ts
+++ b/packages/gui-shared/src/fixtures.ts
@@ -162,6 +162,7 @@ export const statusFixture: GuiStatusData = {
       needs_update: false,
     },
   ],
+  managed_apps: [],
   vault: {
     status: "uninitialized",
     setup_state: "uninitialized",

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -274,7 +274,7 @@ function SurfaceContent({ activeItem, activeSurface, fileRoot, status }: {
     maintenance: <PlannedSurface label={text.maintenance} detail={text.projectWorkIntro} />,
     performance: <PlannedSurface label={text.performance} detail={text.projectWorkIntro} />,
     reports: <PlannedSurface label={text.reports} detail={text.projectWorkIntro} />,
-    apps: <AppsSurface />,
+    apps: <AppsSurface status={status} />,
     installation: <InstallationSurface />,
     projects: <ProjectsSurface status={status} />,
     security: <SecuritySurface status={status} />,

--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -1,6 +1,8 @@
-import { type ReactElement, useState } from "react";
+import type { GuiAppActionId, GuiAppActionJobSummary, GuiManagedAppSummary, GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
+import { type Dispatch, type ReactElement, type SetStateAction, useEffect, useState } from "react";
+import { FiDownload, FiExternalLink, FiRefreshCw, FiRepeat, FiTrash2 } from "react-icons/fi";
 import type { InventoryColumn } from "./app-model";
-import { appRows, installationRows, text } from "./app-model";
+import { installationRows, text } from "./app-model";
 
 interface DraftInventoryRow {
   id: string;
@@ -9,7 +11,23 @@ interface DraftInventoryRow {
 
 let draftRowCounter = 0;
 
-export function AppsSurface(): ReactElement {
+export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement {
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [jobs, setJobs] = useState<Record<string, GuiAppActionJobSummary>>({});
+  const selectedJob = selectedJobId === null ? null : jobs[selectedJobId] ?? null;
+
+  useEffect(() => {
+    if (selectedJob === null || selectedJob.status !== "running") {
+      return undefined;
+    }
+
+    const timer = window.setInterval(() => {
+      void refreshJob(selectedJob.id, setJobs);
+    }, 1_500);
+
+    return () => window.clearInterval(timer);
+  }, [selectedJob]);
+
   return (
     <section className="panel" aria-label={text.apps}>
       <div className="section-heading">
@@ -17,14 +35,96 @@ export function AppsSurface(): ReactElement {
         <h2>{text.apps}</h2>
         <p>{text.appsIntro}</p>
       </div>
-      <div className="data-table">
-        <div className="data-row header-row"><span>{text.name}</span><span>{text.latest}</span><span>{text.channel}</span><span>{text.website}</span></div>
-        {appRows.map((row) => (
-          <div className="data-row" key={row.name}><span>{row.name}</span><span>{row.latest}</span><span>{row.channel}</span><span>{row.website}</span></div>
+      <div className="managed-app-list">
+        {status.managed_apps.map((app) => (
+          <ManagedAppRow app={app} key={app.id} onJob={(job) => { setJobs((current) => ({ ...current, [job.id]: job })); setSelectedJobId(job.id); }} />
         ))}
       </div>
+      {selectedJob ? <AppActionTerminal job={selectedJob} /> : <p className="empty-state compact-notice">Install/update actions run as allowlisted background jobs and stream here. xterm.js with a node-pty bridge is the right next step for full TUI apps such as OpenCode; this view starts with non-interactive command logs.</p>}
     </section>
   );
+}
+
+function ManagedAppRow({ app, onJob }: { app: GuiManagedAppSummary; onJob: (job: GuiAppActionJobSummary) => void }): ReactElement {
+  return (
+    <article className="managed-app-row">
+      <div className="managed-app-main">
+        <div>
+          <p className="eyebrow">{app.category}</p>
+          <h3>{app.name}</h3>
+          <p>{app.description}</p>
+        </div>
+        <div className="managed-app-links">
+          <OriginLink href={app.origin_website_url} label={text.website} />
+          <OriginLink href={app.origin_repo_url} label="Repo" />
+        </div>
+      </div>
+      <div className="managed-app-details">
+        <ToggleSwitch checked={app.aidevops_install} label="setup installs" />
+        <ToggleSwitch checked={app.aidevops_update} label="update maintains" />
+        <AppMeta label="Installed" value={app.installed_version} />
+        <AppMeta label="Latest" value={app.latest_version} />
+        <AppMeta label={text.path} value={app.install_path_ref} />
+        <AppMeta label="Status" value={app.status} />
+      </div>
+      <div className="managed-app-actions">
+        {app.actions.map((action) => <AppActionButton action={action.id} app={app} disabled={!action.enabled} key={action.id} onJob={onJob} title={action.command_preview} />)}
+      </div>
+    </article>
+  );
+}
+
+function OriginLink({ href, label }: { href: string; label: string }): ReactElement {
+  if (href.length === 0) {
+    return <span className="origin-missing">{label}: source pending</span>;
+  }
+
+  return <a href={href} rel="noreferrer" target="_blank">{label} <FiExternalLink aria-hidden="true" /></a>;
+}
+
+function ToggleSwitch({ checked, label }: { checked: boolean; label: string }): ReactElement {
+  return <span className="managed-toggle"><span aria-hidden="true" className={checked ? "switch-track checked" : "switch-track"}><span /></span>{label}</span>;
+}
+
+function AppMeta({ label, value }: { label: string; value: string }): ReactElement {
+  return <span className="app-meta"><small>{label}</small><strong>{value}</strong></span>;
+}
+
+function AppActionButton({ action, app, disabled, onJob, title }: { action: GuiAppActionId; app: GuiManagedAppSummary; disabled: boolean; onJob: (job: GuiAppActionJobSummary) => void; title: string }): ReactElement {
+  const icon = action === "install" ? <FiDownload /> : action === "update" ? <FiRefreshCw /> : action === "reinstall" ? <FiRepeat /> : <FiTrash2 />;
+
+  async function runAction(): Promise<void> {
+    if (disabled) {
+      return;
+    }
+    if ((action === "remove" || action === "reinstall") && !window.confirm(`${action} ${app.name}?`)) {
+      return;
+    }
+
+    const response = await fetch(`/api/apps/${encodeURIComponent(app.id)}/actions/${action}`, { method: "POST" });
+    const envelope = await response.json() as GuiResponseEnvelope<GuiAppActionJobSummary>;
+    onJob(envelope.data);
+  }
+
+  return <button aria-label={`${action} ${app.name}`} className="app-action-button" disabled={disabled} onClick={() => void runAction()} title={title} type="button">{icon}</button>;
+}
+
+function AppActionTerminal({ job }: { job: GuiAppActionJobSummary }): ReactElement {
+  return (
+    <section className="app-terminal" aria-label="App action terminal output">
+      <header><strong>{job.app_id} {job.action}</strong><span>{job.status}{job.exit_code === null ? "" : ` (${job.exit_code})`}</span></header>
+      <pre>{job.output.join("\n")}</pre>
+    </section>
+  );
+}
+
+async function refreshJob(jobId: string, setJobs: Dispatch<SetStateAction<Record<string, GuiAppActionJobSummary>>>): Promise<void> {
+  const response = await fetch(`/api/apps/jobs/${encodeURIComponent(jobId)}`);
+  if (!response.ok) {
+    return;
+  }
+  const envelope = await response.json() as GuiResponseEnvelope<GuiAppActionJobSummary>;
+  setJobs((current) => ({ ...current, [envelope.data.id]: envelope.data }));
 }
 
 export function InstallationSurface(): ReactElement {

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -138,7 +138,7 @@ export const text = {
   aidevops: "aidevops",
   appShell: "App shell",
   apps: "Apps",
-  appsIntro: "App and CLI inventory for tools installed or updated by aidevops. Version and homepage adapters are planned.",
+  appsIntro: "App and CLI inventory for tools installed or updated by aidevops, with origin links, install/update policy, versions, paths, and allowlisted background actions.",
   appStatusPending: "adapter pending",
   brands: "Brands",
   brandsIntro: "Draft brand inventory for names and website references.",
@@ -414,15 +414,6 @@ export const fileRootBySurface: Partial<Record<SurfaceId, GuiFileRootId>> = {
   git: "git",
 };
 
-export const appRows = [
-  { name: "aidevops", latest: text.appStatusPending, channel: "setup/update", website: "https://aidevops.sh" },
-  { name: "OpenCode", latest: text.appStatusPending, channel: "runtime", website: text.appStatusPending },
-  { name: "Bun", latest: text.appStatusPending, channel: "toolchain", website: text.appStatusPending },
-  { name: "GitHub CLI", latest: text.appStatusPending, channel: "git", website: text.appStatusPending },
-  { name: "ShellCheck", latest: text.appStatusPending, channel: "quality", website: text.appStatusPending },
-  { name: "Biome", latest: text.appStatusPending, channel: "quality", website: text.appStatusPending },
-];
-
 export const installationRows = [
   { name: "OpenCode runtime", install: true, update: true, scope: "core" },
   { name: "GUI desktop launcher", install: true, update: true, scope: "local" },
@@ -576,7 +567,7 @@ export function surfaceRecordCounts(status: GuiStatusData): SurfaceRecordCounts 
   return {
     agents: status.capabilities.length,
     aiProviders: oauthAccounts,
-    apps: appRows.length,
+    apps: status.managed_apps.length || status.ai_apps.length,
     config: status.settings.key_count || status.settings.keys.length,
     git: status.local_repos.total || status.local_repos.repos.length,
     hosts: populatedInventoryRowCount("hosts"),

--- a/packages/gui-web/src/status-client.ts
+++ b/packages/gui-web/src/status-client.ts
@@ -86,6 +86,7 @@ function normalizeStatusEnvelope(envelope: GuiResponseEnvelope<Partial<GuiStatus
       oauth_pool: { ...statusFixture.oauth_pool, ...data.oauth_pool, providers: data.oauth_pool?.providers ?? statusFixture.oauth_pool.providers },
       setup_targets: data.setup_targets ?? statusFixture.setup_targets,
       ai_apps: data.ai_apps ?? statusFixture.ai_apps,
+      managed_apps: data.managed_apps ?? statusFixture.managed_apps,
       vault: {
         ...statusFixture.vault,
         ...data.vault,

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1600,9 +1600,172 @@ code {
 
 .data-table,
 .editable-table,
-.installation-list {
+.installation-list,
+.managed-app-list {
   display: grid;
   overflow: hidden;
+}
+
+.managed-app-list {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  margin-bottom: 12px;
+}
+
+.managed-app-row {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(220px, 1.3fr) minmax(260px, 1.7fr) auto;
+  padding: 14px;
+}
+
+.managed-app-row + .managed-app-row {
+  border-top: 1px solid var(--border);
+}
+
+.managed-app-main,
+.managed-app-main > div,
+.app-meta {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.managed-app-main h3,
+.managed-app-main p {
+  margin: 0;
+}
+
+.managed-app-main p:not(.eyebrow) {
+  color: var(--text-secondary);
+}
+
+.managed-app-links,
+.managed-app-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.managed-app-links a,
+.origin-missing {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 800;
+  gap: 4px;
+  padding: 6px 9px;
+  text-decoration: none;
+}
+
+.origin-missing {
+  color: var(--text-muted);
+}
+
+.managed-app-details {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.managed-toggle,
+.app-meta {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.managed-toggle {
+  align-items: center;
+  color: var(--text-secondary);
+  display: flex;
+  font-size: 0.78rem;
+  font-weight: 800;
+  gap: 8px;
+  text-transform: uppercase;
+}
+
+.switch-track {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: inline-flex;
+  padding: 2px;
+  width: 34px;
+}
+
+.switch-track span {
+  background: var(--text-muted);
+  border-radius: 50%;
+  height: 14px;
+  transform: translateX(0);
+  transition: transform 140ms ease, background 140ms ease;
+  width: 14px;
+}
+
+.switch-track.checked span {
+  background: var(--accent);
+  transform: translateX(14px);
+}
+
+.app-meta small {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.app-meta strong {
+  color: var(--text-primary);
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.app-action-button {
+  align-items: center;
+  border-radius: 12px;
+  display: inline-flex;
+  height: 38px;
+  justify-content: center;
+  padding: 0;
+  width: 38px;
+}
+
+.app-action-button:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.app-terminal {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  color: var(--text-secondary);
+  overflow: hidden;
+}
+
+.app-terminal header {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 12px;
+}
+
+.app-terminal pre {
+  margin: 0;
+  max-height: 360px;
+  overflow: auto;
+  padding: 12px;
+  white-space: pre-wrap;
 }
 
 .data-row,
@@ -2082,6 +2245,10 @@ code {
   .file-workspace {
     grid-template-columns: 1fr;
   }
+
+  .managed-app-row {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 980px) {
@@ -2146,6 +2313,7 @@ code {
 
   .data-row,
   .editable-row,
+  .managed-app-details,
   .provider-account-list li {
     grid-template-columns: 1fr;
   }

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -73,7 +73,7 @@ describe("dashboard shell", () => {
     expect(counts.localSetup).toBe(2);
     expect(counts.agents).toBe(3);
     expect(counts.vault).toBe(4);
-    expect(counts.apps).toBe(6);
+    expect(counts.apps).toBe(2);
   });
 
   test("normalizes legacy status payloads from older local API processes", async () => {


### PR DESCRIPTION
## Summary
- Add a managed apps inventory to aidevops.app with origin links, install/update policy switches, installed/latest versions, paths, and responsive single-column-friendly rows.
- Add allowlisted background app action routes for install/update/reinstall plus in-memory job output polling.
- Add an app action log terminal panel and document xterm.js + node-pty as the next step for full TUI workloads such as OpenCode.

Resolves #25702

## Verification
- `bun run typecheck`
- `bun test packages/gui-shared/tests packages/gui-api/tests packages/gui-web/tests`
- `bun ./node_modules/vite/bin/vite.js build --config packages/gui-web/vite.config.ts`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.28.0 with gpt-5.5 spent 35m and 285,247 tokens on this with the user in an interactive session.