### PR TITLE
GH#26030: fix: broaden qlty empty sarif miner guidance

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -734,6 +734,9 @@ render_issue_body_markdown() {
 				"\n  affected files: " + (($example.affected_paths // []) | .[0:8] | join(", ")) +
 				(if (($example.affected_paths // []) | length) > 8 then ", ..." else "" end)
 			else "" end;
+		def qlty_empty_sarif_signature($check_name; $signature):
+			(($check_name | test("Qlty[[:space:]]+Smell[[:space:]]+Threshold"; "i"))
+			 and ($signature | test("empty[[:space:]-]*SARIF"; "i")));
 		def systemic_fix_guidance($check_name; $signature):
 			if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
 				"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
@@ -743,6 +746,14 @@ render_issue_body_markdown() {
 				"1. Open the CodeFactor details URL from Evidence first; do not infer the reported file/rule from the GitHub run alone.\n" +
 				"2. If CodeFactor details are unavailable, inspect the affected files listed in Evidence and the closest existing lint/test guard for those file types. If no focused guard exists, add one under `.agents/scripts/tests/` or the target package tests.\n" +
 				"3. Run the focused guard plus the nearest local linter before opening a PR.\n"
+			elif qlty_empty_sarif_signature($check_name; $signature) then
+				"- Qlty Smell Threshold empty-SARIF failures are shared tooling failures, not PR-specific smell regressions.\n" +
+				"- Harden the absolute threshold workflow/helper so empty `qlty smells --all --sarif` output emits diagnostic warning context and does not block unrelated PRs.\n" +
+				"- Keep valid SARIF output blocking when the count exceeds `QLTY_SMELL_THRESHOLD`, and keep the delta-based qlty regression gate as the PR-specific smell guard.\n" +
+				"\n## Worker Guidance\n" +
+				"1. Edit `.agents/scripts/qlty-smell-threshold-helper.sh` and `.github/workflows/code-quality.yml`; do not change application files to satisfy an empty-SARIF signature.\n" +
+				"2. Add or update `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh` to cover empty, valid-pass, and valid-fail SARIF paths.\n" +
+				"3. Run `shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh` plus the focused qlty threshold helper test before opening a PR.\n"
 			else
 				"- Patch the failing workflow/check once at the source (workflow file, shared action, or toolchain pin), then rerun failed checks on affected PRs.\n" +
 				"- Add a regression guard to detect this signature early in future pulses.\n"
@@ -891,6 +902,9 @@ build_issue_body() {
 					) | join("; ")) +
 					(if (($example.annotations // []) | length) > 3 then "; ..." else "" end)
 				else "" end;
+			def qlty_empty_sarif_signature($check_name; $signature):
+				(($check_name | test("Qlty[[:space:]]+Smell[[:space:]]+Threshold"; "i"))
+				 and ($signature | test("empty[[:space:]-]*SARIF"; "i")));
 			def systemic_fix_guidance($check_name; $signature):
 				if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
 					"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
@@ -901,7 +915,7 @@ build_issue_body() {
 					"1. Open the CodeFactor details URL from Evidence first; do not infer the reported file/rule from the GitHub run alone.\n" +
 					"2. If CodeFactor details are unavailable, inspect the affected files listed in Evidence and the closest existing lint/test guard for those file types. If no focused guard exists, add one under `.agents/scripts/tests/` or the target package tests.\n" +
 					"3. Run the focused guard plus the nearest local linter before opening a PR.\n"
-				elif $check_name == "Qlty Smell Threshold" and $signature == "Failed to run qlty smells (empty SARIF output)" then
+				elif qlty_empty_sarif_signature($check_name; $signature) then
 					"- Qlty Smell Threshold empty-SARIF failures are shared tooling failures, not PR-specific smell regressions.\n" +
 					"- Harden the absolute threshold workflow/helper so empty `qlty smells --all --sarif` output emits diagnostic warning context and does not block unrelated PRs.\n" +
 					"- Keep valid SARIF output blocking when the count exceeds `QLTY_SMELL_THRESHOLD`, and keep the delta-based qlty regression gate as the PR-specific smell guard.\n" +

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -122,6 +122,27 @@ qlty_empty_sarif_cluster_json='{
   ]
 }'
 
+qlty_decorated_empty_sarif_cluster_json='{
+  "repo": "marcusquinn/aidevops",
+  "check_name": "Qlty Smell Threshold",
+  "signature": "Qlty Smell Threshold Qlty smell threshold check 2026-06-30T10:13:09.8159029Z echo ::error::Failed to run qlty smells (empty SARIF output)",
+  "count": 2,
+  "is_infra": false,
+  "sources": ["pr:#26016", "pr:#26015"],
+  "examples": [
+    {
+      "source_kind": "pr",
+      "source_ref": "#26016",
+      "source_url": "https://github.com/marcusquinn/aidevops/pull/26016",
+      "run_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+      "details_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+      "affected_paths": [],
+      "annotations": [],
+      "conclusion": "failure"
+    }
+  ]
+}'
+
 empty_evidence_cluster_json=$(cat <<'JSON'
 {
   "repo": "marcusquinn/aidevops",
@@ -156,7 +177,9 @@ JSON
 
 body=$(build_issue_body "$cluster_json" "46250abc5695" "2" "false")
 qlty_body=$(build_issue_body "$qlty_empty_sarif_cluster_json" "d627959fbedf" "2" "false")
+qlty_decorated_body=$(build_issue_body "$qlty_decorated_empty_sarif_cluster_json" "595a224919c1" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
+legacy_qlty_body=$(render_issue_body_markdown "[$qlty_decorated_empty_sarif_cluster_json]" "2")
 if empty_evidence_output=$(create_or_preview_issue "$empty_evidence_cluster_json" "abc123" "2" "true" "false" 2>&1); then
 	empty_evidence_status=0
 else
@@ -215,11 +238,15 @@ assert_contains "build_issue_body includes Qlty Worker Guidance" "## Worker Guid
 assert_contains "build_issue_body classifies qlty empty SARIF as shared tooling" "empty-SARIF failures are shared tooling failures" "$qlty_body"
 assert_contains "build_issue_body points qlty workers at helper" ".agents/scripts/qlty-smell-threshold-helper.sh" "$qlty_body"
 assert_contains "build_issue_body preserves qlty ratchet semantics" "Keep valid SARIF output blocking" "$qlty_body"
+assert_contains "build_issue_body classifies decorated qlty empty SARIF signature" "empty-SARIF failures are shared tooling failures" "$qlty_decorated_body"
+assert_contains "build_issue_body decorated qlty points at helper" ".agents/scripts/qlty-smell-threshold-helper.sh" "$qlty_decorated_body"
 assert_equals "create_or_preview_issue rejects no-evidence clusters" "1" "$empty_evidence_status"
 assert_contains "create_or_preview_issue explains no-evidence skip" "no evidence examples" "$empty_evidence_output"
 assert_contains "render_issue_body_markdown includes Worker Guidance" "## Worker Guidance" "$legacy_body"
 assert_contains "render_issue_body_markdown directs workers to provider details" "details URL" "$legacy_body"
 assert_contains "render_issue_body_markdown includes affected file fallback" "affected files: .agents/scripts/vault-crypto-helper.py, .agents/scripts/vault-helper.sh" "$legacy_body"
+assert_contains "render_issue_body_markdown classifies decorated qlty empty SARIF" "empty-SARIF failures are shared tooling failures" "$legacy_qlty_body"
+assert_contains "render_issue_body_markdown qlty guidance points at helper" ".agents/scripts/qlty-smell-threshold-helper.sh" "$legacy_qlty_body"
 assert_contains "fetch_pr_changed_paths_json returns unique sorted paths" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$paths_json"
 assert_equals "fetch_pr_changed_paths_json emits one JSON array on gh failure" '[]' "$failed_paths_json"
 assert_equals "fetch_check_run_annotations_summary_json returns provider annotations" '[{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}]' "$annotations_json"


### PR DESCRIPTION
## Summary

Broadened gh-failure-miner Qlty empty-SARIF detection so decorated GitHub Actions log signatures still render worker-ready shared-tooling guidance; added regression coverage for exact decorated signatures in both issue-body render paths.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

Resolves #26030


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 76,863 tokens on this as a headless worker.