### PR TITLE
feat: add AI-session incremental setup

### DIFF
--- a/.agents/aidevops/setup.md
+++ b/.agents/aidevops/setup.md
@@ -22,6 +22,7 @@ tools:
 - **Run**: `cd ~/Git/aidevops && ./setup.sh`
 - **Update**: `git pull && ./setup.sh` (backs up existing configs automatically)
 - **Scoped deploy**: `./setup.sh --stage agents` or `aidevops setup --scope agents`
+- **AI-session update**: `./setup.sh --stage ai-session` applies changed deploy stages and falls back to full setup when unsafe
 - **Agents**: `~/.aidevops/agents/` | **Backups**: `~/.aidevops/config-backups/` | **Credentials**: `~/.config/aidevops/credentials.sh`
 
 **What setup.sh does**: checks required deps (`jq`, `curl`, `ssh`, `sqlite3`) and optional deps (`sshpass`, `gh`, `glab`, `tea`); copies `.agents/` → `~/.aidevops/agents/` with timestamped config backups; injects AGENTS.md pointer into `~/.opencode/AGENTS.md`, `~/.cursor/AGENTS.md`, `~/.claude/AGENTS.md`, `~/.config/cursor/AGENTS.md`; updates OpenCode agent paths in `~/.config/opencode/opencode.json`.
@@ -46,10 +47,14 @@ Use scoped setup when the change is isolated and a full deploy would add avoidab
 | Hook change | `./setup.sh --stage hooks` or `aidevops setup --scope hooks` |
 | Tabby profile change | `./setup.sh --stage tabby` or `aidevops setup --scope tabby` |
 | launchd/routine/pulse plist change | `./setup.sh --stage pulse` or `aidevops setup --scope pulse` |
+| AI session after release/update | `./setup.sh --stage ai-session` or `aidevops setup --scope ai-session` |
 
 `./setup.sh --stage` also accepts the canonical stage names: `setup_opencode_cli`,
 `deploy_aidevops_agents`, `setup_safety_hooks`, `setup_tabby`, and
-`setup_supervisor_pulse`. Unknown stages fail non-zero and print the valid list.
+`setup_supervisor_pulse`. The `ai-session` scope compares `~/.aidevops/.deployed-sha`
+with the current checkout, runs the changed deploy stages, verifies `VERSION` and
+`.deployed-sha`, and then runs full non-interactive setup only when incremental setup
+is unsafe or fails. Unknown stages fail non-zero and print the valid list.
 
 ## Manual Configuration
 

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -598,8 +598,9 @@ _check_hotfix_available() {
 # -----------------------------------------------------------------------------
 # _check_script_drift: detect SHA drift between deployed agents and canonical
 # repo HEAD. Triggers a silent background redeploy when framework code files
-# (scripts/, agents/, workflows/, prompts/, hooks/) have changed since the last
-# deploy. Doc-only drift (reference/, templates/, todo/, *.md) is skipped.
+# (scripts/, agents/, workflows/, prompts/, hooks/, setup.sh, aidevops.sh, VERSION)
+# have changed since the last deploy. Doc-only drift (reference/, templates/,
+# todo/, *.md) is skipped.
 # t2156: automating the manual "cp + restart pulse" workaround that was needed
 # after 3bbe31f36 merged but the production pulse kept using stale code for 90+
 # minutes — see GH#19432–19443 blast radius.
@@ -642,7 +643,7 @@ _check_script_drift() {
 	local has_code_drift=0
 	while IFS= read -r filepath; do
 		case "$filepath" in
-		.agents/scripts/* | .agents/agents/* | .agents/workflows/* | .agents/prompts/* | .agents/hooks/*)
+		.agents/scripts/* | .agents/agents/* | .agents/workflows/* | .agents/prompts/* | .agents/hooks/* | setup.sh | aidevops.sh | VERSION)
 			has_code_drift=1
 			break
 			;;
@@ -655,18 +656,18 @@ _check_script_drift() {
 	fi
 
 	# Framework code drift detected.
-	# setup.sh --non-interactive deploys, writes .deployed-sha, and restarts the
-	# pulse — no manual stamp update or pulse restart needed here.
+	# setup.sh --stage ai-session applies changed deploy stages first; the setup
+	# mode falls back to full non-interactive setup when it cannot prove safety.
 	local setup_script="$framework_repo/setup.sh"
 	if [[ ! -x "$setup_script" ]]; then
-		echo "Script drift detected (${deployed_sha:0:7}→${current_sha:0:7}) but setup.sh not executable — run: cd ~/Git/aidevops && ./setup.sh --non-interactive"
+		echo "Script drift detected (${deployed_sha:0:7}→${current_sha:0:7}) but setup.sh not executable — run: cd ~/Git/aidevops && ./setup.sh --stage ai-session"
 		return 0
 	fi
 
 	echo "Script drift detected (${deployed_sha:0:7}→${current_sha:0:7}). Redeploying in background..."
 	# t2729 (Option B): redirect at subshell level so the background process
 	# never holds the parent's stdout FD open for synchronous callers.
-	(bash "$setup_script" --non-interactive) >/dev/null 2>&1 &
+	(bash "$setup_script" --stage ai-session || bash "$setup_script" --non-interactive) >/dev/null 2>&1 &
 
 	return 0
 }

--- a/.agents/scripts/auto-update-helper-check.sh
+++ b/.agents/scripts/auto-update-helper-check.sh
@@ -248,6 +248,16 @@ update_state() {
 	return 0
 }
 
+_run_setup_ai_session_with_fallback() {
+	local setup_script="${INSTALL_DIR}/setup.sh"
+	if bash "$setup_script" --stage ai-session >>"$LOG_FILE" 2>&1; then
+		return 0
+	fi
+	log_warn "AI-session incremental setup failed or is unavailable; retrying full setup"
+	bash "$setup_script" --non-interactive >>"$LOG_FILE" 2>&1
+	return $?
+}
+
 #######################################
 # Handle stale deployed agents when repo version matches remote.
 # Checks VERSION mismatch and sentinel script hash drift; re-deploys if needed.
@@ -263,7 +273,7 @@ _cmd_check_stale_agent_redeploy() {
 	deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
 	if [[ "$current" != "$deployed_version" ]]; then
 		log_warn "Deployed agents stale ($deployed_version), re-deploying..."
-		if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
+		if _run_setup_ai_session_with_fallback; then
 			local redeployed_version
 			redeployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
 			if [[ "$current" == "$redeployed_version" ]]; then
@@ -307,7 +317,7 @@ _cmd_check_stale_agent_redeploy() {
 			fi
 			if [[ "$has_code_drift" -eq 1 ]]; then
 				log_warn "Script drift detected (${deployed_sha:0:7}→${head_sha:0:7} at v$current) — re-deploying agents..."
-				if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
+				if _run_setup_ai_session_with_fallback; then
 					log_info "Agents re-deployed after script drift (${deployed_sha:0:7}→${head_sha:0:7})"
 				else
 					log_error "setup.sh failed during script-drift re-deploy (exit code: $?)"
@@ -403,10 +413,11 @@ _cmd_check_perform_update() {
 		return 1
 	fi
 
-	# Run setup.sh non-interactively to deploy agents
-	log_info "Running setup.sh --non-interactive..."
+	# Run setup with an incremental first pass; setup.sh falls back to full setup
+	# when changed setup logic cannot be applied safely.
+	log_info "Running setup.sh --stage ai-session..."
 	local _setup_exit=0
-	bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1 || _setup_exit=$?
+	_run_setup_ai_session_with_fallback || _setup_exit=$?
 
 	# GH#21060 / t2911: Log slowest 5 stages from this run so that
 	# "tail -50 ~/.aidevops/logs/auto-update.log | grep Slowest" is

--- a/.agents/scripts/auto-update-helper-status.sh
+++ b/.agents/scripts/auto-update-helper-status.sh
@@ -427,7 +427,7 @@ HOW IT WORKS:
     3. If newer version found:
        a. Acquires lock (prevents concurrent updates)
        b. Runs git pull --ff-only
-       c. Runs setup.sh --non-interactive to deploy agents
+       c. Runs setup.sh --stage ai-session (full setup fallback) to deploy agents
     4. Safe to run while AI sessions are active
     5. Skips if another update is already in progress
     6. Runs daily skill freshness check (24h gate):

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -512,6 +512,16 @@ update_state() {
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/auto-update-freshness-lib.sh"
 
+_run_setup_ai_session_with_fallback() {
+	local setup_script="${INSTALL_DIR}/setup.sh"
+	if bash "$setup_script" --stage ai-session >>"$LOG_FILE" 2>&1; then
+		return 0
+	fi
+	log_warn "AI-session incremental setup failed or is unavailable; retrying full setup"
+	bash "$setup_script" --non-interactive >>"$LOG_FILE" 2>&1
+	return $?
+}
+
 #######################################
 # Handle stale deployed agents when repo version matches remote.
 # Checks VERSION mismatch and sentinel script hash drift; re-deploys if needed.
@@ -527,7 +537,7 @@ _cmd_check_stale_agent_redeploy() {
 	deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
 	if [[ "$current" != "$deployed_version" ]]; then
 		log_warn "Deployed agents stale ($deployed_version), re-deploying..."
-		if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
+		if _run_setup_ai_session_with_fallback; then
 			local redeployed_version
 			redeployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
 			if [[ "$current" == "$redeployed_version" ]]; then
@@ -571,7 +581,7 @@ _cmd_check_stale_agent_redeploy() {
 			fi
 			if [[ "$has_code_drift" -eq 1 ]]; then
 				log_warn "Script drift detected (${deployed_sha:0:7}→${head_sha:0:7} at v$current) — re-deploying agents..."
-				if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
+				if _run_setup_ai_session_with_fallback; then
 					log_info "Agents re-deployed after script drift (${deployed_sha:0:7}→${head_sha:0:7})"
 				else
 					log_error "setup.sh failed during script-drift re-deploy (exit code: $?)"
@@ -667,10 +677,11 @@ _cmd_check_perform_update() {
 		return 1
 	fi
 
-	# Run setup.sh non-interactively to deploy agents
-	log_info "Running setup.sh --non-interactive..."
+	# Run setup with an incremental first pass; setup.sh falls back to full setup
+	# when changed setup logic cannot be applied safely.
+	log_info "Running setup.sh --stage ai-session..."
 	local _setup_exit=0
-	bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1 || _setup_exit=$?
+	_run_setup_ai_session_with_fallback || _setup_exit=$?
 
 	# GH#21060 / t2911: Log slowest 5 stages from this run so that
 	# "tail -50 ~/.aidevops/logs/auto-update.log | grep Slowest" is
@@ -1617,7 +1628,7 @@ HOW IT WORKS:
     3. If newer version found:
        a. Acquires lock (prevents concurrent updates)
        b. Runs git pull --ff-only
-       c. Runs setup.sh --non-interactive to deploy agents
+       c. Runs setup.sh --stage ai-session (full setup fallback) to deploy agents
     4. Safe to run while AI sessions are active
     5. Skips if another update is already in progress
     6. Runs daily skill freshness check (24h gate):

--- a/.agents/scripts/tests/test-cmd-update-sha-drift.sh
+++ b/.agents/scripts/tests/test-cmd-update-sha-drift.sh
@@ -59,6 +59,7 @@ print_result() {
 
 AIDEVOPS_SH="$WORKTREE_ROOT/aidevops.sh"
 AUTO_UPDATE_SH="$WORKTREE_ROOT/.agents/scripts/auto-update-helper.sh"
+UPDATE_CHECK_SH="$WORKTREE_ROOT/.agents/scripts/aidevops-update-check.sh"
 
 # Test 1: aidevops.sh cmd_update references .deployed-sha in the VERSION-match branch
 if grep -q '\.deployed-sha' "$AIDEVOPS_SH" &&
@@ -76,6 +77,15 @@ if grep -q '\.agents/scripts/' "$AIDEVOPS_SH" &&
 else
 	print_result "aidevops.sh filters for framework code paths" 1 \
 		"(expected .agents/scripts/ case and has_code_drift variable)"
+fi
+
+# Test 2b: aidevops.sh uses the AI-session setup scope for update redeploys.
+if grep -q -- '--stage ai-session' "$AIDEVOPS_SH" &&
+	grep -q '_run_update_setup' "$AIDEVOPS_SH"; then
+	print_result "aidevops.sh update uses incremental setup scope" 0
+else
+	print_result "aidevops.sh update uses incremental setup scope" 1 \
+		"(expected _run_update_setup and --stage ai-session)"
 fi
 
 # Test 3: auto-update-helper.sh no longer uses single-sentinel SHA-256 check
@@ -104,6 +114,24 @@ if grep -q '\.agents/scripts/' "$AUTO_UPDATE_SH" &&
 else
 	print_result "auto-update-helper.sh filters for framework code paths" 1 \
 		"(expected .agents/scripts/ case and drift filter)"
+fi
+
+# Test 5b: session-start update checks use the AI-session incremental setup scope.
+if grep -q -- '--stage ai-session' "$UPDATE_CHECK_SH" &&
+	grep -q -- '--non-interactive' "$UPDATE_CHECK_SH"; then
+	print_result "update-check script drift uses incremental setup with full fallback" 0
+else
+	print_result "update-check script drift uses incremental setup with full fallback" 1 \
+		"(expected --stage ai-session and --non-interactive fallback)"
+fi
+
+# Test 5c: auto-update helper uses the AI-session incremental setup helper.
+if grep -q '_run_setup_ai_session_with_fallback' "$AUTO_UPDATE_SH" &&
+	grep -q -- '--stage ai-session' "$AUTO_UPDATE_SH"; then
+	print_result "auto-update helper uses incremental setup helper" 0
+else
+	print_result "auto-update helper uses incremental setup helper" 1 \
+		"(expected _run_setup_ai_session_with_fallback and --stage ai-session)"
 fi
 
 # ---------------------------------------------------------------------------
@@ -212,7 +240,7 @@ run_cmd_update_stamp_branch() {
 					has_code_drift=1
 				fi
 				if [[ "$has_code_drift" -eq 1 ]]; then
-					bash "$INSTALL_DIR/setup.sh" --non-interactive >/dev/null 2>&1
+					bash "$INSTALL_DIR/setup.sh" --stage ai-session >/dev/null 2>&1
 				fi
 			fi
 		fi

--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -92,14 +92,17 @@ test_setup_stage_contract() {
 	assert_contains "tabby scope maps to setup_tabby" "$text" "tabby | \"\$SETUP_STAGE_TABBY\") printf '%s' \"\$SETUP_STAGE_TABBY\""
 	assert_contains "pulse scope maps to setup_supervisor_pulse" "$text" "pulse | \"\$SETUP_STAGE_PULSE\") printf '%s' \"\$SETUP_STAGE_PULSE\""
 	assert_contains "gui-desktop scope maps to native app installer" "$text" "gui-desktop | gui | app | \"\$SETUP_STAGE_GUI_DESKTOP\") printf '%s' \"\$SETUP_STAGE_GUI_DESKTOP\""
+	assert_contains "ai-session scope maps to incremental setup" "$text" "ai-session | ai | \"\$SETUP_STAGE_AI_SESSION\") printf '%s' \"\$SETUP_STAGE_AI_SESSION\""
+	assert_contains "ai-session scoped stage falls back to full setup" "$text" "AI-session incremental setup unavailable or failed; falling back to full setup"
+	assert_contains "ai-session verifies deployed sha" "$text" "_setup_ai_session_verify_deploy \"\$current_sha\""
 	assert_contains "gui desktop default path is opt-in gated" "$text" "_time_step \"setup_gui_desktop_app_opt_in\" _setup_offer_gui_desktop_app"
 	assert_contains "gui desktop env flag enables install" "$text" "AIDEVOPS_GUI_DESKTOP_INSTALL"
 	assert_contains "gui desktop app dir can be configured" "$text" "AIDEVOPS_GUI_DESKTOP_APP_DIR"
 	assert_contains "existing gui desktop app refreshes during update" "$text" "Refreshing existing macOS"
 	assert_contains "gui desktop scoped stage runs installer" "$text" "_time_step \"\$SETUP_STAGE_GUI_DESKTOP\" setup_gui_desktop_app"
-	assert_contains "agents scoped stage registers opencode plugin" "$text" "_time_step \"setup_opencode_plugins\" setup_opencode_plugins"
-	assert_occurrence_count "scoped and noninteractive setup register opencode plugin" "$text" \
-		"_time_step \"setup_opencode_plugins\" setup_opencode_plugins" 2
+	assert_contains "agents scoped stage registers opencode plugin" "$text" "_time_step \"\$SETUP_STAGE_OPENCODE_PLUGINS\" setup_opencode_plugins"
+	assert_occurrence_count "scoped, ai-session, and noninteractive setup register opencode plugin" "$text" \
+		"_time_step \"\$SETUP_STAGE_OPENCODE_PLUGINS\" setup_opencode_plugins" 3
 	assert_contains "unknown stages print actionable help" "$text" "Unknown setup stage/scope"
 	return 0
 }
@@ -114,6 +117,7 @@ test_cli_scope_contract() {
 	assert_contains "aidevops exposes setup command" "$text" "setup) cmd_setup \"\$@\" ;;"
 	assert_contains "aidevops setup requires scope" "$text" "Usage: aidevops setup --scope <scope>"
 	assert_contains "aidevops setup lists gui-desktop scope" "$text" "gui-desktop  Install native macOS aidevops.app only"
+	assert_contains "aidevops setup lists ai-session scope" "$text" "ai-session  Apply changed deploy stages; fall back to full setup if needed"
 	assert_contains "aidevops setup passes scope to setup.sh" "$text" "bash \"\$setup_script\" --stage \"\$scope\""
 	assert_contains "aidevops setup full preserves full setup" "$text" "bash \"\$setup_script\" --non-interactive"
 	return 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -206,6 +206,16 @@ source "${AIDEVOPS_CLI_MODULES_DIR}/aidevops-update-lib.sh"
 # shellcheck disable=SC1091
 source "${AIDEVOPS_CLI_MODULES_DIR}/aidevops-upgrade-planning-lib.sh"
 
+_run_update_setup() {
+	local setup_script="${INSTALL_DIR}/setup.sh"
+	if [[ ! -f "$setup_script" ]]; then
+		print_error "setup.sh not found at $setup_script"
+		return 1
+	fi
+	bash "$setup_script" --stage ai-session
+	return $?
+}
+
 # Update/upgrade command
 cmd_update() {
 	local skip_project_sync=false
@@ -243,8 +253,8 @@ cmd_update() {
 			deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
 			if [[ "$repo_version" != "$deployed_version" ]]; then
 				print_warning "Deployed agents ($deployed_version) don't match repo ($repo_version)"
-				print_info "Re-running setup to sync agents..."
-				bash "$INSTALL_DIR/setup.sh" --non-interactive
+				print_info "Re-running incremental setup to sync agents..."
+				_run_update_setup
 			else
 				# t2706: VERSION matches but .deployed-sha may lag HEAD when
 				# fixes land between releases. Detect and redeploy on framework
@@ -267,8 +277,8 @@ cmd_update() {
 						fi
 						if [[ "$has_code_drift" -eq 1 ]]; then
 							print_warning "Deployed scripts drifted (${deployed_sha:0:7}→${local_hash:0:7})"
-							print_info "Re-running setup to deploy latest scripts..."
-							bash "$INSTALL_DIR/setup.sh" --non-interactive
+							print_info "Re-running incremental setup to deploy latest scripts..."
+							_run_update_setup
 						fi
 						# GH#21735: workflow templates can change between
 						# releases without triggering has_code_drift (templates
@@ -313,9 +323,9 @@ cmd_update() {
 			# Verify supply chain integrity before applying changes
 			_update_verify_signature
 			echo ""
-			print_info "Running setup to apply changes..."
+			print_info "Running incremental setup to apply changes (falls back to full setup if needed)..."
 			local setup_exit=0
-			bash "$INSTALL_DIR/setup.sh" --non-interactive || setup_exit=$?
+			_run_update_setup || setup_exit=$?
 			git checkout -- . 2>/dev/null || true
 			local repo_version deployed_version
 			repo_version=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
@@ -770,6 +780,7 @@ _cmd_setup_help() {
 	printf '%s\n' "  tabby     Sync Tabby terminal profiles only"
 	printf '%s\n' "  pulse     Install/refresh the pulse scheduler only"
 	printf '%s\n' "  gui-desktop  Install native macOS aidevops.app only"
+	printf '%s\n' "  ai-session  Apply changed deploy stages; fall back to full setup if needed"
 	printf '%s\n' "  full      Run ./setup.sh --non-interactive"
 	return 0
 }
@@ -830,7 +841,7 @@ cmd_setup() {
 _help_commands() {
 	echo "Commands:"
 	echo "  init [features]    Initialize aidevops in current project"
-	echo "  setup --scope <s>  Run scoped setup/deploy (opencode, agents, hooks, tabby, pulse, gui-desktop, full)"
+	echo "  setup --scope <s>  Run scoped setup/deploy (opencode, agents, hooks, tabby, pulse, gui-desktop, ai-session, full)"
 	echo "  init-routines      Scaffold private routines repo (--org <name> | --local)"
 	echo "  upgrade-planning   Upgrade TODO.md/PLANS.md to latest templates"
 	echo "  features           List available features for init"

--- a/setup.sh
+++ b/setup.sh
@@ -38,6 +38,9 @@ SETUP_STAGE_HOOKS="setup_safety_hooks"
 SETUP_STAGE_TABBY="setup_tabby"
 SETUP_STAGE_PULSE="setup_supervisor_pulse"
 SETUP_STAGE_GUI_DESKTOP="setup_gui_desktop_app"
+SETUP_STAGE_AI_SESSION="setup_ai_session_incremental"
+SETUP_STAGE_OPENCODE_PLUGINS="setup_opencode_plugins"
+SETUP_STAGE_HOTFIX_CONFIG="_deploy_hotfix_config"
 SETUP_GUI_APP_NAME="aidevops.app"
 SETUP_OS_DARWIN="Darwin"
 # Python compatibility floor used by setup checks and skill/tool gating.
@@ -392,8 +395,8 @@ parse_args() {
 			echo "Use --clean after removing or renaming agents to sync deletions."
 			echo "Use --interactive to control each step individually."
 			echo "Use --non-interactive for CI/CD or AI agent shells (no stdin required)."
-			echo "Use --stage for targeted updates: opencode, agents, hooks, tabby, pulse, gui-desktop, full."
-			echo "Stage aliases: ${SETUP_STAGE_OPENCODE}, ${SETUP_STAGE_AGENTS}, ${SETUP_STAGE_HOOKS}, ${SETUP_STAGE_TABBY}, ${SETUP_STAGE_PULSE}, ${SETUP_STAGE_GUI_DESKTOP}."
+			echo "Use --stage for targeted updates: opencode, agents, hooks, tabby, pulse, gui-desktop, ai-session, full."
+			echo "Stage aliases: ${SETUP_STAGE_OPENCODE}, ${SETUP_STAGE_AGENTS}, ${SETUP_STAGE_HOOKS}, ${SETUP_STAGE_TABBY}, ${SETUP_STAGE_PULSE}, ${SETUP_STAGE_GUI_DESKTOP}, ${SETUP_STAGE_AI_SESSION}."
 			echo "Install ${SETUP_GUI_APP_NAME} explicitly with --stage gui-desktop or AIDEVOPS_GUI_DESKTOP_INSTALL=true."
 			echo "Use --update to check for tool updates after setup completes."
 			exit 0
@@ -419,6 +422,7 @@ _setup_print_stage_help() {
 	printf '  tabby    | %s                 Sync Tabby profiles only\n' "$SETUP_STAGE_TABBY"
 	printf '  pulse    | %s      Install/refresh pulse scheduler only\n' "$SETUP_STAGE_PULSE"
 	printf '  gui-desktop | gui | app | %s  Install native macOS %s only\n' "$SETUP_STAGE_GUI_DESKTOP" "$SETUP_GUI_APP_NAME"
+	printf '  ai-session | ai | %s  Run changed deploy stages, then full setup on failure\n' "$SETUP_STAGE_AI_SESSION"
 	printf '%s\n' "  full                                  Run the default full setup path"
 	return 0
 }
@@ -432,6 +436,7 @@ _setup_canonical_stage() {
 	tabby | "$SETUP_STAGE_TABBY") printf '%s' "$SETUP_STAGE_TABBY" ;;
 	pulse | "$SETUP_STAGE_PULSE") printf '%s' "$SETUP_STAGE_PULSE" ;;
 	gui-desktop | gui | app | "$SETUP_STAGE_GUI_DESKTOP") printf '%s' "$SETUP_STAGE_GUI_DESKTOP" ;;
+	ai-session | ai | "$SETUP_STAGE_AI_SESSION") printf '%s' "$SETUP_STAGE_AI_SESSION" ;;
 	full) printf '%s' "full" ;;
 	*) return 1 ;;
 	esac
@@ -1185,6 +1190,185 @@ _setup_init_stage_timing_log() {
 	return 0
 }
 
+_setup_ai_session_reset_plan() {
+	_SETUP_AI_SESSION_NEEDS_AGENTS=0
+	_SETUP_AI_SESSION_NEEDS_CLI=0
+	_SETUP_AI_SESSION_NEEDS_HOOKS=0
+	_SETUP_AI_SESSION_NEEDS_PULSE=0
+	_SETUP_AI_SESSION_NEEDS_GUI=0
+	_SETUP_AI_SESSION_REQUIRES_FULL=0
+	return 0
+}
+
+_setup_ai_session_setup_sh_version_only() {
+	local deployed_sha="$1"
+	local current_sha="$2"
+	local diff_output=""
+	local line=""
+	local payload=""
+
+	diff_output=$(git -C "$INSTALL_DIR" diff --unified=0 "$deployed_sha" "$current_sha" -- setup.sh 2>/dev/null) || return 1
+	while IFS= read -r line; do
+		case "$line" in
+		"diff --git "* | "index "* | "--- "* | "+++ "* | "@@"*)
+			continue
+			;;
+		+* | -*)
+			payload="${line#?}"
+			if [[ "$payload" != "# Version: "* ]]; then
+				return 1
+			fi
+			;;
+		esac
+	done <<<"$diff_output"
+
+	return 0
+}
+
+_setup_ai_session_plan_file() {
+	local filepath="$1"
+	local deployed_sha="$2"
+	local current_sha="$3"
+
+	case "$filepath" in
+	setup.sh)
+		if _setup_ai_session_setup_sh_version_only "$deployed_sha" "$current_sha"; then
+			print_info "setup.sh drift is release-version metadata only; incremental setup can continue"
+		else
+			print_warning "setup.sh changed beyond the release-version header; full setup required"
+			_SETUP_AI_SESSION_REQUIRES_FULL=1
+		fi
+		;;
+	aidevops.sh)
+		_SETUP_AI_SESSION_NEEDS_CLI=1
+		;;
+	.agents/hooks/*)
+		_SETUP_AI_SESSION_NEEDS_HOOKS=1
+		;;
+	.agents/scripts/setup/modules/schedulers*.sh | .agents/scripts/setup/_scheduler_runtime.sh)
+		_SETUP_AI_SESSION_NEEDS_PULSE=1
+		;;
+	.agents/scripts/setup/modules/agent-deploy.sh | .agents/scripts/setup/modules/plugins.sh)
+		:
+		;;
+	.agents/scripts/setup/*)
+		print_warning "Setup implementation changed ($filepath); full setup required"
+		_SETUP_AI_SESSION_REQUIRES_FULL=1
+		;;
+	packages/gui-api/* | packages/gui-desktop/* | packages/gui-shared/* | packages/gui-web/*)
+		_SETUP_AI_SESSION_NEEDS_GUI=1
+		;;
+	esac
+
+	return 0
+}
+
+_setup_ai_session_build_plan() {
+	local changed_files="$1"
+	local deployed_sha="$2"
+	local current_sha="$3"
+	local filepath=""
+
+	_setup_ai_session_reset_plan
+	# Deploying agents is the cheap, atomic baseline: it copies .agents/, writes
+	# VERSION, writes .deployed-sha, and restarts pulse asynchronously.
+	_SETUP_AI_SESSION_NEEDS_AGENTS=1
+	while IFS= read -r filepath; do
+		[[ -n "$filepath" ]] || continue
+		_setup_ai_session_plan_file "$filepath" "$deployed_sha" "$current_sha"
+	done <<<"$changed_files"
+
+	return 0
+}
+
+_setup_ai_session_verify_deploy() {
+	local expected_sha="$1"
+	local repo_version=""
+	local deployed_version=""
+	local deployed_sha=""
+
+	if [[ -f "$INSTALL_DIR/VERSION" ]]; then
+		repo_version=$(tr -d '[:space:]' <"$INSTALL_DIR/VERSION" 2>/dev/null) || repo_version=""
+	fi
+	if [[ -f "$HOME/.aidevops/agents/VERSION" ]]; then
+		deployed_version=$(tr -d '[:space:]' <"$HOME/.aidevops/agents/VERSION" 2>/dev/null) || deployed_version=""
+	fi
+	if [[ -f "$HOME/.aidevops/.deployed-sha" ]]; then
+		deployed_sha=$(tr -d '[:space:]' <"$HOME/.aidevops/.deployed-sha" 2>/dev/null) || deployed_sha=""
+	fi
+
+	if [[ -z "$repo_version" || "$repo_version" != "$deployed_version" ]]; then
+		print_warning "AI-session incremental verification failed: repo version=${repo_version:-unknown}, deployed=${deployed_version:-none}"
+		return 1
+	fi
+	if [[ -z "$deployed_sha" || "$deployed_sha" != "$expected_sha" ]]; then
+		print_warning "AI-session incremental verification failed: deployed SHA=${deployed_sha:-none}, expected=${expected_sha:0:12}"
+		return 1
+	fi
+
+	return 0
+}
+
+_setup_run_ai_session_incremental() {
+	local os="$1"
+	local stamp_file="$HOME/.aidevops/.deployed-sha"
+	local deployed_sha=""
+	local current_sha=""
+	local changed_files=""
+
+	print_info "AI-session setup mode: applying changed deploy stages only"
+	if [[ ! -d "$INSTALL_DIR/.git" || ! -f "$stamp_file" ]]; then
+		print_warning "AI-session incremental setup needs a git checkout and deployed SHA stamp"
+		return 1
+	fi
+
+	deployed_sha=$(tr -d '[:space:]' <"$stamp_file" 2>/dev/null) || deployed_sha=""
+	current_sha=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null) || current_sha=""
+	if [[ -z "$deployed_sha" || -z "$current_sha" ]]; then
+		print_warning "AI-session incremental setup could not resolve deployed/current SHAs"
+		return 1
+	fi
+
+	if [[ "$deployed_sha" == "$current_sha" ]]; then
+		print_success "AI-session setup: deployed SHA already matches current checkout"
+		_setup_ai_session_verify_deploy "$current_sha" || return $?
+		return 0
+	fi
+
+	changed_files=$(git -C "$INSTALL_DIR" diff --name-only "$deployed_sha" "$current_sha" 2>/dev/null) || {
+		print_warning "AI-session incremental setup could not diff ${deployed_sha:0:7}..${current_sha:0:7}"
+		return 1
+	}
+
+	_setup_ai_session_build_plan "$changed_files" "$deployed_sha" "$current_sha"
+	if [[ "$_SETUP_AI_SESSION_REQUIRES_FULL" -eq 1 ]]; then
+		return 1
+	fi
+
+	_setup_init_stage_timing_log
+	if [[ "$_SETUP_AI_SESSION_NEEDS_AGENTS" -eq 1 ]]; then
+		_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents || return $?
+		_time_step "$SETUP_STAGE_OPENCODE_PLUGINS" setup_opencode_plugins || return $?
+		_time_step "$SETUP_STAGE_HOTFIX_CONFIG" _deploy_hotfix_config || return $?
+	fi
+	if [[ "$_SETUP_AI_SESSION_NEEDS_CLI" -eq 1 ]]; then
+		_time_step "install_aidevops_cli" install_aidevops_cli || return $?
+	fi
+	if [[ "$_SETUP_AI_SESSION_NEEDS_HOOKS" -eq 1 ]]; then
+		_time_step "$SETUP_STAGE_HOOKS" setup_safety_hooks || return $?
+	fi
+	if [[ "$_SETUP_AI_SESSION_NEEDS_PULSE" -eq 1 ]]; then
+		_time_step "$SETUP_STAGE_PULSE" setup_supervisor_pulse "$os" || return $?
+	fi
+	if [[ "$_SETUP_AI_SESSION_NEEDS_GUI" -eq 1 ]]; then
+		_time_step "setup_gui_desktop_app_opt_in" _setup_offer_gui_desktop_app || return $?
+	fi
+
+	_setup_ai_session_verify_deploy "$current_sha" || return $?
+	print_success "AI-session incremental setup complete (${deployed_sha:0:7}→${current_sha:0:7})"
+	return 0
+}
+
 _setup_run_scoped_stage() {
 	local os="$1"
 	local stage
@@ -1205,8 +1389,8 @@ _setup_run_scoped_stage() {
 		;;
 	"$SETUP_STAGE_AGENTS")
 		_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
-		_time_step "setup_opencode_plugins" setup_opencode_plugins
-		_time_step "_deploy_hotfix_config" _deploy_hotfix_config
+		_time_step "$SETUP_STAGE_OPENCODE_PLUGINS" setup_opencode_plugins
+		_time_step "$SETUP_STAGE_HOTFIX_CONFIG" _deploy_hotfix_config
 		;;
 	"$SETUP_STAGE_HOOKS")
 		_time_step "$SETUP_STAGE_HOOKS" setup_safety_hooks
@@ -1219,6 +1403,13 @@ _setup_run_scoped_stage() {
 		;;
 	"$SETUP_STAGE_GUI_DESKTOP")
 		_time_step "$SETUP_STAGE_GUI_DESKTOP" setup_gui_desktop_app
+		;;
+	"$SETUP_STAGE_AI_SESSION")
+		if ! _setup_run_ai_session_incremental "$os"; then
+			print_warning "AI-session incremental setup unavailable or failed; falling back to full setup"
+			_setup_run_non_interactive || return $?
+			_setup_post_setup_steps "$os" || return $?
+		fi
 		;;
 	*)
 		print_error "Unsupported canonical setup stage: $stage"
@@ -1266,9 +1457,9 @@ _setup_run_non_interactive() {
 	_time_step "$SETUP_STAGE_OPENCODE" setup_opencode_cli
 	_time_step "validate_opencode_config" validate_opencode_config
 	_time_step "$SETUP_STAGE_AGENTS" deploy_aidevops_agents
-	_time_step "setup_opencode_plugins" setup_opencode_plugins
+	_time_step "$SETUP_STAGE_OPENCODE_PLUGINS" setup_opencode_plugins
 	_time_step "_setup_install_pulse_plist_early" _setup_install_pulse_plist_early
-	_time_step "_deploy_hotfix_config" _deploy_hotfix_config
+	_time_step "$SETUP_STAGE_HOTFIX_CONFIG" _deploy_hotfix_config
 	_time_step "setup_opencode_desktop_launcher" setup_opencode_desktop_launcher
 	_time_step "sync_agent_sources" sync_agent_sources
 	_time_step "install_aidevops_cli" install_aidevops_cli


### PR DESCRIPTION
For #26678

## Summary

- Add `setup.sh --stage ai-session` / `aidevops setup --scope ai-session` for AI-session-friendly incremental deploys.
- Compare `~/.aidevops/.deployed-sha` with the current checkout, run only changed deploy stages, and verify deployed `VERSION` plus `.deployed-sha`.
- Route `aidevops update`, session-start drift redeploy, and auto-update helpers through the incremental path with full setup fallback.

## Runtime Testing

Self-assessed. This is shell/setup orchestration; no app runtime is required. Local shell syntax, ShellCheck, scoped-dispatch tests, update-drift tests, and full local linter gates were run.

## Verification

- `git diff --check`
- `bash -n setup.sh aidevops.sh .agents/scripts/aidevops-update-check.sh .agents/scripts/auto-update-helper.sh .agents/scripts/auto-update-helper-check.sh .agents/scripts/auto-update-helper-status.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh .agents/scripts/tests/test-cmd-update-sha-drift.sh`
- `shellcheck setup.sh aidevops.sh .agents/scripts/aidevops-update-check.sh .agents/scripts/auto-update-helper.sh .agents/scripts/auto-update-helper-check.sh .agents/scripts/auto-update-helper-status.sh .agents/scripts/tests/test-setup-scoped-dispatch.sh .agents/scripts/tests/test-cmd-update-sha-drift.sh`
- `.agents/scripts/tests/test-setup-scoped-dispatch.sh`
- `.agents/scripts/tests/test-cmd-update-sha-drift.sh`
- `bash .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh`
- `.agents/scripts/linters-local.sh`

## Key decisions

- `ai-session` always performs the atomic agents deploy as the cheap baseline because that writes deployed `VERSION`, writes `.deployed-sha`, and restarts pulse asynchronously.
- Setup implementation changes that are not release-version metadata fall back to full setup so incremental mode does not apply stale setup semantics.
- Existing full setup remains available as `--non-interactive` and `--stage full`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.67 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1h 10m and 380,164 tokens on this with the user in an interactive session.
