### PR TITLE
GH#25903: avoid hardcoded signature model fallback

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -63,6 +63,21 @@ import {
 export { FAIL_REASON };
 export { SIG_MARKER, hasTrustedSignatureSignal, isGhWriteCommand, isMachineProtocolCommand };
 
+function _signatureHelperEnv() {
+  const helperEnv = {
+    ...process.env,
+    AIDEVOPS_SIG_CLI: process.env.AIDEVOPS_SIG_CLI || "OpenCode",
+    AIDEVOPS_SIG_TOKENS: process.env.AIDEVOPS_SIG_TOKENS || "0",
+  };
+  const model = process.env.AIDEVOPS_SIG_MODEL || process.env.OPENCODE_MODEL || "";
+  if (model) {
+    helperEnv.AIDEVOPS_SIG_MODEL = model;
+  } else {
+    delete helperEnv.AIDEVOPS_SIG_MODEL;
+  }
+  return helperEnv;
+}
+
 /**
  * Generate a signature footer by invoking gh-signature-helper.sh synchronously.
  * Returns `{ status: "ok", sig }` on success or
@@ -79,13 +94,7 @@ function _generateSignature(helperPath, bodyValue, log) {
       encoding: "utf-8",
       timeout: 1500,
       stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        AIDEVOPS_SIG_CLI: process.env.AIDEVOPS_SIG_CLI || "OpenCode",
-        AIDEVOPS_SIG_MODEL:
-          process.env.AIDEVOPS_SIG_MODEL || process.env.OPENCODE_MODEL || "openai/gpt-5.5",
-        AIDEVOPS_SIG_TOKENS: process.env.AIDEVOPS_SIG_TOKENS || "0",
-      },
+      env: _signatureHelperEnv(),
     });
     if (!sig || !sig.includes(SIG_MARKER)) {
       log("WARN", "gh-signature-helper output missing marker; refusing to inject");

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -375,6 +375,81 @@ printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n
     assert.match(readFileSync(argvLog, "utf-8"), /footer --no-session --body/);
   });
 
+  test("does not invent a model when no signature model env is available", () => {
+    const priorSigModel = process.env.AIDEVOPS_SIG_MODEL;
+    const priorOpenCodeModel = process.env.OPENCODE_MODEL;
+    delete process.env.AIDEVOPS_SIG_MODEL;
+    delete process.env.OPENCODE_MODEL;
+
+    try {
+      const dir = mkdtempSync(join(tmpdir(), "t25903-no-model-fallback-"));
+      const helper = join(dir, "gh-signature-helper.sh");
+      const envLog = join(dir, "helper-env.log");
+      writeFileSync(
+        helper,
+        `#!/usr/bin/env bash
+printf '%s' "\${AIDEVOPS_SIG_MODEL-}" >"${envLog}"
+printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n'
+`,
+      );
+      chmodSync(helper, 0o755);
+      const { log } = makeLogger();
+      const cmd = 'gh issue comment 1 --repo o/r --body "hello"';
+      const out = tryRepairSignature(cmd, dir, log);
+      assert.equal(out.status, "ok");
+      assert.equal(readFileSync(envLog, "utf-8"), "");
+      assert.doesNotMatch(out.cmd, /openai\/gpt-5\.5/);
+    } finally {
+      if (priorSigModel === undefined) {
+        delete process.env.AIDEVOPS_SIG_MODEL;
+      } else {
+        process.env.AIDEVOPS_SIG_MODEL = priorSigModel;
+      }
+      if (priorOpenCodeModel === undefined) {
+        delete process.env.OPENCODE_MODEL;
+      } else {
+        process.env.OPENCODE_MODEL = priorOpenCodeModel;
+      }
+    }
+  });
+
+  test("forwards OPENCODE_MODEL to the no-session signature helper", () => {
+    const priorSigModel = process.env.AIDEVOPS_SIG_MODEL;
+    const priorOpenCodeModel = process.env.OPENCODE_MODEL;
+    delete process.env.AIDEVOPS_SIG_MODEL;
+    process.env.OPENCODE_MODEL = "openai/example-model";
+
+    try {
+      const dir = mkdtempSync(join(tmpdir(), "t25903-opencode-model-"));
+      const helper = join(dir, "gh-signature-helper.sh");
+      const envLog = join(dir, "helper-env.log");
+      writeFileSync(
+        helper,
+        `#!/usr/bin/env bash
+printf '%s' "\${AIDEVOPS_SIG_MODEL-}" >"${envLog}"
+printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n'
+`,
+      );
+      chmodSync(helper, 0o755);
+      const { log } = makeLogger();
+      const cmd = 'gh issue comment 1 --repo o/r --body "hello"';
+      const out = tryRepairSignature(cmd, dir, log);
+      assert.equal(out.status, "ok");
+      assert.equal(readFileSync(envLog, "utf-8"), "openai/example-model");
+    } finally {
+      if (priorSigModel === undefined) {
+        delete process.env.AIDEVOPS_SIG_MODEL;
+      } else {
+        process.env.AIDEVOPS_SIG_MODEL = priorSigModel;
+      }
+      if (priorOpenCodeModel === undefined) {
+        delete process.env.OPENCODE_MODEL;
+      } else {
+        process.env.OPENCODE_MODEL = priorOpenCodeModel;
+      }
+    }
+  });
+
   test("allows same-command body-file creation for exec-time shim repair", () => {
     const dir = setupStubHelper();
     const bodyFile = join(dir, "created-later.md");


### PR DESCRIPTION
## Summary

- Removes the hardcoded `openai/gpt-5.5` fallback from OpenCode signature repair.
- Keeps the cheap `gh-signature-helper.sh footer --no-session --body ...` path instead of adding session DB probing to the pre-exec hook.
- Forwards `AIDEVOPS_SIG_MODEL` when present, falls back to `OPENCODE_MODEL` when present, and otherwise omits the model from the footer.
- Adds regression coverage for both no-model and `OPENCODE_MODEL` forwarding cases.

## Validation

PR #25899 identified a real bug: `.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs` could publish a guessed model when hook/session env was missing. The submitted PR's intent is valid, but the DB-probing implementation adds duplicate runtime-session logic in a pre-exec hook. This PR fixes the root symptom with a smaller fail-safe path.

## Verification

```bash
node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
node --check .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
node --check .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
git diff --check origin/main...HEAD
.agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD --output-md /tmp/qlty-report-gh25903.md --sarif-base /tmp/qlty-base-gh25903.sarif --sarif-head /tmp/qlty-head-gh25903.sarif
```

Qlty local result: base 46, head 46, delta 0.

Resolves #25903

Related: #25899
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.35 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1h 23m and 129,231 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature generation handling so environment settings are passed more consistently, with safer fallback behavior when model-related values are missing.
  * Strengthened signature repair behavior to preserve expected command output across different environment configurations.

* **Tests**
  * Added coverage for signature repair scenarios involving unset and forwarded environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->