### PR TITLE
fix: optimize markdoc tag offset lookup (Resolves #26540)

### DIFF
--- a/.agents/scripts/markdoc-tags-json.py
+++ b/.agents/scripts/markdoc-tags-json.py
@@ -21,10 +21,9 @@ ATTR_RE = re.compile(
 )
 
 
-def line_col_to_char(lines: list[str], line_num: int, col_num: int) -> int:
+def line_col_to_char(line_offsets: list[int], line_num: int, col_num: int) -> int:
     """Convert 1-based line/col to a 0-based character offset."""
-    offset = sum(len(lines[i]) + 1 for i in range(line_num - 1))
-    return offset + (col_num - 1)
+    return line_offsets[line_num - 1] + (col_num - 1)
 
 
 def parse_rows(tsv_data: str) -> list[dict[str, Any]]:
@@ -142,13 +141,17 @@ def append_open_tag(
 def build_tags(content: str, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Build the tag JSON array from parsed tag rows."""
     lines = content.split("\n")
+    line_offsets = [0]
+    for line in lines:
+        line_offsets.append(line_offsets[-1] + len(line) + 1)
+
     results: list[dict[str, Any]] = []
     open_stack: list[dict[str, Any]] = []
 
     for row in rows:
         tag = row["tag"]
         line_num = row["line"]
-        char_pos = line_col_to_char(lines, line_num, row["col"])
+        char_pos = line_col_to_char(line_offsets, line_num, row["col"])
         end_pos = tag_end(content, char_pos)
 
         if row["is_close"]:


### PR DESCRIPTION
## Summary
- Precompute cumulative line offsets once in .agents/scripts/markdoc-tags-json.py.
- Use O(1) line/column-to-character offset lookup for each parsed Markdoc tag.

## Testing
- python3 -m py_compile .agents/scripts/markdoc-tags-json.py
- .agents/scripts/tests/test-markdoc-extract.sh

Resolves #26540
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.50 plugin for [OpenCode](https://opencode.ai) v1.17.13
