### PR TITLE
GH#26846: docs: harden public launch checklist

### DIFF
--- a/.agents/workflows/public-launch-checklist.md
+++ b/.agents/workflows/public-launch-checklist.md
@@ -50,7 +50,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 - Replace untrusted `innerHTML`, template-string rendering, and HTML concatenation with DOM APIs/text nodes.
 - Validate external URL protocols before rendering links.
 - Add `rel="noopener noreferrer"` to all `target="_blank"` links.
-- Sandbox generated iframes unless broader privileges are required and documented.
+- Sandbox generated iframes unless broader privileges are required and documented; avoid combining `allow-scripts` with `allow-same-origin` to prevent sandbox bypass.
 - Avoid shipping large internal datasets to the browser; lazy-load or split data where practical.
 - Keep third-party analytics/chat/widgets consent-gated where consent applies.
 - Run build/lint/typecheck and page-load checks available for the repo.
@@ -76,7 +76,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 
 - Verify backups before production changes.
 - Confirm CRM/form/test submissions use fake data until production is approved.
-- Verify analytics, logging, alerts, email notifications, uptime checks, and error monitoring are working without exposing secrets.
+- Verify analytics, logging, alerts, email notifications, uptime checks, and error monitoring are working without exposing secrets or customer PII.
 - Document service costs, accounts, credentials storage location, and dashboard/inbox updates without including passwords/tokens.
 
 ## 8. Evidence and handoff
@@ -91,7 +91,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 Use project-specific terms plus:
 
 ```text
-LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-
+LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|dev\.|staging\.
 ```
 
 ## Related workflows


### PR DESCRIPTION
## Summary

Updated the public launch checklist to address review feedback from PR #26844: iframe sandbox guidance now warns against combining allow-scripts with allow-same-origin, observability checks include customer PII exposure, and exposure search terms include localhost, loopback, dev, and staging markers.

## Files Changed

.agents/workflows/public-launch-checklist.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/linters-local.sh; relevant Markdown/security gates passed before later framework-wide timeout. Ran npx markdownlint-cli2 .agents/workflows/public-launch-checklist.md: 0 errors.

Resolves #26846


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 8m and 38,375 tokens on this as a headless worker.