### PR TITLE
GH#26957: preserve greeting cache handoff

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -286,6 +286,9 @@ function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now }) 
     try {
       if (now() >= deadline || now() - statSync(lockDir).mtimeMs > lockStaleMs) return;
     } catch {
+      // The owner may publish the cache and remove its lock between our cache
+      // read and lock stat. Re-check once so that handoff still emits it.
+      emitCachedGreeting(client, readGreetingCache(cacheFile));
       return;
     }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -160,6 +160,34 @@ test("cold-cache plugin processes share one refresh and all receive its greeting
   assert.equal(readFileSync(f.cacheFile, "utf8").trim(), NEW_GREETING);
 });
 
+test("cold-cache follower emits a cache published while its owner lock disappears", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  const lockDir = join(f.cacheDir, "session-greeting-refresh.lock");
+  mkdirSync(lockDir);
+  let nowCalls = 0;
+  const now = () => {
+    nowCalls += 1;
+    if (nowCalls === 4) {
+      writeFileSync(f.cacheFile, `${NEW_GREETING}\n`);
+      rmSync(lockDir, { recursive: true, force: true });
+    }
+    return 1000;
+  };
+  const client = f.client();
+  const handler = createGreetingHandler({
+    ...handlerOptions(f, client, async () => {
+      throw new Error("follower must not start a refresh");
+    }),
+    now,
+  });
+
+  await handler({ event: { type: "session.created" } });
+  await waitFor(() => f.clients[0].length === 1);
+
+  assert.equal(f.clients[0][0].message.includes(NEW_GREETING), true);
+});
+
 test("an expired owner cannot release a replacement owner's lock", async (t) => {
   const f = fixture();
   t.after(() => f.cleanup());


### PR DESCRIPTION
## Summary

Re-check the greeting cache when a follower observes the refresh lock disappear, and add a deterministic regression test for the publication/removal race.

## Files Changed

.agents/plugins/opencode-aidevops/greeting.mjs, .agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test tests/test-greeting-single-flight.mjs; npm test (293 passed); .agents/scripts/linters-local.sh --changed

Resolves #26957


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 66,281 tokens on this as a headless worker.