### PR TITLE
GH#26251: fix: localize review gate state

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -941,6 +941,10 @@ do_check() {
 	local all_commenters
 	all_commenters=$(get_all_bot_commenters "$pr_number" "$repo")
 
+	local REVIEW_GATE_FOUND_BOTS=""
+	local REVIEW_GATE_RATE_LIMITED_BOTS=""
+	local REVIEW_GATE_NON_REVIEW_BOTS=""
+
 	local status_contexts
 	status_contexts=$(_get_success_status_contexts "$pr_number" "$repo" || true)
 	local prepared_status_contexts=""


### PR DESCRIPTION
## Summary

Localizes the review-gate state buckets in `do_check` so the extracted helper updates dynamically scoped locals instead of leaving the bucket names in the global namespace.

## Files Changed

- `.agents/scripts/review-bot-gate-helper.sh`

## Runtime Testing

- `bash -n .agents/scripts/review-bot-gate-helper.sh`
- `shellcheck .agents/scripts/review-bot-gate-helper.sh`
- `bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh`
- `.agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/review-bot-gate-helper.sh`

Closes #26251

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13
