### PR TITLE
GH#26814: docs: guard new-task tracker grep task id

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -148,7 +148,7 @@ For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state.
 ```bash
 if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
   ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
-  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
+  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id:?}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
   [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
 fi
 ```


### PR DESCRIPTION
## Summary

Guarded the new-task pending tracker ref grep with ${task_id:?} so an empty task_id cannot match an unrelated TODO.md entry.

## Files Changed

.agents/workflows/new-task.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-lint-workflows-helper.sh; bash .agents/scripts/workflow-cascade-lint.sh .agents/workflows/new-task.md

Resolves #26814


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.81 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 2m and 56,307 tokens on this as a headless worker.