### PR TITLE
GH#26066: fix: validate watchdog CPU stall threshold

### DIFF
--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -130,19 +130,23 @@ assert_contains \
 	'STALL_CPU_THRESHOLD="${WORKER_STALL_CPU_THRESHOLD:-2}"' \
 	"$watchdog_source"
 assert_contains \
-	"4b. CPU check defers kill (worker_stall_deferred lifecycle marker)" \
+	"4b. STALL_CPU_THRESHOLD falls back when non-numeric" \
+	'[[ "$stall_cpu_threshold" =~ ^[0-9]+$ ]] || stall_cpu_threshold=2' \
+	"$watchdog_source"
+assert_contains \
+	"4c. CPU check defers kill (worker_stall_deferred lifecycle marker)" \
 	"worker_stall_deferred" \
 	"$watchdog_source"
 assert_contains \
-	"4c. Network semantic helper exists" \
+	"4d. Network semantic helper exists" \
 	"_watchdog_tree_network_active()" \
 	"$watchdog_source"
 assert_contains \
-	"4d. Network-active defers are labeled distinctly" \
+	"4e. Network-active defers are labeled distinctly" \
 	"reason=network_active" \
 	"$watchdog_source"
 assert_contains \
-	"4e. Network helper probes established HTTPS/API sockets" \
+	"4f. Network helper probes established HTTPS/API sockets" \
 	"established_https" \
 	"$watchdog_source"
 

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -750,7 +750,9 @@ _monitor_handle_confirmed_stall() {
 	fi
 
 	tree_cpu=$(_watchdog_tree_cpu "$WORKER_PID")
-	if [[ "$tree_cpu" -ge "$STALL_CPU_THRESHOLD" ]]; then
+	local stall_cpu_threshold="$STALL_CPU_THRESHOLD"
+	[[ "$stall_cpu_threshold" =~ ^[0-9]+$ ]] || stall_cpu_threshold=2
+	if [[ "$tree_cpu" -ge "$stall_cpu_threshold" ]]; then
 		_monitor_defer_stall "cpu_active" "cpu=${tree_cpu}% "
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Validated the watchdog CPU stall threshold before numeric comparisons so non-numeric WORKER_STALL_CPU_THRESHOLD values fall back to the safe default instead of triggering bash integer errors. Added a structural regression assertion for the fallback.

## Files Changed

.agents/scripts/tests/test-watchdog-no-false-kill.sh,.agents/scripts/worker-activity-watchdog.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-watchdog-no-false-kill.sh; shellcheck .agents/scripts/worker-activity-watchdog.sh

Resolves #26066


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.42 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 41,273 tokens on this as a headless worker.