### PR TITLE
GH#25767: fix: sync sidebar session selection

### DIFF
--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -222,6 +222,11 @@ function ConversationSidebar({ conversationMode, selectedLocalRepoIndex, selecte
     ? []
     : status.opencode_sessions.sessions.filter((session) => session.repo_path_ref === selectedRepo.path_ref);
   const activeSessionId = sessions.some((session) => session.id_ref === selectedSessionId) ? selectedSessionId : sessions[0]?.id_ref;
+  useEffect(() => {
+    if (activeSessionId !== selectedSessionId) {
+      setSelectedSessionId(activeSessionId);
+    }
+  }, [activeSessionId, selectedSessionId, setSelectedSessionId]);
   const canSelectPreviousRepo = selectedLocalRepoIndex > 0;
   const canSelectNextRepo = selectedLocalRepoIndex < repos.length - 1;
 


### PR DESCRIPTION
## Summary

Synchronize the parent selectedSessionId with the sidebar's active session fallback so the workspace loads the highlighted session when the current session is missing or belongs to another repository.

## Files Changed

packages/gui-web/src/AppNavigation.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun run gui:test:components; bun run typecheck

Resolves #25767


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.11 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 33,024 tokens on this as a headless worker.