### PR TITLE
GH#26371: fix: move pulse snapshot probes out of python

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -33,6 +33,9 @@ main() {
 	local repo_path="${AIDEVOPS_REPO_PATH:-$HOME/Git/aidevops}"
 	local log_dir="${AIDEVOPS_LOG_DIR:-$HOME/.aidevops/logs}"
 	local review_thread_state_dir="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR:-$HOME/.aidevops/.agent-workspace/pr-review-thread-response}"
+	local active_worker_processes=""
+	local worker_worktree_count="0"
+	local graphql_budget_status=""
 	local as_json=0
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
@@ -48,7 +51,29 @@ main() {
 	done
 	local window_s
 	window_s="$(_seconds "$window")"
-	python3 "${SCRIPT_DIR}/pulse-current-state.py" "$log_dir" "$repo_path" "$window_s" "$as_json" "$SCRIPT_DIR" "$review_thread_state_dir"
+	if [[ -f "${SCRIPT_DIR}/worker-lifecycle-common.sh" ]]; then
+		# Keep worker process discovery in the shell lifecycle helper so Python
+		# static-analysis checks do not flag a subprocess bridge for this metric.
+		# shellcheck source=.agents/scripts/worker-lifecycle-common.sh
+		source "${SCRIPT_DIR}/worker-lifecycle-common.sh" >/dev/null 2>&1 || true
+		if declare -F count_active_workers >/dev/null 2>&1; then
+			active_worker_processes="$(count_active_workers 2>/dev/null || true)"
+		fi
+	fi
+	if git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
+		worker_worktree_count="$(git -C "$repo_path" worktree list 2>/dev/null \
+			| grep -Ec 'feature/(auto-|gh-)' || true)"
+	fi
+	if [[ -x "${SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh" ]]; then
+		graphql_budget_status="$("${SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh" \
+			status --cached 2>/dev/null || true)"
+	fi
+	AIDEVOPS_ACTIVE_WORKER_PROCESSES="$active_worker_processes" \
+		AIDEVOPS_WORKER_WORKTREE_COUNT="$worker_worktree_count" \
+		AIDEVOPS_GRAPHQL_BUDGET_STATUS="$graphql_budget_status" \
+		python3 "${SCRIPT_DIR}/pulse-current-state.py" \
+			"$log_dir" "$repo_path" "$window_s" "$as_json" "$SCRIPT_DIR" \
+			"$review_thread_state_dir"
 	return 0
 }
 

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -7,7 +7,6 @@
 import datetime
 import json
 import os
-import subprocess
 import sys
 import time
 from collections import Counter, defaultdict, deque
@@ -231,37 +230,26 @@ top_pre_launch_blockers = [
     for reason, count in sorted(pre_launch_blockers.items(), key=lambda item: (-item[1], item[0]))
 ]
 
-worktrees = []
-try:
-    out = subprocess.check_output(['git', '-C', repo_path, 'worktree', 'list'], text=True, stderr=subprocess.DEVNULL)
-    worktrees = [line for line in out.splitlines() if 'feature/auto-' in line or 'feature/gh-' in line]
-except (OSError, subprocess.CalledProcessError):
+worker_worktree_count = os.environ.get('AIDEVOPS_WORKER_WORKTREE_COUNT', '0')
+if worker_worktree_count.isdigit():
+    worktrees = [None] * int(worker_worktree_count)
+else:
     worktrees = []
 
 active_worker_processes = None
-worker_lifecycle_common = os.path.join(script_dir, 'worker-lifecycle-common.sh')
-if os.path.exists(worker_lifecycle_common):
-    try:
-        active_worker_output = subprocess.check_output(
-            ['bash', '-c', 'source "$1" >/dev/null 2>&1 && count_active_workers', '_', worker_lifecycle_common],
-            text=True,
-            stderr=subprocess.DEVNULL,
-            timeout=5,
-        ).strip()
-        if active_worker_output.isdigit():
-            active_worker_processes = int(active_worker_output)
-    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        active_worker_processes = None
+active_worker_output = os.environ.get('AIDEVOPS_ACTIVE_WORKER_PROCESSES', '')
+if active_worker_output.isdigit():
+    active_worker_processes = int(active_worker_output)
 
-graphql_budget_status = 'UNKNOWN: no cached status'
-breaker = os.path.join(script_dir, 'pulse-rate-limit-circuit-breaker.sh')
-try:
-    graphql_budget_status = subprocess.check_output(
-        [breaker, 'status', '--cached'], text=True, stderr=subprocess.DEVNULL, timeout=5
-    ).strip() or graphql_budget_status
-except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-    pass
-dispatch_api_blocked = dispatch_blocked_by_graphql_budget(graphql_budget_status, graphql_budget, pre_launch_blockers)
+graphql_budget_status = (
+    os.environ.get('AIDEVOPS_GRAPHQL_BUDGET_STATUS')
+    or 'UNKNOWN: no cached status'
+)
+dispatch_api_blocked = dispatch_blocked_by_graphql_budget(
+    graphql_budget_status,
+    graphql_budget,
+    pre_launch_blockers,
+)
 current_state_guardrails = {
     'applied_count': counter_hits.get('pulse_dispatch_current_state_guardrail_applied', 0),
     'available_slots_last': gauge_values.get('pulse_dispatch_guardrail_available_slots'),

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -140,6 +140,10 @@ assert 'pulse-current-state.py' in helper_source
 assert 'from collections import Counter, defaultdict, deque' in implementation_source
 assert 'readlines()[-limit:]' not in implementation_source
 assert 'deque(handle, maxlen=limit)' in implementation_source
+assert 'AIDEVOPS_ACTIVE_WORKER_PROCESSES' in helper_source
+assert 'AIDEVOPS_ACTIVE_WORKER_PROCESSES' in implementation_source
+assert 'import subprocess' not in implementation_source
+assert 'subprocess.check_output' not in implementation_source
 PY
 
 printf 'PASS pulse-current-state-helper\n'


### PR DESCRIPTION
## Summary

Moved current-state worker/worktree/rate-limit probes into the shell helper and passed sanitized values to the Python renderer, removing the Python subprocess bridge flagged by CodeFactor. Added a regression assertion that pulse-current-state.py does not import or call subprocess.

## Files Changed

.agents/scripts/pulse-current-state-helper.sh,.agents/scripts/pulse-current-state.py,.agents/scripts/tests/test-pulse-current-state-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-current-state-helper.sh; bash .agents/scripts/tests/test-pulse-check-helper.sh; shellcheck .agents/scripts/pulse-current-state-helper.sh .agents/scripts/tests/test-pulse-current-state-helper.sh .agents/scripts/tests/test-pulse-check-helper.sh; python3 -m py_compile .agents/scripts/pulse-current-state.py

Resolves #26371


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.24 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 6m and 71,695 tokens on this as a headless worker.