### PR TITLE
GH#26637: test: cover shared dep comment URL parsing

### DIFF
--- a/.agents/scripts/tests/test-test-helpers.sh
+++ b/.agents/scripts/tests/test-test-helpers.sh
@@ -229,10 +229,10 @@ out=$(_test_discover_shared_deps "$cond_src")
 assert_eq "only unconditional source discovered" "real-sibling.sh" "$out"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 8: discover tolerates trailing comments with slashes
+# Test 8: discover tolerates trailing comments with URL/path slashes
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 8: trailing comments with slashes do not corrupt basename parsing"
+echo "Test 8: trailing comments with URL/path slashes do not corrupt basename parsing"
 comment_src=$(mktemp -d 2>/dev/null || mktemp -d -t commentsrc)
 # shellcheck disable=SC2064
 trap "rm -rf '$tmpdir' '$fake_src' '$fake_dest' '$empty_src' '$cond_src' '$comment_src'" EXIT
@@ -240,11 +240,11 @@ cat >"${comment_src}/shared-constants.sh" <<'EOF'
 #!/usr/bin/env bash
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 source "${_SC_SELF%/*}/real-sibling.sh" # fallback/retry docs/path
-_source_shared_module_with_retry "${_SC_SELF%/*}/retry-sibling.sh" # fallback/retry
+_source_shared_module_with_retry "${_SC_SELF%/*}/retry-sibling.sh" # https://example.invalid/fallback/retry
 EOF
 
 out=$(_test_discover_shared_deps "$comment_src")
-assert_eq "comments with slashes do not affect discovered basenames" $'real-sibling.sh\nretry-sibling.sh' "$out"
+assert_eq "comments with URL/path slashes do not affect discovered basenames" $'real-sibling.sh\nretry-sibling.sh' "$out"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary


### PR DESCRIPTION
## Summary

Strengthened the shared dependency parser regression test so trailing comments include URL/path slashes, matching the review feedback scenario already handled by the parser.

## Files Changed

.agents/scripts/tests/test-test-helpers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/tests/lib/test-helpers.sh .agents/scripts/tests/test-test-helpers.sh; shellcheck .agents/scripts/tests/lib/test-helpers.sh .agents/scripts/tests/test-test-helpers.sh; bash .agents/scripts/tests/test-test-helpers.sh

Resolves #26637


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 62,528 tokens on this as a headless worker.