### PR TITLE
auto-recover: orphaned worker branch for #26073

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -907,7 +907,7 @@ _emit_ci_failure_guidance_blocks() {
 		[[ "$class" == "OTHER" ]] && continue
 
 		local resolution_cmd="" guidance=""
-		local fallback_resolution_cmd="" fallback_guidance=""
+		local fallback_resolution_cmd="" fallback_guidance="" cr="" gr="" rr="" guide_raw=""
 		if [[ -f "$conf_file" ]]; then
 			while IFS='|' read -r cr gr rr guide_raw; do
 				local cn="${cr#"${cr%%[![:space:]]*}"}"


### PR DESCRIPTION
Local branch recovery PR — worker committed locally but exited before pushing or opening a PR.

Branch `feature/auto-20260630-185516-gh26073` had local commits from headless worker session `issue-26073` and was published by the recovery path before this PR was created (GH#25374).

Resolves #26073

<!-- aidevops:orphan-recovery worker_local_branch_unpushed session=issue-26073 -->