### PR TITLE
GH#26131 fix: refine screenshot notification layout

### DIFF
--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -813,8 +813,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             toggleButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 3.5),
             toggleButton.heightAnchor.constraint(equalToConstant: 22),
             toggleButton.widthAnchor.constraint(equalToConstant: 22),
-            cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -24),
-            cameraButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 3.5),
+            cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -9),
+            cameraButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 5.5),
             cameraButton.heightAnchor.constraint(equalToConstant: 22),
             cameraButton.widthAnchor.constraint(equalToConstant: 22)
         ])

--- a/packages/gui-web/src/ScreenshotCaptureNotification.tsx
+++ b/packages/gui-web/src/ScreenshotCaptureNotification.tsx
@@ -29,7 +29,9 @@ export function ScreenshotCaptureNotification({ notification, onDismiss }: { not
     <div className="screenshot-capture-notification" role="status">
       <div>
         <strong>Screenshot captured</strong>
-        <span>Saved to <button className="screenshot-path-button" onClick={revealScreenshot} title={notification.path} type="button">{notification.path}</button>; path copied to clipboard.</span>
+        <span>Saved to</span>
+        <span className="screenshot-file-path-line"><span className="screenshot-file-path-label">File path</span> <button className="screenshot-path-button" onClick={revealScreenshot} title={notification.path} type="button">{notification.path}</button></span>
+        <span>File path copied to clipboard.</span>
       </div>
       <button aria-label="Dismiss screenshot notification" className="screenshot-dismiss-button" onClick={onDismiss} type="button">×</button>
     </div>

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -320,7 +320,7 @@ code {
   display: flex;
   gap: 12px;
   max-width: min(720px, calc(100vw - 48px));
-  padding: 8px 10px 8px 14px;
+  padding: 8px 10px 8px 20px;
   width: 100%;
 }
 
@@ -343,11 +343,26 @@ code {
   text-overflow: ellipsis;
 }
 
+.screenshot-capture-notification .screenshot-file-path-line {
+  align-items: baseline;
+  display: flex;
+  gap: 6px;
+}
+
+.screenshot-capture-notification .screenshot-file-path-label {
+  color: var(--text-primary);
+  flex: 0 0 auto;
+  font-weight: 800;
+  overflow: visible;
+}
+
 .screenshot-capture-notification .screenshot-path-button {
   background: transparent;
   border: 0;
   color: var(--accent);
+  flex: 1 1 auto;
   font: inherit;
+  min-width: 0;
   padding: 0;
   text-decoration: underline;
   overflow-wrap: anywhere;

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -422,13 +422,17 @@ describe("dashboard shell", () => {
     expect(screenshotSource).toContain("aidevops:screenshot-captured");
     expect(screenshotSource).toContain("screenshotNotifications.map");
     expect(screenshotSource).toContain("screenshot-capture-notification");
+    expect(screenshotSource).toContain("File path");
+    expect(screenshotSource).toContain("File path copied to clipboard.");
     expect(screenshotSource).toContain("screenshot-path-button");
     expect(screenshotSource).toContain("screenshot-dismiss-button");
     expect(css).toContain(".screenshot-capture-notification-stack");
+    expect(css).toContain("padding: 8px 10px 8px 20px");
     expect(css).toContain(".screenshot-capture-notification");
     expect(desktopInstaller).toContain("Screenshot App");
     expect(desktopInstaller).toContain("Screenshot Page");
-    expect(desktopInstaller).toContain("cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -24)");
+    expect(desktopInstaller).toContain("cameraButton.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -9)");
+    expect(desktopInstaller).toContain("cameraButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 5.5)");
     expect(desktopInstaller).toContain("savePageScreenshotAfterRestoringScroll");
     expect(desktopInstaller).toContain("homeDirectoryForCurrentUser.appendingPathComponent(\"Screenshots\"");
     expect(desktopInstaller).toContain("aidevops-app-screenshot-");


### PR DESCRIPTION
## Summary\n- move the native screenshot camera icon 15px right and 2px down\n- add more left padding inside screenshot notifications\n- put the saved file path on a new line labelled "File path"\n- remove the semicolon before the clipboard copy sentence\n\nResolves #26131\n\n## Verification\n- bun test packages/gui-web/tests/component.test.ts\n- bun run typecheck\n- shellcheck packages/gui-desktop/scripts/install-macos-app.sh\n- bash packages/gui-desktop/scripts/install-macos-app.sh --check
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.1 plugin for [OpenCode](https://opencode.ai) v1.17.12
