### PR TITLE
GH#26391: clarify circuit breaker meta blocker wording

### DIFF
--- a/.agents/scripts/circuit-breaker-meta-filer.sh
+++ b/.agents/scripts/circuit-breaker-meta-filer.sh
@@ -376,7 +376,7 @@ ${stages_slice:-(no matching stage records)}
 
 1. Root cause identified and named explicitly in the PR description (which file/function/race).
 2. Fix lands as a normal PR with \`Resolves #<this>\` (NOT \`Resolves #${issue_number}\` — this meta-issue is the unit of work, the original is downstream).
-3. PR merge automatically removes the meta \`blocked-by\` label from #${issue_number} via \`_unblock_circuit_breaker_meta_original\`.
+3. PR merge automatically removes the meta blocker label that points from the original issue to this meta-issue via \`_unblock_circuit_breaker_meta_original\`.
 4. If no other circuit-breaker markers remain on #${issue_number}, NMR is also cleared automatically.
 5. A regression test exists for the specific failure mode identified (test in \`.agents/scripts/tests/\`).
 

--- a/.agents/scripts/tests/test-circuit-breaker-meta-filer.sh
+++ b/.agents/scripts/tests/test-circuit-breaker-meta-filer.sh
@@ -230,6 +230,13 @@ else
 	print_result "first-trip: no_work verification includes stale pagination test" 1 "stub log: $(cat "$STUB_LOG")"
 fi
 
+if grep -q 'meta blocker label that points from the original issue to this meta-issue' "$STUB_LOG" \
+	&& ! grep -Fq "meta \`blocked-by\` label from #21840" "$STUB_LOG"; then
+	print_result "first-trip: acceptance describes meta blocker unambiguously" 0
+else
+	print_result "first-trip: acceptance describes meta blocker unambiguously" 1 "stub log: $(cat "$STUB_LOG")"
+fi
+
 # =============================================================================
 # Test 1b: Public app repos without framework sources route metas to aidevops
 # =============================================================================


### PR DESCRIPTION
## Summary

Rephrased the circuit-breaker meta issue acceptance text so it no longer appears to label the original issue as blocked by itself, and added regression coverage for the generated wording.

## Files Changed

.agents/scripts/circuit-breaker-meta-filer.sh,.agents/scripts/tests/test-circuit-breaker-meta-filer.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh (28 passed, 0 failed); shellcheck .agents/scripts/circuit-breaker-meta-filer.sh .agents/scripts/tests/test-circuit-breaker-meta-filer.sh

Resolves #26391


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.25 with gpt-5.5 spent 14m and 108,674 tokens on this with the user in an interactive session.