### PR TITLE
GH#26639: fix: harden indexing backup state updates

### DIFF
--- a/.agents/scripts/optimise-indexing-backups-helper.sh
+++ b/.agents/scripts/optimise-indexing-backups-helper.sh
@@ -88,7 +88,12 @@ try:
         data = json.load(handle)
 except Exception:
     data = {}
-value = data.get(platform, {}).get(key, 0)
+if not isinstance(data, dict):
+    data = {}
+entry = data.get(platform, {})
+if not isinstance(entry, dict):
+    entry = {}
+value = entry.get(key, 0)
 print(value if value not in (None, "") else 0)
 PY
     return 0
@@ -110,12 +115,19 @@ try:
         data = json.load(handle)
 except Exception:
     data = {}
+if not isinstance(data, dict):
+    data = {}
 entry = data.get(platform, {})
+if not isinstance(entry, dict):
+    entry = {}
 if success != "-":
     entry["last_success_at"] = int(success)
-entry["last_mode"] = mode
-entry["last_applied_count"] = int(applied)
-entry["last_warning_count"] = int(warnings)
+if mode != "-":
+    entry["last_mode"] = mode
+if applied != "-":
+    entry["last_applied_count"] = int(applied)
+if warnings != "-":
+    entry["last_warning_count"] = int(warnings)
 entry["last_version"] = "1.0.0"
 if notified != "-":
     entry["last_notified_at"] = int(notified)
@@ -340,7 +352,7 @@ _cmd_scan() {
             --apply|apply) mode="apply" ;;
             --dry-run) mode="dry-run" ;;
             --json) json="true" ;;
-            --path|--include-backup-client|--skip-backup-client) shift ;;
+            --path|--include-backup-client|--skip-backup-client) [[ "$#" -gt 1 ]] && shift ;;
             --path=*|--include-backup-client=*|--skip-backup-client=*) ;;
             *) ;;
         esac
@@ -421,7 +433,7 @@ _maybe_notify() {
     elif [[ "$platform" == "linux" ]] && command -v notify-send >/dev/null 2>&1 && [[ -z "${AIDEVOPS_HEADLESS:-}" ]]; then
         notify-send "${label} indexing/backup optimisation stale" "Run ${command_name}" >/dev/null 2>&1 || true
     fi
-    _state_update "$platform" "-" "reminder" "0" "0" "$now"
+    _state_update "$platform" "-" "reminder" "-" "-" "$now"
     return 0
 }
 
@@ -436,8 +448,8 @@ _cmd_reminder() {
         case "$arg" in
             --format=*) format="${arg#--format=}" ;;
             --format)
-                shift
-                if [[ "$#" -gt 0 ]]; then
+                if [[ "$#" -gt 1 ]]; then
+                    shift
                     arg="$1"
                     format="$arg"
                 else

--- a/.agents/scripts/tests/test-optimise-indexing-backups-helper.sh
+++ b/.agents/scripts/tests/test-optimise-indexing-backups-helper.sh
@@ -62,4 +62,22 @@ $HELPER linux scan --dry-run >/dev/null
 fresh_output="$($HELPER linux reminder --format=toast --no-notify)"
 [[ -z "$fresh_output" ]] || fail "fresh state should suppress reminder"
 
+$HELPER linux scan --dry-run --path >/dev/null
+$HELPER linux reminder --format >/dev/null
+
+printf '[]\n' >"$AIDEVOPS_STATE_DIR/optimise-indexing-backups.json"
+$HELPER linux scan --dry-run >/dev/null
+printf '%s\n' "$(<"$AIDEVOPS_STATE_DIR/optimise-indexing-backups.json")" | jq -e '.linux.last_applied_count == 0 and .linux.last_warning_count == 0' >/dev/null
+
+export AIDEVOPS_OPTIMISE_NOW=2000000000
+$HELPER linux apply >/dev/null
+applied_before="$(jq -r '.linux.last_applied_count' "$AIDEVOPS_STATE_DIR/optimise-indexing-backups.json")"
+warnings_before="$(jq -r '.linux.last_warning_count' "$AIDEVOPS_STATE_DIR/optimise-indexing-backups.json")"
+export AIDEVOPS_OPTIMISE_NOW=3000000000
+$HELPER linux reminder --format=toast --no-notify >/dev/null
+applied_after="$(jq -r '.linux.last_applied_count' "$AIDEVOPS_STATE_DIR/optimise-indexing-backups.json")"
+warnings_after="$(jq -r '.linux.last_warning_count' "$AIDEVOPS_STATE_DIR/optimise-indexing-backups.json")"
+[[ "$applied_after" == "$applied_before" ]] || fail "reminder should preserve last applied count"
+[[ "$warnings_after" == "$warnings_before" ]] || fail "reminder should preserve last warning count"
+
 printf 'OK: optimise-indexing-backups-helper tests passed\n'


### PR DESCRIPTION
## Summary

Hardened optimise-indexing-backups state JSON handling, preserved last run counts during reminders, guarded value-consuming flags when arguments are missing, and added regression coverage for those review findings.

## Files Changed

.agents/scripts/optimise-indexing-backups-helper.sh,.agents/scripts/tests/test-optimise-indexing-backups-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-optimise-indexing-backups-helper.sh; shellcheck .agents/scripts/optimise-indexing-backups-helper.sh .agents/scripts/tests/test-optimise-indexing-backups-helper.sh; .agents/scripts/linters-local.sh (timed out at Secretlint after earlier gates showed no new blocking findings)

Resolves #26639


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 8m and 51,817 tokens on this as a headless worker.