### PR TITLE
fix: guard contrast readiness waits

### DIFF
--- a/.agents/scripts/accessibility/playwright-contrast.mjs
+++ b/.agents/scripts/accessibility/playwright-contrast.mjs
@@ -231,20 +231,28 @@ async function waitForPageReady(page, timeout) {
   await page.waitForLoadState('load', { timeout });
   await page.evaluate(async () => {
     if (document.fonts?.ready) {
+      let timeoutId;
       await Promise.race([
         document.fonts.ready,
-        new Promise((resolve) => setTimeout(resolve, 2000)),
+        new Promise((resolve) => {
+          timeoutId = setTimeout(resolve, 2000);
+        }),
       ]);
+      if (timeoutId) clearTimeout(timeoutId);
     }
     await new Promise((resolve) => {
       let settled = false;
+      let frameId;
+      let timeoutId;
       const finish = () => {
         if (settled) return;
         settled = true;
+        if (frameId) cancelAnimationFrame(frameId);
+        if (timeoutId) clearTimeout(timeoutId);
         resolve();
       };
-      requestAnimationFrame(finish);
-      setTimeout(finish, 100);
+      frameId = requestAnimationFrame(finish);
+      timeoutId = setTimeout(finish, 100);
     });
   });
 }

--- a/.agents/scripts/accessibility/playwright-contrast.mjs
+++ b/.agents/scripts/accessibility/playwright-contrast.mjs
@@ -230,8 +230,22 @@ function formatMarkdown(results, level) {
 async function waitForPageReady(page, timeout) {
   await page.waitForLoadState('load', { timeout });
   await page.evaluate(async () => {
-    if (document.fonts?.ready) await document.fonts.ready;
-    await new Promise((resolve) => requestAnimationFrame(resolve));
+    if (document.fonts?.ready) {
+      await Promise.race([
+        document.fonts.ready,
+        new Promise((resolve) => setTimeout(resolve, 2000)),
+      ]);
+    }
+    await new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      requestAnimationFrame(finish);
+      setTimeout(finish, 100);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- Preserved the prior bounded waits for `document.fonts.ready` and `requestAnimationFrame` in `.agents/scripts/accessibility/playwright-contrast.mjs`.
- Cleaned up fallback timers and animation-frame handles after readiness settles, addressing the follow-up bot feedback from closed PR #26450.

## Testing
- `node --check .agents/scripts/accessibility/playwright-contrast.mjs`

Resolves #26424

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13
