### PR TITLE
fix: guard new-task tracker lookup

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -148,7 +148,7 @@ For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state.
 ```bash
 if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
   ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
-  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id:?}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
+  task_ref=$([[ -n "${task_id:-}" ]] && grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
   [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
 fi
 ```


### PR DESCRIPTION
## Summary
- Guard the documented new-task tracker-ref grep so it only runs when task_id is non-empty.
- Preserve the explicit "Tracker issue creation failed" error path instead of relying on `${task_id:?}` inside command substitution.

## Testing
- `rg -n '\$\{task_id:\?\}' .agents/workflows/new-task.md; test $? -eq 1`
- `bash -n .agents/scripts/issue-sync-helper.sh`

Resolves #26833
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.0 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 1m and 33,538 tokens on this as a headless worker.