### PR TITLE
GH#25883: test: split report render fixture assertions

### DIFF
--- a/.agents/scripts/report_render_blocks.py
+++ b/.agents/scripts/report_render_blocks.py
@@ -68,7 +68,7 @@ def is_markdown_table_separator_row(cells: list[str]) -> bool:
     if not cells:
         return False
     separator_cells = [html.unescape(cell) for cell in cells]
-    return all(re.fullmatch(r":?-{3,}:?", cell) for cell in separator_cells)
+    return all(re.fullmatch(r":?-+:?", cell) for cell in separator_cells)
 
 
 def split_markdown_table_row(line: str) -> list[str]:

--- a/.agents/scripts/tests/test-report-render-helper.sh
+++ b/.agents/scripts/tests/test-report-render-helper.sh
@@ -69,9 +69,9 @@ assert_not_contains() {
 	return 0
 }
 
-test_render_markdown_fixture() {
-	local _out="${TEST_ROOT}/report.html"
-	"$HELPER_SH" render "${FIXTURE_DIR}/llm-visibility-report-sample.md" --template editorial-evidence --output "$_out"
+assert_markdown_render_components() {
+	local _out="$1"
+
 	assert_contains "$_out" "sticky-toc" "Markdown render includes sticky TOC"
 	assert_contains "$_out" "list-style: none" "Markdown render removes browser TOC list numbering"
 	assert_contains "$_out" "@media print" "Markdown render includes print CSS"
@@ -107,6 +107,12 @@ test_render_markdown_fixture() {
 	assert_contains "$_out" "class=\"code-copy\"" "Markdown render includes copy buttons for code"
 	assert_contains "$_out" "code-copy.is-copied" "Markdown render includes copy feedback state"
 	assert_contains "$_out" "class=\"accordion action-prompt\"" "Markdown render includes action prompt accordions"
+	return 0
+}
+
+assert_action_prompts_inside_action_sections() {
+	local _out="$1"
+
 	if python3 - "$_out" <<'PYHTML'
 from pathlib import Path
 import sys
@@ -130,6 +136,12 @@ PYHTML
 	else
 		print_result "Markdown render places action prompts inside action sections" 1 "Expected action prompt markup before closing action section"
 	fi
+	return 0
+}
+
+assert_markdown_pdf_and_print_links() {
+	local _out="$1"
+
 	assert_contains "$_out" "<details class=\"accordion\" open" "Markdown render opens accordions for PDF output"
 	assert_contains "$_out" "class=\"toc-pdf-link\"" "Markdown render includes TOC PDF link"
 	assert_contains "$_out" ">A4</a>" "Markdown render labels portrait PDF as A4"
@@ -145,6 +157,12 @@ PYHTML
 	assert_contains "$_out" "text-wrap: pretty" "Markdown render includes smart text wrapping"
 	assert_contains "$_out" "style=\"--bar-value: 64%\"" "Markdown render splits bar chart rows"
 	assert_contains "${TEST_ROOT}/llm-visibility-report-sample-action-prompts.md" "Guide me through the tools" "Render writes companion action prompts file"
+	return 0
+}
+
+assert_markdown_toc_numbering() {
+	local _out="$1"
+
 	assert_contains "$_out" "heading-number\">1.</span> Method" "Markdown render numbers body H2 headings"
 	if grep -qF "Chapter 1 /" "$_out"; then
 		print_result "Markdown TOC omits Chapter prefix" 1 "Found Chapter prefix in rendered TOC labels"
@@ -176,12 +194,29 @@ PYHTML
 	else
 		print_result "Markdown TOC omits badges" 1 "Found badge markup in rendered TOC"
 	fi
+	return 0
+}
+
+assert_markdown_footer_and_source_comments() {
+	local _out="$1"
+
 	assert_contains "$_out" "<footer class=\"report-footer\">" "Markdown render includes copyright footer"
 	if grep -q "&lt;!-- SPDX-License-Identifier" "$_out"; then
 		print_result "Markdown render suppresses source comments" 1 "SPDX comment leaked into rendered HTML"
 	else
 		print_result "Markdown render suppresses source comments" 0
 	fi
+	return 0
+}
+
+test_render_markdown_fixture() {
+	local _out="${TEST_ROOT}/report.html"
+	"$HELPER_SH" render "${FIXTURE_DIR}/llm-visibility-report-sample.md" --template editorial-evidence --output "$_out"
+	assert_markdown_render_components "$_out"
+	assert_action_prompts_inside_action_sections "$_out"
+	assert_markdown_pdf_and_print_links "$_out"
+	assert_markdown_toc_numbering "$_out"
+	assert_markdown_footer_and_source_comments "$_out"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Split the oversized test_render_markdown_fixture shell test into focused assertion helpers; preserved the render flow; fixed the Markdown table separator parser so the existing report-render helper suite passes; complexity metrics now report 0 functions over 100 lines for .agents/scripts/tests/test-report-render-helper.sh.\n\n## Complexity Bump Justification\nScanner evidence before this issue reported test_render_markdown_fixture at 114 lines in .agents/scripts/tests/test-report-render-helper.sh. After extraction, .agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/tests/test-report-render-helper.sh reports Long functions (>100 lines): 0.

## Files Changed

.agents/scripts/report_render_blocks.py,.agents/scripts/tests/test-report-render-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/tests/test-report-render-helper.sh; shellcheck .agents/scripts/tests/test-report-render-helper.sh; python3 -m py_compile .agents/scripts/report_render_blocks.py; bash .agents/scripts/tests/test-report-render-helper.sh; .agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/tests/test-report-render-helper.sh

Resolves #25883


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 88,733 tokens on this as a headless worker.