### PR TITLE
GH#3541: fix: wait for contrast font readiness

### DIFF
--- a/.agents/scripts/accessibility/playwright-contrast.mjs
+++ b/.agents/scripts/accessibility/playwright-contrast.mjs
@@ -227,6 +227,14 @@ function formatMarkdown(results, level) {
   return lines.join('\n');
 }
 
+async function waitForPageReady(page, timeout) {
+  await page.waitForLoadState('load', { timeout });
+  await page.evaluate(async () => {
+    if (document.fonts?.ready) await document.fonts.ready;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  });
+}
+
 // ============================================================================
 // Main
 // ============================================================================
@@ -240,7 +248,7 @@ async function main() {
     await context.addInitScript(BROWSER_SCRIPT);
     const page = await context.newPage();
     await page.goto(options.url, { waitUntil: 'load', timeout: options.timeout });
-    await page.evaluate(() => document.fonts.ready);
+    await waitForPageReady(page, options.timeout);
     const results = await page.evaluate('extractContrastData()');
     let filtered = options.failOnly ? results.filter((r) => isFailingAtLevel(r, options.level)) : results;
     if (options.limit > 0) filtered = filtered.slice(0, options.limit);


### PR DESCRIPTION
## Summary

Replaced the contrast audit readiness step with a page readiness helper that waits for load state, document.fonts.ready when available, and one animation frame before extracting contrast data.

## Files Changed

.agents/scripts/accessibility/playwright-contrast.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/scripts/accessibility/playwright-contrast.mjs passed; root npm run typecheck is blocked locally because @types/bun is declared in package.json but absent from node_modules, and the changed .mjs file is outside tsconfig.json include; .agents/scripts/linters-local.sh ran until the 240s watchdog timeout after passing SonarCloud, secretlint, TOON, skill frontmatter, secret safety, pulse canary, repository layout, and Bash 3.2 checks, with only unrelated advisory markdown/ratchet output before timeout.

Resolves #3541


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 9m and 105,481 tokens on this as a headless worker.