### PR TITLE
t18034: feat: add Pulse Workers observability shell

### DIFF
--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -3,6 +3,7 @@ import type { GuiMachineSummary, GuiStatusData } from "@aidevops/gui-shared";
 import { useEffect, useState, type ReactNode } from "react";
 import type { IconType } from "react-icons";
 import {
+  FiActivity,
   FiBookmark,
   FiBox,
   FiBriefcase,
@@ -41,6 +42,7 @@ import { VaultPadlock, vaultCollectionForSurface } from "./VaultBadges";
 export { hueFromInputValue } from "./AppearanceControls";
 
 const surfaceIcons: Record<SurfaceIconName, IconType> = {
+  activity: FiActivity,
   apps: FiBox,
   bookmark: FiBookmark,
   brand: FiBriefcase,

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -385,7 +385,7 @@ function SurfaceContent({ activeItem, activeSurface, fileRoot, openSurface, stat
     aiSessions: <AiSessionsSurface selectedRepoIndex={0} status={status} />,
     channels: <CommsConversationSurface mode="channels" />,
     directMessages: <CommsConversationSurface mode="directMessages" />,
-    workers: <PlannedSurface label={text.workers} detail={text.workersIntro} />,
+    workers: <PulseWorkersSurface />,
     repos: <PlannedSurface label={text.repos} detail={text.reposIntro} />,
     deployments: <PlannedSurface label={text.deployments} detail={text.deploymentsIntro} />,
     routines: <PlannedSurface label={text.routines} detail={text.routineDetail} />,
@@ -435,6 +435,118 @@ function SurfaceContent({ activeItem, activeSurface, fileRoot, openSurface, stat
   }
 
   return staticSurfaces[activeSurface] ?? null;
+}
+
+const pulseKpis = [
+  { label: "Healthy worker sessions · last 24h · all managed repos", value: "86%", detail: "18 of 21 sessions ended merged, closed, or intentionally deferred." },
+  { label: "Attention queue · last 24h · all managed repos", value: "5", detail: "Review stalls, API pressure, and CI capacity are grouped before raw events." },
+  { label: "Token and cost sample · last 24h · provider scope", value: "1.8M / $14", detail: "Provider/model totals stay metadata-only and exclude prompt or secret payloads." },
+  { label: "Systemic fixes created · trailing 7d · aidevops repo", value: "9", detail: "Blindspots become worker-ready follow-up tasks when patterns repeat." },
+] as const;
+
+const pulseAttentionItems = [
+  "2 PRs waiting on terminal CI results, not failures",
+  "1 worker loop matched stale-symptom diagnostics",
+  "GitHub API allowance below dispatch comfort threshold",
+] as const;
+
+const pulseFilters = ["Repo", "Event type", "Outcome", "Resource", "Provider / model", "Issue origin", "Author", "Author association"] as const;
+
+const pulseActivityRows = [
+  { time: "09:42", event: "Worker session", scope: "marcusquinn/aidevops #25912", outcome: "In progress", resource: "OpenCode · gpt-5.5", origin: "origin:interactive", actor: "MEMBER" },
+  { time: "09:18", event: "Review gate", scope: "PR #25909", outcome: "Merged", resource: "CI green · 42k tokens", origin: "aidevops-created", actor: "OWNER" },
+  { time: "08:51", event: "Community bug report", scope: "Issue #25876", outcome: "Needs maintainer review", resource: "REST budget ok", origin: "third-party", actor: "CONTRIBUTOR" },
+] as const;
+
+function PulseWorkersSurface(): ReactElement {
+  return (
+    <section className="pulse-workers-surface" aria-label={text.workers}>
+      <div className="planned-card pulse-hero">
+        <p className="eyebrow">Observability shell · fixture-backed · read-only</p>
+        <h2>{text.workers}</h2>
+        <p>{text.workersIntro}</p>
+        <div className="pulse-scope-strip" aria-label="Pulse scope and time range">
+          <span><strong>Period</strong> Last 24h · all managed repos</span>
+          <span><strong>Comparison</strong> Previous 24h baseline</span>
+          <span><strong>Sample</strong> 21 worker sessions · 184 events</span>
+          <span><strong>Trust boundary</strong> Metadata/status only; protected payloads excluded</span>
+        </div>
+      </div>
+      <section className="pulse-kpi-grid" aria-label="Pulse health summary">
+        {pulseKpis.map((kpi) => (
+          <article className="metric-card pulse-kpi-card" key={kpi.label}>
+            <span>{kpi.label}</span>
+            <strong>{kpi.value}</strong>
+            <p>{kpi.detail}</p>
+          </article>
+        ))}
+      </section>
+      <section className="pulse-layout" aria-label="Pulse observability hierarchy">
+        <article className="planned-card pulse-attention-panel">
+          <div className="split-heading">
+            <div>
+              <p className="eyebrow">Exceptions first</p>
+              <h3>Needs attention</h3>
+            </div>
+            <span className="count-pill">planned actions disabled</span>
+          </div>
+          <ul>
+            {pulseAttentionItems.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+          <button disabled title="Action routes need audited worker control APIs" type="button">Create systemic fix (planned)</button>
+        </article>
+        <article className="planned-card pulse-chart-panel">
+          <p className="eyebrow">Trends</p>
+          <h3>Health trend placeholder</h3>
+          <div className="pulse-chart-placeholder" aria-label="Chart placeholder showing health, queue, token, cost, API, and CI capacity trends">
+            <span>health</span><span>queue</span><span>tokens</span><span>cost</span><span>api</span><span>ci</span>
+          </div>
+          <p>Charts will derive from the canonical event stream: Pulse, workers, commands, CI, issues, PRs, reviews, and outcomes.</p>
+        </article>
+      </section>
+      <section className="planned-card pulse-activity-panel" aria-label="Unified activity stream">
+        <div className="split-heading">
+          <div>
+            <p className="eyebrow">Canonical stream</p>
+            <h3>Unified activity</h3>
+          </div>
+          <div className="pulse-filter-row" aria-label="Quick filters">
+            {pulseFilters.map((filter) => <button disabled key={filter} title={`${filter} filter is planned`} type="button">{filter}</button>)}
+          </div>
+        </div>
+        <div className="pulse-activity-table" role="table" aria-label="Pulse and worker events">
+          <div className="pulse-activity-row pulse-activity-header" role="row">
+            <span>When</span><span>Event</span><span>Scope</span><span>Outcome</span><span>Resource</span><span>Origin / actor</span>
+          </div>
+          {pulseActivityRows.map((row) => (
+            <article className="pulse-activity-row" role="row" key={`${row.time}-${row.scope}`}>
+              <span data-label="When">{row.time}</span>
+              <span data-label="Event">{row.event}</span>
+              <span data-label="Scope">{row.scope}</span>
+              <span data-label="Outcome">{row.outcome}</span>
+              <span data-label="Resource">{row.resource}</span>
+              <span data-label="Origin / actor">{row.origin} · {row.actor}</span>
+            </article>
+          ))}
+        </div>
+        <p className="notice compact-notice">Mobile activity cards replace the dense table on small screens. Detail drawer becomes a full-screen sheet on small screens, and terminal panel becomes full-screen later.</p>
+      </section>
+      <section className="pulse-layout" aria-label="Drilldown and planned actions">
+        <article className="planned-card pulse-drilldown-panel">
+          <p className="eyebrow">Drilldown placeholder</p>
+          <h3>What happened, when, why, how, who acted, and what resources were available</h3>
+          <p>Selected event details will connect timeline evidence, issue/PR/review context, provider/model/tokens/time/cost metadata, GitHub/API allowance, queue/concurrency, CI capacity, and local resource snapshots without exposing secrets.</p>
+        </article>
+        <article className="planned-card pulse-actions-panel">
+          <p className="eyebrow">Planned controls</p>
+          <h3>Actions stay disabled until audited routes land</h3>
+          <button disabled title="Terminal output needs a read-only command-output adapter" type="button">Open terminal output (planned)</button>
+          <button disabled title="Dispatch needs worker control and trust-boundary APIs" type="button">Redispatch worker (planned)</button>
+          <button disabled title="Persistence needs a write-action manifest and audit trail" type="button">Save systemic fix (planned)</button>
+        </article>
+      </section>
+    </section>
+  );
 }
 
 function HelpSurface(): ReactElement {

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -465,12 +465,12 @@ function PulseWorkersSurface(): ReactElement {
         <p className="eyebrow">Observability shell · fixture-backed · read-only</p>
         <h2>{text.workers}</h2>
         <p>{text.workersIntro}</p>
-        <div className="pulse-scope-strip" aria-label="Pulse scope and time range">
+        <section className="pulse-scope-strip" aria-label="Pulse scope and time range">
           <span><strong>Period</strong> Last 24h · all managed repos</span>
           <span><strong>Comparison</strong> Previous 24h baseline</span>
           <span><strong>Sample</strong> 21 worker sessions · 184 events</span>
           <span><strong>Trust boundary</strong> Metadata/status only; protected payloads excluded</span>
-        </div>
+        </section>
       </div>
       <section className="pulse-kpi-grid" aria-label="Pulse health summary">
         {pulseKpis.map((kpi) => (
@@ -498,7 +498,7 @@ function PulseWorkersSurface(): ReactElement {
         <article className="planned-card pulse-chart-panel">
           <p className="eyebrow">Trends</p>
           <h3>Health trend placeholder</h3>
-          <div className="pulse-chart-placeholder" aria-label="Chart placeholder showing health, queue, token, cost, API, and CI capacity trends">
+          <div className="pulse-chart-placeholder" aria-label="Chart placeholder showing health, queue, token, cost, API, and CI capacity trends" role="img">
             <span>health</span><span>queue</span><span>tokens</span><span>cost</span><span>api</span><span>ci</span>
           </div>
           <p>Charts will derive from the canonical event stream: Pulse, workers, commands, CI, issues, PRs, reviews, and outcomes.</p>
@@ -510,25 +510,29 @@ function PulseWorkersSurface(): ReactElement {
             <p className="eyebrow">Canonical stream</p>
             <h3>Unified activity</h3>
           </div>
-          <div className="pulse-filter-row" aria-label="Quick filters">
+          <section className="pulse-filter-row" aria-label="Quick filters">
             {pulseFilters.map((filter) => <button disabled key={filter} title={`${filter} filter is planned`} type="button">{filter}</button>)}
-          </div>
+          </section>
         </div>
-        <div className="pulse-activity-table" role="table" aria-label="Pulse and worker events">
-          <div className="pulse-activity-row pulse-activity-header" role="row">
-            <span>When</span><span>Event</span><span>Scope</span><span>Outcome</span><span>Resource</span><span>Origin / actor</span>
-          </div>
-          {pulseActivityRows.map((row) => (
-            <article className="pulse-activity-row" role="row" key={`${row.time}-${row.scope}`}>
-              <span data-label="When">{row.time}</span>
-              <span data-label="Event">{row.event}</span>
-              <span data-label="Scope">{row.scope}</span>
-              <span data-label="Outcome">{row.outcome}</span>
-              <span data-label="Resource">{row.resource}</span>
-              <span data-label="Origin / actor">{row.origin} · {row.actor}</span>
-            </article>
-          ))}
-        </div>
+        <table className="pulse-activity-table" aria-label="Pulse and worker events">
+          <thead>
+            <tr className="pulse-activity-row pulse-activity-header">
+              <th scope="col">When</th><th scope="col">Event</th><th scope="col">Scope</th><th scope="col">Outcome</th><th scope="col">Resource</th><th scope="col">Origin / actor</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pulseActivityRows.map((row) => (
+              <tr className="pulse-activity-row" key={`${row.time}-${row.scope}`}>
+                <td data-label="When">{row.time}</td>
+                <td data-label="Event">{row.event}</td>
+                <td data-label="Scope">{row.scope}</td>
+                <td data-label="Outcome">{row.outcome}</td>
+                <td data-label="Resource">{row.resource}</td>
+                <td data-label="Origin / actor">{row.origin} · {row.actor}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
         <p className="notice compact-notice">Mobile activity cards replace the dense table on small screens. Detail drawer becomes a full-screen sheet on small screens, and terminal panel becomes full-screen later.</p>
       </section>
       <section className="pulse-layout" aria-label="Drilldown and planned actions">

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -19,6 +19,7 @@ export type FontPreference =
   | "Ubuntu Mono";
 export type FontSizePreference = "xs" | "s" | "m" | "lg" | "xl";
 export const surfaceIconNames = {
+  activity: true,
   apps: true,
   bookmark: true,
   brand: true,
@@ -273,8 +274,8 @@ export const text = {
   socialMedia: "Social Media",
   socialMediaIntro: "Social profiles, pages, handles, audience notes, and channel ownership are planned.",
   tasks: "Tasks",
-  workers: "Workers",
-  workersIntro: "Worker activity, task handoffs, event threads, and status transitions will render here as conversation events and workflow summaries.",
+  workers: "Pulse & Workers",
+  workersIntro: "Pulse & Workers brings worker sessions, event streams, outcomes, resources, and systemic fixes into one observability console so attention goes to exceptions, bottlenecks, and reusable improvements instead of raw noise.",
   theme: "Theme",
   appearance: "Appearance",
   hue: "Hue",
@@ -367,7 +368,7 @@ export const navGroups: SurfaceNavGroup[] = [
     mode: "devops",
     items: [
       plannedNavItem("aiSessions", text.aiSessions, "AI chat and OpenCode sessions", "terminal"),
-      plannedNavItem("workers", text.workers, "Worker activity and event threads", "users"),
+      plannedNavItem("workers", text.workers, "Pulse, worker sessions, outcomes, and resources", "activity"),
       { id: "git", label: text.localRepos, description: "~/Git explorer", icon: "folder" },
       plannedNavItem("repos", text.repos, "Unified local and remote repo context", "git"),
       { id: "projects", label: text.projects, description: "repos.json summary", icon: "git" },

--- a/packages/gui-web/src/dashboard.ts
+++ b/packages/gui-web/src/dashboard.ts
@@ -37,7 +37,7 @@ export function renderDashboardHtml(status: GuiResponseEnvelope<GuiStatusData>):
     .map((capability) => `<li>${escapeHtml(capability.label)}: ${escapeHtml(capability.status)}</li>`)
     .join("");
   const navSections = [
-    { heading: "Development", items: ["AI Sessions", "Workers", "Local Repos", "Repos", "Remote Repos", "Deployments", "Secrets", "AI Providers"] },
+    { heading: "Development", items: ["AI Sessions", "Pulse & Workers", "Local Repos", "Repos", "Remote Repos", "Deployments", "Secrets", "AI Providers"] },
     { heading: "Account", items: ["Help", "Settings", "Notifications", "Admin"] },
     { heading: "Operations", items: ["Dashboard", "Vault", "Agents file explorer", "Config", "Local Setup", "Routines"] },
     { heading: "Infrastructure", items: ["Devices", "VPNs & Proxies", "Apps", "Installation", "Registrars", "Hosts", "Servers"] },

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -2221,6 +2221,146 @@ code {
   margin-bottom: 16px;
 }
 
+.pulse-workers-surface {
+  display: grid;
+  gap: 16px;
+}
+
+.pulse-hero {
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, transparent), transparent 64%),
+    var(--surface-elevated);
+}
+
+.pulse-scope-strip,
+.pulse-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pulse-scope-strip span,
+.pulse-filter-row button {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  padding: 7px 10px;
+}
+
+.pulse-scope-strip strong {
+  color: var(--accent);
+  margin-right: 6px;
+  text-transform: uppercase;
+}
+
+.pulse-kpi-grid,
+.pulse-layout {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.pulse-kpi-card {
+  display: grid;
+  gap: 8px;
+}
+
+.pulse-kpi-card span,
+.pulse-chart-panel p,
+.pulse-drilldown-panel p,
+.pulse-actions-panel p {
+  color: var(--text-secondary);
+}
+
+.pulse-kpi-card strong {
+  color: var(--accent);
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: -0.08em;
+  line-height: 1;
+}
+
+.pulse-attention-panel,
+.pulse-chart-panel,
+.pulse-activity-panel,
+.pulse-drilldown-panel,
+.pulse-actions-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.pulse-attention-panel ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.pulse-chart-placeholder {
+  align-items: end;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  min-height: 180px;
+  padding: 14px;
+}
+
+.pulse-chart-placeholder span {
+  align-items: end;
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+  border: 1px solid var(--border-accent);
+  border-radius: 12px 12px 4px 4px;
+  color: var(--accent-strong);
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 900;
+  justify-content: center;
+  min-height: calc(40px + var(--bar-index, 1) * 18px);
+  padding: 8px 4px;
+  text-transform: uppercase;
+}
+
+.pulse-chart-placeholder span:nth-child(2) { --bar-index: 3; }
+.pulse-chart-placeholder span:nth-child(3) { --bar-index: 5; }
+.pulse-chart-placeholder span:nth-child(4) { --bar-index: 2; }
+.pulse-chart-placeholder span:nth-child(5) { --bar-index: 4; }
+.pulse-chart-placeholder span:nth-child(6) { --bar-index: 3; }
+
+.pulse-activity-table {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  display: grid;
+  overflow: hidden;
+}
+
+.pulse-activity-row {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 0.7fr 1fr 1.4fr 1fr 1.2fr 1.2fr;
+  padding: 12px 14px;
+}
+
+.pulse-activity-row + .pulse-activity-row {
+  border-top: 1px solid var(--border);
+}
+
+.pulse-activity-header {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.pulse-actions-panel button,
+.pulse-attention-panel button {
+  justify-self: start;
+}
+
 .apps-surface .compact-notice {
   margin-bottom: 0;
 }
@@ -3666,8 +3806,23 @@ button.managed-toggle:focus-visible {
   .data-row,
   .editable-row,
   .managed-app-details,
+  .pulse-activity-row,
   .provider-account-list li {
     grid-template-columns: 1fr;
+  }
+
+  .pulse-activity-header {
+    display: none;
+  }
+
+  .pulse-activity-row {
+    background: var(--surface-elevated);
+  }
+
+  .pulse-activity-row span::before {
+    color: var(--text-muted);
+    content: attr(data-label) ": ";
+    font-weight: 900;
   }
 
   .pill-tabs {

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -2337,6 +2337,11 @@ code {
   overflow: hidden;
 }
 
+.pulse-activity-table thead,
+.pulse-activity-table tbody {
+  display: grid;
+}
+
 .pulse-activity-row {
   display: grid;
   gap: 10px;
@@ -2346,6 +2351,12 @@ code {
 
 .pulse-activity-row + .pulse-activity-row {
   border-top: 1px solid var(--border);
+}
+
+.pulse-activity-row th,
+.pulse-activity-row td {
+  font-weight: inherit;
+  text-align: left;
 }
 
 .pulse-activity-header {
@@ -3819,7 +3830,7 @@ button.managed-toggle:focus-visible {
     background: var(--surface-elevated);
   }
 
-  .pulse-activity-row span::before {
+  .pulse-activity-row td::before {
     color: var(--text-muted);
     content: attr(data-label) ": ";
     font-weight: 900;

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -45,7 +45,7 @@ describe("dashboard shell", () => {
     expect(html).toContain("AI Sessions");
     expect(html).toContain("Channels");
     expect(html).toContain("Direct Messages");
-    expect(html).toContain("Workers");
+    expect(html).toContain("Pulse &amp; Workers");
     expect(html).toContain("Deployments");
     expect(html).toContain("Secrets");
     expect(html).toContain("AI Providers");
@@ -130,6 +130,21 @@ describe("dashboard shell", () => {
     expect(html).toContain("ready for Tambo cards");
     expect(html).toContain("MessageScroller-compatible transcript");
     expect(html).toContain("New, rename, pin, archive, delete, share, and export");
+  });
+
+  test("renders Pulse and Workers observability shell with read-only fixture hierarchy", () => {
+    const html = renderWorkspaceSurface(workersItem, "workers");
+
+    expect(html).toContain("Pulse &amp; Workers");
+    expect(html).toContain("Last 24h · all managed repos");
+    expect(html).toContain("Needs attention");
+    expect(html).toContain("Health trend placeholder");
+    expect(html).toContain("Provider / model");
+    expect(html).toContain("Community bug report");
+    expect(html).toContain("Mobile activity cards");
+    expect(html).toContain("Detail drawer becomes a full-screen sheet on small screens");
+    expect(html).toContain("Open terminal output (planned)");
+    expect(html).toContain("Create systemic fix (planned)");
   });
 
   test("renders channel and DM conversation surfaces from the unified model", () => {
@@ -431,6 +446,13 @@ const directMessagesItem: SurfaceNavItem = {
   icon: "message",
   id: "directMessages",
   label: "Direct Messages",
+};
+
+const workersItem: SurfaceNavItem = {
+  description: "Pulse, worker sessions, outcomes, and resources",
+  icon: "activity",
+  id: "workers",
+  label: "Pulse & Workers",
 };
 
 const managedAppFixture: GuiManagedAppSummary = {


### PR DESCRIPTION
## Summary

Renamed the Workers development surface to Pulse & Workers, mapped it to the Feather activity icon while keeping the workers route id, replaced the placeholder surface with a read-only fixture-backed observability hierarchy, added responsive/mobile card CSS, and updated dashboard/component expectations.

## Files Changed

packages/gui-web/src/AppNavigation.tsx,packages/gui-web/src/AppWorkspace.tsx,packages/gui-web/src/app-model.ts,packages/gui-web/src/dashboard.ts,packages/gui-web/src/styles.css,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check HEAD~1..HEAD passed. Required commands 'bun test packages/gui-shared/tests/schema.test.ts packages/gui-web/tests/component.test.ts packages/gui-web/tests/security.test.ts' and 'bun run --cwd packages/gui-web build' could not run locally because bun is not installed in the worker environment and node_modules is absent; repo has only bun.lock, so no alternate package-manager install was performed.

Resolves #25912


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.37 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 6m and 67,419 tokens on this as a headless worker.