### PR TITLE
GH#26068: fix: guard worktree cleanup skip globals

### DIFF
--- a/.agents/scripts/tests/test-worktree-cleanup-empty-branch.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-empty-branch.sh
@@ -350,6 +350,36 @@ test_branch_list_exact_matching() {
 }
 test_branch_list_exact_matching
 
+test_skip_cleanup_emit_handles_unset_globals() {
+	local rc=""
+	rc=$(
+		set -u
+		log_worktree_removal_event() {
+			local event_type="$1"
+			local caller="$2"
+			local wt_path="$3"
+			local reason="$4"
+			local mode="$5"
+			[[ -z "$event_type" && -z "$caller" && "$wt_path" == "$FAKE_REPO" && "$reason" == "unset-globals" && -z "$mode" ]]
+			return $?
+		}
+
+		# shellcheck source=/dev/null
+		source "$CLEAN_LIB_PATH" >/dev/null 2>&1 || exit 9
+
+		unset RED NC _WTAR_SKIPPED _WTAR_WH_CALLER _WT_CLEAN_MODE_SKIPPED 2>/dev/null || true
+		_skip_cleanup_emit "feature/unset-globals" "$FAKE_REPO" "unset globals" "unset-globals" >/dev/null 2>&1
+		echo "$?"
+	)
+	if [[ "$rc" == "0" ]]; then
+		print_result "_skip_cleanup_emit tolerates unset globals under set -u" 0
+	else
+		print_result "_skip_cleanup_emit tolerates unset globals under set -u" 1 "(rc=$rc)"
+	fi
+	return 0
+}
+test_skip_cleanup_emit_handles_unset_globals
+
 # =============================================================================
 # Summary
 # =============================================================================

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -179,10 +179,10 @@ _skip_cleanup_emit() {
 	local reason_message="$3"
 	local audit_reason="$4"
 
-	echo -e "  ${RED}$wt_branch${NC} (${reason_message} - skipping)"
+	echo -e "  ${RED:-}$wt_branch${NC:-} (${reason_message} - skipping)"
 	echo "    $wt_path"
 	printf '\n'
-	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "$audit_reason" "$_WT_CLEAN_MODE_SKIPPED"
+	log_worktree_removal_event "${_WTAR_SKIPPED:-}" "${_WTAR_WH_CALLER:-}" "$wt_path" "$audit_reason" "${_WT_CLEAN_MODE_SKIPPED:-}"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Guarded worktree cleanup skip output and audit logging against unset color/audit globals under set -u, and added a regression test covering _skip_cleanup_emit with those globals unset.

## Files Changed

.agents/scripts/tests/test-worktree-cleanup-empty-branch.sh,.agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh; shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-worktree-cleanup-empty-branch.sh

Resolves #26068


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.0 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 3m and 45,374 tokens on this as a headless worker.