### PR TITLE
GH#25890: fix: suppress false simplification stall sweeps

### DIFF
--- a/.agents/scripts/pulse-simplification-orchestration.sh
+++ b/.agents/scripts/pulse-simplification-orchestration.sh
@@ -415,12 +415,12 @@ _complexity_scan_sweep_check() {
 			sweep_reason=$(echo "$sweep_result" | cut -d'|' -f2)
 			gh_create_issue --repo "$aidevops_slug" \
 				--title "LLM complexity sweep: review stalled function-complexity debt" \
-				--label "function-complexity-debt" --label "auto-dispatch" --label "tier:thinking" \
+				--label "function-complexity-debt" --label "auto-dispatch" --label "tier:thinking" --label "worker-ready" \
 				--body "## Daily LLM sweep (automated, GH#15285)
 
 **Trigger:** ${sweep_reason}
 
-The deterministic complexity scan detected that function-complexity debt has not decreased in the configured stall window. An LLM-powered deep review is needed to:
+The deterministic complexity scan detected that function-complexity debt has not decreased in the configured stall window and recent-closure throughput is zero. An LLM-powered deep review is needed to:
 
 1. Identify why existing function-complexity-debt issues are not being resolved
 2. Re-prioritize the backlog based on actual impact
@@ -429,7 +429,14 @@ The deterministic complexity scan detected that function-complexity debt has not
 
 ### Scope
 
-Review all open \`function-complexity-debt\` issues and the current \`simplification-state.json\`. Focus on the top 10 largest files first." >/dev/null 2>&1 || true
+Review all open \`function-complexity-debt\` issues and the current \`simplification-state.json\`. Focus on the top 10 largest files first.
+
+### Worker Guidance
+
+- Target files: \`.agents/scripts/pulse-simplification-scan.sh\`, \`.agents/scripts/complexity-scan-helper.sh\`, \`.agents/scripts/pulse-dispatch-engine.sh\`, and matching tests under \`.agents/scripts/tests/\`.
+- Reference pattern: keep sweep creation aligned with \`complexity-scan-helper.sh sweep-check\`, including the recent-closure throughput guard before declaring a stall.
+- Do not close debt issues solely because they are old. Close only when current repo evidence shows the file is deleted, already simplified, or duplicated.
+- Verification: run \`.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh\` plus ShellCheck on changed shell scripts." >/dev/null 2>&1 || true
 			"$scan_helper" sweep-done 2>>"$LOGFILE" || true
 		fi
 	fi

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -111,10 +111,38 @@ _complexity_scan_tree_changed() {
 	return 0
 }
 
+# Count recently closed function-complexity-debt issues for throughput-aware stall checks.
+# Arguments: $1 - now_epoch, $2 - aidevops_slug, $3 - window_seconds
+# Outputs: integer closure count
+_complexity_recent_debt_closures() {
+	local now_epoch="$1"
+	local aidevops_slug="$2"
+	local window_seconds="$3"
+	local since_epoch=$((now_epoch - window_seconds))
+	local since_date=""
+	local recent_closures=""
+
+	since_date=$(date -u -d "@${since_epoch}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) ||
+		since_date=$(date -u -r "$since_epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) ||
+		since_date=""
+	if [[ -z "$since_date" ]]; then
+		printf '0\n'
+		return 0
+	fi
+
+	recent_closures=$(gh api graphql \
+		-f query="query { search(query:\"repo:${aidevops_slug} label:function-complexity-debt is:issue is:closed closed:>${since_date}\", type:ISSUE) { issueCount } }" \
+		--jq '.data.search.issueCount' 2>/dev/null) || recent_closures="0"
+	[[ "$recent_closures" =~ ^[0-9]+$ ]] || recent_closures="0"
+	printf '%s\n' "$recent_closures"
+	return 0
+}
+
 # Check if the daily LLM sweep is due and debt is stalled.
 # The LLM sweep fires when:
 #   1. COMPLEXITY_LLM_SWEEP_INTERVAL has elapsed since last sweep, AND
-#   2. The open function-complexity-debt count has not decreased since last check
+#   2. The open function-complexity-debt count has not decreased since last check, AND
+#   3. Zero function-complexity-debt issues closed during the stall window
 # Arguments: $1 - now_epoch, $2 - aidevops_slug
 # Returns: 0 if sweep is due, 1 if not due
 _complexity_llm_sweep_due() {
@@ -162,6 +190,18 @@ _complexity_llm_sweep_due() {
 			printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
 			return 1
 		fi
+	fi
+
+	# GH#18286/GH#25890: A flat or growing open count is not a stall when
+	# workers are closing debt and the scanner is replenishing the backlog at a
+	# similar rate. Only create an LLM sweep when recent throughput is zero.
+	local recent_closures
+	recent_closures=$(_complexity_recent_debt_closures "$now_epoch" "$aidevops_slug" "$COMPLEXITY_LLM_SWEEP_INTERVAL")
+	[[ "$recent_closures" =~ ^[0-9]+$ ]] || recent_closures="0"
+	if [[ "$recent_closures" -gt 0 ]]; then
+		echo "[pulse-wrapper] Complexity LLM sweep: debt at ${current_count} but ${recent_closures} issue(s) closed in the last $((COMPLEXITY_LLM_SWEEP_INTERVAL / 3600))h — active throughput, sweep not needed" >>"$LOGFILE"
+		printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+		return 1
 	fi
 
 	# GH#17536: Skip sweep when all remaining debt issues are already dispatched.
@@ -222,7 +262,7 @@ _complexity_run_llm_sweep() {
 
 **Open function-complexity-debt issues:** ${current_count:-unknown}
 
-The simplification debt count has not decreased in the last $((COMPLEXITY_LLM_SWEEP_INTERVAL / 3600))h. This issue is a prompt for the LLM to review the current state and suggest approach adjustments.
+The simplification debt count has not decreased in the last $((COMPLEXITY_LLM_SWEEP_INTERVAL / 3600))h, and the throughput guard found no recent function-complexity-debt closures. This issue is a worker-ready prompt for the LLM to review the current state and ship a small self-healing improvement when the cause is clear.
 
 ### Questions to investigate
 
@@ -236,6 +276,13 @@ The simplification debt count has not decreased in the last $((COMPLEXITY_LLM_SW
 - Review the oldest 10 open function-complexity-debt issues and close any that are no longer relevant.
 - Check if \`tier:simple\` and \`tier:standard\` issues are being dispatched — if not, verify the pulse is routing them correctly.
 - If debt is growing, consider lowering \`COMPLEXITY_MD_MIN_LINES\` or \`COMPLEXITY_FILE_VIOLATION_THRESHOLD\` to catch more candidates.
+
+### Worker Guidance
+
+- Target files: \`.agents/scripts/pulse-simplification-scan.sh\`, \`.agents/scripts/complexity-scan-helper.sh\`, \`.agents/scripts/pulse-dispatch-engine.sh\`, and matching tests under \`.agents/scripts/tests/\`.
+- Reference pattern: keep the inline sweep guard consistent with \`complexity-scan-helper.sh sweep-check\`, especially the recent-closure throughput check before filing a stall issue.
+- Do not close debt issues solely because they are old. Close only when current repo evidence shows the file is deleted, already simplified, or duplicated.
+- Verification: run \`.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh\` plus ShellCheck on changed shell scripts.
 
 ### Confidence: low
 
@@ -263,7 +310,7 @@ This is an automated stall-detection sweep. The LLM should review the actual iss
 	# on other runners, producing audit trail gaps.
 	if gh_create_issue --repo "$aidevops_slug" \
 		--title "perf: simplification debt stalled — LLM sweep needed ($(date -u +%Y-%m-%d))" \
-		--label "function-complexity-debt" $sweep_review_label --label "tier:thinking" \
+		--label "function-complexity-debt" $sweep_review_label --label "tier:thinking" --label "worker-ready" \
 		--body "$sweep_body" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Complexity LLM sweep: created stall-review issue" >>"$LOGFILE"
 	else

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -26,6 +26,7 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 ORIGINAL_HOME="${HOME}"
+ORIGINAL_PATH="${PATH}"
 
 print_result() {
 	local test_name="$1"
@@ -59,6 +60,7 @@ setup_test_env() {
 
 teardown_test_env() {
 	export HOME="$ORIGINAL_HOME"
+	export PATH="$ORIGINAL_PATH"
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
@@ -74,6 +76,39 @@ make_test_repo() {
 	printf '#!/usr/bin/env bash\n# test file\necho hello\n' >"${repo_path}/.agents/scripts/test.sh"
 	git -C "$repo_path" add . 2>/dev/null
 	git -C "$repo_path" commit -q -m "init" 2>/dev/null
+	return 0
+}
+
+install_fake_gh_for_sweep() {
+	local stub_dir="${TEST_ROOT}/stub-bin"
+	mkdir -p "$stub_dir"
+	cat >"${stub_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+cmd="$1"
+subcmd="${2:-}"
+args="$*"
+case "$cmd" in
+	api)
+		if [[ "$subcmd" == "graphql" ]]; then
+			if [[ "$args" == *"search(query"* ]]; then
+				printf '%s\n' "${GH_RECENT_CLOSURES:-0}"
+			else
+				printf '%s\n' "${GH_OPEN_DEBT_COUNT:-0}"
+			fi
+			exit 0
+		fi
+		;;
+	issue)
+		if [[ "$subcmd" == "list" ]]; then
+			printf '%s\n' "${GH_ISSUE_LIST_JSON:-[]}"
+			exit 0
+		fi
+		;;
+esac
+exit 0
+EOF
+	chmod +x "${stub_dir}/gh"
+	export PATH="${stub_dir}:${ORIGINAL_PATH}"
 	return 0
 }
 
@@ -189,6 +224,46 @@ test_llm_sweep_check_interval_guard() {
 	return 0
 }
 
+test_llm_sweep_skips_when_recent_closures_exist() {
+	install_fake_gh_for_sweep
+	local now_epoch
+	now_epoch=$(date +%s)
+	local old_epoch=$((now_epoch - COMPLEXITY_LLM_SWEEP_INTERVAL - 60))
+	printf '%s\n' "$old_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	printf '10\n' >"$COMPLEXITY_DEBT_COUNT_FILE"
+	export GH_OPEN_DEBT_COUNT=10
+	export GH_RECENT_CLOSURES=2
+	export GH_ISSUE_LIST_JSON='[]'
+
+	if ! _complexity_llm_sweep_due "$now_epoch" "test/repo" 2>/dev/null; then
+		print_result "_complexity_llm_sweep_due: active throughput suppresses stall sweep" 0
+	else
+		print_result "_complexity_llm_sweep_due: active throughput suppresses stall sweep" 1 "expected 1 (not due)"
+	fi
+	unset GH_OPEN_DEBT_COUNT GH_RECENT_CLOSURES GH_ISSUE_LIST_JSON
+	return 0
+}
+
+test_llm_sweep_due_when_zero_recent_closures() {
+	install_fake_gh_for_sweep
+	local now_epoch
+	now_epoch=$(date +%s)
+	local old_epoch=$((now_epoch - COMPLEXITY_LLM_SWEEP_INTERVAL - 60))
+	printf '%s\n' "$old_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	printf '10\n' >"$COMPLEXITY_DEBT_COUNT_FILE"
+	export GH_OPEN_DEBT_COUNT=10
+	export GH_RECENT_CLOSURES=0
+	export GH_ISSUE_LIST_JSON='[]'
+
+	if _complexity_llm_sweep_due "$now_epoch" "test/repo" 2>/dev/null; then
+		print_result "_complexity_llm_sweep_due: zero recent closures allows stall sweep" 0
+	else
+		print_result "_complexity_llm_sweep_due: zero recent closures allows stall sweep" 1 "expected 0 (due)"
+	fi
+	unset GH_OPEN_DEBT_COUNT GH_RECENT_CLOSURES GH_ISSUE_LIST_JSON
+	return 0
+}
+
 # =============================================================================
 # Tests: _complexity_scan_check_interval
 # =============================================================================
@@ -248,6 +323,8 @@ main() {
 	test_tree_changed_after_commit_returns_changed
 	test_llm_sweep_not_due_when_interval_not_elapsed
 	test_llm_sweep_check_interval_guard
+	test_llm_sweep_skips_when_recent_closures_exist
+	test_llm_sweep_due_when_zero_recent_closures
 	test_check_interval_due_when_no_last_run
 	test_check_interval_not_due_when_recent
 	test_check_interval_due_when_elapsed


### PR DESCRIPTION
## Summary

Added a recent-closure throughput guard to the inline simplification LLM sweep so flat/growing debt counts do not file stall tasks while workers are closing function-complexity debt. Marked generated sweep issues worker-ready with concrete target files, reference patterns, and verification steps in both sweep creation paths.

## Files Changed

.agents/scripts/pulse-simplification-orchestration.sh,.agents/scripts/pulse-simplification-scan.sh,.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh; shellcheck .agents/scripts/pulse-simplification-scan.sh .agents/scripts/pulse-simplification-orchestration.sh .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

Resolves #25890


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.39 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 13m and 103,004 tokens on this as a headless worker.