### PR TITLE
GH#26452: test: harden email helper portability scan

### DIFF
--- a/tests/test-email-agent-helper.sh
+++ b/tests/test-email-agent-helper.sh
@@ -305,8 +305,13 @@ test_code_extraction_patterns_are_portable() {
 
 	local pcre_flag="grep -o""P"
 	local whitespace_escape='\\['"s"']'
+	local files=("${BASH_SOURCE[0]}")
 	local matches
-	matches=$(grep -nE "${pcre_flag}|${whitespace_escape}" "${BASH_SOURCE[0]}" "$HELPER" || true)
+
+	if [[ -n "${HELPER:-}" && -f "$HELPER" ]]; then
+		files+=("$HELPER")
+	fi
+	matches=$(grep -nE "${pcre_flag}|${whitespace_escape}" "${files[@]}" || true)
 
 	assert_eq "No GNU-only grep PCRE flag or PCRE whitespace escapes" "" "$matches"
 	return 0


### PR DESCRIPTION
## Summary

Guarded the portability scan against unset or missing HELPER by building a files array from the test script and appending the helper path only when it is set and exists.

## Files Changed

tests/test-email-agent-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-email-agent-helper.sh; shellcheck tests/test-email-agent-helper.sh

Resolves #26452


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 48,822 tokens on this as a headless worker.