### PR TITLE
GH#26119: fix: harden failure miner comment filtering

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -176,7 +176,10 @@ filter_signature_noise_lines() {
 			}
 			gsub(/\033\[[0-9;]*[A-Za-z]/, "", payload)
 			gsub(/^[[:space:]]+/, "", payload)
-			if (payload ~ /^#[[:space:]]/) {
+			# GitHub Actions sometimes echoes shell comments from multi-line run blocks
+			# as UNKNOWN STEP log rows. Treat plain comments and xtrace-prefixed
+			# comments as noise so they cannot become systemic failure signatures.
+			if (payload ~ /^([+][[:space:]]*)*#[[:space:]]*/) {
 				next
 			}
 			print raw

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -64,6 +64,9 @@ assert_equals "runner-echoed shell comment is skipped" "gate / review-bot-gate G
 filtered=$(filter_signature_noise_lines $'job\tUNKNOWN STEP\ttime\t\033[36;1m# comment cannot merge\033[0m\njob\tStep\ttime\treal error')
 assert_equals "comment-only log lines are filtered" $'job\tStep\ttime\treal error' "$filtered"
 
+filtered=$(filter_signature_noise_lines $'job\tUNKNOWN STEP\ttime\t+ # rate-limit grace is disabled — they cannot merge on rate-limit-only.\njob\tStep\ttime\treal error')
+assert_equals "xtrace-prefixed shell comments are filtered" $'job\tStep\ttime\treal error' "$filtered"
+
 printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then
 	exit 1


### PR DESCRIPTION
## Summary

Hardened gh-failure-miner log noise filtering so GitHub runner-echoed shell comments, including xtrace-prefixed comments, are skipped before systemic failure signature extraction. Added regression coverage for the review-bot-gate rate-limit comment signature.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh; bash .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

Resolves #26119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.1 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 3m and 53,954 tokens on this as a headless worker.