### PR TITLE
t18061: fix(opencode): preserve desktop session history after restart

### DIFF
--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -154,6 +154,43 @@ build_desktop_data_dir() {
     return 0
 }
 
+launcher_state_dir() {
+    printf '%s/opencode-launcher' "${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}"
+    return 0
+}
+
+last_data_dir_file() {
+    local state_dir
+    state_dir=$(launcher_state_dir)
+    printf '%s/last-data-dir' "${state_dir}"
+    return 0
+}
+
+remember_data_dir() {
+    local data_dir="$1"
+    local state_dir marker tmp_marker
+
+    [[ -n "${data_dir}" ]] || return 0
+    state_dir=$(launcher_state_dir)
+    marker=$(last_data_dir_file)
+    tmp_marker="${marker}.$$"
+    mkdir -p "${state_dir}" 2>/dev/null || return 0
+    printf '%s\n' "${data_dir}" >"${tmp_marker}" 2>/dev/null || return 0
+    mv "${tmp_marker}" "${marker}" 2>/dev/null || return 0
+    return 0
+}
+
+read_last_data_dir() {
+    local marker data_dir
+
+    marker=$(last_data_dir_file)
+    [[ -r "${marker}" ]] || return 1
+    IFS= read -r data_dir <"${marker}" || return 1
+    [[ -n "${data_dir}" && -d "${data_dir}/opencode" ]] || return 1
+    printf '%s' "${data_dir}"
+    return 0
+}
+
 xml_escape() {
     local value="$1"
     value=${value//&/\&amp;}
@@ -466,6 +503,9 @@ cmd_desktop_launch() {
     fi
     [[ -d "${launch_dir}" ]] || { print_error "Directory not found: ${launch_dir}"; return 1; }
 
+    if [[ -z "${data_dir}" && ${from_app} -eq 1 && ${launch_dir_set} -eq 0 && -z "${session_id}" ]]; then
+        data_dir=$(read_last_data_dir || true)
+    fi
     if [[ -z "${data_dir}" ]]; then
         if ((launch_dir_set == 1)); then
             data_dir=$(build_desktop_data_dir "${session_id}" "${launch_dir}")
@@ -476,6 +516,7 @@ cmd_desktop_launch() {
     mkdir -p "${data_dir}/opencode" || return 1
     copy_auth_json "${data_dir}" || true
     prewarm_opencode_data_dir "${data_dir}"
+    remember_data_dir "${data_dir}"
 
     if ((dry_run == 1)); then
         printf 'cd %q && XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1 %q' "${launch_dir}" "${data_dir}" "${desktop_binary}"
@@ -594,6 +635,7 @@ main() {
     # pre-launch terminal output and can leave visible redraw artifacts.
     copy_auth_json "${data_dir}" || true
     prewarm_opencode_data_dir "${data_dir}"
+    remember_data_dir "${data_dir}"
 
     if ((dry_run == 1)); then
         printf 'cd %q && XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1 opencode' "${launch_dir}" "${data_dir}"

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -127,6 +127,15 @@ else
 fi
 
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" desktop launch --from-app --source-binary "${desktop_source}" --dry-run 2>&1)
+if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-interactive/test-session"* ]] \
+    && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]]; then
+    _pass "desktop app launch resumes last isolated data dir"
+else
+    _fail "desktop app launch did not reuse last data dir: ${output}"
+fi
+
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
     "${HELPER}" desktop launch --source-binary "${desktop_source}" --dir "${launch_dir}" --dry-run 2>&1)
 if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-desktop/desktop-project-repo-"* ]] \
     && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - clarify circuit breaker meta blocker wording (#26393)
+- preserve aidevops-managed OpenCode Desktop session history after restart
 
 ## [3.31.25] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.31.27] - 2026-07-03
+
+### Fixed
+
+- preserve aidevops-managed OpenCode Desktop session history after restart
+
 ## [3.31.26] - 2026-07-03
 
 ### Fixed
 
 - clarify circuit breaker meta blocker wording (#26393)
-- preserve aidevops-managed OpenCode Desktop session history after restart
 
 ## [3.31.25] - 2026-07-02
 

--- a/TODO.md
+++ b/TODO.md
@@ -1092,6 +1092,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18056 perf(pulse): investigate remaining GraphQL budget exhaustion after PR-list cache work #framework #github #investigate #parent-task #performance #pulse ref:GH#26227 verified:2026-07-02 completed:2026-07-02
 
+- [ ] t18061 fix(opencode): preserve desktop session history after restart #bug #framework #opencode ref:GH#26394
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
Resolves #26394

## Summary
- Persist the last aidevops-managed OpenCode data directory when launching terminal/Desktop sessions.
- Make the generated OpenCode Desktop app reuse that last data directory on restart when no explicit project directory is supplied.
- Add a regression test covering Desktop app restart history continuity.

## Root cause
Aidevops intentionally launches OpenCode with isolated `XDG_DATA_HOME` directories to avoid shared SQLite lock contention. The generated Desktop app, when restarted without an explicit `--dir`, fell back to a separate `desktop-default` data directory, so recent sessions stored in the terminal/project shard were invisible to the session picker.

## Verification
- `bash .agents/scripts/tests/test-opencode-launcher-helper.sh`
- `shellcheck .agents/scripts/opencode-launcher-helper.sh .agents/scripts/tests/test-opencode-launcher-helper.sh`
- `npx --no-install secretlint .agents/scripts/opencode-launcher-helper.sh .agents/scripts/tests/test-opencode-launcher-helper.sh`
- `.agents/scripts/linters-local.sh` attempted twice; timed out during repository-wide Secretlint after earlier gates passed (SonarCloud green, string literal ratchet clean, forbidden FD locks clean, shellcheckrc parity clean).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.26 plugin for [OpenCode](https://opencode.ai) v1.17.13
