### PR TITLE
t18036: Populate Pulse & Workers status from telemetry

### DIFF
--- a/packages/gui-api/src/status-adapter.ts
+++ b/packages/gui-api/src/status-adapter.ts
@@ -41,6 +41,7 @@ import {
 } from "./status-adapter-utils";
 import { readLocalReposSetupSummary } from "./status-local-repos";
 import { readManagedApps } from "./status-managed-apps";
+import { readPulseWorkersSummary } from "./status-pulse-workers";
 import { readVaultSummary } from "./status-vault";
 
 export { readVaultSummary } from "./status-vault";
@@ -48,6 +49,7 @@ export { readVaultSummary } from "./status-vault";
 export interface StatusAdapterOptions {
   repoRoot?: string;
   observedAt?: string;
+  pulseWorkers?: Parameters<typeof readPulseWorkersSummary>[0];
 }
 
 export const STATUS_ADAPTER_COMMAND = ["aidevops", "status"] as const;
@@ -80,6 +82,7 @@ export function readStatus(
   const opencodeSessions = readOpenCodeSessions(opencodeDbPath, opencodeDbPathRef, localRepos.repos);
   const oauthPool = readOAuthPoolSummary(oauthPoolPath, oauthPoolPathRef);
   const vault = readVaultSummary(repoRoot);
+  const pulseWorkers = readPulseWorkersSummary({ observedAt: options.observedAt, oauthPoolPath, ...options.pulseWorkers });
   const notifications = buildStatusNotifications({
     aiApps,
     greetingOutput: readOptionalText(expandHome(greetingCachePathRef)) ?? "",
@@ -99,6 +102,7 @@ export function readStatus(
     ...setupTargets.map((target) => target.path_ref),
     ...aiApps.flatMap((app) => [app.app_path_ref, app.binary_path_ref, app.config_path_ref, app.aidevops_target_path_ref]),
     ...managedApps.map((app) => app.install_path_ref),
+    ...pulseWorkers.source_path_refs,
   ].filter(isSourcePathRef);
 
   const data: GuiStatusData = {
@@ -148,6 +152,7 @@ export function readStatus(
     managed_apps: managedApps,
     notifications,
     vault,
+    pulse_workers: pulseWorkers.summary,
   };
 
   const envelope = createEnvelope({

--- a/packages/gui-api/src/status-pulse-workers.ts
+++ b/packages/gui-api/src/status-pulse-workers.ts
@@ -1,0 +1,378 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type GuiPulseAuthorAssociation,
+  type GuiPulseIssueOrigin,
+  type GuiPulseProviderId,
+  type GuiPulseResourceKind,
+  type GuiPulseResourceSnapshot,
+  type GuiPulseWorkerActivityEvent,
+  type GuiPulseWorkerChartSeries,
+  type GuiPulseWorkerKpiCard,
+  type GuiPulseWorkerOutcome,
+  type GuiPulseWorkerSeverity,
+  type GuiPulseWorkerStatus,
+  type GuiPulseWorkerSummary,
+  type GuiPulseWorkerUsageSnapshot,
+  type GuiPulsePeriodBucket,
+  pulseWorkersFixture,
+} from "../../gui-shared/src";
+import { collapseHome, expandHome, formatEpochField, isRecord, readJsonObject, stringField } from "./status-adapter-utils";
+
+export interface PulseWorkersAdapterOptions {
+  metricsPath?: string;
+  pulseStatsPath?: string;
+  resourceMetricsPath?: string;
+  tokenReportsRoot?: string;
+  oauthPoolPath?: string;
+  observedAt?: string;
+  nowMs?: number;
+}
+
+interface SourceState {
+  path_ref: string;
+  health: "present" | "missing" | "invalid";
+  observed_at: string;
+}
+
+type MetricRecord = Record<string, unknown>;
+
+const DAY_MS = 86_400_000;
+const WEEK_MS = 7 * DAY_MS;
+const DEFAULT_SCOPE = "local aidevops telemetry";
+const DEFAULT_METRICS_PATH_REF = "~/.aidevops/logs/headless-runtime-metrics.jsonl";
+const DEFAULT_PULSE_STATS_PATH_REF = "~/.aidevops/logs/pulse-stats.json";
+const DEFAULT_RESOURCE_METRICS_PATH_REF = "~/.aidevops/logs/resource-metrics.jsonl";
+const DEFAULT_TOKEN_REPORTS_ROOT_REF = "~/.aidevops/_reports/token-use";
+
+export function readPulseWorkersSummary(options: PulseWorkersAdapterOptions = {}): { summary: GuiPulseWorkerSummary; source_path_refs: string[] } {
+  const nowMs = options.nowMs ?? Date.parse(options.observedAt ?? new Date().toISOString());
+  const observedAt = new Date(Number.isFinite(nowMs) ? nowMs : Date.now()).toISOString();
+  const metricsPath = options.metricsPath ?? expandHome(DEFAULT_METRICS_PATH_REF);
+  const pulseStatsPath = options.pulseStatsPath ?? expandHome(DEFAULT_PULSE_STATS_PATH_REF);
+  const resourceMetricsPath = options.resourceMetricsPath ?? expandHome(DEFAULT_RESOURCE_METRICS_PATH_REF);
+  const tokenReportsRoot = options.tokenReportsRoot ?? expandHome(DEFAULT_TOKEN_REPORTS_ROOT_REF);
+  const oauthPoolPath = options.oauthPoolPath ?? expandHome("~/.aidevops/oauth-pool.json");
+
+  const metrics = readJsonLines(metricsPath);
+  const resources = readJsonLines(resourceMetricsPath);
+  const tokenReports = readTokenReports(tokenReportsRoot);
+  const pulseStats = readJsonObject(pulseStatsPath);
+  const oauthPool = readJsonObject(oauthPoolPath);
+  const sourceStates: SourceState[] = [
+    stateFor(metricsPath, metrics.health, observedAt),
+    stateFor(pulseStatsPath, pulseStats.health, observedAt),
+    stateFor(resourceMetricsPath, resources.health, observedAt),
+    stateFor(tokenReportsRoot, tokenReports.health, observedAt),
+    stateFor(oauthPoolPath, oauthPool.health, observedAt),
+  ];
+
+  const dayMetrics = filterWindow(metrics.records, nowMs, DAY_MS);
+  const weekMetrics = filterWindow(metrics.records, nowMs, WEEK_MS);
+  const pulseCounters = extractPulseCounters(pulseStats.value, nowMs);
+  const resourceSnapshots = resourceMetricsToSnapshots(resources.records, observedAt);
+  const usageSamples = collectUsageSamples([...dayMetrics, ...tokenReports.records]);
+  const events = buildEvents(dayMetrics, resourceSnapshots, usageSamples, observedAt);
+  const warnings = buildAttention(sourceStates, pulseCounters, resourceSnapshots, oauthPool.value);
+
+  const summary: GuiPulseWorkerSummary = {
+    value_policy: "metadata_only_no_prompt_payloads_no_secrets",
+    selected_period: "day",
+    period_label: "Last 24h",
+    scope_label: DEFAULT_SCOPE,
+    comparison_label: "Prior local telemetry window",
+    updated_at: observedAt,
+    kpis: buildKpis(dayMetrics, weekMetrics, pulseCounters, usageSamples, resourceSnapshots),
+    attention: warnings,
+    filters: buildFilters(events),
+    charts: buildCharts(metrics.records, pulseCounters, nowMs),
+    events,
+  };
+
+  return { summary, source_path_refs: sourceStates.map((source) => source.path_ref) };
+}
+
+function readJsonLines(pathName: string): { health: "present" | "missing" | "invalid"; records: MetricRecord[] } {
+  if (!existsSync(pathName)) {
+    return { health: "missing", records: [] };
+  }
+  try {
+    const records = readFileSync(pathName, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter(isRecord);
+    return { health: "present", records };
+  } catch {
+    return { health: "invalid", records: [] };
+  }
+}
+
+function readTokenReports(root: string): { health: "present" | "missing" | "invalid"; records: MetricRecord[] } {
+  if (!existsSync(root)) {
+    return { health: "missing", records: [] };
+  }
+  try {
+    const records = readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(root, entry.name, "report.json"))
+      .filter((pathName) => existsSync(pathName))
+      .slice(-25)
+      .map((pathName) => JSON.parse(readFileSync(pathName, "utf8")))
+      .filter(isRecord);
+    return { health: "present", records };
+  } catch {
+    return { health: "invalid", records: [] };
+  }
+}
+
+function stateFor(pathName: string, health: SourceState["health"], observedAt: string): SourceState {
+  return { path_ref: collapseHome(pathName), health, observed_at: observedAt };
+}
+
+function filterWindow(records: MetricRecord[], nowMs: number, windowMs: number): MetricRecord[] {
+  const cutoff = nowMs - windowMs;
+  return records.filter((record) => {
+    const time = recordTimeMs(record);
+    return time !== null && time >= cutoff && time <= nowMs;
+  });
+}
+
+function recordTimeMs(record: MetricRecord): number | null {
+  for (const key of ["ts", "timestamp", "started_at", "finished_at", "created_at", "updated_at"]) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value > 9_999_999_999 ? value : value * 1000;
+    }
+    if (typeof value === "string" && value.length > 0) {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return null;
+}
+
+function extractPulseCounters(value: Record<string, unknown>, nowMs: number): Record<string, number> {
+  const counters = isRecord(value.counters) ? value.counters : {};
+  return Object.fromEntries(Object.entries(counters).map(([name, entries]) => [name, countRecentTimestamps(entries, nowMs, DAY_MS)]));
+}
+
+function countRecentTimestamps(value: unknown, nowMs: number, windowMs: number): number {
+  if (!Array.isArray(value)) {
+    return 0;
+  }
+  const cutoff = nowMs - windowMs;
+  return value.filter((entry) => {
+    const ms = typeof entry === "number" ? (entry > 9_999_999_999 ? entry : entry * 1000) : Date.parse(String(entry));
+    return Number.isFinite(ms) && ms >= cutoff && ms <= nowMs;
+  }).length;
+}
+
+function buildKpis(dayMetrics: MetricRecord[], weekMetrics: MetricRecord[], counters: Record<string, number>, usage: GuiPulseWorkerUsageSnapshot[], resources: GuiPulseResourceSnapshot[]): GuiPulseWorkerKpiCard[] {
+  const total = dayMetrics.length;
+  const healthy = dayMetrics.filter((record) => isHealthyOutcome(outcomeFromRecord(record))).length;
+  const rate = total === 0 ? 0 : Math.round((healthy / total) * 100);
+  const totalTokens = usage.reduce((sum, item) => sum + item.total_tokens, 0);
+  const costRefs = usage.map((item) => item.estimated_cost_ref).filter((item): item is string => item !== null);
+  const attentionCount = Object.values(counters).reduce((sum, count) => sum + count, 0) + resources.filter((resource) => resource.pressure !== "low" && resource.pressure !== "unknown").length;
+
+  return [
+    { id: "worker-outcomes-24h", label: "Healthy worker outcomes", value: total === 0 ? "unknown" : `${rate}%`, period_label: "Last 24h", scope_label: DEFAULT_SCOPE, comparison_label: "computed from local worker metrics", sample_size: total, status: total === 0 ? "attention" : rate >= 80 ? "healthy" : "attention", detail: total === 0 ? "No local worker outcome records were available for the last 24h." : `${healthy} of ${total} local worker sessions ended merged, closed, completed, or deferred.` },
+    { id: "attention-signals", label: "Attention signals", value: String(attentionCount), period_label: "Last 24h", scope_label: DEFAULT_SCOPE, comparison_label: "pulse counters plus resource pressure", sample_size: Object.keys(counters).length + resources.length, status: attentionCount > 0 ? "attention" : "healthy", detail: "Counts canonical Pulse counters and observed resource pressure without treating missing telemetry as failure." },
+    { id: "token-cost", label: "Token and cost sample", value: totalTokens > 0 ? `${totalTokens.toLocaleString()} tokens` : "unknown", period_label: "Last 24h", scope_label: "provider/model metadata", comparison_label: costRefs.length > 0 ? "cost refs observed" : "cost unavailable", sample_size: usage.length, status: usage.length > 0 ? "healthy" : "attention", detail: "Token usage is derived from metadata fields only; prompts, command output, credential paths, and message payloads are excluded." },
+    { id: "systemic-fixes", label: "Systemic fixes observed", value: String(weekMetrics.filter((record) => outcomeFromRecord(record) === "created_followup").length), period_label: "Trailing 7d", scope_label: DEFAULT_SCOPE, comparison_label: "worker outcome metadata", sample_size: weekMetrics.length, status: "completed", detail: "Follow-up/systemic-fix outcomes are counted only when canonical local metrics record them." },
+  ];
+}
+
+function buildAttention(sources: SourceState[], counters: Record<string, number>, resources: GuiPulseResourceSnapshot[], oauthPool: Record<string, unknown>) {
+  const missing = sources.filter((source) => source.health !== "present");
+  const attention = missing.map((source) => ({ id: `source-${source.health}-${slug(source.path_ref)}`, severity: source.health === "invalid" ? "warning" as const : "info" as const, title: `Telemetry source ${source.health}`, detail: `${source.path_ref} was ${source.health}; the GUI used safe empty summaries for that source.`, event_ref: null }));
+  for (const [name, count] of Object.entries(counters).filter(([, count]) => count > 0)) {
+    attention.push({ id: `pulse-counter-${slug(name)}`, severity: "warning", title: `Pulse counter active: ${name}`, detail: `${count} events observed in the selected local period.`, event_ref: null });
+  }
+  for (const resource of resources.filter((item) => item.pressure === "medium" || item.pressure === "high")) {
+    attention.push({ id: `resource-${slug(resource.kind)}-${slug(resource.label)}`, severity: resource.pressure === "high" ? "critical" : "warning", title: `${resource.label} pressure ${resource.pressure}`, detail: resource.available_label, event_ref: null });
+  }
+  if (!hasAvailableProvider(oauthPool)) {
+    attention.push({ id: "provider-availability-unknown", severity: "info", title: "Provider availability unknown", detail: "OAuth pool metadata did not expose an available provider account count; the GUI marks provider capacity as unknown.", event_ref: null });
+  }
+  return attention.slice(0, 12);
+}
+
+function buildEvents(records: MetricRecord[], resources: GuiPulseResourceSnapshot[], usage: GuiPulseWorkerUsageSnapshot[], observedAt: string): GuiPulseWorkerActivityEvent[] {
+  return records.slice(-25).reverse().map((record, index) => {
+    const outcome = outcomeFromRecord(record);
+    const status = statusFromOutcome(outcome);
+    const issue = stringOrNumber(record.issue ?? record.issue_number);
+    const pr = stringOrNumber(record.pr ?? record.pr_number ?? record.pull_request);
+    const repo = stringField(record, "repo") ?? null;
+    return {
+      id: `event:worker:${issue ?? index}:${recordTimeMs(record) ?? index}`,
+      type: "worker_session",
+      status,
+      outcome,
+      severity: severityFromStatus(status),
+      occurred_at: recordTimeMs(record) === null ? observedAt : new Date(recordTimeMs(record) as number).toISOString(),
+      title: "Worker session",
+      summary: summaryFromRecord(record, outcome),
+      pulse_run_ref: stringField(record, "pulse_run_ref") ?? null,
+      worker_session_ref: stringField(record, "session_key") ?? stringField(record, "worker_session_ref") ?? null,
+      issue_ref: issue === null ? null : `#${issue.replace(/^#/, "")}`,
+      pull_request_ref: pr === null ? null : `#${pr.replace(/^#/, "")}`,
+      command_job_ref: stringField(record, "command_job_ref") ?? null,
+      repo_ref: repo,
+      actor_ref: stringField(record, "actor") ?? "worker:auto-dispatch",
+      issue_origin: issueOriginFromRecord(record),
+      author_association: authorAssociationFromRecord(record),
+      duration_ms: durationMsFromRecord(record),
+      usage: usageFromRecord(record) ?? usage[index] ?? null,
+      resources,
+      drilldown_sections: [
+        { label: "Evidence", body: "Derived from local worker outcome/resource metadata; prompt text and command payloads are not exposed." },
+        { label: "Outcome", body: outcome },
+      ],
+    };
+  });
+}
+
+function buildFilters(events: GuiPulseWorkerActivityEvent[]): GuiPulseWorkerSummary["filters"] {
+  return {
+    repos: countOptions(events.map((event) => event.repo_ref).filter(Boolean) as string[], "repo:"),
+    event_types: countOptions(events.map((event) => event.type)),
+    outcomes: countOptions(events.map((event) => event.outcome)),
+    resources: countOptions(events.flatMap((event) => event.resources.map((resource) => resource.kind))),
+    providers: countOptions(events.map((event) => event.usage === null ? null : `${event.usage.provider}:${event.usage.model_ref ?? "unknown"}`).filter(Boolean) as string[]),
+    issue_origins: countOptions(events.map((event) => event.issue_origin)),
+    authors: countOptions(events.map((event) => event.actor_ref).filter(Boolean) as string[], "actor:"),
+    author_associations: countOptions(events.map((event) => event.author_association)),
+  };
+}
+
+function buildCharts(records: MetricRecord[], counters: Record<string, number>, nowMs: number): GuiPulseWorkerChartSeries[] {
+  const specs: Array<[GuiPulsePeriodBucket, number, string]> = [["day", DAY_MS, "Last 24h"], ["week", WEEK_MS, "Trailing 7d"], ["month", 30 * DAY_MS, "Trailing 30d"], ["year", 365 * DAY_MS, "Trailing 365d"]];
+  const counterTotal = Object.values(counters).reduce((sum, count) => sum + count, 0);
+  return [{ id: "worker-events", label: "Worker events", unit: "count", points: specs.map(([period, windowMs, label]) => ({ period, period_label: label, scope_label: DEFAULT_SCOPE, bucket_start: new Date(nowMs - windowMs).toISOString(), bucket_end: new Date(nowMs).toISOString(), value: filterWindow(records, nowMs, windowMs).length + (period === "day" ? counterTotal : 0) })) }];
+}
+
+function resourceMetricsToSnapshots(records: MetricRecord[], observedAt: string): GuiPulseResourceSnapshot[] {
+  return records.slice(-5).map((record) => {
+    const rssKb = numberValue(record.rss_kb ?? record.peak_rss_kb);
+    return { kind: "memory" as GuiPulseResourceKind, label: stringField(record, "role") ?? "Process memory", available_label: rssKb === null ? "unknown" : `${Math.round(rssKb / 1024)} MB RSS`, pressure: rssKb === null ? "unknown" : rssKb > 2_000_000 ? "high" : rssKb > 750_000 ? "medium" : "low", observed_at: recordTimeMs(record) === null ? observedAt : new Date(recordTimeMs(record) as number).toISOString(), reset_at: null };
+  });
+}
+
+function collectUsageSamples(records: MetricRecord[]): GuiPulseWorkerUsageSnapshot[] {
+  return records.map(usageFromRecord).filter((usage): usage is GuiPulseWorkerUsageSnapshot => usage !== null);
+}
+
+function usageFromRecord(record: MetricRecord): GuiPulseWorkerUsageSnapshot | null {
+  const input = numberValue(record.input_tokens ?? record.prompt_tokens);
+  const output = numberValue(record.output_tokens ?? record.completion_tokens);
+  const total = numberValue(record.total_tokens) ?? (input ?? 0) + (output ?? 0);
+  if (total <= 0 && input === null && output === null) {
+    return null;
+  }
+  const provider = providerFromString(stringField(record, "provider") ?? stringField(record, "provider_id"));
+  const model = stringField(record, "model") ?? stringField(record, "model_ref") ?? null;
+  return { provider, provider_ref: `provider:${provider}`, model_ref: model, input_tokens: input ?? 0, output_tokens: output ?? 0, cached_tokens: numberValue(record.cached_tokens) ?? 0, total_tokens: total, cost_ref: costRef(record), estimated_cost_ref: costRef(record), wall_time_ms: numberValue(record.wall_time_ms ?? record.duration_ms) ?? 0 };
+}
+
+function outcomeFromRecord(record: MetricRecord): GuiPulseWorkerOutcome {
+  const raw = String(record.outcome ?? record.result ?? record.status ?? "in_progress").toLowerCase();
+  if (["merged", "closed", "in_progress", "needs_maintainer_review", "blocked", "failed", "deferred", "created_followup"].includes(raw)) {
+    return raw as GuiPulseWorkerOutcome;
+  }
+  if (raw.includes("success") || raw.includes("complete")) return "merged";
+  if (raw.includes("follow")) return "created_followup";
+  if (raw.includes("defer")) return "deferred";
+  if (raw.includes("block")) return "blocked";
+  if (raw.includes("fail") || raw.includes("kill")) return "failed";
+  return "in_progress";
+}
+
+function statusFromOutcome(outcome: GuiPulseWorkerOutcome): GuiPulseWorkerStatus {
+  if (outcome === "failed") return "failed";
+  if (outcome === "blocked" || outcome === "needs_maintainer_review") return "blocked";
+  if (outcome === "in_progress") return "running";
+  if (outcome === "deferred") return "deferred";
+  return "completed";
+}
+
+function severityFromStatus(status: GuiPulseWorkerStatus): GuiPulseWorkerSeverity {
+  if (status === "failed" || status === "blocked") return "critical";
+  if (status === "attention" || status === "deferred") return "warning";
+  if (status === "completed" || status === "healthy") return "success";
+  return "info";
+}
+
+function isHealthyOutcome(outcome: GuiPulseWorkerOutcome): boolean {
+  return ["merged", "closed", "deferred", "created_followup"].includes(outcome);
+}
+
+function issueOriginFromRecord(record: MetricRecord): GuiPulseIssueOrigin {
+  const raw = String(record.issue_origin ?? record.origin ?? "unknown").toLowerCase();
+  if (["aidevops_created", "maintainer_created", "origin_interactive", "third_party", "unknown"].includes(raw)) return raw as GuiPulseIssueOrigin;
+  if (raw.includes("interactive")) return "origin_interactive";
+  if (raw.includes("third") || raw.includes("community")) return "third_party";
+  if (raw.includes("maintainer")) return "maintainer_created";
+  if (raw.includes("aidevops")) return "aidevops_created";
+  return "unknown";
+}
+
+function authorAssociationFromRecord(record: MetricRecord): GuiPulseAuthorAssociation {
+  const raw = String(record.author_association ?? "UNKNOWN").toUpperCase();
+  if (["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "NONE", "UNKNOWN"].includes(raw)) return raw as GuiPulseAuthorAssociation;
+  return "UNKNOWN";
+}
+
+function durationMsFromRecord(record: MetricRecord): number | null {
+  const duration = numberValue(record.duration_ms ?? record.wall_time_ms);
+  if (duration !== null) return duration;
+  const elapsed = numberValue(record.elapsed_s);
+  return elapsed === null ? null : elapsed * 1000;
+}
+
+function summaryFromRecord(record: MetricRecord, outcome: GuiPulseWorkerOutcome): string {
+  const issue = stringOrNumber(record.issue ?? record.issue_number);
+  return issue === null ? `Worker outcome: ${outcome}.` : `Worker outcome for #${issue.replace(/^#/, "")}: ${outcome}.`;
+}
+
+function countOptions(values: string[], prefix = ""): Array<{ id: string; label: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.entries()].map(([label, count]) => ({ id: `${prefix}${slug(label)}`, label, count })).sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+function hasAvailableProvider(value: Record<string, unknown>): boolean {
+  const providers = Array.isArray(value.providers) ? value.providers : [];
+  return providers.some((provider) => isRecord(provider) && (numberValue(provider.available) ?? 0) > 0);
+}
+
+function costRef(record: MetricRecord): string | null {
+  const cost = record.estimated_cost_ref ?? record.cost_ref;
+  if (typeof cost === "string" && cost.length > 0 && !cost.includes("/")) return cost;
+  const amount = numberValue(record.estimated_cost_usd ?? record.cost_usd);
+  return amount === null ? null : `$${amount.toFixed(2)} estimated`;
+}
+
+function providerFromString(value: string | undefined): GuiPulseProviderId {
+  if (value === "anthropic" || value === "openai" || value === "cursor" || value === "google" || value === "local") return value;
+  return "unknown";
+}
+
+function stringOrNumber(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "unknown";
+}

--- a/packages/gui-api/src/status-pulse-workers.ts
+++ b/packages/gui-api/src/status-pulse-workers.ts
@@ -203,7 +203,7 @@ function buildAttention(sources: SourceState[], counters: Record<string, number>
 }
 
 function buildEvents(records: MetricRecord[], resources: GuiPulseResourceSnapshot[], usage: GuiPulseWorkerUsageSnapshot[], observedAt: string): GuiPulseWorkerActivityEvent[] {
-  return records.slice(-25).reverse().map((record, index) => {
+  return records.slice(-25).sort((left, right) => (recordTimeMs(right) ?? 0) - (recordTimeMs(left) ?? 0)).map((record, index) => {
     const outcome = outcomeFromRecord(record);
     const status = statusFromOutcome(outcome);
     const issue = stringOrNumber(record.issue ?? record.issue_number);

--- a/packages/gui-api/src/status-pulse-workers.ts
+++ b/packages/gui-api/src/status-pulse-workers.ts
@@ -187,9 +187,9 @@ function buildKpis(dayMetrics: MetricRecord[], weekMetrics: MetricRecord[], coun
   ];
 }
 
-function buildAttention(sources: SourceState[], counters: Record<string, number>, resources: GuiPulseResourceSnapshot[], oauthPool: Record<string, unknown>) {
+function buildAttention(sources: SourceState[], counters: Record<string, number>, resources: GuiPulseResourceSnapshot[], oauthPool: Record<string, unknown>): GuiPulseWorkerSummary["attention"] {
   const missing = sources.filter((source) => source.health !== "present");
-  const attention = missing.map((source) => ({ id: `source-${source.health}-${slug(source.path_ref)}`, severity: source.health === "invalid" ? "warning" as const : "info" as const, title: `Telemetry source ${source.health}`, detail: `${source.path_ref} was ${source.health}; the GUI used safe empty summaries for that source.`, event_ref: null }));
+  const attention: GuiPulseWorkerSummary["attention"] = missing.map((source) => ({ id: `source-${source.health}-${slug(source.path_ref)}`, severity: source.health === "invalid" ? "warning" : "info", title: `Telemetry source ${source.health}`, detail: `${source.path_ref} was ${source.health}; the GUI used safe empty summaries for that source.`, event_ref: null }));
   for (const [name, count] of Object.entries(counters).filter(([, count]) => count > 0)) {
     attention.push({ id: `pulse-counter-${slug(name)}`, severity: "warning", title: `Pulse counter active: ${name}`, detail: `${count} events observed in the selected local period.`, event_ref: null });
   }

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readStatus, readVaultStatus, readVaultSummary, STATUS_ADAPTER_COMMAND } from "../src/status-adapter";
 import { resolveBinary } from "../src/status-adapter-utils";
+import { readPulseWorkersSummary } from "../src/status-pulse-workers";
 
 describe("status adapter", () => {
   test("uses an exact helper command pattern", () => {
@@ -40,10 +41,55 @@ describe("status adapter", () => {
     expect(JSON.stringify(response.data.ai_apps)).not.toContain("token");
     expect(response.data.notifications.every((notification) => notification.source_ref.length > 0)).toBe(true);
     expect(response.data.vault.value_policy).toBe("metadata_only_no_secret_material");
+    expect(response.data.pulse_workers.value_policy).toBe("metadata_only_no_prompt_payloads_no_secrets");
+    expect(response.source.path_refs).toContain("~/.aidevops/logs/headless-runtime-metrics.jsonl");
     expect(response.data.vault.readiness.remote_unlock_enabled).toBe(false);
     expect(JSON.stringify(response.data.vault)).not.toContain("SECRET_SENTINEL_DO_NOT_RENDER");
     expect(response.data.capabilities.length).toBeGreaterThan(0);
     expect(response.data.secrets[0]).toEqual({ name: "GITHUB_TOKEN", status: "unchecked" });
+  });
+
+  test("populates Pulse and Workers status from local telemetry files", () => {
+    const root = mkdtempSync(join(tmpdir(), "aidevops-gui-pulse-workers-"));
+    const metricsPath = join(root, "headless-runtime-metrics.jsonl");
+    const pulseStatsPath = join(root, "pulse-stats.json");
+    const resourcesPath = join(root, "resource-metrics.jsonl");
+    const tokenReportsRoot = join(root, "token-reports");
+    const reportDir = join(tokenReportsRoot, "20260630T094500Z");
+    const oauthPoolPath = join(root, "oauth-pool.json");
+    mkdirSync(reportDir, { recursive: true });
+    writeFileSync(metricsPath, [
+      JSON.stringify({ ts: 1782810000, result: "success", issue: 25914, pr: 25999, repo: "marcusquinn/aidevops", provider: "openai", model: "gpt-5.5", input_tokens: 1200, output_tokens: 300, cached_tokens: 100, estimated_cost_usd: 0.42, duration_ms: 60000, issue_origin: "origin_interactive", author_association: "MEMBER" }),
+      JSON.stringify({ ts: 1782806400, result: "blocked", issue: 25910, repo: "marcusquinn/aidevops", provider: "anthropic", model: "sonnet", total_tokens: 900, issue_origin: "third_party", author_association: "CONTRIBUTOR" }),
+    ].join("\n"));
+    writeFileSync(pulseStatsPath, JSON.stringify({ counters: { pre_dispatch_aborts: [1782810000], retry_queue: [1782806400, 1000] } }));
+    writeFileSync(resourcesPath, JSON.stringify({ ts: 1782810000, role: "worker", rss_kb: 900000, peak_rss_kb: 900000, result: "success" }));
+    writeFileSync(join(reportDir, "report.json"), JSON.stringify({ provider: "openai", model: "gpt-5.5", input_tokens: 500, output_tokens: 150, total_tokens: 650, estimated_cost_ref: "$0.08 estimated" }));
+    writeFileSync(oauthPoolPath, JSON.stringify({ providers: [{ provider: "openai", available: 2 }] }));
+
+    const result = readPulseWorkersSummary({ metricsPath, pulseStatsPath, resourceMetricsPath: resourcesPath, tokenReportsRoot, oauthPoolPath, observedAt: "2026-06-30T09:45:00.000Z", nowMs: 1782812700000 });
+
+    expect(result.summary.kpis.find((kpi) => kpi.id === "worker-outcomes-24h")?.sample_size).toBe(2);
+    expect(result.summary.events[0].issue_ref).toBe("#25914");
+    expect(result.summary.events[0].usage?.provider).toBe("openai");
+    expect(result.summary.events[0].usage?.estimated_cost_ref).toBe("$0.42 estimated");
+    expect(result.summary.events[0].resources[0].pressure).toBe("medium");
+    expect(result.summary.attention.map((item) => item.id)).toContain("pulse-counter-pre-dispatch-aborts");
+    expect(result.summary.filters.providers.map((item) => item.label)).toContain("openai:gpt-5.5");
+    expect(JSON.stringify(result.summary)).not.toContain(root);
+  });
+
+  test("returns safe Pulse and Workers warnings for missing or malformed telemetry", () => {
+    const root = mkdtempSync(join(tmpdir(), "aidevops-gui-pulse-workers-missing-"));
+    const invalidPulseStatsPath = join(root, "pulse-stats.json");
+    writeFileSync(invalidPulseStatsPath, "not-json");
+
+    const result = readPulseWorkersSummary({ metricsPath: join(root, "missing.jsonl"), pulseStatsPath: invalidPulseStatsPath, resourceMetricsPath: join(root, "missing-resources.jsonl"), tokenReportsRoot: join(root, "reports"), oauthPoolPath: join(root, "oauth-pool.json"), observedAt: "2026-06-30T09:45:00.000Z" });
+
+    expect(result.summary.events).toEqual([]);
+    expect(result.summary.kpis.find((kpi) => kpi.id === "worker-outcomes-24h")?.value).toBe("unknown");
+    expect(result.summary.attention.some((item) => item.title === "Telemetry source invalid")).toBe(true);
+    expect(result.summary.attention.some((item) => item.id === "provider-availability-unknown")).toBe(true);
   });
 
   test("returns a metadata-only Vault envelope", () => {


### PR DESCRIPTION
## Summary

- Adds a read-only Pulse & Workers status adapter for local telemetry metadata.
- Wires `pulse_workers` into the GUI status envelope and source refs.
- Adds adapter tests covering worker outcomes, Pulse counters, token/cost metadata, resource pressure, missing/corrupt sources, provider availability, and path redaction.

Resolves #25914

## Verification

- `~/.bun/bin/bun test packages/gui-api/tests/status-adapter.test.ts packages/gui-shared/tests/schema.test.ts packages/gui-web/tests/component.test.ts packages/gui-web/tests/security.test.ts` — 39 pass, 0 fail.
- `~/.bun/bin/bun ./node_modules/vite/bin/vite.js build --config packages/gui-web/vite.config.ts` — built successfully; Vite warned that the shell was using Node.js 22.6.0 while Vite recommends 20.19+ or 22.12+.

## Notes

- The originally recovered worktree was owned by an active `issue-25914` worker process, so this PR was created from a dedicated resume worktree seeded at the recovered branch HEAD to avoid editing another session's worktree.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.38 plugin for [OpenCode](https://opencode.ai) v1.17.11
