### PR TITLE
GH#26583: fix: harden dashboard systemd cleanup

### DIFF
--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1722,24 +1722,29 @@ cleanup_legacy_dashboard_launchagent() {
 		;;
 	Linux)
 		local user_systemd_dir="$HOME/.config/systemd/user"
+		local has_systemd=0
+		if command -v systemctl >/dev/null && systemctl --user status >/dev/null; then
+			has_systemd=1
+		fi
 		local removed=0
 		local unit
 		for unit in "$systemd_unit" "$legacy_systemd_unit"; do
-			if command -v systemctl >/dev/null 2>&1; then
-				systemctl --user disable --now "${unit}.service" >/dev/null 2>&1 || true
-				systemctl --user disable --now "${unit}.timer" >/dev/null 2>&1 || true
+			[[ -z "$unit" ]] && continue
+			if [[ "$has_systemd" -eq 1 ]]; then
+				systemctl --user disable --now "${unit}.service" || true
+				systemctl --user disable --now "${unit}.timer" || true
 			fi
 			if [[ -e "${user_systemd_dir}/${unit}.service" ]]; then
-				mv "${user_systemd_dir}/${unit}.service" "${user_systemd_dir}/${unit}.service.disabled-$(date -u +%Y%m%d%H%M%S)" 2>/dev/null || rm -f "${user_systemd_dir}/${unit}.service"
+				mv "${user_systemd_dir}/${unit}.service" "${user_systemd_dir}/${unit}.service.disabled-$(date -u +%Y%m%d%H%M%S)" || rm -f "${user_systemd_dir}/${unit}.service"
 				removed=$((removed + 1))
 			fi
 			if [[ -e "${user_systemd_dir}/${unit}.timer" ]]; then
-				mv "${user_systemd_dir}/${unit}.timer" "${user_systemd_dir}/${unit}.timer.disabled-$(date -u +%Y%m%d%H%M%S)" 2>/dev/null || rm -f "${user_systemd_dir}/${unit}.timer"
+				mv "${user_systemd_dir}/${unit}.timer" "${user_systemd_dir}/${unit}.timer.disabled-$(date -u +%Y%m%d%H%M%S)" || rm -f "${user_systemd_dir}/${unit}.timer"
 				removed=$((removed + 1))
 			fi
 		done
-		if [[ "$removed" -gt 0 ]] && command -v systemctl >/dev/null 2>&1; then
-			systemctl --user daemon-reload >/dev/null 2>&1 || true
+		if [[ "$removed" -gt 0 ]] && [[ "$has_systemd" -eq 1 ]]; then
+			systemctl --user daemon-reload || true
 			print_info "Removed stale dashboard systemd unit(s); r912 is disabled or unmanaged"
 		fi
 		;;

--- a/.agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh
+++ b/.agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh
@@ -46,13 +46,15 @@ test_cleanup_function_is_guarded_by_r912_state() {
 		printf '%s' "$snippet" | grep -qE 'r912' && \
 		printf '%s' "$snippet" | grep -qF 'launchctl bootout' && \
 		printf '%s' "$snippet" | grep -qF 'sh.aidevops.dashboard' && \
+		printf '%s' "$snippet" | grep -qF 'systemctl --user status' && \
+		printf '%s' "$snippet" | grep -qF "[[ -z \"\$unit\" ]] && continue" && \
 		printf '%s' "$snippet" | grep -qF 'systemctl --user disable --now' && \
 		printf '%s' "$snippet" | grep -qF 'daemon-reload'; then
 		print_result "legacy dashboard cleanup is gated by r912 disabled state" 0
 		return 0
 	fi
 	print_result "legacy dashboard cleanup is gated by r912 disabled state" 1 \
-		"Expected launchd + systemd labels, routines TODO guard, r912 check, bootout, disable, and daemon-reload"
+		"Expected launchd + systemd labels, routines TODO guard, r912 check, bootout, active systemd user manager check, empty unit guard, disable, and daemon-reload"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Hardened legacy dashboard systemd cleanup by checking the user manager before systemctl actions, skipping empty unit names, and preserving systemctl/file-operation errors. Updated the static regression test to require the systemd status guard and empty unit guard.

## Files Changed

.agents/scripts/setup/modules/migrations.sh,.agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/setup/modules/migrations.sh .agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh; bash .agents/scripts/tests/test-legacy-dashboard-launchagent-cleanup.sh

Resolves #26583


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 52,402 tokens on this as a headless worker.