### PR TITLE
GH#26067: fix: guard pulse stop flag checks

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -771,7 +771,7 @@ _dispatch_apply_startup_capacity_ramp() {
 #######################################
 _dispatch_compute_capacity() {
 	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
-	if [[ -f "$STOP_FLAG" ]]; then
+	if [[ -f "${STOP_FLAG:-}" ]]; then
 		echo "[pulse-wrapper] Dispatch_max skipped: stop flag present" >>"$LOGFILE"
 		return 1
 	fi
@@ -1834,7 +1834,7 @@ _dispatch_max_should_stop() {
 		echo "[pulse-wrapper] Dispatch_max: parallel iter=${processed_count} — stopping (successes=${successes_so_far} + in_flight=${in_flight_count} >= effective_slots=${effective_slots})" >>"$LOGFILE"
 		return 0
 	fi
-	if [[ -f "$STOP_FLAG" ]]; then
+	if [[ -f "${STOP_FLAG:-}" ]]; then
 		echo "[pulse-wrapper] Dispatch_max stopping early: stop flag appeared" >>"$LOGFILE"
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Guarded pulse dispatch STOP_FLAG file checks with safe default expansion so unset STOP_FLAG does not trip set -u paths.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-dispatch-lib.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh; .agents/scripts/tests/test-dispatch-max-parallel.sh

Resolves #26067


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 61,051 tokens on this as a headless worker.