### PR TITLE
GH#26642: protect canonical cleanup refresh

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -555,13 +555,20 @@ _merge_refresh_canonical_for_cleanup() {
 	local default_branch="$2"
 	[[ -d "$canonical_dir" && -n "$default_branch" ]] || return 1
 
-	# Refresh remote state without changing the canonical worktree's checked-out
-	# branch. A pull from a non-default branch can fast-forward that branch to the
-	# default branch tip, corrupting unrelated active work.
-	if git -C "$canonical_dir" fetch origin "$default_branch" >/dev/null 2>&1; then
+	local current_canonical_branch=""
+	current_canonical_branch=$(git -C "$canonical_dir" branch --show-current 2>/dev/null || true)
+
+	# Pull only when the canonical worktree is already on the default branch. If a
+	# user has another active branch checked out there, update the local default
+	# branch ref via fetch instead so cleanup never merges default into that branch.
+	if [[ "$current_canonical_branch" == "$default_branch" ]]; then
+		if git -C "$canonical_dir" pull --ff-only origin "$default_branch" >/dev/null 2>&1; then
+			return 0
+		fi
+	elif git -C "$canonical_dir" fetch origin "$default_branch:$default_branch" >/dev/null 2>&1; then
 		return 0
 	fi
-	print_warning "Post-merge worktree cleanup: canonical fetch skipped/failed for ${canonical_dir}; continuing cleanup"
+	print_warning "Post-merge worktree cleanup: canonical pull/fetch skipped/failed for ${canonical_dir}; continuing cleanup"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -200,6 +200,8 @@ test_cmd_merge_removes_current_linked_worktree() {
 	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
 	local active_before=""
 	active_before=$(git -C "$canonical_repo" rev-parse feature/active)
+	local remote_main=""
+	remote_main=$(git -C "${TEST_ROOT}/updater" rev-parse main)
 
 	cmd_merge "123" "example/repo" --squash
 
@@ -217,12 +219,51 @@ test_cmd_merge_removes_current_linked_worktree() {
 	if [[ "$(git -C "$canonical_repo" rev-parse feature/active)" != "$active_before" ]]; then
 		rc=1
 	fi
+	if [[ "$(git -C "$canonical_repo" rev-parse main)" != "$remote_main" ]]; then
+		rc=1
+	fi
 	print_result "cmd_merge removes current linked worktree after immediate merge" "$rc"
+	return 0
+}
+
+test_refresh_canonical_pulls_when_default_checked_out() {
+	local canonical_repo="${TEST_ROOT}/repo-default"
+	local origin_repo="${TEST_ROOT}/origin-default.git"
+	local updater_repo="${TEST_ROOT}/updater-default"
+	mkdir -p "$canonical_repo"
+	git -C "$canonical_repo" init -q -b main
+	git -C "$canonical_repo" config user.email test@example.invalid
+	git -C "$canonical_repo" config user.name 'Aidevops Test'
+	printf 'base\n' >"${canonical_repo}/README.md"
+	git -C "$canonical_repo" add README.md
+	git -C "$canonical_repo" commit -q -m 'init'
+	git clone -q --bare "$canonical_repo" "$origin_repo"
+	git -C "$canonical_repo" remote add origin "$origin_repo"
+	git -C "$canonical_repo" push -q -u origin main
+	git clone -q "$origin_repo" "$updater_repo"
+	git -C "$updater_repo" config user.email test@example.invalid
+	git -C "$updater_repo" config user.name 'Aidevops Test'
+	printf 'remote main advance\n' >>"${updater_repo}/README.md"
+	git -C "$updater_repo" add README.md
+	git -C "$updater_repo" commit -q -m 'advance main'
+	git -C "$updater_repo" push -q origin main
+
+	_merge_refresh_canonical_for_cleanup "$canonical_repo" "main"
+
+	local rc=0
+	if [[ "$(git -C "$canonical_repo" branch --show-current)" != "main" ]]; then
+		rc=1
+	fi
+	if [[ "$(git -C "$canonical_repo" rev-parse main)" != "$(git -C "$updater_repo" rev-parse main)" ]]; then
+		rc=1
+	fi
+	print_result "refresh canonical pulls when default branch checked out" "$rc"
 	return 0
 }
 
 main() {
 	setup_subject
+	test_refresh_canonical_pulls_when_default_checked_out
 	test_cmd_merge_removes_current_linked_worktree
 	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1


### PR DESCRIPTION
Resolves #26642

## Summary
- Update `.agents/scripts/full-loop-helper-merge.sh` so post-merge cleanup pulls only when the canonical repo is on its default branch.
- Fetch the default branch ref when another branch is checked out, avoiding merges into unrelated active branches.
- Extend `.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh` to cover default-branch pull and non-default branch fetch behavior.

## Testing
- `bash .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`
- `shellcheck .agents/scripts/full-loop-helper-merge.sh .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 6m and 49,963 tokens on this as a headless worker.