### PR TITLE
GH#26827: docs: deduplicate 3.32.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add vault passphrase modal (#26825)
+- Add Vault passphrase setup, unlock, and lock modal UI (#26825)
 
 ### Changed
 
@@ -25,12 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation: document provider credential naming (#26820)
 - fix: harden pulse cleanup clean status check (#26817)
 - Documentation: guard new-task tracker grep task id (#26816)
-
-## [3.32.0] - 2026-07-07
-
-### Added
-
-- Add Vault passphrase setup, unlock, and lock modal UI (#26825)
 
 ## [3.31.81] - 2026-07-07
 


### PR DESCRIPTION
## Summary

Deduplicated the v3.32.0 changelog heading into one section while preserving the Vault passphrase modal and GUI row stretching references.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 inline assertion counted one v3.32.0 heading and verified #26825/#26826 references

Resolves #26827


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.0 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 1m and 28,667 tokens on this as a headless worker.