### PR TITLE
GH#26549: fix: prefix markdoc helper error

### DIFF
--- a/.agents/scripts/markdoc-extract.sh
+++ b/.agents/scripts/markdoc-extract.sh
@@ -201,7 +201,8 @@ _build_tags_json() {
 
 	local _py_exit=0
 	if [[ ! -f "${TAGS_JSON_PY:-}" ]]; then
-		printf 'ERROR: Python helper script not found: %s\n' "${TAGS_JSON_PY:-}" >&2
+		printf '%b[%s] ERROR: Python helper script not found: %s%b\n' \
+			"$RED" "$SCRIPT_NAME" "${TAGS_JSON_PY:-}" "$NC" >&2
 		_py_exit=2
 	else
 		python3 "${TAGS_JSON_PY:-}" "$_file" "$_tsv_file" || _py_exit=$?


### PR DESCRIPTION
## Summary

Updated .agents/scripts/markdoc-extract.sh so the missing Python helper error uses the script-name-prefixed coloured logging format used by _die.

## Files Changed

.agents/scripts/markdoc-extract.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-markdoc-extract.sh; shellcheck .agents/scripts/markdoc-extract.sh

Resolves #26549


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.51 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 52,955 tokens on this as a headless worker.