### PR TITLE
fix: preserve dark theme background properties

### DIFF
--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -218,7 +218,7 @@ body {
 }
 
 :root[data-theme="dark"] body {
-  background:
+  background-image:
     radial-gradient(ellipse 78% 64% at top left,
       hsl(var(--accent-hue) 96% 22% / 62%) 0%,
       hsl(var(--accent-hue) 92% 18% / 34%) 34%,


### PR DESCRIPTION
Resolves #26076

## Summary
- Changed `packages/gui-web/src/styles.css` dark theme body rule to set `background-image` instead of the `background` shorthand.
- Preserves the base `background-attachment: fixed`, `background-repeat: no-repeat`, and fallback background color.

## Testing
- `bun test packages/gui-web/tests` (failed: `bun` is not installed in this runtime)
- Static verification: `git diff --stat HEAD~1..HEAD` and file read confirmed the only implementation change is `background` -> `background-image`.

MERGE_SUMMARY
Changed the dark theme body background declaration to avoid resetting base background attachment/repeat/fallback properties.

[aidevops.sh](https://aidevops.sh) automated worker.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.42 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 5m and 43,226 tokens on this as a headless worker.
