### PR TITLE
docs: require completion summary bullets

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -50,6 +50,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Never present intent as completed work. Every claim needs proof: path, command result, PR/issue number, or metric.
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.
 - Before declaring completion, scan conversation for unfulfilled commitments, unnotified external parties, and displaced requests.
+- Completed-session messages must include a concise bullet list of the changes/fixes implemented in this session for review.
 - Memory recall is mandatory before non-trivial edits, debugging, PR review, git side effects, or design decisions: CLI `memory-helper.sh recall --query "<task keywords>" --limit 5`; OpenCode tool `aidevops_memory` with `{action:"recall", query:"<task keywords>", limit:"5"}`. Store only concrete reusable lessons: `{action:"store", content:"<lesson with evidence>", confidence:"medium"}`. Empty `aidevops_memory` calls are invalid; never use them as placeholders.
 - Before non-trivial code changes, run one duplicate/collision check: `prework-discovery-helper.sh --keywords "<task>" --files "<targets>" [--repo owner/repo]`.
 - Before changing third-party API/error-code mappings, verify the installed dependency version and local exported symbols first; brief authors include this checklist via `templates/brief-template.md`.


### PR DESCRIPTION
## Summary
- Require completed-session messages to include a concise bullet list of changes/fixes implemented in the session for review.
- Place the rule beside existing completion-discipline guidance in `.agents/AGENTS.md`.

## Testing
- `.agents/scripts/linters-local.sh`

## Runtime Testing
- self-assessed: prompt/documentation guidance only; no runtime behaviour changed.

Resolves #25838

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.27 with gpt-5.5 spent 29m and 216,700 tokens on this with the user in an interactive session.
