### PR TITLE
GH#25878: defer watchdog stalls for active API sockets

### DIFF
--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -9,7 +9,7 @@
 #   1. _watchdog_tree_cpu function exists in worker-activity-watchdog.sh
 #   2. STALL_TIMEOUT default is 600s (raised from 300s)
 #   3. Structured [lifecycle] worker_killed lines are emitted by _kill_worker
-#   4. CPU semantic check defers kill when tree_cpu >= STALL_CPU_THRESHOLD
+#   4. Semantic checks defer kill for network-active or CPU-active workers
 #   5. Hard-kill fires regardless of CPU (safety net)
 #   6. pulse-watchdog.sh kill sites emit [lifecycle] lines
 #   7. pulse-dispatch-engine.sh timeout handler emits [lifecycle] line
@@ -133,21 +133,52 @@ assert_contains \
 	"4b. CPU check defers kill (worker_stall_deferred lifecycle marker)" \
 	"worker_stall_deferred" \
 	"$watchdog_source"
+assert_contains \
+	"4c. Network semantic helper exists" \
+	"_watchdog_tree_network_active()" \
+	"$watchdog_source"
+assert_contains \
+	"4d. Network-active defers are labeled distinctly" \
+	"reason=network_active" \
+	"$watchdog_source"
+assert_contains \
+	"4e. Network helper probes established HTTPS/API sockets" \
+	"established_https" \
+	"$watchdog_source"
 
 #######################################
-# Test 5: Hard-kill fires regardless of CPU
-# (The hard-kill block must come BEFORE the CPU check in the code)
+# Test 5: Hard-kill fires regardless of semantic liveness checks
+# (The hard-kill block must come BEFORE network/CPU checks in the code)
 #######################################
 # Verify hard-kill check comes before CPU check by checking line order
 hard_kill_line=$(grep -n "HARD_KILL_SECONDS.*elapsed_total.*HARD_KILL_SECONDS" "${SCRIPT_DIR}/worker-activity-watchdog.sh" | head -1 | cut -d: -f1)
+network_check_line=$(grep -n "_watchdog_tree_network_active.*WORKER_PID" "${SCRIPT_DIR}/worker-activity-watchdog.sh" | head -1 | cut -d: -f1)
 cpu_check_line=$(grep -n "_watchdog_tree_cpu.*WORKER_PID" "${SCRIPT_DIR}/worker-activity-watchdog.sh" | head -1 | cut -d: -f1)
-if [[ -n "$hard_kill_line" && -n "$cpu_check_line" && "$hard_kill_line" -lt "$cpu_check_line" ]]; then
+if [[ -n "$hard_kill_line" && -n "$network_check_line" && "$hard_kill_line" -lt "$network_check_line" ]]; then
 	TESTS_RUN=$((TESTS_RUN + 1))
-	echo "${TEST_GREEN}PASS${TEST_NC}: 5. Hard-kill check precedes CPU check (line $hard_kill_line < $cpu_check_line)"
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5a. Hard-kill check precedes network-active check (line $hard_kill_line < $network_check_line)"
 else
 	TESTS_RUN=$((TESTS_RUN + 1))
 	TESTS_FAILED=$((TESTS_FAILED + 1))
-	echo "${TEST_RED}FAIL${TEST_NC}: 5. Hard-kill check must precede CPU check (hard_kill=$hard_kill_line, cpu=$cpu_check_line)"
+	echo "${TEST_RED}FAIL${TEST_NC}: 5a. Hard-kill check must precede network-active check (hard_kill=$hard_kill_line, network=$network_check_line)"
+fi
+if [[ -n "$hard_kill_line" && -n "$cpu_check_line" && "$hard_kill_line" -lt "$cpu_check_line" ]]; then
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5b. Hard-kill check precedes CPU check (line $hard_kill_line < $cpu_check_line)"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5b. Hard-kill check must precede CPU check (hard_kill=$hard_kill_line, cpu=$cpu_check_line)"
+fi
+
+provider_check_line=$(grep -n "if _output_has_provider_rate_limit" "${SCRIPT_DIR}/worker-activity-watchdog.sh" | head -1 | cut -d: -f1)
+if [[ -n "$provider_check_line" && -n "$network_check_line" && "$provider_check_line" -lt "$network_check_line" ]]; then
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5c. Provider-failure check precedes network-active defer (line $provider_check_line < $network_check_line)"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5c. Provider-failure check must precede network-active defer (provider=$provider_check_line, network=$network_check_line)"
 fi
 
 #######################################
@@ -296,11 +327,15 @@ assert_contains \
 	"reason=cpu_active" \
 	"$watchdog_source"
 assert_contains \
-	"12c. CI-wait defers are labeled distinctly" \
+	"12c. Network-active defers are labeled distinctly" \
+	"reason=network_active" \
+	"$watchdog_source"
+assert_contains \
+	"12d. CI-wait defers are labeled distinctly" \
 	"reason=ci_wait" \
 	"$watchdog_source"
 assert_contains \
-	"12d. Output-active path is documented as live work" \
+	"12e. Output-active path is documented as live work" \
 	"output-active" \
 	"$watchdog_source"
 
@@ -534,6 +569,95 @@ kill "$live_worker_pid" "$live_watchdog_pid" 2>/dev/null || true
 wait "$live_worker_pid" 2>/dev/null || true
 wait "$live_watchdog_pid" 2>/dev/null || true
 rm -rf "$tmp_dir"
+
+#######################################
+# Test 24: Runtime — network-active quiet worker survives beyond stall timeout
+#######################################
+if command -v python3 >/dev/null 2>&1 && { command -v lsof >/dev/null 2>&1 || command -v ss >/dev/null 2>&1; }; then
+	network_tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t watchdog-network-live)
+	network_output="${network_tmp_dir}/worker.out"
+	network_exit="${network_tmp_dir}/worker.exit"
+	network_log="${network_tmp_dir}/lifecycle.log"
+	network_ready="${network_tmp_dir}/ready"
+	network_script="${network_tmp_dir}/network_worker.py"
+	printf 'model API request started\n' >"$network_output"
+	network_initial_size=$(wc -c <"$network_output" 2>/dev/null || printf '0')
+	network_initial_size="${network_initial_size##* }"
+
+	cat >"$network_script" <<'PY'
+import socket
+import sys
+import time
+
+ready_path = sys.argv[1]
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 8443))
+server.listen(1)
+client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+client.connect(("127.0.0.1", 8443))
+connection, _address = server.accept()
+with open(ready_path, "w", encoding="utf-8") as ready_file:
+    ready_file.write("ready\n")
+try:
+    time.sleep(30)
+finally:
+    connection.close()
+    client.close()
+    server.close()
+PY
+
+	python3 "$network_script" "$network_ready" >/dev/null 2>&1 &
+	network_worker_pid=$!
+	for _network_wait in 1 2 3 4 5; do
+		[[ -f "$network_ready" ]] && break
+		sleep 1
+	done
+
+	if kill -0 "$network_worker_pid" 2>/dev/null && [[ -f "$network_ready" ]]; then
+		WORKER_LIFECYCLE_LOG="$network_log" \
+			"${SCRIPT_DIR}/worker-activity-watchdog.sh" \
+			--output-file "$network_output" \
+			--worker-pid "$network_worker_pid" \
+			--exit-code-file "$network_exit" \
+			--stall-timeout 1 \
+			--poll-interval 1 \
+			--hard-kill-seconds 0 >/dev/null 2>&1 &
+		network_watchdog_pid=$!
+
+		sleep 8
+		network_after_size=$(wc -c <"$network_output" 2>/dev/null || printf '0')
+		network_after_size="${network_after_size##* }"
+		if kill -0 "$network_worker_pid" 2>/dev/null && [[ ! -f "${network_exit}.watchdog_killed" ]] && grep -q 'reason=network_active' "$network_log" 2>/dev/null; then
+			TESTS_RUN=$((TESTS_RUN + 1))
+			echo "${TEST_GREEN}PASS${TEST_NC}: 24a. Network-active quiet worker survives beyond stall timeout (API-wait path)"
+		else
+			TESTS_RUN=$((TESTS_RUN + 1))
+			TESTS_FAILED=$((TESTS_FAILED + 1))
+			echo "${TEST_RED}FAIL${TEST_NC}: 24a. Network-active quiet worker was killed or not audited as network_active"
+		fi
+		if [[ "$network_initial_size" == "$network_after_size" ]]; then
+			TESTS_RUN=$((TESTS_RUN + 1))
+			echo "${TEST_GREEN}PASS${TEST_NC}: 24b. Network-active defer does not grow monitored output file"
+		else
+			TESTS_RUN=$((TESTS_RUN + 1))
+			TESTS_FAILED=$((TESTS_FAILED + 1))
+			echo "${TEST_RED}FAIL${TEST_NC}: 24b. Network-active defer changed monitored output size (${network_initial_size} -> ${network_after_size})"
+		fi
+
+		kill "$network_watchdog_pid" 2>/dev/null || true
+		wait "$network_watchdog_pid" 2>/dev/null || true
+	else
+		TESTS_RUN=$((TESTS_RUN + 1))
+		echo "${TEST_GREEN}PASS${TEST_NC}: 24. Network-active runtime test skipped — local 127.0.0.1:8443 unavailable"
+	fi
+	kill "$network_worker_pid" 2>/dev/null || true
+	wait "$network_worker_pid" 2>/dev/null || true
+	rm -rf "$network_tmp_dir"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "${TEST_GREEN}PASS${TEST_NC}: 24. Network-active runtime test skipped — python3 plus lsof/ss required"
+fi
 
 #######################################
 # Summary

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -16,7 +16,8 @@
 #   Phase 1 (fast, 0-30s): Any output at all. Zero bytes = dead runtime.
 #   Phase 2 (continuous):   File growth. No growth for stall_timeout triggers
 #                            classification (provider failure, CI wait,
-#                            CPU-active, or no-progress) before any kill.
+#                            network-active, CPU-active, or no-progress) before
+#                            any kill.
 #
 # On stall:
 #   - Writes WATCHDOG_KILL marker to output file
@@ -300,6 +301,101 @@ _watchdog_tree_cpu() {
 	# cpu_seconds_in_window / window_duration * 100 = recent CPU percentage
 	echo $(( total_delta * 100 / sample_interval ))
 	return 0
+}
+
+#######################################
+# Return whether lsof sees an established HTTPS/API socket for the process tree.
+#
+# Fail-closed: if lsof is missing, lacks visibility, or returns no matching
+# outbound remote port, this function returns 1 so the watchdog falls through to
+# the CPU/no-progress logic. Matching only established TCP sockets whose remote
+# endpoint is a common HTTPS/API port limits false positives from listeners or
+# unrelated local sockets; the hard-kill threshold remains the absolute cap.
+#
+# Arguments:
+#   $@ - PID list to inspect
+# Returns: 0 when active network evidence exists, 1 otherwise
+#######################################
+_watchdog_lsof_network_active() {
+	local pid_list=("$@")
+	command -v lsof >/dev/null 2>&1 || return 1
+
+	local pid="" pid_csv=""
+	for pid in "${pid_list[@]}"; do
+		[[ "$pid" =~ ^[0-9]+$ ]] || continue
+		pid_csv="${pid_csv:+${pid_csv},}${pid}"
+	done
+	[[ -n "$pid_csv" ]] || return 1
+
+	local lsof_output=""
+	lsof_output=$(lsof -nP -a -p "$pid_csv" -iTCP -sTCP:ESTABLISHED 2>/dev/null || true)
+	[[ -n "$lsof_output" ]] || return 1
+
+	if printf '%s\n' "$lsof_output" | grep -Eq -- '->[^[:space:]]+:(443|8443)([[:space:]]|$)'; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Return whether ss sees an established HTTPS/API socket for the process tree.
+#
+# Linux fallback for environments without lsof. `ss -p` may hide process
+# metadata on restricted systems; that is treated as no evidence (fail-closed),
+# not as a reason to keep a quiet worker alive indefinitely.
+#
+# Arguments:
+#   $@ - PID list to inspect
+# Returns: 0 when active network evidence exists, 1 otherwise
+#######################################
+_watchdog_ss_network_active() {
+	local pid_list=("$@")
+	command -v ss >/dev/null 2>&1 || return 1
+
+	local ss_output=""
+	ss_output=$(ss -Htanp state established 2>/dev/null || true)
+	[[ -n "$ss_output" ]] || return 1
+
+	local pid=""
+	for pid in "${pid_list[@]}"; do
+		[[ "$pid" =~ ^[0-9]+$ ]] || continue
+		if printf '%s\n' "$ss_output" | grep -Eq -- "[[:space:]][^[:space:]]+:(443|8443)([[:space:]]|$).*pid=${pid},"; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+#######################################
+# Return whether the worker process tree has active HTTPS/API network evidence.
+#
+# This is deliberately semantic liveness, not a stderr heartbeat: it never writes
+# to the monitored output file, it only defers no-output kills when a real
+# process-tree socket is established, and the cumulative hard-kill backstop still
+# frees slots for runaway/dead processes.
+#
+# Arguments:
+#   $1 - root PID to inspect
+# Returns: 0 when active network evidence exists, 1 otherwise
+#######################################
+_watchdog_tree_network_active() {
+	local root_pid="${1:-}"
+	[[ "$root_pid" =~ ^[0-9]+$ ]] || return 1
+
+	local pid_list=("$root_pid")
+	local pid=""
+	while IFS= read -r pid; do
+		[[ "$pid" =~ ^[0-9]+$ ]] || continue
+		pid_list+=("$pid")
+	done < <(_get_descendant_pids "$root_pid")
+
+	if _watchdog_lsof_network_active "${pid_list[@]}"; then
+		return 0
+	fi
+	if _watchdog_ss_network_active "${pid_list[@]}"; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################
@@ -621,6 +717,22 @@ _monitor() {
 			if _output_has_ci_wait; then
 				deferred_stall_seconds=$((deferred_stall_seconds + stall_seconds))
 				printf '[lifecycle] worker_stall_deferred pid=%s reason=ci_wait stall_seconds=%ss deferred_total=%ss ts=%s\n' \
+					"$WORKER_PID" "$stall_seconds" "$deferred_stall_seconds" \
+					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+					>>"$LIFECYCLE_LOG" 2>/dev/null || true
+				stall_seconds=0
+				sleep "$POLL_INTERVAL"
+				continue
+			fi
+
+			# GH#25878: An AI/API call can be live while producing no stderr and
+			# little recent CPU. Treat an established HTTPS/API socket in the worker
+			# process tree as semantic liveness, but log only to LIFECYCLE_LOG so the
+			# monitored output file does not self-reset the stall counter. Missing or
+			# restricted network tooling fails closed and falls through to CPU/no-progress.
+			if _watchdog_tree_network_active "$WORKER_PID"; then
+				deferred_stall_seconds=$((deferred_stall_seconds + stall_seconds))
+				printf '[lifecycle] worker_stall_deferred pid=%s reason=network_active signal=established_https stall_seconds=%ss deferred_total=%ss ts=%s\n' \
 					"$WORKER_PID" "$stall_seconds" "$deferred_stall_seconds" \
 					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 					>>"$LIFECYCLE_LOG" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Added process-tree HTTPS/API socket liveness detection to `worker-activity-watchdog.sh` so quiet AI API waits defer no-output restarts without emitting stderr heartbeats.

## Files Changed

- `.agents/scripts/worker-activity-watchdog.sh`
- `.agents/scripts/tests/test-watchdog-no-false-kill.sh`

## Runtime Testing

- **Risk level:** High (worker watchdog/polling loop and process recovery path)
- **Verification:**
  - `.agents/scripts/tests/test-watchdog-no-false-kill.sh` — 66 tests, 0 failures
  - `shellcheck -S error .agents/scripts/worker-activity-watchdog.sh .agents/scripts/tests/test-watchdog-no-false-kill.sh`
  - `.agents/scripts/linters-local.sh` — `ALL LOCAL CHECKS PASSED` (with pre-existing advisory markdown/ratchet output)

## Safety and Recovery Decisions

- Hard-kill remains the first stall branch, so runaway/dead workers still free the slot at `WORKER_STALL_HARD_KILL_SECONDS`.
- Provider-failure markers still beat network-active deferral, avoiding false recovery for known rate-limit/provider failures.
- Network checks fail closed when `lsof`/`ss` is unavailable or lacks process visibility, preserving the previous kill path rather than indefinitely deferring.
- Network-active deferrals log only to `WORKER_LIFECYCLE_LOG`; they never grow the monitored output file or self-reset the output-growth watchdog.
- Scanner state was not broadened in this PR: once false network/API kills are prevented, the existing same-fingerprint cooldown remains the anti-flap control for genuinely killed workers.

Resolves #25878



<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.32 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 47m and 275,399 tokens on this with the user in an interactive session.
