### PR TITLE
GH#26847: fix: guard empty new-task tracker id

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -147,8 +147,9 @@ For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state.
 
 ```bash
 if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
+  [[ -n "${task_id:-}" ]] || { echo "Tracker issue creation failed: task_id is empty" >&2; exit 1; }
   ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
-  task_ref=$([[ -n "${task_id:-}" ]] && grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
+  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
   [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
 fi
 ```


### PR DESCRIPTION
## Summary

Added an explicit task_id validation before the new-task workflow documents running issue-sync-helper.sh push, and simplified the tracker ref lookup to run only after the ID is known to be non-empty.

## Files Changed

.agents/workflows/new-task.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh (passed SonarCloud, changed-shell string literal check, FD-lock policy, ShellCheck RC parity; command timed out at Secretlint after 240s without emitting a finding)

Resolves #26847


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 7m and 30,807 tokens on this as a headless worker.