### PR TITLE
t18081: Prevent profile contributions corruption on API failures

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -25,6 +25,8 @@ METRICS_FILE="${HOME}/.aidevops/.agent-workspace/observability/metrics.jsonl"
 OBS_DB_FILE="${HOME}/.aidevops/.agent-workspace/observability/llm-requests.db"
 OPENCODE_DB_FILE="${HOME}/.local/share/opencode/opencode.db"
 OPENCODE_ARCHIVE_DB_FILE="${HOME}/.local/share/opencode/opencode-archive.db"
+CONTRIBUTIONS_START_MARKER='<!-- CONTRIBUTIONS-START -->'
+CONTRIBUTIONS_END_MARKER='<!-- CONTRIBUTIONS-END -->'
 
 # --- Resolve profile repo path from repos.json ---
 _resolve_profile_repo() {
@@ -224,9 +226,84 @@ _normalize_readme_for_compare() {
 	return 0
 }
 
+# --- Fetch and validate one contribution record ---
+# Prints a sanitized tab-separated name, description, and URL. API failures and
+# malformed responses fail closed so error payloads can never become Markdown.
+_fetch_contribution_record() {
+	local endpoint="$1"
+	local jq_filter="$2"
+	local context="$3"
+	local record=""
+	local malformed_warning="Warning: malformed GitHub API response for ${context}"
+
+	if ! record=$(gh api "$endpoint" --jq "$jq_filter" 2>/dev/null); then
+		echo "Warning: GitHub API failed for ${context}" >&2
+		return 1
+	fi
+	if [[ -z "$record" || "$record" == *$'\n'* ]]; then
+		echo "$malformed_warning" >&2
+		return 1
+	fi
+
+	local name="${record%%$'\t'*}"
+	local remainder="${record#*$'\t'}"
+	if [[ "$remainder" == "$record" ]]; then
+		echo "$malformed_warning" >&2
+		return 1
+	fi
+	local description="${remainder%%$'\t'*}"
+	local url="${remainder#*$'\t'}"
+	if [[ "$url" == "$remainder" || "$url" == *$'\t'* ]]; then
+		echo "$malformed_warning" >&2
+		return 1
+	fi
+	name=$(_sanitize_md "$name")
+	description=$(_sanitize_md "$description")
+	url=$(_sanitize_url "$url")
+	if [[ "$name" == *'<'* || "$name" == *'>'* || "$description" == *'<'* || "$description" == *'>'* ]]; then
+		echo "Warning: unsafe GitHub API record for ${context}" >&2
+		return 1
+	fi
+	if [[ -z "$name" || -z "$url" ]]; then
+		echo "Warning: invalid GitHub API record for ${context}" >&2
+		return 1
+	fi
+	[[ -n "$description" ]] || description="No description"
+	printf '%s\t%s\t%s\n' "$name" "$description" "$url"
+	return 0
+}
+
+# --- List and validate fork names for the profile user ---
+_list_profile_fork_names() {
+	local gh_user="$1"
+	local repos_json=""
+	if ! repos_json=$(gh api "users/${gh_user}/repos?per_page=100&sort=updated" --paginate 2>/dev/null); then
+		echo "Warning: GitHub API failed while listing profile repositories" >&2
+		return 1
+	fi
+	if ! printf '%s\n' "$repos_json" | jq -e -s '
+		length > 0 and all(.[];
+			type == "array" and all(.[];
+				type == "object"
+				and (.fork | type) == "boolean"
+				and (.name | type) == "string"
+			)
+		)
+	' >/dev/null 2>&1; then
+		echo "Warning: malformed GitHub API repository list" >&2
+		return 1
+	fi
+	if ! printf '%s\n' "$repos_json" | jq -r '.[] | select(.fork == true) | .name'; then
+		echo "Warning: could not parse GitHub API repository list" >&2
+		return 1
+	fi
+	return 0
+}
+
 # --- Generate contributions list from forks + repos.json contributed entries ---
 # Outputs markdown lines (one per contributed repo), or empty string if none.
-# Uses core API only (no search API) — ~11 calls per run.
+# Uses core API only (no search API) — ~11 sequential calls per run. Sequential
+# collection prevents concurrent gh output streams from interleaving.
 # Deduplicates across all sources using a newline-delimited "seen" list with
 # exact matching (bash 3.2 compatible — no associative arrays).
 _generate_contributions() {
@@ -238,47 +315,40 @@ _generate_contributions() {
 	local seen_repos=""
 
 	# Source 1: forks — resolve parent URLs
-	local repos_json
-	repos_json=$(gh api "users/${gh_user}/repos?per_page=100&sort=updated" --paginate 2>/dev/null) || repos_json="[]"
-
 	local fork_names
-	fork_names=$(echo "$repos_json" | jq -r '.[] | select(.fork == true) | .name')
+	fork_names=$(_list_profile_fork_names "$gh_user") || return 1
 	if [[ -n "$fork_names" ]]; then
-		local fork_details
-		# shellcheck disable=SC2016
-		fork_details=$(echo "$fork_names" | xargs -P 6 -I{} gh api "repos/${gh_user}/{}" --jq '
-			"\(.name | gsub("[\\[\\]()`]"; ""))\t\((.description // "No description") | gsub("[\\t\\n]"; " ") | gsub("[\\[\\]()`]"; ""))\t\(.parent.html_url // .html_url)"
-		' 2>/dev/null || true)
-		while IFS=$'\t' read -r rname rdesc rurl; do
-			[[ -z "$rname" ]] && continue
-			# Reset IFS to default before $() calls — prevents zsh IFS leak corrupting PATH lookup
-			local _saved_ifs="$IFS"
-			IFS=$' \t\n'
-			# Deduplicate within forks (xargs -P can return duplicates)
+		local fork_filter
+		fork_filter='"\(.name // "")\t\((.description // "No description") | gsub("[\\t\\n\\r]"; " "))\t\(.parent.html_url // "")"'
+		while IFS= read -r fork_name; do
+			[[ -z "$fork_name" ]] && continue
+			local fork_record
+			fork_record=$(_fetch_contribution_record "repos/${gh_user}/${fork_name}" "$fork_filter" "fork ${fork_name}") || return 1
+			local rname rdesc rurl
+			IFS=$'\t' read -r rname rdesc rurl <<<"$fork_record"
 			if [[ -n "$seen_repos" ]] && grep -qxF "$rname" <<<"$seen_repos" 2>/dev/null; then
-				IFS="$_saved_ifs"
 				continue
 			fi
-			rname=$(_sanitize_md "$rname")
-			rdesc=$(_sanitize_md "$rdesc")
-			rurl=$(_sanitize_url "$rurl")
-			IFS="$_saved_ifs"
-			[[ -z "$rurl" ]] && continue
 			seen_repos="${seen_repos}${rname}"$'\n'
 			contrib_repos="${contrib_repos}- **[${rname}](${rurl})** -- ${rdesc}"$'\n'
-		done <<<"$fork_details"
+		done <<<"$fork_names"
 	fi
 
 	# Source 2: repos.json "contributed: true" entries (non-fork contributions)
 	local repos_config="${HOME}/.config/aidevops/repos.json"
 	if [[ -f "$repos_config" ]] && command -v jq &>/dev/null; then
 		local contributed_slugs
-		contributed_slugs=$(jq -r '
+		if ! contributed_slugs=$(jq -r '
 			(.initialized_repos // (to_entries | map(.value)))[]
 			| select(.contributed == true)
 			| .slug // empty
-		' "$repos_config" 2>/dev/null || true)
+		' "$repos_config" 2>/dev/null); then
+			echo "Warning: could not parse contributed repositories config" >&2
+			return 1
+		fi
 
+		local repo_filter
+		repo_filter='"\(.name // "")\t\((.description // "No description") | gsub("[\\t\\n\\r]"; " "))\t\(.html_url // "")"'
 		while IFS= read -r slug; do
 			[[ -z "$slug" ]] && continue
 			local repo_name
@@ -287,12 +357,9 @@ _generate_contributions() {
 			if [[ -n "$seen_repos" ]] && grep -qxF "$repo_name" <<<"$seen_repos" 2>/dev/null; then
 				continue
 			fi
-			# Fetch description from GitHub API (1 call per contributed repo)
-			local desc
-			desc=$(gh api "repos/${slug}" --jq '.description // "No description"' 2>/dev/null || echo "No description")
-			desc=$(_sanitize_md "$desc")
-			local url="https://github.com/${slug}"
-			repo_name=$(_sanitize_md "$repo_name")
+			local repo_record desc url
+			repo_record=$(_fetch_contribution_record "repos/${slug}" "$repo_filter" "repository ${slug}") || return 1
+			IFS=$'\t' read -r repo_name desc url <<<"$repo_record"
 			seen_repos="${seen_repos}${repo_name}"$'\n'
 			contrib_repos="${contrib_repos}- **[${repo_name}](${url})** -- ${desc}"$'\n'
 		done <<<"$contributed_slugs"
@@ -307,6 +374,18 @@ _generate_contributions() {
 	fi
 
 	printf '%s' "$contrib_repos"
+	return 0
+}
+
+# --- Generate contributions for a new rich README without blocking init ---
+_generate_initial_contributions() {
+	local gh_user="$1"
+	local contributions=""
+	if ! contributions=$(_generate_contributions "$gh_user"); then
+		echo "Warning: initial Contributions block omitted because GitHub data was unavailable" >&2
+		return 0
+	fi
+	printf '%s' "$contributions"
 	return 0
 }
 
@@ -516,7 +595,7 @@ _generate_rich_readme() {
 
 	# Build contributions section using shared helper
 	local contrib_repos
-	contrib_repos=$(_generate_contributions "$gh_user")
+	contrib_repos=$(_generate_initial_contributions "$gh_user")
 
 	# Build connect section
 	local connect
@@ -553,7 +632,7 @@ _generate_rich_readme() {
 		if [[ -n "$contrib_repos" ]]; then
 			echo "## Contributions"
 			echo ""
-			printf '%s' "$contrib_repos"
+			printf '%s\n' "$contrib_repos"
 		fi
 		echo "<!-- CONTRIBUTIONS-END -->"
 		echo ""
@@ -1009,25 +1088,96 @@ cmd_update() {
 	return 0
 }
 
+# --- Classify contribution marker topology ---
+_contribution_marker_state() {
+	local readme_path="$1"
+	if [[ ! -r "$readme_path" ]]; then
+		printf '%s\n' invalid
+		return 0
+	fi
+	local start_exact end_exact start_any end_any
+	start_exact=$(grep -cFx "$CONTRIBUTIONS_START_MARKER" "$readme_path" 2>/dev/null || true)
+	end_exact=$(grep -cFx "$CONTRIBUTIONS_END_MARKER" "$readme_path" 2>/dev/null || true)
+	start_any=$(grep -cF 'CONTRIBUTIONS-START' "$readme_path" 2>/dev/null || true)
+	end_any=$(grep -cF 'CONTRIBUTIONS-END' "$readme_path" 2>/dev/null || true)
+
+	if [[ "$start_exact" -eq 1 && "$end_exact" -eq 1 && "$start_any" -eq 1 && "$end_any" -eq 1 ]]; then
+		local start_line end_line
+		start_line=$(grep -nFx "$CONTRIBUTIONS_START_MARKER" "$readme_path" | cut -d: -f1)
+		end_line=$(grep -nFx "$CONTRIBUTIONS_END_MARKER" "$readme_path" | cut -d: -f1)
+		[[ "$start_line" -lt "$end_line" ]] && printf '%s\n' valid || printf '%s\n' invalid
+		return 0
+	fi
+	if [[ "$start_any" -eq 0 && "$end_any" -eq 0 ]]; then
+		printf '%s\n' absent
+		return 0
+	fi
+	if [[ "$start_exact" -eq 1 && "$start_any" -eq 1 && "$end_exact" -eq 0 && "$end_any" -eq 1 ]] &&
+		awk -v marker="$CONTRIBUTIONS_END_MARKER" '
+			index($0, marker) > 1 && index($0, marker) + length(marker) - 1 == length($0) { found = 1 }
+			END { exit(found ? 0 : 1) }
+		' "$readme_path"; then
+		printf '%s\n' legacy-joined-end
+		return 0
+	fi
+	printf '%s\n' invalid
+	return 0
+}
+
+# --- Normalize the legacy generated form with END joined to the last item ---
+_normalize_legacy_contribution_end() {
+	local readme_path="$1"
+	local output_path="$2"
+	awk -v marker="$CONTRIBUTIONS_END_MARKER" '
+		{
+			position = index($0, marker)
+			if (position > 1 && position + length(marker) - 1 == length($0)) {
+				print substr($0, 1, position - 1)
+				print marker
+				next
+			}
+			print
+		}
+	' "$readme_path" >"$output_path"
+	return $?
+}
+
 # --- Migrate static Contributions section to auto-updated markers ---
 # Usage: _update_contributions_migrate_markers <readme_path> <dry_run>
-# Returns 0 on success, 1 if END marker still missing after migration.
 _update_contributions_migrate_markers() {
 	local readme_path="$1"
 	local dry_run="$2"
+	local marker_state
+	marker_state=$(_contribution_marker_state "$readme_path")
 
-	if grep -q '<!-- CONTRIBUTIONS-START -->' "$readme_path"; then
-		# Markers already present — check for END marker
-		if ! grep -q '<!-- CONTRIBUTIONS-END -->' "$readme_path"; then
-			if [[ "$dry_run" == true ]]; then
-				echo "Note: markers would be injected on actual run"
-				return 1
-			fi
-			echo "Error: <!-- CONTRIBUTIONS-END --> marker not found" >&2
+	case "$marker_state" in
+	valid)
+		return 0
+		;;
+	invalid)
+		echo "Error: Contributions markers must be one standalone, ordered pair" >&2
+		return 1
+		;;
+	legacy-joined-end)
+		if [[ "$dry_run" == true ]]; then
+			echo "Note: legacy joined Contributions marker would be normalized"
 			return 1
 		fi
+		local normalize_tmp
+		normalize_tmp=$(mktemp)
+		if ! _normalize_legacy_contribution_end "$readme_path" "$normalize_tmp"; then
+			rm -f "$normalize_tmp"
+			return 1
+		fi
+		if [[ "$(_contribution_marker_state "$normalize_tmp")" != valid ]]; then
+			rm -f "$normalize_tmp"
+			return 1
+		fi
+		mv "$normalize_tmp" "$readme_path"
 		return 0
-	fi
+		;;
+	absent) ;;
+	esac
 
 	if [[ "$dry_run" == true ]]; then
 		echo "Note: CONTRIBUTIONS markers not found — would migrate static section"
@@ -1037,32 +1187,82 @@ _update_contributions_migrate_markers() {
 	echo "Migrating static Contributions section to auto-updated markers..."
 	local inject_tmp
 	inject_tmp=$(mktemp)
-	awk '
+	if ! awk -v start_marker="$CONTRIBUTIONS_START_MARKER" -v end_marker="$CONTRIBUTIONS_END_MARKER" '
 		/^## Contributions/ { in_old_contrib = 1; next }
 		in_old_contrib && /^## / {
 			in_old_contrib = 0
-			print "<!-- CONTRIBUTIONS-START -->"
-			print "<!-- CONTRIBUTIONS-END -->"
+			print start_marker
+			print end_marker
 			print ""
 			print $0
 			next
 		}
 		in_old_contrib { next }
 		{ print }
-	' "$readme_path" >"$inject_tmp"
-	# If EOF reached while still in old section, append markers
-	if ! grep -q '<!-- CONTRIBUTIONS-START -->' "$inject_tmp"; then
-		{
-			echo "<!-- CONTRIBUTIONS-START -->"
-			echo "<!-- CONTRIBUTIONS-END -->"
-		} >>"$inject_tmp"
-	fi
-	mv "$inject_tmp" "$readme_path"
-
-	if ! grep -q '<!-- CONTRIBUTIONS-END -->' "$readme_path"; then
-		echo "Error: <!-- CONTRIBUTIONS-END --> marker not found after migration" >&2
+	' "$readme_path" >"$inject_tmp"; then
+		rm -f "$inject_tmp"
 		return 1
 	fi
+	# If EOF reached while still in old section, append markers
+	if ! grep -qxF "$CONTRIBUTIONS_START_MARKER" "$inject_tmp"; then
+		{
+			echo "$CONTRIBUTIONS_START_MARKER"
+			echo "$CONTRIBUTIONS_END_MARKER"
+		} >>"$inject_tmp"
+	fi
+	if [[ "$(_contribution_marker_state "$inject_tmp")" != valid ]]; then
+		echo "Error: valid Contributions markers not found after migration" >&2
+		rm -f "$inject_tmp"
+		return 1
+	fi
+	mv "$inject_tmp" "$readme_path"
+	return 0
+}
+
+# --- Record the daily contributions throttle after a complete refresh ---
+_record_contributions_update() {
+	local cache_dir="${HOME}/.aidevops/cache"
+	if ! mkdir -p "$cache_dir"; then
+		echo "Warning: could not create contributions throttle cache" >&2
+		return 1
+	fi
+	if ! date -u +"%Y-%m-%d" >"${cache_dir}/contributions-last-update"; then
+		echo "Warning: could not record contributions refresh timestamp" >&2
+		return 1
+	fi
+	return 0
+}
+
+_contributions_pending_push_file() {
+	printf '%s\n' "${HOME}/.aidevops/cache/contributions-pending-push"
+	return 0
+}
+
+_record_pending_contributions_push() {
+	local profile_repo="$1"
+	local pending_file
+	pending_file=$(_contributions_pending_push_file)
+	mkdir -p "${pending_file%/*}" || return 1
+	git -C "$profile_repo" rev-parse HEAD >"$pending_file"
+	return $?
+}
+
+_clear_pending_contributions_push() {
+	local pending_file
+	pending_file=$(_contributions_pending_push_file)
+	rm -f "$pending_file"
+	return 0
+}
+
+# --- Resolve the profile repository's push branch ---
+_profile_default_branch() {
+	local profile_repo="$1"
+	local default_branch=""
+	default_branch=$(git -C "$profile_repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
+	if [[ -z "$default_branch" ]]; then
+		default_branch=$(git -C "$profile_repo" branch --show-current 2>/dev/null || true)
+	fi
+	printf '%s\n' "${default_branch:-main}"
 	return 0
 }
 
@@ -1078,28 +1278,106 @@ _update_contributions_push() {
 	local commit_msg
 	commit_msg="chore: update profile contributions ($(date -u +%Y-%m-%d))"
 	git -C "$profile_repo" add README.md
-	git -C "$profile_repo" commit -m "$commit_msg" --no-verify 2>/dev/null || {
-		echo "No changes to commit"
-		return 0
-	}
+	if ! git -C "$profile_repo" commit -m "$commit_msg" --no-verify -- README.md 2>/dev/null; then
+		echo "Warning: contributions commit failed" >&2
+		return 1
+	fi
+	_record_pending_contributions_push "$profile_repo" || return 1
 
 	local default_branch
-	default_branch=$(git -C "$profile_repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
-	if [[ -z "$default_branch" ]]; then
-		default_branch=$(git -C "$profile_repo" branch --show-current 2>/dev/null || true)
-	fi
-	default_branch="${default_branch:-main}"
-	git -C "$profile_repo" push origin "$default_branch" 2>/dev/null || {
+	default_branch=$(_profile_default_branch "$profile_repo")
+	if ! git -C "$profile_repo" push origin "$default_branch" 2>/dev/null; then
 		echo "Warning: push failed — contributions committed locally" >&2
-		return 0
-	}
-
-	# Record last-run timestamp for daily throttle
-	local cache_dir="${HOME}/.aidevops/cache"
-	mkdir -p "$cache_dir"
-	date -u +"%Y-%m-%d" >"${cache_dir}/contributions-last-update"
+		return 1
+	fi
+	_clear_pending_contributions_push
+	_record_contributions_update || return 1
 
 	echo "Profile contributions updated and pushed"
+	return 0
+}
+
+# --- Verify a profile write cannot publish unrelated local work ---
+_ensure_profile_write_ready() {
+	local profile_repo="$1"
+	local readme_status=""
+	if ! readme_status=$(git -C "$profile_repo" status --porcelain -- README.md 2>/dev/null); then
+		echo "Warning: could not verify local profile README state" >&2
+		return 1
+	fi
+	if [[ -n "$readme_status" ]]; then
+		echo "Warning: local profile README has uncommitted changes; refusing automated commit" >&2
+		return 1
+	fi
+	if ! git -C "$profile_repo" diff --cached --quiet; then
+		echo "Warning: profile repository has unrelated staged changes" >&2
+		return 1
+	fi
+
+	local default_branch ahead_count pending_file pending_sha head_sha
+	default_branch=$(_profile_default_branch "$profile_repo")
+	if ! ahead_count=$(git -C "$profile_repo" rev-list --count "origin/${default_branch}..HEAD" 2>/dev/null); then
+		echo "Warning: could not verify whether profile contributions were pushed" >&2
+		return 1
+	fi
+	if [[ "$ahead_count" -gt 0 ]] 2>/dev/null; then
+		pending_file=$(_contributions_pending_push_file)
+		if [[ ! -f "$pending_file" ]]; then
+			echo "Warning: local profile branch has unrelated unpushed commits" >&2
+			return 1
+		fi
+		pending_sha=$(<"$pending_file")
+		head_sha=$(git -C "$profile_repo" rev-parse HEAD 2>/dev/null || true)
+		if [[ -z "$pending_sha" || "$pending_sha" != "$head_sha" ]]; then
+			echo "Warning: pending contributions marker does not match local profile HEAD" >&2
+			return 1
+		fi
+		if ! git -C "$profile_repo" push origin "$default_branch" 2>/dev/null; then
+			echo "Warning: pending profile contributions push failed" >&2
+			return 1
+		fi
+	fi
+	_clear_pending_contributions_push
+	return 0
+}
+
+# --- Complete a local no-op without suppressing pending push retries ---
+_finalize_unchanged_contributions() {
+	local profile_repo="$1"
+	_ensure_profile_write_ready "$profile_repo" || return 1
+	_record_contributions_update || return 1
+	return 0
+}
+
+# --- Render a validated contributions block into a candidate README ---
+_render_contributions_candidate() {
+	local readme_path="$1"
+	local new_contribs="$2"
+	local contribs_block=""
+	if [[ -n "$new_contribs" ]]; then
+		contribs_block="## Contributions"$'\n'$'\n'"${new_contribs}"$'\n'
+	fi
+	if ! CONTRIBS_BLOCK="$contribs_block" awk \
+		-v start_marker="$CONTRIBUTIONS_START_MARKER" \
+		-v end_marker="$CONTRIBUTIONS_END_MARKER" '
+		$0 == start_marker {
+			print
+			skip = 1
+			next
+		}
+		$0 == end_marker {
+			skip = 0
+			block = ENVIRON["CONTRIBS_BLOCK"]
+			if (block != "") {
+				printf "%s", block
+			}
+			print
+			next
+		}
+		!skip { print }
+	' "$readme_path"; then
+		return 1
+	fi
 	return 0
 }
 
@@ -1122,9 +1400,6 @@ cmd_update_contributions() {
 		return 1
 	fi
 
-	# Ensure CONTRIBUTIONS markers exist (migrate from static section if needed)
-	_update_contributions_migrate_markers "$readme_path" "$dry_run" || return 0
-
 	# Resolve GitHub username
 	local gh_user
 	gh_user=$(_resolve_profile_user "$profile_repo")
@@ -1135,39 +1410,46 @@ cmd_update_contributions() {
 
 	# Generate new contributions content
 	local new_contribs
-	new_contribs=$(_generate_contributions "$gh_user")
+	if ! new_contribs=$(_generate_contributions "$gh_user"); then
+		echo "Warning: contributions refresh aborted; existing Contributions block was preserved" >&2
+		return 1
+	fi
+	if [[ "$dry_run" != true ]]; then
+		_ensure_profile_write_ready "$profile_repo" || return 1
+	fi
 
-	# Build the replacement block
-	local contribs_block=""
-	if [[ -n "$new_contribs" ]]; then
-		contribs_block="## Contributions"$'\n'$'\n'"${new_contribs}"
+	# Build every migration and render in temporary files. README.md is replaced
+	# only after all remote reads, marker transforms, and rendering succeed.
+	local migration_source
+	migration_source=$(mktemp)
+	if ! cp "$readme_path" "$migration_source"; then
+		rm -f "$migration_source"
+		return 1
+	fi
+	if ! _update_contributions_migrate_markers "$migration_source" "$dry_run"; then
+		rm -f "$migration_source"
+		if [[ "$dry_run" == true ]] && [[ "$(_contribution_marker_state "$readme_path")" == absent ]]; then
+			return 0
+		fi
+		return 1
 	fi
 
 	# Replace content between markers
 	local tmp_file
 	tmp_file=$(mktemp)
-	CONTRIBS_BLOCK="$contribs_block" awk '
-		/<!-- CONTRIBUTIONS-START -->/ {
-			print "<!-- CONTRIBUTIONS-START -->"
-			skip = 1
-			next
-		}
-		/<!-- CONTRIBUTIONS-END -->/ {
-			skip = 0
-			block = ENVIRON["CONTRIBS_BLOCK"]
-			if (block != "") {
-				printf "%s", block
-			}
-			print "<!-- CONTRIBUTIONS-END -->"
-			next
-		}
-		!skip { print }
-	' "$readme_path" >"$tmp_file"
+	if ! _render_contributions_candidate "$migration_source" "$new_contribs" >"$tmp_file"; then
+		rm -f "$migration_source" "$tmp_file"
+		return 1
+	fi
+	rm -f "$migration_source"
 
 	# Check if content actually changed
 	if diff -q "$readme_path" "$tmp_file" >/dev/null 2>&1; then
 		echo "Contributions unchanged — skipping"
 		rm -f "$tmp_file"
+		if [[ "$dry_run" != true ]]; then
+			_finalize_unchanged_contributions "$profile_repo" || return 1
+		fi
 		return 0
 	fi
 
@@ -1179,8 +1461,11 @@ cmd_update_contributions() {
 	fi
 
 	# Apply changes and push
-	mv "$tmp_file" "$readme_path"
-	_update_contributions_push "$profile_repo"
+	if ! mv "$tmp_file" "$readme_path"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	_update_contributions_push "$profile_repo" || return 1
 	return 0
 }
 

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -326,7 +326,7 @@ _generate_contributions() {
 			fork_record=$(_fetch_contribution_record "repos/${gh_user}/${fork_name}" "$fork_filter" "fork ${fork_name}") || return 1
 			local rname rdesc rurl
 			IFS=$'\t' read -r rname rdesc rurl <<<"$fork_record"
-			if [[ -n "$seen_repos" ]] && grep -qxF "$rname" <<<"$seen_repos" 2>/dev/null; then
+			if [[ -n "$seen_repos" ]] && grep -qxF -- "$rname" <<<"$seen_repos" 2>/dev/null; then
 				continue
 			fi
 			seen_repos="${seen_repos}${rname}"$'\n'
@@ -354,7 +354,7 @@ _generate_contributions() {
 			local repo_name
 			repo_name="${slug##*/}"
 			# Deduplicate against all previously seen repos (forks + earlier entries)
-			if [[ -n "$seen_repos" ]] && grep -qxF "$repo_name" <<<"$seen_repos" 2>/dev/null; then
+			if [[ -n "$seen_repos" ]] && grep -qxF -- "$repo_name" <<<"$seen_repos" 2>/dev/null; then
 				continue
 			fi
 			local repo_record desc url

--- a/.agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh
+++ b/.agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh
@@ -1,0 +1,674 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for fail-closed profile contribution generation.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../profile-readme-helper.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n       %s\n' "$name" "$detail"
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+write_gh_stub() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+
+scenario="${GH_SCENARIO:-success}"
+[[ "${1:-}" == "api" ]] || exit 1
+endpoint="${2:-}"
+
+case "$endpoint" in
+users/fixture/repos*)
+	case "$scenario" in
+	list-failure)
+		printf '%s\n' '{"message":"API rate limit exceeded","status":"403"}'
+		exit 1
+		;;
+	list-failure-valid-output)
+		printf '%s\n' '[{"fork":true,"name":"fork-one"}]'
+		exit 1
+		;;
+	malformed-list)
+		printf '%s\n' '{"message":"API rate limit exceeded","status":"403"}'
+		exit 0
+		;;
+	esac
+	printf '%s\n' '[{"fork":true,"name":"fork-one"}]'
+	exit 0
+	;;
+repos/fixture/fork-one)
+	case "$scenario" in
+	fork-failure)
+		printf '%s\n' '{"message":"API rate limit exceeded","status":"403"}'
+		exit 1
+		;;
+	fork-failure-valid-output)
+		printf 'fork-one\tFork description\thttps://example.invalid/fork-one\n'
+		exit 1
+		;;
+	malformed-fork)
+		printf '%s\n' '{"message":"API rate limit exceeded","status":"403"}'
+		exit 0
+		;;
+	marker-injection)
+		printf 'fork-one\tUnsafe <!-- CONTRIBUTIONS-END --> marker\thttps://example.invalid/fork-one\n'
+		exit 0
+		;;
+	synthesized-marker)
+		printf 'fork-one\tUnsafe <![-- CONTRIBUTIONS-END --]> marker\thttps://example.invalid/fork-one\n'
+		exit 0
+		;;
+	changed)
+		printf 'fork-one\tChanged fork description\thttps://example.invalid/fork-one\n'
+		exit 0
+		;;
+	esac
+	printf 'fork-one\tFork description\thttps://example.invalid/fork-one\n'
+	exit 0
+	;;
+repos/upstream/configured)
+	if [[ "$scenario" == "configured-failure" ]]; then
+		printf '%s\n' '{"message":"API rate limit exceeded","status":"403"}'
+		exit 1
+	fi
+	if [[ "$scenario" == "configured-failure-valid-output" ]]; then
+		printf 'configured\tNo description\thttps://example.invalid/configured\n'
+		exit 1
+	fi
+	printf 'configured\tNo description\thttps://example.invalid/configured\n'
+	exit 0
+	;;
+esac
+
+exit 1
+STUB
+	chmod +x "${bin_dir}/gh"
+	return 0
+}
+
+create_fixture() {
+	local case_name="$1"
+	local case_root="${TEST_ROOT}/${case_name}"
+	local fixture_home="${case_root}/home"
+	local profile_repo="${case_root}/fixture"
+	local remote_repo="${case_root}/remote.git"
+
+	mkdir -p "${fixture_home}/.config/aidevops" "$profile_repo"
+	git init --bare --initial-branch=main "$remote_repo" >/dev/null
+	git init -b main "$profile_repo" >/dev/null
+	git -C "$profile_repo" config user.name "Fixture"
+	git -C "$profile_repo" config user.email "fixture@example.invalid"
+	git -C "$profile_repo" config commit.gpgsign false
+	git -C "$profile_repo" remote add origin "$remote_repo"
+
+	cat >"${profile_repo}/README.md" <<'README'
+# Fixture Profile
+
+<!-- CONTRIBUTIONS-START -->
+## Contributions
+
+- **[last-known-good](https://example.invalid/last-known-good)** -- Preserved content
+<!-- CONTRIBUTIONS-END -->
+README
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: seed profile" >/dev/null
+	git -C "$profile_repo" push -u origin main >/dev/null
+
+	cat >"${fixture_home}/.config/aidevops/repos.json" <<EOF
+{
+  "initialized_repos": [
+    {
+      "path": "${profile_repo}",
+      "slug": "fixture/fixture",
+      "priority": "profile"
+    },
+    {
+      "path": "${case_root}/configured",
+      "slug": "upstream/configured",
+      "contributed": true
+    }
+  ]
+}
+EOF
+	write_gh_stub "${case_root}/bin"
+	printf '%s\n' "$case_root"
+	return 0
+}
+
+run_failure_case() {
+	local scenario="$1"
+	local case_root
+	case_root=$(create_fixture "$scenario") || return 1
+	local profile_repo="${case_root}/fixture"
+	local before_file="${case_root}/before.md"
+	cp "${profile_repo}/README.md" "$before_file"
+
+	local output=""
+	local exit_code=0
+	output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO="$scenario" \
+		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		fail "$scenario fails closed" "helper unexpectedly succeeded"
+		return 0
+	fi
+	if ! cmp -s "$before_file" "${profile_repo}/README.md"; then
+		fail "$scenario preserves README" "README changed after API failure"
+		return 0
+	fi
+	if [[ -n "$(git -C "$profile_repo" status --porcelain)" ]]; then
+		fail "$scenario preserves git state" "profile repository became dirty"
+		return 0
+	fi
+	if [[ "$output" == *"API rate limit exceeded"* ]]; then
+		fail "$scenario discards API error payload" "raw error payload leaked into output"
+		return 0
+	fi
+	if [[ "$output" != *"preserv"* ]]; then
+		fail "$scenario reports preservation" "missing preservation warning: ${output}"
+		return 0
+	fi
+	if [[ -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]]; then
+		fail "$scenario leaves throttle open" "failure incorrectly recorded as a successful refresh"
+		return 0
+	fi
+	pass "$scenario fails closed without mutation"
+	return 0
+}
+
+test_static_section_failure_preserves_content() {
+	local case_root
+	case_root=$(create_fixture "static-section-failure") || return 1
+	local profile_repo="${case_root}/fixture"
+	cat >"${profile_repo}/README.md" <<'README'
+# Fixture Profile
+
+## Contributions
+
+- **[last-known-good](https://example.invalid/last-known-good)** -- Preserved static content
+
+## Connect
+
+- Existing content
+README
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: use static contributions" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+	cp "${profile_repo}/README.md" "${case_root}/before-static.md"
+
+	local output=""
+	local exit_code=0
+	output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=list-failure \
+		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-static.md" "${profile_repo}/README.md"; then
+		fail "marker migration waits for validated data" "exit=${exit_code} output=${output}"
+		return 0
+	fi
+	if [[ -n "$(git -C "$profile_repo" status --porcelain)" ]]; then
+		fail "marker migration failure preserves git state" "profile repository became dirty"
+		return 0
+	fi
+	pass "marker migration waits for validated data"
+	return 0
+}
+
+test_static_transform_failure_preserves_content() {
+	local case_root
+	case_root=$(create_fixture "static-transform-failure") || return 1
+	local profile_repo="${case_root}/fixture"
+	cat >"${profile_repo}/README.md" <<'README'
+# Fixture Profile
+
+## Contributions
+
+- Existing static contribution
+
+## Connect
+README
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: use static section" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+	cp "${profile_repo}/README.md" "${case_root}/before-transform.md"
+	cat >"${case_root}/bin/awk" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+	chmod +x "${case_root}/bin/awk"
+
+	local exit_code=0
+	HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-transform.md" "${profile_repo}/README.md"; then
+		fail "static transform failure preserves content" "exit=${exit_code}"
+		return 0
+	fi
+	pass "static transform failure preserves content"
+	return 0
+}
+
+test_invalid_static_transform_preserves_content() {
+	local case_root
+	case_root=$(create_fixture "invalid-static-transform") || return 1
+	local profile_repo="${case_root}/fixture"
+	cat >"${profile_repo}/README.md" <<'README'
+# Fixture Profile
+## Contributions
+- First section
+## Connect
+## Contributions
+- Second section
+## End
+README
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: duplicate static sections" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+	cp "${profile_repo}/README.md" "${case_root}/before-invalid-transform.md"
+
+	local exit_code=0
+	HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-invalid-transform.md" "${profile_repo}/README.md"; then
+		fail "invalid static transform preserves content" "exit=${exit_code}"
+		return 0
+	fi
+	pass "invalid static transform preserves content"
+	return 0
+}
+
+test_renderer_failure_after_migration_preserves_content() {
+	local case_root
+	case_root=$(create_fixture "renderer-after-migration") || return 1
+	local profile_repo="${case_root}/fixture"
+	cat >"${profile_repo}/README.md" <<'README'
+# Fixture Profile
+## Contributions
+- Existing static contribution
+## Connect
+README
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: static section before renderer failure" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+	cp "${profile_repo}/README.md" "${case_root}/before-renderer.md"
+	local real_awk
+	real_awk=$(command -v awk)
+	cat >"${case_root}/bin/awk" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+*in_old_contrib*) exec "${real_awk}" "\$@" ;;
+*) exit 1 ;;
+esac
+STUB
+	chmod +x "${case_root}/bin/awk"
+
+	local exit_code=0
+	HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-renderer.md" "${profile_repo}/README.md"; then
+		fail "renderer failure after migration preserves content" "exit=${exit_code}"
+		return 0
+	fi
+	pass "renderer failure after migration preserves content"
+	return 0
+}
+
+test_final_replacement_failure_preserves_content() {
+	local case_root
+	case_root=$(create_fixture "final-replacement-failure") || return 1
+	local profile_repo="${case_root}/fixture"
+	cp "${profile_repo}/README.md" "${case_root}/before-replacement.md"
+	cat >"${case_root}/bin/mv" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+	chmod +x "${case_root}/bin/mv"
+
+	local exit_code=0
+	HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-replacement.md" "${profile_repo}/README.md"; then
+		fail "final replacement failure preserves content" "exit=${exit_code}"
+		return 0
+	fi
+	if [[ -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]]; then
+		fail "final replacement failure leaves throttle open" "failure recorded as success"
+		return 0
+	fi
+	pass "final replacement failure preserves content"
+	return 0
+}
+
+test_malformed_markers_fail() {
+	local case_root
+	case_root=$(create_fixture "malformed-markers") || return 1
+	local profile_repo="${case_root}/fixture"
+	local readme="${profile_repo}/README.md"
+	grep -vF '<!-- CONTRIBUTIONS-END -->' "$readme" >"${case_root}/without-end.md"
+	mv "${case_root}/without-end.md" "$readme"
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: remove end marker" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+	cp "$readme" "${case_root}/before-malformed.md"
+
+	local output=""
+	local exit_code=0
+	output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-malformed.md" "$readme"; then
+		fail "malformed markers fail without mutation" "exit=${exit_code} output=${output}"
+		return 0
+	fi
+	if [[ -n "$(git -C "$profile_repo" status --porcelain)" ]]; then
+		fail "malformed markers preserve git state" "profile repository became dirty"
+		return 0
+	fi
+	pass "malformed markers fail without mutation"
+	return 0
+}
+
+test_marker_topology_rejected() {
+	local topology="$1"
+	local case_root
+	case_root=$(create_fixture "topology-${topology}") || return 1
+	local profile_repo="${case_root}/fixture"
+	local readme="${profile_repo}/README.md"
+	case "$topology" in
+	orphan-end)
+		grep -vF '<!-- CONTRIBUTIONS-START -->' "$readme" >"${case_root}/invalid.md"
+		;;
+	reversed)
+		cat >"${case_root}/invalid.md" <<'README'
+# Fixture Profile
+<!-- CONTRIBUTIONS-END -->
+Old content
+<!-- CONTRIBUTIONS-START -->
+README
+		;;
+	duplicate-start)
+		cp "$readme" "${case_root}/invalid.md"
+		printf '%s\n' '<!-- CONTRIBUTIONS-START -->' >>"${case_root}/invalid.md"
+		;;
+	joined-end-before-start)
+		cat >"${case_root}/invalid.md" <<'README'
+# Fixture Profile
+Old content<!-- CONTRIBUTIONS-END -->
+<!-- CONTRIBUTIONS-START -->
+README
+		;;
+	esac
+	mv "${case_root}/invalid.md" "$readme"
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: create invalid marker topology" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+	cp "$readme" "${case_root}/before-topology.md"
+
+	local output=""
+	local exit_code=0
+	output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]] || ! cmp -s "${case_root}/before-topology.md" "$readme"; then
+		fail "${topology} marker topology is rejected" "exit=${exit_code} output=${output}"
+		return 0
+	fi
+	pass "${topology} marker topology is rejected"
+	return 0
+}
+
+test_legacy_joined_marker_is_repaired() {
+	local case_root
+	case_root=$(create_fixture "legacy-joined-marker") || return 1
+	local profile_repo="${case_root}/fixture"
+	local readme="${profile_repo}/README.md"
+	awk '
+		/last-known-good/ { printf "%s", $0; next }
+		/<!-- CONTRIBUTIONS-END -->/ { print; next }
+		{ print }
+	' "$readme" >"${case_root}/joined.md"
+	mv "${case_root}/joined.md" "$readme"
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "test: join legacy end marker" >/dev/null
+	git -C "$profile_repo" push origin main >/dev/null
+
+	local output=""
+	if ! output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1); then
+		fail "legacy joined marker is repaired" "$output"
+		return 0
+	fi
+	if [[ "$(grep -cFx '<!-- CONTRIBUTIONS-START -->' "$readme")" -ne 1 ]] ||
+		[[ "$(grep -cFx '<!-- CONTRIBUTIONS-END -->' "$readme")" -ne 1 ]]; then
+		fail "legacy joined marker becomes one exact pair" "marker counts are invalid"
+		return 0
+	fi
+	pass "legacy joined marker is repaired"
+	return 0
+}
+
+test_successful_refresh() {
+	local case_root
+	case_root=$(create_fixture "success") || return 1
+	local profile_repo="${case_root}/fixture"
+	local output=""
+
+	if ! output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1); then
+		fail "healthy refresh succeeds" "$output"
+		return 0
+	fi
+	local readme="${profile_repo}/README.md"
+	if ! grep -Fq -- '- **[configured](https://example.invalid/configured)** -- No description' "$readme" ||
+		! grep -Fq -- '- **[fork-one](https://example.invalid/fork-one)** -- Fork description' "$readme"; then
+		fail "healthy refresh renders validated records" "expected contribution lines missing"
+		return 0
+	fi
+	local configured_line fork_line
+	configured_line=$(grep -nF -- '- **[configured]' "$readme" | cut -d: -f1)
+	fork_line=$(grep -nF -- '- **[fork-one]' "$readme" | cut -d: -f1)
+	if [[ "$configured_line" -ge "$fork_line" ]]; then
+		fail "healthy refresh sorts records" "configured=${configured_line} fork=${fork_line}"
+		return 0
+	fi
+	if ! grep -qxF '<!-- CONTRIBUTIONS-END -->' "$readme"; then
+		fail "healthy refresh keeps end marker on its own line" "end marker was joined to generated content"
+		return 0
+	fi
+	if [[ ! -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]]; then
+		fail "healthy refresh records throttle" "success timestamp missing"
+		return 0
+	fi
+	pass "healthy refresh renders deterministic validated content"
+	return 0
+}
+
+test_unchanged_refresh_records_throttle() {
+	local case_root
+	case_root=$(create_fixture "unchanged") || return 1
+	local profile_repo="${case_root}/fixture"
+	local run_env_path="${case_root}/bin:${PATH}"
+
+	if ! HOME="${case_root}/home" PATH="$run_env_path" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions >/dev/null 2>&1; then
+		fail "unchanged refresh fixture setup" "initial refresh failed"
+		return 0
+	fi
+	rm -f "${case_root}/home/.aidevops/cache/contributions-last-update"
+	local before_head
+	before_head=$(git -C "$profile_repo" rev-parse HEAD)
+	local output=""
+	if ! output=$(HOME="${case_root}/home" PATH="$run_env_path" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1); then
+		fail "unchanged refresh succeeds" "$output"
+		return 0
+	fi
+	if [[ "$output" != *"Contributions unchanged"* ]] ||
+		[[ ! -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]] ||
+		[[ "$before_head" != "$(git -C "$profile_repo" rev-parse HEAD)" ]]; then
+		fail "unchanged refresh records throttle" "output=${output}"
+		return 0
+	fi
+	pass "unchanged refresh records throttle without a commit"
+	return 0
+}
+
+test_push_failure_propagates() {
+	local case_root
+	case_root=$(create_fixture "push-failure") || return 1
+	local profile_repo="${case_root}/fixture"
+	git -C "$profile_repo" remote set-url origin "${case_root}/missing-remote.git"
+
+	local output=""
+	local exit_code=0
+	output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 0 || "$output" != *"push failed"* ]]; then
+		fail "push failure propagates" "exit=${exit_code} output=${output}"
+		return 0
+	fi
+	if [[ -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]]; then
+		fail "push failure leaves throttle open" "failure incorrectly recorded as success"
+		return 0
+	fi
+
+	git -C "$profile_repo" remote set-url origin "${case_root}/remote.git"
+	local retry_output=""
+	if ! retry_output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions 2>&1); then
+		fail "push retry succeeds" "$retry_output"
+		return 0
+	fi
+	local local_head remote_head
+	local_head=$(git -C "$profile_repo" rev-parse HEAD)
+	remote_head=$(git --git-dir="${case_root}/remote.git" rev-parse main)
+	if [[ "$local_head" != "$remote_head" ]] ||
+		[[ ! -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]]; then
+		fail "push retry closes throttle after remote sync" "local=${local_head} remote=${remote_head} output=${retry_output}"
+		return 0
+	fi
+	pass "push failure propagates and retry synchronizes remote"
+	return 0
+}
+
+test_unrelated_local_work_is_not_published() {
+	local mode="$1"
+	local case_root
+	case_root=$(create_fixture "unrelated-${mode}") || return 1
+	local profile_repo="${case_root}/fixture"
+	local run_path="${case_root}/bin:${PATH}"
+	if ! HOME="${case_root}/home" PATH="$run_path" GH_SCENARIO=success \
+		bash "$HELPER" update-contributions >/dev/null 2>&1; then
+		fail "${mode} local-work fixture setup" "initial refresh failed"
+		return 0
+	fi
+	rm -f "${case_root}/home/.aidevops/cache/contributions-last-update"
+	local remote_before
+	remote_before=$(git --git-dir="${case_root}/remote.git" rev-parse main)
+	if [[ "$mode" == dirty-readme ]]; then
+		printf '%s\n' 'Manual draft' >>"${profile_repo}/README.md"
+	elif [[ "$mode" == staged-file ]]; then
+		printf '%s\n' 'Unrelated staged file' >"${profile_repo}/NOTES.md"
+		git -C "$profile_repo" add NOTES.md
+	else
+		printf '%s\n' 'Unrelated local commit' >"${profile_repo}/NOTES.md"
+		git -C "$profile_repo" add NOTES.md
+		git -C "$profile_repo" commit -m "docs: unrelated local work" >/dev/null
+	fi
+
+	local output=""
+	local exit_code=0
+	output=$(HOME="${case_root}/home" PATH="$run_path" GH_SCENARIO=changed \
+		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
+	local remote_after
+	remote_after=$(git --git-dir="${case_root}/remote.git" rev-parse main)
+	if [[ "$exit_code" -eq 0 || "$remote_before" != "$remote_after" ]]; then
+		fail "${mode} local work is not published" "exit=${exit_code} output=${output}"
+		return 0
+	fi
+	pass "${mode} local work is not published"
+	return 0
+}
+
+test_renderer_failure_propagates() {
+	local exit_code=0
+	(
+		set -- help
+		# shellcheck source=../profile-readme-helper.sh
+		source "$HELPER" >/dev/null
+		_render_contributions_candidate "/missing/profile-readme" "validated"
+	) >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]]; then
+		fail "renderer failure propagates" "missing input unexpectedly succeeded"
+		return 0
+	fi
+	pass "renderer failure propagates"
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/profile-contributions-test.XXXXXX") || return 1
+	trap teardown EXIT
+
+	run_failure_case "list-failure"
+	run_failure_case "list-failure-valid-output"
+	run_failure_case "malformed-list"
+	run_failure_case "fork-failure"
+	run_failure_case "fork-failure-valid-output"
+	run_failure_case "malformed-fork"
+	run_failure_case "configured-failure"
+	run_failure_case "configured-failure-valid-output"
+	run_failure_case "marker-injection"
+	run_failure_case "synthesized-marker"
+	test_static_section_failure_preserves_content
+	test_static_transform_failure_preserves_content
+	test_invalid_static_transform_preserves_content
+	test_renderer_failure_after_migration_preserves_content
+	test_final_replacement_failure_preserves_content
+	test_malformed_markers_fail
+	test_marker_topology_rejected "orphan-end"
+	test_marker_topology_rejected "reversed"
+	test_marker_topology_rejected "duplicate-start"
+	test_marker_topology_rejected "joined-end-before-start"
+	test_legacy_joined_marker_is_repaired
+	test_successful_refresh
+	test_unchanged_refresh_records_throttle
+	test_push_failure_propagates
+	test_unrelated_local_work_is_not_published "dirty-readme"
+	test_unrelated_local_work_is_not_published "ahead-commit"
+	test_unrelated_local_work_is_not_published "staged-file"
+	test_renderer_failure_propagates
+
+	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -356,6 +356,12 @@ jobs:
         bash .agents/scripts/tests/test-profile-readme-boundary.sh
         echo "Profile README boundary guard passed"
 
+    - name: Profile README Contributions Fail-Closed Guard
+      run: |
+        echo "Running profile README contributions fail-closed regression guard..."
+        bash .agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh
+        echo "Profile README contributions fail-closed guard passed"
+
     - name: Stats Functions Characterization (t2044)
       run: |
         echo "Running stats-functions.sh characterization tests..."


### PR DESCRIPTION
## Summary

Make profile contribution refreshes validate all GitHub responses, preserve last-known-good content on every failure, repair legacy joined markers transactionally, and prevent unrelated local work from being published.

## Files Changed

.agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh, .github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 28 focused fail-closed integration cases, 10 profile boundary cases, Bash syntax, ShellCheck, shfmt, actionlint, git diff check, and independent code/audit reviews.

Resolves #26937


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.5 with gpt-5.6-sol spent 1h 8m and 613,684 tokens on this with the user in an interactive session.