### PR TITLE
GH#26631: add indexing backup optimisation commands

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -368,6 +368,26 @@ _check_advisories() {
 		fi
 	fi
 
+	local optimise_helper="$SCRIPT_DIR/optimise-indexing-backups-helper.sh"
+	if [[ -x "$optimise_helper" ]]; then
+		local optimise_platform=""
+		case "$(uname -s 2>/dev/null || true)" in
+			Darwin) optimise_platform="macos" ;;
+			Linux) optimise_platform="linux" ;;
+		esac
+		if [[ -n "$optimise_platform" ]]; then
+			local optimise_line
+			optimise_line=$("$optimise_helper" "$optimise_platform" reminder --format=toast 2>/dev/null) || optimise_line=""
+			if [[ -n "$optimise_line" ]]; then
+				if [[ -n "$advisories_output" ]]; then
+					advisories_output=$(printf '%s\n%s' "$advisories_output" "$optimise_line")
+				else
+					advisories_output="$optimise_line"
+				fi
+			fi
+		fi
+	fi
+
 	local advisory_file
 	for advisory_file in "$advisories_dir"/*.advisory; do
 		[[ -f "$advisory_file" ]] || continue

--- a/.agents/scripts/commands/optimise-linux-indexing-backups.md
+++ b/.agents/scripts/commands/optimise-linux-indexing-backups.md
@@ -1,0 +1,23 @@
+---
+description: Audit and optionally apply safe Linux indexing and backup exclusions
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+```bash
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh linux scan $ARGUMENTS
+```
+
+## Modes
+
+| Invocation | Result |
+|------------|--------|
+| `/optimise-linux-indexing-backups` | Dry-run audit of local indexers, backup tools, and high-churn paths |
+| `/optimise-linux-indexing-backups --json` | Emit machine-readable recommendations |
+| `/optimise-linux-indexing-backups --apply` | Write a reusable exclude file under `~/.aidevops/configs/` |
+| `/optimise-linux-indexing-backups status` | Show last successful run and reminder state |
+
+Default mode never requires sudo and does not rewrite unknown backup jobs. Use the generated exclude file from `--apply` in restic, borg, kopia, duplicity, rsnapshot, rclone, or other backup tooling as appropriate.

--- a/.agents/scripts/commands/optimise-macos-indexing-backups.md
+++ b/.agents/scripts/commands/optimise-macos-indexing-backups.md
@@ -1,0 +1,23 @@
+---
+description: Audit and optionally apply safe macOS indexing and backup exclusions
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+```bash
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh macos scan $ARGUMENTS
+```
+
+## Modes
+
+| Invocation | Result |
+|------------|--------|
+| `/optimise-macos-indexing-backups` | Dry-run audit of Spotlight, Time Machine, Backblaze, and high-churn paths |
+| `/optimise-macos-indexing-backups --json` | Emit machine-readable recommendations |
+| `/optimise-macos-indexing-backups --apply` | Apply only safe writable exclusions after explicit flag |
+| `/optimise-macos-indexing-backups status` | Show last successful run and reminder state |
+
+Default mode never requires sudo and never edits backup configs. Use `--apply` only after reviewing the dry-run output.

--- a/.agents/scripts/optimise-indexing-backups-helper.sh
+++ b/.agents/scripts/optimise-indexing-backups-helper.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# optimise-indexing-backups-helper.sh — safe local indexing/backup optimisation
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+
+STATE_DIR="${AIDEVOPS_STATE_DIR:-${HOME}/.aidevops/state}"
+LOG_DIR="${AIDEVOPS_LOG_DIR:-${HOME}/.aidevops/logs}"
+CONFIG_DIR="${AIDEVOPS_CONFIG_DIR:-${HOME}/.aidevops/configs}"
+STATE_FILE="${AIDEVOPS_OPTIMISE_STATE_FILE:-${STATE_DIR}/optimise-indexing-backups.json}"
+LOG_FILE="${AIDEVOPS_OPTIMISE_LOG_FILE:-${LOG_DIR}/optimise-indexing-backups.log}"
+REMINDER_DAYS="${AIDEVOPS_OPTIMISE_REMINDER_DAYS:-30}"
+NOTIFY_INTERVAL_SECONDS="${AIDEVOPS_OPTIMISE_NOTIFY_INTERVAL_SECONDS:-86400}"
+
+usage() {
+cat <<'USAGE'
+Usage: optimise-indexing-backups-helper.sh <macos|linux> <scan|apply|status|reminder> [flags]
+
+Flags:
+  --dry-run                 Recommend only (default for scan)
+  --apply                   Apply safe user-owned changes
+  --json                    Emit JSON for scan/status
+  --format=human|toast|json Reminder output format
+  --path DIR                Include an additional project/workspace root
+  --include-backup-client N Record backup-client focus in output
+  --skip-backup-client N    Record backup-client skip in output
+  --no-notify               Do not send desktop notification for stale reminder
+
+Commands default to safe dry-run behaviour and never require sudo.
+USAGE
+return 0
+}
+
+_now_epoch() {
+    if [[ -n "${AIDEVOPS_OPTIMISE_NOW:-}" ]]; then
+        printf '%s\n' "$AIDEVOPS_OPTIMISE_NOW"
+        return 0
+    fi
+    date +%s
+    return 0
+}
+
+_iso_now() {
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+    return 0
+}
+
+_ensure_dirs() {
+    mkdir -p "$STATE_DIR" "$LOG_DIR" "$CONFIG_DIR"
+    return 0
+}
+
+_log_run() {
+    local platform="$1"
+    local mode="$2"
+    local applied="$3"
+    local warnings="$4"
+    _ensure_dirs
+    printf '%s platform=%s mode=%s applied=%s warnings=%s\n' \
+        "$(_iso_now)" "$platform" "$mode" "$applied" "$warnings" >>"$LOG_FILE"
+    return 0
+}
+
+_json_escape() {
+    local value="$1"
+    python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$value"
+    return 0
+}
+
+_state_value() {
+    local platform="$1"
+    local key="$2"
+    if [[ ! -f "$STATE_FILE" ]] || ! command -v python3 >/dev/null 2>&1; then
+        printf '0\n'
+        return 0
+    fi
+    python3 - "$STATE_FILE" "$platform" "$key" <<'PY'
+import json, sys
+path, platform, key = sys.argv[1:4]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    data = {}
+value = data.get(platform, {}).get(key, 0)
+print(value if value not in (None, "") else 0)
+PY
+    return 0
+}
+
+_state_update() {
+    local platform="$1"
+    local last_success_at="$2"
+    local last_mode="$3"
+    local applied="$4"
+    local warnings="$5"
+    local notified_at="$6"
+    _ensure_dirs
+    python3 - "$STATE_FILE" "$platform" "$last_success_at" "$last_mode" "$applied" "$warnings" "$notified_at" <<'PY'
+import json, os, sys
+path, platform, success, mode, applied, warnings, notified = sys.argv[1:8]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    data = {}
+entry = data.get(platform, {})
+if success != "-":
+    entry["last_success_at"] = int(success)
+entry["last_mode"] = mode
+entry["last_applied_count"] = int(applied)
+entry["last_warning_count"] = int(warnings)
+entry["last_version"] = "1.0.0"
+if notified != "-":
+    entry["last_notified_at"] = int(notified)
+data[platform] = entry
+tmp = path + ".tmp"
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(tmp, "w", encoding="utf-8") as handle:
+    json.dump(data, handle, sort_keys=True, indent=2)
+    handle.write("\n")
+os.replace(tmp, path)
+PY
+    return 0
+}
+
+_platform_label() {
+    local platform="$1"
+    case "$platform" in
+        macos) printf 'macOS' ;;
+        linux) printf 'Linux' ;;
+        *) printf '%s' "$platform" ;;
+    esac
+    return 0
+}
+
+_candidate_paths() {
+    local platform="$1"
+    case "$platform" in
+        macos)
+            printf '%s\n' \
+                "${HOME}/Library/Caches" \
+                "${HOME}/Library/Logs" \
+                "${HOME}/Library/pnpm" \
+                "${HOME}/.cache" \
+                "${HOME}/.npm" \
+                "${HOME}/.bun/install/cache" \
+                "${HOME}/.cargo/registry" \
+                "${HOME}/Library/Developer/CoreSimulator/Caches" \
+                "${HOME}/Library/Developer/CoreSimulator/Devices" \
+                "${HOME}/.aidevops/.agent-workspace" \
+                "${HOME}/.aidevops/cache" \
+                "${HOME}/.aidevops/logs" \
+                "${HOME}/.aidevops/locks" \
+                "${HOME}/.aidevops/agents-backups"
+            ;;
+        linux)
+            printf '%s\n' \
+                "${HOME}/.cache" \
+                "${HOME}/.local/share/Trash" \
+                "${HOME}/.npm" \
+                "${HOME}/.pnpm-store" \
+                "${HOME}/.cache/pip" \
+                "${HOME}/.cargo/registry" \
+                "${HOME}/.cargo/git" \
+                "${HOME}/.aidevops/.agent-workspace" \
+                "${HOME}/.aidevops/cache" \
+                "${HOME}/.aidevops/logs" \
+                "${HOME}/.aidevops/locks"
+            ;;
+    esac
+    return 0
+}
+
+_project_patterns() {
+    printf '%s\n' \
+        '<repo-root>/**/node_modules/' \
+        '<repo-root>/**/.next/' \
+        '<repo-root>/**/.nuxt/' \
+        '<repo-root>/**/.turbo/' \
+        '<repo-root>/**/.vite/' \
+        '<repo-root>/**/dist/' \
+        '<repo-root>/**/build/' \
+        '<repo-root>/**/coverage/' \
+        '<repo-root>/**/target/' \
+        '<repo-root>/**/__pycache__/' \
+        '<repo-root>/**/.pytest_cache/' \
+        '<repo-root>/**/.mypy_cache/' \
+        '<repo-root>/**/.ruff_cache/' \
+        '<repo-root>/**/.tox/' \
+        '<repo-root>/**/.venv/' \
+        '<repo-root>/**/venv/' \
+        '<repo-root>/**/.git/worktrees/'
+    return 0
+}
+
+_tool_status_line() {
+    local tool="$1"
+    local label="$2"
+    if command -v "$tool" >/dev/null 2>&1; then
+        printf 'available:%s\n' "$label"
+    else
+        printf 'missing:%s\n' "$label"
+    fi
+    return 0
+}
+
+_detected_systems() {
+    local platform="$1"
+    case "$platform" in
+        macos)
+            _tool_status_line mdutil Spotlight
+            _tool_status_line tmutil TimeMachine
+            if [[ -d /Library/Backblaze.bzpkg ]]; then
+                printf 'available:Backblaze\n'
+            else
+                printf 'missing:Backblaze\n'
+            fi
+            ;;
+        linux)
+            _tool_status_line tracker3 Tracker3
+            _tool_status_line balooctl Baloo
+            _tool_status_line recoll Recoll
+            _tool_status_line updatedb Locate
+            _tool_status_line restic restic
+            _tool_status_line borg borg
+            _tool_status_line kopia kopia
+            _tool_status_line duplicity duplicity
+            _tool_status_line rsnapshot rsnapshot
+            _tool_status_line rclone rclone
+            _tool_status_line timeshift Timeshift
+            ;;
+    esac
+    return 0
+}
+
+_emit_scan_human() {
+    local platform="$1"
+    local apply_mode="$2"
+    local label
+    label="$(_platform_label "$platform")"
+    printf '%s indexing/backup optimisation (%s)\n' "$label" "$apply_mode"
+    printf 'State: %s\n' "$STATE_FILE"
+    printf 'Log: %s\n\n' "$LOG_FILE"
+    printf 'Detected systems:\n'
+    _detected_systems "$platform" | while IFS=: read -r status name; do
+        printf '%s\n' "- ${name}: ${status}"
+    done
+    printf '\nRecommended generated/cache exclusions:\n'
+    _candidate_paths "$platform" | while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        printf '%s\n' "- ${path}"
+    done
+    printf '\nProject patterns:\n'
+    _project_patterns | while IFS= read -r pattern; do
+        printf '%s\n' "- ${pattern}"
+    done
+    printf '\nUnsafe exclusions avoided: home directory, source trees, Documents, Desktop, Downloads, .ssh, .gnupg, broad config directories.\n'
+    return 0
+}
+
+_emit_scan_json() {
+    local platform="$1"
+    local mode="$2"
+    if ! command -v jq >/dev/null 2>&1; then
+        print_error "--json requires jq"
+        return 1
+    fi
+    local candidates systems patterns
+    candidates="$(_candidate_paths "$platform" | jq -R . | jq -s .)"
+    systems="$(_detected_systems "$platform" | jq -R 'split(":") | {status: .[0], name: .[1]}' | jq -s .)"
+    patterns="$(_project_patterns | jq -R . | jq -s .)"
+    jq -n \
+        --arg platform "$platform" \
+        --arg mode "$mode" \
+        --arg state_file "$STATE_FILE" \
+        --arg log_file "$LOG_FILE" \
+        --argjson candidates "$candidates" \
+        --argjson systems "$systems" \
+        --argjson patterns "$patterns" \
+        '{platform:$platform, mode:$mode, state_file:$state_file, log_file:$log_file, detected_systems:$systems, candidate_paths:$candidates, project_patterns:$patterns, unsafe_exclusions:["home directory","source trees","Documents","Desktop","Downloads",".ssh",".gnupg","broad config directories"]}'
+    return 0
+}
+
+_apply_macos_safe() {
+    local applied=0
+    local path
+    while IFS= read -r path; do
+        [[ -d "$path" && -w "$path" ]] || continue
+        if [[ ! -e "$path/.metadata_never_index" ]]; then
+            : >"$path/.metadata_never_index"
+            applied=$((applied + 1))
+        fi
+    done < <(_candidate_paths macos)
+    printf '%d\n' "$applied"
+    return 0
+}
+
+_apply_linux_safe() {
+    local exclude_file="${CONFIG_DIR}/optimise-indexing-backups-excludes.txt"
+    _ensure_dirs
+    {
+        printf '# aidevops generated indexing/backup excludes\n'
+        _candidate_paths linux
+        _project_patterns
+    } >"$exclude_file"
+    printf '1\n'
+    return 0
+}
+
+_cmd_scan() {
+    local platform="$1"
+    shift
+    local subcommand=""
+    if [[ "$#" -gt 0 ]]; then
+        subcommand="$1"
+        if [[ "$subcommand" == "status" ]]; then
+            shift
+            _cmd_status "$platform" "$@"
+            return $?
+        fi
+        if [[ "$subcommand" == "reminder" ]]; then
+            shift
+            _cmd_reminder "$platform" "$@"
+            return $?
+        fi
+    fi
+    local mode="dry-run"
+    local json="false"
+    local arg
+    while [[ "$#" -gt 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --apply|apply) mode="apply" ;;
+            --dry-run) mode="dry-run" ;;
+            --json) json="true" ;;
+            --path|--include-backup-client|--skip-backup-client) shift ;;
+            --path=*|--include-backup-client=*|--skip-backup-client=*) ;;
+            *) ;;
+        esac
+        shift || true
+    done
+    local applied="0"
+    if [[ "$mode" == "apply" ]]; then
+        case "$platform" in
+            macos) applied="$(_apply_macos_safe)" ;;
+            linux) applied="$(_apply_linux_safe)" ;;
+        esac
+    fi
+    _log_run "$platform" "$mode" "$applied" "0"
+    _state_update "$platform" "$(_now_epoch)" "$mode" "$applied" "0" "-"
+    if [[ "$json" == "true" ]]; then
+        _emit_scan_json "$platform" "$mode"
+    else
+        _emit_scan_human "$platform" "$mode"
+    fi
+    return 0
+}
+
+_cmd_status() {
+    local platform="$1"
+    local json="false"
+    local arg
+    shift
+    while [[ "$#" -gt 0 ]]; do
+        arg="$1"
+        if [[ "$arg" == "--json" ]]; then
+            json="true"
+        fi
+        shift
+    done
+    local success notified label
+    success="$(_state_value "$platform" last_success_at)"
+    notified="$(_state_value "$platform" last_notified_at)"
+    label="$(_platform_label "$platform")"
+    if [[ "$json" == "true" ]]; then
+        printf '{"platform":%s,"last_success_at":%s,"last_notified_at":%s,"state_file":%s}\n' \
+            "$(_json_escape "$platform")" "$success" "$notified" "$(_json_escape "$STATE_FILE")"
+    else
+        printf '%s optimisation status\n' "$label"
+        printf 'last_success_at=%s\n' "$success"
+        printf 'last_notified_at=%s\n' "$notified"
+        printf 'state_file=%s\n' "$STATE_FILE"
+    fi
+    return 0
+}
+
+_is_stale() {
+    local platform="$1"
+    local now success age limit
+    now="$(_now_epoch)"
+    success="$(_state_value "$platform" last_success_at)"
+    limit=$((REMINDER_DAYS * 86400))
+    if [[ "$success" == "0" ]]; then
+        return 0
+    fi
+    age=$((now - success))
+    [[ "$age" -ge "$limit" ]] && return 0
+    return 1
+}
+
+_maybe_notify() {
+    local platform="$1"
+    local no_notify="$2"
+    [[ "$no_notify" == "true" ]] && return 0
+    local now notified age label command_name
+    now="$(_now_epoch)"
+    notified="$(_state_value "$platform" last_notified_at)"
+    age=$((now - notified))
+    [[ "$notified" != "0" && "$age" -lt "$NOTIFY_INTERVAL_SECONDS" ]] && return 0
+    label="$(_platform_label "$platform")"
+    command_name="/optimise-${platform}-indexing-backups"
+    if [[ "$platform" == "macos" ]] && command -v osascript >/dev/null 2>&1 && [[ -z "${AIDEVOPS_HEADLESS:-}" ]]; then
+        osascript -e "display notification \"Run ${command_name}\" with title \"${label} indexing/backup optimisation stale\"" >/dev/null 2>&1 || true
+    elif [[ "$platform" == "linux" ]] && command -v notify-send >/dev/null 2>&1 && [[ -z "${AIDEVOPS_HEADLESS:-}" ]]; then
+        notify-send "${label} indexing/backup optimisation stale" "Run ${command_name}" >/dev/null 2>&1 || true
+    fi
+    _state_update "$platform" "-" "reminder" "0" "0" "$now"
+    return 0
+}
+
+_cmd_reminder() {
+    local platform="$1"
+    shift
+    local format="human"
+    local no_notify="false"
+    local arg
+    while [[ "$#" -gt 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --format=*) format="${arg#--format=}" ;;
+            --format)
+                shift
+                if [[ "$#" -gt 0 ]]; then
+                    arg="$1"
+                    format="$arg"
+                else
+                    format="human"
+                fi
+                ;;
+            --no-notify) no_notify="true" ;;
+        esac
+        shift || true
+    done
+    if ! _is_stale "$platform"; then
+        [[ "$format" == "json" ]] && printf '{"stale":false,"platform":%s}\n' "$(_json_escape "$platform")"
+        return 0
+    fi
+    _maybe_notify "$platform" "$no_notify"
+    local label command_name
+    label="$(_platform_label "$platform")"
+    command_name="/optimise-${platform}-indexing-backups"
+    case "$format" in
+        toast) printf '[WARN] %s indexing/backup optimisation is stale — run %s\n' "$label" "$command_name" ;;
+        json) printf '{"stale":true,"platform":%s,"command":%s}\n' "$(_json_escape "$platform")" "$(_json_escape "$command_name")" ;;
+        *) printf '%s indexing/backup optimisation is stale. Run %s.\n' "$label" "$command_name" ;;
+    esac
+    return 0
+}
+
+main() {
+    local platform=""
+    local command_name="scan"
+    local arg=""
+    if [[ "$#" -gt 0 ]]; then
+        arg="$1"
+        platform="$arg"
+        shift
+    fi
+    if [[ "$#" -gt 0 ]]; then
+        arg="$1"
+        command_name="$arg"
+        shift
+    fi
+    if [[ -z "$platform" || "$platform" == "help" || "$platform" == "--help" ]]; then
+        usage
+        return 0
+    fi
+    case "$platform" in
+        macos|linux) ;;
+        *) print_error "platform must be macos or linux"; return 2 ;;
+    esac
+    case "$command_name" in
+        scan) _cmd_scan "$platform" "$@" ;;
+        apply) _cmd_scan "$platform" --apply "$@" ;;
+        status) _cmd_status "$platform" "$@" ;;
+        reminder) _cmd_reminder "$platform" "$@" ;;
+        help|--help) usage ;;
+        *) print_error "unknown command: $command_name"; return 2 ;;
+    esac
+    return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-optimise-indexing-backups-helper.sh
+++ b/.agents/scripts/tests/test-optimise-indexing-backups-helper.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+HELPER="${ROOT_DIR}/.agents/scripts/optimise-indexing-backups-helper.sh"
+
+fail() {
+    local message="$1"
+    printf 'FAIL: %s\n' "$message" >&2
+    return 1
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    case "$haystack" in
+        *"$needle"*) return 0 ;;
+        *) fail "expected output to contain: $needle" ;;
+    esac
+    return 0
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    case "$haystack" in
+        *"$needle"*) fail "expected output not to contain: $needle" ;;
+        *) return 0 ;;
+    esac
+    return 0
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+export HOME="$tmpdir/home"
+export AIDEVOPS_STATE_DIR="$tmpdir/state"
+export AIDEVOPS_LOG_DIR="$tmpdir/logs"
+export AIDEVOPS_CONFIG_DIR="$tmpdir/configs"
+export AIDEVOPS_HEADLESS=true
+mkdir -p "$HOME"
+
+json_output="$($HELPER macos scan --dry-run --json)"
+printf '%s\n' "$json_output" | jq -e '.platform == "macos" and .mode == "dry-run" and (.project_patterns | index("<repo-root>/**/node_modules/"))' >/dev/null
+assert_contains "$json_output" "<repo-root>/**/.turbo/"
+assert_not_contains "$json_output" "/Users/"
+
+linux_output="$($HELPER linux apply --json)"
+printf '%s\n' "$linux_output" | jq -e '.platform == "linux" and .mode == "apply"' >/dev/null
+[[ -f "$AIDEVOPS_CONFIG_DIR/optimise-indexing-backups-excludes.txt" ]] || fail "linux apply did not create exclude file"
+assert_contains "$(<"$AIDEVOPS_CONFIG_DIR/optimise-indexing-backups-excludes.txt")" "<repo-root>/**/.venv/"
+
+export AIDEVOPS_OPTIMISE_NOW=2000000000
+stale_output="$($HELPER linux reminder --format=toast --no-notify)"
+assert_contains "$stale_output" "[WARN] Linux indexing/backup optimisation is stale"
+
+$HELPER linux scan --dry-run >/dev/null
+fresh_output="$($HELPER linux reminder --format=toast --no-notify)"
+[[ -z "$fresh_output" ]] || fail "fresh state should suppress reminder"
+
+printf 'OK: optimise-indexing-backups-helper tests passed\n'

--- a/.agents/tools/terminal/optimise-linux-indexing-backups.md
+++ b/.agents/tools/terminal/optimise-linux-indexing-backups.md
@@ -1,0 +1,36 @@
+---
+description: Linux indexing and backup optimisation guidance for local indexers and backup tools
+mode: subagent
+tools:
+  read: true
+  bash: true
+  grep: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Linux Indexing and Backup Optimisation
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Reduce local indexing and backup churn from reproducible caches and generated files.
+- **Command**: `/optimise-linux-indexing-backups`.
+- **Helper**: `scripts/optimise-indexing-backups-helper.sh linux scan`.
+- **Default**: dry-run recommendations only.
+
+<!-- AI-CONTEXT-END -->
+
+## Safe exclusions
+
+Prefer user-owned generated/cache paths: `~/.cache/`, `~/.local/share/Trash/`, package-manager caches, cargo registries, aidevops cache/log/lock directories, and generated project paths like `<repo-root>/**/node_modules/`, `<repo-root>/**/.venv/`, `<repo-root>/**/venv/`, `<repo-root>/**/target/`, `<repo-root>/**/__pycache__/`, and `<repo-root>/**/.pytest_cache/`.
+
+Do not exclude the whole home directory, source trees, documents, secrets, or broad configuration directories.
+
+## System notes
+
+- Indexers: detect Tracker/Tracker3, Baloo, Recoll, and locate/plocate/mlocate before recommending changes.
+- Backup tools: detect restic, borg, kopia, duplicity/deja-dup, rsnapshot, rclone, and Timeshift. Prefer a generated exclude file under `~/.aidevops/configs/` and show how to reference it rather than rewriting unknown jobs.
+- Privileged config such as `/etc/updatedb.conf` should be reported as a follow-up command for the operator, not silently edited.

--- a/.agents/tools/terminal/optimise-macos-indexing-backups.md
+++ b/.agents/tools/terminal/optimise-macos-indexing-backups.md
@@ -1,0 +1,36 @@
+---
+description: macOS indexing and backup optimisation guidance for Spotlight, Time Machine, and Backblaze
+mode: subagent
+tools:
+  read: true
+  bash: true
+  grep: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# macOS Indexing and Backup Optimisation
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Reduce local CPU, disk I/O, and backup churn from reproducible caches and generated files.
+- **Command**: `/optimise-macos-indexing-backups`.
+- **Helper**: `scripts/optimise-indexing-backups-helper.sh macos scan`.
+- **Default**: dry-run recommendations only.
+
+<!-- AI-CONTEXT-END -->
+
+## Safe exclusions
+
+Prefer generated/cache directories: `~/Library/Caches/`, `~/Library/Logs/`, `~/.cache/`, package-manager caches, simulator caches, aidevops cache/log/lock directories, and generated project paths like `<repo-root>/**/node_modules/`, `<repo-root>/**/.next/`, `<repo-root>/**/.turbo/`, `<repo-root>/**/dist/`, `<repo-root>/**/build/`, and `<repo-root>/**/coverage/`.
+
+Do not exclude the whole home directory, project source trees, `Documents`, `Desktop`, `Downloads`, `.ssh`, `.gnupg`, broad configuration directories, or entire application support trees.
+
+## System notes
+
+- Spotlight: use `.metadata_never_index` for writable generated directories; use `mdutil -s` and `mdutil -a -s` for status only.
+- Time Machine: recommend `tmutil addexclusion` and verify with `tmutil isexcluded` when permissions allow.
+- Backblaze: editable rules live in `/Library/Backblaze.bzpkg/bzdata/bzexcluderules_editable.xml`; GUI-visible directory exclusions are `bzdirfilter` entries in `/Library/Backblaze.bzpkg/bzdata/bzinfo.xml` and should be mirrored to `.sidecopy` when present. Back up XML files, validate XML, and never print account, login, token, or identity fields. `skipFirstCharThenStartsWith` omits the leading slash, for example `users/<user>/` or `volumes/<volume>/`.

--- a/.agents/workflows/optimise-linux-indexing-backups.md
+++ b/.agents/workflows/optimise-linux-indexing-backups.md
@@ -1,0 +1,34 @@
+---
+description: Audit and safely optimise Linux indexing and backup exclusions
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+```bash
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh linux scan $ARGUMENTS
+```
+
+## Safety contract
+
+- Dry-run is the default.
+- Detect installed systems before recommending edits.
+- Do not require sudo in default mode; print privileged follow-up steps instead.
+- Prefer a generated exclude file under `~/.aidevops/configs/` over rewriting unknown backup jobs.
+
+## Linux coverage
+
+- Indexers: GNOME Tracker/Tracker3, KDE Baloo, Recoll, and locate/plocate/mlocate pruning.
+- Backup tools: restic, borg, kopia, duplicity/deja-dup, rsnapshot, rclone, and Timeshift where installed.
+- High-churn paths: `~/.cache/`, trash, package caches, cargo registries, container/build caches where detected, aidevops runtime caches, and generated project directories such as `<repo-root>/**/.venv/`, `<repo-root>/**/target/`, `<repo-root>/**/__pycache__/`, and `<repo-root>/**/.pytest_cache/`.
+
+## Verification
+
+Run:
+
+```bash
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh linux scan --dry-run --json
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh linux status
+```

--- a/.agents/workflows/optimise-macos-indexing-backups.md
+++ b/.agents/workflows/optimise-macos-indexing-backups.md
@@ -1,0 +1,35 @@
+---
+description: Audit and safely optimise macOS indexing and backup exclusions
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+```bash
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh macos scan $ARGUMENTS
+```
+
+## Safety contract
+
+- Dry-run is the default.
+- Do not exclude the whole home directory, project source trees, `Documents`, `Desktop`, `Downloads`, `.ssh`, `.gnupg`, or broad app support directories.
+- Redact or avoid backup identity, login, token, and account fields in all output.
+- Config-file mutation requires `--apply`, a backup copy, and XML/config validation.
+
+## macOS coverage
+
+- Spotlight: check `mdutil` status and create `.metadata_never_index` only in writable generated/cache directories.
+- Time Machine: recommend `tmutil addexclusion`; verify with `tmutil isexcluded` when permissions allow.
+- Backblaze: detect editable XML locations, recommend generic `bzexcluderules_editable.xml` rules, and avoid printing sensitive fields.
+- High-churn paths: user caches, package caches, simulator caches, aidevops runtime cache/log/lock directories, and generated project directories such as `<repo-root>/**/node_modules/`, `<repo-root>/**/.turbo/`, `<repo-root>/**/dist/`, and `<repo-root>/**/coverage/`.
+
+## Verification
+
+Run:
+
+```bash
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh macos scan --dry-run --json
+~/.aidevops/agents/scripts/optimise-indexing-backups-helper.sh macos status
+```


### PR DESCRIPTION
## Summary

- Adds `/optimise-macos-indexing-backups` and `/optimise-linux-indexing-backups` command/workflow docs.
- Adds `optimise-indexing-backups-helper.sh` with dry-run scan, apply, status, and 30-day reminder modes for macOS/Linux.
- Integrates stale optimisation reminders into `aidevops-update-check.sh` toast output.
- Adds focused helper tests for JSON output, Linux exclude-file generation, stale/fresh reminder behaviour, and private-path avoidance.

## Verification

- `shellcheck .agents/scripts/optimise-indexing-backups-helper.sh .agents/scripts/tests/test-optimise-indexing-backups-helper.sh`
- `.agents/scripts/tests/test-optimise-indexing-backups-helper.sh`
- `.agents/scripts/optimise-indexing-backups-helper.sh macos scan --dry-run --json >/tmp/aidevops-macos-scan.json && jq -e '.platform == "macos"' /tmp/aidevops-macos-scan.json >/dev/null`
- `.agents/scripts/linters-local.sh` (passes; existing advisory markdown/ratchet/complexity warnings reported by the suite)

Resolves #26631
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.61 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 19m and 129,611 tokens on this as a headless worker.