### PR TITLE
fix: validate doc complexity by file lines

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -428,6 +428,11 @@ _validator_agent_doc_simplification_gate() {
 # Re-measures function complexity in the cited file. If no functions exceed
 # the threshold, the premise is falsified.
 #
+# Historical issues may carry this generator marker for Markdown agent-doc
+# findings. Those issues are file-size findings, not shell-function findings;
+# validate them against whole-file line count so closure comments do not claim
+# "0 functions" for documentation files (GH#25993).
+#
 # Expects CITED_FILE and CITED_THRESHOLD to be set by cmd_validate().
 # ---------------------------------------------------------------------------
 _validator_function_complexity_gate() {
@@ -456,6 +461,21 @@ _validator_function_complexity_gate() {
 		return 10
 	fi
 
+	case "$CITED_FILE" in
+	*.sh) ;;
+	*)
+		local line_count
+		line_count=$(wc -l <"$target_file" 2>/dev/null | tr -d ' ') || line_count=0
+		if [[ "$line_count" -lt "$CITED_THRESHOLD" ]]; then
+			_log "INFO" "function-complexity-gate validator: ${CITED_FILE} is now ${line_count} lines (threshold ${CITED_THRESHOLD}) — premise falsified"
+			VALIDATOR_RATIONALE="File \`${CITED_FILE}\` is now ${line_count} lines, below the ${CITED_THRESHOLD}-line threshold. Premise falsified. Not dispatching."
+			return 10
+		fi
+		_log "INFO" "function-complexity-gate validator: ${CITED_FILE} is still ${line_count} lines (threshold ${CITED_THRESHOLD}) — premise holds"
+		return 0
+		;;
+	esac
+
 	# Count functions exceeding the threshold (same awk as complexity-scan-helper.sh)
 	local violation_count
 	violation_count=$(awk -v threshold="$CITED_THRESHOLD" '
@@ -469,6 +489,10 @@ _validator_function_complexity_gate() {
 		VALIDATOR_RATIONALE="File \`${CITED_FILE}\` has 0 functions exceeding ${CITED_THRESHOLD} lines on HEAD. Premise falsified. Not dispatching."
 		return 10
 	fi
+
+	_log "INFO" "function-complexity-gate validator: ${violation_count} function(s) still exceed ${CITED_THRESHOLD} lines in ${CITED_FILE} — premise holds"
+	return 0
+}
 
 # ---------------------------------------------------------------------------
 # Runtime-audit validator (t3072)
@@ -524,10 +548,6 @@ _validator_runtime_audit() {
 
 	_log "WARN" "runtime-audit validator: detector=${DETECTOR_ID} returned rc=${detector_rc} (unexpected) — validator error"
 	return 20
-}
-
-	_log "INFO" "function-complexity-gate validator: ${violation_count} function(s) still exceed ${CITED_THRESHOLD} lines in ${CITED_FILE} — premise holds"
-	return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh
@@ -12,6 +12,7 @@
 #   test_agent_doc_premise_holds            — markdown file at threshold → exit 0
 #   test_function_complexity_falsified      — no violations remain → exit 10
 #   test_function_complexity_holds          — violations still present → exit 0
+#   test_function_marker_markdown_uses_file_lines — legacy marker on docs → file-line rationale
 #   test_missing_attributes                 — marker without attributes → exit 20
 
 set -euo pipefail
@@ -86,7 +87,22 @@ sys.stdout.write(body)
 	exit 0
 fi
 
-# gh issue comment / gh issue close / gh label create — succeed silently
+# gh issue comment / gh issue close / gh label create — succeed silently.
+# When GH_STUB_COMMENT_CAPTURE is set, record comment bodies for assertions.
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "comment" && -n "\${GH_STUB_COMMENT_CAPTURE:-}" ]]; then
+	_body=""
+	while [[ \$# -gt 0 ]]; do
+		case "\$1" in
+		--body)
+			shift
+			_body="\${1:-}"
+			;;
+		esac
+		shift || true
+	done
+	printf '%s' "\$_body" >"\$GH_STUB_COMMENT_CAPTURE"
+	exit 0
+fi
 if [[ "\${1:-}" == "issue" || "\${1:-}" == "label" ]]; then
 	exit 0
 fi
@@ -363,6 +379,49 @@ big_func() {
 	return 0
 }
 
+# test_function_marker_markdown_uses_file_lines — legacy issues created before
+# the agent-doc marker fix may still use function-complexity-gate for Markdown.
+# Expected: validator exits 10 and rationale uses whole-file line counts.
+test_function_marker_markdown_uses_file_lines() {
+	setup_test_env
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=function-complexity-gate cited_file=.agents/aidevops/knowledge-plane.md threshold=500 -->\n## Agent doc simplification\n**Current size:** 1029 lines\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	local file_content=""
+	local i
+	for i in $(seq 1 120); do
+		file_content="${file_content}doc line ${i}\n"
+	done
+	create_git_stub_with_file "success" ".agents/aidevops/knowledge-plane.md" "$(printf '%b' "$file_content")"
+
+	local comment_capture="${TEST_ROOT}/comment.txt"
+	export GH_STUB_COMMENT_CAPTURE="$comment_capture"
+	local rc=0
+	"$HELPER_SCRIPT" validate "108" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+	unset GH_STUB_COMMENT_CAPTURE
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "function_marker_markdown_uses_file_lines exits 10" 0
+	else
+		print_result "function_marker_markdown_uses_file_lines exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	local comment_body=""
+	if [[ -f "$comment_capture" ]]; then
+		comment_body=$(<"$comment_capture")
+	fi
+	if printf '%s' "$comment_body" | grep -Eq 'is now 1(19|20) lines, below the 500-line threshold' && ! printf '%s' "$comment_body" | grep -q 'functions exceeding'; then
+		print_result "function_marker_markdown_uses_file_line_rationale" 0
+	else
+		print_result "function_marker_markdown_uses_file_line_rationale" 1 "Expected file-line rationale without function wording"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 # test_missing_attributes — marker present but without cited_file/threshold
 # Expected: validator exits 20 (validator error — missing attributes)
 test_missing_attributes() {
@@ -404,6 +463,7 @@ main() {
 	test_agent_doc_premise_holds
 	test_function_complexity_falsified
 	test_function_complexity_holds
+	test_function_marker_markdown_uses_file_lines
 	test_missing_attributes
 
 	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary
- Treat legacy `function-complexity-gate` markers on non-shell files as whole-file line-count findings.
- Keep shell files on the existing function-length validation path.
- Add regression coverage that captures the pre-dispatch closure comment and rejects the misleading `functions exceeding` rationale for Markdown files.

## Verification
- `bash -n .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-pre-dispatch-validator-large-file.sh`
- `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-pre-dispatch-validator-large-file.sh`
- `.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh` — 10 tests passed
- `.agents/scripts/complexity-regression-helper.sh check --metric function-complexity --base origin/main --head HEAD` — no new violations
- `.agents/scripts/linters-local.sh` partially completed through Bash 3.2 compatibility; timed out at the repository-wide function complexity gate after 900s. Targeted CI-equivalent function-complexity regression check passed.

Resolves #25993

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.6 plugin for [OpenCode](https://opencode.ai) v1.17.12
