### PR TITLE
GH#26594: fix: keep strong actionable review feedback

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -232,7 +232,7 @@ _apply_positive_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $strong_actionable |
 
-		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
+		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
 
 		($body | test(
 			"\\bmerging\\.?$|\\bmerge (this|the) pr\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -96,7 +96,7 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $strong_actionable |
 
-		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
+		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
 
 		# GH#5668: merge/CI-status comments are not actionable review feedback
 		($body | test(
@@ -446,6 +446,19 @@ return nil, fmt.Errorf("invalid input: %w", err)
 		print_result "keep review with suggestion fence" 0
 	else
 		print_result "keep review with suggestion fence" 1 "expected keep, got ${result}"
+	fi
+	return 0
+}
+
+test_keeps_review_with_strong_actionable_keyword_only() {
+	# Strong actionable terms such as "needs" are intentionally outside
+	# actionable_raw; they must still keep an otherwise positive review.
+	local result
+	result=$(_test_approval_filter "Looks good overall, but this needs a regression test.")
+	if [[ "$result" == "keep" ]]; then
+		print_result "keep review with strong actionable keyword only" 0
+	else
+		print_result "keep review with strong actionable keyword only" 1 "expected keep, got ${result}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -253,6 +253,7 @@ main() {
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report
 	test_keeps_review_with_suggestion_fence
+	test_keeps_review_with_strong_actionable_keyword_only
 
 	echo ""
 	echo "Running --include-positive flag tests (GH#4733)"


### PR DESCRIPTION
## Summary

- Updated `.agents/scripts/quality-feedback-findings-lib.sh` so `$strong_actionable` can make review feedback actionable even when `$actionable_raw` is false.
- Mirrored the jq expression in `.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh`.
- Added and wired a regression test for a positive review containing only a strong actionable keyword (`needs`).

Resolves #26594

## Testing

- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` (64/64 passed)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 5m and 62,745 tokens on this as a headless worker.
