### PR TITLE
GH#25696: fix pulse merge API lookup caching

### DIFF
--- a/.agents/scripts/pulse-merge-author-checks.sh
+++ b/.agents/scripts/pulse-merge-author-checks.sh
@@ -73,6 +73,16 @@ _pulse_author_permission_state_set() {
 	return 0
 }
 
+_pulse_author_permission_cache_key() {
+	local repo_slug="$1"
+	local author="$2"
+	local safe_key=""
+	safe_key=$(printf '%s|%s' "$repo_slug" "$author" | tr -c '[:alnum:]._-' '_')
+	[[ -n "$safe_key" ]] || safe_key="empty"
+	printf '%s' "$safe_key"
+	return 0
+}
+
 #######################################
 # Look up a PR author's repository permission via App-aware REST when available.
 # #aidevops:trust-boundary — collaborator/maintainer trust checks must not
@@ -81,7 +91,7 @@ _pulse_author_permission_state_set() {
 # Output: permission level on lookup success.
 # Returns: 0=lookup success, 2=lookup failure.
 #######################################
-_pulse_author_permission_lookup() {
+_pulse_author_permission_lookup_uncached() {
 	local author="$1"
 	local repo_slug="$2"
 	local out_var="${3:-}"
@@ -115,6 +125,55 @@ _pulse_author_permission_lookup() {
 		printf '%s\n' "$pulse_perm_value"
 	fi
 	return 0
+}
+
+_pulse_author_permission_lookup() {
+	local author="$1"
+	local repo_slug="$2"
+	local out_var="${3:-}"
+	local cache_dir="${AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR:-}"
+	local cache_file="" cache_key=""
+	local cache_rc="" cache_state="" cache_http="" cache_value=""
+	local lookup_rc=0 lookup_value=""
+
+	if [[ -n "$cache_dir" && -d "$cache_dir" ]]; then
+		cache_key=$(_pulse_author_permission_cache_key "$repo_slug" "$author")
+		cache_file="${cache_dir}/${cache_key}"
+		if [[ -f "$cache_file" ]]; then
+			{
+				IFS= read -r cache_rc || cache_rc=""
+				IFS= read -r cache_state || cache_state="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+				IFS= read -r cache_http || cache_http="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+				IFS= read -r cache_value || cache_value="$_PULSE_AUTHOR_PERMISSION_UNKNOWN"
+			} <"$cache_file"
+			[[ "$cache_rc" =~ ^[0-9]+$ ]] || cache_rc=2
+			_pulse_author_permission_state_set "$cache_state" "$cache_http" "$cache_value"
+			if [[ "$cache_rc" -eq 0 ]]; then
+				if [[ -n "$out_var" ]]; then
+					printf -v "$out_var" '%s' "$cache_value"
+				else
+					printf '%s\n' "$cache_value"
+				fi
+				return 0
+			fi
+			return 2
+		fi
+	fi
+
+	_pulse_author_permission_lookup_uncached "$author" "$repo_slug" lookup_value
+	lookup_rc=$?
+	if [[ -n "$cache_file" ]]; then
+		printf '%s\n%s\n%s\n%s\n' "$lookup_rc" "$_PULSE_AUTHOR_PERMISSION_LOOKUP_STATE" "$_PULSE_AUTHOR_PERMISSION_HTTP" "$_PULSE_AUTHOR_PERMISSION_VALUE" >"$cache_file"
+	fi
+	if [[ "$lookup_rc" -eq 0 ]]; then
+		if [[ -n "$out_var" ]]; then
+			printf -v "$out_var" '%s' "$lookup_value"
+		else
+			printf '%s\n' "$lookup_value"
+		fi
+		return 0
+	fi
+	return 2
 }
 
 #######################################

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -109,6 +109,15 @@ _pmp_log_repo_timing_summary() {
 	return 0
 }
 
+_pmp_cache_key() {
+	local raw_key="$1"
+	local safe_key=""
+	safe_key=$(printf '%s' "$raw_key" | tr -c '[:alnum:]._-' '_')
+	[[ -n "$safe_key" ]] || safe_key="empty"
+	printf '%s' "$safe_key"
+	return 0
+}
+
 # PR backlog categories exposed in logs. These are scheduling/observability
 # buckets only; _process_single_ready_pr still enforces every merge safety gate
 # before approving, merging, closing, or dispatching a fix worker.
@@ -519,6 +528,14 @@ _merge_ready_prs_for_repo() {
 		return 0
 	fi
 
+	local AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR=""
+	local AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR=""
+	AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-pulse-required-contexts.XXXXXX" 2>/dev/null) || AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR=""
+	AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-pulse-author-perms.XXXXXX" 2>/dev/null) || AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR=""
+	if [[ -z "$AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR" || -z "$AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR" ]]; then
+		echo "[pulse-wrapper] Merge pass: per-repo cache setup incomplete for ${repo_slug}; continuing without one or more caches (GH#25696)" >>"$LOGFILE"
+	fi
+
 	pr_json=$(_pmp_enrich_prs_with_rest_check_status "$repo_slug" "$pr_json")
 
 	_pmp_log_pr_backlog_counts "$repo_slug" "$pr_json"
@@ -545,6 +562,9 @@ _merge_ready_prs_for_repo() {
 		4) ;;
 		esac
 	done
+
+	[[ -n "$AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR" ]] && rm -rf -- "$AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR"
+	[[ -n "$AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR" ]] && rm -rf -- "$AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR"
 
 	eval "${_merged_var}=${merged}; ${_closed_var}=${closed}; ${_failed_var}=${failed}"
 	return 0
@@ -1329,7 +1349,7 @@ _required_contexts_from_rulesets_for_default_branch() {
 #   1 — real error (default branch resolve failed, or non-404 API error) —
 #       caller MUST fail closed to preserve t2922 invariant.
 #######################################
-_required_contexts_for_default_branch() {
+_required_contexts_for_default_branch_uncached() {
 	local repo_slug="$1"
 	local default_branch="" _db_exit=0
 	default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null)
@@ -1390,6 +1410,44 @@ _required_contexts_for_default_branch() {
 		printf '%s\n' "$ruleset_contexts"
 	fi
 	return 0
+}
+
+_required_contexts_for_default_branch() {
+	local repo_slug="$1"
+	local cache_dir="${AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR:-}"
+	local cache_key="" cache_body_file="" cache_rc_file="" cache_rc=""
+	local contexts="" rc=0
+
+	if [[ -n "$cache_dir" && -d "$cache_dir" ]]; then
+		cache_key=$(_pmp_cache_key "$repo_slug")
+		cache_body_file="${cache_dir}/${cache_key}.body"
+		cache_rc_file="${cache_dir}/${cache_key}.rc"
+		if [[ -f "$cache_rc_file" && -f "$cache_body_file" ]]; then
+			cache_rc=$(<"$cache_rc_file")
+			[[ "$cache_rc" =~ ^[0-9]+$ ]] || cache_rc=1
+			if [[ "$cache_rc" -eq 0 && -s "$cache_body_file" ]]; then
+				while IFS= read -r contexts; do
+					printf '%s\n' "$contexts"
+				done <"$cache_body_file"
+			fi
+			return "$cache_rc"
+		fi
+	fi
+
+	contexts=$(_required_contexts_for_default_branch_uncached "$repo_slug")
+	rc=$?
+	if [[ -n "$cache_body_file" && -n "$cache_rc_file" ]]; then
+		printf '%s\n' "$rc" >"$cache_rc_file"
+		if [[ -n "$contexts" ]]; then
+			printf '%s\n' "$contexts" >"$cache_body_file"
+		else
+			: >"$cache_body_file"
+		fi
+	fi
+	if [[ "$rc" -eq 0 && -n "$contexts" ]]; then
+		printf '%s\n' "$contexts"
+	fi
+	return "$rc"
 }
 
 _check_required_checks_passing() {

--- a/.agents/tests/test-pulse-merge-cycle-cache.sh
+++ b/.agents/tests/test-pulse-merge-cycle-cache.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression checks for per-cycle pulse merge API caches.
+#
+# Usage: bash .agents/tests/test-pulse-merge-cycle-cache.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="${SCRIPT_DIR}/../scripts"
+LOGFILE="${TMPDIR:-/tmp}/aidevops-pulse-cache-test.log"
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+_pass() {
+	local name="$1"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	printf '  [PASS] %s\n' "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local reason="${2:-}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  [FAIL] %s%s\n' "$name" "${reason:+ — ${reason}}"
+	return 0
+}
+
+_gh_permission_calls=0
+_gh_collaborator_permission_lookup() {
+	local repo_slug="$1"
+	local author="$2"
+	local out_var="$3"
+	_gh_permission_calls=$((_gh_permission_calls + 1))
+	[[ "$repo_slug" == "owner/repo" && "$author" == "worker" ]] || return 1
+	printf -v "$out_var" '%s' "write"
+	AIDEVOPS_GH_COLLAB_PERMISSION_HTTP=200
+	return 0
+}
+
+# shellcheck source=../scripts/pulse-merge-author-checks.sh
+source "${SCRIPTS_DIR}/pulse-merge-author-checks.sh"
+
+test_author_permission_lookup_uses_cycle_cache() {
+	local name="author permission lookup caches repo/author within a cycle"
+	local cache_dir="" first_perm="" second_perm=""
+	cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-author-cache-test.XXXXXX") || return 1
+	AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR="$cache_dir"
+	_gh_permission_calls=0
+
+	_pulse_author_permission_lookup "worker" "owner/repo" first_perm || true
+	_pulse_author_permission_lookup "worker" "owner/repo" second_perm || true
+	rm -rf -- "$cache_dir"
+	unset AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR
+
+	if [[ "$first_perm" != "write" || "$second_perm" != "write" ]]; then
+		_fail "$name" "expected cached permission write/write, got ${first_perm}/${second_perm}"
+		return 0
+	fi
+	if [[ "$_gh_permission_calls" -ne 1 ]]; then
+		_fail "$name" "expected 1 API lookup, got ${_gh_permission_calls}"
+		return 0
+	fi
+	_pass "$name"
+	return 0
+}
+
+_GH_REPO_CALLS_FILE="${TMPDIR:-/tmp}/aidevops-context-cache-repo-calls.$$"
+_GH_PROTECTION_CALLS_FILE="${TMPDIR:-/tmp}/aidevops-context-cache-protection-calls.$$"
+_GH_RULESET_CALLS_FILE="${TMPDIR:-/tmp}/aidevops-context-cache-ruleset-calls.$$"
+_increment_counter_file() {
+	local counter_file="$1"
+	local current_value="0"
+	if [[ -f "$counter_file" ]]; then
+		current_value=$(<"$counter_file")
+	fi
+	[[ "$current_value" =~ ^[0-9]+$ ]] || current_value=0
+	current_value=$((current_value + 1))
+	printf '%s\n' "$current_value" >"$counter_file"
+	return 0
+}
+
+_read_counter_file() {
+	local counter_file="$1"
+	local current_value="0"
+	if [[ -f "$counter_file" ]]; then
+		current_value=$(<"$counter_file")
+	fi
+	[[ "$current_value" =~ ^[0-9]+$ ]] || current_value=0
+	printf '%s' "$current_value"
+	return 0
+}
+
+gh() {
+	local subcommand="$1"
+	local endpoint="${2:-}"
+	[[ "$subcommand" == "api" ]] || return 1
+	case "$endpoint" in
+	"repos/owner/repo")
+		_increment_counter_file "$_GH_REPO_CALLS_FILE"
+		printf '%s\n' "main"
+		return 0
+		;;
+	"repos/owner/repo/branches/main/protection/required_status_checks")
+		_increment_counter_file "$_GH_PROTECTION_CALLS_FILE"
+		printf '{"contexts":["ci/test"]}\n'
+		return 0
+		;;
+	"repos/owner/repo/rulesets")
+		_increment_counter_file "$_GH_RULESET_CALLS_FILE"
+		printf '[]\n'
+		return 0
+		;;
+	esac
+	return 1
+}
+
+# shellcheck source=../scripts/pulse-merge-process.sh
+source "${SCRIPTS_DIR}/pulse-merge-process.sh"
+
+test_required_context_lookup_uses_cycle_cache() {
+	local name="required context lookup caches repo default-branch contexts within a cycle"
+	local cache_dir="" first_contexts="" second_contexts=""
+	local repo_calls="" protection_calls="" ruleset_calls=""
+	cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-context-cache-test.XXXXXX") || return 1
+	AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR="$cache_dir"
+	printf '0\n' >"$_GH_REPO_CALLS_FILE"
+	printf '0\n' >"$_GH_PROTECTION_CALLS_FILE"
+	printf '0\n' >"$_GH_RULESET_CALLS_FILE"
+
+	first_contexts=$(_required_contexts_for_default_branch "owner/repo") || true
+	second_contexts=$(_required_contexts_for_default_branch "owner/repo") || true
+	rm -rf -- "$cache_dir"
+	unset AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR
+	repo_calls=$(_read_counter_file "$_GH_REPO_CALLS_FILE")
+	protection_calls=$(_read_counter_file "$_GH_PROTECTION_CALLS_FILE")
+	ruleset_calls=$(_read_counter_file "$_GH_RULESET_CALLS_FILE")
+	rm -f -- "$_GH_REPO_CALLS_FILE" "$_GH_PROTECTION_CALLS_FILE" "$_GH_RULESET_CALLS_FILE"
+
+	if [[ "$first_contexts" != "ci/test" || "$second_contexts" != "ci/test" ]]; then
+		_fail "$name" "expected ci/test contexts, got ${first_contexts}/${second_contexts}"
+		return 0
+	fi
+	if [[ "$repo_calls" -ne 1 || "$protection_calls" -ne 1 || "$ruleset_calls" -ne 1 ]]; then
+		_fail "$name" "expected one repo/protection/ruleset call, got ${repo_calls}/${protection_calls}/${ruleset_calls}"
+		return 0
+	fi
+	_pass "$name"
+	return 0
+}
+
+main() {
+	test_author_permission_lookup_uses_cycle_cache
+	test_required_context_lookup_uses_cycle_cache
+
+	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Cache required branch/ruleset contexts once per merge pass repo cycle.
- Cache collaborator permission lookups by repo/author within the same cycle.
- Add regression coverage for both per-cycle caches.

Resolves #25696

## Verification

- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge-author-checks.sh .agents/tests/test-pulse-merge-cycle-cache.sh`
- `bash .agents/tests/test-pulse-merge-required-checks.sh`
- `bash .agents/tests/test-pulse-merge-cycle-cache.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.1 with gpt-5.5 spent 43m and 128,922 tokens on this with the user in an interactive session.