### PR TITLE
GH#26772: fix: guard pulse batch cache hit counter

### DIFF
--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -347,7 +347,7 @@ _prefetch_repo_issues() {
 			issue_json="$_batch_issues"
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_issues: using batch cache for ${slug}" >>"$LOGFILE"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$((_PULSE_HEALTH_BATCH_CACHE_HITS + 1))
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
 		fi
 	fi
 


### PR DESCRIPTION
## Summary

Guarded the pulse batch cache hit counter increment with a default fallback so set -u cannot fail when the counter has not been initialized.

## Files Changed

.agents/scripts/pulse-prefetch-fetch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-prefetch-fetch.sh; shellcheck .agents/scripts/pulse-prefetch-fetch.sh

Resolves #26772


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 79,237 tokens on this as a headless worker.