### PR TITLE
GH#26906: fix: filter singular nongreedy acknowledgement

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -48,7 +48,7 @@ _build_inline_findings() {
 			"\\baddressed in [0-9a-f]{7,40}\\b|" +
 			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
 			"(?s:\\bthank you for the verification\\b.*?\\badding the regression test\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
-			"(?s:\\bthank you for the update\\b.*?\\bnon-greedy quantifiers\\b.*?\\bregression suite\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
+			"(?s:\\bthank you for the update\\b.*?\\bnon-greedy quantifiers?\\b.*?\\bregression suite\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
 			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 			"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -491,10 +491,10 @@ test_skips_pr26877_regression_test_verification_ack() {
 test_skips_pr26892_nongreedy_quantifier_ack() {
 	local comments result
 	# shellcheck disable=SC2016  # literal inline-comment JSON includes Markdown backticks
-	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update and for confirming that the non-greedy quantifiers have been applied and verified by the regression suite. This change correctly addresses the potential for false positives in the regex matching logic.","path":".agents/scripts/quality-feedback-findings-lib.sh","line":50,"html_url":"https://example.invalid/review","created_at":"2026-07-09T00:00:00Z"}]'
+	comments='[{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update and for confirming that the non-greedy quantifiers have been applied and verified by the regression suite. This change correctly addresses the potential for false positives in the regex matching logic.","path":".agents/scripts/quality-feedback-findings-lib.sh","line":50,"html_url":"https://example.invalid/review","created_at":"2026-07-09T00:00:00Z"},{"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the update and for confirming that the non-greedy quantifier has been applied and verified by the regression suite. This change correctly addresses the potential for false positives in the regex matching logic.","path":".agents/scripts/quality-feedback-findings-lib.sh","line":51,"html_url":"https://example.invalid/review","created_at":"2026-07-09T00:00:00Z"}]'
 	result=$(_build_inline_findings "$comments" "26892" "medium" | jq 'length')
 	if [[ "$result" == "0" ]]; then
-		print_result "skip PR #26892 non-greedy-quantifier acknowledgement" 0
+		print_result "skip PR #26892 non-greedy-quantifier acknowledgements" 0
 	else
 		print_result "skip PR #26892 non-greedy-quantifier acknowledgement" 1 "expected 0 findings, got ${result}"
 	fi


### PR DESCRIPTION
Resolves #26906

## Summary
- Updated `.agents/scripts/quality-feedback-findings-lib.sh` so the non-greedy acknowledgement filter matches both `non-greedy quantifier` and `non-greedy quantifiers`.
- Expanded `.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh` to cover singular and plural acknowledgement wording in the same regression fixture.

## Testing
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` — 72/72 passed
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh` — passed

<!-- MERGE_SUMMARY -->
## Merge summary
- Fixed quality-feedback false positive filtering for singular non-greedy quantifier acknowledgement wording.
- Added regression coverage for both singular and plural acknowledgement variants.

## Verification
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` — 72/72 passed
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh` — passed
<!-- /MERGE_SUMMARY -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.15 with gpt-5.5 spent 2m and 45,254 tokens on this as a headless worker.