### PR TITLE
GH#26745: fix issue-sync not-planned reopen guard

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -178,6 +178,14 @@ _has_prior_reopen_comment() {
 	return 1
 }
 
+_is_not_planned_state_reason() {
+	local reason="$1"
+	local normalized
+	normalized=$(printf '%s' "$reason" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
+	[[ "$normalized" == "not_planned" ]] && return 0
+	return 1
+}
+
 # Mark a TODO entry as done: [ ] -> [x] with completed: date.
 # Also handles [-] (cancelled/declined) entries — leaves marker as [-].
 _mark_todo_done() {
@@ -482,11 +490,14 @@ cmd_reopen() {
 		local tid
 		tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
 
-		# Check closure reason — skip NOT_PLANNED (deliberately declined)
+		# Check closure reason — skip not_planned (deliberately declined).
+		# GitHub GraphQL returns NOT_PLANNED while REST returns not_planned;
+		# normalize before comparing so consolidated/not-planned tasks are not
+		# accidentally reopened by the TODO source-of-truth guard.
 		local reason
 		reason=$(printf '%s\n' "$issue_json" | jq -r 'select(type == "object") | .state_reason // .stateReason // ""' 2>/dev/null || printf '')
-		if [[ "$reason" == "NOT_PLANNED" ]]; then
-			log_verbose "#$ref_num ($tid) closed as NOT_PLANNED — skipping"
+		if _is_not_planned_state_reason "$reason"; then
+			log_verbose "#$ref_num ($tid) closed as not_planned — skipping"
 			not_planned=$((not_planned + 1))
 			continue
 		fi

--- a/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
+++ b/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
@@ -85,6 +85,10 @@ check_failure "unexpected issue payloads are not treated as PRs" _reopen_ref_is_
 check_success "prior canonical reopen comments are detected" _has_prior_reopen_comment "owner/repo" "202"
 check_failure "unrelated comments do not suppress reopen" _has_prior_reopen_comment "owner/repo" "203"
 check_failure "unexpected comments payloads do not suppress reopen" _has_prior_reopen_comment "owner/repo" "204"
+check_success "GraphQL NOT_PLANNED reason is skipped" _is_not_planned_state_reason "NOT_PLANNED"
+check_success "REST not_planned reason is skipped" _is_not_planned_state_reason "not_planned"
+check_success "hyphenated not-planned reason is skipped" _is_not_planned_state_reason "not-planned"
+check_failure "completed reason is not treated as not planned" _is_not_planned_state_reason "COMPLETED"
 
 printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Normalize GitHub closure reasons before the TODO reopen guard decides whether a closed task was deliberately not planned, preventing REST not_planned issues from being reopened.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-issue-sync-reopen-churn.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-issue-sync-reopen-churn.sh; .agents/scripts/tests/test-issue-sync-close-signature.sh; shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-reopen-churn.sh .agents/scripts/tests/test-issue-sync-close-signature.sh; .agents/scripts/linters-local.sh --changed

Resolves #26745


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.77 with gpt-5.5 spent 10m and 340,366 tokens on this with the user in an interactive session.