### PR TITLE
t18026: fix Apps tooltips and version detection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1040,6 +1040,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18022 QA and release aidevops.app AI collaboration workspace #auto-dispatch #feat #priority:high ref:GH#25715
 
+- [ ] t18026 Fix Apps tooltips links and version detection ref:GH#25798
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/packages/gui-api/src/status-adapter-utils.ts
+++ b/packages/gui-api/src/status-adapter-utils.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 export function readJsonObject(pathName: string): { health: "present" | "missing" | "invalid"; value: Record<string, unknown> } {
@@ -112,17 +112,60 @@ export function firstExistingPathRef(pathRefs: string[]): string | null {
   return pathRefs.find((pathRef) => existsSync(expandHome(pathRef))) ?? null;
 }
 
+export function firstExecutablePathRef(pathRefs: string[]): string | null {
+  return pathRefs.find((pathRef) => isExecutable(expandHome(pathRef))) ?? null;
+}
+
+export function isExecutable(pathName: string): boolean {
+  try {
+    if (!statSync(pathName).isFile()) {
+      return false;
+    }
+    accessSync(pathName, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function resolveBinary(binary: string): string | null {
+  const candidatePath = binaryPathCandidates(binary).find((pathName) => isExecutable(pathName));
+  if (candidatePath !== undefined) {
+    return candidatePath;
+  }
+
   try {
     const output = execFileSync("which", [binary], {
+      env: { ...process.env, PATH: expandedPath() },
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
-      timeout: 200,
+      timeout: 350,
     }).trim();
     return output.split("\n").find((line) => line.length > 0) ?? null;
   } catch {
     return null;
   }
+}
+
+function binaryPathCandidates(binary: string): string[] {
+  return expandedPath().split(":").filter(Boolean).map((dir) => join(dir, binary));
+}
+
+function expandedPath(): string {
+  const home = process.env.HOME ?? "";
+  const extraPaths = [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    join(home, ".bun/bin"),
+    join(home, ".local/bin"),
+    join(home, ".cursor/bin"),
+    join(home, ".qlty/bin"),
+  ];
+  return [...new Set([...(process.env.PATH ?? "").split(":"), ...extraPaths].filter(Boolean))].join(":");
 }
 
 export function readBinaryVersion(binaryPath: string, args: string[]): string {
@@ -132,9 +175,10 @@ export function readBinaryVersion(binaryPath: string, args: string[]): string {
 
   try {
     const output = execFileSync(binaryPath, args, {
+      env: { ...process.env, PATH: expandedPath() },
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 150,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 650,
     }).trim();
     return output.split("\n").find((line) => line.length > 0) ?? "unknown";
   } catch {

--- a/packages/gui-api/src/status-managed-apps.ts
+++ b/packages/gui-api/src/status-managed-apps.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import type { GuiAppActionId, GuiManagedAppSummary } from "../../gui-shared/src";
-import { collapseHome, expandHome, firstExistingPathRef, readBinaryVersion, resolveBinary } from "./status-adapter-utils";
+import { collapseHome, expandHome, firstExecutablePathRef, firstExistingPathRef, readBinaryVersion, resolveBinary } from "./status-adapter-utils";
 
 type ManagedAppActionCommands = Partial<Record<GuiAppActionId, string>>;
 
@@ -180,7 +180,7 @@ function setupScopeActions(scope: string): ManagedAppActionCommands {
 }
 
 function managedAppSummary(definition: ManagedAppDefinition, latestVersion: string, installedVersion: string): GuiManagedAppSummary {
-  const binaryPath = definition.binary === null ? null : resolveBinary(definition.binary);
+  const binaryPath = definition.binary === null ? null : executableInstallPath(definition.install_path_refs) ?? resolveBinary(definition.binary);
   const installPathRef = firstExistingPathRef(definition.install_path_refs) ?? definition.install_path_refs[0] ?? "not found";
   const installedVersionText = readManagedAppVersion(definition, binaryPath, installedVersion);
   const latestVersionText = definition.latest_version_source === "aidevops"
@@ -231,7 +231,13 @@ function readManagedAppVersion(definition: ManagedAppDefinition, binaryPath: str
     return readAppBundleVersion(existingPathRef) ?? "installed";
   }
 
-  return readBinaryVersion(binaryPath, definition.version_args);
+  const versionText = readBinaryVersion(binaryPath, definition.version_args);
+  return versionText === "unknown" ? "installed" : versionText;
+}
+
+function executableInstallPath(pathRefs: string[]): string | null {
+  const executablePathRef = firstExecutablePathRef(pathRefs);
+  return executablePathRef === null ? null : expandHome(executablePathRef);
 }
 
 function readAppBundleVersion(pathRef: string): string | null {
@@ -239,5 +245,11 @@ function readAppBundleVersion(pathRef: string): string | null {
     return null;
   }
 
-  return readBinaryVersion("/usr/libexec/PlistBuddy", ["-c", "Print :CFBundleShortVersionString", `${expandHome(pathRef)}/Contents/Info.plist`]);
+  const version = readBinaryVersion("/usr/libexec/PlistBuddy", ["-c", "Print :CFBundleShortVersionString", `${expandHome(pathRef)}/Contents/Info.plist`]);
+  if (version !== "unknown") {
+    return version;
+  }
+
+  const bundleVersion = readBinaryVersion("/usr/libexec/PlistBuddy", ["-c", "Print :CFBundleVersion", `${expandHome(pathRef)}/Contents/Info.plist`]);
+  return bundleVersion === "unknown" ? null : bundleVersion;
 }

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -338,7 +338,7 @@ final class DraggableTitlebarView: NSView {
     }
 }
 
-final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScriptMessageHandler, NSMenuItemValidation, NSWindowDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, NSMenuItemValidation, NSWindowDelegate {
     private var window: NSWindow!
     private var aboutWindow: NSWindow?
     private var titlebarToggleButton: NSButton?
@@ -414,6 +414,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         }
 
         decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        guard let url = navigationAction.request.url else {
+            return nil
+        }
+
+        if url.scheme == "http" || url.scheme == "https" {
+            NSWorkspace.shared.open(url)
+        }
+
+        return nil
     }
 
     private func isLocalAppURL(_ url: URL) -> Bool {
@@ -677,11 +689,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     private func configureWindow() {
         let configuration = WKWebViewConfiguration()
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
         let userContentController = WKUserContentController()
         userContentController.add(self, name: "accentHue")
         configuration.userContentController = userContentController
         webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         webView.translatesAutoresizingMaskIntoConstraints = false
 
         let contentContainer = NSView()

--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -1,5 +1,5 @@
 import type { GuiAppActionId, GuiAppActionJobSummary, GuiManagedAppSummary, GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
-import { type Dispatch, type MouseEvent as ReactMouseEvent, type ReactElement, type ReactNode, type SetStateAction, useEffect, useRef, useState } from "react";
+import { type CSSProperties, type Dispatch, type FocusEvent as ReactFocusEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactElement, type ReactNode, type SetStateAction, useEffect, useRef, useState } from "react";
 import type { IconType } from "react-icons";
 import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
 import { FiChevronDown, FiCode, FiDownload, FiExternalLink, FiGlobe, FiMonitor, FiRefreshCw, FiRepeat, FiTerminal, FiTrash2, FiX } from "react-icons/fi";
@@ -24,18 +24,20 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
   const [expandedAppId, setExpandedAppId] = useState<string | null>(() => sortedManagedApps(status.managed_apps).find((app) => managedCategoryForApp(app) === "core")?.id ?? null);
   const [jobs, setJobs] = useState<Record<string, GuiAppActionJobSummary>>({});
   const [dismissedJobIds, setDismissedJobIds] = useState<Set<string>>(() => new Set());
+  const [tooltip, setTooltip] = useState<AppTooltipState | null>(null);
   const [policyJobs, setPolicyJobs] = useState<Record<string, GuiAppActionJobSummary[]>>({});
   const [policyToggles, setPolicyToggles] = useState<ManagedPolicyToggleState>(() => readManagedPolicyToggles());
   const selectedJob = selectedJobId === null ? null : jobs[selectedJobId] ?? null;
   const managedApps = sortedManagedApps(status.managed_apps).map((app) => applyManagedPolicyToggles(app, policyToggles[app.id]));
   const visibleManagedApps = managedApps.filter((app) => managedCategoryForApp(app) === managedCategory);
+  const firstVisibleManagedAppId = visibleManagedApps[0]?.id ?? null;
   const visibleRecommendedApps = recommendedApps.filter((app) => recommendedAppMatchesFilters(app, recommendedPlatform, recommendedOs));
   const selectRecommendedPlatform = (value: RecommendedPlatformFilterId) => setRecommendedPlatform((current) => nextRecommendedFilterValue(current, value, "all"));
   const selectRecommendedOs = (value: RecommendedOsId) => setRecommendedOs((current) => nextRecommendedFilterValue(current, value, "all"));
 
   useEffect(() => {
-    setExpandedAppId(visibleManagedApps[0]?.id ?? null);
-  }, [managedCategory, status.managed_apps]);
+    setExpandedAppId(firstVisibleManagedAppId);
+  }, [firstVisibleManagedAppId]);
 
   const runningJobIdsKey = Object.values(jobs).filter((job) => job.status === "running").map((job) => job.id).sort().join("|");
 
@@ -57,7 +59,7 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
   }, [runningJobIdsKey]);
 
   return (
-    <section className="apps-surface" aria-label={text.apps}>
+    <section className="apps-surface" aria-label={text.apps} onBlur={() => setTooltip(null)} onFocus={showFocusedAppTooltip(setTooltip)} onPointerLeave={() => setTooltip(null)} onPointerMove={showPointedAppTooltip(setTooltip)}>
       <div className="section-heading">
         <p className="eyebrow">{text.infrastructure}</p>
         <h2>{text.apps}</h2>
@@ -103,6 +105,7 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
         </div>
         <p className="empty-state compact-notice">Install/update actions run as allowlisted background jobs and stream inside each app panel. xterm.js with a node-pty bridge is the right next step for full TUI apps such as OpenCode; this view starts with non-interactive command logs.</p>
       </> : <RecommendedAppsSurface apps={visibleRecommendedApps} os={recommendedOs} platform={recommendedPlatform} setOs={selectRecommendedOs} setPlatform={selectRecommendedPlatform} />}
+      {tooltip === null ? null : <AppTooltip tooltip={tooltip} />}
     </section>
   );
 }
@@ -151,7 +154,8 @@ function ManagedAppPanel({ app, dismissedJobIds, expanded, job, onDismissJob, on
 }
 
 function SummaryChip({ label, value }: { label: string; value: string }): ReactElement {
-  return <span className="managed-summary-chip"><small>{label}</small><span>{value}</span></span>;
+  const tooltip = `${label}: ${value}`;
+  return <span className="managed-summary-chip" data-tooltip={tooltip} title={tooltip}><small>{label}</small><span>{value}</span></span>;
 }
 
 function OriginLink({ href, label }: { href: string; label: string }): ReactElement {
@@ -159,7 +163,7 @@ function OriginLink({ href, label }: { href: string; label: string }): ReactElem
     return <span className="origin-missing">{label}: source pending</span>;
   }
 
-  return <a href={href} onClick={(event) => openExternalLink(event, href)} rel="noreferrer" target="_blank" title={href}>{label} <FiExternalLink aria-hidden="true" /></a>;
+  return <a data-tooltip={href} href={href} onClick={(event) => openExternalLink(event, href)} rel="noreferrer" target="_blank" title={href}>{label} <FiExternalLink aria-hidden="true" /></a>;
 }
 
 function ToggleSwitch({ checked, disabled = false, label, onChange }: { checked: boolean; disabled?: boolean; label: string; onChange: (checked: boolean) => void }): ReactElement {
@@ -218,7 +222,7 @@ function AppActionTerminal({ job, onDismiss }: { job: GuiAppActionJobSummary; on
     if (outputRef.current !== null) {
       outputRef.current.scrollTop = outputRef.current.scrollHeight;
     }
-  }, [job.output]);
+  }, [job.output.length]);
 
   return (
     <section className="app-terminal" id={`app-job-${job.id}`} aria-label="App action terminal output">
@@ -594,17 +598,70 @@ function writeManagedPolicyToggles(policy: ManagedPolicyToggleState): void {
   window.localStorage.setItem("aidevops-gui-managed-app-policy", JSON.stringify(policy));
 }
 
+interface AppTooltipState {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function showPointedAppTooltip(setTooltip: Dispatch<SetStateAction<AppTooltipState | null>>) {
+  return (event: ReactPointerEvent<HTMLElement>) => {
+    const target = tooltipTarget(event.target);
+    setTooltip(target === null ? null : tooltipForElement(target));
+  };
+}
+
+function showFocusedAppTooltip(setTooltip: Dispatch<SetStateAction<AppTooltipState | null>>) {
+  return (event: ReactFocusEvent<HTMLElement>) => {
+    const target = tooltipTarget(event.target);
+    if (target !== null) {
+      setTooltip(tooltipForElement(target));
+    }
+  };
+}
+
+function tooltipTarget(target: EventTarget): HTMLElement | null {
+  return target instanceof HTMLElement ? target.closest<HTMLElement>("[data-tooltip]") : null;
+}
+
+function tooltipForElement(element: HTMLElement): AppTooltipState | null {
+  const textValue = element.dataset.tooltip;
+  if (textValue === undefined || textValue.length === 0) {
+    return null;
+  }
+
+  const rect = element.getBoundingClientRect();
+  return { text: textValue, x: rect.left + (rect.width / 2), y: rect.top };
+}
+
+function AppTooltip({ tooltip }: { tooltip: AppTooltipState }): ReactElement {
+  const style = {
+    "--tooltip-x": `${tooltip.x}px`,
+    "--tooltip-y": `${tooltip.y}px`,
+  } as CSSProperties;
+
+  return <div className="app-global-tooltip" role="tooltip" style={style}>{tooltip.text}</div>;
+}
+
 function openExternalLink(event: ReactMouseEvent<HTMLAnchorElement>, href: string): void {
   event.stopPropagation();
   if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
     return;
   }
 
+  event.preventDefault();
+  if (document.documentElement.dataset.desktopShell === "macos") {
+    window.location.assign(href);
+    return;
+  }
+
   const opened = window.open(href, "_blank", "noopener,noreferrer");
   if (opened !== null) {
-    event.preventDefault();
     opened.opener = null;
+    return;
   }
+
+  window.location.assign(href);
 }
 
 export function InstallationSurface(): ReactElement {

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -2558,6 +2558,32 @@ button.managed-toggle:focus-visible {
   transform: translate(-50%, 0);
 }
 
+.apps-surface [data-tooltip]::after {
+  content: none;
+}
+
+.app-global-tooltip {
+  background: color-mix(in srgb, var(--surface-elevated) 94%, black);
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border));
+  border-radius: 10px;
+  box-shadow: 0 18px 46px rgb(0 0 0 / 38%);
+  color: var(--text-primary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  left: clamp(12px, var(--tooltip-x), calc(100vw - 12px));
+  line-height: 1.35;
+  max-width: min(440px, 72vw);
+  overflow-wrap: anywhere;
+  padding: 8px 10px;
+  pointer-events: none;
+  position: fixed;
+  text-align: left;
+  top: var(--tooltip-y);
+  transform: translate(-50%, calc(-100% - 10px));
+  width: max-content;
+  z-index: 10000;
+}
+
 .data-row,
 .editable-row {
   display: grid;

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -187,8 +187,12 @@ describe("dashboard shell", () => {
     expect(html).not.toContain("App and CLI inventory for tools installed or updated by aidevops");
     expect(source.indexOf("Recommended app operating system filters")).toBeLessThan(source.indexOf("Recommended app platform filters"));
     expect(html).toContain("app-meta managed-app-path");
+    expect(html).toContain("data-tooltip=\"Installed: 3.29.11\"");
+    expect(html).toContain("data-tooltip=\"Latest: 3.29.11\"");
     expect(sectionBetween(html, "managed-app-details", "app-meta managed-app-path")).not.toContain("Installed");
     expect(sectionBetween(html, "managed-app-details", "app-meta managed-app-path")).not.toContain("Latest");
+    expect(source).toContain("data-tooltip={href}");
+    expect(source).toContain("app-global-tooltip");
     expect(source).toContain("terminalStatusLabel(job)");
     expect(source).toContain("https://apps.apple.com/us/app/telegram-messenger/id686449807");
     expect(source).toContain("https://play.google.com/store/apps/details?id=org.telegram.messenger");


### PR DESCRIPTION
## Summary

- Render Apps tooltips as fixed-position top-level UI so cards and content frames no longer clip URL/version hints.
- Add URL tooltips and desktop-safe external link launching for Apps origin/recommended links.
- Improve managed app version detection by resolving executable install paths, expanding common PATH locations, and falling back to bundle/build versions or `installed`.

## Verification

- `bun test packages/gui-web/tests`
- `bun test packages/gui-api/tests`
- `bun run typecheck`
- `bun run gui:desktop:check`
- `bash -n packages/gui-desktop/scripts/install-macos-app.sh`
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh`
- `.agents/scripts/markdownlint-diff-helper.sh --mode biome --base origin/main --head HEAD --output-md /tmp/biome-report-local.md`
- `git diff --check`

Resolves #25798

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.19 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
