### PR TITLE
t18068: add cross-platform local permissions diagnostics

### DIFF
--- a/.agents/scripts/commands/local-permissions-check.md
+++ b/.agents/scripts/commands/local-permissions-check.md
@@ -1,5 +1,5 @@
 ---
-description: Audit macOS privacy permissions for aidevops host apps such as Tabby, Terminal, iTerm, OpenCode, Cursor, Claude, VS Code, Zed, and Warp
+description: Audit local host/runtime permissions for aidevops on macOS, Linux, Windows, and WSL
 agent: local-permissions-check
 mode: subagent
 ---
@@ -7,7 +7,9 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Run a read-only local macOS permission diagnostic for aidevops workflows.
+Run a read-only local permission/capability diagnostic for aidevops workflows.
+macOS reports TCC host-app privacy state; Linux, Windows, and WSL report safe
+session, sandbox, filesystem, execution-policy, and UI automation caveats.
 
 Arguments: $ARGUMENTS
 
@@ -34,11 +36,16 @@ Arguments: $ARGUMENTS
 ## Safety
 
 - Read-only by default: do not reset TCC, grant permissions, or intentionally
-  trigger prompts.
+  trigger prompts; do not change Windows execution policy, start services, or use
+  sudo/admin privileges.
 - macOS permissions apply to the host app that launched aidevops, not to child
   `bash`, `zsh`, `opencode`, or `aidevops` processes.
 - For Tabby-launched sessions with Trash cleanup failures, check Full Disk Access
   for Tabby in System Settings → Privacy & Security.
+- Linux Wayland screenshots/UI automation often require desktop portals; X11,
+  Flatpak, Snap, containers, and WSL have separate boundaries.
+- Windows/WSL reports are advisory unless a safe shell signal exists; protected
+  folders and Defender Controlled Folder Access usually require manual checking.
 
 ## Verification references
 

--- a/.agents/scripts/local-permissions-check-helper.sh
+++ b/.agents/scripts/local-permissions-check-helper.sh
@@ -6,7 +6,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 STATUS_UNKNOWN="unknown"
+STATUS_MISSING="missing"
 STATE_INSTALLED="installed"
+PLATFORM_DARWIN="Darwin"
+JSON_FIELD_ACTIVE_HOST="active_host"
+JSON_FIELD_NAME="name"
+JSON_FIELD_PLATFORM="platform"
+JSON_FIELD_SUPPORTED="supported"
+JSON_FIELD_STATUS="status"
 
 APP_ROWS=$(cat <<'DATA'
 aidevops.app|aidevops|sh.aidevops.app,com.aidevops.app|aidevops.app|host|Full Disk Access;Accessibility;Automation: System Events;Screen Recording|Enable privacy permissions for aidevops.app when launching sessions from the desktop app.
@@ -58,16 +65,59 @@ platform_name() {
 is_macos() {
 	local platform
 	platform="$(platform_name)"
-	[[ "$platform" == "Darwin" ]]
+	[[ "$platform" == "$PLATFORM_DARWIN" ]]
 	return $?
+}
+
+is_windows_platform() {
+	local platform
+	platform="$(platform_name)"
+	case "$platform" in
+		MINGW*|MSYS*|CYGWIN*) return 0 ;;
+	esac
+	return 1
+}
+
+is_wsl_session() {
+	if [[ -n "${WSL_DISTRO_NAME:-}" || -n "${WSL_INTEROP:-}" ]]; then
+		return 0
+	fi
+	if [[ -r /proc/sys/kernel/osrelease ]]; then
+		local release
+		IFS= read -r release </proc/sys/kernel/osrelease || release=""
+		release="$(printf '%s' "$release" | tr '[:upper:]' '[:lower:]')"
+		if [[ "$release" == *microsoft* || "$release" == *wsl* ]]; then
+			return 0
+		fi
+	fi
+	return 1
+}
+
+platform_family() {
+	local platform
+	platform="$(platform_name)"
+	if [[ "$platform" == "$PLATFORM_DARWIN" ]]; then
+		printf 'macos'
+	elif is_windows_platform; then
+		printf 'windows'
+	elif [[ "$platform" == "Linux" ]] && is_wsl_session; then
+		printf 'wsl'
+	elif [[ "$platform" == "Linux" ]]; then
+		printf 'linux'
+	else
+		printf 'unknown'
+	fi
+	return 0
 }
 
 usage() {
 	cat <<'USAGE'
 Usage: local-permissions-check-helper.sh report|json|doctor|apps [--app APP|--all|--active-host]
 
-Read-only macOS TCC diagnostic for aidevops host-app permissions. The helper
-never resets, grants, or prompts for permissions.
+Read-only local capability diagnostic for aidevops host/runtime permissions.
+macOS reports TCC host-app privacy state; Linux and Windows/WSL report safe
+session, sandbox, filesystem, and automation caveats. The helper never resets,
+grants, changes policy, or prompts for permissions.
 USAGE
 	return 0
 }
@@ -252,7 +302,7 @@ permission_status() {
 	local permission_row services service status aggregate
 	permission_row="$(printf '%s\n' "$PERMISSION_ROWS" | while IFS= read -r row; do [[ "$(permission_field "$row" name)" == "$permission_name" ]] && printf '%s\n' "$row" && break; done)"
 	services="$(permission_field "$permission_row" services)"
-	aggregate="missing"
+	aggregate="$STATUS_MISSING"
 	IFS=',' read -r -a service_names <<<"$services"
 	for service in "${service_names[@]}"; do
 		if status="$(tcc_fixture_status "$service" "$bundle_id")"; then
@@ -316,17 +366,228 @@ render_unsupported_report() {
 	local platform
 	platform="$(platform_name)"
 	if [[ "$format" == "json" ]]; then
-		printf '{"platform":"%s","supported":false,"status":"unsupported","message":"local-permissions-check is macOS-only and read-only"}\n' "$(json_escape "$platform")"
+		printf '{"%s":"%s","%s":false,"%s":"%s","checks":[{"%s":"platform support","%s":"unknown","needed_for":"local capability diagnostics","action":"Review this platform manually; no safe backend is available yet","evidence":"unrecognized uname"}]}\n' "$JSON_FIELD_PLATFORM" "$(json_escape "$platform")" "$JSON_FIELD_SUPPORTED" "$JSON_FIELD_ACTIVE_HOST" "$(json_escape "$(detect_active_host)")" "$JSON_FIELD_NAME" "$JSON_FIELD_STATUS"
 	else
 		printf 'local-permissions-check: unsupported platform (%s)\n' "$platform"
-		printf 'This diagnostic reads macOS TCC privacy state and is read-only by default.\n'
+		printf 'This diagnostic is read-only; no safe platform backend is available yet.\n'
 	fi
+	return 0
+}
+
+env_status() {
+	local value="$1"
+	if [[ -n "$value" && "$value" != "$STATUS_UNKNOWN" ]]; then
+		printf 'conditional'
+	else
+		printf '%s' "$STATUS_UNKNOWN"
+	fi
+	return 0
+}
+
+linux_desktop_evidence() {
+	local desktop="${XDG_CURRENT_DESKTOP:-}"
+	local session="${XDG_SESSION_TYPE:-}"
+	local display="$STATUS_MISSING"
+	if [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+		display="Wayland display variable present"
+	elif [[ -n "${DISPLAY:-}" ]]; then
+		display="X11 display variable present"
+	fi
+	if [[ -n "$desktop" || -n "$session" ]]; then
+		printf 'desktop=%s session=%s; %s' "${desktop:-unknown}" "${session:-unknown}" "$display"
+	else
+		printf 'desktop/session variables missing; %s' "$display"
+	fi
+	return 0
+}
+
+linux_desktop_status() {
+	if [[ -n "${XDG_CURRENT_DESKTOP:-}" || -n "${XDG_SESSION_TYPE:-}" || -n "${WAYLAND_DISPLAY:-}" || -n "${DISPLAY:-}" ]]; then
+		printf 'conditional'
+	else
+		printf '%s' "$STATUS_UNKNOWN"
+	fi
+	return 0
+}
+
+sandbox_evidence() {
+	local evidence="none detected"
+	if [[ -n "${FLATPAK_ID:-}" || -e /.flatpak-info ]]; then
+		evidence="Flatpak indicator present"
+	elif [[ -n "${SNAP:-}" || -n "${SNAP_NAME:-}" ]]; then
+		evidence="Snap indicator present"
+	elif [[ -f /.dockerenv || -n "${container:-}" ]]; then
+		evidence="container indicator present"
+	elif is_wsl_session; then
+		evidence="WSL indicator present"
+	fi
+	printf '%s' "$evidence"
+	return 0
+}
+
+sandbox_status() {
+	if [[ -n "${FLATPAK_ID:-}" || -e /.flatpak-info || -n "${SNAP:-}" || -n "${SNAP_NAME:-}" || -f /.dockerenv || -n "${container:-}" ]] || is_wsl_session; then
+		printf 'conditional'
+	else
+		printf 'missing'
+	fi
+	return 0
+}
+
+trash_status() {
+	if [[ -n "${XDG_DATA_HOME:-}" && -d "${XDG_DATA_HOME}/Trash" ]]; then
+		printf 'granted'
+	elif [[ -n "${HOME:-}" && -d "${HOME}/.local/share/Trash" ]]; then
+		printf 'granted'
+	else
+		printf '%s' "$STATUS_UNKNOWN"
+	fi
+	return 0
+}
+
+systemd_user_status() {
+	if [[ -n "${XDG_RUNTIME_DIR:-}" && -S "${XDG_RUNTIME_DIR}/systemd/private" ]]; then
+		printf 'granted'
+	elif command -v systemctl >/dev/null 2>&1; then
+		printf 'conditional'
+	else
+		printf '%s' "$STATUS_UNKNOWN"
+	fi
+	return 0
+}
+
+windows_host_evidence() {
+	local evidence
+	evidence="shell=$(platform_name)"
+	if [[ -n "${WT_SESSION:-}" ]]; then
+		evidence="${evidence}; Windows Terminal session variable present"
+	fi
+	if [[ -n "${TERM_PROGRAM:-}" ]]; then
+		evidence="${evidence}; TERM_PROGRAM=$(json_escape "$TERM_PROGRAM")"
+	fi
+	if [[ -n "${VSCODE_PID:-}" ]]; then
+		evidence="${evidence}; VS Code host variable present"
+	fi
+	printf '%s' "$evidence"
+	return 0
+}
+
+powershell_policy_evidence() {
+	local shell_name=""
+	if command -v pwsh >/dev/null 2>&1; then
+		shell_name="pwsh"
+	elif command -v powershell.exe >/dev/null 2>&1; then
+		shell_name="powershell.exe"
+	elif command -v powershell >/dev/null 2>&1; then
+		shell_name="powershell"
+	fi
+	if [[ -n "$shell_name" ]]; then
+		printf 'PowerShell available for non-mutating Get-ExecutionPolicy checks (%s)' "$shell_name"
+	else
+		printf 'PowerShell not found in current PATH'
+	fi
+	return 0
+}
+
+linux_check_rows() {
+	local platform active desktop_status desktop_evidence sandbox_status_value sandbox_evidence_value trash_status_value systemd_status_value
+	platform="$(platform_name)"
+	active="$(detect_active_host)"
+	desktop_status="$(linux_desktop_status)"
+	desktop_evidence="$(linux_desktop_evidence)"
+	sandbox_status_value="$(sandbox_status)"
+	sandbox_evidence_value="$(sandbox_evidence)"
+	trash_status_value="$(trash_status)"
+	systemd_status_value="$(systemd_user_status)"
+	printf 'platform/session|conditional|runtime-specific aidevops workflows|Use platform/session evidence to decide whether desktop automation, shell, or service workflows are available|uname=%s\n' "$platform"
+	printf 'active host|%s|host-specific troubleshooting|Grant or debug permissions on the terminal/editor host when the OS attaches permissions to the host|active_host=%s\n' "$(env_status "$active")" "$active"
+	printf 'desktop session|%s|screenshots and UI automation|Wayland often requires desktop portals; X11 behaviour differs by compositor and tool|%s\n' "$desktop_status" "$desktop_evidence"
+	printf 'sandbox boundary|%s|filesystem, browser, and UI automation|If sandbox indicators are present, check Flatpak/Snap/container/WSL portal and filesystem grants separately|%s\n' "$sandbox_status_value" "$sandbox_evidence_value"
+	printf 'XDG Trash|%s|safe cleanup of temporary worktrees|Ensure the host session exposes an XDG Trash location; this helper only checks common marker directories|common XDG Trash marker check\n' "$trash_status_value"
+	printf 'systemd user manager|%s|scheduled/background local services|Use systemctl --user diagnostics manually when service workflows fail; helper does not start services|systemd user socket or command availability check\n' "$systemd_status_value"
+	return 0
+}
+
+windows_check_rows() {
+	local platform active wsl_status wsl_evidence ps_status ps_evidence host_evidence
+	platform="$(platform_name)"
+	active="$(detect_active_host)"
+	wsl_status="$STATUS_MISSING"
+	wsl_evidence="not detected"
+	if is_wsl_session; then
+		wsl_status="conditional"
+		wsl_evidence="WSL environment indicator present; Windows app privacy and Linux filesystem permissions are separate"
+	fi
+	ps_status="$(if command -v pwsh >/dev/null 2>&1 || command -v powershell.exe >/dev/null 2>&1 || command -v powershell >/dev/null 2>&1; then printf 'conditional'; else printf '%s' "$STATUS_UNKNOWN"; fi)"
+	ps_evidence="$(powershell_policy_evidence)"
+	host_evidence="$(windows_host_evidence)"
+	printf 'platform/runtime|conditional|Windows shell and filesystem workflows|Interpret results according to the current shell: Git Bash, MSYS, Cygwin, PowerShell, or WSL|uname=%s OS=%s\n' "$platform" "${OS:-unknown}"
+	printf 'active host|%s|host-specific troubleshooting|Check permissions and terminal privacy on the parent terminal/editor host when applicable|active_host=%s\n' "$(env_status "$active")" "$active"
+	printf 'WSL boundary|%s|cross-boundary file, browser, and Windows app automation|Keep Windows privacy permissions separate from Linux filesystem and WSL distribution permissions|%s\n' "$wsl_status" "$wsl_evidence"
+	printf 'PowerShell execution policy|%s|script execution from PowerShell-adjacent workflows|Query Get-ExecutionPolicy manually if PowerShell scripts fail; this helper does not change policy|%s\n' "$ps_status" "$ps_evidence"
+	printf 'Protected folders / Defender CFA|%s|writes to Desktop, Documents, and protected folders|Check Windows Security Controlled Folder Access manually when writes are blocked; no safe shell signal was assumed|manual check required\n' "$STATUS_UNKNOWN"
+	printf 'Windows host hints|conditional|terminal/editor-specific permissions|Use exposed environment hints to identify Windows Terminal, VS Code, Cursor, or another host|%s\n' "$host_evidence"
+	return 0
+}
+
+render_check_table() {
+	local rows="$1"
+	printf '%-32s %-11s %-38s %s\n' 'Check' 'Status' 'Needed for' 'Action'
+	printf '%-32s %-11s %-38s %s\n' '-----' '------' '----------' '------'
+	while IFS='|' read -r name status needed action evidence; do
+		[[ -n "${name:-}" ]] || continue
+		printf '%-32s %-11s %-38s %s\n' "$name" "$status" "$needed" "$action"
+		printf '  evidence: %s\n' "$evidence"
+	done <<<"$rows"
+	return 0
+}
+
+render_platform_report() {
+	local family="$1"
+	local rows active platform
+	active="$(detect_active_host)"
+	platform="$(platform_name)"
+	case "$family" in
+		linux) rows="$(linux_check_rows)" ;;
+		wsl|windows) rows="$(windows_check_rows)" ;;
+		*) render_unsupported_report report; return 0 ;;
+	esac
+	printf 'local-permissions-check: %s capability report (%s)\n' "$family" "$platform"
+	printf 'Active host: %s\n' "$active"
+	printf 'Safety: read-only; no permission resets, policy changes, sudo/admin actions, or private directory listings.\n\n'
+	render_check_table "$rows"
+	return 0
+}
+
+render_platform_json() {
+	local family="$1"
+	local rows active platform first_check=true
+	active="$(detect_active_host)"
+	platform="$(platform_name)"
+	case "$family" in
+		linux) rows="$(linux_check_rows)" ;;
+		wsl|windows) rows="$(windows_check_rows)" ;;
+		*) render_unsupported_report json; return 0 ;;
+	esac
+	printf '{"%s":"%s","family":"%s","%s":true,"%s":"%s","checks":[' "$JSON_FIELD_PLATFORM" "$(json_escape "$platform")" "$(json_escape "$family")" "$JSON_FIELD_SUPPORTED" "$JSON_FIELD_ACTIVE_HOST" "$(json_escape "$active")"
+	while IFS='|' read -r name status needed action evidence; do
+		[[ -n "${name:-}" ]] || continue
+		if [[ "$first_check" == true ]]; then
+			first_check=false
+		else
+			printf ','
+		fi
+		printf '{"%s":"%s","%s":"%s","needed_for":"%s","action":"%s","evidence":"%s"}' "$JSON_FIELD_NAME" "$(json_escape "$name")" "$JSON_FIELD_STATUS" "$(json_escape "$status")" "$(json_escape "$needed")" "$(json_escape "$action")" "$(json_escape "$evidence")"
+	done <<<"$rows"
+	printf ']}\n'
 	return 0
 }
 
 render_apps() {
 	if ! is_macos; then
-		render_unsupported_report report
+		printf 'Host/runtime app inventory is macOS-specific.\n'
+		printf 'Active host: %s\n' "$(detect_active_host)"
+		printf 'Use report or json for %s capability checks.\n' "$(platform_family)"
 		return 0
 	fi
 	printf 'Installed aidevops host/editor app inventory:\n\n'
@@ -346,7 +607,7 @@ render_apps() {
 render_report() {
 	local selector="$1"
 	if ! is_macos; then
-		render_unsupported_report report
+		render_platform_report "$(platform_family)"
 		return 0
 	fi
 
@@ -397,13 +658,13 @@ render_report() {
 render_json() {
 	local selector="$1"
 	if ! is_macos; then
-		render_unsupported_report json
+		render_platform_json "$(platform_family)"
 		return 0
 	fi
 
 	local active first_app=true
 	active="$(detect_active_host)"
-	printf '{"platform":"Darwin","supported":true,"active_host":"%s","privacy_model":"permissions apply to the host app","apps":[' "$(json_escape "$active")"
+	printf '{"%s":"%s","%s":true,"%s":"%s","privacy_model":"permissions apply to the host app","apps":[' "$JSON_FIELD_PLATFORM" "$PLATFORM_DARWIN" "$JSON_FIELD_SUPPORTED" "$JSON_FIELD_ACTIVE_HOST" "$(json_escape "$active")"
 	while IFS= read -r row; do
 		[[ -n "$row" ]] || continue
 		local display bundle role installed permissions first_perm permission status
@@ -419,7 +680,7 @@ render_json() {
 		else
 			printf ','
 		fi
-		printf '{"name":"%s","bundle":"%s","role":"%s","installed":%s,"permissions":[' "$(json_escape "$display")" "$(json_escape "$bundle")" "$(json_escape "$role")" "$installed"
+		printf '{"%s":"%s","bundle":"%s","role":"%s","installed":%s,"permissions":[' "$JSON_FIELD_NAME" "$(json_escape "$display")" "$(json_escape "$bundle")" "$(json_escape "$role")" "$installed"
 		permissions="$(app_field "$row" permissions)"
 		IFS=';' read -r -a permission_names <<<"$permissions"
 		first_perm=true
@@ -430,7 +691,7 @@ render_json() {
 			else
 				printf ','
 			fi
-			printf '{"name":"%s","status":"%s"}' "$(json_escape "$permission")" "$(json_escape "$status")"
+			printf '{"%s":"%s","%s":"%s"}' "$JSON_FIELD_NAME" "$(json_escape "$permission")" "$JSON_FIELD_STATUS" "$(json_escape "$status")"
 		done
 		printf ']}'
 	done < <(selected_app_rows "$selector")

--- a/.agents/scripts/tests/test-local-permissions-check-helper.sh
+++ b/.agents/scripts/tests/test-local-permissions-check-helper.sh
@@ -109,8 +109,27 @@ assert_contains "json includes granted evidence" '"status":"granted"' "$json_out
 assert_contains "json includes denied evidence" '"status":"denied"' "$json_output"
 assert_not_contains "json omits private app root path" "$apps_root" "$json_output"
 
-unsupported_output="$(LPC_UNAME=Linux "$HELPER" report --active-host)"
-assert_contains "non-macOS degrades cleanly" "unsupported platform (Linux)" "$unsupported_output"
+linux_output="$(LPC_UNAME=Linux XDG_CURRENT_DESKTOP=GNOME XDG_SESSION_TYPE=wayland WAYLAND_DISPLAY=wayland-0 LPC_ACTIVE_HOST=Code "$HELPER" report --active-host)"
+assert_contains "linux report is supported" "linux capability report (Linux)" "$linux_output"
+assert_contains "linux reports desktop session" "desktop session" "$linux_output"
+assert_contains "linux reports Wayland caveat" "Wayland often requires desktop portals" "$linux_output"
+assert_not_contains "linux no longer returns generic unsupported" "unsupported platform" "$linux_output"
+
+linux_json_output="$(LPC_UNAME=Linux XDG_CURRENT_DESKTOP=GNOME XDG_SESSION_TYPE=wayland WAYLAND_DISPLAY=wayland-0 LPC_ACTIVE_HOST=Code "$HELPER" json --active-host)"
+assert_contains "linux json marks supported" '"supported":true' "$linux_json_output"
+assert_contains "linux json includes checks" '"checks":[' "$linux_json_output"
+assert_contains "linux json includes desktop evidence" '"name":"desktop session"' "$linux_json_output"
+assert_not_contains "linux json omits private test root" "$TEST_ROOT" "$linux_json_output"
+
+windows_output="$(LPC_UNAME=MINGW64_NT-10.0 OS=Windows_NT WT_SESSION=fixture LPC_ACTIVE_HOST=WindowsTerminal "$HELPER" report --active-host)"
+assert_contains "windows report is supported" "windows capability report (MINGW64_NT-10.0)" "$windows_output"
+assert_contains "windows reports execution policy caveat" "PowerShell execution policy" "$windows_output"
+assert_contains "windows reports protected folder caveat" "Protected folders / Defender CFA" "$windows_output"
+assert_not_contains "windows no longer returns generic unsupported" "unsupported platform" "$windows_output"
+
+wsl_output="$(LPC_UNAME=Linux WSL_DISTRO_NAME=Ubuntu LPC_ACTIVE_HOST=WindowsTerminal "$HELPER" report --active-host)"
+assert_contains "wsl report uses windows boundary checks" "wsl capability report (Linux)" "$wsl_output"
+assert_contains "wsl explains separate permissions" "Windows app privacy and Linux filesystem permissions are separate" "$wsl_output"
 
 apps_output="$(LPC_UNAME=Darwin LPC_APP_ROOTS="$apps_root" "$HELPER" apps)"
 assert_contains "apps command lists Tabby" "Tabby" "$apps_output"

--- a/.agents/tools/security/local-permissions-check.md
+++ b/.agents/tools/security/local-permissions-check.md
@@ -1,5 +1,5 @@
 ---
-description: Specialist guidance for read-only macOS local permission diagnostics for aidevops host apps
+description: Specialist guidance for read-only local permission diagnostics for aidevops host/runtime environments
 mode: subagent
 ---
 
@@ -8,9 +8,10 @@ mode: subagent
 
 # local-permissions-check
 
-Use this agent for macOS privacy/TCC diagnostics when aidevops workflows fail to
-access Trash, protected folders, screenshots, UI automation, Apple Events,
-microphone/camera, Contacts, Calendar, or Reminders.
+Use this agent for local permission/capability diagnostics when aidevops
+workflows fail to access Trash, protected folders, screenshots, UI automation,
+Apple Events, microphone/camera, Contacts, Calendar, Reminders, Windows script
+execution, Linux desktop portals, sandbox boundaries, or local services.
 
 ## Operating model
 
@@ -20,11 +21,14 @@ microphone/camera, Contacts, Calendar, or Reminders.
    ~/.aidevops/agents/scripts/local-permissions-check-helper.sh report --active-host
    ```
 
-2. Explain that permissions attach to the host app: Tabby, Terminal, iTerm,
-   OpenCode Desktop, Cursor, Claude, VS Code, Zed, Warp, or aidevops.app.
-3. Treat `unknown` as unresolved, not granted. It can mean the TCC database is
+2. Interpret the platform backend: macOS TCC host-app permissions, Linux
+   session/sandbox evidence, Windows/MSYS/Cygwin host and policy caveats, or WSL
+   boundary separation.
+3. On macOS, explain that permissions attach to the host app: Tabby, Terminal,
+   iTerm, OpenCode Desktop, Cursor, Claude, VS Code, Zed, Warp, or aidevops.app.
+4. Treat `unknown` as unresolved, not granted. It can mean the TCC database is
    unreadable without Full Disk Access or the macOS schema differs.
-4. For Tabby Trash failures, recommend granting Full Disk Access to Tabby.
+5. For Tabby Trash failures, recommend granting Full Disk Access to Tabby.
 
 ## Permission map
 
@@ -36,11 +40,17 @@ microphone/camera, Contacts, Calendar, or Reminders.
 - Screen Recording: screenshots, browser QA, UI verification.
 - Microphone/Camera: optional voice/video workflows.
 - Contacts/Calendar/Reminders: optional productivity integrations.
+- Linux: Wayland/X11 session, portals, Flatpak/Snap/container/WSL boundaries,
+  XDG Trash marker availability, and systemd user-manager availability.
+- Windows/WSL: shell/runtime, Windows Terminal/editor hints, WSL boundary,
+  PowerShell execution-policy caveats, and protected-folder/CFA manual checks.
 
 ## Safety
 
 - Read-only default: never reset TCC, grant permissions, or force prompts.
 - Do not print raw TCC rows or private paths in public issues/PR comments.
+- Never change PowerShell execution policy, start systemd services, use
+  sudo/admin privileges, or list private user directories.
 - If the user explicitly asks how to grant permissions, point to System Settings
   → Privacy & Security and name the host app shown by the helper.
 

--- a/.agents/workflows/local-permissions-check.md
+++ b/.agents/workflows/local-permissions-check.md
@@ -1,5 +1,5 @@
 ---
-description: Read-only workflow for diagnosing macOS privacy permissions needed by aidevops host apps
+description: Read-only workflow for diagnosing local permissions needed by aidevops host/runtime environments
 agent: local-permissions-check
 mode: subagent
 ---
@@ -7,9 +7,10 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Use this workflow when aidevops cannot access Trash, protected Library data,
+Use this workflow when aidevops cannot access Trash, protected data,
 screenshots, UI automation, Apple Events, microphone/camera, Contacts, Calendar,
-or Reminders from a macOS-launched session.
+Reminders, Windows script execution, Linux desktop portals, sandbox boundaries,
+or local service/session capabilities.
 
 ## First command
 
@@ -37,6 +38,13 @@ host/editor inventory.
   be granted only for workflows that explicitly need them.
 - `unknown` is not equivalent to `granted`; it usually means the TCC database is
   unreadable from the current host app or the macOS schema could not be queried.
+- Linux reports session and sandbox evidence only: desktop/session variables,
+  Wayland/X11 hints, Flatpak/Snap/container/WSL markers, common XDG Trash marker
+  availability, and systemd user-manager availability. Wayland screenshots/UI
+  automation are conditional and often require portals.
+- Windows/MSYS/Cygwin/Git Bash reports shell/runtime hints, WSL boundaries,
+  PowerShell execution-policy caveats, Windows Terminal/editor hints, and manual
+  checks for protected folders or Defender Controlled Folder Access.
 
 ## Safety rules
 
@@ -46,6 +54,8 @@ host/editor inventory.
   listings in issue comments or public logs.
 - Opening System Settings is optional user action; the default helper is
   read-only and does not open it.
+- Do not change PowerShell execution policy, open Windows Security, start systemd
+  services, use sudo/admin privileges, or list private user directories.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Extends `local-permissions-check-helper.sh` beyond macOS-only TCC reporting with read-only Linux, Windows, and WSL capability diagnostics.
- Adds normalized platform JSON checks for `platform`, `supported`, `active_host`, and per-check `name/status/needed_for/action/evidence` fields without private path leakage.
- Updates `/local-permissions-check`, workflow, and security-agent docs to describe macOS, Linux, Windows, and WSL coverage and safety limits.
- Adds fixture-driven Linux, Windows, and WSL regression coverage while preserving macOS fixture coverage.

Resolves #26635

## Verification

- `bash .agents/scripts/tests/test-local-permissions-check-helper.sh` — 31 tests passed.
- `shellcheck .agents/scripts/local-permissions-check-helper.sh .agents/scripts/tests/test-local-permissions-check-helper.sh` — passed.
- Manual smoke checks passed:
  - `.agents/scripts/local-permissions-check-helper.sh report --active-host`
  - `.agents/scripts/local-permissions-check-helper.sh json --active-host`
  - `LPC_UNAME=Linux .agents/scripts/local-permissions-check-helper.sh report --active-host`
  - `LPC_UNAME=MINGW64_NT-10.0 .agents/scripts/local-permissions-check-helper.sh report --active-host`
- `.agents/scripts/linters-local.sh` — passed SonarCloud, string-literal, forbidden FD-lock, and ShellCheck RC parity gates, then timed out after 300s while running Secretlint.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.64 plugin for [OpenCode](https://opencode.ai) v1.17.13
