### PR TITLE
t18018: Add AI sessions workspace

### DIFF
--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -1,6 +1,6 @@
 /* jshint esversion: 11 */
 import { type ReactElement, type ReactNode, useEffect, useState } from "react";
-import { FiAlertTriangle, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
+import { FiAlertTriangle, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiFileText, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiPaperclip, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
 import type { GuiFileRootId, GuiNotificationSummary, GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
 import type { ConversationMode, ShellMode, SurfaceId, SurfaceNavItem } from "./app-model";
@@ -213,29 +213,26 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, selec
   status: GuiStatusData;
 }) {
   const selectedRepo = status.local_repos.repos[selectedLocalRepoIndex] ?? status.local_repos.repos[0];
-  const selectedSession = selectedRepo === undefined
-    ? undefined
-    : status.opencode_sessions.sessions.find((session) => session.id_ref === selectedSessionId && session.repo_path_ref === selectedRepo.path_ref) ?? status.opencode_sessions.sessions.find((session) => session.repo_path_ref === selectedRepo.path_ref);
+  const selectedSession = selectedRepo === undefined ? undefined : sessionForRepo(status, selectedRepo.path_ref, selectedSessionId);
   const title = conversationMode === "ai" ? selectedRepo?.name ?? text.opencodeSessions : text.teams;
 
+  if (conversationMode === "ai") {
+    return <AiSessionsSurface selectedRepoIndex={selectedLocalRepoIndex} selectedSessionId={selectedSession?.id_ref} status={status} />;
+  }
+
   return (
-    <section className="chat-surface" aria-label={conversationMode === "ai" ? text.opencodeSessions : "People chat"}>
+    <section className="chat-surface" aria-label="People chat">
       <div className="chat-thread-panel">
         <header className="chat-thread-header">
           <div>
-            <p className="eyebrow">{conversationMode === "ai" ? text.opencodeSessions : "SimpleX channels"}</p>
+            <p className="eyebrow">SimpleX channels</p>
             <h2><FiHash aria-hidden="true" /> {title}</h2>
           </div>
           <span className="count-pill">{text.readOnly}</span>
         </header>
         <div className="chat-message-list">
-          {conversationMode === "ai" ? <>
-            <ChatBubble speaker="assistant" title={selectedSession?.title ?? "AI session bridge"} body={selectedSession ? `Most recent OpenCode session metadata: ${selectedSession.model} via ${selectedSession.agent}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the turbostarter/ai chat bridge lands.` : "OpenCode session creation and continuation need an audited write route. This panel is ready for the turbostarter/ai chat surface once that adapter is connected."} />
-            <ChatBubble speaker="user" title={selectedRepo?.name ?? "Local repo"} body={selectedRepo ? `Selected repo: ${selectedRepo.path_ref}. Session metadata is grouped per local repo and sorted newest first from ${status.opencode_sessions.path_ref}.` : "No local repos were discovered yet."} />
-          </> : <>
-            <ChatBubble speaker="assistant" title="SimpleX transport" body={text.simplexReady} />
-            <ChatBubble speaker="user" title="People channel" body="Teams and direct messages share the same Slack-like channel layout while protected message payloads remain behind Vault policy." />
-          </>}
+          <ChatBubble speaker="assistant" title="SimpleX transport" body={text.simplexReady} />
+          <ChatBubble speaker="user" title="People channel" body="Teams and direct messages share the same Slack-like channel layout while protected message payloads remain behind Vault policy." />
         </div>
         <form className="chat-composer" aria-label="Chat composer">
           <textarea disabled placeholder={text.chatInputPlaceholder} />
@@ -244,6 +241,72 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, selec
       </div>
     </section>
   );
+}
+
+function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { selectedRepoIndex: number; selectedSessionId?: string; status: GuiStatusData }): ReactElement {
+  const selectedRepo = status.local_repos.repos[selectedRepoIndex] ?? status.local_repos.repos[0];
+  const selectedSession = selectedRepo === undefined ? undefined : sessionForRepo(status, selectedRepo.path_ref, selectedSessionId);
+  const providerOptions = status.oauth_pool.providers.filter((provider) => provider.configured || provider.total > 0);
+  const sessionTitle = selectedSession?.title ?? "AI session bridge";
+  const sessionMeta = selectedSession ? `${selectedSession.model} via ${selectedSession.agent}` : "No OpenCode session metadata selected";
+
+  return (
+    <section className="chat-surface ai-sessions-surface" aria-label={text.aiSessions} data-tour="ai-sessions-surface">
+      <aside className="chat-thread-panel" aria-label="AI session controls" data-tour="ai-session-list">
+        <header className="chat-thread-header">
+          <div>
+            <p className="eyebrow">{text.aiSessions}</p>
+            <h2><FiTerminal aria-hidden="true" /> {selectedRepo?.name ?? "Local workspace"}</h2>
+          </div>
+          <span className="count-pill">{text.readOnly}</span>
+        </header>
+        <div className="notice compact-notice">New, rename, pin, archive, delete, share, and export are visible but disabled until audited AI session write routes land.</div>
+        <div className="sidebar-history-controls">
+          {sessionActions.map((action) => <button disabled key={action} title={`${action} needs the AI session write adapter`} type="button">{action}</button>)}
+        </div>
+        <label className="settings-form"><span>Model/provider</span><select disabled defaultValue={providerOptions[0]?.provider ?? "local"} title="Model switching needs the Turbostarter AI transport adapter.">{providerOptions.length === 0 ? <option value="local">Provider setup required</option> : providerOptions.map((provider) => <option key={provider.provider} value={provider.provider}>{provider.provider} ({provider.available}/{provider.total})</option>)}</select></label>
+      </aside>
+      <div className="chat-thread-panel" data-tour="ai-session-transcript">
+        <header className="chat-thread-header">
+          <div>
+            <p className="eyebrow">{sessionMeta}</p>
+            <h2><FiHash aria-hidden="true" /> {sessionTitle}</h2>
+          </div>
+          <button disabled title="Convert to worker task needs dispatch backend support" type="button">Create worker task</button>
+        </header>
+        <div className="chat-message-list" data-tour="message-scroller">
+          <MessageMarker label="Session status" detail="MessageScroller-compatible transcript; auto-scroll must pause when the reader scrolls away from the latest message." />
+          <ChatBubble speaker="assistant" title={sessionTitle} body={selectedSession ? `Most recent OpenCode session metadata: ${sessionMeta}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the Turbostarter AI chat bridge lands.` : "OpenCode session creation and continuation need an audited write route. This surface is ready for the Turbostarter AI adapter once connected."} />
+          <AttachmentCard label="Context attachment" detail={selectedRepo ? `Selected repo context: ${selectedRepo.path_ref}` : "No local repos were discovered yet."} />
+          <MessageMarker label="Reasoning" detail="Reasoning disclosure, tool status, sources, retries, errors, and token usage render here when the AI transport supplies those parts." />
+          <ToolStatusCard />
+        </div>
+        <form className="chat-composer" aria-label="AI prompt composer" data-tour="ai-composer">
+          <button disabled title="Attachments need the audited upload/context adapter" type="button"><FiPaperclip aria-hidden="true" /> Attach</button>
+          <textarea disabled placeholder={text.chatInputPlaceholder} />
+          <button disabled title="Sending needs the Turbostarter AI transport adapter" type="button">Send</button>
+        </form>
+      </div>
+    </section>
+  );
+}
+
+const sessionActions = ["New", "Rename", "Pin", "Archive", "Delete", "Share", "Export"] as const;
+
+function sessionForRepo(status: GuiStatusData, repoPathRef: string, selectedSessionId: string | undefined) {
+  return status.opencode_sessions.sessions.find((session) => session.id_ref === selectedSessionId && session.repo_path_ref === repoPathRef) ?? status.opencode_sessions.sessions.find((session) => session.repo_path_ref === repoPathRef);
+}
+
+function MessageMarker({ detail, label }: { detail: string; label: string }) {
+  return <article className="chat-bubble assistant"><strong>{label}</strong><p>{detail}</p></article>;
+}
+
+function AttachmentCard({ detail, label }: { detail: string; label: string }) {
+  return <article className="chat-bubble user"><strong><FiFileText aria-hidden="true" /> {label}</strong><p>{detail}</p></article>;
+}
+
+function ToolStatusCard() {
+  return <article className="chat-bubble assistant"><strong>Tool status</strong><p>Tool calls, source citations, retries, errors, and usage metadata are reserved for the shared conversation part model.</p></article>;
 }
 
 function ChatBubble({ body, speaker, title }: { body: string; speaker: "assistant" | "user"; title: string }) {
@@ -304,7 +367,7 @@ function SurfaceContent({ activeItem, activeSurface, fileRoot, openSurface, stat
     notifications: <NotificationsSurface openSurface={openSurface} status={status} />,
     admin: <AdminSurface />,
     vault: <VaultSurface status={status} />,
-    aiSessions: <PlannedSurface label={text.aiSessions} detail={text.aiSessionsIntro} />,
+    aiSessions: <AiSessionsSurface selectedRepoIndex={0} status={status} />,
     channels: <PlannedSurface label={text.channels} detail={text.channelsIntro} />,
     directMessages: <PlannedSurface label={text.directMessages} detail={text.directMessagesIntro} />,
     workers: <PlannedSurface label={text.workers} detail={text.workersIntro} />,

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -244,9 +244,9 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, selec
 }
 
 function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { selectedRepoIndex: number; selectedSessionId?: string; status: GuiStatusData }): ReactElement {
-  const selectedRepo = status.local_repos.repos[selectedRepoIndex] ?? status.local_repos.repos[0];
+  const selectedRepo = status.local_repos?.repos?.[selectedRepoIndex] ?? status.local_repos?.repos?.[0];
   const selectedSession = selectedRepo === undefined ? undefined : sessionForRepo(status, selectedRepo.path_ref, selectedSessionId);
-  const providerOptions = status.oauth_pool.providers.filter((provider) => provider.configured || provider.total > 0);
+  const providerOptions = status.oauth_pool?.providers?.filter((provider) => provider.configured || provider.total > 0) ?? [];
   const sessionTitle = selectedSession?.title ?? "AI session bridge";
   const sessionMeta = selectedSession ? `${selectedSession.model} via ${selectedSession.agent}` : "No OpenCode session metadata selected";
 
@@ -264,7 +264,24 @@ function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { s
         <div className="sidebar-history-controls">
           {sessionActions.map((action) => <button disabled key={action} title={`${action} needs the AI session write adapter`} type="button">{action}</button>)}
         </div>
-        <label className="settings-form"><span>Model/provider</span><select disabled defaultValue={providerOptions[0]?.provider ?? "local"} title="Model switching needs the Turbostarter AI transport adapter.">{providerOptions.length === 0 ? <option value="local">Provider setup required</option> : providerOptions.map((provider) => <option key={provider.provider} value={provider.provider}>{provider.provider} ({provider.available}/{provider.total})</option>)}</select></label>
+        <label className="settings-form">
+          <span>Model/provider</span>
+          <select
+            disabled
+            defaultValue={providerOptions[0]?.provider ?? "local"}
+            title="Model switching needs the Turbostarter AI transport adapter."
+          >
+            {providerOptions.length === 0 ? (
+              <option value="local">Provider setup required</option>
+            ) : (
+              providerOptions.map((provider) => (
+                <option key={provider.provider} value={provider.provider}>
+                  {provider.provider} ({provider.available}/{provider.total})
+                </option>
+              ))
+            )}
+          </select>
+        </label>
       </aside>
       <div className="chat-thread-panel" data-tour="ai-session-transcript">
         <header className="chat-thread-header">
@@ -276,12 +293,20 @@ function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { s
         </header>
         <div className="chat-message-list" data-tour="message-scroller">
           <MessageMarker label="Session status" detail="MessageScroller-compatible transcript; auto-scroll must pause when the reader scrolls away from the latest message." />
-          <ChatBubble speaker="assistant" title={sessionTitle} body={selectedSession ? `Most recent OpenCode session metadata: ${sessionMeta}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the Turbostarter AI chat bridge lands.` : "OpenCode session creation and continuation need an audited write route. This surface is ready for the Turbostarter AI adapter once connected."} />
+          <ChatBubble
+            speaker="assistant"
+            title={sessionTitle}
+            body={
+              selectedSession
+                ? `Most recent OpenCode session metadata: ${sessionMeta}, updated ${selectedSession.updated_at}. Message payloads stay out of the status API until the Turbostarter AI chat bridge lands.`
+                : "OpenCode session creation and continuation need an audited write route. This surface is ready for the Turbostarter AI adapter once connected."
+            }
+          />
           <AttachmentCard label="Context attachment" detail={selectedRepo ? `Selected repo context: ${selectedRepo.path_ref}` : "No local repos were discovered yet."} />
           <MessageMarker label="Reasoning" detail="Reasoning disclosure, tool status, sources, retries, errors, and token usage render here when the AI transport supplies those parts." />
           <ToolStatusCard />
         </div>
-        <form className="chat-composer" aria-label="AI prompt composer" data-tour="ai-composer">
+        <form className="chat-composer ai-composer" aria-label="AI prompt composer" data-tour="ai-composer">
           <button disabled title="Attachments need the audited upload/context adapter" type="button"><FiPaperclip aria-hidden="true" /> Attach</button>
           <textarea disabled placeholder={text.chatInputPlaceholder} />
           <button disabled title="Sending needs the Turbostarter AI transport adapter" type="button">Send</button>
@@ -294,7 +319,8 @@ function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { s
 const sessionActions = ["New", "Rename", "Pin", "Archive", "Delete", "Share", "Export"] as const;
 
 function sessionForRepo(status: GuiStatusData, repoPathRef: string, selectedSessionId: string | undefined) {
-  return status.opencode_sessions.sessions.find((session) => session.id_ref === selectedSessionId && session.repo_path_ref === repoPathRef) ?? status.opencode_sessions.sessions.find((session) => session.repo_path_ref === repoPathRef);
+  const sessions = status.opencode_sessions?.sessions ?? [];
+  return sessions.find((session) => session.id_ref === selectedSessionId && session.repo_path_ref === repoPathRef) ?? sessions.find((session) => session.repo_path_ref === repoPathRef);
 }
 
 function MessageMarker({ detail, label }: { detail: string; label: string }) {

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1355,8 +1355,12 @@ code {
   border-top: 1px solid var(--border);
   display: grid;
   gap: 10px;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   padding: 14px;
+}
+
+.chat-composer.ai-composer {
+  grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
 .chat-composer textarea {

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1288,7 +1288,12 @@ code {
 
 .chat-surface {
   display: grid;
+  gap: 16px;
   min-height: 100%;
+}
+
+.ai-sessions-surface {
+  grid-template-columns: minmax(248px, 320px) minmax(0, 1fr);
 }
 
 .chat-thread-panel {
@@ -1350,7 +1355,7 @@ code {
   border-top: 1px solid var(--border);
   display: grid;
   gap: 10px;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   padding: 14px;
 }
 
@@ -1365,12 +1370,30 @@ code {
 }
 
 .chat-composer button {
+  align-items: center;
   background: color-mix(in srgb, var(--accent) 16%, transparent);
   border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
   border-radius: 14px;
   color: var(--accent);
+  display: inline-flex;
   font-weight: 900;
+  gap: 8px;
   padding: 0 18px;
+}
+
+@media (max-width: 980px) {
+  .ai-sessions-surface {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-composer {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-composer button {
+    justify-content: center;
+    min-height: 44px;
+  }
 }
 
 .hero-panel,

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -284,7 +284,7 @@ const aiSessionsItem: SurfaceNavItem = {
 };
 
 function noop(): void {
-  return undefined;
+  // test callback placeholder
 }
 
 function storageFrom(values: Record<string, string>): Pick<Storage, "getItem"> {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { appearanceStorageKeys, clampSidebarWidth, loadingBrandGlyph, loadingSkeletonPanelLabels, readStoredAppearancePreferences } from "../src/App";
 import { hueFromInputValue } from "../src/AppNavigation";
+import { Workspace } from "../src/AppWorkspace";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
-import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts } from "../src/app-model";
+import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
 
@@ -85,6 +88,39 @@ describe("dashboard shell", () => {
     expect(counts.apps).toBe(2);
     expect(counts.aiSessions).toBe(mockedStatus().data.opencode_sessions.sessions.length);
     expect(counts.repos).toBe(mockedStatus().data.local_repos.total + mockedStatus().data.repos.total);
+  });
+
+  test("renders AI session controls with audited-route placeholders", () => {
+    const status = mockedStatus().data;
+    const html = renderToStaticMarkup(createElement(Workspace, {
+      activeItem: aiSessionsItem,
+      activeSectionLabel: "Development",
+      activeSurface: "aiSessions",
+      canGoBack: false,
+      canGoForward: false,
+      conversationMode: "ai",
+      fileRoot: undefined,
+      goBack: noop,
+      goForward: noop,
+      selectedLocalRepoIndex: 0,
+      selectedSessionId: status.opencode_sessions.sessions[0]?.id_ref,
+      setActiveSurface: noop,
+      setConversationMode: noop,
+      setSelectedLocalRepoIndex: noop,
+      setSelectedSessionId: noop,
+      setShellMode: noop,
+      shellMode: "sessions",
+      status,
+    }));
+
+    expect(html).toContain("AI Sessions");
+    expect(html).toContain("data-tour=\"ai-sessions-surface\"");
+    expect(html).toContain("Model/provider");
+    expect(html).toContain("Create worker task");
+    expect(html).toContain("Context attachment");
+    expect(html).toContain("Tool status");
+    expect(html).toContain("MessageScroller-compatible transcript");
+    expect(html).toContain("New, rename, pin, archive, delete, share, and export");
   });
 
   test("normalizes legacy status payloads from older local API processes", async () => {
@@ -238,6 +274,17 @@ function keyEvent(key: string): Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey
 
 function paletteItem(id: string, label: string, tag: string) {
   return { description: label, icon: "grid" as const, id, label, searchText: label, surface: "overview" as const, tag };
+}
+
+const aiSessionsItem: SurfaceNavItem = {
+  description: "AI session workspace",
+  icon: "terminal",
+  id: "aiSessions",
+  label: "AI Sessions",
+};
+
+function noop(): void {
+  return undefined;
 }
 
 function storageFrom(values: Record<string, string>): Pick<Storage, "getItem"> {


### PR DESCRIPTION
## Summary
- Replace the AI chat placeholder with an AI Sessions workspace for local OpenCode session metadata.
- Add read-only model/provider selection, attachment, reasoning/tool/source/usage affordances, session actions, share/export placeholders, and session-to-worker CTA.
- Add responsive two-column session styling and a server-rendered component test for the audited-route placeholders.

## Verification
- `git diff --check`
- `bun test packages/gui-web/tests`
- `npm run typecheck`

Resolves #25711

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.6 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4h 51m and 872,496 tokens on this with the user in an interactive session. Overall, 3h 59m since this issue was created.
