### PR TITLE
fix: strip agent intent from tool args

### DIFF
--- a/.agents/plugins/opencode-aidevops/intent-tracing.mjs
+++ b/.agents/plugins/opencode-aidevops/intent-tracing.mjs
@@ -22,9 +22,11 @@ export const INTENT_FIELD = "agent__intent";
 const intentByCallId = new Map();
 
 /**
- * Extract and store the intent field from tool call args.
+ * Extract, store, and strip the intent field from tool call args.
  * Called from toolExecuteBefore — stores intent keyed by callID for
  * retrieval in toolExecuteAfter when the tool call is recorded to the DB.
+ * The metadata is consumed by aidevops observability and must not remain in
+ * executable tool arguments passed onward to OpenCode or host tools.
  *
  * @param {string} callID - Unique tool call identifier
  * @param {object} args - Tool call arguments (may contain agent__intent)
@@ -33,7 +35,12 @@ const intentByCallId = new Map();
 export function extractAndStoreIntent(callID, args) {
   if (!args || typeof args !== "object") return undefined;
 
+  const hasIntent = Object.prototype.hasOwnProperty.call(args, INTENT_FIELD);
   const raw = args[INTENT_FIELD];
+  if (hasIntent) {
+    delete args[INTENT_FIELD];
+  }
+
   if (typeof raw !== "string") return undefined;
 
   const intent = raw.trim();

--- a/.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage for GH#25895: intent metadata is schema-injected so it
+// can reach the plugin, but must be consumed before executable tool args reach
+// OpenCode's host-side validation/execution paths.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractAndStoreIntent, consumeIntent } from "../intent-tracing.mjs";
+
+describe("extractAndStoreIntent", () => {
+  test("stores and strips agent__intent while preserving Bash workdir", () => {
+    const callID = "call-gh-25895-bash";
+    const args = {
+      command: "git status --short",
+      workdir: "/tmp/aidevops-workspace",
+      agent__intent: " Inspecting repository state before editing ",
+    };
+
+    const intent = extractAndStoreIntent(callID, args);
+
+    assert.equal(intent, "Inspecting repository state before editing");
+    assert.equal(consumeIntent(callID), "Inspecting repository state before editing");
+    assert.equal(args.workdir, "/tmp/aidevops-workspace");
+    assert.ok(!Object.prototype.hasOwnProperty.call(args, "agent__intent"));
+  });
+
+  test("strips agent__intent from Read filePath args before execution", () => {
+    const callID = "call-gh-25895-read";
+    const args = {
+      filePath: "/tmp/aidevops-workspace/README.md",
+      agent__intent: "Reading a file to understand context",
+    };
+
+    extractAndStoreIntent(callID, args);
+
+    assert.equal(consumeIntent(callID), "Reading a file to understand context");
+    assert.deepEqual(args, { filePath: "/tmp/aidevops-workspace/README.md" });
+  });
+
+  test("strips malformed intent metadata without storing it", () => {
+    const callID = "call-gh-25895-custom";
+    const args = {
+      target: "custom-tool",
+      agent__intent: 42,
+    };
+
+    const intent = extractAndStoreIntent(callID, args);
+
+    assert.equal(intent, undefined);
+    assert.equal(consumeIntent(callID), undefined);
+    assert.deepEqual(args, { target: "custom-tool" });
+  });
+});


### PR DESCRIPTION
## Summary
- Strip `agent__intent` from mutable tool args immediately after aidevops observability extracts it.
- Preserve existing intent storage/consumption semantics for `tool.execute.after`.
- Add GH#25895 regression coverage for Bash `workdir`, Read `filePath`, and malformed custom tool metadata.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs .agents/plugins/opencode-aidevops/tests/test-intent-schema-injection.mjs .agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs`
- `.agents/scripts/linters-local.sh` (passed; existing advisory markdown/ratchet/complexity debt reported)

Resolves #25895

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.34 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
