### PR TITLE
GH#26062: fix: avoid self-comparison smell checks

### DIFF
--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -26,13 +26,26 @@ find_qlty() {
 	return 1
 }
 
+is_non_negative_integer() {
+	local _value="$1"
+	case "$_value" in
+		'' | *[!0-9]*)
+			return 1
+			;;
+		*)
+			return 0
+			;;
+	esac
+	return 1
+}
+
 read_threshold() {
 	local _conf="$1"
 	local _threshold="0"
 	local _val=""
 	if [ -f "$_conf" ]; then
 		_val=$(grep '^QLTY_SMELL_THRESHOLD=' "$_conf" | cut -d= -f2 || true)
-		if [ -n "$_val" ] && [ "$_val" -eq "$_val" ] 2>/dev/null; then
+		if is_non_negative_integer "$_val"; then
 			_threshold="$_val"
 		fi
 	fi
@@ -115,7 +128,7 @@ run_threshold_check() {
 	rm -f "$_diag_file"
 
 	_count=$(printf '%s\n' "$_sarif" | jq '.runs[0].results | length' 2>/dev/null || true)
-	if ! [ "$_count" -eq "$_count" ] 2>/dev/null; then
+	if ! is_non_negative_integer "$_count"; then
 		printf '::error::Failed to parse smell count from SARIF output\n'
 		return 1
 	fi


### PR DESCRIPTION
## Summary

Replaced self-comparison integer validation in qlty-smell-threshold-helper.sh with an explicit non-negative integer validator so SonarCloud shelldre:S1764 no longer flags the threshold and SARIF count checks.

## Files Changed

.agents/scripts/qlty-smell-threshold-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; shellcheck .agents/scripts/qlty-smell-threshold-helper.sh; bash -n .agents/scripts/qlty-smell-threshold-helper.sh; git diff --check; SonarCloud API still reports the pre-analysis open shelldre:S1764 issues, while the local source no longer contains the flagged self-comparisons.

Resolves #26062


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.3 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 2m and 68,202 tokens on this as a headless worker.