### PR TITLE
GH#26210: fix: preserve network doctor check statuses

### DIFF
--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -280,23 +280,24 @@ handle_doctor() {
 emit_network_doctor_json() {
 	local proxy_available="false"
 	local vpn_available="false"
-	local check_status="missing_helper"
+	local proxy_status="missing_helper"
+	local vpn_status="missing_helper"
 
 	if capability_available "proxy_vpn"; then
 		proxy_available="true"
-		check_status="ready"
+		proxy_status="ready"
 	fi
 	if helper_available nostr-vpn-helper.sh || command_available wg || command_available tailscale; then
 		vpn_available="true"
-		check_status="ready"
+		vpn_status="ready"
 	fi
 
 	printf '{"schema_version":1,"contacted_targets":false,"doctor":"network","provider_class":"proxy_or_vpn","checks":[{"key":"proxy_vpn","available":%s,"status":"%s"},{"key":"vpn","available":%s,"status":"%s"}],"notes":["sanitized readiness only","no IP addresses, proxy credentials, session IDs, cookies, or private paths are printed"]}\n' \
 		"$(json_bool "$proxy_available")" \
-		"$(json_escape "$check_status")" \
+		"$(json_escape "$proxy_status")" \
 		"$(json_bool "$vpn_available")" \
-		"$(json_escape "$check_status")"
-	return 0
+		"$(json_escape "$vpn_status")"
+	return $?
 }
 
 emit_fingerprint_doctor_json() {

--- a/.agents/scripts/tests/test-reach-failover.sh
+++ b/.agents/scripts/tests/test-reach-failover.sh
@@ -75,6 +75,26 @@ assert_contains "$network_output" '"contacted_targets":false' "network doctor do
 assert_not_contains "$network_output" "user:pass" "network doctor omits proxy credentials"
 assert_not_contains "$network_output" "$ROOT_DIR" "network doctor omits private paths"
 
+isolated_network_doctor() {
+	local temp_dir=""
+	local temp_bin=""
+	temp_dir="$(mktemp -d)"
+	temp_bin="${temp_dir}/bin"
+	mkdir -p "$temp_bin"
+	cp "$HELPER" "${temp_dir}/reach-helper.sh"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"${temp_dir}/anti-detect-helper.sh"
+	chmod +x "${temp_dir}/anti-detect-helper.sh"
+	ln -s /usr/bin/dirname "${temp_bin}/dirname"
+	PATH="$temp_bin" /bin/bash "${temp_dir}/reach-helper.sh" network doctor --format json
+	rm -rf "$temp_dir"
+	return 0
+}
+
+mixed_network_output="$(isolated_network_doctor)"
+assert_json_valid "$mixed_network_output" "network doctor emits valid JSON with mixed readiness"
+assert_contains "$mixed_network_output" '{"key":"proxy_vpn","available":true,"status":"ready"}' "network doctor reports proxy readiness independently"
+assert_contains "$mixed_network_output" '{"key":"vpn","available":false,"status":"missing_helper"}' "network doctor preserves missing VPN status independently"
+
 fingerprint_output="$(AIDEVOPS_REACH_TEST_FORCE_MISSING=1 "$HELPER" fingerprint doctor --format json)"
 assert_json_valid "$fingerprint_output" "fingerprint doctor emits valid JSON"
 assert_contains "$fingerprint_output" '"doctor":"fingerprint"' "fingerprint doctor identifies itself"


### PR DESCRIPTION
## Summary

Updated network doctor JSON emission to track proxy and VPN readiness with independent status variables, and added a mixed-readiness regression test.

## Files Changed

.agents/scripts/reach-helper.sh,.agents/scripts/tests/test-reach-failover.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-reach-failover.sh; shellcheck .agents/scripts/reach-helper.sh .agents/scripts/tests/test-reach-failover.sh

Resolves #26210


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 5m and 52,673 tokens on this as a headless worker.