### PR TITLE
GH#26761: test: guard pulse prefetch unbound vars

### DIFF
--- a/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#26761 / t2863 pulse prefetch set -u safety.
+# The CI failure miner observed repeated Pulse Unbound-Var Lint failures in
+# pulse-prefetch-orchestration.sh and pulse-prefetch-repo.sh. The concrete
+# declarations were fixed by initialising every variable at declaration time;
+# this test keeps those two high-churn prefetch modules in the focused gate.
+
+set -u
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)"
+
+fail() {
+	local message="$1"
+	printf '[FAIL] %s\n' "$message" >&2
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf '[PASS] %s\n' "$message"
+	return 0
+}
+
+main() {
+	local checker="${TEST_REPO_ROOT}/.agents/scripts/pulse-unbound-var-check.sh"
+	local orchestration="${TEST_REPO_ROOT}/.agents/scripts/pulse-prefetch-orchestration.sh"
+	local repo="${TEST_REPO_ROOT}/.agents/scripts/pulse-prefetch-repo.sh"
+	local output=""
+
+	if [[ ! -x "$checker" ]]; then
+		fail "pulse unbound-var checker is not executable: ${checker}"
+		return 1
+	fi
+
+	output=$("$checker" --scan-files "$orchestration" "$repo" 2>&1) || {
+		printf '%s\n' "$output" >&2
+		fail "pulse prefetch modules contain uninitialised multi-var locals"
+		return 1
+	}
+
+	if [[ "$output" != *"No violations found."* ]]; then
+		printf '%s\n' "$output" >&2
+		fail "pulse unbound-var checker did not report a clean focused scan"
+		return 1
+	fi
+
+	pass "pulse prefetch modules keep local declarations initialised"
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added a focused regression test that scans pulse-prefetch-orchestration.sh and pulse-prefetch-repo.sh with pulse-unbound-var-check.sh so the GH#26761 uninitialised multi-var local pattern stays fixed.

## Files Changed

.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh; .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-prefetch-orchestration.sh .agents/scripts/pulse-prefetch-repo.sh; shellcheck .agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh .agents/scripts/pulse-prefetch-orchestration.sh .agents/scripts/pulse-prefetch-repo.sh

Resolves #26761


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 73,665 tokens on this as a headless worker.