### PR TITLE
GH#26063: fix: guard stale worker mock state dir

### DIFF
--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -340,7 +340,7 @@ EOF
 # Returns: path to mock gh directory via stdout
 #######################################
 create_stale_worker_mock_gh() {
-	local state_dir="$1"
+	local state_dir="${1:?state_dir is required}"
 	local terminal_body="${2:-}"
 	local mock_bin_dir
 	local mock_gh_path


### PR DESCRIPTION
## Summary

Guarded create_stale_worker_mock_gh with required state_dir parameter expansion so an empty or missing state directory cannot resolve the mock gh bin path to /bin.

## Files Changed

.agents/scripts/tests/test-dispatch-claim-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-dispatch-claim-helper.sh; .agents/scripts/tests/test-dispatch-claim-helper.sh

Resolves #26063


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 31,951 tokens on this as a headless worker.