### PR TITLE
GH#26363: use worker process counts for pulse capacity

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -11,7 +11,10 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 
 ($current.pulse_gauges.dispatch_capacity_final_max_workers // 0 | number_or_zero) as $max_workers |
 ($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // 0 | number_or_zero) as $available_slots |
-([$max_workers - $available_slots, 0] | max) as $active_workers |
+([$max_workers - $available_slots, 0] | max) as $inferred_active_workers |
+(if ($current.active_worker_processes // null) == null then null else ($current.active_worker_processes | number_or_zero) end) as $active_worker_processes |
+(if $active_worker_processes == null then $inferred_active_workers else $active_worker_processes end) as $active_workers |
+(if $active_worker_processes == null then $available_slots else ([$max_workers - $active_worker_processes, 0] | max) end) as $effective_available_slots |
 ($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
 ($queue.aggregate.available_old // 0 | number_or_zero) as $old_available |
 ($queue.aggregate.needs_tier // 0 | number_or_zero) as $needs_tier |
@@ -30,7 +33,9 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
   summary: {
     max_workers: $max_workers,
     active_workers: $active_workers,
-    available_slots: $available_slots,
+    active_workers_source: (if $active_worker_processes == null then "capacity_gauge" else "process_scan" end),
+    inferred_active_workers: $inferred_active_workers,
+    available_slots: $effective_available_slots,
     dispatch_alive: ($current.dispatch_alive // false),
     dispatch_stage_events: ($current.dispatch_stage_events // 0),
     worker_launches_in_window: $spawned,
@@ -57,6 +62,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     pulse_gauges: ($current.pulse_gauges // {}),
     current_state_guardrails: ($current.current_state_guardrails // {}),
     dispatch_pacing: ($current.dispatch_pacing // {}),
+    active_worker_processes: ($current.active_worker_processes // null),
     top_pre_launch_blockers: ($current.top_pre_launch_blockers // [])
   },
   worker_activity: {

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -238,6 +238,21 @@ try:
 except (OSError, subprocess.CalledProcessError):
     worktrees = []
 
+active_worker_processes = None
+worker_lifecycle_common = os.path.join(script_dir, 'worker-lifecycle-common.sh')
+if os.path.exists(worker_lifecycle_common):
+    try:
+        active_worker_output = subprocess.check_output(
+            ['bash', '-c', 'source "$1" >/dev/null 2>&1 && count_active_workers', '_', worker_lifecycle_common],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        ).strip()
+        if active_worker_output.isdigit():
+            active_worker_processes = int(active_worker_output)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        active_worker_processes = None
+
 graphql_budget_status = 'UNKNOWN: no cached status'
 breaker = os.path.join(script_dir, 'pulse-rate-limit-circuit-breaker.sh')
 try:
@@ -397,6 +412,7 @@ result = {
     'pulse_counter_hits': counter_hits,
     'pulse_gauges': gauge_values,
     'wrapper_activity_lines': len(wrapper_activity),
+    'active_worker_processes': active_worker_processes,
     'worker_worktrees': len(worktrees),
     'dispatch_alive': bool(stage_records or metrics or counter_hits or worktrees),
     'graphql_budget_status': graphql_budget_status,
@@ -426,6 +442,7 @@ else:
     print(f'- GraphQL budget: {graphql_budget_status}')
     print(f'- Prefetch cache: {json.dumps(prefetch_cache, sort_keys=True)}')
     print(f'- Dispatch API blocked by GraphQL: {str(dispatch_api_blocked).lower()}')
+    print(f'- Active worker processes: {active_worker_processes if active_worker_processes is not None else "unknown"}')
     if api_consumers:
         print(f'- Top GraphQL consumers: {json.dumps(api_consumers)}')
     print(f'- API call pressure: {json.dumps(api_pressure, sort_keys=True)}')

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -98,6 +98,7 @@ cat <<'JSON'
 {
   "dispatch_alive": true,
   "dispatch_stage_events": 12,
+  "active_worker_processes": 0,
   "current_state_guardrails": {"available_slots_last": 6},
   "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
   "worker_outcomes": {"spawned": 4},
@@ -233,6 +234,32 @@ IDS=$(printf '%s' "$JSON_OUT" | jq -r '[.findings[].id] | sort | join(",")')
 assert_eq "json finding IDs" "auto-dispatch-missing-tier-labels,pulse-launch-accounting-gap,pulse-underfilled-auto-dispatch-queue" "$IDS"
 JSON_PRIVATE_COUNT=$(printf '%s' "$JSON_OUT" | grep -c "private/repo-one" 2>/dev/null || true)
 assert_eq "json output removes raw worker examples" "0" "$JSON_PRIVATE_COUNT"
+ACTIVE_SOURCE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.active_workers_source')
+assert_eq "json uses process scan when available" "process_scan" "$ACTIVE_SOURCE"
+
+cat >"${TEST_ROOT}/current-state-active.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": true,
+  "dispatch_stage_events": 12,
+  "active_worker_processes": 2,
+  "current_state_guardrails": {"available_slots_last": 6},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
+  "worker_outcomes": {"spawned": 0},
+  "worker_terminal_events": 0,
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state-active.sh"
+JSON_ACTIVE_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-active.sh" "$HELPER" json 2>&1)
+ACTIVE_COUNT=$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '.summary.active_workers')
+ACTIVE_AVAILABLE=$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '.summary.available_slots')
+ACTIVE_IDS=$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '[.findings[].id] | sort | join(",")')
+assert_eq "json reports process-scan active workers" "2" "$ACTIVE_COUNT"
+assert_eq "json recomputes available slots from process count" "4" "$ACTIVE_AVAILABLE"
+assert_eq "process-scan active workers suppress underfill finding" "auto-dispatch-missing-tier-labels" "$ACTIVE_IDS"
 
 cat >"${TEST_ROOT}/current-state.sh" <<'SH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- Add active worker process counting to `pulse-current-state.py` using the existing worker lifecycle helper.
- Prefer process-scan active worker counts in `pulse-check-report.jq` when available, while retaining the prior capacity-gauge fallback.
- Cover process-scan reporting and underfill suppression in `test-pulse-check-helper.sh`.

## Verification

- `.agents/scripts/tests/test-pulse-check-helper.sh`
- `python3 -m py_compile .agents/scripts/pulse-current-state.py`
- `.agents/scripts/pulse-check-helper.sh --json` no longer reports `pulse-underfilled-auto-dispatch-queue`; it reports `active_workers_source=process_scan` with current active worker evidence.

Resolves #26363
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.22 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 27,560 tokens on this as a headless worker.