### PR TITLE
fix: gate file size on markdown docs

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -376,8 +376,11 @@ scan_dir_nesting_depth() {
 # ---------------------------------------------------------------------------
 # scan_dir_file_size <dir> [<out-file>] [<files-filter>]
 #
-# .sh and .py files over 1500 lines. Output: <file>\tSIZE\t<lines>.
-# Identity key: (file, 'SIZE'). (t2171)
+# Non-code Markdown files over 500 lines, excluding README.md. Code file
+# length is intentionally not gated here; code scalability is covered by
+# function-complexity and nesting-depth gates, which produce more actionable
+# work than whole-file line counts for cohesive helper modules. Output:
+# <file>\tSIZE\t<lines>. Identity key: (file, 'SIZE'). (t2171, GH#25993)
 #
 # Optional <files-filter>: newline-separated relative paths from
 # `git diff --name-only`; when non-empty, only those files are scanned
@@ -390,9 +393,9 @@ scan_dir_file_size() {
 
 	local _files
 	if [ -n "$_files_filter" ]; then
-		_files=$(_filter_to_abs_paths "$_dir" "$_files_filter" "sh py")
+		_files=$(_filter_to_abs_paths "$_dir" "$_files_filter" "md")
 	else
-		_files=$(_collect_files "$_dir" "sh py")
+		_files=$(_collect_files "$_dir" "md")
 	fi
 	if [ -z "$_files" ]; then
 		[ -n "$_out" ] && : >"$_out"
@@ -407,8 +410,11 @@ scan_dir_file_size() {
 		[ -n "$_file" ] || continue
 		[ -f "$_file" ] || continue
 		_rel_file="${_file#"${_dir}/"}"
+		case "$_rel_file" in
+		README.md | */README.md) continue ;;
+		esac
 		_lc=$(wc -l <"$_file" 2>/dev/null | tr -d ' ')
-		if [ "${_lc:-0}" -gt 1500 ] 2>/dev/null; then
+		if [ "${_lc:-0}" -gt 500 ] 2>/dev/null; then
 			printf '%s\tSIZE\t%s\n' "$_rel_file" "$_lc" >>"$_result_file"
 		fi
 	done <<<"$_files"
@@ -564,7 +570,7 @@ metric_unit() {
 	case "$_metric" in
 	function-complexity) printf 'function(s) >100 lines' ;;
 	nesting-depth) printf 'file(s) with nesting depth >8' ;;
-	file-size) printf 'file(s) >1500 lines' ;;
+	file-size) printf 'non-README Markdown file(s) >500 lines' ;;
 	bash32-compat) printf 'bash 3.2-incompatible construct(s)' ;;
 	*) printf 'violation(s)' ;;
 	esac

--- a/.agents/scripts/file-size-regression-helper.sh
+++ b/.agents/scripts/file-size-regression-helper.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# file-size-regression-helper.sh — ratchet gate for shell/Python file line count (t2938)
+# file-size-regression-helper.sh — ratchet gate for non-code Markdown line count (t2938)
 #
 # Converts the absolute file-size gate from linters-local.sh into a net-increase
 # (ratchet) gate. Block only when the PR adds files over the limit, not for
@@ -11,7 +11,7 @@
 #
 # Subcommands:
 #   scan      <dir>  [--output <file>] [--limit <N>]
-#                    Scan a directory for .sh/.py files over <limit> lines.
+#                    Scan a directory for non-README .md files over <limit> lines.
 #                    Outputs TSV: relative-path TAB line-count.
 #   scan-ref  <ref>  [--output <file>] [--limit <N>]
 #                    Same as scan but reads content from a git ref (no checkout).
@@ -48,7 +48,7 @@
 set -uo pipefail
 
 SCRIPT_NAME=$(basename "$0")
-readonly FILE_SIZE_DEFAULT_LIMIT=1500
+readonly FILE_SIZE_DEFAULT_LIMIT=500
 
 # ---------------------------------------------------------------------------
 # Logging helpers
@@ -68,7 +68,7 @@ die() {
 
 # ---------------------------------------------------------------------------
 # scan_violations_dir <dir> <limit>
-# Scan a plain directory for .sh/.py files with more than <limit> lines.
+# Scan a plain directory for non-README .md files with more than <limit> lines.
 # Outputs TSV: path-relative-to-dir TAB line-count  (sorted by path).
 # ---------------------------------------------------------------------------
 scan_violations_dir() {
@@ -81,7 +81,7 @@ scan_violations_dir() {
 	# shellcheck disable=SC2064
 	trap "rm -f '$_tmp'" RETURN
 
-	find "$_dir_abs" -type f \( -name "*.sh" -o -name "*.py" \) | sort | while IFS= read -r _f; do
+	find "$_dir_abs" -type f -name "*.md" ! -name "README.md" | sort | while IFS= read -r _f; do
 		local _lc
 		_lc=$(wc -l < "$_f") || _lc=0
 		_lc=${_lc//[^0-9]/}
@@ -97,7 +97,7 @@ scan_violations_dir() {
 
 # ---------------------------------------------------------------------------
 # scan_violations_ref <ref> <limit>
-# Scan a git ref for .sh/.py files with more than <limit> lines.
+# Scan a git ref for non-README .md files with more than <limit> lines.
 # Uses a temporary git worktree so wc -l runs on local files (fast for
 # repos with 1000+ scripts). Worktree is always removed via trap.
 # Outputs TSV: git-path TAB line-count  (sorted by path).
@@ -200,7 +200,7 @@ write_report() {
 		printf '| Metric | Base (`%s`) | Head (`%s`) | Delta |\n' \
 			"${_base_sha:0:7}" "${_head_sha:0:7}"
 		printf '|---|---:|---:|---:|\n'
-		printf '| Files >%d lines | %d | %d | %+d |\n\n' \
+		printf '| Non-README Markdown files >%d lines | %d | %d | %+d |\n\n' \
 			"$FILE_SIZE_DEFAULT_LIMIT" "$_base_count" "$_head_count" "$_net_delta"
 		if [ "$_is_regression" -eq 1 ] && [ -n "$_new_paths" ]; then
 			printf '### New oversized files\n\n'

--- a/.agents/scripts/linters-local-analysis.sh
+++ b/.agents/scripts/linters-local-analysis.sh
@@ -721,14 +721,16 @@ append_file_size_result() {
 # =============================================================================
 # File Size Check — ratchet-based gate (t2938)
 # =============================================================================
-# Block only when this commit introduces a net increase in files >1500 lines,
-# or adds a brand-new file >1500 lines. Pre-existing debt does not block.
+# Block only when this commit introduces a net increase in non-README Markdown
+# files >500 lines, or adds a brand-new non-README Markdown file >500 lines.
+# Code file size is not gated here; function-complexity/nesting-depth gates
+# provide more actionable code limits. Pre-existing debt does not block.
 # Framework rule: t2228 — "Any gate MUST be ratchet-based: block only on regressions."
 #
 # Parity: matches the per-file regression check in code-quality.yml "File size check"
 # step, which already uses complexity-regression-helper.sh with the same semantics.
 #
-# The WARN advisory (files >800 lines) is unchanged — informational only.
+# The local display mirrors the ratchet scope: non-README Markdown only.
 
 check_file_size() {
 	echo -e "${BLUE}Checking File Size (ratchet gate — t2938)...${NC}"
@@ -741,15 +743,12 @@ check_file_size() {
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -f '${tmp_file}'"
 
-	for file in "${ALL_SH_FILES[@]}"; do
+	local md_files=""
+	md_files=$(git ls-files '*.md' 2>/dev/null | grep -Ev '(^|/)README\.md$|_archive/' || true)
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
 		append_file_size_result "$file" "$tmp_file" "$MAX_FILE_LINES_WARN" "$MAX_FILE_LINES_BLOCK"
-	done
-
-	# Also check Python files in the scripts directory (shared discovery)
-	lint_python_files_local
-	for file in "${LINT_PY_FILES_LOCAL[@]}"; do
-		append_file_size_result "$file" "$tmp_file" "$MAX_FILE_LINES_WARN" "$MAX_FILE_LINES_BLOCK"
-	done
+	done <<<"$md_files"
 
 	if [[ -s "$tmp_file" ]]; then
 		block_violations=$(safe_grep_count '^BLOCK' "$tmp_file")
@@ -759,10 +758,10 @@ check_file_size() {
 		block_violations=${block_violations:-0}
 		warn_violations=${warn_violations:-0}
 
-		# Advisory display — show WARN and BLOCK files for developer awareness.
+		# Advisory display — show non-README Markdown files for developer awareness.
 		# These are informational; the ratchet gate below decides whether to block.
 		if [[ "$block_violations" -gt 0 ]]; then
-			print_warning "File size: $block_violations files exceed ${MAX_FILE_LINES_BLOCK} lines (should be split)"
+			print_warning "File size: $block_violations non-README Markdown files exceed ${MAX_FILE_LINES_BLOCK} lines (should be split or indexed)"
 			grep '^BLOCK' "$tmp_file" | sed 's/^BLOCK /  /' | head -10
 		fi
 
@@ -781,35 +780,16 @@ check_file_size() {
 		return 0
 	fi
 
-	# Detect docs-only changes: if no .sh or .py files are staged/modified, skip.
-	local changed_code_files
-	changed_code_files=$(git diff --name-only HEAD 2>/dev/null | grep -cE '\.(sh|py)$' || true)
-	changed_code_files=${changed_code_files//[^0-9]/}
-	changed_code_files=${changed_code_files:-0}
-	if [[ "$changed_code_files" -eq 0 ]]; then
-		local staged_code
-		staged_code=$(git diff --cached --name-only 2>/dev/null | grep -cE '\.(sh|py)$' || true)
-		staged_code=${staged_code//[^0-9]/}
-		staged_code=${staged_code:-0}
-		changed_code_files=$((changed_code_files + staged_code))
-	fi
-
-	if [[ "$changed_code_files" -eq 0 ]]; then
-		local total=$((block_violations + warn_violations))
-		print_info "File size: docs-only commit detected — ratchet gate skipped. $total oversized files (advisory)."
-		return 0
-	fi
-
 	local ratchet_exit=0
 	"$helper_script" check || ratchet_exit=$?
 
 	if [[ "$ratchet_exit" -eq 0 ]]; then
 		local total=$((block_violations + warn_violations))
-		print_success "File size: no regression. $total oversized files ($block_violations over ${MAX_FILE_LINES_BLOCK}, $warn_violations advisory). Tracked by #21146."
+		print_success "File size: no regression. $total oversized non-README Markdown files ($block_violations over ${MAX_FILE_LINES_BLOCK}, $warn_violations advisory). Tracked by #21146."
 		return 0
 	fi
 
-	print_error "File size: regression — new file(s) added over ${MAX_FILE_LINES_BLOCK} lines. Split before committing, or add the 'complexity-bump-ok' label in the PR."
+	print_error "File size: regression — new non-README Markdown file(s) added over ${MAX_FILE_LINES_BLOCK} lines. Split/index before committing, or add the 'complexity-bump-ok' label in the PR."
 	return 1
 }
 

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -74,13 +74,14 @@ readonly MAX_STRING_LITERAL_ISSUES=2300
 # Thresholds are set above the current baseline to catch regressions, not existing debt.
 # Existing debt is tracked by the code-simplifier (priority 8, human-gated).
 #
-# Baseline (2026-03-16): 404 functions >100 lines, 245 files >8 nesting, 33 files >1500 lines
+# Baseline (2026-03-16): 404 functions >100 lines, 245 files >8 nesting.
 # These thresholds allow the current baseline but block significant new additions.
 # Reduce thresholds as existing debt is paid down.
 #
 # - Function length: warn >50, block >100. Threshold allows current 404 + small margin.
 # - Nesting depth: warn >5, block >8. Threshold allows current 245 + small margin.
-# - File size: warn >800, block >1500. Gate is now ratchet-based (t2938) —
+# - File size: non-README Markdown >500 lines. Code file size is not gated;
+#   function length and nesting-depth gates provide actionable code limits.
 #   MAX_FILE_SIZE_VIOLATIONS removed; ratchet compares against origin/main HEAD.
 readonly MAX_FUNCTION_LENGTH_WARN=50
 readonly MAX_FUNCTION_LENGTH_BLOCK=100
@@ -88,8 +89,8 @@ readonly MAX_FUNCTION_LENGTH_VIOLATIONS=420
 readonly MAX_NESTING_DEPTH_WARN=5
 readonly MAX_NESTING_DEPTH_BLOCK=8
 readonly MAX_NESTING_VIOLATIONS=260
-readonly MAX_FILE_LINES_WARN=800
-readonly MAX_FILE_LINES_BLOCK=1500
+readonly MAX_FILE_LINES_WARN=500
+readonly MAX_FILE_LINES_BLOCK=500
 
 print_header() {
 	echo -e "${BLUE}Local Linters - Fast Offline Quality Checks${NC}"

--- a/.agents/scripts/tests/test-complexity-regression-helper.sh
+++ b/.agents/scripts/tests/test-complexity-regression-helper.sh
@@ -12,10 +12,11 @@
 #   6.  dry-run:                     --dry-run scans current tree and exits 0 regardless
 #   7.  nesting-depth clean-to-new:  new file with depth 10 → exit 1 (t2171)
 #   8.  nesting-depth stable:        pre-existing deep file unchanged → exit 0 (t2171)
-#   9.  file-size clean-to-new:      new 2000-line .sh → exit 1 (t2171)
-#   10. file-size stable:            pre-existing 2000-line file unchanged → exit 0 (t2171)
-#   11. bash32-compat clean-to-new:  new associative-array declaration → exit 1 (t2171)
-#   12. bash32-compat stable:        pre-existing nameref unchanged → exit 0 (t2171)
+#   9.  file-size clean-to-new:      new 501-line .md → exit 1 (t2171)
+#   10. file-size stable:            pre-existing 501-line .md unchanged → exit 0 (t2171)
+#   11. file-size ignores code/readme: oversized .sh + README.md → exit 0
+#   12. bash32-compat clean-to-new:  new associative-array declaration → exit 1 (t2171)
+#   13. bash32-compat stable:        pre-existing nameref unchanged → exit 0 (t2171)
 
 set -euo pipefail
 
@@ -398,7 +399,7 @@ test_nesting_stable() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 9: file-size — clean-to-new. Head adds a 2000-line .sh file → exit 1.
+# Test 9: file-size — clean-to-new. Head adds a 501-line .md file → exit 1.
 # ---------------------------------------------------------------------------
 test_file_size_clean_to_new() {
 	setup
@@ -406,9 +407,9 @@ test_file_size_clean_to_new() {
 	local _head_dir="$TEST_ROOT/head"
 	mkdir -p "$_base_dir" "$_head_dir"
 
-	make_large_file "$_base_dir/small.sh" 100
-	cp "$_base_dir/small.sh" "$_head_dir/small.sh"
-	make_large_file "$_head_dir/huge.sh" 2000
+	make_large_file "$_base_dir/small.md" 100
+	cp "$_base_dir/small.md" "$_head_dir/small.md"
+	make_large_file "$_head_dir/huge.md" 501
 
 	local _base_scan="$TEST_ROOT/base.tsv"
 	local _head_scan="$TEST_ROOT/head.tsv"
@@ -418,16 +419,16 @@ test_file_size_clean_to_new() {
 	run_diff "$_base_scan" "$_head_scan" file-size
 
 	if [ "$_DIFF_EXIT" -eq 1 ]; then
-		print_result "file-size: new 2000-line .sh → exit 1" 0
+		print_result "file-size: new 501-line .md → exit 1" 0
 	else
-		print_result "file-size: new 2000-line .sh → exit 1" 1 "got exit $_DIFF_EXIT"
+		print_result "file-size: new 501-line .md → exit 1" 1 "got exit $_DIFF_EXIT"
 	fi
 	teardown
 	return 0
 }
 
 # ---------------------------------------------------------------------------
-# Test 10: file-size — stable. Same 2000-line file at both → exit 0.
+# Test 10: file-size — stable. Same 501-line Markdown file at both → exit 0.
 # ---------------------------------------------------------------------------
 test_file_size_stable() {
 	setup
@@ -435,8 +436,8 @@ test_file_size_stable() {
 	local _head_dir="$TEST_ROOT/head"
 	mkdir -p "$_base_dir" "$_head_dir"
 
-	make_large_file "$_base_dir/huge.sh" 2000
-	cp "$_base_dir/huge.sh" "$_head_dir/huge.sh"
+	make_large_file "$_base_dir/huge.md" 501
+	cp "$_base_dir/huge.md" "$_head_dir/huge.md"
 
 	local _base_scan="$TEST_ROOT/base.tsv"
 	local _head_scan="$TEST_ROOT/head.tsv"
@@ -446,16 +447,44 @@ test_file_size_stable() {
 	run_diff "$_base_scan" "$_head_scan" file-size
 
 	if [ "$_DIFF_EXIT" -eq 0 ]; then
-		print_result "file-size: pre-existing 2000-line file unchanged → exit 0" 0
+		print_result "file-size: pre-existing 501-line md unchanged → exit 0" 0
 	else
-		print_result "file-size: pre-existing 2000-line file unchanged → exit 0" 1 "got exit $_DIFF_EXIT"
+		print_result "file-size: pre-existing 501-line md unchanged → exit 0" 1 "got exit $_DIFF_EXIT"
 	fi
 	teardown
 	return 0
 }
 
 # ---------------------------------------------------------------------------
-# Test 11: bash32-compat — clean-to-new. Head adds associative-array
+# Test 11: file-size — oversized code files and README.md are ignored.
+# ---------------------------------------------------------------------------
+test_file_size_ignores_code_and_readme() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	make_large_file "$_head_dir/huge.sh" 2000
+	make_large_file "$_head_dir/README.md" 1000
+
+	local _base_scan="$TEST_ROOT/base.tsv"
+	local _head_scan="$TEST_ROOT/head.tsv"
+	"$HELPER" scan "$_base_dir" --output "$_base_scan" --metric file-size
+	"$HELPER" scan "$_head_dir" --output "$_head_scan" --metric file-size
+
+	run_diff "$_base_scan" "$_head_scan" file-size
+
+	if [ "$_DIFF_EXIT" -eq 0 ]; then
+		print_result "file-size: oversized code and README ignored → exit 0" 0
+	else
+		print_result "file-size: oversized code and README ignored → exit 0" 1 "got exit $_DIFF_EXIT"
+	fi
+	teardown
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 12: bash32-compat — clean-to-new. Head adds associative-array
 # declaration (bash 4.0+ only) → exit 1.
 # ---------------------------------------------------------------------------
 test_bash32_clean_to_new() {
@@ -485,7 +514,7 @@ test_bash32_clean_to_new() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 12: bash32-compat — stable. Existing nameref at base and head → exit 0.
+# Test 13: bash32-compat — stable. Existing nameref at base and head → exit 0.
 # ---------------------------------------------------------------------------
 test_bash32_stable() {
 	setup
@@ -513,7 +542,7 @@ test_bash32_stable() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 13: diff-scoped check — 2 changed .sh files detected in <15s (t2827)
+# Test 14: diff-scoped check — 2 changed .sh files detected in <15s (t2827)
 #
 # Creates a real git repo (required for `check` which uses git worktrees),
 # makes a base commit with small functions, a head commit adding a 105-line
@@ -567,7 +596,7 @@ test_diff_scoped_timing() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 14: diff-scoped skip — doc-only diff (no .sh/.py changes) exits 0 (t2827)
+# Test 15: diff-scoped skip — doc-only diff (no .sh/.py changes) exits 0 (t2827)
 #
 # When the diff between base and head contains no .sh or .py files, the check
 # subcommand should exit 0 immediately without creating any worktrees.
@@ -627,6 +656,7 @@ test_nesting_clean_to_new
 test_nesting_stable
 test_file_size_clean_to_new
 test_file_size_stable
+test_file_size_ignores_code_and_readme
 test_bash32_clean_to_new
 test_bash32_stable
 test_diff_scoped_timing

--- a/.agents/scripts/tests/test-file-size-regression-helper.sh
+++ b/.agents/scripts/tests/test-file-size-regression-helper.sh
@@ -8,9 +8,10 @@
 #   1. zero-violation baseline  — no files over limit at base or head → exit 0
 #   2. baseline-equals-head     — same set of violations at base and head → exit 0
 #   3. head-greater-than-base   — head adds a new oversized file → exit 1
-#   4. new-file-over-limit      — new file >1500 lines even though net count is
+#   4. new-file-over-limit      — new file >500 lines even though net count is
 #                                 unchanged (one removed, one added) → exit 1
 #   5. docs-only                — --docs-only flag skips gate → exit 0
+#   6. code-and-readme-ignored  — oversized code and README.md do not count
 #
 # Usage: bash .agents/scripts/tests/test-file-size-regression-helper.sh
 # Requires: the helper at .agents/scripts/file-size-regression-helper.sh
@@ -67,17 +68,17 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# make_sh_file <path> <lines>
-# Create a shell script file with exactly <lines> trivial no-op lines.
+# make_doc_file <path> <lines>
+# Create a Markdown/doc fixture file with exactly <lines> trivial lines.
 # ---------------------------------------------------------------------------
-make_sh_file() {
+make_doc_file() {
 	local _path="$1"
 	local _lines="$2"
 	mkdir -p "$(dirname "$_path")"
-	printf '#!/usr/bin/env bash\n' > "$_path"
-	local _i=1
+	: >"$_path"
+	local _i=0
 	while [ "$_i" -lt "$_lines" ]; do
-		printf ': # pad %d\n' "$_i" >> "$_path"
+		printf 'doc line %d\n' "$_i" >>"$_path"
 		_i=$((_i + 1))
 	done
 	return 0
@@ -118,9 +119,9 @@ test_zero_violation_baseline() {
 	local _head_dir="$TEST_ROOT/head"
 	mkdir -p "$_base_dir" "$_head_dir"
 
-	# Both base and head have a small file (well under 1500 lines)
-	make_sh_file "$_base_dir/small.sh" 100
-	make_sh_file "$_head_dir/small.sh" 100
+	# Both base and head have a small Markdown file (well under 500 lines)
+	make_doc_file "$_base_dir/small.md" 100
+	make_doc_file "$_head_dir/small.md" 100
 
 	local _base_tsv="$TEST_ROOT/base.tsv"
 	local _head_tsv="$TEST_ROOT/head.tsv"
@@ -149,8 +150,8 @@ test_baseline_equals_head() {
 	mkdir -p "$_base_dir" "$_head_dir"
 
 	# Both base and head have the same large file
-	make_sh_file "$_base_dir/big.sh" 1600
-	make_sh_file "$_head_dir/big.sh" 1600
+	make_doc_file "$_base_dir/big.md" 501
+	make_doc_file "$_head_dir/big.md" 501
 
 	local _base_tsv="$TEST_ROOT/base.tsv"
 	local _head_tsv="$TEST_ROOT/head.tsv"
@@ -179,11 +180,11 @@ test_head_greater_than_base() {
 	mkdir -p "$_base_dir" "$_head_dir"
 
 	# Base: one large file
-	make_sh_file "$_base_dir/existing.sh" 1600
+	make_doc_file "$_base_dir/existing.md" 501
 
 	# Head: same file plus a new oversized file
-	make_sh_file "$_head_dir/existing.sh" 1600
-	make_sh_file "$_head_dir/new_giant.sh" 2000
+	make_doc_file "$_head_dir/existing.md" 501
+	make_doc_file "$_head_dir/new_giant.md" 600
 
 	local _base_tsv="$TEST_ROOT/base.tsv"
 	local _head_tsv="$TEST_ROOT/head.tsv"
@@ -205,8 +206,8 @@ test_head_greater_than_base() {
 # ===========================================================================
 # Test 4: new-file-over-limit — net count unchanged but new file added → exit 1
 #
-# Scenario: base has file A (>1500 lines). Head removes A but adds file B
-# (>1500 lines). Net count: same (1). Still a regression because B is a new
+# Scenario: base has file A (>500 lines). Head removes A but adds file B
+# (>500 lines). Net count: same (1). Still a regression because B is a new
 # oversized file that wasn't in base. The ratchet must catch this to prevent
 # gaming the gate by cycling oversized files.
 # ===========================================================================
@@ -216,11 +217,11 @@ test_new_file_over_limit_net_unchanged() {
 	local _head_dir="$TEST_ROOT/head"
 	mkdir -p "$_base_dir" "$_head_dir"
 
-	# Base: one large file (file_a.sh)
-	make_sh_file "$_base_dir/file_a.sh" 1600
+	# Base: one large Markdown file (file_a.md)
+	make_doc_file "$_base_dir/file_a.md" 501
 
-	# Head: file_a.sh removed, file_b.sh added (different path, both >1500 lines)
-	make_sh_file "$_head_dir/file_b.sh" 1600
+	# Head: file_a.md removed, file_b.md added (different path, both >500 lines)
+	make_doc_file "$_head_dir/file_b.md" 501
 
 	local _base_tsv="$TEST_ROOT/base.tsv"
 	local _head_tsv="$TEST_ROOT/head.tsv"
@@ -254,9 +255,9 @@ test_docs_only_skip() {
 	mkdir -p "$_base_dir" "$_head_dir"
 
 	# Head has more violations than base — would normally fail
-	make_sh_file "$_base_dir/existing.sh" 1600
-	make_sh_file "$_head_dir/existing.sh" 1600
-	make_sh_file "$_head_dir/also_big.sh" 1700
+	make_doc_file "$_base_dir/existing.md" 501
+	make_doc_file "$_head_dir/existing.md" 501
+	make_doc_file "$_head_dir/also_big.md" 600
 
 	local _base_tsv="$TEST_ROOT/base.tsv"
 	local _head_tsv="$TEST_ROOT/head.tsv"
@@ -270,6 +271,36 @@ test_docs_only_skip() {
 		print_result "docs-only: --docs-only flag skips gate → exit 0" 0
 	else
 		print_result "docs-only: --docs-only flag skips gate → exit 0" 1 \
+			"got exit $_DIFF_EXIT, expected 0"
+	fi
+	teardown
+	return 0
+}
+
+# ===========================================================================
+# Test 6: code-and-readme-ignored — oversized code and README.md do not count
+# ===========================================================================
+test_code_and_readme_ignored() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	make_doc_file "$_head_dir/README.md" 1000
+	make_doc_file "$_head_dir/script.sh" 1000
+	make_doc_file "$_head_dir/module.py" 1000
+
+	local _base_tsv="$TEST_ROOT/base.tsv"
+	local _head_tsv="$TEST_ROOT/head.tsv"
+	run_scan "$_base_dir" "$_base_tsv"
+	run_scan "$_head_dir" "$_head_tsv"
+
+	run_diff "$_base_tsv" "$_head_tsv"
+
+	if [ "$_DIFF_EXIT" -eq 0 ]; then
+		print_result "code-and-readme-ignored: oversized code and README.md → exit 0" 0
+	else
+		print_result "code-and-readme-ignored: oversized code and README.md → exit 0" 1 \
 			"got exit $_DIFF_EXIT, expected 0"
 	fi
 	teardown
@@ -293,6 +324,7 @@ main() {
 	test_head_greater_than_base
 	test_new_file_over_limit_net_unchanged
 	test_docs_only_skip
+	test_code_and_readme_ignored
 
 	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 

--- a/.agents/scripts/tests/test-linters-local-complexity-gates.sh
+++ b/.agents/scripts/tests/test-linters-local-complexity-gates.sh
@@ -113,8 +113,8 @@ source_linter_analysis() {
 	MAX_NESTING_DEPTH_WARN=5
 	MAX_NESTING_DEPTH_BLOCK=8
 	MAX_NESTING_VIOLATIONS=1
-	MAX_FILE_LINES_WARN=800
-	MAX_FILE_LINES_BLOCK=1500
+	MAX_FILE_LINES_WARN=500
+	MAX_FILE_LINES_BLOCK=500
 	# shellcheck source=../linters-local-analysis.sh
 	source "${REPO_ROOT}/.agents/scripts/linters-local-analysis.sh"
 	return 0

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -662,7 +662,9 @@ jobs:
 
     - name: File size check
       # t2171 + t2938: ratchet gate — block only when the PR introduces a net
-      # increase in files >1500 lines, or adds a brand-new oversized file.
+      # increase in non-README Markdown files >500 lines, or adds a brand-new
+      # oversized non-README Markdown file. Code file size is not gated here;
+      # function-complexity/nesting-depth gates provide actionable code limits.
       # Pre-existing debt does not block. Matches linters-local.sh (t2228 rule).
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -676,7 +678,7 @@ jobs:
         set -euo pipefail
 
         # --- Informational: total violation count (no threshold gate) ---
-        echo "Scanning file sizes (>1500 lines)..."
+        echo "Scanning non-README Markdown file sizes (>500 lines)..."
         total_out=$(.agents/scripts/complexity-regression-helper.sh check --dry-run \
           --metric file-size 2>/dev/null \
           | grep '^Total violations' || echo "Total violations (file-size): unknown")
@@ -731,11 +733,11 @@ jobs:
         fi
 
         if [ "${HAS_OVERRIDE}" = "true" ]; then
-          echo "::warning::New file size violations detected but 'complexity-bump-ok' label is set — allowing with warning."
+          echo "::warning::New non-README Markdown file size violations detected but 'complexity-bump-ok' label is set — allowing with warning."
           exit 0
         fi
 
-        echo "::error::New file size violations introduced in this PR. Add the 'complexity-bump-ok' label with a '## Complexity Bump Justification' section to override."
+        echo "::error::New non-README Markdown file size violations introduced in this PR. Add the 'complexity-bump-ok' label with a '## Complexity Bump Justification' section to override."
         exit 1
 
     - name: Python cyclomatic complexity (Lizard)


### PR DESCRIPTION
## Summary
- Retarget file-size gates from oversized code files to non-README Markdown files over 500 lines.
- Keep code scalability governed by function-complexity and nesting-depth gates instead of whole-file line count.
- Align local lint output, CI wording, helper defaults, and regression tests with the new policy.

## Verification
- `bash -n .agents/scripts/linters-local.sh .agents/scripts/linters-local-analysis.sh .agents/scripts/complexity-regression-helper.sh .agents/scripts/file-size-regression-helper.sh .agents/scripts/tests/test-complexity-regression-helper.sh .agents/scripts/tests/test-file-size-regression-helper.sh .agents/scripts/tests/test-linters-local-complexity-gates.sh`
- `shellcheck .agents/scripts/linters-local.sh .agents/scripts/linters-local-analysis.sh .agents/scripts/complexity-regression-helper.sh .agents/scripts/file-size-regression-helper.sh .agents/scripts/tests/test-complexity-regression-helper.sh .agents/scripts/tests/test-file-size-regression-helper.sh .agents/scripts/tests/test-linters-local-complexity-gates.sh`
- `.agents/scripts/tests/test-complexity-regression-helper.sh` — 15 tests passed
- `.agents/scripts/tests/test-file-size-regression-helper.sh` — 6 tests passed
- `bash .agents/scripts/tests/test-linters-local-complexity-gates.sh` — 5 tests passed
- `.agents/scripts/linters-local.sh` — passed; Markdown style and ratchet debt warnings are advisory/pre-existing

Ref #25993

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.9 plugin for [OpenCode](https://opencode.ai) v1.17.12
