### PR TITLE
fix: use bash conditionals in file size helper

### DIFF
--- a/.agents/scripts/file-size-regression-helper.sh
+++ b/.agents/scripts/file-size-regression-helper.sh
@@ -512,15 +512,15 @@ cmd_check_run_diff() {
 	local _allow_increase="${6:-0}"
 	local _diff_exit=0
 
-	if [ -n "$_output_md" ] && [ "$_allow_increase" = "1" ]; then
+	if [[ -n "$_output_md" && "$_allow_increase" == "1" ]]; then
 		cmd_diff --base-file "$_base_tsv" --head-file "$_head_tsv" \
 			--base-sha "$_base_sha" --head-sha "$_head_sha" \
 			--output-md "$_output_md" --allow-increase || _diff_exit=$?
-	elif [ -n "$_output_md" ]; then
+	elif [[ -n "$_output_md" ]]; then
 		cmd_diff --base-file "$_base_tsv" --head-file "$_head_tsv" \
 			--base-sha "$_base_sha" --head-sha "$_head_sha" \
 			--output-md "$_output_md" || _diff_exit=$?
-	elif [ "$_allow_increase" = "1" ]; then
+	elif [[ "$_allow_increase" == "1" ]]; then
 		cmd_diff --base-file "$_base_tsv" --head-file "$_head_tsv" \
 			--base-sha "$_base_sha" --head-sha "$_head_sha" \
 			--allow-increase || _diff_exit=$?


### PR DESCRIPTION
## Summary
- Updated `.agents/scripts/file-size-regression-helper.sh` `cmd_check_run_diff` conditionals to use Bash `[[ ... ]]` syntax for the output/allow-increase branches.
- Resolves review feedback from PR #26543 carried by issue #26548.

## Testing
- `shellcheck .agents/scripts/file-size-regression-helper.sh`
- `bash .agents/scripts/tests/test-file-size-regression-helper.sh` (6/6 tests passed)

MERGE_SUMMARY
- Change: `.agents/scripts/file-size-regression-helper.sh` now uses Bash `[[ ... ]]` conditionals in the affected `cmd_check_run_diff` branch chain.
- Verification: ShellCheck passed for the helper; file-size helper regression tests passed 6/6.

Resolves #26548

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.51 plugin for [OpenCode](https://opencode.ai) v1.17.13
