### PR TITLE
GH#26027: fix: reinforce qlty empty SARIF diagnostics

### DIFF
--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -97,6 +97,8 @@ empty_output=$("$HELPER" "$CONF" 2>&1)
 empty_rc=$?
 assert_rc "empty SARIF output is warning-only" "0" "$empty_rc"
 assert_contains "empty SARIF warning emitted" "empty SARIF output" "$empty_output"
+assert_contains "empty SARIF includes qlty version" "Qlty version: qlty test-stub" "$empty_output"
+assert_contains "empty SARIF includes stderr diagnostics" "simulated qlty empty output" "$empty_output"
 
 write_stub_qlty pass "$BIN_DIR"
 pass_output=$("$HELPER" "$CONF" 2>&1)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -840,6 +840,9 @@ jobs:
 
     - name: Qlty smell threshold check
       run: |
+        # GH#26027: keep empty-SARIF handling in the helper so transient qlty
+        # output failures stay diagnostic-only while valid threshold
+        # regressions remain blocking.
         .agents/scripts/qlty-smell-threshold-helper.sh \
           .agents/configs/complexity-thresholds.conf
 


### PR DESCRIPTION
## Summary

Reinforced the Qlty Smell Threshold empty-SARIF guard by asserting the warning path includes qlty version and stderr diagnostics, and documented in code-quality.yml that threshold empty-SARIF handling stays diagnostic-only while valid threshold regressions remain blocking.

## Files Changed

.agents/scripts/tests/test-qlty-smell-threshold-helper.sh,.github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; python3 YAML parse of .github/workflows/code-quality.yml

Resolves #26027


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 51,128 tokens on this as a headless worker.