### PR TITLE
fix: separate gui brand icon styles

### DIFF
--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -579,7 +579,6 @@ code {
   letter-spacing: -0.05em;
 }
 
-.brand-icon,
 .terminal-mark {
   align-items: center;
   background: color-mix(in srgb, var(--accent) 15%, #0a0a0a);
@@ -601,6 +600,8 @@ code {
   display: block;
   flex: 0 0 auto;
   filter: drop-shadow(0 8px 18px rgb(0 0 0 / 24%));
+  height: 44px;
+  width: 44px;
 }
 
 .brand-icon-bg {


### PR DESCRIPTION
## Summary
- Separated `.terminal-mark` from `.brand-icon` so the SVG brand icon no longer inherits terminal badge layout/background/border rules.
- Preserved the brand icon rendered size with explicit `height` and `width` in the `.brand-icon` block.

Resolves #26475

## Testing
- `npm run gui:build` (blocked: `bun` is not installed in the worker environment)
- `npm run gui:test:components` (blocked: `bun` is not installed in the worker environment)

MERGE_SUMMARY: Separated the GUI terminal mark and brand icon CSS rules, keeping the terminal badge styling scoped to `.terminal-mark` and explicitly sizing `.brand-icon` to preserve the current visual layout. Verification was attempted with GUI build and component tests but could not run because `bun` is not installed in the worker environment.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.36 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 32,124 tokens on this as a headless worker.
