### PR TITLE
GH#26860: docs: refine launch checklist environment regex

### DIFF
--- a/.agents/workflows/public-launch-checklist.md
+++ b/.agents/workflows/public-launch-checklist.md
@@ -91,7 +91,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 Use project-specific terms plus:
 
 ```text
-LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|dev[.-]|staging[.-]
+LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|\b(dev|staging)(\.|-[a-zA-Z0-9-]+\.)
 ```
 
 ## Related workflows


### PR DESCRIPTION
## Summary

Refined the public launch exposure search pattern so dev/staging matches target host or hyphenated subdomain prefixes instead of broad dev-/staging- development terms; added a word boundary to avoid embedded-domain false positives.

## Files Changed

.agents/workflows/public-launch-checklist.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 inline regex regression check for dev/staging host matches and development-term non-matches; npx --no-install secretlint .agents/workflows/public-launch-checklist.md; .agents/scripts/linters-local.sh attempted twice but repository-wide Secretlint exceeded 120s and 240s timeouts

Resolves #26860


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.14 with gpt-5.5 spent 8m and 37,316 tokens on this as a headless worker.