### PR TITLE
t18044: fix pulse productivity dispatch gaps

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -182,7 +182,7 @@ _pulse_worker_log_prelaunch_failure_reason() {
 #   $3 - optional grace timeout in seconds
 #
 # Exit codes:
-#   0 - worker launch appears valid (process observed, no CLI usage output marker)
+#   0 - worker launch appears valid (process remains alive after stability check)
 #   1 - launch invalid (no process within grace window or usage output detected)
 #######################################
 check_worker_launch() {
@@ -207,8 +207,13 @@ check_worker_launch() {
 
 	local elapsed=0
 	local poll_seconds=2
+	local stability_seconds="${PULSE_LAUNCH_STABILITY_SECONDS:-3}"
 	local candidate=""
 	local prelaunch_failure_reason=""
+	[[ "$stability_seconds" =~ ^[0-9]+$ ]] || stability_seconds=3
+	if [[ "$stability_seconds" -lt 1 ]]; then
+		stability_seconds=1
+	fi
 	while [[ "$elapsed" -lt "$grace_seconds" ]]; do
 		for candidate in "${log_candidates[@]}"; do
 			prelaunch_failure_reason=$(_pulse_worker_log_prelaunch_failure_reason "$candidate")
@@ -234,7 +239,12 @@ check_worker_launch() {
 			# is confirmed. Resetting on launch defeated the counter
 			# entirely — workers that launched but died during execution
 			# were invisible. (GH#2076, GH#17378)
-			return 0
+			sleep "$stability_seconds"
+			elapsed=$((elapsed + stability_seconds))
+			if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
+				return 0
+			fi
+			echo "[pulse-wrapper] Launch validation transient for issue #${issue_number} (${repo_slug}) — process disappeared during ${stability_seconds}s stability check" >>"$LOGFILE"
 		fi
 		sleep "$poll_seconds"
 		elapsed=$((elapsed + poll_seconds))

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -258,6 +258,59 @@ _reevaluate_stale_continuations() {
 }
 
 #######################################
+# Backfill auto-dispatch metadata onto open simplification-debt issues that are
+# already available and not explicitly blocked. Simplification scanners can
+# create maintainer-review-shaped issues; after approval/normalization they may
+# retain status:available + function-complexity-debt without auto-dispatch,
+# leaving real work visible but unreachable by the pulse queue scanner.
+#
+# Arguments:
+#   $1 - repo slug
+# Outputs: number of issues updated
+# Returns: 0 always (best-effort; label repair must not break pulse)
+#######################################
+_backfill_simplification_auto_dispatch_labels() {
+	local slug="$1"
+	local issues_json="[]"
+	local updated=0
+
+	[[ -n "$slug" ]] || {
+		printf '0\n'
+		return 0
+	}
+
+	issues_json=$(gh_issue_list --repo "$slug" --state open \
+		--label "function-complexity-debt" --label "status:available" \
+		--json number,labels --limit 100 2>/dev/null) || issues_json="[]"
+
+	local num="" labels_to_add=""
+	while IFS=$'\t' read -r num labels_to_add; do
+		[[ "$num" =~ ^[0-9]+$ ]] || continue
+		[[ -n "$labels_to_add" ]] || labels_to_add="auto-dispatch"
+		if gh issue edit "$num" --repo "$slug" \
+			--add-label "$labels_to_add" >/dev/null 2>&1; then
+			updated=$((updated + 1))
+		fi
+	done < <(printf '%s' "$issues_json" | jq -r '
+		.[]?
+		| (.labels | map(.name)) as $labels
+		| select(($labels | index("auto-dispatch")) == null)
+		| select(($labels | index("no-auto-dispatch")) == null)
+		| select(($labels | index("needs-maintainer-review")) == null)
+		| select(($labels | index("parent-task")) == null)
+		| select(($labels | index("status:blocked")) == null)
+		| select(($labels | index("status:queued")) == null)
+		| select(($labels | index("status:in-progress")) == null)
+		| select(($labels | index("status:in-review")) == null)
+		| [(.number // empty), (if any($labels[]; startswith("tier:")) then "auto-dispatch" else "auto-dispatch,tier:standard" end)]
+		| @tsv
+	' 2>/dev/null)
+
+	printf '%s\n' "$updated"
+	return 0
+}
+
+#######################################
 # Re-evaluate needs-simplification labeled issues across pulse repos.
 # Same pattern as _reevaluate_consolidation_labels: issues filtered out
 # by the needs-* exclusion never reach dispatch_with_dedup, so the
@@ -275,6 +328,7 @@ _reevaluate_simplification_labels() {
 	[[ -f "$repos_json" ]] || return 0
 
 	local total_cleared=0
+	local total_backfilled=0
 	while IFS='|' read -r slug rpath; do
 		[[ -n "$slug" && -n "$rpath" ]] || continue
 
@@ -285,6 +339,11 @@ _reevaluate_simplification_labels() {
 		# Sentinel in _pulse_refresh_repo prevents redundant pulls if both
 		# the dispatch loop and triage loop hit the same repo in one cycle.
 		_pulse_refresh_repo "$rpath"
+
+		local backfilled_count=0
+		backfilled_count=$(_backfill_simplification_auto_dispatch_labels "$slug") || backfilled_count=0
+		[[ "$backfilled_count" =~ ^[0-9]+$ ]] || backfilled_count=0
+		total_backfilled=$((total_backfilled + backfilled_count))
 
 		local issues_json
 		issues_json=$(gh_issue_list --repo "$slug" --state open \
@@ -323,6 +382,9 @@ _reevaluate_simplification_labels() {
 
 	if [[ "$total_cleared" -gt 0 ]]; then
 		echo "[pulse-wrapper] Simplification re-evaluation: cleared ${total_cleared} stale needs-simplification label(s)" >>"$LOGFILE"
+	fi
+	if [[ "$total_backfilled" -gt 0 ]]; then
+		echo "[pulse-wrapper] Simplification re-evaluation: backfilled auto-dispatch on ${total_backfilled} function-complexity-debt issue(s)" >>"$LOGFILE"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -595,12 +595,13 @@ test_failure_classification_distinct() {
 	# These are wired in pulse-dispatch-engine.sh check_worker_launch.
 	if grep -q '"no_worker_process"' "$PULSE_ENGINE" \
 		&& grep -q '"cli_usage_output"' "$PULSE_ENGINE" \
-		&& grep -q 'worker_worktree_live_owner' "$PULSE_ENGINE"; then
+		&& grep -q 'worker_worktree_live_owner' "$PULSE_ENGINE" \
+		&& grep -q 'PULSE_LAUNCH_STABILITY_SECONDS' "$PULSE_ENGINE"; then
 		print_result "invariant: launch failures classified distinctly (no_worker_process vs cli_usage_output)" 0
 		return 0
 	fi
 	print_result "invariant: launch failures classified distinctly (no_worker_process vs cli_usage_output)" 1 \
-		"Expected 'no_worker_process', 'cli_usage_output', and 'worker_worktree_live_owner' classifications in $PULSE_ENGINE"
+		"Expected launch classifications and PULSE_LAUNCH_STABILITY_SECONDS guard in $PULSE_ENGINE"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-wrapper-characterization.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-characterization.sh
@@ -231,6 +231,7 @@ readonly -a EXPECTED_FUNCTIONS=(
 	"_gh_idempotent_comment"
 	"_issue_needs_consolidation"
 	"_reevaluate_consolidation_labels"
+	"_backfill_simplification_auto_dispatch_labels"
 	"_reevaluate_simplification_labels"
 	"_consolidation_child_exists"
 	"_consolidation_substantive_comments"

--- a/.agents/scripts/tests/test-simplification-auto-dispatch-backfill.sh
+++ b/.agents/scripts/tests/test-simplification-auto-dispatch-backfill.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOGFILE="$TMP_DIR/pulse.log"
+REPOS_JSON="$TMP_DIR/repos.json"
+export LOGFILE REPOS_JSON
+
+gh_issue_list() {
+	printf '%s\n' '[
+		{"number": 101, "labels": [{"name":"status:available"},{"name":"function-complexity-debt"}]},
+		{"number": 102, "labels": [{"name":"status:available"},{"name":"function-complexity-debt"},{"name":"tier:thinking"}]},
+		{"number": 103, "labels": [{"name":"status:available"},{"name":"function-complexity-debt"},{"name":"auto-dispatch"}]},
+		{"number": 104, "labels": [{"name":"status:available"},{"name":"function-complexity-debt"},{"name":"needs-maintainer-review"}]},
+		{"number": 105, "labels": [{"name":"status:available"},{"name":"function-complexity-debt"},{"name":"no-auto-dispatch"}]}
+	]'
+	return 0
+}
+
+gh() {
+	if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+		printf '%s\t%s\n' "$3" "${7:-}" >>"$TMP_DIR/edits.tsv"
+		return 0
+	fi
+	return 1
+}
+
+# shellcheck source=../pulse-triage-evaluation.sh
+source "$SCRIPT_DIR/pulse-triage-evaluation.sh"
+
+updated="$(_backfill_simplification_auto_dispatch_labels "marcusquinn/aidevops")"
+[[ "$updated" == "2" ]]
+
+grep -q $'^101\tauto-dispatch,tier:standard$' "$TMP_DIR/edits.tsv"
+grep -q $'^102\tauto-dispatch$' "$TMP_DIR/edits.tsv"
+if grep -q '^103' "$TMP_DIR/edits.tsv"; then
+	exit 1
+fi
+if grep -q '^104' "$TMP_DIR/edits.tsv"; then
+	exit 1
+fi
+if grep -q '^105' "$TMP_DIR/edits.tsv"; then
+	exit 1
+fi
+
+printf 'PASS simplification auto-dispatch backfill\n'

--- a/TODO.md
+++ b/TODO.md
@@ -1064,6 +1064,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18039 Add productivity insights and systemic fix feedback to Pulse & Workers #auto-dispatch #dashboard #feat #observability #pulse #self-improvement ~4h blocked-by:t18038 ref:GH#25917 logged:2026-06-30 -> [todo/tasks/t18039-brief.md]
 
+- [ ] t18044 Fix pulse productivity dispatch gaps #bug ref:GH#26133
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- require pulse launch validation to observe a worker process across a short stability window before counting it as spawned
- backfill auto-dispatch metadata onto available simplification-debt issues that are not explicitly blocked
- add regression coverage for simplification backfill and launch-accounting guard coverage

## Verification
- `bash .agents/scripts/tests/test-simplification-auto-dispatch-backfill.sh`
- `bash .agents/scripts/tests/test-no-worker-process-fix.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh`
- `shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/pulse-triage-evaluation.sh .agents/scripts/tests/test-simplification-auto-dispatch-backfill.sh .agents/scripts/tests/test-no-worker-process-fix.sh .agents/scripts/tests/test-pulse-wrapper-characterization.sh`
- `git diff --check`

## Release note
Fixes pulse worker productivity underfill by avoiding false-positive launch accounting and making simplification-debt work dispatchable once available.

Resolves #26133

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.1 plugin for [OpenCode](https://opencode.ai) v1.17.12
