### PR TITLE
GH#26899: fix: defer pulse merge on pending required checks

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -79,6 +79,27 @@ _check_required_pr_checks_passing_fallback() {
 				pr_sha=$(_pmrc_gh_read gh pr view "$pr_number" --repo "$repo_slug" \
 					--json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || pr_sha=""
 			fi
+			if [[ -n "$pr_sha" ]]; then
+				local status_json="" pending_gate_status_count="" _ps_exit=0
+				status_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${pr_sha}/status" 2>/dev/null) || status_json=""
+				if [[ -n "$status_json" && "$status_json" != null ]]; then
+					pending_gate_status_count=$(jq '
+						"maintainer-gate" as $stable |
+						"Maintainer Review & Assignee Gate" as $legacy |
+						[.statuses[]?
+						| (.context // "") as $name
+						| select(($name == $stable or $name == $legacy)
+							and (((.state // "") | ascii_downcase) == "pending"))
+						] | length' <<<"$status_json" 2>/dev/null)
+					_ps_exit=$?
+					if [[ $_ps_exit -ne 0 || -z "$pending_gate_status_count" ]]; then
+						return 2
+					fi
+					if [[ "$pending_gate_status_count" -gt 0 ]]; then
+						return 1
+					fi
+				fi
+			fi
 			if [[ -n "$pr_sha" ]] && declare -F gh_pr_check_runs_rest >/dev/null 2>&1; then
 				rollup_json=$(gh_pr_check_runs_rest "$repo_slug" "$pr_sha" 2>/dev/null) || rollup_json=""
 				if [[ -n "$rollup_json" && "$rollup_json" != null ]]; then

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1188,13 +1188,14 @@ ${merge_output}"
 		merge_failure_context="[admin merge]
 ${merge_output}"
 	fi
-	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Required status check"* && "$merge_output" == *"is expected"* ]]; then
+	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Required status check"* \
+		&& ( "$merge_output" == *" is expected"* || "$merge_output" == *" is pending"* ) ]]; then
 		local _missing_check_update_output=""
 		local _missing_check_update_exit=0
 		_missing_check_update_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
 		_missing_check_update_exit=$?
 		if [[ $_missing_check_update_exit -eq 0 ]]; then
-			echo "[pulse-wrapper] Deterministic merge: admin merge reported an expected required status check for PR #${pr_number} in ${repo_slug}; update-branch requested and merge deferred (GH#26897): ${merge_output}" >>"$LOGFILE"
+			echo "[pulse-wrapper] Deterministic merge: admin merge reported an expected/pending required status check for PR #${pr_number} in ${repo_slug}; update-branch requested and merge deferred (GH#26899): ${merge_output}" >>"$LOGFILE"
 			return 4
 		fi
 		merge_failure_context="${merge_failure_context}

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -118,6 +118,11 @@ if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
 	exit 0
 fi
 
+# `gh pr merge <N> --repo <slug> --disable-auto`
+if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--disable-auto"* ]]; then
+	exit 0
+fi
+
 # `gh pr merge <N> --repo <slug> --auto --squash`
 if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
 	exit 0

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -158,7 +158,7 @@ fi
 
 if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	empty_required | empty_required_pending_fallback | empty_required_stale_maintainer_gate_fallback)
+	empty_required | empty_required_pending_fallback | empty_required_stale_maintainer_gate_fallback | empty_required_current_pending_maintainer_gate_fallback)
 		apply_jq '{"contexts":[]}' "$@"
 		exit 0
 		;;
@@ -199,7 +199,7 @@ if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
 		]' "$@"
 		exit 2
 		;;
-	empty_required_stale_maintainer_gate_fallback)
+	empty_required_stale_maintainer_gate_fallback | empty_required_current_pending_maintainer_gate_fallback)
 		apply_jq '[
 			{"name":"Complexity Analysis","state":"SUCCESS","bucket":"pass"},
 			{"name":"maintainer-gate","state":"PENDING","bucket":"pending"}
@@ -226,7 +226,7 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 			{"name":"Sync Issue Hygiene on PR Merge","conclusion":"failure","status":"completed"}
 		]}'
 		;;
-	empty_required_stale_maintainer_gate_fallback)
+	empty_required_stale_maintainer_gate_fallback | empty_required_current_pending_maintainer_gate_fallback)
 		local_json='{"check_runs":[
 			{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
 			{"name":"Complexity Analysis","conclusion":"success","status":"completed"}
@@ -282,6 +282,10 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 fi
 
 if [[ "$1" == "api" && "$*" == *"/commits/"* && "$*" == *"/status"* ]]; then
+	if [[ "${MOCK_GH_MODE:-all_pass}" == "empty_required_current_pending_maintainer_gate_fallback" ]]; then
+		apply_jq '{"statuses":[{"context":"maintainer-gate","state":"pending"}]}' "$@"
+		exit 0
+	fi
 	apply_jq '{"statuses":[]}' "$@"
 	exit 0
 fi
@@ -590,6 +594,20 @@ test_empty_required_stale_maintainer_gate_fallback_allows_merge() {
 	return 0
 }
 
+test_empty_required_current_pending_maintainer_gate_fallback_blocks_merge() {
+	# GH#26899: if the current head still has a pending maintainer-gate status
+	# context, GitHub can reject admin merge even though the maintainer-gate
+	# CheckRun succeeded. Treat that as active, not stale, so pulse defers instead
+	# of counting repeated failed admin merge attempts as zero-progress cycles.
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="empty_required_current_pending_maintainer_gate_fallback"
+	assert_passing_check_returns 1 "empty branch contexts + current pending maintainer-gate status → strict passing gate blocks"
+	assert_log_contains "PR-level required checks are not passing" \
+		"current pending maintainer-gate: fallback skip reason logged"
+	return 0
+}
+
 test_pr_checks_empty_success_outputs_json_array() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -755,6 +773,7 @@ main() {
 	test_gh_api_error_fails_closed
 	test_required_checks_gh_reads_are_timeout_wrapped
 	test_empty_required_stale_maintainer_gate_fallback_allows_merge
+	test_empty_required_current_pending_maintainer_gate_fallback_blocks_merge
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -100,7 +100,12 @@ if [[ "$mode" == "expected-check" && "$1" == "pr" && "$2" == "merge" && "$*" == 
 	exit 1
 fi
 
-if [[ "$mode" == "expected-check" && "$1" == "pr" && "$2" == "update-branch" ]]; then
+if [[ "$mode" == "pending-check" && "$1" == "pr" && "$2" == "merge" && "$*" == *"--admin"* ]]; then
+	printf '%s\n' 'GraphQL: Required status check "maintainer-gate" is pending. (mergePullRequest)' >&2
+	exit 1
+fi
+
+if [[ ( "$mode" == "expected-check" || "$mode" == "pending-check" ) && "$1" == "pr" && "$2" == "update-branch" ]]; then
 	exit 0
 fi
 
@@ -325,7 +330,7 @@ test_expected_required_check_updates_branch_and_defers() {
 		unset GH_STUB_MODE
 		return 0
 	fi
-	if ! grep -qE 'expected required status check.*GH#26897' "$LOGFILE"; then
+	if ! grep -qE 'expected/pending required status check.*GH#26899' "$LOGFILE"; then
 		print_result "expected required-check blocker writes defer audit log" 1 \
 			"pulse log: $(cat "$LOGFILE")"
 		teardown_test_env
@@ -333,6 +338,35 @@ test_expected_required_check_updates_branch_and_defers() {
 		return 0
 	fi
 	print_result "expected required-check blocker updates branch and defers" 0
+	teardown_test_env
+	unset GH_STUB_MODE
+	return 0
+}
+
+test_pending_required_check_updates_branch_and_defers() {
+	GH_STUB_MODE="pending-check"
+	setup_test_env
+	define_function_under_test || { teardown_test_env; unset GH_STUB_MODE; return 0; }
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 4 ]]; then
+		print_result "pending required-check blocker defers after update-branch" 1 \
+			"Expected 4, got ${result}; log: $(cat "$LOGFILE")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	if ! grep -qE 'gh pr update-branch 77 --repo owner/repo' "$GH_LOG"; then
+		print_result "pending required-check blocker invokes update-branch" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	print_result "pending required-check blocker updates branch and defers" 0
 	teardown_test_env
 	unset GH_STUB_MODE
 	return 0
@@ -445,6 +479,7 @@ main() {
 	test_green_behind_update_defers_before_merge_attempts
 	test_draft_pr_without_origin_labels_skips_merge_write
 	test_expected_required_check_updates_branch_and_defers
+	test_pending_required_check_updates_branch_and_defers
 	test_stale_cache_401_retries_admin_merge_once
 	test_ruleset_fallback_failure_preserves_admin_conversation_context
 


### PR DESCRIPTION
## Summary

Added current-head pending maintainer-gate status detection so stale-alias fallback does not treat active pending gates as passing; extended admin merge required-check handling to defer expected/pending blockers after update-branch; preserved stale native auto-merge disable behavior from the merged recovery fix.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-native-auto.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh .agents/scripts/tests/test-pulse-merge-native-auto.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh .agents/scripts/tests/test-pulse-merge-native-auto.sh; .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh; .agents/scripts/tests/test-pulse-merge-native-auto.sh

Resolves #26899


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 11m and 149,501 tokens on this as a headless worker.