### PR TITLE
fix: avoid PR branch refresh during active CI

### DIFF
--- a/.agents/reference/ci-gate-policy.md
+++ b/.agents/reference/ci-gate-policy.md
@@ -40,6 +40,13 @@ feedback loops when they find defects.
    PRs. Broad reboot, fleet, migration-recovery, and manual crypto-review drills
    are staging/release advisory until stable enough for every PR. See
    `reference/vault-security-review.md`.
+9. Before refreshing a PR branch from its base branch, check required checks on
+   the current head SHA. If required checks are queued or in progress and the PR
+   is not conflicted or explicitly blocked by an up-to-date ruleset, keep the
+   head stable: wait for the current run or enable platform-native auto-merge.
+10. Repositories that require testing the exact merge result should use merge
+   queue or platform-native queued merge behaviour instead of repeatedly mutating
+   PR branches while CI is active.
 
 ## Ruleset checklist
 
@@ -77,6 +84,10 @@ work; only defects in the PR's own code block the PR.
 - Full E2E on every develop PR when most failures are unrelated flakes.
 - Parallel update/rerun of many PRs when each merge invalidates the next one's
   strict up-to-date checks.
+- Updating a PR branch during active required CI just to "refresh" it; this
+  starts a new check suite for the new head and can discard nearly-finished work.
+- Diagnosing or redispatching from a failed check without first verifying that
+  the failure belongs to the current PR head SHA.
 - Redispatching new workers for advisory E2E failures instead of filing focused
   follow-up tasks.
 - Treating delayed, pending, cancelled, or infrastructure-timed-out checks as

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -87,8 +87,9 @@ issue for dispatch.
 Repair triggers:
 
 - Required checks in `fail` or `cancel` buckets.
-- Native auto-merge already set, but at least one required check remains
-  `pending` longer than `AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS` (default 300s).
+- Native auto-merge already set and the current head has a terminal required
+  check failure. Pending/in-progress required checks are non-terminal and should
+  continue running instead of being restarted by a branch refresh.
 
 Safety boundaries:
 
@@ -99,6 +100,11 @@ Safety boundaries:
 - Repair feedback is deduplicated by linked issue + PR + head SHA marker
   (`<!-- ci-feedback:PR...:SHA... -->`) so each stuck head queues at most one
   repair action.
+- Failed checks from older head SHAs are stale symptoms. Ignore them for repair
+  routing and continue monitoring the latest head SHA.
+- Superseded active runs may be cancelled only when the operator/helper can
+  prove the run belongs to the same PR/branch, its head SHA is not the latest PR
+  head SHA, and the run is still queued or in progress; otherwise leave it alone.
 
 Diagnosis commands:
 

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1006,6 +1006,25 @@ _attempt_pr_ci_rebase_retry() {
 		fi
 	fi
 
+	# GH#26406: branch updates restart the current head's check suite. Only use
+	# update-branch as a CI-drift repair when the current head has a terminal
+	# required-check failure. Pending/in-progress required checks are not failures,
+	# and stale failures from older head SHAs must not trigger a branch refresh.
+	local _terminal_check_rc=0
+	_check_required_checks_has_terminal_failure "$repo_slug" "$pr_number"
+	_terminal_check_rc=$?
+	if [[ $_terminal_check_rc -eq 1 ]]; then
+		if _check_required_checks_have_pending_or_in_progress "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: skipping CI-drift update-branch because required checks are active on the current head; wait for current CI or rely on native auto-merge to avoid restarting checks (GH#26406)" >>"$LOGFILE"
+			return 1
+		fi
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: skipping CI-drift update-branch because no terminal required-check failure belongs to the current head; stale/non-required failure ignored (GH#26406)" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ $_terminal_check_rc -ne 0 ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: required-check head-state unavailable before CI-drift update-branch; fail-open to existing update-branch behaviour (GH#26406)" >>"$LOGFILE"
+	fi
+
 	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: attempting CI-drift rebase via update-branch (t2805)" >>"$LOGFILE"
 
 	local _ub_output _ub_exit

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -212,7 +212,7 @@ _check_required_checks_has_terminal_failure() {
 
 	local rollup_json=""
 	rollup_json=$(gh_pr_check_runs_rest "$repo_slug" "$pr_sha" 2>/dev/null) || rollup_json=""
-	if [[ -z "$rollup_json" || "$rollup_json" == "null" ]]; then
+	if [[ -z "$rollup_json" || "$rollup_json" == null ]]; then
 		echo "[pulse-merge] _check_required_checks_has_terminal_failure: REST check-runs fetch failed for PR #${pr_number} in ${repo_slug} — failing closed (t3567)" >>"$LOGFILE"
 		return 2
 	fi
@@ -247,5 +247,75 @@ _check_required_checks_has_terminal_failure() {
 	fi
 
 	echo "[pulse-merge] _check_required_checks_has_terminal_failure: no terminal failed required contexts for PR #${pr_number} in ${repo_slug} (t3567)" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
+# Return whether any branch-protection-required check on the current PR head is
+# queued, pending, in progress, waiting, or absent from the current head rollup.
+# This is the pre-update guard for branch refresh paths: mutating a PR branch
+# while required checks are still active restarts CI and wastes runner time.
+#
+# Args: $1=repo_slug, $2=pr_number
+# Returns: 0=pending/in-progress required check found, 1=no active required
+#          checks, 2=API/parse error
+#######################################
+_check_required_checks_have_pending_or_in_progress() {
+	local repo_slug="$1"
+	local pr_number="$2"
+
+	local required_contexts=""
+	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 2
+	if [[ -z "$required_contexts" ]]; then
+		echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: no required contexts for ${repo_slug} — no active required checks (GH#26406)" >>"$LOGFILE"
+		return 1
+	fi
+
+	local pr_sha=""
+	pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json headRefOid --jq '.headRefOid // ""') || true
+	if [[ -z "$pr_sha" ]]; then
+		echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: headRefOid fetch failed for PR #${pr_number} in ${repo_slug} — failing open for branch-update caller (GH#26406)" >>"$LOGFILE"
+		return 2
+	fi
+
+	local rollup_json=""
+	rollup_json=$(gh_pr_check_runs_rest "$repo_slug" "$pr_sha" 2>/dev/null) || rollup_json=""
+	if [[ -z "$rollup_json" || "$rollup_json" == null ]]; then
+		echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: REST check-runs fetch failed for PR #${pr_number} in ${repo_slug} — failing open for branch-update caller (GH#26406)" >>"$LOGFILE"
+		return 2
+	fi
+
+	local req_json
+	req_json=$(printf '%s' "$required_contexts" \
+		| jq -Rsc '[split("\n")[] | select(length > 0)]' 2>/dev/null) || req_json="[]"
+
+	local pending_count="" _pc_exit=0
+	pending_count=$(jq -n \
+		--argjson req "$req_json" \
+		--argjson checks "$rollup_json" \
+		'$req | map(
+			. as $ctx |
+			($checks | map(select((.name // "") == $ctx)) | last) as $c |
+			if $c == null then true
+			elif (($c.conclusion // "") | length) == 0 then true
+			elif (($c.status // "" | ascii_downcase)
+				| . == "queued" or . == "pending" or . == "in_progress" or . == "waiting" or . == "requested") then true
+			else false
+			end
+		) | map(select(.)) | length' 2>/dev/null)
+	_pc_exit=$?
+
+	if [[ $_pc_exit -ne 0 || -z "$pending_count" ]]; then
+		echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: jq evaluation failed for PR #${pr_number} in ${repo_slug} — failing open for branch-update caller (GH#26406)" >>"$LOGFILE"
+		return 2
+	fi
+
+	if [[ "$pending_count" -gt 0 ]]; then
+		echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: ${pending_count} active required check(s) on current head for PR #${pr_number} in ${repo_slug} (GH#26406)" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: no active required checks on current head for PR #${pr_number} in ${repo_slug} (GH#26406)" >>"$LOGFILE"
 	return 1
 }

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -478,6 +478,70 @@ test_unknown_mergeable_refreshed_before_conflict_handler() {
 	return 0
 }
 
+test_ci_rebase_update_branch_has_active_check_guard() {
+	local helper_src guard_pos update_pos terminal_pos
+	helper_src=$(awk '
+		/^_attempt_pr_ci_rebase_retry\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^}$/ { exit }
+	' "$PROCESS_SCRIPT")
+
+	terminal_pos=$(printf '%s\n' "$helper_src" | awk '/_check_required_checks_has_terminal_failure/ { print NR; exit }')
+	guard_pos=$(printf '%s\n' "$helper_src" | awk '/_check_required_checks_have_pending_or_in_progress/ { print NR; exit }')
+	update_pos=$(printf '%s\n' "$helper_src" | awk '/_ub_output=\$\(gh pr update-branch/ { print NR; exit }')
+
+	if [[ -z "$terminal_pos" || -z "$guard_pos" || -z "$update_pos" ]]; then
+		print_result "CI-drift update-branch checks current-head required state first" 1 \
+			"Expected terminal check, active-check guard, and update-branch call (terminal=${terminal_pos}, guard=${guard_pos}, update=${update_pos})"
+		return 0
+	fi
+
+	if [[ "$terminal_pos" -ge "$guard_pos" || "$guard_pos" -ge "$update_pos" ]]; then
+		print_result "CI-drift update-branch checks current-head required state first" 1 \
+			"Expected terminal check before active guard before update-branch (terminal=${terminal_pos}, guard=${guard_pos}, update=${update_pos})"
+		return 0
+	fi
+
+	if [[ "$helper_src" != *"required checks are active on the current head"* || "$helper_src" != *"stale/non-required failure ignored"* ]]; then
+		print_result "CI-drift update-branch checks current-head required state first" 1 \
+			"Expected audit logs for active checks and stale/non-current failures"
+		return 0
+	fi
+
+	print_result "CI-drift update-branch checks current-head required state first" 0
+	return 0
+}
+
+test_required_check_pending_classifier_exists() {
+	local helper_src
+	helper_src=$(awk '
+		/^_check_required_checks_have_pending_or_in_progress\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^}$/ { exit }
+	' "${SCRIPT_DIR}/../pulse-merge-required-checks.sh")
+
+	if [[ -z "$helper_src" ]]; then
+		print_result "required-check pending classifier is available" 1 \
+			"Could not extract _check_required_checks_have_pending_or_in_progress"
+		return 0
+	fi
+
+	if [[ "$helper_src" != *"headRefOid"* || "$helper_src" != *"gh_pr_check_runs_rest"* ]]; then
+		print_result "required-check pending classifier is available" 1 \
+			"Classifier must use current headRefOid and REST check-runs"
+		return 0
+	fi
+
+	if [[ "$helper_src" != *"queued"* || "$helper_src" != *"in_progress"* || "$helper_src" != *"waiting"* ]]; then
+		print_result "required-check pending classifier is available" 1 \
+			"Classifier must recognise queued/in_progress/waiting active states"
+		return 0
+	fi
+
+	print_result "required-check pending classifier is available" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -499,6 +563,8 @@ main() {
 	test_stale_route_runs_before_protected_precheck
 	test_mergeable_refetch_after_update_branch
 	test_unknown_mergeable_refreshed_before_conflict_handler
+	test_ci_rebase_update_branch_has_active_check_guard
+	test_required_check_pending_classifier_exists
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -65,6 +65,13 @@ command-substitution `--body` patterns are blocked by the signature gate.
 
 Interactive aidevops PRs default to draft until the user explicitly asks to finalise/ready the PR or invokes `/pr-loop`. To permit pulse merge throughput after finalisation, also opt in with `allow-auto-merge`, `AIDEVOPS_INTERACTIVE_PR_AUTO_MERGE=1`, global `orchestration.interactive_pr_auto_merge=true`, or per-repo `repos.json` `interactive_pr_auto_merge=true`.
 
+When a PR is approved, mergeable, non-draft, and not blocked by review/security/
+maintainer labels, prefer `gh pr merge --auto` or the host platform's merge queue
+over refreshing the PR branch while required checks are queued or running.
+Updating the branch creates a new head SHA and restarts checks; only do it when
+the PR is conflicted, a ruleset requires an up-to-date branch, or the current
+head has a terminal required-check failure that a base refresh can plausibly fix.
+
 ## Merging Pull Requests
 
 | Strategy | Flag | When |


### PR DESCRIPTION
## Summary

- Added a current-head required-check pending classifier keyed by PR head SHA.
- Guarded CI-drift update-branch so active required checks wait instead of being restarted.
- Kept current terminal required-check failures eligible for the existing base-refresh retry while ignoring stale/non-current failures.
- Documented auto-merge/merge-queue trade-offs and safe superseded-run cancellation conditions.

## Testing

- .agents/scripts/tests/test-pulse-merge-update-branch.sh
- shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-update-branch.sh

Resolves #26406
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.31 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 8m and 168,189 tokens on this as a headless worker.