### PR TITLE
fix: refine Apps terminal and links

### DIFF
--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -148,7 +148,7 @@ function startAppActionJob(appId: string, action: GuiAppActionId, command: strin
 
   const child = spawn(command[0], command.slice(1), {
     cwd: process.cwd(),
-    env: { ...process.env, AIDEVOPS_NON_INTERACTIVE: "true" },
+    env: { ...process.env, AIDEVOPS_NON_INTERACTIVE: "true", CLICOLOR_FORCE: "1", FORCE_COLOR: "1", TERM: process.env.TERM ?? "xterm-256color" },
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (child.stdout !== null) {

--- a/packages/gui-api/src/status-managed-apps.ts
+++ b/packages/gui-api/src/status-managed-apps.ts
@@ -119,7 +119,7 @@ const MANAGED_APP_DEFINITIONS: ManagedAppDefinition[] = [
     category: "automation",
     binary: null,
     version_args: [],
-    install_path_refs: ["~/Library/LaunchAgents/sh.aidevops.pulse.plist", "~/.aidevops/.agent-workspace/pulse"],
+    install_path_refs: ["~/Library/LaunchAgents/sh.aidevops.pulse.plist", "~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist", "~/Library/LaunchAgents/sh.aidevops.supervisor-pulse.plist", "~/.aidevops/.agent-workspace/pulse"],
     origin_website_url: "https://aidevops.sh",
     origin_repo_url: "https://github.com/marcusquinn/aidevops.git",
     aidevops_install: true,
@@ -143,7 +143,7 @@ const MANAGED_APP_DEFINITIONS: ManagedAppDefinition[] = [
   binaryApp({ id: "cursor", name: "Cursor CLI", description: "Cursor command-line integration and config targets.", category: "cli", binary: "cursor", version_args: ["--version"], install_path_refs: ["~/.cursor/bin/cursor", "/Applications/Cursor.app"], origin_website_url: "https://cursor.com/install", origin_repo_url: "" }),
   binaryApp({ id: "zed", name: "Zed", description: "Optional editor installed by setup when selected.", category: "editor", binary: "zed", version_args: ["--version"], install_path_refs: ["/Applications/Zed.app", "/opt/homebrew/bin/zed", "/usr/local/bin/zed"], origin_website_url: "https://zed.dev/download", origin_repo_url: "", aidevops_install: false, aidevops_update: false }),
   binaryApp({ id: "orbstack", name: "OrbStack", description: "Optional local container/VM runtime for macOS development.", category: "runtime", binary: "orb", version_args: ["version"], install_path_refs: ["/Applications/OrbStack.app", "/opt/homebrew/bin/orb"], origin_website_url: "https://orbstack.dev/", origin_repo_url: "", aidevops_install: false, aidevops_update: false }),
-  binaryApp({ id: "ollama", name: "Ollama", description: "Optional local model runtime for local AI workflows.", category: "ai runtime", binary: "ollama", version_args: ["--version"], install_path_refs: ["/Applications/Ollama.app", "/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"], origin_website_url: "https://ollama.com", origin_repo_url: "" }),
+  binaryApp({ id: "ollama", name: "Ollama", description: "Optional local model runtime for local AI workflows.", category: "ai runtime", binary: "ollama", version_args: ["--version"], install_path_refs: ["~/Applications/Ollama.app", "/Applications/Ollama.app", "/opt/homebrew/bin/ollama", "/usr/local/bin/ollama"], origin_website_url: "https://ollama.com", origin_repo_url: "" }),
 ];
 
 export function readManagedApps(latestVersion: string, installedVersion: string): GuiManagedAppSummary[] {
@@ -200,7 +200,7 @@ function managedAppSummary(definition: ManagedAppDefinition, latestVersion: stri
     aidevops_update: definition.aidevops_update,
     installed_version: installedVersionText,
     latest_version: latestVersionText,
-    install_path_ref: binaryPath === null ? installPathRef : collapseHome(binaryPath),
+    install_path_ref: collapseHome(binaryPath ?? expandHome(installPathRef)),
     status: binaryPath !== null || definition.install_path_refs.some((pathRef) => existsSync(expandHome(pathRef))) ? "found" : "missing",
     actions: (["install", "update", "reinstall", "remove"] as const).map((action) => managedAppAction(definition.action_commands, action)),
   };

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -33,6 +33,8 @@ describe("status adapter", () => {
     expect(JSON.stringify(response.data.oauth_pool)).not.toContain("\"refresh\"");
     expect(response.data.setup_targets.map((target) => target.path_ref)).toContain("~/.aidevops/agents/VERSION");
     expect(response.data.setup_targets.every((target) => typeof target.needs_update === "boolean")).toBe(true);
+    expect(response.data.managed_apps.map((app) => app.id)).toContain("pulse");
+    expect(response.data.managed_apps.find((app) => app.id === "ollama")?.install_path_ref).not.toBe("not found");
     expect(response.data.ai_apps.map((app) => app.name)).toEqual(["OpenCode", "Claude Code", "Codex CLI", "Cursor"]);
     expect(JSON.stringify(response.data.ai_apps)).not.toContain("token");
     expect(response.data.notifications.every((notification) => notification.source_ref.length > 0)).toBe(true);

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -396,6 +396,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         }
     }
 
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if isLocalAppURL(url) {
+            decisionHandler(.allow)
+            return
+        }
+
+        if url.scheme == "http" || url.scheme == "https" {
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+
+    private func isLocalAppURL(_ url: URL) -> Bool {
+        let host = url.host ?? ""
+        return (host == "127.0.0.1" || host == "localhost") && url.port == Int(webPort)
+    }
+
     private func configureMenu() {
         let appName = "aidevops"
         let mainMenu = NSMenu(title: "Main Menu")

--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -247,17 +247,18 @@ function renderTerminalOutput(lines: string[]): ReactNode[] {
 
 function renderAnsiLine(line: string, keyPrefix: string): ReactNode[] {
   const nodes: ReactNode[] = [];
-  const ansiPattern = /\u001b\[([0-9;]*)m/g;
+  const ansiPattern = new RegExp("\\x1b\\[([0-9;]*)m", "g");
   let activeClass = "";
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
+  let match = ansiPattern.exec(line);
 
-  while ((match = ansiPattern.exec(line)) !== null) {
+  while (match !== null) {
     if (match.index > lastIndex) {
       nodes.push(terminalSpan(line.slice(lastIndex, match.index), activeClass, `${keyPrefix}-${nodes.length}`));
     }
     activeClass = ansiClassForCodes(match[1]);
     lastIndex = ansiPattern.lastIndex;
+    match = ansiPattern.exec(line);
   }
 
   if (lastIndex < line.length) {

--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -1,8 +1,8 @@
 import type { GuiAppActionId, GuiAppActionJobSummary, GuiManagedAppSummary, GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
-import { type Dispatch, type MouseEvent as ReactMouseEvent, type ReactElement, type SetStateAction, useEffect, useRef, useState } from "react";
+import { type Dispatch, type MouseEvent as ReactMouseEvent, type ReactElement, type ReactNode, type SetStateAction, useEffect, useRef, useState } from "react";
 import type { IconType } from "react-icons";
 import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
-import { FiChevronDown, FiCode, FiDownload, FiExternalLink, FiGlobe, FiMonitor, FiRefreshCw, FiRepeat, FiTerminal, FiTrash2 } from "react-icons/fi";
+import { FiChevronDown, FiCode, FiDownload, FiExternalLink, FiGlobe, FiMonitor, FiRefreshCw, FiRepeat, FiTerminal, FiTrash2, FiX } from "react-icons/fi";
 import { IoLogoAndroid } from "react-icons/io";
 import { SiIos } from "react-icons/si";
 import type { InventoryColumn } from "./app-model";
@@ -23,6 +23,7 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
   const [expandedAppId, setExpandedAppId] = useState<string | null>(() => sortedManagedApps(status.managed_apps).find((app) => managedCategoryForApp(app) === "core")?.id ?? null);
   const [jobs, setJobs] = useState<Record<string, GuiAppActionJobSummary>>({});
+  const [dismissedJobIds, setDismissedJobIds] = useState<Set<string>>(() => new Set());
   const [policyJobs, setPolicyJobs] = useState<Record<string, GuiAppActionJobSummary[]>>({});
   const [policyToggles, setPolicyToggles] = useState<ManagedPolicyToggleState>(() => readManagedPolicyToggles());
   const selectedJob = selectedJobId === null ? null : jobs[selectedJobId] ?? null;
@@ -36,17 +37,24 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
     setExpandedAppId(visibleManagedApps[0]?.id ?? null);
   }, [managedCategory, status.managed_apps]);
 
+  const runningJobIdsKey = Object.values(jobs).filter((job) => job.status === "running").map((job) => job.id).sort().join("|");
+
   useEffect(() => {
-    if (selectedJob === null || selectedJob.status !== "running") {
+    const runningJobIds = runningJobIdsKey.split("|").filter(Boolean);
+    if (runningJobIds.length === 0) {
       return undefined;
     }
 
-    const timer = window.setInterval(() => {
-      void refreshJob(selectedJob.id, setJobs);
-    }, 1_500);
+    const refreshRunningJobs = () => {
+      for (const jobId of runningJobIds) {
+        void refreshJob(jobId, setJobs);
+      }
+    };
+    refreshRunningJobs();
+    const timer = window.setInterval(refreshRunningJobs, 1_500);
 
     return () => window.clearInterval(timer);
-  }, [selectedJob]);
+  }, [runningJobIdsKey]);
 
   return (
     <section className="apps-surface" aria-label={text.apps}>
@@ -65,8 +73,15 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
               expanded={expandedAppId === app.id}
               job={jobForApp(app.id, jobs, selectedJob)}
               key={app.id}
+              dismissedJobIds={dismissedJobIds}
               policyJobs={policyJobs[app.id] ?? []}
+              onDismissJob={(jobId) => setDismissedJobIds((current) => new Set([...current, jobId]))}
               onJob={(job) => {
+                setDismissedJobIds((current) => {
+                  const next = new Set(current);
+                  next.delete(job.id);
+                  return next;
+                });
                 setJobs((current) => ({ ...current, [job.id]: job }));
                 setSelectedJobId(job.id);
                 setExpandedAppId(app.id);
@@ -92,8 +107,10 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
   );
 }
 
-function ManagedAppPanel({ app, expanded, job, onJob, onPolicyToggle, onToggle, policyJobs }: { app: GuiManagedAppSummary; expanded: boolean; job: GuiAppActionJobSummary | null; onJob: (job: GuiAppActionJobSummary) => void; onPolicyToggle: (policy: ManagedPolicyId, value: boolean) => void; onToggle: () => void; policyJobs: GuiAppActionJobSummary[] }): ReactElement {
+function ManagedAppPanel({ app, dismissedJobIds, expanded, job, onDismissJob, onJob, onPolicyToggle, onToggle, policyJobs }: { app: GuiManagedAppSummary; dismissedJobIds: Set<string>; expanded: boolean; job: GuiAppActionJobSummary | null; onDismissJob: (jobId: string) => void; onJob: (job: GuiAppActionJobSummary) => void; onPolicyToggle: (policy: ManagedPolicyId, value: boolean) => void; onToggle: () => void; policyJobs: GuiAppActionJobSummary[] }): ReactElement {
   const lockedPolicy = isEssentialManagedApp(app);
+  const visibleJob = job === null || dismissedJobIds.has(job.id) ? null : job;
+  const visiblePolicyJobs = policyJobs.filter((policyJob) => !dismissedJobIds.has(policyJob.id));
 
   return (
     <article className={expanded ? "managed-app-card expanded" : "managed-app-card"}>
@@ -122,12 +139,12 @@ function ManagedAppPanel({ app, expanded, job, onJob, onPolicyToggle, onToggle, 
       <div className="managed-app-details">
         <ToggleSwitch checked={app.aidevops_install} disabled={lockedPolicy} label="setup installs" onChange={(value) => onPolicyToggle("setup", value)} />
         <ToggleSwitch checked={app.aidevops_update} disabled={lockedPolicy} label="update maintains" onChange={(value) => onPolicyToggle("update", value)} />
-        {job ? <AppLogLink job={job} /> : null}
+        {visibleJob ? <AppLogLink job={visibleJob} /> : null}
       </div>
       <AppMeta className="managed-app-path" label={text.path} value={app.install_path_ref} />
-      {job ? <AppActionTerminal job={job} /> : null}
-      {policyJobs.map((policyJob) => <AppActionTerminal job={policyJob} key={policyJob.id} />)}
-      {job === null && policyJobs.length === 0 ? <p className="empty-state compact-notice">No recent command output for this app. Run an action or change a policy toggle to open this app's terminal log.</p> : null}
+      {visibleJob ? <AppActionTerminal job={visibleJob} onDismiss={onDismissJob} /> : null}
+      {visiblePolicyJobs.map((policyJob) => <AppActionTerminal job={policyJob} key={policyJob.id} onDismiss={onDismissJob} />)}
+      {visibleJob === null && visiblePolicyJobs.length === 0 ? <p className="empty-state compact-notice">No recent command output for this app. Run an action or change a policy toggle to open this app's terminal log.</p> : null}
       </div> : null}
     </article>
   );
@@ -194,7 +211,7 @@ function ConfirmActionModal({ action, app, close, commandPreview, confirm }: { a
   );
 }
 
-function AppActionTerminal({ job }: { job: GuiAppActionJobSummary }): ReactElement {
+function AppActionTerminal({ job, onDismiss }: { job: GuiAppActionJobSummary; onDismiss: (jobId: string) => void }): ReactElement {
   const outputRef = useRef<HTMLPreElement | null>(null);
 
   useEffect(() => {
@@ -205,10 +222,68 @@ function AppActionTerminal({ job }: { job: GuiAppActionJobSummary }): ReactEleme
 
   return (
     <section className="app-terminal" id={`app-job-${job.id}`} aria-label="App action terminal output">
-      <header><strong>{job.app_id} {job.action}</strong><span>{job.status}{job.exit_code === null ? "" : ` (${job.exit_code})`}</span></header>
-      <pre ref={outputRef}>{job.output.join("\n")}</pre>
+      <header><strong>{job.app_id} {job.action}</strong><span>{terminalStatusLabel(job)}</span><button aria-label={`Dismiss ${job.app_id} ${job.action} terminal output`} className="terminal-close-button" onClick={() => onDismiss(job.id)} title="Dismiss terminal output" type="button"><FiX aria-hidden="true" /></button></header>
+      <pre ref={outputRef}>{renderTerminalOutput(job.output)}</pre>
     </section>
   );
+}
+
+function terminalStatusLabel(job: GuiAppActionJobSummary): string {
+  if (job.status === "running") {
+    return "running";
+  }
+  if (job.exit_code === null) {
+    return job.status;
+  }
+  return `${job.status} · exit ${job.exit_code}`;
+}
+
+function renderTerminalOutput(lines: string[]): ReactNode[] {
+  return lines.flatMap((line, index) => [
+    ...renderAnsiLine(line, `line-${index}`),
+    index === lines.length - 1 ? null : "\n",
+  ]).filter((node): node is ReactNode => node !== null);
+}
+
+function renderAnsiLine(line: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const ansiPattern = /\u001b\[([0-9;]*)m/g;
+  let activeClass = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = ansiPattern.exec(line)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(terminalSpan(line.slice(lastIndex, match.index), activeClass, `${keyPrefix}-${nodes.length}`));
+    }
+    activeClass = ansiClassForCodes(match[1]);
+    lastIndex = ansiPattern.lastIndex;
+  }
+
+  if (lastIndex < line.length) {
+    nodes.push(terminalSpan(line.slice(lastIndex), activeClass, `${keyPrefix}-${nodes.length}`));
+  }
+
+  if (nodes.length === 0) {
+    nodes.push(terminalSpan(line, activeClass, `${keyPrefix}-0`));
+  }
+
+  return nodes;
+}
+
+function terminalSpan(textValue: string, className: string, key: string): ReactNode {
+  const promptClass = textValue.startsWith("$ ") ? "ansi-prompt" : "";
+  const combinedClass = [className, promptClass].filter(Boolean).join(" ");
+  return combinedClass.length > 0 ? <span className={combinedClass} key={key}>{textValue}</span> : textValue;
+}
+
+function ansiClassForCodes(rawCodes: string): string {
+  const codes = rawCodes.length === 0 ? [0] : rawCodes.split(";").map((code) => Number.parseInt(code, 10));
+  const colorCode = [...codes].reverse().find((code) => (code >= 30 && code <= 37) || (code >= 90 && code <= 97));
+  if (colorCode === undefined) {
+    return "";
+  }
+  return `ansi-fg-${colorCode}`;
 }
 
 async function refreshJob(jobId: string, setJobs: Dispatch<SetStateAction<Record<string, GuiAppActionJobSummary>>>): Promise<void> {
@@ -321,16 +396,16 @@ const recommendedOsTabs: TabOption<RecommendedOsId>[] = [
 ];
 
 const recommendedApps = ([
-  { name: "Affinity Studio", description: "Creative design suite.", websiteUrl: "https://www.affinity.studio/", alternativeToUrl: "https://alternativeto.net/software/affinity-1/", os: ["macos", "windows", "ios"], platforms: [] },
-  { name: "Bitwarden", description: "Open source password manager.", websiteUrl: "https://bitwarden.com", alternativeToUrl: "https://alternativeto.net/software/bitwarden--free-password-manager/", repoUrl: "https://github.com/bitwarden", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "saas", "cli", "api"] },
-  { name: "Brave Browser", description: "Privacy-focused web browser.", websiteUrl: "https://brave.com/", alternativeToUrl: "https://alternativeto.net/software/brave/", os: ["macos", "linux", "windows", "ios", "android"], platforms: [] },
+  { name: "Affinity Studio", description: "Creative design suite.", websiteUrl: "https://www.affinity.studio/", alternativeToUrl: "https://alternativeto.net/software/affinity-1/", os: ["macos", "windows"], platforms: [] },
+  { name: "Bitwarden", description: "Open source password manager.", websiteUrl: "https://bitwarden.com", alternativeToUrl: "https://alternativeto.net/software/bitwarden--free-password-manager/", repoUrl: "https://github.com/bitwarden", iosUrl: "https://itunes.apple.com/app/bitwarden-free-password-manager/id1137397744?mt=8", androidUrl: "https://play.google.com/store/apps/details?id=com.x8bit.bitwarden", fdroidUrl: "https://mobileapp.bitwarden.com/fdroid/repo", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "saas", "cli", "api"] },
+  { name: "Brave Browser", description: "Privacy-focused web browser.", websiteUrl: "https://brave.com/", alternativeToUrl: "https://alternativeto.net/software/brave/", iosUrl: "https://apps.apple.com/app/brave-private-web-browser-vpn/id1052879175?mt=8", androidUrl: "https://play.google.com/store/apps/details?id=com.brave.browser", os: ["macos", "linux", "windows", "ios", "android"], platforms: [] },
   { name: "Cloudron", description: "Self-hosted app platform.", websiteUrl: "https://www.cloudron.io/", alternativeToUrl: "https://alternativeto.net/software/cloudron/", os: ["linux"], platforms: ["webapp", "cli", "api"] },
   { name: "Collabora Online", description: "Online office collaboration.", websiteUrl: "https://www.collaboraonline.com/collabora-online/", alternativeToUrl: "https://alternativeto.net/software/collabora-online/", os: ["linux"], platforms: ["webapp", "api"] },
   { name: "Cometly", description: "Marketing attribution analytics.", websiteUrl: "https://www.cometly.com/", os: [], platforms: ["saas", "api"] },
   { name: "DaVinci Resolve", description: "Professional video editing, color, VFX, and audio post-production.", websiteUrl: "https://www.blackmagicdesign.com/products/davinciresolve/", alternativeToUrl: "https://alternativeto.net/software/davinci-resolve/", os: ["macos", "linux", "windows"], platforms: [] },
   { name: "DocuSeal", description: "Open source document signing.", websiteUrl: "https://www.docuseal.com/", alternativeToUrl: "https://alternativeto.net/software/docuseal/", os: ["linux"], platforms: ["webapp", "saas", "api"] },
-  { name: "Element", description: "Matrix messaging client.", websiteUrl: "https://element.io/", alternativeToUrl: "https://alternativeto.net/software/element-app/", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp"] },
-  { name: "Enpass", description: "Offline-first password manager.", websiteUrl: "https://www.enpass.io/", alternativeToUrl: "https://alternativeto.net/software/enpass/", os: ["macos", "linux", "windows", "ios", "android"], platforms: [] },
+  { name: "Element", description: "Matrix messaging client.", websiteUrl: "https://element.io/", alternativeToUrl: "https://alternativeto.net/software/element-app/", iosUrl: "https://apps.apple.com/app/id1631335820", androidUrl: "https://play.google.com/store/apps/details?id=io.element.android.x", fdroidUrl: "https://f-droid.org/en/packages/io.element.android.x/", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp"] },
+  { name: "Enpass", description: "Offline-first password manager.", websiteUrl: "https://www.enpass.io/", alternativeToUrl: "https://alternativeto.net/software/enpass/", iosUrl: "https://apps.apple.com/app/apple-store/id455566716?pt=637991", androidUrl: "https://play.google.com/store/apps/details?id=io.enpass.app", os: ["macos", "linux", "windows", "ios", "android"], platforms: [] },
   { name: "EspoCRM", description: "Open source CRM.", websiteUrl: "https://www.espocrm.com/", alternativeToUrl: "https://alternativeto.net/software/espocrm/", os: ["linux"], platforms: ["webapp", "saas", "api"] },
   { name: "Fathom Analytics", description: "Privacy-first analytics.", websiteUrl: "https://usefathom.com/", alternativeToUrl: "https://alternativeto.net/software/fathom-analytics/", os: [], platforms: ["saas", "api"] },
   { name: "FontBase", description: "Font management and reference tool.", websiteUrl: "https://fontba.se/", alternativeToUrl: "https://alternativeto.net/software/fontbase/", os: ["macos"], platforms: [] },
@@ -341,10 +416,10 @@ const recommendedApps = ([
   { name: "LibreOffice", description: "Open source office suite.", websiteUrl: "https://www.libreoffice.org/", alternativeToUrl: "https://alternativeto.net/software/libreoffice/", os: ["macos", "linux", "windows"], platforms: [] },
   { name: "LocalWP", description: "Local WordPress development.", websiteUrl: "https://localwp.com/", alternativeToUrl: "https://alternativeto.net/software/local-by-flywheel/", os: ["macos", "linux", "windows"], platforms: [] },
   { name: "Matomo", description: "Open analytics platform.", websiteUrl: "https://matomo.org/", alternativeToUrl: "https://alternativeto.net/software/piwik/", os: ["linux"], platforms: ["webapp", "saas", "api"] },
-  { name: "Nextcloud", description: "Open source content collaboration platform.", websiteUrl: "https://nextcloud.com/", alternativeToUrl: "https://alternativeto.net/software/nextcloud/", repoUrl: "https://github.com/nextcloud", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "saas", "api"] },
+  { name: "Nextcloud", description: "Open source content collaboration platform.", websiteUrl: "https://nextcloud.com/", alternativeToUrl: "https://alternativeto.net/software/nextcloud/", repoUrl: "https://github.com/nextcloud", iosUrl: "https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8", androidUrl: "https://play.google.com/store/apps/details?id=com.nextcloud.client", fdroidUrl: "https://f-droid.org/packages/com.nextcloud.client/", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "saas", "api"] },
   { name: "Nextcloud Talk", description: "Open source video calls, chat, and collaboration for Nextcloud.", websiteUrl: "https://nextcloud.com/talk/", repoUrl: "https://github.com/nextcloud/spreed", iosUrl: "https://apps.apple.com/us/app/nextcloud-talk/id1296825574", androidUrl: "https://play.google.com/store/apps/details?id=com.nextcloud.talk2&hl=en", os: ["ios", "android"], platforms: ["webapp"] },
   { name: "OBS Studio", description: "Open source video recording and live streaming.", websiteUrl: "https://obsproject.com/", alternativeToUrl: "https://alternativeto.net/software/open-broadcaster-software/", repoUrl: "https://github.com/obsproject/obs-studio", os: ["macos", "linux", "windows"], platforms: [] },
-  { name: "ONLYOFFICE", description: "Office and document collaboration.", websiteUrl: "https://www.onlyoffice.com/", alternativeToUrl: "https://alternativeto.net/software/onlyoffice/", repoUrl: "https://github.com/ONLYOFFICE/", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "saas", "api"] },
+  { name: "ONLYOFFICE", description: "Office and document collaboration.", websiteUrl: "https://www.onlyoffice.com/", alternativeToUrl: "https://alternativeto.net/software/onlyoffice/", repoUrl: "https://github.com/ONLYOFFICE/", iosUrl: "https://apps.apple.com/us/app/onlyoffice-documents/id944896972", androidUrl: "https://play.google.com/store/apps/details?id=com.onlyoffice.documents", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "saas", "api"] },
   { name: "OpenScreen", description: "Open screen-sharing project.", websiteUrl: "https://github.com/getopenscreen/openscreen/releases", alternativeToUrl: "https://alternativeto.net/software/openscreen/", repoUrl: "https://github.com/getopenscreen/openscreen", os: ["macos", "linux", "windows"], platforms: [] },
   { name: "Osaurus", description: "AI app workspace.", websiteUrl: "https://osaurus.ai/", alternativeToUrl: "https://alternativeto.net/software/osaurus/", os: ["macos"], platforms: [] },
   { name: "Parallels Desktop", description: "Run Windows, Linux, and virtual machines on macOS.", websiteUrl: "https://www.parallels.com/products/desktop/", alternativeToUrl: "https://alternativeto.net/software/parallels-desktop/about/", os: ["macos"], platforms: [] },
@@ -357,13 +432,13 @@ const recommendedApps = ([
   { name: "QuickFile", description: "Accounting platform.", websiteUrl: "https://www.quickfile.co.uk/", os: [], platforms: ["saas", "api"] },
   { name: "Reframed", description: "Creative framing utility.", websiteUrl: "https://www.reframed.dev/", alternativeToUrl: "https://alternativeto.net/software/reframed/", os: ["macos"], platforms: [] },
   { name: "Rybbit", description: "Web analytics.", websiteUrl: "https://rybbit.com/", alternativeToUrl: "https://alternativeto.net/software/rybbit/", os: ["linux"], platforms: ["webapp", "saas", "api"] },
-  { name: "SchildiChat", description: "Matrix messaging client.", websiteUrl: "https://schildi.chat/", alternativeToUrl: "https://alternativeto.net/software/schildichat/", os: ["macos", "linux", "windows", "android"], platforms: ["webapp"] },
-  { name: "ScreenFlow", description: "Screen recording and editing.", websiteUrl: "https://www.telestream.net/screenflow/", alternativeToUrl: "https://alternativeto.net/software/screenflow/", os: ["macos", "ios"], platforms: [] },
+  { name: "SchildiChat", description: "Matrix messaging client.", websiteUrl: "https://schildi.chat/", alternativeToUrl: "https://alternativeto.net/software/schildichat/", androidUrl: "https://play.google.com/store/apps/details?id=chat.schildi.android", fdroidUrl: "https://schildi.chat/next/install-from-sc-fdroid", os: ["macos", "linux", "windows", "android"], platforms: ["webapp"] },
+  { name: "ScreenFlow", description: "Screen recording and editing.", websiteUrl: "https://www.telestream.net/screenflow/", alternativeToUrl: "https://alternativeto.net/software/screenflow/", os: ["macos"], platforms: [] },
   { name: "SEO Utils", description: "Desktop SEO tools.", websiteUrl: "https://seoutils.app/", os: ["macos", "linux", "windows"], platforms: [] },
   { name: "Shottr", description: "macOS screenshot utility.", websiteUrl: "https://shottr.cc/", alternativeToUrl: "https://alternativeto.net/software/shottr/", os: ["macos"], platforms: [] },
-  { name: "Signal", description: "Private messenger.", websiteUrl: "https://signal.org/", alternativeToUrl: "https://alternativeto.net/software/signal-private-messenger/", os: ["macos", "linux", "windows", "ios", "android"], platforms: [] },
-  { name: "SimpleX Chat", description: "Private messenger with no user IDs.", websiteUrl: "https://simplex.chat/", alternativeToUrl: "https://alternativeto.net/software/simplex-chat/about/", repoUrl: "https://github.com/simplex-chat", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["cli"] },
-  { name: "Telegram", description: "Cloud-based mobile and desktop messaging app.", websiteUrl: "https://telegram.org/", iosUrl: "https://telegram.org/dl/ios", androidUrl: "https://telegram.org/android", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "api"] },
+  { name: "Signal", description: "Private messenger.", websiteUrl: "https://signal.org/", alternativeToUrl: "https://alternativeto.net/software/signal-private-messenger/", iosUrl: "https://apps.apple.com/us/app/signal-private-messenger/id874139669", androidUrl: "https://play.google.com/store/apps/details?id=org.thoughtcrime.securesms", os: ["macos", "linux", "windows", "ios", "android"], platforms: [] },
+  { name: "SimpleX Chat", description: "Private messenger with no user IDs.", websiteUrl: "https://simplex.chat/", alternativeToUrl: "https://alternativeto.net/software/simplex-chat/about/", repoUrl: "https://github.com/simplex-chat", iosUrl: "https://apps.apple.com/us/app/simplex-chat/id1605771084", androidUrl: "https://play.google.com/store/apps/details?id=chat.simplex.app", fdroidUrl: "https://simplex.chat/fdroid", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["cli"] },
+  { name: "Telegram", description: "Cloud-based mobile and desktop messaging app.", websiteUrl: "https://telegram.org/", iosUrl: "https://apps.apple.com/us/app/telegram-messenger/id686449807", androidUrl: "https://play.google.com/store/apps/details?id=org.telegram.messenger", os: ["macos", "linux", "windows", "ios", "android"], platforms: ["webapp", "api"] },
   { name: "Thunderbird", description: "Email and calendar app.", websiteUrl: "https://www.thunderbird.net/", alternativeToUrl: "https://alternativeto.net/software/mozilla-thunderbird/about/", os: ["macos", "linux", "windows"], platforms: [] },
   { name: "Ubicloud", description: "Open cloud platform.", websiteUrl: "https://www.ubicloud.com/", alternativeToUrl: "https://alternativeto.net/software/ubicloud/about/", repoUrl: "https://github.com/ubicloud/ubicloud", os: ["linux"], platforms: ["webapp", "saas", "cli", "api"] },
   { name: "Vaultwarden", description: "Alternative Bitwarden server implementation.", websiteUrl: "https://github.com/dani-garcia/vaultwarden", alternativeToUrl: "https://alternativeto.net/software/vaultwarden/", repoUrl: "https://github.com/dani-garcia/vaultwarden", os: ["linux"], platforms: ["webapp", "api"] },

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -147,7 +147,7 @@ export const text = {
   aidevops: "aidevops",
   appShell: "App shell",
   apps: "Apps",
-  appsIntro: "The app toolkit we use and recommend to enable all the things we can do with AI, development, and operations to create and share our work. Opinionated preferences based on open-source-first, lowest-costs, highest-quality UI & UX, teamwork, data security, privacy, and AI-usage capabilities.",
+  appsIntro: "These are the apps we use and recommend from our tried & tested toolkit — enabling all the things we can do with AI, development, and operations to create and share our work. Opinionated preferences based on open-source-first, lowest-costs, highest-quality UI & UX, teamwork, data security, privacy, and AI-usage capabilities.",
   appStatusPending: "adapter pending",
   brands: "Brands",
   brandsIntro: "Draft brand inventory for names and website references.",

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1316,7 +1316,8 @@ code {
 .workspace-scroll {
   display: grid;
   gap: 16px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 18px;
 }
 
@@ -2053,7 +2054,8 @@ code {
   border: 1px solid var(--border);
   border-radius: 18px;
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 7%);
-  overflow: visible;
+  min-width: 0;
+  overflow: hidden;
   transition: background 140ms ease, border-color 140ms ease;
 }
 
@@ -2174,6 +2176,7 @@ code {
   gap: 16px;
   padding: 0 16px 16px;
   position: relative;
+  min-width: 0;
 }
 
 .managed-app-toolbar {
@@ -2182,6 +2185,7 @@ code {
   gap: 16px;
   grid-template-columns: minmax(0, 1fr) auto;
   padding-top: 16px;
+  min-width: 0;
 }
 
 .managed-app-links,
@@ -2194,6 +2198,7 @@ code {
 
 .managed-app-actions {
   justify-content: end;
+  min-width: 0;
 }
 
 .managed-app-links a,
@@ -2393,6 +2398,7 @@ button.managed-toggle:focus-visible {
   border: 1px solid var(--border);
   border-radius: 16px;
   color: color-mix(in srgb, var(--accent) 78%, white);
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -2405,9 +2411,38 @@ button.managed-toggle:focus-visible {
   padding: 10px 12px;
 }
 
+.app-terminal header strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .app-terminal header span {
+  flex: 0 0 auto;
   color: var(--text-muted);
   text-align: right;
+}
+
+.terminal-close-button {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--text-muted);
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 28px;
+  justify-content: center;
+  padding: 0;
+  width: 28px;
+}
+
+.terminal-close-button:hover,
+.terminal-close-button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  color: var(--accent);
+  outline: none;
 }
 
 .app-terminal pre {
@@ -2418,6 +2453,24 @@ button.managed-toggle:focus-visible {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+.ansi-prompt { color: #7ee787; }
+.ansi-fg-30,
+.ansi-fg-90 { color: #8b949e; }
+.ansi-fg-31,
+.ansi-fg-91 { color: #ff7b72; }
+.ansi-fg-32,
+.ansi-fg-92 { color: #7ee787; }
+.ansi-fg-33,
+.ansi-fg-93 { color: #f2cc60; }
+.ansi-fg-34,
+.ansi-fg-94 { color: #79c0ff; }
+.ansi-fg-35,
+.ansi-fg-95 { color: #d2a8ff; }
+.ansi-fg-36,
+.ansi-fg-96 { color: #76e3ea; }
+.ansi-fg-37,
+.ansi-fg-97 { color: #f0f6fc; }
 
 .modal-backdrop {
   align-items: center;

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -181,12 +181,15 @@ describe("dashboard shell", () => {
     const source = readFileSync("packages/gui-web/src/InventorySurfaces.tsx", "utf8");
 
     expect(html).toContain("AIDevOps");
-    expect(html).toContain("The app toolkit we use and recommend to enable all the things we can do with AI");
+    expect(html).toContain("These are the apps we use and recommend from our tried &amp; tested toolkit — enabling all the things we can do with AI");
     expect(html).not.toContain("App and CLI inventory for tools installed or updated by aidevops");
     expect(source.indexOf("Recommended app operating system filters")).toBeLessThan(source.indexOf("Recommended app platform filters"));
     expect(html).toContain("app-meta managed-app-path");
     expect(sectionBetween(html, "managed-app-details", "app-meta managed-app-path")).not.toContain("Installed");
     expect(sectionBetween(html, "managed-app-details", "app-meta managed-app-path")).not.toContain("Latest");
+    expect(source).toContain("terminalStatusLabel(job)");
+    expect(source).toContain("https://apps.apple.com/us/app/telegram-messenger/id686449807");
+    expect(source).toContain("https://play.google.com/store/apps/details?id=org.telegram.messenger");
   });
 
   test("returns recommended filters to all when the active non-all option is selected again", () => {


### PR DESCRIPTION
Resolves #25790

## Summary

- Fix Apps page overflow, terminal dismissal/status labels, live polling, and ANSI colour rendering.
- Add recommended mobile store links and remove invalid iOS platform claims.
- Improve Pulse/Ollama install-path detection and desktop external-link handling.

## Verification

- `bun test packages/gui-web/tests`
- `bun test packages/gui-api/tests`
- `bun run typecheck`
- `bun run gui:desktop:check`
- `bash -n packages/gui-desktop/scripts/install-macos-app.sh`
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh`
- `.agents/scripts/markdownlint-diff-helper.sh --mode biome --base origin/main --head HEAD --output-md /tmp/biome-report-local.md`

## Notes

- `.agents/scripts/linters-local.sh` reached advisory checks but timed out during broad shell portability scanning; focused checks above passed.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.16 with gpt-5.5 spent 46m and 831,076 tokens on this with the user in an interactive session.