### PR TITLE
GH#26278: fix: restore repo health branch on rewrite failure

### DIFF
--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -661,7 +661,7 @@ _commit_repo_aidevops_version() {
 	if ! git -C "$repo_path" add .aidevops.json >/dev/null 2>&1 ||
 		! git -C "$repo_path" commit -m "chore: bump .aidevops.json to v${target_version} (r914)" >/dev/null 2>&1; then
 		log_warn "bump failed ($slug): commit error"
-		git -C "$repo_path" checkout -f -q "$default_branch" || true
+		git -C "$repo_path" checkout -f -q "$default_branch" >/dev/null 2>&1 || true
 		return 1
 	fi
 	return 0
@@ -732,6 +732,9 @@ _bump_single_repo() {
 
 	# Atomic jq rewrite — NEVER sed (session lesson mem_20260419012142_0aa16fa7)
 	if ! _rewrite_repo_aidevops_version "$slug" "$adj_file" "$target_version"; then
+		if [[ "$local_only" != "true" ]]; then
+			git -C "$repo_path" checkout -f -q "$default_branch" >/dev/null 2>&1 || true
+		fi
 		echo failed
 		return 0
 	fi

--- a/.agents/scripts/tests/test-repo-aidevops-health.sh
+++ b/.agents/scripts/tests/test-repo-aidevops-health.sh
@@ -235,7 +235,25 @@ CURRENT_BRANCH=$(git -C "$WORK_REPO" rev-parse --abbrev-ref HEAD)
 assert "PR creation failure restores default branch" "$CURRENT_BRANCH" "main"
 
 # ---------------------------------------------------------------------------
-# Test 9 — rerunning a machine branch force-pushes replacement commits
+# Test 9 — rewrite failures restore the default branch
+# ---------------------------------------------------------------------------
+REWRITE_FAIL_RESULT=$( (
+	_rewrite_repo_aidevops_version() {
+		local slug="$1"
+		local adj_file="$2"
+		local target_version="$3"
+		return 1
+	}
+	BUMP_OUT=$(_bump_single_repo "test/pr-bump-repo" "$WORK_REPO" "false" "8.8.8" "0")
+	CURRENT_BRANCH=$(git -C "$WORK_REPO" rev-parse --abbrev-ref HEAD)
+	printf '%s\t%s\n' "$BUMP_OUT" "$CURRENT_BRANCH"
+) )
+IFS=$'\t' read -r REWRITE_FAIL_OUT REWRITE_FAIL_BRANCH <<<"$REWRITE_FAIL_RESULT"
+assert "rewrite failure reports failed" "$REWRITE_FAIL_OUT" "failed"
+assert "rewrite failure restores default branch" "$REWRITE_FAIL_BRANCH" "main"
+
+# ---------------------------------------------------------------------------
+# Test 10 — rerunning a machine branch force-pushes replacement commits
 # ---------------------------------------------------------------------------
 gh_create_pr() {
 	printf '%s\n' "$*" >"$GH_CREATE_PR_ARGS"
@@ -249,7 +267,7 @@ REMOTE_BRANCH_VERSION=$(git -C "$WORK_REPO" show "origin/chore/aidevops-version-
 assert "non-local bump rerun replaces remote version branch" "$REMOTE_BRANCH_VERSION" "9.9.9"
 
 # ---------------------------------------------------------------------------
-# Test 10 — recovery reset only runs when .aidevops.json is the sole ahead file
+# Test 11 — recovery reset only runs when .aidevops.json is the sole ahead file
 # ---------------------------------------------------------------------------
 MULTI_REMOTE_DIR="$FIXTURE_DIR/multi-remote"
 MULTI_REPO="$FIXTURE_DIR/multi-ahead-repo"


### PR DESCRIPTION
## Summary

Restored default-branch checkout when repo aidevops version rewrites fail, restored suppressed checkout output in the commit failure path, and added a regression test for rewrite-failure branch recovery.

## Files Changed

.agents/scripts/repo-aidevops-health-helper.sh,.agents/scripts/tests/test-repo-aidevops-health.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/repo-aidevops-health-helper.sh .agents/scripts/tests/test-repo-aidevops-health.sh; .agents/scripts/tests/test-repo-aidevops-health.sh

Resolves #26278


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 46,195 tokens on this as a headless worker.