### PR TITLE
fix: simplify ANSI signature normalization

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -151,8 +151,7 @@ parse_commit_sha_from_subject_url() {
 normalize_signature_line() {
 	local raw_line="$1"
 	local stripped
-	stripped=$(printf '%s' "$raw_line" | sed -E 's/(\x1B|\^\[)\[[0-9;]*[A-Za-z]//g')
-	stripped=$(printf '%s' "$stripped" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+	stripped=$(printf '%s' "$raw_line" | sed -E $'s/(\x1b|\\^\\[)\\[[0-9;]*[A-Za-z]//g; s/[[:space:]]+/ /g; s/^ //; s/ $//')
 	if [[ -z "$stripped" ]]; then
 		printf '%s' "no_error_signature_detected"
 		return 0

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -151,7 +151,7 @@ parse_commit_sha_from_subject_url() {
 normalize_signature_line() {
 	local raw_line="$1"
 	local stripped
-	stripped=$(printf '%s' "$raw_line" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g; s/\^\[\[[0-9;]*[A-Za-z]//g')
+	stripped=$(printf '%s' "$raw_line" | sed -E 's/(\x1B|\^\[)\[[0-9;]*[A-Za-z]//g')
 	stripped=$(printf '%s' "$stripped" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
 	if [[ -z "$stripped" ]]; then
 		printf '%s' "no_error_signature_detected"

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -81,6 +81,9 @@ assert_equals "GH#26308 caret-escaped ANSI comment-only signature normalizes emp
 signature=$(normalize_signature_line $'^[[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.^[[0m')
 assert_equals "GH#26308 caret-escaped ANSI is stripped during normalization" "# rate-limit grace is disabled — they cannot merge on rate-limit-only." "$signature"
 
+signature=$(normalize_signature_line $'\033[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.\033[0m')
+assert_equals "GH#26308 raw ANSI is stripped during normalization" "# rate-limit grace is disabled — they cannot merge on rate-limit-only." "$signature"
+
 printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then
 	exit 1


### PR DESCRIPTION
## Summary
- Combined the ANSI and caret-escaped ANSI signature stripping in `.agents/scripts/gh-failure-miner-helper.sh` into one sed alternation.
- Preserved existing normalization behavior covered by signature-noise tests.

Resolves #26437

## Testing
- `shellcheck .agents/scripts/gh-failure-miner-helper.sh`
- `.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 56,105 tokens on this as a headless worker.