### PR TITLE
GH#26075: fix: harden pulse worker insight filters

### DIFF
--- a/packages/gui-api/src/status-pulse-workers.ts
+++ b/packages/gui-api/src/status-pulse-workers.ts
@@ -244,7 +244,7 @@ function buildInsights(events: GuiPulseWorkerActivityEvent[], dayMetrics: Metric
 
   const currentCost = sumCost(dayMetrics);
   const previousCost = sumCost(previousDayMetrics);
-  const failedCostEvents = events.filter((event) => (event.outcome === "failed" || event.outcome === "blocked") && event.usage?.estimated_cost_ref !== null && event.usage !== null);
+  const failedCostEvents = events.filter((event) => (event.outcome === "failed" || event.outcome === "blocked") && event.usage?.estimated_cost_ref != null);
   if (currentCost > 0 && previousCost > 0 && currentCost >= previousCost * 1.5) {
     findings.push(finding("cost-spike", "cost_spike", "warning", "Cost spike versus previous period", `Estimated selected-period cost is ${currentCost.toFixed(2)} versus ${previousCost.toFixed(2)} in the previous equivalent window.`, "Retry loops or expensive models may be consuming allowance faster than successful outcomes justify.", events, "Create a systemic cost-control task that ties model/provider selection to outcome quality and retry count.", "estimated USD", dayMetrics.length, "medium", `previous equivalent period: ${previousCost.toFixed(2)}`));
   } else if (failedCostEvents.length > 0) {
@@ -278,7 +278,7 @@ function evidenceRefs(events: GuiPulseWorkerActivityEvent[]): string[] {
 
 function verificationSummary(record: MetricRecord): string {
   const value = stringField(record, "verification") ?? stringField(record, "testing") ?? stringField(record, "verification_status");
-  if (value !== undefined && value.length > 0) return value;
+  if (typeof value === "string" && value.length > 0) return value;
   return "Verification missing or weak in local telemetry; outcome should carry command evidence before completion claims.";
 }
 


### PR DESCRIPTION
## Summary

Hardened pulse worker insight filtering by treating missing estimated cost refs with a nullish check and validating verification summaries are strings before reading their length.

## Files Changed

packages/gui-api/src/status-pulse-workers.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check passed. bun test packages/gui-api/tests/*adapter.test.ts and bun run typecheck could not run because bun is not installed in the worker environment; npm exec tsc -- --noEmit could not run because TypeScript dependencies are not installed.

Resolves #26075


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 49,655 tokens on this as a headless worker.