### PR TITLE
GH#26959: fix: suppress applied line-reference feedback

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -192,6 +192,33 @@ _extract_snippet_from_inline_code() {
 	return 1
 }
 
+# _extract_reference_line_fix_snippet: extract the requested replacement from
+# review feedback that narrows a documentation reference to one line.
+# Arguments: $1=body_full
+# Outputs basename:line to stdout; returns 0 on success, 1 if not applicable.
+_extract_reference_line_fix_snippet() {
+	local body_full="$1"
+	local file_name=""
+	local target_line=""
+
+	if [[ "$body_full" =~ [Tt]he[[:space:]]referenced[[:space:]]file[[:space:]]\'([^\']+)\' ]]; then
+		file_name="${BASH_REMATCH[1]}"
+	else
+		return 1
+	fi
+
+	if [[ "$body_full" =~ [Pp]oint[[:space:]]only[[:space:]]to[[:space:]]line[[:space:]]([0-9]+) ]]; then
+		target_line="${BASH_REMATCH[1]}"
+	else
+		return 1
+	fi
+
+	file_name="${file_name##*/}"
+	[[ -z "$file_name" || -z "$target_line" ]] && return 1
+	printf '%s:%s\n' "$file_name" "$target_line"
+	return 0
+}
+
 _extract_verification_snippet() {
 	local body_full="$1"
 	local line=""
@@ -260,6 +287,13 @@ _extract_verification_snippet() {
 		fi
 	done <<<"$body_full"
 
+	# Documentation reviews can express the replacement as prose rather than a
+	# suggestion fence. Convert a precise single-line reference request into a
+	# stable fix snippet before falling back to generic inline-code extraction.
+	if _extract_reference_line_fix_snippet "$body_full"; then
+		return 0
+	fi
+
 	# Fallback: try blockquotes, indented blocks, and inline backtick code
 	_extract_snippet_from_inline_code "$body_full"
 	return $?
@@ -276,6 +310,20 @@ _extract_verification_snippet() {
 _body_has_suggestion_fence() {
 	local body_full="$1"
 	if printf '%s\n' "$body_full" | grep -qE "^\`\`\`suggestion"; then
+		return 0
+	fi
+	return 1
+}
+
+# _body_has_fix_snippet: returns 0 when extraction yields proposed replacement
+# text rather than text describing the existing problem.
+_body_has_fix_snippet() {
+	local body_full="$1"
+
+	if _body_has_suggestion_fence "$body_full"; then
+		return 0
+	fi
+	if _extract_reference_line_fix_snippet "$body_full" >/dev/null; then
 		return 0
 	fi
 	return 1
@@ -422,7 +470,7 @@ _finding_still_exists_on_main() {
 	# - all other sources → snippet is the PROBLEM text.
 	#   Finding is resolved when the problem is ABSENT from HEAD (problem fixed).
 	local is_suggestion_snippet="false"
-	if _body_has_suggestion_fence "$body_full"; then
+	if _body_has_fix_snippet "$body_full"; then
 		is_suggestion_snippet="true"
 	fi
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-verification.sh
@@ -176,6 +176,60 @@ test_handles_suggestion_fence_and_comments() {
 	return 0
 }
 
+test_skips_applied_single_line_reference_fix() {
+	reset_mock_state
+	GH_RAW_CONTENT=$'- **Evidence:**\n  `todo/missions/example/research/resource-baseline.md:26`\n'
+
+	local findings
+	findings='[{"file":"todo/tasks/example-brief.md","line":26,"body_full":"The referenced file '\''resource-baseline.md'\'' contains unrelated evidence on line 25. Please update the reference to point only to line 26 to ensure precise documentation.","reviewer":"gemini","reviewer_login":"gemini-code-assist[bot]","severity":"medium","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
+		print_result "skip single-line reference finding when precise fix is on main" 0
+	else
+		print_result "skip single-line reference finding when precise fix is on main" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+test_keeps_unapplied_single_line_reference_fix() {
+	reset_mock_state
+	GH_RAW_CONTENT=$'- **Evidence:**\n  `todo/missions/example/research/resource-baseline.md:25-26`\n'
+
+	local findings
+	findings='[{"file":"todo/tasks/example-brief.md","line":26,"body_full":"The referenced file '\''resource-baseline.md'\'' contains unrelated evidence on line 25. Please update the reference to point only to line 26 to ensure precise documentation.","reviewer":"gemini","reviewer_login":"gemini-code-assist[bot]","severity":"medium","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "keep single-line reference finding until precise fix is on main" 0
+	else
+		print_result "keep single-line reference finding until precise fix is on main" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
 test_keeps_unverifiable_finding() {
 	reset_mock_state
 	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nreturn 0\n'

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -215,6 +215,8 @@ main() {
 	test_skips_deleted_file
 	test_handles_diff_fence_without_false_positive
 	test_handles_suggestion_fence_and_comments
+	test_skips_applied_single_line_reference_fix
+	test_keeps_unapplied_single_line_reference_fix
 	test_keeps_unverifiable_finding
 	test_transient_api_error_keeps_finding_as_unverifiable
 	test_uses_default_branch_ref_for_contents_lookup


### PR DESCRIPTION
## Summary

Recognize prose requests that narrow documentation references to one line, then suppress the quality-debt finding when the precise basename:line replacement is already present on the default branch. Added applied and unapplied regression coverage.

## Files Changed

.agents/scripts/quality-feedback-helper.sh, .agents/scripts/tests/test-quality-feedback-main-verification-verification.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (74/74 passed); bash -n and ShellCheck on changed scripts; .agents/scripts/linters-local.sh --changed

Resolves #26959


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 17m and 93,451 tokens on this as a headless worker.