### PR TITLE
auto-recover: orphaned worker branch for #26847

### DIFF
--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -147,8 +147,9 @@ For GitHub-backed tracked tasks, `ref:none` is an incomplete intermediate state.
 
 ```bash
 if [[ "${task_offline:-false}" != "true" && "${task_ref:-}" == "none" ]]; then
+  [[ -n "${task_id:-}" ]] || { echo "Tracker issue creation failed: task_id is empty" >&2; exit 1; }
   ~/.aidevops/agents/scripts/issue-sync-helper.sh push "$task_id"
-  task_ref=$([[ -n "${task_id:-}" ]] && grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
+  task_ref=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_id}[[:space:]]" TODO.md | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/^ref://' || true)
   [[ -n "$task_ref" ]] || { echo "Tracker issue creation failed for $task_id" >&2; exit 1; }
 fi
 ```


### PR DESCRIPTION
Local branch recovery PR — worker committed locally but exited before pushing or opening a PR.

Branch `feature/auto-20260708-070514-gh26847` had local commits from headless worker session `issue-26847` and was published by the recovery path before this PR was created (GH#25374).

Resolves #26847

<!-- aidevops:orphan-recovery worker_local_branch_unpushed session=issue-26847 -->