### PR TITLE
GH#26023: fix: add qlty empty-sarif miner guidance

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -896,10 +896,19 @@ build_issue_body() {
 					"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
 					"- If the details URL is inaccessible, use the `affected files` evidence from the failing PRs to identify the nearest local linter/static-analysis guard before editing.\n" +
 					"- Reproduce the provider finding locally with the nearest repo linter/style/static-analysis command, fix the source issue rather than suppressing CodeFactor, and add a focused regression guard for the reported rule/file.\n" +
-					"\n## Worker Guidance\n" +
+					"\n" +
+					"## Worker Guidance\n" +
 					"1. Open the CodeFactor details URL from Evidence first; do not infer the reported file/rule from the GitHub run alone.\n" +
 					"2. If CodeFactor details are unavailable, inspect the affected files listed in Evidence and the closest existing lint/test guard for those file types. If no focused guard exists, add one under `.agents/scripts/tests/` or the target package tests.\n" +
 					"3. Run the focused guard plus the nearest local linter before opening a PR.\n"
+				elif $check_name == "Qlty Smell Threshold" and $signature == "Failed to run qlty smells (empty SARIF output)" then
+					"- Qlty Smell Threshold empty-SARIF failures are shared tooling failures, not PR-specific smell regressions.\n" +
+					"- Harden the absolute threshold workflow/helper so empty `qlty smells --all --sarif` output emits diagnostic warning context and does not block unrelated PRs.\n" +
+					"- Keep valid SARIF output blocking when the count exceeds `QLTY_SMELL_THRESHOLD`, and keep the delta-based qlty regression gate as the PR-specific smell guard.\n" +
+					"\n## Worker Guidance\n" +
+					"1. Edit `.agents/scripts/qlty-smell-threshold-helper.sh` and `.github/workflows/code-quality.yml`; do not change application files to satisfy an empty-SARIF signature.\n" +
+					"2. Add or update `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh` to cover empty, valid-pass, and valid-fail SARIF paths.\n" +
+					"3. Run `shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh` plus the focused qlty threshold helper test before opening a PR.\n"
 				else
 					"- Fix the workflow/check at the source, then rerun failed checks on affected PRs.\n" +
 					"- Add a regression guard for this signature in pulse routine outputs.\n"

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -101,6 +101,27 @@ cluster_json=$(cat <<'JSON'
 JSON
 )
 
+qlty_empty_sarif_cluster_json='{
+  "repo": "marcusquinn/aidevops",
+  "check_name": "Qlty Smell Threshold",
+  "signature": "Failed to run qlty smells (empty SARIF output)",
+  "count": 2,
+  "is_infra": false,
+  "sources": ["pr:#26016", "pr:#26015"],
+  "examples": [
+    {
+      "source_kind": "pr",
+      "source_ref": "#26016",
+      "source_url": "https://github.com/marcusquinn/aidevops/pull/26016",
+      "run_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+      "details_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+      "affected_paths": [],
+      "annotations": [],
+      "conclusion": "failure"
+    }
+  ]
+}'
+
 empty_evidence_cluster_json=$(cat <<'JSON'
 {
   "repo": "marcusquinn/aidevops",
@@ -134,6 +155,7 @@ JSON
 )
 
 body=$(build_issue_body "$cluster_json" "46250abc5695" "2" "false")
+qlty_body=$(build_issue_body "$qlty_empty_sarif_cluster_json" "d627959fbedf" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
 if empty_evidence_output=$(create_or_preview_issue "$empty_evidence_cluster_json" "abc123" "2" "true" "false" 2>&1); then
 	empty_evidence_status=0
@@ -189,6 +211,10 @@ assert_contains "build_issue_body includes CodeFactor annotations" "reported fin
 assert_contains "build_issue_body handles unavailable details" "If CodeFactor details are unavailable" "$body"
 assert_contains "build_issue_body preserves failure signature context" "failure:codefactor.io" "$body"
 assert_contains "build_issue_body asks for focused regression guard" "focused regression guard" "$body"
+assert_contains "build_issue_body includes Qlty Worker Guidance" "## Worker Guidance" "$qlty_body"
+assert_contains "build_issue_body classifies qlty empty SARIF as shared tooling" "empty-SARIF failures are shared tooling failures" "$qlty_body"
+assert_contains "build_issue_body points qlty workers at helper" ".agents/scripts/qlty-smell-threshold-helper.sh" "$qlty_body"
+assert_contains "build_issue_body preserves qlty ratchet semantics" "Keep valid SARIF output blocking" "$qlty_body"
 assert_equals "create_or_preview_issue rejects no-evidence clusters" "1" "$empty_evidence_status"
 assert_contains "create_or_preview_issue explains no-evidence skip" "no evidence examples" "$empty_evidence_output"
 assert_contains "render_issue_body_markdown includes Worker Guidance" "## Worker Guidance" "$legacy_body"


### PR DESCRIPTION
## Summary

Added Qlty Smell Threshold empty-SARIF specific Worker Guidance to gh-failure-miner issue bodies and regression coverage so future systemic issues route workers to the shared qlty threshold helper/workflow instead of generic application-code repair.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh

Resolves #26023


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 6m and 78,113 tokens on this as a headless worker.