### PR TITLE
fix: filter timestamped failure miner comments

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -175,6 +175,10 @@ filter_signature_noise_lines() {
 				}
 			}
 			gsub(/\033\[[0-9;]*[A-Za-z]/, "", payload)
+			# gh may return raw log rows with the ISO timestamp still prefixed
+			# instead of tab-separated job/step/time columns; remove it before
+			# classifying shell comments as signature noise.
+			sub(/^20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9:.]+Z[[:space:]]+/, "", payload)
 			gsub(/^[[:space:]]+/, "", payload)
 			# GitHub Actions sometimes echoes shell comments from multi-line run blocks
 			# as UNKNOWN STEP log rows. Treat plain comments and xtrace-prefixed

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -71,6 +71,9 @@ filtered=$(filter_signature_noise_lines $'gate / review-bot-gate\tUNKNOWN STEP\t
 signature=$(normalize_signature_line "$filtered")
 assert_equals "GH#26127 comment-only systemic signature normalizes empty" "no_error_signature_detected" "$signature"
 
+filtered=$(filter_signature_noise_lines $'2026-06-30T20:14:24.8559907Z \033[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.\033[0m\n2026-06-30T20:14:25.0000000Z ::error::No AI review bots have posted a real, settled review on this PR yet.')
+assert_equals "GH#26144 timestamp-prefixed shell comments are filtered" $'2026-06-30T20:14:25.0000000Z ::error::No AI review bots have posted a real, settled review on this PR yet.' "$filtered"
+
 printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then
 	exit 1


### PR DESCRIPTION
## Summary
- Filter timestamp-prefixed raw GitHub Actions log rows before classifying shell comments as gh-failure-miner signature noise.
- Add a GH#26144 regression for the review-bot-gate rate-limit grace comment so it cannot become a systemic CI signature.

## Testing
- bash .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
- shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

Resolves #26144

MERGE_SUMMARY: gh-failure-miner now strips ISO timestamps from raw log rows before filtering shell-comment noise, and the regression test covers the review-bot-gate rate-limit grace comment signature observed in #26144.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.4 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 4m and 54,813 tokens on this as a headless worker.