### PR TITLE
GH#25918: fix: reduce Tambo validator complexity

### DIFF
--- a/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
+++ b/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#25918: CodeFactor reported the Tambo payload
+# validator range in packages/gui-shared/src/tambo.ts. Keep the exported
+# validator as a compact orchestration entrypoint and push validation branches
+# into focused helpers that the package tests cover directly.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TAMBO_FILE="${REPO_ROOT}/packages/gui-shared/src/tambo.ts"
+
+if [[ ! -f "$TAMBO_FILE" ]]; then
+	printf 'FAIL: missing Tambo schema file: %s\n' "$TAMBO_FILE" >&2
+	exit 1
+fi
+
+python3 - "$TAMBO_FILE" <<'PY'
+import re
+import sys
+
+tambo_path = sys.argv[1]
+source = open(tambo_path, encoding="utf-8").read().splitlines()
+
+start = None
+brace_depth = 0
+body_lines = []
+for line_number, line in enumerate(source, start=1):
+    if start is None and line.startswith("export function validateTamboComponentPayload"):
+        start = line_number
+    if start is None:
+        continue
+    body_lines.append(line)
+    brace_depth += line.count("{") - line.count("}")
+    if brace_depth == 0 and line_number > start:
+        break
+
+if start is None:
+    print("FAIL: validateTamboComponentPayload export not found", file=sys.stderr)
+    sys.exit(1)
+
+body = "\n".join(body_lines)
+line_count = len(body_lines)
+branch_count = len(re.findall(r"\b(if|for|while|switch)\b", body))
+
+if line_count > 12:
+    print(f"FAIL: validateTamboComponentPayload is {line_count} lines; keep <= 12", file=sys.stderr)
+    sys.exit(1)
+if branch_count > 1:
+    print(f"FAIL: validateTamboComponentPayload has {branch_count} branches; keep <= 1", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: Tambo validator entrypoint remains CodeFactor-friendly")
+PY

--- a/packages/gui-shared/src/tambo.ts
+++ b/packages/gui-shared/src/tambo.ts
@@ -159,53 +159,89 @@ export const TAMBO_PROVIDER_CONFIG: GuiTamboProviderConfig = {
 };
 
 export function validateTamboComponentPayload(payload: unknown, scope: GuiConversationScope): GuiTamboValidationResult {
+  const envelope = validateTamboPayloadEnvelope(payload, scope);
+  if (!envelope.ok) {
+    return envelope.result;
+  }
+
+  const errors = validateTamboComponentProps(envelope.schema, envelope.props);
+  return { ok: errors.length === 0, component: envelope.schema.name, props: envelope.props, errors };
+}
+
+type TamboPayloadEnvelopeValidation =
+  | { ok: true; schema: GuiTamboComponentSchema; props: Record<string, unknown> }
+  | { ok: false; result: GuiTamboValidationResult };
+
+function validateTamboPayloadEnvelope(payload: unknown, scope: GuiConversationScope): TamboPayloadEnvelopeValidation {
   if (!isRecord(payload)) {
-    return invalid(null, {}, "payload_not_object");
+    return { ok: false, result: invalid(null, {}, "payload_not_object") };
   }
   if (typeof payload.component !== "string") {
-    return invalid(null, {}, "component_missing");
+    return { ok: false, result: invalid(null, {}, "component_missing") };
   }
-  const schema = TAMBO_COMPONENT_SCHEMAS.find((candidate) => candidate.name === payload.component);
+
+  const schema = findTamboComponentSchema(payload.component);
   if (schema === undefined) {
-    return invalid(null, {}, "component_not_registered");
+    return { ok: false, result: invalid(null, {}, "component_not_registered") };
   }
-  if (payload.tenant_ref !== scope.tenant_ref) {
-    return invalid(schema.name, {}, "tenant_scope_mismatch");
-  }
-  if (typeof payload.session_ref !== "string" || payload.session_ref.length === 0) {
-    return invalid(schema.name, {}, "session_ref_missing");
-  }
-  if (payload.read_only !== true) {
-    return invalid(schema.name, {}, "component_not_read_only");
+
+  const envelopeError = validateScopedTamboEnvelope(payload, scope);
+  if (envelopeError !== null) {
+    return { ok: false, result: invalid(schema.name, {}, envelopeError) };
   }
   if (!isRecord(payload.props)) {
-    return invalid(schema.name, {}, "props_not_object");
+    return { ok: false, result: invalid(schema.name, {}, "props_not_object") };
   }
 
-  const errors: string[] = [];
-  const props = payload.props;
-  for (const key of Object.keys(props)) {
-    if (schema.properties[key] === undefined) {
-      errors.push(`unexpected_prop:${key}`);
-    }
+  return { ok: true, schema, props: payload.props };
+}
+
+function findTamboComponentSchema(component: string): GuiTamboComponentSchema | undefined {
+  return TAMBO_COMPONENT_SCHEMAS.find((candidate) => candidate.name === component);
+}
+
+function validateScopedTamboEnvelope(payload: Record<string, unknown>, scope: GuiConversationScope): string | null {
+  if (payload.tenant_ref !== scope.tenant_ref) {
+    return "tenant_scope_mismatch";
   }
-  for (const [key, propSchema] of Object.entries(schema.properties)) {
+  if (typeof payload.session_ref !== "string" || payload.session_ref.length === 0) {
+    return "session_ref_missing";
+  }
+  if (payload.read_only !== true) {
+    return "component_not_read_only";
+  }
+  return null;
+}
+
+function validateTamboComponentProps(schema: GuiTamboComponentSchema, props: Record<string, unknown>): string[] {
+  return [
+    ...findUnexpectedTamboProps(schema, props),
+    ...findInvalidTamboProps(schema, props),
+    ...findTamboComponentSpecificErrors(schema, props),
+  ];
+}
+
+function findUnexpectedTamboProps(schema: GuiTamboComponentSchema, props: Record<string, unknown>): string[] {
+  return Object.keys(props)
+    .filter((key) => schema.properties[key] === undefined)
+    .map((key) => `unexpected_prop:${key}`);
+}
+
+function findInvalidTamboProps(schema: GuiTamboComponentSchema, props: Record<string, unknown>): string[] {
+  return Object.entries(schema.properties).flatMap(([key, propSchema]) => {
     const value = props[key];
     if (value === undefined) {
-      if (propSchema.required) {
-        errors.push(`missing_prop:${key}`);
-      }
-      continue;
+      return propSchema.required ? [`missing_prop:${key}`] : [];
     }
-    if (!valueMatchesType(value, propSchema.type)) {
-      errors.push(`invalid_prop:${key}`);
-    }
-  }
-  if (schema.name === "ApprovalPromptCard" && props.disabled !== true) {
-    errors.push("approval_prompt_must_be_disabled");
-  }
+    return valueMatchesType(value, propSchema.type) ? [] : [`invalid_prop:${key}`];
+  });
+}
 
-  return { ok: errors.length === 0, component: schema.name, props, errors };
+function findTamboComponentSpecificErrors(schema: GuiTamboComponentSchema, props: Record<string, unknown>): string[] {
+  if (schema.name === "ApprovalPromptCard" && props.disabled !== true) {
+    return ["approval_prompt_must_be_disabled"];
+  }
+  return [];
 }
 
 function invalid(component: GuiTamboComponentName | null, props: Record<string, unknown>, error: string): GuiTamboValidationResult {


### PR DESCRIPTION
## Summary

Refactored validateTamboComponentPayload into focused envelope, schema, and props helpers; added a GH#25918 CodeFactor regression guard for the exported validator range.

## Files Changed

.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh,packages/gui-shared/src/tambo.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: bash .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh; PASS: shellcheck .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh; PASS: pre-commit hook during final commit; NOT RUN: bun test packages/gui-shared/tests (bun not installed); NOT RUN: npm run typecheck --if-present (tsc not installed)

Resolves #25918


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.37 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 68,182 tokens on this as a headless worker.