### PR TITLE
GH#26392: skip cooling OAuth providers

### DIFF
--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -20,7 +20,7 @@
 #   - shared-constants.sh (print_error, print_info, print_warning)
 #   - headless-runtime-lib.sh Section 1 functions (db_query, sql_escape, trim_spaces)
 #   - headless-runtime-provider.sh (extract_provider, provider_auth_available,
-#     model_backoff_active)
+#     provider_oauth_pool_available, model_backoff_active)
 #   - worker-lifecycle-common.sh (resolve_model_tier)
 #   - Constants from headless-runtime-helper.sh (OPENCODE_BIN_DEFAULT,
 #     DEFAULT_HEADLESS_MODELS, SCRIPT_DIR)
@@ -301,6 +301,11 @@ _choose_model_auto() {
 		# This keeps Codex in the default list for users with OpenAI OAuth while
 		# being invisible to users who have no OpenAI auth at all.
 		if ! provider_auth_available "$current_provider"; then
+			continue
+		fi
+		# Skip OAuth-backed providers when every pool account is cooling down.
+		# Static API keys bypass this provider-level OAuth pool gate.
+		if ! provider_oauth_pool_available "$current_provider"; then
 			continue
 		fi
 		# Check model-level backoff (rate limits) and provider-level (auth errors)

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -167,6 +167,63 @@ provider_auth_available() {
 	esac
 }
 
+provider_static_auth_available() {
+	local provider="$1"
+	case "$provider" in
+	anthropic)
+		[[ -n "${ANTHROPIC_API_KEY:-}" ]]
+		return $?
+		;;
+	openai)
+		[[ -n "${OPENAI_API_KEY:-}" ]]
+		return $?
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+# provider_oauth_pool_available: true when the OAuth pool has at least one
+# immediately usable account for the provider. Static API keys bypass this gate;
+# a missing provider pool also stays non-blocking for legacy auth-only setups.
+provider_oauth_pool_available() {
+	local provider="$1"
+	local pool_file="${HOME}/.aidevops/oauth-pool.json"
+
+	if provider_static_auth_available "$provider"; then
+		return 0
+	fi
+	[[ -f "$pool_file" ]] || return 0
+
+	POOL_FILE="$pool_file" PROVIDER="$provider" python3 <<'PY' >/dev/null 2>&1
+import json
+import os
+import sys
+import time
+
+try:
+    with open(os.environ["POOL_FILE"], encoding="utf-8") as fh:
+        pool = json.load(fh)
+except Exception:
+    sys.exit(0)
+
+accounts = pool.get(os.environ["PROVIDER"], [])
+if not accounts:
+    sys.exit(0)
+
+now_ms = int(time.time() * 1000)
+for account in accounts:
+    status = account.get("status", "active")
+    cooldown_until = int(account.get("cooldownUntil") or 0)
+    if status in ("active", "idle") and cooldown_until <= now_ms:
+        sys.exit(0)
+
+sys.exit(1)
+PY
+	return $?
+}
+
 opencode_auth_has_provider() {
 	local provider="$1"
 	local auth_file="${OPENCODE_AUTH_FILE:-${HOME}/.local/share/opencode/auth.json}"

--- a/.agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh
+++ b/.agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS="$(cd "${TEST_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/headless-oauth-pool-gate.XXXXXX")"
+HOME="$TMP_DIR/home"
+mkdir -p "$HOME/.aidevops"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+print_error() { printf 'ERROR: %s\n' "$1" >&2; return 0; }
+print_info() { printf 'INFO: %s\n' "$1" >&2; return 0; }
+print_warning() { printf 'WARN: %s\n' "$1" >&2; return 0; }
+timeout_sec() { return 1; }
+
+OPENCODE_AUTH_FILE="$TMP_DIR/auth.json"
+OPENCODE_BIN_DEFAULT="opencode"
+OAUTH_POOL_HELPER="$TMP_DIR/oauth-pool-helper.sh"
+DEFAULT_HEADLESS_MODELS="openai/gpt-5.5"
+unset ANTHROPIC_API_KEY || true
+unset OPENAI_API_KEY || true
+
+# shellcheck source=/dev/null
+source "${AGENTS_SCRIPTS}/headless-runtime-provider.sh"
+# shellcheck source=/dev/null
+source "${AGENTS_SCRIPTS}/headless-runtime-model.sh"
+
+failures=0
+
+assert_equals() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [[ "$expected" != "$actual" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$message" "$expected" "$actual" >&2
+		failures=$((failures + 1))
+		return 1
+	fi
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+get_configured_models() {
+	printf '%s\n' "${TEST_MODELS[@]}"
+	return 0
+}
+
+get_last_provider() {
+	printf '%s' ""
+	return 0
+}
+
+set_last_provider() {
+	local role="$1"
+	local provider="$2"
+	: "$role" "$provider"
+	return 0
+}
+
+provider_auth_available() {
+	local provider="$1"
+	: "$provider"
+	return 0
+}
+
+model_backoff_active() {
+	local model="$1"
+	: "$model"
+	return 1
+}
+
+_choose_model_tier_downgrade() {
+	local current_model="$1"
+	: "$current_model"
+	return 0
+}
+
+write_pool() {
+	local body="$1"
+	printf '%s\n' "$body" >"$HOME/.aidevops/oauth-pool.json"
+	return 0
+}
+
+future_ms() {
+	python3 - <<'PY'
+import time
+print(int(time.time() * 1000) + 3600_000)
+PY
+	return 0
+}
+
+past_ms() {
+	python3 - <<'PY'
+import time
+print(int(time.time() * 1000) - 3600_000)
+PY
+	return 0
+}
+
+TEST_MODELS=("openai/gpt-5.5" "anthropic/claude-sonnet-4-6")
+cooldown="$(future_ms)"
+write_pool "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${cooldown}},{\"email\":\"two@example.test\",\"status\":\"auth-error\",\"cooldownUntil\":${cooldown}}],\"anthropic\":[{\"email\":\"ok@example.test\",\"status\":\"active\",\"cooldownUntil\":0}]}"
+actual="$(_choose_model_auto "worker" "sonnet")"
+assert_equals "anthropic/claude-sonnet-4-6" "$actual" "all cooling OpenAI OAuth pool accounts are skipped" || true
+
+cooldown="$(future_ms)"
+write_pool "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${cooldown}},{\"email\":\"two@example.test\",\"status\":\"idle\",\"cooldownUntil\":0}]}"
+actual="$(_choose_model_auto "worker" "sonnet")"
+assert_equals "openai/gpt-5.5" "$actual" "one available OpenAI OAuth pool account keeps provider selectable" || true
+
+cooldown="$(future_ms)"
+OPENAI_API_KEY="static-test-key"
+export OPENAI_API_KEY
+write_pool "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${cooldown}}]}"
+actual="$(_choose_model_auto "worker" "sonnet")"
+assert_equals "openai/gpt-5.5" "$actual" "static OpenAI API key bypasses OAuth pool cooldown gate" || true
+unset OPENAI_API_KEY
+
+rm -f "$HOME/.aidevops/oauth-pool.json"
+actual="$(_choose_model_auto "worker" "sonnet")"
+assert_equals "openai/gpt-5.5" "$actual" "missing OAuth pool remains non-blocking for legacy auth" || true
+
+cooldown="$(past_ms)"
+write_pool "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"idle\",\"cooldownUntil\":${cooldown}}]}"
+actual="$(_choose_model_auto "worker" "sonnet")"
+assert_equals "openai/gpt-5.5" "$actual" "expired cooldown does not block an otherwise idle account" || true
+
+if [[ "$failures" -ne 0 ]]; then
+	printf '\n%d OAuth pool gate regression test(s) failed\n' "$failures" >&2
+	exit 1
+fi
+
+printf '\nAll OAuth pool gate tests passed\n'
+exit 0


### PR DESCRIPTION
## Summary

Adds an OAuth-pool availability gate to automatic headless model selection so providers with every pooled OAuth account cooling down are skipped, while static API keys and legacy auth-only setups remain selectable.

## Files Changed

.agents/scripts/headless-runtime-model.sh,.agents/scripts/headless-runtime-provider.sh,.agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh; shellcheck .agents/scripts/headless-runtime-provider.sh .agents/scripts/headless-runtime-model.sh .agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh; bash .agents/scripts/tests/test-canary-saturation-classification.sh; bash .agents/scripts/tests/test-headless-runtime-failure-classification.sh; .agents/scripts/linters-local.sh reached advisory gates but timed out during shell portability after secretlint, SonarCloud, secretlint, TOON, skill frontmatter, secret policy, and pulse canary passed

Resolves #26392


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.26 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 32m and 119,402 tokens on this with the user in an interactive session.