### PR TITLE
GH#26770: fix: filter positive guard-check review feedback

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -49,6 +49,7 @@ _build_inline_findings() {
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
 			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
+			"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +
 			"\\bno further concerns?\\b|" +
 			"\\bno further feedback\\b|" +
 			"\\bno further recommendations?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -866,6 +866,17 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 		print_result "positive inline acknowledgement reply using addressed is filtered" 1 "expected 0 findings, got ${count}"
 	fi
 
+	acknowledgement_body='Thank you for the update, marcusquinn. Using `${task_ref:-}` consistently for guard checks is the correct approach to prevent unbound variable errors when `set -u` is enabled. The verification steps you'
+	acknowledgement_body+="'ve taken, including the regression test, provide good confidence in this fix."
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "issue #26770 positive inline guard-check acknowledgement is filtered" 0
+	else
+		print_result "issue #26770 positive inline guard-check acknowledgement is filtered" 1 "expected 0 findings, got ${count}"
+	fi
+
 	_restore_mock_gh
 	return 0
 }


### PR DESCRIPTION
## Summary

Added an inline review acknowledgement filter for Gemini guard-check praise that mentions consistent ${task_ref:-} use, correct approach, verification steps, and confidence, plus a regression case for issue #26770.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (70/70 passed); shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh

Resolves #26770


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 63,777 tokens on this as a headless worker.