### PR TITLE
GH#26842: polish GUI nav badges and form fields

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,11 +90,11 @@ components:
     textColor: "{colors.on-surface}"
     rounded: "{rounded.lg}"
   input-default:
-    backgroundColor: "{colors.background}"
+    backgroundColor: "{colors.surface-raised}"
     textColor: "{colors.on-surface}"
     typography: "{typography.body-md}"
-    rounded: "{rounded.md}"
-    padding: 8px
+    rounded: "{rounded.xl}"
+    padding: 8px 12px
   button-primary:
     backgroundColor: "{colors.tertiary}"
     textColor: "{colors.on-tertiary}"
@@ -254,7 +254,7 @@ Core component rules:
 
 - **Page shell:** `#0d1117` background, `#c9d1d9` text, 20px padding, system font.
 - **Cards:** `#161b22` background, `#30363d` border, 8px radius, 16px padding. Hover changes border to `#58a6ff`.
-- **Inputs:** `#0d1117` background, `#30363d` border, `#c9d1d9` text, 6px radius, 8px 12px padding.
+- **Inputs, selects, and textareas:** use macOS-inspired inset fields: raised dark surface, subtle top highlight, 1px border, 12px radius, 8px 12px padding, native-density 38-44px height, subdued disabled text, and an accent focus ring. Dropdowns should keep the same field shell and use a compact chevron affordance.
 - **Primary buttons:** green `#238636` fill with white text; hover `#2ea043`.
 - **Secondary buttons:** `#21262d` fill, `#30363d` border, `#c9d1d9` text; hover `#30363d`.
 - **Danger buttons:** red `#da3633` fill and border; hover `#f85149`.

--- a/packages/gui-web/src/AppNavigation.tsx
+++ b/packages/gui-web/src/AppNavigation.tsx
@@ -369,8 +369,8 @@ function SidebarItem({ activeSurface, item, onVaultRequest, recordCount, setActi
             {shouldShowCount ? <span className="surface-count">({recordCount})</span> : null}
           </span>
         </span>
-        {vaultCollection ? <VaultPadlock collection={vaultCollection} compact vault={status.vault} /> : null}
         {item.badge ? <em>{item.badge}</em> : null}
+        {vaultCollection ? <VaultPadlock collection={vaultCollection} compact vault={status.vault} /> : null}
       </button>
     </li>
   );

--- a/packages/gui-web/src/styles.css
+++ b/packages/gui-web/src/styles.css
@@ -239,8 +239,63 @@ body {
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
+}
+
+:where(input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([type="color"]), select, textarea) {
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 12%), rgb(255 255 255 / 0%)),
+    color-mix(in srgb, var(--surface-muted) 88%, var(--surface-elevated));
+  border: 1px solid color-mix(in srgb, var(--border) 86%, var(--surface-elevated));
+  border-radius: 12px;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 18%),
+    inset 0 -1px 0 rgb(0 0 0 / 8%),
+    0 1px 2px rgb(0 0 0 / 8%);
+  color: var(--text-primary);
+  min-height: 38px;
+  padding: 8px 12px;
+  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease, color 140ms ease;
+}
+
+:where(input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([type="color"]), select, textarea)::placeholder {
+  color: color-mix(in srgb, var(--text-muted) 78%, transparent);
+}
+
+:where(input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([type="color"]), select, textarea):hover:not(:disabled) {
+  border-color: var(--border-hover);
+}
+
+:where(input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([type="color"]), select, textarea):focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent),
+    inset 0 1px 0 rgb(255 255 255 / 22%),
+    0 1px 2px rgb(0 0 0 / 10%);
+  outline: none;
+}
+
+:where(input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not([type="color"]), select, textarea):disabled {
+  color: var(--text-secondary);
+  cursor: not-allowed;
+  opacity: 0.9;
+}
+
+select {
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%),
+    linear-gradient(180deg, rgb(255 255 255 / 12%), rgb(255 255 255 / 0%));
+  background-position:
+    calc(100% - 16px) 50%,
+    calc(100% - 11px) 50%,
+    0 0;
+  background-repeat: no-repeat;
+  background-size: 5px 5px, 5px 5px, 100% 100%;
+  padding-right: 32px;
 }
 
 button {


### PR DESCRIPTION
Resolves #26842

## Summary
- Move left-nav planned badges before Vault locked badges so planned status reads first.
- Add shared macOS-inspired styling for inputs, selects, and textareas with inset surfaces, hover/focus rings, disabled states, and custom select chevrons.
- Update DESIGN.md with the form-field visual direction.

## Testing
- `npm run gui:ci`

## Runtime Testing
- Self-assessed UI/CSS change; production GUI build completed via `npm run gui:ci`.

## Key decisions
- Used a low-specificity shared field rule so existing component-specific sizing can still override it where needed.
- Kept dropdowns visually aligned with text fields while retaining a compact chevron affordance.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.0 with gpt-5.5 spent 5m and 133,511 tokens on this with the user in an interactive session.
