### PR TITLE
GH#25796: clarify review thread GraphQL resolution

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -686,6 +686,9 @@ Thread preview: ${preview}
    '${SCRIPT_DIR}/pr-review-thread-response-scanner.sh reply'; resolve with
    '${SCRIPT_DIR}/pr-review-thread-response-scanner.sh resolve' only after
    you have verified the finding is addressed or no longer applies.
+   Review-thread read/reply/resolve operations are GraphQL-only in this helper;
+   use the scanner commands above or 'gh api graphql'. The resolveReviewThread
+   mutation has no REST endpoint, so do not try 'gh api repos/...' for resolve.
 4. For each unresolved bot finding:
    - Verify the premise by reading the cited file and surrounding context.
    - If it is a correctness/security defect in PR-owned code, hand-apply the fix,
@@ -703,6 +706,8 @@ Verification context:
 - Prefer focused tests/lint for changed files.
 - Preserve existing PR scope and provenance labels.
 - Keep comments concise and cite files/commands as evidence.
+- Completion requires each verified-addressed thread to be resolved with
+  resolveReviewThread via '${SCRIPT_DIR}/pr-review-thread-response-scanner.sh resolve'.
 PROMPT_EOF
 	printf '%s\n' "$prompt_file"
 	return 0

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -256,6 +256,22 @@ test_dispatch_prompt_uses_framework_script_path() {
 	return 0
 }
 
+test_dispatch_prompt_mentions_graphql_only_thread_operations() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if grep -q 'Review-thread read/reply/resolve operations are GraphQL-only' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
+		grep -q 'resolveReviewThread' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
+		grep -q 'has no REST endpoint' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
+		grep -q 'Completion requires each verified-addressed thread to be resolved' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
+		print_result "dispatch prompt explains GraphQL-only thread resolution" 0
+	else
+		print_result "dispatch prompt explains GraphQL-only thread resolution" 1 "prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_pr_launches_targeted_worker_with_human_opt_in() {
 	setup_test_env
 	export STUB_THREADS_MODE="human"
@@ -478,6 +494,7 @@ main() {
 	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state
 	test_dispatch_prompt_uses_framework_script_path
+	test_dispatch_prompt_mentions_graphql_only_thread_operations
 	test_dispatch_pr_launches_targeted_worker_with_human_opt_in
 	test_dispatch_is_idempotent_for_same_fingerprint
 	test_dispatch_skips_mixed_fingerprint_during_inflight_window


### PR DESCRIPTION
## Summary

Updated the PR review-thread response worker prompt to state review-thread read/reply/resolve operations are GraphQL-only, call out that resolveReviewThread has no REST endpoint, and require verified-addressed threads to be resolved via the scanner resolve command.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh,.agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pr-review-thread-response-scanner.sh (20 passed, 0 failed); shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

Resolves #25796


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.21 with gpt-5.5 spent 2h 43m and 95,413 tokens on this with the user in an interactive session.