### PR TITLE
GH#26308: fix: filter caret-escaped ANSI failure signatures

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -151,7 +151,7 @@ parse_commit_sha_from_subject_url() {
 normalize_signature_line() {
 	local raw_line="$1"
 	local stripped
-	stripped=$(printf '%s' "$raw_line" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g')
+	stripped=$(printf '%s' "$raw_line" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g; s/\^\[\[[0-9;]*[A-Za-z]//g')
 	stripped=$(printf '%s' "$stripped" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
 	if [[ -z "$stripped" ]]; then
 		printf '%s' "no_error_signature_detected"
@@ -175,6 +175,7 @@ filter_signature_noise_lines() {
 				}
 			}
 			gsub(/\033\[[0-9;]*[A-Za-z]/, "", payload)
+			gsub(/\^\[\[[0-9;]*[A-Za-z]/, "", payload)
 			# gh may return raw log rows with the ISO timestamp still prefixed
 			# instead of tab-separated job/step/time columns; remove it before
 			# classifying shell comments as signature noise.

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -74,6 +74,13 @@ assert_equals "GH#26127 comment-only systemic signature normalizes empty" "no_er
 filtered=$(filter_signature_noise_lines $'2026-06-30T20:14:24.8559907Z \033[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.\033[0m\n2026-06-30T20:14:25.0000000Z ::error::No AI review bots have posted a real, settled review on this PR yet.')
 assert_equals "GH#26144 timestamp-prefixed shell comments are filtered" $'2026-06-30T20:14:25.0000000Z ::error::No AI review bots have posted a real, settled review on this PR yet.' "$filtered"
 
+filtered=$(filter_signature_noise_lines $'gate / review-bot-gate\tUNKNOWN STEP\t2026-07-02T07:13:54.3733546Z\t^[[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.^[[0m')
+signature=$(normalize_signature_line "$filtered")
+assert_equals "GH#26308 caret-escaped ANSI comment-only signature normalizes empty" "no_error_signature_detected" "$signature"
+
+signature=$(normalize_signature_line $'^[[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.^[[0m')
+assert_equals "GH#26308 caret-escaped ANSI is stripped during normalization" "# rate-limit grace is disabled — they cannot merge on rate-limit-only." "$signature"
+
 printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then
 	exit 1


### PR DESCRIPTION
## Summary

Filtered caret-escaped ANSI control sequences before gh-failure-miner classifies shell-comment log rows, and added GH#26308 regression coverage so review-bot-gate comments cannot become systemic CI signatures.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh,.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

Resolves #26308


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 70,512 tokens on this as a headless worker.