### PR TITLE
GH#26537: fix: validate dispatch ledger expire ttl

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -757,7 +757,12 @@ _cmd_expire_parse_ttl() {
 		option="${1:-}"
 		case "$option" in
 		--ttl)
-			ttl_arg="${2:-$DEFAULT_TTL}"
+			if [[ $# -lt 2 ]]; then
+				echo "Error: --ttl requires an argument" >&2
+				return 1
+			fi
+
+			ttl_arg="${2:-}"
 			ttl="$ttl_arg"
 			shift 2
 			;;

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -386,6 +386,24 @@ test_expire_dead_pid() {
 }
 
 #######################################
+# Test: expire rejects --ttl without a value
+#######################################
+test_expire_missing_ttl_value() {
+	setup_test_env
+
+	run_helper "$LEDGER_HELPER" expire --ttl
+
+	local result=0
+	if [[ "$LAST_EXIT" -eq 0 ]]; then
+		result=1
+	fi
+
+	print_result "expire rejects --ttl without a value" "$result" "exit=${LAST_EXIT}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
 # Test: check detects dead PID and marks as failed
 #######################################
 test_check_dead_pid_marks_failed() {
@@ -755,6 +773,7 @@ main() {
 	test_count_inflight
 	test_expire_by_ttl
 	test_expire_dead_pid
+	test_expire_missing_ttl_value
 	test_check_dead_pid_marks_failed
 	test_prune_old_entries
 	test_status_runs


### PR DESCRIPTION
## Summary

Validated dispatch-ledger expire --ttl requires a value before shift 2, preventing set -e termination on missing argument; added regression coverage for the missing --ttl value case.

## Files Changed

.agents/scripts/dispatch-ledger-helper.sh,.agents/scripts/tests/test-dispatch-ledger-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-dispatch-ledger-helper.sh; shellcheck .agents/scripts/dispatch-ledger-helper.sh .agents/scripts/tests/test-dispatch-ledger-helper.sh

Resolves #26537


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.50 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 45,551 tokens on this as a headless worker.