### PR TITLE
GH#25976: fix: cache auto-dispatch label lookup

### DIFF
--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -289,9 +289,10 @@ list_dispatchable_issue_candidates_json() {
 			# candidate build and dispatch.
 			select(($labels | index("parent-task")) == null) |
 			select(($labels | index("no-auto-dispatch")) == null) |
-			select((($labels | index("status:in-progress")) == null) or (($labels | index($auto_dispatch_label)) != null)) |
-			select((($labels | index("status:in-review")) == null) or (($labels | index($auto_dispatch_label)) != null)) |
-			select((($labels | index("status:claimed")) == null) or (($labels | index($auto_dispatch_label)) != null)) |
+			(($labels | index($auto_dispatch_label)) != null) as $has_auto_dispatch |
+			select((($labels | index("status:in-progress")) == null) or $has_auto_dispatch) |
+			select((($labels | index("status:in-review")) == null) or $has_auto_dispatch) |
+			select((($labels | index("status:claimed")) == null) or $has_auto_dispatch) |
 			select(($labels | index("status:done")) == null) |
 			{
 				number,


### PR DESCRIPTION
## Summary

Cached the jq auto-dispatch label membership check in list_dispatchable_issue_candidates_json so the status label filters reuse a single boolean instead of recalculating the same lookup.

## Files Changed

.agents/scripts/pulse-repo-meta.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-repo-meta.sh; bash -n .agents/scripts/pulse-repo-meta.sh

Resolves #25976


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 57,047 tokens on this as a headless worker.