### PR TITLE
GH#25927: split pulse merge fix worker test setup

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -62,7 +62,7 @@ EOF
 	echo 'Original issue body.' >"${TEST_ROOT}/issue-body.txt"
 }
 
-setup_test_env() {
+setup_test_paths() {
 	TEST_ROOT=$(mktemp -d)
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
@@ -71,10 +71,10 @@ setup_test_env() {
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
+	return 0
+}
 
-	# Mock gh: logs every call and returns canned data based on the
-	# subcommand. Reads/writes to files under TEST_ROOT so tests can
-	# inspect/alter state between runs.
+write_gh_mock_command_cases() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
@@ -140,7 +140,12 @@ case "$_subcmd" in
 	exit 0
 	;;
 esac
+GHEOF
+	return 0
+}
 
+append_gh_mock_api_cases() {
+	cat >>"${TEST_ROOT}/bin/gh" <<'GHEOF'
 # `gh api repos/...` uses the URL as $2, so the simple `case "$1 $2"`
 # pattern above can't match it. Handle api separately.
 if [[ "${1:-}" == "api" ]]; then
@@ -172,6 +177,17 @@ fi
 
 exit 0
 GHEOF
+	return 0
+}
+
+setup_test_env() {
+	setup_test_paths
+
+	# Mock gh: logs every call and returns canned data based on the
+	# subcommand. Reads/writes to files under TEST_ROOT so tests can
+	# inspect/alter state between runs.
+	write_gh_mock_command_cases
+	append_gh_mock_api_cases
 	chmod +x "${TEST_ROOT}/bin/gh"
 	return 0
 }


### PR DESCRIPTION
## Summary
- Split `setup_test_env()` in `.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh` into focused helpers for path setup and gh mock generation.
- Preserved the existing mock `gh` command behavior while reducing the cited function below the 100-line complexity threshold.

## Testing
- `bash -n .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`
- `shellcheck .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`
- `bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`
- `.agents/scripts/complexity-regression-helper.sh scan . --metric function-complexity --output /tmp/fc-scan-gh25927.txt` with no target-file violations

## Complexity Bump Justification
Scanner evidence from issue #25927 cited `.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh:65`, where `setup_test_env()` measured lines=112 against threshold=100. This change extracts setup and mock-writing helpers so the local function-complexity scan reports new=0 target-file violations for `.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`.

The `complexity-bump-ok` label is applied because the issue guidance requires this section for complexity-gate PRs, not because this PR intentionally adds a new violation. The refactor reduces the cited oversized function while preserving test fixture behavior.

Resolves #25927
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.1 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 6m and 53,218 tokens on this as a headless worker.