### PR TITLE
For #26346: recognise dirty PR linked issue references

### DIFF
--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -407,7 +407,7 @@ _dps_labels_has() {
 # `AGENTS.md` ("Parent-task PR keyword rule") and the closing-keyword
 # regex used by `_extract_linked_issue` in pulse-merge.sh:
 #
-#   - Closing keywords: `(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#NNN` (case-
+#   - Closing keywords: `(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+#NNN` (case-
 #     insensitive). These auto-close the linked issue when the PR merges.
 #   - `For #NNN` (case-insensitive) — canonical planning-PR non-closing marker.
 #   - `Ref #NNN` (case-insensitive) — alternate non-closing reference.
@@ -418,7 +418,7 @@ _dps_pr_body_has_issue_reference() {
 	local body="$1"
 	[[ -n "$body" ]] || return 1
 	# Closing keywords — same regex pulse-merge.sh:_extract_linked_issue uses.
-	if printf '%s' "$body" | grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#[0-9]+' >/dev/null 2>&1; then
+	if printf '%s' "$body" | grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+#[0-9]+' >/dev/null 2>&1; then
 		return 0
 	fi
 	# Non-closing references: "For #NNN" or "Ref #NNN" (word boundary on the
@@ -1364,7 +1364,7 @@ _dps_main() {
 		# Single-PR spot mode.
 		local pr_obj
 		pr_obj=$(gh pr view "$pr_filter" --repo "$repo_filter" \
-			--json number,mergeStateStatus,createdAt,updatedAt,author,labels,headRefName,baseRefName 2>/dev/null) || pr_obj=""
+			--json number,mergeStateStatus,createdAt,updatedAt,author,labels,headRefName,baseRefName,body 2>/dev/null) || pr_obj=""
 		if [[ -z "$pr_obj" ]]; then
 			_dps_log "gh pr view failed (target: $repo_filter#$pr_filter)"
 			return 1

--- a/.agents/scripts/tests/test-dirty-pr-sweep.sh
+++ b/.agents/scripts/tests/test-dirty-pr-sweep.sh
@@ -301,6 +301,12 @@ case "$decision" in
 	*) print_result "t2711: origin:interactive + Resolves #NNN + 10d → notify (within 14d window)" 1 "got: $decision" ;;
 esac
 
+if _dps_pr_body_has_issue_reference "This PR fixes the problem. Resolves #26346."; then
+	print_result "t2711: closing keyword reference parser recognises Resolves #NNN" 0
+else
+	print_result "t2711: closing keyword reference parser recognises Resolves #NNN" 1 "Resolves #NNN was not detected"
+fi
+
 # =============================================================================
 # Test 6a-worker-backed: origin:interactive PR against an origin:worker issue
 #                       routes semantic conflicts for worker redispatch.


### PR DESCRIPTION
## Summary
- Fixes dirty PR sweep issue-reference detection by replacing non-portable `\s+` ERE usage with POSIX `[[:space:]]+`.
- Includes PR body in `--repo --pr` spot mode so linked worker issues are visible to the classifier.
- Adds a direct regression that `Resolves #NNN` is recognised by the reference parser.

For #26346

## Verification
- `bash -n .agents/scripts/pulse-dirty-pr-sweep.sh .agents/scripts/tests/test-dirty-pr-sweep.sh && shellcheck .agents/scripts/pulse-dirty-pr-sweep.sh .agents/scripts/tests/test-dirty-pr-sweep.sh`
- `bash .agents/scripts/tests/test-dirty-pr-sweep.sh` — 20 tests, 0 failed
- `bash .agents/scripts/secretlint-helper.sh scan .agents/scripts/pulse-dirty-pr-sweep.sh`
- `bash .agents/scripts/secretlint-helper.sh scan .agents/scripts/tests/test-dirty-pr-sweep.sh`
- `DRY_RUN=1 DIRTY_PR_SWEEP_ACTION_COOLDOWN=0 bash .agents/scripts/pulse-dirty-pr-sweep.sh --dry-run --repo marcusquinn/aidevops --pr 26358` → `decision=conflict reason=worker-backed-semantic-conflict`

## Worker context
Files to review:
- `.agents/scripts/pulse-dirty-pr-sweep.sh`: reference parser and spot-mode `gh pr view` JSON fields.
- `.agents/scripts/tests/test-dirty-pr-sweep.sh`: closing-keyword regression.

Pattern:
- Use POSIX ERE character classes with `grep -E`; do not use PCRE shorthands like `\s`.
- Keep single-PR spot mode aligned with batch mode fields when classifier logic depends on PR body metadata.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.45 plugin for [OpenCode](https://opencode.ai) v1.17.13
