### PR TITLE
GH#26113: fix: filter failure miner log noise

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -161,6 +161,30 @@ normalize_signature_line() {
 	return 0
 }
 
+filter_signature_noise_lines() {
+	local logs="$1"
+	printf '%s\n' "$logs" | awk '
+		{
+			raw = $0
+			payload = $0
+			n = split(raw, fields, "\t")
+			if (n >= 4) {
+				payload = fields[4]
+				for (i = 5; i <= n; i++) {
+					payload = payload "\t" fields[i]
+				}
+			}
+			gsub(/\033\[[0-9;]*[A-Za-z]/, "", payload)
+			gsub(/^[[:space:]]+/, "", payload)
+			if (payload ~ /^#[[:space:]]/) {
+				next
+			}
+			print raw
+		}
+	'
+	return 0
+}
+
 select_failed_job_json() {
 	local repo_slug="$1"
 	local run_id="$2"
@@ -237,6 +261,7 @@ extract_failure_signature() {
 	local failed_job_json
 	local zero_step_signature
 	local logs
+	local filtered_logs
 	local failed_job_id
 
 	failed_job_json=$(select_failed_job_json "$repo_slug" "$run_id" "$check_run_id")
@@ -260,25 +285,26 @@ extract_failure_signature() {
 		printf '%s' "no_failed_log_output"
 		return 0
 	fi
+	filtered_logs=$(filter_signature_noise_lines "$logs")
 
 	# Check for known infrastructure error patterns before extracting a generic signature.
 	# These patterns indicate billing/runner issues, not code defects. (GH#18093)
 	local infra_line
-	infra_line=$(printf '%s\n' "$logs" | grep -iE "recent account payments have failed|spending limit needs to be increased" | head -1 || true)
+	infra_line=$(printf '%s\n' "$filtered_logs" | grep -iE "recent account payments have failed|spending limit needs to be increased" | head -1 || true)
 	if [[ -n "$infra_line" ]]; then
 		printf '%s' "infra:billing_exhausted"
 		return 0
 	fi
-	infra_line=$(printf '%s\n' "$logs" | grep -iE "Runner.*unavailable|no matching runner|runner.*not found" | head -1 || true)
+	infra_line=$(printf '%s\n' "$filtered_logs" | grep -iE "Runner.*unavailable|no matching runner|runner.*not found" | head -1 || true)
 	if [[ -n "$infra_line" ]]; then
 		printf '%s' "infra:runner_unavailable"
 		return 0
 	fi
 
 	local candidate
-	candidate=$(printf '%s\n' "$logs" | awk 'BEGIN{IGNORECASE=1} /error|exception|traceback|failed|denied|timeout|cannot|invalid|forbidden|unauthorized/ {print; exit}')
+	candidate=$(printf '%s\n' "$filtered_logs" | awk 'BEGIN{IGNORECASE=1} /error|exception|traceback|failed|denied|timeout|cannot|invalid|forbidden|unauthorized/ {print; exit}')
 	if [[ -z "$candidate" ]]; then
-		candidate=$(printf '%s\n' "$logs" | awk 'NF {print; exit}')
+		candidate=$(printf '%s\n' "$filtered_logs" | awk 'NF {print; exit}')
 	fi
 
 	normalize_signature_line "$candidate"

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#26113: gh-failure-miner must not cluster GitHub
+# runner-echoed shell comments as failure signatures.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_equals() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected: %s\n' "$(printf '%q' "$expected")"
+		printf '  actual:   %s\n' "$(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+HELPER="$SCRIPT_DIR/gh-failure-miner-helper.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf '%sFATAL%s: %s not found\n' "$TEST_RED" "$TEST_NC" "$HELPER" >&2
+	exit 1
+fi
+
+set -- help
+# shellcheck source=/dev/null
+source "$HELPER" >/dev/null
+
+gh() {
+	local first="${1:-}" second="${2:-}" endpoint="${3:-}"
+	if [[ "$first" == "api" && "$endpoint" == "repos/marcusquinn/aidevops/actions/runs/28472942857/jobs" ]]; then
+		printf '%s\n' '{"jobs":[{"id":84390104069,"conclusion":"failure","check_run_url":"https://api.github.com/repos/marcusquinn/aidevops/check-runs/84390104069","steps":[{"name":"Gate result","conclusion":"failure"}]}]}'
+		return 0
+	fi
+	if [[ "$first" == "run" && "$second" == "view" ]]; then
+		printf 'gate / review-bot-gate\tUNKNOWN STEP\t2026-06-30T20:14:24.8559907Z\t\033[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.\033[0m\n'
+		printf 'gate / review-bot-gate\tGate result\t2026-06-30T20:14:25.0000000Z\t::error::No AI review bots have posted a real, settled review on this PR yet.\n'
+		return 0
+	fi
+	return 1
+}
+
+signature=$(extract_failure_signature "marcusquinn/aidevops" "28472942857" "84390104069")
+assert_equals "runner-echoed shell comment is skipped" "gate / review-bot-gate Gate result 2026-06-30T20:14:25.0000000Z ::error::No AI review bots have posted a real, settled review on this PR yet." "$signature"
+
+filtered=$(filter_signature_noise_lines $'job\tUNKNOWN STEP\ttime\t\033[36;1m# comment cannot merge\033[0m\njob\tStep\ttime\treal error')
+assert_equals "comment-only log lines are filtered" $'job\tStep\ttime\treal error' "$filtered"
+
+printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Filtered GitHub runner-echoed shell comments before gh-failure-miner selects CI failure signatures, preventing review-bot-gate comment echoes from forming systemic failure clusters. Added GH#26113 regression coverage for UNKNOWN STEP comment noise.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh; bash -n .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

Resolves #26113


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.0 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 4m and 66,750 tokens on this as a headless worker.