### PR TITLE
GH#26142 fix: refine screenshot saved-path notice

### DIFF
--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -1058,7 +1058,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         let directory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Screenshots", isDirectory: true)
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            let fileURL = directory.appendingPathComponent("aidevops-app-screenshot-\(sanitizeFilenameComponent(nameComponent))-\(screenshotTimestamp()).png")
+            let fileURL = directory.appendingPathComponent("aidevops-app-screenshot-\(screenshotTimestamp())-\(sanitizeFilenameComponent(nameComponent)).png")
             try data.write(to: fileURL, options: .atomic)
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(fileURL.path, forType: .string)

--- a/packages/gui-web/src/ScreenshotCaptureNotification.tsx
+++ b/packages/gui-web/src/ScreenshotCaptureNotification.tsx
@@ -27,10 +27,10 @@ export function ScreenshotCaptureNotification({ notification, onDismiss }: { not
 
   return (
     <div className="screenshot-capture-notification" role="status">
+      <span aria-hidden="true" className="screenshot-info-icon">i</span>
       <div>
         <strong>Screenshot captured</strong>
-        <span>Saved to</span>
-        <span className="screenshot-file-path-line"><span className="screenshot-file-path-label">File path</span> <button className="screenshot-path-button" onClick={revealScreenshot} title={notification.path} type="button">{notification.path}</button></span>
+        <span className="screenshot-file-path-line"><span className="screenshot-file-path-label">Saved to:</span> <button className="screenshot-path-button" onClick={revealScreenshot} title={notification.path} type="button">{notification.path}</button></span>
         <span>File path copied to clipboard.</span>
       </div>
       <button aria-label="Dismiss screenshot notification" className="screenshot-dismiss-button" onClick={onDismiss} type="button">×</button>

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -320,8 +320,25 @@ code {
   display: flex;
   gap: 12px;
   max-width: min(720px, calc(100vw - 48px));
-  padding: 8px 10px 8px 20px;
+  padding: 8px 10px 8px 14px;
   width: 100%;
+}
+
+.screenshot-capture-notification .screenshot-info-icon {
+  align-items: center;
+  align-self: center;
+  background: color-mix(in srgb, var(--accent) 16%, var(--surface-muted));
+  border: 1px solid var(--border-accent);
+  border-radius: 999px;
+  color: var(--accent);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  font-weight: 900;
+  height: 28px;
+  justify-content: center;
+  line-height: 1;
+  width: 28px;
 }
 
 .screenshot-capture-notification > div {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -422,12 +422,13 @@ describe("dashboard shell", () => {
     expect(screenshotSource).toContain("aidevops:screenshot-captured");
     expect(screenshotSource).toContain("screenshotNotifications.map");
     expect(screenshotSource).toContain("screenshot-capture-notification");
-    expect(screenshotSource).toContain("File path");
+    expect(screenshotSource).toContain("screenshot-info-icon");
+    expect(screenshotSource).toContain("Saved to:");
     expect(screenshotSource).toContain("File path copied to clipboard.");
     expect(screenshotSource).toContain("screenshot-path-button");
     expect(screenshotSource).toContain("screenshot-dismiss-button");
     expect(css).toContain(".screenshot-capture-notification-stack");
-    expect(css).toContain("padding: 8px 10px 8px 20px");
+    expect(css).toContain(".screenshot-capture-notification .screenshot-info-icon");
     expect(css).toContain(".screenshot-capture-notification");
     expect(desktopInstaller).toContain("Screenshot App");
     expect(desktopInstaller).toContain("Screenshot Page");
@@ -435,7 +436,7 @@ describe("dashboard shell", () => {
     expect(desktopInstaller).toContain("cameraButton.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: 5.5)");
     expect(desktopInstaller).toContain("savePageScreenshotAfterRestoringScroll");
     expect(desktopInstaller).toContain("homeDirectoryForCurrentUser.appendingPathComponent(\"Screenshots\"");
-    expect(desktopInstaller).toContain("aidevops-app-screenshot-");
+    expect(desktopInstaller).toContain("aidevops-app-screenshot-\\(screenshotTimestamp())-\\(sanitizeFilenameComponent(nameComponent)).png");
     expect(desktopInstaller).toContain("NSPasteboard.general.setString(fileURL.path");
   });
 


### PR DESCRIPTION
## Summary\n- add a circular info icon at the left of screenshot notifications so text clears the rounded pill edge\n- simplify the saved-path line to "Saved to:" followed by the path\n- remove duplicate "File path" wording from the notification body\n- move the screenshot name component after the timestamp in generated PNG names\n\nResolves #26142\n\n## Verification\n- bun test packages/gui-web/tests/component.test.ts\n- bun run typecheck\n- shellcheck packages/gui-desktop/scripts/install-macos-app.sh\n- bash packages/gui-desktop/scripts/install-macos-app.sh --check
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.4 plugin for [OpenCode](https://opencode.ai) v1.17.12
