### PR TITLE
GH#26733: fix: harden positive review acknowledgement filter

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -47,7 +47,7 @@ _build_inline_findings() {
 			"aidevops:review-thread-response|" +
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
-			"(?s:\\bthank you for the update\\b.*\\bimplementation\\b.*\\bcorrectly addresses?\\b.*\\brobust (approach|validation|handling)\\b)|" +
+			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 			"\\bno further concerns?\\b|" +
 			"\\bno further feedback\\b|" +
 			"\\bno further recommendations?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -449,6 +449,19 @@ test_skips_pr26721_positive_implementation_ack() {
 	return 0
 }
 
+test_skips_positive_implementation_ack_with_address_variants() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The implementation in `abc1234` correctly addressed the edge case by using explicit validation across a long review body with several clauses. This is a robust validation pattern for shell helpers.","path":".agents/scripts/example-helper.sh","line":42,"html_url":"https://example.invalid/review","created_at":"2026-07-06T00:00:00Z"},{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update. The implementation now correctly address the issue by preserving the intended branch behavior across a long review body with several clauses. This is a robust handling pattern for shell helpers.","path":".agents/scripts/example-helper.sh","line":43,"html_url":"https://example.invalid/review","created_at":"2026-07-06T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "26733" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip positive implementation acknowledgement address variants" 0
+	else
+		print_result "skip positive implementation acknowledgement address variants" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -252,6 +252,7 @@ main() {
 	test_skips_incorporates_necessary_synchronization_ack_without_race_phrase
 	test_skips_pr25504_verification_ack
 	test_skips_pr26721_positive_implementation_ack
+	test_skips_positive_implementation_ack_with_address_variants
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Updated the inline acknowledgement suppression regex in .agents/scripts/quality-feedback-findings-lib.sh to match correctly address/addressed/addresses variants while using non-greedy dotall wildcards, then added regression coverage for the address variants in the quality-feedback verification suite.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (68/68 passed)

Resolves #26733


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.76 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 46,595 tokens on this as a headless worker.