### PR TITLE
GH#26369: refresh GUI font dependencies

### DIFF
--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -144,6 +144,8 @@ test_gui_desktop_installer_contract() {
 
 	assert_contains "installer honours configured app dir env" "$text" 'AIDEVOPS_GUI_DESKTOP_APP_DIR'
 	assert_contains "installer keeps explicit app-dir override" "$text" '--app-dir'
+	assert_contains "installer dependency check includes new Cal Sans font package" "$text" 'node_modules/@fontsource/cal-sans'
+	assert_contains "installer dependency check includes new Zilla Slab font package" "$text" 'node_modules/@fontsource/zilla-slab'
 	return 0
 }
 

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -51,9 +51,40 @@ validate_environment() {
 
 gui_dependencies_present() {
   local root="$1"
+  local dependency_path=""
 
-  [[ -f "${root}/node_modules/vite/bin/vite.js" && -d "${root}/node_modules/react" && -d "${root}/node_modules/react-icons" ]]
-  return $?
+  while IFS= read -r dependency_path; do
+    if [[ -z "$dependency_path" ]]; then
+      continue
+    fi
+    if [[ ! -e "${root}/${dependency_path}" ]]; then
+      return 1
+    fi
+  done <<'DEPENDENCIES'
+node_modules/vite/bin/vite.js
+node_modules/react
+node_modules/react-icons
+node_modules/@fontsource/cal-sans
+node_modules/@fontsource/courier-prime
+node_modules/@fontsource/dm-mono
+node_modules/@fontsource/dm-sans
+node_modules/@fontsource/fredoka
+node_modules/@fontsource/ibm-plex-mono
+node_modules/@fontsource/ibm-plex-sans
+node_modules/@fontsource/ibm-plex-serif
+node_modules/@fontsource/inter
+node_modules/@fontsource/mohave
+node_modules/@fontsource/playpen-sans
+node_modules/@fontsource/poppins
+node_modules/@fontsource/source-sans-3
+node_modules/@fontsource/source-serif-4
+node_modules/@fontsource/tilt-neon
+node_modules/@fontsource/ubuntu
+node_modules/@fontsource/ubuntu-mono
+node_modules/@fontsource/zilla-slab
+DEPENDENCIES
+
+  return 0
 }
 
 ensure_gui_dependencies() {
@@ -189,6 +220,68 @@ require_bun() {
   return 0
 }
 
+gui_dependencies_present() {
+  local dependency_path=""
+
+  while IFS= read -r dependency_path; do
+    if [[ -z "\${dependency_path}" ]]; then
+      continue
+    fi
+    if [[ ! -e "\${dependency_path}" ]]; then
+      return 1
+    fi
+  done <<'DEPENDENCIES'
+node_modules/vite/bin/vite.js
+node_modules/react
+node_modules/react-icons
+node_modules/@fontsource/cal-sans
+node_modules/@fontsource/courier-prime
+node_modules/@fontsource/dm-mono
+node_modules/@fontsource/dm-sans
+node_modules/@fontsource/fredoka
+node_modules/@fontsource/ibm-plex-mono
+node_modules/@fontsource/ibm-plex-sans
+node_modules/@fontsource/ibm-plex-serif
+node_modules/@fontsource/inter
+node_modules/@fontsource/mohave
+node_modules/@fontsource/playpen-sans
+node_modules/@fontsource/poppins
+node_modules/@fontsource/source-sans-3
+node_modules/@fontsource/source-serif-4
+node_modules/@fontsource/tilt-neon
+node_modules/@fontsource/ubuntu
+node_modules/@fontsource/ubuntu-mono
+node_modules/@fontsource/zilla-slab
+DEPENDENCIES
+
+  return 0
+}
+
+ensure_gui_dependencies() {
+  if gui_dependencies_present; then
+    return 0
+  fi
+
+  require_bun
+  if [[ ! -f "bun.lock" ]]; then
+    printf 'GUI dependencies are missing and bun.lock was not found in %s\n' "\${REPO_ROOT}" >"\${LAUNCHER_LOG}"
+    notify "aidevops GUI dependencies are missing and bun.lock was not found."
+    return 1
+  fi
+  printf 'Installing GUI dependencies with bun install --frozen-lockfile in %s\n' "\${REPO_ROOT}" >"\${LAUNCHER_LOG}"
+  if ! "\${BUN_BIN}" install --frozen-lockfile >>"\${LAUNCHER_LOG}" 2>&1; then
+    notify "aidevops GUI dependency install failed. Check \${LAUNCHER_LOG}."
+    return 1
+  fi
+  if ! gui_dependencies_present; then
+    printf 'GUI dependencies are still missing after bun install in %s\n' "\${REPO_ROOT}" >>"\${LAUNCHER_LOG}"
+    notify "aidevops GUI dependencies are still missing after install."
+    return 1
+  fi
+
+  return 0
+}
+
 port_pids() {
   local port="\$1"
 
@@ -293,6 +386,10 @@ sleep 1
 
 if ! url_ready "\${API_HEALTH_URL}" || ! url_ready "\${WEB_HEALTH_URL}"; then
   require_bun
+fi
+
+if ! url_ready "\${WEB_HEALTH_URL}"; then
+  ensure_gui_dependencies
 fi
 
 if ! url_ready "\${API_HEALTH_URL}"; then


### PR DESCRIPTION
## Summary

- Expanded the macOS GUI installer dependency check to include every `@fontsource/*` package imported by `packages/gui-web/src/main.tsx`.
- Added launcher-time self-healing so aidevops.app runs `bun install --frozen-lockfile` before starting Vite when GUI dependencies are incomplete.
- Added regression coverage for the font dependency manifest in the setup scoped dispatch test.

Resolves #26369

## Testing

- `bash packages/gui-desktop/scripts/install-macos-app.sh --check` failed before install when font packages were missing, then passed after installer self-healed with `bun install --frozen-lockfile`.
- `bash -n /var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/aidevops-test-app/aidevops.app/Contents/Resources/aidevops-gui-services.sh`
- `npm run gui:ci`
- `bash .agents/scripts/tests/test-setup-scoped-dispatch.sh`
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh`
- `npm run gui:desktop:check`
- `.agents/scripts/linters-local.sh` reached repo-wide pre-existing/advisory gates; targeted checks above passed and worktree is clean.

## Runtime Testing

- self-assessed: built a temporary macOS app bundle under `/var/folders/sr/8166n5f968b56j6tccj024vr0000gn/T/opencode/aidevops-test-app` and validated the generated launcher syntax.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.23 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1h 11m and 439,653 tokens on this with the user in an interactive session.
