### PR TITLE
fix: unblock auto-dispatch review handoffs

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -167,7 +167,7 @@ _dsi_target_is_pull_request() {
 _dsi_guard_no_interactive_hold() {
 	local labels_csv="$1"
 	local labels_with_commas=",${labels_csv},"
-	if [[ "$labels_with_commas" == *",status:in-review,"* ]]; then
+	if [[ "$labels_with_commas" == *",status:in-review,"* && "$labels_with_commas" != *",auto-dispatch,"* ]]; then
 		_dsi_err "Target carries an interactive review hold label; refusing worker dispatch (GH#22948)"
 		return 1
 	fi

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1122,8 +1122,7 @@ _is_task_committed_to_main() {
 #######################################
 # Detect labels that mean a human/review workflow owns the target.
 #
-# status:in-review is the live interactive hold label applied by full-loop and
-# interactive-session-helper. origin:interactive is provenance: it blocks only
+# status:in-review and origin:interactive are live interactive hold signals only
 # while the issue is not explicitly worker-dispatchable. auto-dispatch is the
 # handoff signal for issues left by an interactive session after the human has
 # moved on, so it must not strand work forever (GH#22964/GH#22965).
@@ -1136,7 +1135,7 @@ _dispatch_has_interactive_hold() {
 	local issue_meta_json="$1"
 	[[ -n "$issue_meta_json" ]] || return 1
 	printf '%s' "$issue_meta_json" |
-		jq -e '.labels | map(.name) | (index("status:in-review") or (index("origin:interactive") and (index("auto-dispatch") | not)))' >/dev/null 2>&1
+		jq -e '.labels | map(.name) | ((index("auto-dispatch") | not) and (index("status:in-review") or index("origin:interactive")))' >/dev/null 2>&1
 	return $?
 }
 
@@ -1195,9 +1194,8 @@ _dispatch_dedup_check_layers() {
 	target_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
 
 	# GH#22948/GH#22964: interactive/review hold guard independent of assignee
-	# identity. The Layer 6 assignment guard intentionally lets self-assignment
-	# through. status:in-review remains a live human lock; origin:interactive is
-	# provenance only when auto-dispatch explicitly hands the issue to workers.
+	# identity. auto-dispatch is an explicit worker handoff, so active claim
+	# liveness/staleness is delegated to Layer 6 instead of blocked here.
 	_dss_t0=$(_ds_now_ns)
 	if _dispatch_has_interactive_hold "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: interactive review hold label present (GH#22948)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -211,8 +211,9 @@ repo_allows_pulse_write_actions() {
 #   - supervisor/persistent/routine-tracking/infrastructure (non-work telemetry/advisories)
 #   - parent-task (decomposition tracker, never directly dispatchable; t2924)
 #   - no-auto-dispatch (explicit dispatch opt-out; t2924)
-#   - status:in-progress, status:in-review, status:claimed, status:done
-#     (active or completed claims that the dispatcher would always block; t2924)
+#   - status:in-progress, status:in-review, status:claimed without auto-dispatch
+#     (active claims that the dispatcher would otherwise block; t2924)
+#   - status:done (completed work, never dispatchable)
 # Everything else passes through for the downstream dedup layers to decide.
 #
 # t2924 rationale: filtering these at candidate-build time (instead of dispatch
@@ -222,6 +223,10 @@ repo_allows_pulse_write_actions() {
 # per cycle. The dispatch-time check (dispatch-dedup-helper.sh::is-assigned)
 # remains as defense-in-depth for the race window between candidate build and
 # dispatch.
+#
+# Auto-dispatch is an explicit worker handoff, so active status labels must not
+# hide those issues from stale-assignment recovery. They stay in the candidate
+# stream and Layer 6 decides whether the claim is live, stale, or safe to take.
 #
 # Arguments:
 #   $1 - repo slug (owner/repo)
@@ -256,7 +261,7 @@ list_dispatchable_issue_candidates_json() {
 	fi
 	rm -f "$issue_dispatch_err"
 
-	printf '%s' "$issue_json" | jq -c '
+	printf '%s' "$issue_json" | jq -c --arg auto_dispatch_label 'auto-dispatch' '
 		[
 			.[] |
 			(.labels | map(.name)) as $labels |
@@ -284,9 +289,9 @@ list_dispatchable_issue_candidates_json() {
 			# candidate build and dispatch.
 			select(($labels | index("parent-task")) == null) |
 			select(($labels | index("no-auto-dispatch")) == null) |
-			select(($labels | index("status:in-progress")) == null) |
-			select(($labels | index("status:in-review")) == null) |
-			select(($labels | index("status:claimed")) == null) |
+			select((($labels | index("status:in-progress")) == null) or (($labels | index($auto_dispatch_label)) != null)) |
+			select((($labels | index("status:in-review")) == null) or (($labels | index($auto_dispatch_label)) != null)) |
+			select((($labels | index("status:claimed")) == null) or (($labels | index($auto_dispatch_label)) != null)) |
 			select(($labels | index("status:done")) == null) |
 			{
 				number,

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -541,13 +541,13 @@ test_pr_target_guard_fails_closed_on_api_error() {
 	return 0
 }
 
-test_interactive_hold_guard_blocks_review_label() {
+test_interactive_hold_guard_blocks_review_label_without_handoff() {
 	local rc=0
-	_dsi_guard_no_interactive_hold "bug,status:in-review,auto-dispatch" >/dev/null 2>&1 || rc=$?
+	_dsi_guard_no_interactive_hold "bug,status:in-review" >/dev/null 2>&1 || rc=$?
 
 	local check=1
 	[[ "$rc" -eq 1 ]] && check=0
-	print_result "interactive hold guard blocks status:in-review" "$check" "rc=$rc"
+	print_result "interactive hold guard blocks status:in-review without handoff" "$check" "rc=$rc"
 	return 0
 }
 
@@ -568,6 +568,16 @@ test_interactive_hold_guard_allows_auto_dispatch_handoff() {
 	local check=1
 	[[ "$rc" -eq 0 ]] && check=0
 	print_result "interactive hold guard allows auto-dispatch handoff" "$check" "rc=$rc"
+	return 0
+}
+
+test_interactive_hold_guard_allows_auto_dispatch_review_handoff() {
+	local rc=0
+	_dsi_guard_no_interactive_hold "bug,status:in-review,auto-dispatch" >/dev/null 2>&1 || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 0 ]] && check=0
+	print_result "interactive hold guard allows auto-dispatch review handoff" "$check" "rc=$rc"
 	return 0
 }
 
@@ -898,9 +908,10 @@ _run_tests() {
 	test_pr_target_guard_detects_pull_request
 	test_pr_target_guard_allows_plain_issue
 	test_pr_target_guard_fails_closed_on_api_error
-	test_interactive_hold_guard_blocks_review_label
+	test_interactive_hold_guard_blocks_review_label_without_handoff
 	test_interactive_hold_guard_blocks_origin_interactive_without_handoff
 	test_interactive_hold_guard_allows_auto_dispatch_handoff
+	test_interactive_hold_guard_allows_auto_dispatch_review_handoff
 	test_maintainer_review_guard_blocks_manual_dispatch
 	test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup
 	test_agent_flag_parses_with_default

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -105,13 +105,13 @@ test_pr_guard_allows_plain_issue() {
 	return 0
 }
 
-test_interactive_hold_blocks_in_review() {
-	local meta='{"labels":[{"name":"auto-dispatch"},{"name":"status:in-review"}]}'
+test_interactive_hold_blocks_in_review_without_handoff() {
+	local meta='{"labels":[{"name":"status:in-review"}]}'
 	if _dispatch_has_interactive_hold "$meta"; then
-		print_result "interactive hold blocks status:in-review" 0
+		print_result "interactive hold blocks status:in-review without handoff" 0
 		return 0
 	fi
-	print_result "interactive hold blocks status:in-review" 1 "expected status:in-review to block"
+	print_result "interactive hold blocks status:in-review without handoff" 1 "expected status:in-review to block"
 	return 0
 }
 
@@ -132,6 +132,16 @@ test_interactive_hold_allows_auto_dispatch_handoff() {
 		return 0
 	fi
 	print_result "interactive hold allows auto-dispatch handoff" 0
+	return 0
+}
+
+test_interactive_hold_allows_auto_dispatch_review_handoff() {
+	local meta='{"labels":[{"name":"status:in-review"},{"name":"auto-dispatch"},{"name":"bug"}]}'
+	if _dispatch_has_interactive_hold "$meta"; then
+		print_result "interactive hold allows auto-dispatch review handoff" 1 "auto-dispatch should route status:in-review to stale-claim dedup"
+		return 0
+	fi
+	print_result "interactive hold allows auto-dispatch review handoff" 0
 	return 0
 }
 
@@ -181,9 +191,10 @@ main() {
 
 	test_pr_guard_uses_rest_issue_object
 	test_pr_guard_allows_plain_issue
-	test_interactive_hold_blocks_in_review
+	test_interactive_hold_blocks_in_review_without_handoff
 	test_interactive_hold_blocks_origin_interactive
 	test_interactive_hold_allows_auto_dispatch_handoff
+	test_interactive_hold_allows_auto_dispatch_review_handoff
 	test_interactive_hold_allows_worker_issue
 	test_interactive_hold_emits_structured_block_reason
 	test_pr_guard_emits_structured_block_reason

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -285,22 +285,24 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	  {"number":7,"title":"needs docs","updatedAt":"2026-03-31T00:06:00Z","assignees":[],"labels":[{"name":"needs-docs"}]},
 	  {"number":8,"title":"supervisor telemetry","updatedAt":"2026-03-31T00:07:00Z","assignees":[],"labels":[{"name":"supervisor"}]},
 	  {"number":9,"title":"in progress but runnable","updatedAt":"2026-03-31T00:08:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-progress"}]},
-	  {"number":10,"title":"Infrastructure outage: 2 checks affected","updatedAt":"2026-03-31T00:09:00Z","assignees":[],"labels":[{"name":"infrastructure"},{"name":"source:ci-failure-miner"},{"name":"status:available"}]}
+	  {"number":10,"title":"Infrastructure outage: 2 checks affected","updatedAt":"2026-03-31T00:09:00Z","assignees":[],"labels":[{"name":"infrastructure"},{"name":"source:ci-failure-miner"},{"name":"status:available"}]},
+	  {"number":11,"title":"auto dispatch in review","updatedAt":"2026-03-31T00:10:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-review"},{"name":"auto-dispatch"}]}
 	]'
 	GH_PR_LIST_JSON='[]'
 
 	local output
 	output=$(list_dispatchable_issue_candidates "owner/repo" 100)
 
-	# t2924: status:in-progress is filtered at candidate-build time to avoid
-	# re-evaluating always-blocked candidates every pulse cycle.  Issue #9
-	# carries status:in-progress and must NOT appear in the output.
-	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* && "$output" != *$'10|Infrastructure outage: 2 checks affected'* ]]; then
-		print_result "list_dispatchable_issue_candidates is default-open except needs-* and active-status labels" 0
+	# t2924 filters active status labels at candidate-build time to avoid
+	# re-evaluating always-blocked candidates every pulse cycle. auto-dispatch is
+	# the exception: it must reach Layer 6 so stale assignment recovery can unstick
+	# worker-intended issues left with status:in-review.
+	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" == *$'11|auto dispatch in review'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* && "$output" != *$'10|Infrastructure outage: 2 checks affected'* ]]; then
+		print_result "list_dispatchable_issue_candidates lets auto-dispatch active-status issues reach dedup" 0
 		return 0
 	fi
 
-	print_result "list_dispatchable_issue_candidates is default-open except needs-* and active-status labels" 1 "Unexpected candidate set: ${output}"
+	print_result "list_dispatchable_issue_candidates lets auto-dispatch active-status issues reach dedup" 1 "Unexpected candidate set: ${output}"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Resolves #25908.

- Allow `auto-dispatch` issues carrying `status:in-progress`, `status:in-review`, or `status:claimed` to reach the dispatch dedup layer instead of being filtered at candidate-build time.
- Treat `auto-dispatch` as an explicit worker handoff for the early interactive-hold guard, while preserving the hold for non-handoff `status:in-review` and `origin:interactive` issues.
- Align manual single-issue dispatch guard and regression tests with the pulse path.

## Root cause

Pulse capacity and API budget were available, but worker-intended issues with `auto-dispatch + status:in-review` were blocked before stale-assignment recovery could run. The candidate builder filtered active-status labels, and the early interactive-hold gate treated `status:in-review` as an unconditional hold. That prevented Layer 6 dedup from determining whether a claim was live, stale, or safe to take over.

## Verification

- `.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh`
- `.agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `.agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `shellcheck .agents/scripts/pulse-repo-meta.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh .agents/scripts/tests/test-pulse-wrapper-worker-count.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `git diff --check`
- `.agents/scripts/linters-local.sh`

## Worker context

Files changed:

- `.agents/scripts/pulse-repo-meta.sh` — candidate filtering exception for auto-dispatch active-status issues.
- `.agents/scripts/pulse-dispatch-core.sh` — interactive-hold gate now delegates auto-dispatch handoffs to dedup.
- `.agents/scripts/dispatch-single-issue-helper.sh` — manual guard parity.
- `.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh`
- `.agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `.agents/scripts/tests/test-dispatch-single-issue-helper.sh`

Pattern to verify: `auto-dispatch` is a worker handoff; non-handoff `status:in-review`/`origin:interactive` remains protected by the interactive-hold guard.
