### PR TITLE
fix: recover sudo gh auth for approvals

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -35,18 +35,29 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
-# Resolve the real user's home directory, handling sudo env_reset on Linux.
-# Under sudo on Linux, HOME is reset to /root/ by env_reset; SUDO_USER holds
-# the original username. getent passwd is the canonical resolver on Linux.
-# On macOS, sudo does not reset HOME (and getent is not available), so the
-# fallback to $HOME is correct for both platforms.
+# Resolve the real user's home directory, handling sudo env_reset.
+# Under sudo, HOME may point at root's home while SUDO_USER holds the invoking
+# username. getent passwd is canonical on Linux; dscl is canonical on macOS.
 # Security: no escalation — root already has full filesystem access.
 _resolve_real_home() {
-	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
-		local real_home
-		real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
-		if [[ -n "$real_home" ]]; then
-			printf '%s' "$real_home"
+	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+		local real_home=""
+		if command -v getent &>/dev/null; then
+			real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+			if [[ -n "$real_home" ]]; then
+				printf '%s' "$real_home"
+				return 0
+			fi
+		fi
+		if command -v dscl &>/dev/null; then
+			real_home=$(dscl . -read "/Users/${SUDO_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2; exit}' || true)
+			if [[ -n "$real_home" ]]; then
+				printf '%s' "$real_home"
+				return 0
+			fi
+		fi
+		if [[ -d "/Users/${SUDO_USER}" ]]; then
+			printf '/Users/%s' "$SUDO_USER"
 			return 0
 		fi
 	fi
@@ -112,47 +123,103 @@ _print_error() {
 	return 0
 }
 
+_approval_use_gh_token() {
+	local token="${1:-}"
+	local previous_token="${GH_TOKEN:-}"
+	local token_was_set="${GH_TOKEN+x}"
+
+	if [[ -z "$token" ]]; then
+		return 1
+	fi
+
+	export GH_TOKEN="$token"
+	if gh auth status >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ -n "$token_was_set" ]]; then
+		export GH_TOKEN="$previous_token"
+	else
+		unset GH_TOKEN
+	fi
+	return 1
+}
+
+_approval_user_gh_token() {
+	if [[ -z "${SUDO_USER:-}" || "$(id -u)" -ne 0 ]]; then
+		return 1
+	fi
+
+	local real_uid=""
+	real_uid=$(id -u "$SUDO_USER" 2>/dev/null || true)
+	local real_home=""
+	real_home=$(_resolve_real_home)
+	local gh_home_env="HOME=${real_home}"
+	local token=""
+
+	# Linux: reconnect to the user's D-Bus session so gh can reach keyring-backed auth.
+	if [[ -n "$real_uid" && -S "/run/user/${real_uid}/bus" ]] && command -v runuser &>/dev/null; then
+		token=$(runuser -u "$SUDO_USER" -- env \
+			"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${real_uid}/bus" \
+			"XDG_RUNTIME_DIR=/run/user/${real_uid}" \
+			"$gh_home_env" \
+			gh auth token 2>/dev/null || true)
+		if [[ -n "$token" ]]; then
+			printf '%s' "$token"
+			return 0
+		fi
+	fi
+
+	# macOS: run in the invoking user's launchd session so gh can reach Keychain.
+	if [[ -n "$real_uid" ]] && command -v launchctl &>/dev/null && command -v sudo &>/dev/null; then
+		token=$(launchctl asuser "$real_uid" sudo -u "$SUDO_USER" -H env \
+			"$gh_home_env" gh auth token 2>/dev/null || true)
+		if [[ -n "$token" ]]; then
+			printf '%s' "$token"
+			return 0
+		fi
+	fi
+
+	# Portable fallback for non-keyring gh storage and sudo configurations that
+	# permit root to switch back to the invoking user without another password.
+	if command -v sudo &>/dev/null; then
+		token=$(sudo -u "$SUDO_USER" -H env "$gh_home_env" gh auth token 2>/dev/null || true)
+		if [[ -n "$token" ]]; then
+			printf '%s' "$token"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
 _require_gh_auth() {
 	if gh auth status >/dev/null 2>&1; then
 		return 0
 	fi
-	# Under sudo on Linux, gnome-keyring is inaccessible because env_reset strips
-	# DBUS_SESSION_BUS_ADDRESS. Attempt automatic token resolution via two methods
-	# before falling back to a descriptive error.
+	# Under sudo, gh may be unable to access the invoking user's keyring/keychain.
+	# Attempt automatic token recovery before falling back to a descriptive error.
 	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
-		local real_uid=""
-		real_uid=$(id -u "$SUDO_USER" 2>/dev/null || echo "")
-		# Method 1: reconnect to user's D-Bus session socket via runuser
-		if [[ -n "$real_uid" && -S "/run/user/${real_uid}/bus" ]] && command -v runuser &>/dev/null; then
-			local token=""
-			token=$(runuser -u "$SUDO_USER" -- env \
-				"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${real_uid}/bus" \
-				"XDG_RUNTIME_DIR=/run/user/${real_uid}" \
-				gh auth token 2>/dev/null || echo "")
-			if [[ -n "$token" ]]; then
-				export GH_TOKEN="$token"
-				if gh auth status >/dev/null 2>&1; then
-					return 0
-				fi
-			fi
+		local user_token=""
+		user_token=$(_approval_user_gh_token || true)
+		if _approval_use_gh_token "$user_token"; then
+			return 0
 		fi
-		# Method 2: read token directly from gh config file (non-keyring storage)
+
+		# Read token directly from gh config file for non-keyring storage.
 		local real_home
 		real_home=$(_resolve_real_home)
 		local gh_hosts="${real_home}/.config/gh/hosts.yml"
 		if [[ -f "$gh_hosts" ]]; then
 			local file_token=""
-			file_token=$(awk '/oauth_token:/{print $2; exit}' "$gh_hosts" 2>/dev/null || echo "")
-			if [[ -n "$file_token" ]]; then
-				export GH_TOKEN="$file_token"
-				if gh auth status >/dev/null 2>&1; then
-					return 0
-				fi
+			file_token=$(awk '/oauth_token:/{print $2; exit}' "$gh_hosts" 2>/dev/null || true)
+			if _approval_use_gh_token "$file_token"; then
+				return 0
 			fi
 		fi
 	fi
-	_print_error "gh authentication failed (common under sudo on Linux — gnome-keyring is inaccessible)"
-	_print_info "Workaround: export GH_TOKEN=\$(gh auth token) && sudo --preserve-env=GH_TOKEN aidevops approve ..."
+	_print_error "gh authentication failed under sudo; automatic recovery from the invoking user's gh auth failed"
+	_print_info "Check 'gh auth status' as your user, then retry sudo aidevops approve. If sudo strips auth, pass GH_TOKEN via sudo --preserve-env=GH_TOKEN."
 	return 1
 }
 

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression tests for approval-helper.sh sudo gh authentication recovery.
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+PASS=0
+FAIL=0
+LAST_OUTPUT=""
+LAST_RC=0
+
+pass() {
+	local name="$1"
+	printf '  PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf '  FAIL: %s\n' "$name"
+	if [[ -n "$detail" ]]; then
+		printf '    %s\n' "$detail"
+	fi
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected '${expected}', got '${actual}'"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing '${needle}'"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "unexpected '${needle}'"
+	fi
+	return 0
+}
+
+run_case() {
+	local name="$1"
+	local script="$2"
+	local expected_rc="$3"
+	local output=""
+	local rc=0
+
+	output=$(APPROVAL_HELPER_UNDER_TEST="$PARENT_DIR/approval-helper.sh" bash -c "$script" 2>&1) || rc=$?
+	LAST_OUTPUT="$output"
+	LAST_RC=$rc
+	assert_eq "$name rc" "$expected_rc" "$rc"
+	return 0
+}
+
+printf 'Test: approval-helper sudo gh auth recovery\n'
+printf '===========================================\n\n'
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "macOS real home resolves through dscl under sudo" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	[[ "$_APPROVAL_HOME" == "/Users/alice" ]]
+' 0
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth recovers token from invoking macOS user session" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "mac-user-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" && "${GH_TOKEN:-}" == "mac-user-token" ]]; then return 0; fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 0
+assert_not_contains "recovered token is not printed" "$LAST_OUTPUT" "mac-user-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth failure reports recovery failure without token leakage" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "bad-token"; return 0; }
+	sudo() { return 1; }
+	gh() { return 1; }
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 1
+assert_contains "auth failure explains automatic recovery" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_not_contains "failed token is not printed" "$LAST_OUTPUT" "bad-token"
+
+printf '\n===========================================\n'
+printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -19,17 +19,23 @@ BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # Paths
-# When running under sudo on Linux, env_reset rewrites HOME to /root/; SUDO_USER
-# holds the original username. getent passwd is the canonical resolver on Linux.
-# On macOS, sudo preserves HOME by default (env_keep+="HOME MAIL" in /etc/sudoers)
-# and getent is not available, so the fallback to $HOME is correct.
+# When running under sudo, env_reset may rewrite HOME to root's home; SUDO_USER
+# holds the original username. getent passwd is canonical on Linux; dscl is
+# canonical on macOS. Fall back to $HOME only when those resolvers are absent.
 # The command -v getent guard MUST be present — omitting it crashes aidevops.sh
 # under `set -euo pipefail` on any BSD system and breaks sudo aidevops approve.
 # Mirrors the pattern in .agents/scripts/approval-helper.sh:_resolve_real_home().
 # Security: no escalation — root already has full filesystem access.
 _AIDEVOPS_REAL_HOME="$HOME"
-if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
-	_tmp_real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+	_tmp_real_home=""
+	if command -v getent &>/dev/null; then
+		_tmp_real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+	elif command -v dscl &>/dev/null; then
+		_tmp_real_home=$(dscl . -read "/Users/${SUDO_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2; exit}' || true)
+	elif [[ -d "/Users/${SUDO_USER}" ]]; then
+		_tmp_real_home="/Users/${SUDO_USER}"
+	fi
 	if [[ -n "$_tmp_real_home" ]]; then
 		_AIDEVOPS_REAL_HOME="$_tmp_real_home"
 	fi


### PR DESCRIPTION
## Summary

- recover `gh` authentication for `sudo aidevops approve ...` when root cannot access the invoking user's keychain/keyring
- resolve the real sudo user home on macOS with `dscl` as well as Linux with `getent`
- add regression coverage proving token recovery succeeds without printing tokens

## Verification

- `bash .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh`
- `bash .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `bash .agents/scripts/tests/test-approval-helper-verify-state.sh && bash .agents/scripts/tests/test-approval-prompts-repo-qualified.sh && bash .agents/scripts/tests/test-approval-rest-fallback-state.sh && bash .agents/scripts/tests/test-approval-wrappers-available.sh`
- `shellcheck aidevops.sh .agents/scripts/approval-helper.sh .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh`
- `bash -n aidevops.sh .agents/scripts/approval-helper.sh .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh`
- `git diff --check`

## Security assessment

- The regression failed closed before approval signing/commenting.
- Recovered tokens are assigned only to `GH_TOKEN` for the approval process after `gh auth status` validates them.
- Tests assert recovered and rejected token values are not printed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.24 with gpt-5.5 spent 6h 28m and 416,033 tokens on this with the user in an interactive session.
