### PR TITLE
GH#26908: fix: align acknowledgement test label

### DIFF
--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -496,7 +496,7 @@ test_skips_pr26892_nongreedy_quantifier_ack() {
 	if [[ "$result" == "0" ]]; then
 		print_result "skip PR #26892 non-greedy-quantifier acknowledgements" 0
 	else
-		print_result "skip PR #26892 non-greedy-quantifier acknowledgement" 1 "expected 0 findings, got ${result}"
+		print_result "skip PR #26892 non-greedy-quantifier acknowledgements" 1 "expected 0 findings, got ${result}"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Updated the PR #26892 non-greedy-quantifier test failure label so it uses the same plural acknowledgements wording as the success label.

## Files Changed

.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh; shellcheck .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh

Resolves #26908


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.5 spent 1m and 32,021 tokens on this as a headless worker.