### PR TITLE
t18016: Add GUI conversation contracts

### DIFF
--- a/docs/gui/data-model.md
+++ b/docs/gui/data-model.md
@@ -292,6 +292,105 @@ Suggested fields:
 Capsules are not bearer tokens for arbitrary shell access. They must be scoped,
 expiring, replay-protected, and enforced locally by the target machine.
 
+### Conversation
+
+A `Conversation` is the shared collaboration container for AI sessions,
+channels, direct messages, group DMs, and worker/event threads.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `conversation_type`: `ai_session`, `channel`, `dm`, `group_dm`, or
+  `worker_thread`.
+- `title`: display name or generated session title.
+- `tenant_ref`, `workspace_ref`, `repo_ref`: local ownership and repo scope.
+- `source_ref`: OpenCode session, imported channel, worker run, or local draft
+  source reference.
+- `status`: `active`, `archived`, or `read_only`.
+- `created_at`, `updated_at`.
+
+Conversation scope is mandatory. The GUI must be able to prove that a thread is
+owned by the current local tenant/workspace and, where applicable, bound to the
+selected repo before rendering protected message payloads.
+
+### ConversationParticipant
+
+A `ConversationParticipant` links a human, AI assistant, worker, or system bot to
+a conversation.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `conversation_id`.
+- `participant_kind`: `human`, `ai_assistant`, `worker`, or `system_bot`.
+- `display_name`: local display label.
+- `identity_ref`: optional `Identity` reference for human participants.
+- `agent_ref`: optional aidevops/OpenCode agent reference.
+- `worker_ref`: optional worker or task-capsule reference.
+- `membership_state`: `active`, `invited`, `left`, or `removed`.
+- `joined_at`.
+
+Membership gates read access. Removed participants must not be treated as active
+readers even if old messages reference them as historical senders.
+
+### ConversationMessage
+
+A `ConversationMessage` is an ordered envelope in a conversation. Payloads live
+in message parts so AI, event, and GenUI content can share the same timeline.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `conversation_id`.
+- `sender_participant_id`: nullable for system-generated markers.
+- `sender_kind`: `human`, `ai_assistant`, `worker`, `system_bot`, or `system`.
+- `sequence`: monotonically increasing conversation-local order.
+- `status`: `draft`, `sent`, `delivered`, `failed`, or `redacted`.
+- `usage_metadata`: nullable provider/model/token/cost reference metadata.
+- `created_at`, `edited_at`.
+
+Message ordering uses `sequence` first and timestamp only as a deterministic
+tie-breaker. Import adapters should preserve source ordering and assign local
+sequence values before rendering.
+
+### ConversationMessagePart
+
+A `ConversationMessagePart` stores the ordered pieces that make up a message.
+
+Suggested fields:
+
+- `id`: stable internal ID.
+- `message_id`.
+- `part_kind`: `text`, `file`, `tool_call`, `source`, `tambo_component`,
+  `approval_prompt`, or `event_marker`.
+- `ordinal`: message-local order.
+- `text`: text payload when applicable.
+- `payload_json`: schema-validated non-secret structured payload.
+- `file_ref`: file/attachment reference, not raw file bytes.
+- `source_ref`: citation, helper, workflow, or evidence reference.
+
+Tambo component payloads are message parts, not separate conversation owners.
+Tool calls, approval prompts, and event markers may carry structured payloads,
+but those payloads must not include secret values, private keys, raw cookies, or
+credential-bearing command output.
+
+### ConversationReaction and read state
+
+`ConversationReaction` and `ConversationReadState` keep social feedback and read
+progress outside message payloads.
+
+Suggested reaction fields:
+
+- `id`, `message_id`, `participant_id`, `reaction`, `created_at`.
+
+Suggested read-state fields:
+
+- `conversation_id`, `participant_id`, `last_read_message_id`,
+  `last_read_sequence`, `updated_at`.
+
+Read state is participant-scoped and conversation-scoped. It must not leak which
+private repo or protected channel another tenant/workspace can see.
+
 ### AuditEvent
 
 An `AuditEvent` records non-secret evidence about reads, writes, confirmations,

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -185,6 +185,100 @@ export interface GuiOpenCodeSessionRegistrySummary {
   sessions: GuiOpenCodeSessionSummary[];
 }
 
+export type GuiConversationType = "ai_session" | "channel" | "dm" | "group_dm" | "worker_thread";
+
+export type GuiConversationParticipantKind = "human" | "ai_assistant" | "worker" | "system_bot";
+
+export type GuiConversationMessageSenderKind = GuiConversationParticipantKind | "system";
+
+export type GuiConversationMessagePartKind = "text" | "file" | "tool_call" | "source" | "tambo_component" | "approval_prompt" | "event_marker";
+
+export interface GuiConversationScope {
+  tenant_ref: string;
+  workspace_ref: string;
+  repo_ref: string | null;
+}
+
+export interface GuiConversation {
+  id: string;
+  type: GuiConversationType;
+  title: string;
+  scope: GuiConversationScope;
+  source_ref: string;
+  status: "active" | "archived" | "read_only";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GuiConversationParticipant {
+  id: string;
+  conversation_id: string;
+  kind: GuiConversationParticipantKind;
+  display_name: string;
+  identity_ref: string | null;
+  agent_ref: string | null;
+  worker_ref: string | null;
+  membership_state: "active" | "invited" | "left" | "removed";
+  joined_at: string;
+}
+
+export interface GuiConversationUsageMetadata {
+  provider_ref: string | null;
+  model_ref: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost_ref: string | null;
+}
+
+export interface GuiConversationMessage {
+  id: string;
+  conversation_id: string;
+  sender_participant_id: string | null;
+  sender_kind: GuiConversationMessageSenderKind;
+  sequence: number;
+  status: "draft" | "sent" | "delivered" | "failed" | "redacted";
+  usage: GuiConversationUsageMetadata | null;
+  created_at: string;
+  edited_at: string | null;
+}
+
+export interface GuiConversationMessagePart {
+  id: string;
+  message_id: string;
+  kind: GuiConversationMessagePartKind;
+  ordinal: number;
+  text: string | null;
+  payload_json: Record<string, unknown> | null;
+  file_ref: string | null;
+  source_ref: string | null;
+}
+
+export interface GuiConversationReaction {
+  id: string;
+  message_id: string;
+  participant_id: string;
+  reaction: string;
+  created_at: string;
+}
+
+export interface GuiConversationReadState {
+  conversation_id: string;
+  participant_id: string;
+  last_read_message_id: string | null;
+  last_read_sequence: number;
+  updated_at: string;
+}
+
+export interface GuiConversationThread {
+  conversation: GuiConversation;
+  participants: GuiConversationParticipant[];
+  messages: GuiConversationMessage[];
+  parts: GuiConversationMessagePart[];
+  reactions: GuiConversationReaction[];
+  read_states: GuiConversationReadState[];
+}
+
 export type GuiAiProviderId = "anthropic" | "openai" | "cursor" | "google";
 
 export interface GuiOAuthPoolAccountSummary {
@@ -498,4 +592,20 @@ export function assertNoSecretSentinels(value: unknown): void {
 
 export function isReadOnlyManifest(manifest: GuiRouteManifest): boolean {
   return manifest.method === "GET" && manifest.classification === "read";
+}
+
+export function sortConversationMessages<TMessage extends Pick<GuiConversationMessage, "sequence" | "created_at">>(messages: TMessage[]): TMessage[] {
+  return [...messages].sort((left, right) => left.sequence - right.sequence || left.created_at.localeCompare(right.created_at));
+}
+
+export function sortConversationMessageParts<TPart extends Pick<GuiConversationMessagePart, "ordinal">>(parts: TPart[]): TPart[] {
+  return [...parts].sort((left, right) => left.ordinal - right.ordinal);
+}
+
+export function participantCanReadConversation(thread: GuiConversationThread, participantId: string): boolean {
+  return thread.participants.some((participant) => participant.id === participantId && participant.membership_state === "active");
+}
+
+export function conversationHasScope(thread: GuiConversationThread, scope: GuiConversationScope): boolean {
+  return thread.conversation.scope.tenant_ref === scope.tenant_ref && thread.conversation.scope.workspace_ref === scope.workspace_ref && thread.conversation.scope.repo_ref === scope.repo_ref;
 }

--- a/packages/gui-shared/tests/schema.test.ts
+++ b/packages/gui-shared/tests/schema.test.ts
@@ -3,10 +3,15 @@ import {
   createEnvelope,
   FILE_EXPLORER_ROUTE_MANIFEST,
   GUI_FILE_ROOTS,
+  conversationHasScope,
   isReadOnlyManifest,
+  participantCanReadConversation,
+  sortConversationMessageParts,
+  sortConversationMessages,
   STATUS_ROUTE_MANIFEST,
   statusFixture,
   VAULT_STATUS_ROUTE_MANIFEST,
+  type GuiConversationThread,
 } from "../src";
 
 describe("GUI shared schema contracts", () => {
@@ -55,4 +60,177 @@ describe("GUI shared schema contracts", () => {
     expect(envelope.data.ai_apps.map((app) => app.name)).toContain("OpenCode");
     expect(envelope.data.capabilities[0].status).toBe("available");
   });
+
+  test("conversation thread model preserves tenant scope and active membership", () => {
+    const thread = conversationThreadFixture();
+
+    expect(conversationHasScope(thread, {
+      tenant_ref: "tenant:local-owner",
+      workspace_ref: "workspace:aidevops",
+      repo_ref: "repo:marcusquinn/aidevops",
+    })).toBe(true);
+    expect(conversationHasScope(thread, {
+      tenant_ref: "tenant:other",
+      workspace_ref: "workspace:aidevops",
+      repo_ref: "repo:marcusquinn/aidevops",
+    })).toBe(false);
+    expect(participantCanReadConversation(thread, "participant:human-owner")).toBe(true);
+    expect(participantCanReadConversation(thread, "participant:removed-user")).toBe(false);
+  });
+
+  test("conversation messages and parts keep deterministic ordering", () => {
+    const thread = conversationThreadFixture();
+    const orderedMessages = sortConversationMessages(thread.messages);
+    const orderedParts = sortConversationMessageParts(thread.parts.filter((part) => part.message_id === "message:assistant-1"));
+
+    expect(orderedMessages.map((message) => message.id)).toEqual(["message:user-1", "message:assistant-1"]);
+    expect(orderedParts.map((part) => part.kind)).toEqual(["text", "tool_call", "tambo_component"]);
+    expect(orderedParts[2].payload_json).toEqual({ component: "ReleaseReadinessCard", status: "planned" });
+    expect(orderedMessages[1].usage?.total_tokens).toBe(168);
+  });
 });
+
+function conversationThreadFixture(): GuiConversationThread {
+  return {
+    conversation: {
+      id: "conversation:ai-session-1",
+      type: "ai_session",
+      title: "Plan AI collaboration workspace",
+      scope: {
+        tenant_ref: "tenant:local-owner",
+        workspace_ref: "workspace:aidevops",
+        repo_ref: "repo:marcusquinn/aidevops",
+      },
+      source_ref: "opencode:session:metadata-only",
+      status: "active",
+      created_at: "2026-06-27T18:00:00.000Z",
+      updated_at: "2026-06-27T18:01:00.000Z",
+    },
+    participants: [
+      {
+        id: "participant:human-owner",
+        conversation_id: "conversation:ai-session-1",
+        kind: "human",
+        display_name: "Local owner",
+        identity_ref: "identity:owner",
+        agent_ref: null,
+        worker_ref: null,
+        membership_state: "active",
+        joined_at: "2026-06-27T18:00:00.000Z",
+      },
+      {
+        id: "participant:assistant",
+        conversation_id: "conversation:ai-session-1",
+        kind: "ai_assistant",
+        display_name: "AI DevOps",
+        identity_ref: null,
+        agent_ref: "agent:build-plus",
+        worker_ref: null,
+        membership_state: "active",
+        joined_at: "2026-06-27T18:00:00.000Z",
+      },
+      {
+        id: "participant:removed-user",
+        conversation_id: "conversation:ai-session-1",
+        kind: "human",
+        display_name: "Former member",
+        identity_ref: "identity:former",
+        agent_ref: null,
+        worker_ref: null,
+        membership_state: "removed",
+        joined_at: "2026-06-27T18:00:00.000Z",
+      },
+    ],
+    messages: [
+      {
+        id: "message:assistant-1",
+        conversation_id: "conversation:ai-session-1",
+        sender_participant_id: "participant:assistant",
+        sender_kind: "ai_assistant",
+        sequence: 2,
+        status: "sent",
+        usage: {
+          provider_ref: "provider:anthropic",
+          model_ref: "model:claude-sonnet",
+          input_tokens: 120,
+          output_tokens: 48,
+          total_tokens: 168,
+          cost_ref: null,
+        },
+        created_at: "2026-06-27T18:01:00.000Z",
+        edited_at: null,
+      },
+      {
+        id: "message:user-1",
+        conversation_id: "conversation:ai-session-1",
+        sender_participant_id: "participant:human-owner",
+        sender_kind: "human",
+        sequence: 1,
+        status: "sent",
+        usage: null,
+        created_at: "2026-06-27T18:00:30.000Z",
+        edited_at: null,
+      },
+    ],
+    parts: [
+      {
+        id: "part:assistant-card",
+        message_id: "message:assistant-1",
+        kind: "tambo_component",
+        ordinal: 3,
+        text: null,
+        payload_json: { component: "ReleaseReadinessCard", status: "planned" },
+        file_ref: null,
+        source_ref: null,
+      },
+      {
+        id: "part:assistant-text",
+        message_id: "message:assistant-1",
+        kind: "text",
+        ordinal: 1,
+        text: "Here is the implementation map.",
+        payload_json: null,
+        file_ref: null,
+        source_ref: null,
+      },
+      {
+        id: "part:assistant-tool",
+        message_id: "message:assistant-1",
+        kind: "tool_call",
+        ordinal: 2,
+        text: null,
+        payload_json: { helper: "git ls-files", result: "ok" },
+        file_ref: null,
+        source_ref: "docs/architecture/ai-collaboration-workspace.md",
+      },
+      {
+        id: "part:user-text",
+        message_id: "message:user-1",
+        kind: "text",
+        ordinal: 1,
+        text: "Map the conversation model.",
+        payload_json: null,
+        file_ref: null,
+        source_ref: null,
+      },
+    ],
+    reactions: [
+      {
+        id: "reaction:ack",
+        message_id: "message:assistant-1",
+        participant_id: "participant:human-owner",
+        reaction: "ack",
+        created_at: "2026-06-27T18:02:00.000Z",
+      },
+    ],
+    read_states: [
+      {
+        conversation_id: "conversation:ai-session-1",
+        participant_id: "participant:human-owner",
+        last_read_message_id: "message:assistant-1",
+        last_read_sequence: 2,
+        updated_at: "2026-06-27T18:02:00.000Z",
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds shared GUI conversation contracts for AI sessions, channels, DMs, group DMs, and worker threads.
- Documents conversation, participant, message, message-part, reaction, read-state, and usage metadata fields in `docs/gui/data-model.md`.
- Adds schema tests for tenant/workspace/repo scope, active participant membership, message ordering, message-part ordering, Tambo component payload persistence, and usage metadata.

## Dependency
- For #25707.
- This child was blocked by #25708; #25708 is closed by PR #25717.

## Verification
- `git diff --check`
- `bun test packages/gui-shared/tests` (7 pass, 0 fail)
- `npm run typecheck`

Resolves #25709

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1h 44m and 598,728 tokens on this with the user in an interactive session.
