### PR TITLE
GH#26585: fix: avoid redundant stale PR activity lookups

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -648,7 +648,8 @@ _stale_assignment_has_recent_activity() {
 
 #######################################
 # Determine whether recent open PR activity protects a stale-looking assignment.
-# Args: $1 = issue number, $2 = repo slug, $3 = now epoch, $4 = threshold seconds
+# Args: $1 = issue number, $2 = repo slug, $3 = now epoch, $4 = threshold seconds,
+#       $5 = optional precomputed "<number>|<updatedAt>" open PR activity
 # Returns: 0 if recent PR activity exists, 1 otherwise
 #######################################
 _stale_assignment_has_recent_open_pr_activity() {
@@ -656,8 +657,11 @@ _stale_assignment_has_recent_open_pr_activity() {
 	local repo_slug="$2"
 	local now_epoch="$3"
 	local effective_threshold="$4"
-	local open_pr_activity open_pr_number open_pr_updated_at open_pr_epoch open_pr_age
-	open_pr_activity=$(_stale_recovery_find_open_pr_activity "$issue_number" "$repo_slug")
+	local open_pr_activity="${5:-}"
+	local open_pr_number open_pr_updated_at open_pr_epoch open_pr_age
+	if [[ "$#" -lt 5 ]]; then
+		open_pr_activity=$(_stale_recovery_find_open_pr_activity "$issue_number" "$repo_slug")
+	fi
 	[[ -z "$open_pr_activity" ]] && return 1
 	open_pr_number="${open_pr_activity%%|*}"
 	open_pr_updated_at="${open_pr_activity#*|}"

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh
@@ -73,6 +73,7 @@ gh() {
 	local cmd="${1:-}"
 	shift || true
 	if [[ "$cmd" == "pr" && "${1:-}" == "list" ]]; then
+		printf 'pr_list\n' >>"$GH_CALL_LOG"
 		if [[ -n "$OPEN_PR_ACTIVITY" ]]; then
 			local _number="${OPEN_PR_ACTIVITY%%|*}"
 			local _updated="${OPEN_PR_ACTIVITY#*|}"
@@ -186,6 +187,17 @@ else
 		pass "recent open PR activity prevents stale recovery"
 	else
 		fail "recent open PR activity prevents stale recovery" "recovery hook was called"
+	fi
+fi
+
+: >"$GH_CALL_LOG"
+if _stale_assignment_has_recent_open_pr_activity "123" "owner/repo" "$(date +%s)" "600" ""; then
+	fail "explicit empty open PR activity is treated as no recent PR" "helper returned success for an explicit empty value"
+else
+	if grep -q '^pr_list$' "$GH_CALL_LOG" 2>/dev/null; then
+		fail "explicit empty open PR activity skips lookup" "gh pr list was called despite the fifth argument being present"
+	else
+		pass "explicit empty open PR activity skips lookup"
 	fi
 fi
 


### PR DESCRIPTION
## Summary

Refactored _stale_assignment_has_recent_open_pr_activity to accept an optional precomputed open PR activity value and skip gh pr list when the fifth argument is explicitly present; added regression coverage for explicit empty values.

## Files Changed

.agents/scripts/dispatch-dedup-stale.sh,.agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh; .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh

Resolves #26585


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 53,813 tokens on this as a headless worker.