### PR TITLE
GH#26055: fix qlty empty SARIF diagnostics

### DIFF
--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -47,6 +47,8 @@ emit_sarif_warning() {
 	local _stdout_preview="${4:-}"
 	local _qlty_rc="${5:-}"
 	printf '::warning::qlty smells produced %s SARIF output — skipping absolute smell threshold check\n' "$_reason"
+	printf 'Absolute threshold status: diagnostic-only for this run; PR-specific qlty delta gate remains authoritative.\n'
+	printf 'Command: %s smells --all --sarif --no-snippets --quiet\n' "$_qlty_bin"
 	if [ -n "$_qlty_rc" ]; then
 		printf 'qlty smells exit code: %s\n' "$_qlty_rc"
 	fi

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -111,6 +111,8 @@ empty_output=$("$HELPER" "$CONF" 2>&1)
 empty_rc=$?
 assert_rc "empty SARIF output is warning-only" "0" "$empty_rc"
 assert_contains "empty SARIF warning emitted" "empty SARIF output" "$empty_output"
+assert_contains "empty SARIF explains diagnostic-only scope" "Absolute threshold status: diagnostic-only" "$empty_output"
+assert_contains "empty SARIF includes command context" "smells --all --sarif --no-snippets --quiet" "$empty_output"
 assert_contains "empty SARIF includes qlty version" "Qlty version: qlty test-stub" "$empty_output"
 assert_contains "empty SARIF includes stderr diagnostics" "simulated qlty empty output" "$empty_output"
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -843,6 +843,9 @@ jobs:
         # GH#26043: keep empty-SARIF handling in the helper so transient qlty
         # output failures stay diagnostic-only while valid threshold
         # regressions remain blocking.
+        # GH#26055: the helper must emit command/version/stderr context for
+        # empty SARIF and return success; do not reintroduce inline
+        # "Failed to run qlty smells (empty SARIF output)" errors here.
         .agents/scripts/qlty-smell-threshold-helper.sh \
           .agents/configs/complexity-thresholds.conf
 


### PR DESCRIPTION
## Summary
- Harden `.agents/scripts/qlty-smell-threshold-helper.sh` empty/invalid SARIF warnings with diagnostic-only scope and exact command context.
- Document the workflow guard in `.github/workflows/code-quality.yml` so empty SARIF remains warning-only while valid threshold regressions block.
- Extend `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh` coverage for the new empty-SARIF diagnostics.

## Testing
- `shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh`
- `bash .agents/scripts/tests/test-qlty-smell-threshold-helper.sh`

MERGE_SUMMARY: Qlty empty-SARIF threshold failures now emit diagnostic context and remain non-blocking, with regression coverage preserving valid pass/fail threshold behavior.

Resolves #26055

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 42,471 tokens on this as a headless worker.