### PR TITLE
GH#26293: fix stats health dashboard fallbacks

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -172,7 +172,7 @@ _update_health_issue_body_or_fail() {
 	body_edit_stderr=$(_gh_with_timeout write gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" \
 		--body "$body" 2>&1 >/dev/null) || {
 		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" \
-			>>"$LOGFILE"
+			>>"${LOGFILE:-/dev/null}"
 		return 1
 	}
 	return 0
@@ -199,9 +199,9 @@ _refresh_health_issue_title_from_body() {
 	IFS='|' read -r pr_count assigned_issue_count worker_count <<<"$counts_raw"
 
 	local pr_label="PRs"
-	[[ "$pr_count" -eq 1 ]] && pr_label="PR"
+	[[ "${pr_count:-0}" -eq 1 ]] && pr_label="PR"
 	local worker_label="workers"
-	[[ "$worker_count" -eq 1 ]] && worker_label="worker"
+	[[ "${worker_count:-0}" -eq 1 ]] && worker_label="worker"
 
 	_update_health_issue_title \
 		"$health_issue_number" "$repo_slug" "$runner_prefix" \


### PR DESCRIPTION
## Summary
- Guard health dashboard body-update failure logging with `${LOGFILE:-/dev/null}` so unset `LOGFILE` does not abort under `set -u`.
- Default extracted PR and worker counts to `0` before integer comparisons so empty parse results do not produce runtime comparison errors.

## Testing
- `shellcheck .agents/scripts/stats-health-dashboard.sh`

Resolves #26293

MERGE_SUMMARY: Guarded stats health dashboard fallback paths for unset LOGFILE and empty extracted counts; verified with shellcheck.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 33,506 tokens on this as a headless worker.
