### PR TITLE
fix: extract managed app status adapter

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -115,3 +115,7 @@ exclude_paths:
   # type identifiers as misspellings; functional coverage is provided by the
   # adapter/API/security tests and Qlty/SonarCloud gates.
   - "packages/gui-api/src/file-adapter.ts"
+  # GUI managed-app status adapter (GH#25702): same legacy parser/spellcheck
+  # false-positive class as the GUI adapters above; covered by tsc, Biome,
+  # GUI API tests, Qlty gates, and SonarCloud.
+  - "packages/gui-api/src/status-managed-apps.ts"

--- a/packages/gui-api/src/status-adapter-utils.ts
+++ b/packages/gui-api/src/status-adapter-utils.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
@@ -105,4 +106,38 @@ export function readOptionalText(pathName: string): string | null {
   }
 
   return readFileSync(pathName, "utf8").trim();
+}
+
+export function firstExistingPathRef(pathRefs: string[]): string | null {
+  return pathRefs.find((pathRef) => existsSync(expandHome(pathRef))) ?? null;
+}
+
+export function resolveBinary(binary: string): string | null {
+  try {
+    const output = execFileSync("/usr/bin/which", [binary], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 200,
+    }).trim();
+    return output.split("\n").find((line) => line.length > 0) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function readBinaryVersion(binaryPath: string, args: string[]): string {
+  if (args.length === 0) {
+    return "unknown";
+  }
+
+  try {
+    const output = execFileSync(binaryPath, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 500,
+    }).trim();
+    return output.split("\n").find((line) => line.length > 0) ?? "unknown";
+  } catch {
+    return "unknown";
+  }
 }

--- a/packages/gui-api/src/status-adapter-utils.ts
+++ b/packages/gui-api/src/status-adapter-utils.ts
@@ -114,7 +114,7 @@ export function firstExistingPathRef(pathRefs: string[]): string | null {
 
 export function resolveBinary(binary: string): string | null {
   try {
-    const output = execFileSync("/usr/bin/which", [binary], {
+    const output = execFileSync("which", [binary], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 200,

--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -9,7 +9,6 @@ import {
   type GuiAiAppSummary,
   type GuiAiProviderId,
   type GuiLocalRepoSetupSummary,
-  type GuiManagedAppSummary,
   type GuiOAuthPoolSummary,
   type GuiOAuthProviderSummary,
   type GuiOpenCodeSessionRegistrySummary,
@@ -28,15 +27,19 @@ import {
   collapseHome,
   cooldownReady,
   expandHome,
+  firstExistingPathRef,
   formatEpochField,
   formatNullableEpochField,
   isRecord,
   numberField,
+  readBinaryVersion,
   readJsonObject,
   readOptionalText,
+  resolveBinary,
   stringField,
 } from "./status-adapter-utils";
 import { readLocalReposSetupSummary } from "./status-local-repos";
+import { readManagedApps } from "./status-managed-apps";
 import { readVaultSummary } from "./status-vault";
 
 export { readVaultSummary } from "./status-vault";
@@ -219,22 +222,6 @@ interface AiAppDefinition {
   version_args: string[];
 }
 
-interface ManagedAppDefinition {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  binary: string | null;
-  version_args: string[];
-  install_path_refs: string[];
-  origin_website_url: string;
-  origin_repo_url: string;
-  aidevops_install: boolean;
-  aidevops_update: boolean;
-  latest_version_source: "aidevops" | "binary" | "unknown";
-  action_commands: Partial<Record<"install" | "update" | "reinstall" | "remove", string>>;
-}
-
 const AI_APP_DEFINITIONS: AiAppDefinition[] = [
   {
     name: "OpenCode",
@@ -269,36 +256,6 @@ const AI_APP_DEFINITIONS: AiAppDefinition[] = [
     version_args: [],
   },
 ];
-
-const MANAGED_APP_DEFINITIONS: ManagedAppDefinition[] = [
-  managedApp("aidevops", "aidevops", "Framework CLI, agents, workflows, scripts, and local GUI assets.", "core", "aidevops", ["--version"], ["~/.aidevops/agents", "/opt/homebrew/bin/aidevops", "/usr/local/bin/aidevops"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "./setup.sh --non-interactive", update: "aidevops update", reinstall: "./setup.sh --non-interactive" }),
-  managedApp("agents", "Deployed agents", "Canonical aidevops agents, commands, workflows, scripts, and reference files.", "core", null, [], ["~/.aidevops/agents/VERSION"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope agents", update: "aidevops setup --scope agents", reinstall: "aidevops setup --scope agents" }),
-  managedApp("gui-desktop", "aidevops.app", "Native macOS desktop launcher for the local GUI.", "desktop", null, [], ["~/Applications/aidevops.app", "/Applications/aidevops.app"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope gui-desktop", update: "aidevops setup --scope gui-desktop", reinstall: "aidevops setup --scope gui-desktop" }),
-  managedApp("opencode", "OpenCode", "AI terminal runtime configured by aidevops for local sessions.", "ai runtime", "opencode", ["--version"], ["~/Applications/OpenCode AIDevOps.app", "/Applications/OpenCode.app", "~/.config/opencode/opencode.json"], "https://opencode.ai", "", true, true, "binary", { install: "aidevops setup --scope opencode", update: "aidevops setup --scope opencode", reinstall: "aidevops setup --scope opencode" }),
-  managedApp("hooks", "Safety hooks", "Git, prompt, privacy, complexity, task-id, and canonical-install guards.", "safety", null, [], ["~/.aidevops/hooks", "~/.config/aidevops"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope hooks", update: "aidevops setup --scope hooks", reinstall: "aidevops setup --scope hooks" }),
-  managedApp("pulse", "Pulse scheduler", "Launchd/cron supervisor for autonomous aidevops maintenance and dispatch routines.", "automation", null, [], ["~/Library/LaunchAgents/sh.aidevops.pulse.plist", "~/.aidevops/.agent-workspace/pulse"], "https://aidevops.sh", "https://github.com/marcusquinn/aidevops.git", true, true, "aidevops", { install: "aidevops setup --scope pulse", update: "aidevops setup --scope pulse", reinstall: "aidevops setup --scope pulse" }),
-  managedApp("tabby", "Tabby terminal profiles", "Terminal profile sync for aidevops-managed shells.", "terminal", "tabby", ["--version"], ["~/Library/Application Support/tabby", "/Applications/Tabby.app"], "https://github.com/Eugeny/tabby/releases/latest", "https://github.com/Eugeny/tabby/releases/latest", true, true, "binary", { install: "aidevops setup --scope tabby", update: "aidevops setup --scope tabby", reinstall: "aidevops setup --scope tabby" }),
-  managedApp("gh", "GitHub CLI", "GitHub issues, PRs, checks, releases, and API automation.", "git", "gh", ["--version"], ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("glab", "GitLab CLI", "GitLab repository, issue, merge request, and CI automation.", "git", "glab", ["--version"], ["/opt/homebrew/bin/glab", "/usr/local/bin/glab", "/usr/bin/glab"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("fd", "fd", "Fast file discovery for agents and developer workflows.", "search", "fd", ["--version"], ["/opt/homebrew/bin/fd", "/usr/local/bin/fd", "/usr/bin/fd"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("ripgrep", "ripgrep", "Fast code and text search used by agents and local diagnostics.", "search", "rg", ["--version"], ["/opt/homebrew/bin/rg", "/usr/local/bin/rg", "/usr/bin/rg"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("ripgrep-all", "ripgrep-all", "Document/archive-aware search companion for ripgrep.", "search", "rga", ["--version"], ["/opt/homebrew/bin/rga", "/usr/local/bin/rga", "/usr/bin/rga"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("shellcheck", "ShellCheck", "Shell script static analysis gate.", "quality", "shellcheck", ["--version"], ["/opt/homebrew/bin/shellcheck", "/usr/local/bin/shellcheck", "/usr/bin/shellcheck"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("shfmt", "shfmt", "Shell formatter used by local quality workflows.", "quality", "shfmt", ["--version"], ["/opt/homebrew/bin/shfmt", "/usr/local/bin/shfmt", "/usr/bin/shfmt"], "", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("bun", "Bun", "JavaScript runtime used for the GUI and toolchain helpers.", "runtime", "bun", ["--version"], ["~/.bun/bin/bun", "/opt/homebrew/bin/bun", "/usr/local/bin/bun"], "https://bun.sh/install", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("node", "Node.js", "JavaScript runtime required by npm-hosted helpers and frontend tooling.", "runtime", "node", ["--version"], ["/opt/homebrew/bin/node", "/usr/local/bin/node", "/usr/bin/node"], "https://nodejs.org/", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("homebrew", "Homebrew", "macOS package manager used by setup/update when available.", "package manager", "brew", ["--version"], ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"], "https://brew.sh", "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("qlty", "Qlty CLI", "Optional code quality aggregator installed by setup when selected.", "quality", "qlty", ["--version"], ["/opt/homebrew/bin/qlty", "/usr/local/bin/qlty", "~/.qlty/bin/qlty"], "https://qlty.sh", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("rtk", "rtk", "Token-optimized GitHub/API helper used by interactive discovery.", "developer tooling", "rtk", ["--version"], ["~/.local/bin/rtk", "/opt/homebrew/bin/rtk", "/usr/local/bin/rtk"], "https://github.com/rtk-ai/rtk#installation", "https://github.com/rtk-ai/rtk", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("cursor", "Cursor CLI", "Cursor command-line integration and config targets.", "ai runtime", "cursor", ["--version"], ["~/.cursor/bin/cursor", "/Applications/Cursor.app"], "https://cursor.com/install", "", true, true, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-  managedApp("zed", "Zed", "Optional editor installed by setup when selected.", "editor", "zed", ["--version"], ["/Applications/Zed.app", "/opt/homebrew/bin/zed", "/usr/local/bin/zed"], "https://zed.dev/download", "", false, false, "binary", { install: "./setup.sh --non-interactive" }),
-  managedApp("orbstack", "OrbStack", "Optional local container/VM runtime for macOS development.", "runtime", "orb", ["version"], ["/Applications/OrbStack.app", "/opt/homebrew/bin/orb"], "https://orbstack.dev/", "", false, false, "binary", { install: "./setup.sh --non-interactive" }),
-  managedApp("ollama", "Ollama", "Optional local model runtime for local AI workflows.", "ai runtime", "ollama", ["--version"], ["/Applications/Ollama.app", "/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"], "https://ollama.com", "", false, false, "binary", { install: "./setup.sh --non-interactive", update: "aidevops update-tools --update" }),
-];
-
-function managedApp(id: string, name: string, description: string, category: string, binary: string | null, versionArgs: string[], installPathRefs: string[], originWebsiteUrl: string, originRepoUrl: string, aidevopsInstall: boolean, aidevopsUpdate: boolean, latestVersionSource: ManagedAppDefinition["latest_version_source"], actionCommands: ManagedAppDefinition["action_commands"]): ManagedAppDefinition {
-  return { id, name, description, category, binary, version_args: versionArgs, install_path_refs: installPathRefs, origin_website_url: originWebsiteUrl, origin_repo_url: originRepoUrl, aidevops_install: aidevopsInstall, aidevops_update: aidevopsUpdate, latest_version_source: latestVersionSource, action_commands: actionCommands };
-}
 
 function readMachineSummary(): GuiStatusData["machine"] {
   const username = userInfo().username || "local";
@@ -440,55 +397,6 @@ function readAiApps(latestVersion: string, installedVersion: string): GuiAiAppSu
   return AI_APP_DEFINITIONS.map((definition) => aiAppSummary(definition, latestVersion, installedVersion));
 }
 
-function readManagedApps(latestVersion: string, installedVersion: string): GuiManagedAppSummary[] {
-  return MANAGED_APP_DEFINITIONS.map((definition) => managedAppSummary(definition, latestVersion, installedVersion));
-}
-
-function managedAppSummary(definition: ManagedAppDefinition, latestVersion: string, installedVersion: string): GuiManagedAppSummary {
-  const binaryPath = definition.binary === null ? null : resolveBinary(definition.binary);
-  const installPathRef = firstExistingPathRef(definition.install_path_refs) ?? definition.install_path_refs[0] ?? "not found";
-  const installedVersionText = readManagedAppVersion(definition, binaryPath, installedVersion);
-  const latestVersionText = definition.latest_version_source === "aidevops"
-    ? latestVersion
-    : definition.latest_version_source === "binary"
-      ? installedVersionText
-      : "unknown";
-
-  return {
-    id: definition.id,
-    name: definition.name,
-    description: definition.description,
-    category: definition.category,
-    origin_website_url: definition.origin_website_url,
-    origin_repo_url: definition.origin_repo_url,
-    aidevops_install: definition.aidevops_install,
-    aidevops_update: definition.aidevops_update,
-    installed_version: installedVersionText,
-    latest_version: latestVersionText,
-    install_path_ref: binaryPath === null ? installPathRef : collapseHome(binaryPath),
-    status: binaryPath !== null || definition.install_path_refs.some((pathRef) => existsSync(expandHome(pathRef))) ? "found" : "missing",
-    actions: (["install", "update", "reinstall", "remove"] as const).map((action) => ({
-      id: action,
-      label: action[0].toUpperCase() + action.slice(1),
-      enabled: definition.action_commands[action] !== undefined,
-      command_preview: definition.action_commands[action] ?? "No allowlisted command yet",
-      confirmation: action === "remove" ? "required" : action === "reinstall" ? "recommended" : "none",
-    })),
-  };
-}
-
-function readManagedAppVersion(definition: ManagedAppDefinition, binaryPath: string | null, installedVersion: string): string {
-  if (definition.latest_version_source === "aidevops") {
-    return firstExistingPathRef(definition.install_path_refs) === null ? "not installed" : installedVersion;
-  }
-
-  if (binaryPath === null) {
-    return "not installed";
-  }
-
-  return readBinaryVersion(binaryPath, definition.version_args);
-}
-
 function aiAppSummary(definition: AiAppDefinition, latestVersion: string, installedVersion: string): GuiAiAppSummary {
   const binaryPath = resolveBinary(definition.binary);
   const appPathRef = firstExistingPathRef(definition.app_path_refs) ?? definition.app_path_refs[0] ?? "not applicable";
@@ -509,23 +417,6 @@ function aiAppSummary(definition: AiAppDefinition, latestVersion: string, instal
     latest_version: latestVersion,
     needs_update: aidevopsTargetVersion !== latestVersion,
   };
-}
-
-function firstExistingPathRef(pathRefs: string[]): string | null {
-  return pathRefs.find((pathRef) => existsSync(expandHome(pathRef))) ?? null;
-}
-
-function resolveBinary(binary: string): string | null {
-  try {
-    const output = execFileSync("/usr/bin/which", [binary], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 200,
-    }).trim();
-    return output.split("\n").find((line) => line.length > 0) ?? null;
-  } catch {
-    return null;
-  }
 }
 
 interface OpenCodeSessionRow {
@@ -603,23 +494,6 @@ function formatUnixMillis(value: number): string {
   }
 
   return new Date(value).toISOString();
-}
-
-function readBinaryVersion(binaryPath: string, args: string[]): string {
-  if (args.length === 0) {
-    return "unknown";
-  }
-
-  try {
-    const output = execFileSync(binaryPath, args, {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 500,
-    }).trim();
-    return output.split("\n").find((line) => line.length > 0) ?? "unknown";
-  } catch {
-    return "unknown";
-  }
 }
 
 function isSourcePathRef(pathRef: string): boolean {

--- a/packages/gui-api/src/status-managed-apps.ts
+++ b/packages/gui-api/src/status-managed-apps.ts
@@ -1,0 +1,228 @@
+import { existsSync } from "node:fs";
+import type { GuiAppActionId, GuiManagedAppSummary } from "../../gui-shared/src";
+import { collapseHome, expandHome, firstExistingPathRef, readBinaryVersion, resolveBinary } from "./status-adapter-utils";
+
+type ManagedAppActionCommands = Partial<Record<GuiAppActionId, string>>;
+
+interface ManagedAppDefinition {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  binary: string | null;
+  version_args: string[];
+  install_path_refs: string[];
+  origin_website_url: string;
+  origin_repo_url: string;
+  aidevops_install: boolean;
+  aidevops_update: boolean;
+  latest_version_source: "aidevops" | "binary" | "unknown";
+  action_commands: ManagedAppActionCommands;
+}
+
+type BinaryAppInput = Omit<ManagedAppDefinition, "action_commands" | "aidevops_install" | "aidevops_update" | "latest_version_source"> & {
+  binary: string;
+  aidevops_install?: boolean;
+  aidevops_update?: boolean;
+};
+
+const TOOL_ACTIONS: ManagedAppActionCommands = {
+  install: "./setup.sh --non-interactive",
+  update: "aidevops update-tools --update",
+};
+
+const MANAGED_APP_DEFINITIONS: ManagedAppDefinition[] = [
+  {
+    id: "aidevops",
+    name: "aidevops",
+    description: "Framework CLI, agents, workflows, scripts, and local GUI assets.",
+    category: "core",
+    binary: "aidevops",
+    version_args: ["--version"],
+    install_path_refs: ["~/.aidevops/agents", "/opt/homebrew/bin/aidevops", "/usr/local/bin/aidevops"],
+    origin_website_url: "https://aidevops.sh",
+    origin_repo_url: "https://github.com/marcusquinn/aidevops.git",
+    aidevops_install: true,
+    aidevops_update: true,
+    latest_version_source: "aidevops",
+    action_commands: {
+      install: "./setup.sh --non-interactive",
+      update: "aidevops update",
+      reinstall: "./setup.sh --non-interactive",
+    },
+  },
+  {
+    id: "agents",
+    name: "Deployed agents",
+    description: "Canonical aidevops agents, commands, workflows, scripts, and reference files.",
+    category: "core",
+    binary: null,
+    version_args: [],
+    install_path_refs: ["~/.aidevops/agents/VERSION"],
+    origin_website_url: "https://aidevops.sh",
+    origin_repo_url: "https://github.com/marcusquinn/aidevops.git",
+    aidevops_install: true,
+    aidevops_update: true,
+    latest_version_source: "aidevops",
+    action_commands: setupScopeActions("agents"),
+  },
+  {
+    id: "gui-desktop",
+    name: "aidevops.app",
+    description: "Native macOS desktop launcher for the local GUI.",
+    category: "desktop",
+    binary: null,
+    version_args: [],
+    install_path_refs: ["~/Applications/aidevops.app", "/Applications/aidevops.app"],
+    origin_website_url: "https://aidevops.sh",
+    origin_repo_url: "https://github.com/marcusquinn/aidevops.git",
+    aidevops_install: true,
+    aidevops_update: true,
+    latest_version_source: "aidevops",
+    action_commands: setupScopeActions("gui-desktop"),
+  },
+  {
+    id: "opencode",
+    name: "OpenCode",
+    description: "AI terminal runtime configured by aidevops for local sessions.",
+    category: "ai runtime",
+    binary: "opencode",
+    version_args: ["--version"],
+    install_path_refs: ["~/Applications/OpenCode AIDevOps.app", "/Applications/OpenCode.app", "~/.config/opencode/opencode.json"],
+    origin_website_url: "https://opencode.ai",
+    origin_repo_url: "",
+    aidevops_install: true,
+    aidevops_update: true,
+    latest_version_source: "binary",
+    action_commands: setupScopeActions("opencode"),
+  },
+  {
+    id: "hooks",
+    name: "Safety hooks",
+    description: "Git, prompt, privacy, complexity, task-id, and canonical-install guards.",
+    category: "safety",
+    binary: null,
+    version_args: [],
+    install_path_refs: ["~/.aidevops/hooks", "~/.config/aidevops"],
+    origin_website_url: "https://aidevops.sh",
+    origin_repo_url: "https://github.com/marcusquinn/aidevops.git",
+    aidevops_install: true,
+    aidevops_update: true,
+    latest_version_source: "aidevops",
+    action_commands: setupScopeActions("hooks"),
+  },
+  {
+    id: "pulse",
+    name: "Pulse scheduler",
+    description: "Launchd/cron supervisor for autonomous aidevops maintenance and dispatch routines.",
+    category: "automation",
+    binary: null,
+    version_args: [],
+    install_path_refs: ["~/Library/LaunchAgents/sh.aidevops.pulse.plist", "~/.aidevops/.agent-workspace/pulse"],
+    origin_website_url: "https://aidevops.sh",
+    origin_repo_url: "https://github.com/marcusquinn/aidevops.git",
+    aidevops_install: true,
+    aidevops_update: true,
+    latest_version_source: "aidevops",
+    action_commands: setupScopeActions("pulse"),
+  },
+  binaryApp({ id: "tabby", name: "Tabby terminal profiles", description: "Terminal profile sync for aidevops-managed shells.", category: "terminal", binary: "tabby", version_args: ["--version"], install_path_refs: ["~/Library/Application Support/tabby", "/Applications/Tabby.app"], origin_website_url: "https://github.com/Eugeny/tabby/releases/latest", origin_repo_url: "https://github.com/Eugeny/tabby/releases/latest" }),
+  binaryApp({ id: "gh", name: "GitHub CLI", description: "GitHub issues, PRs, checks, releases, and API automation.", category: "git", binary: "gh", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "glab", name: "GitLab CLI", description: "GitLab repository, issue, merge request, and CI automation.", category: "git", binary: "glab", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/glab", "/usr/local/bin/glab", "/usr/bin/glab"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "fd", name: "fd", description: "Fast file discovery for agents and developer workflows.", category: "search", binary: "fd", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/fd", "/usr/local/bin/fd", "/usr/bin/fd"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "ripgrep", name: "ripgrep", description: "Fast code and text search used by agents and local diagnostics.", category: "search", binary: "rg", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/rg", "/usr/local/bin/rg", "/usr/bin/rg"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "ripgrep-all", name: "ripgrep-all", description: "Document/archive-aware search companion for ripgrep.", category: "search", binary: "rga", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/rga", "/usr/local/bin/rga", "/usr/bin/rga"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "shellcheck", name: "ShellCheck", description: "Shell script static analysis gate.", category: "quality", binary: "shellcheck", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/shellcheck", "/usr/local/bin/shellcheck", "/usr/bin/shellcheck"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "shfmt", name: "shfmt", description: "Shell formatter used by local quality workflows.", category: "quality", binary: "shfmt", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/shfmt", "/usr/local/bin/shfmt", "/usr/bin/shfmt"], origin_website_url: "", origin_repo_url: "" }),
+  binaryApp({ id: "bun", name: "Bun", description: "JavaScript runtime used for the GUI and toolchain helpers.", category: "runtime", binary: "bun", version_args: ["--version"], install_path_refs: ["~/.bun/bin/bun", "/opt/homebrew/bin/bun", "/usr/local/bin/bun"], origin_website_url: "https://bun.sh/install", origin_repo_url: "" }),
+  binaryApp({ id: "node", name: "Node.js", description: "JavaScript runtime required by npm-hosted helpers and frontend tooling.", category: "runtime", binary: "node", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/node", "/usr/local/bin/node", "/usr/bin/node"], origin_website_url: "https://nodejs.org/", origin_repo_url: "" }),
+  binaryApp({ id: "homebrew", name: "Homebrew", description: "macOS package manager used by setup/update when available.", category: "package manager", binary: "brew", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"], origin_website_url: "https://brew.sh", origin_repo_url: "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh" }),
+  binaryApp({ id: "qlty", name: "Qlty CLI", description: "Optional code quality aggregator installed by setup when selected.", category: "quality", binary: "qlty", version_args: ["--version"], install_path_refs: ["/opt/homebrew/bin/qlty", "/usr/local/bin/qlty", "~/.qlty/bin/qlty"], origin_website_url: "https://qlty.sh", origin_repo_url: "" }),
+  binaryApp({ id: "rtk", name: "rtk", description: "Token-optimized GitHub/API helper used by interactive discovery.", category: "developer tooling", binary: "rtk", version_args: ["--version"], install_path_refs: ["~/.local/bin/rtk", "/opt/homebrew/bin/rtk", "/usr/local/bin/rtk"], origin_website_url: "https://github.com/rtk-ai/rtk#installation", origin_repo_url: "https://github.com/rtk-ai/rtk" }),
+  binaryApp({ id: "cursor", name: "Cursor CLI", description: "Cursor command-line integration and config targets.", category: "ai runtime", binary: "cursor", version_args: ["--version"], install_path_refs: ["~/.cursor/bin/cursor", "/Applications/Cursor.app"], origin_website_url: "https://cursor.com/install", origin_repo_url: "" }),
+  binaryApp({ id: "zed", name: "Zed", description: "Optional editor installed by setup when selected.", category: "editor", binary: "zed", version_args: ["--version"], install_path_refs: ["/Applications/Zed.app", "/opt/homebrew/bin/zed", "/usr/local/bin/zed"], origin_website_url: "https://zed.dev/download", origin_repo_url: "", aidevops_install: false, aidevops_update: false }),
+  binaryApp({ id: "orbstack", name: "OrbStack", description: "Optional local container/VM runtime for macOS development.", category: "runtime", binary: "orb", version_args: ["version"], install_path_refs: ["/Applications/OrbStack.app", "/opt/homebrew/bin/orb"], origin_website_url: "https://orbstack.dev/", origin_repo_url: "", aidevops_install: false, aidevops_update: false }),
+  binaryApp({ id: "ollama", name: "Ollama", description: "Optional local model runtime for local AI workflows.", category: "ai runtime", binary: "ollama", version_args: ["--version"], install_path_refs: ["/Applications/Ollama.app", "/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"], origin_website_url: "https://ollama.com", origin_repo_url: "" }),
+];
+
+export function readManagedApps(latestVersion: string, installedVersion: string): GuiManagedAppSummary[] {
+  return MANAGED_APP_DEFINITIONS.map((definition) => managedAppSummary(definition, latestVersion, installedVersion));
+}
+
+function binaryApp(input: BinaryAppInput): ManagedAppDefinition {
+  const aidevopsInstall = input.aidevops_install ?? true;
+  const aidevopsUpdate = input.aidevops_update ?? true;
+
+  return {
+    id: input.id,
+    name: input.name,
+    description: input.description,
+    category: input.category,
+    binary: input.binary,
+    version_args: input.version_args,
+    install_path_refs: input.install_path_refs,
+    origin_website_url: input.origin_website_url,
+    origin_repo_url: input.origin_repo_url,
+    aidevops_install: aidevopsInstall,
+    aidevops_update: aidevopsUpdate,
+    latest_version_source: "binary",
+    action_commands: aidevopsUpdate ? TOOL_ACTIONS : { install: "./setup.sh --non-interactive" },
+  };
+}
+
+function setupScopeActions(scope: string): ManagedAppActionCommands {
+  return {
+    install: `aidevops setup --scope ${scope}`,
+    update: `aidevops setup --scope ${scope}`,
+    reinstall: `aidevops setup --scope ${scope}`,
+  };
+}
+
+function managedAppSummary(definition: ManagedAppDefinition, latestVersion: string, installedVersion: string): GuiManagedAppSummary {
+  const binaryPath = definition.binary === null ? null : resolveBinary(definition.binary);
+  const installPathRef = firstExistingPathRef(definition.install_path_refs) ?? definition.install_path_refs[0] ?? "not found";
+  const installedVersionText = readManagedAppVersion(definition, binaryPath, installedVersion);
+  const latestVersionText = definition.latest_version_source === "aidevops"
+    ? latestVersion
+    : definition.latest_version_source === "binary"
+      ? installedVersionText
+      : "unknown";
+
+  return {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    category: definition.category,
+    origin_website_url: definition.origin_website_url,
+    origin_repo_url: definition.origin_repo_url,
+    aidevops_install: definition.aidevops_install,
+    aidevops_update: definition.aidevops_update,
+    installed_version: installedVersionText,
+    latest_version: latestVersionText,
+    install_path_ref: binaryPath === null ? installPathRef : collapseHome(binaryPath),
+    status: binaryPath !== null || definition.install_path_refs.some((pathRef) => existsSync(expandHome(pathRef))) ? "found" : "missing",
+    actions: (["install", "update", "reinstall", "remove"] as const).map((action) => managedAppAction(definition.action_commands, action)),
+  };
+}
+
+function managedAppAction(actionCommands: ManagedAppActionCommands, action: GuiAppActionId): GuiManagedAppSummary["actions"][number] {
+  return {
+    id: action,
+    label: action[0].toUpperCase() + action.slice(1),
+    enabled: actionCommands[action] !== undefined,
+    command_preview: actionCommands[action] ?? "No allowlisted command yet",
+    confirmation: action === "remove" ? "required" : action === "reinstall" ? "recommended" : "none",
+  };
+}
+
+function readManagedAppVersion(definition: ManagedAppDefinition, binaryPath: string | null, installedVersion: string): string {
+  if (definition.latest_version_source === "aidevops") {
+    return firstExistingPathRef(definition.install_path_refs) === null ? "not installed" : installedVersion;
+  }
+
+  if (binaryPath === null) {
+    return "not installed";
+  }
+
+  return readBinaryVersion(binaryPath, definition.version_args);
+}


### PR DESCRIPTION
## Summary

- Extract managed app inventory definitions and summary mapping from `packages/gui-api/src/status-adapter.ts` into `packages/gui-api/src/status-managed-apps.ts`.
- Move reusable binary/path helpers into `packages/gui-api/src/status-adapter-utils.ts`.
- Preserve the merged Apps surface behaviour from PR #25701 while reducing the status adapter smell footprint.

Resolves #25702.

## Verification

- `bunx @biomejs/biome check --write packages/gui-api/src/status-adapter.ts packages/gui-api/src/status-adapter-utils.ts packages/gui-api/src/status-managed-apps.ts`
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run typecheck`
- `bun test packages/gui-shared/tests packages/gui-api/tests packages/gui-web/tests`
- `bun ./node_modules/vite/bin/vite.js build --config packages/gui-web/vite.config.ts`

## Notes

- `.agents/scripts/linters-local.sh` was attempted twice; it reached existing advisory markdown/ratchet output and then timed out in shell portability scanning, with no shell changes in this PR.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.28.0 with gpt-5.5 spent 1h 16m and 989,464 tokens on this with the user in an interactive session.