### PR TITLE
fix: recover OAuth pool when getAuth refresh fails

### DIFF
--- a/.agents/plugins/opencode-aidevops/provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth.mjs
@@ -82,6 +82,61 @@ function resolvePoolState(sessionAccountEmail, accessToken) {
 }
 
 /**
+ * Detect OpenCode's built-in OAuth refresh failure before our fetch wrapper runs.
+ * @param {unknown} err
+ */
+function isRefresh401Failure(err) {
+  const message = String(err?.message || err || "");
+  return /token refresh failed:\s*(401|403)/i.test(message);
+}
+
+/** @param {string} token @param {object|undefined} account */
+function buildRecoveredAuth(token, account) {
+  return {
+    type: "oauth",
+    access: token,
+    refresh: account?.refresh || "",
+    expires: account?.expires || Date.now() + 3600_000,
+  };
+}
+
+/**
+ * Recover when getAuth() itself throws "Token refresh failed: 401/403".
+ * OpenCode refreshes expired built-in OAuth credentials before returning auth,
+ * so provider response recovery cannot run unless we catch that preflight error.
+ */
+async function recoverAuthFromPool(client, sessionAccountEmail) {
+  const accounts = getAccounts("anthropic");
+  normalizeExpiredCooldowns("anthropic", accounts);
+  if (sessionAccountEmail) {
+    const own = await refreshSessionOwnAccount(client, accounts, sessionAccountEmail);
+    if (own) {
+      const account = getAccounts("anthropic").find((a) => a.email === own.email);
+      return { auth: buildRecoveredAuth(own.token, account), sessionAccountEmail: own.email };
+    }
+  }
+  const rotated = await rotatePoolAccounts(client, accounts);
+  if (!rotated) return null;
+  const account = getAccounts("anthropic").find((a) => a.email === rotated.email);
+  return { auth: buildRecoveredAuth(rotated.token, account), sessionAccountEmail: rotated.email };
+}
+
+/** @param {Function} getAuth @param {any} client @param {string|null} sessionAccountEmail */
+async function getAuthWithPoolRecovery(getAuth, client, sessionAccountEmail) {
+  try {
+    return { auth: await getAuth(), sessionAccountEmail };
+  } catch (err) {
+    if (!isRefresh401Failure(err)) throw err;
+    console.error(
+      `[aidevops] provider-auth: built-in token refresh failed before request (${err.message}) — attempting pool recovery`,
+    );
+    const recovered = await recoverAuthFromPool(client, sessionAccountEmail);
+    if (recovered) return recovered;
+    throw err;
+  }
+}
+
+/**
  * Resolve the current session's access token.
  * Handles session affinity, pool rotation, and exhaustion wait.
  */
@@ -218,7 +273,9 @@ async function handle400ThirdPartyRecovery(client, response, accessToken, sessio
  * Execute the authenticated fetch with token resolution, body transform, and error recovery.
  */
 async function executeAuthenticatedFetch(client, getAuth, input, init, sessionAccountEmail) {
-  const auth = await getAuth();
+  const authState = await getAuthWithPoolRecovery(getAuth, client, sessionAccountEmail);
+  const auth = authState.auth;
+  sessionAccountEmail = authState.sessionAccountEmail;
   if (auth.type !== "oauth") return { response: await fetch(input, init), sessionAccountEmail };
   const resolved = await resolveAccessToken(client, auth, sessionAccountEmail);
   const accessToken = resolved.accessToken ?? auth.access;
@@ -254,14 +311,20 @@ export function createProviderAuthHook(client) {
   return {
     provider: "anthropic",
     async loader(getAuth, provider) {
-      const auth = await getAuth();
-      if (auth.type !== "oauth") return {};
+      const initialAuthState = await getAuthWithPoolRecovery(getAuth, client, null);
+      if (initialAuthState.auth.type !== "oauth") return {};
       zeroOutModelCosts(provider);
-      let sessionAccountEmail = null;
+      let sessionAccountEmail = initialAuthState.sessionAccountEmail;
+      let nextAuthOverride = initialAuthState.auth;
       return {
         apiKey: "",
         async fetch(input, init) {
-          const result = await executeAuthenticatedFetch(client, getAuth, input, init, sessionAccountEmail);
+          const result = await executeAuthenticatedFetch(client, async () => {
+            if (!nextAuthOverride) return getAuth();
+            const auth = nextAuthOverride;
+            nextAuthOverride = null;
+            return auth;
+          }, input, init, sessionAccountEmail);
           sessionAccountEmail = result.sessionAccountEmail;
           return result.response;
         },

--- a/.agents/plugins/opencode-aidevops/tests/test-provider-auth-getauth-recovery.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-provider-auth-getauth-recovery.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+test("provider auth recovers when getAuth throws Token refresh failed: 401", async () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-provider-auth-401-"));
+  const aidevopsDir = join(home, ".aidevops");
+  mkdirSync(aidevopsDir, { recursive: true });
+  writeFileSync(join(aidevopsDir, "oauth-pool.json"), JSON.stringify({
+    anthropic: [{
+      email: "pool@example.com",
+      access: "valid-pool-access",
+      refresh: "valid-pool-refresh",
+      expires: Date.now() + 3600_000,
+      status: "idle",
+      cooldownUntil: 0,
+      lastUsed: "2026-01-01T00:00:00.000Z",
+    }],
+  }));
+
+  const previousHome = process.env.HOME;
+  const previousFetch = globalThis.fetch;
+  process.env.HOME = home;
+  const authSetCalls = [];
+  globalThis.fetch = async (_input, init) => {
+    assert.equal(init.headers.get("authorization"), "Bearer valid-pool-access");
+    return new Response("ok", { status: 200 });
+  };
+
+  try {
+    const { createProviderAuthHook } = await import(`../provider-auth.mjs?case=${Date.now()}-${Math.random()}`);
+    const hook = createProviderAuthHook({
+      auth: {
+        async set(payload) { authSetCalls.push(payload); },
+      },
+    });
+    const provider = { models: { test: {} } };
+    const auth = await hook.loader(async () => {
+      throw new Error("Token refresh failed: 401");
+    }, provider);
+
+    const response = await auth.fetch("http://127.0.0.1/v1/messages", { method: "POST", body: "{}" });
+
+    assert.equal(response.status, 200);
+    assert.equal(authSetCalls.length, 1);
+    assert.equal(authSetCalls[0].body.access, "valid-pool-access");
+  } finally {
+    process.env.HOME = previousHome;
+    globalThis.fetch = previousFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- Recover from OpenCode built-in `getAuth()` failures that throw `Token refresh failed: 401/403` before the provider fetch wrapper can run.
- Fall back to the OAuth pool, preserve session account affinity when possible, and rotate to an available pool account otherwise.
- Add regression coverage for pre-request 401 recovery using a temp OAuth pool.

## Root cause

Prior PR #5612 handled 401/403 responses from Anthropic after our custom provider fetch wrapper was active. The recurring session failure happens earlier: OpenCode can refresh expired built-in OAuth credentials inside `getAuth()` and throw before any request reaches `handle401Recovery()`.

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-provider-auth-getauth-recovery.mjs .agents/plugins/opencode-aidevops/tests/test-oauth-refresh-backoff.mjs` — pass, 3 tests.
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs` — pass, 279 tests.
- `.agents/scripts/linters-local.sh` — pass; historical/advisory debt reported, final result `ALL LOCAL CHECKS PASSED!`.

For #5243. Related: PR #5612, PR #5359.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.42 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 25m and 278,892 tokens on this with the user in an interactive session.
