### PR TITLE
t18050: feat(reach): add capture inbox workflow

### DIFF
--- a/.agents/aidevops/knowledge-plane.md
+++ b/.agents/aidevops/knowledge-plane.md
@@ -38,6 +38,14 @@ _knowledge/          ← root (or ~/.aidevops/.agent-workspace/knowledge/)
 **Provision:** `aidevops knowledge init repo` or `aidevops knowledge init personal`.
 **Repair:** `aidevops knowledge provision` is idempotent — safe to re-run.
 
+Reach-captured web/app evidence enters knowledge only through `_knowledge/inbox/`
+or `_knowledge/staging/`. `reach capture --dest knowledge-inbox` writes raw
+artifacts under `_knowledge/inbox/web/` with `sensitivity:"unverified"`,
+`trust:"unverified"`, and `review_required:true`; promotion into `sources/` or
+`collections/` requires a separate review path. The capture command also appends
+an `_inbox/triage.log` audit row with `source:"reach-capture"` so provenance is
+visible before durable knowledge-plane ingestion.
+
 ## .gitignore Rules
 
 The provisioner writes two sets of `.gitignore` rules:

--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -19,6 +19,17 @@ if ! type log_error &>/dev/null; then
 	}
 fi
 
+readonly REACH_KEY_SCHEMA_VERSION="schema_version"
+readonly REACH_KEY_BACKEND="backend"
+readonly REACH_KEY_SENSITIVITY="sensitivity"
+readonly REACH_KEY_TRUST="trust"
+readonly REACH_VAL_UNVERIFIED="unverified"
+readonly REACH_VAL_NONE="none"
+readonly REACH_VAL_FETCH="fetch"
+readonly REACH_VAL_AUTO="auto"
+readonly REACH_VAL_FILE="file"
+readonly REACH_VAL_UNAVAILABLE="unavailable"
+
 usage() {
 	cat <<'EOF'
 Usage: reach-helper.sh <command> [options]
@@ -32,6 +43,7 @@ Commands:
   cookie status|register|clear [options] --format json
   classify-failure [--http-status <code>] [--has-login-wall true|false] [--has-captcha true|false] [--timeout true|false] [--selector-drift true|false] [--content-empty true|false] [--bot-block true|false] --format json
   route --objective <text> [--auth none|cookie|profile|manual] [--scope public|private] --format json
+  capture --input <url-or-file> [--dest inbox|knowledge-inbox] [--method auto|file|fetch|crawl|browser] --format json
   help
 
 The helper does not contact arbitrary targets. Profile/cookie broker commands
@@ -133,9 +145,62 @@ safe_hash() {
 	elif command_available python3; then
 		hash_value="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())' <<<"$input")"
 	else
-		hash_value="unavailable"
+		hash_value="$REACH_VAL_UNAVAILABLE"
 	fi
 	printf '%s' "${hash_value:0:16}"
+	return 0
+}
+
+safe_sha256() {
+	local input="$1"
+	local hash_value=""
+	if command_available sha256sum; then
+		# shell-portability: ignore next -- guarded by command_available; shasum/python3 fallbacks cover macOS.
+		hash_value="$(printf '%s' "$input" | sha256sum | cut -d' ' -f1)"
+	elif command_available shasum; then
+		hash_value="$(printf '%s' "$input" | shasum -a 256 | cut -d' ' -f1)"
+	elif command_available python3; then
+		hash_value="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())' <<<"$input")"
+	else
+		hash_value="$REACH_VAL_UNAVAILABLE"
+	fi
+	printf '%s' "$hash_value"
+	return 0
+}
+
+file_sha256() {
+	local file_path="$1"
+	local hash_value=""
+	if command_available sha256sum; then
+		# shell-portability: ignore next -- guarded by command_available; shasum/python3 fallbacks cover macOS.
+		hash_value="$(sha256sum "$file_path" | cut -d' ' -f1)"
+	elif command_available shasum; then
+		hash_value="$(shasum -a 256 "$file_path" | cut -d' ' -f1)"
+	elif command_available python3; then
+		hash_value="$(python3 - "$file_path" <<'PY'
+import hashlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(hashlib.sha256(handle.read()).hexdigest())
+PY
+)"
+	else
+		hash_value="$REACH_VAL_UNAVAILABLE"
+	fi
+	printf '%s' "$hash_value"
+	return 0
+}
+
+file_bytes() {
+	local file_path="$1"
+	local byte_count=""
+	if byte_count="$(wc -c <"$file_path")"; then
+		byte_count="${byte_count//[[:space:]]/}"
+		printf '%s' "$byte_count"
+		return 0
+	fi
+	printf '0'
 	return 0
 }
 
@@ -165,6 +230,65 @@ PY
 		return 0
 	fi
 	date -u -r "$epoch_value" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d "@$epoch_value" '+%Y-%m-%dT%H:%M:%SZ'
+	return 0
+}
+
+epoch_to_stamp() {
+	local epoch_value="$1"
+	if command_available python3; then
+		python3 - "$epoch_value" <<'PY'
+import datetime
+import sys
+
+timestamp = int(sys.argv[1])
+if hasattr(datetime, "UTC"):
+    dt = datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
+else:
+    dt = datetime.datetime.utcfromtimestamp(timestamp)
+print(dt.strftime("%Y%m%dT%H%M%SZ"))
+PY
+		return 0
+	fi
+	date -u -r "$epoch_value" '+%Y%m%dT%H%M%SZ' 2>/dev/null || date -u -d "@$epoch_value" '+%Y%m%dT%H%M%SZ'
+	return 0
+}
+
+relative_path() {
+	local file_path="$1"
+	local root_path="${2:-$PWD}"
+	if [[ "$file_path" == "$root_path"/* ]]; then
+		printf '%s' "${file_path#"$root_path"/}"
+		return 0
+	fi
+	printf '%s' "$file_path"
+	return 0
+}
+
+capture_source_label() {
+	local input_ref="$1"
+	local method_value="$2"
+	local label=""
+	if [[ "$method_value" == "$REACH_VAL_FILE" && -f "$input_ref" ]]; then
+		label="local-file:$(basename "$input_ref")"
+	elif [[ "$input_ref" =~ ^https?:// ]]; then
+		label="url:$(safe_hash "$input_ref")"
+	else
+		label="input:$(safe_hash "$input_ref")"
+	fi
+	printf '%s' "$(sanitize_text "$label")"
+	return 0
+}
+
+capture_slug() {
+	local input_ref="$1"
+	local method_value="$2"
+	local slug_source=""
+	if [[ "$method_value" == "$REACH_VAL_FILE" && -f "$input_ref" ]]; then
+		slug_source="$(basename "$input_ref")"
+	else
+		slug_source="capture-$(safe_hash "$input_ref")"
+	fi
+	safe_key "$slug_source"
 	return 0
 }
 
@@ -200,6 +324,8 @@ json_field_value() {
 	python3 - "$file_path" "$field_name" <<'PY'
 import json
 import sys
+
+ENCODING = "utf-8"
 
 with open(sys.argv[1], "r", encoding="utf-8") as handle:
     data = json.load(handle)
@@ -1365,6 +1491,278 @@ handle_route() {
 	return 0
 }
 
+capture_extension_for_input() {
+	local input_ref="$1"
+	local extension="md"
+	case "${input_ref##*.}" in
+		html | htm) extension="html" ;;
+		md | markdown) extension="md" ;;
+		txt | text) extension="txt" ;;
+		json) extension="json" ;;
+		*) extension="md" ;;
+	esac
+	printf '%s' "$extension"
+	return 0
+}
+
+capture_copy_file() {
+	local input_ref="$1"
+	local artifact_path="$2"
+	if [[ ! -f "$input_ref" ]]; then
+		log_error "capture file input not found"
+		return 1
+	fi
+	cp "$input_ref" "$artifact_path"
+	return 0
+}
+
+capture_fetch_url() {
+	local input_ref="$1"
+	local artifact_path="$2"
+	if ! command_available curl; then
+		log_error "curl is required for URL capture"
+		return 1
+	fi
+	curl --fail --location --silent --show-error --max-time 30 --output "$artifact_path" "$input_ref"
+	return $?
+}
+
+capture_route_json() {
+	local input_ref="$1"
+	local method_value="$2"
+	local objective=""
+	objective="capture $method_value $(capture_source_label "$input_ref" "$method_value")"
+	handle_route --objective "$objective" --scope public --format json
+	return $?
+}
+
+capture_route_backend() {
+	local route_json="$1"
+	local backend_value="$REACH_VAL_FETCH"
+	if command_available python3; then
+		backend_value="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get(sys.argv[1], sys.argv[2]))' "$REACH_KEY_BACKEND" "$REACH_VAL_FETCH" <<<"$route_json")"
+	fi
+	printf '%s' "$backend_value"
+	return 0
+}
+
+capture_write_metadata() {
+	local meta_path="$1"
+	local captured_at="$2"
+	local source_ref="$3"
+	local source_hash="$4"
+	local method_value="$5"
+	local backend_value="$6"
+	local route_json="$7"
+	local sha256_value="$8"
+	local byte_count="$9"
+	local artifact_rel="${10}"
+	local meta_rel="${11}"
+	python3 - "$meta_path" "$captured_at" "$source_ref" "$source_hash" "$method_value" "$backend_value" "$route_json" "$sha256_value" "$byte_count" "$artifact_rel" "$meta_rel" "$REACH_KEY_SCHEMA_VERSION" "$REACH_KEY_BACKEND" "$REACH_KEY_SENSITIVITY" "$REACH_KEY_TRUST" "$REACH_VAL_UNVERIFIED" "$REACH_VAL_NONE" <<'PY'
+import json
+import sys
+
+(
+    meta_path,
+    captured_at,
+    source_ref,
+    source_hash,
+    method,
+    backend,
+    route_json,
+    sha256,
+    byte_count,
+    artifact_rel,
+    meta_rel,
+    schema_key,
+    backend_key,
+    sensitivity_key,
+    trust_key,
+    unverified_value,
+    none_value,
+) = sys.argv[1:]
+try:
+    route_decision = json.loads(route_json)
+except json.JSONDecodeError:
+    route_decision = {schema_key: 1, backend_key: backend, "blocked_reason": "route_parse_failed"}
+metadata = {
+    schema_key: 1,
+    "captured_at": captured_at,
+    "source_ref": source_ref,
+    "source_hash": source_hash,
+    "method": method,
+    backend_key: backend,
+    "route_decision": route_decision,
+    "profile_label": none_value,
+    "proxy_class": none_value,
+    "failure_class": none_value,
+    sensitivity_key: unverified_value,
+    trust_key: unverified_value,
+    "sha256": sha256,
+    "bytes": int(byte_count),
+    "artifact_paths": [artifact_rel, meta_rel],
+    "review_required": True,
+}
+with open(meta_path, "w") as handle:
+    json.dump(metadata, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+	return $?
+}
+
+capture_append_triage() {
+	local triage_path="$1"
+	local captured_at="$2"
+	local sub_folder="$3"
+	local source_ref="$4"
+	local meta_rel="$5"
+	local method_value="$6"
+	local backend_value="$7"
+	local source_hash="$8"
+	mkdir -p "$(dirname "$triage_path")"
+	python3 - "$triage_path" "$captured_at" "$sub_folder" "$source_ref" "$meta_rel" "$method_value" "$backend_value" "$source_hash" "$REACH_KEY_BACKEND" "$REACH_KEY_SENSITIVITY" "$REACH_KEY_TRUST" "$REACH_VAL_UNVERIFIED" <<'PY'
+import json
+import sys
+
+triage_path, captured_at, sub_folder, source_ref, meta_rel, method, backend, source_hash, backend_key, sensitivity_key, trust_key, unverified_value = sys.argv[1:]
+entry = {
+    "ts": captured_at,
+    "source": "reach-capture",
+    "sub": sub_folder,
+    "orig": source_ref,
+    "path": meta_rel,
+    "method": method,
+    backend_key: backend,
+    "provenance_hash": source_hash,
+    "status": "pending",
+    sensitivity_key: unverified_value,
+    trust_key: unverified_value,
+}
+with open(triage_path, "a") as handle:
+    handle.write(json.dumps(entry, sort_keys=True, separators=(",", ":")) + "\n")
+PY
+	return $?
+}
+
+handle_capture() {
+	local input_ref=""
+	local dest="inbox"
+	local method="$REACH_VAL_AUTO"
+	local format="json"
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--input)
+				shift
+				input_ref="${1:-}"
+				;;
+			--dest)
+				shift
+				dest="${1:-}"
+				;;
+			--method)
+				shift
+				method="${1:-}"
+				;;
+			--format)
+				shift
+				format="${1:-}"
+				;;
+			*)
+				log_error "Unknown capture option: $arg"
+				return 1
+				;;
+		esac
+		shift || true
+	done
+
+	require_json_format "$format" || return 1
+	if [[ -z "$input_ref" ]]; then
+		log_error "capture requires --input"
+		return 1
+	fi
+	case "$dest" in
+		inbox | knowledge-inbox) ;;
+		*) log_error "Invalid --dest: $dest"; return 1 ;;
+	esac
+	case "$method" in
+		auto | file | fetch | crawl | browser) ;;
+		*) log_error "Invalid --method: $method"; return 1 ;;
+	esac
+	if [[ "$method" == "auto" ]]; then
+		if [[ -f "$input_ref" ]]; then
+			method="$REACH_VAL_FILE"
+		else
+			method="$REACH_VAL_FETCH"
+		fi
+	fi
+	if [[ "$method" == "$REACH_VAL_FILE" && ! -f "$input_ref" ]]; then
+		log_error "capture --method file requires a local file input"
+		return 1
+	fi
+
+	local epoch_value=""
+	local captured_at=""
+	local stamp=""
+	local slug=""
+	local extension=""
+	local base_dir=""
+	local sub_folder="web"
+	local artifact_path=""
+	local meta_path=""
+	local artifact_rel=""
+	local meta_rel=""
+	local route_json=""
+	local backend=""
+	local source_ref=""
+	local source_hash=""
+	local sha256_value=""
+	local byte_count=""
+	epoch_value="$(now_epoch)"
+	captured_at="$(epoch_to_iso "$epoch_value")"
+	stamp="$(epoch_to_stamp "$epoch_value")"
+	slug="$(capture_slug "$input_ref" "$method")"
+	extension="$(capture_extension_for_input "$input_ref")"
+	if [[ "$dest" == "knowledge-inbox" ]]; then
+		base_dir="_knowledge/inbox/web"
+		sub_folder="knowledge-inbox"
+	else
+		base_dir="_inbox/web"
+	fi
+	mkdir -p "$base_dir" "_inbox"
+	artifact_path="${base_dir}/${slug}_${stamp}.${extension}"
+	meta_path="${base_dir}/${slug}_${stamp}.meta.json"
+	if [[ "$method" == "$REACH_VAL_FILE" ]]; then
+		capture_copy_file "$input_ref" "$artifact_path" || return 1
+	else
+		capture_fetch_url "$input_ref" "$artifact_path" || return 1
+	fi
+	artifact_rel="$(relative_path "$artifact_path")"
+	meta_rel="$(relative_path "$meta_path")"
+	route_json="$(capture_route_json "$input_ref" "$method")"
+	backend="$(capture_route_backend "$route_json")"
+	if [[ "$method" != "$REACH_VAL_AUTO" && "$method" != "$REACH_VAL_FILE" && "$method" != "$REACH_VAL_FETCH" ]]; then
+		backend="$method"
+	fi
+	source_ref="$(capture_source_label "$input_ref" "$method")"
+	source_hash="$(safe_sha256 "$input_ref")"
+	sha256_value="$(file_sha256 "$artifact_path")"
+	byte_count="$(file_bytes "$artifact_path")"
+	capture_write_metadata "$meta_path" "$captured_at" "$source_ref" "$source_hash" "$method" "$backend" "$route_json" "$sha256_value" "$byte_count" "$artifact_rel" "$meta_rel" || return 1
+	capture_append_triage "_inbox/triage.log" "$captured_at" "$sub_folder" "$source_ref" "$meta_rel" "$method" "$backend" "$source_hash" || return 1
+	printf '{"%s":1,"dest":"%s","artifact_path":"%s","meta_path":"%s","triage_log":"_inbox/triage.log","%s":"%s","%s":"%s","review_required":true}\n' \
+		"$(json_escape "$REACH_KEY_SCHEMA_VERSION")" \
+		"$(json_escape "$dest")" \
+		"$(json_escape "$artifact_rel")" \
+		"$(json_escape "$meta_rel")" \
+		"$(json_escape "$REACH_KEY_SENSITIVITY")" \
+		"$(json_escape "$REACH_VAL_UNVERIFIED")" \
+		"$(json_escape "$REACH_KEY_TRUST")" \
+		"$(json_escape "$REACH_VAL_UNVERIFIED")"
+	return 0
+}
+
 main() {
 	local command="${1:-help}"
 	if [[ $# -gt 0 ]]; then
@@ -1402,6 +1800,10 @@ main() {
 			;;
 		classify-failure)
 			handle_classify_failure "$@"
+			return $?
+			;;
+		capture)
+			handle_capture "$@"
 			return $?
 			;;
 		route)

--- a/.agents/scripts/reach-helper.sh
+++ b/.agents/scripts/reach-helper.sh
@@ -1644,30 +1644,29 @@ PY
 	return $?
 }
 
-handle_capture() {
-	local input_ref=""
-	local dest="inbox"
-	local method="$REACH_VAL_AUTO"
-	local format="json"
-
+capture_parse_args() {
+	REACH_CAPTURE_INPUT_REF=""
+	REACH_CAPTURE_DEST="inbox"
+	REACH_CAPTURE_METHOD="$REACH_VAL_AUTO"
+	REACH_CAPTURE_FORMAT="json"
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
 			--input)
 				shift
-				input_ref="${1:-}"
+				REACH_CAPTURE_INPUT_REF="${1:-}"
 				;;
 			--dest)
 				shift
-				dest="${1:-}"
+				REACH_CAPTURE_DEST="${1:-}"
 				;;
 			--method)
 				shift
-				method="${1:-}"
+				REACH_CAPTURE_METHOD="${1:-}"
 				;;
 			--format)
 				shift
-				format="${1:-}"
+				REACH_CAPTURE_FORMAT="${1:-}"
 				;;
 			*)
 				log_error "Unknown capture option: $arg"
@@ -1676,7 +1675,14 @@ handle_capture() {
 		esac
 		shift || true
 	done
+	return 0
+}
 
+capture_validate_request() {
+	local input_ref="$1"
+	local dest="$2"
+	local method="$3"
+	local format="$4"
 	require_json_format "$format" || return 1
 	if [[ -z "$input_ref" ]]; then
 		log_error "capture requires --input"
@@ -1701,14 +1707,66 @@ handle_capture() {
 		log_error "capture --method file requires a local file input"
 		return 1
 	fi
+	return 0
+}
 
+capture_resolve_method() {
+	local input_ref="$1"
+	local method="$2"
+	if [[ "$method" == "$REACH_VAL_AUTO" ]]; then
+		if [[ -f "$input_ref" ]]; then
+			method="$REACH_VAL_FILE"
+		else
+			method="$REACH_VAL_FETCH"
+		fi
+	fi
+	printf '%s' "$method"
+	return 0
+}
+
+capture_base_dir() {
+	local dest="$1"
+	if [[ "$dest" == "knowledge-inbox" ]]; then
+		printf '%s' '_knowledge/inbox/web'
+		return 0
+	fi
+	printf '%s' '_inbox/web'
+	return 0
+}
+
+capture_sub_folder() {
+	local dest="$1"
+	if [[ "$dest" == "knowledge-inbox" ]]; then
+		printf '%s' 'knowledge-inbox'
+		return 0
+	fi
+	printf '%s' 'web'
+	return 0
+}
+
+capture_materialize_artifact() {
+	local input_ref="$1"
+	local method="$2"
+	local artifact_path="$3"
+	if [[ "$method" == "$REACH_VAL_FILE" ]]; then
+		capture_copy_file "$input_ref" "$artifact_path" || return 1
+	else
+		capture_fetch_url "$input_ref" "$artifact_path" || return 1
+	fi
+	return 0
+}
+
+capture_execute() {
+	local input_ref="$1"
+	local dest="$2"
+	local method="$3"
 	local epoch_value=""
 	local captured_at=""
 	local stamp=""
 	local slug=""
 	local extension=""
 	local base_dir=""
-	local sub_folder="web"
+	local sub_folder=""
 	local artifact_path=""
 	local meta_path=""
 	local artifact_rel=""
@@ -1724,20 +1782,12 @@ handle_capture() {
 	stamp="$(epoch_to_stamp "$epoch_value")"
 	slug="$(capture_slug "$input_ref" "$method")"
 	extension="$(capture_extension_for_input "$input_ref")"
-	if [[ "$dest" == "knowledge-inbox" ]]; then
-		base_dir="_knowledge/inbox/web"
-		sub_folder="knowledge-inbox"
-	else
-		base_dir="_inbox/web"
-	fi
+	base_dir="$(capture_base_dir "$dest")"
+	sub_folder="$(capture_sub_folder "$dest")"
 	mkdir -p "$base_dir" "_inbox"
 	artifact_path="${base_dir}/${slug}_${stamp}.${extension}"
 	meta_path="${base_dir}/${slug}_${stamp}.meta.json"
-	if [[ "$method" == "$REACH_VAL_FILE" ]]; then
-		capture_copy_file "$input_ref" "$artifact_path" || return 1
-	else
-		capture_fetch_url "$input_ref" "$artifact_path" || return 1
-	fi
+	capture_materialize_artifact "$input_ref" "$method" "$artifact_path" || return 1
 	artifact_rel="$(relative_path "$artifact_path")"
 	meta_rel="$(relative_path "$meta_path")"
 	route_json="$(capture_route_json "$input_ref" "$method")"
@@ -1761,6 +1811,14 @@ handle_capture() {
 		"$(json_escape "$REACH_KEY_TRUST")" \
 		"$(json_escape "$REACH_VAL_UNVERIFIED")"
 	return 0
+}
+
+handle_capture() {
+	capture_parse_args "$@" || return 1
+	capture_validate_request "$REACH_CAPTURE_INPUT_REF" "$REACH_CAPTURE_DEST" "$REACH_CAPTURE_METHOD" "$REACH_CAPTURE_FORMAT" || return 1
+	REACH_CAPTURE_METHOD="$(capture_resolve_method "$REACH_CAPTURE_INPUT_REF" "$REACH_CAPTURE_METHOD")"
+	capture_execute "$REACH_CAPTURE_INPUT_REF" "$REACH_CAPTURE_DEST" "$REACH_CAPTURE_METHOD"
+	return $?
 }
 
 main() {

--- a/.agents/scripts/tests/test-reach-capture.sh
+++ b/.agents/scripts/tests/test-reach-capture.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-reach-capture.sh - Local fixture tests for reach capture artifacts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../reach-helper.sh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+	local output="$1"
+	local expected="$2"
+	local description="$3"
+
+	if grep -Fq -- "$expected" <<<"$output"; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Expected output to contain: %s\n' "$expected"
+		printf '    Output: %s\n' "$output"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local output="$1"
+	local unexpected="$2"
+	local description="$3"
+
+	if grep -Fq -- "$unexpected" <<<"$output"; then
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Unexpected output: %s\n' "$unexpected"
+		printf '    Output: %s\n' "$output"
+	else
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	fi
+	return 0
+}
+
+assert_json_valid() {
+	local output="$1"
+	local description="$2"
+
+	if python3 -m json.tool >/dev/null 2>&1 <<<"$output"; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: %s\n' "$description"
+		printf '    Invalid JSON: %s\n' "$output"
+	fi
+	return 0
+}
+
+json_value() {
+	local json_text="$1"
+	local field_name="$2"
+	if python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get(sys.argv[1], ""))' "$field_name" <<<"$json_text"; then
+		return 0
+	fi
+	return 1
+}
+
+meta_value() {
+	local file_path="$1"
+	local field_name="$2"
+	if python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get(sys.argv[2], ""))' "$file_path" "$field_name"; then
+		return 0
+	fi
+	return 1
+}
+
+cleanup() {
+	local temp_dir="$1"
+	if [[ -n "$temp_dir" && -d "$temp_dir" ]]; then
+		rm -rf "$temp_dir"
+	fi
+	return 0
+}
+
+printf '=== Reach Capture Tests ===\n\n'
+
+temp_dir="$(mktemp -d)"
+trap 'cleanup "$temp_dir"' EXIT
+
+fixture="${temp_dir}/fixture.html"
+cat >"$fixture" <<'HTML'
+<!doctype html>
+<html><body><h1>Fixture capture</h1><p>Local deterministic evidence.</p></body></html>
+HTML
+
+pushd "$temp_dir" >/dev/null
+
+capture_output="$($HELPER capture --input "$fixture" --dest inbox --method file --format json)"
+assert_json_valid "$capture_output" "capture emits valid JSON"
+assert_contains "$capture_output" '"dest":"inbox"' "capture reports inbox destination"
+assert_contains "$capture_output" '"sensitivity":"unverified"' "capture output keeps sensitivity unverified"
+assert_contains "$capture_output" '"trust":"unverified"' "capture output keeps trust unverified"
+assert_not_contains "$capture_output" "$temp_dir" "capture output omits private temp path"
+
+artifact_path="$(json_value "$capture_output" artifact_path)"
+meta_path="$(json_value "$capture_output" meta_path)"
+if [[ -f "$artifact_path" && -f "$meta_path" ]]; then
+	PASS=$((PASS + 1))
+	printf '  PASS: capture writes artifact and metadata\n'
+else
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: capture writes artifact and metadata\n'
+fi
+
+metadata_text="$(<"$meta_path")"
+assert_json_valid "$metadata_text" "metadata is valid JSON"
+assert_contains "$metadata_text" '"source_ref": "local-file:fixture.html"' "metadata uses sanitized source ref"
+assert_contains "$metadata_text" '"method": "file"' "metadata records method"
+assert_contains "$metadata_text" '"sensitivity": "unverified"' "metadata sensitivity is unverified"
+assert_contains "$metadata_text" '"trust": "unverified"' "metadata trust is unverified"
+assert_contains "$metadata_text" '"review_required": true' "metadata requires review"
+assert_not_contains "$metadata_text" "$temp_dir" "metadata omits private temp path"
+
+metadata_bytes="$(meta_value "$meta_path" bytes)"
+if [[ "$metadata_bytes" -gt 0 ]]; then
+	PASS=$((PASS + 1))
+	printf '  PASS: metadata records non-zero byte count\n'
+else
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: metadata records non-zero byte count\n'
+fi
+
+triage_text="$(<"_inbox/triage.log")"
+assert_contains "$triage_text" '"source":"reach-capture"' "triage log records reach capture source"
+assert_contains "$triage_text" '"sub":"web"' "triage log records web sub-folder"
+assert_contains "$triage_text" '"status":"pending"' "triage log leaves capture pending"
+assert_contains "$triage_text" '"trust":"unverified"' "triage log records unverified trust"
+assert_not_contains "$triage_text" "$temp_dir" "triage log omits private temp path"
+
+knowledge_output="$($HELPER capture --input "$fixture" --dest knowledge-inbox --method file --format json)"
+assert_json_valid "$knowledge_output" "knowledge-inbox capture emits valid JSON"
+assert_contains "$knowledge_output" '"dest":"knowledge-inbox"' "knowledge capture reports knowledge-inbox destination"
+knowledge_artifact="$(json_value "$knowledge_output" artifact_path)"
+if [[ "$knowledge_artifact" == _knowledge/inbox/web/* && -f "$knowledge_artifact" ]]; then
+	PASS=$((PASS + 1))
+	printf '  PASS: knowledge capture stays in knowledge inbox\n'
+else
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: knowledge capture stays in knowledge inbox\n'
+	printf '    Artifact: %s\n' "$knowledge_artifact"
+fi
+
+popd >/dev/null
+
+printf '\nPassed: %d\nFailed: %d\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/templates/inbox-readme.md
+++ b/.agents/templates/inbox-readme.md
@@ -27,6 +27,7 @@ authoritative.
 
 ```json
 {"ts":"2026-04-25T19:00:00Z","source":"cli-add","sub":"email","orig":"/tmp/foo.eml","path":"_inbox/email/foo_20260425T190000.eml","status":"pending","sensitivity":"unverified"}
+{"ts":"2026-07-01T12:00:00Z","source":"reach-capture","sub":"web","orig":"local-file:example.html","path":"_inbox/web/example_20260701T120000Z.meta.json","method":"file","backend":"fetch","provenance_hash":"...","status":"pending","sensitivity":"unverified","trust":"unverified"}
 ```
 
 Fields:
@@ -37,6 +38,16 @@ Fields:
 - `path` — current path within `_inbox/`
 - `status` — `pending` (awaiting triage), `triaged` (routed), `rejected` (discarded)
 - `sensitivity` — `unverified` until P2c triage classifies the item
+- `trust` — `unverified` until review promotes or rejects the capture
+- `method` / `backend` — reach capture method and selected route backend when `source:"reach-capture"`
+- `provenance_hash` — hash of the sanitized source reference for reach-captured artifacts
+
+`reach capture` writes web evidence into `_inbox/web/` by default and stores a
+sidecar `.meta.json` with `schema_version`, `captured_at`, `source_ref`,
+`source_hash`, `method`, `backend`, `route_decision`, `profile_label`,
+`proxy_class`, `failure_class`, `sensitivity`, `trust`, `sha256`, `bytes`,
+`artifact_paths`, and `review_required`. Source refs are sanitized labels, not
+raw private paths, cookies, authorization headers, or proxy credentials.
 
 **Never modify `triage.log` after write.** Use `aidevops inbox find <query>` to search it.
 


### PR DESCRIPTION
## Summary

- Add `reach capture` for deterministic file/URL capture into `_inbox/web/` or `_knowledge/inbox/web/`.
- Write sanitized `.meta.json` provenance sidecars plus append-only `_inbox/triage.log` audit rows.
- Document reach-capture trust/sensitivity gates in inbox and knowledge-plane docs.
- Add local fixture coverage for artifact creation, metadata shape, triage logging, knowledge inbox staging, and private-path sanitization.

## Verification

- `shellcheck .agents/scripts/reach-helper.sh .agents/scripts/tests/test-reach-capture.sh`
- `.agents/scripts/tests/test-reach-capture.sh` → 22 passed, 0 failed
- `./aidevops.sh reach capture --input .agents/templates/inbox-readme.md --dest inbox --method file --format json`
- pre-commit hook passed on both commits

Resolves #26168
