### PR TITLE
GH#25896: Reconcile consolidated issues fixed by merged PRs

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -489,6 +489,44 @@ _should_lia() {
 	return 0
 }
 
+#######################################
+# Extract issue numbers from explicit "Supersedes #N" prose.
+#
+# Kept narrow on purpose: the reconciler should only close a consolidated
+# successor when the successor itself declares that it supersedes an issue
+# already fixed by a merged PR. Generic "see #N"/"related #N" prose is not
+# sufficient terminal evidence.
+#
+# Args: $1 = issue body
+# Stdout: newline-delimited issue numbers, deduplicated
+#######################################
+_pir_extract_superseded_issue_nums() {
+	local issue_body="$1"
+	[[ -n "$issue_body" ]] || return 0
+
+	printf '%s' "$issue_body" | \
+		grep -oiE 'supersedes[[:space:]]+#[0-9]+' 2>/dev/null | \
+		grep -oE '[0-9]+' | sort -un
+	return 0
+}
+
+#######################################
+# Lookup the merged PR number for an issue in the OIMP lookup string.
+# Args: $1 = issue number, $2 = oimp lookup string
+# Stdout: first matching PR number or empty
+#######################################
+_pir_lookup_oimp_pr_for_issue() {
+	local issue_num="$1"
+	local oimp_lookup="$2"
+	[[ "$issue_num" =~ ^[0-9]+$ && -n "$oimp_lookup" ]] || return 0
+
+	printf '%s' "$oimp_lookup" \
+		| grep -oE "\|${issue_num}=[0-9]+" 2>/dev/null \
+		| head -1 \
+		| cut -d= -f2
+	return 0
+}
+
 ##############################################
 # t2776: Per-issue action helpers for reconcile_issues_single_pass.
 # Each helper encapsulates the action logic for one reconcile sub-stage.
@@ -614,20 +652,32 @@ _action_rsd_single() {
 #   $3 = verify_helper (path to verify-issue-close-helper.sh)
 #   $4 = oimp_lookup (pipe-delimited |num=pr|...| string from
 #        _build_oimp_lookup_for_slug; may be empty if prefetch failed)
+#   $5 = issue_body (optional; used to close consolidated successors whose
+#        body declares `Supersedes #N` and PR lookup shows #N was fixed)
 # Returns: 0 if closed, 1 otherwise
 #######################################
 _action_oimp_single() {
 	local slug="$1" issue_num="$2" verify_helper="$3"
 	local oimp_lookup="${4:-}"
+	local issue_body="${5:-}"
 
 	# t2985: lookup PR number locally instead of `gh pr list --search`.
 	# Empty lookup → no merged PR found → return 1 (next-cycle retry).
 	local merged_pr_num=""
-	if [[ -n "$oimp_lookup" ]]; then
-		merged_pr_num=$(printf '%s' "$oimp_lookup" \
-			| grep -oE "\|${issue_num}=[0-9]+" 2>/dev/null \
-			| head -1 \
-			| cut -d= -f2) || merged_pr_num=""
+	local close_comment=""
+	merged_pr_num=$(_pir_lookup_oimp_pr_for_issue "$issue_num" "$oimp_lookup") || merged_pr_num=""
+	if [[ -n "$merged_pr_num" && "$merged_pr_num" =~ ^[0-9]+$ ]]; then
+		close_comment="Closing: linked PR #${merged_pr_num} was already merged. Detected by reconcile pass."
+	else
+		local superseded_num=""
+		while IFS= read -r superseded_num; do
+			[[ "$superseded_num" =~ ^[0-9]+$ ]] || continue
+			merged_pr_num=$(_pir_lookup_oimp_pr_for_issue "$superseded_num" "$oimp_lookup") || merged_pr_num=""
+			if [[ -n "$merged_pr_num" && "$merged_pr_num" =~ ^[0-9]+$ ]]; then
+				close_comment="Closing: this consolidated issue supersedes #${superseded_num}, and merged PR #${merged_pr_num} already fixed that superseded issue. Detected by reconcile pass."
+				break
+			fi
+		done < <(_pir_extract_superseded_issue_nums "$issue_body")
 	fi
 	[[ -n "$merged_pr_num" && "$merged_pr_num" =~ ^[0-9]+$ ]] || return 1
 
@@ -644,7 +694,7 @@ _action_oimp_single() {
 	fi
 
 	gh issue close "$issue_num" --repo "$slug" \
-		--comment "Closing: linked PR #${merged_pr_num} was already merged. Detected by reconcile pass." \
+		--comment "$close_comment" \
 		>/dev/null 2>&1 || return 1
 
 	if declare -F fast_fail_reset >/dev/null 2>&1; then

--- a/.agents/scripts/pulse-issue-reconcile-close.sh
+++ b/.agents/scripts/pulse-issue-reconcile-close.sh
@@ -230,7 +230,7 @@ reconcile_open_issues_with_merged_prs() {
 			issues_json=$(printf '%s' "$_cache_issues_oimp" | jq -c '.[0:30]' 2>/dev/null) || issues_json="[]"
 		else
 			issues_json=$(gh_issue_list --repo "$slug" --state open \
-				--json number,title,labels --limit 30 2>/dev/null) || issues_json="[]"
+				--json number,title,labels,body --limit 30 2>/dev/null) || issues_json="[]"
 		fi
 		[[ -n "$issues_json" && "$issues_json" != "$_PIR_NULL" ]] || continue
 
@@ -253,8 +253,9 @@ reconcile_open_issues_with_merged_prs() {
 
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" ]]; do
-			local issue_num
+			local issue_num issue_body
 			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
+			issue_body=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].body // ""' 2>/dev/null) || issue_body=""
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
@@ -264,7 +265,7 @@ reconcile_open_issues_with_merged_prs() {
 
 			# t2776: delegate per-issue action to shared helper (_action_oimp_single).
 			# t2985: pass oimp_lookup as 4th arg.
-			if _action_oimp_single "$slug" "$issue_num" "$verify_helper" "$oimp_lookup"; then
+			if _action_oimp_single "$slug" "$issue_num" "$verify_helper" "$oimp_lookup" "$issue_body"; then
 				total_closed=$((total_closed + 1))
 			fi
 		done

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1405,7 +1405,7 @@ reconcile_issues_single_pass() {
 			# Stage 3: close open issues whose linked PR already merged (global cap)
 			if [[ "$oimp_total_closed" -lt "$oimp_max" ]] && \
 				_should_oimp "$issue_num" "$parent_task_nums"; then
-				if _action_oimp_single "$slug" "$issue_num" "$verify_helper" "$oimp_lookup"; then
+				if _action_oimp_single "$slug" "$issue_num" "$verify_helper" "$oimp_lookup" "$issue_body"; then
 					oimp_total_closed=$((oimp_total_closed + 1))
 					continue
 				fi

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -678,24 +678,71 @@ test_t2985_action_oimp_single_signature() {
 		all_ok=0
 	fi
 
-	# 3. The single-pass call site in RECONCILE_SH passes 4 args (slug, issue,
-	#    verify, lookup). Use grep -E to match the multi-arg form and require
-	#    oimp_lookup at end.
+	# 3. The single-pass call site in RECONCILE_SH passes the lookup and issue
+	#    body. Use grep -E to match the multi-arg form and require both values.
 	# SC2016: single-quoted pattern intentionally contains literal $slug etc. —
 	# grepping for the literal source string, no expansion wanted.
 	local call_count
 	# shellcheck disable=SC2016
-	call_count=$(grep -cE '_action_oimp_single "\$slug" "\$issue_num" "\$verify_helper" "\$oimp_lookup"' \
+	call_count=$(grep -cE '_action_oimp_single "\$slug" "\$issue_num" "\$verify_helper" "\$oimp_lookup" "\$issue_body"' \
 		"${RECONCILE_SH}" 2>/dev/null || true)
 	[[ "$call_count" =~ ^[0-9]+$ ]] || call_count=0
 	if [[ "$call_count" -ge 1 ]]; then
-		_pass "t2985: ${call_count} call site(s) pass oimp_lookup to _action_oimp_single"
+		_pass "t2985: ${call_count} call site(s) pass oimp_lookup and issue_body to _action_oimp_single"
 	else
-		_fail "t2985: expected ≥1 call site passing oimp_lookup, got ${call_count}"
+		_fail "t2985: expected ≥1 call site passing oimp_lookup and issue_body, got ${call_count}"
 		all_ok=0
 	fi
 
 	[[ "$all_ok" == "1" ]] && _pass "t2985: _action_oimp_single signature contract enforced"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 15b (GH#25896): consolidated successor closes when superseded issue was fixed
+# ---------------------------------------------------------------------------
+test_gh25896_oimp_closes_consolidated_successor() {
+	local actions_sh="${SCRIPT_DIR}/../pulse-issue-reconcile-actions.sh"
+	local tmp_dir out_file log_file result
+	tmp_dir=$(mktemp -d)
+	out_file="${tmp_dir}/gh.out"
+	log_file="${tmp_dir}/pulse.log"
+
+	result=$(bash -c '
+		actions_sh="$1"
+		out_file="$2"
+		log_file="$3"
+		LOGFILE="$log_file"
+		export LOGFILE out_file
+		gh() {
+			printf "%s\n" "$*" >>"$out_file"
+			return 0
+		}
+		fast_fail_reset() { return 0; }
+		unlock_issue_after_worker() { return 0; }
+		export -f gh fast_fail_reset unlock_issue_after_worker
+		# shellcheck disable=SC1090
+		source "$actions_sh"
+		_action_oimp_single "test/repo" "25896" "/bin/true" "|25877=25894|" "_Supersedes #25877 — this issue is the consolidated spec._"
+		printf "rc=%s\n" "$?"
+	' -- "$actions_sh" "$out_file" "$log_file" 2>&1)
+
+	local all_ok=1
+	if [[ "$result" != *"rc=0"* ]]; then
+		_fail "GH#25896: consolidated successor action returned unexpected result: ${result}"
+		all_ok=0
+	fi
+	if ! grep -q 'issue close 25896 --repo test/repo' "$out_file" 2>/dev/null; then
+		_fail "GH#25896: expected close of consolidated successor #25896"
+		all_ok=0
+	fi
+	if ! grep -q 'supersedes #25877, and merged PR #25894 already fixed' "$out_file" 2>/dev/null; then
+		_fail "GH#25896: close comment did not cite superseded issue and merged PR evidence"
+		all_ok=0
+	fi
+
+	rm -rf "$tmp_dir"
+	[[ "$all_ok" == "1" ]] && _pass "GH#25896: OIMP closes consolidated successor using Supersedes #N merged-PR evidence"
 	return 0
 }
 
@@ -878,6 +925,7 @@ test_t2985_oimp_lookup_builder
 test_gh22802_oimp_lookup_requires_merged_at
 test_t2985_oimp_lookup_no_prefix_collision
 test_t2985_action_oimp_single_signature
+test_gh25896_oimp_closes_consolidated_successor
 test_available_feedback_worker_issue_not_assigned
 test_feedback_backfill_uses_label_constants
 


### PR DESCRIPTION
## Summary

Teach pulse issue reconciliation to close consolidated successor issues when their body explicitly says `Supersedes #N` and a merged PR already resolved that superseded issue. This uses #25896 as the regression example so workers do not redispatch stale consolidated work after the original issue was fixed.

## Files Changed

- `.agents/scripts/pulse-issue-reconcile-actions.sh`
  - Adds narrow `Supersedes #N` extraction and OIMP lookup helper.
  - Extends `_action_oimp_single` to close consolidated successors using merged-PR evidence from the superseded issue.
- `.agents/scripts/pulse-issue-reconcile-close.sh`
  - Includes issue body in standalone OIMP reconciliation and passes it to the action helper.
- `.agents/scripts/pulse-issue-reconcile.sh`
  - Passes issue body from the single-pass reconciler into `_action_oimp_single`.
- `.agents/scripts/tests/test-pulse-issue-reconcile.sh`
  - Adds GH#25896 regression coverage: issue #25896 supersedes #25877, lookup maps #25877 to merged PR #25894, and the action closes #25896 with evidence.

## Verification

Passed:

```bash
bash .agents/scripts/tests/test-pulse-issue-reconcile.sh
shellcheck .agents/scripts/pulse-issue-reconcile-actions.sh .agents/scripts/pulse-issue-reconcile-close.sh .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/tests/test-pulse-issue-reconcile.sh
git diff --check
```

Broad local linter note:

```bash
.agents/scripts/linters-local.sh
```

Completed Sonar, Qlty advisory, string-literal ratchet, lock guard, Secretlint, Markdown advisory, TOON, skill frontmatter, secret-safety policy, pulse canary, ratchets advisory, repo-layout, and Bash 3.2 compatibility. It timed out after 10 minutes during the later shell-portability phase, so targeted ShellCheck and Bash 3.2 compatibility are the blocking shell evidence for this PR.

Resolves #25896

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.38 plugin for [OpenCode](https://opencode.ai) v1.17.13
