### PR TITLE
GH#25736: fix: select latest app job by timestamp

### DIFF
--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -224,7 +224,14 @@ function jobForApp(appId: string, jobs: Record<string, GuiAppActionJobSummary>, 
     return selectedJob;
   }
 
-  return Object.values(jobs).reverse().find((job) => job.app_id === appId) ?? null;
+  let latestJob: GuiAppActionJobSummary | null = null;
+  for (const job of Object.values(jobs)) {
+    if (job.app_id === appId && (latestJob === null || job.started_at > latestJob.started_at)) {
+      latestJob = job;
+    }
+  }
+
+  return latestJob;
 }
 
 function sortedManagedApps(apps: GuiManagedAppSummary[]): GuiManagedAppSummary[] {


### PR DESCRIPTION
## Summary

Updated InventorySurfaces jobForApp to scan matching app jobs once and select the latest started_at timestamp instead of relying on reversed object value order.

## Files Changed

packages/gui-web/src/InventorySurfaces.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun install --ignore-scripts; bun run gui:test:components; bun run typecheck

Resolves #25736


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.11 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 36,699 tokens on this as a headless worker.