### PR TITLE
fix: simplify wrapper sentinel lookup

### DIFF
--- a/.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh
+++ b/.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh
@@ -27,13 +27,7 @@ if [[ ! -f "$HELPER" ]]; then
 fi
 
 helper_content=$(<"$HELPER")
-wrapper_started_line=""
-while IFS= read -r line; do
-	if [[ "$line" == *"WRAPPER_STARTED"* ]]; then
-		wrapper_started_line="$line"
-		break
-	fi
-done <"$HELPER"
+wrapper_started_line=$(grep -F "WRAPPER_STARTED" "$HELPER" | tail -n 1 || true)
 
 # shellcheck disable=SC2016 # literal generated wrapper line; variables expand in the generated wrapper, not in this test.
 sentinel_line='echo "WRAPPER_STARTED task_id=${task_id} wrapper_pid=\$\$ host=${host} timestamp=\$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${remote_log_file}" || true'


### PR DESCRIPTION
## Summary

- Replaces the manual `while read` scan in `.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh` with a fixed-string `grep` pipeline.
- Uses `tail -n 1` so the test checks the last generated `WRAPPER_STARTED` line if multiple matches exist.

## Testing

- `shellcheck .agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh`
- `.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh`

Resolves #26425

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 87,269 tokens on this as a headless worker.