### PR TITLE
GH#26964: simplify vault test input decoding

### DIFF
--- a/.agents/scripts/tests/test-vault-helper.sh
+++ b/.agents/scripts/tests/test-vault-helper.sh
@@ -67,7 +67,7 @@ import subprocess
 import sys
 import time
 
-inputs = os.fdopen(3, "rb").read().decode().encode().decode("unicode_escape").splitlines()
+inputs = os.fdopen(3, "rb").read().decode("unicode_escape").splitlines()
 cmd = sys.argv[1:]
 master, slave = pty.openpty()
 proc = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=slave)


### PR DESCRIPTION
## Summary

Removed the redundant default decode and re-encode round trip from the vault TTY test harness while preserving unicode_escape processing.

## Files Changed

.agents/scripts/tests/test-vault-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-vault-helper.sh (28 passed); shellcheck .agents/scripts/tests/test-vault-helper.sh; git diff --check

Resolves #26964


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 24,778 tokens on this as a headless worker.