### PR TITLE
GH#5750: test: guard runner helper simplification

### DIFF
--- a/.agents/scripts/tests/test-runner-helper-simplification.sh
+++ b/.agents/scripts/tests/test-runner-helper-simplification.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-runner-helper-simplification.sh — Regression guard for GH#5750
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../runner-helper.sh"
+THRESHOLD="${COMPLEXITY_FUNC_LINE_THRESHOLD:-100}"
+
+measure_function_lines() {
+	local function_name="$1"
+	awk -v target="${function_name}() {" '
+		index($0, target) == 1 {
+			in_func = 1
+			next
+		}
+		in_func {
+			line_count++
+			if ($0 ~ /^\}/) {
+				print line_count - 1
+				exit
+			}
+		}
+	' "$HELPER"
+	return 0
+}
+
+assert_under_threshold() {
+	local function_name="$1"
+	local lines
+	lines="$(measure_function_lines "$function_name")"
+
+	if [[ -z "$lines" ]]; then
+		printf 'FAIL %s not found in runner-helper.sh\n' "$function_name" >&2
+		return 1
+	fi
+
+	if [[ "$lines" -gt "$THRESHOLD" ]]; then
+		printf 'FAIL %s is %s lines, threshold is %s\n' "$function_name" "$lines" "$THRESHOLD" >&2
+		return 1
+	fi
+
+	printf 'PASS %s is %s lines (<= %s)\n' "$function_name" "$lines" "$THRESHOLD"
+	return 0
+}
+
+assert_under_threshold "cmd_create"
+assert_under_threshold "cmd_run"


### PR DESCRIPTION
## Summary

Added a focused regression test proving runner-helper cmd_create and cmd_run stay under the 100-line function complexity threshold; verified runner-helper currently has zero long functions.

## Files Changed

.agents/scripts/tests/test-runner-helper-simplification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/runner-helper.sh && bash -n .agents/scripts/tests/test-runner-helper-simplification.sh; shellcheck .agents/scripts/runner-helper.sh .agents/scripts/tests/test-runner-helper-simplification.sh; bash .agents/scripts/tests/test-runner-helper-simplification.sh && .agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/runner-helper.sh

Resolves #5750


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 84,337 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression check to keep key command-handling logic within a manageable complexity limit.
  * The check reports clear pass/fail messages and warns if a target command handler is missing or becomes too large.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->