### PR TITLE
fix: harden launchd routine self-healing

### DIFF
--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -65,12 +65,10 @@
 set -euo pipefail
 
 # --- Bash 3.2 re-exec self-heal (GH#19348, t2146) ----------------------------
-# This script uses `${var,,}` case conversion at lines ~463-466 (bash 4.0+)
-# to avoid `tr` subprocess forks in the pattern-matcher hot path. Running
-# under /bin/bash 3.2 on macOS the script aborts with "bad substitution"
-# before it can do any useful work. The associative-array maps at the old
-# lines 399/508 were already converted to sparse indexed arrays as a first
-# line of defense, but the case-conversion path is the showstopper.
+# Historically this script used Bash 4-only lowercase expansion in the
+# pattern-matcher hot path. Running under /bin/bash 3.2 on macOS made the script
+# abort with "bad substitution" before it could do useful work. The hot path is
+# now portable too, but the re-exec guard remains useful defense-in-depth.
 #
 # Sourcing shared-constants.sh triggers the framework-wide re-exec guard:
 # if this script is invoked under bash < 4 AND a modern bash is available
@@ -471,6 +469,16 @@ _batch_get_process_ages() {
 # Regex patterns (containing ".*") match against the full command line.
 # Arguments: $1=pattern, $2=cmd_name (basename), $3=full_cmd
 # Returns: 0 if match, 1 if no match
+_memory_pressure_lower() {
+	local value="$1"
+	# Bash 3.2 compatible lowercasing. This script is usually launched with a
+	# modern Homebrew bash, but direct/manual invocations and stale launchd plists
+	# can still execute under macOS /bin/bash. Avoiding Bash 4 lowercase expansion
+	# keeps the monitor self-healing instead of failing before it can report.
+	printf '%s' "$value" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
 _matches_monitor_pattern() {
 	local pattern="$1"
 	local cmd_name="$2"
@@ -484,9 +492,9 @@ _matches_monitor_pattern() {
 		fi
 	else
 		# Simple pattern — match against basename only
-		# Use bash 4+ ${var,,} lowercasing to avoid tr subprocess forks
-		local cmd_lower="${cmd_name,,}"
-		local pattern_lower="${pattern,,}"
+		local cmd_lower pattern_lower
+		cmd_lower=$(_memory_pressure_lower "$cmd_name")
+		pattern_lower=$(_memory_pressure_lower "$pattern")
 		if [[ "$cmd_lower" == *"$pattern_lower"* ]]; then
 			return 0
 		fi

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1686,3 +1686,35 @@ aidevops-repo-sync"
 	date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
 	return 0
 }
+
+# Remove stale experimental dashboard LaunchAgent when the framework no longer
+# installs or enables it. Mac migrations can preserve ~/Library/LaunchAgents
+# entries even after aidevops-routines disables r912, creating perpetual
+# EX_CONFIG launchd churn for an unmanaged service.
+cleanup_legacy_dashboard_launchagent() {
+	case "$(uname -s)" in
+	D*) ;;
+	*) return 0 ;;
+	esac
+
+	local label="com.aidevops.dashboard"
+	local plist="$HOME/Library/LaunchAgents/${label}.plist"
+	local routines_todo="$HOME/Git/aidevops-routines/TODO.md"
+	local r912_enabled="false"
+
+	if [[ -f "$routines_todo" ]] && grep -qE '^- \[x\] r912[[:space:]]' "$routines_todo"; then
+		r912_enabled="true"
+	fi
+
+	if [[ "$r912_enabled" == "true" || ! -e "$plist" ]]; then
+		return 0
+	fi
+
+	local domain
+	domain="gui/$(id -u)"
+	launchctl bootout "${domain}/${label}" >/dev/null 2>&1 || true
+	launchctl unload "$plist" >/dev/null 2>&1 || true
+	mv "$plist" "${plist}.disabled-$(date -u +%Y%m%d%H%M%S)" 2>/dev/null || rm -f "$plist"
+	print_info "Removed stale dashboard LaunchAgent (${label}); r912 is disabled or unmanaged"
+	return 0
+}

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -921,8 +921,41 @@ fast_cp() {
 # =============================================================================
 
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+
+# Source a split-out shared module with a short retry window. During hot deploys
+# or migrated-machine restores, launchd can start a long-lived helper while the
+# agents directory is being replaced. A bare `source path` then fails with
+# "No such file or directory" even though the file appears moments later. The
+# retry keeps scheduled helpers self-healing without masking persistent install
+# corruption.
+_source_shared_module_with_retry() {
+	local module_path="$1"
+	local attempts="${AIDEVOPS_SHARED_SOURCE_ATTEMPTS:-5}"
+	local interval="${AIDEVOPS_SHARED_SOURCE_INTERVAL:-1}"
+	local attempt=1
+
+	[[ "$attempts" =~ ^[0-9]+$ ]] || attempts=5
+	[[ "$interval" =~ ^[0-9]+$ ]] || interval=1
+	[[ "$attempts" -gt 0 ]] || attempts=1
+
+	while [[ "$attempt" -le "$attempts" ]]; do
+		if [[ -f "$module_path" ]]; then
+			# shellcheck source=/dev/null
+			source "$module_path"
+			return $?
+		fi
+		if [[ "$attempt" -lt "$attempts" && "$interval" -gt 0 ]]; then
+			sleep "$interval"
+		fi
+		attempt=$((attempt + 1))
+	done
+
+	printf '[ERROR] shared module missing after %s attempt(s): %s\n' "$attempts" "$module_path" >&2
+	return 1
+}
+
 # shellcheck source=./portable-stat.sh
-source "${_SC_SELF%/*}/portable-stat.sh"
+_source_shared_module_with_retry "${_SC_SELF%/*}/portable-stat.sh"
 # _file_size_bytes, _file_perms, _file_mtime_epoch, _file_owner, _stat_batch,
 # _stat_translate_fmt are now provided by portable-stat.sh (GH#21742).
 
@@ -1129,7 +1162,7 @@ _save_cleanup_scope() {
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # shellcheck source=./shared-gh-wrappers.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
-source "${_SC_SELF%/*}/shared-gh-wrappers.sh"
+_source_shared_module_with_retry "${_SC_SELF%/*}/shared-gh-wrappers.sh"
 
 
 #######################################
@@ -1294,7 +1327,7 @@ clear_active_status_on_release() {
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # shellcheck source=./shared-todo-commit.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
-source "${_SC_SELF%/*}/shared-todo-commit.sh"
+_source_shared_module_with_retry "${_SC_SELF%/*}/shared-todo-commit.sh"
 
 # =============================================================================
 # Worktree Ownership Registry (t189) — extracted module
@@ -1428,7 +1461,7 @@ _is_process_alive_and_matches() {
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # shellcheck source=./shared-model-tier.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
-source "${_SC_SELF%/*}/shared-model-tier.sh"
+_source_shared_module_with_retry "${_SC_SELF%/*}/shared-model-tier.sh"
 
 # =============================================================================
 # Configuration Loader & Feature Toggles -- extracted module
@@ -1446,7 +1479,7 @@ source "${_SC_SELF%/*}/shared-model-tier.sh"
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # shellcheck source=./shared-feature-toggles.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
-source "${_SC_SELF%/*}/shared-feature-toggles.sh"
+_source_shared_module_with_retry "${_SC_SELF%/*}/shared-feature-toggles.sh"
 
 # This ensures all constants are available when this file is sourced
 export CONTENT_TYPE_JSON CONTENT_TYPE_FORM USER_AGENT

--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -171,6 +171,27 @@ _stats_wrapper_on_exit() {
 	return "$ec"
 }
 
+_stats_wrapper_run_health_update() {
+	local update_ec=0
+	update_health_issues || update_ec=$?
+	case "$update_ec" in
+	0)
+		return 0
+		;;
+	75)
+		# EX_TEMPFAIL is the GitHub cooldown/rate-limit path used by the gh
+		# wrappers. Treat it as a successful scheduler tick: the routine did the
+		# safe thing by preserving cached dashboards and backing off, so launchd
+		# should not mark the job as broken or create failure streak noise.
+		echo "[stats-wrapper] HEALTH-DASHBOARD-DEFERRED transient exit=${update_ec} at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
+		return 0
+		;;
+	*)
+		return "$update_ec"
+		;;
+	esac
+}
+
 #######################################
 # Main
 #######################################
@@ -266,7 +287,7 @@ main() {
 		local sweep_ec=$?
 		echo "[stats-wrapper] QUALITY-SWEEP-FAIL exit=${sweep_ec} at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
 	}
-	update_health_issues
+	_stats_wrapper_run_health_update
 
 	echo "[stats-wrapper] Finished at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
 	return 0

--- a/.agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh
+++ b/.agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Static regression checks for stale dashboard LaunchAgent cleanup.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+MIGRATIONS_SH="${REPO_ROOT}/.agents/scripts/setup/modules/migrations.sh"
+SETUP_SH="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_cleanup_function_is_guarded_by_r912_state() {
+	local snippet
+	snippet=$(awk '
+		/^cleanup_legacy_dashboard_launchagent\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^[[:space:]]*}/ { exit }
+	' "$MIGRATIONS_SH")
+	if printf '%s' "$snippet" | grep -qF 'com.aidevops.dashboard' && \
+		printf '%s' "$snippet" | grep -qF 'aidevops-routines/TODO.md' && \
+		printf '%s' "$snippet" | grep -qE 'r912' && \
+		printf '%s' "$snippet" | grep -qF 'launchctl bootout'; then
+		print_result "legacy dashboard cleanup is gated by r912 disabled state" 0
+		return 0
+	fi
+	print_result "legacy dashboard cleanup is gated by r912 disabled state" 1 \
+		"Expected label, routines TODO guard, r912 check, and launchctl bootout"
+	return 0
+}
+
+test_cleanup_runs_in_setup_paths() {
+	local count
+	count=$(grep -cF 'cleanup_legacy_dashboard_launchagent' "$SETUP_SH")
+	if [[ "$count" -ge 2 ]]; then
+		print_result "legacy dashboard cleanup runs in interactive and non-interactive setup" 0
+		return 0
+	fi
+	print_result "legacy dashboard cleanup runs in interactive and non-interactive setup" 1 \
+		"Expected cleanup_legacy_dashboard_launchagent in both setup paths, found $count"
+	return 0
+}
+
+main() {
+	test_cleanup_function_is_guarded_by_r912_state
+	test_cleanup_runs_in_setup_paths
+	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh
+++ b/.agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh
@@ -147,6 +147,15 @@ test_critical_service_exit_nonzero_and_logs() {
 	return "$result"
 }
 
+test_no_bash4_lowercase_expansion() {
+	if grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*,,\}' "$MONITOR_SCRIPT"; then
+		print_result "monitor avoids Bash 4-only lowercase expansion" 1 "Found \${var,,} expansion"
+		return 1
+	fi
+	print_result "monitor avoids Bash 4-only lowercase expansion" 0
+	return 0
+}
+
 main() {
 	if [[ ! -f "$MONITOR_SCRIPT" ]]; then
 		printf '%bFAIL%b monitor script missing: %s\n' "$TEST_RED" "$TEST_RESET" "$MONITOR_SCRIPT"
@@ -154,6 +163,7 @@ main() {
 	fi
 
 	setup_fake_ps
+	test_no_bash4_lowercase_expansion || true
 	test_ok_service_exit_zero || true
 	test_warning_service_exit_zero_and_logs || true
 	test_critical_service_exit_nonzero_and_logs || true

--- a/.agents/scripts/tests/test-shared-constants-source-retry.sh
+++ b/.agents/scripts/tests/test-shared-constants-source-retry.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression checks for launchd/update race hardening in shared-constants.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SHARED_CONSTANTS="${SCRIPT_DIR}/../shared-constants.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_split_modules_use_retry_helper() {
+	local missing=""
+	local module
+	for module in portable-stat shared-gh-wrappers shared-todo-commit shared-model-tier shared-feature-toggles; do
+		if ! grep -qF "_source_shared_module_with_retry \"\${_SC_SELF%/*}/${module}.sh\"" "$SHARED_CONSTANTS"; then
+			missing="${missing:+$missing }${module}"
+		fi
+	done
+
+	if [[ -z "$missing" ]]; then
+		print_result "shared split modules source through retry helper" 0
+		return 0
+	fi
+	print_result "shared split modules source through retry helper" 1 "missing retry for: $missing"
+	return 0
+}
+
+test_retry_helper_has_bounded_attempts() {
+	local snippet
+	snippet=$(awk '
+		/^_source_shared_module_with_retry\(\) \{/ { in_helper=1 }
+		in_helper { print }
+		in_helper && /^[[:space:]]*}/ { exit }
+	' "$SHARED_CONSTANTS")
+	if printf '%s' "$snippet" | grep -qF 'AIDEVOPS_SHARED_SOURCE_ATTEMPTS' && \
+		printf '%s' "$snippet" | grep -qF 'shared module missing after' && \
+		printf '%s' "$snippet" | grep -qE '^[[:space:]]*return 1'; then
+		print_result "shared source retry is bounded and reports persistent corruption" 0
+		return 0
+	fi
+	print_result "shared source retry is bounded and reports persistent corruption" 1 \
+		"Expected bounded attempts, diagnostic message, and return 1"
+	return 0
+}
+
+main() {
+	test_split_modules_use_retry_helper
+	test_retry_helper_has_bounded_attempts
+	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -152,10 +152,10 @@ test_export_before_self_check() {
 	return 0
 }
 
-# Test 5: dashboard refresh failures must not be swallowed by the wrapper.
-# The EXIT trap only emits HEALTH-DASHBOARD-FAIL when main() returns non-zero;
-# keeping `update_health_issues || true` here would recreate the silent-stale
-# dashboard failure mode from GH#24264.
+# Test 5: dashboard refresh failures must not be blindly swallowed by the wrapper.
+# The wrapper may intentionally defer EX_TEMPFAIL/rate-limit exits, but ordinary
+# dashboard failures must still flow through _stats_wrapper_run_health_update so
+# the EXIT trap can emit HEALTH-DASHBOARD-FAIL.
 test_dashboard_update_failure_not_swallowed() {
 	local production_snippet
 	production_snippet=$(awk '
@@ -168,12 +168,30 @@ test_dashboard_update_failure_not_swallowed() {
 			"stats-wrapper.sh still swallows update_health_issues failures with '|| true'"
 		return 0
 	fi
-	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*update_health_issues[[:space:]]*$'; then
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*_stats_wrapper_run_health_update[[:space:]]*$'; then
 		print_result "dashboard update failures propagate to stats-wrapper trap" 0
 		return 0
 	fi
 	print_result "dashboard update failures propagate to stats-wrapper trap" 1 \
-		"Expected a direct update_health_issues call in stats-wrapper.sh"
+		"Expected _stats_wrapper_run_health_update call in stats-wrapper.sh"
+	return 0
+}
+
+test_transient_dashboard_tempfail_is_deferred() {
+	local helper_snippet
+	helper_snippet=$(awk '
+		/^_stats_wrapper_run_health_update\(\) \{/ { in_helper=1 }
+		in_helper { print }
+		in_helper && /^[[:space:]]*}$/ { exit }
+	' "$WRAPPER_SCRIPT")
+	if printf '%s' "$helper_snippet" | grep -qE '^[[:space:]]*75\)' && \
+		printf '%s' "$helper_snippet" | grep -qF 'HEALTH-DASHBOARD-DEFERRED' && \
+		printf '%s' "$helper_snippet" | grep -qE "^[[:space:]]*return \"\\\$update_ec\""; then
+		print_result "stats-wrapper defers EX_TEMPFAIL but propagates other dashboard failures" 0
+		return 0
+	fi
+	print_result "stats-wrapper defers EX_TEMPFAIL but propagates other dashboard failures" 1 \
+		"Expected rc=75 defer path plus default return update_ec in _stats_wrapper_run_health_update"
 	return 0
 }
 
@@ -202,6 +220,7 @@ main_test() {
 	test_export_is_inside_main_not_top_level
 	test_export_before_self_check
 	test_dashboard_update_failure_not_swallowed
+	test_transient_dashboard_tempfail_is_deferred
 	test_dashboard_body_edit_failure_returns_nonzero
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-worker-watchdog-find-workers.sh
+++ b/.agents/scripts/tests/test-worker-watchdog-find-workers.sh
@@ -209,6 +209,19 @@ test_output_shape_pid_elapsed_command() {
 	return 0
 }
 
+test_worker_watchdog_script_dir_retry_present() {
+	local watchdog_script="${LIB_DIR}/worker-watchdog.sh"
+	if grep -qF '_resolve_script_dir_with_retry' "$watchdog_script" && \
+		grep -qF 'AIDEVOPS_SCRIPT_DIR_ATTEMPTS' "$watchdog_script" && \
+		grep -qF "\${HOME}/.aidevops/agents/scripts" "$watchdog_script"; then
+		print_result "worker-watchdog retries script-dir resolution during deploy races" 0
+		return 0
+	fi
+	print_result "worker-watchdog retries script-dir resolution during deploy races" 1 \
+		"Expected retry helper and deployed-dir fallback in worker-watchdog.sh"
+	return 0
+}
+
 run_all() {
 	setup_test_env
 	test_alternation_pattern_matches_headless_with_model_flag
@@ -219,6 +232,7 @@ run_all() {
 	test_interactive_opencode_excluded
 	test_unrelated_process_excluded
 	test_output_shape_pid_elapsed_command
+	test_worker_watchdog_script_dir_retry_present
 	teardown_test_env
 	return 0
 }

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -63,7 +63,39 @@ fi
 export PATH="${_aidevops_path_prefix}:${PATH}"
 unset _aidevops_path_prefix
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+_resolve_script_dir_with_retry() {
+	local source_path="$1"
+	local lib_dir
+	local attempts="${AIDEVOPS_SCRIPT_DIR_ATTEMPTS:-5}"
+	local interval="${AIDEVOPS_SCRIPT_DIR_INTERVAL:-1}"
+	local attempt=1
+
+	[[ "$attempts" =~ ^[0-9]+$ ]] || attempts=5
+	[[ "$interval" =~ ^[0-9]+$ ]] || interval=1
+	[[ "$attempts" -gt 0 ]] || attempts=1
+
+	lib_dir="$(dirname "$source_path")"
+	while [[ "$attempt" -le "$attempts" ]]; do
+		if [[ -d "$lib_dir" ]]; then
+			cd "$lib_dir" && pwd
+			return $?
+		fi
+		if [[ "$attempt" -lt "$attempts" && "$interval" -gt 0 ]]; then
+			sleep "$interval"
+		fi
+		attempt=$((attempt + 1))
+	done
+
+	if [[ -d "${HOME}/.aidevops/agents/scripts" ]]; then
+		cd "${HOME}/.aidevops/agents/scripts" && pwd
+		return $?
+	fi
+
+	printf '[worker-watchdog] script directory unavailable after %s attempt(s): %s\n' "$attempts" "$lib_dir" >&2
+	return 1
+}
+
+SCRIPT_DIR="$(_resolve_script_dir_with_retry "${BASH_SOURCE[0]}")" || exit 1
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=/dev/null

--- a/setup.sh
+++ b/setup.sh
@@ -1256,6 +1256,7 @@ _setup_run_non_interactive() {
 	_time_step "cleanup_stale_health_issue_caches" cleanup_stale_health_issue_caches
 	_time_step "cleanup_worktree_entries_in_repos_json" cleanup_worktree_entries_in_repos_json
 	_time_step "_cleanup_legacy_model_config" _cleanup_legacy_model_config
+	_time_step "cleanup_legacy_dashboard_launchagent" cleanup_legacy_dashboard_launchagent
 	# t2888: install/heal opencode-ai. Companion to t2887's runtime canary
 	# fail-fast -- t2887 detects when $OPENCODE_BIN_DEFAULT is wrong, this
 	# one fixes it by reinstalling opencode-ai@latest (overwriting any bin
@@ -1424,7 +1425,7 @@ _setup_run_interactive() {
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
 	# Silent one-shot migrations (idempotent, flag-guarded — no prompt needed).
-	cleanup_stale_health_issue_caches; cleanup_worktree_entries_in_repos_json; _cleanup_legacy_model_config
+	cleanup_stale_health_issue_caches; cleanup_worktree_entries_in_repos_json; _cleanup_legacy_model_config; cleanup_legacy_dashboard_launchagent
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 	confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 	confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift


### PR DESCRIPTION
## Summary

- Resolves #26558.
- Hardens memory pressure monitoring against macOS Bash 3.2/stale launchd plist invocations by removing Bash 4-only lowercase expansion.
- Adds bounded retry sourcing for split shared modules so launchd helpers survive hot-deploy or migration-time file replacement races.
- Makes worker watchdog script-dir resolution retry and fall back to the deployed scripts directory.
- Treats stats-wrapper GitHub EX_TEMPFAIL/rate-limit cooldown as a deferred scheduler tick while preserving hard failures.
- Removes stale `com.aidevops.dashboard` LaunchAgent when r912 is disabled/unmanaged, preventing EX_CONFIG churn after Mac migration.

## Verification

- `bash .agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh`
- `bash .agents/scripts/tests/test-shared-constants-source-retry.sh`
- `bash .agents/scripts/tests/test-worker-watchdog-find-workers.sh`
- `bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh`
- `bash .agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh`
- `shellcheck .agents/scripts/memory-pressure-monitor.sh .agents/scripts/shared-constants.sh .agents/scripts/worker-watchdog.sh .agents/scripts/stats-wrapper.sh .agents/scripts/setup/modules/migrations.sh setup.sh .agents/scripts/tests/test-memory-pressure-monitor-service-exit.sh .agents/scripts/tests/test-shared-constants-source-retry.sh .agents/scripts/tests/test-worker-watchdog-find-workers.sh .agents/scripts/tests/test-stats-wrapper-headless-export.sh .agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh`
- `.agents/scripts/linters-local.sh`
- `./setup.sh --non-interactive`

## Local post-deploy evidence

- `cleanup_legacy_dashboard_launchagent` removed stale `com.aidevops.dashboard` LaunchAgent.
- `launchctl print gui/$(id -u)/com.aidevops.dashboard` reports service not found.
- `sh.aidevops.memory-pressure-monitor` is loaded with `/opt/homebrew/bin/bash`; manual `/bin/bash` run no longer emits bad substitution and exits only because real memory thresholds are currently exceeded.
- `stats-wrapper.sh --dry-run` passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.51 plugin for [OpenCode](https://opencode.ai) v1.17.13
