### PR TITLE
GH#26641: fix: format full-loop changed file list

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -116,7 +116,7 @@ cmd_commit_and_pr() {
 	local base_branch="" base_ref=""
 	base_branch=$(_resolve_remote_default_branch origin) || return 1
 	base_ref="origin/${base_branch}"
-	files_changed=$(git diff --name-only "${base_ref}..HEAD" 2>/dev/null | tr '\n' ', ' | sed 's/,$//' || echo "")
+	files_changed=$(git diff --name-only "${base_ref}..HEAD" 2>/dev/null | tr '\n' ',' | sed 's/,$//; s/,/, /g' || echo "")
 
 	# t2242: Determine closing keyword — auto-swap Resolves to For when linked
 	# issue has parent-task label, unless --allow-parent-close overrides.


### PR DESCRIPTION
## Summary

Corrected full-loop PR body file-list formatting so newline-separated changed paths become comma-and-space separated instead of comma-only output.

## Files Changed

.agents/scripts/full-loop-helper.sh

## Runtime Testing

- **Risk level:** Low (shell helper formatting only)
- **Verification:** shellcheck .agents/scripts/full-loop-helper.sh; focused pipeline check for file1/file2/file3 formatting; bash -n .agents/scripts/full-loop-helper.sh

Resolves #26641
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 66,626 tokens on this as a headless worker.