### PR TITLE
test: preserve explicit queued status

### DIFF
--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -516,6 +516,20 @@ else
 		"status_count=$status_n line: $last"
 fi
 
+# B'8a: explicit queued status wins — this mirrors GH#20715's test fixture.
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --repo o/r --title "t2792: test-explicit-status-queued" --body "body" \
+	--label "status:queued,origin:worker,auto-dispatch" >/dev/null 2>&1
+status_n=$(count_status_labels_in_log)
+last=$(tail -1 "$GH_RECORD_FILE")
+if [[ "$status_n" == "1" && "$last" == *"status:queued"* && "$last" != *"status:available"* ]]; then
+	print_result "B'8a: gh_create_issue preserves explicit status:queued" 0
+else
+	print_result "B'8a: gh_create_issue preserves explicit status:queued" 1 \
+		"status_count=$status_n line: $last"
+fi
+
 # B'9: TODO-derived status wins — default status must inspect derived labels.
 # Regression for GH#23581: gh_create_issue filtered --todo-task-id from argv,
 # then checked only the filtered caller args for status labels. A status derived

--- a/TODO.md
+++ b/TODO.md
@@ -3319,7 +3319,7 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t2793 t2789: test-no-duplicates #auto-dispatch ref:GH#20716 pr:#2794 completed:2026-07-06
 
-- [x] t2792 t2789: test-explicit-status-queued #auto-dispatch ref:GH#20715 completed:2026-07-06
+- [x] t2792 t2789: test-explicit-status-queued #auto-dispatch ref:GH#20715 verified:2026-07-06 completed:2026-07-06
 
 - [x] t2795 t2789: final-test #auto-dispatch ref:GH#20718 pr:#2796 completed:2026-07-06
 

--- a/TODO.md
+++ b/TODO.md
@@ -3319,7 +3319,7 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t2793 t2789: test-no-duplicates #auto-dispatch ref:GH#20716 pr:#2794 completed:2026-07-06
 
-- [ ] t2792 t2789: test-explicit-status-queued #auto-dispatch ref:GH#20715
+- [x] t2792 t2789: test-explicit-status-queued #auto-dispatch ref:GH#20715 completed:2026-07-06
 
 - [x] t2795 t2789: final-test #auto-dispatch ref:GH#20718 pr:#2796 completed:2026-07-06
 


### PR DESCRIPTION
## Summary
- Adds a focused regression test proving `gh_create_issue` preserves explicit `status:queued` labels instead of injecting `status:available`.
- Marks t2792 / GH#20715 verified in TODO.md so issue-sync can close it with proof.

Resolves #20715

## Testing
- `.agents/scripts/tests/test-origin-label-mutex-create.sh` (28 tests, 0 failed)
- `.agents/scripts/linters-local.sh` passed early gates and timed out at Secretlint after 240s
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.76 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 6m and 62,174 tokens on this as a headless worker.