### PR TITLE
t3023: fix: evict closed issues during dispatch

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -18,6 +18,7 @@
 # Usage:
 #   pulse-batch-prefetch-helper.sh refresh              # Fetch and cache
 #   pulse-batch-prefetch-helper.sh cache-path --kind issues --slug owner/repo
+#   pulse-batch-prefetch-helper.sh evict-issue owner/repo 123
 #   pulse-batch-prefetch-helper.sh clear                # Wipe cache
 #   pulse-batch-prefetch-helper.sh status               # Show cache ages
 #
@@ -845,6 +846,41 @@ _cmd_read_cache() {
 }
 
 # =============================================================================
+# Subcommand: evict-issue
+# Remove a single issue from the normalized owner/repo issues cache.
+# Arguments: owner/repo issue_number
+# =============================================================================
+_cmd_evict_issue() {
+	local slug="$1"
+	local issue_number="$2"
+
+	if [[ -z "$slug" || -z "$issue_number" ]]; then
+		echo "Usage: pulse-batch-prefetch-helper.sh evict-issue owner/repo issue_number" >&2
+		return 1
+	fi
+
+	_check_enabled || return 0
+
+	local cache_file
+	cache_file=$(_cache_file_path "$_KIND_ISSUES" "$slug")
+	if [[ ! -f "$cache_file" ]]; then
+		return 0
+	fi
+
+	local tmp_file
+	tmp_file=$(mktemp)
+	if jq --argjson issue_number "$issue_number" '(.items // []) as $items | .items = [$items[] | select((.number // 0) != $issue_number)]' "$cache_file" >"$tmp_file" 2>/dev/null; then
+		mv "$tmp_file" "$cache_file"
+		_log "evicted issue #${issue_number} from issues cache for ${slug}"
+		return 0
+	fi
+
+	rm -f "$tmp_file"
+	_log "failed to evict issue #${issue_number} from issues cache for ${slug}"
+	return 1
+}
+
+# =============================================================================
 # Subcommand: clear
 # =============================================================================
 _cmd_clear() {
@@ -931,6 +967,9 @@ main() {
 	read-cache)
 		_cmd_read_cache "$@"
 		;;
+	evict-issue)
+		_cmd_evict_issue "$@"
+		;;
 	clear)
 		_cmd_clear
 		;;
@@ -944,6 +983,7 @@ main() {
 		echo "  refresh                          Fetch all repos via org-level search and cache"
 		echo "  cache-path --kind K --slug S     Return cache path if fresh, exit 1 if stale"
 		echo "  read-cache --kind K --slug S     Read cached items as JSON array"
+		echo "  evict-issue owner/repo N         Remove one issue from the issues cache"
 		echo "  clear                            Wipe batch cache directory"
 		echo "  status                           Show cache file ages and counts"
 		echo ""

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1595,6 +1595,13 @@ dispatch_with_dedup() {
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to load issue metadata" >>"$LOGFILE"
 		return 1
 	fi
+	local issue_state
+	issue_state=$(printf '%s' "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null | tr '[:lower:]' '[:upper:]') || issue_state=""
+	if [[ "$issue_state" == "CLOSED" ]]; then
+		echo "[dispatch] Skipping #${issue_number}: state=CLOSED" >>"$LOGFILE"
+		pulse-batch-prefetch-helper.sh evict-issue "$repo_slug" "$issue_number" 2>/dev/null || true
+		return 1
+	fi
 
 	# GH#22948: hard PR-target guard before any lifecycle mutation. A pull
 	# request shares the Issues API number space, but it is already an


### PR DESCRIPTION
## Summary

Added a closed-state guard after dispatch metadata load and evicted stale closed issues from the batch-prefetch issues cache.

## Files Changed

.agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/pulse-dispatch-core.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-batch-prefetch-helper.sh; shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-batch-prefetch-helper.sh; temp-cache evict-issue smoke test with jq assertion

Resolves #21580


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.76 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 54,693 tokens on this as a headless worker.