### PR TITLE
fix: harden GUI sidebar session selection

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -267,6 +267,11 @@ function SidebarResizeHandle(): ReactElement {
       event.preventDefault();
       setSidebarWidth((current) => clampSidebarWidth(current + (event.key === "ArrowRight" ? 16 : -16)));
     }
+
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      setSidebarWidth(event.key === "Home" ? minSidebarWidth : maxSidebarWidth);
+    }
   };
 
   return <hr aria-label="Resize sidebar" aria-orientation="vertical" aria-valuemax={maxSidebarWidth} aria-valuemin={minSidebarWidth} aria-valuenow={sidebarWidth} className="sidebar-resize-handle" onKeyDown={resizeSidebarWithKeyboard} onMouseDown={startSidebarResize} tabIndex={0} />;

--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -221,6 +221,7 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, selecte
   const sessions = selectedRepo === undefined
     ? []
     : status.opencode_sessions.sessions.filter((session) => session.repo_path_ref === selectedRepo.path_ref);
+  const activeSessionId = sessions.some((session) => session.id_ref === selectedSessionId) ? selectedSessionId : sessions[0]?.id_ref;
   const canSelectPreviousRepo = selectedLocalRepoIndex > 0;
   const canSelectNextRepo = selectedLocalRepoIndex < repos.length - 1;
 
@@ -243,7 +244,7 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, selecte
         {selectedRepo ? <ul>
           {sessions.length === 0
             ? <li><button className="surface-link active" type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{selectedRepo.name}</strong><small>No OpenCode sessions found for this repo yet.</small></span><em>{text.planned}</em></button></li>
-            : sessions.map((session) => <li key={session.id_ref}><button className={(selectedSessionId ?? sessions[0]?.id_ref) === session.id_ref ? "surface-link active" : "surface-link"} onClick={() => setSelectedSessionId(session.id_ref)} type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{session.title}</strong><small>{session.updated_at}</small></span></button></li>)}
+            : sessions.map((session) => <li key={session.id_ref}><button className={activeSessionId === session.id_ref ? "surface-link active" : "surface-link"} onClick={() => setSelectedSessionId(session.id_ref)} type="button"><span className="surface-icon" aria-hidden="true"><FiHash /></span><span className="surface-copy"><strong>{session.title}</strong><small>{session.updated_at}</small></span></button></li>)}
         </ul> : <p className="empty-sidebar-state">No local repos discovered.</p>}
       </section>
       </>}


### PR DESCRIPTION
## Summary

- keep a session highlighted when the stored selected session belongs to another repo
- add splitter semantics plus Home/End keyboard bounds to the sidebar resize handle

Follow-up for #25703 and #25704.

## Verification

- `bunx tsc --noEmit`
- `bun test packages/gui-web/tests`
- `bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build`
- `git diff --check`
- `bunx biome check packages/gui-web/src/App.tsx packages/gui-web/src/AppNavigation.tsx`
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD` → base: 46, head: 46, delta: 0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.28.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
