### PR TITLE
GH#3198: fix: harden post-merge scanner diagnostics

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -285,14 +285,14 @@ fetch_review_threads_json() {
 					}
 				}
 			}
-		' 2>/dev/null) || rc=$?
+		') || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		log "fetch_review_threads_json: gh graphql failed for ${repo}#${pr} (rc=${rc})"
 		return 2
 	fi
 	# Validate the response is shaped as expected. If the API returned an
 	# error object instead of data, treat it as a fetch failure.
-	if ! printf '%s' "$resp" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null 2>&1; then
+	if ! printf '%s' "$resp" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null; then
 		log "fetch_review_threads_json: malformed response for ${repo}#${pr}"
 		return 2
 	fi
@@ -351,7 +351,7 @@ fetch_inline_comments_md() {
 					+ "\n"
 				) | join("\n")
 			end
-		' 2>/dev/null) || {
+		') || {
 		log "fetch_inline_comments_md: jq failed on ${repo}#${pr}"
 		return 2
 	}
@@ -386,7 +386,7 @@ fetch_inline_comments_md() {
 fetch_review_summaries_md() {
 	local repo="$1" pr="$2"
 	local resp rc=0
-	resp=$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate 2>/dev/null) || rc=$?
+	resp=$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate) || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		log "fetch_review_summaries_md: gh api failed for ${repo}#${pr} (rc=${rc})"
 		return 2
@@ -421,7 +421,7 @@ fetch_review_summaries_md() {
 					+ "\n"
 				) | join("\n")
 			end
-		' 2>/dev/null) || {
+		') || {
 		log "fetch_review_summaries_md: jq failed on ${repo}#${pr}"
 		return 2
 	}
@@ -458,7 +458,7 @@ fetch_file_refs_md() {
 				| select(.path != null)
 				| "- `\(.path):\(.line // "?")`"
 			] | unique | .[]
-		' 2>/dev/null) || {
+		') || {
 		log "fetch_file_refs_md: jq failed on ${repo}#${pr}"
 		return 2
 	}
@@ -841,7 +841,7 @@ _Refreshed by \`post-merge-review-scanner.sh refresh\` (t2054)._"
 		return 1
 	fi
 	if gh issue close "$issue_number" --repo "$repo" \
-		--comment "$close_comment" >/dev/null 2>&1; then
+		--comment "$close_comment" >/dev/null; then
 		log "issue #${issue_number}: closed (no unresolved findings on PR #${pr})"
 		return 1
 	fi
@@ -930,7 +930,7 @@ _refresh_one_issue() {
 	# Bare `gh issue edit` always uses GraphQL and silently fails the body
 	# update when the 5000/hr GraphQL budget is exhausted. PR #21733 model.
 	if gh_issue_edit_safe "$issue_number" --repo "$repo" \
-		--body "$new_body_with_sig" >/dev/null 2>&1; then
+		--body "$new_body_with_sig" >/dev/null; then
 		log "issue #${issue_number}: body updated"
 		return 0
 	fi
@@ -951,7 +951,7 @@ do_refresh() {
 	local issues_json
 	issues_json=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
 		--state open --limit "$SCANNER_REFRESH_LIMIT" \
-		--json number,title,body 2>/dev/null || echo "[]")
+		--json number,title,body || echo "[]")
 
 	if [[ "$issues_json" == "[]" ]]; then
 		log "No open review-followup issues found"

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -481,6 +481,22 @@ out=$(do_refresh "stub/repo" "true" 2>&1) || rc=$?
 assert_rc "refresh skips malformed title without erroring" "0" "$rc"
 assert_contains "refresh logs malformed title skip" "cannot extract PR number" "$out"
 
+echo ""
+echo "Test: fetch_review_summaries_md — nullable review body does not abort jq"
+write_graphql_fixture "$FIX_GRAPHQL"
+jq -n '[{user: {login: "gemini-code-assist"}, body: null, html_url: "https://example/review"}]' >"$FIX_REVIEWS"
+rc=0
+out=$(fetch_review_summaries_md "stub/repo" "42" 2>&1) || rc=$?
+assert_rc "nullable review body returns success" "0" "$rc"
+if [[ -z "$out" ]]; then
+	echo "  PASS: nullable review body is ignored without jq error"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: nullable review body produced output or error"
+	echo "    actual (first 200): ${out:0:200}"
+	FAIL=$((FAIL + 1))
+fi
+
 # -----------------------------------------------------------------------------
 # Error-propagation tests (CodeRabbit CR on PR #18736)
 #
@@ -553,8 +569,16 @@ echo ""
 echo "Test: fetch_review_threads_json — gh failure returns exit 2"
 install_failing_gh
 rc=0
-fetch_review_threads_json "stub/repo" "42" >/dev/null 2>&1 || rc=$?
+out=$(fetch_review_threads_json "stub/repo" "42" 2>&1) || rc=$?
 assert_rc "fetch_review_threads_json propagates gh failure" "2" "$rc"
+assert_contains "fetch_review_threads_json surfaces gh stderr" "gh stub: simulated failure for api graphql" "$out"
+
+echo ""
+echo "Test: fetch_review_summaries_md — gh failure returns exit 2 and surfaces stderr"
+rc=0
+out=$(fetch_review_summaries_md "stub/repo" "42" 2>&1) || rc=$?
+assert_rc "fetch_review_summaries_md propagates gh failure" "2" "$rc"
+assert_contains "fetch_review_summaries_md surfaces gh stderr" "gh stub: simulated failure for api repos/stub/repo/pulls/42/reviews" "$out"
 
 echo ""
 echo "Test: build_pr_followup_body — fetch error returns exit 2 (NOT 1)"


### PR DESCRIPTION
## Summary

Removed stderr suppression from post-merge review scanner GitHub and jq failure paths so authentication, API, and filter errors remain visible while preserving rc=2 fetch-error handling. Added regressions for nullable review bodies and surfaced gh stderr.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh,.agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-post-merge-review-scanner.sh (52 passed); shellcheck .agents/scripts/post-merge-review-scanner.sh .agents/scripts/tests/test-post-merge-review-scanner.sh; .agents/scripts/complexity-regression-helper.sh check --base origin/main --metric function-complexity/nesting-depth/file-size/bash32-compat (no new violations); .agents/scripts/linters-local.sh attempted twice, timed out at repository-wide gates after pre-existing/advisory debt

Resolves #3198


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 14m and 116,621 tokens on this as a headless worker.