### PR TITLE
GH#26771: fix: harden issue sync close reason handling

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -179,7 +179,7 @@ _has_prior_reopen_comment() {
 }
 
 _is_not_planned_state_reason() {
-	local reason="$1"
+	local reason="${1:-}"
 	local normalized
 	normalized=$(printf '%s' "$reason" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
 	[[ "$normalized" == "not_planned" ]] && return 0

--- a/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
+++ b/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
@@ -89,6 +89,7 @@ check_success "GraphQL NOT_PLANNED reason is skipped" _is_not_planned_state_reas
 check_success "REST not_planned reason is skipped" _is_not_planned_state_reason "not_planned"
 check_success "hyphenated not-planned reason is skipped" _is_not_planned_state_reason "not-planned"
 check_failure "completed reason is not treated as not planned" _is_not_planned_state_reason "COMPLETED"
+check_failure "missing close reason is not treated as not planned" _is_not_planned_state_reason
 
 printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Handled missing close reasons safely in issue-sync-helper-close.sh and added regression coverage for invoking _is_not_planned_state_reason with no argument.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-issue-sync-reopen-churn.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-reopen-churn.sh; shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-reopen-churn.sh

Resolves #26771


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 43,308 tokens on this as a headless worker.