### PR TITLE
GH#25814: test: harden requirements lock validation

### DIFF
--- a/.agents/scripts/tests/test-requirements-lock-generated.sh
+++ b/.agents/scripts/tests/test-requirements-lock-generated.sh
@@ -19,11 +19,16 @@ main() {
 	local seen_dependency=0
 	local line_number=0
 
+	if [[ ! -f "${LOCK_FILE:-}" ]]; then
+		printf 'FAIL: requirements-lock.txt not found at %s\n' "${LOCK_FILE:-}" >&2
+		return 1
+	fi
+
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		line_number=$((line_number + 1))
 
 		if [[ "$seen_dependency" -eq 0 ]]; then
-			if [[ "$line" == *==* ]]; then
+			if [[ "$line" == *==* && "$line" != \#* ]]; then
 				seen_dependency=1
 			fi
 			continue


### PR DESCRIPTION
## Summary

Added a regular-file guard before reading requirements-lock.txt and ensured comment lines containing == do not mark the dependency section.

## Files Changed

.agents/scripts/tests/test-requirements-lock-generated.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-requirements-lock-generated.sh; shellcheck .agents/scripts/tests/test-requirements-lock-generated.sh

Resolves #25814


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.24 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 30,173 tokens on this as a headless worker.