### PR TITLE
GH#26774: fix: harden claim task label dedupe

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -380,12 +380,12 @@ _validate_and_normalize_args() {
 # duplicate-label warnings/noise in tests and wrapper fallbacks.
 _dedupe_csv_labels() {
 	local labels_csv="$1"
-	local saved_ifs="$IFS"
 	local result=""
 	local label=""
 	local trimmed=""
-	IFS=','
-	for label in $labels_csv; do
+	local -a label_arr=()
+	IFS=',' read -r -a label_arr <<<"$labels_csv"
+	for label in "${label_arr[@]}"; do
 		trimmed="${label#"${label%%[![:space:]]*}"}"
 		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
 		[[ -z "$trimmed" ]] && continue
@@ -398,7 +398,6 @@ _dedupe_csv_labels() {
 			result="$trimmed"
 		fi
 	done
-	IFS="$saved_ifs"
 	printf '%s\n' "$result"
 	return 0
 }


### PR DESCRIPTION
## Summary

Updated .agents/scripts/claim-task-id.sh so _dedupe_csv_labels splits comma-separated labels into a Bash array with read -r -a, then iterates quoted array elements. This prevents pathname expansion for wildcard label text while preserving trim and first-occurrence dedupe behavior.

## Files Changed

.agents/scripts/claim-task-id.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/claim-task-id.sh; sourced .agents/scripts/claim-task-id.sh from a temp directory containing files and verified _dedupe_csv_labels keeps wildcard labels literal while trimming and deduping

Resolves #26774


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 38,703 tokens on this as a headless worker.