### PR TITLE
fix: resume pulse merge after checkpoints

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -450,6 +450,70 @@ _pmp_checkpoint_resume_skip_repo() {
 	return 0
 }
 
+_pmp_add_counter_var() {
+	local counter_var="$1"
+	local increment="${2:-0}"
+	local current=""
+
+	[[ "$counter_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	current="${!counter_var}"
+	[[ "$current" =~ ^[0-9]+$ ]] || current=0
+	[[ "$increment" =~ ^[0-9]+$ ]] || increment=0
+	printf -v "$counter_var" '%s' "$((current + increment))"
+	return 0
+}
+
+_pmp_process_merge_repo_for_pass() {
+	local repo_slug="$1"
+	local checkpoint_file="$2"
+	local logfile="$3"
+	local stop_flag="$4"
+	local total_merged_var="$5"
+	local total_closed_var="$6"
+	local total_failed_var="$7"
+	local total_eligible_var="$8"
+	local completed_all_var="$9"
+
+	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+		|| ! repo_allows_pulse_write_actions "$repo_slug"; then
+		echo "[pulse-wrapper] Deterministic merge pass skipped ${repo_slug}: repo role is contributor/read-only" >>"$logfile"
+		_pmp_write_merge_checkpoint "$checkpoint_file" "$repo_slug"
+		return 0
+	fi
+
+	local repo_merged=0 repo_closed=0 repo_failed=0 _mr_repo_pr_count=0
+	local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0 _mr_repo_stuck_detector_s=0
+	local _mr_repo_start _mr_repo_stuck_start _mr_repo_total_s=0
+	_mr_repo_start=$(_pmp_now_epoch)
+
+	_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed _mr_repo_pr_count "_mr_repo_"
+	_pmp_add_counter_var "$total_merged_var" "$repo_merged"
+	_pmp_add_counter_var "$total_closed_var" "$repo_closed"
+	_pmp_add_counter_var "$total_failed_var" "$repo_failed"
+
+	_mr_repo_stuck_start=$(_pmp_now_epoch)
+	if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
+		pulse_merge_stuck_run_pass "$repo_slug" || true
+	fi
+	if declare -F _pms_count_eligible_unmerged_for_repo >/dev/null 2>&1; then
+		local _repo_eligible
+		_repo_eligible=$(_pms_count_eligible_unmerged_for_repo "$repo_slug" 2>/dev/null) || _repo_eligible=0
+		[[ "$_repo_eligible" =~ ^[0-9]+$ ]] || _repo_eligible=0
+		_pmp_add_counter_var "$total_eligible_var" "$_repo_eligible"
+	fi
+
+	_pmp_add_elapsed_seconds _mr_repo_stuck_detector_s "$_mr_repo_stuck_start"
+	_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
+	_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
+	_pmp_write_merge_checkpoint "$checkpoint_file" "$repo_slug"
+
+	if [[ -f "$stop_flag" ]]; then
+		echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$logfile"
+		printf -v "$completed_all_var" '%s' '0'
+	fi
+	return 0
+}
+
 merge_ready_prs_all_repos() {
 	# Initialise required env vars with ${VAR:-default} guards so this
 	# function can be called standalone from pulse-merge-routine.sh (t2862)
@@ -493,50 +557,9 @@ merge_ready_prs_all_repos() {
 		if _pmp_checkpoint_resume_skip_repo "$repo_slug" "$_mr_checkpoint" _mr_resume_pending; then
 			continue
 		fi
-		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
-			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
-			echo "[pulse-wrapper] Deterministic merge pass skipped ${repo_slug}: repo role is contributor/read-only" >>"$_mr_logfile"
-			_pmp_write_merge_checkpoint "$_mr_checkpoint_file" "$repo_slug"
-			continue
-		fi
-
-		local repo_merged=0
-		local repo_closed=0
-		local repo_failed=0
-		local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0 _mr_repo_stuck_detector_s=0
-		local _mr_repo_start
-		_mr_repo_start=$(_pmp_now_epoch)
-
-		local _mr_repo_pr_count=0
-		_merge_ready_prs_for_repo "$repo_slug" repo_merged repo_closed repo_failed _mr_repo_pr_count "_mr_repo_"
-
-		total_merged=$((total_merged + repo_merged))
-		total_closed=$((total_closed + repo_closed))
-		total_failed=$((total_failed + repo_failed))
-
-		# t3193: run the stuck-merge detector pass for this repo.
-		local _mr_repo_stuck_start
-		_mr_repo_stuck_start=$(_pmp_now_epoch)
-		if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
-			pulse_merge_stuck_run_pass "$repo_slug" || true
-		fi
-
-		# t3193: count this repo's eligible-but-unmerged contribution.
-		if declare -F _pms_count_eligible_unmerged_for_repo >/dev/null 2>&1; then
-			local _repo_eligible
-			_repo_eligible=$(_pms_count_eligible_unmerged_for_repo "$repo_slug" 2>/dev/null) || _repo_eligible=0
-			[[ "$_repo_eligible" =~ ^[0-9]+$ ]] || _repo_eligible=0
-			total_eligible_unmerged=$((total_eligible_unmerged + _repo_eligible))
-		fi
-		_pmp_add_elapsed_seconds _mr_repo_stuck_detector_s "$_mr_repo_stuck_start"
-		local _mr_repo_total_s=0
-		_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
-		_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
-		_pmp_write_merge_checkpoint "$_mr_checkpoint_file" "$repo_slug"
-
-		if [[ -f "$_mr_stop_flag" ]]; then
-			echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$_mr_logfile"
-			_mr_completed_all=0
+		_pmp_process_merge_repo_for_pass "$repo_slug" "$_mr_checkpoint_file" "$_mr_logfile" "$_mr_stop_flag" \
+			total_merged total_closed total_failed total_eligible_unmerged _mr_completed_all
+		if [[ "$_mr_completed_all" -eq 0 ]]; then
 			break
 		fi
 	done <<<"$_mr_repo_rows"

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -52,6 +52,7 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
 : "${STOP_FLAG:=${HOME}/.aidevops/logs/pulse-session.stop}"
 : "${PULSE_MERGE_BATCH_LIMIT:=50}"
+: "${PULSE_MERGE_CHECKPOINT_FILE:=${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 
 #######################################
 # Low-overhead timing helpers for per-repo merge summaries.
@@ -361,6 +362,43 @@ _pmp_log_pr_backlog_counts() {
 	return 0
 }
 
+_pmp_write_merge_checkpoint() {
+	local checkpoint_file="$1"
+	local repo_slug="$2"
+	local checkpoint_dir=""
+
+	[[ -n "$checkpoint_file" && -n "$repo_slug" ]] || return 0
+	checkpoint_dir="${checkpoint_file%/*}"
+	if [[ -n "$checkpoint_dir" && "$checkpoint_dir" != "$checkpoint_file" ]]; then
+		mkdir -p "$checkpoint_dir" 2>/dev/null || return 0
+	fi
+	printf '%s\n' "$repo_slug" >"$checkpoint_file" 2>/dev/null || true
+	return 0
+}
+
+_pmp_clear_merge_checkpoint() {
+	local checkpoint_file="$1"
+
+	[[ -n "$checkpoint_file" ]] || return 0
+	rm -f "$checkpoint_file" 2>/dev/null || true
+	return 0
+}
+
+_pmp_repo_rows_contain_slug() {
+	local repo_rows="$1"
+	local checkpoint_slug="$2"
+	local row_slug="" row_path=""
+
+	[[ -n "$repo_rows" && -n "$checkpoint_slug" ]] || return 1
+	while IFS='|' read -r row_slug row_path; do
+		[[ -n "$row_slug" ]] || continue
+		if [[ "$row_slug" == "$checkpoint_slug" ]]; then
+			return 0
+		fi
+	done <<<"$repo_rows"
+	return 1
+}
+
 merge_ready_prs_all_repos() {
 	# Initialise required env vars with ${VAR:-default} guards so this
 	# function can be called standalone from pulse-merge-routine.sh (t2862)
@@ -369,6 +407,7 @@ merge_ready_prs_all_repos() {
 	local _mr_stop_flag="${STOP_FLAG:-${HOME}/.aidevops/logs/pulse-session.stop}"
 	local _mr_repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 	local _mr_logfile="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
+	local _mr_checkpoint_file="${PULSE_MERGE_CHECKPOINT_FILE:-${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 	PULSE_MERGE_BATCH_LIMIT="${PULSE_MERGE_BATCH_LIMIT:-50}"
 	local _mr_pass_start
 	_mr_pass_start=$(_pmp_now_epoch)
@@ -388,12 +427,40 @@ merge_ready_prs_all_repos() {
 	local total_failed=0
 
 	local total_eligible_unmerged=0
+	local _mr_repo_rows=""
+	local _mr_checkpoint=""
+	local _mr_resume_pending=0
+	local _mr_resumed_from_checkpoint=0
+	local _mr_completed_all=1
+
+	_mr_repo_rows=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null) || _mr_repo_rows=""
+	if [[ -n "$_mr_checkpoint_file" && -f "$_mr_checkpoint_file" ]]; then
+		IFS= read -r _mr_checkpoint <"$_mr_checkpoint_file" || _mr_checkpoint=""
+		if [[ -n "$_mr_checkpoint" ]]; then
+			if _pmp_repo_rows_contain_slug "$_mr_repo_rows" "$_mr_checkpoint"; then
+				_mr_resume_pending=1
+				_mr_resumed_from_checkpoint=1
+				echo "[pulse-wrapper] Deterministic merge pass resuming after checkpoint repo=${_mr_checkpoint}" >>"$_mr_logfile"
+			else
+				echo "[pulse-wrapper] Deterministic merge pass ignoring stale checkpoint repo=${_mr_checkpoint}" >>"$_mr_logfile"
+				_pmp_clear_merge_checkpoint "$_mr_checkpoint_file"
+				_mr_checkpoint=""
+			fi
+		fi
+	fi
 
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" ]] || continue
+		if [[ "$_mr_resume_pending" -eq 1 ]]; then
+			if [[ "$repo_slug" == "$_mr_checkpoint" ]]; then
+				_mr_resume_pending=0
+			fi
+			continue
+		fi
 		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
 			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
 			echo "[pulse-wrapper] Deterministic merge pass skipped ${repo_slug}: repo role is contributor/read-only" >>"$_mr_logfile"
+			_pmp_write_merge_checkpoint "$_mr_checkpoint_file" "$repo_slug"
 			continue
 		fi
 
@@ -429,16 +496,26 @@ merge_ready_prs_all_repos() {
 		local _mr_repo_total_s=0
 		_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
 		_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
+		_pmp_write_merge_checkpoint "$_mr_checkpoint_file" "$repo_slug"
 
 		if [[ -f "$_mr_stop_flag" ]]; then
 			echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$_mr_logfile"
+			_mr_completed_all=0
 			break
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null)
+	done <<<"$_mr_repo_rows"
+
+	if [[ "$_mr_completed_all" -eq 1 ]]; then
+		_pmp_clear_merge_checkpoint "$_mr_checkpoint_file"
+	fi
 
 	# t3193: record the zero-progress signal AFTER all repos have been processed.
+	# Checkpoint-resumed passes intentionally skip this aggregate signal because
+	# they only cover the tail of the repo list; the next fresh full pass records
+	# the all-repo zero-progress state without partial-pass distortion.
 	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
-	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
+	if [[ "$_mr_completed_all" -eq 1 && "$_mr_resumed_from_checkpoint" -eq 0 ]] \
+		&& declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
 		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
 	fi
 

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -52,6 +52,7 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
 : "${STOP_FLAG:=${HOME}/.aidevops/logs/pulse-session.stop}"
 : "${PULSE_MERGE_BATCH_LIMIT:=50}"
+: "${PULSE_MERGE_CHECKPOINT_FILE:=${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 
 #######################################
 # Low-overhead timing helpers for per-repo merge summaries.
@@ -361,6 +362,94 @@ _pmp_log_pr_backlog_counts() {
 	return 0
 }
 
+_pmp_write_merge_checkpoint() {
+	local checkpoint_file="$1"
+	local repo_slug="$2"
+	local checkpoint_dir=""
+
+	[[ -n "$checkpoint_file" && -n "$repo_slug" ]] || return 0
+	checkpoint_dir="${checkpoint_file%/*}"
+	if [[ -n "$checkpoint_dir" && "$checkpoint_dir" != "$checkpoint_file" ]]; then
+		mkdir -p "$checkpoint_dir" 2>/dev/null || return 0
+	fi
+	printf '%s\n' "$repo_slug" >"$checkpoint_file" 2>/dev/null || true
+	return 0
+}
+
+_pmp_clear_merge_checkpoint() {
+	local checkpoint_file="$1"
+
+	[[ -n "$checkpoint_file" ]] || return 0
+	rm -f "$checkpoint_file" 2>/dev/null || true
+	return 0
+}
+
+_pmp_repo_rows_contain_slug() {
+	local repo_rows="$1"
+	local checkpoint_slug="$2"
+	local row_slug="" row_path=""
+
+	[[ -n "$repo_rows" && -n "$checkpoint_slug" ]] || return 1
+	while IFS='|' read -r row_slug row_path; do
+		[[ -n "$row_slug" ]] || continue
+		if [[ "$row_slug" == "$checkpoint_slug" ]]; then
+			return 0
+		fi
+	done <<<"$repo_rows"
+	return 1
+}
+
+_pmp_prepare_merge_checkpoint_resume() {
+	local repo_rows="$1"
+	local checkpoint_file="$2"
+	local logfile="$3"
+	local checkpoint_var="$4"
+	local resume_pending_var="$5"
+	local resumed_var="$6"
+	local checkpoint=""
+	local resume_pending=0
+	local resumed=0
+
+	[[ "$checkpoint_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	[[ "$resume_pending_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	[[ "$resumed_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+
+	if [[ -n "$checkpoint_file" && -f "$checkpoint_file" ]]; then
+		IFS= read -r checkpoint <"$checkpoint_file" || checkpoint=""
+		if [[ -n "$checkpoint" ]]; then
+			if _pmp_repo_rows_contain_slug "$repo_rows" "$checkpoint"; then
+				resume_pending=1
+				resumed=1
+				echo "[pulse-wrapper] Deterministic merge pass resuming after checkpoint repo=${checkpoint}" >>"$logfile"
+			else
+				echo "[pulse-wrapper] Deterministic merge pass ignoring stale checkpoint repo=${checkpoint}" >>"$logfile"
+				_pmp_clear_merge_checkpoint "$checkpoint_file"
+				checkpoint=""
+			fi
+		fi
+	fi
+
+	printf -v "$checkpoint_var" '%s' "$checkpoint"
+	printf -v "$resume_pending_var" '%s' "$resume_pending"
+	printf -v "$resumed_var" '%s' "$resumed"
+	return 0
+}
+
+_pmp_checkpoint_resume_skip_repo() {
+	local repo_slug="$1"
+	local checkpoint="$2"
+	local resume_pending_var="$3"
+	local resume_pending=""
+
+	[[ "$resume_pending_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	resume_pending="${!resume_pending_var}"
+	[[ "$resume_pending" -eq 1 ]] || return 1
+	if [[ "$repo_slug" == "$checkpoint" ]]; then
+		printf -v "$resume_pending_var" '%s' '0'
+	fi
+	return 0
+}
+
 merge_ready_prs_all_repos() {
 	# Initialise required env vars with ${VAR:-default} guards so this
 	# function can be called standalone from pulse-merge-routine.sh (t2862)
@@ -369,6 +458,7 @@ merge_ready_prs_all_repos() {
 	local _mr_stop_flag="${STOP_FLAG:-${HOME}/.aidevops/logs/pulse-session.stop}"
 	local _mr_repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 	local _mr_logfile="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
+	local _mr_checkpoint_file="${PULSE_MERGE_CHECKPOINT_FILE:-${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 	PULSE_MERGE_BATCH_LIMIT="${PULSE_MERGE_BATCH_LIMIT:-50}"
 	local _mr_pass_start
 	_mr_pass_start=$(_pmp_now_epoch)
@@ -388,12 +478,25 @@ merge_ready_prs_all_repos() {
 	local total_failed=0
 
 	local total_eligible_unmerged=0
+	local _mr_repo_rows=""
+	local _mr_checkpoint=""
+	local _mr_resume_pending=0
+	local _mr_resumed_from_checkpoint=0
+	local _mr_completed_all=1
+
+	_mr_repo_rows=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null) || _mr_repo_rows=""
+	_pmp_prepare_merge_checkpoint_resume "$_mr_repo_rows" "$_mr_checkpoint_file" "$_mr_logfile" \
+		_mr_checkpoint _mr_resume_pending _mr_resumed_from_checkpoint || true
 
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" ]] || continue
+		if _pmp_checkpoint_resume_skip_repo "$repo_slug" "$_mr_checkpoint" _mr_resume_pending; then
+			continue
+		fi
 		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
 			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
 			echo "[pulse-wrapper] Deterministic merge pass skipped ${repo_slug}: repo role is contributor/read-only" >>"$_mr_logfile"
+			_pmp_write_merge_checkpoint "$_mr_checkpoint_file" "$repo_slug"
 			continue
 		fi
 
@@ -429,16 +532,26 @@ merge_ready_prs_all_repos() {
 		local _mr_repo_total_s=0
 		_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
 		_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
+		_pmp_write_merge_checkpoint "$_mr_checkpoint_file" "$repo_slug"
 
 		if [[ -f "$_mr_stop_flag" ]]; then
 			echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$_mr_logfile"
+			_mr_completed_all=0
 			break
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null)
+	done <<<"$_mr_repo_rows"
+
+	if [[ "$_mr_completed_all" -eq 1 ]]; then
+		_pmp_clear_merge_checkpoint "$_mr_checkpoint_file"
+	fi
 
 	# t3193: record the zero-progress signal AFTER all repos have been processed.
+	# Checkpoint-resumed passes intentionally skip this aggregate signal because
+	# they only cover the tail of the repo list; the next fresh full pass records
+	# the all-repo zero-progress state without partial-pass distortion.
 	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
-	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
+	if [[ "$_mr_completed_all" -eq 1 && "$_mr_resumed_from_checkpoint" -eq 0 ]] \
+		&& declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
 		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
 	fi
 

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -424,7 +424,7 @@ _pmp_prepare_merge_checkpoint_resume() {
 	[[ "$resumed_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
 
 	if [[ -n "$checkpoint_file" && -f "$checkpoint_file" ]]; then
-		IFS= read -r checkpoint <"$checkpoint_file" || checkpoint=""
+		IFS= read -r checkpoint <"$checkpoint_file" || [[ -n "$checkpoint" ]]
 		if [[ -n "$checkpoint" ]]; then
 			if _pmp_repo_rows_contain_slug "$repo_rows" "$checkpoint"; then
 				resume_pending=1
@@ -556,6 +556,7 @@ merge_ready_prs_all_repos() {
 	local _mr_resume_pending=0
 	local _mr_resumed_from_checkpoint=0
 	local _mr_completed_all=1
+	local repo_slug="" repo_path=""
 
 	_mr_repo_rows=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null) || _mr_repo_rows=""
 	_pmp_prepare_merge_checkpoint_resume "$_mr_repo_rows" "$_mr_checkpoint_file" "$_mr_logfile" \

--- a/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
@@ -147,6 +147,16 @@ merge_ready_prs_all_repos
 assert_equals "fresh pass processes all repos" "org/one org/two org/three " "$PROCESSED_REPOS"
 assert_equals "fresh full pass records zero-progress aggregate" "3:0:0 " "$ZERO_PROGRESS_CALLS"
 
+printf '%s' 'org/one' >"$PULSE_MERGE_CHECKPOINT_FILE"
+PROCESSED_REPOS=""
+merge_ready_prs_all_repos
+assert_equals "checkpoint without newline still resumes" "org/two org/three " "$PROCESSED_REPOS"
+if [[ ! -f "$PULSE_MERGE_CHECKPOINT_FILE" ]]; then
+	pass "checkpoint without newline clears after resume"
+else
+	fail "checkpoint without newline clears after resume" "checkpoint still exists"
+fi
+
 if [[ "$TESTS_FAILED" -eq 0 ]]; then
 	printf '\n%sAll %s tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
 	exit 0

--- a/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+PROCESS_FILE="${SCRIPTS_DIR}/pulse-merge-process.sh"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$name"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	return 0
+}
+
+assert_equals() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected=[$expected] actual=[$actual]"
+	fi
+	return 0
+}
+
+TMPDIR_TEST=$(mktemp -d "${TMPDIR:-/tmp}/pulse-merge-checkpoint-test-XXXXXX") || exit 1
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+export HOME="$TMPDIR_TEST/home"
+mkdir -p "$HOME/.aidevops/logs" "$HOME/.config/aidevops" || exit 1
+export LOGFILE="$HOME/.aidevops/logs/pulse.log"
+export STOP_FLAG="$HOME/.aidevops/logs/pulse-session.stop"
+export REPOS_JSON="$HOME/.config/aidevops/repos.json"
+export PULSE_MERGE_CHECKPOINT_FILE="$HOME/.aidevops/logs/pulse-merge-checkpoint"
+
+cat >"$REPOS_JSON" <<'JSON'
+{
+  "initialized_repos": [
+    {"slug": "org/one", "path": "/tmp/one", "pulse": true},
+    {"slug": "org/two", "path": "/tmp/two", "pulse": true},
+    {"slug": "org/three", "path": "/tmp/three", "pulse": true}
+  ]
+}
+JSON
+
+# shellcheck disable=SC1090
+source "$PROCESS_FILE"
+
+PROCESSED_REPOS=""
+ZERO_PROGRESS_CALLS=""
+STOP_AFTER_REPO=""
+
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	return 0
+}
+
+_merge_ready_prs_for_repo() {
+	local repo_slug="$1"
+	local merged_var="$2"
+	local closed_var="$3"
+	local failed_var="$4"
+	local pr_count_var="${5:-}"
+
+	PROCESSED_REPOS="${PROCESSED_REPOS}${repo_slug} "
+	eval "${merged_var}=0; ${closed_var}=0; ${failed_var}=0"
+	if [[ -n "$pr_count_var" ]]; then
+		printf -v "$pr_count_var" '%s' '0'
+	fi
+	if [[ "$repo_slug" == "$STOP_AFTER_REPO" ]]; then
+		: >"$STOP_FLAG"
+	fi
+	return 0
+}
+
+pulse_merge_stuck_run_pass() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	return 0
+}
+
+_pms_count_eligible_unmerged_for_repo() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	printf '1'
+	return 0
+}
+
+pulse_merge_zero_progress_record() {
+	local eligible_unmerged="$1"
+	local merged="$2"
+	local closed="$3"
+	ZERO_PROGRESS_CALLS="${ZERO_PROGRESS_CALLS}${eligible_unmerged}:${merged}:${closed} "
+	return 0
+}
+
+printf '%sRunning pulse merge checkpoint resume tests (GH#25697)%s\n' "$TEST_GREEN" "$TEST_NC"
+
+STOP_AFTER_REPO="org/two"
+merge_ready_prs_all_repos
+assert_equals "first pass stops after repo two" "org/one org/two " "$PROCESSED_REPOS"
+assert_equals "checkpoint records last fully processed repo" "org/two" "$(tr -d '\n' <"$PULSE_MERGE_CHECKPOINT_FILE")"
+assert_equals "interrupted partial pass does not record zero-progress aggregate" "" "$ZERO_PROGRESS_CALLS"
+
+rm -f "$STOP_FLAG"
+STOP_AFTER_REPO=""
+PROCESSED_REPOS=""
+merge_ready_prs_all_repos
+assert_equals "resumed pass starts after checkpointed repo" "org/three " "$PROCESSED_REPOS"
+if [[ ! -f "$PULSE_MERGE_CHECKPOINT_FILE" ]]; then
+	pass "checkpoint clears after resumed tail completes"
+else
+	fail "checkpoint clears after resumed tail completes" "checkpoint still exists"
+fi
+assert_equals "resumed partial pass skips zero-progress aggregate" "" "$ZERO_PROGRESS_CALLS"
+
+PROCESSED_REPOS=""
+merge_ready_prs_all_repos
+assert_equals "fresh pass processes all repos" "org/one org/two org/three " "$PROCESSED_REPOS"
+assert_equals "fresh full pass records zero-progress aggregate" "3:0:0 " "$ZERO_PROGRESS_CALLS"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '\n%sAll %s tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+fi
+
+printf '\n%s%s/%s tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+exit 1


### PR DESCRIPTION
## Summary
- add a pulse merge checkpoint file that records the last fully processed repo
- resume subsequent merge passes after the checkpointed repo so tail repos are reached
- skip zero-progress aggregate recording on interrupted/resumed partial passes and clear stale/completed checkpoints

Resolves #25697

## Verification
- `.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh`
- `.agents/scripts/tests/test-pulse-merge-routine-timeout.sh`
- `.agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh`
- `bash -n .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh`
- `.agents/scripts/linters-local.sh` (partial: passed SonarCloud, secretlint, shellcheckrc parity, pulse canary, Bash 3.2/portability before timing out in later broad complexity gate)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
