### PR TITLE
GH#26769: fix: filter confirmation feedback acknowledgements

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -47,6 +47,7 @@ _build_inline_findings() {
 			"aidevops:review-thread-response|" +
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
+			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 			"\\bno further concerns?\\b|" +
 			"\\bno further feedback\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -462,6 +462,19 @@ test_skips_positive_implementation_ack_with_address_variants() {
 	return 0
 }
 
+test_skips_pr26751_confirmation_feedback_ack() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the confirmation and for addressing the feedback. The updated mock in `.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh` now correctly handles the argument count check and safely propagates the exit code, which improves the robustness of the test suite.","path":".agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh","line":164,"html_url":"https://example.invalid/review","created_at":"2026-07-07T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "26751" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip PR #26751 confirmation feedback acknowledgement" 0
+	else
+		print_result "skip PR #26751 confirmation feedback acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -253,6 +253,7 @@ main() {
 	test_skips_pr25504_verification_ack
 	test_skips_pr26721_positive_implementation_ack
 	test_skips_positive_implementation_ack_with_address_variants
+	test_skips_pr26751_confirmation_feedback_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Filtered Gemini confirmation-only inline acknowledgements that thank the author for addressing feedback and praise the updated mock as robust, preventing positive-only review comments from becoming quality-debt issues. Added a PR #26751 regression test and wired it into the quality-feedback verification suite.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (69/69 passed); bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #26769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 70,401 tokens on this as a headless worker.