### PR TITLE
GH#25982: test: harden tambo codefactor guard

### DIFF
--- a/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
+++ b/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression guard for GH#25918: CodeFactor reported the Tambo payload
-# validator range in packages/gui-shared/src/tambo.ts. Keep the exported
-# validator as a compact orchestration entrypoint and push validation branches
-# into focused helpers that the package tests cover directly.
+# Regression guard for GH#25918/GH#25982: CodeFactor reported the Tambo payload
+# validator range in packages/gui-shared/src/tambo.ts. Keep each validator
+# function in that reported span compact and push validation branches into
+# focused helpers that the package tests cover directly.
 
 set -u
 
@@ -19,39 +19,52 @@ if [[ ! -f "$TAMBO_FILE" ]]; then
 fi
 
 python3 - "$TAMBO_FILE" <<'PY'
-import re
 import sys
 
 tambo_path = sys.argv[1]
 source = open(tambo_path, encoding="utf-8").read().splitlines()
 
-start = None
+limits = {
+    "validateTamboComponentPayload": {"lines": 12, "branches": 1},
+    "validateTamboPayloadEnvelope": {"lines": 22, "branches": 3},
+    "resolveTamboComponentLookup": {"lines": 12, "branches": 2},
+}
+
+functions = {}
+current_name = None
 brace_depth = 0
 body_lines = []
-for line_number, line in enumerate(source, start=1):
-    if start is None and line.startswith("export function validateTamboComponentPayload"):
-        start = line_number
-    if start is None:
+for line in source:
+    if current_name is None:
+        for name in limits:
+            if line.startswith(f"function {name}") or line.startswith(f"export function {name}"):
+                current_name = name
+                body_lines = []
+                brace_depth = 0
+                break
+    if current_name is None:
         continue
     body_lines.append(line)
     brace_depth += line.count("{") - line.count("}")
-    if brace_depth == 0 and line_number > start:
-        break
+    if brace_depth == 0 and len(body_lines) > 1:
+        functions[current_name] = body_lines
+        current_name = None
 
-if start is None:
-    print("FAIL: validateTamboComponentPayload export not found", file=sys.stderr)
+missing = sorted(set(limits) - set(functions))
+if missing:
+    print(f"FAIL: Tambo validator function(s) not found: {', '.join(missing)}", file=sys.stderr)
     sys.exit(1)
 
-body = "\n".join(body_lines)
-line_count = len(body_lines)
-branch_count = len(re.findall(r"\b(if|for|while|switch)\b", body))
+for name, body_lines in functions.items():
+    body = "\n".join(body_lines)
+    line_count = len(body_lines)
+    branch_count = sum(body.count(token) for token in ("if (", "for (", "while (", "switch ("))
+    if line_count > limits[name]["lines"]:
+        print(f"FAIL: {name} is {line_count} lines; keep <= {limits[name]['lines']}", file=sys.stderr)
+        sys.exit(1)
+    if branch_count > limits[name]["branches"]:
+        print(f"FAIL: {name} has {branch_count} branches; keep <= {limits[name]['branches']}", file=sys.stderr)
+        sys.exit(1)
 
-if line_count > 12:
-    print(f"FAIL: validateTamboComponentPayload is {line_count} lines; keep <= 12", file=sys.stderr)
-    sys.exit(1)
-if branch_count > 1:
-    print(f"FAIL: validateTamboComponentPayload has {branch_count} branches; keep <= 1", file=sys.stderr)
-    sys.exit(1)
-
-print("PASS: Tambo validator entrypoint remains CodeFactor-friendly")
+print("PASS: Tambo validator span remains CodeFactor-friendly")
 PY


### PR DESCRIPTION
## Summary

Expanded the Tambo CodeFactor regression guard to validate every compact helper in the reported packages/gui-shared/src/tambo.ts:161-209 span, not only the exported entrypoint.

## Files Changed

.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh: PASS; shellcheck .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh: PASS; bun test packages/gui-shared/tests/schema.test.ts: BLOCKED locally because bun is not installed

Resolves #25982


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 102,959 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the regression check to cover multiple validator functions instead of just one.
  * Added stricter complexity limits so future changes are more likely to stay within maintainable bounds.
  * Improved detection of missing validator functions and added clearer pass/fail reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->