### PR TITLE
fix: restore GUI font switcher

### DIFF
--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -69,6 +69,7 @@ body {
     radial-gradient(ellipse at top left, color-mix(in srgb, var(--accent) 16%, transparent) 0%, transparent 36%),
     var(--bg-secondary);
   color: var(--text-primary);
+  font-family: var(--font-family-app);
   line-height: 1.6;
   margin: 0;
   font-size: var(--font-size-app);

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -206,11 +206,13 @@ describe("dashboard shell", () => {
 
   test("ships critical loading styles before React hydrates", () => {
     const html = readFileSync("packages/gui-web/index.html", "utf8");
+    const css = readFileSync("packages/gui-web/src/styles.css", "utf8");
 
     expect(html).toContain("loading-brand-overlay");
     expect(html).toContain("loading-cursor-blink");
     expect(html).toContain("aidevops-gui-theme");
     expect(html).toContain("app-loading-shell");
+    expect(css).toContain("font-family: var(--font-family-app);");
   });
 
   test("maps command palette single-key shortcuts", () => {


### PR DESCRIPTION
Fixes #25732

## Summary
- Restores the GUI font switcher by applying `--font-family-app` on `body`, overriding the critical loading fallback font after hydration.
- Adds a component regression assertion that the app stylesheet keeps the body bound to the font preference CSS variable.

## Verification
- `bun run gui:test:components`
- `bun run typecheck`
- `bun ./node_modules/vite/bin/vite.js build --config packages/gui-web/vite.config.ts`
- `.agents/scripts/linters-local.sh` (required checks passed through Secretlint; broader advisory gates reported existing markdown/ratchet warnings and the full run timed out later in shell portability)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.7 with gpt-5.5 spent 22m and 115,907 tokens on this with the user in an interactive session.