### PR TITLE
For #26897: fix stuck merge recovery

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -2243,6 +2243,12 @@ _set_native_auto_merge_or_skip() {
 		if _stuck_seconds=$(_auto_merge_stuck_seconds "$pr_number" "$repo_slug" "$_pr_state"); then
 			local _threshold="${AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS:-300}"
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge stuck ${_stuck_seconds}s (>${_threshold}s) in BLOCKED+MERGEABLE with no failing/pending required checks — falling through to immediate merge (t3192)" >>"$LOGFILE"
+			local _disable_auto_output=""
+			if _disable_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --disable-auto 2>&1); then
+				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled stale native auto-merge before immediate merge (GH#26897)" >>"$LOGFILE"
+			else
+				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: failed to disable stale native auto-merge before immediate merge (GH#26897): ${_disable_auto_output}" >>"$LOGFILE"
+			fi
 			return 1
 		fi
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1188,6 +1188,20 @@ ${merge_output}"
 		merge_failure_context="[admin merge]
 ${merge_output}"
 	fi
+	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Required status check"* && "$merge_output" == *"is expected"* ]]; then
+		local _missing_check_update_output=""
+		local _missing_check_update_exit=0
+		_missing_check_update_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+		_missing_check_update_exit=$?
+		if [[ $_missing_check_update_exit -eq 0 ]]; then
+			echo "[pulse-wrapper] Deterministic merge: admin merge reported an expected required status check for PR #${pr_number} in ${repo_slug}; update-branch requested and merge deferred (GH#26897): ${merge_output}" >>"$LOGFILE"
+			return 4
+		fi
+		merge_failure_context="${merge_failure_context}
+
+[missing required-check update-branch fallback]
+${_missing_check_update_output}"
+	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
 		_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -123,6 +123,11 @@ if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
 	exit 0
 fi
 
+# `gh pr merge <N> --repo <slug> --disable-auto`
+if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--disable-auto"* ]]; then
+	exit 0
+fi
+
 # `gh pr update-branch <N> --repo <slug>`
 if [[ "$1" == "pr" && "$2" == "update-branch" ]]; then
 	exit 0
@@ -411,6 +416,49 @@ test_case_e_stale_pending_defers() {
 }
 
 # =============================================================================
+# Case (H): PR already has autoMergeRequest, is stale, and checks are green
+# =============================================================================
+test_case_h_stuck_green_disables_auto_before_fallthrough() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	local old_enabled_at
+	old_enabled_at=$(date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+		|| date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+		|| echo '2026-04-30T16:00:00Z')
+	printf '{"autoMergeRequest":{"enabledAt":"%s"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+		"$old_enabled_at" >"${TEST_ROOT}/auto_merge_request.txt"
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+	export AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS=60
+
+	local result=0
+	_set_native_auto_merge_or_skip "800" "owner/repo" || result=$?
+	unset AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "Case (H): stuck green auto_merge → returns 1 (fall-through)" 1 \
+			"Expected exit 1, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'gh pr merge 800 --repo owner/repo --disable-auto' "$GH_LOG"; then
+		print_result "Case (H): stuck green auto_merge → disables stale auto-merge" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'disabled stale native auto-merge.*GH#26897' "$LOGFILE"; then
+		print_result "Case (H): stuck green auto_merge → disable audit log written" 1 \
+			"pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (H): stuck green auto_merge → disables stale auto-merge and falls through" 0
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
 # Case (F): existing auto-merge is green but behind → update branch and defer
 # =============================================================================
 test_case_f_green_behind_updates_branch() {
@@ -521,6 +569,7 @@ main() {
 	test_case_c_already_set_no_op
 	test_case_d_repo_disallows_falls_through
 	test_case_e_stale_pending_defers
+	test_case_h_stuck_green_disables_auto_before_fallthrough
 	test_case_f_green_behind_updates_branch
 	test_case_g_green_behind_without_auto_merge_updates_branch
 	test_native_auto_defer_not_counted_as_completed_merge

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -95,6 +95,15 @@ if [[ "$mode" == "conversation-chain" && "$1" == "pr" && "$2" == "merge" ]]; the
 	exit 1
 fi
 
+if [[ "$mode" == "expected-check" && "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
+	printf '%s\n' 'GraphQL: Required status check "review-bot-gate" is expected. (mergePullRequest)' >&2
+	exit 1
+fi
+
+if [[ "$mode" == "expected-check" && "$1" == "pr" && "$2" == "update-branch" ]]; then
+	exit 0
+fi
+
 if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
 	printf '%s\n' 'GraphQL: Repository rule violations found' >&2
 	exit 1
@@ -293,6 +302,42 @@ test_draft_pr_without_origin_labels_skips_merge_write() {
 	return 0
 }
 
+test_expected_required_check_updates_branch_and_defers() {
+	GH_STUB_MODE="expected-check"
+	setup_test_env
+	define_function_under_test || { teardown_test_env; unset GH_STUB_MODE; return 0; }
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 4 ]]; then
+		print_result "expected required-check blocker defers after update-branch" 1 \
+			"Expected 4, got ${result}; log: $(cat "$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	if ! grep -qE 'gh pr update-branch 77 --repo owner/repo' "$GH_LOG"; then
+		print_result "expected required-check blocker invokes update-branch" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	if ! grep -qE 'expected required status check.*GH#26897' "$LOGFILE"; then
+		print_result "expected required-check blocker writes defer audit log" 1 \
+			"pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	print_result "expected required-check blocker updates branch and defers" 0
+	teardown_test_env
+	unset GH_STUB_MODE
+	return 0
+}
+
 test_stale_cache_401_retries_admin_merge_once() {
 	GH_STUB_MODE="stale-cache-401"
 	setup_test_env
@@ -399,6 +444,7 @@ main() {
 	test_ruleset_violation_enables_auto_merge_without_admin
 	test_green_behind_update_defers_before_merge_attempts
 	test_draft_pr_without_origin_labels_skips_merge_write
+	test_expected_required_check_updates_branch_and_defers
 	test_stale_cache_401_retries_admin_merge_once
 	test_ruleset_fallback_failure_preserves_admin_conversation_context
 


### PR DESCRIPTION
For #26897.

## Summary

- Disable stale native auto-merge before the immediate deterministic merge fallback, preventing an existing auto-merge request from masking the real merge blocker.
- Treat GitHub `Required status check "..." is expected` admin-merge errors as missing required-check drift: request `gh pr update-branch` and defer instead of recording another failed merge cycle.
- Add regression coverage for stale native auto-merge recovery and missing expected required-check refresh.

## Testing

- `.agents/scripts/tests/test-pulse-merge-native-auto.sh`
- `.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh`
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-native-auto.sh .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh`

## Live evidence

- Issue #26897 auto-closed after pulse detected recovery: one PR merged after a 16-cycle zero-progress streak and `pulse_merge_zero_progress_cycles` reset to 0.
- Local live probe on PR #26892 disabled stale native auto-merge and re-queued native auto-merge, exposing/handling the expected required-check blocker path.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 10m and 175,742 tokens on this as a headless worker.