### PR TITLE
GH#26057: fix: suppress stale qlty empty sarif issues

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -978,6 +978,30 @@ issue_already_exists() {
 	[[ "$existing_count" -gt 0 ]]
 }
 
+is_qlty_empty_sarif_signature() {
+	local check_name="$1"
+	local signature="$2"
+	[[ "$check_name" =~ [Qq]lty[[:space:]]+Smell[[:space:]]+Threshold ]] && [[ "$signature" =~ [Ee]mpty[[:space:]-]*SARIF ]]
+	return $?
+}
+
+is_obsolete_qlty_empty_sarif_cluster() {
+	local check_name="$1"
+	local signature="$2"
+	local helper_path="${SCRIPT_DIR}/qlty-smell-threshold-helper.sh"
+	if ! is_qlty_empty_sarif_signature "$check_name" "$signature"; then
+		return 1
+	fi
+	if [[ ! -f "$helper_path" ]]; then
+		return 1
+	fi
+	if grep -qF 'Failed to run qlty smells (empty SARIF output)' "$helper_path"; then
+		return 1
+	fi
+	grep -qF 'skipping absolute smell threshold check' "$helper_path"
+	return $?
+}
+
 create_or_preview_issue() {
 	local cluster_json="$1"
 	local pattern_id="$2"
@@ -1127,6 +1151,12 @@ create_systemic_issues() {
 		local pattern_id
 		pattern_id=$(compute_pattern_id "${repo_slug}|${check_name}|${signature}")
 		local signal_tag="gh-failure-miner:${pattern_id}"
+
+		if is_obsolete_qlty_empty_sarif_cluster "$check_name" "$signature"; then
+			echo "Skipping cluster for ${check_name} - empty SARIF failure signature is already handled by qlty-smell-threshold-helper.sh"
+			idx=$((idx + 1))
+			continue
+		fi
 
 		if issue_already_exists "$repo_slug" "$signal_tag"; then
 			echo "Skipping cluster for ${check_name} - existing open issue with ${signal_tag}"

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -1071,6 +1071,22 @@ create_or_preview_issue() {
 	return 0
 }
 
+should_skip_code_defect_cluster() {
+	local repo_slug="$1"
+	local check_name="$2"
+	local signature="$3"
+	local signal_tag="$4"
+	if is_obsolete_qlty_empty_sarif_cluster "$check_name" "$signature"; then
+		echo "Skipping cluster for ${check_name} - empty SARIF failure signature is already handled by qlty-smell-threshold-helper.sh"
+		return 0
+	fi
+	if issue_already_exists "$repo_slug" "$signal_tag"; then
+		echo "Skipping cluster for ${check_name} - existing open issue with ${signal_tag}"
+		return 0
+	fi
+	return 1
+}
+
 create_systemic_issues() {
 	local events_json="$1"
 	local systemic_threshold="$2"
@@ -1152,14 +1168,7 @@ create_systemic_issues() {
 		pattern_id=$(compute_pattern_id "${repo_slug}|${check_name}|${signature}")
 		local signal_tag="gh-failure-miner:${pattern_id}"
 
-		if is_obsolete_qlty_empty_sarif_cluster "$check_name" "$signature"; then
-			echo "Skipping cluster for ${check_name} - empty SARIF failure signature is already handled by qlty-smell-threshold-helper.sh"
-			idx=$((idx + 1))
-			continue
-		fi
-
-		if issue_already_exists "$repo_slug" "$signal_tag"; then
-			echo "Skipping cluster for ${check_name} - existing open issue with ${signal_tag}"
+		if should_skip_code_defect_cluster "$repo_slug" "$check_name" "$signature" "$signal_tag"; then
 			idx=$((idx + 1))
 			continue
 		fi

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -180,6 +180,7 @@ qlty_body=$(build_issue_body "$qlty_empty_sarif_cluster_json" "d627959fbedf" "2"
 qlty_decorated_body=$(build_issue_body "$qlty_decorated_empty_sarif_cluster_json" "595a224919c1" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
 legacy_qlty_body=$(render_issue_body_markdown "[$qlty_decorated_empty_sarif_cluster_json]" "2")
+qlty_skip_output=$(create_systemic_issues "[$qlty_empty_sarif_cluster_json]" "2" "3" "true" "auto-dispatch" 2>&1)
 if empty_evidence_output=$(create_or_preview_issue "$empty_evidence_cluster_json" "abc123" "2" "true" "false" 2>&1); then
 	empty_evidence_status=0
 else
@@ -247,6 +248,8 @@ assert_contains "render_issue_body_markdown directs workers to provider details"
 assert_contains "render_issue_body_markdown includes affected file fallback" "affected files: .agents/scripts/vault-crypto-helper.py, .agents/scripts/vault-helper.sh" "$legacy_body"
 assert_contains "render_issue_body_markdown classifies decorated qlty empty SARIF" "empty-SARIF failures are shared tooling failures" "$legacy_qlty_body"
 assert_contains "render_issue_body_markdown qlty guidance points at helper" ".agents/scripts/qlty-smell-threshold-helper.sh" "$legacy_qlty_body"
+assert_contains "create_systemic_issues skips remediated qlty empty SARIF clusters" "empty SARIF failure signature is already handled" "$qlty_skip_output"
+assert_contains "create_systemic_issues reports zero created for remediated qlty empty SARIF" "Processed 0 systemic cluster(s)" "$qlty_skip_output"
 assert_contains "fetch_pr_changed_paths_json returns unique sorted paths" '[".agents/scripts/vault-crypto-helper.py",".agents/scripts/vault-helper.sh"]' "$paths_json"
 assert_equals "fetch_pr_changed_paths_json emits one JSON array on gh failure" '[]' "$failed_paths_json"
 assert_equals "fetch_check_run_annotations_summary_json returns provider annotations" '[{"path":".agents/scripts/vault-crypto-helper.py","start_line":119,"annotation_level":"warning","title":"Bandit B603","message":"subprocess call: check for execution of untrusted input"}]' "$annotations_json"

--- a/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh
@@ -122,6 +122,35 @@ qlty_empty_sarif_cluster_json='{
   ]
 }'
 
+qlty_empty_sarif_events_json='[
+  {
+    "repo": "marcusquinn/aidevops",
+    "source_kind": "pr",
+    "source_ref": "#26016",
+    "source_url": "https://github.com/marcusquinn/aidevops/pull/26016",
+    "check_name": "Qlty Smell Threshold",
+    "signature": "Failed to run qlty smells (empty SARIF output)",
+    "run_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+    "details_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+    "affected_paths": [],
+    "annotations": [],
+    "conclusion": "failure"
+  },
+  {
+    "repo": "marcusquinn/aidevops",
+    "source_kind": "pr",
+    "source_ref": "#26015",
+    "source_url": "https://github.com/marcusquinn/aidevops/pull/26015",
+    "check_name": "Qlty Smell Threshold",
+    "signature": "Failed to run qlty smells (empty SARIF output)",
+    "run_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+    "details_url": "https://github.com/marcusquinn/aidevops/actions/runs/28436868573/job/84264809560",
+    "affected_paths": [],
+    "annotations": [],
+    "conclusion": "failure"
+  }
+]'
+
 qlty_decorated_empty_sarif_cluster_json='{
   "repo": "marcusquinn/aidevops",
   "check_name": "Qlty Smell Threshold",
@@ -180,7 +209,7 @@ qlty_body=$(build_issue_body "$qlty_empty_sarif_cluster_json" "d627959fbedf" "2"
 qlty_decorated_body=$(build_issue_body "$qlty_decorated_empty_sarif_cluster_json" "595a224919c1" "2" "false")
 legacy_body=$(render_issue_body_markdown "$events_json" "2")
 legacy_qlty_body=$(render_issue_body_markdown "[$qlty_decorated_empty_sarif_cluster_json]" "2")
-qlty_skip_output=$(create_systemic_issues "[$qlty_empty_sarif_cluster_json]" "2" "3" "true" "auto-dispatch" 2>&1)
+qlty_skip_output=$(create_systemic_issues "$qlty_empty_sarif_events_json" "2" "3" "true" "auto-dispatch" 2>&1)
 if empty_evidence_output=$(create_or_preview_issue "$empty_evidence_cluster_json" "abc123" "2" "true" "false" 2>&1); then
 	empty_evidence_status=0
 else


### PR DESCRIPTION
## Summary

Suppresses already-remediated Qlty Smell Threshold empty-SARIF clusters in the failure miner so stale CI notifications do not create new auto-dispatch issues after qlty-smell-threshold-helper.sh has been hardened. Adds raw-event regression coverage for the duplicate PR failure signature and keeps create_systemic_issues under the function-complexity gate.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh && .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh && .agents/scripts/tests/test-qlty-smell-threshold-helper.sh && .agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --metric function-complexity --output-md /tmp/complexity-report.md

Resolves #26057


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 8m and 105,553 tokens on this as a headless worker.