### PR TITLE
fix: read deployed routines helper version

### DIFF
--- a/.agents/scripts/routines-health-helper.sh
+++ b/.agents/scripts/routines-health-helper.sh
@@ -95,9 +95,14 @@ deployed_version() {
 }
 
 script_version() {
-	local version_file="${SCRIPT_DIR}/../../VERSION"
-	if [[ -r "$version_file" ]]; then
-		tr -d '[:space:]' <"$version_file"
+	local deployed_version_file="${SCRIPT_DIR}/../VERSION"
+	local source_version_file="${SCRIPT_DIR}/../../VERSION"
+	if [[ -r "$deployed_version_file" ]]; then
+		tr -d '[:space:]' <"$deployed_version_file"
+		return 0
+	fi
+	if [[ -r "$source_version_file" ]]; then
+		tr -d '[:space:]' <"$source_version_file"
 		return 0
 	fi
 	printf 'unknown'

--- a/.agents/scripts/tests/test-routines-health-helper.sh
+++ b/.agents/scripts/tests/test-routines-health-helper.sh
@@ -54,9 +54,22 @@ test_repair_safe_is_gated_by_r912() {
 	return 0
 }
 
+test_script_version_prefers_deployed_agents_version() {
+	local snippet
+	snippet="$(sed -n '/script_version()/,/^}/p' "$HELPER")"
+	if printf '%s' "$snippet" | grep -qF 'SCRIPT_DIR}/../VERSION' && \
+		printf '%s' "$snippet" | grep -qF 'SCRIPT_DIR}/../../VERSION'; then
+		print_result "script version prefers deployed agents VERSION" 0
+		return 0
+	fi
+	print_result "script version prefers deployed agents VERSION" 1
+	return 0
+}
+
 main() {
 	test_json_check_outputs_expected_keys
 	test_repair_safe_is_gated_by_r912
+	test_script_version_prefers_deployed_agents_version
 	if [[ "$failures" -ne 0 ]]; then
 		printf 'Tests failed: %s\n' "$failures" >&2
 		return 1


### PR DESCRIPTION
## Summary
- Fix `routines-health-helper.sh` version lookup when running from deployed agents.
- Prefer deployed `agents/VERSION`, with source checkout `VERSION` as fallback.
- Add regression coverage for the deployed/source version lookup order.

Resolves #26616

## Verification
- `bash .agents/scripts/tests/test-routines-health-helper.sh`
- `bash -n .agents/scripts/routines-health-helper.sh .agents/scripts/tests/test-routines-health-helper.sh`
- `shellcheck .agents/scripts/routines-health-helper.sh .agents/scripts/tests/test-routines-health-helper.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.56 plugin for [OpenCode](https://opencode.ai) v1.17.13
