### PR TITLE
GH#26723: fix: suppress positive inline review acknowledgements

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -47,6 +47,7 @@ _build_inline_findings() {
 			"aidevops:review-thread-response|" +
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
+			"(?s:\\bthank you for the update\\b.*\\bimplementation\\b.*\\bcorrectly addresses?\\b.*\\brobust (approach|validation|handling)\\b)|" +
 			"\\bno further concerns?\\b|" +
 			"\\bno further feedback\\b|" +
 			"\\bno further recommendations?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -436,6 +436,19 @@ test_skips_pr25504_verification_ack() {
 	return 0
 }
 
+test_skips_pr26721_positive_implementation_ack() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update, @maintainer. The implementation in `cf2ad85` correctly addresses the issue by preserving the `read` condition to handle files without trailing newlines while explicitly filtering empty lines before logging. This is a robust approach for parsing file paths in shell scripts.","path":".agents/scripts/file-size-regression-helper.sh","line":227,"html_url":"https://example.invalid/review","created_at":"2026-07-06T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "26721" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip PR #26721 positive implementation acknowledgement" 0
+	else
+		print_result "skip PR #26721 positive implementation acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -251,6 +251,7 @@ main() {
 	test_skips_pr25362_race_condition_ack
 	test_skips_incorporates_necessary_synchronization_ack_without_race_phrase
 	test_skips_pr25504_verification_ack
+	test_skips_pr26721_positive_implementation_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Added a positive inline acknowledgement filter for Gemini review comments like PR #26721 that thank the maintainer, say the implementation correctly addresses the issue, and describe robust handling; added a regression test so the scanner returns zero findings for that positive acknowledgement.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh; bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh && shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #26723


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.72 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3m and 104,045 tokens on this as a headless worker.