### PR TITLE
fix: guard contrast readiness waits

### DIFF
--- a/.agents/scripts/accessibility/playwright-contrast.mjs
+++ b/.agents/scripts/accessibility/playwright-contrast.mjs
@@ -230,8 +230,22 @@ function formatMarkdown(results, level) {
 async function waitForPageReady(page, timeout) {
   await page.waitForLoadState('load', { timeout });
   await page.evaluate(async () => {
-    if (document.fonts?.ready) await document.fonts.ready;
-    await new Promise((resolve) => requestAnimationFrame(resolve));
+    if (document.fonts?.ready) {
+      await Promise.race([
+        document.fonts.ready,
+        new Promise((resolve) => setTimeout(resolve, 2000)),
+      ]);
+    }
+    await new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      requestAnimationFrame(finish);
+      setTimeout(finish, 100);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- Added bounded fallback waits for `document.fonts.ready` and `requestAnimationFrame` in `.agents/scripts/accessibility/playwright-contrast.mjs`.
- Prevents the contrast helper from hanging indefinitely when fonts stall or animation frames are throttled in headless/browser-background conditions.

## Testing
- `node --check .agents/scripts/accessibility/playwright-contrast.mjs`

Resolves #26424

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 47,643 tokens on this as a headless worker.