### PR TITLE
GH#25779: fix: pass review thread fingerprints to workers

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -658,7 +658,8 @@ _prrts_write_prompt_file() {
 	local pr_number="$3"
 	local title="$4"
 	local thread_count="$5"
-	local preview="$6"
+	local fingerprint="$6"
+	local preview="$7"
 	local prompt_file="" safe_slug=""
 	_prrts_ensure_dirs
 	safe_slug="$(_prrts_safe_slug "$repo_slug")"
@@ -670,6 +671,7 @@ Target: PR #${pr_number} in ${repo_slug}
 Local repo path: ${repo_path}
 PR title: ${title}
 Detected unresolved bot review threads: ${thread_count}
+Unresolved thread IDs: ${fingerprint}
 Thread preview: ${preview}
 
 ## Required workflow
@@ -712,7 +714,8 @@ _prrts_dispatch_worker() {
 	local pr_number="$3"
 	local title="$4"
 	local thread_count="$5"
-	local preview="$6"
+	local fingerprint="$6"
+	local preview="$7"
 	local prompt_file="" session_key="" model=""
 	local -a cmd
 
@@ -720,7 +723,7 @@ _prrts_dispatch_worker() {
 		_prrts_log "dispatch: headless-runtime-helper missing or not executable: ${HEADLESS_RUNTIME_HELPER}"
 		return 1
 	fi
-	prompt_file="$(_prrts_write_prompt_file "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$preview")"
+	prompt_file="$(_prrts_write_prompt_file "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview")"
 	session_key="$(_prrts_session_key "$repo_slug" "$pr_number")"
 	cmd=("$HEADLESS_RUNTIME_HELPER" run
 		--role worker
@@ -768,7 +771,7 @@ _prrts_dispatch_guarded() {
 		_prrts_remove_lock_dir "$lock_dir"
 		return 0
 	fi
-	if ! _prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$preview"; then
+	if ! _prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview"; then
 		_prrts_remove_lock_dir "$lock_dir"
 		return 1
 	fi

--- a/.agents/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/tests/test-pr-review-thread-response-scanner.sh
@@ -169,10 +169,48 @@ test_reply_prepends_author_when_first_content_is_not_mention() {
 	return 0
 }
 
+test_dispatch_prompt_includes_thread_fingerprint() {
+	printf '==> dispatch prompt includes unresolved thread IDs\n'
+	_setup
+	local fake_bin="${TEST_TMPDIR}/bin"
+	local capture="${TEST_TMPDIR}/gh-args.log"
+	local fake_headless="${TEST_TMPDIR}/headless-runtime-helper.sh"
+	local state_dir="${TEST_TMPDIR}/state"
+	local prompt_file="${state_dir}/marcusquinn-aidevops-123-prompt.md"
+	_write_fake_gh "$fake_bin"
+	mkdir -p "$(dirname "$fake_headless")"
+	cat >"$fake_headless" <<'FAKE_HEADLESS'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+FAKE_HEADLESS
+	chmod +x "$fake_headless"
+
+	if FAKE_GH_CAPTURE="$capture" \
+		AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="$state_dir" \
+		HEADLESS_RUNTIME_HELPER="$fake_headless" \
+		PATH="${fake_bin}:$PATH" \
+		"$SCANNER" dispatch-pr "marcusquinn/aidevops" "$TEST_TMPDIR" "123"; then
+		_pass "dispatch-pr succeeds"
+	else
+		_fail "dispatch-pr succeeds"
+	fi
+
+	if [[ -f "$prompt_file" ]] && grep -q -- 'Unresolved thread IDs: THREAD_1:' "$prompt_file"; then
+		_pass "prompt exposes GraphQL thread ID fingerprint"
+	else
+		_fail "prompt exposes GraphQL thread ID fingerprint" "prompt: ${prompt_file}"
+	fi
+
+	_teardown
+	return 0
+}
+
 main() {
 	test_scan_passes_nonempty_owner_and_name_to_graphql
 	test_reply_recognises_existing_mention_after_whitespace_and_comment
 	test_reply_prepends_author_when_first_content_is_not_mention
+	test_dispatch_prompt_includes_thread_fingerprint
 	printf 'Results: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1


### PR DESCRIPTION
## Summary

Forwarded unresolved review thread fingerprints from dispatch guard through worker prompt generation so workers receive GraphQL thread IDs; added focused dispatch-pr regression coverage for prompt content.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh,.agents/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pr-review-thread-response-scanner.sh && shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/tests/test-pr-review-thread-response-scanner.sh

Resolves #25779


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.14 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 63,268 tokens on this as a headless worker.