### PR TITLE
GH#26232: fix: guard issue sync test trap cleanup

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
+++ b/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
@@ -12,7 +12,7 @@ WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/issue-sync-reusable.yml"
 TESTS_RUN=0
 TESTS_FAILED=0
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+trap 'rm -rf "${TMP:-}"' EXIT
 
 print_result() {
 	local name="$1" passed="$2"


### PR DESCRIPTION
## Summary

Guarded the issue sync enrich bounds test EXIT trap with ${TMP:-} so cleanup remains safe under set -u if TMP is unset.

## Files Changed

.agents/scripts/tests/test-issue-sync-enrich-bounds.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-issue-sync-enrich-bounds.sh; .agents/scripts/tests/test-issue-sync-enrich-bounds.sh

Resolves #26232


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.17 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1m and 28,131 tokens on this as a headless worker.