### PR TITLE
GH#26889: fix: filter positive review acknowledgement

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -47,7 +47,7 @@ _build_inline_findings() {
 			"aidevops:review-thread-response|" +
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
-			"(?s:\\bthank you for the verification\\b.*\\badding the regression test\\b.*\\bcorrectly address(es|ed)?\\b)|" +
+			"(?s:\\bthank you for the verification\\b.*?\\badding the regression test\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
 			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -47,6 +47,7 @@ _build_inline_findings() {
 			"aidevops:review-thread-response|" +
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
+			"(?s:\\bthank you for the verification\\b.*\\badding the regression test\\b.*\\bcorrectly address(es|ed)?\\b)|" +
 			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -475,6 +475,19 @@ test_skips_pr26751_confirmation_feedback_ack() {
 	return 0
 }
 
+test_skips_pr26877_regression_test_verification_ack() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the verification and for adding the regression test. The inclusion of the guard clause and the updated process detection logic in `.agents/scripts/audit-worktree-removal-helper.sh` correctly addresses the potential false positive identified.","path":".agents/scripts/audit-worktree-removal-helper.sh","line":138,"html_url":"https://example.invalid/review","created_at":"2026-07-09T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "26877" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip PR #26877 regression-test verification acknowledgement" 0
+	else
+		print_result "skip PR #26877 regression-test verification acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -254,6 +254,7 @@ main() {
 	test_skips_pr26721_positive_implementation_ack
 	test_skips_positive_implementation_ack_with_address_variants
 	test_skips_pr26751_confirmation_feedback_ack
+	test_skips_pr26877_regression_test_verification_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Filtered the PR #26877 Gemini inline acknowledgement as resolved/positive feedback instead of new quality debt, and added a regression test to the quality-feedback main verification suite.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (71/71 passed)

Resolves #26889


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 2m and 61,914 tokens on this as a headless worker.