### PR TITLE
GH#26627: fix: recover commit-and-pr rebase failures

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -96,7 +96,7 @@ cmd_pre_merge_gate() {
 
 # Parse commit-and-pr arguments into caller-scoped variables.
 # Expects the caller to have declared: issue_number, commit_message, pr_title,
-# summary_what, summary_testing, summary_decisions, extra_labels (array).
+# summary_what, summary_testing, summary_decisions, skip_rebase, extra_labels (array).
 # Returns 1 on unknown argument.
 _parse_commit_and_pr_args() {
 	while [[ $# -gt 0 ]]; do
@@ -139,12 +139,58 @@ _parse_commit_and_pr_args() {
 			skip_hooks=1
 			shift
 			;;
+		--no-rebase)
+			# GH#26627: explicit recovery mode after a failed/aborted rebase.
+			# Pushes only after clean-state and ahead-of-base checks pass.
+			skip_rebase=1
+			shift
+			;;
 		*)
 			print_error "Unknown argument: $1"
 			return 1
 			;;
 		esac
 	done
+	return 0
+}
+
+# Resolve the remote default branch for cross-repo commit-and-pr operations.
+# Returns 0 and prints the branch name, or returns 1 with remediation guidance.
+_resolve_remote_default_branch() {
+	local remote_name="${1:-origin}"
+	local ref=""
+
+	ref=$(git symbolic-ref --short "refs/remotes/${remote_name}/HEAD" 2>/dev/null || true)
+	if [[ -n "$ref" ]]; then
+		printf '%s\n' "${ref#${remote_name}/}"
+		return 0
+	fi
+
+	print_error "Cannot determine ${remote_name} default branch from refs/remotes/${remote_name}/HEAD."
+	print_error "Run: git remote set-head ${remote_name} --auto"
+	print_error "Then retry: full-loop-helper.sh commit-and-pr ..."
+	return 1
+}
+
+# Ensure no rebase/merge state is active before recovery-mode push.
+_ensure_no_in_progress_integration() {
+	local git_dir=""
+	git_dir=$(git rev-parse --git-dir 2>/dev/null) || git_dir=""
+	if [[ -z "$git_dir" ]]; then
+		print_error "Cannot inspect git state for rebase/merge recovery."
+		return 1
+	fi
+
+	local rebase_merge="" rebase_apply="" merge_head=""
+	rebase_merge=$(git rev-parse --git-path rebase-merge 2>/dev/null || printf '%s' "${git_dir}/rebase-merge")
+	rebase_apply=$(git rev-parse --git-path rebase-apply 2>/dev/null || printf '%s' "${git_dir}/rebase-apply")
+	merge_head=$(git rev-parse --git-path MERGE_HEAD 2>/dev/null || printf '%s' "${git_dir}/MERGE_HEAD")
+
+	if [[ -e "$rebase_merge" || -e "$rebase_apply" || -e "$merge_head" ]]; then
+		print_error "Refusing recovery push while a rebase or merge is in progress."
+		print_error "Resolve/abort the operation first, then retry with --no-rebase if appropriate."
+		return 1
+	fi
 	return 0
 }
 
@@ -202,13 +248,15 @@ _stage_and_commit() {
 	fi
 
 	if git diff --cached --quiet 2>/dev/null; then
-		local ahead=""
-		ahead=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+		local base_branch="" base_ref="" ahead=""
+		base_branch=$(_resolve_remote_default_branch origin) || return 1
+		base_ref="origin/${base_branch}"
+		ahead=$(git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo "0")
 		if [[ "$ahead" == "0" ]]; then
-			print_error "No changes to commit and no commits ahead of main."
+			print_error "No changes to commit and no commits ahead of ${base_branch}."
 			return 1
 		fi
-		print_info "No new changes to commit, but ${ahead} commit(s) ahead of main. Proceeding to PR."
+		print_info "No new changes to commit, but ${ahead} commit(s) ahead of ${base_branch}. Proceeding to PR."
 	else
 		if ! git commit -m "$commit_message"; then
 			print_error "git commit failed"
@@ -523,41 +571,59 @@ _check_and_handle_shallow_clone() {
 	fi
 }
 
-# Rebase onto origin/main and force-push the current branch.
-# Args: $1=branch $2=skip_hooks (0|1, optional, default 0)
+# Rebase onto the detected origin default branch and force-push the current branch.
+# Args: $1=branch $2=skip_hooks (0|1, optional, default 0) $3=skip_rebase (0|1, optional, default 0)
 # Returns 1 on rebase conflict or push failure.
 _rebase_and_push() {
 	local branch="$1"
 	local skip_hooks="${2:-0}"
+	local skip_rebase="${3:-0}"
+	local base_branch="" base_ref=""
+	base_branch=$(_resolve_remote_default_branch origin) || return 1
+	base_ref="origin/${base_branch}"
 
-	print_info "Rebasing onto origin/main..."
-	if ! git fetch origin main --quiet 2>/dev/null; then
-		print_warning "git fetch origin main failed — proceeding with current state"
-	fi
-	# GH#21900: detect shallow clone before rebase to avoid add/add conflict cascade.
-	_check_and_handle_shallow_clone || return 1
-	if ! git rebase origin/main 2>/dev/null; then
-		print_error "Rebase conflict. Resolve conflicts, then run: git rebase --continue && full-loop-helper.sh commit-and-pr ..."
-		git rebase --abort 2>/dev/null || true
-		return 1
+	if [[ "$skip_rebase" == "1" ]]; then
+		print_warning "Skipping rebase by explicit request (--no-rebase); validating clean recovery state."
+		_ensure_no_in_progress_integration || return 1
+		local ahead=""
+		ahead=$(git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo "0")
+		if [[ "$ahead" == "0" ]]; then
+			print_error "Refusing --no-rebase push: HEAD is not ahead of ${base_ref}."
+			return 1
+		fi
+	else
+		print_info "Rebasing onto ${base_ref}..."
+		if ! git fetch origin "$base_branch" --quiet 2>/dev/null; then
+			print_warning "git fetch origin ${base_branch} failed — proceeding with current state"
+		fi
+		# GH#21900: detect shallow clone before rebase to avoid add/add conflict cascade.
+		_check_and_handle_shallow_clone || return 1
+		if ! git rebase "$base_ref" 2>/dev/null; then
+			git rebase --abort 2>/dev/null || true
+			print_error "Rebase conflict/abort while rebasing onto ${base_ref}."
+			print_error "After inspecting the branch and confirming a PR without rebase is safe, retry:"
+			print_error "  full-loop-helper.sh commit-and-pr ... --no-rebase"
+			print_error "Do not fall back to raw inline 'gh pr create --body ...'; keep the wrapper path."
+			return 1
+		fi
 	fi
 
 	# t2229 Layer 3: auto-reset .task-counter if rebase picked up a stale value.
-	# After rebase, the branch may carry a counter lower than origin/main's
-	# current value (race: main advanced between rebase-base and push).
-	# Reset to origin/main's value to prevent silent regression on merge.
+	# After rebase, the branch may carry a counter lower than the base branch's
+	# current value (race: base advanced between rebase-base and push).
+	# Reset to the base branch value to prevent silent regression on merge.
 	if [[ -f .task-counter ]]; then
 		local branch_counter="" base_counter=""
 		branch_counter=$(tr -d '[:space:]' <.task-counter 2>/dev/null) || true
-		base_counter=$(git show origin/main:.task-counter 2>/dev/null | tr -d '[:space:]') || true
+		base_counter=$(git show "${base_ref}:.task-counter" 2>/dev/null | tr -d '[:space:]') || true
 		if [[ -n "$branch_counter" && -n "$base_counter" ]] \
 			&& [[ "$branch_counter" =~ ^[0-9]+$ ]] \
 			&& [[ "$base_counter" =~ ^[0-9]+$ ]] \
 			&& [[ "$((10#$branch_counter))" -lt "$((10#$base_counter))" ]]; then
 			print_info "Auto-resetting .task-counter: ${branch_counter} → ${base_counter} (base drifted during rebase)"
-			echo "$base_counter" > .task-counter
+			printf '%s\n' "$base_counter" >.task-counter
 			git add .task-counter
-			git commit -m "chore: reset .task-counter to origin/main value (t2229 race prevention)" --no-verify
+			git commit -m "chore: reset .task-counter to ${base_ref} value (t2229 race prevention)" --no-verify
 		fi
 	fi
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -56,11 +56,12 @@ source "${SCRIPT_DIR}/full-loop-helper-merge.sh"
 # Collapses full-loop steps 4.1-4.2.1 into a single deterministic call.
 # Workers and interactive sessions both use this — no parallel logic.
 #
-# Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...] [--allow-parent-close] [--skip-hooks]
+# Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...] [--allow-parent-close] [--skip-hooks] [--no-rebase]
 # Exit codes: 0 = PR created (prints PR number to stdout), 1 = failure
 # --allow-parent-close: skip the parent-task keyword guard (final-phase PR only)
 # --skip-hooks: pass --no-verify to git push (bypasses pre-push hooks). Use for doc-only PRs
 #   after manually verifying no secrets/private-slugs in the diff. See GH#20138.
+# --no-rebase: explicit recovery mode after a failed rebase; requires clean git state and commits ahead of the detected base branch.
 #
 # On rebase conflict: returns 1 with instructions. Caller must resolve and retry.
 # On push failure: returns 1. Caller should check remote state.
@@ -70,7 +71,7 @@ cmd_commit_and_pr() {
 	local issue_number="" commit_message="" pr_title="" summary_what="" summary_testing="" summary_decisions=""
 	local -a extra_labels=()
 	local allow_parent_close=0
-	local skip_hooks=0
+	local skip_hooks=0 skip_rebase=0
 
 	_parse_commit_and_pr_args "$@" || return 1
 
@@ -83,7 +84,7 @@ cmd_commit_and_pr() {
 	# Inserted between commit and push so amends apply to the same commit
 	# the worker just made, and so failures abort BEFORE we push broken code.
 	_run_project_validators "$skip_hooks" || return 1
-	_rebase_and_push "$branch" "$skip_hooks" || return 1
+	_rebase_and_push "$branch" "$skip_hooks" "$skip_rebase" || return 1
 
 	# Build PR metadata (t2720: prefer tNNN from TODO.md so issue-sync's
 	# PR-merge auto-completion regex can extract a task_id and flip [ ] → [x]).
@@ -112,7 +113,10 @@ cmd_commit_and_pr() {
 	fi
 
 	local files_changed=""
-	files_changed=$(git diff --name-only origin/main..HEAD 2>/dev/null | tr '\n' ', ' | sed 's/,$//' || echo "")
+	local base_branch="" base_ref=""
+	base_branch=$(_resolve_remote_default_branch origin) || return 1
+	base_ref="origin/${base_branch}"
+	files_changed=$(git diff --name-only "${base_ref}..HEAD" 2>/dev/null | tr '\n' ', ' | sed 's/,$//' || echo "")
 
 	# t2242: Determine closing keyword — auto-swap Resolves to For when linked
 	# issue has parent-task label, unless --allow-parent-close overrides.
@@ -199,6 +203,7 @@ Commands:
   commit-and-pr|create-pr --issue N --message "msg"
                                  Stage, commit, rebase, push, create PR, post merge summary
                 [--skip-hooks]             Pass --no-verify to git push (doc-only PRs, GH#20138)
+                [--no-rebase]              Explicit recovery mode after a failed/aborted rebase
   pre-merge-gate <PR> [REPO]    Check review bot gate before merge (GH#17541)
   merge <PR> [REPO] [--squash|--merge|--rebase] [--admin] [--auto]
                                 Gate-enforced merge (runs pre-merge-gate first).

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -115,6 +115,13 @@ eval "$(sed -n '/^_create_pr() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit
 # shellcheck disable=SC2312
 eval "$(sed -n '/^_post_merge_summary() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
+# Extract default-branch and recovery helpers used by _rebase_and_push
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_resolve_remote_default_branch() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
+
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_ensure_no_in_progress_integration() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
+
 # Extract _rebase_and_push
 # shellcheck disable=SC2312
 eval "$(sed -n '/^_rebase_and_push() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
@@ -126,8 +133,25 @@ eval "$(sed -n '/^_rebase_and_push() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-
 
 # Stub: git branch --show-current → always returns "feature/t2767-test"
 git() {
+	printf 'git %s\n' "$*" >>"$STUB_LOG"
 	if [[ "${1:-}" == "branch" && "${2:-}" == "--show-current" ]]; then
 		printf 'feature/t2767-test\n'
+		return 0
+	fi
+	if [[ "${1:-}" == "symbolic-ref" && "${2:-}" == "--short" && "${3:-}" == "refs/remotes/origin/HEAD" ]]; then
+		printf '%s\n' "${TEST_REMOTE_HEAD:-origin/main}"
+		return 0
+	fi
+	if [[ "${1:-}" == "rev-list" && "${2:-}" == "--count" ]]; then
+		printf '1\n'
+		return 0
+	fi
+	if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--git-dir" ]]; then
+		printf '%s/.git\n' "$TMP"
+		return 0
+	fi
+	if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--git-path" ]]; then
+		printf '%s/.git/%s\n' "$TMP" "${3:-}"
 		return 0
 	fi
 	if [[ "${1:-}" == "fetch" ]]; then
@@ -139,6 +163,9 @@ git() {
 	if [[ "${1:-}" == "push" ]]; then
 		printf "branch 'feature/t2767-test' set up to track 'origin/feature/t2767-test'.\n"
 		return 0
+	fi
+	if [[ "${1:-}" == "show" ]]; then
+		return 1
 	fi
 	command git "$@"
 	return $?
@@ -438,6 +465,58 @@ else
 	fail "push stdout hygiene: _rebase_and_push emits no stdout" \
 		"got '${rebase_push_output}'"
 fi
+
+# =============================================================================
+# Test 3d: _rebase_and_push uses the detected remote default branch
+# Expected: non-main origin/HEAD causes fetch/rebase/diff safety checks to use develop.
+# =============================================================================
+: >"$STUB_LOG"
+TEST_REMOTE_HEAD="origin/develop"
+default_branch_rc=0
+_rebase_and_push "feature/t2767-test" 0 >/dev/null 2>&1 || default_branch_rc=$?
+
+if [[ "$default_branch_rc" -eq 0 ]]; then
+	pass "default branch: _rebase_and_push succeeds for non-main remote HEAD"
+else
+	fail "default branch: _rebase_and_push succeeds for non-main remote HEAD" \
+		"got exit $default_branch_rc; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if grep -q "git fetch origin develop --quiet" "$STUB_LOG" 2>/dev/null &&
+	grep -q "git rebase origin/develop" "$STUB_LOG" 2>/dev/null &&
+	! grep -q "git rebase origin/main" "$STUB_LOG" 2>/dev/null; then
+	pass "default branch: rebase path uses origin/develop rather than origin/main"
+else
+	fail "default branch: rebase path uses origin/develop rather than origin/main" \
+		"stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Test 3e: _rebase_and_push --no-rebase recovery keeps wrapper path pushable
+# Expected: explicit recovery mode skips git rebase and still pushes after checks.
+# =============================================================================
+: >"$STUB_LOG"
+TEST_REMOTE_HEAD="origin/develop"
+no_rebase_rc=0
+_rebase_and_push "feature/t2767-test" 0 1 >/dev/null 2>&1 || no_rebase_rc=$?
+
+if [[ "$no_rebase_rc" -eq 0 ]]; then
+	pass "no-rebase recovery: explicit mode succeeds with clean ahead branch"
+else
+	fail "no-rebase recovery: explicit mode succeeds with clean ahead branch" \
+		"got exit $no_rebase_rc; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if ! grep -q "git rebase" "$STUB_LOG" 2>/dev/null &&
+	grep -q "git rev-list --count origin/develop..HEAD" "$STUB_LOG" 2>/dev/null &&
+	grep -q "git push -u origin feature/t2767-test --force-with-lease" "$STUB_LOG" 2>/dev/null; then
+	pass "no-rebase recovery: skips rebase and pushes via wrapper path"
+else
+	fail "no-rebase recovery: skips rebase and pushes via wrapper path" \
+		"stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+TEST_REMOTE_HEAD="origin/main"
 
 # =============================================================================
 # Test 4: _post_merge_summary idempotency — skip when canonical comment already exists


### PR DESCRIPTION
## Summary

Detect the remote default branch for commit-and-pr rebase/diff/counter checks, add explicit --no-rebase recovery mode with clean-state/ahead checks, and keep workers on the wrapper PR path after rebase failures.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh,.agents/scripts/full-loop-helper.sh,.agents/scripts/tests/test-commit-and-pr-partial-success.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n full-loop helper files; shellcheck -x -S warning targeted helper/test files; test-commit-and-pr-partial-success.sh (27 tests); linters-local.sh progressed through core gates but timed out later on broad repository ratchets with pre-existing advisory/blocking debt.

Resolves #26627
Resolves #26626


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.60 with gpt-5.5 spent 30m and 106,970 tokens on this with the user in an interactive session.
