### PR TITLE
GH#26894: fix: ignore stale maintainer gate pending aliases

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -2002,7 +2002,7 @@ _check_required_checks_passing() {
 	# No required contexts → nothing required, treat as passing.
 	if [[ -z "$required_contexts" ]]; then
 		local fallback_rc=0
-		_check_required_pr_checks_passing_fallback "$repo_slug" "$pr_number"
+		_check_required_pr_checks_passing_fallback "$repo_slug" "$pr_number" >/dev/null
 		fallback_rc=$?
 		if [[ $fallback_rc -eq 0 ]]; then
 			echo "[pulse-merge] _check_required_checks_passing: no branch/ruleset contexts and PR required checks are passing or absent for PR #${pr_number} in ${repo_slug} — allowing (t2922)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -54,6 +54,52 @@ _check_required_pr_checks_passing_fallback() {
 	fi
 
 	if [[ "$nonpassing_count" -gt 0 ]]; then
+		local stale_gate_pending_count="" _sg_exit=0
+		stale_gate_pending_count=$(printf '%s' "$checks_json" | jq '
+			"pass" as $pass | "PENDING" as $pending |
+			"maintainer-gate" as $stable |
+			"Maintainer Review & Assignee Gate" as $legacy |
+			[.[]?
+			| (.name // "") as $name
+			| select((.bucket // "") != $pass)
+			| select(((.state // "") | ascii_upcase) == $pending)
+			| select($name == $stable or $name == $legacy)
+		] | length' 2>/dev/null)
+		_sg_exit=$?
+		if [[ $_sg_exit -ne 0 || -z "$stale_gate_pending_count" ]]; then
+			return 2
+		fi
+
+		if [[ "$stale_gate_pending_count" -eq "$nonpassing_count" ]]; then
+			local pr_sha="" rollup_json="" gate_pass_count="" _gp_exit=0
+			if declare -F gh_pr_view >/dev/null 2>&1; then
+				pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+					--json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || pr_sha=""
+			else
+				pr_sha=$(_pmrc_gh_read gh pr view "$pr_number" --repo "$repo_slug" \
+					--json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || pr_sha=""
+			fi
+			if [[ -n "$pr_sha" ]] && declare -F gh_pr_check_runs_rest >/dev/null 2>&1; then
+				rollup_json=$(gh_pr_check_runs_rest "$repo_slug" "$pr_sha" 2>/dev/null) || rollup_json=""
+				if [[ -n "$rollup_json" && "$rollup_json" != null ]]; then
+					gate_pass_count=$(jq '
+						"gate / Maintainer Review & Assignee Gate" as $gate |
+						"success" as $ok | "neutral" as $neutral |
+						"skipped" as $skipped |
+						[.[]?
+						| select((.name // "") == $gate)
+						| ((.conclusion // "") | ascii_downcase) as $conclusion
+						| select($conclusion == $ok or $conclusion == $neutral
+							or $conclusion == $skipped)
+					] | length' <<<"$rollup_json" 2>/dev/null)
+					_gp_exit=$?
+					if [[ $_gp_exit -eq 0 && "$gate_pass_count" =~ ^[0-9]+$ \
+						&& "$gate_pass_count" -gt 0 ]]; then
+						return 0
+					fi
+				fi
+			fi
+		fi
 		return 1
 	fi
 	return 0

--- a/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+++ b/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
@@ -59,6 +59,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # _check_required_checks_passing was moved to pulse-merge-process.sh
 # (GH#21595, t3030).
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+REQUIRED_CHECKS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-required-checks.sh"
 
 readonly TEST_RED=$'\033[0;31m'
 readonly TEST_GREEN=$'\033[0;32m'
@@ -337,6 +338,8 @@ define_function_under_test() {
 	fi
 	# shellcheck disable=SC1090  # dynamic source from sibling lib
 	source "$checks_lib"
+	# shellcheck disable=SC1090  # dynamic source from sibling lib
+	source "$REQUIRED_CHECKS_SCRIPT"
 	gh_pr_view() {
 		if gh pr view "$@"; then
 			return 0
@@ -367,6 +370,18 @@ define_function_under_test() {
 	fi
 	# shellcheck disable=SC1090  # dynamic source from extracted helper
 	eval "$rulesets_src"
+
+	local uncached_src
+	uncached_src=$(awk '
+		/^_required_contexts_for_default_branch_uncached\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$uncached_src" ]]; then
+		printf 'ERROR: could not extract _required_contexts_for_default_branch_uncached from %s\n' \
+			"$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$uncached_src"
 
 	local helper_src
 	helper_src=$(awk '
@@ -487,7 +502,7 @@ test_no_required_contexts() {
 	export MOCK_BP_MODE="no_required"
 	export MOCK_ROLLUP_MODE="all_required_pass"
 	assert_returns 0 "no required contexts in branch protection or rulesets → allowed"
-	assert_log_contains "no required contexts" \
+	assert_log_contains "no branch/ruleset contexts" \
 		"no_required: pass message logged"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -74,6 +74,9 @@ print_result() {
 #   skipping_only   — required check-run concludes skipped
 #   empty_required_pending_fallback — branch/ruleset APIs expose no contexts,
 #      but `gh pr checks --required` reports a pending required check
+#   empty_required_stale_maintainer_gate_fallback — branch/ruleset APIs expose
+#      no contexts, `gh pr checks --required` has a stale pending maintainer-gate
+#      status, and the current head's maintainer-gate CheckRun is successful
 #   pr_checks_empty_failure — PR-level required checks exits non-zero with no JSON
 #   ruleset_review_malformed_optional — ruleset detail has unexpected shapes
 #   error           — branch-protection API exits non-zero
@@ -155,7 +158,7 @@ fi
 
 if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	empty_required | empty_required_pending_fallback)
+	empty_required | empty_required_pending_fallback | empty_required_stale_maintainer_gate_fallback)
 		apply_jq '{"contexts":[]}' "$@"
 		exit 0
 		;;
@@ -196,6 +199,13 @@ if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
 		]' "$@"
 		exit 2
 		;;
+	empty_required_stale_maintainer_gate_fallback)
+		apply_jq '[
+			{"name":"Complexity Analysis","state":"SUCCESS","bucket":"pass"},
+			{"name":"maintainer-gate","state":"PENDING","bucket":"pending"}
+		]' "$@"
+		exit 1
+		;;
 	pr_checks_empty_failure)
 		exit 1
 		;;
@@ -214,6 +224,12 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 			{"name":"required-a","conclusion":"success","status":"completed"},
 			{"name":"required-b","conclusion":"success","status":"completed"},
 			{"name":"Sync Issue Hygiene on PR Merge","conclusion":"failure","status":"completed"}
+		]}'
+		;;
+	empty_required_stale_maintainer_gate_fallback)
+		local_json='{"check_runs":[
+			{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
+			{"name":"Complexity Analysis","conclusion":"success","status":"completed"}
 		]}'
 		;;
 	one_fail)
@@ -345,6 +361,7 @@ define_function_under_test() {
 
 	eval_function_from_file _ruleset_ref_matches_default_branch "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _required_contexts_from_rulesets_for_default_branch "$MERGE_SCRIPT" || return 1
+	eval_function_from_file _required_contexts_for_default_branch_uncached "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _required_contexts_for_default_branch "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _check_required_checks_passing "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _pr_required_checks_pass "$MERGE_SCRIPT" || return 1
@@ -562,6 +579,17 @@ test_empty_required_pending_fallback_blocks_ready_merge() {
 	return 0
 }
 
+test_empty_required_stale_maintainer_gate_fallback_allows_merge() {
+	# GH#26894: maintainer-gate can leave a legacy commit status pending after
+	# its current-head CheckRun has completed successfully. That stale alias must
+	# not hold an otherwise ready worker PR in the zero-progress denominator.
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="empty_required_stale_maintainer_gate_fallback"
+	assert_passing_check_returns 0 "empty branch contexts + stale maintainer-gate status with passing CheckRun → allowed"
+	return 0
+}
+
 test_pr_checks_empty_success_outputs_json_array() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -726,6 +754,7 @@ main() {
 	test_ruleset_review_malformed_optional_does_not_fail_parse
 	test_gh_api_error_fails_closed
 	test_required_checks_gh_reads_are_timeout_wrapped
+	test_empty_required_stale_maintainer_gate_fallback_allows_merge
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Root cause: PR-level required-check fallback treated stale pending maintainer-gate legacy commit statuses as non-passing even when the current head's Maintainer Gate check run had succeeded, leaving eligible merge candidates stuck and incrementing zero-progress cycles. Fix: allow only known maintainer-gate legacy pending aliases when every non-passing required item is that alias and the current-head maintainer-gate CheckRun is success/neutral/skipped; suppress fallback JSON stdout from the aggregate gate; refresh required-check test harness dependencies.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh (43 tests, 0 failed); bash .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh (34 tests, 0 failed); shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh; live local probe: patched _check_required_checks_passing marcusquinn/aidevops 26893 returned rc=0

Resolves #26894


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 7m and 138,183 tokens on this as a headless worker.