### PR TITLE
test: harden pulse prefetch regression harness

### DIFF
--- a/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
@@ -10,7 +10,7 @@
 
 set -u
 
-TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 TEST_REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)"
 
 fail() {
@@ -26,6 +26,7 @@ pass() {
 }
 
 main() {
+	local bash_bin="${BASH:-bash}"
 	local checker="${TEST_REPO_ROOT}/.agents/scripts/pulse-unbound-var-check.sh"
 	local orchestration="${TEST_REPO_ROOT}/.agents/scripts/pulse-prefetch-orchestration.sh"
 	local repo="${TEST_REPO_ROOT}/.agents/scripts/pulse-prefetch-repo.sh"
@@ -36,7 +37,7 @@ main() {
 		return 1
 	fi
 
-	output=$(bash "$checker" --scan-files "$orchestration" "$repo" 2>&1) || {
+	output=$("$bash_bin" "$checker" --scan-files "$orchestration" "$repo" 2>&1) || {
 		printf '%s\n' "$output" >&2
 		fail "pulse prefetch modules contain uninitialised multi-var locals"
 		return 1

--- a/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
@@ -10,17 +10,17 @@
 
 set -u
 
-TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TEST_REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)"
 
 fail() {
-	local message="$1"
+	local message="${1:-}"
 	printf '[FAIL] %s\n' "$message" >&2
 	return 1
 }
 
 pass() {
-	local message="$1"
+	local message="${1:-}"
 	printf '[PASS] %s\n' "$message"
 	return 0
 }
@@ -31,12 +31,12 @@ main() {
 	local repo="${TEST_REPO_ROOT}/.agents/scripts/pulse-prefetch-repo.sh"
 	local output=""
 
-	if [[ ! -x "$checker" ]]; then
-		fail "pulse unbound-var checker is not executable: ${checker}"
+	if [[ ! -f "$checker" ]]; then
+		fail "pulse unbound-var checker is missing: ${checker}"
 		return 1
 	fi
 
-	output=$("$checker" --scan-files "$orchestration" "$repo" 2>&1) || {
+	output=$(bash "$checker" --scan-files "$orchestration" "$repo" 2>&1) || {
 		printf '%s\n' "$output" >&2
 		fail "pulse prefetch modules contain uninitialised multi-var locals"
 		return 1


### PR DESCRIPTION
## Summary
- Harden `.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh` against nounset edge cases in the script path and helper messages.
- Check the checker script by file existence and invoke it through `bash` so executable permissions are not required.

Resolves #26764

## Testing
- `bash .agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh`
- `shellcheck .agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 34,465 tokens on this as a headless worker.