### PR TITLE
fix: limit NMR breaker retry per episode

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -726,7 +726,7 @@ After worktree pre-creation, `pulse-dispatch-worker-launch.sh` calls `dispatch-d
 
 The hold is branch-specific: a different branch or a different issue does not inherit the count. Triage the diagnostic by running the suggested `gh pr list --head <branch>` command; if the branch already has the intended PR, link/merge it, otherwise remove or reset the stale issue-linked worktree/branch so a fresh branch can dispatch.
 
-If the issue later shows repeated `<!-- aidevops-signed-approval -->` comments followed by fresh `needs-maintainer-review` labels but no new breaker comment, treat it as the same unresolved recovery episode. `pulse-nmr-approval.sh` preserves NMR from prior breaker history across marker-less relabels and only allows one automatic retry after a newer aidevops release; repeated same-release retries require `sudo aidevops approve issue <N> <repo>` after inspecting the branch/worktree evidence.
+If the issue later shows repeated `<!-- aidevops-signed-approval -->` comments followed by fresh `needs-maintainer-review` labels but no new breaker comment, treat it as the same unresolved recovery episode. `pulse-nmr-approval.sh` preserves NMR from prior breaker history across marker-less relabels and only allows one automatic retry for the breaker-version lineage after a newer aidevops release; later unrelated patch releases stay held until `sudo aidevops approve issue <N> <repo>` after inspecting the branch/worktree evidence.
 
 ## GitHub API Budget, Instrumentation, and Cache Priming
 

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -690,18 +690,20 @@ _nmr_retry_breaker_event_json() {
 }
 
 #######################################
-# Check if the current aidevops release already auto-retried this breaker.
+# Check if this breaker episode already consumed its automatic release retry.
 #
 # Args:
 #   $1 - comments_json
 #   $2 - breaker_at
 #   $3 - current_version
-# Returns: 0 if an approval comment from current_version exists after breaker.
+#   $4 - breaker_version (optional; enables episode-scoped lineage guard)
+# Returns: 0 if an auto-approval comment already consumed this retry.
 #######################################
 _nmr_retry_already_used_for_version() {
 	local comments_json="$1"
 	local breaker_at="$2"
 	local current_version="$3"
+	local breaker_version="${4:-}"
 
 	[[ -n "$comments_json" && -n "$breaker_at" && -n "$current_version" ]] || return 1
 
@@ -726,6 +728,31 @@ _nmr_retry_already_used_for_version() {
 
 	if [[ "$approval_at_current_version_count" -gt 0 ]]; then
 		return 0
+	fi
+
+	if [[ -n "$breaker_version" ]]; then
+		local episode_retry_count
+		episode_retry_count=$(printf '%s' "$comments_json" | jq -r \
+			--arg breaker_at "$breaker_at" \
+			--arg approval_marker "aidevops-signed-approval" \
+			--arg retry_prefix "automated breaker retry allowed after aidevops upgrade ${breaker_version} ->" '
+			(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+			elif type == "array" then .
+			else [] end)
+			| [
+				.[]
+				| select(.created_at != null)
+				| select((.created_at | fromdateiso8601) > ($breaker_at | fromdateiso8601))
+				| select((.body // "") | contains($approval_marker))
+				| select((.body // "") | contains($retry_prefix))
+			]
+			| length
+		' 2>/dev/null) || episode_retry_count=0
+		[[ "$episode_retry_count" =~ ^[0-9]+$ ]] || episode_retry_count=0
+
+		if [[ "$episode_retry_count" -gt 0 ]]; then
+			return 0
+		fi
 	fi
 
 	return 1
@@ -790,7 +817,7 @@ _nmr_breaker_release_retry_reason() {
 	current_version=$(_nmr_current_aidevops_version)
 	[[ -n "$current_version" ]] || return 1
 
-	if _nmr_retry_already_used_for_version "$comments_json" "$breaker_at" "$current_version"; then
+	if _nmr_retry_already_used_for_version "$comments_json" "$breaker_at" "$current_version" "$breaker_version"; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -818,6 +818,23 @@ test_markerless_relabel_after_recovery_breaker_retry_is_once_per_release() {
 	return 0
 }
 
+test_markerless_relabel_after_recovery_breaker_retry_is_once_per_episode() {
+	set_timeline '[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"runner-a"},"created_at":"2026-07-04T05:07:53Z"},{"event":"unlabeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"runner-b"},"created_at":"2026-07-04T13:50:33Z"},{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"runner-a"},"created_at":"2026-07-04T13:54:57Z"}]'
+	set_comments '[{"created_at":"2026-07-04T05:07:55Z","body":"<!-- dispatch-circuit-breaker:worker_recovery_loop -->\n## Dispatch paused: repeated worker recovery failures\n---\n[aidevops.sh](https://aidevops.sh) v3.31.49 automated scan."},{"created_at":"2026-07-04T13:50:31Z","body":"<!-- aidevops-signed-approval -->\nAuto-approved: automated breaker retry allowed after aidevops upgrade 3.31.49 -> 3.31.54.\n---\n[aidevops.sh](https://aidevops.sh) v3.31.54 automated scan."}]'
+	set_issue_meta '{"labels":[{"name":"needs-maintainer-review"},{"name":"origin:worker"},{"name":"auto-dispatch"}]}'
+	AIDEVOPS_CURRENT_VERSION_OVERRIDE=3.31.62
+	export AIDEVOPS_CURRENT_VERSION_OVERRIDE
+	if _nmr_applied_by_maintainer 8337 exampleorg/examplerepo maintainer; then
+		unset AIDEVOPS_CURRENT_VERSION_OVERRIDE
+		print_result "marker-less recovery relabel retry is once per breaker episode" 0
+		return 0
+	fi
+	unset AIDEVOPS_CURRENT_VERSION_OVERRIDE
+	print_result "marker-less recovery relabel retry is once per breaker episode" 1 \
+		"Expected exit 0 — a later unrelated patch release must not retry the same unresolved breaker episode"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -875,6 +892,7 @@ main() {
 	test_markerless_relabel_after_recovery_breaker_preserves_same_release
 	test_markerless_relabel_after_recovery_breaker_allows_upgrade_retry
 	test_markerless_relabel_after_recovery_breaker_retry_is_once_per_release
+	test_markerless_relabel_after_recovery_breaker_retry_is_once_per_episode
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Added an episode-scoped guard so marker-less breaker-history NMR relabels only get one automatic release retry for the breaker-version lineage, even after later unrelated patch releases.
- Added a regression fixture covering breaker version X, auto-approval at version Y, failed retry with NMR relabel, then current version Z preserving NMR.
- Updated worker diagnostics guidance to describe the lineage-scoped hold.

## Testing

- `.agents/scripts/tests/test-pulse-nmr-automation-signature.sh`
- `.agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh`
- `shellcheck .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-pulse-nmr-automation-signature.sh .agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh`

Resolves #26651

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13
