### PR TITLE
GH#26856: docs: refine public launch exposure regex

### DIFF
--- a/.agents/workflows/public-launch-checklist.md
+++ b/.agents/workflows/public-launch-checklist.md
@@ -91,7 +91,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 Use project-specific terms plus:
 
 ```text
-LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|dev\.|staging\.
+LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|dev[.-]|staging[.-]
 ```
 
 ## Related workflows


### PR DESCRIPTION
## Summary

Refined the public launch checklist exposure regex to escape make.com, cover 0.0.0.0 and ::1 loopback addresses, and match dev/staging host prefixes with dot or hyphen separators.

## Files Changed

.agents/workflows/public-launch-checklist.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 inline regex validation against make.com, loopback, dev/staging positive cases and makeXcom negative case. markdownlint-cli2 unavailable locally/on PATH.

Resolves #26856


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 1m and 36,264 tokens on this as a headless worker.