### PR TITLE
GH#26026: fix: treat blank qlty sarif as empty

### DIFF
--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -53,6 +53,12 @@ emit_empty_sarif_warning() {
 	return 0
 }
 
+is_blank_output() {
+	local _value="$1"
+	[[ -z "${_value//[[:space:]]/}" ]]
+	return $?
+}
+
 run_threshold_check() {
 	local _conf="${1:-.agents/configs/complexity-thresholds.conf}"
 	local _threshold=""
@@ -76,7 +82,7 @@ run_threshold_check() {
 	printf 'Counting total qlty smells across all files...\n'
 	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
 	_sarif=$("$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file" || true)
-	if [ -z "$_sarif" ]; then
+	if is_blank_output "$_sarif"; then
 		emit_empty_sarif_warning "$_diag_file" "$_qlty_bin"
 		rm -f "$_diag_file"
 		return 0

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -61,6 +61,11 @@ case "${QLTY_STUB_MODE:-empty}" in
 		printf 'simulated qlty empty output\n' >&2
 		exit 0
 		;;
+	blank)
+		printf '  \n\t\n'
+		printf 'simulated qlty blank output\n' >&2
+		exit 0
+		;;
 	pass)
 		printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"ok.py"}}}]}]}]}'
 		exit 0
@@ -97,6 +102,12 @@ empty_output=$("$HELPER" "$CONF" 2>&1)
 empty_rc=$?
 assert_rc "empty SARIF output is warning-only" "0" "$empty_rc"
 assert_contains "empty SARIF warning emitted" "empty SARIF output" "$empty_output"
+
+write_stub_qlty blank "$BIN_DIR"
+blank_output=$("$HELPER" "$CONF" 2>&1)
+blank_rc=$?
+assert_rc "blank SARIF output is warning-only" "0" "$blank_rc"
+assert_contains "blank SARIF warning emitted" "empty SARIF output" "$blank_output"
 
 write_stub_qlty pass "$BIN_DIR"
 pass_output=$("$HELPER" "$CONF" 2>&1)


### PR DESCRIPTION
## Summary

Hardened the Qlty smell threshold helper so whitespace-only SARIF output is classified with the existing empty-SARIF warning path instead of falling through to a parse failure. Expanded the focused regression test to cover empty, blank, valid-pass, and valid-fail SARIF paths.

## Files Changed

.agents/scripts/qlty-smell-threshold-helper.sh,.agents/scripts/tests/test-qlty-smell-threshold-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; bash .agents/scripts/tests/test-qlty-smell-threshold-helper.sh

Resolves #26026


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 80,291 tokens on this as a headless worker.