### PR TITLE
fix(opencode): skip same auth copy in launcher

### DIFF
--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -97,6 +97,7 @@ copy_auth_json() {
     local target_auth="${target_data_dir}/opencode/auth.json"
 
     [[ -f "${source_auth}" ]] || return 0
+    [[ "${source_auth}" == "${target_auth}" ]] && return 0
     mkdir -p "$(dirname "${target_auth}")" || return 1
     cp "${source_auth}" "${target_auth}" || return 1
     chmod 600 "${target_auth}" 2>/dev/null || true

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -101,6 +101,15 @@ else
     _fail "explicit session-id output unexpected: ${output}"
 fi
 
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" XDG_DATA_HOME="${work_dir}/opencode-interactive/test-session" \
+    "${HELPER}" --dir "${launch_dir}" --session-id test-session --dry-run 2>&1)
+if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-interactive/test-session"* ]] \
+    && [[ "${output}" != *"identical"* ]]; then
+    _pass "launcher skips auth copy when source and target match"
+else
+    _fail "same auth copy guard output unexpected: ${output}"
+fi
+
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
     "${HELPER}" --shared-db --dir "${launch_dir}" -- --version 2>&1)
 if [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB="* ]] \


### PR DESCRIPTION
Ref #26394

## Summary
- Skip the launcher auth copy when the source and target `auth.json` paths are identical.
- Add a regression test for launching from inside an already-isolated OpenCode session.

## Root cause
After #26396, running the fixed launcher from an already-isolated session can resolve the source and target auth files to the same path. `cp` then emits an "identical" warning, which pollutes otherwise quiet launcher/dry-run output.

## Verification
- `bash .agents/scripts/tests/test-opencode-launcher-helper.sh`
- `shellcheck .agents/scripts/opencode-launcher-helper.sh .agents/scripts/tests/test-opencode-launcher-helper.sh`
- `npx --no-install secretlint .agents/scripts/opencode-launcher-helper.sh .agents/scripts/tests/test-opencode-launcher-helper.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.17.13
