### PR TITLE
GH#26156: fix OpenAI token refresh recovery

### DIFF
--- a/.agents/plugins/opencode-aidevops/openai-auth-refresh-recovery.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-auth-refresh-recovery.mjs
@@ -1,0 +1,78 @@
+/**
+ * OpenAI OAuth refresh recovery.
+ *
+ * OpenCode refreshes built-in OpenAI OAuth credentials via auth.openai.com
+ * before its model request reaches api.openai.com/v1/*. A 401/403 there would
+ * otherwise surface as `Token refresh failed: 401` and stop the session before
+ * the normal OpenAI API fetch rotation path can run.
+ */
+
+import { getAccounts, markAuthRefreshFailure, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
+import { OPENAI_TOKEN_ENDPOINT } from "./oauth-pool-constants.mjs";
+
+const TOKEN_REFRESH_FAILURE_STATUSES = new Set([401, 403]);
+
+function requestUrl(input) {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input?.url || "";
+}
+
+export function isOpenAITokenRefreshRequest(input) {
+  try {
+    const url = new URL(requestUrl(input));
+    const endpoint = new URL(OPENAI_TOKEN_ENDPOINT);
+    return url.origin === endpoint.origin && url.pathname === endpoint.pathname;
+  } catch { return false; }
+}
+
+export async function readOpenAITokenRefreshBody(input, init) {
+  let bodyText = "";
+  try {
+    if (typeof init?.body === "string") bodyText = init.body;
+    else if (init?.body instanceof URLSearchParams) bodyText = init.body.toString();
+    else if (typeof Request !== "undefined" && input instanceof Request) bodyText = await input.clone().text();
+  } catch {
+    // Best-effort: request body may be a non-cloneable stream.
+  }
+  return bodyText;
+}
+
+function extractOpenAIRefreshToken(bodyText) {
+  let refreshToken = "";
+  try {
+    const params = new URLSearchParams(bodyText);
+    if (params.get("grant_type") === "refresh_token") refreshToken = params.get("refresh_token") || "";
+  } catch { /* malformed form body: no matching pool account */ }
+  return refreshToken;
+}
+
+function resolveOpenAIRefreshAccount(bodyText) {
+  const refreshToken = extractOpenAIRefreshToken(bodyText);
+  return getAccounts("openai").find((account) => account.refresh === refreshToken) || null;
+}
+
+function buildOpenAITokenRefreshResponse(account) {
+  const expiresAt = Number(account.expires) || Date.now() + 3600_000;
+  const expiresIn = Math.max(1, Math.floor((expiresAt - Date.now()) / 1000));
+  return new Response(JSON.stringify({
+    access_token: account.access,
+    refresh_token: account.refresh,
+    expires_in: expiresIn,
+    token_type: "Bearer",
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function handleOpenAITokenRefreshFailure(ctx) {
+  const { client, response, bodyText } = ctx;
+  if (!TOKEN_REFRESH_FAILURE_STATUSES.has(response.status)) return response;
+  const current = resolveOpenAIRefreshAccount(bodyText);
+  const currentEmail = current?.email || "unknown";
+  if (current) markAuthRefreshFailure("openai", current);
+  console.error(`[aidevops] OpenAI provider: token refresh failed (${response.status}) for ${currentEmail} — rotating pool account`);
+  const rotated = await rotateOpenAIPoolToken(client, current?.email);
+  return rotated?.access ? buildOpenAITokenRefreshResponse(rotated) : response;
+}

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -186,23 +186,20 @@ async function handleOpenAIFetchRequest(ctx) {
   const retryInput = openaiRequest ? buildRetryRequest(input) : input;
   const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
   const response = await originalFetch(input, firstInit);
+  let result = response;
 
   if (tokenRefreshRequest) {
-    return handleOpenAITokenRefreshFailure({
+    result = await handleOpenAITokenRefreshFailure({
       client,
       response,
       bodyText: tokenRefreshBody,
     });
-  }
-  if (!openaiRequest) return response;
-  if (await isOpenAIUsageLimitResponse(response)) {
-    return handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
-  }
-  if (await isOpenAIOverloadResponse(response)) {
-    return handleOpenAIOverload({ client, originalFetch, init: firstInit, response, retryInput });
-  }
-  if (response.ok) {
-    return wrapOpenAIOverloadStream({
+  } else if (openaiRequest && await isOpenAIUsageLimitResponse(response)) {
+    result = await handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
+  } else if (openaiRequest && await isOpenAIOverloadResponse(response)) {
+    result = await handleOpenAIOverload({ client, originalFetch, init: firstInit, response, retryInput });
+  } else if (openaiRequest && response.ok) {
+    result = wrapOpenAIOverloadStream({
       originalFetch,
       response,
       retryInput,
@@ -211,7 +208,7 @@ async function handleOpenAIFetchRequest(ctx) {
       onRetry: (retry) => notifyOpenAIOverloadRetry(client, retry),
     });
   }
-  return response;
+  return result;
 }
 
 export function installOpenAIProviderFetchRotation(client) {

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -6,16 +6,16 @@
  * usage-limited accounts and retries once with another pooled account.
  */
 
-import { getAccounts, markAuthRefreshFailure, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
-import { OPENAI_TOKEN_ENDPOINT } from "./oauth-pool-constants.mjs";
+import { getAccounts, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
 import { annotateOpenAIOverloadResponse, formatRetryDelay, isOpenAIOverloadText, overloadRetryDelaysMs, sleep, wrapOpenAIOverloadStream } from "./openai-overload-retry.mjs";
+import { handleOpenAITokenRefreshFailure, isOpenAITokenRefreshRequest, readOpenAITokenRefreshBody } from "./openai-auth-refresh-recovery.mjs";
 
 export { isOpenAIOverloadText } from "./openai-overload-retry.mjs";
+export { isOpenAITokenRefreshRequest } from "./openai-auth-refresh-recovery.mjs";
 
 const OPENAI_API_HOST = "api.openai.com";
 const OPENAI_API_PREFIX = "/v1/";
 const DEFAULT_OPENAI_COOLDOWN_MS = 300_000;
-const TOKEN_REFRESH_FAILURE_STATUSES = new Set([401, 403]);
 const USAGE_LIMIT_MARKERS = [
   "usage limit",
   "rate limit",
@@ -47,14 +47,6 @@ export function isOpenAIProviderRequest(input) {
   try {
     const url = new URL(requestUrl(input));
     return url.hostname === OPENAI_API_HOST && url.pathname.startsWith(OPENAI_API_PREFIX);
-  } catch { return false; }
-}
-
-export function isOpenAITokenRefreshRequest(input) {
-  try {
-    const url = new URL(requestUrl(input));
-    const endpoint = new URL(OPENAI_TOKEN_ENDPOINT);
-    return url.origin === endpoint.origin && url.pathname === endpoint.pathname;
   } catch { return false; }
 }
 
@@ -124,54 +116,6 @@ function buildRetryInit(input, init, accessToken) {
   return retryInit;
 }
 
-async function readRequestBodyText(input, init) {
-  try {
-    if (typeof init?.body === "string") return init.body;
-    if (init?.body instanceof URLSearchParams) return init.body.toString();
-    if (typeof Request !== "undefined" && input instanceof Request) return await input.clone().text();
-  } catch { /* best-effort: request body may be a non-cloneable stream */ }
-  return "";
-}
-
-function extractOpenAIRefreshToken(bodyText) {
-  try {
-    const params = new URLSearchParams(bodyText);
-    if (params.get("grant_type") !== "refresh_token") return "";
-    return params.get("refresh_token") || "";
-  } catch { return ""; }
-}
-
-function resolveOpenAIRefreshAccount(refreshToken) {
-  if (!refreshToken) return null;
-  return getAccounts("openai").find((account) => account.refresh === refreshToken) || null;
-}
-
-function buildOpenAITokenRefreshResponse(account) {
-  const expiresAt = Number(account.expires) || Date.now() + 3600_000;
-  const expiresIn = Math.max(1, Math.floor((expiresAt - Date.now()) / 1000));
-  return new Response(JSON.stringify({
-    access_token: account.access,
-    refresh_token: account.refresh,
-    expires_in: expiresIn,
-    token_type: "Bearer",
-  }), {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-async function handleOpenAITokenRefreshFailure(ctx) {
-  const { client, response, refreshToken } = ctx;
-  if (!TOKEN_REFRESH_FAILURE_STATUSES.has(response.status)) return response;
-  const current = resolveOpenAIRefreshAccount(refreshToken);
-  const currentEmail = current?.email || "unknown";
-  if (current) markAuthRefreshFailure("openai", current);
-  console.error(`[aidevops] OpenAI provider: token refresh failed (${response.status}) for ${currentEmail} — rotating pool account`);
-  const rotated = await rotateOpenAIPoolToken(client, current?.email);
-  if (!rotated?.access) return response;
-  return buildOpenAITokenRefreshResponse(rotated);
-}
-
 async function handleOpenAIUsageLimit(ctx) {
   const { client, originalFetch, input, init, response, retryInput } = ctx;
   const current = resolveOpenAIAccount(extractBearerToken(input, init));
@@ -238,7 +182,7 @@ async function handleOpenAIFetchRequest(ctx) {
   const { client, originalFetch, input, init } = ctx;
   const openaiRequest = isOpenAIProviderRequest(input);
   const tokenRefreshRequest = isOpenAITokenRefreshRequest(input);
-  const tokenRefreshBody = tokenRefreshRequest ? await readRequestBodyText(input, init) : "";
+  const tokenRefreshBody = tokenRefreshRequest ? await readOpenAITokenRefreshBody(input, init) : "";
   const retryInput = openaiRequest ? buildRetryRequest(input) : input;
   const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
   const response = await originalFetch(input, firstInit);
@@ -247,7 +191,7 @@ async function handleOpenAIFetchRequest(ctx) {
     return handleOpenAITokenRefreshFailure({
       client,
       response,
-      refreshToken: extractOpenAIRefreshToken(tokenRefreshBody),
+      bodyText: tokenRefreshBody,
     });
   }
   if (!openaiRequest) return response;

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -6,7 +6,8 @@
  * usage-limited accounts and retries once with another pooled account.
  */
 
-import { getAccounts, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
+import { getAccounts, markAuthRefreshFailure, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
+import { OPENAI_TOKEN_ENDPOINT } from "./oauth-pool-constants.mjs";
 import { annotateOpenAIOverloadResponse, formatRetryDelay, isOpenAIOverloadText, overloadRetryDelaysMs, sleep, wrapOpenAIOverloadStream } from "./openai-overload-retry.mjs";
 
 export { isOpenAIOverloadText } from "./openai-overload-retry.mjs";
@@ -14,6 +15,7 @@ export { isOpenAIOverloadText } from "./openai-overload-retry.mjs";
 const OPENAI_API_HOST = "api.openai.com";
 const OPENAI_API_PREFIX = "/v1/";
 const DEFAULT_OPENAI_COOLDOWN_MS = 300_000;
+const TOKEN_REFRESH_FAILURE_STATUSES = new Set([401, 403]);
 const USAGE_LIMIT_MARKERS = [
   "usage limit",
   "rate limit",
@@ -45,6 +47,14 @@ export function isOpenAIProviderRequest(input) {
   try {
     const url = new URL(requestUrl(input));
     return url.hostname === OPENAI_API_HOST && url.pathname.startsWith(OPENAI_API_PREFIX);
+  } catch { return false; }
+}
+
+export function isOpenAITokenRefreshRequest(input) {
+  try {
+    const url = new URL(requestUrl(input));
+    const endpoint = new URL(OPENAI_TOKEN_ENDPOINT);
+    return url.origin === endpoint.origin && url.pathname === endpoint.pathname;
   } catch { return false; }
 }
 
@@ -114,6 +124,54 @@ function buildRetryInit(input, init, accessToken) {
   return retryInit;
 }
 
+async function readRequestBodyText(input, init) {
+  try {
+    if (typeof init?.body === "string") return init.body;
+    if (init?.body instanceof URLSearchParams) return init.body.toString();
+    if (typeof Request !== "undefined" && input instanceof Request) return await input.clone().text();
+  } catch { /* best-effort: request body may be a non-cloneable stream */ }
+  return "";
+}
+
+function extractOpenAIRefreshToken(bodyText) {
+  try {
+    const params = new URLSearchParams(bodyText);
+    if (params.get("grant_type") !== "refresh_token") return "";
+    return params.get("refresh_token") || "";
+  } catch { return ""; }
+}
+
+function resolveOpenAIRefreshAccount(refreshToken) {
+  if (!refreshToken) return null;
+  return getAccounts("openai").find((account) => account.refresh === refreshToken) || null;
+}
+
+function buildOpenAITokenRefreshResponse(account) {
+  const expiresAt = Number(account.expires) || Date.now() + 3600_000;
+  const expiresIn = Math.max(1, Math.floor((expiresAt - Date.now()) / 1000));
+  return new Response(JSON.stringify({
+    access_token: account.access,
+    refresh_token: account.refresh,
+    expires_in: expiresIn,
+    token_type: "Bearer",
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function handleOpenAITokenRefreshFailure(ctx) {
+  const { client, response, refreshToken } = ctx;
+  if (!TOKEN_REFRESH_FAILURE_STATUSES.has(response.status)) return response;
+  const current = resolveOpenAIRefreshAccount(refreshToken);
+  const currentEmail = current?.email || "unknown";
+  if (current) markAuthRefreshFailure("openai", current);
+  console.error(`[aidevops] OpenAI provider: token refresh failed (${response.status}) for ${currentEmail} — rotating pool account`);
+  const rotated = await rotateOpenAIPoolToken(client, current?.email);
+  if (!rotated?.access) return response;
+  return buildOpenAITokenRefreshResponse(rotated);
+}
+
 async function handleOpenAIUsageLimit(ctx) {
   const { client, originalFetch, input, init, response, retryInput } = ctx;
   const current = resolveOpenAIAccount(extractBearerToken(input, init));
@@ -179,10 +237,19 @@ async function maybeRotateBeforeOpenAIFetch(client, input, init) {
 async function handleOpenAIFetchRequest(ctx) {
   const { client, originalFetch, input, init } = ctx;
   const openaiRequest = isOpenAIProviderRequest(input);
+  const tokenRefreshRequest = isOpenAITokenRefreshRequest(input);
+  const tokenRefreshBody = tokenRefreshRequest ? await readRequestBodyText(input, init) : "";
   const retryInput = openaiRequest ? buildRetryRequest(input) : input;
   const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
   const response = await originalFetch(input, firstInit);
 
+  if (tokenRefreshRequest) {
+    return handleOpenAITokenRefreshFailure({
+      client,
+      response,
+      refreshToken: extractOpenAIRefreshToken(tokenRefreshBody),
+    });
+  }
   if (!openaiRequest) return response;
   if (await isOpenAIUsageLimitResponse(response)) {
     return handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -10,10 +10,12 @@ function loadModule() {
 }
 
 test("detects OpenAI provider requests only", async () => {
-  const { isOpenAIProviderRequest } = await loadModule();
+  const { isOpenAIProviderRequest, isOpenAITokenRefreshRequest } = await loadModule();
   assert.equal(isOpenAIProviderRequest("https://api.openai.com/v1/chat/completions"), true);
   assert.equal(isOpenAIProviderRequest("https://api.openai.com/dashboard"), false);
   assert.equal(isOpenAIProviderRequest("https://example.com/v1/chat/completions"), false);
+  assert.equal(isOpenAITokenRefreshRequest("https://auth.openai.com/oauth/token"), true);
+  assert.equal(isOpenAITokenRefreshRequest("https://api.openai.com/v1/responses"), false);
 });
 
 test("detects OpenAI usage-limit responses", async () => {
@@ -89,6 +91,36 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
     assert.equal(responseRotation.pool.openai[1].status, "active");
     assert.equal(responseRotation.authWrites[0].path.id, "openai");
     assert.equal(responseRotation.authWrites[0].body.accountId, "acct_healthy");
+
+    const tokenRefreshRecovery = await withInstalledGuard({
+      openai: [
+        { email: "expired@example.com", access: "expired-token", refresh: "expired-refresh", expires: 1, status: "active", cooldownUntil: 0, lastUsed: "2026-01-02T00:00:00Z" },
+        { email: "fallback@example.com", access: "fallback-token", refresh: "fallback-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_fallback" },
+      ],
+    }, async (input, init, calls) => {
+      calls.push({ url: String(input), body: String(init?.body || "") });
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }, {
+      url: "https://auth.openai.com/oauth/token",
+      init: {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: "expired-refresh", client_id: "app_test" }).toString(),
+      },
+    });
+
+    const recoveredTokenPayload = await tokenRefreshRecovery.response.json();
+    assert.equal(tokenRefreshRecovery.response.status, 200);
+    assert.equal(recoveredTokenPayload.access_token, "fallback-token");
+    assert.equal(recoveredTokenPayload.refresh_token, "fallback-refresh");
+    assert.equal(tokenRefreshRecovery.pool.openai[0].status, "auth-error");
+    assert.equal(tokenRefreshRecovery.pool.openai[1].status, "active");
+    assert.equal(tokenRefreshRecovery.authWrites[0].path.id, "openai");
+    assert.equal(tokenRefreshRecovery.authWrites[0].body.access, "fallback-token");
+    assert.equal(tokenRefreshRecovery.authWrites[0].body.accountId, "acct_fallback");
 
     const cooldownPreflight = await withInstalledGuard({
       openai: [


### PR DESCRIPTION
## Summary

- Intercept OpenAI OAuth token endpoint 401/403 responses before OpenCode turns them into `Token refresh failed: 401` session errors.
- Mark the matching OpenAI pool account as `auth-error`, rotate to another available pool account, and return a successful token refresh payload.
- Add regression coverage for OpenAI token refresh endpoint recovery alongside existing API request rotation coverage.

Resolves #26156

## Verification

```bash
node --test .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs .agents/plugins/opencode-aidevops/tests/test-provider-auth-getauth-recovery.mjs .agents/plugins/opencode-aidevops/tests/test-oauth-refresh-backoff.mjs
node --test .agents/plugins/opencode-aidevops/tests/*.mjs
git diff --check
qlty check .agents/plugins/opencode-aidevops/openai-provider-auth.mjs
```

## Notes

`.agents/scripts/linters-local.sh` was attempted twice and timed out at the shell-portability phase after plugin tests passed and unrelated advisory markdown/ratchet warnings were reported. The deterministic failure from `full-loop-helper.sh commit-and-pr` was `npm run typecheck` -> `tsc: command not found`, indicating missing local TypeScript tooling rather than a code type error.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.11 with gpt-5.5 spent 38m and 461,003 tokens on this with the user in an interactive session.