### PR TITLE
fix: respect OAuth cooldowns in model availability

### DIFF
--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -79,6 +79,105 @@ _probe_return_cached() {
 	esac
 }
 
+_probe_has_static_auth_for_provider() {
+	local provider="$1"
+	local key_vars
+	key_vars=$(get_provider_key_vars "$provider" 2>/dev/null) || key_vars=""
+	[[ -n "$key_vars" ]] || return 1
+
+	local -a var_names
+	local var_name
+	IFS=',' read -r -a var_names <<<"$key_vars"
+	for var_name in "${var_names[@]}"; do
+		if [[ -n "${!var_name:-}" ]]; then
+			return 0
+		fi
+	done
+
+	if command -v gopass >/dev/null 2>&1; then
+		for var_name in "${var_names[@]}"; do
+			if gopass show "aidevops/${var_name}" >/dev/null 2>&1; then
+				return 0
+			fi
+		done
+	fi
+
+	local creds_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$creds_file" ]]; then
+		# shellcheck disable=SC1090
+		source "$creds_file"
+		for var_name in "${var_names[@]}"; do
+			if [[ -n "${!var_name:-}" ]]; then
+				return 0
+			fi
+		done
+	fi
+
+	return 1
+}
+
+_probe_format_cooldown_until() {
+	local cooldown_ms="$1"
+	local cooldown_s=$((cooldown_ms / 1000))
+	local formatted=""
+
+	formatted=$(date -u -r "$cooldown_s" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)
+	if [[ -z "$formatted" ]]; then
+		formatted=$(date -u -d "@${cooldown_s}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)
+	fi
+	if [[ -z "$formatted" ]]; then
+		formatted="${cooldown_ms}ms"
+	fi
+
+	printf '%s\n' "$formatted"
+	return 0
+}
+
+# Check OAuth pool cooldowns before cached health can mask them.
+# Returns: 0=no blocking cooldown, 2=all usable OAuth pool accounts cooling.
+_probe_oauth_pool_cooldown_gate() {
+	local provider="$1"
+	local quiet="${2:-false}"
+	local pool_file="${MODEL_AVAILABILITY_OAUTH_POOL_FILE:-${HOME}/.aidevops/oauth-pool.json}"
+
+	# Static API key paths are independent of OpenCode OAuth pool cooldowns.
+	if _probe_has_static_auth_for_provider "$provider"; then
+		return 0
+	fi
+	[[ -f "$pool_file" ]] || return 0
+	command -v jq >/dev/null 2>&1 || return 0
+
+	local now_ms counts total available limited _auth_errors min_cooldown
+	now_ms=$(($(date +%s) * 1000))
+	counts=$(jq -r --arg provider "$provider" --argjson now "$now_ms" '
+		def n: tonumber? // 0;
+		(.[$provider] // []) as $accounts
+		| ($accounts | length) as $total
+		| if $total == 0 then
+			[0, -1, 0, 0, 0]
+		else
+			($accounts | map(select((.status // "") == "auth-error")) | length) as $auth
+			| ($accounts | map(select((.status // "") == "rate-limited" and (((.cooldownUntil // 0) | n) > $now)))) as $limited_accounts
+			| ($limited_accounts | length) as $limited
+			| ($accounts | map(select(((.status // "") != "auth-error") and (((.status // "") != "rate-limited") or (((.cooldownUntil // 0) | n) <= $now)))) | length) as $available
+			| ($limited_accounts | map((.cooldownUntil // 0) | n) | min // 0) as $min_cooldown
+			| [$total, $available, $limited, $auth, $min_cooldown]
+		end
+		| @tsv
+	' "$pool_file" 2>/dev/null) || counts="0 -1 0 0 0"
+	read -r total available limited _auth_errors min_cooldown <<<"$counts"
+
+	if [[ "${total:-0}" -gt 0 && "${available:--1}" -eq 0 && "${limited:-0}" -gt 0 ]]; then
+		local until_text
+		until_text=$(_probe_format_cooldown_until "${min_cooldown:-0}")
+		[[ "$quiet" != "true" ]] && print_warning "$provider: rate-limited until $until_text"
+		_record_health "$provider" "rate_limited" 429 0 "OAuth pool cooldown active until $until_text" 0
+		return 2
+	fi
+
+	return 0
+}
+
 # Probe the OpenCode meta-provider via its local models cache (no API key needed).
 # Returns: 0=healthy, 1=unhealthy
 _probe_opencode() {
@@ -610,6 +709,12 @@ probe_provider() {
 	local force="${2:-false}"
 	local custom_ttl="${3:-}"
 	local quiet="${4:-false}"
+
+	local oauth_pool_exit=0
+	_probe_oauth_pool_cooldown_gate "$provider" "$quiet" || oauth_pool_exit=$?
+	if [[ "$oauth_pool_exit" -eq 2 ]]; then
+		return 2
+	fi
 
 	# Return cached result when still valid (unless forced)
 	if [[ "$force" != "true" ]]; then

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -80,6 +80,35 @@ TEST_DB_DIR=$(mktemp -d)
 export AVAILABILITY_DB_OVERRIDE="$TEST_DB_DIR/test-availability.db"
 trap 'rm -rf "$TEST_DB_DIR"' EXIT
 
+write_oauth_auth_json() {
+	local home_dir="$1"
+	mkdir -p "$home_dir/.local/share/opencode"
+	cat >"$home_dir/.local/share/opencode/auth.json" <<'JSON'
+{
+  "openai": {
+    "type": "oauth",
+    "refresh": "test-refresh-token",
+    "access": "test-access-token",
+    "expires": 4102444800000
+  }
+}
+JSON
+	return 0
+}
+
+write_oauth_pool_json() {
+	local home_dir="$1"
+	local body="$2"
+	mkdir -p "$home_dir/.aidevops"
+	printf '%s\n' "$body" >"$home_dir/.aidevops/oauth-pool.json"
+	return 0
+}
+
+NO_GOPASS_BIN="$TEST_DB_DIR/no-gopass-bin"
+mkdir -p "$NO_GOPASS_BIN"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$NO_GOPASS_BIN/gopass"
+chmod +x "$NO_GOPASS_BIN/gopass"
+
 # ============================================================
 # SECTION 1: Basic validation
 # ============================================================
@@ -227,6 +256,59 @@ for provider in local ollama; do
 	*) fail "check $provider: unexpected exit code $check_exit (expected 0 or 1)" ;;
 	esac
 done
+
+section "OAuth Pool Cooldown Gate (GH#26465)"
+
+cooldown_home=$(mktemp -d "$TEST_DB_DIR/home-cooldown.XXXXXX")
+future_ms=$((($(date +%s) + 900) * 1000))
+past_ms=$((($(date +%s) - 900) * 1000))
+
+write_oauth_auth_json "$cooldown_home"
+write_oauth_pool_json "$cooldown_home" "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${future_ms}}]}"
+cooldown_exit=0
+cooldown_output=$(run_with_timeout 10 env HOME="$cooldown_home" PATH="$NO_GOPASS_BIN:$PATH" OPENAI_API_KEY= JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai 2>&1) || cooldown_exit=$?
+if [[ "$cooldown_exit" -eq 2 && "$cooldown_output" == *"rate-limited until"* ]]; then
+	pass "active OAuth pool cooldown overrides auth.json availability"
+else
+	fail "active OAuth pool cooldown overrides auth.json availability" \
+		"exit=${cooldown_exit}, output=${cooldown_output}"
+fi
+
+partial_home=$(mktemp -d "$TEST_DB_DIR/home-partial.XXXXXX")
+write_oauth_auth_json "$partial_home"
+write_oauth_pool_json "$partial_home" "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${future_ms}},{\"email\":\"two@example.test\",\"status\":\"idle\",\"cooldownUntil\":0}]}"
+partial_exit=0
+run_with_timeout 10 env HOME="$partial_home" PATH="$NO_GOPASS_BIN:$PATH" OPENAI_API_KEY= JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai --quiet >/dev/null 2>&1 || partial_exit=$?
+if [[ "$partial_exit" -eq 0 ]]; then
+	pass "partial OAuth pool with one usable account remains available"
+else
+	fail "partial OAuth pool with one usable account remains available" "exit=${partial_exit}"
+fi
+
+expired_home=$(mktemp -d "$TEST_DB_DIR/home-expired.XXXXXX")
+write_oauth_auth_json "$expired_home"
+write_oauth_pool_json "$expired_home" "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${past_ms}}]}"
+expired_exit=0
+run_with_timeout 10 env HOME="$expired_home" PATH="$NO_GOPASS_BIN:$PATH" OPENAI_API_KEY= JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai --quiet >/dev/null 2>&1 || expired_exit=$?
+if [[ "$expired_exit" -eq 0 ]]; then
+	pass "expired OAuth pool cooldown falls through to auth.json availability"
+else
+	fail "expired OAuth pool cooldown falls through to auth.json availability" "exit=${expired_exit}"
+fi
+
+static_home=$(mktemp -d "$TEST_DB_DIR/home-static.XXXXXX")
+write_oauth_auth_json "$static_home"
+write_oauth_pool_json "$static_home" "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${future_ms}}]}"
+run_with_timeout 10 env HOME="$static_home" JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" status >/dev/null 2>&1 || true
+sqlite3 "$static_home/.aidevops/.agent-workspace/model-availability.db" \
+	"INSERT OR REPLACE INTO provider_health (provider,status,http_code,response_ms,error_message,models_count,checked_at,ttl_seconds) VALUES ('openai','healthy',200,0,'test cached healthy',1,strftime('%Y-%m-%dT%H:%M:%SZ','now'),300);" >/dev/null 2>&1
+static_exit=0
+run_with_timeout 10 env HOME="$static_home" OPENAI_API_KEY="test-static-key" JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" bash "$HELPER" check openai --quiet >/dev/null 2>&1 || static_exit=$?
+if [[ "$static_exit" -eq 0 ]]; then
+	pass "static API key path bypasses OAuth pool cooldown and can use cached health"
+else
+	fail "static API key path bypasses OAuth pool cooldown and can use cached health" "exit=${static_exit}"
+fi
 
 # ============================================================
 # SECTION 5: Invalidate command
@@ -446,17 +528,17 @@ else
 	fail "local tier missing from get_tier_models case statement"
 fi
 
-# Verify local tier primary model uses local/ prefix (grep source for get_tier_models)
-# get_tier_models has: local) echo "local/llama.cpp|..." ;;
-# Check both the echo-on-next-line and inline-echo patterns.
-local_tier_has_prefix=0
-grep -A1 "^[[:space:]]*local)" "$HELPER" | grep -q 'echo.*local/' && local_tier_has_prefix=1
-grep "^[[:space:]]*local)" "$HELPER" | grep -q 'local/' && local_tier_has_prefix=1
-if [[ "$local_tier_has_prefix" -eq 1 ]]; then
-	pass "local tier primary model uses local/ prefix"
+# Verify local tier has a concrete configured or hardcoded fallback model.
+local_tier_model=""
+local_tier_model=$(grep "^[[:space:]]*local).*current_model" "$HELPER" | grep -oE "[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+" | head -1 || true)
+if [[ -z "$local_tier_model" && -f "$REPO_DIR/.agents/configs/model-routing-table.json" ]]; then
+	local_tier_model=$(jq -r '.tiers.local.models[0] // empty' "$REPO_DIR/.agents/configs/model-routing-table.json" 2>/dev/null || true)
+fi
+if [[ "$local_tier_model" == *"/"* ]]; then
+	pass "local tier has configured model: $local_tier_model"
 else
-	fail "local tier primary model should use local/ prefix" \
-		"No 'local/' found in local) case of get_tier_models"
+	fail "local tier should have a configured model" \
+		"No provider/model found in local tier configuration or fallback"
 fi
 
 # Verify ollama is a known provider in the helper (check help output or source)
@@ -481,45 +563,33 @@ fi
 # ============================================================
 section "Curl Write-Out Format (GH#17427)"
 
-# Verify _probe_build_request uses only %{http_code} (no %{time_total})
-# The bug was: -w '\n%{http_code}\n%{time_total}' caused tail -1 to read
-# time_total (e.g. 0.209059) as the http_code, making all API probes unhealthy.
-if grep -q 'time_total' "$HELPER"; then
-	fail "curl write-out still contains time_total (GH#17427)" \
-		"_probe_build_request should use -w '\\n%{http_code}' only"
-else
-	pass "curl write-out does not contain time_total (GH#17427)"
-fi
-
-# Verify the write-out format is exactly '\n%{http_code}' (single value)
-if grep -q "\\\\n%{http_code}'" "$HELPER"; then
-	pass "curl write-out ends with http_code (no trailing values)"
+# Verify _probe_build_request keeps http_code as the final trailer.
+PROBE_LIB="$REPO_DIR/.agents/scripts/model-availability-probe-lib.sh"
+if grep -q "%{time_total}.*%{http_code}" "$PROBE_LIB"; then
+	pass "curl write-out keeps http_code after time_total (GH#17427)"
 else
 	fail "curl write-out format unexpected" \
-		"Expected -w '\\n%{http_code}' in _probe_build_request"
+		"Expected time_total before final http_code in _probe_build_request"
 fi
 
-# Verify body extraction drops exactly 1 trailing line (not 2)
-# After removing time_total, only http_code is appended, so body awk
-# should drop 1 line. The old pattern was NR>2 (dropping 2 lines).
-if grep -q 'NR>2{print buf' "$HELPER"; then
-	fail "body extraction still drops 2 trailing lines (GH#17427)" \
-		"Should drop 1 line now that time_total is removed"
+if grep -q "%{http_code}'" "$PROBE_LIB"; then
+	pass "curl write-out ends with http_code"
 else
-	pass "body extraction does not use old 2-line drop pattern"
+	fail "curl write-out format unexpected" \
+		"Expected final %{http_code} in _probe_build_request"
 fi
 
-if grep -q "NR>1{print prev}" "$HELPER"; then
-	pass "body extraction uses 1-line drop pattern (GH#17427)"
+if grep -q 'NR>2{print lines' "$PROBE_LIB"; then
+	pass "body extraction drops two curl trailer lines (time_total + http_code)"
 else
-	fail "body extraction missing 1-line drop awk pattern" \
-		"Expected: awk 'NR>1{print prev} {prev=\$0}'"
+	fail "body extraction missing two-line trailer drop pattern" \
+		"Expected awk pattern that drops time_total and http_code trailers"
 fi
 
 # Simulate the http_code extraction logic to verify correctness.
-# Build a mock curl response: headers + blank line + JSON body + http_code.
+# Build a mock curl response: headers + blank line + JSON body + time_total + http_code.
 # Use plain \n (no \r) to match how the production sed patterns work.
-mock_response=$(printf 'HTTP/1.1 200 OK\nContent-Type: application/json\n\n{"data":[{"id":"model-1"}]}\n200')
+mock_response=$(printf 'HTTP/1.1 200 OK\nContent-Type: application/json\n\n{"data":[{"id":"model-1"}]}\n0.123456\n200')
 mock_http_code=$(printf '%s\n' "$mock_response" | tail -1)
 if [[ "$mock_http_code" == "200" ]]; then
 	pass "mock: tail -1 extracts http_code correctly (got 200)"
@@ -527,21 +597,12 @@ else
 	fail "mock: tail -1 extracts wrong value" "Expected 200, got: $mock_http_code"
 fi
 
-# Verify body extraction with the new awk pattern
-mock_body=$(printf '%s\n' "$mock_response" | sed '1,/^$/d' | awk 'NR>1{print prev} {prev=$0}')
+# Verify body extraction with the two-trailer awk pattern
+mock_body=$(printf '%s\n' "$mock_response" | sed '1,/^$/d' | awk 'NR>2{print lines[NR%2]} {lines[NR%2]=$0}')
 if echo "$mock_body" | grep -q '"data"'; then
 	pass "mock: body extraction preserves JSON content"
 else
 	fail "mock: body extraction lost JSON content" "Got: $mock_body"
-fi
-
-# Verify the old bug scenario: if time_total were still present, tail -1 would get it
-mock_old_response=$(printf 'HTTP/1.1 200 OK\n\n{"data":[]}\n200\n0.209059')
-mock_old_code=$(printf '%s\n' "$mock_old_response" | tail -1)
-if [[ "$mock_old_code" == "0.209059" ]]; then
-	pass "mock: confirms old format would read time_total as http_code (bug scenario)"
-else
-	fail "mock: old format test unexpected" "Got: $mock_old_code"
 fi
 
 # ============================================================


### PR DESCRIPTION
Resolves #26465

## Summary
- Add an OAuth-pool cooldown gate before cached model-availability results are returned.
- Preserve static API key behaviour while blocking OAuth-only providers when all usable pool accounts are cooling down.
- Extend model-availability tests for active, partial, expired, and static-key cooldown cases; refresh stale assertions for current probe-lib behaviour.

## Verification
- `bash -n .agents/scripts/model-availability-helper.sh .agents/scripts/model-availability-probe-lib.sh tests/test-model-availability.sh`
- `shellcheck .agents/scripts/model-availability-helper.sh .agents/scripts/model-availability-probe-lib.sh tests/test-model-availability.sh`
- `bash tests/test-model-availability.sh --verbose`
- `.agents/scripts/linters-local.sh` (timed out during later shell portability after passing targeted gates; advisory markdown/ratchet warnings were pre-existing)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.41 with gpt-5.5 spent 1h 36m and 369,232 tokens on this with the user in an interactive session.