### PR TITLE
GH#26940: Fix agent test multi-case JSON channel corruption

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -474,8 +474,8 @@ _cmd_run_print_header() {
 #   $6  - suite timeout (default)
 #   $7  - current results JSON array
 # Outputs:
-#   Line 1: updated results JSON array
-#   Line 2: outcome — "pass", "fail", or "skip"
+#   File descriptor 3: updated results JSON array followed by outcome
+#   Standard output: human-readable progress and validation diagnostics
 #######################################
 _cmd_run_execute_test() {
 	local test_json="$1"
@@ -510,8 +510,8 @@ _cmd_run_execute_test() {
 		echo -e "  ${YELLOW}SKIPPED${NC}"
 		results=$(echo "$results" | jq --arg id "$test_id" --arg status "skipped" \
 			'. + [{"id": $id, "status": $status}]')
-		echo "$results"
-		echo "skip"
+		printf '%s\n' "$results" >&3
+		printf '%s\n' "skip" >&3
 		return 0
 	fi
 
@@ -539,8 +539,8 @@ _cmd_run_execute_test() {
 			--arg error "timeout_or_error" \
 			--argjson duration "$test_duration" \
 			'. + [{"id": $id, "status": $status, "error": $error, "duration": $duration}]')
-		echo "$results"
-		echo "fail"
+		printf '%s\n' "$results" >&3
+		printf '%s\n' "fail" >&3
 		return 0
 	fi
 
@@ -564,8 +564,8 @@ _cmd_run_execute_test() {
 		--argjson chars "$response_chars" \
 		'. + [{"id": $id, "status": $status, "response_preview": $response, "duration": $duration, "response_chars": $chars}]')
 
-	echo "$results"
-	echo "$run_status"
+	printf '%s\n' "$results" >&3
+	printf '%s\n' "$run_status" >&3
 	return 0
 }
 
@@ -793,6 +793,37 @@ _cmd_run_emit_json_metrics() {
 }
 
 #######################################
+# Capture one test's machine result while routing human output separately
+# Arguments:
+#   $1-$7 - forwarded to _cmd_run_execute_test
+#   $8    - whether JSON-only output is enabled
+# Outputs:
+#   Updated results JSON array followed by outcome on stdout
+#######################################
+_cmd_run_capture_test() {
+	local test_json="$1"
+	local test_index="$2"
+	local test_count="$3"
+	local suite_agent="$4"
+	local suite_model="$5"
+	local suite_timeout="$6"
+	local results="$7"
+	local json_output="$8"
+
+	exec 3>&1
+	if [[ "$json_output" == "false" ]]; then
+		exec 1>&2
+	else
+		exec 1>/dev/null
+	fi
+	_cmd_run_execute_test \
+		"$test_json" "$test_index" "$test_count" \
+		"$suite_agent" "$suite_model" "$suite_timeout" \
+		"$results"
+	return 0
+}
+
+#######################################
 # RUN command - execute a test suite
 # Arguments:
 #   $1 - test file path or name
@@ -852,10 +883,10 @@ cmd_run() {
 		test_json=$(echo "$suite" | jq -c ".tests[$i]")
 
 		local exec_output outcome
-		exec_output=$(_cmd_run_execute_test \
+		exec_output=$(_cmd_run_capture_test \
 			"$test_json" "$i" "$test_count" \
 			"$suite_agent" "$suite_model" "$suite_timeout" \
-			"$results")
+			"$results" "$json_output")
 		results=$(echo "$exec_output" | sed '$d')
 		outcome=$(echo "$exec_output" | tail -n 1)
 
@@ -1398,4 +1429,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$TEST_SCRIPT_DIR/../../.." && pwd)" || exit
+TEST_ROOT=$(mktemp -d)
+export HOME="$TEST_ROOT/home"
+export AGENT_TEST_CLI="mock"
+mkdir -p "$HOME"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# shellcheck source=../agent-test-helper.sh
+source "$REPO_ROOT/.agents/scripts/agent-test-helper.sh"
+
+run_prompt() {
+	local prompt="$1"
+	local agent="$2"
+	local model="$3"
+	local timeout="$4"
+	: "$agent" "$model" "$timeout"
+
+	case "$prompt" in
+	timeout)
+		printf '%s\n' "[TIMEOUT after ${timeout}s]"
+		return 1
+		;;
+	*)
+		printf '%s\n' "mock response for ${prompt}"
+		return 0
+		;;
+	esac
+}
+
+_cmd_run_sync_pattern_tracker() {
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+pass_suite="$TEST_ROOT/pass-suite.json"
+cat >"$pass_suite" <<'JSON'
+{
+  "name": "output-channel-pass",
+  "tests": [
+    {"id": "first", "prompt": "first", "expect_contains": ["mock response"]},
+    {"id": "second", "prompt": "second", "expect_contains": ["mock response"]}
+  ]
+}
+JSON
+
+human_stdout="$TEST_ROOT/human.stdout"
+human_stderr="$TEST_ROOT/human.stderr"
+cmd_run "$pass_suite" >"$human_stdout" 2>"$human_stderr" ||
+	fail "passing suite returned non-zero"
+
+grep -q '\[1/2\] first' "$human_stderr" ||
+	fail "human output omitted first-case progress"
+grep -q '\[2/2\] second' "$human_stderr" ||
+	fail "human output omitted second-case progress"
+
+pass_result=$(ls -1 "$RESULTS_DIR"/output-channel-pass-*.json)
+jq -e '.summary.passed == 2 and .summary.failed == 0 and (.results | length) == 2' \
+	"$pass_result" >/dev/null || fail "passing result file is invalid or incomplete"
+
+fail_suite="$TEST_ROOT/fail-suite.json"
+cat >"$fail_suite" <<'JSON'
+{
+  "name": "output-channel-fail",
+  "timeout": 1,
+  "tests": [
+    {"id": "expectation", "prompt": "wrong", "expect_contains": ["missing"]},
+    {"id": "timeout", "prompt": "timeout", "expect_contains": ["unused"]}
+  ]
+}
+JSON
+
+human_fail_output="$TEST_ROOT/human-fail.output"
+human_fail_status=0
+cmd_run "$fail_suite" >"$human_fail_output" 2>&1 || human_fail_status=$?
+[[ $human_fail_status -ne 0 ]] || fail "human-mode failing suite returned zero"
+grep -q 'Expected to contain: "missing"' "$human_fail_output" ||
+	fail "human output omitted expectation failure"
+grep -q 'Error/timeout' "$human_fail_output" ||
+	fail "human output omitted timeout failure"
+
+json_stdout="$TEST_ROOT/json.stdout"
+json_stderr="$TEST_ROOT/json.stderr"
+fail_status=0
+cmd_run "$fail_suite" --json >"$json_stdout" 2>"$json_stderr" || fail_status=$?
+[[ $fail_status -ne 0 ]] || fail "failing suite returned zero"
+jq -e '.passed == 0 and .failed == 2 and .total == 2' "$json_stdout" >/dev/null ||
+	fail "--json stdout contains non-metric output"
+
+fail_result=$(ls -1 "$RESULTS_DIR"/output-channel-fail-*.json)
+jq -e '.summary.failed == 2 and (.results | length) == 2 and .results[1].error == "timeout_or_error"' \
+	"$fail_result" >/dev/null || fail "failing result file is invalid or incomplete"
+
+printf '%s\n' "PASS: agent test output channels remain parseable across multiple cases"


### PR DESCRIPTION
## Summary

- route per-case progress and validation diagnostics away from captured machine results
- suppress human-readable case output in `--json` mode while preserving normal-mode progress
- add deterministic multi-case passing, expectation-failure, and timeout regression coverage

## Testing

- `bash .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- `shellcheck .agents/scripts/agent-test-helper.sh .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- `shfmt -d .agents/scripts/agent-test-helper.sh .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- `.agents/scripts/linters-local.sh --changed --no-cache`

Resolves #26940

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 101,059 tokens on this as a headless worker.