### PR TITLE
fix: clear GUI followup quality regressions

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -1,15 +1,11 @@
 import type { GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
-import { type Dispatch, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactElement, type SetStateAction, useEffect, useState } from "react";
+import { type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactElement, useEffect, useState } from "react";
 import { MachineRail, Sidebar } from "./AppNavigation";
 import { Workspace } from "./AppWorkspace";
 import type { ConversationMode, FontPreference, FontSizePreference, ShellMode, SurfaceId, ThemePreference } from "./app-model";
 import { DEFAULT_ACCENT_HUE, DEFAULT_FONT, DEFAULT_FONT_SIZE, fileRootBySurface, findSurface, findSurfaceSectionLabel, fontFamilyForPreference, fontSizeForPreference, getSystemTheme, isFontPreference, isFontSizePreference } from "./app-model";
+import { type NavigationHistory, nextHistoryIndex, useNavigationHistoryKeyboard } from "./navigation-history";
 import { fetchStatus, mockedStatus } from "./status-client";
-
-interface NavigationHistory {
-  entries: SurfaceId[];
-  index: number;
-}
 
 interface WebKitBridgeWindow extends Window {
   webkit?: {
@@ -67,40 +63,6 @@ export function readStoredAppearancePreferences(storage: ReadableAppearanceStora
     showNavCounts: readStoredBoolean(storage, appearanceStorageKeys.showNavCounts, true),
     themePreference: savedTheme === "system" || savedTheme === "light" || savedTheme === "dark" ? savedTheme : "system",
   };
-}
-
-export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
-  if (typeof HTMLElement === "undefined" || !(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  return target.isContentEditable || target.closest("input, textarea, select, [contenteditable], [role='textbox']") !== null;
-}
-
-function nextHistoryIndex(current: NavigationHistory, direction: -1 | 1): number {
-  return Math.min(Math.max(0, current.entries.length - 1), Math.max(0, current.index + direction));
-}
-
-function useNavigationHistoryKeyboard(setNavigation: Dispatch<SetStateAction<NavigationHistory>>): void {
-  useEffect(() => {
-    const navigateHistoryWithKeyboard = (event: globalThis.KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || isEditableKeyboardTarget(event.target) || isEditableKeyboardTarget(document.activeElement)) {
-        return;
-      }
-
-      const direction: -1 | 1 | null = event.key === "[" ? -1 : event.key === "]" ? 1 : null;
-      if (direction === null) {
-        return;
-      }
-
-      event.preventDefault();
-      setNavigation((current) => ({ ...current, index: nextHistoryIndex(current, direction) }));
-    };
-
-    window.addEventListener("keydown", navigateHistoryWithKeyboard);
-
-    return () => window.removeEventListener("keydown", navigateHistoryWithKeyboard);
-  }, [setNavigation]);
 }
 
 export function App(): ReactElement {

--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -507,7 +507,8 @@ function SidebarFooter({ accentHue, fontPreference, fontSizePreference, setAccen
               type="range"
               value={fontSizeIndex}
             />
-            <div className="range-labels" aria-label="Font size shortcuts">
+            <fieldset className="range-labels">
+              <legend className="sr-only">Font size shortcuts</legend>
               {fontSizeOptions.map((option) => (
                 <button
                   aria-pressed={option.value === fontSizePreference}
@@ -519,7 +520,7 @@ function SidebarFooter({ accentHue, fontPreference, fontSizePreference, setAccen
                   {option.label}
                 </button>
               ))}
-            </div>
+            </fieldset>
           </div>
           <div className="font-control">
             <span id="appearance-font-selector-label">{text.font}</span>

--- a/packages/gui-web/src/navigation-history.ts
+++ b/packages/gui-web/src/navigation-history.ts
@@ -1,0 +1,49 @@
+import { type Dispatch, type SetStateAction, useEffect } from "react";
+import type { SurfaceId } from "./app-model";
+
+export interface NavigationHistory {
+  entries: SurfaceId[];
+  index: number;
+}
+
+export function nextHistoryIndex(current: NavigationHistory, direction: -1 | 1): number {
+  return Math.min(Math.max(0, current.entries.length - 1), Math.max(0, current.index + direction));
+}
+
+export function useNavigationHistoryKeyboard(setNavigation: Dispatch<SetStateAction<NavigationHistory>>): void {
+  useEffect(() => {
+    const navigateHistoryWithKeyboard = (event: globalThis.KeyboardEvent) => {
+      if (shouldIgnoreHistoryShortcut(event)) {
+        return;
+      }
+
+      const direction = historyShortcutDirection(event.key);
+      if (direction === null) {
+        return;
+      }
+
+      event.preventDefault();
+      setNavigation((current) => ({ ...current, index: nextHistoryIndex(current, direction) }));
+    };
+
+    window.addEventListener("keydown", navigateHistoryWithKeyboard);
+
+    return () => window.removeEventListener("keydown", navigateHistoryWithKeyboard);
+  }, [setNavigation]);
+}
+
+function shouldIgnoreHistoryShortcut(event: globalThis.KeyboardEvent): boolean {
+  return !(event.metaKey || event.ctrlKey) || isEditableKeyboardTarget(event.target) || isEditableKeyboardTarget(document.activeElement);
+}
+
+function historyShortcutDirection(key: string): -1 | 1 | null {
+  return key === "[" ? -1 : key === "]" ? 1 : null;
+}
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (typeof HTMLElement === "undefined" || !(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return target.isContentEditable || target.closest("input, textarea, select, [contenteditable], [role='textbox']") !== null;
+}

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -828,11 +828,14 @@ code {
 }
 
 .range-labels {
+  border: 0;
   color: var(--text-muted);
   display: grid;
   font-size: 0.7rem;
   font-weight: 900;
   grid-template-columns: repeat(5, 1fr);
+  margin: 0;
+  padding: 0;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
For #25753
For #25733
Follow-up to #25793

## Summary
- move GUI history shortcut helpers out of `App.tsx` to remove the Qlty file-complexity regression introduced by #25793
- switch the font-size shortcut group to a semantic `fieldset` and reset fieldset styling so Biome no longer reports a new accessibility violation

## Verification
```bash
bun test packages/gui-web/tests
bun run typecheck
.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/qlty-post25793.md
.agents/scripts/markdownlint-diff-helper.sh --mode biome --base origin/main --head HEAD --output-md /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/biome-post25793.md
```

## Results
- Qlty smell regression: improvement, 49 → 48 (-1)
- Biome baseline diff: improvement, 7 → 6 (-1)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.18 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
