### PR TITLE
GH#26752: fix: guide pulse unbound-var failure miner issues

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -769,7 +769,10 @@ render_issue_body_markdown() {
 			else "" end;
 		def qlty_empty_sarif_signature($check_name; $signature):
 			(($check_name | test("Qlty[[:space:]]+Smell[[:space:]]+Threshold"; "i"))
-			 and ($signature | test("empty[[:space:]-]*SARIF"; "i")));
+				 and ($signature | test("empty[[:space:]-]*SARIF"; "i")));
+		def pulse_unbound_var_signature($check_name; $signature):
+			(($check_name | test("Pulse[[:space:]]+Unbound-Var[[:space:]]+Lint"; "i"))
+				 or ($signature | test("Pulse unbound-var violations found|multi-var local without init|pulse-unbound-var"; "i")));
 		def systemic_fix_guidance($check_name; $signature):
 			if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
 				"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
@@ -787,6 +790,14 @@ render_issue_body_markdown() {
 				"1. Edit `.agents/scripts/qlty-smell-threshold-helper.sh` and `.github/workflows/code-quality.yml`; do not change application files to satisfy an empty-SARIF signature.\n" +
 				"2. Add or update `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh` to cover empty, valid-pass, and valid-fail SARIF paths.\n" +
 				"3. Run `shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh` plus the focused qlty threshold helper test before opening a PR.\n"
+			elif pulse_unbound_var_signature($check_name; $signature) then
+				"- Pulse Unbound-Var Lint is a PR-specific shell safety gate; repeated failures usually mean multiple PR branches introduced `local foo bar` declarations, not that the workflow itself is broken.\n" +
+				"- Read the `<!-- pulse-unbound-var-check -->` PR comment or failed log report and fix the listed `pulse-*.sh` files by initialising every local variable at declaration time.\n" +
+				"- Only edit `.github/workflows/pulse-unbound-var-check.yml` or `.agents/scripts/pulse-unbound-var-check.sh` when the reported file lines are false positives or the report cannot identify the offending lines.\n" +
+				"\n## Worker Guidance\n" +
+				"1. Open each Evidence PR comment containing `<!-- pulse-unbound-var-check -->`; use the reported file paths and line numbers as the authoritative target list.\n" +
+				"2. Fix each listed declaration with explicit initialisers, e.g. `local now=0 elapsed=0` or `local _cached_prs=\"\" _cached_issues=\"\"`.\n" +
+				"3. Run `.agents/scripts/pulse-unbound-var-check.sh --scan-files <changed pulse scripts>` plus `shellcheck` on the changed shell files before opening a PR.\n"
 			else
 				"- Patch the failing workflow/check once at the source (workflow file, shared action, or toolchain pin), then rerun failed checks on affected PRs.\n" +
 				"- Add a regression guard to detect this signature early in future pulses.\n"
@@ -938,7 +949,10 @@ build_issue_body() {
 				else "" end;
 			def qlty_empty_sarif_signature($check_name; $signature):
 				(($check_name | test("Qlty[[:space:]]+Smell[[:space:]]+Threshold"; "i"))
-				 and ($signature | test("empty[[:space:]-]*SARIF"; "i")));
+					 and ($signature | test("empty[[:space:]-]*SARIF"; "i")));
+			def pulse_unbound_var_signature($check_name; $signature):
+				(($check_name | test("Pulse[[:space:]]+Unbound-Var[[:space:]]+Lint"; "i"))
+					 or ($signature | test("Pulse unbound-var violations found|multi-var local without init|pulse-unbound-var"; "i")));
 			def systemic_fix_guidance($check_name; $signature):
 				if (($check_name | test("CodeFactor"; "i")) or ($signature == "failure:codefactor.io")) then
 					"- CodeFactor is an external advisory/static-analysis check. GitHub Actions logs usually only show `failure:codefactor.io`; read the CodeFactor details URL in Evidence for the file, line, and rule.\n" +
@@ -957,6 +971,14 @@ build_issue_body() {
 					"1. Edit `.agents/scripts/qlty-smell-threshold-helper.sh` and `.github/workflows/code-quality.yml`; do not change application files to satisfy an empty-SARIF signature.\n" +
 					"2. Add or update `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh` to cover empty, valid-pass, and valid-fail SARIF paths.\n" +
 					"3. Run `shellcheck .agents/scripts/qlty-smell-threshold-helper.sh .agents/scripts/tests/test-qlty-smell-threshold-helper.sh` plus the focused qlty threshold helper test before opening a PR.\n"
+				elif pulse_unbound_var_signature($check_name; $signature) then
+					"- Pulse Unbound-Var Lint is a PR-specific shell safety gate; repeated failures usually mean multiple PR branches introduced `local foo bar` declarations, not that the workflow itself is broken.\n" +
+					"- Read the `<!-- pulse-unbound-var-check -->` PR comment or failed log report and fix the listed `pulse-*.sh` files by initialising every local variable at declaration time.\n" +
+					"- Only edit `.github/workflows/pulse-unbound-var-check.yml` or `.agents/scripts/pulse-unbound-var-check.sh` when the reported file lines are false positives or the report cannot identify the offending lines.\n" +
+					"\n## Worker Guidance\n" +
+					"1. Open each Evidence PR comment containing `<!-- pulse-unbound-var-check -->`; use the reported file paths and line numbers as the authoritative target list.\n" +
+					"2. Fix each listed declaration with explicit initialisers, e.g. `local now=0 elapsed=0` or `local _cached_prs=\"\" _cached_issues=\"\"`.\n" +
+					"3. Run `.agents/scripts/pulse-unbound-var-check.sh --scan-files <changed pulse scripts>` plus `shellcheck` on the changed shell files before opening a PR.\n"
 				else
 					"- Fix the workflow/check at the source, then rerun failed checks on affected PRs.\n" +
 					"- Add a regression guard for this signature in pulse routine outputs.\n"

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -32,6 +32,19 @@ assert_equals() {
 	return 0
 }
 
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" == *"$needle"* ]]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  missing: %s\n' "$(printf '%q' "$needle")"
+	fi
+	return 0
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
 HELPER="$SCRIPT_DIR/gh-failure-miner-helper.sh"
 
@@ -83,6 +96,12 @@ assert_equals "GH#26308 caret-escaped ANSI is stripped during normalization" "# 
 
 signature=$(normalize_signature_line $'\033[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.\033[0m')
 assert_equals "GH#26308 raw ANSI is stripped during normalization" "# rate-limit grace is disabled — they cannot merge on rate-limit-only." "$signature"
+
+cluster_json='{"check_name":"Pulse Unbound-Var Lint","signature":"Pulse unbound-var violations found. See PR comment for details.","count":2,"examples":[{"source_kind":"pr","source_ref":"26744","source_url":"https://example.invalid/pull/26744","run_url":"https://example.invalid/actions/runs/1","details_url":"https://example.invalid/actions/runs/1","conclusion":"failure","affected_paths":[],"annotations":[]}]}'
+issue_body=$(build_issue_body "$cluster_json" "testpattern" 2 "false")
+assert_contains "Pulse unbound-var guidance classifies PR-specific lint" "Pulse Unbound-Var Lint is a PR-specific shell safety gate" "$issue_body"
+assert_contains "Pulse unbound-var guidance points workers at PR comment marker" "<!-- pulse-unbound-var-check -->" "$issue_body"
+assert_contains "Pulse unbound-var guidance preserves focused verification" ".agents/scripts/pulse-unbound-var-check.sh --scan-files <changed pulse scripts>" "$issue_body"
 
 printf '\nTests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Added Pulse Unbound-Var Lint-specific failure-miner guidance so generated systemic CI issues direct workers to the PR comment marker, the reported pulse script declarations, and focused shell verification instead of treating the lint gate as a shared workflow outage. Added regression coverage in the failure-miner signature-noise test.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh, .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh; shellcheck .agents/scripts/gh-failure-miner-helper.sh .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

Resolves #26752


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 71,388 tokens on this as a headless worker.