### PR TITLE
fix: rotate review-thread scanner candidates

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -500,6 +500,73 @@ _prrts_lock_dir() {
 	return 0
 }
 
+_prrts_cursor_file() {
+	local repo_slug="$1"
+	local safe_slug=""
+	safe_slug="$(_prrts_safe_slug "$repo_slug")"
+	printf '%s/%s-cursor.state\n' "$STATE_DIR" "$safe_slug"
+	return 0
+}
+
+_prrts_read_cursor() {
+	local repo_slug="$1"
+	local cursor_var="$2"
+	local cursor_file="" cursor_key="" cursor_line_value="" cursor_value=""
+	cursor_file="$(_prrts_cursor_file "$repo_slug")"
+	if [[ -f "$cursor_file" ]]; then
+		while IFS='=' read -r cursor_key cursor_line_value; do
+			case "$cursor_key" in
+			pr_number) cursor_value="$cursor_line_value" ;;
+			esac
+		done <"$cursor_file"
+	fi
+	[[ "$cursor_value" =~ ^[0-9]+$ ]] || cursor_value=""
+	printf -v "$cursor_var" '%s' "$cursor_value"
+	return 0
+}
+
+_prrts_write_cursor() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local cursor_file="" cursor_tmp=""
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
+	_prrts_ensure_dirs
+	cursor_file="$(_prrts_cursor_file "$repo_slug")"
+	cursor_tmp="${cursor_file}.$$"
+	{
+		printf 'pr_number=%s\n' "$pr_number"
+		printf 'updated_at=%s\n' "$(date +%s)"
+	} >"$cursor_tmp"
+	mv "$cursor_tmp" "$cursor_file"
+	return 0
+}
+
+_prrts_rotate_candidates_after_cursor() {
+	local candidates="$1"
+	local cursor="$2"
+	if [[ -z "$cursor" || ! "$cursor" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$candidates"
+		return 0
+	fi
+	printf '%s\n' "$candidates" | awk -F '\t' -v cursor="$cursor" '
+		{
+			rows[++count] = $0
+			if ($1 == cursor) {
+				cursor_index = count
+			}
+		}
+		END {
+			if (cursor_index > 0 && cursor_index < count) {
+				for (i = cursor_index + 1; i <= count; i++) print rows[i]
+				for (i = 1; i <= cursor_index; i++) print rows[i]
+			} else {
+				for (i = 1; i <= count; i++) print rows[i]
+			}
+		}
+	'
+	return 0
+}
+
 _prrts_write_lock_metadata() {
 	local lock_dir="$1"
 	local now_epoch="$2"
@@ -793,6 +860,7 @@ _prrts_dispatch_repo() {
 	local pr_number="" thread_count="" fingerprint="" title="" head_ref="" author="" preview=""
 	local checked_count=0 fetch_error_count=0 graphql_exhausted_count=0 list_failed=0
 	local status_key="" status_value=""
+	local cursor="" last_considered=""
 
 	if [[ -z "$repo_path" || ! -d "${repo_path/#\~/$HOME}" ]]; then
 		_prrts_log "dispatch: ${repo_slug} skipped — repo path missing or not a directory (${repo_path})"
@@ -834,13 +902,27 @@ _prrts_dispatch_repo() {
 	}
 	now_epoch="$(date +%s)"
 	max_per_repo="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO" "2" "1")"
+	_prrts_read_cursor "$repo_slug" cursor
+	candidates="$(_prrts_rotate_candidates_after_cursor "$candidates" "$cursor")"
+	if [[ -n "$cursor" ]]; then
+		_prrts_log "dispatch: ${repo_slug} rotated candidates after cursor PR #${cursor}"
+	fi
 	while IFS=$'\t' read -r pr_number thread_count fingerprint title head_ref author preview; do
 		[[ -n "$pr_number" ]] || continue
-		[[ "$dispatched" -lt "$max_per_repo" ]] || break
+		last_considered="$pr_number"
 		if _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$now_epoch" "$dry_run" "dispatch" "$head_ref" "$author"; then
 			dispatched=$((dispatched + 1))
 		fi
+		[[ "$dispatched" -lt "$max_per_repo" ]] || break
 	done <<<"$candidates"
+	if [[ -n "$last_considered" ]]; then
+		if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
+			_prrts_log "dry-run: would update ${repo_slug} dispatch cursor to PR #${last_considered}"
+		else
+			_prrts_write_cursor "$repo_slug" "$last_considered"
+			_prrts_log "dispatch: ${repo_slug} updated cursor to PR #${last_considered}"
+		fi
+	fi
 	_prrts_log "dispatch: ${repo_slug} completed, dispatched=${dispatched}, dry_run=${dry_run}"
 	return 0
 }

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -386,6 +386,67 @@ test_dispatch_reports_fetch_errors_when_scan_blind() {
 	return 0
 }
 
+test_dispatch_rotates_candidates_with_repo_cursor() {
+	setup_test_env
+	export PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO=2
+	export STUB_PR_LIST=$'1	One	false	origin:worker	feature/one	worker-bot
+2	Two	false	origin:worker	feature/two	worker-bot
+3	Three	false	origin:worker	feature/three	worker-bot
+4	Four	false	origin:worker	feature/four	worker-bot
+5	Five	false	origin:worker	feature/five	worker-bot'
+	local state_dir="$AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR"
+	local cursor_file="${state_dir}/owner-repo-cursor.state"
+
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local first_window=""
+	first_window="$(for pr_number in 1 2 3 4 5; do if [[ -f "${state_dir}/owner-repo-${pr_number}.state" ]]; then printf '%s' "$pr_number"; fi; done)"
+	rm -f "${state_dir}"/owner-repo-[0-9]*.state
+
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local second_window=""
+	second_window="$(for pr_number in 1 2 3 4 5; do if [[ -f "${state_dir}/owner-repo-${pr_number}.state" ]]; then printf '%s' "$pr_number"; fi; done)"
+	rm -f "${state_dir}"/owner-repo-[0-9]*.state
+
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local third_window=""
+	third_window="$(for pr_number in 1 2 3 4 5; do if [[ -f "${state_dir}/owner-repo-${pr_number}.state" ]]; then printf '%s' "$pr_number"; fi; done)"
+	local cursor_value=""
+	cursor_value="$(grep '^pr_number=' "$cursor_file" 2>/dev/null || true)"
+
+	if [[ "$first_window" == "12" && "$second_window" == "34" && "$third_window" == "15" && "$cursor_value" == "pr_number=1" ]]; then
+		print_result "dispatch rotates candidate windows with repo cursor" 0
+	else
+		print_result "dispatch rotates candidate windows with repo cursor" 1 "first=${first_window}, second=${second_window}, third=${third_window}, cursor=${cursor_value}, log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_stale_cursor_falls_back_to_original_order() {
+	setup_test_env
+	export PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO=2
+	export STUB_PR_LIST=$'1	One	false	origin:worker	feature/one	worker-bot
+2	Two	false	origin:worker	feature/two	worker-bot
+3	Three	false	origin:worker	feature/three	worker-bot'
+	local state_dir="$AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR"
+	local cursor_file="${state_dir}/owner-repo-cursor.state"
+	printf 'pr_number=999\n' >"$cursor_file"
+
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local dispatched_window=""
+	dispatched_window="$(for pr_number in 1 2 3; do if [[ -f "${state_dir}/owner-repo-${pr_number}.state" ]]; then printf '%s' "$pr_number"; fi; done)"
+	local cursor_value=""
+	cursor_value="$(grep '^pr_number=' "$cursor_file" 2>/dev/null || true)"
+
+	if [[ "$dispatched_window" == "12" && "$cursor_value" == "pr_number=2" ]]; then
+		print_result "dispatch stale cursor falls back to original order" 0
+	else
+		print_result "dispatch stale cursor falls back to original order" 1 "window=${dispatched_window}, cursor=${cursor_value}"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_reply_and_resolve_use_graphql_mutations() {
 	setup_test_env
 	local body_file="${TEST_ROOT}/reply.md"
@@ -502,6 +563,8 @@ main() {
 	test_dispatch_pr_reclaims_stale_lock
 	test_dispatch_reports_graphql_budget_exhaustion_when_scan_blind
 	test_dispatch_reports_fetch_errors_when_scan_blind
+	test_dispatch_rotates_candidates_with_repo_cursor
+	test_dispatch_stale_cursor_falls_back_to_original_order
 	test_reply_and_resolve_use_graphql_mutations
 	test_reply_auto_prepends_thread_author
 	test_reply_does_not_double_prepend_thread_author


### PR DESCRIPTION
## Summary

- add a per-repo dispatch cursor for `pr-review-thread-response-scanner.sh`
- rotate candidate rows after the last considered PR while preserving the current `gh pr list` order
- advance the cursor on considered rows, not only successful launches, so skipped/cooldown PRs do not pin the scanner at the front
- keep dry-run non-destructive and log the cursor that would be written

Resolves #25800

## Verification

- `bash .agents/scripts/tests/test-pr-review-thread-response-scanner.sh`
- `shellcheck .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh`
- `bash -n .agents/scripts/pr-review-thread-response-scanner.sh .agents/scripts/tests/test-pr-review-thread-response-scanner.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh` progressed through changed-file blocking gates including S1192, Secretlint, ShellCheck RC parity, pulse canary, and Bash 3.2 compatibility; it timed out later in broad shell portability after advisory-only existing repository warnings

## Notes

- Cursor state is stored in the existing scanner state directory using the existing safe slug pattern.
- Tests cover five eligible PRs with `max_per_repo=2`, successive rotated windows, wraparound, and stale/missing cursor fallback.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.24 with gpt-5.5 spent 6h 51m and 485,360 tokens on this with the user in an interactive session.
