### PR TITLE
fix: validate approval target kind

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -329,6 +329,40 @@ _fetch_target_title() {
 	return 0
 }
 
+_validate_approval_target_kind() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local issue_json=""
+
+	issue_json=$(_approval_fetch_issue_json "$target_number" "$slug") || {
+		_print_error "Could not resolve ${target_type} #${target_number} in ${slug}. Check the number, repo, and whether this is an issue or PR."
+		if [[ "$target_type" == "pr" ]]; then
+			_print_info "If this is an issue, use: sudo aidevops approve issue ${target_number} ${slug}"
+		else
+			_print_info "If this is a PR, use: sudo aidevops approve pr ${target_number} ${slug}"
+		fi
+		return 1
+	}
+
+	if [[ "$target_type" == "pr" ]]; then
+		if ! printf '%s' "$issue_json" | jq -e 'has("pull_request")' >/dev/null 2>&1; then
+			_print_error "#${target_number} in ${slug} is an issue, not a PR."
+			_print_info "Use: sudo aidevops approve issue ${target_number} ${slug}"
+			return 1
+		fi
+		return 0
+	fi
+
+	if printf '%s' "$issue_json" | jq -e 'has("pull_request")' >/dev/null 2>&1; then
+		_print_error "#${target_number} in ${slug} is a PR, not an issue."
+		_print_info "Use: sudo aidevops approve pr ${target_number} ${slug}"
+		return 1
+	fi
+
+	return 0
+}
+
 _confirm_approval() {
 	local target_type="$1"
 	local target_number="$2"
@@ -733,6 +767,7 @@ _approve_target() {
 	_require_gh_auth || return 1
 
 	slug=$(_resolve_slug_or_fail "$slug" "$slug_error") || return 1
+	_validate_approval_target_kind "$target_type" "$target_number" "$slug" || return 1
 
 	local title
 	title=$(_fetch_target_title "$target_type" "$target_number" "$slug")

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -249,6 +249,7 @@ run_case "post-approval protection failure blocks final success" '
 	_require_approval_key() { return 0; }
 	_require_gh_auth() { return 0; }
 	_resolve_slug_or_fail() { local slug="${1:-}"; printf "%s" "$slug"; return 0; }
+	_validate_approval_target_kind() { return 0; }
 	_fetch_target_title() { printf "Mock issue"; return 0; }
 	_confirm_approval() { return 0; }
 	_sign_approval_payload() { local payload="$1"; local actual_key="$2"; local sig_file="$3"; : "$payload" "$actual_key"; printf "mock-signature" >"$sig_file"; return 0; }

--- a/.agents/scripts/tests/test-approval-helper-target-kind.sh
+++ b/.agents/scripts/tests/test-approval-helper-target-kind.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression tests for approval-helper.sh issue/PR target kind diagnostics.
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+PASS=0
+FAIL=0
+LAST_OUTPUT=""
+LAST_RC=0
+
+pass() {
+	local name="$1"
+	printf '  PASS: %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf '  FAIL: %s\n' "$name"
+	if [[ -n "$detail" ]]; then
+		printf '    %s\n' "$detail"
+	fi
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected '${expected}', got '${actual}'"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing '${needle}'"
+	fi
+	return 0
+}
+
+run_case() {
+	local name="$1"
+	local script="$2"
+	local expected_rc="$3"
+	local output=""
+	local rc=0
+
+	output=$(APPROVAL_HELPER_UNDER_TEST="$PARENT_DIR/approval-helper.sh" bash -c "$script" 2>&1) || rc=$?
+	LAST_OUTPUT="$output"
+	LAST_RC=$rc
+	assert_eq "$name rc" "$expected_rc" "$rc"
+	return 0
+}
+
+printf 'Test: approval-helper target kind diagnostics\n'
+printf '=============================================\n\n'
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "PR command rejects issue target" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_fetch_issue_json() { printf "%s" "{\"number\":26392,\"title\":\"Issue title\"}"; return 0; }
+	_validate_approval_target_kind pr 26392 marcusquinn/aidevops
+' 1
+assert_contains "PR command names wrong target kind" "$LAST_OUTPUT" "#26392 in marcusquinn/aidevops is an issue, not a PR."
+assert_contains "PR command advises issue approval command" "$LAST_OUTPUT" "sudo aidevops approve issue 26392 marcusquinn/aidevops"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "issue command rejects PR target" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_fetch_issue_json() { printf "%s" "{\"number\":99,\"pull_request\":{\"url\":\"https://api.github.test/pr\"}}"; return 0; }
+	_validate_approval_target_kind issue 99 marcusquinn/aidevops
+' 1
+assert_contains "issue command names wrong target kind" "$LAST_OUTPUT" "#99 in marcusquinn/aidevops is a PR, not an issue."
+assert_contains "issue command advises PR approval command" "$LAST_OUTPUT" "sudo aidevops approve pr 99 marcusquinn/aidevops"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "missing target gives check issue or PR guidance" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_fetch_issue_json() { return 1; }
+	_validate_approval_target_kind pr 404 marcusquinn/aidevops
+' 1
+assert_contains "missing target asks to check target type" "$LAST_OUTPUT" "Check the number, repo, and whether this is an issue or PR."
+assert_contains "missing PR target suggests issue command" "$LAST_OUTPUT" "sudo aidevops approve issue 404 marcusquinn/aidevops"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "matching issue target succeeds" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_fetch_issue_json() { printf "%s" "{\"number\":123}"; return 0; }
+	_validate_approval_target_kind issue 123 marcusquinn/aidevops
+' 0
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "matching PR target succeeds" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_fetch_issue_json() { printf "%s" "{\"number\":456,\"pull_request\":{}}"; return 0; }
+	_validate_approval_target_kind pr 456 marcusquinn/aidevops
+' 0
+
+printf '\n%d tests passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
For #26392

## Summary
- Validate approval target kind with REST before prompting/signing.
- Reject `approve pr <issue-number>` and `approve issue <pr-number>` with explicit corrective commands.
- Add regression coverage for wrong-target diagnostics and update the full approval-flow fixture for the new validation gate.

## Verification
- `.agents/scripts/tests/test-approval-helper-target-kind.sh`
- `.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh`
- `shellcheck .agents/scripts/approval-helper.sh .agents/scripts/tests/test-approval-helper-target-kind.sh .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh`
- `.agents/scripts/tests/test-lint-shell-portability.sh`
- `.agents/scripts/tests/test-aidevops-sh-portability.sh`
- `.agents/scripts/linters-local.sh` progressed through security/markdown advisory/ratchets/repo layout/Bash 3.2; tool timed out in shell portability phase, then targeted portability checks passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.26 plugin for [OpenCode](https://opencode.ai) v1.17.13
