### PR TITLE
t18019: Add channels and DMs workspace

### DIFF
--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -1,12 +1,12 @@
 /* jshint esversion: 11 */
 import { type ReactElement, type ReactNode, useEffect, useState } from "react";
-import { FiAlertTriangle, FiAtSign, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiFileText, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiPaperclip, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
-import { sortConversationMessageParts, sortConversationMessages, type GuiConversationMessage, type GuiConversationMessagePart, type GuiConversationThread, type GuiFileRootId, type GuiNotificationSummary, type GuiStatusData } from "../../gui-shared/src";
+import { FiAlertTriangle, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiFileText, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiPaperclip, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
+import type { GuiFileRootId, GuiNotificationSummary, GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
 import type { ConversationMode, ShellMode, SurfaceId, SurfaceNavItem } from "./app-model";
 import { inventorySurfaceConfigs, surfaceIds, text } from "./app-model";
 import { CommandPalette, type CommandPaletteSelection, commandPaletteShortcutQuery } from "./CommandPalette";
-import { conversationThreads } from "./conversation-fixtures";
+import { CommsConversationSurface } from "./CommsConversationSurface";
 import { FileExplorerSurface } from "./FileExplorerSurface";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
 import { AiProvidersSurface, LocalReposSurface, LockedVaultGate, OverviewSurface, PlannedSurface, ProjectsSurface, SecuritySurface, VaultSurface } from "./StatusSurfaces";
@@ -224,95 +224,6 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, selec
   return (
     <CommsConversationSurface mode={title === text.teams ? "people" : "channels"} />
   );
-}
-
-function CommsConversationSurface({ mode }: { mode: "channels" | "directMessages" | "people" }): ReactElement {
-  const conversations = mode === "directMessages" ? conversationThreads.filter((thread) => thread.conversation.type === "dm" || thread.conversation.type === "group_dm") : conversationThreads.filter((thread) => thread.conversation.type === "channel");
-  const selectedThread = conversations[0] ?? conversationThreads[0];
-  const partsByMessage = new Map<string, GuiConversationMessagePart[]>();
-
-  for (const part of sortConversationMessageParts(selectedThread.parts)) {
-    partsByMessage.set(part.message_id, [...(partsByMessage.get(part.message_id) ?? []), part]);
-  }
-
-  return (
-    <section className="chat-surface comms-surface" aria-label={mode === "directMessages" ? text.directMessages : text.channels} data-tour="comms-conversations">
-      <aside className="chat-thread-panel conversation-list-panel" aria-label="Conversation list">
-        <header className="chat-thread-header">
-          <div>
-            <p className="eyebrow">Unified conversation model</p>
-            <h2>{mode === "directMessages" ? <FiAtSign aria-hidden="true" /> : <FiHash aria-hidden="true" />} {mode === "directMessages" ? text.directMessages : text.channels}</h2>
-          </div>
-          <button disabled title="Creating conversations needs encrypted transport and audited write routes" type="button">Create</button>
-        </header>
-        <label className="conversation-search"><FiSearch aria-hidden="true" /><span className="sr-only">Search conversations</span><input disabled placeholder="Search channels, DMs, mentions" /></label>
-        <div className="notice compact-notice">{text.simplexReady}</div>
-        <ul className="conversation-list">
-          {conversations.map((thread) => <ConversationListItem key={thread.conversation.id} thread={thread} />)}
-        </ul>
-      </aside>
-      <div className="chat-thread-panel conversation-detail-panel">
-        <header className="chat-thread-header">
-          <div>
-            <p className="eyebrow">{selectedThread.conversation.scope.workspace_ref} · {selectedThread.conversation.status}</p>
-            <h2>{selectedThread.conversation.type === "channel" ? <FiHash aria-hidden="true" /> : <FiMessageSquare aria-hidden="true" />} {selectedThread.conversation.title}</h2>
-          </div>
-          <span className="count-pill">{participantSummary(selectedThread)}</span>
-        </header>
-        <div className="participant-strip">
-          {selectedThread.participants.map((participant) => <span key={participant.id}>{participant.display_name}<small>{participant.kind}</small></span>)}
-        </div>
-        <div className="chat-message-list" data-tour="comms-message-timeline">
-          {sortConversationMessages(selectedThread.messages).map((message) => <ConversationMessageRow key={message.id} message={message} parts={partsByMessage.get(message.id) ?? []} thread={selectedThread} />)}
-        </div>
-        <form className="chat-composer" aria-label="Conversation composer">
-          <textarea disabled placeholder={text.chatInputPlaceholder} />
-          <button disabled title="Sending messages needs the encrypted transport adapter" type="button">Send</button>
-        </form>
-      </div>
-    </section>
-  );
-}
-
-function ConversationListItem({ thread }: { thread: GuiConversationThread }): ReactElement {
-  const latestMessage = sortConversationMessages(thread.messages).at(-1);
-  const unread = unreadCount(thread);
-
-  return (
-    <li>
-      <button className="surface-link" type="button">
-        <span className="surface-icon" aria-hidden="true">{thread.conversation.type === "channel" ? <FiHash /> : <FiMessageSquare />}</span>
-        <span className="surface-copy"><strong>{thread.conversation.title}</strong><small>{latestMessage ? latestMessage.created_at : "No messages yet"}</small></span>
-        {unread > 0 ? <em>{unread}</em> : null}
-      </button>
-    </li>
-  );
-}
-
-function ConversationMessageRow({ message, parts, thread }: { message: GuiConversationMessage; parts: GuiConversationMessagePart[]; thread: GuiConversationThread }): ReactElement {
-  const sender = thread.participants.find((participant) => participant.id === message.sender_participant_id);
-  const reactions = thread.reactions.filter((reaction) => reaction.message_id === message.id);
-  const speaker = message.sender_kind === "human" ? "user" : "assistant";
-
-  return (
-    <article className={`chat-bubble ${speaker}`} data-sender-kind={message.sender_kind}>
-      <strong>{sender?.display_name ?? message.sender_kind}</strong>
-      {parts.map((part) => <p key={part.id}>{part.text ?? part.kind}</p>)}
-      <small>{message.status} · {message.created_at}</small>
-      {reactions.length > 0 ? <div className="reaction-row">{reactions.map((reaction) => <span key={reaction.id}>{reaction.reaction}</span>)}</div> : null}
-    </article>
-  );
-}
-
-function participantSummary(thread: GuiConversationThread): string {
-  const active = thread.participants.filter((participant) => participant.membership_state === "active").length;
-  return `${active} members`;
-}
-
-function unreadCount(thread: GuiConversationThread): number {
-  const lastSequence = Math.max(0, ...thread.messages.map((message) => message.sequence));
-  const localRead = thread.read_states[0]?.last_read_sequence ?? 0;
-  return Math.max(0, lastSequence - localRead);
 }
 
 function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { selectedRepoIndex: number; selectedSessionId?: string; status: GuiStatusData }): ReactElement {

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -1,7 +1,7 @@
 /* jshint esversion: 11 */
 import { type ReactElement, type ReactNode, useEffect, useState } from "react";
-import { FiAlertTriangle, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiFileText, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiPaperclip, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
-import type { GuiFileRootId, GuiNotificationSummary, GuiStatusData } from "../../gui-shared/src";
+import { FiAlertTriangle, FiAtSign, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiFileText, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiPaperclip, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
+import { sortConversationMessageParts, sortConversationMessages, type GuiConversationMessage, type GuiConversationMessagePart, type GuiConversationThread, type GuiFileRootId, type GuiNotificationSummary, type GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
 import type { ConversationMode, ShellMode, SurfaceId, SurfaceNavItem } from "./app-model";
 import { inventorySurfaceConfigs, surfaceIds, text } from "./app-model";
@@ -221,27 +221,135 @@ function ConversationWorkspace({ conversationMode, selectedLocalRepoIndex, selec
   }
 
   return (
-    <section className="chat-surface" aria-label="People chat">
-      <div className="chat-thread-panel">
+    <CommsConversationSurface mode={title === text.teams ? "people" : "channels"} />
+  );
+}
+
+function CommsConversationSurface({ mode }: { mode: "channels" | "directMessages" | "people" }): ReactElement {
+  const conversations = mode === "directMessages" ? conversationThreads.filter((thread) => thread.conversation.type === "dm" || thread.conversation.type === "group_dm") : conversationThreads.filter((thread) => thread.conversation.type === "channel");
+  const selectedThread = conversations[0] ?? conversationThreads[0];
+  const partsByMessage = new Map<string, GuiConversationMessagePart[]>();
+
+  for (const part of sortConversationMessageParts(selectedThread.parts)) {
+    partsByMessage.set(part.message_id, [...(partsByMessage.get(part.message_id) ?? []), part]);
+  }
+
+  return (
+    <section className="chat-surface comms-surface" aria-label={mode === "directMessages" ? text.directMessages : text.channels} data-tour="comms-conversations">
+      <aside className="chat-thread-panel conversation-list-panel" aria-label="Conversation list">
         <header className="chat-thread-header">
           <div>
-            <p className="eyebrow">SimpleX channels</p>
-            <h2><FiHash aria-hidden="true" /> {title}</h2>
+            <p className="eyebrow">Unified conversation model</p>
+            <h2>{mode === "directMessages" ? <FiAtSign aria-hidden="true" /> : <FiHash aria-hidden="true" />} {mode === "directMessages" ? text.directMessages : text.channels}</h2>
           </div>
-          <span className="count-pill">{text.readOnly}</span>
+          <button disabled title="Creating conversations needs encrypted transport and audited write routes" type="button">Create</button>
         </header>
-        <div className="chat-message-list">
-          <ChatBubble speaker="assistant" title="SimpleX transport" body={text.simplexReady} />
-          <ChatBubble speaker="user" title="People channel" body="Teams and direct messages share the same Slack-like channel layout while protected message payloads remain behind Vault policy." />
+        <label className="conversation-search"><FiSearch aria-hidden="true" /><span className="sr-only">Search conversations</span><input disabled placeholder="Search channels, DMs, mentions" /></label>
+        <div className="notice compact-notice">{text.simplexReady}</div>
+        <ul className="conversation-list">
+          {conversations.map((thread) => <ConversationListItem key={thread.conversation.id} thread={thread} />)}
+        </ul>
+      </aside>
+      <div className="chat-thread-panel conversation-detail-panel">
+        <header className="chat-thread-header">
+          <div>
+            <p className="eyebrow">{selectedThread.conversation.scope.workspace_ref} · {selectedThread.conversation.status}</p>
+            <h2>{selectedThread.conversation.type === "channel" ? <FiHash aria-hidden="true" /> : <FiMessageSquare aria-hidden="true" />} {selectedThread.conversation.title}</h2>
+          </div>
+          <span className="count-pill">{participantSummary(selectedThread)}</span>
+        </header>
+        <div className="participant-strip">
+          {selectedThread.participants.map((participant) => <span key={participant.id}>{participant.display_name}<small>{participant.kind}</small></span>)}
         </div>
-        <form className="chat-composer" aria-label="Chat composer">
+        <div className="chat-message-list" data-tour="comms-message-timeline">
+          {sortConversationMessages(selectedThread.messages).map((message) => <ConversationMessageRow key={message.id} message={message} parts={partsByMessage.get(message.id) ?? []} thread={selectedThread} />)}
+        </div>
+        <form className="chat-composer" aria-label="Conversation composer">
           <textarea disabled placeholder={text.chatInputPlaceholder} />
-          <button disabled type="button">Send</button>
+          <button disabled title="Sending messages needs the encrypted transport adapter" type="button">Send</button>
         </form>
       </div>
     </section>
   );
 }
+
+function ConversationListItem({ thread }: { thread: GuiConversationThread }): ReactElement {
+  const latestMessage = sortConversationMessages(thread.messages).at(-1);
+  const unread = unreadCount(thread);
+
+  return (
+    <li>
+      <button className="surface-link" type="button">
+        <span className="surface-icon" aria-hidden="true">{thread.conversation.type === "channel" ? <FiHash /> : <FiMessageSquare />}</span>
+        <span className="surface-copy"><strong>{thread.conversation.title}</strong><small>{latestMessage ? latestMessage.created_at : "No messages yet"}</small></span>
+        {unread > 0 ? <em>{unread}</em> : null}
+      </button>
+    </li>
+  );
+}
+
+function ConversationMessageRow({ message, parts, thread }: { message: GuiConversationMessage; parts: GuiConversationMessagePart[]; thread: GuiConversationThread }): ReactElement {
+  const sender = thread.participants.find((participant) => participant.id === message.sender_participant_id);
+  const reactions = thread.reactions.filter((reaction) => reaction.message_id === message.id);
+  const speaker = message.sender_kind === "human" ? "user" : "assistant";
+
+  return (
+    <article className={`chat-bubble ${speaker}`} data-sender-kind={message.sender_kind}>
+      <strong>{sender?.display_name ?? message.sender_kind}</strong>
+      {parts.map((part) => <p key={part.id}>{part.text ?? part.kind}</p>)}
+      <small>{message.status} · {message.created_at}</small>
+      {reactions.length > 0 ? <div className="reaction-row">{reactions.map((reaction) => <span key={reaction.id}>{reaction.reaction}</span>)}</div> : null}
+    </article>
+  );
+}
+
+function participantSummary(thread: GuiConversationThread): string {
+  const active = thread.participants.filter((participant) => participant.membership_state === "active").length;
+  return `${active} members`;
+}
+
+function unreadCount(thread: GuiConversationThread): number {
+  const lastSequence = Math.max(0, ...thread.messages.map((message) => message.sequence));
+  const localRead = thread.read_states[0]?.last_read_sequence ?? 0;
+  return Math.max(0, lastSequence - localRead);
+}
+
+const conversationThreads: GuiConversationThread[] = [
+  {
+    conversation: { id: "channel-general", type: "channel", title: "general", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:channels/general", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:20:00Z" },
+    participants: [
+      { id: "participant-local", conversation_id: "channel-general", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
+      { id: "participant-ai", conversation_id: "channel-general", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
+      { id: "participant-system", conversation_id: "channel-general", kind: "system_bot", display_name: "System", identity_ref: null, agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
+    ],
+    messages: [
+      { id: "message-general-1", conversation_id: "channel-general", sender_participant_id: "participant-system", sender_kind: "system", sequence: 1, status: "sent", usage: null, created_at: "2026-06-27T12:00:00Z", edited_at: null },
+      { id: "message-general-2", conversation_id: "channel-general", sender_participant_id: "participant-ai", sender_kind: "ai_assistant", sequence: 2, status: "delivered", usage: { provider_ref: "local", model_ref: "workflow-summary", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost_ref: null }, created_at: "2026-06-27T12:15:00Z", edited_at: null },
+    ],
+    parts: [
+      { id: "part-general-1", message_id: "message-general-1", kind: "event_marker", ordinal: 1, text: "#general is ready for repo, deployment, review, and incident coordination.", payload_json: null, file_ref: null, source_ref: "seed" },
+      { id: "part-general-2", message_id: "message-general-2", kind: "text", ordinal: 1, text: "Mention @AI DevOps or a worker to turn a thread into an audited task once write routes land.", payload_json: null, file_ref: null, source_ref: null },
+    ],
+    reactions: [{ id: "reaction-general-1", message_id: "message-general-2", participant_id: "participant-local", reaction: "ack", created_at: "2026-06-27T12:16:00Z" }],
+    read_states: [{ conversation_id: "channel-general", participant_id: "participant-local", last_read_message_id: "message-general-1", last_read_sequence: 1, updated_at: "2026-06-27T12:10:00Z" }],
+  },
+  {
+    conversation: { id: "channel-workers", type: "channel", title: "worker-feed", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: "current" }, source_ref: "seed:channels/worker-feed", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:30:00Z" },
+    participants: [{ id: "participant-worker", conversation_id: "channel-workers", kind: "worker", display_name: "Worker queue", identity_ref: null, agent_ref: null, worker_ref: "workers", membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
+    messages: [{ id: "message-workers-1", conversation_id: "channel-workers", sender_participant_id: "participant-worker", sender_kind: "worker", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:30:00Z", edited_at: null }],
+    parts: [{ id: "part-workers-1", message_id: "message-workers-1", kind: "event_marker", ordinal: 1, text: "Worker events for reviews, deployments, incidents, and releases collect here.", payload_json: null, file_ref: null, source_ref: "seed" }],
+    reactions: [],
+    read_states: [{ conversation_id: "channel-workers", participant_id: "participant-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
+  },
+  {
+    conversation: { id: "dm-ai-devops", type: "dm", title: "AI DevOps", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:dms/ai-devops", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:40:00Z" },
+    participants: [{ id: "participant-dm-local", conversation_id: "dm-ai-devops", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }, { id: "participant-dm-ai", conversation_id: "dm-ai-devops", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
+    messages: [{ id: "message-dm-1", conversation_id: "dm-ai-devops", sender_participant_id: "participant-dm-ai", sender_kind: "ai_assistant", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:40:00Z", edited_at: null }],
+    parts: [{ id: "part-dm-1", message_id: "message-dm-1", kind: "text", ordinal: 1, text: "Direct support threads share the same message parts, participants, reactions, and read state as channels.", payload_json: null, file_ref: null, source_ref: null }],
+    reactions: [],
+    read_states: [{ conversation_id: "dm-ai-devops", participant_id: "participant-dm-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
+  },
+];
 
 function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { selectedRepoIndex: number; selectedSessionId?: string; status: GuiStatusData }): ReactElement {
   const selectedRepo = status.local_repos?.repos?.[selectedRepoIndex] ?? status.local_repos?.repos?.[0];
@@ -394,8 +502,8 @@ function SurfaceContent({ activeItem, activeSurface, fileRoot, openSurface, stat
     admin: <AdminSurface />,
     vault: <VaultSurface status={status} />,
     aiSessions: <AiSessionsSurface selectedRepoIndex={0} status={status} />,
-    channels: <PlannedSurface label={text.channels} detail={text.channelsIntro} />,
-    directMessages: <PlannedSurface label={text.directMessages} detail={text.directMessagesIntro} />,
+    channels: <CommsConversationSurface mode="channels" />,
+    directMessages: <CommsConversationSurface mode="directMessages" />,
     workers: <PlannedSurface label={text.workers} detail={text.workersIntro} />,
     repos: <PlannedSurface label={text.repos} detail={text.reposIntro} />,
     deployments: <PlannedSurface label={text.deployments} detail={text.deploymentsIntro} />,

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -6,6 +6,7 @@ import { SurfaceGlyph } from "./AppNavigation";
 import type { ConversationMode, ShellMode, SurfaceId, SurfaceNavItem } from "./app-model";
 import { inventorySurfaceConfigs, surfaceIds, text } from "./app-model";
 import { CommandPalette, type CommandPaletteSelection, commandPaletteShortcutQuery } from "./CommandPalette";
+import { conversationThreads } from "./conversation-fixtures";
 import { FileExplorerSurface } from "./FileExplorerSurface";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
 import { AiProvidersSurface, LocalReposSurface, LockedVaultGate, OverviewSurface, PlannedSurface, ProjectsSurface, SecuritySurface, VaultSurface } from "./StatusSurfaces";
@@ -313,43 +314,6 @@ function unreadCount(thread: GuiConversationThread): number {
   const localRead = thread.read_states[0]?.last_read_sequence ?? 0;
   return Math.max(0, lastSequence - localRead);
 }
-
-const conversationThreads: GuiConversationThread[] = [
-  {
-    conversation: { id: "channel-general", type: "channel", title: "general", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:channels/general", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:20:00Z" },
-    participants: [
-      { id: "participant-local", conversation_id: "channel-general", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
-      { id: "participant-ai", conversation_id: "channel-general", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
-      { id: "participant-system", conversation_id: "channel-general", kind: "system_bot", display_name: "System", identity_ref: null, agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
-    ],
-    messages: [
-      { id: "message-general-1", conversation_id: "channel-general", sender_participant_id: "participant-system", sender_kind: "system", sequence: 1, status: "sent", usage: null, created_at: "2026-06-27T12:00:00Z", edited_at: null },
-      { id: "message-general-2", conversation_id: "channel-general", sender_participant_id: "participant-ai", sender_kind: "ai_assistant", sequence: 2, status: "delivered", usage: { provider_ref: "local", model_ref: "workflow-summary", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost_ref: null }, created_at: "2026-06-27T12:15:00Z", edited_at: null },
-    ],
-    parts: [
-      { id: "part-general-1", message_id: "message-general-1", kind: "event_marker", ordinal: 1, text: "#general is ready for repo, deployment, review, and incident coordination.", payload_json: null, file_ref: null, source_ref: "seed" },
-      { id: "part-general-2", message_id: "message-general-2", kind: "text", ordinal: 1, text: "Mention @AI DevOps or a worker to turn a thread into an audited task once write routes land.", payload_json: null, file_ref: null, source_ref: null },
-    ],
-    reactions: [{ id: "reaction-general-1", message_id: "message-general-2", participant_id: "participant-local", reaction: "ack", created_at: "2026-06-27T12:16:00Z" }],
-    read_states: [{ conversation_id: "channel-general", participant_id: "participant-local", last_read_message_id: "message-general-1", last_read_sequence: 1, updated_at: "2026-06-27T12:10:00Z" }],
-  },
-  {
-    conversation: { id: "channel-workers", type: "channel", title: "worker-feed", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: "current" }, source_ref: "seed:channels/worker-feed", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:30:00Z" },
-    participants: [{ id: "participant-worker", conversation_id: "channel-workers", kind: "worker", display_name: "Worker queue", identity_ref: null, agent_ref: null, worker_ref: "workers", membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
-    messages: [{ id: "message-workers-1", conversation_id: "channel-workers", sender_participant_id: "participant-worker", sender_kind: "worker", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:30:00Z", edited_at: null }],
-    parts: [{ id: "part-workers-1", message_id: "message-workers-1", kind: "event_marker", ordinal: 1, text: "Worker events for reviews, deployments, incidents, and releases collect here.", payload_json: null, file_ref: null, source_ref: "seed" }],
-    reactions: [],
-    read_states: [{ conversation_id: "channel-workers", participant_id: "participant-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
-  },
-  {
-    conversation: { id: "dm-ai-devops", type: "dm", title: "AI DevOps", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:dms/ai-devops", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:40:00Z" },
-    participants: [{ id: "participant-dm-local", conversation_id: "dm-ai-devops", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }, { id: "participant-dm-ai", conversation_id: "dm-ai-devops", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
-    messages: [{ id: "message-dm-1", conversation_id: "dm-ai-devops", sender_participant_id: "participant-dm-ai", sender_kind: "ai_assistant", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:40:00Z", edited_at: null }],
-    parts: [{ id: "part-dm-1", message_id: "message-dm-1", kind: "text", ordinal: 1, text: "Direct support threads share the same message parts, participants, reactions, and read state as channels.", payload_json: null, file_ref: null, source_ref: null }],
-    reactions: [],
-    read_states: [{ conversation_id: "dm-ai-devops", participant_id: "participant-dm-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
-  },
-];
 
 function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { selectedRepoIndex: number; selectedSessionId?: string; status: GuiStatusData }): ReactElement {
   const selectedRepo = status.local_repos?.repos?.[selectedRepoIndex] ?? status.local_repos?.repos?.[0];

--- a/packages/gui-web/src/CommsConversationSurface.tsx
+++ b/packages/gui-web/src/CommsConversationSurface.tsx
@@ -1,0 +1,93 @@
+import { FiAtSign, FiHash, FiMessageSquare, FiSearch } from "react-icons/fi";
+import { sortConversationMessageParts, sortConversationMessages, type GuiConversationMessage, type GuiConversationMessagePart, type GuiConversationThread } from "../../gui-shared/src";
+import { text } from "./app-model";
+import { conversationThreads } from "./conversation-fixtures";
+
+export function CommsConversationSurface({ mode }: { mode: "channels" | "directMessages" | "people" }) {
+  const conversations = mode === "directMessages" ? conversationThreads.filter((thread) => thread.conversation.type === "dm" || thread.conversation.type === "group_dm") : conversationThreads.filter((thread) => thread.conversation.type === "channel");
+  const selectedThread = conversations[0] ?? conversationThreads[0];
+  const partsByMessage = new Map<string, GuiConversationMessagePart[]>();
+
+  for (const part of sortConversationMessageParts(selectedThread.parts)) {
+    partsByMessage.set(part.message_id, [...(partsByMessage.get(part.message_id) ?? []), part]);
+  }
+
+  return (
+    <section className="chat-surface comms-surface" aria-label={mode === "directMessages" ? text.directMessages : text.channels} data-tour="comms-conversations">
+      <aside className="chat-thread-panel conversation-list-panel" aria-label="Conversation list">
+        <header className="chat-thread-header">
+          <div>
+            <p className="eyebrow">Unified conversation model</p>
+            <h2>{mode === "directMessages" ? <FiAtSign aria-hidden="true" /> : <FiHash aria-hidden="true" />} {mode === "directMessages" ? text.directMessages : text.channels}</h2>
+          </div>
+          <button disabled title="Creating conversations needs encrypted transport and audited write routes" type="button">Create</button>
+        </header>
+        <label className="conversation-search"><FiSearch aria-hidden="true" /><span className="sr-only">Search conversations</span><input disabled placeholder="Search channels, DMs, mentions" /></label>
+        <div className="notice compact-notice">{text.simplexReady}</div>
+        <ul className="conversation-list">
+          {conversations.map((thread) => <ConversationListItem key={thread.conversation.id} thread={thread} />)}
+        </ul>
+      </aside>
+      <div className="chat-thread-panel conversation-detail-panel">
+        <header className="chat-thread-header">
+          <div>
+            <p className="eyebrow">{selectedThread.conversation.scope.workspace_ref} · {selectedThread.conversation.status}</p>
+            <h2>{selectedThread.conversation.type === "channel" ? <FiHash aria-hidden="true" /> : <FiMessageSquare aria-hidden="true" />} {selectedThread.conversation.title}</h2>
+          </div>
+          <span className="count-pill">{participantSummary(selectedThread)}</span>
+        </header>
+        <div className="participant-strip">
+          {selectedThread.participants.map((participant) => <span key={participant.id}>{participant.display_name}<small>{participant.kind}</small></span>)}
+        </div>
+        <div className="chat-message-list" data-tour="comms-message-timeline">
+          {sortConversationMessages(selectedThread.messages).map((message) => <ConversationMessageRow key={message.id} message={message} parts={partsByMessage.get(message.id) ?? []} thread={selectedThread} />)}
+        </div>
+        <form className="chat-composer" aria-label="Conversation composer">
+          <textarea disabled placeholder={text.chatInputPlaceholder} />
+          <button disabled title="Sending messages needs the encrypted transport adapter" type="button">Send</button>
+        </form>
+      </div>
+    </section>
+  );
+}
+
+function ConversationListItem({ thread }: { thread: GuiConversationThread }) {
+  const latestMessage = sortConversationMessages(thread.messages).at(-1);
+  const unread = unreadCount(thread);
+
+  return (
+    <li>
+      <button className="surface-link" type="button">
+        <span className="surface-icon" aria-hidden="true">{thread.conversation.type === "channel" ? <FiHash /> : <FiMessageSquare />}</span>
+        <span className="surface-copy"><strong>{thread.conversation.title}</strong><small>{latestMessage ? latestMessage.created_at : "No messages yet"}</small></span>
+        {unread > 0 ? <em>{unread}</em> : null}
+      </button>
+    </li>
+  );
+}
+
+function ConversationMessageRow({ message, parts, thread }: { message: GuiConversationMessage; parts: GuiConversationMessagePart[]; thread: GuiConversationThread }) {
+  const sender = thread.participants.find((participant) => participant.id === message.sender_participant_id);
+  const reactions = thread.reactions.filter((reaction) => reaction.message_id === message.id);
+  const speaker = message.sender_kind === "human" ? "user" : "assistant";
+
+  return (
+    <article className={`chat-bubble ${speaker}`} data-sender-kind={message.sender_kind}>
+      <strong>{sender?.display_name ?? message.sender_kind}</strong>
+      {parts.map((part) => <p key={part.id}>{part.text ?? part.kind}</p>)}
+      <small>{message.status} · {message.created_at}</small>
+      {reactions.length > 0 ? <div className="reaction-row">{reactions.map((reaction) => <span key={reaction.id}>{reaction.reaction}</span>)}</div> : null}
+    </article>
+  );
+}
+
+function participantSummary(thread: GuiConversationThread): string {
+  const active = thread.participants.filter((participant) => participant.membership_state === "active").length;
+  return `${active} members`;
+}
+
+function unreadCount(thread: GuiConversationThread): number {
+  const lastSequence = Math.max(0, ...thread.messages.map((message) => message.sequence));
+  const localRead = thread.read_states[0]?.last_read_sequence ?? 0;
+  return Math.max(0, lastSequence - localRead);
+}

--- a/packages/gui-web/src/conversation-fixtures.ts
+++ b/packages/gui-web/src/conversation-fixtures.ts
@@ -1,0 +1,38 @@
+import type { GuiConversationThread } from "../../gui-shared/src";
+
+export const conversationThreads: GuiConversationThread[] = [
+  {
+    conversation: { id: "channel-general", type: "channel", title: "general", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:channels/general", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:20:00Z" },
+    participants: [
+      { id: "participant-local", conversation_id: "channel-general", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
+      { id: "participant-ai", conversation_id: "channel-general", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
+      { id: "participant-system", conversation_id: "channel-general", kind: "system_bot", display_name: "System", identity_ref: null, agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" },
+    ],
+    messages: [
+      { id: "message-general-1", conversation_id: "channel-general", sender_participant_id: "participant-system", sender_kind: "system", sequence: 1, status: "sent", usage: null, created_at: "2026-06-27T12:00:00Z", edited_at: null },
+      { id: "message-general-2", conversation_id: "channel-general", sender_participant_id: "participant-ai", sender_kind: "ai_assistant", sequence: 2, status: "delivered", usage: { provider_ref: "local", model_ref: "workflow-summary", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost_ref: null }, created_at: "2026-06-27T12:15:00Z", edited_at: null },
+    ],
+    parts: [
+      { id: "part-general-1", message_id: "message-general-1", kind: "event_marker", ordinal: 1, text: "#general is ready for repo, deployment, review, and incident coordination.", payload_json: null, file_ref: null, source_ref: "seed" },
+      { id: "part-general-2", message_id: "message-general-2", kind: "text", ordinal: 1, text: "Mention @AI DevOps or a worker to turn a thread into an audited task once write routes land.", payload_json: null, file_ref: null, source_ref: null },
+    ],
+    reactions: [{ id: "reaction-general-1", message_id: "message-general-2", participant_id: "participant-local", reaction: "ack", created_at: "2026-06-27T12:16:00Z" }],
+    read_states: [{ conversation_id: "channel-general", participant_id: "participant-local", last_read_message_id: "message-general-1", last_read_sequence: 1, updated_at: "2026-06-27T12:10:00Z" }],
+  },
+  {
+    conversation: { id: "channel-workers", type: "channel", title: "worker-feed", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: "current" }, source_ref: "seed:channels/worker-feed", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:30:00Z" },
+    participants: [{ id: "participant-worker", conversation_id: "channel-workers", kind: "worker", display_name: "Worker queue", identity_ref: null, agent_ref: null, worker_ref: "workers", membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
+    messages: [{ id: "message-workers-1", conversation_id: "channel-workers", sender_participant_id: "participant-worker", sender_kind: "worker", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:30:00Z", edited_at: null }],
+    parts: [{ id: "part-workers-1", message_id: "message-workers-1", kind: "event_marker", ordinal: 1, text: "Worker events for reviews, deployments, incidents, and releases collect here.", payload_json: null, file_ref: null, source_ref: "seed" }],
+    reactions: [],
+    read_states: [{ conversation_id: "channel-workers", participant_id: "participant-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
+  },
+  {
+    conversation: { id: "dm-ai-devops", type: "dm", title: "AI DevOps", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:dms/ai-devops", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:40:00Z" },
+    participants: [{ id: "participant-dm-local", conversation_id: "dm-ai-devops", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }, { id: "participant-dm-ai", conversation_id: "dm-ai-devops", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
+    messages: [{ id: "message-dm-1", conversation_id: "dm-ai-devops", sender_participant_id: "participant-dm-ai", sender_kind: "ai_assistant", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:40:00Z", edited_at: null }],
+    parts: [{ id: "part-dm-1", message_id: "message-dm-1", kind: "text", ordinal: 1, text: "Direct support threads share the same message parts, participants, reactions, and read state as channels.", payload_json: null, file_ref: null, source_ref: null }],
+    reactions: [],
+    read_states: [{ conversation_id: "dm-ai-devops", participant_id: "participant-dm-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
+  },
+];

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1286,6 +1286,14 @@ code {
   gap: 16px;
 }
 
+.sr-only {
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
 .chat-surface {
   display: grid;
   gap: 16px;
@@ -1294,6 +1302,10 @@ code {
 
 .ai-sessions-surface {
   grid-template-columns: minmax(248px, 320px) minmax(0, 1fr);
+}
+
+.comms-surface {
+  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
 }
 
 .chat-thread-panel {
@@ -1351,6 +1363,69 @@ code {
   margin: 0;
 }
 
+.chat-bubble small {
+  color: var(--text-muted);
+}
+
+.chat-bubble[data-sender-kind="system"],
+.chat-bubble[data-sender-kind="worker"] {
+  border-style: dashed;
+}
+
+.conversation-list-panel {
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+}
+
+.conversation-search {
+  align-items: center;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  display: flex;
+  gap: 8px;
+  margin: 14px;
+  padding: 10px 12px;
+}
+
+.conversation-search input {
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  min-width: 0;
+  width: 100%;
+}
+
+.conversation-list {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0 14px 14px;
+}
+
+.participant-strip,
+.reaction-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 18px 0;
+}
+
+.participant-strip span,
+.reaction-row span {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  gap: 6px;
+  padding: 6px 9px;
+}
+
+.participant-strip small {
+  color: var(--text-muted);
+}
+
 .chat-composer {
   border-top: 1px solid var(--border);
   display: grid;
@@ -1386,7 +1461,8 @@ code {
 }
 
 @media (max-width: 980px) {
-  .ai-sessions-surface {
+  .ai-sessions-surface,
+  .comms-surface {
     grid-template-columns: 1fr;
   }
 

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -123,6 +123,22 @@ describe("dashboard shell", () => {
     expect(html).toContain("New, rename, pin, archive, delete, share, and export");
   });
 
+  test("renders channel and DM conversation surfaces from the unified model", () => {
+    const channelHtml = renderWorkspaceSurface(channelsItem, "channels");
+    const dmHtml = renderWorkspaceSurface(directMessagesItem, "directMessages");
+
+    expect(channelHtml).toContain("Unified conversation model");
+    expect(channelHtml).toContain("general");
+    expect(channelHtml).toContain("worker-feed");
+    expect(channelHtml).toContain("data-sender-kind=\"system\"");
+    expect(channelHtml).toContain("ack");
+    expect(channelHtml).toContain("3 members");
+    expect(dmHtml).toContain("Direct Messages");
+    expect(dmHtml).toContain("AI DevOps");
+    expect(dmHtml).toContain("Direct support threads share the same message parts");
+    expect(dmHtml).toContain("Search channels, DMs, mentions");
+  });
+
   test("normalizes legacy status payloads from older local API processes", async () => {
     const legacyFetch = (async () => new Response(JSON.stringify({
       ok: true,
@@ -282,6 +298,43 @@ const aiSessionsItem: SurfaceNavItem = {
   id: "aiSessions",
   label: "AI Sessions",
 };
+
+const channelsItem: SurfaceNavItem = {
+  description: "Team channels",
+  icon: "hash",
+  id: "channels",
+  label: "Channels",
+};
+
+const directMessagesItem: SurfaceNavItem = {
+  description: "Direct messages",
+  icon: "message",
+  id: "directMessages",
+  label: "Direct Messages",
+};
+
+function renderWorkspaceSurface(activeItem: SurfaceNavItem, activeSurface: SurfaceNavItem["id"]): string {
+  return renderToStaticMarkup(createElement(Workspace, {
+    activeItem,
+    activeSectionLabel: "Management",
+    activeSurface,
+    canGoBack: false,
+    canGoForward: false,
+    conversationMode: "people",
+    fileRoot: undefined,
+    goBack: noop,
+    goForward: noop,
+    selectedLocalRepoIndex: 0,
+    selectedSessionId: undefined,
+    setActiveSurface: noop,
+    setConversationMode: noop,
+    setSelectedLocalRepoIndex: noop,
+    setSelectedSessionId: noop,
+    setShellMode: noop,
+    shellMode: "devices",
+    status: mockedStatus().data,
+  }));
+}
 
 function noop(): void {
   // test callback placeholder


### PR DESCRIPTION
## Summary
- Replace channel and direct-message placeholders with a unified conversation-model workspace.
- Seed channel, worker-feed, and DM threads with participants, message parts, reactions, unread/read state, and distinct system/AI/worker rendering.
- Add responsive conversation-list/detail styling plus a server-rendered component test for channel and DM surfaces.

## Verification
- `git diff --check origin/main...HEAD`
- `bun test packages/gui-web/tests`
- `npm run typecheck`
- `.agents/scripts/markdownlint-diff-helper.sh --mode biome --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/biome-25712.md`

Resolves #25712

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.7 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5h 18m and 1,079,061 tokens on this with the user in an interactive session. Overall, 4h 25m since this issue was created.
