### PR TITLE
GH#25769: fix: buffer gui app action output lines

### DIFF
--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import * as readline from "node:readline";
 import { Hono } from "hono";
 import { APP_ACTION_ROUTE_MANIFEST, APP_ACTION_STATUS_ROUTE_MANIFEST, BANNED_ROUTE_PATTERNS, createEnvelope, FILE_EXPLORER_ROUTE_MANIFEST, type GuiAppActionId, type GuiAppActionJobSummary, STATUS_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
 import { readFileExplorer } from "./file-adapter";
@@ -150,10 +151,16 @@ function startAppActionJob(appId: string, action: GuiAppActionId, command: strin
     env: { ...process.env, AIDEVOPS_NON_INTERACTIVE: "true" },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  child.stdout.on("data", (chunk) => appendJobOutput(job, chunk.toString()));
-  child.stderr.on("data", (chunk) => appendJobOutput(job, chunk.toString()));
+  if (child.stdout !== null) {
+    const stdoutLines = readline.createInterface({ input: child.stdout, terminal: false });
+    stdoutLines.on("line", (line) => appendJobLine(job, line));
+  }
+  if (child.stderr !== null) {
+    const stderrLines = readline.createInterface({ input: child.stderr, terminal: false });
+    stderrLines.on("line", (line) => appendJobLine(job, line));
+  }
   child.on("error", (error) => {
-    appendJobOutput(job, error.message);
+    appendJobLine(job, error.message);
     job.status = "failed";
     job.finished_at = new Date().toISOString();
     job.exit_code = 127;
@@ -167,8 +174,11 @@ function startAppActionJob(appId: string, action: GuiAppActionId, command: strin
   return job;
 }
 
-function appendJobOutput(job: GuiAppActionJobSummary, output: string): void {
-  job.output.push(...output.split(/\r?\n/).filter((line) => line.length > 0).map(redactOutputLine));
+function appendJobLine(job: GuiAppActionJobSummary, line: string): void {
+  if (line.length === 0) {
+    return;
+  }
+  job.output.push(redactOutputLine(line));
   if (job.output.length > 400) {
     job.output.splice(1, job.output.length - 400);
   }


### PR DESCRIPTION
## Summary

Buffered GUI app action stdout and stderr with Node readline so arbitrary stream chunks are parsed as complete lines, with null stream guards and existing redaction/retention behavior preserved.

## Files Changed

packages/gui-api/src/app.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun test packages/gui-api/tests/status-route.test.ts && bun run typecheck

Resolves #25769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.11 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 37,742 tokens on this as a headless worker.