### PR TITLE
GH#26175: docs: add UI design briefing guidance

### DIFF
--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -51,6 +51,7 @@ Treat valuable session learning as system input, not disposable transcript conte
 - **Apply now** when the lesson directly improves the user's requested aim without widening risk.
 - **Brief for workers** when the lesson exposes a fixable bug, missing validator, missing doc, recurring failure mode, or automation gap. Use worker-ready context: files, pattern, evidence, verification, and an explicit note when paths are unknown.
 - **Store memory/reference** when the lesson is reusable but not immediately dispatchable, especially diagnostics, edge cases, duplicate patterns, and "similar but different" hazards.
+- **Route design learning by scope:** durable repo-specific UI patterns belong in that repo's `DESIGN.md`; generic aidevops briefing/verification patterns become aidevops issues with anonymised evidence; uncertain or broad design lessons become worker-ready follow-ups instead of bloating global docs.
 - **Avoid speculative bloat:** capture observed examples and evidence; do not add global guidance for hypothetical failures.
 
 ### Similar-but-different hazards

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -232,7 +232,15 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
       keep the startup file to a short rule/pointer, move long rationale/examples to
       a reference or workflow doc, and verify `.agents/AGENTS.md` stays under the
       agents-md-size-check CI ratchet unless the PR explicitly justifies a baseline
-      bump. -->
+      bump.
+
+      UI/UX CONTEXT PROMPT:
+      For layout, styling, component, or UX tasks, add compact design context where
+      it helps the worker choose the right pattern: repo `DESIGN.md` status/path;
+      relevant rule or canonical example; similar-but-different alternatives that
+      were considered and why they do/do not apply; and responsive/accessibility
+      evidence expected. Reference `tools/design/design-md.md` and
+      `workflows/ui-verification.md` instead of expanding a mandatory design essay. -->
 
 ### Progressive Context Plan
 
@@ -247,6 +255,7 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
 - **Load only if:** `{path or doc}` — {trigger condition; e.g., conflict, CI failure, shell complexity gate}
 - **Why:** {the implementation choice or safety constraint this context informs}
 - **Stop when:** {evidence gathered; e.g., target function, reference pattern, constraints, and verification command are clear}
+- **For UI/UX tasks:** {DESIGN.md path/status, rule/example to follow, close alternatives to avoid, and responsive/accessibility evidence needed}
 
 ### Worker Quick-Start
 
@@ -344,11 +353,16 @@ from `_parse_phases_section` — then add new logic to the slimmed parent functi
      critical tested path. Advisory failures should become follow-up issues with
      evidence, not hidden blockers. See `.agents/reference/ci-gate-policy.md`.
 
-     Generated-type lint trap: when changed files depend on generated Content
-     Collections or route/content types, include the CI changed-file lint path
-     when available: `node .github/scripts/lint-changed-files.mjs --base-ref <base>`.
-     Prefer runtime validation, local schemas, or typed wrappers that lint before
-     generation; avoid unused blanket eslint disables. -->
+      Generated-type lint trap: when changed files depend on generated Content
+      Collections or route/content types, include the CI changed-file lint path
+      when available: `node .github/scripts/lint-changed-files.mjs --base-ref <base>`.
+      Prefer runtime validation, local schemas, or typed wrappers that lint before
+      generation; avoid unused blanket eslint disables.
+
+      UI/UX verification prompt: for layout-affecting changes, require evidence at
+      mobile/tablet/desktop widths when practical, name accessibility checks, and
+      state whether repo DESIGN.md was checked, updated, or intentionally left for
+      a follow-up. -->
 
 ```bash
 {Command(s) to confirm the implementation works — e.g., shellcheck, grep, test run}
@@ -429,6 +443,7 @@ that defines how to machine-check the criterion. See `.agents/scripts/verify-bri
 
 - [ ] Tests pass (`npm test` / `bun test` / project-specific)
 - [ ] Lint clean (`eslint` / `shellcheck` / project-specific; React/TypeScript ESLint warnings such as `react-hooks/exhaustive-deps` count as actionable even when lint exits `0`)
+- [ ] UI changes cite the checked/updated DESIGN.md source or a follow-up issue; layout changes include mobile/tablet/desktop responsive evidence and named accessibility checks.
 - [ ] Qlty smells resolved (for `#simplification` tasks): `~/.qlty/bin/qlty smells --all 2>&1 | grep '<target_file>' | grep -c . | grep -q '^0$'`
 
   ```yaml

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -164,6 +164,7 @@ A dispatch comment that says "implement issue #42" teaches nothing. One that say
 - **Routing**: See `brief/routing.md` for when to use this agent (work item creation, comments, PR descriptions)
 - **Headless resilience**: Anticipate empty results, wrong paths, ambiguous states in headless briefs. Every step should answer "what if this returns nothing?" Details: `brief/tier-standard.md`
 - **Progressive context**: For tasks with 3+ workflow/reference docs or >2,000 reference lines, include `### Progressive Context Plan` from `templates/brief-template.md` so workers know what to load, when, why, and when to stop.
+- **UI/UX briefs**: Include repo `DESIGN.md` status/path, the relevant rule or canonical example, similar-but-different alternatives considered, and a responsive/accessibility verification plan. Point to `tools/design/design-md.md` and `workflows/ui-verification.md`; do not inline a full design template.
 - **Tier-specific formats**:
   - `tier:simple` → `brief/tier-simple.md` (prescriptive, exact code blocks)
   - `tier:standard` → `brief/tier-standard.md` (skeletons, judgment required)


### PR DESCRIPTION
## Summary

Added compact UI/UX briefing guidance for DESIGN.md context, similar-but-different design alternatives, responsive/accessibility evidence, and design-learning routing without expanding always-loaded guidance.

## Files Changed

.agents/reference/self-improvement.md,.agents/templates/brief-template.md,.agents/workflows/brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep -n 'DESIGN.md\|responsive\|similar-but-different\|design learning' .agents/workflows/brief.md .agents/templates/brief-template.md .agents/reference/self-improvement.md (passed); .agents/scripts/linters-local.sh reached Secretlint and timed out twice after earlier gates passed; changed-file Secretlint passed with: secretlint .agents/workflows/brief.md .agents/templates/brief-template.md .agents/reference/self-improvement.md --format compact

Resolves #26175


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 11m and 66,948 tokens on this as a headless worker.