### PR TITLE
GH#25963: fix complexity sweep interval tests

### DIFF
--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -228,7 +228,7 @@ test_llm_sweep_skips_when_recent_closures_exist() {
 	install_fake_gh_for_sweep
 	local now_epoch
 	now_epoch=$(date +%s)
-	local old_epoch=$((now_epoch - COMPLEXITY_LLM_SWEEP_INTERVAL - 60))
+	local old_epoch=$((now_epoch - ${COMPLEXITY_LLM_SWEEP_INTERVAL:-0} - 60))
 	printf '%s\n' "$old_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
 	printf '10\n' >"$COMPLEXITY_DEBT_COUNT_FILE"
 	export GH_OPEN_DEBT_COUNT=10
@@ -248,7 +248,7 @@ test_llm_sweep_due_when_zero_recent_closures() {
 	install_fake_gh_for_sweep
 	local now_epoch
 	now_epoch=$(date +%s)
-	local old_epoch=$((now_epoch - COMPLEXITY_LLM_SWEEP_INTERVAL - 60))
+	local old_epoch=$((now_epoch - ${COMPLEXITY_LLM_SWEEP_INTERVAL:-0} - 60))
 	printf '%s\n' "$old_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
 	printf '10\n' >"$COMPLEXITY_DEBT_COUNT_FILE"
 	export GH_OPEN_DEBT_COUNT=10


### PR DESCRIPTION
## Summary
- Hardened complexity LLM sweep test timestamp setup against unset or empty COMPLEXITY_LLM_SWEEP_INTERVAL.
- Updated both affected test cases in .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh.

## Testing
- shellcheck .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
- .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

Resolves #25963
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 36,045 tokens on this as a headless worker.