### PR TITLE
t18062: Add attribution guidance and provenance monitoring docs

### DIFF
--- a/.agents/reference/attribution-monitoring.md
+++ b/.agents/reference/attribution-monitoring.md
@@ -9,6 +9,10 @@ MIT-licensed copying is legal; attribution is expected. This system detects dist
 
 **Tool:** `attribution-detection-helper.sh` — see `scripts/attribution-detection-helper.sh`
 
+**Public attribution guide:** see repository `ATTRIBUTION.md` for the required
+MIT notice, preferred derivative credit text, and public list of
+provenance-sensitive innovation areas.
+
 ## Quick Start
 
 ```bash
@@ -46,6 +50,19 @@ attribution-detection-helper.sh canary add my-comment "# aidevops: my-unique-com
 2. **Stable** — won't change frequently (avoid version numbers)
 3. **Searchable** — short enough for GitHub code search (< 256 chars)
 4. **Non-sensitive** — safe to search for publicly
+
+### Behavioural fingerprint areas
+
+Keep exact search strings private, but monitor for distinctive aidevops
+behaviour clusters as well as literal source strings:
+
+- prompt-injection scanning for issue, PR, web, MCP, and tool-output content;
+- `needs-maintainer-review` gates, NMR automation, and cryptographic approvals;
+- interactive issue/PR locking through origin labels, active statuses, and claim stamps;
+- linked-worktree safety and pre-edit gates;
+- review-bot settlement gates before merge;
+- parent-task dispatch blockers and decomposition lifecycle controls;
+- provenance checks, origin pings, and attribution canaries.
 
 ## Private Detection Repo
 

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,58 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Attribution
+
+aidevops is MIT licensed. You may use, copy, modify, and redistribute it,
+including commercially, when the MIT license terms are followed.
+
+## Required by the MIT license
+
+Keep the copyright notice and permission notice with every copy or substantial
+portion of the software:
+
+```text
+Copyright (c) 2025-2026 Marcus Quinn
+```
+
+Do not remove SPDX headers, license files, copyright notices, or attribution
+from copied files.
+
+## Preferred attribution for derivatives
+
+If you build a framework, agent runtime, automation bot, workflow library, or
+commercial product derived from aidevops patterns or code, please add visible
+credit in your README, documentation, or about page:
+
+```markdown
+Based on or inspired by [aidevops](https://github.com/marcusquinn/aidevops),
+Copyright (c) 2025-2026 Marcus Quinn, MIT licensed.
+```
+
+For packages or apps, also keep the MIT license notice in your distributed
+license bundle.
+
+## Protected provenance signals
+
+Several aidevops subsystems are intentionally traceable through public history,
+copyright headers, names, comments, workflows, and behavioural fingerprints. The
+signals exist to distinguish legitimate reuse with attribution from stripped or
+misrepresented redistribution.
+
+Examples of provenance-sensitive innovations include:
+
+- prompt-injection scanning for untrusted issue, PR, web, and tool output;
+- maintainer-review gates and cryptographic approval for `needs-maintainer-review`;
+- issue and PR lifecycle locking via origin labels, active statuses, and claim stamps;
+- linked-worktree safety rules for interactive and headless workers;
+- review-bot settlement gates before merge;
+- parent-task dispatch blockers and decomposition lifecycle controls;
+- provenance monitoring, origin checks, and attribution canaries.
+
+These ideas may be reimplemented under the license, but copied code and
+substantial derivative systems should retain attribution.
+
+## Questions
+
+If you are building on aidevops and want the right credit text, open a discussion
+or issue in the upstream repository.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ The result: an AI operations platform that manages projects across every busines
 
 [![Languages by lines of code](docs/metrics/badges/languages.svg)](docs/metrics/repo-metrics.md)
 
+## Attribution
+
+aidevops is MIT licensed. Reuse is welcome, including commercial use, provided
+the copyright and license notices are retained. If you build a derivative
+framework, automation bot, workflow library, or commercial product from aidevops
+code or distinctive operating patterns, see [ATTRIBUTION.md](ATTRIBUTION.md) for
+the required notices and preferred credit text.
+
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference

--- a/TODO.md
+++ b/TODO.md
@@ -1094,6 +1094,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18061 fix(opencode): preserve desktop session history after restart #bug #framework #opencode ref:GH#26394 pr:#26396 completed:2026-07-02
 
+- [ ] t18062 Add attribution guidance and provenance monitoring docs #auto-dispatch #documentation ref:GH#26495
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

- add public ATTRIBUTION.md with MIT notice requirements and preferred derivative credit text
- document provenance-sensitive innovation areas including prompt-injection defenses, NMR crypto approval, issue/PR locking, review-bot gates, parent-task blockers, and linked-worktree safety
- point attribution monitoring docs at the public attribution guide while keeping exact private search strings out of the public repo

## Verification

- python3 header check for README.md, ATTRIBUTION.md, and .agents/reference/attribution-monitoring.md
- git diff --check
- .agents/scripts/linters-local.sh (passed through Markdown/style/secret/pulse canary; timed out later during broad shell portability after existing advisory ratchet warnings)

Resolves #26495

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.46 plugin for [OpenCode](https://opencode.ai) v1.17.13
