### PR TITLE
GH#26031: fix: harden qlty smell threshold sarif validation

### DIFF
--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -40,12 +40,18 @@ read_threshold() {
 	return 0
 }
 
-emit_empty_sarif_warning() {
-	local _diag_file="$1"
-	local _qlty_bin="$2"
-	printf '::warning::qlty smells produced empty SARIF output — skipping absolute smell threshold check\n'
+emit_sarif_warning() {
+	local _reason="$1"
+	local _diag_file="$2"
+	local _qlty_bin="$3"
+	local _stdout_preview="${4:-}"
+	printf '::warning::qlty smells produced %s SARIF output — skipping absolute smell threshold check\n' "$_reason"
 	printf 'Qlty version: '
 	"$_qlty_bin" --version 2>/dev/null || printf 'unknown\n'
+	if [ -n "$_stdout_preview" ]; then
+		printf '\nqlty stdout preview:\n'
+		printf '%s\n' "${_stdout_preview:0:2000}"
+	fi
 	if [ -s "$_diag_file" ]; then
 		printf '\nqlty stderr (first 40 lines):\n'
 		sed -n '1,40p' "$_diag_file"
@@ -56,6 +62,12 @@ emit_empty_sarif_warning() {
 is_blank_output() {
 	local _value="$1"
 	[[ -z "${_value//[[:space:]]/}" ]]
+	return $?
+}
+
+is_valid_sarif_results() {
+	local _value="$1"
+	printf '%s\n' "$_value" | jq -e '.runs[0].results | type == "array"' >/dev/null 2>&1
 	return $?
 }
 
@@ -83,7 +95,12 @@ run_threshold_check() {
 	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
 	_sarif=$("$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file" || true)
 	if is_blank_output "$_sarif"; then
-		emit_empty_sarif_warning "$_diag_file" "$_qlty_bin"
+		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" ""
+		rm -f "$_diag_file"
+		return 0
+	fi
+	if ! is_valid_sarif_results "$_sarif"; then
+		emit_sarif_warning "invalid" "$_diag_file" "$_qlty_bin" "$_sarif"
 		rm -f "$_diag_file"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -66,6 +66,11 @@ case "${QLTY_STUB_MODE:-empty}" in
 		printf 'simulated qlty blank output\n' >&2
 		exit 0
 		;;
+	invalid)
+		printf 'simulated non-sarif stdout\n'
+		printf 'simulated qlty invalid output diagnostics\n' >&2
+		exit 0
+		;;
 	pass)
 		printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"ok.py"}}}]}]}]}'
 		exit 0
@@ -110,6 +115,14 @@ blank_output=$("$HELPER" "$CONF" 2>&1)
 blank_rc=$?
 assert_rc "blank SARIF output is warning-only" "0" "$blank_rc"
 assert_contains "blank SARIF warning emitted" "empty SARIF output" "$blank_output"
+
+write_stub_qlty invalid "$BIN_DIR"
+invalid_output=$("$HELPER" "$CONF" 2>&1)
+invalid_rc=$?
+assert_rc "invalid SARIF output is warning-only" "0" "$invalid_rc"
+assert_contains "invalid SARIF warning emitted" "invalid SARIF output" "$invalid_output"
+assert_contains "invalid SARIF includes stdout preview" "simulated non-sarif stdout" "$invalid_output"
+assert_contains "invalid SARIF includes stderr diagnostics" "simulated qlty invalid output diagnostics" "$invalid_output"
 
 write_stub_qlty pass "$BIN_DIR"
 pass_output=$("$HELPER" "$CONF" 2>&1)


### PR DESCRIPTION
## Summary

Hardened the Qlty Smell Threshold helper so malformed/non-SARIF qlty output is treated like empty output: it emits diagnostic warning context and skips only the absolute threshold gate, while valid SARIF threshold regressions remain blocking. Added a regression stub/test for invalid stdout plus stderr diagnostics.

## Files Changed

.agents/scripts/qlty-smell-threshold-helper.sh,.agents/scripts/tests/test-qlty-smell-threshold-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; .agents/scripts/tests/test-qlty-smell-threshold-helper.sh

Resolves #26031


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 4m and 57,328 tokens on this as a headless worker.