### PR TITLE
fix: refine Apps surface layout and filters

### DIFF
--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -29,6 +29,8 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
   const managedApps = sortedManagedApps(status.managed_apps).map((app) => applyManagedPolicyToggles(app, policyToggles[app.id]));
   const visibleManagedApps = managedApps.filter((app) => managedCategoryForApp(app) === managedCategory);
   const visibleRecommendedApps = recommendedApps.filter((app) => recommendedAppMatchesFilters(app, recommendedPlatform, recommendedOs));
+  const selectRecommendedPlatform = (value: RecommendedPlatformFilterId) => setRecommendedPlatform((current) => nextRecommendedFilterValue(current, value, "all"));
+  const selectRecommendedOs = (value: RecommendedOsId) => setRecommendedOs((current) => nextRecommendedFilterValue(current, value, "all"));
 
   useEffect(() => {
     setExpandedAppId(visibleManagedApps[0]?.id ?? null);
@@ -85,7 +87,7 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
           ))}
         </div>
         <p className="empty-state compact-notice">Install/update actions run as allowlisted background jobs and stream inside each app panel. xterm.js with a node-pty bridge is the right next step for full TUI apps such as OpenCode; this view starts with non-interactive command logs.</p>
-      </> : <RecommendedAppsSurface apps={visibleRecommendedApps} os={recommendedOs} platform={recommendedPlatform} setOs={setRecommendedOs} setPlatform={setRecommendedPlatform} />}
+      </> : <RecommendedAppsSurface apps={visibleRecommendedApps} os={recommendedOs} platform={recommendedPlatform} setOs={selectRecommendedOs} setPlatform={selectRecommendedPlatform} />}
     </section>
   );
 }
@@ -120,11 +122,9 @@ function ManagedAppPanel({ app, expanded, job, onJob, onPolicyToggle, onToggle, 
       <div className="managed-app-details">
         <ToggleSwitch checked={app.aidevops_install} disabled={lockedPolicy} label="setup installs" onChange={(value) => onPolicyToggle("setup", value)} />
         <ToggleSwitch checked={app.aidevops_update} disabled={lockedPolicy} label="update maintains" onChange={(value) => onPolicyToggle("update", value)} />
-        <AppMeta label="Installed" value={app.installed_version} />
-        <AppMeta label="Latest" value={app.latest_version} />
-        <AppMeta label={text.path} value={app.install_path_ref} />
         {job ? <AppLogLink job={job} /> : null}
       </div>
+      <AppMeta className="managed-app-path" label={text.path} value={app.install_path_ref} />
       {job ? <AppActionTerminal job={job} /> : null}
       {policyJobs.map((policyJob) => <AppActionTerminal job={policyJob} key={policyJob.id} />)}
       {job === null && policyJobs.length === 0 ? <p className="empty-state compact-notice">No recent command output for this app. Run an action or change a policy toggle to open this app's terminal log.</p> : null}
@@ -146,11 +146,11 @@ function OriginLink({ href, label }: { href: string; label: string }): ReactElem
 }
 
 function ToggleSwitch({ checked, disabled = false, label, onChange }: { checked: boolean; disabled?: boolean; label: string; onChange: (checked: boolean) => void }): ReactElement {
-  return <button aria-pressed={checked} className={checked ? "managed-toggle checked" : "managed-toggle"} data-tooltip={disabled ? "Essential aidevops component; policy is locked on" : undefined} disabled={disabled} onClick={() => onChange(!checked)} title={disabled ? "Essential aidevops component; policy is locked on" : undefined} type="button"><span aria-hidden="true" className={checked ? "switch-track checked" : "switch-track"}><span /></span>{label}</button>;
+  return <button aria-pressed={checked} className={checked ? "managed-toggle checked" : "managed-toggle"} data-tooltip={disabled ? "Essential aidevops component; policy is locked on" : undefined} disabled={disabled} onClick={() => onChange(!checked)} title={disabled ? "Essential aidevops component; policy is locked on" : undefined} type="button"><span className="managed-toggle-label">{label}</span><span aria-hidden="true" className={checked ? "switch-track checked" : "switch-track"}><span /></span></button>;
 }
 
-function AppMeta({ label, value }: { label: string; value: string }): ReactElement {
-  return <span className="app-meta"><small>{label}</small><strong>{value}</strong></span>;
+function AppMeta({ className = "", label, value }: { className?: string; label: string; value: string }): ReactElement {
+  return <span className={className.length > 0 ? `app-meta ${className}` : "app-meta"}><small>{label}</small><strong>{value}</strong></span>;
 }
 
 function AppLogLink({ job }: { job: GuiAppActionJobSummary }): ReactElement {
@@ -291,7 +291,7 @@ interface RecommendedApp {
 }
 
 const appCollectionTabs: TabOption<AppCollectionId>[] = [
-  { id: "aidevops", label: "aidevops" },
+  { id: "aidevops", label: "AIDevOps" },
   { id: "recommended", label: "Recommended" },
 ];
 
@@ -379,8 +379,8 @@ function TabNav<T extends string>({ label, onChange, tabs, value }: { label: str
 function RecommendedAppsSurface({ apps, os, platform, setOs, setPlatform }: { apps: RecommendedApp[]; os: RecommendedOsId; platform: RecommendedPlatformFilterId; setOs: (os: RecommendedOsId) => void; setPlatform: (platform: RecommendedPlatformFilterId) => void }): ReactElement {
   return <>
     <div className="recommended-filter-tabs">
-      <TabNav label="Recommended app platform filters" tabs={recommendedPlatformTabs} value={platform} onChange={setPlatform} />
       <TabNav label="Recommended app operating system filters" tabs={recommendedOsTabs} value={os} onChange={setOs} />
+      <TabNav label="Recommended app platform filters" tabs={recommendedPlatformTabs} value={platform} onChange={setPlatform} />
     </div>
     <div className="recommended-app-grid">
       {apps.map((app) => <RecommendedAppCard app={app} key={app.name} setOs={setOs} setPlatform={setPlatform} />)}
@@ -457,6 +457,10 @@ function recommendedAppMatchesFilters(app: RecommendedApp, platform: Recommended
   const osMatches = os === "all" || app.os.includes(os);
 
   return platformMatches && osMatches;
+}
+
+export function nextRecommendedFilterValue<T extends string>(current: T, next: T, defaultValue: T): T {
+  return current === next && next !== defaultValue ? defaultValue : next;
 }
 
 function applyManagedPolicyToggles(app: GuiManagedAppSummary, policy: Partial<Record<ManagedPolicyId, boolean>> | undefined): GuiManagedAppSummary {

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -147,7 +147,7 @@ export const text = {
   aidevops: "aidevops",
   appShell: "App shell",
   apps: "Apps",
-  appsIntro: "App and CLI inventory for tools installed or updated by aidevops, with origin links, install/update policy, versions, paths, and allowlisted background actions.",
+  appsIntro: "The app toolkit we use and recommend to enable all the things we can do with AI, development, and operations to create and share our work. Opinionated preferences based on open-source-first, lowest-costs, highest-quality UI & UX, teamwork, data security, privacy, and AI-usage capabilities.",
   appStatusPending: "adapter pending",
   brands: "Brands",
   brandsIntro: "Draft brand inventory for names and website references.",

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -943,9 +943,8 @@ code {
 .header-actions > .header-action-menu {
   align-items: center;
   display: inline-flex;
-  flex: 0 0 38px;
+  flex: 0 0 auto;
   justify-content: center;
-  width: 38px;
 }
 
 .workspace-search {
@@ -1001,6 +1000,7 @@ code {
 }
 
 .header-action-menu {
+  gap: 10px;
   position: relative;
 }
 
@@ -1784,15 +1784,23 @@ code {
 }
 
 .section-heading {
-  margin-bottom: 18px;
+  margin-bottom: 16px;
   max-width: 860px;
+}
+
+.section-heading .eyebrow {
+  margin: 0 0 9px;
 }
 
 .section-heading h2 {
   font-size: 1.7rem;
   letter-spacing: -0.05em;
   line-height: 1.04;
-  margin: 6px 0 8px;
+  margin: 0 0 16px;
+}
+
+.section-heading p {
+  margin: 0;
 }
 
 .section-heading p,
@@ -2003,13 +2011,25 @@ code {
 }
 
 .apps-surface {
-  display: grid;
   align-content: start;
-  gap: 10px;
+  display: grid;
+  gap: 0;
 }
 
 .apps-surface .section-heading {
-  margin-bottom: 8px;
+  margin-bottom: 18px;
+}
+
+.apps-surface > .app-subnav {
+  margin-bottom: 18px;
+}
+
+.apps-surface > .app-subnav + .app-subnav {
+  margin-bottom: 16px;
+}
+
+.apps-surface .compact-notice {
+  margin-bottom: 0;
 }
 
 .data-table,
@@ -2021,8 +2041,8 @@ code {
 }
 
 .managed-app-list {
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: 16px;
+  margin-bottom: 16px;
   overflow: visible;
 }
 
@@ -2033,7 +2053,7 @@ code {
   border: 1px solid var(--border);
   border-radius: 18px;
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 7%);
-  overflow: hidden;
+  overflow: visible;
   transition: background 140ms ease, border-color 140ms ease;
 }
 
@@ -2071,14 +2091,23 @@ code {
 .managed-app-title-block,
 .app-meta {
   display: grid;
-  gap: 7px;
   min-width: 0;
+}
+
+.managed-app-title-block {
+  gap: 0;
+}
+
+.managed-app-title-block .eyebrow {
+  line-height: 1;
+  margin: 0 0 8px;
 }
 
 .managed-app-title-block strong {
   font-size: clamp(1.12rem, 2vw, 1.4rem);
   letter-spacing: -0.04em;
   line-height: 1.15;
+  margin-bottom: 16px;
 }
 
 .managed-app-title-block > span:last-child {
@@ -2097,14 +2126,16 @@ code {
 
 .managed-summary-chip {
   align-items: center;
+  align-content: center;
   background: color-mix(in srgb, var(--surface-elevated) 92%, transparent);
   border: 1px solid var(--border);
   border-radius: 999px;
   display: inline-grid;
   gap: 1px;
   justify-items: center;
+  min-height: 58px;
   min-width: 118px;
-  padding: 7px 11px;
+  padding: 7px 12px;
   text-align: center;
 }
 
@@ -2120,6 +2151,7 @@ code {
   color: var(--text-primary);
   font-size: 0.84rem;
   font-weight: 800;
+  line-height: 1.15;
   max-width: 18ch;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2139,7 +2171,7 @@ code {
 .managed-app-body {
   border-top: 1px solid var(--border);
   display: grid;
-  gap: 14px;
+  gap: 16px;
   padding: 0 16px 16px;
   position: relative;
 }
@@ -2147,9 +2179,9 @@ code {
 .managed-app-toolbar {
   align-items: start;
   display: grid;
-  gap: 12px;
+  gap: 16px;
   grid-template-columns: minmax(0, 1fr) auto;
-  padding-top: 14px;
+  padding-top: 16px;
 }
 
 .managed-app-links,
@@ -2195,11 +2227,16 @@ code {
   grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
 }
 
+.managed-app-path {
+  min-height: auto;
+}
+
 .managed-toggle,
 .app-meta {
   background: var(--surface-elevated);
   border: 1px solid var(--border);
   border-radius: 12px;
+  gap: 7px;
   min-width: 0;
   min-height: 64px;
   padding: 10px 12px;
@@ -2211,8 +2248,13 @@ code {
   display: flex;
   font-size: 0.78rem;
   font-weight: 800;
-  gap: 8px;
+  gap: 12px;
+  justify-content: space-between;
   text-transform: uppercase;
+}
+
+.managed-toggle-label {
+  min-width: 0;
 }
 
 button.managed-toggle {
@@ -2236,6 +2278,7 @@ button.managed-toggle:focus-visible {
   border: 1px solid color-mix(in srgb, #ef4444 44%, var(--border));
   border-radius: 999px;
   display: inline-flex;
+  flex: 0 0 auto;
   padding: 2px;
   width: 34px;
 }
@@ -2293,17 +2336,25 @@ button.managed-toggle:focus-visible {
   color: var(--accent);
   display: inline-flex;
   gap: 7px;
-  min-height: 42px;
   justify-content: center;
+  line-height: 1;
+  min-height: 42px;
   padding: 0 12px;
   position: relative;
   transition: background 140ms ease, border-color 140ms ease, color 140ms ease, transform 140ms ease;
 }
 
 .app-action-button span {
+  align-items: center;
+  display: inline-flex;
   font-size: 0.7rem;
   font-weight: 900;
+  line-height: 1;
   text-transform: uppercase;
+}
+
+.app-action-button svg {
+  flex: 0 0 auto;
 }
 
 .app-action-button:hover,
@@ -2421,7 +2472,7 @@ button.managed-toggle:focus-visible {
   content: attr(data-tooltip);
   font-size: 0.72rem;
   font-weight: 700;
-  left: clamp(10px, 50%, calc(100vw - 330px));
+  left: 50%;
   line-height: 1.35;
   max-width: min(320px, 72vw);
   opacity: 0;
@@ -2432,7 +2483,7 @@ button.managed-toggle:focus-visible {
   transform: translate(-50%, 4px);
   transition: opacity 140ms ease, transform 140ms ease;
   width: max-content;
-  z-index: 400;
+  z-index: 1000;
 }
 
 [data-tooltip]:hover::after,
@@ -2526,7 +2577,8 @@ button.managed-toggle:focus-visible {
 .recommended-filter-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 16px;
+  margin-bottom: 16px;
 }
 
 .recommended-app-grid {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -7,10 +7,11 @@ import { hueFromInputValue } from "../src/AppNavigation";
 import { Workspace } from "../src/AppWorkspace";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
 import { CommsConversationSurface } from "../src/CommsConversationSurface";
+import { AppsSurface, nextRecommendedFilterValue } from "../src/InventorySurfaces";
 import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
-import type { GuiConversationThread } from "../../gui-shared/src";
+import type { GuiConversationThread, GuiManagedAppSummary } from "../../gui-shared/src";
 
 describe("dashboard shell", () => {
   test("renders setup/status placeholders", () => {
@@ -175,6 +176,25 @@ describe("dashboard shell", () => {
     expect(status.data.machine.initials).toBe("LM");
   });
 
+  test("renders updated Apps copy, casing, filter order, and compact managed metadata", () => {
+    const html = renderToStaticMarkup(createElement(AppsSurface, { status: { ...mockedStatus().data, managed_apps: [managedAppFixture] } }));
+    const source = readFileSync("packages/gui-web/src/InventorySurfaces.tsx", "utf8");
+
+    expect(html).toContain("AIDevOps");
+    expect(html).toContain("The app toolkit we use and recommend to enable all the things we can do with AI");
+    expect(html).not.toContain("App and CLI inventory for tools installed or updated by aidevops");
+    expect(source.indexOf("Recommended app operating system filters")).toBeLessThan(source.indexOf("Recommended app platform filters"));
+    expect(html).toContain("app-meta managed-app-path");
+    expect(sectionBetween(html, "managed-app-details", "app-meta managed-app-path")).not.toContain("Installed");
+    expect(sectionBetween(html, "managed-app-details", "app-meta managed-app-path")).not.toContain("Latest");
+  });
+
+  test("returns recommended filters to all when the active non-all option is selected again", () => {
+    expect(nextRecommendedFilterValue("macos", "macos", "all")).toBe("all");
+    expect(nextRecommendedFilterValue("macos", "linux", "all")).toBe("linux");
+    expect(nextRecommendedFilterValue("all", "all", "all")).toBe("all");
+  });
+
   test("loads saved appearance preferences before persistence effects run", () => {
     const preferences = readStoredAppearancePreferences(storageFrom({
       [appearanceStorageKeys.accentHue]: "210",
@@ -329,6 +349,22 @@ const directMessagesItem: SurfaceNavItem = {
   label: "Direct Messages",
 };
 
+const managedAppFixture: GuiManagedAppSummary = {
+  actions: [{ command_preview: "aidevops app update aidevops", confirmation: "recommended", enabled: true, id: "update", label: "Update" }],
+  aidevops_install: true,
+  aidevops_update: true,
+  category: "core",
+  description: "Framework CLI, agents, workflows, scripts, and local GUI assets.",
+  id: "aidevops",
+  install_path_ref: "/usr/local/bin/aidevops",
+  installed_version: "3.29.11",
+  latest_version: "3.29.11",
+  name: "aidevops",
+  origin_repo_url: "",
+  origin_website_url: "",
+  status: "found",
+};
+
 function renderWorkspaceSurface(activeItem: SurfaceNavItem, activeSurface: SurfaceNavItem["id"]): string {
   return renderToStaticMarkup(createElement(Workspace, {
     activeItem,
@@ -354,6 +390,16 @@ function renderWorkspaceSurface(activeItem: SurfaceNavItem, activeSurface: Surfa
 
 function noop(): void {
   // test callback placeholder
+}
+
+function sectionBetween(text: string, startNeedle: string, endNeedle: string): string {
+  const start = text.indexOf(startNeedle);
+  const end = text.indexOf(endNeedle, start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThanOrEqual(start);
+
+  return text.slice(start, end);
 }
 
 function storageFrom(values: Record<string, string>): Pick<Storage, "getItem"> {


### PR DESCRIPTION
## Summary
- Update Apps intro copy and the collection tab casing to `AIDevOps`.
- Put recommended OS filters before interface filters and make repeated non-All selections reset to All.
- Tighten Apps spacing, align summary/action button text, fix header action spacing, raise tooltips, move policy switches right of labels, and move path metadata to its own expanded row.

## Files changed
- `packages/gui-web/src/app-model.ts`
- `packages/gui-web/src/InventorySurfaces.tsx`
- `packages/gui-web/src/styles.css`
- `packages/gui-web/tests/component.test.ts`

## Verification
- `bun run gui:test:components` — 19 pass, 0 fail
- `bun run typecheck` — pass
- `bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build` — pass
- `git diff --check` — pass
- `.agents/scripts/linters-local.sh` — partial pass; timed out during repository-wide shell portability after relevant UI gates, Secretlint, layout, Bash 3.2, and advisory checks completed

## Notes
- Resolves #25785.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.12 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 27m and 292,831 tokens on this with the user in an interactive session.
