### PR TITLE
GH#25877: Load safe-edit wrapper dependencies

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -35,6 +35,25 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+# Load dependencies when this focused module is sourced directly instead of via
+# shared-gh-wrappers.sh. Set our include guard before this block so the
+# orchestrator can safely source this file without recursive redefinition.
+if ! command -v _gh_validate_edit_args >/dev/null 2>&1; then
+	if [[ -f "${SCRIPT_DIR}/shared-gh-wrappers.sh" ]]; then
+		# shellcheck source=shared-gh-wrappers.sh
+		# shellcheck disable=SC1091  # resolved from SCRIPT_DIR at runtime
+		source "${SCRIPT_DIR}/shared-gh-wrappers.sh"
+	fi
+fi
+if ! command -v _rest_should_fallback >/dev/null 2>&1 ||
+	! command -v _rest_issue_edit >/dev/null 2>&1; then
+	if [[ -f "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+		# shellcheck source=shared-gh-wrappers-rest-fallback.sh
+		# shellcheck disable=SC1091  # resolved from SCRIPT_DIR at runtime
+		source "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh"
+	fi
+fi
+
 #######################################
 # Internal: audit-log a safety rejection.
 # Non-fatal — if audit-log-helper.sh is unavailable, the stderr message

--- a/.agents/scripts/tests/test-gh-edit-safety.sh
+++ b/.agents/scripts/tests/test-gh-edit-safety.sh
@@ -90,6 +90,40 @@ source "${SCRIPTS_DIR}/shared-constants.sh" 2>/dev/null || {
 
 # ── Tests ──
 
+section "0. shared-gh-wrappers-safe-edit standalone dependency loading"
+
+SAFE_EDIT_FILE="${SCRIPTS_DIR}/shared-gh-wrappers-safe-edit.sh"
+standalone_output=$(bash -c '
+set -u
+safe_edit_file="$1"
+calls_file="$(mktemp)"
+export calls_file
+gh() {
+	local arg1="${1:-}"
+	local arg2="${2:-}"
+	printf "%s\n" "$*" >>"$calls_file"
+	if [[ "$arg1 $arg2" == "issue view" || "$arg1 $arg2" == "pr view" ]]; then
+		printf "%s\n" "{\"title\":\"Existing\",\"body\":\"Existing\",\"labels\":[]}"
+	fi
+	return 0
+}
+export -f gh
+source "$safe_edit_file"
+gh_issue_edit_safe 123 --repo "test/repo" --body "body"
+rc=$?
+calls=$(wc -l <"$calls_file" | tr -d "[:space:]")
+rm -f "$calls_file"
+printf "rc=%s calls=%s\n" "$rc" "$calls"
+exit "$rc"
+' -- "$SAFE_EDIT_FILE" 2>&1)
+standalone_rc=$?
+if [[ $standalone_rc -eq 0 && "$standalone_output" == *"rc=0"* ]]; then
+	pass "standalone safe-edit source loads validation dependencies"
+else
+	fail "standalone safe-edit source should edit with valid args" \
+		"rc=${standalone_rc}; output: ${standalone_output}"
+fi
+
 section "1. _gh_validate_edit_args — empty title rejection"
 
 _gh_validate_edit_args --title "" --repo "test/repo" 2>/dev/null


### PR DESCRIPTION
## Summary

Make shared-gh-wrappers-safe-edit.sh load its validator and REST fallback dependencies when sourced directly, preserving the existing orchestrator include guard path.

## Files Changed

.agents/scripts/shared-gh-wrappers-safe-edit.sh,.agents/scripts/tests/test-gh-edit-safety.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed .agents/scripts/tests/test-gh-edit-safety.sh, .agents/scripts/tests/test-shared-gh-wrappers-standalone.sh, shellcheck on touched scripts, and git diff --check.

Resolves #25877


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 with gpt-5.5 spent 14m and 131,705 tokens on this with the user in an interactive session.