### PR TITLE
GH#26659: update green behind PR branches without auto-merge

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -22,6 +22,7 @@
 #   - _route_pr_to_fix_worker             — unified fix-worker dispatch (t2203)
 #   - _retarget_stacked_children          — stacked PR retargeting (t2412)
 #   - _attempt_worker_briefed_auto_merge  — worker-briefed trust chain (t2449)
+#   - _attempt_green_behind_update_branch — green+BEHIND branch refresh (GH#26659)
 #   - _check_required_checks_passing      — branch-protection context check (t2922)
 #
 # Usage: source "${SCRIPT_DIR}/pulse-merge-process.sh"
@@ -1040,6 +1041,23 @@ _attempt_pr_ci_rebase_retry() {
 	return 1
 }
 
+_pmp_extract_update_branch_state() {
+	local __auto_var="$1"
+	local __state_var="$2"
+	local __mergeable_var="$3"
+	local _pr_state="$4"
+	local __existing_auto_val="" __merge_state_val="" __mergeable_val="" _RS=$'\x1e'
+
+	IFS="$_RS" read -r __existing_auto_val __merge_state_val __mergeable_val <<<"$(printf '%s' "$_pr_state" \
+		| jq -r '"\(if .autoMergeRequest then "present" else "" end)\u001e\(.mergeStateStatus // "")\u001e\(.mergeable // "")"' \
+		|| true)"
+	_pmp_normalize_mergeable_state_into __mergeable_val "$__mergeable_val"
+	printf -v "$__auto_var" '%s' "$__existing_auto_val"
+	printf -v "$__state_var" '%s' "$__merge_state_val"
+	printf -v "$__mergeable_var" '%s' "$__mergeable_val"
+	return 0
+}
+
 #######################################
 # Update an already-auto-merge-enabled PR that is otherwise green but behind.
 #
@@ -1065,10 +1083,7 @@ _attempt_existing_auto_merge_behind_update_branch() {
 	[[ -n "$_pr_state" ]] || return 1
 
 	local _existing_auto="" _merge_state="" _mergeable=""
-	IFS=$'\t' read -r _existing_auto _merge_state _mergeable <<<"$(printf '%s' "$_pr_state" \
-		| jq -r '[if .autoMergeRequest then "present" else "" end, .mergeStateStatus // "", .mergeable // ""] | @tsv' \
-		|| true)"
-	_pmp_normalize_mergeable_state_into _mergeable "$_mergeable"
+	_pmp_extract_update_branch_state _existing_auto _merge_state _mergeable "$_pr_state"
 
 	[[ -n "$_existing_auto" ]] || return 1
 	[[ "$_merge_state" == BEHIND ]] || return 1
@@ -1084,6 +1099,50 @@ _attempt_existing_auto_merge_behind_update_branch() {
 	fi
 
 	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge is green but BEHIND — update-branch failed, falling through: ${_ub_output}" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
+# Update a green PR that is BEHIND when no native auto-merge request exists.
+#
+# Repositories with allow_auto_merge disabled cannot use the native auto-merge
+# fallback. If a protected green PR is behind, admin/direct merge attempts can
+# fail forever with "head branch is not up to date" unless pulse updates the
+# branch before trying those merge paths.
+#
+# Caller must have already passed maintainer/review/security gates and stopped
+# DRY_RUN before invoking because this helper performs a GitHub write.
+#
+# Returns 0 if update-branch succeeded and caller should defer to the next
+# cycle; 1 if no update was needed or update-branch failed.
+# GH#26659
+#######################################
+_attempt_green_behind_update_branch() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	local _pr_state=""
+	_pr_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json autoMergeRequest,mergeStateStatus,mergeable 2>/dev/null) || _pr_state=""
+	[[ -n "$_pr_state" ]] || return 1
+
+	local _existing_auto="" _merge_state="" _mergeable=""
+	_pmp_extract_update_branch_state _existing_auto _merge_state _mergeable "$_pr_state"
+
+	[[ -z "$_existing_auto" ]] || return 1
+	[[ "$_merge_state" == BEHIND ]] || return 1
+	[[ "$_mergeable" == MERGEABLE ]] || return 1
+	_check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1 || return 1
+
+	local _ub_output="" _ub_exit=0
+	_ub_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+	_ub_exit=$?
+	if [[ $_ub_exit -eq 0 ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: green but BEHIND without native auto-merge — update-branch succeeded, deferring to next cycle (GH#26659)" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: green but BEHIND without native auto-merge — update-branch failed, falling through: ${_ub_output}" >>"$LOGFILE"
 	return 1
 }
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -51,7 +51,7 @@
 #     _pulse_merge_dismiss_coderabbit_nits, _pr_required_checks_pass,
 #     _attempt_pr_ci_rebase_retry, _route_pr_to_fix_worker,
 #     _retarget_stacked_children, _attempt_worker_briefed_auto_merge,
-#     _check_required_checks_passing
+#     _attempt_green_behind_update_branch, _check_required_checks_passing
 #   - pulse-merge-author-checks.sh: _is_collaborator_author,
 #     _is_owner_or_member_author, _check_interactive_pr_gates
 #   Functions kept here (>100 lines — identity-key preservation):
@@ -1111,6 +1111,12 @@ _process_single_ready_pr() {
 	# branch before the t3070 native-auto defer path, otherwise pulse keeps
 	# waiting for GitHub to do work that GitHub requires a branch update for.
 	if _attempt_existing_auto_merge_behind_update_branch "$pr_number" "$repo_slug"; then
+		return 1
+	fi
+	# GH#26659: repos with native auto-merge disabled still need green+BEHIND
+	# branches updated before admin/direct merge attempts, otherwise rulesets and
+	# branch-protection "head branch is not up to date" errors can loop forever.
+	if _attempt_green_behind_update_branch "$pr_number" "$repo_slug"; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -22,6 +22,8 @@
 #             → returns 0 and keeps deferring because pending checks are non-terminal
 #   Case (F): autoMergeRequest + MERGEABLE + BEHIND + green required checks
 #             → update-branch succeeds and caller defers to the next cycle
+#   Case (G): no autoMergeRequest + MERGEABLE + BEHIND + green required checks
+#             → update-branch succeeds and caller defers to the next cycle
 #
 # Also verifies the caller contract: native auto-merge defer returns 4 from
 # _process_single_ready_pr and _merge_ready_prs_for_repo does not count that as
@@ -146,20 +148,26 @@ teardown_test_env() {
 # into the test shell. _set_native_auto_merge_or_skip calls
 # _auto_merge_stuck_seconds (t3192), so we extract that too.
 define_helpers_under_test() {
-	local src_stuck src_repo_allow src_green_behind src_set_native
+	local src_stuck src_repo_allow src_extract_state src_existing_green_behind src_green_behind src_set_native
 	src_stuck=$(awk '
 		/^_auto_merge_stuck_seconds\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_repo_allow=$(awk '
 		/^_repo_allows_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
-	src_green_behind=$(awk '
+	src_extract_state=$(awk '
+		/^_pmp_extract_update_branch_state\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$PROCESS_SCRIPT")
+	src_existing_green_behind=$(awk '
 		/^_attempt_existing_auto_merge_behind_update_branch\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$PROCESS_SCRIPT")
+	src_green_behind=$(awk '
+		/^_attempt_green_behind_update_branch\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_set_native=$(awk '
 		/^_set_native_auto_merge_or_skip\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_green_behind" || -z "$src_set_native" ]]; then
+	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_extract_state" || -z "$src_existing_green_behind" || -z "$src_green_behind" || -z "$src_set_native" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -167,6 +175,10 @@ define_helpers_under_test() {
 	eval "$src_stuck"
 	# shellcheck disable=SC1090
 	eval "$src_repo_allow"
+	# shellcheck disable=SC1090
+	eval "$src_extract_state"
+	# shellcheck disable=SC1090
+	eval "$src_existing_green_behind"
 	# shellcheck disable=SC1090
 	eval "$src_green_behind"
 	# shellcheck disable=SC1090
@@ -435,6 +447,43 @@ test_case_f_green_behind_updates_branch() {
 	return 0
 }
 
+# =============================================================================
+# Case (G): no native auto-merge request, green but behind → update branch/defer
+# =============================================================================
+test_case_g_green_behind_without_auto_merge_updates_branch() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"autoMergeRequest":null,"mergeStateStatus":"BEHIND","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+
+	local result=0
+	_attempt_green_behind_update_branch "700" "owner/repo" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (G): green BEHIND without auto_merge → update-branch returns 0" 1 \
+			"Expected exit 0, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'gh pr update-branch 700 --repo owner/repo' "$GH_LOG"; then
+		print_result "Case (G): green BEHIND without auto_merge → invokes update-branch" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'green but BEHIND without native auto-merge.*update-branch succeeded.*GH#26659' "$LOGFILE"; then
+		print_result "Case (G): green BEHIND without auto_merge → audit log written" 1 \
+			"pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (G): green BEHIND without auto_merge → updates branch and defers" 0
+	teardown_test_env
+	return 0
+}
+
 test_native_auto_defer_not_counted_as_completed_merge() {
 	local process_src merge_src
 	process_src=$(awk '
@@ -473,6 +522,7 @@ main() {
 	test_case_d_repo_disallows_falls_through
 	test_case_e_stale_pending_defers
 	test_case_f_green_behind_updates_branch
+	test_case_g_green_behind_without_auto_merge_updates_branch
 	test_native_auto_defer_not_counted_as_completed_merge
 
 	printf '\n=================================\n'

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -145,6 +145,19 @@ _pmp_normalize_mergeable_state_into() {
 	return 0
 }
 
+_pmp_normalize_review_decision_into() {
+	local __var_name="$1"
+	local __value="$2"
+	printf -v "$__var_name" '%s' "$__value"
+	return 0
+}
+
+_pmp_review_decision_is_unknown() {
+	local __value="$1"
+	[[ -z "$__value" || "$__value" == "UNKNOWN" ]]
+	return $?
+}
+
 _resolve_pr_mergeable_status() { return 0; }
 _extract_linked_issue() { printf '123'; return 0; }
 _check_pr_merge_gates() { return 0; }
@@ -156,6 +169,7 @@ _retarget_stacked_children() { return 0; }
 _pulse_merge_admin_safety_check() { return 0; }
 _set_native_auto_merge_or_skip() { return 1; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
+_attempt_green_behind_update_branch() { return "${GREEN_BEHIND_UPDATE_RC:-1}"; }
 _handle_post_merge_actions() { return 0; }
 gh_pr_view() { printf '{"labels":[]}'; return 0; }
 
@@ -217,6 +231,36 @@ test_ruleset_violation_enables_auto_merge_without_admin() {
 	fi
 	print_result "ruleset violation fallback enables native auto-merge and succeeds" 0
 	teardown_test_env
+	return 0
+}
+
+test_green_behind_update_defers_before_merge_attempts() {
+	unset GH_STUB_MODE
+	GREEN_BEHIND_UPDATE_RC=0
+	setup_test_env
+	define_function_under_test || { teardown_test_env; unset GREEN_BEHIND_UPDATE_RC; return 0; }
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "green BEHIND update defers before merge attempts" 1 \
+			"Expected 1, got ${result}; log: $(cat "$LOGFILE")"
+		teardown_test_env
+		unset GREEN_BEHIND_UPDATE_RC
+		return 0
+	fi
+	if grep -qE 'gh pr merge 77' "$GH_LOG"; then
+		print_result "green BEHIND update avoids admin/native/direct merge writes" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		unset GREEN_BEHIND_UPDATE_RC
+		return 0
+	fi
+	print_result "green BEHIND update defers before merge attempts" 0
+	teardown_test_env
+	unset GREEN_BEHIND_UPDATE_RC
 	return 0
 }
 
@@ -353,6 +397,7 @@ test_ruleset_fallback_failure_preserves_admin_conversation_context() {
 
 main() {
 	test_ruleset_violation_enables_auto_merge_without_admin
+	test_green_behind_update_defers_before_merge_attempts
 	test_draft_pr_without_origin_labels_skips_merge_write
 	test_stale_cache_401_retries_admin_merge_once
 	test_ruleset_fallback_failure_preserves_admin_conversation_context

--- a/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
+++ b/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
@@ -92,6 +92,7 @@ _check_ruleset_required_reviews_passing() { sleep 1; return 0; }
 approve_collaborator_pr() { return 0; }
 _pmp_consolidate_duplicate_pr_groups() { return 0; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
+_attempt_green_behind_update_branch() { return 1; }
 _set_native_auto_merge_or_skip() { return 0; }
 _handle_post_merge_actions() { return 0; }
 pulse_merge_stuck_run_pass() { sleep 1; return 0; }


### PR DESCRIPTION
## Summary

Added a green+BEHIND update-branch path for PRs without native auto-merge, reusing the protected post-gate write boundary before admin/direct merge attempts.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-native-auto.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh, .agents/scripts/tests/test-pulse-merge-timing-summary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-pulse-merge-native-auto.sh; test-pulse-merge-ruleset-fallback.sh; bash test-pulse-merge-timing-summary.sh; focused shellcheck; linters-local.sh

Resolves #26659


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.63 with gpt-5.5 spent 1h 10m and 225,489 tokens on this with the user in an interactive session.