### PR TITLE
t18022 docs(gui): document release gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Release-gate GUI commands for the AI collaboration workspace: `gui:lint`,
+  `gui:typecheck`, `gui:build`, and `gui:ci`.
+- Documented final QA coverage for AI Sessions, Channels, Direct Messages,
+  Tambo generative UI cards, shadcn-style chat primitives, and signposts tours.
+
 ## [3.31.14] - 2026-07-01
 
 ### Changed

--- a/docs/gui/testing-ci-cd.md
+++ b/docs/gui/testing-ci-cd.md
@@ -187,9 +187,8 @@ Release verification must cover:
 
 ## Scaffold command contract
 
-The first implementation PR that creates GUI packages must add these root-level
-npm scripts and document their package-manager equivalent if the workspace uses
-something other than npm:
+The scaffold now exposes the release-gate commands from the root `package.json`.
+Use these scripts for AI collaboration workspace QA before cutting a release:
 
 ```bash
 npm run gui:lint
@@ -204,11 +203,45 @@ npm run gui:build
 npm run gui:ci
 ```
 
-`npm run gui:ci` is the required local pre-PR contract for GUI code changes. For
-the scaffold phase it expands to lint, typecheck, schema/unit, adapter fixture,
-API route, component, security/redaction, smoke, and production build checks.
+`npm run gui:ci` is the required local pre-PR contract for GUI code changes. It
+expands to typecheck, schema/unit, adapter fixture, API route, component,
+security/redaction, smoke, and production build checks. `npm run gui:lint` is a
+trust-boundary lint surrogate until a dedicated JavaScript/TypeScript lint
+configuration is added; it runs the browser/shared/API security tests that guard
+against secret rendering, arbitrary helper execution, and untrusted HTML.
 Cloudron and desktop commands are added to `gui:ci` only after their paths exist
 and their jobs are stable enough to gate GUI changes.
+
+### AI collaboration workspace release smoke
+
+For the release that introduced AI Sessions, Channels, Direct Messages, Tambo
+cards, shadcn-style chat primitives, and signposts tours, use this release smoke
+set after all implementation child issues have merged:
+
+```bash
+bun install --frozen-lockfile
+npm run gui:lint
+npm run gui:typecheck
+npm run gui:test:schema
+npm run gui:test:adapters
+npm run gui:test:api
+npm run gui:test:components
+npm run gui:test:security
+npm run gui:test:smoke
+npm run gui:build
+```
+
+Coverage focus:
+
+- AI Sessions, Channels, and Direct Messages render through the unified
+  conversation fixtures and component tests.
+- Tambo generative UI card schemas remain strict and read-only by default.
+- shadcn-style transcript primitives preserve message scrolling, attachments,
+  markers, and accessible event rows.
+- Signposts tours stay route scoped and the button remains immediately left of
+  notifications.
+- Security tests continue to prove that browser code never renders secrets,
+  raw helper commands, or untrusted HTML.
 
 Documentation-only changes under `docs/gui/` use the repository markdown checks
 and do not require TypeScript jobs unless they modify runnable examples or test

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "gui:test:components": "bun test packages/gui-web/tests",
     "gui:test:security": "bun test packages/gui-shared/tests/security.test.ts packages/gui-api/tests/security.test.ts packages/gui-web/tests/security.test.ts",
     "gui:test:smoke": "bun test packages/gui-api/tests/smoke.test.ts",
+    "gui:lint": "bun test packages/gui-web/tests/security.test.ts packages/gui-shared/tests/security.test.ts packages/gui-api/tests/security.test.ts",
+    "gui:typecheck": "tsc --noEmit",
+    "gui:build": "bun ./node_modules/vite/bin/vite.js build --config packages/gui-web/vite.config.ts",
+    "gui:ci": "npm run gui:lint && npm run gui:typecheck && npm run gui:test:schema && npm run gui:test:adapters && npm run gui:test:api && npm run gui:test:components && npm run gui:test:security && npm run gui:test:smoke && npm run gui:build",
     "gui:desktop:check": "bash packages/gui-desktop/scripts/install-macos-app.sh --check",
     "gui:desktop:install:macos": "bash packages/gui-desktop/scripts/install-macos-app.sh",
     "postinstall": "node scripts/npm-postinstall.cjs || true"


### PR DESCRIPTION
## Summary

- Add root GUI release-gate scripts for lint, typecheck, build, and full GUI CI.
- Document the AI collaboration workspace release smoke set and coverage focus.
- Preserve required/advisory/release-only GUI gate guidance after the v3.31.14 release bump.

For #25715

## Verification

- PASS: pre-commit quality validation during commit/amend.
- PASS: `git diff --check origin/main...HEAD`.
- PASS: `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid')"`.
- PASS: `npm run gui:typecheck` in the original resumed worktree with existing dependencies.
- PASS: `npx vite build --config packages/gui-web/vite.config.ts` in the original resumed worktree with existing dependencies.
- BLOCKED: `npm run gui:ci` in the resumed environment stops at `gui:lint` because `bun` is not installed: `sh: 1: bun: not found`.

## Notes

- All issue blockers named in #25715 were checked and are closed: #25708, #25709, #25710, #25711, #25712, #25713, and #25714.
- The default branch already points at tag/release `v3.31.14`; this PR documents the gate and scripts rather than cutting another release.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.13 plugin for [OpenCode](https://opencode.ai) v1.17.12
