### PR TITLE
Resolves #26427: align knowledge-plane review followup

### DIFF
--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -73,7 +73,7 @@ Each ingested source should have a `meta.json` alongside its content in `sources
   "sha256": "hex-hash-of-original-file",
   "ingested_at": "2026-04-25T00:00:00Z",
   "ingested_by": "agent-or-username",
-  "sensitivity": "public|internal|confidential|restricted",
+  "sensitivity": "public|internal|pii|sensitive|privileged",
   "trust": "unverified|reviewed|trusted|authoritative",
   "blob_path": null,
   "size_bytes": 12345
@@ -108,7 +108,7 @@ Written at provision time from `.agents/templates/knowledge-config.json`:
   "trust_default": "unverified",
   "blob_threshold_bytes": 31457280,
   "trust_ladder": ["unverified", "reviewed", "trusted", "authoritative"],
-  "sensitivity_levels": ["public", "internal", "confidential", "restricted"],
+  "sensitivity_levels": ["public", "internal", "pii", "sensitive", "privileged"],
   "ingest_policy": {
     "auto_sha256": true,
     "require_meta": true

--- a/.agents/aidevops/knowledge-plane/02-email-sources.md
+++ b/.agents/aidevops/knowledge-plane/02-email-sources.md
@@ -186,6 +186,11 @@ Field reference:
 
 `password_ref` supports two forms:
 
+1. A `gopass:<path>` reference, which resolves the password from gopass. This is
+   strongly preferred because the secret stays in the encrypted password store.
+2. An environment variable name containing the password. This is permitted for
+   constrained automation, but is less secure and discouraged for production use.
+
 ## Email Thread Reconstruction (t2856)
 
 Email sources with `"kind": "email"` support JWZ-style thread reconstruction.


### PR DESCRIPTION
## Summary

- Aligns knowledge-plane sensitivity examples with active tiers: public, internal, pii, sensitive, privileged.
- Completes email password_ref credential-resolution guidance and documents gopass as the strongly preferred option.

Resolves #26427

## Testing

- npx --yes markdownlint-cli2 .agents/aidevops/knowledge-plane/01-core-contract.md .agents/aidevops/knowledge-plane/02-email-sources.md

MERGE_SUMMARY: Aligned knowledge-plane sensitivity documentation with active policy tiers and completed email credential-resolution guidance; verified with markdownlint-cli2.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 39,480 tokens on this as a headless worker.
