### PR TITLE
GH#25734: fix: harden conversation surface collections

### DIFF
--- a/packages/gui-web/src/CommsConversationSurface.tsx
+++ b/packages/gui-web/src/CommsConversationSurface.tsx
@@ -3,12 +3,29 @@ import { sortConversationMessageParts, sortConversationMessages, type GuiConvers
 import { text } from "./app-model";
 import { conversationThreads } from "./conversation-fixtures";
 
-export function CommsConversationSurface({ mode }: { mode: "channels" | "directMessages" | "people" }) {
-  const conversations = mode === "directMessages" ? conversationThreads.filter((thread) => thread.conversation.type === "dm" || thread.conversation.type === "group_dm") : conversationThreads.filter((thread) => thread.conversation.type === "channel");
-  const selectedThread = conversations[0] ?? conversationThreads[0];
+export function CommsConversationSurface({ mode, threads = conversationThreads }: { mode: "channels" | "directMessages" | "people"; threads?: GuiConversationThread[] }) {
+  const availableThreads = threads ?? [];
+  const conversations = mode === "directMessages" ? availableThreads.filter((thread) => thread.conversation.type === "dm" || thread.conversation.type === "group_dm") : availableThreads.filter((thread) => thread.conversation.type === "channel");
+  const selectedThread = conversations[0] ?? availableThreads[0];
   const partsByMessage = new Map<string, GuiConversationMessagePart[]>();
 
-  for (const part of sortConversationMessageParts(selectedThread.parts)) {
+  if (!selectedThread) {
+    return (
+      <section className="chat-surface comms-surface" aria-label={mode === "directMessages" ? text.directMessages : text.channels} data-tour="comms-conversations">
+        <aside className="chat-thread-panel conversation-list-panel" aria-label="Conversation list">
+          <header className="chat-thread-header">
+            <div>
+              <p className="eyebrow">Unified conversation model</p>
+              <h2>{mode === "directMessages" ? <FiAtSign aria-hidden="true" /> : <FiHash aria-hidden="true" />} {mode === "directMessages" ? text.directMessages : text.channels}</h2>
+            </div>
+          </header>
+          <div className="notice compact-notice">No conversations yet</div>
+        </aside>
+      </section>
+    );
+  }
+
+  for (const part of sortConversationMessageParts(conversationParts(selectedThread))) {
     partsByMessage.set(part.message_id, [...(partsByMessage.get(part.message_id) ?? []), part]);
   }
 
@@ -37,10 +54,10 @@ export function CommsConversationSurface({ mode }: { mode: "channels" | "directM
           <span className="count-pill">{participantSummary(selectedThread)}</span>
         </header>
         <div className="participant-strip">
-          {selectedThread.participants.map((participant) => <span key={participant.id}>{participant.display_name}<small>{participant.kind}</small></span>)}
+          {conversationParticipants(selectedThread).map((participant) => <span key={participant.id}>{participant.display_name}<small>{participant.kind}</small></span>)}
         </div>
         <div className="chat-message-list" data-tour="comms-message-timeline">
-          {sortConversationMessages(selectedThread.messages).map((message) => <ConversationMessageRow key={message.id} message={message} parts={partsByMessage.get(message.id) ?? []} thread={selectedThread} />)}
+          {sortConversationMessages(conversationMessages(selectedThread)).map((message) => <ConversationMessageRow key={message.id} message={message} parts={partsByMessage.get(message.id) ?? []} thread={selectedThread} />)}
         </div>
         <form className="chat-composer" aria-label="Conversation composer">
           <textarea disabled placeholder={text.chatInputPlaceholder} />
@@ -52,7 +69,7 @@ export function CommsConversationSurface({ mode }: { mode: "channels" | "directM
 }
 
 function ConversationListItem({ thread }: { thread: GuiConversationThread }) {
-  const latestMessage = sortConversationMessages(thread.messages).at(-1);
+  const latestMessage = sortConversationMessages(conversationMessages(thread)).at(-1);
   const unread = unreadCount(thread);
 
   return (
@@ -67,8 +84,8 @@ function ConversationListItem({ thread }: { thread: GuiConversationThread }) {
 }
 
 function ConversationMessageRow({ message, parts, thread }: { message: GuiConversationMessage; parts: GuiConversationMessagePart[]; thread: GuiConversationThread }) {
-  const sender = thread.participants.find((participant) => participant.id === message.sender_participant_id);
-  const reactions = thread.reactions.filter((reaction) => reaction.message_id === message.id);
+  const sender = conversationParticipants(thread).find((participant) => participant.id === message.sender_participant_id);
+  const reactions = conversationReactions(thread).filter((reaction) => reaction.message_id === message.id);
   const speaker = message.sender_kind === "human" ? "user" : "assistant";
 
   return (
@@ -82,12 +99,32 @@ function ConversationMessageRow({ message, parts, thread }: { message: GuiConver
 }
 
 function participantSummary(thread: GuiConversationThread): string {
-  const active = thread.participants.filter((participant) => participant.membership_state === "active").length;
+  const active = conversationParticipants(thread).filter((participant) => participant.membership_state === "active").length;
   return `${active} members`;
 }
 
 function unreadCount(thread: GuiConversationThread): number {
-  const lastSequence = Math.max(0, ...thread.messages.map((message) => message.sequence));
-  const localRead = thread.read_states[0]?.last_read_sequence ?? 0;
+  const lastSequence = Math.max(0, ...conversationMessages(thread).map((message) => message.sequence));
+  const localRead = conversationReadStates(thread)[0]?.last_read_sequence ?? 0;
   return Math.max(0, lastSequence - localRead);
+}
+
+function conversationMessages(thread: GuiConversationThread): GuiConversationMessage[] {
+  return thread.messages ?? [];
+}
+
+function conversationParts(thread: GuiConversationThread): GuiConversationMessagePart[] {
+  return thread.parts ?? [];
+}
+
+function conversationParticipants(thread: GuiConversationThread): GuiConversationThread["participants"] {
+  return thread.participants ?? [];
+}
+
+function conversationReactions(thread: GuiConversationThread): GuiConversationThread["reactions"] {
+  return thread.reactions ?? [];
+}
+
+function conversationReadStates(thread: GuiConversationThread): GuiConversationThread["read_states"] {
+  return thread.read_states ?? [];
 }

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -6,9 +6,11 @@ import { appearanceStorageKeys, clampSidebarWidth, loadingBrandGlyph, loadingSke
 import { hueFromInputValue } from "../src/AppNavigation";
 import { Workspace } from "../src/AppWorkspace";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
+import { CommsConversationSurface } from "../src/CommsConversationSurface";
 import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
+import type { GuiConversationThread } from "../../gui-shared/src";
 
 describe("dashboard shell", () => {
   test("renders setup/status placeholders", () => {
@@ -137,6 +139,18 @@ describe("dashboard shell", () => {
     expect(dmHtml).toContain("AI DevOps");
     expect(dmHtml).toContain("Direct support threads share the same message parts");
     expect(dmHtml).toContain("Search channels, DMs, mentions");
+  });
+
+  test("renders conversation threads when optional collections are absent", () => {
+    const html = renderToStaticMarkup(createElement(CommsConversationSurface, {
+      mode: "channels",
+      threads: [{
+        conversation: { id: "channel-partial", type: "channel", title: "partial", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "test", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T00:00:00Z" },
+      } as GuiConversationThread],
+    }));
+
+    expect(html).toContain("partial");
+    expect(html).toContain("0 members");
   });
 
   test("normalizes legacy status payloads from older local API processes", async () => {


### PR DESCRIPTION
## Summary

Hardened the GUI conversation surface against partial thread payloads by defaulting missing messages, participants, parts, reactions, and read states to empty arrays; added a component regression test for missing optional collections.

## Files Changed

packages/gui-web/src/CommsConversationSurface.tsx,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun test packages/gui-web/tests/component.test.ts; bun run typecheck

Resolves #25734


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.12 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 53,810 tokens on this as a headless worker.