### PR TITLE
GH#26966: tolerate Vault helper warnings

### DIFF
--- a/packages/gui-api/src/status-vault.ts
+++ b/packages/gui-api/src/status-vault.ts
@@ -91,7 +91,7 @@ function readVaultCommand<T extends VaultProbeValue>(
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 750,
   });
-  if (result.error !== undefined || result.signal !== null || result.status === null || result.stderr.length > 0) return null;
+  if (result.error !== undefined || result.signal !== null || result.status === null) return null;
   const output = result.stdout.endsWith("\n") ? result.stdout.slice(0, -1) : result.stdout;
   if (output.length === 0 || output.includes("\n") || output.includes("\r") || output.trim() !== output) return null;
   return isAllowed(output) && isExpectedVaultExit(command, output, result.status) ? output : null;

--- a/packages/gui-api/src/status-vault.ts
+++ b/packages/gui-api/src/status-vault.ts
@@ -88,7 +88,7 @@ function readVaultCommand<T extends VaultProbeValue>(
   const result = spawnSync("/bin/bash", [helperPath, command], {
     encoding: "utf8",
     env: vaultProbeEnvironment(),
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "ignore"],
     timeout: 750,
   });
   if (result.error !== undefined || result.signal !== null || result.status === null) return null;

--- a/packages/gui-api/tests/status-adapter.test.ts
+++ b/packages/gui-api/tests/status-adapter.test.ts
@@ -229,19 +229,23 @@ describe("status adapter", () => {
     expect(readVaultSummary(repoRoot).status).toBe("unknown");
   });
 
-  test("rejects whitespace-only stderr", () => {
+  test("accepts valid Vault output when the helper emits a stderr warning", () => {
     const repoRoot = mkdtempSync(join(tmpdir(), "aidevops-gui-vault-whitespace-stderr-"));
     const scriptsDir = join(repoRoot, ".agents", "scripts");
     mkdirSync(scriptsDir, { recursive: true });
     writeFileSync(join(scriptsDir, "vault-helper.sh"), [
       "case \"$1\" in",
-      "  status) printf '%s\\n' locked; printf ' ' >&2 ;;",
+      "  status) printf '%s\\n' locked; printf '%s\\n' 'runtime warning' >&2 ;;",
       "  setup-state) printf '%s\\n' migration-ready ;;",
       "  *) exit 1 ;;",
       "esac",
     ].join("\n"));
 
-    expect(readVaultSummary(repoRoot).status).toBe("unknown");
+    const vault = readVaultSummary(repoRoot);
+
+    expect(vault.helper_status).toBe("available");
+    expect(vault.status).toBe("locked");
+    expect(vault.setup_state).toBe("migration-ready");
   });
 
   test("preserves the Linux runtime directory for broker status probes", () => {


### PR DESCRIPTION
## Summary

Accept strictly validated Vault status output even when the helper emits a non-fatal stderr warning, with regression coverage.

## Files Changed

packages/gui-api/src/status-vault.ts, packages/gui-api/tests/status-adapter.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified with bun test packages/gui-api/tests (34 pass); npm run gui:typecheck; npm run gui:lint (11 pass).

Resolves #26966


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 44,088 tokens on this as a headless worker.