### PR TITLE
fix: address remote dispatch sentinel diagnostics

### DIFF
--- a/.agents/scripts/remote-dispatch-helper.sh
+++ b/.agents/scripts/remote-dispatch-helper.sh
@@ -608,7 +608,7 @@ PROMPT_EOF
 	wrapper_content=$(
 		cat <<WRAPPER_EOF
 #!/usr/bin/env bash
-echo "WRAPPER_STARTED task_id=${task_id} wrapper_pid=\$\$ host=${host} timestamp=\$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${remote_log_file}" 2>/dev/null || true
+echo "WRAPPER_STARTED task_id=${task_id} wrapper_pid=\$\$ host=${host} timestamp=\$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${remote_log_file}" || true
 
 # Cleanup handler
 cleanup_children() {

--- a/.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh
+++ b/.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for wrapper sentinel diagnostics in remote-dispatch-helper.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
+HELPER="${REPO_ROOT}/.agents/scripts/remote-dispatch-helper.sh"
+
+pass() {
+	printf '  PASS %s\n' "$1"
+	return 0
+}
+
+fail() {
+	printf '  FAIL %s\n' "$1" >&2
+	[[ -n "${2:-}" ]] && printf '       %s\n' "$2" >&2
+	exit 1
+	return 1
+}
+
+if [[ ! -f "$HELPER" ]]; then
+	fail "helper file exists" "$HELPER"
+fi
+
+helper_content=$(<"$HELPER")
+wrapper_started_line=""
+while IFS= read -r line; do
+	if [[ "$line" == *"WRAPPER_STARTED"* ]]; then
+		wrapper_started_line="$line"
+		break
+	fi
+done <"$HELPER"
+
+# shellcheck disable=SC2016 # literal generated wrapper line; variables expand in the generated wrapper, not in this test.
+sentinel_line='echo "WRAPPER_STARTED task_id=${task_id} wrapper_pid=\$\$ host=${host} timestamp=\$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${remote_log_file}" || true'
+
+if [[ "$helper_content" == *"$sentinel_line"* ]]; then
+	pass "wrapper sentinel preserves runtime PID expansion and avoids blanket stderr suppression"
+else
+	fail "wrapper sentinel line should not use 2>/dev/null" "expected: $sentinel_line"
+fi
+
+if [[ "$wrapper_started_line" != *"2>/dev/null"* ]]; then
+	pass "WRAPPER_STARTED writes do not suppress diagnostic errors"
+else
+	fail "WRAPPER_STARTED write still suppresses errors with 2>/dev/null" "$wrapper_started_line"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Resolves #3635.
- The original PR #1981 supervisor module paths were removed by later refactors, so this applies the live equivalent sentinel-diagnostic fix in `.agents/scripts/remote-dispatch-helper.sh`.
- Removes blanket `2>/dev/null` suppression from the generated `WRAPPER_STARTED` write while preserving `wrapper_pid=$$` runtime expansion.
- Adds `.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh` to guard the generated sentinel line.

## Testing
- `bash .agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh && shellcheck .agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh .agents/scripts/remote-dispatch-helper.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13
