### PR TITLE
GH#26872: docs: add Codacy bot skip guidance

### DIFF
--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -71,7 +71,7 @@ When reading GitHub issue/PR threads, prefer `gh-thread-clean-helper.sh view iss
 
 ### Bot comment noise skip when reading (8c, token waste prevention)
 
-`gh-thread-clean-helper.sh` strips common bot internal-state/status noise. From bot comments, use only actionable file:line findings; use `gh pr checks` for pass/fail status. Treat SonarQube Cloud quality-gate badge summaries from `sonarqubecloud[bot]` as duplicate status noise unless the task is about SonarQube configuration. Treat Augment PR summary blocks (`<!-- augment-pr-summary -->`, `<details>` summaries) as duplicate PR-summary noise unless the task is about bot-output classification. Read full bot comments only for CI/review-bot configuration tasks.
+`gh-thread-clean-helper.sh` strips common bot internal-state/status noise. From bot comments, use only actionable file:line findings; use `gh pr checks` for pass/fail status. Treat SonarQube Cloud quality-gate badge summaries from `sonarqubecloud[bot]` as duplicate status noise unless the task is about SonarQube configuration. Treat Codacy zero-issue/status summaries from `codacy-production[bot]` (for example, `Up to standards`, `0 issues`, Codacy metric links, AI-reviewer promos, and update tips) as duplicate status noise unless the task is about Codacy configuration. Treat Augment PR summary blocks (`<!-- augment-pr-summary -->`, `<details>` summaries) as duplicate PR-summary noise unless the task is about bot-output classification. Read full bot comments only for CI/review-bot configuration tasks.
 
 ### Operational comment skip when reading (8d, token waste prevention)
 

--- a/.agents/scripts/tests/test-unknown-bot-alert-workflow.sh
+++ b/.agents/scripts/tests/test-unknown-bot-alert-workflow.sh
@@ -84,6 +84,15 @@ test_sonarqubecloud_bot_is_known() {
 	return 1
 }
 
+test_codacy_production_bot_is_known() {
+	if grep -Fxq 'codacy-production[bot]' "$KNOWN_BOTS_FILE"; then
+		print_result "codacy-production bot is in known bots config" 0
+		return 0
+	fi
+	print_result "codacy-production bot is in known bots config" 1 "missing from $KNOWN_BOTS_FILE"
+	return 1
+}
+
 main() {
 	if [[ ! -f "$WORKFLOW_FILE" ]]; then
 		print_result "workflow exists" 1 "$WORKFLOW_FILE"
@@ -94,6 +103,7 @@ main() {
 	test_missing_unknown_bot_label_does_not_break_workflow
 	test_generated_guidance_targets_current_docs
 	test_sonarqubecloud_bot_is_known
+	test_codacy_production_bot_is_known
 
 	printf '\nPassed: %d, Failed: %d\n' "$pass_count" "$fail_count"
 	if [[ "$fail_count" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Added explicit Codacy zero-issue/status-summary skip guidance to gh-command-discipline rule #8c and extended the unknown-bot workflow regression test to assert codacy-production[bot] remains in the known-bots config.

## Files Changed

.agents/reference/gh-command-discipline.md, .agents/scripts/tests/test-unknown-bot-alert-workflow.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-unknown-bot-alert-workflow.sh; shellcheck .agents/scripts/tests/test-unknown-bot-alert-workflow.sh

Resolves #26872


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 1m and 32,436 tokens on this as a headless worker.