### PR TITLE
GH#26090: fix: harden gui pulse worker actions

### DIFF
--- a/packages/gui-api/src/app.ts
+++ b/packages/gui-api/src/app.ts
@@ -122,9 +122,8 @@ export function createGuiApiApp() {
 
   app.post(PULSE_WORKERS_ACTION_ROUTE_MANIFEST.route, (context) => {
     const action = context.req.param("action") as GuiPulseWorkerActionId;
-    const actionCommand = pulseWorkerActionCommands[action];
 
-    if (actionCommand === undefined) {
+    if (!Object.hasOwn(pulseWorkerActionCommands, action)) {
       return context.json(createEnvelope({
         operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
         source: { surface: "pulse_workers", authority: "allowlisted local command runner", path_refs: [] },
@@ -133,6 +132,7 @@ export function createGuiApiApp() {
       }), 400);
     }
 
+    const actionCommand = pulseWorkerActionCommands[action];
     const job = startPulseWorkerActionJob(action, actionCommand.command, actionCommand.target_ref, actionCommand.audit_ref);
     return context.json(createEnvelope({
       operation_id: PULSE_WORKERS_ACTION_ROUTE_MANIFEST.operation_id,
@@ -199,6 +199,7 @@ export function createGuiApiApp() {
 
 function startAppActionJob(appId: string, action: GuiAppActionId, command: string[]): GuiAppActionJobSummary {
   const now = new Date().toISOString();
+  const redactLine = createOutputLineRedactor();
   const job: GuiAppActionJobSummary = {
     id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
     app_id: appId,
@@ -219,11 +220,11 @@ function startAppActionJob(appId: string, action: GuiAppActionId, command: strin
   });
   if (child.stdout !== null) {
     const stdoutLines = readline.createInterface({ input: child.stdout, terminal: false });
-    stdoutLines.on("line", (line) => appendJobLine(job, line));
+    stdoutLines.on("line", (line) => appendJobLine(job, line, redactLine));
   }
   if (child.stderr !== null) {
     const stderrLines = readline.createInterface({ input: child.stderr, terminal: false });
-    stderrLines.on("line", (line) => appendJobLine(job, line));
+    stderrLines.on("line", (line) => appendJobLine(job, line, redactLine));
   }
   child.on("error", (error) => {
     appendJobLine(job, error.message);
@@ -240,11 +241,11 @@ function startAppActionJob(appId: string, action: GuiAppActionId, command: strin
   return job;
 }
 
-function appendJobLine(job: GuiAppActionJobSummary, line: string): void {
+function appendJobLine(job: GuiAppActionJobSummary, line: string, redactLine: (line: string) => string = redactOutputLine): void {
   if (line.length === 0) {
     return;
   }
-  job.output.push(redactOutputLine(line));
+  job.output.push(redactLine(line));
   if (job.output.length > 400) {
     job.output.splice(1, job.output.length - 400);
   }
@@ -252,6 +253,7 @@ function appendJobLine(job: GuiAppActionJobSummary, line: string): void {
 
 function startPulseWorkerActionJob(action: GuiPulseWorkerActionId, command: string[], targetRef: string, auditRef: string): GuiPulseWorkerActionJobSummary {
   const now = new Date().toISOString();
+  const redactLine = createOutputLineRedactor();
   const job: GuiPulseWorkerActionJobSummary = {
     id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
     action,
@@ -265,7 +267,7 @@ function startPulseWorkerActionJob(action: GuiPulseWorkerActionId, command: stri
     audit_ref: auditRef,
   };
   pulseWorkerActionJobs.set(job.id, job);
-  startBackgroundProcess(command, (line) => appendPulseWorkerJobLine(job, line), (code) => {
+  startBackgroundProcess(command, (line) => appendPulseWorkerJobLine(job, line, redactLine), (code) => {
     job.status = code === 0 ? "completed" : "failed";
     job.finished_at = new Date().toISOString();
     job.exit_code = code;
@@ -274,17 +276,26 @@ function startPulseWorkerActionJob(action: GuiPulseWorkerActionId, command: stri
   return job;
 }
 
-function appendPulseWorkerJobLine(job: GuiPulseWorkerActionJobSummary, line: string): void {
+function appendPulseWorkerJobLine(job: GuiPulseWorkerActionJobSummary, line: string, redactLine: (line: string) => string = redactOutputLine): void {
   if (line.length === 0) {
     return;
   }
-  job.output.push(redactOutputLine(line));
+  job.output.push(redactLine(line));
   if (job.output.length > 400) {
     job.output.splice(1, job.output.length - 400);
   }
 }
 
 function startBackgroundProcess(command: string[], appendLine: (line: string) => void, finish: (code: number) => void): void {
+  let finished = false;
+  const safeFinish = (code: number): void => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    finish(code);
+  };
+
   const child = spawn(command[0], command.slice(1), {
     cwd: process.cwd(),
     env: { ...process.env, AIDEVOPS_NON_INTERACTIVE: "true", CLICOLOR_FORCE: "1", FORCE_COLOR: "1", TERM: process.env.TERM ?? "xterm-256color" },
@@ -298,9 +309,29 @@ function startBackgroundProcess(command: string[], appendLine: (line: string) =>
   }
   child.on("error", (error) => {
     appendLine(error.message);
-    finish(127);
+    safeFinish(127);
   });
-  child.on("close", (code) => finish(code ?? 1));
+  child.on("close", (code) => safeFinish(code ?? 1));
+}
+
+export function createOutputLineRedactor(): (line: string) => string {
+  let inPrivateKeyBlock = false;
+
+  return (line: string): string => {
+    if (/-----BEGIN [A-Z ]+ PRIVATE KEY-----/.test(line)) {
+      inPrivateKeyBlock = !/-----END [A-Z ]+ PRIVATE KEY-----/.test(line);
+      return "[redacted private key]";
+    }
+
+    if (inPrivateKeyBlock) {
+      if (/-----END [A-Z ]+ PRIVATE KEY-----/.test(line)) {
+        inPrivateKeyBlock = false;
+      }
+      return "[redacted private key]";
+    }
+
+    return redactOutputLine(line);
+  };
 }
 
 function redactOutputLine(line: string): string {

--- a/packages/gui-api/tests/security.test.ts
+++ b/packages/gui-api/tests/security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { BANNED_ROUTE_PATTERNS, containsSecretSentinel } from "../../gui-shared/src";
-import { app } from "../src/app";
+import { app, createOutputLineRedactor } from "../src/app";
 
 describe("API trust boundary", () => {
   test("banned arbitrary command routes reject POST requests", async () => {
@@ -50,5 +50,34 @@ describe("API trust boundary", () => {
     expect(response.status).toBe(400);
     expect(body.errors).toContain("path_outside_root");
     expect(containsSecretSentinel(body)).toBe(false);
+  });
+
+  test("pulse worker action route rejects inherited object property names", async () => {
+    const response = await app.request("/api/pulse-workers/actions/toString", { method: "POST" });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.errors).toContain("action_not_allowlisted");
+  });
+
+  test("background output redactor redacts multiline private key blocks", () => {
+    const redactLine = createOutputLineRedactor();
+    const privateKeyBegin = "-----BEGIN OPENSSH " + "PRIVATE KEY-----";
+    const privateKeyEnd = "-----END OPENSSH " + "PRIVATE KEY-----";
+    const output = [
+      "before",
+      privateKeyBegin,
+      "synthetic-private-key-fixture-body",
+      privateKeyEnd,
+      "after token=secret-value",
+    ].map((line) => redactLine(line));
+
+    expect(output).toEqual([
+      "before",
+      "[redacted private key]",
+      "[redacted private key]",
+      "[redacted private key]",
+      "after token=[redacted]",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Hardened GUI Pulse & Workers action dispatch by requiring own allowlist keys, added per-job output redaction state for multiline private key blocks, guarded background process finish callbacks against double completion, and added regression coverage for inherited action names plus multiline PEM redaction.

## Files Changed

packages/gui-api/src/app.ts,packages/gui-api/tests/security.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Attempted: bun test packages/gui-api/tests/security.test.ts (blocked: bun not found); bun test packages/gui-api/tests (blocked: bun not found); bunx tsc --noEmit (blocked: bunx not found); npm run typecheck (blocked: local tsc not found); .agents/scripts/linters-local.sh (timed out during Secretlint after reporting pre-existing remote Sonar/Qlty status).

Resolves #26090


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.42 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 7m and 54,303 tokens on this as a headless worker.