### PR TITLE
fix: add opt-in review-thread remediation before routing

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -107,23 +107,40 @@ _pulse_merge_repo_path_for_slug() {
 	return 0
 }
 
+_pulse_merge_dispatch_review_thread_remediation() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local repo_path="" scanner="${_PULSE_MERGE_DIR}/pr-review-thread-response-scanner.sh"
+
+	if [[ ! -x "$scanner" ]]; then
+		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: scanner missing or not executable (${scanner})" >>"$LOGFILE"
+		return 1
+	fi
+	if ! repo_path="$(_pulse_merge_repo_path_for_slug "$repo_slug")"; then
+		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: repo path not found in configured repos" >>"$LOGFILE"
+		return 1
+	fi
+	if ! PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true "$scanner" dispatch-pr "$repo_slug" "$repo_path" "$pr_number" >>"$LOGFILE" 2>&1; then
+		echo "[pulse-merge] review-thread remediation dispatch failed for PR #${pr_number} in ${repo_slug} ${reason}" >>"$LOGFILE"
+		return 1
+	fi
+	echo "[pulse-merge] review-thread remediation queued for PR #${pr_number} in ${repo_slug} ${reason}" >>"$LOGFILE"
+	return 0
+}
+
 _pulse_merge_maybe_dispatch_review_thread_remediation() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local merge_output="$3"
-	local repo_path="" scanner="${_PULSE_MERGE_DIR}/pr-review-thread-response-scanner.sh"
 
 	[[ "$merge_output" == *"A conversation must be resolved"* ]] || return 0
-	if [[ ! -x "$scanner" ]]; then
-		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: scanner missing or not executable (${scanner})" >>"$LOGFILE"
-		return 0
-	fi
-	if ! repo_path="$(_pulse_merge_repo_path_for_slug "$repo_slug")"; then
-		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: repo path not found in configured repos" >>"$LOGFILE"
-		return 0
-	fi
-	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true "$scanner" dispatch-pr "$repo_slug" "$repo_path" "$pr_number" >>"$LOGFILE" 2>&1 || true
-	echo "[pulse-merge] review-thread remediation queued for PR #${pr_number} in ${repo_slug} after unresolved conversation merge blocker" >>"$LOGFILE"
+	_pulse_merge_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "after unresolved conversation merge blocker" || true
+	return 0
+}
+
+_pulse_merge_changes_requested_thread_remediation_first_enabled() {
+	[[ "${AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST:-0}" == "1" ]] || return 1
 	return 0
 }
 
@@ -243,8 +260,23 @@ _handle_changes_requested_review_gate() {
 		return 1
 	fi
 
-	# No coderabbit-nits-ok label — route worker-authored PRs for fix
-	# dispatch and skip the merge (t2203: consolidated in helper).
+	local _cr_label_list=",${_cr_pr_labels},"
+	# Optional policy override (GH#26535): by default CHANGES_REQUESTED worker
+	# PRs keep the historical fast-routing behaviour below. Operators who prefer
+	# preserving the PR/review context can opt in to a remediation-first cycle.
+	if _pulse_merge_changes_requested_thread_remediation_first_enabled \
+		&& [[ "$_cr_label_list" == *"${_OW_LABEL_PAT}"* \
+			|| "$_cr_label_list" == *",origin:worker-takeover,"* ]] \
+		&& [[ "$_cr_label_list" != *",external-contributor,"* ]] \
+		&& [[ "$_cr_label_list" != *",no-takeover,"* ]] \
+		&& [[ "$_cr_label_list" != *",review-routed-to-issue,"* ]] \
+		&& _pulse_merge_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "after CHANGES_REQUESTED review gate"; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; review-thread remediation queued" >>"$LOGFILE"
+		return 1
+	fi
+
+	# If remediation is unavailable or fails to dispatch, route worker-authored
+	# PRs for fix dispatch and skip the merge (t2203: consolidated in helper).
 	_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "review" "$_cr_pr_labels" || true
 	echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
 	return 1

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -44,6 +44,8 @@ SCANNER
 	: >"$LOGFILE"
 	: >"$SCANNER_LOG"
 	_PULSE_MERGE_DIR="${TEST_ROOT}/scripts"
+	_OW_LABEL_PAT=",origin:worker,"
+	unset AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST
 	return 0
 }
 
@@ -56,14 +58,23 @@ teardown_test_env() {
 }
 
 define_helpers_under_test() {
-	local src_repo_path="" src_dispatch=""
+	local src_repo_path="" src_dispatch="" src_maybe_dispatch="" src_enabled="" src_changes_gate=""
 	src_repo_path=$(awk '
 		/^_pulse_merge_repo_path_for_slug\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
 	src_dispatch=$(awk '
+		/^_pulse_merge_dispatch_review_thread_remediation\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$MERGE_SCRIPT")
+	src_maybe_dispatch=$(awk '
 		/^_pulse_merge_maybe_dispatch_review_thread_remediation\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
-	if [[ -z "$src_repo_path" || -z "$src_dispatch" ]]; then
+	src_enabled=$(awk '
+		/^_pulse_merge_changes_requested_thread_remediation_first_enabled\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$MERGE_SCRIPT")
+	src_changes_gate=$(awk '
+		/^_handle_changes_requested_review_gate\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$src_repo_path" || -z "$src_dispatch" || -z "$src_maybe_dispatch" || -z "$src_enabled" || -z "$src_changes_gate" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
@@ -71,6 +82,12 @@ define_helpers_under_test() {
 	eval "$src_repo_path"
 	# shellcheck disable=SC1090
 	eval "$src_dispatch"
+	# shellcheck disable=SC1090
+	eval "$src_maybe_dispatch"
+	# shellcheck disable=SC1090
+	eval "$src_enabled"
+	# shellcheck disable=SC1090
+	eval "$src_changes_gate"
 	return 0
 }
 
@@ -107,9 +124,125 @@ test_other_merge_failures_do_not_dispatch_review_thread_remediation() {
 	return 0
 }
 
+test_changes_requested_routes_by_default() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	if _handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker"; then
+		print_result "CHANGES_REQUESTED routes by default" 1 \
+			"Expected gate to skip merge after default routing"
+	elif [[ ! -s "$SCANNER_LOG" ]] && grep -q 'route 77 owner/repo' "$route_log"; then
+		print_result "CHANGES_REQUESTED routes by default" 0
+	else
+		print_result "CHANGES_REQUESTED routes by default" 1 \
+			"scanner=$(tr '\n' ';' <"$SCANNER_LOG"), route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_changes_requested_opt_in_dispatches_remediation_without_routing() {
+	setup_test_env
+	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	if _handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker"; then
+		print_result "opt-in CHANGES_REQUESTED remediation keeps PR open before routing" 1 \
+			"Expected gate to skip merge after queuing remediation"
+	elif grep -q 'include_human=true args=dispatch-pr owner/repo' "$SCANNER_LOG" \
+		&& grep -q ' 77$' "$SCANNER_LOG" \
+		&& [[ ! -s "$route_log" ]] \
+		&& grep -q 'review-thread remediation queued for PR #77 in owner/repo after CHANGES_REQUESTED review gate' "$LOGFILE"; then
+		print_result "opt-in CHANGES_REQUESTED remediation keeps PR open before routing" 0
+	else
+		print_result "opt-in CHANGES_REQUESTED remediation keeps PR open before routing" 1 \
+			"scanner=$(tr '\n' ';' <"$SCANNER_LOG"), route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_changes_requested_routes_when_remediation_unavailable() {
+	setup_test_env
+	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
+	chmod -x "${TEST_ROOT}/scripts/pr-review-thread-response-scanner.sh"
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	if _handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker"; then
+		print_result "CHANGES_REQUESTED falls back to routing when remediation unavailable" 1 \
+			"Expected gate to skip merge after fallback routing"
+	elif grep -q 'route 77 owner/repo' "$route_log" \
+		&& grep -q 'review-thread remediation skipped for PR #77 in owner/repo: scanner missing or not executable' "$LOGFILE"; then
+		print_result "CHANGES_REQUESTED falls back to routing when remediation unavailable" 0
+	else
+		print_result "CHANGES_REQUESTED falls back to routing when remediation unavailable" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_changes_requested_skips_remediation_for_external_contributor() {
+	setup_test_env
+	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	if _handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker,external-contributor"; then
+		print_result "external contributor CHANGES_REQUESTED skips remediation" 1 \
+			"Expected gate to skip merge"
+	elif [[ ! -s "$SCANNER_LOG" ]] && grep -q 'route 77 owner/repo' "$route_log"; then
+		print_result "external contributor CHANGES_REQUESTED skips remediation" 0
+	else
+		print_result "external contributor CHANGES_REQUESTED skips remediation" 1 \
+			"scanner=$(tr '\n' ';' <"$SCANNER_LOG"), route=$(tr '\n' ';' <"$route_log")"
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_unresolved_conversation_dispatches_targeted_human_thread_remediation
 	test_other_merge_failures_do_not_dispatch_review_thread_remediation
+	test_changes_requested_routes_by_default
+	test_changes_requested_opt_in_dispatches_remediation_without_routing
+	test_changes_requested_routes_when_remediation_unavailable
+	test_changes_requested_skips_remediation_for_external_contributor
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	printf 'Tests failed: %d\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/todo/tasks/GH#26535-brief.md
+++ b/todo/tasks/GH#26535-brief.md
@@ -1,0 +1,33 @@
+# GH#26535 — Review-thread remediation before PR closure
+
+Worker-ready issue body at https://github.com/marcusquinn/aidevops/issues/26535
+
+## Goal
+
+Add an opt-in pulse merge setting so worker PRs with
+`reviewDecision=CHANGES_REQUESTED` can try review-thread remediation before
+closing the PR and redispatching the linked issue.
+
+## Files Scope
+
+- `.agents/scripts/pulse-merge.sh`
+- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`
+
+## Required behavior
+
+- Preserve the default fast-routing policy: non-CodeRabbit
+  `reviewDecision=CHANGES_REQUESTED` still routes feedback to the linked issue
+  and closes the worker PR.
+- When `AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1`, dispatch
+  `pr-review-thread-response-scanner.sh dispatch-pr` with human review threads
+  included before routing.
+- When remediation dispatch succeeds, return early from the merge gate and keep
+  the PR open for the remediation cycle.
+- In opt-in mode, only fall back to `_route_pr_to_fix_worker` when remediation
+  is unavailable, repo lookup fails, or dispatch fails.
+- Preserve the existing unresolved-conversation merge-blocker remediation path.
+
+## Verification
+
+- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`
+- ShellCheck on touched shell files.


### PR DESCRIPTION
## Summary

- Adds a reusable review-thread remediation dispatch helper with success/fallback signalling.
- Preserves the default `CHANGES_REQUESTED` fast-routing policy: worker PR review feedback still routes to the linked issue and closes the PR unless explicitly opted in.
- Adds opt-in `AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1` to queue review-thread remediation first, keep the PR open for that remediation cycle, and fall back to routing only when remediation is unavailable or dispatch fails.
- Adds a worker-ready brief for GH#26535 and regression coverage for both default and opt-in behavior.

Resolves #26535

## Verification

- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh` — passed, 6 tests.
- `.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh` — passed, 9 tests.
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh` — passed.
- `npx markdownlint-cli2 "todo/tasks/GH#26535-brief.md"` — passed.
- `.agents/scripts/linters-local.sh` — passed; repo-wide advisory warnings reported but final result: ALL LOCAL CHECKS PASSED.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.50 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1h 18m and 240,470 tokens on this with the user in an interactive session.