### PR TITLE
GH#26823: fix GUI surface row stretching

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -219,6 +219,8 @@ Use a compact 4px base with an 8px rhythm:
 - Grid gap: 16px; dashboard cards use `repeat(auto-fill, minmax(300px, 1fr))`.
 - Panel/card padding: 16px.
 - Form/control horizontal rhythm: 8px or 12px gaps.
+- Workspace scroll containers and page/form grids should use content-sized rows (`align-content: start`, form grid items `align-items: start`) so cards and controls never stretch vertically to fill spare viewport space.
+- Form controls should fill their column width with a 44px minimum height; labels stay attached to their controls with an 8px internal gap.
 - Sidebar width: 420px default, 320px minimum, 640px maximum from `.opencode/ui/chat-sidebar/constants.ts`.
 - Message and panel content should use a readable max width near 600px when not in a dashboard grid.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1102,6 +1102,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18064 Fix GUI desktop dependency startup failure #bug ref:GH#26569 pr:#26570 completed:2026-07-05
 
+- [ ] t18069 Fix GUI surface row stretching #bug #no-auto-dispatch ref:GH#26823
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -1659,6 +1659,8 @@ code {
 }
 
 .workspace-scroll {
+  align-content: start;
+  align-items: start;
   display: grid;
   gap: 16px;
   overflow-x: hidden;
@@ -1667,6 +1669,7 @@ code {
 }
 
 .surface-page {
+  align-content: start;
   display: grid;
   gap: 16px;
 }
@@ -1973,17 +1976,21 @@ code {
 
 .settings-surface,
 .settings-form {
+  align-content: start;
   display: grid;
   gap: 16px;
 }
 
 .settings-form {
+  align-items: start;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .settings-form label {
+  align-content: start;
   display: grid;
   gap: 8px;
+  min-height: 0;
 }
 
 .settings-form span {
@@ -1997,7 +2004,9 @@ code {
   border: 1px solid var(--border);
   border-radius: 14px;
   color: var(--text-secondary);
+  min-height: 44px;
   padding: 11px 12px;
+  width: 100%;
 }
 
 .notification-list li {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -486,6 +486,17 @@ describe("dashboard shell", () => {
     expect(css).not.toContain("border-color: color-mix(in srgb, var(--accent) 52%, transparent)");
   });
 
+  test("keeps workspace surface grids content-sized instead of vertically stretched", () => {
+    const css = readFileSync(`${guiWebRoot}/src/styles.css`, "utf8");
+
+    expect(css).toMatch(/\.workspace-scroll\s*\{[^}]*align-content:\s*start;[^}]*align-items:\s*start;/s);
+    expect(css).toMatch(/\.surface-page\s*\{[^}]*align-content:\s*start;/s);
+    expect(css).toMatch(/\.settings-surface,\n\.settings-form\s*\{[^}]*align-content:\s*start;/s);
+    expect(css).toMatch(/\.settings-form\s*\{[^}]*align-items:\s*start;[^}]*grid-template-columns:\s*repeat\(auto-fit, minmax\(240px, 1fr\)\);/s);
+    expect(css).toMatch(/\.settings-form label\s*\{[^}]*align-content:\s*start;[^}]*min-height:\s*0;/s);
+    expect(css).toMatch(/\.settings-form input,\n\.settings-form select\s*\{[^}]*min-height:\s*44px;[^}]*width:\s*100%;/s);
+  });
+
   test("clamps sidebar width to compact and wide bounds", () => {
     expect(clampSidebarWidth(120)).toBe(300);
     expect(clampSidebarWidth(360)).toBe(360);


### PR DESCRIPTION
## Summary

Resolves #26823.

- Stop workspace/page/settings CSS grids from stretching auto rows to fill spare viewport height.
- Keep settings form labels and controls content-sized with 44px minimum-height controls.
- Document the content-sized row rule in `DESIGN.md` so future GUI surfaces follow the same template.
- Track the task in `TODO.md` as `t18069`.

## Testing

- `bun test packages/gui-web/tests/component.test.ts`
- `npm run gui:ci`
- `.agents/scripts/linters-local.sh` (passed with historical/advisory warnings only)

## Runtime Testing

- Runtime-verified with local Vite GUI and headless Chrome CDP on the Settings surface.
- Desktop 1440x900: active heading `Settings`; hero-to-form gap 16px; form control heights 44-46px; no horizontal overflow; no console errors or failed requests.
- Mobile 390x844: active heading `Settings`; hero-to-form gap 16px; form control heights 44-46px; no horizontal overflow; no console errors or failed requests.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.81 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 54m and 420,094 tokens on this with the user in an interactive session.
