### PR TITLE
t18047: feat: add reach capability registry and router

### DIFF
--- a/.agents/aidevops/reach-capture.md
+++ b/.agents/aidevops/reach-capture.md
@@ -1,0 +1,62 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Reach and Capture
+
+Use this registry when an agent needs to choose the lowest-agency way to reach,
+capture, stage, or mine web content. The first implementation is intentionally
+advisory: it reports available local primitives and emits a route decision; it
+does not mutate browser profiles, cookies, proxies, inboxes, knowledge stores,
+performance logs, or feedback artifacts.
+
+## Capability Registry
+
+| Capability | Backend key | Agency | Use first when | Local readiness signal | Artifact plane |
+|------------|-------------|--------|----------------|------------------------|----------------|
+| Fetch/static parse | `fetch` | 1 | Public/static pages, obvious JSON, no login | `curl` or `python3` present | caller-selected |
+| Crawl4AI/WaterCrawl crawler | `crawler` | 2 | Many public pages, sitemaps, docs, structured extraction | `crawl4ai-helper.sh`, `watercrawl-helper.sh`, or `site-crawler-helper.sh` | caller-selected |
+| Deterministic browser | `browser` | 3 | Known UI flow, forms, downloads, repeatable selectors | `agent-browser-helper.sh`, `browser-qa-helper.sh`, or Playwright tooling | traces/screenshots/downloads |
+| Persistent profile | `persistent_profile` | 4 | Recurring logged-in workflows with approved stored state | `dev-browser-helper.sh` or browser profile storage | `browser-profiles` workspace |
+| Cookie-session reuse | `cookie_session` | 4 | Authenticated API calls from an existing approved session | `sweet-cookie` tooling or `anti-detect-helper.sh` cookies support | storage state/cookie export |
+| Anti-detect profile | `anti_detect_profile` | 6 | Authorized profile or fingerprint isolation need | `anti-detect-helper.sh` | profile workspace |
+| Proxy/VPN | `proxy_vpn` | 6 | Authorized geo, isolation, or reputation separation need | `anti-detect-helper.sh proxy` support or VPN/proxy helper | proxy metadata |
+| `_inbox` capture | `inbox_capture` | storage | Human-visible capture, triage, or later processing | `inbox-helper.sh` | `_inbox` |
+| `_knowledge` staging | `knowledge_staging` | storage | Durable reusable knowledge or indexed research | `knowledge-helper.sh` | `_knowledge` |
+| `_performance` logging | `performance_logging` | telemetry | Repeatable workflow measurement | `performance`/metrics helpers when present | `_performance` |
+| `_feedback` mining | `feedback_mining` | telemetry | Mine prior failures, reviews, comments, or outcomes | feedback/quality helpers when present | `_feedback` |
+
+## Route Decision Schema
+
+`reach-helper.sh route --format json` returns one JSON object with this shape:
+
+```json
+{
+  "backend": "fetch|crawler|browser|persistent_profile|cookie_session|anti_detect_profile|manual_review",
+  "agency_level": 1,
+  "mode": "static|crawl|deterministic_browser|profile|cookie_session|authorized_stealth|manual",
+  "headed": false,
+  "profile_policy": "none|avoid|use_existing_approved_profile|required|blocked",
+  "cookie_policy": "none|avoid|reuse_approved_session|required|blocked",
+  "proxy_policy": "none|avoid|authorized_only|required|blocked",
+  "offload": "local|worker|manual",
+  "capture_destination": "caller_selected|_inbox|_knowledge|_performance|_feedback",
+  "safety_notes": ["sanitized notes only"],
+  "expected_artifacts": ["sanitized artifact kinds only"],
+  "blocked_reason": ""
+}
+```
+
+Routing follows `.agents/workflows/auto-browse.md`: fetch/static parse first,
+then crawler, deterministic browser, persistent profile or cookie reuse for
+approved authenticated work, and anti-detect/proxy only for explicit authorized
+isolation needs. Private/manual authentication without an approved reusable
+session returns `manual_review` with `blocked_reason` set instead of attempting
+capture.
+
+## Safety Boundaries
+
+- Do not contact arbitrary targets during `doctor` or `capabilities` checks.
+- Do not print credentials, cookie values, proxy auth, local private paths, or
+  raw private target strings in route output.
+- Treat profile, cookie, proxy, inbox, knowledge, performance, and feedback
+  mutation as follow-up work with separate task briefs and verification.

--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -280,6 +280,142 @@ lower_text() {
 	return 0
 }
 
+route_set_defaults() {
+	backend="fetch"
+	agency_level="1"
+	mode="static"
+	headed="false"
+	profile_policy="none"
+	cookie_policy="none"
+	proxy_policy="none"
+	offload="local"
+	capture_destination="caller_selected"
+	safety_notes='"start with public/static retrieval before browser automation","route output is sanitized and advisory only"'
+	expected_artifacts='"static response or parsed text"'
+	blocked_reason=""
+	return 0
+}
+
+route_set_private_block() {
+	backend="manual_review"
+	agency_level="0"
+	mode="manual"
+	headed="false"
+	profile_policy="blocked"
+	cookie_policy="blocked"
+	proxy_policy="blocked"
+	offload="manual"
+	capture_destination="caller_selected"
+	safety_notes='"private scope requires explicit authorization or approved reusable session","no target details are echoed"'
+	expected_artifacts='"authorization decision"'
+	blocked_reason="private scope requires auth cookie, profile, or manual approval"
+	return 0
+}
+
+route_set_manual_auth() {
+	backend="manual_review"
+	agency_level="0"
+	mode="manual"
+	headed="true"
+	profile_policy="required"
+	cookie_policy="blocked"
+	proxy_policy="authorized_only"
+	offload="manual"
+	safety_notes='"manual authentication must stay user-controlled","no credential or target details are echoed"'
+	expected_artifacts='"manual auth handoff notes"'
+	blocked_reason="manual authentication required"
+	return 0
+}
+
+route_set_cookie_session() {
+	backend="cookie_session"
+	agency_level="4"
+	mode="cookie_session"
+	cookie_policy="reuse_approved_session"
+	profile_policy="avoid"
+	proxy_policy="authorized_only"
+	expected_artifacts='"storage state or authenticated API response"'
+	safety_notes='"reuse only approved cookie sessions","never print cookie values"'
+	return 0
+}
+
+route_set_persistent_profile() {
+	backend="persistent_profile"
+	agency_level="4"
+	mode="profile"
+	headed="true"
+	profile_policy="use_existing_approved_profile"
+	cookie_policy="reuse_approved_session"
+	proxy_policy="authorized_only"
+	expected_artifacts='"profile-backed trace or download"'
+	safety_notes='"use only approved persistent profiles","do not mutate profiles from this helper"'
+	return 0
+}
+
+route_set_stealth() {
+	backend="anti_detect_profile"
+	agency_level="6"
+	mode="authorized_stealth"
+	headed="true"
+	profile_policy="required"
+	cookie_policy="avoid"
+	proxy_policy="authorized_only"
+	expected_artifacts='"authorized isolated browser trace"'
+	safety_notes='"anti-detect and proxy use require explicit authorization","do not print proxy credentials"'
+	return 0
+}
+
+route_set_browser() {
+	backend="browser"
+	agency_level="3"
+	mode="deterministic_browser"
+	headed="false"
+	profile_policy="avoid"
+	cookie_policy="avoid"
+	proxy_policy="none"
+	expected_artifacts='"DOM text, trace, screenshot only when needed, or download"'
+	safety_notes='"prefer ARIA and DOM extraction over screenshots","use deterministic selectors before high-agency tools"'
+	return 0
+}
+
+route_set_crawler() {
+	backend="crawler"
+	agency_level="2"
+	mode="crawl"
+	profile_policy="none"
+	cookie_policy="none"
+	proxy_policy="none"
+	expected_artifacts='"crawl manifest and extracted records"'
+	safety_notes='"crawl only public or authorized content","respect robots and rate limits"'
+	return 0
+}
+
+route_apply_capture_destination() {
+	local objective_text="$1"
+	if [[ "$objective_text" == *inbox* || "$objective_text" == *capture* ]]; then
+		capture_destination="_inbox"
+	elif [[ "$objective_text" == *knowledge* || "$objective_text" == *research* ]]; then
+		capture_destination="_knowledge"
+	elif [[ "$objective_text" == *performance* || "$objective_text" == *metric* ]]; then
+		capture_destination="_performance"
+	elif [[ "$objective_text" == *feedback* || "$objective_text" == *review* ]]; then
+		capture_destination="_feedback"
+	fi
+	return 0
+}
+
+route_apply_objective() {
+	local objective_text="$1"
+	if [[ "$objective_text" == *proxy* || "$objective_text" == *vpn* || "$objective_text" == *geo* || "$objective_text" == *anti-detect* || "$objective_text" == *stealth* ]]; then
+		route_set_stealth
+	elif [[ "$objective_text" == *form* || "$objective_text" == *login* || "$objective_text" == *download* || "$objective_text" == *click* || "$objective_text" == *dashboard* || "$objective_text" == *browser* ]]; then
+		route_set_browser
+	elif [[ "$objective_text" == *crawl* || "$objective_text" == *sitemap* || "$objective_text" == *"many pages"* || "$objective_text" == *docs* || "$objective_text" == *documentation* ]]; then
+		route_set_crawler
+	fi
+	return 0
+}
+
 handle_route() {
 	local objective=""
 	local auth="none"
@@ -329,103 +465,32 @@ handle_route() {
 
 	local objective_lower
 	objective_lower="$(lower_text "$objective")"
-	local backend="fetch"
-	local agency_level="1"
-	local mode="static"
-	local headed="false"
-	local profile_policy="none"
-	local cookie_policy="none"
-	local proxy_policy="none"
-	local offload="local"
-	local capture_destination="caller_selected"
-	local safety_notes='"start with public/static retrieval before browser automation","route output is sanitized and advisory only"'
-	local expected_artifacts='"static response or parsed text"'
+	local backend=""
+	local agency_level=""
+	local mode=""
+	local headed=""
+	local profile_policy=""
+	local cookie_policy=""
+	local proxy_policy=""
+	local offload=""
+	local capture_destination=""
+	local safety_notes=""
+	local expected_artifacts=""
 	local blocked_reason=""
+	route_set_defaults
 
 	if [[ "$scope" == "private" && "$auth" == "none" ]]; then
-		backend="manual_review"
-		agency_level="0"
-		mode="manual"
-		headed="false"
-		profile_policy="blocked"
-		cookie_policy="blocked"
-		proxy_policy="blocked"
-		offload="manual"
-		capture_destination="caller_selected"
-		safety_notes='"private scope requires explicit authorization or approved reusable session","no target details are echoed"'
-		expected_artifacts='"authorization decision"'
-		blocked_reason="private scope requires auth cookie, profile, or manual approval"
+		route_set_private_block
 	elif [[ "$auth" == "manual" ]]; then
-		backend="manual_review"
-		agency_level="0"
-		mode="manual"
-		headed="true"
-		profile_policy="required"
-		cookie_policy="blocked"
-		proxy_policy="authorized_only"
-		offload="manual"
-		safety_notes='"manual authentication must stay user-controlled","no credential or target details are echoed"'
-		expected_artifacts='"manual auth handoff notes"'
-		blocked_reason="manual authentication required"
+		route_set_manual_auth
 	elif [[ "$auth" == "cookie" ]]; then
-		backend="cookie_session"
-		agency_level="4"
-		mode="cookie_session"
-		cookie_policy="reuse_approved_session"
-		profile_policy="avoid"
-		proxy_policy="authorized_only"
-		expected_artifacts='"storage state or authenticated API response"'
-		safety_notes='"reuse only approved cookie sessions","never print cookie values"'
+		route_set_cookie_session
 	elif [[ "$auth" == "profile" ]]; then
-		backend="persistent_profile"
-		agency_level="4"
-		mode="profile"
-		headed="true"
-		profile_policy="use_existing_approved_profile"
-		cookie_policy="reuse_approved_session"
-		proxy_policy="authorized_only"
-		expected_artifacts='"profile-backed trace or download"'
-		safety_notes='"use only approved persistent profiles","do not mutate profiles from this helper"'
-	elif [[ "$objective_lower" == *proxy* || "$objective_lower" == *vpn* || "$objective_lower" == *geo* || "$objective_lower" == *anti-detect* || "$objective_lower" == *stealth* ]]; then
-		backend="anti_detect_profile"
-		agency_level="6"
-		mode="authorized_stealth"
-		headed="true"
-		profile_policy="required"
-		cookie_policy="avoid"
-		proxy_policy="authorized_only"
-		expected_artifacts='"authorized isolated browser trace"'
-		safety_notes='"anti-detect and proxy use require explicit authorization","do not print proxy credentials"'
-	elif [[ "$objective_lower" == *form* || "$objective_lower" == *login* || "$objective_lower" == *download* || "$objective_lower" == *click* || "$objective_lower" == *dashboard* || "$objective_lower" == *browser* ]]; then
-		backend="browser"
-		agency_level="3"
-		mode="deterministic_browser"
-		headed="false"
-		profile_policy="avoid"
-		cookie_policy="avoid"
-		proxy_policy="none"
-		expected_artifacts='"DOM text, trace, screenshot only when needed, or download"'
-		safety_notes='"prefer ARIA and DOM extraction over screenshots","use deterministic selectors before high-agency tools"'
-	elif [[ "$objective_lower" == *crawl* || "$objective_lower" == *sitemap* || "$objective_lower" == *"many pages"* || "$objective_lower" == *docs* || "$objective_lower" == *documentation* ]]; then
-		backend="crawler"
-		agency_level="2"
-		mode="crawl"
-		profile_policy="none"
-		cookie_policy="none"
-		proxy_policy="none"
-		expected_artifacts='"crawl manifest and extracted records"'
-		safety_notes='"crawl only public or authorized content","respect robots and rate limits"'
+		route_set_persistent_profile
+	else
+		route_apply_objective "$objective_lower"
 	fi
-
-	if [[ "$objective_lower" == *inbox* || "$objective_lower" == *capture* ]]; then
-		capture_destination="_inbox"
-	elif [[ "$objective_lower" == *knowledge* || "$objective_lower" == *research* ]]; then
-		capture_destination="_knowledge"
-	elif [[ "$objective_lower" == *performance* || "$objective_lower" == *metric* ]]; then
-		capture_destination="_performance"
-	elif [[ "$objective_lower" == *feedback* || "$objective_lower" == *review* ]]; then
-		capture_destination="_feedback"
-	fi
+	route_apply_capture_destination "$objective_lower"
 
 	local safe_blocked_reason
 	safe_blocked_reason="$(sanitize_text "$blocked_reason")"

--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# reach-helper.sh - Capability registry, doctor, and minimum-agency router.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	# shellcheck source=/dev/null
+	source "${SCRIPT_DIR}/shared-constants.sh"
+fi
+
+if ! type log_error &>/dev/null; then
+	log_error() {
+		printf '[ERROR] %s\n' "$*" >&2
+		return 0
+	}
+fi
+
+usage() {
+	cat <<'EOF'
+Usage: reach-helper.sh <command> [options]
+
+Commands:
+  capabilities --format json
+  doctor --format json
+  route --objective <text> [--auth none|cookie|profile|manual] [--scope public|private] --format json
+  help
+
+The helper is advisory only. It does not contact arbitrary targets or mutate
+profiles, cookies, proxies, inbox, knowledge, performance, or feedback stores.
+EOF
+	return 0
+}
+
+json_bool() {
+	local value="$1"
+	if [[ "$value" == "true" ]]; then
+		printf 'true'
+		return 0
+	fi
+	printf 'false'
+	return 0
+}
+
+json_escape() {
+	local input="$1"
+	local output=""
+	local char=""
+	local i=0
+	local length=${#input}
+
+	while [[ $i -lt $length ]]; do
+		char="${input:i:1}"
+		case "$char" in
+			'"') output+="\\\"" ;;
+			\\) output+="\\\\" ;;
+			$'\n') output+="\\n" ;;
+			$'\r') output+="\\r" ;;
+			$'\t') output+="\\t" ;;
+			*) output+="$char" ;;
+		esac
+		i=$((i + 1))
+	done
+
+	printf '%s' "$output"
+	return 0
+}
+
+sanitize_text() {
+	local input="$1"
+	local sanitized="$input"
+
+	sanitized="${sanitized//http:\/\//redacted-url}"
+	sanitized="${sanitized//https:\/\//redacted-url}"
+	sanitized="${sanitized//@/ at-redacted }"
+	sanitized="${sanitized//${HOME:-__NO_HOME__}/~}"
+	printf '%s' "$sanitized"
+	return 0
+}
+
+command_available() {
+	local command_name="$1"
+	if [[ "${AIDEVOPS_REACH_TEST_FORCE_MISSING:-}" == "1" ]]; then
+		return 1
+	fi
+	if command -v "$command_name" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+helper_available() {
+	local helper_name="$1"
+	if [[ "${AIDEVOPS_REACH_TEST_FORCE_MISSING:-}" == "1" ]]; then
+		return 1
+	fi
+	if [[ -x "${SCRIPT_DIR}/${helper_name}" ]]; then
+		return 0
+	fi
+	if command -v "$helper_name" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+capability_available() {
+	local capability_key="$1"
+	if [[ "${AIDEVOPS_REACH_TEST_FORCE_MISSING:-}" == "1" ]]; then
+		return 1
+	fi
+	case "$capability_key" in
+		fetch)
+			if command_available curl || command_available python3; then
+				return 0
+			fi
+			;;
+		crawler)
+			if helper_available crawl4ai-helper.sh || helper_available watercrawl-helper.sh || helper_available site-crawler-helper.sh; then
+				return 0
+			fi
+			;;
+		browser)
+			if helper_available agent-browser-helper.sh || helper_available browser-qa-helper.sh || command_available playwright; then
+				return 0
+			fi
+			;;
+		persistent_profile)
+			if helper_available dev-browser-helper.sh || [[ -d "${HOME}/.aidevops/.agent-workspace/browser-profiles" ]]; then
+				return 0
+			fi
+			;;
+		cookie_session)
+			if command_available sweet-cookie || helper_available anti-detect-helper.sh; then
+				return 0
+			fi
+			;;
+		anti_detect_profile | proxy_vpn)
+			if helper_available anti-detect-helper.sh; then
+				return 0
+			fi
+			;;
+		inbox_capture)
+			if helper_available inbox-helper.sh; then
+				return 0
+			fi
+			;;
+		knowledge_staging)
+			if helper_available knowledge-helper.sh; then
+				return 0
+			fi
+			;;
+		performance_logging)
+			if helper_available resource-metrics-helper.sh || helper_available report-token-use-helper.sh; then
+				return 0
+			fi
+			;;
+		feedback_mining)
+			if helper_available quality-feedback-helper.sh || helper_available findings-to-tasks-helper.sh; then
+				return 0
+			fi
+			;;
+		*)
+			return 1
+			;;
+	esac
+	return 1
+}
+
+print_capability_object() {
+	local key="$1"
+	local name="$2"
+	local agency="$3"
+	local mode="$4"
+	local available="false"
+
+	if capability_available "$key"; then
+		available="true"
+	fi
+
+	printf '{"key":"%s","name":"%s","agency":"%s","mode":"%s","available":%s}' \
+		"$(json_escape "$key")" \
+		"$(json_escape "$name")" \
+		"$(json_escape "$agency")" \
+		"$(json_escape "$mode")" \
+		"$(json_bool "$available")"
+	return 0
+}
+
+emit_capabilities_json() {
+	printf '{"schema_version":1,"capabilities":['
+	print_capability_object "fetch" "Fetch/static parse" "1" "static"
+	printf ','
+	print_capability_object "crawler" "Crawl4AI/WaterCrawl crawler" "2" "crawl"
+	printf ','
+	print_capability_object "browser" "Deterministic browser" "3" "deterministic_browser"
+	printf ','
+	print_capability_object "persistent_profile" "Persistent profile" "4" "profile"
+	printf ','
+	print_capability_object "cookie_session" "Cookie-session reuse" "4" "cookie_session"
+	printf ','
+	print_capability_object "anti_detect_profile" "Anti-detect profile" "6" "authorized_stealth"
+	printf ','
+	print_capability_object "proxy_vpn" "Proxy/VPN" "6" "authorized_proxy"
+	printf ','
+	print_capability_object "inbox_capture" "_inbox capture" "storage" "capture"
+	printf ','
+	print_capability_object "knowledge_staging" "_knowledge staging" "storage" "staging"
+	printf ','
+	print_capability_object "performance_logging" "_performance logging" "telemetry" "logging"
+	printf ','
+	print_capability_object "feedback_mining" "_feedback mining" "telemetry" "mining"
+	printf ']}\n'
+	return 0
+}
+
+require_json_format() {
+	local format="$1"
+	if [[ "$format" != "json" ]]; then
+		log_error "Only --format json is supported"
+		return 1
+	fi
+	return 0
+}
+
+handle_capabilities() {
+	local format="json"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--format)
+				shift
+				format="${1:-}"
+				;;
+			*)
+				log_error "Unknown capabilities option: $arg"
+				return 1
+				;;
+		esac
+		shift || true
+	done
+	require_json_format "$format" || return 1
+	emit_capabilities_json
+	return 0
+}
+
+handle_doctor() {
+	local format="json"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--format)
+				shift
+				format="${1:-}"
+				;;
+			*)
+				log_error "Unknown doctor option: $arg"
+				return 1
+				;;
+		esac
+		shift || true
+	done
+	require_json_format "$format" || return 1
+	local capabilities_json=""
+	local checks_json=""
+	capabilities_json="$(emit_capabilities_json)"
+	checks_json="${capabilities_json#*\"capabilities\":}"
+	checks_json="${checks_json%\}}"
+	printf '{"schema_version":1,"contacted_targets":false,"checks":'
+	printf '%s' "$checks_json"
+	printf '}\n'
+	return 0
+}
+
+lower_text() {
+	local input="$1"
+	printf '%s' "$input" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+handle_route() {
+	local objective=""
+	local auth="none"
+	local scope="public"
+	local format="json"
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--objective)
+				shift
+				objective="${1:-}"
+				;;
+			--auth)
+				shift
+				auth="${1:-}"
+				;;
+			--scope)
+				shift
+				scope="${1:-}"
+				;;
+			--format)
+				shift
+				format="${1:-}"
+				;;
+			*)
+				log_error "Unknown route option: $arg"
+				return 1
+				;;
+		esac
+		shift || true
+	done
+
+	require_json_format "$format" || return 1
+	if [[ -z "$objective" ]]; then
+		log_error "route requires --objective"
+		return 1
+	fi
+	case "$auth" in
+		none | cookie | profile | manual) ;;
+		*) log_error "Invalid --auth: $auth"; return 1 ;;
+	esac
+	case "$scope" in
+		public | private) ;;
+		*) log_error "Invalid --scope: $scope"; return 1 ;;
+	esac
+
+	local objective_lower
+	objective_lower="$(lower_text "$objective")"
+	local backend="fetch"
+	local agency_level="1"
+	local mode="static"
+	local headed="false"
+	local profile_policy="none"
+	local cookie_policy="none"
+	local proxy_policy="none"
+	local offload="local"
+	local capture_destination="caller_selected"
+	local safety_notes='"start with public/static retrieval before browser automation","route output is sanitized and advisory only"'
+	local expected_artifacts='"static response or parsed text"'
+	local blocked_reason=""
+
+	if [[ "$scope" == "private" && "$auth" == "none" ]]; then
+		backend="manual_review"
+		agency_level="0"
+		mode="manual"
+		headed="false"
+		profile_policy="blocked"
+		cookie_policy="blocked"
+		proxy_policy="blocked"
+		offload="manual"
+		capture_destination="caller_selected"
+		safety_notes='"private scope requires explicit authorization or approved reusable session","no target details are echoed"'
+		expected_artifacts='"authorization decision"'
+		blocked_reason="private scope requires auth cookie, profile, or manual approval"
+	elif [[ "$auth" == "manual" ]]; then
+		backend="manual_review"
+		agency_level="0"
+		mode="manual"
+		headed="true"
+		profile_policy="required"
+		cookie_policy="blocked"
+		proxy_policy="authorized_only"
+		offload="manual"
+		safety_notes='"manual authentication must stay user-controlled","no credential or target details are echoed"'
+		expected_artifacts='"manual auth handoff notes"'
+		blocked_reason="manual authentication required"
+	elif [[ "$auth" == "cookie" ]]; then
+		backend="cookie_session"
+		agency_level="4"
+		mode="cookie_session"
+		cookie_policy="reuse_approved_session"
+		profile_policy="avoid"
+		proxy_policy="authorized_only"
+		expected_artifacts='"storage state or authenticated API response"'
+		safety_notes='"reuse only approved cookie sessions","never print cookie values"'
+	elif [[ "$auth" == "profile" ]]; then
+		backend="persistent_profile"
+		agency_level="4"
+		mode="profile"
+		headed="true"
+		profile_policy="use_existing_approved_profile"
+		cookie_policy="reuse_approved_session"
+		proxy_policy="authorized_only"
+		expected_artifacts='"profile-backed trace or download"'
+		safety_notes='"use only approved persistent profiles","do not mutate profiles from this helper"'
+	elif [[ "$objective_lower" == *proxy* || "$objective_lower" == *vpn* || "$objective_lower" == *geo* || "$objective_lower" == *anti-detect* || "$objective_lower" == *stealth* ]]; then
+		backend="anti_detect_profile"
+		agency_level="6"
+		mode="authorized_stealth"
+		headed="true"
+		profile_policy="required"
+		cookie_policy="avoid"
+		proxy_policy="authorized_only"
+		expected_artifacts='"authorized isolated browser trace"'
+		safety_notes='"anti-detect and proxy use require explicit authorization","do not print proxy credentials"'
+	elif [[ "$objective_lower" == *form* || "$objective_lower" == *login* || "$objective_lower" == *download* || "$objective_lower" == *click* || "$objective_lower" == *dashboard* || "$objective_lower" == *browser* ]]; then
+		backend="browser"
+		agency_level="3"
+		mode="deterministic_browser"
+		headed="false"
+		profile_policy="avoid"
+		cookie_policy="avoid"
+		proxy_policy="none"
+		expected_artifacts='"DOM text, trace, screenshot only when needed, or download"'
+		safety_notes='"prefer ARIA and DOM extraction over screenshots","use deterministic selectors before high-agency tools"'
+	elif [[ "$objective_lower" == *crawl* || "$objective_lower" == *sitemap* || "$objective_lower" == *"many pages"* || "$objective_lower" == *docs* || "$objective_lower" == *documentation* ]]; then
+		backend="crawler"
+		agency_level="2"
+		mode="crawl"
+		profile_policy="none"
+		cookie_policy="none"
+		proxy_policy="none"
+		expected_artifacts='"crawl manifest and extracted records"'
+		safety_notes='"crawl only public or authorized content","respect robots and rate limits"'
+	fi
+
+	if [[ "$objective_lower" == *inbox* || "$objective_lower" == *capture* ]]; then
+		capture_destination="_inbox"
+	elif [[ "$objective_lower" == *knowledge* || "$objective_lower" == *research* ]]; then
+		capture_destination="_knowledge"
+	elif [[ "$objective_lower" == *performance* || "$objective_lower" == *metric* ]]; then
+		capture_destination="_performance"
+	elif [[ "$objective_lower" == *feedback* || "$objective_lower" == *review* ]]; then
+		capture_destination="_feedback"
+	fi
+
+	local safe_blocked_reason
+	safe_blocked_reason="$(sanitize_text "$blocked_reason")"
+	printf '{"schema_version":1,"backend":"%s","agency_level":%s,"mode":"%s","headed":%s,"profile_policy":"%s","cookie_policy":"%s","proxy_policy":"%s","offload":"%s","capture_destination":"%s","safety_notes":[%s],"expected_artifacts":[%s],"blocked_reason":"%s"}\n' \
+		"$(json_escape "$backend")" \
+		"$agency_level" \
+		"$(json_escape "$mode")" \
+		"$(json_bool "$headed")" \
+		"$(json_escape "$profile_policy")" \
+		"$(json_escape "$cookie_policy")" \
+		"$(json_escape "$proxy_policy")" \
+		"$(json_escape "$offload")" \
+		"$(json_escape "$capture_destination")" \
+		"$safety_notes" \
+		"$expected_artifacts" \
+		"$(json_escape "$safe_blocked_reason")"
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	if [[ $# -gt 0 ]]; then
+		shift
+	fi
+
+	case "$command" in
+		help | -h | --help)
+			usage
+			return 0
+			;;
+		capabilities)
+			handle_capabilities "$@"
+			return $?
+			;;
+		doctor)
+			handle_doctor "$@"
+			return $?
+			;;
+		route)
+			handle_route "$@"
+			return $?
+			;;
+		*)
+			log_error "Unknown command: $command"
+			usage >&2
+			return 1
+			;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-reach-helper.sh
+++ b/.agents/scripts/tests/test-reach-helper.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-reach-helper.sh - Focused tests for reach-helper.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../reach-helper.sh"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+	local output="$1"
+	local expected="$2"
+	local description="$3"
+
+	if grep -Fq -- "$expected" <<<"$output"; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Expected output to contain: %s\n' "$expected"
+		printf '    Output: %s\n' "$output"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local output="$1"
+	local unexpected="$2"
+	local description="$3"
+
+	if grep -Fq -- "$unexpected" <<<"$output"; then
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Unexpected output: %s\n' "$unexpected"
+		printf '    Output: %s\n' "$output"
+	else
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	fi
+	return 0
+}
+
+assert_json_valid() {
+	local output="$1"
+	local description="$2"
+
+	if python3 -m json.tool >/dev/null 2>&1 <<<"$output"; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Invalid JSON: %s\n' "$output"
+	fi
+	return 0
+}
+
+assert_exit_failure() {
+	local description="$1"
+	shift
+
+	if "$@" >/tmp/reach-helper-test.out 2>/tmp/reach-helper-test.err; then
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+	else
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	fi
+	return 0
+}
+
+printf '=== Reach Helper Tests ===\n\n'
+
+help_output="$($HELPER help)"
+assert_contains "$help_output" "capabilities --format json" "help lists capabilities command"
+assert_contains "$help_output" "route --objective" "help lists route command"
+
+capabilities_output="$($HELPER capabilities --format json)"
+assert_json_valid "$capabilities_output" "capabilities emits valid JSON"
+assert_contains "$capabilities_output" '"key":"fetch"' "registry includes fetch capability"
+assert_contains "$capabilities_output" '"key":"crawler"' "registry includes crawler capability"
+assert_contains "$capabilities_output" '"key":"browser"' "registry includes browser capability"
+assert_contains "$capabilities_output" '"key":"persistent_profile"' "registry includes persistent profile capability"
+assert_contains "$capabilities_output" '"key":"cookie_session"' "registry includes cookie capability"
+assert_contains "$capabilities_output" '"key":"proxy_vpn"' "registry includes proxy capability"
+assert_contains "$capabilities_output" '"key":"inbox_capture"' "registry includes inbox capability"
+assert_contains "$capabilities_output" '"key":"knowledge_staging"' "registry includes knowledge capability"
+assert_contains "$capabilities_output" '"key":"performance_logging"' "registry includes performance capability"
+assert_contains "$capabilities_output" '"key":"feedback_mining"' "registry includes feedback capability"
+
+doctor_output="$(AIDEVOPS_REACH_TEST_FORCE_MISSING=1 $HELPER doctor --format json)"
+assert_json_valid "$doctor_output" "doctor emits valid JSON with missing tools"
+assert_contains "$doctor_output" '"contacted_targets":false' "doctor does not contact targets"
+assert_contains "$doctor_output" '"available":false' "doctor reports missing local readiness"
+
+route_output="$($HELPER route --objective "capture public documentation" --scope public --format json)"
+assert_json_valid "$route_output" "route emits valid JSON"
+assert_contains "$route_output" '"backend":"crawler"' "public documentation routes to crawler"
+assert_contains "$route_output" '"agency_level":2' "public documentation uses crawler agency level"
+assert_contains "$route_output" '"capture_destination":"_inbox"' "capture objective selects inbox destination"
+
+private_output="$($HELPER route --objective "private dashboard" --scope private --format json)"
+assert_contains "$private_output" '"backend":"manual_review"' "private unauthenticated route blocks"
+assert_contains "$private_output" '"blocked_reason":"private scope requires auth cookie, profile, or manual approval"' "blocked reason is explicit"
+
+sanitized_output="$($HELPER route --objective "capture https://user:pass@example.invalid private docs ${ROOT_DIR}" --scope private --format json)"
+assert_not_contains "$sanitized_output" "user:pass" "route output omits credential-like objective details"
+assert_not_contains "$sanitized_output" "$ROOT_DIR" "route output omits private local path"
+assert_not_contains "$sanitized_output" "example.invalid" "route output omits raw private target"
+
+assert_exit_failure "unknown command fails" "$HELPER" unknown-command
+
+printf '\nPassed: %d\nFailed: %d\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1712,6 +1712,7 @@ main() {
 			;;
 		esac
 		;;
+	reach) _dispatch_helper "reach-helper.sh" "reach-helper.sh" "$@" ;;
 	config | configure) _dispatch_config "$@" ;;
 	uninstall | remove) cmd_uninstall ;;
 	version | v | -v | --version) cmd_version ;;


### PR DESCRIPTION
## Summary

Added reach/capture capability documentation, a reach-helper CLI with capabilities/doctor/route JSON commands, aidevops reach dispatch, and focused tests for registry, doctor, routing, unknown commands, and sanitization.

## Files Changed

.agents/aidevops/reach-capture.md,.agents/scripts/reach-helper.sh,.agents/scripts/tests/test-reach-helper.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/reach-helper.sh .agents/scripts/tests/test-reach-helper.sh; .agents/scripts/tests/test-reach-helper.sh; ./aidevops.sh reach doctor --format json; ./aidevops.sh reach route --objective 'capture public documentation' --scope public --format json

Resolves #26165


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 9m and 118,809 tokens on this as a headless worker.