### PR TITLE
GH#26043: fix: harden qlty empty sarif failure diagnostics

### DIFF
--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -45,7 +45,11 @@ emit_sarif_warning() {
 	local _diag_file="$2"
 	local _qlty_bin="$3"
 	local _stdout_preview="${4:-}"
+	local _qlty_rc="${5:-}"
 	printf '::warning::qlty smells produced %s SARIF output — skipping absolute smell threshold check\n' "$_reason"
+	if [ -n "$_qlty_rc" ]; then
+		printf 'qlty smells exit code: %s\n' "$_qlty_rc"
+	fi
 	printf 'Qlty version: '
 	"$_qlty_bin" --version 2>/dev/null || printf 'unknown\n'
 	if [ -n "$_stdout_preview" ]; then
@@ -79,6 +83,7 @@ run_threshold_check() {
 	local _sarif=""
 	local _count=""
 	local _headroom=""
+	local _qlty_rc="0"
 
 	_threshold=$(read_threshold "$_conf")
 	if [ "$_threshold" -eq 0 ]; then
@@ -93,14 +98,15 @@ run_threshold_check() {
 
 	printf 'Counting total qlty smells across all files...\n'
 	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
-	_sarif=$("$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file" || true)
+	_sarif=$("$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file")
+	_qlty_rc=$?
 	if is_blank_output "$_sarif"; then
-		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" ""
+		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" "" "$_qlty_rc"
 		rm -f "$_diag_file"
 		return 0
 	fi
 	if ! is_valid_sarif_results "$_sarif"; then
-		emit_sarif_warning "invalid" "$_diag_file" "$_qlty_bin" "$_sarif"
+		emit_sarif_warning "invalid" "$_diag_file" "$_qlty_bin" "$_sarif" "$_qlty_rc"
 		rm -f "$_diag_file"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -61,6 +61,10 @@ case "${QLTY_STUB_MODE:-empty}" in
 		printf 'simulated qlty empty output\n' >&2
 		exit 0
 		;;
+	empty-fail)
+		printf 'simulated qlty empty failure diagnostics\n' >&2
+		exit 2
+		;;
 	blank)
 		printf '  \n\t\n'
 		printf 'simulated qlty blank output\n' >&2
@@ -109,6 +113,13 @@ assert_rc "empty SARIF output is warning-only" "0" "$empty_rc"
 assert_contains "empty SARIF warning emitted" "empty SARIF output" "$empty_output"
 assert_contains "empty SARIF includes qlty version" "Qlty version: qlty test-stub" "$empty_output"
 assert_contains "empty SARIF includes stderr diagnostics" "simulated qlty empty output" "$empty_output"
+
+write_stub_qlty empty-fail "$BIN_DIR"
+empty_fail_output=$("$HELPER" "$CONF" 2>&1)
+empty_fail_rc=$?
+assert_rc "empty SARIF output with qlty failure is warning-only" "0" "$empty_fail_rc"
+assert_contains "empty SARIF failure includes qlty exit code" "qlty smells exit code: 2" "$empty_fail_output"
+assert_contains "empty SARIF failure includes stderr diagnostics" "simulated qlty empty failure diagnostics" "$empty_fail_output"
 
 write_stub_qlty blank "$BIN_DIR"
 blank_output=$("$HELPER" "$CONF" 2>&1)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -840,7 +840,7 @@ jobs:
 
     - name: Qlty smell threshold check
       run: |
-        # GH#26027: keep empty-SARIF handling in the helper so transient qlty
+        # GH#26043: keep empty-SARIF handling in the helper so transient qlty
         # output failures stay diagnostic-only while valid threshold
         # regressions remain blocking.
         .agents/scripts/qlty-smell-threshold-helper.sh \


### PR DESCRIPTION
## Summary

Hardened the qlty smell threshold helper so empty SARIF output from a nonzero qlty invocation remains warning-only with captured exit-code diagnostics; added focused regression coverage; updated the workflow comment to reference GH#26043.

## Files Changed

.agents/scripts/qlty-smell-threshold-helper.sh,.agents/scripts/tests/test-qlty-smell-threshold-helper.sh,.github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; bash .agents/scripts/tests/test-qlty-smell-threshold-helper.sh

Resolves #26043


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 42,011 tokens on this as a headless worker.