### PR TITLE
For #26241: persist pulse PR view cache

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -972,10 +972,15 @@ _dlw_exec_detached() {
 	local -a worker_command=(
 		env
 		AIDEVOPS_GH_PR_LIST_CACHE_DISABLE=1
-		AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1
 		PULSE_PR_LIST_PROVIDER_CACHE_DISABLE=1
 		"$@"
 	)
+	# GH#26241: do not blanket-disable AIDEVOPS_GH_PR_VIEW_CACHE for workers.
+	# Pulse now uses a stable TTL-scoped PR view cache, and mutation-sensitive
+	# merge/update paths set AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 at the individual
+	# read site. Keeping worker PR-view reads cacheable avoids a cold-cache burst
+	# from every detached worker while preserving fresh reads where correctness
+	# requires bypassing cache.
 
 	# t2814 (Phase 3, fix #3): Close inherited file descriptors >2 before
 	# exec to prevent FD leak from the pulse parent into the worker. The

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1626,9 +1626,11 @@ main() {
 		echo "[pulse-wrapper] REST-first read routing enabled for REST-equivalent gh issue/pr list/view calls (GH#22525)" >>"$LOGFILE"
 	fi
 
-	# GH#23433/GH#23604: reuse PR metadata within this pulse cycle. The wrapper
-	# caches are opt-in so standalone tests/debugging keep exact read semantics,
-	# but pulse can avoid re-fetching the same PR list/view data across gates.
+	# GH#23433/GH#23604/GH#26241: reuse PR metadata within and across pulse
+	# cycles. The wrapper caches are opt-in so standalone tests/debugging keep
+	# exact read semantics, but pulse can avoid re-fetching the same PR list/view
+	# data across gates. PR view caches use TTL-based freshness and a stable cache
+	# directory so repeated daemon restarts do not create cold PID-scoped caches.
 	local _pulse_pr_cache_cleanup_scope=0
 	local _pulse_rm_rf="rm -rf"
 	unset AIDEVOPS_GH_PR_VIEW_CACHE
@@ -1641,7 +1643,7 @@ main() {
 	unset PULSE_PR_LIST_PROVIDER_CACHE_TTL
 	if [[ "${AIDEVOPS_PULSE_PR_VIEW_CACHE:-1}" == "1" ]]; then
 		export AIDEVOPS_GH_PR_VIEW_CACHE=1
-		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${TMPDIR:-/tmp}/aidevops-pulse-pr-view-cache-${$}"
+		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${AIDEVOPS_PULSE_PR_VIEW_CACHE_DIR:-${HOME}/.aidevops/cache/pulse-pr-view-cache}"
 		export AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}"
 		_save_cleanup_scope
 		push_cleanup 'release_instance_lock'
@@ -1649,14 +1651,10 @@ main() {
 		# register release_instance_lock before replacing the direct EXIT trap.
 		trap '_run_cleanups' EXIT
 		_pulse_pr_cache_cleanup_scope=1
-		push_cleanup "${_pulse_rm_rf} \"${AIDEVOPS_GH_PR_VIEW_CACHE_DIR}\""
-		if ! rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
-			printf '[pulse-wrapper] Failed to reset REST PR view cache directory: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
-		fi
 		if ! mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
 			printf '[pulse-wrapper] Failed to create REST PR view cache directory: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
 		fi
-		echo "[pulse-wrapper] Per-cycle PR view cache enabled for duplicate repo#PR reads ttl=${AIDEVOPS_GH_PR_VIEW_CACHE_TTL}s (GH#23433/GH#23604)" >>"$LOGFILE"
+		echo "[pulse-wrapper] Persistent PR view cache enabled for duplicate repo#PR reads dir=${AIDEVOPS_GH_PR_VIEW_CACHE_DIR} ttl=${AIDEVOPS_GH_PR_VIEW_CACHE_TTL}s (GH#23433/GH#23604/GH#26241)" >>"$LOGFILE"
 	fi
 
 	if [[ "${AIDEVOPS_PULSE_PR_LIST_CACHE:-1}" == "1" ]]; then

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -66,14 +66,16 @@ _GH_LAST_GRAPHQL_REMAINING=""
 _GH_REST_PR_VIEW_CACHE_DIR=""
 
 #######################################
-# Return 0 when REST PR view responses may be reused within this shell.
-# Process-scoped: later pulse cycles start fresh. Mutation-sensitive callers
-# MUST bypass with AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1.
+# Return 0 when REST PR view responses may be reused within the configured TTL.
+# Pulse may point this at a stable cross-cycle directory; mutation-sensitive
+# callers MUST bypass with AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1.
 # Returns: 0 when enabled, 1 otherwise.
 #######################################
 _rest_pr_view_cache_enabled() {
 	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE:-0}" == "1" ]] || return 1
 	[[ "${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" == "1" ]] && return 1
+	local ttl="${AIDEVOPS_GH_PR_VIEW_CACHE_TTL:-15}"
+	[[ "$ttl" =~ ^[0-9]+$ && "$ttl" -gt 0 ]] || return 1
 	command -v jq >/dev/null 2>&1 || return 1
 	jq -n 'true' >/dev/null 2>&1 || return 1
 	return 0
@@ -131,6 +133,42 @@ _rest_pr_view_emit_json() {
 	fi
 	printf '%s\n' "$raw_json"
 	return 0
+}
+
+#######################################
+# Try to emit a fresh cached REST PR object.
+# Args: $1=cache_path $2=cache_ttl $3=cache_name $4=json_fields $5=jq_expr
+# Returns: 0 when cache emitted, 1 when caller should fetch fresh data.
+#######################################
+_rest_pr_view_cache_emit_if_fresh() {
+	local cache_path="$1"
+	local cache_ttl="$2"
+	local cache_name="$3"
+	local json_fields="$4"
+	local jq_expr="$5"
+	local cache_now=""
+	local cache_mtime=""
+	local cache_age=0
+	local raw_json=""
+	cache_now=$(date +%s 2>/dev/null || printf '0')
+	cache_mtime=$(perl -e 'print((stat($ARGV[0]))[9] || 0)' "$cache_path" 2>/dev/null || printf '0')
+	if [[ "$cache_now" =~ ^[0-9]+$ && "$cache_mtime" =~ ^[0-9]+$ ]]; then
+		cache_age=$(( cache_now - cache_mtime ))
+	else
+		cache_age=$(( cache_ttl + 1 ))
+	fi
+	if [[ "$cache_age" -lt 0 || "$cache_age" -gt "$cache_ttl" ]]; then
+		gh_record_call other "$cache_name" unknown other stale 2>/dev/null || true
+		return 1
+	fi
+	raw_json="$(jq -c '.' "$cache_path" 2>/dev/null)" || raw_json=""
+	if [[ -z "$raw_json" ]]; then
+		gh_record_call other "$cache_name" unknown other invalid-json 2>/dev/null || true
+		return 1
+	fi
+	gh_record_call other "$cache_name" unknown other hit 2>/dev/null || true
+	_rest_pr_view_emit_json "$raw_json" "$json_fields" "$jq_expr"
+	return $?
 }
 
 #######################################
@@ -1062,16 +1100,11 @@ _rest_pr_view() {
 	local cache_path=""
 	local raw_json=""
 	local cache_name="rest_pr_view_cache"
+	local cache_ttl="${AIDEVOPS_GH_PR_VIEW_CACHE_TTL:-15}"
 	if _rest_pr_view_cache_enabled; then
 		cache_path="$(_rest_pr_view_cache_path "$repo" "$num")" || { cache_path=""; gh_record_call other "$cache_name" unknown other bypass 2>/dev/null || true; }
 		if [[ -n "$cache_path" && -s "$cache_path" ]]; then
-			raw_json="$(jq -c '.' "$cache_path" 2>/dev/null)" || raw_json=""
-			if [[ -n "$raw_json" ]]; then
-				gh_record_call other "$cache_name" unknown other hit 2>/dev/null || true
-				_rest_pr_view_emit_json "$raw_json" "$json_fields" "$jq_expr"
-				return $?
-			fi
-			gh_record_call other "$cache_name" unknown other invalid-json 2>/dev/null || true
+			_rest_pr_view_cache_emit_if_fresh "$cache_path" "$cache_ttl" "$cache_name" "$json_fields" "$jq_expr" && return $?
 		elif [[ -n "$cache_path" ]]; then
 			gh_record_call other "$cache_name" unknown other miss 2>/dev/null || true
 		fi

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1324,6 +1324,30 @@ else
 	fail "pulse-diagnose api-budget reports sanitized PR view cache counters" \
 		"diag=${diag_output}"
 fi
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+: >"$AIDEVOPS_GH_API_LOG"
+export STUB_RATE_LIMIT_REMAINING=0
+export AIDEVOPS_GH_PR_VIEW_CACHE=1
+export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="$TMP/rest-pr-view-stale-cache"
+export AIDEVOPS_GH_PR_VIEW_CACHE_TTL=1
+rm -rf "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"
+export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"stale first"}'
+_rest_pr_view 123 --repo "owner/repo" --json title --jq '.title' >/dev/null 2>&1 || true
+cache_file="$AIDEVOPS_GH_PR_VIEW_CACHE_DIR/owner_repo__123.json"
+perl -e 'utime(time - 5, time - 5, @ARGV)' "$cache_file" 2>/dev/null || true
+export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"fresh second"}'
+rest_stale_title=$(_rest_pr_view 123 --repo "owner/repo" --json title --jq '.title' 2>/dev/null || true)
+rest_stale_calls=$(grep -cE '^api /repos/owner/repo/pulls/123( |$)' "$GH_CALLS" 2>/dev/null || true)
+rest_cache_stales=$(grep -c $'rest_pr_view_cache\tother\tunknown\tother\tstale' "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)
+if [[ "$rest_stale_title" == "fresh second" && "$rest_stale_calls" == "2" && "$rest_cache_stales" == "1" ]]; then
+	pass "_rest_pr_view repo#PR cache refetches stale persistent entries"
+else
+	fail "_rest_pr_view repo#PR cache refetches stale persistent entries" \
+		"title=${rest_stale_title} calls=${rest_stale_calls} stale=${rest_cache_stales} GH_CALLS=$(cat "$GH_CALLS") API_LOG=$(cat "$AIDEVOPS_GH_API_LOG")"
+fi
+unset STUB_PR_VIEW_FIXTURE
 unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIEW_CACHE_TTL
 
 : >"$GH_CALLS"

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -327,13 +327,14 @@ test_fd_closure_fallback_path() {
 
 test_worker_launch_disables_pulse_pr_caches() {
 	if grep -q 'AIDEVOPS_GH_PR_LIST_CACHE_DISABLE=1' "$WORKER_LAUNCH" \
-		&& grep -q 'AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1' "$WORKER_LAUNCH" \
+		&& ! grep -q '^[[:space:]]*AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1' "$WORKER_LAUNCH" \
+		&& grep -q 'mutation-sensitive' "$WORKER_LAUNCH" \
 		&& grep -q 'PULSE_PR_LIST_PROVIDER_CACHE_DISABLE=1' "$WORKER_LAUNCH"; then
-		print_result "fix #3: worker launch disables pulse-scoped PR caches" 0
+		print_result "fix #3: worker launch keeps TTL-scoped PR view cache available" 0
 		return 0
 	fi
-	print_result "fix #3: worker launch disables pulse-scoped PR caches" 1 \
-		"Expected worker launch to disable inherited pulse PR caches in $WORKER_LAUNCH"
+	print_result "fix #3: worker launch keeps TTL-scoped PR view cache available" 1 \
+		"Expected worker launch to disable list/provider caches but not blanket-disable PR view cache in $WORKER_LAUNCH"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -219,6 +219,12 @@ test_pr_cache_ttls_are_per_cycle() {
 	if ! grep -q 'AIDEVOPS_GH_PR_VIEW_CACHE_TTL=.*AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600' "$WRAPPER_SCRIPT"; then
 		missing="${missing} view-ttl"
 	fi
+	if grep -Eq "AIDEVOPS_GH_PR_VIEW_CACHE_DIR=.*\\$\\$|AIDEVOPS_GH_PR_VIEW_CACHE_DIR=.*\\$\\{\\$\\}" "$WRAPPER_SCRIPT"; then
+		missing="${missing} pid-scoped-view-cache-dir"
+	fi
+	if ! grep -q 'AIDEVOPS_GH_PR_VIEW_CACHE_DIR=.*\.aidevops/cache/pulse-pr-view-cache' "$WRAPPER_SCRIPT"; then
+		missing="${missing} stable-view-cache-dir"
+	fi
 	if ! grep -q 'AIDEVOPS_GH_PR_LIST_CACHE_TTL=.*AIDEVOPS_PULSE_PR_LIST_CACHE_TTL:-3600' "$WRAPPER_SCRIPT"; then
 		missing="${missing} list-ttl"
 	fi
@@ -233,10 +239,10 @@ test_pr_cache_ttls_are_per_cycle() {
 	fi
 
 	if [[ -z "$missing" ]]; then
-		print_result "pulse configures per-cycle PR list/view cache TTLs and EXIT cleanup" 0
+		print_result "pulse configures persistent PR view cache plus per-cycle PR list cache TTLs and EXIT cleanup" 0
 		return 0
 	fi
-	print_result "pulse configures per-cycle PR list/view cache TTLs and EXIT cleanup" 1 \
+	print_result "pulse configures persistent PR view cache plus per-cycle PR list cache TTLs and EXIT cleanup" 1 \
 		"Missing pulse cache wiring:${missing}"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Keep pulse PR-view caches in a stable TTL-scoped directory instead of PID-scoped temp dirs.
- Add TTL enforcement to the REST repo#PR cache so persistent entries refetch after expiry.
- Stop blanket-disabling PR-view cache inheritance for detached workers while preserving explicit mutation-sensitive bypasses.

For #26241

## Testing

- `.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh` — 68/68 passed
- `.agents/scripts/tests/test-pulse-wrapper-canary.sh` — 5/5 passed
- `.agents/scripts/tests/test-no-worker-process-fix.sh` — 27/27 passed
- `shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh .agents/scripts/tests/test-pulse-wrapper-canary.sh .agents/scripts/tests/test-no-worker-process-fix.sh`
- `.agents/scripts/linters-local.sh` — all local checks passed; advisory pre-existing Markdown/ratchet warnings remained non-blocking

## Scope note

This is the cache-lifetime/worker-cache phase approved in the issue review. It intentionally leaves full REST/GQL mixed-field split work for a separate higher-risk phase under #26241.

## Runtime Testing

Self-assessed: shell wrapper/cache policy change covered by unit/static tests; no live pulse daemon restart was run in this session.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.17 with gpt-5.5 spent 3h 8m and 147,594 tokens on this with the user in an interactive session.
