### PR TITLE
GH#26280: fix: harden mixed pr view splitting

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -336,9 +336,9 @@ _gh_pr_view_args_for_json_fields() {
 	while [[ $# -gt 0 ]]; do
 		_arg="$1"
 		case "$_arg" in
-		--json) printf '%s\0%s\0' --json "$_json_fields"; _saw_json=1; shift 2 ;;
+		--json) printf '%s\0%s\0' --json "$_json_fields"; _saw_json=1; shift $(( $# >= 2 ? 2 : 1 )) ;;
 		--json=*) printf '%s\0%s\0' --json "$_json_fields"; _saw_json=1; shift ;;
-		--jq | -q) shift 2 ;;
+		--jq | -q) shift $(( $# >= 2 ? 2 : 1 )) ;;
 		--jq=* | -q=*) shift ;;
 		*) printf '%s\0' "$_arg"; shift ;;
 		esac
@@ -396,7 +396,7 @@ _gh_pr_view_try_mixed_split() {
 	_rest_out="$(_rest_pr_view "${_rest_args[@]}")" || return 1
 	gh_record_call graphql gh_pr_view_split 2>/dev/null || true
 	_gql_out="$(_gh_with_timeout read gh pr view "${_gql_args[@]}")" || return 1
-	_merged="$(jq -c -s '.[0] * .[1]' < <(printf '%s\n%s\n' "$_rest_out" "$_gql_out"))" || return 1
+	_merged="$(jq -c -s '(.[0] // {}) * (.[1] // {})' < <(printf '%s\n%s\n' "$_rest_out" "$_gql_out"))" || return 1
 	if [[ -n "$_jq_expr" ]]; then
 		printf '%s\n' "$_merged" | jq -r "$_jq_expr"
 		return $?

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1254,6 +1254,43 @@ unset STUB_PR_VIEW_FIXTURE STUB_PR_VIEW_STDOUT
 
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
+trailing_json_args=""
+trailing_json_args="$(_gh_pr_view_args_for_json_fields "number" 123 --repo "owner/repo" --json 2>"$TMP/trailing-json.err" | tr '\0' ' ')"
+if [[ "$trailing_json_args" == "123 --repo owner/repo --json number " && ! -s "$TMP/trailing-json.err" ]]; then
+	pass "gh_pr_view arg splitter handles trailing --json without shift error"
+else
+	fail "gh_pr_view arg splitter handles trailing --json without shift error" \
+		"args=${trailing_json_args} stderr=$(cat "$TMP/trailing-json.err")"
+fi
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+trailing_jq_args=""
+trailing_jq_args="$(_gh_pr_view_args_for_json_fields "number" 123 --repo "owner/repo" --jq 2>"$TMP/trailing-jq.err" | tr '\0' ' ')"
+if [[ "$trailing_jq_args" == "123 --repo owner/repo --json number " && ! -s "$TMP/trailing-jq.err" ]]; then
+	pass "gh_pr_view arg splitter handles trailing --jq without shift error"
+else
+	fail "gh_pr_view arg splitter handles trailing --jq without shift error" \
+		"args=${trailing_jq_args} stderr=$(cat "$TMP/trailing-jq.err")"
+fi
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+: >"$AIDEVOPS_GH_API_LOG"
+export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"rest title","state":"open"}'
+export STUB_PR_VIEW_STDOUT=''
+mixed_split_empty_gql_value=$(gh_pr_view 123 --repo "owner/repo" --json title,statusCheckRollup --jq '.title // empty' 2>/dev/null || true)
+mixed_split_empty_gql_calls=$(grep -cE '^pr view 123 --repo owner/repo --json statusCheckRollup$' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$mixed_split_empty_gql_value" == "rest title" && "$mixed_split_empty_gql_calls" == "1" ]]; then
+	pass "gh_pr_view mixed split tolerates successful empty GraphQL stdout"
+else
+	fail "gh_pr_view mixed split tolerates successful empty GraphQL stdout" \
+		"value=${mixed_split_empty_gql_value} gql_calls=${mixed_split_empty_gql_calls} GH_CALLS=$(cat "$GH_CALLS") API_LOG=$(cat "$AIDEVOPS_GH_API_LOG")"
+fi
+unset STUB_PR_VIEW_FIXTURE STUB_PR_VIEW_STDOUT
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
 export AIDEVOPS_GH_PR_LIST_CACHE_DIR="$TMP/pr-list-cache"
 export AIDEVOPS_GH_PR_LIST_CACHE_TTL=30
 gh_pr_list --repo "owner/repo" --state open --json number --jq length --limit 200 >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Hardened mixed REST/GQL gh_pr_view splitting by making trailing --json/--jq shifts defensive and merging split JSON with null-safe jq fallbacks; added regression coverage for trailing options and empty GraphQL stdout.

## Files Changed

.agents/scripts/shared-gh-wrappers-status.sh,.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-status.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh (72/72 tests passed)

Resolves #26280


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 65,375 tokens on this as a headless worker.