### PR TITLE
GH#26595: fix: suppress systemd status probe noise

### DIFF
--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1723,7 +1723,7 @@ cleanup_legacy_dashboard_launchagent() {
 	Linux)
 		local user_systemd_dir="$HOME/.config/systemd/user"
 		local has_systemd=0
-		if command -v systemctl >/dev/null && systemctl --user status >/dev/null; then
+		if command -v systemctl >/dev/null && systemctl --user status >/dev/null 2>&1; then
 			has_systemd=1
 		fi
 		local removed=0


### PR DESCRIPTION
## Summary
- Suppresses stderr from the Linux `systemctl --user status` probe in `cleanup_legacy_dashboard_launchagent`.
- Keeps expected inactive user-bus cases quiet while preserving the existing graceful fallback when systemd is unavailable.

## Testing
- `shellcheck .agents/scripts/setup/modules/migrations.sh`

Resolves #26595
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 2m and 49,154 tokens on this as a headless worker.