### PR TITLE
GH#26073: fix: localize pulse merge feedback read variables

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -907,7 +907,7 @@ _emit_ci_failure_guidance_blocks() {
 		[[ "$class" == "OTHER" ]] && continue
 
 		local resolution_cmd="" guidance=""
-		local fallback_resolution_cmd="" fallback_guidance=""
+		local fallback_resolution_cmd="" fallback_guidance="" cr="" gr="" rr="" guide_raw=""
 		if [[ -f "$conf_file" ]]; then
 			while IFS='|' read -r cr gr rr guide_raw; do
 				local cn="${cr#"${cr%%[![:space:]]*}"}"


### PR DESCRIPTION
## Summary

Declared cr, gr, rr, and guide_raw as local variables in _emit_ci_failure_guidance_blocks so read-populated fields do not leak into the broader script scope.

## Files Changed

.agents/scripts/pulse-merge-feedback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-feedback.sh

Resolves #26073


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 1m and 54,113 tokens on this as a headless worker.