### PR TITLE
fix: reject signature-only GitHub issue bodies

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -902,14 +902,14 @@ build_issue_body() {
 	if [[ "$is_infra" == "true" ]]; then
 		printf '%s\n' "$cluster_json" | jq -r '
 			"## Summary\n" +
-			"- Affected checks: " + (.check_names | join(", ")) + "\n" +
+			"- Affected checks: " + ((.check_names // [(.check_name // "multiple-checks")]) | join(", ")) + "\n" +
 			"- Events observed: " + (.count|tostring) + "\n" +
-			"- Sources affected: " + ((.sources | length)|tostring) + "\n\n" +
+			"- Sources affected: " + (((.sources // []) | length)|tostring) + "\n\n" +
 			"## Why this looks like an infrastructure outage\n" +
 			"- All checks failed simultaneously across multiple PRs/commits.\n" +
 			"- This pattern indicates a billing or runner infrastructure issue, not a code defect.\n\n" +
 			"## Evidence\n" +
-			(.examples | map("- " + .source_kind + ":" + .source_ref + " (" + .conclusion + ")" +
+			((.examples // []) | map("- " + (.source_kind // "source") + ":" + (.source_ref // "unknown") + " (" + (.conclusion // "unknown") + ")" +
 			  (if .source_url != null then " - " + .source_url else "" end) +
 			  (if .run_url != null then " - " + .run_url else "" end) +
 			  (if .details_url != null then " - " + .details_url else "" end)
@@ -920,6 +920,7 @@ build_issue_body() {
 			"- Do NOT make code changes to fix this — the root cause is external.\n\n" +
 			"Signal tag: `gh-failure-miner:" + $pattern_id + "`\n"
 		' --arg pattern_id "$pattern_id" --argjson threshold "$threshold"
+		return $?
 	else
 		printf '%s\n' "$cluster_json" | jq -r '
 			def affected_paths_line($example):
@@ -984,7 +985,7 @@ build_issue_body() {
 			"Signal tag: `gh-failure-miner:" + $pattern_id + "`\n"
 		' --arg pattern_id "$pattern_id" --argjson threshold "$threshold"
 	fi
-	return 0
+	return $?
 }
 
 ensure_repo_labels() {
@@ -1056,7 +1057,14 @@ create_or_preview_issue() {
 	local title
 	title=$(build_issue_title "$check_name" "$count" "$is_infra")
 	local body
-	body=$(build_issue_body "$cluster_json" "$pattern_id" "$systemic_threshold" "$is_infra")
+	if ! body=$(build_issue_body "$cluster_json" "$pattern_id" "$systemic_threshold" "$is_infra"); then
+		echo "Skipping cluster for ${check_name} - issue body generation failed"
+		return 1
+	fi
+	if [[ -z "${body//[[:space:]]/}" ]]; then
+		echo "Skipping cluster for ${check_name} - generated issue body was empty"
+		return 1
+	fi
 
 	if [[ "$dry_run" == "true" ]]; then
 		if [[ "$is_infra" == "true" ]]; then

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -433,6 +433,36 @@ $(cat "$err_file" 2>/dev/null || true)"
 # Internal: rejection reason for the most recent _gh_validate_edit_args call.
 _GH_EDIT_REJECTION_REASON=""
 
+_gh_body_has_substantive_content() {
+	local body_value="$1"
+	local unsigned_body
+	unsigned_body="${body_value%%<!-- aidevops:sig -->*}"
+	unsigned_body="${unsigned_body#"${unsigned_body%%[![:space:]]*}"}"
+	unsigned_body="${unsigned_body%"${unsigned_body##*[![:space:]]}"}"
+	[[ -n "$unsigned_body" ]]
+	return $?
+}
+
+_gh_validate_body_file_content() {
+	local body_file_val="$1"
+	local file_size
+	file_size=$(wc -c <"$body_file_val" 2>/dev/null || echo "0")
+	file_size=$(echo "$file_size" | tr -d '[:space:]')
+	if [[ "$file_size" -eq 0 ]]; then
+		_GH_EDIT_REJECTION_REASON="body-file '${body_file_val}' is empty"
+		printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+		return 1
+	fi
+	local body_file_body
+	body_file_body=$(<"$body_file_val")
+	if ! _gh_body_has_substantive_content "$body_file_body"; then
+		_GH_EDIT_REJECTION_REASON="body-file '${body_file_val}' has no content before signature footer"
+		printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+		return 1
+	fi
+	return 0
+}
+
 #######################################
 # Internal: validate --title and --body/--body-file args.
 # Returns 0 if valid, 1 if rejected (with stderr message + _GH_EDIT_REJECTION_REASON).
@@ -502,10 +532,7 @@ _gh_validate_edit_args() {
 
 	# Validate body if present
 	if [[ "$has_body" -eq 1 ]]; then
-		local trimmed_body
-		trimmed_body="${body_val#"${body_val%%[![:space:]]*}"}"
-		trimmed_body="${trimmed_body%"${trimmed_body##*[![:space:]]}"}"
-		if [[ -z "$trimmed_body" ]]; then
+		if ! _gh_body_has_substantive_content "$body_val"; then
 			_GH_EDIT_REJECTION_REASON="empty body (after trimming whitespace)"
 			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
 			return 1
@@ -529,16 +556,7 @@ _gh_validate_edit_args() {
 			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
 			return 1
 		fi
-		if [[ -f "$body_file_val" ]]; then
-			local file_size
-			file_size=$(wc -c <"$body_file_val" 2>/dev/null || echo "0")
-			file_size=$(echo "$file_size" | tr -d '[:space:]')
-			if [[ "$file_size" -eq 0 ]]; then
-				_GH_EDIT_REJECTION_REASON="body-file '${body_file_val}' is empty"
-				printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
-				return 1
-			fi
-		fi
+		_gh_validate_body_file_content "$body_file_val" || return 1
 	fi
 
 	return 0

--- a/.agents/scripts/tests/test-generated-issue-worker-labels.sh
+++ b/.agents/scripts/tests/test-generated-issue-worker-labels.sh
@@ -165,8 +165,11 @@ test_quality_feedback_labels() {
 }
 
 test_failure_miner_labels() {
-	local cluster_json
+	local cluster_json legacy_infra_cluster_json legacy_infra_body
 	cluster_json='{"repo":"marcusquinn/aidevops","check_name":"ShellCheck","check_names":["ShellCheck"],"signature":"failure:shellcheck","count":2,"sources":["pr:#1"],"examples":[{"source_ref":"pr:#1"}]}'
+	legacy_infra_cluster_json='{"repo":"marcusquinn/aidevops","check_name":"ShellCheck","signature":"failure:shellcheck","count":2,"sources":["pr:#1"],"examples":[{"source_ref":"pr:#1"}]}'
+	legacy_infra_body=$(build_issue_body "$legacy_infra_cluster_json" "abc123" "2" "true")
+	[[ "$legacy_infra_body" == *"Affected checks: ShellCheck"* ]] && print_result "infra miner falls back to check_name when check_names is absent" 0 || print_result "infra miner falls back to check_name when check_names is absent" 1 "$legacy_infra_body"
 	reset_create_log
 	create_or_preview_issue "$cluster_json" "abc123" "2" "false" "false" >/dev/null
 	assert_create_contains "failure miner has auto-dispatch" "--label auto-dispatch"

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
@@ -175,11 +175,50 @@ assert_missing_body_file_rejected_before_gh() {
 	return 0
 }
 
+assert_signature_only_body_rejected_before_gh() {
+	reset_capture
+	local sig_only_body=$'\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) existing\n'
+	if gh_create_pr --repo o/r --title "Reject signature-only body" --body "$sig_only_body" >/dev/null 2>"${TEST_ROOT}/sig-only-body.err"; then
+		print_result "signature-only --body is rejected before gh" 1 "wrapper returned success"
+		return 0
+	fi
+	local gh_calls rejection_count
+	gh_calls=$(wc -l <"$GH_ARGV_RECORD_FILE" | tr -d '[:space:]')
+	rejection_count=$(grep -c "empty body (after trimming whitespace)" "${TEST_ROOT}/sig-only-body.err" 2>/dev/null || true)
+	if [[ "$gh_calls" == "0" && "$rejection_count" == "1" ]]; then
+		print_result "signature-only --body is rejected before gh" 0
+	else
+		print_result "signature-only --body is rejected before gh" 1 "gh_calls=${gh_calls}, rejection_count=${rejection_count}"
+	fi
+	return 0
+}
+
+assert_signature_only_body_file_rejected_before_gh() {
+	reset_capture
+	local body_file="${TEST_ROOT}/signature-only.md"
+	printf '\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) existing\n' >"$body_file"
+	if gh_create_pr --repo o/r --title "Reject signature-only body-file" --body-file "$body_file" >/dev/null 2>"${TEST_ROOT}/sig-only-file.err"; then
+		print_result "signature-only --body-file is rejected before gh" 1 "wrapper returned success"
+		return 0
+	fi
+	local gh_calls rejection_count
+	gh_calls=$(wc -l <"$GH_ARGV_RECORD_FILE" | tr -d '[:space:]')
+	rejection_count=$(grep -c "has no content before signature footer" "${TEST_ROOT}/sig-only-file.err" 2>/dev/null || true)
+	if [[ "$gh_calls" == "0" && "$rejection_count" == "1" ]]; then
+		print_result "signature-only --body-file is rejected before gh" 0
+	else
+		print_result "signature-only --body-file is rejected before gh" 1 "gh_calls=${gh_calls}, rejection_count=${rejection_count}"
+	fi
+	return 0
+}
+
 assert_body_file_signed "gh_create_pr --body-file signs temp body" "pr-create"
 assert_body_file_signed "gh_pr_comment --body-file signs temp body" "pr-comment"
 assert_existing_signature_not_duplicated
 assert_signed_relative_body_file_normalized
 assert_missing_body_file_rejected_before_gh
+assert_signature_only_body_rejected_before_gh
+assert_signature_only_body_file_rejected_before_gh
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Root cause: #25940 was created by the CI failure miner infrastructure-advisory path with a legacy/test-shaped cluster that had `check_name` but no `check_names`; the infra body `jq` expression failed, leaving only the aidevops signature footer.
- Add a wrapper-level safety invariant so `gh_create_issue` / `gh_create_pr` reject bodies that contain no substantive content before `<!-- aidevops:sig -->`.
- Harden failure-miner infra body rendering to tolerate missing optional fields and skip creation if body generation fails or renders empty.

## Verification
- `bash .agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh`
- `bash .agents/scripts/tests/test-generated-issue-worker-labels.sh`
- `bash .agents/scripts/tests/test-gh-failure-miner-codefactor-guidance.sh`
- `shellcheck .agents/scripts/shared-gh-wrappers.sh .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh .agents/scripts/tests/test-generated-issue-worker-labels.sh`
- `RATCHET_STEP_TIMEOUT_SECONDS=300 .agents/scripts/linters-local.sh`

Resolves #25940
