### PR TITLE
GH#25962: fix: harden simplification sweep interval defaults

### DIFF
--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -115,9 +115,9 @@ _complexity_scan_tree_changed() {
 # Arguments: $1 - now_epoch, $2 - aidevops_slug, $3 - window_seconds
 # Outputs: integer closure count
 _complexity_recent_debt_closures() {
-	local now_epoch="$1"
-	local aidevops_slug="$2"
-	local window_seconds="$3"
+	local now_epoch="${1:-0}"
+	local aidevops_slug="${2:-}"
+	local window_seconds="${3:-0}"
 	local since_epoch=$((now_epoch - window_seconds))
 	local since_date=""
 	local recent_closures=""
@@ -146,8 +146,9 @@ _complexity_recent_debt_closures() {
 # Arguments: $1 - now_epoch, $2 - aidevops_slug
 # Returns: 0 if sweep is due, 1 if not due
 _complexity_llm_sweep_due() {
-	local now_epoch="$1"
-	local aidevops_slug="$2"
+	local now_epoch="${1:-0}"
+	local aidevops_slug="${2:-}"
+	local sweep_interval="${COMPLEXITY_LLM_SWEEP_INTERVAL:-0}"
 
 	# Interval guard
 	if [[ -f "$COMPLEXITY_LLM_SWEEP_LAST_RUN" ]]; then
@@ -155,7 +156,7 @@ _complexity_llm_sweep_due() {
 		last_sweep=$(cat "$COMPLEXITY_LLM_SWEEP_LAST_RUN" 2>/dev/null || echo "0")
 		[[ "$last_sweep" =~ ^[0-9]+$ ]] || last_sweep=0
 		local elapsed=$((now_epoch - last_sweep))
-		if [[ "$elapsed" -lt "$COMPLEXITY_LLM_SWEEP_INTERVAL" ]]; then
+		if [[ "$elapsed" -lt "$sweep_interval" ]]; then
 			return 1
 		fi
 	fi
@@ -196,10 +197,10 @@ _complexity_llm_sweep_due() {
 	# workers are closing debt and the scanner is replenishing the backlog at a
 	# similar rate. Only create an LLM sweep when recent throughput is zero.
 	local recent_closures
-	recent_closures=$(_complexity_recent_debt_closures "$now_epoch" "$aidevops_slug" "$COMPLEXITY_LLM_SWEEP_INTERVAL")
+	recent_closures=$(_complexity_recent_debt_closures "$now_epoch" "$aidevops_slug" "$sweep_interval")
 	[[ "$recent_closures" =~ ^[0-9]+$ ]] || recent_closures="0"
 	if [[ "$recent_closures" -gt 0 ]]; then
-		echo "[pulse-wrapper] Complexity LLM sweep: debt at ${current_count} but ${recent_closures} issue(s) closed in the last $((COMPLEXITY_LLM_SWEEP_INTERVAL / 3600))h — active throughput, sweep not needed" >>"$LOGFILE"
+		echo "[pulse-wrapper] Complexity LLM sweep: debt at ${current_count} but ${recent_closures} issue(s) closed in the last $((sweep_interval / 3600))h — active throughput, sweep not needed" >>"$LOGFILE"
 		printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
 		return 1
 	fi
@@ -262,7 +263,7 @@ _complexity_run_llm_sweep() {
 
 **Open function-complexity-debt issues:** ${current_count:-unknown}
 
-The simplification debt count has not decreased in the last $((COMPLEXITY_LLM_SWEEP_INTERVAL / 3600))h, and the throughput guard found no recent function-complexity-debt closures. This issue is a worker-ready prompt for the LLM to review the current state and ship a small self-healing improvement when the cause is clear.
+The simplification debt count has not decreased in the last $((${COMPLEXITY_LLM_SWEEP_INTERVAL:-0} / 3600))h, and the throughput guard found no recent function-complexity-debt closures. This issue is a worker-ready prompt for the LLM to review the current state and ship a small self-healing improvement when the cause is clear.
 
 ### Questions to investigate
 

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -10,6 +10,8 @@
 #   - _complexity_llm_sweep_due: returns 1 when interval not elapsed
 #   - _complexity_llm_sweep_due: returns 1 when debt count decreased
 #   - _complexity_llm_sweep_due: returns 0 when interval elapsed and debt stalled
+#   - _complexity_llm_sweep_due: tolerates an unset sweep interval under set -u
+#   - _complexity_recent_debt_closures: tolerates empty arithmetic inputs under set -u
 #   - _complexity_scan_check_interval: returns 0 when no last-run file
 #   - _complexity_scan_check_interval: returns 1 when interval not elapsed
 
@@ -264,6 +266,42 @@ test_llm_sweep_due_when_zero_recent_closures() {
 	return 0
 }
 
+test_recent_closures_defaults_empty_arithmetic_inputs() {
+	install_fake_gh_for_sweep
+	export GH_RECENT_CLOSURES=0
+	local recent_closures
+	recent_closures=$(_complexity_recent_debt_closures "" "test/repo" "")
+	if [[ "$recent_closures" == "0" ]]; then
+		print_result "_complexity_recent_debt_closures: defaults empty arithmetic inputs" 0
+	else
+		print_result "_complexity_recent_debt_closures: defaults empty arithmetic inputs" 1 "expected 0, got '$recent_closures'"
+	fi
+	unset GH_RECENT_CLOSURES
+	return 0
+}
+
+test_llm_sweep_unset_interval_does_not_trip_strict_mode() {
+	install_fake_gh_for_sweep
+	local previous_interval="${COMPLEXITY_LLM_SWEEP_INTERVAL:-}"
+	local now_epoch
+	now_epoch=$(date +%s)
+	printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	export GH_OPEN_DEBT_COUNT=10
+	export GH_RECENT_CLOSURES=1
+	export GH_ISSUE_LIST_JSON='[]'
+	unset COMPLEXITY_LLM_SWEEP_INTERVAL
+
+	if _complexity_llm_sweep_due "$now_epoch" "test/repo" >/dev/null 2>&1 || [[ $? -eq 1 ]]; then
+		print_result "_complexity_llm_sweep_due: unset interval is strict-mode safe" 0
+	else
+		print_result "_complexity_llm_sweep_due: unset interval is strict-mode safe" 1 "function errored with interval unset"
+	fi
+
+	COMPLEXITY_LLM_SWEEP_INTERVAL="$previous_interval"
+	unset GH_OPEN_DEBT_COUNT GH_RECENT_CLOSURES GH_ISSUE_LIST_JSON
+	return 0
+}
+
 # =============================================================================
 # Tests: _complexity_scan_check_interval
 # =============================================================================
@@ -325,6 +363,8 @@ main() {
 	test_llm_sweep_check_interval_guard
 	test_llm_sweep_skips_when_recent_closures_exist
 	test_llm_sweep_due_when_zero_recent_closures
+	test_recent_closures_defaults_empty_arithmetic_inputs
+	test_llm_sweep_unset_interval_does_not_trip_strict_mode
 	test_check_interval_due_when_no_last_run
 	test_check_interval_not_due_when_recent
 	test_check_interval_due_when_elapsed


### PR DESCRIPTION
## Summary

Hardened simplification sweep arithmetic under strict mode by defaulting optional epoch/window/interval values and added regression coverage for empty closure inputs plus an unset sweep interval.

## Files Changed

.agents/scripts/pulse-simplification-scan.sh,.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh (14/14 passed); shellcheck .agents/scripts/pulse-simplification-scan.sh .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

Resolves #25962


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 6m and 59,196 tokens on this as a headless worker.