### PR TITLE
GH#26070: fix: guard related findings labels

### DIFF
--- a/packages/gui-web/src/PulseWorkersSurface.tsx
+++ b/packages/gui-web/src/PulseWorkersSurface.tsx
@@ -266,7 +266,10 @@ function PulseDrilldownPanel({ event }: { event: PulseEvent | undefined }): Reac
 }
 
 function relatedFindings(event: PulseEvent): string[] {
-  return event.drilldown_sections?.filter((section) => section.label.toLowerCase().includes("systemic") || section.label.toLowerCase().includes("verification")).map((section) => `${section.label}: ${section.body}`) ?? [];
+  return event.drilldown_sections?.filter((section) => {
+    const label = section.label?.toLowerCase();
+    return label?.includes("systemic") || label?.includes("verification");
+  }).map((section) => `${section.label}: ${section.body}`) ?? [];
 }
 
 function buildFilterGroups(pulse: GuiStatusData["pulse_workers"]): PulseFilterGroup[] {


### PR DESCRIPTION
## Summary

Updated relatedFindings in packages/gui-web/src/PulseWorkersSurface.tsx to lowercase each drilldown label once and tolerate missing labels before matching systemic or verification findings.

## Files Changed

packages/gui-web/src/PulseWorkersSurface.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Attempted bun run typecheck && bun run gui:test:components (blocked: bun not installed). Attempted npm exec -- tsc --noEmit (blocked: node_modules missing and TypeScript unavailable).

Resolves #26070


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 2m and 53,352 tokens on this as a headless worker.