### PR TITLE
GH#26829: fix: avoid repeated vault setup prompt

### DIFF
--- a/packages/gui-web/src/App.tsx
+++ b/packages/gui-web/src/App.tsx
@@ -1,5 +1,5 @@
 import type { GuiResponseEnvelope, GuiStatusData } from "@aidevops/gui-shared";
-import { type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactElement, useEffect, useState } from "react";
+import { type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactElement, useEffect, useRef, useState } from "react";
 import { MachineRail, Sidebar } from "./AppNavigation";
 import { Workspace } from "./AppWorkspace";
 import type { ContrastPreference, ConversationMode, FontPreference, FontSizePreference, ShellMode, SurfaceId, ThemePreference } from "./app-model";
@@ -108,6 +108,7 @@ export function App(): ReactElement {
   const [selectedLocalRepoIndex, setSelectedLocalRepoIndex] = useState(0);
   const [selectedSessionId, setSelectedSessionId] = useState<string | undefined>();
   const [vaultDialogIntent, setVaultDialogIntent] = useState<VaultDialogIntent | null>(null);
+  const hasPromptedVaultSetup = useRef(false);
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">("light");
   const resolvedTheme = themePreference === "system" ? systemTheme : themePreference;
   const activeSurface: SurfaceId = navigation.entries[navigation.index] ?? "overview";
@@ -213,7 +214,8 @@ export function App(): ReactElement {
   }, [status.data.local_repos.repos.length]);
 
   useEffect(() => {
-    if (!statusLoading && status.data.vault.readiness.setup_required) {
+    if (shouldPromptVaultSetup(statusLoading, status.data.vault.readiness.setup_required, hasPromptedVaultSetup.current)) {
+      hasPromptedVaultSetup.current = true;
       setVaultDialogIntent("setup");
     }
   }, [status.data.vault.readiness.setup_required, statusLoading]);
@@ -341,6 +343,10 @@ function LoadingBrandOverlay(): ReactElement {
 
 export function clampSidebarWidth(width: number): number {
   return Math.min(maxSidebarWidth, Math.max(minSidebarWidth, Math.round(width)));
+}
+
+export function shouldPromptVaultSetup(statusLoading: boolean, setupRequired: boolean, hasPromptedVaultSetup: boolean): boolean {
+  return !statusLoading && setupRequired && !hasPromptedVaultSetup;
 }
 
 function SidebarResizeHandle(): ReactElement {

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { appearanceStorageKeys, clampSidebarWidth, loadingBrandGlyph, loadingSkeletonPanelLabels, readStoredAppearancePreferences } from "../src/App";
+import { appearanceStorageKeys, clampSidebarWidth, loadingBrandGlyph, loadingSkeletonPanelLabels, readStoredAppearancePreferences, shouldPromptVaultSetup } from "../src/App";
 import { hueFromInputValue } from "../src/AppNavigation";
 import { wrappedOptionIndex } from "../src/AppearanceControls";
 import { Workspace } from "../src/AppWorkspace";
@@ -99,6 +99,13 @@ describe("dashboard shell", () => {
     expect(counts.apps).toBe(2);
     expect(counts.aiSessions).toBe(mockedStatus().data.opencode_sessions.sessions.length);
     expect(counts.repos).toBe(mockedStatus().data.local_repos.total + mockedStatus().data.repos.total);
+  });
+
+  test("prompts for vault setup only once per loaded session", () => {
+    expect(shouldPromptVaultSetup(false, true, false)).toBe(true);
+    expect(shouldPromptVaultSetup(false, true, true)).toBe(false);
+    expect(shouldPromptVaultSetup(true, true, false)).toBe(false);
+    expect(shouldPromptVaultSetup(false, false, false)).toBe(false);
   });
 
   test("renders AI session controls with audited-route placeholders", () => {


### PR DESCRIPTION
## Summary

Added a session-scoped vault setup prompt guard in packages/gui-web/src/App.tsx and covered the prompt predicate in packages/gui-web/tests/component.test.ts.

## Files Changed

packages/gui-web/src/App.tsx, packages/gui-web/tests/component.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run gui:test:components; npm run gui:typecheck

Resolves #26829


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.0 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 3m and 49,523 tokens on this as a headless worker.