### PR TITLE
feat: refine GUI session sidebar

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -1,5 +1,5 @@
 import type { GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
-import { type ReactElement, useEffect, useState } from "react";
+import { type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactElement, useEffect, useState } from "react";
 import { MachineRail, Sidebar } from "./AppNavigation";
 import { Workspace } from "./AppWorkspace";
 import type { ConversationMode, FontPreference, FontSizePreference, ShellMode, SurfaceId, ThemePreference } from "./app-model";
@@ -32,8 +32,13 @@ export const appearanceStorageKeys = {
   machineRail: "aidevops-gui-show-machine-rail",
   showBorders: "aidevops-gui-show-borders",
   showNavCounts: "aidevops-gui-show-nav-counts",
+  sidebarWidth: "aidevops-gui-sidebar-width",
   theme: "aidevops-gui-theme",
 } as const;
+
+const defaultSidebarWidth = 302;
+const minSidebarWidth = 248;
+const maxSidebarWidth = 520;
 
 export interface StoredAppearancePreferences {
   accentHue: number;
@@ -76,6 +81,7 @@ export function App(): ReactElement {
   const [shellMode, setShellMode] = useState<ShellMode>("devices");
   const [conversationMode, setConversationMode] = useState<ConversationMode>("ai");
   const [selectedLocalRepoIndex, setSelectedLocalRepoIndex] = useState(0);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>();
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">("light");
   const resolvedTheme = themePreference === "system" ? systemTheme : themePreference;
   const activeSurface: SurfaceId = navigation.entries[navigation.index] ?? "overview";
@@ -184,12 +190,14 @@ export function App(): ReactElement {
         fontSizePreference={fontSizePreference}
         fontPreference={fontPreference}
         selectedLocalRepoIndex={selectedLocalRepoIndex}
+        selectedSessionId={selectedSessionId}
         setAccentHue={setAccentHue}
         setActiveSurface={setActiveSurface}
         setConversationMode={setConversationMode}
         setFontSizePreference={setFontSizePreference}
         setFontPreference={setFontPreference}
         setSelectedLocalRepoIndex={setSelectedLocalRepoIndex}
+        setSelectedSessionId={setSelectedSessionId}
         setShellMode={setShellMode}
         setShowBorders={setShowBorders}
         setShowNavCounts={setShowNavCounts}
@@ -200,6 +208,7 @@ export function App(): ReactElement {
         status={status.data}
         themePreference={themePreference}
       />
+      <SidebarResizeHandle />
       <Workspace
         activeItem={activeItem}
         activeSectionLabel={activeSectionLabel}
@@ -211,8 +220,11 @@ export function App(): ReactElement {
         goBack={goBack}
         goForward={goForward}
         selectedLocalRepoIndex={selectedLocalRepoIndex}
+        selectedSessionId={selectedSessionId}
         setActiveSurface={setActiveSurface}
         setConversationMode={setConversationMode}
+        setSelectedLocalRepoIndex={setSelectedLocalRepoIndex}
+        setSelectedSessionId={setSelectedSessionId}
         setShellMode={setShellMode}
         shellMode={shellMode}
         status={status.data}
@@ -220,6 +232,49 @@ export function App(): ReactElement {
       <DesktopStatusBar status={status.data} />
     </main>
   );
+}
+
+export function clampSidebarWidth(width: number): number {
+  return Math.min(maxSidebarWidth, Math.max(minSidebarWidth, Math.round(width)));
+}
+
+function SidebarResizeHandle(): ReactElement {
+  const [sidebarWidth, setSidebarWidth] = useState(() => readStoredSidebarWidth());
+
+  useEffect(() => {
+    document.documentElement.style.setProperty("--sidebar-width", `${sidebarWidth}px`);
+    persistAppearancePreference(appearanceStorageKeys.sidebarWidth, String(sidebarWidth));
+  }, [sidebarWidth]);
+
+  const startSidebarResize = (event: ReactMouseEvent<HTMLElement>) => {
+    const startX = event.clientX;
+    const startWidth = sidebarWidth;
+    const resizeSidebar = (moveEvent: MouseEvent) => setSidebarWidth(clampSidebarWidth(startWidth + moveEvent.clientX - startX));
+    const stopResize = () => {
+      document.documentElement.classList.remove("resizing-sidebar");
+      window.removeEventListener("mousemove", resizeSidebar);
+      window.removeEventListener("mouseup", stopResize);
+    };
+
+    event.preventDefault();
+    document.documentElement.classList.add("resizing-sidebar");
+    window.addEventListener("mousemove", resizeSidebar);
+    window.addEventListener("mouseup", stopResize);
+  };
+
+  const resizeSidebarWithKeyboard = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      event.preventDefault();
+      setSidebarWidth((current) => clampSidebarWidth(current + (event.key === "ArrowRight" ? 16 : -16)));
+    }
+  };
+
+  return <hr aria-label="Resize sidebar" aria-orientation="vertical" aria-valuemax={maxSidebarWidth} aria-valuemin={minSidebarWidth} aria-valuenow={sidebarWidth} className="sidebar-resize-handle" onKeyDown={resizeSidebarWithKeyboard} onMouseDown={startSidebarResize} tabIndex={0} />;
+}
+
+function readStoredSidebarWidth(storage: ReadableAppearanceStorage | undefined = browserLocalStorage()): number {
+  const savedWidth = Number.parseInt(storage?.getItem(appearanceStorageKeys.sidebarWidth) ?? "", 10);
+  return Number.isFinite(savedWidth) ? clampSidebarWidth(savedWidth) : defaultSidebarWidth;
 }
 
 function sendNativeAccentHue(hue: number): void {

--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -110,19 +110,21 @@ export function MachineRail({ machine }: { machine?: GuiMachineSummary }) {
   );
 }
 
-export function Sidebar({ activeSurface, accentHue, conversationMode, fontPreference, fontSizePreference, selectedLocalRepoIndex, setAccentHue, setActiveSurface, setConversationMode, setFontPreference, setFontSizePreference, setSelectedLocalRepoIndex, setShellMode, setShowBorders, setShowNavCounts, setThemePreference, shellMode, showBorders, showNavCounts, status, themePreference }: {
+export function Sidebar({ activeSurface, accentHue, conversationMode, fontPreference, fontSizePreference, selectedLocalRepoIndex, selectedSessionId, setAccentHue, setActiveSurface, setConversationMode, setFontPreference, setFontSizePreference, setSelectedLocalRepoIndex, setSelectedSessionId, setShellMode, setShowBorders, setShowNavCounts, setThemePreference, shellMode, showBorders, showNavCounts, status, themePreference }: {
   activeSurface: SurfaceId;
   accentHue: number;
   conversationMode: ConversationMode;
   fontPreference: FontPreference;
   fontSizePreference: FontSizePreference;
   selectedLocalRepoIndex: number;
+  selectedSessionId: string | undefined;
   setAccentHue: (hue: number) => void;
   setActiveSurface: (surface: SurfaceId) => void;
   setConversationMode: (mode: ConversationMode) => void;
   setFontPreference: (font: FontPreference) => void;
   setFontSizePreference: (size: FontSizePreference) => void;
   setSelectedLocalRepoIndex: (index: number) => void;
+  setSelectedSessionId: (id: string | undefined) => void;
   setShellMode: (mode: ShellMode) => void;
   setShowBorders: (show: boolean) => void;
   setShowNavCounts: (show: boolean) => void;
@@ -154,8 +156,10 @@ export function Sidebar({ activeSurface, accentHue, conversationMode, fontPrefer
         </> : <ConversationSidebar
           conversationMode={conversationMode}
           selectedLocalRepoIndex={selectedLocalRepoIndex}
+          selectedSessionId={selectedSessionId}
           setConversationMode={setConversationMode}
           setSelectedLocalRepoIndex={setSelectedLocalRepoIndex}
+          setSelectedSessionId={setSelectedSessionId}
           status={status}
         />}
       </nav>
@@ -203,11 +207,13 @@ function IconSwitch<TValue extends string>({ ariaLabel, options, value }: {
   );
 }
 
-function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConversationMode, setSelectedLocalRepoIndex, status }: {
+function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, selectedSessionId, setConversationMode, setSelectedLocalRepoIndex, setSelectedSessionId, status }: {
   conversationMode: ConversationMode;
   selectedLocalRepoIndex: number;
+  selectedSessionId: string | undefined;
   setConversationMode: (mode: ConversationMode) => void;
   setSelectedLocalRepoIndex: (index: number) => void;
+  setSelectedSessionId: (id: string | undefined) => void;
   status: GuiStatusData;
 }) {
   const repos = status.local_repos.repos;
@@ -226,19 +232,18 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, setConv
       <section className="repo-session-selector" aria-label={text.localRepoSelector}>
         <span className="repo-selector-heading" id="local-repo-selector-label">{text.localRepos}</span>
         <div className="selector-with-stepper repo-selector-row">
-          <button aria-label="Previous local repo" className="selector-step-button" disabled={!canSelectPreviousRepo} onClick={() => setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1))} type="button"><FiChevronLeft aria-hidden="true" /></button>
-          <select aria-labelledby="local-repo-selector-label" onChange={(event) => setSelectedLocalRepoIndex(Number.parseInt(event.currentTarget.value, 10))} value={Math.min(selectedLocalRepoIndex, Math.max(0, repos.length - 1))}>
+          <button aria-label="Previous local repo" className="selector-step-button" disabled={!canSelectPreviousRepo} onClick={() => { setSelectedLocalRepoIndex(Math.max(0, selectedLocalRepoIndex - 1)); setSelectedSessionId(undefined); }} type="button"><FiChevronLeft aria-hidden="true" /></button>
+          <select aria-labelledby="local-repo-selector-label" onChange={(event) => { setSelectedLocalRepoIndex(Number.parseInt(event.currentTarget.value, 10)); setSelectedSessionId(undefined); }} value={Math.min(selectedLocalRepoIndex, Math.max(0, repos.length - 1))}>
             {repos.length === 0 ? <option value={0}>No local repos</option> : repos.map((repo, index) => <option key={repo.path_ref} value={index}>{repo.name}</option>)}
           </select>
-          <button aria-label="Next local repo" className="selector-step-button" disabled={!canSelectNextRepo} onClick={() => setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1))} type="button"><FiChevronRight aria-hidden="true" /></button>
+          <button aria-label="Next local repo" className="selector-step-button" disabled={!canSelectNextRepo} onClick={() => { setSelectedLocalRepoIndex(Math.min(repos.length - 1, selectedLocalRepoIndex + 1)); setSelectedSessionId(undefined); }} type="button"><FiChevronRight aria-hidden="true" /></button>
         </div>
       </section>
       <section className="sidebar-group session-history-list">
-        <h2>{text.sessionHistory}</h2>
         {selectedRepo ? <ul>
           {sessions.length === 0
             ? <li><button className="surface-link active" type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{selectedRepo.name}</strong><small>No OpenCode sessions found for this repo yet.</small></span><em>{text.planned}</em></button></li>
-            : sessions.map((session, index) => <li key={session.id_ref}><button className={index === 0 ? "surface-link active" : "surface-link"} type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{session.title}</strong><small>{session.updated_at}</small></span></button></li>)}
+            : sessions.map((session) => <li key={session.id_ref}><button className={(selectedSessionId ?? sessions[0]?.id_ref) === session.id_ref ? "surface-link active" : "surface-link"} onClick={() => setSelectedSessionId(session.id_ref)} type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{session.title}</strong><small>{session.updated_at}</small></span></button></li>)}
         </ul> : <p className="empty-sidebar-state">No local repos discovered.</p>}
       </section>
       </>}
@@ -251,13 +256,11 @@ function PeopleChannelList() {
     <section aria-label="People channels">
       <div className="notice compact-notice">{text.simplexReady}</div>
       <section className="sidebar-group session-history-list">
-        <h2>{text.teams}</h2>
         <ul>
           {["aidevops", "clients", "ops"].map((team) => <li key={team}><button className="surface-link" type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{team}</strong><small>SimpleX team channel placeholder</small></span></button></li>)}
         </ul>
       </section>
       <section className="sidebar-group session-history-list">
-        <h2>{text.directMessages}</h2>
         <ul>
           {["Marcus", "AI DevOps"].map((person) => <li key={person}><button className="surface-link" type="button"><span className="surface-icon" aria-hidden="true"><FiMessageSquare /></span><span className="surface-copy"><strong>{person}</strong><small>encrypted DM placeholder</small></span></button></li>)}
         </ul>

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -5,7 +5,7 @@ import type { GuiFileRootId, GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
 import type { ConversationMode, ShellMode, SurfaceId, SurfaceNavItem } from "./app-model";
 import { inventorySurfaceConfigs, text } from "./app-model";
-import { CommandPalette, commandPaletteShortcutQuery } from "./CommandPalette";
+import { CommandPalette, type CommandPaletteSelection, commandPaletteShortcutQuery } from "./CommandPalette";
 import { FileExplorerSurface } from "./FileExplorerSurface";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
 import { AiProvidersSurface, LocalReposSurface, LockedVaultGate, OverviewSurface, PlannedSurface, ProjectsSurface, SecuritySurface, VaultSurface } from "./StatusSurfaces";
@@ -16,7 +16,7 @@ const communityLinks = {
   x: "https://x.com/marcuswquinn",
 } as const;
 
-export function Workspace({ activeItem, activeSectionLabel, activeSurface, canGoBack, canGoForward, conversationMode, fileRoot, goBack, goForward, selectedLocalRepoIndex, setActiveSurface, setConversationMode, setShellMode, shellMode, status }: {
+export function Workspace({ activeItem, activeSectionLabel, activeSurface, canGoBack, canGoForward, conversationMode, fileRoot, goBack, goForward, selectedLocalRepoIndex, selectedSessionId, setActiveSurface, setConversationMode, setSelectedLocalRepoIndex, setSelectedSessionId, setShellMode, shellMode, status }: {
   activeItem: SurfaceNavItem;
   activeSectionLabel: string;
   activeSurface: SurfaceId;
@@ -27,25 +27,28 @@ export function Workspace({ activeItem, activeSectionLabel, activeSurface, canGo
   goBack: () => void;
   goForward: () => void;
   selectedLocalRepoIndex: number;
+  selectedSessionId: string | undefined;
   setActiveSurface: (surface: SurfaceId) => void;
   setConversationMode: (mode: ConversationMode) => void;
+  setSelectedLocalRepoIndex: (index: number) => void;
+  setSelectedSessionId: (id: string | undefined) => void;
   setShellMode: (mode: ShellMode) => void;
   shellMode: ShellMode;
   status: GuiStatusData;
 }) {
   return (
     <section className="app-inset" aria-label={text.workspaceLabel}>
-      <WorkspaceHeader activeItem={activeItem} activeSectionLabel={activeSectionLabel} activeSurface={activeSurface} canGoBack={canGoBack} canGoForward={canGoForward} goBack={goBack} goForward={goForward} setActiveSurface={setActiveSurface} setConversationMode={setConversationMode} setShellMode={setShellMode} status={status} />
+      <WorkspaceHeader activeItem={activeItem} activeSectionLabel={activeSectionLabel} activeSurface={activeSurface} canGoBack={canGoBack} canGoForward={canGoForward} goBack={goBack} goForward={goForward} setActiveSurface={setActiveSurface} setConversationMode={setConversationMode} setSelectedLocalRepoIndex={setSelectedLocalRepoIndex} setSelectedSessionId={setSelectedSessionId} setShellMode={setShellMode} status={status} />
       <div className="workspace-scroll">
         {shellMode === "sessions"
-          ? <ConversationWorkspace conversationMode={conversationMode} selectedLocalRepoIndex={selectedLocalRepoIndex} status={status} />
+          ? <ConversationWorkspace conversationMode={conversationMode} selectedLocalRepoIndex={selectedLocalRepoIndex} selectedSessionId={selectedSessionId} status={status} />
           : <SurfaceContent activeItem={activeItem} activeSurface={activeSurface} fileRoot={fileRoot} status={status} />}
       </div>
     </section>
   );
 }
 
-function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoBack, canGoForward, goBack, goForward, setActiveSurface, setConversationMode, setShellMode, status }: {
+function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoBack, canGoForward, goBack, goForward, setActiveSurface, setConversationMode, setSelectedLocalRepoIndex, setSelectedSessionId, setShellMode, status }: {
   activeItem: SurfaceNavItem;
   activeSectionLabel: string;
   activeSurface: SurfaceId;
@@ -55,6 +58,8 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
   goForward: () => void;
   setActiveSurface: (surface: SurfaceId) => void;
   setConversationMode: (mode: ConversationMode) => void;
+  setSelectedLocalRepoIndex: (index: number) => void;
+  setSelectedSessionId: (id: string | undefined) => void;
   setShellMode: (mode: ShellMode) => void;
   status: GuiStatusData;
 }): ReactElement {
@@ -87,8 +92,13 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
     setProfileOpen(false);
   };
 
-  const openItem = ({ conversationMode, shellMode, surface }: { conversationMode?: ConversationMode; shellMode?: ShellMode; surface: SurfaceId }) => {
+  const openItem = ({ conversationMode, repoPathRef, sessionId, shellMode, surface }: CommandPaletteSelection) => {
+    const repoIndex = status.local_repos.repos.findIndex((repo) => repo.path_ref === repoPathRef);
     setShellMode(shellMode ?? "devices");
+    if (repoIndex >= 0) {
+      setSelectedLocalRepoIndex(repoIndex);
+    }
+    setSelectedSessionId(sessionId);
     if (conversationMode) {
       setConversationMode(conversationMode);
     }
@@ -176,15 +186,16 @@ function NotificationsMenu({ openSurface }: { openSurface: (surface: SurfaceId) 
   );
 }
 
-function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, status }: {
+function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, selectedSessionId, status }: {
   conversationMode: ConversationMode;
   selectedLocalRepoIndex: number;
+  selectedSessionId: string | undefined;
   status: GuiStatusData;
 }) {
   const selectedRepo = status.local_repos.repos[selectedLocalRepoIndex] ?? status.local_repos.repos[0];
   const selectedSession = selectedRepo === undefined
     ? undefined
-    : status.opencode_sessions.sessions.find((session) => session.repo_path_ref === selectedRepo.path_ref);
+    : status.opencode_sessions.sessions.find((session) => session.id_ref === selectedSessionId && session.repo_path_ref === selectedRepo.path_ref) ?? status.opencode_sessions.sessions.find((session) => session.repo_path_ref === selectedRepo.path_ref);
   const title = conversationMode === "ai" ? selectedRepo?.name ?? text.opencodeSessions : text.teams;
 
   return (

--- a/packages/gui-web/src/CommandPalette.tsx
+++ b/packages/gui-web/src/CommandPalette.tsx
@@ -15,7 +15,9 @@ interface CommandPaletteItem {
   iconGlyph?: string;
   id: string;
   label: string;
+  repoPathRef?: string;
   searchText: string;
+  sessionId?: string;
   shellMode?: ShellMode;
   surface: SurfaceId;
   tag: string;
@@ -61,6 +63,8 @@ const plannedChannelItems: CommandPaletteItem[] = [
 
 export interface CommandPaletteSelection {
   conversationMode?: ConversationMode;
+  repoPathRef?: string;
+  sessionId?: string;
   shellMode?: ShellMode;
   surface: SurfaceId;
 }
@@ -80,7 +84,7 @@ export function CommandPalette({ activeSurface, close, initialQuery, openItem, s
       if (item.action === "copy-current-link") {
         void copyCurrentSurfaceLink(item.surface);
       }
-      openItem({ conversationMode: item.conversationMode, shellMode: item.shellMode, surface: item.surface });
+      openItem({ conversationMode: item.conversationMode, repoPathRef: item.repoPathRef, sessionId: item.sessionId, shellMode: item.shellMode, surface: item.surface });
     }
   }, [openItem, recentIds]);
 
@@ -165,13 +169,14 @@ export function commandPaletteMatches(items: CommandPaletteItem[], query: string
   const normalizedQuery = query.trim().toLowerCase();
   const prefix = normalizedQuery.charAt(0);
   const scopedItems = itemsForCommandPrefix(items, prefix);
+  const filterQuery = commandPaletteShortcutEntries.some(([shortcut]) => shortcut === prefix) ? normalizedQuery.slice(1).trim() : normalizedQuery;
 
   if (normalizedQuery.length === 0 || commandPaletteShortcutEntries.some(([shortcut]) => shortcut === normalizedQuery)) {
     return orderCommandItemsByRecency(scopedItems, recentIds).slice(0, 8);
   }
 
   return scopedItems
-    .filter((item) => item.searchText.toLowerCase().includes(normalizedQuery))
+    .filter((item) => item.searchText.toLowerCase().includes(filterQuery))
     .slice(0, 8);
 }
 
@@ -197,7 +202,9 @@ function commandPaletteItems(status: GuiStatusData, activeSurface: SurfaceId): C
     iconGlyph: "_",
     id: `session-${session.id_ref}`,
     label: `_${session.title}`,
+    repoPathRef: session.repo_path_ref,
     searchText: `_${session.title} ${session.title} ${session.repo_path_ref} ${session.agent} ${session.model}`,
+    sessionId: session.id_ref,
     surface: "git",
     shellMode: "sessions",
     conversationMode: "ai",

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -99,15 +99,16 @@ code {
 
 .app-shell {
   display: grid;
-  gap: 8px;
-  grid-template-columns: 72px 302px minmax(0, 1fr);
+  column-gap: 8px;
+  grid-template-columns: 72px var(--sidebar-width, 302px) 8px minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr) auto;
   height: 100vh;
   padding: calc(var(--shell-gutter) + var(--desktop-titlebar-height)) var(--shell-gutter) var(--shell-gutter);
+  row-gap: 8px;
 }
 
 .app-shell.machine-rail-collapsed {
-  grid-template-columns: 302px minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width, 302px) 8px minmax(0, 1fr);
 }
 
 .desktop-titlebar-tagline {
@@ -158,6 +159,54 @@ code {
   gap: 10px;
   justify-items: center;
   padding: 12px 8px;
+}
+
+.app-shell > .app-sidebar {
+  grid-column: 2;
+}
+
+.app-shell > .sidebar-resize-handle {
+  grid-column: 3;
+}
+
+.app-shell > .app-inset {
+  grid-column: 4;
+}
+
+.app-shell.machine-rail-collapsed > .app-sidebar {
+  grid-column: 1;
+}
+
+.app-shell.machine-rail-collapsed > .sidebar-resize-handle {
+  grid-column: 2;
+}
+
+.app-shell.machine-rail-collapsed > .app-inset {
+  grid-column: 3;
+}
+
+.sidebar-resize-handle {
+  align-self: stretch;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: col-resize;
+  grid-row: 1;
+  margin: 0;
+  min-height: 0;
+}
+
+.sidebar-resize-handle:hover,
+.sidebar-resize-handle:focus-visible,
+.resizing-sidebar .sidebar-resize-handle {
+  background: color-mix(in srgb, var(--accent) 24%, transparent);
+  outline: none;
+}
+
+.resizing-sidebar,
+.resizing-sidebar * {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .machine-orb,
@@ -329,7 +378,8 @@ code {
 }
 
 .sidebar-content {
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 0 10px 12px;
 }
 
@@ -365,6 +415,7 @@ code {
 .conversation-panel {
   display: grid;
   gap: 12px;
+  min-width: 0;
   padding: 0 6px;
 }
 
@@ -439,6 +490,7 @@ code {
   min-height: 40px;
   min-width: 0;
   padding: 8px;
+  width: 100%;
 }
 
 .session-history-list .surface-link {
@@ -2133,6 +2185,17 @@ code {
   .desktop-status-bar {
     grid-column: 1;
     grid-row: auto;
+  }
+
+  .app-shell > .app-sidebar,
+  .app-shell > .app-inset,
+  .app-shell.machine-rail-collapsed > .app-sidebar,
+  .app-shell.machine-rail-collapsed > .app-inset {
+    grid-column: 1;
+  }
+
+  .sidebar-resize-handle {
+    display: none;
   }
 
   .desktop-status-bar {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { appearanceStorageKeys, readStoredAppearancePreferences } from "../src/App";
+import { appearanceStorageKeys, clampSidebarWidth, readStoredAppearancePreferences } from "../src/App";
 import { hueFromInputValue } from "../src/AppNavigation";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
 import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts } from "../src/app-model";
@@ -147,6 +147,12 @@ describe("dashboard shell", () => {
     expect(hueFromInputValue("1e")).toBeNull();
   });
 
+  test("clamps sidebar width to compact and wide bounds", () => {
+    expect(clampSidebarWidth(120)).toBe(248);
+    expect(clampSidebarWidth(360)).toBe(360);
+    expect(clampSidebarWidth(800)).toBe(520);
+  });
+
   test("maps command palette single-key shortcuts", () => {
     for (const [shortcut, query] of commandPaletteShortcutEntries) {
       expect(commandPaletteShortcutQuery(keyEvent(shortcut))).toBe(query);
@@ -179,6 +185,18 @@ describe("dashboard shell", () => {
     expect(commandPaletteMatches(items, "?", []).map((item) => item.tag)).toEqual(["Help"]);
     expect(commandPaletteMatches(items, ":", []).map((item) => item.tag)).toEqual(["Emoji"]);
     expect(commandPaletteMatches(items, "^", []).map((item) => item.tag)).toEqual(["Link"]);
+  });
+
+  test("filters scoped command palette queries after the shortcut symbol", () => {
+    const items = [
+      paletteItem("session-ui", "_UI command palette", "AI session"),
+      paletteItem("session-pulse", "_Pulse diagnostics", "AI session"),
+      paletteItem("channel-devops", "#devops", "Channel"),
+      paletteItem("channel-comms", "#comms", "Channel"),
+    ];
+
+    expect(commandPaletteMatches(items, "_pulse", []).map((item) => item.id)).toEqual(["session-pulse"]);
+    expect(commandPaletteMatches(items, "#comm", []).map((item) => item.id)).toEqual(["channel-comms"]);
   });
 
   test("orders command palette recent selections first", () => {


### PR DESCRIPTION
## Summary

- route `_` command palette AI session selections to the matching repo/session
- filter scoped command palette queries after the leading shortcut symbol
- simplify the conversations sidebar and add a draggable/keyboard sidebar resize handle

Resolves #25703

## Verification

- `bunx tsc --noEmit`
- `bun test packages/gui-web/tests`
- `bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build`
- `git diff --check`
- `bunx biome check packages/gui-web/src/App.tsx packages/gui-web/src/AppNavigation.tsx packages/gui-web/src/AppWorkspace.tsx packages/gui-web/src/CommandPalette.tsx packages/gui-web/tests/component.test.ts`
- `.agents/scripts/qlty-regression-helper.sh --base main --head HEAD` → base: 44, head: 44, delta: 0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.28.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
