### PR TITLE
t18053: Archive OpenCode isolated DB event rows

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -150,6 +150,18 @@ FORCE_VACUUM_SIZE_MB=0 VACUUM_FREELIST_THRESHOLD=0.0 \
   for example keeping roughly the 500 most recently active sessions in the
   active database.
 
+The archive helper follows OpenCode's active DB resolution: `OPENCODE_DB_PATH`
+or `OPENCODE_DB` overrides win first, then `XDG_DATA_HOME/opencode/opencode.db`,
+then `~/.local/share/opencode/opencode.db`. The archive DB defaults next to the
+active DB. This matters for aidevops-managed isolated project shards under
+`~/.aidevops/.agent-workspace/work/opencode-interactive/`.
+
+Archiving moves the normalized session rows (`session`, `message`, `part`,
+`todo`, `session_share`) and matching `event` rows where
+`event.aggregate_id = session.id`. On recent OpenCode releases the `event` table
+can dominate DB size because it stores repeated message update payloads; leaving
+those rows behind prevents archiving from reducing startup cost.
+
 Examples:
 
 ```bash

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -15,8 +15,10 @@
 #   opencode-db-archive.sh help
 #
 # Environment:
-#   OPENCODE_DB          — active DB path (default: ~/.local/share/opencode/opencode.db)
-#   OPENCODE_ARCHIVE_DB  — archive DB path (default: ~/.local/share/opencode/opencode-archive.db)
+#   OPENCODE_DB_PATH     — active DB path override used by aidevops/OpenCode helpers
+#   OPENCODE_DB          — active DB path override (fallback)
+#   XDG_DATA_HOME        — default data root (default: ~/.local/share)
+#   OPENCODE_ARCHIVE_DB  — archive DB path (default: next to active opencode.db)
 # -----------------------------------------------------------------------------
 
 set -Eeuo pipefail
@@ -29,14 +31,20 @@ _oda_dir="${BASH_SOURCE[0]%/*}"
 # --- Configuration -----------------------------------------------------------
 
 readonly SCRIPT_NAME="opencode-db-archive"
-readonly DEFAULT_DB="$HOME/.local/share/opencode/opencode.db"
-readonly DEFAULT_ARCHIVE_DB="$HOME/.local/share/opencode/opencode-archive.db"
+readonly DEFAULT_DATA_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/opencode"
+readonly DEFAULT_DB="${DEFAULT_DATA_DIR}/opencode.db"
 readonly DEFAULT_RETENTION_DAYS=30
 readonly DEFAULT_BATCH_SIZE=500
 readonly DEFAULT_MAX_DURATION=60
+readonly EVENT_TABLE_NAME="event"
 
-ACTIVE_DB="${OPENCODE_DB:-$DEFAULT_DB}"
-ARCHIVE_DB="${OPENCODE_ARCHIVE_DB:-$DEFAULT_ARCHIVE_DB}"
+ACTIVE_DB="${OPENCODE_DB_PATH:-${OPENCODE_DB:-$DEFAULT_DB}}"
+_archive_default_dir="${ACTIVE_DB%/*}"
+if [[ "$_archive_default_dir" == "$ACTIVE_DB" ]]; then
+	_archive_default_dir="."
+fi
+ARCHIVE_DB="${OPENCODE_ARCHIVE_DB:-${_archive_default_dir}/opencode-archive.db}"
+unset _archive_default_dir
 
 # --- Output helpers -----------------------------------------------------------
 
@@ -260,6 +268,16 @@ CREATE TABLE IF NOT EXISTS `session_share` (
 	CONSTRAINT `fk_session_share_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS `event` (
+	`id` text PRIMARY KEY,
+	`aggregate_id` text NOT NULL,
+	`seq` integer NOT NULL,
+	`type` text NOT NULL,
+	`data` text NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS `event_aggregate_seq_idx` ON `event` (`aggregate_id`,`seq`);
+CREATE INDEX IF NOT EXISTS `event_aggregate_type_seq_idx` ON `event` (`aggregate_id`,`type`,`seq`);
+
 -- WAL mode for the archive too (better read concurrency)
 PRAGMA journal_mode=WAL;
 SCHEMA_SQL
@@ -299,6 +317,37 @@ _sqlite_has_column() {
 		"SELECT COUNT(*) FROM pragma_table_info('${table_name}') WHERE name='${column_name}';" 2>/dev/null || true)
 	[[ "$count" == "1" ]]
 	return $?
+}
+
+_sqlite_has_table() {
+	local db="$1"
+	local table_name="$2"
+	local count
+
+	count=$(sqlite3 "$db" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='${table_name}';" 2>/dev/null || true)
+	[[ "$count" == "1" ]]
+	return $?
+}
+
+_archive_event_count_sql() {
+	local candidate_filter="$1"
+	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+		printf 'SELECT COUNT(*) FROM event WHERE aggregate_id IN (SELECT id FROM session WHERE %s);\n' "$candidate_filter"
+	else
+		printf 'SELECT 0;\n'
+	fi
+	return 0
+}
+
+_archive_event_bytes_sql() {
+	local candidate_filter="$1"
+	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+		printf 'SELECT COALESCE(SUM(LENGTH(data)), 0) FROM event WHERE aggregate_id IN (SELECT id FROM session WHERE %s);\n' "$candidate_filter"
+	else
+		printf 'SELECT 0;\n'
+	fi
+	return 0
 }
 
 _archive_project_insert_columns() {
@@ -514,11 +563,13 @@ cmd_archive() {
 
 	if ((dry_run)); then
 		# Show what would be archived
-		local msg_count part_count todo_count share_count
+		local msg_count part_count todo_count share_count event_count event_bytes
 		msg_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM message WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		part_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM part WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		todo_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM todo WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		share_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_share WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		event_count=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_count_sql "$candidate_filter")")
+		event_bytes=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_bytes_sql "$candidate_filter")")
 
 		echo ""
 		echo "=== DRY RUN — would archive: ==="
@@ -527,6 +578,7 @@ cmd_archive() {
 		echo "  Parts:          $part_count"
 		echo "  Todos:          $todo_count"
 		echo "  Session shares: $share_count"
+		echo "  Events:         $event_count ($(format_bytes "$event_bytes"))"
 		echo ""
 		print_info "Run without --dry-run to proceed."
 		return 0
@@ -537,10 +589,14 @@ cmd_archive() {
 
 	local project_insert_columns project_select_columns
 	local session_insert_columns session_select_columns
+	local has_event_table=0
 	project_insert_columns=$(_archive_project_insert_columns)
 	project_select_columns=$(_archive_project_select_columns)
 	session_insert_columns=$(_archive_session_insert_columns)
 	session_select_columns=$(_archive_session_select_columns)
+	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+		has_event_table=1
+	fi
 
 	local size_before
 	size_before=$(file_size_bytes "$ACTIVE_DB")
@@ -593,6 +649,12 @@ cmd_archive() {
 		local in_clause=""
 		in_clause=$(printf '%s\n' "$session_ids" | sed "s/.*/'&'/" | tr '\n' ',' | sed 's/,$//')
 
+		local event_copy_sql="" event_delete_sql=""
+		if ((has_event_table)); then
+			event_copy_sql="INSERT OR IGNORE INTO archive.event SELECT * FROM event WHERE aggregate_id IN ($in_clause);"
+			event_delete_sql="DELETE FROM event WHERE aggregate_id IN ($in_clause);"
+		fi
+
 		# Single transaction: copy to archive then delete from active.
 		# ATTACH and DETACH are within the same sqlite3 invocation — the attachment
 		# is released automatically when the process exits. The trap above ensures
@@ -628,11 +690,18 @@ SELECT * FROM todo WHERE session_id IN ($in_clause);
 INSERT OR IGNORE INTO archive.session_share
 SELECT * FROM session_share WHERE session_id IN ($in_clause);
 
+-- Copy event stream rows when the active DB has OpenCode's event table.
+-- OpenCode stores session-scoped event history with aggregate_id=session.id.
+-- This table is often the largest object in opencode.db, so leaving it behind
+-- defeats archiving.
+${event_copy_sql}
+
 -- Delete from active (child tables first since FK CASCADE is not enforced)
 DELETE FROM part WHERE session_id IN ($in_clause);
 DELETE FROM todo WHERE session_id IN ($in_clause);
 DELETE FROM session_share WHERE session_id IN ($in_clause);
 DELETE FROM message WHERE session_id IN ($in_clause);
+${event_delete_sql}
 DELETE FROM session WHERE id IN ($in_clause);
 
 COMMIT;
@@ -706,18 +775,21 @@ cmd_stats() {
 	echo "=== Active DB: $ACTIVE_DB ==="
 	echo "  Size: $(format_bytes "$(file_size_bytes "$ACTIVE_DB")")"
 
-	local session_count msg_count part_count todo_count share_count
+	local session_count msg_count part_count todo_count share_count event_count event_bytes
 	session_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session;")
 	msg_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM message;")
 	part_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM part;")
 	todo_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM todo;")
 	share_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_share;")
+	event_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM event;" 2>/dev/null || echo "0")
+	event_bytes=$(sqlite3 "$ACTIVE_DB" "SELECT COALESCE(SUM(LENGTH(data)), 0) FROM event;" 2>/dev/null || echo "0")
 
 	echo "  Sessions:       $session_count"
 	echo "  Messages:       $msg_count"
 	echo "  Parts:          $part_count"
 	echo "  Todos:          $todo_count"
 	echo "  Session shares: $share_count"
+	echo "  Events:         $event_count ($(format_bytes "$event_bytes"))"
 
 	# Last-update distribution
 	local last_7d last_30d older
@@ -736,18 +808,21 @@ cmd_stats() {
 		echo "=== Archive DB: $ARCHIVE_DB ==="
 		echo "  Size: $(format_bytes "$(file_size_bytes "$ARCHIVE_DB")")"
 
-		local arch_session arch_msg arch_part arch_todo arch_share
+		local arch_session arch_msg arch_part arch_todo arch_share arch_event arch_event_bytes
 		arch_session=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session;" 2>/dev/null || echo "0")
 		arch_msg=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM message;" 2>/dev/null || echo "0")
 		arch_part=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM part;" 2>/dev/null || echo "0")
 		arch_todo=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM todo;" 2>/dev/null || echo "0")
 		arch_share=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session_share;" 2>/dev/null || echo "0")
+		arch_event=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM event;" 2>/dev/null || echo "0")
+		arch_event_bytes=$(sqlite3 "$ARCHIVE_DB" "SELECT COALESCE(SUM(LENGTH(data)), 0) FROM event;" 2>/dev/null || echo "0")
 
 		echo "  Sessions:       $arch_session"
 		echo "  Messages:       $arch_msg"
 		echo "  Parts:          $arch_part"
 		echo "  Todos:          $arch_todo"
 		echo "  Session shares: $arch_share"
+		echo "  Events:         $arch_event ($(format_bytes "$arch_event_bytes"))"
 
 		# Last-update distribution in archive
 		local arch_7d arch_30d arch_older
@@ -787,8 +862,10 @@ ARCHIVE OPTIONS:
   --max-duration-seconds N  Stop after N seconds even when not done (default: 60)
 
 ENVIRONMENT:
-  OPENCODE_DB               Active DB path (default: ~/.local/share/opencode/opencode.db)
-  OPENCODE_ARCHIVE_DB       Archive DB path (default: ~/.local/share/opencode/opencode-archive.db)
+  XDG_DATA_HOME             Data root for default DB path (default: ~/.local/share)
+  OPENCODE_DB_PATH          Active DB path override used by aidevops/OpenCode helpers
+  OPENCODE_DB               Active DB path override (fallback)
+  OPENCODE_ARCHIVE_DB       Archive DB path (default: next to active opencode.db)
 
 EXAMPLES:
   # Show current stats

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -90,9 +90,13 @@ CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_create
 CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
 CREATE TABLE todo (session_id text NOT NULL, content text NOT NULL, status text NOT NULL, priority text NOT NULL, position integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, PRIMARY KEY(session_id, position));
 CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secret text NOT NULL, url text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL);
+CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL, type text NOT NULL, data text NOT NULL);
+CREATE UNIQUE INDEX event_aggregate_seq_idx ON event (aggregate_id, seq);
+CREATE INDEX event_aggregate_type_seq_idx ON event (aggregate_id, type, seq);
 INSERT INTO project VALUES ('proj1', '/tmp/worktree', 'git', 'project', NULL, NULL, 1, 1, NULL, '{}', NULL, NULL);
 INSERT INTO session VALUES ('ses1', 'proj1', NULL, 'slug', '/tmp/dir', 'title', '1.0.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, 1, NULL, NULL, 'workspace1', '/tmp/session-path');
 INSERT INTO message VALUES ('msg1', 'ses1', 1, 1, '{}');
+INSERT INTO event VALUES ('evt1', 'ses1', 1, 'session.updated.1', '{"ok":true}');
 SQL
 	return 0
 }
@@ -187,6 +191,9 @@ CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_create
 CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
 CREATE TABLE todo (session_id text NOT NULL, content text NOT NULL, status text NOT NULL, priority text NOT NULL, position integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, PRIMARY KEY(session_id, position));
 CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secret text NOT NULL, url text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL);
+CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL, type text NOT NULL, data text NOT NULL);
+CREATE UNIQUE INDEX event_aggregate_seq_idx ON event (aggregate_id, seq);
+CREATE INDEX event_aggregate_type_seq_idx ON event (aggregate_id, type, seq);
 INSERT INTO project VALUES ('proj1', '/tmp/worktree', 'git', 'project', NULL, NULL, 1, 1, NULL, '{}', NULL, NULL);
 SQL
 
@@ -198,6 +205,8 @@ SQL
 			"INSERT INTO session VALUES ('${session_id}', 'proj1', NULL, '${session_id}', '/tmp/dir', '${session_id}', '1.0.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, ${created_ms}, ${updated_ms}, NULL, NULL, 'workspace1', '/tmp/${session_id}');"
 		sqlite3 "$ACTIVE_DB" \
 			"INSERT INTO message VALUES ('msg-${session_id}', '${session_id}', ${created_ms}, ${updated_ms}, '{}');"
+		sqlite3 "$ACTIVE_DB" \
+			"INSERT INTO event VALUES ('evt-${session_id}', '${session_id}', 1, 'session.updated.1', '{\"session\":\"${session_id}\"}');"
 	done <<<"$sessions_csv"
 	return 0
 }
@@ -238,6 +247,21 @@ else
 	_fail "archived session still present in active DB"
 fi
 
+event_table_count=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM pragma_table_info('event') WHERE name='aggregate_id';")
+if [[ "$event_table_count" == "1" ]]; then
+	_pass "legacy archive schema gains event table"
+else
+	_fail "archive.event table missing after migration"
+fi
+
+archived_event_count=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM event WHERE aggregate_id='ses1';")
+active_event_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM event WHERE aggregate_id='ses1';")
+if [[ "$archived_event_count" == "1" && "$active_event_count" == "0" ]]; then
+	_pass "session event rows moved from active DB to archive DB"
+else
+	_fail "event archive mismatch: archived=${archived_event_count}, active=${active_event_count}"
+fi
+
 _reset_dbs
 _make_active_db_with_sessions $'s1,1000,5000\ns2,2000,1000\ns3,3000,4000\ns4,4000,2000\ns5,5000,3000'
 
@@ -264,6 +288,13 @@ if [[ "$archived_count_sessions" == "s2,s4,s5" ]]; then
 	_pass "count-based retention archives sessions outside update-time keep target"
 else
 	_fail "count-based retention archived unexpected sessions: ${archived_count_sessions}"
+fi
+
+archived_count_events=$(sqlite3 "$ARCHIVE_DB" "SELECT GROUP_CONCAT(aggregate_id, ',') FROM (SELECT aggregate_id FROM event ORDER BY aggregate_id);")
+if [[ "$archived_count_events" == "s2,s4,s5" ]]; then
+	_pass "count-based retention archives matching event stream rows"
+else
+	_fail "count-based retention archived unexpected events: ${archived_count_events}"
 fi
 
 _reset_dbs
@@ -348,6 +379,62 @@ if [[ "$combined_active" == "old2,mid,new" ]]; then
 	_pass "combined retention uses conservative update-time intersection"
 else
 	_fail "combined retention kept unexpected active sessions: ${combined_active}"
+fi
+
+xdg_data_home="${SANDBOX}/xdg-data"
+mkdir -p "${xdg_data_home}/opencode"
+saved_active_db="$ACTIVE_DB"
+saved_archive_db="$ARCHIVE_DB"
+ACTIVE_DB="${xdg_data_home}/opencode/opencode.db"
+ARCHIVE_DB="${xdg_data_home}/opencode/opencode-archive.db"
+_make_active_db_with_session_path
+ACTIVE_DB="$saved_active_db"
+ARCHIVE_DB="$saved_archive_db"
+
+set +e
+out=$(XDG_DATA_HOME="$xdg_data_home" "$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive honors XDG_DATA_HOME default DB path"
+else
+	_fail "XDG_DATA_HOME archive failed with rc=$rc — output: $out"
+fi
+
+xdg_archived_event_count=$(sqlite3 "${xdg_data_home}/opencode/opencode-archive.db" "SELECT COUNT(*) FROM event WHERE aggregate_id='ses1';")
+if [[ "$xdg_archived_event_count" == "1" ]]; then
+	_pass "XDG_DATA_HOME archive stores events next to isolated DB"
+else
+	_fail "XDG_DATA_HOME event archive mismatch: ${xdg_archived_event_count}"
+fi
+
+path_override_dir="${SANDBOX}/path-override"
+mkdir -p "$path_override_dir"
+saved_active_db="$ACTIVE_DB"
+saved_archive_db="$ARCHIVE_DB"
+ACTIVE_DB="${path_override_dir}/custom-opencode.db"
+ARCHIVE_DB="${path_override_dir}/opencode-archive.db"
+_make_active_db_with_session_path
+ACTIVE_DB="$saved_active_db"
+ARCHIVE_DB="$saved_archive_db"
+
+set +e
+out=$(OPENCODE_DB_PATH="${path_override_dir}/custom-opencode.db" "$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive honors OPENCODE_DB_PATH override"
+else
+	_fail "OPENCODE_DB_PATH archive failed with rc=$rc — output: $out"
+fi
+
+path_override_event_count=$(sqlite3 "${path_override_dir}/opencode-archive.db" "SELECT COUNT(*) FROM event WHERE aggregate_id='ses1';")
+if [[ "$path_override_event_count" == "1" ]]; then
+	_pass "OPENCODE_DB_PATH archive defaults archive DB next to active DB"
+else
+	_fail "OPENCODE_DB_PATH event archive mismatch: ${path_override_event_count}"
 fi
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/TODO.md
+++ b/TODO.md
@@ -1080,6 +1080,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18045 Refresh issue dependency state before dispatch #auto-dispatch #bug #priority:high ref:GH#26152 pr:#26153 completed:2026-07-01
 
+- [ ] t18053 fix: archive OpenCode isolated DB event rows #bug #database #opencode #performance ref:GH#26220
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Fix OpenCode DB archive handling for aidevops-managed isolated XDG_DATA_HOME/OPENCODE_DB_PATH shards and move matching event rows with archived sessions so large event tables no longer remain in the active DB.

## Files Changed

.agents/reference/opencode-maintenance.md,.agents/scripts/opencode-db-archive.sh,.agents/scripts/tests/test-opencode-db-archive.sh,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-opencode-db-archive.sh; bash .agents/scripts/tests/test-opencode-db-maintenance.sh; shellcheck .agents/scripts/opencode-db-archive.sh .agents/scripts/tests/test-opencode-db-archive.sh; git diff --check; .agents/scripts/linters-local.sh (targeted gates passed; repo-wide pre-existing complexity/file-size gates reported separately)

Resolves #26220


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.15 plugin for [OpenCode](https://opencode.ai) v1.17.12 with gpt-5.5 spent 13h 12m and 1,622,468 tokens on this with the user in an interactive session.