### PR TITLE
GH#26805: docs: remove duplicate changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests: preserve explicit queued status (#26735)
 - Tests: guard claim task status default (#26734)
 - Maintenance: sync GitHub issue refs to TODO.md [skip ci]
-- Maintenance: sync GitHub issue refs to TODO.md [skip ci]
 
 ### Fixed
 
@@ -46,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tests: preserve explicit queued status (#26735)
 - Tests: guard claim task status default (#26734)
-- Maintenance: sync GitHub issue refs to TODO.md [skip ci]
 - Maintenance: sync GitHub issue refs to TODO.md [skip ci]
 
 ## [3.31.76] - 2026-07-06


### PR DESCRIPTION
## Summary

Removed duplicate 'Maintenance: sync GitHub issue refs to TODO.md [skip ci]' changelog entries from the affected 3.31.77 release notes and the copied 3.31.78 entry so the release notes contain a single entry per section.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 duplicate-entry check: No consecutive duplicate maintenance sync entries; .agents/scripts/markdownlint-diff-helper.sh --base origin/main (reported no markdown files changed/skipped)

Resolves #26805


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 53,542 tokens on this as a headless worker.