### PR TITLE
GH#26578: fix: propagate scanner refresh list failures

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -948,10 +948,14 @@ do_refresh() {
 	local repo="$1" dry_run="$2"
 	log "Refreshing open review-followup issues in ${repo} (dry_run=${dry_run})"
 
-	local issues_json
+	local issues_json rc=0
 	issues_json=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
 		--state open --limit "$SCANNER_REFRESH_LIMIT" \
-		--json number,title,body || echo "[]")
+		--json number,title,body) || rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		log "do_refresh: gh issue list failed (rc=${rc})"
+		return 2
+	fi
 
 	if [[ "$issues_json" == "[]" ]]; then
 		log "No open review-followup issues found"

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -528,6 +528,7 @@ echo "gh stub: simulated failure for $cmd $sub" >&2
 exit 1
 FAIL_STUB_EOF
 	chmod +x "${STUB_BIN}/gh"
+	return 0
 }
 
 install_ok_gh() {
@@ -563,7 +564,28 @@ repo) echo 'stub/repo' ;;
 esac
 OK_STUB_EOF
 	chmod +x "${STUB_BIN}/gh"
+	return 0
 }
+
+echo ""
+echo "Test: do_refresh — issue list failure returns rc=2"
+cat >"${STUB_BIN}/gh" <<'ISSUE_LIST_FAIL_STUB_EOF'
+#!/usr/bin/env bash
+cmd="${1:-}"
+sub="${2:-}"
+if [[ "$cmd" == "issue" && "$sub" == "list" ]]; then
+	echo "gh stub: simulated issue list failure" >&2
+	exit 1
+fi
+echo '[]'
+ISSUE_LIST_FAIL_STUB_EOF
+chmod +x "${STUB_BIN}/gh"
+rc=0
+out=$(do_refresh "stub/repo" "true" 2>&1) || rc=$?
+assert_rc "refresh propagates issue list failure" "2" "$rc"
+assert_contains "refresh logs issue list failure" "do_refresh: gh issue list failed (rc=1)" "$out"
+assert_not_contains "refresh does not treat issue list failure as empty" "No open review-followup issues found" "$out"
+install_ok_gh
 
 echo ""
 echo "Test: fetch_review_threads_json — gh failure returns exit 2"


### PR DESCRIPTION
## Summary

Updated do_refresh to surface gh issue list failures instead of falling back to an empty issue list, and added regression coverage for the failure path.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh,.agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/post-merge-review-scanner.sh .agents/scripts/tests/test-post-merge-review-scanner.sh; bash .agents/scripts/tests/test-post-merge-review-scanner.sh (55 passed, 0 failed)

Resolves #26578


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 52,598 tokens on this as a headless worker.