### PR TITLE
fix: dedupe quality sweep worker targets

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -58,6 +58,7 @@ _log() {
 # Add new validators here by calling _register_validators() pattern.
 # ---------------------------------------------------------------------------
 declare -A _VALIDATOR_REGISTRY=()
+_PREDISPATCH_CLOSE_REASON_NOT_PLANNED="not planned"
 
 # ---------------------------------------------------------------------------
 # Self-hosting dispatch-path file patterns (t2819, t2821)
@@ -176,6 +177,135 @@ Closing this stale zero-progress meta-issue in the pre-dispatch validator so aut
 		_log "WARN" "#${issue_number}: failed to close recovered zero-progress meta-issue"
 	_log "INFO" "#${issue_number}: zero-progress meta premise recovered — issue closed, dispatch blocked"
 	return 10
+}
+
+# ---------------------------------------------------------------------------
+# Function-complexity-sweep duplicate detector.
+#
+# The quality sweep emits one issue per cited file. Older sweep versions
+# deduped by title using the full path even though the title only contained the
+# basename, which allowed duplicate issues for the same cited_file marker. Close
+# later duplicates before worker launch so two workers do not race the same file.
+# ---------------------------------------------------------------------------
+_extract_function_complexity_sweep_cited_file() {
+	local issue_body="$1"
+	local generator_line=""
+
+	generator_line=$(printf '%s' "$issue_body" | grep -oE '<!-- aidevops:generator=function-complexity-sweep[^>]*-->' | head -1) || generator_line=""
+	[[ -n "$generator_line" ]] || return 1
+
+	printf '%s' "$generator_line" | grep -oE 'cited_file=[^ >]+' | sed 's/cited_file=//' 2>/dev/null
+	return 0
+}
+
+_function_complexity_sweep_duplicate_rows() {
+	local slug="$1"
+	local cited_file="$2"
+
+	gh issue list --repo "$slug" \
+		--label "function-complexity-debt" --state open \
+		--search "\"cited_file=${cited_file}\" in:body" \
+		--json number,labels \
+		--jq '.[] | [.number, ([.labels[].name] | join(","))] | @tsv' 2>/dev/null
+	return $?
+}
+
+_function_complexity_row_is_active() {
+	local labels="$1"
+
+	case ",$labels," in
+	*,status:in-progress,* | *,status:in-review,* | *,status:claimed,*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+_select_function_complexity_survivor() {
+	local rows="$1"
+	local survivor=""
+	local first_number=""
+	local number=""
+	local labels=""
+
+	while IFS=$'\t' read -r number labels; do
+		[[ "$number" =~ ^[0-9]+$ ]] || continue
+		if [[ -z "$first_number" || "$number" -lt "$first_number" ]]; then
+			first_number="$number"
+		fi
+		if _function_complexity_row_is_active "$labels"; then
+			if [[ -z "$survivor" || "$number" -lt "$survivor" ]]; then
+				survivor="$number"
+			fi
+		fi
+	done <<<"$rows"
+
+	printf '%s' "${survivor:-$first_number}"
+	return 0
+}
+
+_close_function_complexity_duplicate_issue() {
+	local issue_number="$1"
+	local slug="$2"
+	local cited_file="$3"
+	local survivor="$4"
+
+	local comment_body=""
+	comment_body="## Duplicate quality-sweep issue
+
+This issue targets the same quality-sweep marker as #${survivor}: cited_file=${cited_file}.
+
+Closing it before worker dispatch so automation does not launch duplicate workers against the same file. Continue via #${survivor}."
+
+	gh_issue_comment "$issue_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1 ||
+		_log "WARN" "#${issue_number}: failed to comment on duplicate function-complexity-sweep issue"
+	gh issue close "$issue_number" --repo "$slug" --reason "$_PREDISPATCH_CLOSE_REASON_NOT_PLANNED" >/dev/null 2>&1 ||
+		_log "WARN" "#${issue_number}: failed to close duplicate function-complexity-sweep issue"
+	_log "INFO" "#${issue_number}: duplicate function-complexity-sweep issue closed; survivor=#${survivor} cited_file=${cited_file}"
+	return 0
+}
+
+_close_function_complexity_sweep_duplicates() {
+	local issue_number="$1"
+	local slug="$2"
+	local issue_body="$3"
+	local cited_file=""
+
+	cited_file=$(_extract_function_complexity_sweep_cited_file "$issue_body") || return 0
+	[[ -n "$cited_file" ]] || return 0
+
+	local rows=""
+	if ! rows=$(_function_complexity_sweep_duplicate_rows "$slug" "$cited_file"); then
+		_log "WARN" "#${issue_number}: duplicate function-complexity-sweep lookup failed for ${cited_file} — dispatch proceeds"
+		return 0
+	fi
+	[[ -n "$rows" ]] || return 0
+
+	local issue_count="0"
+	issue_count=$(printf '%s\n' "$rows" | awk -F '\t' '$1 ~ /^[0-9]+$/ { count++ } END { print count+0 }') || issue_count="0"
+	[[ "$issue_count" -gt 1 ]] || return 0
+
+	local survivor=""
+	survivor=$(_select_function_complexity_survivor "$rows")
+	[[ -n "$survivor" ]] || return 0
+
+	if [[ "$issue_number" != "$survivor" ]]; then
+		_close_function_complexity_duplicate_issue "$issue_number" "$slug" "$cited_file" "$survivor"
+		return 10
+	fi
+
+	local duplicate_number=""
+	local duplicate_labels=""
+	while IFS=$'\t' read -r duplicate_number duplicate_labels; do
+		: "$duplicate_labels"
+		[[ "$duplicate_number" =~ ^[0-9]+$ ]] || continue
+		[[ "$duplicate_number" == "$survivor" ]] && continue
+		_close_function_complexity_duplicate_issue "$duplicate_number" "$slug" "$cited_file" "$survivor"
+	done <<<"$rows"
+
+	return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -971,7 +1101,7 @@ EOF
 
 	gh_issue_comment "$issue_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1 ||
 		_log "WARN" "#${issue_number}: failed to post review-feedback supersession rationale"
-	gh issue close "$issue_number" --repo "$slug" --reason "not planned" >/dev/null 2>&1 ||
+	gh issue close "$issue_number" --repo "$slug" --reason "$_PREDISPATCH_CLOSE_REASON_NOT_PLANNED" >/dev/null 2>&1 ||
 		_log "WARN" "#${issue_number}: failed to close superseded review-feedback issue"
 
 	_log "INFO" "#${issue_number}: closed as superseded by merged PR #${pr_number}"
@@ -1122,7 +1252,7 @@ EOF
 		_log "WARN" "Failed to post rationale comment on #${issue_number}"
 
 	# Close the issue with reason "not planned"
-	gh issue close "$issue_number" --repo "$slug" --reason "not planned" >/dev/null 2>&1 ||
+	gh issue close "$issue_number" --repo "$slug" --reason "$_PREDISPATCH_CLOSE_REASON_NOT_PLANNED" >/dev/null 2>&1 ||
 		_log "WARN" "Failed to close issue #${issue_number}"
 
 	_log "INFO" "Closed issue #${issue_number} in ${slug} as not planned (premise falsified)"
@@ -1149,6 +1279,15 @@ _run_pre_generator_validators() {
 	fi
 	if [[ "$review_feedback_rc" -ne 0 ]]; then
 		_log "WARN" "#${issue_number}: review-feedback supersession detector returned rc=${review_feedback_rc} — dispatch proceeds"
+	fi
+
+	local quality_duplicate_rc=0
+	_close_function_complexity_sweep_duplicates "$issue_number" "$slug" "$issue_body" || quality_duplicate_rc=$?
+	if [[ "$quality_duplicate_rc" -eq 10 ]]; then
+		return 10
+	fi
+	if [[ "$quality_duplicate_rc" -ne 0 ]]; then
+		_log "WARN" "#${issue_number}: function-complexity-sweep duplicate detector returned rc=${quality_duplicate_rc} — dispatch proceeds"
 	fi
 
 	local zero_progress_rc=0

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -715,13 +715,20 @@ _create_simplification_issues() {
 		[[ -z "$file_path" ]] && continue
 		[[ "$issues_created" -ge "$max_issues_per_sweep" ]] && break
 
-		# Deduplicate via server-side title search — accurate across all issues.
-		# The file path is in the title, so searching by path is reliable.
+		# Deduplicate via the generator marker in the issue body. The title only
+		# contains the basename, so title+full-path search misses existing issues
+		# and creates duplicate worker targets for the same file.
 		local existing_count
 		existing_count=$(gh issue list --repo "$repo_slug" \
 			--label "function-complexity-debt" --state open \
-			--search "in:title \"$file_path\"" \
-			--json number --jq 'length' 2>/dev/null) || existing_count="0"
+			--search "\"cited_file=${file_path}\" in:body" \
+			--json number --jq 'length' 2>/dev/null) || {
+			echo "[stats] Function-complexity-debt issue search failed for ${file_path}; skipping create to avoid duplicates" >>"$LOGFILE"
+			continue
+		}
+		if [[ ! "$existing_count" =~ ^[0-9]+$ ]]; then
+			existing_count="0"
+		fi
 		if [[ "${existing_count:-0}" -gt 0 ]]; then
 			continue
 		fi

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -359,6 +359,40 @@ GHEOF
 	return 0
 }
 
+create_gh_stub_function_complexity_duplicate() {
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	local actions_file="${TEST_ROOT}/gh-actions.log"
+	printf '<!-- aidevops:generator=function-complexity-sweep cited_file=packages/gui-web/src/InventorySurfaces.tsx smell_count=3 -->\n## Qlty Maintainability\n' >"$body_file"
+	: >"$actions_file"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="\$*"
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	python3 -c "import sys; sys.stdout.write(open('${body_file}').read())" 2>/dev/null
+	exit 0
+fi
+
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "list" ]] && printf '%s' "\$args" | grep -qF 'cited_file=packages/gui-web/src/InventorySurfaces.tsx'; then
+	printf '25757\tstatus:available,function-complexity-debt\n25778\tstatus:available,function-complexity-debt\n'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "issue" && ( "\${2:-}" == "comment" || "\${2:-}" == "close" ) ]]; then
+	printf '%s\n' "\$args" >>'${actions_file}'
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -605,6 +639,29 @@ test_source_review_scanner_label_enters_supersession_scope() {
 	return 0
 }
 
+test_function_complexity_sweep_duplicate_closes_later_issue() {
+	setup_test_env
+	create_gh_stub_function_complexity_duplicate
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "25778" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "function_complexity_sweep duplicate later issue exits 10" 0
+	else
+		print_result "function_complexity_sweep duplicate later issue exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	if grep -q "close 25778" "${TEST_ROOT}/gh-actions.log" 2>/dev/null; then
+		print_result "function_complexity_sweep duplicate closes current issue" 0
+	else
+		print_result "function_complexity_sweep duplicate closes current issue" 1 "Expected close action for #25778"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -630,6 +687,7 @@ main() {
 	test_review_feedback_preserves_version_directory_paths
 	test_review_followup_label_enters_supersession_scope
 	test_source_review_scanner_label_enters_supersession_scope
+	test_function_complexity_sweep_duplicate_closes_later_issue
 
 	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary
- Fix quality-sweep simplification issue creation to dedupe by the `cited_file=...` generator marker in the issue body, not by full path in a basename-only title.
- Add a pre-dispatch duplicate detector that closes later `function-complexity-sweep` duplicates before worker launch, preserving the oldest/active survivor.
- Add regression coverage for the duplicate pre-dispatch closure path.

## Root cause
Issues #25757 and #25778 are duplicate worker targets for the same marker: `cited_file=packages/gui-web/src/InventorySurfaces.tsx`. The sweep attempted to dedupe with `in:title "$file_path"`, but the created title only includes `InventorySurfaces.tsx`, so the full path can never match and duplicate issues can be created/redispatched.

## Verification
- `bash -n .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-pre-dispatch-validator.sh`
- `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-pre-dispatch-validator.sh`
- `.agents/scripts/tests/test-pre-dispatch-validator.sh` (15 tests, 0 failed)
- `.agents/scripts/linters-local.sh` (passed; markdown/ratchet debt reported as advisory/pre-existing)

For #25757
For #25778

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.17 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
