### PR TITLE
fix: harden opencode archive defaults

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -31,7 +31,13 @@ _oda_dir="${BASH_SOURCE[0]%/*}"
 # --- Configuration -----------------------------------------------------------
 
 readonly SCRIPT_NAME="opencode-db-archive"
-readonly DEFAULT_DATA_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/opencode"
+if [[ -n "${XDG_DATA_HOME:-}" ]]; then
+	readonly DEFAULT_DATA_DIR="${XDG_DATA_HOME}/opencode"
+elif [[ -n "${HOME:-}" ]]; then
+	readonly DEFAULT_DATA_DIR="${HOME}/.local/share/opencode"
+else
+	readonly DEFAULT_DATA_DIR="opencode"
+fi
 readonly DEFAULT_DB="${DEFAULT_DATA_DIR}/opencode.db"
 readonly DEFAULT_RETENTION_DAYS=30
 readonly DEFAULT_BATCH_SIZE=500
@@ -332,7 +338,16 @@ _sqlite_has_table() {
 
 _archive_event_count_sql() {
 	local candidate_filter="$1"
-	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+	local has_event_table="${2:-}"
+	if (($# < 2)); then
+		if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+			has_event_table=1
+		else
+			has_event_table=0
+		fi
+	fi
+
+	if ((has_event_table)); then
 		printf 'SELECT COUNT(*) FROM event WHERE aggregate_id IN (SELECT id FROM session WHERE %s);\n' "$candidate_filter"
 	else
 		printf 'SELECT 0;\n'
@@ -342,7 +357,16 @@ _archive_event_count_sql() {
 
 _archive_event_bytes_sql() {
 	local candidate_filter="$1"
-	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+	local has_event_table="${2:-}"
+	if (($# < 2)); then
+		if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+			has_event_table=1
+		else
+			has_event_table=0
+		fi
+	fi
+
+	if ((has_event_table)); then
 		printf 'SELECT COALESCE(SUM(LENGTH(data)), 0) FROM event WHERE aggregate_id IN (SELECT id FROM session WHERE %s);\n' "$candidate_filter"
 	else
 		printf 'SELECT 0;\n'
@@ -564,12 +588,16 @@ cmd_archive() {
 	if ((dry_run)); then
 		# Show what would be archived
 		local msg_count part_count todo_count share_count event_count event_bytes
+		local has_event_table=0
+		if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+			has_event_table=1
+		fi
 		msg_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM message WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		part_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM part WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		todo_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM todo WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		share_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_share WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
-		event_count=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_count_sql "$candidate_filter")")
-		event_bytes=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_bytes_sql "$candidate_filter")")
+		event_count=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_count_sql "$candidate_filter" "$has_event_table")")
+		event_bytes=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_bytes_sql "$candidate_filter" "$has_event_table")")
 
 		echo ""
 		echo "=== DRY RUN — would archive: ==="

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -437,6 +437,38 @@ else
 	_fail "OPENCODE_DB_PATH event archive mismatch: ${path_override_event_count}"
 fi
 
+home_unset_dir="${SANDBOX}/home-unset"
+mkdir -p "${home_unset_dir}/opencode"
+saved_active_db="$ACTIVE_DB"
+saved_archive_db="$ARCHIVE_DB"
+ACTIVE_DB="${home_unset_dir}/opencode/opencode.db"
+ARCHIVE_DB="${home_unset_dir}/opencode/opencode-archive.db"
+_make_active_db_with_session_path
+ACTIVE_DB="$saved_active_db"
+ARCHIVE_DB="$saved_archive_db"
+
+set +e
+out=$(env -u HOME XDG_DATA_HOME="$home_unset_dir" "$HELPER" archive --dry-run --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive dry run is safe when HOME is unset and XDG_DATA_HOME is set"
+else
+	_fail "HOME-unset dry run failed with rc=$rc — output: $out"
+fi
+
+set +e
+out=$(env -u HOME -u XDG_DATA_HOME "$HELPER" stats 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 && "$out" == *"Active DB not found: opencode/opencode.db"* ]]; then
+	_pass "archive default path avoids root directory when HOME and XDG_DATA_HOME are unset"
+else
+	_fail "HOME/XDG unset default path mismatch with rc=$rc — output: $out"
+fi
+
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then
 	exit 1


### PR DESCRIPTION
## Summary
- Harden OpenCode archive default path resolution when HOME/XDG_DATA_HOME are unset or empty.
- Reuse a precomputed event-table flag for dry-run event count and byte SQL helpers.
- Add regression coverage for unset HOME/XDG_DATA_HOME default-path behavior.

## Testing
- shellcheck .agents/scripts/opencode-db-archive.sh .agents/scripts/tests/test-opencode-db-archive.sh
- bash .agents/scripts/tests/test-opencode-db-archive.sh (22 passed, 0 failed)
- .agents/scripts/linters-local.sh (progressed through SonarCloud/Qlty/string-literal/FD-lock/shellcheckrc; timed out at Secretlint after 240s)

Resolves #26233
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.17 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 11m and 60,184 tokens on this as a headless worker.