### PR TITLE
Fix headless OpenCode auth continuation (#26138)

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -138,6 +138,7 @@ from pathlib import Path
 trusted_chunks = []
 provider_line = re.compile(r"\b(openai|anthropic|claude|provider|api)\b", re.I)
 runtime_line = re.compile(r"\[(worker_exit_diagnostics|provider_error|runtime_error)\]", re.I)
+auth_runtime_line = re.compile(r"\b(token refresh failed|invalid_grant|invalid refresh token)\b", re.I)
 
 for raw_line in Path(sys.argv[1]).read_text(errors='ignore').splitlines():
     line = raw_line.strip()
@@ -154,7 +155,7 @@ for raw_line in Path(sys.argv[1]).read_text(errors='ignore').splitlines():
             has_error_record = any(key in obj for key in ('error', 'status', 'provider_error_type', 'provider_status'))
             if has_provider and has_error_record:
                 trusted = True
-    elif provider_line.search(line) or runtime_line.search(line):
+    elif provider_line.search(line) or runtime_line.search(line) or auth_runtime_line.search(line):
         trusted = True
     if trusted:
         trusted_chunks.append(line)
@@ -252,7 +253,7 @@ service_interruption_continue_candidate() {
 	local session_id="$4"
 	: "${5:-}"
 
-	if [[ "$failure_reason" == "provider_error" ]]; then
+	if [[ "$failure_reason" == "provider_error" || "$failure_reason" == "auth_error" ]]; then
 		if [[ "$activity_detected" == "1" || -n "$session_id" ]]; then
 			return 0
 		fi

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -964,6 +964,32 @@ test_service_interruption_candidate_uses_separate_path() {
 		print_result "rate limits do not consume service interruption budget" 1
 	fi
 
+	if service_interruption_continue_candidate "auth_error" "1" "1" "" "auth_error"; then
+		print_result "auth errors with activity consume service interruption budget" 0
+	else
+		print_result "auth errors with activity consume service interruption budget" 1
+	fi
+
+	if ! service_interruption_continue_candidate "auth_error" "1" "0" "" "auth_error"; then
+		print_result "startup auth errors do not consume service interruption budget" 0
+	else
+		print_result "startup auth errors do not consume service interruption budget" 1
+	fi
+
+	local auth_refresh_output_file="${TEST_ROOT}/service-interruption-auth-refresh.out"
+	printf '%s\n' '{"type":"text","sessionID":"ses_auth","text":"editing files"}' 'Token refresh failed: 401' >"$auth_refresh_output_file"
+	_run_result_label=""
+	_run_failure_reason=""
+	status=0
+	_handle_run_result 1 "$auth_refresh_output_file" "worker" "anthropic" "issue-23037" "anthropic/claude-sonnet-4-6" || status=$?
+
+	if [[ "$status" -eq 81 && "$_run_result_label" == "service_interruption_continue" && "$_run_failure_reason" == "auth_error" && -f "$auth_refresh_output_file" ]]; then
+		print_result "token refresh 401 with session evidence resumes as service interruption" 0
+	else
+		print_result "token refresh 401 with session evidence resumes as service interruption" 1 \
+			"status=$status label=${_run_result_label:-<empty>} reason=${_run_failure_reason:-<empty>} output_exists=$([[ -f "$auth_refresh_output_file" ]] && printf yes || printf no)"
+	fi
+
 	if service_interruption_continue_candidate "local_error" "137" "1" "" ""; then
 		print_result "SIGKILL with activity can resume as interruption" 0
 	else


### PR DESCRIPTION
## Summary

- Trust bare runtime auth-refresh failures (`Token refresh failed`, `invalid_grant`, `invalid refresh token`) in the headless failure classifier.
- Allow `auth_error` to use bounded service-interruption continuation when activity/session evidence exists.
- Add regression coverage for activity-backed auth errors, startup auth errors, and token-refresh 401 continuation.

Resolves #26138

## Verification

```bash
shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh
bash .agents/scripts/tests/test-headless-runtime-helper.sh
bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh
.agents/scripts/linters-local.sh
```

## Notes

Startup auth failures without activity/session evidence still do not consume the service-interruption continuation budget.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.4 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 5h 27m and 692,918 tokens on this with the user in an interactive session.
