### PR TITLE
t18020: integrate Tambo generative UI cards into conversations

### DIFF
--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import * as readline from "node:readline";
 import { Hono } from "hono";
-import { APP_ACTION_ROUTE_MANIFEST, APP_ACTION_STATUS_ROUTE_MANIFEST, BANNED_ROUTE_PATTERNS, createEnvelope, FILE_EXPLORER_ROUTE_MANIFEST, type GuiAppActionId, type GuiAppActionJobSummary, STATUS_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
+import { APP_ACTION_ROUTE_MANIFEST, APP_ACTION_STATUS_ROUTE_MANIFEST, BANNED_ROUTE_PATTERNS, createEnvelope, FILE_EXPLORER_ROUTE_MANIFEST, type GuiAppActionId, type GuiAppActionJobSummary, STATUS_ROUTE_MANIFEST, TAMBO_PROVIDER_CONFIG, TAMBO_PROXY_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
 import { readFileExplorer } from "./file-adapter";
 import { readStatus, readVaultStatus } from "./status-adapter";
 
@@ -51,6 +51,22 @@ export function createGuiApiApp() {
 
   app.get(VAULT_STATUS_ROUTE_MANIFEST.route, (context) => {
     return context.json(readVaultStatus());
+  });
+
+  app.get(TAMBO_PROXY_ROUTE_MANIFEST.route, (context) => {
+    const tenantRef = context.req.query("tenant_ref") ?? "local";
+    const workspaceRef = context.req.query("workspace_ref") ?? "aidevops";
+    const sessionRef = context.req.query("session_ref") ?? "conversation:local";
+
+    return context.json(createEnvelope({
+      operation_id: TAMBO_PROXY_ROUTE_MANIFEST.operation_id,
+      source: { surface: "conversations", authority: "server-side Tambo proxy metadata", path_refs: ["packages/gui-shared/src/tambo.ts"] },
+      data: {
+        ...TAMBO_PROVIDER_CONFIG,
+        thread_key_ref: `${tenantRef}:${workspaceRef}:${sessionRef}`,
+      },
+      warnings: ["Tambo provider secrets stay server-side; this route exposes component metadata and scoped thread keys only."],
+    }));
   });
 
   app.post(APP_ACTION_ROUTE_MANIFEST.route, (context) => {

--- a/packages/gui-api/tests/security.test.ts
+++ b/packages/gui-api/tests/security.test.ts
@@ -24,6 +24,17 @@ describe("API trust boundary", () => {
     expect(containsSecretSentinel(body)).toBe(false);
   });
 
+  test("Tambo provider route exposes metadata without browser secrets", async () => {
+    const response = await app.request("/api/tambo/session?tenant_ref=local&workspace_ref=aidevops&session_ref=channel-general");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.secret_policy).toBe("server_only_no_browser_tokens");
+    expect(body.data).not.toHaveProperty("api_key");
+    expect(body.data).not.toHaveProperty("authorization");
+    expect(containsSecretSentinel(body)).toBe(false);
+  });
+
   test("file explorer rejects path traversal outside allowlisted roots", async () => {
     const response = await app.request("/api/files/agents?path=../../.ssh");
     const body = await response.json();

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -1,6 +1,6 @@
 export type GuiRouteClassification = "read" | "write" | "destructive";
 
-export type GuiOperationId = "setup.status.read" | "capabilities.read" | "filesystem.read" | "vault.status.read" | "apps.action.run" | "apps.action.status";
+export type GuiOperationId = "setup.status.read" | "capabilities.read" | "filesystem.read" | "vault.status.read" | "apps.action.run" | "apps.action.status" | "tambo.session.read";
 
 export type GuiFileRootId = "agents" | "config" | "localSetup" | "git";
 

--- a/packages/gui-shared/src/index.ts
+++ b/packages/gui-shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./contracts";
 export * from "./fixtures";
 export * from "./notifications";
+export * from "./tambo";

--- a/packages/gui-shared/src/tambo.ts
+++ b/packages/gui-shared/src/tambo.ts
@@ -1,0 +1,224 @@
+import type { GuiConversationScope, GuiRouteManifest } from "./contracts";
+
+export type GuiTamboComponentName = "TaskCard" | "PullRequestCard" | "CICheckSummary" | "WorkerStatusCard" | "DeploymentStatusCard" | "RepoHealthCard" | "ApprovalPromptCard";
+
+export type GuiTamboComponentMode = "read_only" | "request_only";
+
+export type GuiTamboPropType = "string" | "number" | "boolean" | "string_array";
+
+export interface GuiTamboPropSchema {
+  type: GuiTamboPropType;
+  required: boolean;
+}
+
+export interface GuiTamboComponentSchema {
+  name: GuiTamboComponentName;
+  description: string;
+  mode: GuiTamboComponentMode;
+  additionalProperties: false;
+  properties: Record<string, GuiTamboPropSchema>;
+}
+
+export interface GuiTamboComponentPayload {
+  component: GuiTamboComponentName;
+  tenant_ref: string;
+  session_ref: string;
+  read_only: boolean;
+  props: Record<string, unknown>;
+}
+
+export interface GuiTamboValidationResult {
+  ok: boolean;
+  component: GuiTamboComponentName | null;
+  props: Record<string, unknown>;
+  errors: string[];
+}
+
+export interface GuiTamboProviderConfig {
+  provider: "tambo";
+  proxy_route: string;
+  secret_policy: "server_only_no_browser_tokens";
+  thread_key_policy: "tenant_workspace_session_scoped";
+  components: GuiTamboComponentSchema[];
+  deferred_interactables: string[];
+}
+
+export const TAMBO_PROXY_ROUTE_MANIFEST: GuiRouteManifest = {
+  route: "/api/tambo/session",
+  method: "GET",
+  operation_id: "tambo.session.read",
+  classification: "read",
+  source_surface: "conversations",
+  adapter: "tambo.readProviderConfig",
+  command_pattern: ["server-proxied", "metadata-only", "no-browser-secrets"],
+  redactions: ["secret_values", "credential_paths", "private_key_material", "tambo_api_keys"],
+};
+
+export const TAMBO_COMPONENT_SCHEMAS: readonly GuiTamboComponentSchema[] = [
+  {
+    name: "TaskCard",
+    description: "Read-only task or issue status card.",
+    mode: "read_only",
+    additionalProperties: false,
+    properties: {
+      title: { type: "string", required: true },
+      status: { type: "string", required: true },
+      priority: { type: "string", required: false },
+      owner: { type: "string", required: false },
+      repo: { type: "string", required: false },
+      reference: { type: "string", required: false },
+    },
+  },
+  {
+    name: "PullRequestCard",
+    description: "Read-only pull request summary card.",
+    mode: "read_only",
+    additionalProperties: false,
+    properties: {
+      title: { type: "string", required: true },
+      status: { type: "string", required: true },
+      branch: { type: "string", required: false },
+      checks: { type: "string", required: false },
+      review: { type: "string", required: false },
+      reference: { type: "string", required: false },
+    },
+  },
+  {
+    name: "CICheckSummary",
+    description: "Read-only CI status summary card.",
+    mode: "read_only",
+    additionalProperties: false,
+    properties: {
+      status: { type: "string", required: true },
+      passed: { type: "number", required: true },
+      failed: { type: "number", required: true },
+      pending: { type: "number", required: false },
+      summary: { type: "string", required: false },
+    },
+  },
+  {
+    name: "WorkerStatusCard",
+    description: "Read-only worker progress card.",
+    mode: "read_only",
+    additionalProperties: false,
+    properties: {
+      worker: { type: "string", required: true },
+      status: { type: "string", required: true },
+      task: { type: "string", required: false },
+      progress: { type: "number", required: false },
+      blockers: { type: "string_array", required: false },
+    },
+  },
+  {
+    name: "DeploymentStatusCard",
+    description: "Read-only deployment environment status card.",
+    mode: "read_only",
+    additionalProperties: false,
+    properties: {
+      environment: { type: "string", required: true },
+      status: { type: "string", required: true },
+      version: { type: "string", required: false },
+      health: { type: "string", required: false },
+    },
+  },
+  {
+    name: "RepoHealthCard",
+    description: "Read-only repository health card.",
+    mode: "read_only",
+    additionalProperties: false,
+    properties: {
+      repo: { type: "string", required: true },
+      status: { type: "string", required: true },
+      open_prs: { type: "number", required: false },
+      failing_checks: { type: "number", required: false },
+      notes: { type: "string_array", required: false },
+    },
+  },
+  {
+    name: "ApprovalPromptCard",
+    description: "Request-only approval card. Mutating approval execution is deferred until audited approval tooling exists.",
+    mode: "request_only",
+    additionalProperties: false,
+    properties: {
+      action: { type: "string", required: true },
+      reason: { type: "string", required: true },
+      risk: { type: "string", required: true },
+      requested_by: { type: "string", required: false },
+      disabled: { type: "boolean", required: true },
+    },
+  },
+] as const;
+
+export const TAMBO_PROVIDER_CONFIG: GuiTamboProviderConfig = {
+  provider: "tambo",
+  proxy_route: TAMBO_PROXY_ROUTE_MANIFEST.route,
+  secret_policy: "server_only_no_browser_tokens",
+  thread_key_policy: "tenant_workspace_session_scoped",
+  components: [...TAMBO_COMPONENT_SCHEMAS],
+  deferred_interactables: ["mutating approvals", "deployment actions", "PR merge/retry actions", "worker dispatch writes"],
+};
+
+export function validateTamboComponentPayload(payload: unknown, scope: GuiConversationScope): GuiTamboValidationResult {
+  if (!isRecord(payload)) {
+    return invalid(null, {}, "payload_not_object");
+  }
+  if (typeof payload.component !== "string") {
+    return invalid(null, {}, "component_missing");
+  }
+  const schema = TAMBO_COMPONENT_SCHEMAS.find((candidate) => candidate.name === payload.component);
+  if (schema === undefined) {
+    return invalid(null, {}, "component_not_registered");
+  }
+  if (payload.tenant_ref !== scope.tenant_ref) {
+    return invalid(schema.name, {}, "tenant_scope_mismatch");
+  }
+  if (typeof payload.session_ref !== "string" || payload.session_ref.length === 0) {
+    return invalid(schema.name, {}, "session_ref_missing");
+  }
+  if (payload.read_only !== true) {
+    return invalid(schema.name, {}, "component_not_read_only");
+  }
+  if (!isRecord(payload.props)) {
+    return invalid(schema.name, {}, "props_not_object");
+  }
+
+  const errors: string[] = [];
+  const props = payload.props;
+  for (const key of Object.keys(props)) {
+    if (schema.properties[key] === undefined) {
+      errors.push(`unexpected_prop:${key}`);
+    }
+  }
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
+    const value = props[key];
+    if (value === undefined) {
+      if (propSchema.required) {
+        errors.push(`missing_prop:${key}`);
+      }
+      continue;
+    }
+    if (!valueMatchesType(value, propSchema.type)) {
+      errors.push(`invalid_prop:${key}`);
+    }
+  }
+  if (schema.name === "ApprovalPromptCard" && props.disabled !== true) {
+    errors.push("approval_prompt_must_be_disabled");
+  }
+
+  return { ok: errors.length === 0, component: schema.name, props, errors };
+}
+
+function invalid(component: GuiTamboComponentName | null, props: Record<string, unknown>, error: string): GuiTamboValidationResult {
+  return { ok: false, component, props, errors: [error] };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function valueMatchesType(value: unknown, type: GuiTamboPropType): boolean {
+  if (type === "string_array") {
+    return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+  }
+  return typeof value === type;
+}

--- a/packages/gui-shared/tests/schema.test.ts
+++ b/packages/gui-shared/tests/schema.test.ts
@@ -9,7 +9,10 @@ import {
   sortConversationMessageParts,
   sortConversationMessages,
   STATUS_ROUTE_MANIFEST,
+  TAMBO_COMPONENT_SCHEMAS,
+  TAMBO_PROXY_ROUTE_MANIFEST,
   statusFixture,
+  validateTamboComponentPayload,
   VAULT_STATUS_ROUTE_MANIFEST,
   type GuiConversationThread,
 } from "../src";
@@ -30,6 +33,26 @@ describe("GUI shared schema contracts", () => {
     expect(isReadOnlyManifest(VAULT_STATUS_ROUTE_MANIFEST)).toBe(true);
     expect(VAULT_STATUS_ROUTE_MANIFEST.operation_id).toBe("vault.status.read");
     expect(VAULT_STATUS_ROUTE_MANIFEST.redactions).toContain("vault_passphrases");
+  });
+
+  test("Tambo route and registered component schemas are strict and read-safe", () => {
+    expect(isReadOnlyManifest(TAMBO_PROXY_ROUTE_MANIFEST)).toBe(true);
+    expect(TAMBO_PROXY_ROUTE_MANIFEST.redactions).toContain("tambo_api_keys");
+    expect(TAMBO_COMPONENT_SCHEMAS.map((schema) => schema.name)).toEqual(["TaskCard", "PullRequestCard", "CICheckSummary", "WorkerStatusCard", "DeploymentStatusCard", "RepoHealthCard", "ApprovalPromptCard"]);
+    expect(TAMBO_COMPONENT_SCHEMAS.every((schema) => schema.additionalProperties === false)).toBe(true);
+  });
+
+  test("Tambo payload validation enforces tenant scope and strict props", () => {
+    const scope = { tenant_ref: "tenant:local-owner", workspace_ref: "workspace:aidevops", repo_ref: "repo:marcusquinn/aidevops" };
+    const valid = validateTamboComponentPayload({ component: "TaskCard", tenant_ref: "tenant:local-owner", session_ref: "conversation:ai-session-1", read_only: true, props: { title: "Implement Tambo", status: "in review", reference: "#25713" } }, scope);
+    const wrongTenant = validateTamboComponentPayload({ component: "TaskCard", tenant_ref: "tenant:other", session_ref: "conversation:ai-session-1", read_only: true, props: { title: "Implement Tambo", status: "in review" } }, scope);
+    const extraProp = validateTamboComponentPayload({ component: "TaskCard", tenant_ref: "tenant:local-owner", session_ref: "conversation:ai-session-1", read_only: true, props: { title: "Implement Tambo", status: "in review", href: "not-allowed" } }, scope);
+    const activeApproval = validateTamboComponentPayload({ component: "ApprovalPromptCard", tenant_ref: "tenant:local-owner", session_ref: "conversation:ai-session-1", read_only: true, props: { action: "Merge", reason: "Checks passed", risk: "high", disabled: false } }, scope);
+
+    expect(valid.ok).toBe(true);
+    expect(wrongTenant.errors).toContain("tenant_scope_mismatch");
+    expect(extraProp.errors).toContain("unexpected_prop:href");
+    expect(activeApproval.errors).toContain("approval_prompt_must_be_disabled");
   });
 
   test("status envelope preserves source and redaction metadata", () => {

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -8,6 +8,7 @@ import { inventorySurfaceConfigs, surfaceIds, text } from "./app-model";
 import { CommandPalette, type CommandPaletteSelection, commandPaletteShortcutQuery } from "./CommandPalette";
 import { CommsConversationSurface } from "./CommsConversationSurface";
 import { FileExplorerSurface } from "./FileExplorerSurface";
+import { TamboConversationPart } from "./GenUiCards";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
 import { AiProvidersSurface, LocalReposSurface, LockedVaultGate, OverviewSurface, PlannedSurface, ProjectsSurface, SecuritySurface, VaultSurface } from "./StatusSurfaces";
 import { isVaultSurfaceLocked, vaultCollectionForSurface } from "./VaultBadges";
@@ -289,6 +290,10 @@ function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { s
           <AttachmentCard label="Context attachment" detail={selectedRepo ? `Selected repo context: ${selectedRepo.path_ref}` : "No local repos were discovered yet."} />
           <MessageMarker label="Reasoning" detail="Reasoning disclosure, tool status, sources, retries, errors, and token usage render here when the AI transport supplies those parts." />
           <ToolStatusCard />
+          <TamboConversationPart
+            part={{ id: "ai-session-tambo-preview", message_id: "ai-session-preview", kind: "tambo_component", ordinal: 1, text: null, payload_json: { component: "RepoHealthCard", tenant_ref: "local", session_ref: selectedSession?.id_ref ?? "ai-session-preview", read_only: true, props: { repo: selectedRepo?.name ?? "local workspace", status: "ready for Tambo cards", open_prs: 0, failing_checks: 0, notes: ["Server-proxied provider metadata", "Read-only schemas first"] } }, file_ref: null, source_ref: "tambo:ai-session-preview" }}
+            scope={{ tenant_ref: "local", workspace_ref: "aidevops", repo_ref: selectedRepo?.slug ?? null }}
+          />
         </div>
         <form className="chat-composer ai-composer" aria-label="AI prompt composer" data-tour="ai-composer">
           <button disabled title="Attachments need the audited upload/context adapter" type="button"><FiPaperclip aria-hidden="true" /> Attach</button>

--- a/packages/gui-web/src/CommsConversationSurface.tsx
+++ b/packages/gui-web/src/CommsConversationSurface.tsx
@@ -1,5 +1,6 @@
 import { FiAtSign, FiHash, FiMessageSquare, FiSearch } from "react-icons/fi";
 import { sortConversationMessageParts, sortConversationMessages, type GuiConversationMessage, type GuiConversationMessagePart, type GuiConversationThread } from "../../gui-shared/src";
+import { TamboConversationPart } from "./GenUiCards";
 import { text } from "./app-model";
 import { conversationThreads } from "./conversation-fixtures";
 
@@ -91,11 +92,18 @@ function ConversationMessageRow({ message, parts, thread }: { message: GuiConver
   return (
     <article className={`chat-bubble ${speaker}`} data-sender-kind={message.sender_kind}>
       <strong>{sender?.display_name ?? message.sender_kind}</strong>
-      {parts.map((part) => <p key={part.id}>{part.text ?? part.kind}</p>)}
+      {parts.map((part) => <ConversationPart key={part.id} part={part} thread={thread} />)}
       <small>{message.status} · {message.created_at}</small>
       {reactions.length > 0 ? <div className="reaction-row">{reactions.map((reaction) => <span key={reaction.id}>{reaction.reaction}</span>)}</div> : null}
     </article>
   );
+}
+
+function ConversationPart({ part, thread }: { part: GuiConversationMessagePart; thread: GuiConversationThread }) {
+  if (part.kind === "tambo_component" || part.kind === "approval_prompt") {
+    return <TamboConversationPart part={part} scope={thread.conversation.scope} />;
+  }
+  return <p>{part.text ?? part.kind}</p>;
 }
 
 function participantSummary(thread: GuiConversationThread): string {

--- a/packages/gui-web/src/GenUiCards.tsx
+++ b/packages/gui-web/src/GenUiCards.tsx
@@ -1,0 +1,52 @@
+import { validateTamboComponentPayload, type GuiConversationMessagePart, type GuiConversationScope, type GuiTamboValidationResult } from "../../gui-shared/src";
+
+export function TamboConversationPart({ part, scope }: { part: GuiConversationMessagePart; scope: GuiConversationScope }) {
+  const validation = validateTamboComponentPayload(part.payload_json, scope);
+
+  if (!validation.ok) {
+    return <div className="genui-card genui-card-invalid" data-genui-component={validation.component ?? "unknown"} role="note"><strong>Unsupported DevOps card</strong><small>{validation.errors.join(", ")}</small></div>;
+  }
+
+  return <DevOpsCard validation={validation} />;
+}
+
+function DevOpsCard({ validation }: { validation: GuiTamboValidationResult }) {
+  const props = validation.props;
+  const entries = Object.entries(props).filter(([key]) => key !== "title" && key !== "disabled");
+
+  return (
+    <section className="genui-card" data-genui-component={validation.component ?? "unknown"} aria-label={`${validation.component} DevOps card`}>
+      <header>
+        <p className="eyebrow">Tambo GenUI · read-only</p>
+        <h3>{stringProp(props.title) ?? validation.component}</h3>
+      </header>
+      <dl>
+        {entries.map(([key, value]) => <CardProperty key={key} name={key} value={value} />)}
+      </dl>
+      {validation.component === "ApprovalPromptCard" ? <p className="genui-deferred">Approval execution is deferred until audited approval tooling exists.</p> : null}
+    </section>
+  );
+}
+
+function CardProperty({ name, value }: { name: string; value: unknown }) {
+  return (
+    <div>
+      <dt>{name.replaceAll("_", " ")}</dt>
+      <dd>{formatValue(value)}</dd>
+    </div>
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "—";
+}
+
+function stringProp(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}

--- a/packages/gui-web/src/conversation-fixtures.ts
+++ b/packages/gui-web/src/conversation-fixtures.ts
@@ -11,10 +11,12 @@ export const conversationThreads: GuiConversationThread[] = [
     messages: [
       { id: "message-general-1", conversation_id: "channel-general", sender_participant_id: "participant-system", sender_kind: "system", sequence: 1, status: "sent", usage: null, created_at: "2026-06-27T12:00:00Z", edited_at: null },
       { id: "message-general-2", conversation_id: "channel-general", sender_participant_id: "participant-ai", sender_kind: "ai_assistant", sequence: 2, status: "delivered", usage: { provider_ref: "local", model_ref: "workflow-summary", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost_ref: null }, created_at: "2026-06-27T12:15:00Z", edited_at: null },
+      { id: "message-general-3", conversation_id: "channel-general", sender_participant_id: "participant-ai", sender_kind: "ai_assistant", sequence: 3, status: "delivered", usage: { provider_ref: "tambo", model_ref: "devops-card", input_tokens: 0, output_tokens: 0, total_tokens: 0, cost_ref: null }, created_at: "2026-06-27T12:18:00Z", edited_at: null },
     ],
     parts: [
       { id: "part-general-1", message_id: "message-general-1", kind: "event_marker", ordinal: 1, text: "#general is ready for repo, deployment, review, and incident coordination.", payload_json: null, file_ref: null, source_ref: "seed" },
       { id: "part-general-2", message_id: "message-general-2", kind: "text", ordinal: 1, text: "Mention @AI DevOps or a worker to turn a thread into an audited task once write routes land.", payload_json: null, file_ref: null, source_ref: null },
+      { id: "part-general-3", message_id: "message-general-3", kind: "tambo_component", ordinal: 1, text: null, payload_json: { component: "TaskCard", tenant_ref: "local", session_ref: "channel-general", read_only: true, props: { title: "Integrate Tambo GenUI cards", status: "read-only preview", priority: "high", owner: "AI DevOps", repo: "aidevops", reference: "#25713" } }, file_ref: null, source_ref: "tambo:seed" },
     ],
     reactions: [{ id: "reaction-general-1", message_id: "message-general-2", participant_id: "participant-local", reaction: "ack", created_at: "2026-06-27T12:16:00Z" }],
     read_states: [{ conversation_id: "channel-general", participant_id: "participant-local", last_read_message_id: "message-general-1", last_read_sequence: 1, updated_at: "2026-06-27T12:10:00Z" }],
@@ -31,7 +33,10 @@ export const conversationThreads: GuiConversationThread[] = [
     conversation: { id: "dm-ai-devops", type: "dm", title: "AI DevOps", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "seed:dms/ai-devops", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T12:40:00Z" },
     participants: [{ id: "participant-dm-local", conversation_id: "dm-ai-devops", kind: "human", display_name: "Local user", identity_ref: "local:user", agent_ref: null, worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }, { id: "participant-dm-ai", conversation_id: "dm-ai-devops", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
     messages: [{ id: "message-dm-1", conversation_id: "dm-ai-devops", sender_participant_id: "participant-dm-ai", sender_kind: "ai_assistant", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T12:40:00Z", edited_at: null }],
-    parts: [{ id: "part-dm-1", message_id: "message-dm-1", kind: "text", ordinal: 1, text: "Direct support threads share the same message parts, participants, reactions, and read state as channels.", payload_json: null, file_ref: null, source_ref: null }],
+    parts: [
+      { id: "part-dm-1", message_id: "message-dm-1", kind: "text", ordinal: 1, text: "Direct support threads share the same message parts, participants, reactions, and read state as channels.", payload_json: null, file_ref: null, source_ref: null },
+      { id: "part-dm-2", message_id: "message-dm-1", kind: "approval_prompt", ordinal: 2, text: null, payload_json: { component: "ApprovalPromptCard", tenant_ref: "local", session_ref: "dm-ai-devops", read_only: true, props: { action: "Dispatch worker", reason: "Requires audited approval backend before mutation", risk: "medium", requested_by: "AI DevOps", disabled: true } }, file_ref: null, source_ref: "tambo:seed" },
+    ],
     reactions: [],
     read_states: [{ conversation_id: "dm-ai-devops", participant_id: "participant-dm-local", last_read_message_id: null, last_read_sequence: 0, updated_at: "2026-06-27T12:00:00Z" }],
   },

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1562,6 +1562,48 @@ code {
   border-style: dashed;
 }
 
+.genui-card {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-accent);
+  border-radius: 14px;
+  display: grid;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 12px;
+}
+
+.genui-card-invalid {
+  border-color: var(--border-warning);
+}
+
+.genui-card h3 {
+  margin: 0;
+}
+
+.genui-card dl {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  margin: 0;
+}
+
+.genui-card dt {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  text-transform: uppercase;
+}
+
+.genui-card dd {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.genui-deferred {
+  border-top: 1px dashed var(--border);
+  color: var(--text-muted);
+  padding-top: 8px;
+}
+
 .conversation-list-panel {
   grid-template-rows: auto auto auto minmax(0, 1fr);
 }

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -126,6 +126,8 @@ describe("dashboard shell", () => {
     expect(html).toContain("Create worker task");
     expect(html).toContain("Context attachment");
     expect(html).toContain("Tool status");
+    expect(html).toContain("data-genui-component=\"RepoHealthCard\"");
+    expect(html).toContain("ready for Tambo cards");
     expect(html).toContain("MessageScroller-compatible transcript");
     expect(html).toContain("New, rename, pin, archive, delete, share, and export");
   });
@@ -138,12 +140,33 @@ describe("dashboard shell", () => {
     expect(channelHtml).toContain("general");
     expect(channelHtml).toContain("worker-feed");
     expect(channelHtml).toContain("data-sender-kind=\"system\"");
+    expect(channelHtml).toContain("data-genui-component=\"TaskCard\"");
+    expect(channelHtml).toContain("Integrate Tambo GenUI cards");
     expect(channelHtml).toContain("ack");
     expect(channelHtml).toContain("3 members");
     expect(dmHtml).toContain("Direct Messages");
     expect(dmHtml).toContain("AI DevOps");
     expect(dmHtml).toContain("Direct support threads share the same message parts");
+    expect(dmHtml).toContain("data-genui-component=\"ApprovalPromptCard\"");
+    expect(dmHtml).toContain("Approval execution is deferred until audited approval tooling exists.");
     expect(dmHtml).toContain("Search channels, DMs, mentions");
+  });
+
+  test("rejects unsafe Tambo component payloads during conversation rendering", () => {
+    const html = renderToStaticMarkup(createElement(CommsConversationSurface, {
+      mode: "channels",
+      threads: [{
+        conversation: { id: "channel-unsafe", type: "channel", title: "unsafe", scope: { tenant_ref: "local", workspace_ref: "aidevops", repo_ref: null }, source_ref: "test", status: "read_only", created_at: "2026-06-27T00:00:00Z", updated_at: "2026-06-27T00:00:00Z" },
+        participants: [{ id: "participant-ai", conversation_id: "channel-unsafe", kind: "ai_assistant", display_name: "AI DevOps", identity_ref: null, agent_ref: "aidevops", worker_ref: null, membership_state: "active", joined_at: "2026-06-27T00:00:00Z" }],
+        messages: [{ id: "message-unsafe", conversation_id: "channel-unsafe", sender_participant_id: "participant-ai", sender_kind: "ai_assistant", sequence: 1, status: "delivered", usage: null, created_at: "2026-06-27T00:00:00Z", edited_at: null }],
+        parts: [{ id: "part-unsafe", message_id: "message-unsafe", kind: "tambo_component", ordinal: 1, text: null, payload_json: { component: "TaskCard", tenant_ref: "other", session_ref: "channel-unsafe", read_only: true, props: { title: "Unsafe", status: "blocked", href: "not allowed" } }, file_ref: null, source_ref: "test" }],
+        reactions: [],
+        read_states: [],
+      } satisfies GuiConversationThread],
+    }));
+
+    expect(html).toContain("Unsupported DevOps card");
+    expect(html).toContain("tenant_scope_mismatch");
   });
 
   test("renders conversation threads when optional collections are absent", () => {


### PR DESCRIPTION
## Summary
- Adds a server-side Tambo provider contract and read-only component registry for DevOps cards.
- Renders validated `tambo_component` message parts inline across AI sessions, channels, and DMs.
- Adds strict schema, tenant isolation, unsafe payload, and static render coverage for Tambo cards.

## Verification
- `bun test packages/gui-shared/tests packages/gui-api/tests/security.test.ts packages/gui-web/tests` (blocked locally: `bun: command not found`)
- `bun run typecheck` (blocked locally: `bun: command not found`)
- `npx --no-install tsc --noEmit` (blocked locally: TypeScript compiler is not installed in this worktree)

Resolves #25713

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.37 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 64,752 tokens on this as a headless worker.