### PR TITLE
test: guard portable email code extraction patterns

### DIFF
--- a/tests/test-email-agent-helper.sh
+++ b/tests/test-email-agent-helper.sh
@@ -300,6 +300,18 @@ test_code_extraction_no_false_positives() {
 	assert_eq "No false link in normal email" "" "$link_match"
 }
 
+test_code_extraction_patterns_are_portable() {
+	echo "Test: Code extraction patterns avoid GNU-only grep"
+
+	local pcre_flag="grep -o""P"
+	local whitespace_escape='\\['"s"']'
+	local matches
+	matches=$(grep -nE "${pcre_flag}|${whitespace_escape}" "${BASH_SOURCE[0]}" || true)
+
+	assert_eq "No GNU-only grep PCRE flag or PCRE whitespace escapes" "" "$matches"
+	return 0
+}
+
 test_code_storage() {
 	echo "Test: Code storage in database"
 
@@ -649,6 +661,8 @@ main() {
 	test_code_extraction_multiple
 	echo ""
 	test_code_extraction_no_false_positives
+	echo ""
+	test_code_extraction_patterns_are_portable
 	echo ""
 	test_code_storage
 	echo ""


### PR DESCRIPTION
## Summary

- Added a regression test that scans the email helper test file for GNU-only grep PCRE usage.
- Guards against reintroducing grep -oP or PCRE whitespace escapes in code extraction patterns.

## Testing
- bash tests/test-email-agent-helper.sh
- shellcheck tests/test-email-agent-helper.sh

Resolves #3285
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 77,703 tokens on this as a headless worker.