### PR TITLE
GH#25975: fix: harden pulse interactive hold labels

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1128,14 +1128,14 @@ _is_task_committed_to_main() {
 # moved on, so it must not strand work forever (GH#22964/GH#22965).
 #
 # Args:
-#   $1 - issue metadata JSON with .labels[].name
+#   $1 - issue metadata JSON with optional .labels[].name
 # Returns: 0 when an interactive hold label is present, 1 otherwise
 #######################################
 _dispatch_has_interactive_hold() {
 	local issue_meta_json="$1"
 	[[ -n "$issue_meta_json" ]] || return 1
 	printf '%s' "$issue_meta_json" |
-		jq -e '.labels | map(.name) | ((index("auto-dispatch") | not) and (index("status:in-review") or index("origin:interactive")))' >/dev/null 2>&1
+		jq -e '(.labels // []) | map(.name) | ((index("auto-dispatch") | not) and (index("status:in-review") or index("origin:interactive")))' >/dev/null 2>&1
 	return $?
 }
 


### PR DESCRIPTION
## Summary

Updated .agents/scripts/pulse-dispatch-core.sh so _dispatch_has_interactive_hold treats missing or null issue labels as an empty label array before mapping label names. Refreshed the function argument comment to document optional labels.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-core.sh; direct jq regression checks for missing labels, null labels, status:in-review hold, and auto-dispatch carve-out

Resolves #25975


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 61,450 tokens on this as a headless worker.