### PR TITLE
GH#26654: honor OAuth pool source in OpenAI gate

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -178,6 +178,7 @@ export async function injectPoolToken(client, skipEmail) {
 
 export async function applyOpenAIPoolAccount(client, account) {
   process.env.OPENAI_API_KEY = account.access;
+  process.env.AIDEVOPS_OPENAI_API_KEY_SOURCE = "oauth-pool";
   try {
     await client.auth.set({
       path: { id: "openai" },

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -175,7 +175,7 @@ provider_static_auth_available() {
 		return $?
 		;;
 	openai)
-		[[ -n "${OPENAI_API_KEY:-}" ]]
+		[[ -n "${OPENAI_API_KEY:-}" && "${AIDEVOPS_OPENAI_API_KEY_SOURCE:-}" != "oauth-pool" ]]
 		return $?
 		;;
 	*)

--- a/.agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh
+++ b/.agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh
@@ -124,6 +124,15 @@ actual="$(_choose_model_auto "worker" "sonnet")"
 assert_equals "openai/gpt-5.5" "$actual" "static OpenAI API key bypasses OAuth pool cooldown gate" || true
 unset OPENAI_API_KEY
 
+cooldown="$(future_ms)"
+OPENAI_API_KEY="oauth-pool-access-token"
+AIDEVOPS_OPENAI_API_KEY_SOURCE="oauth-pool"
+export OPENAI_API_KEY AIDEVOPS_OPENAI_API_KEY_SOURCE
+write_pool "{\"openai\":[{\"email\":\"one@example.test\",\"status\":\"rate-limited\",\"cooldownUntil\":${cooldown}}],\"anthropic\":[{\"email\":\"ok@example.test\",\"status\":\"active\",\"cooldownUntil\":0}]}"
+actual="$(_choose_model_auto "worker" "sonnet")"
+assert_equals "anthropic/claude-sonnet-4-6" "$actual" "OAuth-injected OpenAI API key does not bypass OAuth pool cooldown gate" || true
+unset OPENAI_API_KEY AIDEVOPS_OPENAI_API_KEY_SOURCE
+
 rm -f "$HOME/.aidevops/oauth-pool.json"
 actual="$(_choose_model_auto "worker" "sonnet")"
 assert_equals "openai/gpt-5.5" "$actual" "missing OAuth pool remains non-blocking for legacy auth" || true


### PR DESCRIPTION
## Summary

Mark OpenAI API keys injected from the OAuth pool and keep those tokens subject to the pool availability gate while preserving static API key bypasses.

## Files Changed

.agents/plugins/opencode-aidevops/oauth-pool.mjs,.agents/scripts/headless-runtime-provider.sh,.agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh; shellcheck .agents/scripts/headless-runtime-provider.sh .agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh; node --check .agents/plugins/opencode-aidevops/oauth-pool.mjs; npm run typecheck; .agents/scripts/linters-local.sh

Resolves #26654


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.62 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1h 4m and 80,106 tokens on this with the user in an interactive session.