### PR TITLE
t18027: reduce GUI header qlty complexity

### DIFF
--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -7,10 +7,8 @@ import {
   FiBox,
   FiBriefcase,
   FiCalendar,
-  FiChevronDown,
   FiChevronLeft,
   FiChevronRight,
-  FiChevronUp,
   FiClock,
   FiDownloadCloud,
   FiFileText,
@@ -29,7 +27,6 @@ import {
   FiMessageSquare,
   FiMonitor,
   FiPackage,
-  FiRotateCcw,
   FiServer,
   FiSettings,
   FiShield,
@@ -37,8 +34,11 @@ import {
   FiUsers,
 } from "react-icons/fi";
 import type { ContrastPreference, ConversationMode, FontPreference, FontSizePreference, ShellMode, SidebarMode, SurfaceIconName, SurfaceId, SurfaceNavGroup, SurfaceNavItem, ThemePreference } from "./app-model";
-import { DEFAULT_ACCENT_HUE, contrastOptions, dashboardNavItem, fontFamilyForPreference, fontOptions, fontSizeOptions, navGroups, sidebarModeForSurface, surfaceRecordCounts, text } from "./app-model";
+import { dashboardNavItem, navGroups, sidebarModeForSurface, surfaceRecordCounts, text } from "./app-model";
+import { SidebarFooter } from "./AppearanceControls";
 import { VaultPadlock, vaultCollectionForSurface } from "./VaultBadges";
+
+export { hueFromInputValue } from "./AppearanceControls";
 
 const surfaceIcons: Record<SurfaceIconName, IconType> = {
   apps: FiBox,
@@ -70,22 +70,6 @@ const surfaceIcons: Record<SurfaceIconName, IconType> = {
   terminal: FiTerminal,
   users: FiUsers,
 };
-
-export function hueFromInputValue(value: string): number | null {
-  const trimmedValue = value.trim();
-
-  if (trimmedValue.length === 0) {
-    return null;
-  }
-
-  const hue = Number(trimmedValue);
-
-  if (!Number.isInteger(hue)) {
-    return null;
-  }
-
-  return Math.min(359, Math.max(0, hue));
-}
 
 export function SurfaceGlyph({ icon }: { icon: SurfaceIconName }) {
   const Icon = surfaceIcons[icon];
@@ -383,189 +367,5 @@ function SidebarHeader({ setActiveSurface, setShellMode, shellMode }: {
         />
       </div>
     </header>
-  );
-}
-
-function SidebarFooter({ accentHue, contrastPreference, fontPreference, fontSizePreference, setAccentHue, setContrastPreference, setFontPreference, setFontSizePreference, setShowBorders, setShowNavCounts, setThemePreference, showBorders, showNavCounts, themePreference }: {
-  accentHue: number;
-  contrastPreference: ContrastPreference;
-  fontPreference: FontPreference;
-  fontSizePreference: FontSizePreference;
-  setAccentHue: (hue: number) => void;
-  setContrastPreference: (contrast: ContrastPreference) => void;
-  setFontPreference: (font: FontPreference) => void;
-  setFontSizePreference: (size: FontSizePreference) => void;
-  setShowBorders: (show: boolean) => void;
-  setShowNavCounts: (show: boolean) => void;
-  setThemePreference: (theme: ThemePreference) => void;
-  showBorders: boolean;
-  showNavCounts: boolean;
-  themePreference: ThemePreference;
-}) {
-  const [appearanceOpen, setAppearanceOpen] = useState(true);
-  const AppearanceChevron = appearanceOpen ? FiChevronDown : FiChevronUp;
-  const selectedFontFamily = fontFamilyForPreference(fontPreference);
-  const fontIndex = Math.max(0, fontOptions.findIndex((option) => option.value === fontPreference));
-  const fontSizeIndex = Math.max(0, fontSizeOptions.findIndex((option) => option.value === fontSizePreference));
-  const canSelectPreviousFont = fontIndex > 0;
-  const canSelectNextFont = fontIndex < fontOptions.length - 1;
-  const [hueInput, setHueInput] = useState(() => String(accentHue));
-  const setFontByIndex = (index: number) => {
-    const nextFont = fontOptions[index]?.value;
-
-    if (nextFont === undefined) {
-      return;
-    }
-
-    setFontPreference(nextFont);
-  };
-  const updateAccentHue = (value: number) => {
-    if (!Number.isFinite(value)) {
-      return;
-    }
-    setAccentHue(Math.min(359, Math.max(0, value)));
-  };
-  const updateHueInput = (value: string) => {
-    setHueInput(value);
-
-    const nextHue = hueFromInputValue(value);
-
-    if (nextHue === null) {
-      return;
-    }
-
-    updateAccentHue(nextHue);
-  };
-
-  useEffect(() => {
-    setHueInput(String(accentHue));
-  }, [accentHue]);
-
-  return (
-    <footer className="sidebar-footer">
-      <section className={appearanceOpen ? "appearance-panel open" : "appearance-panel collapsed"}>
-        <button
-          aria-expanded={appearanceOpen}
-          className="appearance-panel-tab"
-          onClick={() => setAppearanceOpen((current) => !current)}
-          type="button"
-        >
-          {text.appearance}
-          <AppearanceChevron aria-hidden="true" className="appearance-chevron" />
-        </button>
-        {appearanceOpen ? <div className="appearance-panel-body">
-          <fieldset className="theme-control compact" aria-label={text.theme}>
-            {(["system", "light", "dark"] as const).map((theme) => (
-              <button
-                aria-pressed={themePreference === theme}
-                className={themePreference === theme ? "theme-option active" : "theme-option"}
-                key={theme}
-                onClick={() => setThemePreference(theme)}
-                type="button"
-              >
-                {theme}
-              </button>
-            ))}
-          </fieldset>
-          <div className="theme-hue-control">
-            <div className="theme-control-heading">
-              <div className="hue-label-row">
-                <label htmlFor="theme-hue-slider">{text.hue}</label>
-                <input
-                  aria-label="Hue value"
-                  className="hue-number-input"
-                  max="359"
-                  min="0"
-                  onChange={(event) => updateHueInput(event.currentTarget.value)}
-                  type="number"
-                  value={hueInput}
-                />
-              </div>
-              <button aria-label="Reset hue to default" className="icon-reset-button" onClick={() => setAccentHue(DEFAULT_ACCENT_HUE)} title={text.reset} type="button"><FiRotateCcw aria-hidden="true" /></button>
-            </div>
-            <input
-              id="theme-hue-slider"
-              max="359"
-              min="0"
-              onChange={(event) => updateAccentHue(Number.parseInt(event.currentTarget.value, 10))}
-              type="range"
-              value={accentHue}
-            />
-          </div>
-          <fieldset className="contrast-control" aria-label={text.contrast}>
-            <legend>{text.contrast}</legend>
-            <div className="contrast-options">
-              {contrastOptions.map((option) => (
-                <button
-                  aria-pressed={contrastPreference === option.value}
-                  className={contrastPreference === option.value ? "active" : ""}
-                  key={option.value}
-                  onClick={() => setContrastPreference(option.value)}
-                  type="button"
-                >
-                  {option.label}
-                </button>
-              ))}
-            </div>
-          </fieldset>
-          <label className="switch-control appearance-switch">
-            <strong>{text.showBorders}</strong>
-            <input checked={showBorders} onChange={(event) => setShowBorders(event.currentTarget.checked)} type="checkbox" />
-            <span aria-hidden="true" />
-          </label>
-          <label className="switch-control appearance-switch">
-            <strong>{text.showCounts}</strong>
-            <input checked={showNavCounts} onChange={(event) => setShowNavCounts(event.currentTarget.checked)} type="checkbox" />
-            <span aria-hidden="true" />
-          </label>
-          <div className="font-size-control">
-            <label htmlFor="font-size-slider">{text.fontSize}</label>
-            <input
-              id="font-size-slider"
-              max={fontSizeOptions.length - 1}
-              min="0"
-              onChange={(event) => setFontSizePreference(fontSizeOptions[Number.parseInt(event.currentTarget.value, 10)]?.value ?? "xs")}
-              step="1"
-              type="range"
-              value={fontSizeIndex}
-            />
-            <fieldset className="range-labels">
-              <legend className="sr-only">Font size shortcuts</legend>
-              {fontSizeOptions.map((option) => (
-                <button
-                  aria-pressed={option.value === fontSizePreference}
-                  className={option.value === fontSizePreference ? "active" : ""}
-                  key={option.value}
-                  onClick={() => setFontSizePreference(option.value)}
-                  type="button"
-                >
-                  {option.label}
-                </button>
-              ))}
-            </fieldset>
-          </div>
-          <div className="font-control">
-            <span id="appearance-font-selector-label">{text.font}</span>
-            <div className="selector-with-stepper font-selector-row">
-              <button aria-label="Previous font" className="selector-step-button" disabled={!canSelectPreviousFont} onClick={() => setFontByIndex(fontIndex - 1)} type="button"><FiChevronLeft aria-hidden="true" /></button>
-              <select
-                aria-labelledby="appearance-font-selector-label"
-                onChange={(event) => setFontPreference(event.currentTarget.value as FontPreference)}
-                style={{ fontFamily: selectedFontFamily }}
-                value={fontPreference}
-              >
-                {fontOptions.map((option) => (
-                  <option key={option.value} style={{ fontFamily: option.fontFamily }} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              <button aria-label="Next font" className="selector-step-button" disabled={!canSelectNextFont} onClick={() => setFontByIndex(fontIndex + 1)} type="button"><FiChevronRight aria-hidden="true" /></button>
-            </div>
-          </div>
-        </div>
-        : null}
-      </section>
-    </footer>
   );
 }

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -1,5 +1,5 @@
 /* jshint esversion: 11 */
-import { type ReactElement, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
 import { FiAlertTriangle, FiBell, FiCheckCircle, FiChevronLeft, FiChevronRight, FiCommand, FiFileText, FiGlobe, FiHash, FiHelpCircle, FiInfo, FiLogOut, FiMessageSquare, FiPaperclip, FiSearch, FiSettings, FiShield, FiTerminal, FiTool, FiUser } from "react-icons/fi";
 import type { GuiFileRootId, GuiNotificationSummary, GuiStatusData } from "../../gui-shared/src";
 import { SurfaceGlyph } from "./AppNavigation";
@@ -11,6 +11,7 @@ import { FileExplorerSurface } from "./FileExplorerSurface";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
 import { AiProvidersSurface, LocalReposSurface, LockedVaultGate, OverviewSurface, PlannedSurface, ProjectsSurface, SecuritySurface, VaultSurface } from "./StatusSurfaces";
 import { isVaultSurfaceLocked, vaultCollectionForSurface } from "./VaultBadges";
+import { applyCommandPaletteSelection, useHeaderMenuState } from "./workspace-header-state";
 
 const communityLinks = {
   github: "https://github.com/marcusquinn/aidevops",
@@ -64,32 +65,12 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
   setShellMode: (mode: ShellMode) => void;
   status: GuiStatusData;
 }): ReactElement {
-  const [assistantOpen, setAssistantOpen] = useState(false);
   const [commandInitialQuery, setCommandInitialQuery] = useState("");
   const [commandOpen, setCommandOpen] = useState(false);
-  const [notificationsOpen, setNotificationsOpen] = useState(false);
-  const [profileOpen, setProfileOpen] = useState(false);
-  const headerActionsRef = useRef<HTMLDivElement | null>(null);
-  const closeHeaderTimerRef = useRef<number | null>(null);
+  const headerMenus = useHeaderMenuState();
   const userInitials = status.machine.initials || "AI";
   const userName = status.machine.username || "Local user";
   const activeNotifications = status.notifications.filter((notification) => notification.status === "active");
-  const clearScheduledHeaderClose = useCallback(() => {
-    if (closeHeaderTimerRef.current !== null) {
-      window.clearTimeout(closeHeaderTimerRef.current);
-      closeHeaderTimerRef.current = null;
-    }
-  }, []);
-  const closeHeaderMenus = useCallback(() => {
-    clearScheduledHeaderClose();
-    setAssistantOpen(false);
-    setNotificationsOpen(false);
-    setProfileOpen(false);
-  }, [clearScheduledHeaderClose]);
-  const scheduleHeaderMenusClose = useCallback(() => {
-    clearScheduledHeaderClose();
-    closeHeaderTimerRef.current = window.setTimeout(closeHeaderMenus, 2_400);
-  }, [clearScheduledHeaderClose, closeHeaderMenus]);
 
   useEffect(() => {
     const openCommandPalette = (event: KeyboardEvent) => {
@@ -107,47 +88,17 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
     return () => window.removeEventListener("keydown", openCommandPalette);
   }, [goBack, goForward]);
 
-  useEffect(() => {
-    const closeOnPointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && headerActionsRef.current?.contains(target)) {
-        return;
-      }
-
-      closeHeaderMenus();
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeHeaderMenus();
-      }
-    };
-
-    document.addEventListener("pointerdown", closeOnPointerDown, true);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("pointerdown", closeOnPointerDown, true);
-      document.removeEventListener("keydown", closeOnEscape);
-      clearScheduledHeaderClose();
-    };
-  }, [clearScheduledHeaderClose, closeHeaderMenus]);
-
-  const closeMenus = () => {
-    closeHeaderMenus();
-  };
-
-  const openItem = ({ conversationMode, repoPathRef, sessionId, shellMode, surface }: CommandPaletteSelection) => {
-    const repoIndex = status.local_repos.repos.findIndex((repo) => repo.path_ref === repoPathRef);
-    setShellMode(shellMode ?? "devices");
-    if (repoIndex >= 0) {
-      setSelectedLocalRepoIndex(repoIndex);
-    }
-    setSelectedSessionId(sessionId);
-    if (conversationMode) {
-      setConversationMode(conversationMode);
-    }
-    setActiveSurface(surface);
-    closeMenus();
-    setCommandOpen(false);
+  const openItem = (selection: CommandPaletteSelection) => {
+    applyCommandPaletteSelection(selection, {
+      closeCommandPalette: () => setCommandOpen(false),
+      closeHeaderMenus: headerMenus.closeHeaderMenus,
+      setActiveSurface,
+      setConversationMode,
+      setSelectedLocalRepoIndex,
+      setSelectedSessionId,
+      setShellMode,
+      status,
+    });
   };
 
   return (
@@ -170,28 +121,28 @@ function WorkspaceHeader({ activeItem, activeSectionLabel, activeSurface, canGoB
           <strong>{text.searchPlaceholder}</strong>
         </button>
       </div>
-      <div className="header-actions" onPointerEnter={clearScheduledHeaderClose} onPointerLeave={scheduleHeaderMenusClose} ref={headerActionsRef}>
+      <div className="header-actions" onPointerEnter={headerMenus.clearScheduledHeaderClose} onPointerLeave={headerMenus.scheduleHeaderMenusClose} ref={headerMenus.headerActionsRef}>
         <div className="header-action-menu">
-          <button aria-label="Open signposts and help" className="header-icon-button" onClick={() => { closeHeaderMenus(); openItem({ surface: "help" }); }} title="Signposts and help (?)" type="button">
+          <button aria-label="Open signposts and help" className="header-icon-button" onClick={() => { headerMenus.closeHeaderMenus(); openItem({ surface: "help" }); }} title="Signposts and help (?)" type="button">
             <FiHelpCircle aria-hidden="true" />
           </button>
-          <button aria-expanded={notificationsOpen} aria-label="Open notifications" className="header-icon-button" onClick={() => { clearScheduledHeaderClose(); setNotificationsOpen((current) => !current); setProfileOpen(false); setAssistantOpen(false); }} type="button">
+          <button aria-expanded={headerMenus.notificationsOpen} aria-label="Open notifications" className="header-icon-button" onClick={headerMenus.toggleNotifications} type="button">
             <FiBell aria-hidden="true" />
             {activeNotifications.length > 0 ? <span className="notification-dot" aria-hidden="true" /> : null}
           </button>
-          {notificationsOpen ? <NotificationsMenu notifications={status.notifications} openSurface={(surface) => openItem({ surface })} /> : null}
+          {headerMenus.notificationsOpen ? <NotificationsMenu notifications={status.notifications} openSurface={(surface) => openItem({ surface })} /> : null}
         </div>
-        <button aria-pressed={assistantOpen} aria-label="Toggle AI Assistant" className={assistantOpen ? "header-icon-button active" : "header-icon-button"} onClick={() => { clearScheduledHeaderClose(); setAssistantOpen((current) => !current); setNotificationsOpen(false); setProfileOpen(false); }} title="AI sessions (_)" type="button">
+        <button aria-pressed={headerMenus.assistantOpen} aria-label="Toggle AI Assistant" className={headerMenus.assistantOpen ? "header-icon-button active" : "header-icon-button"} onClick={headerMenus.toggleAssistant} title="AI sessions (_)" type="button">
           <FiTerminal aria-hidden="true" />
         </button>
         <div className="header-action-menu">
-          <button aria-expanded={profileOpen} aria-label={`Open profile menu for ${userName}`} className="profile-avatar-button" onClick={() => { clearScheduledHeaderClose(); setProfileOpen((current) => !current); setNotificationsOpen(false); setAssistantOpen(false); }} title={userName} type="button">
+          <button aria-expanded={headerMenus.profileOpen} aria-label={`Open profile menu for ${userName}`} className="profile-avatar-button" onClick={headerMenus.toggleProfile} title={userName} type="button">
             <span>{userInitials}</span>
           </button>
-          {profileOpen ? <ProfileMenu openSurface={(surface) => openItem({ surface })} userName={userName} /> : null}
+          {headerMenus.profileOpen ? <ProfileMenu openSurface={(surface) => openItem({ surface })} userName={userName} /> : null}
         </div>
       </div>
-      {assistantOpen ? <AssistantPanel activeSurface={activeSurface} userName={userName} /> : null}
+      {headerMenus.assistantOpen ? <AssistantPanel activeSurface={activeSurface} userName={userName} /> : null}
       {commandOpen ? <CommandPalette activeSurface={activeSurface} close={() => setCommandOpen(false)} initialQuery={commandInitialQuery} openItem={openItem} status={status} /> : null}
     </header>
   );

--- a/packages/gui-web/src/AppearanceControls.tsx
+++ b/packages/gui-web/src/AppearanceControls.tsx
@@ -1,0 +1,244 @@
+import { type ReactElement, useEffect, useState } from "react";
+import { FiChevronDown, FiChevronLeft, FiChevronRight, FiChevronUp, FiRotateCcw } from "react-icons/fi";
+import type { ContrastPreference, FontPreference, FontSizePreference, ThemePreference } from "./app-model";
+import { DEFAULT_ACCENT_HUE, contrastOptions, fontFamilyForPreference, fontOptions, fontSizeOptions, text } from "./app-model";
+
+export function hueFromInputValue(value: string): number | null {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.length === 0) {
+    return null;
+  }
+
+  const hue = Number(trimmedValue);
+
+  if (!Number.isInteger(hue)) {
+    return null;
+  }
+
+  return Math.min(359, Math.max(0, hue));
+}
+
+export function SidebarFooter(props: SidebarFooterProps): ReactElement {
+  const [appearanceOpen, setAppearanceOpen] = useState(true);
+  const AppearanceChevron = appearanceOpen ? FiChevronDown : FiChevronUp;
+
+  return (
+    <footer className="sidebar-footer">
+      <section className={appearanceOpen ? "appearance-panel open" : "appearance-panel collapsed"}>
+        <button
+          aria-expanded={appearanceOpen}
+          className="appearance-panel-tab"
+          onClick={() => setAppearanceOpen((current) => !current)}
+          type="button"
+        >
+          {text.appearance}
+          <AppearanceChevron aria-hidden="true" className="appearance-chevron" />
+        </button>
+        {appearanceOpen ? <AppearancePanelBody {...props} /> : null}
+      </section>
+    </footer>
+  );
+}
+
+interface SidebarFooterProps {
+  accentHue: number;
+  contrastPreference: ContrastPreference;
+  fontPreference: FontPreference;
+  fontSizePreference: FontSizePreference;
+  setAccentHue: (hue: number) => void;
+  setContrastPreference: (contrast: ContrastPreference) => void;
+  setFontPreference: (font: FontPreference) => void;
+  setFontSizePreference: (size: FontSizePreference) => void;
+  setShowBorders: (show: boolean) => void;
+  setShowNavCounts: (show: boolean) => void;
+  setThemePreference: (theme: ThemePreference) => void;
+  showBorders: boolean;
+  showNavCounts: boolean;
+  themePreference: ThemePreference;
+}
+
+function AppearancePanelBody({ accentHue, contrastPreference, fontPreference, fontSizePreference, setAccentHue, setContrastPreference, setFontPreference, setFontSizePreference, setShowBorders, setShowNavCounts, setThemePreference, showBorders, showNavCounts, themePreference }: SidebarFooterProps): ReactElement {
+  return (
+    <div className="appearance-panel-body">
+      <ThemeControl setThemePreference={setThemePreference} themePreference={themePreference} />
+      <HueControl accentHue={accentHue} setAccentHue={setAccentHue} />
+      <ContrastControl contrastPreference={contrastPreference} setContrastPreference={setContrastPreference} />
+      <AppearanceSwitches setShowBorders={setShowBorders} setShowNavCounts={setShowNavCounts} showBorders={showBorders} showNavCounts={showNavCounts} />
+      <FontSizeControl fontSizePreference={fontSizePreference} setFontSizePreference={setFontSizePreference} />
+      <FontControl fontPreference={fontPreference} setFontPreference={setFontPreference} />
+    </div>
+  );
+}
+
+function ThemeControl({ setThemePreference, themePreference }: { setThemePreference: (theme: ThemePreference) => void; themePreference: ThemePreference }): ReactElement {
+  return (
+    <fieldset className="theme-control compact" aria-label={text.theme}>
+      {(["system", "light", "dark"] as const).map((theme) => (
+        <button
+          aria-pressed={themePreference === theme}
+          className={themePreference === theme ? "theme-option active" : "theme-option"}
+          key={theme}
+          onClick={() => setThemePreference(theme)}
+          type="button"
+        >
+          {theme}
+        </button>
+      ))}
+    </fieldset>
+  );
+}
+
+function HueControl({ accentHue, setAccentHue }: { accentHue: number; setAccentHue: (hue: number) => void }): ReactElement {
+  const [hueInput, setHueInput] = useState(() => String(accentHue));
+  const updateAccentHue = (value: number) => {
+    if (Number.isFinite(value)) {
+      setAccentHue(Math.min(359, Math.max(0, value)));
+    }
+  };
+  const updateHueInput = (value: string) => {
+    setHueInput(value);
+    const nextHue = hueFromInputValue(value);
+    if (nextHue !== null) {
+      updateAccentHue(nextHue);
+    }
+  };
+
+  useEffect(() => {
+    setHueInput(String(accentHue));
+  }, [accentHue]);
+
+  return (
+    <div className="theme-hue-control">
+      <div className="theme-control-heading">
+        <div className="hue-label-row">
+          <label htmlFor="theme-hue-slider">{text.hue}</label>
+          <input
+            aria-label="Hue value"
+            className="hue-number-input"
+            max="359"
+            min="0"
+            onChange={(event) => updateHueInput(event.currentTarget.value)}
+            type="number"
+            value={hueInput}
+          />
+        </div>
+        <button aria-label="Reset hue to default" className="icon-reset-button" onClick={() => setAccentHue(DEFAULT_ACCENT_HUE)} title={text.reset} type="button"><FiRotateCcw aria-hidden="true" /></button>
+      </div>
+      <input
+        id="theme-hue-slider"
+        max="359"
+        min="0"
+        onChange={(event) => updateAccentHue(Number.parseInt(event.currentTarget.value, 10))}
+        type="range"
+        value={accentHue}
+      />
+    </div>
+  );
+}
+
+function ContrastControl({ contrastPreference, setContrastPreference }: { contrastPreference: ContrastPreference; setContrastPreference: (contrast: ContrastPreference) => void }): ReactElement {
+  return (
+    <fieldset className="contrast-control" aria-label={text.contrast}>
+      <legend>{text.contrast}</legend>
+      <div className="contrast-options">
+        {contrastOptions.map((option) => (
+          <button
+            aria-pressed={contrastPreference === option.value}
+            className={contrastPreference === option.value ? "active" : ""}
+            key={option.value}
+            onClick={() => setContrastPreference(option.value)}
+            type="button"
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function AppearanceSwitches({ setShowBorders, setShowNavCounts, showBorders, showNavCounts }: { setShowBorders: (show: boolean) => void; setShowNavCounts: (show: boolean) => void; showBorders: boolean; showNavCounts: boolean }): ReactElement {
+  return (
+    <>
+      <label className="switch-control appearance-switch">
+        <strong>{text.showBorders}</strong>
+        <input checked={showBorders} onChange={(event) => setShowBorders(event.currentTarget.checked)} type="checkbox" />
+        <span aria-hidden="true" />
+      </label>
+      <label className="switch-control appearance-switch">
+        <strong>{text.showCounts}</strong>
+        <input checked={showNavCounts} onChange={(event) => setShowNavCounts(event.currentTarget.checked)} type="checkbox" />
+        <span aria-hidden="true" />
+      </label>
+    </>
+  );
+}
+
+function FontSizeControl({ fontSizePreference, setFontSizePreference }: { fontSizePreference: FontSizePreference; setFontSizePreference: (size: FontSizePreference) => void }): ReactElement {
+  const fontSizeIndex = Math.max(0, fontSizeOptions.findIndex((option) => option.value === fontSizePreference));
+
+  return (
+    <div className="font-size-control">
+      <label htmlFor="font-size-slider">{text.fontSize}</label>
+      <input
+        id="font-size-slider"
+        max={fontSizeOptions.length - 1}
+        min="0"
+        onChange={(event) => setFontSizePreference(fontSizeOptions[Number.parseInt(event.currentTarget.value, 10)]?.value ?? "xs")}
+        step="1"
+        type="range"
+        value={fontSizeIndex}
+      />
+      <fieldset className="range-labels">
+        <legend className="sr-only">Font size shortcuts</legend>
+        {fontSizeOptions.map((option) => (
+          <button
+            aria-pressed={option.value === fontSizePreference}
+            className={option.value === fontSizePreference ? "active" : ""}
+            key={option.value}
+            onClick={() => setFontSizePreference(option.value)}
+            type="button"
+          >
+            {option.label}
+          </button>
+        ))}
+      </fieldset>
+    </div>
+  );
+}
+
+function FontControl({ fontPreference, setFontPreference }: { fontPreference: FontPreference; setFontPreference: (font: FontPreference) => void }): ReactElement {
+  const selectedFontFamily = fontFamilyForPreference(fontPreference);
+  const fontIndex = Math.max(0, fontOptions.findIndex((option) => option.value === fontPreference));
+  const canSelectPreviousFont = fontIndex > 0;
+  const canSelectNextFont = fontIndex < fontOptions.length - 1;
+  const setFontByIndex = (index: number) => {
+    const nextFont = fontOptions[index]?.value;
+    if (nextFont !== undefined) {
+      setFontPreference(nextFont);
+    }
+  };
+
+  return (
+    <div className="font-control">
+      <span id="appearance-font-selector-label">{text.font}</span>
+      <div className="selector-with-stepper font-selector-row">
+        <button aria-label="Previous font" className="selector-step-button" disabled={!canSelectPreviousFont} onClick={() => setFontByIndex(fontIndex - 1)} type="button"><FiChevronLeft aria-hidden="true" /></button>
+        <select
+          aria-labelledby="appearance-font-selector-label"
+          onChange={(event) => setFontPreference(event.currentTarget.value as FontPreference)}
+          style={{ fontFamily: selectedFontFamily }}
+          value={fontPreference}
+        >
+          {fontOptions.map((option) => (
+            <option key={option.value} style={{ fontFamily: option.fontFamily }} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <button aria-label="Next font" className="selector-step-button" disabled={!canSelectNextFont} onClick={() => setFontByIndex(fontIndex + 1)} type="button"><FiChevronRight aria-hidden="true" /></button>
+      </div>
+    </div>
+  );
+}

--- a/packages/gui-web/src/workspace-header-state.ts
+++ b/packages/gui-web/src/workspace-header-state.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GuiStatusData } from "../../gui-shared/src";
+import type { ConversationMode, ShellMode, SurfaceId } from "./app-model";
+import type { CommandPaletteSelection } from "./CommandPalette";
+
+export function useHeaderMenuState() {
+  const [assistantOpen, setAssistantOpen] = useState(false);
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const headerActionsRef = useRef<HTMLDivElement | null>(null);
+  const closeHeaderTimerRef = useRef<number | null>(null);
+  const clearScheduledHeaderClose = useCallback(() => {
+    if (closeHeaderTimerRef.current !== null) {
+      window.clearTimeout(closeHeaderTimerRef.current);
+      closeHeaderTimerRef.current = null;
+    }
+  }, []);
+  const closeHeaderMenus = useCallback(() => {
+    clearScheduledHeaderClose();
+    setAssistantOpen(false);
+    setNotificationsOpen(false);
+    setProfileOpen(false);
+  }, [clearScheduledHeaderClose]);
+  const scheduleHeaderMenusClose = useCallback(() => {
+    clearScheduledHeaderClose();
+    closeHeaderTimerRef.current = window.setTimeout(closeHeaderMenus, 2_400);
+  }, [clearScheduledHeaderClose, closeHeaderMenus]);
+  const toggleNotifications = useCallback(() => {
+    clearScheduledHeaderClose();
+    setNotificationsOpen((current) => !current);
+    setProfileOpen(false);
+    setAssistantOpen(false);
+  }, [clearScheduledHeaderClose]);
+  const toggleAssistant = useCallback(() => {
+    clearScheduledHeaderClose();
+    setAssistantOpen((current) => !current);
+    setNotificationsOpen(false);
+    setProfileOpen(false);
+  }, [clearScheduledHeaderClose]);
+  const toggleProfile = useCallback(() => {
+    clearScheduledHeaderClose();
+    setProfileOpen((current) => !current);
+    setNotificationsOpen(false);
+    setAssistantOpen(false);
+  }, [clearScheduledHeaderClose]);
+
+  useEffect(() => {
+    const closeOnPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || !headerActionsRef.current?.contains(target)) {
+        closeHeaderMenus();
+      }
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeHeaderMenus();
+      }
+    };
+
+    document.addEventListener("pointerdown", closeOnPointerDown, true);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointerDown, true);
+      document.removeEventListener("keydown", closeOnEscape);
+      clearScheduledHeaderClose();
+    };
+  }, [clearScheduledHeaderClose, closeHeaderMenus]);
+
+  return {
+    assistantOpen,
+    clearScheduledHeaderClose,
+    closeHeaderMenus,
+    headerActionsRef,
+    notificationsOpen,
+    profileOpen,
+    scheduleHeaderMenusClose,
+    toggleAssistant,
+    toggleNotifications,
+    toggleProfile,
+  };
+}
+
+export interface CommandPaletteNavigationActions {
+  closeCommandPalette: () => void;
+  closeHeaderMenus: () => void;
+  setActiveSurface: (surface: SurfaceId) => void;
+  setConversationMode: (mode: ConversationMode) => void;
+  setSelectedLocalRepoIndex: (index: number) => void;
+  setSelectedSessionId: (id: string | undefined) => void;
+  setShellMode: (mode: ShellMode) => void;
+  status: GuiStatusData;
+}
+
+export function applyCommandPaletteSelection({ conversationMode, repoPathRef, sessionId, shellMode, surface }: CommandPaletteSelection, actions: CommandPaletteNavigationActions): void {
+  const repoIndex = actions.status.local_repos.repos.findIndex((repo) => repo.path_ref === repoPathRef);
+  actions.setShellMode(shellMode ?? "devices");
+  if (repoIndex >= 0) {
+    actions.setSelectedLocalRepoIndex(repoIndex);
+  }
+  actions.setSelectedSessionId(sessionId);
+  if (conversationMode) {
+    actions.setConversationMode(conversationMode);
+  }
+  actions.setActiveSurface(surface);
+  actions.closeHeaderMenus();
+  actions.closeCommandPalette();
+}

--- a/todo/tasks/t18027-brief.md
+++ b/todo/tasks/t18027-brief.md
@@ -61,6 +61,8 @@ Model on the existing Apps surface custom-tooltip approach in `packages/gui-web/
 - `packages/gui-web/src/InventorySurfaces.tsx` — global tooltip alignment state and viewport-edge placement.
 - `packages/gui-web/src/AppWorkspace.tsx` — header popover mutual exclusion, click-away/Escape close, and delayed hover-away close.
 - `packages/gui-web/src/AppNavigation.tsx` — logo dashboard navigation and Appearance contrast controls.
+- `packages/gui-web/src/AppearanceControls.tsx` — extracted Appearance footer controls and hue parsing helper.
+- `packages/gui-web/src/workspace-header-state.ts` — extracted header menu state and command palette selection helpers.
 - `packages/gui-web/src/App.tsx` — contrast persistence and document dataset wiring.
 - `packages/gui-web/src/app-model.ts` — contrast preference type, options, default, validator, and label copy.
 - `packages/gui-web/src/styles.css` — tooltip placement, app icon hit-area alignment, recommended tile hover/focus states, and contrast CSS variables.
@@ -79,6 +81,7 @@ Model on the existing Apps surface custom-tooltip approach in `packages/gui-web/
 7. Make the logo return to Dashboard and restore the devices rail mode.
 8. Add persisted low/medium/high Appearance contrast preferences with CSS theme variants.
 9. Allow the full local `/api/status` redaction test up to 10 seconds because it exercises local status probes and can exceed Bun's 5-second default on loaded developer machines.
+10. Extract Appearance controls and header menu state into smaller modules to keep the Qlty smell threshold/regression gates clean.
 
 ### Verification
 
@@ -89,6 +92,7 @@ Model on the existing Apps surface custom-tooltip approach in `packages/gui-web/
 - `shellcheck packages/gui-desktop/scripts/install-macos-app.sh`
 - `bun run gui:desktop:check`
 - `git diff --check`
+- `qlty smells --all --sarif --no-snippets --quiet` / `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD`
 
 ## Acceptance
 


### PR DESCRIPTION
## Summary

- extract Appearance footer controls into `AppearanceControls.tsx`
- extract workspace header menu state/command selection helpers into `workspace-header-state.ts`
- reduce Qlty smell count from 51 to 47 after the merged GUI polish PR

## Verification

- `bun test packages/gui-web/tests`
- `bun run typecheck`
- `git diff --check origin/main...HEAD`
- `qlty smells --all --sarif --no-snippets --quiet` (47 total smells, threshold 47)
- `.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD` (delta -4)
- `npx --yes @biomejs/biome@2.4.12 lint packages/gui-web/src/AppNavigation.tsx packages/gui-web/src/AppWorkspace.tsx packages/gui-web/src/AppearanceControls.tsx packages/gui-web/src/workspace-header-state.ts`

Ref #25822
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.22 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5h 29m and 2,769,237 tokens on this with the user in an interactive session.