### PR TITLE
GH#26116 fix: polish desktop screenshot UI

### DIFF
--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -813,7 +813,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             toggleButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 3.5),
             toggleButton.heightAnchor.constraint(equalToConstant: 22),
             toggleButton.widthAnchor.constraint(equalToConstant: 22),
-            cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -92),
+            cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -24),
             cameraButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 3.5),
             cameraButton.heightAnchor.constraint(equalToConstant: 22),
             cameraButton.widthAnchor.constraint(equalToConstant: 22)
@@ -1010,8 +1010,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             let offsetKey = Int(actualOffset.rounded())
             var nextCapturedOffsets = capturedOffsets
             if capturedOffsets.contains(offsetKey) {
-                self.restoreWorkspaceScroll(originalScrollTop)
-                self.saveScreenshot(image: composite, nameComponent: pageName)
+                self.savePageScreenshotAfterRestoringScroll(image: composite, nameComponent: pageName, scrollTop: originalScrollTop)
                 return
             }
             nextCapturedOffsets.insert(offsetKey)
@@ -1027,8 +1026,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
                     }
 
                     if actualOffset + viewportHeight >= contentHeight - 1 {
-                        self.restoreWorkspaceScroll(originalScrollTop)
-                        self.saveScreenshot(image: composite, nameComponent: pageName)
+                        self.savePageScreenshotAfterRestoringScroll(image: composite, nameComponent: pageName, scrollTop: originalScrollTop)
                     } else {
                         let nextOffset = min(contentHeight - viewportHeight, actualOffset + viewportHeight)
                         self.captureWorkspaceChunk(rect: rect, contentHeight: contentHeight, viewportHeight: viewportHeight, originalScrollTop: originalScrollTop, targetOffset: nextOffset, pageName: pageName, composite: composite, capturedOffsets: nextCapturedOffsets)
@@ -1040,6 +1038,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
 
     private func restoreWorkspaceScroll(_ scrollTop: CGFloat) {
         webView.evaluateJavaScript("document.querySelector('.workspace-scroll')?.scrollTo({ top: \(Int(scrollTop)), behavior: 'instant' }); true;", completionHandler: nil)
+    }
+
+    private func savePageScreenshotAfterRestoringScroll(image: NSImage, nameComponent: String, scrollTop: CGFloat) {
+        webView.evaluateJavaScript("document.querySelector('.workspace-scroll')?.scrollTo({ top: \(Int(scrollTop)), behavior: 'instant' }); true;") { [weak self] _, _ in
+            DispatchQueue.main.async {
+                self?.saveScreenshot(image: image, nameComponent: nameComponent)
+            }
+        }
     }
 
     private func saveScreenshot(image: NSImage, nameComponent: String) {

--- a/packages/gui-web/src/ScreenshotCaptureNotification.tsx
+++ b/packages/gui-web/src/ScreenshotCaptureNotification.tsx
@@ -1,8 +1,12 @@
-import { type ReactElement, useEffect, useState } from "react";
+import { type ReactElement, useEffect, useRef, useState } from "react";
 
 export interface ScreenshotCapturedDetail {
   path: string;
   url: string;
+}
+
+interface ScreenshotCapturedNotification extends ScreenshotCapturedDetail {
+  id: number;
 }
 
 interface WebKitExternalLinkWindow extends Window {
@@ -25,21 +29,23 @@ export function ScreenshotCaptureNotification({ notification, onDismiss }: { not
     <div className="screenshot-capture-notification" role="status">
       <div>
         <strong>Screenshot captured</strong>
-        <span>Saved to <button onClick={revealScreenshot} type="button">{notification.path}</button>; path copied to clipboard.</span>
+        <span>Saved to <button className="screenshot-path-button" onClick={revealScreenshot} title={notification.path} type="button">{notification.path}</button>; path copied to clipboard.</span>
       </div>
-      <button aria-label="Dismiss screenshot notification" onClick={onDismiss} type="button">×</button>
+      <button aria-label="Dismiss screenshot notification" className="screenshot-dismiss-button" onClick={onDismiss} type="button">×</button>
     </div>
   );
 }
 
 export function ScreenshotCaptureNotificationHost(): ReactElement | null {
-  const [screenshotNotification, setScreenshotNotification] = useState<ScreenshotCapturedDetail | undefined>();
+  const nextNotificationId = useRef(0);
+  const [screenshotNotifications, setScreenshotNotifications] = useState<ScreenshotCapturedNotification[]>([]);
 
   useEffect(() => {
     const showScreenshotNotification = (event: Event) => {
       const detail = (event as CustomEvent<Partial<ScreenshotCapturedDetail>>).detail;
       if (detail !== undefined && typeof detail.path === "string" && typeof detail.url === "string") {
-        setScreenshotNotification({ path: detail.path, url: detail.url });
+        nextNotificationId.current += 1;
+        setScreenshotNotifications((current) => [...current, { id: nextNotificationId.current, path: detail.path, url: detail.url }]);
       }
     };
 
@@ -47,5 +53,15 @@ export function ScreenshotCaptureNotificationHost(): ReactElement | null {
     return () => window.removeEventListener("aidevops:screenshot-captured", showScreenshotNotification);
   }, []);
 
-  return screenshotNotification ? <ScreenshotCaptureNotification notification={screenshotNotification} onDismiss={() => setScreenshotNotification(undefined)} /> : null;
+  return screenshotNotifications.length > 0 ? (
+    <div className="screenshot-capture-notification-stack">
+      {screenshotNotifications.map((notification) => (
+        <ScreenshotCaptureNotification
+          key={notification.id}
+          notification={notification}
+          onDismiss={() => setScreenshotNotifications((current) => current.filter((item) => item.id !== notification.id))}
+        />
+      ))}
+    </div>
+  ) : null;
 }

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -298,6 +298,18 @@ code {
   z-index: 20;
 }
 
+.screenshot-capture-notification-stack {
+  display: grid;
+  gap: 8px;
+  left: 50%;
+  max-width: min(840px, calc(100vw - 48px));
+  position: fixed;
+  top: calc(var(--desktop-titlebar-height) + 10px);
+  transform: translateX(-50%);
+  width: max-content;
+  z-index: 40;
+}
+
 .screenshot-capture-notification {
   align-items: center;
   background: color-mix(in srgb, var(--surface-elevated) 94%, transparent);
@@ -307,13 +319,9 @@ code {
   color: var(--text-secondary);
   display: flex;
   gap: 12px;
-  left: 50%;
   max-width: min(720px, calc(100vw - 48px));
   padding: 8px 10px 8px 14px;
-  position: fixed;
-  top: calc(var(--desktop-titlebar-height) + 10px);
-  transform: translateX(-50%);
-  z-index: 40;
+  width: 100%;
 }
 
 .screenshot-capture-notification > div {
@@ -333,31 +341,42 @@ code {
   line-height: 1.25;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.screenshot-capture-notification button {
+.screenshot-capture-notification .screenshot-path-button {
   background: transparent;
   border: 0;
   color: var(--accent);
   font: inherit;
   padding: 0;
   text-decoration: underline;
+  overflow-wrap: anywhere;
+  text-align: left;
 }
 
-.screenshot-capture-notification > button {
+.screenshot-capture-notification .screenshot-dismiss-button {
   align-items: center;
   background: var(--surface-muted);
-  border: 1px solid transparent;
+  border: 1px solid var(--border);
   border-radius: 999px;
   color: var(--text-secondary);
   display: inline-flex;
   flex: 0 0 auto;
-  font-size: 1rem;
-  height: 24px;
+  font: inherit;
+  font-size: 1.1rem;
+  height: 38px;
   justify-content: center;
   line-height: 1;
-  width: 24px;
+  padding: 0;
+  text-decoration: none;
+  width: 38px;
+}
+
+.screenshot-capture-notification .screenshot-dismiss-button:hover,
+.screenshot-capture-notification .screenshot-dismiss-button:focus-visible {
+  border-color: var(--border-accent);
+  color: var(--accent);
+  outline: none;
 }
 
 .machine-rail,

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -420,10 +420,16 @@ describe("dashboard shell", () => {
 
     expect(appSource).toContain("ScreenshotCaptureNotificationHost");
     expect(screenshotSource).toContain("aidevops:screenshot-captured");
+    expect(screenshotSource).toContain("screenshotNotifications.map");
     expect(screenshotSource).toContain("screenshot-capture-notification");
+    expect(screenshotSource).toContain("screenshot-path-button");
+    expect(screenshotSource).toContain("screenshot-dismiss-button");
+    expect(css).toContain(".screenshot-capture-notification-stack");
     expect(css).toContain(".screenshot-capture-notification");
     expect(desktopInstaller).toContain("Screenshot App");
     expect(desktopInstaller).toContain("Screenshot Page");
+    expect(desktopInstaller).toContain("cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -24)");
+    expect(desktopInstaller).toContain("savePageScreenshotAfterRestoringScroll");
     expect(desktopInstaller).toContain("homeDirectoryForCurrentUser.appendingPathComponent(\"Screenshots\"");
     expect(desktopInstaller).toContain("aidevops-app-screenshot-");
     expect(desktopInstaller).toContain("NSPasteboard.general.setString(fileURL.path");


### PR DESCRIPTION
## Summary\n- move the native camera button closer to the top-right while preserving the titlebar toggle vertical alignment\n- save page screenshots only after scroll restoration callback so the notification payload/path is delivered consistently\n- stack screenshot notifications instead of replacing earlier captures\n- restyle the dismiss button to match top-bar icon buttons and remove inherited underline\n\nResolves #26116\n\n## Verification\n- bun test packages/gui-web/tests/component.test.ts\n- bun run typecheck\n- shellcheck packages/gui-desktop/scripts/install-macos-app.sh\n- bash packages/gui-desktop/scripts/install-macos-app.sh --check
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.0 plugin for [OpenCode](https://opencode.ai) v1.17.12
