### PR TITLE
GH#26284: docs: escape mosaic SVG tag text

### DIFF
--- a/todo/tasks/t18057-brief.md
+++ b/todo/tasks/t18057-brief.md
@@ -85,7 +85,7 @@ Keep the capability generic. Do not mention private projects, client names, loca
    - use 200px square tiles as the default recognisable-photo baseline;
    - allow smaller tiles only when the user wants abstract texture rather than recognisable photos;
    - assemble the output with explicit width/height attributes or CSS dimensions for every tile;
-   - avoid SVG `<symbol>/<use>` indirection for raster-heavy mosaics unless the renderer is proven to preserve embedded image rendering;
+   - avoid SVG &lt;symbol&gt;/&lt;use&gt; indirection for raster-heavy mosaics unless the renderer is proven to preserve embedded image rendering;
    - generate at least one proof artifact that compares the final mosaic with representative source images and tile assets.
 3. Include quality heuristics:
    - enough source-image variety to avoid obvious repetition;


### PR DESCRIPTION
## Summary

Escaped the SVG symbol/use tag references in todo/tasks/t18057-brief.md with HTML entities so Markdown renders them as literal text.

## Files Changed

todo/tasks/t18057-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 todo/tasks/t18057-brief.md

For #26284


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 49,949 tokens on this as a headless worker.