### PR TITLE
GH#26550: clean stale LLM lock on skipped cycles

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -284,6 +284,9 @@ _pulse_record_llm_failure() {
 _pulse_maybe_run_llm_supervisor() {
 	local skip_llm=false
 	local llm_trigger_mode="stall"
+	local llm_lockdir="${LOCKDIR}.llm"
+	local _llm_lock_acquired=0
+	local _llm_lock_checked=0
 	if [[ "${PULSE_FORCE_LLM:-0}" != "1" ]] && ! _should_run_llm_supervisor; then
 		skip_llm=true
 		echo "[pulse-wrapper] Skipping LLM supervisor (backlog progressing, daily sweep not due)" >>"$LOGFILE"
@@ -296,47 +299,62 @@ _pulse_maybe_run_llm_supervisor() {
 		fi
 	fi
 
-	if [[ "$skip_llm" == "false" ]]; then
-		# Use a separate LLM lock so only one LLM session runs at a time,
-		# without blocking the deterministic 2-min cycle.
-		local llm_lockdir="${LOCKDIR}.llm"
-		local _llm_lock_acquired=false
-
-		if mkdir "$llm_lockdir" 2>/dev/null; then
-			_llm_lock_acquired=true
-		elif _handle_stale_llm_lock "$llm_lockdir"; then
-			# GH#20613: stale lock reclaimed — we now own it
-			_llm_lock_acquired=true
+	if [[ -d "$llm_lockdir" ]]; then
+		_llm_lock_checked=1
+		if _handle_stale_llm_lock "$llm_lockdir"; then
+			# GH#20613/GH#26550: stale lock reclaimed — we now own it.
+			_llm_lock_acquired=1
 		fi
+	fi
 
-		if [[ "$_llm_lock_acquired" == "true" ]]; then
-			echo "$$" >"${llm_lockdir}/pid" 2>/dev/null || true
-			# shellcheck disable=SC2064
-			trap "rm -rf '$llm_lockdir' 2>/dev/null; release_instance_lock" EXIT
-
-			local underfill_output
-			underfill_output=$(_compute_initial_underfill)
-			local initial_underfilled_mode="" initial_underfill_pct=""
-			initial_underfilled_mode=$(echo "$underfill_output" | sed -n '1p')
-			initial_underfill_pct=$(echo "$underfill_output" | sed -n '2p')
-
-			local pulse_start_epoch="" pulse_rc=""
-			pulse_start_epoch=$(date +%s)
-			_pulse_record_llm_attempt "$llm_trigger_mode" || true
-			pulse_rc=0
-			run_pulse "$initial_underfilled_mode" "$initial_underfill_pct" "$llm_trigger_mode" || pulse_rc=$?
-			local pulse_end_epoch
-			pulse_end_epoch=$(date +%s)
-			local pulse_duration=$((pulse_end_epoch - pulse_start_epoch))
-
-			if [[ "$pulse_rc" -eq 0 ]]; then
-				_pulse_record_llm_success "$llm_trigger_mode" || true
-				_run_early_exit_recycle_loop "$pulse_duration"
-			else
-				_pulse_record_llm_failure "$llm_trigger_mode" "$pulse_rc"
-			fi
+	if [[ "$skip_llm" == "true" ]]; then
+		if [[ "$_llm_lock_acquired" -eq 1 ]]; then
+			# GH#26550: skip cycles only perform cleanup. _handle_stale_llm_lock
+			# re-acquires after clearing, so release the reclaimed LLM lock instead
+			# of leaving a self-created lock behind until the next eligible cycle.
 			rm -rf "$llm_lockdir" 2>/dev/null || true
 		fi
+		return 0
+	fi
+
+	# Use a separate LLM lock so only one LLM session runs at a time,
+	# without blocking the deterministic 2-min cycle.
+	if [[ "$_llm_lock_acquired" -ne 1 ]]; then
+		if mkdir "$llm_lockdir" 2>/dev/null; then
+			_llm_lock_acquired=1
+		elif [[ "$_llm_lock_checked" -ne 1 && -d "$llm_lockdir" ]] && _handle_stale_llm_lock "$llm_lockdir"; then
+			# GH#20613: stale lock reclaimed — we now own it
+			_llm_lock_acquired=1
+		fi
+	fi
+
+	if [[ "$_llm_lock_acquired" -eq 1 ]]; then
+		echo "$$" >"${llm_lockdir}/pid" 2>/dev/null || true
+		# shellcheck disable=SC2064
+		trap "rm -rf '$llm_lockdir' 2>/dev/null; release_instance_lock" EXIT
+
+		local underfill_output
+		underfill_output=$(_compute_initial_underfill)
+		local initial_underfilled_mode="" initial_underfill_pct=""
+		initial_underfilled_mode=$(echo "$underfill_output" | sed -n '1p')
+		initial_underfill_pct=$(echo "$underfill_output" | sed -n '2p')
+
+		local pulse_start_epoch="" pulse_rc=""
+		pulse_start_epoch=$(date +%s)
+		_pulse_record_llm_attempt "$llm_trigger_mode" || true
+		pulse_rc=0
+		run_pulse "$initial_underfilled_mode" "$initial_underfill_pct" "$llm_trigger_mode" || pulse_rc=$?
+		local pulse_end_epoch
+		pulse_end_epoch=$(date +%s)
+		local pulse_duration=$((pulse_end_epoch - pulse_start_epoch))
+
+		if [[ "$pulse_rc" -eq 0 ]]; then
+			_pulse_record_llm_success "$llm_trigger_mode" || true
+			_run_early_exit_recycle_loop "$pulse_duration"
+		else
+			_pulse_record_llm_failure "$llm_trigger_mode" "$pulse_rc"
+		fi
+		rm -rf "$llm_lockdir" 2>/dev/null || true
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-lock-force-reclaim.sh
+++ b/.agents/scripts/tests/test-pulse-lock-force-reclaim.sh
@@ -90,7 +90,10 @@ setup_sandbox() {
 	# Create a fake pulse-wrapper.sh script that tests can launch
 	cat >"${TEST_ROOT}/pulse-wrapper.sh" <<'FAKEOF'
 #!/usr/bin/env bash
-exec sleep 60
+# Keep this shell process alive so ps command output still contains
+# "pulse-wrapper.sh"; exec would replace argv with plain "sleep" and trigger
+# the PID-reuse branch instead of the live pulse-wrapper owner branch.
+sleep 60
 FAKEOF
 	chmod +x "${TEST_ROOT}/pulse-wrapper.sh"
 

--- a/.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh
+++ b/.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh
@@ -10,14 +10,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HOME="${ROOT}/home"
 PULSE_DIR="${HOME}/.aidevops/.agent-workspace/supervisor"
 LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+LOCKDIR="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 mkdir -p "$PULSE_DIR" "$(dirname "$LOGFILE")" "$(dirname "$REPOS_JSON")"
 printf '{"initialized_repos":[]}\n' >"$REPOS_JSON"
+PULSE_FORCE_LLM=0
 
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/pulse-instance-lock.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-wrapper-cycle.sh"
 
@@ -43,6 +48,17 @@ printf '%s\n' "$((now_epoch - 10))" >"${PULSE_DIR}/last_llm_attempt_epoch"
 if _should_run_llm_supervisor || [[ -f "${PULSE_DIR}/llm_trigger_mode" ]]; then
 	fail "recent failed LLM attempt did not apply retry cooldown"
 fi
+
+llm_lockdir="${LOCKDIR}.llm"
+dead_pid=999987
+while ps -p "$dead_pid" >/dev/null 2>&1; do
+	dead_pid=$((dead_pid + 1))
+done
+mkdir -p "$llm_lockdir"
+printf '%s\n' "$dead_pid" >"${llm_lockdir}/pid"
+_pulse_maybe_run_llm_supervisor || fail "skip-cycle stale LLM lock cleanup returned non-zero"
+[[ ! -d "$llm_lockdir" ]] || fail "skip-cycle stale LLM lock cleanup left a reclaimed lock behind"
+grep -q "Stale LLM lockdir detected (owner PID ${dead_pid} is dead)" "$WRAPPER_LOGFILE" || fail "skip-cycle stale LLM lock cleanup did not log stale owner"
 
 printf '%s\n' "$((now_epoch - 120))" >"${PULSE_DIR}/last_llm_attempt_epoch"
 _should_run_llm_supervisor || fail "old failed LLM attempt did not permit retry"


### PR DESCRIPTION
## Summary

Decoupled stale LLM lock cleanup from LLM supervisor start eligibility so skipped cycles reclaim dead-owner lockdirs and release the reclaimed lock instead of blocking future eligible runs. Added regression coverage for failure-cooldown skip cycles and repaired the force-reclaim fake pulse owner so existing LLM lock tests exercise the live-owner branch.

## Files Changed

.agents/scripts/pulse-wrapper-cycle.sh,.agents/scripts/tests/test-pulse-lock-force-reclaim.sh,.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/pulse-instance-lock.sh .agents/scripts/tests/test-pulse-sigpipe-llm-state.sh .agents/scripts/tests/test-pulse-lock-force-reclaim.sh; bash .agents/scripts/tests/test-pulse-sigpipe-llm-state.sh; bash .agents/scripts/tests/test-pulse-lock-force-reclaim.sh; .agents/scripts/linters-local.sh

Resolves #26550


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.51 with gpt-5.5 spent 41m and 134,562 tokens on this with the user in an interactive session.