### PR TITLE
GH#26159: guide new-topic session hygiene

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -46,6 +46,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
 - Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
 - During in-progress work, classify new user messages before acting: immediate correction/steerage changes the active plan; supplemental context is retained/applied when relevant; follow-up work becomes a todo after the current work reaches a safe pause or completion point.
+- Interactive sessions with active prior task context: if the user starts a clearly unrelated objective where clean context would materially help, briefly recommend `/new` or a new tab and ask whether to continue here. Details: `reference/session.md`.
 - Drive to verified completion. Run relevant tests/lint/build before claiming done; if not verified, say so.
 - Never present intent as completed work. Every claim needs proof: path, command result, PR/issue number, or metric.
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -16,6 +16,18 @@ Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers). Long-r
 - Cleanup: commit or stash changes, then run `wt merge` to clean merged worktrees.
 - Full docs: `workflows/session-manager.md`.
 
+## New Topic Hygiene
+
+Use only in interactive sessions; headless workers stay on their assigned task.
+
+Trigger only when meaningful prior task context exists and the user starts a clearly unrelated objective where context isolation would materially improve quality, safety, or efficiency. Do not trigger for short one-off questions, follow-ups, clarifications, corrections, implementation phases, active-task dependencies, planned task queues, or related discoveries.
+
+Before doing the new work, respond briefly:
+
+> This looks like a separate topic. For cleaner context, it’s usually better to start fresh: use `/new` or open a new tab/session, then paste this request there. Would you like to start fresh, or should I continue here?
+
+If the user chooses to continue, proceed without repeating the warning for that topic.
+
 ## Context Compaction Resilience
 
 Context compaction drops operational state unless written to disk. Use `/checkpoint` to persist and restore.


### PR DESCRIPTION
## Summary

- Add a compact always-loaded `AGENTS.md` rule for interactive new-topic session hygiene.
- Add `reference/session.md` guidance with rare-trigger criteria, headless exclusion, and suggested wording for `/new` or a new tab/session.

Resolves #26159

## Testing

- `.agents/scripts/linters-local.sh` — passed.
- `.agents/scripts/verify-agent-discoverability.sh` — passed.
- `.agents/scripts/progressive-load-check.sh --quiet` — pre-existing failure also present on `main` for unrelated missing legacy pointers.

## Runtime Testing

- Self-assessed docs/prompt guidance change; no runtime code path.

## Decisions

- Kept always-loaded guidance to one pointer line to preserve progressive disclosure.
- Scoped the warning to interactive sessions with meaningful prior task context so headless workers and short asides are not affected.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.11 with gpt-5.5 spent 38m and 78,257 tokens on this with the user in an interactive session.