### PR TITLE
t18029: scope session checkpoints by repo

### DIFF
--- a/.agents/plugins/opencode-aidevops/compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/compaction.mjs
@@ -5,6 +5,7 @@
 
 import { existsSync, readFileSync } from "fs";
 import { execSync } from "child_process";
+import { createHash } from "crypto";
 import { join } from "path";
 
 /**
@@ -143,16 +144,44 @@ function getGitContext(directory) {
 }
 
 /**
- * Get session checkpoint state if it exists.
- * @param {string} workspaceDir
+ * Resolve the git repository root for a directory.
+ * @param {string} directory
  * @returns {string}
  */
-function getCheckpointState(workspaceDir) {
-  const checkpointFile = join(
-    workspaceDir,
-    "tmp",
-    "session-checkpoint.md",
-  );
+function getGitRoot(directory) {
+  return run(`git -C "${directory}" rev-parse --show-toplevel 2>/dev/null`);
+}
+
+/**
+ * Return the repo-scoped checkpoint path for the active directory.
+ *
+ * Checkpoints used to be a singleton under tmp/session-checkpoint.md. That
+ * allowed a compaction in one repository to replay the previous repository's
+ * operational state. Use a hash of the local git root instead so filenames do
+ * not disclose private repo names and foreign checkpoints are not considered.
+ *
+ * @param {string} workspaceDir
+ * @param {string} directory
+ * @returns {string}
+ */
+function getScopedCheckpointPath(workspaceDir, directory) {
+  const gitRoot = getGitRoot(directory);
+  if (!gitRoot) return "";
+
+  const key = createHash("sha256").update(gitRoot).digest("hex").slice(0, 16);
+  return join(workspaceDir, "tmp", "session-checkpoints", `repo-${key}.md`);
+}
+
+/**
+ * Get session checkpoint state if it exists.
+ * @param {string} workspaceDir
+ * @param {string} directory - Current working directory
+ * @returns {string}
+ */
+function getCheckpointState(workspaceDir, directory) {
+  const checkpointFile = getScopedCheckpointPath(workspaceDir, directory);
+  if (!checkpointFile) return "";
+
   const content = readIfExists(checkpointFile);
   if (!content) return "";
 
@@ -196,7 +225,7 @@ export async function compactingHook(deps, _input, output, directory) {
   const sections = [
     getAgentState(workspaceDir),
     getLoopGuardrails(directory),
-    getCheckpointState(workspaceDir),
+    getCheckpointState(workspaceDir, directory),
     getRelevantMemories(scriptsDir, directory),
     getGitContext(directory),
     getMailboxState(scriptsDir),

--- a/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage: compaction checkpoints must be scoped to the active
+// repository. A legacy global checkpoint, or a scoped checkpoint for a sibling
+// repository, must not be injected into the current session summary.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function initRepo(repoDir) {
+  mkdirSync(repoDir, { recursive: true });
+  execFileSync("git", ["init", "-q"], { cwd: repoDir });
+  return repoDir;
+}
+
+function scopedCheckpointPath(workspaceDir, repoDir) {
+  const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  }).trim();
+  const key = createHash("sha256").update(root).digest("hex").slice(0, 16);
+  return resolve(workspaceDir, "tmp", "session-checkpoints", `repo-${key}.md`);
+}
+
+test("compaction injects only the active repository checkpoint", async () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "aidevops-compaction-scope-"));
+
+  try {
+    const workspaceDir = resolve(tempDir, "workspace");
+    const scriptsDir = resolve(tempDir, "scripts");
+    const targetRepo = initRepo(resolve(tempDir, "target-repo"));
+    const otherRepo = initRepo(resolve(tempDir, "other-repo"));
+
+    mkdirSync(resolve(workspaceDir, "tmp", "session-checkpoints"), { recursive: true });
+    mkdirSync(scriptsDir, { recursive: true });
+
+    writeFileSync(
+      resolve(workspaceDir, "tmp", "session-checkpoint.md"),
+      "UNRELATED_LEGACY_CHECKPOINT_STATE\n",
+      "utf8",
+    );
+    writeFileSync(
+      scopedCheckpointPath(workspaceDir, otherRepo),
+      "UNRELATED_SIBLING_CHECKPOINT_STATE\n",
+      "utf8",
+    );
+    writeFileSync(
+      scopedCheckpointPath(workspaceDir, targetRepo),
+      "TARGET_REPO_CHECKPOINT_STATE\n",
+      "utf8",
+    );
+
+    const { compactingHook } = await import(resolve(__dirname, "..", "compaction.mjs"));
+    const output = { context: [] };
+
+    await compactingHook({ workspaceDir, scriptsDir }, { sessionID: "test" }, output, targetRepo);
+
+    const payload = output.context.join("\n");
+    assert.match(payload, /TARGET_REPO_CHECKPOINT_STATE/);
+    assert.doesNotMatch(payload, /UNRELATED_LEGACY_CHECKPOINT_STATE/);
+    assert.doesNotMatch(payload, /UNRELATED_SIBLING_CHECKPOINT_STATE/);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -26,8 +26,11 @@
 #   --elapsed <mins>  Minutes elapsed in session
 #   --target <mins>   Target session duration in minutes
 #
-# The checkpoint file is written to:
-#   ~/.aidevops/.agent-workspace/tmp/session-checkpoint.md
+# Checkpoints are repo-scoped and written to:
+#   ~/.aidevops/.agent-workspace/tmp/session-checkpoints/repo-<hash>.md
+# Legacy singleton checkpoints at tmp/session-checkpoint.md are ignored by
+# load/continuation paths so one repository cannot replay another repository's
+# operational state during compaction.
 #
 # Design: AI agent writes checkpoint after each task completion and reads it
 # before starting the next task. Survives context compaction because state
@@ -39,13 +42,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly CHECKPOINT_DIR="${HOME}/.aidevops/.agent-workspace/tmp"
-readonly CHECKPOINT_FILE="${CHECKPOINT_DIR}/session-checkpoint.md"
+readonly CHECKPOINT_SCOPED_DIR="${CHECKPOINT_DIR}/session-checkpoints"
+readonly LEGACY_CHECKPOINT_FILE="${CHECKPOINT_DIR}/session-checkpoint.md"
 
 [[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Credential patterns to redact from checkpoint content.
 # Focused on secrets (API keys, tokens, passwords, connection strings).
-# Does NOT include emails/IPs/home paths — those are fine in checkpoints.
+# Does NOT include emails/IPs/home paths; repo-scoped checkpoint isolation is
+# the privacy boundary that prevents cross-project replay of those details.
 # Patterns sourced from privacy-filter-helper.sh DEFAULT_PATTERNS (credential subset).
 #
 # Note on false positives: sk-/pk- prefixes with 20+ alphanumeric chars may match
@@ -107,10 +112,12 @@ readonly -a CREDENTIAL_PATTERNS=(
 # CREDENTIAL_PATTERNS contain metacharacters and URL slashes that conflict
 # with any fixed sed delimiter (/, #, etc.).
 # Arguments:
-#   $1 - file path to sanitize (defaults to CHECKPOINT_FILE)
+#   $1 - file path to sanitize (defaults to current repo-scoped checkpoint)
 # Returns: 0 always (redaction failure is non-fatal)
 sanitize_checkpoint() {
-	local target_file="${1:-$CHECKPOINT_FILE}"
+	local default_file=""
+	default_file="$(checkpoint_file_for_current_scope)"
+	local target_file="${1:-$default_file}"
 
 	if [[ ! -f "$target_file" ]]; then
 		return 0
@@ -155,6 +162,51 @@ ensure_dir() {
 	if [[ ! -d "$CHECKPOINT_DIR" ]]; then
 		mkdir -p "$CHECKPOINT_DIR"
 	fi
+	if [[ ! -d "$CHECKPOINT_SCOPED_DIR" ]]; then
+		mkdir -p "$CHECKPOINT_SCOPED_DIR"
+	fi
+	return 0
+}
+
+# Resolve the repository scope used for checkpoint isolation.
+# Returns the git root when available, otherwise the physical current directory.
+checkpoint_scope_root() {
+	local root=""
+	root="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P 2>/dev/null || printf '%s' "$PWD")"
+	printf '%s\n' "$root"
+	return 0
+}
+
+# Derive a stable, non-disclosing filename key from a repository scope.
+checkpoint_scope_key() {
+	local scope_root="$1"
+	local digest=""
+	digest="$(printf '%s' "$scope_root" | shasum -a 256 | cut -d ' ' -f 1)"
+	printf '%s\n' "${digest:0:16}"
+	return 0
+}
+
+# Return the checkpoint file for the current repository scope.
+checkpoint_file_for_current_scope() {
+	local scope_root=""
+	local scope_key=""
+	scope_root="$(checkpoint_scope_root)"
+	scope_key="$(checkpoint_scope_key "$scope_root")"
+	printf '%s/repo-%s.md\n' "$CHECKPOINT_SCOPED_DIR" "$scope_key"
+	return 0
+}
+
+# Return a single-line git branch label without leaking stderr from unborn repos.
+current_branch_label() {
+	local branch=""
+	branch="$(git branch --show-current 2>/dev/null || true)"
+	if [[ -z "$branch" ]]; then
+		branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+	fi
+	if [[ -z "$branch" ]]; then
+		branch="unknown"
+	fi
+	printf '%s\n' "$branch"
 	return 0
 }
 
@@ -248,9 +300,11 @@ _parse_save_args() {
 # Write the checkpoint markdown file using current _save_* variables.
 # Expects _save_branch and _save_timestamp to be set by caller.
 # Arguments:
-#   $1 - output file path (defaults to CHECKPOINT_FILE)
+#   $1 - output file path (defaults to current repo-scoped checkpoint)
 _write_checkpoint_file() {
-	local output_file="${1:-$CHECKPOINT_FILE}"
+	local default_file=""
+	default_file="$(checkpoint_file_for_current_scope)"
+	local output_file="${1:-$default_file}"
 	cat >"$output_file" <<EOF
 # Session Checkpoint
 
@@ -261,6 +315,7 @@ Updated: ${_save_timestamp}
 | Field | Value |
 |-------|-------|
 | Current Task | ${_save_task:-none} |
+| Repository Scope | ${_save_repo_scope:-unknown} |
 | Branch | ${_save_branch} |
 | Worktree | ${_save_worktree:-not set} |
 | Batch/PR | ${_save_batch:-not set} |
@@ -296,10 +351,13 @@ cmd_save() {
 	ensure_dir
 
 	_save_timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	_save_repo_scope="$(checkpoint_scope_root)"
+	local checkpoint_file=""
+	checkpoint_file="$(checkpoint_file_for_current_scope)"
 
 	# Auto-detect git state if not provided
 	if [[ -z "$_save_branch" ]]; then
-		_save_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+		_save_branch="$(current_branch_label)"
 	fi
 
 	# Atomic write: write to temp file, sanitize, then mv to final location.
@@ -316,36 +374,48 @@ cmd_save() {
 	# Write checkpoint to temp file, sanitize it, then atomically move
 	_write_checkpoint_file "$temp_file"
 	sanitize_checkpoint "$temp_file"
-	if ! mv "$temp_file" "$CHECKPOINT_FILE"; then
+	if ! mv "$temp_file" "$checkpoint_file"; then
 		rm -f "$temp_file"
-		print_error "Failed to write checkpoint to ${CHECKPOINT_FILE}"
+		print_error "Failed to write checkpoint to ${checkpoint_file}"
 		return 1
 	fi
 
-	print_success "Checkpoint saved: ${CHECKPOINT_FILE}"
+	print_success "Checkpoint saved: ${checkpoint_file}"
 	print_info "Task: ${_save_task:-none} | Branch: ${_save_branch} | ${_save_timestamp}"
 	return 0
 }
 
 cmd_load() {
-	if [[ ! -f "$CHECKPOINT_FILE" ]]; then
-		print_warning "No checkpoint found at ${CHECKPOINT_FILE}"
+	local checkpoint_file=""
+	checkpoint_file="$(checkpoint_file_for_current_scope)"
+
+	if [[ ! -f "$checkpoint_file" ]]; then
+		print_warning "No checkpoint found at ${checkpoint_file}"
+		if [[ -f "$LEGACY_CHECKPOINT_FILE" ]]; then
+			print_warning "Legacy global checkpoint ignored for repo privacy isolation"
+		fi
 		print_info "Run: session-checkpoint-helper.sh save --task <id> --next <ids>"
 		return 1
 	fi
 
-	cat "$CHECKPOINT_FILE"
+	cat "$checkpoint_file"
 
 	# Auto-recall relevant memories after loading checkpoint
 	local memory_helper="${SCRIPT_DIR}/memory-helper.sh"
 	if [[ -x "$memory_helper" ]]; then
 		echo ""
-		echo "## Relevant Memories (from prior sessions)"
+		echo "## Relevant Memories (repo-scoped)"
 		echo ""
 
-		# Recall recent memories to provide context for resumed session
+		# Recall only memories attached to the current repository scope. Global
+		# --recent recall can replay unrelated private project details in a public
+		# repo session.
+		local repo_scope=""
+		local repo_name=""
 		local memories
-		memories=$("$memory_helper" recall --recent --limit 5 --format text 2>/dev/null || echo "")
+		repo_scope="$(checkpoint_scope_root)"
+		repo_name="$(basename "$repo_scope")"
+		memories=$("$memory_helper" recall --query "$repo_name" --project "$repo_scope" --limit 5 --format text 2>/dev/null || echo "")
 
 		if [[ -n "$memories" && "$memories" != *"No memories found"* ]]; then
 			echo "$memories"
@@ -358,8 +428,11 @@ cmd_load() {
 }
 
 cmd_clear() {
-	if [[ -f "$CHECKPOINT_FILE" ]]; then
-		rm "$CHECKPOINT_FILE"
+	local checkpoint_file=""
+	checkpoint_file="$(checkpoint_file_for_current_scope)"
+
+	if [[ -f "$checkpoint_file" ]]; then
+		rm "$checkpoint_file"
 		print_success "Checkpoint cleared"
 	else
 		print_info "No checkpoint to clear"
@@ -368,7 +441,10 @@ cmd_clear() {
 }
 
 cmd_status() {
-	if [[ ! -f "$CHECKPOINT_FILE" ]]; then
+	local checkpoint_file=""
+	checkpoint_file="$(checkpoint_file_for_current_scope)"
+
+	if [[ ! -f "$checkpoint_file" ]]; then
 		print_warning "No active checkpoint"
 		return 1
 	fi
@@ -378,7 +454,7 @@ cmd_status() {
 	local file_mtime
 
 	now="$(date +%s)"
-	file_mtime="$(_file_mtime_epoch "$CHECKPOINT_FILE")"
+	file_mtime="$(_file_mtime_epoch "$checkpoint_file")"
 	file_age_seconds=$((now - file_mtime))
 
 	local age_display
@@ -392,15 +468,15 @@ cmd_status() {
 
 	# Extract key fields
 	local current_task
-	current_task="$(awk -F'|' '/Current Task/ {gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3; exit}' "$CHECKPOINT_FILE" || echo "unknown")"
+	current_task="$(awk -F'|' '/Current Task/ {gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3; exit}' "$checkpoint_file" || echo "unknown")"
 	local branch
-	branch="$(awk -F'|' '/Branch/ {gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3; exit}' "$CHECKPOINT_FILE" || echo "unknown")"
+	branch="$(awk -F'|' '/Branch/ {gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3; exit}' "$checkpoint_file" || echo "unknown")"
 
 	printf '%b\n' "${BOLD}Checkpoint Status${NC}"
 	printf "  Age:    %s\n" "$age_display"
 	printf "  Task:   %s\n" "$current_task"
 	printf "  Branch: %s\n" "$branch"
-	printf "  File:   %s\n" "$CHECKPOINT_FILE"
+	printf "  File:   %s\n" "$checkpoint_file"
 
 	if [[ $file_age_seconds -gt 1800 ]]; then
 		print_warning "  Warning: Checkpoint is stale (>30min). Consider updating."
@@ -412,8 +488,9 @@ cmd_status() {
 # Sets module-scoped _cont_* variables for use by cmd_continuation().
 _gather_continuation_state() {
 	_cont_repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")"
-	_cont_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+	_cont_branch="$(current_branch_label)"
 	_cont_repo_name="$(basename "$_cont_repo_root")"
+	_cont_checkpoint_file="$(checkpoint_file_for_current_scope)"
 
 	# Git state
 	_cont_uncommitted="$(git status --short 2>/dev/null || echo "")"
@@ -442,15 +519,22 @@ _gather_continuation_state() {
 
 	# Checkpoint note
 	_cont_checkpoint_note="none"
-	if [[ -f "$CHECKPOINT_FILE" ]]; then
-		_cont_checkpoint_note="$(awk '/^## Context Note$/,/^## /' "$CHECKPOINT_FILE" | sed '1d;/^## /d' | sed '/^$/d' || echo "none")"
+	if [[ -f "$_cont_checkpoint_file" ]]; then
+		_cont_checkpoint_note="$(awk '
+			/^## Context Note$/ { capture = 1; next }
+			capture && /^## / { exit }
+			capture && NF { print }
+		' "$_cont_checkpoint_file" || echo "")"
+		if [[ -z "$_cont_checkpoint_note" ]]; then
+			_cont_checkpoint_note="none"
+		fi
 	fi
 
 	# Memory recall
 	_cont_recent_memories="none"
 	local memory_helper="${SCRIPT_DIR}/memory-helper.sh"
 	if [[ -x "$memory_helper" ]]; then
-		_cont_recent_memories="$(bash "$memory_helper" recall --recent --limit 3 2>/dev/null || echo "none")"
+		_cont_recent_memories="$(bash "$memory_helper" recall --query "$_cont_repo_name" --project "$_cont_repo_root" --limit 3 2>/dev/null || echo "none")"
 	fi
 
 	return 0
@@ -505,7 +589,7 @@ ${_cont_worktrees}
 **Last checkpoint note**:
 ${_cont_checkpoint_note}
 
-**Recent memories**:
+**Repo-scoped memories**:
 ${_cont_recent_memories}
 
 ### Instructions

--- a/.agents/scripts/tests/test-session-checkpoint-repo-scope.sh
+++ b/.agents/scripts/tests/test-session-checkpoint-repo-scope.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+HELPER="${REPO_ROOT}/.agents/scripts/session-checkpoint-helper.sh"
+
+fail() {
+	local message="$1"
+	printf '%s\n' "$message" >&2
+	exit 1
+}
+
+assert_contains() {
+	local label="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		fail "${label}: expected to find ${needle}"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local label="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		fail "${label}: unexpected ${needle}"
+	fi
+	return 0
+}
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+export HOME="${tmp_root}/home"
+mkdir -p "$HOME"
+
+tmp_bin="${tmp_root}/bin"
+mkdir -p "$tmp_bin"
+cat >"${tmp_bin}/gh" <<'GH'
+#!/usr/bin/env bash
+exit 0
+GH
+chmod +x "${tmp_bin}/gh"
+export PATH="${tmp_bin}:${PATH}"
+
+repo_one="${tmp_root}/repo-one"
+repo_two="${tmp_root}/repo-two"
+repo_three="${tmp_root}/repo-three"
+mkdir -p "$repo_one" "$repo_two" "$repo_three"
+git -C "$repo_one" init -q
+git -C "$repo_two" init -q
+git -C "$repo_three" init -q
+
+save_one_output="$(cd "$repo_one" && "$HELPER" save --task t1 --note "TARGET_REPO_SCOPED_NOTE" 2>&1)"
+assert_contains "repo one save path" "$save_one_output" "session-checkpoints/repo-"
+
+load_one_output="$(cd "$repo_one" && "$HELPER" load 2>&1)"
+assert_contains "repo one load" "$load_one_output" "TARGET_REPO_SCOPED_NOTE"
+
+set +e
+load_two_output="$(cd "$repo_two" && "$HELPER" load 2>&1)"
+load_two_rc=$?
+set -e
+if [[ "$load_two_rc" -eq 0 ]]; then
+	fail "repo two unexpectedly loaded repo one checkpoint"
+fi
+assert_not_contains "repo two load" "$load_two_output" "TARGET_REPO_SCOPED_NOTE"
+
+(cd "$repo_two" && "$HELPER" save --task t2 --note "SIBLING_REPO_SCOPED_NOTE" >/dev/null)
+load_one_again="$(cd "$repo_one" && "$HELPER" load 2>&1)"
+assert_contains "repo one reload" "$load_one_again" "TARGET_REPO_SCOPED_NOTE"
+assert_not_contains "repo one reload" "$load_one_again" "SIBLING_REPO_SCOPED_NOTE"
+
+continuation_one="$(cd "$repo_one" && "$HELPER" continuation 2>&1)"
+assert_contains "repo one continuation" "$continuation_one" "TARGET_REPO_SCOPED_NOTE"
+assert_contains "repo one continuation memory label" "$continuation_one" "Repo-scoped memories"
+assert_not_contains "repo one continuation" "$continuation_one" "SIBLING_REPO_SCOPED_NOTE"
+
+mkdir -p "$HOME/.aidevops/.agent-workspace/tmp"
+printf '%s\n' "LEGACY_UNRELATED_CHECKPOINT_STATE" >"$HOME/.aidevops/.agent-workspace/tmp/session-checkpoint.md"
+
+set +e
+load_three_output="$(cd "$repo_three" && "$HELPER" load 2>&1)"
+load_three_rc=$?
+set -e
+if [[ "$load_three_rc" -eq 0 ]]; then
+	fail "repo three unexpectedly loaded legacy global checkpoint"
+fi
+assert_contains "repo three legacy warning" "$load_three_output" "Legacy global checkpoint ignored"
+assert_not_contains "repo three load" "$load_three_output" "LEGACY_UNRELATED_CHECKPOINT_STATE"
+
+continuation_three="$(cd "$repo_three" && "$HELPER" continuation 2>&1)"
+assert_not_contains "repo three continuation" "$continuation_three" "LEGACY_UNRELATED_CHECKPOINT_STATE"
+assert_not_contains "repo three continuation" "$continuation_three" "TARGET_REPO_SCOPED_NOTE"
+assert_not_contains "repo three continuation" "$continuation_three" "SIBLING_REPO_SCOPED_NOTE"
+
+printf 'session-checkpoint repo scope test passed\n'

--- a/TODO.md
+++ b/TODO.md
@@ -1045,6 +1045,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18027 Polish GUI app interactions and contrast controls #bug ref:GH#25822 pr:#25823 completed:2026-06-28
 
+- [ ] t18029 Scope session checkpoints to active repository #type:bug ref:GH#25835
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

- Scope OpenCode compaction checkpoint reads to the active repository root using a non-disclosing hash-derived checkpoint filename.
- Move `session-checkpoint-helper.sh` save/load/status/clear/continuation to repo-scoped checkpoint files.
- Scope continuation memory recall to the active repository and ignore the legacy singleton checkpoint for continuation paths.
- Add regression tests for legacy singleton and sibling-repository checkpoint isolation.

Resolves #25835

## Privacy notes

This PR intentionally describes the issue generically as unrelated repository state. It does not include private repository names, private paths, or private project details.

## Verification

```bash
shellcheck .agents/scripts/session-checkpoint-helper.sh .agents/scripts/tests/test-session-checkpoint-repo-scope.sh
bash -n .agents/scripts/session-checkpoint-helper.sh .agents/scripts/tests/test-session-checkpoint-repo-scope.sh
.agents/scripts/tests/test-session-checkpoint-repo-scope.sh
node --test .agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
(cd .agents/plugins/opencode-aidevops && npm test)
git diff --check
```

Additional checks:

```bash
git grep -Ili '<private-project-marker>' -- .
# expected: 0 tracked matches
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.27 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
