### PR TITLE
GH#25953: fix: add pulse activity table aria roles

### DIFF
--- a/packages/gui-web/src/PulseWorkersSurface.tsx
+++ b/packages/gui-web/src/PulseWorkersSurface.tsx
@@ -133,18 +133,18 @@ export function PulseWorkersSurface({ status }: { status: GuiStatusData }): Reac
         <table className="pulse-activity-table" aria-label="Pulse and worker events">
           <thead>
             <tr className="pulse-activity-row pulse-activity-header">
-              <th scope="col">When</th><th scope="col">Event</th><th scope="col">Scope</th><th scope="col">Outcome</th><th scope="col">Resource</th><th scope="col">Origin / actor</th>
+              <th role="columnheader" scope="col">When</th><th role="columnheader" scope="col">Event</th><th role="columnheader" scope="col">Scope</th><th role="columnheader" scope="col">Outcome</th><th role="columnheader" scope="col">Resource</th><th role="columnheader" scope="col">Origin / actor</th>
             </tr>
           </thead>
           <tbody>
             {pulse.events.map((row) => (
               <tr className={row.id === selectedEvent?.id ? "pulse-activity-row selected" : "pulse-activity-row"} key={row.id}>
-                <td data-label="When"><button className="pulse-row-select" onClick={() => setSelectedEventId(row.id)} type="button">{row.occurred_at.slice(11, 16)}</button></td>
-                <td data-label="Event"><strong>{row.title}</strong><span>{row.summary}</span></td>
-                <td data-label="Scope">{[row.repo_ref, row.issue_ref ?? row.pull_request_ref, row.worker_session_ref].filter(Boolean).join(" · ")}</td>
-                <td data-label="Outcome">{humanize(row.outcome)} · {humanize(row.status)}</td>
-                <td data-label="Resource">{resourceSummary(row)}</td>
-                <td data-label="Origin / actor">{humanize(row.issue_origin, "-")} · {row.author_association} · {row.actor_ref ?? "actor pending"}</td>
+                <td data-label="When" role="cell"><button className="pulse-row-select" onClick={() => setSelectedEventId(row.id)} type="button">{row.occurred_at.slice(11, 16)}</button></td>
+                <td data-label="Event" role="cell"><strong>{row.title}</strong><span>{row.summary}</span></td>
+                <td data-label="Scope" role="cell">{[row.repo_ref, row.issue_ref ?? row.pull_request_ref, row.worker_session_ref].filter(Boolean).join(" · ")}</td>
+                <td data-label="Outcome" role="cell">{humanize(row.outcome)} · {humanize(row.status)}</td>
+                <td data-label="Resource" role="cell">{resourceSummary(row)}</td>
+                <td data-label="Origin / actor" role="cell">{humanize(row.issue_origin, "-")} · {row.author_association} · {row.actor_ref ?? "actor pending"}</td>
               </tr>
             ))}
           </tbody>

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -165,6 +165,8 @@ describe("dashboard shell", () => {
     expect(html).toContain("Expensive runs");
     expect(html).toContain("Community bug report");
     expect(html).toContain("third-party · CONTRIBUTOR");
+    expect(html).toContain("role=\"columnheader\"");
+    expect(html).toContain("role=\"cell\"");
     expect(html).toContain("OpenAI · gpt-5.5");
     expect(html).toContain("114,000 tokens");
     expect(html).toContain("Mobile activity cards");


### PR DESCRIPTION
## Summary

Added explicit columnheader roles to Pulse & Workers activity table headers, explicit cell roles to activity data cells, and component-test coverage that rendered markup includes both roles.

## Files Changed

packages/gui-web/src/PulseWorkersSurface.tsx,packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Pre-commit quality validation passed during commit. Attempted bun test packages/gui-web/tests/component.test.ts but bun is not installed in this worker environment. Attempted .agents/scripts/linters-local.sh; it timed out after 240s during Secretlint after reporting a pre-existing remote SonarCloud gate failure. Attempted full-loop project validator typecheck; npm run typecheck failed because tsc is not installed and node_modules is absent in this worker worktree.

Resolves #25953


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 8m and 88,311 tokens on this as a headless worker.