### PR TITLE
fix: unify GUI app loading screen

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -267,6 +267,7 @@ Core component rules:
 - Use a rounded black square with subtle cyan glow, a cyan ring at low opacity, and `#8ce8ff` prompt glyph fill.
 - Prompt glyph placement follows the current website asset: `translate(512 522) scale(0.94) translate(-288 -256)` inside a `1024x1024` SVG viewBox.
 - Icon SVGs should include accessible names when they are content-bearing; decorative duplicates should be hidden from assistive technology.
+- The desktop app launch path should show one branded loading treatment: defer native WebKit startup to the web loading shell and keep the React loading skeleton visually identical so users do not see multiple distinct loading screens.
 
 ## Design capture during harness sessions
 

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -457,7 +457,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     private var webView: WKWebView!
     private let apiPort = ProcessInfo.processInfo.environment["AIDEVOPS_GUI_API_PORT"] ?? "8787"
     private let webPort = ProcessInfo.processInfo.environment["AIDEVOPS_GUI_WEB_PORT"] ?? "5173"
-    private let defaultAccentHue: CGFloat = 123
+    private let defaultAccentHue: CGFloat = 191
     private let mainWindowFrameAutosaveName = "aidevops-main-window"
     private let titlebarHeight: CGFloat = 24
     private let serviceQueue = DispatchQueue(label: "sh.aidevops.gui.services")
@@ -467,7 +467,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     func applicationDidFinishLaunching(_ notification: Notification) {
         configureMenu()
         configureWindow()
-        loadStatusHTML(title: "Starting aidevops", detail: "Preparing the local read-only GUI services…")
         startServicesAndLoadApp()
     }
 
@@ -1342,7 +1341,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             .status { align-items: center; display: flex; gap: 10px; grid-column: 1 / -1; justify-content: center; padding: 0 12px; }
             .status i { border-radius: 999px; height: 8px; width: 8px; }
             .status span { height: 10px; width: 96px; }
-            .rail i, .sidebar b, .sidebar span, .sidebar i, .workspace b, .workspace span, .workspace i, .cards i, .block, .status i, .status span { animation: pulse 1.35s ease-in-out infinite; background: linear-gradient(90deg, #202020, hsl(123 74% 66% / 16%), #202020); background-size: 220% 100%; border: 1px solid var(--border); border-radius: 999px; display: block; }
+            .rail i, .sidebar b, .sidebar span, .sidebar i, .workspace b, .workspace span, .workspace i, .cards i, .block, .status i, .status span { animation: pulse 1.35s ease-in-out infinite; background: linear-gradient(90deg, #202020, rgb(102 217 242 / 16%), #202020); background-size: 220% 100%; border: 1px solid var(--border); border-radius: 999px; display: block; }
             .block, .cards i { border-radius: 18px; }
             @keyframes pulse { 0% { background-position: 120% 0; opacity: .52; } 50% { opacity: .95; } 100% { background-position: -120% 0; opacity: .52; } }
             @keyframes cursor { 0%, 48% { opacity: 1; } 49%, 100% { opacity: 0; } }
@@ -1396,6 +1395,7 @@ write_app_bundle() {
   version="$(app_version "$root")"
 
   mkdir -p "$macos_dir" "$resources_dir"
+  rm -f "${resources_dir}/aidevops.icns" "${resources_dir}/aidevops.svg"
   cat > "${contents_dir}/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
@@ -1420,6 +1420,8 @@ PLIST
   write_service_helper "$root" "$resources_dir"
   write_webview_source "$resources_dir"
   compile_webview_app "$resources_dir" "$macos_dir"
+  touch "${resources_dir}/aidevops.icns" "${contents_dir}/Info.plist" "$app_path"
+  qlmanage -r cache >/dev/null 2>&1 || true
   printf 'Installed %s\n' "$app_path"
   return 0
 }

--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -35,11 +35,24 @@ export const appearanceStorageKeys = {
   theme: "aidevops-gui-theme",
 } as const;
 
+function AidevopsLoadingIcon(): ReactElement {
+  return (
+    <svg className="loading-brand-icon" viewBox="0 0 1024 1024" role="img" aria-label="AI DevOps prompt icon">
+      <rect x="88" y="88" width="848" height="848" rx="188" fill="#000000" />
+      <rect x="88" y="88" width="848" height="848" rx="188" fill="#66d9f2" opacity="0.22" />
+      <rect x="116" y="116" width="792" height="792" rx="160" fill="none" stroke="#66d9f2" strokeOpacity="0.36" strokeWidth="18" />
+      <g transform="translate(512 522) scale(0.94) translate(-288 -256)">
+        <path fill="#8ce8ff" d="M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z" />
+      </g>
+    </svg>
+  );
+}
+
 const defaultSidebarWidth = 302;
 const minSidebarWidth = 300;
 const maxSidebarWidth = 520;
 export const loadingSkeletonPanelLabels = ["machine rail", "sidebar", "workspace", "status bar"] as const;
-export const loadingBrandGlyph = ">_";
+export const loadingBrandGlyph = "AI DevOps prompt icon";
 const loadingMachineOrbKeys = ["machine-orb-a", "machine-orb-b", "machine-orb-c", "machine-orb-d", "machine-orb-e", "machine-orb-f"] as const;
 const loadingListRows = [
   { key: "loading-list-a", variant: "short" },
@@ -323,6 +336,7 @@ function LoadingBrandOverlay(): ReactElement {
   return (
     <div className="loading-brand-overlay" aria-label="Starting aidevops" role="status">
       <span className="loading-brand-mark" aria-hidden="true">
+        <AidevopsLoadingIcon />
         <span className="loading-brand-word">aidevops</span>
         <span className="loading-brand-chevron">&gt;</span>
         <span className="loading-brand-cursor">_</span>

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -453,7 +453,7 @@ describe("dashboard shell", () => {
 
   test("keeps the loading skeleton aligned to the shell landmarks", () => {
     expect(loadingSkeletonPanelLabels).toEqual(["machine rail", "sidebar", "workspace", "status bar"]);
-    expect(loadingBrandGlyph).toBe(">_");
+    expect(loadingBrandGlyph).toBe("AI DevOps prompt icon");
   });
 
   test("wires desktop screenshot capture controls to native save notifications", () => {
@@ -489,10 +489,22 @@ describe("dashboard shell", () => {
     const css = readFileSync(`${guiWebRoot}/src/styles.css`, "utf8");
 
     expect(html).toContain("loading-brand-overlay");
+    expect(html).toContain("loading-brand-icon");
+    expect(html).toContain("#8ce8ff");
     expect(html).toContain("loading-cursor-blink");
     expect(html).toContain("aidevops-gui-theme");
     expect(html).toContain("app-loading-shell");
     expect(css).toMatch(/font-family:\s*var\(--font-family-app\);/);
+  });
+
+  test("desktop wrapper defers to the web loading shell and refreshes app icon metadata", () => {
+    const desktopInstaller = readFileSync(`${guiWebRoot}/../gui-desktop/scripts/install-macos-app.sh`, "utf8");
+
+    expect(desktopInstaller).not.toContain('loadStatusHTML(title: "Starting aidevops"');
+    expect(desktopInstaller).toContain('viewBox="0 0 1024 1024" role="img" aria-labelledby="title desc"');
+    expect(desktopInstaller).toContain('rm -f "${resources_dir}/aidevops.icns" "${resources_dir}/aidevops.svg"');
+    expect(desktopInstaller).toContain('touch "${resources_dir}/aidevops.icns" "${contents_dir}/Info.plist" "$app_path"');
+    expect(desktopInstaller).toContain("qlmanage -r cache");
   });
 
   test("maps command palette single-key shortcuts", () => {


### PR DESCRIPTION
## Summary
- Remove the native WebKit startup loading page so the desktop app defers to the single web loading shell.
- Update the React loading overlay to use the approved cyan prompt icon, matching the pre-hydration shell.
- Refresh generated app icon metadata during macOS app install so local `aidevops.app` reopens with the latest icon.
- Document the one-loading-screen preference in `DESIGN.md`.

Resolves #26471

## Verification
- `npm run typecheck` — pass
- `npm run gui:test:components` — 32 pass
- `npm run gui:desktop:check` — pass
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh` — pass
- `git diff --check` — pass
- `.agents/scripts/version-manager.sh validate` — pass
- temp app install to `/var/.../opencode/aidevops-app-install-test` — pass; generated `aidevops.icns` and `aidevops.svg`
- `.agents/scripts/linters-local.sh` — partial: passed through Bash 3.2 compatibility; timed out during shell portability after 300s, with only advisory ratchet warnings before timeout

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.35 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1h 8m and 816,000 tokens on this with the user in an interactive session.
