### PR TITLE
GH#26069: fix: reuse gh shim policy content

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -1243,14 +1243,20 @@ _shim_target_matches_local_checkout() {
 
 _shim_file_mentions_issue_first_policy() {
 	local file_path="$1"
+	local content="${2:-}"
 	local policy_pattern='issue-first|linked issue|every human-authored pr'
 	local reference_pattern='closes #|fixes #|resolves #|for #|ref #'
-	[[ -f "$file_path" ]] || return 1
-	if grep -Eiq "$policy_pattern" "$file_path" &&
-		grep -Eiq "$reference_pattern" "$file_path"; then
-		return 0
+	if [[ -n "$content" ]]; then
+		if grep -Eiq "$policy_pattern" <<<"$content" &&
+			grep -Eiq "$reference_pattern" <<<"$content"; then
+			return 0
+		fi
+		return 1
 	fi
-	return 1
+	[[ -f "$file_path" ]] || return 1
+	content=$(<"$file_path")
+	_shim_file_mentions_issue_first_policy "$file_path" "$content"
+	return $?
 }
 
 _shim_local_policy_requires_linked_issue() {


### PR DESCRIPTION
## Summary

Refactored .agents/scripts/gh _shim_file_mentions_issue_first_policy to accept optional precomputed content and make the file fallback read once before reusing the content path, avoiding redundant file grep I/O while preserving existing linked-issue policy detection.

## Files Changed

.agents/scripts/gh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/gh; shellcheck .agents/scripts/gh; .agents/scripts/tests/test-gh-shim.sh (45 passed, 0 failed)

Resolves #26069


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.42 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 59,447 tokens on this as a headless worker.