### PR TITLE
GH#26440: docs: qualify UI brief reference paths

### DIFF
--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -239,8 +239,8 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
       it helps the worker choose the right pattern: repo `DESIGN.md` status/path;
       relevant rule or canonical example; similar-but-different alternatives that
       were considered and why they do/do not apply; and responsive/accessibility
-      evidence expected. Reference `tools/design/design-md.md` and
-      `workflows/ui-verification.md` instead of expanding a mandatory design essay. -->
+      evidence expected. Reference `.agents/tools/design/design-md.md` and
+      `.agents/workflows/ui-verification.md` instead of expanding a mandatory design essay. -->
 
 ### Progressive Context Plan
 


### PR DESCRIPTION
## Summary

Updated the UI/UX brief-template references so design-md and ui-verification paths include the .agents/ prefix expected by worker context.

## Files Changed

.agents/templates/brief-template.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 .agents/templates/brief-template.md

Resolves #26440


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 39,583 tokens on this as a headless worker.