### PR TITLE
GH#3523: fix: filter historic fix praise in review feedback

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -205,6 +205,13 @@ _apply_positive_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
+		# Review summaries often describe the bug the PR already fixed, e.g.
+		# "corrects a broken URL". Do not treat those historic defect words as
+		# new quality-debt findings when the same body is otherwise praise-only.
+		($body | test(
+			"\\b(corrects?|fix(es|ed)?|replaces?|addresses?)\\b[^.\\n]*(\\bbroken\\b|\\bincorrect\\b|\\bwrong\\b|\\bbug\\b|\\bissue\\b)|" +
+			"\\b(change|fix) is correct\\b|\\bcorrect and improves?\\b"; "i")) as $historic_fix_praise |
+
 		($body | test(
 			"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend(ed|ing)?\\b|" +
 			"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'"'"'?t|do not)\\b|" +
@@ -215,7 +222,7 @@ _apply_positive_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable_raw |
 
-		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not)) as $actionable |
+		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and (($historic_fix_praise and $summary_praise_only) | not)) as $actionable |
 
 		($body | test(
 			"\\bmerging\\.?$|\\bmerge (this|the) pr\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -73,6 +73,10 @@ _test_approval_filter() {
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
 		($body | test(
+			"\\b(corrects?|fix(es|ed)?|replaces?|addresses?)\\b[^.\\n]*(\\bbroken\\b|\\bincorrect\\b|\\bwrong\\b|\\bbug\\b|\\bissue\\b)|" +
+			"\\b(change|fix) is correct\\b|\\bcorrect and improves?\\b"; "i")) as $historic_fix_praise |
+
+		($body | test(
 			"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend(ed|ing)?\\b|" +
 			"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'"'"'?t|do not)\\b|" +
 			"\\bvulnerab|\\binsecure|\\binjection\\b|\\bxss\\b|\\bcsrf\\b|" +
@@ -82,7 +86,7 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable_raw |
 
-		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not)) as $actionable |
+		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and (($historic_fix_praise and $summary_praise_only) | not)) as $actionable |
 
 		# GH#5668: merge/CI-status comments are not actionable review feedback
 		($body | test(
@@ -243,6 +247,20 @@ test_skips_no_suggestions_at_this_time_review() {
 		print_result "skip 'no suggestions at this time' review" 0
 	else
 		print_result "skip 'no suggestions at this time' review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_pr155_historic_broken_url_praise_review() {
+	local result
+	# shellcheck disable=SC2016  # literal review body includes Markdown backticks
+	result=$(_test_approval_filter '## Code Review
+
+This pull request corrects a broken placeholder URL for the `ultimate-multisite` plugin in the `wp-preferred.md` documentation file. The change is straightforward and accurate, replacing the incorrect link with the proper URL to the plugin page. The change is correct and improves the quality of the documentation.' "COMMENTED" "gemini")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip PR #155 historic broken-URL praise review" 0
+	else
+		print_result "skip PR #155 historic broken-URL praise review" 1 "expected skip, got ${result}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -238,6 +238,7 @@ main() {
 	test_skips_no_further_recommendations_review
 	test_skips_gemini_style_positive_summary_review
 	test_skips_no_suggestions_at_this_time_review
+	test_skips_pr155_historic_broken_url_praise_review
 	test_skips_no_suggestions_for_improvement_review
 	test_skips_review_thread_response_inline_comment
 	test_skips_no_further_concerns_inline_ack


### PR DESCRIPTION
## Summary

Filtered praise-only review summaries that mention defects already fixed by the PR, preventing positive reviews like PR #155 from being filed as quality-debt. Added a regression test for the historic broken-URL praise body.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh,.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh,.agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (60/60 passed); shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh; bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #3523


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 6m and 78,879 tokens on this as a headless worker.