### PR TITLE
GH#26582: fix: harden font dependency test parsing

### DIFF
--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -159,10 +159,10 @@ installer_text = installer_path.read_text()
 package_json = json.loads(package_path.read_text())
 expected = sorted(
     f"node_modules/{name}"
-    for name in package_json.get("dependencies", {})
+    for name in (package_json.get("dependencies") or {})
     if name.startswith("@fontsource/")
 )
-actual = sorted(set(re.findall(r"node_modules/@fontsource/[a-z0-9-]+", installer_text)))
+actual = sorted(set(re.findall(r"node_modules/@fontsource/[a-z0-9_.-]+", installer_text)))
 if actual == expected:
     sys.exit(0)
 print("expected font dependencies:", ", ".join(expected), file=sys.stderr)


### PR DESCRIPTION
## Summary

Hardened the GUI desktop installer dependency parity test by tolerating null package.json dependencies and matching npm font package names that include underscores or dots.

## Files Changed

.agents/scripts/tests/test-setup-scoped-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-setup-scoped-dispatch.sh; .agents/scripts/tests/test-setup-scoped-dispatch.sh

Resolves #26582


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1m and 32,234 tokens on this as a headless worker.