### PR TITLE
GH#26045: fix PR origin label reconciliation

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -855,6 +855,9 @@ _compose_pr_title() {
 # t2767: Implements partial-success recovery — when gh_create_pr exits non-zero but a PR
 # already exists for the current branch (GitHub created it but a follow-up update failed),
 # we recover and continue instead of bailing out.
+# GH#26045: After extracting the PR number, verify/re-apply the current session
+# origin label via set_origin_label so recovered partial-success PRs cannot remain
+# unlabeled and unroutable by pulse CI/review repair workers.
 _create_pr() {
 	local repo="$1" pr_title="$2" pr_body="$3" origin_label="$4"
 	shift 4
@@ -868,13 +871,10 @@ _create_pr() {
 	# this caller's $origin_label disagreed with gh_create_pr's session-detected
 	# label (env-var divergence — see full-loop-helper.sh t3088 fix), GitHub
 	# applied BOTH labels, producing the t2200 mutual-exclusion violation.
-	# Canonical failure: PR #21825. Origin label is now injected exactly once,
-	# inside gh_create_pr, via session_origin_label(). $origin_label is retained
-	# in the function signature for backward compat with existing callers.
+	# Canonical failure: PR #21825. Origin label is now injected at creation by
+	# gh_create_pr, via session_origin_label(), then reconciled below after the
+	# PR number is known to cover partial-success recovery gaps (GH#26045).
 	local -a pr_cmd=(gh_create_pr --repo "$repo" --title "$pr_title" --body "$pr_body")
-	# Reference the parameter to avoid shellcheck SC2034 (unused variable).
-	# Intentionally suppressed: $origin_label is the legacy interface — see comment above.
-	: "${origin_label:-}"
 	for lbl in "${extra_labels[@]+"${extra_labels[@]}"}"; do
 		pr_cmd+=(--label "$lbl")
 	done
@@ -913,6 +913,19 @@ _create_pr() {
 	fi
 	if [[ -z "$pr_number" ]]; then
 		print_error "Could not extract PR number from: ${pr_url}"
+		return 1
+	fi
+
+	local origin_name="${origin_label#origin:}"
+	case "$origin_name" in
+	interactive | worker | worker-takeover) ;;
+	*)
+		print_error "Could not normalize origin label '${origin_label}' for PR #${pr_number}"
+		return 1
+		;;
+	esac
+	if ! set_origin_label "$pr_number" "$repo" "$origin_name" --pr >/dev/null 2>&1; then
+		print_error "Could not verify origin:${origin_name} on PR #${pr_number}; retry commit-and-pr after GitHub writes recover"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -213,6 +213,23 @@ gh_pr_comment() {
 }
 export -f gh_pr_comment
 
+# Control variable: set to 1 to simulate post-create origin reconciliation failure.
+SET_ORIGIN_LABEL_FAIL=0
+
+set_origin_label() {
+	local issue_num="${1:-}"
+	local repo_slug="${2:-}"
+	local new_origin="${3:-}"
+	shift 3 || return 1
+	printf 'set_origin_label num=%s repo=%s origin=%s flags=%s\n' \
+		"$issue_num" "$repo_slug" "$new_origin" "$*" >>"$STUB_LOG"
+	if [[ "$SET_ORIGIN_LABEL_FAIL" -eq 1 ]]; then
+		return 1
+	fi
+	return 0
+}
+export -f set_origin_label
+
 # =============================================================================
 # Test 1: _create_pr partial-success recovery
 # gh_create_pr returns non-zero, but _gh_recover_pr_if_exists finds the PR.
@@ -245,6 +262,13 @@ if grep -q "recovering (t2767)" "$STUB_LOG" 2>/dev/null; then
 else
 	fail "partial-success recovery: recovery log message emitted" \
 		"expected '[INFO] ... recovering (t2767)' in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if grep -q "set_origin_label num=999 repo=owner/repo origin=worker flags=--pr" "$STUB_LOG" 2>/dev/null; then
+	pass "partial-success recovery: origin label reconciled on recovered PR"
+else
+	fail "partial-success recovery: origin label reconciled on recovered PR" \
+		"expected set_origin_label for PR 999; got: $(cat "$STUB_LOG" 2>/dev/null)"
 fi
 
 # =============================================================================
@@ -300,6 +324,43 @@ else
 	fail "normal success: _create_pr outputs correct PR number (888)" \
 		"got '${success_pr_number}'"
 fi
+
+if grep -q "set_origin_label num=888 repo=owner/repo origin=worker flags=--pr" "$STUB_LOG" 2>/dev/null; then
+	pass "normal success: origin label reconciled on created PR"
+else
+	fail "normal success: origin label reconciled on created PR" \
+		"expected set_origin_label for PR 888; got: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Test 3a: _create_pr fails closed when origin label reconciliation fails
+# Expected: PR creation does not report success when provenance cannot be verified.
+# =============================================================================
+: >"$STUB_LOG"
+GH_CREATE_PR_FAIL=0
+GH_RECOVER_PR_URL=""
+GH_CREATE_PR_URL="https://github.com/owner/repo/pull/889"
+GH_CREATE_PR_STDERR_LOG=""
+SET_ORIGIN_LABEL_FAIL=1
+
+label_fail_rc=0
+_create_pr "owner/repo" "t2767: test" "body text" "origin:worker" >/dev/null 2>&1 || label_fail_rc=$?
+
+if [[ "$label_fail_rc" -ne 0 ]]; then
+	pass "origin reconciliation failure: _create_pr fails closed"
+else
+	fail "origin reconciliation failure: _create_pr fails closed" \
+		"expected non-zero exit; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if grep -q "Could not verify origin:worker on PR #889" "$STUB_LOG" 2>/dev/null; then
+	pass "origin reconciliation failure: error message emitted"
+else
+	fail "origin reconciliation failure: error message emitted" \
+		"expected verification failure in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+SET_ORIGIN_LABEL_FAIL=0
 
 # =============================================================================
 # Test 3b: _create_pr REST fallback logs do not pollute machine stdout

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -172,6 +172,7 @@ define_process_helper() {
 	ROUTE_LABELS=""
 	DISMISS_CALLS=0
 	PR_REQUIRED_CHECKS_RC=1
+	REBASE_RETRY_RC=1
 	REFRESHED_MERGEABLE="UNKNOWN"
 
 	_resolve_pr_mergeable_status() { local pr_number="$1" repo_slug="$2" mergeable="$3"; [[ -n "$pr_number$repo_slug$mergeable" ]]; RESOLVE_CALLS=$((RESOLVE_CALLS + 1)); return 0; }
@@ -182,7 +183,7 @@ define_process_helper() {
 	_check_required_checks_passing() { local repo_slug="$1" pr_number="$2"; [[ -n "$repo_slug$pr_number" ]]; return 1; }
 	_is_trusted_dependabot_update_pr() { local pr_number="$1" repo_slug="$2" pr_author="$3"; [[ -n "$pr_number$repo_slug$pr_author" ]]; return 1; }
 	_trusted_dependabot_non_review_checks_green() { local pr_number="$1" repo_slug="$2" pr_obj="$3"; [[ -n "$pr_number$repo_slug$pr_obj" ]]; return 1; }
-	_attempt_pr_ci_rebase_retry() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; return 1; }
+	_attempt_pr_ci_rebase_retry() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; return "$REBASE_RETRY_RC"; }
 	_route_pr_to_fix_worker() { local pr_number="$1" repo_slug="$2" linked_issue="$3" mode="$4" pr_labels="${5:-}"; ROUTE_CALLS=$((ROUTE_CALLS + 1)); ROUTE_ARGS="${pr_number}|${repo_slug}|${linked_issue}|${mode}"; ROUTE_LABELS="$pr_labels"; return 0; }
 	_pulse_merge_dismiss_coderabbit_nits() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; DISMISS_CALLS=$((DISMISS_CALLS + 1)); if [[ "${DISMISS_NITS_RC:-0}" -eq 0 ]]; then return 0; fi; return 1; }
 	_attempt_pr_update_branch() { return 1; }
@@ -233,6 +234,27 @@ test_red_pr_passes_gates_before_repair_route() {
 		print_result "red PR routes one CI repair after gates pass" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
 	else
 		print_result "red PR passes gates then routes exactly one CI repair" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_rebase_success_defers_ci_repair_route() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for rebase deferral" 1 "could not extract _process_single_ready_pr"; teardown_test_env; return 0; }
+
+	local rc=0
+	REBASE_RETRY_RC=0
+	_process_single_ready_pr "owner/repo" "$PR_OBJECT" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "successful CI-drift rebase defers CI repair routing" 1 "Expected skip return 1, got ${rc}"
+	elif [[ "$GATE_CALLS" -ne 1 ]]; then
+		print_result "successful CI-drift rebase defers CI repair routing" 1 "gate_calls=${GATE_CALLS}"
+	elif [[ "$ROUTE_CALLS" -ne 0 ]]; then
+		print_result "successful CI-drift rebase defers CI repair routing" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
+	else
+		print_result "successful CI-drift rebase defers CI repair routing" 0
 	fi
 	teardown_test_env
 	return 0
@@ -431,6 +453,7 @@ test_ci_feedback_emits_advisory_failure_when_required_clean() {
 
 main() {
 	test_red_pr_passes_gates_before_repair_route
+	test_rebase_success_defers_ci_repair_route
 	test_changes_requested_unknown_routes_before_mergeable_skip
 	test_coderabbit_nits_ok_dismissed_once_before_late_gate
 	test_changes_requested_explicit_empty_labels_skip_refetch


### PR DESCRIPTION
## Summary

Reconciles the current session origin label after PR creation/recovery so worker PRs cannot remain unlabeled and unroutable by pulse repair workers; adds regression coverage for recovered PR labels and t2805 rebase deferral.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh,.agents/scripts/tests/test-commit-and-pr-partial-success.sh,.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-commit-and-pr-partial-success.sh; bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh; shellcheck on touched scripts. Full linters-local attempted; blocked by pre-existing repo-wide Markdown/complexity debt unrelated to this diff.

Resolves #26045


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 with gpt-5.5 spent 43m and 161,625 tokens on this with the user in an interactive session.