### PR TITLE
GH#26958: propagate update cache write failures

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -705,22 +705,19 @@ _write_cache() {
 
 	mkdir -p "$cache_dir"
 	temp_file=$(mktemp "$cache_dir/session-greeting.XXXXXX") || return 1
-	if _write_cache_contents "$output" "$runtime_hint" "$nudge_output" \
+	_write_cache_contents "$output" "$runtime_hint" "$nudge_output" \
 		"$session_warning" "$security_posture" "$secret_hygiene" \
-		"$advisories_output" "$contribution_watch" >"$temp_file"; then
-		:
-	else
+		"$advisories_output" "$contribution_watch" >"$temp_file" || {
 		rc=$?
 		rm -f "$temp_file"
 		return "$rc"
-	fi
-	if mv -f "$temp_file" "$cache_file"; then
-		return 0
-	else
+	}
+	mv -f "$temp_file" "$cache_file" || {
 		rc=$?
 		rm -f "$temp_file"
 		return "$rc"
-	fi
+	}
+	return 0
 }
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -675,6 +675,20 @@ _check_script_drift() {
 # -----------------------------------------------------------------------------
 # _write_cache: persist session greeting to cache for agents without Bash.
 # -----------------------------------------------------------------------------
+_write_cache_contents() {
+	local line=""
+	local rc=0
+
+	for line in "$@"; do
+		[[ -n "$line" ]] || continue
+		printf '%s\n' "$line"
+		rc=$?
+		[[ "$rc" -eq 0 ]] || return "$rc"
+	done
+
+	return 0
+}
+
 _write_cache() {
 	local cache_dir="$1"
 	local output="$2"
@@ -687,28 +701,26 @@ _write_cache() {
 	local contribution_watch="$9"
 	local cache_file="$cache_dir/session-greeting.txt"
 	local temp_file=""
+	local rc=0
 
 	mkdir -p "$cache_dir"
 	temp_file=$(mktemp "$cache_dir/session-greeting.XXXXXX") || return 1
-	if ! {
-		echo "$output"
-		[[ -n "$runtime_hint" ]] && echo "$runtime_hint"
-		[[ -n "$nudge_output" ]] && echo "$nudge_output"
-		[[ -n "$session_warning" ]] && echo "$session_warning"
-		[[ -n "$security_posture" ]] && echo "$security_posture"
-		[[ -n "$secret_hygiene" ]] && echo "$secret_hygiene"
-		[[ -n "$advisories_output" ]] && echo "$advisories_output"
-		[[ -n "$contribution_watch" ]] && echo "$contribution_watch"
-		true
-	} >"$temp_file"; then
+	if _write_cache_contents "$output" "$runtime_hint" "$nudge_output" \
+		"$session_warning" "$security_posture" "$secret_hygiene" \
+		"$advisories_output" "$contribution_watch" >"$temp_file"; then
+		:
+	else
+		rc=$?
 		rm -f "$temp_file"
-		return 1
+		return "$rc"
 	fi
-	if ! mv -f "$temp_file" "$cache_file"; then
+	if mv -f "$temp_file" "$cache_file"; then
+		return 0
+	else
+		rc=$?
 		rm -f "$temp_file"
-		return 1
+		return "$rc"
 	fi
-	return 0
 }
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
+++ b/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
@@ -13,6 +13,14 @@ TEST_ROOT=""
 ORIGINAL_PATH="$PATH"
 ORIGINAL_HOME="$HOME"
 
+# Load only the cache helpers so failure paths can be exercised without running
+# the update check's main entry point.
+# shellcheck source=/dev/null
+source <(awk '
+	/^_write_cache_contents\(\)/,/^}/ { print }
+	/^_write_cache\(\)/,/^}/ { print }
+' "$UPDATE_CHECK")
+
 cleanup() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
@@ -85,8 +93,65 @@ test_supported_gh_has_no_warning() {
 	return 0
 }
 
+test_cache_write_propagates_output_failure() {
+	local cache_dir=""
+	local status=0
+	cache_dir=$(mktemp -d)
+
+	set +e
+	(
+		printf() {
+			local value="${2:-}"
+			local rc=0
+			if [[ "$value" == "fail-write" ]]; then
+				return 17
+			fi
+			builtin printf "$@"
+			rc=$?
+			return "$rc"
+		}
+		_write_cache "$cache_dir" "greeting" "fail-write" "" "" "" "" "" ""
+	)
+	status=$?
+	set -e
+
+	if [[ "$status" -eq 17 ]] && [[ -z "$(compgen -G "$cache_dir/session-greeting.*" || true)" ]]; then
+		print_result "cache output failure preserves status and removes temp file" 0
+	else
+		print_result "cache output failure preserves status and removes temp file" 1 "status=${status}"
+	fi
+	rm -rf "$cache_dir"
+	return 0
+}
+
+test_cache_write_propagates_move_failure() {
+	local cache_dir=""
+	local status=0
+	cache_dir=$(mktemp -d)
+
+	set +e
+	(
+		mv() {
+			return 23
+		}
+		_write_cache "$cache_dir" "greeting" "" "" "" "" "" "" ""
+	)
+	status=$?
+	set -e
+
+	if [[ "$status" -eq 23 ]] && [[ -z "$(compgen -G "$cache_dir/session-greeting.*" || true)" ]]; then
+		print_result "cache move failure preserves status and removes temp file" 0
+	else
+		print_result "cache move failure preserves status and removes temp file" 1 "status=${status}"
+	fi
+	rm -rf "$cache_dir"
+	return 0
+}
+
 test_old_gh_warns_in_update_check
 test_supported_gh_has_no_warning
+test_cache_write_propagates_output_failure
+test_cache_write_propagates_move_failure
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
+++ b/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
@@ -17,8 +17,8 @@ ORIGINAL_HOME="$HOME"
 # the update check's main entry point.
 # shellcheck source=/dev/null
 source <(awk '
-	/^_write_cache_contents\(\)/,/^}/ { print }
-	/^_write_cache\(\)/,/^}/ { print }
+	/^_write_cache_contents[[:space:]]*\(\)/,/^}/ { print }
+	/^_write_cache[[:space:]]*\(\)/,/^}/ { print }
 ' "$UPDATE_CHECK")
 
 cleanup() {


### PR DESCRIPTION
## Summary

- Preserve exact cache output and move failure statuses.
- Remove temporary greeting-cache files after either failure path.
- Add regression tests for output and move failures.

## Testing

- `bash -n .agents/scripts/aidevops-update-check.sh .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh`
- `shellcheck .agents/scripts/aidevops-update-check.sh .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh`
- `bash .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh` (4/4 passed)
- `.agents/scripts/linters-local.sh --changed`

## Runtime Testing

Self-assessed: focused shell regression tests exercise both failure paths and cache cleanup.

Resolves #26958

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 74,638 tokens on this as a headless worker.
