### PR TITLE
GH#26865: docs: fix launch environment regex

### DIFF
--- a/.agents/workflows/public-launch-checklist.md
+++ b/.agents/workflows/public-launch-checklist.md
@@ -91,7 +91,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 Use project-specific terms plus:
 
 ```text
-LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|(?<![a-zA-Z0-9-])(dev|staging)(\.|-[a-zA-Z0-9-]+\.)
+LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|\b(dev|staging)(\.|-[a-zA-Z0-9-]+\.)(?=[a-zA-Z0-9-]+\.)
 ```
 
 ## Related workflows


### PR DESCRIPTION
## Summary
- Updated `.agents/workflows/public-launch-checklist.md` exposure regex to match hyphenated dev/staging subdomains such as `api-dev.example.com` and `my-dev-env.example.com`.
- Kept the guard against second-level domains such as `web-dev.com` and `web-staging.com` by requiring another domain segment after the matched dev/staging segment.

## Testing
- `python3` focused regex fixture check for dev/staging subdomain positives and second-level negatives
- `npx --no-install secretlint .agents/workflows/public-launch-checklist.md`
- `.agents/scripts/linters-local.sh` progressed through cached SonarCloud/Qlty and other gates but exceeded the 240s worker-safe timeout during Secretlint; focused Secretlint was run separately

Resolves #26865

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.14
