### PR TITLE
fix: dedupe claim task labels

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -366,11 +366,40 @@ _validate_and_normalize_args() {
 		local _normalised_labels=""
 		_normalised_labels=$(map_tags_to_labels "$TASK_LABELS" 2>/dev/null) || true
 		[[ -n "$_normalised_labels" ]] && TASK_LABELS="$_normalised_labels"
+		TASK_LABELS=$(_dedupe_csv_labels "$TASK_LABELS")
 	fi
 
 	# GH#21991: advisory structural check on --description before issue creation.
 	# Non-blocking by default; set AIDEVOPS_BODY_FORMAT_STRICT=1 to hard-fail.
 	_validate_description_format
+	return 0
+}
+
+# _dedupe_csv_labels — preserve first occurrence while removing duplicate labels.
+# GitHub ultimately deduplicates applied labels, but keeping the argv clean avoids
+# duplicate-label warnings/noise in tests and wrapper fallbacks.
+_dedupe_csv_labels() {
+	local labels_csv="$1"
+	local saved_ifs="$IFS"
+	local result=""
+	local label=""
+	local trimmed=""
+	IFS=','
+	for label in $labels_csv; do
+		trimmed="${label#"${label%%[![:space:]]*}"}"
+		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+		[[ -z "$trimmed" ]] && continue
+		if [[ ",${result}," == *",${trimmed},"* ]]; then
+			continue
+		fi
+		if [[ -n "$result" ]]; then
+			result="${result},${trimmed}"
+		else
+			result="$trimmed"
+		fi
+	done
+	IFS="$saved_ifs"
+	printf '%s\n' "$result"
 	return 0
 }
 
@@ -578,6 +607,7 @@ create_github_issue() {
 			labels="status:available"
 		fi
 	fi
+	[[ -n "$labels" ]] && labels=$(_dedupe_csv_labels "$labels")
 
 	# Pass labels to gh_create_issue; origin label is appended automatically by
 	# the wrapper (avoids duplicate-label injection, t3039).

--- a/.agents/scripts/tests/test-claim-task-id-status-default.sh
+++ b/.agents/scripts/tests/test-claim-task-id-status-default.sh
@@ -158,6 +158,10 @@ args_explicit=$(run_create 'auto-dispatch,status:blocked,tier:standard')
 assert_contains "explicit_status_preserved" "$args_explicit" '--label auto-dispatch,status:blocked,tier:standard'
 assert_not_contains "explicit_status_no_default" "$args_explicit" 'status:available'
 
+args_duplicate=$(run_create 'auto-dispatch,tier:standard,auto-dispatch,status:available,tier:standard')
+assert_contains "duplicate_labels_collapsed" "$args_duplicate" '--label auto-dispatch,tier:standard,status:available'
+assert_not_contains "duplicate_labels_no_repeat" "$args_duplicate" 'auto-dispatch,tier:standard,auto-dispatch'
+
 if [[ $FAIL -eq 0 ]]; then
 	printf '%sAll claim-task-id status default tests passed%s (%d assertions)\n' "$GREEN" "$NC" "$PASS"
 	exit 0


### PR DESCRIPTION
Summary:
Deduplicate repeated labels before claim-task issue creation.

Testing:
status default regression passed
shell lint passed

Resolves #20717
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.76 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 4m and 70,815 tokens on this as a headless worker.