### PR TITLE
fix: preserve opencode continuation db state

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1242,14 +1242,13 @@ _seed_worker_db_session_context() {
 	[[ -f "$shared_db" ]] || return 0
 	mkdir -p "${isolated_dir}/opencode" 2>/dev/null || return 0
 
-	# Fresh isolated auth dirs may not have a migrated DB yet. Copy the schema from
-	# the shared DB so the targeted row copy has compatible tables without importing
-	# unrelated session/message data. Immediately copy OpenCode migration metadata
-	# too: a schema-only DB has tables but an empty migration ledger, which makes
-	# OpenCode/Drizzle replay CREATE TABLE migrations and fail before continuation
-	# can start.
+	# Fresh isolated auth dirs may not have a migrated DB yet. Copy the shared DB
+	# with SQLite backup, then prune unrelated rows below. A schema-only copy can
+	# still miss SQLite/OpenCode migration state and make Drizzle replay CREATE
+	# TABLE migrations against existing user tables ("table project already
+	# exists") during continuation retries.
 	if [[ ! -f "$worker_db" ]]; then
-		sqlite3 -cmd ".timeout 5000" "$shared_db" .schema 2>/dev/null | sqlite3 "$worker_db" >/dev/null 2>&1 || return 0
+		sqlite3 -cmd ".timeout 5000" "$shared_db" ".backup '${worker_db}'" >/dev/null 2>&1 || return 0
 	fi
 
 	_sync_worker_db_migration_ledgers "$worker_db" "$shared_db"
@@ -1264,6 +1263,9 @@ _seed_worker_db_session_context() {
 			WHERE id IN (SELECT project_id FROM shared.session WHERE id = '${session_id_sql}');
 		INSERT OR IGNORE INTO session SELECT * FROM shared.session WHERE id = '${session_id_sql}';
 		INSERT OR IGNORE INTO message SELECT * FROM shared.message WHERE session_id = '${session_id_sql}';
+		DELETE FROM main.message WHERE session_id != '${session_id_sql}';
+		DELETE FROM main.session WHERE id != '${session_id_sql}';
+		DELETE FROM main.project WHERE id NOT IN (SELECT project_id FROM main.session);
 		DETACH DATABASE shared;
 	SQL
 	return 0

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1296,6 +1296,55 @@ SQL
 	return 0
 }
 
+test_seed_worker_db_session_context_uses_backup_for_fresh_db() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-backup-seed"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+PRAGMA user_version = 42;
+CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash TEXT NOT NULL, created_at INTEGER);
+CREATE TABLE data_migration (id TEXT PRIMARY KEY, updated_at INTEGER NOT NULL);
+CREATE TABLE migration (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL);
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
+INSERT INTO __drizzle_migrations VALUES (1, 'schema-ready', 12345);
+INSERT INTO data_migration VALUES ('data-ready', 67890);
+INSERT INTO migration VALUES ('opencode-v17-ready', 1700000000);
+INSERT INTO project VALUES ('project-keep', 'Keep Project');
+INSERT INTO project VALUES ('project-other', 'Other Project');
+INSERT INTO session VALUES ('session-keep', 'project-keep', 'Keep');
+INSERT INTO session VALUES ('session-other', 'project-other', 'Other');
+INSERT INTO message VALUES ('message-keep', 'session-keep', 'one');
+INSERT INTO message VALUES ('message-other', 'session-other', 'other');
+SQL
+
+	_seed_worker_db_session_context "$isolated_dir" "session-keep"
+
+	local user_version schema_migrations sessions other_sessions messages other_messages projects other_projects
+	user_version=$(sqlite3 "$worker_db" "PRAGMA user_version;")
+	schema_migrations=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM __drizzle_migrations WHERE hash = 'schema-ready';")
+	sessions=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM session WHERE id = 'session-keep';")
+	other_sessions=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM session WHERE id = 'session-other';")
+	messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-keep';")
+	other_messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-other';")
+	projects=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM project WHERE id = 'project-keep';")
+	other_projects=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM project WHERE id = 'project-other';")
+
+	if [[ "$user_version" == "42" && "$schema_migrations" == "1" && "$sessions" == "1" && "$other_sessions" == "0" && "$messages" == "1" && "$other_messages" == "0" && "$projects" == "1" && "$other_projects" == "0" ]]; then
+		print_result "seed worker DB uses shared backup for fresh continuation DB" 0
+		return 0
+	fi
+
+	print_result "seed worker DB uses shared backup for fresh continuation DB" 1 \
+		"user_version=$user_version schema_migrations=$schema_migrations sessions=$sessions other_sessions=$other_sessions messages=$messages other_messages=$other_messages projects=$projects other_projects=$other_projects"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-prewarm"
@@ -2516,6 +2565,7 @@ main() {
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
 	test_seed_worker_db_session_context_copies_only_selected_session
 	test_seed_worker_db_session_context_copies_migration_metadata
+	test_seed_worker_db_session_context_uses_backup_for_fresh_db
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_sync_worker_db_migration_metadata_replaces_stale_ledgers
 	test_copy_worker_db_migration_ledger_preserves_rows_when_attach_fails


### PR DESCRIPTION
## Summary
- Seed fresh isolated OpenCode continuation DBs with SQLite `.backup` from the shared DB instead of schema-only replay.
- Prune the worker DB back to the target session/project/message rows after backup, preserving migration/user-version state while avoiding unrelated session payloads.
- Add regression coverage for the fresh continuation DB path that preserves migration state and prunes unrelated rows.

## Root cause
The #25757 retest after v3.29.18 progressed into real implementation, then was SIGKILLed mid-session. The continuation path seeded a fresh isolated DB by replaying only schema plus selected rows; OpenCode/Drizzle still treated the DB as migration-incomplete and failed with `table project already exists` before the worker could resume.

## Verification
- `bash -n .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh` (94 tests, 0 failures)
- `.agents/scripts/linters-local.sh` (passed; markdown/ratchet debt reported as advisory/pre-existing)

For #25757
For #25778

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.19 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
