### PR TITLE
Add desktop screenshot capture menu

### DIFF
--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -341,6 +341,7 @@ final class DraggableTitlebarView: NSView {
 final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, NSMenuItemValidation, NSWindowDelegate {
     private var window: NSWindow!
     private var aboutWindow: NSWindow?
+    private var titlebarCameraButton: NSButton?
     private var titlebarToggleButton: NSButton?
     private var webView: WKWebView!
     private let apiPort = ProcessInfo.processInfo.environment["AIDEVOPS_GUI_API_PORT"] ?? "8787"
@@ -408,7 +409,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             return
         }
 
+        if revealFileURL(url) {
+            return
+        }
+
         _ = openExternalURL(url)
+    }
+
+    private func revealFileURL(_ url: URL) -> Bool {
+        guard url.isFileURL else {
+            return false
+        }
+
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+        return true
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
@@ -552,7 +566,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             return webView?.canGoBack ?? false
         case #selector(goForward(_:)):
             return webView?.canGoForward ?? false
-        case #selector(reloadPage(_:)), #selector(stopLoading(_:)), #selector(resetZoom(_:)), #selector(zoomIn(_:)), #selector(zoomOut(_:)):
+        case #selector(reloadPage(_:)), #selector(stopLoading(_:)), #selector(resetZoom(_:)), #selector(zoomIn(_:)), #selector(zoomOut(_:)), #selector(captureAppScreenshot(_:)), #selector(capturePageScreenshot(_:)):
             return webView != nil
         default:
             return true
@@ -779,11 +793,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
 
         overlay.addSubview(toggleButton)
         titlebarToggleButton = toggleButton
+
+        let cameraButton = NSButton(frame: .zero)
+        cameraButton.action = #selector(showScreenshotMenu(_:))
+        cameraButton.bezelStyle = .regularSquare
+        cameraButton.contentTintColor = defaultButtonAccent
+        cameraButton.image = cameraImage()
+        cameraButton.imagePosition = .imageOnly
+        cameraButton.isBordered = false
+        cameraButton.setButtonType(.momentaryChange)
+        cameraButton.target = self
+        cameraButton.toolTip = "Capture an aidevops screenshot"
+        cameraButton.translatesAutoresizingMaskIntoConstraints = false
+
+        overlay.addSubview(cameraButton)
+        titlebarCameraButton = cameraButton
         NSLayoutConstraint.activate([
             toggleButton.leadingAnchor.constraint(equalTo: overlay.leadingAnchor, constant: 92),
             toggleButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 3.5),
             toggleButton.heightAnchor.constraint(equalToConstant: 22),
-            toggleButton.widthAnchor.constraint(equalToConstant: 22)
+            toggleButton.widthAnchor.constraint(equalToConstant: 22),
+            cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -92),
+            cameraButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 3.5),
+            cameraButton.heightAnchor.constraint(equalToConstant: 22),
+            cameraButton.widthAnchor.constraint(equalToConstant: 22)
         ])
 
         return overlay
@@ -791,6 +824,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
 
     private func updateTitlebarAccent(hue: CGFloat) {
         let normalizedHue = min(359, max(0, hue))
+        titlebarCameraButton?.contentTintColor = accentColor(hueDegrees: normalizedHue, alpha: 0.9)
         titlebarToggleButton?.contentTintColor = accentColor(hueDegrees: normalizedHue, alpha: 0.9)
     }
 
@@ -866,8 +900,189 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         return image
     }
 
+    private func cameraImage() -> NSImage {
+        let image = NSImage(size: NSSize(width: 20, height: 20), flipped: false) { _ in
+            let body = NSBezierPath(roundedRect: NSRect(x: 3, y: 6, width: 14, height: 10), xRadius: 2.7, yRadius: 2.7)
+            body.lineWidth = 2
+            NSColor.labelColor.setStroke()
+            body.stroke()
+
+            let prism = NSBezierPath(roundedRect: NSRect(x: 6, y: 14, width: 5, height: 2.3), xRadius: 1, yRadius: 1)
+            prism.lineWidth = 1.8
+            prism.stroke()
+
+            let lens = NSBezierPath(ovalIn: NSRect(x: 7.1, y: 8.1, width: 5.8, height: 5.8))
+            lens.lineWidth = 1.8
+            lens.stroke()
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
     @objc private func toggleMachineRail(_ sender: Any?) {
         webView.evaluateJavaScript("window.dispatchEvent(new CustomEvent('aidevops:toggle-machine-rail')); true;", completionHandler: nil)
+    }
+
+    @objc private func showScreenshotMenu(_ sender: Any?) {
+        guard let button = sender as? NSButton else {
+            return
+        }
+
+        let menu = NSMenu(title: "Screenshots")
+        menu.addItem(menuItem("Screenshot App", action: #selector(captureAppScreenshot(_:)), target: self))
+        menu.addItem(menuItem("Screenshot Page", action: #selector(capturePageScreenshot(_:)), target: self))
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 3), in: button)
+    }
+
+    @objc private func captureAppScreenshot(_ sender: Any?) {
+        guard let contentView = window.contentView else {
+            return
+        }
+
+        let bounds = contentView.bounds
+        guard let representation = contentView.bitmapImageRepForCachingDisplay(in: bounds) else {
+            return
+        }
+
+        contentView.cacheDisplay(in: bounds, to: representation)
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(representation)
+        saveScreenshot(image: image, nameComponent: "window")
+    }
+
+    @objc private func capturePageScreenshot(_ sender: Any?) {
+        let script = """
+        (() => {
+          const el = document.querySelector('.workspace-scroll');
+          const title = document.querySelector('.header-title h1')?.textContent || document.title || 'page';
+          if (!el) return null;
+          const rect = el.getBoundingClientRect();
+          return { x: rect.left, y: rect.top, width: rect.width, height: rect.height, scrollHeight: el.scrollHeight, title, originalScrollTop: el.scrollTop };
+        })();
+        """
+
+        webView.evaluateJavaScript(script) { [weak self] result, _ in
+            guard let self = self, let info = result as? [String: Any] else {
+                return
+            }
+
+            self.captureScrollableWorkspace(info: info)
+        }
+    }
+
+    private func captureScrollableWorkspace(info: [String: Any]) {
+        guard let x = info["x"] as? NSNumber,
+              let y = info["y"] as? NSNumber,
+              let width = info["width"] as? NSNumber,
+              let height = info["height"] as? NSNumber,
+              let scrollHeight = info["scrollHeight"] as? NSNumber else {
+            return
+        }
+
+        let viewportHeight = max(1, CGFloat(height.doubleValue))
+        let contentHeight = max(viewportHeight, CGFloat(scrollHeight.doubleValue))
+        let contentWidth = max(1, CGFloat(width.doubleValue))
+        let captureRect = CGRect(x: CGFloat(x.doubleValue), y: CGFloat(y.doubleValue), width: contentWidth, height: viewportHeight)
+        let pageName = sanitizeFilenameComponent((info["title"] as? String) ?? "page")
+        let originalScrollTop = CGFloat((info["originalScrollTop"] as? NSNumber)?.doubleValue ?? 0)
+        let composite = NSImage(size: NSSize(width: contentWidth, height: contentHeight))
+        captureWorkspaceChunk(rect: captureRect, contentHeight: contentHeight, viewportHeight: viewportHeight, originalScrollTop: originalScrollTop, targetOffset: 0, pageName: pageName, composite: composite, capturedOffsets: Set<Int>())
+    }
+
+    private func captureWorkspaceChunk(rect: CGRect, contentHeight: CGFloat, viewportHeight: CGFloat, originalScrollTop: CGFloat, targetOffset: CGFloat, pageName: String, composite: NSImage, capturedOffsets: Set<Int>) {
+        let scrollScript = """
+        (() => {
+          const el = document.querySelector('.workspace-scroll');
+          if (!el) return null;
+          el.scrollTop = \(Int(targetOffset));
+          return el.scrollTop;
+        })();
+        """
+
+        webView.evaluateJavaScript(scrollScript) { [weak self] result, _ in
+            guard let self = self else {
+                return
+            }
+
+            let actualOffset = CGFloat((result as? NSNumber)?.doubleValue ?? Double(targetOffset))
+            let offsetKey = Int(actualOffset.rounded())
+            var nextCapturedOffsets = capturedOffsets
+            if capturedOffsets.contains(offsetKey) {
+                self.restoreWorkspaceScroll(originalScrollTop)
+                self.saveScreenshot(image: composite, nameComponent: pageName)
+                return
+            }
+            nextCapturedOffsets.insert(offsetKey)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                let configuration = WKSnapshotConfiguration()
+                configuration.rect = rect
+                self.webView.takeSnapshot(with: configuration) { snapshot, _ in
+                    if let snapshot = snapshot {
+                        composite.lockFocus()
+                        snapshot.draw(in: NSRect(x: 0, y: contentHeight - actualOffset - viewportHeight, width: rect.width, height: viewportHeight), from: .zero, operation: .copy, fraction: 1)
+                        composite.unlockFocus()
+                    }
+
+                    if actualOffset + viewportHeight >= contentHeight - 1 {
+                        self.restoreWorkspaceScroll(originalScrollTop)
+                        self.saveScreenshot(image: composite, nameComponent: pageName)
+                    } else {
+                        let nextOffset = min(contentHeight - viewportHeight, actualOffset + viewportHeight)
+                        self.captureWorkspaceChunk(rect: rect, contentHeight: contentHeight, viewportHeight: viewportHeight, originalScrollTop: originalScrollTop, targetOffset: nextOffset, pageName: pageName, composite: composite, capturedOffsets: nextCapturedOffsets)
+                    }
+                }
+            }
+        }
+    }
+
+    private func restoreWorkspaceScroll(_ scrollTop: CGFloat) {
+        webView.evaluateJavaScript("document.querySelector('.workspace-scroll')?.scrollTo({ top: \(Int(scrollTop)), behavior: 'instant' }); true;", completionHandler: nil)
+    }
+
+    private func saveScreenshot(image: NSImage, nameComponent: String) {
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let data = bitmap.representation(using: .png, properties: [:]) else {
+            return
+        }
+
+        let directory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Screenshots", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let fileURL = directory.appendingPathComponent("aidevops-app-screenshot-\(sanitizeFilenameComponent(nameComponent))-\(screenshotTimestamp()).png")
+            try data.write(to: fileURL, options: .atomic)
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(fileURL.path, forType: .string)
+            notifyScreenshotCaptured(fileURL: fileURL)
+        } catch {
+            NSSound.beep()
+        }
+    }
+
+    private func screenshotTimestamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyMMdd-HHmmss"
+        return formatter.string(from: Date())
+    }
+
+    private func sanitizeFilenameComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let mapped = value.lowercased().unicodeScalars.map { allowed.contains($0) ? String($0) : "-" }.joined()
+        let collapsed = mapped.split(separator: "-").joined(separator: "-")
+        return collapsed.isEmpty ? "page" : collapsed
+    }
+
+    private func notifyScreenshotCaptured(fileURL: URL) {
+        guard let payloadData = try? JSONSerialization.data(withJSONObject: ["path": fileURL.path, "url": fileURL.absoluteString], options: []),
+              let payload = String(data: payloadData, encoding: .utf8) else {
+            return
+        }
+
+        let script = "window.dispatchEvent(new CustomEvent('aidevops:screenshot-captured', { detail: \(payload) })); true;"
+        webView.evaluateJavaScript(script, completionHandler: nil)
     }
 
     private func saveMainWindowFrame() {

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -5,6 +5,7 @@ import { Workspace } from "./AppWorkspace";
 import type { ContrastPreference, ConversationMode, FontPreference, FontSizePreference, ShellMode, SurfaceId, ThemePreference } from "./app-model";
 import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, fileRootBySurface, findSurface, findSurfaceSectionLabel, fontFamilyForPreference, fontSizeForPreference, getSystemTheme, isContrastPreference, isFontPreference, isFontSizePreference } from "./app-model";
 import { type NavigationHistory, nextHistoryIndex, useNavigationHistoryKeyboard } from "./navigation-history";
+import { ScreenshotCaptureNotification, type ScreenshotCapturedDetail } from "./ScreenshotCaptureNotification";
 import { fetchStatus, mockedStatus } from "./status-client";
 
 interface WebKitBridgeWindow extends Window {
@@ -13,16 +14,8 @@ interface WebKitBridgeWindow extends Window {
       accentHue?: {
         postMessage: (hue: number) => void;
       };
-      externalLink?: {
-        postMessage: (href: string) => void;
-      };
     };
   };
-}
-
-interface ScreenshotCapturedDetail {
-  path: string;
-  url: string;
 }
 
 type AppearanceStorage = Pick<Storage, "getItem" | "setItem">;
@@ -219,11 +212,9 @@ export function App(): ReactElement {
   useEffect(() => {
     const showScreenshotNotification = (event: Event) => {
       const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
-      if (detail === undefined || typeof detail.path !== "string" || typeof detail.url !== "string") {
-        return;
+      if (detail !== undefined && typeof detail.path === "string" && typeof detail.url === "string") {
+        setScreenshotNotification({ path: detail.path, url: detail.url });
       }
-
-      setScreenshotNotification({ path: detail.path, url: detail.url });
     };
 
     window.addEventListener("aidevops:screenshot-captured", showScreenshotNotification);
@@ -289,23 +280,6 @@ export function App(): ReactElement {
       />
       <DesktopStatusBar status={status.data} />
     </main>
-  );
-}
-
-function ScreenshotCaptureNotification({ notification, onDismiss }: { notification: ScreenshotCapturedDetail; onDismiss: () => void }): ReactElement {
-  const revealScreenshot = () => {
-    const webkit = (window as WebKitBridgeWindow).webkit;
-    webkit?.messageHandlers?.externalLink?.postMessage(notification.url);
-  };
-
-  return (
-    <div className="screenshot-capture-notification" role="status">
-      <div>
-        <strong>Screenshot captured</strong>
-        <span>Saved to <button onClick={revealScreenshot} type="button">{notification.path}</button>; path copied to clipboard.</span>
-      </div>
-      <button aria-label="Dismiss screenshot notification" onClick={onDismiss} type="button">×</button>
-    </div>
   );
 }
 

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -13,8 +13,16 @@ interface WebKitBridgeWindow extends Window {
       accentHue?: {
         postMessage: (hue: number) => void;
       };
+      externalLink?: {
+        postMessage: (href: string) => void;
+      };
     };
   };
+}
+
+interface ScreenshotCapturedDetail {
+  path: string;
+  url: string;
 }
 
 type AppearanceStorage = Pick<Storage, "getItem" | "setItem">;
@@ -103,6 +111,7 @@ export function App(): ReactElement {
   const [conversationMode, setConversationMode] = useState<ConversationMode>("ai");
   const [selectedLocalRepoIndex, setSelectedLocalRepoIndex] = useState(0);
   const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>();
+  const [screenshotNotification, setScreenshotNotification] = useState<ScreenshotCapturedDetail | undefined>();
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">("light");
   const resolvedTheme = themePreference === "system" ? systemTheme : themePreference;
   const activeSurface: SurfaceId = navigation.entries[navigation.index] ?? "overview";
@@ -207,6 +216,20 @@ export function App(): ReactElement {
     setSelectedLocalRepoIndex((current) => Math.min(current, Math.max(0, status.data.local_repos.repos.length - 1)));
   }, [status.data.local_repos.repos.length]);
 
+  useEffect(() => {
+    const showScreenshotNotification = (event: Event) => {
+      const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
+      if (detail === undefined || typeof detail.path !== "string" || typeof detail.url !== "string") {
+        return;
+      }
+
+      setScreenshotNotification({ path: detail.path, url: detail.url });
+    };
+
+    window.addEventListener("aidevops:screenshot-captured", showScreenshotNotification);
+    return () => window.removeEventListener("aidevops:screenshot-captured", showScreenshotNotification);
+  }, []);
+
   if (statusLoading) {
     return <AppLoadingSkeleton machineRailVisible={machineRailVisible} />;
   }
@@ -214,6 +237,7 @@ export function App(): ReactElement {
   return (
     <main className={machineRailVisible ? "app-shell" : "app-shell machine-rail-collapsed"}>
       <div className="desktop-titlebar-tagline" aria-hidden="true">Your data protected. Your systems managed. Your creations published.</div>
+      {screenshotNotification ? <ScreenshotCaptureNotification notification={screenshotNotification} onDismiss={() => setScreenshotNotification(undefined)} /> : null}
       {machineRailVisible ? <MachineRail machine={status.data.machine} /> : null}
       <Sidebar
         activeSurface={activeSurface}
@@ -265,6 +289,23 @@ export function App(): ReactElement {
       />
       <DesktopStatusBar status={status.data} />
     </main>
+  );
+}
+
+function ScreenshotCaptureNotification({ notification, onDismiss }: { notification: ScreenshotCapturedDetail; onDismiss: () => void }): ReactElement {
+  const revealScreenshot = () => {
+    const webkit = (window as WebKitBridgeWindow).webkit;
+    webkit?.messageHandlers?.externalLink?.postMessage(notification.url);
+  };
+
+  return (
+    <div className="screenshot-capture-notification" role="status">
+      <div>
+        <strong>Screenshot captured</strong>
+        <span>Saved to <button onClick={revealScreenshot} type="button">{notification.path}</button>; path copied to clipboard.</span>
+      </div>
+      <button aria-label="Dismiss screenshot notification" onClick={onDismiss} type="button">×</button>
+    </div>
   );
 }
 

--- a/packages/gui-web/src/ScreenshotCaptureNotification.tsx
+++ b/packages/gui-web/src/ScreenshotCaptureNotification.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from "react";
+
+export interface ScreenshotCapturedDetail {
+  path: string;
+  url: string;
+}
+
+interface WebKitExternalLinkWindow extends Window {
+  webkit?: {
+    messageHandlers?: {
+      externalLink?: {
+        postMessage: (href: string) => void;
+      };
+    };
+  };
+}
+
+export function ScreenshotCaptureNotification({ notification, onDismiss }: { notification: ScreenshotCapturedDetail; onDismiss: () => void }): ReactElement {
+  const revealScreenshot = () => {
+    const webkit = (window as WebKitExternalLinkWindow).webkit;
+    webkit?.messageHandlers?.externalLink?.postMessage(notification.url);
+  };
+
+  return (
+    <div className="screenshot-capture-notification" role="status">
+      <div>
+        <strong>Screenshot captured</strong>
+        <span>Saved to <button onClick={revealScreenshot} type="button">{notification.path}</button>; path copied to clipboard.</span>
+      </div>
+      <button aria-label="Dismiss screenshot notification" onClick={onDismiss} type="button">×</button>
+    </div>
+  );
+}

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -298,6 +298,68 @@ code {
   z-index: 20;
 }
 
+.screenshot-capture-notification {
+  align-items: center;
+  background: color-mix(in srgb, var(--surface-elevated) 94%, transparent);
+  border: 1px solid var(--border-accent);
+  border-radius: 999px;
+  box-shadow: var(--glass-panel-shadow);
+  color: var(--text-secondary);
+  display: flex;
+  gap: 12px;
+  left: 50%;
+  max-width: min(720px, calc(100vw - 48px));
+  padding: 8px 10px 8px 14px;
+  position: fixed;
+  top: calc(var(--desktop-titlebar-height) + 10px);
+  transform: translateX(-50%);
+  z-index: 40;
+}
+
+.screenshot-capture-notification > div {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.screenshot-capture-notification strong {
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.screenshot-capture-notification span {
+  font-size: 0.74rem;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.screenshot-capture-notification button {
+  background: transparent;
+  border: 0;
+  color: var(--accent);
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.screenshot-capture-notification > button {
+  align-items: center;
+  background: var(--surface-muted);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 1rem;
+  height: 24px;
+  justify-content: center;
+  line-height: 1;
+  width: 24px;
+}
+
 .machine-rail,
 .app-sidebar,
 .app-inset {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -414,11 +414,12 @@ describe("dashboard shell", () => {
 
   test("wires desktop screenshot capture controls to native save notifications", () => {
     const appSource = readFileSync(`${guiWebRoot}/src/App.tsx`, "utf8");
+    const screenshotSource = readFileSync(`${guiWebRoot}/src/ScreenshotCaptureNotification.tsx`, "utf8");
     const css = readFileSync(`${guiWebRoot}/src/styles.css`, "utf8");
     const desktopInstaller = readFileSync(`${guiWebRoot}/../gui-desktop/scripts/install-macos-app.sh`, "utf8");
 
     expect(appSource).toContain("aidevops:screenshot-captured");
-    expect(appSource).toContain("screenshot-capture-notification");
+    expect(screenshotSource).toContain("screenshot-capture-notification");
     expect(css).toContain(".screenshot-capture-notification");
     expect(desktopInstaller).toContain("Screenshot App");
     expect(desktopInstaller).toContain("Screenshot Page");

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -146,7 +146,8 @@ describe("dashboard shell", () => {
     const workersNavItem = navGroups.flatMap((group) => group.items).find((item) => item.id === "workers");
 
     expect(html).toContain("Pulse &amp; Workers");
-    expect(workersNavItem).toMatchObject({ badge: undefined, label: "Pulse & Workers" });
+    expect(workersNavItem).toMatchObject({ label: "Pulse & Workers" });
+    expect(workersNavItem?.badge).toBeUndefined();
     expect(html).toContain("Data-driven observability");
     expect(html).toContain("Repo scope");
     expect(html).toContain("Issue origin");
@@ -409,6 +410,21 @@ describe("dashboard shell", () => {
   test("keeps the loading skeleton aligned to the shell landmarks", () => {
     expect(loadingSkeletonPanelLabels).toEqual(["machine rail", "sidebar", "workspace", "status bar"]);
     expect(loadingBrandGlyph).toBe(">_");
+  });
+
+  test("wires desktop screenshot capture controls to native save notifications", () => {
+    const appSource = readFileSync(`${guiWebRoot}/src/App.tsx`, "utf8");
+    const css = readFileSync(`${guiWebRoot}/src/styles.css`, "utf8");
+    const desktopInstaller = readFileSync(`${guiWebRoot}/../gui-desktop/scripts/install-macos-app.sh`, "utf8");
+
+    expect(appSource).toContain("aidevops:screenshot-captured");
+    expect(appSource).toContain("screenshot-capture-notification");
+    expect(css).toContain(".screenshot-capture-notification");
+    expect(desktopInstaller).toContain("Screenshot App");
+    expect(desktopInstaller).toContain("Screenshot Page");
+    expect(desktopInstaller).toContain("homeDirectoryForCurrentUser.appendingPathComponent(\"Screenshots\"");
+    expect(desktopInstaller).toContain("aidevops-app-screenshot-");
+    expect(desktopInstaller).toContain("NSPasteboard.general.setString(fileURL.path");
   });
 
   test("ships critical loading styles before React hydrates", () => {


### PR DESCRIPTION
Resolves #26102

## Summary
- Add a native macOS titlebar camera button beside the existing sidebar toggle affordance.
- Add a screenshot menu with Screenshot App and Screenshot Page actions.
- Save PNGs into ~/Screenshots using aidevops-app-screenshot-{window/page-name}-{yyMMdd-HHmmss}.png, copy the saved path to the clipboard, and notify the web UI with a dismissible badge that can reveal the file in Finder.
- Add regression coverage for the desktop screenshot wiring and make the Pulse & Workers badge assertion explicit for current Bun behavior.

## Verification
- `bun test packages/gui-web/tests/component.test.ts` — 25 pass
- `bun run typecheck` — pass
- `bash packages/gui-desktop/scripts/install-macos-app.sh --check` — pass
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — pass
- `.agents/scripts/linters-local.sh` — non-terminal after 300s; before timeout it reported pre-existing/advisory Sonar/Markdown findings, Secretlint passed, then timed out during ratchet counting.

## Files
- `packages/gui-desktop/scripts/install-macos-app.sh`
- `packages/gui-web/src/App.tsx`
- `packages/gui-web/src/styles.css`
- `packages/gui-web/tests/component.test.ts`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 plugin for [OpenCode](https://opencode.ai) v1.17.11
