### PR TITLE
GH#26360: fix CI repair check routing

### DIFF
--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -97,6 +97,22 @@ def read_state_file(path):
     return state
 
 
+def graphql_pressure_seen(graphql_budget, pre_launch_blockers):
+    if graphql_budget['skipped_low_count'] > 0:
+        return True
+    if graphql_budget['circuit_broken_count'] > 0:
+        return True
+    return pre_launch_blockers.get('graphql_circuit_breaker', 0) > 0
+
+
+def dispatch_blocked_by_graphql_budget(graphql_budget_status, graphql_budget, pre_launch_blockers):
+    if graphql_budget_status.startswith('TRIPPED:'):
+        return True
+    if graphql_budget_status.startswith('OK:'):
+        return False
+    return graphql_pressure_seen(graphql_budget, pre_launch_blockers)
+
+
 stage_records = []
 for line in recent_lines(os.path.join(log_dir, 'dispatch-stages.tsv')):
     record = parse_stage(line)
@@ -229,17 +245,7 @@ try:
     ).strip() or graphql_budget_status
 except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
     pass
-dispatch_api_blocked = (
-    graphql_budget_status.startswith('TRIPPED:')
-    or (
-        not graphql_budget_status.startswith('OK:')
-        and (
-            graphql_budget['skipped_low_count'] > 0
-            or graphql_budget['circuit_broken_count'] > 0
-            or pre_launch_blockers.get('graphql_circuit_breaker', 0) > 0
-        )
-    )
-)
+dispatch_api_blocked = dispatch_blocked_by_graphql_budget(graphql_budget_status, graphql_budget, pre_launch_blockers)
 current_state_guardrails = {
     'applied_count': counter_hits.get('pulse_dispatch_current_state_guardrail_applied', 0),
     'available_slots_last': gauge_values.get('pulse_dispatch_guardrail_available_slots'),

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -379,7 +379,7 @@ _ci_actionable_failed_checks_markdown() {
 # Return terminal failed check details and names from one jq pass.
 #
 # Args:
-#   $1 - checks_json (array from gh pr checks --json name,bucket,conclusion,link)
+#   $1 - checks_json (array from gh pr checks --json name,bucket,state,link)
 #   $2 - terminal_failed_check_filter (jq select expression)
 #
 # Output: first line is filtered checks JSON, followed by a marker and one
@@ -391,7 +391,7 @@ _ci_terminal_failed_check_results() {
 	local terminal_failed_check_filter="$2"
 
 	[[ -n "$checks_json" ]] || checks_json="[]"
-	printf '%s' "$checks_json" | jq -r "([.[] | select(${terminal_failed_check_filter}) | {name, conclusion, link}] | tojson), \"__AIDEVOPS_CHECK_NAMES__\", (.[] | select(${terminal_failed_check_filter}) | .name)" 2>/dev/null || {
+	printf '%s' "$checks_json" | jq -r "([.[] | select(${terminal_failed_check_filter}) | {name, conclusion: ((.conclusion // .state // \"\") | ascii_downcase), link}] | tojson), \"__AIDEVOPS_CHECK_NAMES__\", (.[] | select(${terminal_failed_check_filter}) | .name)" 2>/dev/null || {
 		printf '[]\n__AIDEVOPS_CHECK_NAMES__\n'
 		return 0
 	}
@@ -441,12 +441,12 @@ _dispatch_ci_fix_worker() {
 	# full check set so advisory-only terminal failures can still carry
 	# pattern-specific repair guidance.
 	local terminal_failed_check_filter
-	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and ((.conclusion // "") | test("^(failure|action_required)$")) and ((.link // "") != "")'
+	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and (((.conclusion // .state // "") | ascii_downcase) | test("^(failure|action_required)$")) and ((.link // "") != "")'
 	local checks_json="$supplied_checks_json" result_marker=$'\n__AIDEVOPS_CHECK_NAMES__'
 	local check_results="" failing_checks_json="" failing_checks="" failing_names="" classification_output=""
 	if [[ -z "$checks_json" ]]; then
 		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
-			--json name,bucket,conclusion,link \
+			--json name,bucket,state,link \
 			2>/dev/null) || checks_json="[]"
 	fi
 	check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
@@ -458,7 +458,7 @@ _dispatch_ci_fix_worker() {
 
 	if [[ -z "$failing_checks" && -z "$supplied_checks_json" ]]; then
 		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" \
-			--json name,bucket,conclusion,link \
+			--json name,bucket,state,link \
 			2>/dev/null) || checks_json="[]"
 		check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
 		failing_checks_json="${check_results%%"$result_marker"*}"

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -88,28 +88,32 @@ fi
 	if [[ "${1:-} ${2:-}" == "pr checks" ]]; then
 		_is_required=0
 		[[ "$*" == *" --required "* || "$*" == *" --required"* ]] && _is_required=1
-	if [[ "$*" == *"name,bucket,conclusion,link"* ]]; then
-		case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-			terminal_failure:1 | log_exit_143:1)
-				printf '%s\n' '[{"name":"Lint","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
-				;;
-			pending_only:*|mixed_pending_pass:*)
-				printf '[]\n'
-				;;
-			infra_timeout:1)
-				printf '%s\n' '[{"name":"Lint","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
-				;;
-			advisory_failure:0)
-				printf '%s\n' '[{"name":"Docs","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/789"}]'
-				;;
-			advisory_failure:1)
-				printf '[]\n'
-				;;
+		if [[ "$*" == *"conclusion"* ]]; then
+			printf '%s\n' 'Unknown JSON field: "conclusion"' >&2
+			exit 1
+		fi
+		if [[ "$*" == *"name,bucket,state,link"* ]]; then
+			case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
+				terminal_failure:1 | log_exit_143:1)
+					printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+					;;
+				pending_only:*|mixed_pending_pass:*)
+					printf '[]\n'
+					;;
+				infra_timeout:1)
+					printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+					;;
+				advisory_failure:0)
+					printf '%s\n' '[{"name":"Docs","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/789"}]'
+					;;
+				advisory_failure:1)
+					printf '[]\n'
+					;;
 			esac
+			exit 0
+		fi
 		exit 0
 	fi
-	exit 0
-fi
 
 if [[ "${1:-} ${2:-}" == "issue view" ]]; then
 	if [[ "$*" == *"--json body"* ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -107,8 +107,12 @@ case "$_subcmd" in
 		printf '%s\n' 'Lint'
 		exit 0
 	fi
-	if [[ "$*" == *"--json name,bucket,conclusion,link"* ]]; then
-		printf '%s\n' '[{"name":"Lint","bucket":"fail","conclusion":"failure","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+	if [[ "$*" == *"conclusion"* ]]; then
+		printf '%s\n' 'Unknown JSON field: "conclusion"' >&2
+		exit 1
+	fi
+	if [[ "$*" == *"--json name,bucket,state,link"* ]]; then
+		printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
 		exit 0
 	fi
 	exit 0


### PR DESCRIPTION
## Summary
- Request `state` instead of obsolete `conclusion` from `gh pr checks` in CI repair routing.
- Normalize both `state` and legacy/precomputed `conclusion` to keep feedback text stable.
- Update CI repair tests so mocks reject the obsolete field and prove the supported `state` shape routes repair feedback.

Resolves #26360

## Root cause
`gh pr checks --json name,bucket,conclusion,link` fails on GitHub CLI 2.95.0 because `conclusion` is no longer an exported field. The helper swallowed the failure as `[]`, so deterministic merge saw red required checks but CI repair routing skipped with `no actionable failed checks with URLs`.

## Verification
- `gh --version`
- `gh pr checks <sample> --required --json name,bucket,state,link`
- `bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
- `bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`
- `shellcheck .agents/scripts/pulse-merge-feedback.sh .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.19 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 12h 55m and 789,004 tokens on this with the user in an interactive session.
