### PR TITLE
GH#26426: test: scan email helper for portable patterns

### DIFF
--- a/tests/test-email-agent-helper.sh
+++ b/tests/test-email-agent-helper.sh
@@ -306,7 +306,7 @@ test_code_extraction_patterns_are_portable() {
 	local pcre_flag="grep -o""P"
 	local whitespace_escape='\\['"s"']'
 	local matches
-	matches=$(grep -nE "${pcre_flag}|${whitespace_escape}" "${BASH_SOURCE[0]}" || true)
+	matches=$(grep -nE "${pcre_flag}|${whitespace_escape}" "${BASH_SOURCE[0]}" "$HELPER" || true)
 
 	assert_eq "No GNU-only grep PCRE flag or PCRE whitespace escapes" "" "$matches"
 	return 0


### PR DESCRIPTION
## Summary

Extended the portable grep-pattern regression test to scan both the test file and the production email-agent helper so GNU-only extraction patterns are caught in production code.

## Files Changed

tests/test-email-agent-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck tests/test-email-agent-helper.sh .agents/scripts/email-agent-helper.sh && tests/test-email-agent-helper.sh

Resolves #26426


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1m and 51,081 tokens on this as a headless worker.