### PR TITLE
GH#26078: fix: suppress dep graph jq diagnostics

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -430,7 +430,7 @@ _refresh_all_blockers_resolved() {
 
 	# Issue number blockers
 	local blocker_nums="" bnum=""
-	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]?' || true)
+	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]?' 2>/dev/null || true)
 	while IFS= read -r bnum; do
 		[[ "$bnum" =~ ^[0-9]+$ ]] || continue
 		is_open=$(printf '%s' "$open_issues_json" | jq --argjson n "$bnum" 'index($n) != null' 2>/dev/null) || is_open="false"
@@ -461,7 +461,7 @@ _refresh_cleanup_resolved_blocker_labels() {
 
 	local removed_count=0
 	local blocker_nums="" blocker_num="" stale_label=""
-	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]?' || true)
+	blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]?' 2>/dev/null || true)
 	while IFS= read -r blocker_num; do
 		[[ "$blocker_num" =~ ^[0-9]+$ ]] || continue
 		stale_label="blocked-by:#${blocker_num}"


### PR DESCRIPTION
## Summary

Suppressed jq stderr when parsing optional issue_nums arrays in pulse dep graph blocker resolution and stale-label cleanup.

## Files Changed

.agents/scripts/pulse-dep-graph.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dep-graph.sh

Resolves #26078


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 2m and 31,870 tokens on this as a headless worker.