### PR TITLE
GH#26276: fix: localize review gate bot state

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -931,6 +931,9 @@ _emit_review_gate_check_result() {
 do_check() {
 	local pr_number="$1"
 	local repo="$2"
+	local REVIEW_GATE_FOUND_BOTS=""
+	local REVIEW_GATE_RATE_LIMITED_BOTS=""
+	local REVIEW_GATE_NON_REVIEW_BOTS=""
 
 	# Check skip label first
 	if check_for_skip_label "$pr_number" "$repo"; then


### PR DESCRIPTION
## Summary

Declared review gate bot state variables local in do_check so helper functions share initialized state through Bash dynamic scoping without polluting globals.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/review-bot-gate-helper.sh; pre-commit validation during git commit

Resolves #26276


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 52,171 tokens on this as a headless worker.