### PR TITLE
GH#26815: fix: harden pulse cleanup clean status check

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1732,7 +1732,8 @@ _pc_classify_orphan_sibling_dir() {
 		standalone_branch=$(git -C "$candidate_path" branch --show-current 2>/dev/null || true)
 		case "$standalone_branch" in
 		main | master)
-			if [[ -z "$(git -C "$candidate_path" status --porcelain 2>/dev/null)" ]]; then
+			local status_out=""
+			if status_out=$(git -C "$candidate_path" status --porcelain 2>/dev/null) && [[ -z "$status_out" ]]; then
 				printf '%s\n' "unregistered-standalone-clean-${standalone_branch}-dir"
 				return 0
 			fi

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -147,6 +147,50 @@ test_orphan_sibling_dirs_move_to_trash_only() {
 	return 0
 }
 
+test_standalone_clean_check_requires_successful_status() {
+	local candidate_path="$TEST_ROOT/Git/_worktrees/aidevops-release-clone-status-fails"
+	mkdir -p "$candidate_path/.git"
+
+	local fake_bin="$TEST_ROOT/fake-bin"
+	mkdir -p "$fake_bin"
+	cat >"$fake_bin/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-C" ]]; then
+	shift 2
+fi
+case "${1:-} ${2:-}" in
+"branch --show-current")
+	printf 'main\n'
+	exit 0
+	;;
+"status --porcelain")
+	exit 128
+	;;
+*)
+	exit 1
+	;;
+esac
+SH
+	chmod +x "$fake_bin/git"
+
+	local old_path="$PATH"
+	PATH="$fake_bin:$PATH"
+	local reason=""
+	set +e
+	reason=$(_pc_orphan_sibling_cleanup_reason "$candidate_path" "$TEST_ROOT/Git/aidevops" "$(date +%s)")
+	local rc=$?
+	set -e
+	PATH="$old_path"
+
+	if [[ "$rc" -eq 1 && -z "$reason" ]]; then
+		print_result "standalone clean check requires successful git status" 0
+	else
+		print_result "standalone clean check requires successful git status" 1 "expected preserve on failed status, got rc=$rc reason=$reason"
+	fi
+	return 0
+}
+
 main() {
 	if ! command -v jq >/dev/null 2>&1; then
 		printf 'SKIP jq unavailable\n'
@@ -155,6 +199,7 @@ main() {
 	setup_fixture
 	load_subject
 	test_orphan_sibling_dirs_move_to_trash_only
+	test_standalone_clean_check_requires_successful_status
 	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -178,7 +178,7 @@ SH
 	PATH="$fake_bin:$PATH"
 	local reason=""
 	set +e
-	reason=$(_pc_orphan_sibling_cleanup_reason "$candidate_path" "$TEST_ROOT/Git/aidevops" "$(date +%s)")
+	reason=$(_pc_classify_orphan_sibling_dir "$TEST_ROOT/Git/aidevops" "$candidate_path" "$(date +%s)")
 	local rc=$?
 	set -e
 	PATH="$old_path"


### PR DESCRIPTION
## Summary

Hardened orphan sibling cleanup so clean standalone main/master repositories are only trash-eligible when git status --porcelain succeeds and is empty. Added a regression test that fakes git status failure with empty stdout and verifies the directory is preserved.

## Files Changed

.agents/scripts/pulse-cleanup.sh, .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh; shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh

Resolves #26815


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.81 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 2m and 49,614 tokens on this as a headless worker.