### PR TITLE
t18023: fix: keep PR mergeable views on GraphQL

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -379,7 +379,7 @@ _rest_pr_view_can_preserve_args() {
 	local field
 	while IFS= read -r field; do
 		case "$field" in
-		statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files|reviewDecision|autoMergeRequest|mergeStateStatus) return 1 ;;
+		mergeable|statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files|reviewDecision|autoMergeRequest|mergeStateStatus) return 1 ;;
 		*) ;;
 		esac
 	done < <(_rest_split_csv "$fields")

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1016,8 +1016,10 @@ unset STUB_PR_VIEW_FIXTURE
 : >"$GH_INFO_OUTPUT"
 export STUB_RATE_LIMIT_REMAINING=0
 export STUB_PR_VIEW_FIXTURE='{"number":123,"mergeable":true}'
+export STUB_PRIMARY_FAIL=1
 
 pr_view_mergeable=$(gh_pr_view 123 --repo "owner/repo" --json mergeable --jq '.mergeable' 2>/dev/null || true)
+unset STUB_PRIMARY_FAIL
 
 if [[ "$pr_view_mergeable" == "MERGEABLE" ]]; then
 	pass "gh_pr_view REST fallback normalizes mergeable=true to MERGEABLE"
@@ -1034,8 +1036,10 @@ unset STUB_PR_VIEW_FIXTURE
 : >"$GH_INFO_OUTPUT"
 export STUB_RATE_LIMIT_REMAINING=0
 export STUB_PR_VIEW_FIXTURE='{"number":123,"mergeable":null}'
+export STUB_PRIMARY_FAIL=1
 
 pr_view_mergeable=$(gh_pr_view 123 --repo "owner/repo" --json mergeable --jq '.mergeable' 2>/dev/null || true)
+unset STUB_PRIMARY_FAIL
 
 if [[ "$pr_view_mergeable" == "UNKNOWN" ]]; then
 	pass "gh_pr_view REST fallback normalizes mergeable=null to UNKNOWN"
@@ -1057,7 +1061,9 @@ export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMP}/pr_view_cache"
 rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"
 
 pr_view_cached_title=$(gh_pr_view 123 --repo "owner/repo" --json title --jq '.title' 2>/dev/null || true)
+export STUB_PRIMARY_FAIL=1
 pr_view_cached_mergeable=$(gh_pr_view 123 --repo "owner/repo" --json mergeable --jq '.mergeable' 2>/dev/null || true)
+unset STUB_PRIMARY_FAIL
 pr_view_rest_calls=$(grep -cE '^api /repos/owner/repo/pulls/123$' "$GH_CALLS" 2>/dev/null || true)
 
 if [[ "$pr_view_cached_title" == "cached title" && "$pr_view_cached_mergeable" == "MERGEABLE" && "$pr_view_rest_calls" == "1" ]]; then
@@ -1236,7 +1242,7 @@ unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIE
 
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
-unsupported_pr_view_fields=(statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
+unsupported_pr_view_fields=(mergeable statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
 unsupported_preserve_ok=1
 for field in "${unsupported_pr_view_fields[@]}"; do
 	if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json "$field"; then


### PR DESCRIPTION
## Summary

Added mergeable to the gh_pr_view GraphQL-only freshness exclusion so REST-first routing no longer proactively projects single-PR mergeability reads, and updated REST fallback tests to force primary failure where mergeable projection is intentionally covered.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

Resolves #25695


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.3 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 39,235 tokens on this as a headless worker.