### PR TITLE
fix(dispatch): recover zero-commit orphan branches

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -225,6 +225,55 @@ _ddh_hold_unrecoverable_orphan_branch() {
 }
 
 #######################################
+# Auto-recover a provably disposable zero-commit orphan branch.
+#
+# Args: $1 issue, $2 repo, $3 branch, $4 remote probe, $5 commit count,
+#       $6 comments endpoint, $7 comments json
+# Returns: 0 if recovered, 1 if caller should keep normal hold/block logic
+#######################################
+_ddh_auto_recover_zero_commit_orphan_branch() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local branch_name="$3"
+	local remote_probe="$4"
+	local commit_count="$5"
+	local comments_post_endpoint="$6"
+	local comments_json="$7"
+	local pr_hint="$_DDH_ORPHAN_PR_HINT_NONE"
+	local existing_recovery="0"
+
+	[[ "$commit_count" == "0" ]] || return 1
+	pr_hint=$(_ddh_orphan_branch_pr_hint "$repo_slug" "$branch_name")
+	[[ "$pr_hint" == "$_DDH_ORPHAN_PR_HINT_NONE" ]] || return 1
+
+	existing_recovery=$(printf '%s' "$comments_json" |
+		jq -r --arg branch "$branch_name" '
+			[.[][] | (.body // empty)
+			| select(contains("worker-branch-orphan-auto-recovered branch=" + $branch + " "))] | length
+		' 2>/dev/null) || existing_recovery="0"
+	[[ "$existing_recovery" =~ ^[0-9]+$ ]] || existing_recovery=0
+
+	if gh api -X DELETE "repos/${repo_slug}/git/refs/heads/${branch_name}" >/dev/null 2>&1; then
+		if [[ "$existing_recovery" -eq 0 ]]; then
+			local diag=""
+			# shellcheck disable=SC2016 # Backticks are literal Markdown in this printf template.
+			diag=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan-auto-recovered branch=%s issue=%s reason=zero_commits commit_count=%s -->\n## Dispatch recovered: zero-commit worker_branch_orphan\n\nThe dispatch path found `WORKER_BRANCH_ORPHAN` telemetry for issue #%s on branch `%s`, but the remote branch has zero commits and no open or closed PR references it. The remote branch was deleted so dispatch can create or reuse a clean worker branch instead of feeding the no-work circuit breaker.\n\n- Branch: `%s`\n- Remote-branch probe: `%s`\n- Branch commit count: `%s`\n- PR for branch: none\n- Local worktree cleanup: not forced; any local state remains available for normal safety checks.\n<!-- ops:end -->' \
+				"$branch_name" "$issue_number" "$commit_count" \
+				"$issue_number" "$branch_name" "$branch_name" "$remote_probe" "$commit_count")
+			gh api "$comments_post_endpoint" \
+				--method POST \
+				--field body="$diag" \
+				>/dev/null 2>&1 || true
+		fi
+		printf 'WORKER_BRANCH_ORPHAN_AUTO_RECOVERED (issue=%s repo=%s branch=%s reason=zero_commits remote_probe=%s commit_count=%s)\n' \
+			"$issue_number" "$repo_slug" "$branch_name" "$remote_probe" "$commit_count"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Extract canonical dedup keys from a title string.
 # Looks for patterns: issue #NNN, PR #NNN, tNNN (task IDs), issue-NNN, pr-NNN.
 # Args: $1 = title string
@@ -1095,6 +1144,10 @@ _ddh_hold_unrecoverable_orphan_branch_if_needed() {
 		return 0
 	fi
 	if [[ "$commit_count" == "0" ]]; then
+		if _ddh_auto_recover_zero_commit_orphan_branch "$issue_number" "$repo_slug" "$branch_name" \
+			"$remote_probe" "$commit_count" "$comments_post_endpoint" "$comments_json"; then
+			return 0
+		fi
 		_ddh_hold_unrecoverable_orphan_branch "$issue_number" "$repo_slug" "$branch_name" \
 			"zero_commits" "$remote_probe" "$remote_exists" "$commit_count" \
 			"$comments_post_endpoint" "$comments_json"

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1626,6 +1626,10 @@ _dlw_check_worker_branch_orphan_loop() {
 
 	local orphan_loop_out=""
 	if orphan_loop_out=$("$dedup_helper" check-orphan-loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$todo_file" "$worker_worktree_path" 2>/dev/null); then
+		if [[ "$orphan_loop_out" == *"WORKER_BRANCH_ORPHAN_AUTO_RECOVERED"* ]]; then
+			echo "[dispatch_with_dedup] Auto-recovered orphan branch for #${issue_number} in ${repo_slug}: ${orphan_loop_out}" >>"$LOGFILE"
+			return 1
+		fi
 		echo "[dispatch_with_dedup] Dispatch held for #${issue_number} in ${repo_slug}: ${orphan_loop_out}" >>"$LOGFILE"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
+++ b/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
@@ -79,7 +79,8 @@ create_gh_stub() {
     {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
     {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/other session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
     {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/missing session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
-    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/empty session=issue-100 ts=${now_iso}\n<!-- ops:end -->"}
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/empty session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
+    {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/empty-pr session=issue-100 ts=${now_iso}\n<!-- ops:end -->"}
   ]
 ]
 EOF
@@ -106,6 +107,10 @@ EOF
 set -euo pipefail
 
 if [[ "${1:-}" == "api" ]]; then
+	if [[ "$*" == *" -X DELETE "* ]]; then
+		printf '%s\n' "$*" >>"${TEST_ROOT}/deleted-refs.log"
+		exit 0
+	fi
 	issue=""
 	for arg in "$@"; do
 		if [[ "$arg" =~ /issues/([0-9]+)/comments ]]; then
@@ -128,6 +133,9 @@ if [[ "${1:-}" == "api" ]]; then
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	if [[ "$*" == *"--head feature/empty "* ]]; then
+		exit 0
+	fi
 	if [[ "$*" == *"owner/develop-repo"* ]]; then
 		exit 0
 	fi
@@ -177,7 +185,7 @@ fi
 
 if [[ "${1:-}" == "rev-list" && "${2:-}" == "--count" ]]; then
 	case "${3:-}" in
-		origin/main..origin/feature/empty|origin/feature/empty)
+		origin/main..origin/feature/empty|origin/feature/empty|origin/main..origin/feature/empty-pr|origin/feature/empty-pr)
 			printf '0\n'
 			;;
 		*)
@@ -263,17 +271,31 @@ test_orphan_comment_without_remote_branch_blocks_immediately() {
 	return 0
 }
 
-test_orphan_comment_with_zero_commits_blocks_immediately() {
+test_orphan_comment_with_zero_commits_auto_recovers() {
 	local output=""
 	if output=$("$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/empty "" "${TEST_ROOT}/wt-zero-commits" 2>/dev/null); then
-		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_UNRECOVERABLE_BLOCKED"* && "$output" == *"reason=zero_commits"* ]] && grep -q -- "Branch commit count: \`0\`" "${TEST_ROOT}/posts/100.argv"; then
-			print_result "orphan marker with zero remote branch commits holds dispatch" 0
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_AUTO_RECOVERED"* ]] && grep -q -- "feature/empty" "${TEST_ROOT}/deleted-refs.log" && grep -q -- "worker-branch-orphan-auto-recovered" "${TEST_ROOT}/posts/100.argv"; then
+			print_result "orphan marker with zero remote branch commits auto-recovers" 0
 			return 0
 		fi
-		print_result "orphan marker with zero remote branch commits holds dispatch" 1 "Output/post missing zero-commit evidence: ${output}"
+		print_result "orphan marker with zero remote branch commits auto-recovers" 1 "Output/post missing auto-recovery evidence: ${output}"
 		return 0
 	fi
-	print_result "orphan marker with zero remote branch commits holds dispatch" 1 "Expected dispatch hold"
+	print_result "orphan marker with zero remote branch commits auto-recovers" 1 "Expected auto-recovery result"
+	return 0
+}
+
+test_zero_commit_branch_with_pr_still_holds() {
+	local output=""
+	if output=$("$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/empty-pr "" "${TEST_ROOT}/wt-zero-commits" 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_UNRECOVERABLE_BLOCKED"* && "$output" == *"reason=zero_commits"* ]]; then
+			print_result "zero-commit orphan with PR keeps recovery hold" 0
+			return 0
+		fi
+		print_result "zero-commit orphan with PR keeps recovery hold" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+	print_result "zero-commit orphan with PR keeps recovery hold" 1 "Expected dispatch hold"
 	return 0
 }
 
@@ -285,7 +307,8 @@ main() {
 	test_unrelated_failure_class_does_not_block
 	test_orphan_loop_next_action_uses_configured_base
 	test_orphan_comment_without_remote_branch_blocks_immediately
-	test_orphan_comment_with_zero_commits_blocks_immediately
+	test_orphan_comment_with_zero_commits_auto_recovers
+	test_zero_commit_branch_with_pr_still_holds
 	teardown_test_env
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"


### PR DESCRIPTION
## What

Recover proven zero-commit worker branch orphans without repeating the no-work circuit-breaker loop.

## Changes

- Adds safe auto-recovery for orphan branches only when branch commit count is exactly zero and no PR references the branch.
- Keeps remote_branch_missing on the existing hold path so missing remote refs cannot discard local-only work.
- Lets dispatch continue after auto-recovery instead of treating recovery as a hold.
- Adds regression coverage for zero-commit recovery and zero-commit branches with PRs.

## Verification

- .agents/scripts/tests/test-worker-branch-orphan-loop.sh
- shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-worker-branch-orphan-loop.sh
- .agents/scripts/linters-local.sh

Resolves #26402
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.31 plugin for [OpenCode](https://opencode.ai) v1.17.13
