### PR TITLE
docs: add public launch checklist

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -84,6 +84,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Auto-approval/merge helpers must self-validate collaborator/author trust and preserve GH#17671 defence-in-depth; add `#aidevops:trust-boundary` above new checks.
 - Confirm destructive operations. For critical/high-risk destructive ops, use `verify-operation-helper.sh check/verify` and respect the result. Log security operations with `audit-log-helper.sh` without credential values.
 - Never include private repo names, private basenames, or local/private paths in public issues/PRs/comments/reviews/TODO. Use placeholders. Privacy/pre-push details: `reference/pre-push-guards.md`.
+- Before public launch of any site/app/tool/plugin, run the public launch checklist and exposure review in `workflows/public-launch-checklist.md` and `workflows/preflight.md`.
 - npm supply-chain incidents: isolate before token revocation when destructive persistence is plausible; scan with `aidevops security supply-chain scan`. Playbook: `reference/npm-supply-chain-response.md`.
 
 ### Git workflow

--- a/.agents/workflows/preflight.md
+++ b/.agents/workflows/preflight.md
@@ -31,6 +31,7 @@ tools:
 2. ShellCheck + Secretlint (~10s, blocking)
 3. Markdown + return statements (~20s, blocking)
 4. SonarCloud status (~5s, advisory)
+5. Website/app/tool launch exposure review (manual blocking before public launch)
 
 <!-- AI-CONTEXT-END -->
 
@@ -65,6 +66,59 @@ tools:
 |-------|------|----------|
 | SonarCloud status | API check | Advisory |
 | Codacy grade | API check | Advisory |
+
+### Phase 5: Public Launch Exposure Review (manual blocking)
+
+Full launch checklist: `workflows/public-launch-checklist.md`.
+
+For any new or changed public website, app, dashboard, widget, form, CRM bridge,
+WordPress plugin, static site, generated embed, or business tool, run this before
+publishing, deploying, merging to the live branch, or telling the user it is
+launch-ready:
+
+1. **Browser-inspect assumption**: assume any visitor can view source, inspect
+   bundled JavaScript, read static build artifacts, and call public endpoints.
+2. **Public artifact scan**: inspect the actual deploy/public build inputs, not
+   only source code. Confirm internal files are excluded from the public build
+   (`README.md`, `TODO.md`, `SESSION-STATE.md`, `docs/`, `prompts/`, `todo/`,
+   `inbox/`, scripts, scrapers, reports, agent metadata, test fixtures, local
+   notes, backups, and generated artifacts that reveal operations).
+3. **Secret and endpoint scan**: search public files and bundles for API keys,
+   tokens, webhooks, CRM lead-capture URLs, Formspree/automation endpoints,
+   admin URLs, private callback URLs, payment/customer identifiers, and internal
+   hostnames. Public static pages must not write directly to privileged backends;
+   use a server-side proxy with rate limits and signature/origin checks.
+4. **Source/research exposure scan**: search public files for scraping/source
+   names, competitor/source URLs, crawler notes, lead lists, report artifacts,
+   prompt libraries, internal SOPs, and strategy notes. Public pages may link to
+   normal show/organizer/dealer websites when intended, but must not expose how
+   private automation discovers or prioritizes sources unless explicitly approved.
+5. **Compliance and clone residue scan**: confirm required public pages and
+   applicable trust/compliance pages exist, then search copy, metadata, legal
+   pages, schema, OG tags, favicons/logos, analytics IDs, contacts, package/app
+   names, screenshots, testimonials, and footer/header text for old-brand,
+   prior-client, template, placeholder, or cloned-stack content.
+6. **Public endpoint hardening**: every public webhook/API/form endpoint must
+   have the narrowest practical permissions, input sanitization, payload size
+   limits, rate limiting/spam protection, and provider signature verification
+   where available. Long private URLs are a backup lock, not the only lock.
+7. **DOM/XSS and new-tab scan**: replace untrusted `innerHTML`/template-string
+   rendering with DOM APIs/text nodes; validate URL protocols; add
+   `rel="noopener noreferrer"` to `target="_blank"`; sandbox generated iframes
+   unless the feature requires broader privileges.
+8. **Performance check**: remove unused client-side code, do not load third-party
+   trackers/chat/widgets before consent where consent applies, avoid shipping
+   large internal datasets to the browser, and run the relevant build/lint/page
+   load checks before approval.
+9. **Evidence**: record the exact searches/checks, files changed, version number,
+   and remaining risks in the repo changelog/session state. If verification is
+   incomplete, say so and do not call the launch secure.
+
+Use project-specific search terms, for example: `LeadCapture`, `webhook`,
+`token`, `secret`, `api_key`, `scrap`, `crawl`, `source_url`, competitor/source
+names, `_scripts`, `_scrapers`, `docs/`, `SESSION-STATE`, `innerHTML`,
+`target="_blank"`, `lorem`, `placeholder`, old domains, old support contacts,
+analytics/tag IDs, and public endpoint paths.
 
 ## Commands
 

--- a/.agents/workflows/public-launch-checklist.md
+++ b/.agents/workflows/public-launch-checklist.md
@@ -1,0 +1,103 @@
+---
+description: Public launch checklist for websites, apps, plugins, dashboards, widgets, and tools
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Public Launch Checklist
+
+Use before publishing, deploying, merging to the live branch, removing noindex,
+submitting sitemaps, enabling real customer automation, or telling the user a new
+public website/app/plugin/widget/dashboard/tool is launch-ready.
+
+## 1. Scope and approval
+
+- Confirm the launch target, domain/app URL, repo/branch/worktree, and user-visible version.
+- Confirm what will become public now versus later.
+- Get explicit approval for publishing, DNS/live changes, noindex removal, SMS/email automation, paid services, data deletion, or production CRM changes.
+- Record a rollback point: git commit/tag, deployment ID, WordPress DB/export/revision, or backup name.
+
+## 2. Public exposure review
+
+- Assume any visitor can inspect HTML, JavaScript bundles, static files, source maps, widgets, forms, iframes, and public API endpoints.
+- Search the actual public build inputs and generated output for secrets, private URLs, tokens, API keys, CRM lead-capture URLs, webhook URLs, admin paths, internal hostnames, account IDs, payment/customer identifiers, and private callback URLs.
+- Verify internal docs are excluded from public output: `README.md`, `TODO.md`, `SESSION-STATE.md`, `docs/`, `prompts/`, `todo/`, `inbox/`, scripts, scrapers, reports, backups, fixtures, agent metadata, and local notes.
+- Search for exposed research/ops terms: scraping/source names, competitor/source URLs, crawler notes, lead lists, prompt libraries, source prioritisation, and internal SOPs.
+- Public static pages must not write directly to privileged backends. Use a server-side proxy/Worker/API with rate limits and signature/origin checks.
+
+## 3. Public endpoint and form security
+
+- List every public webhook/API/form endpoint and what it can do.
+- Require the narrowest possible permissions and inputs.
+- Add sanitization, payload size limits, rate limiting/spam protection, replay protection where possible, and provider signature verification where available.
+- Treat long private URLs as a second lock, not the only lock.
+- Verify honeypot/CAPTCHA/Turnstile/Formspree/domain allowlisting where applicable.
+- Do not enable SMS/MMS or customer messaging until consent wording, opt-out handling, A2P/registration, and explicit user approval are complete.
+
+## 4. Front-end safety and performance
+
+- Replace untrusted `innerHTML`, template-string rendering, and HTML concatenation with DOM APIs/text nodes.
+- Validate external URL protocols before rendering links.
+- Add `rel="noopener noreferrer"` to all `target="_blank"` links.
+- Sandbox generated iframes unless broader privileges are required and documented.
+- Avoid shipping large internal datasets to the browser; lazy-load or split data where practical.
+- Keep third-party analytics/chat/widgets consent-gated where consent applies.
+- Run build/lint/typecheck and page-load checks available for the repo.
+
+## 5. Content, legal, and trust
+
+- Confirm no private names, personal addresses, unapproved entity names, or sensitive internal details appear publicly.
+- Confirm required public pages from `tools/app-stack/public-site-surfaces.md` exist, are linked from the footer/sitemap, and match the launch scope: `/about`, `/contact`, `/privacy`, and `/terms` or documented equivalents.
+- Confirm applicable trust/compliance pages exist and are accurate: cookie/tracking notice, accessibility statement, data-protection/security overview, confidentiality/conflict-handling statement, commerce policies, refunds/cancellation/shipping, SMS/email consent and opt-out, and sector-specific compliance pages.
+- Check Terms, Privacy, disclaimers, contact details, cookie consent, tracking disclosures, and SMS/email consent wording against the actual product, routes, jurisdiction, processors, support channels, and implemented controls.
+- Search public copy, metadata, legal pages, schema/JSON-LD, OG tags, favicons/logos, analytics/tag IDs, contact details, support links, package/app names, screenshots, sample testimonials, and footer/header text for copied content from another brand, prior client, template starter, or cloned stack.
+- Verify certification, permit, partner, guarantee, pricing, and compliance claims are accurate and permissioned.
+- Do not imply compliance, certification, encryption, AI isolation, human conflict separation, accessibility conformance, or data-protection controls without evidence.
+- Ensure WordPress/public CMS content remains draft until the user explicitly approves publishing.
+
+## 6. SEO and launch gates
+
+- Confirm title/meta/OG, canonical URLs, sitemap, robots/noindex, redirects, 404, favicon/logo, mobile layout, accessibility basics, and schema validity.
+- Submit sitemap/Search Console only after launch approval and noindex removal.
+- Do not create or change Google Business Profile, local listings, outreach, ads, or DNS without explicit approval.
+
+## 7. Data, integrations, and observability
+
+- Verify backups before production changes.
+- Confirm CRM/form/test submissions use fake data until production is approved.
+- Verify analytics, logging, alerts, email notifications, uptime checks, and error monitoring are working without exposing secrets.
+- Document service costs, accounts, credentials storage location, and dashboard/inbox updates without including passwords/tokens.
+
+## 8. Evidence and handoff
+
+- Record version number, commit hash, deployment/build result, checks run, URLs tested, and rollback point.
+- Record remaining risks and blocked items plainly.
+- Update project `SESSION-STATE.md`, changelog/version log, and TODO/dashboard follow-ups.
+- Before completion, scan the conversation for unfulfilled launch promises and displaced requests.
+
+## Suggested exposure search terms
+
+Use project-specific terms plus:
+
+```text
+LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-
+```
+
+## Related workflows
+
+- `workflows/preflight.md` — includes the public launch exposure review gate.
+- `workflows/ui-verification.md` — UI/browser checks.
+- `tools/app-stack/public-site-surfaces.md` — standard public pages, trust pages, schema, and launch verification.
+- `reference/pre-push-guards.md` — privacy and push guards.
+- `reference/secret-handling.md` — credential handling.


### PR DESCRIPTION
Resolves #26840
Supersedes #26841

## Summary
- Add a public launch exposure review gate to preflight.
- Add a reusable public launch checklist for sites, apps, plugins, dashboards, widgets, and tools.
- Include standard public/compliance pages from the app-stack public surfaces guidance.
- Add clone/template residue checks for old-brand, prior-client, placeholder, analytics, metadata, legal-page, and schema copy.
- Add a short always-loaded pointer from the user guide to the detailed checklist.

## Files changed
- `.agents/AGENTS.md`: one-line pointer to the launch checklist.
- `.agents/workflows/preflight.md`: blocking exposure review for public launches.
- `.agents/workflows/public-launch-checklist.md`: detailed checklist and verification commands.

## Verification
- `git diff --check origin/main...HEAD`
- `.agents/scripts/secretlint-helper.sh scan .agents/AGENTS.md`
- `.agents/scripts/secretlint-helper.sh scan .agents/workflows/preflight.md`
- `.agents/scripts/secretlint-helper.sh scan .agents/workflows/public-launch-checklist.md`
- `.agents/scripts/prompt-guard-helper.sh scan-file .agents/workflows/preflight.md`
- `.agents/scripts/prompt-guard-helper.sh scan-file .agents/workflows/public-launch-checklist.md`
- `npx markdownlint-cli2 .agents/AGENTS.md .agents/workflows/preflight.md .agents/workflows/public-launch-checklist.md`

Note: `.agents/scripts/linters-local.sh --fast` was attempted twice but timed out in broad historical/advisory gates after changed-file documentation checks had passed; no changed shell files were included.

Co-authored-by: Milo Hiss <milohiss77@gmail.com>

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.1 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 42m and 102,461 tokens on this with the user in an interactive session.
