### PR TITLE
GH#25742: fix: align pulse merge routine test label

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -323,9 +323,9 @@ parser_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$PARSER_HARNESS" 2>&1)
 parser_rc=$?
 
 if [[ "$parser_rc" -eq 0 ]]; then
-	pass "11: leading --repo defaults to run subcommand"
+	pass "12: leading --repo defaults to run subcommand"
 else
-	fail "11: leading --repo defaults to run subcommand" \
+	fail "12: leading --repo defaults to run subcommand" \
 		"harness rc=${parser_rc}, output=${parser_output}"
 fi
 


### PR DESCRIPTION
## Summary

Updated the pulse merge routine standalone test assertion label from scenario 11 to scenario 12 so it matches the documented scenario list.

## Files Changed

.agents/scripts/tests/test-pulse-merge-routine-standalone.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-routine-standalone.sh && bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh

Resolves #25742


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.11 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 56,790 tokens on this as a headless worker.