### PR TITLE
Fix ref:none tracked task false success

### DIFF
--- a/.agents/scripts/issue-sync-helper-push.sh
+++ b/.agents/scripts/issue-sync-helper-push.sh
@@ -91,6 +91,17 @@ _push_auto_assign_interactive() {
 	return 0
 }
 
+# _push_create_issue_without_labels: degraded creation path for tokens that can
+# create issues but cannot read/apply repository labels. Labels can be repaired
+# by a later enrich/reconcile pass; the durable tracker issue is the invariant.
+_push_create_issue_without_labels() {
+	local repo="$1" title="$2" body="$3" assignee="$4"
+	local -a fallback_args=("--repo" "$repo" "--title" "$title" "--body" "$body")
+	[[ -n "$assignee" ]] && fallback_args+=("--assignee" "$assignee")
+	gh issue create "${fallback_args[@]}" 2>&1 # aidevops-allow: raw-gh-wrapper
+	return $?
+}
+
 # _push_create_issue: create a GitHub issue for task_id with race-condition guard.
 # Sets _PUSH_CREATED_NUM on success (empty on failure/skip).
 # Returns 0=created, 1=skipped (race), 2=error.
@@ -140,6 +151,13 @@ _push_create_issue() {
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, retrying issue create via REST for $task_id"
 		{
 			combined=$(_rest_issue_create "${args[@]}" 2>&1)
+			gh_exit=$?
+		} || true
+	fi
+	if [[ $gh_exit -ne 0 && "$combined" == *"repository.labels"* ]]; then
+		print_warning "Label lookup failed for $task_id; retrying issue creation without labels"
+		{
+			combined=$(_push_create_issue_without_labels "$repo" "$title" "$body" "$assignee")
 			gh_exit=$?
 		} || true
 	fi
@@ -245,13 +263,19 @@ cmd_push() {
 	print_info "Processing ${#tasks[@]} task(s) for push to $repo"
 	gh_create_label "$repo" "status:available" "0E8A16" "Task is available for claiming"
 
-	local created=0 skipped=0
+	local created=0 skipped=0 failed=0
 	for task_id in "${tasks[@]}"; do
 		local result
-		result=$(_push_process_task "$task_id" "$repo" "$todo_file" "$project_root")
+		if ! result=$(_push_process_task "$task_id" "$repo" "$todo_file" "$project_root"); then
+			failed=$((failed + 1))
+		fi
 		[[ "$result" == *"CREATED"* ]] && created=$((created + 1))
 		[[ "$result" == *"SKIPPED"* ]] && skipped=$((skipped + 1))
 	done
-	print_info "Push complete: $created created, $skipped skipped"
+	print_info "Push complete: $created created, $skipped skipped, $failed failed"
+	if [[ $failed -gt 0 ]]; then
+		print_error "Issue creation failed for $failed task(s); TODO.md still contains active task(s) without GitHub refs"
+		return 1
+	fi
 	return 0
 }

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -246,6 +246,9 @@ _push_process_task() {
 		echo "CREATED"
 	elif [[ $rc -eq 1 ]]; then
 		echo "SKIPPED"
+	else
+		echo "FAILED"
+		return 1
 	fi
 	return 0
 }

--- a/.agents/scripts/new-task-helper.sh
+++ b/.agents/scripts/new-task-helper.sh
@@ -205,6 +205,34 @@ _append_todo_entry() {
 	return 0
 }
 
+# Resolve a pending ref:none task after TODO.md and the brief exist. This keeps
+# GitHub-backed /new-task flows from reporting success before the tracker issue
+# is durable. Explicit --offline/--no-issue flows bypass this helper.
+_resolve_pending_task_ref() {
+	local task_id="$1" task_ref="$2" repo_path="$3" todo_file="$4"
+	[[ "$task_ref" != "none" ]] && { printf '%s\n' "$task_ref"; return 0; }
+
+	local sync_helper="$SCRIPT_DIR/issue-sync-helper.sh"
+	if [[ ! -x "$sync_helper" ]]; then
+		log_error "Cannot resolve $task_id ref:none — issue-sync-helper.sh is missing"
+		return 1
+	fi
+	if ! (cd "$repo_path" && "$sync_helper" push "$task_id" >/dev/null); then
+		log_error "Tracker issue creation failed for $task_id"
+		return 1
+	fi
+
+	local refreshed_ref=""
+	refreshed_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" "$todo_file" \
+		| grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
+	if [[ -z "$refreshed_ref" ]]; then
+		log_error "Tracker issue creation left $task_id without ref:GH# in TODO.md"
+		return 1
+	fi
+	printf '%s\n' "$refreshed_ref"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # cmd_batch decomposition (GH#18705)
 #
@@ -500,6 +528,9 @@ _process_one_batch_title() {
 
 	_append_todo_entry "$task_id" "$title" "$task_ref" "$todo_file" ||
 		log_warn "TODO entry failed for $task_id — continuing"
+	if [[ "$_BATCH_NO_ISSUE" != "true" && "$_BATCH_OFFLINE" != "true" ]]; then
+		task_ref=$(_resolve_pending_task_ref "$task_id" "$task_ref" "$repo_path" "$todo_file") || return 1
+	fi
 
 	_BATCH_RESULT_IDS+=("$task_id")
 	_BATCH_RESULT_TITLES+=("$title")

--- a/.agents/scripts/tests/test-issue-sync-push-failures.sh
+++ b/.agents/scripts/tests/test-issue-sync-push-failures.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$ROOT_DIR/.agents/scripts/issue-sync-helper-push.sh"
+
+pass() { printf 'PASS: %s\n' "$1"; return 0; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+print_info() { printf '[INFO] %s\n' "$*"; return 0; }
+print_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
+print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
+
+# shellcheck source=../issue-sync-helper-push.sh
+source "$HELPER"
+
+_init_cmd() {
+	_CMD_REPO="example/repo"
+	_CMD_TODO="/tmp/todo.md"
+	_CMD_ROOT="/tmp"
+	return 0
+}
+
+gh_create_label() { return 0; }
+_push_build_task_list() { printf 't999\n'; return 0; }
+
+_push_process_task() {
+	local task_id="$1"
+	printf 'FAILED\n'
+	[[ "$task_id" == "t999" ]] || return 1
+	return 1
+}
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+GITHUB_ACTIONS=true
+FORCE_PUSH=false
+if cmd_push "" >"$TMPDIR_TEST/push.out" 2>"$TMPDIR_TEST/push.err"; then
+	fail "cmd_push succeeded despite failed issue creation"
+fi
+grep -q '1 failed' "$TMPDIR_TEST/push.out" || fail "cmd_push did not report failed task count"
+grep -q 'Issue creation failed' "$TMPDIR_TEST/push.err" || fail "cmd_push did not emit actionable failure"
+pass "cmd_push returns non-zero when issue creation fails"
+
+cat >"$TMPDIR_TEST/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "issue create" ]]; then
+	printf 'https://github.com/example/repo/issues/123\n'
+	exit 0
+fi
+exit 1
+GH_EOF
+chmod +x "$TMPDIR_TEST/gh"
+PATH="$TMPDIR_TEST:$PATH"
+
+fallback_output=$(_push_create_issue_without_labels "example/repo" "t999: title" "body" "") || \
+	fail "degraded issue creation helper failed"
+[[ "$fallback_output" == *"/issues/123"* ]] || fail "degraded issue creation helper lost issue URL"
+pass "degraded issue creation without labels preserves durable tracker creation"

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -39,6 +39,7 @@ done <<< "$output"
 ```
 
 Output variables: `TASK_ID=tNNN`, `TASK_REF=GH#NNN`, `TASK_ISSUE_URL=https://...`, `TASK_OFFLINE=false`.
+If `TASK_REF=none` and `TASK_OFFLINE=false`, treat it as a pending tracker issue, not a completed tracked task. Do not present it as filed or run issue-number operations yet; continue only until the brief/TODO entry exists, then run Step 4.5 before presenting success.
 
 ### Step 2: Present to User
 
@@ -57,7 +58,7 @@ Options:
 
 ```bash
 REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
-if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
+if [[ -n "$task_ref" && "$task_ref" != "none" && "$task_ref" != "offline" && -n "$REPO_SLUG" ]]; then
   ISSUE_NUM="${task_ref#GH#}"
   WORKER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
   gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" \
@@ -138,6 +139,24 @@ Narrative phases without a per-phase marker are NOT auto-filed unless `<!-- phas
 
 ```markdown
 - [ ] {task_id} {title} #{tag} #{origin} ~{estimate} ref:{task_ref} logged:{YYYY-MM-DD}
+```
+
+### Step 4.5: Resolve Pending Tracker Ref
+
+For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state. Unless the user explicitly requested `--offline`, `--no-issue`, or local-only planning, create and verify the tracker after the TODO entry and brief exist:
+
+```bash
+if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
+  ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
+  task_ref=$(grep -E "^[[:space:]]*- \[[ x]\] ${task_id} " TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://')
+  [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
+fi
+```
+
+Before reporting the task as filed, verify the issue exists:
+
+```bash
+gh issue view "${task_ref#GH#}" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" >/dev/null
 ```
 
 `#{origin}`: `#interactive` (user present) or `#worker` (headless). Detect via `detect_session_origin` from `shared-constants.sh`. Maps to `origin:interactive` / `origin:worker` GitHub labels on issue sync.

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -58,7 +58,7 @@ Options:
 
 ```bash
 REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
-if [[ -n "$task_ref" && "$task_ref" != "none" && "$task_ref" != "offline" && -n "$REPO_SLUG" ]]; then
+if [[ -n "${task_ref:-}" && "${task_ref:-}" != "none" && "${task_ref:-}" != "offline" && -n "$REPO_SLUG" ]]; then
   ISSUE_NUM="${task_ref#GH#}"
   WORKER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
   gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" \
@@ -148,7 +148,7 @@ For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state.
 ```bash
 if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
   ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
-  task_ref=$(grep -E "^[[:space:]]*- \[[ x]\] ${task_id} " TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://')
+  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
   [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
 fi
 ```

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -127,7 +127,7 @@ jobs:
         if: steps.check-author.outputs.skip != 'true'
         run: |
           echo "=== Creating issues for new tasks ==="
-          bash __aidevops/.agents/scripts/issue-sync-helper.sh push --verbose || true
+          bash __aidevops/.agents/scripts/issue-sync-helper.sh push --verbose
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
           # t1984: override origin detection and assignee target so issues


### PR DESCRIPTION
## Summary
- Treat `ref:none` as a pending tracker state in `/new-task` guidance and batch helper flows.
- Resolve pending refs after TODO/brief creation via `issue-sync-helper.sh push <task_id>` and fail if no `ref:GH#NNN` is produced.
- Propagate issue creation failures from issue-sync push and fail the reusable workflow instead of masking them.
- Add degraded issue creation without labels when GitHub label lookup fails with `repository.labels`.
- Add regression coverage for failed push propagation and label-degraded issue creation.

Resolves #26742

## Verification
- `bash .agents/scripts/tests/test-issue-sync-push-failures.sh`
- `shellcheck .agents/scripts/new-task-helper.sh .agents/scripts/issue-sync-helper.sh .agents/scripts/issue-sync-helper-push.sh .agents/scripts/tests/test-issue-sync-push-failures.sh`
- `.agents/scripts/linters-local.sh` (passed; pre-existing/advisory warnings only)
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.78 with gpt-5.5 spent 50m and 265,382 tokens on this with the user in an interactive session.