### PR TITLE
t18032: Hide GUI stroke effects when borders disabled

### DIFF
--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -134,7 +134,7 @@
   --border-danger: transparent;
   --border-hover: transparent;
   --border-warning: transparent;
-  --glass-panel-shadow: var(--shadow-soft);
+  --glass-panel-shadow: none;
 }
 
 :root[data-borders="hidden"] :where(
@@ -142,6 +142,10 @@
   .app-sidebar,
   .app-inset,
   .desktop-status-bar,
+  .app-global-tooltip,
+  .confirm-modal,
+  .loading-brand-overlay,
+  .popover-menu,
   .workspace-header,
   button,
   input,
@@ -151,30 +155,44 @@
   [class*="button"],
   [class*="card"],
   [class*="control"],
+  [class*="dot"],
   [class*="entry"],
   [class*="item"],
+  [class*="loading"],
+  [class*="mark"],
   [class*="menu"],
+  [class*="modal"],
   [class*="orb"],
   [class*="panel"],
   [class*="pill"],
+  [class*="popover"],
   [class*="preview"],
   [class*="row"],
   [class*="selector"],
   [class*="surface"],
   [class*="switch"],
-  [class*="tag"]
+  [class*="tag"],
+  [class*="tooltip"]
 ) {
   border-color: transparent !important;
+  box-shadow: none !important;
+  outline-color: transparent !important;
 }
 
-:root[data-borders="hidden"] :where(
-  .github-notification-card,
-  .managed-app-card,
-  .notification-preview,
-  .status-dot,
-  .terminal-mark
-) {
-  box-shadow: none;
+:root[data-borders="hidden"] *,
+:root[data-borders="hidden"] *::before,
+:root[data-borders="hidden"] *::after {
+  border-color: transparent !important;
+  outline-color: transparent !important;
+}
+
+:root[data-borders="hidden"] [data-tooltip]::after {
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+:root[data-borders="hidden"] .desktop-status-bar span:not(.status-dot)::before {
+  color: transparent !important;
 }
 
 *,

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -284,8 +284,16 @@ describe("dashboard shell", () => {
 
     expect(css).toContain(':root[data-borders="hidden"]');
     expect(css).toContain("--border-accent: transparent");
+    expect(css).toContain("--glass-panel-shadow: none");
     expect(css).toContain(':root[data-borders="hidden"] :where(');
     expect(css).toContain("border-color: transparent !important");
+    expect(css).toContain("box-shadow: none !important");
+    expect(css).toContain("outline-color: transparent !important");
+    expect(css).toContain(":root[data-borders=\"hidden\"] *,\n:root[data-borders=\"hidden\"] *::before,\n:root[data-borders=\"hidden\"] *::after");
+    expect(css).toContain(":root[data-borders=\"hidden\"] [data-tooltip]::after");
+    expect(css).toContain(":root[data-borders=\"hidden\"] .desktop-status-bar span:not(.status-dot)::before");
+    expect(css).toContain("[class*=\"tooltip\"]");
+    expect(css).toContain("[class*=\"loading\"]");
     expect(css).toContain(".appearance-segmented-control");
     expect(css).toContain(".appearance-panel {\n  background: transparent");
     expect(css).toContain("font-size: 0.86em");


### PR DESCRIPTION
## Summary

- Makes hidden border mode suppress stroke shadows/rings and outline colors in addition to tokenized border colors.
- Covers tooltip pseudo-elements, status bar separator bullets, modals, popovers, loading overlays, dots, marks, and broad UI class patterns.
- Adds CSS regression assertions for hidden shadow, outline, pseudo-element, tooltip, and loading stroke coverage.

## Verification

- [x] `bun test packages/gui-web/tests`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] `.agents/scripts/linters-local.sh` (passed; advisory markdown, ratchet, canary timeout, and historical complexity warnings only)

Resolves #25855

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.30 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
