### PR TITLE
fix: guard empty worker label match

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -265,7 +265,7 @@ _handle_changes_requested_review_gate() {
 	# PRs keep the historical fast-routing behaviour below. Operators who prefer
 	# preserving the PR/review context can opt in to a remediation-first cycle.
 	if _pulse_merge_changes_requested_thread_remediation_first_enabled \
-		&& [[ "$_cr_label_list" == *"${_OW_LABEL_PAT:-}"* \
+		&& [[ ( -n "${_OW_LABEL_PAT:-}" && "$_cr_label_list" == *"${_OW_LABEL_PAT:-}"* ) \
 			|| "$_cr_label_list" == *",origin:worker-takeover,"* ]] \
 		&& [[ "$_cr_label_list" != *",external-contributor,"* ]] \
 		&& [[ "$_cr_label_list" != *",no-takeover,"* ]] \

--- a/.agents/scripts/shared-constants-deps-check.sh
+++ b/.agents/scripts/shared-constants-deps-check.sh
@@ -147,8 +147,9 @@ layer3_check() {
 # -----------------------------------------------------------------------------
 # Layer 4: verify parser contract still holds
 # -----------------------------------------------------------------------------
-# The helper's discovery regex is a single simple pattern:
-#   awk '/^source[[:space:]]/ && /_SC_SELF/ { ... }'
+# The helper's discovery regex accepts file-scope mandatory shared-module loads:
+#   `source "${_SC_SELF%/*}/<file>.sh"`
+#   `_source_shared_module_with_retry "${_SC_SELF%/*}/<file>.sh"`
 #
 # If shared-constants.sh *has* sibling source directives (detectable via a
 # cheap grep), the helper MUST return a non-empty list. If the cheap grep
@@ -162,9 +163,9 @@ layer4_check() {
 		return 1
 	fi
 
-	# Cheap grep: count candidate sibling-source lines.
+	# Cheap grep: count candidate mandatory sibling-source lines.
 	local cheap_count
-	cheap_count=$(grep -cE '^source[[:space:]]+"\$\{_SC_SELF%/\*\}/' "$SHARED_CONSTANTS" || true)
+	cheap_count=$(grep -cE '^(source|_source_shared_module_with_retry)[[:space:]]+"\$\{_SC_SELF%/\*\}/' "$SHARED_CONSTANTS" || true)
 	cheap_count=${cheap_count:-0}
 
 	# Call the parser in a subshell so its errors / output don't leak.
@@ -188,7 +189,7 @@ layer4_check() {
 		fail "Layer 4: shared-constants.sh has $cheap_count sibling source lines but parser found 0"
 		warn "The helper's discovery regex no longer matches the source syntax."
 		warn "Grep candidate lines:"
-		grep -nE '^source[[:space:]]+"\$\{_SC_SELF%/\*\}/' "$SHARED_CONSTANTS" | sed 's/^/  /' >&2
+		grep -nE '^(source|_source_shared_module_with_retry)[[:space:]]+"\$\{_SC_SELF%/\*\}/' "$SHARED_CONSTANTS" | sed 's/^/  /' >&2
 		return 1
 	fi
 

--- a/.agents/scripts/tests/lib/test-helpers.sh
+++ b/.agents/scripts/tests/lib/test-helpers.sh
@@ -29,10 +29,12 @@
 # Contract
 # --------
 # - `_test_discover_shared_deps <dir>` — echoes one filename per line for every
-#   bare `source "${_SC_SELF%/*}/<file>.sh"` directive in
-#   `<dir>/shared-constants.sh`. Conditional sources (guarded by `[[ -r ... ]]`
-#   or equivalent) are intentionally ignored — they are benign when the file
-#   is absent and do not break sourcing.
+#   mandatory shared module load in `<dir>/shared-constants.sh`: either the
+#   historical bare `source "${_SC_SELF%/*}/<file>.sh"` form or the retry-aware
+#   `_source_shared_module_with_retry "${_SC_SELF%/*}/<file>.sh"` form.
+#   Conditional sources (guarded by `[[ -r ... ]]` or equivalent) are
+#   intentionally ignored — they are benign when the file is absent and do not
+#   break sourcing.
 # - `_test_copy_shared_deps <src_dir> <dest_dir>` — copies `shared-constants.sh`
 #   plus every sibling it discovers into `<dest_dir>`. Returns non-zero with a
 #   clear "FAIL:" message if any dep is missing in the source tree. Callers
@@ -78,8 +80,8 @@ _TEST_HELPERS_LOADED=1
 # -----------------------------------------------------------------------------
 # _test_discover_shared_deps <dir>
 # -----------------------------------------------------------------------------
-# Parses <dir>/shared-constants.sh and echoes every sibling file it sources
-# via the `source "${_SC_SELF%/*}/<filename>.sh"` pattern, one per line.
+# Parses <dir>/shared-constants.sh and echoes every mandatory sibling file it
+# sources, one per line.
 #
 # Matches only UNCONDITIONAL, file-scope directives. Conditional sources
 # (e.g., `if [[ -r "$path" ]]; then source "$path"; fi` blocks inside
@@ -105,10 +107,11 @@ _test_discover_shared_deps() {
 		return 1
 	fi
 
-	# Match lines that begin with `source "${_SC_SELF%/*}/<filename>.sh"`
-	# (no leading whitespace — file-scope only). Extract the basename.
+	# Match file-scope mandatory loads and extract the basename. Conditional
+	# source guards use a leading `[[ -r ... ]] && source ...` expression and are
+	# intentionally excluded.
 	awk '
-		/^source[[:space:]]/ && /_SC_SELF/ {
+		(/^(source|_source_shared_module_with_retry)[[:space:]]/ && /_SC_SELF/) {
 			line = $0
 			# Strip everything up to and including the last slash
 			sub(/.*\//, "", line)

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -236,6 +236,34 @@ test_changes_requested_skips_remediation_for_external_contributor() {
 	return 0
 }
 
+test_changes_requested_empty_worker_label_pattern_does_not_match_every_label() {
+	setup_test_env
+	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
+	_OW_LABEL_PAT=""
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	if _handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:interactive"; then
+		print_result "empty worker label pattern does not match every PR label" 1 \
+			"Expected gate to skip merge after fallback routing"
+	elif [[ ! -s "$SCANNER_LOG" ]] && grep -q 'route 77 owner/repo' "$route_log"; then
+		print_result "empty worker label pattern does not match every PR label" 0
+	else
+		print_result "empty worker label pattern does not match every PR label" 1 \
+			"scanner=$(tr '\n' ';' <"$SCANNER_LOG"), route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_unresolved_conversation_dispatches_targeted_human_thread_remediation
 	test_other_merge_failures_do_not_dispatch_review_thread_remediation
@@ -243,6 +271,7 @@ main() {
 	test_changes_requested_opt_in_dispatches_remediation_without_routing
 	test_changes_requested_routes_when_remediation_unavailable
 	test_changes_requested_skips_remediation_for_external_contributor
+	test_changes_requested_empty_worker_label_pattern_does_not_match_every_label
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	printf 'Tests failed: %d\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Guard empty `_OW_LABEL_PAT` before using it in the CHANGES_REQUESTED remediation-first glob.
- Preserve the explicit `origin:worker-takeover` path.
- Add regression coverage for an empty worker label pattern with a non-worker PR label.

Resolves #26560

## Testing
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`
- `bash -n .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`
- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.52 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 81,824 tokens on this as a headless worker.