### PR TITLE
GH#26282: fix: guard empty resource metrics samples

### DIFF
--- a/.agents/scripts/resource-metrics-helper.sh
+++ b/.agents/scripts/resource-metrics-helper.sh
@@ -177,9 +177,19 @@ sample_resource_metrics() {
 
 	mkdir -p "$(dirname "$out_file")" 2>/dev/null || true
 	local start_ts end_ts elapsed_s sample_count peak_rss_kb rss_sum_kb cpu_seconds
+	start_ts=$(date -u +%s)
+	end_ts="$start_ts"
+	elapsed_s=0
+	sample_count=0
+	peak_rss_kb=0
+	rss_sum_kb=0
+	cpu_seconds="0.000"
+
 	local metrics
 	metrics=$(_sample_resource_metrics_loop "$pid" "$stop_file" "$interval")
-	IFS=$'\t' read -r start_ts end_ts elapsed_s sample_count peak_rss_kb rss_sum_kb cpu_seconds <<<"$metrics"
+	if [[ -n "$metrics" ]]; then
+		IFS=$'\t' read -r start_ts end_ts elapsed_s sample_count peak_rss_kb rss_sum_kb cpu_seconds <<<"$metrics"
+	fi
 	local avg_rss_kb=0
 	if [[ "$sample_count" -gt 0 ]]; then
 		avg_rss_kb=$((rss_sum_kb / sample_count))


### PR DESCRIPTION
## Summary

Initialized resource metric values with safe defaults and only parsed sampler output when non-empty, preventing empty metrics from reaching arithmetic and timestamp formatting.

## Files Changed

.agents/scripts/resource-metrics-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/resource-metrics-helper.sh; overridden empty _sample_resource_metrics_loop produced valid JSON via sample_resource_metrics

Resolves #26282


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 59,702 tokens on this as a headless worker.