### PR TITLE
fix: share pulse start epoch bootstrap

### DIFF
--- a/.agents/scripts/complexity-scan-runner.sh
+++ b/.agents/scripts/complexity-scan-runner.sh
@@ -74,6 +74,13 @@ fi
 source "${SCRIPT_DIR}/pulse-wrapper-config.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-repo-meta.sh"
+
+# Standalone launchd/cron runs do not enter through pulse-wrapper.sh, but the
+# simplification issue builders use PULSE_START_EPOCH for signature footers.
+# Centralise the bootstrap with pulse-merge-routine.sh so new standalone pulse
+# runners do not need to duplicate the same set-u guard.
+aidevops_ensure_pulse_start_epoch
+
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-simplification.sh"
 # shellcheck source=/dev/null

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -133,16 +133,10 @@ source "${SCRIPT_DIR}/pulse-merge-stuck.sh"
 # safe default here so standalone invocation doesn't hit an unbound variable.
 PULSE_MERGE_BATCH_LIMIT="${PULSE_MERGE_BATCH_LIMIT:-50}"
 
-# PULSE_START_EPOCH is normally set by pulse-wrapper.sh:180 (the canonical
-# bootstrap path). It's referenced by pulse-merge.sh:326 inside
-# _handle_post_merge_actions and by pulse-simplification-*.sh. Under
-# `set -euo pipefail` (line 42 of this file), an unset reference is a hard
-# fail — every launchd invocation would crash before doing anything useful
-# (t3036, GH#21616). Initialise to current epoch so elapsed-time math works
-# even when no pulse cycle preceded this invocation. Export so subprocesses
-# (gh-signature-helper.sh, etc.) inherit the value consistently.
-PULSE_START_EPOCH="${PULSE_START_EPOCH:-$(date +%s)}"
-export PULSE_START_EPOCH
+# PULSE_START_EPOCH is normally set by pulse-wrapper.sh. Shared bootstrap keeps
+# standalone runners safe under `set -u` and exports the value for helpers that
+# append GitHub signature footers (t3036/GH#21616, complexity runner parity).
+aidevops_ensure_pulse_start_epoch
 
 # STOP_FLAG / REPOS_JSON: normally set by pulse-wrapper-config.sh; the
 # ${VAR:-default} guards below are defence-in-depth for edge-case sourcing

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -101,6 +101,25 @@ if [[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]]; then
 	unset AIDEVOPS_BASH_REEXECED
 fi
 
+# Ensure standalone pulse-adjacent runners have the elapsed-time baseline that
+# pulse-wrapper.sh normally exports. Helpers that create GitHub comments/issues
+# use PULSE_START_EPOCH for signature footers; launchd/cron runners that source
+# pulse libraries directly need the same safe default under `set -u`.
+aidevops_ensure_pulse_start_epoch() {
+	local fallback_epoch=""
+
+	if [[ "${PULSE_START_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+		export PULSE_START_EPOCH
+		return 0
+	fi
+
+	fallback_epoch=$(date +%s 2>/dev/null || printf '0')
+	[[ "$fallback_epoch" =~ ^[0-9]+$ ]] || fallback_epoch=0
+	PULSE_START_EPOCH="$fallback_epoch"
+	export PULSE_START_EPOCH
+	return 0
+}
+
 # =============================================================================
 # Tool Version Pins
 # =============================================================================

--- a/.agents/scripts/tests/test-complexity-scan-runner-standalone.sh
+++ b/.agents/scripts/tests/test-complexity-scan-runner-standalone.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-complexity-scan-runner-standalone.sh — standalone runner bootstrap guard.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+RUNNER_FILE="${SCRIPTS_DIR}/complexity-scan-runner.sh"
+SHARED_CONSTANTS_FILE="${SCRIPTS_DIR}/shared-constants.sh"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$name"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	return 0
+}
+
+if [[ ! -f "$RUNNER_FILE" ]]; then
+	printf '%sFATAL%s complexity-scan-runner.sh not found at %s\n' \
+		"$TEST_RED" "$TEST_NC" "$RUNNER_FILE"
+	exit 1
+fi
+
+printf '%sRunning complexity-scan-runner standalone tests%s\n' \
+	"$TEST_GREEN" "$TEST_NC"
+
+unset PULSE_START_EPOCH
+
+test_home=""
+test_home=$(mktemp -d)
+
+help_stderr=$(HOME="$test_home" LC_ALL=C timeout 30 "$RUNNER_FILE" help 2>&1 >/dev/null) || true
+help_exit=$(HOME="$test_home" LC_ALL=C timeout 30 "$RUNNER_FILE" help >/dev/null 2>&1; printf '%s' "$?")
+
+if [[ "$help_exit" == "0" ]]; then
+	pass "1: help exits 0 with PULSE_START_EPOCH unset"
+else
+	fail "1: help exits 0 with PULSE_START_EPOCH unset" \
+		"exit=$help_exit, stderr=$help_stderr"
+fi
+
+if printf '%s\n' "$help_stderr" | grep -q 'unbound variable'; then
+	fail "2: no unbound variable during standalone bootstrap" \
+		"stderr=$help_stderr"
+else
+	pass "2: no unbound variable during standalone bootstrap"
+fi
+
+if grep -qE '^aidevops_ensure_pulse_start_epoch\(\) \{' "$SHARED_CONSTANTS_FILE"; then
+	pass "3: shared PULSE_START_EPOCH bootstrap helper exists"
+else
+	fail "3: shared PULSE_START_EPOCH bootstrap helper exists" \
+		"missing aidevops_ensure_pulse_start_epoch definition"
+fi
+
+if grep -qE '^aidevops_ensure_pulse_start_epoch$' "$RUNNER_FILE"; then
+	pass "4: complexity runner calls shared PULSE_START_EPOCH bootstrap"
+else
+	fail "4: complexity runner calls shared PULSE_START_EPOCH bootstrap" \
+		"missing aidevops_ensure_pulse_start_epoch call"
+fi
+
+rm -rf "$test_home"
+
+printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -ne 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -33,7 +33,7 @@
 #   1. --help completes with exit 0 and no stderr noise
 #   2. --help emits no 'command not found' errors
 #   3. --help emits no 'unbound variable' errors
-#   4. The routine file initialises PULSE_START_EPOCH (grep guard)
+#   4. The routine file calls shared PULSE_START_EPOCH bootstrap (grep guard)
 #   5. The routine file sources pulse-dispatch-core.sh (grep guard)
 #   6. The routine file sources pulse-fast-fail.sh (grep guard)
 #   7. runtime helpers define _should_setup_noninteractive_pulse_merge_routine
@@ -145,15 +145,15 @@ else
 fi
 
 # =============================================================================
-# Test 4: PULSE_START_EPOCH is initialised in the env-var defaults block
+# Test 4: PULSE_START_EPOCH is initialised via shared bootstrap
 # =============================================================================
 printf '\n=== Source-content guards ===\n'
 
-if grep -qE '^PULSE_START_EPOCH="\$\{PULSE_START_EPOCH:-' "$ROUTINE_FILE"; then
-	pass "4: PULSE_START_EPOCH initialised with default in routine"
+if grep -qE '^aidevops_ensure_pulse_start_epoch$' "$ROUTINE_FILE"; then
+	pass "4: PULSE_START_EPOCH initialised via shared bootstrap"
 else
-	fail "4: PULSE_START_EPOCH initialised with default in routine" \
-		"missing 'PULSE_START_EPOCH=\"\${PULSE_START_EPOCH:-...}' line"
+	fail "4: PULSE_START_EPOCH initialised via shared bootstrap" \
+		"missing aidevops_ensure_pulse_start_epoch call"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add shared `aidevops_ensure_pulse_start_epoch` bootstrap for standalone pulse-adjacent runners.
- Use it from `complexity-scan-runner.sh` so simplification issue signature footers do not crash when `PULSE_START_EPOCH` is unset.
- Reuse the same helper from `pulse-merge-routine.sh` and update/add standalone bootstrap regression tests.

Resolves #25843

## Verification

- `bash .agents/scripts/tests/test-complexity-scan-runner-standalone.sh`
- `bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `shellcheck .agents/scripts/shared-constants.sh .agents/scripts/complexity-scan-runner.sh .agents/scripts/pulse-merge-routine.sh .agents/scripts/tests/test-complexity-scan-runner-standalone.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh`
- `.agents/scripts/linters-local.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.29 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 35m and 430,564 tokens on this with the user in an interactive session.