### PR TITLE
GH#26849: fix: preserve vault modal form semantics

### DIFF
--- a/packages/gui-web/src/VaultPassphraseModal.tsx
+++ b/packages/gui-web/src/VaultPassphraseModal.tsx
@@ -51,32 +51,36 @@ export function VaultPassphraseModal({ intent, onClose, vault }: {
 
   return (
     <div className="vault-modal-backdrop" role="presentation">
-      <form
+      <section
         aria-label={title}
         aria-modal="true"
         className="vault-modal"
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (canContinue) {
-            continueFlow();
-          }
-        }}
         role="dialog"
       >
-        <header className="vault-modal-header">
-          <span className="vault-modal-icon" aria-hidden="true">{intent === "lock" ? <FiLock /> : <FiUnlock />}</span>
-          <div>
-            <p className="eyebrow">aidevops Vault</p>
-            <h2>{title}</h2>
-          </div>
-        </header>
-        {setupMode ? <SetupStep accepted={savedWarningAccepted} confirm={passphraseConfirm} match={setupPassphrasesMatch} onAcceptChange={setSavedWarningAccepted} onConfirmChange={setPassphraseConfirm} onPassphraseChange={setPassphrase} onUnlockPassphraseChange={setUnlockPassphrase} passphrase={passphrase} step={step} unlockMatch={finalPassphraseMatches} unlockPassphrase={unlockPassphrase} /> : <UnlockStep intent={intent} onUnlockPassphraseChange={setUnlockPassphrase} unlockPassphrase={unlockPassphrase} vault={vault} />}
-        <footer className="vault-modal-actions">
-          <button className="secondary-action" onClick={onClose} type="button">Cancel</button>
-          <button className="primary-action" disabled={!canContinue} type="submit">{setupMode && step < 2 ? "Continue" : actionLabel}</button>
-        </footer>
-        <p className="vault-modal-footnote">Passphrases stay in this local dialog state only and are never shown in logs, issues, command arguments, or AI chat.</p>
-      </form>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (canContinue) {
+              continueFlow();
+            }
+          }}
+          style={{ display: "contents" }}
+        >
+          <header className="vault-modal-header">
+            <span className="vault-modal-icon" aria-hidden="true">{intent === "lock" ? <FiLock /> : <FiUnlock />}</span>
+            <div>
+              <p className="eyebrow">aidevops Vault</p>
+              <h2>{title}</h2>
+            </div>
+          </header>
+          {setupMode ? <SetupStep accepted={savedWarningAccepted} confirm={passphraseConfirm} match={setupPassphrasesMatch} onAcceptChange={setSavedWarningAccepted} onConfirmChange={setPassphraseConfirm} onPassphraseChange={setPassphrase} onUnlockPassphraseChange={setUnlockPassphrase} passphrase={passphrase} step={step} unlockMatch={finalPassphraseMatches} unlockPassphrase={unlockPassphrase} /> : <UnlockStep intent={intent} onUnlockPassphraseChange={setUnlockPassphrase} unlockPassphrase={unlockPassphrase} vault={vault} />}
+          <footer className="vault-modal-actions">
+            <button className="secondary-action" onClick={onClose} type="button">Cancel</button>
+            <button className="primary-action" disabled={!canContinue} type="submit">{setupMode && step < 2 ? "Continue" : actionLabel}</button>
+          </footer>
+          <p className="vault-modal-footnote">Passphrases stay in this local dialog state only and are never shown in logs, issues, command arguments, or AI chat.</p>
+        </form>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Updated VaultPassphraseModal so the dialog role remains on the modal section while keyboard submit behavior is handled by a nested form using display: contents.

## Files Changed

packages/gui-web/src/VaultPassphraseModal.tsx

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run gui:typecheck; npm run gui:test:components

Resolves #26849


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 1m and 35,783 tokens on this as a headless worker.