### PR TITLE
GH#26476: fix: guard wrapper sentinel lookup

### DIFF
--- a/.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh
+++ b/.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh
@@ -29,6 +29,10 @@ fi
 helper_content=$(<"$HELPER")
 wrapper_started_line=$(grep -F "WRAPPER_STARTED" "$HELPER" | tail -n 1 || true)
 
+if [[ -z "$wrapper_started_line" ]]; then
+	fail "WRAPPER_STARTED line exists in helper script" "$HELPER"
+fi
+
 # shellcheck disable=SC2016 # literal generated wrapper line; variables expand in the generated wrapper, not in this test.
 sentinel_line='echo "WRAPPER_STARTED task_id=${task_id} wrapper_pid=\$\$ host=${host} timestamp=\$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${remote_log_file}" || true'
 


### PR DESCRIPTION
## Summary

Added an explicit empty-result guard for the WRAPPER_STARTED lookup in .agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh so the regression test fails when the sentinel line is missing instead of silently passing.

## Files Changed

.agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh; shellcheck .agents/scripts/tests/test-remote-dispatch-wrapper-sentinel.sh

Resolves #26476


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.36 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 47,349 tokens on this as a headless worker.