### PR TITLE
GH#25988: fix: guard pulse drilldown sections

### DIFF
--- a/packages/gui-web/src/PulseWorkersSurface.tsx
+++ b/packages/gui-web/src/PulseWorkersSurface.tsx
@@ -266,7 +266,7 @@ function PulseDrilldownPanel({ event }: { event: PulseEvent | undefined }): Reac
 }
 
 function relatedFindings(event: PulseEvent): string[] {
-  return event.drilldown_sections.filter((section) => section.label.toLowerCase().includes("systemic") || section.label.toLowerCase().includes("verification")).map((section) => `${section.label}: ${section.body}`);
+  return event.drilldown_sections?.filter((section) => section.label.toLowerCase().includes("systemic") || section.label.toLowerCase().includes("verification")).map((section) => `${section.label}: ${section.body}`) ?? [];
 }
 
 function buildFilterGroups(pulse: GuiStatusData["pulse_workers"]): PulseFilterGroup[] {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -9,10 +9,11 @@ import { Workspace } from "../src/AppWorkspace";
 import { commandPaletteMatches, commandPaletteShortcutEntries, commandPaletteShortcutQuery, orderCommandItemsByRecency, rememberCommandPaletteItemId } from "../src/CommandPalette";
 import { CommsConversationSurface } from "../src/CommsConversationSurface";
 import { AppsSurface, nextRecommendedFilterValue } from "../src/InventorySurfaces";
+import { PulseWorkersSurface } from "../src/PulseWorkersSurface";
 import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, chatPrimitiveStackDecision, navGroups, surfaceRecordCounts, type SurfaceNavItem } from "../src/app-model";
 import { renderDashboardHtml } from "../src/dashboard";
 import { fetchStatus, mockedStatus } from "../src/status-client";
-import type { GuiConversationThread, GuiManagedAppSummary } from "../../gui-shared/src";
+import type { GuiConversationThread, GuiManagedAppSummary, GuiStatusData } from "../../gui-shared/src";
 
 const guiWebRoot = `${import.meta.dir}/..`;
 
@@ -182,6 +183,24 @@ describe("dashboard shell", () => {
     expect(html).toContain("confirmation required");
     expect(html).toContain("terminal panel becomes a full-screen panel/sheet");
     expect(html).toContain("Destructive controls such as stopping workers");
+  });
+
+  test("renders Pulse and Workers detail drawer when drilldown sections are absent", () => {
+    const status = mockedStatus().data;
+    const [firstEvent, ...remainingEvents] = status.pulse_workers.events;
+    const eventWithoutDrilldownSections = { ...firstEvent, drilldown_sections: undefined } as unknown as typeof firstEvent;
+    const html = renderToStaticMarkup(createElement(PulseWorkersSurface, {
+      status: {
+        ...status,
+        pulse_workers: {
+          ...status.pulse_workers,
+          events: [eventWithoutDrilldownSections, ...remainingEvents],
+        },
+      } satisfies GuiStatusData,
+    }));
+
+    expect(html).toContain("No failure analysis recorded.");
+    expect(html).toContain("No grouped finding attached to this event.");
   });
 
   test("renders channel and DM conversation surfaces from the unified model", () => {


### PR DESCRIPTION
## Summary

Guarded the PulseWorkersSurface related-findings helper against absent drilldown_sections and added a component regression test covering the fallback drawer copy.

## Files Changed

packages/gui-web/src/PulseWorkersSurface.tsx,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node_modules/.bin/tsc --noEmit passed; bun test packages/gui-web/tests/component.test.ts could not run because bun is not installed in the worker image

Resolves #25988


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 72,157 tokens on this as a headless worker.