### PR TITLE
GH#3202: fix: validate urbit post payload shape

### DIFF
--- a/.agents/services/communications/urbit.md
+++ b/.agents/services/communications/urbit.md
@@ -81,9 +81,20 @@ sse.listen({
     fetch(channelUrl, { method: "PUT", headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify([{ id: Date.now(), action: "ack", "event-id": data.id }]) })
     const nodes = data.json?.["add-nodes"]?.nodes ?? {}
-    for (const node of Object.values(nodes) as any[]) {
-      const author = node?.post?.author
-      const text = (node?.post?.contents ?? []).filter((c: any) => c.text).map((c: any) => c.text).join(" ")
+    for (const node of Object.values(nodes) as unknown[]) {
+      if (!node || typeof node !== "object") continue
+      const post = (node as Record<string, unknown>).post
+      if (!post || typeof post !== "object") continue
+      const postObj = post as Record<string, unknown>
+      if (typeof postObj.author !== "string") continue
+      if (!Array.isArray(postObj.contents)) continue
+      const author = postObj.author
+      const text = postObj.contents
+        .filter((c): c is { text: string } => {
+          return !!c && typeof c === "object" && typeof (c as { text?: unknown }).text === "string"
+        })
+        .map((c) => c.text)
+        .join(" ")
       if (author && author !== SHIP_NAME) console.log(`~${author}: ${text}`)
     }
   },


### PR DESCRIPTION
## Summary

Validated Urbit graph-store post payloads before reading author and filtering contents so malformed posts are skipped safely.

## Files Changed

.agents/services/communications/urbit.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/services/communications/urbit.md passed. .agents/scripts/linters-local.sh reached Secretlint and exceeded bounded 240s after earlier gates passed/only existing Qlty advisory smells.

Resolves #3202


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 8m and 39,088 tokens on this as a headless worker.