### PR TITLE
test: harden pulse fallback resolver test

### DIFF
--- a/.agents/scripts/tests/test-approve-kicks-pulse.sh
+++ b/.agents/scripts/tests/test-approve-kicks-pulse.sh
@@ -448,6 +448,7 @@ resolver_result=$(
 (
 	# shellcheck disable=SC1091
 	source "${PARENT_DIR}/pulse-wrapper-bootstrap.sh" >/dev/null 2>&1
+	unset -f gh_pr_list
 
 	gh() {
 		local cmd="${1:-}"


### PR DESCRIPTION
## Summary
- Added an explicit `unset -f gh_pr_list` in Test 9 after sourcing `pulse-wrapper-bootstrap.sh`.
- Keeps the raw `gh pr list` fallback assertion hermetic when wrapper definitions leak from bootstrap or the environment.

## Testing
- `shellcheck .agents/scripts/tests/test-approve-kicks-pulse.sh`
- `.agents/scripts/tests/test-approve-kicks-pulse.sh`

MERGE_SUMMARY: Hardened the pulse linked-PR fallback resolver test by ensuring Test 9 removes any inherited `gh_pr_list` wrapper before exercising the raw `gh` fallback.

Resolves #26428

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 38,392 tokens on this as a headless worker.
