### PR TITLE
GH#26891: docs: broaden launch environment regex

### DIFF
--- a/.agents/workflows/public-launch-checklist.md
+++ b/.agents/workflows/public-launch-checklist.md
@@ -91,7 +91,7 @@ public website/app/plugin/widget/dashboard/tool is launch-ready.
 Use project-specific terms plus:
 
 ```text
-LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|\b(dev|staging)(\.|-[a-zA-Z0-9-]+\.)(?=[a-zA-Z0-9-]+\.)
+LeadCapture|webhook|token|secret|api_key|apikey|auth|password|private|callback|admin|crm|formspree|zapier|make\.com|n8n|scrap|crawl|source_url|sourceUrl|competitor|_scripts|_scrapers|docs/|SESSION-STATE|TODO|README|inbox|innerHTML|target="_blank"|iframe|lorem|ipsum|example|placeholder|template|starter|ACME|old domain|old brand|support@|privacy@|terms|cookie|accessibility|data protection|confidentiality|refund|shipping|cancellation|GTM-|GA-|UA-|localhost|127\.0\.0\.1|0\.0\.0\.0|::1|[a-zA-Z0-9-]*(dev|staging)(\.|-[a-zA-Z0-9-]+\.)(?=[a-zA-Z0-9-]+\.)
 ```
 
 ## Related workflows


### PR DESCRIPTION
## Summary

Broadened the public-launch exposure search regex so dev/staging markers are detected when embedded in a subdomain label, while preserving the existing suffix/domain-boundary guard.

## Files Changed

.agents/workflows/public-launch-checklist.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 regex sample checks for api-dev/mydev/webdev/apistaging positives and device/developer negatives; .agents/scripts/linters-local.sh --changed

Resolves #26891


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 1m and 43,938 tokens on this as a headless worker.