### PR TITLE
fix: harden review followup hot paths

### DIFF
--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -493,8 +493,13 @@ _matches_monitor_pattern() {
 	else
 		# Simple pattern — match against basename only
 		local cmd_lower pattern_lower
-		cmd_lower=$(_memory_pressure_lower "$cmd_name")
-		pattern_lower=$(_memory_pressure_lower "$pattern")
+		if [[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]]; then
+			cmd_lower="${cmd_name,,}"
+			pattern_lower="${pattern,,}"
+		else
+			cmd_lower=$(_memory_pressure_lower "$cmd_name")
+			pattern_lower=$(_memory_pressure_lower "$pattern")
+		fi
 		if [[ "$cmd_lower" == *"$pattern_lower"* ]]; then
 			return 0
 		fi

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -77,7 +77,7 @@ _resolve_script_dir_with_retry() {
 	lib_dir="$(dirname "$source_path")"
 	while [[ "$attempt" -le "$attempts" ]]; do
 		if [[ -d "$lib_dir" ]]; then
-			cd "$lib_dir" && pwd
+			CDPATH='' cd "$lib_dir" && pwd
 			return $?
 		fi
 		if [[ "$attempt" -lt "$attempts" && "$interval" -gt 0 ]]; then
@@ -86,8 +86,8 @@ _resolve_script_dir_with_retry() {
 		attempt=$((attempt + 1))
 	done
 
-	if [[ -d "${HOME}/.aidevops/agents/scripts" ]]; then
-		cd "${HOME}/.aidevops/agents/scripts" && pwd
+	if [[ -d "${HOME:+$HOME/.aidevops/agents/scripts}" ]]; then
+		CDPATH='' cd "${HOME:+$HOME/.aidevops/agents/scripts}" && pwd
 		return $?
 	fi
 


### PR DESCRIPTION
## Summary

- Optimizes `.agents/scripts/memory-pressure-monitor.sh` simple-pattern lowercasing by using native Bash 4+ `${var,,}` expansion with the existing Bash 3.2 fallback.
- Hardens `.agents/scripts/worker-watchdog.sh` script directory resolution by clearing `CDPATH` for `cd` calls and avoiding root-level fallback paths when `HOME` is empty.

Resolves #26586

## Testing

- `shellcheck .agents/scripts/memory-pressure-monitor.sh .agents/scripts/worker-watchdog.sh`
- `bash -n .agents/scripts/memory-pressure-monitor.sh .agents/scripts/worker-watchdog.sh`
- `bash tests/test-memory-pressure-monitor.sh` (fails before assertions: missing `tests/shared-constants.sh` in the existing harness)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 48,111 tokens on this as a headless worker.