### PR TITLE
t18031: reduce app action qlty smells

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1047,6 +1047,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18029 Scope session checkpoints to active repository #type:bug ref:GH#25835 pr:#25837 completed:2026-06-29
 
+- [ ] t18031 fix(gui): reduce AppActionButton qlty smells after v3.29.28 release failure #bug #interactive ~1h ref:GH#25842 logged:2026-06-29
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/packages/gui-web/src/ManagedAppPanel.tsx
+++ b/packages/gui-web/src/ManagedAppPanel.tsx
@@ -79,8 +79,52 @@ function AppLogLink({ job }: { job: GuiAppActionJobSummary }): ReactElement {
   return <a className="app-meta app-log-link" href={`#app-job-${job.id}`}><small>Logs</small><strong>{job.action} · {job.status}</strong></a>;
 }
 
+function appActionIcon(action: GuiAppActionId): ReactElement {
+  const icons: Record<GuiAppActionId, ReactElement> = {
+    install: <FiDownload />,
+    reinstall: <FiRepeat />,
+    remove: <FiTrash2 />,
+    update: <FiRefreshCw />,
+  };
+
+  return icons[action];
+}
+
+function appActionButtonClass(action: GuiAppActionId): string {
+  return action === "remove" ? "app-action-button remove" : "app-action-button";
+}
+
+function envelopeErrorSummary(envelope: Partial<GuiResponseEnvelope<GuiAppActionJobSummary>>): string {
+  return Array.isArray(envelope.errors) && envelope.errors.length > 0 ? envelope.errors.join("; ") : "unknown error";
+}
+
+async function requestAppActionJob(app: GuiManagedAppSummary, action: GuiAppActionId): Promise<GuiAppActionJobSummary | null> {
+  let job: GuiAppActionJobSummary | null = null;
+
+  try {
+    const response = await fetch(`/api/apps/${encodeURIComponent(app.id)}/actions/${action}`, { method: "POST" });
+    if (!response.ok) {
+      console.error(`Failed to run ${action} for ${app.id}: ${response.status} ${response.statusText}`);
+    } else {
+      const envelope = await response.json() as Partial<GuiResponseEnvelope<GuiAppActionJobSummary>> | null;
+      if (envelope === null || typeof envelope !== "object") {
+        console.error(`Action ${action} for ${app.id} returned an invalid response envelope`);
+      } else if (envelope.ok !== true) {
+        console.error(`Action ${action} for ${app.id} returned an error envelope: ${envelopeErrorSummary(envelope)}`);
+      } else if (!("data" in envelope)) {
+        console.error(`Action ${action} for ${app.id} returned a response envelope without job data`);
+      } else {
+        job = envelope.data as GuiAppActionJobSummary;
+      }
+    }
+  } catch (error) {
+    console.error(`Network error running ${action} for ${app.id}:`, error);
+  }
+
+  return job;
+}
+
 function AppActionButton({ action, app, commandPreview, disabled, onJob }: { action: GuiAppActionId; app: GuiManagedAppSummary; commandPreview: string; disabled: boolean; onJob: (job: GuiAppActionJobSummary) => void }): ReactElement {
-  const icon = action === "install" ? <FiDownload /> : action === "update" ? <FiRefreshCw /> : action === "reinstall" ? <FiRepeat /> : <FiTrash2 />;
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   async function runAction(): Promise<void> {
@@ -88,38 +132,14 @@ function AppActionButton({ action, app, commandPreview, disabled, onJob }: { act
       return;
     }
 
-    try {
-      const response = await fetch(`/api/apps/${encodeURIComponent(app.id)}/actions/${action}`, { method: "POST" });
-      if (!response.ok) {
-        console.error(`Failed to run ${action} for ${app.id}: ${response.status} ${response.statusText}`);
-        return;
-      }
-
-      const envelope = await response.json() as Partial<GuiResponseEnvelope<GuiAppActionJobSummary>> | null;
-      if (envelope === null || typeof envelope !== "object") {
-        console.error(`Action ${action} for ${app.id} returned an invalid response envelope`);
-        return;
-      }
-
-      if (envelope.ok !== true) {
-        const errors = Array.isArray(envelope.errors) && envelope.errors.length > 0 ? envelope.errors.join("; ") : "unknown error";
-        console.error(`Action ${action} for ${app.id} returned an error envelope: ${errors}`);
-        return;
-      }
-
-      if (!("data" in envelope)) {
-        console.error(`Action ${action} for ${app.id} returned a response envelope without job data`);
-        return;
-      }
-
-      onJob(envelope.data as GuiAppActionJobSummary);
-    } catch (error) {
-      console.error(`Network error running ${action} for ${app.id}:`, error);
+    const job = await requestAppActionJob(app, action);
+    if (job !== null) {
+      onJob(job);
     }
   }
 
   return <>
-    <button aria-label={`${action} ${app.name}`} className={action === "remove" ? "app-action-button remove" : "app-action-button"} data-tooltip={commandPreview} disabled={disabled} onClick={() => setConfirmOpen(true)} type="button">{icon}<span>{action}</span></button>
+    <button aria-label={`${action} ${app.name}`} className={appActionButtonClass(action)} data-tooltip={commandPreview} disabled={disabled} onClick={() => setConfirmOpen(true)} type="button">{appActionIcon(action)}<span>{action}</span></button>
     {confirmOpen ? <ConfirmActionModal action={action} app={app} commandPreview={commandPreview} close={() => setConfirmOpen(false)} confirm={() => { setConfirmOpen(false); void runAction(); }} /> : null}
   </>;
 }
@@ -134,7 +154,7 @@ function ConfirmActionModal({ action, app, close, commandPreview, confirm }: { a
         <code>{commandPreview}</code>
         <div className="confirm-modal-actions">
           <button className="secondary-action" onClick={close} type="button">Cancel</button>
-          <button className={action === "remove" ? "app-action-button remove" : "app-action-button"} onClick={confirm} type="button">Confirm</button>
+          <button className={appActionButtonClass(action)} onClick={confirm} type="button">Confirm</button>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary

- Refactor `AppActionButton` so the component only manages UI state and delegates action icon/class selection plus API request/error handling to focused helpers.
- Reduce total qlty smell count from 48 to 46, bringing `Qlty Smell Threshold` back under the configured threshold of 47.
- Normalize TODO metadata for `t18031`.

## Verification

- `bun test packages/gui-web/tests`
- `bun run typecheck`
- `~/.qlty/bin/qlty smells --all --sarif --no-snippets --quiet` → `46`
- `git diff --check`

Resolves #25842

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.29 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 13h 24m and 5,022,027 tokens on this with the user in an interactive session.
