### PR TITLE
fix: guard gui path expansion without HOME

### DIFF
--- a/packages/gui-api/src/status-adapter-utils.ts
+++ b/packages/gui-api/src/status-adapter-utils.ts
@@ -152,7 +152,6 @@ function binaryPathCandidates(binary: string): string[] {
 }
 
 function expandedPath(): string {
-  const home = process.env.HOME ?? "";
   const extraPaths = [
     "/opt/homebrew/bin",
     "/usr/local/bin",
@@ -160,11 +159,16 @@ function expandedPath(): string {
     "/bin",
     "/usr/sbin",
     "/sbin",
-    join(home, ".bun/bin"),
-    join(home, ".local/bin"),
-    join(home, ".cursor/bin"),
-    join(home, ".qlty/bin"),
   ];
+  const home = process.env.HOME;
+  if (home) {
+    extraPaths.push(
+      join(home, ".bun/bin"),
+      join(home, ".local/bin"),
+      join(home, ".cursor/bin"),
+      join(home, ".qlty/bin"),
+    );
+  }
   return [...new Set([...(process.env.PATH ?? "").split(":"), ...extraPaths].filter(Boolean))].join(":");
 }
 

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readStatus, readVaultStatus, readVaultSummary, STATUS_ADAPTER_COMMAND } from "../src/status-adapter";
+import { resolveBinary } from "../src/status-adapter-utils";
 
 describe("status adapter", () => {
   test("uses an exact helper command pattern", () => {
@@ -78,5 +79,37 @@ describe("status adapter", () => {
     expect(vault.status).toBe("unlocked");
     expect(vault.setup_state).toBe("migration-ready");
     expect(vault.readiness.migration_allowed).toBe(true);
+  });
+
+  test("does not search relative home tool paths when HOME is unset", () => {
+    const originalCwd = process.cwd();
+    const originalHome = process.env.HOME;
+    const originalPath = process.env.PATH;
+    const repoRoot = mkdtempSync(join(tmpdir(), "aidevops-gui-relative-path-"));
+    const fakeBinDir = join(repoRoot, ".bun", "bin");
+    const fakeBinary = join(fakeBinDir, "aidevops-relative-path-sentinel");
+    mkdirSync(fakeBinDir, { recursive: true });
+    writeFileSync(fakeBinary, "#!/bin/sh\nexit 0\n");
+    chmodSync(fakeBinary, 0o700);
+
+    try {
+      process.chdir(repoRoot);
+      delete process.env.HOME;
+      process.env.PATH = "";
+
+      expect(resolveBinary("aidevops-relative-path-sentinel")).toBeNull();
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Guard GUI status PATH expansion so home-relative tool directories are appended only when HOME is set.
- Add a regression test that unsets HOME and verifies resolveBinary does not discover a cwd-relative sentinel binary.

## Testing
- Passed: HOME-bun test packages/gui-api/tests/status-adapter.test.ts
- Partial: .agents/scripts/linters-local.sh reached SonarCloud/Qlty/Secretlint, then exceeded the 240s headless watchdog-safe timeout.

MERGE_SUMMARY: Guarded GUI path expansion against relative HOME-derived PATH entries and added regression coverage.

Resolves #25806

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.21 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
