### PR TITLE
t18046: Optimise OpenCode aidevops plugin startup latency

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -11,7 +11,7 @@ import { registerPoolProvider, getAccounts, ensureValidToken } from "./oauth-poo
 import { getCursorProxyPort, registerCursorProvider } from "./cursor-proxy.mjs";
 import { getGoogleProxyPort, registerGoogleProvider } from "./google-proxy.mjs";
 import { getClaudeProxyPort, registerClaudeProvider } from "./claude-proxy.mjs";
-import { checkOpenCodeVersionDrift } from "./version-tracking.mjs";
+import { checkOpenCodeVersionDriftAsync } from "./version-tracking.mjs";
 import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
 
 /**
@@ -250,9 +250,8 @@ function registerClaudeCliModels(config) {
 /**
  * Log a summary of config hook changes (silent when nothing changed).
  * @param {object} counts - { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude }
- * @param {string|null} versionDrift
  */
-function logConfigSummary(counts, versionDrift) {
+function logConfigSummary(counts) {
   const labels = [
     [counts.agents, "agents"],
     [counts.mcps, "MCPs"],
@@ -270,9 +269,16 @@ function logConfigSummary(counts, versionDrift) {
   if (parts.length > 0) {
     console.error(`[aidevops] Config hook: ${parts.join(", ")}`);
   }
-  if (versionDrift) {
+}
+
+/**
+ * Check OpenCode/plugin version drift without blocking startup.
+ * @param {string} pluginDir
+ */
+function logVersionDriftAsync(pluginDir) {
+  checkOpenCodeVersionDriftAsync(pluginDir, (versionDrift) => {
     console.error(`[aidevops] Version drift: ${versionDrift}`);
-  }
+  });
 }
 
 /**
@@ -333,7 +339,7 @@ export function createConfigHook(deps) {
 
     logConfigSummary(
       { agents, mcps, agentTools, poolCleaned, anthropic, cursor, google, claude },
-      checkOpenCodeVersionDrift(pluginDir),
     );
+    logVersionDriftAsync(pluginDir);
   };
 }

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -3,27 +3,38 @@
 // Extracted from index.mjs (t1914) — MCP registration logic.
 // ---------------------------------------------------------------------------
 
-import { execSync } from "child_process";
+import { accessSync, constants } from "fs";
 import { platform } from "os";
+import { delimiter, join } from "path";
 
 const IS_MACOS = platform() === "darwin";
 
 /**
- * Run a shell command and return stdout, or empty string on failure.
- * @param {string} cmd
- * @param {number} [timeout=5000]
+ * Resolve an executable from PATH without spawning `which` during startup.
+ * @param {string} name
  * @returns {string}
  */
-function run(cmd, timeout = 5000) {
-  try {
-    return execSync(cmd, {
-      encoding: "utf-8",
-      timeout,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-  } catch {
-    return "";
+function findExecutable(name) {
+  if (!name) return "";
+
+  const pathExts = process.platform === "win32"
+    ? (process.env.PATHEXT || ".EXE;.CMD;.BAT;.COM").split(";")
+    : [""];
+  const pathDirs = (process.env.PATH || "").split(delimiter).filter(Boolean);
+  const candidates = name.includes("/") || name.includes("\\")
+    ? [name]
+    : pathDirs.flatMap((dir) => pathExts.map((ext) => join(dir, `${name}${ext}`)));
+
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // keep searching
+    }
   }
+
+  return "";
 }
 
 /**
@@ -34,8 +45,8 @@ function run(cmd, timeout = 5000) {
 let _pkgRunner = null;
 function getPkgRunner() {
   if (_pkgRunner !== null) return _pkgRunner;
-  const bunPath = run("which bun");
-  const npxPath = run("which npx");
+  const bunPath = findExecutable("bun");
+  const npxPath = findExecutable("npx");
   _pkgRunner = bunPath ? `${bunPath} x` : npxPath || "npx";
   return _pkgRunner;
 }
@@ -283,7 +294,7 @@ function shouldSkipMcp(mcp, tools) {
   if (mcp.macOnly && !IS_MACOS) return true;
 
   if (mcp.requiresBinary) {
-    const binaryPath = run(`which ${mcp.requiresBinary}`);
+    const binaryPath = findExecutable(mcp.requiresBinary);
     if (!binaryPath) {
       if (mcp.toolPattern) tools[mcp.toolPattern] = false;
       return true;

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -32,6 +32,7 @@ const DEFAULT_OBS_DIR = join(HOME, ".aidevops", ".agent-workspace", "observabili
 // importing this module. See tests/test-observability-concurrent-init.sh (t2900).
 const DB_PATH = process.env.AIDEVOPS_OBS_DB_OVERRIDE || join(DEFAULT_OBS_DIR, "llm-requests.db");
 const OBS_DIR = dirname(DB_PATH);
+const COST_BACKFILL_MARKER = `${DB_PATH}.cost-backfill-v1.done`;
 
 // ---------------------------------------------------------------------------
 // Pricing table — loaded from shared JSON (single source of truth).
@@ -169,7 +170,7 @@ function initDatabase() {
   // 100% of worker startups. Read-only check first — no lock contention,
   // skips the slow path entirely once the DB is ready.
   if (existsSync(DB_PATH) && _isSchemaInitialized()) {
-    return _runDataMigrations();
+    return _runDataMigrations({ intentColumnReady: true });
   }
 
   // SLOW PATH (t2900): serialise schema creation across concurrent workers
@@ -180,7 +181,7 @@ function initDatabase() {
     // DOUBLE-CHECKED LOCKING: another worker may have completed init while
     // we waited. If schema is now ready, skip the writer-lock-heavy path.
     if (existsSync(DB_PATH) && _isSchemaInitialized()) {
-      return _runDataMigrations();
+      return _runDataMigrations({ intentColumnReady: true });
     }
     if (!_createSchema()) return false;
     return _runDataMigrations();
@@ -312,30 +313,31 @@ CREATE INDEX IF NOT EXISTS idx_session_summaries_session
 /**
  * Idempotent data migrations that run on every plugin init.
  *
- * Both migrations are no-ops on the second+ run (they check state first /
- * have `WHERE cost=0` filters), so calling this on the fast path is cheap.
- * It still touches the writer lock briefly when the SELECT promotes to a
- * BEGIN IMMEDIATE — but the per-call write is a microsecond, not a 459MB
- * journal flush, so writer-queue contention is no longer the bottleneck.
+ * Schema migrations stay synchronous because later writes depend on them.
+ * Historical data backfills are scheduled after startup so large observability
+ * databases do not block the OpenCode TUI on table scans or writer locks.
  *
+ * @param {{ intentColumnReady?: boolean }} [options]
  * @returns {boolean} true on success (best-effort — never returns false)
  */
-function _runDataMigrations() {
+function _runDataMigrations(options = {}) {
   // Migration: add intent column to tool_calls if it doesn't exist (t1309).
   // Check first to avoid noisy "duplicate column" errors in logs.
   // Fresh DBs already have the column from the CREATE TABLE above.
-  const hasIntentCol = sqliteExecSync(
-    "SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent';",
-    5000,
-  );
+  const hasIntentCol = options.intentColumnReady
+    ? "1"
+    : sqliteExecSync(
+      "SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent';",
+      5000,
+    );
   if (hasIntentCol === "0") {
     sqliteExecSync("ALTER TABLE tool_calls ADD COLUMN intent TEXT;", 5000);
   }
 
   // Migration: backfill cost for rows where cost=0 but tokens exist.
   // OpenCode never provided msg.cost — all historical rows have cost=0.
-  // This runs once (subsequent runs find 0 rows to update) and takes ~1s.
-  backfillCosts();
+  // Non-critical historical cleanup; never block the TUI startup path on it.
+  scheduleCostBackfill();
 
   return true;
 }
@@ -473,12 +475,62 @@ function _releaseInitLock(lockDir, ownerFile) {
 }
 
 /**
+ * Return true when historical rows still need the cost backfill.
+ *
+ * This runs only from the delayed background migration path. On large SQLite
+ * DBs even this read-only probe can take seconds without a completion marker,
+ * so it must not be called from initDatabase().
+ *
+ * @returns {boolean}
+ */
+function hasCostBackfillCandidates() {
+  if (existsSync(COST_BACKFILL_MARKER)) return false;
+
+  const result = sqliteExecSync(
+    "SELECT 1 FROM llm_requests WHERE cost = 0.0 AND tokens_total > 0 LIMIT 1;",
+    5000,
+  );
+  if (result === null) return false;
+
+  const hasCandidates = result === "1";
+  if (!hasCandidates) markCostBackfillComplete();
+  return hasCandidates;
+}
+
+/** Schedule the one-time historical cost backfill outside plugin startup. */
+function scheduleCostBackfill() {
+  if (existsSync(COST_BACKFILL_MARKER)) return;
+
+  const timer = setTimeout(() => {
+    try {
+      backfillCosts();
+    } catch (err) {
+      if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+        console.error(`[aidevops] Observability: delayed cost backfill failed: ${err.message}`);
+      }
+    }
+  }, 2500);
+  timer.unref?.();
+}
+
+/** Record that the one-time historical cost migration is complete. */
+function markCostBackfillComplete() {
+  try {
+    writeFileSync(COST_BACKFILL_MARKER, `${new Date().toISOString()}\n`, { mode: 0o600 });
+  } catch {
+    // best-effort marker only; migration remains safe without it
+  }
+}
+
+/**
  * Backfill cost for historical rows where cost=0 but tokens exist.
  * Uses SQL CASE expressions matching the JS pricing table to avoid
  * round-tripping each row through JS. Runs in a single UPDATE statement.
  * Idempotent — only updates rows where cost=0 AND tokens_total>0.
  */
 function backfillCosts() {
+  if (!hasCostBackfillCandidates()) return;
+
   // Build SQL CASE expression from the pricing table
   const cases = Object.entries(MODEL_PRICING).map(([key, p]) =>
     `WHEN lower(model_id) LIKE '%${key}%' THEN ` +
@@ -516,9 +568,10 @@ SELECT session_id, MIN(timestamp), MAX(timestamp), COUNT(*),
   MAX(project_path), GROUP_CONCAT(DISTINCT model_id)
 FROM llm_requests
 GROUP BY session_id;
-`, 30000);
+    `, 30000);
     console.error("[aidevops] Observability: rebuilt session_summaries with corrected costs");
   }
+  markCostBackfillComplete();
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
@@ -56,6 +56,66 @@ test("config-hook.mjs skips optional provider discovery until proxy ports are ac
   );
 });
 
+test("config-hook.mjs does not run opencode --version synchronously during startup", () => {
+  const src = readFileSync(resolve(pluginDir, "config-hook.mjs"), "utf8");
+
+  assert.match(
+    src,
+    /checkOpenCodeVersionDriftAsync\(pluginDir/,
+    "Version drift checks should be scheduled asynchronously.",
+  );
+  assert.doesNotMatch(
+    src,
+    /checkOpenCodeVersionDrift\(pluginDir\)/,
+    "Config hook must not block startup on the opencode CLI version probe.",
+  );
+});
+
+test("mcp-registry.mjs resolves binaries without spawning which", () => {
+  const src = readFileSync(resolve(pluginDir, "mcp-registry.mjs"), "utf8");
+
+  assert.match(
+    src,
+    /function findExecutable\(name\)/,
+    "MCP registry should use an in-process PATH lookup.",
+  );
+  assert.doesNotMatch(
+    src,
+    /execSync|which /,
+    "MCP registration must not spawn `which` during the config hook.",
+  );
+});
+
+test("observability.mjs skips heavy cost backfill when no rows need migration", () => {
+  const src = readFileSync(resolve(pluginDir, "observability.mjs"), "utf8");
+
+  assert.match(
+    src,
+    /scheduleCostBackfill\(\);/,
+    "Historical cost backfills should be scheduled outside synchronous startup.",
+  );
+  assert.match(
+    src,
+    /function hasCostBackfillCandidates\(\)/,
+    "Observability should still probe before running the expensive backfill.",
+  );
+  assert.match(
+    src,
+    /COST_BACKFILL_MARKER/,
+    "Completed one-time backfills should be memoized outside the hot startup path.",
+  );
+  assert.match(
+    src,
+    /if \(!hasCostBackfillCandidates\(\)\) return;/,
+    "The expensive cost UPDATE must be skipped once the backfill is complete.",
+  );
+  assert.match(
+    src,
+    /_runDataMigrations\(\{ intentColumnReady: true \}\)/,
+    "Known-good schemas should skip redundant intent-column migration probes.",
+  );
+});
+
 test("initPoolAuth does not seed unsupported pending auth entries", async () => {
   const tempHome = mkdtempSync(resolve(tmpdir(), "aidevops-oauth-pool-"));
   const previousHome = process.env.HOME;

--- a/.agents/plugins/opencode-aidevops/version-tracking.mjs
+++ b/.agents/plugins/opencode-aidevops/version-tracking.mjs
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import { readFileSync, existsSync } from "fs";
-import { execSync } from "child_process";
+import { execSync, execFile } from "child_process";
 import { join } from "path";
 
 /**
@@ -83,6 +83,24 @@ export function compareSemver(a, b) {
 }
 
 /**
+ * Build a version drift notice from tracked metadata and running version text.
+ * @param {{ tracked: string, repo: string }} meta
+ * @param {string} running
+ * @returns {string | null}
+ */
+function buildVersionDriftNotice(meta, running) {
+  const runningClean = String(running || "").replace(/^v/, "").trim();
+  if (!runningClean) return null;
+
+  const cmp = compareSemver(meta.tracked, runningClean);
+  if (cmp < 0) {
+    return `opencode ${runningClean} running, plugin tested against ${meta.tracked} — review ${meta.repo} changelog`;
+  }
+
+  return null;
+}
+
+/**
  * Check if the running opencode version is ahead of the tracked version.
  * Logs a notice if an update to the plugin's tracked_version is needed.
  * @param {string} pluginDir - Path to the plugin directory
@@ -93,15 +111,24 @@ export function checkOpenCodeVersionDrift(pluginDir) {
   if (!meta) return null;
 
   const running = run("opencode --version 2>/dev/null");
-  if (!running) return null;
+  return buildVersionDriftNotice(meta, running);
+}
 
-  // Strip any leading 'v' and whitespace
-  const runningClean = running.replace(/^v/, "").trim();
-  const cmp = compareSemver(meta.tracked, runningClean);
+/**
+ * Check the running opencode version without blocking the config hook.
+ * @param {string} pluginDir
+ * @param {(notice: string) => void} onNotice
+ * @returns {boolean} true when the async check was scheduled
+ */
+export function checkOpenCodeVersionDriftAsync(pluginDir, onNotice) {
+  const meta = getTrackedOpenCodeVersion(pluginDir);
+  if (!meta) return false;
 
-  if (cmp < 0) {
-    return `opencode ${runningClean} running, plugin tested against ${meta.tracked} — review ${meta.repo} changelog`;
-  }
+  execFile("opencode", ["--version"], { timeout: 5000 }, (err, stdout) => {
+    if (err) return;
+    const notice = buildVersionDriftNotice(meta, stdout);
+    if (notice) onNotice?.(notice);
+  });
 
-  return null;
+  return true;
 }


### PR DESCRIPTION
## Summary

Reduced OpenCode aidevops plugin startup latency by making version drift checks asynchronous, replacing MCP binary which subprocesses with in-process PATH lookup, and moving historical observability cost backfill work off the synchronous init path.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs,.agents/plugins/opencode-aidevops/mcp-registry.mjs,.agents/plugins/opencode-aidevops/observability.mjs,.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs,.agents/plugins/opencode-aidevops/version-tracking.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs; node --test .agents/plugins/opencode-aidevops/tests/*.mjs; git diff --check; node --check on changed .mjs files; .agents/scripts/linters-local.sh; npm run typecheck; measured config hook at 12.6ms and observability init at 136.5ms after optimisation.

Resolves #26157


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.11 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 54m and 417,412 tokens on this with the user in an interactive session.