### PR TITLE
fix: vacuum seeded worker OpenCode DB

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1257,8 +1257,10 @@ _seed_worker_db_session_context() {
 	shared_db_sql=$(sql_escape "$shared_db")
 	session_id_sql=$(sql_escape "$session_id")
 	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
+		.bail on
 		.timeout 5000
 		ATTACH DATABASE '${shared_db_sql}' AS shared;
+		BEGIN IMMEDIATE;
 		INSERT OR IGNORE INTO project SELECT * FROM shared.project
 			WHERE id IN (SELECT project_id FROM shared.session WHERE id = '${session_id_sql}');
 		INSERT OR IGNORE INTO session SELECT * FROM shared.session WHERE id = '${session_id_sql}';
@@ -1266,7 +1268,9 @@ _seed_worker_db_session_context() {
 		DELETE FROM main.message WHERE session_id != '${session_id_sql}';
 		DELETE FROM main.session WHERE id != '${session_id_sql}';
 		DELETE FROM main.project WHERE id NOT IN (SELECT project_id FROM main.session);
+		COMMIT;
 		DETACH DATABASE shared;
+		VACUUM;
 	SQL
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1345,6 +1345,42 @@ SQL
 	return 0
 }
 
+test_seed_worker_db_session_context_vacuums_pruned_backup() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-vacuum-seed"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<'SQL'
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data BLOB NOT NULL);
+INSERT INTO project VALUES ('project-keep', 'Keep Project');
+INSERT INTO project VALUES ('project-other', 'Other Project');
+INSERT INTO session VALUES ('session-keep', 'project-keep', 'Keep');
+INSERT INTO session VALUES ('session-other', 'project-other', 'Other');
+INSERT INTO message VALUES ('message-keep', 'session-keep', zeroblob(1024));
+INSERT INTO message VALUES ('message-other', 'session-other', zeroblob(1048576));
+SQL
+
+	_seed_worker_db_session_context "$isolated_dir" "session-keep"
+
+	local other_messages freelist_count
+	other_messages=$(sqlite3 "$worker_db" "SELECT COUNT(*) FROM message WHERE session_id = 'session-other';")
+	freelist_count=$(sqlite3 "$worker_db" "PRAGMA freelist_count;")
+
+	if [[ "$other_messages" == "0" && "$freelist_count" == "0" ]]; then
+		print_result "seed worker DB vacuums pruned backup pages" 0
+		return 0
+	fi
+
+	print_result "seed worker DB vacuums pruned backup pages" 1 \
+		"other_messages=$other_messages freelist_count=$freelist_count"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-prewarm"
@@ -2566,6 +2602,7 @@ main() {
 	test_seed_worker_db_session_context_copies_only_selected_session
 	test_seed_worker_db_session_context_copies_migration_metadata
 	test_seed_worker_db_session_context_uses_backup_for_fresh_db
+	test_seed_worker_db_session_context_vacuums_pruned_backup
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_sync_worker_db_migration_metadata_replaces_stale_ledgers
 	test_copy_worker_db_migration_ledger_preserves_rows_when_attach_fails


### PR DESCRIPTION
## Summary
- Wrap continuation worker DB session seeding in `.bail on` plus `BEGIN IMMEDIATE`/`COMMIT` for atomic pruning after attaching the shared DB.
- Run `VACUUM` after detaching the shared DB so copied-and-pruned isolated worker databases do not retain unrelated session/message rows in free pages.
- Add regression coverage that seeds a large unrelated message and verifies pruned worker DB freelist pages are reclaimed.

## Testing
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`

Resolves #25805

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.21 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
