### PR TITLE
GH#26799: docs: harden new-task ref checks

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -148,7 +148,7 @@ For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state.
 ```bash
 if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
   ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
-  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
+  task_ref=$({ grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md || true; } | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
   [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
 fi
 ```
@@ -156,7 +156,9 @@ fi
 Before reporting the task as filed, verify the issue exists:
 
 ```bash
-gh issue view "${task_ref#GH#}" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" >/dev/null
+if [[ -n "${task_ref:-}" && "${task_ref:-}" != "none" && "${task_ref:-}" != "offline" ]]; then
+  gh issue view "${task_ref#GH#}" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" >/dev/null
+fi
 ```
 
 `#{origin}`: `#interactive` (user present) or `#worker` (headless). Detect via `detect_session_origin` from `shared-constants.sh`. Maps to `origin:interactive` / `origin:worker` GitHub labels on issue sync.


### PR DESCRIPTION
## Summary

Updated the new-task workflow shell example to tolerate grep no-match paths under pipefail and to guard task_ref reads under set -u before verifying the tracker issue.

## Files Changed

.agents/workflows/new-task.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/workflows/new-task.md; bash -euo pipefail snippet covering no-match grep and unset task_ref guard

Resolves #26799


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 70,038 tokens on this as a headless worker.