### PR TITLE
GH#26950: allow same-session worktree PID rollover

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -390,13 +390,43 @@ register_worktree() {
 	return 0
 }
 
+_wt_is_trusted_opencode_session() {
+	local session_id="$1"
+	[[ -n "${OPENCODE_SESSION_ID:-}" ]] || return 1
+	[[ "$session_id" == "$OPENCODE_SESSION_ID" ]] || return 1
+	[[ "$session_id" == ses_* ]] || return 1
+	return 0
+}
+
+_wt_existing_owner_claim_state() {
+	local wt_path="$1"
+	local owner_pid="$2"
+	local existing_owner_info=""
+	existing_owner_info=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+		SELECT owner_pid, COALESCE(owner_session, '') FROM worktree_owners
+		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+	" 2>/dev/null || echo "")
+	local existing_owner_pid=""
+	local existing_owner_session=""
+	IFS='|' read -r existing_owner_pid existing_owner_session <<<"$existing_owner_info"
+	local existing_owner_pid_sql=0
+	[[ "$existing_owner_pid" =~ ^[0-9]+$ ]] && existing_owner_pid_sql="$existing_owner_pid"
+	local existing_owner_dead=0
+	if [[ -n "$existing_owner_pid" ]] && [[ "$existing_owner_pid" != "$owner_pid" ]] && \
+		! kill -0 "$existing_owner_pid" 2>/dev/null; then
+		existing_owner_dead=1
+	fi
+	printf '%s|%s|%s|%s' "$existing_owner_pid" "$existing_owner_session" "$existing_owner_pid_sql" "$existing_owner_dead"
+	return 0
+}
+
 # Claim ownership of a worktree without overwriting another live owner.
 # Arguments:
 #   $1 - worktree path (required)
 #   $2 - branch name (required)
 #   Flags: --task <id>, --batch <id>, --session <id>, --owner-pid <pid>
 # Returns:
-#   0 - ownership acquired or already held by this owner_pid
+#   0 - ownership acquired or already held by this owner_pid or OpenCode session
 #   1 - another live owner currently holds the worktree
 claim_worktree_ownership() {
 	local wt_path="$1"
@@ -434,27 +464,48 @@ claim_worktree_ownership() {
 	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
 	local owner_comm
 	owner_comm=$(_get_proc_comm "$owner_pid")
+	local trusted_opencode_session=0
+	_wt_is_trusted_opencode_session "$session_id" && trusted_opencode_session=1
 
 	_init_registry_db
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
-	local existing_owner_pid
-	existing_owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
-        SELECT owner_pid FROM worktree_owners
-        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
-    " 2>/dev/null || echo "")
+	local existing_owner_pid=""
+	local existing_owner_session=""
+	local existing_owner_pid_sql=0
+	local existing_owner_dead=0
+	local existing_owner_state=""
+	existing_owner_state=$(_wt_existing_owner_claim_state "$wt_path" "$owner_pid")
+	IFS='|' read -r existing_owner_pid existing_owner_session existing_owner_pid_sql existing_owner_dead <<<"$existing_owner_state"
 
-	if [[ -n "$existing_owner_pid" ]] && [[ "$existing_owner_pid" != "$owner_pid" ]]; then
-		if ! kill -0 "$existing_owner_pid" 2>/dev/null; then
-			unregister_worktree "$wt_path"
-		fi
-	fi
-
-	{
+	local final_owner_info=""
+	final_owner_info=$({
 		_wt_sqlite_set_owner_pid_param "$owner_pid"
 		printf '%s\n' "
-        INSERT OR IGNORE INTO worktree_owners
-            (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_comm, owner_dead_seen_at)
+		BEGIN IMMEDIATE;
+		DELETE FROM worktree_owners
+		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
+		  AND owner_pid = ${existing_owner_pid_sql}
+		  AND COALESCE(owner_session, '') = '$(_wt_sql_escape "$existing_owner_session")'
+		  AND ${existing_owner_dead} = 1;
+
+		UPDATE worktree_owners
+		SET branch = '$(_wt_sql_escape "$branch")',
+			owner_pid = :owner_pid,
+			owner_session = '$(_wt_sql_escape "$session_id")',
+			owner_batch = '$(_wt_sql_escape "$batch_id")',
+			task_id = '$(_wt_sql_escape "$task_id")',
+			owner_comm = '$(_wt_sql_escape "$owner_comm")',
+			owner_dead_seen_at = ''
+		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
+		  AND (
+			owner_pid = :owner_pid
+			OR (${trusted_opencode_session} = 1
+				AND owner_session = '$(_wt_sql_escape "$session_id")')
+		  );
+
+		INSERT OR IGNORE INTO worktree_owners
+			(worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_comm, owner_dead_seen_at)
         VALUES
             ('$(_wt_sql_escape "$wt_path")',
              '$(_wt_sql_escape "$branch")',
@@ -462,28 +513,16 @@ claim_worktree_ownership() {
              '$(_wt_sql_escape "$session_id")',
              '$(_wt_sql_escape "$batch_id")',
              '$(_wt_sql_escape "$task_id")',
-             '$(_wt_sql_escape "$owner_comm")',
-             '');
-    "
-	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null || true
+			 '$(_wt_sql_escape "$owner_comm")',
+			 '');
+		COMMIT;
+		SELECT owner_pid || '|' || COALESCE(owner_session, '')
+		FROM worktree_owners
+		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+	"
+	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null) || return 1
 
-	local final_owner_pid
-	final_owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
-        SELECT owner_pid FROM worktree_owners
-        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
-    " 2>/dev/null || echo "")
-
-	if [[ "$final_owner_pid" == "$owner_pid" ]]; then
-		sqlite3 "$WORKTREE_REGISTRY_DB" "
-            UPDATE worktree_owners
-            SET branch = '$(_wt_sql_escape "$branch")',
-                owner_session = '$(_wt_sql_escape "$session_id")',
-                owner_batch = '$(_wt_sql_escape "$batch_id")',
-                task_id = '$(_wt_sql_escape "$task_id")',
-                owner_comm = '$(_wt_sql_escape "$owner_comm")',
-                owner_dead_seen_at = ''
-            WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
-        " 2>/dev/null || true
+	if [[ "${final_owner_info%%|*}" == "$owner_pid" ]]; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -167,6 +167,39 @@ test_blocks_when_linked_worktree_owned_by_another_live_process() {
 	return 0
 }
 
+test_allows_same_opencode_session_pid_rollover() {
+	local worktree_path="${TEST_ROOT}/same-session-worktree"
+	git -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/same-session-worktree >/dev/null 2>&1
+
+	ensure_registry_schema
+	local original_pid=""
+	local rollover_pid=""
+	sleep 30 >/dev/null 2>&1 &
+	original_pid=$!
+	sleep 30 >/dev/null 2>&1 &
+	rollover_pid=$!
+	OPENCODE_PID="" OPENCODE_SESSION_ID="ses_pre_edit_rollover" PRE_EDIT_OWNER_PID="$original_pid" run_helper "$worktree_path" >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	output=$(OPENCODE_PID="" OPENCODE_SESSION_ID="ses_pre_edit_rollover" PRE_EDIT_OWNER_PID="$rollover_pid" run_helper "$worktree_path" 2>&1) || exit_code=$?
+	kill "$original_pid" "$rollover_pid" >/dev/null 2>&1 || true
+	wait "$original_pid" "$rollover_pid" 2>/dev/null || true
+
+	local stored_owner=""
+	stored_owner=$(sqlite3 -separator '|' "$TEST_REGISTRY_DB" "
+		SELECT owner_pid, owner_session FROM worktree_owners
+		WHERE branch = 'bugfix/same-session-worktree';
+	" 2>/dev/null || true)
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" != *"WORKTREE_OWNERSHIP_CONFLICT=true"* ]] && [[ "$stored_owner" == "${rollover_pid}|ses_pre_edit_rollover" ]]; then
+		print_result "allows same OpenCode session after owner PID rollover" 0
+		return 0
+	fi
+
+	print_result "allows same OpenCode session after owner PID rollover" 1 "exit=${exit_code} owner=${stored_owner} output=${output}"
+	return 0
+}
+
 test_allowlisted_path_allows_edit_on_main() {
 	# Ensure repo is on main for this test
 	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
@@ -273,6 +306,7 @@ main() {
 	test_allows_linked_worktree_edits
 	test_warns_when_canonical_repo_is_off_main
 	test_blocks_when_linked_worktree_owned_by_another_live_process
+	test_allows_same_opencode_session_pid_rollover
 	test_allowlisted_path_allows_edit_on_main
 	test_path_traversal_blocked_on_main
 	test_absolute_path_outside_repo_blocked_on_main

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worktree-registry-session-claim.sh — GH#26950 regression guard.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REGISTRY_LIB="${SCRIPT_DIR}/../shared-worktree-registry.sh"
+TEST_ROOT=$(mktemp -d)
+WORKTREE_REGISTRY_DIR="${TEST_ROOT}/registry"
+WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
+export WORKTREE_REGISTRY_DIR WORKTREE_REGISTRY_DB
+
+TESTS_RUN=0
+TESTS_FAILED=0
+OWNER_PID=""
+CLAIM_PID=""
+
+cleanup() {
+	[[ -n "$OWNER_PID" ]] && kill "$OWNER_PID" >/dev/null 2>&1 || true
+	[[ -n "$CLAIM_PID" ]] && kill "$CLAIM_PID" >/dev/null 2>&1 || true
+	wait "$OWNER_PID" "$CLAIM_PID" 2>/dev/null || true
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+# shellcheck source=../shared-worktree-registry.sh
+source "$REGISTRY_LIB"
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s\n' "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+start_live_pids() {
+	sleep 30 &
+	OWNER_PID=$!
+	sleep 30 &
+	CLAIM_PID=$!
+	return 0
+}
+
+reset_registry() {
+	rm -rf "$WORKTREE_REGISTRY_DIR"
+	return 0
+}
+
+owner_info() {
+	local wt_path="$1"
+	check_worktree_owner "$wt_path" 2>/dev/null || true
+	return 0
+}
+
+test_same_opencode_session_rolls_owner_pid() {
+	local wt_path="${TEST_ROOT}/same-session"
+	mkdir -p "$wt_path"
+	export OPENCODE_SESSION_ID="ses_same_session"
+	register_worktree "$wt_path" "feature/same-session" --owner-pid "$OWNER_PID" --session "$OPENCODE_SESSION_ID"
+
+	local rc=0
+	claim_worktree_ownership "$wt_path" "feature/same-session" --owner-pid "$CLAIM_PID" --session "$OPENCODE_SESSION_ID" || rc=1
+	[[ "$(owner_info "$wt_path")" == "${CLAIM_PID}|${OPENCODE_SESSION_ID}|"* ]] || rc=1
+	print_result "same trusted OpenCode session rolls owner PID" "$rc"
+	return 0
+}
+
+test_different_session_stays_blocked() {
+	reset_registry
+	local wt_path="${TEST_ROOT}/different-session"
+	mkdir -p "$wt_path"
+	register_worktree "$wt_path" "feature/different-session" --owner-pid "$OWNER_PID" --session "ses_original"
+	export OPENCODE_SESSION_ID="ses_other"
+
+	local rc=0
+	if claim_worktree_ownership "$wt_path" "feature/different-session" --owner-pid "$CLAIM_PID" --session "$OPENCODE_SESSION_ID"; then
+		rc=1
+	fi
+	[[ "$(owner_info "$wt_path")" == "${OWNER_PID}|ses_original|"* ]] || rc=1
+	print_result "different live session remains blocked" "$rc"
+	return 0
+}
+
+test_empty_session_cannot_roll_owner_pid() {
+	reset_registry
+	local wt_path="${TEST_ROOT}/empty-session"
+	mkdir -p "$wt_path"
+	unset OPENCODE_SESSION_ID
+	register_worktree "$wt_path" "feature/empty-session" --owner-pid "$OWNER_PID" --session ""
+
+	local rc=0
+	if claim_worktree_ownership "$wt_path" "feature/empty-session" --owner-pid "$CLAIM_PID" --session ""; then
+		rc=1
+	fi
+	[[ "$(owner_info "$wt_path")" == "${OWNER_PID}||"* ]] || rc=1
+	print_result "empty session cannot bypass live owner" "$rc"
+	return 0
+}
+
+test_untrusted_session_cannot_roll_owner_pid() {
+	reset_registry
+	local wt_path="${TEST_ROOT}/untrusted-session"
+	mkdir -p "$wt_path"
+	register_worktree "$wt_path" "feature/untrusted-session" --owner-pid "$OWNER_PID" --session "caller-supplied"
+	unset OPENCODE_SESSION_ID
+
+	local rc=0
+	if claim_worktree_ownership "$wt_path" "feature/untrusted-session" --owner-pid "$CLAIM_PID" --session "caller-supplied"; then
+		rc=1
+	fi
+	[[ "$(owner_info "$wt_path")" == "${OWNER_PID}|caller-supplied|"* ]] || rc=1
+	print_result "untrusted session cannot bypass live owner" "$rc"
+	return 0
+}
+
+main() {
+	start_live_pids
+	test_same_opencode_session_rolls_owner_pid
+	test_different_session_stays_blocked
+	test_empty_session_cannot_roll_owner_pid
+	test_untrusted_session_cannot_roll_owner_pid
+	printf 'Results: %s/%s passed, %s failed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]] && return 0
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Allow a verified OpenCode session to atomically refresh its worktree owner PID while preserving live-owner isolation

## Files Changed

.agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-pre-edit-check.sh, .agents/scripts/tests/test-worktree-registry-session-claim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Registry claim tests 4/4; dead-owner tests 8/8; pre-edit tests 10/10; ShellCheck and shell portability clean; function-complexity and Bash 3.2 regression gates report no new violations

Resolves #26950


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 10m and 151,483 tokens on this as a headless worker.