### PR TITLE
fix: skip no-evidence failure miner clusters

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -968,6 +968,10 @@ create_or_preview_issue() {
 	repo_slug=$(printf '%s\n' "$cluster_json" | jq -r '.repo')
 	check_name=$(printf '%s\n' "$cluster_json" | jq -r '.check_name // "multiple-checks"')
 	count=$(printf '%s\n' "$cluster_json" | jq -r '.count')
+	if ! printf '%s\n' "$cluster_json" | jq -e 'any((.examples // [])[]?; ([.source_ref, .source_url, .run_url, .details_url] | map(. // "") | any(. != "")))' >/dev/null; then
+		echo "Skipping cluster for ${check_name} - no evidence examples"
+		return 1
+	fi
 
 	local title
 	title=$(build_issue_title "$check_name" "$count" "$is_infra")
@@ -1050,8 +1054,9 @@ create_systemic_issues() {
 			echo "Skipping infra advisory for ${infra_repo} - existing open issue with ${signal_tag}"
 			continue
 		fi
-		create_or_preview_issue "$advisory_cluster" "$pattern_id" "$systemic_threshold" "$dry_run" "true"
-		created=$((created + 1))
+		if create_or_preview_issue "$advisory_cluster" "$pattern_id" "$systemic_threshold" "$dry_run" "true"; then
+			created=$((created + 1))
+		fi
 	done <<<"$infra_repos"
 
 	# --- Code-defect cluster pass ---
@@ -1098,9 +1103,9 @@ create_systemic_issues() {
 			continue
 		fi
 
-		create_or_preview_issue "$cluster_json" "$pattern_id" "$systemic_threshold" "$dry_run" "false" ${extra_labels[@]+"${extra_labels[@]}"}
-
-		created=$((created + 1))
+		if create_or_preview_issue "$cluster_json" "$pattern_id" "$systemic_threshold" "$dry_run" "false" ${extra_labels[@]+"${extra_labels[@]}"}; then
+			created=$((created + 1))
+		fi
 		idx=$((idx + 1))
 	done
 

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -101,6 +101,19 @@ cluster_json=$(cat <<'JSON'
 JSON
 )
 
+empty_evidence_cluster_json=$(cat <<'JSON'
+{
+  "repo": "marcusquinn/aidevops",
+  "check_name": "ShellCheck",
+  "signature": "failure:shellcheck",
+  "count": 2,
+  "is_infra": false,
+  "sources": [],
+  "examples": []
+}
+JSON
+)
+
 events_json=$(cat <<'JSON'
 [
   {
@@ -122,6 +135,11 @@ JSON
 
 body=$(build_issue_body "$cluster_json" "46250abc5695" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
+if empty_evidence_output=$(create_or_preview_issue "$empty_evidence_cluster_json" "abc123" "2" "true" "false" 2>&1); then
+	empty_evidence_status=0
+else
+	empty_evidence_status=$?
+fi
 paths_json=$(fetch_pr_changed_paths_json "marcusquinn/aidevops" "25324")
 annotations_json=$(fetch_check_run_annotations_summary_json "marcusquinn/aidevops" "123")
 GH_MODE=fail
@@ -171,6 +189,8 @@ assert_contains "build_issue_body includes CodeFactor annotations" "reported fin
 assert_contains "build_issue_body handles unavailable details" "If CodeFactor details are unavailable" "$body"
 assert_contains "build_issue_body preserves failure signature context" "failure:codefactor.io" "$body"
 assert_contains "build_issue_body asks for focused regression guard" "focused regression guard" "$body"
+assert_equals "create_or_preview_issue rejects no-evidence clusters" "1" "$empty_evidence_status"
+assert_contains "create_or_preview_issue explains no-evidence skip" "no evidence examples" "$empty_evidence_output"
 assert_contains "render_issue_body_markdown includes Worker Guidance" "## Worker Guidance" "$legacy_body"
 assert_contains "render_issue_body_markdown directs workers to provider details" "details URL" "$legacy_body"
 assert_contains "render_issue_body_markdown includes affected file fallback" "affected files: .agents/scripts/vault-crypto-helper.py, .agents/scripts/vault-helper.sh" "$legacy_body"


### PR DESCRIPTION
## Summary
- Skip failure-miner issue creation when a cluster has no source/run/details evidence.
- Count only successfully-created or previewed issues so empty clusters do not consume the max-issues budget.
- Add regression coverage for the ShellCheck no-evidence cluster that produced GH#25939.

## Verification
- `shellcheck -S error .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh`
- `.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh` (19 tests)

Resolves #25939

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.39 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1h 19m and 499,753 tokens on this as a headless worker.