### PR TITLE
GH#25990: fix: trim failure miner extra labels

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -1011,6 +1011,7 @@ create_or_preview_issue() {
 			IFS=',' read -r -a label_parts <<<"$label"
 			local label_part
 			for label_part in "${label_parts[@]}"; do
+				label_part=$(printf '%s\n' "$label_part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 				[[ -n "$label_part" ]] || continue
 				[[ "$seen_labels" == *",${label_part},"* ]] && continue
 				create_cmd+=(--label "$label_part")

--- a/.agents/scripts/tests/test-generated-issue-worker-labels.sh
+++ b/.agents/scripts/tests/test-generated-issue-worker-labels.sh
@@ -166,7 +166,7 @@ test_quality_feedback_labels() {
 
 test_failure_miner_labels() {
 	local cluster_json
-	cluster_json='{"repo":"marcusquinn/aidevops","check_name":"ShellCheck","check_names":["ShellCheck"],"signature":"failure:shellcheck","count":2,"sources":["pr:#1"],"examples":[]}'
+	cluster_json='{"repo":"marcusquinn/aidevops","check_name":"ShellCheck","check_names":["ShellCheck"],"signature":"failure:shellcheck","count":2,"sources":["pr:#1"],"examples":[{"source_ref":"pr:#1"}]}'
 	reset_create_log
 	create_or_preview_issue "$cluster_json" "abc123" "2" "false" "false" >/dev/null
 	assert_create_contains "failure miner has auto-dispatch" "--label auto-dispatch"
@@ -177,6 +177,12 @@ test_failure_miner_labels() {
 	reset_create_log
 	create_or_preview_issue "$cluster_json" "abc123" "2" "false" "false" "auto-dispatch" >/dev/null
 	[[ "$(count_create_occurrences "--label auto-dispatch")" == "1" ]] && print_result "failure miner dedupes scheduler auto-dispatch label" 0 || print_result "failure miner dedupes scheduler auto-dispatch label" 1 "$(create_log_text)"
+
+	reset_create_log
+	create_or_preview_issue "$cluster_json" "abc123" "2" "false" "false" "custom:one, custom:two, auto-dispatch" >/dev/null
+	assert_create_contains "failure miner trims comma-separated labels" "--label custom:two"
+	assert_create_not_contains "failure miner omits whitespace-padded labels" "--label  custom:two"
+	[[ "$(count_create_occurrences "--label auto-dispatch")" == "1" ]] && print_result "failure miner dedupes trimmed scheduler label" 0 || print_result "failure miner dedupes trimmed scheduler label" 1 "$(create_log_text)"
 
 	reset_create_log
 	create_or_preview_issue "$cluster_json" "abc123" "2" "false" "true" >/dev/null


### PR DESCRIPTION
## Summary

Trim comma-separated failure miner extra labels before dedupe/issue creation; update generated issue label regression coverage, including evidence-backed failure miner fixtures.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-generated-issue-worker-labels.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-generated-issue-worker-labels.sh && bash .agents/scripts/tests/test-generated-issue-worker-labels.sh

Resolves #25990


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 59,989 tokens on this as a headless worker.