### PR TITLE
GH#26870: docs: document serve-sim event log

### DIFF
--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -36,10 +36,11 @@ serve-sim --list -q               # List running simulator streams
 serve-sim tap 0.5 0.9             # Tap normalized screen coordinates
 serve-sim button home             # Send hardware button
 serve-sim type "hello"            # Type into focused field
+serve-sim event-log -n 50         # Show recent simulator actions
 serve-sim --kill                  # Stop stream(s)
 ```
 
-Use `serve-sim` when the user needs a visible, browser-shareable simulator surface. Pair it with `agent-device`, `ios-simulator-mcp`, or `maestro` when the task needs accessibility refs, MCP tool calls, or repeatable E2E flows. Current upstream builds serve capture, accessibility, and HID input through an in-process native addon instead of a separate `serve-sim-bin` helper, so malformed browser input should be ignored rather than crash the preview server. Native builds now use SwiftPM's `swiftbuild` build system for the Node addon, so source installs need a current Xcode/Swift toolchain rather than only simulator runtime access. The preview defaults to H.264 when available and can switch or auto-downgrade to MJPEG when hardware decoding is unstable during screen recording; use `--codec <auto|mjpeg>` when the host must pin stream compatibility. Recent upstream versions also use incremental MJPEG and AVCC buffering, async native capture/HID paths with per-connection backpressure, and paged simulator-grid loading, which keeps large multi-device catalogs and long recording sessions responsive. Upstream simulator-backed test suites now serialize Bun test execution (`bun test --max-concurrency=1`) against the shared booted simulator and retry once after rebooting the simulator when transport-style failures indicate a simulator wedge.
+Use `serve-sim` when the user needs a visible, browser-shareable simulator surface. Pair it with `agent-device`, `ios-simulator-mcp`, or `maestro` when the task needs accessibility refs, MCP tool calls, or repeatable E2E flows. Current upstream builds serve capture, accessibility, and HID input through an in-process native addon instead of a separate `serve-sim-bin` helper, so malformed browser input should be ignored rather than crash the preview server. Native builds now use SwiftPM's `swiftbuild` build system for the Node addon, so source installs need a current Xcode/Swift toolchain rather than only simulator runtime access. The preview defaults to H.264 when available and can switch or auto-downgrade to MJPEG when hardware decoding is unstable during screen recording; use `--codec <auto|mjpeg>` when the host must pin stream compatibility. Recent upstream versions also use incremental MJPEG and AVCC buffering, async native capture/HID paths with per-connection backpressure, and paged simulator-grid loading, which keeps large multi-device catalogs and long recording sessions responsive. Upstream now records recent simulator actions in an event log that is available from the browser tools panel and `serve-sim event-log`; use it to inspect recent taps, drags, hardware buttons, rotation, memory warnings, camera/UI commands, app launches, screenshots, and command failures without scraping browser logs. Upstream simulator-backed test suites now serialize Bun test execution (`bun test --max-concurrency=1`) against the shared booted simulator and retry once after rebooting the simulator when transport-style failures indicate a simulator wedge.
 
 <!-- AI-CONTEXT-END -->
 
@@ -80,6 +81,7 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 | Gesture | `serve-sim gesture '<json>' [-d udid]` | Use documented JSON shape; avoid guessing coordinates |
 | Button | `serve-sim button home [-d udid]` | Hardware/home/app-switcher style controls |
 | Type | `serve-sim type "text" [-d udid]` | Also supports `--stdin` and `--file <path>` |
+| Recent event log | `serve-sim event-log [-d udid] [-n count] [-j]` | Reads recent simulator actions from a running `serve-sim` server; use `-j` for structured agent output |
 | Toggle software keyboard | Press `Cmd+K` in the preview | Mirrors Simulator's software keyboard toggle without changing hardware-keyboard state |
 | Rotate | `serve-sim rotate landscape_left [-d udid]` | portrait, portrait_upside_down, landscape_left, landscape_right |
 | Memory warning | `serve-sim memory-warning [-d udid]` | Simulator memory-pressure test |
@@ -97,9 +99,10 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 5. Use `agent-device snapshot` or `ios-simulator-mcp` for accessibility-aware targeting; use `serve-sim` for the shared visual stream and simulator-specific commands.
 6. If the browser preview stutters, drops frames, or reports an H.264 decoder failure while screen recording, restart with `serve-sim --codec mjpeg`, switch the Stream → Codec control to MJPEG, or append `?codec=mjpeg` to the preview URL.
 7. For plain coordinate taps, use `serve-sim tap <x> <y>` with normalized 0..1 values; reserve `serve-sim gesture '<json>'` for drag, swipe, and multi-touch shapes.
-8. Run shared-simulator Bun suites serially (`bun test --max-concurrency=1 ...`) so one simulator stream, pointer state, or native helper crash does not cascade across concurrent tests.
-9. Treat isolated `ConnectionRefused` / `server not alive`, hook timeout, or `ECONNRESET` failures in shared-simulator suites as possible simulator wedges: reboot the simulator and retry once before attributing the failure to app code.
-10. Clean up with `serve-sim --kill` unless the user asks to keep the simulator stream running.
+8. When diagnosing what just happened, open the Event Log panel in the browser tools area or run `serve-sim event-log -n 50 -j` against the active server; printable keyboard input is intentionally redacted while control keys, normalized tap/drag coordinates, command status, and device labels remain visible.
+9. Run shared-simulator Bun suites serially (`bun test --max-concurrency=1 ...`) so one simulator stream, pointer state, or native helper crash does not cascade across concurrent tests.
+10. Treat isolated `ConnectionRefused` / `server not alive`, hook timeout, or `ECONNRESET` failures in shared-simulator suites as possible simulator wedges: reboot the simulator and retry once before attributing the failure to app code.
+11. Clean up with `serve-sim --kill` unless the user asks to keep the simulator stream running.
 
 ## Expo / Dev Server Embedding
 


### PR DESCRIPTION
## Summary

Updated .agents/tools/mobile/serve-sim.md for upstream serve-sim af681b8: added the event-log command to quick reference/core commands and documented browser Event Log panel plus JSON event-log workflow guidance.

## Files Changed

.agents/tools/mobile/serve-sim.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed: git diff --check HEAD~1..HEAD. Attempted: bash .agents/scripts/tests/test-tool-install-serve-sim.sh (fails on existing supported-host install expectation while this branch changes only .agents/tools/mobile/serve-sim.md). Not run: markdownlint-cli2 unavailable locally.

Resolves #26870


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 2m and 115,052 tokens on this as a headless worker.