### PR TITLE
GH#25991: fix: simplify linked issue policy regex

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -1243,9 +1243,11 @@ _shim_target_matches_local_checkout() {
 
 _shim_file_mentions_issue_first_policy() {
 	local file_path="$1"
+	local policy_pattern='issue-first|linked issue|every human-authored pr'
+	local reference_pattern='closes #|fixes #|resolves #|for #|ref #'
 	[[ -f "$file_path" ]] || return 1
-	if grep -Eiq 'issue-first|linked issue|Every human-authored PR' "$file_path" &&
-		grep -Eiq 'Closes #|Fixes #|Resolves #|For #|Ref #' "$file_path"; then
+	if grep -Eiq "$policy_pattern" "$file_path" &&
+		grep -Eiq "$reference_pattern" "$file_path"; then
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
## Summary

Simplified the gh shim linked-issue policy detection regexes by using lowercase case-insensitive patterns stored in named locals, preserving existing behavior while removing mixed-case redundant pattern text.

## Files Changed

.agents/scripts/gh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh; bash .agents/scripts/tests/test-gh-shim.sh

Resolves #25991


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 52,500 tokens on this as a headless worker.