### PR TITLE
fix(dispatch): auto-recover zero-commit orphan branches (#26402)

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -180,6 +180,68 @@ _ddh_probe_orphan_branch_state() {
 }
 
 #######################################
+# Auto-recover an orphan branch that has no useful content.
+#
+# When a branch exists on the remote but has zero commits beyond the base
+# (or the remote branch is missing), AND no open PR references the branch,
+# there is nothing to recover. Auto-cleanup breaks the permanent dispatch
+# loop that otherwise causes stale_timeout/no_work fast-fail accumulation
+# and eventually trips the t2769 circuit breaker (Majowka/mesh-manager#1214).
+#
+# Args: $1 issue, $2 repo, $3 branch, $4 reason (zero_commits|remote_branch_missing),
+#       $5 worktree path, $6 comments endpoint
+# Returns: 0 on successful recovery, 1 if recovery not possible
+#######################################
+_ddh_auto_recover_orphan_branch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local branch_name="$3"
+	local hold_reason="$4"
+	local worktree_path="$5"
+	local comments_post_endpoint="$6"
+
+	# Guard: do not auto-recover if an open PR references this branch.
+	local pr_for_branch=""
+	pr_for_branch=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state open \
+		--json number --jq '.[0].number // empty' 2>/dev/null || true)
+	if [[ -n "$pr_for_branch" ]]; then
+		return 1
+	fi
+
+	# Delete the remote orphan branch (zero commits = nothing to lose).
+	local remote_deleted="no"
+	if [[ "$hold_reason" == "zero_commits" ]]; then
+		if gh api -X DELETE "repos/${repo_slug}/git/refs/heads/${branch_name}" >/dev/null 2>&1; then
+			remote_deleted="yes"
+		elif [[ -n "$worktree_path" && ( -d "$worktree_path/.git" || -f "$worktree_path/.git" ) ]]; then
+			# Fallback: try git push --delete from the worktree.
+			if GIT_TERMINAL_PROMPT=0 git -C "$worktree_path" push origin --delete "$branch_name" 2>/dev/null; then
+				remote_deleted="yes"
+			fi
+		fi
+	else
+		# remote_branch_missing — nothing to delete on remote, but local cleanup is still needed.
+		remote_deleted="n/a"
+	fi
+
+	# Post a recovery comment so there is an audit trail.
+	local diag=""
+	# shellcheck disable=SC2016 # Backticks are literal Markdown in this printf template.
+	diag=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan-auto-recovered:cleanup branch=%s issue=%s reason=%s remote_deleted=%s -->\n## Auto-recovered: orphan branch cleanup\n\nThe dispatch path found `WORKER_BRANCH_ORPHAN` telemetry for issue #%s on branch `%s` with reason `%s`. No open PR references this branch, so the orphan was auto-cleaned to prevent dispatch loops (Majowka/mesh-manager#1214).\n\n- Branch: `%s`\n- Remote branch deleted: `%s`\n- Next action: dispatch will create a fresh worktree and branch on the next cycle.\n<!-- ops:end -->' \
+		"$branch_name" "$issue_number" "$hold_reason" "$remote_deleted" \
+		"$issue_number" "$branch_name" "$hold_reason" \
+		"$branch_name" "$remote_deleted")
+	gh api "$comments_post_endpoint" \
+		--method POST \
+		--field body="$diag" \
+		>/dev/null 2>&1 || true
+
+	printf 'WORKER_BRANCH_ORPHAN_AUTO_RECOVERED (issue=%s repo=%s branch=%s reason=%s remote_deleted=%s)\n' \
+		"$issue_number" "$repo_slug" "$branch_name" "$hold_reason" "$remote_deleted"
+	return 0
+}
+
+#######################################
 # Post a diagnostic and hold dispatch for unrecoverable orphan evidence.
 #
 # Args: $1 issue, $2 repo, $3 branch, $4 reason, $5 remote probe,
@@ -1089,14 +1151,32 @@ _ddh_hold_unrecoverable_orphan_branch_if_needed() {
 	: "${state_repo}"
 
 	if [[ "$remote_exists" == "no" ]]; then
+		# t3076/GH#1214: try auto-recovery before holding. If no open PR
+		# references this branch, clean up and let the next cycle dispatch
+		# with a fresh worktree instead of looping until the circuit breaker
+		# fires.
+		if _ddh_auto_recover_orphan_branch "$issue_number" "$repo_slug" "$branch_name" \
+			"remote_branch_missing" "$worktree_path" "$comments_post_endpoint"; then
+			return 0
+		fi
 		_ddh_hold_unrecoverable_orphan_branch "$issue_number" "$repo_slug" "$branch_name" \
 			"remote_branch_missing" "$remote_probe" "$remote_exists" "$commit_count" \
 			"$comments_post_endpoint" "$comments_json"
 		return 0
 	fi
 	if [[ "$commit_count" == "0" ]]; then
+		# t3076/GH#1214: try auto-recovery before holding. Zero commits
+		# means the branch has nothing to PR. If no open PR references
+		# this branch, delete the remote orphan and let the next dispatch
+		# create a fresh worktree+branch.
+		# the codebase ratchet flags repeated boolean-token literals.
+		local _reason_zero="zero_commits"
+		if _ddh_auto_recover_orphan_branch "$issue_number" "$repo_slug" "$branch_name" \
+			"$_reason_zero" "$worktree_path" "$comments_post_endpoint"; then
+			return 0
+		fi
 		_ddh_hold_unrecoverable_orphan_branch "$issue_number" "$repo_slug" "$branch_name" \
-			"zero_commits" "$remote_probe" "$remote_exists" "$commit_count" \
+			"$_reason_zero" "$remote_probe" "$remote_exists" "$commit_count" \
 			"$comments_post_endpoint" "$comments_json"
 		return 0
 	fi

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -85,6 +85,23 @@ _classify_stale_recovery_crash_type() {
 		return 0
 	fi
 
+	# t3076/GH#1214: check for orphan auto-recovery or unrecoverable-blocked
+	# diagnostic comments. If the most recent lifecycle event is an orphan
+	# cleanup, the stale assignment resulted from a pre-launch abort at the
+	# orphan detection stage, not a real worker failure. Classify as
+	# "orphan_blocked" instead of "no_work" to prevent the fast-fail entry
+	# from feeding the t2769 per-issue no_work circuit breaker.
+	local _orphan_marker_count
+	_orphan_marker_count=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --jq '[.[] | (.body // "") | select(
+			test("worker-branch-orphan-auto-recovered|worker-branch-orphan-unrecoverable:blocked")
+		)] | length' 2>/dev/null) || _orphan_marker_count=0
+	[[ "$_orphan_marker_count" =~ ^[0-9]+$ ]] || _orphan_marker_count=0
+	if [[ "$_orphan_marker_count" -gt 0 ]]; then
+		printf 'orphan_blocked'
+		return 0
+	fi
+
 	# No PR, no branch — the worker died before producing any durable
 	# artifact. Classify as no_work so the cascade tier escalation
 	# comment renders the "Likely infrastructure/transient failure" line.

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1627,10 +1627,66 @@ _dlw_check_worker_branch_orphan_loop() {
 	local orphan_loop_out=""
 	if orphan_loop_out=$("$dedup_helper" check-orphan-loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$todo_file" "$worker_worktree_path" 2>/dev/null); then
 		echo "[dispatch_with_dedup] Dispatch held for #${issue_number} in ${repo_slug}: ${orphan_loop_out}" >>"$LOGFILE"
+		# t3076/GH#1214: when the orphan check auto-recovered a zero-commit
+		# or missing-remote branch, clean up the local worktree so the next
+		# dispatch cycle creates a fresh one instead of re-entering this
+		# loop and eventually tripping the no_work circuit breaker.
+		if [[ "$orphan_loop_out" == *"WORKER_BRANCH_ORPHAN_AUTO_RECOVERED"* && -n "$worker_worktree_path" ]]; then
+			_dlw_cleanup_auto_recovered_worktree "$issue_number" "$repo_slug" "$worker_worktree_path" "$worker_worktree_branch"
+		fi
 		return 0
 	fi
 
 	return 1
+}
+
+#######################################
+# Clean up a local worktree after orphan branch auto-recovery.
+#
+# After dispatch-dedup-helper.sh auto-deletes a zero-commit remote branch,
+# the local worktree must also be removed so the next dispatch cycle does
+# not reuse it and re-enter the orphan detection loop.
+#
+# Args: $1 issue, $2 repo, $3 worktree path, $4 branch name
+# Returns: 0 always (best-effort cleanup)
+#######################################
+_dlw_cleanup_auto_recovered_worktree() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local worktree_path="$3"
+	local branch_name="$4"
+
+	[[ -n "$worktree_path" ]] || return 0
+
+	# Find the parent repo path for git worktree prune.
+	local repo_path=""
+	repo_path=$(git -C "$worktree_path" rev-parse --git-common-dir 2>/dev/null | sed 's|/\.git$||') || repo_path=""
+
+	# Remove the worktree directory.
+	if [[ -d "$worktree_path" ]]; then
+		git worktree remove --force "$worktree_path" 2>/dev/null ||
+			rm -rf "$worktree_path" 2>/dev/null || true
+	fi
+
+	# Prune stale worktree entries.
+	if [[ -n "$repo_path" && -d "$repo_path" ]]; then
+		git -C "$repo_path" worktree prune 2>/dev/null || true
+	fi
+
+	# Unregister from the worktree registry if available.
+	if declare -F unregister_worktree >/dev/null 2>&1; then
+		unregister_worktree "$worktree_path" 2>/dev/null || true
+	fi
+
+	# Log the audit trail for the worktree removal.
+	if declare -F log_worktree_removal_event >/dev/null 2>&1; then
+		log_worktree_removal_event "${_WTAR_REMOVED:-removed}" \
+			"dispatch-orphan-recovery" "$worktree_path" \
+			"auto-recovered-orphan" "permanent" 2>/dev/null || true
+	fi
+
+	echo "[dispatch_with_dedup] Auto-recovered orphan worktree for #${issue_number} in ${repo_slug}: removed ${worktree_path} (branch: ${branch_name})" >>"$LOGFILE"
+	return 0
 }
 
 _dlw_min_worker_floor_active() {

--- a/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
+++ b/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
@@ -101,11 +101,31 @@ EOF
 ]
 EOF
 
+	# t3076/GH#1214: comments for issue 400 in owner/develop-repo (no PR exists for this repo).
+	cat >"${TEST_ROOT}/comments-400.json" <<EOF
+[
+  [
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/empty session=issue-400 ts=${now_iso}\n<!-- ops:end -->"},
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/missing session=issue-400 ts=${now_iso}\n<!-- ops:end -->"}
+  ]
+]
+EOF
+
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
 if [[ "${1:-}" == "api" ]]; then
+	# Handle DELETE requests (e.g., remote branch deletion in auto-recovery)
+	if [[ " $* " == *" -X DELETE "* || " $* " == *" --method DELETE "* ]]; then
+		for arg in "$@"; do
+			if [[ "$arg" =~ git/refs/heads/ ]]; then
+				printf '%s\n' "$*" >>"${TEST_ROOT}/api-deletes.log"
+				exit 0
+			fi
+		done
+		exit 0
+	fi
 	issue=""
 	for arg in "$@"; do
 		if [[ "$arg" =~ /issues/([0-9]+)/comments ]]; then
@@ -129,8 +149,10 @@ fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	if [[ "$*" == *"owner/develop-repo"* ]]; then
+		# t3076: owner/develop-repo has no PRs → auto-recovery proceeds
 		exit 0
 	fi
+	# Default: return a PR so auto-recovery is skipped
 	printf '#123 (OPEN) https://example.invalid/pr/123\n'
 	exit 0
 fi
@@ -177,13 +199,19 @@ fi
 
 if [[ "${1:-}" == "rev-list" && "${2:-}" == "--count" ]]; then
 	case "${3:-}" in
-		origin/main..origin/feature/empty|origin/feature/empty)
+		origin/main..origin/feature/empty|origin/develop..origin/feature/empty|origin/feature/empty)
 			printf '0\n'
 			;;
 		*)
 			printf '2\n'
 			;;
 	esac
+	exit 0
+fi
+
+# t3076: handle push --delete for orphan auto-recovery
+if [[ "${1:-}" == "push" && " $* " == *" --delete "* ]]; then
+	printf '%s\n' "$*" >>"${TEST_ROOT}/git-push-deletes.log"
 	exit 0
 fi
 
@@ -265,6 +293,8 @@ test_orphan_comment_without_remote_branch_blocks_immediately() {
 
 test_orphan_comment_with_zero_commits_blocks_immediately() {
 	local output=""
+	# owner/repo returns an open PR from the stub, so auto-recovery is skipped
+	# and the hold behavior is preserved.
 	if output=$("$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/empty "" "${TEST_ROOT}/wt-zero-commits" 2>/dev/null); then
 		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_UNRECOVERABLE_BLOCKED"* && "$output" == *"reason=zero_commits"* ]] && grep -q -- "Branch commit count: \`0\`" "${TEST_ROOT}/posts/100.argv"; then
 			print_result "orphan marker with zero remote branch commits holds dispatch" 0
@@ -277,6 +307,61 @@ test_orphan_comment_with_zero_commits_blocks_immediately() {
 	return 0
 }
 
+# t3076/GH#1214: zero-commit orphan with no open PR triggers auto-recovery.
+# Auto-recovery deletes the remote branch and posts a recovery comment so the
+# next dispatch cycle creates a fresh worktree instead of looping until the
+# t2769 no_work circuit breaker fires.
+test_zero_commits_no_pr_triggers_auto_recovery() {
+	local output=""
+	# owner/develop-repo returns no PRs from the stub → auto-recovery proceeds.
+	if output=$("$HELPER_SCRIPT" check-orphan-loop 400 owner/develop-repo feature/empty "" "${TEST_ROOT}/wt-zero-commits" 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_AUTO_RECOVERED"* && "$output" == *"reason=zero_commits"* ]]; then
+			if [[ -f "${TEST_ROOT}/posts/400.argv" ]] && grep -q "worker-branch-orphan-auto-recovered:cleanup" "${TEST_ROOT}/posts/400.argv"; then
+				print_result "t3076: zero commits + no PR → auto-recovery with comment" 0
+				return 0
+			fi
+			print_result "t3076: zero commits + no PR → auto-recovery with comment" 1 "Missing recovery comment post"
+			return 0
+		fi
+		print_result "t3076: zero commits + no PR → auto-recovery with comment" 1 "Expected AUTO_RECOVERED output, got: ${output}"
+		return 0
+	fi
+	print_result "t3076: zero commits + no PR → auto-recovery with comment" 1 "Expected exit 0 (dispatch hold after auto-recovery)"
+	return 0
+}
+
+# t3076/GH#1214: missing remote branch with no open PR also triggers auto-recovery.
+test_missing_remote_no_pr_triggers_auto_recovery() {
+	local output=""
+	# owner/develop-repo returns no PRs from the stub → auto-recovery proceeds.
+	if output=$("$HELPER_SCRIPT" check-orphan-loop 400 owner/develop-repo feature/missing "" "${TEST_ROOT}/wt-with-commits" 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_AUTO_RECOVERED"* && "$output" == *"reason=remote_branch_missing"* ]]; then
+			print_result "t3076: missing remote + no PR → auto-recovery" 0
+			return 0
+		fi
+		print_result "t3076: missing remote + no PR → auto-recovery" 1 "Expected AUTO_RECOVERED output, got: ${output}"
+		return 0
+	fi
+	print_result "t3076: missing remote + no PR → auto-recovery" 1 "Expected exit 0 (dispatch hold after auto-recovery)"
+	return 0
+}
+
+# t3076/GH#1214: zero-commit orphan WITH an open PR falls back to hold.
+test_zero_commits_with_pr_still_holds() {
+	local output=""
+	# owner/repo returns an open PR from the stub → auto-recovery is skipped.
+	if output=$("$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/empty "" "${TEST_ROOT}/wt-zero-commits" 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_UNRECOVERABLE_BLOCKED"* ]]; then
+			print_result "t3076: zero commits + open PR → hold (no auto-recovery)" 0
+			return 0
+		fi
+		print_result "t3076: zero commits + open PR → hold (no auto-recovery)" 1 "Expected UNRECOVERABLE_BLOCKED, got: ${output}"
+		return 0
+	fi
+	print_result "t3076: zero commits + open PR → hold (no auto-recovery)" 1 "Expected dispatch hold"
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_same_issue_branch_blocks_and_posts_diagnostic
@@ -286,6 +371,9 @@ main() {
 	test_orphan_loop_next_action_uses_configured_base
 	test_orphan_comment_without_remote_branch_blocks_immediately
 	test_orphan_comment_with_zero_commits_blocks_immediately
+	test_zero_commits_no_pr_triggers_auto_recovery
+	test_missing_remote_no_pr_triggers_auto_recovery
+	test_zero_commits_with_pr_still_holds
 	teardown_test_env
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"


### PR DESCRIPTION
## What

Auto-recover zero-commit orphan branches to prevent the permanent dispatch loop that trips the t2769 no_work circuit breaker.

## Root cause

When a worker crashes before making commits, the orphan branch detection (`WORKER_BRANCH_ORPHAN_UNRECOVERABLE_BLOCKED` with `reason=zero_commits`) holds dispatch indefinitely. Nothing cleans up the orphan branch or worktree between cycles, so each subsequent cycle triggers:

1. Worktree reuse → orphan detection → rc=2 (blocked)
2. Claim deleted (pre-launch abort) → assignment remains
3. Stale recovery → `stale_timeout/no_work` fast-fail

After 4 cycles, the t2769 no_work circuit breaker fires.

**Observed on**: Majowka/mesh-manager#48 → circuit-breaker meta-issue Majowka/mesh-manager#1214.

## Fix

### Primary: auto-recover orphan branches (`dispatch-dedup-helper.sh`)

New function `_ddh_auto_recover_orphan_branch()`:
- Checks for open PRs referencing the branch (if found → falls back to existing hold behavior)
- Deletes the remote orphan branch via `gh api -X DELETE` (zero commits = nothing to lose)
- Posts an audit trail comment with recovery details
- Called for both `zero_commits` and `remote_branch_missing` reasons

### Caller-side cleanup (`pulse-dispatch-worker-launch.sh`)

New function `_dlw_cleanup_auto_recovered_worktree()`:
- Removes the local worktree after auto-recovery
- Prunes git worktree metadata
- Unregisters from worktree registry
- Next dispatch cycle creates a fresh worktree with a new branch name

### Defense-in-depth (`pulse-dispatch-dedup-layers.sh`)

In `_classify_stale_recovery_crash_type()`:
- Checks for orphan auto-recovery or unrecoverable-blocked diagnostic comments
- Classifies as `orphan_blocked` instead of `no_work`
- Prevents orphan-related fast-fail entries from feeding the circuit breaker

## Testing

- All 10 regression tests pass (7 existing + 3 new):
  - zero commits + no PR → auto-recovery with comment
  - missing remote + no PR → auto-recovery
  - zero commits + open PR → hold (no auto-recovery, existing behavior)
- Pre-existing tests unchanged
- Pre-commit quality checks pass

## Files changed

| File | Change |
|------|--------|
| `.agents/scripts/dispatch-dedup-helper.sh` | Add `_ddh_auto_recover_orphan_branch()`, try auto-recovery before hold |
| `.agents/scripts/pulse-dispatch-worker-launch.sh` | Add `_dlw_cleanup_auto_recovered_worktree()`, clean up after auto-recovery |
| `.agents/scripts/pulse-dispatch-dedup-layers.sh` | Add orphan-blocked classification in crash type classifier |
| `.agents/scripts/tests/test-worker-branch-orphan-loop.sh` | Add 3 regression tests for auto-recovery |

For Majowka/mesh-manager#1214

Resolves #26402
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.29 plugin for [OpenCode](https://opencode.ai) v1.17.13 with claude-opus-4-6 spent 27m and 57,328 tokens on this as a headless worker.