### PR TITLE
fix: relax generated worktree cleanup

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1207,6 +1207,135 @@ _pc_local_commit_archive_secs() {
 }
 
 #######################################
+# Return stale generated clean worktree archive threshold in seconds.
+#
+# Generated auto/review worktrees are worker/session artifacts. When clean,
+# inactive, and old enough, keeping them for the generic local-commit
+# branch-preservation threshold only accumulates cruft.
+#
+# Environment:
+#   ORPHAN_GENERATED_CLEAN_ARCHIVE_SECS — default 43200 (12h), minimum 3600.
+#   ORPHAN_DETACHED_REVIEW_ARCHIVE_SECS — legacy alias.
+# Returns 0 always; prints a validated integer.
+#######################################
+_pc_generated_clean_archive_secs() {
+	local archive_secs="${ORPHAN_GENERATED_CLEAN_ARCHIVE_SECS:-${ORPHAN_DETACHED_REVIEW_ARCHIVE_SECS:-43200}}"
+	archive_secs="${archive_secs//[!0-9]/}"
+	if [[ -z "$archive_secs" || "$archive_secs" -lt 3600 ]]; then
+		archive_secs=43200
+	fi
+	printf '%s\n' "$archive_secs"
+	return 0
+}
+
+#######################################
+# Return stale generated dirty worktree archive threshold in seconds.
+#
+# Dirty generated worktrees may contain useful failed-worker artifacts. Keep
+# them longer than clean generated cruft, then stash and preserve the branch.
+#
+# Environment:
+#   ORPHAN_GENERATED_DIRTY_ARCHIVE_SECS — default 604800 (7d), minimum 86400.
+# Returns 0 always; prints a validated integer.
+#######################################
+_pc_generated_dirty_archive_secs() {
+	local archive_secs="${ORPHAN_GENERATED_DIRTY_ARCHIVE_SECS:-604800}"
+	archive_secs="${archive_secs//[!0-9]/}"
+	if [[ -z "$archive_secs" || "$archive_secs" -lt 86400 ]]; then
+		archive_secs=604800
+	fi
+	printf '%s\n' "$archive_secs"
+	return 0
+}
+
+#######################################
+# Check whether a worktree path or branch is generated worker/review cruft.
+#
+# Args:
+#   $1 - worktree path
+#   $2 - worktree branch (optional)
+# Returns: 0 when path/branch matches generated auto/review naming.
+#######################################
+_pc_is_generated_clean_cruft_worktree() {
+	local wt_path="$1"
+	local wt_branch="${2:-}"
+	local wt_name=""
+	[[ -n "$wt_path" ]] || return 1
+	wt_name=$(basename "$wt_path")
+	case "$wt_name" in
+	*-auto-* | *-review-* | *-review | *-thread-response | *-pr-[0-9]* | *-pr[0-9]*)
+		return 0
+		;;
+	esac
+	case "$wt_branch" in
+	feature/auto-* | */auto-* | *-auto-* | review/* | */review-* | *-review-* | pr-[0-9]* | pr[0-9]* | */pr-[0-9]* | */pr[0-9]*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+#######################################
+# Remove clean generated worktrees before the generic branch-preservation gate.
+#
+# Args mirror _pc_handle_local_commit_no_pr_worktree.
+# Returns: 0 if removed, 1 if not eligible or removal failed.
+#######################################
+_pc_handle_generated_clean_cruft_worktree() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local orphan_issue_num="$4"
+	local commits_ahead="$5"
+	local dirty_count="$6"
+	local wt_age_secs="$7"
+	local repo_name_age="$8"
+	local repo_slug_age="${9:-}"
+	local removal_reason="detached-review-cruft"
+	local branch_pr_num=""
+	local archive_secs
+	local audit_context
+	local guard_ok
+	guard_ok=$(printf 'cle%s' 'ar')
+
+	_pc_is_generated_clean_cruft_worktree "$wt_path_age" "$wt_branch_age" || return 1
+	if [[ -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
+		_pc_branch_has_pr "$repo_slug_age" "$wt_branch_age" "open" && return 1
+		branch_pr_num=$(_pc_pr_from_branch "$wt_branch_age" 2>/dev/null || true)
+		if [[ -n "$branch_pr_num" ]] && _pc_pr_terminal_for_branch_archive "$branch_pr_num" "$repo_slug_age" >/dev/null 2>&1; then
+			return 1
+		fi
+	fi
+	if [[ "$dirty_count" -gt 0 ]]; then
+		[[ -n "$wt_branch_age" ]] || return 1
+		archive_secs=$(_pc_generated_dirty_archive_secs)
+		removal_reason="generated-dirty-cruft"
+	else
+		archive_secs=$(_pc_generated_clean_archive_secs)
+	fi
+	[[ "$wt_age_secs" -ge "$archive_secs" ]] || return 1
+
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "generated-clean-cruft" "$guard_ok" "$guard_ok" "$guard_ok" "branch-preserved-if-present")
+	if [[ -n "$wt_branch_age" ]]; then
+		if [[ "$dirty_count" -gt 0 ]]; then
+			echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age} — dirty generated auto/review worktree older than ${archive_secs}s; stash archived and branch preserved" >>"$LOGFILE"
+		else
+			echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age} — clean generated auto/review worktree older than ${archive_secs}s; branch preserved" >>"$LOGFILE"
+		fi
+		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
+		return $?
+	fi
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing detached generated worktree — clean auto/review cruft older than ${archive_secs}s" >>"$LOGFILE"
+	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$removal_reason" "$audit_context"; then
+		git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null || return 1
+		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "$removal_reason" "permanent" "$audit_context"
+	fi
+	git -C "$rp_age" worktree prune 2>/dev/null || true
+	unregister_worktree "$wt_path_age" 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Handle an age-eligible worktree that has local commits but no PR.
 #
 # Args:
@@ -1252,6 +1381,9 @@ _pc_handle_local_commit_no_pr_worktree() {
 		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — PR #${branch_pr_num} is ${branch_pr_state}; local commits preserved on branch" >>"$LOGFILE"
 		_pc_remove_local_commit_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
 		return $?
+	fi
+	if _pc_handle_generated_clean_cruft_worktree "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+		return 0
 	fi
 
 	archive_secs=$(_pc_local_commit_archive_secs)
@@ -1303,6 +1435,34 @@ _pc_handle_terminal_worktree_archive() {
 		return $?
 	fi
 	return 1
+}
+
+#######################################
+# Skip cleanup when recent worker metrics show the issue/session is active.
+#
+# Args mirror the state tuple used by _cleanup_single_worktree.
+# Returns: 0 if cleanup should skip, 1 otherwise.
+#######################################
+_pc_skip_recent_worker_metric_cleanup() {
+	local wt_path_age="$1"
+	local wt_branch_age="$2"
+	local orphan_issue_num="$3"
+	local commits_ahead="$4"
+	local dirty_count="$5"
+	local wt_age_secs="$6"
+	local now_epoch="$7"
+	local repo_name_age="$8"
+	local age_grace="${ORPHAN_WORKTREE_GRACE_SECS:-1800}"
+	local audit_context
+	local guard_ok
+	guard_ok=$(printf 'cle%s' 'ar')
+	if ! _pc_recent_worker_metric_exists "$orphan_issue_num" "$now_epoch" "$age_grace"; then
+		return 1
+	fi
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "$guard_ok" "$guard_ok" "active" "none")
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — recent worker runtime metric/session record" >>"$LOGFILE"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "active-worker-metric" "skipped" "$audit_context"
+	return 0
 }
 
 #######################################
@@ -1364,6 +1524,17 @@ _cleanup_single_worktree() {
 		return 1
 	fi
 
+	local audit_context
+	local guard_ok
+	guard_ok=$(printf 'cle%s' 'ar')
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "$guard_ok" "$guard_ok" "$guard_ok" "none")
+	if _pc_skip_recent_worker_metric_cleanup "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$now_epoch" "$repo_name_age"; then
+		return 1
+	fi
+	if _pc_handle_generated_clean_cruft_worktree "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+		return 0
+	fi
+
 	local reason
 	if ! reason=$(_evaluate_worktree_removal "$commits_ahead" "$dirty_count" "$wt_age_secs" "$wt_branch_age" "$repo_slug_age"); then
 		_pc_log_not_age_eligible_skip "$wt_path_age" "$wt_branch_age" "$commits_ahead" "$dirty_count" "$wt_age_secs" "not-eligible"
@@ -1374,17 +1545,6 @@ _cleanup_single_worktree() {
 		return 1
 	fi
 
-	local age_grace="${ORPHAN_WORKTREE_GRACE_SECS:-1800}"
-	local audit_context
-	local guard_ok
-	guard_ok=$(printf 'cle%s' 'ar')
-	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "$guard_ok" "$guard_ok" "$guard_ok" "none")
-	if _pc_recent_worker_metric_exists "$orphan_issue_num" "$now_epoch" "$age_grace"; then
-		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "$guard_ok" "$guard_ok" "active" "none")
-		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — recent worker runtime metric/session record" >>"$LOGFILE"
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "active-worker-metric" "skipped" "$audit_context"
-		return 1
-	fi
 	if [[ "$commits_ahead" -gt 0 && "$reason" == *"no PR"* ]]; then
 		_pc_handle_local_commit_no_pr_worktree "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"
 		return $?
@@ -1504,7 +1664,7 @@ _pc_orphan_sibling_name_allowed() {
 	local candidate_name="$2"
 	[[ -n "$repo_name" && -n "$candidate_name" ]] || return 1
 	case "$candidate_name" in
-	"${repo_name}-feature-"* | "${repo_name}-fix-"* | "${repo_name}-chore-"* | "${repo_name}-docs-"* | "${repo_name}-refactor-"* | "${repo_name}-bugfix-"* | "${repo_name}-issue-"* | "${repo_name}-gh"* | "${repo_name}-pr"* | "${repo_name}-t"[0-9]* | "${repo_name}-repair-"* | "${repo_name}-review-"* | "${repo_name}.fix-"* | "${repo_name}.bugfix-"* | "${repo_name}.refactor-"*)
+	"${repo_name}-feature-"* | "${repo_name}-fix-"* | "${repo_name}-chore-"* | "${repo_name}-docs-"* | "${repo_name}-refactor-"* | "${repo_name}-bugfix-"* | "${repo_name}-issue-"* | "${repo_name}-gh"* | "${repo_name}-pr"* | "${repo_name}-t"[0-9]* | "${repo_name}-repair-"* | "${repo_name}-review-"* | "${repo_name}-release-"* | "${repo_name}-release-clone-"* | "${repo_name}.fix-"* | "${repo_name}.bugfix-"* | "${repo_name}.refactor-"*)
 		return 0
 		;;
 	*)
@@ -1568,6 +1728,16 @@ _pc_classify_orphan_sibling_dir() {
 		return 0
 	fi
 	if [[ -d "$candidate_path/.git" ]]; then
+		local standalone_branch=""
+		standalone_branch=$(git -C "$candidate_path" branch --show-current 2>/dev/null || true)
+		case "$standalone_branch" in
+		main | master)
+			if [[ -z "$(git -C "$candidate_path" status --porcelain 2>/dev/null)" ]]; then
+				printf '%s\n' "unregistered-standalone-clean-${standalone_branch}-dir"
+				return 0
+			fi
+			;;
+		esac
 		return 1
 	fi
 	printf '%s\n' "unregistered-non-git-worker-dir"

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -87,6 +87,15 @@ JSON
 	mkdir -p "$TEST_ROOT/Git/aidevops-cloudron-app"
 	git -C "$TEST_ROOT/Git/aidevops-cloudron-app" init -q
 
+	# Clean generated release clone under the worktree base: recoverable cruft.
+	mkdir -p "$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57"
+	git -C "$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57" init -q -b main
+	git -C "$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57" config user.email test@example.invalid
+	git -C "$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57" config user.name 'Aidevops Test'
+	printf 'release\n' >"$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57/README.md"
+	git -C "$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57" add README.md
+	git -C "$TEST_ROOT/Git/_worktrees/aidevops-release-clone-3.31.57" commit -q -m 'release clone'
+
 	return 0
 }
 
@@ -103,8 +112,8 @@ test_orphan_sibling_dirs_move_to_trash_only() {
 	local moved_count
 	moved_count=$(_pc_cleanup_orphan_sibling_dirs "$repo_json" "$(date +%s)")
 
-	if [[ "$moved_count" -ne 6 ]]; then
-		print_result "orphan sibling cleanup moves eligible sibling and centralized outliers" 1 "expected 6 moved, got $moved_count"
+	if [[ "$moved_count" -ne 7 ]]; then
+		print_result "orphan sibling cleanup moves eligible sibling and centralized outliers" 1 "expected 7 moved, got $moved_count"
 		return 0
 	fi
 
@@ -130,10 +139,10 @@ test_orphan_sibling_dirs_move_to_trash_only() {
 			trashed_count=$((trashed_count + 1))
 		done
 	done
-	if [[ "$trashed_count" -eq 6 ]]; then
+	if [[ "$trashed_count" -eq 7 ]]; then
 		print_result "eligible outliers are recoverable in trash bucket" 0
 	else
-		print_result "eligible outliers are recoverable in trash bucket" 1 "expected 6 trashed dirs, got $trashed_count"
+		print_result "eligible outliers are recoverable in trash bucket" 1 "expected 7 trashed dirs, got $trashed_count"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -72,6 +72,35 @@ setup_repo_with_worker_worktree() {
 	return 0
 }
 
+setup_repo_with_detached_review_worktree() {
+	local repo_dir="$1"
+	local wt_path="$2"
+	local age_spec="${3:-2 days ago}"
+	mkdir -p "$repo_dir"
+	(
+		cd "$repo_dir" || exit 1
+		git init -q -b main
+		git config user.email "test@example.invalid"
+		git config user.name "Test Worker"
+		printf 'base\n' >README.md
+		git add README.md
+		git commit -q -m "init"
+		git worktree add -q --detach "$wt_path" main
+	)
+	(
+		cd "$wt_path" || exit 1
+		printf 'review change\n' >review.txt
+		git add review.txt
+		git commit -q -m "review commit"
+	)
+	local old_ts
+	old_ts=$(date -u -v-2d +%Y%m%d%H%M 2>/dev/null \
+		|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
+		|| printf '202601010000\n')
+	touch -t "$old_ts" "$wt_path/.git"
+	return 0
+}
+
 source_pulse_cleanup_with_stubs() {
 	LOGFILE="${TEST_ROOT}/pulse.log"
 	export LOGFILE
@@ -345,7 +374,7 @@ test_recent_metric_blocks_local_commit_no_pr_removal() {
 test_local_commit_no_pr_skips_without_recent_metric() {
 	local repo_dir="${TEST_ROOT}/repo-no-metric"
 	local wt_path="${TEST_ROOT}/worker-wt-no-metric"
-	local branch_name="feature/auto-20260507-190802-gh23075"
+	local branch_name="feature/manual-20260507-190802-gh23075"
 	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
 	source_pulse_cleanup_with_stubs || return 1
 
@@ -450,6 +479,115 @@ test_stale_local_commit_no_pr_removes_worktree_preserves_branch() {
 	return 0
 }
 
+test_stale_detached_review_cruft_removes_without_branch() {
+	local repo_dir="${TEST_ROOT}/repo-detached-review"
+	local wt_path="${TEST_ROOT}/aidevops-pr1234-review-response"
+	setup_repo_with_detached_review_worktree "$repo_dir" "$wt_path" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-detached-review-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 0 ]] || rc=1
+	[[ ! -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-removed.*detached-review-cruft.*mode=permanent' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "stale clean detached review worktree is removed as cruft" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_stale_clean_auto_worktree_removes_folder_preserves_branch() {
+	local repo_dir="${TEST_ROOT}/repo-clean-auto"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-20260507-190806-gh23080"
+	local branch_name="feature/auto-20260507-190806-gh23080"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "2 days ago" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-clean-auto-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local branch_exists=1
+	git -C "$repo_dir" rev-parse --verify "refs/heads/${branch_name}" >/dev/null 2>&1 && branch_exists=0
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 0 ]] || rc=1
+	[[ ! -d "$wt_path" ]] || rc=1
+	[[ "$branch_exists" -eq 0 ]] || rc=1
+	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'pr_state=generated-clean-cruft' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "stale clean auto worktree removes folder while preserving branch" "$rc" \
+		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_dirty_auto_under_seven_days_is_preserved() {
+	local repo_dir="${TEST_ROOT}/repo-dirty-auto-young"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-20260507-190807-gh23081"
+	local branch_name="feature/auto-20260507-190807-gh23081"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "2 days ago" || return 1
+	printf 'dirty work\n' >"$wt_path/dirty.txt"
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-dirty-auto-young-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*local-commits-no-pr.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "dirty generated auto worktree under 7 days is preserved" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_dirty_auto_over_seven_days_stashes_and_preserves_branch() {
+	local repo_dir="${TEST_ROOT}/repo-dirty-auto-stale"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-20260507-190808-gh23082"
+	local branch_name="feature/auto-20260507-190808-gh23082"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "8 days ago" || return 1
+	printf 'dirty work\n' >"$wt_path/dirty.txt"
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-dirty-auto-stale-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local branch_exists=1
+	git -C "$repo_dir" rev-parse --verify "refs/heads/${branch_name}" >/dev/null 2>&1 && branch_exists=0
+	local stash_count=0
+	stash_count=$(git -C "$repo_dir" stash list 2>/dev/null | grep -c 'aidevops worktree cleanup archive' || true)
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 0 ]] || rc=1
+	[[ ! -d "$wt_path" ]] || rc=1
+	[[ "$branch_exists" -eq 0 ]] || rc=1
+	[[ "$stash_count" -gt 0 ]] || rc=1
+	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "dirty generated auto worktree over 7 days is stashed and removed" "$rc" \
+		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists stash_count=$stash_count log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
 test_no_newline_pr_output_blocks_local_commit_cleanup() {
 	source_pulse_cleanup_with_stubs || return 1
 	gh_pr_list() { printf '42'; return 0; }
@@ -542,6 +680,10 @@ test_closed_issue_dirty_worktree_stashes_and_preserves_branch
 test_terminal_worktree_bypasses_stale_owner_signal
 test_fix_numeric_closed_issue_worktree_archives
 test_stale_local_commit_no_pr_removes_worktree_preserves_branch
+test_stale_detached_review_cruft_removes_without_branch
+test_stale_clean_auto_worktree_removes_folder_preserves_branch
+test_dirty_auto_under_seven_days_is_preserved
+test_dirty_auto_over_seven_days_stashes_and_preserves_branch
 test_no_newline_pr_output_blocks_local_commit_cleanup
 test_no_newline_open_pr_output_blocks_clean_fastpath
 test_branch_pr_lookup_uses_null_safe_jq_filter


### PR DESCRIPTION
## Summary

- Clean generated `*-auto-*`, `*-review-*`, PR/review/thread worktrees after a 12h stale threshold.
- Stash and remove dirty generated worktrees only after 7 days, preserving the branch.
- Treat clean generated release clone dirs under the central worktree base as recoverable cleanup cruft.
- Preserve open PRs, active worker metrics, active owners/claims, dirty generated work younger than 7 days, and local-only repos.

## Verification

- `bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh` — 19/19 passed
- `bash .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh` — 3/3 passed
- `shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh` — passed
- `.agents/scripts/linters-local.sh` — ALL LOCAL CHECKS PASSED

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.14

Resolves #26811
