### PR TITLE
GH#26968: suppress resolved review feedback threads

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -27,6 +27,39 @@ _build_inline_findings() {
 	local min_severity="$3"
 
 	echo "$comments" | jq --arg pr "$pr_num" --arg min_sev "$min_severity" '
+		def resolution_or_ack:
+			test(
+				"aidevops:review-thread-response|" +
+				"\\baddressed in [0-9a-f]{7,40}\\b|" +
+				"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
+				"(?s:\\bthank you for the verification\\b.*?\\badding the regression test\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
+				"(?s:\\bthank you for the update\\b.*?\\bnon-greedy quantifiers?\\b.*?\\bregression suite\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
+				"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
+				"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
+				"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +
+				"(?s:\\bthank you for the clarification\\b.*?\\byou are (absolutely )?correct\\b.*?\\bproperly managed\\b.*?\\bcleanup routines?\\b)|" +
+				"\\bno further concerns?\\b|" +
+				"\\bno further feedback\\b|" +
+				"\\bno further recommendations?\\b|" +
+				"\\bno further action (is )?(needed|required)\\b|" +
+				"\\bthread is resolved\\b|" +
+				"(?s:\\b(already )?incorporate[sd]?\\b.*\\bnecessary synchronization\\b)|" +
+				"\\brace condition\\b.*\\b(is|was) indeed addressed\\b|" +
+				"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
+				"\\bimplementation looks correct and address(es|ed)?\\b|" +
+				"\\btests are passing\\b";
+				"i"
+			);
+
+		# A positive reviewer reply is closure evidence for its parent finding.
+		# Suppress both the acknowledgement and the resolved root comment so an
+		# unverifiable stale snippet cannot recreate already-addressed debt.
+		([.[] |
+			select(.in_reply_to_id != null) |
+			select((.body // "") | resolution_or_ack) |
+			.in_reply_to_id
+		]) as $resolved_parent_ids |
+
 		[.[] |
 		# Determine reviewer type
 		(.user.login) as $login |
@@ -43,26 +76,10 @@ _build_inline_findings() {
 		# Skip thread-resolution replies and positive acknowledgements that appear
 		# as inline review comments. These are closure evidence from a review-thread
 		# response worker, not new quality debt (GH#24939).
-		($body | test(
-			"aidevops:review-thread-response|" +
-			"\\baddressed in [0-9a-f]{7,40}\\b|" +
-			"(?s:\\bthank you for verifying\\b.*\\blooks good\\b)|" +
-			"(?s:\\bthank you for the verification\\b.*?\\badding the regression test\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
-			"(?s:\\bthank you for the update\\b.*?\\bnon-greedy quantifiers?\\b.*?\\bregression suite\\b.*?\\bcorrectly address(es|ed)?\\b)|" +
-			"(?s:\\bthank you for the confirmation\\b.*?\\baddressing the feedback\\b.*?\\bcorrectly handles?\\b.*?\\bimproves?\\b.*?\\brobustness\\b)|" +
-			"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
-			"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +
-			"\\bno further concerns?\\b|" +
-			"\\bno further feedback\\b|" +
-			"\\bno further recommendations?\\b|" +
-			"\\bno further action (is )?(needed|required)\\b|" +
-			"\\bthread is resolved\\b|" +
-			"(?s:\\b(already )?incorporate[sd]?\\b.*\\bnecessary synchronization\\b)|" +
-			"\\brace condition\\b.*\\b(is|was) indeed addressed\\b|" +
-			"\\bimplementation[[:space:]]+((is|was|has[[:space:]]+been)[[:space:]]+)?(confirmed|verified)\\b|" +
-			"\\bimplementation looks correct and address(es|ed)?\\b|" +
-			"\\btests are passing\\b"; "i")) as $resolution_or_ack |
+		($body | resolution_or_ack) as $resolution_or_ack |
 		select($resolution_or_ack | not) |
+		(.id // null) as $comment_id |
+		select($comment_id == null or (($resolved_parent_ids | index($comment_id)) == null)) |
 
 		# Extract severity from body
 		(if ($body | test("security-critical\\.svg|🔴.*critical|CRITICAL"; "i")) then "critical"

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -514,6 +514,19 @@ test_skips_pr26892_nongreedy_quantifier_ack() {
 	return 0
 }
 
+test_skips_pr26938_resolved_timeout_thread() {
+	local comments result
+	# shellcheck disable=SC2016  # literal review JSON includes a Markdown code span
+	comments='[{"id":3559925333,"user":{"login":"gemini-code-assist[bot]"},"body":"If the modal is closed or unmounted within 3 seconds of clicking the terminal launch button, the timeout callback will still execute and attempt to call setLaunchStatus, which can cause a React state update on an unmounted component warning. It is best practice to store the timeout ID in a ref and clear it when the component unmounts.","path":"packages/gui-web/src/VaultAccessModal.tsx","original_line":67,"html_url":"https://example.invalid/review-root","created_at":"2026-07-10T15:05:49Z"},{"id":3560321224,"in_reply_to_id":3559925333,"user":{"login":"gemini-code-assist[bot]"},"body":"Thank you for the clarification, @maintainer. You are absolutely correct; the timeout logic has been moved to `useVaultAccessDialog.ts` and is now properly managed with cleanup routines. I appreciate you pointing out the current implementation details.","path":"packages/gui-web/src/VaultAccessModal.tsx","original_line":67,"html_url":"https://example.invalid/review-reply","created_at":"2026-07-10T16:06:22Z"}]'
+	result=$(_build_inline_findings "$comments" "26938" "medium" | jq 'length')
+	if [[ "$result" == "0" ]]; then
+		print_result "skip PR #26938 resolved timeout thread" 0
+	else
+		print_result "skip PR #26938 resolved timeout thread" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -257,6 +257,7 @@ main() {
 	test_skips_pr26751_confirmation_feedback_ack
 	test_skips_pr26877_regression_test_verification_ack
 	test_skips_pr26892_nongreedy_quantifier_ack
+	test_skips_pr26938_resolved_timeout_thread
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Treat positive inline review replies as closure evidence, suppress their resolved parent comments, and cover PR #26938's timeout-cleanup acknowledgement with a regression test.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (74/74); bash -n and shellcheck on all changed shell files; git diff --check

Resolves #26968


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 11m and 177,910 tokens on this as a headless worker.