### PR TITLE
GH#26003: docs: record chat primitive stack audit

### DIFF
--- a/docs/architecture/ai-collaboration-workspace.md
+++ b/docs/architecture/ai-collaboration-workspace.md
@@ -120,6 +120,36 @@ Use a hybrid architecture:
 This keeps the current local-first Vite/Hono architecture, avoids adopting a
 second persistence owner, and gives each child issue a clear boundary.
 
+### Phase 1 audit outcome for #26003
+
+The current app shell already has the navigation seams needed for the remaining
+phases, so Phase 1 should not introduce a second router or app shell:
+
+- `packages/gui-web/src/App.tsx` owns `ShellMode`, `ConversationMode`, local
+  navigation history, selected repo, and selected session state.
+- `packages/gui-web/src/AppNavigation.tsx` owns the machine rail, DevOps/Comms
+  groups, and the AI/People conversation sidebar switch.
+- `packages/gui-web/src/AppWorkspace.tsx` owns the header action placement,
+  assistant panel, `ConversationWorkspace`, and current AI/channel/DM surfaces.
+- `packages/gui-web/src/app-model.ts` owns the typed surface registry and now
+  exports `chatPrimitiveStackDecision` so tests and later workers share one
+  source of truth for the selected chat primitives.
+
+The exact stack decision for implementation phases is:
+
+| Layer | Decision | Why |
+|-------|----------|-----|
+| App shell owner | Keep the local Vite shell and typed surface registry | Existing state/history/sidebar seams already cover AI sessions, channels, DMs, workers, repos, deployments, and settings. |
+| AI session foundation | Follow Turbostarter AI product patterns | It covers persistence, AI SDK transport, models, attachments, tool/reasoning panels, sharing, history, archive/delete/pin, and usage metadata. |
+| Chat UI primitives | Adopt local shadcn-style `MessageScroller`, `Message`, `Bubble`, `Attachment`, and `Marker` equivalents | They map directly to the existing transcript placeholders and can be introduced without changing persistence ownership. |
+| Generative UI | Use Tambo only for embedded DevOps cards/interactables | Cards should render as conversation parts; Tambo must not own channel storage, DM transport, or ordinary chat persistence. |
+| Tours | Keep signposts/tours in the header help slot | Tours are onboarding infrastructure and remain separate from chat primitives. |
+
+Do not adopt Next.js route ownership or Tambo ordinary-chat persistence in these
+phases. Later workers should extract the repeated local chat markup in
+`AppWorkspace.tsx` and `CommsConversationSurface.tsx` into reusable local
+components that match the selected primitive names.
+
 ## Implementation map for child issues
 
 ### Issue #25709: unified conversations model

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -148,6 +148,13 @@ export interface InventorySurfaceConfig {
   title: string;
 }
 
+export interface ChatPrimitiveStackDecision {
+  adopt: string[];
+  defer: string[];
+  foundation: string;
+  owner: "local_vite_shell";
+}
+
 export type SurfaceRecordCounts = Partial<Record<SurfaceId, number>>;
 
 export const text = {
@@ -318,6 +325,13 @@ export const DEFAULT_ACCENT_HUE = 123;
 export const DEFAULT_CONTRAST: ContrastPreference = "low";
 export const DEFAULT_FONT: FontPreference = "Inter";
 export const DEFAULT_FONT_SIZE: FontSizePreference = "xs";
+
+export const chatPrimitiveStackDecision: ChatPrimitiveStackDecision = {
+  owner: "local_vite_shell",
+  foundation: "Turbostarter AI patterns supply persistence, AI SDK transport, model selection, attachments, tool/reasoning panels, sharing, and session actions behind audited routes.",
+  adopt: ["MessageScroller", "Message", "Bubble", "Attachment", "Marker"],
+  defer: ["Tambo ordinary chat persistence", "Tambo channel transport", "React Joyride as chat infrastructure", "Next.js route ownership"],
+};
 
 export const contrastOptions: ContrastOption[] = [
   { value: "low", label: "Low" },

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -9,7 +9,7 @@ import { Workspace } from "../src/AppWorkspace";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
 import { CommsConversationSurface } from "../src/CommsConversationSurface";
 import { AppsSurface, nextRecommendedFilterValue } from "../src/InventorySurfaces";
-import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
+import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, chatPrimitiveStackDecision, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
 import type { GuiConversationThread, GuiManagedAppSummary } from "../../gui-shared/src";
@@ -130,6 +130,14 @@ describe("dashboard shell", () => {
     expect(html).toContain("ready for Tambo cards");
     expect(html).toContain("MessageScroller-compatible transcript");
     expect(html).toContain("New, rename, pin, archive, delete, share, and export");
+  });
+
+  test("records the audited chat primitive stack decision", () => {
+    expect(chatPrimitiveStackDecision.owner).toBe("local_vite_shell");
+    expect(chatPrimitiveStackDecision.foundation).toContain("Turbostarter AI patterns");
+    expect(chatPrimitiveStackDecision.adopt).toEqual(["MessageScroller", "Message", "Bubble", "Attachment", "Marker"]);
+    expect(chatPrimitiveStackDecision.defer).toContain("Tambo ordinary chat persistence");
+    expect(chatPrimitiveStackDecision.defer).toContain("Next.js route ownership");
   });
 
   test("renders Pulse and Workers data-driven dashboard with filters and drilldown", () => {


### PR DESCRIPTION
## Summary

Audited the existing aidevops.app shell/navigation seams, recorded the exact hybrid chat primitive stack decision in docs, and exported a tested chatPrimitiveStackDecision contract for later GUI workers.

## Files Changed

docs/architecture/ai-collaboration-workspace.md,packages/gui-web/src/app-model.ts,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; npx --yes markdownlint-cli2@0.22.0 docs/architecture/ai-collaboration-workspace.md; bun test packages/gui-web/tests/component.test.ts (blocked: bun command not found); npx tsc --noEmit (blocked: local TypeScript compiler unavailable)

Resolves #26003


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 96,057 tokens on this as a headless worker.