### PR TITLE
fix: restore sudo gh auth recovery

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -155,7 +155,13 @@ _approval_user_gh_token() {
 	local real_home=""
 	real_home=$(_resolve_real_home)
 	local gh_home_env="HOME=${real_home}"
+	local gh_bin=""
+	gh_bin=$(type -P gh 2>/dev/null || command -v gh 2>/dev/null || true)
 	local token=""
+
+	if [[ -z "$gh_bin" ]]; then
+		return 1
+	fi
 
 	# Linux: reconnect to the user's D-Bus session so gh can reach keyring-backed auth.
 	if [[ -n "$real_uid" && -S "/run/user/${real_uid}/bus" ]] && command -v runuser &>/dev/null; then
@@ -163,7 +169,7 @@ _approval_user_gh_token() {
 			"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${real_uid}/bus" \
 			"XDG_RUNTIME_DIR=/run/user/${real_uid}" \
 			"$gh_home_env" \
-			gh auth token 2>/dev/null || true)
+			"$gh_bin" auth token 2>/dev/null || true)
 		if [[ -n "$token" ]]; then
 			printf '%s' "$token"
 			return 0
@@ -173,7 +179,7 @@ _approval_user_gh_token() {
 	# macOS: run in the invoking user's launchd session so gh can reach Keychain.
 	if [[ -n "$real_uid" ]] && command -v launchctl &>/dev/null && command -v sudo &>/dev/null; then
 		token=$(launchctl asuser "$real_uid" sudo -u "$SUDO_USER" -H env \
-			"$gh_home_env" gh auth token 2>/dev/null || true)
+			"$gh_home_env" "$gh_bin" auth token 2>/dev/null || true)
 		if [[ -n "$token" ]]; then
 			printf '%s' "$token"
 			return 0
@@ -183,7 +189,7 @@ _approval_user_gh_token() {
 	# Portable fallback for non-keyring gh storage and sudo configurations that
 	# permit root to switch back to the invoking user without another password.
 	if command -v sudo &>/dev/null; then
-		token=$(sudo -u "$SUDO_USER" -H env "$gh_home_env" gh auth token 2>/dev/null || true)
+		token=$(sudo -u "$SUDO_USER" -H env "$gh_home_env" "$gh_bin" auth token 2>/dev/null || true)
 		if [[ -n "$token" ]]; then
 			printf '%s' "$token"
 			return 0

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -153,10 +153,12 @@ run_case "sudo gh auth recovery uses absolute gh binary when sudo path is restri
 	getent() { return 1; }
 	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
 	launchctl() {
-		shift 8
-		if [[ "${1:-}" == "$tmpdir/gh" && "${2:-}" == "auth" && "${3:-}" == "token" ]]; then
-			"$@"
-			return $?
+		if [[ "$#" -ge 8 ]]; then
+			shift 8
+			if [[ "${1:-}" == "$tmpdir/gh" && "${2:-}" == "auth" && "${3:-}" == "token" ]]; then
+				"$@"
+				return $?
+			fi
 		fi
 		return 1
 	}

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -134,6 +134,46 @@ run_case "sudo gh auth recovers token from invoking macOS user session" '
 assert_not_contains "recovered token is not printed" "$LAST_OUTPUT" "mac-user-token"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth recovery uses absolute gh binary when sudo path is restricted" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	tmpdir=$(mktemp -d)
+	trap '\''rm -rf "$tmpdir"'\'' EXIT
+	printf '\''#!/usr/bin/env bash\nif [[ "$1 $2" == "auth token" ]]; then printf path-token; exit 0; fi\nexit 1\n'\'' >"$tmpdir/gh"
+	chmod +x "$tmpdir/gh"
+	export PATH="$tmpdir:$PATH"
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() {
+		shift 8
+		if [[ "${1:-}" == "$tmpdir/gh" && "${2:-}" == "auth" && "${3:-}" == "token" ]]; then
+			"$@"
+			return $?
+		fi
+		return 1
+	}
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" && "${GH_TOKEN:-}" == "path-token" ]]; then return 0; fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 0
+assert_not_contains "absolute path recovered token is not printed" "$LAST_OUTPUT" "path-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "sudo gh auth failure reports recovery failure without token leakage" '
 	set -uo pipefail
 	export SUDO_USER=alice


### PR DESCRIPTION
Resolves #26750

## Summary

- restore sudo approval gh auth recovery by resolving and reusing the absolute gh binary path
- cover restricted sudo PATH recovery so nested launchctl/sudo -u calls keep using the user-authenticated gh binary

## Verification

- bash .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
- shellcheck .agents/scripts/approval-helper.sh .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
- manual: sudo aidevops approve issue 26742 worked after deploying the fix
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.78 with gpt-5.5 spent 20m and 186,771 tokens on this with the user in an interactive session.