### PR TITLE
GH#26423: fix: harden pr salvage candidate filtering

### DIFF
--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -322,7 +322,12 @@ fetch_unmerged_pr_records() {
 filter_salvage_candidate_records() {
 	local candidate_records="$1"
 
-	echo "$candidate_records" | jq '[.[] | select((.mergedAt == null) and (.additions > 0) and ((.state // "CLOSED") == "CLOSED"))]' || echo "[]"
+	if [[ -z "$candidate_records" || "$candidate_records" == "[]" ]]; then
+		printf '%s\n' "[]"
+		return 0
+	fi
+
+	printf '%s\n' "$candidate_records" | jq '[.[] | select((.mergedAt == null) and (.additions > 0) and ((.state // "CLOSED") == "CLOSED"))]' || printf '%s\n' "[]"
 	return 0
 }
 
@@ -385,7 +390,6 @@ scan_repo() {
 	local lookback_days="${2:-$DEFAULT_LOOKBACK_DAYS}"
 	local pr_numbers="${3:-}"
 	local unmerged
-	local count
 
 	if [[ -n "$pr_numbers" ]]; then
 		unmerged=$(collect_explicit_pr_records "$slug" "$pr_numbers")
@@ -395,9 +399,8 @@ scan_repo() {
 
 	# Safety filter: remove any that slipped through with mergedAt set or 0 additions
 	unmerged=$(filter_salvage_candidate_records "$unmerged")
-	count=$(echo "$unmerged" | jq 'length')
-	if [[ "$count" -eq 0 ]]; then
-		echo "[]"
+	if [[ -z "$unmerged" || "$unmerged" == "[]" ]]; then
+		printf '%s\n' "[]"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pr-salvage-helper.sh
+++ b/.agents/scripts/tests/test-pr-salvage-helper.sh
@@ -150,6 +150,23 @@ test_cmd_scan_accepts_hash_prefixed_pr_numbers() {
 	return 0
 }
 
+test_filter_returns_empty_array_for_empty_inputs() {
+	# shellcheck source=/dev/null
+	source "${TEST_SCRIPT_DIR}/pr-salvage-helper.sh"
+
+	local empty_result
+	local blank_result
+	empty_result=$(filter_salvage_candidate_records "[]")
+	blank_result=$(filter_salvage_candidate_records "")
+
+	if [[ "$empty_result" == "[]" && "$blank_result" == "[]" ]]; then
+		print_result "filter returns [] for empty candidate inputs" 0
+	else
+		print_result "filter returns [] for empty candidate inputs" 1 "expected both empty outputs to be [], got '${empty_result}' and '${blank_result}'"
+	fi
+	return 0
+}
+
 run_tests() {
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
@@ -160,6 +177,7 @@ run_tests() {
 	test_closed_pr_list_requests_state_field
 	test_explicit_pr_numbers_fetch_exact_records
 	test_cmd_scan_accepts_hash_prefixed_pr_numbers
+	test_filter_returns_empty_array_for_empty_inputs
 
 	printf '\nResults: %s run, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	rm -f "$GH_CLOSED_LIST_ARGS_FILE"


### PR DESCRIPTION
## Summary

Replaced unsafe echo-based jq piping in pr-salvage candidate filtering with empty-input guards and printf, avoided jq length checks for empty arrays in scan_repo, and added regression coverage for empty filter inputs.

## Files Changed

.agents/scripts/pr-salvage-helper.sh,.agents/scripts/tests/test-pr-salvage-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pr-salvage-helper.sh .agents/scripts/tests/test-pr-salvage-helper.sh; bash .agents/scripts/tests/test-pr-salvage-helper.sh

Resolves #26423


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 71,586 tokens on this as a headless worker.