### PR TITLE
GH#26236: docs: clarify design pattern wording

### DIFF
--- a/.agents/tools/design/design-md.md
+++ b/.agents/tools/design/design-md.md
@@ -71,7 +71,7 @@ Upstream `@google/design.md` v0.2.0 and follow-up commit `18508f2` were reviewed
 - Read the repo-root `DESIGN.md` before UI/UX implementation when present; apply its cross-cutting rules and canonical examples before inventing new patterns.
 - When implementation reveals a durable repo-specific preference, update `DESIGN.md` in the same PR with a short rationale and concrete reference paths where known.
 - If the preference is uncertain, too broad, or outside the PR scope, create a worker-ready follow-up issue instead; if the learning is generic across repos, route it as an aidevops self-improvement issue with anonymised, repo-safe evidence.
-- Before standardising a close pattern, record the similar-but-different reasoning: which nearby patterns were considered, why the chosen pattern fits, and what differs.
+- Before standardising a closely related pattern, record the similar-but-different reasoning: which nearby patterns were considered, why the chosen pattern fits, and what differs.
 - If no repo convention exists for responsive behaviour, use responsive best-practice defaults or present explicit options; do not let desktop-only output silently become the standard.
 - Keep updates concise and durable: stable patterns only, no session transcripts, example-led guidance, and no rule expansion without evidence.
 


### PR DESCRIPTION
## Summary

Clarified the ambiguous DESIGN.md guidance phrase from 'close pattern' to 'closely related pattern' in .agents/tools/design/design-md.md.

## Files Changed

.agents/tools/design/design-md.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Pre-commit hook passed on commit/amend. .agents/scripts/linters-local.sh was attempted twice but exceeded bounded timeouts at Secretlint after earlier gates passed.

Resolves #26236


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.17 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 9m and 33,065 tokens on this as a headless worker.