### PR TITLE
GH#26091: fix: align GenUI aria label fallback

### DIFF
--- a/packages/gui-web/src/GenUiCards.tsx
+++ b/packages/gui-web/src/GenUiCards.tsx
@@ -16,7 +16,7 @@ function DevOpsCard({ validation }: { validation: GuiTamboValidationResult }) {
   const entries = Object.entries(props).filter(([key]) => key !== "title" && key !== "disabled");
 
   return (
-    <section className="genui-card" data-genui-component={validation.component ?? "unknown"} aria-label={`${validation.component} ${text.devOpsCard}`}>
+    <section className="genui-card" data-genui-component={validation.component ?? "unknown"} aria-label={`${validation.component ?? "unknown"} ${text.devOpsCard}`}>
       <header>
         <p className="eyebrow">{text.tamboGenUiReadOnly}</p>
         <h3>{stringProp(props.title) ?? validation.component}</h3>


### PR DESCRIPTION
## Summary

Updated the GenUI DevOps card aria-label to use the same nullish fallback as data-genui-component, avoiding nullable component coercion.

## Files Changed

packages/gui-web/src/GenUiCards.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Attempted bun test packages/gui-web/tests and bun run typecheck; both blocked because bun is not installed in the worker environment. Attempted npm install --no-package-lock; blocked by workspace:* protocol in this Bun workspace. Attempted npx tsc --noEmit/npm run typecheck; blocked because local TypeScript dependencies are unavailable.

Resolves #26091


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 3m and 31,366 tokens on this as a headless worker.