### PR TITLE
GH#25740: fix: harden GUI notification followups

### DIFF
--- a/packages/gui-shared/src/notifications.ts
+++ b/packages/gui-shared/src/notifications.ts
@@ -17,7 +17,7 @@ const toastSeverityRank: Record<GuiNotificationSeverity, number> = {
 
 const warningLineMatchers: Array<(line: string) => boolean> = [
   (line) => line.startsWith("Pulse stalled"),
-  (line) => /contribution\(s\) need/i.test(line),
+  (line) => /contribution(\(s\)|s)?\s+needs?/i.test(line),
   (line) => line.startsWith("[OPENCODE MAINTENANCE]"),
   (line) => line.startsWith("[WARNING]"),
   (line) => line.startsWith("[WARN]"),
@@ -28,7 +28,7 @@ const toastTitleRules: Array<{ matches: (line: string) => boolean; title: string
   { matches: (line) => line.startsWith("[ERROR]"), title: "Startup error" },
   { matches: (line) => line.startsWith("[OPENCODE MAINTENANCE]"), title: "OpenCode maintenance" },
   { matches: (line) => line.startsWith("Pulse stalled"), title: "Pulse stalled" },
-  { matches: (line) => /contribution\(s\) need/i.test(line), title: "External contribution review" },
+  { matches: (line) => /contribution(\(s\)|s)?\s+needs?/i.test(line), title: "External contribution review" },
   { matches: (line) => line.startsWith("[WARNING]") || line.startsWith("[WARN]"), title: "Startup warning" },
   { matches: (line) => line.startsWith("Security: all protections active"), title: "Security protections active" },
 ];
@@ -93,10 +93,10 @@ function buildToastNotifications(greetingOutput: string): GuiNotificationSummary
 }
 
 function buildGuiStateNotifications(input: BuildNotificationInput): GuiNotificationSummary[] {
-  const setupNeedsUpdate = input.setupTargets.filter((target) => target.needs_update);
-  const appNeedsUpdate = input.aiApps.filter((app) => app.needs_update);
-  const authErrors = input.oauthPool.providers.filter((provider) => provider.auth_errors > 0);
-  const rateLimited = input.oauthPool.providers.filter((provider) => provider.rate_limited > 0);
+  const setupNeedsUpdate = (input.setupTargets ?? []).filter((target) => target.needs_update);
+  const appNeedsUpdate = (input.aiApps ?? []).filter((app) => app.needs_update);
+  const authErrors = (input.oauthPool?.providers ?? []).filter((provider) => provider.auth_errors > 0);
+  const rateLimited = (input.oauthPool?.providers ?? []).filter((provider) => provider.rate_limited > 0);
   const notifications: GuiNotificationSummary[] = [];
 
   if (input.restartRequired) {

--- a/packages/gui-shared/tests/notifications.test.ts
+++ b/packages/gui-shared/tests/notifications.test.ts
@@ -5,6 +5,9 @@ describe("notification logic", () => {
   test("classifies OpenCode toast lines with the same severity ordering", () => {
     expect(classifyToastLine("[SECURITY ADVISORY] rotate token")).toBe("error");
     expect(classifyToastLine("[WARN] GitHub CLI prerequisite requires gh >= 2.51.0")).toBe("warning");
+    expect(classifyToastLine("1 contribution need maintainer review")).toBe("warning");
+    expect(classifyToastLine("2 contributions need maintainer review")).toBe("warning");
+    expect(classifyToastLine("Contribution(s) needs maintainer review")).toBe("warning");
     expect(classifyToastLine("Security: all protections active")).toBe("success");
     expect(classifyToastLine("aidevops v3.29.0 running in OpenCode v1.17.11")).toBe("info");
     expect(classifyToastLine("UPDATE_AVAILABLE|3.30.0")).toBeNull();
@@ -28,5 +31,15 @@ describe("notification logic", () => {
     expect(notifications.map((notification) => notification.severity)).toContain("success");
     expect(notifications.some((notification) => notification.actions.some((action) => action.kind === "surface" && action.enabled))).toBe(true);
     expect(notifications.find((notification) => notification.id === "gui-restart-required")?.status).toBe("active");
+  });
+
+  test("tolerates partially loaded GUI status payloads", () => {
+    const notifications = buildStatusNotifications({
+      greetingOutput: "Security: all protections active",
+      restartRequired: false,
+    } as Parameters<typeof buildStatusNotifications>[0]);
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.severity).toBe("success");
   });
 });

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -189,21 +189,30 @@ function NotificationsMenu({ notifications, openSurface }: { notifications: GuiN
         <span>{active.length} active</span>
       </div>
       {preview.length === 0 ? <p>No current aidevops notifications.</p> : null}
-      {preview.map((notification) => <NotificationPreview key={notification.id} notification={notification} />)}
+      {preview.map((notification) => (
+        <NotificationPreview
+          key={notification.id}
+          notification={notification}
+          onClick={() => {
+            const action = notification.actions.find((candidate) => candidate.enabled && candidate.kind === "surface" && isSurfaceId(candidate.surface_id));
+            openSurface(action?.kind === "surface" && isSurfaceId(action.surface_id) ? action.surface_id : "notifications");
+          }}
+        />
+      ))}
       <button onClick={() => openSurface("notifications")} role="menuitem" type="button">Open notifications</button>
     </div>
   );
 }
 
-function NotificationPreview({ notification }: { notification: GuiNotificationSummary }): ReactElement {
+function NotificationPreview({ notification, onClick }: { notification: GuiNotificationSummary; onClick: () => void }): ReactElement {
   return (
-    <article className={`notification-preview ${notification.severity}`}>
+    <button className={`notification-preview ${notification.severity}`} onClick={onClick} role="menuitem" type="button">
       <span aria-hidden="true"><NotificationIcon notification={notification} /></span>
       <div>
         <strong>{notification.title}</strong>
         <small>{notification.category} · {notification.status}</small>
       </div>
-    </article>
+    </button>
   );
 }
 
@@ -528,7 +537,7 @@ function NotificationCard({ notification, openSurface }: { notification: GuiNoti
               return <button className="secondary-action" disabled={!action.enabled} key={action.id} onClick={() => openSurface(surfaceId)} type="button">{action.label}</button>;
             }
 
-            return <button className="secondary-action" disabled key={action.id} title={action.command_preview} type="button">{action.label}</button>;
+            return <button className="secondary-action" disabled={!action.enabled} key={action.id} title={action.command_preview} type="button">{action.label}</button>;
           })}
         </div>
       </div>

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -13,6 +13,14 @@
   --font-family-app: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --font-size-app: 16px;
   --glass-panel-shadow: inset 0 1px 0 rgb(255 255 255 / 58%), inset 0 -1px 0 rgb(0 0 0 / 3%), var(--shadow-soft);
+  --notification-error-bg: rgb(207 34 46 / 10%);
+  --notification-error-fg: #cf222e;
+  --notification-info-bg: rgb(9 105 218 / 10%);
+  --notification-info-fg: #0969da;
+  --notification-success-bg: rgb(26 127 55 / 10%);
+  --notification-success-fg: #1a7f37;
+  --notification-warning-bg: rgb(191 135 0 / 12%);
+  --notification-warning-fg: #9a6700;
   --shell-gutter: 8px;
   --shadow-soft: 0 18px 56px rgb(15 23 42 / 9%);
   --surface-elevated: #ffffff;
@@ -43,6 +51,14 @@
   --border-hover: color-mix(in srgb, rgb(255 255 255 / 22%) 74%, rgb(255 255 255 / 40%));
   --code-bg: hsl(var(--accent-hue) 18% 6%);
   --glass-panel-shadow: inset 0 1px 0 rgb(255 255 255 / 10%), inset 0 -1px 0 rgb(0 0 0 / 24%), var(--shadow-soft);
+  --notification-error-bg: rgb(255 123 114 / 13%);
+  --notification-error-fg: #ff7b72;
+  --notification-info-bg: rgb(88 166 255 / 13%);
+  --notification-info-fg: #58a6ff;
+  --notification-success-bg: rgb(86 211 100 / 13%);
+  --notification-success-fg: #56d364;
+  --notification-warning-bg: rgb(210 153 34 / 15%);
+  --notification-warning-fg: #d29922;
   --shadow-soft: 0 24px 80px rgb(0 0 0 / 40%);
   --surface-elevated: #151515;
   --surface-muted: #202020;
@@ -1082,11 +1098,22 @@ code {
 }
 
 .notification-preview {
+  background: var(--notification-bg, transparent);
   border: 1px solid var(--border);
   border-left: 4px solid var(--notification-color, var(--accent));
   border-radius: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
   gap: 10px;
   padding: 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.notification-preview:hover,
+.notification-preview:focus-visible {
+  border-color: var(--notification-color, var(--accent));
+  outline: none;
 }
 
 .notification-preview > span {
@@ -1106,29 +1133,29 @@ code {
 
 .notification-preview.error,
 .github-notification-card.error {
-  --notification-color: #cf222e;
-  --notification-bg: rgb(207 34 46 / 10%);
+  --notification-color: var(--notification-error-fg);
+  --notification-bg: var(--notification-error-bg);
 }
 
 .notification-preview.warning,
 .github-notification-card.warning {
-  --notification-color: #9a6700;
-  --notification-bg: rgb(191 135 0 / 12%);
+  --notification-color: var(--notification-warning-fg);
+  --notification-bg: var(--notification-warning-bg);
 }
 
 .notification-preview.info,
 .github-notification-card.info {
-  --notification-color: #0969da;
-  --notification-bg: rgb(9 105 218 / 10%);
+  --notification-color: var(--notification-info-fg);
+  --notification-bg: var(--notification-info-bg);
 }
 
 .notification-preview.success,
 .github-notification-card.success {
-  --notification-color: #1a7f37;
-  --notification-bg: rgb(26 127 55 / 10%);
+  --notification-color: var(--notification-success-fg);
+  --notification-bg: var(--notification-success-bg);
 }
 
-.popover-menu button,
+.popover-menu button:not(.notification-preview),
 .popover-menu a {
   align-items: center;
   background: transparent;
@@ -1142,9 +1169,9 @@ code {
   text-decoration: none;
 }
 
-.popover-menu button:hover:not(:disabled),
+.popover-menu button:not(.notification-preview):hover:not(:disabled),
 .popover-menu a:hover,
-.popover-menu button:focus-visible,
+.popover-menu button:not(.notification-preview):focus-visible,
 .popover-menu a:focus-visible {
   background: var(--surface-muted);
   color: var(--accent);


### PR DESCRIPTION
## Summary

Hardened GUI notification handling by adding partial status guards, broader contribution toast matching, clickable notification previews, dynamic non-surface action disabled state, and theme-aware notification severity colors.

## Files Changed

packages/gui-shared/src/notifications.ts,packages/gui-shared/tests/notifications.test.ts,packages/gui-web/src/AppWorkspace.tsx,packages/gui-web/src/styles.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun test packages/gui-shared/tests/notifications.test.ts; bun run typecheck; bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build

Resolves #25740


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.11 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 7m and 84,673 tokens on this as a headless worker.