### PR TITLE
GH#26538: fix: harden file-size check arg handling

### DIFF
--- a/.agents/scripts/file-size-regression-helper.sh
+++ b/.agents/scripts/file-size-regression-helper.sh
@@ -504,15 +504,15 @@ cmd_check_scan_head() {
 # cmd_check_run_diff <base-tsv> <head-tsv> <base-sha> <head-sha> <output-md> <allow>
 # ---------------------------------------------------------------------------
 cmd_check_run_diff() {
-	local _base_tsv="$1"
-	local _head_tsv="$2"
-	local _base_sha="$3"
-	local _head_sha="$4"
-	local _output_md="$5"
-	local _allow_increase="$6"
+	local _base_tsv="${1:-}"
+	local _head_tsv="${2:-}"
+	local _base_sha="${3:-}"
+	local _head_sha="${4:-}"
+	local _output_md="${5:-}"
+	local _allow_increase="${6:-0}"
 	local _diff_exit=0
 
-	if [ -n "$_output_md" ] && [ "$_allow_increase" -eq 1 ]; then
+	if [ -n "$_output_md" ] && [ "$_allow_increase" = "1" ]; then
 		cmd_diff --base-file "$_base_tsv" --head-file "$_head_tsv" \
 			--base-sha "$_base_sha" --head-sha "$_head_sha" \
 			--output-md "$_output_md" --allow-increase || _diff_exit=$?
@@ -520,7 +520,7 @@ cmd_check_run_diff() {
 		cmd_diff --base-file "$_base_tsv" --head-file "$_head_tsv" \
 			--base-sha "$_base_sha" --head-sha "$_head_sha" \
 			--output-md "$_output_md" || _diff_exit=$?
-	elif [ "$_allow_increase" -eq 1 ]; then
+	elif [ "$_allow_increase" = "1" ]; then
 		cmd_diff --base-file "$_base_tsv" --head-file "$_head_tsv" \
 			--base-sha "$_base_sha" --head-sha "$_head_sha" \
 			--allow-increase || _diff_exit=$?


### PR DESCRIPTION
## Summary

Hardened cmd_check_run_diff in .agents/scripts/file-size-regression-helper.sh by defaulting optional positional parameters and using string comparison for the allow-increase flag so missing or non-integer values do not trigger shell integer errors under set -u.

## Files Changed

.agents/scripts/file-size-regression-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-file-size-regression-helper.sh; shellcheck .agents/scripts/file-size-regression-helper.sh .agents/scripts/tests/test-file-size-regression-helper.sh; pre-commit hook during WIP commit

Resolves #26538


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.50 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 68,675 tokens on this as a headless worker.