### PR TITLE
t18042: Add pulse-check diagnostics routine

### DIFF
--- a/.agents/reference/diagnostics-discipline.md
+++ b/.agents/reference/diagnostics-discipline.md
@@ -37,7 +37,7 @@ When an incident appears to match a bug in TODO.md or recent commits, READ the c
 
 When verifying whether workers are actually running, dispatching, or producing PRs — i.e. answering "is the pulse alive and productive?" — use the canonical outcome ledger, not file timestamps. File mtime tells you when something was *touched*; the canonical sources tell you the *outcome*. Confusing the two is a recurring misdiagnosis class (canonical failure: t3215, where a session reported "0 workers in 48h" from `worker-NNN.log` mtimes while canonical sources showed 28 successful workers and 49 PRs in the same window).
 
-Start with `worker-activity-helper.sh summary [--since 1h|6h|24h|48h|7d] [--json] [--no-pr-check] [--repo OWNER/REPO]` for historical productivity. For “right now” questions, use `pulse-current-state-helper.sh --window 15m`.
+Start with `worker-activity-helper.sh summary [--since 1h|6h|24h|48h|7d] [--json] [--no-pr-check] [--repo OWNER/REPO]` for historical productivity. For “right now” questions, use `pulse-current-state-helper.sh --window 15m`. For a combined utilisation/queue/API recommendation, use `pulse-check-helper.sh report` (interactive) or `pulse-check-helper.sh apply` (deduplicated self-improvement routine).
 
 NOT canonical sources:
 
@@ -51,7 +51,7 @@ Scope: applies before publishing any productivity-level claim ("workers aren't r
 
 When the user asks any variant of "is the pulse working?" / "are workers running?" / "is real work happening now?" / "why so many failed-looking comments?" — answer from a **5-15 minute window of current-state evidence**, never from 24h/48h historical aggregates. The act of the user asking is itself signal that real-time progress notifications are missing; presenting historical totals to defend a degraded present is misdirect.
 
-Run `pulse-current-state-helper.sh --window 15m` before answering. It summarizes dispatch stages, worker terminal events, pulse counters, wrapper activity, and worker worktrees from a current evidence window.
+Run `pulse-current-state-helper.sh --window 15m` before answering. It summarizes dispatch stages, worker terminal events, pulse counters, wrapper activity, and worker worktrees from a current evidence window. `/pulse-check` wraps that current-state evidence with repos.json auto-dispatch queue counts and worker outcome aggregates when the question is about utilisation or self-improvement recommendations.
 
 For provider/model/account questions, use `worker-activity-helper.sh providers --since 1h` before reading raw logs. Do not run broad recursive searches over `~/.aidevops/logs` or OpenCode storage for routine diagnostics; use bounded helpers first, then inspect a named log only if the helper identifies a specific timeframe or failure class.
 

--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -83,3 +83,32 @@ Each detector lives in `.agents/scripts/runtime-audit-rules/<id>.sh` as a self-c
 - **Adding a detector that calls `gh`, `curl`, or any network API.** The whole point is local-only inspection — network calls amplify the very blind spot we're closing.
 - **Filing a finding without a marker.** The marker is what the pre-dispatch validator uses to re-check before dispatch. Without it, stale findings consume worker time.
 - **Lowering thresholds to surface "everything".** Every false positive trains the operator to ignore the routine. Tune for high precision; the supervisor's task triage is the lower-precision layer.
+
+## Pulse Check (r915)
+
+`r915` runs `pulse-check-helper.sh apply` once daily. Unlike
+`r-runtime-audit`, it is intentionally allowed to make bounded GitHub reads: its
+job is to compare **current worker utilisation** with the **repos.json
+auto-dispatch queue** and provider/API budget signals.
+
+The helper is also the backing command for `/pulse-check` in interactive chats:
+
+```bash
+pulse-check-helper.sh report
+pulse-check-helper.sh json
+pulse-check-helper.sh apply --repo owner/repo
+```
+
+It gathers evidence from:
+
+- `pulse-current-state-helper.sh --window 15m --json` for live dispatch,
+  launch, guardrail, and API-budget state.
+- `worker-activity-helper.sh summary --since 1h/24h --json --no-pr-check` for
+  canonical recent and historical worker outcomes.
+- A privacy-preserving aggregate scan of open `auto-dispatch` issues across
+  pulse-enabled `repos.json` entries.
+
+`apply` mode files only deduplicated self-improvement issues with the marker
+`<!-- aidevops:generator=pulse-check finding=... -->`; issue bodies must stay
+aggregate-only and must not include private repo names, local paths, issue
+titles, or raw worker examples.

--- a/.agents/scripts/commands/pulse-check.md
+++ b/.agents/scripts/commands/pulse-check.md
@@ -1,0 +1,54 @@
+---
+description: Pulse and worker utilisation diagnostics across repos.json, with self-improvement recommendations
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Run a bounded pulse/worker productivity check for interactive sessions.
+
+Arguments: $ARGUMENTS
+
+## Goal
+
+Answer “is the pulse using available concurrency and model/provider allowance?”
+from canonical current-state evidence, not process snapshots or log mtimes.
+
+## Procedure
+
+1. Run the deterministic helper first:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-check-helper.sh report $ARGUMENTS
+   ```
+
+2. If the user asks for machine-readable evidence:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-check-helper.sh json $ARGUMENTS
+   ```
+
+3. If the user explicitly asks to file self-improvement work, or this is the
+   scheduled daily routine, use deduplicated apply mode:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-check-helper.sh apply $ARGUMENTS
+   ```
+
+## Interpretation
+
+- Prioritise 5–15 minute current-state evidence for “is work happening now?”
+  claims.
+- Use 24h/48h aggregates only for trend context and failure-family clustering.
+- An issue is worth filing only when the helper marks a finding `autofile=true`
+  or you can cite equivalent evidence from the helper JSON.
+- Do not publish private repo names, local paths, issue titles, or raw worker
+  examples in public comments/issues; the helper output is aggregate by design.
+
+## Verification references
+
+- `.agents/reference/diagnostics-discipline.md`
+- `.agents/reference/worker-diagnostics.md`
+- `.agents/scripts/tests/test-pulse-check-helper.sh`

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -296,7 +296,7 @@ _apply_finding() {
 	source "$GH_WRAPPERS"
 
 	local body_file=""
-	body_file=$(mktemp "${TMPDIR:-/tmp}/pulse-check-issue.XXXXXX.md") || return 1
+	body_file=$(mktemp "${TMPDIR:-/tmp}/pulse-check-issue.XXXXXX") || return 1
 	_finding_issue_body "$finding_id" "$title" "$severity" "$evidence_markdown" "$recommendation" >"$body_file"
 
 	local labels="auto-dispatch,tier:standard,bug,framework,pulse,self-improvement,source:pulse-check"

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -1,0 +1,637 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC1091
+#
+# pulse-check-helper.sh — bounded pulse/worker utilisation diagnostics.
+#
+# This helper combines the canonical current-state and worker outcome ledgers
+# with a privacy-preserving scan of repos.json auto-dispatch issues. It is safe
+# for interactive diagnosis and for a daily self-improvement routine because
+# --apply files only deduplicated, aggregate framework issues.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+CURRENT_STATE_HELPER="${PULSE_CHECK_CURRENT_STATE_HELPER:-${SCRIPT_DIR}/pulse-current-state-helper.sh}"
+WORKER_ACTIVITY_HELPER="${PULSE_CHECK_WORKER_ACTIVITY_HELPER:-${SCRIPT_DIR}/worker-activity-helper.sh}"
+RUNNER_HEALTH_HELPER="${PULSE_CHECK_RUNNER_HEALTH_HELPER:-${SCRIPT_DIR}/pulse-runner-health-helper.sh}"
+PULSE_DIAGNOSE_HELPER="${PULSE_CHECK_PULSE_DIAGNOSE_HELPER:-${SCRIPT_DIR}/pulse-diagnose-helper.sh}"
+GH_WRAPPERS="${PULSE_CHECK_GH_WRAPPERS:-${SCRIPT_DIR}/shared-gh-wrappers.sh}"
+REPOS_JSON="${PULSE_CHECK_REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+
+COMMAND="report"
+WINDOW="15m"
+SINCE="24h"
+RECENT_SINCE="1h"
+APPLY_REPO="${PULSE_CHECK_APPLY_REPO:-}"
+JSON_OUTPUT=0
+APPLY_MODE=0
+MAX_ISSUES_PER_REPO="${PULSE_CHECK_MAX_ISSUES_PER_REPO:-100}"
+AVAILABLE_THRESHOLD="${PULSE_CHECK_AVAILABLE_THRESHOLD:-3}"
+OLD_AVAILABLE_MINUTES="${PULSE_CHECK_OLD_AVAILABLE_MINUTES:-30}"
+
+_usage() {
+	cat <<EOF
+Usage: $(basename "$0") [report|json|apply|help] [options]
+
+Options:
+  --window <15m|30m|1h>       Current-state window (default: ${WINDOW})
+  --since <1h|6h|24h|48h|7d> Historical worker summary window (default: ${SINCE})
+  --recent <1h|6h|24h>       Recent worker outcome window (default: ${RECENT_SINCE})
+  --repo <owner/repo>        Repo for --apply self-improvement issues
+  --max-issues <N>           Per-repo auto-dispatch issue scan limit (default: ${MAX_ISSUES_PER_REPO})
+  --available-threshold <N>  Queue depth threshold for underfill findings (default: ${AVAILABLE_THRESHOLD})
+  --old-available-minutes <N> Age threshold for stale available queue counts (default: ${OLD_AVAILABLE_MINUTES})
+  --json                     Emit JSON report
+  --apply                    File deduplicated self-improvement issues for autofile findings
+  --help                     Show this help
+
+Subcommands:
+  report  Human-readable diagnostics (default)
+  json    Machine-readable diagnostics
+  apply   Human-readable diagnostics plus deduplicated issue creation
+EOF
+	return 0
+}
+
+_parse_args() {
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		local next="${2:-}"
+		case "$arg" in
+		report) COMMAND="report"; shift ;;
+		json) COMMAND="json"; JSON_OUTPUT=1; shift ;;
+		apply) COMMAND="apply"; APPLY_MODE=1; shift ;;
+		--window) WINDOW="$next"; shift 2 ;;
+		--since) SINCE="$next"; shift 2 ;;
+		--recent) RECENT_SINCE="$next"; shift 2 ;;
+		--repo) APPLY_REPO="$next"; shift 2 ;;
+		--max-issues) MAX_ISSUES_PER_REPO="$next"; shift 2 ;;
+		--available-threshold) AVAILABLE_THRESHOLD="$next"; shift 2 ;;
+		--old-available-minutes) OLD_AVAILABLE_MINUTES="$next"; shift 2 ;;
+		--json) JSON_OUTPUT=1; shift ;;
+		--apply) APPLY_MODE=1; shift ;;
+		help|--help|-h) _usage; exit 0 ;;
+		*) print_warning "pulse-check: unknown argument: ${arg}"; _usage; exit 1 ;;
+		esac
+	done
+	return 0
+}
+
+_validate_numeric_options() {
+	[[ "$MAX_ISSUES_PER_REPO" =~ ^[0-9]+$ ]] || MAX_ISSUES_PER_REPO=100
+	[[ "$AVAILABLE_THRESHOLD" =~ ^[0-9]+$ ]] || AVAILABLE_THRESHOLD=3
+	[[ "$OLD_AVAILABLE_MINUTES" =~ ^[0-9]+$ ]] || OLD_AVAILABLE_MINUTES=30
+	return 0
+}
+
+_run_json_helper() {
+	local fallback_json="$1"
+	shift
+
+	local output=""
+	local rc=0
+	output=$("$@" 2>/dev/null) || rc=$?
+	if [[ "$rc" -ne 0 || -z "$output" ]] || ! printf '%s' "$output" | jq empty >/dev/null 2>&1; then
+		printf '%s\n' "$fallback_json"
+		return 0
+	fi
+	printf '%s\n' "$output"
+	return 0
+}
+
+_scan_auto_dispatch_queue() {
+	PULSE_CHECK_REPOS_JSON="$REPOS_JSON" \
+		PULSE_CHECK_MAX_ISSUES_PER_REPO="$MAX_ISSUES_PER_REPO" \
+		PULSE_CHECK_OLD_AVAILABLE_MINUTES="$OLD_AVAILABLE_MINUTES" \
+		python3 - <<'PY'
+import datetime
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+repos_json = pathlib.Path(os.environ.get("PULSE_CHECK_REPOS_JSON", ""))
+skip_gh = os.environ.get("PULSE_CHECK_SKIP_GH", "") in {"1", "true", "TRUE", "yes", "YES"}
+try:
+    max_issues = int(os.environ.get("PULSE_CHECK_MAX_ISSUES_PER_REPO", "100"))
+except ValueError:
+    max_issues = 100
+try:
+    old_minutes = int(os.environ.get("PULSE_CHECK_OLD_AVAILABLE_MINUTES", "30"))
+except ValueError:
+    old_minutes = 30
+
+aggregate = {
+    "repos": 0,
+    "auto_dispatch_open": 0,
+    "available_unassigned": 0,
+    "available_old": 0,
+    "oldest_available_age_min": 0,
+    "repos_with_available": 0,
+    "queued": 0,
+    "assigned": 0,
+    "blocked_labels": 0,
+    "needs_tier": 0,
+    "needs_status": 0,
+    "parent_task": 0,
+    "nmr": 0,
+    "no_auto_dispatch": 0,
+    "gh_errors": 0,
+}
+
+try:
+    data = json.loads(repos_json.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    print(json.dumps({"aggregate": aggregate, "error": f"repos_json_unreadable:{exc.__class__.__name__}"}))
+    sys.exit(0)
+
+repos = [
+    repo for repo in data.get("initialized_repos", [])
+    if repo.get("pulse") is True and not repo.get("local_only") and repo.get("slug")
+]
+aggregate["repos"] = len(repos)
+if skip_gh:
+    print(json.dumps({"aggregate": aggregate, "error": "api_cooldown_active"}))
+    sys.exit(0)
+if shutil.which("gh") is None:
+    print(json.dumps({"aggregate": aggregate, "error": "gh_missing"}))
+    sys.exit(0)
+
+now = datetime.datetime.now(datetime.timezone.utc)
+blocking_labels = {
+    "parent-task",
+    "needs-maintainer-review",
+    "no-auto-dispatch",
+    "hold-for-review",
+    "blocked",
+    "status:blocked",
+    "status:in-review",
+}
+
+for repo in repos:
+    slug = str(repo.get("slug") or "")
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", slug,
+        "--state", "open",
+        "--label", "auto-dispatch",
+        "--limit", str(max_issues),
+        "--json", "number,title,labels,assignees,updatedAt",
+    ]
+    try:
+        completed = subprocess.run(cmd, text=True, capture_output=True, timeout=30, check=False)
+    except (OSError, subprocess.SubprocessError):
+        aggregate["gh_errors"] += 1
+        continue
+    if completed.returncode != 0:
+        aggregate["gh_errors"] += 1
+        continue
+    try:
+        issues = json.loads(completed.stdout or "[]")
+    except json.JSONDecodeError:
+        aggregate["gh_errors"] += 1
+        continue
+
+    repo_available = 0
+    for issue in issues:
+        labels = {str(label.get("name") or "") for label in issue.get("labels", [])}
+        assigned = bool(issue.get("assignees"))
+        blocked = bool(labels & blocking_labels)
+        aggregate["auto_dispatch_open"] += 1
+        if assigned:
+            aggregate["assigned"] += 1
+        if "status:queued" in labels:
+            aggregate["queued"] += 1
+        if not any(label.startswith("tier:") for label in labels):
+            aggregate["needs_tier"] += 1
+        if not any(label.startswith("status:") for label in labels):
+            aggregate["needs_status"] += 1
+        if blocked:
+            aggregate["blocked_labels"] += 1
+        if "parent-task" in labels:
+            aggregate["parent_task"] += 1
+        if "needs-maintainer-review" in labels:
+            aggregate["nmr"] += 1
+        if "no-auto-dispatch" in labels:
+            aggregate["no_auto_dispatch"] += 1
+        if "status:available" in labels and not assigned and not blocked:
+            repo_available += 1
+            aggregate["available_unassigned"] += 1
+            updated_at = str(issue.get("updatedAt") or "")
+            try:
+                updated = datetime.datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                age_min = int((now - updated).total_seconds() // 60)
+            except (ValueError, TypeError):
+                age_min = 0
+            if age_min >= old_minutes:
+                aggregate["available_old"] += 1
+            if age_min > aggregate["oldest_available_age_min"]:
+                aggregate["oldest_available_age_min"] = age_min
+    if repo_available > 0:
+        aggregate["repos_with_available"] += 1
+
+print(json.dumps({"aggregate": aggregate, "scanned_at": now.isoformat()}))
+PY
+	return 0
+}
+
+_collect_report_json() {
+	local current_state="{}"
+	local worker_summary="{}"
+	local worker_recent="{}"
+	local providers="{}"
+	local runner_health="{}"
+	local api_budget="{}"
+	local queue="{}"
+
+	current_state=$(_run_json_helper '{}' "$CURRENT_STATE_HELPER" --window "$WINDOW" --json)
+	worker_summary=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" summary --since "$SINCE" --json --no-pr-check)
+	worker_recent=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" summary --since "$RECENT_SINCE" --json --no-pr-check)
+	providers=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" providers --since "$RECENT_SINCE" --json)
+	runner_health=$(_run_json_helper '{}' "$RUNNER_HEALTH_HELPER" diagnose --json)
+	api_budget=$(_run_json_helper '{}' "$PULSE_DIAGNOSE_HELPER" api-budget --json)
+	local skip_queue_scan="0"
+	if printf '%s' "$api_budget" | jq -e '((.secondary_cooldown_state // "") | contains("active=yes"))' >/dev/null 2>&1; then
+		skip_queue_scan="1"
+	fi
+	if [[ "$skip_queue_scan" == "1" ]]; then
+		queue=$(PULSE_CHECK_SKIP_GH=1 _scan_auto_dispatch_queue)
+	else
+		queue=$(_scan_auto_dispatch_queue)
+	fi
+
+	jq -n \
+		--arg window "$WINDOW" \
+		--arg since "$SINCE" \
+		--arg recent "$RECENT_SINCE" \
+		--argjson threshold "$AVAILABLE_THRESHOLD" \
+		--argjson current "$current_state" \
+		--argjson summary "$worker_summary" \
+		--argjson recent_summary "$worker_recent" \
+		--argjson providers "$providers" \
+		--argjson runner "$runner_health" \
+		--argjson api "$api_budget" \
+		--argjson queue "$queue" '
+		def number_or_zero: (tonumber? // 0);
+		def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
+			id: $id,
+			severity: $severity,
+			title: $title,
+			evidence: $evidence,
+			recommendation: $recommendation,
+			autofile: $autofile
+		};
+		($current.pulse_gauges.dispatch_capacity_final_max_workers // 0 | number_or_zero) as $max_workers |
+		($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // 0 | number_or_zero) as $available_slots |
+		([$max_workers - $available_slots, 0] | max) as $active_workers |
+		($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
+		($queue.aggregate.available_old // 0 | number_or_zero) as $old_available |
+		($queue.aggregate.needs_tier // 0 | number_or_zero) as $needs_tier |
+		($queue.aggregate.gh_errors // 0 | number_or_zero) as $gh_errors |
+		($queue.error // "") as $queue_error |
+		($current.worker_outcomes.spawned // 0 | number_or_zero) as $spawned |
+		($recent_summary.metrics.total // 0 | number_or_zero) as $recent_total |
+		($summary.metrics.total // 0 | number_or_zero) as $hist_total |
+		($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
+		($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
+		{
+			generated_at: (now | todateiso8601),
+			inputs: {current_window: $window, historical_window: $since, recent_window: $recent},
+			summary: {
+				max_workers: $max_workers,
+				active_workers: $active_workers,
+				available_slots: $available_slots,
+				dispatch_alive: ($current.dispatch_alive // false),
+				dispatch_stage_events: ($current.dispatch_stage_events // 0),
+				worker_launches_in_window: $spawned,
+				worker_terminal_events_in_window: ($current.worker_terminal_events // 0),
+				recent_worker_events: $recent_total,
+				historical_worker_events: $hist_total,
+				historical_worker_successes: $hist_success,
+				historical_success_rate: (if $hist_total > 0 then (($hist_success / $hist_total) * 100 | floor) else null end),
+				auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
+				auto_dispatch_available_unassigned: $available_issues,
+				auto_dispatch_available_old: $old_available,
+				auto_dispatch_repos_with_available: ($queue.aggregate.repos_with_available // 0),
+				auto_dispatch_scan_errors: $gh_errors,
+				auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
+				graphql_budget_status: ($current.graphql_budget_status // "unknown"),
+				runner_health: ($runner.finding // "unknown")
+			},
+			queue: ($queue.aggregate // {}),
+			current_state: {
+				dispatch_stage_counts: ($current.dispatch_stage_counts // {}),
+				worker_outcomes: ($current.worker_outcomes // {}),
+				pulse_counter_hits: ($current.pulse_counter_hits // {}),
+				pulse_gauges: ($current.pulse_gauges // {}),
+				current_state_guardrails: ($current.current_state_guardrails // {}),
+				dispatch_pacing: ($current.dispatch_pacing // {}),
+				top_pre_launch_blockers: ($current.top_pre_launch_blockers // [])
+			},
+			worker_activity: {
+				historical: {
+					window: ($summary.window // {}),
+					metrics: (($summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
+					pulse_stats: ($summary.pulse_stats // {})
+				},
+				recent: {
+					window: ($recent_summary.window // {}),
+					metrics: (($recent_summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
+					pulse_stats: ($recent_summary.pulse_stats // {})
+				},
+				providers: ($providers.provider_diagnostics // {})
+			},
+			runner_health: $runner,
+			api_budget: {
+				graphql_circuit_breaker_trips: ($api.graphql_circuit_breaker_trips // 0),
+				reserve_mode_cycles: ($api.reserve_mode_cycles // 0),
+				deferred_optional_stages: ($api.deferred_optional_stages // 0),
+				secondary_cooldown_state: ($api.secondary_cooldown_state // "unknown"),
+				cadence_api_risk: ($api.cadence_api_risk // "unknown")
+			},
+			findings: ([
+				if ($available_issues >= $threshold and $active_workers == 0) then
+					finding(
+						"pulse-underfilled-auto-dispatch-queue";
+						"high";
+						"Auto-dispatch queue is visible while worker capacity is empty";
+						[
+							("active_workers=" + ($active_workers | tostring) + "/" + ($max_workers | tostring)),
+							("available_unassigned_auto_dispatch=" + ($available_issues | tostring)),
+							("available_older_than_threshold=" + ($old_available | tostring)),
+							("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
+						];
+						"Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health.";
+						true
+					)
+				else empty end,
+				if ($spawned >= 3 and $active_workers == 0 and $recent_total == 0) then
+					finding(
+						"pulse-launch-accounting-gap";
+						"high";
+						"Pulse recorded worker launches without active workers or recent terminal metrics";
+						[
+							("worker_launches_in_current_window=" + ($spawned | tostring)),
+							("recent_worker_metric_events=" + ($recent_total | tostring)),
+							("active_workers=" + ($active_workers | tostring)),
+							("available_slots=" + ($available_slots | tostring))
+						];
+						"Add or repair launch-validation evidence so every spawned worker becomes an active process, a terminal metric, or a classified launch failure.";
+						true
+					)
+				else empty end,
+				if ($needs_tier > 0) then
+					finding(
+						"auto-dispatch-missing-tier-labels";
+						"medium";
+						"Some auto-dispatch issues are missing tier labels";
+						[("missing_tier_count=" + ($needs_tier | tostring))];
+						"Run or repair label normalisation so auto-dispatch issues carry exactly one tier label before worker pickup.";
+						false
+					)
+				else empty end,
+				if ($gh_errors > 0) then
+					finding(
+						"pulse-check-gh-scan-errors";
+						"medium";
+						"Auto-dispatch queue scan had GitHub read errors";
+						[("gh_errors=" + ($gh_errors | tostring))];
+						"Check GitHub authentication and API budget before treating queue counts as complete.";
+						false
+					)
+				else empty end,
+				if ($queue_error != "") then
+					finding(
+						"pulse-check-queue-scan-skipped";
+						"medium";
+						"Auto-dispatch queue scan was skipped or incomplete";
+						[("queue_scan_state=" + $queue_error)];
+						"Re-run pulse-check after API cooldown clears before making queue-depth or underfill claims.";
+						false
+					)
+				else empty end,
+				if ($graphql_trips > 0 or ($current.dispatch_api_blocked // false) == true) then
+					finding(
+						"github-api-budget-blocking-dispatch";
+						"high";
+						"GitHub API budget is blocking or degrading dispatch";
+						[("graphql_circuit_breaker_trips=" + ($graphql_trips | tostring)), ("dispatch_api_blocked=" + (($current.dispatch_api_blocked // false) | tostring))];
+						"Use pulse-diagnose-helper api-budget to identify top callers and shift avoidable reads to cache/REST before increasing concurrency.";
+						true
+					)
+				else empty end,
+				if ($hist_total >= 10 and (($hist_success * 100) / $hist_total) < 70) then
+					finding(
+						"worker-success-rate-regression";
+						"medium";
+						"Historical worker success rate is below the productivity target";
+						[("success_rate_percent=" + (((($hist_success * 100) / $hist_total) | floor) | tostring)), ("worker_events=" + ($hist_total | tostring))];
+						"Cluster failure families with worker-activity-helper summary --json, then file targeted fixes for the dominant cause instead of increasing concurrency.";
+						false
+					)
+				else empty end
+			])
+		}'
+	return 0
+}
+
+_render_text_report() {
+	local report_json="$1"
+	printf '%s' "$report_json" | jq -r '
+		def percent_text: if . == null then "n/a" else (. | tostring) + "%" end;
+		"Pulse Check — " + .generated_at,
+		"",
+		"## Current utilisation",
+		"- Active workers: " + (.summary.active_workers | tostring) + " / " + (.summary.max_workers | tostring) + " (available slots: " + (.summary.available_slots | tostring) + ")",
+		"- Auto-dispatch queue: " + (.summary.auto_dispatch_available_unassigned | tostring) + " available / " + (.summary.auto_dispatch_open | tostring) + " open across " + (.queue.repos | tostring) + " pulse repos",
+		"- Queue scan state: " + (.summary.auto_dispatch_scan_state // "scanned"),
+		"- Current window launches: " + (.summary.worker_launches_in_window | tostring) + "; terminal worker events: " + (.summary.worker_terminal_events_in_window | tostring),
+		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " success rate: " + (.summary.historical_success_rate | percent_text),
+		"- GraphQL/API: " + (.summary.graphql_budget_status // "unknown"),
+		"- Runner health: " + (.summary.runner_health // "unknown"),
+		"",
+		"## Findings",
+		(if (.findings | length) == 0 then "- None above thresholds" else (.findings[] | "- [" + .severity + "] " + .title + " (`" + .id + "`) — " + .recommendation) end),
+		"",
+		"## Evidence commands",
+		"- pulse-current-state-helper.sh --window " + .inputs.current_window + " --json",
+		"- worker-activity-helper.sh summary --since " + .inputs.recent_window + " --json --no-pr-check",
+		"- worker-activity-helper.sh summary --since " + .inputs.historical_window + " --json --no-pr-check",
+		"- pulse-diagnose-helper.sh cycle-health --window 1h",
+		"",
+		"Privacy: report aggregates repos.json queue state and omits repo slugs, local paths, and issue titles."
+	'
+	return 0
+}
+
+_resolve_apply_repo() {
+	if [[ -n "$APPLY_REPO" ]]; then
+		printf '%s\n' "$APPLY_REPO"
+		return 0
+	fi
+	gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true
+	return 0
+}
+
+_existing_open_issue_for_finding() {
+	local slug="$1"
+	local finding_id="$2"
+	local marker="aidevops:generator=pulse-check finding=${finding_id}"
+	gh issue list --repo "$slug" --state open --search "in:body \"${marker}\"" \
+		--limit 1 --json number,url 2>/dev/null \
+		| jq -r '.[0] // empty | "\(.number)\t\(.url)"' 2>/dev/null
+	return 0
+}
+
+_finding_issue_body() {
+	local finding_id="$1"
+	local title="$2"
+	local severity="$3"
+	local evidence_markdown="$4"
+	local recommendation="$5"
+
+	cat <<EOF
+<!-- aidevops:generator=pulse-check finding=${finding_id} -->
+
+## Finding
+
+${title}
+
+Severity: ${severity}
+
+## Evidence
+
+${evidence_markdown}
+
+Source commands:
+
+- \`.agents/scripts/pulse-check-helper.sh --json\`
+- \`.agents/scripts/pulse-current-state-helper.sh --window 15m --json\`
+- \`.agents/scripts/worker-activity-helper.sh summary --since 1h --json --no-pr-check\`
+- \`.agents/scripts/pulse-diagnose-helper.sh cycle-health --window 1h\`
+
+## Recommendation
+
+${recommendation}
+
+## Implementation context
+
+- Primary files: \`.agents/scripts/pulse-check-helper.sh\`, \`.agents/scripts/pulse-current-state-helper.sh\`, \`.agents/scripts/worker-activity-helper.sh\`, \`.agents/scripts/pulse-diagnose-helper.sh\`, \`.agents/scripts/pulse-dispatch-worker-launch.sh\`, \`.agents/scripts/headless-runtime-helper.sh\`.
+- Reference patterns: \`.agents/reference/diagnostics-discipline.md\` and \`.agents/reference/worker-diagnostics.md\`.
+- If the exact broken path differs, keep the fix in the pulse/worker diagnostics layer and update this issue with the verified file path before implementation.
+
+## Verification
+
+- \`.agents/scripts/tests/test-pulse-check-helper.sh\`
+- \`.agents/scripts/pulse-check-helper.sh --json\` shows the finding cleared or downgraded with current evidence.
+- Relevant focused tests for any touched pulse/worker helper.
+
+Privacy note: this issue intentionally uses aggregate counts only; do not add private repo names, private basenames, local paths, or issue titles.
+EOF
+	return 0
+}
+
+_apply_finding() {
+	local slug="$1"
+	local finding_json="$2"
+	local finding_id=""
+	local title=""
+	local severity=""
+	local recommendation=""
+	local evidence_markdown=""
+
+	finding_id=$(printf '%s' "$finding_json" | jq -r '.id')
+	title=$(printf '%s' "$finding_json" | jq -r '.title')
+	severity=$(printf '%s' "$finding_json" | jq -r '.severity')
+	recommendation=$(printf '%s' "$finding_json" | jq -r '.recommendation')
+	evidence_markdown=$(printf '%s' "$finding_json" | jq -r '.evidence | map("- " + .) | join("\n")')
+
+	local existing=""
+	existing=$(_existing_open_issue_for_finding "$slug" "$finding_id")
+	if [[ -n "$existing" ]]; then
+		local existing_number=""
+		local existing_url=""
+		IFS=$'\t' read -r existing_number existing_url <<<"$existing"
+		print_info "pulse-check: finding=${finding_id} already tracked by #${existing_number} (${existing_url})"
+		return 0
+	fi
+
+	if [[ ! -f "$GH_WRAPPERS" ]]; then
+		print_error "pulse-check: gh wrappers not found: ${GH_WRAPPERS}"
+		return 1
+	fi
+	# shellcheck source=./shared-gh-wrappers.sh
+	source "$GH_WRAPPERS"
+
+	local body_file=""
+	body_file=$(mktemp "${TMPDIR:-/tmp}/pulse-check-issue.XXXXXX.md") || return 1
+	_finding_issue_body "$finding_id" "$title" "$severity" "$evidence_markdown" "$recommendation" >"$body_file"
+
+	local labels="auto-dispatch,tier:standard,bug,framework,pulse,self-improvement,source:pulse-check"
+	local issue_output=""
+	issue_output=$(gh_create_issue --repo "$slug" --title "$title" --body-file "$body_file" --label "$labels" 2>&1) || {
+		local issue_rc=$?
+		rm -f "$body_file"
+		print_error "pulse-check: failed to create issue for ${finding_id}: ${issue_output}"
+		return "$issue_rc"
+	}
+	rm -f "$body_file"
+	print_success "pulse-check: filed ${issue_output} for finding=${finding_id}"
+	return 0
+}
+
+_apply_findings() {
+	local report_json="$1"
+	local slug=""
+	slug=$(_resolve_apply_repo)
+	if [[ -z "$slug" ]]; then
+		print_error "pulse-check: --apply requires --repo <owner/repo> or a gh repo context"
+		return 1
+	fi
+
+	local applied_count=0
+	while IFS= read -r finding_json; do
+		[[ -n "$finding_json" ]] || continue
+		_apply_finding "$slug" "$finding_json" || true
+		applied_count=$((applied_count + 1))
+	done < <(printf '%s' "$report_json" | jq -c '.findings[] | select(.autofile == true)')
+
+	if [[ "$applied_count" -eq 0 ]]; then
+		print_info "pulse-check: no autofile findings above thresholds"
+	fi
+	return 0
+}
+
+_main() {
+	_parse_args "$@"
+	_validate_numeric_options
+	if [[ "$COMMAND" == "json" ]]; then
+		JSON_OUTPUT=1
+	elif [[ "$COMMAND" == "apply" ]]; then
+		APPLY_MODE=1
+	fi
+
+	local report_json=""
+	report_json=$(_collect_report_json)
+
+	if [[ "$APPLY_MODE" -eq 1 ]]; then
+		_apply_findings "$report_json"
+	fi
+
+	if [[ "$JSON_OUTPUT" -eq 1 ]]; then
+		printf '%s\n' "$report_json"
+	else
+		_render_text_report "$report_json"
+	fi
+	return 0
+}
+
+_main "$@"

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -22,6 +22,8 @@ WORKER_ACTIVITY_HELPER="${PULSE_CHECK_WORKER_ACTIVITY_HELPER:-${SCRIPT_DIR}/work
 RUNNER_HEALTH_HELPER="${PULSE_CHECK_RUNNER_HEALTH_HELPER:-${SCRIPT_DIR}/pulse-runner-health-helper.sh}"
 PULSE_DIAGNOSE_HELPER="${PULSE_CHECK_PULSE_DIAGNOSE_HELPER:-${SCRIPT_DIR}/pulse-diagnose-helper.sh}"
 GH_WRAPPERS="${PULSE_CHECK_GH_WRAPPERS:-${SCRIPT_DIR}/shared-gh-wrappers.sh}"
+REPORT_FILTER="${PULSE_CHECK_REPORT_FILTER:-${SCRIPT_DIR}/pulse-check-report.jq}"
+QUEUE_SCANNER="${PULSE_CHECK_QUEUE_SCANNER:-${SCRIPT_DIR}/pulse-check-queue-scan.py}"
 REPOS_JSON="${PULSE_CHECK_REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 
 COMMAND="report"
@@ -106,140 +108,16 @@ _run_json_helper() {
 }
 
 _scan_auto_dispatch_queue() {
+	if [[ ! -f "$QUEUE_SCANNER" ]]; then
+		print_error "pulse-check: queue scanner not found: ${QUEUE_SCANNER}"
+		printf '{"aggregate":{"repos":0,"auto_dispatch_open":0,"available_unassigned":0,"available_old":0,"oldest_available_age_min":0,"repos_with_available":0,"queued":0,"assigned":0,"blocked_labels":0,"needs_tier":0,"needs_status":0,"parent_task":0,"nmr":0,"no_auto_dispatch":0,"gh_errors":0},"error":"queue_scanner_missing"}\n'
+		return 0
+	fi
+
 	PULSE_CHECK_REPOS_JSON="$REPOS_JSON" \
 		PULSE_CHECK_MAX_ISSUES_PER_REPO="$MAX_ISSUES_PER_REPO" \
 		PULSE_CHECK_OLD_AVAILABLE_MINUTES="$OLD_AVAILABLE_MINUTES" \
-		python3 - <<'PY'
-import datetime
-import json
-import os
-import pathlib
-import shutil
-import subprocess
-import sys
-
-repos_json = pathlib.Path(os.environ.get("PULSE_CHECK_REPOS_JSON", ""))
-skip_gh = os.environ.get("PULSE_CHECK_SKIP_GH", "") in {"1", "true", "TRUE", "yes", "YES"}
-try:
-    max_issues = int(os.environ.get("PULSE_CHECK_MAX_ISSUES_PER_REPO", "100"))
-except ValueError:
-    max_issues = 100
-try:
-    old_minutes = int(os.environ.get("PULSE_CHECK_OLD_AVAILABLE_MINUTES", "30"))
-except ValueError:
-    old_minutes = 30
-
-aggregate = {
-    "repos": 0,
-    "auto_dispatch_open": 0,
-    "available_unassigned": 0,
-    "available_old": 0,
-    "oldest_available_age_min": 0,
-    "repos_with_available": 0,
-    "queued": 0,
-    "assigned": 0,
-    "blocked_labels": 0,
-    "needs_tier": 0,
-    "needs_status": 0,
-    "parent_task": 0,
-    "nmr": 0,
-    "no_auto_dispatch": 0,
-    "gh_errors": 0,
-}
-
-try:
-    data = json.loads(repos_json.read_text(encoding="utf-8"))
-except (OSError, json.JSONDecodeError) as exc:
-    print(json.dumps({"aggregate": aggregate, "error": f"repos_json_unreadable:{exc.__class__.__name__}"}))
-    sys.exit(0)
-
-repos = [
-    repo for repo in data.get("initialized_repos", [])
-    if repo.get("pulse") is True and not repo.get("local_only") and repo.get("slug")
-]
-aggregate["repos"] = len(repos)
-if skip_gh:
-    print(json.dumps({"aggregate": aggregate, "error": "api_cooldown_active"}))
-    sys.exit(0)
-if shutil.which("gh") is None:
-    print(json.dumps({"aggregate": aggregate, "error": "gh_missing"}))
-    sys.exit(0)
-
-now = datetime.datetime.now(datetime.timezone.utc)
-blocking_labels = {
-    "parent-task",
-    "needs-maintainer-review",
-    "no-auto-dispatch",
-    "hold-for-review",
-    "blocked",
-    "status:blocked",
-    "status:in-review",
-}
-
-for repo in repos:
-    slug = str(repo.get("slug") or "")
-    cmd = [
-        "gh", "issue", "list",
-        "--repo", slug,
-        "--state", "open",
-        "--label", "auto-dispatch",
-        "--limit", str(max_issues),
-        "--json", "number,title,labels,assignees,updatedAt",
-    ]
-    try:
-        completed = subprocess.run(cmd, text=True, capture_output=True, timeout=30, check=False)
-    except (OSError, subprocess.SubprocessError):
-        aggregate["gh_errors"] += 1
-        continue
-    if completed.returncode != 0:
-        aggregate["gh_errors"] += 1
-        continue
-    try:
-        issues = json.loads(completed.stdout or "[]")
-    except json.JSONDecodeError:
-        aggregate["gh_errors"] += 1
-        continue
-
-    repo_available = 0
-    for issue in issues:
-        labels = {str(label.get("name") or "") for label in issue.get("labels", [])}
-        assigned = bool(issue.get("assignees"))
-        blocked = bool(labels & blocking_labels)
-        aggregate["auto_dispatch_open"] += 1
-        if assigned:
-            aggregate["assigned"] += 1
-        if "status:queued" in labels:
-            aggregate["queued"] += 1
-        if not any(label.startswith("tier:") for label in labels):
-            aggregate["needs_tier"] += 1
-        if not any(label.startswith("status:") for label in labels):
-            aggregate["needs_status"] += 1
-        if blocked:
-            aggregate["blocked_labels"] += 1
-        if "parent-task" in labels:
-            aggregate["parent_task"] += 1
-        if "needs-maintainer-review" in labels:
-            aggregate["nmr"] += 1
-        if "no-auto-dispatch" in labels:
-            aggregate["no_auto_dispatch"] += 1
-        if "status:available" in labels and not assigned and not blocked:
-            repo_available += 1
-            aggregate["available_unassigned"] += 1
-            updated_at = str(issue.get("updatedAt") or "")
-            try:
-                updated = datetime.datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-                age_min = int((now - updated).total_seconds() // 60)
-            except (ValueError, TypeError):
-                age_min = 0
-            if age_min >= old_minutes:
-                aggregate["available_old"] += 1
-            if age_min > aggregate["oldest_available_age_min"]:
-                aggregate["oldest_available_age_min"] = age_min
-    if repo_available > 0:
-        aggregate["repos_with_available"] += 1
-
-print(json.dumps({"aggregate": aggregate, "scanned_at": now.isoformat()}))
-PY
+		python3 "$QUEUE_SCANNER"
 	return 0
 }
 
@@ -268,6 +146,11 @@ _collect_report_json() {
 		queue=$(_scan_auto_dispatch_queue)
 	fi
 
+	if [[ ! -f "$REPORT_FILTER" ]]; then
+		print_error "pulse-check: report filter not found: ${REPORT_FILTER}"
+		return 1
+	fi
+
 	jq -n \
 		--arg window "$WINDOW" \
 		--arg since "$SINCE" \
@@ -279,167 +162,8 @@ _collect_report_json() {
 		--argjson providers "$providers" \
 		--argjson runner "$runner_health" \
 		--argjson api "$api_budget" \
-		--argjson queue "$queue" '
-		def number_or_zero: (tonumber? // 0);
-		def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
-			id: $id,
-			severity: $severity,
-			title: $title,
-			evidence: $evidence,
-			recommendation: $recommendation,
-			autofile: $autofile
-		};
-		($current.pulse_gauges.dispatch_capacity_final_max_workers // 0 | number_or_zero) as $max_workers |
-		($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // 0 | number_or_zero) as $available_slots |
-		([$max_workers - $available_slots, 0] | max) as $active_workers |
-		($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
-		($queue.aggregate.available_old // 0 | number_or_zero) as $old_available |
-		($queue.aggregate.needs_tier // 0 | number_or_zero) as $needs_tier |
-		($queue.aggregate.gh_errors // 0 | number_or_zero) as $gh_errors |
-		($queue.error // "") as $queue_error |
-		($current.worker_outcomes.spawned // 0 | number_or_zero) as $spawned |
-		($recent_summary.metrics.total // 0 | number_or_zero) as $recent_total |
-		($summary.metrics.total // 0 | number_or_zero) as $hist_total |
-		($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
-		($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
-		{
-			generated_at: (now | todateiso8601),
-			inputs: {current_window: $window, historical_window: $since, recent_window: $recent},
-			summary: {
-				max_workers: $max_workers,
-				active_workers: $active_workers,
-				available_slots: $available_slots,
-				dispatch_alive: ($current.dispatch_alive // false),
-				dispatch_stage_events: ($current.dispatch_stage_events // 0),
-				worker_launches_in_window: $spawned,
-				worker_terminal_events_in_window: ($current.worker_terminal_events // 0),
-				recent_worker_events: $recent_total,
-				historical_worker_events: $hist_total,
-				historical_worker_successes: $hist_success,
-				historical_success_rate: (if $hist_total > 0 then (($hist_success / $hist_total) * 100 | floor) else null end),
-				auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
-				auto_dispatch_available_unassigned: $available_issues,
-				auto_dispatch_available_old: $old_available,
-				auto_dispatch_repos_with_available: ($queue.aggregate.repos_with_available // 0),
-				auto_dispatch_scan_errors: $gh_errors,
-				auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
-				graphql_budget_status: ($current.graphql_budget_status // "unknown"),
-				runner_health: ($runner.finding // "unknown")
-			},
-			queue: ($queue.aggregate // {}),
-			current_state: {
-				dispatch_stage_counts: ($current.dispatch_stage_counts // {}),
-				worker_outcomes: ($current.worker_outcomes // {}),
-				pulse_counter_hits: ($current.pulse_counter_hits // {}),
-				pulse_gauges: ($current.pulse_gauges // {}),
-				current_state_guardrails: ($current.current_state_guardrails // {}),
-				dispatch_pacing: ($current.dispatch_pacing // {}),
-				top_pre_launch_blockers: ($current.top_pre_launch_blockers // [])
-			},
-			worker_activity: {
-				historical: {
-					window: ($summary.window // {}),
-					metrics: (($summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
-					pulse_stats: ($summary.pulse_stats // {})
-				},
-				recent: {
-					window: ($recent_summary.window // {}),
-					metrics: (($recent_summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
-					pulse_stats: ($recent_summary.pulse_stats // {})
-				},
-				providers: ($providers.provider_diagnostics // {})
-			},
-			runner_health: $runner,
-			api_budget: {
-				graphql_circuit_breaker_trips: ($api.graphql_circuit_breaker_trips // 0),
-				reserve_mode_cycles: ($api.reserve_mode_cycles // 0),
-				deferred_optional_stages: ($api.deferred_optional_stages // 0),
-				secondary_cooldown_state: ($api.secondary_cooldown_state // "unknown"),
-				cadence_api_risk: ($api.cadence_api_risk // "unknown")
-			},
-			findings: ([
-				if ($available_issues >= $threshold and $active_workers == 0) then
-					finding(
-						"pulse-underfilled-auto-dispatch-queue";
-						"high";
-						"Auto-dispatch queue is visible while worker capacity is empty";
-						[
-							("active_workers=" + ($active_workers | tostring) + "/" + ($max_workers | tostring)),
-							("available_unassigned_auto_dispatch=" + ($available_issues | tostring)),
-							("available_older_than_threshold=" + ($old_available | tostring)),
-							("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
-						];
-						"Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health.";
-						true
-					)
-				else empty end,
-				if ($spawned >= 3 and $active_workers == 0 and $recent_total == 0) then
-					finding(
-						"pulse-launch-accounting-gap";
-						"high";
-						"Pulse recorded worker launches without active workers or recent terminal metrics";
-						[
-							("worker_launches_in_current_window=" + ($spawned | tostring)),
-							("recent_worker_metric_events=" + ($recent_total | tostring)),
-							("active_workers=" + ($active_workers | tostring)),
-							("available_slots=" + ($available_slots | tostring))
-						];
-						"Add or repair launch-validation evidence so every spawned worker becomes an active process, a terminal metric, or a classified launch failure.";
-						true
-					)
-				else empty end,
-				if ($needs_tier > 0) then
-					finding(
-						"auto-dispatch-missing-tier-labels";
-						"medium";
-						"Some auto-dispatch issues are missing tier labels";
-						[("missing_tier_count=" + ($needs_tier | tostring))];
-						"Run or repair label normalisation so auto-dispatch issues carry exactly one tier label before worker pickup.";
-						false
-					)
-				else empty end,
-				if ($gh_errors > 0) then
-					finding(
-						"pulse-check-gh-scan-errors";
-						"medium";
-						"Auto-dispatch queue scan had GitHub read errors";
-						[("gh_errors=" + ($gh_errors | tostring))];
-						"Check GitHub authentication and API budget before treating queue counts as complete.";
-						false
-					)
-				else empty end,
-				if ($queue_error != "") then
-					finding(
-						"pulse-check-queue-scan-skipped";
-						"medium";
-						"Auto-dispatch queue scan was skipped or incomplete";
-						[("queue_scan_state=" + $queue_error)];
-						"Re-run pulse-check after API cooldown clears before making queue-depth or underfill claims.";
-						false
-					)
-				else empty end,
-				if ($graphql_trips > 0 or ($current.dispatch_api_blocked // false) == true) then
-					finding(
-						"github-api-budget-blocking-dispatch";
-						"high";
-						"GitHub API budget is blocking or degrading dispatch";
-						[("graphql_circuit_breaker_trips=" + ($graphql_trips | tostring)), ("dispatch_api_blocked=" + (($current.dispatch_api_blocked // false) | tostring))];
-						"Use pulse-diagnose-helper api-budget to identify top callers and shift avoidable reads to cache/REST before increasing concurrency.";
-						true
-					)
-				else empty end,
-				if ($hist_total >= 10 and (($hist_success * 100) / $hist_total) < 70) then
-					finding(
-						"worker-success-rate-regression";
-						"medium";
-						"Historical worker success rate is below the productivity target";
-						[("success_rate_percent=" + (((($hist_success * 100) / $hist_total) | floor) | tostring)), ("worker_events=" + ($hist_total | tostring))];
-						"Cluster failure families with worker-activity-helper summary --json, then file targeted fixes for the dominant cause instead of increasing concurrency.";
-						false
-					)
-				else empty end
-			])
-		}'
+		--argjson queue "$queue" \
+		-f "$REPORT_FILTER"
 	return 0
 }
 

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -9,6 +9,7 @@ import datetime as dt
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -17,6 +18,7 @@ from typing import Any
 AGGREGATE_KEY = "aggregate"
 ERROR_KEY = "error"
 GH_ERRORS_KEY = "gh_errors"
+REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def _int_from_env(name: str, default: int) -> int:
@@ -60,6 +62,10 @@ def _issue_labels(issue: dict[str, Any]) -> set[str]:
     if not isinstance(labels, list):
         return set()
     return {str(label.get("name") or "") for label in labels if isinstance(label, dict)}
+
+
+def _valid_repo_slug(slug: str) -> bool:
+    return bool(REPO_SLUG_RE.fullmatch(slug))
 
 
 def _issue_age_minutes(issue: dict[str, Any], now: dt.datetime) -> int:
@@ -109,6 +115,9 @@ def main() -> int:
 
     for repo in repos:
         slug = str(repo.get("slug") or "")
+        if not _valid_repo_slug(slug):
+            aggregate[GH_ERRORS_KEY] += 1
+            continue
         cmd = [
             "gh", "issue", "list",
             "--repo", slug,
@@ -118,7 +127,14 @@ def main() -> int:
             "--json", "number,title,labels,assignees,updatedAt",
         ]
         try:
-            completed = subprocess.run(cmd, text=True, capture_output=True, timeout=30, check=False)
+            # Fixed argv, shell=False, validated owner/repo slug.
+            completed = subprocess.run(  # nosec B603
+                cmd,
+                text=True,
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
         except (OSError, subprocess.SubprocessError):
             aggregate[GH_ERRORS_KEY] += 1
             continue

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Privacy-preserving repos.json auto-dispatch queue scanner."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+AGGREGATE_KEY = "aggregate"
+ERROR_KEY = "error"
+GH_ERRORS_KEY = "gh_errors"
+
+
+def _int_from_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _empty_aggregate() -> dict[str, int]:
+    return {
+        "repos": 0,
+        "auto_dispatch_open": 0,
+        "available_unassigned": 0,
+        "available_old": 0,
+        "oldest_available_age_min": 0,
+        "repos_with_available": 0,
+        "queued": 0,
+        "assigned": 0,
+        "blocked_labels": 0,
+        "needs_tier": 0,
+        "needs_status": 0,
+        "parent_task": 0,
+        "nmr": 0,
+        "no_auto_dispatch": 0,
+        GH_ERRORS_KEY: 0,
+    }
+
+
+def _emit(aggregate: dict[str, int], error: str = "", scanned_at: str = "") -> None:
+    payload: dict[str, Any] = {AGGREGATE_KEY: aggregate}
+    if error:
+        payload[ERROR_KEY] = error
+    if scanned_at:
+        payload["scanned_at"] = scanned_at
+    print(json.dumps(payload))
+
+
+def _issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels", [])
+    if not isinstance(labels, list):
+        return set()
+    return {str(label.get("name") or "") for label in labels if isinstance(label, dict)}
+
+
+def _issue_age_minutes(issue: dict[str, Any], now: dt.datetime) -> int:
+    updated_at = str(issue.get("updatedAt") or "")
+    try:
+        updated = dt.datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 0
+    return int((now - updated).total_seconds() // 60)
+
+
+def main() -> int:
+    repos_json = pathlib.Path(os.environ.get("PULSE_CHECK_REPOS_JSON", ""))
+    skip_gh = os.environ.get("PULSE_CHECK_SKIP_GH", "") in {"1", "true", "TRUE", "yes", "YES"}
+    max_issues = _int_from_env("PULSE_CHECK_MAX_ISSUES_PER_REPO", 100)
+    old_minutes = _int_from_env("PULSE_CHECK_OLD_AVAILABLE_MINUTES", 30)
+    aggregate = _empty_aggregate()
+
+    try:
+        data = json.loads(repos_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _emit(aggregate, f"repos_json_unreadable:{exc.__class__.__name__}")
+        return 0
+
+    repos = [
+        repo for repo in data.get("initialized_repos", [])
+        if repo.get("pulse") is True and not repo.get("local_only") and repo.get("slug")
+    ]
+    aggregate["repos"] = len(repos)
+    if skip_gh:
+        _emit(aggregate, "api_cooldown_active")
+        return 0
+    if shutil.which("gh") is None:
+        _emit(aggregate, "gh_missing")
+        return 0
+
+    now = dt.datetime.now(dt.timezone.utc)
+    blocking_labels = {
+        "parent-task",
+        "needs-maintainer-review",
+        "no-auto-dispatch",
+        "hold-for-review",
+        "blocked",
+        "status:blocked",
+        "status:in-review",
+    }
+
+    for repo in repos:
+        slug = str(repo.get("slug") or "")
+        cmd = [
+            "gh", "issue", "list",
+            "--repo", slug,
+            "--state", "open",
+            "--label", "auto-dispatch",
+            "--limit", str(max_issues),
+            "--json", "number,title,labels,assignees,updatedAt",
+        ]
+        try:
+            completed = subprocess.run(cmd, text=True, capture_output=True, timeout=30, check=False)
+        except (OSError, subprocess.SubprocessError):
+            aggregate[GH_ERRORS_KEY] += 1
+            continue
+        if completed.returncode != 0:
+            aggregate[GH_ERRORS_KEY] += 1
+            continue
+        try:
+            issues = json.loads(completed.stdout or "[]")
+        except json.JSONDecodeError:
+            aggregate[GH_ERRORS_KEY] += 1
+            continue
+
+        repo_available = 0
+        for issue in issues:
+            labels = _issue_labels(issue)
+            assigned = bool(issue.get("assignees"))
+            blocked = bool(labels & blocking_labels)
+            aggregate["auto_dispatch_open"] += 1
+            aggregate["assigned"] += int(assigned)
+            aggregate["queued"] += int("status:queued" in labels)
+            aggregate["needs_tier"] += int(not any(label.startswith("tier:") for label in labels))
+            aggregate["needs_status"] += int(not any(label.startswith("status:") for label in labels))
+            aggregate["blocked_labels"] += int(blocked)
+            aggregate["parent_task"] += int("parent-task" in labels)
+            aggregate["nmr"] += int("needs-maintainer-review" in labels)
+            aggregate["no_auto_dispatch"] += int("no-auto-dispatch" in labels)
+            if "status:available" in labels and not assigned and not blocked:
+                repo_available += 1
+                aggregate["available_unassigned"] += 1
+                age_min = _issue_age_minutes(issue, now)
+                aggregate["available_old"] += int(age_min >= old_minutes)
+                aggregate["oldest_available_age_min"] = max(aggregate["oldest_available_age_min"], age_min)
+        aggregate["repos_with_available"] += int(repo_available > 0)
+
+    _emit(aggregate, scanned_at=now.isoformat())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -1,0 +1,162 @@
+def number_or_zero: (tonumber? // 0);
+
+def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
+  id: $id,
+  severity: $severity,
+  title: $title,
+  evidence: $evidence,
+  recommendation: $recommendation,
+  autofile: $autofile
+};
+
+($current.pulse_gauges.dispatch_capacity_final_max_workers // 0 | number_or_zero) as $max_workers |
+($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // 0 | number_or_zero) as $available_slots |
+([$max_workers - $available_slots, 0] | max) as $active_workers |
+($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
+($queue.aggregate.available_old // 0 | number_or_zero) as $old_available |
+($queue.aggregate.needs_tier // 0 | number_or_zero) as $needs_tier |
+($queue.aggregate.gh_errors // 0 | number_or_zero) as $gh_errors |
+($queue.error // "") as $queue_error |
+($current.worker_outcomes.spawned // 0 | number_or_zero) as $spawned |
+($recent_summary.metrics.total // 0 | number_or_zero) as $recent_total |
+($summary.metrics.total // 0 | number_or_zero) as $hist_total |
+($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
+($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
+{
+  generated_at: (now | todateiso8601),
+  inputs: {current_window: $window, historical_window: $since, recent_window: $recent},
+  summary: {
+    max_workers: $max_workers,
+    active_workers: $active_workers,
+    available_slots: $available_slots,
+    dispatch_alive: ($current.dispatch_alive // false),
+    dispatch_stage_events: ($current.dispatch_stage_events // 0),
+    worker_launches_in_window: $spawned,
+    worker_terminal_events_in_window: ($current.worker_terminal_events // 0),
+    recent_worker_events: $recent_total,
+    historical_worker_events: $hist_total,
+    historical_worker_successes: $hist_success,
+    historical_success_rate: (if $hist_total > 0 then (($hist_success / $hist_total) * 100 | floor) else null end),
+    auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
+    auto_dispatch_available_unassigned: $available_issues,
+    auto_dispatch_available_old: $old_available,
+    auto_dispatch_repos_with_available: ($queue.aggregate.repos_with_available // 0),
+    auto_dispatch_scan_errors: $gh_errors,
+    auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
+    graphql_budget_status: ($current.graphql_budget_status // "unknown"),
+    runner_health: ($runner.finding // "unknown")
+  },
+  queue: ($queue.aggregate // {}),
+  current_state: {
+    dispatch_stage_counts: ($current.dispatch_stage_counts // {}),
+    worker_outcomes: ($current.worker_outcomes // {}),
+    pulse_counter_hits: ($current.pulse_counter_hits // {}),
+    pulse_gauges: ($current.pulse_gauges // {}),
+    current_state_guardrails: ($current.current_state_guardrails // {}),
+    dispatch_pacing: ($current.dispatch_pacing // {}),
+    top_pre_launch_blockers: ($current.top_pre_launch_blockers // [])
+  },
+  worker_activity: {
+    historical: {
+      window: ($summary.window // {}),
+      metrics: (($summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
+      pulse_stats: ($summary.pulse_stats // {})
+    },
+    recent: {
+      window: ($recent_summary.window // {}),
+      metrics: (($recent_summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
+      pulse_stats: ($recent_summary.pulse_stats // {})
+    },
+    providers: ($providers.provider_diagnostics // {})
+  },
+  runner_health: $runner,
+  api_budget: {
+    graphql_circuit_breaker_trips: ($api.graphql_circuit_breaker_trips // 0),
+    reserve_mode_cycles: ($api.reserve_mode_cycles // 0),
+    deferred_optional_stages: ($api.deferred_optional_stages // 0),
+    secondary_cooldown_state: ($api.secondary_cooldown_state // "unknown"),
+    cadence_api_risk: ($api.cadence_api_risk // "unknown")
+  },
+  findings: ([
+    if ($available_issues >= $threshold and $active_workers == 0) then
+      finding(
+        "pulse-underfilled-auto-dispatch-queue";
+        "high";
+        "Auto-dispatch queue is visible while worker capacity is empty";
+        [
+          ("active_workers=" + ($active_workers | tostring) + "/" + ($max_workers | tostring)),
+          ("available_unassigned_auto_dispatch=" + ($available_issues | tostring)),
+          ("available_older_than_threshold=" + ($old_available | tostring)),
+          ("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
+        ];
+        "Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health.";
+        true
+      )
+    else empty end,
+    if ($spawned >= 3 and $active_workers == 0 and $recent_total == 0) then
+      finding(
+        "pulse-launch-accounting-gap";
+        "high";
+        "Pulse recorded worker launches without active workers or recent terminal metrics";
+        [
+          ("worker_launches_in_current_window=" + ($spawned | tostring)),
+          ("recent_worker_metric_events=" + ($recent_total | tostring)),
+          ("active_workers=" + ($active_workers | tostring)),
+          ("available_slots=" + ($available_slots | tostring))
+        ];
+        "Add or repair launch-validation evidence so every spawned worker becomes an active process, a terminal metric, or a classified launch failure.";
+        true
+      )
+    else empty end,
+    if ($needs_tier > 0) then
+      finding(
+        "auto-dispatch-missing-tier-labels";
+        "medium";
+        "Some auto-dispatch issues are missing tier labels";
+        [("missing_tier_count=" + ($needs_tier | tostring))];
+        "Run or repair label normalisation so auto-dispatch issues carry exactly one tier label before worker pickup.";
+        false
+      )
+    else empty end,
+    if ($gh_errors > 0) then
+      finding(
+        "pulse-check-gh-scan-errors";
+        "medium";
+        "Auto-dispatch queue scan had GitHub read errors";
+        [("gh_errors=" + ($gh_errors | tostring))];
+        "Check GitHub authentication and API budget before treating queue counts as complete.";
+        false
+      )
+    else empty end,
+    if ($queue_error != "") then
+      finding(
+        "pulse-check-queue-scan-skipped";
+        "medium";
+        "Auto-dispatch queue scan was skipped or incomplete";
+        [("queue_scan_state=" + $queue_error)];
+        "Re-run pulse-check after API cooldown clears before making queue-depth or underfill claims.";
+        false
+      )
+    else empty end,
+    if ($graphql_trips > 0 or ($current.dispatch_api_blocked // false) == true) then
+      finding(
+        "github-api-budget-blocking-dispatch";
+        "high";
+        "GitHub API budget is blocking or degrading dispatch";
+        [("graphql_circuit_breaker_trips=" + ($graphql_trips | tostring)), ("dispatch_api_blocked=" + (($current.dispatch_api_blocked // false) | tostring))];
+        "Use pulse-diagnose-helper api-budget to identify top callers and shift avoidable reads to cache/REST before increasing concurrency.";
+        true
+      )
+    else empty end,
+    if ($hist_total >= 10 and (($hist_success * 100) / $hist_total) < 70) then
+      finding(
+        "worker-success-rate-regression";
+        "medium";
+        "Historical worker success rate is below the productivity target";
+        [("success_rate_percent=" + (((($hist_success * 100) / $hist_total) | floor) | tostring)), ("worker_events=" + ($hist_total | tostring))];
+        "Cluster failure families with worker-activity-helper summary --json, then file targeted fixes for the dominant cause instead of increasing concurrency.";
+        false
+      )
+    else empty end
+  ])
+}

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -36,12 +36,24 @@ ENTRIES
 }
 
 # ---------------------------------------------------------------------------
+# _is_darwin_os <os>
+# Returns 0 when the routine description target is macOS.
+# ---------------------------------------------------------------------------
+_is_darwin_os() {
+	local os="$1"
+	if [[ "$os" == "darwin" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
 # _platform_footnote <os>
 # Outputs a cross-platform reference footnote for the other OS.
 # ---------------------------------------------------------------------------
 _platform_footnote() {
 	local os="$1"
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		cat <<'FOOT'
 
 ---
@@ -74,7 +86,7 @@ _scheduler_row() {
 	local interval_sec="$2"
 	local plist_label="$3"
 	local systemd_unit="$4"
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		echo "| Scheduler | launchd \`${plist_label}\` (StartInterval: ${interval_sec}) |"
 	else
 		echo "| Scheduler | systemd \`${systemd_unit}.timer\` (OnUnitActiveSec=${interval_sec}s) |"
@@ -91,7 +103,7 @@ _scheduler_row_calendar() {
 	local calendar_desc="$2"
 	local plist_label="$3"
 	local systemd_unit="$4"
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		echo "| Scheduler | launchd \`${plist_label}\` (${calendar_desc}) |"
 	else
 		echo "| Scheduler | systemd \`${systemd_unit}.timer\` (OnCalendar=${calendar_desc}) |"
@@ -107,7 +119,7 @@ _diag_commands() {
 	local os="$1"
 	local plist_label="$2"
 	local systemd_unit="$3"
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		cat <<EOF
 - \`launchctl list | grep ${plist_label##*.}\` — PID and exit status
 - \`log show --predicate 'subsystem == "com.apple.launchd"' --last 5m | grep ${plist_label##*.}\` — recent launches
@@ -328,7 +340,7 @@ EOF
 describe_r905() {
 	local os="${1:-darwin}"
 	local mem_check_cmd mem_monitor
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		mem_check_cmd="\`memory_pressure\` command — current system pressure"
 		mem_monitor="Activity Monitor → Memory tab — pressure graph"
 	else
@@ -492,7 +504,7 @@ EOF
 describe_r909() {
 	local os="${1:-darwin}"
 	local screen_time_check
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		screen_time_check="System Settings → Screen Time — raw data"
 	else
 		screen_time_check="\`~/.aidevops/.agent-workspace/cron/screen-time/\` — snapshot data (no native Screen Time on Linux)"
@@ -612,7 +624,7 @@ EOF
 describe_r912() {
 	local os="${1:-darwin}"
 	local status_cmd
-	if [[ "$os" == "darwin" ]]; then
+	if _is_darwin_os "$os"; then
 		status_cmd="\`launchctl list | grep dashboard\` — process status"
 	else
 		status_cmd="\`systemctl --user status sh.aidevops.dashboard\` — service status"
@@ -815,7 +827,10 @@ EOF
 }
 
 describe_r915() {
-	local os="${1:-darwin}"
+	local os="${1:-}"
+	if [[ -z "$os" ]]; then
+		os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	fi
 	cat <<EOF
 # r915: Pulse check
 

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -30,6 +30,7 @@ r911|x|OAuth token refresh|repeat:cron(*/30 * * * *)|~10s|scripts/oauth-pool-hel
 r912| |Dashboard server|repeat:persistent|~0s|server/index.ts|service
 r913|x|Weekly opencode DB maintenance|repeat:weekly(sun@04:00)|~2m|scripts/opencode-db-maintenance-helper.sh auto|script
 r914|x|Repo aidevops health — bump stale .aidevops.json, detect drift|repeat:daily(@03:30)|~2m|scripts/repo-aidevops-health-helper.sh run|script
+r915|x|Pulse check — worker utilisation and self-improvement recommendations|repeat:daily(@06:20)|~5m|scripts/pulse-check-helper.sh apply|script
 ENTRIES
 	return 0
 }
@@ -808,6 +809,59 @@ $(_diag_commands "$os" "sh.aidevops.repo-aidevops-health" "sh.aidevops.repo-aide
 - \`~/.aidevops/cache/repo-aidevops-health-state.json\` — last run summary.
 - \`.aidevops/agents/VERSION\` — current framework version (bump target).
 - Drift issues on \`marcusquinn/aidevops\` labelled \`repos-drift\` or \`no-init\`.
+$(_platform_footnote "$os")
+EOF
+	return 0
+}
+
+describe_r915() {
+	local os="${1:-darwin}"
+	cat <<EOF
+# r915: Pulse check
+
+## Overview
+
+Daily bounded diagnostics for pulse and worker productivity. It compares
+current worker capacity, recent terminal worker metrics, provider/API budget,
+and repos.json auto-dispatch queue depth, then files deduplicated
+self-improvement issues only for high-confidence productivity gaps.
+
+## Schedule
+
+| Field | Value |
+|-------|-------|
+| Frequency | Daily at 06:20 |
+| Type | script |
+| Expected duration | ~5 minutes |
+| Script | \`scripts/pulse-check-helper.sh apply\` |
+$(_scheduler_row_calendar "$os" "StartCalendarInterval: Hour=6, Minute=20" "sh.aidevops.pulse-check" "sh.aidevops.pulse-check")
+
+## What it does
+
+1. Runs \`pulse-current-state-helper.sh --window 15m --json\` for live
+   dispatch, worker launch, guardrail, and API-budget evidence.
+2. Runs \`worker-activity-helper.sh summary --since 1h/24h --json --no-pr-check\`
+   for canonical recent and historical worker outcomes.
+3. Scans pulse-enabled repos in \`repos.json\` for open \`auto-dispatch\`
+   issues using aggregate counts only; repo names, local paths, and issue titles
+   are intentionally omitted from output and filed issues.
+4. Files or reuses self-improvement issues marked with
+   \`<!-- aidevops:generator=pulse-check finding=... -->\` when a finding is
+   high-confidence and worker-dispatchable.
+
+## Safety rails
+
+- Uses aggregate queue metrics to preserve private repo/path confidentiality.
+- Uses wrapper-created issues with \`--body-file\` and dedupe markers.
+- Does not increase concurrency by itself; recommendations must cite evidence.
+- JSON output removes raw worker examples that may contain repo slugs or paths.
+
+## What to check
+
+$(_diag_commands "$os" "sh.aidevops.pulse-check" "sh.aidevops.pulse-check")
+- \`pulse-check-helper.sh report\` — ad-hoc interactive report.
+- \`pulse-check-helper.sh json\` — machine-readable evidence.
+- Open issues carrying \`source:pulse-check\` — deduplicated improvements.
 $(_platform_footnote "$os")
 EOF
 	return 0

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pulse-check-helper.sh — offline tests for pulse-check-helper.sh.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_contains() {
+	local label="$1"
+	local needle="$2"
+	local haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected to find: %s\n' "$needle"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local label="$1"
+	local needle="$2"
+	local haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  did not expect to find: %s\n' "$needle"
+	else
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	fi
+	return 0
+}
+
+assert_eq() {
+	local label="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected: %s\n  actual:   %s\n' "$expected" "$actual"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="${SCRIPT_DIR}/pulse-check-helper.sh"
+CORE_ROUTINES="${SCRIPT_DIR}/routines/core-routines.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	printf '%sFATAL%s: helper not executable: %s\n' "$TEST_RED" "$TEST_NC" "$HELPER"
+	exit 1
+fi
+
+TEST_ROOT="$(mktemp -d -t pulse-check-test-XXXXXX)"
+BIN_DIR="${TEST_ROOT}/bin"
+mkdir -p "$BIN_DIR"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+cat >"${TEST_ROOT}/repos.json" <<'JSON'
+{
+  "initialized_repos": [
+    {"slug": "private/repo-one", "pulse": true, "local_only": false},
+    {"slug": "public/repo-two", "pulse": true, "local_only": false},
+    {"slug": "ignored/local", "pulse": true, "local_only": true}
+  ]
+}
+JSON
+
+cat >"${TEST_ROOT}/current-state.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": true,
+  "dispatch_stage_events": 12,
+  "current_state_guardrails": {"available_slots_last": 6},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
+  "worker_outcomes": {"spawned": 4},
+  "worker_terminal_events": 0,
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state.sh"
+
+cat >"${TEST_ROOT}/worker-activity.sh" <<'SH'
+#!/usr/bin/env bash
+cmd="${1:-}"
+shift || true
+if [[ "$cmd" == "providers" ]]; then
+  cat <<'JSON'
+{"provider_diagnostics":{"provider_model_usage":[],"recent_events":[],"account_pool":[{"provider":"openai","total":1,"available":1,"capacity_slots":24,"active_idle":1,"rate_limited":0,"auth_errors":0}]}}
+JSON
+  exit 0
+fi
+since="24h"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) since="${2:-24h}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ "$since" == "1h" ]]; then
+  cat <<'JSON'
+{"window":{"since":"1h"},"metrics":{"total":0,"succeeded":0,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"samples":0,"avg":0,"max":0},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{}}
+JSON
+else
+  cat <<'JSON'
+{"window":{"since":"24h"},"metrics":{"total":10,"succeeded":8,"result_counts":{"success":8,"blocked":2},"diagnostic_focus":{},"timing_ms":{"samples":10,"avg":1000,"max":2000},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{}}
+JSON
+fi
+SH
+chmod +x "${TEST_ROOT}/worker-activity.sh"
+
+cat >"${TEST_ROOT}/runner-health.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"finding":"HEALTHY"}
+JSON
+SH
+chmod +x "${TEST_ROOT}/runner-health.sh"
+
+cat >"${TEST_ROOT}/pulse-diagnose.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"graphql_circuit_breaker_trips":0,"reserve_mode_cycles":0,"deferred_optional_stages":0,"secondary_cooldown_state":"active=no","cadence_api_risk":"risk=ok"}
+JSON
+SH
+chmod +x "${TEST_ROOT}/pulse-diagnose.sh"
+
+cat >"${BIN_DIR}/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ " $* " == *" repo view "* ]]; then
+  printf 'owner/aidevops\n'
+  exit 0
+fi
+if [[ " $* " == *" --search "* ]]; then
+  printf '[]\n'
+  exit 0
+fi
+if [[ " $* " == *"private/repo-one"* ]]; then
+  cat <<'JSON'
+[
+  {"number":1,"title":"secret one","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
+  {"number":2,"title":"secret two","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
+  {"number":3,"title":"secret three","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
+  {"number":4,"title":"secret four","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]}
+]
+JSON
+  exit 0
+fi
+cat <<'JSON'
+[
+  {"number":5,"title":"public five","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
+  {"number":6,"title":"public six","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}
+]
+JSON
+SH
+chmod +x "${BIN_DIR}/gh"
+
+cat >"${TEST_ROOT}/wrappers.sh" <<'SH'
+#!/usr/bin/env bash
+gh_create_issue() {
+  local repo=""
+  local title=""
+  local body_file=""
+  local labels=""
+  while [[ $# -gt 0 ]]; do
+    local arg="$1"
+    case "$arg" in
+      --repo) repo="${2:-}"; shift 2 ;;
+      --title) title="${2:-}"; shift 2 ;;
+      --body-file) body_file="${2:-}"; shift 2 ;;
+      --label) labels="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  printf 'repo=%s\ntitle=%s\nlabels=%s\nbody_file=%s\n' "$repo" "$title" "$labels" "$body_file" >>"${PULSE_CHECK_CAPTURE}"
+  cp "$body_file" "${PULSE_CHECK_CAPTURE}.body"
+  printf 'created-issue-1\n'
+  return 0
+}
+SH
+
+COMMON_ENV=(
+	"PATH=${BIN_DIR}:$PATH"
+	"PULSE_CHECK_REPOS_JSON=${TEST_ROOT}/repos.json"
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state.sh"
+	"PULSE_CHECK_WORKER_ACTIVITY_HELPER=${TEST_ROOT}/worker-activity.sh"
+	"PULSE_CHECK_RUNNER_HEALTH_HELPER=${TEST_ROOT}/runner-health.sh"
+	"PULSE_CHECK_PULSE_DIAGNOSE_HELPER=${TEST_ROOT}/pulse-diagnose.sh"
+	"PULSE_CHECK_GH_WRAPPERS=${TEST_ROOT}/wrappers.sh"
+	"PULSE_CHECK_CAPTURE=${TEST_ROOT}/capture.txt"
+)
+
+printf '%s=== pulse-check-helper.sh tests ===%s\n' "$TEST_BLUE" "$TEST_NC"
+
+OUT=$(env "${COMMON_ENV[@]}" "$HELPER" report 2>&1)
+assert_contains "text report shows empty active capacity" "Active workers: 0 / 6" "$OUT"
+assert_contains "text report shows aggregate queue" "Auto-dispatch queue: 6 available / 6 open" "$OUT"
+assert_contains "underfilled finding appears" "pulse-underfilled-auto-dispatch-queue" "$OUT"
+assert_contains "launch accounting finding appears" "pulse-launch-accounting-gap" "$OUT"
+assert_not_contains "text report omits private slug" "private/repo-one" "$OUT"
+assert_not_contains "text report omits issue titles" "secret one" "$OUT"
+
+JSON_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" json 2>&1)
+IDS=$(printf '%s' "$JSON_OUT" | jq -r '[.findings[].id] | sort | join(",")')
+assert_eq "json finding IDs" "auto-dispatch-missing-tier-labels,pulse-launch-accounting-gap,pulse-underfilled-auto-dispatch-queue" "$IDS"
+JSON_PRIVATE_COUNT=$(printf '%s' "$JSON_OUT" | grep -c "private/repo-one" 2>/dev/null || true)
+assert_eq "json output removes raw worker examples" "0" "$JSON_PRIVATE_COUNT"
+
+APPLY_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" apply --repo owner/aidevops 2>&1)
+assert_contains "apply reports issue filing" "pulse-check: filed" "$APPLY_OUT"
+BODY=$(cat "${TEST_ROOT}/capture.txt.body")
+assert_contains "apply body carries marker" "aidevops:generator=pulse-check finding=" "$BODY"
+assert_contains "apply body carries verification" ".agents/scripts/tests/test-pulse-check-helper.sh" "$BODY"
+assert_not_contains "apply body omits private slug" "private/repo-one" "$BODY"
+assert_not_contains "apply body omits issue title" "secret one" "$BODY"
+
+# shellcheck source=../routines/core-routines.sh
+CORE_OUTPUT=$(source "$CORE_ROUTINES" && get_core_routine_entries)
+assert_contains "r915 registered as core routine" "r915|x|Pulse check" "$CORE_OUTPUT"
+if (
+	# shellcheck source=../routines/core-routines.sh
+	source "$CORE_ROUTINES" && declare -F describe_r915 >/dev/null 2>&1
+); then
+	assert_eq "describe_r915 function exists" "0" "0"
+else
+	assert_eq "describe_r915 function exists" "0" "1"
+fi
+
+printf '\n%sTests run:%s %s | %sFailures:%s %s\n' "$TEST_BLUE" "$TEST_NC" "$TESTS_RUN" "$TEST_BLUE" "$TEST_NC" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -ne 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/workflows/pulse-check.md
+++ b/.agents/workflows/pulse-check.md
@@ -1,0 +1,54 @@
+---
+description: Pulse and worker utilisation diagnostics across repos.json, with self-improvement recommendations
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Run a bounded pulse/worker productivity check for interactive sessions.
+
+Arguments: $ARGUMENTS
+
+## Goal
+
+Answer “is the pulse using available concurrency and model/provider allowance?”
+from canonical current-state evidence, not process snapshots or log mtimes.
+
+## Procedure
+
+1. Run the deterministic helper first:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-check-helper.sh report $ARGUMENTS
+   ```
+
+2. If the user asks for machine-readable evidence:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-check-helper.sh json $ARGUMENTS
+   ```
+
+3. If the user explicitly asks to file self-improvement work, or this is the
+   scheduled daily routine, use deduplicated apply mode:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-check-helper.sh apply $ARGUMENTS
+   ```
+
+## Interpretation
+
+- Prioritise 5–15 minute current-state evidence for “is work happening now?”
+  claims.
+- Use 24h/48h aggregates only for trend context and failure-family clustering.
+- An issue is worth filing only when the helper marks a finding `autofile=true`
+  or you can cite equivalent evidence from the helper JSON.
+- Do not publish private repo names, local paths, issue titles, or raw worker
+  examples in public comments/issues; the helper output is aggregate by design.
+
+## Verification references
+
+- `.agents/reference/diagnostics-discipline.md`
+- `.agents/reference/worker-diagnostics.md`
+- `.agents/scripts/tests/test-pulse-check-helper.sh`

--- a/.agents/workflows/strategic-review.md
+++ b/.agents/workflows/strategic-review.md
@@ -12,14 +12,19 @@ You are the strategic reviewer. Run every 4 hours at opus tier. The sonnet pulse
 
 ## Step 1: Gather State
 
-Gather state for ALL pulse-enabled repos — not just aidevops.
+Start with the bounded pulse-check evidence. It is the canonical entry point for
+utilisation claims because it combines current-state worker evidence,
+repos.json auto-dispatch queue counts, provider/API budget, and deduplicated
+self-improvement recommendations without leaking private repo names.
 
 ```bash
-# Pulse-enabled repos
-jq '[.initialized_repos[] | select(.pulse == true and .local_only != true)]' ~/.config/aidevops/repos.json
+~/.aidevops/agents/scripts/pulse-check-helper.sh report
+~/.aidevops/agents/scripts/pulse-check-helper.sh json
 ```
 
-Per repo (run all, skip none):
+Only run per-repo GitHub reads when the pulse-check report identifies a
+specific unresolved queue, PR, or state-consistency question. Keep output
+private unless publishing to a private channel.
 
 ```bash
 # Per-repo: open PRs
@@ -37,17 +42,6 @@ gh issue list --repo <owner/repo> --state open --json number,title,labels,update
 # Per-repo: TODO.md tasks
 # rg '^\- \[ \] t\d+' ~/Git/<repo>/TODO.md
 # rg -c '^\- \[x\] t\d+' ~/Git/<repo>/TODO.md
-```
-
-```bash
-# Active worktrees — iterate all managed repos
-jq -r '[.initialized_repos[] | select(.pulse == true and .local_only != true)] | .[].path' ~/.config/aidevops/repos.json | while read -r repo_path; do
-  echo "=== $repo_path ==="
-  git -C "$repo_path" worktree list 2>/dev/null || echo "(not a git repo or path missing)"
-done
-
-# Running workers
-pgrep -f '/full-loop' 2>/dev/null | wc -l | tr -d ' '
 ```
 
 **Product repos have higher priority than tooling repos.** Check `priority` field in repos.json.

--- a/TODO.md
+++ b/TODO.md
@@ -1064,6 +1064,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18039 Add productivity insights and systemic fix feedback to Pulse & Workers #auto-dispatch #dashboard #feat #observability #pulse #self-improvement ~4h blocked-by:t18038 ref:GH#25917 logged:2026-06-30 -> [todo/tasks/t18039-brief.md]
 
+- [ ] t18042 Add pulse-check diagnostics routine #feat #framework #no-auto-dispatch #pulse ref:GH#26099
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -94,6 +94,7 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 - [x] r045 Email filter tick: auto-attach matched email sources to cases repeat:cron(*/15 * * * *) run:scripts/email-filter-helper.sh tick
 - [x] r046 Canonical-recovery sweep — re-attempt failed git pull/stash for repos with active advisory files (t3027) repeat:cron(*/10 * * * *) ~1m run:scripts/canonical-recovery-routine.sh tick
 - [ ] r-runtime-audit Runtime health audit — surface operational regressions invisible to the supervisor LLM (counter trends, process leaks, deploy mtime drift, log novelty, stuck pulse state) (t3072) repeat:cron(*/30 * * * *) ~2m run:scripts/runtime-health-audit-helper.sh --apply
+- [x] r-pulse-check Daily pulse/worker utilisation check — aggregate repos.json auto-dispatch queue, active capacity, provider/API budget, and file deduplicated self-improvement issues for high-confidence productivity gaps repeat:daily(@06:20) ~5m run:scripts/pulse-check-helper.sh apply
 
 ## Ready
 

--- a/TODO.md
+++ b/TODO.md
@@ -1064,8 +1064,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18039 Add productivity insights and systemic fix feedback to Pulse & Workers #auto-dispatch #dashboard #feat #observability #pulse #self-improvement ~4h blocked-by:t18038 ref:GH#25917 logged:2026-06-30 -> [todo/tasks/t18039-brief.md]
 
-- [ ] t18042 Add pulse-check diagnostics routine #feat #framework #no-auto-dispatch #pulse ref:GH#26099
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

- Add `/pulse-check` backed by `pulse-check-helper.sh` for bounded pulse/worker utilisation diagnostics.
- Add daily `r915` pulse-check routine plus TODO entry for deduplicated self-improvement issue filing.
- Keep queue diagnostics privacy-preserving by reporting aggregate repos.json counts only.
- Update strategic-review and diagnostics docs to use pulse-check as the combined utilisation/queue/API entry point.

Resolves #26099

## Verification

- `.agents/scripts/tests/test-pulse-check-helper.sh`
- `shellcheck ".agents/scripts/pulse-check-helper.sh" ".agents/scripts/tests/test-pulse-check-helper.sh" ".agents/scripts/routines/core-routines.sh"`
- `python3 -m py_compile ".agents/scripts/pulse-check-queue-scan.py"`
- `.agents/scripts/tests/test-pulse-routines-cron-extraction.sh && .agents/scripts/tests/test-pulse-routines-selector.sh && .agents/scripts/tests/test-opencode-db-maintenance.sh`
- `.agents/scripts/linters-local.sh` (passes; existing SonarCloud badge warning remains non-blocking in local gate output)

## Notes

- Interactive user requested full-loop through release.
- Original `pulse-check-diagnostics` remote branch was superseded after issue-counter sync moved `main`; this PR uses `pulse-check-diagnostics-release` to avoid force-pushing.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 with gpt-5.5 spent 2h 2m and 727,930 tokens on this with the user in an interactive session.