### PR TITLE
fix: validate routine comment JSON

### DIFF
--- a/.agents/scripts/routine-comment-responder.sh
+++ b/.agents/scripts/routine-comment-responder.sh
@@ -102,7 +102,15 @@ _fetch_comment() {
 		fi
 		_log "dispatch: comment ${comment_id} on #${issue_number} lookup failed — skipping (${lookup_summary})"
 		_mark_comment_skipped "$responded_file" "$comment_id" "lookup failed"
-		return 1
+		printf '{}\n'
+		return 0
+	fi
+
+	if ! printf '%s\n' "$comment_json" | jq . >/dev/null; then
+		_log "dispatch: comment ${comment_id} on #${issue_number} returned invalid JSON — skipping"
+		_mark_comment_skipped "$responded_file" "$comment_id" "invalid JSON"
+		printf '{}\n'
+		return 0
 	fi
 
 	printf '%s\n' "$comment_json"
@@ -293,6 +301,9 @@ cmd_dispatch() {
 
 	local comment_json comment_body
 	if ! comment_json=$(_fetch_comment "$repo_slug" "$issue_number" "$comment_id" "$responded_file"); then
+		return 0
+	fi
+	if [[ "$comment_json" == "{}" ]]; then
 		return 0
 	fi
 	comment_body=$(printf '%s\n' "$comment_json" | jq -r '.body // ""')


### PR DESCRIPTION
## Summary

- Validates fetched routine comment JSON before downstream jq consumers parse it.
- Returns an empty object sentinel for fetch/validation failures after marking the comment skipped.
- Skips dispatch when the sentinel payload is returned, avoiding worker launches for invalid comments.

## Testing

- `shellcheck .agents/scripts/routine-comment-responder.sh`
- `.agents/scripts/linters-local.sh` (timed out at Secretlint after earlier gates passed)

Resolves #26432
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 7m and 65,992 tokens on this as a headless worker.