### PR TITLE
fix: teach shared constants deps parser retry sources

### DIFF
--- a/.agents/scripts/shared-constants-deps-check.sh
+++ b/.agents/scripts/shared-constants-deps-check.sh
@@ -17,7 +17,8 @@
 #   2. `layer4` — verify that `_test_discover_shared_deps` (run against the
 #      on-disk `shared-constants.sh`) still succeeds and returns at least one
 #      sibling. This is a lightweight sanity check that the parser contract
-#      (match `source "${_SC_SELF%/*}/<file>.sh"` on a line by itself) still
+#      (match `source "${_SC_SELF%/*}/<file>.sh"` or the retrying helper
+#      equivalent on a line by itself) still
 #      holds after any edit to shared-constants.sh. If shared-constants.sh is
 #      ever rewritten in a way that uses a different sibling-source syntax,
 #      this check will flag it immediately.
@@ -27,7 +28,7 @@
 # Exit 2  = parser returned no siblings from shared-constants.sh — only an
 #           error when shared-constants.sh *does* have `source` directives
 #           for sub-libraries (otherwise legitimate state = exit 0). Best-effort
-#           heuristic: if a grep for `source "${_SC_SELF%/*}/` finds matches
+#           heuristic: if a grep for sibling source/retry-helper lines finds matches
 #           and the parser returns zero, something is wrong.
 # Exit 3  = invalid invocation / missing prerequisite file.
 # =============================================================================

--- a/.agents/scripts/tests/lib/test-helpers.sh
+++ b/.agents/scripts/tests/lib/test-helpers.sh
@@ -113,6 +113,8 @@ _test_discover_shared_deps() {
 	awk '
 		(/^(source|_source_shared_module_with_retry)[[:space:]]/ && /_SC_SELF/) {
 			line = $0
+			# Strip trailing comments before slash-based basename extraction.
+			sub(/[[:space:]]*#.*/, "", line)
 			# Strip everything up to and including the last slash
 			sub(/.*\//, "", line)
 			# Strip trailing quote and anything after it

--- a/.agents/scripts/tests/test-test-helpers.sh
+++ b/.agents/scripts/tests/test-test-helpers.sh
@@ -229,6 +229,24 @@ out=$(_test_discover_shared_deps "$cond_src")
 assert_eq "only unconditional source discovered" "real-sibling.sh" "$out"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Test 8: discover tolerates trailing comments with slashes
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 8: trailing comments with slashes do not corrupt basename parsing"
+comment_src=$(mktemp -d 2>/dev/null || mktemp -d -t commentsrc)
+# shellcheck disable=SC2064
+trap "rm -rf '$tmpdir' '$fake_src' '$fake_dest' '$empty_src' '$cond_src' '$comment_src'" EXIT
+cat >"${comment_src}/shared-constants.sh" <<'EOF'
+#!/usr/bin/env bash
+_SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+source "${_SC_SELF%/*}/real-sibling.sh" # fallback/retry docs/path
+_source_shared_module_with_retry "${_SC_SELF%/*}/retry-sibling.sh" # fallback/retry
+EOF
+
+out=$(_test_discover_shared_deps "$comment_src")
+assert_eq "comments with slashes do not affect discovered basenames" $'real-sibling.sh\nretry-sibling.sh' "$out"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- Resolves #26562.
- Updates the shared-constants dependency parser to recognise `_source_shared_module_with_retry "${_SC_SELF%/*}/..."` calls introduced by #26559.
- Keeps the test-harness dependency guard aligned so temp-dir shared-constants tests copy and source all split shared modules.

## Verification

- `bash .agents/scripts/shared-constants-deps-check.sh`
- `bash .agents/scripts/tests/test-test-helpers.sh`
- `shellcheck .agents/scripts/shared-constants-deps-check.sh .agents/scripts/tests/lib/test-helpers.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.52 plugin for [OpenCode](https://opencode.ai) v1.17.13
