### PR TITLE
t18058: perf: coalesce pulse merge PR list scans

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -54,6 +54,16 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${PULSE_MERGE_BATCH_LIMIT:=50}"
 : "${PULSE_MERGE_CHECKPOINT_FILE:=${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 
+# Load the exact-output PR-list provider cache for standalone module tests and
+# direct routine sourcing. pulse-wrapper.sh also sources this before the merge
+# modules, so the include guard in pulse-pr-list-cache.sh keeps this idempotent.
+_PULSE_MERGE_PROCESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${_PULSE_MERGE_PROCESS_DIR}/pulse-pr-list-cache.sh" ]]; then
+	# shellcheck source=./pulse-pr-list-cache.sh
+	# shellcheck disable=SC1091
+	source "${_PULSE_MERGE_PROCESS_DIR}/pulse-pr-list-cache.sh"
+fi
+
 #######################################
 # Low-overhead timing helpers for per-repo merge summaries.
 #
@@ -718,20 +728,26 @@ _merge_ready_prs_for_repo() {
 	local closed=0
 	local failed=0
 
-	# Fetch open PRs without GraphQL statusCheckRollup. Backlog scheduling is
-	# enriched below from REST check-suites so merge polling preserves GraphQL
-	# budget for dispatch.
+	# Fetch open PRs through the exact-output provider cache. Backlog scheduling
+	# is enriched below from REST check-suites so repeated merge/stuck scans can
+	# share a per-cycle PR-list snapshot without changing jq consumer semantics.
 	local pr_json pr_merge_err
 	local _list_start
 	_list_start=$(_pmp_now_epoch)
 	pr_merge_err=$(mktemp)
-	pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json "$(_pulse_merge_ready_pr_json_fields)" \
-		--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
+	if declare -F pulse_pr_list_get >/dev/null 2>&1; then
+		pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open \
+			--json "$(_pulse_merge_ready_pr_json_fields)" \
+			--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
+	else
+		pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
+			--json "$(_pulse_merge_ready_pr_json_fields)" \
+			--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
+	fi
 	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg
 		_pr_merge_err_msg=$(cat "$pr_merge_err" 2>/dev/null || echo "unknown error")
-		echo "[pulse-wrapper] _process_merge_batch: gh_pr_list FAILED for ${repo_slug}: ${_pr_merge_err_msg}" >>"$LOGFILE"
+		echo "[pulse-wrapper] _process_merge_batch: pulse_pr_list_get FAILED for ${repo_slug}: ${_pr_merge_err_msg}" >>"$LOGFILE"
 		pr_json="[]"
 	fi
 	rm -f "$pr_merge_err"

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -66,6 +66,15 @@ _PULSE_MERGE_STUCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${_PULSE_MERGE_STUCK_DIR}/pulse-stats-helper.sh"
 
+# Load the exact-output PR-list provider cache for the stuck-merge hot paths.
+# pulse-wrapper.sh sources this earlier in normal operation; the include guard
+# keeps direct module tests and wrapper sourcing idempotent.
+if [[ -f "${_PULSE_MERGE_STUCK_DIR}/pulse-pr-list-cache.sh" ]]; then
+	# shellcheck source=./pulse-pr-list-cache.sh
+	# shellcheck disable=SC1091
+	source "${_PULSE_MERGE_STUCK_DIR}/pulse-pr-list-cache.sh"
+fi
+
 # Source the rate-limit / Actions-queue helper for _check_actions_queue_saturation
 # (t3211, GH#21942). Defined alongside the GraphQL circuit breaker because both
 # concern GitHub-side resource exhaustion. The source is best-effort — if the
@@ -118,6 +127,19 @@ readonly _PMS_COUNTER_QUEUE_SATURATION_EVENTS="pulse_actions_queue_saturation_ev
 readonly _PMS_GAUGE_ZERO_PROGRESS_CYCLES='pulse_merge_zero_progress_cycles'
 readonly _PMS_GAUGE_ZERO_PROGRESS_RECOVERY_CHECK_TS='pulse_merge_zero_progress_recovery_check_ts'
 readonly _PMS_JQ_NULL_GUARD="null"
+
+#######################################
+# Shared open-PR field shape for stuck-merge list scans.
+#
+# Keeps the zero-progress counter and stuck detector on one exact-output
+# provider-cache key while preserving both consumers' fields: author is needed
+# by _pms_count_eligible_unmerged_for_repo, updatedAt by
+# pulse_merge_stuck_run_pass, and the remaining fields gate eligibility.
+#######################################
+_pms_pr_list_json_fields() {
+	printf '%s' 'number,mergeable,reviewDecision,isDraft,labels,author,updatedAt'
+	return 0
+}
 readonly _PMS_RUNNER_SATURATION_MARKER_TEXT="merge-stuck:runner-queue-saturation"
 # jq filter snippet that selects normalized REST check entries with a failing
 # conclusion/state. Extracted so the upcase predicate is defined exactly once
@@ -1204,8 +1226,8 @@ _pms_count_eligible_unmerged_for_repo() {
 	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
 
 	local pr_json
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--json number,mergeable,reviewDecision,isDraft,labels,author \
+	pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open \
+		--json "$(_pms_pr_list_json_fields)" \
 		--limit 50 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
 
@@ -1353,8 +1375,8 @@ pulse_merge_stuck_run_pass() {
 
 	# Fetch open PRs with the fields the detector needs.
 	local pr_json
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--json number,mergeable,reviewDecision,isDraft,labels,updatedAt \
+	pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open \
+		--json "$(_pms_pr_list_json_fields)" \
 		--limit 50 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
 

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -87,10 +87,20 @@ test_merge_ready_pr_list_failure_logs_error() {
 	return 0
 }
 
+test_merge_ready_pr_list_uses_provider_cache() {
+	if ! file_contains "$MERGE_PROCESS" 'pulse_pr_list_get --repo "$repo_slug" --state open'; then
+		print_result "merge-ready PR list uses provider cache" 1 "_merge_ready_prs_for_repo must route through pulse_pr_list_get for per-cycle coalescing"
+		return 0
+	fi
+	print_result "merge-ready PR list uses provider cache" 0
+	return 0
+}
+
 main() {
 	test_ready_pr_fields_include_process_metadata
 	test_callers_use_shared_field_helper
 	test_merge_ready_pr_list_failure_logs_error
+	test_merge_ready_pr_list_uses_provider_cache
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -424,29 +424,31 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "--- Section 6: zero-progress count gate parity ---"
 
-gh() {
-	local command_name="${1:-}"
-	local subcommand="${2:-}"
-	if [[ "$command_name" == "pr" && "$subcommand" == "list" ]]; then
-		printf '%s\n' '[
-{"number":101,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
-{"number":102,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"author":{"login":"trusted"}},
-{"number":103,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"author":{"login":"trusted"}},
-{"number":104,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"hold-for-review"}],"author":{"login":"trusted"}},
-{"number":105,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
-{"number":106,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
-{"number":107,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"external"}},
-{"number":108,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"}},
-{"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null},
-{"number":110,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":null,"author":{"login":"external"}},
-{"number":111,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"}],"author":{"login":"trusted"}},
-{"number":112,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"},{"name":"allow-auto-merge"}],"author":{"login":"trusted"}},
-{"number":113,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"external-contributor"}],"author":{"login":"trusted"}},
-{"number":114,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"external-contributor"}],"author":{"login":"trusted"}}
+export PULSE_PR_LIST_PROVIDER_CACHE_DIR="$TEST_TMPDIR/pr-list-cache"
+export PULSE_PR_LIST_PROVIDER_CACHE_TTL=3600
+unset PULSE_PR_LIST_PROVIDER_CACHE_DISABLE
+PMS_TEST_PR_LIST_CALLS="$TEST_TMPDIR/pr-list-calls.log"
+: >"$PMS_TEST_PR_LIST_CALLS"
+
+gh_pr_list() {
+	printf '%s\n' "$*" >>"$PMS_TEST_PR_LIST_CALLS"
+	printf '%s\n' '[
+{"number":101,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":102,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":103,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":104,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"hold-for-review"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":105,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":106,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":107,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"external"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":108,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null,"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":110,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":null,"author":{"login":"external"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":111,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":112,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:interactive"},{"name":"allow-auto-merge"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":113,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"external-contributor"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"},
+{"number":114,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"external-contributor"}],"author":{"login":"trusted"},"updatedAt":"2026-01-01T00:00:00Z"}
 ]'
-		return 0
-	fi
-	return 1
+	return 0
 }
 
 _check_required_checks_passing() {
@@ -503,6 +505,27 @@ _interactive_pr_auto_merge_allowed() {
 got=$(_pms_count_eligible_unmerged_for_repo "example/repo")
 assert_eq "6a: zero-progress count excludes read-only merge-gate blockers" "4" "$got"
 
+_pms_compute_saturation_state() {
+	printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+	return 0
+}
+
+_pms_handle_classified_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local is_saturated="$3"
+	[[ -n "$pr_number" && -n "$repo_slug" && -n "$is_saturated" ]] || return 1
+	printf 'HANDLED'
+	return 0
+}
+
+AIDEVOPS_MERGE_STUCK_AGE_MINUTES=1
+AIDEVOPS_MERGE_PATTERN_MIN_PRS=99
+pulse_merge_stuck_run_pass "example/repo" >/dev/null 2>&1
+shape_calls=$(grep -cF -- '--json number,mergeable,reviewDecision,isDraft,labels,author,updatedAt --limit 50' "$PMS_TEST_PR_LIST_CALLS" 2>/dev/null || true)
+assert_eq "6a.1: stuck scans share one provider-cache PR-list shape" "1" "$shape_calls"
+AIDEVOPS_MERGE_PATTERN_MIN_PRS=3
+
 PMS_TEST_COUNT_AUTHORS_FILE="$TEST_TMPDIR/count-authors.log"
 : >"$PMS_TEST_COUNT_AUTHORS_FILE"
 _pms_pr_counts_for_zero_progress() {
@@ -516,16 +539,12 @@ _pms_pr_counts_for_zero_progress() {
 	return 0
 }
 
-gh() {
-	local command_name="${1:-}"
-	local subcommand="${2:-}"
-	if [[ "$command_name" == "pr" && "$subcommand" == "list" ]]; then
-		printf '%s\n' '[
-{"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null}
+export PULSE_PR_LIST_PROVIDER_CACHE_DIR="$TEST_TMPDIR/pr-list-cache-null-author"
+gh_pr_list() {
+	printf '%s\n' '[
+{"number":109,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"author":null,"updatedAt":"2026-01-01T00:00:00Z"}
 ]'
-		return 0
-	fi
-	return 1
+	return 0
 }
 
 got=$(_pms_count_eligible_unmerged_for_repo "example/repo")


### PR DESCRIPTION
## Summary

Routed deterministic merge/stuck PR-list scans through pulse_pr_list_get and shared the stuck detector field shape so repeated repo/cycle reads hit the provider cache.

## Files Changed

.agents/scripts/pulse-merge-process.sh,.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh,.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-pr-list-cache.sh; .agents/scripts/tests/test-pulse-merge-stuck.sh; .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh; shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge-stuck.sh

Resolves #26329


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 12m and 164,507 tokens on this as a headless worker.