### PR TITLE
GH#26961: Avoid ls when selecting agent test results

### DIFF
--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -65,9 +65,9 @@ grep -q '\[1/2\] first' "$human_stderr" ||
 grep -q '\[2/2\] second' "$human_stderr" ||
 	fail "human output omitted second-case progress"
 
-pass_result=$(ls -1 "$RESULTS_DIR"/output-channel-pass-*.json)
+pass_results=("$RESULTS_DIR"/output-channel-pass-*.json)
 jq -e '.summary.passed == 2 and .summary.failed == 0 and (.results | length) == 2' \
-	"$pass_result" >/dev/null || fail "passing result file is invalid or incomplete"
+	"${pass_results[0]}" >/dev/null || fail "passing result file is invalid or incomplete"
 
 fail_suite="$TEST_ROOT/fail-suite.json"
 cat >"$fail_suite" <<'JSON'
@@ -98,8 +98,8 @@ cmd_run "$fail_suite" --json >"$json_stdout" 2>"$json_stderr" || fail_status=$?
 jq -e '.passed == 0 and .failed == 2 and .total == 2' "$json_stdout" >/dev/null ||
 	fail "--json stdout contains non-metric output"
 
-fail_result=$(ls -1 "$RESULTS_DIR"/output-channel-fail-*.json)
+fail_results=("$RESULTS_DIR"/output-channel-fail-*.json)
 jq -e '.summary.failed == 2 and (.results | length) == 2 and .results[1].error == "timeout_or_error"' \
-	"$fail_result" >/dev/null || fail "failing result file is invalid or incomplete"
+	"${fail_results[0]}" >/dev/null || fail "failing result file is invalid or incomplete"
 
 printf '%s\n' "PASS: agent test output channels remain parseable across multiple cases"

--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -66,6 +66,7 @@ grep -q '\[2/2\] second' "$human_stderr" ||
 	fail "human output omitted second-case progress"
 
 pass_results=("$RESULTS_DIR"/output-channel-pass-*.json)
+[[ -f "${pass_results[0]:-}" ]] || fail "passing result file was not created"
 jq -e '.summary.passed == 2 and .summary.failed == 0 and (.results | length) == 2' \
 	"${pass_results[0]}" >/dev/null || fail "passing result file is invalid or incomplete"
 
@@ -99,6 +100,7 @@ jq -e '.passed == 0 and .failed == 2 and .total == 2' "$json_stdout" >/dev/null 
 	fail "--json stdout contains non-metric output"
 
 fail_results=("$RESULTS_DIR"/output-channel-fail-*.json)
+[[ -f "${fail_results[0]:-}" ]] || fail "failing result file was not created"
 jq -e '.summary.failed == 2 and (.results | length) == 2 and .results[1].error == "timeout_or_error"' \
 	"${fail_results[0]}" >/dev/null || fail "failing result file is invalid or incomplete"
 


### PR DESCRIPTION
## Summary

Replace command-substitution ls calls with Bash glob arrays for passing and failing agent-test result files.

## Files Changed

.agents/scripts/tests/test-agent-test-helper-output-channel.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Target test passed three consecutive runs; bash -n, ShellCheck, and linters-local.sh --changed passed.

Resolves #26961


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 11m and 56,923 tokens on this as a headless worker.