### PR TITLE
GH#26413: test: guard iphub docs provider path

### DIFF
--- a/.agents/scripts/tests/test-ip-rep-iphub-docs.sh
+++ b/.agents/scripts/tests/test-ip-rep-iphub-docs.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 PROVIDER_PATH="${SCRIPT_DIR}/../providers/ip-rep-iphub.sh"
 
+if [[ ! -f "$PROVIDER_PATH" ]]; then
+	printf 'Error: Provider script not found at %s\n' "$PROVIDER_PATH" >&2
+	exit 1
+fi
+
 PASS=0
 FAIL=0
 


### PR DESCRIPTION
## Summary

Added an early provider-script existence check to the IP Hub provider documentation regression test so missing or renamed provider files fail with a clear error before assertions run.

## Files Changed

.agents/scripts/tests/test-ip-rep-iphub-docs.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-ip-rep-iphub-docs.sh && .agents/scripts/tests/test-ip-rep-iphub-docs.sh

Resolves #26413


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.32 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1m and 54,293 tokens on this as a headless worker.