### PR TITLE
fix: handle app action request failures

### DIFF
--- a/packages/gui-web/src/ManagedAppPanel.tsx
+++ b/packages/gui-web/src/ManagedAppPanel.tsx
@@ -87,9 +87,23 @@ function AppActionButton({ action, app, commandPreview, disabled, onJob }: { act
       return;
     }
 
-    const response = await fetch(`/api/apps/${encodeURIComponent(app.id)}/actions/${action}`, { method: "POST" });
-    const envelope = await response.json() as GuiResponseEnvelope<GuiAppActionJobSummary>;
-    onJob(envelope.data);
+    try {
+      const response = await fetch(`/api/apps/${encodeURIComponent(app.id)}/actions/${action}`, { method: "POST" });
+      if (!response.ok) {
+        console.error(`Failed to run ${action} for ${app.id}: ${response.status} ${response.statusText}`);
+        return;
+      }
+
+      const envelope = await response.json() as GuiResponseEnvelope<GuiAppActionJobSummary>;
+      if (!envelope.ok) {
+        console.error(`Action ${action} for ${app.id} returned an error envelope: ${envelope.errors.join("; ")}`);
+        return;
+      }
+
+      onJob(envelope.data);
+    } catch (error) {
+      console.error(`Network error running ${action} for ${app.id}:`, error);
+    }
   }
 
   return <>

--- a/packages/gui-web/src/ManagedAppPanel.tsx
+++ b/packages/gui-web/src/ManagedAppPanel.tsx
@@ -94,13 +94,24 @@ function AppActionButton({ action, app, commandPreview, disabled, onJob }: { act
         return;
       }
 
-      const envelope = await response.json() as GuiResponseEnvelope<GuiAppActionJobSummary>;
-      if (!envelope.ok) {
-        console.error(`Action ${action} for ${app.id} returned an error envelope: ${envelope.errors.join("; ")}`);
+      const envelope = await response.json() as Partial<GuiResponseEnvelope<GuiAppActionJobSummary>> | null;
+      if (envelope === null || typeof envelope !== "object") {
+        console.error(`Action ${action} for ${app.id} returned an invalid response envelope`);
         return;
       }
 
-      onJob(envelope.data);
+      if (envelope.ok !== true) {
+        const errors = Array.isArray(envelope.errors) && envelope.errors.length > 0 ? envelope.errors.join("; ") : "unknown error";
+        console.error(`Action ${action} for ${app.id} returned an error envelope: ${errors}`);
+        return;
+      }
+
+      if (!("data" in envelope)) {
+        console.error(`Action ${action} for ${app.id} returned a response envelope without job data`);
+        return;
+      }
+
+      onJob(envelope.data as GuiAppActionJobSummary);
     } catch (error) {
       console.error(`Network error running ${action} for ${app.id}:`, error);
     }

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -183,6 +183,7 @@ describe("dashboard shell", () => {
     const source = [
       readFileSync(`${guiWebRoot}/src/AppActionTerminal.tsx`, "utf8"),
       readFileSync(`${guiWebRoot}/src/InventorySurfaces.tsx`, "utf8"),
+      readFileSync(`${guiWebRoot}/src/ManagedAppPanel.tsx`, "utf8"),
       readFileSync(`${guiWebRoot}/src/RecommendedAppsSurface.tsx`, "utf8"),
     ].join("\n");
 
@@ -198,6 +199,8 @@ describe("dashboard shell", () => {
     expect(source).toContain("data-tooltip={href}");
     expect(source).toContain("app-global-tooltip");
     expect(source).toContain("terminalStatusLabel(job)");
+    expect(source).toContain("if (!response.ok)");
+    expect(source).toContain("Network error running");
     expect(source).toContain("https://apps.apple.com/us/app/telegram-messenger/id686449807");
     expect(source).toContain("https://play.google.com/store/apps/details?id=org.telegram.messenger");
   });

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -200,6 +200,7 @@ describe("dashboard shell", () => {
     expect(source).toContain("app-global-tooltip");
     expect(source).toContain("terminalStatusLabel(job)");
     expect(source).toContain("if (!response.ok)");
+    expect(source).toContain("envelope === null");
     expect(source).toContain("Network error running");
     expect(source).toContain("https://apps.apple.com/us/app/telegram-messenger/id686449807");
     expect(source).toContain("https://play.google.com/store/apps/details?id=org.telegram.messenger");


### PR DESCRIPTION
Resolves #25804

## MERGE_SUMMARY

Handled failed app action POST responses by checking `response.ok` before JSON parsing, rejecting error envelopes without calling `onJob`, and catching network/JSON failures. Added component-test source assertions to retain the `response.ok` and network-error handling guard.

## Testing

- Pre-commit quality validation passed during commit.
- `bun test packages/gui-web/tests` could not run because `bun` is not installed on PATH in this worker environment.
- `npm run typecheck` / `npx tsc --noEmit` could not run because `node_modules` / TypeScript are not installed in this worktree.
- Re-ran full-loop helper with project validators skipped for this environment-only toolchain gap after confirming `node_modules` and `tsc` are absent.
- Verified git status/diff after edit and rebased onto `origin/main`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.21 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
