### PR TITLE
t18064: fix GUI desktop dependency checks

### DIFF
--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -9,6 +9,7 @@ REPO_ROOT="${SCRIPT_DIR}/../../.."
 SETUP_SH="${REPO_ROOT}/setup.sh"
 AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
 PACKAGE_JSON="${REPO_ROOT}/package.json"
+GUI_WEB_PACKAGE_JSON="${REPO_ROOT}/packages/gui-web/package.json"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -145,8 +146,35 @@ test_gui_desktop_installer_contract() {
 
 	assert_contains "installer honours configured app dir env" "$text" 'AIDEVOPS_GUI_DESKTOP_APP_DIR'
 	assert_contains "installer keeps explicit app-dir override" "$text" '--app-dir'
-	assert_contains "installer dependency check includes new Cal Sans font package" "$text" 'node_modules/@fontsource/cal-sans'
 	assert_contains "installer dependency check includes new Zilla Slab font package" "$text" 'node_modules/@fontsource/zilla-slab'
+	python3 - "$installer" "$GUI_WEB_PACKAGE_JSON" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+installer_path = pathlib.Path(sys.argv[1])
+package_path = pathlib.Path(sys.argv[2])
+installer_text = installer_path.read_text()
+package_json = json.loads(package_path.read_text())
+expected = sorted(
+    f"node_modules/{name}"
+    for name in package_json.get("dependencies", {})
+    if name.startswith("@fontsource/")
+)
+actual = sorted(set(re.findall(r"node_modules/@fontsource/[a-z0-9-]+", installer_text)))
+if actual == expected:
+    sys.exit(0)
+print("expected font dependencies:", ", ".join(expected), file=sys.stderr)
+print("installer font dependencies:", ", ".join(actual), file=sys.stderr)
+sys.exit(1)
+PY
+	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "installer font dependency checks match GUI web package" 0
+		return 0
+	fi
+	print_result "installer font dependency checks match GUI web package" 1 "packages/gui-desktop/scripts/install-macos-app.sh is out of sync with packages/gui-web/package.json"
 	return 0
 }
 

--- a/TODO.md
+++ b/TODO.md
@@ -1098,6 +1098,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18063 Add social graph preview to README ref:GH#26497 pr:#26498 completed:2026-07-04
 
+- [ ] t18064 Fix GUI desktop dependency startup failure #bug ref:GH#26569
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/packages/gui-desktop/scripts/install-macos-app.sh
+++ b/packages/gui-desktop/scripts/install-macos-app.sh
@@ -248,7 +248,6 @@ gui_dependencies_present() {
 node_modules/vite/bin/vite.js
 node_modules/react
 node_modules/react-icons
-node_modules/@fontsource/cal-sans
 node_modules/@fontsource/courier-prime
 node_modules/@fontsource/dm-mono
 node_modules/@fontsource/dm-sans


### PR DESCRIPTION
## Summary

- Remove stale `@fontsource/cal-sans` from the generated macOS GUI service dependency check.
- Add a regression test that compares installer font dependency sentinels against `packages/gui-web/package.json`.
- Reinstalled and smoke-started the local `/Applications/aidevops.app`; launcher log now reports both local services ready.

## Verification

- `.agents/scripts/tests/test-setup-scoped-dispatch.sh`
- `bun install --frozen-lockfile && npm run gui:desktop:check`
- `shellcheck packages/gui-desktop/scripts/install-macos-app.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh`
- `npm run gui:ci`
- `npm run gui:desktop:install:macos`
- `/Applications/aidevops.app/Contents/Resources/aidevops-gui-services.sh start`
- Read `~/Library/Logs/aidevops-gui/launcher.log`: `aidevops GUI services ready: API http://127.0.0.1:8787/api/health, web http://127.0.0.1:5173/`

## Notes

- `.agents/scripts/linters-local.sh` completed with unrelated pre-existing blocking quality debt in repository-wide complexity/file-size gates; targeted ShellCheck and GUI CI passed.

Resolves #26569

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.52 plugin for [OpenCode](https://opencode.ai) v1.17.13
