### PR TITLE
GH#26878: fix: prevent known bot fallback alerts

### DIFF
--- a/.agents/scripts/tests/test-unknown-bot-alert-workflow.sh
+++ b/.agents/scripts/tests/test-unknown-bot-alert-workflow.sh
@@ -78,19 +78,25 @@ test_generated_guidance_targets_current_docs() {
 test_sonarqubecloud_bot_is_known() {
 	if grep -Fxq 'sonarqubecloud[bot]' "$KNOWN_BOTS_FILE"; then
 		print_result "sonarqubecloud bot is in known bots config" 0
-		return 0
+	else
+		print_result "sonarqubecloud bot is in known bots config" 1 "missing from $KNOWN_BOTS_FILE"
+		return 1
 	fi
-	print_result "sonarqubecloud bot is in known bots config" 1 "missing from $KNOWN_BOTS_FILE"
-	return 1
+
+	assert_contains "sonarqubecloud bot is in workflow fallback" '"sonarqubecloud[bot]"'
+	return 0
 }
 
 test_codacy_production_bot_is_known() {
 	if grep -Fxq 'codacy-production[bot]' "$KNOWN_BOTS_FILE"; then
 		print_result "codacy-production bot is in known bots config" 0
-		return 0
+	else
+		print_result "codacy-production bot is in known bots config" 1 "missing from $KNOWN_BOTS_FILE"
+		return 1
 	fi
-	print_result "codacy-production bot is in known bots config" 1 "missing from $KNOWN_BOTS_FILE"
-	return 1
+
+	assert_contains "codacy-production bot is in workflow fallback" '"codacy-production[bot]"'
+	return 0
 }
 
 main() {

--- a/.github/workflows/unknown-bot-alert.yml
+++ b/.github/workflows/unknown-bot-alert.yml
@@ -45,8 +45,16 @@ jobs:
               KNOWN_BOTS+=("$line")
             done <<< "$BOTS_FILE"
           else
-            # Fallback: minimal list to avoid false alerts on common bots
-            KNOWN_BOTS=("github-actions[bot]" "dependabot[bot]" "renovate[bot]")
+            # Fallback: minimal list to avoid false alerts on common bots and
+            # known review bots when the single-source config fetch is briefly
+            # unavailable or not yet updated on the default branch.
+            KNOWN_BOTS=(
+              "sonarqubecloud[bot]"
+              "codacy-production[bot]"
+              "github-actions[bot]"
+              "dependabot[bot]"
+              "renovate[bot]"
+            )
           fi
 
           is_known=false


### PR DESCRIPTION
## Summary

Added sonarqubecloud[bot] and codacy-production[bot] to the unknown-bot alert workflow fallback list so transient config-fetch/default-branch lag does not reopen known-bot alerts; extended the workflow regression test to assert these known review bots are present in both the config and fallback.

## Files Changed

.agents/scripts/tests/test-unknown-bot-alert-workflow.sh, .github/workflows/unknown-bot-alert.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-unknown-bot-alert-workflow.sh; bash -n .agents/scripts/tests/test-unknown-bot-alert-workflow.sh; shellcheck .agents/scripts/tests/test-unknown-bot-alert-workflow.sh

Resolves #26878


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.3 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 1m and 31,164 tokens on this as a headless worker.