### PR TITLE
For #2560: wire bundle-aware pulse worker routing

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -161,7 +161,7 @@ _dlw_setup_worker_log() {
 # without the complexity of multi-value stdout parsing (bash 3.2 has no
 # namerefs — pattern from GH#18705 decomposition memory lesson):
 #   _DLW_DISPATCH_TIER        — cascade tier name: simple|standard|thinking
-#   _DLW_DISPATCH_MODEL_TIER  — runtime tier: haiku|sonnet|opus
+#   _DLW_DISPATCH_MODEL_TIER  — runtime tier: haiku|sonnet|opus|bundle tier
 #   _DLW_SELECTED_MODEL       — concrete model name, or empty for auto-select
 #
 # ROUND-ROBIN MODEL SELECTION (owned by this helper, NOT the caller).
@@ -178,11 +178,12 @@ _dlw_setup_worker_log() {
 # arbitrary model here bypasses the round-robin and causes provider
 # imbalance. History: GH#17503 moved model resolution here from the worker.
 #
-# Arguments: issue_meta_json, model_override
+# Arguments: issue_meta_json, model_override, repo_path
 #######################################
 _dlw_resolve_tier_and_model() {
 	local issue_meta_json="$1"
 	local model_override="$2"
+	local repo_path="${3:-}"
 
 	_DLW_DISPATCH_TIER="standard"
 	_DLW_DISPATCH_MODEL_TIER="sonnet"
@@ -207,12 +208,108 @@ _dlw_resolve_tier_and_model() {
 		;;
 	esac
 
+	# t1364.6: when issue labels do not force a tier, let project bundles
+	# right-size worker model selection for implementation work. Explicit model
+	# overrides and tier:* labels still win.
+	if [[ -z "$model_override" && -z "$resolved_tier" && -n "$repo_path" ]]; then
+		local bundle_tier
+		bundle_tier=$(_dlw_bundle_model_tier "$repo_path") || bundle_tier=""
+		if [[ -n "$bundle_tier" ]]; then
+			_DLW_DISPATCH_TIER="bundle"
+			_DLW_DISPATCH_MODEL_TIER="$bundle_tier"
+		fi
+	fi
+
 	_DLW_SELECTED_MODEL=""
 	if [[ -n "$model_override" ]]; then
 		_DLW_SELECTED_MODEL="$model_override"
 	else
 		_DLW_SELECTED_MODEL=$("$HEADLESS_RUNTIME_HELPER" select --role worker --tier "$_DLW_DISPATCH_MODEL_TIER" 2>/dev/null) || _DLW_SELECTED_MODEL=""
 	fi
+	return 0
+}
+
+#######################################
+# Resolve implementation model tier from the project bundle, if configured.
+# Arguments:
+#   $1 - repo_path
+# Stdout: tier name (empty if unavailable)
+#######################################
+_dlw_bundle_model_tier() {
+	local repo_path="$1"
+	local bundle_helper="${_DLW_SCRIPT_DIR:-${BASH_SOURCE[0]%/*}}/bundle-helper.sh"
+
+	if [[ -z "$repo_path" || ! -x "$bundle_helper" ]]; then
+		return 0
+	fi
+
+	"$bundle_helper" get model_defaults.implementation "$repo_path" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Classify a task into a coarse bundle agent_routing domain.
+# Arguments:
+#   $1 - issue_title
+#   $2 - prompt
+# Stdout: routing domain key
+#######################################
+_dlw_bundle_routing_domain() {
+	local issue_title="$1"
+	local prompt="$2"
+	local text
+	text=$(printf '%s %s' "$issue_title" "$prompt" | tr '[:upper:]' '[:lower:]')
+
+	case "$text" in
+	*seo* | *sitemap* | *schema* | *ranking* | *metadata* | *meta\ tag*)
+		printf 'seo\n'
+		return 0
+		;;
+	*content* | *blog* | *newsletter* | *social* | *video* | *copywriting*)
+		printf 'content\n'
+		return 0
+		;;
+	*accessibility* | *a11y* | *wcag*)
+		printf 'accessibility\n'
+		return 0
+		;;
+	*deploy* | *docker* | *terraform* | *infrastructure* | *cloudflare*)
+		printf 'infrastructure\n'
+		return 0
+		;;
+	*document* | *readme* | *docs*)
+		printf 'documentation\n'
+		return 0
+		;;
+	*)
+		printf 'code\n'
+		return 0
+		;;
+	esac
+}
+
+#######################################
+# Resolve preferred worker agent from bundle agent_routing.
+# Arguments:
+#   $1 - repo_path
+#   $2 - issue_title
+#   $3 - prompt
+# Stdout: agent name (empty if unavailable)
+#######################################
+_dlw_bundle_agent_name() {
+	local repo_path="$1"
+	local issue_title="$2"
+	local prompt="$3"
+	local bundle_helper="${_DLW_SCRIPT_DIR:-${BASH_SOURCE[0]%/*}}/bundle-helper.sh"
+
+	if [[ -z "$repo_path" || ! -x "$bundle_helper" ]]; then
+		return 0
+	fi
+
+	local domain
+	domain=$(_dlw_bundle_routing_domain "$issue_title" "$prompt")
+	"$bundle_helper" resolve "$repo_path" 2>/dev/null | jq -r --arg domain "$domain" \
+		'.agent_routing[$domain] // .agent_routing.code // empty' 2>/dev/null || true
 	return 0
 }
 
@@ -1375,6 +1472,11 @@ _dlw_nohup_launch() {
 		# no-activity/provider failures while preserving explicit --model pins.
 		worker_cmd+=(--initial-model "$selected_model")
 	fi
+	local bundle_agent
+	bundle_agent=$(_dlw_bundle_agent_name "$repo_path" "$issue_title" "$prompt") || bundle_agent=""
+	if [[ -n "$bundle_agent" ]]; then
+		worker_cmd+=(--agent "$bundle_agent")
+	fi
 
 	# t2757: Detach worker via setsid (extracted to helper)
 	_dlw_exec_detached "$worker_log" "$issue_number" "${worker_cmd[@]}"
@@ -1846,7 +1948,7 @@ _dispatch_launch_worker() {
 	fi
 
 	_ds_t0=$(_ds_now_ns)
-	_dlw_resolve_tier_and_model "$issue_meta_json" "$model_override"
+	_dlw_resolve_tier_and_model "$issue_meta_json" "$model_override" "$repo_path"
 	_ds_record "$issue_number" "$repo_slug" "resolve_tier_model" "$_ds_t0"
 	local dispatch_tier="$_DLW_DISPATCH_TIER" dispatch_model_tier="$_DLW_DISPATCH_MODEL_TIER" selected_model="$_DLW_SELECTED_MODEL"
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -189,6 +189,10 @@ _dlw_resolve_tier_and_model() {
 	_DLW_DISPATCH_MODEL_TIER="sonnet"
 	local issue_labels_csv
 	issue_labels_csv=$(printf '%s' "$issue_meta_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels_csv=""
+	local explicit_tier_label=0
+	if _dlw_has_explicit_tier_label "$issue_labels_csv"; then
+		explicit_tier_label=1
+	fi
 
 	# Resolve tier from labels, preferring highest rank when multiple present (t1997)
 	local resolved_tier
@@ -211,7 +215,7 @@ _dlw_resolve_tier_and_model() {
 	# t1364.6: when issue labels do not force a tier, let project bundles
 	# right-size worker model selection for implementation work. Explicit model
 	# overrides and tier:* labels still win.
-	if [[ -z "$model_override" && -z "$resolved_tier" && -n "$repo_path" ]]; then
+	if [[ -z "$model_override" && "$explicit_tier_label" -eq 0 && -n "$repo_path" ]]; then
 		local bundle_tier
 		bundle_tier=$(_dlw_bundle_model_tier "$repo_path") || bundle_tier=""
 		if [[ -n "$bundle_tier" ]]; then
@@ -227,6 +231,26 @@ _dlw_resolve_tier_and_model() {
 		_DLW_SELECTED_MODEL=$("$HEADLESS_RUNTIME_HELPER" select --role worker --tier "$_DLW_DISPATCH_MODEL_TIER" 2>/dev/null) || _DLW_SELECTED_MODEL=""
 	fi
 	return 0
+}
+
+#######################################
+# Check whether labels include an explicit worker tier.
+# _resolve_worker_tier defaults unlabeled issues to tier:standard, so callers
+# need this helper to distinguish an authored tier label from the fallback.
+# Arguments:
+#   $1 - comma-separated label list
+# Returns: 0 when a tier:* label is present, 1 otherwise
+#######################################
+_dlw_has_explicit_tier_label() {
+	local labels_csv="$1"
+	local labels_lower
+	labels_lower=$(printf '%s' "$labels_csv" | tr '[:upper:]' '[:lower:]')
+	local labels_with_commas=",${labels_lower},"
+
+	case "$labels_with_commas" in
+	*,tier:thinking,* | *,tier:standard,* | *,tier:simple,*) return 0 ;;
+	*) return 1 ;;
+	esac
 }
 
 #######################################

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -140,6 +140,65 @@ else
 	fail "native blockedBy lookup failure should emit blocked_by_native_lookup_unavailable"
 fi
 
+cat >"${TEST_TMP}/bin/headless-runtime-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+tier=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--tier)
+		tier="${2:-}"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+printf 'selected-%s\n' "$tier"
+EOF
+chmod +x "${TEST_TMP}/bin/headless-runtime-helper.sh" || fail "failed to make headless runtime stub executable"
+
+_resolve_worker_tier() {
+	local labels_csv="$1"
+	local labels_lower
+	labels_lower=$(printf '%s' "$labels_csv" | tr '[:upper:]' '[:lower:]')
+	local labels_with_commas=",${labels_lower},"
+
+	if [[ "$labels_with_commas" == *",tier:thinking,"* ]]; then
+		printf 'tier:thinking'
+	elif [[ "$labels_with_commas" == *",tier:standard,"* ]]; then
+		printf 'tier:standard'
+	elif [[ "$labels_with_commas" == *",tier:simple,"* ]]; then
+		printf 'tier:simple'
+	else
+		printf 'tier:standard'
+	fi
+	return 0
+}
+
+bundle_repo="${TEST_TMP}/content-site"
+mkdir -p "$bundle_repo" || fail "failed to create bundle repo fixture"
+printf '{"bundle":"content-site"}\n' >"${bundle_repo}/.aidevops.json" || fail "failed to create bundle config fixture"
+
+HEADLESS_RUNTIME_HELPER="${TEST_TMP}/bin/headless-runtime-helper.sh" \
+	_dlw_resolve_tier_and_model '{"labels":[]}' "" "$bundle_repo"
+
+if [[ "$_DLW_DISPATCH_TIER" != "bundle" || "$_DLW_DISPATCH_MODEL_TIER" != "haiku" || "$_DLW_SELECTED_MODEL" != "selected-haiku" ]]; then
+	fail "bundle model default was not applied to unlabeled worker dispatch"
+fi
+
+HEADLESS_RUNTIME_HELPER="${TEST_TMP}/bin/headless-runtime-helper.sh" \
+	_dlw_resolve_tier_and_model '{"labels":[{"name":"tier:thinking"}]}' "" "$bundle_repo"
+
+if [[ "$_DLW_DISPATCH_TIER" != "thinking" || "$_DLW_DISPATCH_MODEL_TIER" != "opus" || "$_DLW_SELECTED_MODEL" != "selected-opus" ]]; then
+	fail "explicit tier label did not override bundle model default"
+fi
+
+seo_agent=$(_dlw_bundle_agent_name "$bundle_repo" "Improve SEO metadata" "Update sitemap and schema") || fail "bundle agent routing lookup failed"
+if [[ "$seo_agent" != "SEO" ]]; then
+	fail "bundle agent routing did not select SEO for SEO task"
+fi
+
 printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
 printf 'PASS: root node_modules payload is skipped by default\n'
 printf 'PASS: root node_modules .bin tooling is linked by default\n'
@@ -148,4 +207,7 @@ printf 'PASS: pulse worker launch forwards dispatching GitHub login\n'
 printf 'PASS: systemd PID resolver handles final unterminated property\n'
 printf 'PASS: worker launch hard-stops unresolved blocked-by dependencies\n'
 printf 'PASS: native blockedBy lookup failure remains fail-closed with classified reason\n'
+printf 'PASS: bundle defaults route unlabeled worker model selection\n'
+printf 'PASS: explicit tier labels override bundle model defaults\n'
+printf 'PASS: bundle agent_routing selects task-specific worker agents\n'
 exit 0


### PR DESCRIPTION
## Summary

- Applies bundle `model_defaults.implementation` when pulse worker dispatch has no explicit `tier:*` label or model override.
- Adds bundle `agent_routing` lookup before worker launch so domain tasks can use the bundle-preferred agent.
- Adds regression coverage for bundle model default selection, explicit tier precedence, and SEO agent routing.

## Verification

- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `git diff --check origin/main...HEAD`
- `.agents/scripts/bundle-helper.sh get model_defaults.implementation . && .agents/scripts/bundle-helper.sh get agent_routing .`

For #2560

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved worker routing so bundled projects can automatically use the appropriate default model tier when no explicit tier label is set.
  * Added smarter task routing for bundle-based agent selection, including better handling for SEO-related work.

* **Bug Fixes**
  * Explicit tier labels now take precedence over bundle defaults, helping ensure the selected worker configuration matches the issue’s stated priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->