### PR TITLE
GH#26364: fix pulse launch validation accounting

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -18,6 +18,8 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 ($queue.aggregate.gh_errors // 0 | number_or_zero) as $gh_errors |
 ($queue.error // "") as $queue_error |
 ($current.worker_outcomes.spawned // 0 | number_or_zero) as $spawned |
+($current.worker_outcomes.launch_validation_failed // $current.pulse_counter_hits.dispatch_worker_launch_failed // 0 | number_or_zero) as $launch_validation_failed |
+($current.worker_terminal_events // 0 | number_or_zero) as $current_terminal_events |
 ($recent_summary.metrics.total // 0 | number_or_zero) as $recent_total |
 ($summary.metrics.total // 0 | number_or_zero) as $hist_total |
 ($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
@@ -32,7 +34,8 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     dispatch_alive: ($current.dispatch_alive // false),
     dispatch_stage_events: ($current.dispatch_stage_events // 0),
     worker_launches_in_window: $spawned,
-    worker_terminal_events_in_window: ($current.worker_terminal_events // 0),
+    worker_terminal_events_in_window: $current_terminal_events,
+    worker_launch_validation_failures_in_window: $launch_validation_failed,
     recent_worker_events: $recent_total,
     historical_worker_events: $hist_total,
     historical_worker_successes: $hist_success,
@@ -93,7 +96,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
         true
       )
     else empty end,
-    if ($spawned >= 3 and $active_workers == 0 and $recent_total == 0) then
+    if (($spawned - ([($recent_total), ($current_terminal_events)] | max) - $launch_validation_failed) >= 3 and $active_workers == 0) then
       finding(
         "pulse-launch-accounting-gap";
         "high";
@@ -101,6 +104,8 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
         [
           ("worker_launches_in_current_window=" + ($spawned | tostring)),
           ("recent_worker_metric_events=" + ($recent_total | tostring)),
+          ("worker_terminal_events_in_current_window=" + ($current_terminal_events | tostring)),
+          ("worker_launch_validation_failures_in_current_window=" + ($launch_validation_failed | tostring)),
           ("active_workers=" + ($active_workers | tostring)),
           ("available_slots=" + ($available_slots | tostring))
         ];

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -182,6 +182,7 @@ load_blocked_count = counter_hits.get('dispatch_load_blocked', 0) + sum(
 rate_limit_count = metric_class_counts.get('rate_limit', 0)
 watchdog_kill_count = metric_class_counts.get('watchdog_stall_killed', 0)
 noop_count = metric_class_counts.get('worker_noop', 0)
+launch_validation_failure_count = counter_hits.get('dispatch_worker_launch_failed', 0)
 pr_opened_count, pr_opened_examples = line_count(['pr opened', 'opened pr', 'pull request'], wrapper_activity)
 pr_merged_count, pr_merged_examples = line_count(['pr merged', 'merged pr', 'squash merged'], wrapper_activity)
 issue_closed_count, issue_closed_examples = line_count(['issue closed', 'closed issue', 'status:done'], wrapper_activity)
@@ -373,6 +374,7 @@ result = {
         'watchdog_killed': watchdog_kill_count,
         'rate_limited': rate_limit_count,
         'no_op': noop_count,
+        'launch_validation_failed': launch_validation_failure_count,
         'pr_opened': pr_opened_count,
         'pr_merged': pr_merged_count,
         'issue_closed': issue_closed_count,

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -234,6 +234,25 @@ assert_eq "json finding IDs" "auto-dispatch-missing-tier-labels,pulse-launch-acc
 JSON_PRIVATE_COUNT=$(printf '%s' "$JSON_OUT" | grep -c "private/repo-one" 2>/dev/null || true)
 assert_eq "json output removes raw worker examples" "0" "$JSON_PRIVATE_COUNT"
 
+cat >"${TEST_ROOT}/current-state.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": true,
+  "dispatch_stage_events": 12,
+  "current_state_guardrails": {"available_slots_last": 6},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
+  "worker_outcomes": {"spawned": 4, "launch_validation_failed": 4},
+  "worker_terminal_events": 0,
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state.sh"
+CLASSIFIED_JSON_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" json 2>&1)
+CLASSIFIED_IDS=$(printf '%s' "$CLASSIFIED_JSON_OUT" | jq -r '[.findings[].id] | sort | join(",")')
+assert_eq "classified launch failures suppress launch accounting gap" "auto-dispatch-missing-tier-labels,pulse-underfilled-auto-dispatch-queue" "$CLASSIFIED_IDS"
+
 APPLY_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" apply --repo owner/aidevops 2>&1)
 assert_contains "apply reports issue filing" "pulse-check: filed" "$APPLY_OUT"
 BODY=$(cat "${TEST_ROOT}/capture.txt.body")


### PR DESCRIPTION
## Summary
- Track `dispatch_worker_launch_failed` as `launch_validation_failed` in the pulse current-state snapshot.
- Make `pulse-launch-accounting-gap` fire only when launches remain unaccounted for after terminal metrics and classified launch-validation failures.
- Add an offline regression fixture proving classified launch failures suppress the false-positive launch accounting gap.

## Testing
- `.agents/scripts/tests/test-pulse-check-helper.sh`
- `shellcheck .agents/scripts/pulse-check-helper.sh .agents/scripts/tests/test-pulse-check-helper.sh .agents/scripts/pulse-current-state-helper.sh`
- `python3 -m py_compile .agents/scripts/pulse-current-state.py`
- `.agents/scripts/pulse-check-helper.sh --json`

Resolves #26364

<!-- MERGE_SUMMARY
summary: Accounted pulse launch-validation failures so the launch accounting gap only reports genuinely unaccounted launches.
testing: test-pulse-check-helper, shellcheck focused helpers, py_compile pulse-current-state, pulse-check --json.
-->
