### PR TITLE
fix: reduce markdoc extract function complexity

### DIFF
--- a/.agents/scripts/markdoc-extract.sh
+++ b/.agents/scripts/markdoc-extract.sh
@@ -38,6 +38,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Locate companion validator — same directory, or env override.
 VALIDATE_SH="${MARKDOC_VALIDATE_SH:-${SCRIPT_DIR}/markdoc-validate.sh}"
+TAGS_JSON_PY="${MARKDOC_TAGS_JSON_PY:-${SCRIPT_DIR}/markdoc-tags-json.py}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -199,129 +200,7 @@ _build_tags_json() {
 	_parse_tags "$_file" >"$_tsv_file"
 
 	local _py_exit=0
-	python3 - "$_file" "$_tsv_file" <<'PYEOF' || _py_exit=$?
-import sys, json, re
-
-file_path = sys.argv[1]
-tsv_path  = sys.argv[2]
-
-# Read file content for char offset computation
-with open(file_path, encoding='utf-8') as f:
-    content = f.read()
-
-lines = content.split('\n')
-
-def line_col_to_char(line_num, col_num):
-    """Convert 1-based line/col to 0-based char offset."""
-    offset = sum(len(lines[i]) + 1 for i in range(line_num - 1))
-    return offset + (col_num - 1)
-
-# Read TSV from temp file (safe from quoting issues)
-with open(tsv_path, encoding='utf-8') as f:
-    tsv_data = f.read()
-
-rows = []
-for row in tsv_data.strip().split('\n'):
-    if not row.strip():
-        continue
-    parts = row.split('\t', 5)
-    if len(parts) < 6:
-        parts += [''] * (6 - len(parts))
-    ln, col, tag, is_close, is_self, attrs = parts
-    rows.append({
-        'line': int(ln),
-        'col': int(col),
-        'tag': tag,
-        'is_close': is_close == '1',
-        'is_self': is_self == '1',
-        'attrs_str': attrs
-    })
-
-ATTR_RE = re.compile(
-    r'(?:^|\s)([\w-]+)\s*=\s*(?:"([^"]*)"|\047([^\047]*)\047|([^\s"\']+))'
-)
-
-def parse_attrs(attrs_str):
-    result = {}
-    for m in ATTR_RE.finditer(attrs_str):
-        key = m.group(1)
-        val = (m.group(2) if m.group(2) is not None
-               else m.group(3) if m.group(3) is not None
-               else m.group(4))
-        result[key] = val
-    return result
-
-# Build result array
-results = []
-open_stack = []
-
-for row in rows:
-    tag = row['tag']
-    ln = row['line']
-    col = row['col']
-    attrs_str = row['attrs_str']
-    is_close = row['is_close']
-    is_self = row['is_self']
-
-    char_pos = line_col_to_char(ln, col)
-
-    if is_close:
-        matched_idx = None
-        for i in range(len(open_stack) - 1, -1, -1):
-            if open_stack[i]['tag'] == tag:
-                matched_idx = i
-                break
-        if matched_idx is not None:
-            open_entry = open_stack.pop(matched_idx)
-            result_idx = open_entry['result_idx']
-            close_end = content.find('%}', char_pos)
-            if close_end != -1:
-                close_end += 2
-            else:
-                close_end = char_pos
-            results[result_idx]['char_end'] = close_end
-            results[result_idx]['line_end'] = ln
-    elif is_self:
-        tag_end = content.find('%}', char_pos)
-        if tag_end != -1:
-            tag_end += 2
-        else:
-            tag_end = char_pos
-        results.append({
-            'tag': tag,
-            'attrs': parse_attrs(attrs_str),
-            'scope': 'inline',
-            'char_start': char_pos,
-            'char_end': tag_end,
-            'line_start': ln,
-            'line_end': ln,
-        })
-    else:
-        tag_end = content.find('%}', char_pos)
-        if tag_end != -1:
-            tag_end += 2
-        else:
-            tag_end = char_pos
-        scope = 'section' if open_stack else 'file'
-        result_idx = len(results)
-        results.append({
-            'tag': tag,
-            'attrs': parse_attrs(attrs_str),
-            'scope': scope,
-            'char_start': char_pos,
-            'char_end': tag_end,
-            'line_start': ln,
-            'line_end': ln,
-        })
-        open_stack.append({
-            'tag': tag,
-            'char_start': char_pos,
-            'line_start': ln,
-            'result_idx': result_idx,
-        })
-
-print(json.dumps(results, indent=2))
-PYEOF
+	python3 "$TAGS_JSON_PY" "$_file" "$_tsv_file" || _py_exit=$?
 
 	rm -f "$_tsv_file"
 	if [[ "$_py_exit" -ne 0 ]]; then

--- a/.agents/scripts/markdoc-tags-json.py
+++ b/.agents/scripts/markdoc-tags-json.py
@@ -93,13 +93,14 @@ def close_tag(
 
 
 def append_self_closing_tag(
-    results: list[dict[str, Any]], tag: str, attrs_str: str, char_pos: int, end_pos: int, line_num: int
+    results: list[dict[str, Any]], row: dict[str, Any], char_pos: int, end_pos: int
 ) -> None:
     """Append an inline self-closing tag result."""
+    line_num = row["line"]
     results.append(
         {
-            "tag": tag,
-            "attrs": parse_attrs(attrs_str),
+            "tag": row["tag"],
+            "attrs": parse_attrs(row["attrs_str"]),
             "scope": "inline",
             "char_start": char_pos,
             "char_end": end_pos,
@@ -110,15 +111,17 @@ def append_self_closing_tag(
 
 
 def append_open_tag(
-    results: list[dict[str, Any]], open_stack: list[dict[str, Any]], tag: str, attrs_str: str, char_pos: int, end_pos: int, line_num: int
+    results: list[dict[str, Any]], open_stack: list[dict[str, Any]], row: dict[str, Any], char_pos: int, end_pos: int
 ) -> None:
     """Append an opening tag result and push it on the open-tag stack."""
+    tag = row["tag"]
+    line_num = row["line"]
     scope = "section" if open_stack else "file"
     result_idx = len(results)
     results.append(
         {
             "tag": tag,
-            "attrs": parse_attrs(attrs_str),
+            "attrs": parse_attrs(row["attrs_str"]),
             "scope": scope,
             "char_start": char_pos,
             "char_end": end_pos,
@@ -151,9 +154,9 @@ def build_tags(content: str, rows: list[dict[str, Any]]) -> list[dict[str, Any]]
         if row["is_close"]:
             close_tag(results, open_stack, tag, line_num, end_pos)
         elif row["is_self"]:
-            append_self_closing_tag(results, tag, row["attrs_str"], char_pos, end_pos, line_num)
+            append_self_closing_tag(results, row, char_pos, end_pos)
         else:
-            append_open_tag(results, open_stack, tag, row["attrs_str"], char_pos, end_pos, line_num)
+            append_open_tag(results, open_stack, row, char_pos, end_pos)
 
     return results
 

--- a/.agents/scripts/markdoc-tags-json.py
+++ b/.agents/scripts/markdoc-tags-json.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Build markdoc-extract tag JSON from parser TSV.
+
+This helper keeps the Python tag-shaping logic out of the shell wrapper so the
+shell function-complexity scanner measures only shell orchestration.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ATTR_RE = re.compile(
+    r"(?:^|\s)([\w-]+)\s*=\s*(?:\"([^\"]*)\"|\047([^\047]*)\047|([^\s\"\']+))"
+)
+
+
+def line_col_to_char(lines: list[str], line_num: int, col_num: int) -> int:
+    """Convert 1-based line/col to a 0-based character offset."""
+    offset = sum(len(lines[i]) + 1 for i in range(line_num - 1))
+    return offset + (col_num - 1)
+
+
+def parse_rows(tsv_data: str) -> list[dict[str, Any]]:
+    """Parse tag parser TSV into row dictionaries."""
+    rows: list[dict[str, Any]] = []
+    for row in tsv_data.strip().split("\n"):
+        if not row.strip():
+            continue
+        parts = row.split("\t", 5)
+        if len(parts) < 6:
+            parts += [""] * (6 - len(parts))
+        ln, col, tag, is_close, is_self, attrs = parts
+        rows.append(
+            {
+                "line": int(ln),
+                "col": int(col),
+                "tag": tag,
+                "is_close": is_close == "1",
+                "is_self": is_self == "1",
+                "attrs_str": attrs,
+            }
+        )
+    return rows
+
+
+def parse_attrs(attrs_str: str) -> dict[str, str]:
+    """Parse a Markdoc-style attrs string into a JSON-ready dict."""
+    result: dict[str, str] = {}
+    for match in ATTR_RE.finditer(attrs_str):
+        key = match.group(1)
+        val = (
+            match.group(2)
+            if match.group(2) is not None
+            else match.group(3)
+            if match.group(3) is not None
+            else match.group(4)
+        )
+        result[key] = val
+    return result
+
+
+def tag_end(content: str, char_pos: int) -> int:
+    """Return the end offset for the tag marker starting near char_pos."""
+    marker_end = content.find("%}", char_pos)
+    if marker_end != -1:
+        return marker_end + 2
+    return char_pos
+
+
+def close_tag(
+    results: list[dict[str, Any]], open_stack: list[dict[str, Any]], tag: str, line_num: int, close_end: int
+) -> None:
+    """Update the matching open tag result when a close tag is encountered."""
+    matched_idx = None
+    for idx in range(len(open_stack) - 1, -1, -1):
+        if open_stack[idx]["tag"] == tag:
+            matched_idx = idx
+            break
+    if matched_idx is None:
+        return
+
+    open_entry = open_stack.pop(matched_idx)
+    result_idx = open_entry["result_idx"]
+    results[result_idx]["char_end"] = close_end
+    results[result_idx]["line_end"] = line_num
+
+
+def append_self_closing_tag(
+    results: list[dict[str, Any]], tag: str, attrs_str: str, char_pos: int, end_pos: int, line_num: int
+) -> None:
+    """Append an inline self-closing tag result."""
+    results.append(
+        {
+            "tag": tag,
+            "attrs": parse_attrs(attrs_str),
+            "scope": "inline",
+            "char_start": char_pos,
+            "char_end": end_pos,
+            "line_start": line_num,
+            "line_end": line_num,
+        }
+    )
+
+
+def append_open_tag(
+    results: list[dict[str, Any]], open_stack: list[dict[str, Any]], tag: str, attrs_str: str, char_pos: int, end_pos: int, line_num: int
+) -> None:
+    """Append an opening tag result and push it on the open-tag stack."""
+    scope = "section" if open_stack else "file"
+    result_idx = len(results)
+    results.append(
+        {
+            "tag": tag,
+            "attrs": parse_attrs(attrs_str),
+            "scope": scope,
+            "char_start": char_pos,
+            "char_end": end_pos,
+            "line_start": line_num,
+            "line_end": line_num,
+        }
+    )
+    open_stack.append(
+        {
+            "tag": tag,
+            "char_start": char_pos,
+            "line_start": line_num,
+            "result_idx": result_idx,
+        }
+    )
+
+
+def build_tags(content: str, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build the tag JSON array from parsed tag rows."""
+    lines = content.split("\n")
+    results: list[dict[str, Any]] = []
+    open_stack: list[dict[str, Any]] = []
+
+    for row in rows:
+        tag = row["tag"]
+        line_num = row["line"]
+        char_pos = line_col_to_char(lines, line_num, row["col"])
+        end_pos = tag_end(content, char_pos)
+
+        if row["is_close"]:
+            close_tag(results, open_stack, tag, line_num, end_pos)
+        elif row["is_self"]:
+            append_self_closing_tag(results, tag, row["attrs_str"], char_pos, end_pos, line_num)
+        else:
+            append_open_tag(results, open_stack, tag, row["attrs_str"], char_pos, end_pos, line_num)
+
+    return results
+
+
+def main(argv: list[str]) -> int:
+    """CLI entry point."""
+    if len(argv) != 3:
+        print("usage: markdoc-tags-json.py <file> <tags.tsv>", file=sys.stderr)
+        return 2
+
+    file_path = Path(argv[1])
+    tsv_path = Path(argv[2])
+    content = file_path.read_text(encoding="utf-8")
+    rows = parse_rows(tsv_path.read_text(encoding="utf-8"))
+    print(json.dumps(build_tags(content, rows), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Move Markdoc tag JSON construction out of `markdoc-extract.sh` into `markdoc-tags-json.py` so the shell extractor no longer has a >100-line `_build_tags_json()` function.
- Keep the shell extractor as the orchestrator: parse tags to TSV, invoke the Python helper, then write the existing artefacts.
- Adjust Python helper function signatures so the new-file qlty gate reports 0 smells.

Resolves #26513

## Verification
- `bash -n .agents/scripts/markdoc-extract.sh`
- `python3 -m py_compile .agents/scripts/markdoc-tags-json.py`
- `shellcheck .agents/scripts/markdoc-extract.sh`
- `.agents/scripts/tests/test-markdoc-extract.sh` — 4 tests, 0 failed
- `.agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/markdoc-extract.sh` — Long functions (>100 lines): 0
- `.agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/markdoc-tags-json.py` — Long functions (>100 lines): 0
- `.agents/scripts/qlty-new-file-gate-helper.sh scan --base origin/main` — Total smells in new files: 0
- `.agents/scripts/qlty-regression-helper.sh --base origin/main` — base: 53, head: 53, delta: 0, no regression

## Notes
- Full `.agents/scripts/linters-local.sh` was attempted twice but did not complete within 300s while running the repository-wide Secretlint step; targeted required gates above passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.49 plugin for [OpenCode](https://opencode.ai) v1.17.13
