### PR TITLE
GH#26747: fix: initialise pulse prefetch locals

### DIFF
--- a/.agents/scripts/pulse-prefetch-orchestration.sh
+++ b/.agents/scripts/pulse-prefetch-orchestration.sh
@@ -279,7 +279,7 @@ check_repo_pulse_interval() {
 		[[ "$val" =~ ^[0-9]+$ ]] && last_polled="$val"
 	fi
 
-	local now elapsed
+	local now=0 elapsed=0
 	now=$(date +%s)
 	elapsed=$((now - last_polled))
 
@@ -384,7 +384,7 @@ check_repo_pulse_schedule() {
 		# (bash treats 08/09 as invalid octal without the 10# prefix)
 		local current_hour
 		current_hour=$(date +%H)
-		local cur ph_s ph_e
+		local cur=0 ph_s=0 ph_e=0
 		cur=$((10#${current_hour}))
 		ph_s=$((10#${ph_start}))
 		ph_e=$((10#${ph_end}))
@@ -505,7 +505,7 @@ check_repo_tier_skip() {
 		[[ "$val" =~ ^[0-9]+$ ]] && last_check="$val"
 	fi
 
-	local now elapsed
+	local now=0 elapsed=0
 	now=$(date +%s)
 	elapsed=$((now - last_check))
 

--- a/.agents/scripts/pulse-prefetch-repo.sh
+++ b/.agents/scripts/pulse-prefetch-repo.sh
@@ -52,7 +52,7 @@ _prefetch_single_repo_idle_skip() {
 	echo "> LLM may skip deep analysis of this repo this cycle."
 	echo ""
 
-	local _cached_prs _cached_issues _cached_pr_count _cached_issue_count
+	local _cached_prs="" _cached_issues="" _cached_pr_count=0 _cached_issue_count=0
 	_cached_prs=$(echo "$cache_entry" | jq -c '.prs // []' 2>/dev/null) || _cached_prs="[]"
 	_cached_issues=$(echo "$cache_entry" | jq -c '.issues // []' 2>/dev/null) || _cached_issues="[]"
 	_cached_pr_count=$(echo "$_cached_prs" | jq 'length' 2>/dev/null) || _cached_pr_count=0
@@ -91,7 +91,7 @@ _prefetch_single_repo_idle_skip() {
 
 	# Replay cached issue sections using same filter logic as _prefetch_repo_issues
 	# GH#20048: shared helper replaces inline jq non-task filter
-	local _filtered_cached _disp_json _sweep_json _disp_count _sweep_count
+	local _filtered_cached="" _disp_json="" _sweep_json="" _disp_count=0 _sweep_count=0
 	_filtered_cached=$(echo "$_cached_issues" | _filter_non_task_issues)
 	_disp_json=$(echo "$_filtered_cached" | jq -c '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")) | not)]' 2>/dev/null) || _disp_json="[]"
 	_sweep_json=$(echo "$_filtered_cached" | jq -c '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")))]' 2>/dev/null) || _sweep_json="[]"


### PR DESCRIPTION
## Summary

Initialised multi-variable local declarations in pulse prefetch helpers so the Pulse Unbound-Var Lint gate no longer flags the split prefetch modules.

## Files Changed

.agents/scripts/pulse-prefetch-orchestration.sh, .agents/scripts/pulse-prefetch-repo.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-prefetch-orchestration.sh .agents/scripts/pulse-prefetch-repo.sh; GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 bash .agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh; GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 bash .agents/scripts/tests/test-puv-diff-scoping.sh; shellcheck .agents/scripts/pulse-prefetch-orchestration.sh .agents/scripts/pulse-prefetch-repo.sh

Resolves #26747


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.78 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 58,177 tokens on this as a headless worker.