### PR TITLE
GH#26622: fix worktree cleanup lifecycle

### DIFF
--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -215,7 +215,9 @@ main() {
 	cleanup_worktrees || rc=$?
 	_prune_dirty_worktree_backups
 
-	if [[ "$rc" -eq 0 ]]; then
+	if [[ "${CLEANUP_WORKTREES_SKIPPED:-0}" == "1" ]]; then
+		echo "[cleanup-worktrees-async] cleanup_worktrees skipped by safety gate — last-run NOT updated" >>"$LOGFILE"
+	elif [[ "$rc" -eq 0 ]]; then
 		_update_last_run
 		echo "[cleanup-worktrees-async] Completed successfully at $(date -u '+%Y-%m-%dT%H:%M:%SZ'). last-run updated." >>"$LOGFILE"
 	else

--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -25,6 +25,7 @@
 # Environment:
 #   CLEANUP_WORKTREES_ASYNC_CADENCE_MIN — min minutes between runs (default 10)
 #   DIRTY_WORKTREE_BACKUP_RETENTION_DAYS — stale dirty-backup retention (default 30)
+#   AIDEVOPS_LOG_DIR — explicit log directory override (required if HOME unset)
 #
 # Observability (for pulse-diagnose-helper.sh):
 #   ~/.aidevops/logs/cleanup_worktrees.log      — progress log
@@ -38,8 +39,16 @@ set -euo pipefail
 # PATHS
 # ============================================================
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly LOG_DIR="${HOME}/.aidevops/logs"
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)"
+unset _SCRIPT_PATH
+
+if [[ -z "${AIDEVOPS_LOG_DIR:-}" && -z "${HOME:-}" ]]; then
+	printf '%s\n' "[cleanup-worktrees-async] ERROR: HOME is unset and AIDEVOPS_LOG_DIR is not configured" >&2
+	exit 1
+fi
+
+readonly LOG_DIR="${AIDEVOPS_LOG_DIR:-${HOME:-}/.aidevops/logs}"
 readonly LOGFILE="${LOG_DIR}/cleanup_worktrees.log"
 readonly LOCK_DIR="${LOG_DIR}/cleanup_worktrees.lock"
 readonly PID_FILE="${LOCK_DIR}/pid"

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -550,15 +550,18 @@ _merge_default_branch_for_cleanup() {
 	return 0
 }
 
-_merge_pull_canonical_for_cleanup() {
+_merge_refresh_canonical_for_cleanup() {
 	local canonical_dir="$1"
 	local default_branch="$2"
 	[[ -d "$canonical_dir" && -n "$default_branch" ]] || return 1
 
-	if git -C "$canonical_dir" pull --ff-only origin "$default_branch" >/dev/null 2>&1; then
+	# Refresh remote state without changing the canonical worktree's checked-out
+	# branch. A pull from a non-default branch can fast-forward that branch to the
+	# default branch tip, corrupting unrelated active work.
+	if git -C "$canonical_dir" fetch origin "$default_branch" >/dev/null 2>&1; then
 		return 0
 	fi
-	print_warning "Post-merge worktree cleanup: canonical pull skipped/failed for ${canonical_dir}; continuing cleanup"
+	print_warning "Post-merge worktree cleanup: canonical fetch skipped/failed for ${canonical_dir}; continuing cleanup"
 	return 0
 }
 
@@ -567,7 +570,7 @@ _merge_resolve_worktree_helper() {
 		printf '%s\n' "${SCRIPT_DIR}/worktree-helper.sh"
 		return 0
 	fi
-	if [[ -x "${HOME}/.aidevops/agents/scripts/worktree-helper.sh" ]]; then
+	if [[ -n "${HOME:-}" && -x "${HOME}/.aidevops/agents/scripts/worktree-helper.sh" ]]; then
 		printf '%s\n' "${HOME}/.aidevops/agents/scripts/worktree-helper.sh"
 		return 0
 	fi
@@ -604,7 +607,7 @@ _merge_cleanup_linked_worktree() {
 	print_info "Post-merge worktree cleanup: removing linked worktree ${worktree_path} for ${branch_name} in ${repo}"
 	local default_branch=""
 	default_branch=$(_merge_default_branch_for_cleanup "$canonical_dir")
-	_merge_pull_canonical_for_cleanup "$canonical_dir" "$default_branch"
+	_merge_refresh_canonical_for_cleanup "$canonical_dir" "$default_branch"
 
 	if ! cd "$canonical_dir" 2>/dev/null; then
 		print_warning "Post-merge worktree cleanup: could not cd to canonical repo ${canonical_dir}"

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -510,6 +510,118 @@ _retarget_stacked_children_interactive() {
 	return 0
 }
 
+# --- Post-Merge Worktree Cleanup ---
+
+_merge_current_worktree_cleanup_plan() {
+	local pr_head_ref="$1"
+	[[ -n "$pr_head_ref" ]] || return 1
+
+	local current_branch=""
+	current_branch=$(git branch --show-current 2>/dev/null || true)
+	[[ -n "$current_branch" && "$current_branch" == "$pr_head_ref" ]] || return 1
+
+	local current_root=""
+	current_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	[[ -n "$current_root" ]] || return 1
+
+	local porcelain=""
+	porcelain=$(git worktree list --porcelain 2>/dev/null || true)
+	[[ -n "$porcelain" ]] || return 1
+
+	local canonical_dir=""
+	canonical_dir="${porcelain%%$'\n'*}"
+	canonical_dir="${canonical_dir#worktree }"
+	[[ -n "$canonical_dir" && "$canonical_dir" != "$current_root" ]] || return 1
+
+	printf '%s\t%s\t%s\n' "$current_root" "$current_branch" "$canonical_dir"
+	return 0
+}
+
+_merge_default_branch_for_cleanup() {
+	local canonical_dir="$1"
+	local default_ref=""
+	default_ref=$(git -C "$canonical_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)
+	default_ref="${default_ref#refs/remotes/origin/}"
+	if [[ -n "$default_ref" && "$default_ref" != refs/* ]]; then
+		printf '%s\n' "$default_ref"
+		return 0
+	fi
+	printf '%s\n' "main"
+	return 0
+}
+
+_merge_pull_canonical_for_cleanup() {
+	local canonical_dir="$1"
+	local default_branch="$2"
+	[[ -d "$canonical_dir" && -n "$default_branch" ]] || return 1
+
+	if git -C "$canonical_dir" pull --ff-only origin "$default_branch" >/dev/null 2>&1; then
+		return 0
+	fi
+	print_warning "Post-merge worktree cleanup: canonical pull skipped/failed for ${canonical_dir}; continuing cleanup"
+	return 0
+}
+
+_merge_resolve_worktree_helper() {
+	if [[ -x "${SCRIPT_DIR}/worktree-helper.sh" ]]; then
+		printf '%s\n' "${SCRIPT_DIR}/worktree-helper.sh"
+		return 0
+	fi
+	if [[ -x "${HOME}/.aidevops/agents/scripts/worktree-helper.sh" ]]; then
+		printf '%s\n' "${HOME}/.aidevops/agents/scripts/worktree-helper.sh"
+		return 0
+	fi
+	return 1
+}
+
+_merge_remove_worktree_for_cleanup() {
+	local worktree_path="$1"
+	local branch_name="$2"
+	local canonical_dir="$3"
+	local helper_path=""
+
+	helper_path=$(_merge_resolve_worktree_helper 2>/dev/null || true)
+	if [[ -n "$helper_path" ]]; then
+		WORKTREE_FORCE_REMOVE=1 "$helper_path" remove "$branch_name" --force >/dev/null 2>&1 && return 0
+		print_warning "Post-merge worktree cleanup: helper removal failed for ${branch_name}; trying git worktree remove"
+	fi
+
+	git -C "$canonical_dir" worktree remove --force "$worktree_path" >/dev/null 2>&1 || return 1
+	git -C "$canonical_dir" worktree prune >/dev/null 2>&1 || true
+	return 0
+}
+
+_merge_cleanup_linked_worktree() {
+	local cleanup_plan="$1"
+	local repo="$2"
+	[[ -n "$cleanup_plan" ]] || return 0
+
+	local worktree_path="" branch_name="" canonical_dir=""
+	IFS=$'\t' read -r worktree_path branch_name canonical_dir <<<"$cleanup_plan"
+	[[ -n "$worktree_path" && -n "$branch_name" && -n "$canonical_dir" ]] || return 0
+	[[ -d "$canonical_dir" ]] || return 0
+
+	print_info "Post-merge worktree cleanup: removing linked worktree ${worktree_path} for ${branch_name} in ${repo}"
+	local default_branch=""
+	default_branch=$(_merge_default_branch_for_cleanup "$canonical_dir")
+	_merge_pull_canonical_for_cleanup "$canonical_dir" "$default_branch"
+
+	if ! cd "$canonical_dir" 2>/dev/null; then
+		print_warning "Post-merge worktree cleanup: could not cd to canonical repo ${canonical_dir}"
+		return 0
+	fi
+
+	if _merge_remove_worktree_for_cleanup "$worktree_path" "$branch_name" "$canonical_dir"; then
+		git push origin --delete "$branch_name" >/dev/null 2>&1 || true
+		git branch -D "$branch_name" >/dev/null 2>&1 || true
+		print_success "Post-merge worktree cleanup complete for ${branch_name}"
+		return 0
+	fi
+
+	print_warning "Post-merge worktree cleanup did not remove ${worktree_path}; safety-net cleanup will retry later"
+	return 0
+}
+
 # --- Merge Command ---
 
 # Merge wrapper (GH#17541) — enforces review-bot-gate then merges.
@@ -578,6 +690,13 @@ cmd_merge() {
 
 	repo=$(_merge_resolve_repo "$repo") || return 1
 
+	local _cleanup_plan=""
+	if [[ "$has_auto" -eq 0 ]]; then
+		local _pr_head_ref=""
+		_pr_head_ref=$(gh pr view "$pr_number" --repo "$repo" --json headRefName --jq '.headRefName // empty' 2>/dev/null || true)
+		_cleanup_plan=$(_merge_current_worktree_cleanup_plan "$_pr_head_ref" 2>/dev/null || true)
+	fi
+
 	# Gate: enforce review-bot-gate before merge.
 	cmd_pre_merge_gate "$pr_number" "$repo" || {
 		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
@@ -615,6 +734,9 @@ cmd_merge() {
 	fi
 
 	_merge_unlock_resources "$pr_number" "$repo"
+	if [[ "$has_auto" -eq 0 && -n "$_cleanup_plan" ]]; then
+		_merge_cleanup_linked_worktree "$_cleanup_plan" "$repo" || true
+	fi
 
 	return 0
 }

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1654,6 +1654,7 @@ _pc_cleanup_orphan_sibling_dirs() {
 # See also: GH#18346 (silent-skip logging fix preserved in helpers above)
 #######################################
 cleanup_worktrees() {
+	CLEANUP_WORKTREES_SKIPPED=0
 	# GH#18979: Skip cleanup when API rate limit is low — both passes call
 	# `gh pr list` per repo/worktree, and blocking rate-limit waits cause
 	# the cleanup stage to hang for 10+ minutes, stalling the entire pulse
@@ -1663,6 +1664,7 @@ cleanup_worktrees() {
 	_rl_remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || _rl_remaining=""
 	if [[ "$_rl_remaining" =~ ^[0-9]+$ ]] && [[ "$_rl_remaining" -lt 100 ]]; then
 		echo "[pulse-wrapper] Worktree cleanup: skipped — GraphQL rate limit low (${_rl_remaining} remaining)" >>"$LOGFILE"
+		CLEANUP_WORKTREES_SKIPPED=1
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -87,7 +87,16 @@ STUB
 	# Use literal return 0 / return 1 (not a variable) so the pre-commit
 	# return-statement ratchet doesn't flag the heredoc-embedded function.
 	local mock_ran_file="${TEST_DIR}/mock-ran"
-	if [[ "${MOCK_CLEANUP_EXIT:-0}" -ne 0 ]]; then
+	if [[ "${MOCK_CLEANUP_SKIPPED:-0}" -eq 1 ]]; then
+		cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
+# stub pulse-cleanup.sh
+cleanup_worktrees() {
+	printf 'MOCK_RAN\n' >>"${mock_ran_file}"
+	CLEANUP_WORKTREES_SKIPPED=1
+	return 0
+}
+STUB
+	elif [[ "${MOCK_CLEANUP_EXIT:-0}" -ne 0 ]]; then
 		cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
 # stub pulse-cleanup.sh
 _mock_cleanup_worktrees() {
@@ -266,7 +275,26 @@ test_failed_cleanup_no_last_run_update() {
 }
 
 # ============================================================
-# TEST 7: lock released on exit (no orphaned lock after run)
+# TEST 7: skipped cleanup — last-run NOT updated on safety skip
+# ============================================================
+test_skipped_cleanup_no_last_run_update() {
+	local logs_dir="${TEST_DIR}/.aidevops/logs"
+	local last_run_file="${logs_dir}/cleanup_worktrees.last-run"
+	rm -f "$last_run_file"
+
+	MOCK_CLEANUP_SKIPPED=1 run_helper_in_isolation || true
+
+	if [[ ! -f "$last_run_file" ]]; then
+		print_result "skipped-cleanup: last-run not updated on safety skip" 0
+	else
+		print_result "skipped-cleanup: last-run not updated on safety skip" 1 \
+			"last-run was updated despite cleanup safety skip"
+	fi
+	return 0
+}
+
+# ============================================================
+# TEST 8: lock released on exit (no orphaned lock after run)
 # ============================================================
 test_lock_released_after_run() {
 	local logs_dir="${TEST_DIR}/.aidevops/logs"
@@ -314,6 +342,9 @@ main() {
 
 	teardown; setup
 	test_failed_cleanup_no_last_run_update
+
+	teardown; setup
+	test_skipped_cleanup_no_last_run_update
 
 	teardown; setup
 	test_lock_released_after_run

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -124,9 +124,16 @@ STUB
 	cp "$HELPER" "${stub_dir}/cleanup-worktrees-async-helper.sh"
 	chmod +x "${stub_dir}/cleanup-worktrees-async-helper.sh"
 
-	env HOME="$TEST_DIR" \
-		CLEANUP_WORKTREES_ASYNC_CADENCE_MIN="${CLEANUP_WORKTREES_ASYNC_CADENCE_MIN:-10}" \
-		bash "${stub_dir}/cleanup-worktrees-async-helper.sh" 2>/dev/null || true
+	if [[ "${RUN_HELPER_UNSET_HOME:-0}" -eq 1 ]]; then
+		env -u HOME \
+			AIDEVOPS_LOG_DIR="${AIDEVOPS_LOG_DIR:-${TEST_DIR}/custom-logs}" \
+			CLEANUP_WORKTREES_ASYNC_CADENCE_MIN="${CLEANUP_WORKTREES_ASYNC_CADENCE_MIN:-10}" \
+			bash "${stub_dir}/cleanup-worktrees-async-helper.sh" 2>/dev/null || true
+	else
+		env HOME="$TEST_DIR" \
+			CLEANUP_WORKTREES_ASYNC_CADENCE_MIN="${CLEANUP_WORKTREES_ASYNC_CADENCE_MIN:-10}" \
+			bash "${stub_dir}/cleanup-worktrees-async-helper.sh" 2>/dev/null || true
+	fi
 	return 0
 }
 
@@ -313,6 +320,28 @@ test_lock_released_after_run() {
 }
 
 # ============================================================
+# TEST 9: HOME unset — explicit log dir avoids set -u unbound errors
+# ============================================================
+test_home_unset_uses_explicit_log_dir() {
+	local custom_log_dir="${TEST_DIR}/custom-logs"
+	local last_run_file="${custom_log_dir}/cleanup_worktrees.last-run"
+	local mock_ran="${TEST_DIR}/mock-ran"
+	rm -rf "$custom_log_dir"
+	rm -f "$mock_ran"
+
+	RUN_HELPER_UNSET_HOME=1 AIDEVOPS_LOG_DIR="$custom_log_dir" MOCK_CLEANUP_EXIT=0 \
+		run_helper_in_isolation || true
+
+	if [[ -f "$mock_ran" && -f "$last_run_file" ]]; then
+		print_result "home-unset: explicit log dir avoids unbound HOME" 0
+	else
+		print_result "home-unset: explicit log dir avoids unbound HOME" 1 \
+			"mock or last-run file missing when HOME was unset"
+	fi
+	return 0
+}
+
+# ============================================================
 # MAIN
 # ============================================================
 
@@ -348,6 +377,9 @@ main() {
 
 	teardown; setup
 	test_lock_released_after_run
+
+	teardown; setup
+	test_home_unset_uses_explicit_log_dir
 
 	echo ""
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -162,6 +162,8 @@ TRASH
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 
 	local canonical_repo="${TEST_ROOT}/repo"
+	local origin_repo="${TEST_ROOT}/origin.git"
+	local updater_repo="${TEST_ROOT}/updater"
 	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
 	mkdir -p "$canonical_repo" "${worktree_path%/*}"
 	git -C "$canonical_repo" init -q -b main
@@ -170,7 +172,18 @@ TRASH
 	printf 'base\n' >"${canonical_repo}/README.md"
 	git -C "$canonical_repo" add README.md
 	git -C "$canonical_repo" commit -q -m 'init'
+	git clone -q --bare "$canonical_repo" "$origin_repo"
+	git -C "$canonical_repo" remote add origin "$origin_repo"
+	git -C "$canonical_repo" push -q -u origin main
 	git -C "$canonical_repo" worktree add -q "$worktree_path" -b feature/full-loop-cleanup
+	git -C "$canonical_repo" checkout -q -b feature/active
+	git clone -q "$origin_repo" "$updater_repo"
+	git -C "$updater_repo" config user.email test@example.invalid
+	git -C "$updater_repo" config user.name 'Aidevops Test'
+	printf 'remote main advance\n' >>"${updater_repo}/README.md"
+	git -C "$updater_repo" add README.md
+	git -C "$updater_repo" commit -q -m 'advance main'
+	git -C "$updater_repo" push -q origin main
 
 	cd "$worktree_path"
 	export SCRIPT_DIR="$AGENTS_SCRIPTS_DIR"
@@ -185,6 +198,8 @@ TRASH
 test_cmd_merge_removes_current_linked_worktree() {
 	local canonical_repo="${TEST_ROOT}/repo"
 	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+	local active_before=""
+	active_before=$(git -C "$canonical_repo" rev-parse feature/active)
 
 	cmd_merge "123" "example/repo" --squash
 
@@ -194,6 +209,12 @@ test_cmd_merge_removes_current_linked_worktree() {
 	fi
 	[[ ! -d "$worktree_path" ]] || rc=1
 	if git -C "$canonical_repo" show-ref --verify --quiet refs/heads/feature/full-loop-cleanup; then
+		rc=1
+	fi
+	if [[ "$(git -C "$canonical_repo" branch --show-current)" != "feature/active" ]]; then
+		rc=1
+	fi
+	if [[ "$(git -C "$canonical_repo" rev-parse feature/active)" != "$active_before" ]]; then
 		rc=1
 	fi
 	print_result "cmd_merge removes current linked worktree after immediate merge" "$rc"

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+	else
+		printf 'FAIL %s\n' "$test_name"
+		[[ -n "$message" ]] && printf '  %s\n' "$message"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+gh() {
+	local command="${1:-}"
+	local subcommand="${2:-}"
+	local args="$*"
+	if [[ "$command" == "pr" && "$subcommand" == "view" ]]; then
+		if [[ "$args" == *"headRefName"* ]]; then
+			printf '%s\n' "feature/full-loop-cleanup"
+			return 0
+		fi
+		if [[ "$args" == *"body"* ]]; then
+			printf '%s\n' "Resolves #42"
+			return 0
+		fi
+	fi
+	return 0
+}
+
+cmd_pre_merge_gate() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+	[[ -n "$pr_number" && -n "$repo" ]] || return 1
+	return 0
+}
+
+_merge_execute() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+	local merge_method="${3:-}"
+	local has_admin="${4:-}"
+	local has_auto="${5:-}"
+	[[ -n "$pr_number" && -n "$repo" && -n "$merge_method" && -n "$has_admin" && -n "$has_auto" ]] || return 1
+	return 0
+}
+
+_retarget_stacked_children_interactive() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+	[[ -n "$pr_number" && -n "$repo" ]] || return 1
+	return 0
+}
+
+_merge_unlock_resources() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+	[[ -n "$pr_number" && -n "$repo" ]] || return 1
+	return 0
+}
+
+release_interactive_claim_on_merge() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+	local issue_number="${3:-}"
+	[[ -n "$pr_number" && -n "$repo" && -n "$issue_number" ]] || return 1
+	return 0
+}
+
+auto_file_next_phase() {
+	local issue_number="${1:-}"
+	local repo="${2:-}"
+	[[ -n "$issue_number" && -n "$repo" ]] || return 1
+	return 0
+}
+
+install_subject_stubs() {
+	# full-loop-helper-merge.sh defines several of these symbols. Reinstall the
+	# stubs after sourcing so cmd_merge exercises orchestration and cleanup only.
+	cmd_pre_merge_gate() {
+		local pr_number="${1:-}"
+		local repo="${2:-}"
+		[[ -n "$pr_number" && -n "$repo" ]] || return 1
+		return 0
+	}
+
+	_merge_execute() {
+		local pr_number="${1:-}"
+		local repo="${2:-}"
+		local merge_method="${3:-}"
+		local has_admin="${4:-}"
+		local has_auto="${5:-}"
+		[[ -n "$pr_number" && -n "$repo" && -n "$merge_method" && -n "$has_admin" && -n "$has_auto" ]] || return 1
+		return 0
+	}
+
+	_retarget_stacked_children_interactive() {
+		local pr_number="${1:-}"
+		local repo="${2:-}"
+		[[ -n "$pr_number" && -n "$repo" ]] || return 1
+		return 0
+	}
+
+	_merge_unlock_resources() {
+		local pr_number="${1:-}"
+		local repo="${2:-}"
+		[[ -n "$pr_number" && -n "$repo" ]] || return 1
+		return 0
+	}
+
+	release_interactive_claim_on_merge() {
+		local pr_number="${1:-}"
+		local repo="${2:-}"
+		local issue_number="${3:-}"
+		[[ -n "$pr_number" && -n "$repo" && -n "$issue_number" ]] || return 1
+		return 0
+	}
+
+	auto_file_next_phase() {
+		local issue_number="${1:-}"
+		local repo="${2:-}"
+		[[ -n "$issue_number" && -n "$repo" ]] || return 1
+		return 0
+	}
+
+	return 0
+}
+
+setup_subject() {
+	TEST_ROOT=$(mktemp -d)
+	trap teardown EXIT
+	export HOME="${TEST_ROOT}/home"
+	export AIDEVOPS_SKIP_AUTO_CLAIM=1
+	mkdir -p "$HOME" "${TEST_ROOT}/bin"
+	cat >"${TEST_ROOT}/bin/trash" <<'TRASH'
+#!/usr/bin/env bash
+exit 1
+TRASH
+	chmod +x "${TEST_ROOT}/bin/trash"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+
+	local canonical_repo="${TEST_ROOT}/repo"
+	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+	mkdir -p "$canonical_repo" "${worktree_path%/*}"
+	git -C "$canonical_repo" init -q -b main
+	git -C "$canonical_repo" config user.email test@example.invalid
+	git -C "$canonical_repo" config user.name 'Aidevops Test'
+	printf 'base\n' >"${canonical_repo}/README.md"
+	git -C "$canonical_repo" add README.md
+	git -C "$canonical_repo" commit -q -m 'init'
+	git -C "$canonical_repo" worktree add -q "$worktree_path" -b feature/full-loop-cleanup
+
+	cd "$worktree_path"
+	export SCRIPT_DIR="$AGENTS_SCRIPTS_DIR"
+	# shellcheck source=../shared-constants.sh
+	source "${AGENTS_SCRIPTS_DIR}/shared-constants.sh"
+	# shellcheck source=../full-loop-helper-merge.sh
+	source "${AGENTS_SCRIPTS_DIR}/full-loop-helper-merge.sh"
+	install_subject_stubs
+	return 0
+}
+
+test_cmd_merge_removes_current_linked_worktree() {
+	local canonical_repo="${TEST_ROOT}/repo"
+	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+
+	cmd_merge "123" "example/repo" --squash
+
+	local rc=0
+	if git -C "$canonical_repo" worktree list --porcelain | grep -q "$worktree_path"; then
+		rc=1
+	fi
+	[[ ! -d "$worktree_path" ]] || rc=1
+	if git -C "$canonical_repo" show-ref --verify --quiet refs/heads/feature/full-loop-cleanup; then
+		rc=1
+	fi
+	print_result "cmd_merge removes current linked worktree after immediate merge" "$rc"
+	return 0
+}
+
+main() {
+	setup_subject
+	test_cmd_merge_removes_current_linked_worktree
+	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-worktree-helper-nested-path-guard.sh
+++ b/.agents/scripts/tests/test-worktree-helper-nested-path-guard.sh
@@ -14,8 +14,11 @@
 # The fix (t2701) added `_cmd_add_assert_path_outside_repo` which refuses
 # to create a worktree at a path that resolves inside the repo working
 # tree, with a mentoring error that points users at the correct usage.
-# An env override `AIDEVOPS_WORKTREE_ALLOW_NESTED=1` bypasses the guard
-# for rare legitimate cases.
+# The guard now also rejects sibling/custom paths outside the configured
+# central worktree base (`~/Git/_worktrees`) to prevent durable litter under
+# `~/Git`. Env override `AIDEVOPS_WORKTREE_ALLOW_NESTED=1` bypasses all checks
+# for rare legitimate nested fixtures; `AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1`
+# bypasses only the central-base guard.
 #
 # Assertions:
 #   Unit: _worktree_resolve_abs_path
@@ -27,14 +30,17 @@
 #   Unit: _cmd_add_assert_path_outside_repo
 #     5. Path === repo root is rejected (nested/shadow)
 #     6. Path inside repo working tree is rejected
-#     7. Sibling path outside repo is allowed
-#     8. AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses guard even on nested
-#     9. When not in a repo (get_repo_root empty), guard defers (returns 0)
+#     7. Central worktree-base path outside repo is allowed
+#     8. Sibling path under the repo parent is rejected by default
+#     9. AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1 bypasses central-base guard
+#     10. AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses guard even on nested
+#     11. When not in a repo (get_repo_root empty), guard defers (returns 0)
 #
 #   Integration (end-to-end CLI):
-#     10. `add feature/X main` aborts non-zero, does NOT create $CWD/main/
-#     11. `add feature/X .` aborts non-zero
-#     12. `AIDEVOPS_WORKTREE_ALLOW_NESTED=1 add feature/X some-nested-path`
+#     12. `add feature/X main` aborts non-zero, does NOT create $CWD/main/
+#     13. `add feature/X .` aborts non-zero
+#     14. `add feature/X ../repo-feature-X` aborts non-zero
+#     15. `AIDEVOPS_WORKTREE_ALLOW_NESTED=1 add feature/X some-nested-path`
 #         is NOT blocked by the guard (may still fail later for unrelated
 #         reasons like a missing base ref — we only assert the guard
 #         doesn't emit its mentoring error)
@@ -68,26 +74,34 @@ TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 # Fake repo with one commit so HEAD exists.
-FAKE_REPO="${TEST_ROOT}/repo"
-mkdir -p "$FAKE_REPO"
+FAKE_REPO="${TEST_ROOT}/Git/repo"
+WORKTREE_BASE="${TEST_ROOT}/Git/_worktrees"
+mkdir -p "$FAKE_REPO" "$WORKTREE_BASE"
 git -C "$FAKE_REPO" init -q -b main
 git -C "$FAKE_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+export AIDEVOPS_WORKTREE_BASE_DIR="$WORKTREE_BASE"
 
 # =============================================================================
-# Unit tests — source just the three functions we need, avoiding side
-# effects of sourcing the whole helper.
+# Unit tests — source only the path/add sub-library plus minimal git helpers,
+# avoiding side effects of sourcing the whole helper graph.
 # =============================================================================
 
 # Colors may already be set by the caller's shell; guard them.
 : "${RED:=$'\033[0;31m'}"
 : "${NC:=$'\033[0m'}"
 
-# Extract `get_repo_root`, `_worktree_resolve_abs_path`, and
-# `_cmd_add_assert_path_outside_repo` from worktree-helper.sh.
-HELPER_SRC="${TEST_SCRIPTS_DIR}/worktree-helper.sh"
-eval "$(sed -n '/^get_repo_root()/,/^}/p' "$HELPER_SRC")"
-eval "$(sed -n '/^_worktree_resolve_abs_path()/,/^}/p' "$HELPER_SRC")"
-eval "$(sed -n '/^_cmd_add_assert_path_outside_repo()/,/^}/p' "$HELPER_SRC")"
+# Extract only minimal git helpers, then source the add/path sub-library under test.
+HELPER_CLI="${TEST_SCRIPTS_DIR}/worktree-helper.sh"
+HELPER_GIT_SRC="${TEST_SCRIPTS_DIR}/worktree-helper-git.sh"
+HELPER_ADD_SRC="${TEST_SCRIPTS_DIR}/worktree-helper-add.sh"
+eval "$(sed -n '/^get_repo_root()/,/^}/p' "$HELPER_GIT_SRC")"
+eval "$(sed -n '/^get_repo_name()/,/^}/p' "$HELPER_GIT_SRC")"
+aidevops_worktree_base_dir_configured() {
+	printf '%s\n' "$WORKTREE_BASE"
+	return 0
+}
+# shellcheck source=../worktree-helper-add.sh
+source "$HELPER_ADD_SRC"
 
 # ---- _worktree_resolve_abs_path ---------------------------------------------
 # Test 1: relative path resolves to CWD-absolute
@@ -142,14 +156,29 @@ if _cmd_add_assert_path_outside_repo "." "feature/x" 2>/dev/null; then
 fi
 print_result "assert: '.' (CWD === repo root) is rejected" "$rc"
 
-# Test 7: Sibling path outside the repo is allowed
+# Test 7: Central worktree-base path outside the repo is allowed
 rc=0
-if ! _cmd_add_assert_path_outside_repo "${TEST_ROOT}/sibling-worktree" "feature/x" 2>/dev/null; then
+if ! _cmd_add_assert_path_outside_repo "${WORKTREE_BASE}/repo-feature-x" "feature/x" 2>/dev/null; then
 	rc=1
 fi
-print_result "assert: sibling path outside repo is allowed" "$rc"
+print_result "assert: central worktree-base path outside repo is allowed" "$rc"
 
-# Test 8: AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses guard on nested path
+# Test 8: Sibling path under repo parent is rejected by default
+rc=0
+if _cmd_add_assert_path_outside_repo "${TEST_ROOT}/Git/repo-feature-x" "feature/x" 2>/dev/null; then
+	rc=1
+fi
+print_result "assert: sibling path under repo parent is rejected" "$rc"
+
+# Test 9: AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1 bypasses central-base guard
+rc=0
+if ! AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1 _cmd_add_assert_path_outside_repo "${TEST_ROOT}/Git/repo-feature-x" "feature/x" 2>/dev/null; then
+	rc=1
+fi
+print_result "assert: AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1 bypasses central-base guard" "$rc"
+unset AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH
+
+# Test 10: AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses guard on nested path
 rc=0
 if ! AIDEVOPS_WORKTREE_ALLOW_NESTED=1 _cmd_add_assert_path_outside_repo "main" "feature/x" 2>/dev/null; then
 	rc=1
@@ -157,7 +186,7 @@ fi
 print_result "assert: AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses guard" "$rc"
 unset AIDEVOPS_WORKTREE_ALLOW_NESTED
 
-# Test 9: When not in a repo (get_repo_root empty), guard defers
+# Test 11: When not in a repo (get_repo_root empty), guard defers
 rc=0
 cd "$TEST_ROOT"  # not inside a git repo
 if ! _cmd_add_assert_path_outside_repo "anywhere" "feature/x" 2>/dev/null; then
@@ -172,31 +201,42 @@ cd "$FAKE_REPO"
 export AIDEVOPS_SKIP_AUTO_CLAIM=1      # skip interactive-session-helper side effects
 export AIDEVOPS_NO_NETWORK=1            # defensive: some helpers honour this
 
-# Test 10: `add feature/x main` aborts non-zero, leaves no nested worktree
+# Test 12: `add feature/x main` aborts non-zero, leaves no nested worktree
 rc=0
 set +e
-bash "$HELPER_SRC" add feature/t2701-testbranch main >/dev/null 2>&1
+bash "$HELPER_CLI" add feature/t2701-testbranch main >/dev/null 2>&1
 exit_code=$?
 set -e
 [[ "$exit_code" -ne 0 ]] || rc=1
 [[ ! -e "${FAKE_REPO}/main" ]] || rc=1
 print_result "cli: 'add feature/x main' aborts, no nested dir created" "$rc" "(exit=$exit_code, main_exists=$([[ -e "${FAKE_REPO}/main" ]] && echo yes || echo no))"
 
-# Test 11: `add feature/x .` aborts non-zero
+# Test 13: `add feature/x .` aborts non-zero
 rc=0
 set +e
-bash "$HELPER_SRC" add feature/t2701-testbranch2 . >/dev/null 2>&1
+bash "$HELPER_CLI" add feature/t2701-testbranch2 . >/dev/null 2>&1
 exit_code=$?
 set -e
 [[ "$exit_code" -ne 0 ]] || rc=1
 print_result "cli: 'add feature/x .' aborts" "$rc" "(exit=$exit_code)"
 
-# Test 12: Bypass env var lets the guard pass (downstream may still fail for
+# Test 14: Explicit sibling path under repo parent aborts non-zero by default
+rc=0
+SIBLING_PATH="${TEST_ROOT}/Git/repo-feature-t2701-sibling"
+set +e
+bash "$HELPER_CLI" add feature/t2701-sibling "$SIBLING_PATH" >/dev/null 2>&1
+exit_code=$?
+set -e
+[[ "$exit_code" -ne 0 ]] || rc=1
+[[ ! -e "$SIBLING_PATH" ]] || rc=1
+print_result "cli: explicit sibling path under repo parent aborts" "$rc" "(exit=$exit_code, sibling_exists=$([[ -e "$SIBLING_PATH" ]] && echo yes || echo no))"
+
+# Test 15: Bypass env var lets the guard pass (downstream may still fail for
 # unrelated reasons like create-branch mechanics, but the t2701 mentoring
 # error must NOT appear in stderr).
 rc=0
 set +e
-stderr_out="$(AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bash "$HELPER_SRC" add feature/t2701-testbranch3 nested-ok 2>&1 >/dev/null)"
+stderr_out="$(AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bash "$HELPER_CLI" add feature/t2701-testbranch3 nested-ok 2>&1 >/dev/null)"
 set -e
 # The mentoring error contains the word 'AIDEVOPS_WORKTREE_ALLOW_NESTED' only
 # when the guard fires. If the guard was bypassed, that string must NOT appear.

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -456,8 +456,10 @@ _worktree_resolve_abs_path() {
 	return 0
 }
 
-# t2701: Assert that the requested worktree path is not inside the canonical
-# repo working tree. Aborts with a mentoring error on containment.
+# t2701/t3601: Assert that the requested worktree path follows aidevops
+# worktree placement policy: never inside the canonical repo and, by default,
+# under the configured central worktree base (`~/Git/_worktrees`). Aborts with a
+# mentoring error on containment or sibling/custom path litter.
 #
 # The helper's `add <branch> [path]` signature does not mirror git's own
 # `git worktree add -b <branch> <path> [<base>]` — our second positional is a
@@ -466,43 +468,51 @@ _worktree_resolve_abs_path() {
 # canonical repo (state confusion, cleanup-script blast radius, pull/merge
 # inconsistency). This guard rejects that input with a mentoring error.
 #
-# Env override: AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses the check for rare
-# legitimate cases (test fixtures, documented intent).
-_cmd_add_assert_path_outside_repo() {
-	local path="$1"
-	local branch="$2"
-
-	if [[ "${AIDEVOPS_WORKTREE_ALLOW_NESTED:-0}" = "1" ]]; then
-		return 0
-	fi
-
-	local abs_path abs_repo repo_root
-	abs_path="$(_worktree_resolve_abs_path "$path")"
-	repo_root="$(get_repo_root)"
-	if [[ -z "$repo_root" ]]; then
-		# Not in a repo — cmd_add has its own "not in a git repo" check; defer.
-		return 0
-	fi
-	abs_repo="$(cd "$repo_root" && pwd -P)"
-
-	# Containment: abs_path equals repo root OR starts with "$abs_repo/".
-	# The trailing '/' on abs_path handles the "equals" case cleanly.
-	case "$abs_path/" in
-		"$abs_repo"/*) : ;;  # nested
-		*)             return 0 ;;  # outside repo, allowed
-	esac
-
-	# Mentoring error to stderr
-	local suggested_path
+# Env override: AIDEVOPS_WORKTREE_ALLOW_NESTED=1 bypasses all path checks for
+# rare legitimate nested fixtures. AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1 allows
+# explicit non-central paths while still rejecting paths inside the repo.
+_cmd_add_suggested_central_path() {
+	local branch="$1"
+	local abs_repo="$2"
+	local abs_base="${3:-}"
+	local suggested_path=""
 	suggested_path=$(generate_worktree_path "$branch" 2>/dev/null || true)
-	if [[ -z "$suggested_path" ]]; then
-		local parent_dir repo_name slug
-		parent_dir="$(dirname -- "$abs_repo")"
-		repo_name="$(basename -- "$abs_repo")"
-		slug="$(echo "$branch" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
-		suggested_path="${parent_dir}/${repo_name}-${slug}"
+	if [[ -n "$suggested_path" ]]; then
+		printf '%s\n' "$suggested_path"
+		return 0
 	fi
 
+	local repo_name slug parent_dir
+	repo_name="$(basename -- "$abs_repo")"
+	slug="$(echo "$branch" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
+	if [[ -n "$abs_base" ]]; then
+		printf '%s/%s-%s\n' "$abs_base" "$repo_name" "$slug"
+		return 0
+	fi
+	parent_dir="$(dirname -- "$abs_repo")"
+	printf '%s/_worktrees/%s-%s\n' "$parent_dir" "$repo_name" "$slug"
+	return 0
+}
+
+_cmd_add_configured_worktree_base_abs() {
+	local configured_base=""
+	if declare -F aidevops_worktree_base_dir_configured >/dev/null 2>&1; then
+		configured_base=$(aidevops_worktree_base_dir_configured)
+	fi
+	if [[ -z "$configured_base" ]]; then
+		configured_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME:-}/Git/_worktrees}"
+	fi
+	_worktree_resolve_abs_path "$configured_base"
+	return 0
+}
+
+_cmd_add_emit_nested_path_error() {
+	local path="$1"
+	local abs_path="$2"
+	local abs_repo="$3"
+	local branch="$4"
+	local suggested_path=""
+	suggested_path=$(_cmd_add_suggested_central_path "$branch" "$abs_repo")
 	{
 		echo -e "${RED}Error: Worktree path '$path' resolves to '$abs_path',${NC}"
 		echo -e "${RED}which is inside the canonical repo working tree ('$abs_repo').${NC}"
@@ -513,18 +523,76 @@ _cmd_add_assert_path_outside_repo() {
 		echo "If you meant to branch off 'main' (or another base branch), note that"
 		echo "the 'path' argument is a FILESYSTEM PATH, not a base branch. Options:"
 		echo ""
-		echo "  - Omit [path] for auto-generated sibling path:"
+		echo "  - Omit [path] for auto-generated central path:"
 		echo "      worktree-helper.sh add $branch"
 		echo ""
-		echo "  - Pass an explicit path OUTSIDE the repo:"
+		echo "  - Use the configured central worktree base explicitly:"
 		echo "      worktree-helper.sh add $branch $suggested_path"
 		echo ""
-		echo "The created worktree branches from HEAD automatically; you do not"
-		echo "need to specify a base branch."
+		echo "The created worktree branches from origin/<default-branch> automatically;"
+		echo "use --base <ref> only when a different base is required."
 		echo ""
 		echo "(Override: AIDEVOPS_WORKTREE_ALLOW_NESTED=1 — use only with a documented"
 		echo "reason for a nested worktree.)"
 	} >&2
+	return 0
+}
+
+_cmd_add_emit_noncentral_path_error() {
+	local path="$1"
+	local abs_path="$2"
+	local abs_repo="$3"
+	local abs_base="$4"
+	local branch="$5"
+	local suggested_path=""
+	suggested_path=$(_cmd_add_suggested_central_path "$branch" "$abs_repo" "$abs_base")
+	{
+		echo -e "${RED}Error: Worktree path '$path' resolves to '$abs_path',${NC}"
+		echo -e "${RED}which is outside the configured worktree base ('$abs_base').${NC}"
+		echo ""
+		echo "Durable aidevops worktrees must use one central, backup-excludable"
+		echo "directory so cleanup can find them and ~/Git does not accumulate sibling"
+		echo "repo/worktree litter. Options:"
+		echo ""
+		echo "  - Omit [path] for auto-generated central path:"
+		echo "      worktree-helper.sh add $branch"
+		echo ""
+		echo "  - Pass an explicit path under the configured worktree base:"
+		echo "      worktree-helper.sh add $branch $suggested_path"
+		echo ""
+		echo "Configure the base with AIDEVOPS_WORKTREE_BASE_DIR or repos.json"
+		echo "worktree_base_dir when you need a different durable location."
+		echo ""
+		echo "(Override: AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1 — use only with a"
+		echo "documented cleanup owner and retention plan.)"
+	} >&2
+	return 0
+}
+
+_cmd_add_assert_path_outside_repo() {
+	local path="$1"
+	local branch="$2"
+
+	[[ "${AIDEVOPS_WORKTREE_ALLOW_NESTED:-0}" = "1" ]] && return 0
+
+	local abs_path abs_repo repo_root
+	abs_path="$(_worktree_resolve_abs_path "$path")"
+	repo_root="$(get_repo_root)"
+	[[ -z "$repo_root" ]] && return 0
+	abs_repo="$(cd "$repo_root" && pwd -P)"
+
+	if [[ "$abs_path/" == "$abs_repo"/* ]]; then
+		_cmd_add_emit_nested_path_error "$path" "$abs_path" "$abs_repo" "$branch"
+		return 1
+	fi
+	[[ "${AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH:-0}" = "1" ]] && return 0
+
+	local abs_base=""
+	abs_base="$(_cmd_add_configured_worktree_base_abs)"
+	case "$abs_path/" in
+	"$abs_base"/*) return 0 ;;
+	esac
+	_cmd_add_emit_noncentral_path_error "$path" "$abs_path" "$abs_repo" "$abs_base" "$branch"
 	return 1
 }
 

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -451,11 +451,11 @@ _help_print_examples_and_notes() {
 EXAMPLES
   # Start work on a feature (creates worktree)
   worktree-helper.sh add feature/user-auth
-  cd ~/Git/myrepo-feature-user-auth || exit
+  cd ~/Git/_worktrees/myrepo-feature-user-auth || exit
 
   # Open another terminal for a bugfix
   worktree-helper.sh add bugfix/login-timeout
-  cd ~/Git/myrepo-bugfix-login-timeout || exit
+  cd ~/Git/_worktrees/myrepo-bugfix-login-timeout || exit
 
   # List all worktrees
   worktree-helper.sh list
@@ -467,9 +467,9 @@ EXAMPLES
   worktree-helper.sh registry list
 
 DIRECTORY STRUCTURE
-  ~/Git/myrepo/                      # Main worktree (main branch)
-  ~/Git/myrepo-feature-user-auth/    # Linked worktree (feature/user-auth)
-  ~/Git/myrepo-bugfix-login/         # Linked worktree (bugfix/login)
+  ~/Git/myrepo/                                 # Main worktree (main branch)
+  ~/Git/_worktrees/myrepo-feature-user-auth/    # Linked worktree (feature/user-auth)
+  ~/Git/_worktrees/myrepo-bugfix-login/         # Linked worktree (bugfix/login)
 
 STALE REMOTE DETECTION (t1060, GH#3797)
   When creating a new branch, the script checks for stale remote refs

--- a/.agents/tools/git/worktrunk.md
+++ b/.agents/tools/git/worktrunk.md
@@ -52,9 +52,9 @@ wt commit                   # Commit with LLM-generated message (requires llm pi
 
 | Task | Worktrunk | Plain git |
 |------|-----------|-----------|
-| Switch worktrees | `wt switch feat` | `cd ../repo.feat` |
-| Create + start Claude | `wt switch -c -x claude feat` | `git worktree add -b feat ../repo.feat && cd ../repo.feat && claude` |
-| Clean up | `wt remove` | `cd ../repo && git worktree remove ../repo.feat && git branch -d feat` |
+| Switch worktrees | `wt switch feat` | `cd ~/Git/_worktrees/repo-feat` |
+| Create + start Claude | `wt switch -c -x claude feat` | `git worktree add -b feat ~/Git/_worktrees/repo-feat && cd ~/Git/_worktrees/repo-feat && claude` |
+| Clean up | `wt remove` | `cd ~/Git/repo && git worktree remove ~/Git/_worktrees/repo-feat && git branch -d feat` |
 | List with status | `wt list` | `git worktree list` (paths only) |
 | Shell integration | Built-in (cd support) | Manual |
 | Hooks | Yes (post-create, pre-merge, etc.) | No |
@@ -79,10 +79,12 @@ npm install
 
 ```bash
 wt config show
-wt config set path_template "../{repo}.{branch}"  # default
+wt config set path_template "$HOME/Git/_worktrees/{repo}-{branch}"  # aidevops policy; avoid ~/Git sibling litter
 wt config set merge_strategy squash
 wt config set llm_commits true  # AI-generated commit messages via llm
 ```
+
+Do not use Worktrunk's default sibling path template (`../{repo}.{branch}`) for aidevops-managed work. Keep durable linked worktrees under `${AIDEVOPS_WORKTREE_BASE_DIR:-~/Git/_worktrees}` so cleanup and backup exclusions can find them.
 
 ## Integration with aidevops
 

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -161,11 +161,11 @@ Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[
 full-loop-helper.sh merge "$PR_NUMBER" "$REPO"
 ```
 
-Calls `review-bot-gate-helper.sh wait` (polls every 60s, up to 10 min) then `gh pr merge --squash`. Gate failure blocks merge. Do NOT call `gh pr merge` directly — the wrapper is the only sanctioned merge path. In interactive admin/maintainer sessions, the wrapper may use `--admin` automatically when branch policy only blocks self-review/review count after checks and NMR gates pass; do not ask the user to approve their own PR. For self-modifying full-loop helper fixes, call the committed worktree path instead: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
+Calls `review-bot-gate-helper.sh wait` (polls every 60s, up to 10 min) then `gh pr merge --squash`. Gate failure blocks merge. Do NOT call `gh pr merge` directly — the wrapper is the only sanctioned merge path. After an immediate successful merge, the wrapper removes the current linked worktree when the current branch matches the PR head; `--auto` queues the merge and leaves cleanup to the safety-net sweep. In interactive admin/maintainer sessions, the wrapper may use `--admin` automatically when branch policy only blocks self-review/review count after checks and NMR gates pass; do not ask the user to approve their own PR. For self-modifying full-loop helper fixes, call the committed worktree path instead: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
 
 Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$REPO"`.
 
-**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge`. Direct `gh pr merge --squash` bypasses the review bot gate (GH#17541). Wrapper enforces: (1) review-bot-gate wait, (2) squash merge, (3) no `--delete-branch` from inside worktree.
+**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge`. Direct `gh pr merge --squash` bypasses the review bot gate (GH#17541). Wrapper enforces: (1) review-bot-gate wait, (2) squash merge, (3) no `--delete-branch` from inside worktree, (4) post-merge self-cleanup for the current linked worktree when the current branch matches the PR head. `--auto` queues only; scheduled cleanup handles it later.
 
 **4.6 Auto-Release (aidevops only):** `version-manager.sh bump patch`, tag, push, `gh release create`, `setup.sh --non-interactive`.
 
@@ -173,7 +173,7 @@ Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$R
 
 **4.8 Postflight + Deploy:** verify release health; `setup.sh --non-interactive`. Emit: `<promise>FULL_LOOP_COMPLETE</promise>`.
 
-**4.9 Worktree Cleanup (GH#6740 — MANDATORY):** `cd` canonical dir, pull, `worktree-helper.sh remove "$BRANCH_NAME" --force`, delete remote branch.
+**4.9 Worktree Cleanup (GH#6740 — MANDATORY):** immediate merges through `full-loop-helper.sh merge` self-clean the current linked worktree. If cleanup is skipped/failed, manually `cd` canonical dir, pull, `worktree-helper.sh remove "$BRANCH_NAME" --force`, delete remote branch; scheduled pulse cleanup is only a safety net.
 
 ---
 

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -9,10 +9,10 @@ After a PR merges, clean up the linked worktree and return the canonical repo to
 
 ## Automated Cleanup (workers — GH#6740)
 
-Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.9). The pulse `cleanup_worktrees()` stage is a safety net — workers must not rely on it; self-cleanup prevents accumulation during batch dispatch.
+Workers dispatched via `/full-loop` self-clean after successful immediate merges through `full-loop-helper.sh merge` (Step 4.9). The pulse `cleanup_worktrees()` stage is a safety net — workers must not rely on it; self-cleanup prevents accumulation during batch dispatch. `--auto` only queues the merge, so scheduled cleanup handles that later after the PR actually merges.
 
 ```bash
-# After gh pr merge --squash succeeds:
+# Fallback/manual sequence after gh pr merge --squash succeeds:
 WORKTREE_PATH="$(pwd)"
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 CANONICAL_DIR="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -33,19 +33,19 @@ tools:
 **Worktrunk** (preferred — shell cd, hooks, CI status, merge workflow):
 
 ```bash
-wt switch -c feature/my-feature        # Create worktree + cd into it
+wt switch -c feature/my-feature        # Create worktree + cd into it (configure path_template to ~/Git/_worktrees)
 wt list                                # List worktrees with CI status
 wt merge                               # Squash/rebase/merge + cleanup
 wt remove                              # Remove current worktree
 wt switch -c hotfix/security-patch     # Hotfix without leaving feature work
-opencode ~/Git/myrepo-feature-auth/    # Multiple AI sessions on separate worktrees
+opencode ~/Git/_worktrees/myrepo-feature-auth/  # Multiple AI sessions on separate worktrees
 ```
 
 **worktree-helper.sh** (fallback — no cd support):
 
 ```bash
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/my-feature          # Auto-path: ~/Git/_worktrees/<repo>-feature-my-feature; cd into printed path
-${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/my-feature ~/custom  # Custom path; cd into that path
+${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/my-feature "$HOME/Git/_worktrees/<repo>-feature-my-feature"  # Explicit central path
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh list                            # List worktrees
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh status                          # Status overview
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh remove feature/auth             # Removes directory, NOT the branch
@@ -65,7 +65,7 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-sessions.sh list   # Li
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-sessions.sh open   # Interactive: select + open
 ```
 
-**Worker self-cleanup (GH#6740):** Workers must remove their worktree after PR merge — batch dispatches (50+ workers) accumulate worktrees faster than pulse cleanup. See `full-loop.md` Step 4.8 and `commands/worktree-cleanup.md`.
+**Worker self-cleanup (GH#6740):** `full-loop-helper.sh merge` now removes the current linked worktree after an immediate successful merge when the current branch matches the PR head. The pulse cleanup stage remains a safety net — batch dispatches (50+ workers) can still accumulate abandoned worktrees faster than scheduled cleanup. See `full-loop.md` Step 4.9 and `commands/worktree-cleanup.md`.
 
 ## Ownership Safety (t189)
 
@@ -82,7 +82,7 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh remove featur
 | Problem | Fix |
 |---------|-----|
 | "Branch is already checked out" | `git worktree list \| grep feature/auth` — use or remove that worktree |
-| "Worktree path already exists" | `rm -rf ~/Git/myrepo-feature-auth` if safe, then re-add |
+| "Worktree path already exists" | `worktree-helper.sh remove feature/auth --force` if safe, then re-add under `~/Git/_worktrees` |
 | Stale worktree references | `git worktree prune` |
 | Detached HEAD | `cd` into worktree, `git checkout feature/auth` |
 | Worktree deleted mid-session | `git branch --list feature/my-feature` → `worktree-helper.sh add feature/my-feature` → `git stash pop` |

--- a/TODO.md
+++ b/TODO.md
@@ -1100,6 +1100,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18064 Fix GUI desktop dependency startup failure #bug ref:GH#26569 pr:#26570 completed:2026-07-05
 
+- [ ] t18065 Fix worktree cleanup lifecycle to prevent worktree litter #bug ref:GH#26622
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1100,8 +1100,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18064 Fix GUI desktop dependency startup failure #bug ref:GH#26569 pr:#26570 completed:2026-07-05
 
-- [ ] t18065 Fix worktree cleanup lifecycle to prevent worktree litter #bug ref:GH#26622
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Resolves #26622.
- Root cause: full-loop merge documented post-merge worktree cleanup but did not enforce it in `full-loop-helper.sh merge`, so merged worker worktrees relied on slower pulse sweeps.
- Prevents new sibling litter by requiring `worktree-helper.sh add` paths to live under the configured central worktree base by default.
- Makes async cleanup retries more reliable by not advancing `cleanup_worktrees.last-run` when cleanup is skipped for low GraphQL budget.
- Updates worktree/Worktrunk docs to consistently use the central worktree base.

## Testing
- `bash .agents/scripts/tests/test-worktree-helper-nested-path-guard.sh`
- `bash .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`
- `bash .agents/scripts/tests/test-cleanup-worktrees-async.sh`
- `bash .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh`
- `bash .agents/scripts/tests/test-worktree-centralized-paths.sh`
- `.agents/scripts/shellcheck-wrapper.sh .agents/scripts/worktree-helper-add.sh .agents/scripts/worktree-helper-cmds.sh .agents/scripts/full-loop-helper-merge.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/cleanup-worktrees-async-helper.sh .agents/scripts/tests/test-worktree-helper-nested-path-guard.sh .agents/scripts/tests/test-cleanup-worktrees-async.sh .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`
- `.agents/scripts/linters-local.sh` passed before the final issue-link rebase; targeted regression tests were rerun after the final rebase.

## Runtime Testing
- Risk: medium shell workflow automation.
- Runtime-verified with fake git worktree merge test that confirms `cmd_merge` removes the current linked worktree after immediate merge.

## Key decisions
- `--auto` merge queues do not self-clean because the PR has not merged yet; scheduled cleanup remains responsible after the merge lands.
- `AIDEVOPS_WORKTREE_ALLOW_CUSTOM_PATH=1` remains available for documented exceptions, while nested paths still require `AIDEVOPS_WORKTREE_ALLOW_NESTED=1`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.59 with gpt-5.5 spent 1h 25m and 632,943 tokens on this with the user in an interactive session.
