### PR TITLE
GH#26766: test: harden pulse stale-base script setup

### DIFF
--- a/.agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh
+++ b/.agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh
@@ -45,7 +45,7 @@
 
 set -u
 
-TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TEST_REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)"
 
 if [[ -t 1 ]]; then
@@ -138,6 +138,8 @@ init_test_repo() {
 		git init -q -b main
 		git config user.email "test@example.com"
 		git config user.name "Test User"
+		git config commit.gpgsign false
+		git config tag.gpgsign false
 		mkdir -p .agents/scripts
 		cat >.agents/scripts/pulse-test.sh <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Updated .agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh to resolve nounset-safe BASH_SOURCE handling and disabled signing in its temporary git fixture so the regression test is hermetic under globally signed git configs.

## Files Changed

.agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh; .agents/scripts/tests/test-pulse-unbound-var-check-stale-base.sh

Resolves #26766


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 39,899 tokens on this as a headless worker.