### PR TITLE
GH#25749: chore: remove generated lockfile comment

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,7 +23,6 @@ cloudpickle==3.1.2
 colorlog==6.10.1
 datasets==4.4.1
 dill==0.4.0
-# KNOWN: no patched diskcache release; retained because dspy requires diskcache>=5.6.0.
 diskcache==5.6.3
 distro==1.9.0
 dspy==3.1.0b1


### PR DESCRIPTION
## Summary

Removed the manual diskcache note from requirements-lock.txt while keeping the audited diskcache pin and the durable rationale in requirements.txt.

## Files Changed

requirements-lock.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 assertion confirmed the generated lockfile comment is absent and diskcache==5.6.3 remains; .agents/scripts/linters-local.sh was attempted but timed out after 240s during existing ratchet counting after non-blocking advisory output.

Resolves #25749


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.11 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 6m and 29,863 tokens on this as a headless worker.