### PR TITLE
GH#25891: docs: adopt app store connect skills refresh

### DIFF
--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -29,7 +29,7 @@ tools:
 - **Context resolution**: explicit `--app-id` > `.asc/project.json` > prompt user to `asc init` (CI must use `--app-id` or pre-run `asc init`)
 - **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands; v0.18.1 adds review-submission item drill-down, sales-report rollups/schema selection, and an app-availability territory-limit fix; checked at `04fde49`, whose post-0.18.1 delta only refreshes homepage app-wall metadata for BetaReels and related app listings)
 - **Website**: https://asccli.app | **Web apps**: [Command Center](https://asccli.app/command-center), [Console](https://asccli.app/console), [Screenshot Studio](https://asccli.app/editor)
-- **Skills**: [Official](https://github.com/tddworks/asc-cli-skills) (27 command-group skills, checked at `6465c10feb89`) | [Community](https://github.com/rudrankriyam/app-store-connect-cli-skills) (23 workflow skills, checked at `ed0049a`)
+- **Skills**: [Official](https://github.com/tddworks/asc-cli-skills) (27 command-group skills, checked at `6465c10feb89`) | [Community](https://github.com/rudrankriyam/app-store-connect-cli-skills) (23 workflow skills, checked at `4e7d88b`)
 - **Requirements**: macOS 13+, App Store Connect API key, `jq` (workflow scripts use `jq -r`)
 
 **Dependency check**: Before any `asc` command:
@@ -163,7 +163,7 @@ Run `asc web-server` to start the local API bridge (ports 8420 HTTP, 8421 HTTPS)
 
 ## Agent Skills
 
-Install on-demand (not pre-loaded): **Official** `asc skills install --all` (per-command reference) | **Community** `asc install-skills` or `npx skills add rudrankriyam/app-store-connect-cli-skills` (workflow orchestration: releases, ASO, localization, RevenueCat, crash triage, Apple Ads). These upstream skill packs are tracked for review but intentionally remain on-demand until aidevops has a multi-skill import strategy for repositories containing dozens of `SKILL.md` files. Latest reviewed official skill change adds build export-compliance handling; latest community refresh (`ed0049a`) adds Apple Ads auth/org/campaign/reporting/raw-API guidance, safe live-testing guardrails, Apple Ads notes in the general asc command-usage skill, and a signing caveat: Apple `profileState` is not a complete expiration signal, so expired-profile audits must compare `expirationDate` against the current date instead of relying only on `INVALID`.
+Install on-demand (not pre-loaded): **Official** `asc skills install --all` (per-command reference) | **Community** `asc install-skills` or `npx skills add rudrankriyam/app-store-connect-cli-skills` (workflow orchestration: releases, ASO, localization, RevenueCat, crash triage, Apple Ads). These upstream skill packs are tracked for review but intentionally remain on-demand until aidevops has a multi-skill import strategy for repositories containing dozens of `SKILL.md` files. Latest reviewed official skill change adds build export-compliance handling; latest community refresh (`4e7d88b`) keeps the Apple Ads auth/org/campaign/reporting/raw-API guidance, safe live-testing guardrails, Apple Ads command-usage notes, and profile-expiration caveat, and updates review item examples to use the nested `asc review items add` form instead of the legacy `asc review items-add` spelling.
 
 ## Blitz MCP Server (Optional)
 


### PR DESCRIPTION
## Summary

Updated the App Store Connect agent note to record community skills at 4e7d88b and document the nested 'asc review items add' command form adopted upstream.

## Files Changed

.agents/tools/mobile/app-store-connect.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted secret scan passed: npx --no-install secretlint .agents/tools/mobile/app-store-connect.md. Diff hygiene passed: git diff --check origin/main...HEAD. Full .agents/scripts/linters-local.sh was attempted twice and timed out during Secretlint after earlier gates passed.

Resolves #25891


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 9m and 63,912 tokens on this as a headless worker.