### PR TITLE
GH#25924: fix: reduce tambo validation complexity

### DIFF
--- a/packages/gui-shared/src/tambo.ts
+++ b/packages/gui-shared/src/tambo.ts
@@ -172,28 +172,58 @@ type TamboPayloadEnvelopeValidation =
   | { ok: true; schema: GuiTamboComponentSchema; props: Record<string, unknown> }
   | { ok: false; result: GuiTamboValidationResult };
 
+type TamboComponentLookup =
+  | { ok: true; payload: Record<string, unknown>; schema: GuiTamboComponentSchema }
+  | { ok: false; result: GuiTamboValidationResult };
+
 function validateTamboPayloadEnvelope(payload: unknown, scope: GuiConversationScope): TamboPayloadEnvelopeValidation {
+  const lookup = resolveTamboComponentLookup(payload);
+  if (lookup.ok === false) {
+    return lookup;
+  }
+
+  const envelopeError = validateScopedTamboEnvelope(lookup.payload, scope);
+  if (envelopeError !== null) {
+    return { ok: false, result: invalid(lookup.schema.name, {}, envelopeError) };
+  }
+
+  const props = resolveTamboComponentProps(lookup.schema, lookup.payload.props);
+  if (props.ok === false) {
+    return props;
+  }
+
+  return { ok: true, schema: lookup.schema, props: props.value };
+}
+
+function resolveTamboComponentLookup(payload: unknown): TamboComponentLookup {
   if (!isRecord(payload)) {
     return { ok: false, result: invalid(null, {}, "payload_not_object") };
   }
-  if (typeof payload.component !== "string") {
-    return { ok: false, result: invalid(null, {}, "component_missing") };
-  }
 
-  const schema = findTamboComponentSchema(payload.component);
+  const schema = resolveTamboComponentSchema(payload.component);
   if (schema === undefined) {
-    return { ok: false, result: invalid(null, {}, "component_not_registered") };
+    return { ok: false, result: invalid(null, {}, componentLookupError(payload.component)) };
   }
 
-  const envelopeError = validateScopedTamboEnvelope(payload, scope);
-  if (envelopeError !== null) {
-    return { ok: false, result: invalid(schema.name, {}, envelopeError) };
-  }
-  if (!isRecord(payload.props)) {
+  return { ok: true, payload, schema };
+}
+
+function resolveTamboComponentSchema(component: unknown): GuiTamboComponentSchema | undefined {
+  return typeof component === "string" ? findTamboComponentSchema(component) : undefined;
+}
+
+function componentLookupError(component: unknown): string {
+  return typeof component === "string" ? "component_not_registered" : "component_missing";
+}
+
+function resolveTamboComponentProps(
+  schema: GuiTamboComponentSchema,
+  props: unknown,
+): { ok: true; value: Record<string, unknown> } | { ok: false; result: GuiTamboValidationResult } {
+  if (!isRecord(props)) {
     return { ok: false, result: invalid(schema.name, {}, "props_not_object") };
   }
-
-  return { ok: true, schema, props: payload.props };
+  return { ok: true, value: props };
 }
 
 function findTamboComponentSchema(component: string): GuiTamboComponentSchema | undefined {

--- a/packages/gui-shared/tests/schema.test.ts
+++ b/packages/gui-shared/tests/schema.test.ts
@@ -55,6 +55,15 @@ describe("GUI shared schema contracts", () => {
     expect(activeApproval.errors).toContain("approval_prompt_must_be_disabled");
   });
 
+  test("Tambo payload validation reports malformed envelopes before props", () => {
+    const scope = { tenant_ref: "tenant:local-owner", workspace_ref: "workspace:aidevops", repo_ref: "repo:marcusquinn/aidevops" };
+
+    expect(validateTamboComponentPayload(null, scope).errors).toEqual(["payload_not_object"]);
+    expect(validateTamboComponentPayload({ props: {} }, scope).errors).toEqual(["component_missing"]);
+    expect(validateTamboComponentPayload({ component: "UnknownCard", props: {} }, scope).errors).toEqual(["component_not_registered"]);
+    expect(validateTamboComponentPayload({ component: "TaskCard", tenant_ref: "tenant:local-owner", session_ref: "conversation:ai-session-1", read_only: true, props: [] }, scope).errors).toEqual(["props_not_object"]);
+  });
+
   test("status envelope preserves source and redaction metadata", () => {
     const envelope = createEnvelope({
       operation_id: "setup.status.read",


### PR DESCRIPTION
## Summary

Refactored Tambo component payload envelope validation into smaller lookup, schema, and props helpers while preserving error ordering; added schema test coverage for malformed Tambo envelopes.

## Files Changed

packages/gui-shared/src/tambo.ts,packages/gui-shared/tests/schema.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun test packages/gui-shared/tests/schema.test.ts (blocked: bun not installed in worker image); bun run typecheck (blocked: bun not installed in worker image); npx --no-install tsc --noEmit (blocked: local TypeScript compiler not installed); .agents/scripts/linters-local.sh (SonarCloud green and changed-shell gates passed before timeout during Secretlint)

Resolves #25924


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.40 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 8m and 41,673 tokens on this as a headless worker.