### PR TITLE
t18067: Centralize terminal worktree cleanup

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1690,7 +1690,7 @@ _pc_relocate_registered_worktree() {
 		target_path=$(aidevops_generate_worktree_path "$main_wt_move" "$wt_branch_move" 2>/dev/null || true)
 	fi
 	if [[ -z "$target_path" ]]; then
-		local repo_name_move branch_slug_move
+		local repo_name_move="" branch_slug_move=""
 		repo_name_move=$(basename "$main_wt_move")
 		branch_slug_move=$(printf '%s\n' "$wt_branch_move" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 		target_path="${central_base}/${repo_name_move}-${branch_slug_move}"
@@ -1740,7 +1740,7 @@ _pc_relocate_registered_worktrees() {
 	while IFS= read -r rp_move; do
 		[[ -z "$rp_move" ]] && continue
 		[[ -d "$rp_move/.git" || -f "$rp_move/.git" ]] || continue
-		local porcelain_move main_wt_move wt_path_move wt_branch_move line_move
+		local porcelain_move="" main_wt_move="" wt_path_move="" wt_branch_move="" line_move=""
 		porcelain_move=$(git -C "$rp_move" worktree list --porcelain 2>/dev/null || true)
 		[[ -n "$porcelain_move" ]] || continue
 		main_wt_move="${porcelain_move%%$'\n'*}"

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1352,16 +1352,16 @@ _cleanup_single_worktree() {
 		return 1
 	fi
 
-	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
-		return 1
-	fi
-
 	local repo_name_age
 	repo_name_age=$(basename "$rp_age")
 	local orphan_issue_num=""
 	orphan_issue_num=$(_pc_issue_from_branch "$wt_branch_age" 2>/dev/null || true)
 	if _pc_handle_terminal_worktree_archive "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
 		return 0
+	fi
+
+	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
+		return 1
 	fi
 
 	local reason
@@ -1641,6 +1641,134 @@ _pc_cleanup_orphan_sibling_dirs() {
 }
 
 #######################################
+# Determine whether a worktree path is under a parent directory.
+#
+# Args:
+#   $1 - child path
+#   $2 - parent directory
+# Returns: 0 when child is inside parent, 1 otherwise
+#######################################
+_pc_path_inside_dir() {
+	local child_path="$1"
+	local parent_dir="$2"
+	[[ -n "$child_path" && -n "$parent_dir" ]] || return 1
+	case "$child_path" in
+	"$parent_dir"/*) return 0 ;;
+	esac
+	return 1
+}
+
+#######################################
+# Relocate one registered linked worktree into the central worktree base.
+#
+# Args:
+#   $1 - canonical repo path
+#   $2 - main worktree path
+#   $3 - worktree path to move
+#   $4 - branch name
+#   $5 - central worktree base directory
+# Returns: 0 when moved, 1 when skipped or failed
+#######################################
+_pc_relocate_registered_worktree() {
+	local rp_move="$1"
+	local main_wt_move="$2"
+	local wt_path_move="$3"
+	local wt_branch_move="$4"
+	local central_base="$5"
+
+	[[ -n "$rp_move" && -n "$main_wt_move" && -n "$wt_path_move" && -n "$wt_branch_move" && -n "$central_base" ]] || return 1
+	[[ "$wt_path_move" != "$main_wt_move" ]] || return 1
+	_pc_path_inside_dir "$wt_path_move" "$central_base" && return 1
+
+	local repo_parent_move
+	repo_parent_move=$(dirname "$main_wt_move")
+	_pc_path_inside_dir "$wt_path_move" "$repo_parent_move" || return 1
+	worktree_removal_guard "$wt_path_move" "$_WTAR_PC_CALLER" "centralize-worktree" || return 1
+
+	local target_path=""
+	if declare -F aidevops_generate_worktree_path >/dev/null 2>&1; then
+		target_path=$(aidevops_generate_worktree_path "$main_wt_move" "$wt_branch_move" 2>/dev/null || true)
+	fi
+	if [[ -z "$target_path" ]]; then
+		local repo_name_move branch_slug_move
+		repo_name_move=$(basename "$main_wt_move")
+		branch_slug_move=$(printf '%s\n' "$wt_branch_move" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+		target_path="${central_base}/${repo_name_move}-${branch_slug_move}"
+	fi
+	[[ -n "$target_path" && "$target_path" != "$wt_path_move" ]] || return 1
+	[[ ! -e "$target_path" ]] || {
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_move" "centralize-target-exists" "skipped"
+		return 1
+	}
+	mkdir -p "$(dirname "$target_path")" 2>/dev/null || return 1
+
+	if git -C "$rp_move" worktree move "$wt_path_move" "$target_path" >/dev/null 2>&1; then
+		unregister_worktree "$wt_path_move" 2>/dev/null || true
+		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_move" "centralized-worktree" "moved" "target=central-worktree-base branch=$wt_branch_move"
+		return 0
+	fi
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_move" "centralize-move-failed" "skipped"
+	return 1
+}
+
+#######################################
+# Relocate registered linked worktrees from repo parents into central base.
+#
+# Args:
+#   $1 - repos_json: managed repo registry
+# Outputs: number of worktrees relocated
+# Returns: 0 always
+#######################################
+_pc_relocate_registered_worktrees() {
+	local repos_json="$1"
+	local moved_count=0
+	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || { echo 0; return 0; }
+
+	local central_base=""
+	if declare -F aidevops_worktree_base_dir >/dev/null 2>&1; then
+		central_base=$(aidevops_worktree_base_dir 2>/dev/null || true)
+	elif declare -F aidevops_worktree_base_dir_configured >/dev/null 2>&1; then
+		central_base=$(aidevops_worktree_base_dir_configured 2>/dev/null || true)
+		[[ -n "$central_base" ]] && mkdir -p "$central_base" 2>/dev/null || true
+	fi
+	[[ -n "$central_base" && -d "$central_base" ]] || { echo 0; return 0; }
+
+	local repo_paths_move
+	repo_paths_move=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null || printf '')
+
+	local rp_move
+	while IFS= read -r rp_move; do
+		[[ -z "$rp_move" ]] && continue
+		[[ -d "$rp_move/.git" || -f "$rp_move/.git" ]] || continue
+		local porcelain_move main_wt_move wt_path_move wt_branch_move line_move
+		porcelain_move=$(git -C "$rp_move" worktree list --porcelain 2>/dev/null || true)
+		[[ -n "$porcelain_move" ]] || continue
+		main_wt_move="${porcelain_move%%$'\n'*}"
+		main_wt_move="${main_wt_move#worktree }"
+		[[ -n "$main_wt_move" ]] || continue
+		wt_path_move=""
+		wt_branch_move=""
+		while IFS= read -r line_move; do
+			if [[ "$line_move" =~ ^worktree\ (.+)$ ]]; then
+				wt_path_move="${BASH_REMATCH[1]}"
+				wt_branch_move=""
+			elif [[ "$line_move" =~ ^branch\ refs/heads/(.+)$ ]]; then
+				wt_branch_move="${BASH_REMATCH[1]}"
+			elif [[ -z "$line_move" ]]; then
+				if _pc_relocate_registered_worktree "$rp_move" "$main_wt_move" "$wt_path_move" "$wt_branch_move" "$central_base"; then
+					moved_count=$((moved_count + 1))
+				fi
+				wt_path_move=""
+				wt_branch_move=""
+			fi
+		done <<<"${porcelain_move}"$'\n'
+	done <<<"$repo_paths_move"
+
+	echo "$moved_count"
+	return 0
+}
+
+#######################################
 # Clean up worktrees for merged/closed PRs and orphaned workers
 # across ALL managed repos.
 #
@@ -1719,7 +1847,16 @@ cleanup_worktrees() {
 		done < <(git -C "$rp_age" worktree list 2>/dev/null)
 	done <<<"$repo_paths_age"
 
-	# Pass 3: filesystem outliers that are no longer present in git worktree
+	# Pass 3: registered linked worktrees accidentally created beside canonical
+	# repos are moved into the central worktree base instead of cluttering the
+	# canonical repo parent.
+	local registered_moved
+	registered_moved=$(_pc_relocate_registered_worktrees "$repos_json")
+	if [[ "$registered_moved" -gt 0 ]]; then
+		echo "[pulse-wrapper] Worktree relocation total: $registered_moved worktree(s) moved to central base" >>"$LOGFILE"
+	fi
+
+	# Pass 4: filesystem outliers that are no longer present in git worktree
 	# metadata. These are moved to a recoverable trash bucket only; standalone
 	# git repos and valid gitfile worktrees are skipped.
 	local orphan_dirs_moved

--- a/.agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PULSE_CLEANUP="${SCRIPT_DIR}/../pulse-cleanup.sh"
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s %s\n' "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+setup_subject() {
+	TEST_ROOT=$(mktemp -d)
+	TEST_ROOT=$(cd "$TEST_ROOT" && pwd -P) || return 1
+	trap teardown EXIT
+	export HOME="${TEST_ROOT}/home"
+	export AIDEVOPS_REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+	export AIDEVOPS_WORKTREE_BASE_DIR="${TEST_ROOT}/Git/_worktrees"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup.log"
+	mkdir -p "${HOME}/.config/aidevops" "${HOME}/.aidevops/logs" "${TEST_ROOT}/Git"
+
+	is_registered_canonical() { return 1; }
+	unregister_worktree() { local wt_path="$1"; : "$wt_path"; return 0; }
+	gh() { return 1; }
+	gh_pr_list() { return 0; }
+	recover_failed_launch_state() { return 0; }
+	gh_issue_comment() { return 0; }
+
+	unset _PULSE_CLEANUP_LOADED 2>/dev/null || true
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../portable-stat.sh
+	source "${SCRIPT_DIR}/../portable-stat.sh"
+	# shellcheck source=../pulse-cleanup.sh
+	source "$PULSE_CLEANUP"
+	return 0
+}
+
+test_registered_parent_worktree_moves_to_central_base() {
+	setup_subject || return 1
+	local repo_dir="${TEST_ROOT}/Git/example"
+	local old_wt="${TEST_ROOT}/Git/example-feature-old-location"
+	local new_wt="${TEST_ROOT}/Git/_worktrees/example-feature-old-location"
+	local branch="feature/old-location"
+	local rc=0 moved=""
+
+	mkdir -p "$repo_dir" || rc=1
+	git -C "$repo_dir" init -q -b main || rc=1
+	git -C "$repo_dir" config user.email test@example.invalid || rc=1
+	git -C "$repo_dir" config user.name 'Aidevops Test' || rc=1
+	printf 'base\n' >"${repo_dir}/README.md" || rc=1
+	git -C "$repo_dir" add README.md || rc=1
+	git -C "$repo_dir" commit -q -m init || rc=1
+	git -C "$repo_dir" worktree add -q -b "$branch" "$old_wt" main || rc=1
+	printf '{"initialized_repos":[{"slug":"example/repo","path":"%s","local_only":false}],"worktree_base_dir":"%s"}\n' \
+		"$repo_dir" "$AIDEVOPS_WORKTREE_BASE_DIR" >"$AIDEVOPS_REPOS_JSON" || rc=1
+
+	moved=$(_pc_relocate_registered_worktrees "$AIDEVOPS_REPOS_JSON") || rc=1
+
+	[[ "$moved" == "1" ]] || rc=1
+	[[ ! -d "$old_wt" ]] || rc=1
+	[[ -d "$new_wt" ]] || rc=1
+	git -C "$repo_dir" worktree list --porcelain | grep -q "worktree $new_wt" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*centralized-worktree.*mode=moved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "registered parent worktree moves to central base" "$rc" \
+		"moved=$moved log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_current_worktree_is_not_moved() {
+	teardown
+	setup_subject || return 1
+	local repo_dir="${TEST_ROOT}/Git/example-current"
+	local old_wt="${TEST_ROOT}/Git/example-current-feature-active"
+	local branch="feature/active"
+	local rc=0 moved=""
+	mkdir -p "$repo_dir" || rc=1
+	git -C "$repo_dir" init -q -b main || rc=1
+	git -C "$repo_dir" config user.email test@example.invalid || rc=1
+	git -C "$repo_dir" config user.name 'Aidevops Test' || rc=1
+	git -C "$repo_dir" commit -q --allow-empty -m init || rc=1
+	git -C "$repo_dir" worktree add -q -b "$branch" "$old_wt" main || rc=1
+	printf '{"initialized_repos":[{"slug":"example/current","path":"%s","local_only":false}],"worktree_base_dir":"%s"}\n' \
+		"$repo_dir" "$AIDEVOPS_WORKTREE_BASE_DIR" >"$AIDEVOPS_REPOS_JSON" || rc=1
+
+	(
+		cd "$old_wt" || exit 1
+		moved=$(_pc_relocate_registered_worktrees "$AIDEVOPS_REPOS_JSON") || exit 1
+		[[ "$moved" == "0" ]] || exit 1
+	) || rc=1
+	[[ -d "$old_wt" ]] || rc=1
+	grep -q 'worktree-skipped.*current-worktree.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "current worktree is not relocated" "$rc" \
+		"log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_registered_parent_worktree_moves_to_central_base
+test_current_worktree_is_not_moved
+
+printf '\n'
+printf 'Results: %s/%s passed, %s failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -242,6 +242,42 @@ test_closed_issue_dirty_worktree_stashes_and_preserves_branch() {
 	return 0
 }
 
+test_terminal_worktree_bypasses_stale_owner_signal() {
+	local repo_dir="${TEST_ROOT}/repo-terminal-owner"
+	local wt_path="${TEST_ROOT}/worker-wt-terminal-owner"
+	local branch_name="feature/auto-20260507-190808-gh23083"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+	is_worktree_owned_by_others() { return 0; }
+	gh() {
+		local command_name="${1:-}"
+		local subcommand_name="${2:-}"
+		local target_number="${3:-}"
+		if [[ "$command_name" == "issue" && "$subcommand_name" == "view" && "$target_number" == "23083" ]]; then
+			printf '%s\n' "CLOSED"
+			return 0
+		fi
+		return 1
+	}
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-terminal-owner-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 0 ]] || rc=1
+	[[ ! -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'recovery_path=branch-preserved-closed-issue' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "terminal worktree bypasses stale owner signal" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
 test_fix_numeric_closed_issue_worktree_archives() {
 	local repo_dir="${TEST_ROOT}/repo-fix-numeric-closed-issue"
 	local wt_path="${TEST_ROOT}/worker-wt-fix-numeric-closed-issue"
@@ -503,6 +539,7 @@ test_closed_issue_local_commit_no_pr_removes_before_age_threshold
 test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold
 test_merged_branch_pr_removes_before_age_threshold
 test_closed_issue_dirty_worktree_stashes_and_preserves_branch
+test_terminal_worktree_bypasses_stale_owner_signal
 test_fix_numeric_closed_issue_worktree_archives
 test_stale_local_commit_no_pr_removes_worktree_preserves_branch
 test_no_newline_pr_output_blocks_local_commit_cleanup

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -120,6 +120,35 @@ test_protected_pass_set_blocks_branch_merged_removal() {
 	return 0
 }
 
+test_terminal_pr_proof_bypasses_protected_pass_skip() {
+	local repo_path="${TEST_ROOT}/repo-terminal-protected"
+	local wt_path="${TEST_ROOT}/wt-terminal-protected"
+	local log_file="${TEST_ROOT}/terminal-protected-cleanup.log"
+	local branch="feature/gh-99032-terminal-protected"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'terminal\n' >"$repo_path/terminal.txt" || rc=1
+	git -C "$repo_path" add terminal.txt || rc=1
+	git -C "$repo_path" commit -q -m "terminal branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_protected_mark "$wt_path"
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	) || rc=1
+
+	[[ ! -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-removed.*branch-merged.*mode=permanent.*merge_proof_result=github-merged-pr" || rc=1
+	print_result "terminal PR proof bypasses protected pass skip" "$rc" \
+		"Expected terminal PR proof to remove protected-pass worktree. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
 test_squash_merged_pr_without_ancestor_proof_classifies() {
 	local repo_path="${TEST_ROOT}/repo-unproven"
 	local wt_path="${TEST_ROOT}/wt-unproven"
@@ -521,6 +550,7 @@ test_closed_issue_dirty_unproven_branch_stashes_and_preserves_branch() {
 
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
+test_terminal_pr_proof_bypasses_protected_pass_skip
 test_squash_merged_pr_without_ancestor_proof_classifies
 test_prefetched_merged_pr_metadata_skips_exact_head_lookup
 test_merged_pr_list_passes_explicit_repo_slug

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -523,10 +523,33 @@ _clean_branch_list_contains_exact() {
 	return 0
 }
 
+_clean_branch_has_terminal_pr_proof() {
+	local wt_branch="$1"
+	local merged_prs="${2:-}"
+	local closed_prs="${3:-}"
+
+	[[ -n "$wt_branch" ]] || return 1
+	_clean_branch_list_contains_exact "$wt_branch" "$merged_prs" && return 0
+	_clean_branch_list_contains_exact "$wt_branch" "$closed_prs" && return 0
+	_clean_branch_has_exact_merged_pr "$wt_branch" "$merged_prs" && return 0
+	return 1
+}
+
+_clean_merge_type_has_terminal_pr_proof() {
+	local merge_type="$1"
+	case "$merge_type" in
+	"$_WT_CLEAN_TYPE_SQUASH_MERGED_PR" | "$_WT_CLEAN_TYPE_CLOSED_PR" | "$_WT_CLEAN_TYPE_CLOSED_ISSUE_ARCHIVE")
+		return 0
+		;;
+	esac
+	return 1
+}
+
 _WT_CLEAN_PROTECTED_PATHS="${_WT_CLEAN_PROTECTED_PATHS:-}"
 _WT_CLEAN_LAST_MERGE_TYPE="${_WT_CLEAN_LAST_MERGE_TYPE:-}"
 _WT_CLEAN_LAST_AUDIT_CONTEXT="${_WT_CLEAN_LAST_AUDIT_CONTEXT:-}"
 _WT_CLEAN_TYPE_SQUASH_MERGED_PR="squash-merged PR"
+_WT_CLEAN_TYPE_CLOSED_PR="closed PR"
 _WT_CLEAN_PROOF_GH_MERGED_PR="github-merged-pr"
 _WT_CLEAN_PROOF_GH_MERGED_PR_STATE="github-merged-pr-state"
 _WT_CLEAN_REASON_BRANCH_MERGED="branch-merged"
@@ -657,7 +680,7 @@ _clean_branch_requires_ancestor_proof() {
 	local merge_type="$1"
 
 	case "$merge_type" in
-	"$_WT_CLEAN_TYPE_SQUASH_MERGED_PR" | "closed PR")
+	"$_WT_CLEAN_TYPE_SQUASH_MERGED_PR" | "$_WT_CLEAN_TYPE_CLOSED_PR")
 		# GitHub squash merges intentionally create a new target-branch commit,
 		# and abandoned closed PRs are not expected to reach the default branch.
 		# In both cases, GitHub PR state is the proof source rather than ancestry.
@@ -699,6 +722,33 @@ _clean_resolve_merge_proof() {
 	return 1
 }
 
+_clean_select_merge_type() {
+	local wt_branch="$1"
+	local default_br="$2"
+	local remote_unknown="$3"
+	local merged_prs="$4"
+	local closed_prs="$5"
+
+	if git branch --merged "$default_br" 2>/dev/null | grep -q "^\s*$wt_branch$" \
+		&& ! branch_has_zero_commits_ahead "$wt_branch" "$default_br"; then
+		printf '%s\n' "merged"
+		return 0
+	fi
+	if _clean_branch_has_exact_merged_pr "$wt_branch" "$merged_prs"; then
+		printf '%s\n' "$_WT_CLEAN_TYPE_SQUASH_MERGED_PR"
+		return 0
+	fi
+	if _clean_branch_list_contains_exact "$wt_branch" "$closed_prs"; then
+		printf '%s\n' "$_WT_CLEAN_TYPE_CLOSED_PR"
+		return 0
+	fi
+	if [[ "$remote_unknown" == "false" ]] && branch_was_pushed "$wt_branch" && ! _branch_exists_on_any_remote "$wt_branch"; then
+		printf '%s\n' "remote deleted"
+		return 0
+	fi
+	return 1
+}
+
 # Determine if a worktree entry is merged, and print it if so.
 # Args: $1=wt_path, $2=wt_branch, $3=default_branch, $4=remote_state_unknown,
 #       $5=merged_pr_branches, $6=open_pr_branches, $7=force_merged,
@@ -714,7 +764,6 @@ _clean_classify_worktree() {
 	local force_merged="$7"
 	local closed_prs="${8:-}"
 
-	local is_merged=false
 	local merge_type=""
 	local head_sha="unknown"
 	local proof_result="unavailable"
@@ -723,28 +772,14 @@ _clean_classify_worktree() {
 	_WT_CLEAN_LAST_AUDIT_CONTEXT=""
 	_WT_CLEAN_LAST_PRESERVE_BRANCH="$_WT_CLEAN_BOOL_FALSE"
 
-	if _clean_protected_contains "$wt_path"; then
+	if _clean_protected_contains "$wt_path" &&
+		! _clean_branch_has_terminal_pr_proof "$wt_branch" "$merged_prs" "$closed_prs"; then
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "$_WT_CLEAN_REASON_PROTECTED_PASS" "$_WT_CLEAN_MODE_SKIPPED" \
 			"branch=$wt_branch target_branch=$default_br owner_guard=protected protected_status=pass-local"
 		return 0
 	fi
 
-	if git branch --merged "$default_br" 2>/dev/null | grep -q "^\s*$wt_branch$" \
-		&& ! branch_has_zero_commits_ahead "$wt_branch" "$default_br"; then
-		is_merged=true
-		merge_type="merged"
-	elif _clean_branch_has_exact_merged_pr "$wt_branch" "$merged_prs"; then
-		is_merged=true
-		merge_type="$_WT_CLEAN_TYPE_SQUASH_MERGED_PR"
-	elif _clean_branch_list_contains_exact "$wt_branch" "$closed_prs"; then
-		is_merged=true
-		merge_type="closed PR"
-	elif [[ "$remote_unknown" == "false" ]] && branch_was_pushed "$wt_branch" && ! _branch_exists_on_any_remote "$wt_branch"; then
-		is_merged=true
-		merge_type="remote deleted"
-	fi
-
-	if [[ "$is_merged" == "false" ]]; then
+	if ! merge_type=$(_clean_select_merge_type "$wt_branch" "$default_br" "$remote_unknown" "$merged_prs" "$closed_prs"); then
 		return 0
 	fi
 
@@ -774,10 +809,18 @@ _clean_classify_worktree() {
 		return 0
 	fi
 
-	# Apply safety checks using shared helper
-	if should_skip_cleanup "$wt_path" "$wt_branch" "$default_br" "$open_prs" "$force_merged"; then
-		_clean_protected_mark "$wt_path"
-		return 0
+	# Terminal PR/closed-issue proof means the worktree is no longer active work.
+	# Keep hard current/canonical/process-cwd guards, but do not let stale owner,
+	# protected-pass, grace, or dirty markers preserve terminal clutter forever.
+	if _clean_merge_type_has_terminal_pr_proof "$merge_type" ||
+		_clean_branch_has_terminal_pr_proof "$wt_branch" "$merged_prs" "$closed_prs"; then
+		_skip_cleanup_for_current_worktree "$wt_path" "$wt_branch" && return 0
+	else
+		# Apply safety checks using shared helper
+		if should_skip_cleanup "$wt_path" "$wt_branch" "$default_br" "$open_prs" "$force_merged"; then
+			_clean_protected_mark "$wt_path"
+			return 0
+		fi
 	fi
 
 	if _clean_branch_requires_ancestor_proof "$merge_type"; then
@@ -917,7 +960,8 @@ _clean_remove_merged() {
 			worktree_branch="${BASH_REMATCH[1]}"
 		elif [[ -z "$line" ]]; then
 			if [[ -n "$worktree_branch" ]] && [[ "$worktree_branch" != "$default_br" ]] && [[ "$worktree_path" != "$main_wt_path" ]]; then
-				if _clean_protected_contains "$worktree_path"; then
+				if _clean_protected_contains "$worktree_path" &&
+					! _clean_branch_has_terminal_pr_proof "$worktree_branch" "$merged_prs" "$closed_prs"; then
 					log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_PROTECTED_PASS" "$_WT_CLEAN_MODE_SKIPPED" \
 						"branch=$worktree_branch target_branch=$default_br owner_guard=protected protected_status=pass-local"
 					worktree_path=""
@@ -932,7 +976,8 @@ _clean_remove_merged() {
 				local preserve_branch="$_WT_CLEAN_LAST_PRESERVE_BRANCH"
 				if [[ -n "$merge_type" ]]; then
 					echo -e "${BLUE}Removing $worktree_branch...${NC}" >&2
-					if _clean_protected_contains "$worktree_path"; then
+					if _clean_protected_contains "$worktree_path" &&
+						! _clean_branch_has_terminal_pr_proof "$worktree_branch" "$merged_prs" "$closed_prs"; then
 						log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_PROTECTED_PASS" "$_WT_CLEAN_MODE_SKIPPED" \
 							"branch=$worktree_branch target_branch=$default_br owner_guard=protected protected_status=pass-local"
 						echo -e "${YELLOW}Skipped $worktree_branch - protected earlier in this cleanup pass${NC}" >&2


### PR DESCRIPTION
## Summary

Terminal merged/closed PR and closed-issue proof now bypasses stale owner/protected/dirty soft blockers while preserving hard current/canonical/process guards. Registered sibling worktrees under the repo parent are moved into the configured central worktree base.

## Files Changed

.agents/configs/simplification-state.json, .agents/plugins/opencode-aidevops/oauth-pool.mjs, .agents/reference/platform-support.md, .agents/reference/worker-diagnostics.md, .agents/scripts/aidevops-update-check.sh, .agents/scripts/commands/local-permissions-check.md, .agents/scripts/commands/optimise-windows-indexing-backups.md, .agents/scripts/headless-runtime-provider.sh, .agents/scripts/local-permissions-check-helper.sh, .agents/scripts/optimise-indexing-backups-helper.sh, .agents/scripts/pulse-cleanup.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/tests/test-headless-runtime-oauth-pool-gate.sh, .agents/scripts/tests/test-local-permissions-check-helper.sh, .agents/scripts/tests/test-optimise-indexing-backups-helper.sh, .agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh, .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh, .agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh, .agents/scripts/tests/test-pulse-merge-native-auto.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh, .agents/scripts/tests/test-pulse-merge-timing-summary.sh, .agents/scripts/tests/test-pulse-nmr-automation-signature.sh, .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh, .agents/scripts/worktree-clean-lib.sh, .agents/templates/brief-template.md, .agents/tools/security/local-permissions-check.md, .agents/tools/terminal/optimise-windows-indexing-backups.md, .agents/workflows/brief.md, .agents/workflows/local-permissions-check.md, .agents/workflows/optimise-windows-indexing-backups.md, .claude-plugin/marketplace.json, CHANGELOG.md, README.md, TODO.md, VERSION, aidevops.sh, package.json, setup.sh, sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh; bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh; bash .agents/scripts/tests/test-worktree-centralized-paths.sh; bash .agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh; shellcheck changed cleanup scripts/tests; .agents/scripts/linters-local.sh reached unrelated file-size ratchet noise captured in GH#26670.

Resolves #26634


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.66 with gpt-5.5 spent 7h 59m and 1,986,626 tokens on this with the user in an interactive session.