### PR TITLE
fix: initialise pulse merge locals

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -916,7 +916,7 @@ _merge_ready_prs_for_repo() {
 	local _timing_prefix="${6:-}"
 
 	local merged=0 closed=0 failed=0
-	local pr_json pr_merge_err _list_start pr_count
+	local pr_json="" pr_merge_err="" _list_start="" pr_count=""
 	_list_start=$(_pmp_now_epoch)
 	pr_merge_err=$(mktemp)
 	if declare -F pulse_pr_list_get >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Initialise the new pulse merge local declarations added by PR #26718 so the diff-scoped Pulse Unbound-Var gate stays clean.
- No behavior change beyond set-u-safe declarations.

## Verification
- `.agents/scripts/pulse-unbound-var-check.sh` against diff additions — no violations
- `.agents/scripts/tests/test-pulse-merge-pr-cursor-resume.sh`
- `.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh`
- `bash .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh`
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-pr-cursor-resume.sh`
- `.agents/scripts/linters-local.sh`

For #26708
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.71 with gpt-5.5 spent 1h 8m and 391,322 tokens on this with the user in an interactive session.