### PR TITLE
GH#26643: fix: guard headless runtime version defaults

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -403,8 +403,8 @@ _hrff_build_claim_released_line() {
 	local runner_name="$2"
 	local exit_code_arg="$3"
 	local session_count_arg="$4"
-	local aidevops_version="$AIDEVOPS_UNKNOWN_VERSION"
-	local opencode_version="$AIDEVOPS_UNKNOWN_VERSION"
+	local aidevops_version="${AIDEVOPS_UNKNOWN_VERSION:-}"
+	local opencode_version="${AIDEVOPS_UNKNOWN_VERSION:-}"
 	local release_ts=""
 	local machine_readable_part=""
 


### PR DESCRIPTION
## Summary

Guarded CLAIM_RELEASED version default initialisation in `.agents/scripts/headless-runtime-failure.sh` with unset-safe parameter expansion.

## Files Changed

.agents/scripts/headless-runtime-failure.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-failure.sh; bash -n .agents/scripts/headless-runtime-failure.sh

Resolves #26643

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 51,280 tokens on this as a headless worker.