### PR TITLE
GH#26902: test: remove duplicate pulse merge mock

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -118,11 +118,6 @@ if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
 	exit 0
 fi
 
-# `gh pr merge <N> --repo <slug> --disable-auto`
-if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--disable-auto"* ]]; then
-	exit 0
-fi
-
 # `gh pr merge <N> --repo <slug> --auto --squash`
 if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
 	exit 0


### PR DESCRIPTION
## Summary

Removed the redundant --disable-auto mock block from .agents/scripts/tests/test-pulse-merge-native-auto.sh while keeping the remaining merge mock coverage intact.

## Files Changed

.agents/scripts/tests/test-pulse-merge-native-auto.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-native-auto.sh && .agents/scripts/tests/test-pulse-merge-native-auto.sh

Resolves #26902


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.16 with gpt-5.5 spent 1m and 30,522 tokens on this as a headless worker.