### PR TITLE
GH#26477: test: harden email helper path check

### DIFF
--- a/tests/test-email-agent-helper.sh
+++ b/tests/test-email-agent-helper.sh
@@ -308,8 +308,8 @@ test_code_extraction_patterns_are_portable() {
 	local files=("${BASH_SOURCE[0]}")
 	local matches
 
-	if [[ -n "${HELPER:-}" && -f "$HELPER" ]]; then
-		files+=("$HELPER")
+	if [[ -f "${HELPER:-}" ]]; then
+		files+=("${HELPER:-}")
 	fi
 	matches=$(grep -nE "${pcre_flag}|${whitespace_escape}" "${files[@]}" || true)
 


### PR DESCRIPTION
## Summary
- Resolves #26477
- Hardens the email helper portability test by using `${HELPER:-}` directly in the `-f` check.
- Avoids an unbound-variable risk under `set -u` while preserving the existing file list behavior.

## Testing
- `shellcheck tests/test-email-agent-helper.sh`
- `bash tests/test-email-agent-helper.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.36 plugin for [OpenCode](https://opencode.ai) v1.17.13
