### PR TITLE
Resolves #26455: test simplification issue count return

### DIFF
--- a/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
@@ -16,6 +16,7 @@ TMP=$(mktemp -d "${TMPDIR:-/tmp}/t-sweep-nmr.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
 CREATE_CALLS="${TMP}/create-calls.log"
+COUNT_FILE="${TMP}/created-count.txt"
 LOGFILE="${TMP}/pulse.log"
 export LOGFILE
 
@@ -95,7 +96,8 @@ JSON
 
 printf '\n[a] trusted repo writer skips NMR\n'
 true >"$CREATE_CALLS"
-qlty_section=""
+true >"$COUNT_FILE"
+qlty_section="caller-owned-section"
 _gh_current_user_allows_repo_write() {
 	AIDEVOPS_GH_WRITE_PERMISSION_USER="maintainer"
 	AIDEVOPS_GH_WRITE_PERMISSION_LEVEL="admin"
@@ -103,27 +105,48 @@ _gh_current_user_allows_repo_write() {
 	export AIDEVOPS_GH_WRITE_PERMISSION_USER AIDEVOPS_GH_WRITE_PERMISSION_LEVEL AIDEVOPS_GH_WRITE_PERMISSION_REASON
 	return 0
 }
-_create_simplification_issues "test/repo" "$(make_sarif)"
+_create_simplification_issues "test/repo" "$(make_sarif)" >"$COUNT_FILE"
 if grep -q -- '--label needs-maintainer-review' "$CREATE_CALLS" 2>/dev/null; then
 	fail "trusted-writer-no-nmr-label" "unexpected NMR label: $(cat "$CREATE_CALLS")"
 else
 	pass "trusted-writer-no-nmr-label"
 fi
+if [[ "$(<"$COUNT_FILE")" == "1" ]]; then
+	pass "simplification-count-stdout"
+else
+	fail "simplification-count-stdout" "expected count 1, got: $(<"$COUNT_FILE")"
+fi
+if [[ "$qlty_section" == "caller-owned-section" ]]; then
+	pass "simplification-no-caller-qlty-section-mutation"
+else
+	fail "simplification-no-caller-qlty-section-mutation" "caller qlty_section mutated to: $qlty_section"
+fi
 
 printf '\n[b] unverified identity keeps NMR\n'
 true >"$CREATE_CALLS"
-qlty_section=""
+true >"$COUNT_FILE"
+qlty_section="caller-owned-section"
 unset AIDEVOPS_GH_WRITE_PERMISSION_USER AIDEVOPS_GH_WRITE_PERMISSION_LEVEL AIDEVOPS_GH_WRITE_PERMISSION_REASON
 _gh_current_user_allows_repo_write() {
 	AIDEVOPS_GH_WRITE_PERMISSION_REASON="permission-lookup-failed:api-failure"
 	export AIDEVOPS_GH_WRITE_PERMISSION_REASON
 	return 1
 }
-_create_simplification_issues "test/repo" "$(make_sarif)"
+_create_simplification_issues "test/repo" "$(make_sarif)" >"$COUNT_FILE"
 if grep -q -- '--label needs-maintainer-review' "$CREATE_CALLS" 2>/dev/null; then
 	pass "unverified-keeps-nmr-label"
 else
 	fail "unverified-keeps-nmr-label" "missing NMR label: $(cat "$CREATE_CALLS")"
+fi
+if [[ "$(<"$COUNT_FILE")" == "1" ]]; then
+	pass "unverified-count-stdout"
+else
+	fail "unverified-count-stdout" "expected count 1, got: $(<"$COUNT_FILE")"
+fi
+if [[ "$qlty_section" == "caller-owned-section" ]]; then
+	pass "unverified-no-caller-qlty-section-mutation"
+else
+	fail "unverified-no-caller-qlty-section-mutation" "caller qlty_section mutated to: $qlty_section"
 fi
 
 export HOME="$ORIGINAL_HOME"

--- a/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
@@ -116,10 +116,10 @@ if [[ "$(<"$COUNT_FILE")" == "1" ]]; then
 else
 	fail "simplification-count-stdout" "expected count 1, got: $(<"$COUNT_FILE")"
 fi
-if [[ "$qlty_section" == "caller-owned-section" ]]; then
+if [[ "${qlty_section:-}" == "caller-owned-section" ]]; then
 	pass "simplification-no-caller-qlty-section-mutation"
 else
-	fail "simplification-no-caller-qlty-section-mutation" "caller qlty_section mutated to: $qlty_section"
+	fail "simplification-no-caller-qlty-section-mutation" "caller qlty_section mutated to: ${qlty_section:-<unset>}"
 fi
 
 printf '\n[b] unverified identity keeps NMR\n'
@@ -143,10 +143,10 @@ if [[ "$(<"$COUNT_FILE")" == "1" ]]; then
 else
 	fail "unverified-count-stdout" "expected count 1, got: $(<"$COUNT_FILE")"
 fi
-if [[ "$qlty_section" == "caller-owned-section" ]]; then
+if [[ "${qlty_section:-}" == "caller-owned-section" ]]; then
 	pass "unverified-no-caller-qlty-section-mutation"
 else
-	fail "unverified-no-caller-qlty-section-mutation" "caller qlty_section mutated to: $qlty_section"
+	fail "unverified-no-caller-qlty-section-mutation" "caller qlty_section mutated to: ${qlty_section:-<unset>}"
 fi
 
 export HOME="$ORIGINAL_HOME"


### PR DESCRIPTION
## Summary
- Added regression coverage that captures _create_simplification_issues stdout into a count file.
- Asserted the helper leaves the caller-owned qlty_section unchanged for trusted and unverified identities.

## Testing
- bash .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
- shellcheck .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh

Resolves #26455
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 41,279 tokens on this as a headless worker.