### PR TITLE
GH#26903: fix: filter non-greedy quantifier acknowledgement

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -48,6 +48,7 @@ _build_inline_findings() {
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
 			"(?s:\\bthank you for the verification\\b.*?\\badding the regression test\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
+			"(?s:\\bthank you for the update\\b.*?\\bnon-greedy quantifiers\\b.*?\\bregression suite\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
 			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -488,6 +488,19 @@ test_skips_pr26877_regression_test_verification_ack() {
 	return 0
 }
 
+test_skips_pr26892_nongreedy_quantifier_ack() {
+	local comments result
+	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update and for confirming that the non-greedy quantifiers have been applied and verified by the regression suite. This change correctly addresses the potential for false positives in the regex matching logic.","path":".agents/scripts/quality-feedback-findings-lib.sh","line":50,"html_url":"https://example.invalid/review","created_at":"2026-07-09T00:00:00Z"}]'
+	result=$(_build_inline_findings "$comments" "26892" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip PR #26892 non-greedy-quantifier acknowledgement" 0
+	else
+		print_result "skip PR #26892 non-greedy-quantifier acknowledgement" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -255,6 +255,7 @@ main() {
 	test_skips_positive_implementation_ack_with_address_variants
 	test_skips_pr26751_confirmation_feedback_ack
 	test_skips_pr26877_regression_test_verification_ack
+	test_skips_pr26892_nongreedy_quantifier_ack
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Added a positive inline-acknowledgement filter for the PR #26892 Gemini comment so the quality-debt scanner no longer treats confirmation that non-greedy quantifiers were verified by the regression suite as actionable debt. Added and wired a regression test covering the captured comment text.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh; bash -n .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh

Resolves #26903


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.16 with gpt-5.5 spent 3m and 52,387 tokens on this as a headless worker.