### PR TITLE
GH#26732: fix: guard optional vault collection preview policy

### DIFF
--- a/packages/gui-web/src/VaultBadges.tsx
+++ b/packages/gui-web/src/VaultBadges.tsx
@@ -12,7 +12,7 @@ export function vaultCollectionForSurface(
 
 export function isVaultSurfaceLocked(vault: GuiVaultStatusData, surface: SurfaceId): boolean {
   const collection = vaultCollectionForSurface(vault, surface);
-  return surface !== "vault" && collection?.encrypted === true && collection.preview_policy === "hidden_while_locked" && !vault.unlocked;
+  return surface !== "vault" && collection?.encrypted === true && collection?.preview_policy === "hidden_while_locked" && !vault.unlocked;
 }
 
 export function vaultCollectionTooltip(collection: GuiVaultCollectionSummary): string {


### PR DESCRIPTION
## Summary

Updated VaultBadges to use optional chaining when reading a vault collection preview policy after vaultCollectionForSurface can return undefined.

## Files Changed

packages/gui-web/src/VaultBadges.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run gui:typecheck; npm run gui:test:components

Resolves #26732


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.76 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 54,709 tokens on this as a headless worker.