### PR TITLE
fix: add full-loop create-pr alias

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -157,7 +157,7 @@ _validate_commit_and_pr_inputs() {
 	local issue_number="$1" commit_message="$2"
 
 	if [[ -z "$issue_number" || -z "$commit_message" ]]; then
-		print_error "Usage: full-loop-helper.sh commit-and-pr --issue <N> --message <msg>"
+		print_error "Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg>"
 		return 1
 	fi
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -56,7 +56,7 @@ source "${SCRIPT_DIR}/full-loop-helper-merge.sh"
 # Collapses full-loop steps 4.1-4.2.1 into a single deterministic call.
 # Workers and interactive sessions both use this — no parallel logic.
 #
-# Usage: full-loop-helper.sh commit-and-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...] [--allow-parent-close] [--skip-hooks]
+# Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...] [--allow-parent-close] [--skip-hooks]
 # Exit codes: 0 = PR created (prints PR number to stdout), 1 = failure
 # --allow-parent-close: skip the parent-task keyword guard (final-phase PR only)
 # --skip-hooks: pass --no-verify to git push (bypasses pre-push hooks). Use for doc-only PRs
@@ -196,7 +196,8 @@ Commands:
   status                        Show current loop state
   cancel                        Cancel active loop
   logs [N]                      Show last N log lines (default: 50)
-  commit-and-pr --issue N --message "msg"  Stage, commit, rebase, push, create PR, post merge summary
+  commit-and-pr|create-pr --issue N --message "msg"
+                                 Stage, commit, rebase, push, create PR, post merge summary
                 [--skip-hooks]             Pass --no-verify to git push (doc-only PRs, GH#20138)
   pre-merge-gate <PR> [REPO]    Check review bot gate before merge (GH#17541)
   merge <PR> [REPO] [--squash|--merge|--rebase] [--admin] [--auto]
@@ -232,7 +233,7 @@ main() {
 	case "$command" in
 	start) cmd_start "$@" ;; resume) cmd_resume ;; status) cmd_status ;;
 	cancel) cmd_cancel ;; logs) cmd_logs "$@" ;; _run_foreground) _run_foreground "$@" ;;
-	commit-and-pr) cmd_commit_and_pr "$@" ;;
+	commit-and-pr | create-pr) cmd_commit_and_pr "$@" ;;
 	pre-merge-gate) cmd_pre_merge_gate "$@" ;;
 	merge) cmd_merge "$@" ;;
 	help | --help | -h) show_help ;;

--- a/.agents/scripts/tests/test-full-loop-create-pr-alias.sh
+++ b/.agents/scripts/tests/test-full-loop-create-pr-alias.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression guard for GH#26533: `create-pr` must stay on the full-loop
+# wrapper path instead of failing as an unknown command and nudging workers
+# toward raw `gh pr create` fallback without provenance labels.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../full-loop-helper.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+assert_contains() {
+	local label="$1"
+	local haystack="$2"
+	local needle="$3"
+
+	if [[ "$haystack" != *"$needle"* ]]; then
+		fail "$label missing expected text: $needle"
+		return 1
+	fi
+	return 0
+}
+
+main() {
+	local help_output=""
+	help_output=$("$HELPER" help 2>&1)
+	assert_contains "help output" "$help_output" "commit-and-pr|create-pr"
+
+	local alias_output=""
+	local rc=0
+	alias_output=$("$HELPER" create-pr 2>&1) || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		fail "create-pr without required args should fail validation"
+		return 1
+	fi
+	if [[ "$alias_output" == *"Unknown command: create-pr"* ]]; then
+		fail "create-pr fell through to unknown-command handler"
+		return 1
+	fi
+	assert_contains "create-pr validation" "$alias_output" "commit-and-pr|create-pr"
+
+	printf 'PASS: full-loop create-pr alias\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds create-pr as a direct alias for commit-and-pr, updates help/validation usage text, and adds a regression test so workers stay on the wrapper path that applies provenance labels.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh,.agents/scripts/full-loop-helper.sh,.agents/scripts/tests/test-full-loop-create-pr-alias.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: .agents/scripts/tests/test-full-loop-create-pr-alias.sh; PASS: shellcheck .agents/scripts/full-loop-helper.sh .agents/scripts/full-loop-helper-commit.sh .agents/scripts/tests/test-full-loop-create-pr-alias.sh; PARTIAL: .agents/scripts/linters-local.sh passed focused gates through Bash 3.2 compatibility and advisory checks, then timed out during shell portability after reporting only pre-existing/advisory markdown, ratchet, and layout warnings.

Resolves #26533


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.49 with gpt-5.5 spent 19m and 93,332 tokens on this with the user in an interactive session.