### PR TITLE
GH#26725: clarify session title naming guidance

### DIFF
--- a/.agents/scripts/generate-opencode-commands-automation.sh
+++ b/.agents/scripts/generate-opencode-commands-automation.sh
@@ -36,7 +36,7 @@ Start a Ralph loop for iterative development.
 
 Arguments: $ARGUMENTS
 
-**Session Title**: Only set a session title if one hasn't been set already (e.g., by `/ralph-task`). If the prompt references issue/PR work, use `session-rename` with the work item first (`"Issue #123: concise summary"` or `"PR #456: concise summary"`). Otherwise use a concise version of the prompt (truncate to ~60 chars if needed).
+**Session Title**: Only set a session title if one hasn't been set already (e.g., by `/ralph-task`). If the prompt references issue/PR work, use `session-rename` with the work item and issue/PR title first (`"Issue #123: Fix dispatch title prefix"` or `"PR #456: Refresh auth workflow tests"`). Otherwise use a meaningful version of the prompt. Do not impose an arbitrary length limit; keep the automatically appended AIDevOps version suffix.
 
 **Usage:**
 ```bash

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -721,8 +721,8 @@ Setup shortcuts -- the dispatcher has already done these for you:
   are not running. Do NOT attempt to create a worktree yourself.
 - Do NOT call aidevops-update-check.sh -- it exits immediately for headless workers.
 - Do NOT call session-rename or session-rename_sync_branch -- your session title
-  is already set by the dispatcher with the issue marker first (for example,
-  `Issue #123: succinct description`).
+  is already set by the dispatcher with the issue marker and issue title first
+  (for example, `Issue #123: Fix dispatch title prefix`).
 
 Key framework file paths (use these directly, do NOT search for them):
 - Normal project repos: full-loop workflow is deployed at ~/.aidevops/agents/scripts/commands/full-loop.md

--- a/.agents/scripts/tests/test-headless-contract-clarity.sh
+++ b/.agents/scripts/tests/test-headless-contract-clarity.sh
@@ -72,17 +72,17 @@ export AIDEVOPS_BASH_REEXECED=1
 source "$LIB_FILE"
 
 # ---------------------------------------------------------------------------
-# Case 1: Contract marker is V8 (not the contradictory V6)
+# Case 1: Contract marker is V9 (not the contradictory V6)
 # ---------------------------------------------------------------------------
-test_contract_version_is_v8() {
+test_contract_version_is_v9() {
 	local output
 	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
 
-	if [[ "$output" == *"HEADLESS_CONTINUATION_CONTRACT_V8"* ]]; then
-		_pass "contract_version_is_v8"
+	if [[ "$output" == *"HEADLESS_CONTINUATION_CONTRACT_V9"* ]]; then
+		_pass "contract_version_is_v9"
 	else
-		_fail "contract_version_is_v8" \
-			"Expected HEADLESS_CONTINUATION_CONTRACT_V8 in output, not found"
+		_fail "contract_version_is_v9" \
+			"Expected HEADLESS_CONTINUATION_CONTRACT_V9 in output, not found"
 	fi
 	return 0
 }
@@ -235,7 +235,7 @@ test_graphql_rate_limit_fallback_guidance() {
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
-test_contract_version_is_v8
+test_contract_version_is_v9
 test_no_worktree_creation_fallback
 test_unconditional_do_not_call_worktree_helper
 test_no_simultaneous_prohibit_and_permit

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -717,7 +717,7 @@ test_deleted_launch_cwd_recovers_to_work_dir() {
 test_does_not_double_append() {
 	local prompt='/full-loop Continue issue #14964
 
-[HEADLESS_CONTINUATION_CONTRACT_V8]
+[HEADLESS_CONTINUATION_CONTRACT_V9]
 This worker run is unattended.'
 	local output
 	output=$(append_worker_headless_contract "$prompt")

--- a/.opencode/command/rename.md
+++ b/.opencode/command/rename.md
@@ -9,4 +9,8 @@ Rename this session to: $ARGUMENTS
 
 Use the session-rename tool to update the session title.
 
-For issue/PR work, keep the work item at the beginning, followed by a succinct description: `Issue #123: fix dispatch title prefix` or `PR #456: review auth workflow`.
+For issue/PR work, keep the work item at the beginning and include the issue/PR title or a recognizable title-based summary: `Issue #123: Fix dispatch title prefix` or `PR #456: Refresh auth workflow tests`.
+
+For generic follow-up work, preserve the source title and add the action at the end when useful: `PR #456: Refresh auth workflow tests — review thread`, not just `PR #456: review-thread response`.
+
+Do not impose an arbitrary length limit; prefer a title that is meaningfully distinguishable in the UI. Keep the automatically appended `· AIDevOps x.y.z` suffix.

--- a/.opencode/command/sync-branch.md
+++ b/.opencode/command/sync-branch.md
@@ -7,4 +7,4 @@ description: Sync session title with current git branch
 
 Use the session-rename_sync_branch tool to rename this session to match the current git branch name only when no issue/PR-prefixed title is already set.
 
-If working on an issue or PR, prefer an explicit title first: `Issue #123: succinct description` or `PR #456: succinct description`.
+If working on an issue or PR, prefer an explicit title first and include the issue/PR title or a recognizable shortened form: `Issue #123: Fix dispatch title prefix` or `PR #456: Refresh auth workflow tests`.

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -96,11 +96,11 @@ function syncSessionWithBranch(
 
 export default tool({
   description:
-    "Rename the current session to a new title. For issue/PR work, start titles with the issue or PR marker (for example, 'Issue #123: concise summary' or 'PR #456: concise summary') so tabs and session search group by the work item.",
+    "Rename the current session to a meaningful new title. For issue/PR work, start with the issue or PR marker and include the issue/PR title or a recognizable shortened form (for example, 'Issue #123: Fix dispatch title prefix' or 'PR #456: Refresh auth workflow tests') so tabs and session search remain distinguishable. The AIDevOps version suffix is appended automatically and should remain present.",
   args: {
     title: tool.schema
       .string()
-      .describe("New title for the session (prefer 'Issue #123: concise summary' or 'PR #456: concise summary' when working on an issue/PR; otherwise use a short branch/task summary)"),
+      .describe("New meaningful title for the session (for issue/PR work, prefer 'Issue #123: <issue title>' or 'PR #456: <PR title>'; add a short action suffix like '— review thread' only when helpful; otherwise use a meaningful branch/task summary; keep the automatically appended AIDevOps version suffix)"),
   },
   async execute(args, context) {
     const { sessionID } = context
@@ -124,7 +124,7 @@ export default tool({
 // repo on main must not clobber meaningful titles (t2252).
 export const sync_branch = tool({
   description:
-    "Rename the current session to match the current git branch name. Call this after creating or switching branches only when no issue/PR-prefixed title is already set; issue/PR work should keep 'Issue #123: ...' or 'PR #456: ...' at the beginning.",
+    "Rename the current session to match the current git branch name. Call this after creating or switching branches only when no issue/PR-prefixed title is already set; issue/PR work should keep 'Issue #123: <issue title>' or 'PR #456: <PR title>' at the beginning.",
   args: {},
   async execute(_args, context) {
     const { sessionID } = context


### PR DESCRIPTION
## Summary
- Prefer issue/PR session titles that include the actual issue/PR title or a recognizable title-based summary.
- Preserve source titles for follow-up work and append action context, e.g. `— review thread`, instead of vague titles.
- Avoid arbitrary session-title length limits and keep the automatically appended `· AIDevOps x.y.z` suffix.
- Update stale headless contract marker tests from V8 to V9.

Resolves #26725

## Verification
- `.agents/scripts/tests/test-session-rename-ts.mjs`
- `.agents/scripts/tests/test-headless-contract-clarity.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/generate-opencode-commands-automation.sh .agents/scripts/tests/test-headless-contract-clarity.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.72 plugin for [OpenCode](https://opencode.ai) v1.17.13
