### PR TITLE
GH#25992: fix: harden intent extraction for immutable args

### DIFF
--- a/.agents/plugins/opencode-aidevops/intent-tracing.mjs
+++ b/.agents/plugins/opencode-aidevops/intent-tracing.mjs
@@ -38,7 +38,12 @@ export function extractAndStoreIntent(callID, args) {
   const hasIntent = Object.prototype.hasOwnProperty.call(args, INTENT_FIELD);
   const raw = args[INTENT_FIELD];
   if (hasIntent) {
-    delete args[INTENT_FIELD];
+    try {
+      delete args[INTENT_FIELD];
+    } catch {
+      // Tool args can come from host/runtime objects with frozen or
+      // non-configurable properties; extraction must not crash execution.
+    }
   }
 
   if (typeof raw !== "string") return undefined;

--- a/.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs
@@ -53,4 +53,20 @@ describe("extractAndStoreIntent", () => {
     assert.equal(consumeIntent(callID), undefined);
     assert.deepEqual(args, { target: "custom-tool" });
   });
+
+  test("stores intent without throwing for non-configurable args", () => {
+    const callID = "call-gh-25992-nonconfigurable";
+    const args = { target: "custom-tool" };
+    Object.defineProperty(args, "agent__intent", {
+      value: "Recording intent from immutable host args",
+      configurable: false,
+      enumerable: true,
+    });
+
+    const intent = extractAndStoreIntent(callID, args);
+
+    assert.equal(intent, "Recording intent from immutable host args");
+    assert.equal(consumeIntent(callID), "Recording intent from immutable host args");
+    assert.equal(args.agent__intent, "Recording intent from immutable host args");
+  });
 });


### PR DESCRIPTION
## Summary

Wrapped intent metadata deletion so frozen or non-configurable tool argument objects cannot crash extraction, and added regression coverage for non-configurable agent__intent properties.

## Files Changed

.agents/plugins/opencode-aidevops/intent-tracing.mjs,.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test (from .agents/plugins/opencode-aidevops); npm run typecheck

Resolves #25992


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 88,922 tokens on this as a headless worker.