### PR TITLE
GH#25972: fix: harden Tambo complexity test path lookup

### DIFF
--- a/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
+++ b/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
@@ -9,7 +9,7 @@
 
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
 TAMBO_FILE="${REPO_ROOT}/packages/gui-shared/src/tambo.ts"
 


### PR DESCRIPTION
## Summary

Updated .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh to safely expand BASH_SOURCE[0] under set -u so the script does not fail when BASH_SOURCE is unset.

## Files Changed

.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh; bash .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh

Resolves #25972


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 30,760 tokens on this as a headless worker.