### PR TITLE
GH#26957: preserve greeting cache handoff

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -288,8 +288,14 @@ function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now }) 
     } catch {
       // The owner may publish the cache and remove its lock between our cache
       // read and lock stat. Re-check once so that handoff still emits it.
-      emitCachedGreeting(client, readGreetingCache(cacheFile));
-      return;
+      const finalCached = readGreetingCache(cacheFile);
+      if (finalCached) {
+        emitCachedGreeting(client, finalCached);
+        return;
+      }
+      // A stale-lock contender may have renamed the old lock but not created
+      // its replacement yet. Keep polling within the original safety bound.
+      if (now() >= deadline) return;
     }
 
     const timer = setTimeout(poll, 25);

--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -286,6 +286,9 @@ function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now }) 
     try {
       if (now() >= deadline || now() - statSync(lockDir).mtimeMs > lockStaleMs) return;
     } catch {
+      // The owner may publish the cache and remove its lock between our cache
+      // read and lock stat. Re-check once so that handoff still emits it.
+      emitCachedGreeting(client, readGreetingCache(cacheFile));
       return;
     }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -160,6 +160,34 @@ test("cold-cache plugin processes share one refresh and all receive its greeting
   assert.equal(readFileSync(f.cacheFile, "utf8").trim(), NEW_GREETING);
 });
 
+test("cold-cache follower emits a cache published while its owner lock disappears", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  const lockDir = join(f.cacheDir, "session-greeting-refresh.lock");
+  mkdirSync(lockDir);
+  let nowCalls = 0;
+  const now = () => {
+    nowCalls += 1;
+    if (nowCalls === 4) {
+      writeFileSync(f.cacheFile, `${NEW_GREETING}\n`);
+      rmSync(lockDir, { recursive: true, force: true });
+    }
+    return 1000;
+  };
+  const client = f.client();
+  const handler = createGreetingHandler({
+    ...handlerOptions(f, client, async () => {
+      throw new Error("follower must not start a refresh");
+    }),
+    now,
+  });
+
+  await handler({ event: { type: "session.created" } });
+  await waitFor(() => f.clients[0].length === 1);
+
+  assert.equal(f.clients[0][0].message.includes(NEW_GREETING), true);
+});
+
 test("an expired owner cannot release a replacement owner's lock", async (t) => {
   const f = fixture();
   t.after(() => f.cleanup());

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -168,7 +168,7 @@ test("cold-cache follower emits a cache published while its owner lock disappear
   let nowCalls = 0;
   const now = () => {
     nowCalls += 1;
-    if (nowCalls === 4) {
+    if (nowCalls === 5) {
       writeFileSync(f.cacheFile, `${NEW_GREETING}\n`);
       rmSync(lockDir, { recursive: true, force: true });
     }
@@ -183,6 +183,35 @@ test("cold-cache follower emits a cache published while its owner lock disappear
   });
 
   await handler({ event: { type: "session.created" } });
+  await waitFor(() => f.clients[0].length === 1);
+
+  assert.equal(nowCalls, 5);
+  assert.equal(f.clients[0][0].message.includes(NEW_GREETING), true);
+});
+
+test("cold-cache follower survives a transient lock gap before publication", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  const lockDir = join(f.cacheDir, "session-greeting-refresh.lock");
+  mkdirSync(lockDir);
+  let nowCalls = 0;
+  const now = () => {
+    nowCalls += 1;
+    if (nowCalls === 5) rmSync(lockDir, { recursive: true, force: true });
+    if (nowCalls === 6) mkdirSync(lockDir);
+    return 1000;
+  };
+  const handler = createGreetingHandler({
+    ...handlerOptions(f, f.client(), async () => {
+      throw new Error("follower must not start a refresh");
+    }),
+    now,
+  });
+
+  await handler({ event: { type: "session.created" } });
+  assert.equal(nowCalls, 6);
+  writeFileSync(f.cacheFile, `${NEW_GREETING}\n`);
+  rmSync(lockDir, { recursive: true, force: true });
   await waitFor(() => f.clients[0].length === 1);
 
   assert.equal(f.clients[0][0].message.includes(NEW_GREETING), true);


### PR DESCRIPTION
## Summary

Re-check the cache when a refresh lock vanishes, continue bounded polling across transient stale-lock replacement gaps, and cover both races deterministically.

## Files Changed

.agents/plugins/opencode-aidevops/greeting.mjs, .agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test tests/test-greeting-single-flight.mjs (9 passed); npm test (294 passed); .agents/scripts/linters-local.sh --changed

Resolves #26957


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 20m and 161,064 tokens on this as a headless worker.