### PR TITLE
fix: guard pulse merge optional globals

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -111,7 +111,7 @@ _pulse_merge_dispatch_review_thread_remediation() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local reason="$3"
-	local repo_path="" scanner="${_PULSE_MERGE_DIR}/pr-review-thread-response-scanner.sh"
+	local repo_path="" scanner="${_PULSE_MERGE_DIR:-}/pr-review-thread-response-scanner.sh"
 
 	if [[ ! -x "$scanner" ]]; then
 		echo "[pulse-merge] review-thread remediation skipped for PR #${pr_number} in ${repo_slug}: scanner missing or not executable (${scanner})" >>"$LOGFILE"
@@ -265,7 +265,7 @@ _handle_changes_requested_review_gate() {
 	# PRs keep the historical fast-routing behaviour below. Operators who prefer
 	# preserving the PR/review context can opt in to a remediation-first cycle.
 	if _pulse_merge_changes_requested_thread_remediation_first_enabled \
-		&& [[ "$_cr_label_list" == *"${_OW_LABEL_PAT}"* \
+		&& [[ "$_cr_label_list" == *"${_OW_LABEL_PAT:-}"* \
 			|| "$_cr_label_list" == *",origin:worker-takeover,"* ]] \
 		&& [[ "$_cr_label_list" != *",external-contributor,"* ]] \
 		&& [[ "$_cr_label_list" != *",no-takeover,"* ]] \


### PR DESCRIPTION
Resolves #26547

## Summary
- Guard `_PULSE_MERGE_DIR` with `${_PULSE_MERGE_DIR:-}` when building the review-thread scanner path.
- Guard `_OW_LABEL_PAT` with `${_OW_LABEL_PAT:-}` in the CHANGES_REQUESTED remediation label check.

## Testing
- `bash -n .agents/scripts/pulse-merge.sh`
- `shellcheck .agents/scripts/pulse-merge.sh`
- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`

MERGE_SUMMARY: Guard optional pulse-merge globals so `set -u` cannot abort review-thread remediation checks when those globals are unset.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.51 plugin for [OpenCode](https://opencode.ai) v1.17.13
