### PR TITLE
GH#25961: harden dep graph blocker parsing

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -97,8 +97,8 @@ _dep_graph_process_issue_json() {
 	label_names=$(printf '%s' "$issue_json" | jq -r '.labels[]?.name // empty' 2>/dev/null) || label_names=""
 	label_blocker_tids=$(printf '%s' "$label_names" | grep -oE '^blocked-by:t[0-9]+(\.[0-9a-z]+)*$' | sed 's/^blocked-by:t//' || true)
 	label_blocker_nums=$(printf '%s' "$label_names" | grep -oE '^blocked-by:#[0-9]+$' | grep -oE '[0-9]+' || true)
-	blocker_tids=$(printf '%s\n%s\n' "$body_blocker_tids" "$label_blocker_tids" | grep -v '^$' | sort -u || true)
-	blocker_nums=$(printf '%s\n%s\n' "$body_blocker_nums" "$label_blocker_nums" | grep -v '^$' | sort -u || true)
+	blocker_tids=$(printf '%s\n%s\n' "$body_blocker_tids" "$label_blocker_tids" | sed '/^$/d' | sort -u)
+	blocker_nums=$(printf '%s\n%s\n' "$body_blocker_nums" "$label_blocker_nums" | sed '/^$/d' | sort -u)
 
 	local tid_arr="" num_arr=""
 	tid_arr=$(printf '%s' "$blocker_tids" | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || tid_arr='[]'
@@ -430,7 +430,7 @@ _refresh_all_blockers_resolved() {
 
 	# Issue number blockers
 	local blocker_nums="" bnum=""
-	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]' 2>/dev/null) || blocker_nums=""
+	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]?' || true)
 	while IFS= read -r bnum; do
 		[[ "$bnum" =~ ^[0-9]+$ ]] || continue
 		is_open=$(printf '%s' "$open_issues_json" | jq --argjson n "$bnum" 'index($n) != null' 2>/dev/null) || is_open="false"
@@ -461,7 +461,7 @@ _refresh_cleanup_resolved_blocker_labels() {
 
 	local removed_count=0
 	local blocker_nums="" blocker_num="" stale_label=""
-	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]' 2>/dev/null) || blocker_nums=""
+	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]?' || true)
 	while IFS= read -r blocker_num; do
 		[[ "$blocker_num" =~ ^[0-9]+$ ]] || continue
 		stale_label="blocked-by:#${blocker_num}"


### PR DESCRIPTION
## Summary

Hardened pulse dependency graph blocker parsing by replacing empty-line grep filters with sed deletion and making issue-number cache lookups optional without suppressing jq diagnostics.

## Files Changed

.agents/scripts/pulse-dep-graph.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-dep-graph-blocked-by.sh; shellcheck .agents/scripts/pulse-dep-graph.sh .agents/tests/test-pulse-dep-graph-blocked-by.sh

Resolves #25961


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 82,799 tokens on this as a headless worker.