### PR TITLE
Ref #26253: fix: harden repo health bump cleanup

### DIFF
--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -636,7 +636,11 @@ _rewrite_repo_aidevops_version() {
 		rm -f "$tmp_adj"
 		return 1
 	fi
-	mv "$tmp_adj" "$adj_file"
+	if ! mv "$tmp_adj" "$adj_file"; then
+		log_warn "bump failed ($slug): mv error for $adj_file"
+		rm -f "$tmp_adj"
+		return 1
+	fi
 	return 0
 }
 
@@ -657,7 +661,7 @@ _commit_repo_aidevops_version() {
 	if ! git -C "$repo_path" add .aidevops.json >/dev/null 2>&1 ||
 		! git -C "$repo_path" commit -m "chore: bump .aidevops.json to v${target_version} (r914)" >/dev/null 2>&1; then
 		log_warn "bump failed ($slug): commit error"
-		git -C "$repo_path" checkout -q "$default_branch" >/dev/null 2>&1 || true
+		git -C "$repo_path" checkout -f -q "$default_branch" || true
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
## Summary
- Handles `mv` failure in `_rewrite_repo_aidevops_version` so temporary files are cleaned up and the bump returns failure instead of continuing silently.
- Uses forced checkout in `_commit_repo_aidevops_version` failure recovery so branch restoration is reliable when the failed commit leaves `.aidevops.json` modified.

## Context
- Follow-up hardening from Gemini review on merged PR #26265.
- Ref #26253.

## Verification
- `bash -n .agents/scripts/repo-aidevops-health-helper.sh`
- `shellcheck .agents/scripts/repo-aidevops-health-helper.sh`
- `bash .agents/scripts/tests/test-repo-aidevops-health.sh` (22 tests, 0 failed)
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --metric function-complexity`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.18 plugin for [OpenCode](https://opencode.ai) v1.17.13
