### PR TITLE
chore: mark t1368 complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4406,4 +4406,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t18059 test(pulse): cover linked-PR fallback gh_pr_list routing #auto-dispatch #framework #github #performance #pulse #testing ref:GH#26330
 
-- [ ] t1368 Write-time quality enforcement rules #enhancement ref:GH#2660
+- [x] t1368 Write-time quality enforcement rules #enhancement ref:GH#2660 pr:#2659 completed:2026-03-01


### PR DESCRIPTION
For #2660

## Summary
- Mark `t1368` complete in `TODO.md` now that PR #2659 implemented the tracked write-time quality enforcement work.
- Record the completion metadata (`pr:#2659 completed:2026-03-01`) so TODO sync stays aligned with the closed issue.

## Verification
- `gh issue view 2660 --repo marcusquinn/aidevops --json number,state,closedAt,labels,comments,url`
- `git diff origin/main...HEAD -- TODO.md`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13
