### PR TITLE
t18049: feat(reach): add failover health classification

### DIFF
--- a/.agents/aidevops/reach-capture.md
+++ b/.agents/aidevops/reach-capture.md
@@ -40,6 +40,8 @@ performance logs, or feedback artifacts.
   "proxy_policy": "none|avoid|authorized_only|required|blocked",
   "offload": "local|worker|manual",
   "capture_destination": "caller_selected|_inbox|_knowledge|_performance|_feedback",
+  "failure_policy": "sanitized retry and stop policy",
+  "failover_order": ["fetch", "crawler", "browser"],
   "safety_notes": ["sanitized notes only"],
   "expected_artifacts": ["sanitized artifact kinds only"],
   "blocked_reason": ""
@@ -53,10 +55,47 @@ isolation needs. Private/manual authentication without an approved reusable
 session returns `manual_review` with `blocked_reason` set instead of attempting
 capture.
 
+## Health Doctors
+
+`reach-helper.sh network doctor --format json` reports sanitized proxy/VPN
+readiness. It may expose provider class, check keys, boolean availability, and
+generic status values. It must not print IP addresses, proxy credentials,
+session IDs, cookies, private target strings, or local private paths.
+
+`reach-helper.sh fingerprint doctor --format json` reports sanitized browser and
+fingerprint/profile readiness. Profile types follow the anti-detect browser
+decision tree: persistent, clean, warm, or disposable. Doctor output is local
+readiness only and does not contact arbitrary targets.
+
+## Failure Classes and Failover
+
+`reach-helper.sh classify-failure --format json` emits:
+
+- `failure_class`: one of `success`, `network_timeout`, `proxy_unhealthy`,
+  `rate_limited`, `captcha_required`, `bot_block`, `auth_required`,
+  `scope_forbidden`, `selector_drift`, `content_empty`, or `unknown`.
+- `temporary`: whether backoff or a route change may plausibly succeed.
+- `retry_after_seconds`: conservative minimum wait before retrying.
+- `next_action`: sanitized action guidance.
+- `safe_to_failover`: whether an authorized alternate route may be used.
+- `requires_authorization`: whether new approval/session/scope is required.
+- `notes`: sanitized operational constraints.
+
+Failover is safe only for temporary classes such as `network_timeout`,
+`proxy_unhealthy`, `rate_limited`, `captcha_required`, `bot_block`, and
+`content_empty`, and only within the existing authorization boundary. Do not
+retry the same blocked identity after `bot_block`; switch only to a healthy,
+authorized profile/proxy or stop. `selector_drift` requires extraction repair,
+not identity failover. `auth_required` and `scope_forbidden` are hard stops:
+never recommend proxy, VPN, fingerprint, cookie, or profile failover without new
+authorization for that scope.
+
 ## Safety Boundaries
 
 - Do not contact arbitrary targets during `doctor` or `capabilities` checks.
 - Do not print credentials, cookie values, proxy auth, local private paths, or
   raw private target strings in route output.
+- Do not use proxy, VPN, fingerprint, profile, or cookie changes to bypass
+  authentication, authorization, robots, rate-limit, or terms boundaries.
 - Treat profile, cookie, proxy, inbox, knowledge, performance, and feedback
   mutation as follow-up work with separate task briefs and verification.

--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -26,6 +26,9 @@ Usage: reach-helper.sh <command> [options]
 Commands:
   capabilities --format json
   doctor --format json
+  network doctor --format json
+  fingerprint doctor --format json
+  classify-failure [--http-status <code>] [--has-login-wall true|false] [--has-captcha true|false] [--timeout true|false] [--selector-drift true|false] [--content-empty true|false] [--bot-block true|false] --format json
   route --objective <text> [--auth none|cookie|profile|manual] [--scope public|private] --format json
   help
 
@@ -274,6 +277,262 @@ handle_doctor() {
 	return 0
 }
 
+emit_network_doctor_json() {
+	local proxy_available="false"
+	local vpn_available="false"
+	local check_status="missing_helper"
+
+	if capability_available "proxy_vpn"; then
+		proxy_available="true"
+		check_status="ready"
+	fi
+	if helper_available nostr-vpn-helper.sh || command_available wg || command_available tailscale; then
+		vpn_available="true"
+		check_status="ready"
+	fi
+
+	printf '{"schema_version":1,"contacted_targets":false,"doctor":"network","provider_class":"proxy_or_vpn","checks":[{"key":"proxy_vpn","available":%s,"status":"%s"},{"key":"vpn","available":%s,"status":"%s"}],"notes":["sanitized readiness only","no IP addresses, proxy credentials, session IDs, cookies, or private paths are printed"]}\n' \
+		"$(json_bool "$proxy_available")" \
+		"$(json_escape "$check_status")" \
+		"$(json_bool "$vpn_available")" \
+		"$(json_escape "$check_status")"
+	return 0
+}
+
+emit_fingerprint_doctor_json() {
+	local profile_available="false"
+	local browser_available="false"
+	local profile_status="missing_helper"
+	local browser_status="missing_helper"
+
+	if capability_available "anti_detect_profile"; then
+		profile_available="true"
+		profile_status="ready"
+	fi
+	if capability_available "browser"; then
+		browser_available="true"
+		browser_status="ready"
+	fi
+
+	printf '{"schema_version":1,"contacted_targets":false,"doctor":"fingerprint","profile_type":"persistent_clean_warm_or_disposable","checks":[{"key":"anti_detect_profile","available":%s,"status":"%s"},{"key":"deterministic_browser","available":%s,"status":"%s"}],"notes":["authorized automation only","no profile paths, session IDs, cookies, or private targets are printed"]}\n' \
+		"$(json_bool "$profile_available")" \
+		"$(json_escape "$profile_status")" \
+		"$(json_bool "$browser_available")" \
+		"$(json_escape "$browser_status")"
+	return 0
+}
+
+handle_nested_doctor() {
+	local doctor_name="$1"
+	shift
+	local subcommand="${1:-}"
+	if [[ "$subcommand" != "doctor" ]]; then
+		log_error "$doctor_name requires the doctor subcommand"
+		return 1
+	fi
+	shift
+
+	local format="json"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--format)
+				shift
+				format="${1:-}"
+				;;
+			*)
+				log_error "Unknown $doctor_name doctor option: $arg"
+				return 1
+				;;
+		esac
+		shift || true
+	done
+	require_json_format "$format" || return 1
+
+	case "$doctor_name" in
+		network)
+			emit_network_doctor_json
+			return $?
+			;;
+		fingerprint)
+			emit_fingerprint_doctor_json
+			return $?
+			;;
+		*)
+			log_error "Unknown doctor: $doctor_name"
+			return 1
+			;;
+	esac
+}
+
+normalize_bool_option() {
+	local value="$1"
+	local option_name="$2"
+	case "$value" in
+		true | false)
+			printf '%s' "$value"
+			return 0
+			;;
+		*)
+			log_error "$option_name must be true or false"
+			return 1
+			;;
+	esac
+}
+
+classify_failure() {
+	local http_status="$1"
+	local has_login_wall="$2"
+	local has_captcha="$3"
+	local timeout="$4"
+	local selector_drift="$5"
+	local content_empty="$6"
+	local bot_block="$7"
+
+	failure_class="unknown"
+	temporary="false"
+	retry_after_seconds="0"
+	next_action="stop and inspect sanitized evidence before retrying"
+	safe_to_failover="false"
+	requires_authorization="false"
+	notes='"no credentials, cookies, IP addresses, session IDs, or private paths are included"'
+
+	if [[ "$timeout" == "true" ]]; then
+		failure_class="network_timeout"
+		temporary="true"
+		retry_after_seconds="60"
+		next_action="retry once with backoff, then use an authorized alternate route"
+		safe_to_failover="true"
+	elif [[ "$has_login_wall" == "true" || "$http_status" == "401" ]]; then
+		failure_class="auth_required"
+		next_action="stop and obtain explicit authorization or an approved reusable session"
+		requires_authorization="true"
+	elif [[ "$http_status" == "403" ]]; then
+		failure_class="scope_forbidden"
+		next_action="stop; do not fail over without new authorization for the protected scope"
+		requires_authorization="true"
+	elif [[ "$has_captcha" == "true" ]]; then
+		failure_class="captcha_required"
+		temporary="true"
+		next_action="pause for authorized CAPTCHA handling; do not bypass policy"
+	elif [[ "$bot_block" == "true" || "$http_status" == "418" ]]; then
+		failure_class="bot_block"
+		temporary="true"
+		retry_after_seconds="300"
+		next_action="stop current identity and use only an authorized fresh profile or proxy"
+		safe_to_failover="true"
+	elif [[ "$http_status" == "407" || "$http_status" == "502" || "$http_status" == "503" ]]; then
+		failure_class="proxy_unhealthy"
+		temporary="true"
+		retry_after_seconds="120"
+		next_action="run network doctor and switch only to a healthy authorized proxy or VPN"
+		safe_to_failover="true"
+	elif [[ "$http_status" == "429" ]]; then
+		failure_class="rate_limited"
+		temporary="true"
+		retry_after_seconds="300"
+		next_action="respect rate limits, back off, then retry or fail over within authorization"
+		safe_to_failover="true"
+	elif [[ "$selector_drift" == "true" ]]; then
+		failure_class="selector_drift"
+		next_action="update selectors or extraction logic before retrying"
+	elif [[ "$content_empty" == "true" ]]; then
+		failure_class="content_empty"
+		temporary="true"
+		retry_after_seconds="30"
+		next_action="retry with a lower-agency parser, then escalate to deterministic browser if authorized"
+		safe_to_failover="true"
+	elif [[ "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+		failure_class="success"
+		next_action="continue with extraction"
+	elif [[ "$http_status" == "408" || "$http_status" == "504" ]]; then
+		failure_class="network_timeout"
+		temporary="true"
+		retry_after_seconds="60"
+		next_action="retry once with backoff, then use an authorized alternate route"
+		safe_to_failover="true"
+	fi
+	return 0
+}
+
+handle_classify_failure() {
+	local http_status="0"
+	local has_login_wall="false"
+	local has_captcha="false"
+	local timeout="false"
+	local selector_drift="false"
+	local content_empty="false"
+	local bot_block="false"
+	local format="json"
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--http-status)
+				shift
+				http_status="${1:-0}"
+				;;
+			--has-login-wall)
+				shift
+				has_login_wall="$(normalize_bool_option "${1:-}" "$arg")" || return 1
+				;;
+			--has-captcha)
+				shift
+				has_captcha="$(normalize_bool_option "${1:-}" "$arg")" || return 1
+				;;
+			--timeout)
+				shift
+				timeout="$(normalize_bool_option "${1:-}" "$arg")" || return 1
+				;;
+			--selector-drift)
+				shift
+				selector_drift="$(normalize_bool_option "${1:-}" "$arg")" || return 1
+				;;
+			--content-empty)
+				shift
+				content_empty="$(normalize_bool_option "${1:-}" "$arg")" || return 1
+				;;
+			--bot-block)
+				shift
+				bot_block="$(normalize_bool_option "${1:-}" "$arg")" || return 1
+				;;
+			--format)
+				shift
+				format="${1:-}"
+				;;
+			*)
+				log_error "Unknown classify-failure option: $arg"
+				return 1
+				;;
+		esac
+		shift || true
+	done
+	require_json_format "$format" || return 1
+	if [[ ! "$http_status" =~ ^[0-9][0-9][0-9]$ && "$http_status" != "0" ]]; then
+		log_error "--http-status must be a three-digit status code"
+		return 1
+	fi
+
+	local failure_class=""
+	local temporary=""
+	local retry_after_seconds=""
+	local next_action=""
+	local safe_to_failover=""
+	local requires_authorization=""
+	local notes=""
+	classify_failure "$http_status" "$has_login_wall" "$has_captcha" "$timeout" "$selector_drift" "$content_empty" "$bot_block"
+
+	printf '{"schema_version":1,"failure_class":"%s","temporary":%s,"retry_after_seconds":%s,"next_action":"%s","safe_to_failover":%s,"requires_authorization":%s,"notes":[%s]}\n' \
+		"$(json_escape "$failure_class")" \
+		"$(json_bool "$temporary")" \
+		"$retry_after_seconds" \
+		"$(json_escape "$next_action")" \
+		"$(json_bool "$safe_to_failover")" \
+		"$(json_bool "$requires_authorization")" \
+		"$notes"
+	return 0
+}
+
 lower_text() {
 	local input="$1"
 	printf '%s' "$input" | tr '[:upper:]' '[:lower:]'
@@ -292,6 +551,8 @@ route_set_defaults() {
 	capture_destination="caller_selected"
 	safety_notes='"start with public/static retrieval before browser automation","route output is sanitized and advisory only"'
 	expected_artifacts='"static response or parsed text"'
+	failure_policy="retry_temporary_failures_only; stop on auth_required or scope_forbidden without new authorization"
+	failover_order='"fetch","crawler","browser","persistent_profile","cookie_session","anti_detect_profile","proxy_vpn"'
 	blocked_reason=""
 	return 0
 }
@@ -308,6 +569,8 @@ route_set_private_block() {
 	capture_destination="caller_selected"
 	safety_notes='"private scope requires explicit authorization or approved reusable session","no target details are echoed"'
 	expected_artifacts='"authorization decision"'
+	failure_policy="authorization_required; failover is blocked until scope is approved"
+	failover_order=''
 	blocked_reason="private scope requires auth cookie, profile, or manual approval"
 	return 0
 }
@@ -323,6 +586,8 @@ route_set_manual_auth() {
 	offload="manual"
 	safety_notes='"manual authentication must stay user-controlled","no credential or target details are echoed"'
 	expected_artifacts='"manual auth handoff notes"'
+	failure_policy="manual_authentication_required; failover is blocked until authorization is captured"
+	failover_order=''
 	blocked_reason="manual authentication required"
 	return 0
 }
@@ -336,6 +601,8 @@ route_set_cookie_session() {
 	proxy_policy="authorized_only"
 	expected_artifacts='"storage state or authenticated API response"'
 	safety_notes='"reuse only approved cookie sessions","never print cookie values"'
+	failure_policy="stop on auth_required or scope_forbidden; otherwise retry once before authorized failover"
+	failover_order='"cookie_session","persistent_profile","browser"'
 	return 0
 }
 
@@ -349,6 +616,8 @@ route_set_persistent_profile() {
 	proxy_policy="authorized_only"
 	expected_artifacts='"profile-backed trace or download"'
 	safety_notes='"use only approved persistent profiles","do not mutate profiles from this helper"'
+	failure_policy="stop on auth_required or scope_forbidden; do not switch identity without approval"
+	failover_order='"persistent_profile","cookie_session","browser"'
 	return 0
 }
 
@@ -362,6 +631,8 @@ route_set_stealth() {
 	proxy_policy="authorized_only"
 	expected_artifacts='"authorized isolated browser trace"'
 	safety_notes='"anti-detect and proxy use require explicit authorization","do not print proxy credentials"'
+	failure_policy="fail over only for temporary network, rate-limit, CAPTCHA, bot-block, or empty-content classes; stop on auth_required and scope_forbidden"
+	failover_order='"anti_detect_profile","proxy_vpn","browser","crawler","fetch"'
 	return 0
 }
 
@@ -375,6 +646,8 @@ route_set_browser() {
 	proxy_policy="none"
 	expected_artifacts='"DOM text, trace, screenshot only when needed, or download"'
 	safety_notes='"prefer ARIA and DOM extraction over screenshots","use deterministic selectors before high-agency tools"'
+	failure_policy="retry selector or temporary network failures; stop on auth_required or scope_forbidden"
+	failover_order='"browser","crawler","fetch","persistent_profile"'
 	return 0
 }
 
@@ -387,6 +660,8 @@ route_set_crawler() {
 	proxy_policy="none"
 	expected_artifacts='"crawl manifest and extracted records"'
 	safety_notes='"crawl only public or authorized content","respect robots and rate limits"'
+	failure_policy="retry temporary failures with backoff; escalate to browser only when authorized"
+	failover_order='"crawler","fetch","browser"'
 	return 0
 }
 
@@ -476,6 +751,8 @@ handle_route() {
 	local capture_destination=""
 	local safety_notes=""
 	local expected_artifacts=""
+	local failure_policy=""
+	local failover_order=""
 	local blocked_reason=""
 	route_set_defaults
 
@@ -494,7 +771,7 @@ handle_route() {
 
 	local safe_blocked_reason
 	safe_blocked_reason="$(sanitize_text "$blocked_reason")"
-	printf '{"schema_version":1,"backend":"%s","agency_level":%s,"mode":"%s","headed":%s,"profile_policy":"%s","cookie_policy":"%s","proxy_policy":"%s","offload":"%s","capture_destination":"%s","safety_notes":[%s],"expected_artifacts":[%s],"blocked_reason":"%s"}\n' \
+	printf '{"schema_version":1,"backend":"%s","agency_level":%s,"mode":"%s","headed":%s,"profile_policy":"%s","cookie_policy":"%s","proxy_policy":"%s","offload":"%s","capture_destination":"%s","failure_policy":"%s","failover_order":[%s],"safety_notes":[%s],"expected_artifacts":[%s],"blocked_reason":"%s"}\n' \
 		"$(json_escape "$backend")" \
 		"$agency_level" \
 		"$(json_escape "$mode")" \
@@ -504,6 +781,8 @@ handle_route() {
 		"$(json_escape "$proxy_policy")" \
 		"$(json_escape "$offload")" \
 		"$(json_escape "$capture_destination")" \
+		"$(json_escape "$failure_policy")" \
+		"$failover_order" \
 		"$safety_notes" \
 		"$expected_artifacts" \
 		"$(json_escape "$safe_blocked_reason")"
@@ -527,6 +806,18 @@ main() {
 			;;
 		doctor)
 			handle_doctor "$@"
+			return $?
+			;;
+		network)
+			handle_nested_doctor "network" "$@"
+			return $?
+			;;
+		fingerprint)
+			handle_nested_doctor "fingerprint" "$@"
+			return $?
+			;;
+		classify-failure)
+			handle_classify_failure "$@"
 			return $?
 			;;
 		route)

--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -407,20 +407,21 @@ classify_failure() {
 		failure_class="auth_required"
 		next_action="stop and obtain explicit authorization or an approved reusable session"
 		requires_authorization="true"
-	elif [[ "$http_status" == "403" ]]; then
-		failure_class="scope_forbidden"
-		next_action="stop; do not fail over without new authorization for the protected scope"
-		requires_authorization="true"
 	elif [[ "$has_captcha" == "true" ]]; then
 		failure_class="captcha_required"
 		temporary="true"
 		next_action="pause for authorized CAPTCHA handling; do not bypass policy"
+		safe_to_failover="true"
 	elif [[ "$bot_block" == "true" || "$http_status" == "418" ]]; then
 		failure_class="bot_block"
 		temporary="true"
 		retry_after_seconds="300"
 		next_action="stop current identity and use only an authorized fresh profile or proxy"
 		safe_to_failover="true"
+	elif [[ "$http_status" == "403" ]]; then
+		failure_class="scope_forbidden"
+		next_action="stop; do not fail over without new authorization for the protected scope"
+		requires_authorization="true"
 	elif [[ "$http_status" == "407" || "$http_status" == "502" || "$http_status" == "503" ]]; then
 		failure_class="proxy_unhealthy"
 		temporary="true"

--- a/.agents/scripts/tests/test-reach-failover.sh
+++ b/.agents/scripts/tests/test-reach-failover.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-reach-failover.sh - Focused tests for reach failure classification.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../reach-helper.sh"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+	local output="$1"
+	local expected="$2"
+	local description="$3"
+
+	if grep -Fq -- "$expected" <<<"$output"; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Expected output to contain: %s\n' "$expected"
+		printf '    Output: %s\n' "$output"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local output="$1"
+	local unexpected="$2"
+	local description="$3"
+
+	if grep -Fq -- "$unexpected" <<<"$output"; then
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Unexpected output: %s\n' "$unexpected"
+		printf '    Output: %s\n' "$output"
+	else
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	fi
+	return 0
+}
+
+assert_json_valid() {
+	local output="$1"
+	local description="$2"
+
+	if python3 -m json.tool >/dev/null 2>&1 <<<"$output"; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Invalid JSON: %s\n' "$output"
+	fi
+	return 0
+}
+
+run_classifier() {
+	"$HELPER" classify-failure "$@" --format json
+	return $?
+}
+
+printf '=== Reach Failover Tests ===\n\n'
+
+network_output="$(AIDEVOPS_REACH_TEST_FORCE_MISSING=1 "$HELPER" network doctor --format json)"
+assert_json_valid "$network_output" "network doctor emits valid JSON"
+assert_contains "$network_output" '"doctor":"network"' "network doctor identifies itself"
+assert_contains "$network_output" '"contacted_targets":false' "network doctor does not contact targets"
+assert_not_contains "$network_output" "user:pass" "network doctor omits proxy credentials"
+assert_not_contains "$network_output" "$ROOT_DIR" "network doctor omits private paths"
+
+fingerprint_output="$(AIDEVOPS_REACH_TEST_FORCE_MISSING=1 "$HELPER" fingerprint doctor --format json)"
+assert_json_valid "$fingerprint_output" "fingerprint doctor emits valid JSON"
+assert_contains "$fingerprint_output" '"doctor":"fingerprint"' "fingerprint doctor identifies itself"
+assert_contains "$fingerprint_output" '"contacted_targets":false' "fingerprint doctor does not contact targets"
+assert_not_contains "$fingerprint_output" "$HOME" "fingerprint doctor omits home path"
+
+timeout_output="$(run_classifier --timeout true)"
+assert_contains "$timeout_output" '"failure_class":"network_timeout"' "timeout maps to network_timeout"
+assert_contains "$timeout_output" '"temporary":true' "timeout is temporary"
+assert_contains "$timeout_output" '"safe_to_failover":true' "timeout can fail over safely"
+
+captcha_output="$(run_classifier --has-captcha true)"
+assert_contains "$captcha_output" '"failure_class":"captcha_required"' "CAPTCHA maps to captcha_required"
+assert_contains "$captcha_output" '"temporary":true' "CAPTCHA is temporary"
+
+login_output="$(run_classifier --has-login-wall true)"
+assert_contains "$login_output" '"failure_class":"auth_required"' "login wall maps to auth_required"
+assert_contains "$login_output" '"requires_authorization":true' "login wall requires authorization"
+assert_contains "$login_output" '"safe_to_failover":false' "login wall cannot fail over"
+
+forbidden_output="$(run_classifier --http-status 403)"
+assert_contains "$forbidden_output" '"failure_class":"scope_forbidden"' "403 maps to scope_forbidden"
+assert_contains "$forbidden_output" '"requires_authorization":true' "403 requires authorization"
+assert_contains "$forbidden_output" '"safe_to_failover":false' "403 cannot fail over"
+
+rate_output="$(run_classifier --http-status 429)"
+assert_contains "$rate_output" '"failure_class":"rate_limited"' "429 maps to rate_limited"
+assert_contains "$rate_output" '"retry_after_seconds":300' "429 recommends backoff"
+
+selector_output="$(run_classifier --selector-drift true)"
+assert_contains "$selector_output" '"failure_class":"selector_drift"' "selector drift is classified"
+assert_contains "$selector_output" '"safe_to_failover":false' "selector drift needs repair, not failover"
+
+empty_output="$(run_classifier --content-empty true)"
+assert_contains "$empty_output" '"failure_class":"content_empty"' "empty content is classified"
+assert_contains "$empty_output" '"safe_to_failover":true' "empty content can use authorized failover"
+
+unknown_output="$(run_classifier --http-status 520)"
+assert_contains "$unknown_output" '"failure_class":"unknown"' "unknown status remains unknown"
+assert_contains "$unknown_output" '"safe_to_failover":false' "unknown status does not fail over by default"
+
+route_output="$($HELPER route --objective "proxy capture https://user:pass@example.invalid ${ROOT_DIR}" --format json)"
+assert_json_valid "$route_output" "route with failover fields emits valid JSON"
+assert_contains "$route_output" '"failure_policy":' "route includes failure policy"
+assert_contains "$route_output" '"failover_order":[' "route includes failover order"
+assert_not_contains "$route_output" "user:pass" "route output omits objective credentials"
+assert_not_contains "$route_output" "example.invalid" "route output omits raw target"
+assert_not_contains "$route_output" "$ROOT_DIR" "route output omits private local path"
+
+printf '\nPassed: %d\nFailed: %d\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/tests/test-reach-failover.sh
+++ b/.agents/scripts/tests/test-reach-failover.sh
@@ -89,6 +89,7 @@ assert_contains "$timeout_output" '"safe_to_failover":true' "timeout can fail ov
 captcha_output="$(run_classifier --has-captcha true)"
 assert_contains "$captcha_output" '"failure_class":"captcha_required"' "CAPTCHA maps to captcha_required"
 assert_contains "$captcha_output" '"temporary":true' "CAPTCHA is temporary"
+assert_contains "$captcha_output" '"safe_to_failover":true' "CAPTCHA can use authorized failover"
 
 login_output="$(run_classifier --has-login-wall true)"
 assert_contains "$login_output" '"failure_class":"auth_required"' "login wall maps to auth_required"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1126,8 +1126,13 @@ cmd_version() {
 _dispatch_helper() {
 	local script_name="$1" error_name="$2"
 	shift 2
-	local hp="$AGENTS_DIR/scripts/$script_name"
-	[[ ! -f "$hp" ]] && hp="$INSTALL_DIR/.agents/scripts/$script_name"
+	local source_hp="$INSTALL_DIR/.agents/scripts/$script_name"
+	local deployed_hp="$AGENTS_DIR/scripts/$script_name"
+	local hp="$deployed_hp"
+	if [[ -f "$source_hp" && -f "$INSTALL_DIR/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh" ]]; then
+		hp="$source_hp"
+	fi
+	[[ ! -f "$hp" ]] && hp="$source_hp"
 	if [[ -f "$hp" ]]; then
 		bash "$hp" "$@"
 	else


### PR DESCRIPTION
## Summary

Added sanitized reach network and fingerprint doctor commands, failure classification JSON output, route failure policy/failover order fields, docs for failure classes, and focused failover/sanitization tests.

## Files Changed

.agents/aidevops/reach-capture.md,.agents/scripts/reach-helper.sh,.agents/scripts/tests/test-reach-failover.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck aidevops.sh .agents/scripts/reach-helper.sh .agents/scripts/tests/test-reach-failover.sh; .agents/scripts/tests/test-reach-helper.sh; .agents/scripts/tests/test-reach-failover.sh; ./aidevops.sh reach network doctor --format json; ./aidevops.sh reach classify-failure --http-status 429 --format json

Resolves #26167


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 10m and 125,234 tokens on this as a headless worker.