### PR TITLE
GH#26620: fix: guard non-issue claim release

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -334,19 +334,24 @@ _release_dispatch_claim() {
 	local exit_code_arg="${3:-}"
 	local session_count_arg="${4:-}"
 
-	# Extract issue number and repo slug from the worker contract first, then
-	# fall back to legacy session-key parsing. Manual dispatch session keys include
-	# a timestamp suffix (`manual-cli-<issue>-<epoch>`), so parsing trailing digits
-	# targets a nonexistent issue unless WORKER_ISSUE_NUMBER wins.
+	# Extract issue number and repo slug from the explicit worker contract first,
+	# then fall back only to canonical issue-scoped session keys. Non-task sessions
+	# can legitimately end in digits (for example validation timestamps); treating
+	# arbitrary trailing digits as issue numbers causes fake GitHub cleanup writes.
 	local issue_number=""
 	local repo_slug=""
 	if [[ "${WORKER_ISSUE_NUMBER:-}" =~ ^[0-9]+$ ]]; then
 		issue_number="$WORKER_ISSUE_NUMBER"
+	elif [[ "$session_key" =~ ^issue-([0-9]+)$ ]]; then
+		issue_number="${BASH_REMATCH[1]}"
 	else
-		issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
+		issue_number=""
 	fi
 	# Try to get repo slug from the dispatch ledger or env
 	repo_slug="${DISPATCH_REPO_SLUG:-}"
+	if [[ -z "$issue_number" && -z "${WORKER_ISSUE_NUMBER:-}" ]]; then
+		return 0
+	fi
 
 	# Supervisor/pulse cleanup paths can source this module and run the generic
 	# EXIT cleanup without ever having claimed a worker issue. With no issue and

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2023,6 +2023,35 @@ test_worker_produced_output_branch_with_pr_returns_pr_exists() {
 	return 0
 }
 
+test_release_dispatch_claim_ignores_non_issue_session_key_digits() {
+	local result status gh_called active_called unlock_called output
+	result=$(
+		unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+		DISPATCH_REPO_SLUG="owner/repo"
+		WORKER_GITHUB_LOGIN="test-runner"
+		gh_called=0
+		active_called=0
+		unlock_called=0
+		gh() { gh_called=$((gh_called + 1)); return 0; }
+		clear_active_status_on_release() { active_called=1; return 0; }
+		_unlock_issue_after_dispatch_release() { unlock_called=1; return 0; }
+
+		local release_output="" release_status=0
+		release_output=$(_release_dispatch_claim "validation-gh3343-positive-review-20260705" "worker_complete" 0 1 2>&1) || release_status=$?
+		printf '%s|%s|%s|%s|%s' "$release_status" "$gh_called" "$active_called" "$unlock_called" "$release_output"
+	)
+	IFS='|' read -r status gh_called active_called unlock_called output <<<"$result"
+
+	if [[ "$status" -eq 0 && "$gh_called" -eq 0 && "$active_called" -eq 0 && "$unlock_called" -eq 0 && -z "$output" ]]; then
+		print_result "release claim ignores non-issue session keys ending in digits" 0
+		return 0
+	fi
+
+	print_result "release claim ignores non-issue session keys ending in digits" 1 \
+		"status=$status gh=$gh_called active=$active_called unlock=$unlock_called output=${output:-<empty>}"
+	return 0
+}
+
 test_cmd_run_finish_emits_noop_for_zero_output() {
 	local work_dir="${TEST_ROOT}/repo-finish-noop"
 	_setup_test_git_repo "$work_dir" 0
@@ -2649,6 +2678,7 @@ main() {
 	test_worker_produced_output_branch_no_pr_returns_branch_orphan
 	test_worker_produced_output_local_branch_no_remote_returns_local_branch_unpushed
 	test_worker_produced_output_branch_with_pr_returns_pr_exists
+	test_release_dispatch_claim_ignores_non_issue_session_key_digits
 	test_cmd_run_finish_emits_noop_for_zero_output
 	test_cmd_run_finish_emits_complete_for_real_output
 	test_cmd_run_finish_emits_complete_when_no_workdir


### PR DESCRIPTION
## Summary

Restricted headless claim-release issue-number fallback to explicit WORKER_ISSUE_NUMBER or canonical issue-<number> session keys, preventing validation/non-task session keys ending in digits from attempting fake GitHub cleanup. Added regression coverage asserting no CLAIM_RELEASED/status-clear/unlock call for validation-gh3343-positive-review-20260705.

## Files Changed

.agents/scripts/headless-runtime-failure.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-failure.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #26620


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.58 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 101,628 tokens on this as a headless worker.