### PR TITLE
GH#26077: fix: harden tambo complexity branch counting

### DIFF
--- a/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
+++ b/.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh
@@ -19,6 +19,7 @@ if [[ ! -f "$TAMBO_FILE" ]]; then
 fi
 
 python3 - "$TAMBO_FILE" <<'PY'
+import re
 import sys
 
 tambo_path = sys.argv[1]
@@ -58,7 +59,7 @@ if missing:
 for name, body_lines in functions.items():
     body = "\n".join(body_lines)
     line_count = len(body_lines)
-    branch_count = sum(body.count(token) for token in ("if (", "for (", "while (", "switch ("))
+    branch_count = len(re.findall(r"\b(if|for|while|switch)\b", body))
     if line_count > limits[name]["lines"]:
         print(f"FAIL: {name} is {line_count} lines; keep <= {limits[name]['lines']}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

Updated the Tambo CodeFactor complexity regression guard to count branch keywords with a word-boundary regex instead of fragile exact string formatting matches.

## Files Changed

.agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh; shellcheck .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh; git diff --check -- .agents/scripts/tests/test-gui-tambo-codefactor-complexity.sh

Resolves #26077


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 2m and 31,485 tokens on this as a headless worker.