### PR TITLE
t18037: feat: build pulse workers dashboard

### DIFF
--- a/packages/gui-shared/src/tambo.ts
+++ b/packages/gui-shared/src/tambo.ts
@@ -160,7 +160,7 @@ export const TAMBO_PROVIDER_CONFIG: GuiTamboProviderConfig = {
 
 export function validateTamboComponentPayload(payload: unknown, scope: GuiConversationScope): GuiTamboValidationResult {
   const envelope = validateTamboPayloadEnvelope(payload, scope);
-  if (!envelope.ok) {
+  if (envelope.ok === false) {
     return envelope.result;
   }
 

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -10,6 +10,7 @@ import { CommsConversationSurface } from "./CommsConversationSurface";
 import { FileExplorerSurface } from "./FileExplorerSurface";
 import { TamboConversationPart } from "./GenUiCards";
 import { AppsSurface, EditableInventorySurface, InstallationSurface } from "./InventorySurfaces";
+import { PulseWorkersSurface } from "./PulseWorkersSurface";
 import { AiProvidersSurface, LocalReposSurface, LockedVaultGate, OverviewSurface, PlannedSurface, ProjectsSurface, SecuritySurface, VaultSurface } from "./StatusSurfaces";
 import { isVaultSurfaceLocked, vaultCollectionForSurface } from "./VaultBadges";
 import { applyCommandPaletteSelection, useHeaderMenuState } from "./workspace-header-state";
@@ -435,114 +436,6 @@ function SurfaceContent({ activeItem, activeSurface, fileRoot, openSurface, stat
   }
 
   return staticSurfaces[activeSurface] ?? null;
-}
-
-const pulseFilters = ["Repo", "Event type", "Outcome", "Resource", "Provider / model", "Issue origin", "Author", "Author association"] as const;
-
-function PulseWorkersSurface({ status }: { status: GuiStatusData }): ReactElement {
-  const pulse = status.pulse_workers;
-
-  return (
-    <section className="pulse-workers-surface" aria-label={text.workers}>
-      <div className="planned-card pulse-hero">
-        <p className="eyebrow">Observability shell · fixture-backed · read-only</p>
-        <h2>{text.workers}</h2>
-        <p>{text.workersIntro}</p>
-        <section className="pulse-scope-strip" aria-label="Pulse scope and time range">
-          <span><strong>Period</strong> {pulse.period_label} · {pulse.scope_label}</span>
-          <span><strong>Comparison</strong> {pulse.comparison_label}</span>
-          <span><strong>Sample</strong> {pulse.events.length} canonical events · {pulse.kpis.reduce((total, kpi) => total + (kpi.sample_size ?? 0), 0)} samples</span>
-          <span><strong>Trust boundary</strong> Metadata/status only; protected payloads excluded</span>
-        </section>
-      </div>
-      <section className="pulse-kpi-grid" aria-label="Pulse health summary">
-        {pulse.kpis.map((kpi) => (
-          <article className="metric-card pulse-kpi-card" key={kpi.id}>
-            <span>{kpi.label} · {kpi.period_label} · {kpi.scope_label}</span>
-            <strong>{kpi.value}</strong>
-            <p>{kpi.detail} {kpi.comparison_label}</p>
-          </article>
-        ))}
-      </section>
-      <section className="pulse-layout" aria-label="Pulse observability hierarchy">
-        <article className="planned-card pulse-attention-panel">
-          <div className="split-heading">
-            <div>
-              <p className="eyebrow">Exceptions first</p>
-              <h3>Needs attention</h3>
-            </div>
-            <span className="count-pill">planned actions disabled</span>
-          </div>
-          <ul>
-            {pulse.attention.map((item) => <li key={item.id}>{item.title}: {item.detail}</li>)}
-          </ul>
-          <button disabled title="Action routes need audited worker control APIs" type="button">Create systemic fix (planned)</button>
-        </article>
-        <article className="planned-card pulse-chart-panel">
-          <p className="eyebrow">Trends</p>
-          <h3>Health trend placeholder</h3>
-          <div className="pulse-chart-placeholder" aria-label="Chart placeholder showing health, queue, token, cost, API, and CI capacity trends" role="img">
-            <span>health</span><span>queue</span><span>tokens</span><span>cost</span><span>api</span><span>ci</span>
-          </div>
-          <p>Charts derive from {pulse.charts.map((chart) => chart.points[0]?.period).filter(Boolean).join("/")} fixture buckets across the canonical event stream: Pulse, workers, commands, CI, issues, PRs, reviews, and outcomes.</p>
-        </article>
-      </section>
-      <section className="planned-card pulse-activity-panel" aria-label="Unified activity stream">
-        <div className="split-heading">
-          <div>
-            <p className="eyebrow">Canonical stream</p>
-            <h3>Unified activity</h3>
-          </div>
-          <section className="pulse-filter-row" aria-label="Quick filters">
-            {pulseFilters.map((filter) => <button disabled key={filter} title={`${filter} filter is planned`} type="button">{filter}</button>)}
-          </section>
-        </div>
-        <table className="pulse-activity-table" aria-label="Pulse and worker events">
-          <thead>
-            <tr className="pulse-activity-row pulse-activity-header">
-              <th scope="col">When</th><th scope="col">Event</th><th scope="col">Scope</th><th scope="col">Outcome</th><th scope="col">Resource</th><th scope="col">Origin / actor</th>
-            </tr>
-          </thead>
-          <tbody>
-            {pulse.events.map((row) => (
-              <tr className="pulse-activity-row" key={row.id}>
-                <td data-label="When">{row.occurred_at.slice(11, 16)}</td>
-                <td data-label="Event">{row.title}</td>
-                <td data-label="Scope">{[row.repo_ref, row.issue_ref ?? row.pull_request_ref].filter(Boolean).join(" ")}</td>
-                <td data-label="Outcome">{row.outcome.replaceAll("_", " ")}</td>
-                <td data-label="Resource">{resourceSummary(row)}</td>
-                <td data-label="Origin / actor">{row.issue_origin.replaceAll("_", "-")} · {row.author_association}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p className="notice compact-notice">Mobile activity cards replace the dense table on small screens. Detail drawer becomes a full-screen sheet on small screens, and terminal panel becomes full-screen later.</p>
-      </section>
-      <section className="pulse-layout" aria-label="Drilldown and planned actions">
-        <article className="planned-card pulse-drilldown-panel">
-          <p className="eyebrow">Drilldown placeholder</p>
-          <h3>What happened, when, why, how, who acted, and what resources were available</h3>
-          <p>Selected event details will connect timeline evidence, issue/PR/review context, provider/model/tokens/time/cost metadata, GitHub/API allowance, queue/concurrency, CI capacity, and local resource snapshots without exposing secrets.</p>
-        </article>
-        <article className="planned-card pulse-actions-panel">
-          <p className="eyebrow">Planned controls</p>
-          <h3>Actions stay disabled until audited routes land</h3>
-          <button disabled title="Terminal output needs a read-only command-output adapter" type="button">Open terminal output (planned)</button>
-          <button disabled title="Dispatch needs worker control and trust-boundary APIs" type="button">Redispatch worker (planned)</button>
-          <button disabled title="Persistence needs a write-action manifest and audit trail" type="button">Save systemic fix (planned)</button>
-        </article>
-      </section>
-    </section>
-  );
-}
-
-function resourceSummary(row: GuiStatusData["pulse_workers"]["events"][number]): string {
-  const model = row.usage?.model_ref?.replace("model:", "");
-  const providerLabel = row.usage?.provider === "openai" ? "OpenAI" : row.usage?.provider === "anthropic" ? "Anthropic" : row.usage?.provider;
-  const provider = row.usage === null ? row.resources[0]?.available_label ?? "metadata only" : `${providerLabel ?? "Provider"} · ${model ?? "model metadata pending"}`;
-  const tokens = row.usage === null ? "" : ` · ${row.usage.total_tokens.toLocaleString()} tokens`;
-
-  return `${provider}${tokens}`;
 }
 
 function HelpSurface(): ReactElement {

--- a/packages/gui-web/src/AppWorkspace.tsx
+++ b/packages/gui-web/src/AppWorkspace.tsx
@@ -293,7 +293,7 @@ function AiSessionsSurface({ selectedRepoIndex, selectedSessionId, status }: { s
           <ToolStatusCard />
           <TamboConversationPart
             part={{ id: "ai-session-tambo-preview", message_id: "ai-session-preview", kind: "tambo_component", ordinal: 1, text: null, payload_json: { component: "RepoHealthCard", tenant_ref: "local", session_ref: selectedSession?.id_ref ?? "ai-session-preview", read_only: true, props: { repo: selectedRepo?.name ?? "local workspace", status: "ready for Tambo cards", open_prs: 0, failing_checks: 0, notes: ["Server-proxied provider metadata", "Read-only schemas first"] } }, file_ref: null, source_ref: "tambo:ai-session-preview" }}
-            scope={{ tenant_ref: "local", workspace_ref: "aidevops", repo_ref: selectedRepo?.slug ?? null }}
+            scope={{ tenant_ref: "local", workspace_ref: "aidevops", repo_ref: selectedRepo?.path_ref ?? null }}
           />
         </div>
         <form className="chat-composer ai-composer" aria-label="AI prompt composer" data-tour="ai-composer">

--- a/packages/gui-web/src/PulseWorkersSurface.tsx
+++ b/packages/gui-web/src/PulseWorkersSurface.tsx
@@ -1,0 +1,262 @@
+import { type CSSProperties, type ReactElement, useState } from "react";
+import type { GuiPulseWorkerActivityEvent, GuiPulseWorkerChartSeries, GuiStatusData } from "../../gui-shared/src";
+import { text } from "./app-model";
+
+type PulseEvent = GuiPulseWorkerActivityEvent;
+type PulseFilterGroup = { label: string; values: string[] };
+
+const quickFilters = ["Needs attention", "Stalled workers", "Failed terminal checks", "Expensive runs", "Third-party issues", "No verification"];
+
+export function PulseWorkersSurface({ status }: { status: GuiStatusData }): ReactElement {
+  const pulse = status.pulse_workers;
+  const [selectedEventId, setSelectedEventId] = useState(pulse.events[0]?.id ?? "");
+  const selectedEvent = pulse.events.find((event) => event.id === selectedEventId) ?? pulse.events[0];
+  const filterGroups = buildFilterGroups(pulse);
+  const chartSeries = pulse.charts.slice(0, 4);
+  const sampleSize = pulse.kpis.reduce((total, kpi) => total + (kpi.sample_size ?? 0), 0);
+
+  return (
+    <section className="pulse-workers-surface" aria-label={text.workers}>
+      <div className="planned-card pulse-hero">
+        <p className="eyebrow">Data-driven observability · shared pulse_workers status · read-only</p>
+        <h2>{text.workers}</h2>
+        <p>{text.workersIntro}</p>
+        <section className="pulse-scope-strip" aria-label="Pulse scope and time range">
+          <span><strong>Period</strong> {pulse.period_label} · {periodChoices(pulse.selected_period)}</span>
+          <span><strong>Repo scope</strong> {pulse.scope_label}</span>
+          <span><strong>Issue origin</strong> {filterSummary(pulse.filters.issue_origins)}</span>
+          <span><strong>Provider/model scope</strong> {filterSummary(pulse.filters.providers)}</span>
+          <span><strong>Comparison</strong> {pulse.comparison_label}</span>
+          <span><strong>Sample</strong> {pulse.events.length} canonical events · {sampleSize} samples</span>
+          <span><strong>Trust boundary</strong> Metadata/status only; protected payloads excluded</span>
+        </section>
+      </div>
+
+      <section className="pulse-kpi-grid" aria-label="Pulse health summary">
+        {pulse.kpis.map((kpi) => (
+          <article className={`metric-card pulse-kpi-card pulse-status-${kpi.status}`} key={kpi.id}>
+            <span>{kpi.label} · {kpi.period_label} · {kpi.scope_label}</span>
+            <strong>{kpi.value}</strong>
+            <p>{kpi.detail} {kpi.comparison_label}{kpi.sample_size === undefined ? "" : ` · n=${kpi.sample_size}`}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="pulse-layout pulse-overview-layout" aria-label="Pulse observability hierarchy">
+        <article className="planned-card pulse-attention-panel">
+          <div className="split-heading">
+            <div>
+              <p className="eyebrow">Exceptions first</p>
+              <h3>Needs attention</h3>
+            </div>
+            <span className="count-pill">{pulse.attention.length} findings · planned actions disabled</span>
+          </div>
+          <ul>
+            {pulse.attention.map((item) => <li className={`pulse-attention-${item.severity}`} key={item.id}><strong>{item.title}</strong>: {item.detail}</li>)}
+          </ul>
+          <button disabled title="Action routes need audited worker control APIs" type="button">Create systemic fix (planned)</button>
+        </article>
+
+        <section className="pulse-chart-grid" aria-label="Pulse trend charts">
+          {chartSeries.map((chart) => <PulseChartPanel chart={chart} key={chart.id} />)}
+        </section>
+      </section>
+
+      <section className="planned-card pulse-filter-panel" aria-label="Pulse filters">
+        <div className="split-heading">
+          <div>
+            <p className="eyebrow">Filter controls</p>
+            <h3>Scope the canonical event stream</h3>
+          </div>
+          <span className="count-pill">disabled preview controls</span>
+        </div>
+        <div className="pulse-filter-groups">
+          {filterGroups.map((group) => (
+            <fieldset className="pulse-filter-group" key={group.label}>
+              <legend>{group.label}</legend>
+              <div className="pulse-filter-row">
+                {group.values.map((value) => <button disabled key={`${group.label}-${value}`} title={`${group.label}: ${value} filter is planned`} type="button">{value}</button>)}
+              </div>
+            </fieldset>
+          ))}
+        </div>
+      </section>
+
+      <section className="planned-card pulse-activity-panel" aria-label="Unified activity stream">
+        <div className="split-heading">
+          <div>
+            <p className="eyebrow">Canonical stream</p>
+            <h3>Unified activity</h3>
+          </div>
+          <section className="pulse-filter-row pulse-quick-filter-row" aria-label="Quick filters">
+            {quickFilters.map((filter) => <button disabled key={filter} title={`${filter} quick filter is planned`} type="button">{filter}</button>)}
+          </section>
+        </div>
+        <table className="pulse-activity-table" aria-label="Pulse and worker events">
+          <thead>
+            <tr className="pulse-activity-row pulse-activity-header">
+              <th scope="col">When</th><th scope="col">Event</th><th scope="col">Scope</th><th scope="col">Outcome</th><th scope="col">Resource</th><th scope="col">Origin / actor</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pulse.events.map((row) => (
+              <tr className={row.id === selectedEvent?.id ? "pulse-activity-row selected" : "pulse-activity-row"} key={row.id}>
+                <td data-label="When"><button className="pulse-row-select" onClick={() => setSelectedEventId(row.id)} type="button">{row.occurred_at.slice(11, 16)}</button></td>
+                <td data-label="Event"><strong>{row.title}</strong><span>{row.summary}</span></td>
+                <td data-label="Scope">{[row.repo_ref, row.issue_ref ?? row.pull_request_ref, row.worker_session_ref].filter(Boolean).join(" · ")}</td>
+                <td data-label="Outcome">{humanize(row.outcome)} · {humanize(row.status)}</td>
+                <td data-label="Resource">{resourceSummary(row)}</td>
+                <td data-label="Origin / actor">{humanize(row.issue_origin, "-")} · {row.author_association} · {row.actor_ref ?? "actor pending"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="pulse-card-stream" aria-label="Mobile activity cards">
+          {pulse.events.map((row) => (
+            <button className={row.id === selectedEvent?.id ? "pulse-event-card selected" : "pulse-event-card"} key={row.id} onClick={() => setSelectedEventId(row.id)} type="button">
+              <span>{row.occurred_at.slice(11, 16)} · {humanize(row.severity)}</span>
+              <strong>{row.title}</strong>
+              <small>{humanize(row.outcome)} · {resourceSummary(row)}</small>
+            </button>
+          ))}
+        </div>
+        <p className="notice compact-notice">Mobile activity cards replace the dense table on small screens. Detail drawer becomes a full-screen sheet on small screens, and terminal panel becomes full-screen later.</p>
+      </section>
+
+      <section className="pulse-layout" aria-label="Drilldown and planned actions">
+        <PulseDrilldownPanel event={selectedEvent} />
+        <article className="planned-card pulse-actions-panel">
+          <p className="eyebrow">Planned controls</p>
+          <h3>Actions stay disabled until audited routes land</h3>
+          <button disabled title="Terminal output needs a read-only command-output adapter" type="button">Open terminal output (planned)</button>
+          <button disabled title="Dispatch needs worker control and trust-boundary APIs" type="button">Redispatch worker (planned)</button>
+          <button disabled title="Persistence needs a write-action manifest and audit trail" type="button">Save systemic fix (planned)</button>
+        </article>
+      </section>
+    </section>
+  );
+}
+
+function PulseChartPanel({ chart }: { chart: GuiPulseWorkerChartSeries }): ReactElement {
+  const maxValue = Math.max(...chart.points.map((point) => point.value), 1);
+
+  return (
+    <article className="planned-card pulse-chart-panel">
+      <p className="eyebrow">Trends · day/week/month/year</p>
+      <h3>{chart.label}</h3>
+      <div className="pulse-chart-placeholder" aria-label={`${chart.label} chart for day week month year buckets`} role="img">
+        {chart.points.map((point) => <span key={`${chart.id}-${point.period}`} style={{ "--bar-height": `${Math.max(18, Math.round((point.value / maxValue) * 100))}%` } as CSSProperties}>{point.period}</span>)}
+      </div>
+      <p>{chart.unit} · {chart.points.map((point) => `${point.period_label}: ${point.value}`).join(" · ")}</p>
+    </article>
+  );
+}
+
+function PulseDrilldownPanel({ event }: { event: PulseEvent | undefined }): ReactElement {
+  if (event === undefined) {
+    return (
+      <article className="planned-card pulse-drilldown-panel pulse-detail-drawer" aria-label="Pulse event detail drawer">
+        <p className="eyebrow">Drilldown drawer</p>
+        <h3>No activity selected</h3>
+        <p>Selected event details will connect timeline evidence, issue/PR/review context, usage, resources, failure analysis, suggested systemic fixes, and planned actions without exposing secrets.</p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="planned-card pulse-drilldown-panel pulse-detail-drawer" aria-label="Pulse event detail drawer">
+      <p className="eyebrow">Drilldown drawer · selected row</p>
+      <h3>{event.title}</h3>
+      <dl className="pulse-detail-grid">
+        <div><dt>What</dt><dd>{event.summary}</dd></div>
+        <div><dt>When</dt><dd>{event.occurred_at} · {durationLabel(event.duration_ms)}</dd></div>
+        <div><dt>Why</dt><dd>{event.drilldown_sections.find((section) => section.label.toLowerCase().includes("failure"))?.body ?? event.drilldown_sections[0]?.body ?? "No failure analysis recorded."}</dd></div>
+        <div><dt>How</dt><dd>{[event.type, event.status, event.outcome].map((value) => humanize(value)).join(" · ")}</dd></div>
+        <div><dt>Who</dt><dd>{event.actor_ref ?? "actor pending"} · {humanize(event.issue_origin, "-")} · {event.author_association}</dd></div>
+        <div><dt>Issue / PR / session refs</dt><dd>{[event.repo_ref, event.issue_ref, event.pull_request_ref, event.worker_session_ref, event.command_job_ref, event.pulse_run_ref].filter(Boolean).join(" · ")}</dd></div>
+        <div><dt>Usage and cost</dt><dd>{usageSummary(event)}</dd></div>
+        <div><dt>Resources</dt><dd>{event.resources.map((resource) => `${resource.label}: ${resource.available_label} (${resource.pressure})`).join(" · ") || "Resource metadata pending"}</dd></div>
+        <div><dt>Suggested systemic fix</dt><dd>{event.drilldown_sections.find((section) => section.label.toLowerCase().includes("fix"))?.body ?? "Create a worker-ready follow-up when repeated blindspots appear."}</dd></div>
+        <div><dt>Planned actions</dt><dd>Open terminal output, redispatch worker, save systemic fix, and attach timeline evidence remain disabled until Phase 5 action routes land.</dd></div>
+      </dl>
+    </article>
+  );
+}
+
+function buildFilterGroups(pulse: GuiStatusData["pulse_workers"]): PulseFilterGroup[] {
+  return [
+    { label: "Repo", values: optionLabels(pulse.filters.repos) },
+    { label: "Event type", values: optionLabels(pulse.filters.event_types) },
+    { label: "Outcome", values: optionLabels(pulse.filters.outcomes) },
+    { label: "Status", values: unique(pulse.events.map((event) => humanize(event.status))) },
+    { label: "Severity", values: unique(pulse.events.map((event) => humanize(event.severity))) },
+    { label: "Resource", values: optionLabels(pulse.filters.resources) },
+    { label: "Provider / model", values: optionLabels(pulse.filters.providers) },
+    { label: "Model", values: unique(pulse.events.map((event) => event.usage?.model_ref?.replace("model:", "") ?? "model pending")) },
+    { label: "Issue origin", values: optionLabels(pulse.filters.issue_origins) },
+    { label: "Author", values: optionLabels(pulse.filters.authors) },
+    { label: "Author association", values: optionLabels(pulse.filters.author_associations) },
+    { label: "Cost range", values: unique(pulse.events.map((event) => event.usage?.estimated_cost_ref ?? "no cost metadata")) },
+    { label: "Duration range", values: unique(pulse.events.map((event) => durationBucket(event.duration_ms))) },
+  ];
+}
+
+function optionLabels(options: Array<{ label: string; count: number }>): string[] {
+  return options.map((option) => `${option.label} (${option.count})`);
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function filterSummary(options: Array<{ label: string; count: number }>): string {
+  return optionLabels(options).slice(0, 3).join(" · ") || "all";
+}
+
+function periodChoices(selected: string): string {
+  return ["day", "week", "month", "year"].map((period) => period === selected ? `${period} selected` : period).join(" / ");
+}
+
+function resourceSummary(row: PulseEvent): string {
+  const model = row.usage?.model_ref?.replace("model:", "");
+  const providerLabel = row.usage?.provider === "openai" ? "OpenAI" : row.usage?.provider === "anthropic" ? "Anthropic" : row.usage?.provider;
+  const provider = row.usage === null ? row.resources[0]?.available_label ?? "metadata only" : `${providerLabel ?? "Provider"} · ${model ?? "model metadata pending"}`;
+  const tokens = row.usage === null ? "" : ` · ${row.usage.total_tokens.toLocaleString()} tokens`;
+  const cost = row.usage?.estimated_cost_ref === null || row.usage?.estimated_cost_ref === undefined ? "" : ` · ${row.usage.estimated_cost_ref}`;
+
+  return `${provider}${tokens}${cost}`;
+}
+
+function usageSummary(event: PulseEvent): string {
+  if (event.usage === null) {
+    return "Usage metadata pending or not applicable.";
+  }
+
+  return `${event.usage.provider} · ${event.usage.model_ref ?? "model pending"} · ${event.usage.total_tokens.toLocaleString()} tokens · ${event.usage.estimated_cost_ref ?? "cost pending"} · ${durationLabel(event.usage.wall_time_ms)}`;
+}
+
+function durationBucket(durationMs: number | null): string {
+  if (durationMs === null) {
+    return "duration pending";
+  }
+  if (durationMs < 300000) {
+    return "under 5m";
+  }
+  if (durationMs < 1800000) {
+    return "5m-30m";
+  }
+
+  return "30m+";
+}
+
+function durationLabel(durationMs: number | null): string {
+  if (durationMs === null) {
+    return "duration pending";
+  }
+
+  return `${Math.round(durationMs / 60000)}m`;
+}
+
+function humanize(value: string, replacement = " "): string {
+  return value.replaceAll("_", replacement);
+}

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -2261,6 +2261,10 @@ code {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.pulse-overview-layout {
+  grid-template-columns: minmax(280px, 0.8fr) minmax(320px, 1.2fr);
+}
+
 .pulse-kpi-card {
   display: grid;
   gap: 8px;
@@ -2284,9 +2288,21 @@ code {
 .pulse-chart-panel,
 .pulse-activity-panel,
 .pulse-drilldown-panel,
-.pulse-actions-panel {
+.pulse-actions-panel,
+.pulse-filter-panel {
   display: grid;
   gap: 12px;
+}
+
+.pulse-attention-critical,
+.pulse-status-blocked strong,
+.pulse-status-failed strong {
+  color: var(--notification-error-fg);
+}
+
+.pulse-attention-warning,
+.pulse-status-needs_attention strong {
+  color: var(--notification-warning-fg);
 }
 
 .pulse-attention-panel ul {
@@ -2318,9 +2334,35 @@ code {
   font-size: 0.75rem;
   font-weight: 900;
   justify-content: center;
-  min-height: calc(40px + var(--bar-index, 1) * 18px);
+  min-height: max(40px, var(--bar-height, calc(40px + var(--bar-index, 1) * 18px)));
   padding: 8px 4px;
   text-transform: uppercase;
+}
+
+.pulse-chart-grid,
+.pulse-filter-groups {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.pulse-filter-group {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  margin: 0;
+  padding: 10px;
+}
+
+.pulse-filter-group legend {
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 900;
+  padding: 0 6px;
+  text-transform: uppercase;
+}
+
+.pulse-quick-filter-row {
+  justify-content: flex-end;
 }
 
 .pulse-chart-placeholder span:nth-child(2) { --bar-index: 3; }
@@ -2349,6 +2391,25 @@ code {
   padding: 12px 14px;
 }
 
+.pulse-activity-row.selected {
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
+
+.pulse-activity-row td {
+  display: grid;
+  gap: 3px;
+}
+
+.pulse-activity-row td span {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.pulse-row-select {
+  justify-self: start;
+  padding: 4px 8px;
+}
+
 .pulse-activity-row + .pulse-activity-row {
   border-top: 1px solid var(--border);
 }
@@ -2370,6 +2431,59 @@ code {
 .pulse-actions-panel button,
 .pulse-attention-panel button {
   justify-self: start;
+}
+
+.pulse-card-stream {
+  display: none;
+}
+
+.pulse-event-card {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  color: var(--text-primary);
+  display: grid;
+  gap: 5px;
+  padding: 12px;
+  text-align: left;
+}
+
+.pulse-event-card.selected {
+  border-color: var(--border-accent);
+}
+
+.pulse-event-card span,
+.pulse-event-card small {
+  color: var(--text-secondary);
+}
+
+.pulse-detail-drawer {
+  border-left: 4px solid var(--border-accent);
+}
+
+.pulse-detail-grid {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.pulse-detail-grid div {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px;
+}
+
+.pulse-detail-grid dt {
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.pulse-detail-grid dd {
+  color: var(--text-secondary);
+  margin: 3px 0 0;
 }
 
 .apps-surface .compact-notice {
@@ -3817,9 +3931,24 @@ button.managed-toggle:focus-visible {
   .data-row,
   .editable-row,
   .managed-app-details,
+  .pulse-overview-layout,
   .pulse-activity-row,
   .provider-account-list li {
     grid-template-columns: 1fr;
+  }
+
+  .pulse-chart-grid,
+  .pulse-filter-groups {
+    grid-template-columns: 1fr;
+  }
+
+  .pulse-activity-table {
+    display: none;
+  }
+
+  .pulse-card-stream {
+    display: grid;
+    gap: 10px;
   }
 
   .pulse-activity-header {
@@ -3834,6 +3963,20 @@ button.managed-toggle:focus-visible {
     color: var(--text-muted);
     content: attr(data-label) ": ";
     font-weight: 900;
+  }
+
+  .pulse-detail-drawer {
+    border-left: 0;
+    border-radius: 0;
+    margin-inline: -16px;
+  }
+
+  .pulse-detail-drawer::before {
+    color: var(--text-muted);
+    content: "Full-screen sheet layout on small screens";
+    font-size: 0.78rem;
+    font-weight: 900;
+    text-transform: uppercase;
   }
 
   .pill-tabs {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -132,20 +132,33 @@ describe("dashboard shell", () => {
     expect(html).toContain("New, rename, pin, archive, delete, share, and export");
   });
 
-  test("renders Pulse and Workers observability shell with read-only fixture hierarchy", () => {
+  test("renders Pulse and Workers data-driven dashboard with filters and drilldown", () => {
     const html = renderWorkspaceSurface(workersItem, "workers");
 
     expect(html).toContain("Pulse &amp; Workers");
-    expect(html).toContain("Last 24h · all managed repos");
+    expect(html).toContain("Data-driven observability");
+    expect(html).toContain("Repo scope");
+    expect(html).toContain("Issue origin");
+    expect(html).toContain("Provider/model scope");
     expect(html).toContain("Needs attention");
-    expect(html).toContain("Health trend placeholder");
+    expect(html).toContain("Trends · day/week/month/year");
+    expect(html).toContain("Filter controls");
+    expect(html).toContain("Status");
+    expect(html).toContain("Severity");
     expect(html).toContain("Provider / model");
+    expect(html).toContain("Cost range");
+    expect(html).toContain("Duration range");
+    expect(html).toContain("Expensive runs");
     expect(html).toContain("Community bug report");
     expect(html).toContain("third-party · CONTRIBUTOR");
     expect(html).toContain("OpenAI · gpt-5.5");
     expect(html).toContain("114,000 tokens");
     expect(html).toContain("Mobile activity cards");
     expect(html).toContain("Detail drawer becomes a full-screen sheet on small screens");
+    expect(html).toContain("Drilldown drawer");
+    expect(html).toContain("Suggested systemic fix");
+    expect(html).toContain("Usage and cost");
+    expect(html).toContain("Planned actions");
     expect(html).toContain("Open terminal output (planned)");
     expect(html).toContain("Create systemic fix (planned)");
   });


### PR DESCRIPTION
## Summary

Replaced the workers placeholder with a shared pulse_workers-driven dashboard, contextual KPI/scope strips, attention queue, chart panels, filter controls, desktop table/mobile cards, and selected-event drilldown with planned action affordances. Also repaired two GUI typecheck blockers discovered by the PR helper.

## Files Changed

packages/gui-shared/src/tambo.ts,packages/gui-web/src/AppWorkspace.tsx,packages/gui-web/src/PulseWorkersSurface.tsx,packages/gui-web/src/styles.css,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: npm run typecheck. PASS: ~/.bun/bin/bun test packages/gui-shared/tests/schema.test.ts packages/gui-web/tests/component.test.ts packages/gui-web/tests/security.test.ts. PASS: ~/.bun/bin/bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build (Vite emitted a Node 22.6.0 warning but completed successfully).

Resolves #25915


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.39 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 11m and 102,008 tokens on this as a headless worker.