### PR TITLE
For #26102: reduce screenshot GUI shell complexity

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -4,8 +4,9 @@ import { MachineRail, Sidebar } from "./AppNavigation";
 import { Workspace } from "./AppWorkspace";
 import type { ContrastPreference, ConversationMode, FontPreference, FontSizePreference, ShellMode, SurfaceId, ThemePreference } from "./app-model";
 import { DEFAULT_ACCENT_HUE, DEFAULT_CONTRAST, DEFAULT_FONT, DEFAULT_FONT_SIZE, fileRootBySurface, findSurface, findSurfaceSectionLabel, fontFamilyForPreference, fontSizeForPreference, getSystemTheme, isContrastPreference, isFontPreference, isFontSizePreference } from "./app-model";
+import { DesktopStatusBar } from "./DesktopStatusBar";
 import { type NavigationHistory, nextHistoryIndex, useNavigationHistoryKeyboard } from "./navigation-history";
-import { ScreenshotCaptureNotification, type ScreenshotCapturedDetail } from "./ScreenshotCaptureNotification";
+import { ScreenshotCaptureNotificationHost } from "./ScreenshotCaptureNotification";
 import { fetchStatus, mockedStatus } from "./status-client";
 
 interface WebKitBridgeWindow extends Window {
@@ -104,7 +105,6 @@ export function App(): ReactElement {
   const [conversationMode, setConversationMode] = useState<ConversationMode>("ai");
   const [selectedLocalRepoIndex, setSelectedLocalRepoIndex] = useState(0);
   const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>();
-  const [screenshotNotification, setScreenshotNotification] = useState<ScreenshotCapturedDetail | undefined>();
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">("light");
   const resolvedTheme = themePreference === "system" ? systemTheme : themePreference;
   const activeSurface: SurfaceId = navigation.entries[navigation.index] ?? "overview";
@@ -209,18 +209,6 @@ export function App(): ReactElement {
     setSelectedLocalRepoIndex((current) => Math.min(current, Math.max(0, status.data.local_repos.repos.length - 1)));
   }, [status.data.local_repos.repos.length]);
 
-  useEffect(() => {
-    const showScreenshotNotification = (event: Event) => {
-      const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
-      if (detail !== undefined && typeof detail.path === "string" && typeof detail.url === "string") {
-        setScreenshotNotification({ path: detail.path, url: detail.url });
-      }
-    };
-
-    window.addEventListener("aidevops:screenshot-captured", showScreenshotNotification);
-    return () => window.removeEventListener("aidevops:screenshot-captured", showScreenshotNotification);
-  }, []);
-
   if (statusLoading) {
     return <AppLoadingSkeleton machineRailVisible={machineRailVisible} />;
   }
@@ -228,7 +216,7 @@ export function App(): ReactElement {
   return (
     <main className={machineRailVisible ? "app-shell" : "app-shell machine-rail-collapsed"}>
       <div className="desktop-titlebar-tagline" aria-hidden="true">Your data protected. Your systems managed. Your creations published.</div>
-      {screenshotNotification ? <ScreenshotCaptureNotification notification={screenshotNotification} onDismiss={() => setScreenshotNotification(undefined)} /> : null}
+      <ScreenshotCaptureNotificationHost />
       {machineRailVisible ? <MachineRail machine={status.data.machine} /> : null}
       <Sidebar
         activeSurface={activeSurface}
@@ -437,30 +425,4 @@ function readStoredBoolean(storage: ReadableAppearanceStorage | undefined, key: 
   }
 
   return fallback;
-}
-
-function DesktopStatusBar({ status }: { status: GuiStatusData }): ReactElement {
-  const version = status.update.installed_version !== "unknown" ? status.update.installed_version : status.aidevops_version;
-  const versionLabel = version === "unknown" || version.startsWith("v") ? version : `v${version}`;
-  const needsUpdate = status.setup_targets.filter((target) => target.needs_update).length + status.ai_apps.filter((app) => app.needs_update).length;
-  const oauthAccounts = status.oauth_pool.providers.reduce((total, provider) => total + provider.total, 0);
-  const localRepoCount = status.local_repos.total || status.local_repos.repos.length;
-  const remoteRepoCount = status.repos.total || status.repos.repos.length;
-  const statusLabel = status.update.restart_required ? "Restart required" : "Ready";
-  const vaultLabel = status.vault?.unlocked ? "Vault unlocked" : `Vault ${status.vault?.status ?? "unknown"}`;
-
-  return (
-    <div className="desktop-status-bar" role="status">
-      <span className={status.update.restart_required ? "status-dot warn" : "status-dot"} aria-hidden="true" />
-      <strong>{statusLabel}</strong>
-      <span>Read-only local GUI</span>
-      <span>{versionLabel}</span>
-      <span>{localRepoCount} local repos</span>
-      <span>{remoteRepoCount} remote repos</span>
-      <span>{status.secrets.length} secrets</span>
-      <span>{vaultLabel}</span>
-      <span>{oauthAccounts} provider accounts</span>
-      <span>{needsUpdate} need update</span>
-    </div>
-  );
 }

--- a/packages/gui-web/src/DesktopStatusBar.tsx
+++ b/packages/gui-web/src/DesktopStatusBar.tsx
@@ -1,0 +1,28 @@
+import type { GuiStatusData } from "@aidevops/gui-shared";
+import type { ReactElement } from "react";
+
+export function DesktopStatusBar({ status }: { status: GuiStatusData }): ReactElement {
+  const version = status.update.installed_version !== "unknown" ? status.update.installed_version : status.aidevops_version;
+  const versionLabel = version === "unknown" || version.startsWith("v") ? version : `v${version}`;
+  const needsUpdate = status.setup_targets.filter((target) => target.needs_update).length + status.ai_apps.filter((app) => app.needs_update).length;
+  const oauthAccounts = status.oauth_pool.providers.reduce((total, provider) => total + provider.total, 0);
+  const localRepoCount = status.local_repos.total || status.local_repos.repos.length;
+  const remoteRepoCount = status.repos.total || status.repos.repos.length;
+  const statusLabel = status.update.restart_required ? "Restart required" : "Ready";
+  const vaultLabel = status.vault?.unlocked ? "Vault unlocked" : `Vault ${status.vault?.status ?? "unknown"}`;
+
+  return (
+    <div className="desktop-status-bar" role="status">
+      <span className={status.update.restart_required ? "status-dot warn" : "status-dot"} aria-hidden="true" />
+      <strong>{statusLabel}</strong>
+      <span>Read-only local GUI</span>
+      <span>{versionLabel}</span>
+      <span>{localRepoCount} local repos</span>
+      <span>{remoteRepoCount} remote repos</span>
+      <span>{status.secrets.length} secrets</span>
+      <span>{vaultLabel}</span>
+      <span>{oauthAccounts} provider accounts</span>
+      <span>{needsUpdate} need update</span>
+    </div>
+  );
+}

--- a/packages/gui-web/src/ScreenshotCaptureNotification.tsx
+++ b/packages/gui-web/src/ScreenshotCaptureNotification.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 
 export interface ScreenshotCapturedDetail {
   path: string;
@@ -30,4 +30,22 @@ export function ScreenshotCaptureNotification({ notification, onDismiss }: { not
       <button aria-label="Dismiss screenshot notification" onClick={onDismiss} type="button">×</button>
     </div>
   );
+}
+
+export function ScreenshotCaptureNotificationHost(): ReactElement | null {
+  const [screenshotNotification, setScreenshotNotification] = useState<ScreenshotCapturedDetail | undefined>();
+
+  useEffect(() => {
+    const showScreenshotNotification = (event: Event) => {
+      const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
+      if (detail !== undefined && typeof detail.path === "string" && typeof detail.url === "string") {
+        setScreenshotNotification({ path: detail.path, url: detail.url });
+      }
+    };
+
+    window.addEventListener("aidevops:screenshot-captured", showScreenshotNotification);
+    return () => window.removeEventListener("aidevops:screenshot-captured", showScreenshotNotification);
+  }, []);
+
+  return screenshotNotification ? <ScreenshotCaptureNotification notification={screenshotNotification} onDismiss={() => setScreenshotNotification(undefined)} /> : null;
 }

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -418,7 +418,8 @@ describe("dashboard shell", () => {
     const css = readFileSync(`${guiWebRoot}/src/styles.css`, "utf8");
     const desktopInstaller = readFileSync(`${guiWebRoot}/../gui-desktop/scripts/install-macos-app.sh`, "utf8");
 
-    expect(appSource).toContain("aidevops:screenshot-captured");
+    expect(appSource).toContain("ScreenshotCaptureNotificationHost");
+    expect(screenshotSource).toContain("aidevops:screenshot-captured");
     expect(screenshotSource).toContain("screenshot-capture-notification");
     expect(css).toContain(".screenshot-capture-notification");
     expect(desktopInstaller).toContain("Screenshot App");


### PR DESCRIPTION
For #26102

## Summary
- Split screenshot notification host state into `ScreenshotCaptureNotification.tsx`.
- Move `DesktopStatusBar` out of `App.tsx`.
- Keep the merged screenshot feature behavior unchanged while reducing `App.tsx` qlty complexity after PR #26104 merged before the qlty-split commit landed.

## Verification
- `bun test packages/gui-web/tests/component.test.ts` — 25 pass
- `bun run typecheck` — pass
- `bash packages/gui-desktop/scripts/install-macos-app.sh --check` — pass
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — pass

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.43 plugin for [OpenCode](https://opencode.ai) v1.17.11
