### PR TITLE
GH#26640: fix: harden local permissions tcc handling

### DIFF
--- a/.agents/scripts/local-permissions-check-helper.sh
+++ b/.agents/scripts/local-permissions-check-helper.sh
@@ -153,7 +153,7 @@ app_is_installed() {
 	local row="$1"
 	local paths roots app_name root
 	paths="$(app_field "$row" paths)"
-	roots="${LPC_APP_ROOTS:-/Applications:/System/Applications:${HOME}/Applications}"
+	roots="${LPC_APP_ROOTS:-/Applications:/System/Applications:${HOME:+$HOME/Applications}}"
 	IFS=',' read -r -a app_names <<<"$paths"
 	IFS=':' read -r -a root_names <<<"$roots"
 	for app_name in "${app_names[@]}"; do
@@ -204,7 +204,7 @@ tcc_db_path() {
 		printf '%s' "$LPC_TCC_DB"
 		return 0
 	fi
-	printf '%s/Library/Application Support/com.apple.TCC/TCC.db' "$HOME"
+	printf '%s' "${HOME:+$HOME/Library/Application Support/com.apple.TCC/TCC.db}"
 	return 0
 }
 
@@ -233,7 +233,7 @@ tcc_sqlite_status() {
 	else
 		return 2
 	fi
-	result="$(sqlite3 "$db" "SELECT ${select_expr} FROM access WHERE service='${escaped_service}' AND client='${escaped_bundle}' ORDER BY last_modified DESC LIMIT 1;" 2>/dev/null || true)"
+	result="$(sqlite3 "$db" "SELECT ${select_expr} FROM access WHERE service='${escaped_service}' AND client='${escaped_bundle}' ORDER BY last_modified DESC LIMIT 1;" 2>/dev/null)" || return 2
 	if [[ -z "$result" ]]; then
 		printf 'missing'
 		return 0

--- a/.agents/scripts/tests/test-local-permissions-check-helper.sh
+++ b/.agents/scripts/tests/test-local-permissions-check-helper.sh
@@ -84,6 +84,25 @@ unknown_output="$(LPC_UNAME=Darwin LPC_ACTIVE_HOST=Tabby LPC_TCC_ROWS="${TEST_RO
 assert_contains "unreadable TCC state is unknown" "unknown" "$unknown_output"
 assert_contains "unknown is not treated as OK" "Check System Settings" "$unknown_output"
 
+fake_bin="${TEST_ROOT}/bin"
+mkdir -p "$fake_bin"
+cat >"${fake_bin}/sqlite3" <<'SQLITE'
+#!/usr/bin/env bash
+set -u
+query="${2:-}"
+if [[ "$query" == "PRAGMA table_info(access);" ]]; then
+	printf '0|auth_value|INTEGER|0||0\n'
+	exit 0
+fi
+exit 1
+SQLITE
+chmod +x "${fake_bin}/sqlite3"
+fake_tcc_db="${TEST_ROOT}/TCC.db"
+touch "$fake_tcc_db"
+sqlite_error_output="$(LPC_UNAME=Darwin LPC_ACTIVE_HOST=Tabby LPC_TCC_ROWS="${TEST_ROOT}/missing.txt" LPC_TCC_DB="$fake_tcc_db" LPC_APP_ROOTS="$apps_root" PATH="${fake_bin}:$PATH" "$HELPER" report --active-host)"
+assert_contains "sqlite read errors are unknown" "unknown" "$sqlite_error_output"
+assert_contains "sqlite read errors are not missing" "Check System Settings" "$sqlite_error_output"
+
 json_output="$(LPC_UNAME=Darwin LPC_ACTIVE_HOST=Tabby LPC_TCC_ROWS="$fixture_rows" LPC_APP_ROOTS="$apps_root" "$HELPER" json --active-host)"
 assert_contains "json names active host" '"active_host":"Tabby"' "$json_output"
 assert_contains "json includes granted evidence" '"status":"granted"' "$json_output"


### PR DESCRIPTION
## Summary

Hardened local permissions defaults so HOME-derived paths are omitted when HOME is empty, and sqlite read failures now surface as unknown instead of missing. Added regression coverage for sqlite SELECT failures.

## Files Changed

.agents/scripts/local-permissions-check-helper.sh, .agents/scripts/tests/test-local-permissions-check-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-local-permissions-check-helper.sh; shellcheck .agents/scripts/local-permissions-check-helper.sh .agents/scripts/tests/test-local-permissions-check-helper.sh

Resolves #26640


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 39,359 tokens on this as a headless worker.