### PR TITLE
GH#25970: fix: preserve tool latest reference updates

### DIFF
--- a/.agents/scripts/tests/test-tool-version-check-classify.sh
+++ b/.agents/scripts/tests/test-tool-version-check-classify.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#25970: _classify_tool_status must update caller
+# by-reference variables even when the caller's latest variable is passed as
+# latest_ref.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOL_VERSION_CHECK="$REPO_ROOT/.agents/scripts/tool-version-check.sh"
+
+if [[ ! -f "$TOOL_VERSION_CHECK" ]]; then
+	printf 'FAIL: cannot find %s\n' "$TOOL_VERSION_CHECK" >&2
+	exit 1
+fi
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/t25970-XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+extract_function() {
+	awk '
+		/^_classify_tool_status\(\)/, /^}$/ { print; next }
+	' "$TOOL_VERSION_CHECK" >"$SANDBOX/extract.sh"
+	if ! grep -q '^_classify_tool_status()' "$SANDBOX/extract.sh"; then
+		printf 'FAIL: extraction did not capture _classify_tool_status\n' >&2
+		exit 1
+	fi
+	return 0
+}
+
+source_extracted() {
+	GREEN="green"
+	RED="red"
+	YELLOW="yellow"
+	AIDEVOPS_GH_MIN_SLURP_VERSION="2.67.0"
+	INSTALLED_COUNT=0
+	OUTDATED_COUNT=0
+	NOT_INSTALLED_COUNT=0
+	TIMEOUT_COUNT=0
+	UNKNOWN_COUNT=0
+	OUTDATED_PACKAGES=()
+	version_lt() {
+		local left="$1"
+		local right="$2"
+		if [[ "$left" < "$right" ]]; then
+			return 0
+		fi
+		return 1
+	}
+	aidevops_gh_slurp_supported() {
+		return 0
+	}
+	# shellcheck source=/dev/null
+	source "$SANDBOX/extract.sh"
+	return 0
+}
+
+extract_function
+source_extracted
+
+status=""
+icon=""
+color=""
+latest="1.2.3"
+
+_classify_tool_status "example" "1.0.0" "unknown" "upgrade example" status icon color latest
+
+if [[ "$status" != "unknown" ]]; then
+	printf 'FAIL: expected status unknown, got %s\n' "$status" >&2
+	exit 1
+fi
+
+if [[ "$latest" != "unknown" ]]; then
+	printf 'FAIL: latest_ref was not updated; expected unknown, got %s\n' "$latest" >&2
+	exit 1
+fi
+
+printf 'PASS: _classify_tool_status updates caller latest_ref\n'
+exit 0

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -453,7 +453,7 @@ _tool_latest_version() {
 _classify_tool_status() {
 	local cmd="$1"
 	local installed="$2"
-	local latest="$3"
+	local latest_val="$3"
 	local update_cmd="$4"
 	local status_ref="$5"
 	local icon_ref="$6"
@@ -463,7 +463,7 @@ _classify_tool_status() {
 	local class_status="up_to_date"
 	local class_icon="✓"
 	local class_color="$GREEN"
-	local effective_latest="$latest"
+	local effective_latest="$latest_val"
 
 	if [[ "$cmd" == "gh" && "$installed" != "not installed" ]] && ! aidevops_gh_slurp_supported; then
 		class_status="minimum_required"
@@ -482,12 +482,12 @@ _classify_tool_status() {
 		class_icon="⏱"
 		class_color="$RED"
 		((++TIMEOUT_COUNT))
-	elif [[ "$installed" == "unknown" || "$latest" == "unknown" ]]; then
+	elif [[ "$installed" == "unknown" || "$latest_val" == "unknown" ]]; then
 		class_status="unknown"
 		class_icon="?"
 		class_color="$YELLOW"
 		((++UNKNOWN_COUNT))
-	elif [[ "$installed" != "$latest" ]] && version_lt "$installed" "$latest"; then
+	elif [[ "$installed" != "$latest_val" ]] && version_lt "$installed" "$latest_val"; then
 		class_status="outdated"
 		class_icon="⬆"
 		class_color="$RED"


### PR DESCRIPTION
## Summary

Renamed the _classify_tool_status local latest input to latest_val so printf -v latest_ref updates the caller variable instead of a dynamically scoped local, and added regression coverage for the by-reference latest update path.

## Files Changed

.agents/scripts/tests/test-tool-version-check-classify.sh,.agents/scripts/tool-version-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: .agents/scripts/tests/test-tool-version-check-classify.sh; Passed: shellcheck .agents/scripts/tool-version-check.sh .agents/scripts/tests/test-tool-version-check-classify.sh; Partial: .agents/scripts/linters-local.sh reached Sonar/Qlty/string-literal/shellcheckrc then timed out during Secretlint after 300s.

Resolves #25970


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 12m and 61,904 tokens on this as a headless worker.