### PR TITLE
GH#25989: fix: scope GUI body gradient to dark theme

### DIFF
--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -205,6 +205,20 @@
 
 body {
   background:
+    radial-gradient(ellipse at top left, color-mix(in srgb, var(--accent) 16%, transparent) 0%, transparent 36%),
+    var(--bg-secondary);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+  color: var(--text-primary);
+  font-family: var(--font-family-app);
+  line-height: 1.6;
+  margin: 0;
+  min-height: 100vh;
+  font-size: var(--font-size-app);
+}
+
+:root[data-theme="dark"] body {
+  background:
     radial-gradient(ellipse 78% 64% at top left,
       hsl(var(--accent-hue) 96% 22% / 62%) 0%,
       hsl(var(--accent-hue) 92% 18% / 34%) 34%,
@@ -221,14 +235,6 @@ body {
       color-mix(in srgb, hsl(var(--accent-hue) 92% 16%) 44%, var(--bg-secondary)) 0%,
       color-mix(in srgb, hsl(var(--accent-hue) 80% 12%) 14%, var(--bg-secondary)) 48%,
       color-mix(in srgb, var(--accent) 6%, var(--bg-primary)) 100%);
-  background-attachment: fixed;
-  background-repeat: no-repeat;
-  color: var(--text-primary);
-  font-family: var(--font-family-app);
-  line-height: 1.6;
-  margin: 0;
-  min-height: 100vh;
-  font-size: var(--font-size-app);
 }
 
 button,


### PR DESCRIPTION
## Summary

Scoped the multi-layer dark gradient to :root[data-theme="dark"] body and restored a light-friendly body background for the default/light theme in packages/gui-web/src/styles.css.

## Files Changed

packages/gui-web/src/styles.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Pre-commit hook passed during commit/amend; attempted bun run gui:test:components but bun is not installed on PATH in this worker environment.

Resolves #25989


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 96,266 tokens on this as a headless worker.