### PR TITLE
GH#26874: fix: route PR repairs via linked worker issues

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1376,6 +1376,8 @@ _route_pr_to_fix_worker() {
 	local pr_title="${6:-}"
 	local updated_at="${7:-}"
 	local head_ref_oid="${8:-}"
+	local issue_labels=""
+	local issue_has_worker_origin=0
 
 	# No linked issue → nothing to route to
 	[[ -z "$linked_issue" ]] && return 1
@@ -1409,9 +1411,33 @@ _route_pr_to_fix_worker() {
 		return 1
 	fi
 
+	if [[ ",${pr_labels}," != *",origin:worker,"* \
+		&& ",${pr_labels}," != *",origin:worker-takeover,"* \
+		&& ",${pr_labels}," != *",origin:interactive,"* ]]; then
+		issue_labels=$(gh api "repos/${repo_slug}/issues/${linked_issue}" \
+			--jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+		if [[ ",${issue_labels}," == *",origin:worker,"* ]]; then
+			issue_has_worker_origin=1
+		fi
+	fi
+
 	# Worker-origin PRs: dispatch directly
 	if [[ ( -n "${_OW_LABEL_PAT:-}" && ",${pr_labels}," == *"${_OW_LABEL_PAT:-}"* ) ]] \
-		|| [[ ",${pr_labels}," == *",origin:worker-takeover,"* ]]; then
+		|| [[ ",${pr_labels}," == *",origin:worker-takeover,"* ]] \
+		|| [[ "$issue_has_worker_origin" -eq 1 ]]; then
+		if [[ "$issue_has_worker_origin" -eq 1 ]]; then
+			local fallback_pr_author=""
+			fallback_pr_author=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+				--json author --jq '.author.login // ""' 2>/dev/null) || fallback_pr_author=""
+			#aidevops:trust-boundary — issue-origin fallback is only for same-repo collaborator PRs whose PR labels lost origin metadata.
+			if [[ -z "$fallback_pr_author" ]] \
+				|| ! declare -F _is_collaborator_author >/dev/null 2>&1 \
+				|| ! _is_collaborator_author "$fallback_pr_author" "$repo_slug"; then
+				echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} linked issue #${linked_issue} has origin:worker but PR author trust could not be confirmed" >>"$LOGFILE"
+				return 1
+			fi
+			echo "[pulse-wrapper] _route_pr_to_fix_worker: PR #${pr_number} in ${repo_slug} using linked issue #${linked_issue} origin:worker fallback" >>"$LOGFILE"
+		fi
 		case "$kind" in
 			review)   _dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || true ;;
 			conflict) _dispatch_conflict_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" || true ;;

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -69,6 +69,10 @@ install_stubs() {
 			printf '%s\n' "${COMPARE_BEHIND:-1}"
 			return 0
 		fi
+		if [[ "$arg1" == "api" && "$args" == *"repos/owner/repo/issues/456"* ]]; then
+			printf '%s\n' "${ISSUE_LABELS:-origin:worker,status:in-review}"
+			return 0
+		fi
 		if [[ "$arg1" == "pr" && "$arg2" == "update-branch" ]]; then
 			return 1
 		fi
@@ -85,12 +89,17 @@ install_stubs() {
 			printf 'origin:worker\n'
 			return 0
 		fi
+		if [[ "$args" == *"author"* ]]; then
+			printf '%s\n' "${PR_AUTHOR:-maintainer}"
+			return 0
+		fi
 		return 0
 	}
 	_dispatch_ci_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-ci %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_interactive_pr_is_stale() { return 1; }
+	_is_collaborator_author() { local author="$1"; [[ "$author" == "maintainer" ]]; return $?; }
 	return 0
 }
 
@@ -140,6 +149,52 @@ test_route_uses_provided_labels() {
 	return 0
 }
 
+test_route_falls_back_to_linked_worker_issue_for_ci() {
+	: >"$GH_CALL_LOG"
+	export ISSUE_LABELS="origin:worker,status:in-review"
+	export PR_AUTHOR="maintainer"
+	_route_pr_to_fix_worker "8614" "owner/repo" "456" "ci" "status:in-review" || true
+
+	if ! grep -q "dispatch-ci 8614 owner/repo 456" "$GH_CALL_LOG"; then
+		fail "fix-worker route falls back to linked worker issue for CI" "Expected CI dispatch: $(cat "$GH_CALL_LOG")"
+		return 0
+	fi
+	if ! grep -q "repos/owner/repo/issues/456" "$GH_CALL_LOG"; then
+		fail "fix-worker route falls back to linked worker issue for CI" "Expected linked issue label fetch: $(cat "$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "fix-worker route falls back to linked worker issue for CI"
+	return 0
+}
+
+test_route_falls_back_to_linked_worker_issue_for_conflict() {
+	: >"$GH_CALL_LOG"
+	export ISSUE_LABELS="origin:worker,status:in-review"
+	export PR_AUTHOR="maintainer"
+	_route_pr_to_fix_worker "8592" "owner/repo" "456" "conflict" "status:in-review" "dirty PR" || true
+
+	if ! grep -q "dispatch-conflict 8592 owner/repo 456" "$GH_CALL_LOG"; then
+		fail "fix-worker route falls back to linked worker issue for conflict" "Expected conflict dispatch: $(cat "$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "fix-worker route falls back to linked worker issue for conflict"
+	return 0
+}
+
+test_issue_origin_fallback_requires_collaborator_pr_author() {
+	: >"$GH_CALL_LOG"
+	export ISSUE_LABELS="origin:worker,status:in-review"
+	export PR_AUTHOR="external"
+	_route_pr_to_fix_worker "8613" "owner/repo" "456" "conflict" "status:in-review" "dirty PR" || true
+
+	if grep -q "dispatch-conflict" "$GH_CALL_LOG"; then
+		fail "issue-origin fallback requires collaborator PR author" "Unexpected dispatch: $(cat "$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "issue-origin fallback requires collaborator PR author"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -148,6 +203,9 @@ main() {
 	test_ci_rebase_uses_provided_context
 	test_ci_rebase_fetches_when_context_missing
 	test_route_uses_provided_labels
+	test_route_falls_back_to_linked_worker_issue_for_ci
+	test_route_falls_back_to_linked_worker_issue_for_conflict
+	test_issue_origin_fallback_requires_collaborator_pr_author
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?


### PR DESCRIPTION
Resolves #26874

## Summary
- route CI/review/conflict repair workers when a PR is missing `origin:*` labels but its linked issue is `origin:worker`
- keep the fallback fail-closed by confirming the PR author is a repository collaborator before dispatch
- add regression coverage for the AwardsApp stuck patterns: red CI PR #8614, dirty/conflicting PRs #8592 and #8613, and an external-author denial case

## Root cause
Pulse repair routing trusted only PR labels. The affected PRs had only `status:in-review` on the PR, while the linked issues retained `origin:worker`, so CI failure and conflict routing saw the failures but refused to dispatch repair workers.

## Verification
- `bash -n .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-pr-context.sh`
- `.agents/scripts/tests/test-pulse-merge-pr-context.sh`
- `.agents/scripts/tests/test-pulse-merge-update-branch.sh`
- `.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
- `.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh`
- `.agents/scripts/linters-local.sh` (completed with ALL LOCAL CHECKS PASSED; pre-existing/advisory markdown/complexity debt reported)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.15
