### PR TITLE
GH#26819: docs: document provider credential naming

### DIFF
--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -83,6 +83,8 @@ bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh set <service-name> Y
 
 **Multi-account naming**: When you hold credentials for several accounts on the same provider at once (personal + work GitHub, multiple OpenAI projects, several Hetzner projects), suffix the bare name with `-<account>` / `_<ACCOUNT>` — e.g. `github-token-personal` and `github-token-work`, or `hcloud-token-project-a` and `hcloud-token-project-b`. The bare provider name remains the default for the single-account case. Full convention: `gopass.md` "Naming with multiple accounts".
 
+**Provider token label + value pairs**: `aidevops secret set <NAME>` and the plaintext fallback both store one value per name. If a provider has a non-sensitive local token label and a sensitive access token value, keep them separate: `<PROVIDER>_<ORG>_<PURPOSE>_TOKEN_NAME` for the label and `<PROVIDER>_<ORG>_<PURPOSE>_ACCESS_TOKEN` for the value. Add a developer or device discriminator, such as `_DEV_A` or `_LAPTOP_2`, before `TOKEN_NAME` / `ACCESS_TOKEN` when one workstation stores multiple developers' or devices' tokens. Never document token values; token labels may be documented only when they are non-sensitive.
+
 ### 4. Verify
 
 ```bash

--- a/.agents/tools/credentials/gopass.md
+++ b/.agents/tools/credentials/gopass.md
@@ -88,6 +88,48 @@ aidevops secret set AWS_ACCESS_KEY_ID_STAGING
 
 The bare provider name (`GITHUB_TOKEN`, `OPENAI_API_KEY`) remains the default for the single-account case — only suffix when you actually need to disambiguate. If you instead need one account active **at a time** and want to switch sets between projects, use `multi-tenant.md`.
 
+### Naming provider token labels and token values
+
+`aidevops secret set <NAME>` stores exactly one value under one environment-style
+name. When a provider exposes both a local token label/name and a sensitive token
+value, store or document those as separate names:
+
+- `<PROVIDER>_<ORG>_<PURPOSE>_TOKEN_NAME` — non-sensitive provider token label.
+- `<PROVIDER>_<ORG>_<PURPOSE>_ACCESS_TOKEN` — sensitive token value, stored with
+  `aidevops secret set` and never written in documentation, issues, PRs, logs, or
+  chat.
+
+Use stable, generic organisation and purpose tags that do not reveal private
+repositories, private customers, or local private paths. Agents may record known
+non-sensitive provider token labels when that helps humans identify which token to
+rotate, but must never record the token value.
+
+Examples for two developers working on the same `PRODUCTS_SYNC` purpose with
+different local provider token labels:
+
+```bash
+# Developer A: token label is safe to write down; token value is not.
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_TOKEN_NAME
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_ACCESS_TOKEN
+
+# Developer B on the same purpose, with a different provider-side token label.
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_B_TOKEN_NAME
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_B_ACCESS_TOKEN
+```
+
+When one physical device stores tokens for multiple developers, organisations, or
+purposes, add a short developer or device discriminator before the final field:
+
+```bash
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_A_TOKEN_NAME
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_A_ACCESS_TOKEN
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_LAPTOP_2_TOKEN_NAME
+aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_LAPTOP_2_ACCESS_TOKEN
+```
+
+For plaintext fallback exports in `credentials.sh`, use the same SCREAMING_SNAKE_CASE
+names and keep the file at permission `600`.
+
 ### Using Secrets in Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Documented provider credential naming conventions for separate non-sensitive token labels and sensitive access token values, including developer/device discriminators for multi-developer or multi-device local storage.

## Files Changed

.agents/tools/credentials/api-key-setup.md, .agents/tools/credentials/gopass.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npx markdownlint-cli2 .agents/tools/credentials/gopass.md .agents/tools/credentials/api-key-setup.md; npx secretlint .agents/tools/credentials/gopass.md .agents/tools/credentials/api-key-setup.md; .agents/scripts/linters-local.sh completed documentation-relevant gates before timeout: Secretlint, Markdown, TOON, skill frontmatter, secret safety policy, and Bash compatibility

Resolves #26819


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.81 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 10m and 82,661 tokens on this as a headless worker.