### PR TITLE
GH#26763: test: document pulse unbound-var regression issue

### DIFF
--- a/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression test for GH#26761 / t2863 pulse prefetch set -u safety.
+# Regression test for GH#26761 and GH#26763 / t2863 pulse prefetch set -u safety.
 # The CI failure miner observed repeated Pulse Unbound-Var Lint failures in
 # pulse-prefetch-orchestration.sh and pulse-prefetch-repo.sh. The concrete
 # declarations were fixed by initialising every variable at declaration time;


### PR DESCRIPTION
## Summary

Tied the focused pulse prefetch unbound-var regression test to GH#26763 after verifying the reported prefetch locals are already initialised on this branch.

## Files Changed

.agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/pulse-unbound-var-check.sh --scan-files .agents/scripts/pulse-prefetch-orchestration.sh .agents/scripts/pulse-prefetch-repo.sh; shellcheck .agents/scripts/pulse-prefetch-orchestration.sh .agents/scripts/pulse-prefetch-repo.sh .agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh; .agents/scripts/tests/test-pulse-prefetch-unbound-var-regression.sh

Resolves #26763


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 63,381 tokens on this as a headless worker.