### PR TITLE
GH#26832: docs: clarify gopass token discriminator guidance

### DIFF
--- a/.agents/tools/credentials/gopass.md
+++ b/.agents/tools/credentials/gopass.md
@@ -117,8 +117,9 @@ aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_B_TOKEN_NAME
 aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_B_ACCESS_TOKEN
 ```
 
-When one physical device stores tokens for multiple developers, organisations, or
-purposes, add a short developer or device discriminator before the final field:
+When a shared store or a single device stores tokens for multiple developers or
+devices under the same organisation and purpose, add a short developer or device
+discriminator before the final field:
 
 ```bash
 aidevops secret set PROVIDER_ORG_PRODUCTS_SYNC_DEV_A_TOKEN_NAME


### PR DESCRIPTION
## Summary

Clarified the gopass credential naming docs so developer/device discriminators are only described for multiple developers or devices under the same organisation and purpose.

## Files Changed

.agents/tools/credentials/gopass.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted Secretlint passed for .agents/tools/credentials/gopass.md. Broad .agents/scripts/linters-local.sh reached the 240s worker timeout during Secretlint after earlier gates passed.

Resolves #26832


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.0 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 5m and 30,687 tokens on this as a headless worker.