### PR TITLE
GH#26714: fix: combine linter mode exports

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -183,8 +183,7 @@ main() {
 		case "$arg" in
 		--changed | --fast-pr)
 			export LINTERS_LOCAL_CHANGED=true
-			LINTERS_LOCAL_MODE="$LINTERS_LOCAL_MODE_CHANGED"
-			export LINTERS_LOCAL_MODE
+			export LINTERS_LOCAL_MODE="$LINTERS_LOCAL_MODE_CHANGED"
 			;;
 		--no-cache)
 			export LINTERS_LOCAL_CACHE_ENABLED=false
@@ -193,8 +192,7 @@ main() {
 			export LINTERS_LOCAL_FULL=true
 			export LINTERS_LOCAL_CACHE_ENABLED=false
 			export LINTERS_LOCAL_STRICT_BROAD_GATES=true
-			LINTERS_LOCAL_MODE=full
-			export LINTERS_LOCAL_MODE
+			export LINTERS_LOCAL_MODE=full
 			;;
 		--update-baseline | --init-baseline)
 			export RATCHET_UPDATE_BASELINE=true


### PR DESCRIPTION
## Summary

Combined separate LINTERS_LOCAL_MODE assignment/export pairs into single export statements for --changed/--fast-pr and --full modes in .agents/scripts/linters-local.sh.

## Files Changed

.agents/scripts/linters-local.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh --changed

Resolves #26714


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.71 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1m and 20,740 tokens on this as a headless worker.