### PR TITLE
t18038: feat: add pulse worker action controls

### DIFF
--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import * as readline from "node:readline";
 import { Hono } from "hono";
-import { APP_ACTION_ROUTE_MANIFEST, APP_ACTION_STATUS_ROUTE_MANIFEST, BANNED_ROUTE_PATTERNS, createEnvelope, FILE_EXPLORER_ROUTE_MANIFEST, type GuiAppActionId, type GuiAppActionJobSummary, STATUS_ROUTE_MANIFEST, TAMBO_PROVIDER_CONFIG, TAMBO_PROXY_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
+import { APP_ACTION_ROUTE_MANIFEST, APP_ACTION_STATUS_ROUTE_MANIFEST, BANNED_ROUTE_PATTERNS, createEnvelope, FILE_EXPLORER_ROUTE_MANIFEST, type GuiAppActionId, type GuiAppActionJobSummary, type GuiPulseWorkerActionId, type GuiPulseWorkerActionJobSummary, PULSE_WORKERS_ACTION_ROUTE_MANIFEST, PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST, STATUS_ROUTE_MANIFEST, TAMBO_PROVIDER_CONFIG, TAMBO_PROXY_ROUTE_MANIFEST, VAULT_STATUS_ROUTE_MANIFEST } from "../../gui-shared/src";
 import { readFileExplorer } from "./file-adapter";
 import { readStatus, readVaultStatus } from "./status-adapter";
 
@@ -33,6 +33,15 @@ const appActionCommands: Record<string, Partial<Record<GuiAppActionId, string[]>
 };
 
 const appActionJobs = new Map<string, GuiAppActionJobSummary>();
+
+const pulseWorkerActionCommands: Record<GuiPulseWorkerActionId, { command: string[]; audit_ref: string; target_ref: string }> = {
+  diagnose: { command: ["aidevops", "pulse", "diagnose", "--gui", "--metadata-only"], audit_ref: "gui:pulse-workers:diagnose", target_ref: "selected event" },
+  run_pulse: { command: ["aidevops", "pulse", "run", "--scope", "gui"], audit_ref: "gui:pulse-workers:run-pulse", target_ref: "current filtered scope" },
+  open_logs: { command: ["aidevops", "pulse", "logs", "--metadata-only"], audit_ref: "gui:pulse-workers:open-logs", target_ref: "selected event evidence refs" },
+  create_systemic_fix: { command: ["aidevops", "task", "create", "--from-pulse", "--worker-ready"], audit_ref: "gui:pulse-workers:create-systemic-fix", target_ref: "selected event systemic-fix context" },
+};
+
+const pulseWorkerActionJobs = new Map<string, GuiPulseWorkerActionJobSummary>();
 
 export function createGuiApiApp() {
   const app = new Hono();
@@ -107,6 +116,47 @@ export function createGuiApiApp() {
     return context.json(createEnvelope({
       operation_id: APP_ACTION_STATUS_ROUTE_MANIFEST.operation_id,
       source: { surface: "apps", authority: "background job store", path_refs: [] },
+      data: job,
+    }));
+  });
+
+  app.post(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.route, (context) => {
+    const action = context.req.param("action") as GuiPulseWorkerActionId;
+    const actionCommand = pulseWorkerActionCommands[action];
+
+    if (actionCommand === undefined) {
+      return context.json(createEnvelope({
+        operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
+        source: { surface: "pulse_workers", authority: "allowlisted local command runner", path_refs: [] },
+        data: rejectedPulseWorkerJob(action, "No allowlisted command for this Pulse & Workers action."),
+        errors: ["action_not_allowlisted"],
+      }), 400);
+    }
+
+    const job = startPulseWorkerActionJob(action, actionCommand.command, actionCommand.target_ref, actionCommand.audit_ref);
+    return context.json(createEnvelope({
+      operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
+      source: { surface: "pulse_workers", authority: "allowlisted local command runner", path_refs: [".agents/scripts", "packages/gui-api/src/app.ts"] },
+      data: job,
+      warnings: ["Command runs locally in the background through an explicit allowlist. Output is redacted and retained in memory for this GUI API process only."],
+    }), 202);
+  });
+
+  app.get(PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST.route, (context) => {
+    const jobId = context.req.param("jobId");
+    const job = pulseWorkerActionJobs.get(jobId);
+    if (job === undefined) {
+      return context.json(createEnvelope({
+        operation_id: PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST.operation_id,
+        source: { surface: "pulse_workers", authority: "background job store", path_refs: [] },
+        data: rejectedPulseWorkerJob("diagnose", "Unknown Pulse & Workers job."),
+        errors: ["unknown_job"],
+      }), 404);
+    }
+
+    return context.json(createEnvelope({
+      operation_id: PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST.operation_id,
+      source: { surface: "pulse_workers", authority: "background job store", path_refs: [] },
       data: job,
     }));
   });
@@ -200,13 +250,74 @@ function appendJobLine(job: GuiAppActionJobSummary, line: string): void {
   }
 }
 
+function startPulseWorkerActionJob(action: GuiPulseWorkerActionId, command: string[], targetRef: string, auditRef: string): GuiPulseWorkerActionJobSummary {
+  const now = new Date().toISOString();
+  const job: GuiPulseWorkerActionJobSummary = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    action,
+    target_ref: targetRef,
+    status: "running",
+    command_preview: command.join(" "),
+    started_at: now,
+    finished_at: null,
+    exit_code: null,
+    output: [`$ ${command.join(" ")}`, `audit_ref=${auditRef}`],
+    audit_ref: auditRef,
+  };
+  pulseWorkerActionJobs.set(job.id, job);
+  startBackgroundProcess(command, (line) => appendPulseWorkerJobLine(job, line), (code) => {
+    job.status = code === 0 ? "completed" : "failed";
+    job.finished_at = new Date().toISOString();
+    job.exit_code = code;
+  });
+
+  return job;
+}
+
+function appendPulseWorkerJobLine(job: GuiPulseWorkerActionJobSummary, line: string): void {
+  if (line.length === 0) {
+    return;
+  }
+  job.output.push(redactOutputLine(line));
+  if (job.output.length > 400) {
+    job.output.splice(1, job.output.length - 400);
+  }
+}
+
+function startBackgroundProcess(command: string[], appendLine: (line: string) => void, finish: (code: number) => void): void {
+  const child = spawn(command[0], command.slice(1), {
+    cwd: process.cwd(),
+    env: { ...process.env, AIDEVOPS_NON_INTERACTIVE: "true", CLICOLOR_FORCE: "1", FORCE_COLOR: "1", TERM: process.env.TERM ?? "xterm-256color" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (child.stdout !== null) {
+    readline.createInterface({ input: child.stdout, terminal: false }).on("line", appendLine);
+  }
+  if (child.stderr !== null) {
+    readline.createInterface({ input: child.stderr, terminal: false }).on("line", appendLine);
+  }
+  child.on("error", (error) => {
+    appendLine(error.message);
+    finish(127);
+  });
+  child.on("close", (code) => finish(code ?? 1));
+}
+
 function redactOutputLine(line: string): string {
-  return line.replace(/(token|secret|password|authorization)=\S+/gi, "$1=[redacted]");
+  return line
+    .replace(/(token|secret|password|authorization|api[_-]?key|sessionid)=\S+/gi, "$1=[redacted]")
+    .replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
+    .replace(/-----BEGIN [A-Z ]+ PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+ PRIVATE KEY-----/g, "[redacted private key]");
 }
 
 function rejectedJob(appId: string, action: GuiAppActionId, message: string): GuiAppActionJobSummary {
   const now = new Date().toISOString();
   return { id: "rejected", app_id: appId, action, status: "rejected", command_preview: "not run", started_at: now, finished_at: now, exit_code: null, output: [message] };
+}
+
+function rejectedPulseWorkerJob(action: GuiPulseWorkerActionId, message: string): GuiPulseWorkerActionJobSummary {
+  const now = new Date().toISOString();
+  return { id: "rejected", action, target_ref: "none", status: "rejected", command_preview: "not run", started_at: now, finished_at: now, exit_code: null, output: [message], audit_ref: "gui:pulse-workers:rejected" };
 }
 
 export const app = createGuiApiApp();

--- a/packages/gui-api/tests/status-route.test.ts
+++ b/packages/gui-api/tests/status-route.test.ts
@@ -32,6 +32,25 @@ describe("status API route", () => {
     expect(body.errors).toContain("action_not_allowlisted");
   });
 
+  test("Pulse and Workers actions reject commands outside the allowlist", async () => {
+    const response = await app.request("/api/pulse-workers/actions/not-real", { method: "POST" });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.operation_id).toBe("pulse_workers.action.run");
+    expect(body.errors).toContain("action_not_allowlisted");
+    expect(body.data.command_preview).toBe("not run");
+  });
+
+  test("Pulse and Workers job status fails closed for unknown jobs", async () => {
+    const response = await app.request("/api/pulse-workers/jobs/not-real");
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.operation_id).toBe("pulse_workers.action.status");
+    expect(body.errors).toContain("unknown_job");
+  });
+
   test("unknown routes fail closed", async () => {
     const response = await app.request("/api/unknown");
     const body = await response.json();

--- a/packages/gui-shared/src/contracts.ts
+++ b/packages/gui-shared/src/contracts.ts
@@ -1,6 +1,6 @@
 export type GuiRouteClassification = "read" | "write" | "destructive";
 
-export type GuiOperationId = "setup.status.read" | "capabilities.read" | "filesystem.read" | "vault.status.read" | "apps.action.run" | "apps.action.status" | "tambo.session.read";
+export type GuiOperationId = "setup.status.read" | "capabilities.read" | "filesystem.read" | "vault.status.read" | "apps.action.run" | "apps.action.status" | "pulse_workers.action.run" | "pulse_workers.action.status" | "tambo.session.read";
 
 export type GuiFileRootId = "agents" | "config" | "localSetup" | "git";
 
@@ -104,6 +104,34 @@ export interface GuiAppActionJobSummary {
   finished_at: string | null;
   exit_code: number | null;
   output: string[];
+}
+
+export type GuiPulseWorkerActionId = "diagnose" | "run_pulse" | "open_logs" | "create_systemic_fix";
+
+export interface GuiPulseWorkerActionSummary {
+  id: GuiPulseWorkerActionId;
+  label: string;
+  enabled: boolean;
+  classification: GuiRouteClassification;
+  confirmation: "none" | "recommended" | "required";
+  command_preview: string;
+  target_ref: string;
+  scope_copy: string;
+  expected_effect: string;
+  audit_ref: string;
+}
+
+export interface GuiPulseWorkerActionJobSummary {
+  id: string;
+  action: GuiPulseWorkerActionId;
+  target_ref: string;
+  status: "running" | "completed" | "failed" | "rejected";
+  command_preview: string;
+  started_at: string;
+  finished_at: string | null;
+  exit_code: number | null;
+  output: string[];
+  audit_ref: string;
 }
 
 export interface GuiSecretReference {
@@ -345,6 +373,7 @@ export interface GuiPulseWorkerSummary {
   };
   charts: GuiPulseWorkerChartSeries[];
   events: GuiPulseWorkerActivityEvent[];
+  actions: GuiPulseWorkerActionSummary[];
 }
 
 export interface GuiConversationMessage {
@@ -653,6 +682,28 @@ export const APP_ACTION_STATUS_ROUTE_MANIFEST: GuiRouteManifest = {
   adapter: "appActions.readAppActionJob",
   command_pattern: ["background-job", "metadata-and-output-only"],
   redactions: ["secret_values", "credential_paths", "private_key_material"],
+};
+
+export const PULSE_WORKERS_ACTION_ROUTE_MANIFEST: GuiRouteManifest = {
+  route: "/api/pulse-workers/actions/:action",
+  method: "POST",
+  operation_id: "pulse_workers.action.run",
+  classification: "write",
+  source_surface: "pulse_workers",
+  adapter: "pulseWorkerActions.startPulseWorkerAction",
+  command_pattern: ["allowlisted", "aidevops", "pulse/worker-diagnostics", "background-job"],
+  redactions: ["secret_values", "credential_paths", "private_key_material", "github_tokens", "authorization_headers", "session_cookies"],
+};
+
+export const PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST: GuiRouteManifest = {
+  route: "/api/pulse-workers/jobs/:jobId",
+  method: "GET",
+  operation_id: "pulse_workers.action.status",
+  classification: "read",
+  source_surface: "pulse_workers",
+  adapter: "pulseWorkerActions.readPulseWorkerActionJob",
+  command_pattern: ["background-job", "metadata-and-redacted-output-only"],
+  redactions: ["secret_values", "credential_paths", "private_key_material", "github_tokens", "authorization_headers", "session_cookies"],
 };
 
 export const GUI_FILE_ROOTS: readonly GuiFileRootDefinition[] = [

--- a/packages/gui-shared/src/fixtures.ts
+++ b/packages/gui-shared/src/fixtures.ts
@@ -118,6 +118,12 @@ export const pulseWorkersFixture: GuiPulseWorkerSummary = {
       drilldown_sections: [{ label: "Trust boundary", body: "Non-collaborator instructions are facts only; no install commands or secrets are accepted." }],
     },
   ],
+  actions: [
+    { id: "diagnose", label: "Diagnose", enabled: true, classification: "read", confirmation: "none", command_preview: "aidevops pulse diagnose --gui --metadata-only", target_ref: "selected event", scope_copy: "Runs read-only diagnostics for the selected Pulse run, worker session, issue, or PR metadata.", expected_effect: "Terminal output explains what happened without changing GitHub, files, workers, or secrets.", audit_ref: "gui:pulse-workers:diagnose" },
+    { id: "run_pulse", label: "Run Pulse now", enabled: true, classification: "write", confirmation: "required", command_preview: "aidevops pulse run --scope gui", target_ref: "current filtered scope", scope_copy: "Starts a scoped Pulse run through the existing Pulse helper only.", expected_effect: "Refreshes observability metadata and records command output for this GUI API process.", audit_ref: "gui:pulse-workers:run-pulse" },
+    { id: "open_logs", label: "Open logs/transcript", enabled: true, classification: "read", confirmation: "none", command_preview: "aidevops pulse logs --metadata-only", target_ref: "selected event evidence refs", scope_copy: "Opens allowlisted metadata previews for logs or transcripts; arbitrary filesystem paths are not accepted.", expected_effect: "Shows redacted references and previews only.", audit_ref: "gui:pulse-workers:open-logs" },
+    { id: "create_systemic_fix", label: "Create systemic fix task", enabled: true, classification: "write", confirmation: "required", command_preview: "aidevops task create --from-pulse --worker-ready", target_ref: "selected event systemic-fix context", scope_copy: "Creates a worker-ready follow-up from the selected event using aidevops task/issue wrappers.", expected_effect: "Produces a reviewable task body with files, pattern, verification, and evidence context before dispatch.", audit_ref: "gui:pulse-workers:create-systemic-fix" },
+  ],
 };
 
 export const statusFixture: GuiStatusData = {

--- a/packages/gui-shared/tests/schema.test.ts
+++ b/packages/gui-shared/tests/schema.test.ts
@@ -6,6 +6,8 @@ import {
   conversationHasScope,
   isReadOnlyManifest,
   participantCanReadConversation,
+  PULSE_WORKERS_ACTION_ROUTE_MANIFEST,
+  PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST,
   sortConversationMessageParts,
   sortConversationMessages,
   STATUS_ROUTE_MANIFEST,
@@ -40,6 +42,14 @@ describe("GUI shared schema contracts", () => {
     expect(TAMBO_PROXY_ROUTE_MANIFEST.redactions).toContain("tambo_api_keys");
     expect(TAMBO_COMPONENT_SCHEMAS.map((schema) => schema.name)).toEqual(["TaskCard", "PullRequestCard", "CICheckSummary", "WorkerStatusCard", "DeploymentStatusCard", "RepoHealthCard", "ApprovalPromptCard"]);
     expect(TAMBO_COMPONENT_SCHEMAS.every((schema) => schema.additionalProperties === false)).toBe(true);
+  });
+
+  test("Pulse and Workers action routes declare allowlisted command boundaries", () => {
+    expect(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id).toBe("pulse_workers.action.run");
+    expect(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.classification).toBe("write");
+    expect(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.command_pattern).toContain("allowlisted");
+    expect(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.redactions).toContain("authorization_headers");
+    expect(isReadOnlyManifest(PULSE_WORKERS_ACTION_STATUS_ROUTE_MANIFEST)).toBe(true);
   });
 
   test("Tambo payload validation enforces tenant scope and strict props", () => {
@@ -94,6 +104,8 @@ describe("GUI shared schema contracts", () => {
     expect(envelope.data.pulse_workers.events[2].issue_origin).toBe("third_party");
     expect(envelope.data.pulse_workers.events[2].author_association).toBe("CONTRIBUTOR");
     expect(envelope.data.pulse_workers.charts.map((chart) => chart.points[0]?.period)).toEqual(["day", "week", "month", "year"]);
+    expect(envelope.data.pulse_workers.actions.map((action) => action.id)).toEqual(["diagnose", "run_pulse", "open_logs", "create_systemic_fix"]);
+    expect(envelope.data.pulse_workers.actions.filter((action) => action.classification === "write").every((action) => action.confirmation === "required")).toBe(true);
     expect(envelope.data.vault.collections.map((collection) => collection.surface_ids).flat()).toContain("agents");
     expect(envelope.data.setup_targets[0].path_ref).toBe("~/.aidevops/agents/VERSION");
     expect(envelope.data.ai_apps.map((app) => app.name)).toContain("OpenCode");

--- a/packages/gui-web/src/AppActionTerminal.tsx
+++ b/packages/gui-web/src/AppActionTerminal.tsx
@@ -1,11 +1,14 @@
-import type { GuiAppActionJobSummary } from "@aidevops/gui-shared";
+import type { GuiAppActionJobSummary, GuiPulseWorkerActionJobSummary } from "@aidevops/gui-shared";
 import { type ReactElement, type ReactNode, useEffect, useRef } from "react";
 import { FiX } from "react-icons/fi";
 
 const ANSI_PATTERN = /\x1b\[([0-9;]*)m/g;
 
-export function AppActionTerminal({ job, onDismiss }: { job: GuiAppActionJobSummary; onDismiss: (jobId: string) => void }): ReactElement {
+type TerminalJob = GuiAppActionJobSummary | GuiPulseWorkerActionJobSummary;
+
+export function AppActionTerminal({ job, label, onDismiss }: { job: TerminalJob; label?: string; onDismiss: (jobId: string) => void }): ReactElement {
   const outputRef = useRef<HTMLPreElement | null>(null);
+  const title = label ?? terminalTitle(job);
 
   useEffect(() => {
     if (outputRef.current !== null) {
@@ -14,11 +17,15 @@ export function AppActionTerminal({ job, onDismiss }: { job: GuiAppActionJobSumm
   }, [job.output.length]);
 
   return (
-    <section className="app-terminal" id={`app-job-${job.id}`} aria-label="App action terminal output">
-      <header><strong>{job.app_id} {job.action}</strong><span>{terminalStatusLabel(job)}</span><button aria-label={`Dismiss ${job.app_id} ${job.action} terminal output`} className="terminal-close-button" onClick={() => onDismiss(job.id)} title="Dismiss terminal output" type="button"><FiX aria-hidden="true" /></button></header>
+    <section className="app-terminal" id={`app-job-${job.id}`} aria-label={`${title} terminal output`}>
+      <header><strong>{title}</strong><span>{terminalStatusLabel(job)}</span><button aria-label={`Dismiss ${title} terminal output`} className="terminal-close-button" onClick={() => onDismiss(job.id)} title="Dismiss terminal output" type="button"><FiX aria-hidden="true" /></button></header>
       <pre ref={outputRef}>{renderTerminalOutput(job.output)}</pre>
     </section>
   );
+}
+
+function terminalTitle(job: TerminalJob): string {
+  return "app_id" in job ? `${job.app_id} ${job.action}` : `Pulse & Workers ${job.action}`;
 }
 
 function terminalStatusLabel(job: GuiAppActionJobSummary): string {

--- a/packages/gui-web/src/PulseWorkersSurface.tsx
+++ b/packages/gui-web/src/PulseWorkersSurface.tsx
@@ -1,5 +1,6 @@
-import { type CSSProperties, type ReactElement, useState } from "react";
-import type { GuiPulseWorkerActivityEvent, GuiPulseWorkerChartSeries, GuiStatusData } from "../../gui-shared/src";
+import { type CSSProperties, type Dispatch, type ReactElement, type SetStateAction, useEffect, useState } from "react";
+import type { GuiPulseWorkerActionJobSummary, GuiPulseWorkerActionSummary, GuiPulseWorkerActivityEvent, GuiPulseWorkerChartSeries, GuiResponseEnvelope, GuiStatusData } from "../../gui-shared/src";
+import { AppActionTerminal } from "./AppActionTerminal";
 import { text } from "./app-model";
 
 type PulseEvent = GuiPulseWorkerActivityEvent;
@@ -10,10 +11,32 @@ const quickFilters = ["Needs attention", "Stalled workers", "Failed terminal che
 export function PulseWorkersSurface({ status }: { status: GuiStatusData }): ReactElement {
   const pulse = status.pulse_workers;
   const [selectedEventId, setSelectedEventId] = useState(pulse.events[0]?.id ?? "");
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [jobs, setJobs] = useState<Record<string, GuiPulseWorkerActionJobSummary>>({});
+  const [dismissedJobIds, setDismissedJobIds] = useState<Set<string>>(() => new Set());
   const selectedEvent = pulse.events.find((event) => event.id === selectedEventId) ?? pulse.events[0];
+  const selectedJob = selectedJobId === null ? null : jobs[selectedJobId] ?? null;
   const filterGroups = buildFilterGroups(pulse);
   const chartSeries = pulse.charts.slice(0, 4);
   const sampleSize = pulse.kpis.reduce((total, kpi) => total + (kpi.sample_size ?? 0), 0);
+  const runningJobIdsKey = Object.values(jobs).filter((job) => job.status === "running").map((job) => job.id).sort().join("|");
+
+  useEffect(() => {
+    const runningJobIds = runningJobIdsKey.split("|").filter(Boolean);
+    if (runningJobIds.length === 0) {
+      return undefined;
+    }
+
+    const refreshRunningJobs = () => {
+      for (const jobId of runningJobIds) {
+        void refreshPulseWorkerJob(jobId, setJobs);
+      }
+    };
+    refreshRunningJobs();
+    const timer = window.setInterval(refreshRunningJobs, 1_500);
+
+    return () => window.clearInterval(timer);
+  }, [runningJobIdsKey]);
 
   return (
     <section className="pulse-workers-surface" aria-label={text.workers}>
@@ -49,12 +72,12 @@ export function PulseWorkersSurface({ status }: { status: GuiStatusData }): Reac
               <p className="eyebrow">Exceptions first</p>
               <h3>Needs attention</h3>
             </div>
-            <span className="count-pill">{pulse.attention.length} findings · planned actions disabled</span>
+            <span className="count-pill">{pulse.attention.length} findings · allowlisted actions only</span>
           </div>
           <ul>
             {pulse.attention.map((item) => <li className={`pulse-attention-${item.severity}`} key={item.id}><strong>{item.title}</strong>: {item.detail}</li>)}
           </ul>
-          <button disabled title="Action routes need audited worker control APIs" type="button">Create systemic fix (planned)</button>
+          <button disabled={!actionById(pulse.actions, "create_systemic_fix")?.enabled} onClick={() => void runPulseWorkerAction(actionById(pulse.actions, "create_systemic_fix"), setJobs, setSelectedJobId, setDismissedJobIds)} title="Create a worker-ready systemic-fix task from selected evidence" type="button">Create systemic fix task</button>
         </article>
 
         <section className="pulse-chart-grid" aria-label="Pulse trend charts">
@@ -120,21 +143,64 @@ export function PulseWorkersSurface({ status }: { status: GuiStatusData }): Reac
             </button>
           ))}
         </div>
-        <p className="notice compact-notice">Mobile activity cards replace the dense table on small screens. Detail drawer becomes a full-screen sheet on small screens, and terminal panel becomes full-screen later.</p>
+        <p className="notice compact-notice">Mobile activity cards replace the dense table on small screens. Detail drawer becomes a full-screen sheet on small screens, and terminal panel becomes a full-screen panel/sheet for command output.</p>
       </section>
 
       <section className="pulse-layout" aria-label="Drilldown and planned actions">
         <PulseDrilldownPanel event={selectedEvent} />
-        <article className="planned-card pulse-actions-panel">
-          <p className="eyebrow">Planned controls</p>
-          <h3>Actions stay disabled until audited routes land</h3>
-          <button disabled title="Terminal output needs a read-only command-output adapter" type="button">Open terminal output (planned)</button>
-          <button disabled title="Dispatch needs worker control and trust-boundary APIs" type="button">Redispatch worker (planned)</button>
-          <button disabled title="Persistence needs a write-action manifest and audit trail" type="button">Save systemic fix (planned)</button>
+        <article className="planned-card pulse-actions-panel" aria-label="Pulse and Workers action buttons">
+          <p className="eyebrow">Allowlisted controls</p>
+          <h3>Safe actions with terminal output</h3>
+          <p className="notice compact-notice">Read-only diagnostics are separated from write actions. Destructive controls such as stopping workers, closing PRs, cleanup, and rebase/update branch remain deferred.</p>
+          <div className="pulse-action-list">
+            {pulse.actions.map((action) => (
+              <button disabled={!action.enabled} key={action.id} onClick={() => void runPulseWorkerAction(action, setJobs, setSelectedJobId, setDismissedJobIds)} title={action.scope_copy} type="button">
+                <strong>{action.label}</strong>
+                <span>{action.classification} · confirmation {action.confirmation} · {action.target_ref}</span>
+              </button>
+            ))}
+          </div>
+          <dl className="pulse-detail-grid pulse-action-confirmations">
+            {pulse.actions.map((action) => <div key={`${action.id}-copy`}><dt>{action.label}</dt><dd>{action.scope_copy} {action.expected_effect} Command preview: {action.command_preview}. Audit/source ref: {action.audit_ref}.</dd></div>)}
+          </dl>
+          <p className="notice compact-notice">Create systemic fix task generates worker-ready context from the selected event: files/patterns when known, evidence refs, verification commands, and protected-data notes before wrapper dispatch.</p>
+          {selectedJob === null || dismissedJobIds.has(selectedJob.id) ? null : <AppActionTerminal job={selectedJob} label={`Pulse & Workers ${selectedJob.action}`} onDismiss={(jobId) => setDismissedJobIds((current) => new Set([...current, jobId]))} />}
         </article>
       </section>
     </section>
   );
+}
+
+async function refreshPulseWorkerJob(jobId: string, setJobs: Dispatch<SetStateAction<Record<string, GuiPulseWorkerActionJobSummary>>>): Promise<void> {
+  const response = await fetch(`/api/pulse-workers/jobs/${encodeURIComponent(jobId)}`);
+  if (!response.ok) {
+    return;
+  }
+  const envelope = await response.json() as GuiResponseEnvelope<GuiPulseWorkerActionJobSummary>;
+  setJobs((current) => ({ ...current, [envelope.data.id]: envelope.data }));
+}
+
+async function runPulseWorkerAction(action: GuiPulseWorkerActionSummary | undefined, setJobs: Dispatch<SetStateAction<Record<string, GuiPulseWorkerActionJobSummary>>>, setSelectedJobId: Dispatch<SetStateAction<string | null>>, setDismissedJobIds: Dispatch<SetStateAction<Set<string>>>): Promise<void> {
+  if (action === undefined || !action.enabled) {
+    return;
+  }
+  if (action.confirmation === "required" && typeof window !== "undefined" && !window.confirm(`${action.label}\n\nScope: ${action.scope_copy}\nExpected effect: ${action.expected_effect}\nCommand: ${action.command_preview}`)) {
+    return;
+  }
+
+  const response = await fetch(`/api/pulse-workers/actions/${encodeURIComponent(action.id)}`, { method: "POST" });
+  const envelope = await response.json() as GuiResponseEnvelope<GuiPulseWorkerActionJobSummary>;
+  setDismissedJobIds((current) => {
+    const next = new Set(current);
+    next.delete(envelope.data.id);
+    return next;
+  });
+  setJobs((current) => ({ ...current, [envelope.data.id]: envelope.data }));
+  setSelectedJobId(envelope.data.id);
+}
+
+function actionById(actions: GuiPulseWorkerActionSummary[], id: GuiPulseWorkerActionSummary["id"]): GuiPulseWorkerActionSummary | undefined {
+  return actions.find((action) => action.id === id);
 }
 
 function PulseChartPanel({ chart }: { chart: GuiPulseWorkerChartSeries }): ReactElement {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -158,9 +158,15 @@ describe("dashboard shell", () => {
     expect(html).toContain("Drilldown drawer");
     expect(html).toContain("Suggested systemic fix");
     expect(html).toContain("Usage and cost");
-    expect(html).toContain("Planned actions");
-    expect(html).toContain("Open terminal output (planned)");
-    expect(html).toContain("Create systemic fix (planned)");
+    expect(html).toContain("Allowlisted controls");
+    expect(html).toContain("Safe actions with terminal output");
+    expect(html).toContain("Diagnose");
+    expect(html).toContain("Run Pulse now");
+    expect(html).toContain("Open logs/transcript");
+    expect(html).toContain("Create systemic fix task");
+    expect(html).toContain("confirmation required");
+    expect(html).toContain("terminal panel becomes a full-screen panel/sheet");
+    expect(html).toContain("Destructive controls such as stopping workers");
   });
 
   test("renders channel and DM conversation surfaces from the unified model", () => {


### PR DESCRIPTION
## Summary

Added shared Pulse & Workers action contracts and manifests, allowlisted GUI API job routes with redaction, contextual dashboard action buttons with confirmation copy and terminal output reuse, plus schema/component/API coverage.

## Files Changed

packages/gui-api/src/app.ts,packages/gui-api/tests/status-route.test.ts,packages/gui-shared/src/contracts.ts,packages/gui-shared/src/fixtures.ts,packages/gui-shared/tests/schema.test.ts,packages/gui-web/src/AppActionTerminal.tsx,packages/gui-web/src/PulseWorkersSurface.tsx,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun test packages/gui-shared/tests/schema.test.ts packages/gui-web/tests/component.test.ts packages/gui-web/tests/security.test.ts packages/gui-api/tests/status-route.test.ts; bun ./node_modules/vite/bin/vite.js --config packages/gui-web/vite.config.ts build. Issue-specified bun run --cwd packages/gui-web build is unavailable because packages/gui-web/package.json has no build script.

Resolves #25916


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 9m and 92,010 tokens on this as a headless worker.