### PR TITLE
fix: harden subagent index checks

### DIFF
--- a/.agents/scripts/subagent-index-helper.sh
+++ b/.agents/scripts/subagent-index-helper.sh
@@ -163,13 +163,18 @@ check_toon_cardinality() {
 	local header_pattern="$3"
 	local regenerate_hint="$4"
 	local declared_rows actual_rows
+	local index_file="${INDEX_FILE:-}"
 
-	declared_rows=$(sed -n "$header_pattern" "$INDEX_FILE")
+	if [[ ! -f "$index_file" ]]; then
+		return 0
+	fi
+
+	declared_rows=$(sed -n "$header_pattern" "$index_file")
 	if [[ -z "$declared_rows" ]]; then
 		return 0
 	fi
 
-	actual_rows=$(count_toon_block_rows "$block_name" "$INDEX_FILE")
+	actual_rows=$(count_toon_block_rows "$block_name" "$index_file")
 	echo "Declared ${display_name} rows: ${declared_rows}"
 	echo "Actual ${display_name} rows: ${actual_rows}"
 	if [[ "$declared_rows" != "$actual_rows" ]]; then
@@ -183,9 +188,15 @@ check_toon_cardinality() {
 
 count_subagent_markdown_files() {
 	local actual_count=0
+	local agents_dir="${AGENTS_DIR:-}"
 
-	for subdir in $SUBAGENT_DIRS; do
-		local dir_path="${AGENTS_DIR}/${subdir}"
+	if [[ -z "$agents_dir" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	for subdir in ${SUBAGENT_DIRS:-}; do
+		local dir_path="${agents_dir}/${subdir}"
 		[[ -d "$dir_path" ]] || continue
 		local dir_count
 		dir_count=$(find "$dir_path" -name "*.md" -type f \
@@ -199,7 +210,12 @@ count_subagent_markdown_files() {
 }
 
 count_index_leaf_entries() {
-	local index_file="$1"
+	local index_file="${1:-}"
+
+	if [[ ! -f "$index_file" ]]; then
+		echo "0"
+		return 0
+	fi
 
 	awk '
 		BEGIN { in_block = 0; count = 0 }

--- a/.agents/scripts/tests/test-plugin-subagent-index.sh
+++ b/.agents/scripts/tests/test-plugin-subagent-index.sh
@@ -106,10 +106,35 @@ test_check_validates_plugin_cardinality() {
 	return 0
 }
 
+test_unset_globals_do_not_read_stdin() {
+	local helper="$TEST_HOME/.aidevops/agents/scripts/subagent-index-helper.sh"
+	local output=""
+	local status=0
+
+	output=$(bash -c '
+		helper_path="$2"
+		set -- help
+		source "$helper_path" >/dev/null
+		unset AGENTS_DIR SUBAGENT_DIRS INDEX_FILE
+		count_subagent_markdown_files
+		count_index_leaf_entries
+		check_toon_cardinality "plugin_agents" "plugin" "s/^x$/x/p" "regenerate"
+	' bash help "$helper" 2>&1)
+	status=$?
+
+	if [[ "$status" -eq 0 && "$output" == $'0\n0' ]]; then
+		print_result "unset globals do not read stdin" 0
+	else
+		print_result "unset globals do not read stdin" 1 "$output"
+	fi
+	return 0
+}
+
 main() {
 	setup
 	test_plugin_namespace_indexed
 	test_check_validates_plugin_cardinality
+	test_unset_globals_do_not_read_stdin
 
 	echo ""
 	echo "Tests run: $TESTS_RUN"


### PR DESCRIPTION
## Summary
- Harden `subagent-index-helper.sh` against unset or missing `AGENTS_DIR`, `INDEX_FILE`, and index path inputs.
- Make count/check helpers return safely instead of scanning root-level directories or waiting on stdin.
- Add regression coverage for unset globals in `test-plugin-subagent-index.sh`.

## Testing
- PASS: `.agents/scripts/tests/test-plugin-subagent-index.sh`
- PASS: `shellcheck .agents/scripts/subagent-index-helper.sh .agents/scripts/tests/test-plugin-subagent-index.sh`
- PARTIAL: `.agents/scripts/linters-local.sh` reported an existing SonarCloud quality gate failure, then timed out during Secretlint after targeted shell gates passed.

Resolves #26064

MERGE_SUMMARY: Hardened subagent index validation helpers against unset paths and added regression coverage for unset globals.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 10m and 52,033 tokens on this as a headless worker.