### PR TITLE
fix(issue-sync): harden enrich bound defaults

### DIFF
--- a/.agents/scripts/issue-sync-helper-enrich.sh
+++ b/.agents/scripts/issue-sync-helper-enrich.sh
@@ -95,7 +95,7 @@ _enrich_resolve_bounds() {
 }
 
 _enrich_log_bounds_if_active() {
-	local max_issues="$1" max_seconds="$2"
+	local max_issues="${1:-0}" max_seconds="${2:-0}"
 	if [[ "$max_issues" -gt 0 || "$max_seconds" -gt 0 ]]; then
 		print_info "Bounded enrich active: max_issues=${max_issues}, max_seconds=${max_seconds}"
 	fi
@@ -103,15 +103,15 @@ _enrich_log_bounds_if_active() {
 }
 
 _enrich_should_stop_for_bounds() {
-	local max_issues="$1" max_seconds="$2" processed="$3" total="$4" started_at="$5"
+	local max_issues="${1:-0}" max_seconds="${2:-0}" processed="${3:-0}" total="${4:-0}" started_at="${5:-0}"
 	if [[ "$max_issues" -gt 0 && "$processed" -ge "$max_issues" ]]; then
 		print_warning "Stopping bounded enrich after ${processed} issue(s); ${total} were eligible"
 		return 0
 	fi
 	if [[ "$max_seconds" -gt 0 ]]; then
 		local now elapsed
-		now=$(date +%s)
-		elapsed=$((now - started_at))
+		now=$(date +%s || echo "0")
+		elapsed=$((${now:-0} - ${started_at:-0}))
 		if [[ "$elapsed" -ge "$max_seconds" ]]; then
 			print_warning "Stopping bounded enrich after ${elapsed}s and ${processed} issue(s); ${total} were eligible"
 			return 0
@@ -460,7 +460,7 @@ cmd_enrich() {
 	local enriched=0
 	local processed=0
 	local started_at
-	started_at=$(date +%s)
+	started_at=$(date +%s || echo "0")
 	for task_id in "${tasks[@]}"; do
 		if _enrich_should_stop_for_bounds "$max_issues" "$max_seconds" "$processed" "${#tasks[@]}" "$started_at"; then
 			break

--- a/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
+++ b/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
@@ -125,11 +125,49 @@ test_invalid_bounds_are_ignored() {
 	return 0
 }
 
+test_bounds_helpers_tolerate_missing_values() {
+	local output
+	output=$(_enrich_log_bounds_if_active 2>&1)
+	if _enrich_should_stop_for_bounds 2>/dev/null; then
+		printf '%s\n' "$output"
+		print_result "bounds helpers default missing values safely" 1
+		return 0
+	fi
+	if [[ -z "$output" ]]; then
+		print_result "bounds helpers default missing values safely" 0
+	else
+		printf '%s\n' "$output"
+		print_result "bounds helpers default missing values safely" 1
+	fi
+	return 0
+}
+
+test_elapsed_bound_tolerates_date_failure() {
+	date() {
+		return 1
+	}
+	local output
+	set +e
+	output=$(_enrich_should_stop_for_bounds 0 1 0 1 "" 2>&1)
+	local status=$?
+	set -e
+	unset -f date
+	if [[ "$status" -eq 1 && -z "$output" ]]; then
+		print_result "elapsed bound uses safe date and started_at defaults" 0
+	else
+		printf '%s\n' "$output"
+		print_result "elapsed bound uses safe date and started_at defaults" 1
+	fi
+	return 0
+}
+
 main() {
 	test_workflow_push_sets_bounded_enrich
 	test_max_issues_bounds_enrich_loop
 	test_target_task_ignores_routine_bounds
 	test_invalid_bounds_are_ignored
+	test_bounds_helpers_tolerate_missing_values
+	test_elapsed_bound_tolerates_date_failure
 	printf 'Tests run: %s\n' "$TESTS_RUN"
 	printf 'Tests failed: %s\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Default enrich bound helper parameters to `0` so missing arguments do not trip `set -u` or arithmetic checks.
- Add safe epoch fallbacks when `date +%s` fails or returns empty before elapsed-bound arithmetic.
- Extend enrich bounds tests for missing helper args and date-failure fallback coverage.

## Verification
- `bash .agents/scripts/tests/test-issue-sync-enrich-bounds.sh`
- `shellcheck .agents/scripts/issue-sync-helper-enrich.sh .agents/scripts/tests/test-issue-sync-enrich-bounds.sh`
- `.agents/scripts/linters-local.sh` timed out twice while checking Secretlint after earlier gates passed: SonarCloud passed, Qlty warning was pre-existing/advisory, string literals no new repeats, FD locks passed, shellcheckrc parity passed.

Resolves #26231

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.17 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 15m and 71,915 tokens on this as a headless worker.