### PR TITLE
GH#26002: feat: activate Pulse Workers navigation shell

### DIFF
--- a/packages/gui-web/src/AppActionTerminal.tsx
+++ b/packages/gui-web/src/AppActionTerminal.tsx
@@ -28,7 +28,7 @@ function terminalTitle(job: TerminalJob): string {
   return "app_id" in job ? `${job.app_id} ${job.action}` : `Pulse & Workers ${job.action}`;
 }
 
-function terminalStatusLabel(job: GuiAppActionJobSummary): string {
+function terminalStatusLabel(job: TerminalJob): string {
   if (job.status === "running") {
     return "running";
   }

--- a/packages/gui-web/src/app-model.ts
+++ b/packages/gui-web/src/app-model.ts
@@ -386,7 +386,7 @@ export const navGroups: SurfaceNavGroup[] = [
     mode: "devops",
     items: [
       plannedNavItem("aiSessions", text.aiSessions, "AI chat and OpenCode sessions", "terminal"),
-      plannedNavItem("workers", text.workers, "Pulse, worker sessions, outcomes, and resources", "activity"),
+      { id: "workers", label: text.workers, description: "Pulse, worker sessions, outcomes, and resources", icon: "activity" },
       { id: "git", label: text.localRepos, description: "~/Git explorer", icon: "folder" },
       plannedNavItem("repos", text.repos, "Unified local and remote repo context", "git"),
       { id: "projects", label: text.projects, description: "repos.json summary", icon: "git" },

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -9,7 +9,7 @@ import { Workspace } from "../src/AppWorkspace";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
 import { CommsConversationSurface } from "../src/CommsConversationSurface";
 import { AppsSurface, nextRecommendedFilterValue } from "../src/InventorySurfaces";
-import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, chatPrimitiveStackDecision, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
+import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, chatPrimitiveStackDecision, navGroups, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
 import type { GuiConversationThread, GuiManagedAppSummary } from "../../gui-shared/src";
@@ -142,8 +142,10 @@ describe("dashboard shell", () => {
 
   test("renders Pulse and Workers data-driven dashboard with filters and drilldown", () => {
     const html = renderWorkspaceSurface(workersItem, "workers");
+    const workersNavItem = navGroups.flatMap((group) => group.items).find((item) => item.id === "workers");
 
     expect(html).toContain("Pulse &amp; Workers");
+    expect(workersNavItem).toMatchObject({ badge: undefined, label: "Pulse & Workers" });
     expect(html).toContain("Data-driven observability");
     expect(html).toContain("Repo scope");
     expect(html).toContain("Issue origin");


### PR DESCRIPTION
## Summary

Activated the Pulse & Workers navigation item as an implemented fixture-backed observability shell rather than a planned placeholder, added component coverage for the active navigation label and badge state, and fixed the shared action terminal status helper so Pulse worker action jobs satisfy typecheck.

## Files Changed

packages/gui-web/src/AppActionTerminal.tsx,packages/gui-web/src/app-model.ts,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Pre-commit quality validation passed. npm run typecheck passed after local dependency hydration for the worker image. Attempted bun test packages/gui-web/tests/component.test.ts, but bun is not installed in this worker environment.

Resolves #26002


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 7m and 93,483 tokens on this as a headless worker.